### PR TITLE
Add adapter-sqlite to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@0glabs/0g-ts-sdk": "0.2.1",
     "@coinbase/coinbase-sdk": "0.10.0",
+    "@elizaos-plugins/adapter-sqlite": "workspace:*",
     "@deepgram/sdk": "^3.9.0",
     "@injectivelabs/sdk-ts": "^1.14.33",
     "@vitest/eslint-plugin": "1.0.1",


### PR DESCRIPTION
This fixes `adapter-sqlite` not loading as the default adapter (occurs when no other plugins provide it).

https://github.com/elizaOS/eliza/blob/6f40883c7ae5bdb491a55753562785c40eaa7432/agent/src/index.ts#L678

Note `adapter-sqlite` is still present in `packages` for convenience. It can be externalized and installed from registry too, by changing the dep specifier to pull from npm/repo/whatever.