### PR TITLE
chore: removed duplicate JSON import

### DIFF
--- a/scripts/bug_hunt/main.py
+++ b/scripts/bug_hunt/main.py
@@ -27,7 +27,6 @@ def setup_logging():
 logger = setup_logging()
 
 from typing import Dict, Any, List, Optional
-import json
 import asyncio
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskID
 from rich.markdown import Markdown


### PR DESCRIPTION
## What does this PR do?

I noticed that the `json` module is imported twice in the code.
I removed the second import to clean up the code and improve readability.