### PR TITLE
Update documentation links 

### DIFF
--- a/packages/plugin-obsidian/README.md
+++ b/packages/plugin-obsidian/README.md
@@ -229,6 +229,6 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 For support, please:
 
-1. Check the [documentation](https://docs.elizaos.com)
+1. Check the [documentation](https://elizaos.github.io/eliza/)
 2. Open an issue in the repository
 3. Join our [Discord community](https://discord.gg/elizaos)


### PR DESCRIPTION
Update documentation links in README.md

Changes:
- Updated documentation link in packages/plugin-obsidian/README.md from https://docs.elizaos.com to https://elizaos.github.io/eliza/

Why:
This update redirects users to the correct documentation URL on GitHub Pages, ensuring access to up-to-date documentation.