### PR TITLE
docs: Typo fix README.md

### DIFF
--- a/packages/plugin-stargaze/README.md
+++ b/packages/plugin-stargaze/README.md
@@ -14,7 +14,7 @@ pnpm add @elizaos/plugin-stargaze
 
 ## Configuration
 
-Set up your environment with the required Stargaze API endpoint, currently Stargaze offers https://graphql.mainnet.stargaze-apis.com/graphql publically.
+Set up your environment with the required Stargaze API endpoint, currently Stargaze offers https://graphql.mainnet.stargaze-apis.com/graphql publicly.
 
 | Variable Name | Description |
 | ------------- | ----------- |


### PR DESCRIPTION
# Typo Fix in README.md

## Description
Corrected a typo:
- Replaced `publically` with `publicly` in the README file.

---

This PR is ready for review. 🚀
