### PR TITLE
docs: fix branch naming example in CONTRIBUTING.md

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -1,30 +1,21 @@
 # Contributing to Eliza
 
-First off, thank you for considering contributing to Eliza! We welcome contributions from everyone, regardless of experience level.
+First off, thank you for considering contributing to elizaOS! We welcome improvements and contributions.
 
 ## Contribution License Agreement
 
-By contributing to Eliza, you agree that your contributions will be licensed under the MIT License. This means:
+By contributing to elizaOS, you agree that your contributions will be licensed under the MIT License. This means:
 
 1. You grant us (and everyone else) a perpetual, worldwide, non-exclusive, royalty-free license to use your contributions.
 2. Your contributions are and will be available as Free and Open Source Software (FOSS).
 3. You have the right to submit the work under this license.
 4. You understand that your contributions are public and that a record of the contribution is maintained indefinitely.
 
-## The OODA Loop: A Framework for Contribution
-
-We believe in the power of the OODA Loop - a decision-making framework that emphasizes speed and adaptability. OODA stands for:
-
-- **Observe**: Gather information and insights about the project, the community, and the broader AI ecosystem.
-- **Orient**: Analyze your observations to identify opportunities for contribution and improvement.
-- **Decide**: Choose a course of action based on your analysis. This could be proposing a new feature, fixing a bug, or creating content.
-- **Act**: Execute your decision and share your work with the community.
-
 ## How to Contribute
 
 ### For Developers
 
-1. **Extend Eliza's Capabilities**
+1. **Extend elizaOS's Capabilities**
 
     - Develop new actions, evaluators, and providers
     - Improve existing components and modules
@@ -36,13 +27,13 @@ We believe in the power of the OODA Loop - a decision-making framework that emph
     - Optimize performance
     - Improve deployment solutions
 
-3. Fork the repo and create your branch from `main`.
-    1. The name of the branch should start with the issue number and be descriptive of the changes you are making.
+3. Fork the repo and create your branch from `develop`.
+    1. The name of the branch could start with the issue number and be descriptive of the changes you are making.
     2. Example: 9999-add-test-for-bug-123
 4. If you've added code that should be tested, add tests.
 5. Ensure the test suite passes.
 6. Make sure your code lints.
-7. Issue that pull request!
+7. Issue that pull request to the `develop` branch!
 
 ## Styleguides
 
@@ -67,7 +58,18 @@ We believe in the power of the OODA Loop - a decision-making framework that emph
 
 ## Additional Notes
 
-### Issue and Pull Request Labels
+### Pull Request Titles
+
+This section lists the title prefix we use to help us track and manage pull requests. These prefixes must be lower case
+
+- `fix` - Issues that fixes bugs.
+- `feat` - New feature, updates or improvemnts.
+- `docs` - Issues or pull requests related to documentation.
+- `chore` - General repo maintenance
+
+Please place a colon follow by a space (`: `) in your PR title
+
+### Issue Labels
 
 This section lists the labels we use to help us track and manage issues and pull requests.
 
@@ -78,7 +80,8 @@ This section lists the labels we use to help us track and manage issues and pull
 
 ## Getting Help
 
-- Join [Discord](https://discord.gg/ai16z)
+- Join [Development Discord](https://discord.gg/elizaOS)
+- Join [DAO Discord](https://discord.gg/ai16z)
 - Check [FAQ](faq.md)
 - Create GitHub issues
 
@@ -87,43 +90,3 @@ This section lists the labels we use to help us track and manage issues and pull
 - [Local Development Guide](guides/local-development.md)
 - [Configuration Guide](guides/configuration.md)
 - [API Documentation](api)
-
-## Contributor Guide
-
-Welcome to the Eliza contributor guide! This document is designed to help you understand how you can be part of building the future of autonomous AI agents, regardless of your technical background.
-
-### Code of Conduct
-
-#### Our Pledge
-
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
-
-#### Our Standards
-
-Examples of behavior that contributes to creating a positive environment include:
-
-- Using welcoming and inclusive language
-- Being respectful of differing viewpoints and experiences
-- Gracefully accepting constructive criticism
-- Focusing on what is best for the community
-- Showing empathy towards other community members
-
-Examples of unacceptable behavior include:
-
-- The use of sexualized language or imagery and unwelcome sexual attention or advances
-- Trolling, insulting/derogatory comments, and personal or political attacks
-- Public or private harassment
-- Publishing others' private information without explicit permission
-- Other conduct which could reasonably be considered inappropriate in a professional setting
-
-#### Our Responsibilities
-
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
-
-#### Scope
-
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
-
-Thank you for contributing to Eliza and helping build the future of autonomous AI agents! 🎉

--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -38,7 +38,7 @@ We believe in the power of the OODA Loop - a decision-making framework that emph
 
 3. Fork the repo and create your branch from `main`.
     1. The name of the branch should start with the issue number and be descriptive of the changes you are making.
-    2. Example: 9999--add-test-for-bug-123
+    2. Example: 9999-add-test-for-bug-123
 4. If you've added code that should be tested, add tests.
 5. Ensure the test suite passes.
 6. Make sure your code lints.


### PR DESCRIPTION
## What does this PR do?

The example uses a double hyphen (`--`) between the issue number and the description, which isn't standard practice.
I've updated it to use a single hyphen (`-`) to align with common Git conventions.  

This change ensures clarity and consistency for contributors when creating new branches.  

### Changes
- Updated `9999--add-test-for-bug-123` to `9999-add-test-for-bug-123`.  