### PR TITLE
feat: add typing indicator to telegram

### DIFF
--- a/packages/plugin-telegram/src/messageManager.ts
+++ b/packages/plugin-telegram/src/messageManager.ts
@@ -149,6 +149,8 @@ export class MessageManager {
 
       const telegramButtons = convertToTelegramButtons(content.buttons ?? []);
 
+      await ctx.telegram.sendChatAction(ctx.chat.id, 'typing');
+
       for (let i = 0; i < chunks.length; i++) {
         const chunk = escapeMarkdown(chunks[i]);
         const sentMessage = (await ctx.telegram.sendMessage(ctx.chat.id, chunk, {


### PR DESCRIPTION
# Risks

low – this change adds a typing indicator (sendChatAction) to simulate a more humanlike interaction pattern.

# Background

## What does this PR do?

adds a typing indicator to telegram bots to improve user experience and give feedback that the bot is “typing” while processing the response. this is done via telegram’s sendChatAction endpoint with the typing action. the goal is to make the interaction feel less abrupt and more natural, especially when responses have slight delays due to processing or API latency.

## What kind of change is this?

Features (non-breaking change which adds functionality)

# Documentation changes needed?

None

# Testing

## Where should a reviewer start?

run an agent and message it on telegram. you should expect to see "typing..." underneath the bots username before it sends its response.

## Screenshots

### Before

Currently, when the agent is processing a user message, this just shows a static status until the message comes through.

![image](https://github.com/user-attachments/assets/bdece5cb-74bd-444b-a302-7ea85f4cc2d5)

### After

This change makes it so the bot sends 'typing...' while it is responding to create a better UX. This is especially good for long delays / latency, so the user doesn't have to wonder whether the agent received the message or not.

![image](https://github.com/user-attachments/assets/e3f37e6b-be31-4c4d-9b8d-4baf1c649865)

## Discord username

nickb0181