### PR TITLE
add node_modules to .gitignore

### DIFF
--- a/packages/plugin-starter/.gitignore
+++ b/packages/plugin-starter/.gitignore
@@ -1,1 +1,2 @@
 dist/
+node_modules/


### PR DESCRIPTION
node_modules wasnt in the gitignore in plugin-starter template, resulting in trouble pushing the plugin repo to github. added it so it works well.