### PR TITLE
fix: resolve database transaction deadlock

### DIFF
--- a/packages/plugin-sql/src/base.ts
+++ b/packages/plugin-sql/src/base.ts
@@ -570,15 +570,6 @@ export abstract class BaseDrizzleAdapter<
     return this.withDatabase(async () => {
       try {
         return await this.db.transaction(async (tx) => {
-          // try get entity by id
-          const existingEntity = await this.getEntityById(entity.id as UUID);
-          if (existingEntity) {
-            logger.debug('Entity already exists:', {
-              entity,
-            });
-            return true;
-          }
-
           await tx.insert(entityTable).values(entity);
 
           logger.debug('Entity created successfully:', {


### PR DESCRIPTION
# Database Transaction Deadlock Fix

## Issue
Database connections getting stuck in "idle in transaction" state, causing unresponsiveness.

## Root Cause
The `getWorld` method inside `createWorld` wasn't supposed to be merged. This combination caused transactions to hang without completion.

## Fix
Removed the problematic code:

```diff
async createWorld(world: World): Promise<UUID> {
  return this.withDatabase(async () => {
    const newWorldId = world.id || v4();
-   // This check was causing the problem - created a transaction but didn't complete it
-   const existingWorld = await this.getWorld(newWorldId);
-   if (existingWorld) {
-     return existingWorld.id;
-   }
    await this.db.insert(worldTable).values({
      ...world,
      id: newWorldId,
    });
    return newWorldId;
  });
}
```

## Verification
Run PGlite and verify it's working without "idle in transaction" errors in logs.
