### PR TITLE
Fixed a typo

### DIFF
--- a/docs/api/classes/MemoryCacheAdapter.md
+++ b/docs/api/classes/MemoryCacheAdapter.md
@@ -10,11 +10,11 @@
 
 ### new MemoryCacheAdapter()
 
-> **new MemoryCacheAdapter**(`initalData`?): [`MemoryCacheAdapter`](MemoryCacheAdapter.md)
+> **new MemoryCacheAdapter**(`initialData`?): [`MemoryCacheAdapter`](MemoryCacheAdapter.md)
 
 #### Parameters
 
-• **initalData?**: `Map`\<`string`, `string`\>
+• **initialData?**: `Map`\<`string`, `string`\>
 
 #### Returns
 


### PR DESCRIPTION
Fixed a typo in the parameter name from initalData → initialData for correct spelling.