### PR TITLE
fix: openai stt

### DIFF
--- a/packages/plugin-openai/src/index.ts
+++ b/packages/plugin-openai/src/index.ts
@@ -389,7 +389,8 @@ export const openaiPlugin: Plugin = {
       logger.log('audioBuffer', audioBuffer);
       const baseURL = runtime.getSetting('OPENAI_BASE_URL') ?? 'https://api.openai.com/v1';
       const formData = new FormData();
-      formData.append('file', new Blob([audioBuffer], { type: 'audio/mp3' }));
+
+      formData.append('file', new File([audioBuffer], 'recording.mp3', { type: 'audio/mp3' }));
       formData.append('model', 'whisper-1');
       const response = await fetch(`${baseURL}/audio/transcriptions`, {
         method: 'POST',


### PR DESCRIPTION
Currently, OpenAI transcription is not working with the GUI and Discord. I'm not sure, but maybe something changed on OpenAI's end since I didn't see any related changes in our codebase. I changed it to use a file instead of a blob, and it now works with both the GUI and Discord as I tested.