### PR TITLE
fix: expose telegram types

### DIFF
--- a/packages/plugin-telegram/src/index.ts
+++ b/packages/plugin-telegram/src/index.ts
@@ -2,6 +2,7 @@ import type { Plugin } from '@elizaos/core';
 import { TELEGRAM_SERVICE_NAME } from './constants';
 import { TelegramService } from './service';
 import { TelegramTestSuite } from './tests';
+import { MessageManager } from './messageManager';
 
 const telegramPlugin: Plugin = {
   name: TELEGRAM_SERVICE_NAME,
@@ -9,4 +10,6 @@ const telegramPlugin: Plugin = {
   services: [TelegramService],
   tests: [new TelegramTestSuite()],
 };
+
+export { TelegramService, MessageManager };
 export default telegramPlugin;


### PR DESCRIPTION
# Risks

low – this change only affects the type exports from the package. it makes more internal types publicly available for consumers but does not alter runtime behavior.

# Background

## What does this PR do?

Exposed `messageManager` and `telegramService` from telegram package so users can import and use as needed in their agents, especially as types. 

One use case for this would be exposing a function you can call at the top level of the agent that allows you to send a message through telegram on command. This way you can send notifications through the agent.

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

There should be no changes that require testing. Automated tests are acceptable.

## Discord username

nickb0181