### PR TITLE
fix: Missing LETZAI model

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -261,6 +261,7 @@ export enum ModelProviderName {
     NINETEEN_AI = "nineteen_ai",
     AKASH_CHAT_API = "akash_chat_api",
     LIVEPEER = "livepeer",
+    LETZAI = "letzai",
     DEEPSEEK="deepseek",
     INFERA="infera"
 }


### PR DESCRIPTION
## Pull Request: Add LETZAI to ModelProviderName enum
## What does this PR do?
Adds missing LETZAI enum value to ModelProviderName to fix type errors in agent/src/index.ts.
## Changes needed:
In @elizaos/packages/core, add to ModelProviderName enum:

## Testing
1. Build core package
2. Verify agent/src/index.ts compiles without errors 
3. Verify LETZAI provider works with getTokenForProvider()

## Risk Level: Low
- Simple enum addition
- Only affects type system
- No runtime behavior changes

## Testing Steps
1. Add enum value
2. Run `pnpm build` in core package
3. Run `pnpm build` in agent package
4. Verify no TypeScript errors in agent/src/index.ts

No documentation changes needed as this is an internal enum update.