### PR TITLE
feat: (ragKnowledge) Enhance RAG knowledge handling

### DIFF
--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -16,6 +16,7 @@ import {
     type Relationship,
     type UUID,
     RAGKnowledgeItem,
+    type ChunkRow,
 } from "@elizaos/core";
 import { Database } from "better-sqlite3";
 import { v4 } from "uuid";
@@ -966,8 +967,106 @@ export class SqliteDatabaseAdapter
     }
 
     async removeKnowledge(id: UUID): Promise<void> {
-        const sql = `DELETE FROM knowledge WHERE id = ?`;
-        this.db.prepare(sql).run(id);
+        if (typeof id !== "string") {
+            throw new Error("Knowledge ID must be a string");
+        }
+
+        try {
+            // Execute the transaction and ensure it's called with ()
+            await this.db.transaction(() => {
+                if (id.includes("*")) {
+                    const pattern = id.replace("*", "%");
+                    const sql = "DELETE FROM knowledge WHERE id LIKE ?";
+                    elizaLogger.debug(
+                        `[Knowledge Remove] Executing SQL: ${sql} with pattern: ${pattern}`
+                    );
+                    const stmt = this.db.prepare(sql);
+                    const result = stmt.run(pattern);
+                    elizaLogger.debug(
+                        `[Knowledge Remove] Pattern deletion affected ${result.changes} rows`
+                    );
+                    return result.changes; // Return changes for logging
+                } else {
+                    // Log queries before execution
+                    const selectSql = "SELECT id FROM knowledge WHERE id = ?";
+                    const chunkSql =
+                        "SELECT id FROM knowledge WHERE json_extract(content, '$.metadata.originalId') = ?";
+                    elizaLogger.debug(`[Knowledge Remove] Checking existence with:
+                        Main: ${selectSql} [${id}]
+                        Chunks: ${chunkSql} [${id}]`);
+
+                    const mainEntry = this.db.prepare(selectSql).get(id) as
+                        | ChunkRow
+                        | undefined;
+                    const chunks = this.db
+                        .prepare(chunkSql)
+                        .all(id) as ChunkRow[];
+
+                    elizaLogger.debug(`[Knowledge Remove] Found:`, {
+                        mainEntryExists: !!mainEntry?.id,
+                        chunkCount: chunks.length,
+                        chunkIds: chunks.map((c) => c.id),
+                    });
+
+                    // Execute and log chunk deletion
+                    const chunkDeleteSql =
+                        "DELETE FROM knowledge WHERE json_extract(content, '$.metadata.originalId') = ?";
+                    elizaLogger.debug(
+                        `[Knowledge Remove] Executing chunk deletion: ${chunkDeleteSql} [${id}]`
+                    );
+                    const chunkResult = this.db.prepare(chunkDeleteSql).run(id);
+                    elizaLogger.debug(
+                        `[Knowledge Remove] Chunk deletion affected ${chunkResult.changes} rows`
+                    );
+
+                    // Execute and log main entry deletion
+                    const mainDeleteSql = "DELETE FROM knowledge WHERE id = ?";
+                    elizaLogger.debug(
+                        `[Knowledge Remove] Executing main deletion: ${mainDeleteSql} [${id}]`
+                    );
+                    const mainResult = this.db.prepare(mainDeleteSql).run(id);
+                    elizaLogger.debug(
+                        `[Knowledge Remove] Main deletion affected ${mainResult.changes} rows`
+                    );
+
+                    const totalChanges =
+                        chunkResult.changes + mainResult.changes;
+                    elizaLogger.debug(
+                        `[Knowledge Remove] Total rows affected: ${totalChanges}`
+                    );
+
+                    // Verify deletion
+                    const verifyMain = this.db.prepare(selectSql).get(id);
+                    const verifyChunks = this.db.prepare(chunkSql).all(id);
+                    elizaLogger.debug(
+                        `[Knowledge Remove] Post-deletion check:`,
+                        {
+                            mainStillExists: !!verifyMain,
+                            remainingChunks: verifyChunks.length,
+                        }
+                    );
+
+                    return totalChanges; // Return changes for logging
+                }
+            })(); // Important: Call the transaction function
+
+            elizaLogger.debug(
+                `[Knowledge Remove] Transaction completed for id: ${id}`
+            );
+        } catch (error) {
+            elizaLogger.error("[Knowledge Remove] Error:", {
+                id,
+                error:
+                    error instanceof Error
+                        ? {
+                              message: error.message,
+                              stack: error.stack,
+                              name: error.name,
+                          }
+                        : error,
+            });
+            throw error;
+        }
     }
 
     async clearKnowledge(agentId: UUID, shared?: boolean): Promise<void> {

--- a/packages/core/src/environment.ts
+++ b/packages/core/src/environment.ts
@@ -77,15 +77,23 @@ export const CharacterSchema = z.object({
     postExamples: z.array(z.string()),
     topics: z.array(z.string()),
     adjectives: z.array(z.string()),
-    knowledge: z.array(
-        z.union([
-            z.string(),
-            z.object({
-                path: z.string(),
-                shared: z.boolean().optional()
-            })
-        ])
-    ).optional(),
+    knowledge: z
+        .array(
+            z.union([
+                z.string(), // Direct knowledge strings
+                z.object({
+                    // Individual file config
+                    path: z.string(),
+                    shared: z.boolean().optional(),
+                }),
+                z.object({
+                    // Directory config
+                    directory: z.string(),
+                    shared: z.boolean().optional(),
+                }),
+            ])
+        )
+        .optional(),
     clients: z.array(z.nativeEnum(Clients)),
     plugins: z.union([z.array(z.string()), z.array(PluginSchema)]),
     settings: z

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -52,7 +52,7 @@ import {
 import { fal } from "@fal-ai/client";
 
 import BigNumber from "bignumber.js";
-import {createPublicClient, http} from "viem";
+import { createPublicClient, http } from "viem";
 
 type Tool = CoreTool<any, any>;
 type StepResult = AIStepResult<any>;
@@ -169,20 +169,41 @@ async function truncateTiktoken(
  * Get OnChain EternalAI System Prompt
  * @returns System Prompt
  */
-async function getOnChainEternalAISystemPrompt(runtime: IAgentRuntime): Promise<string> | undefined {
-    const agentId = runtime.getSetting("ETERNALAI_AGENT_ID")
+async function getOnChainEternalAISystemPrompt(
+    runtime: IAgentRuntime
+): Promise<string> | undefined {
+    const agentId = runtime.getSetting("ETERNALAI_AGENT_ID");
     const providerUrl = runtime.getSetting("ETERNALAI_RPC_URL");
-    const contractAddress = runtime.getSetting("ETERNALAI_AGENT_CONTRACT_ADDRESS");
+    const contractAddress = runtime.getSetting(
+        "ETERNALAI_AGENT_CONTRACT_ADDRESS"
+    );
     if (agentId && providerUrl && contractAddress) {
         // get on-chain system-prompt
-        const contractABI = [{"inputs": [{"internalType": "uint256", "name": "_agentId", "type": "uint256"}], "name": "getAgentSystemPrompt", "outputs": [{"internalType": "bytes[]", "name": "","type": "bytes[]"}], "stateMutability": "view", "type": "function"}];
+        const contractABI = [
+            {
+                inputs: [
+                    {
+                        internalType: "uint256",
+                        name: "_agentId",
+                        type: "uint256",
+                    },
+                ],
+                name: "getAgentSystemPrompt",
+                outputs: [
+                    { internalType: "bytes[]", name: "", type: "bytes[]" },
+                ],
+                stateMutability: "view",
+                type: "function",
+            },
+        ];
 
         const publicClient = createPublicClient({
             transport: http(providerUrl),
         });
 
         try {
-            const validAddress: `0x${string}` = contractAddress as `0x${string}`;
+            const validAddress: `0x${string}` =
+                contractAddress as `0x${string}`;
             const result = await publicClient.readContract({
                 address: validAddress,
                 abi: contractABI,
@@ -190,17 +211,17 @@ async function getOnChainEternalAISystemPrompt(runtime: IAgentRuntime): Promise<
                 args: [new BigNumber(agentId)],
             });
             if (result) {
-                elizaLogger.info('on-chain system-prompt response', result[0]);
+                elizaLogger.info("on-chain system-prompt response", result[0]);
                 const value = result[0].toString().replace("0x", "");
-                let content = Buffer.from(value, 'hex').toString('utf-8');
-                elizaLogger.info('on-chain system-prompt', content);
-                return await fetchEternalAISystemPrompt(runtime, content)
+                const content = Buffer.from(value, "hex").toString("utf-8");
+                elizaLogger.info("on-chain system-prompt", content);
+                return await fetchEternalAISystemPrompt(runtime, content);
             } else {
                 return undefined;
             }
         } catch (error) {
             elizaLogger.error(error);
-            elizaLogger.error('err', error);
+            elizaLogger.error("err", error);
         }
     }
     return undefined;
@@ -210,34 +231,42 @@ async function getOnChainEternalAISystemPrompt(runtime: IAgentRuntime): Promise<
  * Fetch EternalAI System Prompt
  * @returns System Prompt
  */
-async function fetchEternalAISystemPrompt(runtime: IAgentRuntime, content: string): Promise<string> | undefined {
-    const IPFS = "ipfs://"
+async function fetchEternalAISystemPrompt(
+    runtime: IAgentRuntime,
+    content: string
+): Promise<string> | undefined {
+    const IPFS = "ipfs://";
     const containsSubstring: boolean = content.includes(IPFS);
     if (containsSubstring) {
-
-        const lightHouse = content.replace(IPFS, "https://gateway.lighthouse.storage/ipfs/");
-        elizaLogger.info("fetch lightHouse", lightHouse)
+        const lightHouse = content.replace(
+            IPFS,
+            "https://gateway.lighthouse.storage/ipfs/"
+        );
+        elizaLogger.info("fetch lightHouse", lightHouse);
         const responseLH = await fetch(lightHouse, {
             method: "GET",
         });
-        elizaLogger.info("fetch lightHouse resp", responseLH)
+        elizaLogger.info("fetch lightHouse resp", responseLH);
         if (responseLH.ok) {
             const data = await responseLH.text();
             return data;
         } else {
-            const gcs = content.replace(IPFS, "https://cdn.eternalai.org/upload/")
-            elizaLogger.info("fetch gcs", gcs)
+            const gcs = content.replace(
+                IPFS,
+                "https://cdn.eternalai.org/upload/"
+            );
+            elizaLogger.info("fetch gcs", gcs);
             const responseGCS = await fetch(gcs, {
                 method: "GET",
             });
-            elizaLogger.info("fetch lightHouse gcs", responseGCS)
+            elizaLogger.info("fetch lightHouse gcs", responseGCS);
             if (responseGCS.ok) {
                 const data = await responseGCS.text();
                 return data;
             } else {
-                throw new Error("invalid on-chain system prompt")
+                throw new Error("invalid on-chain system prompt");
             }
-            return undefined
+            return undefined;
         }
     } else {
         return content;
@@ -250,8 +279,12 @@ async function fetchEternalAISystemPrompt(runtime: IAgentRuntime, content: strin
  * @param provider The model provider name
  * @returns The Cloudflare Gateway base URL if enabled, undefined otherwise
  */
-function getCloudflareGatewayBaseURL(runtime: IAgentRuntime, provider: string): string | undefined {
-    const isCloudflareEnabled = runtime.getSetting("CLOUDFLARE_GW_ENABLED") === "true";
+function getCloudflareGatewayBaseURL(
+    runtime: IAgentRuntime,
+    provider: string
+): string | undefined {
+    const isCloudflareEnabled =
+        runtime.getSetting("CLOUDFLARE_GW_ENABLED") === "true";
     const cloudflareAccountId = runtime.getSetting("CLOUDFLARE_AI_ACCOUNT_ID");
     const cloudflareGatewayId = runtime.getSetting("CLOUDFLARE_AI_GATEWAY_ID");
 
@@ -259,7 +292,7 @@ function getCloudflareGatewayBaseURL(runtime: IAgentRuntime, provider: string): 
         isEnabled: isCloudflareEnabled,
         hasAccountId: !!cloudflareAccountId,
         hasGatewayId: !!cloudflareGatewayId,
-        provider: provider
+        provider: provider,
     });
 
     if (!isCloudflareEnabled) {
@@ -268,12 +301,16 @@ function getCloudflareGatewayBaseURL(runtime: IAgentRuntime, provider: string): 
     }
 
     if (!cloudflareAccountId) {
-        elizaLogger.warn("Cloudflare Gateway is enabled but CLOUDFLARE_AI_ACCOUNT_ID is not set");
+        elizaLogger.warn(
+            "Cloudflare Gateway is enabled but CLOUDFLARE_AI_ACCOUNT_ID is not set"
+        );
         return undefined;
     }
 
     if (!cloudflareGatewayId) {
-        elizaLogger.warn("Cloudflare Gateway is enabled but CLOUDFLARE_AI_GATEWAY_ID is not set");
+        elizaLogger.warn(
+            "Cloudflare Gateway is enabled but CLOUDFLARE_AI_GATEWAY_ID is not set"
+        );
         return undefined;
     }
 
@@ -282,7 +319,7 @@ function getCloudflareGatewayBaseURL(runtime: IAgentRuntime, provider: string): 
         provider,
         baseURL,
         accountId: cloudflareAccountId,
-        gatewayId: cloudflareGatewayId
+        gatewayId: cloudflareGatewayId,
     });
 
     return baseURL;
@@ -372,9 +409,13 @@ export async function generateText({
         hasRuntime: !!runtime,
         runtimeSettings: {
             CLOUDFLARE_GW_ENABLED: runtime.getSetting("CLOUDFLARE_GW_ENABLED"),
-            CLOUDFLARE_AI_ACCOUNT_ID: runtime.getSetting("CLOUDFLARE_AI_ACCOUNT_ID"),
-            CLOUDFLARE_AI_GATEWAY_ID: runtime.getSetting("CLOUDFLARE_AI_GATEWAY_ID")
-        }
+            CLOUDFLARE_AI_ACCOUNT_ID: runtime.getSetting(
+                "CLOUDFLARE_AI_ACCOUNT_ID"
+            ),
+            CLOUDFLARE_AI_GATEWAY_ID: runtime.getSetting(
+                "CLOUDFLARE_AI_GATEWAY_ID"
+            ),
+        },
     });
 
     const endpoint =
@@ -494,8 +535,11 @@ export async function generateText({
             case ModelProviderName.TOGETHER:
             case ModelProviderName.NINETEEN_AI:
             case ModelProviderName.AKASH_CHAT_API: {
-                elizaLogger.debug("Initializing OpenAI model with Cloudflare check");
-                const baseURL = getCloudflareGatewayBaseURL(runtime, 'openai') || endpoint;
+                elizaLogger.debug(
+                    "Initializing OpenAI model with Cloudflare check"
+                );
+                const baseURL =
+                    getCloudflareGatewayBaseURL(runtime, "openai") || endpoint;
 
                 //elizaLogger.debug("OpenAI baseURL result:", { baseURL });
                 const openai = createOpenAI({
@@ -565,17 +609,26 @@ export async function generateText({
                     },
                 });
 
-                let system_prompt = runtime.character.system ?? settings.SYSTEM_PROMPT ?? undefined;
+                let system_prompt =
+                    runtime.character.system ??
+                    settings.SYSTEM_PROMPT ??
+                    undefined;
                 try {
-                    const on_chain_system_prompt = await getOnChainEternalAISystemPrompt(runtime);
+                    const on_chain_system_prompt =
+                        await getOnChainEternalAISystemPrompt(runtime);
                     if (!on_chain_system_prompt) {
-                        elizaLogger.error(new Error("invalid on_chain_system_prompt"))
+                        elizaLogger.error(
+                            new Error("invalid on_chain_system_prompt")
+                        );
                     } else {
-                        system_prompt = on_chain_system_prompt
-                        elizaLogger.info("new on-chain system prompt", system_prompt)
+                        system_prompt = on_chain_system_prompt;
+                        elizaLogger.info(
+                            "new on-chain system prompt",
+                            system_prompt
+                        );
                     }
                 } catch (e) {
-                    elizaLogger.error(e)
+                    elizaLogger.error(e);
                 }
 
                 const { text: openaiResponse } = await aiGenerateText({
@@ -643,11 +696,19 @@ export async function generateText({
             }
 
             case ModelProviderName.ANTHROPIC: {
-                elizaLogger.debug("Initializing Anthropic model with Cloudflare check");
-                const baseURL = getCloudflareGatewayBaseURL(runtime, 'anthropic') || "https://api.anthropic.com/v1";
+                elizaLogger.debug(
+                    "Initializing Anthropic model with Cloudflare check"
+                );
+                const baseURL =
+                    getCloudflareGatewayBaseURL(runtime, "anthropic") ||
+                    "https://api.anthropic.com/v1";
                 elizaLogger.debug("Anthropic baseURL result:", { baseURL });
 
-                const anthropic = createAnthropic({ apiKey, baseURL, fetch: runtime.fetch });
+                const anthropic = createAnthropic({
+                    apiKey,
+                    baseURL,
+                    fetch: runtime.fetch,
+                });
                 const { text: anthropicResponse } = await aiGenerateText({
                     model: anthropic.languageModel(model),
                     prompt: context,
@@ -735,10 +796,16 @@ export async function generateText({
             }
 
             case ModelProviderName.GROQ: {
-                elizaLogger.debug("Initializing Groq model with Cloudflare check");
-                const baseURL = getCloudflareGatewayBaseURL(runtime, 'groq');
+                elizaLogger.debug(
+                    "Initializing Groq model with Cloudflare check"
+                );
+                const baseURL = getCloudflareGatewayBaseURL(runtime, "groq");
                 elizaLogger.debug("Groq baseURL result:", { baseURL });
-                const groq = createGroq({ apiKey, fetch: runtime.fetch, baseURL });
+                const groq = createGroq({
+                    apiKey,
+                    fetch: runtime.fetch,
+                    baseURL,
+                });
 
                 const { text: groqResponse } = await aiGenerateText({
                     model: groq.languageModel(model),
@@ -1177,12 +1244,22 @@ export async function splitChunks(
     chunkSize: number = 512,
     bleed: number = 20
 ): Promise<string[]> {
+    elizaLogger.debug(`[splitChunks] Starting text split`);
+
     const textSplitter = new RecursiveCharacterTextSplitter({
         chunkSize: Number(chunkSize),
         chunkOverlap: Number(bleed),
     });
 
-    return textSplitter.splitText(content);
+    const chunks = await textSplitter.splitText(content);
+    elizaLogger.debug(`[splitChunks] Split complete:`, {
+        numberOfChunks: chunks.length,
+        averageChunkSize:
+            chunks.reduce((acc, chunk) => acc + chunk.length, 0) /
+            chunks.length,
+    });
+
+    return chunks;
 }
 
 /**
@@ -2020,7 +2097,9 @@ async function handleOpenAI({
     provider: _provider,
     runtime,
 }: ProviderOptions): Promise<GenerateObjectResult<unknown>> {
-    const baseURL = getCloudflareGatewayBaseURL(runtime, 'openai') || models.openai.endpoint;
+    const baseURL =
+        getCloudflareGatewayBaseURL(runtime, "openai") ||
+        models.openai.endpoint;
     const openai = createOpenAI({ apiKey, baseURL });
     return await aiGenerateObject({
         model: openai.languageModel(model),
@@ -2049,7 +2128,7 @@ async function handleAnthropic({
     runtime,
 }: ProviderOptions): Promise<GenerateObjectResult<unknown>> {
     elizaLogger.debug("Handling Anthropic request with Cloudflare check");
-    const baseURL = getCloudflareGatewayBaseURL(runtime, 'anthropic');
+    const baseURL = getCloudflareGatewayBaseURL(runtime, "anthropic");
     elizaLogger.debug("Anthropic handleAnthropic baseURL:", { baseURL });
 
     const anthropic = createAnthropic({ apiKey, baseURL });
@@ -2106,7 +2185,7 @@ async function handleGroq({
     runtime,
 }: ProviderOptions): Promise<GenerateObjectResult<unknown>> {
     elizaLogger.debug("Handling Groq request with Cloudflare check");
-    const baseURL = getCloudflareGatewayBaseURL(runtime, 'groq');
+    const baseURL = getCloudflareGatewayBaseURL(runtime, "groq");
     elizaLogger.debug("Groq handleGroq baseURL:", { baseURL });
 
     const groq = createGroq({ apiKey, baseURL });

--- a/packages/core/src/localembeddingManager.ts
+++ b/packages/core/src/localembeddingManager.ts
@@ -104,17 +104,17 @@ class LocalEmbeddingModelManager {
         try {
             // Let fastembed handle tokenization internally
             const embedding = await this.model.queryEmbed(input);
-            // Debug the raw embedding
-            elizaLogger.debug("Raw embedding from BGE:", {
-                type: typeof embedding,
-                isArray: Array.isArray(embedding),
-                dimensions: Array.isArray(embedding)
-                    ? embedding.length
-                    : "not an array",
-                sample: Array.isArray(embedding)
-                    ? embedding.slice(0, 5)
-                    : embedding,
-            });
+            // Debug the raw embedding - uncomment if debugging embeddings
+            // elizaLogger.debug("Raw embedding from BGE:", {
+            //     type: typeof embedding,
+            //     isArray: Array.isArray(embedding),
+            //     dimensions: Array.isArray(embedding)
+            //         ? embedding.length
+            //         : "not an array",
+            //     sample: Array.isArray(embedding)
+            //         ? embedding.slice(0, 5)
+            //         : embedding,
+            // });
             return this.processEmbedding(embedding);
         } catch (error) {
             elizaLogger.error("Embedding generation failed:", error);

--- a/packages/core/src/ragknowledge.ts
+++ b/packages/core/src/ragknowledge.ts
@@ -6,8 +6,11 @@ import {
     IRAGKnowledgeManager,
     RAGKnowledgeItem,
     UUID,
+    KnowledgeScope,
 } from "./types.ts";
 import { stringToUuid } from "./uuid.ts";
+import { existsSync } from "fs";
+import { join } from "path";
 
 /**
  * Manage knowledge in the database.
@@ -24,14 +27,24 @@ export class RAGKnowledgeManager implements IRAGKnowledgeManager {
     tableName: string;
 
     /**
+     * The root directory where RAG knowledge files are located (internal)
+     */
+    knowledgeRoot: string;
+
+    /**
      * Constructs a new KnowledgeManager instance.
      * @param opts Options for the manager.
      * @param opts.tableName The name of the table this manager will operate on.
      * @param opts.runtime The AgentRuntime instance associated with this manager.
      */
-    constructor(opts: { tableName: string; runtime: IAgentRuntime }) {
+    constructor(opts: {
+        tableName: string;
+        runtime: IAgentRuntime;
+        knowledgeRoot: string;
+    }) {
         this.runtime = opts.runtime;
         this.tableName = opts.tableName;
+        this.knowledgeRoot = opts.knowledgeRoot;
     }
 
     private readonly defaultRAGMatchThreshold = 0.85;
@@ -111,23 +124,25 @@ export class RAGKnowledgeManager implements IRAGKnowledgeManager {
             return "";
         }
 
-        return content
-            .replace(/```[\s\S]*?```/g, "")
-            .replace(/`.*?`/g, "")
-            .replace(/#{1,6}\s*(.*)/g, "$1")
-            .replace(/!\[(.*?)\]\(.*?\)/g, "$1")
-            .replace(/\[(.*?)\]\(.*?\)/g, "$1")
-            .replace(/(https?:\/\/)?(www\.)?([^\s]+\.[^\s]+)/g, "$3")
-            .replace(/<@[!&]?\d+>/g, "")
-            .replace(/<[^>]*>/g, "")
-            .replace(/^\s*[-*_]{3,}\s*$/gm, "")
-            .replace(/\/\*[\s\S]*?\*\//g, "")
-            .replace(/\/\/.*/g, "")
-            .replace(/\s+/g, " ")
-            .replace(/\n{3,}/g, "\n\n")
-            .replace(/[^a-zA-Z0-9\s\-_./:?=&]/g, "")
-            .trim()
-            .toLowerCase();
+        return (
+            content
+                .replace(/```[\s\S]*?```/g, "")
+                .replace(/`.*?`/g, "")
+                .replace(/#{1,6}\s*(.*)/g, "$1")
+                .replace(/!\[(.*?)\]\(.*?\)/g, "$1")
+                .replace(/\[(.*?)\]\(.*?\)/g, "$1")
+                .replace(/(https?:\/\/)?(www\.)?([^\s]+\.[^\s]+)/g, "$3")
+                .replace(/<@[!&]?\d+>/g, "")
+                .replace(/<[^>]*>/g, "")
+                .replace(/^\s*[-*_]{3,}\s*$/gm, "")
+                .replace(/\/\*[\s\S]*?\*\//g, "")
+                .replace(/\/\/.*/g, "")
+                .replace(/\s+/g, " ")
+                .replace(/\n{3,}/g, "\n\n")
+                // .replace(/[^a-zA-Z0-9\s\-_./:?=&]/g, "") --this strips out CJK characters
+                .trim()
+                .toLowerCase()
+        );
     }
 
     private hasProximityMatch(text: string, terms: string[]): boolean {
@@ -355,6 +370,126 @@ export class RAGKnowledgeManager implements IRAGKnowledgeManager {
         );
     }
 
+    /**
+     * Lists all knowledge entries for an agent without semantic search or reranking.
+     * Used primarily for administrative tasks like cleanup.
+     *
+     * @param agentId The agent ID to fetch knowledge entries for
+     * @returns Array of RAGKnowledgeItem entries
+     */
+    async listAllKnowledge(agentId: UUID): Promise<RAGKnowledgeItem[]> {
+        elizaLogger.debug(
+            `[Knowledge List] Fetching all entries for agent: ${agentId}`
+        );
+
+        try {
+            // Only pass the required agentId parameter
+            const results = await this.runtime.databaseAdapter.getKnowledge({
+                agentId: agentId,
+            });
+
+            elizaLogger.debug(
+                `[Knowledge List] Found ${results.length} entries`
+            );
+            return results;
+        } catch (error) {
+            elizaLogger.error(
+                "[Knowledge List] Error fetching knowledge entries:",
+                error
+            );
+            throw error;
+        }
+    }
+
+    async cleanupDeletedKnowledgeFiles() {
+        try {
+            elizaLogger.debug(
+                "[Cleanup] Starting knowledge cleanup process, agent: ",
+                this.runtime.agentId
+            );
+
+            elizaLogger.debug(
+                `[Cleanup] Knowledge root path: ${this.knowledgeRoot}`
+            );
+
+            const existingKnowledge = await this.listAllKnowledge(
+                this.runtime.agentId
+            );
+            // Only process parent documents, ignore chunks
+            const parentDocuments = existingKnowledge.filter(
+                (item) =>
+                    !item.id.includes("chunk") && item.content.metadata?.source // Must have a source path
+            );
+
+            elizaLogger.debug(
+                `[Cleanup] Found ${parentDocuments.length} parent documents to check`
+            );
+
+            for (const item of parentDocuments) {
+                const relativePath = item.content.metadata?.source;
+                const filePath = join(this.knowledgeRoot, relativePath);
+
+                elizaLogger.debug(
+                    `[Cleanup] Checking joined file path: ${filePath}`
+                );
+
+                if (!existsSync(filePath)) {
+                    elizaLogger.warn(
+                        `[Cleanup] File not found, starting removal process: ${filePath}`
+                    );
+
+                    const idToRemove = item.id;
+                    elizaLogger.debug(
+                        `[Cleanup] Using ID for removal: ${idToRemove}`
+                    );
+
+                    try {
+                        // Just remove the parent document - this will cascade to chunks
+                        await this.removeKnowledge(idToRemove);
+
+                        // // Clean up the cache
+                        // const baseCacheKeyWithWildcard = `${this.generateKnowledgeCacheKeyBase(
+                        //     idToRemove,
+                        //     item.content.metadata?.isShared || false
+                        // )}*`;
+                        // await this.cacheManager.deleteByPattern({
+                        //     keyPattern: baseCacheKeyWithWildcard,
+                        // });
+
+                        elizaLogger.success(
+                            `[Cleanup] Successfully removed knowledge for file: ${filePath}`
+                        );
+                    } catch (deleteError) {
+                        elizaLogger.error(
+                            `[Cleanup] Error during deletion process for ${filePath}:`,
+                            deleteError instanceof Error
+                                ? {
+                                      message: deleteError.message,
+                                      stack: deleteError.stack,
+                                      name: deleteError.name,
+                                  }
+                                : deleteError
+                        );
+                    }
+                }
+            }
+
+            elizaLogger.debug("[Cleanup] Finished knowledge cleanup process");
+        } catch (error) {
+            elizaLogger.error(
+                "[Cleanup] Error cleaning up deleted knowledge files:",
+                error
+            );
+        }
+    }
+
+    public generateScopedId(path: string, isShared: boolean): UUID {
+        // Prefix the path with scope before generating UUID to ensure different IDs for shared vs private
+        const scope = isShared ? KnowledgeScope.SHARED : KnowledgeScope.PRIVATE;
+        const scopedPath = `${scope}-${path}`;
+        return stringToUuid(scopedPath);
+    }
+
     async processFile(file: {
         path: string;
         content: string;
@@ -375,6 +510,12 @@ export class RAGKnowledgeManager implements IRAGKnowledgeManager {
                 `[File Progress] Starting ${file.path} (${fileSizeKB.toFixed(2)} KB)`
             );
 
+            // Generate scoped ID for the file
+            const scopedId = this.generateScopedId(
+                file.path,
+                file.isShared || false
+            );
+
             // Step 1: Preprocessing
             //const preprocessStart = Date.now();
             const processedContent = this.preprocess(content);
@@ -390,7 +531,7 @@ export class RAGKnowledgeManager implements IRAGKnowledgeManager {
 
             // Step 3: Create main document
             await this.runtime.databaseAdapter.createKnowledge({
-                id: stringToUuid(file.path),
+                id: scopedId,
                 agentId: this.runtime.agentId,
                 content: {
                     text: content,
@@ -431,7 +572,7 @@ export class RAGKnowledgeManager implements IRAGKnowledgeManager {
                 await Promise.all(
                     embeddings.map(async (embeddingArray, index) => {
                         const chunkId =
-                            `${stringToUuid(file.path)}-chunk-${i + index}` as UUID;
+                            `${scopedId}-chunk-${i + index}` as UUID;
                         const chunkEmbedding = new Float32Array(embeddingArray);
 
                         await this.runtime.databaseAdapter.createKnowledge({
@@ -444,8 +585,9 @@ export class RAGKnowledgeManager implements IRAGKnowledgeManager {
                                     type: file.type,
                                     isShared: file.isShared || false,
                                     isChunk: true,
-                                    originalId: stringToUuid(file.path),
+                                    originalId: scopedId,
                                     chunkIndex: i + index,
+                                    originalPath: file.path,
                                 },
                             },
                             embedding: chunkEmbedding,
@@ -457,7 +599,7 @@ export class RAGKnowledgeManager implements IRAGKnowledgeManager {
                 processedChunks += batch.length;
                 const batchTime = (Date.now() - batchStart) / 1000;
                 elizaLogger.info(
-                    `[Batch Progress] Processed ${processedChunks}/${totalChunks} chunks (${batchTime.toFixed(2)}s for batch)`
+                    `[Batch Progress] ${file.path}: Processed ${processedChunks}/${totalChunks} chunks (${batchTime.toFixed(2)}s for batch)`
                 );
             }
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -37,7 +37,7 @@ import {
     IRAGKnowledgeManager,
     IVerifiableInferenceAdapter,
     KnowledgeItem,
-    //RAGKnowledgeItem,
+    // RAGKnowledgeItem,
     //Media,
     ModelClass,
     ModelProviderName,
@@ -51,13 +51,25 @@ import {
     type Actor,
     type Evaluator,
     type Memory,
+    DirectoryItem,
 } from "./types.ts";
 import { stringToUuid } from "./uuid.ts";
-
+import { glob } from "glob";
+import { existsSync } from "fs";
 /**
  * Represents the runtime environment for an agent, handling message processing,
  * action registration, and interaction with external services like OpenAI and Supabase.
  */
+
+function isDirectoryItem(item: any): item is DirectoryItem {
+    return (
+        typeof item === "object" &&
+        item !== null &&
+        "directory" in item &&
+        typeof item.directory === "string"
+    );
+}
+
 export class AgentRuntime implements IAgentRuntime {
     /**
      * Default count for recent messages to be kept in memory.
@@ -152,6 +164,8 @@ export class AgentRuntime implements IAgentRuntime {
     knowledgeManager: IMemoryManager;
 
     ragKnowledgeManager: IRAGKnowledgeManager;
+
+    private readonly knowledgeRoot: string;
 
     services: Map<ServiceType, Service> = new Map();
     memoryManagers: Map<string, IMemoryManager> = new Map();
@@ -249,6 +263,22 @@ export class AgentRuntime implements IAgentRuntime {
             characterModelProvider: opts.character?.modelProvider,
         });
 
+        elizaLogger.debug(
+            `[AgentRuntime] Process working directory: ${process.cwd()}`
+        );
+
+        // Define the root path once
+        this.knowledgeRoot = join(
+            process.cwd(),
+            "..",
+            "characters",
+            "knowledge"
+        );
+
+        elizaLogger.debug(
+            `[AgentRuntime] Process knowledgeRoot: ${this.knowledgeRoot}`
+        );
+
         this.#conversationLength =
             opts.conversationLength ?? this.#conversationLength;
 
@@ -309,6 +339,7 @@ export class AgentRuntime implements IAgentRuntime {
         this.ragKnowledgeManager = new RAGKnowledgeManager({
             runtime: this,
             tableName: "knowledge",
+            knowledgeRoot: this.knowledgeRoot,
         });
 
         (opts.managers ?? []).forEach((manager: IMemoryManager) => {
@@ -438,17 +469,90 @@ export class AgentRuntime implements IAgentRuntime {
             this.character.knowledge &&
             this.character.knowledge.length > 0
         ) {
+            elizaLogger.info(
+                `[RAG Check] RAG Knowledge enabled: ${this.character.settings.ragKnowledge}`
+            );
+            elizaLogger.info(
+                `[RAG Check] Knowledge items:`,
+                this.character.knowledge
+            );
+
             if (this.character.settings.ragKnowledge) {
-                await this.processCharacterRAGKnowledge(
-                    this.character.knowledge
+                // Type guards with logging for each knowledge type
+                const [directoryKnowledge, pathKnowledge, stringKnowledge] =
+                    this.character.knowledge.reduce(
+                        (acc, item) => {
+                            if (typeof item === "object") {
+                                if (isDirectoryItem(item)) {
+                                    elizaLogger.debug(
+                                        `[RAG Filter] Found directory item: ${JSON.stringify(item)}`
+                                    );
+                                    acc[0].push(item);
+                                } else if ("path" in item) {
+                                    elizaLogger.debug(
+                                        `[RAG Filter] Found path item: ${JSON.stringify(item)}`
+                                    );
+                                    acc[1].push(item);
+                                }
+                            } else if (typeof item === "string") {
+                                elizaLogger.debug(
+                                    `[RAG Filter] Found string item: ${item.slice(0, 100)}...`
+                                );
+                                acc[2].push(item);
+                            }
+                            return acc;
+                        },
+                        [[], [], []] as [
+                            Array<{ directory: string; shared?: boolean }>,
+                            Array<{ path: string; shared?: boolean }>,
+                            Array<string>,
+                        ]
+                    );
+
+                elizaLogger.info(
+                    `[RAG Summary] Found ${directoryKnowledge.length} directories, ${pathKnowledge.length} paths, and ${stringKnowledge.length} strings`
                 );
+
+                // Process each type of knowledge
+                if (directoryKnowledge.length > 0) {
+                    elizaLogger.info(
+                        `[RAG Process] Processing directory knowledge sources:`
+                    );
+                    for (const dir of directoryKnowledge) {
+                        elizaLogger.info(
+                            `  - Directory: ${dir.directory} (shared: ${!!dir.shared})`
+                        );
+                        await this.processCharacterRAGDirectory(dir);
+                    }
+                }
+
+                if (pathKnowledge.length > 0) {
+                    elizaLogger.info(
+                        `[RAG Process] Processing individual file knowledge sources`
+                    );
+                    await this.processCharacterRAGKnowledge(pathKnowledge);
+                }
+
+                if (stringKnowledge.length > 0) {
+                    elizaLogger.info(
+                        `[RAG Process] Processing direct string knowledge`
+                    );
+                    await this.processCharacterKnowledge(stringKnowledge);
+                }
             } else {
+                // Non-RAG mode: only process string knowledge
                 const stringKnowledge = this.character.knowledge.filter(
                     (item): item is string => typeof item === "string"
                 );
-
                 await this.processCharacterKnowledge(stringKnowledge);
             }
+
+            // After all new knowledge is processed, clean up any deleted files
+            elizaLogger.info(
+                `[RAG Cleanup] Starting cleanup of deleted knowledge files`
+            );
+            await this.ragKnowledgeManager.cleanupDeletedKnowledgeFiles();
+            elizaLogger.info(`[RAG Cleanup] Cleanup complete`);
         }
     }
 
@@ -546,13 +650,7 @@ export class AgentRuntime implements IAgentRuntime {
                     ["md", "txt", "pdf"].includes(fileExtension)
                 ) {
                     try {
-                        const rootPath = join(process.cwd(), "..");
-                        const filePath = join(
-                            rootPath,
-                            "characters",
-                            "knowledge",
-                            contentItem
-                        );
+                        const filePath = join(this.knowledgeRoot, contentItem);
                         elizaLogger.info(
                             "Attempting to read file from:",
                             filePath
@@ -664,6 +762,115 @@ export class AgentRuntime implements IAgentRuntime {
             elizaLogger.warn(
                 "Some knowledge items failed to process, but continuing with available knowledge"
             );
+        }
+    }
+
+    /**
+     * Processes directory-based RAG knowledge by recursively loading and processing files.
+     * @param dirConfig The directory configuration containing path and shared flag
+     */
+    private async processCharacterRAGDirectory(dirConfig: {
+        directory: string;
+        shared?: boolean;
+    }) {
+        if (!dirConfig.directory) {
+            elizaLogger.error("[RAG Directory] No directory specified");
+            return;
+        }
+
+        // Sanitize directory path to prevent traversal attacks
+        const sanitizedDir = dirConfig.directory.replace(/\.\./g, "");
+        const dirPath = join(this.knowledgeRoot, sanitizedDir);
+
+        try {
+            // Check if directory exists
+            const dirExists = existsSync(dirPath);
+            if (!dirExists) {
+                elizaLogger.error(
+                    `[RAG Directory] Directory does not exist: ${sanitizedDir}`
+                );
+                return;
+            }
+
+            elizaLogger.debug(`[RAG Directory] Searching in: ${dirPath}`);
+            // Use glob to find all matching files in directory
+            const files = await glob("**/*.{md,txt,pdf}", {
+                cwd: dirPath,
+                nodir: true,
+                absolute: false,
+            });
+
+            if (files.length === 0) {
+                elizaLogger.warn(
+                    `No matching files found in directory: ${dirConfig.directory}`
+                );
+                return;
+            }
+
+            elizaLogger.info(
+                `[RAG Directory] Found ${files.length} files in ${dirConfig.directory}`
+            );
+
+            // Process files in batches to avoid memory issues
+            const BATCH_SIZE = 5;
+            for (let i = 0; i < files.length; i += BATCH_SIZE) {
+                const batch = files.slice(i, i + BATCH_SIZE);
+
+                await Promise.all(
+                    batch.map(async (file) => {
+                        try {
+                            const relativePath = join(sanitizedDir, file);
+
+                            elizaLogger.debug(
+                                `[RAG Directory] Processing file ${i + 1}/${files.length}:`,
+                                {
+                                    file,
+                                    relativePath,
+                                    shared: dirConfig.shared,
+                                }
+                            );
+
+                            await this.processCharacterRAGKnowledge([
+                                {
+                                    path: relativePath,
+                                    shared: dirConfig.shared,
+                                },
+                            ]);
+                        } catch (error) {
+                            elizaLogger.error(
+                                `[RAG Directory] Failed to process file: ${file}`,
+                                error instanceof Error
+                                    ? {
+                                          name: error.name,
+                                          message: error.message,
+                                          stack: error.stack,
+                                      }
+                                    : error
+                            );
+                        }
+                    })
+                );
+
+                elizaLogger.debug(
+                    `[RAG Directory] Completed batch ${Math.min(i + BATCH_SIZE, files.length)}/${files.length} files`
+                );
+            }
+
+            elizaLogger.success(
+                `[RAG Directory] Successfully processed directory: ${sanitizedDir}`
+            );
+        } catch (error) {
+            elizaLogger.error(
+                `[RAG Directory] Failed to process directory: ${sanitizedDir}`,
+                error instanceof Error
+                    ? {
+                          name: error.name,
+                          message: error.message,
+                          stack: error.stack,
+                      }
+                    : error
+            );
+            throw error; // Re-throw to let caller handle it
         }
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1139,6 +1139,7 @@ export interface IRAGKnowledgeManager {
         type: "pdf" | "md" | "txt";
         isShared: boolean;
     }): Promise<void>;
+    cleanupDeletedKnowledgeFiles(): Promise<void>;
 }
 
 export type CacheOptions = {
@@ -1558,4 +1559,23 @@ export enum TranscriptionProvider {
 export enum ActionTimelineType {
     ForYou = "foryou",
     Following = "following",
+}
+
+export enum KnowledgeScope {
+    SHARED = "shared",
+    PRIVATE = "private",
+}
+
+export enum CacheKeyPrefix {
+    KNOWLEDGE = "knowledge",
+}
+
+export interface DirectoryItem {
+    directory: string;
+    shared?: boolean;
+}
+
+export interface ChunkRow {
+    id: string;
+    // Add other properties if needed
 }


### PR DESCRIPTION
- Added support for double-byte characters (e.g., Chinese) to ensure proper processing.
- Implemented cleanup of deleted knowledge files to maintain data integrity.
- Enabled loading knowledge from directories, simplifying configuration and management.

These improvements address performance and usability issues, facilitating better support for large knowledge sets.

Closes #2323

# Risks

These are changes to ragKnowledge so should be low.

# Testing

In your character card, set:
"ragKnowledge": true,

and configure your knowledge folders.  Direct files and strings are still supported, below is a sample:

```
"knowledge": [
        {
            "path": "hexagrams/harvardYenchingHexagrams.md"
        },
        {
            "directory": "shared/warringstates",
            "shared": true
        },
        "The art of war is of vital importance to the state. It is a matter of life and death, a road either to safety or to ruin."
    ],
```

Then, place these files and directories under eliza/characters/knowledge.

Scenarios to test:
1) indexing multiple knowledge files just by placing in a directory (no need to list each file)
2) removing files, and check logs to see that the entries are removed from the knowledge table
3) changing file contents will also re-trigger indexing on next startup, and re-indexing will be shown in the log

I start my agent like:
pnpm start:debug --character="characters/qwen.character.json" > agent.log 2>&1

This uses the target that shows debug messages from the elizaLogger

## Where should a reviewer start?

runtime.ts - initialize() is the main entry point that calls processCharacterRAGKnowledge() and processCharacterRAGDirectory.  Both processCharacterRAGDirectory has most of the changes.

ragknowledge.ts - ids are now scoped to private or shared to prevent issues when the same knowledge is moved between shared folder and private folders.  double byte characters were stripped on pre-processing so that line was commented out.  And embedding of knowledge files was optimized.

The only additions to generation.ts was logging, so no need to focus too much on that.

localembeddingmanager.ts just has embedding logging commented out, as it was too verbose (it was displaying a long vector string in debug mode)

## Discord username
hosermage