### PR TITLE
fix: default character openai => llamalocal

### DIFF
--- a/packages/core/src/defaultCharacter.ts
+++ b/packages/core/src/defaultCharacter.ts
@@ -5,7 +5,7 @@ export const defaultCharacter: Character = {
     username: "eliza",
     plugins: [],
     clients: [],
-    modelProvider: ModelProviderName.OPENAI,
+    modelProvider: ModelProviderName.LLAMALOCAL,
     settings: {
         secrets: {},
         voice: {


### PR DESCRIPTION
# Risks

Low

# Background

## What does this PR do?

Change default character model provider back to the original default

## What kind of change is this?

Improvements (misc. changes to existing features)

## Why are we doing this? Any context or related work?

openai was temporary to get someone's PR in

# Documentation changes needed?

My changes do not require a change to the project documentation.
