### PR TITLE
fix: tts api

### DIFF
--- a/packages/cli/src/utils/audioBuffer.ts
+++ b/packages/cli/src/utils/audioBuffer.ts
@@ -1,0 +1,42 @@
+import { Readable } from 'node:stream';
+
+export async function convertToAudioBuffer(speechResponse: any): Promise<Buffer> {
+  if (Buffer.isBuffer(speechResponse)) {
+    return speechResponse;
+  }
+
+  if (typeof speechResponse?.getReader === 'function') {
+    // Handle Web ReadableStream
+    const reader = (speechResponse as ReadableStream<Uint8Array>).getReader();
+    const chunks: Uint8Array[] = [];
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) chunks.push(value);
+      }
+      return Buffer.concat(chunks);
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  if (
+    speechResponse instanceof Readable ||
+    (speechResponse &&
+      speechResponse.readable === true &&
+      typeof speechResponse.pipe === 'function' &&
+      typeof speechResponse.on === 'function')
+  ) {
+    // Handle Node Readable Stream
+    return new Promise<Buffer>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+      speechResponse.on('data', (chunk) => chunks.push(Buffer.from(chunk)));
+      speechResponse.on('end', () => resolve(Buffer.concat(chunks)));
+      speechResponse.on('error', (err) => reject(err));
+    });
+  }
+
+  throw new Error('Unexpected response type from TEXT_TO_SPEECH model');
+}


### PR DESCRIPTION
This PR addresses an issue where plugin-openai TTS wasn't working because it returns a Web ReadableStream. The fix properly handles all types of stream responses for TTS APIs