### PR TITLE
fix: Fix typo in import statement for Solana AgentKit plugin Update i…

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -87,7 +87,7 @@ import { openWeatherPlugin } from "@elizaos/plugin-open-weather";
 import { quaiPlugin } from "@elizaos/plugin-quai";
 import { sgxPlugin } from "@elizaos/plugin-sgx";
 import { solanaPlugin } from "@elizaos/plugin-solana";
-import { solanaAgentkitPlguin } from "@elizaos/plugin-solana-agentkit";
+import { solanaAgentkitPlugin } from "@elizaos/plugin-solana-agentkit";
 import { squidRouterPlugin } from "@elizaos/plugin-squid-router";
 import { stargazePlugin } from "@elizaos/plugin-stargaze";
 import { storyPlugin } from "@elizaos/plugin-story";
@@ -788,7 +788,7 @@ export async function createAgent(
                 ? solanaPlugin
                 : null,
             getSecret(character, "SOLANA_PRIVATE_KEY")
-                ? solanaAgentkitPlguin
+                ? solanaAgentkitPlugin
                 : null,
             getSecret(character, "AUTONOME_JWT_TOKEN") ? autonomePlugin : null,
             (getSecret(character, "NEAR_ADDRESS") ||

--- a/packages/plugin-solana-agentkit/src/index.ts
+++ b/packages/plugin-solana-agentkit/src/index.ts
@@ -1,7 +1,7 @@
 import { Plugin } from "@elizaos/core";
 import createToken from "./actions/createToken.ts";
 
-export const solanaAgentkitPlguin: Plugin = {
+export const solanaAgentkitPlugin: Plugin = {
     name: "solana",
     description: "Solana Plugin with solana agent kit for Eliza",
     actions: [createToken],
@@ -9,4 +9,4 @@ export const solanaAgentkitPlguin: Plugin = {
     providers: [],
 };
 
-export default solanaAgentkitPlguin;
+export default solanaAgentkitPlugin;


### PR DESCRIPTION
Typo in the import statement for the Solana AgentKit plugin.
The word "plguin" was misspelled and corrected to "**plugin**".