### PR TITLE
fix: change handleAnthropic default mode to auto

### DIFF
--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -2263,6 +2263,10 @@ async function handleAnthropic({
     runtime,
 }: ProviderOptions): Promise<GenerateObjectResult<unknown>> {
     elizaLogger.debug("Handling Anthropic request with Cloudflare check");
+    if (mode === "json") {
+        elizaLogger.warn("Anthropic mode is set to json, changing to auto");
+        mode = "auto";
+    }
     const baseURL = getCloudflareGatewayBaseURL(runtime, "anthropic");
     elizaLogger.debug("Anthropic handleAnthropic baseURL:", { baseURL });
 

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -2258,7 +2258,7 @@ async function handleAnthropic({
     schema,
     schemaName,
     schemaDescription,
-    mode = "json",
+    mode = "auto",
     modelOptions,
     runtime,
 }: ProviderOptions): Promise<GenerateObjectResult<unknown>> {


### PR DESCRIPTION
# Relates to
Issue: https://github.com/elizaOS/eliza/issues/3017

# Risks
Low - This is a minor change to use a different object generation mode for Anthropic models only. The change is isolated and doesn't affect other providers.

# Background

## What does this PR do?
Changes the default object generation mode from "json" to "auto" for Anthropic/Claude models since they don't support JSON mode. This fixes compatibility issues when using the Twitter plugin with Anthropic models.

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
1. Review the change in `packages/core/src/generation.ts`
2. Test Twitter plugin functionality with Anthropic/Claude models

## Detailed testing steps
1. Configure a character to use Anthropic/Claude as the model provider
2. Enable Twitter plugin
3. Trigger a tweet generation action
4. Verify that the tweet generates successfully without JSON mode errors
5. Verify that other model providers still work as expected
