### PR TITLE
fix: gpu recognition on docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ RUN apt-get update && \
 
 RUN npm install -g bun@1.2.5 turbo@2.3.3
 
+RUN apt-get update && apt-get install -y pciutils
+
 COPY --from=builder /app/package.json ./
 COPY --from=builder /app/turbo.json ./
 COPY --from=builder /app/tsconfig.json ./

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     ports:
       - '127.0.0.1:5432:5432'
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      test: [ 'CMD-SHELL', 'pg_isready -U postgres' ]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -56,6 +56,13 @@ services:
     restart: always
     networks:
       - eliza-network
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [ gpu ]
 
 networks:
   eliza-network:


### PR DESCRIPTION
### PR Description: Add pciutils to Dockerfile for GPU detection
**Changes**
Added pciutils package installation to the Dockerfile
Fixes GPU detection issue when running the container
**Problem**
The container was failing to detect GPU capabilities because the lspci command was missing. This resulted in the error:
`[ERROR: Linux GPU detection failed
  cmd: "lspci | grep -i vga",
  stderr: "/bin/sh: 1: lspci: not found\n"`
**Solution**
Added pciutils package to the Dockerfile which provides the lspci command needed for GPU detection. This enables proper hardware capability detection when the container starts.
