### PR TITLE
feat: Add plugin-ethstorage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -821,3 +821,9 @@ HYPERBOLIC_LOG_LEVEL=debug
 
 # Football Plugin Configuration
 FOOTBALL_API_KEY=                   # API key from Football-Data.org (https://www.football-data.org/)
+
+
+# EthStorage DA Configuration
+ETHSTORAGE_PRIVATE_KEY=
+ETHSTORAGE_ADDRESS=0x64003adbdf3014f7E38FC6BE752EB047b95da89A
+ETHSTORAGE_RPC_URL=https://rpc.beta.testnet.l2.quarkchain.io:8545

--- a/agent/package.json
+++ b/agent/package.json
@@ -123,7 +123,8 @@
         "@elizaos/plugin-suno": "workspace:*",
         "@elizaos/plugin-udio": "workspace:*",
         "@elizaos/plugin-hyperbolic": "workspace:*",
-            "@elizaos/plugin-football": "workspace:*",
+        "@elizaos/plugin-football": "workspace:*",
+        "@elizaos/plugin-ethstorage": "workspace:*",
     "readline": "1.3.0",
         "ws": "8.18.0",
         "yargs": "17.7.2"

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -133,6 +133,7 @@ import yargs from "yargs";
 import { emailPlugin } from "@elizaos/plugin-email";
 import { sunoPlugin } from "@elizaos/plugin-suno";
 import { udioPlugin } from "@elizaos/plugin-udio";
+import { ethstoragePlugin } from "@elizaos/plugin-ethstorage"
 
 const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
 const __dirname = path.dirname(__filename); // get the name of the directory
@@ -1164,7 +1165,8 @@ export async function createAgent(
                 ? hyperbolicPlugin
                 : null,
             getSecret(character, "SUNO_API_KEY") ? sunoPlugin : null,
-            getSecret(character, "UDIO_AUTH_TOKEN") ? udioPlugin : null
+            getSecret(character, "UDIO_AUTH_TOKEN") ? udioPlugin : null,
+            getSecret(character, "ETHSTORAGE_PRIVATE_KEY") ? ethstoragePlugin : null,
         ].filter(Boolean),
         providers: [],
         managers: [],

--- a/packages/plugin-ethstorage/.npmignore
+++ b/packages/plugin-ethstorage/.npmignore
@@ -1,0 +1,6 @@
+*
+
+!dist/**
+!package.json
+!readme.md
+!tsup.config.ts

--- a/packages/plugin-ethstorage/README.md
+++ b/packages/plugin-ethstorage/README.md
@@ -1,0 +1,39 @@
+# @elizaos/plugin-ethstorage - Plugin for EthStorage
+
+This plugin allows interaction with the EthStorage decentralized storage network using Eliza. By default, it operates on the beta testnet, but you can switch to other testnets by updating the `ETHSTORAGE_RPC_URL` in the `.env` file. The mainnet is not yet available.
+
+## Actions
+- **transfer**: This action enables the transfer of QKC tokens from the agent's wallet (specified via `ETHSTORAGE_PRIVATE_KEY`) to another wallet. To use, just mention the transfer of tokens to an EthStorage account.
+
+    - Name: `SEND_TOKEN`
+
+    - Message sample: `Send 100 QKC to 0x341Cb1a94ef69499F97E93c41707B21326C0Cc87`
+
+- **submitData**: This action enables the submission of any arbitrary data to the EthStorage decentralized storage network. To use, just mention that you need to send "any data" to EthStorage using the key you specified.
+
+    - Name: `SUBMIT_DATA`
+
+    - Message sample: `Submit the following data using key 'my_key' to EthStorage "Hello World!"`
+
+## Usage & Testing
+
+### Detailed testing steps
+- In the .env file, set the following values:
+    - ETHSTORAGE_ADDRESS: The entry contract address for storing data on the EthStorage network (default is set to the beta testnet but can be updated if needed).
+    - ETHSTORAGE_RPC_URL: The RPC endpoint for connecting to the desired EthStorage network (default is set to the beta testnet).
+    - ETHSTORAGE_PRIVATE_KEY: The private key for the agent’s wallet.
+- **Transfer Tokens**
+    - To test the transfer function, you need tokens in your EthStorage account. On the testnet, you can use the [EthStorage Faucet](https://qkc-l2-faucet.eth.sep.w3link.io/). If you need more tokens, please ping us on [Discord](https://discord.com/invite/xhCwaMp7ps), and we can send them over.
+    - Run the agent and prompt it with: "send <AMOUNT> QKC to <any other EthStorage account>" - e.g. `send 1 QKC to 0x341Cb1a94ef69499F97E93c41707B21326C0Cc87`
+    - If the transaction is successful, the agent will return the Tx Hash.
+      The tx hash can be checked on the EthStorage block explorer at [https://explorer.beta.testnet.l2.quarkchain.io](https://explorer.beta.testnet.l2.quarkchain.io).
+
+- **Submit Data**
+    - To test data submission, you need tokens in your EthStorage account to pay fees. On the testnet, you can use the [EthStorage Faucet](https://qkc-l2-faucet.eth.sep.w3link.io/). If you need more tokens, please ping us on [Discord](https://discord.com/invite/xhCwaMp7ps), and we can send them over.
+    - Run the agent and prompt it with: "Submit the following data using the key <KEY> to EthStorage <DATA>" - e.g. `Submit the following data using the key 'my_key' to EthStorage "Hello World!"`
+    - If the transaction is successful, the agent will return the Tx Hash. The tx hash can be checked on the EthStorage block explorer at [https://explorer.beta.testnet.l2.quarkchain.io](https://explorer.beta.testnet.l2.quarkchain.io).
+
+## Resources
+- [EthStorage Documentation](https://docs.ethstorage.io/)
+- [Learn more about EthStorage](https://ethstorage.io/)
+- [Awesome EthStorage Repo](https://github.com/ethstorage/)

--- a/packages/plugin-ethstorage/package.json
+++ b/packages/plugin-ethstorage/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "@elizaos/plugin-ethstorage",
+    "main": "dist/index.js",
+    "type": "module",
+    "types": "dist/index.d.ts",
+    "dependencies": {
+        "@elizaos/core": "workspace:*",
+        "@elizaos/plugin-trustdb": "workspace:*",
+        "ethers": "^6.13.5",
+        "kzg-wasm": "^0.4.0"
+    },
+    "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsup": "8.3.5"
+    },
+    "scripts": {
+        "build": "tsup --format esm --dts",
+        "dev": "tsup --format esm --dts --watch"
+    }
+}

--- a/packages/plugin-ethstorage/src/actions/submitData.ts
+++ b/packages/plugin-ethstorage/src/actions/submitData.ts
@@ -1,0 +1,206 @@
+import {
+    type ActionExample,
+    type HandlerCallback,
+    type IAgentRuntime,
+    type Memory,
+    ModelClass,
+    type State,
+    type Action,
+    elizaLogger,
+    composeContext,
+    generateObjectDeprecated,
+} from "@elizaos/core";
+import { ethers } from "ethers";
+import { ethstorageConfig } from "../environment";
+import { BlobUploader } from "../utils/uploader";
+import { encodeOpBlobs } from "../utils/blobs.ts";
+
+export const EthStorageAbi: readonly string[] = [
+    'function putBlobs(bytes32[] memory _keys, uint256[] memory _blobIdxs, uint256[] memory _lengths)',
+    'function putBlob(bytes32 _key, uint256 _blobIdx, uint256 _length) public payable',
+    'function get(bytes32 _key, uint8 _decodeType, uint256 _off, uint256 _len) public view returns (bytes memory)',
+    'function size(bytes32 _key) public view returns (uint256)',
+    'function upfrontPayment() public view returns (uint256)'
+];
+
+export function stringToHex(s: string): string {
+    return ethers.hexlify(ethers.toUtf8Bytes(s));
+}
+
+export async function sendData(
+    RPC: string, privateKey: string,
+    address: string, key: string, data: Buffer
+): Promise<string> {
+    const blobUploader = await BlobUploader.create(RPC, privateKey);
+    const provider = new ethers.JsonRpcProvider(RPC);
+    const wallet = new ethers.Wallet(privateKey, provider);
+    const contract = new ethers.Contract(address, EthStorageAbi, wallet);
+    const hexKey = ethers.keccak256(stringToHex(key));
+    const storageCost = await contract.upfrontPayment();
+    const tx = await contract.putBlob.populateTransaction(hexKey, 0, data.length, {
+        value: storageCost,
+    });
+
+    const blobs = encodeOpBlobs(data);
+    const txRes = await blobUploader.sendTx(tx, blobs);
+    elizaLogger.log(`tx hash ${txRes.hash}`);
+    const receipt = await txRes.wait();
+    return receipt?.status === 1 ? txRes.hash : undefined;
+}
+
+const submitDataTemplate = `Respond with a JSON markdown block containing only the extracted values. Use null for any values that cannot be determined.
+
+
+Example response:
+\`\`\`json
+{
+    "key": "data_key"
+    "data": "Hello World, this is the data I submitted",
+}
+\`\`\`
+
+{{recentMessages}}
+
+Given the recent messages, extract the following information about the requested EthStorage data submission:
+- Key of the data to be submitted
+- Data to be submitted
+
+Respond with a JSON markdown block containing only the extracted values.`;
+
+export default {
+    name: "UPLOAD_DATA",
+    similes: [
+        "UPLOAD_DATA_TO_ETHSTORAGE",
+        "SUBMIT_DATA",
+        "SUBMIT_DATA_TO_ETHSTORAGE",
+        "SEND_DATA",
+        "SEND_DATA_TO_ETHSTORAGE",
+        "POST_DATA",
+        "POST_DATA_TO_ETHSTORAGE",
+        "POST_DATA_ON_ETHSTORAGE_NETWORK",
+        "POST_DATA_TO_ETHSTORAGE_NETWORK",
+        "SEND_DATA_ON_ETHSTORAGE_NETWORK",
+        "SEND_DATA_TO_ETHSTORAGE_NETWORK",
+        "SUBMIT_DATA_ON_ETHSTORAGE_NETWORK",
+        "SUBMIT_DATA_TO_ETHSTORAGE_NETWORK",
+        "UPLOAD_DATA_ON_ETHSTORAGE_NETWORK",
+        "UPLOAD_DATA_TO_ETHSTORAGE_NETWORK",
+    ],
+    validate: async (runtime: IAgentRuntime, _message: Memory) => {
+        await ethstorageConfig(runtime);
+        return true;
+    },
+    description: "Submit data to EthStorage as per user command",
+    handler: async (
+        runtime: IAgentRuntime,
+        message: Memory,
+        state: State,
+        _options: { [key: string]: unknown },
+        callback?: HandlerCallback
+    ): Promise<boolean> => {
+        elizaLogger.log("Starting SUBMIT_DATA handler...");
+
+        // Initialize or update state
+        if (!state) {
+            state = (await runtime.composeState(message)) as State;
+        } else {
+            state = await runtime.updateRecentMessageState(state);
+        }
+
+        // Compose transfer context
+        const submitDataContext = composeContext({
+            state,
+            template: submitDataTemplate,
+        });
+
+        // Generate transfer content
+        const content = await generateObjectDeprecated({
+            runtime,
+            context: submitDataContext,
+            modelClass: ModelClass.SMALL,
+        });
+
+        if (content.data != null && content.key !== "") {
+            try {
+                const RPC = runtime.getSetting("ETHSTORAGE_RPC_URL");
+                const privateKey = runtime.getSetting("ETHSTORAGE_PRIVATE_KEY")!;
+                const address = runtime.getSetting("ETHSTORAGE_ADDRESS");
+
+                elizaLogger.log(`Transaction Data is ${content.data}`);
+                const data = Buffer.from(content.data);
+
+                //submit data
+                const hash= await sendData(RPC, privateKey, address, content.key, data);
+                if (hash) {
+                    elizaLogger.success(
+                        `Data submitted! \n Tx Hash: ${hash}`
+                    );
+                    if (callback) {
+                        await callback({
+                            text: `Data submitted! \n Tx Hash: ${hash}`,
+                            content: {},
+                        });
+                    }
+                }
+
+                return true;
+            } catch (error) {
+                elizaLogger.error("Error during data submission:", error);
+                if (callback) {
+                    callback({
+                        text: `Error submitting data: ${error.message}`,
+                        content: { error: error.message },
+                    });
+                }
+                return false;
+            }
+        } else {
+            elizaLogger.log("No data mentioned to be submitted");
+        }
+    },
+
+    examples: [
+        [
+            {
+                user: "{{user1}}",
+                content: {
+                    text: "Submit the following data using the key 'data_key' to EthStorage 'Hello World!'",
+                },
+            },
+            {
+                user: "{{agent}}",
+                content: {
+                    text: "Sure, I'll send the data 'Hello World!' using the key 'data_key' to EthStorage now.",
+                    action: "SUBMIT_DATA",
+                },
+            },
+            {
+                user: "{{agent}}",
+                content: {
+                    text: "Successfully submitted the data 'Hello World!' using the key 'data_key' to EthStorage \nTransaction: 0x748057951ff79cea6de0e13b2ef70a1e9f443e9c83ed90e5601f8b45144a4ed4",
+                },
+            },
+        ],
+        [
+            {
+                user: "{{user1}}",
+                content: {
+                    text: "Submit 'Don't Fight, Unite!' to EthStorage using the key 'my_key'",
+                },
+            },
+            {
+                user: "{{agent}}",
+                content: {
+                    text: "Sure, I'll send the data 'Don't Fight, Unite!' to EthStorage using the key 'my_key' now.",
+                    action: "SUBMIT_DATA",
+                },
+            },
+            {
+                user: "{{agent}}",
+                content: {
+                    text: "Successfully submitted the data 'Don't Fight, Unite!' using the key 'my_key' to EthStorage \nTransaction: 0x748057951ff79cea6de0e13b2ef70a1e9f443e9c83ed90e5601f8b45144a4ed4",
+                },
+            },
+        ],
+    ] as ActionExample[][],
+} as Action;

--- a/packages/plugin-ethstorage/src/actions/transfer.ts
+++ b/packages/plugin-ethstorage/src/actions/transfer.ts
@@ -1,0 +1,198 @@
+import {
+    type ActionExample,
+    type Content,
+    type HandlerCallback,
+    type IAgentRuntime,
+    type Memory,
+    ModelClass,
+    type State,
+    type Action,
+    elizaLogger,
+    composeContext,
+    generateObjectDeprecated,
+} from "@elizaos/core";
+import { ethstorageConfig } from "../environment";
+import { ethers } from "ethers";
+
+export interface TransferContent extends Content {
+    recipient: string;
+    amount: string | number;
+}
+
+export function isTransferContent(
+    content: TransferContent
+): content is TransferContent {
+    // Validate types
+    const validTypes =
+        typeof content.recipient === "string" &&
+        (typeof content.amount === "string" ||
+            typeof content.amount === "number");
+    if (!validTypes) {
+        return false;
+    }
+
+    // Validate addresses
+    return ethers.isAddress(content.recipient);
+}
+
+const transferTemplate = `Respond with a JSON markdown block containing only the extracted values. Use null for any values that cannot be determined.
+
+
+Example response:
+\`\`\`json
+{
+    "recipient": "0x341Cb1a94ef69499F97E93c41707B21326C0Cc87",
+    "amount": "1000"
+}
+\`\`\`
+
+{{recentMessages}}
+
+Given the recent messages, extract the following information about the requested ETHSTORAGE token transfer:
+- Recipient wallet address
+- Amount of QKC to transfer
+
+Respond with a JSON markdown block containing only the extracted values.`;
+
+export default {
+    name: "SEND_TOKEN",
+    similes: [
+        "TRANSFER_TOKEN",
+        "TRANSFER_TOKEN_ON_ETHSTORAGE",
+        "TRANSFER_TOKENS_ON_ETHSTORAGE",
+        "SEND_TOKEN_ON_ETHSTORAGE",
+        "SEND_TOKENS_ON_ETHSTORAGE",
+        "PAY_ON_ETHSTORAGE",
+    ],
+    validate: async (runtime: IAgentRuntime, _message: Memory) => {
+        await ethstorageConfig(runtime);
+        return true;
+    },
+    description:
+        "Transfer tokens from the agent's wallet to another address",
+    handler: async (
+        runtime: IAgentRuntime,
+        message: Memory,
+        state: State,
+        _options: { [key: string]: unknown },
+        callback?: HandlerCallback
+    ): Promise<boolean> => {
+        elizaLogger.log("Starting SEND_TOKEN handler...");
+
+        // Initialize or update state
+        if (!state) {
+            state = (await runtime.composeState(message)) as State;
+        } else {
+            state = await runtime.updateRecentMessageState(state);
+        }
+
+        // Compose transfer context
+        const transferContext = composeContext({
+            state,
+            template: transferTemplate,
+        });
+
+        // Generate transfer content
+        const content = await generateObjectDeprecated({
+            runtime,
+            context: transferContext,
+            modelClass: ModelClass.SMALL,
+        });
+
+        // Validate transfer content
+        if (!isTransferContent(content)) {
+            console.log(content);
+            console.error("Invalid content for TRANSFER_TOKEN action.");
+            if (callback) {
+                callback({
+                    text: "Unable to process transfer request. Invalid content provided.",
+                    content: {error: "Invalid transfer content"},
+                });
+            }
+            return false;
+        }
+
+        if (content.amount != null && content.recipient != null) {
+            try {
+                const RPC = runtime.getSetting("ETHSTORAGE_RPC_URL");
+                const PRIVATE_KEY = runtime.getSetting("ETHSTORAGE_PRIVATE_KEY")!;
+
+                const provider = new ethers.JsonRpcProvider(RPC);
+                const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
+                const tx = await wallet.sendTransaction({
+                    to: content.recipient,
+                    value: ethers.parseEther(content.amount.toString()),
+                });
+                await tx.wait();
+
+                elizaLogger.success(
+                    "Transfer completed successfully! Transaction hash: " + tx.hash
+                );
+                if (callback) {
+                    callback({
+                        text: `Transfer completed successfully! Transaction hash: ${tx.hash} `,
+                        content: {},
+                    });
+                }
+
+                return true;
+            } catch (error) {
+                elizaLogger.error("Error during token transfer:", error);
+                if (callback) {
+                    callback({
+                        text: `Error transferring tokens: ${error.message}`,
+                        content: { error: error.message },
+                    });
+                }
+                return false;
+            }
+        } else {
+            elizaLogger.log("Either amount or recipient not specified");
+        }
+    },
+
+    examples: [
+        [
+            {
+                user: "{{user1}}",
+                content: {
+                    text: "Send 100 QKC to 0x114B242D931B47D5cDcEe7AF065856f70ee278C4",
+                },
+            },
+            {
+                user: "{{agent}}",
+                content: {
+                    text: "Sure, I'll send 100 QKC to that address now.",
+                    action: "SEND_TOKEN",
+                },
+            },
+            {
+                user: "{{agent}}",
+                content: {
+                    text: "Successfully sent 100 QKC to 0x114B242D931B47D5cDcEe7AF065856f70ee278C4\nTransaction: 0x748057951ff79cea6de0e13b2ef70a1e9f443e9c83ed90e5601f8b45144a4ed4",
+                },
+            },
+        ],
+        [
+            {
+                user: "{{user1}}",
+                content: {
+                    text: "Please send 100 QKC tokens to 0x114B242D931B47D5cDcEe7AF065856f70ee278C4",
+                },
+            },
+            {
+                user: "{{agent}}",
+                content: {
+                    text: "Of course. Sending 100 QKC to that address now.",
+                    action: "SEND_TOKEN",
+                },
+            },
+            {
+                user: "{{agent}}",
+                content: {
+                    text: "Successfully sent 100 QKC to 0x114B242D931B47D5cDcEe7AF065856f70ee278C4\nTransaction: 0x0b9f23e69ea91ba98926744472717960cc7018d35bc3165bdba6ae41670da0f0",
+                },
+            },
+        ],
+    ] as ActionExample[][],
+} as Action;

--- a/packages/plugin-ethstorage/src/environment.ts
+++ b/packages/plugin-ethstorage/src/environment.ts
@@ -1,0 +1,37 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { z } from "zod";
+
+export const ethstorageEnvSchema = z.object({
+    ETHSTORAGE_PRIVATE_KEY: z.string().min(1, "EthStorage private key is required"),
+    ETHSTORAGE_ADDRESS: z.string().min(1, "EthStorage address is required"),
+    ETHSTORAGE_RPC_URL: z.string().min(1, "EthStorage RPC url is required"),
+});
+
+export type ethstorageConfig = z.infer<typeof ethstorageEnvSchema>;
+
+export async function ethstorageConfig(
+    runtime: IAgentRuntime
+): Promise<ethstorageConfig> {
+    try {
+        const config = {
+            ETHSTORAGE_PRIVATE_KEY:
+                runtime.getSetting("ETHSTORAGE_PRIVATE_KEY") || process.env.ETHSTORAGE_PRIVATE_KEY,
+            ETHSTORAGE_ADDRESS:
+                runtime.getSetting("ETHSTORAGE_ADDRESS") || process.env.ETHSTORAGE_ADDRESS,
+            ETHSTORAGE_RPC_URL:
+                runtime.getSetting("ETHSTORAGE_RPC_URL") || process.env.ETHSTORAGE_RPC_URL,
+        };
+
+        return ethstorageEnvSchema.parse(config);
+    } catch (error) {
+        if (error instanceof z.ZodError) {
+            const errorMessages = error.errors
+                .map((err) => `${err.path.join(".")}: ${err.message}`)
+                .join("\n");
+            throw new Error(
+                `EthStorage configuration validation failed:\n${errorMessages}`
+            );
+        }
+        throw error;
+    }
+}

--- a/packages/plugin-ethstorage/src/index.ts
+++ b/packages/plugin-ethstorage/src/index.ts
@@ -1,0 +1,18 @@
+import type { Plugin } from "@elizaos/core";
+
+export * from "./actions/submitData";
+export * from "./actions/transfer";
+
+import transfer from "./actions/transfer";
+import submitData from "./actions/submitData";
+
+export const ethstoragePlugin: Plugin = {
+    name: "ethstorage",
+    description: "Ethstorage DA publishing plugin",
+    providers: [],
+    evaluators: [],
+    services: [],
+    actions: [transfer, submitData],
+};
+
+export default ethstoragePlugin;

--- a/packages/plugin-ethstorage/src/utils/blobs.ts
+++ b/packages/plugin-ethstorage/src/utils/blobs.ts
@@ -1,0 +1,137 @@
+const BlobTxBytesPerFieldElement: number = 32;      // Size in bytes of a field element
+const BlobTxFieldElementsPerBlob: number = 4096;
+export const BLOB_SIZE: number = BlobTxBytesPerFieldElement * BlobTxFieldElementsPerBlob;
+
+// OP BLOB
+const MaxBlobDataSize = (4 * 31 + 3) * 1024 - 4;
+const EncodingVersion = 0;
+const Rounds = 1024; // number of encode/decode rounds
+
+export function copy(des: Uint8Array, desOff: number, src: Uint8Array, srcOff: number): number {
+    const srcLength = src.length - srcOff;
+    const desLength = des.length - desOff;
+    const length = Math.min(srcLength, desLength);
+    des.set(src.subarray(srcOff, srcOff + length), desOff);
+    return length;
+}
+
+export function encodeOpBlobs(data: Uint8Array): Uint8Array[] {
+    const len = data.length;
+    if (len === 0) {
+        throw new Error('invalid blob data');
+    }
+    const blobs: Uint8Array[] = [];
+    for (let i = 0; i < len; i += MaxBlobDataSize) {
+        let max = i + MaxBlobDataSize;
+        if (max > len) {
+            max = len;
+        }
+        const blob = encodeOpBlob(data.subarray(i, max));
+        blobs.push(blob);
+    }
+    return blobs;
+}
+
+export function encodeOpBlob(data: Uint8Array): Uint8Array {
+    if (data.length > MaxBlobDataSize) {
+        throw new Error(`too much data to encode in one blob, len=${data.length}`);
+    }
+
+    const b = new Uint8Array(BLOB_SIZE).fill(0);
+    let readOffset = 0;
+
+    // read 1 byte of input, 0 if there is no input left
+    const read1 = (): number => {
+        if (readOffset >= data.length) {
+            return 0;
+        }
+        const out = data[readOffset];
+        readOffset += 1;
+        return out;
+    }
+
+    let writeOffset = 0;
+    const buf31 = new Uint8Array(31);
+    const zero31 = new Uint8Array(31);
+    // Read up to 31 bytes of input (left-aligned), into buf31.
+    const read31 = (): void => {
+        if (readOffset >= data.length) {
+            copy(buf31, 0, zero31, 0);
+            return;
+        }
+
+        const n = copy(buf31, 0, data, readOffset); // copy as much data as we can
+        copy(buf31, n, zero31, 0);       // pad with zeroes (since there might not be enough data)
+        readOffset += n;
+    }
+    // Write a byte, updates the write-offset.
+    // Asserts that the write-offset matches encoding-algorithm expectations.
+    // Asserts that the value is 6 bits.
+    const write1 = (v: number): void => {
+        if (writeOffset % 32 !== 0) {
+            throw new Error(`blob encoding: invalid byte write offset: ${writeOffset}`);
+        }
+
+        const tag = v & 0b1100_0000;
+        if (tag !== 0) {
+            throw new Error(`blob encoding: invalid 6 bit value: 0b${v.toString(2)}`);
+        }
+        b[writeOffset] = v;
+        writeOffset += 1;
+    }
+    // Write buf31 to the blob, updates the write-offset.
+    // Asserts that the write-offset matches encoding-algorithm expectations.
+    const write31 = (): void => {
+        if (writeOffset % 32 !== 1) {
+            throw new Error(`blob encoding: invalid bytes31 write offset: ${writeOffset}`);
+        }
+
+        copy(b, writeOffset, buf31, 0);
+        writeOffset += 31;
+    }
+
+    for (let round = 0; round < Rounds && readOffset < data.length; round++) {
+        // The first field element encodes the version and the length of the data in [1:5].
+        // This is a manual substitute for read31(), preparing the buf31.
+        if (round === 0) {
+            buf31[0] = EncodingVersion;
+            // Encode the length as big-endian uint24.
+            // The length check at the start above ensures we can always fit the length value into only 3 bytes.
+            const ilen = data.length;
+            buf31[1] = (ilen >> 16) & 0xFF;
+            buf31[2] = (ilen >> 8) & 0xFF;
+            buf31[3] = ilen & 0xFF;
+
+            readOffset += copy(buf31, 4, data, 0);
+        } else {
+            read31();
+        }
+
+        const x = read1();
+        const A = x & 0b0011_1111;
+        write1(A);
+        write31();
+
+        read31();
+        const y = read1();
+        const B = (y & 0b0000_1111) | ((x & 0b1100_0000) >> 2);
+        write1(B);
+        write31();
+
+        read31();
+        const z = read1();
+        const C = z & 0b0011_1111;
+        write1(C);
+        write31();
+
+        read31();
+        const D = ((z & 0b1100_0000) >> 2) | ((y & 0b1111_0000) >> 4);
+        write1(D);
+        write31();
+    }
+
+    if (readOffset < data.length) {
+        throw new Error(`expected to fit data but failed, read offset: ${readOffset}, data: ${data}`);
+    }
+    return b;
+}

--- a/packages/plugin-ethstorage/src/utils/uploader.ts
+++ b/packages/plugin-ethstorage/src/utils/uploader.ts
@@ -1,0 +1,114 @@
+import { ethers } from "ethers";
+import { loadKZG, TrustedSetup } from 'kzg-wasm';
+
+// KZG
+interface KZG {
+    loadTrustedSetup: (trustedSetup?: TrustedSetup) => number;
+    freeTrustedSetup: () => void;
+    blobToKzgCommitment: (blob: Uint8Array) => Uint8Array;
+    computeBlobKzgProof: (blob: Uint8Array, commitment: Uint8Array) => Uint8Array;
+    verifyBlobKzgProofBatch: (blobs: Uint8Array[], commitments: Uint8Array[], proofs: Uint8Array[]) => boolean;
+    verifyKzgProof: (commitment: Uint8Array, z: Uint8Array, y: Uint8Array, proof: Uint8Array) => boolean;
+    verifyBlobKzgProof: (blob: Uint8Array, commitment: Uint8Array, proof: Uint8Array) => boolean
+}
+
+function commitmentsToVersionedHashes(commitment: Uint8Array): Uint8Array {
+    const computedVersionedHash = new Uint8Array(32);
+    computedVersionedHash.set([0x01], 0);
+    const hash = ethers.getBytes(ethers.sha256(commitment));
+    computedVersionedHash.set(hash.subarray(1), 1);
+    return computedVersionedHash;
+}
+
+// blob gas price
+const MIN_BLOB_GASPRICE: bigint = 1n;
+const BLOB_GASPRICE_UPDATE_FRACTION: bigint = 3338477n;
+
+function fakeExponential(factor: bigint, numerator: bigint, denominator: bigint): bigint {
+    let i: bigint = 1n;
+    let output: bigint = 0n;
+    let numerator_accum: bigint = factor * denominator;
+    while (numerator_accum > 0n) {
+        output += numerator_accum;
+        numerator_accum = (numerator_accum * numerator) / (denominator * i);
+        i++;
+    }
+    return output / denominator;
+}
+
+export class BlobUploader {
+    private readonly provider: ethers.JsonRpcProvider;
+    private readonly wallet: ethers.Wallet;
+    private kzg!: KZG;
+
+    static async create(rpc: string, pk: string): Promise<BlobUploader> {
+        const uploader = new BlobUploader(rpc, pk);
+        await uploader.init();
+        return uploader;
+    }
+
+    private constructor(rpc: string, pk: string) {
+        this.provider = new ethers.JsonRpcProvider(rpc);
+        this.wallet = new ethers.Wallet(pk, this.provider);
+    }
+
+    private async init() {
+        if (!this.kzg) {
+            this.kzg = await loadKZG();
+        }
+    }
+
+    async getBlobGasPrice(): Promise<bigint> {
+        // get current block
+        const block = await this.provider.getBlock("latest");
+        if (block === null || block.excessBlobGas === null) {
+            throw new Error("Block has no excessBlobGas");
+        }
+        const excessBlobGas = BigInt(block.excessBlobGas);
+        const gas = fakeExponential(MIN_BLOB_GASPRICE, excessBlobGas, BLOB_GASPRICE_UPDATE_FRACTION);
+        return gas * 11n / 10n;
+    }
+
+    async getGasPrice(): Promise<ethers.FeeData> {
+        return await this.provider.getFeeData();
+    }
+
+    async sendTx(
+        tx: ethers.TransactionRequest,
+        blobs: Uint8Array[] | null = null,
+        commitments: Uint8Array[] | null = null,
+    ): Promise<ethers.TransactionResponse> {
+        if (!blobs) {
+            return await this.wallet.sendTransaction(tx);
+        }
+
+        if (tx.maxFeePerBlobGas == null) {
+            tx.maxFeePerBlobGas = await this.getBlobGasPrice();
+        }
+
+        // blobs
+        const kzg = this.kzg;
+        const ethersBlobs: ethers.BlobLike[] = [];
+        const versionedHashes: string[] = [];
+        for (let i = 0; i < blobs.length; i++) {
+            const blob = blobs[i];
+            const commitment = (commitments && commitments.length > i) ? commitments[i] : kzg.blobToKzgCommitment(blob);
+            const proof = kzg.computeBlobKzgProof(blob, commitment);
+            ethersBlobs.push({
+                data: blob,
+                proof: proof,
+                commitment: commitment
+            });
+
+            const hash = commitmentsToVersionedHashes(commitment);
+            versionedHashes.push(ethers.hexlify(hash));
+        }
+
+        // send
+        tx.type = 3;
+        tx.blobVersionedHashes = versionedHashes;
+        tx.blobs = ethersBlobs;
+        tx.kzg = kzg;
+        return await this.wallet.sendTransaction(tx);
+    }
+}

--- a/packages/plugin-ethstorage/tsconfig.json
+++ b/packages/plugin-ethstorage/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../core/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "src",
+        "types": [
+            "node"
+        ]
+    },
+    "include": [
+        "src/**/*.ts",
+    ]
+}

--- a/packages/plugin-ethstorage/tsup.config.ts
+++ b/packages/plugin-ethstorage/tsup.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+    entry: ["src/index.ts"],
+    outDir: "dist",
+    sourcemap: true,
+    clean: true,
+    format: ["esm"], // Ensure you're targeting CommonJS
+    external: [
+        "dotenv", // Externalize dotenv to prevent bundling
+        "fs", // Externalize fs to use Node.js built-in module
+        "path", // Externalize other built-ins if necessary
+        "@reflink/reflink",
+        "@node-llama-cpp",
+        "https",
+        "http",
+        "agentkeepalive",
+        "safe-buffer",
+        // Add other modules you want to externalize
+    ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -257,6 +257,9 @@ importers:
       '@elizaos/plugin-email':
         specifier: workspace:*
         version: link:../packages/plugin-email
+      '@elizaos/plugin-ethstorage':
+        specifier: workspace:*
+        version: link:../packages/plugin-ethstorage
       '@elizaos/plugin-evm':
         specifier: workspace:*
         version: link:../packages/plugin-evm
@@ -2138,6 +2141,28 @@ importers:
       typescript:
         specifier: ^5.0.0
         version: 5.6.3
+
+  packages/plugin-ethstorage:
+    dependencies:
+      '@elizaos/core':
+        specifier: workspace:*
+        version: link:../core
+      '@elizaos/plugin-trustdb':
+        specifier: workspace:*
+        version: link:../plugin-trustdb
+      ethers:
+        specifier: ^6.13.5
+        version: 6.13.5(bufferutil@4.0.9)(utf-8-validate@6.0.5)
+      kzg-wasm:
+        specifier: ^0.4.0
+        version: 0.4.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.17.9
+      tsup:
+        specifier: 8.3.5
+        version: 8.3.5(@swc/core@1.10.9(@swc/helpers@0.5.15))(jiti@2.4.2)(postcss@8.5.1)(tsx@4.19.2)(typescript@5.7.3)(yaml@2.7.0)
 
   packages/plugin-evm:
     dependencies:
@@ -18932,6 +18957,9 @@ packages:
   ky@0.33.3:
     resolution: {integrity: sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==}
     engines: {node: '>=14.16'}
+
+  kzg-wasm@0.4.0:
+    resolution: {integrity: sha512-hKEwFbKrY1LZnAH5gY8+PlVWfkGnj2wd2tc83eIgzuC4NoshXqplW9OzGlBDqpAmXxwhiN8fgPG2+NcvUIBSwg==}
 
   labeled-stream-splicer@2.0.2:
     resolution: {integrity: sha512-Ca4LSXFFZUjPScRaqOcFxneA0VpKZr4MMYCljyQr4LIewTLb3Y0IUTIsnBBsVubIeEfxeSZpSjSsRM8APEQaAw==}
@@ -52089,6 +52117,8 @@ snapshots:
       web-streams-polyfill: 3.3.3
 
   ky@0.33.3: {}
+
+  kzg-wasm@0.4.0: {}
 
   labeled-stream-splicer@2.0.2:
     dependencies:


### PR DESCRIPTION
# Relates to
The PR is not related to any issues.

# Risks
Low risk, this PR is to add a new plugin, does not affect the core functionalities of Eliza.

# Background
There are existing tools that assist users in interacting with decentralized storage networks like EthStorage. These tools enable users to store and retrieve data in a decentralized manner, leveraging blockchain-based storage mechanisms. The EthStorage plugin allows for the transfer of QKC tokens and submission of arbitrary data to the EthStorage network, offering users a way to interact with decentralized storage easily. The plugin also provides a simple interface to interact with the EthStorage testnet and, once the mainnet is available, will enable mainnet interactions.

## What does this PR do?
This PR adds the `plugin-ethstorage`, which interacts with the EthStorage decentralized storage network. The plugin supports two primary actions: transferring QKC tokens and submitting data to the EthStorage network. It is designed to work with the testnet, and the configuration can be customized via environment variables.

## What kind of change is this?
Features

# Documentation changes needed?
No changes required for Eliza's documentation. The `plugin-ethstorage` documentation has been updated to reflect its functionality.

# Testing
## Where should a reviewer start?
Reviewers should integrate the plugin into a local agent and ensure the `.env` file is properly configured with `ETHSTORAGE_ADDRESS` (default set to the testnet), `ETHSTORAGE_PRIVATE_KEY,` and `ETHSTORAGE_RPC_URL` (a default value is provided, but you can modify it if needed).

## Detailed testing steps
1. Ensure the `.env` file is configured with `ETHSTORAGE_ADDRESS`, `ETHSTORAGE_PRIVATE_KEY`, and `ETHSTORAGE_RPC_URL`. The `ETHSTORAGE_ADDRESS` is set to the default testnet value, and `ETHSTORAGE_RPC_URL` has a default value as well, but both can be changed if needed.
3. Test the transfer function by running: `send <AMOUNT> QKC to <any other EthStorage account>`.
4. Test the data submission functionality by running: `Submit the following data using the key <KEY> to EthStorage <DATA>`.
5. Verify that both actions are successfully executed by checking the transaction hash on the [EthStorage testnet explorer](https://explorer.beta.testnet.l2.quarkchain.io).

## Screenshots
<!-- If there are UI changes, include before and after screenshots. -->

## Deploy Notes
Please ensure that the `ETHSTORAGE_ADDRESS`, `ETHSTORAGE_RPC_URL` and `ETHSTORAGE_PRIVATE_KEY` are correctly configured before deploying the plugin.

## Database changes
No database changes.

## Deployment instructions
No additional deployment steps required other than configuring the environment variables.
