### PR TITLE
fix: remove messageHandlerTemplate phase from bootstrap to speed replies up

### DIFF
--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -238,7 +238,7 @@ const messageReceivedHandler = async ({
         logger.debug(`*** Raw Response Type: ${typeof response} ***`);
 
         // parseJSONObjectFromText does a ```json check and clean
-        responseContent = parseJSONObjectFromText(processedResponse) as Content;
+        responseContent = parseJSONObjectFromText(response) as Content;
         logger.debug('*** Parsed Response Object ***', responseContent);
 
         retries++;


### PR DESCRIPTION
# Risks

Low, now messageReceivedHandler doesn't allow multiple action selection

# Background

## What does this PR do?

- retry on JSON parsing fails
- removed messageHandlerTemplate stage

## What kind of change is this?

Improvements (misc. changes to existing features)

## Why are we doing this? Any context or related work?

Remove 2nd small LLM call.

# Documentation changes needed?

My changes do not require a change to the project documentation.