### PR TITLE
Typo fix in read.me

### DIFF
--- a/packages/plugin-squid-router/README.md
+++ b/packages/plugin-squid-router/README.md
@@ -1,7 +1,7 @@
 # @elizaos/squid-router
 
 This plugin adds Squid Router functionality to Eliza agents. It allows cross chain swaps between blockchains.
-For now, only swaps beteen EVM chains are supported, but the plan is to add swaps from/to Solana and the Cosomos ecosystem.
+For now, only swaps between EVM chains are supported, but the plan is to add swaps from/to Solana and the Cosomos ecosystem.
 For supported chains and tokens, please refer to the [Squid Router documentation](https://docs.squidrouter.com/).
 
 ## Configuration


### PR DESCRIPTION
# Pull Request: Fix Typo in `README.md` ("beteen" → "between")



This pull request corrects a typo in the `README.md` file for the `@elizaos/squid-router` package. The word "beteen" was updated to "between" to enhance readability and accuracy.


- Corrected the typo in the following sentence:
  ```diff
  - For now, only swaps beteen EVM chains are supported, but the plan is to add swaps from/to Solana and the Cosomos ecosystem.
  + For now, only swaps between EVM chains are supported, but the plan is to add swaps from/to Solana and the Cosmos ecosystem.
