### PR TITLE
feat: add EmailClient for Eliza

### DIFF
--- a/packages/plugin-email/README.md
+++ b/packages/plugin-email/README.md
@@ -1,0 +1,52 @@
+# Description
+
+EmailClient Plugin for Eliza.
+
+# Settings
+
+The following settings will be declared on your environment variable or inside your agent' settings:
+
+## SMTP Section
+
+- `EMAIL_OUTGOING_SERVICE`: "smtp" | "gmail"
+- `EMAIL_OUTGOING_HOST`: SMTP Hostname or IP to connect to. Required only when "smtp" service is configured.
+- `EMAIL_OUTGOING_PORT`: the port to connect to (defaults to 465 for secure connections, otherwise 587). Required only if "smtp" is configured.
+- `EMAIL_SECURE`: if true the connection will use TLS, otherwise TLS will be used if server supports STARTLS extension. Set to true if port 465 is selected.
+- `EMAIL_OUTGOING_USER`: Username
+- `EMAIL_OUTGOING_PASS`: Password. If "gmail" selected you will need to provision a dedicated password for the agent [1]
+
+## IMAP Section
+
+- `EMAIL_INCOMING_SERVICE`: "imap"
+- `EMAIL_INCOMING_HOST`: IMAP Hostname or IP to conenct to
+- `EMAIL_INCOMING_PORT`: the port to connect to (defaults to 993)
+- `EMAIL_INCOMING_USER`: Username
+- `EMAIL_INCOMING_PASS`: Password
+
+[1] https://support.google.com/mail/answer/185833?hl=en
+
+## Usage
+
+1. Install the Plugin: First, import the plugin into your agent by running the following command:
+
+```
+pnpm add @elizaos/plugin-email
+```
+
+2. Send Emails: You can send emails using the following method:
+
+```
+this.runtime.clients.email.send({
+    to: "recipient@example.com",
+    subject: "Your Subject Here",
+    text: "Your email body here."
+});
+```
+
+3. Receive Emails: To receive emails, register a callback function that will be invoked when an email is received:
+
+```
+this.runtime.clients.email.receive((email) => {
+    console.log("Email Received:", email);
+});
+```

--- a/packages/plugin-email/eslint.config.mjs
+++ b/packages/plugin-email/eslint.config.mjs
@@ -1,0 +1,3 @@
+import eslintGlobalConfig from "../../eslint.config.mjs";
+
+export default [...eslintGlobalConfig];

--- a/packages/plugin-email/package.json
+++ b/packages/plugin-email/package.json
@@ -1,0 +1,40 @@
+{
+    "name": "@elizaos/plugin-email",
+    "version": "0.1.0",
+    "type": "module",
+    "main": "./dist/index.js",
+    "module": "dist/index.js",
+    "types": "./dist/index.d.ts",
+    "scripts": {
+        "build": "tsup --format esm --dts",
+        "test": "jest",
+        "lint": "eslint --fix --cache ."
+    },
+    "dependencies": {
+        "@elizaos/adapter-postgres": "workspace:^",
+        "@elizaos/core": "workspace:^",
+        "mail-notifier": "^0.5.0",
+        "nodemailer": "^6.9.16",
+        "z": "^1.0.9"
+    },
+    "exports": {
+        "./package.json": "./package.json",
+        ".": {
+            "import": {
+                "@elizaos/source": "./src/index.ts",
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            }
+        }
+    },
+    "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "@types/mail-notifier": "0.5.2",
+        "@types/node": "^20.0.0",
+        "@types/nodemailer": "^6.4.17",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.2.5",
+        "ts-jest-mock-import-meta": "^1.2.1",
+        "typescript": "^5.0.0"
+    }
+}

--- a/packages/plugin-email/src/clients/emailClient.ts
+++ b/packages/plugin-email/src/clients/emailClient.ts
@@ -1,0 +1,200 @@
+import { Client, elizaLogger, IAgentRuntime, ServiceType } from "@elizaos/core";
+import MailNotifier, { Config, EmailContent } from "mail-notifier";
+import nodemailer, { Transporter } from "nodemailer";
+import {
+    validateIncomingEmailConfig,
+    validateOutgoingEmailConfig,
+} from "../config/email";
+import {
+    OutgoingConfig,
+    EmailOutgoingProvider,
+    GmailConfig,
+    SmtpConfig,
+    SendEmailOptions,
+    EmailResponse,
+    IncomingConfig,
+} from "../types";
+import EventEmitter from "events";
+
+class IncomingEmailManager extends EventEmitter {
+    private static instance: IncomingEmailManager | null = null;
+    private notifier: any;
+
+    private constructor(config: IncomingConfig) {
+        super();
+        let imapSettings: Config = {
+            user: config.user,
+            password: config.pass,
+            host: config.host,
+            port: config.port,
+            tls: true,
+            tlsOptions: { rejectUnauthorized: false },
+        };
+
+        this.notifier = MailNotifier(imapSettings);
+    }
+
+    start() {
+        this.notifier
+            .on("end", () => this.notifier.start())
+            .on("mail", (mail: EmailContent) => {
+                this.emit("mail", mail);
+            })
+            .start();
+    }
+
+    stop() {
+        this.notifier.stop();
+    }
+
+    listen(callback: (mail: EmailContent) => void) {
+        this.notifier.on("mail", callback);
+    }
+    static getInstance(config: IncomingConfig): IncomingEmailManager {
+        if (!this.instance) {
+            if (!config) {
+                // TODO - check the condition to enable Smtp
+                elizaLogger.warn(
+                    `IMAP configuration is missing. Unable to receive emails.`
+                );
+                return null;
+            }
+            this.instance = new IncomingEmailManager(config);
+        }
+        return this.instance;
+    }
+}
+
+class OutgoingEmailManager {
+    private static instance: OutgoingEmailManager | null = null;
+
+    private transporter: Transporter | null = null;
+    private config: OutgoingConfig | null = null;
+
+    private constructor(config: OutgoingConfig) {
+        this.config = config;
+        switch (this.config?.provider) {
+            case EmailOutgoingProvider.GMAIL:
+                this.config = this.config as GmailConfig;
+                this.transporter = nodemailer.createTransport({
+                    service: "Gmail",
+                    secure: false,
+                    auth: {
+                        user: this.config.user,
+                        pass: this.config.pass,
+                    },
+                });
+                break;
+            case EmailOutgoingProvider.SMTP:
+                this.config = this.config as SmtpConfig;
+                this.transporter = nodemailer.createTransport({
+                    host: this.config.host,
+                    port: this.config.port,
+                    secure: this.config.secure,
+                    auth: {
+                        user: this.config.user,
+                        pass: this.config.pass,
+                    },
+                });
+                break;
+            default:
+                throw new Error(
+                    `Invalid email provider: ${this.config?.provider}`
+                );
+        }
+    }
+    async send(options: SendEmailOptions): Promise<EmailResponse> {
+        const mailOptions = {
+            from: options.from || this.config.user,
+            to: options.to,
+            subject: options.subject,
+            text: options.text,
+        };
+        return await this.transporter?.sendMail(mailOptions);
+    }
+
+    static getInstance(config: OutgoingConfig): OutgoingEmailManager {
+        if (!this.instance) {
+            if (!config) {
+                // TODO - check the condition to enable Smtp
+                elizaLogger.warn(
+                    `SMTP configuration is missing. Unable to send emails.`
+                );
+                return null;
+            }
+            this.instance = new OutgoingEmailManager(config);
+        }
+        return this.instance;
+    }
+}
+export class EmailClient {
+    private runtime: IAgentRuntime;
+    private incomingConfig: IncomingConfig | null = null;
+    private outgoingConfig: OutgoingConfig | null = null;
+
+    private outgoingEmailManager: OutgoingEmailManager | null = null;
+    private incomingEmailManager: IncomingEmailManager | null = null;
+
+    constructor(runtime: IAgentRuntime) {
+        this.runtime = runtime;
+    }
+    async initialize(): Promise<void> {
+        this.incomingConfig = await validateIncomingEmailConfig(this.runtime);
+        this.outgoingConfig = await validateOutgoingEmailConfig(this.runtime);
+
+        this.outgoingEmailManager = OutgoingEmailManager.getInstance(
+            this.outgoingConfig
+        );
+        this.incomingEmailManager = IncomingEmailManager.getInstance(
+            this.incomingConfig
+        );
+
+        if (this.incomingEmailManager) {
+            this.incomingEmailManager.start();
+        }
+        let incomingStatus = this.incomingEmailManager ? "✅ " : "❌ ";
+        let outgoingStatus = this.outgoingEmailManager ? "✅ " : "❌ ";
+        elizaLogger.info(
+            `Email service initialized successfully: ${incomingStatus}Incoming - ${outgoingStatus}Outgoing`
+        );
+    }
+
+    async stop(): Promise<void> {
+        if (this.incomingEmailManager) {
+            this.incomingEmailManager.stop();
+        }
+    }
+    async send(options: SendEmailOptions): Promise<EmailResponse> {
+        if (!this.outgoingEmailManager) {
+            throw new Error(
+                "Email service is not initialized for sending emails"
+            );
+        }
+        return await this.outgoingEmailManager?.send(options);
+    }
+
+    receive(callback: (mail: EmailContent) => void): void {
+        if (!this.incomingEmailManager) {
+            throw new Error(
+                "Email service is not initialized for receiving emails"
+            );
+        }
+        this.incomingEmailManager?.listen(callback);
+    }
+}
+interface ClientWithType extends Client {
+    type: string;
+}
+export const EmailClientInterface: ClientWithType = {
+    type: "email",
+    start: async (runtime: IAgentRuntime) => {
+        const client = new EmailClient(runtime);
+        await client.initialize();
+        return client;
+    },
+    stop: async (_runtime: IAgentRuntime) => {
+        console.warn("Email client does not support stopping yet");
+    },
+};
+
+export default EmailClientInterface;

--- a/packages/plugin-email/src/config/email.ts
+++ b/packages/plugin-email/src/config/email.ts
@@ -1,0 +1,151 @@
+import { elizaLogger, IAgentRuntime } from "@elizaos/core";
+import {
+    EmailOutgoingProvider,
+    EmailIncomingProvider,
+    OutgoingConfig,
+    GmailConfig,
+    IncomingConfig,
+    SmtpConfig,
+} from "../types/config";
+import { z } from "zod";
+
+// Define the schema for other providers
+const GmailConfigSchema = z.object({
+    provider: z.literal(EmailOutgoingProvider.GMAIL),
+    service: z.string().optional(),
+    user: z.string().min(1, "User is required"),
+    pass: z.string().min(1, "Password is required"),
+});
+
+const SmtpConfigSchema = z.object({
+    provider: z.literal(EmailOutgoingProvider.SMTP),
+    host: z.string(),
+    port: z.number(),
+    secure: z.boolean(),
+    user: z.string().min(1, "User is required"),
+    pass: z.string().min(1, "Password is required"),
+});
+
+const ImapConfigSchema = z.object({
+    provider: z.literal(EmailIncomingProvider.IMAP),
+    host: z.string(),
+    port: z.number(),
+    user: z.string().min(1, "User is required"),
+    pass: z.string().min(1, "Password is required"),
+});
+
+// Function to validate EmailConfig
+export function validateOutgoingEmailConfig(
+    runtime: IAgentRuntime
+): OutgoingConfig {
+    elizaLogger.debug("Verifying email service settings...");
+    try {
+        let config: GmailConfig | SmtpConfig;
+
+        let result;
+        let provider =
+            runtime.getSetting("EMAIL_OUTGOING_SERVICE") ||
+            process.env.EMAIL_PROVIDER;
+
+        if (!provider) {
+            elizaLogger.warn(`Email outgoing service not set.`);
+            return null;
+        }
+        switch (provider?.toLowerCase()) {
+            case EmailOutgoingProvider.GMAIL:
+                config = {
+                    provider: EmailOutgoingProvider.GMAIL,
+                    service: "Gmail",
+                    user:
+                        runtime.getSetting("EMAIL_OUTGOING_USER") ||
+                        process.env.EMAIL_OUTGOING_USER,
+                    pass:
+                        runtime.getSetting("EMAIL_OUTGOING_PASS") ||
+                        process.env.EMAIL_OUTGOING_PASS,
+                } as GmailConfig;
+                result = GmailConfigSchema.safeParse(config);
+                break;
+            case EmailOutgoingProvider.SMTP:
+                config = {
+                    provider: EmailOutgoingProvider.SMTP,
+                    host:
+                        runtime.getSetting("EMAIL_OUTGOING_HOST") ||
+                        process.env.EMAIL_OUTGOING_HOST,
+                    port:
+                        Number(
+                            runtime.getSetting("EMAIL_OUTGOING_PORT") ||
+                                process.env.EMAIL_OUTGOING_PORT
+                        ) || 465,
+                    user:
+                        runtime.getSetting("EMAIL_OUTGOING_USER") ||
+                        process.env.EMAIL_USER,
+                    pass:
+                        runtime.getSetting("EMAIL_OUTGOING_PASS") ||
+                        process.env.EMAIL_PASS,
+                } as SmtpConfig;
+
+                config.secure = config.port === 465;
+                result = SmtpConfigSchema.safeParse(config);
+                break;
+            default:
+                elizaLogger.warn(
+                    `Email provider not supported: ${provider}. Please use one of the following supported providers: "smtp" or "gmail".`
+                );
+                return null;
+        }
+
+        if (!result.success) {
+            throw new Error(
+                `Email configuration validation failed\n${result.error.errors.map((e) => e.message).join("\n")}`
+            );
+        }
+        return config;
+    } catch (error) {
+        if (error instanceof z.ZodError) {
+            const errorMessages = error.errors
+                .map((err) => `${err.path.join(".")}: ${err.message}`)
+                .join("\n");
+            throw new Error(
+                `Email configuration validation failed:\n${errorMessages}`
+            );
+        }
+        throw error;
+    }
+}
+
+export function validateIncomingEmailConfig(
+    runtime: IAgentRuntime
+): IncomingConfig {
+    let provider =
+        runtime.getSetting("EMAIL_INCOMING_SERVICE") ||
+        process.env.EMAIL_INCOMING_SERVICE;
+    if (!provider) {
+        elizaLogger.warn(`Email incoming service not set.`);
+        return null;
+    }
+    let config = {
+        provider: EmailIncomingProvider.IMAP,
+        host:
+            runtime.getSetting("EMAIL_INCOMING_HOST") ||
+            process.env.EMAIL_INCOMING_HOST,
+        port:
+            Number(
+                runtime.getSetting("EMAIL_INCOMING_PORT") ||
+                    process.env.EMAIL_INCOMING_PORT
+            ) || 993,
+        user:
+            runtime.getSetting("EMAIL_INCOMING_USER") ||
+            process.env.EMAIL_INCOMING_USER,
+        pass:
+            runtime.getSetting("EMAIL_INCOMING_PASS") ||
+            process.env.EMAIL_INCOMING_PASS,
+    } as IncomingConfig;
+
+    let result = ImapConfigSchema.safeParse(config);
+    if (!result.success) {
+        throw new Error(
+            `Email configuration validation failed\n${result.error.errors.map((e) => e.message).join("\n")}`
+        );
+    }
+    return config;
+}

--- a/packages/plugin-email/src/index.ts
+++ b/packages/plugin-email/src/index.ts
@@ -1,0 +1,15 @@
+import type { Plugin } from "@elizaos/core";
+import { EmailClientInterface } from "./clients/emailClient";
+
+export const emailPlugin: Plugin = {
+    name: "email",
+    description: "Email plugin for Eliza",
+    clients: [EmailClientInterface],
+    actions: [],
+    evaluators: [],
+    services: [],
+};
+
+export * from "./types";
+
+export default emailPlugin;

--- a/packages/plugin-email/src/types/config.ts
+++ b/packages/plugin-email/src/types/config.ts
@@ -1,0 +1,32 @@
+export enum EmailOutgoingProvider {
+    GMAIL = "gmail",
+    SMTP = "smtp",
+}
+
+export enum EmailIncomingProvider {
+    IMAP = "imap",
+}
+interface BaseConfig {
+    provider: EmailOutgoingProvider;
+    user: string;
+    pass: string;
+}
+export interface GmailConfig extends BaseConfig {
+    service: string;
+}
+export interface SmtpConfig extends BaseConfig {
+    host: string;
+    port: number;
+    secure: boolean;
+}
+
+export interface ImapConfig {
+    provider: EmailIncomingProvider;
+    host: string;
+    port: number;
+    user: string;
+    pass: string;
+}
+
+export type OutgoingConfig = GmailConfig | SmtpConfig;
+export type IncomingConfig = ImapConfig;

--- a/packages/plugin-email/src/types/email.ts
+++ b/packages/plugin-email/src/types/email.ts
@@ -1,0 +1,32 @@
+import { Service } from "@elizaos/core";
+import { EmailContent } from "mail-notifier";
+
+interface EmailAttachment {
+    filename: string;
+    path: string;
+    cid?: string;
+}
+
+export interface SendEmailOptions {
+    from?: string;
+    to: string | string[];
+    subject: string;
+    text?: string;
+    html?: string;
+    attachments?: EmailAttachment[];
+    cc?: string | string[];
+    bcc?: string | string[];
+    replyTo?: string;
+}
+
+export interface EmailResponse {
+    success: boolean;
+    messageId?: string;
+    response?: string;
+    error?: string;
+}
+
+export interface IEmailService extends Service {
+    send(options: SendEmailOptions): Promise<EmailResponse>;
+    receive(callback: (mail: EmailContent) => void): void;
+}

--- a/packages/plugin-email/src/types/index.ts
+++ b/packages/plugin-email/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from "./config";
+export * from "./email";

--- a/packages/plugin-email/tsconfig.json
+++ b/packages/plugin-email/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../core/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "./src",
+    },
+    "include": [
+        "src/**/*.ts"
+    ]
+}

--- a/packages/plugin-email/tsup.config.ts
+++ b/packages/plugin-email/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+    entry: ["src/index.ts"],
+    outDir: "dist",
+    sourcemap: true,
+    clean: true,
+    format: ["esm"], // Ensure you're targeting CommonJS
+    external: [
+        "nodemailer", // Externalize dotenv to prevent bundling
+        "mail-notifier",
+        "z", // Externalize fs to use Node.js built-in module
+    ],
+});


### PR DESCRIPTION
Add an email integration plugin that would allow agents to receive and send emails.

# Relates to

2641

# Risks

No risk. New plugin

# Background

## What does this PR do?
Provide an implementation for an emailClient.


## What kind of change is this?
Improvement

## Why are we doing this? Any context or related work?
Currently, there's no built-in way for agents to handle email communications directly. This limits the agent's ability to engage in email-based workflows and automated email responses, which is essential for many business processes.

# Documentation changes needed?
No required

# Testing

## Where should a reviewer start?
README.md provided

## Detailed testing steps
No provided


<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->

## Discord username
jteso

