### PR TITLE
feat: Add deleteTweet()

### DIFF
--- a/packages/plugin-twitter/src/client/client.ts
+++ b/packages/plugin-twitter/src/client/client.ts
@@ -68,6 +68,7 @@ import {
   createCreateTweetRequestV2,
   createQuoteTweetRequest,
   defaultOptions,
+  deleteTweet,
   fetchListTweets,
   getAllRetweeters,
   getArticle,
@@ -795,6 +796,16 @@ export class Client {
     }
   ) {
     return await createQuoteTweetRequest(text, quotedTweetId, this.auth, options?.mediaData);
+  }
+
+  /**
+   * Delete a tweet with the given ID.
+   * @param tweetId The ID of the tweet to delete.
+   * @returns A promise that resolves when the tweet is deleted.
+   */
+  public async deleteTweet(tweetId: string): Promise<Response> {
+    // Call the deleteTweet function from tweets.ts 
+    return await deleteTweet(tweetId, this.auth);
   }
 
   /**

--- a/packages/plugin-twitter/src/client/tweets.test.ts
+++ b/packages/plugin-twitter/src/client/tweets.test.ts
@@ -374,6 +374,26 @@ test('client can get a tweet with getTweetV2', async () => {
   expect(tweet?.text).toBeDefined();
 });
 
+test('scraper can delete tweet', async () => {
+  const client = await getClient();
+
+  const draftText = 'This Tweet will be deleted' + Date.now().toString();
+
+  const response = await client.sendTweet(draftText);
+  const result = await response.json();
+
+  expect(result).toBeDefined();
+
+  const tweetId = result?.data?.create_tweet?.tweet_results?.result?.rest_id;
+  expect(tweetId).toBeDefined();
+
+  await client.deleteTweet(tweetId as string);
+
+  // Verify the tweet is actually deleted
+  const deletedTweet = await client.getTweet(tweetId as string);
+  expect(deletedTweet).toBeNull();
+});
+
 test('client can get multiple tweets with getTweetsV2', async () => {
   if (shouldSkipV2Tests) {
     return console.warn("Skipping 'getTweetV2' test due to missing API keys.");


### PR DESCRIPTION
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

- Request to add same changes as in https://github.com/elizaOS/agent-twitter-client from @tcm390 

# Risks

- Low: No error if you try to accidentally delete a tweet which is not yours, simply nothing happens

# Background

## What does this PR do?

- Add deleteTweet() function to tweets.ts
- Add deleteTweet() wrapping method for Client class
- Add test for deleteTweet() to tweet.tests.ts

## What kind of change is this?

Feature

## Discord username
@paoloanzn 
btw i'm in the development server but I can't join the other server as if I'm banned :( 