### PR TITLE
fix: client-twitter homeTimeline name parse bug

### DIFF
--- a/packages/client-twitter/src/base.ts
+++ b/packages/client-twitter/src/base.ts
@@ -271,7 +271,7 @@ export class ClientBase extends EventEmitter {
                 const obj = {
                     id: tweet.id,
                     name:
-                        tweet.name ?? tweet?.user_results?.result?.legacy.name,
+                        tweet.name ?? tweet.core?.user_results?.result?.legacy.name,
                     username:
                         tweet.username ??
                         tweet.core?.user_results?.result?.legacy.screen_name,


### PR DESCRIPTION
Currently, using the API always returns name as undefined.
It should be retrieved from .core, like the username on the line below, but it is missing.