### PR TITLE
added bc .gitignore wasnt getting copied from plugin-starter

### DIFF
--- a/packages/cli/src/utils/copy-template.ts
+++ b/packages/cli/src/utils/copy-template.ts
@@ -84,6 +84,13 @@ export async function copyTemplate(
   // Copy template files
   await copyDir(templateDir, targetDir);
 
+  // Explicitly check and copy .gitignore file (hidden files can be missed)
+  const srcGitignore = path.join(templateDir, '.gitignore');
+  const destGitignore = path.join(targetDir, '.gitignore');
+  if (existsSync(srcGitignore) && !existsSync(destGitignore)) {
+    await fs.copyFile(srcGitignore, destGitignore);
+  }
+
   // Update package.json with new name and dependency versions
   const packageJsonPath = path.join(targetDir, 'package.json');
 


### PR DESCRIPTION
added this small change because .gitignore wasnt getting copied over on plugin-starter copying via the cli.