### PR TITLE
fix: fixing the error parsing json when an array is a value in a JSON…

### DIFF
--- a/packages/core/__tests__/parsing.test.ts
+++ b/packages/core/__tests__/parsing.test.ts
@@ -125,6 +125,13 @@ describe("Parsing Module", () => {
             });
         });
 
+        it("should parse JSON objects containing array values", () => {
+            const input = '{"key": ["item1", "item2", "item3"]}';
+            expect(parseJSONObjectFromText(input)).toEqual({
+                key: ["item1", "item2", "item3"],
+            });
+        });
+
         it("should handle empty objects", () => {
             expect(parseJSONObjectFromText("```json\n{}\n```")).toEqual({});
             expect(parseJSONObjectFromText("{}")).toEqual({});

--- a/packages/core/src/parsing.ts
+++ b/packages/core/src/parsing.ts
@@ -237,7 +237,7 @@ export const normalizeJsonString = (str: string) => {
 
     // "key": unquotedValue → "key": "unquotedValue"
     str = str.replace(
-      /("[\w\d_-]+")\s*: \s*(?!")([\s\S]+?)(?=(,\s*"|\}$))/g,
+      /("[\w\d_-]+")\s*: \s*(?!"|\[)([\s\S]+?)(?=(,\s*"|\}$))/g,
       '$1: "$2"',
     );
 


### PR DESCRIPTION
… object

# Relates to

Haven't created a ticket, but it seems to be related to recent changes in the `normalizeJsonString` function.

When using the Slack client, JSON like:

```json
{
  "objective": "The user wants to summarize multiple PDFs they have attached in the conversation.",
  "attachmentIds": [
    "028eece0-2a70-0db4-a7bf-bc7b8fed8188",
    "f7feb9ac-f7af-0ce6-a697-35262ec54340",
    "bde191a9-8aa7-0ef7-8ecb-8fbe944a2da9",
    "f51b8f51-a9af-0a8e-91a8-ecabc34c1698"
  ]
}
```

was raising errors like `SyntaxError: Bad control character in string literal in JSON at position 120 (line 2 column 22)` because the normalize function is inserting a double-quote on the second line like this:

```
{"objective": "The user wants to summarize multiple PDFs they have attached in the conversation.",
  "attachmentIds": "[
    "028eece0-2a70-0db4-a7bf-bc7b8fed8188"",
    "f7feb9ac-f7af-0ce6-a697-35262ec54340",
    "bde191a9-8aa7-0ef7-8ecb-8fbe944a2da9",
    "f51b8f51-a9af-0a8e-91a8-ecabc34c1698"
  ]}
```

# Risks

Low

# Background

## What does this PR do?

Created a failing test and modified the regular expression to test if the first character of the value is an opening square bracket. 

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Note

When running the tests, I was getting other errors, but doesn't seem related to my changes