### PR TITLE
Update ElizaOS Documentation link

### DIFF
--- a/packages/plugin-tts/README.md
+++ b/packages/plugin-tts/README.md
@@ -166,7 +166,7 @@ Special thanks to:
 
 For more information about TTS capabilities:
 - [FAL.ai Documentation](https://fal.ai/docs)
-- [ElizaOS Documentation](https://docs.elizaos.com)
+- [ElizaOS Documentation](https://elizaos.github.io/eliza/)
 
 ## License
 


### PR DESCRIPTION
Update ElizaOS Documentation link

Changes:
- Updated documentation link from https://docs.elizaos.com to https://elizaos.github.io/eliza/



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated documentation URL for the TTS plugin package
	- Minor formatting adjustment to README file

<!-- end of auto-generated comment: release notes by coderabbit.ai -->