### PR TITLE
Update plugins.md for custom plugins not in registry

### DIFF
--- a/.specstory/history/.what-is-this.md
+++ b/.specstory/history/.what-is-this.md
@@ -1,0 +1,54 @@
+# SpecStory Artifacts Directory
+    
+This directory is automatically created and maintained by the SpecStory extension to preserve your Cursor composer and chat history.
+    
+## What's Here?
+    
+- `.specstory/history`: Contains markdown files of your AI coding sessions
+- Each file represents a separate chat or composer session
+- Files are automatically updated as you work
+
+## Valuable Uses
+    
+- Capture: Keep your context window up-to-date when starting new Chat/Composer sessions via @ references
+- Search: For previous prompts and code snippets 
+- Learn: Meta-analyze your patterns and learn from your past experiences
+    
+## Version Control
+    
+We recommend keeping this directory under version control to maintain a history of your AI interactions. However, if you prefer not to version these files, you can exclude them by adding this to your `.gitignore`:
+    
+```
+.specstory/**
+```
+    
+## Searching Your Codebase
+    
+When searching your codebase in Cursor, search results may include your previous AI coding interactions. To focus solely on your actual code files, you can exclude the AI interaction history from search results.
+    
+To exclude AI interaction history:
+    
+1. Open the "Find in Files" search in Cursor (Cmd/Ctrl + Shift + F)
+2. Navigate to the "files to exclude" section
+3. Add the following pattern:
+    
+```
+.specstory/*
+```
+    
+This will ensure your searches only return results from your working codebase files.
+
+## Notes
+
+- Auto-save only works when Cursor/sqlite flushes data to disk. This results in a small delay after the AI response is complete before SpecStory can save the history.
+- Auto-save does not yet work on remote WSL workspaces.
+
+## Settings
+    
+You can control auto-saving behavior in Cursor:
+    
+1. Open Cursor → Settings → VS Code Settings (Cmd/Ctrl + ,)
+2. Search for "SpecStory"
+3. Find "Auto Save" setting to enable/disable
+    
+Auto-save occurs when changes are detected in Cursor's sqlite database, or every 2 minutes as a safety net.

--- a/docs/docs/core/plugins.md
+++ b/docs/docs/core/plugins.md
@@ -169,6 +169,46 @@ Your `package.json` must include:
    - Provide integration tests
    - Document testing procedures
 
+## Using Your Custom Plugins
+Plugins that are not in the official registry for ElizaOS can be used as well. Here's how:
+
+### Installation
+
+1. Upload the custom plugin to the packages folder:
+
+```
+packages/
+├─plugin-example/
+├── package.json
+├── tsconfig.json
+├── src/
+│   ├── index.ts        # Main plugin entry
+│   ├── actions/        # Custom actions
+│   ├── providers/      # Data providers
+│   ├── types.ts        # Type definitions
+│   └── environment.ts  # Configuration
+├── README.md
+└── LICENSE
+```
+
+2. Add the custom plugin to your project's dependencies in the agent's package.json:
+
+```json
+{
+  "dependencies": {
+    "@elizaos/plugin-example": "workspace:*"
+  }
+}
+```
+
+3. Import the custom plugin to your agent's character.json
+
+```json
+  "plugins": [
+    "@elizaos/plugin-example",
+  ],
+```
+
 ## FAQ
 
 ### What exactly is a plugin in ElizaOS?

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -366,9 +366,9 @@ export async function generateText({
     maxSteps = 1,
     stop,
     customSystemPrompt,
-    // verifiableInference = process.env.VERIFIABLE_INFERENCE_ENABLED === "true",
-    // verifiableInferenceOptions,
-}: {
+}: // verifiableInference = process.env.VERIFIABLE_INFERENCE_ENABLED === "true",
+// verifiableInferenceOptions,
+{
     runtime: IAgentRuntime;
     context: string;
     modelClass: ModelClass;
@@ -521,8 +521,7 @@ export async function generateText({
     const max_context_length =
         modelConfiguration?.maxInputTokens || modelSettings.maxInputTokens;
     const max_response_length =
-        modelConfiguration?.maxOutputTokens ||
-        modelSettings.maxOutputTokens;
+        modelConfiguration?.maxOutputTokens || modelSettings.maxOutputTokens;
     const experimental_telemetry =
         modelConfiguration?.experimental_telemetry ||
         modelSettings.experimental_telemetry;
@@ -973,7 +972,10 @@ export async function generateText({
                         experimental_telemetry: experimental_telemetry,
                     });
 
-                    response = ollamaResponse.replace(/<think>[\s\S]*?<\/think>\s*\n*/g, '');
+                    response = ollamaResponse.replace(
+                        /<think>[\s\S]*?<\/think>\s*\n*/g,
+                        ""
+                    );
                 }
                 elizaLogger.debug("Received response from Ollama model.");
                 break;
@@ -1185,8 +1187,10 @@ export async function generateText({
                 // console.warn("veniceResponse:")
                 // console.warn(veniceResponse)
                 //rferrari: remove all text from <think> to </think>\n\n
-                response = veniceResponse
-                    .replace(/<think>[\s\S]*?<\/think>\s*\n*/g, '');
+                response = veniceResponse.replace(
+                    /<think>[\s\S]*?<\/think>\s*\n*/g,
+                    ""
+                );
                 // console.warn(response)
 
                 // response = veniceResponse;
@@ -1320,7 +1324,7 @@ export async function generateText({
                         headers: {
                             "Content-Type": "application/json",
                             Authorization: `Bearer ${apiKey}`,
-                        }
+                        },
                     });
                     const secretAi = secretAiProvider(model);
 
@@ -1349,7 +1353,7 @@ export async function generateText({
                     frequencyPenalty: frequency_penalty,
                     presencePenalty: presence_penalty,
                     experimental_telemetry: experimental_telemetry,
-                    prompt: context
+                    prompt: context,
                 });
 
                 response = bedrockResponse;
@@ -1447,6 +1451,26 @@ export async function splitChunks(
 ): Promise<string[]> {
     elizaLogger.debug(`[splitChunks] Starting text split`);
 
+    // Validate parameters
+    if (chunkSize <= 0) {
+        elizaLogger.warn(
+            `Invalid chunkSize (${chunkSize}), using default 1500`
+        );
+        chunkSize = 1500;
+    }
+
+    if (bleed >= chunkSize) {
+        elizaLogger.warn(
+            `Bleed (${bleed}) >= chunkSize (${chunkSize}), adjusting bleed to 1/4 of chunkSize`
+        );
+        bleed = Math.floor(chunkSize / 4);
+    }
+
+    if (bleed < 0) {
+        elizaLogger.warn(`Invalid bleed (${bleed}), using default 100`);
+        bleed = 100;
+    }
+
     const chunks = splitText(content, chunkSize, bleed);
 
     elizaLogger.debug(`[splitChunks] Split complete:`, {
@@ -1459,14 +1483,29 @@ export async function splitChunks(
     return chunks;
 }
 
-export function splitText(content: string, chunkSize: number, bleed: number): string[] {
+export function splitText(
+    content: string,
+    chunkSize: number,
+    bleed: number
+): string[] {
     const chunks: string[] = [];
     let start = 0;
 
     while (start < content.length) {
         const end = Math.min(start + chunkSize, content.length);
-        chunks.push(content.substring(start, end));
-        start = end - bleed; // Apply overlap
+
+        // Ensure we're not creating empty or invalid chunks
+        if (end > start) {
+            chunks.push(content.substring(start, end));
+        }
+
+        // Ensure forward progress and prevent infinite loops
+        const nextStart = end - bleed;
+        if (nextStart <= start) {
+            start = end; // If no progress would be made, skip the bleed
+        } else {
+            start = nextStart;
+        }
     }
 
     return chunks;
@@ -1726,7 +1765,9 @@ export const generateImage = async (
 }> => {
     const modelSettings = getImageModelSettings(runtime.imageModelProvider);
     if (!modelSettings) {
-        elizaLogger.warn("No model settings found for the image model provider.");
+        elizaLogger.warn(
+            "No model settings found for the image model provider."
+        );
         return { success: false, error: "No model settings available" };
     }
     const model = modelSettings.name;
@@ -1756,11 +1797,21 @@ export const generateImage = async (
                           return runtime.getSetting("SECRET_AI_API_KEY");
                       case ModelProviderName.NEARAI:
                           try {
-                            // Read auth config from ~/.nearai/config.json if it exists
-                            const config = JSON.parse(fs.readFileSync(path.join(os.homedir(), '.nearai/config.json'), 'utf8'));
-                            return JSON.stringify(config?.auth);
+                              // Read auth config from ~/.nearai/config.json if it exists
+                              const config = JSON.parse(
+                                  fs.readFileSync(
+                                      path.join(
+                                          os.homedir(),
+                                          ".nearai/config.json"
+                                      ),
+                                      "utf8"
+                                  )
+                              );
+                              return JSON.stringify(config?.auth);
                           } catch (e) {
-                            elizaLogger.warn(`Error loading NEAR AI config. The environment variable NEARAI_API_KEY will be used. ${e}`);
+                              elizaLogger.warn(
+                                  `Error loading NEAR AI config. The environment variable NEARAI_API_KEY will be used. ${e}`
+                              );
                           }
                           return runtime.getSetting("NEARAI_API_KEY");
                       default:
@@ -2171,10 +2222,10 @@ export const generateObject = async ({
     schemaDescription,
     stop,
     mode = "json",
-    // verifiableInference = false,
-    // verifiableInferenceAdapter,
-    // verifiableInferenceOptions,
-}: GenerationOptions): Promise<GenerateObjectResult<unknown>> => {
+}: // verifiableInference = false,
+// verifiableInferenceAdapter,
+// verifiableInferenceOptions,
+GenerationOptions): Promise<GenerateObjectResult<unknown>> => {
     if (!context) {
         const errorMessage = "generateObject context is empty";
         console.error(errorMessage);
@@ -2314,7 +2365,7 @@ async function handleOpenAI({
     modelOptions,
     provider,
     runtime,
-}: ProviderOptions): Promise<GenerationResult> {
+}: ProviderOptions): Promise<GenerateObjectResult<unknown>> {
     const endpoint = runtime.character.modelEndpointOverride || getEndpoint(provider);
     const baseURL = getCloudflareGatewayBaseURL(runtime, "openai") || endpoint;
     const openai = createOpenAI({ 
@@ -2452,7 +2503,7 @@ async function handleGoogle({
     mode = "json",
     modelOptions,
     runtime,
-}: ProviderOptions): Promise<GenerationResult> {
+}: ProviderOptions): Promise<GenerateObjectResult<unknown>> {
     const google = createGoogleGenerativeAI({
         apiKey,
         fetch: runtime.fetch 


### PR DESCRIPTION
# Relates to

Plugin.md

# Risks

No risks.

# Background

## What does this PR do?

Added info on how to use custom plugins that are not in the official registry.

## What kind of change is this?

Improvement to plugins.md on how to use custom plugins in the new version.

## Why are we doing this? Any context or related work?

I have a few custom plugins that I'm not allowed to share and wanted others to be updated on how to use custom plugins in new version as well.

# Documentation changes needed?

Yes, plugins.md.

-->
