### PR TITLE
configuration: Set Lava as the default RPC URL for NEAR and Starknet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -423,7 +423,7 @@ ABSTRACT_RPC_URL=https://api.testnet.abs.xyz
 # Starknet Configuration
 STARKNET_ADDRESS=
 STARKNET_PRIVATE_KEY=
-STARKNET_RPC_URL=
+STARKNET_RPC_URL=https://rpc.starknet-testnet.lava.build
 
 # Lens Network Configuration
 LENS_ADDRESS=
@@ -555,7 +555,7 @@ NEAR_WALLET_SECRET_KEY= # NEAR Wallet Secret Key
 NEAR_WALLET_PUBLIC_KEY= # NEAR Wallet Public Key
 NEAR_ADDRESS=
 NEAR_SLIPPAGE=1
-NEAR_RPC_URL=https://rpc.testnet.near.org
+NEAR_RPC_URL=https://near-testnet.lava.build
 NEAR_NETWORK=testnet # or mainnet
 
 # ZKsync Era Configuration


### PR DESCRIPTION
**Relates to**
N/A

**Risks**
Low

**Background / What does this PR do?**
This PR updates the default RPC URLs for NEAR and Starknet to use Lava.

**What kind of change is this?**
Improvements (configuration changes)

**Documentation changes needed?**
My changes do not require a change to the project documentation.

**Discord username**
@rod_of_nim

**Email address**
[nimrod@magmadevs.com](mailto:nimrod@magmadevs.com)

<div align="center">
  <h1>
    <a href="https://lavanet.xyz">
      <img src="https://user-images.githubusercontent.com/2770565/223762290-44afc792-8ad4-4dbb-b2c2-532780d6c5de.png" alt="Lava Network" width="30" height="25">
      Lava Network
    </a>
  </h1>
</div>