### PR TITLE
fix: ensure plugins

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -647,6 +647,8 @@ const startAgents = async (options: {
   // if characters are provided, start the agents with the characters
   if (options.characters) {
     for (const character of options.characters) {
+      // Initialize plugins as an empty array if undefined
+      character.plugins = character.plugins || [];
       // make sure character has sql plugin
       const hasSqlPlugin = character.plugins.some((plugin) => plugin.includes('plugin-sql'));
       if (!hasSqlPlugin) {


### PR DESCRIPTION
```
[2025-04-15 20:57:12] ERROR: An error occurred:
    message: "(TypeError) Cannot read properties of undefined (reading 'some')"
    stack: [
      "TypeError: Cannot read properties of undefined (reading 'some')",
      "at startAgents (file:///root/twitter/packages/cli/dist/chunk-V43JKZMH.js:83348:47)",
      "at async _Command.<anonymous> (file:///root/twitter/packages/cli/dist/chunk-V43JKZMH.js:83482:5)",
      "at async _Command.parseAsync (file:///root/twitter/packages/cli/dist/chunk-5LH7NKB4.js:1721:9)",
      "at async main (file:///root/twitter/packages/cli/dist/index.js:117:3)"
```