### PR TITLE
Fix: Prevent app crash when REMOTE_CHARACTER_URLS is undefined

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1101,9 +1101,10 @@ const checkPortAvailable = (port: number): Promise<boolean> => {
     });
 };
 
-const hasValidRemoteUrls = () =>
-    process.env.REMOTE_CHARACTER_URLS != "" &&
-    process.env.REMOTE_CHARACTER_URLS.startsWith("http")
+const hasValidRemoteUrls = () => {
+    const remoteUrls = process.env.REMOTE_CHARACTER_URLS;
+    return remoteUrls && remoteUrls !== "" && remoteUrls.startsWith('http');
+};
 
 const startAgents = async () => {
     const directClient = new DirectClient();


### PR DESCRIPTION
right now if the REMOTE_CHARACTER_URLS environment variable is not defined, the app would crash

The issue causing the app to crash when the REMOTE_CHARACTER_URLS environment variable is not defined originated from changes introduced in PR https://github.com/elizaOS/eliza/pull/2328

<img width="891" alt="Screenshot_2025-01-16_at_9 33 37_PM" src="https://github.com/user-attachments/assets/b38bab5c-0d26-45c6-bbdc-5d20d1a0e4d6" />

