### PR TITLE
fix: twitter - add actions suppress action ability.

### DIFF
--- a/packages/client-twitter/src/interactions.ts
+++ b/packages/client-twitter/src/interactions.ts
@@ -496,7 +496,24 @@ export class TwitterInteractionClient {
                         return memories;
                     };
 
-                    const responseMessages = await callback(response);
+                    const action = this.runtime.actions.find((a) => a.name === response.action);
+                    const shouldSuppressInitialMessage = action?.suppressInitialMessage;
+
+                    let responseMessages = [];
+
+                    if (!shouldSuppressInitialMessage) {
+                        responseMessages = await callback(response);
+                    } else {
+                        responseMessages = [{
+                            id: stringToUuid(tweet.id + "-" + this.runtime.agentId),
+                            userId: this.runtime.agentId,
+                            agentId: this.runtime.agentId,
+                            content: response,
+                            roomId: message.roomId,
+                            embedding: getEmbeddingZeroVector(),
+                            createdAt: Date.now(),
+                        }];
+                    }
 
                     state = (await this.runtime.updateRecentMessageState(
                         state
@@ -515,9 +532,11 @@ export class TwitterInteractionClient {
                             responseMessage
                         );
                     }
+
                     const responseTweetId =
                     responseMessages[responseMessages.length - 1]?.content
                         ?.tweetId;
+
                     await this.runtime.processActions(
                         message,
                         responseMessages,


### PR DESCRIPTION
# Relates to


# Risks

Low

# Background

## What does this PR do?

## What kind of change is this?

Improvements (misc. changes to existing features)


## Why are we doing this? Any context or related work?
When actions had the suppressInitialMessage flag, it would not work on other clients.

Added ability back so actions can properly suppress the initial response if enabled.

# Documentation changes needed?

My changes do not require a change to the project documentation.


# Testing

## Where should a reviewer start?

## Detailed testing steps

Implement changes, trigger an action and watch for suppression of initial message.

## Screenshots
### Before
### After

# Deploy Notes

## Database changes

## Deployment instructions

## Discord username
