### PR TITLE
fix: Double Responses from Continue Action

### DIFF
--- a/packages/plugin-bootstrap/src/actions/continue.ts
+++ b/packages/plugin-bootstrap/src/actions/continue.ts
@@ -133,7 +133,7 @@ export const continueAction: Action = {
         if ((lastAgentMessage && lastAgentMessage.content.text &&
             (lastAgentMessage.content.text.endsWith("?") ||
             lastAgentMessage.content.text.endsWith("!"))) || (message.content.text.endsWith("?") || message.content.text.endsWith("!"))) {
-            elizaLogger.log(`[CONTINUE] My last message had question/exclamation. Not proceeding.`);
+            elizaLogger.log(`[CONTINUE] Last message had question/exclamation. Not proceeding.`);
             return;
         }
 

--- a/packages/plugin-bootstrap/src/actions/continue.ts
+++ b/packages/plugin-bootstrap/src/actions/continue.ts
@@ -91,18 +91,60 @@ export const continueAction: Action = {
         options: any,
         callback: HandlerCallback
     ) => {
-        if (
-            message.content.text.endsWith("?") ||
-            message.content.text.endsWith("!")
-        ) {
-            return;
-        }
-
         if (!state) {
             state = (await runtime.composeState(message)) as State;
         }
-
         state = await runtime.updateRecentMessageState(state);
+
+        // Get the agent's recent messages
+        const agentMessages = state.recentMessagesData
+            .filter((m: { userId: any }) => m.userId === runtime.agentId)
+            .sort((a: Memory, b: Memory) => {
+                // Sort by timestamp if available, assuming newer messages have higher timestamps
+                const aTime = a.createdAt || 0;
+                const bTime = b.createdAt || 0;
+                return bTime - aTime;
+            });
+
+        // Check for immediate double response (responding twice in a row to the same message)
+        const lastAgentMessage = agentMessages[0];
+
+        if (lastAgentMessage?.content?.inReplyTo === message.id) {
+            // If our last message was already a response to this message, only allow continue if:
+            // 1. The last message had a CONTINUE action
+            // 2. We haven't hit the maxContinuesInARow limit
+            const continueCount = agentMessages
+            .filter((m: Memory) => m.content?.inReplyTo === message.id)
+            .filter((m: Memory) => m.content?.action === 'CONTINUE')
+            .length;
+
+            if (continueCount >= maxContinuesInARow) {
+                elizaLogger.log(`[CONTINUE] Max continues (${maxContinuesInARow}) reached for this message chain`);
+                return;
+            }
+
+            if (lastAgentMessage.content?.action !== 'CONTINUE') {
+                elizaLogger.log(`[CONTINUE] Last message wasn't a CONTINUE, preventing double response`);
+                return;
+            }
+        }
+
+        // Check if our last message or message ended with a question/exclamation and warrants a stop
+        if ((lastAgentMessage && lastAgentMessage.content.text &&
+            (lastAgentMessage.content.text.endsWith("?") ||
+            lastAgentMessage.content.text.endsWith("!"))) || (message.content.text.endsWith("?") || message.content.text.endsWith("!"))) {
+            elizaLogger.log(`[CONTINUE] My last message had question/exclamation. Not proceeding.`);
+            return;
+        }
+
+        // Prevent exact duplicate messages
+        const messageExists = agentMessages
+            .slice(0, maxContinuesInARow + 1)
+            .some((m: { content: any }) => m.content.text === message.content.text);
+
+        if (messageExists) {
+            return;
+        }
 
         async function _shouldContinue(state: State): Promise<boolean> {
             // If none of the above conditions are met, use the generateText to decide
@@ -120,12 +162,14 @@ export const continueAction: Action = {
             return response;
         }
 
+        // Use AI to determine if we should continue
         const shouldContinue = await _shouldContinue(state);
         if (!shouldContinue) {
-            elizaLogger.log("Not elaborating, returning");
+            elizaLogger.log("[CONTINUE] Not elaborating, returning");
             return;
         }
 
+        // Generate and send response
         const context = composeContext({
             state,
             template:
@@ -150,32 +194,17 @@ export const continueAction: Action = {
             type: "continue",
         });
 
-        // prevent repetition
-        const messageExists = state.recentMessagesData
-            .filter((m: { userId: any }) => m.userId === runtime.agentId)
-            .slice(0, maxContinuesInARow + 1)
-            .some((m: { content: any }) => m.content === message.content);
-
-        if (messageExists) {
-            return;
-        }
-
         await callback(response);
 
-        // if the action is CONTINUE, check if we are over maxContinuesInARow
+        // Check if we need to clear the CONTINUE action
         if (response.action === "CONTINUE") {
-            const agentMessages = state.recentMessagesData
-                .filter((m: { userId: any }) => m.userId === runtime.agentId)
-                .map((m: { content: any }) => (m.content as Content).action);
+            const continueCount = agentMessages
+                .slice(0, maxContinuesInARow)
+                .filter((m: Memory) => m.content?.action === 'CONTINUE')
+                .length;
 
-            const lastMessages = agentMessages.slice(0, maxContinuesInARow);
-            if (lastMessages.length >= maxContinuesInARow) {
-                const allContinues = lastMessages.every(
-                    (m: string | undefined) => m === "CONTINUE"
-                );
-                if (allContinues) {
-                    response.action = null;
-                }
+            if (continueCount >= maxContinuesInARow - 1) {  // -1 because we're about to add another
+                response.action = null;
             }
         }
 


### PR DESCRIPTION
# Relates to:


# Risks

Low

# Background

## What does this PR do?

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

This PR fixes a double response issue that was caused by the CONTINUE action in the plugin-bootstrap. The agent would respond to the same message multiple time due to the continue trigger.

# Documentation changes needed?

N/A

# Testing

## Where should a reviewer start?

## Detailed testing steps

Test sending a message, watch logs for CONTINUE message to be triggered, watch logs as agent logs that a response has already been sent to an existing message or not responding further.

The double response was seen as triggered in a CONTINUE action whe the agent would ask/frame response a certain way back to the user. Which on subsequent messages, would trigger the callback to respond to the same message multiple times.

Where the continue action is meant for a natural flow of thoughts to keep generating, on normal back and forth convo's it would duplicate response.

Fix below now stops that as it takes into consideration its own message it just responded to, and how it framed to either not respond again, or continue a thought as it was intended.

---TESTING Screen Record---
1st section shows a previous double response, which is triggered by the question the agent asked to the user, which in turn triggers a double response on the next reply from the user

2nd section shows continue being triggered as normal, but not triggering another response in the handler callback since it already responded. This will still allow continue to allow the agent to "continue" a thought it had as it was intended, also, per the examples.

https://github.com/user-attachments/assets/0ed92c8f-dc99-4c3b-95fc-9c0052f56197


# Deploy Notes

## Database changes

## Deployment instructions

## Discord username
ninja_dev
