### PR TITLE
Added feature: Plugin Merkle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -543,6 +543,11 @@ CLOUDFLARE_AI_GATEWAY_ID= # Cloudflare AI Gateway ID - found in the Cloudflare D
 APTOS_PRIVATE_KEY= # Aptos private key
 APTOS_NETWORK=     # Must be one of mainnet, testnet
 
+# Merkle Trade
+MERKLE_TRADE_LOG_LEVEL=debug
+MERKLE_TRADE_NETWORK=testnet        # Must be one of mainnet, testnet
+MERKLE_TRADE_APTOS_PRIVATE_KEY=     # Aptos private key
+
 # MultiversX
 MVX_PRIVATE_KEY=                    # Multiversx private key
 MVX_NETWORK=                        # must be one of mainnet, devnet, testnet

--- a/packages/plugin-merkle/.npmignore
+++ b/packages/plugin-merkle/.npmignore
@@ -1,0 +1,6 @@
+*
+
+!dist/**
+!package.json
+!readme.md
+!tsup.config.ts

--- a/packages/plugin-merkle/README.md
+++ b/packages/plugin-merkle/README.md
@@ -1,0 +1,67 @@
+# @elizaos/plugin-merkle
+
+This plugin is a sample plugin for interacting with MerkleTrade within the elizaOS ecosystem.
+
+## Configuration
+
+The plugin requires the following environment variables to be set:
+
+Merkle Configuration
+
+```env
+MERKLE_TRADE_LOG_LEVEL=debug
+MERKLE_TRADE_NETWORK=               # Must be one of mainnet, testnet
+MERKLE_TRADE_APTOS_PRIVATE_KEY=     # Aptos private key
+```
+
+## Usage
+
+### Example
+
+```bash
+// The plugin responds to natural language like:
+
+You: "Open a BTC Long position on the Merkle Trade platform with 1000 pay and 10 leverage."
+Agent: "Successfully market order BTC with 1000 pay and 10 leverage, Transaction: 0x104af5d1a786a2e1a4721a721b2cfccc7e15fa41eec15a489ba1768790adb523"
+```
+
+## Actions
+
+-   OPEN_ORDER
+-   GET_PRICE
+-   GET_POSITION
+-   GET_ORDER
+-   GET_BALANCE
+-   FULLY_CLOSE_POSITION
+
+## Development Guide
+
+### Setting Up Development Environment
+
+1. Clone the repository
+2. Install dependencies:
+
+```bash
+cd packages/plugin-merkle
+
+pnpm install
+```
+
+3. Build the plugin:
+
+```bash
+pnpm build
+```
+
+## Dependencies
+
+-   @elizaos/core: v0.1.9
+-   @merkletrade/ts-sdk: ^v1.0.0
+-   @aptos-labs/ts-sdk: ^v1.26.0
+-   node-cache: 5.1.2
+
+For more information:
+
+-   [Merkle Documentation](https://docs.merkle.trade/)
+-   [Aptos Documentation](https://aptos.dev/)
+-   [Move Language Guide](https://move-language.github.io/move/)

--- a/packages/plugin-merkle/package.json
+++ b/packages/plugin-merkle/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@elizaos/plugin-merkle",
+  "version": "0.1.9-alpha.1",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "@elizaos/source": "./src/index.ts",
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@elizaos/core": "v0.1.9",
+    "@merkletrade/ts-sdk": "^1.0.0",
+    "@aptos-labs/ts-sdk": "^1.26.0",
+    "node-cache": "5.1.2",
+    "tsup": "8.3.5",
+    "vitest": "2.1.4"
+  },
+  "scripts": {
+    "build": "tsup --format esm --dts",
+    "dev": "tsup --format esm --dts --watch",
+    "test": "vitest run",
+    "lint": "biome lint .",
+    "lint:fix": "biome check --write .",
+    "format": "biome format .",
+    "format:fix": "biome format --write ."
+  },
+  "peerDependencies": {
+    "form-data": "4.0.1",
+    "whatwg-url": "7.1.0"
+  }
+}

--- a/packages/plugin-merkle/src/actions/fullyClosePosition.ts
+++ b/packages/plugin-merkle/src/actions/fullyClosePosition.ts
@@ -1,0 +1,137 @@
+import { elizaLogger, generateObjectDeprecated } from "@elizaos/core";
+import {
+	type ActionExample,
+	type HandlerCallback,
+	type IAgentRuntime,
+	type Memory,
+	ModelClass,
+	type State,
+	type Action,
+} from "@elizaos/core";
+import { composeContext } from "@elizaos/core";
+import { FullyClosePositionSchema } from "../types";
+import { checkEnv, newMerkleService } from "../utils";
+
+const fullyCloseOrderTemplate = `Respond with a JSON markdown block containing only the extracted values. Use null for any values that cannot be determined.
+
+Example response:
+\`\`\`json
+{
+    "coinSymbol": "BTC",
+    "side": "LONG",
+}
+\`\`\`
+
+{{recentMessages}}
+
+Given the recent messages, extract the following information about the requested futures position order:
+- coinSymbol : Coin symbol (Must be a valid coin symbol, Must be provided by the user)
+- side : Side of the position (Must be "LONG" or "SHORT", Must be provided by the user)
+
+Respond with a JSON markdown block containing only the extracted values.`;
+
+export default {
+  name: "FULLY_CLOSE_POSITION",
+  similes: ["CLOSE_POSITION"],
+  description: "Fully close all positions on the Merkle Trade platform",
+  examples: [
+    [
+      {
+        user: "{{user}}",
+        content: {
+          text: "Close BTC Long position on the Merkle Trade platform",
+        },
+      },
+      {
+        user: "{{agent}}",
+        content: {
+          text: "Successfully close position BTC with LONG position, Transaction: 0x104af5d1a786a2e1a4721a721b2cfccc7e15fa41eec15a489ba1768790adb523",
+          action: "FULLY_CLOSE_POSITION",
+        },
+      }
+    ]
+  ] as ActionExample[][],
+  validate: async (runtime: IAgentRuntime) => {
+    return checkEnv(runtime);
+  },
+	handler: async (
+		runtime: IAgentRuntime,
+		message: Memory,
+		state: State,
+		_options: { [key: string]: unknown },
+		callback?: HandlerCallback,
+	): Promise<boolean> => {
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    let content: any;
+    try {
+      let currentState = state;
+      if (!currentState) {
+        currentState = (await runtime.composeState(message)) as State;
+      } else {
+        currentState = await runtime.updateRecentMessageState(currentState);
+      }
+
+      const context = composeContext({
+        state: currentState,
+        template: fullyCloseOrderTemplate,
+      });
+
+      content = await generateObjectDeprecated({
+        runtime,
+        context: context,
+        modelClass: ModelClass.LARGE,
+      });
+
+      if (content && typeof content.side === "string") {
+        switch (content.side.toUpperCase()) {
+          case "LONG":
+            content.side = "LONG";
+            break;
+          case "SHORT":
+            content.side = "SHORT";
+            break;
+          default:
+            throw new Error("Invalid side");
+        }
+      }
+
+      const parseResult = FullyClosePositionSchema.safeParse(content);
+      if (!parseResult.success) {
+        throw new Error(
+          `Invalid open order content: ${JSON.stringify(parseResult.error.errors, null, 2)}`
+        );
+      }
+      const { coinSymbol, side } = parseResult.data
+
+      const merkleService = await newMerkleService(runtime)
+
+      const positions = await merkleService.getPositions()
+      const position = positions.find(p => p.pairType.split("::")[2].includes(coinSymbol.toUpperCase()) && p.isLong === (side === "LONG"))
+      if (!position) {
+        throw new Error(`Position not found for ${coinSymbol} with ${side} position`)
+      }
+      const tx = await merkleService.closePosition(position)
+      if (callback) {
+        callback({
+          text: `Successfully close position ${coinSymbol} with ${side} position, Transaction: ${tx.hash}`,
+          content: tx,
+        });
+      }
+      elizaLogger.info("Successfully close position", tx.hash);
+
+      return true
+    } catch (error) {
+      elizaLogger.error("Error during fully close position:", {
+        content,
+        message: error.message,
+      });
+      if (callback) {
+        callback({
+          text: `Error during fully close position: ${error.message}`,
+          content: { error: error.message },
+        });
+      }
+      return false
+    }
+  },
+} as Action;

--- a/packages/plugin-merkle/src/actions/getBalance.ts
+++ b/packages/plugin-merkle/src/actions/getBalance.ts
@@ -1,0 +1,77 @@
+import { elizaLogger } from "@elizaos/core";
+import type {
+	ActionExample,
+	HandlerCallback,
+	IAgentRuntime,
+	Memory,
+	State,
+	Action,
+} from "@elizaos/core";
+import { checkEnv, newMerkleService } from "../utils";
+import { toNumber } from "@merkletrade/ts-sdk";
+
+export default {
+  name: "GET_BALANCE",
+  similes: ["BALANCE"],
+  description: "Get the balance of the user on the Merkle Trade platform",
+  examples: [
+    [
+      {
+        user: "{{user}}",
+        content: {
+          text: "What is my balance?",
+        },
+      },
+      {
+        user: "{{agent}}",
+        content: {
+          text: "Balance:\nUSDC\t|\t1000000",
+          action: "GET_BALANCE",
+        },
+      }
+    ]
+  ] as ActionExample[][],
+  validate: async (runtime: IAgentRuntime) => {
+    return checkEnv(runtime);
+  },
+	handler: async (
+		runtime: IAgentRuntime,
+		message: Memory,
+		state: State,
+		_options: { [key: string]: unknown },
+		callback?: HandlerCallback,
+	): Promise<boolean> => {
+    try {
+      let currentState = state;
+      if (!currentState) {
+        currentState = (await runtime.composeState(message)) as State;
+      } else {
+        currentState = await runtime.updateRecentMessageState(currentState);
+      }
+
+      const merkleService = await newMerkleService(runtime)
+
+      const balance = await merkleService.getBalance()
+      if (!balance) {
+        throw new Error("Balance not found")
+      }
+      const usdc = toNumber(balance.usdc, 6)
+      if (callback) {
+        callback({ text: `Balance:\nUSDC\t|\t${usdc}` });
+      }
+      elizaLogger.info("Successfully get balance");
+      return true
+    } catch (error) {
+      elizaLogger.error("Error during get balance:", {
+        message: error.message,
+      });
+      if (callback) {
+        callback({
+          text: `Error during get balance: ${error.message}`,
+          content: { error: error.message },
+        });
+      }
+      return false
+    }
+  },
+} as Action;

--- a/packages/plugin-merkle/src/actions/getOrder.ts
+++ b/packages/plugin-merkle/src/actions/getOrder.ts
@@ -1,0 +1,85 @@
+import { elizaLogger } from "@elizaos/core";
+import type{
+	ActionExample,
+	HandlerCallback,
+	IAgentRuntime,
+	Memory,
+	State,
+	Action,
+} from "@elizaos/core";
+import { checkEnv, newMerkleService } from "../utils";
+import { toNumber } from "@merkletrade/ts-sdk";
+
+export default {
+  name: "GET_ORDER",
+  similes: ["ORDER"],
+  description: "Get the order of the user on the Merkle Trade platform",
+  examples: [
+    [
+      {
+        user: "{{user}}",
+        content: {
+          text: "Get the order of the user on the Merkle Trade platform",
+        },
+      },
+      {
+        user: "{{agent}}",
+        content: {
+          text: "Orders\n----------------------------\nETH (Long, increase) order: 9940.36$ at 2600$\nBTC (Long, increase) order: 970.87$ at 80000$",
+          action: "GET_ORDER",
+        },
+      }
+    ]
+  ] as ActionExample[][],
+  validate: async (runtime: IAgentRuntime) => {
+    return checkEnv(runtime);
+  },
+	handler: async (
+		runtime: IAgentRuntime,
+		message: Memory,
+		state: State,
+		_options: { [key: string]: unknown },
+		callback?: HandlerCallback,
+	): Promise<boolean> => {
+    try {
+      let currentState = state;
+      if (!currentState) {
+        currentState = (await runtime.composeState(message)) as State;
+      } else {
+        currentState = await runtime.updateRecentMessageState(currentState);
+      }
+
+      const merkleService = await newMerkleService(runtime)
+
+      const orders = await merkleService.getOrders()
+      if (!orders) {
+        throw new Error("Orders not found")
+      }
+
+      const tableData = orders.map(order => [
+        order.pairType.split("::")[2].split("_")[0],
+        order.isLong ? "Long" : "Short",
+        order.isIncrease ? "Increase" : "Decrease",
+        toNumber(order.sizeDelta, 6).toFixed(2),
+        toNumber(order.price, 10),
+      ])
+
+      const logs = tableData.map(row => {
+        const [pair, side, type, size, price] = row
+        return `${pair} (${side}, ${String(type).toLowerCase()}) order: ${size}$ at ${price}$`
+      })
+
+      if (callback) {
+        callback({ text: `Orders\n----------------------------\n${logs.join("\n")}` });
+      }
+      elizaLogger.info("Successfully get orders");
+      return true
+    } catch (error) {
+      elizaLogger.error("Error during get orders:", { message: error.message });
+      if (callback) {
+        callback({ text: `Error during get orders: ${error.message}` });
+      }
+      return false
+    }
+  },
+} as Action;

--- a/packages/plugin-merkle/src/actions/getPosition.ts
+++ b/packages/plugin-merkle/src/actions/getPosition.ts
@@ -1,0 +1,96 @@
+import { elizaLogger } from "@elizaos/core";
+import type{
+	ActionExample,
+	HandlerCallback,
+	IAgentRuntime,
+	Memory,
+	State,
+	Action,
+} from "@elizaos/core";
+import { checkEnv, newMerkleService } from "../utils";
+import { calcPnlWithoutFee, dec, div, fromNumber, toNumber } from "@merkletrade/ts-sdk";
+
+export default {
+  name: "GET_POSITION",
+  similes: ["POSITION"],
+  description: "Get the position of the user on the Merkle Trade platform",
+  examples: [
+    [
+      {
+        user: "{{user}}",
+        content: {
+          text: "Get the position of the user on the Merkle Trade platform",
+        },
+      },
+      {
+        user: "{{agent}}",
+        content: {
+          text: "Positions\n----------------------------\nETH (50x Long)\nAvg Price: 2783.714542352$\nCollateral: 19.417476$\nPnL: -37.36% (-7.26$)",
+          action: "GET_POSITION",
+        },
+      }
+    ]
+  ] as ActionExample[][],
+  validate: async (runtime: IAgentRuntime) => {
+    return checkEnv(runtime);
+  },
+	handler: async (
+		runtime: IAgentRuntime,
+		message: Memory,
+		state: State,
+		_options: { [key: string]: unknown },
+		callback?: HandlerCallback,
+	): Promise<boolean> => {
+    try {
+      let currentState = state;
+      if (!currentState) {
+        currentState = (await runtime.composeState(message)) as State;
+      } else {
+        currentState = await runtime.updateRecentMessageState(currentState);
+      }
+
+      const merkleService = await newMerkleService(runtime)
+
+      const positions = await merkleService.getPositions()
+      if (!positions) {
+        throw new Error("Positions not found")
+      }
+
+      const summary = await merkleService.getSummary()
+      if (!summary) {
+        throw new Error("Summary not found")
+      }
+
+      const logs = [
+        "Positions",
+        ...positions.map(position => {
+        const pair = position.pairType.split("::")[2].split("_")[0]
+        const side = position.isLong ? "Long" : "Short"
+        const collateral = toNumber(position.collateral, 6)
+        const leverage = Math.round(toNumber(position.size, 6) / collateral)
+        const currentPrice = fromNumber(summary.prices.find(price => price.id.includes(pair))?.price, 10)
+        const avgPrice = toNumber(position.avgPrice, 10).toFixed(2)
+        const pnl = toNumber(calcPnlWithoutFee({
+          position: position,
+          executePrice: currentPrice,
+          decreaseOrder: { sizeDelta: position.size}
+        }), 6)
+        const pnlRate = ((pnl / collateral) * 100).toFixed(2)
+        return `${pair} (${leverage}x ${side})\nAvg Price: ${avgPrice}$\nCollateral: ${collateral.toFixed(2)}$\nPnL: ${pnlRate}% (${pnl.toFixed(2)}$)`
+      })
+      ].join("\n----------------------------\n")
+
+      if (callback) {
+        callback({ text: logs });
+      }
+      elizaLogger.info("Successfully get orders");
+      return true
+    } catch (error) {
+      elizaLogger.error("Error during get orders:", { message: error.message });
+      if (callback) {
+        callback({ text: `Error during get orders: ${error.message}` });
+      }
+      return false
+    }
+  },
+} as Action;

--- a/packages/plugin-merkle/src/actions/getPrice.ts
+++ b/packages/plugin-merkle/src/actions/getPrice.ts
@@ -1,0 +1,122 @@
+import { elizaLogger, generateObjectDeprecated } from "@elizaos/core";
+import {
+	type ActionExample,
+	type HandlerCallback,
+	type IAgentRuntime,
+	type Memory,
+	ModelClass,
+	type State,
+	type Action,
+} from "@elizaos/core";
+import { composeContext } from "@elizaos/core";
+import { GetPriceSchema } from "../types";
+import { checkEnv, newMerkleService } from "../utils";
+
+const getPriceTemplate = `Respond with a JSON markdown block containing only the extracted values. Use null for any values that cannot be determined.
+
+Example response:
+\`\`\`json
+{
+    "coinSymbol": "BTC"
+}
+\`\`\`
+
+{{recentMessages}}
+
+Given the recent messages, extract the following information about the requested futures position order:
+- coinSymbol : Coin symbol (Must be a valid coin symbol, Must be provided by the user)
+
+Respond with a JSON markdown block containing only the extracted values.`;
+
+export default {
+	name: "GET_PRICE",
+	similes: ["PRICE"],
+	description: "Get the price of the coin on the Merkle Trade platform",
+	examples: [
+    [
+      {
+        user: "{{user}}",
+        content: {
+          text: "What is the price of BTC?",
+        },
+      },
+      {
+        user: "{{agent}}",
+        content: {
+          text: "The price of BTC is 98000",
+          action: "GET_PRICE",
+        },
+      },
+    ]
+	] as ActionExample[][],
+	validate: async (runtime: IAgentRuntime) => {
+		return checkEnv(runtime);
+	},
+	handler: async (
+		runtime: IAgentRuntime,
+		message: Memory,
+		state: State,
+		_options: { [key: string]: unknown },
+		callback?: HandlerCallback,
+	): Promise<boolean> => {
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    let content: any;
+    try {
+      let currentState = state;
+      if (!currentState) {
+        currentState = (await runtime.composeState(message)) as State;
+      } else {
+        currentState = await runtime.updateRecentMessageState(currentState);
+      }
+
+      const context = composeContext({
+        state: currentState,
+        template: getPriceTemplate,
+      });
+
+      content = await generateObjectDeprecated({
+        runtime,
+        context: context,
+        modelClass: ModelClass.SMALL,
+      });
+
+      const parseResult = GetPriceSchema.safeParse(content);
+      if (!parseResult.success) {
+        throw new Error(
+          `Invalid get price content:\n${JSON.stringify(content, null, 2)}\n${JSON.stringify(parseResult.error.errors, null, 2)}`
+        );
+      }
+
+      const merkleService = await newMerkleService(runtime)
+      const summary = await merkleService.getSummary()
+      if (!summary) {
+        throw new Error("Summary not found")
+      }
+
+      const price = summary.prices.find(price => price.id.includes(content.coinSymbol))
+      if (!price) {
+        throw new Error("Price not found")
+      }
+
+      if (callback) {
+        callback({
+          text: `The price of ${content.coinSymbol} is ${price.price}`,
+          content: price,
+        });
+      }
+      elizaLogger.info("Successfully get price");
+      return true;
+    } catch (error) {
+      elizaLogger.error("Error during get price:", {
+        message: error.message,
+      });
+      if (callback) {
+        callback({
+          text: `Error during get price: ${error.message}`,
+          content: { error: error.message },
+        });
+      }
+      return false;
+    }
+	},
+} as Action;

--- a/packages/plugin-merkle/src/actions/openOrder.ts
+++ b/packages/plugin-merkle/src/actions/openOrder.ts
@@ -1,0 +1,274 @@
+import { elizaLogger, generateObjectDeprecated } from "@elizaos/core";
+import {
+	type ActionExample,
+	type HandlerCallback,
+	type IAgentRuntime,
+	type Memory,
+	ModelClass,
+	type State,
+	type Action,
+} from "@elizaos/core";
+import { composeContext } from "@elizaos/core";
+import type {
+	CommittedTransactionResponse,
+	PendingTransactionResponse,
+} from "@aptos-labs/ts-sdk";
+import { OpenOrderSchema } from "../types";
+import { checkEnv, newMerkleService } from "../utils";
+
+const openOrderTemplate = `Respond with a JSON markdown block containing only the extracted values. Use null for any values that cannot be determined.
+
+Example response:
+\`\`\`json
+{
+    "coinSymbol": "BTC",
+    "pay": 1000,
+    "leverage": 10,
+    "side": "LONG",
+    "type": "MARKET"
+}
+\`\`\`
+
+\`\`\`json
+{
+    "coinSymbol": "BTC",
+    "pay": 1000,
+    "leverage": 10,
+    "side": "SHORT",
+    "type": "LIMIT",
+    "limitOrderPrice": 98000
+}
+\`\`\`
+
+{{recentMessages}}
+
+Given the recent messages, extract the following information about the requested futures position order:
+- coinSymbol : Coin symbol (Must be a valid coin symbol, Must be provided by the user)
+- pay : Pay amount (Must be a number, Must be provided by the user)
+- leverage : Leverage (Must be 3 to 1000, Must be provided by the user)
+- type : Type of order (Must be "MARKET" or "LIMIT")
+- side : Side of the position (Must be "LONG" or "SHORT", Must be provided by the user)
+- limitOrderPrice : Limit order price (Must be a number, optional)
+
+Respond with a JSON markdown block containing only the extracted values.`;
+
+export default {
+	name: "OPEN_ORDER",
+	similes: [
+    "FUTURES_TRADE",
+    "OPEN_MARKET_ORDER",-
+		"OPEN_LIMIT_ORDER",
+		"BUY_LONG",
+		"BUT_SHORT",
+		"OPEN_POSITION",
+		"PLACE_ORDER",
+	],
+	description: "Open a futures position on the Merkle Trade platform",
+	examples: [
+		[
+			{
+				user: "{{user}}",
+				content: {
+					text: "Open a BTC Long position on the Merkle Trade platform with 1000 pay and 10 leverage",
+				},
+			},
+			{
+				user: "{{agent}}",
+				content: {
+					text: "Successfully market order BTC with 1000 pay and 10 leverage, Transaction: 0x104af5d1a786a2e1a4721a721b2cfccc7e15fa41eec15a489ba1768790adb523",
+					action: "OPEN_ORDER",
+				},
+			},
+		],
+    [
+			{
+				user: "{{user}}",
+				content: {
+					text: "Buy a BTC on the Merkle Trade platform with 100 pay and 100 leverage",
+				},
+			},
+      {
+        user: "{{agent}}",
+        content: {
+          text: "Is it a long position or a short position?"
+        },
+      },
+      {
+        user: "{{user}}",
+        content: {
+          text: "Short Position"
+        },
+      },
+			{
+				user: "{{agent}}",
+				content: {
+					text: "Successfully open short position BTC with 1000 pay and 10 leverage, Transaction: 0x104af5d1a786a2e1a4721a721b2cfccc7e15fa41eec15a489ba1768790adb523",
+					action: "OPEN_ORDER",
+				},
+			},
+    ],
+    [
+      {
+        user: "{{user}}",
+        content: {
+          text: "Open a BTC Long position on the Merkle Trade platform with 1000 pay and 10 leverage at 98000",
+        },
+      },
+      {
+        user: "{{agent}}",
+        content: {
+          text: "Successfully limit order BTC at 98000 with 1000 pay and 10 leverage, Transaction: 0x104af5d1a786a2e1a4721a721b2cfccc7e15fa41eec15a489ba1768790adb523",
+          action: "OPEN_ORDER",
+        },
+      },
+    ],
+    [
+      {
+        user: "{{user}}",
+        content: {
+          text: "Execute a ETH limit order on the Merkle Trade platform with 1000 pay and 10 leverage at 98000",
+        },
+      },
+      {
+        user: "{{agent}}",
+        content: {
+          text: "Is it a long position or a short position?"
+        },
+      },
+      {
+        user: "{{user}}",
+        content: {
+          text: "Long Position"
+        },
+      },
+      {
+        user: "{{agent}}",
+        content: {
+          text: "Successfully limit long order ETH at 98000 with 1000 pay, 10 leverage, Transaction: 0x104af5d1a786a2e1a4721a721b2cfccc7e15fa41eec15a489ba1768790adb523",
+          action: "OPEN_ORDER",
+        },
+      },
+    ]
+	] as ActionExample[][],
+	validate: async (runtime: IAgentRuntime) => {
+		return checkEnv(runtime);
+	},
+	handler: async (
+		runtime: IAgentRuntime,
+		message: Memory,
+		state: State,
+		_options: { [key: string]: unknown },
+		callback?: HandlerCallback,
+	): Promise<boolean> => {
+    // biome-ignore lint/suspicious/noExplicitAny: <explanation>
+    let content: any;
+    try {
+      let currentState = state;
+      if (!currentState) {
+        currentState = (await runtime.composeState(message)) as State;
+      } else {
+        currentState = await runtime.updateRecentMessageState(currentState);
+      }
+
+      const context = composeContext({
+        state: currentState,
+        template: openOrderTemplate,
+      });
+
+      content = await generateObjectDeprecated({
+        runtime,
+        context: context,
+        modelClass: ModelClass.LARGE,
+      });
+
+      if (content && typeof content.pay === "string") {
+        content.pay = Number.parseFloat(content.pay);
+      }
+      if (content && typeof content.leverage === "string") {
+        content.leverage = Number.parseFloat(content.leverage);
+      }
+      if (content && typeof content.side === "string") {
+        switch (content.side.toUpperCase()) {
+          case "LONG":
+            content.side = "LONG";
+            break;
+          case "SHORT":
+            content.side = "SHORT";
+            break;
+          default:
+            throw new Error("Must be provide a valid side. Long or Short");
+        }
+      }
+      if (content && typeof content.type === "string") {
+        switch (content.type.toUpperCase()) {
+          case "MARKET":
+            content.type = "MARKET";
+            break;
+          case "LIMIT":
+            content.type = "LIMIT";
+            break;
+          default:
+            throw new Error("Invalid type");
+        }
+      }
+      if (content && typeof content.limitOrderPrice === "string") {
+        content.limitOrderPrice = content.limitOrderPrice === "null" ? null : Number.parseFloat(content.limitOrderPrice);
+      }
+
+      const parseResult = OpenOrderSchema.safeParse(content);
+      if (!parseResult.success) {
+        throw new Error(
+          `Invalid open order content:\n${JSON.stringify(content, null, 2)}\n${JSON.stringify(parseResult.error.errors, null, 2)}`
+        );
+      }
+
+      const merkleService = await newMerkleService(runtime)
+
+      let tx: PendingTransactionResponse | CommittedTransactionResponse;
+      if (content && typeof content.type === "string" && content.type === "LIMIT") {
+        tx = await merkleService.placeLimitOrder({
+          pair: content.coinSymbol,
+          pay: content.pay,
+          leverage: content.leverage,
+          isLong: content.side === "LONG",
+          limitOrderPrice: content.limitOrderPrice,
+        })
+        if (callback) {
+          callback({
+            text: `Successfully limit order ${content.coinSymbol} at ${content.limitOrderPrice} with ${content.pay} pay, ${content.leverage} leverage, and ${content.side} position, Transaction: ${tx.hash}`,
+            content: tx,
+          });
+        }
+      } else {
+        tx = await merkleService.placeMarketOrder({
+          pair: content.coinSymbol,
+          pay: content.pay,
+          leverage: content.leverage,
+          isLong: content.side === "LONG",
+        })
+
+        if (callback) {
+          callback({
+            text: `Successfully market order ${content.coinSymbol} with ${content.pay} pay, ${content.leverage} leverage, and ${content.side} position, Transaction: ${tx.hash}`,
+            content: tx,
+          });
+        }
+      }
+
+      elizaLogger.log("Open order successful:", tx.hash);
+      return true;
+    } catch (error) {
+      elizaLogger.error("Error during open order:", {
+        content,
+        message: error.message,
+      });
+      if (callback) {
+        callback({
+          text: `Error during open order: ${error.message}`,
+          content: { error: error.message },
+        });
+      }
+      return false;
+    }
+	},
+} as Action;

--- a/packages/plugin-merkle/src/actions/openOrder.ts
+++ b/packages/plugin-merkle/src/actions/openOrder.ts
@@ -56,10 +56,10 @@ export default {
 	name: "OPEN_ORDER",
 	similes: [
     "FUTURES_TRADE",
-    "OPEN_MARKET_ORDER",-
+    "OPEN_MARKET_ORDER",
 		"OPEN_LIMIT_ORDER",
 		"BUY_LONG",
-		"BUT_SHORT",
+		"BUY_SHORT",
 		"OPEN_POSITION",
 		"PLACE_ORDER",
 	],

--- a/packages/plugin-merkle/src/enviroment.ts
+++ b/packages/plugin-merkle/src/enviroment.ts
@@ -4,10 +4,10 @@ import { z } from "zod";
 export const merkleTradeEnvSchema = z.object({
 	MERKLE_TRADE_NETWORK: z
 		.string()
-		.min(1, "Merkle Aptos private key is required"),
-	MERKLE_TRADE_APTOS_ACCOUNT_ADDRESS: z
+		.min(1, "Merkle Aptos network is required"),
+  MERKLE_TRADE_APTOS_PRIVATE_KEY: z
 		.string()
-		.min(1, "Merkle Aptos account address is required"),
+		.min(1, "Merkle Aptos private key is required"),
 });
 
 export type MerkleTradeConfig = z.infer<typeof merkleTradeEnvSchema>;

--- a/packages/plugin-merkle/src/enviroment.ts
+++ b/packages/plugin-merkle/src/enviroment.ts
@@ -1,0 +1,40 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { z } from "zod";
+
+export const merkleTradeEnvSchema = z.object({
+	MERKLE_TRADE_NETWORK: z
+		.string()
+		.min(1, "Merkle Aptos private key is required"),
+	MERKLE_TRADE_APTOS_ACCOUNT_ADDRESS: z
+		.string()
+		.min(1, "Merkle Aptos account address is required"),
+});
+
+export type MerkleTradeConfig = z.infer<typeof merkleTradeEnvSchema>;
+
+export async function validateConfig(
+	runtime: IAgentRuntime,
+): Promise<MerkleTradeConfig> {
+	try {
+		const config = {
+			MERKLE_TRADE_NETWORK:
+				runtime.getSetting("MERKLE_TRADE_NETWORK") ||
+				process.env.MERKLE_TRADE_NETWORK,
+			MERKLE_TRADE_APTOS_PRIVATE_KEY:
+				runtime.getSetting("MERKLE_TRADE_APTOS_PRIVATE_KEY") ||
+				process.env.MERKLE_TRADE_APTOS_PRIVATE_KEY,
+		};
+
+		return merkleTradeEnvSchema.parse(config);
+	} catch (error) {
+		if (error instanceof z.ZodError) {
+			const errorMessages = error.errors
+				.map((err) => `${err.path.join(".")}: ${err.message}`)
+				.join("\n");
+			throw new Error(
+				`Merkle Trade configuration validation failed:\n${errorMessages}`,
+			);
+		}
+		throw error;
+	}
+}

--- a/packages/plugin-merkle/src/index.ts
+++ b/packages/plugin-merkle/src/index.ts
@@ -1,0 +1,21 @@
+import type { Plugin } from "@elizaos/core";
+import openOrder from "./actions/openOrder.ts";
+import fullyClosePosition from "./actions/fullyClosePosition.ts";
+import getOrder from "./actions/getOrder.ts";
+import getPosition from "./actions/getPosition.ts";
+import getBalance from "./actions/getBalance.ts";
+import getPrice from "./actions/getPrice.js";
+
+const merklePlugin: Plugin = {
+	name: "merkle",
+	description: "Merkle Plugin for Eliza",
+	actions: [openOrder, fullyClosePosition, getOrder, getPosition, getBalance, getPrice],
+	evaluators: [],
+  services: [],
+	providers: [],
+};
+
+export * from "./services.ts";
+export * from "./utils";
+export { merklePlugin };
+export default merklePlugin;

--- a/packages/plugin-merkle/src/services.ts
+++ b/packages/plugin-merkle/src/services.ts
@@ -247,7 +247,7 @@ export class MerkleService {
 	async getSummary() {
     try {
       const cachedSummary = this.cache.get<Summary>(`${this.cacheKey}/summary`);
-      if (cachedSummary) {;
+      if (cachedSummary) {
         return cachedSummary;
       }
       const summary = await this.client.getSummary();

--- a/packages/plugin-merkle/src/services.ts
+++ b/packages/plugin-merkle/src/services.ts
@@ -1,0 +1,275 @@
+import { type Account, Aptos, type CommittedTransactionResponse } from "@aptos-labs/ts-sdk";
+import { elizaLogger } from "@elizaos/core";
+import {
+	MerkleClient,
+  AptosHelpers,
+	calcEntryByPaySize,
+	fromNumber,
+	Decimals,
+  raise,
+  type SummaryPair,
+	type Summary,
+	type MerkleClientConfig,
+  type Position,
+  type Hex,
+  type Order,
+  type WSAPISession,
+} from "@merkletrade/ts-sdk";
+import NodeCache from "node-cache";
+import { firstAsync, sendTransaction, withTimeout } from "./utils";
+
+export class MerkleService {
+	private client: MerkleClient;
+  private aptos: Aptos;
+  private aptosHelper: AptosHelpers;
+  private cache: NodeCache;
+  private cacheKey = "merkle/provider";
+
+  private account: Account;
+  private summary: Summary;
+
+	constructor(config: MerkleClientConfig, account: Account) {
+		this.client = new MerkleClient(config);
+		this.aptosHelper = new AptosHelpers(config);
+		this.cache = new NodeCache({ stdTTL: 300 });
+    this.account = account;
+    this.summary = config.summary;
+    this.aptos = new Aptos(config.aptosConfig);
+	}
+
+  /**
+   * Trading operations
+   */
+
+  /**
+   * Place a market order
+   * @param pair string
+   * @param pay number
+   * @param leverage number
+   * @param isLong boolean
+   * @returns Transaction
+   */
+	async placeMarketOrder({
+		pair,
+		pay,
+		leverage,
+		isLong,
+	}: {
+		pair: string;
+		pay: number;
+		leverage: number;
+		isLong: boolean;
+	}) {
+		const pairInfo = await this.client.getPairInfo({pairId: pair});
+		const pairState = await this.client.getPairState({pairId: pair});
+		const payWithDecimals = fromNumber(pay, Decimals.COLLATERAL);
+
+		const { collateral, size } = calcEntryByPaySize(
+			payWithDecimals,
+			leverage,
+			isLong,
+			pairInfo,
+			pairState,
+		);
+
+    const payload = this.client.payloads.placeMarketOrder({
+      pair: pairInfo.pairType,
+      userAddress: this.getAccountAddress(),
+      sizeDelta: size,
+      collateralDelta: collateral,
+      isLong,
+      isIncrease: true,
+    })
+
+    return await sendTransaction(this.aptos, this.account, payload);
+	}
+
+  /**
+   * Place a limit order
+   * @param pair string
+   * @param pay number
+   * @param leverage number
+   * @param isLong boolean
+   * @param limitOrderPrice number
+   * @returns Transaction
+   */
+  async placeLimitOrder({
+    pair,
+    pay,
+    leverage,
+    isLong,
+    limitOrderPrice,
+  }: {
+    pair: string;
+    pay: number;
+    leverage: number;
+    isLong: boolean;
+    limitOrderPrice: number;
+  }) {
+    const pairInfo = await this.client.getPairInfo({pairId: pair});
+    const pairState = await this.client.getPairState({pairId: pair});
+    const payWithDecimals = fromNumber(pay, Decimals.COLLATERAL);
+
+    const { collateral, size } = calcEntryByPaySize(
+      payWithDecimals,
+      leverage,
+      isLong,
+      pairInfo,
+      pairState,
+    );
+
+    const payload = this.client.payloads.placeLimitOrder({
+      pair: pairInfo.pairType,
+      userAddress: this.getAccountAddress(),
+      sizeDelta: size,
+      collateralDelta: collateral,
+      price: fromNumber(limitOrderPrice, Decimals.PRICE),
+      isLong,
+      isIncrease: true,
+    })
+
+    return await sendTransaction(this.aptos, this.account, payload);
+  }
+
+  /**
+   * Close all positions
+   * @returns Transaction[]
+   */
+  async closeAllPositions() {
+    const positions = await this.getPositions();
+    const txs: CommittedTransactionResponse[] = [];
+    for (const position of positions) { 
+      const tx = await this.closePosition(position);
+      txs.push(tx);
+    }
+    return txs;
+  }
+
+  /**
+   * Close a position
+   * @param position Position
+   * @returns Transaction
+   */
+  async closePosition(position: Position) {
+    try {
+      const payload = this.client.payloads.placeMarketOrder({
+        pair: position.pairType,
+        userAddress: this.getAccountAddress(),
+        sizeDelta: position.size,
+        collateralDelta: position.collateral,
+        isLong: position.isLong,
+        isIncrease: false,
+      });
+      const tx = await sendTransaction(this.aptos, this.account, payload)
+      return tx;
+    } catch (error) {
+      throw this.handleError(error, "closePosition");
+    }
+  }
+
+  /**
+   * Account-related operations
+   */
+	getAccount(): Account {
+		return this.account;
+	}
+
+  /**
+   * Get account address
+   * @returns Hex
+   */
+	getAccountAddress(): Hex {
+		return this.account.accountAddress.toStringLong();
+	}
+
+  /**
+   * Get positions of the account
+   * @returns Position[]
+   */
+	async getPositions(): Promise<Position[]> {
+    const address = this.getAccountAddress();
+    try {
+      return await this.client.getPositions({address});
+    } catch (error) {
+      throw this.handleError(error, `getPositions: ${address}`);
+    }
+	}
+
+  /**
+   * Get orders of the account
+   * @returns Order[]
+   */
+	async getOrders(): Promise<Order[]> {
+    const address = this.getAccountAddress();
+    try {
+      return await this.client.getOrders({address});
+    } catch (error) {
+      throw this.handleError(error, `getOrders: ${address}`);
+    }
+	}
+
+  /**
+   * Get balance of the account
+   * @returns AccountBalance
+   */
+	async getBalance(): Promise<AccountBalance> {
+    try{
+      const usdcBalance = await this.aptosHelper.getUsdcBalance(this.account);
+      return { usdc: usdcBalance } satisfies AccountBalance;
+    } catch (error) {
+      throw this.handleError(error, "getBalance");
+    }
+	}
+
+  /**
+   * Market-related operations
+   */
+  async getLatestPrice(pair: string) {
+    let session: WSAPISession | undefined;
+    try {
+      const pairInfo = this.getPair(pair);
+      session = await this.client.connectWsApi();
+      await session.connect();
+      const priceFeed = session.subscribePriceFeed(pairInfo.id);
+      const price = await withTimeout(firstAsync(priceFeed), 5000);
+      return price;
+    } catch (error) {
+      throw this.handleError(error, "getLatestPrice");
+    } finally {
+      session?.disconnect();
+    }
+  }
+
+  /**
+   * Get summary of the account
+   * @returns SummaryResponse
+   */
+	async getSummary() {
+    try {
+      const cachedSummary = this.cache.get<Summary>(`${this.cacheKey}/summary`);
+      if (cachedSummary) {;
+        return cachedSummary;
+      }
+      const summary = await this.client.getSummary();
+      this.cache.set(`${this.cacheKey}/summary`, summary);
+      return summary;
+    } catch (error) {
+      throw this.handleError(error, "getSummary");
+    }
+	}
+
+  private getPair(rawPair: string): SummaryPair {
+    return this.summary.pairs.find((pair) => pair.id.toUpperCase().includes(rawPair.toUpperCase())) ?? raise("Pair not found");
+  }
+
+  private handleError(error: unknown, context?: string): never {
+		elizaLogger.error("Unexpected error: ", { context, error });
+		throw error;
+	}
+}
+
+export type AccountBalance = {
+	usdc: Decimals.Collateral;
+};
+
+export default MerkleService;

--- a/packages/plugin-merkle/src/types/actions.ts
+++ b/packages/plugin-merkle/src/types/actions.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const OpenOrderSchema = z.object({
+	coinSymbol: z.string().toUpperCase(),
+	pay: z.number(),
+	leverage: z.number(),
+	type: z.enum(["MARKET", "LIMIT"]),
+	side: z.enum(["LONG", "SHORT"]),
+  limitOrderPrice: z.number().optional().nullable(),
+});
+
+export const FullyClosePositionSchema = z.object({
+  coinSymbol: z.string().toUpperCase(),
+  side: z.enum(["LONG", "SHORT"]),
+});
+
+export const GetPriceSchema = z.object({
+  coinSymbol: z.string().toUpperCase(),
+});

--- a/packages/plugin-merkle/src/types/index.ts
+++ b/packages/plugin-merkle/src/types/index.ts
@@ -1,0 +1,2 @@
+export * from "./service";
+export * from "./actions";

--- a/packages/plugin-merkle/src/types/service.ts
+++ b/packages/plugin-merkle/src/types/service.ts
@@ -1,0 +1,2 @@
+import type { Decimals } from "@merkletrade/ts-sdk";
+

--- a/packages/plugin-merkle/src/utils.ts
+++ b/packages/plugin-merkle/src/utils.ts
@@ -1,0 +1,52 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { MerkleService } from "./services";
+import { Account, type Aptos, Ed25519PrivateKey, type InputEntryFunctionData, PrivateKey, PrivateKeyVariants } from "@aptos-labs/ts-sdk";
+import { MerkleClientConfig } from "@merkletrade/ts-sdk";
+
+export const checkEnv = (runtime: IAgentRuntime) => {
+  return !!(
+    runtime.getSetting("MERKLE_TRADE_LOG_LEVEL") &&
+    runtime.getSetting("MERKLE_TRADE_APTOS_PRIVATE_KEY") &&
+    runtime.getSetting("MERKLE_TRADE_NETWORK")
+  );
+};
+
+export const newMerkleService = async (runtime: IAgentRuntime) => {
+  const network = runtime.getSetting("MERKLE_TRADE_NETWORK")
+  const config = network === "mainnet" ? await MerkleClientConfig.mainnet() : await MerkleClientConfig.testnet()
+  const merkleAccount = Account.fromPrivateKey({
+    privateKey: new Ed25519PrivateKey(
+      PrivateKey.formatPrivateKey(runtime.getSetting("MERKLE_TRADE_APTOS_PRIVATE_KEY"), PrivateKeyVariants.Ed25519),
+    ),
+  });
+  const merkleService = new MerkleService(config, merkleAccount)
+  return merkleService
+}
+
+export const firstAsync = async <T>(iterable: AsyncIterable<T>): Promise<T> => {
+  for await (const value of iterable) {
+    return value;
+  }
+  throw new Error("Failed to get value from async iterable");
+}
+
+export const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T> => {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Timeout: ${ms}ms exceeded`)), ms);
+    promise
+      .then(resolve, reject)
+      .finally(() => clearTimeout(timer));
+  });
+}
+
+export const sendTransaction = async (aptos: Aptos, account: Account, payload: InputEntryFunctionData) => {
+  const transaction = await aptos.transaction.build.simple({
+    sender: account.accountAddress,
+    data: payload,
+  });
+  const { hash } = await aptos.signAndSubmitTransaction({
+    signer: account,
+    transaction,
+  });
+  return await aptos.waitForTransaction({ transactionHash: hash });
+}

--- a/packages/plugin-merkle/tsconfig.json
+++ b/packages/plugin-merkle/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../core/tsconfig.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "src"
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/packages/plugin-merkle/tsup.config.ts
+++ b/packages/plugin-merkle/tsup.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+	entry: ["src/index.ts"],
+	outDir: "dist",
+	sourcemap: true,
+	clean: true,
+	format: ["esm"],
+	dts: true,
+	minify: false,
+	splitting: false,
+	external: [
+		"@elizaos/core",
+		"@aptos-labs/ts-sdk",
+		"bignumber",
+		"bignumber.js",
+		"dotenv",
+		"fs",
+		"path",
+		"@reflink/reflink",
+		"@node-llama-cpp",
+		"https",
+		"http",
+		"agentkeepalive",
+		"safe-buffer",
+		"base-x",
+		"bs58",
+		"borsh",
+		"stream",
+		"buffer",
+		"querystring",
+		"amqplib",
+	],
+	noExternal: [],
+	esbuildOptions(options) {
+		options.platform = "node";
+	},
+});


### PR DESCRIPTION
# Relates to
Aptos Blockchain & Merkle Trade

# Risks
Medium

# Background https://github.com/elizaOS/eliza/issues/3564

This is the first PR that introduces the Merkle Trade plugin to elizaos. I am a developer at [Merkle Trade](https://merkle.trade/), and we plan to integrate our plugin into elizaos to enable robust trading functionality on the Aptos blockchain. This integration is set to be showcased at Consensus HK2025, which you can learn more about here: [Consensus HK2025](https://consensus-hongkong2025.coindesk.com/).

## What does this PR do?
Introduces the Merkle Trade plugin to enable Eliza agents to interact with the Merkle Trade platform on the Aptos blockchain.

## What kind of change is this?
Features (non-breaking change which adds functionality)

### Details:
- Adds the ability for Eliza agents to perform trading operations using the Merkle Trade plugin.
- Enhances the user experience for agents interacting with the Merkle Trade platform.

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?
Review the integration points between the Eliza agents and the Merkle Trade plugin, ensuring the communication with the Aptos blockchain is functioning as expected.

## Detailed testing steps
- Rnn tests locally
- All tests passed successfully

# Deploy Notes
No additional deployment instructions are required beyond the standard CI/CD process.

# Database changes
No database changes.

# Deployment instructions
Automated deployment via our CI/CD pipeline.

# Discord username
@coldbell






