### PR TITLE
Try loading character path from repo root

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -184,6 +184,7 @@ async function loadCharacterTryPath(characterPath: string): Promise<Character> {
     // Try different path resolutions in order
     const pathsToTry = [
         characterPath, // exact path as specified
+        path.resolve(process.cwd(), '..', '..', characterPath), // relative to root directory
         path.resolve(process.cwd(), characterPath), // relative to cwd
         path.resolve(process.cwd(), "agent", characterPath), // Add this
         path.resolve(__dirname, characterPath), // relative to current script


### PR DESCRIPTION
This allows the user to specify character paths relative to the repository root:

```
bun run agent -- -- --character=./characters/trump.character.json
```

We add `${cwd}../..` to the list of paths to try, to move up from `packages/agent` to the repo root.