### PR TITLE
fix: include schema.sql and seed.sql in package files

### DIFF
--- a/packages/adapter-postgres/package.json
+++ b/packages/adapter-postgres/package.json
@@ -16,7 +16,9 @@
         }
     },
     "files": [
-        "dist"
+        "dist",
+        "schema.sql",
+        "seed.sql"
     ],
     "dependencies": {
         "@elizaos/core": "workspace:*",


### PR DESCRIPTION
# Relates to

Fixes #2009  - @elizaos/adapter-postgres package does not bundle together schema.sql

# Risks

Low - Adding missing SQL files to package bundling. Only affects package distribution, not functionality.

# Background

## What does this PR do?

Adds schema.sql and seed.sql files to the package.json "files" array to ensure they are properly bundled with the npm package when published.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. Review the package.json changes in packages/adapter-postgres/package.json
2. Verify the added files: schema.sql and seed.sql are included

## Detailed testing steps

1. Run `pnpm install @elizaos/adapter-postgres`
2. Instantiate PostgresDatabaseAdapter
3. Call db.init()
4. Verify no "no such file or directory" errors occur
5. Verify migrations run successfully

# Deploy Notes

After merging, a new package version will need to be published to npm to make the fix available to users.