### PR TITLE
fix: plugin-udio 

### DIFF
--- a/packages/plugin-udio/src/actions/extend.ts
+++ b/packages/plugin-udio/src/actions/extend.ts
@@ -1,6 +1,6 @@
 import type { Action, IAgentRuntime, Memory, State, HandlerCallback } from "@elizaos/core";
 import { UdioProvider } from "../providers/udio";
-import { UdioExtendOptions, UdioResponse } from "../types";
+import type { UdioExtendOptions } from "../types";
 
 const extendMusic: Action = {
     name: "extend",
@@ -22,7 +22,7 @@ const extendMusic: Action = {
         runtime: IAgentRuntime,
         message: Memory,
         state: State,
-        options: { [key: string]: unknown },
+        _options: { [key: string]: unknown },
         callback?: HandlerCallback
     ): Promise<boolean> => {
         try {
@@ -51,7 +51,7 @@ const extendMusic: Action = {
                 if (status.songs.every(song => song.finished)) {
                     if (callback) {
                         callback({
-                            text: `Successfully extended the music based on your prompt`,
+                            text: 'Successfully extended the music based on your prompt',
                             content: status
                         });
                     }

--- a/packages/plugin-udio/src/actions/generate.ts
+++ b/packages/plugin-udio/src/actions/generate.ts
@@ -1,6 +1,6 @@
 import type { Action, IAgentRuntime, Memory, State, HandlerCallback } from "@elizaos/core";
 import { UdioProvider } from "../providers/udio";
-import { UdioGenerateOptions, UdioResponse } from "../types";
+import type { UdioGenerateOptions } from "../types";
 
 const generateMusic: Action = {
     name: "generate",
@@ -22,7 +22,7 @@ const generateMusic: Action = {
         runtime: IAgentRuntime,
         message: Memory,
         state: State,
-        options: { [key: string]: unknown },
+        _options: { [key: string]: unknown },
         callback?: HandlerCallback
     ): Promise<boolean> => {
         try {
@@ -45,7 +45,7 @@ const generateMusic: Action = {
                 if (status.songs.every(song => song.finished)) {
                     if (callback) {
                         callback({
-                            text: `Successfully generated music based on your prompt`,
+                            text: 'Successfully generated music based on your prompt',
                             content: status
                         });
                     }

--- a/packages/plugin-udio/src/index.ts
+++ b/packages/plugin-udio/src/index.ts
@@ -1,4 +1,4 @@
-import { type Plugin, type Provider } from "@elizaos/core";
+import type { Plugin, Provider } from "@elizaos/core";
 import generateMusic from "./actions/generate";
 import extendMusic from "./actions/extend";
 import { UdioProvider } from "./providers/udio";

--- a/packages/plugin-udio/src/providers/udio.ts
+++ b/packages/plugin-udio/src/providers/udio.ts
@@ -1,5 +1,5 @@
 import { IAgentRuntime, Memory, State, type Provider } from "@elizaos/core";
-import { UdioGenerateResponse, UdioSamplerOptions, UdioSong } from "../types";
+import type { UdioGenerateResponse, UdioSamplerOptions, UdioSong } from "../types";
 
 const API_BASE_URL = "https://www.udio.com/api";
 
@@ -25,11 +25,11 @@ export class UdioProvider implements Provider {
         this.baseUrl = config.baseUrl || API_BASE_URL;
     }
 
-    async get(_runtime: IAgentRuntime, _message: Memory, _state?: State): Promise<any> {
+    async get(_runtime: IAgentRuntime, _message: Memory, _state?: State): Promise<UdioProvider> {
         return this;
     }
 
-    async makeRequest(url: string, method: string, data?: any) {
+    async makeRequest(url: string, method: string, data?: Record<string, unknown>) {
         const headers = {
             "Accept": method === 'GET' ? "application/json, text/plain, */*" : "application/json",
             "Content-Type": "application/json",


### PR DESCRIPTION
# Non critical Fixes for Plugin-Udio

## Changes
- Fixed template literal usage in `extend.ts` where string interpolation wasn't needed
- Updated imports to use `import type` syntax in `udio.ts`
- Replaced `any` types with more specific `Record<string, unknown>` type
- Added proper return type for `get` method

## Impact
- No functional changes
- Improved type safety and code quality
- Resolved Biome linting warnings