### PR TITLE
feat: Improve Reply Action to Use Pre-generated Responses

### DIFF
--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -328,6 +328,7 @@ First, think about what you want to do next and plan your actions. Then, write t
 "actions" should be an array of the actions {{agentName}} plans to take based on the thought (if none, use IGNORE, if simply responding with text, use REPLY)
 "providers" should be an optional array of the providers that {{agentName}} will use to have the right context for responding and acting
 "evaluators" should be an optional array of the evaluators that {{agentName}} will use to evaluate the conversation after responding
+"message" should be the next message for {{agentName}} which they will send to the conversation.
 These are the available valid actions: {{actionNames}}
 
 Response format should be formatted in a valid JSON block like this:
@@ -335,7 +336,8 @@ Response format should be formatted in a valid JSON block like this:
 {
     "thought": "<string>",
     "actions": ["<string>", "<string>", ...],
-    "providers": ["<string>", "<string>", ...]
+    "providers": ["<string>", "<string>", ...],
+    "message": "<string>"
 }
 \`\`\`
 

--- a/packages/plugin-bootstrap/src/actions/reply.ts
+++ b/packages/plugin-bootstrap/src/actions/reply.ts
@@ -64,8 +64,28 @@ export const replyAction = {
     message: Memory,
     state: State,
     _options: any,
-    callback: HandlerCallback
+    callback: HandlerCallback,
+    responses?: Memory[]
   ) => {
+    // Find all responses with REPLY action and text
+    const existingResponses = responses?.filter(
+      (response) => response.content.actions?.includes('REPLY') && response.content.message
+    );
+
+    // If we found any existing responses, use them and skip LLM
+    if (existingResponses && existingResponses.length > 0) {
+      for (const response of existingResponses) {
+        const responseContent = {
+          thought: response.content.thought || 'Using provided text for reply',
+          text: response.content.message as string,
+          actions: ['REPLY'],
+        };
+        await callback(responseContent);
+      }
+      return;
+    }
+
+    // Only generate response using LLM if no suitable response was found
     state = await runtime.composeState(message, [
       ...(message.content.providers ?? []),
       'RECENT_MESSAGES',

--- a/packages/plugin-bootstrap/src/actions/reply.ts
+++ b/packages/plugin-bootstrap/src/actions/reply.ts
@@ -19,14 +19,11 @@ import {
  *
  * @type {string}
  */
-const replyTemplate = `# Task: Generate dialog and actions for the character {{agentName}}.
+const replyTemplate = `# Task: Generate dialog for the character {{agentName}}.
 {{providers}}
 # Instructions: Write the next message for {{agentName}}.
-First, think about what you want to do next and plan your actions. Then, write the next message and include the actions you plan to take.
 "thought" should be a short description of what the agent is thinking about and planning.
 "message" should be the next message for {{agentName}} which they will send to the conversation.
-
-These are the available valid actions: {{actionNames}}
 
 Response format should be formatted in a valid JSON block like this:
 \`\`\`json

--- a/packages/plugin-bootstrap/src/index.ts
+++ b/packages/plugin-bootstrap/src/index.ts
@@ -279,7 +279,7 @@ const messageReceivedHandler = async ({
         let retries = 0;
         const maxRetries = 3;
         while (retries < maxRetries && (!responseContent?.thought || !responseContent?.actions)) {
-          const response = await runtime.useModel(ModelType.TEXT_SMALL, {
+          const response = await runtime.useModel(ModelType.TEXT_LARGE, {
             prompt,
           });
 
@@ -314,6 +314,7 @@ const messageReceivedHandler = async ({
             },
           ];
 
+          // First callback without text - this is for the planning stage to show thought messages in GUI
           callback(responseContent);
         }
 


### PR DESCRIPTION
## Changes
1. Modified `reply.ts` to use pre-generated responses from the planning stage
   - Now finds all responses with REPLY action and message
   - Uses existing responses instead of generating new ones when available
   - Only calls LLM if no suitable responses are found

2. Improved `replyTemplate` to be more focused
   - Removed action selection since this is specifically for REPLY