### PR TITLE
Fix anthropic json parse issue

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -88,7 +88,7 @@
     },
     "packages/cli": {
       "name": "@elizaos/cli",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "bin": {
         "elizaos": "./dist/index.js",
       },
@@ -100,10 +100,10 @@
       "devDependencies": {
         "@babel/core": "^7.22.1",
         "@babel/parser": "^7.22.6",
-        "@elizaos/core": "^1.0.0-beta.27",
-        "@elizaos/plugin-anthropic": "^1.0.0-beta.27",
-        "@elizaos/plugin-openai": "^1.0.0-beta.27",
-        "@elizaos/plugin-sql": "^1.0.0-beta.27",
+        "@elizaos/core": "^1.0.0-beta.28",
+        "@elizaos/plugin-anthropic": "^1.0.0-beta.28",
+        "@elizaos/plugin-openai": "^1.0.0-beta.28",
+        "@elizaos/plugin-sql": "^1.0.0-beta.28",
         "@types/babel__core": "^7.20.1",
         "@types/diff": "^5.0.3",
         "@types/fs-extra": "^11.0.1",
@@ -200,7 +200,7 @@
     },
     "packages/core": {
       "name": "@elizaos/core",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@types/hapi__shot": "^6.0.0",
         "buffer": "^6.0.3",
@@ -244,12 +244,12 @@
     },
     "packages/create-eliza": {
       "name": "create-eliza",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "bin": {
         "create-eliza": "index.mjs",
       },
       "dependencies": {
-        "@elizaos/cli": "^1.0.0-beta.27",
+        "@elizaos/cli": "^1.0.0-beta.28",
       },
       "devDependencies": {
         "prettier": "3.5.3",
@@ -289,11 +289,12 @@
     },
     "packages/plugin-anthropic": {
       "name": "@elizaos/plugin-anthropic",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@ai-sdk/anthropic": "^1.1.6",
-        "@elizaos/core": "^1.0.0-beta.27",
+        "@elizaos/core": "^1.0.0-beta.28",
         "fastembed": "^1.0.0",
+        "jsonrepair": "^3.12.0",
         "tsup": "8.4.0",
       },
       "devDependencies": {
@@ -302,9 +303,9 @@
     },
     "packages/plugin-bootstrap": {
       "name": "@elizaos/plugin-bootstrap",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
-        "@elizaos/core": "^1.0.0-beta.27",
+        "@elizaos/core": "^1.0.0-beta.28",
       },
       "devDependencies": {
         "@types/node": "22.8.4",
@@ -319,9 +320,9 @@
     },
     "packages/plugin-browser": {
       "name": "@elizaos/plugin-browser",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
-        "@elizaos/core": "^1.0.0-beta.27",
+        "@elizaos/core": "^1.0.0-beta.28",
         "@types/uuid": "10.0.0",
         "capsolver-npm": "2.0.2",
         "fluent-ffmpeg": "2.1.3",
@@ -342,7 +343,7 @@
     },
     "packages/plugin-discord": {
       "name": "@elizaos/plugin-discord",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@discordjs/opus": "^0.10.0",
         "@discordjs/rest": "2.4.0",
@@ -365,9 +366,9 @@
     },
     "packages/plugin-elevenlabs": {
       "name": "@elizaos/plugin-elevenlabs",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
-        "@elizaos/core": "^1.0.0-beta.27",
+        "@elizaos/core": "^1.0.0-beta.28",
         "tsup": "8.4.0",
       },
       "devDependencies": {
@@ -376,9 +377,9 @@
     },
     "packages/plugin-evm": {
       "name": "@elizaos/plugin-evm",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
-        "@elizaos/plugin-tee": "^1.0.0-beta.27",
+        "@elizaos/plugin-tee": "^1.0.0-beta.28",
         "@hapi/shot": "^6.0.1",
         "@lifi/data-types": "5.15.5",
         "@lifi/sdk": "3.4.1",
@@ -404,7 +405,7 @@
     },
     "packages/plugin-farcaster": {
       "name": "@elizaos/plugin-farcaster",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@neynar/nodejs-sdk": "^2.0.3",
         "lru-cache": "^11.1.0",
@@ -416,11 +417,11 @@
     },
     "packages/plugin-groq": {
       "name": "@elizaos/plugin-groq",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@ai-sdk/groq": "^1.1.9",
         "@ai-sdk/ui-utils": "1.1.9",
-        "@elizaos/core": "^1.0.0-beta.27",
+        "@elizaos/core": "^1.0.0-beta.28",
         "ai": "^4.1.25",
         "js-tiktoken": "^1.0.18",
         "tsup": "8.4.0",
@@ -431,9 +432,9 @@
     },
     "packages/plugin-local-ai": {
       "name": "@elizaos/plugin-local-ai",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
-        "@elizaos/core": "^1.0.0-beta.27",
+        "@elizaos/core": "^1.0.0-beta.28",
         "@huggingface/hub": "^1.0.1",
         "@huggingface/inference": "^3.3.4",
         "@huggingface/transformers": "^3.3.3",
@@ -460,10 +461,10 @@
     },
     "packages/plugin-ollama": {
       "name": "@elizaos/plugin-ollama",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@ai-sdk/ui-utils": "1.1.9",
-        "@elizaos/core": "^1.0.0-beta.27",
+        "@elizaos/core": "^1.0.0-beta.28",
         "ai": "^4.1.25",
         "js-tiktoken": "^1.0.18",
         "ollama-ai-provider": "^1.2.0",
@@ -475,11 +476,11 @@
     },
     "packages/plugin-openai": {
       "name": "@elizaos/plugin-openai",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@ai-sdk/openai": "^1.1.9",
         "@ai-sdk/ui-utils": "1.1.9",
-        "@elizaos/core": "^1.0.0-beta.27",
+        "@elizaos/core": "^1.0.0-beta.28",
         "ai": "^4.1.25",
         "js-tiktoken": "^1.0.18",
         "tsup": "8.4.0",
@@ -490,11 +491,11 @@
     },
     "packages/plugin-pdf": {
       "name": "@elizaos/plugin-pdf",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.705.0",
         "@aws-sdk/s3-request-presigner": "^3.705.0",
-        "@elizaos/core": "^1.0.0-beta.27",
+        "@elizaos/core": "^1.0.0-beta.28",
         "@types/uuid": "10.0.0",
         "capsolver-npm": "2.0.2",
         "fluent-ffmpeg": "2.1.3",
@@ -515,7 +516,7 @@
     },
     "packages/plugin-redpill": {
       "name": "@elizaos/plugin-redpill",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@ai-sdk/openai": "^1.1.9",
         "@ai-sdk/ui-utils": "1.1.9",
@@ -530,7 +531,7 @@
     },
     "packages/plugin-solana": {
       "name": "@elizaos/plugin-solana",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@elizaos/core": "^1.0.0-beta.27",
         "@solana/spl-token": "0.4.9",
@@ -551,10 +552,10 @@
     },
     "packages/plugin-sql": {
       "name": "@elizaos/plugin-sql",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@electric-sql/pglite": "^0.2.17",
-        "@elizaos/core": "^1.0.0-beta.27",
+        "@elizaos/core": "^1.0.0-beta.28",
         "@types/pg": "8.11.10",
         "drizzle-kit": "^0.30.4",
         "drizzle-orm": "^0.39.1",
@@ -580,15 +581,16 @@
       "devDependencies": {
         "prettier": "3.5.3",
         "tsup": "8.4.0",
+        "typescript": "5.8.2",
       },
     },
     "packages/plugin-storage-s3": {
       "name": "@elizaos/plugin-storage-s3",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.705.0",
         "@aws-sdk/s3-request-presigner": "^3.705.0",
-        "@elizaos/core": "^1.0.0-beta.27",
+        "@elizaos/core": "^1.0.0-beta.28",
         "@types/uuid": "10.0.0",
         "capsolver-npm": "2.0.2",
         "fluent-ffmpeg": "2.1.3",
@@ -609,9 +611,9 @@
     },
     "packages/plugin-tee": {
       "name": "@elizaos/plugin-tee",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
-        "@elizaos/core": "^1.0.0-beta.27",
+        "@elizaos/core": "^1.0.0-beta.28",
         "@phala/dstack-sdk": "0.1.11",
         "@solana/web3.js": "1.98.0",
         "viem": "2.23.11",
@@ -624,7 +626,7 @@
     },
     "packages/plugin-telegram": {
       "name": "@elizaos/plugin-telegram",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@telegraf/types": "7.1.0",
         "strip-literal": "^3.0.0",
@@ -639,7 +641,7 @@
     },
     "packages/plugin-twitter": {
       "name": "@elizaos/plugin-twitter",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@elizaos/core": "^1.0.0-beta.27",
         "@roamhq/wrtc": "^0.8.0",
@@ -665,13 +667,26 @@
         "whatwg-url": "7.1.0",
       },
     },
+    "packages/plugin-venice": {
+      "name": "@elizaos/plugin-venice",
+      "version": "1.0.0-beta.28",
+      "dependencies": {
+        "@ai-sdk/openai": "^1.1.9",
+        "@ai-sdk/ui-utils": "1.1.9",
+        "@elizaos/core": "^1.0.0-beta.28",
+        "ai": "^4.1.25",
+        "formdata-node": "^5.0.1",
+        "js-tiktoken": "^1.0.18",
+        "tsup": "8.4.0",
+      },
+    },
     "packages/plugin-video-understanding": {
       "name": "@elizaos/plugin-video-understanding",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.705.0",
         "@aws-sdk/s3-request-presigner": "^3.705.0",
-        "@elizaos/core": "^1.0.0-beta.27",
+        "@elizaos/core": "^1.0.0-beta.28",
         "@types/uuid": "10.0.0",
         "capsolver-npm": "2.0.2",
         "fluent-ffmpeg": "2.1.3",
@@ -710,7 +725,7 @@
     },
     "packages/the-org": {
       "name": "@elizaos/the-org",
-      "version": "1.0.0-beta.27",
+      "version": "1.0.0-beta.28",
       "dependencies": {
         "@elizaos/cli": "^1.0.0-beta.27",
         "@elizaos/core": "^1.0.0-beta.27",
@@ -786,20 +801,18 @@
     "node-llama-cpp",
   ],
   "overrides": {
-    "@nrwl/devkit": "19.8.13",
+    "react": "19.0.0",
+    "eslint": "9.22.0",
+    "got": "12.6.1",
+    "vitest": "3.0.5",
     "@nrwl/tao": "19.8.13",
     "zod": "3.24.1",
-    "eslint": "9.22.0",
-    "react": "19.0.0",
-    "react-dom": "19.0.0",
-    "vitest": "3.0.5",
-    "@metaplex-foundation/umi": "0.9.2",
     "typedoc-plugin-markdown": "4.2.10",
     "buffer": "6.0.3",
-    "@solana/spl-token": "0.4.9",
-    "solana-bankrun": "0.3.1",
-    "got": "12.6.1",
     "form-data": "4.0.2",
+    "@nrwl/devkit": "19.8.13",
+    "react-dom": "19.0.0",
+    "@solana/spl-token": "0.4.9",
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.10.1", "", {}, "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="],
@@ -1405,6 +1418,8 @@
     "@elizaos/plugin-telegram": ["@elizaos/plugin-telegram@workspace:packages/plugin-telegram"],
 
     "@elizaos/plugin-twitter": ["@elizaos/plugin-twitter@workspace:packages/plugin-twitter"],
+
+    "@elizaos/plugin-venice": ["@elizaos/plugin-venice@workspace:packages/plugin-venice"],
 
     "@elizaos/plugin-video-understanding": ["@elizaos/plugin-video-understanding@workspace:packages/plugin-video-understanding"],
 
@@ -4558,6 +4573,8 @@
 
     "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
 
+    "jsonrepair": ["jsonrepair@3.12.0", "", { "bin": { "jsonrepair": "bin/cli.js" } }, "sha512-SWfjz8SuQ0wZjwsxtSJ3Zy8vvLg6aO/kxcp9TWNPGwJKgTZVfhNEQBMk/vPOpYCDFWRxD6QWuI6IHR1t615f0w=="],
+
     "jsonschema": ["jsonschema@1.5.0", "", {}, "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw=="],
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
@@ -6738,6 +6755,8 @@
 
     "@elizaos/plugin-pdf/glob": ["glob@11.0.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^4.0.1", "minimatch": "^10.0.0", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g=="],
 
+    "@elizaos/plugin-starter/typescript": ["typescript@5.8.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="],
+
     "@elizaos/plugin-storage-s3/@types/node": ["@types/node@22.8.4", "", { "dependencies": { "undici-types": "~6.19.8" } }, "sha512-SpNNxkftTJOPk0oN+y2bIqurEXHTA2AOZ3EJDDKeJ5VzkvvORSvmQXGQarcOzWV1ac7DCaPBEdMDxBsM+d8jWw=="],
 
     "@elizaos/plugin-storage-s3/@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
@@ -6751,6 +6770,8 @@
     "@elizaos/plugin-twitter/@vitest/coverage-v8": ["@vitest/coverage-v8@1.1.3", "", { "dependencies": { "@ampproject/remapping": "^2.2.1", "@bcoe/v8-coverage": "^0.2.3", "debug": "^4.3.4", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^4.0.1", "istanbul-reports": "^3.1.6", "magic-string": "^0.30.5", "magicast": "^0.3.2", "picocolors": "^1.0.0", "std-env": "^3.5.0", "test-exclude": "^6.0.0", "v8-to-istanbul": "^9.2.0" }, "peerDependencies": { "vitest": "^1.0.0" } }, "sha512-Uput7t3eIcbSTOTQBzGtS+0kah96bX+szW9qQrLeGe3UmgL2Akn8POnyC2lH7XsnREZOds9aCUTxgXf+4HX5RA=="],
 
     "@elizaos/plugin-twitter/glob": ["glob@11.0.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^4.0.1", "minimatch": "^10.0.0", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g=="],
+
+    "@elizaos/plugin-venice/formdata-node": ["formdata-node@5.0.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-8xnIjMYGKPj+rY2BTbAmpqVpi8der/2FT4d9f7J32FlsCpO5EzZPq3C/N56zdv8KweHzVF6TGijsS1JT6r1H2g=="],
 
     "@elizaos/plugin-video-understanding/@types/node": ["@types/node@22.8.4", "", { "dependencies": { "undici-types": "~6.19.8" } }, "sha512-SpNNxkftTJOPk0oN+y2bIqurEXHTA2AOZ3EJDDKeJ5VzkvvORSvmQXGQarcOzWV1ac7DCaPBEdMDxBsM+d8jWw=="],
 

--- a/packages/plugin-anthropic/package.json
+++ b/packages/plugin-anthropic/package.json
@@ -25,6 +25,7 @@
     "@ai-sdk/anthropic": "^1.1.6",
     "@elizaos/core": "^1.0.0-beta.28",
     "fastembed": "^1.0.0",
+    "jsonrepair": "^3.12.0",
     "tsup": "8.4.0"
   },
   "scripts": {

--- a/packages/plugin-anthropic/src/index.ts
+++ b/packages/plugin-anthropic/src/index.ts
@@ -2,259 +2,7 @@ import { anthropic } from '@ai-sdk/anthropic';
 import type { ObjectGenerationParams, GenerateTextParams, Plugin } from '@elizaos/core';
 import { ModelType, logger } from '@elizaos/core';
 import { generateText } from 'ai';
-import { jsonrepair } from 'jsonrepair';
-
-/**
- * Enhanced function to extract and parse JSON from LLM responses
- * Handles various response formats including mixed markdown and JSON with code blocks
- */
-const extractAndParseJSON = (text: string) => {
-  try {
-    // First attempt: Try direct JSON parsing
-    return JSON.parse(text);
-  } catch (initialError) {
-    logger.debug('Initial JSON parse failed, attempting alternative extraction methods');
-
-    // Try JSONRepair first
-    try {
-      const repaired = jsonrepair(text);
-      return JSON.parse(repaired);
-    } catch (repairError) {
-      logger.debug('JSONRepair failed, proceeding with manual extraction methods');
-    }
-
-    // Check if we have a valid JSON structure with embedded code blocks
-    // This specifically addresses the case where Anthropic returns a valid JSON object
-    // that contains markdown code blocks inside string values
-    const isJsonWithCodeBlocks =
-      text.trim().startsWith('{') && text.trim().endsWith('}') && text.includes('```');
-
-    if (isJsonWithCodeBlocks) {
-      // Replace code blocks with escaped versions to preserve them in the JSON
-      try {
-        // First, try to preserve the code blocks by temporarily replacing them
-        const codeBlockPlaceholders: { placeholder: string; content: string }[] = [];
-        let placeholderCounter = 0;
-        const textWithPlaceholders = text.replace(
-          /```(\w*)\n([\s\S]*?)```/g,
-          (match, language, code) => {
-            const placeholder = `__CODE_BLOCK_${placeholderCounter++}__`;
-            codeBlockPlaceholders.push({
-              placeholder,
-              content: `\`\`\`${language}\n${code}\`\`\``,
-            });
-            return placeholder;
-          }
-        );
-
-        // Try parsing with placeholders
-        let parsed;
-        try {
-          // Try JSONRepair first
-          const repaired = jsonrepair(textWithPlaceholders);
-          parsed = JSON.parse(repaired);
-        } catch (e) {
-          // If JSONRepair fails, try direct parsing
-          parsed = JSON.parse(textWithPlaceholders);
-        }
-
-        // Restore code blocks in the parsed object
-        const restoreCodeBlocks = (obj: any): any => {
-          if (typeof obj === 'string') {
-            let result = obj;
-            for (const { placeholder, content } of codeBlockPlaceholders) {
-              result = result.replace(placeholder, content);
-            }
-            return result;
-          } else if (Array.isArray(obj)) {
-            return obj.map((item) => restoreCodeBlocks(item));
-          } else if (obj !== null && typeof obj === 'object') {
-            const result: Record<string, any> = {};
-            for (const [key, value] of Object.entries(obj)) {
-              result[key] = restoreCodeBlocks(value);
-            }
-            return result;
-          }
-          return obj;
-        };
-
-        return restoreCodeBlocks(parsed);
-      } catch (codeBlockError) {
-        logger.debug('Code block preservation failed, continuing with other methods');
-      }
-    }
-
-    // Try to extract JSON from code blocks
-    const extractFromCodeBlocks = (text: string): string | null => {
-      // First priority: explicit JSON code blocks
-      const jsonBlockRegex = /```json\s*([\s\S]*?)\s*```/;
-      const jsonMatch = text.match(jsonBlockRegex);
-      if (jsonMatch && jsonMatch[1]) {
-        return jsonMatch[1].trim();
-      }
-
-      // Second priority: any code block that contains JSON-like content
-      const anyBlockRegex = /```(?:\w*)\s*([\s\S]*?)\s*```/g;
-      let match;
-      while ((match = anyBlockRegex.exec(text)) !== null) {
-        const blockContent = match[1].trim();
-        if (blockContent.startsWith('{') && blockContent.endsWith('}')) {
-          return blockContent;
-        }
-      }
-
-      return null;
-    };
-
-    const extractedFromCodeBlock = extractFromCodeBlocks(text);
-    if (extractedFromCodeBlock) {
-      try {
-        // Try parsing the extracted content
-        return JSON.parse(extractedFromCodeBlock);
-      } catch (blockParseError) {
-        try {
-          // Try with JSONRepair
-          const repaired = jsonrepair(extractedFromCodeBlock);
-          return JSON.parse(repaired);
-        } catch (blockRepairError) {
-          logger.debug('Failed to parse JSON from code block after repair');
-        }
-      }
-    }
-
-    // Look for JSON structure outside of code blocks
-    const extractJSON = (text: string): string | null => {
-      // Try to find JSON-like content in the text
-      // This regex looks for content that starts with { and ends with }
-      const jsonContentRegex = /(^|\n)\s*(\{[\s\S]*\})\s*($|\n)/;
-      const contentMatch = text.match(jsonContentRegex);
-
-      if (contentMatch && contentMatch[2]) {
-        return contentMatch[2].trim();
-      }
-
-      // If no direct match, try to find the largest JSON-like structure
-      const jsonPattern = /\{[\s\S]*?\}/g;
-      const jsonMatches = text.match(jsonPattern);
-
-      if (jsonMatches && jsonMatches.length > 0) {
-        // Sort matches by length (descending) to try the largest JSON-like structure first
-        return [...jsonMatches].sort((a, b) => b.length - a.length)[0];
-      }
-
-      return null;
-    };
-
-    const extractedJSON = extractJSON(text);
-    if (extractedJSON) {
-      try {
-        // Try parsing the extracted JSON
-        return JSON.parse(extractedJSON);
-      } catch (extractParseError) {
-        try {
-          // Try with JSONRepair
-          const repaired = jsonrepair(extractedJSON);
-          return JSON.parse(repaired);
-        } catch (extractRepairError) {
-          logger.debug('Failed to parse JSON after extraction and repair');
-        }
-      }
-    }
-
-    // Try to manually extract a "thought"/"message" structure which is common
-    const manuallyExtractStructure = (text: string) => {
-      // Extract thought/message pattern if present
-      const thoughtPattern = /"thought"\s*:\s*"([^"]*?)(?:"|$)/;
-      const messagePattern = /"message"\s*:\s*"([^"]*?)(?:"|$)/;
-
-      const thoughtMatch = text.match(thoughtPattern);
-      const messageMatch = text.match(messagePattern);
-
-      if (thoughtMatch || messageMatch) {
-        const extractedContent: Record<string, any> = {
-          type: 'reconstructed_response',
-        };
-
-        if (thoughtMatch) {
-          extractedContent.thought = thoughtMatch[1].replace(/\\n/g, '\n');
-        }
-
-        if (messageMatch) {
-          extractedContent.message = messageMatch[1].replace(/\\n/g, '\n');
-        } else {
-          // If no message was found but we have a thought, try to use the rest of the content as message
-          let remainingContent = text;
-          if (thoughtMatch) {
-            // Remove the thought part from the content
-            remainingContent = remainingContent.replace(thoughtPattern, '');
-          }
-
-          // Look for code blocks in the remaining content
-          const codeBlocks: { language: string; code: string }[] = [];
-          const codeBlockRegex = /```([\w]*)\n([\s\S]*?)```/g;
-          let match;
-
-          while ((match = codeBlockRegex.exec(remainingContent)) !== null) {
-            codeBlocks.push({
-              language: match[1] || 'text',
-              code: match[2].trim(),
-            });
-          }
-
-          if (codeBlocks.length > 0) {
-            extractedContent.codeBlocks = codeBlocks;
-            // Remove code blocks from the remaining content
-            remainingContent = remainingContent.replace(codeBlockRegex, '');
-          }
-
-          // Use the cleaned remaining content as message
-          extractedContent.message = remainingContent.trim();
-        }
-
-        return extractedContent;
-      }
-
-      // For reflection schema-like structure
-      if (text.includes('thought') || text.includes('facts') || text.includes('relationships')) {
-        logger.debug('Attempting to extract reflection schema components');
-
-        const result: Record<string, any> = {
-          thought: '',
-          facts: [],
-          relationships: [],
-          rawContent: text,
-        };
-
-        // Try to extract thought
-        const thoughtMatch = text.match(/thought["\s:]+([^"{}[\],]+)/i);
-        if (thoughtMatch) {
-          result.thought = thoughtMatch[1].trim();
-        }
-
-        // Attempt to extract facts and relationships would go here
-        // This would require more complex parsing logic for arrays
-
-        return result;
-      }
-
-      return null;
-    };
-
-    const manuallyExtracted = manuallyExtractStructure(text);
-    if (manuallyExtracted) {
-      return manuallyExtracted;
-    }
-
-    // Last resort: Return a structured object with the raw text
-    logger.debug(
-      'All JSON extraction methods failed, returning structured object with raw content'
-    );
-    return {
-      type: 'unstructured_response',
-      content: text,
-    };
-  }
-};
+import { extractAndParseJSON, ExtractedJSON, ensureReflectionProperties } from './utils';
 
 /**
  * Plugin for Anthropic.
@@ -377,14 +125,10 @@ export const anthropicPlugin: Plugin = {
           logger.debug('Attempting to parse response from Anthropic model');
           const jsonObject = extractAndParseJSON(text);
 
-          // For reflection schema, ensure we have all required properties
-          if (isReflection && jsonObject) {
-            if (!jsonObject.thought) jsonObject.thought = '';
-            if (!jsonObject.facts) jsonObject.facts = [];
-            if (!jsonObject.relationships) jsonObject.relationships = [];
-          }
+          // Ensure reflection schema has all required properties
+          const processedObject = ensureReflectionProperties(jsonObject, isReflection);
 
-          return jsonObject;
+          return processedObject;
         } catch (parseError) {
           logger.error('Failed to parse JSON from Anthropic response:', parseError);
           logger.error('Raw response:', text);
@@ -436,14 +180,10 @@ export const anthropicPlugin: Plugin = {
           logger.debug('Attempting to parse response from Anthropic model');
           const jsonObject = extractAndParseJSON(text);
 
-          // For reflection schema, ensure we have all required properties
-          if (isReflection && jsonObject) {
-            if (!jsonObject.thought) jsonObject.thought = '';
-            if (!jsonObject.facts) jsonObject.facts = [];
-            if (!jsonObject.relationships) jsonObject.relationships = [];
-          }
+          // Ensure reflection schema has all required properties
+          const processedObject = ensureReflectionProperties(jsonObject, isReflection);
 
-          return jsonObject;
+          return processedObject;
         } catch (parseError) {
           logger.error('Failed to parse JSON from Anthropic response:', parseError);
           logger.error('Raw response:', text);

--- a/packages/plugin-anthropic/src/index.ts
+++ b/packages/plugin-anthropic/src/index.ts
@@ -1,19 +1,260 @@
 import { anthropic } from '@ai-sdk/anthropic';
-import type {
-  IAgentRuntime,
-  ObjectGenerationParams,
-  GenerateTextParams,
-  Plugin,
-} from '@elizaos/core';
+import type { ObjectGenerationParams, GenerateTextParams, Plugin } from '@elizaos/core';
 import { ModelType, logger } from '@elizaos/core';
 import { generateText } from 'ai';
+import { jsonrepair } from 'jsonrepair';
 
-// Define a configuration schema for the Anthropics plugin.
-// const configSchema = z.object({
-// 	ANTHROPIC_API_KEY: z.string().min(1, "Anthropic API key is required"),
-// 	ANTHROPIC_SMALL_MODEL: z.string().optional(),
-// 	ANTHROPIC_LARGE_MODEL: z.string().optional(),
-// });
+/**
+ * Enhanced function to extract and parse JSON from LLM responses
+ * Handles various response formats including mixed markdown and JSON with code blocks
+ */
+const extractAndParseJSON = (text: string) => {
+  try {
+    // First attempt: Try direct JSON parsing
+    return JSON.parse(text);
+  } catch (initialError) {
+    logger.debug('Initial JSON parse failed, attempting alternative extraction methods');
+
+    // Try JSONRepair first
+    try {
+      const repaired = jsonrepair(text);
+      return JSON.parse(repaired);
+    } catch (repairError) {
+      logger.debug('JSONRepair failed, proceeding with manual extraction methods');
+    }
+
+    // Check if we have a valid JSON structure with embedded code blocks
+    // This specifically addresses the case where Anthropic returns a valid JSON object
+    // that contains markdown code blocks inside string values
+    const isJsonWithCodeBlocks =
+      text.trim().startsWith('{') && text.trim().endsWith('}') && text.includes('```');
+
+    if (isJsonWithCodeBlocks) {
+      // Replace code blocks with escaped versions to preserve them in the JSON
+      try {
+        // First, try to preserve the code blocks by temporarily replacing them
+        const codeBlockPlaceholders: { placeholder: string; content: string }[] = [];
+        let placeholderCounter = 0;
+        const textWithPlaceholders = text.replace(
+          /```(\w*)\n([\s\S]*?)```/g,
+          (match, language, code) => {
+            const placeholder = `__CODE_BLOCK_${placeholderCounter++}__`;
+            codeBlockPlaceholders.push({
+              placeholder,
+              content: `\`\`\`${language}\n${code}\`\`\``,
+            });
+            return placeholder;
+          }
+        );
+
+        // Try parsing with placeholders
+        let parsed;
+        try {
+          // Try JSONRepair first
+          const repaired = jsonrepair(textWithPlaceholders);
+          parsed = JSON.parse(repaired);
+        } catch (e) {
+          // If JSONRepair fails, try direct parsing
+          parsed = JSON.parse(textWithPlaceholders);
+        }
+
+        // Restore code blocks in the parsed object
+        const restoreCodeBlocks = (obj: any): any => {
+          if (typeof obj === 'string') {
+            let result = obj;
+            for (const { placeholder, content } of codeBlockPlaceholders) {
+              result = result.replace(placeholder, content);
+            }
+            return result;
+          } else if (Array.isArray(obj)) {
+            return obj.map((item) => restoreCodeBlocks(item));
+          } else if (obj !== null && typeof obj === 'object') {
+            const result: Record<string, any> = {};
+            for (const [key, value] of Object.entries(obj)) {
+              result[key] = restoreCodeBlocks(value);
+            }
+            return result;
+          }
+          return obj;
+        };
+
+        return restoreCodeBlocks(parsed);
+      } catch (codeBlockError) {
+        logger.debug('Code block preservation failed, continuing with other methods');
+      }
+    }
+
+    // Try to extract JSON from code blocks
+    const extractFromCodeBlocks = (text: string): string | null => {
+      // First priority: explicit JSON code blocks
+      const jsonBlockRegex = /```json\s*([\s\S]*?)\s*```/;
+      const jsonMatch = text.match(jsonBlockRegex);
+      if (jsonMatch && jsonMatch[1]) {
+        return jsonMatch[1].trim();
+      }
+
+      // Second priority: any code block that contains JSON-like content
+      const anyBlockRegex = /```(?:\w*)\s*([\s\S]*?)\s*```/g;
+      let match;
+      while ((match = anyBlockRegex.exec(text)) !== null) {
+        const blockContent = match[1].trim();
+        if (blockContent.startsWith('{') && blockContent.endsWith('}')) {
+          return blockContent;
+        }
+      }
+
+      return null;
+    };
+
+    const extractedFromCodeBlock = extractFromCodeBlocks(text);
+    if (extractedFromCodeBlock) {
+      try {
+        // Try parsing the extracted content
+        return JSON.parse(extractedFromCodeBlock);
+      } catch (blockParseError) {
+        try {
+          // Try with JSONRepair
+          const repaired = jsonrepair(extractedFromCodeBlock);
+          return JSON.parse(repaired);
+        } catch (blockRepairError) {
+          logger.debug('Failed to parse JSON from code block after repair');
+        }
+      }
+    }
+
+    // Look for JSON structure outside of code blocks
+    const extractJSON = (text: string): string | null => {
+      // Try to find JSON-like content in the text
+      // This regex looks for content that starts with { and ends with }
+      const jsonContentRegex = /(^|\n)\s*(\{[\s\S]*\})\s*($|\n)/;
+      const contentMatch = text.match(jsonContentRegex);
+
+      if (contentMatch && contentMatch[2]) {
+        return contentMatch[2].trim();
+      }
+
+      // If no direct match, try to find the largest JSON-like structure
+      const jsonPattern = /\{[\s\S]*?\}/g;
+      const jsonMatches = text.match(jsonPattern);
+
+      if (jsonMatches && jsonMatches.length > 0) {
+        // Sort matches by length (descending) to try the largest JSON-like structure first
+        return [...jsonMatches].sort((a, b) => b.length - a.length)[0];
+      }
+
+      return null;
+    };
+
+    const extractedJSON = extractJSON(text);
+    if (extractedJSON) {
+      try {
+        // Try parsing the extracted JSON
+        return JSON.parse(extractedJSON);
+      } catch (extractParseError) {
+        try {
+          // Try with JSONRepair
+          const repaired = jsonrepair(extractedJSON);
+          return JSON.parse(repaired);
+        } catch (extractRepairError) {
+          logger.debug('Failed to parse JSON after extraction and repair');
+        }
+      }
+    }
+
+    // Try to manually extract a "thought"/"message" structure which is common
+    const manuallyExtractStructure = (text: string) => {
+      // Extract thought/message pattern if present
+      const thoughtPattern = /"thought"\s*:\s*"([^"]*?)(?:"|$)/;
+      const messagePattern = /"message"\s*:\s*"([^"]*?)(?:"|$)/;
+
+      const thoughtMatch = text.match(thoughtPattern);
+      const messageMatch = text.match(messagePattern);
+
+      if (thoughtMatch || messageMatch) {
+        const extractedContent: Record<string, any> = {
+          type: 'reconstructed_response',
+        };
+
+        if (thoughtMatch) {
+          extractedContent.thought = thoughtMatch[1].replace(/\\n/g, '\n');
+        }
+
+        if (messageMatch) {
+          extractedContent.message = messageMatch[1].replace(/\\n/g, '\n');
+        } else {
+          // If no message was found but we have a thought, try to use the rest of the content as message
+          let remainingContent = text;
+          if (thoughtMatch) {
+            // Remove the thought part from the content
+            remainingContent = remainingContent.replace(thoughtPattern, '');
+          }
+
+          // Look for code blocks in the remaining content
+          const codeBlocks: { language: string; code: string }[] = [];
+          const codeBlockRegex = /```([\w]*)\n([\s\S]*?)```/g;
+          let match;
+
+          while ((match = codeBlockRegex.exec(remainingContent)) !== null) {
+            codeBlocks.push({
+              language: match[1] || 'text',
+              code: match[2].trim(),
+            });
+          }
+
+          if (codeBlocks.length > 0) {
+            extractedContent.codeBlocks = codeBlocks;
+            // Remove code blocks from the remaining content
+            remainingContent = remainingContent.replace(codeBlockRegex, '');
+          }
+
+          // Use the cleaned remaining content as message
+          extractedContent.message = remainingContent.trim();
+        }
+
+        return extractedContent;
+      }
+
+      // For reflection schema-like structure
+      if (text.includes('thought') || text.includes('facts') || text.includes('relationships')) {
+        logger.debug('Attempting to extract reflection schema components');
+
+        const result: Record<string, any> = {
+          thought: '',
+          facts: [],
+          relationships: [],
+          rawContent: text,
+        };
+
+        // Try to extract thought
+        const thoughtMatch = text.match(/thought["\s:]+([^"{}[\],]+)/i);
+        if (thoughtMatch) {
+          result.thought = thoughtMatch[1].trim();
+        }
+
+        // Attempt to extract facts and relationships would go here
+        // This would require more complex parsing logic for arrays
+
+        return result;
+      }
+
+      return null;
+    };
+
+    const manuallyExtracted = manuallyExtractStructure(text);
+    if (manuallyExtracted) {
+      return manuallyExtracted;
+    }
+
+    // Last resort: Return a structured object with the raw text
+    logger.debug(
+      'All JSON extraction methods failed, returning structured object with raw content'
+    );
+    return {
+      type: 'unstructured_response',
+      content: text,
+    };
+  }
+};
 
 /**
  * Plugin for Anthropic.
@@ -36,13 +277,6 @@ export const anthropicPlugin: Plugin = {
   },
   async init(config: Record<string, string>) {
     try {
-      // const validatedConfig = await configSchema.parseAsync(config);
-
-      // Set all environment variables at once
-      // for (const [key, value] of Object.entries(validatedConfig)) {
-      // 	if (value) process.env[key] = value;
-      // }
-
       // If API key is not set, we'll show a warning but continue
       if (!process.env.ANTHROPIC_API_KEY) {
         logger.warn(
@@ -52,18 +286,10 @@ export const anthropicPlugin: Plugin = {
         return;
       }
     } catch (error) {
-      // if (error instanceof z.ZodError) {
       // Convert to warning instead of error
       logger.warn(
-        `Anthropic plugin configuration issue: ${error.errors
-          .map((e) => e.message)
-          .join(', ')} - You need to configure the ANTHROPIC_API_KEY in your environment variables`
+        `Anthropic plugin configuration issue: ${error} - You need to configure the ANTHROPIC_API_KEY in your environment variables`
       );
-      // Continue execution instead of throwing
-      // } else {
-      // For unexpected errors, still throw
-      // throw error;
-      // }
     }
   },
   models: {
@@ -146,93 +372,10 @@ export const anthropicPlugin: Plugin = {
           temperature: params.temperature || 0.2, // Lower temperature for more predictable structured output
         });
 
-        // Extract JSON from response
+        // Extract and parse JSON from the response with our improved function
         try {
-          // Try to extract JSON from potential code blocks or surrounding text
-          const extractJSON = (text: string): string => {
-            // Try to find content between JSON codeblocks or markdown blocks
-            const jsonBlockRegex = /```(?:json)?\s*([\s\S]*?)\s*```/;
-            const match = text.match(jsonBlockRegex);
-
-            if (match && match[1]) {
-              return match[1].trim();
-            }
-
-            // If no code blocks, try to find JSON-like content
-            // This regex looks for content that starts with { and ends with } across multiple lines
-            const jsonContentRegex = /\s*(\{[\s\S]*\})\s*$/;
-            const contentMatch = text.match(jsonContentRegex);
-
-            if (contentMatch && contentMatch[1]) {
-              return contentMatch[1].trim();
-            }
-
-            // If no JSON-like content found, return the original text
-            return text.trim();
-          };
-
-          const extractedJsonText = extractJSON(text);
-          logger.debug('Extracted JSON text:', extractedJsonText);
-
-          let jsonObject;
-          try {
-            jsonObject = JSON.parse(text);
-          } catch (parseError) {
-            // Try fixing common JSON issues
-            logger.debug('Initial JSON parse failed, attempting to fix common issues');
-
-            // Replace any unescaped newlines in string values
-            let fixedJson = extractedJsonText
-              .replace(/:\s*"([^"]*)(?:\n)([^"]*)"/g, ': "$1\\n$2"')
-              // Remove any non-JSON text that might have gotten mixed into string values
-              .replace(/"([^"]*?)[^a-zA-Z0-9\s\.,;:\-_\(\)"'\[\]{}]([^"]*?)"/g, '"$1$2"')
-              // Fix missing quotes around property names
-              .replace(/(\s*)(\w+)(\s*):/g, '$1"$2"$3:')
-              // Fix trailing commas in arrays and objects
-              .replace(/,(\s*[\]}])/g, '$1');
-
-            // Sometimes strings get corrupted with injected text, try to fix by finding broken strings
-            const brokenStringRegex = /"([^"]*?)([^"]*?)"\s*,\s*"([^"]+)"\s*:/g;
-            while (brokenStringRegex.test(fixedJson)) {
-              fixedJson = fixedJson.replace(brokenStringRegex, '"$1$2",\n"$3":');
-            }
-
-            try {
-              jsonObject = JSON.parse(fixedJson);
-            } catch (finalError) {
-              // Last resort - try manual reconstruction for reflection schema
-              // Find the thought, facts and relationships separately and manually construct the JSON
-              if (isReflection) {
-                logger.debug('Attempting manual reconstruction of reflection schema');
-
-                const thoughtMatch = extractedJsonText.match(/"thought"\s*:\s*"([^"]+)"/);
-                const thoughtValue = thoughtMatch ? thoughtMatch[1] : '';
-
-                // Initialize a basic valid reflection object
-                jsonObject = {
-                  thought: thoughtValue || 'Unable to extract valid thought from model response',
-                  facts: [],
-                  relationships: [],
-                };
-
-                // Try to extract some facts if possible
-                const factMatches = extractedJsonText.match(/"claim"\s*:\s*"([^"]+)"/g);
-                if (factMatches) {
-                  jsonObject.facts = factMatches.map((match) => ({
-                    claim: match.replace(/"claim"\s*:\s*"([^"]+)"/, '$1'),
-                    type: 'fact',
-                    in_bio: false,
-                    already_known: false,
-                  }));
-                }
-
-                logger.debug('Manually reconstructed object:', jsonObject);
-              } else {
-                // For non-reflection schemas, can't reliably reconstruct
-                throw finalError;
-              }
-            }
-          }
+          logger.debug('Attempting to parse response from Anthropic model');
+          const jsonObject = extractAndParseJSON(text);
 
           // For reflection schema, ensure we have all required properties
           if (isReflection && jsonObject) {
@@ -240,20 +383,6 @@ export const anthropicPlugin: Plugin = {
             if (!jsonObject.facts) jsonObject.facts = [];
             if (!jsonObject.relationships) jsonObject.relationships = [];
           }
-
-          // Validate against schema if provided
-          // if (params.schema) {
-          // 	try {
-          // 		return z.object(params.schema).parse(jsonObject);
-          // 	} catch (zodError) {
-          // 		logger.error("Schema validation failed:", zodError);
-          // 		// If we have partial data that matches the schema structure, return what we have
-          // 		if (isReflection && jsonObject.thought) {
-          // 			return jsonObject;
-          // 		}
-          // 		throw zodError;
-          // 	}
-          // }
 
           return jsonObject;
         } catch (parseError) {
@@ -302,108 +431,10 @@ export const anthropicPlugin: Plugin = {
           temperature: params.temperature || 0.2, // Lower temperature for more predictable structured output
         });
 
-        // Extract JSON from response
+        // Extract and parse JSON from the response with our improved function
         try {
-          // Try to extract JSON from potential code blocks or surrounding text
-          const extractJSON = (text: string): string => {
-            // Try to find content between JSON codeblocks or markdown blocks
-            const jsonBlockRegex = /```(?:json)?\s*([\s\S]*?)\s*```/;
-            const match = text.match(jsonBlockRegex);
-
-            if (match && match[1]) {
-              return match[1].trim();
-            }
-
-            // If no code blocks, try to find JSON-like content
-            // This regex looks for content that starts with { and ends with } across multiple lines
-            const jsonContentRegex = /\s*(\{[\s\S]*\})\s*$/;
-            const contentMatch = text.match(jsonContentRegex);
-
-            if (contentMatch && contentMatch[1]) {
-              return contentMatch[1].trim();
-            }
-
-            // If no JSON-like content found, return the original text
-            return text.trim();
-          };
-
-          // Clean up the extracted JSON to remove any debugging or log messages
-          const cleanupJSON = (jsonText: string): string => {
-            // Remove common logging/debugging patterns that might get mixed into the JSON
-            return (
-              jsonText
-                // Remove "Waiting for debugger" and similar messages that break JSON
-                .replace(/Waiting for the debugger[^"]*?(\w)/g, '$1')
-                // Remove any other common debugging outputs
-                .replace(/\[DEBUG\].*?(\n|$)/g, '\n')
-                .replace(/\[LOG\].*?(\n|$)/g, '\n')
-                .replace(/console\.log.*?(\n|$)/g, '\n')
-            );
-          };
-
-          let extractedJsonText = extractJSON(text);
-          extractedJsonText = cleanupJSON(extractedJsonText);
-          logger.debug('Extracted JSON text:', extractedJsonText);
-
-          let jsonObject;
-          try {
-            jsonObject = JSON.parse(extractedJsonText);
-          } catch (parseError) {
-            // Try fixing common JSON issues
-            logger.debug('Initial JSON parse failed, attempting to fix common issues');
-
-            // Replace any unescaped newlines in string values
-            let fixedJson = extractedJsonText
-              .replace(/:\s*"([^"]*)(?:\n)([^"]*)"/g, ': "$1\\n$2"')
-              // Remove any non-JSON text that might have gotten mixed into string values
-              .replace(/"([^"]*?)[^a-zA-Z0-9\s\.,;:\-_\(\)"'\[\]{}]([^"]*?)"/g, '"$1$2"')
-              // Fix missing quotes around property names
-              .replace(/(\s*)(\w+)(\s*):/g, '$1"$2"$3:')
-              // Fix trailing commas in arrays and objects
-              .replace(/,(\s*[\]}])/g, '$1');
-
-            // Sometimes strings get corrupted with injected text, try to fix by finding broken strings
-            const brokenStringRegex = /"([^"]*?)([^"]*?)"\s*,\s*"([^"]+)"\s*:/g;
-            while (brokenStringRegex.test(fixedJson)) {
-              fixedJson = fixedJson.replace(brokenStringRegex, '"$1$2",\n"$3":');
-            }
-
-            try {
-              jsonObject = JSON.parse(fixedJson);
-            } catch (finalError) {
-              // Last resort - try manual reconstruction for reflection schema
-              // Find the thought, facts and relationships separately and manually construct the JSON
-              if (isReflection) {
-                logger.debug('Attempting manual reconstruction of reflection schema');
-
-                const thoughtMatch = extractedJsonText.match(/"thought"\s*:\s*"([^"]+)"/);
-                const thoughtValue = thoughtMatch ? thoughtMatch[1] : '';
-
-                // Initialize a basic valid reflection object
-                jsonObject = {
-                  thought: thoughtValue || 'Unable to extract valid thought from model response',
-                  facts: [],
-                  relationships: [],
-                };
-
-                // Try to extract some facts if possible
-                const factMatches = extractedJsonText.match(/"claim"\s*:\s*"([^"]+)"/g);
-                if (factMatches) {
-                  jsonObject.facts = factMatches.map((match) => ({
-                    claim: match.replace(/"claim"\s*:\s*"([^"]+)"/, '$1'),
-                    type: 'fact',
-                    in_bio: false,
-                    already_known: false,
-                  }));
-                }
-
-                logger.debug('Manually reconstructed object:', jsonObject);
-              } else {
-                // For non-reflection schemas, can't reliably reconstruct
-                throw finalError;
-              }
-            }
-          }
+          logger.debug('Attempting to parse response from Anthropic model');
+          const jsonObject = extractAndParseJSON(text);
 
           // For reflection schema, ensure we have all required properties
           if (isReflection && jsonObject) {
@@ -411,20 +442,6 @@ export const anthropicPlugin: Plugin = {
             if (!jsonObject.facts) jsonObject.facts = [];
             if (!jsonObject.relationships) jsonObject.relationships = [];
           }
-
-          // Validate against schema if provided
-          // if (params.schema) {
-          // 	try {
-          // 		return z.object(params.schema).parse(jsonObject);
-          // 	} catch (zodError) {
-          // 		logger.error("Schema validation failed:", zodError);
-          // 		// If we have partial data that matches the schema structure, return what we have
-          // 		if (isReflection && jsonObject.thought) {
-          // 			return jsonObject;
-          // 		}
-          // 		throw zodError;
-          // 	}
-          // }
 
           return jsonObject;
         } catch (parseError) {
@@ -472,6 +489,24 @@ export const anthropicPlugin: Plugin = {
               logger.log('generated with test_text_large:', text);
             } catch (error) {
               logger.error('Error in test_text_large:', error);
+              throw error;
+            }
+          },
+        },
+        {
+          name: 'anthropic_test_object_with_code_blocks',
+          fn: async (runtime) => {
+            try {
+              const result = await runtime.useModel(ModelType.OBJECT_SMALL, {
+                prompt: 'Give me instructions to install Node.js',
+                schema: { type: 'object' },
+              });
+              logger.log('Generated object with code blocks:', result);
+              if (!result || result.error) {
+                throw new Error('Failed to generate object with code blocks');
+              }
+            } catch (error) {
+              logger.error('Error in test_object_with_code_blocks:', error);
               throw error;
             }
           },

--- a/packages/plugin-anthropic/src/utils.ts
+++ b/packages/plugin-anthropic/src/utils.ts
@@ -1,0 +1,342 @@
+import { logger } from '@elizaos/core';
+import { jsonrepair } from 'jsonrepair';
+
+/**
+ * Type definition for a code block placeholder
+ */
+interface CodeBlockPlaceholder {
+  placeholder: string;
+  content: string;
+}
+
+/**
+ * Type for reconstructed response
+ */
+export interface ReconstructedResponse {
+  type: 'reconstructed_response';
+  thought?: string;
+  message?: string;
+  codeBlocks?: Array<{
+    language: string;
+    code: string;
+  }>;
+}
+
+/**
+ * Type for reflection schema response
+ */
+export interface ReflectionResponse {
+  thought: string;
+  facts: unknown[];
+  relationships: unknown[];
+  rawContent: string;
+}
+
+/**
+ * Type for unstructured response
+ */
+export interface UnstructuredResponse {
+  type: 'unstructured_response';
+  content: string;
+}
+
+/**
+ * Type for JSON extraction result
+ */
+export type ExtractedJSON =
+  | Record<string, unknown>
+  | ReconstructedResponse
+  | ReflectionResponse
+  | UnstructuredResponse;
+
+/**
+ * Helper function to ensure reflection response has all required properties
+ */
+export const ensureReflectionProperties = (
+  obj: ExtractedJSON,
+  isReflection: boolean
+): ExtractedJSON => {
+  // Only process if it's a reflection schema request
+  if (!isReflection) return obj;
+
+  // Check if it's an object with potentially missing reflection properties
+  if (obj !== null && typeof obj === 'object') {
+    // Create a new object with required properties
+    return {
+      ...obj,
+      thought: 'thought' in obj ? obj.thought || '' : '',
+      facts: 'facts' in obj ? obj.facts || [] : [],
+      relationships: 'relationships' in obj ? obj.relationships || [] : [],
+    };
+  }
+
+  return obj;
+};
+
+/**
+ * Enhanced function to extract and parse JSON from LLM responses
+ * Handles various response formats including mixed markdown and JSON with code blocks
+ */
+export const extractAndParseJSON = (text: string): ExtractedJSON => {
+  try {
+    // First attempt: Try direct JSON parsing
+    return JSON.parse(text);
+  } catch (initialError) {
+    logger.debug('Initial JSON parse failed, attempting alternative extraction methods');
+
+    // Try JSONRepair first
+    try {
+      const repaired = jsonrepair(text);
+      return JSON.parse(repaired);
+    } catch (repairError) {
+      logger.debug('JSONRepair failed, proceeding with manual extraction methods');
+    }
+
+    // Check if we have a valid JSON structure with embedded code blocks
+    // This specifically addresses the case where Anthropic returns a valid JSON object
+    // that contains markdown code blocks inside string values
+    const isJsonWithCodeBlocks =
+      text.trim().startsWith('{') && text.trim().endsWith('}') && text.includes('```');
+
+    if (isJsonWithCodeBlocks) {
+      // Replace code blocks with escaped versions to preserve them in the JSON
+      try {
+        // First, try to preserve the code blocks by temporarily replacing them
+        const codeBlockPlaceholders: CodeBlockPlaceholder[] = [];
+        let placeholderCounter = 0;
+        const textWithPlaceholders = text.replace(
+          /```(\w*)\n([\s\S]*?)```/g,
+          (match, language, code) => {
+            const placeholder = `__CODE_BLOCK_${placeholderCounter++}__`;
+            codeBlockPlaceholders.push({
+              placeholder,
+              content: `\`\`\`${language}\n${code}\`\`\``,
+            });
+            return placeholder;
+          }
+        );
+
+        // Try parsing with placeholders
+        let parsed: Record<string, unknown>;
+        try {
+          // Try JSONRepair first
+          const repaired = jsonrepair(textWithPlaceholders);
+          parsed = JSON.parse(repaired);
+        } catch (e) {
+          // If JSONRepair fails, try direct parsing
+          parsed = JSON.parse(textWithPlaceholders);
+        }
+
+        // Restore code blocks in the parsed object
+        const restoreCodeBlocks = (obj: unknown): unknown => {
+          if (typeof obj === 'string') {
+            let result = obj;
+            for (const { placeholder, content } of codeBlockPlaceholders) {
+              result = result.replace(placeholder, content);
+            }
+            return result;
+          } else if (Array.isArray(obj)) {
+            return obj.map((item) => restoreCodeBlocks(item));
+          } else if (obj !== null && typeof obj === 'object') {
+            const result: Record<string, unknown> = {};
+            for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+              result[key] = restoreCodeBlocks(value);
+            }
+            return result;
+          }
+          return obj;
+        };
+
+        return restoreCodeBlocks(parsed) as ExtractedJSON;
+      } catch (codeBlockError) {
+        logger.debug('Code block preservation failed, continuing with other methods');
+      }
+    }
+
+    // Try to extract JSON from code blocks
+    const extractFromCodeBlocks = (text: string): string | null => {
+      // First priority: explicit JSON code blocks
+      const jsonBlockRegex = /```json\s*([\s\S]*?)\s*```/;
+      const jsonMatch = text.match(jsonBlockRegex);
+      if (jsonMatch && jsonMatch[1]) {
+        return jsonMatch[1].trim();
+      }
+
+      // Second priority: any code block that contains JSON-like content
+      const anyBlockRegex = /```(?:\w*)\s*([\s\S]*?)\s*```/g;
+      let match;
+      while ((match = anyBlockRegex.exec(text)) !== null) {
+        const blockContent = match[1].trim();
+        if (blockContent.startsWith('{') && blockContent.endsWith('}')) {
+          return blockContent;
+        }
+      }
+
+      return null;
+    };
+
+    const extractedFromCodeBlock = extractFromCodeBlocks(text);
+    if (extractedFromCodeBlock) {
+      try {
+        // Try parsing the extracted content
+        return JSON.parse(extractedFromCodeBlock);
+      } catch (blockParseError) {
+        try {
+          // Try with JSONRepair
+          const repaired = jsonrepair(extractedFromCodeBlock);
+          return JSON.parse(repaired);
+        } catch (blockRepairError) {
+          logger.debug('Failed to parse JSON from code block after repair');
+        }
+      }
+    }
+
+    // Look for JSON structure outside of code blocks
+    const extractJSON = (text: string): string | null => {
+      // Try to find JSON-like content in the text
+      // This regex looks for content that starts with { and ends with }
+      const jsonContentRegex = /(^|\n)\s*(\{[\s\S]*\})\s*($|\n)/;
+      const contentMatch = text.match(jsonContentRegex);
+
+      if (contentMatch && contentMatch[2]) {
+        return contentMatch[2].trim();
+      }
+
+      // If no direct match, try to find the largest JSON-like structure
+      const jsonPattern = /\{[\s\S]*?\}/g;
+      const jsonMatches = text.match(jsonPattern);
+
+      if (jsonMatches && jsonMatches.length > 0) {
+        // Sort matches by length (descending) to try the largest JSON-like structure first
+        return [...jsonMatches].sort((a, b) => b.length - a.length)[0];
+      }
+
+      return null;
+    };
+
+    const extractedJSON = extractJSON(text);
+    if (extractedJSON) {
+      try {
+        // Try parsing the extracted JSON
+        return JSON.parse(extractedJSON);
+      } catch (extractParseError) {
+        try {
+          // Try with JSONRepair
+          const repaired = jsonrepair(extractedJSON);
+          return JSON.parse(repaired);
+        } catch (extractRepairError) {
+          logger.debug('Failed to parse JSON after extraction and repair');
+        }
+      }
+    }
+
+    // Try to manually extract a "thought"/"message" structure which is common
+    const manuallyExtractStructure = (
+      text: string
+    ): ReconstructedResponse | ReflectionResponse | null => {
+      // Extract thought/message pattern if present
+      const thoughtPattern = /"thought"\s*:\s*"([^"]*?)(?:"|$)/;
+      const messagePattern = /"message"\s*:\s*"([^"]*?)(?:"|$)/;
+
+      const thoughtMatch = text.match(thoughtPattern);
+      const messageMatch = text.match(messagePattern);
+
+      if (thoughtMatch || messageMatch) {
+        const extractedContent: ReconstructedResponse = {
+          type: 'reconstructed_response',
+        };
+
+        if (thoughtMatch) {
+          extractedContent.thought = thoughtMatch[1].replace(/\\n/g, '\n');
+        }
+
+        if (messageMatch) {
+          extractedContent.message = messageMatch[1].replace(/\\n/g, '\n');
+        } else {
+          // If no message was found but we have a thought, try to use the rest of the content as message
+          let remainingContent = text;
+          if (thoughtMatch) {
+            // Remove the thought part from the content
+            remainingContent = remainingContent.replace(thoughtPattern, '');
+          }
+
+          // Look for code blocks in the remaining content
+          const codeBlocks: Array<{ language: string; code: string }> = [];
+          const codeBlockRegex = /```([\w]*)\n([\s\S]*?)```/g;
+          let match;
+
+          while ((match = codeBlockRegex.exec(remainingContent)) !== null) {
+            codeBlocks.push({
+              language: match[1] || 'text',
+              code: match[2].trim(),
+            });
+          }
+
+          if (codeBlocks.length > 0) {
+            extractedContent.codeBlocks = codeBlocks;
+            // Remove code blocks from the remaining content
+            remainingContent = remainingContent.replace(codeBlockRegex, '');
+          }
+
+          // Use the cleaned remaining content as message
+          extractedContent.message = remainingContent.trim();
+        }
+
+        return extractedContent;
+      }
+
+      // For reflection schema-like structure
+      if (text.includes('thought') || text.includes('facts') || text.includes('relationships')) {
+        logger.debug('Attempting to extract reflection schema components');
+
+        const result: ReflectionResponse = {
+          thought: '',
+          facts: [],
+          relationships: [],
+          rawContent: text,
+        };
+
+        // Try to extract thought
+        const thoughtMatch = text.match(/thought["\s:]+([^"{}[\],]+)/i);
+        if (thoughtMatch) {
+          result.thought = thoughtMatch[1].trim();
+        }
+
+        // Attempt to extract facts and relationships would go here
+        // This would require more complex parsing logic for arrays
+
+        return result;
+      }
+
+      return null;
+    };
+
+    const manuallyExtracted = manuallyExtractStructure(text);
+    if (manuallyExtracted) {
+      return manuallyExtracted;
+    }
+
+    // Last resort: Return a structured object with the raw text
+    logger.debug(
+      'All JSON extraction methods failed, returning structured object with raw content'
+    );
+    return {
+      type: 'unstructured_response',
+      content: text,
+    };
+  }
+};
+
+// Future config schema for generateObject
+/**
+ * Configuration schema for Anthropic plugin.
+ * This will be used when we switch to generateObject instead of generateText.
+ */
+export const configSchemaComment = `
+// Define a configuration schema for the Anthropics plugin.
+// const configSchema = z.object({
+// 	ANTHROPIC_API_KEY: z.string().min(1, "Anthropic API key is required"),
+// 	ANTHROPIC_SMALL_MODEL: z.string().optional(),
+// 	ANTHROPIC_LARGE_MODEL: z.string().optional(),
+// });
+`;


### PR DESCRIPTION
# Fix Anthropic Plugin JSON Parsing for Responses with Code Blocks

## Risks

Low - This PR addresses an edge case in the JSON parsing logic for Anthropic responses containing code blocks. The changes improve the robustness of the existing error handling without changing the API.

## Background

### What does this PR do?

This PR fixes an issue in the Anthropic plugin where responses containing code blocks with language identifiers (like `bash`) are causing JSON parsing errors. The specific issue occurs when the model returns valid JSON containing markdown code blocks in string values, but the parser fails to handle the content correctly.

### What kind of change is this?

Bug fix (non-breaking change which fixes an issue)

### Documentation changes needed?

No documentation changes are required as this fixes an internal parsing mechanism.

## Testing

### Where should a reviewer start?

The reviewer should start by examining the `extractAndParseJSON` function in `packages/plugin-anthropic/src/index.ts` to understand how the JSON parsing has been improved.

### Detailed testing steps

1. Test sending messages that would result in responses with code blocks
2. Verify that responses with bash/code blocks are correctly parsed
3. Verify that the error "Invalid JSON returned from Anthropic model" no longer occurs for valid responses with code blocks

## Screenshots

### Before

Error when receiving a response with code blocks:

```
[2025-04-08 13:06:47] ERROR: Failed to parse JSON from Anthropic response:
    message: "(SyntaxError) JSON Parse error: Unexpected identifier \"bash\""
[2025-04-08 13:06:47] ERROR: Raw response: {
    "thought": "I'll help them get started with ElizaOS by providing clear installation instructions from the documentation",
    "message": "I'll help you get started with ElizaOS! The quickest way is to install the CLI tool globally:\n\n1. Install the CLI:\nbash\nnpm install -g @elizaos/cli@beta\n\n\n2. Create a new project:\nbash\nelizaos create\n\n\n3. Start your project:\nbash\ncd your-project\nelizaos start\n\n\nOnce started, you can visit https://localhost:3000 to interact with your agent through the web interface. Let me know if you need help with any specific part of the setup!"
}
```

### After

The same response is now correctly parsed without errors, allowing the agent to properly display messages with code blocks.

<img width="493" alt="image" src="https://github.com/user-attachments/assets/3a4ac9e8-38a8-410d-a465-077526a2fd88" />

<img width="531" alt="image" src="https://github.com/user-attachments/assets/1a8fc76a-d3fa-4b37-82f8-f43af62abe3e" />

<img width="853" alt="image" src="https://github.com/user-attachments/assets/dd026ddc-56ce-4579-a9a8-f2676c8e6415" />

<img width="870" alt="image" src="https://github.com/user-attachments/assets/7f33a73c-ecfa-46a5-ae33-9e96e94ffc4c" />

## Deploy Notes

No special deployment notes required. This is a non-breaking change that fixes a parsing issue in the Anthropic plugin.
