### PR TITLE
fix: PDF Message Sending Failure & getInstance Bug

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -481,7 +481,7 @@ export class AgentRuntime implements IAgentRuntime {
                     }
                     if (plugin.services) {
                         for(const service of plugin.services){
-                            this.services.set(service.serviceType, service);
+                            this.registerService(service);
                         }
                     }
                     if (plugin.routes) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1004,7 +1004,7 @@ export abstract class Service {
 
   public static getInstance<T extends Service>(): T {
     if (!Service.instance) {
-      Service.instance = new (Service as any)();
+      Service.instance = new (this as any)();
     }
     return Service.instance as T;
   }

--- a/packages/plugin-discord/src/messages.ts
+++ b/packages/plugin-discord/src/messages.ts
@@ -114,6 +114,11 @@ export class MessageManager {
         attachments.push(...processedAudioAttachments);
       }
 
+      if (!processedContent && !attachments?.length) {
+        // Only process messages that are not empty
+        return;
+      }
+
       const userIdUUID = stringToUuid(userId);
       const messageId = stringToUuid(`${message.id}-${this.runtime.agentId}`);
 

--- a/packages/plugin-discord/src/messages.ts
+++ b/packages/plugin-discord/src/messages.ts
@@ -125,7 +125,7 @@ export class MessageManager {
         content: {
           name: name,
           userName: userName,
-          text: processedContent,
+          text: processedContent || " ",
           attachments: attachments,
           source: "discord",
           url: message.url,


### PR DESCRIPTION
1. Fix App Crash When Sending a PDF Message with No Text
Currently, sending a PDF message without any accompanying text causes the app to crash due to this line:
[packages/core/src/memory.ts#L100](https://github.com/elizaOS/eliza/blob/5f154c305fac51743cc32ee9fea798701c752bb8/packages/core/src/memory.ts#L100).

This PR ensures that messages containing only attachments (e.g., PDF files) default to an empty string instead of undefined, preventing the crash.

2. Fix getInstance Breaking All Services
Currently, all services are unusable due to a broken getInstance function. This PR fixes the issue.

Error message:

<img width="817" alt="Screenshot 2025-02-26 at 3 42 52 PM" src="https://github.com/user-attachments/assets/6e6cab66-5ec7-49c1-b66c-649405b24232" />
