### PR TITLE
feat: Add message buttons

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -47,9 +47,6 @@ export interface Content {
   /** Array of media attachments */
   attachments?: Media[];
 
-  /** Array of buttons */
-  buttons?: Button[];
-
   /**
    * Additional dynamic properties
    * Use specific properties above instead of this when possible
@@ -498,18 +495,6 @@ export type Media = {
 
   /** Content type */
   contentType?: string;
-};
-
-/**
- * Represents a flexible button configuration
- */
-export type Button = {
-  /** The type of button */
-  kind: 'login' | 'url';
-  /** The text to display on the button */
-  text: string;
-  /** The URL or endpoint the button should link to */
-  url: string;
 };
 
 export enum ChannelType {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -47,6 +47,9 @@ export interface Content {
   /** Array of media attachments */
   attachments?: Media[];
 
+  /** Array of buttons */
+  buttons?: Button[];
+
   /**
    * Additional dynamic properties
    * Use specific properties above instead of this when possible
@@ -495,6 +498,18 @@ export type Media = {
 
   /** Content type */
   contentType?: string;
+};
+
+/**
+ * Represents a flexible button configuration
+ */
+export type Button = {
+  /** The type of button */
+  kind: 'login' | 'url';
+  /** The text to display on the button */
+  text: string;
+  /** The URL or endpoint the button should link to */
+  url: string;
 };
 
 export enum ChannelType {

--- a/packages/plugin-telegram/README.md
+++ b/packages/plugin-telegram/README.md
@@ -85,3 +85,40 @@ npm run dev
 ```bash
 bun start --character="characters/your-character.json"
 ```
+
+## Utilizing Telegram Buttons
+
+Send a message with native Telegram buttons by adding an array of buttons in the message content. Here is an example of adding a button for authenticating a users' Telegram account.
+
+```typescript
+export const initAuthHandshakeAction: Action = {
+  name: 'INIT_AUTH_HANDSHAKE',
+  description: 'Initiates the identity linking and authentication flow for new users.',
+  validate: async (_runtime, _message, _state) => {
+    return _message.content.source === 'telegram';
+  },
+  handler: async (runtime, message, _state, _options, callback): Promise<boolean> => {
+    try {
+      const user = await getUser(message.userId);
+      if (user) return false;
+
+      callback({
+        text: "Let's get you set up with a new account",
+        buttons: [
+          {
+            text: '🔑 Authenticate with Telegram',
+            url: `${FRONTEND_URL}/integrations/telegram`,
+            kind: 'login',
+          },
+        ],
+      }).catch((error) => {
+        console.error('Error sending callback:', error);
+      });
+
+      return true;
+    } catch (error) {
+      ...
+    }
+  },
+};
+```

--- a/packages/plugin-telegram/README.md
+++ b/packages/plugin-telegram/README.md
@@ -88,7 +88,7 @@ bun start --character="characters/your-character.json"
 
 ## Utilizing Telegram Buttons
 
-Send a message with native Telegram buttons by adding an array of buttons in the message content. Here is an example of adding a button for authenticating a users' Telegram account.
+To send a message with native Telegram buttons, include an array of buttons in the message content. The following action demonstrates how to initiate a login flow using a Telegram button.
 
 ```typescript
 export const initAuthHandshakeAction: Action = {

--- a/packages/plugin-telegram/src/messageManager.ts
+++ b/packages/plugin-telegram/src/messageManager.ts
@@ -19,7 +19,8 @@ import {
   type TelegramMessageSentPayload,
   type TelegramReactionReceivedPayload,
 } from './types';
-import { escapeMarkdown } from './utils';
+import { convertToTelegramButtons, escapeMarkdown } from './utils';
+import { Markup } from 'telegraf';
 
 import fs from 'node:fs';
 
@@ -145,12 +146,15 @@ export class MessageManager {
       const chunks = this.splitMessage(content.text);
       const sentMessages: Message.TextMessage[] = [];
 
+      const telegramButtons = convertToTelegramButtons(content.buttons);
+
       for (let i = 0; i < chunks.length; i++) {
         const chunk = escapeMarkdown(chunks[i]);
         const sentMessage = (await ctx.telegram.sendMessage(ctx.chat.id, chunk, {
           reply_parameters:
             i === 0 && replyToMessageId ? { message_id: replyToMessageId } : undefined,
           parse_mode: 'Markdown',
+          ...Markup.inlineKeyboard(telegramButtons),
         })) as Message.TextMessage;
 
         sentMessages.push(sentMessage);

--- a/packages/plugin-telegram/src/messageManager.ts
+++ b/packages/plugin-telegram/src/messageManager.ts
@@ -14,6 +14,7 @@ import {
 import type { Chat, Message, ReactionType, Update } from '@telegraf/types';
 import type { Context, NarrowedContext, Telegraf } from 'telegraf';
 import {
+  TelegramContent,
   TelegramEventTypes,
   type TelegramMessageReceivedPayload,
   type TelegramMessageSentPayload,
@@ -106,13 +107,13 @@ export class MessageManager {
    * Sends a message in chunks, handling attachments and splitting the message if necessary
    *
    * @param {Context} ctx - The context object representing the current state of the bot
-   * @param {Content} content - The content of the message to be sent
+   * @param {TelegramContent} content - The content of the message to be sent
    * @param {number} [replyToMessageId] - The ID of the message to reply to, if any
    * @returns {Promise<Message.TextMessage[]>} - An array of TextMessage objects representing the messages sent
    */
   async sendMessageInChunks(
     ctx: Context,
-    content: Content,
+    content: TelegramContent,
     replyToMessageId?: number
   ): Promise<Message.TextMessage[]> {
     if (content.attachments && content.attachments.length > 0) {

--- a/packages/plugin-telegram/src/messageManager.ts
+++ b/packages/plugin-telegram/src/messageManager.ts
@@ -147,7 +147,7 @@ export class MessageManager {
       const chunks = this.splitMessage(content.text);
       const sentMessages: Message.TextMessage[] = [];
 
-      const telegramButtons = convertToTelegramButtons(content.buttons);
+      const telegramButtons = convertToTelegramButtons(content.buttons ?? []);
 
       for (let i = 0; i < chunks.length; i++) {
         const chunk = escapeMarkdown(chunks[i]);

--- a/packages/plugin-telegram/src/types.ts
+++ b/packages/plugin-telegram/src/types.ts
@@ -1,6 +1,26 @@
-import type { EntityPayload, MessagePayload, WorldPayload } from '@elizaos/core';
+import type { Content, EntityPayload, MessagePayload, WorldPayload } from '@elizaos/core';
 import type { Chat, Message, ReactionType } from '@telegraf/types';
 import type { Context } from 'telegraf';
+
+/**
+ * Extention of the core Content type just for Telegram
+ */
+export interface TelegramContent extends Content {
+  /** Array of buttons */
+  buttons?: Button[];
+}
+
+/**
+ * Represents a flexible button configuration
+ */
+export type Button = {
+  /** The type of button */
+  kind: 'login' | 'url';
+  /** The text to display on the button */
+  text: string;
+  /** The URL or endpoint the button should link to */
+  url: string;
+};
 
 /**
  * Telegram-specific event types

--- a/packages/plugin-telegram/src/utils.ts
+++ b/packages/plugin-telegram/src/utils.ts
@@ -1,3 +1,7 @@
+import { Markup } from 'telegraf';
+import { Button } from '@elizaos/core';
+import { InlineKeyboardButton } from '@telegraf/types';
+
 /**
  * Escapes Markdown special characters in the given text, excluding code blocks.
  * @param {string} text - The text to escape Markdown characters from.
@@ -56,4 +60,20 @@ export function splitMessage(text: string, maxLength = 4096): string[] {
 
   if (currentChunk) chunks.push(currentChunk);
   return chunks;
+}
+
+/**
+ * Converts Eliza buttons into Telegram buttons
+ * @param {Button[]} buttons - The buttons from Eliza content
+ * @returns {InlineKeyboardButton[]} Array of Telegram buttons
+ */
+export function convertToTelegramButtons(buttons: Button[]): InlineKeyboardButton[] {
+  return buttons.map((button: Button) => {
+    switch (button.kind) {
+      case 'login':
+        return Markup.button.login(button.text, button.url);
+      case 'url':
+        return Markup.button.url(button.text, button.url);
+    }
+  });
 }

--- a/packages/plugin-telegram/src/utils.ts
+++ b/packages/plugin-telegram/src/utils.ts
@@ -1,6 +1,6 @@
 import { Markup } from 'telegraf';
-import { Button } from '@elizaos/core';
 import { InlineKeyboardButton } from '@telegraf/types';
+import { Button } from './types';
 
 /**
  * Escapes Markdown special characters in the given text, excluding code blocks.

--- a/packages/plugin-telegram/src/utils.ts
+++ b/packages/plugin-telegram/src/utils.ts
@@ -67,7 +67,8 @@ export function splitMessage(text: string, maxLength = 4096): string[] {
  * @param {Button[]} buttons - The buttons from Eliza content
  * @returns {InlineKeyboardButton[]} Array of Telegram buttons
  */
-export function convertToTelegramButtons(buttons: Button[]): InlineKeyboardButton[] {
+export function convertToTelegramButtons(buttons?: Button[] | null): InlineKeyboardButton[] {
+  if (!buttons) return [];
   return buttons.map((button: Button) => {
     switch (button.kind) {
       case 'login':


### PR DESCRIPTION
# Risks

Low - The changes are focused on adding button support to the Telegram plugin, which is a non-breaking change. The main risk would be if the button conversion logic has any edge cases not covered by testing.

# Background

## What does this PR do?

This PR adds support for interactive buttons in Telegram messages through the Eliza framework. It introduces a new Button type in the core package and implements the conversion of these buttons to Telegram's inline keyboard format.

## What kind of change is this?

Features (non-breaking change which adds functionality)

# Documentation changes needed?

My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.

# Testing

## Where should a reviewer start?

The reviewer should start by examining the new Button type in packages/core/src/types.ts and then look at how it's implemented in the Telegram plugin.

## Detailed testing steps

- Test sending a message with login buttons
  - Verify the buttons appear correctly in Telegram
  - Verify the login flow works as expected
- Test sending a message with URL buttons
  - Verify the buttons appear correctly in Telegram
  - Verify clicking the buttons opens the correct URLs
- Test sending messages with no buttons
  - Verify existing functionality remains unchanged

## Screenshots

### Before

Currently, to send a user a link to a resource or to login, the best you can do is send plain text with a link.

![image](https://github.com/user-attachments/assets/1449ed43-f76e-4633-87d2-c876420e089c)

### After

This PR implements the ability to send buttons in the message content and manages displaying the buttons in telegram.

![image](https://github.com/user-attachments/assets/703c371c-d4f3-4be4-997a-f418e3f21a70)

# Deploy Notes

No special deployment notes required. This is a non-breaking change that adds new functionality.