### PR TITLE
fix(core): improve OpenAI-like provider endpoint resolution in `generation.ts`

### DIFF
--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -2233,12 +2233,13 @@ async function handleOpenAI({
     schemaDescription,
     mode = "json",
     modelOptions,
-    provider: _provider,
+    provider,
     runtime,
 }: ProviderOptions): Promise<GenerateObjectResult<unknown>> {
+    const endpoint =
+        runtime.character.modelEndpointOverride || getEndpoint(provider);
     const baseURL =
-        getCloudflareGatewayBaseURL(runtime, "openai") ||
-        models.openai.endpoint;
+        getCloudflareGatewayBaseURL(runtime, "openai") || endpoint;
     const openai = createOpenAI({ apiKey, baseURL });
     return await aiGenerateObject({
         model: openai.languageModel(model),


### PR DESCRIPTION
# Relates to

N/A

# Risks

Medium (it's core plugin)

# Background

When configuring an OpenAI-Like Provider, the `generateText` call works, but the `generateObject` call fails. The reason is an endpoint error because `generateText` uses 

```ts
const endpoint =
    runtime.character.modelEndpointOverride || getEndpoint(provider);
```

That is the correct endpoint, but `generateObject` directly uses openai which is not accurate.

## What does this PR do?

Fix this issue.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.


## Discord username

bt.wood
