### PR TITLE
fix: Fixed issue with async handling in getTweets method

### DIFF
--- a/scripts/gettweets.mjs
+++ b/scripts/gettweets.mjs
@@ -22,7 +22,7 @@ const TWEETS_FILE = "tweets.json";
             console.log("Logged in successfully!");
 
             // Fetch all tweets for the user "@realdonaldtrump"
-            const tweets = scraper.getTweets("pmarca", 2000);
+            const tweets = await scraper.getTweets("pmarca", 2000);
 
             // Initialize an empty array to store the fetched tweets
             let fetchedTweets = [];


### PR DESCRIPTION
# What does this PR do?  
This change fixes an issue where the `getTweets` method was not awaited, causing potential issues with handling the returned promise. The method is asynchronous, so I added `await` to properly wait for the promise to resolve.

## What kind of change is this?  
- Bug fix

## Why are we doing this? Any context or related work?  
The method `scraper.getTweets` is asynchronous and returns a promise. Without using `await`, the code may continue execution before the promise is resolved, leading to unexpected results. This fix ensures the method completes before working with its response.

# Testing  
Tested by running the function and confirming that the correct list of tweets is returned after the promise is resolved.