### PR TITLE
fix: Make client use relative URL & firefox fixes

### DIFF
--- a/packages/client/src/components/chat.tsx
+++ b/packages/client/src/components/chat.tsx
@@ -11,6 +11,7 @@ import { useAgent, useMessages } from '@/hooks/use-query-hooks';
 import { cn, getEntityId, moment } from '@/lib/utils';
 import SocketIOManager from '@/lib/socketio-manager';
 import { WorldManager } from '@/lib/world-manager';
+import { randomUUID } from '@/lib/utils';
 import type { IAttachment } from '@/types';
 import type { Content, UUID } from '@elizaos/core';
 import { AgentStatus } from '@elizaos/core';
@@ -315,7 +316,7 @@ export default function Page({ agentId }: { agentId: UUID }) {
       senderName: USER_NAME,
       roomId: roomId,
       source: SOURCE_NAME,
-      id: crypto.randomUUID(), // Add a unique ID for React keys and duplicate detection
+      id: randomUUID(), // Add a unique ID for React keys and duplicate detection
     };
 
     console.log('[Chat] Adding user message to UI:', userMessage);

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -2,7 +2,6 @@ import type { Agent, Character, UUID, Memory } from '@elizaos/core';
 import { WorldManager } from './world-manager';
 
 const API_PREFIX = '/api';
-const BASE_URL = `http://localhost:${import.meta.env.VITE_SERVER_PORT}${API_PREFIX}`;
 
 /**
  * A function that handles fetching data from a specified URL with various options.
@@ -25,12 +24,9 @@ const fetcher = async ({
   headers?: HeadersInit;
 }) => {
   // Ensure URL starts with a slash if it's a relative path
-  const normalizedUrl = url.startsWith('/') ? url : `/${url}`;
+  const normalizedUrl = API_PREFIX + (url.startsWith('/') ? url : `/${url}`);
 
-  // Construct the full URL
-  const fullUrl = `${BASE_URL}${normalizedUrl}`;
-
-  console.log('API Request:', method || 'GET', fullUrl);
+  console.log('API Request:', method || 'GET', normalizedUrl);
 
   const options: RequestInit = {
     method: method ?? 'GET',
@@ -59,7 +55,7 @@ const fetcher = async ({
   }
 
   try {
-    const response = await fetch(fullUrl, options);
+    const response = await fetch(normalizedUrl, options);
     const contentType = response.headers.get('Content-Type');
 
     if (contentType === 'audio/mpeg') {

--- a/packages/client/src/lib/socketio-manager.ts
+++ b/packages/client/src/lib/socketio-manager.ts
@@ -3,8 +3,9 @@ import { SOCKET_MESSAGE_TYPE } from '@elizaos/core';
 import EventEmitter from 'eventemitter3';
 import { io, type Socket } from 'socket.io-client';
 import { WorldManager } from './world-manager';
+import { randomUUID } from './utils';
 
-const BASE_URL = `http://localhost:${import.meta.env.VITE_SERVER_PORT}`;
+//const BASE_URL = `http://localhost:${import.meta.env.VITE_SERVER_PORT}`;
 
 /**
  * SocketIOManager handles real-time communication between the client and server
@@ -44,7 +45,9 @@ class SocketIOManager extends EventEmitter {
     this.entityId = entityId;
 
     // Create a single socket connection
-    this.socket = io(BASE_URL, {
+    const fullURL = window.location.origin + '/';
+    console.log('connecting to', fullURL);
+    this.socket = io(fullURL, {
       autoConnect: true,
       reconnection: true,
     });
@@ -181,7 +184,7 @@ class SocketIOManager extends EventEmitter {
       await this.connectPromise;
     }
 
-    const messageId = crypto.randomUUID();
+    const messageId = randomUUID();
     const worldId = WorldManager.getWorldId();
 
     console.log(`[SocketIO] Sending message to room ${roomId}`);

--- a/packages/client/src/lib/utils.ts
+++ b/packages/client/src/lib/utils.ts
@@ -41,6 +41,11 @@ export function urlToCharacterName(urlName: string): string {
   return urlName.replace(/-+/g, ' ');
 }
 
+// crypto.randomUUID only works in https context in firefox
+export function randomUUID(): UUID {
+  return URL.createObjectURL(new Blob()).split('/').pop();
+}
+
 export function getEntityId(): UUID {
   const USER_ID_KEY = 'elizaos-client-user-id';
   const existingUserId = localStorage.getItem(USER_ID_KEY);
@@ -49,7 +54,7 @@ export function getEntityId(): UUID {
     return existingUserId as UUID;
   }
 
-  const newUserId = crypto.randomUUID() as UUID;
+  const newUserId = randomUUID() as UUID;
   localStorage.setItem(USER_ID_KEY, newUserId);
 
   return newUserId;

--- a/packages/client/src/lib/world-manager.ts
+++ b/packages/client/src/lib/world-manager.ts
@@ -1,4 +1,5 @@
 import type { UUID } from '@elizaos/core';
+import { randomUUID } from './utils';
 
 // Key used for storing the worldId in localStorage
 const WORLD_ID_KEY = 'elizaos-world-id';
@@ -28,7 +29,7 @@ export const WorldManager = {
     }
 
     // Create a new worldId if one doesn't exist
-    const newWorldId = crypto.randomUUID() as UUID;
+    const newWorldId = randomUUID() as UUID;
     localStorage.setItem(WORLD_ID_KEY, newWorldId);
 
     return newWorldId;
@@ -38,7 +39,7 @@ export const WorldManager = {
    * Reset the world ID (mainly for testing purposes)
    */
   resetWorldId: (): UUID => {
-    const newWorldId = crypto.randomUUID() as UUID;
+    const newWorldId = randomUUID() as UUID;
     localStorage.setItem(WORLD_ID_KEY, newWorldId);
     return newWorldId;
   },
@@ -67,7 +68,7 @@ export const WorldManager = {
 
     if (options?.isGroup) {
       // For group chats, generate a new UUID
-      return crypto.randomUUID() as UUID;
+      return randomUUID() as UUID;
     }
 
     // For 1:1 chats with an agent, use the agent ID as the room ID


### PR DESCRIPTION
- don't need localhost hardcoded
- fixes firefox since crypto.randomUUID is only available in https context and most users will be using http