### PR TITLE
fix: plugin-telegram

### DIFF
--- a/packages/plugin-telegram/src/index.ts
+++ b/packages/plugin-telegram/src/index.ts
@@ -7,6 +7,7 @@ import { TelegramTestSuite } from "./tests.ts";
 import { TELEGRAM_SERVICE_NAME } from "./constants.ts";
 
 export class TelegramService implements Service {
+    static serviceType = TELEGRAM_SERVICE_NAME; 
     name = TELEGRAM_SERVICE_NAME;
     private bot: Telegraf<Context>;
     private runtime: IAgentRuntime;


### PR DESCRIPTION
Added the serviceType to the telegram to have multi platform for Ruby.
Is just a line of code but it let me test cross platform worlds.
just this.
static serviceType = TELEGRAM_SERVICE_NAME 

![Screenshot 2025-03-09 at 17 23 11](https://github.com/user-attachments/assets/8d9f8581-ac3e-4147-a2a3-f8e984d7bf02)
