### PR TITLE
chore: fix local llm throwing undefined error

### DIFF
--- a/packages/plugin-local-ai/src/index.ts
+++ b/packages/plugin-local-ai/src/index.ts
@@ -681,7 +681,8 @@ class LocalAIManager {
         temperature: 0.7,
         topP: 0.9,
         repeatPenalty: {
-          punishTokensFilter: () => this.smallModel!.tokenize(wordsToPunish.join(' ')),
+          punishTokensFilter: () =>
+            this.smallModel ? this.smallModel.tokenize(wordsToPunish.join(' ')) : [],
           penalty: 1.2,
           frequencyPenalty: 0.7,
           presencePenalty: 0.7,


### PR DESCRIPTION
fixes local ai throwing

```
[2025-04-29 15:06:40] DEBUG: API request: GET /ping
[2025-04-29 15:06:40] DEBUG: API request: GET /agents/b850bc30-45f8-0041-a00a-83df46d8555d/logs
[2025-04-29 15:06:40] DEBUG: Skipping plugin handler for specific route: /agents/b850bc30-45f8-0041-a00a-83df46d8555d/logs
[2025-04-29 15:06:41] DEBUG: API request: GET /agents/b850bc30-45f8-0041-a00a-83df46d8555d/memories
[2025-04-29 15:06:41] DEBUG: Skipping plugin handler for specific route: /agents/b850bc30-45f8-0041-a00a-83df46d8555d/memories
2820 |       let response = await this.chatSession.prompt(params.prompt, {
2821 |         maxTokens: 8192,
2822 |         temperature: 0.7,
2823 |         topP: 0.9,
2824 |         repeatPenalty: {
2825 |           punishTokensFilter: () => this.smallModel.tokenize(wordsToPunish.join(" ")),
                                                ^
TypeError: undefined is not an object (evaluating 'this.smallModel.tokenize')
      at punishTokensFilter (/Users/studio/Documents/GitHub/eliza/packages/plugin-local-ai/dist/index.js:2825:42)
      at getPenaltyTokens (/Users/studio/Documents/GitHub/eliza/node_modules/node-llama-cpp/dist/evaluator/LlamaChat/LlamaChat.js:883:55)
      at _resolveSamplerConfig (/Users/studio/Documents/GitHub/eliza/node_modules/node-llama-cpp/dist/evaluator/LlamaContext/LlamaContext.js:1422:29)
      at <anonymous> (/Users/studio/Documents/GitHub/eliza/node_modules/node-llama-cpp/dist/evaluator/LlamaContext/LlamaContext.js:1159:52)
      at <anonymous> (/Users/studio/Documents/GitHub/eliza/node_modules/node-llama-cpp/dist/evaluator/LlamaContext/LlamaContext.js:368:51)
      at map (1:11)
      at <anonymous> (/Users/studio/Documents/GitHub/eliza/node_modules/node-llama-cpp/dist/evaluator/LlamaContext/LlamaContext.js:354:69)
[2025-04-29 15:06:44] INFO: Starting graceful shutdown of PGlite client...
[2025-04-29 15:06:44] INFO: PGlite client shutdown completed successfully
```