### PR TITLE
correct faq docs link in both contribution md files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ This section lists the labels we use to help us track and manage issues and pull
 ## Getting Help
 
 - Join [Discord](https://discord.gg/ai16z)
-- Check [FAQ](docs/community/faq.md)
+- Check [FAQ](docs/docs/faq.md)
 - Create GitHub issues
 
 ## Additional Resources

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -79,7 +79,7 @@ This section lists the labels we use to help us track and manage issues and pull
 ## Getting Help
 
 - Join [Discord](https://discord.gg/ai16z)
-- Check [FAQ](docs/community/faq.md)
+- Check [FAQ](docs/docs/faq.md)
 - Create GitHub issues
 
 ## Additional Resources


### PR DESCRIPTION
This pull request includes a small change to the `CONTRIBUTING.md` and `docs/docs/contributing.md` files. The change corrects the link to the FAQ page to point to the correct location.

* [`CONTRIBUTING.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L82-R82): Updated the FAQ link from `docs/community/faq.md` to `docs/docs/faq.md`.
* [`docs/docs/contributing.md`](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L82-R82): Updated the FAQ link from `docs/community/faq.md` to `docs/docs/faq.md`.

<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to 1838

https://github.com/elizaOS/eliza/issues/1838

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low - docs change

# Background

Read the contributing docs, they were broken, submitting a PR

## What does this PR do?

fixes the docs

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

Includes documentation change

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

Check that you do want this FAQ link to go to [docs/docs/faq.md](https://github.com/elizaOS/eliza/blob/main/docs/docs/faq.md) and not [docs/community/faq-and-support.md](https://github.com/elizaOS/eliza/blob/main/docs/community/faq-and-support.md)

## Detailed testing steps

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username
macs
-->
