### PR TITLE
Fix: Correct broken Pump.fun link

### DIFF
--- a/docs/community/Discord/the_arena/price-talk-trenches/chat_2024-11-29.md
+++ b/docs/community/Discord/the_arena/price-talk-trenches/chat_2024-11-29.md
@@ -22,7 +22,7 @@ The chat focused on discussing the potential of creating viral content with a ne
 - @Artego helped @DrNeuro with Creating SantaGPT by providing Artego offered help with creating viral content for a new character.
 - Prime helped Olga with identity verification by providing Nivlac helps clarify the identity of Olga/SOL.
 - @Nivlac helped @Sai with Verifying legitimacy of offers by providing @Nivlac and others helped verify the high chance of SHAW CA offer being a scam.
-- [skott](https://discordapp.com/users/@me) helped [shaw](https://pump.fun/-FH5Yuax2hg6ct3tM4hPKXjmBFZ2e9TjLiouUK6fApump) with Improve AI engagement. by providing Suggestion to make AI more memetic and engaging.
+- [skott](https://discordapp.com/users/@me) helped [shaw](https://pump.fun/coin/FH5Yuax2hg6ct3tM4hPKXjmBFZ2e9TjLiouUK6fApump) with Improve AI engagement. by providing Suggestion to make AI more memetic and engaging.
 - [Sai](https://pump.fun/8ayZaoAZGUejEqgaKG1pQ8upy8iXhDdevgCZAHodpump) helped [DrNeuro] with Create Twitter banner. by providing Offer to help with Twitter banner creation.
 - @hat helped @nodderne with Sharing insights on a platform by providing Hat suggested using Twitter for sharing longer posts in threads.
 - @tradoor helped [community] with Clarify the purpose and function of a specific Discord server room by providing Discussion on ACT I discord's 'backroom', provided by tradoor


### PR DESCRIPTION
This pull request updates a broken Pump.fun link 
The old link was missing the /coin/ path, leading to a 404 error. The new link correctly directs to the intended resource.