### PR TITLE
fix: ImageVisionModelProvider Not Applied in Runtime for Image Description Service

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -370,14 +370,23 @@ export class AgentRuntime implements IAgentRuntime {
 
         this.imageModelProvider =
             this.character.imageModelProvider ?? this.modelProvider;
-
+        
+        this.imageVisionModelProvider =
+            this.character.imageVisionModelProvider ?? this.modelProvider;
+            
         elizaLogger.info(
           `${this.character.name}(${this.agentId}) - Selected model provider:`,
           this.modelProvider
         );
+
         elizaLogger.info(
           `${this.character.name}(${this.agentId}) - Selected image model provider:`,
-          this.imageVisionModelProvider
+          this.imageModelProvider
+        );
+
+        elizaLogger.info(
+            `${this.character.name}(${this.agentId}) - Selected image vision model provider:`,
+            this.imageVisionModelProvider
         );
 
         // Validate model provider


### PR DESCRIPTION
The `imageVisionModelProvider` is used in the image description service, but its value is never applied at runtime. As a result, even if a user sets it in the character file, it has no effect. This PR ensures that the imageVisionModelProvider is correctly set at runtime.