### PR TITLE
feat: Enable Multiple remote character urls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,8 @@ SERVER_PORT=3000
 SUPABASE_URL=
 SUPABASE_ANON_KEY=
 
-# Remote character url (optional)
-REMOTE_CHARACTER_URL=
+# Comma separated list of remote character urls (optional)
+REMOTE_CHARACTER_URLS=
 
 ###############################
 #### Client Configurations ####

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1104,8 +1104,6 @@ const startAgents = async () => {
     let charactersArg = args.characters || args.character;
     let characters = [defaultCharacter];
 
-    
-        
     if (charactersArg || hasValidRemoteUrls()) {
         characters = await loadCharacters(charactersArg);
     }

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -244,12 +244,15 @@ async function loadCharacter(filePath: string): Promise<Character> {
     return jsonToCharacter(filePath, character);
 }
 
+function commaSeparatedStringToArray(commaSeparated: string): string[] {
+    return commaSeparated?.split(",").map(value => value.trim())
+}
+
+
 export async function loadCharacters(
     charactersArg: string
 ): Promise<Character[]> {
-    let characterPaths = charactersArg
-        ?.split(",")
-        .map((filePath) => filePath.trim());
+    let characterPaths = commaSeparatedStringToArray(charactersArg)
     const loadedCharacters: Character[] = [];
 
     if (characterPaths?.length > 0) {
@@ -321,17 +324,16 @@ export async function loadCharacters(
         }
     }
 
-    if (loadedCharacters.length === 0) {
-        if (
-            process.env.REMOTE_CHARACTER_URL != "" &&
-            process.env.REMOTE_CHARACTER_URL.startsWith("http")
-        ) {
-            const character = await loadCharacterFromUrl(
-                process.env.REMOTE_CHARACTER_URL
-            );
+    if (hasValidRemoteUrls()) {
+        elizaLogger.info("Loading characters from remote URLs");
+        let characterUrls = commaSeparatedStringToArray(process.env.REMOTE_CHARACTER_URLS)
+        for (const characterUrl of characterUrls) {
+            const character = await loadCharacterFromUrl(characterUrl);
             loadedCharacters.push(character);
         }
+    }
 
+    if (loadedCharacters.length === 0) {
         elizaLogger.info("No characters found, using default character");
         loadedCharacters.push(defaultCharacter);
     }
@@ -1091,6 +1093,10 @@ const checkPortAvailable = (port: number): Promise<boolean> => {
     });
 };
 
+const hasValidRemoteUrls = () =>
+    process.env.REMOTE_CHARACTER_URLS != "" &&
+    process.env.REMOTE_CHARACTER_URLS.startsWith("http")
+
 const startAgents = async () => {
     const directClient = new DirectClient();
     let serverPort = parseInt(settings.SERVER_PORT || "3000");
@@ -1098,7 +1104,9 @@ const startAgents = async () => {
     let charactersArg = args.characters || args.character;
     let characters = [defaultCharacter];
 
-    if (charactersArg) {
+    
+        
+    if (charactersArg || hasValidRemoteUrls()) {
         characters = await loadCharacters(charactersArg);
     }
 


### PR DESCRIPTION
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

[Issue #2252](https://github.com/elizaOS/eliza/issues/2252)
[Expands on PR #2281](https://github.com/elizaOS/eliza/pull/2281)

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->
- Security risk using character URLs

# Background

## What does this PR do?
Allows multiple remote character urls to be used whether in conjuction with `character(s)` param or not

## Detailed testing steps
- A user can start the server with OR without character(s) params and the remote character(s) will load