### PR TITLE
fix: media download action

### DIFF
--- a/packages/plugin-discord/src/actions/downloadMedia.ts
+++ b/packages/plugin-discord/src/actions/downloadMedia.ts
@@ -114,8 +114,6 @@ export default {
             attachments: [],
         };
 
-        const filename = path.basename(mediaPath);
-
         const maxRetries = 3;
         let retries = 0;
 
@@ -125,7 +123,7 @@ export default {
                     {
                         ...response,
                     },
-                    [`content_cache/${filename}`]
+                    [mediaPath]
                 );
                 break;
             } catch (error) {

--- a/packages/plugin-node/package.json
+++ b/packages/plugin-node/package.json
@@ -77,6 +77,9 @@
         "youtube-dl-exec": "3.0.15",
         "cookie": "0.7.0"
     },
+    "trustedDependencies": [
+        "youtube-dl-exec"
+    ],
     "devDependencies": {
         "@types/node": "22.8.4",
         "tsup": "8.3.5"


### PR DESCRIPTION
In the current branch, the video service fails due to a missing yt-dlp dependency in the youtube-dl-exec module. This happens because Bun does not install yt-dlp automatically unless you manually navigate to the youtube-dl-exec folder and run npm i.

To resolve this, this PR adds the trustedDependencies to plugin-node's package.json

This ensures that Bun installs youtube-dl-exec correctly, including its required dependencies.

Error Screenshot:

<img width="832" alt="Screenshot 2025-02-26 at 6 57 32 PM" src="https://github.com/user-attachments/assets/6ba258a1-a3e2-4c84-955e-ced1401497a0" />

result:

<img width="516" alt="Screenshot 2025-02-26 at 7 02 47 PM" src="https://github.com/user-attachments/assets/471b9518-6d05-4984-b97a-dbe545fad006" />

