### PR TITLE
Fix GitHub Authentication Prompt During Start CLI Command

### DIFF
--- a/packages/cli/src/utils/install-plugin.ts
+++ b/packages/cli/src/utils/install-plugin.ts
@@ -105,13 +105,17 @@ export async function installPlugin(
   // Mark this plugin as installed to ensure we don't get into an infinite loop
   logger.info(`Installing plugin: ${repository}`);
 
-  // Clean repository URL
+  // Clean repository URL - only if it looks like a GitHub URL
   let repoUrl = repository;
-  if (repoUrl.startsWith('git+')) {
-    repoUrl = repoUrl.substring(4);
-  }
-  if (repoUrl.endsWith('.git')) {
-    repoUrl = repoUrl.slice(0, -4);
+
+  // Leave scoped packages as-is to prioritize npm registry
+  if (!repository.startsWith('@')) {
+    if (repoUrl.startsWith('git+')) {
+      repoUrl = repoUrl.substring(4);
+    }
+    if (repoUrl.endsWith('.git')) {
+      repoUrl = repoUrl.slice(0, -4);
+    }
   }
 
   // Get installation context info


### PR DESCRIPTION
**Issue:**

Users were unexpectedly prompted for GitHub authentication during normal CLI operations like elizaos start, while the same command run through npx elizaos start did not require authentication. This inconsistency created a confusing user experience and unnecessary friction.

**Root Cause:**

The CLI was using GitHub-authenticated API calls for routine operations like looking up plugin metadata and registry indexes, even when these operations could be performed without authentication. Specifically:
The plugin installation process (installPlugin) was using getPluginMetadata() which required GitHub authentication
The registry lookup functions were defaulting to authenticated GitHub API endpoints. When installing plugins, the CLI was *sometimes* preferring authentication-required methods over authentication-free alternatives, specifically when the plugin installation failed for some reason, it would fallback to something that requires gh auth.

**Solution:**

I implemented several key changes to eliminate the need for GitHub authentication during normal CLI usage while preserving it for operations that genuinely require it (like publishing):

- Created a new getLocalRegistryIndex() function that retrieves registry data through authentication-free methods:
   -First tries fetching from the public GitHub raw URL
   -Falls back to using a local cache file
   -Finally defaults to built-in registry data as a last resort

- Modified getPluginRepository() to exclusively use the new non-authenticated method, eliminating its dependency on getPluginMetadata()
- Updated getPluginVersion() to skip metadata lookup entirely and use non-authenticated getPackageDetails() or simply return the requested version

Enhanced the plugin installation process in executeInstallation() to:

- Prioritize npm registry installations which don't require GitHub auth
- Fall back to GitHub shorthand syntax (github:org/repo) which doesn't require authentication
- Preserve scoped package names during npm installation attempts

These changes should ensure that users will never be prompted for GitHub authentication during routine operations like elizaos start or automatic plugin installation, while maintaining the ability to authenticate when needed for publishing or registry management commands.