### PR TITLE
fix: check if init exist before calling

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -201,7 +201,7 @@ export class AgentRuntime implements IAgentRuntime {
     }
 
     // Initialize the plugin if it has an init function
-    if (plugin.init) {
+    if (plugin && 'init' in plugin && plugin.init !== null && typeof plugin.init === 'function') {
       try {
         await plugin.init(plugin.config || {}, this);
         this.runtimeLogger.debug(`Success: Plugin ${plugin.name} initialized successfully`);


### PR DESCRIPTION
Make sure `init` exist on plugin before we call it. 

error: 

```
[2025-04-13 14:10:02] WARN: Failed to load or prepare plugin specified by name: @elizaos/plugin-bootstrap
[2025-04-13 14:10:02] ERROR: An error occurred:
message: "(TypeError) Cannot read properties of undefined (reading 'init')"
stack: [
"TypeError: Cannot read properties of undefined (reading 'init')",
"at AgentRuntime.initialize (file:///Users/root1/.npm/_npx/594f2c2739bbbf45/node_modules/@elizaos/cli/dist/chunk-GFPVHNVN.js:46086:24)",
"at startAgent (file:///Users/root1/.npm/_npx/594f2c2739bbbf45/node_modules/@elizaos/cli/dist/chunk-U6NYC23Y.js:83211:17)",
"at process.processTicksAndRejections (node/process/task_queues:105:5)",
"at async startAgents (file:///Users/root1/.npm/_npx/594f2c2739bbbf45/node_modules/@elizaos/cli/dist/chunk-U6NYC23Y.js:83415:7)",
"at async *Command.<anonymous> (file:///Users/root1/.npm/*npx/594f2c2739bbbf45/node_modules/@elizaos/cli/dist/chunk-U6NYC23Y.js:83456:5)",
"at async *Command.parseAsync (file:///Users/root1/.npm/*npx/594f2c2739bbbf45/node_modules/@elizaos/cli/dist/chunk-5LH7NKB4.js:1721:9)",
"at async main (file:///Users/root1/.npm/_npx/594f2c2739bbbf45/node_modules/@elizaos/cli/dist/index.js:117:3)"
]
[2025-04-13 14:10:02] ERROR: Error details: Cannot read properties of undefined (reading 'init')
[2025-04-13 14:10:02] ERROR: Stack trace: TypeError: Cannot read properties of undefined (reading 'init')
at AgentRuntime.initialize (file:///Users/root1/.npm/_npx/594f2c2739bbbf45/node_modules/@elizaos/cli/dist/chunk-GFPVHNVN.js:46086:24)
at startAgent (file:///Users/root1/.npm/_npx/594f2c2739bbbf45/node_modules/@elizaos/cli/dist/chunk-U6NYC23Y.js:83211:17)
at process.processTicksAndRejections (node/process/task_queues:105:5)
at async startAgents (file:///Users/root1/.npm/_npx/594f2c2739bbbf45/node_modules/@elizaos/cli/dist/chunk-U6NYC23Y.js:83415:7)
at async *Command.<anonymous> (file:///Users/root1/.npm/*npx/594f2c2739bbbf45/node_modules/@elizaos/cli/dist/chunk-U6NYC23Y.js:83456:5)
at async *Command.parseAsync (file:///Users/root1/.npm/*npx/594f2c2739bbbf45/node_modules/@elizaos/cli/dist/chunk-5LH7NKB4.js:1721:9)
at async main (file:///Users/root1/.npm/_npx/594f2c2739bbbf45/node_modules/@elizaos/cli/dist/index.js:117:3)
```
