### PR TITLE
feat: add plugin viction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -413,6 +413,11 @@ BASE_MINT=So11111111111111111111111111111111111111112
 SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
 HELIUS_API_KEY=
 
+# Viction Configuration
+VICTION_ADDRESS=
+VICTION_PRIVATE_KEY=
+VICTION_RPC_URL=
+
 # Abstract Configuration
 ABSTRACT_ADDRESS=
 ABSTRACT_PRIVATE_KEY=
@@ -967,4 +972,3 @@ BUNDLE_EXECUTOR_ADDRESS=          # Address of the bundle executor contract
 # DESK Exchange Plugin Configration
 DESK_EXCHANGE_PRIVATE_KEY=                  # Required for trading and cancelling orders
 DESK_EXCHANGE_NETWORK=                      # "mainnet" or "testnet
-

--- a/agent/package.json
+++ b/agent/package.json
@@ -152,6 +152,7 @@
         "@elizaos/plugin-near": "workspace:*",
         "@elizaos/plugin-stargaze": "workspace:*",
         "@elizaos/plugin-zksync-era": "workspace:*",
+        "@elizaos/plugin-viction": "workspace:*",
         "readline": "1.3.0",
         "ws": "8.18.0",
         "yargs": "17.7.2"

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -157,7 +157,7 @@ import { ankrPlugin } from "@elizaos/plugin-ankr";
 import { formPlugin } from "@elizaos/plugin-form";
 import { MongoClient } from "mongodb";
 import { quickIntelPlugin } from "@elizaos/plugin-quick-intel";
-
+import { victionPlugin } from "@elizaos/plugin-viction";
 import { trikonPlugin } from "@elizaos/plugin-trikon";
 import arbitragePlugin from "@elizaos/plugin-arbitrage";
 const __filename = fileURLToPath(import.meta.url); // get the resolved path to the file
@@ -1050,6 +1050,10 @@ export async function createAgent(
                 ? nitroPlugin
                 : null,
             getSecret(character, "TAVILY_API_KEY") ? webSearchPlugin : null,
+            (getSecret(character, "VICTION_ADDRESS") &&
+                getSecret(character, "VICTION_ADDRESS")?.startsWith("0x"))
+                ? victionPlugin
+                : null,
             getSecret(character, "SOLANA_PUBLIC_KEY") ||
             (getSecret(character, "WALLET_PUBLIC_KEY") &&
                 !getSecret(character, "WALLET_PUBLIC_KEY")?.startsWith("0x"))

--- a/packages/plugin-viction/.npmignore
+++ b/packages/plugin-viction/.npmignore
@@ -1,0 +1,6 @@
+*
+
+!dist/**
+!package.json
+!readme.md
+!tsup.config.ts

--- a/packages/plugin-viction/README.MD
+++ b/packages/plugin-viction/README.MD
@@ -1,0 +1,178 @@
+# @elizaos/plugin-viction
+
+Core Viction blockchain plugin for Eliza OS that provides essential services and actions for token operations, trading, and DeFi integrations.
+
+## Overview
+
+The Viction plugin serves as a foundational component of Eliza OS, bridging Viction blockchain capabilities with the Eliza ecosystem. It provides crucial services for token operations, trading, portfolio management, and DeFi integrations, enabling both automated and user-directed interactions with the Viction blockchain.
+
+## Features
+
+### Token Operations
+- **Token Information**: Provide Viction information
+- **Token Transfers**: Send and receive tokens securely native and non-native
+
+## Installation
+
+```bash
+npm install @elizaos/plugin-viction
+```
+
+## Configuration
+
+Configure the plugin by setting the following environment variables:
+
+```typescript
+const victionEnvSchema = {
+    VICTION_ADDRESS: string,
+    VICTION_PRIVATE_KEY: string,
+    VICTION_RPC_URL: string
+};
+```
+
+## Usage
+
+### Basic Setup
+
+```typescript
+import { victionPlugin } from "@elizaos/plugin-viction";
+
+// Initialize the plugin
+const runtime = await initializeRuntime({
+    plugins: [victionPlugin],
+});
+```
+
+## Actions
+
+### vic_infomations
+
+Provide Viction's information
+
+```typescript
+// Example usage
+const result = await runtime.executeAction("GIVE_VICTION_INFOMATION", {});
+```
+
+### transferVic
+
+Transfers VIC between wallets.
+
+```typescript
+// Example usage
+const result = await runtime.executeAction("SEND_VIC", {
+    recipient: "RecipientAddressHere",
+    amount: "1000",
+});
+```
+### transferTokens
+
+Transfers tokens between wallets.
+
+```typescript
+// Example usage
+const result = await runtime.executeAction("SEND_TOKEN", {
+    recipient: "RecipientAddressHere",
+    tokenAddress: "TokenAddressHere"
+    amount: "1000",
+});
+```
+## Performance Optimization
+
+1. **Cache Management**
+
+    - Implement token data caching
+    - Configure cache TTL settings
+    - Monitor cache hit rates
+
+2. **RPC Optimization**
+
+    - Use connection pooling
+    - Implement request batching
+    - Monitor RPC usage
+
+3. **Transaction Management**
+    - Optimize transaction bundling
+    - Implement retry strategies
+    - Monitor transaction success rates
+
+## System Requirements
+
+- Node.js 16.x or higher
+- Minimum 4GB RAM recommended
+- Stable internet connection
+- Access to Viction RPC endpoint
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Wallet Connection Failures**
+
+```bash
+Error: Failed to connect to wallet
+```
+
+- Verify RPC endpoint is accessible
+- Check wallet configuration settings
+- Ensure proper network selection
+
+2. **Transaction Errors**
+
+```bash
+Error: Transaction failed
+```
+
+- Check account balances
+- Verify transaction parameters
+- Ensure proper fee configuration
+
+
+## Safety & Security
+
+### Best Practices
+
+1. **Environment Variables**
+
+    - Store sensitive keys in environment variables
+    - Use .env.example for non-sensitive defaults
+    - Never commit real credentials to version control
+
+## Performance Optimization
+
+1. **Cache Management**
+
+    - Implement token data caching
+    - Configure cache TTL settings
+    - Monitor cache hit rates
+
+2. **RPC Optimization**
+
+    - Use connection pooling
+    - Implement request batching
+    - Monitor RPC usage
+
+3. **Transaction Management**
+    - Optimize transaction bundling
+    - Implement retry strategies
+    - Monitor transaction success rates
+
+## Support
+
+For issues and feature requests, please:
+
+1. Check the troubleshooting guide above
+2. Review existing GitHub issues
+3. Submit a new issue with:
+    - System information
+    - Error logs
+    - Steps to reproduce
+    - Transaction IDs (if applicable)
+
+## Contributing
+
+Contributions are welcome! Please see the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information.
+
+## License
+
+This plugin is part of the Eliza project. See the main project repository for license information.

--- a/packages/plugin-viction/package.json
+++ b/packages/plugin-viction/package.json
@@ -1,0 +1,36 @@
+{
+    "name": "@elizaos/plugin-viction",
+    "version": "0.1.0-alpha.1",
+    "type": "module",
+    "main": "dist/index.js",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "exports": {
+        "./package.json": "./package.json",
+        ".": {
+            "import": {
+                "@elizaos/source": "./src/index.ts",
+                "types": "./dist/index.d.ts",
+                "default": "./dist/index.js"
+            }
+        }
+    },
+    "files": [
+        "dist"
+    ],
+    "dependencies": {
+        "web3": "1.8.1",
+        "@elizaos/core": "workspace:*",
+        "tsup": "8.3.5",
+        "vitest": "2.1.4"
+    },
+    "scripts": {
+        "build": "tsup --format esm --dts",
+        "dev": "tsup --format esm --dts --watch",
+        "test": "vitest run"
+    },
+    "peerDependencies": {
+        "form-data": "4.0.1",
+        "whatwg-url": "7.1.0"
+    }
+}

--- a/packages/plugin-viction/src/abi/index.ts
+++ b/packages/plugin-viction/src/abi/index.ts
@@ -1,0 +1,1 @@
+export * from './token'

--- a/packages/plugin-viction/src/abi/token.ts
+++ b/packages/plugin-viction/src/abi/token.ts
@@ -1,0 +1,288 @@
+export const ERC20ABI = [
+    {
+      inputs: [
+        {
+          internalType: 'string',
+          name: 'name_',
+          type: 'string'
+        },
+        {
+          internalType: 'string',
+          name: 'symbol_',
+          type: 'string'
+        }
+      ],
+      stateMutability: 'nonpayable',
+      type: 'constructor'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'owner',
+          type: 'address'
+        },
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'spender',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'value',
+          type: 'uint256'
+        }
+      ],
+      name: 'Approval',
+      type: 'event'
+    },
+    {
+      anonymous: false,
+      inputs: [
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'from',
+          type: 'address'
+        },
+        {
+          indexed: true,
+          internalType: 'address',
+          name: 'to',
+          type: 'address'
+        },
+        {
+          indexed: false,
+          internalType: 'uint256',
+          name: 'value',
+          type: 'uint256'
+        }
+      ],
+      name: 'Transfer',
+      type: 'event'
+    },
+    {
+      inputs: [
+        {
+          internalType: 'address',
+          name: 'owner',
+          type: 'address'
+        },
+        {
+          internalType: 'address',
+          name: 'spender',
+          type: 'address'
+        }
+      ],
+      name: 'allowance',
+      outputs: [
+        {
+          internalType: 'uint256',
+          name: '',
+          type: 'uint256'
+        }
+      ],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [
+        {
+          internalType: 'address',
+          name: 'spender',
+          type: 'address'
+        },
+        {
+          internalType: 'uint256',
+          name: 'amount',
+          type: 'uint256'
+        }
+      ],
+      name: 'approve',
+      outputs: [
+        {
+          internalType: 'bool',
+          name: '',
+          type: 'bool'
+        }
+      ],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [
+        {
+          internalType: 'address',
+          name: 'account',
+          type: 'address'
+        }
+      ],
+      name: 'balanceOf',
+      outputs: [
+        {
+          internalType: 'uint256',
+          name: '',
+          type: 'uint256'
+        }
+      ],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [],
+      name: 'decimals',
+      outputs: [
+        {
+          internalType: 'uint8',
+          name: '',
+          type: 'uint8'
+        }
+      ],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [
+        {
+          internalType: 'address',
+          name: 'spender',
+          type: 'address'
+        },
+        {
+          internalType: 'uint256',
+          name: 'subtractedValue',
+          type: 'uint256'
+        }
+      ],
+      name: 'decreaseAllowance',
+      outputs: [
+        {
+          internalType: 'bool',
+          name: '',
+          type: 'bool'
+        }
+      ],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [
+        {
+          internalType: 'address',
+          name: 'spender',
+          type: 'address'
+        },
+        {
+          internalType: 'uint256',
+          name: 'addedValue',
+          type: 'uint256'
+        }
+      ],
+      name: 'increaseAllowance',
+      outputs: [
+        {
+          internalType: 'bool',
+          name: '',
+          type: 'bool'
+        }
+      ],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [],
+      name: 'name',
+      outputs: [
+        {
+          internalType: 'string',
+          name: '',
+          type: 'string'
+        }
+      ],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [],
+      name: 'symbol',
+      outputs: [
+        {
+          internalType: 'string',
+          name: '',
+          type: 'string'
+        }
+      ],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [],
+      name: 'totalSupply',
+      outputs: [
+        {
+          internalType: 'uint256',
+          name: '',
+          type: 'uint256'
+        }
+      ],
+      stateMutability: 'view',
+      type: 'function'
+    },
+    {
+      inputs: [
+        {
+          internalType: 'address',
+          name: 'recipient',
+          type: 'address'
+        },
+        {
+          internalType: 'uint256',
+          name: 'amount',
+          type: 'uint256'
+        }
+      ],
+      name: 'transfer',
+      outputs: [
+        {
+          internalType: 'bool',
+          name: '',
+          type: 'bool'
+        }
+      ],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    },
+    {
+      inputs: [
+        {
+          internalType: 'address',
+          name: 'sender',
+          type: 'address'
+        },
+        {
+          internalType: 'address',
+          name: 'recipient',
+          type: 'address'
+        },
+        {
+          internalType: 'uint256',
+          name: 'amount',
+          type: 'uint256'
+        }
+      ],
+      name: 'transferFrom',
+      outputs: [
+        {
+          internalType: 'bool',
+          name: '',
+          type: 'bool'
+        }
+      ],
+      stateMutability: 'nonpayable',
+      type: 'function'
+    }
+]

--- a/packages/plugin-viction/src/actions/transfer.ts
+++ b/packages/plugin-viction/src/actions/transfer.ts
@@ -1,0 +1,190 @@
+import {
+    type ActionExample,
+    type Content,
+    type HandlerCallback,
+    type IAgentRuntime,
+    type Memory,
+    type State,
+    type Action,
+    ModelClass
+} from "@elizaos/core";
+import { generateObjectDeprecated } from "@elizaos/core";
+import { elizaLogger } from "@elizaos/core";
+import { composeContext } from "@elizaos/core";
+import Web3 from 'web3'
+import { ERC20ABI } from "../abi";
+import { unit } from "../constants";
+
+const { toWei, toHex } = Web3.utils
+
+export interface TransferContent extends Content {
+    tokenAddress: string;
+    recipient: string;
+    amount: string | number;
+}
+
+function isTransferContent(
+    _runtime: IAgentRuntime,
+    content: any,
+): content is TransferContent {
+    elizaLogger.log("Content for transfer", content);
+    return (
+        typeof content.tokenAddress === "string" &&
+        typeof content.recipient === "string" &&
+        (typeof content.amount === "string" ||
+            typeof content.amount === "number")
+    );
+}
+
+const transferTemplate = `Respond with a JSON markdown block containing only the extracted values. Use null for any values that cannot be determined.
+
+Example response:
+\`\`\`json
+{
+    "tokenAddress": "0x0Fd0288AAAE91eaF935e2eC14b23486f86516c8C",
+    "recipient": "0xe3FE2dc5Bd9c5516D3895ab3A931b5B545De658E",
+    "amount": "98"
+}
+\`\`\`
+
+{{recentMessages}}
+
+Extract the following information about the requested token transfer:
+- Token contract address
+- Recipient wallet address
+- Amount to transfer
+
+If no token address is mentioned, respond with null.
+`;
+
+
+export default {
+    name: "SEND_TOKEN",
+    similes: [
+        "TRANSFER_TOKEN",
+        "TRANSFER_TOKENS",
+        "SEND_TOKENS",
+        "PAY_TOKEN",
+        "PAY_TOKENS",
+        "PAY",
+    ],
+    validate: async (_runtime: IAgentRuntime, message: Memory) => {
+        // Always retrn true for token transfers, letting the handler deal with specifics
+        elizaLogger.log("Validating token transfer from user:", message.userId);
+        return true;
+    },
+    description: "Transfer Viciotn tokens from agent's wallet to another address",
+    handler: async (
+        runtime: IAgentRuntime,
+        message: Memory,
+        state: State,
+        _options: { [key: string]: unknown },
+        callback?: HandlerCallback,
+    ): Promise<boolean> => {
+        elizaLogger.log("Starting SEND_TOKEN handler...");
+
+        if (!state) {
+            state = (await runtime.composeState(message)) as State;
+        } else {
+            state = await runtime.updateRecentMessageState(state);
+        }
+
+        const transferContext = composeContext({
+            state,
+            template: transferTemplate,
+        });
+
+        const content = await generateObjectDeprecated({
+            runtime,
+            context: transferContext,
+            modelClass: ModelClass.LARGE,
+        });
+
+        if (!isTransferContent(runtime, content)) {
+            if (callback) {
+                callback({
+                    text: "Token address needed to send the token.",
+                    content: { error: "Invalid transfer content" },
+                });
+            }
+            return false;
+        }
+
+        try {
+            const privateKey = runtime.getSetting("VICTION_PRIVATE_KEY")
+            const sender = runtime.getSetting("VICTION_ADDRESS")
+            const rpcUrl = runtime.getSetting("VICTION_RPC_URL")
+
+            const client = new Web3(new Web3.providers.HttpProvider(rpcUrl))
+
+            const nonce = await client.eth.getTransactionCount(sender)
+
+            const contract = new client.eth.Contract(ERC20ABI as any, content.tokenAddress)
+
+            const decimals = await contract.methods.decimals().call()
+
+            const name = await contract.methods.name().call()
+
+            const transaction = {
+                from : sender,
+                nonce,
+                to : content.tokenAddress,
+                value: '0'
+            }
+
+            //@ts-expect-error
+            transaction.data = contract.methods.transfer(content.recipient, String(toWei(content.amount.toString(), unit[decimals]))).encodeABI()
+
+            const gas = await client.eth.estimateGas(transaction)
+
+            //@ts-ignore
+            transaction.gas = toHex(gas)
+            //@ts-ignore
+            transaction.gasLimit = toHex(gas)
+            const { rawTransaction: signedTransaction } = await client.eth.accounts.signTransaction(transaction as any, privateKey as string)
+
+            const { transactionHash }  = await client.eth.sendSignedTransaction(signedTransaction as string)
+
+            if (callback) {
+                callback({
+                    text: `Sent ${content.amount} ${name}. Transaction hash: ${transactionHash}`,
+                    content: {
+                        success: true,
+                        signature: signedTransaction,
+                        amount: content.amount,
+                        recipient: content.recipient,
+                    },
+                });
+            }
+
+            return true;
+        } catch (error) {
+            elizaLogger.error("Error during token transfer:", error);
+            if (callback) {
+                callback({
+                    text: `Issue with the transfer: ${error.message}`,
+                    content: { error: error.message },
+                });
+            }
+            return false;
+        }
+    },
+
+    examples: [
+        [
+            {
+                user: "{{user1}}",
+                content: {
+                    text: "Send 89 C98 0x0Fd0288AAAE91eaF935e2eC14b23486f86516c8C to 0xe3FE2dc5Bd9c5516D3895ab3A931b5B545De658E",
+                },
+            },
+            {
+                user: "{{user2}}",
+                content: {
+                    text: "Sending the tokens now...",
+                    action: "SEND_TOKEN",
+                },
+            },
+        ],
+    ] as ActionExample[][],
+} as Action;

--- a/packages/plugin-viction/src/actions/transfer_vic.ts
+++ b/packages/plugin-viction/src/actions/transfer_vic.ts
@@ -1,0 +1,161 @@
+import {
+    ActionExample,
+    Content,
+    HandlerCallback,
+    IAgentRuntime,
+    Memory,
+    State,
+    ModelClass,
+    type Action,
+} from "@elizaos/core";
+import { elizaLogger } from "@elizaos/core";
+import { composeContext } from "@elizaos/core";
+import { generateObjectDeprecated } from "@elizaos/core";
+import Web3 from 'web3'
+const { toHex, toWei } = Web3.utils
+
+interface VicTransferContent extends Content {
+    recipient: string;
+    amount: number;
+}
+
+const vicTransferTemplate = `Respond with a JSON markdown block containing only the extracted values. Use null for any values that cannot be determined.
+
+Example response:
+\`\`\`json
+{
+    "recipient": "0xe3FE2dc5Bd9c5516D3895ab3A931b5B545De658E",
+    "amount": 98
+}
+\`\`\`
+
+{{recentMessages}}
+
+Extract the following information about the requested VIC transfer:
+- Recipient wallet address
+- Amount of VIC to transfer
+`;
+
+function isVicTransferContent(content: any): content is VicTransferContent {
+    return (
+        typeof content.recipient === "string" &&
+        typeof content.amount === "string"
+    );
+}
+
+export default {
+    name: "SEND_VIC",
+    similes: ["TRANSFER_VIC", "PAY_VIC", "TRANSACT_VIC"],
+    validate: async (_runtime: IAgentRuntime, message: Memory) => {
+        // Always return true for VIC transfers, letting the handler deal with specifics
+        elizaLogger.log("Validating VIC transfer from user:", message.userId);
+        return true;
+    },
+    description: "Transfer native VIC from agent's wallet to specified address",
+    handler: async (
+        runtime: IAgentRuntime,
+        message: Memory,
+        state: State,
+        _options: { [key: string]: unknown },
+        callback?: HandlerCallback,
+    ): Promise<boolean> => {
+        elizaLogger.log("Starting SEND_VIC handler...");
+
+        if (!state) {
+            state = (await runtime.composeState(message)) as State;
+        } else {
+            state = await runtime.updateRecentMessageState(state);
+        }
+
+        const transferContext = composeContext({
+            state,
+            template: vicTransferTemplate,
+        });
+
+        const content = await generateObjectDeprecated({
+            runtime,
+            context: transferContext,
+            modelClass: ModelClass.LARGE,
+        });
+
+        if (!isVicTransferContent(content)) {
+            if (callback) {
+                callback({
+                    text: "Need an address and the amount of VIC to send.",
+                    content: { error: "Invalid transfer content" },
+                });
+            }
+            return false;
+        }
+
+        try {
+            const privateKey = runtime.getSetting("VICTION_PRIVATE_KEY")
+            const sender = runtime.getSetting("VICTION_ADDRESS")
+            const rpcUrl = runtime.getSetting("VICTION_RPC_URL")
+
+            const client = new Web3(new Web3.providers.HttpProvider(rpcUrl))
+
+            const nonce = await client.eth.getTransactionCount(sender)
+
+            const transaction = {
+                from : sender,
+                nonce,
+                to : content.recipient,
+                data : '0x',
+                value: toWei(content.amount.toString())
+            }
+
+            const gas = await client.eth.estimateGas(transaction)
+
+            //@ts-ignore
+            transaction.gas = toHex(gas)
+            //@ts-ignore
+            transaction.gasLimit = toHex(gas)
+
+            const { rawTransaction: signedTransaction } = await client.eth.accounts.signTransaction(transaction as any, privateKey as string)
+
+            const { transactionHash }  = await client.eth.sendSignedTransaction(signedTransaction as string)
+
+            if (callback) {
+                callback({
+                    text: `Sent ${content.amount} VIC. Transaction hash: ${transactionHash}`,
+                    content: {
+                        success: true,
+                        signature: signedTransaction,
+                        amount: content.amount,
+                        recipient: content.recipient,
+                    },
+                });
+            }
+
+            return true;
+        } catch (error) {
+            elizaLogger.error("Error during VIC transfer:", error);
+            if (callback) {
+                callback({
+                    text: `Problem with the VIC transfer: ${error.message}`,
+                    content: { error: error.message },
+                });
+            }
+            return false;
+        }
+    },
+
+    examples: [
+        [
+            {
+                user: "{{user1}}",
+                content: {
+                    text: "Send 98 VIC to 0xe3FE2dc5Bd9c5516D3895ab3A931b5B545De658E",
+                },
+            },
+            {
+                user: "{{user2}}",
+                content: {
+                    text: "Sure thing, VIC on its way.",
+                    action: "SEND_VIC",
+                },
+            },
+        ],
+    ] as ActionExample[][],
+} as Action;

--- a/packages/plugin-viction/src/actions/vic_infomation.ts
+++ b/packages/plugin-viction/src/actions/vic_infomation.ts
@@ -1,0 +1,127 @@
+import {
+    type Action,
+    type IAgentRuntime,
+    type Memory,
+    type HandlerCallback,
+    type State,
+} from "@elizaos/core";
+import { elizaLogger } from "@elizaos/core";
+
+const vic_infomations: Action = {
+    name: "GIVE_VICTION_INFOMATION",
+    similes: [
+        "GIVE_VICTION_INFOMATIONS",
+        "PROVIDE_VICTION_INFORMATION",
+        "PROVIDING_VICTION_INFORMATION",
+    ],
+    description: "Provide information about a Viction",
+    validate: async (_runtime: IAgentRuntime, _message: Memory) => {
+        return true
+    },
+    handler: async (
+        runtime: IAgentRuntime,
+        message: Memory,
+        state: State,
+        _options: { [key: string]: unknown },
+        callback?: HandlerCallback,
+    ) => {
+        elizaLogger.log("Starting GIVE_VIC_INFOMATION handler...");
+
+        if (!state) {
+            state = (await runtime.composeState(message)) as State;
+        } else {
+            state = await runtime.updateRecentMessageState(state);
+        }
+
+        try {
+            if (callback) {
+                callback({
+                    text: `Viction is a layer 1 blockchain renamed from TomoChain, with many outstanding features such as Zero Gas mechanism (no gas fee), high security and good scalability.
+
+The name Viction comes from the ambition of the Ninety-Eight team, when combining "Victory" (victory) and "Vision" (Vision). Viction is aiming for a blockchain with decentralization, good security and high scalability, aiming to attract many users and projects to the network.
+
+VIC Token Key Metric
+    - Token name: Viction.
+    - Ticker: VIC.
+    - Blockchain: Viction, Ethereum.
+    - Contract: 0x05D3606d5c81EB9b7B18530995eC9B29da05FaBa
+    - Token type: Utility, Governance.
+    - Total: 210,000,000 VIC
+
+On October 29, 2024, the Viction network hard forked according to VIP proposal #1. Accordingly, the total supply of VIC increased from 100,000,000 VIC to 210,000,000 VIC.
+
+VIC Token Use Cases
+    - Pay transaction fees on the Viction network.
+    - Participate in governance and vote on Masternodes.
+    - Users can use VIC to stake directly on Viction Wallet and receive rewards.
+    - For project developers, they can use VIC to apply Zero Gas to users.
+
+VIC Token Allocation
+    - Private Round: 31.45%.
+    - Mining Reward: 17%.
+    - Treasury: 16%.
+    - Team & Advisory: 15.9%.
+    - Seed Round: 15.65%.
+    - Public Sale: 4%.
+
+For the 110,000,00 VIC after the hard fork, the allocation will be as follows:
+    - Increasing Security Economic: 27.27%
+    - VIC RetroDrops Program: 18.18%
+    - Community Acceleration Program: 18.18%
+    - R&D and Ecosystem Partnership: 18.18%
+    - Ecosystem Development Program: 9.09%
+    - Future Initiatives: 9.09%
+
+VIC Token Release Schedule
+
+The amount of VIC has been 100% unlocked and fully circulated in the market by 2022. Therefore, the total supply of VIC is changing based on the decision of the Masternode every year.
+
+For the 110,000,000 VIC after the hard fork, the unlocking schedule is as follows:
+    - Increasing Security Economic: 5 million VIC are unlocked gradually in the first 3 years. And every 4 years, the number of unlocked VIC tokens will be halved.
+    - VIC RetroDrops Program: Unlock 1.25 million VIC every quarter.
+    - R&D and Ecosystem Partnership: Unlock evenly over 4 years.
+
+VIC Token Sale
+    - 9/2017: Viction launched its Seed round with 15,650,000 VIC. Each VIC is worth 0.125 USD.
+    - 2/2018: Viction launched its Private round with 31,450,000 VIC, and successfully raised 6,290,000 USD (0.2 USD/VIC).
+    - 3/2018: Viction launched its ICO and successfully raised 1,000,000 USD, with 4,000,000 VIC (0.25 USD/VIC).
+                    `,
+                    content: {
+                        success: true
+                    }
+                });
+            }
+
+            return true
+        } catch (error) {
+            elizaLogger.error("Error during token transfer:", error);
+            if (callback) {
+                callback({
+                    text: `Issue with the infomation: ${error.message}`,
+                    content: { error: error.message },
+                });
+            }
+            return false;
+        }
+
+    },
+    examples: [
+        [
+            {
+                user: "{{user1}}",
+                content: {
+                    text: "Give me infomation about Viction",
+                },
+            },
+            {
+                user: "{{user2}}",
+                content: {
+                    text: "Providing the viction's info now...",
+                    action: "GIVE_VICTION_INFOMATION",
+                },
+            },
+        ],
+    ],
+};
+
+export default vic_infomations;

--- a/packages/plugin-viction/src/constants/decimals.ts
+++ b/packages/plugin-viction/src/constants/decimals.ts
@@ -1,0 +1,9 @@
+export const unit = {
+    3: 'kwei',
+    6: 'mwei',
+    9: 'gwei',
+    12: 'szabo',
+    15: 'finney',
+    18: 'ether',
+    21: 'kether'
+}

--- a/packages/plugin-viction/src/constants/index.ts
+++ b/packages/plugin-viction/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './decimals'

--- a/packages/plugin-viction/src/index.ts
+++ b/packages/plugin-viction/src/index.ts
@@ -1,0 +1,13 @@
+import type { Plugin } from "@elizaos/core";
+import transferToken from "./actions/transfer.ts";
+import transferVic from "./actions/transfer_vic.ts";
+import infoVic from "./actions/vic_infomation.ts";
+
+export const victionPlugin: Plugin = {
+    name: "viction",
+    description: "Viction Plugin for Eliza",
+    actions: [transferToken, transferVic, infoVic],
+    evaluators: [],
+    providers: [],
+};
+export default victionPlugin;

--- a/packages/plugin-viction/tsconfig.json
+++ b/packages/plugin-viction/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../core/tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "src",
+    },
+    "include": [
+        "src/**/*.ts"
+    ]
+}

--- a/packages/plugin-viction/tsup.config.ts
+++ b/packages/plugin-viction/tsup.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+    entry: ["src/index.ts"],
+    outDir: "dist",
+    sourcemap: true,
+    clean: true,
+    format: ["esm"], // Ensure you're targeting CommonJS
+    external: [
+        "dotenv", // Externalize dotenv to prevent bundling
+        "fs", // Externalize fs to use Node.js built-in module
+        "path", // Externalize other built-ins if necessary
+        "@reflink/reflink",
+        "https",
+        "http",
+        "agentkeepalive",
+        // Add other modules you want to externalize
+    ],
+});


### PR DESCRIPTION
# Relates to
https://github.com/elizaOS/eliza/pull/3586

# Risks
Medium

* Handles cryptocurrency transactions
* Manages private keys
* Interacts with Viction networks


# Background

## What does this PR do?
Introduces the @elizaos/plugin-viction package, core plugin that enables comprehensive Viction blockchain interactions including token operations, trading, and DeFi integrations. The plugin enables:

1. Provide information about Viction.
2. Transfer VIC & tokens

## What kind of change is this?
Features (non-breaking change which adds functionality)
* New plugin implementation

## Why are we doing this? Any context or related work?
To add Viction plugin to ElizaOS for Viction community to build ElizaOS AI Agent on Viction

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. Review the main plugin entry point: src/index.ts
2. Examine the core actions:
* transfer_vic.ts
* transfer.ts
* vic_infomation.ts

## Detailed testing steps

1. Install the package
````
pnpm add @elizaos/plugin-viction
````

2. Configure environment variables
````
VICTION_ADDRESS= #Viction address
VICTION_PRIVATE_KEY= #Viction private key
VICTION_RPC_URL= #Viction RPC enpoint for blockchain interactions
````

3. Test basic functionality
````ts
import { victionPlugin } from '@elizaos/plugin-lit';

// Register plugin
runtime.registerPlugin(victionPlugin);

// Test get Viction information
await runtime.executeAction('GIVE_VICTION_INFOMATION', {
  text: "Give me infomation about Viction"
});

// Test transfer VIC 
await runtime.executeAction('SEND_VIC', {
  text: "Send 98 VIC to 0xe3FE2dc5Bd9c5516D3895ab3A931b5B545De658E"
});

// Test transfer token
await runtime.executeAction('SEND_TOKEN', {
  text: "Send 89 C98 0x0Fd0288AAAE91eaF935e2eC14b23486f86516c8C to 0xe3FE2dc5Bd9c5516D3895ab3A931b5B545De658E"
});
````
