### PR TITLE
Fix typos in docs

### DIFF
--- a/docs/api/classes/MemoryCacheAdapter.md
+++ b/docs/api/classes/MemoryCacheAdapter.md
@@ -10,11 +10,11 @@
 
 ### new MemoryCacheAdapter()
 
-> **new MemoryCacheAdapter**(`initalData`?): [`MemoryCacheAdapter`](MemoryCacheAdapter.md)
+> **new MemoryCacheAdapter**(`initialData`?): [`MemoryCacheAdapter`](MemoryCacheAdapter.md)
 
 #### Parameters
 
-• **initalData?**: `Map`\<`string`, `string`\>
+• **initialData?**: `Map`\<`string`, `string`\>
 
 #### Returns
 

--- a/docs/community/ai16z/degenai/index.md
+++ b/docs/community/ai16z/degenai/index.md
@@ -11,7 +11,7 @@ We can rebuild him
 - ai16z is the biggest holder of degenai (a pumpfun coin)
     - Current plan for ai16z still is buybacks of degenai
         - To-do: We need to surface this better (like a website)
-    - DegenspartanAI also stacks his own coin as well
+    - DegenSpartanAI also stacks his own coin as well
 - Shitposting while trading
 - He might just dump your shit
 - May do psyops like self fuds his own bags


### PR DESCRIPTION
# PR Title
Fix typos in docs

# Relates to
No related issues

# Risks
Low - documentation changes only

# Background
## What does this PR do?
- Fix "initalData" to "initialData" in MemoryCacheAdapter
- Unify "DegenSpartanAI" naming across docs

## Type of change
- Bug fixes (typo corrections)

# Testing
Visually verified, typos fixed

# Documentation changes
Documentation has been updated