### PR TITLE
fix: Use PUT method for GitHub file operations to handle non-existent directories

### DIFF
--- a/packages/cli/src/utils/github.ts
+++ b/packages/cli/src/utils/github.ts
@@ -384,7 +384,9 @@ export async function updateFile(
   try {
     // Check if file already exists
     const existingContent = await getFileContent(token, owner, repo, path, branch);
-    const method = existingContent !== null ? 'PUT' : 'POST';
+    // GitHub API behavior: PUT works more reliably than POST for creating files
+    // in directories that may not exist yet, so we always use PUT
+    const method = 'PUT';
 
     // Get the SHA if the file exists
     let sha: string | undefined;


### PR DESCRIPTION
## Description
This PR fixes an issue where the CLI fails to create files in non-existent directories when using the GitHub API, specifically when test publishing a plugin. 

## Problem
When running `npx elizaos plugin publish --test` on a fresh fork, the CLI tries to use the POST method to create files in non-existent directories, which fails with 404 errors. However, using PUT works successfully for the same operation.

## Solution
Modified the `updateFile` function to always use the PUT method instead of conditionally using POST/PUT based on file existence. The GitHub API handles PUT requests more reliably when creating files in directories that don't exist yet.

## Testing
Tested by:
1. Deleting my fork of the registry
2. Running `npx elizaos plugin publish --test` with the original code (fails)
3. Running with the modified code that always uses PUT (succeeds)
4. Verified the test passes consistently when using PUT regardless of whether the directory/file exists

This change ensures a consistent experience for users without requiring them to run commands in a specific order.