### PR TITLE
Fix typos in `payInvoice.ts` and `connector.provider.ts`

### DIFF
--- a/packages/plugin-flow/src/providers/connector.provider.ts
+++ b/packages/plugin-flow/src/providers/connector.provider.ts
@@ -49,16 +49,16 @@ async function _createFlowConnector(
  */
 export async function getFlowConnectorInstance(
     runtime: IAgentRuntime,
-    inputedFlowJSON: { [key: string]: unknown } = undefined
+    inputtedFlowJSON: { [key: string]: unknown } = undefined
 ): Promise<FlowConnector> {
     let connector: FlowConnector;
     if (
-        inputedFlowJSON &&
-        typeof inputedFlowJSON === "object" &&
-        typeof inputedFlowJSON?.networks === "object" &&
-        typeof inputedFlowJSON?.dependencies === "object"
+        inputtedFlowJSON &&
+        typeof inputtedFlowJSON === "object" &&
+        typeof inputtedFlowJSON?.networks === "object" &&
+        typeof inputtedFlowJSON?.dependencies === "object"
     ) {
-        connector = await _createFlowConnector(runtime, inputedFlowJSON);
+        connector = await _createFlowConnector(runtime, inputtedFlowJSON);
     } else {
         connector = await _getDefaultConnectorInstance(runtime);
     }

--- a/packages/plugin-lightning/src/actions/payInvoice.ts
+++ b/packages/plugin-lightning/src/actions/payInvoice.ts
@@ -23,7 +23,7 @@ export class PayInvoiceAction {
         this.lightningProvider = lightningProvider;
     }
 
-    async getAvalibleChannelId(): Promise<string> {
+    async getAvailableChannelId(): Promise<string> {
         const { channels } = await this.lightningProvider.getLndChannel();
         const filteredActiveChannels = channels.filter(
             (channel) => channel.is_active === true
@@ -37,9 +37,9 @@ export class PayInvoiceAction {
         return "";
     }
     async payInvoice(params: PayArgs): Promise<ExtendedPayResult> {
-        const outgoing_channel = await this.getAvalibleChannelId();
+        const outgoing_channel = await this.getAvailableChannelId();
         if (!outgoing_channel) {
-            throw new Error("no avalible channel");
+            throw new Error("no Available channel");
         }
         const requestArgs = {
             outgoing_channel: outgoing_channel,


### PR DESCRIPTION
This PR fixes minor typos in two files within the project:

- **`connector.provider.ts`**
  - Corrected `inputedFlowJSON` → `inputtedFlowJSON` for proper spelling.

- **`payInvoice.ts`**
  - Corrected method name: `getAvalibleChannelId` → `getAvailableChannelId`.
  - Fixed error message typo: `no avalible channel` → `no available channel`.
