### PR TITLE
feat: extend openai plugin to support custom embedding endpoint

### DIFF
--- a/packages/docs/blog/openai-plugin-envs.md
+++ b/packages/docs/blog/openai-plugin-envs.md
@@ -14,7 +14,7 @@ The `plugin-openai` package in this project can connect to any OpenAI-compatible
 An OpenAI-compatible provider is any service that implements the OpenAI API spec. Popular examples include:
 
 - [OpenRouter](https://openrouter.ai/)
-- [Ollama](https://ollama.com/) (with its OpenAI-compatible API)
+- [Ollama](https://ollama.com/) (with its OpenAI-compatible API, supports embedding also)
 - [Local LLMs with an OpenAI API wrapper](https://github.com/abetlen/llama-cpp-python)
 - Other cloud or self-hosted endpoints
 
@@ -31,6 +31,7 @@ The following environment variables are supported by the OpenAI plugin:
 | `OPENAI_SMALL_MODEL`          | Default small model name                                   |
 | `OPENAI_LARGE_MODEL`          | Default large model name                                   |
 | `OPENAI_EMBEDDING_MODEL`      | Embedding model name                                       |
+| `OPENAI_EMBEDDING_URL`        | Base URL specifically for the embedding API endpoint       |
 | `OPENAI_EMBEDDING_DIMENSIONS` | Embedding vector dimensions                                |
 | `SMALL_MODEL`                 | (Fallback) Small model name                                |
 | `LARGE_MODEL`                 | (Fallback) Large model name                                |
@@ -43,6 +44,8 @@ OPENAI_BASE_URL=https://openrouter.ai/api/v1
 OPENAI_SMALL_MODEL=openrouter/gpt-3.5-turbo
 OPENAI_LARGE_MODEL=openrouter/gpt-4
 ```
+
+> **Warning:** OpenRouter does **not** currently support the `/v1/embeddings` endpoint. If you need embeddings, you must use a different provider for them. See the section below on [Handling Providers Without Embedding Support](#handling-providers-without-embedding-support).
 
 ## Example: Connecting to Ollama
 
@@ -81,37 +84,23 @@ OPENAI_LARGE_MODEL=your-model-name-here
 
 For more details, see the [LM Studio OpenAI Compatibility API docs](https://lmstudio.ai/docs/app/api/endpoints/openai).
 
-> **Reminder:**
-> An embedding model is still required for full plugin functionality. We recommend pairing your setup with the Local AI plugin, an OpenAI API key, or a provider that also supports embeddings (such as OpenAI, OpenRouter, or LocalAI).
+## Handling Providers Without Embedding Support
 
-:::tip
-**Best Practice:**
-Keep your `.env` file out of version control! Use environment variable management tools or deployment secrets for production.
-:::
+Some OpenAI-compatible providers (like OpenRouter) might not offer an embedding endpoint (`/v1/embeddings`). If you need embedding functionality (e.g., for memory or context retrieval), you can configure the OpenAI plugin to use a _different_ provider specifically for embeddings using the `OPENAI_EMBEDDING_URL` environment variable.
 
-> **Reminder:**
->
-> - If `OPENAI_BASE_URL` is not set, the plugin defaults to the official OpenAI endpoint.
-> - Model names must match those supported by your provider.
-> - Some providers may require extra headers or parameters—check their docs!
+**Example: OpenRouter for Chat, Ollama for Embeddings**
 
-## 🐞 Troubleshooting
+Let's say you want to use OpenRouter for its wide model selection for chat completion but prefer Ollama's embedding capabilities (see [Ollama OpenAI docs](https://github.com/ollama/ollama/blob/main/docs/openai.md)).
 
-- If you see errors about missing `OPENAI_API_KEY`, make sure it’s set in your environment.
-- For provider-specific errors, double-check your `OPENAI_BASE_URL` and model names.
+```env
+# General API settings (points to OpenRouter)
+OPENAI_API_KEY=your-openrouter-key
+OPENAI_BASE_URL=https://openrouter.ai/api/v1
+OPENAI_SMALL_MODEL=openrouter/gpt-3.5-turbo
+OPENAI_LARGE_MODEL=openrouter/gpt-4
 
-## 🎯 Conclusion
-
-By customizing your environment variables, you can use the OpenAI plugin with any provider that supports the OpenAI API. Swap providers, use local models, or experiment with new services—all with a few config changes. Happy hacking!
-
----
-
-## 🔗 More Links
-
-- [Plugin Guide](https://eliza.how/docs/plugins)
-- [OpenAI API Reference](https://platform.openai.com/docs/api-reference)
-- [OpenRouter Docs](https://openrouter.ai/docs)
-- [Ollama Docs](https://github.com/ollama/ollama/blob/main/docs/openai.md)
-- [LM Studio Docs](https://lmstudio.ai/docs/app/api/endpoints/openai)
-
-_If you have questions or want to contribute more provider examples, feel free to open a PR!_
+# Embedding-specific settings (points to Ollama)
+OPENAI_EMBEDDING_URL=http://localhost:11434/v1 # Your Ollama embedding endpoint
+OPENAI_EMBEDDING_MODEL=all-minilm # Ollama embedding model (e.g., all-minilm)
+# OPENAI_EMBEDDING_DIMENSIONS=1536 # Optional: Specify if needed for your model
+```

--- a/packages/plugin-openai/README.md
+++ b/packages/plugin-openai/README.md
@@ -21,6 +21,7 @@ The plugin requires these environment variables (can be set in .env file or char
   "OPENAI_SMALL_MODEL": "gpt-4o-mini",
   "OPENAI_LARGE_MODEL": "gpt-4o",
   "OPENAI_EMBEDDING_MODEL": "text-embedding-3-small",
+  "OPENAI_EMBEDDING_URL": "optional_custom_endpoint",
   "OPENAI_EMBEDDING_DIMENSIONS": "1536"
 }
 ```
@@ -34,6 +35,7 @@ OPENAI_BASE_URL=optional_custom_endpoint
 OPENAI_SMALL_MODEL=gpt-4o-mini
 OPENAI_LARGE_MODEL=gpt-4o
 OPENAI_EMBEDDING_MODEL=text-embedding-3-small
+OPENAI_EMBEDDING_URL=optional_custom_endpoint
 OPENAI_EMBEDDING_DIMENSIONS=1536
 ```
 
@@ -44,6 +46,7 @@ OPENAI_EMBEDDING_DIMENSIONS=1536
 - `OPENAI_SMALL_MODEL`: Defaults to GPT-4o Mini ("gpt-4o-mini")
 - `OPENAI_LARGE_MODEL`: Defaults to GPT-4o ("gpt-4o")
 - `OPENAI_EMBEDDING_MODEL`: Defaults to text-embedding-3-small ("text-embedding-3-small")
+- `OPENAI_EMBEDDING_URL`: Custom embedding endpoint (defaults to `OPENAI_BASE_URL`)
 - `OPENAI_EMBEDDING_DIMENSIONS`: Defaults to 1536 (1536)
 
 The plugin provides these model classes:

--- a/packages/plugin-openai/src/index.ts
+++ b/packages/plugin-openai/src/index.ts
@@ -127,6 +127,21 @@ function getBaseURL(runtime: IAgentRuntime): string {
 }
 
 /**
+ * Retrieves the OpenAI API base URL for embeddings, falling back to the general base URL.
+ *
+ * @returns The resolved base URL for OpenAI embedding requests.
+ */
+function getEmbeddingBaseURL(runtime: IAgentRuntime): string {
+  const embeddingURL = getSetting(runtime, 'OPENAI_EMBEDDING_URL');
+  if (embeddingURL) {
+    logger.debug(`[OpenAI] Using specific embedding base URL: ${embeddingURL}`);
+    return embeddingURL;
+  }
+  logger.debug('[OpenAI] Falling back to general base URL for embeddings.');
+  return getBaseURL(runtime);
+}
+
+/**
  * Helper function to get the API key for OpenAI
  *
  * @param runtime The runtime context
@@ -432,6 +447,7 @@ export const openaiPlugin: Plugin = {
     SMALL_MODEL: process.env.SMALL_MODEL,
     LARGE_MODEL: process.env.LARGE_MODEL,
     OPENAI_EMBEDDING_MODEL: process.env.OPENAI_EMBEDDING_MODEL,
+    OPENAI_EMBEDDING_URL: process.env.OPENAI_EMBEDDING_URL,
     OPENAI_EMBEDDING_DIMENSIONS: process.env.OPENAI_EMBEDDING_DIMENSIONS,
   },
   async init(_config, runtime) {
@@ -528,7 +544,7 @@ export const openaiPlugin: Plugin = {
       return startLlmSpan(runtime, 'LLM.embedding', attributes, async (span) => {
         span.addEvent('llm.prompt', { 'prompt.content': text });
 
-        const baseURL = getBaseURL(runtime);
+        const embeddingBaseURL = getEmbeddingBaseURL(runtime);
         const apiKey = getApiKey(runtime);
 
         if (!apiKey) {
@@ -540,7 +556,7 @@ export const openaiPlugin: Plugin = {
         }
 
         try {
-          const response = await fetch(`${baseURL}/embeddings`, {
+          const response = await fetch(`${embeddingBaseURL}/embeddings`, {
             method: 'POST',
             headers: {
               Authorization: `Bearer ${apiKey}`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for a new environment variable to specify a separate endpoint for embedding requests, allowing users to configure different providers for chat and embeddings.

- **Documentation**
	- Updated documentation to explain the new embedding endpoint configuration, provide usage examples, and clarify provider compatibility for embeddings.
	- Added guidance for handling providers without embedding support and reorganized related content for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->