### PR TITLE
fix: api issues

### DIFF
--- a/packages/agent/src/server/api/agent.ts
+++ b/packages/agent/src/server/api/agent.ts
@@ -189,7 +189,7 @@ export function agentRouter(
             const updatedAgent = await db.getAgent(agentId);
                 
 
-            const isActive = agents.get(agentId);
+            const isActive = !!agents.get(agentId);
             if (isActive) {
                 // stop existing runtime
                 server?.unregisterAgent(agentId);
@@ -288,7 +288,7 @@ export function agentRouter(
                 return;
             }
 
-            const isActive = agents.get(agentId);
+            const isActive = !!agents.get(agentId);
 
             // Check if agent is already running
             if (isActive) {

--- a/packages/agent/src/server/api/agent.ts
+++ b/packages/agent/src/server/api/agent.ts
@@ -194,7 +194,7 @@ export function agentRouter(
                 // stop existing runtime
                 server?.unregisterAgent(agentId);
                 // start new runtime
-                server?.startAgent(updatedAgent);
+                await server?.startAgent(updatedAgent);
             }
         
             // check if agent got started successfully

--- a/packages/agent/src/server/api/agent.ts
+++ b/packages/agent/src/server/api/agent.ts
@@ -43,7 +43,12 @@ export function agentRouter(
                 bio: agent.bio[0],
                 createdAt: agent.createdAt,
                 updatedAt: agent.updatedAt,
-            })).sort((a: Agent, b: Agent) => a.name.localeCompare(b.name));
+            })).sort((a: Agent, b: Agent) => {
+                if (a.status === b.status) {
+                    return a.name.localeCompare(b.name);
+                }
+                return a.status === "active" ? -1 : 1;
+            });
 
             res.json({
                 success: true,


### PR DESCRIPTION
Currently, attempting certain operations (e.g., starting an agent, editing agent) results in the error: "Cannot read properties of undefined (reading 'databaseAdapter')". 

I noticed that we are trying to access the agent's runtime before it is actually created. If we are starting an agent, that means the runtime does not yet exist, so we shouldn't be attempting to access it beforehand.

<img width="689" alt="Screenshot 2025-03-04 at 1 25 39 PM" src="https://github.com/user-attachments/assets/103be576-f926-4fe2-83da-7772fbe429a5" />

Additionally, I removed some runtime checks that verified whether the runtime’s character name matched the agentId (maybe should check the character id instead?), when the runtime itself was not found. Instead of these repeated checks, maybe we should ensure that every runtime is properly registered, allowing us to reliably retrieve the agent with `agents.get(agentId)`.