### PR TITLE
feat: Add post-processing support for character loading

### DIFF
--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -801,6 +801,7 @@ const handlePostCharacterLoaded = async (character: Character): Promise<Characte
     // Filtering the plugins with the method of handlePostCharacterLoaded
     const processors = character?.postProcessors?.filter(p => typeof p.handlePostCharacterLoaded === 'function');
     if (processors?.length > 0) {
+        processedCharacter = Object.assign({}, character, { postProcessors: undefined });
         // process the character with each processor
         // the order is important, so we loop through the processors
         for (let i = 0; i < processors.length; i++) {

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -792,6 +792,25 @@ const hasValidRemoteUrls = () =>
     process.env.REMOTE_CHARACTER_URLS !== "" &&
     process.env.REMOTE_CHARACTER_URLS.startsWith("http");
 
+/**
+ * Post processing of character after loading
+ * @param character
+ */
+const handlePostCharacterLoaded = async (character: Character): Promise<Character> => {
+    let processedCharacter = character;
+    // Filtering the plugins with the method of handlePostCharacterLoaded
+    const processors = character?.postProcessors?.filter(p => typeof p.handlePostCharacterLoaded === 'function');
+    if (processors?.length > 0) {
+        // process the character with each processor
+        // the order is important, so we loop through the processors
+        for (let i = 0; i < processors.length; i++) {
+            const processor = processors[i];
+            processedCharacter = await processor.handlePostCharacterLoaded(processedCharacter);
+        }
+    }
+    return processedCharacter;
+}
+
 const startAgents = async () => {
     const directClient = new DirectClient();
     let serverPort = Number.parseInt(settings.SERVER_PORT || "3000");
@@ -805,7 +824,8 @@ const startAgents = async () => {
 
     try {
         for (const character of characters) {
-            await startAgent(character, directClient);
+            const processedCharacter = await handlePostCharacterLoaded(character);
+            await startAgent(processedCharacter, directClient);
         }
     } catch (error) {
         elizaLogger.error("Error starting agents:", error);
@@ -825,8 +845,11 @@ const startAgents = async () => {
         // Handle plugins
         character.plugins = await handlePluginImporting(character.plugins);
 
+        // character's post processing
+        const processedCharacter = await handlePostCharacterLoaded(character);
+
         // wrap it so we don't have to inject directClient later
-        return startAgent(character, directClient);
+        return startAgent(processedCharacter, directClient);
     };
 
     directClient.loadCharacterTryPath = loadCharacterTryPath;

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -213,6 +213,13 @@ async function jsonToCharacter(
     }
     // Handle plugins
     character.plugins = await handlePluginImporting(character.plugins);
+
+    // Handle Post Processors plugins
+    if (character.postProcessors?.length > 0) {
+        character.postProcessors = await handlePluginImporting(character.postProcessors);
+    }
+
+    // Handle extends
     if (character.extends) {
         elizaLogger.info(
             `Merging  ${character.name} character with parent characters`
@@ -846,6 +853,10 @@ const startAgents = async () => {
         // Handle plugins
         character.plugins = await handlePluginImporting(character.plugins);
 
+        // Handle Post Processors plugins
+        if (character.postProcessors?.length > 0) {
+            character.postProcessors = await handlePluginImporting(character.postProcessors);
+        }
         // character's post processing
         const processedCharacter = await handlePostCharacterLoaded(character);
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -674,6 +674,9 @@ export type Plugin = {
 
     /** Optional adapters */
     adapters?: Adapter[];
+
+    /** Optional post charactor processor handler */
+    handlePostCharacterLoaded?: (char: Character) => Promise<Character>;
 };
 
 export interface IAgentConfig {
@@ -812,6 +815,9 @@ export type Character = {
 
     /** Available plugins */
     plugins: Plugin[];
+
+    /** Character Processor Plugins */
+    postProcessors?: Pick<Plugin, 'name' | 'description' | 'handlePostCharacterLoaded'>[];
 
     /** Optional configuration */
     settings?: {


### PR DESCRIPTION
# Relates to

n/a

# Risks

Low

# Background

## What does this PR do?

- Introduce `handlePostCharacterLoaded` method in agent startup process
- Add optional `postProcessors` and `handlePostCharacterLoaded` to Character and Plugin types
- Enable plugins to modify characters after initial loading

## What kind of change is this?

Improvements (misc. changes to existing features)

## Why are we doing this? Any context or related work?

Sometimes we need to make some modifications to the dynamic data of Character.
Or, when there are multiple Characters, we need to perform unified post-processing on them through plugins. 
Currently, this can not be achieved. Therefore, a postProcesser mechanism for plugins and Character is introduced.

# Documentation changes needed?

My changes require a change to the project documentation.

## Discord username

bt.wood
