### PR TITLE
Eli2 107/validate and test cli commands functionality

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -440,7 +440,7 @@ export const create = new Command()
       logger.info(`\nYour project is ready! Here's what you can do next:
 1. \`cd ${cdPath}\` to change into your project directory
 2. Run \`npx elizaos start\` to start your project
-3. Visit \`http://localhost:3000\` to view your project in the browser`);
+3. Visit \`http://localhost:3000\` (or your custom port) to view your project in the browser`);
 
       // exit successfully
       // Set the user's shell working directory before exiting

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -273,7 +273,9 @@ export const create = new Command()
       }
 
       // Set up target directory
-      const targetDir = options.dir === '.' ? path.resolve(name) : path.resolve(options.dir);
+      // If -d is ".", create in current directory with project name
+      // If -d is specified, create project directory inside that directory
+      const targetDir = path.resolve(options.dir, name);
 
       // Create or check directory
       if (!existsSync(targetDir)) {
@@ -323,9 +325,9 @@ export const create = new Command()
 
         logger.success('Plugin initialized successfully!');
         logger.info(`\nYour plugin is ready! Here's what you can do next:
-1. \`${colors.cyan('npx @elizaos/cli start')}\` to start development
-2. \`${colors.cyan('npx @elizaos/cli test')}\` to test your plugin
-3. \`${colors.cyan('npx @elizaos/cli plugins publish')}\` to publish your plugin to the registry`);
+1. \`${colors.cyan('npx elizaos start')}\` to start development
+2. \`${colors.cyan('npx elizaos test')}\` to test your plugin
+3. \`${colors.cyan('npx elizaos publish')}\` to publish your plugin to the registry`);
         return;
       }
 
@@ -407,9 +409,14 @@ export const create = new Command()
       logger.success('Project initialized successfully!');
 
       // Show next steps with updated message
+      const cdPath =
+        options.dir === '.'
+          ? name // If creating in current directory, just use the name
+          : path.relative(process.cwd(), targetDir); // Otherwise use path relative to current directory
+
       logger.info(`\nYour project is ready! Here's what you can do next:
-1. \`cd ${targetDir}\` to change into your project directory
-2. Run \`npx @elizaos/cli start\` to start your project
+1. \`cd ${cdPath}\` to change into your project directory
+2. Run \`npx elizaos start\` to start your project
 3. Visit \`http://localhost:3000\` to view your project in the browser`);
 
       // exit successfully

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -334,15 +334,23 @@ export const create = new Command()
           );
         }
 
-        // Change to the created directory
-        logger.info(`Changing to directory: ${targetDir}`);
-        process.chdir(targetDir);
-
         logger.success('Plugin initialized successfully!');
+
+        // Get the relative path for display
+        const cdPath =
+          options.dir === '.'
+            ? projectName // If creating in current directory, just use the name
+            : path.relative(process.cwd(), targetDir); // Otherwise use path relative to current directory
+
         logger.info(`\nYour plugin is ready! Here's what you can do next:
-1. \`${colors.cyan('npx elizaos start')}\` to start development
-2. \`${colors.cyan('npx elizaos test')}\` to test your plugin
-3. \`${colors.cyan('npx elizaos publish')}\` to publish your plugin to the registry`);
+1. \`cd ${cdPath}\` to change into your plugin directory
+2. \`${colors.cyan('npx elizaos start')}\` to start development
+3. \`${colors.cyan('npx elizaos test')}\` to test your plugin
+4. \`${colors.cyan('npx elizaos publish')}\` to publish your plugin to the registry`);
+
+        // Set the user's shell working directory before exiting
+        // Note: This only works if the CLI is run with shell integration
+        process.stdout.write(`\u001B]1337;CurrentDir=${targetDir}\u0007`);
         return;
       }
 

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -109,10 +109,13 @@ function isValidPostgresUrl(url: string): boolean {
   // Basic pattern: postgresql://user:password@host:port/dbname
   const basicPattern = /^postgresql:\/\/[^:]+:[^@]+@[^:]+:\d+\/\w+$/;
 
+  // Cloud pattern: allows for URLs with query parameters like sslmode=require
+  const cloudPattern = /^postgresql:\/\/[^:]+:[^@]+@[^\/]+\/[^?]+(\?.*)?$/;
+
   // More permissive pattern (allows missing password, different formats)
   const permissivePattern = /^postgresql:\/\/.*@.*:\d+\/.*$/;
 
-  return basicPattern.test(url) || permissivePattern.test(url);
+  return basicPattern.test(url) || cloudPattern.test(url) || permissivePattern.test(url);
 }
 
 /**

--- a/packages/cli/src/server/index.ts
+++ b/packages/cli/src/server/index.ts
@@ -55,6 +55,7 @@ export class AgentServer {
   private agents: Map<UUID, IAgentRuntime>;
   public server: http.Server;
   public socketIO: SocketIOServer;
+  private serverPort: number = 3000; // Add property to store current port
 
   public database: any;
   public startAgent!: (character: Character) => Promise<IAgentRuntime>;
@@ -113,10 +114,7 @@ export class AgentServer {
       // wait 250 ms
       await new Promise((resolve) => setTimeout(resolve, 250));
 
-      // Move this message here to be more accurate
-      console.log(
-        `\x1b[32mStartup successful!\nGo to the dashboard at \x1b[1m${AGENT_RUNTIME_URL}\x1b[22m\x1b[0m`
-      );
+      // Success message moved to start method
     } catch (error) {
       logger.error('Failed to initialize:', error);
       throw error;
@@ -490,12 +488,19 @@ export class AgentServer {
         throw new Error(`Invalid port number: ${port}`);
       }
 
+      this.serverPort = port; // Save the port
+
       logger.debug(`Starting server on port ${port}...`);
       logger.debug(`Current agents count: ${this.agents.size}`);
       logger.debug(`Environment: ${process.env.NODE_ENV}`);
 
       // Use http server instead of app.listen
       this.server.listen(port, () => {
+        // Display the dashboard URL with the correct port after the server is actually listening
+        console.log(
+          `\x1b[32mStartup successful!\nGo to the dashboard at \x1b[1mhttp://localhost:${port}\x1b[22m\x1b[0m`
+        );
+
         logger.success(
           `REST API bound to 0.0.0.0:${port}. If running locally, access it at http://localhost:${port}.`
         );

--- a/packages/cli/src/utils/env-prompt.ts
+++ b/packages/cli/src/utils/env-prompt.ts
@@ -114,6 +114,16 @@ const ENV_VAR_CONFIGS: Record<string, EnvVarConfig[]> = {
       secret: false,
     },
   ],
+  postgresql: [
+    {
+      name: 'PostgreSQL URL',
+      key: 'POSTGRES_URL',
+      required: false,
+      description: 'URL for connecting to your PostgreSQL database.',
+      url: 'https://neon.tech/docs/connect/connect-from-any-app',
+      secret: false,
+    },
+  ],
 };
 
 /**
@@ -486,6 +496,19 @@ export function validatePluginConfig(pluginName: string): {
       return {
         valid: true,
         message: 'Anthropic API is properly configured.',
+      };
+
+    case 'postgresql':
+      if (!envVars.POSTGRES_URL || envVars.POSTGRES_URL.trim() === '') {
+        return {
+          valid: true, // Not required by default
+          message: 'PostgreSQL URL is not configured. Using default PGLite database.',
+        };
+      }
+
+      return {
+        valid: true,
+        message: 'PostgreSQL connection is configured.',
       };
 
     default:


### PR DESCRIPTION
# CLI Improvements and Bug Fixes

This PR includes several improvements to the CLI experience and fixes various bugs related to command execution and project setup.

## Key Changes

### Command Standardization and Simplification
* Standardized npx commands across the project, making them more consistent and easier to use
* Unified post-creation directions between projects and plugins for better consistency
* Simplified cd paths in setup instructions

### Bug Fixes
* Fixed custom port display in dashboard URL (previously always showed port 3000)
* Fixed -t flag to properly pass project/plugin name
* Fixed -d flag functionality
* Added support for cloud URL pattern for PostgreSQL to prevent unnecessary warnings
* Fixed --configure flag and added missing imports

### Technical Improvements
* Added support for cloud-hosted PostgreSQL URL patterns
* Enhanced error handling and configuration validation
* Standardized command output formatting

## Note on Testing Progress

This PR represents Part 1 of a comprehensive CLI testing initiative. In this phase, we've completed thorough testing of `npx elizaos create` and `npx elizaos start` commands with all their flags and combinations. Part 2 will focus on testing the remaining CLI commands (test, publish, etc.) and their respective flags.

*Note: This PR is ready for review. Part 2 will be submitted as a separate PR after completion of remaining command testing.*