### PR TITLE
fix: the unexpected corrections for plugin-di caused by biome lint

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,88 +1,96 @@
 {
     "$schema": "https://biomejs.dev/schemas/1.5.3/schema.json",
     "organizeImports": {
-      "enabled": false
+        "enabled": false
     },
     "linter": {
-      "enabled": true,
-      "rules": {
-        "recommended": true,
-        "suspicious": {
-          "noExplicitAny": "warn",
-          "noArrayIndexKey": "warn",
-          "noPrototypeBuiltins": "warn",
-          "noDuplicateObjectKeys": "warn",
-          "noGlobalIsNan": "warn",
-          "noDuplicateFontNames": "warn",
-          "noSelfCompare": "warn",
-          "noDoubleEquals": "warn",
-          "noImplicitAnyLet": "warn",
-          "noAssignInExpressions": "warn",
-          "noExportsInTest": "warn",
-          "noConstEnum": "warn",
-          "noEmptyInterface": "warn"
+        "enabled": true,
+        "rules": {
+            "recommended": true,
+            "suspicious": {
+                "noExplicitAny": "warn",
+                "noArrayIndexKey": "warn",
+                "noPrototypeBuiltins": "warn",
+                "noDuplicateObjectKeys": "warn",
+                "noGlobalIsNan": "warn",
+                "noDuplicateFontNames": "warn",
+                "noSelfCompare": "warn",
+                "noDoubleEquals": "warn",
+                "noImplicitAnyLet": "warn",
+                "noAssignInExpressions": "warn",
+                "noExportsInTest": "warn",
+                "noConstEnum": "warn",
+                "noEmptyInterface": "warn"
+            },
+            "correctness": {
+                "noUnusedVariables": "warn",
+                "noUnreachable": "warn",
+                "useExhaustiveDependencies": "warn",
+                "noSwitchDeclarations": "warn",
+                "noUnnecessaryContinue": "warn",
+                "noInnerDeclarations": "warn"
+            },
+            "style": {
+                "useConst": "warn",
+                "useTemplate": "warn",
+                "useImportType": "warn",
+                "useNodejsImportProtocol": "warn",
+                "noUselessElse": "warn",
+                "useSelfClosingElements": "warn",
+                "useNumberNamespace": "warn",
+                "noUnusedTemplateLiteral": "warn",
+                "noInferrableTypes": "warn",
+                "noNonNullAssertion": "warn",
+                "noParameterAssign": "warn",
+                "useDefaultParameterLast": "warn",
+                "useExponentiationOperator": "warn",
+                "noVar": "warn",
+                "useSingleVarDeclarator": "warn",
+                "useExportType": "warn"
+            },
+            "a11y": {
+                "useAltText": "warn",
+                "useFocusableInteractive": "warn",
+                "useMediaCaption": "warn",
+                "noSvgWithoutTitle": "warn",
+                "useKeyWithClickEvents": "warn"
+            },
+            "complexity": {
+                "noForEach": "warn",
+                "useOptionalChain": "warn",
+                "useArrowFunction": "warn",
+                "useFlatMap": "warn",
+                "useLiteralKeys": "warn",
+                "noBannedTypes": "warn",
+                "noStaticOnlyClass": "warn",
+                "noThisInStatic": "warn",
+                "noUselessConstructor": "warn",
+                "noUselessTernary": "warn",
+                "noUselessSwitchCase": "warn",
+                "noUselessCatch": "warn"
+            },
+            "performance": {
+                "noDelete": "warn",
+                "noAccumulatingSpread": "warn"
+            }
         },
-        "correctness": {
-          "noUnusedVariables": "warn",
-          "noUnreachable": "warn",
-          "useExhaustiveDependencies": "warn",
-          "noSwitchDeclarations": "warn",
-          "noUnnecessaryContinue": "warn",
-          "noInnerDeclarations": "warn"
-        },
-        "style": {
-          "useConst": "warn",
-          "useTemplate": "warn",
-          "useImportType": "warn",
-          "useNodejsImportProtocol": "warn",
-          "noUselessElse": "warn",
-          "useSelfClosingElements": "warn",
-          "useNumberNamespace": "warn",
-          "noUnusedTemplateLiteral": "warn",
-          "noInferrableTypes": "warn",
-          "noNonNullAssertion": "warn",
-          "noParameterAssign": "warn",
-          "useDefaultParameterLast": "warn",
-          "useExponentiationOperator": "warn",
-          "noVar": "warn",
-          "useSingleVarDeclarator": "warn",
-          "useExportType": "warn"
-        },
-        "a11y": {
-          "useAltText": "warn",
-          "useFocusableInteractive": "warn",
-          "useMediaCaption": "warn",
-          "noSvgWithoutTitle": "warn",
-          "useKeyWithClickEvents": "warn"
-        },
-        "complexity": {
-          "noForEach": "warn",
-          "useOptionalChain": "warn",
-          "useArrowFunction": "warn",
-          "useFlatMap": "warn",
-          "useLiteralKeys": "warn",
-          "noBannedTypes": "warn",
-          "noStaticOnlyClass": "warn",
-          "noThisInStatic": "warn",
-          "noUselessConstructor": "warn",
-          "noUselessTernary": "warn",
-          "noUselessSwitchCase": "warn",
-          "noUselessCatch": "warn"
-        },
-        "performance": {
-          "noDelete": "warn",
-          "noAccumulatingSpread": "warn"
-        }
-      },
-      "ignore": ["**/dist/**", "**/node_modules/**", "**/coverage/**", "**/*.json"]
+        "ignore": [
+            "**/dist/**",
+            "**/node_modules/**",
+            "**/coverage/**",
+            "**/*.json"
+        ]
     },
     "formatter": {
-      "enabled": false
+        "enabled": false
     },
     "javascript": {
-      "formatter": {
-        "quoteStyle": "double",
-        "semicolons": "always"
-      }
+        "parser": {
+            "unsafeParameterDecoratorsEnabled": true
+        },
+        "formatter": {
+            "quoteStyle": "double",
+            "semicolons": "always"
+        }
     }
-  }
+}

--- a/packages/_examples/plugin-with-di/src/actions/sampleAction.ts
+++ b/packages/_examples/plugin-with-di/src/actions/sampleAction.ts
@@ -94,11 +94,11 @@ const options: ActionOptions<CreateResourceContent> = {
  */
 @injectable()
 export class CreateResourceAction extends BaseInjectableAction<CreateResourceContent> {
-    private sampleProvider: SampleProvider;
-
-    constructor(sampleProvider: SampleProvider) {
+    constructor(
+        @inject(SampleProvider)
+        private readonly sampleProvider: SampleProvider
+    ) {
         super(options);
-        this.sampleProvider = sampleProvider;
     }
 
     async validate(

--- a/packages/_examples/plugin-with-di/src/providers/sampleProvider.ts
+++ b/packages/_examples/plugin-with-di/src/providers/sampleProvider.ts
@@ -25,11 +25,10 @@ export class SampleProvider
 {
     private _sharedInstance: Record<string, string>;
 
-    private dynamicData: Record<string, string>;
-
-    constructor(dynamicData: Record<string, string>) {
-        this.dynamicData = dynamicData;
-    }
+    constructor(
+        @inject("DYNAMIC_DATA")
+        private readonly dynamicData: Record<string, string>
+    ) {}
 
     // ---- Implementing the InjectableProvider interface ----
 

--- a/packages/_examples/plugin-with-di/src/services/sampleService.ts
+++ b/packages/_examples/plugin-with-di/src/services/sampleService.ts
@@ -26,15 +26,15 @@ export class SampleService extends Service {
     private intervalId: NodeJS.Timeout | null = null;
     private readonly DEFAULT_INTERVAL = 15 * 60 * 1000; // 15 minutes in milliseconds
 
-    private sampleProvider: SampleProvider;
-
-    constructor(sampleProvider: SampleProvider) {
+    constructor(
+        @inject(SampleProvider)
+        private readonly sampleProvider: SampleProvider
+    ) {
         super();
-        this.sampleProvider = sampleProvider;
     }
 
     static get serviceType(): ServiceType {
-        return ServiceType.SAMPLE;
+        return "sample" as ServiceType.SAMPLE;
     }
 
     private static isInitialized = false;

--- a/packages/_examples/plugin/src/services/sampleService.ts
+++ b/packages/_examples/plugin/src/services/sampleService.ts
@@ -23,7 +23,7 @@ export class SampleService extends Service {
     private readonly DEFAULT_INTERVAL = 15 * 60 * 1000; // 15 minutes in milliseconds
 
     static get serviceType(): ServiceType {
-        return ServiceType.SAMPLE;
+        return "sample" as ServiceType.SAMPLE;
     }
 
     private static isInitialized = false;

--- a/packages/plugin-di/src/actions/baseInjectableAction.ts
+++ b/packages/plugin-di/src/actions/baseInjectableAction.ts
@@ -47,7 +47,7 @@ export abstract class BaseInjectableAction<T> implements InjectableAction<T> {
     /**
      * Constructor for the base injectable action
      */
-    constructor(opts: ActionOptions<T>) {
+    constructor(@unmanaged() opts: ActionOptions<T>) {
         // Set the action properties
         this.name = opts.name;
         this.similes = opts.similes;

--- a/packages/plugin-di/src/evaluators/baseInjectableEvaluator.ts
+++ b/packages/plugin-di/src/evaluators/baseInjectableEvaluator.ts
@@ -23,7 +23,7 @@ export abstract class BaseInjectableEvaluator implements InjectableEvaluator {
     /**
      * Constructor for the base injectable action
      */
-    constructor(opts: EvaluatorOptions) {
+    constructor(@unmanaged() opts: EvaluatorOptions) {
         // Set the action properties
         this.name = opts.name;
         this.similes = opts.similes;


### PR DESCRIPTION
# Relates to

Incorrect biome lint in commit:
https://github.com/elizaOS/eliza/commit/4b9510d93e34436e6047dd0e3bbebeafb9326411

cc @wtfsayo 

# Risks

Low

# Background

## What does this PR do?

Because the parameter decorator configuration is not configured in the settings.
Doc: https://biomejs.dev/blog/biome-v1/#support-for-function-class-parameter-decorators 
so added this field in biome.json (and formatted the file)
```json
{
  "javascript": {
    "parser": {
      "unsafeParameterDecoratorsEnabled": true
    }
  }
}
```
The decorator for the DI plugin was incorrectly changed.

At the same time, I noticed that the serviceType of sampleService needed to be revised in its writing, otherwise it would be undefined during actual runtime, so I fixed that as well.

Changes:
- fix erroneous corrections in di plugin caused by biome.
- add Parameter Decorators support in biome
- fix the sample serviceType is undefined

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

## Discord username

bt.wood