### PR TITLE
Fix broken links on contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,8 +84,8 @@ This section lists the labels we use to help us track and manage issues and pull
 
 ## Additional Resources
 
-- [Local Development Guide](docs/guides/local-development.md)
-- [Configuration Guide](docs/guides/configuration.md)
+- [Local Development Guide](docs/docs/guides/local-development.md)
+- [Configuration Guide](docs/docs/guides/configuration.md)
 - [API Documentation](docs/api)
 
 ## Contributor Guide


### PR DESCRIPTION
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

N/A (Fixing broken links in documentation)

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low – This only updates Markdown links and does not affect the application functionality.

# Background

## What does this PR do?

This PR fixes two broken links in CONTRIBUTING.md
## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)