### PR TITLE
fix: duplicate tweet log

### DIFF
--- a/packages/client-twitter/src/post.ts
+++ b/packages/client-twitter/src/post.ts
@@ -184,6 +184,7 @@ export class TwitterPostClient {
                     error
                 );
             });
+            generateNewTweetLoop();
         } else {
             elizaLogger.log("Action processing loop disabled by configuration");
         }

--- a/packages/client-twitter/src/post.ts
+++ b/packages/client-twitter/src/post.ts
@@ -187,7 +187,6 @@ export class TwitterPostClient {
         } else {
             elizaLogger.log("Action processing loop disabled by configuration");
         }
-        generateNewTweetLoop();
     }
 
     constructor(client: ClientBase, runtime: IAgentRuntime) {


### PR DESCRIPTION
- Resolved an issue where `generateNewTweetLoop` was called twice in the `start` method of /packages/client-twitter/src/post.ts.
- The method was invoked at line 174 and line 190 without any conditional checks, leading to two independent tweet scheduling loops being created.
- Move second `generateNewTweetLoop()` inside the `if (enableActionProcessing)`

Fixes #1395

# Relates to:

Issue #1395

# Risks

Low: Removing the redundant call ensures only one scheduling loop, minimal impact on other functionalities.

# Background

## What does this PR do?

This PR fixes an issue where `generateNewTweetLoop` was called twice, leading multiple tweets to be posted. It ensures only a single scheduling loop is initialized by removing the redundant call.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Start by reviewing the `start` method in /packages/client-twitter/src/post.ts, focusing on the moving second `generateNewTweetLoop()` inside the `if (enableActionProcessing)` condition.

## Detailed testing steps

1. Configure the Twitter client and set `POST_IMMEDIATELY=true` to enable immediate tweet posting.
2. Start the service and observe if two tweets are sent, and check if the log contains multiple `Next tweet scheduled in xxx minutes` messages.
3. Verify that after starting the service, only one tweet is sent and the `Next tweet scheduled in xxx minutes` message is logged only once.
4. Confirm that tweets are still being scheduled correctly without any issues.
