### PR TITLE
feat: add support for gravity chain in EVM plugin

### DIFF
--- a/packages/plugin-evm/src/templates/index.ts
+++ b/packages/plugin-evm/src/templates/index.ts
@@ -75,8 +75,8 @@ Respond with a JSON markdown block containing only the extracted values:
 \`\`\`json
 {
     "token": string | null,
-    "fromChain": "ethereum" | "abstract" | "base" | "sepolia" | "bsc" | "arbitrum" | "avalanche" | "polygon" | "optimism" | "cronos" | "gnosis" | "fantom" | "fraxtal" | "klaytn" | "celo" | "moonbeam" | "aurora" | "harmonyOne" | "moonriver" | "arbitrumNova" | "mantle" | "linea" | "scroll" | "filecoin" | "taiko" | "zksync" | "canto" | "alienx" | null,
-    "toChain": "ethereum" | "abstract" | "base" | "sepolia" | "bsc" | "arbitrum" | "avalanche" | "polygon" | "optimism" | "cronos" | "gnosis" | "fantom" | "fraxtal" | "klaytn" | "celo" | "moonbeam" | "aurora" | "harmonyOne" | "moonriver" | "arbitrumNova" | "mantle" | "linea" | "scroll" | "filecoin" | "taiko" | "zksync" | "canto" | "alienx" | null,
+    "fromChain": "ethereum" | "abstract" | "base" | "sepolia" | "bsc" | "arbitrum" | "avalanche" | "polygon" | "optimism" | "cronos" | "gnosis" | "fantom" | "fraxtal" | "klaytn" | "celo" | "moonbeam" | "aurora" | "harmonyOne" | "moonriver" | "arbitrumNova" | "mantle" | "linea" | "scroll" | "filecoin" | "taiko" | "zksync" | "canto" | "alienx" | "gravity" | null,
+    "toChain": "ethereum" | "abstract" | "base" | "sepolia" | "bsc" | "arbitrum" | "avalanche" | "polygon" | "optimism" | "cronos" | "gnosis" | "fantom" | "fraxtal" | "klaytn" | "celo" | "moonbeam" | "aurora" | "harmonyOne" | "moonriver" | "arbitrumNova" | "mantle" | "linea" | "scroll" | "filecoin" | "taiko" | "zksync" | "canto" | "alienx" | "gravity" |  null,
     "amount": string | null,
     "toAddress": string | null
 }

--- a/packages/plugin-evm/src/types/index.ts
+++ b/packages/plugin-evm/src/types/index.ts
@@ -117,6 +117,7 @@ export interface EvmPluginConfig {
         zksync?: string;
         canto?: string;
         alienx?: string;
+        gravity?: string;
     };
     secrets?: {
         EVM_PRIVATE_KEY: string;


### PR DESCRIPTION

# Relates to

No specific issue related.

# Risks

Low. This PR only adds gravity to templates and types.

# Background

## What does this PR do?

- Updated `fromChain` and `toChain` types in `templates/index.ts` to include "gravity".
- Added "gravity" to the `EvmPluginConfig` interface in `types/index.ts`.

This enhancement allows the EVM plugin to handle transactions involving the ["gravity" chain.](https://docs.gravity.xyz/network/using-gravity-alpha-mainnet-l2)

## What kind of change is this?

Features (non-breaking change which adds functionality)


# Documentation changes needed?

My changes do not require a change to the project documentation.


# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->
