### PR TITLE
fix: update zero Gravity (0G) link

### DIFF
--- a/packages/plugin-0g/README.md
+++ b/packages/plugin-0g/README.md
@@ -194,7 +194,7 @@ Contributions are welcome! Please see the [CONTRIBUTING.md](CONTRIBUTING.md) fil
 
 This plugin integrates with and builds upon several key technologies:
 
-- [Zero Gravity (0G)](https://0g.xyz/): Decentralized file storage protocol
+- [Zero Gravity (0G)](https://0g.ai/): Decentralized file storage protocol
 - [IPFS](https://ipfs.tech/): InterPlanetary File System
 - [Filecoin](https://filecoin.io/): Decentralized storage network
 - [Flow](https://flow.com/): Blockchain for open worlds


### PR DESCRIPTION
Update Zero Gravity (0G) link in README.md

Changes:
- Updated Zero Gravity link in packages/plugin-0g/README.md from https://0g.xyz to https://0g.ai

Why:
This update fixes the broken link to Zero Gravity's website by pointing to their current active domain, ensuring users can access the correct project information.