### PR TITLE
fix: still run Farcaster client loop if error

### DIFF
--- a/packages/client-farcaster/src/interactions.ts
+++ b/packages/client-farcaster/src/interactions.ts
@@ -38,9 +38,9 @@ export class FarcasterInteractionManager {
                 await this.handleInteractions();
             } catch (error) {
                 elizaLogger.error(error);
-                return;
             }
 
+            // Always set up next check, even if there was an error
             this.timeout = setTimeout(
                 handleInteractionsLoop,
                 Number(this.client.farcasterConfig?.FARCASTER_POLL_INTERVAL ?? 120) *


### PR DESCRIPTION
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

None

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

Keep running Farcaster client loop even if there's an error 

## What kind of change is this?
Bug fix

## Why are we doing this? Any context or related work?
I had a memory get error and then the Farcaster client stopped checking for new messages

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
Use the Farcaster client 

## Detailed testing steps

Use the farcaster client, if an error happens, it'll still check your messages 

## Discord username

rubinovitz
