### PR TITLE
fix(ragKnowledge): Ensure scoped IDs are properly used to check for existing knowledge

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -181,7 +181,7 @@ export class AgentRuntime implements IAgentRuntime {
 
         if (this.memoryManagers.has(manager.tableName)) {
             elizaLogger.warn(
-                `Memory manager ${manager.tableName} is already registered. Skipping registration.`
+                `Memory manager ${manager.tableName} is already registered. Skipping registration.`,
             );
             return;
         }
@@ -208,7 +208,7 @@ export class AgentRuntime implements IAgentRuntime {
 
         if (this.services.has(serviceType)) {
             elizaLogger.warn(
-                `Service ${serviceType} is already registered. Skipping registration.`
+                `Service ${serviceType} is already registered. Skipping registration.`,
             );
             return;
         }
@@ -264,7 +264,7 @@ export class AgentRuntime implements IAgentRuntime {
         });
 
         elizaLogger.debug(
-            `[AgentRuntime] Process working directory: ${process.cwd()}`
+            `[AgentRuntime] Process working directory: ${process.cwd()}`,
         );
 
         // Define the root path once
@@ -272,11 +272,11 @@ export class AgentRuntime implements IAgentRuntime {
             process.cwd(),
             "..",
             "characters",
-            "knowledge"
+            "knowledge",
         );
 
         elizaLogger.debug(
-            `[AgentRuntime] Process knowledgeRoot: ${this.knowledgeRoot}`
+            `[AgentRuntime] Process knowledgeRoot: ${this.knowledgeRoot}`,
         );
 
         this.#conversationLength =
@@ -299,7 +299,7 @@ export class AgentRuntime implements IAgentRuntime {
         this.ensureUserExists(
             this.agentId,
             this.character.username || this.character.name,
-            this.character.name
+            this.character.name,
         ).then(() => {
             // postgres needs the user to exist before you can add a participant
             this.ensureParticipantExists(this.agentId, this.agentId);
@@ -371,19 +371,17 @@ export class AgentRuntime implements IAgentRuntime {
         this.imageModelProvider =
             this.character.imageModelProvider ?? this.modelProvider;
 
-        elizaLogger.info(
-            `Selected model provider: ${this.modelProvider}`
-        );
+        elizaLogger.info(`Selected model provider: ${this.modelProvider}`);
 
         elizaLogger.info(
-            `Selected image model provider: ${this.imageModelProvider}`
+            `Selected image model provider: ${this.imageModelProvider}`,
         );
 
         this.imageVisionModelProvider =
             this.character.imageVisionModelProvider ?? this.modelProvider;
 
         elizaLogger.info(
-            `Selected image vision model provider: ${this.imageVisionModelProvider}`
+            `Selected image vision model provider: ${this.imageVisionModelProvider}`,
         );
 
         // Validate model provider
@@ -391,7 +389,7 @@ export class AgentRuntime implements IAgentRuntime {
             elizaLogger.error("Invalid model provider:", this.modelProvider);
             elizaLogger.error(
                 "Available providers:",
-                Object.values(ModelProviderName)
+                Object.values(ModelProviderName),
             );
             throw new Error(`Invalid model provider: ${this.modelProvider}`);
         }
@@ -446,12 +444,12 @@ export class AgentRuntime implements IAgentRuntime {
                 await service.initialize(this);
                 this.services.set(serviceType, service);
                 elizaLogger.success(
-                    `Service ${serviceType} initialized successfully`
+                    `Service ${serviceType} initialized successfully`,
                 );
             } catch (error) {
                 elizaLogger.error(
                     `Failed to initialize service ${serviceType}:`,
-                    error
+                    error,
                 );
                 throw error;
             }
@@ -460,7 +458,7 @@ export class AgentRuntime implements IAgentRuntime {
         for (const plugin of this.plugins) {
             if (plugin.services)
                 await Promise.all(
-                    plugin.services?.map((service) => service.initialize(this))
+                    plugin.services?.map((service) => service.initialize(this)),
                 );
         }
 
@@ -470,11 +468,11 @@ export class AgentRuntime implements IAgentRuntime {
             this.character.knowledge.length > 0
         ) {
             elizaLogger.info(
-                `[RAG Check] RAG Knowledge enabled: ${this.character.settings.ragKnowledge ? true : false}`
+                `[RAG Check] RAG Knowledge enabled: ${this.character.settings.ragKnowledge ? true : false}`,
             );
             elizaLogger.info(
                 `[RAG Check] Knowledge items:`,
-                this.character.knowledge
+                this.character.knowledge,
             );
 
             if (this.character.settings.ragKnowledge) {
@@ -485,18 +483,18 @@ export class AgentRuntime implements IAgentRuntime {
                             if (typeof item === "object") {
                                 if (isDirectoryItem(item)) {
                                     elizaLogger.debug(
-                                        `[RAG Filter] Found directory item: ${JSON.stringify(item)}`
+                                        `[RAG Filter] Found directory item: ${JSON.stringify(item)}`,
                                     );
                                     acc[0].push(item);
                                 } else if ("path" in item) {
                                     elizaLogger.debug(
-                                        `[RAG Filter] Found path item: ${JSON.stringify(item)}`
+                                        `[RAG Filter] Found path item: ${JSON.stringify(item)}`,
                                     );
                                     acc[1].push(item);
                                 }
                             } else if (typeof item === "string") {
                                 elizaLogger.debug(
-                                    `[RAG Filter] Found string item: ${item.slice(0, 100)}...`
+                                    `[RAG Filter] Found string item: ${item.slice(0, 100)}...`,
                                 );
                                 acc[2].push(item);
                             }
@@ -506,21 +504,21 @@ export class AgentRuntime implements IAgentRuntime {
                             Array<{ directory: string; shared?: boolean }>,
                             Array<{ path: string; shared?: boolean }>,
                             Array<string>,
-                        ]
+                        ],
                     );
 
                 elizaLogger.info(
-                    `[RAG Summary] Found ${directoryKnowledge.length} directories, ${pathKnowledge.length} paths, and ${stringKnowledge.length} strings`
+                    `[RAG Summary] Found ${directoryKnowledge.length} directories, ${pathKnowledge.length} paths, and ${stringKnowledge.length} strings`,
                 );
 
                 // Process each type of knowledge
                 if (directoryKnowledge.length > 0) {
                     elizaLogger.info(
-                        `[RAG Process] Processing directory knowledge sources:`
+                        `[RAG Process] Processing directory knowledge sources:`,
                     );
                     for (const dir of directoryKnowledge) {
                         elizaLogger.info(
-                            `  - Directory: ${dir.directory} (shared: ${!!dir.shared})`
+                            `  - Directory: ${dir.directory} (shared: ${!!dir.shared})`,
                         );
                         await this.processCharacterRAGDirectory(dir);
                     }
@@ -528,28 +526,28 @@ export class AgentRuntime implements IAgentRuntime {
 
                 if (pathKnowledge.length > 0) {
                     elizaLogger.info(
-                        `[RAG Process] Processing individual file knowledge sources`
+                        `[RAG Process] Processing individual file knowledge sources`,
                     );
                     await this.processCharacterRAGKnowledge(pathKnowledge);
                 }
 
                 if (stringKnowledge.length > 0) {
                     elizaLogger.info(
-                        `[RAG Process] Processing direct string knowledge`
+                        `[RAG Process] Processing direct string knowledge`,
                     );
                     await this.processCharacterKnowledge(stringKnowledge);
                 }
             } else {
                 // Non-RAG mode: only process string knowledge
                 const stringKnowledge = this.character.knowledge.filter(
-                    (item): item is string => typeof item === "string"
+                    (item): item is string => typeof item === "string",
                 );
                 await this.processCharacterKnowledge(stringKnowledge);
             }
 
             // After all new knowledge is processed, clean up any deleted files
             elizaLogger.info(
-                `[RAG Cleanup] Starting cleanup of deleted knowledge files`
+                `[RAG Cleanup] Starting cleanup of deleted knowledge files`,
             );
             await this.ragKnowledgeManager.cleanupDeletedKnowledgeFiles();
             elizaLogger.info(`[RAG Cleanup] Cleanup complete`);
@@ -572,7 +570,7 @@ export class AgentRuntime implements IAgentRuntime {
                 "runtime::stop - requesting",
                 cStr,
                 "client stop for",
-                this.character.name
+                this.character.name,
             );
             c.stop();
         }
@@ -599,7 +597,7 @@ export class AgentRuntime implements IAgentRuntime {
                 "Processing knowledge for ",
                 this.character.name,
                 " - ",
-                item.slice(0, 100)
+                item.slice(0, 100),
             );
 
             await knowledge.set(this, {
@@ -618,7 +616,7 @@ export class AgentRuntime implements IAgentRuntime {
      * An array of knowledge items or objects containing id, path, and content.
      */
     private async processCharacterRAGKnowledge(
-        items: (string | { path: string; shared?: boolean })[]
+        items: (string | { path: string; shared?: boolean })[],
     ) {
         let hasError = false;
 
@@ -638,7 +636,11 @@ export class AgentRuntime implements IAgentRuntime {
                     contentItem = item;
                 }
 
-                const knowledgeId = stringToUuid(contentItem);
+                // const knowledgeId = stringToUuid(contentItem);
+                const knowledgeId = this.ragKnowledgeManager.generateScopedId(
+                    contentItem,
+                    isShared,
+                );
                 const fileExtension = contentItem
                     .split(".")
                     .pop()
@@ -651,54 +653,98 @@ export class AgentRuntime implements IAgentRuntime {
                 ) {
                     try {
                         const filePath = join(this.knowledgeRoot, contentItem);
-                        elizaLogger.info(
-                            "Attempting to read file from:",
-                            filePath
-                        );
+                        // Get existing knowledge first with more detailed logging
+                        elizaLogger.debug("[RAG Query]", {
+                            knowledgeId,
+                            agentId: this.agentId,
+                            relativePath: contentItem,
+                            fullPath: filePath,
+                            isShared,
+                            knowledgeRoot: this.knowledgeRoot,
+                        });
 
                         // Get existing knowledge first
                         const existingKnowledge =
                             await this.ragKnowledgeManager.getKnowledge({
                                 id: knowledgeId,
-                                agentId: this.agentId,
+                                agentId: this.agentId, // Keep agentId as it's used in OR query
                             });
 
+                        elizaLogger.debug("[RAG Query Result]", {
+                            relativePath: contentItem,
+                            fullPath: filePath,
+                            knowledgeId,
+                            isShared,
+                            exists: existingKnowledge.length > 0,
+                            knowledgeCount: existingKnowledge.length,
+                            firstResult: existingKnowledge[0]
+                                ? {
+                                      id: existingKnowledge[0].id,
+                                      agentId: existingKnowledge[0].agentId,
+                                      contentLength:
+                                          existingKnowledge[0].content.text
+                                              .length,
+                                  }
+                                : null,
+                            results: existingKnowledge.map((k) => ({
+                                id: k.id,
+                                agentId: k.agentId,
+                                isBaseKnowledge: !k.id.includes("chunk"),
+                            })),
+                        });
+
+                        // Read file content
                         const content: string = await readFile(
                             filePath,
-                            "utf8"
+                            "utf8",
                         );
                         if (!content) {
                             hasError = true;
                             continue;
                         }
 
-                        // If the file exists in DB, check if content has changed
                         if (existingKnowledge.length > 0) {
                             const existingContent =
                                 existingKnowledge[0].content.text;
+
+                            elizaLogger.debug("[RAG Compare]", {
+                                path: contentItem,
+                                knowledgeId,
+                                isShared,
+                                existingContentLength: existingContent.length,
+                                newContentLength: content.length,
+                                contentSample: content.slice(0, 100),
+                                existingContentSample: existingContent.slice(
+                                    0,
+                                    100,
+                                ),
+                                matches: existingContent === content,
+                            });
+
                             if (existingContent === content) {
                                 elizaLogger.info(
-                                    `File ${contentItem} unchanged, skipping`
+                                    `${isShared ? "Shared knowledge" : "Knowledge"} ${contentItem} unchanged, skipping`,
                                 );
                                 continue;
-                            } else {
-                                // If content changed, remove old knowledge before adding new
-                                await this.ragKnowledgeManager.removeKnowledge(
-                                    knowledgeId
-                                );
-                                // Also remove any associated chunks - this is needed for non-PostgreSQL adapters
-                                // PostgreSQL adapter handles chunks internally via foreign keys
-                                await this.ragKnowledgeManager.removeKnowledge(
-                                    `${knowledgeId}-chunk-*` as UUID
-                                );
                             }
+
+                            // Content changed, remove old knowledge before adding new
+                            elizaLogger.info(
+                                `${isShared ? "Shared knowledge" : "Knowledge"} ${contentItem} changed, updating...`,
+                            );
+                            await this.ragKnowledgeManager.removeKnowledge(
+                                knowledgeId,
+                            );
+                            await this.ragKnowledgeManager.removeKnowledge(
+                                `${knowledgeId}-chunk-*` as UUID,
+                            );
                         }
 
                         elizaLogger.info(
-                            `Successfully read ${fileExtension.toUpperCase()} file content for`,
+                            `Processing ${fileExtension.toUpperCase()} file content for`,
                             this.character.name,
                             "-",
-                            contentItem
+                            contentItem,
                         );
 
                         await this.ragKnowledgeManager.processFile({
@@ -711,9 +757,9 @@ export class AgentRuntime implements IAgentRuntime {
                         hasError = true;
                         elizaLogger.error(
                             `Failed to read knowledge file ${contentItem}. Error details:`,
-                            error?.message || error || "Unknown error"
+                            error?.message || error || "Unknown error",
                         );
-                        continue; // Continue to next item even if this one fails
+                        continue;
                     }
                 } else {
                     // Handle direct knowledge string
@@ -721,7 +767,7 @@ export class AgentRuntime implements IAgentRuntime {
                         "Processing direct knowledge for",
                         this.character.name,
                         "-",
-                        contentItem.slice(0, 100)
+                        contentItem.slice(0, 100),
                     );
 
                     const existingKnowledge =
@@ -732,7 +778,7 @@ export class AgentRuntime implements IAgentRuntime {
 
                     if (existingKnowledge.length > 0) {
                         elizaLogger.info(
-                            `Direct knowledge ${knowledgeId} already exists, skipping`
+                            `Direct knowledge ${knowledgeId} already exists, skipping`,
                         );
                         continue;
                     }
@@ -752,15 +798,15 @@ export class AgentRuntime implements IAgentRuntime {
                 hasError = true;
                 elizaLogger.error(
                     `Error processing knowledge item ${item}:`,
-                    error?.message || error || "Unknown error"
+                    error?.message || error || "Unknown error",
                 );
-                continue; // Continue to next item even if this one fails
+                continue;
             }
         }
 
         if (hasError) {
             elizaLogger.warn(
-                "Some knowledge items failed to process, but continuing with available knowledge"
+                "Some knowledge items failed to process, but continuing with available knowledge",
             );
         }
     }
@@ -787,7 +833,7 @@ export class AgentRuntime implements IAgentRuntime {
             const dirExists = existsSync(dirPath);
             if (!dirExists) {
                 elizaLogger.error(
-                    `[RAG Directory] Directory does not exist: ${sanitizedDir}`
+                    `[RAG Directory] Directory does not exist: ${sanitizedDir}`,
                 );
                 return;
             }
@@ -802,13 +848,13 @@ export class AgentRuntime implements IAgentRuntime {
 
             if (files.length === 0) {
                 elizaLogger.warn(
-                    `No matching files found in directory: ${dirConfig.directory}`
+                    `No matching files found in directory: ${dirConfig.directory}`,
                 );
                 return;
             }
 
             elizaLogger.info(
-                `[RAG Directory] Found ${files.length} files in ${dirConfig.directory}`
+                `[RAG Directory] Found ${files.length} files in ${dirConfig.directory}`,
             );
 
             // Process files in batches to avoid memory issues
@@ -827,7 +873,7 @@ export class AgentRuntime implements IAgentRuntime {
                                     file,
                                     relativePath,
                                     shared: dirConfig.shared,
-                                }
+                                },
                             );
 
                             await this.processCharacterRAGKnowledge([
@@ -845,19 +891,19 @@ export class AgentRuntime implements IAgentRuntime {
                                           message: error.message,
                                           stack: error.stack,
                                       }
-                                    : error
+                                    : error,
                             );
                         }
-                    })
+                    }),
                 );
 
                 elizaLogger.debug(
-                    `[RAG Directory] Completed batch ${Math.min(i + BATCH_SIZE, files.length)}/${files.length} files`
+                    `[RAG Directory] Completed batch ${Math.min(i + BATCH_SIZE, files.length)}/${files.length} files`,
                 );
             }
 
             elizaLogger.success(
-                `[RAG Directory] Successfully processed directory: ${sanitizedDir}`
+                `[RAG Directory] Successfully processed directory: ${sanitizedDir}`,
             );
         } catch (error) {
             elizaLogger.error(
@@ -868,7 +914,7 @@ export class AgentRuntime implements IAgentRuntime {
                           message: error.message,
                           stack: error.stack,
                       }
-                    : error
+                    : error,
             );
             throw error; // Re-throw to let caller handle it
         }
@@ -934,7 +980,7 @@ export class AgentRuntime implements IAgentRuntime {
         message: Memory,
         responses: Memory[],
         state?: State,
-        callback?: HandlerCallback
+        callback?: HandlerCallback,
     ): Promise<void> {
         for (const response of responses) {
             if (!response.content?.action) {
@@ -955,8 +1001,8 @@ export class AgentRuntime implements IAgentRuntime {
                         .replace("_", "")
                         .includes(normalizedAction) ||
                     normalizedAction.includes(
-                        a.name.toLowerCase().replace("_", "")
-                    )
+                        a.name.toLowerCase().replace("_", ""),
+                    ),
             );
 
             if (!action) {
@@ -969,13 +1015,13 @@ export class AgentRuntime implements IAgentRuntime {
                                 .replace("_", "")
                                 .includes(normalizedAction) ||
                             normalizedAction.includes(
-                                simile.toLowerCase().replace("_", "")
-                            )
+                                simile.toLowerCase().replace("_", ""),
+                            ),
                     );
                     if (simileAction) {
                         action = _action;
                         elizaLogger.success(
-                            `Action found in similes: ${action.name}`
+                            `Action found in similes: ${action.name}`,
                         );
                         break;
                     }
@@ -985,7 +1031,7 @@ export class AgentRuntime implements IAgentRuntime {
             if (!action) {
                 elizaLogger.error(
                     "No action found for",
-                    response.content.action
+                    response.content.action,
                 );
                 continue;
             }
@@ -997,7 +1043,7 @@ export class AgentRuntime implements IAgentRuntime {
 
             try {
                 elizaLogger.info(
-                    `Executing handler for action: ${action.name}`
+                    `Executing handler for action: ${action.name}`,
                 );
                 await action.handler(this, message, state, {}, callback);
             } catch (error) {
@@ -1018,7 +1064,7 @@ export class AgentRuntime implements IAgentRuntime {
         message: Memory,
         state: State,
         didRespond?: boolean,
-        callback?: HandlerCallback
+        callback?: HandlerCallback,
     ) {
         const evaluatorPromises = this.evaluators.map(
             async (evaluator: Evaluator) => {
@@ -1034,12 +1080,12 @@ export class AgentRuntime implements IAgentRuntime {
                     return evaluator;
                 }
                 return null;
-            }
+            },
         );
 
         const resolvedEvaluators = await Promise.all(evaluatorPromises);
         const evaluatorsData = resolvedEvaluators.filter(
-            (evaluator): evaluator is Evaluator => evaluator !== null
+            (evaluator): evaluator is Evaluator => evaluator !== null,
         );
 
         // if there are no evaluators this frame, return
@@ -1066,7 +1112,7 @@ export class AgentRuntime implements IAgentRuntime {
         });
 
         const evaluators = parseJsonArrayFromText(
-            result
+            result,
         ) as unknown as string[];
 
         for (const evaluator of this.evaluators) {
@@ -1105,7 +1151,7 @@ export class AgentRuntime implements IAgentRuntime {
         userName: string | null,
         name: string | null,
         email?: string | null,
-        source?: string | null
+        source?: string | null,
     ) {
         const account = await this.databaseAdapter.getAccountById(userId);
         if (!account) {
@@ -1127,11 +1173,11 @@ export class AgentRuntime implements IAgentRuntime {
             await this.databaseAdapter.addParticipant(userId, roomId);
             if (userId === this.agentId) {
                 elizaLogger.log(
-                    `Agent ${this.character.name} linked to room ${roomId} successfully.`
+                    `Agent ${this.character.name} linked to room ${roomId} successfully.`,
                 );
             } else {
                 elizaLogger.log(
-                    `User ${userId} linked to room ${roomId} successfully.`
+                    `User ${userId} linked to room ${roomId} successfully.`,
                 );
             }
         }
@@ -1142,20 +1188,20 @@ export class AgentRuntime implements IAgentRuntime {
         roomId: UUID,
         userName?: string,
         userScreenName?: string,
-        source?: string
+        source?: string,
     ) {
         await Promise.all([
             this.ensureUserExists(
                 this.agentId,
                 this.character.username ?? "Agent",
                 this.character.name ?? "Agent",
-                source
+                source,
             ),
             this.ensureUserExists(
                 userId,
                 userName ?? "User" + userId,
                 userScreenName ?? "User" + userId,
-                source
+                source,
             ),
             this.ensureRoomExists(roomId),
         ]);
@@ -1188,7 +1234,7 @@ export class AgentRuntime implements IAgentRuntime {
      */
     async composeState(
         message: Memory,
-        additionalKeys: { [key: string]: unknown } = {}
+        additionalKeys: { [key: string]: unknown } = {},
     ) {
         const { userId, roomId } = message;
 
@@ -1231,7 +1277,7 @@ export class AgentRuntime implements IAgentRuntime {
         // const lore = formatLore(loreData);
 
         const senderName = actorsData?.find(
-            (actor: Actor) => actor.id === userId
+            (actor: Actor) => actor.id === userId,
         )?.name;
 
         // TODO: We may wish to consolidate and just accept character.name here instead of the actor name
@@ -1245,7 +1291,7 @@ export class AgentRuntime implements IAgentRuntime {
             const lastMessageWithAttachment = recentMessagesData.find(
                 (msg) =>
                     msg.content.attachments &&
-                    msg.content.attachments.length > 0
+                    msg.content.attachments.length > 0,
             );
 
             if (lastMessageWithAttachment) {
@@ -1254,20 +1300,17 @@ export class AgentRuntime implements IAgentRuntime {
                 const oneHourBeforeLastMessage =
                     lastMessageTime - 60 * 60 * 1000; // 1 hour before last message
 
-                allAttachments = recentMessagesData
-                    .reverse()
-                    .flatMap((msg) => {
-                        const msgTime = msg.createdAt ?? Date.now();
-                        const isWithinTime =
-                            msgTime >= oneHourBeforeLastMessage;
-                        const attachments = msg.content.attachments || [];
-                        if (!isWithinTime) {
-                            attachments.forEach((attachment) => {
-                                attachment.text = "[Hidden]";
-                            });
-                        }
-                        return attachments;
-                    });
+                allAttachments = recentMessagesData.reverse().flatMap((msg) => {
+                    const msgTime = msg.createdAt ?? Date.now();
+                    const isWithinTime = msgTime >= oneHourBeforeLastMessage;
+                    const attachments = msg.content.attachments || [];
+                    if (!isWithinTime) {
+                        attachments.forEach((attachment) => {
+                            attachment.text = "[Hidden]";
+                        });
+                    }
+                    return attachments;
+                });
             }
         }
 
@@ -1280,7 +1323,7 @@ URL: ${attachment.url}
 Type: ${attachment.source}
 Description: ${attachment.description}
 Text: ${attachment.text}
-  `
+  `,
             )
             .join("\n");
 
@@ -1289,7 +1332,7 @@ Text: ${attachment.text}
         // Assuming this.lore is an array of lore bits
         if (this.character.lore && this.character.lore.length > 0) {
             const shuffledLore = [...this.character.lore].sort(
-                () => Math.random() - 0.5
+                () => Math.random() - 0.5,
             );
             const selectedLore = shuffledLore.slice(0, 10);
             lore = selectedLore.join("\n");
@@ -1309,7 +1352,7 @@ Text: ${attachment.text}
             .slice(0, 5)
             .map((example) => {
                 const exampleNames = Array.from({ length: 5 }, () =>
-                    uniqueNamesGenerator({ dictionaries: [names] })
+                    uniqueNamesGenerator({ dictionaries: [names] }),
                 );
 
                 return example
@@ -1319,7 +1362,7 @@ Text: ${attachment.text}
                             const placeholder = `{{user${index + 1}}}`;
                             messageString = messageString.replaceAll(
                                 placeholder,
-                                name
+                                name,
                             );
                         });
                         return messageString;
@@ -1330,7 +1373,7 @@ Text: ${attachment.text}
 
         const getRecentInteractions = async (
             userA: UUID,
-            userB: UUID
+            userB: UUID,
         ): Promise<Memory[]> => {
             // Find all rooms where userA and userB are participants
             const rooms = await this.databaseAdapter.getRoomsForParticipants([
@@ -1352,7 +1395,7 @@ Text: ${attachment.text}
                 : [];
 
         const getRecentMessageInteractions = async (
-            recentInteractionsData: Memory[]
+            recentInteractionsData: Memory[],
         ): Promise<string> => {
             // Format the recent messages
             const formattedInteractions = await Promise.all(
@@ -1364,12 +1407,12 @@ Text: ${attachment.text}
                     } else {
                         const accountId =
                             await this.databaseAdapter.getAccountById(
-                                message.userId
+                                message.userId,
                             );
                         sender = accountId?.username || "unknown";
                     }
                     return `${sender}: ${message.content.text}`;
-                })
+                }),
             );
 
             return formattedInteractions.join("\n");
@@ -1380,7 +1423,7 @@ Text: ${attachment.text}
 
         const getRecentPostInteractions = async (
             recentInteractionsData: Memory[],
-            actors: Actor[]
+            actors: Actor[],
         ): Promise<string> => {
             const formattedInteractions = formatPosts({
                 messages: recentInteractionsData,
@@ -1393,7 +1436,7 @@ Text: ${attachment.text}
 
         const formattedPostInteractions = await getRecentPostInteractions(
             recentInteractions,
-            actorsData
+            actorsData,
         );
 
         // if bio is a string, use it. if its an array, pick one at random
@@ -1438,7 +1481,7 @@ Text: ${attachment.text}
                 this.character.adjectives.length > 0
                     ? this.character.adjectives[
                           Math.floor(
-                              Math.random() * this.character.adjectives.length
+                              Math.random() * this.character.adjectives.length,
                           )
                       ]
                     : "",
@@ -1456,7 +1499,7 @@ Text: ${attachment.text}
                 this.character.topics && this.character.topics.length > 0
                     ? this.character.topics[
                           Math.floor(
-                              Math.random() * this.character.topics.length
+                              Math.random() * this.character.topics.length,
                           )
                       ]
                     : null,
@@ -1483,7 +1526,7 @@ Text: ${attachment.text}
                 formattedCharacterPostExamples.replaceAll("\n", "").length > 0
                     ? addHeader(
                           `# Example Posts for ${this.character.name}`,
-                          formattedCharacterPostExamples
+                          formattedCharacterPostExamples,
                       )
                     : "",
             characterMessageExamples:
@@ -1492,7 +1535,7 @@ Text: ${attachment.text}
                     0
                     ? addHeader(
                           `# Example Conversations for ${this.character.name}`,
-                          formattedCharacterMessageExamples
+                          formattedCharacterMessageExamples,
                       )
                     : "",
             messageDirections:
@@ -1504,7 +1547,7 @@ Text: ${attachment.text}
                               const all = this.character?.style?.all || [];
                               const chat = this.character?.style?.chat || [];
                               return [...all, ...chat].join("\n");
-                          })()
+                          })(),
                       )
                     : "",
 
@@ -1517,7 +1560,7 @@ Text: ${attachment.text}
                               const all = this.character?.style?.all || [];
                               const post = this.character?.style?.post || [];
                               return [...all, ...post].join("\n");
-                          })()
+                          })(),
                       )
                     : "",
 
@@ -1553,7 +1596,7 @@ Text: ${attachment.text}
                 goals && goals.length > 0
                     ? addHeader(
                           "# Goals\n{{agentName}} should prioritize accomplishing the objectives that are in progress.",
-                          goals
+                          goals,
                       )
                     : "",
             goalsData,
@@ -1585,7 +1628,7 @@ Text: ${attachment.text}
             const result = await evaluator.validate(
                 this,
                 message,
-                initialState
+                initialState,
             );
             if (result) {
                 return evaluator;
@@ -1601,7 +1644,7 @@ Text: ${attachment.text}
             ]);
 
         const evaluatorsData = resolvedEvaluators.filter(
-            Boolean
+            Boolean,
         ) as Evaluator[];
         const actionsData = resolvedActions.filter(Boolean) as Action[];
 
@@ -1612,14 +1655,14 @@ Text: ${attachment.text}
                 actionsData.length > 0
                     ? addHeader(
                           "# Available Actions",
-                          formatActions(actionsData)
+                          formatActions(actionsData),
                       )
                     : "",
             actionExamples:
                 actionsData.length > 0
                     ? addHeader(
                           "# Action Examples",
-                          composeActionExamples(actionsData, 10)
+                          composeActionExamples(actionsData, 10),
                       )
                     : "",
             evaluatorsData,
@@ -1637,7 +1680,7 @@ Text: ${attachment.text}
                     : "",
             providers: addHeader(
                 `# Additional Information About ${this.character.name} and The World`,
-                providers
+                providers,
             ),
         };
 
@@ -1667,7 +1710,7 @@ Text: ${attachment.text}
             const lastMessageWithAttachment = recentMessagesData.find(
                 (msg) =>
                     msg.content.attachments &&
-                    msg.content.attachments.length > 0
+                    msg.content.attachments.length > 0,
             );
 
             if (lastMessageWithAttachment) {
@@ -1694,7 +1737,7 @@ URL: ${attachment.url}
 Type: ${attachment.source}
 Description: ${attachment.description}
 Text: ${attachment.text}
-    `
+    `,
             )
             .join("\n");
 
@@ -1702,7 +1745,7 @@ Text: ${attachment.text}
             ...state,
             recentMessages: addHeader(
                 "# Conversation Messages",
-                recentMessages
+                recentMessages,
             ),
             recentMessagesData,
             attachments: formattedAttachments,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -408,7 +408,7 @@ export type Handler = (
     message: Memory,
     state?: State,
     options?: { [key: string]: unknown },
-    callback?: HandlerCallback
+    callback?: HandlerCallback,
 ) => Promise<unknown>;
 
 /**
@@ -416,7 +416,7 @@ export type Handler = (
  */
 export type HandlerCallback = (
     response: Content,
-    files?: any
+    files?: any,
 ) => Promise<Memory[]>;
 
 /**
@@ -425,7 +425,7 @@ export type HandlerCallback = (
 export type Validator = (
     runtime: IAgentRuntime,
     message: Memory,
-    state?: State
+    state?: State,
 ) => Promise<boolean>;
 
 /**
@@ -502,7 +502,7 @@ export interface Provider {
     get: (
         runtime: IAgentRuntime,
         message: Memory,
-        state?: State
+        state?: State,
     ) => Promise<any>;
 }
 
@@ -1022,13 +1022,13 @@ export interface IDatabaseAdapter {
             agentId?: UUID;
             unique?: boolean;
             tableName: string;
-        }
+        },
     ): Promise<Memory[]>;
 
     createMemory(
         memory: Memory,
         tableName: string,
-        unique?: boolean
+        unique?: boolean,
     ): Promise<void>;
 
     removeMemory(memoryId: UUID, tableName: string): Promise<void>;
@@ -1038,7 +1038,7 @@ export interface IDatabaseAdapter {
     countMemories(
         roomId: UUID,
         unique?: boolean,
-        tableName?: string
+        tableName?: string,
     ): Promise<number>;
 
     getGoals(params: {
@@ -1077,13 +1077,13 @@ export interface IDatabaseAdapter {
 
     getParticipantUserState(
         roomId: UUID,
-        userId: UUID
+        userId: UUID,
     ): Promise<"FOLLOWED" | "MUTED" | null>;
 
     setParticipantUserState(
         roomId: UUID,
         userId: UUID,
-        state: "FOLLOWED" | "MUTED" | null
+        state: "FOLLOWED" | "MUTED" | null,
     ): Promise<void>;
 
     createRelationship(params: { userA: UUID; userB: UUID }): Promise<boolean>;
@@ -1147,7 +1147,7 @@ export interface IMemoryManager {
     }): Promise<Memory[]>;
 
     getCachedEmbeddings(
-        content: string
+        content: string,
     ): Promise<{ embedding: number[]; levenshtein_score: number }[]>;
 
     getMemoryById(id: UUID): Promise<Memory | null>;
@@ -1162,7 +1162,7 @@ export interface IMemoryManager {
             count?: number;
             roomId: UUID;
             unique?: boolean;
-        }
+        },
     ): Promise<Memory[]>;
 
     createMemory(memory: Memory, unique?: boolean): Promise<void>;
@@ -1202,6 +1202,7 @@ export interface IRAGKnowledgeManager {
         isShared: boolean;
     }): Promise<void>;
     cleanupDeletedKnowledgeFiles(): Promise<void>;
+    generateScopedId(path: string, isShared: boolean): UUID;
 }
 
 export type CacheOptions = {
@@ -1294,14 +1295,14 @@ export interface IAgentRuntime {
         message: Memory,
         responses: Memory[],
         state?: State,
-        callback?: HandlerCallback
+        callback?: HandlerCallback,
     ): Promise<void>;
 
     evaluate(
         message: Memory,
         state?: State,
         didRespond?: boolean,
-        callback?: HandlerCallback
+        callback?: HandlerCallback,
     ): Promise<string[] | null>;
 
     ensureParticipantExists(userId: UUID, roomId: UUID): Promise<void>;
@@ -1310,7 +1311,7 @@ export interface IAgentRuntime {
         userId: UUID,
         userName: string | null,
         name: string | null,
-        source: string | null
+        source: string | null,
     ): Promise<void>;
 
     registerAction(action: Action): void;
@@ -1320,7 +1321,7 @@ export interface IAgentRuntime {
         roomId: UUID,
         userName?: string,
         userScreenName?: string,
-        source?: string
+        source?: string,
     ): Promise<void>;
 
     ensureParticipantInRoom(userId: UUID, roomId: UUID): Promise<void>;
@@ -1329,7 +1330,7 @@ export interface IAgentRuntime {
 
     composeState(
         message: Memory,
-        additionalKeys?: { [key: string]: unknown }
+        additionalKeys?: { [key: string]: unknown },
     ): Promise<State>;
 
     updateRecentMessageState(state: State): Promise<State>;
@@ -1337,14 +1338,14 @@ export interface IAgentRuntime {
 
 export interface IImageDescriptionService extends Service {
     describeImage(
-        imageUrl: string
+        imageUrl: string,
     ): Promise<{ title: string; description: string }>;
 }
 
 export interface ITranscriptionService extends Service {
     transcribeAttachment(audioBuffer: ArrayBuffer): Promise<string | null>;
     transcribeAttachmentLocally(
-        audioBuffer: ArrayBuffer
+        audioBuffer: ArrayBuffer,
     ): Promise<string | null>;
     transcribe(audioBuffer: ArrayBuffer): Promise<string | null>;
     transcribeLocally(audioBuffer: ArrayBuffer): Promise<string | null>;
@@ -1365,7 +1366,7 @@ export interface ITextGenerationService extends Service {
         stop: string[],
         frequency_penalty: number,
         presence_penalty: number,
-        max_tokens: number
+        max_tokens: number,
     ): Promise<any>;
     queueTextCompletion(
         context: string,
@@ -1373,7 +1374,7 @@ export interface ITextGenerationService extends Service {
         stop: string[],
         frequency_penalty: number,
         presence_penalty: number,
-        max_tokens: number
+        max_tokens: number,
     ): Promise<string>;
     getEmbeddingResponse(input: string): Promise<number[] | undefined>;
 }
@@ -1382,7 +1383,7 @@ export interface IBrowserService extends Service {
     closeBrowser(): Promise<void>;
     getPageContent(
         url: string,
-        runtime: IAgentRuntime
+        runtime: IAgentRuntime,
     ): Promise<{ title: string; description: string; bodyContent: string }>;
 }
 
@@ -1401,7 +1402,7 @@ export interface IAwsS3Service extends Service {
         imagePath: string,
         subDirectory: string,
         useSignedUrl: boolean,
-        expiresIn: number
+        expiresIn: number,
     ): Promise<{
         success: boolean;
         url?: string;
@@ -1449,7 +1450,7 @@ export interface IIrysService extends Service {
     getDataFromAnAgent(
         agentsWalletPublicKeys: string[],
         tags: GraphQLTag[],
-        timestamp: IrysTimestamp
+        timestamp: IrysTimestamp,
     ): Promise<DataIrysFetchedFromGQL>;
     workerUploadDataOnIrys(
         data: any,
@@ -1460,13 +1461,13 @@ export interface IIrysService extends Service {
         validationThreshold: number[],
         minimumProviders: number[],
         testProvider: boolean[],
-        reputation: number[]
+        reputation: number[],
     ): Promise<UploadIrysResult>;
     providerUploadDataOnIrys(
         data: any,
         dataType: IrysDataType,
         serviceCategory: string[],
-        protocol: string[]
+        protocol: string[],
     ): Promise<UploadIrysResult>;
 }
 
@@ -1477,7 +1478,7 @@ export interface ITeeLogService extends Service {
         roomId: string,
         userId: string,
         type: string,
-        content: string
+        content: string,
     ): Promise<boolean>;
 }
 
@@ -1596,7 +1597,7 @@ export interface IVerifiableInferenceAdapter {
     generateText(
         context: string,
         modelClass: string,
-        options?: VerifiableInferenceOptions
+        options?: VerifiableInferenceOptions,
     ): Promise<VerifiableInferenceResult>;
 
     /**


### PR DESCRIPTION
fix(ragKnowledge): Ensure scoped IDs are properly used to check for existing knowledge

- Updated logic to correctly handle scoped IDs when verifying existing knowledge entries.
- Improved validation to prevent issues with knowledge retrieval and management.

The problem is in how knowledge IDs are handled between checking for existence and creation. 

1. In `processCharacterRAGKnowledge`, you generate the ID using:
```typescript
const knowledgeId = stringToUuid(contentItem);  // contentItem is the file path
```

2. But in `RAGKnowledgeManager.processFile`, you generate the ID using:
```typescript
const scopedId = this.generateScopedId(file.path, file.isShared || false);
```

The mismatch is here - when you check for existing knowledge using `getKnowledge`, you're using the first ID generation method (just based on file path), but when you actually create the knowledge, you're using the second method (which includes the scope prefix).

This means:
- Check for existence using: `stringToUuid("shared/warringstates/zhibo.md")`
- Actually stored with: `stringToUuid("shared-shared/warringstates/zhibo.md")`

The fix would be to use the same ID generation method in both places. You should modify `processCharacterRAGKnowledge` to use `generateScopedId` when checking for existence:

```typescript
// In processCharacterRAGKnowledge
const knowledgeId = this.ragKnowledgeManager.generateScopedId(contentItem, isShared);
```

Fixes #2689 