### PR TITLE
feat: add default logger level setting to set the logger level to dis…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ SUPABASE_ANON_KEY=
 REMOTE_CHARACTER_URLS=
 
 # Logging
+DEFAULT_LOG_LEVEL=info
 LOG_JSON_FORMAT=            # Print everything in logger as json; false by default
 
 ###############################

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -26,7 +26,10 @@ const createStream = () => {
     });
 };
 
+const defaultLevel = process?.env?.DEFAULT_LOG_LEVEL || "info";
+
 const options = {
+    level: defaultLevel,
     customLevels,
     hooks: {
         logMethod(


### PR DESCRIPTION
# Relates to

<!-- LINK TO ISSUE OR TICKET -->
No linked issue.

# Risks

Low.  
This change introduces a default logger level, which affects logging outputs. Potential risks include unexpected logging behavior if the `DEFAULT_LOG_LEVEL` environment variable is misconfigured or missing.

# Background

## What does this PR do?

This PR introduces a default logger level setting, allowing developers to set the logging verbosity through a `DEFAULT_LOG_LEVEL` environment variable. If the variable is not set, the logger defaults to "info" level.

## What kind of change is this?

- **Features**: Adds functionality to configure the default logger level via an environment variable.

# Documentation changes needed?

My changes require a change to the project documentation.  
- Add details about the new `DEFAULT_LOG_LEVEL` environment variable in the relevant setup/configuration documentation.

# Testing

## Where should a reviewer start?

- Review changes in `.env.example` for the new environment variable.
- Review the implementation in `packages/core/src/logger.ts` for setting the logger level.

## Detailed testing steps

1. Add `DEFAULT_LOG_LEVEL` to your `.env` file and set it to a specific value (e.g., `debug`).
2. Start the application.
3. Verify that the logs are displayed according to the specified level.
4. Remove `DEFAULT_LOG_LEVEL` from `.env` and restart the application.
5. Verify that the logs default to the `info` level.

## Screenshots

No UI changes.

# Deploy Notes

No specific deployment changes. Ensure the `.env` file includes the new `DEFAULT_LOG_LEVEL` variable, if desired, for customized logging behavior.

## Database changes

None.

## Deployment instructions

No additional instructions. Standard deployment process applies.