### PR TITLE
fix: remove forced bootstrap plugin add

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -269,18 +269,6 @@ export async function startAgent(
   // Initialize encryptedChar.plugins if it's undefined
   encryptedChar.plugins = encryptedChar.plugins ?? [];
 
-  // Ensure bootstrap plugin string is present in the character's list if not already loaded
-  const bootstrapPluginName = '@elizaos/plugin-bootstrap';
-  const characterHasBootstrapString = encryptedChar.plugins.includes(bootstrapPluginName);
-  const alreadyLoadedBootstrap = loadedPluginsMap.has(bootstrapPluginName);
-
-  if (!characterHasBootstrapString && !alreadyLoadedBootstrap) {
-    logger.debug(
-      `Adding ${bootstrapPluginName} string to character's plugin list as it was missing and not pre-loaded.`
-    );
-    encryptedChar.plugins.push(bootstrapPluginName);
-  }
-
   const characterPlugins: Plugin[] = [];
 
   // Process and load plugins specified by name in the character definition


### PR DESCRIPTION
This PR removes the forced adding of the bootstrap plugin to projects through the CLI. Projects *can* use the bootstrap plugin, but it isn't forced on them. Makes simple agents much easier.