### PR TITLE
Fix yargs slice in character loading

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -46,7 +46,7 @@ export function parseArguments(): {
     characters?: string;
 } {
     try {
-        return yargs(process.argv.slice(3))
+        return yargs(process.argv.slice(2))
             .option("character", {
                 type: "string",
                 description: "Path to the character JSON file",


### PR DESCRIPTION
To run an agent with a custom character you currently have to do (to escape a few layers of args parsing):

```
bun run agent -- -- --character=./characters/trump.character.json
```

However, this `yargs` parse slices off the argument:

```
ARGV: [
@elizaos/agent:start:       "/Users/a/.nvm/versions/node/v23.6.1/bin/node",
@elizaos/agent:start:       "/Users/a/eliza/packages/agent/src/index.ts",
@elizaos/agent:start:       "--character=./characters/trump.character.json"
@elizaos/agent:start:     ]
```

Note that yes, this command is still running the agent in `node`. That seems like a separate bug, or it could just be my env.