### PR TITLE
Fix PG query: Use only 'text' subfield name, field name is not needed here

### DIFF
--- a/packages/adapter-pglite/src/index.ts
+++ b/packages/adapter-pglite/src/index.ts
@@ -828,12 +828,12 @@ export class PGLiteDatabaseAdapter
                         SELECT
                             embedding,
                             COALESCE(
-                                content->$2->>$3,
+                                content->>$2,
                                 ''
                             ) as content_text
                         FROM memories
-                        WHERE type = $4
-                        AND content->$2->>$3 IS NOT NULL
+                        WHERE type = $3
+                        AND content->>$2 IS NOT NULL
                     )
                     SELECT
                         embedding,
@@ -845,9 +845,9 @@ export class PGLiteDatabaseAdapter
                     WHERE levenshtein(
                         $1,
                         content_text
-                    ) <= $6  -- Add threshold check
+                    ) <= $5  -- Add threshold check
                     ORDER BY levenshtein_score
-                    LIMIT $5
+                    LIMIT $4
                 `;
 
                 const { rows } = await this.query<{
@@ -855,7 +855,6 @@ export class PGLiteDatabaseAdapter
                     levenshtein_score: number;
                 }>(sql, [
                     opts.query_input,
-                    opts.query_field_name,
                     opts.query_field_sub_name,
                     opts.query_table_name,
                     opts.query_match_count,

--- a/packages/adapter-postgres/src/index.ts
+++ b/packages/adapter-postgres/src/index.ts
@@ -1016,12 +1016,12 @@ export class PostgresDatabaseAdapter
                         SELECT
                             embedding,
                             COALESCE(
-                                content->$2->>$3,
+                                content->>$2,
                                 ''
                             ) as content_text
                         FROM memories
-                        WHERE type = $4
-                        AND content->$2->>$3 IS NOT NULL
+                        WHERE type = $3
+                        AND content->>$2 IS NOT NULL
                     )
                     SELECT
                         embedding,
@@ -1033,14 +1033,13 @@ export class PostgresDatabaseAdapter
                     WHERE levenshtein(
                         $1,
                         content_text
-                    ) <= $6  -- Add threshold check
+                    ) <= $5  -- Add threshold check
                     ORDER BY levenshtein_score
-                    LIMIT $5
+                    LIMIT $4
                 `;
 
                 const { rows } = await this.pool.query(sql, [
                     opts.query_input,
-                    opts.query_field_name,
                     opts.query_field_sub_name,
                     opts.query_table_name,
                     opts.query_match_count,


### PR DESCRIPTION
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

<!-- LINK TO ISSUE OR TICKET -->

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?
It fixes a minor bug in adapter-postgres adapter-pglite packages. There's a bug in SQL query in getCachedEmbeddings: `content->$2->>$3` part converts to `content->'content'->>'text'` and it searches in `{"content": {"text":""}}`  of **content** field of the table. But the text of the Memory is located in `{"text":""}` of **content** field.

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?
No

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->
