### PR TITLE
fix client scroll bars

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -81,7 +81,7 @@ function AppContent() {
         <AppSidebar />
         <SidebarInset>
           <div className="flex w-full justify-center">
-            <div className="w-full mt-4 md:max-w-4xl">
+            <div className="w-full md:max-w-4xl">
               <ConnectionErrorBanner />
             </div>
           </div>

--- a/packages/client/src/components/action-viewer.tsx
+++ b/packages/client/src/components/action-viewer.tsx
@@ -320,7 +320,7 @@ export function AgentActionViewer({ agentId, roomId }: AgentActionViewerProps) {
   }
 
   return (
-    <div className="flex flex-col h-[calc(100vh-100px)] min-h-[400px] w-full">
+    <div className="flex flex-col min-h-[400px] w-full">
       <div className="flex justify-between items-center mb-4 px-4 pt-4 flex-none border-b pb-3">
         <div className="flex items-center gap-2">
           <h3 className="text-lg font-medium">Agent Actions</h3>

--- a/packages/client/src/components/agent-sidebar.tsx
+++ b/packages/client/src/components/agent-sidebar.tsx
@@ -44,7 +44,7 @@ export function AgentSidebar({ agentId, agentName }: AgentSidebarProps) {
         </TabsList>
       </div>
 
-      <TabsContent value="actions" className="overflow-y-scroll">
+      <TabsContent value="actions" className="overflow-y-auto">
         {detailsTab === 'actions' && <AgentActionViewer agentId={agentId} />}
       </TabsContent>
       <TabsContent value="logs">

--- a/packages/client/src/components/connection-error-banner.tsx
+++ b/packages/client/src/components/connection-error-banner.tsx
@@ -52,7 +52,7 @@ export function ConnectionErrorBanner({ className }: ConnectionErrorBannerProps)
     <div
       className={cn(
         'bg-opacity-10 border rounded-md p-3 mb-4 w-full md:max-w-4xl',
-        'flex items-center justify-between w-full',
+        'flex items-center justify-between w-full mt-4',
         isUnauthorized
           ? 'bg-yellow-900/20 border-yellow-700 text-yellow-100'
           : 'bg-red-900/20 border-red-700 text-red-100',

--- a/packages/client/src/components/ui/sidebar.tsx
+++ b/packages/client/src/components/ui/sidebar.tsx
@@ -385,7 +385,7 @@ const SidebarContent = React.forwardRef<HTMLDivElement, React.ComponentProps<'di
         ref={ref}
         data-sidebar="content"
         className={cn(
-          'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+          'flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden group-data-[collapsible=icon]:overflow-hidden',
           className
         )}
         {...props}

--- a/packages/client/src/components/ui/tabs.tsx
+++ b/packages/client/src/components/ui/tabs.tsx
@@ -42,7 +42,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      'ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
       className
     )}
     {...props}


### PR DESCRIPTION
Scrollbars were doubled up in task list, also if hover side bar would get scroll weirdly, the main page also had a global scroll bloat.

Now it is much cleaner and fullscreen no scrolls.