### PR TITLE
Pixocracy Plugin

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -152,6 +152,7 @@
         "@elizaos/plugin-near": "workspace:*",
         "@elizaos/plugin-stargaze": "workspace:*",
         "@elizaos/plugin-zksync-era": "workspace:*",
+        "@elizaos/plugin-pixocracy": "workspace:*",
         "readline": "1.3.0",
         "ws": "8.18.0",
         "yargs": "17.7.2"

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -121,6 +121,7 @@ import { tonPlugin } from "@elizaos/plugin-ton";
 import { webSearchPlugin } from "@elizaos/plugin-web-search";
 import { dkgPlugin } from "@elizaos/plugin-dkg";
 import { injectivePlugin } from "@elizaos/plugin-injective";
+import { pixocracyPlugin } from "@elizaos/plugin-pixocracy";
 import { giphyPlugin } from "@elizaos/plugin-giphy";
 import { letzAIPlugin } from "@elizaos/plugin-letzai";
 import { thirdwebPlugin } from "@elizaos/plugin-thirdweb";
@@ -160,6 +161,7 @@ import { quickIntelPlugin } from "@elizaos/plugin-quick-intel";
 
 import { trikonPlugin } from "@elizaos/plugin-trikon";
 import arbitragePlugin from "@elizaos/plugin-arbitrage";
+
 const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
 const __dirname = path.dirname(__filename); // get the name of the directory
 
@@ -506,8 +508,7 @@ async function handlePluginImporting(plugins: string[]) {
                     );
                 } catch (importError) {
                     elizaLogger.error(
-                        `Failed to import plugin: ${plugin}`,
-                        importError
+                        `Failed to import plugin: ${plugin} ${importError}`
                     );
                     return []; // Return null for failed imports
                 }
@@ -1141,6 +1142,7 @@ export async function createAgent(
                 : null,
             goatPlugin,
             zilliqaPlugin,
+            pixocracyPlugin,
             getSecret(character, "COINGECKO_API_KEY") ||
             getSecret(character, "COINGECKO_PRO_API_KEY")
                 ? coingeckoPlugin

--- a/packages/client-discord/package.json
+++ b/packages/client-discord/package.json
@@ -19,11 +19,11 @@
         "dist"
     ],
     "dependencies": {
-        "@discordjs/opus": "github:discordjs/opus",
-        "@discordjs/rest": "2.4.0",
-        "@discordjs/voice": "0.17.0",
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-node": "workspace:*",
+        "@discordjs/opus": "0.10.0",
+        "@discordjs/rest": "2.4.0",
+        "@discordjs/voice": "0.17.0",
         "discord.js": "14.16.3",
         "libsodium-wrappers": "0.7.15",
         "prism-media": "1.3.5"
@@ -38,7 +38,7 @@
         "test": "vitest run"
     },
     "trustedDependencies": {
-        "@discordjs/opus": "github:discordjs/opus",
+        "@discordjs/opus": "0.10.0",
         "@discordjs/voice": "0.17.0"
     },
     "peerDependencies": {

--- a/packages/plugin-pixocracy/.npmignore
+++ b/packages/plugin-pixocracy/.npmignore
@@ -1,0 +1,6 @@
+*
+
+!dist/**
+!package.json
+!readme.md
+!tsup.config.ts

--- a/packages/plugin-pixocracy/README.md
+++ b/packages/plugin-pixocracy/README.md
@@ -1,0 +1,109 @@
+# @elizaos/plugin-pixocracy
+
+A plugin for Eliza OS that enables integration with Pixocracy, allowing your agent to participate in conversations and interactions within the Pixocracy environment.
+
+## Overview
+
+This plugin provides an API interface that allows Pixocracy to communicate with your Eliza agent, enabling dynamic conversations and interactions based on environmental context and character traits.
+
+## Features
+
+- Express-based API endpoints for Pixocracy integration
+- Context-aware dialogue generation
+- Support for character traits and environmental awareness
+- Automatic handling of conversation roles (initiator/responder)
+- Health check endpoint
+
+## Installation
+
+```bash
+pnpm install @elizaos/plugin-pixocracy
+```
+
+## Usage
+
+### Plugin Registration
+
+Add the plugin to your Eliza OS configuration:
+
+```typescript
+import { pixocracyPlugin } from "@elizaos/plugin-pixocracy";
+
+const config = {
+    plugins: [
+        pixocracyPlugin,
+    ],
+};
+```
+
+In a character.json file, you need to add the following:
+```json
+"plugins": ["@elizaos/plugin-pixocracy"]
+```
+
+### API Endpoints
+
+The plugin exposes the following endpoints:
+
+#### Health Check
+```http
+GET /api/pixocracy/health
+```
+Returns the health status, Pixocracy will use this check to determine if your agent is online and ready to receive conversations.
+
+#### Conversation
+```http
+POST /api/pixocracy/converse
+```
+Handles conversation requests from Pixocracy.
+
+Response format:
+```typescript
+{
+    success: boolean,
+    data: {
+        say: string | null,
+        actions: string[] | null
+    }
+}
+```
+
+## Configuration
+
+The plugin starts an Express server on port 3001 by default. You can customize the port by passing it to the PixocracyClient constructor:
+
+```typescript
+const client = new PixocracyClient(runtime, 4000); // Use port 4000 instead
+```
+
+## Example Response
+
+When Pixocracy sends a conversation request, your agent will respond with dialogue and optional actions:
+
+```json
+{
+    "success": true,
+    "data": {
+        "say": "Hello! Beautiful day for a walk in the park, isn't it?",
+        "actions": ["wave", "smile"]
+    }
+}
+```
+
+## Environment Context
+
+Your agent will receive contextual information about:
+- The conversation role (initiator or responder)
+- The other agent's information (name, personality, role)
+- Environmental details (location, time, nearby entities)
+- Previous messages (when responding)
+
+This context helps generate appropriate and contextually relevant responses.
+
+## Contributing
+
+Contributions are welcome! Please ensure your changes maintain compatibility with the Pixocracy platform's expectations.
+
+## License
+
+This plugin is part of the Eliza project. See the main project repository for license information.

--- a/packages/plugin-pixocracy/eslint.config.mjs
+++ b/packages/plugin-pixocracy/eslint.config.mjs
@@ -1,0 +1,3 @@
+import eslintGlobalConfig from "../../eslint.config.mjs";
+
+export default [...eslintGlobalConfig];

--- a/packages/plugin-pixocracy/package.json
+++ b/packages/plugin-pixocracy/package.json
@@ -1,0 +1,36 @@
+{
+    "name": "@elizaos/plugin-pixocracy",
+    "version": "0.1.8-alpha.1",
+    "description": "Pixocracy plugin for ElizaOS",
+    "type": "module",
+    "main": "dist/index.js",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        "./package.json": "./package.json",
+        ".": {
+            "import": {
+                "@elizaos/source": "./src/index.ts",
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            }
+        }
+    },
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "tsup --format esm --dts",
+        "lint": "eslint --fix --cache .",
+        "watch": "tsc --watch",
+        "dev": "tsup src/index.ts --format esm --dts --watch"
+    },
+    "dependencies": {
+      "@elizaos/core": "workspace:*",
+      "express": "^4.18.2"
+    },
+    "devDependencies": {
+      "@types/express": "^4.17.21",
+      "typescript": "^5.0.0"
+    }
+  }

--- a/packages/plugin-pixocracy/src/api.ts
+++ b/packages/plugin-pixocracy/src/api.ts
@@ -21,10 +21,6 @@ export function createPixocracyApiRouter(
         "/api/pixocracy/converse",
         async (req: express.Request, res: express.Response) => {
             try {
-                elizaLogger.log("Raw request received:", {
-                    headers: req.headers,
-                    body: req.body
-                });
                 const pixocracyRes = await createPixocracyDialogue({
                     runtime,
                     req,

--- a/packages/plugin-pixocracy/src/api.ts
+++ b/packages/plugin-pixocracy/src/api.ts
@@ -1,7 +1,7 @@
 import express from "express";
 
-import { elizaLogger, IAgentRuntime } from "@elizaos/core";
-import { createPixocracyDialogue } from "./handlers/createPixocracyDialogue.ts";;
+import { IAgentRuntime } from "@elizaos/core";
+import { createPixocracyDialogue } from "./handlers/createPixocracyDialogue.ts";
 
 export function createPixocracyApiRouter(
     runtime: IAgentRuntime

--- a/packages/plugin-pixocracy/src/api.ts
+++ b/packages/plugin-pixocracy/src/api.ts
@@ -1,0 +1,48 @@
+import express from "express";
+
+import { elizaLogger, IAgentRuntime } from "@elizaos/core";
+import { createPixocracyDialogue } from "./handlers/createPixocracyDialogue.ts";;
+
+export function createPixocracyApiRouter(
+    runtime: IAgentRuntime
+): express.Router {
+    const router = express.Router();
+    router.use(express.json());
+
+    // Health check
+    router.get("/api/pixocracy/health", async (req: express.Request, res: express.Response) => {
+        res.json({
+            success: true,
+            data: "Eliza is healthy",
+        });
+    });
+
+    router.post(
+        "/api/pixocracy/converse",
+        async (req: express.Request, res: express.Response) => {
+            try {
+                elizaLogger.log("Raw request received:", {
+                    headers: req.headers,
+                    body: req.body
+                });
+                const pixocracyRes = await createPixocracyDialogue({
+                    runtime,
+                    req,
+                });
+
+                res.json({
+                    success: true,
+                    data: pixocracyRes,
+                });
+            } catch (e: any) {
+                console.log(e);
+                res.json({
+                    success: false,
+                    data: JSON.stringify(e),
+                });
+            }
+        }
+    );
+
+    return router;
+}

--- a/packages/plugin-pixocracy/src/client.ts
+++ b/packages/plugin-pixocracy/src/client.ts
@@ -1,0 +1,32 @@
+import express from "express";
+import { AgentRuntime, Client, elizaLogger } from "@elizaos/core";
+import { createPixocracyApiRouter } from "./api";
+import { IAgentRuntime } from "@elizaos/core";
+
+export class PixocracyClient {
+    private app: express.Application;
+    private port: number;
+    private runtime: IAgentRuntime;
+
+    constructor(runtime: IAgentRuntime, port: number = 3001) {
+        this.app = express();
+        this.runtime = runtime;
+        this.port = port;
+    }
+
+    public async start(): Promise<void> {
+        // Register routes
+        elizaLogger.log("Starting Pixocracy API...");
+        const apiRouter = createPixocracyApiRouter(this.runtime);
+        this.app.use(apiRouter);
+
+        // Start server
+        this.app.listen(this.port, () => {
+            elizaLogger.log(`Pixocracy API listening on port ${this.port}`);
+        });
+    }
+
+    async stop() {
+        return true;
+    }
+}

--- a/packages/plugin-pixocracy/src/handlers/createPixocracyDialogue.ts
+++ b/packages/plugin-pixocracy/src/handlers/createPixocracyDialogue.ts
@@ -1,0 +1,177 @@
+import {
+    composeContext,
+    Content,
+    elizaLogger,
+    generateText,
+    getEmbeddingZeroVector,
+    IAgentRuntime,
+    Memory,
+    ModelClass,
+    parseJSONObjectFromText,
+    stringToUuid,
+} from "@elizaos/core";
+
+// Types matching the API
+interface AgentContext {
+    name: string;
+    traits?: {
+        personality?: string;
+        role?: string;
+    };
+}
+
+interface EnvironmentContext {
+    nearbyEntities?: {
+        name: string;
+        type: 'agent' | 'npc' | 'object';
+        distance?: number;
+    }[];
+    location?: string;
+    time?: string;
+}
+
+interface ConversationContext {
+    otherAgent: AgentContext;
+    self: AgentContext;
+    environment: EnvironmentContext;
+}
+
+interface PixocracyRequest {
+    role: 'initiator' | 'responder';
+    context: ConversationContext;
+    previousMessage?: any;
+}
+
+export const pixocracyHandlerTemplate = `{{actionExamples}}
+(Action examples are for reference only. Do not use the information from them in your response.)
+
+# Knowledge
+{{knowledge}}
+
+# Task: Generate dialog and actions for the character {{agentName}}.
+About {{agentName}}:
+{{bio}}
+{{lore}}
+
+# Conversation Context
+Role: {{role}}
+
+About Other Agent:
+Name: {{otherAgent.name}}
+{{#if otherAgent.traits.personality}}
+Personality: {{otherAgent.traits.personality}}
+{{/if}}
+Role: {{otherAgent.traits.role}}
+
+Environment:
+Location: {{environment.location}}
+Time: {{environment.time}}
+
+Nearby:
+{{#each environment.nearbyEntities}}
+- {{this.name}} ({{this.type}}){{#if this.distance}} - {{this.distance}} units away{{/if}}
+{{/each}}
+
+{{providers}}
+
+{{attachments}}
+
+# Capabilities
+Note that {{agentName}} is capable of reading/seeing/hearing various forms of media, including images, videos, audio, plaintext and PDFs. Recent attachments have been included above under the "Attachments" section.
+
+{{messageDirections}}
+
+{{recentMessages}}
+
+{{actions}}
+
+{{#if isInitiator}}
+You are initiating the conversation with {{otherAgent.name}}.
+{{else}}
+You are responding to {{otherAgent.name}}.
+Previous message: {{previousMessage}}
+{{/if}}
+
+Response format should be formatted in a JSON block like this:
+\`\`\`json
+{ "say": "string" or null, "actions": (array of strings) or null }
+\`\`\`
+`;
+
+export async function createPixocracyDialogue({
+    runtime,
+    req,
+}: {
+    runtime: IAgentRuntime;
+    req: any;
+}) {
+    const userId = runtime.agentId;
+    const agentName = runtime.character.name;
+    const roomId = stringToUuid("pixocracy-" + agentName);
+
+    const pixocracyRequest = req.body as PixocracyRequest;
+    elizaLogger.log(pixocracyRequest);
+    elizaLogger.log(JSON.stringify(pixocracyRequest));
+    const isInitiator = pixocracyRequest.role === 'initiator';
+
+    const content: Content = {
+        text: JSON.stringify(req.body),
+        attachments: [],
+        source: "pixocracy",
+        inReplyTo: undefined,
+    };
+
+    // Create memory for the message
+    const memory: Memory = {
+        agentId: userId,
+        userId,
+        roomId,
+        content,
+        createdAt: Date.now(),
+        embedding: getEmbeddingZeroVector(),
+    };
+
+    elizaLogger.log('Composing state...', {
+        agentName,
+        role: pixocracyRequest.role,
+        isInitiator,
+        otherAgent: pixocracyRequest.context.otherAgent,
+        environment: pixocracyRequest.context.environment,
+        previousMessage: pixocracyRequest.previousMessage,
+    });
+
+    console.log(pixocracyRequest.context.otherAgent);
+
+    const state = await runtime.composeState(memory, {
+        agentName,
+        role: pixocracyRequest.role,
+        isInitiator,
+        otherAgent: pixocracyRequest.context.otherAgent,
+        environment: pixocracyRequest.context.environment,
+        previousMessage: pixocracyRequest.previousMessage,
+    });
+
+    console.log(state);
+
+    const context = composeContext({
+        state,
+        template: pixocracyHandlerTemplate,
+        templatingEngine: "handlebars",
+    });
+
+    let elizaResponse = await generateText({
+        runtime,
+        context,
+        modelClass: ModelClass.MEDIUM,
+    });
+
+    const response = parseJSONObjectFromText(elizaResponse);
+    if (response) {
+        return response;
+    }
+
+    return {
+        say: null,
+        actions: null,
+    };
+}

--- a/packages/plugin-pixocracy/src/handlers/createPixocracyDialogue.ts
+++ b/packages/plugin-pixocracy/src/handlers/createPixocracyDialogue.ts
@@ -110,8 +110,6 @@ export async function createPixocracyDialogue({
     const roomId = stringToUuid("pixocracy-" + agentName);
 
     const pixocracyRequest = req.body as PixocracyRequest;
-    elizaLogger.log(pixocracyRequest);
-    elizaLogger.log(JSON.stringify(pixocracyRequest));
     const isInitiator = pixocracyRequest.role === 'initiator';
 
     const content: Content = {
@@ -131,7 +129,7 @@ export async function createPixocracyDialogue({
         embedding: getEmbeddingZeroVector(),
     };
 
-    elizaLogger.log('Composing state...', {
+    elizaLogger.debug('Composing state...', {
         agentName,
         role: pixocracyRequest.role,
         isInitiator,
@@ -159,7 +157,7 @@ export async function createPixocracyDialogue({
         templatingEngine: "handlebars",
     });
 
-    let elizaResponse = await generateText({
+    const elizaResponse = await generateText({
         runtime,
         context,
         modelClass: ModelClass.MEDIUM,

--- a/packages/plugin-pixocracy/src/index.ts
+++ b/packages/plugin-pixocracy/src/index.ts
@@ -1,0 +1,33 @@
+import { Client, IAgentRuntime, Plugin } from "@elizaos/core";
+import { PixocracyClient } from "./client.ts";
+export * from "./api.ts";
+
+export async function sleep(ms: number = 3000) {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+
+export const PixocracyClientInterface: Client = {
+    start: async (runtime: IAgentRuntime) => {
+        const client = new PixocracyClient(runtime);
+        await client.start();
+        return client;
+    },
+    stop: async (_runtime: IAgentRuntime, client?: Client) => {
+        if (client instanceof PixocracyClient) {
+            client.stop();
+        }
+    },
+};
+
+export const pixocracyPlugin: Plugin = {
+    name: "pixocracy",
+    description: "Pixocracy plugin",
+    clients: [PixocracyClientInterface],
+    evaluators: [],
+    providers: [],
+};
+
+export default pixocracyPlugin;

--- a/packages/plugin-pixocracy/tsconfig.json
+++ b/packages/plugin-pixocracy/tsconfig.json
@@ -1,0 +1,13 @@
+{
+    "extends": "../core/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "./src",
+        "types": [
+            "node"
+        ]
+    },
+    "include": [
+        "src/**/*.ts",
+    ]
+}

--- a/packages/plugin-pixocracy/tsup.config.ts
+++ b/packages/plugin-pixocracy/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+    entry: ["src/index.ts"],
+    outDir: "dist",
+    sourcemap: true,
+    clean: true,
+    format: ["esm"], // Ensure you're targeting CommonJS
+    external: [],
+});


### PR DESCRIPTION
# Context / Why
This adds a new plugin to integrate with Pixocracy. This will expose 2 endpoints on port 3001:
`/api/pixocracy/converse`
and
`/api/pixocracy/health`

The health endpoint is used for Pixocracy to link with Eliza, and we periodically call this to make sure the agent is still alive,

(For context: Pixocracy is a platform that allow people to add their agents to games that we support, for instance - Minecraft)

For now, we only support the dialogue, but eventually we'll modify the plugin so that users can have their agents decide where to move to, otherwise the game will handle it.

# Risks
The risks are low here, we're just introducing a new plugin. It is not enabled by default :)
