### PR TITLE
Improvement: Default SQL and OpenAI Plugins for New Character

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@elizaos/core": "workspace:*",
+    "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-avatar": "^1.1.3",
     "@radix-ui/react-collapsible": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.6",

--- a/packages/client/src/components/agent-creator.tsx
+++ b/packages/client/src/components/agent-creator.tsx
@@ -18,7 +18,7 @@ const defaultCharacter: Partial<Agent> = {
   bio: [] as string[],
   topics: [] as string[],
   adjectives: [] as string[],
-  plugins: [],
+  plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai'],
   settings: { secrets: {} },
 };
 

--- a/packages/client/src/components/plugins-panel.tsx
+++ b/packages/client/src/components/plugins-panel.tsx
@@ -50,12 +50,12 @@ const ESSENTIAL_PLUGINS: Record<string, EssentialPluginInfo> = {
   '@elizaos/plugin-sql': {
     title: 'Essential Plugin: SQL',
     description:
-      'This plugin provides memory and state storage for your agent. Removing it may cause the agent to lose conversation context and memory capabilities.',
+      'Provides memory and state storage. If removed, replace with an adapter plugin or your agent may lose conversation history and memory capabilities.',
   },
   '@elizaos/plugin-openai': {
     title: 'Essential Plugin: OpenAI',
     description:
-      'This plugin provides core language model access. Removing it without configuring a suitable alternative may cause the agent to malfunction or fail to start.',
+      'Provides language model access. If removed, replace with another LLM plugin or your agent may fail to function properly.',
   },
 };
 


### PR DESCRIPTION

# Relates to

https://linear.app/eliza-labs/issue/ELI2-242/default-sql-and-openai-plugins-for-new-characters-and-warn-on-removal

# Risks

Low - This PR only affects the UI for new agent creation and plugin management. The changes are isolated to frontend components and don't impact core functionality or existing agents.

# Background

## What does this PR do?

1. Adds essential plugins (@elizaos/plugin-sql and @elizaos/plugin-openai) by default when creating new agents
2. Implements warning confirmations when users attempt to remove essential plugins
3. Provides visual indicators to distinguish essential plugins in the UI
4. Preserves user choice after confirmation (plugins stay removed if confirmed)

## What kind of change is this?

Features (non-breaking change which adds functionality)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

1. Create a new agent via the UI
2. Navigate to the Plugins tab in the agent settings

## Detailed testing steps

1. Creating a new agent with default plugins:
   - Go to the agent creation screen
   - Navigate to the Plugins tab
   - Verify that @elizaos/plugin-sql and @elizaos/plugin-openai are listed under "Currently Enabled" by default
   - Verify they have a blue background and blue dot indicator showing they are essential plugins

2. Testing warning dialogs:
   - Click the "×" button next to @elizaos/plugin-sql
   - Verify a warning dialog appears with:
     - Title: "Essential Plugin: SQL"
     - Description explaining it provides memory and state storage
     - "Cancel" and "Confirm Removal" buttons
   - Click "Cancel" and verify the plugin remains in the list
   - Click the "×" button again, then click "Confirm Removal" and verify the plugin is removed

3. Testing the same with OpenAI plugin:
   - Click the "×" button next to @elizaos/plugin-openai
   - Verify a warning dialog appears with OpenAI-specific information
   - Test both cancellation and confirmation flows

4. Testing non-essential plugins:
   - Add a non-essential plugin from the "Search and add plugins..." dialog
   - Click the "×" button next to this plugin
   - Verify it's removed immediately without a confirmation dialog

5. Testing plugin persistence:
   - Remove an essential plugin after confirmation
   - Switch to a different tab and back to Plugins
   - Verify the removed plugin remains removed (doesn't reappear)
   - Save changes and verify the changes persist after reload

## Screenshots

### After
![image](https://github.com/user-attachments/assets/d52d4385-5738-4ae1-95b9-2c9e8336f88b)
![image](https://github.com/user-attachments/assets/d5878cc0-2024-4bb3-9fdc-4d26663c29c8)
![image](https://github.com/user-attachments/assets/78cb35f5-9801-40e8-98d1-9961b6b6086c)

