### PR TITLE
fix: Telegram E2E Test and Group Chat Issue

### DIFF
--- a/packages/plugin-telegram/src/messageManager.ts
+++ b/packages/plugin-telegram/src/messageManager.ts
@@ -278,7 +278,7 @@ export class MessageManager {
                 (chat as Chat.SupergroupChat).title :
                 chat.type === 'channel' ?
                     (chat as Chat.ChannelChat).title :
-                    undefined;
+                    "undefined";
 
             // Get room name from chat title/first name
             const roomName = chat.type === 'private' ?


### PR DESCRIPTION
This PR fixes the E2E test for Telegram by adding the chat attribute to the mocked message.

Additionally, the Telegram agent isn't working in my group chat (chat.type = "group") due to an undefined issue at this [line](https://github.com/elizaOS/eliza/blob/5ff1eb8434a15a074d58e3c99290b6a1067d52e3/packages/plugin-telegram/src/messageManager.ts#L281), which is causing a database error. To resolve this, I set the default world name as a string.

here is the error message:

<img width="820" alt="Screenshot 2025-02-21 at 3 35 10 PM" src="https://github.com/user-attachments/assets/12ac9da4-6bcc-42db-be2c-0c5f9a3f3e23" />
