### PR TITLE
fix: transcription

### DIFF
--- a/packages/plugin-openai/src/index.ts
+++ b/packages/plugin-openai/src/index.ts
@@ -17,7 +17,8 @@ import {
 } from '@elizaos/core';
 import { generateObject, generateText, JSONParseError, JSONValue } from 'ai';
 import { type TiktokenModel, encodingForModel } from 'js-tiktoken';
-import { FormData as NodeFormData, File as NodeFile } from 'formdata-node';
+import FormData from 'form-data';
+import fetch from 'node-fetch';
 
 /**
  * Helper function to get settings with fallback to process.env
@@ -512,8 +513,11 @@ export const openaiPlugin: Plugin = {
       logger.log('audioBuffer', audioBuffer);
       const baseURL = getBaseURL(runtime);
 
-      const formData = new NodeFormData();
-      formData.append('file', new NodeFile([audioBuffer], 'recording.mp3', { type: 'audio/mp3' }));
+      const formData = new FormData();
+      formData.append('file', audioBuffer, {
+        filename: 'recording.mp3',
+        contentType: 'audio/mp3',
+      });
       formData.append('model', 'whisper-1');
 
       const response = await fetch(`${baseURL}/audio/transcriptions`, {

--- a/packages/plugin-twitter/src/interactions.ts
+++ b/packages/plugin-twitter/src/interactions.ts
@@ -192,7 +192,7 @@ export class TwitterInteractionClient {
    * Note: MENTION_RECEIVED is currently disabled (see TODO below)
    */
   async processMentionTweets(mentionCandidates: ClientTweet[]) {
-    console.log('Completed checking mentioned tweets:', mentionCandidates.length);
+    logger.log('Completed checking mentioned tweets:', mentionCandidates.length);
     let uniqueTweetCandidates = [...mentionCandidates];
 
     // Sort tweet candidates by ID in ascending order

--- a/packages/plugin-twitter/src/interactions.ts
+++ b/packages/plugin-twitter/src/interactions.ts
@@ -192,7 +192,7 @@ export class TwitterInteractionClient {
    * Note: MENTION_RECEIVED is currently disabled (see TODO below)
    */
   async processMentionTweets(mentionCandidates: ClientTweet[]) {
-    logger.log('Completed checking mentioned tweets:', mentionCandidates.length);
+    console.log('Completed checking mentioned tweets:', mentionCandidates.length);
     let uniqueTweetCandidates = [...mentionCandidates];
 
     // Sort tweet candidates by ID in ascending order
@@ -543,6 +543,11 @@ export class TwitterInteractionClient {
     // Create a callback for handling the response
     const callback: HandlerCallback = async (response: Content, tweetId?: string) => {
       try {
+        if (!response.text) {
+          logger.warn('No text content in response, skipping tweet reply');
+          return [];
+        }
+
         const tweetToReplyTo = tweetId || tweet.id;
 
         if (this.isDryRun) {
@@ -553,27 +558,24 @@ export class TwitterInteractionClient {
         logger.info(`Replying to tweet ${tweetToReplyTo}`);
 
         // Create the actual tweet using the Twitter API through the client
-        // Type assertion is needed because the Twitter API client doesn't have proper typings
         const replyTweetResult = await this.client.requestQueue.add(() =>
-          (this.client.twitterClient as any).post('statuses/update', {
-            status: response.text.substring(0, 280),
-            in_reply_to_status_id: tweetToReplyTo,
-            auto_populate_reply_metadata: true,
-          })
+          this.client.twitterClient.sendTweet(response.text.substring(0, 280), tweetToReplyTo)
         );
 
         if (!replyTweetResult) {
           throw new Error('Failed to create tweet response');
         }
 
+        // Parse the response to get the tweet ID
+        const responseBody = await (replyTweetResult as Response).json();
+        const tweetResult = responseBody?.data?.create_tweet?.tweet_results?.result;
+
+        if (!tweetResult) {
+          throw new Error('Failed to get tweet result from response');
+        }
+
         // Create memory for our response
-        const responseId = createUniqueUuid(
-          this.runtime,
-          (replyTweetResult as any).id_str ||
-            (replyTweetResult as any).rest_id ||
-            (replyTweetResult as any).legacy.id_str ||
-            (replyTweetResult as any).id
-        );
+        const responseId = createUniqueUuid(this.runtime, tweetResult.rest_id);
         const responseMemory: Memory = {
           id: responseId,
           entityId: this.runtime.agentId,


### PR DESCRIPTION
This PR addresses an issue where transcription was no longer working in both the Discord and GUI. The issue appears to have been introduced in [#4169](https://github.com/elizaOS/eliza/pull/4169), which switched to using NodeFormData. Unfortunately, that change seems to have broken the transcription feature, as the API returned a 400 Bad Request.

To resolve this, I’ve reverted to using the form-data package along with node-fetch. I’ve tested this update, and transcription now works as expected in both Discord and the GUI.