### PR TITLE
Standardize boolean values and update .env file pattern

### DIFF
--- a/packages/client-twitter/src/post.ts
+++ b/packages/client-twitter/src/post.ts
@@ -161,11 +161,11 @@ export class TwitterPostClient {
 
         if (
             this.runtime.getSetting("POST_IMMEDIATELY") != null &&
-            this.runtime.getSetting("POST_IMMEDIATELY") != ""
+            this.runtime.getSetting("POST_IMMEDIATELY") !== ""
         ) {
-            postImmediately = parseBooleanFromText(
-                this.runtime.getSetting("POST_IMMEDIATELY")
-            );
+            // Retrieve setting, default to false if not set or if the value is not "true"
+            postImmediately = this.runtime.getSetting("POST_IMMEDIATELY") === "true" || false;
+
         }
 
         if (postImmediately) {


### PR DESCRIPTION
Replace YES/NO with true/false for boolean variables in .env file. Ensure consistency across the codebase by removing the need for parseBooleanFromText.
Relates to:
<!-- [LINK TO ISSUE OR TICKET](https://github.com/elizaOS/eliza/issues/1391) -->

#1391 - Standardize boolean values and fix pattern for .env file

<!-- Low: This change only modifies how boolean values are handled in the .env file, ensuring consistency and preventing potential parsing errors. Medium: Existing functionality depending on the `parseBooleanFromText` function may need adjustments, but no major system parts are affected. -->
Background
What does this PR do?

This PR replaces the "YES" and "NO" values used in the .env file for boolean variables with true and false to ensure consistency across the codebase. It removes the need for the parseBooleanFromText function, simplifying the parsing logic.
What kind of change is this?

Testing
Where should a reviewer start?

The reviewer should begin by checking the .env file to ensure that all boolean variables are now using true or false instead of "YES" or "NO".
Detailed testing steps

    Check the .env file and verify that all boolean variables (e.g., POST_IMMEDIATELY, TWITTER_SEARCH_ENABLE) now use true or false.
    Ensure that no usage of parseBooleanFromText exists in the codebase anymore.
    Test the functionality where these variables are used to ensure they work correctly as booleans.
