### PR TITLE
fix: Message id collision in Telegram Client

### DIFF
--- a/packages/client-telegram/src/messageManager.ts
+++ b/packages/client-telegram/src/messageManager.ts
@@ -195,11 +195,8 @@ export class MessageManager {
 
             // Check if we should post
             if (
-                timeSinceLastMessage >
-                    this.autoPostConfig.inactivityThreshold ||
-                (randomThreshold &&
-                    timeSinceLastAutoPost >
-                        (this.autoPostConfig.minTimeBetweenPosts || 0))
+                (timeSinceLastMessage > randomThreshold) &&
+                timeSinceLastAutoPost > (this.autoPostConfig.minTimeBetweenPosts || 0)
             ) {
                 try {
                     const roomId = stringToUuid(

--- a/packages/client-telegram/src/messageManager.ts
+++ b/packages/client-telegram/src/messageManager.ts
@@ -195,8 +195,9 @@ export class MessageManager {
 
             // Check if we should post
             if (
-                (timeSinceLastMessage > randomThreshold) &&
-                timeSinceLastAutoPost > (this.autoPostConfig.minTimeBetweenPosts || 0)
+                timeSinceLastMessage > randomThreshold &&
+                timeSinceLastAutoPost >
+                    (this.autoPostConfig.minTimeBetweenPosts || 0)
             ) {
                 try {
                     const roomId = stringToUuid(
@@ -255,7 +256,7 @@ export class MessageManager {
                     // Create and store memories
                     const memories = messages.map((m) => ({
                         id: stringToUuid(
-                            m.message_id.toString() + "-" + this.runtime.agentId
+                            roomId + "-" + m.message_id.toString()
                         ),
                         userId: this.runtime.agentId,
                         agentId: this.runtime.agentId,
@@ -381,9 +382,7 @@ export class MessageManager {
             );
 
             const memories = messages.map((m) => ({
-                id: stringToUuid(
-                    m.message_id.toString() + "-" + this.runtime.agentId
-                ),
+                id: stringToUuid(roomId + "-" + m.message_id.toString()),
                 userId: this.runtime.agentId,
                 agentId: this.runtime.agentId,
                 content: {
@@ -1261,7 +1260,7 @@ export class MessageManager {
 
             // Get message ID
             const messageId = stringToUuid(
-                message.message_id.toString() + "-" + this.runtime.agentId
+                roomId + "-" + message.message_id.toString()
             ) as UUID;
 
             // Handle images
@@ -1336,9 +1335,7 @@ export class MessageManager {
 
                         const memory: Memory = {
                             id: stringToUuid(
-                                sentMessage.message_id.toString() +
-                                    "-" +
-                                    this.runtime.agentId
+                                roomId + "-" + sentMessage.message_id.toString()
                             ),
                             agentId,
                             userId: agentId,


### PR DESCRIPTION
related: https://github.com/elizaOS/eliza/issues/2796

The issue is caused by the message ID being used to create a UUID for memory. Since the message ID could be the same in different Telegram channels, it leads to collisions in memory creation. In this PR, we use the channel ID to create the UUID instead.