### PR TITLE
fix(plugin-discord): stop throwing error when missing service

### DIFF
--- a/packages/plugin-discord/src/messages.ts
+++ b/packages/plugin-discord/src/messages.ts
@@ -318,7 +318,8 @@ export class MessageManager {
       if (this.runtime.getService<IVideoService>(ServiceType.VIDEO)?.isVideoUrl(url)) {
         const videoService = this.runtime.getService<IVideoService>(ServiceType.VIDEO);
         if (!videoService) {
-          throw new Error('Video service not found');
+          logger.warn('Video service not found');
+          continue;
         }
         const videoInfo = await videoService.processVideo(url, this.runtime);
 
@@ -333,7 +334,8 @@ export class MessageManager {
       } else {
         const browserService = this.runtime.getService<IBrowserService>(ServiceType.BROWSER);
         if (!browserService) {
-          throw new Error('Browser service not found');
+          logger.warn('Browser service not found');
+          continue;
         }
 
         const { title, description: summary } = await browserService.getPageContent(


### PR DESCRIPTION
# Relates to

Improving error handling in Discord plugin services

# Risks

**Low**. This change modifies error behavior to avoid processing interruptions while maintaining traceability through logs.

# Background

## What does this PR do?

Replaces thrown exceptions (`throw`) with logged warnings (`logger.warn`) in the `messages.ts` file for services not found during Discord message processing. This modification allows message processing to continue even when certain optional services are unavailable.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Examine the `eliza/packages/plugin-discord/src/messages.ts` file, particularly the sections handling URLs and attachments.

## Detailed testing steps

- Test sending a Discord message containing a URL when the browser service is unavailable
- Verify that the message is still processed correctly without generating a fatal error
- Verify that logs contain appropriate warnings
- Test the same scenario with a video URL when the video service is unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for missing video or browser services by logging warnings instead of interrupting message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->