### PR TITLE
chore: fix missing `await` for tweet scraping

### DIFF
--- a/scripts/gettweets.mjs
+++ b/scripts/gettweets.mjs
@@ -22,7 +22,7 @@ const TWEETS_FILE = "tweets.json";
             console.log("Logged in successfully!");
 
             // Fetch all tweets for the user "@realdonaldtrump"
-            const tweets = scraper.getTweets("pmarca", 2000);
+            const tweets = await scraper.getTweets("pmarca", 2000);
 
             // Initialize an empty array to store the fetched tweets
             let fetchedTweets = [];


### PR DESCRIPTION
## What does this PR do?

I noticed that the call to `scraper.getTweets("pmarca", 2000)` wasn’t using `await`, so the `tweets` variable was getting the promise instead of the actual tweet data. This caused an issue when trying to access the tweets.
I’ve added the missing `await`, so now everything should work as expected and load the tweet data correctly.