### PR TITLE
Fix broken image paths 

### DIFF
--- a/docs/README_JA.md
+++ b/docs/README_JA.md
@@ -1,6 +1,6 @@
 # Eliza
 
-<img src="./docs/static/img/eliza_banner.jpg" alt="Eliza Banner" width="100%" />
+<img src="static/img/eliza_banner.jpg" alt="Eliza Banner" width="100%" />
 
 ## 機能
 


### PR DESCRIPTION
Old path: ./docs/static/img/eliza_banner.jpg
New path: static/img/eliza_banner.jpg

This fixes broken banner images that were not displaying correctly in the translated documentation files.