### PR TITLE
docs: Add weekly contributor meeting notes (2025-02-18 + 2025-02-25)

### DIFF
--- a/docs/community/Contributors/weekly-contributor-meeting/2025-02-18.md
+++ b/docs/community/Contributors/weekly-contributor-meeting/2025-02-18.md
@@ -1,0 +1,58 @@
+---
+title: "Weekly Contributor Meeting Notes"
+date: 2025-02-18    
+description: "Exploring emergent behaviors in the plugin ecosystem, standardizing plugin naming conventions, and discussions on Linea blockchain integration and V2 plugin management improvements."
+---
+
+# Weekly Contributor Meeting Notes
+
+(February 18, 2025 4:00 PM PST)
+
+**Emergent Behaviors: Evolving the Plugin Ecosystem**
+
+
+## Summary
+
+**Discussion on Linea and Agents:**
+
+*   A question is posed about Linea blockchain, revealing most participants are unfamiliar with it.
+*   A speaker (likely a lead/organizer named Shaw) discusses a meeting with Joe Lubin (ConsenSys/MetaMask/Ethereum) and the Linea blockchain.
+*   Linea is described as having fast transaction settlement and using Ethereum as a settlement layer.  It's noted, however, that Linea suffers from a lack of awareness.
+*   Joe Lubin is described as being "pro-agent" and interested in pushing the boundaries of AI into sci-fi territory.
+
+**Meeting Logistics & Github Issues:**
+
+*   Discussion of a broken link to the meeting in the GitHub contributor's voice chat event, stemming from a deleted channel. Plans are made to fix the link and potentially recreate a voice chat channel, keeping in mind the desire to minimize the number of channels.
+*   Discussion about standardizing Plugin names.
+
+**Plugin Discussions (Key Focus):**
+
+*   Discussion of a pull request where someone used their own organization name in a plugin name instead of the standard "elizaOS" prefix.  This sparks discussion about allowing flexibility in plugin naming and the implications for the installer tools and plugin registry.
+*   Upstreet deleted a lot of plug ins from the registry.
+*   Talk about the need for an automated tool (likely integrated into the V2 CLI) to check plugin formatting and consistency before merging PRs.
+
+**Queso's Questions and Emergent Behavior:**
+
+*   Queso asks about the definition of a "plugin":  Is it *only* for connecting to new services (like Solana or Twitter), or can it be used to combine existing plugins to create new, complex behaviors?  Specifically, they want to build an agent/plugin for DAO interactions that uses existing plugins.
+*   This leads to a discussion about "emergent behavior" – combining plugins in ways not explicitly designed to achieve new functionalities.
+*   The response is that creating a plugin for Queso's DAO liaison functionality is appropriate and encouraged.  It doesn't necessarily need a new *connector* but can define a sequence of actions and evaluators using existing functionalities.
+*    Queso is also working on something that rates proposals, and synthesize governance proposals
+*   Shaw expresses strong interest in Queso's work, as it aligns with his current work on "Swarm" functionality (likely a multi-agent system).
+
+**Extended Discussion**
+
+*   **Cloudflare AI Gateway Issue:** Cipher raises a concern about the Cloudflare AI Gateway plugin not passing a bearer token for authentication.  This is a pressing issue because it relates to metering and tracing usage.
+*   **Runtime Discussion (Bun vs. Node.js):**  They discuss the runtime environment (Node.js vs. Bun) and the potential migration to Bun in V2. They talk about the advantages of Bun (native features, reduced dependencies) and its interoperability with Node.js.
+*   **Dependency Management (Axios vs. Fetch):**  They discuss the use of Axios (a popular HTTP client) versus the built-in `fetch` API. Concerns are raised about a bug in Axios, and the advantages of `fetch` (especially in TypeScript) and Undici are mentioned.
+*   **Plugin Structure and Starter Issues:**  Cipher describes their approach to working with plugins: stripping them down to their core components and managing dependencies from a central point. This relates to past issues with the `elizaOS-starter` repository diverging from the main branch and becoming difficult to maintain.
+*   **V2 Plugin Management:** The upcoming V2 plugin management system is described.  It will involve a CLI tool to list, add, and manage plugins from a registry, making the core repository "pluginless" by default.
+*   **Documentation and Automation:**  They discuss the state of the documentation (which is acknowledged as lagging behind development) and the need for automation, including testing and documentation generation for plugins.
+*   **Code Analysis Tools:** Phlo and another participant share tools for analyzing codebases and making them LLM-friendly (RepoMix, Get Ingest/uithub.com).
+*   **Ollama and Local Development:**  A contributor mentions using Ollama (a local LLM) for development to avoid burning through API credits.  They also discuss Cloudflare Workers AI as an alternative.
+*   **Videos:** Making new tutorial videos is discussed
+*   **Plugin Showcase:** Starting a plugin showcase where developers can present their built
+*   **Community Engagement:**  The importance of the Discord community for communication and support is highlighted. The discussion touches on the current market downturn and how it impacts community activity.
+*   **Browser Compatibility:** The desire to explore browser compatibility for ElizaOS is mentioned, along with challenges related to using Python-based tools like `browser` in a JavaScript environment.
+*   **Playwright, Puppeteer, Selenium:** Discussion of browser automation tools (Playwright, Puppeteer, Selenium) and their limitations in JavaScript compared to languages like Rust or Python.
+*   **AI Pmarca:** Discussion about the Pmarca project, which is launching soon.
+*   **RAG Knowledge implementation:** Final discussion about troubleshooting and testing RAG

--- a/docs/community/Contributors/weekly-contributor-meeting/2025-02-25.md
+++ b/docs/community/Contributors/weekly-contributor-meeting/2025-02-25.md
@@ -1,0 +1,40 @@
+---
+title: "Weekly Contributor Meeting Notes"
+date: 2025-02-25
+description: "Updates on plugin migration completion and release 25.8, discussions on V2 development challenges, and documentation improvements during ETH Denver week with expectations of upcoming hackathon project insights."
+---
+
+# Weekly Contributor Meeting Notes
+
+(February 25, 2025 4:00 PM PST)
+
+**ETH Denver and Documentation Catch-Up**
+
+
+## Summary
+
+**Low Attendance:**
+
+*   The meeting started with low attendance, likely due to many contributors being at the ETH Denver conference.
+*   One participant expressed FOMO for not attending ETH Denver.
+
+**Project Updates and Status:**
+
+*   **Plugin Migration and Release:** A contributor mentioned that the plugin migration has been done. Release 25.8, that took the weekend to cut, is out.
+*   The contributor ran adapters through after noticing someone on chat questioned how they work with the latest release, and found bugs, but they were not in the release.
+*   **V2 Status:** Version 2 (V2) of elizaOS is "still kind of broken" and difficult to build on. Several things are waiting to be merged, and a test was planned for later that day.
+*   **V1 Core Updates:** Most of the merging work has been focused on plugins, the registry, and updates to the V1 core.
+*   **Development Branch:** The `develop` branch is a few PRs ahead of `main` (mostly documentation updates), but the CLI tool (specifically the install part) is currently broken on `develop`. A fix is awaiting approval.
+*   **Documentation:** The documentation (particularly the quick start page) is being updated, removing old information and clarifying the flow, especially regarding the moved-out plugins.
+
+**Personal Plans and Discussion:**
+
+*   **Catching Up:** One participant expressed needing to catch up with recent developments, especially regarding Shaw's V2 work.
+*   **Getting Eliza Running Again:** The other participant is planning to dive back into running elizaOS (specifically the `develop` branch, despite the known CLI issue) to get hands-on experience. They plan to document their findings and potentially contribute to documentation improvements. The purpose is to present on the agent landscape.
+*   **Past Experiences:** They reminisced about the early days of elizaOS, where debugging and getting it running was a community effort in the Discord chat.
+*   **Clank Tank:** There was discussion about feedback on Jin's show, Clank Tank, which was mostly positive.
+
+**Hackathons and Future Updates:**
+
+*   It was mentioned that elizaOS is being used extensively in hackathons.
+*   There's an expectation of interesting updates next week from contributors who were working on projects for ETH Denver.


### PR DESCRIPTION
# Relates to
Documentation updates for weekly contributor meetings

# Risks
Low - This is a documentation-only change adding meeting notes.

# Background

## What does this PR do?
Adds meeting notes for two weekly contributor meetings:
- February 18, 2025 covering plugin ecosystem discussions, Linea blockchain integration, and V2 plugin management
- February 25, 2025 covering ETH Denver updates and documentation improvements

## What kind of change is this?
Documentation (adding new meeting notes)

# Documentation changes needed?
My changes are documentation changes themselves, no additional documentation updates needed.

# Testing

## Where should a reviewer start?
Review the two new markdown files:
1. `docs/community/Contributors/weekly-contributor-meeting/2025-02-18.md`
2. `docs/community/Contributors/weekly-contributor-meeting/2025-02-25.md`

## Detailed testing steps
1. Verify markdown formatting is correct
2. Verify dates and titles are consistent with our documentation standards
3. Verify the frontmatter metadata (title, date, description) is properly formatted
4. Check that links within the documents (if any) are valid

<!-- If you are on Discord, please join https://discord.gg/elizaOS and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username
YoungPhlo
-->
