### PR TITLE
fix: agent not found error after GUI creation and resolve merge conflict

### DIFF
--- a/packages/plugin-sql/src/base.ts
+++ b/packages/plugin-sql/src/base.ts
@@ -13,6 +13,7 @@ import {
   type World,
   type Log,
   logger,
+  stringToUuid,
 } from '@elizaos/core';
 import {
   Column,
@@ -160,7 +161,8 @@ export abstract class BaseDrizzleAdapter<
       return existingAgent;
     }
 
-    agent.id = agent.id || (v4() as UUID);
+    agent.id = stringToUuid(agent.name ?? (v4() as UUID));
+
     await this.createAgent(agent);
 
     return agent as Agent;


### PR DESCRIPTION
This PR fixes an issue where starting an agent created via the GUI using the same agent name would result in an error: Agent does not exist in database after ensureAgentExists call.

The issue occurred because multiple agents with the same name but different IDs existed in the database. The ensureAgentExists call would return an agent (based on name), but subsequent logic that expected a specific agentId would fail to find it, causing the error.

This PR ensures the correct agentId is used, resolving the mismatch.

Additionally, this PR resolves merge conflicts between the following PRs:

https://github.com/elizaOS/eliza/pull/4223

https://github.com/elizaOS/eliza/pull/4261