### PR TITLE
0xbbjoker/package scoped singleton db connections

### DIFF
--- a/packages/plugin-sql/src/index.ts
+++ b/packages/plugin-sql/src/index.ts
@@ -10,9 +10,30 @@ import { PGliteClientManager } from "./pg-lite/manager";
 import { PgDatabaseAdapter } from "./pg/adapter";
 import { PostgresConnectionManager } from "./pg/manager";
 
-// Singleton connection managers
-let pgLiteClientManager: PGliteClientManager;
-let postgresConnectionManager: PostgresConnectionManager;
+/**
+ * Global Singleton Instances (Package-scoped)
+ *
+ * These instances are stored globally within the package scope to ensure a single shared instance across multiple adapters within this package.
+ * This approach prevents multiple instantiations due to module caching or multiple imports within the same process.
+ *
+ * IMPORTANT:
+ * - Do NOT directly modify these instances outside their intended initialization logic.
+ * - These instances are NOT exported and should NOT be accessed outside this package.
+ */
+const GLOBAL_SINGLETONS = Symbol.for("@elizaos/plugin-sql/global-singletons");
+
+interface GlobalSingletons {
+	pgLiteClientManager?: PGliteClientManager;
+	postgresConnectionManager?: PostgresConnectionManager;
+}
+
+const globalSymbols = global as unknown as Record<symbol, GlobalSingletons>;
+
+if (!globalSymbols[GLOBAL_SINGLETONS]) {
+	globalSymbols[GLOBAL_SINGLETONS] = {};
+}
+
+const globalSingletons = globalSymbols[GLOBAL_SINGLETONS];
 
 /**
  * Helper function to expand tilde in paths
@@ -42,26 +63,26 @@ export function createDatabaseAdapter(
 	},
 	agentId: UUID,
 ): IDatabaseAdapter {
-	// Expand tilde in database directory path if provided
 	if (config.dataDir) {
 		config.dataDir = expandTildePath(config.dataDir);
 	}
 
 	if (config.postgresUrl) {
-		if (!postgresConnectionManager) {
-			postgresConnectionManager = new PostgresConnectionManager(
+		if (!globalSingletons.postgresConnectionManager) {
+			globalSingletons.postgresConnectionManager = new PostgresConnectionManager(
 				config.postgresUrl,
 			);
 		}
-		return new PgDatabaseAdapter(agentId, postgresConnectionManager);
+		return new PgDatabaseAdapter(agentId, globalSingletons.postgresConnectionManager);
 	}
 
 	const dataDir = config.dataDir ?? "./elizadb";
 
-	if (!pgLiteClientManager) {
-		pgLiteClientManager = new PGliteClientManager({ dataDir });
+	if (!globalSingletons.pgLiteClientManager) {
+		globalSingletons.pgLiteClientManager = new PGliteClientManager({ dataDir });
 	}
-	return new PgliteDatabaseAdapter(agentId, pgLiteClientManager);
+
+	return new PgliteDatabaseAdapter(agentId, globalSingletons.pgLiteClientManager);
 }
 
 /**


### PR DESCRIPTION
# Database Connection Race Condition Fix

This PR fixes a race condition in the `@elizaos/plugin-sql` package where multiple database connections were being created unnecessarily. The issue occurred because module-level variables (`pgLiteClientManager` and `postgresConnectionManager`) were not being properly shared across multiple imports of the module.

## Solution

The solution implements a robust package-scoped singleton pattern using JavaScript symbols to ensure that:

- Only one database connection is created per process
- Multiple adapters can safely share the same connection instance
- Connection managers are properly encapsulated within the package scope

## Key Changes

- Replaced module-level variables with a symbol-based global singleton pattern
- Added comprehensive documentation explaining the pattern and its usage
- Updated the `createDatabaseAdapter` function to use the global singleton instances
