### PR TITLE
feat: support for eternalai provider can make request with chain_id extra data in body

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,9 @@ IMAGE_OPENAI_MODEL=             # Default: dall-e-3
 # Eternal AI's Decentralized Inference API
 ETERNALAI_URL=
 ETERNALAI_MODEL=                # Default: "neuralmagic/Meta-Llama-3.1-405B-Instruct-quantized.w4a16"
+ETERNALAI_CHAIN_ID=45762        #Default: "45762"
 ETERNALAI_API_KEY=
-ETERNAL_AI_LOG_REQUEST=false #Default: false
+ETERNAL_AI_LOG_REQUEST=false    #Default: false
 
 GROK_API_KEY=                   # GROK/xAI API Key
 GROQ_API_KEY=                   # Starts with gsk_

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -389,6 +389,12 @@ export async function generateText({
                     apiKey,
                     baseURL: endpoint,
                     fetch: async (url: string, options: any) => {
+                        const chain_id = runtime.getSetting("ETERNALAI_CHAIN_ID") || "45762"
+                        if (options?.body) {
+                            const body = JSON.parse(options.body);
+                            body.chain_id = chain_id;
+                            options.body = JSON.stringify(body);
+                        }
                         const fetching = await runtime.fetch(url, options);
                         if (
                             parseBooleanFromText(
@@ -400,12 +406,16 @@ export async function generateText({
                                 JSON.stringify(options, null, 2)
                             );
                             const clonedResponse = fetching.clone();
-                            clonedResponse.json().then((data) => {
-                                elizaLogger.info(
-                                    "Response data: ",
-                                    JSON.stringify(data, null, 2)
-                                );
-                            });
+                            try {
+                                clonedResponse.json().then((data) => {
+                                    elizaLogger.info(
+                                        "Response data: ",
+                                        JSON.stringify(data, null, 2)
+                                    );
+                                });
+                            } catch (e) {
+                                elizaLogger.debug(e);
+                            }
                         }
                         return fetching;
                     },


### PR DESCRIPTION
# Risks

Low

# Background

## What does this PR do?

Config eternalai can extra request body with chain_id from env, this PR will replace for PR #1903

## What kind of change is this?

More flexible than with env

## Why are we doing this? Any context or related work?

Currently, Eliza supports only OpenAI. However, centralized AI providers limit user control, pose trust issues, and create single points of failure with high costs and restricted access. Decentralized AI offers a more transparent, accessible, and resilient alternative, empowering users with greater autonomy.

Learn more about our decentralized inference AI: https://eternalai.org/api


# Documentation changes needed?

My changes require a change to the project documentation.

# Testing

## Where should a reviewer start?

Reviewers start from .env.example

## Detailed testing steps

Run pnpm start --characters="path/to/your/characters/eternal.character.json"


# Deploy Notes

## Database changes

No change

## Deployment instructions

Change .env by adding more

ETERNALAI_CHAIN_ID=45762 #Default: "45762"