### PR TITLE
fix: Fix devcontainer.json Port Mapping Syntax and JSON Structure

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,8 +10,8 @@
     },
     "privileged": true,
     "runArgs": [
-        "-p=3000:3000", // Add port for server api
-        "-p=5173:5173", // Add port for client
+        "-p 3000:3000", // Add port for server api
+        "-p 5173:5173", // Add port for client
         //"--volume=/usr/lib/wsl:/usr/lib/wsl", // uncomment for WSL
         //"--volume=/mnt/wslg:/mnt/wslg", // uncomment for WSL
         "--gpus=all", // ! uncomment for vGPU


### PR DESCRIPTION
Fixed port mapping syntax

Old: "-p=3000:3000"
New: "-p 3000:3000"
Old: "-p=5173:5173"
New: "-p 5173:5173"
Reason: The correct syntax for port mapping in Docker is -p <host_port>:<container_port> (without =). Using = can lead to syntax errors or unexpected behavior.