### PR TITLE
fixed: bun installation issue for plugin-bootstrap

### DIFF
--- a/packages/plugin-bootstrap/package.json
+++ b/packages/plugin-bootstrap/package.json
@@ -38,7 +38,6 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "postinstall": "node scripts/postinstall.js",
     "lint": "prettier --write ./src",
     "clean": "rm -rf dist .turbo node_modules .turbo-tsconfig.json tsconfig.tsbuildinfo",
     "format": "prettier --write ./src",


### PR DESCRIPTION
# Relates to

<!-- No specific issue linked -->

# Risks

Low – This change only removes a `postscript` entry from the `plugin-bootstrap` package. Since the script it was referring to no longer exists, removing the reference reduces the chance of errors during post-installation. It does not affect runtime behavior.

# Background

## What does this PR do?

This PR removes the `postscript` section from the `plugin-bootstrap` package's configuration. The script that was being called in this section does not exist anymore, making the entry redundant and potentially error-prone.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Start by reviewing the `plugin-bootstrap` package's configuration (likely `package.json` or similar) and confirm that the removed script reference was indeed pointing to a non-existent script.

## Detailed testing steps

- Run `pnpm install` or the relevant package install command to ensure there are no postscript errors.
- Confirm that `plugin-bootstrap` installs and builds as expected.
- Verify no side effects in downstream packages that depend on `plugin-bootstrap`.

<!-- No UI changes, so no screenshots needed -->
