### PR TITLE
Fix broken image paths

### DIFF
--- a/docs/README_CN.md
+++ b/docs/README_CN.md
@@ -1,6 +1,6 @@
 # Eliza
 
-<img src="./docs/static/img/eliza_banner.jpg" alt="Eliza Banner" width="100%" />
+<img src="static/img/eliza_banner.jpg" alt="Eliza Banner" width="100%" />
 
 ## 功能
 

--- a/docs/README_DE.md
+++ b/docs/README_DE.md
@@ -6,7 +6,7 @@
 
 # dev branch
 
-<img src="./docs/static/img/eliza_banner.jpg" alt="Eliza Banner" width="100%" />
+<img src="static/img/eliza_banner.jpg" alt="Eliza Banner" width="100%" />
 
 _Wie gesehen bei [@DegenSpartanAI](https://x.com/degenspartanai) und [@MarcAIndreessen](https://x.com/pmairca)_
 

--- a/docs/README_FR.md
+++ b/docs/README_FR.md
@@ -1,6 +1,6 @@
 # Eliza
 
-<img src="./docs/static/img/eliza_banner.jpg" alt="Eliza Banner" width="100%" />
+<img src="static/img/eliza_banner.jpg" alt="Eliza Banner" width="100%" />
 
 _Utilisée dans [@DegenSpartanAI](https://x.com/degenspartanai) et [@MarcAIndreessen](https://x.com/pmairca)_
 


### PR DESCRIPTION
Replaced incorrect image paths that caused 404 errors in README_CN.md, README_DE.md, and README_FR.md.

Old path: ./docs/static/img/eliza_banner.jpg
New path: static/img/eliza_banner.jpg

This fixes broken banner images that were not displaying correctly in the translated documentation files.
