### PR TITLE
fix: Handle short text items in knowledge processing

### DIFF
--- a/packages/core/src/knowledge.ts
+++ b/packages/core/src/knowledge.ts
@@ -81,6 +81,25 @@ async function set(
     });
 
     const preprocessed = preprocess(item.content.text);
+    
+    // If text is shorter than chunk size, don't split it
+    if (preprocessed.length <= chunkSize) {
+        const embedding = await embed(runtime, preprocessed);
+        await runtime.knowledgeManager.createMemory({
+            id: stringToUuid(item.id + preprocessed),
+            roomId: runtime.agentId,
+            agentId: runtime.agentId,
+            userId: runtime.agentId,
+            createdAt: Date.now(),
+            content: {
+                source: item.id,
+                text: preprocessed,
+            },
+            embedding,
+        });
+        return;
+    }
+
     const fragments = await splitChunks(preprocessed, chunkSize, bleed);
 
     for (const fragment of fragments) {


### PR DESCRIPTION
# Relates to
No linked issue. This PR addresses a bug found in knowledge processing.

# Risks
Low. Only affects how short text items are processed, with a small isolated change to prevent errors.

# Background
## What does this PR do?
Fixes "Invalid array length" error when processing knowledge items by adding a length check before text chunking.

Problem:
- Knowledge processing fails with "Invalid array length" error for short text items
- Affects multiple character files (snoop.json, make.json, etc.)
- Error occurs in splitText() when trying to chunk small texts

Solution:
- Added length check before chunking in knowledge.set()
- Short texts (< chunkSize) are processed as single chunks
- Maintains existing chunking behavior for longer texts

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

# Testing
## Where should a reviewer start?
packages/core/src/knowledge.ts - Check the added length check condition before chunking.

## Detailed testing steps
- Run the application with short knowledge items (from snoop.json)
- Verify that no "Invalid array length" errors occur
- Ensure longer knowledge items still process correctly with chunking

# Discord username
.boolkeys