### PR TITLE
Eli2 277/fix missing gitignore in plugins created with global cli installation

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -76,6 +76,45 @@ async function installDependencies(targetDir: string) {
 }
 
 /**
+ * Creates .gitignore and .npmignore files in the target directory if they don't exist
+ */
+async function createIgnoreFiles(targetDir: string): Promise<void> {
+  const gitignorePath = path.join(targetDir, '.gitignore');
+  const npmignorePath = path.join(targetDir, '.npmignore');
+
+  // Check if .gitignore exists and create it if not
+  if (!existsSync(gitignorePath)) {
+    // Use the exact content from the original plugin-starter/.gitignore
+    const gitignoreContent = `dist/
+node_modules/
+`;
+
+    try {
+      await fs.writeFile(gitignorePath, gitignoreContent);
+    } catch (error) {
+      console.error(`Failed to create .gitignore: ${error.message}`);
+    }
+  }
+
+  // Check if .npmignore exists and create it if not
+  if (!existsSync(npmignorePath)) {
+    // Use the exact content from the original plugin-starter/.npmignore
+    const npmignoreContent = `.turbo
+dist
+node_modules
+.env
+*.env
+.env.local`;
+
+    try {
+      await fs.writeFile(npmignorePath, npmignoreContent);
+    } catch (error) {
+      console.error(`Failed to create .npmignore: ${error.message}`);
+    }
+  }
+}
+
+/**
  * Initialize a new project or plugin.
  *
  * @param {Object} opts - Options for initialization.
@@ -284,6 +323,8 @@ export const create = new Command()
 
         await copyTemplateUtil('plugin', targetDir, pluginName);
 
+        await createIgnoreFiles(targetDir);
+
         console.info('Installing dependencies...');
         try {
           await runBunCommand(['install', '--no-optional'], targetDir);
@@ -341,6 +382,8 @@ export const create = new Command()
         }
 
         await copyTemplateUtil('project', targetDir, projectName);
+
+        await createIgnoreFiles(targetDir);
 
         const { elizaDbDir, envFilePath } = await getElizaDirectories();
         if (database === 'pglite') {

--- a/packages/cli/src/utils/copy-template.ts
+++ b/packages/cli/src/utils/copy-template.ts
@@ -84,13 +84,6 @@ export async function copyTemplate(
   // Copy template files
   await copyDir(templateDir, targetDir);
 
-  // Explicitly check and copy .gitignore file (hidden files can be missed)
-  const srcGitignore = path.join(templateDir, '.gitignore');
-  const destGitignore = path.join(targetDir, '.gitignore');
-  if (existsSync(srcGitignore) && !existsSync(destGitignore)) {
-    await fs.copyFile(srcGitignore, destGitignore);
-  }
-
   // Update package.json with new name and dependency versions
   const packageJsonPath = path.join(targetDir, 'package.json');
 


### PR DESCRIPTION
**Problem**

When creating plugins or projects using the globally installed ElizaOS CLI, the generated directories were missing .gitignore and .npmignore files. This happened because npm strips these special files during the package publishing process. The absence of .gitignore files was causing GitHub's secret scanning to detect potential security issues and block pushes.

**Solution**

Removed the existing special handling for .gitignore in copy-template.ts that was ineffective with globally installed CLI
Added a new createIgnoreFiles() utility function that explicitly creates .gitignore and .npmignore files if they don't exist
The function uses the exact same content from the original template files
Added calls to this function in both project and plugin creation workflows
This approach ensures these critical files are created regardless of whether they were copied from templates

**Testing**

Tested locally by temporarily renaming the template files and verifying that our code correctly created them
Verified that the files contained the correct content

For full verification, this change should be published to npm and tested as the globally installed CLI

The implementation is designed to handle both local development and globally installed CLI scenarios

This fix ensures that all plugins and projects have proper .gitignore and .npmignore files, preventing GitHub from blocking pushes due to detected security issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically creates `.gitignore` and `.npmignore` files in new projects or plugins if they do not already exist.

- **Refactor**
  - Simplified the process for handling ignore files during project and plugin creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->