### PR TITLE
feat: custom s3 endpoint url for 'plugin-node'

### DIFF
--- a/packages/plugin-node/src/environment.ts
+++ b/packages/plugin-node/src/environment.ts
@@ -81,6 +81,11 @@ export async function validateNodeConfig(
                 AWS_REGION: runtime.getSetting("AWS_REGION"),
                 AWS_S3_BUCKET: runtime.getSetting("AWS_S3_BUCKET"),
                 AWS_S3_UPLOAD_PATH: runtime.getSetting("AWS_S3_UPLOAD_PATH"),
+                AWS_S3_ENDPOINT: runtime.getSetting("AWS_S3_ENDPOINT"),
+                AWS_S3_SSL_ENABLED: runtime.getSetting("AWS_S3_SSL_ENABLED"),
+                AWS_S3_FORCE_PATH_STYLE: runtime.getSetting(
+                    "AWS_S3_FORCE_PATH_STYLE"
+                ),
             }),
         };
 


### PR DESCRIPTION
# Relates to

https://github.com/elizaOS/eliza/issues/2174, and builds upon https://github.com/elizaOS/eliza/pull/2379

# Risks

Low. This affects only the `plugin-node`, and it changes logic in a way that is backward compatible. 

# Background

## What does this PR do?

This changes the `plugin-node` to, optionally, use the set `AWS_S3_ENDPOINT` when generating URLs. If the value is set (e.g., `http://localhost:8014`), it instead uses this custom URL when reading/writing data. Closes https://github.com/elizaOS/eliza/issues/2174.

## What kind of change is this?

Feature; improves the S3 plugin functionality. 

## Why are we doing this? Any context or related work?

The S3 plugin lacked a small feature, which was still enforcing public AWS S3 URLs, even if you're using a local provider.

For reference, I'm building a web3 native object storage layer, which has S3 compatability—called Basin: https://basin.textile.io. We have an S3 adapter that works with MinIO, boto3, etc. I tested this plugin against our adapter, and everything worked as expected (more on this below).

# Documentation changes needed?

N/A

# Testing

## Where should a reviewer start?

If you'd like to test this flow, you'll need to use some local S3 compatible server. A popular one is [MinIO](https://min.io/docs/minio/linux/reference/minio-mc.html). Once you have the server running, it should log the local port. You can then set the `.env` variable `AWS_S3_ENDPOINT` to this value (e.g., `http://localhost:8014`), and then call `uploadFile`. 

## Detailed testing steps

I tested this against our S3 adapter with both raw and resigned URLs. For example:
```ts
const s3 = runtime?.getService(ServiceType.AWS_S3) as IAwsS3Service;
const tempFile = path.join(os.tmpdir(), "test.txt");
writeFileSync(tempFile, "test content");
const fileContent = readFileSync(tempFile, "utf8");
elizaLogger.log("File content:", fileContent);
const { success, url, error } = await s3.uploadFile(
    tempFile,
    "",
    true,
    3600
);
console.log(url);
// Default `url` value: `http://localhost:8014/eliza/images/1736652765063-test.txt`
// If presigned: `http://localhost:8014/eliza/images/1736652765063-test.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKEXAMPLES3S%2F20250112%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20250112T033246Z&X-Amz-Expires=3600&X-Amz-Signature=ebd5aaaf39c272ff22017289327851512597cdc5e9549156cd1adee3426135de&X-Amz-SignedHeaders=host&x-id=GetObject`
```

This assumes `AWS_S3_ENDPOINT` / `AWS_FORCE_PATH_STYLE` are set.

## Discord username

dtb_