### PR TITLE
feat: twitter post media

### DIFF
--- a/packages/client-twitter/src/post.ts
+++ b/packages/client-twitter/src/post.ts
@@ -18,7 +18,7 @@ import type { ClientBase } from "./base.ts";
 import { postActionResponseFooter } from "@elizaos/core";
 import { generateTweetActions } from "@elizaos/core";
 import { type IImageDescriptionService, ServiceType } from "@elizaos/core";
-import { buildConversationThread } from "./utils.ts";
+import { buildConversationThread, fetchMediaData } from "./utils.ts";
 import { twitterMessageHandlerTemplate } from "./interactions.ts";
 import { DEFAULT_MAX_TWEET_LENGTH } from "./environment.ts";
 import {
@@ -442,7 +442,7 @@ export class TwitterPostClient {
             let result;
 
             if (cleanedContent.length > DEFAULT_MAX_TWEET_LENGTH) {
-                result = await this.handleNoteTweet(client, cleanedContent);
+                result = await this.handleNoteTweet(client, cleanedContent); 
             } else {
                 result = await this.sendStandardTweet(client, cleanedContent);
             }
@@ -518,11 +518,16 @@ export class TwitterPostClient {
 
             // First attempt to clean content
             let cleanedContent = "";
+            let mediaData = null;
 
             // Try parsing as JSON first
             const parsedResponse = parseJSONObjectFromText(newTweetContent);
             if (parsedResponse.text) {
                 cleanedContent = parsedResponse.text;
+            }
+
+            if (parsedResponse.attachments && parsedResponse.attachments.length > 0) {
+                mediaData = await fetchMediaData(parsedResponse.attachments);
             }
 
             // Try extracting text attribute

--- a/packages/client-twitter/src/post.ts
+++ b/packages/client-twitter/src/post.ts
@@ -30,6 +30,7 @@ import {
 } from "discord.js";
 import type { State } from "@elizaos/core";
 import type { ActionResponse } from "@elizaos/core";
+import { MediaData } from "./types.ts";
 
 const MAX_TIMELINES_TO_FETCH = 15;
 
@@ -379,11 +380,12 @@ export class TwitterPostClient {
         client: ClientBase,
         content: string,
         tweetId?: string,
+        mediaData?: MediaData[]
     ) {
         try {
             const noteTweetResult = await client.requestQueue.add(
                 async () =>
-                    await client.twitterClient.sendNoteTweet(content, tweetId),
+                    await client.twitterClient.sendNoteTweet(content, tweetId, mediaData),
             );
 
             if (noteTweetResult.errors && noteTweetResult.errors.length > 0) {
@@ -410,11 +412,12 @@ export class TwitterPostClient {
         client: ClientBase,
         content: string,
         tweetId?: string,
+        mediaData?: MediaData[]
     ) {
         try {
             const standardTweetResult = await client.requestQueue.add(
                 async () =>
-                    await client.twitterClient.sendTweet(content, tweetId),
+                    await client.twitterClient.sendTweet(content, tweetId, mediaData),
             );
             const body = await standardTweetResult.json();
             if (!body?.data?.create_tweet?.tweet_results?.result) {
@@ -435,6 +438,7 @@ export class TwitterPostClient {
         roomId: UUID,
         rawTweetContent: string,
         twitterUsername: string,
+        mediaData?: MediaData[]
     ) {
         try {
             elizaLogger.log(`Posting new tweet:\n`);
@@ -442,9 +446,9 @@ export class TwitterPostClient {
             let result;
 
             if (tweetTextForPosting.length > DEFAULT_MAX_TWEET_LENGTH) {
-                result = await this.handleNoteTweet(client, tweetTextForPosting); 
+                result = await this.handleNoteTweet(client, tweetTextForPosting, undefined, mediaData); 
             } else {
-                result = await this.sendStandardTweet(client, tweetTextForPosting);
+                result = await this.sendStandardTweet(client, tweetTextForPosting, undefined, mediaData);
             }
 
             const tweet = this.createTweetObject(
@@ -593,6 +597,7 @@ export class TwitterPostClient {
                         roomId,
                         rawTweetContent,
                         this.twitterUsername,
+                        mediaData,
                     );
                 }
             } catch (error) {

--- a/packages/client-twitter/src/types.ts
+++ b/packages/client-twitter/src/types.ts
@@ -1,0 +1,4 @@
+export type MediaData = {
+    data: Buffer;
+    mediaType: string;
+};

--- a/packages/client-twitter/src/utils.ts
+++ b/packages/client-twitter/src/utils.ts
@@ -164,6 +164,36 @@ export async function buildConversationThread(
     return thread;
 }
 
+export async function fetchMediaData(
+    attachments: Media[]
+): Promise<{ data: Buffer; mediaType: string }[]> {
+    return Promise.all(
+        attachments.map(async (attachment: Media) => {
+            if (/^(http|https):\/\//.test(attachment.url)) {
+                // Handle HTTP URLs
+                const response = await fetch(attachment.url);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch file: ${attachment.url}`);
+                }
+                const mediaBuffer = Buffer.from(await response.arrayBuffer());
+                const mediaType = attachment.contentType;
+                return { data: mediaBuffer, mediaType };
+            } else if (fs.existsSync(attachment.url)) {
+                // Handle local file paths
+                const mediaBuffer = await fs.promises.readFile(
+                    path.resolve(attachment.url)
+                );
+                const mediaType = attachment.contentType;
+                return { data: mediaBuffer, mediaType };
+            } else {
+                throw new Error(
+                    `File not found: ${attachment.url}. Make sure the path is correct.`
+                );
+            }
+        })
+    );
+}
+
 export async function sendTweet(
     client: ClientBase,
     content: Content,
@@ -179,38 +209,10 @@ export async function sendTweet(
     let previousTweetId = inReplyTo;
 
     for (const chunk of tweetChunks) {
-        let mediaData: { data: Buffer; mediaType: string }[] | undefined;
+        let mediaData = null;
 
         if (content.attachments && content.attachments.length > 0) {
-            mediaData = await Promise.all(
-                content.attachments.map(async (attachment: Media) => {
-                    if (/^(http|https):\/\//.test(attachment.url)) {
-                        // Handle HTTP URLs
-                        const response = await fetch(attachment.url);
-                        if (!response.ok) {
-                            throw new Error(
-                                `Failed to fetch file: ${attachment.url}`
-                            );
-                        }
-                        const mediaBuffer = Buffer.from(
-                            await response.arrayBuffer()
-                        );
-                        const mediaType = attachment.contentType;
-                        return { data: mediaBuffer, mediaType };
-                    } else if (fs.existsSync(attachment.url)) {
-                        // Handle local file paths
-                        const mediaBuffer = await fs.promises.readFile(
-                            path.resolve(attachment.url)
-                        );
-                        const mediaType = attachment.contentType;
-                        return { data: mediaBuffer, mediaType };
-                    } else {
-                        throw new Error(
-                            `File not found: ${attachment.url}. Make sure the path is correct.`
-                        );
-                    }
-                })
-            );
+            mediaData = await fetchMediaData(content.attachments);
         }
 
         const cleanChunk = deduplicateMentions(chunk.trim())
@@ -282,7 +284,7 @@ export async function sendTweet(
         },
         roomId,
         embedding: getEmbeddingZeroVector(),
-        createdAt: tweet.timestamp * 1000,
+        createdAt: tweet.timestamp * 1000, 
     }));
 
     return memories;

--- a/packages/client-twitter/src/utils.ts
+++ b/packages/client-twitter/src/utils.ts
@@ -7,6 +7,7 @@ import { elizaLogger } from "@elizaos/core";
 import type { Media } from "@elizaos/core";
 import fs from "fs";
 import path from "path";
+import { MediaData } from "./types";
 
 export const wait = (minTime = 1000, maxTime = 3000) => {
     const waitTime =
@@ -166,7 +167,7 @@ export async function buildConversationThread(
 
 export async function fetchMediaData(
     attachments: Media[]
-): Promise<{ data: Buffer; mediaType: string }[]> {
+): Promise<MediaData[]> {
     return Promise.all(
         attachments.map(async (attachment: Media) => {
             if (/^(http|https):\/\//.test(attachment.url)) {


### PR DESCRIPTION
Adds support for media attachments in tweets and refactors tweet posting logic

- Introduces `MediaData` type for handling media attachments
- Extracts media handling logic into separate `fetchMediaData` utility function
- Renames variables for better clarity around tweet content handling
- Updates tweet posting methods to support media attachments
- Maintains existing approval workflow while adding media support

related: https://github.com/elizaOS/eliza/commit/0c13bfe6908f0d770f5c5eea7f720e9e9d3bc69b#commitcomment-151761396