### PR TITLE
fix: don't force root for install

### DIFF
--- a/packages/plugin-node/scripts/postinstall.js
+++ b/packages/plugin-node/scripts/postinstall.js
@@ -55,10 +55,10 @@ if (!distro || !supportedDistros.some((name) => distro.includes(name))) {
 }
 
 try {
-    execSync("npx playwright install-deps && npx playwright install", {
+    execSync("npx playwright install", {
         stdio: "inherit"
     });
 } catch (err) {
-    console.error("Failed to install Playwright dependencies:", err.message);
+    console.error("Failed to install Playwright you may need to install playwright deps with 'sudo npx playwright install-deps'. Error: ", err.message);
     process.exit(1);
 }


### PR DESCRIPTION
# Risks

Low

# Background

Currently pnpm install on linux (and probably mac etc) is doing a ```npx playwright install-deps``` for the post postinstall script on plugin-node. This forces a super user login for root access which is a huge red flag and generally a bad practice.

## What does this PR do?

Removes the root privileged command and in the rare case the user does not have the required dependencies prints a console message on how to fix. This way users aren't blindly trusting what calls are being made with super user privileges.  

## What kind of change is this?

Bug fix

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

None
