### PR TITLE
Bug: Remove Duplicate Declaration in api.ts

### DIFF
--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -29,7 +29,6 @@ const fetcher = async ({
 
   clientLogger.info('API Request:', method || 'GET', normalizedUrl);
 
-
   const options: RequestInit = {
     method: method ?? 'GET',
     headers: headers
@@ -72,7 +71,6 @@ const fetcher = async ({
       clientLogger.error('API Error:', response.status, response.statusText);
       clientLogger.error('Response:', errorText);
 
-
       let errorMessage = `${response.status}: ${response.statusText}`;
       try {
         const errorObj = JSON.parse(errorText);
@@ -103,11 +101,9 @@ const fetcher = async ({
         const jsonData = await response.json();
         return jsonData;
       } catch (error) {
-
         const text = await response.text();
 
         clientLogger.error('JSON Parse Error:', error);
-        const text = await response.text();
         clientLogger.error(
           'Response text:',
           text.substring(0, 500) + (text.length > 500 ? '...' : '')
@@ -121,7 +117,6 @@ const fetcher = async ({
       return textResponse;
     }
   } catch (error) {
-
     clientLogger.error('Fetch error:', error);
 
     throw error;


### PR DESCRIPTION
## Fix duplicate variable declaration in api.ts

### Problem

The build was failing with the following error:

This was happening because in the json parsing error handler, the `text` variable was being declared twice:

- First at line 104: `const text = await response.text();`
- Then again at line 110: `const text = await response.text();`

This duplicate declaration was causing the TypeScript compiler to fail. Specifically "bun run build" was failing.

### Solution

Removed the second declaration of the `text` variable.

### Changes

- Removed the duplicate declaration at line 110, keeping only the first declaration  
- Everything else same

This change ensures api.ts properly handles json parsing errors while maintaining a clean build process.