### PR TITLE
fix: agent unregistration process with service stop handling

### DIFF
--- a/packages/cli/src/server/index.ts
+++ b/packages/cli/src/server/index.ts
@@ -458,6 +458,22 @@ export class AgentServer {
     }
 
     try {
+      // Retrieve the agent before deleting it from the map
+      const agent = this.agents.get(agentId);
+      
+      if (agent) {
+        // Stop all services of the agent before unregistering it
+        try {
+          agent.stop().catch(stopError => {
+            logger.error(`[AGENT UNREGISTER] Error stopping agent services for ${agentId}:`, stopError);
+          });
+          logger.debug(`[AGENT UNREGISTER] Stopping services for agent ${agentId}`);
+        } catch (stopError) {
+          logger.error(`[AGENT UNREGISTER] Error initiating stop for agent ${agentId}:`, stopError);
+        }
+      }
+      
+      // Delete the agent from the map
       this.agents.delete(agentId);
       logger.debug(`Agent ${agentId} removed from agents map`);
     } catch (error) {


### PR DESCRIPTION
# Relates to

Update agent service management during unregistration

# Risks

Low. This change improves resource management when unregistering agents by ensuring all services are properly stopped.

# Background

## What does this PR do?

This PR enhances the `unregisterAgent` method by adding automatic shutdown of agent services before removing it from the active agents Map. This ensures that all resources are properly released when an agent is unregistered, preventing potential resource leaks or orphaned services that would continue running in the background.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Examine the changes made to the `unregisterAgent` method in the `eliza/packages/cli/src/server/index.ts` file.

## Detailed testing steps

1. Create an agent with active services (e.g., with a Telegram or other plugin)
2. Stop this agent via the API (PUT /:agentId)
3. Verify in the logs that the services are properly stopped
4. Create an agent and delete it via the API (DELETE /:agentId)
5. Verify that the services are properly stopped before deletion