### PR TITLE
Chore/plugin publishing fixes

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -191,28 +191,23 @@ export const create = new Command()
         projectName = nameResponse;
       }
 
-      // Set up target directory
-      // If -d is ".", create in current directory with project name
-      // If -d is specified, create project directory inside that directory
-      let targetDir = path.join(options.dir === '.' ? process.cwd() : options.dir, projectName);
+      // For plugin initialization, add the plugin- prefix if needed
+      if (options.type === 'plugin' && !projectName.startsWith('plugin-')) {
+        // Create a new directory name with the plugin- prefix
+        const prefixedName = `plugin-${projectName}`;
+        logger.info(
+          `Note: Using "${prefixedName}" as the directory name to match package naming convention`
+        );
+
+        // Update project name
+        projectName = prefixedName;
+      }
+
+      // Set up target directory - now calculated only once after projectName is finalized
+      const targetDir = path.join(options.dir === '.' ? process.cwd() : options.dir, projectName);
 
       // For plugin initialization, we can simplify the process
       if (options.type === 'plugin') {
-        // Check if projectName already has plugin- prefix
-        if (!projectName.startsWith('plugin-')) {
-          // Create a new directory name with the plugin- prefix
-          const prefixedName = `plugin-${projectName}`;
-          logger.info(
-            `Note: Using "${prefixedName}" as the directory name to match package naming convention`
-          );
-
-          // Update project name and target directory
-          projectName = prefixedName;
-
-          // Update targetDir to use the prefixed name
-          targetDir = path.join(options.dir === '.' ? process.cwd() : options.dir, projectName);
-        }
-
         // Now create the directory or check if it exists
         if (!existsSync(targetDir)) {
           await fs.mkdir(targetDir, { recursive: true });

--- a/packages/cli/src/commands/plugin.ts
+++ b/packages/cli/src/commands/plugin.ts
@@ -51,7 +51,7 @@ async function checkRegistryRequirements(cwd: string) {
   const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
 
   return {
-    name: packageJson.name.includes('plugin-'),
+    name: packageJson.name.includes('plugin-') || packageJson.name.includes('@elizaos/plugin-'),
     imagesDir: existsSync(path.join(cwd, 'images')),
     logoImage: existsSync(path.join(cwd, 'images', 'logo.jpg')),
     bannerImage: existsSync(path.join(cwd, 'images', 'banner.jpg')),
@@ -205,7 +205,8 @@ plugin
       logger.info('\n📋 Checking Registry Requirements...');
 
       const requirements = {
-        nameCorrect: packageJson.name?.includes('plugin-'),
+        nameCorrect:
+          packageJson.name?.includes('plugin-') || packageJson.name.includes('@elizaos/plugin-'),
         hasRepoUrl: !!packageJson.repository?.url,
         correctRepoUrl:
           packageJson.repository?.url?.includes('github:') &&
@@ -549,7 +550,9 @@ These files are required for registry submission. Your plugin submission will no
             logger.info('\n📋 Rechecking requirements...');
 
             const updatedRequirements = {
-              nameCorrect: packageJson.name?.includes('plugin-'),
+              nameCorrect:
+                packageJson.name?.includes('plugin-') ||
+                packageJson.name.includes('@elizaos/plugin-'),
               hasRepoUrl: !!packageJson.repository?.url,
               correctRepoUrl:
                 packageJson.repository?.url?.includes('github:') &&

--- a/packages/cli/src/commands/plugin.ts
+++ b/packages/cli/src/commands/plugin.ts
@@ -740,8 +740,7 @@ These files are required for registry submission. Your plugin submission will no
         // Push code to GitHub repository
         logger.info('\n📤 Pushing code to GitHub repository...');
 
-        // Use a more robust push approach with force by default
-        let pushResult = false;
+        // Use a more Git-friendly approach without force pushing
         try {
           // Initialize git repo if needed
           await execa('git', ['init'], { cwd });
@@ -763,30 +762,42 @@ These files are required for registry submission. Your plugin submission will no
           await execa('git', ['commit', '-m', 'Initial commit'], { cwd });
           logger.info('Committed changes');
 
-          // Push directly with force-with-lease to avoid errors
-          logger.info('Pushing to GitHub...');
-          await execa('git', ['push', '-u', 'origin', 'main', '--force-with-lease'], {
+          // Check if remote is empty before pushing
+          const remoteCheck = await execa('git', ['ls-remote', '--heads', 'origin'], {
             cwd,
             stdio: 'pipe',
+            reject: false,
           });
 
-          logger.success('✅ Successfully pushed code to GitHub repository!');
-          pushResult = true;
+          if (remoteCheck.exitCode === 0 && remoteCheck.stdout.trim() === '') {
+            // Remote exists but is empty, safe to push
+            logger.info('Remote repository is empty, pushing initial commit...');
+            await execa('git', ['push', '-u', 'origin', 'main'], { cwd });
+            logger.success('✅ Successfully pushed code to GitHub repository!');
+          } else {
+            // Remote has content, create a new branch instead of pushing to main
+            const setupBranch = `setup-${Date.now()}`;
+            logger.info(`Remote repository contains content, creating branch: ${setupBranch}`);
+            await execa('git', ['checkout', '-b', setupBranch], { cwd });
+            await execa('git', ['push', '-u', 'origin', setupBranch], { cwd });
+            logger.success(
+              `✅ Pushed code to branch '${setupBranch}'. Please merge this branch into main.`
+            );
+          }
         } catch (error) {
           logger.error('Failed to push to GitHub:', error.message);
+          logger.info('You may need to manually push your code to GitHub');
 
           const { shouldContinue } = await prompts({
             type: 'confirm',
             name: 'shouldContinue',
-            message: 'Failed to push code to GitHub. Continue with publishing to registry anyway?',
+            message: 'Continue with publishing to registry anyway?',
             initial: false,
           });
 
           if (!shouldContinue) {
             process.exit(1);
           }
-
-          pushResult = false;
         }
       } else {
         // Repository URL exists, but we should verify repo actually exists on GitHub
@@ -806,43 +817,92 @@ These files are required for registry submission. Your plugin submission will no
           });
 
           if (!response.ok) {
-            logger.warn(
-              `Repository at ${packageJson.repository.url} does not exist or is not accessible.`
-            );
-            logger.info('Creating repository and pushing code...');
+            if (response.status === 404) {
+              logger.info(
+                `Repository ${packageJson.repository.url} does not exist. Creating it now...`
+              );
 
-            // Create repository with the same name
-            const result = await createGitHubRepository(
-              credentials.token,
-              repoName,
-              packageJson.description || `${repoName} - ElizaOS plugin`,
-              false, // public repository
-              ['elizaos-plugins'] // topics
-            );
+              // Create repository with the same name
+              const result = await createGitHubRepository(
+                credentials.token,
+                repoName,
+                packageJson.description || `${repoName} - ElizaOS plugin`,
+                false, // public repository
+                ['elizaos-plugins'] // topics
+              );
 
-            if (!result.success) {
-              logger.error(`Failed to create GitHub repository: ${result.message}`);
-              process.exit(1);
-            }
-
-            // Push code to GitHub
-            logger.info('\n📤 Pushing code to GitHub repository...');
-            const pushResult = await pushToGitHub(cwd, result.repoUrl, 'main');
-
-            if (!pushResult) {
-              logger.error('Failed to push code to GitHub.');
-              const { shouldContinue } = await prompts({
-                type: 'confirm',
-                name: 'shouldContinue',
-                message: 'Continue with publishing to registry anyway?',
-                initial: false,
-              });
-
-              if (!shouldContinue) {
+              if (!result.success) {
+                logger.error(`Failed to create GitHub repository: ${result.message}`);
                 process.exit(1);
               }
+
+              // Push code to GitHub repository
+              logger.info('\n📤 Pushing code to GitHub repository...');
+
+              // Use the more Git-friendly approach
+              try {
+                // Initialize git repo if needed
+                await execa('git', ['init'], { cwd });
+                logger.info('Git repository initialized');
+
+                // Create and checkout main branch
+                await execa('git', ['checkout', '-b', 'main'], { cwd });
+                logger.info('Created main branch');
+
+                // Add remote
+                await execa('git', ['remote', 'add', 'origin', result.repoUrl], { cwd });
+                logger.info(`Added remote: ${result.repoUrl}`);
+
+                // Add all files
+                await execa('git', ['add', '.'], { cwd });
+                logger.info('Added files to git');
+
+                // Commit changes
+                await execa('git', ['commit', '-m', 'Initial commit'], { cwd });
+                logger.info('Committed changes');
+
+                // Check if remote is empty before pushing
+                const remoteCheck = await execa('git', ['ls-remote', '--heads', 'origin'], {
+                  cwd,
+                  stdio: 'pipe',
+                  reject: false,
+                });
+
+                if (remoteCheck.exitCode === 0 && remoteCheck.stdout.trim() === '') {
+                  // Remote exists but is empty, safe to push
+                  logger.info('Remote repository is empty, pushing initial commit...');
+                  await execa('git', ['push', '-u', 'origin', 'main'], { cwd });
+                  logger.success('✅ Successfully pushed code to GitHub repository!');
+                } else {
+                  // Remote has content, create a new branch instead of pushing to main
+                  const setupBranch = `setup-${Date.now()}`;
+                  logger.info(
+                    `Remote repository contains content, creating branch: ${setupBranch}`
+                  );
+                  await execa('git', ['checkout', '-b', setupBranch], { cwd });
+                  await execa('git', ['push', '-u', 'origin', setupBranch], { cwd });
+                  logger.success(
+                    `✅ Pushed code to branch '${setupBranch}'. Please merge this branch into main.`
+                  );
+                }
+              } catch (error) {
+                logger.error('Failed to push to GitHub:', error.message);
+                logger.info('You may need to manually push your code to GitHub');
+
+                const { shouldContinue } = await prompts({
+                  type: 'confirm',
+                  name: 'shouldContinue',
+                  message: 'Continue with publishing to registry anyway?',
+                  initial: false,
+                });
+
+                if (!shouldContinue) {
+                  process.exit(1);
+                }
+              }
             } else {
-              logger.success('✅ Successfully pushed code to GitHub repository!');
+              logger.error(`Error verifying repository: ${response.status} ${response.statusText}`);
+              process.exit(1);
             }
           } else {
             logger.success('✅ GitHub repository verified!');

--- a/packages/cli/src/utils/plugin-publisher.ts
+++ b/packages/cli/src/utils/plugin-publisher.ts
@@ -242,10 +242,6 @@ export async function publishToGitHub(
   username: string,
   isTest = false
 ): Promise<boolean | { success: boolean; prUrl?: string }> {
-  if (packageJson.type !== 'plugin') {
-    throw new Error('This function can only be used to publish plugins');
-  }
-
   const token = await getGitHubToken();
   if (!token) {
     logger.error('GitHub token not found. Please set it using the login command.');

--- a/packages/cli/src/utils/plugin-publisher.ts
+++ b/packages/cli/src/utils/plugin-publisher.ts
@@ -242,6 +242,10 @@ export async function publishToGitHub(
   username: string,
   isTest = false
 ): Promise<boolean | { success: boolean; prUrl?: string }> {
+  if (packageJson.type !== 'plugin') {
+    throw new Error('This function can only be used to publish plugins');
+  }
+
   const token = await getGitHubToken();
   if (!token) {
     logger.error('GitHub token not found. Please set it using the login command.');

--- a/packages/plugin-starter/package.json
+++ b/packages/plugin-starter/package.json
@@ -9,7 +9,7 @@
   "types": "dist/index.d.ts",
   "repository": {
     "type": "git",
-    "url": "github:{{GITHUB_USERNAME}}/{{PLUGIN_NAME}}"
+    "url": "https://github.com/elizaos-plugins/plugin-starter"
   },
   "exports": {
     "./package.json": "./package.json",
@@ -49,14 +49,5 @@
   "resolutions": {
     "zod": "3.24.2"
   },
-  "platform": "universal",
-  "agentConfig": {
-    "pluginType": "elizaos:plugin:1.0.0",
-    "pluginParameters": {
-      "API_KEY": {
-        "type": "string",
-        "description": "API key for the service"
-      }
-    }
-  }
+  "gitHead": "b165ad83e5f7a21bc1edbd83374ca087e3cd6b33"
 }


### PR DESCRIPTION
# Chore: Plugin Publishing Improvements

This PR includes a few minor improvements to my previous #4095 plugin publishing workflow:

## Changes
- Enhanced GitHub repository push functionality, before it was using force which isnt elegant or cool
- Added support for `@elizaos/plugin` prefix aliasing in plugin names
- Refactored code for better readability and maintainability