### PR TITLE
feat: [discord] community manager greet + timeout user

### DIFF
--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -236,13 +236,13 @@ export const formatMessages = ({
 
       const timestamp = formatTimestamp(message.createdAt);
 
-      const shortId = message.entityId.slice(-5);
+      // const shortId = message.entityId.slice(-5);
 
       const thoughtString = messageThought
         ? `(${formattedName}'s internal thought: ${messageThought})`
         : null;
 
-      const timestampString = `${timeString} (${timestamp}) [${shortId}]`;
+      const timestampString = `${timeString} (${timestamp}) [${message.entityId}]`;
       const textString = messageText ? `${timestampString} ${formattedName}: ${messageText}` : null;
       const actionString =
         messageActions && messageActions.length > 0

--- a/packages/plugin-discord/src/service.ts
+++ b/packages/plugin-discord/src/service.ts
@@ -202,11 +202,14 @@ export class DiscordService extends Service implements IDiscordService {
       ? `${member.user.username}#${member.user.discriminator}`
       : member.user.username;
 
+    const worldId = createUniqueUuid(this.runtime, guild.id);
+    const entityId = createUniqueUuid(this.runtime, member.id);
+
     // Emit standardized ENTITY_JOINED event
     this.runtime.emitEvent([EventType.ENTITY_JOINED], {
       runtime: this.runtime,
-      entityId: createUniqueUuid(this.runtime, member.id),
-      worldId: createUniqueUuid(this.runtime, guild.id),
+      entityId,
+      worldId,
       source: 'discord',
       metadata: {
         originalId: member.id,
@@ -220,9 +223,10 @@ export class DiscordService extends Service implements IDiscordService {
     // Emit Discord-specific event
     this.runtime.emitEvent([DiscordEventTypes.ENTITY_JOINED], {
       runtime: this.runtime,
-      entityId: createUniqueUuid(this.runtime, member.id),
+      entityId,
       member,
       guild,
+      worldId,
     });
   }
 

--- a/packages/the-org/src/communityManager/index.ts
+++ b/packages/the-org/src/communityManager/index.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type { Character, IAgentRuntime, OnboardingConfig, ProjectAgent } from '@elizaos/core';
 import dotenv from 'dotenv';
 import { initCharacter } from '../init';
+import communityManagerPlugin from './plugins/communityManager';
 
 const imagePath = path.resolve('./src/communityManager/assets/portrait.jpg');
 
@@ -29,12 +30,12 @@ export const character: Character = {
   name: 'Eliza',
   plugins: [
     '@elizaos/plugin-sql',
-    '@elizaos/plugin-anthropic',
+    // '@elizaos/plugin-anthropic',
     '@elizaos/plugin-openai',
     '@elizaos/plugin-discord',
-    '@elizaos/plugin-twitter',
-    '@elizaos/plugin-pdf',
-    '@elizaos/plugin-video-understanding',
+    // '@elizaos/plugin-twitter',
+    // '@elizaos/plugin-pdf',
+    // '@elizaos/plugin-video-understanding',
   ],
   settings: {
     secrets: {
@@ -405,6 +406,7 @@ const config: OnboardingConfig = {
 
 export const communityManager: ProjectAgent = {
   character,
+  plugins: [communityManagerPlugin],
   init: async (runtime: IAgentRuntime) => await initCharacter({ runtime, config }),
 };
 

--- a/packages/the-org/src/communityManager/index.ts
+++ b/packages/the-org/src/communityManager/index.ts
@@ -30,12 +30,12 @@ export const character: Character = {
   name: 'Eliza',
   plugins: [
     '@elizaos/plugin-sql',
-    // '@elizaos/plugin-anthropic',
+    '@elizaos/plugin-anthropic',
     '@elizaos/plugin-openai',
     '@elizaos/plugin-discord',
-    // '@elizaos/plugin-twitter',
-    // '@elizaos/plugin-pdf',
-    // '@elizaos/plugin-video-understanding',
+    '@elizaos/plugin-twitter',
+    '@elizaos/plugin-pdf',
+    '@elizaos/plugin-video-understanding',
   ],
   settings: {
     secrets: {

--- a/packages/the-org/src/communityManager/plugins/communityManager/actions/discord-timeout.ts
+++ b/packages/the-org/src/communityManager/plugins/communityManager/actions/discord-timeout.ts
@@ -1,0 +1,291 @@
+import {
+  type Action,
+  type ActionExample,
+  ChannelType,
+  type HandlerCallback,
+  type IAgentRuntime,
+  type Memory,
+  type State,
+  logger,
+  ModelType,
+  composePromptFromState,
+} from '@elizaos/core';
+import { PermissionsBitField } from 'discord.js';
+
+export const timeoutUserTemplate = `
+# Message Format
+
+Each line looks like this:
+
+[TIMESTAMP] [ENTITY_ID] USERNAME: message content
+
+- The ENTITY_ID is the unique user identifier and is the only thing you should return.
+- USERNAME is shown for context only — do not return it.
+- Mentions like (@some_id) or @username may appear in messages. Do not return those unless that user is clearly the one causing problems.
+- Mentions can be false accusations. Focus on the message content and tone to decide who is violating the rules.
+
+# Instructions
+
+Your job is to:
+1. Identify the ENTITY_ID of a user who is clearly:
+   - Spamming
+   - Using offensive or abusive language
+   - Spreading FUD or harmful content
+
+2. Decide a timeout duration in **seconds**:
+   - Mild offense: 30–60
+   - Moderate: 300–600 (5–10 min)
+   - Severe: 1800+ (30 min or more)
+
+# Output Format
+
+Respond only with a JSON object:
+
+\`\`\`json
+{
+  "id": "ENTITY_ID",
+  "duration": TIMEOUT_IN_SECONDS
+}
+\`\`\`
+
+Or respond with:
+
+\`\`\`json
+{ "id": "none" }
+\`\`\`
+
+if no one should be timed out.
+
+# Conversation
+
+{{recentMessages}}
+`;
+
+const getTargetUserFromMessages = async (
+  runtime: IAgentRuntime,
+  state: State
+): Promise<{ targetEntityId: string | null; timeoutDuration: number | null }> => {
+  const prompt = composePromptFromState({
+    state,
+    template: timeoutUserTemplate,
+  });
+
+  const response = await runtime.useModel(ModelType.TEXT_LARGE, {
+    prompt,
+  });
+
+  let jsonMatch = response.match(/```json\s*([\s\S]*?)```/);
+  const jsonString = jsonMatch ? jsonMatch[1] : response;
+
+  try {
+    const parsed = JSON.parse(jsonString.trim());
+
+    if (!parsed.id || parsed.id.toLowerCase() === 'none') {
+      return { targetEntityId: null, timeoutDuration: null };
+    }
+
+    return {
+      targetEntityId: parsed.id,
+      timeoutDuration: parsed.duration ?? 30, // default to 30s if not provided
+    };
+  } catch (err) {
+    logger.warn(
+      `[TIMEOUT_USER] Failed to parse LLM timeout JSON response: ${err} Raw output: ${response}`
+    );
+    return { targetEntityId: null, timeoutDuration: null };
+  }
+};
+
+export const discordTimeoutUser: Action = {
+  name: 'TIMEOUT_USER',
+  similes: ['TIMEOUT_USER', 'MODERATION_TIMEOUT', 'FUD_TIMEOUT'],
+  description: 'Timeout users who are spreading FUD, spamming, or using inappropriate language.',
+  validate: async (runtime, message, state) => {
+    if (message.content.source !== 'discord') return false;
+    const room = state.data.room ?? (await runtime.getRoom(message.roomId));
+    return room?.type === ChannelType.GROUP;
+  },
+  handler: async (
+    runtime: IAgentRuntime,
+    message: Memory,
+    state: State,
+    _options: any,
+    callback: HandlerCallback
+  ): Promise<boolean> => {
+    logger.info('[TIMEOUT_USER] Checking for target user to timeout...');
+    const room = state.data.room ?? (await runtime.getRoom(message.roomId));
+    const serverId = room?.serverId;
+    if (!serverId) {
+      logger.error('[TIMEOUT_USER] Server ID is missing from room data.');
+      return false;
+    }
+
+    const discordClient = runtime.getService('discord') as any;
+    const guild = discordClient.client.guilds.cache.get(serverId);
+    if (!guild) return false;
+
+    const hasTimeoutPermission = guild.members.me?.permissions.has(
+      PermissionsBitField.Flags.ModerateMembers
+    );
+
+    if (!hasTimeoutPermission) {
+      logger.warn('[TIMEOUT_USER] Missing Moderate Members permission. Cannot perform timeout.');
+      await callback({
+        text: `⚠️ I don't have permission to timeout members. Please give me the **Moderate Members** permission.`,
+        source: 'discord',
+      });
+      return false;
+    }
+
+    const { targetEntityId, timeoutDuration } = await getTargetUserFromMessages(runtime, state);
+    logger.info(
+      `[TIMEOUT_USER] Target identified: ${targetEntityId}, Duration: ${timeoutDuration}s`
+    );
+
+    if (!targetEntityId || !timeoutDuration) {
+      logger.warn('[TIMEOUT_USER] No valid user found to timeout or invalid duration.');
+      return false;
+    }
+
+    let entity = null;
+    try {
+      entity = await (runtime as any).adapter.getEntityById(targetEntityId);
+    } catch (err) {
+      logger.error('[TIMEOUT_USER] Failed to retrieve entity by ID:', err);
+      await callback({
+        text: `⚠️ I couldn't find the user to timeout due to an internal error.`,
+        source: 'discord',
+      });
+      return false;
+    }
+
+    if (!entity) {
+      logger.warn('[TIMEOUT_USER] Entity not found for given ID.');
+      return false;
+    }
+
+    const entityName = entity.metadata['discord']?.userName;
+
+    if (!entityName) {
+      logger.warn('[TIMEOUT_USER] Could not find Discord username in entity metadata.');
+      return false;
+    }
+
+    const member = guild.members.cache.find(
+      (m) => m.user.username.toLowerCase() === entityName.toLowerCase()
+    );
+
+    if (!member) {
+      logger.warn('[TIMEOUT_USER] Discord member not found in guild cache.');
+      return false;
+    }
+
+    try {
+      await member.timeout(timeoutDuration * 1000, 'Inappropriate language or spam detected');
+
+      await runtime.createMemory(
+        {
+          entityId: message.entityId,
+          agentId: message.agentId,
+          roomId: message.roomId,
+          content: {
+            source: 'discord',
+            thought: `${member.displayName} was timed out for inappropriate language.`,
+            actions: ['TIMEOUT_USER'],
+          },
+          metadata: {
+            type: 'MODERATION',
+          },
+        },
+        'messages'
+      );
+      return true;
+    } catch (err) {
+      logger.error(`[TIMEOUT_USER] Failed to timeout user ${member?.displayName}:`, err);
+      await callback({
+        text: `I tried to timeout ${member.displayName} but ran into an error.`,
+        source: 'discord',
+      });
+      return false;
+    }
+  },
+  examples: [
+    [
+      {
+        name: '{{name1}}',
+        content: {
+          text: 'this coin is a scam lol get out now',
+        },
+      },
+      {
+        name: '{{botName}}',
+        content: {
+          text: '{{name1}} has been timed out for FUD.',
+          actions: ['TIMEOUT_USER'],
+        },
+      },
+    ],
+    [
+      {
+        name: '{{name1}}',
+        content: {
+          text: 'fuck this project it’s going to zero',
+        },
+      },
+      {
+        name: '{{botName}}',
+        content: {
+          text: '{{name1}} has been muted for 10 minutes.',
+          actions: ['TIMEOUT_USER'],
+        },
+      },
+    ],
+    [
+      {
+        name: '{{name1}}',
+        content: {
+          text: 'I’m done with this crap — total rug',
+        },
+      },
+      {
+        name: '{{botName}}',
+        content: {
+          text: '{{name1}} has been timed out for aggressive messaging.',
+          actions: ['TIMEOUT_USER'],
+        },
+      },
+    ],
+    [
+      {
+        name: '{{name1}}',
+        content: {
+          text: 'absolute garbage project, can’t believe people buy this',
+        },
+      },
+      {
+        name: '{{botName}}',
+        content: {
+          text: '{{name1}} was muted for spreading toxicity.',
+          actions: ['TIMEOUT_USER'],
+        },
+      },
+    ],
+    [
+      {
+        name: '{{name1}}',
+        content: {
+          text: 'devs are lazy af — still no update',
+        },
+      },
+      {
+        name: '{{botName}}',
+        content: {
+          text: '{{name1}} has been timed out for disrespectful language.',
+          actions: ['TIMEOUT_USER'],
+        },
+      },
+    ],
+  ] as ActionExample[][],
+};
+
+export default discordTimeoutUser;

--- a/packages/the-org/src/communityManager/plugins/communityManager/communityService.ts
+++ b/packages/the-org/src/communityManager/plugins/communityManager/communityService.ts
@@ -1,0 +1,129 @@
+import {
+  type Entity,
+  type IAgentRuntime,
+  type Memory,
+  ModelType,
+  Service,
+  type UUID,
+  logger,
+  World,
+  createUniqueUuid,
+  ChannelType,
+} from '@elizaos/core';
+import { ServiceType } from './types';
+
+export class CommunityManagerService extends Service {
+  static serviceType = ServiceType.COMMUNITY_MANAGER;
+  capabilityDescription = 'community manager';
+
+  private handleDiscordUserJoined = this.onDiscordUserJoined.bind(this);
+
+  constructor(protected runtime: IAgentRuntime) {
+    super(runtime);
+
+    this.addEventListener(runtime);
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<CommunityManagerService> {
+    const service = new CommunityManagerService(runtime);
+    return service;
+  }
+
+  static async stop(runtime: IAgentRuntime): Promise<void> {
+    const service = runtime.getService(ServiceType.COMMUNITY_MANAGER);
+    if (service) {
+      await service.stop();
+    }
+  }
+
+  async stop(): Promise<void> {}
+
+  getGreetChannelId(world: World, guild): string | null {
+    const shouldGreetUser = world.metadata?.settings['SHOULD_GREET_NEW_PERSONS']?.value;
+    const greetChannel = world.metadata?.settings['GREETING_CHANNEL']?.value;
+
+    if (
+      !(
+        shouldGreetUser === true ||
+        String(shouldGreetUser).toLowerCase() === 'true' ||
+        String(shouldGreetUser).toLowerCase() === 'yes'
+      )
+    ) {
+      return null;
+    }
+
+    if (greetChannel) {
+      // Try to get channel by ID
+      let channel = guild.channels.cache.get(greetChannel);
+      if (channel?.isTextBased()) return channel.id;
+
+      // Try to match by name if not found by ID
+      const foundByName = guild.channels.cache.find(
+        (ch) => ch.isTextBased() && ch.name === greetChannel
+      );
+      if (foundByName) return foundByName.id;
+
+      logger.warn(`Greet channel "${greetChannel}" not found by ID or name.`);
+    }
+
+    // Fallback: pick any text-based channel
+    const fallback = guild.channels.cache.find((ch) => ch.isTextBased());
+    if (fallback) return fallback.id;
+
+    return null;
+  }
+
+  async onDiscordUserJoined(params) {
+    const runtime = params.runtime;
+    const member = params.member;
+    const entityId = params.entityId;
+    const guild = params.guild;
+    const worldId = params.worldId;
+
+    const world = await runtime.adapter.getWorld(worldId);
+    const greetChannelId = this.getGreetChannelId(world, guild);
+
+    if (greetChannelId) {
+      const channel = guild.channels.cache.get(greetChannelId);
+      if (channel?.isTextBased()) {
+        // TODO: Allow agents to use a custom greeting prompt from metadata.
+        // This allows server owners to personalize the bot's introduction message for new members.
+
+        const welcomeText = `Welcome <@${member.id}>! I'm ${runtime.character.name}, the community manager. Feel free to introduce yourself!`;
+        await channel.send(welcomeText);
+
+        const roomId = createUniqueUuid(runtime, greetChannelId);
+
+        await runtime.ensureRoomExists({
+          id: roomId,
+          source: 'discord',
+          type: ChannelType.GROUP,
+          channelId: greetChannelId,
+          serverId: guild.id,
+          worldId: worldId,
+        });
+
+        // Create memory of the initial message
+        await runtime.createMemory(
+          {
+            agentId: runtime.agentId,
+            entityId,
+            roomId: roomId,
+            content: {
+              text: welcomeText,
+              actions: ['GREET_NEW_PERSON'],
+            },
+            createdAt: Date.now(),
+          },
+          'messages'
+        );
+      } else {
+        logger.warn(`Channel ${greetChannelId} is not a text-based channel or not found.`);
+      }
+    }
+  }
+
+  addEventListener(runtime: IAgentRuntime): void {
+    runtime.registerEvent('DISCORD_USER_JOINED', this.handleDiscordUserJoined);
+  }
+}

--- a/packages/the-org/src/communityManager/plugins/communityManager/index.ts
+++ b/packages/the-org/src/communityManager/plugins/communityManager/index.ts
@@ -1,0 +1,14 @@
+import type { Plugin } from '@elizaos/core';
+import { CommunityManagerService } from './communityService';
+import discordTimeoutUser from './actions/discord-timeout';
+
+export const communityManagerPlugin: Plugin = {
+  name: 'community manager plugin',
+  description: 'community manager plugin plugin',
+  evaluators: [],
+  providers: [],
+  actions: [discordTimeoutUser],
+  services: [CommunityManagerService],
+};
+
+export default communityManagerPlugin;

--- a/packages/the-org/src/communityManager/plugins/communityManager/types.ts
+++ b/packages/the-org/src/communityManager/plugins/communityManager/types.ts
@@ -1,0 +1,3 @@
+export const ServiceType = {
+  COMMUNITY_MANAGER: 'community_manager',
+} as const;

--- a/packages/the-org/src/index.ts
+++ b/packages/the-org/src/index.ts
@@ -130,12 +130,12 @@ function hasRequiredEnvVars(agent: any): boolean {
 
 // Filter agents based on available environment variables
 const availableAgents = [
-  devRel,
+  // devRel,
   communityManager,
-  investmentManager,
-  liaison,
-  projectManager,
-  socialMediaManager,
+  // investmentManager,
+  // liaison,
+  // projectManager,
+  // socialMediaManager,
 ].filter(hasRequiredEnvVars);
 
 export const project = {


### PR DESCRIPTION
sub pr: https://github.com/elizaOS/eliza/pull/4063

**Summary**
This PR enables Discord community manager to automatically greet users when a new user joins. It also adds a new action that allows agents to timeout users

**TODO**
In a future PR, we could allow agents to use a custom greeting prompt from metadata, so agent can have different greeting message.

We should adapt this behavior to support other platforms, like Telegram.

**Notes**
I updated recentMessages to include the full entity ID so we can retrieve the target Discord username for the timeout action. Let me know if this is acceptable or if we should trim it down.


result:

<img width="1189" alt="Screenshot 2025-03-25 at 11 23 37 PM" src="https://github.com/user-attachments/assets/9192c63b-fadd-42dc-abf7-4e220a574654" />
