### PR TITLE
fix: adding exclusion for extra folder for faster future rebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ agent/content
 eliza.manifest
 eliza.manifest.sgx
 eliza.sig
+
 packages/plugin-nvidia-nim/extra
 packages/plugin-nvidia-nim/old_code
 packages/plugin-nvidia-nim/docs
@@ -87,3 +88,6 @@ scripts/bug_hunt/reports/
 scripts/bug_hunt/reports/*.md
 
 lit-config.json
+
+# Configuration to exclude the extra and local_docs directories
+extra


### PR DESCRIPTION
# Update .gitignore for Faster Rebases

## Changes
- Added `extra` folder to .gitignore to prevent conflicts during rebases
- This helps maintain a cleaner git history when working with local development folders

## Why
When rebasing against upstream, having local development folders like `extra` can cause unnecessary conflicts. This change makes the rebase process smoother by ignoring such folders.

## Impact
- No impact on codebase functionality
- Improves developer experience during rebases
- Reduces merge conflicts with local development folders