### PR TITLE
docs: Add GitHub issues link to CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ This section lists the labels we use to help us track and manage issues and pull
 
 - Join [Discord](https://discord.gg/ai16z)
 - Check [FAQ](docs/docs/faq.md)
-- Create GitHub issues
+- Create [GitHub issues](https://github.com/elizaOS/eliza/issues)
 
 ## Additional Resources
 


### PR DESCRIPTION
# What does this PR do?
This PR links the Github issues page in the "Getting Help" section of CONTRIBUTING.md file.
Here is a before and after changes:

Before:
Create GitHub issues

After:
Create [GitHub issues](https://github.com/elizaOS/eliza/issues)

# What kind of change is this?
It is a small documentation improvement so that new contributors get a nice experience while interacting with the CONTRIBUTING.md file.
