### PR TITLE
Add core types.

### DIFF
--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
 	target: "node23",
 	bundle: true,
 	splitting: true, // Add this for better code splitting
-	dts: false, // Disable type generation
+	dts: true, // Enable type generation
 	// Use esbuild's simpler DTS generation
 	tsconfig: "./tsconfig.build.json", // Use build-specific tsconfig
 	external: [


### PR DESCRIPTION
This enables index.d.ts to be built in /dist. I was seeing no types available errors on imports.