### PR TITLE
fix: hapi types issue

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -211,7 +211,6 @@
         "@opentelemetry/instrumentation-pg": "^0.52.0",
         "@opentelemetry/sdk-metrics": "^1.26.0",
         "@opentelemetry/sdk-node": "^0.53.0",
-        "@types/hapi__shot": "^6.0.0",
         "buffer": "^6.0.3",
         "crypto-browserify": "^3.12.1",
         "dotenv": "16.4.5",
@@ -493,6 +492,7 @@
         "ai": "^4.1.25",
         "js-tiktoken": "^1.0.18",
         "tsup": "8.4.0",
+        "undici": "^7.8.0",
       },
       "devDependencies": {
         "prettier": "3.5.3",
@@ -2723,8 +2723,6 @@
     "@types/gtag.js": ["@types/gtag.js@0.0.12", "", {}, "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg=="],
 
     "@types/hapi": ["@types/hapi@18.0.14", "", { "dependencies": { "@types/boom": "*", "@types/catbox": "*", "@types/iron": "*", "@types/mimos": "*", "@types/node": "*", "@types/podium": "*", "@types/shot": "*", "joi": "^17.3.0" } }, "sha512-/AlCHpOTzHOX7WYGlQAhL75Ca5gsm0S6X7mkW6RWW06e4Eot6xPm76qGXPHagVrpfs8qTKJdysJah/Uhtr8ojw=="],
-
-    "@types/hapi__shot": ["@types/hapi__shot@6.0.0", "", { "dependencies": { "@hapi/shot": "*" } }, "sha512-CUxk0AEQRpIT2cx7EYXkqaXm60LP46ZyEhr/7uov7D/ZLysA5DKkfBtPIYnoWvn8qfcFV/7YHLd3U9gThuhb0A=="],
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,7 +63,6 @@
     "@opentelemetry/instrumentation-pg": "^0.52.0",
     "@opentelemetry/sdk-metrics": "^1.26.0",
     "@opentelemetry/sdk-node": "^0.53.0",
-    "@types/hapi__shot": "^6.0.0",
     "buffer": "^6.0.3",
     "crypto-browserify": "^3.12.1",
     "dotenv": "16.4.5",


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed an unused dependency to streamline the application.
  
I've already merged this recently: https://github.com/elizaOS/eliza/pull/4275/files#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7

So please be careful we don't wanna see `hapi__shot` types. 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->