### PR TITLE
fix README's CONTRIBUTING.md link in plugin-multiversx package

### DIFF
--- a/packages/plugin-multiversx/README.md
+++ b/packages/plugin-multiversx/README.md
@@ -164,7 +164,7 @@ pnpm test:watch
 
 ## Contributing
 
-Contributions are welcome! Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information.
+Contributions are welcome! Please see the [CONTRIBUTING.md](../../CONTRIBUTING.md) file for more information.
 
 ## Credits
 


### PR DESCRIPTION
From `CONTRIBUTING.md` 
To `../../CONTRIBUTING.md`