### PR TITLE
docs: Update Python version requirement from 2.7 to 3.12+

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 ### Prerequisites
 
-- [Python 2.7+](https://www.python.org/downloads/)
+- [Python 3.12+](https://www.python.org/downloads/)
 - [Node.js 23+](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 - [pnpm](https://pnpm.io/installation)
 


### PR DESCRIPTION
I noticed that the project currently specifies Python 2.7 as a requirement. Since Python 2.7 is no longer supported and modern projects typically use Python 3.12 or higher, I’ve updated the requirement to reflect this. 