### PR TITLE
fix: Move init after adapter.init in runtime

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -310,7 +310,6 @@ export class AgentRuntime implements IAgentRuntime {
       this.runtimeLogger.warn('Agent already initialized');
       return;
     }
-    this.isInitialized = true;
 
     // Track registered plugins to avoid duplicates
     const registeredPluginNames = new Set<string>();
@@ -327,6 +326,8 @@ export class AgentRuntime implements IAgentRuntime {
     }
 
     await this.adapter.init();
+
+    this.isInitialized = true;
 
     // First create the agent entity directly
     try {


### PR DESCRIPTION
# Relates to
[<!-- LINK TO ISSUE OR TICKET -->](https://github.com/elizaOS/eliza/issues/4238)


# Risks

Low - This is a simple fix that moves the initialization flag setting after the adapter initialization. The change is minimal and focused on fixing the initialization order.

# Background

## What does this PR do?

This PR fixes the initialization order in the `AgentRuntime` class by moving the `isInitialized` flag setting after the `adapter.init()` call. This ensures that the runtime is only marked as initialized after the database adapter has been properly initialized.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Reviewers should focus on the `initialize()` method in the `AgentRuntime` class, specifically around line 310 where the initialization flag is set.

## Detailed testing steps

- Verify that the runtime is not marked as initialized before the adapter is initialized
- Ensure that all initialization steps complete successfully
- Confirm that the runtime is properly marked as initialized after the adapter initialization
