### PR TITLE
fix: Limit the number of timelines fetched

### DIFF
--- a/packages/client-twitter/src/base.ts
+++ b/packages/client-twitter/src/base.ts
@@ -359,6 +359,9 @@ export class ClientBase extends EventEmitter {
             }))
             .filter((tweet) => tweet.username !== agentUsername) // do not perform action on self-tweets
             .slice(0, count);
+        // TODO: Once the 'count' parameter is fixed in the 'fetchTimeline' method of the 'agent-twitter-client',
+        // this workaround can be removed.
+        // Related issue: https://github.com/elizaOS/agent-twitter-client/issues/43
     }
 
     async fetchSearchTweets(

--- a/packages/client-twitter/src/base.ts
+++ b/packages/client-twitter/src/base.ts
@@ -318,7 +318,7 @@ export class ClientBase extends EventEmitter {
         return processedTimeline;
     }
 
-    async fetchTimelineForActions(): Promise<Tweet[]> {
+    async fetchTimelineForActions(count: number): Promise<Tweet[]> {
         elizaLogger.debug("fetching timeline for actions");
 
         const agentUsername = this.twitterConfig.TWITTER_USERNAME;
@@ -326,8 +326,8 @@ export class ClientBase extends EventEmitter {
         const homeTimeline =
             this.twitterConfig.ACTION_TIMELINE_TYPE ===
             ActionTimelineType.Following
-                ? await this.twitterClient.fetchFollowingTimeline(20, [])
-                : await this.twitterClient.fetchHomeTimeline(20, []);
+                ? await this.twitterClient.fetchFollowingTimeline(count, [])
+                : await this.twitterClient.fetchHomeTimeline(count, []);
 
         return homeTimeline
             .map((tweet) => ({
@@ -357,7 +357,8 @@ export class ClientBase extends EventEmitter {
                         (media) => media.type === "video"
                     ) || [],
             }))
-            .filter((tweet) => tweet.username !== agentUsername); // do not perform action on self-tweets
+            .filter((tweet) => tweet.username !== agentUsername) // do not perform action on self-tweets
+            .slice(0, count);
     }
 
     async fetchSearchTweets(

--- a/packages/client-twitter/src/post.ts
+++ b/packages/client-twitter/src/post.ts
@@ -19,6 +19,8 @@ import { DEFAULT_MAX_TWEET_LENGTH } from "./environment.ts";
 import { State } from "@elizaos/core";
 import { ActionResponse } from "@elizaos/core";
 
+const MAX_TIMELINES_TO_FETCH = 15;
+
 const twitterPostTemplate = `
 # Areas of Expertise
 {{knowledge}}
@@ -627,7 +629,9 @@ export class TwitterPostClient {
                 "twitter"
             );
 
-            const homeTimeline = await this.client.fetchTimelineForActions(15);
+            const homeTimeline = await this.client.fetchTimelineForActions(
+                MAX_TIMELINES_TO_FETCH
+            );
             const maxActionsProcessing =
                 this.client.twitterConfig.MAX_ACTIONS_PROCESSING;
             const processedTimelines = [];

--- a/packages/client-twitter/src/post.ts
+++ b/packages/client-twitter/src/post.ts
@@ -627,10 +627,7 @@ export class TwitterPostClient {
                 "twitter"
             );
 
-            // TODO: Once the 'count' parameter is fixed in the 'fetchTimeline' method of the 'agent-twitter-client',
-            // we should enable the ability to control the number of items fetched here.
-            // Related issue: https://github.com/elizaOS/agent-twitter-client/issues/43
-            const homeTimeline = await this.client.fetchTimelineForActions();
+            const homeTimeline = await this.client.fetchTimelineForActions(15);
             const maxActionsProcessing =
                 this.client.twitterConfig.MAX_ACTIONS_PROCESSING;
             const processedTimelines = [];


### PR DESCRIPTION
Related Issue
https://github.com/elizaOS/agent-twitter-client/issues/43

Problem
The count parameter is currently not functioning. Based on testing, it appears to be ignored on the server side. This is problematic, as the default behavior fetches a large number of timelines:

fetchHomeTimeline: ~30–40 timelines per request
fetchFollowingTimeline: ~100 timelines per request

For users with the action processing feature enabled, this results in excessive LLM API calls (Reference: https://github.com/elizaOS/eliza/pull/1824 introduced a new environment variable to enable user interactions with following timelines.). In this PR, I used a workaround by slicing the timelines before processing to reduce the number of processed items.