### PR TITLE
chore: Fix JSDoc formatting in `traverse()` and typo fix

### DIFF
--- a/scripts/jsdoc-automation/src/DirectoryTraversal.ts
+++ b/scripts/jsdoc-automation/src/DirectoryTraversal.ts
@@ -58,9 +58,7 @@ export class DirectoryTraversal {
      * Traverses the directory based on PRFiles or all files in the root directory.
      * If PRFiles are detected, processes only files from the PR.
      * Otherwise, scans all files in the root directory for TypeScript files.
-     *
-     *
-     * @returns An array of string containing the files to process.
+     * @returns An array of strings containing the files to process.
      */
     public traverse(): string[] {
         if (this.prFiles.length > 0) {


### PR DESCRIPTION
## What does this PR do?

Removed a redundant line break before `@returns` for better readability. Also corrected a grammar issue:  
- **Before:** "An array of string"  
- **After:** "An array of strings"  

No code changes, just a small doc improvement 🚀