### PR TITLE
read modelConfig from character file

### DIFF
--- a/packages/core/src/environment.ts
+++ b/packages/core/src/environment.ts
@@ -106,6 +106,14 @@ export const CharacterSchema = z.object({
                 })
                 .optional(),
             model: z.string().optional(),
+            modelConfig: z.object({
+                maxInputTokens: z.number().optional(),
+                maxOutputTokens: z.number().optional(),
+                temperature: z.number().optional(),
+                frequency_penalty: z.number().optional(),
+                presence_penalty:z.number().optional()
+            })
+            .optional(),
             embeddingModel: z.string().optional(),
         })
         .optional(),

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -502,7 +502,7 @@ export async function generateText({
     const max_context_length =
         modelConfiguration?.maxInputTokens || modelSettings.maxInputTokens;
     const max_response_length =
-        modelConfiguration?.max_response_length ||
+        modelConfiguration?.maxOutputTokens ||
         modelSettings.maxOutputTokens;
     const experimental_telemetry =
         modelConfiguration?.experimental_telemetry ||

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -696,7 +696,7 @@ export type TelemetrySettings = {
 
 export interface ModelConfiguration {
     temperature?: number;
-    max_response_length?: number;
+    maxOutputTokens?: number;
     frequency_penalty?: number;
     presence_penalty?: number;
     maxInputTokens?: number;


### PR DESCRIPTION
# Relates to

https://github.com/elizaOS/eliza/issues/3233

# Risks

Low. IMO, this is only bringing back intended behaviour

# Background

## What does this PR do?

add the `modelConfig` object to the character file schema, so it is not ignored when parsing a character file.
rename `max_response_length` to `maxOutputTokens` to be more consistent with the model settings type.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

Don't know. I did not dive that deep into the docs.

# Testing

I ran a `docker-compose build` to create a new image with my changes. Than ran an agent with a characterfile including the `modelConfig` object. From the API calls I could verify that my deviations from the default model settings (lower temperature, higher maxInputTokens) were applied.

## Discord username

@tbltzk
