### PR TITLE
fix: openai stt

### DIFF
--- a/packages/plugin-openai/tsup.config.ts
+++ b/packages/plugin-openai/tsup.config.ts
@@ -16,7 +16,6 @@ export default defineConfig({
     'http',
     '@elizaos/core',
     'zod',
-    'node-fetch',
     'form-data',
   ],
 });


### PR DESCRIPTION
Externalizing node-fetch was causing failures during transcription requests. This change disables it temporarily to restore functionality.

@0xbbjoker @odilitime — could you please check if this affects anything on the npm side?