### PR TITLE
fix: set agent from api

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1,17 +1,17 @@
 import { DirectClient } from "@elizaos/client-direct";
 import {
+    type Adapter,
     AgentRuntime,
     CacheManager,
     CacheStore,
     type Character,
+    type ClientInstance,
     DbCacheAdapter,
     elizaLogger,
     FsCacheAdapter,
     type IAgentRuntime,
     type IDatabaseAdapter,
     type IDatabaseCacheAdapter,
-    type ClientInstance,
-    type Adapter,
     ModelProviderName,
     parseBooleanFromText,
     settings,
@@ -801,10 +801,8 @@ const startAgents = async () => {
     }
 
     // upload some agent functionality into directClient
-    // XXX TODO: is this still used?
+    // This is used in client-direct/api.ts at "/agents/:agentId/set" route to restart an agent
     directClient.startAgent = async (character) => {
-        throw new Error('not implemented');
-
         // Handle plugins
         character.plugins = await handlePluginImporting(character.plugins);
 
@@ -837,12 +835,12 @@ if (
     parseBooleanFromText(process.env.PREVENT_UNHANDLED_EXIT)
 ) {
     // Handle uncaught exceptions to prevent the process from crashing
-    process.on("uncaughtException", function (err) {
+    process.on("uncaughtException", (err) => {
         console.error("uncaughtException", err);
     });
 
     // Handle unhandled rejections to prevent the process from crashing
-    process.on("unhandledRejection", function (err) {
+    process.on("unhandledRejection", (err) => {
         console.error("unhandledRejection", err);
     });
 }


### PR DESCRIPTION
# Relates to

None

# Risks

Low

# Background

## What does this PR do?
- Rollbacks some changed introduced on https://github.com/elizaOS/eliza/commit/3f66c9aa08829a794c4c52b064c4bc7b81c1049a#diff-6ccf35df0aad3b9693dad2ec6826b8742e506fa4197cf3e5fa2da7c74ca299c9

## What kind of change is this?
- Bug fix (non-breaking change). Fixes a bug where we can't re-initialize an agent through the client direct api on the `/agents/:agentId/set` route.

## Why are we doing this? Any context or related work?
- To be able to continue using the client-direct api to restart agents.

# Documentation changes needed?
None

# Testing
- Install
- Build
- Run the agent
- Make a post request to `/agents/:agentId/set` make sure the restart works as expected.

## Where should a reviewer start?
- Same as own testing

## Discord username
@dtb0x

