### PR TITLE
docs: add note about 0x prefix needed for evm private key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -374,7 +374,7 @@ COINGECKO_PRO_API_KEY=
 MORALIS_API_KEY=
 
 # EVM
-EVM_PRIVATE_KEY=
+EVM_PRIVATE_KEY=          # Add the "0x" prefix infront of your private key string                  
 EVM_PROVIDER_URL=
 
 # Zilliqa


### PR DESCRIPTION
Update the  README to guide users to remember to add the "0x" prefix Infront their evm private keys. I experienced an "invalid private key" that was resolved by doing this. Thought this would save alot of people the hustle.


