### PR TITLE
fix: set default Squid Router plugin throttle to 1000

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -366,7 +366,7 @@ SQUID_SDK_URL=https://apiplus.squidrouter.com # Default: https://apiplus.squidro
 SQUID_INTEGRATOR_ID=                          # get integrator id through https://docs.squidrouter.com/
 SQUID_EVM_ADDRESS=
 SQUID_EVM_PRIVATE_KEY=
-SQUID_API_THROTTLE_INTERVAL= # Default: 0; Used to throttle API calls to avoid rate limiting (in ms)
+SQUID_API_THROTTLE_INTERVAL=1000 # Default: 1000; Used to throttle API calls to avoid rate limiting (in ms)
 
 # TEE Configuration
 # TEE_MODE options:


### PR DESCRIPTION
# Relates to

https://github.com/elizaOS/eliza/pull/1482

# Risks

Low

# Background

## What does this PR do?

Set a better default throttle interval for Squid Router

## What kind of change is this?

Improvement
