### PR TITLE
fix: Google API Key not passing from character file

### DIFF
--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -224,6 +224,7 @@ export async function generateText({
 
             case ModelProviderName.GOOGLE: {
                 const google = createGoogleGenerativeAI({
+                    apiKey,
                     fetch: runtime.fetch,
                 });
 


### PR DESCRIPTION
# Relates to:

# Risks

Low

# Background

## What does this PR do?

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

This PR fixes an issue where the GOOGLE_GENERATIVE_AI_API_KEY is not being passed through if set in the character file.

## Why are we doing this? Any context or related work?
We are fixing a bug.

# Documentation changes needed?
N/A


# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None, automated tests are fine.

Set the GOOGLE_GENERATIVE_AI_API_KEY in the .env file and generation works, than remove it from .env file and set it in character secrets, and generation will fail stating missing API key.

## Screenshots
### Before
### After

# Deploy Notes

## Database changes

## Deployment instructions

## Discord username
ninja_dev
