### PR TITLE
Documentation and Code Corrections: Grammar, Typo, and Formatting Updates

### DIFF
--- a/docs/api/classes/FsCacheAdapter.md
+++ b/docs/api/classes/FsCacheAdapter.md
@@ -28,7 +28,7 @@
 
 ### get()
 
-> **get**(`key`): `Promise`\<`string`\>
+> **get**(`key`): `Promise`<`string`>
 
 #### Parameters
 
@@ -36,7 +36,7 @@
 
 #### Returns
 
-`Promise`\<`string`\>
+`Promise`<`string`>
 
 #### Implementation of
 
@@ -50,7 +50,7 @@
 
 ### set()
 
-> **set**(`key`, `value`): `Promise`\<`void`\>
+> **set**(`key`, `value`): `Promise`<`void`>
 
 #### Parameters
 
@@ -60,7 +60,7 @@
 
 #### Returns
 
-`Promise`\<`void`\>
+`Promise`<`void`>
 
 #### Implementation of
 

--- a/docs/api/classes/FsCacheAdapter.md
+++ b/docs/api/classes/FsCacheAdapter.md
@@ -28,7 +28,7 @@
 
 ### get()
 
-> **get**(`key`): `Promise`<`string`>
+> **get**(`key`): `Promise<string>`
 
 #### Parameters
 
@@ -36,7 +36,7 @@
 
 #### Returns
 
-`Promise`<`string`>
+`Promise<string>`
 
 #### Implementation of
 
@@ -50,7 +50,7 @@
 
 ### set()
 
-> **set**(`key`, `value`): `Promise`<`void`>
+> **set**(`key`, `value`): `Promise<void>`
 
 #### Parameters
 
@@ -60,8 +60,7 @@
 
 #### Returns
 
-`Promise`<`void`>
-
+`Promise<void>`
 #### Implementation of
 
 [`ICacheAdapter`](../interfaces/ICacheAdapter.md).[`set`](../interfaces/ICacheAdapter.md#set)
@@ -74,7 +73,7 @@
 
 ### delete()
 
-> **delete**(`key`): `Promise`\<`void`\>
+> **delete**(`key`): `Promise<void>`
 
 #### Parameters
 
@@ -82,7 +81,7 @@
 
 #### Returns
 
-`Promise`\<`void`\>
+`Promise<void>`
 
 #### Implementation of
 

--- a/docs/api/classes/MemoryCacheAdapter.md
+++ b/docs/api/classes/MemoryCacheAdapter.md
@@ -14,7 +14,7 @@
 
 #### Parameters
 
-• **initialData?**: `Map`\<`string`, `string`\>
+• **initialData?**: `Map<string, string>`
 
 #### Returns
 
@@ -28,7 +28,7 @@
 
 ### data
 
-> **data**: `Map`\<`string`, `string`\>
+> **data**: `Map<string, string>`
 
 #### Defined in
 
@@ -38,7 +38,7 @@
 
 ### get()
 
-> **get**(`key`): `Promise`\<`string`\>
+> **get**(`key`): `Promise<string>`
 
 #### Parameters
 
@@ -46,7 +46,7 @@
 
 #### Returns
 
-`Promise`\<`string`\>
+`Promise<string>`
 
 #### Implementation of
 
@@ -70,7 +70,7 @@
 
 #### Returns
 
-`Promise`\<`void`\>
+`Promise<void>`
 
 #### Implementation of
 
@@ -84,7 +84,7 @@
 
 ### delete()
 
-> **delete**(`key`): `Promise`\<`void`\>
+> **delete**(`key`): `Promise<void>`
 
 #### Parameters
 
@@ -92,7 +92,7 @@
 
 #### Returns
 
-`Promise`\<`void`\>
+`Promise<void>`
 
 #### Implementation of
 

--- a/docs/api/classes/MemoryCacheAdapter.md
+++ b/docs/api/classes/MemoryCacheAdapter.md
@@ -14,7 +14,7 @@
 
 #### Parameters
 
-• **initalData?**: `Map`\<`string`, `string`\>
+• **initialData?**: `Map`\<`string`, `string`\>
 
 #### Returns
 

--- a/docs/api/functions/trimTokens.md
+++ b/docs/api/functions/trimTokens.md
@@ -38,8 +38,7 @@ trimTokens
 
 ## Throws
 
-Throws an error if the runtime settings are invalid or missing required fields.
-
+Throws an error if runtime settings are invalid or missing fields.
 ## Example
 
 ```ts

--- a/docs/api/functions/trimTokens.md
+++ b/docs/api/functions/trimTokens.md
@@ -2,7 +2,7 @@
 
 # Function: trimTokens()
 
-> **trimTokens**(`context`, `maxTokens`, `runtime`): `Promise`\<`string`\>
+> **trimTokens**(`context`, `maxTokens`, `runtime`): `Promise<string>`
 
 Trims the provided text context to a specified token limit using a tokenizer model and type.
 
@@ -26,7 +26,7 @@ The runtime interface providing tokenizer settings.
 
 ## Returns
 
-`Promise`\<`string`\>
+`Promise<string>`
 
 A promise that resolves to the trimmed text.
 


### PR DESCRIPTION
1. Fix Angle Brackets Formatting for Generics
Modified:

Promise<string> → Promise<string>
Promise<void> → Promise<void>
Reason:
The incorrect usage of \< instead of < for generics can cause issues in syntax highlighting, documentation parsing, and code consistency. Standardizing to < ensures proper readability and compatibility.

2. Typo Correction in Variable Name
Modified:

initalData? → initialData?
Reason:
Fixed a typo in the variable name (initalData → initialData). The incorrect spelling could lead to runtime issues or confusion for developers using this variable.

3. Grammar and Clarity Improvement in Error Message
Modified:

"Throws an error if the runtime settings are invalid or missing required fields."
→ "Throws an error if runtime settings are invalid or missing fields."
Reason:
Simplified sentence structure for better readability while maintaining the original meaning. Removing "the" in "the runtime settings" makes it more natural and concise in technical documentation.


