### PR TITLE
fix: further agent entity relation fixes

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1491,7 +1491,7 @@ export class AgentRuntime implements IAgentRuntime {
       await this.adapter.createRoom({
         id,
         name,
-        agentId,
+        agentId: agentId || this.agentId,
         source,
         type,
         channelId,


### PR DESCRIPTION
# Relates to

This is a follow up to https://github.com/elizaOS/eliza/pull/4223

# Risks

Medium: Wrong Foreign key constraints need to be changed to reference `entities` instead of `agents`

# Background

## What does this PR do?

## What kind of change is this?

Bug fixes

There currently is still not a full separation between the concepts of `agents` (characters) and `entities` (instances of a character / an agent)


## Database changes

Consider:
- Removing `agentId` from `memories` – `entityId` already refers to an agent
- Removing `agentId` from `rooms` – `entityId` already refers to an agent
- Changing the FK of `agentId` to reference `entities`

## Discord username

@michavie