### PR TITLE
fix: Remove code duplication in  getGoals call

### DIFF
--- a/packages/plugin-bootstrap/src/evaluators/goal.ts
+++ b/packages/plugin-bootstrap/src/evaluators/goal.ts
@@ -55,12 +55,6 @@ async function handler(
     state: State | undefined,
     options: { [key: string]: unknown } = { onlyInProgress: true }
 ): Promise<Goal[]> {
-    // get goals
-    let goalsData = await getGoals({
-        runtime,
-        roomId: message.roomId,
-        onlyInProgress: options.onlyInProgress as boolean,
-    });
 
     state = (await runtime.composeState(message)) as State;
     const context = composeContext({
@@ -79,10 +73,10 @@ async function handler(
     const updates = parseJsonArrayFromText(response);
 
     // get goals
-    goalsData = await getGoals({
+    const goalsData = await getGoals({
         runtime,
         roomId: message.roomId,
-        onlyInProgress: true,
+        onlyInProgress: options.onlyInProgress as boolean,
     });
 
     // Apply the updates to the goals


### PR DESCRIPTION
# Risks

Low

# Change

Remove code duplication in  getGoals to avoid performance penalty




