### PR TITLE
chore: Fix missing comma in section headers list

### DIFF
--- a/docs/scripts/get-changelog.py
+++ b/docs/scripts/get-changelog.py
@@ -117,7 +117,7 @@ def process_content_block(content):
         r'^## (Other.*?)$',
         r'^## (Major changes.*?)$',
         r'^## (New Features.*?)$',
-        r'^## (New Fixes.*?)$'
+        r'^## (New Fixes.*?)$',
         r'^## (New Contributors.*?)$'
     ]
     


### PR DESCRIPTION
## What does this PR do?

Noticed a missing comma in the `section_headers` list, which caused the last regex pattern to be concatenated incorrectly. This could lead to `New Contributors` headers not being processed as expected.  

Fixed by adding the missing comma to ensure proper separation of regex patterns.