### PR TITLE
fix: Telegram Bad Request: can't parse entities

### DIFF
--- a/packages/client-telegram/src/messageManager.ts
+++ b/packages/client-telegram/src/messageManager.ts
@@ -18,7 +18,7 @@ import { stringToUuid } from "@elizaos/core";
 import { generateMessageResponse, generateShouldRespond } from "@elizaos/core";
 import { messageCompletionFooter, shouldRespondFooter } from "@elizaos/core";
 
-import { cosineSimilarity } from "./utils";
+import { cosineSimilarity, escapeMarkdown } from "./utils";
 import {
     MESSAGE_CONSTANTS,
     TIMING_CONSTANTS,
@@ -692,7 +692,7 @@ export class MessageManager {
             const sentMessages: Message.TextMessage[] = [];
 
             for (let i = 0; i < chunks.length; i++) {
-                const chunk = chunks[i];
+                const chunk = escapeMarkdown(chunks[i]);
                 const sentMessage = (await ctx.telegram.sendMessage(
                     ctx.chat.id,
                     chunk,

--- a/packages/client-telegram/src/utils.ts
+++ b/packages/client-telegram/src/utils.ts
@@ -75,6 +75,29 @@ export function cosineSimilarity(text1: string, text2: string, text3?: string): 
     return dotProduct / maxMagnitude;
 }
 
+export function escapeMarkdown(text: string): string {
+    // Don't escape if it's a code block
+    if (text.startsWith('```') && text.endsWith('```')) {
+        return text;
+    }
+
+    // Split the text by code blocks
+    const parts = text.split(/(```[\s\S]*?```)/g);
+
+    return parts.map((part, index) => {
+        // If it's a code block (odd indices in the split result will be code blocks)
+        if (index % 2 === 1) {
+            return part;
+        }
+        // For regular text, only escape characters that need escaping in Markdown
+        return part
+            // First preserve any intended inline code spans
+            .replace(/`.*?`/g, match => match)
+            // Then only escape the minimal set of special characters that need escaping in Markdown mode
+            .replace(/([*_`\\])/g, '\\$1');
+    }).join('');
+}
+
 /**
  * Splits a message into chunks that fit within Telegram's message length limit
  */


### PR DESCRIPTION
<!-- Use this template by filling in information and copy and pasting relevant items out of the html comments. -->

# Relates to:

[PR 1229](https://github.com/elizaOS/eliza/pull/1229)

# Risks

Low: Fixes TG message handling with markdown, introduced with [PR 1229](https://github.com/elizaOS/eliza/pull/1229)

# Background

## What does this PR do?

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue):

Fixes TG messages "Bad Request: can't parse entities"

And still keeps markdown functionality for regular messages.

## Why are we doing this? Any context or related work?

# Documentation changes needed?

N/A


# Testing

## Where should a reviewer start?

## Detailed testing steps

Added escapeMarkdown function within /utils.ts, imported to messageManager, and passing through TG messages.

# Deploy Notes
N/A

## Database changes
N/A

## Deployment instructions

## Discord username
ninja_dev


