### PR TITLE
fix: rm unused variable X_SERVER_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,7 +85,6 @@ TWITTER_TARGET_USERS=           # Comma separated list of Twitter user names to 
 TWITTER_RETRY_LIMIT=            # Maximum retry attempts for Twitter login
 TWITTER_SPACES_ENABLE=false     # Enable or disable Twitter Spaces logic
 
-X_SERVER_URL=
 XAI_API_KEY=
 XAI_MODEL=
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -188,7 +188,6 @@ TWITTER_USERNAME= # Account username
 TWITTER_PASSWORD= # Account password
 TWITTER_EMAIL= # Account email
 
-X_SERVER_URL=
 XAI_API_KEY=
 XAI_MODEL=
 
@@ -237,7 +236,7 @@ npx --no node-llama-cpp source download --gpu cuda
 ### 本地运行
 
 添加 XAI_MODEL 并将其设置为上述 [使用 Llama 运行](#run-with-llama) 中的选项之一
-您可以将 X_SERVER_URL 和 XAI_API_KEY 留空，它会从 huggingface 下载模型并在本地查询
+您可以将 XAI_API_KEY 留空，它会从 huggingface 下载模型并在本地查询
 
 # 客户端
 

--- a/README_ES.md
+++ b/README_ES.md
@@ -99,7 +99,6 @@ TWITTER_USERNAME= # Nombre de usuario de la cuenta
 TWITTER_PASSWORD= # Contraseña de la cuenta
 TWITTER_EMAIL= # Correo electrónico de la cuenta
 
-X_SERVER_URL=
 XAI_API_KEY=
 XAI_MODEL=
 
@@ -145,7 +144,7 @@ Asegúrese de tener instalado el CUDA Toolkit, incluyendo cuDNN y cuBLAS.
 
 ### Ejecución local
 
-Agregue XAI_MODEL y configúrelo con una de las opciones de [Ejecutar con Llama](#ejecutar-con-llama) - puede dejar X_SERVER_URL y XAI_API_KEY en blanco, descargará el modelo de HuggingFace y realizará consultas localmente
+Agregue XAI_MODEL y configúrelo con una de las opciones de [Ejecutar con Llama](#ejecutar-con-llama) - puede dejar XAI_API_KEY en blanco, descargará el modelo de HuggingFace y realizará consultas localmente
 
 # Clientes
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -97,7 +97,6 @@ TWITTER_USERNAME= # アカウントのユーザー名
 TWITTER_PASSWORD= # アカウントのパスワード
 TWITTER_EMAIL= # アカウントのメール
 
-X_SERVER_URL=
 XAI_API_KEY=
 XAI_MODEL=
 
@@ -145,7 +144,7 @@ CUDA Toolkit、cuDNN、cuBLASをインストールしていることを確認し
 
 ### ローカルでの実行
 
-XAI_MODELを追加し、[Llamaでの実行](#run-with-llama)のオプションのいずれかに設定 - X_SERVER_URLとXAI_API_KEYを空白のままにしておくと、huggingfaceからモデルをダウンロードし、ローカルでクエリを実行します。
+XAI_MODELを追加し、[Llamaでの実行](#run-with-llama)のオプションのいずれかに設定 - XAI_API_KEYを空白のままにしておくと、huggingfaceからモデルをダウンロードし、ローカルでクエリを実行します。
 
 # クライアント
 

--- a/README_PTBR.md
+++ b/README_PTBR.md
@@ -99,7 +99,6 @@ TWITTER_USERNAME= # Nome de usuário da conta
 TWITTER_PASSWORD= # Senha da conta
 TWITTER_EMAIL= # Email da conta
 
-X_SERVER_URL=
 XAI_API_KEY=
 XAI_MODEL=
 
@@ -147,7 +146,7 @@ Certifique-se de ter instalado o CUDA Toolkit, incluindo cuDNN e cuBLAS.
 
 ### Executando localmente
 
-Adicione XAI_MODEL e configure-o para uma das opções acima de [Executar com Llama](#executar-com-llama) - você pode deixar X_SERVER_URL e XAI_API_KEY em branco, ele baixa o modelo do huggingface e faz consultas localmente
+Adicione XAI_MODEL e configure-o para uma das opções acima de [Executar com Llama](#executar-com-llama) - você pode deixar XAI_API_KEY em branco, ele baixa o modelo do huggingface e faz consultas localmente
 
 # Clientes
 

--- a/README_RO.md
+++ b/README_RO.md
@@ -99,7 +99,6 @@ TWITTER_USERNAME= # Nome de usuário da conta
 TWITTER_PASSWORD= # Senha da conta
 TWITTER_EMAIL= # Email da conta
 
-X_SERVER_URL=
 XAI_API_KEY=
 XAI_MODEL=
 
@@ -147,7 +146,7 @@ Asigurați-vă că ați instalat CUDA Toolkit, inclusiv cuDNN și cuBLAS.
 
 ### Rularea locală
 
-Adăugați `XAI_MODEL` și setați-l la una dintre opțiunile de mai sus din [Rularea cu Llama](#rularea-cu-llama) – puteți lăsa `X_SERVER_URL` și `XAI_API_KEY` necompletate, modelul va fi descărcat de pe Hugging Face și interogările vor fi făcute local.
+Adăugați `XAI_MODEL` și setați-l la una dintre opțiunile de mai sus din [Rularea cu Llama](#rularea-cu-llama) – puteți lăsa `XAI_API_KEY` necompletate, modelul va fi descărcat de pe Hugging Face și interogările vor fi făcute local.
 
 # Clienți
 

--- a/README_RS.md
+++ b/README_RS.md
@@ -99,7 +99,6 @@ TWITTER_USERNAME= # Korisničko ime naloga
 TWITTER_PASSWORD= # Lozinka naloga
 TWITTER_EMAIL= # Email naloga
 
-X_SERVER_URL=
 XAI_API_KEY=
 XAI_MODEL=
 
@@ -145,7 +144,7 @@ Uverite se da imate instaliran CUDA Toolkit, uključujući cuDNN i cuBLAS.
 
 ### Lokalno Pokretanje
 
-Dodajte XAI_MODEL i konfigurišite ga sa jednom od opcija iz [Pokretanje sa Llama](#pokretanje-sa-llama) - možete ostaviti X_SERVER_URL i XAI_API_KEY praznim, preuzeće model sa HuggingFace i izvršiti upite lokalno
+Dodajte XAI_MODEL i konfigurišite ga sa jednom od opcija iz [Pokretanje sa Llama](#pokretanje-sa-llama) - možete ostaviti XAI_API_KEY praznim, preuzeće model sa HuggingFace i izvršiti upite lokalno
 
 # Klijenti
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -115,7 +115,6 @@ TWITTER_USERNAME= # Имя пользователя аккаунта
 TWITTER_PASSWORD= # Пароль аккаунта
 TWITTER_EMAIL= # Email аккаунта
 
-X_SERVER_URL=
 XAI_API_KEY=
 XAI_MODEL=
 
@@ -164,7 +163,7 @@ npx --no node-llama-cpp source download --gpu cuda
 
 ### Локальный запуск
 
-Добавьте `XAI_MODEL` и установите его в одно из вышеуказанных значений из [Запуск с Llama](#run-with-llama). Вы можете оставить `X_SERVER_URL` и `XAI_API_KEY` пустыми — модель будет загружена с huggingface и обработана локально.
+Добавьте `XAI_MODEL` и установите его в одно из вышеуказанных значений из [Запуск с Llama](#run-with-llama). Вы можете оставить `XAI_API_KEY` пустыми — модель будет загружена с huggingface и обработана локально.
 
 # Клиенты
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -25,7 +25,6 @@ services:
             - TWITTER_USERNAME=
             - TWITTER_PASSWORD=
             - TWITTER_EMAIL=
-            - X_SERVER_URL=https://api.red-pill.ai/v1
             - BIRDEYE_API_KEY=
             - SOL_ADDRESS=So11111111111111111111111111111111111111112
             - SLIPPAGE=1

--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -95,7 +95,6 @@ TWITTER_USERNAME= # Account username
 TWITTER_PASSWORD= # Account password
 TWITTER_EMAIL= # Account email
 
-X_SERVER_URL=
 XAI_API_KEY=
 XAI_MODEL=
 

--- a/docs/docs/guides/local-development.md
+++ b/docs/docs/guides/local-development.md
@@ -75,7 +75,6 @@ Configure essential development variables:
 ```bash
 # Minimum required for local development
 OPENAI_API_KEY=sk-*           # Optional, for OpenAI features
-X_SERVER_URL=                 # Leave blank for local inference
 XAI_API_KEY=                 # Leave blank for local inference
 XAI_MODEL=meta-llama/Llama-3.1-7b-instruct  # Local model
 ```


### PR DESCRIPTION
# Risks

Low

# Background

## What does this PR do?

Removes the unused X_SERVER_URL that appears to be a relic of legacy code.

## What kind of change is this?

Improvement

## Why are we doing this? Any context or related work?

I noticed this doesn't appear to be used in the code anymore. I also noticed that the XAI_API_KEY is only used for loading the Together API but it has it's own API key var now (which can be used to load the provider). Should I go ahead and remove it as well? I feel like most people think these vars are related to X/Twitter or xAI and may be confused by them.

# Documentation changes needed?

A lot of the documentation does need to be updated to reflect the changes to selecting providers and models. Many may be trying to use this unworking and unused variable. I removed it from the Readme's on here in this PR though.

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

## Discord username

@proteanx (same as on here)
