### PR TITLE
fix: getTasks error

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -281,13 +281,9 @@ export class AgentRuntime implements IAgentRuntime {
     }
 
     if (plugin.services) {
-      for (const service of plugin.services) {
-        if (this.isInitialized) {
-          await this.registerService(service);
-        } else {
-          this.servicesInitQueue.add(service);
-        }
-      }
+      plugin.services.forEach((service) => {
+        this.servicesInitQueue.add(service);
+      });
     }
   }
 
@@ -324,6 +320,11 @@ export class AgentRuntime implements IAgentRuntime {
         registeredPluginNames.add(plugin.name);
         pluginRegistrationPromises.push(await this.registerPlugin(plugin));
       }
+    }
+
+    if (!this.adapter) {
+      console.error('Could not find the adapter plugin. Please include the adapter plugin.');
+      throw new Error('Adapter plugin is missing.');
     }
 
     await this.adapter.init();


### PR DESCRIPTION
related: 
https://github.com/elizaOS/eliza/issues/4238
https://github.com/elizaOS/eliza/pull/4189#issuecomment-2793130288


The issue occurs because the service starts before the runtime is fully set up — meaning the adapter is not be ready yet.