### PR TITLE
Fix Grammar 

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -25,7 +25,7 @@ export default tseslint.config({
 });
 ```
 
-- Replace `tseslint.configs.recommended` to `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
+- Replace `tseslint.configs.recommended` with `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
 - Optionally add `...tseslint.configs.stylisticTypeChecked`
 - Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and update the config:
 


### PR DESCRIPTION
Proper grammar ensures clarity and professionalism in documentation. Using the correct preposition (“with” instead of “to”) avoids confusion and aligns the language with technical writing standards expected in open-source communities