### PR TITLE
fix: migration race condition

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -74,7 +74,7 @@
       "name": "@elizaos/cli",
       "version": "1.0.0-alpha.35",
       "bin": {
-        "elizaos": "./dist/index.js",
+        "elizaos": "./dist/index.js"
       },
       "dependencies": {
         "@electric-sql/pglite": "^0.2.17",
@@ -216,7 +216,7 @@
       "name": "create-eliza",
       "version": "1.0.0-alpha.35",
       "bin": {
-        "create-eliza": "index.mjs",
+        "create-eliza": "index.mjs"
       },
     },
     "packages/docs": {

--- a/packages/cli/src/server/index.ts
+++ b/packages/cli/src/server/index.ts
@@ -94,23 +94,34 @@ export class AgentServer {
 				"00000000-0000-0000-0000-000000000002",
 			);
 
-			// Initialize the database
-			this.database
-				.init()
-				.then(() => {
-					logger.success("Database initialized successfully");
-					this.initializeServer(options);
-				})
-				.catch((error) => {
-					logger.error("Failed to initialize database:", error);
-					throw error;
-				});
+			// Database initialization moved to initialize() method
 		} catch (error) {
 			logger.error("Failed to initialize AgentServer:", error);
 			throw error;
 		}
+	}
 
-		logger.info(`Server started at ${AGENT_RUNTIME_URL}`);
+	/**
+	 * Initializes the database and server.
+	 * 
+	 * @param {ServerOptions} [options] - Optional server options.
+	 * @returns {Promise<void>} A promise that resolves when initialization is complete.
+	 */
+	public async initialize(options?: ServerOptions): Promise<void> {
+		try {
+			// Initialize the database with await
+			await this.database.init();
+			logger.success("Database initialized successfully");
+			
+			// Only continue with server initialization after database is ready
+			await this.initializeServer(options);
+			
+			// Move this message here to be more accurate
+			logger.info(`Server started at ${AGENT_RUNTIME_URL}`);
+		} catch (error) {
+			logger.error("Failed to initialize:", error);
+			throw error;
+		}
 	}
 
 	/**

--- a/packages/plugin-sql/drizzle.config.ts
+++ b/packages/plugin-sql/drizzle.config.ts
@@ -7,11 +7,6 @@ export default defineConfig({
 	dialect: "postgresql",
 	schema: "./src/schema/index.ts",
 	out: "./drizzle/migrations",
-	migrations: {
-		table: "__drizzle_migrations",
-		schema: "public",
-		prefix: "timestamp",
-	},
 	dbCredentials: {
 		url: process.env.POSTGRES_URL || "file://../../pglite",
 	},

--- a/packages/plugin-sql/src/pg-lite/manager.ts
+++ b/packages/plugin-sql/src/pg-lite/manager.ts
@@ -104,23 +104,6 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
 	}
 
 	/**
-	 * Asynchronously checks if migrations exist in the database.
-	 * @returns {Promise<boolean>} A Promise that resolves to true if migrations exist, otherwise false.
-	 */
-	private async hasMigrations(): Promise<boolean> {
-		try {
-			const result = await this.client.query(
-				"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = '__drizzle_migrations')"
-			);
-			return (result.rows[0] as any).exists;
-		} catch (error) {
-			logger.error("Failed to check migrations:", error);
-			return false;
-		}
-	}
-
-
-	/**
 	 * Initializes the client for PGlite.
 	 *
 	 * @returns {Promise<void>} A Promise that resolves when the client is initialized successfully
@@ -158,20 +141,19 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
 
 	/**
 	 * Asynchronously runs database migrations using Drizzle.
+	 * 
+	 * Drizzle will first check if the migrations are already applied.
+	 * If there is a diff between database schema and migrations, it will apply the migrations.
+	 * If they are already applied, it will skip them.
 	 *
 	 * @returns {Promise<void>} A Promise that resolves once the migrations are completed successfully.
 	 */
 	async runMigrations(): Promise<void> {
 		try {
 			const db = drizzle(this.client);
-			if (await this.hasMigrations()) {
-				logger.info("Migrations already exist, skipping...");
-				return;
-			}
 			await migrate(db, {
 				migrationsFolder: path.resolve(__dirname, "../drizzle/migrations"),
 			});
-			logger.info("Migrations completed successfully!");
 		} catch (error) {
 			logger.error("Failed to run database migrations (pglite):", error);
 			// throw error;

--- a/packages/plugin-sql/src/pg/manager.ts
+++ b/packages/plugin-sql/src/pg/manager.ts
@@ -179,22 +179,6 @@ export class PostgresConnectionManager
 	}
 
 	/**
-	 * Asynchronously checks if migrations exist in the database.
-	 * @returns {Promise<boolean>} A Promise that resolves to true if migrations exist, otherwise false.
-	 */
-	private async hasMigrations(): Promise<boolean> {
-		try {
-			const result = await this.pool.query(
-				"SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = '__drizzle_migrations')"
-			);
-			return result.rows[0].exists;
-		} catch (error) {
-			logger.error("Failed to check migrations:", error);
-			return false;
-		}
-	}
-
-	/**
 	 * Cleans up and closes the database pool.
 	 * @returns {Promise<void>} A Promise that resolves when the database pool is closed.
 	 */
@@ -210,22 +194,20 @@ export class PostgresConnectionManager
 	/**
 	 * Asynchronously runs database migrations using the Drizzle library.
 	 *
+	 * Drizzle will first check if the migrations are already applied.
+	 * If there is a diff between database schema and migrations, it will apply the migrations.
+	 * If they are already applied, it will skip them.
+	 *
 	 * @returns {Promise<void>} A Promise that resolves once the migrations are completed successfully.
 	 */
 	async runMigrations(): Promise<void> {
 		try {
 			const db = drizzle(this.pool);
-			if (await this.hasMigrations()) {
-				logger.info("Migrations already exist, skipping...");
-				return;
-			}
 			await migrate(db, {
 				migrationsFolder: path.resolve(__dirname, "../drizzle/migrations"),
 			});
-			logger.info("Migrations completed successfully!");
 		} catch (error) {
 			logger.error("Failed to run database migrations (pg):", error);
-			// throw error;
 			console.trace(error);
 		}
 	}


### PR DESCRIPTION
### What Changed

1. **Unified Migration Sources**
   - Modified `drizzle.config.ts` to ensure that `npx drizzle-kit migrate` generates identical migrations as our code-based migrator
   - This eliminates inconsistencies between static and runtime migration approaches

2. **Improved Migration Process**
   - The CLI database initialization must now be awaited to ensure migrations run to completion
   - All database client managers call `runMigrations()` which leverages Drizzle's built-in migration detection

3. **Smarter Migration Application**
   - Instead of manually checking for applied migrations (which can confuse Drizzle), we now let Drizzle handle diff detection:
   - If there's a difference between the database schema and migrations, Drizzle will apply them
   - If migrations are already applied, Drizzle will skip them
   - This approach works better with schema alterations during development

### Available Migration Methods

The following approaches are now unified and produce consistent results:

1. **Static Migration Generation**:
   ```
   npx drizzle-kit migrate
   ```

2. **Script-based Migration**:
   ```
   bun migrate
   ```
   Runs migrations with connection manager and Drizzle migrator

3. **Runtime Migration**:
   Simply run the project, and it will automatically apply required migrations using the appropriate driver's migrator

### Benefits

- **Developer Experience**: No conflicts when altering tables in development mode
- **Consistency**: Same migration strategy regardless of how the application is started
- **Reliability**: Leverages Drizzle's built-in migration detection rather than custom logic
- **Flexibility**: Choose the migration approach that fits your workflow