### PR TITLE
fix: settings action

### DIFF
--- a/packages/core/src/actions/settings.ts
+++ b/packages/core/src/actions/settings.ts
@@ -397,23 +397,23 @@ async function extractSettingValues(
     function extractValidSettings(obj: unknown, worldSettings: WorldSettings) {
       const extracted = [];
 
-      function walk(node: unknown): void {
+      function traverse(node: unknown): void {
         if (Array.isArray(node)) {
           for (const item of node) {
-            walk(item);
+            traverse(item);
           }
         } else if (typeof node === 'object' && node !== null) {
           for (const [key, value] of Object.entries(node)) {
             if (worldSettings[key] && typeof value !== 'object') {
               extracted.push({ key, value });
             } else {
-              walk(value);
+              traverse(value);
             }
           }
         }
       }
 
-      walk(obj);
+      traverse(obj);
       return extracted;
     }
 

--- a/packages/core/src/actions/settings.ts
+++ b/packages/core/src/actions/settings.ts
@@ -405,7 +405,6 @@ async function extractSettingValues(
         } else if (typeof node === 'object' && node !== null) {
           for (const [key, value] of Object.entries(node)) {
             if (worldSettings[key] && typeof value !== 'object') {
-              // Push in desired format
               extracted.push({ key, value });
             } else {
               walk(value);

--- a/packages/core/src/actions/settings.ts
+++ b/packages/core/src/actions/settings.ts
@@ -387,8 +387,6 @@ async function extractSettingValues(
       }
     );
 
-    console.log('extracted settings response: ', result);
-
     // Validate the extracted settings
     if (!result) {
       return [];
@@ -419,7 +417,6 @@ async function extractSettingValues(
 
     const extractedSettings = extractValidSettings(result, worldSettings);
 
-    console.log('extractedSettings:', extractedSettings);
     return extractedSettings;
   } catch (error) {
     console.error('Error extracting settings:', error);

--- a/packages/core/src/providers/settings.ts
+++ b/packages/core/src/providers/settings.ts
@@ -67,23 +67,46 @@ function generateStatusMessage(
     // Generate appropriate message
     if (isOnboarding) {
       if (requiredUnconfigured > 0) {
-        return `# PRIORITY TASK: Onboarding with ${state.senderName}\n${
-          runtime.character.name
-        } still needs to configure ${requiredUnconfigured} required settings:\n\n${formattedSettings
-          .filter((s) => s.required && !s.configured)
-          .map((s) => `${s.key}: ${s.value}\n(${s.name}) ${s.usageDescription}`)
-          .join('\n\n')}\n\nValid settings keys: ${Object.keys(worldSettings).join(
-          ', '
-        )}\n\nIf the user gives any information related to the settings, ${
-          runtime.character.name
-        } should use the UPDATE_SETTINGS action to update the settings with this new information. ${
-          runtime.character.name
-        } can update any, some or all settings.`;
+        return `# PRIORITY TASK: Onboarding with ${state.senderName}
+    
+    ${runtime.character.name} needs to help the user configure ${requiredUnconfigured} required settings:
+    
+    ${formattedSettings
+      .map((s) => {
+        const label = s.required ? '(Required)' : '(Optional)';
+        return `${s.key}: ${s.value} ${label}\n(${s.name}) ${s.usageDescription}`;
+      })
+      .join('\n\n')}
+    
+    Valid setting keys: ${Object.keys(worldSettings).join(', ')}
+    
+    Instructions for ${runtime.character.name}:
+    
+    - Only update settings if the user is clearly responding to a setting you are currently asking about.
+    - If the user's reply clearly maps to a setting and a valid value, you **must** call the UPDATE_SETTINGS action with the correct key and value. Do not just respond with a message saying it's updated — it must be an action.
+    - Never assume or invent settings. Only use the keys listed above.
+    - If the user asks about a setting, respond using only the data from the list (name, description, and value).
+    - Prioritize configuring required settings before optional ones.`;
       }
-      return `All required settings have been configured! Here's the current configuration:\n\n${formattedSettings
-        .map((s) => `${s.name}: ${s.description}\nValue: ${s.value}`)
-        .join('\n')}`;
+
+      return `All required settings have been configured. Here's the current configuration:
+    
+      ${formattedSettings
+        .map((s) => {
+          const label = s.required ? '(Required)' : '(Optional)';
+          return `${s.key}: ${s.value} ${label}\n(${s.name}) ${s.usageDescription}`;
+        })
+        .join('\n\n')}
+      
+      Valid setting keys: ${Object.keys(worldSettings).join(', ')}
+    
+    Instructions for ${runtime.character.name}:
+    
+    - If the user provides a clear update to a setting, you **must** call the UPDATE_SETTINGS action. Do not just confirm it with a message — always use the action.
+    - Never hallucinate settings or respond with values not listed above.
+    - Answer setting-related questions using only the name, description, and value from the list.`;
     }
+
     // Non-onboarding context - list all public settings with values and descriptions
     return `## Current Configuration\n\n${
       requiredUnconfigured > 0
@@ -245,6 +268,8 @@ export const settingsProvider: Provider = {
 
       // Generate the status message based on the settings
       const output = generateStatusMessage(runtime, worldSettings, isOnboarding, state);
+
+      console.log('output', output);
 
       return {
         data: {

--- a/packages/core/src/providers/settings.ts
+++ b/packages/core/src/providers/settings.ts
@@ -266,8 +266,6 @@ export const settingsProvider: Provider = {
       // Generate the status message based on the settings
       const output = generateStatusMessage(runtime, worldSettings, isOnboarding, state);
 
-      console.log('output', output);
-
       return {
         data: {
           settings: worldSettings,

--- a/packages/core/src/providers/settings.ts
+++ b/packages/core/src/providers/settings.ts
@@ -66,45 +66,42 @@ function generateStatusMessage(
 
     // Generate appropriate message
     if (isOnboarding) {
-      if (requiredUnconfigured > 0) {
-        return `# PRIORITY TASK: Onboarding with ${state.senderName}
-    
-    ${runtime.character.name} needs to help the user configure ${requiredUnconfigured} required settings:
-    
-    ${formattedSettings
-      .map((s) => {
-        const label = s.required ? '(Required)' : '(Optional)';
-        return `${s.key}: ${s.value} ${label}\n(${s.name}) ${s.usageDescription}`;
-      })
-      .join('\n\n')}
-    
-    Valid setting keys: ${Object.keys(worldSettings).join(', ')}
-    
-    Instructions for ${runtime.character.name}:
-    
-    - Only update settings if the user is clearly responding to a setting you are currently asking about.
-    - If the user's reply clearly maps to a setting and a valid value, you **must** call the UPDATE_SETTINGS action with the correct key and value. Do not just respond with a message saying it's updated — it must be an action.
-    - Never assume or invent settings. Only use the keys listed above.
-    - If the user asks about a setting, respond using only the data from the list (name, description, and value).
-    - Prioritize configuring required settings before optional ones.`;
-      }
-
-      return `All required settings have been configured. Here's the current configuration:
-    
-      ${formattedSettings
+      const settingsList = formattedSettings
         .map((s) => {
           const label = s.required ? '(Required)' : '(Optional)';
           return `${s.key}: ${s.value} ${label}\n(${s.name}) ${s.usageDescription}`;
         })
-        .join('\n\n')}
+        .join('\n\n');
+
+      const validKeys = `Valid setting keys: ${Object.keys(worldSettings).join(', ')}`;
+
+      const commonInstructions = `Instructions for ${runtime.character.name}:
+      - Only update settings if the user is clearly responding to a setting you are currently asking about.
+      - If the user's reply clearly maps to a setting and a valid value, you **must** call the UPDATE_SETTINGS action with the correct key and value. Do not just respond with a message saying it's updated — it must be an action.
+      - Never hallucinate settings or respond with values not listed above.
+      - Answer setting-related questions using only the name, description, and value from the list.`;
+
+      if (requiredUnconfigured > 0) {
+        return `# PRIORITY TASK: Onboarding with ${state.senderName}
+
+        ${runtime.character.name} needs to help the user configure ${requiredUnconfigured} required settings:
+        
+        ${settingsList}
+        
+        ${validKeys}
+        
+        ${commonInstructions}
+        
+        - Prioritize configuring required settings before optional ones.`;
+      }
+
+      return `All required settings have been configured. Here's the current configuration:
       
-      Valid setting keys: ${Object.keys(worldSettings).join(', ')}
-    
-    Instructions for ${runtime.character.name}:
-    
-    - If the user provides a clear update to a setting, you **must** call the UPDATE_SETTINGS action. Do not just confirm it with a message — always use the action.
-    - Never hallucinate settings or respond with values not listed above.
-    - Answer setting-related questions using only the name, description, and value from the list.`;
+        ${settingsList}
+        
+        ${validKeys}
+        
+        ${commonInstructions}`;
     }
 
     // Non-onboarding context - list all public settings with values and descriptions


### PR DESCRIPTION
related: https://linear.app/eliza-labs/issue/ELI2-150/hallucinations-in-actions-and-response-of-agents

Currently, I haven’t been able to get the onboarding settings to work due to a few issues:

1. The agent keeps selecting UPDATE_SETTINGS even when I haven’t said anything. It immediately replies with:
"I couldn't understand your settings update. Please try again with a clearer format."

<img width="793" alt="Screenshot 2025-03-25 at 10 24 55 PM" src="https://github.com/user-attachments/assets/3fd304c7-7f30-43a6-92d5-57355cbcbb6d" />

<img width="746" alt="Screenshot 2025-03-25 at 10 34 31 PM" src="https://github.com/user-attachments/assets/7048f90a-258d-401e-8c03-994ef850f00d" />

**It also seems unaware of the current settings and ends up hallucinating them.**

<img width="762" alt="Screenshot 2025-03-27 at 11 49 16 AM" src="https://github.com/user-attachments/assets/7b92fae1-fcb7-4b4d-8e0c-e59cbaa14547" />

2. After fixing the above issue, I still couldn’t apply settings because the result gets cleaned to an empty object if it’s not an array:
https://github.com/elizaOS/eliza/blob/e20bd81fec5c8fd7a7987930faa18f79ab22e775/packages/core/src/actions/settings.ts#L391

I also noticed that the LLM sometimes returns a different structure instead of an array. For example:

```
{
  settings: {
    SHOULD_GREET_NEW_PERSONS: "true",
    GREETING_CHANNEL: "test2",
  },
}
```
```
{
    SHOULD_GREET_NEW_PERSONS: "yes",
}
```

So in this PR, I added a function that extracts valid key-value pairs from the result.

3. Even after fixing those issues, I still couldn’t update the settings that were already configured.

This PR fixes the above issues.

result:

<img width="828" alt="Screenshot 2025-03-25 at 10 30 37 PM" src="https://github.com/user-attachments/assets/9a507731-56b8-4989-badf-10652192f27b" />

<img width="748" alt="Screenshot 2025-03-27 at 11 51 21 AM" src="https://github.com/user-attachments/assets/1271304e-9529-4ca1-9582-80edcbe0805f" />
