### PR TITLE
attempt CLI plugin loader fix

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -50,17 +50,19 @@ async function loadAndPreparePlugin(pluginName: string, version: string): Promis
   logger.debug(`Processing plugin: ${pluginName}`);
   let pluginModule: any;
 
+  const directory = process.cwd();
+
   try {
     // Use the centralized loader first
-    pluginModule = await loadPluginModule(pluginName);
+    pluginModule = await loadPluginModule(pluginName, directory);
 
     if (!pluginModule) {
       // If loading failed, try installing and then loading again
-      logger.info(`Plugin ${pluginName} not available, installing into ${process.cwd()}...`);
+      logger.info(`Plugin ${pluginName} not available, installing into ${directory}...`);
       try {
-        await installPlugin(pluginName, process.cwd(), version);
+        await installPlugin(pluginName, directory, version);
         // Try loading again after installation using the centralized loader
-        pluginModule = await loadPluginModule(pluginName);
+        pluginModule = await loadPluginModule(pluginName, directory);
       } catch (installError) {
         logger.error(`Failed to install plugin ${pluginName}: ${installError}`);
         return null; // Installation failed

--- a/packages/cli/src/utils/install-plugin.ts
+++ b/packages/cli/src/utils/install-plugin.ts
@@ -43,7 +43,7 @@ function getCliDirectory(): string | null {
  */
 async function verifyPluginImport(repository: string, context: string): Promise<boolean> {
   // Use the new centralized loader function
-  const loadedModule = await loadPluginModule(repository);
+  const loadedModule = await loadPluginModule(repository, process.cwd());
 
   if (loadedModule) {
     logger.info(`Successfully verified plugin ${repository} ${context} after installation.`);

--- a/packages/cli/src/utils/load-plugin.ts
+++ b/packages/cli/src/utils/load-plugin.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { logger } from '@elizaos/core';
 
 /**
@@ -8,19 +10,38 @@ import { logger } from '@elizaos/core';
  * - Monorepo packages (through proper package.json and workspace configuration)
  * - Package entry points
  *
+ * If `directory` is provided, it will first try to load from
+ * `<directory>/node_modules/<repository>`.
+ *
  * @param repository - The plugin repository/package name to load.
+ * @param directory  - Optional base directory to resolve the plugin from.
  * @returns The loaded plugin module or null if loading fails.
  */
-export async function loadPluginModule(repository: string): Promise<any | null> {
+export async function loadPluginModule(
+  repository: string,
+  directory?: string
+): Promise<any | null> {
   logger.debug(`Attempting to load plugin module: ${repository}`);
 
   try {
-    const module = await import(repository);
+    let specifier = repository;
+
+    if (directory) {
+      // Resolve to <directory>/node_modules/<repository>
+      const moduleDir = path.resolve(directory, 'node_modules', repository);
+      // Convert to file:// URL so import() can load it
+      specifier = pathToFileURL(moduleDir).href;
+      logger.debug(`Resolving plugin from directory: ${specifier}`);
+    }
+
+    const module = await import(specifier);
     logger.debug(`Successfully loaded plugin '${repository}'`);
     return module;
   } catch (error) {
     logger.warn(
-      `Failed to load plugin module '${repository}': ${error instanceof Error ? error.message : String(error)}`
+      `Failed to load plugin module '${repository}': ${
+        error instanceof Error ? error.message : String(error)
+      }`
     );
     return null;
   }


### PR DESCRIPTION
Issue is on prod CLI:

```
Failed to load plugin module '@elizaos/plugin-bootstrap': Cannot find package '@elizaos/plugin-bootstrap' imported from /home/cjft/.nvm/versions/node/v23.9.0/lib/node_modules/@elizaos/cli/dist/chunk-37ODWVII.js
```

Because the realtive import path is not looking in proper project for node_modules.

Adding `directory` as optional param, supports using the node_modules from the created Eliza project.