### PR TITLE
fix(core): type check crypto values

### DIFF
--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -77,6 +77,11 @@ export function encryptStringValue(value: string, salt: string): string {
       return value;
     }
 
+    if (typeof value !== 'string') {
+      logger.debug(`Value is not a string (type: ${typeof value}), returning as is`);
+      return value;
+    }
+
     // Check if value is already encrypted (has the format "iv:encrypted")
     const parts = value.split(':');
     if (parts.length === 2) {
@@ -127,6 +132,11 @@ export function decryptStringValue(value: string, salt: string): string {
 
     if (typeof value === 'boolean' || typeof value === 'number') {
       logger.debug('Value is a boolean or number, returning as is');
+      return value;
+    }
+
+    if (typeof value !== 'string') {
+      logger.debug(`Value is not a string (type: ${typeof value}), returning as is`);
       return value;
     }
 


### PR DESCRIPTION
# Relates to

Type error during decryption in MCP plugins

# Risks

**Low**. This change adds an additional type check to prevent errors when executing cryptographic functions.

# Background

## What does this PR do?

This PR fixes a `TypeError: value.split is not a function` that occurs on some calls by adding explicit type checking in the encryption and decryption functions.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

Review the changes in `eliza/packages/core/src/settings.ts` where type checks have been added to the `encryptStringValue` and `decryptStringValue` functions.

## Detailed testing steps

- Verify in the logs that no "value.split is not a function" error appears
- Verify that the tool execution completes successfully