### PR TITLE
fix: Revert short knowledge items handling

### DIFF
--- a/packages/core/src/knowledge.ts
+++ b/packages/core/src/knowledge.ts
@@ -81,25 +81,6 @@ async function set(
     });
 
     const preprocessed = preprocess(item.content.text);
-    
-    // If text is shorter than chunk size, don't split it
-    if (preprocessed.length <= chunkSize) {
-        const embedding = await embed(runtime, preprocessed);
-        await runtime.knowledgeManager.createMemory({
-            id: stringToUuid(item.id + preprocessed),
-            roomId: runtime.agentId,
-            agentId: runtime.agentId,
-            userId: runtime.agentId,
-            createdAt: Date.now(),
-            content: {
-                source: item.id,
-                text: preprocessed,
-            },
-            embedding,
-        });
-        return;
-    }
-
     const fragments = await splitChunks(preprocessed, chunkSize, bleed);
 
     for (const fragment of fragments) {


### PR DESCRIPTION
# Relates to

https://github.com/elizaOS/eliza/pull/3652
https://github.com/elizaOS/eliza/pull/3653

# Risks

Low

# Background

## What does this PR do?

Revert's back to the original behavior since the change on https://github.com/elizaOS/eliza/pull/3652 where only needed if the splitText function misbehaves.

## What kind of change is this?

Improvements (misc. changes to existing features)

## Why are we doing this? Any context or related work?

Because less code doing the same is better =)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

packages/core/src/knowledge.ts - Check the deleted code.

## Detailed testing steps

Add a very short knowledge entry into a character (less than 15 characters and it should be enough) and then start the project with that character.

## Discord username

fcatena