### PR TITLE
Fix image generation using imageSettings

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -707,6 +707,18 @@ export type Character = {
     settings?: {
         secrets?: { [key: string]: string };
         intiface?: boolean;
+        imageSettings?: {
+            steps?: number;
+            width?: number;
+            height?: number;
+            negativePrompt?: string;
+            numIterations?: number;
+            guidanceScale?: number;
+            seed?: number;
+            modelId?: string;
+            jobId?: string;
+            count?: number;
+        };
         voice?: {
             model?: string; // For VITS
             url?: string; // Legacy VITS support

--- a/packages/plugin-image-generation/src/index.ts
+++ b/packages/plugin-image-generation/src/index.ts
@@ -120,6 +120,9 @@ const imageGeneration: Action = {
         const imagePrompt = message.content.text;
         elizaLogger.log("Image prompt received:", imagePrompt);
 
+        const imageSettings = runtime.character?.settings?.imageSettings || {};
+        elizaLogger.log("Image settings:", imageSettings);
+
         // TODO: Generate a prompt for the image
 
         const res: { image: string; caption: string }[] = [];

--- a/packages/plugin-image-generation/src/index.ts
+++ b/packages/plugin-image-generation/src/index.ts
@@ -131,23 +131,15 @@ const imageGeneration: Action = {
         const images = await generateImage(
             {
                 prompt: imagePrompt,
-                width: options.width || 1024,
-                height: options.height || 1024,
-                ...(options.count != null ? { count: options.count || 1 } : {}),
-                ...(options.negativePrompt != null
-                    ? { negativePrompt: options.negativePrompt }
-                    : {}),
-                ...(options.numIterations != null
-                    ? { numIterations: options.numIterations }
-                    : {}),
-                ...(options.guidanceScale != null
-                    ? { guidanceScale: options.guidanceScale }
-                    : {}),
-                ...(options.seed != null ? { seed: options.seed } : {}),
-                ...(options.modelId != null
-                    ? { modelId: options.modelId }
-                    : {}),
-                ...(options.jobId != null ? { jobId: options.jobId } : {}),
+                width: options.width || imageSettings.width || 1024,
+                height: options.height || imageSettings.height || 1024,
+                ...(options.count != null || imageSettings.count != null ? { count: options.count || imageSettings.count || 1 } : {}),
+                ...(options.negativePrompt != null || imageSettings.negativePrompt != null ? { negativePrompt: options.negativePrompt || imageSettings.negativePrompt } : {}),
+                ...(options.numIterations != null || imageSettings.numIterations != null ? { numIterations: options.numIterations || imageSettings.numIterations } : {}),
+                ...(options.guidanceScale != null || imageSettings.guidanceScale != null ? { guidanceScale: options.guidanceScale || imageSettings.guidanceScale } : {}),
+                ...(options.seed != null || imageSettings.seed != null ? { seed: options.seed || imageSettings.seed } : {}),
+                ...(options.modelId != null || imageSettings.modelId != null ? { modelId: options.modelId || imageSettings.modelId } : {}),
+                ...(options.jobId != null || imageSettings.jobId != null ? { jobId: options.jobId || imageSettings.jobId } : {}),
             },
             runtime
         );


### PR DESCRIPTION
<!-- Use this template by filling in information and copy and pasting relevant items out of the html comments. -->

# Relates to:

So I started working on adding additional venice features for image generation and noticed that image settings for all models is completely broken. None of the imageSettings from character files which is what the docs currently say to use are actually passed to the API request. So before I submit the PR to add more venice features (I have this done as well) I figured I'd submit this PR to fix imageSettings for character files (while still retaining the ability to pass these options with via js etc).

https://github.com/elizaOS/eliza/issues/1370

<!-- This risks section is to be filled out before final review and merge. -->

# Risks

Low risk, this just provides a fix to an already tested feature.

# Background

## What does this PR do?

We added relevant imageSettings to our types file, created a call to pull the imageSettings in the image generation plugin and then looked for those settings when making our API call to generate an image.

## What kind of change is this?

This is a bug fix, I have a feature PR ready for once this is merged.

<!-- This "Why" section is most relevant if there is no linked issue explaining why. If there is a related issue it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

No documentation changes needed as this actually just fixes what is already suggested in the docs (using imageSettings in character file for image settings)

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested, and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

First you can test the current develop branch that the settings are not used in a character file by adding these settings (the width&height change is easiest)

![image](https://github.com/user-attachments/assets/5f08cd13-3a1c-456a-9565-b91b8f4aa819)
 If you're using openai make sure you use 1792x1024 (or a different supported size option other than the 1024x1024 default) as openai won't let you pick just any size (PR with Venice which lets you pick whatever size coming after this though)

## Detailed testing steps

Now do the same test with this PR and you will notice your settings are passed and your image size is now using your settings.

<!--
None, automated tests are fine.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deploy, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste commandline output. -->
<!--
## Database changes
-->

<!--  If there is something more than the automated steps, please specifiy deploy instructions. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for contribute role and join us in #development-feed -->
<!--
## Discord username

-->
