### PR TITLE
fix: typos in supabase seed file

### DIFF
--- a/packages/adapter-supabase/seed.sql
+++ b/packages/adapter-supabase/seed.sql
@@ -1,3 +1,3 @@
 INSERT INTO public.accounts (id, name, email, "avatarUrl", details) VALUES ('00000000-0000-0000-0000-000000000000', 'Default Agent', 'default@agent.com', '', '{}');
 INSERT INTO public.rooms (id, "createdAt") VALUES ('00000000-0000-0000-0000-000000000000', NOW());
-INSERT INTO public.participants (id, "createdAt", "userId", "roomId", "userState", last_messsage_read) VALUES ('00000000-0000-0000-0000-000000000000', NOW(), 'Default Agent', '00000000-0000-0000-0000-000000000000', NULL, NULL);
+INSERT INTO public.participants (id, "createdAt", "userId", "roomId", "userState", last_message_read) VALUES ('00000000-0000-0000-0000-000000000000', NOW(), 'Default Agent', '00000000-0000-0000-0000-000000000000', NULL, NULL);


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `last_messsage_read` to `last_message_read`

Please review the changes and let me know if any additional changes are needed.