### PR TITLE
fix: Dynamic require of "http" is not supported error

### DIFF
--- a/packages/plugin-ton/tsup.config.ts
+++ b/packages/plugin-ton/tsup.config.ts
@@ -15,5 +15,6 @@ export default defineConfig({
         "https",
         "http",
         "agentkeepalive",
+        "@pinata/sdk"
     ],
 });


### PR DESCRIPTION
When running pnpm start, the following error occurred: (due to new change of this PR: https://github.com/elizaOS/eliza/pull/3211)

<img width="1003" alt="Screenshot 2025-02-05 at 1 57 20 PM" src="https://github.com/user-attachments/assets/22c41dc8-b14f-4342-b40f-898ee615d68e" />


added @pinata/sdk to the external field in tsup.config.ts to ensure that the dependency is not bundled