### PR TITLE
ELI2-185/reflections-agent-asks-all-other-agents-deployed-how-its-doing

### DIFF
--- a/packages/plugin-bootstrap/src/evaluators/reflection.ts
+++ b/packages/plugin-bootstrap/src/evaluators/reflection.ts
@@ -79,7 +79,7 @@ Message Sender: {{senderName}} (ID: {{senderId}})
 {{knownFacts}}
 
 # Instructions:
-1. Generate a self-reflective thought on the conversation. How are you doing? You're not being annoying, are you?
+1. Generate a self-reflective thought on the conversation about your performance and interaction quality.
 2. Extract new facts from the conversation.
 3. Identify and describe relationships between entities.
   - The sourceEntityId is the UUID of the entity initiating the interaction.


### PR DESCRIPTION
## Fix Agents Repeatedly Asking Each Other "How Are You Doing?" in Group Conversations

### Problem

In group settings, agents were frequently asking each other "how are you doing?" during conversations. This was caused by a hardcoded reflection prompt in `reflectionEvaluator`:

> Generate a self-reflective thought on the conversation. How are you doing? You're not being annoying, are you?

The prompt encouraged agents to check in with others, leading to repetitive and unnatural group interactions.

### Solution

- Rewrote the reflection prompt in `packages/plugin-bootstrap/src/evaluators/reflection.ts` to use neutral language that no longer encourages agents to ask others how they’re doing
- This stops the specific loop of agents checking in with each other, while preserving the overall reflection capability

### Further Considerations

- While this change removes the direct "how are you doing?" loop, agents in group settings can still fall into other repetitive or unnatural patterns
- Future improvements may include polishing the existing implementation and architecture to support more natural group chat dynamics

### Testing Done

Tested in multi-agent group conversations. Agents no longer ask each other "how are you doing?" repeatedly, and overall interaction quality has improved, though some repetition issues remain for future refinement.