### PR TITLE
feat: Add Access Token Management to MultiversX Plugin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -519,7 +519,7 @@ APTOS_NETWORK=     # Must be one of mainnet, testnet
 # MultiversX
 MVX_PRIVATE_KEY=                    # Multiversx private key
 MVX_NETWORK=                        # must be one of mainnet, devnet, testnet
-ACCESS_TOKEN_MANAGMENT_TO=everyone  # you can put an userid to limit token managament to one user only (use same id as in the database)
+ACCESS_TOKEN_MANAGEMENT_TO=everyone  # you can put an userid to limit token managament to one user only (use same id as in the database)
 
 # NEAR
 NEAR_WALLET_SECRET_KEY= # NEAR Wallet Secret Key

--- a/.env.example
+++ b/.env.example
@@ -517,8 +517,9 @@ APTOS_PRIVATE_KEY= # Aptos private key
 APTOS_NETWORK=     # Must be one of mainnet, testnet
 
 # MultiversX
-MVX_PRIVATE_KEY= # Multiversx private key
-MVX_NETWORK=     # must be one of mainnet, devnet, testnet
+MVX_PRIVATE_KEY=                    # Multiversx private key
+MVX_NETWORK=                        # must be one of mainnet, devnet, testnet
+ACCESS_TOKEN_MANAGMENT_TO=everyone  # you can put an userid to limit token managament to one user only (use same id as in the database)
 
 # NEAR
 NEAR_WALLET_SECRET_KEY= # NEAR Wallet Secret Key

--- a/packages/plugin-multiversx/src/actions/createToken.ts
+++ b/packages/plugin-multiversx/src/actions/createToken.ts
@@ -20,6 +20,7 @@ export interface CreateTokenContent extends Content {
     decimals: string;
     amount: string;
 }
+import { isUserAuthorized } from "../utils/accessTokenManagement";
 
 const createTokenTemplate = `Respond with a JSON markdown block containing only the extracted values. Use null for any values that cannot be determined.
 
@@ -57,9 +58,25 @@ export default {
         message: Memory,
         state: State,
         _options: { [key: string]: unknown },
-        callback?: HandlerCallback,
+        callback?: HandlerCallback
     ) => {
         elizaLogger.log("Starting CREATE_TOKEN handler...");
+
+        console.log("Handler initialized. Checking user authorization...");
+
+        if (!isUserAuthorized(message.userId, runtime)) {
+            console.error(
+                "Unauthorized user attempted to create a token:",
+                message.userId
+            );
+            if (callback) {
+                callback({
+                    text: "You do not have permission to create a token.",
+                    content: { error: "Unauthorized user" },
+                });
+            }
+            return false;
+        }
 
         // Initialize or update state
         if (!state) {

--- a/packages/plugin-multiversx/src/actions/createToken.ts
+++ b/packages/plugin-multiversx/src/actions/createToken.ts
@@ -48,7 +48,7 @@ export default {
     name: "CREATE_TOKEN",
     similes: ["DEPLOY_TOKEN"],
     validate: async (runtime: IAgentRuntime, message: Memory) => {
-        console.log("Validating config for user:", message.userId);
+        elizaLogger.log("Validating config for user:", message.userId);
         await validateMultiversxConfig(runtime);
         return true;
     },
@@ -62,10 +62,10 @@ export default {
     ) => {
         elizaLogger.log("Starting CREATE_TOKEN handler...");
 
-        console.log("Handler initialized. Checking user authorization...");
+        elizaLogger.log("Handler initialized. Checking user authorization...");
 
         if (!isUserAuthorized(message.userId, runtime)) {
-            console.error(
+            elizaLogger.error(
                 "Unauthorized user attempted to create a token:",
                 message.userId
             );
@@ -105,7 +105,7 @@ export default {
 
         // Validate transfer content
         if (!isCreateTokenContent) {
-            console.error("Invalid content for CREATE_TOKEN action.");
+            elizaLogger.error("Invalid content for CREATE_TOKEN action.");
             if (callback) {
                 callback({
                     text: "Unable to process transfer request. Invalid content provided.",
@@ -134,7 +134,7 @@ export default {
             });
             return true;
         } catch (error) {
-            console.error("Error during creating token:", error);
+            elizaLogger.error("Error during creating token:", error);
             if (callback) {
                 callback({
                     text: `Error creating token: ${error.message}`,

--- a/packages/plugin-multiversx/src/actions/swap.ts
+++ b/packages/plugin-multiversx/src/actions/swap.ts
@@ -26,6 +26,8 @@ import {
 import { denominateAmount, getRawAmount } from "../utils/amount";
 import { getToken } from "../utils/getToken";
 import { filteredTokensQuery } from "../graphql/tokensQuery";
+import { isUserAuthorized } from "../utils/accessTokenManagement";
+
 
 type SwapResultType = {
     swap: {
@@ -86,6 +88,22 @@ export default {
         callback?: HandlerCallback,
     ) => {
         elizaLogger.log("Starting SWAP handler...");
+
+        console.log("Handler initialized. Checking user authorization...");
+
+                if (!isUserAuthorized(message.userId, runtime)) {
+                    console.error(
+                        "Unauthorized user attempted to swap:",
+                        message.userId
+                    );
+                    if (callback) {
+                        callback({
+                            text: "You do not have permission to swap.",
+                            content: { error: "Unauthorized user" },
+                        });
+                    }
+                    return false;
+                }
 
         // Initialize or update state
         if (!state) {

--- a/packages/plugin-multiversx/src/actions/swap.ts
+++ b/packages/plugin-multiversx/src/actions/swap.ts
@@ -75,7 +75,7 @@ export default {
     name: "SWAP",
     similes: ["SWAP_TOKEN", "SWAP_TOKENS"],
     validate: async (runtime: IAgentRuntime, message: Memory) => {
-        console.log("Validating config for user:", message.userId);
+        elizaLogger.log("Validating config for user:", message.userId);
         await validateMultiversxConfig(runtime);
         return true;
     },
@@ -89,10 +89,10 @@ export default {
     ) => {
         elizaLogger.log("Starting SWAP handler...");
 
-        console.log("Handler initialized. Checking user authorization...");
+        elizaLogger.log("Handler initialized. Checking user authorization...");
 
                 if (!isUserAuthorized(message.userId, runtime)) {
-                    console.error(
+                    elizaLogger.error(
                         "Unauthorized user attempted to swap:",
                         message.userId
                     );
@@ -135,7 +135,7 @@ export default {
 
         // Validate transfer content
         if (!isSwapContent) {
-            console.error("Invalid content for SWAP action.");
+            elizaLogger.error("Invalid content for SWAP action.");
 
             callback?.({
                 text: "Unable to process swap request. Invalid content provided.",
@@ -270,7 +270,7 @@ export default {
             });
             return true;
         } catch (error) {
-            console.error("Error during token swap:", error);
+            elizaLogger.error("Error during token swap:", error);
             callback?.({
                 text: "Could not execute the swap.",
                 content: { error: error.message },

--- a/packages/plugin-multiversx/src/actions/transfer.ts
+++ b/packages/plugin-multiversx/src/actions/transfer.ts
@@ -23,6 +23,7 @@ export interface TransferContent extends Content {
     amount: string;
     tokenIdentifier?: string;
 }
+import { isUserAuthorized } from "../utils/accessTokenManagement";
 
 const transferTemplate = `Respond with a JSON markdown block containing only the extracted values. Use null for any values that cannot be determined.
 
@@ -67,6 +68,22 @@ export default {
         callback?: HandlerCallback,
     ) => {
         elizaLogger.log("Starting SEND_TOKEN handler...");
+
+        console.log("Handler initialized. Checking user authorization...");
+
+        if (!isUserAuthorized(message.userId, runtime)) {
+            console.error(
+                "Unauthorized user attempted to transfer a token:",
+                message.userId
+            );
+            if (callback) {
+                callback({
+                    text: "You do not have permission to transfer a token.",
+                    content: { error: "Unauthorized user" },
+                });
+            }
+            return false;
+        }
 
         // Initialize or update state
         if (!state) {

--- a/packages/plugin-multiversx/src/actions/transfer.ts
+++ b/packages/plugin-multiversx/src/actions/transfer.ts
@@ -55,7 +55,7 @@ export default {
         "PAY",
     ],
     validate: async (runtime: IAgentRuntime, message: Memory) => {
-        console.log("Validating config for user:", message.userId);
+        elizaLogger.log("Validating config for user:", message.userId);
         await validateMultiversxConfig(runtime);
         return true;
     },
@@ -69,10 +69,10 @@ export default {
     ) => {
         elizaLogger.log("Starting SEND_TOKEN handler...");
 
-        console.log("Handler initialized. Checking user authorization...");
+        elizaLogger.log("Handler initialized. Checking user authorization...");
 
         if (!isUserAuthorized(message.userId, runtime)) {
-            console.error(
+            elizaLogger.error(
                 "Unauthorized user attempted to transfer a token:",
                 message.userId
             );
@@ -113,7 +113,7 @@ export default {
 
         // Validate transfer content
         if (!isTransferContent) {
-            console.error("Invalid content for TRANSFER_TOKEN action.");
+            elizaLogger.error("Invalid content for TRANSFER_TOKEN action.");
             if (callback) {
                 callback({
                     text: "Unable to process transfer request. Invalid content provided.",
@@ -187,7 +187,7 @@ export default {
 
             return true;
         } catch (error) {
-            console.error("Error during token transfer:", error);
+            elizaLogger.error("Error during token transfer:", error);
             callback?.({
                 text: error.message,
                 content: { error: error.message },

--- a/packages/plugin-multiversx/src/utils/accessTokenManagement.ts
+++ b/packages/plugin-multiversx/src/utils/accessTokenManagement.ts
@@ -1,0 +1,14 @@
+import {type IAgentRuntime} from "@elizaos/core";
+
+export function isUserAuthorized(
+    userId: string,
+    runtime: IAgentRuntime
+): boolean {
+    const authorizedUserId = runtime.getSetting("ACCESS_TOKEN_MANAGMENT_TO");
+    console.log("UserID from message:", userId);
+    console.log("Authorized UserID:", authorizedUserId);
+    if (authorizedUserId === "everyone") {
+        return true;
+    }
+    return userId === authorizedUserId;
+}

--- a/packages/plugin-multiversx/src/utils/accessTokenManagement.ts
+++ b/packages/plugin-multiversx/src/utils/accessTokenManagement.ts
@@ -1,12 +1,12 @@
-import {type IAgentRuntime} from "@elizaos/core";
+import {type IAgentRuntime, elizaLogger} from "@elizaos/core";
 
 export function isUserAuthorized(
     userId: string,
     runtime: IAgentRuntime
 ): boolean {
-    const authorizedUserId = runtime.getSetting("ACCESS_TOKEN_MANAGMENT_TO");
-    console.log("UserID from message:", userId);
-    console.log("Authorized UserID:", authorizedUserId);
+    const authorizedUserId = runtime.getSetting("ACCESS_TOKEN_MANAGEMENT_TO");
+    elizaLogger.log("UserID from message:", userId);
+    elizaLogger.log("Authorized UserID:", authorizedUserId);
     if (authorizedUserId === "everyone") {
         return true;
     }


### PR DESCRIPTION
# Relates to

multiversx-plugin

# Risks

# Background

## What does this PR do?

- Add the possibility to limit token management to one user or all user

## What kind of change is this?

Improvements

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

## Detailed testing steps

- Add a user id in the .env under ACCESS_TOKEN_MANAGMENT_TO (line 522)
- Try creating, transfer or swap a token with the account linked to this id
- Try creating, transfer or swap a token with another account