### PR TITLE
fix: correct OPENROUTER_API_KEY env in config

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -372,7 +372,7 @@ export function getTokenForProvider(
             );
         case ModelProviderName.OPENROUTER:
             return (
-                character.settings?.secrets?.OPENROUTER ||
+                character.settings?.secrets?.OPENROUTER_API_KEY ||
                 settings.OPENROUTER_API_KEY
             );
         case ModelProviderName.GROK:


### PR DESCRIPTION
# Relates to

# Risks
LOW

# Background
set private runtime envs for each character, eg:  
```
character.settings.secrets = {...privateEnvs};
```
use openrouter as ModelProvider and set OPENROUTER_API_KEY as agent runtime secrects 

## What does this PR do?
fix OPENROUTER_API_KEY env bug

## What kind of change is this?
Bug fixes

# Documentation changes needed?
NO

# Testing

## Where should a reviewer start?

## Detailed testing steps
use openrouter as ModelProvider and set OPENROUTER_API_KEY as agent runtime secrects 
## Screenshots
### Before
<img width="397" alt="image" src="https://github.com/user-attachments/assets/fa3504e3-6aee-412d-b80f-0a8caf3f83c0" />

### After
runs correctly
