### PR TITLE
Fix formatting in Browser section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ pnpm clean
 
 ### Interact via Browser
 
-```
 Once the agent is running, you should see the message to run "pnpm start:client" at the end.
-Open another terminal and move to same directory and then run below command and follow the URL to chat to your agent.
+
+Open another terminal, move to same directory, run the command below, then follow the URL to chat with your agent.
 
 ```bash
 pnpm start:client


### PR DESCRIPTION
Hey all! I saw strange formatting in the README.md and figured it was an extra three backticks ```

Sure enough, deleting those made the section render as intended. I also reworded one of the sentences that had three "and"s to make it a little more legible.

# Risks

None? Small README tweak shouldn't break anything.

# Background

## What does this PR do?

Small tweak to a specific section of the README to make it render as intended by the author.

## What kind of change is this?

Improvement to legibility of README.

# Documentation changes needed?

The changes are to the documentation :)

# Testing

## Where should a reviewer start?

Preview the file and lmk if you agree it's an improvement.

Before:
<img width="593" alt="Screenshot 2025-01-15 at 2 15 27 PM" src="https://github.com/user-attachments/assets/1e9dce32-43c2-4bcf-b159-369b24946197" />

After:
<img width="634" alt="Screenshot 2025-01-15 at 2 15 13 PM" src="https://github.com/user-attachments/assets/02e6ba08-4739-4f1e-8c03-75827be8e027" />


## Discord username

Happy to get the role `@derrekwonders`, but not needed for something small like this.