### PR TITLE
fix: remove unnecessary @ts-expect-error directive in chat component

### DIFF
--- a/client/src/components/chat.tsx
+++ b/client/src/components/chat.tsx
@@ -171,7 +171,6 @@ export default function Page({ agentId }: { agentId: UUID }) {
                     {transitions((styles, message) => {
                         const variant = getMessageVariant(message?.user);
                         return (
-                            // @ts-expect-error
                             <animated.div
                                 style={styles}
                                 className="flex flex-col gap-2 p-4"


### PR DESCRIPTION
# Relates to
TypeScript error TS2578 in chat component

# Risks
Low - This is a simple removal of an unnecessary TypeScript directive that was causing an error.

# Background

## What does this PR do?
Removes an unnecessary @ts-expect-error directive in the chat.tsx component that was causing TypeScript error TS2578.

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
1. Check the changes in `client/src/components/chat.tsx`
2. Verify the removal of @ts-expect-error directive

## Detailed testing steps
1. Run `pnpm build` in the client directory
2. Verify that there are no TypeScript errors
3. Verify that the chat component still functions correctly

## Screenshots
### Before
TypeScript error TS2578: Unused '@ts-expect-error' directive

### After
Clean build with no TypeScript errors

# Deploy Notes
No special deployment steps required - standard build process is sufficient.

## Discord username
437475708399255562