### PR TITLE
add embedding zero vector

### DIFF
--- a/packages/plugin-news/src/actions/news.ts
+++ b/packages/plugin-news/src/actions/news.ts
@@ -2,6 +2,7 @@ import {
     ActionExample,
     Content,
     generateText,
+    getEmbeddingZeroVector,
     HandlerCallback,
     IAgentRuntime,
     Memory,
@@ -110,6 +111,7 @@ export const currentNewsAction: Action = {
                 action: "CURRENT_NEWS_RESPONSE",
                 source: _message.content?.source,
             } as Content,
+            embedding: getEmbeddingZeroVector(),
         };
 
         await _runtime.messageManager.createMemory(newMemory);


### PR DESCRIPTION
# Relates to SqliteError: Vector dimension mistmatch.

<!-- LINK TO ISSUE OR TICKET -->
https://github.com/elizaOS/eliza/issues/3355

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low because it's a bug resolution to  ensure that the memory entry being created has a valid embedding format.

# Background

## What does this PR do?

This PR fix a bug in the `plugin-news` by creating a new memory after fetching the news, the system uses getEmbeddingZeroVector() to fill in the embedding field, ensuring the memory is stored correctly in Eliza OS's memory management system.

## What kind of change is this?

Bug fixes

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

## Detailed testing steps

- As a user, chat to the bot for some news
- Ask again some news

## Discord username
@w1ld3r
