### PR TITLE
fix: pnpm install

### DIFF
--- a/packages/plugin-solana-v2/package.json
+++ b/packages/plugin-solana-v2/package.json
@@ -22,7 +22,7 @@
         "@biomejs/biome": "1.5.3",
         "@types/node": "^22.8.7",
         "tsup": "^8.3.5",
-        "vitest": "2.1.9",
+        "vitest": "2.1.9"
     },
     "scripts": {
         "build": "tsup --format esm --dts",


### PR DESCRIPTION
fixes a JSON syntax issue in packages/plugin-solana-v2/package.json that caused the following error during pnpm i:

<img width="1006" alt="Screenshot 2025-02-05 at 1 18 37 PM" src="https://github.com/user-attachments/assets/4bbf1aba-2e25-412d-bc98-e85751049f12" />
