### PR TITLE
Feat/add readme spanish version in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,16 @@
 # Eliza - Multi-agent simulation framework
 
-# https://github.com/elizaos/eliza
+# https://github.com/elizaOS/eliza
 
 # Visit https://eliza.builders for support
 
 ## 🌍 README Translations
 
-[中文说明](./README_CN.md) | [Deutsch](./README_DE.md) | [Français](./README_FR.md) | [ไทย](./README_TH.md)
+[中文说明](./README_CN.md) | [Deutsch](./README_DE.md) | [Français](./README_FR.md) | [ไทย](./README_TH.md) | [Español](README_ES.md)
 
 # dev branch
 
-<img src="./docs/static/img/eliza_banner.jpg" alt="Eliza Banner" width="100%" />
+<img src="static/img/eliza_banner.jpg" alt="Eliza Banner" width="100%" />
 
 _As seen powering [@DegenSpartanAI](https://x.com/degenspartanai) and [@MarcAIndreessen](https://x.com/pmairca)_
 

--- a/docs/README_ES.md
+++ b/docs/README_ES.md
@@ -1,0 +1,179 @@
+# Eliza - Framework de simulación multi-agente
+
+# https://github.com/elizaOS/eliza
+
+# Visita https://eliza.builders para ayuda
+
+## 🌍 Traducciones del README
+
+[中文说明](./README_CN.md) | [Deutsch](./README_DE.md) | [Français](./README_FR.md) | [ไทย](./README_TH.md) | [English](README.md)
+
+# dev branch
+
+<img src="static/img/eliza_banner.jpg" alt="Eliza Banner" width="100%" />
+
+_Respaldado por [@DegenSpartanAI](https://x.com/degenspartanai) y [@MarcAIndreessen](https://x.com/pmairca)_
+
+- Framework de simulación multi-agente
+- Añade tantos caracteres únicos como quieras con [characterfile](https://github.com/elizaOS/characterfile/)
+- Conectores Discord y Twitter con todas las funciones y compatibilidad con canales de voz de Discord.
+- Sistema de memoria RAG completo para conversaciones y documentos.
+- Capacidad para leer enlaces y archivos PDF, transcribir audio y vídeos, resumir conversaciones, etc.
+- Gran capacidad de ampliación: cree sus propias acciones y clientes para ampliar las posibilidades de Eliza.
+- Admite modelos locales y de código abierto (configurado por defecto con Nous Hermes Llama 3.1B).
+- Compatible con OpenAI para la inferencia en la nube en un dispositivo ligero.
+- Modo "Ask Claude" para llamar a Claude en consultas más complejas
+- 100% Typescript
+
+# Primeros pasos
+
+**Prerrequisitos (OBLIGATORIOS):**
+
+- [Node.js 23+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+- [pnpm](https://pnpm.io/installation)
+
+### Edita el archivo .env
+
+- Copie .env.example en .env y rellene los valores apropiados
+- Edita las variables de entorno de TWITTER para añadir el nombre de usuario y la contraseña de tu bot
+
+### Edita el archivo del character
+
+- Mira el archivo `src/core/defaultCharacter.ts` - tú puedes modificarlo
+- También puede cargar caracteres con el comando `pnpm start --characters="path/to/your/character.json"` y ejecutar múltiples bots al mismo tiempo.
+
+Después de configurar el archivo .env y el archivo de caracteres, puedes iniciar el bot con el siguiente comando:
+
+```
+pnpm i
+pnpm start
+```
+
+# Personalizando Eliza
+
+### Añadir acciones personalizadas
+
+Para evitar conflictos de git en el directorio core, recomendamos añadir acciones personalizadas a un directorio `custom_actions` y luego añadirlas al archivo `elizaConfig.yaml`. Consulte el archivo `elizaConfig.example.yaml` para ver un ejemplo.
+
+## Ejecutando con diferentes modelos
+
+### Ejecuta con Llama
+
+Tú puedes ejecutar los modelos Llama 70B o 405B configurando el ambiente `XAI_MODEL` en la variable `meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo` o `meta-llama/Meta-Llama-3.1-405B-Instruct`
+
+### Ejecuta con Grok
+
+Tú puedes ejecutar modelos Grok configurando el ambiente `XAI_MODEL` en la variable `grok-beta`
+
+### Ejecuta con OpenAI
+
+Tú puedes ejecutar modelos OpenAI configurando el ambiente `XAI_MODEL` en la variable `gpt-4-mini` o `gpt-4o`
+
+## Requerimientos adicionales
+
+Puede que necesite instalar Sharp. Si aparece un error al arrancar, intente instalarlo con el siguiente comando:
+
+```
+pnpm install --include=optional sharp
+```
+
+# Configuración del entorno
+
+Tendrás que añadir variables de entorno a tu archivo .env para conectarte a distintas plataformas:
+
+```
+# Variables de entorno necesarias
+DISCORD_APPLICATION_ID=
+DISCORD_API_TOKEN= # Bot token
+OPENAI_API_KEY=sk-* # OpenAI API key, starting with sk-
+ELEVENLABS_XI_API_KEY= # API key from elevenlabs
+
+# CONFIGURACION DE ELEVENLABS
+ELEVENLABS_MODEL_ID=eleven_multilingual_v2
+ELEVENLABS_VOICE_ID=21m00Tcm4TlvDq8ikWAM
+ELEVENLABS_VOICE_STABILITY=0.5
+ELEVENLABS_VOICE_SIMILARITY_BOOST=0.9
+ELEVENLABS_VOICE_STYLE=0.66
+ELEVENLABS_VOICE_USE_SPEAKER_BOOST=false
+ELEVENLABS_OPTIMIZE_STREAMING_LATENCY=4
+ELEVENLABS_OUTPUT_FORMAT=pcm_16000
+
+TWITTER_DRY_RUN=false
+TWITTER_USERNAME= # Account username
+TWITTER_PASSWORD= # Account password
+TWITTER_EMAIL= # Account email
+
+X_SERVER_URL=
+XAI_API_KEY=
+XAI_MODEL=
+
+
+# Para preguntarle cosas a Claude
+ANTHROPIC_API_KEY=
+
+WALLET_SECRET_KEY=EXAMPLE_WALLET_SECRET_KEY
+WALLET_PUBLIC_KEY=EXAMPLE_WALLET_PUBLIC_KEY
+
+BIRDEYE_API_KEY=
+
+SOL_ADDRESS=So11111111111111111111111111111111111111112
+SLIPPAGE=1
+RPC_URL=https://api.mainnet-beta.solana.com
+HELIUS_API_KEY=
+
+
+## Telegram
+TELEGRAM_BOT_TOKEN=
+
+TOGETHER_API_KEY=
+```
+
+# Configuración de la inferencia local
+
+### Configuración CUDA
+
+Si tienes una GPU NVIDIA, puedes instalar CUDA para acelerar drásticamente la inferencia local.
+
+```
+pnpm install
+npx --no node-llama-cpp source download --gpu cuda
+```
+
+Asegúrese de que ha instalado el kit de herramientas CUDA, incluidos cuDNN y cuBLAS.
+
+### Ejecutando localmente
+
+Añade XAI_MODEL y ajústalo a una de las opciones anteriores de [Run with Llama](#run-with-llama) - puedes dejar X_SERVER_URL y XAI_API_KEY en blanco, descarga el modelo de huggingface y lo consulta localmente.
+
+# Clientes
+
+## Discord Bot
+
+Para obtener ayuda con la configuración de su Bot Discord, echa un vistazo aquí: https://discordjs.guide/preparations/setting-up-a-bot-application.html
+
+# Desarrollo
+
+## Pruebas
+
+Para ejecutar el conjunto de pruebas:
+
+```bash
+pnpm test           # Ejecutar las pruebas una vez
+pnpm test:watch    # Ejecutar pruebas en modo vigilancia
+```
+
+Para pruebas database-specific:
+
+```bash
+pnpm test:sqlite   # Ejecuta pruebas con SQLite
+pnpm test:sqljs    # Ejecuta pruebas con with SQL.js
+```
+
+Las pruebas se escriben usando Jest y se encuentran en los archivos `src/**/*.test.ts`. El entorno de pruebas está configurado para:
+
+- Cargar variables de entorno desde `.env.test`.
+- Uso de un tiempo de espera de 2 minutos para pruebas de larga duración
+- Compatibilidad con módulos ESM
+- Ejecutar pruebas en secuencia (--runInBand)
+
+Para crear nuevas pruebas, añade un archivo `.test.ts` junto al código que estás probando.


### PR DESCRIPTION
# Relates to:

Closes #1592 


# Risks

There is no risk because only documentation is added.

# Background

## What does this PR do?

Add the Spanish version of the readme in the docs section so that developers can be informed in a better way and without language barriers.

## What kind of change is this?

Feat documentation in spanish version for docs section and fix the image of Eliza.

### Before
<img width="1018" alt="Before" src="https://github.com/user-attachments/assets/9c733d52-c615-4394-9be4-81509b2271be" />

### After
<img width="1018" alt="After" src="https://github.com/user-attachments/assets/0c033940-aeb8-4102-8381-155d3d4b7c39" />

### README_ES
<img width="827" alt="README_ES" src="https://github.com/user-attachments/assets/a22e500d-8547-4f81-8868-faf67536270d" />


<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there is no linked issue explaining why. If there is a related issue it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?
No.

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for contribute role and join us in #development-feed -->

## Discord username
s_ebit_as


