### PR TITLE
chore: Export bootstrap plugin capabilities

### DIFF
--- a/packages/plugin-bootstrap/src/actions/index.ts
+++ b/packages/plugin-bootstrap/src/actions/index.ts
@@ -1,0 +1,12 @@
+export { choiceAction } from './choice';
+export { followRoomAction } from './followRoom';
+export { ignoreAction } from './ignore';
+export { muteRoomAction } from './muteRoom';
+export { noneAction } from './none';
+export { replyAction } from './reply';
+export { updateRoleAction } from './roles';
+export { sendMessageAction } from './sendMessage';
+export { updateSettingsAction } from './settings';
+export { unfollowRoomAction } from './unfollowRoom';
+export { unmuteRoomAction } from './unmuteRoom';
+export { updateEntityAction } from './updateEntity';

--- a/packages/plugin-bootstrap/src/actions/roles.ts
+++ b/packages/plugin-bootstrap/src/actions/roles.ts
@@ -104,7 +104,7 @@ interface RoleAssignment {
  * @property {Function} handler - A function to handle the execution of the action.
  * @property {ActionExample[][]} examples - Examples demonstrating how the action can be used.
  */
-const updateRoleAction: Action = {
+export const updateRoleAction: Action = {
   name: 'UPDATE_ROLE',
   similes: ['CHANGE_ROLE', 'SET_PERMISSIONS', 'ASSIGN_ROLE', 'MAKE_ADMIN'],
   description: 'Assigns a role (Admin, Owner, None) to a user or list of users in a channel.',
@@ -322,5 +322,3 @@ const updateRoleAction: Action = {
     ],
   ] as ActionExample[][],
 };
-
-export default updateRoleAction;

--- a/packages/plugin-bootstrap/src/actions/settings.ts
+++ b/packages/plugin-bootstrap/src/actions/settings.ts
@@ -694,7 +694,7 @@ async function generateErrorResponse(
  * Enhanced settings action with improved state management and logging
  * Updated to use world metadata instead of cache
  */
-const updateSettingsAction: Action = {
+export const updateSettingsAction: Action = {
   name: 'UPDATE_SETTINGS',
   similes: ['UPDATE_SETTING', 'SAVE_SETTING', 'SET_CONFIGURATION', 'CONFIGURE'],
   description:
@@ -976,5 +976,3 @@ const updateSettingsAction: Action = {
     ],
   ] as ActionExample[][],
 };
-
-export default updateSettingsAction;

--- a/packages/plugin-bootstrap/src/evaluators/index.ts
+++ b/packages/plugin-bootstrap/src/evaluators/index.ts
@@ -1,0 +1,1 @@
+export { reflectionEvaluator } from './reflection';

--- a/packages/plugin-bootstrap/src/index.ts
+++ b/packages/plugin-bootstrap/src/index.ts
@@ -29,38 +29,17 @@ import {
   type WorldPayload,
 } from '@elizaos/core';
 import { v4 } from 'uuid';
-import { choiceAction } from './actions/choice';
-import { followRoomAction } from './actions/followRoom';
-import { ignoreAction } from './actions/ignore';
-import { muteRoomAction } from './actions/muteRoom';
-import { noneAction } from './actions/none';
-import { replyAction } from './actions/reply';
-import updateRoleAction from './actions/roles';
-import { sendMessageAction } from './actions/sendMessage';
-import updateSettingsAction from './actions/settings';
-import { unfollowRoomAction } from './actions/unfollowRoom';
-import { unmuteRoomAction } from './actions/unmuteRoom';
-import { updateEntityAction } from './actions/updateEntity';
-import { reflectionEvaluator } from './evaluators/reflection';
-import { actionsProvider } from './providers/actions';
-import { anxietyProvider } from './providers/anxiety';
-import { attachmentsProvider } from './providers/attachments';
-import { capabilitiesProvider } from './providers/capabilities';
-import { characterProvider } from './providers/character';
-import { choiceProvider } from './providers/choice';
-import { entitiesProvider } from './providers/entities';
-import { evaluatorsProvider } from './providers/evaluators';
-import { factsProvider } from './providers/facts';
-import { knowledgeProvider } from './providers/knowledge';
-import { providersProvider } from './providers/providers';
-import { recentMessagesProvider } from './providers/recentMessages';
-import { relationshipsProvider } from './providers/relationships';
-import { roleProvider } from './providers/roles';
-import { settingsProvider } from './providers/settings';
-import { timeProvider } from './providers/time';
+
+import * as actions from './actions';
+import * as evaluators from './evaluators';
+import * as providers from './providers';
+
 import { ScenarioService } from './services/scenario';
 import { TaskService } from './services/task';
-import { worldProvider } from './providers/world';
+
+export * from './actions';
+export * from './evaluators';
+export * from './providers';
 
 /**
  * Represents media data containing a buffer of data and the media type.
@@ -859,39 +838,39 @@ export const bootstrapPlugin: Plugin = {
   name: 'bootstrap',
   description: 'Agent bootstrap with basic actions and evaluators',
   actions: [
-    replyAction,
-    followRoomAction,
-    unfollowRoomAction,
-    ignoreAction,
-    noneAction,
-    muteRoomAction,
-    unmuteRoomAction,
-    sendMessageAction,
-    updateEntityAction,
-    choiceAction,
-    updateRoleAction,
-    updateSettingsAction,
+    actions.replyAction,
+    actions.followRoomAction,
+    actions.unfollowRoomAction,
+    actions.ignoreAction,
+    actions.noneAction,
+    actions.muteRoomAction,
+    actions.unmuteRoomAction,
+    actions.sendMessageAction,
+    actions.updateEntityAction,
+    actions.choiceAction,
+    actions.updateRoleAction,
+    actions.updateSettingsAction,
   ],
   events,
-  evaluators: [reflectionEvaluator],
+  evaluators: [evaluators.reflectionEvaluator],
   providers: [
-    evaluatorsProvider,
-    anxietyProvider,
-    knowledgeProvider,
-    timeProvider,
-    entitiesProvider,
-    relationshipsProvider,
-    choiceProvider,
-    factsProvider,
-    roleProvider,
-    settingsProvider,
-    capabilitiesProvider,
-    attachmentsProvider,
-    providersProvider,
-    actionsProvider,
-    characterProvider,
-    recentMessagesProvider,
-    worldProvider,
+    providers.evaluatorsProvider,
+    providers.anxietyProvider,
+    providers.knowledgeProvider,
+    providers.timeProvider,
+    providers.entitiesProvider,
+    providers.relationshipsProvider,
+    providers.choiceProvider,
+    providers.factsProvider,
+    providers.roleProvider,
+    providers.settingsProvider,
+    providers.capabilitiesProvider,
+    providers.attachmentsProvider,
+    providers.providersProvider,
+    providers.actionsProvider,
+    providers.characterProvider,
+    providers.recentMessagesProvider,
+    providers.worldProvider,
   ],
   services: [TaskService, ScenarioService],
 };

--- a/packages/plugin-bootstrap/src/providers/index.ts
+++ b/packages/plugin-bootstrap/src/providers/index.ts
@@ -1,0 +1,17 @@
+export { actionsProvider } from './actions';
+export { anxietyProvider } from './anxiety';
+export { attachmentsProvider } from './attachments';
+export { capabilitiesProvider } from './capabilities';
+export { characterProvider } from './character';
+export { choiceProvider } from './choice';
+export { entitiesProvider } from './entities';
+export { evaluatorsProvider } from './evaluators';
+export { factsProvider } from './facts';
+export { knowledgeProvider } from './knowledge';
+export { providersProvider } from './providers';
+export { recentMessagesProvider } from './recentMessages';
+export { relationshipsProvider } from './relationships';
+export { roleProvider } from './roles';
+export { settingsProvider } from './settings';
+export { timeProvider } from './time';
+export { worldProvider } from './world';


### PR DESCRIPTION
Exporting all providers, actions, and evaluators from the bootstrap plugin for a more controlled consumer experience.

# Risks

No breaking changes for regular package consumers. For consistency, `updateRoleAction ` and `updateSettingsAction ` have been changed to named exports as the other actions.

# Background

## What kind of change is this?

Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

## Discord username

@michavie
