### PR TITLE
fix: duplicate twitter post

### DIFF
--- a/packages/client-twitter/src/post.ts
+++ b/packages/client-twitter/src/post.ts
@@ -171,7 +171,6 @@ export class TwitterPostClient {
         if (postImmediately) {
             await this.generateNewTweet();
         }
-        generateNewTweetLoop();
 
         // Add check for ENABLE_ACTION_PROCESSING before starting the loop
         const enableActionProcessing =
@@ -184,10 +183,11 @@ export class TwitterPostClient {
                     error
                 );
             });
-            generateNewTweetLoop();
         } else {
             elizaLogger.log("Action processing loop disabled by configuration");
         }
+        
+        generateNewTweetLoop();
     }
 
     constructor(client: ClientBase, runtime: IAgentRuntime) {


### PR DESCRIPTION
I'm not entirely sure if this would resolve the issue: https://github.com/elizaOS/eliza/pull/1396#issuecomment-2559249056.

From reviewing the code logic, it seems that enabling ENABLE_ACTION_PROCESSING might result in generating two TweetLoop instances. Is this the intended behavior?

@samarth30, could you kindly clarify this when you have a moment? Thank you so much!

related: https://github.com/elizaOS/eliza/issues/1395