### PR TITLE
fix: opus issue

### DIFF
--- a/packages/plugin-discord/package.json
+++ b/packages/plugin-discord/package.json
@@ -22,10 +22,13 @@
     "dist"
   ],
   "dependencies": {
+    "@discordjs/opus": "^0.10.0",
     "@discordjs/rest": "2.4.0",
     "@discordjs/voice": "0.18.0",
     "discord.js": "14.16.3",
     "get-func-name": "^3.0.0",
+    "node-opus": "^0.3.3",
+    "opusscript": "^0.1.1",
     "prism-media": "1.3.5",
     "zod": "3.24.2"
   },


### PR DESCRIPTION
related: https://github.com/elizaOS/eliza/issues/3955

Hi @jmikedupont2, could you provide the reproduction steps for the issue? I've noticed this error message when I try to use voice in Discord, so I’ve added the missing dependencies to the Discord package.json. Could you kindly test it on your end to see if it resolves the issue?