### PR TITLE
Fixed broken API Documentation URL

### DIFF
--- a/docs/docs/guides/local-development.md
+++ b/docs/docs/guides/local-development.md
@@ -476,5 +476,5 @@ npx knowledge2character <character-file> <knowledge-file>
 
 - [Configuration Guide](./configuration.md) for setup details
 - [Advanced Usage](./advanced.md) for complex features
-- [API Documentation](/api) for complete API reference
+- [API Documentation](../../../api) for complete API reference
 - [Contributing Guide](../contributing.md) for contribution guidelines

--- a/docs/docs/guides/local-development.md
+++ b/docs/docs/guides/local-development.md
@@ -476,5 +476,5 @@ npx knowledge2character <character-file> <knowledge-file>
 
 - [Configuration Guide](./configuration.md) for setup details
 - [Advanced Usage](./advanced.md) for complex features
-- [API Documentation](../../../api) for complete API reference
+- [API Documentation](../../api/index.md) for complete API reference
 - [Contributing Guide](../contributing.md) for contribution guidelines


### PR DESCRIPTION
fixed broken API Documentation in local-development.md

it's not a lot, but it's honest work.