### PR TITLE
Feature: Add remote character support via urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ For detailed instructions on using the start script, including character managem
 2. To load custom characters:
     - Use `pnpm start --characters="path/to/your/character.json"`
     - Multiple character files can be loaded simultaneously
+    - You can also load characters from a URL
+        - Example: `pnpm start --characters="https://example.com/character.json"`
+
 3. Connect with X (Twitter)
     - change `"clients": []` to `"clients": ["twitter"]` in the character file to connect with X
 


### PR DESCRIPTION
# Relates to

Issue: https://github.com/elizaOS/eliza/issues/2252

<!-- This risks section must be filled out before the final review and merge. -->
# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->
#### Low 
- Users have to be completely sure that the character file they have hosted remotely is valid, If changes are made to the `Character` schema then the remote URL may not be valid anymore.

## What does this PR do?
- Adds support for remote links to be utilized alongside local character file

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->
Non breaking feature

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->
I adjusted the ReadMe.md to include the new way of utilizing the `characters` method

# Testing
Works: `pnpm start --character="characters/trump.character.json"` // Sample Character
Works: `pnpm start --character="example.com/valid-character.json"` // JSON File
Works: `pnpm start --character="example.com/valid-character.txt"` // Text File
Fails: `pnpm start --character="example.com/invalid-character.json"`
Fails: `pnpm start --character="invalid-url.com/invalid-character"`

## Where should a reviewer start?
Testing that starting the server using the old & new additional ways work as expected.

## Detailed testing steps
- Create an AWS or gist file with an invalid & valid character
- Test the expected scenario
      - Invalid character should say there was an error validating character
      - Valid character should start the server
      - Invalid URL should say there was an error fetching the character 