### PR TITLE
fix: Fix typo in import statement for Solana AgentKit plugin Update i…

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -87,7 +87,7 @@ import { openWeatherPlugin } from "@elizaos/plugin-open-weather";
 import { quaiPlugin } from "@elizaos/plugin-quai";
 import { sgxPlugin } from "@elizaos/plugin-sgx";
 import { solanaPlugin } from "@elizaos/plugin-solana";
-import { solanaAgentkitPlguin } from "@elizaos/plugin-solana-agentkit";
+import { solanaAgentkitPlugin } from "@elizaos/plugin-solana-agentkit";
 import { squidRouterPlugin } from "@elizaos/plugin-squid-router";
 import { stargazePlugin } from "@elizaos/plugin-stargaze";
 import { storyPlugin } from "@elizaos/plugin-story";


### PR DESCRIPTION
### Description
I noticed a typo in the import statement for the Solana AgentKit plugin. The word "Plguin" was misspelled.

I've corrected it to "Plugin" to ensure consistency and avoid potential issues.  

Here's the fix:  
```javascript  
import { solanaAgentkitPlugin } from "@elizaos/plugin-solana-agentkit";  
```  

