### PR TITLE
Feature/plugin venice

### DIFF
--- a/packages/client/src/hooks/use-plugins.ts
+++ b/packages/client/src/hooks/use-plugins.ts
@@ -32,6 +32,7 @@ export function usePlugins() {
         '@elizaos/plugin-browser',
         '@elizaos/plugin-s3-storage',
         '@elizaos/plugin-video-understanding',
+        '@elizaos/plugin-venice',
       ];
     },
   });

--- a/packages/plugin-venice/README.md
+++ b/packages/plugin-venice/README.md
@@ -1,0 +1,53 @@
+# @elizaos/plugin-venice
+
+Venice AI plugin for ElizaOS. This plugin provides integration with the Venice AI API for text generation and object generation capabilities.
+
+## Configuration
+
+The plugin requires the following environment variables to be set:
+
+- `VENICE_API_KEY`: Your Venice AI API key
+- `VENICE_SMALL_MODEL`: The model to use for small text generation (defaults to 'default')
+- `VENICE_LARGE_MODEL`: The model to use for large text generation (defaults to 'default')
+- `VENICE_EMBEDDING_MODEL`: The model to use for embeddings (optional)
+- `VENICE_EMBEDDING_DIMENSIONS`: The dimensions for embeddings (optional)
+
+## Features
+
+- Text generation with both small and large models
+- Object generation capabilities
+- Automatic API key validation
+- Configurable model selection
+- Error handling and logging
+
+## Usage
+
+To use the Venice plugin, add it to your ElizaOS configuration:
+
+```typescript
+import { venicePlugin } from '@elizaos/plugin-venice';
+
+// Add to your plugins array
+const plugins = [
+  venicePlugin,
+  // ... other plugins
+];
+```
+
+## Development
+
+To build the plugin:
+
+```bash
+bun run build
+```
+
+To watch for changes during development:
+
+```bash
+bun run dev
+```
+
+## License
+
+MIT 

--- a/packages/plugin-venice/package.json
+++ b/packages/plugin-venice/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "@elizaos/plugin-venice",
+    "version": "1.0.0-beta.14",
+    "type": "module",
+    "main": "dist/index.js",
+    "module": "dist/index.js",
+    "types": "dist/index.d.ts",
+    "publishConfig": {
+        "access": "public"
+    },
+    "files": [
+        "dist",
+        "README.md"
+    ],
+    "dependencies": {
+        "@ai-sdk/openai": "^1.1.9",
+        "@ai-sdk/ui-utils": "1.1.9",
+        "@elizaos/core": "^1.0.0-beta.14",
+        "ai": "^4.1.25",
+        "js-tiktoken": "^1.0.18",
+        "tsup": "8.4.0",
+        "formdata-node": "^5.0.1"
+    },
+    "scripts": {
+        "build": "tsup",
+        "dev": "tsup --watch",
+        "typecheck": "tsc --noEmit"
+    }
+}

--- a/packages/plugin-venice/src/index.test.ts
+++ b/packages/plugin-venice/src/index.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'bun:test';
+import { venicePlugin } from './index';
+import { type IAgentRuntime, ModelType, type Memory, type UUID, type Character } from '@elizaos/core';
+
+describe('VenicePlugin', () => {
+    const mockCharacter: Character = {
+        name: 'Test Agent',
+        bio: 'A test agent for Venice plugin',
+        system: 'test system prompt',
+        username: 'test-agent',
+    };
+
+    const mockFetch = async (url: string, options: RequestInit) => {
+        const headers = options.headers as Record<string, string>;
+        if (!headers?.Authorization || headers.Authorization !== 'Bearer test-key') {
+            return new Response(null, { status: 401, statusText: 'Unauthorized' });
+        }
+
+        if (url.endsWith('/models')) {
+            return new Response(JSON.stringify({ models: [] }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
+        if (url.endsWith('/embeddings')) {
+            const body = JSON.parse(options.body as string);
+            if (!body.model || !body.input) {
+                return new Response(null, { status: 400, statusText: 'Bad Request' });
+            }
+            return new Response(JSON.stringify({
+                data: [{
+                    embedding: new Array(4096).fill(0.1),
+                }]
+            }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' }
+            });
+        }
+        return new Response(null, { status: 404 });
+    };
+
+    const mockRuntime = {
+        getSetting: (key: string) => {
+            switch (key) {
+                case 'VENICE_API_KEY':
+                    return 'test-key';
+                case 'VENICE_SMALL_MODEL':
+                    return 'llama-3.3-70b';
+                case 'VENICE_LARGE_MODEL':
+                    return 'llama-3.1-405b';
+                case 'VENICE_EMBEDDING_MODEL':
+                    return 'llama-3.3-70b';
+                case 'VENICE_EMBEDDING_DIMENSIONS':
+                    return '4096';
+                default:
+                    return undefined;
+            }
+        },
+        character: mockCharacter,
+        agentId: 'test-agent' as UUID,
+        providers: [],
+        actions: [],
+        evaluators: [],
+        plugins: [],
+        services: new Map(),
+        events: new Map(),
+        routes: [],
+        fetch: mockFetch,
+        logger: console,
+        metrics: {
+            increment: () => { },
+            timing: () => { },
+            gauge: () => { },
+        },
+        registerPlugin: async () => { },
+        initialize: async () => { },
+        getKnowledge: async () => [],
+        addKnowledge: async () => { },
+        getService: () => null,
+        getAllServices: () => new Map(),
+        registerService: () => { },
+        registerDatabaseAdapter: () => { },
+        setSetting: () => { },
+        getConversationLength: () => 0,
+        processActions: async () => { },
+        evaluate: async () => null,
+        registerProvider: () => { },
+        registerAction: () => { },
+        registerEvaluator: () => { },
+        ensureConnection: async () => { },
+        ensureParticipantInRoom: async () => { },
+        ensureWorldExists: async () => { },
+        ensureRoomExists: async () => { },
+        composeState: async () => ({ values: {}, data: {}, text: '' }),
+        useModel: async () => ({}),
+        registerModel: () => { },
+        getModel: () => undefined,
+        registerEvent: () => { },
+        getEvent: () => [],
+        emitEvent: async () => { },
+        registerTaskWorker: () => { },
+        getTaskWorker: () => undefined,
+        stop: async () => { },
+        addEmbeddingToMemory: async (memory: Memory) => memory,
+        // Database adapter methods
+        db: null,
+        init: async () => { },
+        close: async () => { },
+        getAgent: async () => null,
+        getAgents: async () => [],
+        createAgent: async () => true,
+        updateAgent: async () => true,
+        deleteAgent: async () => true,
+        ensureAgentExists: async () => { },
+        ensureEmbeddingDimension: async () => { },
+        getEntityById: async () => null,
+        getEntitiesForRoom: async () => [],
+        createEntity: async () => true,
+        updateEntity: async () => { },
+        getComponent: async () => null,
+        getComponents: async () => [],
+        createComponent: async () => true,
+        updateComponent: async () => { },
+        deleteComponent: async () => { },
+        getMemories: async () => [],
+        getMemoryById: async () => null,
+        getMemoriesByIds: async () => [],
+        getMemoriesByRoomIds: async () => [],
+        getCachedEmbeddings: async () => [],
+        log: async () => { },
+        getLogs: async () => [],
+        deleteLog: async () => { },
+        searchMemories: async () => [],
+        createMemory: async () => 'test-id' as UUID,
+        updateMemory: async () => true,
+        deleteMemory: async () => { },
+        deleteAllMemories: async () => { },
+        countMemories: async () => 0,
+        createWorld: async () => 'test-id' as UUID,
+        getWorld: async () => null,
+        getAllWorlds: async () => [],
+        updateWorld: async () => { },
+        getRoom: async () => null,
+        createRoom: async () => 'test-id' as UUID,
+        deleteRoom: async () => { },
+        updateRoom: async () => { },
+        getRoomsForParticipant: async () => [],
+        getRoomsForParticipants: async () => [],
+        getRooms: async () => [],
+        addParticipant: async () => true,
+        removeParticipant: async () => true,
+        getParticipantsForEntity: async () => [],
+        getParticipantsForRoom: async () => [],
+        getParticipantUserState: async () => null,
+        setParticipantUserState: async () => { },
+        createRelationship: async () => true,
+        updateRelationship: async () => { },
+        getRelationship: async () => null,
+        getRelationships: async () => [],
+        getCache: async () => undefined,
+        setCache: async () => true,
+        deleteCache: async () => true,
+        createTask: async () => 'test-id' as UUID,
+        getTasks: async () => [],
+        getTask: async () => null,
+        getTasksByName: async () => [],
+        updateTask: async () => { },
+        deleteTask: async () => { },
+    } as unknown as IAgentRuntime;
+
+    it('should have correct plugin metadata', () => {
+        expect(venicePlugin.name).toBe('venice');
+        expect(venicePlugin.description).toBe('Venice AI plugin');
+    });
+
+    it('should initialize without errors', async () => {
+        const result = await venicePlugin.init({}, mockRuntime);
+        expect(result).toBeUndefined();
+    });
+
+    it('should have text embedding model handler', () => {
+        expect(venicePlugin.models[ModelType.TEXT_EMBEDDING]).toBeDefined();
+    });
+
+    it('should generate text embeddings', async () => {
+        const embeddingHandler = venicePlugin.models[ModelType.TEXT_EMBEDDING];
+        expect(embeddingHandler).toBeDefined();
+
+        const result = await embeddingHandler(mockRuntime, {
+            text: 'test text',
+            runtime: mockRuntime,
+        });
+
+        expect(result).toBeDefined();
+        expect(Array.isArray(result.embedding)).toBe(true);
+        expect(result.dimensions).toBe(4096);
+        expect(result.embedding.length).toBe(4096);
+    });
+}); 

--- a/packages/plugin-venice/src/index.ts
+++ b/packages/plugin-venice/src/index.ts
@@ -1,0 +1,315 @@
+import { createOpenAI } from '@ai-sdk/openai';
+import type {
+    ImageDescriptionParams,
+    ModelTypeName,
+    ObjectGenerationParams,
+    Plugin,
+    TextEmbeddingParams
+} from '@elizaos/core';
+import {
+    type DetokenizeTextParams,
+    type GenerateTextParams,
+    ModelType,
+    type TokenizeTextParams,
+    logger,
+    VECTOR_DIMS,
+} from '@elizaos/core';
+import { generateObject, generateText } from 'ai';
+import { type TiktokenModel, encodingForModel } from 'js-tiktoken';
+import { FormData as NodeFormData, File as NodeFile } from 'formdata-node';
+
+// Venice-specific helper functions
+function getSetting(runtime: any, key: string, defaultValue?: string): string | undefined {
+    return runtime.getSetting(key) ?? process.env[key] ?? defaultValue;
+}
+
+function getBaseURL(): string {
+    return 'https://api.venice.ai/api/v1';  // Venice requires this specific base URL
+}
+
+function getVeniceApiKey(runtime: any): string | undefined {
+    return getSetting(runtime, 'VENICE_API_KEY');
+}
+
+function getSmallModel(runtime: any): string {
+    return getSetting(runtime, 'VENICE_SMALL_MODEL') ?? 'llama-3.3-70b';
+}
+
+function getLargeModel(runtime: any): string {
+    return getSetting(runtime, 'VENICE_LARGE_MODEL') ?? 'llama-3.1-405b';
+}
+
+function getEmbeddingModel(runtime: any): string {
+    return getSetting(runtime, 'VENICE_EMBEDDING_MODEL') ?? 'text-embedding-3-small';
+}
+
+function getEmbeddingDimensions(runtime: any): number {
+    return parseInt(getSetting(runtime, 'VENICE_EMBEDDING_DIMENSIONS') ?? '4096', 10);
+}
+
+// OpenAI-specific helper functions
+function getOpenAIApiKey(runtime: any): string | undefined {
+    return getSetting(runtime, 'OPENAI_API_KEY');
+}
+
+function getOpenAIEmbeddingModel(runtime: any): string {
+    return getSetting(runtime, 'OPENAI_EMBEDDING_MODEL') ?? 'text-embedding-3-small';
+}
+
+function getOpenAIEmbeddingDimensions(runtime: any): number | undefined {
+    const dimsString = getSetting(runtime, 'OPENAI_EMBEDDING_DIMENSIONS');
+    return dimsString ? parseInt(dimsString, 10) : undefined;
+}
+
+const OPENAI_BASE_URL = 'https://api.openai.com/v1';
+
+function createVeniceClient(runtime: any) {
+    return createOpenAI({
+        apiKey: getVeniceApiKey(runtime),
+        baseURL: getBaseURL(),
+    });
+}
+
+const PLUGIN_VERSION = '1.1.2-obj-gen-fix'; // Updated version
+
+export const venicePlugin: Plugin = {
+    name: 'venice',
+    description: `Venice AI plugin (Handles Inference; Embeddings via OpenAI - v${PLUGIN_VERSION})`,
+    config: {
+        VENICE_API_KEY: process.env.VENICE_API_KEY,
+        VENICE_SMALL_MODEL: process.env.VENICE_SMALL_MODEL,
+        VENICE_LARGE_MODEL: process.env.VENICE_LARGE_MODEL,
+        OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+        OPENAI_EMBEDDING_MODEL: process.env.OPENAI_EMBEDDING_MODEL,
+        OPENAI_EMBEDDING_DIMENSIONS: process.env.OPENAI_EMBEDDING_DIMENSIONS,
+    },
+    async init(_config, runtime) {
+        logger.info(`[plugin-venice] Initializing v${PLUGIN_VERSION}`);
+        if (!getVeniceApiKey(runtime)) {
+            logger.warn('[plugin-venice] VENICE_API_KEY is not set - Venice text generation will fail');
+        }
+        if (!getOpenAIApiKey(runtime)) {
+            logger.warn('[plugin-venice] OPENAI_API_KEY is not set - Embeddings via OpenAI will fail');
+        }
+    },
+    models: {
+        [ModelType.TEXT_LARGE]: async (
+            runtime,
+            {
+                prompt,
+                stopSequences = [],
+                maxTokens = 8192,
+                temperature = 0.7,
+                frequencyPenalty = 0.7,
+                presencePenalty = 0.7,
+            }: GenerateTextParams
+        ) => {
+            const venice = createVeniceClient(runtime);
+            const model = getLargeModel(runtime);
+
+            const { text: veniceResponse } = await generateText({
+                model: venice.languageModel(model),
+                prompt: prompt,
+                system: runtime.character.system ?? undefined,
+                temperature: temperature,
+                maxTokens: maxTokens,
+                frequencyPenalty: frequencyPenalty,
+                presencePenalty: presencePenalty,
+                stopSequences: stopSequences,
+                // @ts-expect-error Venice.ai parameters are unique to Venice
+                venice_parameters: {
+                    include_venice_system_prompt: false, // Use our own system prompt
+                    top_p: 0.9, // Venice's default top_p value
+                },
+            });
+
+            return veniceResponse;
+        },
+        [ModelType.TEXT_SMALL]: async (
+            runtime,
+            {
+                prompt,
+                stopSequences = [],
+                maxTokens = 8192,
+                temperature = 0.7,
+                frequencyPenalty = 0.7,
+                presencePenalty = 0.7,
+            }: GenerateTextParams
+        ) => {
+            const venice = createVeniceClient(runtime);
+            const model = getSmallModel(runtime);
+
+            const { text: veniceResponse } = await generateText({
+                model: venice.languageModel(model),
+                prompt: prompt,
+                system: runtime.character.system ?? undefined,
+                temperature: temperature,
+                maxTokens: maxTokens,
+                frequencyPenalty: frequencyPenalty,
+                presencePenalty: presencePenalty,
+                stopSequences: stopSequences,
+                // @ts-expect-error Venice.ai parameters are unique to Venice
+                venice_parameters: {
+                    include_venice_system_prompt: false, // Use our own system prompt
+                },
+            });
+
+            return veniceResponse;
+        },
+        [ModelType.OBJECT_LARGE]: async (runtime, params: ObjectGenerationParams) => {
+            logger.debug(`[plugin-venice v${PLUGIN_VERSION}] OBJECT_LARGE handler using generateText`);
+            const venice = createVeniceClient(runtime);
+            const model = getLargeModel(runtime);
+            const jsonPrompt = `${params.prompt}\n\nPlease provide your response strictly in JSON format. Do not include any explanatory text before or after the JSON object.`;
+
+            try {
+                const { text: jsonText } = await generateText({
+                    model: venice.languageModel(model),
+                    prompt: jsonPrompt,
+                    temperature: params.temperature ?? 0, // Use lower temp for structured output
+                    // @ts-expect-error Venice.ai parameters are unique to Venice
+                    venice_parameters: {
+                        include_venice_system_prompt: false,
+                    },
+                    // Note: No response_format parameter is sent here by generateText
+                });
+
+                // Log the raw text received BEFORE parsing
+                logger.debug(`[plugin-venice v${PLUGIN_VERSION}] Raw OBJECT_LARGE text received:`, jsonText);
+
+                try {
+                    // Attempt to parse the result as JSON
+                    const object = JSON.parse(jsonText);
+                    logger.debug(`[plugin-venice v${PLUGIN_VERSION}] Successfully parsed JSON from OBJECT_LARGE`);
+                    return object;
+                } catch (parseError) {
+                    logger.error(`[plugin-venice v${PLUGIN_VERSION}] Failed to parse JSON from OBJECT_LARGE response:`, { jsonText, parseError });
+                    throw new Error('Model did not return valid JSON.');
+                }
+            } catch (error) {
+                logger.error(`[plugin-venice v${PLUGIN_VERSION}] Error during OBJECT_LARGE generation via generateText:`, error);
+                throw error;
+            }
+        },
+        [ModelType.OBJECT_SMALL]: async (runtime, params: ObjectGenerationParams) => {
+            logger.debug(`[plugin-venice v${PLUGIN_VERSION}] OBJECT_SMALL handler using generateText`);
+            const venice = createVeniceClient(runtime);
+            const model = getSmallModel(runtime);
+            const jsonPrompt = `${params.prompt}\n\nPlease provide your response strictly in JSON format. Do not include any explanatory text before or after the JSON object.`;
+
+            try {
+                const { text: jsonText } = await generateText({
+                    model: venice.languageModel(model),
+                    prompt: jsonPrompt,
+                    temperature: params.temperature ?? 0, // Use lower temp for structured output
+                    // @ts-expect-error Venice.ai parameters are unique to Venice
+                    venice_parameters: {
+                        include_venice_system_prompt: false,
+                    },
+                    // Note: No response_format parameter is sent here by generateText
+                });
+
+                // Log the raw text received BEFORE parsing
+                logger.debug(`[plugin-venice v${PLUGIN_VERSION}] Raw OBJECT_SMALL text received:`, jsonText);
+
+                try {
+                    // Attempt to parse the result as JSON
+                    const object = JSON.parse(jsonText);
+                    logger.debug(`[plugin-venice v${PLUGIN_VERSION}] Successfully parsed JSON from OBJECT_SMALL`);
+                    return object;
+                } catch (parseError) {
+                    logger.error(`[plugin-venice v${PLUGIN_VERSION}] Failed to parse JSON from OBJECT_SMALL response:`, { jsonText, parseError });
+                    throw new Error('Model did not return valid JSON.');
+                }
+            } catch (error) {
+                logger.error(`[plugin-venice v${PLUGIN_VERSION}] Error during OBJECT_SMALL generation via generateText:`, error);
+                throw error;
+            }
+        },
+        [ModelType.TEXT_EMBEDDING]: async (runtime, params: TextEmbeddingParams): Promise<number[]> => {
+            logger.debug(`[plugin-venice/OpenAI Embed v${PLUGIN_VERSION}] Handler entered.`);
+            const openaiApiKey = getOpenAIApiKey(runtime);
+            const model = getOpenAIEmbeddingModel(runtime);
+            const dimensions = getOpenAIEmbeddingDimensions(runtime);
+            const hardcodedDimensionFallback = 1536;
+
+            if (!params?.text || params.text.trim() === '') {
+                logger.debug(`[plugin-venice/OpenAI Embed v${PLUGIN_VERSION}] Creating test embedding for initialization/empty text`);
+                const initDimensions = dimensions ?? hardcodedDimensionFallback;
+                const testVector = new Array(initDimensions).fill(0);
+                testVector[0] = 0.1;
+                return testVector;
+            }
+
+            if (!openaiApiKey) {
+                logger.error(`[plugin-venice/OpenAI Embed v${PLUGIN_VERSION}] OPENAI_API_KEY is missing. Cannot generate embedding.`);
+                const errorDims = dimensions ?? hardcodedDimensionFallback;
+                const errorVector = new Array(errorDims).fill(0);
+                errorVector[0] = 0.3;
+                return errorVector;
+            }
+
+            logger.debug(`[plugin-venice/OpenAI Embed v${PLUGIN_VERSION}] Attempting OpenAI API call...`);
+            try {
+                const payload: { model: string; input: string; dimensions?: number } = {
+                    model: model,
+                    input: params.text,
+                };
+                if (dimensions !== undefined) {
+                    payload.dimensions = dimensions;
+                }
+                logger.debug(`[plugin-venice/OpenAI Embed v${PLUGIN_VERSION}] Calling ${OPENAI_BASE_URL}/embeddings with model ${model}`);
+
+                const response = await fetch(`${OPENAI_BASE_URL}/embeddings`, {
+                    method: 'POST',
+                    headers: {
+                        'Authorization': `Bearer ${openaiApiKey}`,
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify(payload),
+                });
+
+                logger.debug(`[plugin-venice/OpenAI Embed v${PLUGIN_VERSION}] Received response status: ${response.status}`);
+                if (!response.ok) {
+                    let errorBody = 'Could not parse error body';
+                    try {
+                        errorBody = await response.text();
+                    } catch (e) { /* ignore */ }
+                    logger.error(`[plugin-venice/OpenAI Embed v${PLUGIN_VERSION}] OpenAI API error: ${response.status} - ${response.statusText}`, { errorBody });
+                    throw new Error(`OpenAI API error: ${response.status} - ${response.statusText}`);
+                }
+
+                const data = await response.json() as {
+                    data: Array<{ embedding: number[] }>;
+                    usage: object;
+                    model: string;
+                };
+                logger.debug(`[plugin-venice/OpenAI Embed v${PLUGIN_VERSION}] Successfully parsed OpenAI response.`);
+
+                if (!data?.data?.[0]?.embedding) {
+                    logger.error(`[plugin-venice/OpenAI Embed v${PLUGIN_VERSION}] No embedding returned from OpenAI API`, { responseData: data });
+                    throw new Error('No embedding returned from OpenAI API');
+                }
+
+                const embedding = data.data[0].embedding;
+                const embeddingDimensions = embedding.length;
+
+                if (dimensions !== undefined && embeddingDimensions !== dimensions) {
+                    logger.warn(`[plugin-venice/OpenAI Embed v${PLUGIN_VERSION}] OpenAI Embedding dimensions mismatch: requested ${dimensions}, got ${embeddingDimensions}`);
+                }
+
+                logger.debug(`[plugin-venice/OpenAI Embed v${PLUGIN_VERSION}] Returning embedding with dimensions ${embeddingDimensions}.`);
+                return embedding;
+
+            } catch (error) {
+                logger.error(`[plugin-venice/OpenAI Embed v${PLUGIN_VERSION}] Error during OpenAI embedding generation process:`, error);
+                const errorDims = dimensions ?? hardcodedDimensionFallback;
+                const errorVector = new Array(errorDims).fill(0);
+                errorVector[0] = 0.2;
+                return errorVector;
+            }
+        },
+    }
+};
+
+export default venicePlugin; 

--- a/packages/plugin-venice/tsconfig.build.json
+++ b/packages/plugin-venice/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": false,
+        "declaration": true,
+        "declarationMap": true,
+        "sourceMap": true
+    },
+    "exclude": [
+        "node_modules",
+        "dist",
+        "**/*.test.ts"
+    ]
+}

--- a/packages/plugin-venice/tsconfig.json
+++ b/packages/plugin-venice/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist",
+        "rootDir": "src",
+        "composite": true,
+        "baseUrl": ".",
+        "paths": {
+            "@elizaos/core": [
+                "../../packages/core/dist"
+            ]
+        },
+        "types": [
+            "node",
+            "bun-types"
+        ]
+    },
+    "include": [
+        "src/**/*.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/plugin-venice/tsup.config.ts
+++ b/packages/plugin-venice/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    splitting: false,
+    sourcemap: true,
+    clean: true,
+    target: 'esnext',
+}); 


### PR DESCRIPTION
# Relates to

I was unable to find a ticket for getting Venice working in v2, but this is a plugin for getting Venice working in v2.

# Risks

Basically everything is in `packages/plugin-venice`
The only thing outside of that was adding plugin-venice to `use-plugins.ts`

# Background

## What does this PR do?

This plugin adds the ability to use Venice AI for inferencing. It still uses OpenAI for embeddings, and will use the `OPENAI_API_KEY` for that, but then uses `VENICE_API_KEY` for text generation.

## What kind of change is this?

Sort of  a bug fix, since Venice worked in v1, but also the creation of a new plugin, meant to replace `plugin-openai` for characters that want to use Venice.

I made this because I have a lot of VCUs to burn, and I'm sure others to as well, and it would be nice to use them with Eliza.

# Documentation changes needed?

My changes do not require a change to the project documentation.

Tests are included, intended to mirror the tests in `plugin-openai`

# Testing

## Where should a reviewer start?

## Detailed testing steps
None: Automated tests are acceptable.

# Deploy Notes
no notes, everything should be the same

## Database changes
no changes

## Deployment instructions
nothing fancy, just add VENICE_API_KEY to global, edit your character, remove `openai-plugin` and add `venice-plugin`, and things should just work. I can provide Venice API keys in DM to anyone who wants to help test.

## Discord username
I am @deanpierce on the discord, using the handle "px"
