### PR TITLE
docs: fix title spacing

### DIFF
--- a/packages/docs/src/components/HomepageHeader/index.jsx
+++ b/packages/docs/src/components/HomepageHeader/index.jsx
@@ -14,7 +14,7 @@ function HomepageHeader() {
         <div className={styles.heroSection}>
           <div className={styles.heroLeft}>
             <h1 className={styles.heroTitle}>
-              <span className={styles.heroTitlePrefix}>eliza</span> is a
+              <span className={styles.heroTitlePrefix}>eliza</span> is a{' '}
               <span className={styles.heroTitleHighlight}>powerful AI agent framework</span> for
               autonomy & personality
             </h1>


### PR DESCRIPTION
## Fix Documentation Title Spacing

`eliza is apowerful AI agent framework for autonomy & personality` ---> `eliza is a powerful AI agent framework for autonomy & personality`
