### PR TITLE
docs: Fixed a small syntax issue in the ModelClass Update fine-tuning.md

### DIFF
--- a/docs/docs/advanced/fine-tuning.md
+++ b/docs/docs/advanced/fine-tuning.md
@@ -60,11 +60,11 @@ Models are categorized into different classes based on their capabilities:
 
 ```typescript
 enum ModelClass {
-    SMALL,    // Fast, efficient for simple tasks
-    MEDIUM,   // Balanced performance and capability
-    LARGE,    // Most capable but slower/more expensive
-    EMBEDDING // Specialized for vector embeddings
-    IMAGE     // Image generation capabilities
+    SMALL,     // Fast, efficient for simple tasks
+    MEDIUM,    // Balanced performance and capability
+    LARGE,     // Most capable but slower/more expensive
+    EMBEDDING, // Specialized for vector embeddings
+    IMAGE      // Image generation capabilities
 }
 ```
 


### PR DESCRIPTION
I noticed a syntax issue in the `ModelClass` enum where a comma was missing after the `EMBEDDING` value. This would have caused a compilation error or unexpected behavior. I've added the necessary comma so the code functions as intended.

Here’s the fix I applied:

Before:

```typescript
enum ModelClass {
    SMALL,    // Fast, efficient for simple tasks
    MEDIUM,   // Balanced performance and capability
    LARGE,    // Most capable but slower/more expensive
    EMBEDDING // Specialized for vector embeddings
    IMAGE     // Image generation capabilities
}
```

After:

```typescript
enum ModelClass {
    SMALL,    // Fast, efficient for simple tasks
    MEDIUM,   // Balanced performance and capability
    LARGE,    // Most capable but slower/more expensive
    EMBEDDING, // Specialized for vector embeddings
    IMAGE     // Image generation capabilities
}
```

This minor adjustment ensures that the values are properly separated in the enum, preventing potential issues down the line.