### PR TITLE
fix: small GUI fix

### DIFF
--- a/packages/client/src/components/character-form.tsx
+++ b/packages/client/src/components/character-form.tsx
@@ -241,63 +241,8 @@ export default function CharacterForm({
     }
   };
 
-  const handleVoiceModelChange = (value: string, name: string) => {
-    if (name.startsWith('settings.')) {
-      const path = name.substring(9); // Remove 'settings.' prefix
-
-      if (setCharacterValue.updateSetting) {
-        // Use the specialized method if available
-        setCharacterValue.updateSetting(path, value);
-
-        // Handle voice model change and required plugins
-        if (path === 'voice.model' && value) {
-          const voiceModel = getVoiceModelByValue(value);
-          if (voiceModel) {
-            const currentPlugins = Array.isArray(characterValue.plugins)
-              ? [...characterValue.plugins]
-              : [];
-            const previousVoiceModel = getVoiceModelByValue(characterValue.settings?.voice?.model);
-
-            // Get all voice-related plugins
-            const voicePlugins = getAllRequiredPlugins();
-
-            // Get the required plugin for the new voice model
-            const requiredPlugin = providerPluginMap[voiceModel.provider];
-
-            // Filter out all voice-related plugins
-            const filteredPlugins = currentPlugins.filter(
-              (plugin) => !voicePlugins.includes(plugin)
-            );
-
-            // Add the required plugin for the selected voice model
-            const newPlugins = [...filteredPlugins];
-            if (requiredPlugin && !filteredPlugins.includes(requiredPlugin)) {
-              newPlugins.push(requiredPlugin);
-            }
-
-            // Update the plugins
-            if (setCharacterValue.setPlugins) {
-              setCharacterValue.setPlugins(newPlugins);
-            } else if (setCharacterValue.updateField) {
-              setCharacterValue.updateField('plugins', newPlugins);
-            }
-
-            // Show toast notification
-            if (previousVoiceModel?.provider !== voiceModel.provider) {
-              toast({
-                title: 'Plugin Updated',
-                description: `${requiredPlugin} plugin has been set for the selected voice model.`,
-              });
-            }
-          }
-        }
-      } else {
-        // Fall back to generic updateField
-        setCharacterValue.updateField(name, value);
-      }
-    } else {
-      setCharacterValue.updateField(name, value);
-    }
+  const handleSelectFieldChange = (value: string, name: string) => {
+    setCharacterValue.updateField(name, value);
   };
 
   const updateArray = (path: string, newData: string[]) => {
@@ -411,7 +356,7 @@ export default function CharacterForm({
         <Select
           name={field.name}
           value={field.getValue(characterValue)}
-          onValueChange={(value) => handleVoiceModelChange(value, field.name)}
+          onValueChange={(value) => handleSelectFieldChange(value, field.name)}
         >
           <SelectTrigger>
             <SelectValue

--- a/packages/client/src/components/character-form.tsx
+++ b/packages/client/src/components/character-form.tsx
@@ -22,7 +22,7 @@ import {
   getAllVoiceModels,
   getVoiceModelByValue,
   providerPluginMap,
-  getAllRequiredPlugins,
+  // getAllRequiredPlugins,
 } from '../config/voice-models';
 import { useElevenLabsVoices } from '@/hooks/use-elevenlabs-voices';
 import { Trash, Loader2 } from 'lucide-react';

--- a/packages/client/src/components/character-form.tsx
+++ b/packages/client/src/components/character-form.tsx
@@ -18,12 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import {
-  getAllVoiceModels,
-  getVoiceModelByValue,
-  providerPluginMap,
-  // getAllRequiredPlugins,
-} from '../config/voice-models';
+import { getAllVoiceModels, getVoiceModelByValue, providerPluginMap } from '../config/voice-models';
 import { useElevenLabsVoices } from '@/hooks/use-elevenlabs-voices';
 import { Trash, Loader2 } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';

--- a/packages/client/src/components/character-form.tsx
+++ b/packages/client/src/components/character-form.tsx
@@ -241,8 +241,55 @@ export default function CharacterForm({
     }
   };
 
-  const handleSelectFieldChange = (value: string, name: string) => {
-    setCharacterValue.updateField(name, value);
+  const handleVoiceModelChange = (value: string, name: string) => {
+    if (name.startsWith('settings.')) {
+      const path = name.substring(9); // Remove 'settings.' prefix
+
+      if (setCharacterValue.updateSetting) {
+        // Use the specialized method if available
+        setCharacterValue.updateSetting(path, value);
+
+        // Handle voice model change and required plugins
+        if (path === 'voice.model' && value) {
+          const voiceModel = getVoiceModelByValue(value);
+          if (voiceModel) {
+            const currentPlugins = Array.isArray(characterValue.plugins)
+              ? [...characterValue.plugins]
+              : [];
+            const previousVoiceModel = getVoiceModelByValue(characterValue.settings?.voice?.model);
+
+            // Get the required plugin for the new voice model
+            const requiredPlugin = providerPluginMap[voiceModel.provider];
+
+            // Add the required plugin for the selected voice model
+            const newPlugins = [...currentPlugins];
+            if (requiredPlugin && !currentPlugins.includes(requiredPlugin)) {
+              newPlugins.push(requiredPlugin);
+            }
+
+            // Update the plugins
+            if (setCharacterValue.setPlugins) {
+              setCharacterValue.setPlugins(newPlugins);
+            } else if (setCharacterValue.updateField) {
+              setCharacterValue.updateField('plugins', newPlugins);
+            }
+
+            // Show toast notification
+            if (previousVoiceModel?.provider !== voiceModel.provider) {
+              toast({
+                title: 'Plugin Updated',
+                description: `${requiredPlugin} plugin has been set for the selected voice model.`,
+              });
+            }
+          }
+        }
+      } else {
+        // Fall back to generic updateField
+        setCharacterValue.updateField(name, value);
+      }
+    } else {
+      setCharacterValue.updateField(name, value);
+    }
   };
 
   const updateArray = (path: string, newData: string[]) => {
@@ -356,7 +403,7 @@ export default function CharacterForm({
         <Select
           name={field.name}
           value={field.getValue(characterValue)}
-          onValueChange={(value) => handleSelectFieldChange(value, field.name)}
+          onValueChange={(value) => handleVoiceModelChange(value, field.name)}
         >
           <SelectTrigger>
             <SelectValue

--- a/packages/client/src/components/plugins-panel.tsx
+++ b/packages/client/src/components/plugins-panel.tsx
@@ -215,8 +215,8 @@ export default function PluginsPanel({
               </AlertDialog>
 
               {voiceModelPluginInfo && (
-                <div className="rounded-md bg-blue-50 p-4 mb-4">
-                  <p className="text-xs text-blue-700">
+                <div className="rounded-md border p-4 mb-4">
+                  <p className="text-xs text-white">
                     {(() => {
                       switch (voiceModelPluginInfo.provider) {
                         case 'elevenlabs':
@@ -264,11 +264,9 @@ export default function PluginsPanel({
                             size="sm"
                             key={plugin}
                             className={`inline-flex items-center rounded-full ${
-                              isRequiredByVoice
-                                ? 'bg-green-100 text-green-700 hover:bg-green-200'
-                                : isEssential
-                                  ? 'bg-blue-800 text-blue-700 hover:bg-blue-600'
-                                  : 'bg-primary/10 text-primary hover:bg-primary/20'
+                              isEssential
+                                ? 'bg-blue-800 text-blue-700 hover:bg-blue-600'
+                                : 'bg-primary/10 text-primary hover:bg-primary/20'
                             } px-2.5 py-0.5 text-xs font-medium h-auto`}
                             onClick={() => {
                               // Don't allow removing if it's required by the voice model

--- a/packages/client/src/components/plugins-panel.tsx
+++ b/packages/client/src/components/plugins-panel.tsx
@@ -22,7 +22,7 @@ import type { Agent } from '@elizaos/core';
 import clsx from 'clsx';
 import { useMemo, useState } from 'react';
 import {
-  getAllRequiredPlugins,
+  // getAllRequiredPlugins,
   getVoiceModelByValue,
   providerPluginMap,
 } from '../config/voice-models';
@@ -110,10 +110,10 @@ export default function PluginsPanel({
   }, [characterValue?.settings?.voice?.model, safeCharacterPlugins]);
 
   // Get all voice-related plugins that are currently enabled
-  const enabledVoicePlugins = useMemo(() => {
-    const voicePlugins = getAllRequiredPlugins();
-    return safeCharacterPlugins.filter((plugin) => voicePlugins.includes(plugin));
-  }, [safeCharacterPlugins]);
+  // const enabledVoicePlugins = useMemo(() => {
+  //   const voicePlugins = getAllRequiredPlugins();
+  //   return safeCharacterPlugins.filter((plugin) => voicePlugins.includes(plugin));
+  // }, [safeCharacterPlugins]);
 
   const hasChanged = useMemo(() => {
     if (!initialPlugins) return false;
@@ -232,12 +232,15 @@ export default function PluginsPanel({
                       }
                     })()}
                   </p>
-                  {enabledVoicePlugins.length > 1 && (
+                  {/* 
+                    Commented out for now — this warning doesn't make sense when using ElevenLabs voice model with OpenAI plugin.
+                  */}
+                  {/* {enabledVoicePlugins.length > 1 && (
                     <p className="text-xs text-amber-600 mt-2">
                       Multiple voice plugins detected. This may cause conflicts. Consider removing
                       unused voice plugins.
                     </p>
-                  )}
+                  )} */}
                 </div>
               )}
               {safeCharacterPlugins.length > 0 && (

--- a/packages/client/src/components/plugins-panel.tsx
+++ b/packages/client/src/components/plugins-panel.tsx
@@ -20,6 +20,7 @@ import { usePlugins } from '@/hooks/use-plugins';
 import { useToast } from '@/hooks/use-toast';
 import type { Agent } from '@elizaos/core';
 import clsx from 'clsx';
+import { CircleAlert } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import {
   // getAllRequiredPlugins,
@@ -215,7 +216,8 @@ export default function PluginsPanel({
               </AlertDialog>
 
               {voiceModelPluginInfo && (
-                <div className="rounded-md border p-4 mb-4">
+                <div className="rounded-md border p-4 mb-4 flex items-center gap-2">
+                  <CircleAlert className="h-4 w-4 text-yellow-500" />
                   <p className="text-xs text-white">
                     {(() => {
                       switch (voiceModelPluginInfo.provider) {


### PR DESCRIPTION
This PR fixes several issues:

**1. Removed poor contrast background color for the voice required plugin label**

![image](https://github.com/user-attachments/assets/3ebf4b7a-63de-4f84-aa37-f5c3a7c7c8f4)

**2. Removed the white/blue background color from the "Voice Required" header and replaced it with a neutral color based on feedback from @wtfsayo.**

<img width="822" alt="Screenshot 2025-04-24 at 7 59 44 PM" src="https://github.com/user-attachments/assets/a0eab4a3-f31e-424a-870a-dea2540f312d" />


**3. Disabled the logic that automatically removes plugins based on voice model selection. For example, when switching to the ElevenLabs voice model, it would remove the OpenAI plugin even if it was still needed.**



**4. The warning message doesn't make sense when using the ElevenLabs voice model — it tells me to remove the OpenAI plugin even though it’s unrelated. So I’ve commented it out for now.**

<img width="823" alt="Screenshot 2025-04-24 at 8 01 53 PM" src="https://github.com/user-attachments/assets/029df994-27b7-4214-8664-bd29869587b4" />



