### PR TITLE
fix: generate structured objects and images with NEAR AI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -366,7 +366,7 @@ NEARAI_MODEL=
 SMALL_NEARAI_MODEL=  # Default: fireworks::accounts/fireworks/models/llama-v3p2-3b-instruct
 MEDIUM_NEARAI_MODEL= # Default: fireworks::accounts/fireworks/models/llama-v3p1-70b-instruct
 LARGE_NEARAI_MODEL=  # Default: fireworks::accounts/fireworks/models/llama-v3p1-405b-instruct
-IMAGE_NEARAI_MODE=   # Default: fireworks::accounts/fireworks/models/playground-v2-5-1024px-aesthetic
+IMAGE_NEARAI_MODEL=   # Default: fireworks::accounts/fireworks/models/playground-v2-5-1024px-aesthetic
 
 # Remaining Provider Configurations
 GOOGLE_GENERATIVE_AI_API_KEY= # Gemini API key

--- a/.env.example
+++ b/.env.example
@@ -366,6 +366,7 @@ NEARAI_MODEL=
 SMALL_NEARAI_MODEL=  # Default: fireworks::accounts/fireworks/models/llama-v3p2-3b-instruct
 MEDIUM_NEARAI_MODEL= # Default: fireworks::accounts/fireworks/models/llama-v3p1-70b-instruct
 LARGE_NEARAI_MODEL=  # Default: fireworks::accounts/fireworks/models/llama-v3p1-405b-instruct
+IMAGE_NEARAI_MODE=   # Default: fireworks::accounts/fireworks/models/playground-v2-5-1024px-aesthetic
 
 # Remaining Provider Configurations
 GOOGLE_GENERATIVE_AI_API_KEY= # Gemini API key

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -1731,6 +1731,7 @@ export const generateImage = async (
                           return runtime.getSetting("SECRET_AI_API_KEY");
                       case ModelProviderName.NEARAI:
                           try {
+                            // Read auth config from ~/.nearai/config.json if it exists
                             const config = JSON.parse(fs.readFileSync(path.join(os.homedir(), '.nearai/config.json'), 'utf8'));
                             return JSON.stringify(config?.auth);
                           } catch (e) {
@@ -2682,7 +2683,7 @@ async function handleNearAi({
     modelOptions,
 }: ProviderOptions): Promise<GenerateObjectResult<unknown>> {
     const nearai = createOpenAI({ apiKey, baseURL: models.nearai.endpoint });
-    // require structured output if schema is provided
+    // Require structured output if schema is provided
     const settings = schema ? { structuredOutputs: true } : undefined;
     return await aiGenerateObject({
         model: nearai.languageModel(model, settings),

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -2682,7 +2682,7 @@ async function handleNearAi({
     modelOptions,
 }: ProviderOptions): Promise<GenerateObjectResult<unknown>> {
     const nearai = createOpenAI({ apiKey, baseURL: models.nearai.endpoint });
-    // require structured output if schema is configured
+    // require structured output if schema is provided
     const settings = schema ? { structuredOutputs: true } : undefined;
     return await aiGenerateObject({
         model: nearai.languageModel(model, settings),

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -1734,7 +1734,7 @@ export const generateImage = async (
                             const config = JSON.parse(fs.readFileSync(path.join(os.homedir(), '.nearai/config.json'), 'utf8'));
                             return JSON.stringify(config?.auth);
                           } catch (e) {
-                            elizaLogger.warn(`Error loading NEAR AI config: ${e}`);
+                            elizaLogger.warn(`Error loading NEAR AI config. The environment variable NEARAI_API_KEY will be used. ${e}`);
                           }
                           return runtime.getSetting("NEARAI_API_KEY");
                       default:

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -2682,8 +2682,10 @@ async function handleNearAi({
     modelOptions,
 }: ProviderOptions): Promise<GenerateObjectResult<unknown>> {
     const nearai = createOpenAI({ apiKey, baseURL: models.nearai.endpoint });
+    // require structured output if schema is configured
+    const settings = schema ? { structuredOutputs: true } : undefined;
     return await aiGenerateObject({
-        model: nearai.languageModel(model),
+        model: nearai.languageModel(model, settings),
         schema,
         schemaName,
         schemaDescription,

--- a/packages/core/src/models.ts
+++ b/packages/core/src/models.ts
@@ -1216,6 +1216,9 @@ export const models: Models = {
                 maxOutputTokens: 8192,
                 temperature: 0.6,
             },
+            [ModelClass.IMAGE]: {
+                name: settings.IMAGE_NEARAI_MODEL || "fireworks::accounts/fireworks/models/playground-v2-5-1024px-aesthetic",
+            },
         },
     },
 };


### PR DESCRIPTION
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

https://github.com/elizaOS/eliza/pull/3275

# Risks

Low. This PR fixes a bug we encountered when testing with NEAR AI model provider. 

# Background

## What does this PR do?

The PR https://github.com/elizaOS/eliza/pull/3275 has added NEAR AI as a model provider into Eliza, but it didn't include NEAR AI models into `generateObject` function for generating structured objects, which causes some actions fail to execute. 

In addition, we noticed that NEAR AI image models are not added and included in this PR.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Actions will throw `Unsupported model: nearai` since `handleNearAi` is not implemented. We met this issue when we're testing plugins with a demo agent: https://github.com/think-in-universe/near-eliza-starter/pull/1

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

- `packages/core/src/generation.ts`
    1. added NEAR AI as a model provider for generating structured objects. 
    2. read NEAR AI API key for image generation 
-  `packages/core/src/models.ts`
    1. configure image model from NEAR AI

## Detailed testing steps

I have tested the structured objects generation in my demo agent here: https://github.com/think-in-universe/near-eliza-starter/pull/1

For image generation, I didn't find an easy way to test in the starter project. If there're any examples about how to do this, it would be super helpful. 

