### PR TITLE
feat: add plugin specification wrappers

### DIFF
--- a/packages/core-plugin-v1/.gitignore
+++ b/packages/core-plugin-v1/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+elizaConfig.yaml
+custom_actions/
+cache/
+*.tsbuildinfo

--- a/packages/core-plugin-v1/.npmignore
+++ b/packages/core-plugin-v1/.npmignore
@@ -1,0 +1,6 @@
+*
+
+!dist/**
+!package.json
+!readme.md
+!tsup.config.ts

--- a/packages/core-plugin-v1/LICENSE
+++ b/packages/core-plugin-v1/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Shaw Walters and elizaOS Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core-plugin-v1/package.json
+++ b/packages/core-plugin-v1/package.json
@@ -1,0 +1,81 @@
+{
+  "name": "@elizaos/core-plugin-v1",
+  "version": "1.0.0-beta.27",
+  "description": "",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "watch": "tsc --watch",
+    "clean": "rm -rf dist .turbo node_modules .turbo-tsconfig.json tsconfig.tsbuildinfo",
+    "dev": "tsup --watch",
+    "build:docs": "cd docs && bun run build",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest",
+    "format": "prettier --write ./src",
+    "format:check": "prettier --check ./src",
+    "lint": "prettier --write ./src"
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@eslint/js": "9.16.0",
+    "@rollup/plugin-commonjs": "25.0.8",
+    "@rollup/plugin-json": "6.1.0",
+    "@rollup/plugin-replace": "5.0.7",
+    "@rollup/plugin-terser": "0.1.0",
+    "@rollup/plugin-typescript": "11.1.6",
+    "@types/mocha": "10.0.10",
+    "@types/node": "^22.13.9",
+    "@types/uuid": "10.0.0",
+    "@typescript-eslint/eslint-plugin": "8.26.0",
+    "@typescript-eslint/parser": "8.26.0",
+    "@vitest/coverage-v8": "2.1.5",
+    "lint-staged": "15.2.10",
+    "nodemon": "3.1.7",
+    "pm2": "5.4.3",
+    "prettier": "3.5.3",
+    "rimraf": "6.0.1",
+    "rollup": "2.79.2",
+    "ts-node": "10.9.2",
+    "tslib": "2.8.1",
+    "tsup": "^8.4.0",
+    "typescript": "5.8.2"
+  },
+  "dependencies": {
+    "@elizaos/core-plugin-v2": "1.0.0-beta.27",
+    "@types/hapi__shot": "^6.0.0",
+    "buffer": "^6.0.3",
+    "crypto-browserify": "^3.12.1",
+    "dotenv": "16.4.5",
+    "events": "^3.3.0",
+    "glob": "11.0.0",
+    "handlebars": "^4.7.8",
+    "js-sha1": "0.7.0",
+    "langchain": "^0.3.15",
+    "pino": "^9.6.0",
+    "pino-pretty": "^13.0.0",
+    "stream-browserify": "^3.0.0",
+    "unique-names-generator": "4.7.1",
+    "uuid": "11.0.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "7b01ea21f51671371e738134c80c958483b7b709"
+}

--- a/packages/core-plugin-v1/src/__tests__/actionExample.test.ts
+++ b/packages/core-plugin-v1/src/__tests__/actionExample.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it } from 'vitest';
+import { Content } from '../types';
+import { Content as ContentV2, ActionExample as ActionExampleV2 } from '@elizaos/core-plugin-v2';
+import {
+  ActionExample,
+  convertContentToV1,
+  convertContentToV2,
+  fromV2ActionExample,
+  toV2ActionExample,
+} from '../actionExample';
+
+describe('ActionExample Module', () => {
+  // Common test data
+  const v1Example: ActionExample = {
+    user: 'TestUser',
+    content: {
+      text: 'Hello world',
+      action: 'ACTION1',
+    } as Content,
+  };
+
+  // Equivalent v2 example
+  const v2Example: ActionExampleV2 = {
+    name: 'TestUser',
+    content: {
+      text: 'Hello world',
+      actions: ['ACTION1'],
+    } as ContentV2,
+  };
+
+  describe('convertContentToV1', () => {
+    it('should convert V2 content to V1 content', () => {
+      const v2Content: ContentV2 = {
+        text: 'Test content',
+        actions: ['ACTION1'],
+        metadata: { timestamp: 12345 },
+      } as ContentV2;
+
+      const result = convertContentToV1(v2Content);
+
+      expect(result.text).toBe('Test content');
+      expect(result.action).toBe('ACTION1');
+      // Type assertion to access the metadata property
+      expect((result as any).metadata.timestamp).toBe(12345);
+    });
+
+    it('should handle empty actions array', () => {
+      const v2Content: ContentV2 = {
+        text: 'Test content',
+        actions: [],
+      } as ContentV2;
+
+      const result = convertContentToV1(v2Content);
+
+      expect(result.text).toBe('Test content');
+      expect(result.action).toBeUndefined();
+    });
+
+    it('should handle null or undefined content', () => {
+      // @ts-ignore - testing null content
+      const result1 = convertContentToV1(null);
+      // @ts-ignore - testing undefined content
+      const result2 = convertContentToV1(undefined);
+
+      expect(result1.text).toBe('');
+      expect(result2.text).toBe('');
+    });
+  });
+
+  describe('convertContentToV2', () => {
+    it('should convert V1 content to V2 content', () => {
+      const v1Content = {
+        text: 'Test content',
+        action: 'ACTION1',
+        thought: 'Private thought',
+      } as Content;
+
+      const result = convertContentToV2(v1Content);
+
+      expect(result.text).toBe('Test content');
+      expect(result.actions).toEqual(['ACTION1']);
+      // Access with type assertion
+      expect((result as any).thought).toBe('Private thought');
+    });
+
+    it('should handle undefined action field', () => {
+      const v1Content = {
+        text: 'Test content',
+        action: undefined,
+      } as Content;
+
+      const result = convertContentToV2(v1Content);
+
+      expect(result.text).toBe('Test content');
+      expect(result.actions).toEqual([]);
+    });
+
+    it('should handle null or undefined content', () => {
+      // @ts-ignore - testing null content
+      const result1 = convertContentToV2(null);
+      // @ts-ignore - testing undefined content
+      const result2 = convertContentToV2(undefined);
+
+      expect(result1.text).toBe('');
+      expect(result2.text).toBe('');
+    });
+  });
+
+  describe('fromV2ActionExample', () => {
+    it('should convert v2 ActionExample to v1 ActionExample', () => {
+      const result = fromV2ActionExample(v2Example);
+
+      expect(result.user).toBe(v2Example.name);
+      expect(result.content.text).toBe(v2Example.content.text);
+      expect(result.content.action).toBe(v2Example.content.actions[0]);
+    });
+
+    it('should handle v2 example with minimal content', () => {
+      const minimalV2Example: ActionExampleV2 = {
+        name: 'TestUser',
+        content: {
+          text: 'Minimal example',
+        } as ContentV2,
+      };
+
+      const result = fromV2ActionExample(minimalV2Example);
+
+      expect(result.user).toBe('TestUser');
+      expect(result.content.text).toBe('Minimal example');
+      expect(result.content.action).toBeUndefined();
+    });
+
+    it('should handle empty strings and arrays', () => {
+      const emptyV2Example: ActionExampleV2 = {
+        name: '',
+        content: {
+          text: '',
+          actions: [],
+        } as ContentV2,
+      };
+
+      const result = fromV2ActionExample(emptyV2Example);
+
+      expect(result.user).toBe('');
+      expect(result.content.text).toBe('');
+      expect(result.content.action).toBeUndefined();
+    });
+
+    it('should handle null or undefined example', () => {
+      // @ts-ignore - testing null example
+      const result1 = fromV2ActionExample(null);
+      // @ts-ignore - testing undefined example
+      const result2 = fromV2ActionExample(undefined);
+
+      expect(result1.user).toBe('');
+      expect(result1.content.text).toBe('');
+      expect(result2.user).toBe('');
+      expect(result2.content.text).toBe('');
+    });
+  });
+
+  describe('toV2ActionExample', () => {
+    it('should convert v1 ActionExample to v2 ActionExample', () => {
+      const result = toV2ActionExample(v1Example);
+
+      expect(result.name).toBe(v1Example.user);
+      expect(result.content.text).toBe(v1Example.content.text);
+      expect(result.content.actions).toEqual([v1Example.content.action]);
+    });
+
+    it('should handle v1 example with minimal content', () => {
+      const minimalV1Example: ActionExample = {
+        user: 'TestUser',
+        content: {
+          text: 'Minimal example',
+        } as Content,
+      };
+
+      const result = toV2ActionExample(minimalV1Example);
+
+      expect(result.name).toBe('TestUser');
+      expect(result.content.text).toBe('Minimal example');
+      expect(result.content.actions).toEqual([]);
+    });
+
+    it('should handle complex content structures', () => {
+      const complexV1Example: ActionExample = {
+        user: 'ComplexUser',
+        content: {
+          text: 'Complex example',
+          action: 'ACTION1',
+          metadata: {
+            timestamp: 123456789,
+            source: 'test',
+            nested: {
+              field1: 'value1',
+              field2: 'value2',
+            },
+          },
+        } as unknown as Content,
+      };
+
+      const result = toV2ActionExample(complexV1Example);
+
+      expect(result.name).toBe('ComplexUser');
+      expect(result.content.text).toBe('Complex example');
+      expect(result.content.actions).toEqual(['ACTION1']);
+      // Use type assertions to access the nested properties
+      const metadata = (result.content as any).metadata;
+      expect(metadata.timestamp).toBe(123456789);
+      expect(metadata.nested.field1).toBe('value1');
+    });
+
+    it('should handle null or undefined example', () => {
+      // @ts-ignore - testing null example
+      const result1 = toV2ActionExample(null);
+      // @ts-ignore - testing undefined example
+      const result2 = toV2ActionExample(undefined);
+
+      expect(result1.name).toBe('');
+      expect(result1.content.text).toBe('');
+      expect(result2.name).toBe('');
+      expect(result2.content.text).toBe('');
+    });
+  });
+
+  describe('ActionExample type', () => {
+    it('should match the expected structure', () => {
+      const example: ActionExample = {
+        user: 'User1',
+        content: {
+          text: 'Sample text',
+        } as Content,
+      };
+
+      expect(example).toHaveProperty('user');
+      expect(example).toHaveProperty('content');
+      expect(typeof example.user).toBe('string');
+    });
+  });
+});

--- a/packages/core-plugin-v1/src/__tests__/integration.test.ts
+++ b/packages/core-plugin-v1/src/__tests__/integration.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest';
+import { asUUID } from '../uuid';
+import { State, fromV2State, toV2State } from '../state';
+import { Provider, fromV2Provider, toV2Provider } from '../provider';
+import { ActionExample, fromV2ActionExample, toV2ActionExample } from '../actionExample';
+import { TemplateType, processTemplate } from '../templates';
+
+describe('Integration tests for v1 compatibility layer', () => {
+  // Create UUIDs for testing
+  const userId = asUUID('00000000-0000-0000-0000-000000000123');
+  const agentId = asUUID('00000000-0000-0000-0000-000000000456');
+  const roomId = asUUID('00000000-0000-0000-0000-000000000789');
+
+  // Setup mock runtime
+  const mockRuntime = {
+    getSetting: vi.fn().mockReturnValue('test-setting'),
+    logger: { info: vi.fn(), error: vi.fn() },
+  } as any;
+
+  // Setup mock message
+  const mockMessage = {
+    id: asUUID('00000000-0000-0000-0000-000000000001'),
+    roomId,
+    content: { text: 'Test message' },
+  } as any;
+
+  it('should process a v1 state through a v2 provider and back', async () => {
+    // Create a v1 state
+    const v1State: State = {
+      userId,
+      agentId,
+      roomId: '00000000-0000-0000-0000-000000000789',
+      bio: 'Test bio',
+      lore: 'Test lore',
+      messageDirections: 'Test message directions',
+      postDirections: 'Test post directions',
+      actors: 'User, Agent',
+      recentMessages: 'Some recent messages',
+      recentMessagesData: [],
+      text: 'Original state',
+    };
+
+    // Create a v1 provider
+    const v1Provider: Provider = {
+      name: 'testProvider',
+      get: async (runtime, message, state) => {
+        // Verify the state has correct v1 structure
+        expect(state?.userId).toBe(userId);
+        expect(state?.bio).toBe('Test bio');
+
+        // Return a provider result
+        return {
+          text: `Provider processed state: ${state?.text}`,
+          walletBalance: 123.45,
+          userInfo: {
+            name: 'Test User',
+          },
+        };
+      },
+    };
+
+    // Convert to v2 provider
+    const v2Provider = toV2Provider(v1Provider);
+
+    // Convert state to v2
+    const v2State = toV2State(v1State);
+
+    // Use v2 provider with v2 state
+    const result = await v2Provider.get(mockRuntime, mockMessage, v2State);
+
+    // Verify result
+    expect(result.text).toBe('Provider processed state: Original state');
+    expect(result.walletBalance).toBe(123.45);
+    expect(result.userInfo.name).toBe('Test User');
+
+    // Convert provider back to v1
+    const v1ProviderAgain = fromV2Provider(v2Provider);
+
+    // Use v1 provider with v1 state
+    const resultAgain = await v1ProviderAgain.get(mockRuntime, mockMessage, v1State);
+
+    // Verify result - note this will only be the text since fromV2Provider extracts text
+    expect(resultAgain).toBe('Provider processed state: Original state');
+  });
+
+  it('should process ActionExample through v1->v2->v1 conversion', () => {
+    // Create a v1 ActionExample
+    const v1Example: ActionExample = {
+      user: 'Test User',
+      content: {
+        text: 'Example content',
+        action: 'test-action',
+      },
+    };
+
+    // Convert to v2
+    const v2Example = toV2ActionExample(v1Example);
+
+    // Verify correct conversion
+    expect(v2Example.name).toBe('Test User');
+    expect(v2Example.content.text).toBe('Example content');
+
+    // Convert back to v1
+    const v1ExampleAgain = fromV2ActionExample(v2Example);
+
+    // Verify round-trip preservation
+    expect(v1ExampleAgain).toEqual(v1Example);
+  });
+
+  it('should process templates with state correctly', () => {
+    // Create a template
+    const template: TemplateType = ({ state }) => {
+      return `Hello ${state.userId}, your balance is ${state.walletBalance}`;
+    };
+
+    // Create a state
+    const state: State = {
+      userId,
+      agentId,
+      bio: '',
+      lore: '',
+      messageDirections: '',
+      postDirections: '',
+      actors: '',
+      recentMessages: '',
+      recentMessagesData: [],
+      walletBalance: 50,
+    };
+
+    // Process template
+    const result = processTemplate(template, state);
+
+    // Verify output
+    expect(result).toBe(`Hello ${userId}, your balance is 50`);
+  });
+});

--- a/packages/core-plugin-v1/src/__tests__/provider.test.ts
+++ b/packages/core-plugin-v1/src/__tests__/provider.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Provider } from '../provider';
+import { State } from '../state';
+import { fromV2State } from '../state';
+import { fromV2Provider, toV2Provider } from '../provider';
+import { ProviderResult } from '@elizaos/core-plugin-v2';
+
+// Define ProviderV2 interface for testing
+interface ProviderV2 {
+  name: string;
+  description?: string;
+  dynamic?: boolean;
+  position?: number;
+  private?: boolean;
+  get: (runtime: any, message: any, state: any) => Promise<any>;
+}
+
+// Mock runtime and memory for testing
+const mockRuntime = {
+  getSetting: vi.fn().mockReturnValue('test-setting'),
+  logger: { info: vi.fn(), error: vi.fn() },
+} as any;
+
+const mockMessage = {
+  id: '00000000-0000-0000-0000-000000000001',
+  roomId: '00000000-0000-0000-0000-000000000002',
+  content: { text: 'Test message' },
+} as any;
+
+describe('Provider adapter', () => {
+  it('should convert from v2 provider to v1 provider correctly', async () => {
+    // Arrange
+    const mockResult: ProviderResult = {
+      text: 'Provider result text',
+      values: { key1: 'value1', key2: 'value2' },
+      data: { dataKey: 'dataValue' },
+    };
+
+    const providerV2 = {
+      name: 'testProvider',
+      description: 'Test provider description',
+      get: vi.fn().mockResolvedValue(mockResult),
+    };
+
+    // Act
+    const providerV1 = fromV2Provider(providerV2);
+    const result = await providerV1.get(mockRuntime, mockMessage);
+
+    // Assert
+    expect(result).toEqual('Provider result text');
+    expect(providerV2.get).toHaveBeenCalledWith(mockRuntime, mockMessage, undefined);
+    expect(providerV1.name).toBe('testProvider');
+    expect(providerV1.description).toBe('Test provider description');
+  });
+
+  it('should convert from v1 provider to v2 provider correctly', async () => {
+    // Arrange
+    const mockResult = {
+      text: 'Provider result text',
+      key1: 'value1',
+      key2: 'value2',
+    };
+
+    const providerV1: Provider = {
+      name: 'v1Provider',
+      description: 'V1 provider test',
+      get: vi.fn().mockResolvedValue(mockResult),
+    };
+
+    // Act
+    const providerV2 = toV2Provider(providerV1);
+    const result = await providerV2.get(mockRuntime, mockMessage, {
+      text: '',
+      values: {},
+      data: {},
+    });
+
+    // Assert
+    expect(result).toEqual({
+      ...mockResult,
+      values: {},
+      data: {},
+      text: 'Provider result text',
+    });
+    expect(providerV1.get).toHaveBeenCalledWith(mockRuntime, mockMessage, {
+      text: '',
+      values: {},
+      data: {},
+    });
+    expect(providerV2.name).toBe('v1Provider');
+    expect(providerV2.description).toBe('V1 provider test');
+  });
+
+  it('should handle unnamed v1 providers properly', async () => {
+    // Arrange
+    const unnamedProvider: Provider = {
+      get: vi.fn().mockResolvedValue({ text: 'result' }),
+    };
+
+    // Act
+    const providerV2 = toV2Provider(unnamedProvider);
+
+    // Assert
+    expect(providerV2.name).toBe('unnamed-provider');
+    expect(providerV2.description).toBeUndefined();
+  });
+
+  it('should handle state conversion when passing to v2 provider', async () => {
+    // Arrange
+    // Create a v2 state first, then convert to v1 to ensure compatibility
+    const v2State = {
+      values: {
+        userId: '00000000-0000-0000-0000-000000000003',
+        walletBalance: 100,
+      },
+      data: {},
+      text: '',
+    };
+    const mockState = fromV2State(v2State);
+
+    const mockV2Provider = {
+      name: 'stateTestProvider',
+      get: vi.fn().mockResolvedValue({ text: 'result' }),
+    };
+
+    // Act
+    const v1Provider = fromV2Provider(mockV2Provider);
+    await v1Provider.get(mockRuntime, mockMessage, mockState);
+
+    // Assert
+    // Check that the v2 provider was called with the converted state
+    expect(mockV2Provider.get).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        values: {},
+        data: {},
+        text: '',
+        userId: '00000000-0000-0000-0000-000000000003',
+        walletBalance: 100,
+      })
+    );
+  });
+
+  it('should handle real-world provider example (TON wallet provider)', async () => {
+    // Example based on TON wallet provider from plugin-ton
+    const mockTonWalletProviderV1: Provider = {
+      name: 'tonWalletProvider',
+      get: vi.fn().mockResolvedValue({
+        text: 'You have 10.5 TON in your wallet.',
+        walletAddress: '0x123abc',
+        walletBalance: 10.5,
+        tokenPrices: { TON: 5.25 },
+      }),
+    };
+
+    // Convert to v2
+    const tonWalletProviderV2 = toV2Provider(mockTonWalletProviderV1);
+
+    // Use the v2 provider
+    const result = await tonWalletProviderV2.get(mockRuntime, mockMessage, {
+      text: 'Check my wallet',
+      values: {},
+      data: {},
+    });
+
+    // Assert the result is formatted as a proper ProviderResult
+    expect(result).toEqual({
+      walletAddress: '0x123abc',
+      walletBalance: 10.5,
+      tokenPrices: { TON: 5.25 },
+      text: 'You have 10.5 TON in your wallet.',
+      values: {},
+      data: {},
+    });
+
+    // Convert back to v1 and verify it still works
+    const tonWalletProviderV1Again = fromV2Provider(tonWalletProviderV2);
+    const resultV1 = await tonWalletProviderV1Again.get(mockRuntime, mockMessage);
+
+    expect(resultV1).toEqual('You have 10.5 TON in your wallet.');
+  });
+
+  it('should handle primitive results from V1 providers', async () => {
+    // Arrange
+    const stringProvider: Provider = {
+      name: 'stringProvider',
+      get: vi.fn().mockResolvedValue('Just a string result'),
+    };
+
+    const numberProvider: Provider = {
+      name: 'numberProvider',
+      get: vi.fn().mockResolvedValue(42),
+    };
+
+    // Act
+    const stringProviderV2 = toV2Provider(stringProvider);
+    const numberProviderV2 = toV2Provider(numberProvider);
+
+    const stringResult = await stringProviderV2.get(mockRuntime, mockMessage, {});
+    const numberResult = await numberProviderV2.get(mockRuntime, mockMessage, {});
+
+    // Assert
+    expect(stringResult).toEqual({
+      values: {},
+      data: {},
+      text: 'Just a string result',
+    });
+
+    expect(numberResult).toEqual({
+      values: {},
+      data: {},
+      text: '42',
+    });
+  });
+
+  it('should handle null or undefined results', async () => {
+    // Arrange
+    const nullProvider: Provider = {
+      name: 'nullProvider',
+      get: vi.fn().mockResolvedValue(null),
+    };
+
+    const undefinedProvider: Provider = {
+      name: 'undefinedProvider',
+      get: vi.fn().mockResolvedValue(undefined),
+    };
+
+    // Act
+    const nullProviderV2 = toV2Provider(nullProvider);
+    const undefinedProviderV2 = toV2Provider(undefinedProvider);
+
+    const nullResult = await nullProviderV2.get(mockRuntime, mockMessage, {});
+    const undefinedResult = await undefinedProviderV2.get(mockRuntime, mockMessage, {});
+
+    // Assert
+    expect(nullResult).toEqual({
+      values: {},
+      data: {},
+      text: '',
+    });
+
+    expect(undefinedResult).toEqual({
+      values: {},
+      data: {},
+      text: '',
+    });
+  });
+});

--- a/packages/core-plugin-v1/src/__tests__/state.test.ts
+++ b/packages/core-plugin-v1/src/__tests__/state.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { UUID } from '../types';
+import { State } from '../state';
+
+// Define StateV2 interface for testing
+interface StateV2 {
+  values: { [key: string]: any };
+  data: { [key: string]: any };
+  text: string;
+  [key: string]: any;
+}
+
+// Import the conversion functions
+import { fromV2State, toV2State } from '../state';
+
+// Helper function to create valid UUIDs for testing
+const createTestUUID = (num: number): UUID => {
+  return `00000000-0000-0000-0000-${num.toString().padStart(12, '0')}`;
+};
+
+// Create memory data for testing that matches expected structure
+const emptyMemoryData = [
+  {
+    id: createTestUUID(1),
+    roomId: createTestUUID(3),
+    userId: createTestUUID(4),
+    agentId: createTestUUID(5),
+    content: {
+      text: 'Test message',
+    },
+  },
+];
+
+describe('State adapter', () => {
+  it('should convert from v2 state to v1 state correctly', () => {
+    // Arrange
+    const stateV2: StateV2 = {
+      values: {
+        userId: createTestUUID(123),
+        agentName: 'TestAgent',
+      },
+      data: {
+        walletBalance: 100,
+        tokenPrices: { ETH: 2000 },
+      },
+      text: 'Current state information',
+    };
+
+    // Act
+    const stateV1 = fromV2State(stateV2);
+
+    // Assert
+    expect(stateV1.userId).toBe(createTestUUID(123));
+    expect(stateV1.agentName).toBe('TestAgent');
+    expect(stateV1.walletBalance).toBe(100);
+    expect(stateV1.tokenPrices).toEqual({ ETH: 2000 });
+    expect(stateV1.text).toBe('Current state information');
+    // Check that default properties are set
+    expect(stateV1.bio).toBe('');
+    expect(stateV1.lore).toBe('');
+    expect(stateV1.messageDirections).toBe('');
+    expect(stateV1.postDirections).toBe('');
+    expect(stateV1.recentMessagesData).toEqual([]);
+    expect(stateV1.actors).toBe('');
+  });
+
+  it('should convert from v1 state to v2 state correctly', () => {
+    // Arrange
+    const stateV1: State = {
+      userId: createTestUUID(123),
+      agentName: 'TestAgent',
+      walletBalance: 100,
+      tokenPrices: { ETH: 2000 },
+      text: 'Current state information',
+      recentMessages: 'Some recent messages',
+      recentMessagesData: emptyMemoryData,
+      bio: 'Agent bio',
+      lore: 'Agent lore',
+      messageDirections: 'Handle messages this way',
+      postDirections: 'Handle posts this way',
+      roomId: createTestUUID(456),
+      actors: 'User, Agent',
+    };
+
+    // Act
+    const stateV2 = toV2State(stateV1);
+
+    // Assert
+    expect(stateV2.values).toBeDefined();
+    expect(stateV2.data).toBeDefined();
+    expect(stateV2.text).toBe('Current state information');
+
+    // The original properties should be preserved
+    expect(stateV2.userId).toBe(createTestUUID(123));
+    expect(stateV2.agentName).toBe('TestAgent');
+    expect(stateV2.bio).toBe('Agent bio');
+    expect(stateV2.lore).toBe('Agent lore');
+    expect(stateV2.recentMessagesData).toEqual(emptyMemoryData);
+  });
+
+  it('should handle empty or undefined values', () => {
+    // Arrange
+    const emptyV2: StateV2 = {
+      values: {},
+      data: {},
+      text: '',
+    };
+
+    // Act
+    const emptyV1 = fromV2State(emptyV2);
+    const backToV2 = toV2State(emptyV1);
+
+    // Assert
+    expect(emptyV1).toEqual({
+      bio: '',
+      lore: '',
+      messageDirections: '',
+      postDirections: '',
+      actors: '',
+      recentMessages: '',
+      recentMessagesData: [],
+      text: '',
+    });
+
+    expect(backToV2).toEqual({
+      values: {},
+      data: {},
+      text: '',
+      bio: '',
+      lore: '',
+      messageDirections: '',
+      postDirections: '',
+      actors: '',
+      recentMessages: '',
+      recentMessagesData: [],
+    });
+  });
+
+  it('should handle additional properties from real-world plugins', () => {
+    // Example from plugin-ton (row 102 in CSV)
+    const tonStateV1: State = {
+      userId: createTestUUID(123),
+      agentName: 'TonBot',
+      walletAddress: '0x123abc',
+      walletBalance: 10.5,
+      stakedAmount: 5.25,
+      lastTransaction: '2023-04-01',
+      roomId: createTestUUID(456),
+      recentMessages: 'Recent messages here',
+      recentMessagesData: emptyMemoryData,
+      bio: 'TON blockchain assistant',
+      lore: 'Helps with TON transactions',
+      messageDirections: 'Handle DMs from users',
+      postDirections: 'Post updates about TON',
+      actors: 'User, TonBot',
+      text: 'Current state',
+    };
+
+    // Convert to v2 and back
+    const tonStateV2 = toV2State(tonStateV1);
+    const tonStateV1Again = fromV2State(tonStateV2);
+
+    // Original properties should be preserved through the round trip
+    expect(tonStateV1Again.walletAddress).toBe('0x123abc');
+    expect(tonStateV1Again.walletBalance).toBe(10.5);
+    expect(tonStateV1Again.stakedAmount).toBe(5.25);
+    expect(tonStateV1Again.lastTransaction).toBe('2023-04-01');
+    expect(tonStateV1Again.recentMessagesData).toEqual(emptyMemoryData);
+  });
+});

--- a/packages/core-plugin-v1/src/__tests__/templates.test.ts
+++ b/packages/core-plugin-v1/src/__tests__/templates.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from 'vitest';
+import { State } from '../state';
+import {
+  TemplateType,
+  TemplateValues,
+  createTemplateFunction,
+  getTemplateValues,
+  processTemplate,
+} from '../templates';
+
+// Define a type-safe interface for our test template values
+interface UserTemplateValues extends TemplateValues {
+  age: number;
+  location: string;
+  isActive?: boolean;
+}
+
+describe('Templates Module', () => {
+  describe('TemplateType', () => {
+    it('should allow string templates', () => {
+      const template: TemplateType = 'Hello, world!';
+      expect(typeof template).toBe('string');
+    });
+
+    it('should allow function templates', () => {
+      const template: TemplateType = ({ state }) => `Hello, ${state.userName}!`;
+      expect(typeof template).toBe('function');
+    });
+  });
+
+  describe('createTemplateFunction', () => {
+    it('should handle string templates', () => {
+      const template: TemplateType = 'Hello, world!';
+      const templateFunction = createTemplateFunction(template);
+
+      const state: State = {
+        userId: '12345678-1234-1234-1234-123456789012',
+        userName: 'John',
+        values: {},
+      };
+
+      expect(typeof templateFunction).toBe('function');
+      expect(templateFunction(state)).toBe('Hello, world!');
+    });
+
+    it('should handle function templates', () => {
+      const template: TemplateType = ({ state }) => `Hello, ${state.userName}!`;
+      const templateFunction = createTemplateFunction(template);
+
+      const state: State = {
+        userId: '12345678-1234-1234-1234-123456789012',
+        userName: 'John',
+        values: {},
+      };
+
+      expect(typeof templateFunction).toBe('function');
+      expect(templateFunction(state)).toBe('Hello, John!');
+    });
+
+    it('should handle null/undefined state', () => {
+      const template: TemplateType = ({ state }) => `Hello, ${state?.userName || 'Guest'}!`;
+      const templateFunction = createTemplateFunction(template);
+
+      // @ts-ignore - Testing null state
+      const result = templateFunction(null);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('processTemplate', () => {
+    it('should process string templates', () => {
+      const template: TemplateType = 'Hello, world!';
+      const state: State = {
+        userId: '12345678-1234-1234-1234-123456789012',
+        userName: 'John',
+        values: {},
+      };
+
+      const result = processTemplate(template, state);
+      expect(result).toBe('Hello, world!');
+    });
+
+    it('should process function templates', () => {
+      const template: TemplateType = ({ state }) => `Hello, ${state.userName}!`;
+      const state: State = {
+        userId: '12345678-1234-1234-1234-123456789012',
+        userName: 'John',
+        values: {},
+      };
+
+      const result = processTemplate(template, state);
+      expect(result).toBe('Hello, John!');
+    });
+
+    it('should handle null/undefined templates', () => {
+      const state: State = {
+        userId: '12345678-1234-1234-1234-123456789012',
+        userName: 'John',
+        values: {},
+      };
+
+      // @ts-ignore - Testing null template
+      const result = processTemplate(null, state);
+      expect(result).toBe('');
+    });
+
+    it('should handle null/undefined state', () => {
+      const stringTemplate: TemplateType = 'Static content';
+      const fnTemplate: TemplateType = ({ state }) => `Hello, ${state?.userName || 'Guest'}!`;
+
+      // @ts-ignore - Testing null state
+      const result1 = processTemplate(stringTemplate, null);
+      // @ts-ignore - Testing null state
+      const result2 = processTemplate(fnTemplate, null);
+
+      expect(result1).toBe('Static content');
+      expect(result2).toBe('');
+    });
+  });
+
+  describe('getTemplateValues', () => {
+    it('should provide type-safe access to state values', () => {
+      const state: State = {
+        userId: '12345678-1234-1234-1234-123456789012',
+        userName: 'John',
+        values: {
+          age: 30,
+          location: 'New York',
+          isActive: true,
+        },
+      };
+
+      const values = getTemplateValues<UserTemplateValues>(state);
+
+      expect(values.age).toBe(30);
+      expect(values.location).toBe('New York');
+      expect(values.isActive).toBe(true);
+    });
+
+    it('should apply default values when properties are missing', () => {
+      const state: State = {
+        userId: '12345678-1234-1234-1234-123456789012',
+        userName: 'John',
+        values: {
+          // age is missing
+          location: 'New York',
+        },
+      };
+
+      const values = getTemplateValues<UserTemplateValues>(state, {
+        age: 25,
+        isActive: false,
+      });
+
+      expect(values.age).toBe(25); // Default value
+      expect(values.location).toBe('New York'); // From state
+      expect(values.isActive).toBe(false); // Default value
+    });
+
+    it('should handle null/undefined state', () => {
+      // @ts-ignore - Testing null state
+      const values = getTemplateValues<UserTemplateValues>(null, {
+        age: 0,
+        location: 'Unknown',
+      });
+
+      expect(values.age).toBe(0);
+      expect(values.location).toBe('Unknown');
+    });
+
+    it('should handle null/undefined values in state', () => {
+      const state: State = {
+        userId: '12345678-1234-1234-1234-123456789012',
+        userName: 'John',
+        // values is missing
+      };
+
+      const values = getTemplateValues<UserTemplateValues>(state, {
+        age: 0,
+        location: 'Unknown',
+      });
+
+      expect(values.age).toBe(0);
+      expect(values.location).toBe('Unknown');
+    });
+  });
+
+  describe('Integration', () => {
+    it('should use getTemplateValues with processTemplate', () => {
+      const template: TemplateType = ({ state }) => {
+        const values = getTemplateValues<UserTemplateValues>(state, {
+          age: 0,
+          location: 'Unknown',
+        });
+        return `User: ${state.userName}, Age: ${values.age}, Location: ${values.location}`;
+      };
+
+      const state: State = {
+        userId: '12345678-1234-1234-1234-123456789012',
+        userName: 'John',
+        values: {
+          age: 30,
+          location: 'New York',
+        },
+      };
+
+      const result = processTemplate(template, state);
+      expect(result).toBe('User: John, Age: 30, Location: New York');
+    });
+  });
+});

--- a/packages/core-plugin-v1/src/__tests__/uuid.test.ts
+++ b/packages/core-plugin-v1/src/__tests__/uuid.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { asUUID, UUID } from '../uuid';
+
+describe('UUID Module', () => {
+  describe('UUID Type', () => {
+    it('should define UUID as a string type with specific format', () => {
+      // This is a type-level test, no runtime assertions necessary
+      // Just checking that we can assign a properly formatted string to the UUID type
+      const validUUID: UUID = '123e4567-e89b-12d3-a456-426614174000';
+      expect(validUUID).toBeDefined();
+      expect(typeof validUUID).toBe('string');
+    });
+  });
+
+  describe('asUUID function', () => {
+    it('should accept valid UUIDs and normalize to lowercase', () => {
+      const validUUIDStrings = [
+        '123e4567-e89b-12d3-a456-426614174000',
+        'a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8',
+        '00000000-0000-0000-0000-000000000000',
+        'FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF', // Mixed case test
+        'AbCdEf12-3456-7890-aBcD-eF1234567890', // Mixed case test
+      ];
+
+      validUUIDStrings.forEach((validUUID) => {
+        const result = asUUID(validUUID);
+        // The function should normalize to lowercase
+        expect(result).toBe(validUUID.toLowerCase());
+      });
+    });
+
+    it('should reject invalid UUIDs', () => {
+      const invalidUUIDStrings = [
+        '', // Empty string
+        '123e4567', // Too short
+        '123e4567-e89b-12d3-a456-4266141740001', // Too long
+        '123e4567-e89b-12d3-a456-42661417400g', // Invalid character
+        '123e4567_e89b_12d3_a456_426614174000', // Invalid separator
+        '123e4567-e89b-12d3-a456-4266-14174000', // Wrong format (too many segments)
+        '123e4567-e89b-12d3-a456', // Missing segment
+        null, // Null
+        undefined, // Undefined
+        // Additional cases to test edge cases
+        'gggggggg-gggg-gggg-gggg-gggggggggggg', // All non-hex characters
+        '123456789-1234-1234-1234-123456789012', // Too many digits in first group
+      ];
+
+      invalidUUIDStrings.forEach((invalidUUID) => {
+        expect(() => asUUID(invalidUUID as any)).toThrow('Invalid UUID format');
+      });
+    });
+
+    it('should convert uppercase UUIDs to lowercase', () => {
+      const uppercaseUUID = 'ABCDEF12-3456-7890-ABCD-EF1234567890';
+      const expectedLowercase = 'abcdef12-3456-7890-abcd-ef1234567890';
+
+      const result = asUUID(uppercaseUUID);
+      expect(result).toBe(expectedLowercase);
+    });
+
+    it('should return a branded UUID type', () => {
+      const uuidStr = '123e4567-e89b-12d3-a456-426614174000';
+      const result = asUUID(uuidStr);
+
+      // This is a type-level test, but we can still check the runtime behavior
+      expect(result).toBe(uuidStr); // Already lowercase, so no change
+      expect(typeof result).toBe('string');
+    });
+
+    it('should handle UUIDs with version and variant bits correctly', () => {
+      // UUID version 4 (random) has a specific format for the 13th character (should be 4)
+      // and 17th character (should be 8, 9, a, or b)
+      const uuidV4 = '123e4567-e89b-42d3-a456-426614174000';
+      const result = asUUID(uuidV4);
+      expect(result).toBe(uuidV4);
+      expect(result.charAt(14)).toBe('4'); // 13th character is position 14 in the string (0-indexed)
+    });
+  });
+});

--- a/packages/core-plugin-v1/src/actionExample.ts
+++ b/packages/core-plugin-v1/src/actionExample.ts
@@ -1,0 +1,91 @@
+import { Content, ActionExample as ActionExampleFromTypes } from './types';
+import { ActionExample as ActionExampleV2, Content as ContentV2 } from '@elizaos/core-plugin-v2';
+
+/**
+ * Example content with associated user for demonstration purposes
+ * This is exported from types.ts in v1, but we're recreating it here for the adapter
+ */
+export type ActionExample = ActionExampleFromTypes;
+
+/**
+ * Safely converts a V2 content object to a V1 Content type
+ * Maps known properties and preserves additional ones
+ *
+ * @param content V2 content object
+ * @returns Content compatible with V1
+ */
+export function convertContentToV1(content: ContentV2): Content {
+  if (!content) {
+    return { text: '' } as Content;
+  }
+
+  return {
+    text: content.text || '',
+    // V2 uses 'actions' array, V1 might use 'action' string
+    action:
+      Array.isArray(content.actions) && content.actions.length > 0 ? content.actions[0] : undefined,
+    // Copy all other properties
+    ...Object.entries(content)
+      .filter(([key]) => !['text', 'actions', 'action'].includes(key))
+      .reduce((obj, [key, value]) => ({ ...obj, [key]: value }), {}),
+  } as Content;
+}
+
+/**
+ * Safely converts a V1 Content object to a V2 compatible content type
+ * Maps known properties and preserves additional ones
+ *
+ * @param content V1 Content object
+ * @returns Content compatible with V2
+ */
+export function convertContentToV2(content: Content): ContentV2 {
+  if (!content) {
+    return { text: '' } as ContentV2;
+  }
+
+  return {
+    text: content.text || '',
+    // V1 uses 'action' string, V2 uses 'actions' array
+    actions: content.action ? [content.action] : [],
+    // Copy all other properties
+    ...Object.entries(content)
+      .filter(([key]) => !['text', 'action'].includes(key))
+      .reduce((obj, [key, value]) => ({ ...obj, [key]: value }), {}),
+  } as ContentV2;
+}
+
+/**
+ * Converts v2 ActionExample to v1 compatible ActionExample
+ *
+ * @param exampleV2 The V2 action example to convert
+ * @returns V1 compatible ActionExample
+ */
+export function fromV2ActionExample(exampleV2: ActionExampleV2): ActionExample {
+  if (!exampleV2) {
+    return { user: '', content: { text: '' } as Content };
+  }
+
+  // The main difference is that v2 uses 'name' instead of 'user'
+  return {
+    user: exampleV2.name || '',
+    content: convertContentToV1(exampleV2.content),
+  };
+}
+
+/**
+ * Converts v1 ActionExample to v2 ActionExample
+ *
+ * @param example The V1 action example to convert
+ * @returns V2 compatible ActionExample
+ */
+export function toV2ActionExample(example: ActionExample): ActionExampleV2 {
+  if (!example) {
+    return { name: '', content: { text: '' } as ContentV2 };
+  }
+
+  // Convert v1 format to v2 format
+  return {
+    name: example.user || '',
+    content: convertContentToV2(example.content),
+  };
+}

--- a/packages/core-plugin-v1/src/index.ts
+++ b/packages/core-plugin-v1/src/index.ts
@@ -1,0 +1,71 @@
+// this just imported dotenv, settings will handle wrapping this
+//import "./config.ts"; // Add this line first
+
+/*
+export * from "./actions.ts";
+export * from "./context.ts";
+export * from "./database.ts";
+export * from "./embedding.ts";
+export * from "./evaluators.ts";
+export * from "./generation.ts";
+export * from "./goals.ts";
+export * from "./memory.ts";
+*/
+export * from './messages.ts';
+//export * from "./models.ts";
+export * from './posts.ts';
+//export * from "./providers.ts";
+//export * from "./relationships.ts";
+export * from './runtime.ts';
+/*
+export * from "./settings.ts";
+export * from "./types.ts";
+export * from "./logger.ts";
+export * from "./parsing.ts";
+export * from "./uuid.ts";
+export * from "./environment.ts";
+export * from "./cache.ts";
+export { default as knowledge } from "./knowledge.ts";
+export * from "./ragknowledge.ts";
+export * from "./utils.ts";
+*/
+
+// This is the entrypoint for the core-plugin-v1 package
+// It exports everything needed for v1 plugin compatibility
+
+// Core types
+export * from './types.ts';
+
+// Adapters created for v1 -> v2 compatibility
+// Export only the adapter functions and V1 types to avoid conflicts
+export { fromV2State, toV2State, State } from './state.ts';
+
+export { asUUID, generateUuidFromString } from './uuid.ts';
+
+export {
+  fromV2ActionExample,
+  toV2ActionExample,
+  ActionExample,
+  convertContentToV1,
+  convertContentToV2,
+} from './actionExample.ts';
+
+export { fromV2Provider, toV2Provider, Provider } from './provider.ts';
+
+export {
+  createTemplateFunction,
+  processTemplate,
+  getTemplateValues,
+  TemplateType,
+} from './templates.ts';
+
+// Existing exports
+export * from './messages.ts';
+export * from './posts.ts';
+export * from './runtime.ts';
+
+// TODO: Implement the remaining adapters:
+// - action/handler
+// - database
+// - knowledge / memory
+// - relationships

--- a/packages/core-plugin-v1/src/messages.ts
+++ b/packages/core-plugin-v1/src/messages.ts
@@ -1,0 +1,42 @@
+import {
+  formatMessages as coreFormatMessages,
+  formatTimestamp as coreFormatTimestamp,
+} from '@elizaos/core-plugin-v2';
+
+import type { IAgentRuntime, Actor, Content, Memory, UUID } from './types.ts';
+
+/**
+ * Get details for a list of actors.
+ */
+export async function getActorDetails({
+  runtime,
+  roomId,
+}: {
+  runtime: IAgentRuntime;
+  roomId: UUID;
+}) {
+  // WRITE ME
+}
+
+/**
+ * Format actors into a string
+ * @param actors - list of actors
+ * @returns string
+ */
+export function formatActors({ actors }: { actors: Actor[] }) {
+  // WRITE ME
+}
+
+/**
+ * Format messages into a string
+ * @param messages - list of messages
+ * @param actors - list of actors
+ * @returns string
+ */
+export const formatMessages = ({ messages, actors }: { messages: Memory[]; actors: Actor[] }) => {
+  return coreFormatMessages(message, actors);
+};
+
+export const formatTimestamp = (messageDate: number) => {
+  return coreFormatTimestamp(messageDate);
+};

--- a/packages/core-plugin-v1/src/posts.ts
+++ b/packages/core-plugin-v1/src/posts.ts
@@ -1,0 +1,14 @@
+import type { Actor, Memory } from './types.ts';
+import { formatPosts as coreFormatPosts } from '@elizaos/core-plugin-v2';
+
+export const formatPosts = ({
+  messages,
+  actors,
+  conversationHeader = true,
+}: {
+  messages: Memory[];
+  actors: Actor[];
+  conversationHeader?: boolean;
+}) => {
+  return coreFormatPosts(messages, actors, conversationHeader);
+};

--- a/packages/core-plugin-v1/src/provider.ts
+++ b/packages/core-plugin-v1/src/provider.ts
@@ -1,0 +1,79 @@
+import { IAgentRuntime, Memory, State, Provider as ProviderFromTypes } from './types';
+import { toV2State } from './state';
+import { Provider as ProviderV2, ProviderResult } from '@elizaos/core-plugin-v2';
+
+/**
+ * Provider for external data/services
+ * This is a v1 compatibility wrapper for v2 Provider
+ */
+export type Provider = ProviderFromTypes;
+
+/**
+ * Converts v2 Provider to v1 compatible Provider
+ * Uses the V2 Provider interface to ensure proper optional field handling
+ */
+export function fromV2Provider(providerV2: ProviderV2): Provider {
+  return {
+    name: providerV2.name,
+    description: providerV2.description,
+    dynamic: providerV2.dynamic,
+    position: providerV2.position,
+    private: providerV2.private,
+    get: async (runtime: IAgentRuntime, message: Memory, state?: State) => {
+      // Convert v1 state to v2 state if provided
+      const stateV2 = state ? toV2State(state) : undefined;
+
+      try {
+        // Call the v2 provider with transformed parameters
+        const result = await providerV2.get(runtime as any, message as any, stateV2 as any);
+
+        // Extract text or use an empty string if not present
+        return result.text || '';
+      } catch (error) {
+        console.error(`Error in v2 provider ${providerV2.name}:`, error);
+        throw error;
+      }
+    },
+  };
+}
+
+/**
+ * Converts v1 Provider to v2 Provider
+ * Creates a Provider object conforming to V2 Provider interface
+ */
+export function toV2Provider(provider: Provider): ProviderV2 {
+  return {
+    name: provider.name || 'unnamed-provider',
+    description: provider.description,
+    dynamic: provider.dynamic,
+    position: provider.position,
+    private: provider.private,
+    get: async (runtime: any, message: any, state: any): Promise<ProviderResult> => {
+      try {
+        // Call the v1 provider directly
+        const result = await provider.get(runtime, message, state);
+
+        // Format according to V2 ProviderResult
+        if (typeof result === 'object' && result !== null) {
+          // For objects, preserve all properties for full compatibility
+          return {
+            ...result,
+            values: result.values || {},
+            data: result.data || {},
+            text: result.text || '',
+          };
+        }
+
+        // For primitive results, return as text
+        return {
+          values: {},
+          data: {},
+          text: String(result || ''),
+        };
+      } catch (error) {
+        console.error(`Error in v1 provider ${provider.name || 'unnamed'}:`, error);
+        throw error;
+      }
+    },
+  };
+}

--- a/packages/core-plugin-v1/src/runtime.ts
+++ b/packages/core-plugin-v1/src/runtime.ts
@@ -1,0 +1,297 @@
+import { AgentRuntime as coreAgentRuntime } from '@elizaos/core-plugin-v2';
+import {
+  type Character,
+  type Goal,
+  type HandlerCallback,
+  type IAgentRuntime,
+  type ICacheManager,
+  type IDatabaseAdapter,
+  type IMemoryManager,
+  type IRAGKnowledgeManager,
+  // type IVerifiableInferenceAdapter,
+  type KnowledgeItem,
+  // RAGKnowledgeItem,
+  //Media,
+  ModelClass,
+  ModelProviderName,
+  type Plugin,
+  type Provider,
+  type Adapter,
+  type Service,
+  type ServiceType,
+  type State,
+  type UUID,
+  type Action,
+  type Actor,
+  type Evaluator,
+  type Memory,
+  type DirectoryItem,
+  type ClientInstance,
+} from './types.ts';
+
+import { formatMessages } from './messages.ts';
+
+export class AgentRuntime implements IAgentRuntime {
+  private _runtime;
+  registerMemoryManager(manager: IMemoryManager): void {
+    // WRITE ME
+  }
+  getMemoryManager(tableName: string): IMemoryManager | null {
+    // WRITE ME
+  }
+  getService<T extends Service>(service: ServiceType): T | null {
+    return this._runtime.getService(service);
+  }
+  async registerService(service: Service): Promise<void> {
+    return this._runtime.registerService(service);
+  }
+
+  /**
+   * Creates an instance of AgentRuntime.
+   * @param opts - The options for configuring the AgentRuntime.
+   * @param opts.conversationLength - The number of messages to hold in the recent message cache.
+   * @param opts.token - The JWT token, can be a JWT token if outside worker, or an OpenAI token if inside worker.
+   * @param opts.serverUrl - The URL of the worker.
+   * @param opts.actions - Optional custom actions.
+   * @param opts.evaluators - Optional custom evaluators.
+   * @param opts.services - Optional custom services.
+   * @param opts.memoryManagers - Optional custom memory managers.
+   * @param opts.providers - Optional context providers.
+   * @param opts.model - The model to use for generateText.
+   * @param opts.embeddingModel - The model to use for embedding.
+   * @param opts.agentId - Optional ID of the agent.
+   * @param opts.databaseAdapter - The database adapter used for interacting with the database.
+   * @param opts.fetch - Custom fetch function to use for making requests.
+   */
+  constructor(opts: {
+    conversationLength?: number; // number of messages to hold in the recent message cache
+    agentId?: UUID; // ID of the agent
+    character?: Character; // The character to use for the agent
+    token: string; // JWT token, can be a JWT token if outside worker, or an OpenAI token if inside worker
+    serverUrl?: string; // The URL of the worker
+    actions?: Action[]; // Optional custom actions
+    evaluators?: Evaluator[]; // Optional custom evaluators
+    plugins?: Plugin[];
+    providers?: Provider[];
+    modelProvider: ModelProviderName;
+
+    services?: Service[]; // Map of service name to service instance
+    managers?: IMemoryManager[]; // Map of table name to memory manager
+    databaseAdapter?: IDatabaseAdapter; // The database adapter used for interacting with the database
+    fetch?: typeof fetch | unknown;
+    speechModelPath?: string;
+    cacheManager?: ICacheManager;
+    logging?: boolean;
+    // verifiableInferenceAdapter?: IVerifiableInferenceAdapter;
+  }) {
+    this._runtime = new coreAgentRuntime(opts);
+  }
+
+  //private async initializeDatabase() {}
+
+  async initialize() {
+    return this._runtime.initialize();
+  }
+
+  async stop() {
+    return this._runtime.stop();
+  }
+
+  getSetting(key: string) {
+    return this._runtime.getSetting(key);
+  }
+
+  /**
+   * Get the number of messages that are kept in the conversation buffer.
+   * @returns The number of recent messages to be kept in memory.
+   */
+  getConversationLength() {
+    return this._runtime.getConversationLength();
+  }
+
+  /**
+   * Register an action for the agent to perform.
+   * @param action The action to register.
+   */
+  registerAction(action: Action) {
+    return this._runtime.registerAction(action);
+  }
+
+  /**
+   * Register an evaluator to assess and guide the agent's responses.
+   * @param evaluator The evaluator to register.
+   */
+  registerEvaluator(evaluator: Evaluator) {
+    return this._runtime.registerEvaluator(evaluator);
+  }
+
+  /**
+   * Register a context provider to provide context for message generation.
+   * @param provider The context provider to register.
+   */
+  registerContextProvider(provider: Provider) {
+    return this._runtime.registerContextProvider(provider);
+  }
+
+  /**
+   * Register an adapter for the agent to use.
+   * @param adapter The adapter to register.
+   */
+  registerAdapter(adapter: Adapter) {
+    // WRITE ME, maybe...
+  }
+
+  /**
+   * Process the actions of a message.
+   * @param message The message to process.
+   * @param content The content of the message to process actions from.
+   */
+  async processActions(
+    message: Memory,
+    responses: Memory[],
+    state?: State,
+    callback?: HandlerCallback
+  ): Promise<void> {
+    return this._runtime.processActions(message, responses, state, callback);
+  }
+
+  /**
+   * Evaluate the message and state using the registered evaluators.
+   * @param message The message to evaluate.
+   * @param state The state of the agent.
+   * @param didRespond Whether the agent responded to the message.~
+   * @param callback The handler callback
+   * @returns The results of the evaluation.
+   */
+  async evaluate(message: Memory, state: State, didRespond?: boolean, callback?: HandlerCallback) {
+    // v2 now takes responses: Memory[]
+    return this._runtime.evaluate(message, state, didRespond, callback);
+  }
+
+  /**
+   * Ensure the existence of a participant in the room. If the participant does not exist, they are added to the room.
+   * @param userId - The user ID to ensure the existence of.
+   * @throws An error if the participant cannot be added.
+   */
+  async ensureParticipantExists(userId: UUID, roomId: UUID) {
+    // WRITE ME
+  }
+
+  /**
+   * Ensure the existence of a user in the database. If the user does not exist, they are added to the database.
+   * @param userId - The user ID to ensure the existence of.
+   * @param userName - The user name to ensure the existence of.
+   * @returns
+   */
+  async ensureUserExists(
+    userId: UUID,
+    userName: string | null,
+    name: string | null,
+    email?: string | null,
+    source?: string | null
+  ) {}
+
+  async ensureParticipantInRoom(userId: UUID, roomId: UUID) {
+    return this._runtime.ensureParticipantInRoom(userId, roomId);
+  }
+
+  async ensureConnection(
+    userId: UUID,
+    roomId: UUID,
+    userName?: string,
+    userScreenName?: string,
+    source?: string
+  ) {
+    return this._runtime.ensureConnection(userId, roomId, userName, userScreenname, source);
+  }
+
+  /**
+   * Ensure the existence of a room between the agent and a user. If no room exists, a new room is created and the user
+   * and agent are added as participants. The room ID is returned.
+   * @param roomId - The room ID to create a room with.
+   * @returns The room ID of the room between the agent and the user.
+   * @throws An error if the room cannot be created.
+   */
+  async ensureRoomExists(roomId: UUID) {
+    return this._runtime.ensureRoomExists({
+      id: roomId,
+      name: 'Unknown',
+      source: 'Unknown',
+      type: 'Unknown',
+      chanenlId: roomId,
+      serverId: 0,
+      worldId: 0,
+      metadata: {},
+    });
+  }
+
+  /**
+   * Compose the state of the agent into an object that can be passed or used for response generation.
+   * @param message The message to compose the state from.
+   * @returns The state of the agent.
+   */
+  async composeState(message: Memory, additionalKeys: { [key: string]: unknown } = {}) {
+    return this._runtime.composeState(message, [], []);
+  }
+
+  async updateRecentMessageState(state: State): Promise<State> {
+    const conversationLength = this.getConversationLength();
+
+    // get memories
+    this._runtime.getMemories({
+      roomId: state.roomId,
+      count: conversationLength,
+      unique: false,
+    });
+
+    // use v1 formatMessage
+    const recentMessages = formatMessages({
+      actors: state.actorsData ?? [],
+      messages: recentMessagesData.map((memory: Memory) => {
+        const newMemory = { ...memory };
+        delete newMemory.embedding;
+        return newMemory;
+      }),
+    });
+
+    let allAttachments = [];
+
+    if (recentMessagesData && Array.isArray(recentMessagesData)) {
+      const lastMessageWithAttachment = recentMessagesData.find(
+        (msg) => msg.content.attachments && msg.content.attachments.length > 0
+      );
+
+      if (lastMessageWithAttachment) {
+        const lastMessageTime = lastMessageWithAttachment?.createdAt ?? Date.now();
+        const oneHourBeforeLastMessage = lastMessageTime - 60 * 60 * 1000; // 1 hour before last message
+
+        allAttachments = recentMessagesData
+          .filter((msg) => {
+            const msgTime = msg.createdAt ?? Date.now();
+            return msgTime >= oneHourBeforeLastMessage;
+          })
+          .flatMap((msg) => msg.content.attachments || []);
+      }
+    }
+
+    const formattedAttachments = allAttachments
+      .map(
+        (attachment) =>
+          `ID: ${attachment.id}
+Name: ${attachment.title}
+URL: ${attachment.url}
+Type: ${attachment.source}
+Description: ${attachment.description}
+Text: ${attachment.text}
+    `
+      )
+      .join('\n');
+
+    return {
+      ...state,
+      recentMessages: addHeader('# Conversation Messages', recentMessages),
+      recentMessagesData,
+      attachments: formattedAttachments,
+    } as State;
+  }
+}

--- a/packages/core-plugin-v1/src/state.ts
+++ b/packages/core-plugin-v1/src/state.ts
@@ -1,0 +1,66 @@
+import { UUID, State as StateFromTypes } from './types';
+import { State as StateV2 } from '@elizaos/core-plugin-v2';
+
+/**
+ * Represents the state of a conversation or context
+ * This is a v1 compatibility wrapper for v2 State
+ */
+export type State = StateFromTypes;
+
+/**
+ * Default empty state with required properties
+ */
+const DEFAULT_STATE: Partial<State> = {
+  bio: '',
+  lore: '',
+  messageDirections: '',
+  postDirections: '',
+  actors: '',
+  recentMessages: '',
+  recentMessagesData: [],
+};
+
+/**
+ * Converts v2 State to v1 compatible State
+ * Uses the V2 State interface from core-plugin-v2
+ */
+export function fromV2State(stateV2: StateV2): State {
+  // Create a new state object starting with default values
+  const state: State = {
+    ...DEFAULT_STATE,
+    ...stateV2.values,
+    ...stateV2.data,
+    text: stateV2.text,
+  };
+
+  // Add any other properties from the v2 state
+  for (const key in stateV2) {
+    if (key !== 'values' && key !== 'data' && key !== 'text') {
+      state[key] = stateV2[key];
+    }
+  }
+
+  return state;
+}
+
+/**
+ * Converts v1 State to v2 State
+ * Creates a state object conforming to V2 State interface
+ */
+export function toV2State(state: State): StateV2 {
+  // Create a base v2 state structure
+  const stateV2: StateV2 = {
+    values: {},
+    data: {},
+    text: state.text || '',
+  };
+
+  // Add any properties from v1 state as-is to preserve them
+  for (const key in state) {
+    if (key !== 'text') {
+      stateV2[key] = state[key];
+    }
+  }
+
+  return stateV2;
+}

--- a/packages/core-plugin-v1/src/templates.ts
+++ b/packages/core-plugin-v1/src/templates.ts
@@ -1,0 +1,84 @@
+import { State } from './state';
+import { TemplateType as TemplateTypeV2 } from '@elizaos/core-plugin-v2';
+
+/**
+ * Template type definition for v1 compatibility
+ * A template can be either a string or a function that takes state and returns a string
+ * This aligns with V2's TemplateType
+ */
+export type TemplateType = string | ((options: { state: State }) => string);
+
+/**
+ * Generic template values interface for typed access to state.values
+ * Users can extend this interface for type safety in their templates
+ */
+export interface TemplateValues {
+  [key: string]: unknown;
+}
+
+/**
+ * Create a template function from a v1 template
+ * @param template The v1 template (string or function)
+ * @returns A function that processes the template with the given state
+ */
+export function createTemplateFunction(template: TemplateType): (state: State) => string {
+  if (typeof template === 'string') {
+    // For string templates, just return the string
+    return () => template;
+  } else {
+    // For function templates, wrap it to match the expected signature
+    return (state: State) => {
+      // Handle null or undefined state
+      if (!state) {
+        return '';
+      }
+      return template({ state });
+    };
+  }
+}
+
+/**
+ * Process a template with the given state
+ * @param template The template to process (string or function)
+ * @param state The state to use for processing
+ * @returns The processed template string
+ */
+export function processTemplate(template: TemplateType, state: State): string {
+  // Handle null/undefined template
+  if (!template) {
+    return '';
+  }
+
+  // Handle null/undefined state
+  if (!state) {
+    return typeof template === 'string' ? template : '';
+  }
+
+  if (typeof template === 'string') {
+    return template;
+  } else {
+    return template({ state });
+  }
+}
+
+/**
+ * Type-safe accessor for template values
+ * @param state The state containing the values
+ * @param defaultValues Optional default values to use if values are missing
+ * @returns The values object with type information
+ */
+export function getTemplateValues<T extends TemplateValues>(
+  state: State,
+  defaultValues?: Partial<T>
+): T {
+  if (!state || !state.values) {
+    return (defaultValues || {}) as T;
+  }
+
+  // First cast state.values to a valid object type to use with spread
+  const stateValues = state.values as Record<string, unknown>;
+  const defaults = defaultValues || ({} as Partial<T>);
+
+  // Create a new object with both default values and state values
+  return { ...defaults, ...stateValues } as T;
+}

--- a/packages/core-plugin-v1/src/types.ts
+++ b/packages/core-plugin-v1/src/types.ts
@@ -1,0 +1,1602 @@
+import type { Readable } from 'stream';
+
+/**
+ * Represents a UUID string in the format "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+ */
+export type UUID = `${string}-${string}-${string}-${string}-${string}`;
+
+/**
+ * Represents the content of a message or communication
+ */
+export interface Content {
+  /** The main text content */
+  text: string;
+
+  /** Optional action associated with the message */
+  action?: string;
+
+  /** Optional source/origin of the content */
+  source?: string;
+
+  /** URL of the original message/post (e.g. tweet URL, Discord message link) */
+  url?: string;
+
+  /** UUID of parent message if this is a reply/thread */
+  inReplyTo?: UUID;
+
+  /** Array of media attachments */
+  attachments?: Media[];
+
+  /** Additional dynamic properties */
+  [key: string]: unknown;
+}
+
+/**
+ * Example content with associated user for demonstration purposes
+ */
+export interface ActionExample {
+  /** User associated with the example */
+  user: string;
+
+  /** Content of the example */
+  content: Content;
+}
+
+/**
+ * Example conversation content with user ID
+ */
+export interface ConversationExample {
+  /** UUID of user in conversation */
+  userId: UUID;
+
+  /** Content of the conversation */
+  content: Content;
+}
+
+/**
+ * Represents an actor/participant in a conversation
+ */
+export interface Actor {
+  /** Display name */
+  name: string;
+
+  /** Username/handle */
+  username: string;
+
+  /** Additional profile details */
+  details: {
+    /** Short profile tagline */
+    tagline: string;
+
+    /** Longer profile summary */
+    summary: string;
+
+    /** Favorite quote */
+    quote: string;
+  };
+
+  /** Unique identifier */
+  id: UUID;
+}
+
+/**
+ * Represents a single objective within a goal
+ */
+export interface Objective {
+  /** Optional unique identifier */
+  id?: string;
+
+  /** Description of what needs to be achieved */
+  description: string;
+
+  /** Whether objective is completed */
+  completed: boolean;
+}
+
+/**
+ * Status enum for goals
+ */
+export enum GoalStatus {
+  DONE = 'DONE',
+  FAILED = 'FAILED',
+  IN_PROGRESS = 'IN_PROGRESS',
+}
+
+/**
+ * Represents a high-level goal composed of objectives
+ */
+export interface Goal {
+  /** Optional unique identifier */
+  id?: UUID;
+
+  /** Room ID where goal exists */
+  roomId: UUID;
+
+  /** User ID of goal owner */
+  userId: UUID;
+
+  /** Name/title of the goal */
+  name: string;
+
+  /** Current status */
+  status: GoalStatus;
+
+  /** Component objectives */
+  objectives: Objective[];
+}
+
+/**
+ * Model size/type classification
+ */
+export enum ModelClass {
+  SMALL = 'small',
+  MEDIUM = 'medium',
+  LARGE = 'large',
+  EMBEDDING = 'embedding',
+  IMAGE = 'image',
+}
+
+/**
+ * Model settings
+ */
+export type ModelSettings = {
+  /** Model name */
+  name: string;
+
+  /** Maximum input tokens */
+  maxInputTokens: number;
+
+  /** Maximum output tokens */
+  maxOutputTokens: number;
+
+  /** Optional frequency penalty */
+  frequency_penalty?: number;
+
+  /** Optional presence penalty */
+  presence_penalty?: number;
+
+  /** Optional repetition penalty */
+  repetition_penalty?: number;
+
+  /** Stop sequences */
+  stop: string[];
+
+  /** Temperature setting */
+  temperature: number;
+
+  /** Optional telemetry configuration (experimental) */
+  experimental_telemetry?: TelemetrySettings;
+};
+
+/** Image model settings */
+export type ImageModelSettings = {
+  name: string;
+  steps?: number;
+};
+
+/** Embedding model settings */
+export type EmbeddingModelSettings = {
+  name: string;
+  dimensions?: number;
+};
+
+/**
+ * Configuration for an AI model
+ */
+export type Model = {
+  /** Optional API endpoint */
+  endpoint?: string;
+
+  /** Model names by size class */
+  model: {
+    [ModelClass.SMALL]?: ModelSettings;
+    [ModelClass.MEDIUM]?: ModelSettings;
+    [ModelClass.LARGE]?: ModelSettings;
+    [ModelClass.EMBEDDING]?: EmbeddingModelSettings;
+    [ModelClass.IMAGE]?: ImageModelSettings;
+  };
+};
+
+/**
+ * Model configurations by provider
+ */
+export type Models = {
+  [ModelProviderName.OPENAI]: Model;
+  [ModelProviderName.ETERNALAI]: Model;
+  [ModelProviderName.ANTHROPIC]: Model;
+  [ModelProviderName.GROK]: Model;
+  [ModelProviderName.GROQ]: Model;
+  [ModelProviderName.LLAMACLOUD]: Model;
+  [ModelProviderName.TOGETHER]: Model;
+  [ModelProviderName.LLAMALOCAL]: Model;
+  [ModelProviderName.LMSTUDIO]: Model;
+  [ModelProviderName.GOOGLE]: Model;
+  [ModelProviderName.MISTRAL]: Model;
+  [ModelProviderName.CLAUDE_VERTEX]: Model;
+  [ModelProviderName.REDPILL]: Model;
+  [ModelProviderName.OPENROUTER]: Model;
+  [ModelProviderName.OLLAMA]: Model;
+  [ModelProviderName.HEURIST]: Model;
+  [ModelProviderName.GALADRIEL]: Model;
+  [ModelProviderName.FAL]: Model;
+  [ModelProviderName.GAIANET]: Model;
+  [ModelProviderName.ALI_BAILIAN]: Model;
+  [ModelProviderName.VOLENGINE]: Model;
+  [ModelProviderName.NANOGPT]: Model;
+  [ModelProviderName.HYPERBOLIC]: Model;
+  [ModelProviderName.VENICE]: Model;
+  [ModelProviderName.NVIDIA]: Model;
+  [ModelProviderName.NINETEEN_AI]: Model;
+  [ModelProviderName.AKASH_CHAT_API]: Model;
+  [ModelProviderName.LIVEPEER]: Model;
+  [ModelProviderName.DEEPSEEK]: Model;
+  [ModelProviderName.INFERA]: Model;
+  [ModelProviderName.BEDROCK]: Model;
+  [ModelProviderName.ATOMA]: Model;
+  [ModelProviderName.SECRETAI]: Model;
+  [ModelProviderName.NEARAI]: Model;
+};
+
+/**
+ * Available model providers
+ */
+export enum ModelProviderName {
+  OPENAI = 'openai',
+  ETERNALAI = 'eternalai',
+  ANTHROPIC = 'anthropic',
+  GROK = 'grok',
+  GROQ = 'groq',
+  LLAMACLOUD = 'llama_cloud',
+  TOGETHER = 'together',
+  LLAMALOCAL = 'llama_local',
+  LMSTUDIO = 'lmstudio',
+  GOOGLE = 'google',
+  MISTRAL = 'mistral',
+  CLAUDE_VERTEX = 'claude_vertex',
+  REDPILL = 'redpill',
+  OPENROUTER = 'openrouter',
+  OLLAMA = 'ollama',
+  HEURIST = 'heurist',
+  GALADRIEL = 'galadriel',
+  FAL = 'falai',
+  GAIANET = 'gaianet',
+  ALI_BAILIAN = 'ali_bailian',
+  VOLENGINE = 'volengine',
+  NANOGPT = 'nanogpt',
+  HYPERBOLIC = 'hyperbolic',
+  VENICE = 'venice',
+  NVIDIA = 'nvidia',
+  NINETEEN_AI = 'nineteen_ai',
+  AKASH_CHAT_API = 'akash_chat_api',
+  LIVEPEER = 'livepeer',
+  LETZAI = 'letzai',
+  DEEPSEEK = 'deepseek',
+  INFERA = 'infera',
+  BEDROCK = 'bedrock',
+  ATOMA = 'atoma',
+  SECRETAI = 'secret_ai',
+  NEARAI = 'nearai',
+}
+
+/**
+ * Represents the current state/context of a conversation
+ */
+export interface State {
+  /** ID of user who sent current message */
+  userId?: UUID;
+
+  /** ID of agent in conversation */
+  agentId?: UUID;
+
+  /** Agent's biography */
+  bio?: string;
+
+  /** Agent's background lore */
+  lore?: string;
+
+  /** Message handling directions */
+  messageDirections?: string;
+
+  /** Post handling directions */
+  postDirections?: string;
+
+  /** Current room/conversation ID */
+  roomId?: UUID;
+
+  /** Optional agent name */
+  agentName?: string;
+
+  /** Optional message sender name */
+  senderName?: string;
+
+  /** String representation of conversation actors */
+  actors?: string;
+
+  /** Optional array of actor objects */
+  actorsData?: Actor[];
+
+  /** Optional string representation of goals */
+  goals?: string;
+
+  /** Optional array of goal objects */
+  goalsData?: Goal[];
+
+  /** Recent message history as string */
+  recentMessages?: string;
+
+  /** Recent message objects */
+  recentMessagesData?: Memory[];
+
+  /** Optional valid action names */
+  actionNames?: string;
+
+  /** Optional action descriptions */
+  actions?: string;
+
+  /** Optional action objects */
+  actionsData?: Action[];
+
+  /** Optional action examples */
+  actionExamples?: string;
+
+  /** Optional provider descriptions */
+  providers?: string;
+
+  /** Optional response content */
+  responseData?: Content;
+
+  /** Optional recent interaction objects */
+  recentInteractionsData?: Memory[];
+
+  /** Optional recent interactions string */
+  recentInteractions?: string;
+
+  /** Optional formatted conversation */
+  formattedConversation?: string;
+
+  /** Optional formatted knowledge */
+  knowledge?: string;
+  /** Optional knowledge data */
+  knowledgeData?: KnowledgeItem[];
+  /** Optional knowledge data */
+  ragKnowledgeData?: RAGKnowledgeItem[];
+
+  /** Optional text content */
+  text?: string;
+
+  /** Additional dynamic properties */
+  [key: string]: unknown;
+}
+
+/**
+ * Represents a stored memory/message
+ */
+export interface Memory {
+  /** Optional unique identifier */
+  id?: UUID;
+
+  /** Associated user ID */
+  userId: UUID;
+
+  /** Associated agent ID */
+  agentId: UUID;
+
+  /** Optional creation timestamp */
+  createdAt?: number;
+
+  /** Memory content */
+  content: Content;
+
+  /** Optional embedding vector */
+  embedding?: number[];
+
+  /** Associated room ID */
+  roomId: UUID;
+
+  /** Whether memory is unique */
+  unique?: boolean;
+
+  /** Embedding similarity score */
+  similarity?: number;
+}
+
+/**
+ * Example message for demonstration
+ */
+export interface MessageExample {
+  /** Associated user */
+  user: string;
+
+  /** Message content */
+  content: Content;
+}
+
+/**
+ * Handler function type for processing messages
+ */
+export type Handler = (
+  runtime: IAgentRuntime,
+  message: Memory,
+  state?: State,
+  options?: { [key: string]: unknown },
+  callback?: HandlerCallback
+) => Promise<unknown>;
+
+/**
+ * Callback function type for handlers
+ */
+export type HandlerCallback = (response: Content, files?: any) => Promise<Memory[]>;
+
+/**
+ * Validator function type for actions/evaluators
+ */
+export type Validator = (
+  runtime: IAgentRuntime,
+  message: Memory,
+  state?: State
+) => Promise<boolean>;
+
+/**
+ * Represents an action the agent can perform
+ */
+export interface Action {
+  /** Similar action descriptions */
+  similes: string[];
+
+  /** Detailed description */
+  description: string;
+
+  /** Example usages */
+  examples: ActionExample[][];
+
+  /** Handler function */
+  handler: Handler;
+
+  /** Action name */
+  name: string;
+
+  /** Validation function */
+  validate: Validator;
+
+  /** Whether to suppress the initial message when this action is used */
+  suppressInitialMessage?: boolean;
+}
+
+/**
+ * Example for evaluating agent behavior
+ */
+export interface EvaluationExample {
+  /** Evaluation context */
+  context: string;
+
+  /** Example messages */
+  messages: Array<ActionExample>;
+
+  /** Expected outcome */
+  outcome: string;
+}
+
+/**
+ * Evaluator for assessing agent responses
+ */
+export interface Evaluator {
+  /** Whether to always run */
+  alwaysRun?: boolean;
+
+  /** Detailed description */
+  description: string;
+
+  /** Similar evaluator descriptions */
+  similes: string[];
+
+  /** Example evaluations */
+  examples: EvaluationExample[];
+
+  /** Handler function */
+  handler: Handler;
+
+  /** Evaluator name */
+  name: string;
+
+  /** Validation function */
+  validate: Validator;
+}
+
+/**
+ * Provider for external data/services
+ */
+export interface Provider {
+  /** Provider name */
+  name?: string;
+
+  /** Description of the provider */
+  description?: string;
+
+  /** Whether the provider is dynamic */
+  dynamic?: boolean;
+
+  /** Position of the provider in the provider list */
+  position?: number;
+
+  /** Whether the provider is private */
+  private?: boolean;
+
+  /** Data retrieval function */
+  get: (runtime: IAgentRuntime, message: Memory, state?: State) => Promise<any>;
+}
+
+/**
+ * Represents a relationship between users
+ */
+export interface Relationship {
+  /** Unique identifier */
+  id: UUID;
+
+  /** First user ID */
+  userA: UUID;
+
+  /** Second user ID */
+  userB: UUID;
+
+  /** Primary user ID */
+  userId: UUID;
+
+  /** Associated room ID */
+  roomId: UUID;
+
+  /** Relationship status */
+  status: string;
+
+  /** Optional creation timestamp */
+  createdAt?: string;
+}
+
+/**
+ * Represents a user account
+ */
+export interface Account {
+  /** Unique identifier */
+  id: UUID;
+
+  /** Display name */
+  name: string;
+
+  /** Username */
+  username: string;
+
+  /** Optional additional details */
+  details?: { [key: string]: any };
+
+  /** Optional email */
+  email?: string;
+
+  /** Optional avatar URL */
+  avatarUrl?: string;
+}
+
+/**
+ * Room participant with account details
+ */
+export interface Participant {
+  /** Unique identifier */
+  id: UUID;
+
+  /** Associated account */
+  account: Account;
+}
+
+/**
+ * Represents a conversation room
+ */
+export interface Room {
+  /** Unique identifier */
+  id: UUID;
+
+  /** Room participants */
+  participants: Participant[];
+}
+
+/**
+ * Represents a media attachment
+ */
+export type Media = {
+  /** Unique identifier */
+  id: string;
+
+  /** Media URL */
+  url: string;
+
+  /** Media title */
+  title: string;
+
+  /** Media source */
+  source: string;
+
+  /** Media description */
+  description: string;
+
+  /** Text content */
+  text: string;
+
+  /** Content type */
+  contentType?: string;
+};
+
+/**
+ * Client instance
+ */
+export type ClientInstance = {
+  /** Client name */
+  // name: string;
+
+  /** Stop client connection */
+  stop: (runtime: IAgentRuntime) => Promise<unknown>;
+};
+
+/**
+ * Client interface for platform connections
+ */
+export type Client = {
+  /** Client name */
+  name: string;
+
+  /** Client configuration */
+  config?: { [key: string]: any };
+
+  /** Start client connection */
+  start: (runtime: IAgentRuntime) => Promise<ClientInstance>;
+};
+
+/**
+ * Database adapter initialization
+ */
+export type Adapter = {
+  /** Initialize the adapter */
+  init: (runtime: IAgentRuntime) => IDatabaseAdapter & IDatabaseCacheAdapter;
+};
+
+/**
+ * Plugin for extending agent functionality
+ */
+export type Plugin = {
+  /** Plugin name */
+  name: string;
+
+  /** Plugin npm name */
+  npmName?: string;
+
+  /** Plugin configuration */
+  config?: { [key: string]: any };
+
+  /** Plugin description */
+  description: string;
+
+  /** Optional actions */
+  actions?: Action[];
+
+  /** Optional providers */
+  providers?: Provider[];
+
+  /** Optional evaluators */
+  evaluators?: Evaluator[];
+
+  /** Optional services */
+  services?: Service[];
+
+  /** Optional clients */
+  clients?: Client[];
+
+  /** Optional adapters */
+  adapters?: Adapter[];
+
+  /** Optional post charactor processor handler */
+  handlePostCharacterLoaded?: (char: Character) => Promise<Character>;
+};
+
+export interface IAgentConfig {
+  [key: string]: string;
+}
+
+export type TelemetrySettings = {
+  /**
+   * Enable or disable telemetry. Disabled by default while experimental.
+   */
+  isEnabled?: boolean;
+  /**
+   * Enable or disable input recording. Enabled by default.
+   *
+   * You might want to disable input recording to avoid recording sensitive
+   * information, to reduce data transfers, or to increase performance.
+   */
+  recordInputs?: boolean;
+  /**
+   * Enable or disable output recording. Enabled by default.
+   *
+   * You might want to disable output recording to avoid recording sensitive
+   * information, to reduce data transfers, or to increase performance.
+   */
+  recordOutputs?: boolean;
+  /**
+   * Identifier for this function. Used to group telemetry data by function.
+   */
+  functionId?: string;
+};
+
+export interface ModelConfiguration {
+  temperature?: number;
+  maxOutputTokens?: number;
+  frequency_penalty?: number;
+  presence_penalty?: number;
+  maxInputTokens?: number;
+  experimental_telemetry?: TelemetrySettings;
+}
+
+export type TemplateType = string | ((options: { state: State }) => string);
+
+/**
+ * Configuration for an agent character
+ */
+export type Character = {
+  /** Optional unique identifier */
+  id?: UUID;
+
+  /** Character name */
+  name: string;
+
+  /** Optional username */
+  username?: string;
+
+  /** Optional email */
+  email?: string;
+
+  /** Optional system prompt */
+  system?: string;
+
+  /** Model provider to use */
+  modelProvider: ModelProviderName;
+
+  /** Image model provider to use, if different from modelProvider */
+  imageModelProvider?: ModelProviderName;
+
+  /** Image Vision model provider to use, if different from modelProvider */
+  imageVisionModelProvider?: ModelProviderName;
+
+  /** Optional model endpoint override */
+  modelEndpointOverride?: string;
+
+  /** Optional prompt templates */
+  templates?: {
+    goalsTemplate?: TemplateType;
+    factsTemplate?: TemplateType;
+    messageHandlerTemplate?: TemplateType;
+    shouldRespondTemplate?: TemplateType;
+    continueMessageHandlerTemplate?: TemplateType;
+    evaluationTemplate?: TemplateType;
+    twitterSearchTemplate?: TemplateType;
+    twitterActionTemplate?: TemplateType;
+    twitterPostTemplate?: TemplateType;
+    twitterMessageHandlerTemplate?: TemplateType;
+    twitterShouldRespondTemplate?: TemplateType;
+    twitterVoiceHandlerTemplate?: TemplateType;
+    instagramPostTemplate?: TemplateType;
+    instagramMessageHandlerTemplate?: TemplateType;
+    instagramShouldRespondTemplate?: TemplateType;
+    farcasterPostTemplate?: TemplateType;
+    lensPostTemplate?: TemplateType;
+    farcasterMessageHandlerTemplate?: TemplateType;
+    lensMessageHandlerTemplate?: TemplateType;
+    farcasterShouldRespondTemplate?: TemplateType;
+    lensShouldRespondTemplate?: TemplateType;
+    telegramMessageHandlerTemplate?: TemplateType;
+    telegramShouldRespondTemplate?: TemplateType;
+    telegramAutoPostTemplate?: string;
+    telegramPinnedMessageTemplate?: string;
+    discordAutoPostTemplate?: string;
+    discordAnnouncementHypeTemplate?: string;
+    discordVoiceHandlerTemplate?: TemplateType;
+    discordShouldRespondTemplate?: TemplateType;
+    discordMessageHandlerTemplate?: TemplateType;
+    slackMessageHandlerTemplate?: TemplateType;
+    slackShouldRespondTemplate?: TemplateType;
+    jeeterPostTemplate?: string;
+    jeeterSearchTemplate?: string;
+    jeeterInteractionTemplate?: string;
+    jeeterMessageHandlerTemplate?: string;
+    jeeterShouldRespondTemplate?: string;
+    devaPostTemplate?: string;
+  };
+
+  /** Character biography */
+  bio: string | string[];
+
+  /** Character background lore */
+  lore: string[];
+
+  /** Example messages */
+  messageExamples: MessageExample[][];
+
+  /** Example posts */
+  postExamples: string[];
+
+  /** Known topics */
+  topics: string[];
+
+  /** Character traits */
+  adjectives: string[];
+
+  /** Optional knowledge base */
+  knowledge?: (
+    | string
+    | { path: string; shared?: boolean }
+    | { directory: string; shared?: boolean }
+  )[];
+
+  /** Available plugins */
+  plugins: Plugin[];
+
+  /** Character Processor Plugins */
+  postProcessors?: Pick<Plugin, 'name' | 'description' | 'handlePostCharacterLoaded'>[];
+
+  /** Optional configuration */
+  settings?: {
+    secrets?: { [key: string]: string };
+    intiface?: boolean;
+    imageSettings?: {
+      steps?: number;
+      width?: number;
+      height?: number;
+      cfgScale?: number;
+      negativePrompt?: string;
+      numIterations?: number;
+      guidanceScale?: number;
+      seed?: number;
+      modelId?: string;
+      jobId?: string;
+      count?: number;
+      stylePreset?: string;
+      hideWatermark?: boolean;
+      safeMode?: boolean;
+    };
+    voice?: {
+      model?: string; // For VITS
+      url?: string; // Legacy VITS support
+      elevenlabs?: {
+        // New structured ElevenLabs config
+        voiceId: string;
+        model?: string;
+        stability?: string;
+        similarityBoost?: string;
+        style?: string;
+        useSpeakerBoost?: string;
+      };
+    };
+    model?: string;
+    modelConfig?: ModelConfiguration;
+    embeddingModel?: string;
+    chains?: {
+      evm?: any[];
+      solana?: any[];
+      [key: string]: any[];
+    };
+    transcription?: TranscriptionProvider;
+    ragKnowledge?: boolean;
+  };
+
+  /** Optional client-specific config */
+  clientConfig?: {
+    discord?: {
+      shouldIgnoreBotMessages?: boolean;
+      shouldIgnoreDirectMessages?: boolean;
+      shouldRespondOnlyToMentions?: boolean;
+      messageSimilarityThreshold?: number;
+      isPartOfTeam?: boolean;
+      teamAgentIds?: string[];
+      teamLeaderId?: string;
+      teamMemberInterestKeywords?: string[];
+      allowedChannelIds?: string[];
+      autoPost?: {
+        enabled?: boolean;
+        monitorTime?: number;
+        inactivityThreshold?: number;
+        mainChannelId?: string;
+        announcementChannelIds?: string[];
+        minTimeBetweenPosts?: number;
+      };
+    };
+    telegram?: {
+      shouldIgnoreBotMessages?: boolean;
+      shouldIgnoreDirectMessages?: boolean;
+      shouldRespondOnlyToMentions?: boolean;
+      shouldOnlyJoinInAllowedGroups?: boolean;
+      allowedGroupIds?: string[];
+      messageSimilarityThreshold?: number;
+      isPartOfTeam?: boolean;
+      teamAgentIds?: string[];
+      teamLeaderId?: string;
+      teamMemberInterestKeywords?: string[];
+      autoPost?: {
+        enabled?: boolean;
+        monitorTime?: number;
+        inactivityThreshold?: number;
+        mainChannelId?: string;
+        pinnedMessagesGroups?: string[];
+        minTimeBetweenPosts?: number;
+      };
+    };
+    slack?: {
+      shouldIgnoreBotMessages?: boolean;
+      shouldIgnoreDirectMessages?: boolean;
+    };
+    gitbook?: {
+      keywords?: {
+        projectTerms?: string[];
+        generalQueries?: string[];
+      };
+      documentTriggers?: string[];
+    };
+  };
+
+  /** Writing style guides */
+  style: {
+    all: string[];
+    chat: string[];
+    post: string[];
+  };
+
+  /** Optional Twitter profile */
+  twitterProfile?: {
+    id: string;
+    username: string;
+    screenName: string;
+    bio: string;
+    nicknames?: string[];
+  };
+
+  /** Optional Instagram profile */
+  instagramProfile?: {
+    id: string;
+    username: string;
+    bio: string;
+    nicknames?: string[];
+  };
+
+  /** Optional SimsAI profile */
+  simsaiProfile?: {
+    id: string;
+    username: string;
+    screenName: string;
+    bio: string;
+  };
+
+  /** Optional NFT prompt */
+  nft?: {
+    prompt: string;
+  };
+
+  /**Optinal Parent characters to inherit information from */
+  extends?: string[];
+
+  twitterSpaces?: TwitterSpaceDecisionOptions;
+};
+
+export interface TwitterSpaceDecisionOptions {
+  maxSpeakers?: number;
+  topics?: string[];
+  typicalDurationMinutes?: number;
+  idleKickTimeoutMs?: number;
+  minIntervalBetweenSpacesMinutes?: number;
+  businessHoursOnly?: boolean;
+  randomChance?: number;
+  enableIdleMonitor?: boolean;
+  enableSttTts?: boolean;
+  enableRecording?: boolean;
+  voiceId?: string;
+  sttLanguage?: string;
+  speakerMaxDurationMs?: number;
+}
+
+/**
+ * Interface for database operations
+ */
+export interface IDatabaseAdapter {
+  /** Database instance */
+  db: any;
+
+  /** Optional initialization */
+  init(): Promise<void>;
+
+  /** Close database connection */
+  close(): Promise<void>;
+
+  /** Get account by ID */
+  getAccountById(userId: UUID): Promise<Account | null>;
+
+  /** Create new account */
+  createAccount(account: Account): Promise<boolean>;
+
+  /** Get memories matching criteria */
+  getMemories(params: {
+    roomId: UUID;
+    count?: number;
+    unique?: boolean;
+    tableName: string;
+    agentId: UUID;
+    start?: number;
+    end?: number;
+  }): Promise<Memory[]>;
+
+  getMemoryById(id: UUID): Promise<Memory | null>;
+
+  getMemoriesByIds(ids: UUID[], tableName?: string): Promise<Memory[]>;
+
+  getMemoriesByRoomIds(params: {
+    tableName: string;
+    agentId: UUID;
+    roomIds: UUID[];
+    limit?: number;
+  }): Promise<Memory[]>;
+
+  getCachedEmbeddings(params: {
+    query_table_name: string;
+    query_threshold: number;
+    query_input: string;
+    query_field_name: string;
+    query_field_sub_name: string;
+    query_match_count: number;
+  }): Promise<{ embedding: number[]; levenshtein_score: number }[]>;
+
+  log(params: {
+    body: { [key: string]: unknown };
+    userId: UUID;
+    roomId: UUID;
+    type: string;
+  }): Promise<void>;
+
+  getActorDetails(params: { roomId: UUID }): Promise<Actor[]>;
+
+  searchMemories(params: {
+    tableName: string;
+    agentId: UUID;
+    roomId: UUID;
+    embedding: number[];
+    match_threshold: number;
+    match_count: number;
+    unique: boolean;
+  }): Promise<Memory[]>;
+
+  updateGoalStatus(params: { goalId: UUID; status: GoalStatus }): Promise<void>;
+
+  searchMemoriesByEmbedding(
+    embedding: number[],
+    params: {
+      match_threshold?: number;
+      count?: number;
+      roomId?: UUID;
+      agentId?: UUID;
+      unique?: boolean;
+      tableName: string;
+    }
+  ): Promise<Memory[]>;
+
+  createMemory(memory: Memory, tableName: string, unique?: boolean): Promise<void>;
+
+  removeMemory(memoryId: UUID, tableName: string): Promise<void>;
+
+  removeAllMemories(roomId: UUID, tableName: string): Promise<void>;
+
+  countMemories(roomId: UUID, unique?: boolean, tableName?: string): Promise<number>;
+
+  getGoals(params: {
+    agentId: UUID;
+    roomId: UUID;
+    userId?: UUID | null;
+    onlyInProgress?: boolean;
+    count?: number;
+  }): Promise<Goal[]>;
+
+  updateGoal(goal: Goal): Promise<void>;
+
+  createGoal(goal: Goal): Promise<void>;
+
+  removeGoal(goalId: UUID): Promise<void>;
+
+  removeAllGoals(roomId: UUID): Promise<void>;
+
+  getRoom(roomId: UUID): Promise<UUID | null>;
+
+  createRoom(roomId?: UUID): Promise<UUID>;
+
+  removeRoom(roomId: UUID): Promise<void>;
+
+  getRoomsForParticipant(userId: UUID): Promise<UUID[]>;
+
+  getRoomsForParticipants(userIds: UUID[]): Promise<UUID[]>;
+
+  addParticipant(userId: UUID, roomId: UUID): Promise<boolean>;
+
+  removeParticipant(userId: UUID, roomId: UUID): Promise<boolean>;
+
+  getParticipantsForAccount(userId: UUID): Promise<Participant[]>;
+
+  getParticipantsForRoom(roomId: UUID): Promise<UUID[]>;
+
+  getParticipantUserState(roomId: UUID, userId: UUID): Promise<'FOLLOWED' | 'MUTED' | null>;
+
+  setParticipantUserState(
+    roomId: UUID,
+    userId: UUID,
+    state: 'FOLLOWED' | 'MUTED' | null
+  ): Promise<void>;
+
+  createRelationship(params: { userA: UUID; userB: UUID }): Promise<boolean>;
+
+  getRelationship(params: { userA: UUID; userB: UUID }): Promise<Relationship | null>;
+
+  getRelationships(params: { userId: UUID }): Promise<Relationship[]>;
+
+  getKnowledge(params: {
+    id?: UUID;
+    agentId: UUID;
+    limit?: number;
+    query?: string;
+    conversationContext?: string;
+  }): Promise<RAGKnowledgeItem[]>;
+
+  searchKnowledge(params: {
+    agentId: UUID;
+    embedding: Float32Array;
+    match_threshold: number;
+    match_count: number;
+    searchText?: string;
+  }): Promise<RAGKnowledgeItem[]>;
+
+  createKnowledge(knowledge: RAGKnowledgeItem): Promise<void>;
+  removeKnowledge(id: UUID): Promise<void>;
+  clearKnowledge(agentId: UUID, shared?: boolean): Promise<void>;
+}
+
+export interface IDatabaseCacheAdapter {
+  getCache(params: { agentId: UUID; key: string }): Promise<string | undefined>;
+
+  setCache(params: { agentId: UUID; key: string; value: string }): Promise<boolean>;
+
+  deleteCache(params: { agentId: UUID; key: string }): Promise<boolean>;
+}
+
+export interface IMemoryManager {
+  runtime: IAgentRuntime;
+  tableName: string;
+  constructor: Function;
+
+  addEmbeddingToMemory(memory: Memory): Promise<Memory>;
+
+  getMemories(opts: {
+    roomId: UUID;
+    count?: number;
+    unique?: boolean;
+    start?: number;
+    end?: number;
+  }): Promise<Memory[]>;
+
+  getCachedEmbeddings(
+    content: string
+  ): Promise<{ embedding: number[]; levenshtein_score: number }[]>;
+
+  getMemoryById(id: UUID): Promise<Memory | null>;
+  getMemoriesByRoomIds(params: { roomIds: UUID[]; limit?: number }): Promise<Memory[]>;
+  searchMemoriesByEmbedding(
+    embedding: number[],
+    opts: {
+      match_threshold?: number;
+      count?: number;
+      roomId: UUID;
+      unique?: boolean;
+    }
+  ): Promise<Memory[]>;
+
+  createMemory(memory: Memory, unique?: boolean): Promise<void>;
+
+  removeMemory(memoryId: UUID): Promise<void>;
+
+  removeAllMemories(roomId: UUID): Promise<void>;
+
+  countMemories(roomId: UUID, unique?: boolean): Promise<number>;
+}
+
+export interface IRAGKnowledgeManager {
+  runtime: IAgentRuntime;
+  tableName: string;
+
+  getKnowledge(params: {
+    query?: string;
+    id?: UUID;
+    limit?: number;
+    conversationContext?: string;
+    agentId?: UUID;
+  }): Promise<RAGKnowledgeItem[]>;
+  createKnowledge(item: RAGKnowledgeItem): Promise<void>;
+  removeKnowledge(id: UUID): Promise<void>;
+  searchKnowledge(params: {
+    agentId: UUID;
+    embedding: Float32Array | number[];
+    match_threshold?: number;
+    match_count?: number;
+    searchText?: string;
+  }): Promise<RAGKnowledgeItem[]>;
+  clearKnowledge(shared?: boolean): Promise<void>;
+  processFile(file: {
+    path: string;
+    content: string;
+    type: 'pdf' | 'md' | 'txt';
+    isShared: boolean;
+  }): Promise<void>;
+  cleanupDeletedKnowledgeFiles(): Promise<void>;
+  generateScopedId(path: string, isShared: boolean): UUID;
+}
+
+export type CacheOptions = {
+  expires?: number;
+};
+
+export enum CacheStore {
+  REDIS = 'redis',
+  DATABASE = 'database',
+  FILESYSTEM = 'filesystem',
+}
+
+export interface ICacheManager {
+  get<T = unknown>(key: string): Promise<T | undefined>;
+  set<T>(key: string, value: T, options?: CacheOptions): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+export abstract class Service {
+  private static instance: Service | null = null;
+
+  static get serviceType(): ServiceType {
+    throw new Error('Service must implement static serviceType getter');
+  }
+
+  public static getInstance<T extends Service>(): T {
+    if (!Service.instance) {
+      Service.instance = new (this as any)();
+    }
+    return Service.instance as T;
+  }
+
+  get serviceType(): ServiceType {
+    return (this.constructor as typeof Service).serviceType;
+  }
+
+  // Add abstract initialize method that must be implemented by derived classes
+  abstract initialize(runtime: IAgentRuntime): Promise<void>;
+}
+
+export interface IAgentRuntime {
+  // Properties
+  agentId: UUID;
+  serverUrl: string;
+  databaseAdapter: IDatabaseAdapter;
+  token: string | null;
+  modelProvider: ModelProviderName;
+  imageModelProvider: ModelProviderName;
+  imageVisionModelProvider: ModelProviderName;
+  character: Character;
+  providers: Provider[];
+  actions: Action[];
+  evaluators: Evaluator[];
+  plugins: Plugin[];
+
+  fetch?: typeof fetch | null;
+
+  messageManager: IMemoryManager;
+  descriptionManager: IMemoryManager;
+  documentsManager: IMemoryManager;
+  knowledgeManager: IMemoryManager;
+  ragKnowledgeManager: IRAGKnowledgeManager;
+  loreManager: IMemoryManager;
+
+  cacheManager: ICacheManager;
+
+  services: Map<ServiceType, Service>;
+  clients: ClientInstance[];
+
+  // verifiableInferenceAdapter?: IVerifiableInferenceAdapter | null;
+
+  initialize(): Promise<void>;
+
+  registerMemoryManager(manager: IMemoryManager): void;
+
+  getMemoryManager(name: string): IMemoryManager | null;
+
+  getService<T extends Service>(service: ServiceType): T | null;
+
+  registerService(service: Service): void;
+
+  getSetting(key: string): string | null;
+
+  // Methods
+  getConversationLength(): number;
+
+  processActions(
+    message: Memory,
+    responses: Memory[],
+    state?: State,
+    callback?: HandlerCallback
+  ): Promise<void>;
+
+  evaluate(
+    message: Memory,
+    state?: State,
+    didRespond?: boolean,
+    callback?: HandlerCallback
+  ): Promise<string[] | null>;
+
+  ensureParticipantExists(userId: UUID, roomId: UUID): Promise<void>;
+
+  ensureUserExists(
+    userId: UUID,
+    userName: string | null,
+    name: string | null,
+    source: string | null
+  ): Promise<void>;
+
+  registerAction(action: Action): void;
+
+  ensureConnection(
+    userId: UUID,
+    roomId: UUID,
+    userName?: string,
+    userScreenName?: string,
+    source?: string
+  ): Promise<void>;
+
+  ensureParticipantInRoom(userId: UUID, roomId: UUID): Promise<void>;
+
+  ensureRoomExists(roomId: UUID): Promise<void>;
+
+  composeState(message: Memory, additionalKeys?: { [key: string]: unknown }): Promise<State>;
+
+  updateRecentMessageState(state: State): Promise<State>;
+}
+
+export interface IImageDescriptionService extends Service {
+  describeImage(imageUrl: string): Promise<{ title: string; description: string }>;
+}
+
+export interface ITranscriptionService extends Service {
+  transcribeAttachment(audioBuffer: ArrayBuffer): Promise<string | null>;
+  transcribeAttachmentLocally(audioBuffer: ArrayBuffer): Promise<string | null>;
+  transcribe(audioBuffer: ArrayBuffer): Promise<string | null>;
+  transcribeLocally(audioBuffer: ArrayBuffer): Promise<string | null>;
+}
+
+export interface IVideoService extends Service {
+  isVideoUrl(url: string): boolean;
+  fetchVideoInfo(url: string): Promise<Media>;
+  downloadVideo(videoInfo: Media): Promise<string>;
+  processVideo(url: string, runtime: IAgentRuntime): Promise<Media>;
+}
+
+export interface ITextGenerationService extends Service {
+  initializeModel(): Promise<void>;
+  queueMessageCompletion(
+    context: string,
+    temperature: number,
+    stop: string[],
+    frequency_penalty: number,
+    presence_penalty: number,
+    max_tokens: number
+  ): Promise<any>;
+  queueTextCompletion(
+    context: string,
+    temperature: number,
+    stop: string[],
+    frequency_penalty: number,
+    presence_penalty: number,
+    max_tokens: number
+  ): Promise<string>;
+  getEmbeddingResponse(input: string): Promise<number[] | undefined>;
+}
+
+export interface IBrowserService extends Service {
+  closeBrowser(): Promise<void>;
+  getPageContent(
+    url: string,
+    runtime: IAgentRuntime
+  ): Promise<{ title: string; description: string; bodyContent: string }>;
+}
+
+export interface ISpeechService extends Service {
+  getInstance(): ISpeechService;
+  generate(runtime: IAgentRuntime, text: string): Promise<Readable>;
+}
+
+export interface IPdfService extends Service {
+  getInstance(): IPdfService;
+  convertPdfToText(pdfBuffer: Buffer): Promise<string>;
+}
+
+export interface IAwsS3Service extends Service {
+  uploadFile(
+    imagePath: string,
+    subDirectory: string,
+    useSignedUrl: boolean,
+    expiresIn: number
+  ): Promise<{
+    success: boolean;
+    url?: string;
+    error?: string;
+  }>;
+  generateSignedUrl(fileName: string, expiresIn: number): Promise<string>;
+}
+
+export interface UploadIrysResult {
+  success: boolean;
+  url?: string;
+  error?: string;
+  data?: any;
+}
+
+export interface DataIrysFetchedFromGQL {
+  success: boolean;
+  data: any;
+  error?: string;
+}
+
+export interface GraphQLTag {
+  name: string;
+  values: any[];
+}
+
+export enum IrysMessageType {
+  REQUEST = 'REQUEST',
+  DATA_STORAGE = 'DATA_STORAGE',
+  REQUEST_RESPONSE = 'REQUEST_RESPONSE',
+}
+
+export enum IrysDataType {
+  FILE = 'FILE',
+  IMAGE = 'IMAGE',
+  OTHER = 'OTHER',
+}
+
+export interface IrysTimestamp {
+  from: number;
+  to: number;
+}
+
+export interface IIrysService extends Service {
+  getDataFromAnAgent(
+    agentsWalletPublicKeys: string[],
+    tags: GraphQLTag[],
+    timestamp: IrysTimestamp
+  ): Promise<DataIrysFetchedFromGQL>;
+  workerUploadDataOnIrys(
+    data: any,
+    dataType: IrysDataType,
+    messageType: IrysMessageType,
+    serviceCategory: string[],
+    protocol: string[],
+    validationThreshold: number[],
+    minimumProviders: number[],
+    testProvider: boolean[],
+    reputation: number[]
+  ): Promise<UploadIrysResult>;
+  providerUploadDataOnIrys(
+    data: any,
+    dataType: IrysDataType,
+    serviceCategory: string[],
+    protocol: string[]
+  ): Promise<UploadIrysResult>;
+}
+
+export interface ITeeLogService extends Service {
+  getInstance(): ITeeLogService;
+  log(
+    agentId: string,
+    roomId: string,
+    userId: string,
+    type: string,
+    content: string
+  ): Promise<boolean>;
+}
+
+export enum ServiceType {
+  IMAGE_DESCRIPTION = 'image_description',
+  TRANSCRIPTION = 'transcription',
+  VIDEO = 'video',
+  TEXT_GENERATION = 'text_generation',
+  BROWSER = 'browser',
+  SPEECH_GENERATION = 'speech_generation',
+  PDF = 'pdf',
+  INTIFACE = 'intiface',
+  AWS_S3 = 'aws_s3',
+  BUTTPLUG = 'buttplug',
+  SLACK = 'slack',
+  VERIFIABLE_LOGGING = 'verifiable_logging',
+  IRYS = 'irys',
+  TEE_LOG = 'tee_log',
+  GOPLUS_SECURITY = 'goplus_security',
+  WEB_SEARCH = 'web_search',
+  EMAIL_AUTOMATION = 'email_automation',
+  NKN_CLIENT_SERVICE = 'nkn_client_service',
+}
+
+export enum LoggingLevel {
+  DEBUG = 'debug',
+  VERBOSE = 'verbose',
+  NONE = 'none',
+}
+
+export type KnowledgeItem = {
+  id: UUID;
+  content: Content;
+};
+
+export interface RAGKnowledgeItem {
+  id: UUID;
+  agentId: UUID;
+  content: {
+    text: string;
+    metadata?: {
+      isMain?: boolean;
+      isChunk?: boolean;
+      originalId?: UUID;
+      chunkIndex?: number;
+      source?: string;
+      type?: string;
+      isShared?: boolean;
+      [key: string]: unknown;
+    };
+  };
+  embedding?: Float32Array;
+  createdAt?: number;
+  similarity?: number;
+  score?: number;
+}
+
+export interface ActionResponse {
+  like: boolean;
+  retweet: boolean;
+  quote?: boolean;
+  reply?: boolean;
+}
+
+export interface ISlackService extends Service {
+  client: any;
+}
+
+export enum TokenizerType {
+  Auto = 'auto',
+  TikToken = 'tiktoken',
+}
+
+export enum TranscriptionProvider {
+  OpenAI = 'openai',
+  Deepgram = 'deepgram',
+  Local = 'local',
+}
+
+export enum ActionTimelineType {
+  ForYou = 'foryou',
+  Following = 'following',
+}
+export enum KnowledgeScope {
+  SHARED = 'shared',
+  PRIVATE = 'private',
+}
+
+export enum CacheKeyPrefix {
+  KNOWLEDGE = 'knowledge',
+}
+
+export interface DirectoryItem {
+  directory: string;
+  shared?: boolean;
+}
+
+export interface ChunkRow {
+  id: string;
+  // Add other properties if needed
+}

--- a/packages/core-plugin-v1/src/uuid.ts
+++ b/packages/core-plugin-v1/src/uuid.ts
@@ -1,0 +1,35 @@
+import { UUID as UUIDv1 } from './types';
+import { validateUuid, stringToUuid } from '@elizaos/core-plugin-v2';
+
+/**
+ * Represents a UUID string in the format "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+ * This is a v1 compatibility wrapper for v2 UUID
+ */
+export type UUID = UUIDv1;
+
+/**
+ * Helper function to safely cast a string to strongly typed UUID
+ * Wraps V2's validateUuid function
+ *
+ * @param id The string UUID to validate and cast
+ * @returns The same UUID with branded type information
+ * @throws Error if the UUID format is invalid
+ */
+export function asUUID(id: string): UUID {
+  const validUuid = validateUuid(id);
+  if (!validUuid) {
+    throw new Error(`Invalid UUID format: ${id}`);
+  }
+  return id.toLowerCase() as UUID;
+}
+
+/**
+ * Generates a UUID from a string input
+ * Wraps V2's stringToUuid function
+ *
+ * @param input The string to convert to a UUID
+ * @returns A UUID generated from the input string
+ */
+export function generateUuidFromString(input: string): UUID {
+  return stringToUuid(input);
+}

--- a/packages/core-plugin-v1/tsconfig.build.json
+++ b/packages/core-plugin-v1/tsconfig.build.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "lib": ["ES2021.String"],
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "noEmit": false,
+    "sourceMap": true,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/core-plugin-v1/tsconfig.json
+++ b/packages/core-plugin-v1/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "typeRoots": ["./node_modules/@types"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/core-plugin-v1/tsup.config.ts
+++ b/packages/core-plugin-v1/tsup.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  outDir: 'dist',
+  clean: true,
+  format: ['esm'],
+  target: 'node18',
+  dts: false,
+  external: [
+    'dotenv',
+    'fs',
+    'path',
+    'node:fs',
+    'node:path',
+    'node:crypto',
+    'node:web',
+    'node:stream',
+    'node:buffer',
+    'node:util',
+    'node:events',
+    'node:url',
+    'node:http',
+    'node:https',
+    'http',
+    'https',
+    'sharp',
+    '@solana/web3.js',
+    'zod',
+    '@hapi/shot',
+  ],
+  sourcemap: false,
+});

--- a/packages/core-plugin-v2/.gitignore
+++ b/packages/core-plugin-v2/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+elizaConfig.yaml
+custom_actions/
+cache/
+*.tsbuildinfo

--- a/packages/core-plugin-v2/.npmignore
+++ b/packages/core-plugin-v2/.npmignore
@@ -1,0 +1,6 @@
+*
+
+!dist/**
+!package.json
+!readme.md
+!tsup.config.ts

--- a/packages/core-plugin-v2/LICENSE
+++ b/packages/core-plugin-v2/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Shaw Walters and elizaOS Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core-plugin-v2/package.json
+++ b/packages/core-plugin-v2/package.json
@@ -1,0 +1,81 @@
+{
+  "name": "@elizaos/core-plugin-v2",
+  "version": "1.0.0-beta.27",
+  "description": "",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "watch": "tsc --watch",
+    "clean": "rm -rf dist .turbo node_modules .turbo-tsconfig.json tsconfig.tsbuildinfo",
+    "dev": "tsup --watch",
+    "build:docs": "cd docs && bun run build",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest",
+    "format": "prettier --write ./src",
+    "format:check": "prettier --check ./src",
+    "lint": "prettier --write ./src"
+  },
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@eslint/js": "9.16.0",
+    "@rollup/plugin-commonjs": "25.0.8",
+    "@rollup/plugin-json": "6.1.0",
+    "@rollup/plugin-replace": "5.0.7",
+    "@rollup/plugin-terser": "0.1.0",
+    "@rollup/plugin-typescript": "11.1.6",
+    "@types/mocha": "10.0.10",
+    "@types/node": "^22.13.9",
+    "@types/uuid": "10.0.0",
+    "@typescript-eslint/eslint-plugin": "8.26.0",
+    "@typescript-eslint/parser": "8.26.0",
+    "@vitest/coverage-v8": "2.1.5",
+    "lint-staged": "15.2.10",
+    "nodemon": "3.1.7",
+    "pm2": "5.4.3",
+    "prettier": "3.5.3",
+    "rimraf": "6.0.1",
+    "rollup": "2.79.2",
+    "ts-node": "10.9.2",
+    "tslib": "2.8.1",
+    "tsup": "^8.4.0",
+    "typescript": "5.8.2"
+  },
+  "dependencies": {
+    "@elizaos/core": "1.0.0-beta.27",
+    "@types/hapi__shot": "^6.0.0",
+    "buffer": "^6.0.3",
+    "crypto-browserify": "^3.12.1",
+    "dotenv": "16.4.5",
+    "events": "^3.3.0",
+    "glob": "11.0.0",
+    "handlebars": "^4.7.8",
+    "js-sha1": "0.7.0",
+    "langchain": "^0.3.15",
+    "pino": "^9.6.0",
+    "pino-pretty": "^13.0.0",
+    "stream-browserify": "^3.0.0",
+    "unique-names-generator": "4.7.1",
+    "uuid": "11.0.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "7b01ea21f51671371e738134c80c958483b7b709"
+}

--- a/packages/core-plugin-v2/src/actions.ts
+++ b/packages/core-plugin-v2/src/actions.ts
@@ -1,0 +1,34 @@
+import {
+  composeActionExamples as coreComposeActionExamples,
+  formatActionNames as coreFormatActionNames,
+  formatActions as coreFormatActions,
+} from '@elizaos/core';
+
+/**
+ * Compose a specified number of random action examples from the given actionsData.
+ *
+ * @param {Action[]} actionsData - The list of actions to generate examples from.
+ * @param {number} count - The number of examples to compose.
+ * @returns {string} The formatted action examples.
+ */
+export const composeActionExamples = (actionsData: Action[], count: number) => {
+  return coreComposeActionExamples(actionsData, count);
+};
+
+/**
+ * Formats the names of the provided actions into a comma-separated string.
+ * @param actions - An array of `Action` objects from which to extract names.
+ * @returns A comma-separated string of action names.
+ */
+export function formatActionNames(actions: Action[]) {
+  return coreFormatActionNames(actions);
+}
+
+/**
+ * Formats the provided actions into a detailed string listing each action's name and description, separated by commas and newlines.
+ * @param actions - An array of `Action` objects to format.
+ * @returns A detailed string of actions, including names and descriptions.
+ */
+export function formatActions(actions: Action[]) {
+  return coreFormatActions(actions);
+}

--- a/packages/core-plugin-v2/src/audioUtils.ts
+++ b/packages/core-plugin-v2/src/audioUtils.ts
@@ -1,0 +1,43 @@
+import {
+  getWavHeader as coreGetWavHeader,
+  prependWavHeader as corePrependWavHeader,
+} from '@elizaos/core';
+
+/**
+ * Generates a WAV file header based on the provided audio parameters.
+ * @param {number} audioLength - The length of the audio data in bytes.
+ * @param {number} sampleRate - The sample rate of the audio.
+ * @param {number} [channelCount=1] - The number of channels (default is 1).
+ * @param {number} [bitsPerSample=16] - The number of bits per sample (default is 16).
+ * @returns {Buffer} The WAV file header as a Buffer object.
+ */
+function getWavHeader(
+  audioLength: number,
+  sampleRate: number,
+  channelCount = 1,
+  bitsPerSample = 16
+): Buffer {
+  return coreGetWavHeader(audioLength, sampleRate, channelCount, bitsPerSample);
+}
+
+/**
+ * Prepends a WAV header to a readable stream of audio data.
+ *
+ * @param {Readable} readable - The readable stream containing the audio data.
+ * @param {number} audioLength - The length of the audio data in seconds.
+ * @param {number} sampleRate - The sample rate of the audio data.
+ * @param {number} [channelCount=1] - The number of channels in the audio data (default is 1).
+ * @param {number} [bitsPerSample=16] - The number of bits per sample in the audio data (default is 16).
+ * @returns {Readable} A new readable stream with the WAV header prepended to the audio data.
+ */
+function prependWavHeader(
+  readable: typeof Readable,
+  audioLength: number,
+  sampleRate: number,
+  channelCount = 1,
+  bitsPerSample = 16
+): typeof Readable {
+  return corePrependWavHeader(readable, audioLength, sampleRate, channelCount, bitsPerSample);
+}
+
+export { getWavHeader, prependWavHeader };

--- a/packages/core-plugin-v2/src/database.ts
+++ b/packages/core-plugin-v2/src/database.ts
@@ -1,0 +1,539 @@
+import type {
+  Agent,
+  Component,
+  Entity,
+  IDatabaseAdapter,
+  Log,
+  Memory,
+  Participant,
+  Relationship,
+  Room,
+  Task,
+  UUID,
+  World,
+  MemoryMetadata,
+} from './types';
+
+/**
+ * Database adapter class to be extended by individual database adapters.
+ *
+ * @template DB - The type of the database instance.
+ * @abstract
+ * @implements {IDatabaseAdapter}
+ */
+export abstract class DatabaseAdapter<DB = unknown> implements IDatabaseAdapter {
+  /**
+   * The database instance.
+   */
+  db: DB;
+
+  /**
+   * Initialize the database adapter.
+   * @returns A Promise that resolves when initialization is complete.
+   */
+  abstract init(): Promise<void>;
+
+  /**
+   * Optional close method for the database adapter.
+   * @returns A Promise that resolves when closing is complete.
+   */
+  abstract close(): Promise<void>;
+
+  /**
+   * Retrieves an account by its ID.
+   * @param entityId The UUID of the user account to retrieve.
+   * @returns A Promise that resolves to the Entity object or null if not found.
+   */
+  abstract getEntityById(entityId: UUID): Promise<Entity | null>;
+
+  abstract getEntitiesForRoom(roomId: UUID, includeComponents?: boolean): Promise<Entity[]>;
+
+  /**
+   * Creates a new entity in the database.
+   * @param entity The entity object to create.
+   * @returns A Promise that resolves when the account creation is complete.
+   */
+  abstract createEntity(entity: Entity): Promise<boolean>;
+
+  /**
+   * Updates an existing entity in the database.
+   * @param entity The entity object with updated properties.
+   * @returns A Promise that resolves when the account update is complete.
+   */
+  abstract updateEntity(entity: Entity): Promise<void>;
+
+  /**
+   * Retrieves a single component by entity ID and type.
+   * @param entityId The UUID of the entity the component belongs to
+   * @param type The type identifier for the component
+   * @param worldId Optional UUID of the world the component belongs to
+   * @param sourceEntityId Optional UUID of the source entity
+   * @returns Promise resolving to the Component if found, null otherwise
+   */
+  abstract getComponent(
+    entityId: UUID,
+    type: string,
+    worldId?: UUID,
+    sourceEntityId?: UUID
+  ): Promise<Component | null>;
+
+  /**
+   * Retrieves all components for an entity.
+   * @param entityId The UUID of the entity to get components for
+   * @param worldId Optional UUID of the world to filter components by
+   * @param sourceEntityId Optional UUID of the source entity to filter by
+   * @returns Promise resolving to array of Component objects
+   */
+  abstract getComponents(
+    entityId: UUID,
+    worldId?: UUID,
+    sourceEntityId?: UUID
+  ): Promise<Component[]>;
+
+  /**
+   * Creates a new component in the database.
+   * @param component The component object to create
+   * @returns Promise resolving to true if creation was successful
+   */
+  abstract createComponent(component: Component): Promise<boolean>;
+
+  /**
+   * Updates an existing component in the database.
+   * @param component The component object with updated properties
+   * @returns Promise that resolves when the update is complete
+   */
+  abstract updateComponent(component: Component): Promise<void>;
+
+  /**
+   * Deletes a component from the database.
+   * @param componentId The UUID of the component to delete
+   * @returns Promise that resolves when the deletion is complete
+   */
+  abstract deleteComponent(componentId: UUID): Promise<void>;
+
+  /**
+   * Retrieves memories based on the specified parameters.
+   * @param params An object containing parameters for the memory retrieval.
+   * @returns A Promise that resolves to an array of Memory objects.
+   */
+  abstract getMemories(params: {
+    entityId?: UUID;
+    agentId?: UUID;
+    roomId?: UUID;
+    count?: number;
+    unique?: boolean;
+    tableName: string;
+    start?: number;
+    end?: number;
+  }): Promise<Memory[]>;
+
+  abstract getMemoriesByRoomIds(params: {
+    roomIds: UUID[];
+    tableName: string;
+    limit?: number;
+  }): Promise<Memory[]>;
+
+  abstract getMemoryById(id: UUID): Promise<Memory | null>;
+
+  /**
+   * Retrieves multiple memories by their IDs
+   * @param memoryIds Array of UUIDs of the memories to retrieve
+   * @param tableName Optional table name to filter memories by type
+   * @returns Promise resolving to array of Memory objects
+   */
+  abstract getMemoriesByIds(memoryIds: UUID[], tableName?: string): Promise<Memory[]>;
+
+  /**
+   * Retrieves cached embeddings based on the specified query parameters.
+   * @param params An object containing parameters for the embedding retrieval.
+   * @returns A Promise that resolves to an array of objects containing embeddings and levenshtein scores.
+   */
+  abstract getCachedEmbeddings({
+    query_table_name,
+    query_threshold,
+    query_input,
+    query_field_name,
+    query_field_sub_name,
+    query_match_count,
+  }: {
+    query_table_name: string;
+    query_threshold: number;
+    query_input: string;
+    query_field_name: string;
+    query_field_sub_name: string;
+    query_match_count: number;
+  }): Promise<
+    {
+      embedding: number[];
+      levenshtein_score: number;
+    }[]
+  >;
+
+  /**
+   * Logs an event or action with the specified details.
+   * @param params An object containing parameters for the log entry.
+   * @returns A Promise that resolves when the log entry has been saved.
+   */
+  abstract log(params: {
+    body: { [key: string]: unknown };
+    entityId: UUID;
+    roomId: UUID;
+    type: string;
+  }): Promise<void>;
+
+  /**
+   * Retrieves logs based on the specified parameters.
+   * @param params An object containing parameters for the log retrieval.
+   * @returns A Promise that resolves to an array of Log objects.
+   */
+  abstract getLogs(params: {
+    entityId: UUID;
+    roomId?: UUID;
+    type?: string;
+    count?: number;
+    offset?: number;
+  }): Promise<Log[]>;
+
+  /**
+   * Deletes a log from the database.
+   * @param logId The UUID of the log to delete.
+   * @returns A Promise that resolves when the log has been deleted.
+   */
+  abstract deleteLog(logId: UUID): Promise<void>;
+
+  /**
+   * Searches for memories based on embeddings and other specified parameters.
+   * @param params An object containing parameters for the memory search.
+   * @returns A Promise that resolves to an array of Memory objects.
+   */
+  abstract searchMemories(params: {
+    tableName: string;
+    roomId: UUID;
+    embedding: number[];
+    match_threshold: number;
+    count: number;
+    unique: boolean;
+  }): Promise<Memory[]>;
+
+  /**
+   * Creates a new memory in the database.
+   * @param memory The memory object to create.
+   * @param tableName The table where the memory should be stored.
+   * @param unique Indicates if the memory should be unique.
+   * @returns A Promise that resolves when the memory has been created.
+   */
+  abstract createMemory(memory: Memory, tableName: string, unique?: boolean): Promise<UUID>;
+
+  /**
+   * Updates an existing memory in the database.
+   * @param memory The memory object with updated content and optional embedding
+   * @returns Promise resolving to boolean indicating success
+   */
+  abstract updateMemory(
+    memory: Partial<Memory> & { id: UUID; metadata?: MemoryMetadata }
+  ): Promise<boolean>;
+
+  /**
+   * Removes a specific memory from the database.
+   * @param memoryId The UUID of the memory to remove.
+   * @returns A Promise that resolves when the memory has been removed.
+   */
+  abstract deleteMemory(memoryId: UUID): Promise<void>;
+
+  /**
+   * Removes all memories associated with a specific room.
+   * @param roomId The UUID of the room whose memories should be removed.
+   * @param tableName The table from which the memories should be removed.
+   * @returns A Promise that resolves when all memories have been removed.
+   */
+  abstract deleteAllMemories(roomId: UUID, tableName: string): Promise<void>;
+
+  /**
+   * Counts the number of memories in a specific room.
+   * @param roomId The UUID of the room for which to count memories.
+   * @param unique Specifies whether to count only unique memories.
+   * @param tableName Optional table name to count memories from.
+   * @returns A Promise that resolves to the number of memories.
+   */
+  abstract countMemories(roomId: UUID, unique?: boolean, tableName?: string): Promise<number>;
+
+  /**
+   * Retrieves a world by its ID.
+   * @param id The UUID of the world to retrieve.
+   * @returns A Promise that resolves to the World object or null if not found.
+   */
+  abstract getWorld(id: UUID): Promise<World | null>;
+
+  /**
+   * Retrieves all worlds for an agent.
+   * @returns A Promise that resolves to an array of World objects.
+   */
+  abstract getAllWorlds(): Promise<World[]>;
+
+  /**
+   * Creates a new world in the database.
+   * @param world The world object to create.
+   * @returns A Promise that resolves to the UUID of the created world.
+   */
+  abstract createWorld(world: World): Promise<UUID>;
+
+  /**
+   * Updates an existing world in the database.
+   * @param world The world object with updated properties.
+   * @returns A Promise that resolves when the world has been updated.
+   */
+  abstract updateWorld(world: World): Promise<void>;
+
+  /**
+   * Removes a specific world from the database.
+   * @param id The UUID of the world to remove.
+   * @returns A Promise that resolves when the world has been removed.
+   */
+  abstract removeWorld(id: UUID): Promise<void>;
+
+  /**
+   * Retrieves the room ID for a given room, if it exists.
+   * @param roomId The UUID of the room to retrieve.
+   * @returns A Promise that resolves to the room ID or null if not found.
+   */
+  abstract getRoom(roomId: UUID): Promise<Room | null>;
+
+  /**
+   * Retrieves all rooms for a given world.
+   * @param worldId The UUID of the world to retrieve rooms for.
+   * @returns A Promise that resolves to an array of Room objects.
+   */
+  abstract getRooms(worldId: UUID): Promise<Room[]>;
+
+  /**
+   * Creates a new room with an optional specified ID.
+   * @param roomId Optional UUID to assign to the new room.
+   * @returns A Promise that resolves to the UUID of the created room.
+   */
+  abstract createRoom({ id, source, type, channelId, serverId, worldId }: Room): Promise<UUID>;
+
+  /**
+   * Updates a specific room in the database.
+   * @param room The room object with updated properties.
+   * @returns A Promise that resolves when the room has been updated.
+   */
+  abstract updateRoom(room: Room): Promise<void>;
+
+  /**
+   * Removes a specific room from the database.
+   * @param roomId The UUID of the room to remove.
+   * @returns A Promise that resolves when the room has been removed.
+   */
+  abstract deleteRoom(roomId: UUID): Promise<void>;
+
+  /**
+   * Retrieves room IDs for which a specific user is a participant.
+   * @param entityId The UUID of the user.
+   * @returns A Promise that resolves to an array of room IDs.
+   */
+  abstract getRoomsForParticipant(entityId: UUID): Promise<UUID[]>;
+
+  /**
+   * Retrieves room IDs for which specific users are participants.
+   * @param userIds An array of UUIDs of the users.
+   * @returns A Promise that resolves to an array of room IDs.
+   */
+  abstract getRoomsForParticipants(userIds: UUID[]): Promise<UUID[]>;
+
+  /**
+   * Adds a user as a participant to a specific room.
+   * @param entityId The UUID of the user to add as a participant.
+   * @param roomId The UUID of the room to which the user will be added.
+   * @returns A Promise that resolves to a boolean indicating success or failure.
+   */
+  abstract addParticipant(entityId: UUID, roomId: UUID): Promise<boolean>;
+
+  /**
+   * Removes a user as a participant from a specific room.
+   * @param entityId The UUID of the user to remove as a participant.
+   * @param roomId The UUID of the room from which the user will be removed.
+   * @returns A Promise that resolves to a boolean indicating success or failure.
+   */
+  abstract removeParticipant(entityId: UUID, roomId: UUID): Promise<boolean>;
+
+  /**
+   * Retrieves participants associated with a specific account.
+   * @param entityId The UUID of the account.
+   * @returns A Promise that resolves to an array of Participant objects.
+   */
+  abstract getParticipantsForEntity(entityId: UUID): Promise<Participant[]>;
+
+  /**
+   * Retrieves participants for a specific room.
+   * @param roomId The UUID of the room for which to retrieve participants.
+   * @returns A Promise that resolves to an array of UUIDs representing the participants.
+   */
+  abstract getParticipantsForRoom(roomId: UUID): Promise<UUID[]>;
+
+  abstract getParticipantUserState(
+    roomId: UUID,
+    entityId: UUID
+  ): Promise<'FOLLOWED' | 'MUTED' | null>;
+
+  abstract setParticipantUserState(
+    roomId: UUID,
+    entityId: UUID,
+    state: 'FOLLOWED' | 'MUTED' | null
+  ): Promise<void>;
+
+  /**
+   * Creates a new relationship between two users.
+   * @param params Object containing the relationship details including entity IDs, agent ID, optional tags and metadata
+   * @returns A Promise that resolves to a boolean indicating success or failure of the creation.
+   */
+  abstract createRelationship(params: {
+    sourceEntityId: UUID;
+    targetEntityId: UUID;
+    tags?: string[];
+    metadata?: Record<string, unknown>;
+  }): Promise<boolean>;
+
+  /**
+   * Retrieves a relationship between two users if it exists.
+   * @param params Object containing the entity IDs and agent ID
+   * @returns A Promise that resolves to the Relationship object or null if not found.
+   */
+  abstract getRelationship(params: {
+    sourceEntityId: UUID;
+    targetEntityId: UUID;
+  }): Promise<Relationship | null>;
+
+  /**
+   * Retrieves all relationships for a specific user.
+   * @param params Object containing the user ID, agent ID and optional tags to filter by
+   * @returns A Promise that resolves to an array of Relationship objects.
+   */
+  abstract getRelationships(params: { entityId: UUID; tags?: string[] }): Promise<Relationship[]>;
+
+  /**
+   * Updates an existing relationship between two users.
+   * @param params Object containing the relationship details to update including entity IDs, agent ID, optional tags and metadata
+   * @returns A Promise that resolves to a boolean indicating success or failure of the update.
+   */
+  abstract updateRelationship(params: {
+    sourceEntityId: UUID;
+    targetEntityId: UUID;
+    tags?: string[];
+    metadata?: Record<string, unknown>;
+  }): Promise<void>;
+
+  /**
+   * Retrieves an agent by its ID.
+   * @param agentId The UUID of the agent to retrieve.
+   * @returns A Promise that resolves to the Agent object or null if not found.
+   */
+  abstract getAgent(agentId: UUID): Promise<Agent | null>;
+
+  /**
+   * Retrieves all agents from the database.
+   * @returns A Promise that resolves to an array of Agent objects.
+   */
+  abstract getAgents(): Promise<Agent[]>;
+
+  /**
+   * Creates a new agent in the database.
+   * @param agent The agent object to create.
+   * @returns A Promise that resolves to a boolean indicating success or failure of the creation.
+   */
+  abstract createAgent(agent: Partial<Agent>): Promise<boolean>;
+
+  /**
+   * Updates an existing agent in the database.
+   * @param agentId The UUID of the agent to update.
+   * @param agent The agent object with updated properties.
+   * @returns A Promise that resolves to a boolean indicating success or failure of the update.
+   */
+  abstract updateAgent(agentId: UUID, agent: Partial<Agent>): Promise<boolean>;
+
+  /**
+   * Deletes an agent from the database.
+   * @param agentId The UUID of the agent to delete.
+   * @returns A Promise that resolves to a boolean indicating success or failure of the deletion.
+   */
+  abstract deleteAgent(agentId: UUID): Promise<boolean>;
+
+  /**
+   * Ensures an agent exists in the database.
+   * @param agent The agent object to ensure exists.
+   * @returns A Promise that resolves when the agent has been ensured to exist.
+   */
+  abstract ensureAgentExists(agent: Partial<Agent>): Promise<void>;
+
+  /**
+   * Ensures an embedding dimension exists in the database.
+   * @param dimension The dimension to ensure exists.
+   * @returns A Promise that resolves when the embedding dimension has been ensured to exist.
+   */
+  abstract ensureEmbeddingDimension(dimension: number): Promise<void>;
+
+  /**
+   * Retrieves a cached value by key from the database.
+   * @param key The key to look up in the cache
+   * @returns Promise resolving to the cached string value
+   */
+  abstract getCache<T>(key: string): Promise<T | undefined>;
+
+  /**
+   * Sets a value in the cache with the given key.
+   * @param params Object containing the cache key and value
+   * @param key The key to store the value under
+   * @param value The string value to cache
+   * @returns Promise resolving to true if the cache was set successfully
+   */
+  abstract setCache<T>(key: string, value: T): Promise<boolean>;
+
+  /**
+   * Deletes a value from the cache by key.
+   * @param key The key to delete from the cache
+   * @returns Promise resolving to true if the value was successfully deleted
+   */
+  abstract deleteCache(key: string): Promise<boolean>;
+
+  /**
+   * Creates a new task instance in the database.
+   * @param task The task object to create
+   * @returns Promise resolving to the UUID of the created task
+   */
+  abstract createTask(task: Task): Promise<UUID>;
+
+  /**
+   * Retrieves tasks based on specified parameters.
+   * @param params Object containing optional roomId and tags to filter tasks
+   * @returns Promise resolving to an array of Task objects
+   */
+  abstract getTasks(params: { roomId?: UUID; tags?: string[] }): Promise<Task[]>;
+
+  /**
+   * Retrieves a specific task by its ID.
+   * @param id The UUID of the task to retrieve
+   * @returns Promise resolving to the Task object if found, null otherwise
+   */
+  abstract getTask(id: UUID): Promise<Task | null>;
+
+  /**
+   * Retrieves a specific task by its name.
+   * @param name The name of the task to retrieve
+   * @returns Promise resolving to the Task object if found, null otherwise
+   */
+  abstract getTasksByName(name: string): Promise<Task[]>;
+
+  /**
+   * Updates an existing task in the database.
+   * @param id The UUID of the task to update
+   * @param task Partial Task object containing the fields to update
+   * @returns Promise resolving when the update is complete
+   */
+  abstract updateTask(id: UUID, task: Partial<Task>): Promise<void>;
+
+  /**
+   * Deletes a task from the database.
+   * @param id The UUID of the task to delete
+   * @returns Promise resolving when the deletion is complete
+   */
+  abstract deleteTask(id: UUID): Promise<void>;
+}

--- a/packages/core-plugin-v2/src/entities.ts
+++ b/packages/core-plugin-v2/src/entities.ts
@@ -1,0 +1,72 @@
+import {
+  findEntityByName as coreFindEntityByName,
+  createUniqueUuid as coreCreateUniqueUuid,
+  getEntityDetails as coreGetEntityDetails,
+  formatEntities as coreFormatEntitiese,
+} from '@elizaos/core';
+
+import {
+  type Entity,
+  type IAgentRuntime,
+  type Memory,
+  ModelType,
+  type Relationship,
+  type State,
+  type UUID,
+} from './types';
+
+/**
+ * Finds an entity by name in the given runtime environment.
+ *
+ * @param {IAgentRuntime} runtime - The agent runtime environment.
+ * @param {Memory} message - The memory message containing relevant information.
+ * @param {State} state - The current state of the system.
+ * @returns {Promise<Entity | null>} A promise that resolves to the found entity or null if not found.
+ */
+export async function findEntityByName(
+  runtime: IAgentRuntime,
+  message: Memory,
+  state: State
+): Promise<Entity | null> {
+  return coreFindEntityByName(runtime, message, state);
+}
+
+/**
+ * Function to create a unique UUID based on the runtime and base user ID.
+ *
+ * @param {RuntimeContext} runtime - The runtime context object.
+ * @param {UUID|string} baseUserId - The base user ID to use in generating the UUID.
+ * @returns {UUID} - The unique UUID generated based on the runtime and base user ID.
+ */
+export const createUniqueUuid = (runtime, baseUserId: UUID | string): UUID => {
+  return coreCreateUniqueUuid(runtime, baseUserId);
+};
+
+/**
+ * Retrieves entity details for a specific room from the database.
+ *
+ * @param {Object} params - The input parameters
+ * @param {IAgentRuntime} params.runtime - The Agent Runtime instance
+ * @param {UUID} params.roomId - The ID of the room to retrieve entity details for
+ * @returns {Promise<Array>} - A promise that resolves to an array of unique entity details
+ */
+export async function getEntityDetails({
+  runtime,
+  roomId,
+}: {
+  runtime: IAgentRuntime;
+  roomId: UUID;
+}) {
+  return coreGetEntityDetails({ runtime, roomId });
+}
+
+/**
+ * Format the given entities into a string representation.
+ *
+ * @param {Object} options - The options object.
+ * @param {Entity[]} options.entities - The list of entities to format.
+ * @returns {string} A formatted string representing the entities.
+ */
+export function formatEntities({ entities }: { entities: Entity[] }) {
+  return coreFormatEntities({ entities });
+}

--- a/packages/core-plugin-v2/src/index.ts
+++ b/packages/core-plugin-v2/src/index.ts
@@ -1,0 +1,14 @@
+// Export everything from types
+export * from './types';
+
+// Then all other exports
+export * from './actions';
+export * from './database';
+export * from './entities';
+export * from './logger';
+export * from './prompts';
+export * from './roles';
+export * from './runtime';
+export * from './settings';
+export * from './uuid';
+export * from './audioUtils';

--- a/packages/core-plugin-v2/src/logger.ts
+++ b/packages/core-plugin-v2/src/logger.ts
@@ -1,0 +1,35 @@
+import { logger as coreLogger } from '@elizaos/core';
+
+// logger wrapper/specification
+const logger: Record<
+  | 'trace'
+  | 'debug'
+  | 'success'
+  | 'progress'
+  | 'log'
+  | 'info'
+  | 'warn'
+  | 'error'
+  | 'fatal'
+  | 'clear',
+  LogMethod
+> = {
+  trace: (...args) => coreLogger.trace(...args),
+  debug: (...args) => coreLogger.debug(...args),
+  success: (...args) => coreLogger.debug(...args),
+  progress: (...args) => coreLogger.debug(...args),
+  log: (...args) => coreLogger.info(...args),
+  info: (...args) => coreLogger.info(...args),
+  warn: (...args) => coreLogger.warn(...args),
+  error: (...args) => coreLogger.error(...args),
+  fatal: (...args) => coreLogger.fatal(...args),
+  clear: () => coreLogger.clear(),
+};
+
+export { logger };
+
+// for backward compatibility
+// we should deprecate this
+export const elizaLogger = logger;
+
+export default logger;

--- a/packages/core-plugin-v2/src/prompts.ts
+++ b/packages/core-plugin-v2/src/prompts.ts
@@ -1,0 +1,274 @@
+import {
+  composePrompt as coreComposePrompt,
+  composePromptFromState as coreComposePromptFromState,
+  addHeader as coreAddHeader,
+  composeRandomUser as coreComposeRandomUser,
+  formatPosts as coreFormatPosts,
+  formatMessages as coreFormatMessages,
+  formatTimestamp as coreFormatTimestamp,
+  shouldRespondTemplate as coreShouldRespondTemplate,
+  messageHandlerTemplate as coreMessageHandlerTemplate,
+  postCreationTemplate as corePostCreationTemplate,
+  booleanFooter as coreBooleanFooter,
+  parseBooleanFromText as coreParseBooleanFromText,
+  stringArrayFooter as coreStringArrayFooter,
+  parseJsonArrayFromText as coreParseJsonArrayFromText,
+  extractAttributes as coreExtractAttributes,
+  normalizeJsonString as coreNormalizeJsonString,
+  cleanJsonResponse as coreCleanJsonResponse,
+  postActionResponseFooter as corePostActionResponseFooter,
+  parseActionResponseFromText as coreParseActionResponseFromText,
+  truncateToCompleteSentence as coreTruncateToCompleteSentence,
+  splitChunks as coreSplitChunks,
+  trimTokens as coreTrimTokens,
+} from '@elizaos/core';
+
+/**
+ * Composes a context string by replacing placeholders in a template with corresponding values from the state.
+ *
+ * This function takes a template string with placeholders in the format `{{placeholder}}` and a state object.
+ * It replaces each placeholder with the value from the state object that matches the placeholder's name.
+ * If a matching key is not found in the state object for a given placeholder, the placeholder is replaced with an empty string.
+ *
+ * @param {Object} params - The parameters for composing the context.
+ * @param {State} params.state - The state object containing values to replace the placeholders in the template.
+ * @param {TemplateType} params.template - The template string or function containing placeholders to be replaced with state values.
+ * @returns {string} The composed context string with placeholders replaced by corresponding state values.
+ *
+ * @example
+ * // Given a state object and a template
+ * const state = { userName: "Alice", userAge: 30 };
+ * const template = "Hello, {{userName}}! You are {{userAge}} years old";
+ *
+ * // Composing the context with simple string replacement will result in:
+ * // "Hello, Alice! You are 30 years old."
+ * const contextSimple = composePromptFromState({ state, template });
+ *
+ * // Using composePromptFromState with a template function for dynamic template
+ * const template = ({ state }) => {
+ * const tone = Math.random() > 0.5 ? "kind" : "rude";
+ *   return `Hello, {{userName}}! You are {{userAge}} years old. Be ${tone}`;
+ * };
+ * const contextSimple = composePromptFromState({ state, template });
+ */
+export const composePrompt = ({
+  state,
+  template,
+}: {
+  state: { [key: string]: string };
+  template: TemplateType;
+}) => {
+  return coreComposePrompt(state, template);
+};
+
+/**
+ * Function to compose a prompt using a provided template and state.
+ *
+ * @param {Object} options - Object containing state and template information.
+ * @param {State} options.state - The state object containing values to fill the template.
+ * @param {TemplateType} options.template - The template to be used for composing the prompt.
+ * @returns {string} The composed prompt output.
+ */
+export const composePromptFromState = ({
+  state,
+  template,
+}: {
+  state: State;
+  template: TemplateType;
+}) => {
+  return coreComposePromptFromState(state, template);
+};
+
+/**
+ * Adds a header to a body of text.
+ *
+ * This function takes a header string and a body string and returns a new string with the header prepended to the body.
+ * If the body string is empty, the header is returned as is.
+ *
+ * @param {string} header - The header to add to the body.
+ * @param {string} body - The body to which to add the header.
+ * @returns {string} The body with the header prepended.
+ *
+ * @example
+ * // Given a header and a body
+ * const header = "Header";
+ * const body = "Body";
+ *
+ * // Adding the header to the body will result in:
+ * // "Header\nBody"
+ * const text = addHeader(header, body);
+ */
+export const addHeader = (header: string, body: string) => {
+  return coreAddHeader(header, body);
+};
+
+/**
+ * Generates a string with random user names populated in a template.
+ *
+ * This function generates random user names and populates placeholders
+ * in the provided template with these names. Placeholders in the template should follow the format `{{userX}}`
+ * where `X` is the position of the user (e.g., `{{name1}}`, `{{name2}}`).
+ *
+ * @param {string} template - The template string containing placeholders for random user names.
+ * @param {number} length - The number of random user names to generate.
+ * @returns {string} The template string with placeholders replaced by random user names.
+ *
+ * @example
+ * // Given a template and a length
+ * const template = "Hello, {{name1}}! Meet {{name2}} and {{name3}}.";
+ * const length = 3;
+ *
+ * // Composing the random user string will result in:
+ * // "Hello, John! Meet Alice and Bob."
+ * const result = composeRandomUser(template, length);
+ */
+export const composeRandomUser = (template: string, length: number) => {
+  return coreComposeRandomUser(template, length);
+};
+
+export const formatPosts = ({
+  messages,
+  entities,
+  conversationHeader = true,
+}: {
+  messages: Memory[];
+  entities: Entity[];
+  conversationHeader?: boolean;
+}) => {
+  return coreFormatPosts(messages, entities, conversationHeader);
+};
+
+/**
+ * Format messages into a string
+ * @param {Object} params - The formatting parameters
+ * @param {Memory[]} params.messages - List of messages to format
+ * @param {Entity[]} params.entities - List of entities for name resolution
+ * @returns {string} Formatted message string with timestamps and user information
+ */
+export const formatMessages = ({
+  messages,
+  entities,
+}: {
+  messages: Memory[];
+  entities: Entity[];
+}) => {
+  return coreFormatMessages(messages, entites);
+};
+
+export const formatTimestamp = (messageDate: number) => {
+  return coreFormatTimestamp(messageDate);
+};
+
+export const shouldRespondTemplate: string = coreShouldRespondTemplate;
+export const messageHandlerTemplate: string = coreMessageHandlerTemplate;
+export const postCreationTemplate: string = corePostCreationTemplate;
+export const booleanFooter: string = coreBooleanFooter;
+
+/**
+ * Parses a string to determine its boolean equivalent.
+ *
+ * Recognized affirmative values: "YES", "Y", "TRUE", "T", "1", "ON", "ENABLE"
+ * Recognized negative values: "NO", "N", "FALSE", "F", "0", "OFF", "DISABLE"
+ *
+ * @param {string | undefined | null} value - The input text to parse
+ * @returns {boolean} - Returns `true` for affirmative inputs, `false` for negative or unrecognized inputs
+ */
+export function parseBooleanFromText(value: string | undefined | null): boolean {
+  return coreParseBooleanFromText(value);
+}
+
+export const stringArrayFooter = coreStringArrayFooter;
+
+/**
+ * Parses a JSON array from a given text. The function looks for a JSON block wrapped in triple backticks
+ * with `json` language identifier, and if not found, it searches for an array pattern within the text.
+ * It then attempts to parse the JSON string into a JavaScript object. If parsing is successful and the result
+ * is an array, it returns the array; otherwise, it returns null.
+ *
+ * @param text - The input text from which to extract and parse the JSON array.
+ * @returns An array parsed from the JSON string if successful; otherwise, null.
+ */
+export function parseJsonArrayFromText(text: string) {
+  return coreParseJsonArrayFromText(text);
+}
+
+/**
+ * Parses a JSON object from a given text. The function looks for a JSON block wrapped in triple backticks
+ * with `json` language identifier, and if not found, it searches for an object pattern within the text.
+ * It then attempts to parse the JSON string into a JavaScript object. If parsing is successful and the result
+ * is an object (but not an array), it returns the object; otherwise, it tries to parse an array if the result
+ * is an array, or returns null if parsing is unsuccessful or the result is neither an object nor an array.
+ *
+ * @param text - The input text from which to extract and parse the JSON object.
+ * @returns An object parsed from the JSON string if successful; otherwise, null or the result of parsing an array.
+ */
+export function parseJSONObjectFromText(text: string): Record<string, any> | null {
+  return coreParseJSONObjectFromText(text);
+}
+
+/**
+ * Extracts specific attributes (e.g., user, text, action) from a JSON-like string using regex.
+ * @param response - The cleaned string response to extract attributes from.
+ * @param attributesToExtract - An array of attribute names to extract.
+ * @returns An object containing the extracted attributes.
+ */
+export function extractAttributes(
+  response: string,
+  attributesToExtract?: string[]
+): { [key: string]: string | undefined } {
+  return coreExtractAttributes(response, attributesToExtract);
+}
+
+/**
+ * Normalizes a JSON-like string by correcting formatting issues:
+ * - Removes extra spaces after '{' and before '}'.
+ * - Wraps unquoted values in double quotes.
+ * - Converts single-quoted values to double-quoted.
+ * - Ensures consistency in key-value formatting.
+ * - Normalizes mixed adjacent quote pairs.
+ *
+ * This is useful for cleaning up improperly formatted JSON strings
+ * before parsing them into valid JSON.
+ *
+ * @param str - The JSON-like string to normalize.
+ * @returns A properly formatted JSON string.
+ */
+
+export const normalizeJsonString = (str: string) => {
+  return coreNormalizeJsonString(str);
+};
+
+/**
+ * Cleans a JSON-like response string by removing unnecessary markers, line breaks, and extra whitespace.
+ * This is useful for handling improperly formatted JSON responses from external sources.
+ *
+ * @param response - The raw JSON-like string response to clean.
+ * @returns The cleaned string, ready for parsing or further processing.
+ */
+export function cleanJsonResponse(response: string): string {
+  return coreCleanJsonResponse(response);
+}
+
+export const postActionResponseFooter: string = corePostActionResponseFooter;
+
+export const parseActionResponseFromText = (text: string): { actions: ActionResponse } => {
+  return coreParseActionResponseFromText(text);
+};
+
+/**
+ * Truncate text to fit within the character limit, ensuring it ends at a complete sentence.
+ */
+export function truncateToCompleteSentence(text: string, maxLength: number): string {
+  return coreTruncateToCompleteSentence(text, maxLength);
+}
+
+export async function splitChunks(content: string, chunkSize = 512, bleed = 20): Promise<string[]> {
+  return coreSplitChunks(content, chunkSize, bleed);
+}
+
+/**
+ * Trims the provided text prompt to a specified token limit using a tokenizer model and type.
+ */
+export async function trimTokens(prompt: string, maxTokens: number, runtime: IAgentRuntime) {
+  return coreTrimTokens(prompt, maxTokens, runtime);
+}

--- a/packages/core-plugin-v2/src/roles.ts
+++ b/packages/core-plugin-v2/src/roles.ts
@@ -1,0 +1,41 @@
+import {
+  getUserServerRole as coreGetUserServerRole,
+  findWorldsForOwner as coreFindWorldsForOwner,
+} from '@elizaos/core';
+import { type IAgentRuntime, Role, type World } from './types';
+
+/**
+ * Interface representing the ownership state of servers.
+ * @property {Object.<string, World>} servers - The servers and their corresponding worlds, where the key is the server ID and the value is the World object.
+ */
+export interface ServerOwnershipState {
+  servers: {
+    [serverId: string]: World;
+  };
+}
+
+/**
+ * Retrieve the server role of a specified user entity within a given server.
+ *
+ * @param {IAgentRuntime} runtime - The runtime object containing necessary configurations and services.
+ * @param {string} entityId - The unique identifier of the user entity.
+ * @param {string} serverId - The unique identifier of the server.
+ * @returns {Promise<Role>} The role of the user entity within the server, resolved as a Promise.
+ */
+export async function getUserServerRole(
+  runtime: IAgentRuntime,
+  entityId: string,
+  serverId: string
+): Promise<Role> {
+  return coreGetUserServerRole(runtime, entityId, serverId);
+}
+
+/**
+ * Finds a server where the given user is the owner
+ */
+export async function findWorldsForOwner(
+  runtime: IAgentRuntime,
+  entityId: string
+): Promise<World[] | null> {
+  return coreFindWorldsForOwner(runtime, entityId);
+}

--- a/packages/core-plugin-v2/src/runtime.ts
+++ b/packages/core-plugin-v2/src/runtime.ts
@@ -1,0 +1,684 @@
+import { Semaphore as coreSemaphore, AgentRuntime as coreAgentRuntime } from '@elizaos/core';
+// Import types with the 'type' keyword
+import type {
+  Action,
+  Agent,
+  Character,
+  Component,
+  Entity,
+  Evaluator,
+  HandlerCallback,
+  IAgentRuntime,
+  IDatabaseAdapter,
+  KnowledgeItem,
+  Log,
+  Memory,
+  MemoryMetadata,
+  ModelParamsMap,
+  ModelResultMap,
+  ModelTypeName,
+  Participant,
+  Plugin,
+  Provider,
+  Relationship,
+  Room,
+  Route,
+  RuntimeSettings,
+  Service,
+  ServiceTypeName,
+  State,
+  Task,
+  TaskWorker,
+  UUID,
+  World,
+} from './types';
+
+export class Semaphore {
+  private _semphonre;
+  constructor(count: number) {
+    this._semphonre = new coreSemaphore(count);
+  }
+
+  async acquire(): Promise<void> {
+    return this._semphonre.acquire();
+  }
+
+  release(): void {
+    return this._semphonre.release();
+  }
+}
+
+/**
+ * Represents the runtime environment for an agent.
+ * @class
+ * @implements { IAgentRuntime }
+ * @property { number } #conversationLength - The maximum length of a conversation.
+ * @property { UUID } agentId - The unique identifier for the agent.
+ * @property { Character } character - The character associated with the agent.
+ * @property { IDatabaseAdapter } adapter - The adapter for interacting with the database.
+ * @property {Action[]} actions - The list of actions available to the agent.
+ * @property {Evaluator[]} evaluators - The list of evaluators for decision making.
+ * @property {Provider[]} providers - The list of providers for external services.
+ * @property {Plugin[]} plugins - The list of plugins to extend functionality.
+ */
+export class AgentRuntime implements IAgentRuntime {
+  private _runtime;
+  constructor(opts: {
+    conversationLength?: number;
+    agentId?: UUID;
+    character?: Character;
+    plugins?: Plugin[];
+    fetch?: typeof fetch;
+    adapter?: IDatabaseAdapter;
+    settings?: RuntimeSettings;
+    events?: { [key: string]: ((params: any) => void)[] };
+  }) {
+    this._runtime = new coreAgentRuntime(opts);
+  }
+
+  /**
+   * Registers a plugin with the runtime and initializes its components
+   * @param plugin The plugin to register
+   */
+  async registerPlugin(plugin: Plugin): Promise<void> {
+    return this._runtime.registerPlugin(plugin);
+  }
+
+  getAllServices(): Map<ServiceTypeName, Service> {
+    return this._runtime.services;
+  }
+
+  async stop() {
+    return this._runtime.stop();
+  }
+
+  async initialize() {
+    return this._runtime.initialize();
+  }
+
+  async getKnowledge(message: Memory): Promise<KnowledgeItem[]> {
+    return this._runtime.getKnowledge(message);
+  }
+
+  async addKnowledge(
+    item: KnowledgeItem,
+    options = {
+      targetTokens: 1500,
+      overlap: 200,
+      modelContextSize: 4096,
+    }
+  ) {
+    return this._runtime.addKnowledge(item, options);
+  }
+
+  async processCharacterKnowledge(items: string[]) {
+    return this._runtime.processCharacterKnowledge(items);
+  }
+
+  setSetting(key: string, value: string | boolean | null | any, secret = false) {
+    return this._runtime.setSetting(key, value, secret);
+  }
+
+  getSetting(key: string): string | boolean | null | any {
+    return this._runtime.getSetting(key);
+  }
+
+  /**
+   * Get the number of messages that are kept in the conversation buffer.
+   * @returns The number of recent messages to be kept in memory.
+   */
+  getConversationLength() {
+    return this._runtime.getConversationLength();
+  }
+
+  registerDatabaseAdapter(adapter: IDatabaseAdapter) {
+    return this._runtime.registerDatabaseAdapter(adapter);
+  }
+
+  /**
+   * Register a provider for the agent to use.
+   * @param provider The provider to register.
+   */
+  registerProvider(provider: Provider) {
+    return this._runtime.registerProvider(provider);
+  }
+
+  /**
+   * Register an action for the agent to perform.
+   * @param action The action to register.
+   */
+  registerAction(action: Action) {
+    return this._runtime.registerAction(action);
+  }
+
+  /**
+   * Register an evaluator to assess and guide the agent's responses.
+   * @param evaluator The evaluator to register.
+   */
+  registerEvaluator(evaluator: Evaluator) {
+    return this._runtime.registerEvaluator(evaluator);
+  }
+
+  /**
+   * Register a context provider to provide context for message generation.
+   * @param provider The context provider to register.
+   */
+  registerContextProvider(provider: Provider) {
+    return this._runtime.registerContextProvider(provider);
+  }
+
+  /**
+   * Process the actions of a message.
+   * @param message The message to process.
+   * @param responses The array of response memories to process actions from.
+   * @param state Optional state object for the action processing.
+   * @param callback Optional callback handler for action results.
+   */
+  async processActions(
+    message: Memory,
+    responses: Memory[],
+    state?: State,
+    callback?: HandlerCallback
+  ): Promise<void> {
+    return this._runtime.processActions(message, responses, state, callback);
+  }
+
+  /**
+   * Evaluate the message and state using the registered evaluators.
+   * @param message The message to evaluate.
+   * @param state The state of the agent.
+   * @param didRespond Whether the agent responded to the message.~
+   * @param callback The handler callback
+   * @returns The results of the evaluation.
+   */
+  async evaluate(
+    message: Memory,
+    state: State,
+    didRespond?: boolean,
+    callback?: HandlerCallback,
+    responses?: Memory[]
+  ) {
+    return this._runtime.evaluate(message, state, didRespond, callback, responses);
+  }
+
+  async ensureConnection({
+    entityId,
+    roomId,
+    userName,
+    name,
+    source,
+    type,
+    channelId,
+    serverId,
+    worldId,
+    userId,
+  }: {
+    entityId: UUID;
+    roomId: UUID;
+    userName?: string;
+    name?: string;
+    source?: string;
+    type?: ChannelType;
+    channelId?: string;
+    serverId?: string;
+    worldId?: UUID;
+    userId?: UUID;
+  }) {
+    return this._runtime.ensureConnection({
+      entityId,
+      roomId,
+      userName,
+      name,
+      source,
+      type,
+      channelId,
+      serverId,
+      worldId,
+      userId,
+    });
+  }
+
+  /**
+   * Ensures a participant is added to a room, checking that the entity exists first
+   */
+  async ensureParticipantInRoom(entityId: UUID, roomId: UUID) {
+    return this._runtime.ensureParticipantInRoom(entityId, roomid);
+  }
+
+  async removeParticipant(entityId: UUID, roomId: UUID): Promise<boolean> {
+    return this._runtime.removeParticipant(entityId, roomid);
+  }
+
+  async getParticipantsForEntity(entityId: UUID): Promise<Participant[]> {
+    return this._runtime.getParticipantsForEntity(entityId);
+  }
+
+  async getParticipantsForRoom(roomId: UUID): Promise<UUID[]> {
+    return this._runtime.getParticipantsForRoom(roomid);
+  }
+
+  async addParticipant(entityId: UUID, roomId: UUID): Promise<boolean> {
+    return this._runtime.addParticipant(entityId, roomid);
+  }
+
+  /**
+   * Ensure the existence of a world.
+   */
+  async ensureWorldExists({ id, name, serverId, metadata }: World) {
+    return this._runtime.ensureWorldExists({ id, name, serverId, metadata });
+  }
+
+  /**
+   * Ensure the existence of a room between the agent and a user. If no room exists, a new room is created and the user
+   * and agent are added as participants. The room ID is returned.
+   * @param entityId - The user ID to create a room with.
+   * @returns The room ID of the room between the agent and the user.
+   * @throws An error if the room cannot be created.
+   */
+  async ensureRoomExists({ id, name, source, type, channelId, serverId, worldId, metadata }: Room) {
+    return this._runtime.ensureRoomExists({
+      id,
+      name,
+      source,
+      type,
+      channelId,
+      serverId,
+      worldId,
+      metadata,
+    });
+  }
+
+  /**
+   * Composes the agent's state by gathering data from enabled providers.
+   * @param message - The message to use as context for state composition
+   * @param filterList - Optional list of provider names to include, filtering out all others
+   * @param includeList - Optional list of private provider names to include that would otherwise be filtered out
+   * @returns A State object containing provider data, values, and text
+   */
+  async composeState(
+    message: Memory,
+    filterList: string[] | null = null, // only get providers that are in the filterList
+    includeList: string[] | null = null // include providers that are private, dynamic or otherwise not included by default
+  ): Promise<State> {
+    return this._runtime.composeState({ message, filterList, includeList });
+  }
+
+  getService<T extends Service>(service: ServiceTypeName): T | null {
+    return this._runtime.getService(service);
+  }
+
+  async registerService(service: typeof Service): Promise<void> {
+    return this._runtime.registerService(service);
+  }
+
+  registerModel(modelType: ModelTypeName, handler: (params: any) => Promise<any>) {
+    return this._runtime.registerModel(modelType, handler);
+  }
+
+  getModel(
+    modelType: ModelTypeName
+  ): ((runtime: IAgentRuntime, params: any) => Promise<any>) | undefined {
+    return this._runtime.getModel(modelType);
+  }
+
+  /**
+   * Use a model with strongly typed parameters and return values based on model type
+   * @template T - The model type to use
+   * @template R - The expected return type, defaults to the type defined in ModelResultMap[T]
+   * @param {T} modelType - The type of model to use
+   * @param {ModelParamsMap[T] | any} params - The parameters for the model, typed based on model type
+   * @returns {Promise<R>} - The model result, typed based on the provided generic type parameter
+   */
+  async useModel<T extends ModelTypeName, R = ModelResultMap[T]>(
+    modelType: T,
+    params: Omit<ModelParamsMap[T], 'runtime'> | any
+  ): Promise<R> {
+    return this._runtime.getModel(modelType, params);
+  }
+
+  registerEvent(event: string, handler: (params: any) => Promise<void>) {
+    return this._runtime.registerEvent(event, handler);
+  }
+
+  getEvent(event: string): ((params: any) => Promise<void>)[] | undefined {
+    return this._runtime.getEvent(event);
+  }
+
+  async emitEvent(event: string | string[], params: any) {
+    return this._runtime.emitEvent(event, params);
+  }
+
+  async ensureEmbeddingDimension() {
+    return this._runtime.ensureEmbeddingDimension();
+  }
+
+  registerTaskWorker(taskHandler: TaskWorker): void {
+    return this._runtime.registerTaskWorker(taskHandler);
+  }
+
+  /**
+   * Get a task worker by name
+   */
+  getTaskWorker(name: string): TaskWorker | undefined {
+    return this._runtime.getTaskWorker(name);
+  }
+
+  // Implement database adapter methods
+
+  get db(): any {
+    return this._runtime.db();
+  }
+
+  async init(): Promise<void> {
+    return this._runtime.init();
+  }
+
+  async close(): Promise<void> {
+    return this._runtime.close();
+  }
+
+  async getAgent(agentId: UUID): Promise<Agent | null> {
+    return this._runtime.getAgent(agentId);
+  }
+
+  async getAgents(): Promise<Agent[]> {
+    return this._runtime.getAgents();
+  }
+
+  async createAgent(agent: Partial<Agent>): Promise<boolean> {
+    return this._runtime.createAgent(agent);
+  }
+
+  async updateAgent(agentId: UUID, agent: Partial<Agent>): Promise<boolean> {
+    return this._runtime.updateAgent(agentId, agent);
+  }
+
+  async deleteAgent(agentId: UUID): Promise<boolean> {
+    return this._runtime.deleteAgent(agentId);
+  }
+
+  async ensureAgentExists(agent: Partial<Agent>): Promise<void> {
+    return this._runtime.deleteAgent(agentId);
+  }
+
+  async getEntityById(entityId: UUID): Promise<Entity | null> {
+    return this._runtime.getEntityById(entityId);
+  }
+
+  async getEntitiesForRoom(roomId: UUID, includeComponents?: boolean): Promise<Entity[]> {
+    return this._runtime.getEntitiesForRoom(roomId, includeComponents);
+  }
+
+  async createEntity(entity: Entity): Promise<boolean> {
+    return this._runtime.createEntity(entity);
+  }
+
+  async updateEntity(entity: Entity): Promise<void> {
+    return this._runtime.updateEntity(entity);
+  }
+
+  async getComponent(
+    entityId: UUID,
+    type: string,
+    worldId?: UUID,
+    sourceEntityId?: UUID
+  ): Promise<Component | null> {
+    return this._runtime.getComponent(entityId, type, worldId, sourceEntityId);
+  }
+
+  async getComponents(entityId: UUID, worldId?: UUID, sourceEntityId?: UUID): Promise<Component[]> {
+    return this._runtime.getComponents(entityId, worldId, sourceEntityId);
+  }
+
+  async createComponent(component: Component): Promise<boolean> {
+    return this._runtime.createComponent(component);
+  }
+
+  async updateComponent(component: Component): Promise<void> {
+    return this._runtime.updateComponent(component);
+  }
+
+  async deleteComponent(componentId: UUID): Promise<void> {
+    return this._runtime.deleteComponent(componentId);
+  }
+
+  async addEmbeddingToMemory(memory: Memory): Promise<Memory> {
+    return this._runtime.deleteComponent(componentId);
+  }
+
+  async getMemories(params: {
+    entityId?: UUID;
+    agentId?: UUID;
+    roomId?: UUID;
+    count?: number;
+    unique?: boolean;
+    tableName: string;
+    start?: number;
+    end?: number;
+  }): Promise<Memory[]> {
+    return this._runtime.getMemories(params);
+  }
+
+  async getMemoryById(id: UUID): Promise<Memory | null> {
+    return this._runtime.getMemoryById(id);
+  }
+
+  async getMemoriesByIds(ids: UUID[], tableName?: string): Promise<Memory[]> {
+    return this._runtime.getMemoriesByIds(ids, tableName);
+  }
+
+  async getMemoriesByRoomIds(params: {
+    tableName: string;
+    roomIds: UUID[];
+    limit?: number;
+  }): Promise<Memory[]> {
+    return this._runtime.getMemoriesByRoomIds(params);
+  }
+
+  async getCachedEmbeddings(params: {
+    query_table_name: string;
+    query_threshold: number;
+    query_input: string;
+    query_field_name: string;
+    query_field_sub_name: string;
+    query_match_count: number;
+  }): Promise<{ embedding: number[]; levenshtein_score: number }[]> {
+    return this._runtime.getCachedEmbeddings(params);
+  }
+
+  async log(params: {
+    body: { [key: string]: unknown };
+    entityId: UUID;
+    roomId: UUID;
+    type: string;
+  }): Promise<void> {
+    return this._runtime.log(params);
+  }
+
+  async searchMemories(params: {
+    embedding: number[];
+    match_threshold?: number;
+    count?: number;
+    roomId?: UUID;
+    unique?: boolean;
+    tableName: string;
+  }): Promise<Memory[]> {
+    return this._runtime.searchMemories(params);
+  }
+
+  async createMemory(memory: Memory, tableName: string, unique?: boolean): Promise<UUID> {
+    return this._runtime.createMemory(memory, tableName, unique);
+  }
+
+  async updateMemory(
+    memory: Partial<Memory> & { id: UUID; metadata?: MemoryMetadata }
+  ): Promise<boolean> {
+    return this._runtime.updateMemory(memory);
+  }
+
+  async deleteMemory(memoryId: UUID): Promise<void> {
+    return this._runtime.deleteMemory(memoryId);
+  }
+
+  async deleteAllMemories(roomId: UUID, tableName: string): Promise<void> {
+    return this._runtime.deleteAllMemories(roomId, tableName);
+  }
+
+  async countMemories(roomId: UUID, unique?: boolean, tableName?: string): Promise<number> {
+    return this._runtime.countMemories(roomId, unique, tableName);
+  }
+
+  async getLogs(params: {
+    entityId: UUID;
+    roomId?: UUID;
+    type?: string;
+    count?: number;
+    offset?: number;
+  }): Promise<Log[]> {
+    return this._runtime.getLogs(params);
+  }
+
+  async deleteLog(logId: UUID): Promise<void> {
+    return this._runtime.deleteLog(logId);
+  }
+
+  async createWorld(world: World): Promise<UUID> {
+    return this._runtime.createWorld(world);
+  }
+
+  async getWorld(id: UUID): Promise<World | null> {
+    return this._runtime.getWorld(id);
+  }
+
+  async getAllWorlds(): Promise<World[]> {
+    return this._runtime.getAllWorlds();
+  }
+
+  async updateWorld(world: World): Promise<void> {
+    return this._runtime.updateWorld(world);
+  }
+
+  async getRoom(roomId: UUID): Promise<Room | null> {
+    return this._runtime.getRoom(roomId);
+  }
+
+  async createRoom({ id, name, source, type, channelId, serverId, worldId }: Room): Promise<UUID> {
+    return this._runtime.createRoom({
+      id,
+      name,
+      source,
+      type,
+      channelId,
+      serverId,
+      worldId,
+    });
+  }
+
+  async deleteRoom(roomId: UUID): Promise<void> {
+    return this._runtime.deleteRoom(roomId);
+  }
+
+  async updateRoom(room: Room): Promise<void> {
+    return this._runtime.updateRoom(room);
+  }
+
+  async getRoomsForParticipant(entityId: UUID): Promise<UUID[]> {
+    return this._runtime.getRoomsForParticipant(entityId);
+  }
+
+  async getRoomsForParticipants(userIds: UUID[]): Promise<UUID[]> {
+    return this._runtime.getRoomsForParticipants(userIds);
+  }
+
+  async getRooms(worldId: UUID): Promise<Room[]> {
+    return this._runtime.getRooms(worldId);
+  }
+
+  async getParticipantUserState(
+    roomId: UUID,
+    entityId: UUID
+  ): Promise<'FOLLOWED' | 'MUTED' | null> {
+    return this._runtime.getParticipantUserState(roomId, entityId);
+  }
+
+  async setParticipantUserState(
+    roomId: UUID,
+    entityId: UUID,
+    state: 'FOLLOWED' | 'MUTED' | null
+  ): Promise<void> {
+    return this._runtime.setParticipantUserState(roomId, entityId, state);
+  }
+
+  async createRelationship(params: {
+    sourceEntityId: UUID;
+    targetEntityId: UUID;
+    tags?: string[];
+    metadata?: { [key: string]: any };
+  }): Promise<boolean> {
+    return this._runtime.createRelationship(params);
+  }
+
+  async updateRelationship(relationship: Relationship): Promise<void> {
+    return this._runtime.updateRelationship(relationship);
+  }
+
+  async getRelationship(params: {
+    sourceEntityId: UUID;
+    targetEntityId: UUID;
+  }): Promise<Relationship | null> {
+    return this._runtime.getRelationship(params);
+  }
+
+  async getRelationships(params: { entityId: UUID; tags?: string[] }): Promise<Relationship[]> {
+    return this._runtime.getRelationships(params);
+  }
+
+  async getCache<T>(key: string): Promise<T | undefined> {
+    return this._runtime.getCache<T>(key);
+  }
+
+  async setCache<T>(key: string, value: T): Promise<boolean> {
+    return this._runtime.setCache<T>(key, value);
+  }
+
+  async deleteCache(key: string): Promise<boolean> {
+    return this._runtime.deleteCache(key);
+  }
+
+  async createTask(task: Task): Promise<UUID> {
+    return this._runtime.createTask(task);
+  }
+
+  async getTasks(params: { roomId?: UUID; tags?: string[] }): Promise<Task[]> {
+    return this._runtime.getTasks(params);
+  }
+
+  async getTask(id: UUID): Promise<Task | null> {
+    return this._runtime.getTask(id);
+  }
+
+  async getTasksByName(name: string): Promise<Task[]> {
+    return this._runtime.getTasksByName(name);
+  }
+
+  async updateTask(id: UUID, task: Partial<Task>): Promise<void> {
+    return this._runtime.updateTask(id, task);
+  }
+
+  async deleteTask(id: UUID): Promise<void> {
+    return this._runtime.deleteTask(id);
+  }
+
+  // Event emitter methods
+  on(event: string, callback: (data: any) => void): void {
+    return this._runtime.on(event, callback);
+  }
+
+  off(event: string, callback: (data: any) => void): void {
+    return this._runtime.off(event, callback);
+  }
+
+  emit(event: string, data: any): void {
+    return this._runtime.emit(event, data);
+  }
+}

--- a/packages/core-plugin-v2/src/settings.ts
+++ b/packages/core-plugin-v2/src/settings.ts
@@ -1,0 +1,160 @@
+import {
+  createSettingFromConfig as coreCreateSettingFromConfig,
+  getSalt as coreGetSalt,
+  encryptStringValue as coreEncryptStringValue,
+  decryptStringValue as coreDecryptStringValue,
+  saltSettingValue as coreSaltSettingValue,
+  unsaltSettingValue as coreUnsaltSettingValue,
+  saltWorldSettings as coreSaltWorldSettings,
+  unsaltWorldSettings as coreUnsaltWorldSettings,
+  updateWorldSettings as coreUpdateWorldSettings,
+  getWorldSettings as coreGetWorldSettings,
+  initializeOnboarding as coreInitializeOnboarding,
+  encryptedCharacter as coreEncryptedCharacter,
+  decryptedCharacter as coreDecryptedCharacter,
+  encryptObjectValues as coreEncryptObjectValues,
+  decryptObjectValues as coreDecryptObjectValues,
+} from '@elizaos/core';
+
+/**
+ * Creates a Setting object from a configSetting object by omitting the 'value' property.
+ *
+ * @param {Omit<Setting, 'value'>} configSetting - The configSetting object to create the Setting from.
+ * @returns {Setting} A new Setting object created from the provided configSetting object.
+ */
+export function createSettingFromConfig(configSetting: Omit<Setting, 'value'>): Setting {
+  return coreCreateSettingFromConfig(configSetting);
+}
+
+/**
+ * Retrieves the salt based on env variable SECRET_SALT
+ *
+ * @returns {string} The salt for the agent.
+ */
+export function getSalt(): string {
+  return coreGetSalt();
+}
+
+/**
+ * Common encryption function for string values
+ * @param {string} value - The string value to encrypt
+ * @param {string} salt - The salt to use for encryption
+ * @returns {string} - The encrypted value in 'iv:encrypted' format
+ */
+export function encryptStringValue(value: string, salt: string): string {
+  return coreEncryptStringValue(value, salt);
+}
+
+/**
+ * Common decryption function for string values
+ * @param {string} value - The encrypted value in 'iv:encrypted' format
+ * @param {string} salt - The salt to use for decryption
+ * @returns {string} - The decrypted string value
+ */
+export function decryptStringValue(value: string, salt: string): string {
+  return coreDecryptStringValue(value, salt);
+}
+
+/**
+ * Applies salt to the value of a setting
+ * Only applies to secret settings with string values
+ */
+export function saltSettingValue(setting: Setting, salt: string): Setting {
+  return coreSaltSettingValue(setting, salt);
+}
+
+/**
+ * Removes salt from the value of a setting
+ * Only applies to secret settings with string values
+ */
+export function unsaltSettingValue(setting: Setting, salt: string): Setting {
+  return coreUnsaltSettingValue(setting, salt);
+}
+
+/**
+ * Applies salt to all settings in a WorldSettings object
+ */
+export function saltWorldSettings(worldSettings: WorldSettings, salt: string): WorldSettings {
+  return coreSaltWorldSettings(worldSettings, salt);
+}
+
+/**
+ * Removes salt from all settings in a WorldSettings object
+ */
+export function unsaltWorldSettings(worldSettings: WorldSettings, salt: string): WorldSettings {
+  return coreUnsaltWorldSettings(worldSettings, salt);
+}
+
+/**
+ * Updates settings state in world metadata
+ */
+export async function updateWorldSettings(
+  runtime: IAgentRuntime,
+  serverId: string,
+  worldSettings: WorldSettings
+): Promise<boolean> {
+  return coreUpdateWorldSettings(runtime, serverid, worldSettings);
+}
+
+/**
+ * Gets settings state from world metadata
+ */
+export async function getWorldSettings(
+  runtime: IAgentRuntime,
+  serverId: string
+): Promise<WorldSettings | null> {
+  return coreGetWorldSettings(runtime, serverId);
+}
+
+/**
+ * Initializes settings configuration for a server
+ */
+export async function initializeOnboarding(
+  runtime: IAgentRuntime,
+  world: World,
+  config: OnboardingConfig
+): Promise<WorldSettings | null> {
+  return coreInitializeOnboarding(runtime, world, config);
+}
+
+/**
+ * Encrypts sensitive data in a Character object
+ * @param {Character} character - The character object to encrypt secrets for
+ * @param {IAgentRuntime} runtime - The runtime information needed for salt generation
+ * @returns {Character} - A copy of the character with encrypted secrets
+ */
+export function encryptedCharacter(character: Character): Character {
+  return coreEncryptedCharacter(character);
+}
+
+/**
+ * Decrypts sensitive data in a Character object
+ * @param {Character} character - The character object with encrypted secrets
+ * @param {IAgentRuntime} runtime - The runtime information needed for salt generation
+ * @returns {Character} - A copy of the character with decrypted secrets
+ */
+export function decryptedCharacter(character: Character, runtime: IAgentRuntime): Character {
+  return coreDecryptedCharacter(character, runtime);
+}
+
+/**
+ * Helper function to encrypt all string values in an object
+ * @param {Record<string, any>} obj - Object with values to encrypt
+ * @param {string} salt - The salt to use for encryption
+ * @returns {Record<string, any>} - Object with encrypted values
+ */
+export function encryptObjectValues(obj: Record<string, any>, salt: string): Record<string, any> {
+  return coreEncryptObjectValues(obj, salt);
+}
+
+/**
+ * Helper function to decrypt all string values in an object
+ * @param {Record<string, any>} obj - Object with encrypted values
+ * @param {string} salt - The salt to use for decryption
+ * @returns {Record<string, any>} - Object with decrypted values
+ */
+export function decryptObjectValues(obj: Record<string, any>, salt: string): Record<string, any> {
+  return coreDecryptObjectValues(obj, salt);
+}
+
+export { decryptStringValue as decryptSecret };

--- a/packages/core-plugin-v2/src/types.ts
+++ b/packages/core-plugin-v2/src/types.ts
@@ -1,0 +1,1946 @@
+/**
+ * Type definition for a Universally Unique Identifier (UUID) using a specific format.
+ * @typedef {`${string}-${string}-${string}-${string}-${string}`} UUID
+ */
+/**
+ * Defines a custom type UUID representing a universally unique identifier
+ */
+export type UUID = `${string}-${string}-${string}-${string}-${string}`;
+
+/**
+ * Helper function to safely cast a string to strongly typed UUID
+ * @param id The string UUID to validate and cast
+ * @returns The same UUID with branded type information
+ */
+export function asUUID(id: string): UUID {
+  if (!id || !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) {
+    throw new Error(`Invalid UUID format: ${id}`);
+  }
+  return id as UUID;
+}
+
+/**
+ * Represents the content of a memory, message, or other information
+ */
+export interface Content {
+  /** The agent's internal thought process */
+  thought?: string;
+
+  /** The main text content visible to users */
+  text?: string;
+
+  /** Optional actions to be performed */
+  actions?: string[];
+
+  /** Optional providers to use for context generation */
+  providers?: string[];
+
+  /** Optional source/origin of the content */
+  source?: string;
+
+  /** URL of the original message/post (e.g. tweet URL, Discord message link) */
+  url?: string;
+
+  /** UUID of parent message if this is a reply/thread */
+  inReplyTo?: UUID;
+
+  /** Array of media attachments */
+  attachments?: Media[];
+
+  /**
+   * Additional dynamic properties
+   * Use specific properties above instead of this when possible
+   */
+  [key: string]: unknown;
+}
+
+/**
+ * Example content with associated user for demonstration purposes
+ */
+export interface ActionExample {
+  /** User associated with the example */
+  name: string;
+
+  /** Content of the example */
+  content: Content;
+}
+
+export type ModelTypeName = (typeof ModelType)[keyof typeof ModelType] | string;
+
+/**
+ * Model size/type classification
+ */
+export const ModelType = {
+  SMALL: 'TEXT_SMALL', // kept for backwards compatibility
+  MEDIUM: 'TEXT_LARGE', // kept for backwards compatibility
+  LARGE: 'TEXT_LARGE', // kept for backwards compatibility
+  TEXT_SMALL: 'TEXT_SMALL',
+  TEXT_LARGE: 'TEXT_LARGE',
+  TEXT_EMBEDDING: 'TEXT_EMBEDDING',
+  TEXT_TOKENIZER_ENCODE: 'TEXT_TOKENIZER_ENCODE',
+  TEXT_TOKENIZER_DECODE: 'TEXT_TOKENIZER_DECODE',
+  TEXT_REASONING_SMALL: 'REASONING_SMALL',
+  TEXT_REASONING_LARGE: 'REASONING_LARGE',
+  TEXT_COMPLETION: 'TEXT_COMPLETION',
+  IMAGE: 'IMAGE',
+  IMAGE_DESCRIPTION: 'IMAGE_DESCRIPTION',
+  TRANSCRIPTION: 'TRANSCRIPTION',
+  TEXT_TO_SPEECH: 'TEXT_TO_SPEECH',
+  AUDIO: 'AUDIO',
+  VIDEO: 'VIDEO',
+  OBJECT_SMALL: 'OBJECT_SMALL',
+  OBJECT_LARGE: 'OBJECT_LARGE',
+} as const;
+
+export type ServiceTypeName = (typeof ServiceType)[keyof typeof ServiceType];
+
+export const ServiceType = {
+  TRANSCRIPTION: 'transcription',
+  VIDEO: 'video',
+  BROWSER: 'browser',
+  PDF: 'pdf',
+  REMOTE_FILES: 'aws_s3',
+  WEB_SEARCH: 'web_search',
+  EMAIL: 'email',
+  TEE: 'tee',
+  TASK: 'task',
+} as const;
+
+/**
+ * Represents the current state/context of a conversation
+ */
+export interface State {
+  /** Additional dynamic properties */
+  [key: string]: any;
+  values: {
+    [key: string]: any;
+  };
+  data: {
+    [key: string]: any;
+  };
+  text: string;
+}
+
+/**
+ * Memory type enumeration for built-in memory types
+ */
+export type MemoryTypeAlias = string;
+
+export enum MemoryType {
+  DOCUMENT = 'document',
+  FRAGMENT = 'fragment',
+  MESSAGE = 'message',
+  DESCRIPTION = 'description',
+  CUSTOM = 'custom',
+}
+export type MemoryScope = 'shared' | 'private' | 'room';
+
+/**
+ * Base interface for all memory metadata types
+ */
+export interface BaseMetadata {
+  type: MemoryTypeAlias;
+  source?: string;
+  sourceId?: UUID;
+  scope?: MemoryScope;
+  timestamp?: number;
+  tags?: string[];
+}
+
+export interface DocumentMetadata extends BaseMetadata {
+  type: MemoryType.DOCUMENT;
+}
+
+export interface FragmentMetadata extends BaseMetadata {
+  type: MemoryType.FRAGMENT;
+  documentId: UUID;
+  position: number;
+}
+
+export interface MessageMetadata extends BaseMetadata {
+  type: MemoryType.MESSAGE;
+}
+
+export interface DescriptionMetadata extends BaseMetadata {
+  type: MemoryType.DESCRIPTION;
+}
+
+export interface CustomMetadata extends BaseMetadata {
+  [key: string]: unknown;
+}
+
+export type MemoryMetadata =
+  | DocumentMetadata
+  | FragmentMetadata
+  | MessageMetadata
+  | DescriptionMetadata
+  | CustomMetadata;
+
+/**
+ * Represents a stored memory/message
+ */
+export interface Memory {
+  /** Optional unique identifier */
+  id?: UUID;
+
+  /** Associated user ID */
+  entityId: UUID;
+
+  /** Associated agent ID */
+  agentId?: UUID;
+
+  /** Optional creation timestamp in milliseconds since epoch */
+  createdAt?: number;
+
+  /** Memory content */
+  content: Content;
+
+  /** Optional embedding vector for semantic search */
+  embedding?: number[];
+
+  /** Associated room ID */
+  roomId: UUID;
+
+  /** Whether memory is unique (used to prevent duplicates) */
+  unique?: boolean;
+
+  /** Embedding similarity score (set when retrieved via search) */
+  similarity?: number;
+
+  /** Metadata for the memory */
+  metadata?: MemoryMetadata;
+}
+
+/**
+ * Represents a log entry
+ */
+export interface Log {
+  /** Optional unique identifier */
+  id?: UUID;
+
+  /** Associated entity ID */
+  entityId: UUID;
+
+  /** Associated room ID */
+  roomId?: UUID;
+
+  /** Log body */
+  body: { [key: string]: unknown };
+
+  /** Log type */
+  type: string;
+
+  /** Log creation timestamp */
+  createdAt: Date;
+}
+
+/**
+ * Example message for demonstration
+ */
+export interface MessageExample {
+  /** Associated user */
+  name: string;
+
+  /** Message content */
+  content: Content;
+}
+
+/**
+ * Handler function type for processing messages
+ */
+export type Handler = (
+  runtime: IAgentRuntime,
+  message: Memory,
+  state?: State,
+  options?: { [key: string]: unknown },
+  callback?: HandlerCallback,
+  responses?: Memory[]
+) => Promise<unknown>;
+
+/**
+ * Callback function type for handlers
+ */
+export type HandlerCallback = (response: Content, files?: any) => Promise<Memory[]>;
+
+/**
+ * Validator function type for actions/evaluators
+ */
+export type Validator = (
+  runtime: IAgentRuntime,
+  message: Memory,
+  state?: State
+) => Promise<boolean>;
+
+/**
+ * Represents an action the agent can perform
+ */
+export interface Action {
+  /** Similar action descriptions */
+  similes?: string[];
+
+  /** Detailed description */
+  description: string;
+
+  /** Example usages */
+  examples?: ActionExample[][];
+
+  /** Handler function */
+  handler: Handler;
+
+  /** Action name */
+  name: string;
+
+  /** Validation function */
+  validate: Validator;
+}
+
+/**
+ * Example for evaluating agent behavior
+ */
+export interface EvaluationExample {
+  /** Evaluation context */
+  prompt: string;
+
+  /** Example messages */
+  messages: Array<ActionExample>;
+
+  /** Expected outcome */
+  outcome: string;
+}
+
+/**
+ * Evaluator for assessing agent responses
+ */
+export interface Evaluator {
+  /** Whether to always run */
+  alwaysRun?: boolean;
+
+  /** Detailed description */
+  description: string;
+
+  /** Similar evaluator descriptions */
+  similes?: string[];
+
+  /** Example evaluations */
+  examples: EvaluationExample[];
+
+  /** Handler function */
+  handler: Handler;
+
+  /** Evaluator name */
+  name: string;
+
+  /** Validation function */
+  validate: Validator;
+}
+
+export interface ProviderResult {
+  values?: {
+    [key: string]: any;
+  };
+  data?: {
+    [key: string]: any;
+  };
+  text?: string;
+}
+
+/**
+ * Provider for external data/services
+ */
+export interface Provider {
+  /** Provider name */
+  name: string;
+
+  /** Description of the provider */
+  description?: string;
+
+  /** Whether the provider is dynamic */
+  dynamic?: boolean;
+
+  /** Position of the provider in the provider list, positive or negative */
+  position?: number;
+
+  /**
+   * Whether the provider is private
+   *
+   * Private providers are not displayed in the regular provider list, they have to be called explicitly
+   */
+  private?: boolean;
+
+  /** Data retrieval function */
+  get: (runtime: IAgentRuntime, message: Memory, state: State) => Promise<ProviderResult>;
+}
+
+/**
+ * Represents a relationship between users
+ */
+export interface Relationship {
+  /** Unique identifier */
+  id: UUID;
+
+  /** First user ID */
+  sourceEntityId: UUID;
+
+  /** Second user ID */
+  targetEntityId: UUID;
+
+  /** Agent ID */
+  agentId: UUID;
+
+  /** Tags for filtering/categorizing relationships */
+  tags: string[];
+
+  /** Additional metadata about the relationship */
+  metadata: {
+    [key: string]: any;
+  };
+
+  /** Optional creation timestamp */
+  createdAt?: string;
+}
+
+export interface Component {
+  id: UUID;
+  entityId: UUID;
+  agentId: UUID;
+  roomId: UUID;
+  worldId: UUID;
+  sourceEntityId: UUID;
+  type: string;
+  data: {
+    [key: string]: any;
+  };
+}
+
+/**
+ * Represents a user account
+ */
+export interface Entity {
+  /** Unique identifier, optional on creation */
+  id?: UUID;
+
+  /** Names of the entity */
+  names: string[];
+
+  /** Optional additional metadata */
+  metadata?: { [key: string]: any };
+
+  /** Agent ID this account is related to, for agents should be themselves */
+  agentId: UUID;
+
+  /** Optional array of components */
+  components?: Component[];
+}
+
+export type World = {
+  id: UUID;
+  name?: string;
+  agentId: UUID;
+  serverId: string;
+  metadata?: {
+    ownership?: {
+      ownerId: string;
+    };
+    roles?: {
+      [entityId: UUID]: Role;
+    };
+    [key: string]: unknown;
+  };
+};
+
+export type Room = {
+  id: UUID;
+  name?: string;
+  agentId?: UUID;
+  source: string;
+  type: ChannelType;
+  channelId?: string;
+  serverId?: string;
+  worldId?: UUID;
+  metadata?: Record<string, unknown>;
+};
+
+/**
+ * Room participant with account details
+ */
+export interface Participant {
+  /** Unique identifier */
+  id: UUID;
+
+  /** Associated account */
+  entity: Entity;
+}
+
+/**
+ * Represents a media attachment
+ */
+export type Media = {
+  /** Unique identifier */
+  id: string;
+
+  /** Media URL */
+  url: string;
+
+  /** Media title */
+  title: string;
+
+  /** Media source */
+  source: string;
+
+  /** Media description */
+  description: string;
+
+  /** Text content */
+  text: string;
+
+  /** Content type */
+  contentType?: string;
+};
+
+export enum ChannelType {
+  SELF = 'SELF', // Messages to self
+  DM = 'dm', // Direct messages between two participants
+  GROUP = 'group', // Group messages with multiple participants
+  VOICE_DM = 'VOICE_DM', // Voice direct messages
+  VOICE_GROUP = 'VOICE_GROUP', // Voice channels with multiple participants
+  FEED = 'FEED', // Social media feed
+  THREAD = 'THREAD', // Threaded conversation
+  WORLD = 'WORLD', // World channel
+  FORUM = 'FORUM', // Forum discussion
+  // Legacy types - kept for backward compatibility but should be replaced
+  API = 'API', // @deprecated - Use DM or GROUP instead
+}
+
+/**
+ * Client instance
+ */
+export abstract class Service {
+  /** Runtime instance */
+  protected runtime!: IAgentRuntime;
+
+  constructor(runtime?: IAgentRuntime) {
+    if (runtime) {
+      this.runtime = runtime;
+    }
+  }
+
+  abstract stop(): Promise<void>;
+
+  /** Service type */
+  static serviceType: string;
+
+  /** Service name */
+  abstract capabilityDescription: string;
+
+  /** Service configuration */
+  config?: { [key: string]: any };
+
+  /** Start service connection */
+  static async start(_runtime: IAgentRuntime): Promise<Service> {
+    throw new Error('Not implemented');
+  }
+
+  /** Stop service connection */
+  static async stop(_runtime: IAgentRuntime): Promise<unknown> {
+    throw new Error('Not implemented');
+  }
+}
+
+export type Route = {
+  type: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'STATIC';
+  path: string;
+  filePath?: string;
+  handler?: (req: any, res: any, runtime: IAgentRuntime) => Promise<void>;
+};
+
+/**
+ * Plugin for extending agent functionality
+ */
+export interface Plugin {
+  name: string;
+  description: string;
+
+  // Initialize plugin with runtime services
+  init?: (config: Record<string, string>, runtime: IAgentRuntime) => Promise<void>;
+
+  // Configuration
+  config?: { [key: string]: any };
+
+  services?: (typeof Service)[];
+
+  // Entity component definitions
+  componentTypes?: {
+    name: string;
+    schema: Record<string, unknown>;
+    validator?: (data: any) => boolean;
+  }[];
+
+  // Optional plugin features
+  actions?: Action[];
+  providers?: Provider[];
+  evaluators?: Evaluator[];
+  adapter?: IDatabaseAdapter;
+  models?: {
+    [key: string]: (...args: any[]) => Promise<any>;
+  };
+  events?: {
+    [K in keyof EventPayloadMap]?: EventHandler<K>[];
+  } & {
+    [key: string]: ((params: EventPayload) => Promise<any>)[];
+  };
+  routes?: Route[];
+  tests?: TestSuite[];
+}
+
+export interface ProjectAgent {
+  character: Character;
+  init?: (runtime: IAgentRuntime) => Promise<void>;
+  plugins?: Plugin[];
+  tests?: TestSuite | TestSuite[];
+}
+
+export interface Project {
+  agents: ProjectAgent[];
+}
+
+export type TemplateType =
+  | string
+  | ((options: { state: State | { [key: string]: string } }) => string);
+
+/**
+ * Configuration for an agent character
+ */
+export interface Character {
+  /** Optional unique identifier */
+  id?: UUID;
+
+  /** Character name */
+  name: string;
+
+  /** Optional username */
+  username?: string;
+
+  /** Optional system prompt */
+  system?: string;
+
+  /** Optional prompt templates */
+  templates?: {
+    [key: string]: TemplateType;
+  };
+
+  /** Character biography */
+  bio: string | string[];
+
+  /** Example messages */
+  messageExamples?: MessageExample[][];
+
+  /** Example posts */
+  postExamples?: string[];
+
+  /** Known topics */
+  topics?: string[];
+
+  /** Character traits */
+  adjectives?: string[];
+
+  /** Optional knowledge base */
+  knowledge?: (string | { path: string; shared?: boolean })[];
+
+  /** Available plugins */
+  plugins?: string[];
+
+  /** Optional configuration */
+  settings?: {
+    [key: string]: any | string | boolean | number;
+  };
+
+  /** Optional secrets */
+  secrets?: {
+    [key: string]: string | boolean | number;
+  };
+
+  /** Writing style guides */
+  style?: {
+    all?: string[];
+    chat?: string[];
+    post?: string[];
+  };
+}
+
+export enum AgentStatus {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+}
+
+export interface Agent extends Character {
+  enabled?: boolean;
+  status?: AgentStatus;
+  createdAt: number;
+  updatedAt: number;
+}
+
+/**
+ * Interface for database operations
+ */
+export interface IDatabaseAdapter {
+  /** Database instance */
+  db: any;
+
+  /** Initialize database connection */
+  init(): Promise<void>;
+
+  /** Close database connection */
+  close(): Promise<void>;
+
+  getAgent(agentId: UUID): Promise<Agent | null>;
+
+  /** Get all agents */
+  getAgents(): Promise<Agent[]>;
+
+  createAgent(agent: Partial<Agent>): Promise<boolean>;
+
+  updateAgent(agentId: UUID, agent: Partial<Agent>): Promise<boolean>;
+
+  deleteAgent(agentId: UUID): Promise<boolean>;
+
+  ensureAgentExists(agent: Partial<Agent>): Promise<void>;
+
+  ensureEmbeddingDimension(dimension: number): Promise<void>;
+
+  /** Get entity by ID */
+  getEntityById(entityId: UUID): Promise<Entity | null>;
+
+  /** Get entities for room */
+  getEntitiesForRoom(roomId: UUID, includeComponents?: boolean): Promise<Entity[]>;
+
+  /** Create new entity */
+  createEntity(entity: Entity): Promise<boolean>;
+
+  /** Update entity */
+  updateEntity(entity: Entity): Promise<void>;
+
+  /** Get component by ID */
+  getComponent(
+    entityId: UUID,
+    type: string,
+    worldId?: UUID,
+    sourceEntityId?: UUID
+  ): Promise<Component | null>;
+
+  /** Get all components for an entity */
+  getComponents(entityId: UUID, worldId?: UUID, sourceEntityId?: UUID): Promise<Component[]>;
+
+  /** Create component */
+  createComponent(component: Component): Promise<boolean>;
+
+  /** Update component */
+  updateComponent(component: Component): Promise<void>;
+
+  /** Delete component */
+  deleteComponent(componentId: UUID): Promise<void>;
+
+  /** Get memories matching criteria */
+  getMemories(params: {
+    entityId?: UUID;
+    agentId?: UUID;
+    roomId?: UUID;
+    count?: number;
+    unique?: boolean;
+    tableName: string;
+    start?: number;
+    end?: number;
+  }): Promise<Memory[]>;
+
+  getMemoryById(id: UUID): Promise<Memory | null>;
+
+  getMemoriesByIds(ids: UUID[], tableName?: string): Promise<Memory[]>;
+
+  getMemoriesByRoomIds(params: {
+    tableName: string;
+    roomIds: UUID[];
+    limit?: number;
+  }): Promise<Memory[]>;
+
+  getCachedEmbeddings(params: {
+    query_table_name: string;
+    query_threshold: number;
+    query_input: string;
+    query_field_name: string;
+    query_field_sub_name: string;
+    query_match_count: number;
+  }): Promise<{ embedding: number[]; levenshtein_score: number }[]>;
+
+  log(params: {
+    body: { [key: string]: unknown };
+    entityId: UUID;
+    roomId: UUID;
+    type: string;
+  }): Promise<void>;
+
+  getLogs(params: {
+    entityId: UUID;
+    roomId?: UUID;
+    type?: string;
+    count?: number;
+    offset?: number;
+  }): Promise<Log[]>;
+
+  deleteLog(logId: UUID): Promise<void>;
+
+  searchMemories(params: {
+    embedding: number[];
+    match_threshold?: number;
+    count?: number;
+    roomId?: UUID;
+    unique?: boolean;
+    tableName: string;
+  }): Promise<Memory[]>;
+
+  createMemory(memory: Memory, tableName: string, unique?: boolean): Promise<UUID>;
+
+  updateMemory(memory: Partial<Memory> & { id: UUID; metadata?: MemoryMetadata }): Promise<boolean>;
+
+  deleteMemory(memoryId: UUID): Promise<void>;
+
+  deleteAllMemories(roomId: UUID, tableName: string): Promise<void>;
+
+  countMemories(roomId: UUID, unique?: boolean, tableName?: string): Promise<number>;
+
+  createWorld(world: World): Promise<UUID>;
+
+  getWorld(id: UUID): Promise<World | null>;
+
+  getAllWorlds(): Promise<World[]>;
+
+  updateWorld(world: World): Promise<void>;
+
+  getRoom(roomId: UUID): Promise<Room | null>;
+
+  createRoom({ id, name, source, type, channelId, serverId, worldId }: Room): Promise<UUID>;
+
+  deleteRoom(roomId: UUID): Promise<void>;
+
+  updateRoom(room: Room): Promise<void>;
+
+  getRoomsForParticipant(entityId: UUID): Promise<UUID[]>;
+
+  getRoomsForParticipants(userIds: UUID[]): Promise<UUID[]>;
+
+  getRooms(worldId: UUID): Promise<Room[]>;
+
+  addParticipant(entityId: UUID, roomId: UUID): Promise<boolean>;
+
+  removeParticipant(entityId: UUID, roomId: UUID): Promise<boolean>;
+
+  getParticipantsForEntity(entityId: UUID): Promise<Participant[]>;
+
+  getParticipantsForRoom(roomId: UUID): Promise<UUID[]>;
+
+  getParticipantUserState(roomId: UUID, entityId: UUID): Promise<'FOLLOWED' | 'MUTED' | null>;
+
+  setParticipantUserState(
+    roomId: UUID,
+    entityId: UUID,
+    state: 'FOLLOWED' | 'MUTED' | null
+  ): Promise<void>;
+
+  /**
+   * Creates a new relationship between two entities.
+   * @param params Object containing the relationship details
+   * @returns Promise resolving to boolean indicating success
+   */
+  createRelationship(params: {
+    sourceEntityId: UUID;
+    targetEntityId: UUID;
+    tags?: string[];
+    metadata?: { [key: string]: any };
+  }): Promise<boolean>;
+
+  /**
+   * Updates an existing relationship between two entities.
+   * @param relationship The relationship object with updated data
+   * @returns Promise resolving to void
+   */
+  updateRelationship(relationship: Relationship): Promise<void>;
+
+  /**
+   * Retrieves a relationship between two entities if it exists.
+   * @param params Object containing the entity IDs and agent ID
+   * @returns Promise resolving to the Relationship object or null if not found
+   */
+  getRelationship(params: {
+    sourceEntityId: UUID;
+    targetEntityId: UUID;
+  }): Promise<Relationship | null>;
+
+  /**
+   * Retrieves all relationships for a specific entity.
+   * @param params Object containing the user ID, agent ID and optional tags to filter by
+   * @returns Promise resolving to an array of Relationship objects
+   */
+  getRelationships(params: { entityId: UUID; tags?: string[] }): Promise<Relationship[]>;
+
+  ensureEmbeddingDimension(dimension: number): Promise<void>;
+
+  getCache<T>(key: string): Promise<T | undefined>;
+  setCache<T>(key: string, value: T): Promise<boolean>;
+  deleteCache(key: string): Promise<boolean>;
+
+  // Only task instance methods - definitions are in-memory
+  createTask(task: Task): Promise<UUID>;
+  getTasks(params: { roomId?: UUID; tags?: string[] }): Promise<Task[]>;
+  getTask(id: UUID): Promise<Task | null>;
+  getTasksByName(name: string): Promise<Task[]>;
+  updateTask(id: UUID, task: Partial<Task>): Promise<void>;
+  deleteTask(id: UUID): Promise<void>;
+}
+
+/**
+ * Result interface for embedding similarity searches
+ */
+export interface EmbeddingSearchResult {
+  embedding: number[];
+  levenshtein_score: number;
+}
+
+/**
+ * Options for memory retrieval operations
+ */
+export interface MemoryRetrievalOptions {
+  roomId: UUID;
+  count?: number;
+  unique?: boolean;
+  start?: number;
+  end?: number;
+  agentId?: UUID;
+}
+
+/**
+ * Options for memory search operations
+ */
+export interface MemorySearchOptions {
+  embedding: number[];
+  match_threshold?: number;
+  count?: number;
+  roomId: UUID;
+  agentId?: UUID;
+  unique?: boolean;
+  metadata?: Partial<MemoryMetadata>;
+}
+
+/**
+ * Options for multi-room memory retrieval
+ */
+export interface MultiRoomMemoryOptions {
+  roomIds: UUID[];
+  limit?: number;
+  agentId?: UUID;
+}
+
+/**
+ * Unified options pattern for memory operations
+ * Provides a simpler, more consistent interface
+ */
+export interface UnifiedMemoryOptions {
+  roomId: UUID;
+  limit?: number; // Unified naming (replacing 'count')
+  agentId?: UUID; // Common optional parameter
+  unique?: boolean; // Common flag for duplication control
+  start?: number; // Pagination start
+  end?: number; // Pagination end
+}
+
+/**
+ * Specialized memory search options
+ */
+export interface UnifiedSearchOptions extends UnifiedMemoryOptions {
+  embedding: number[];
+  similarity?: number; // Clearer name than 'match_threshold'
+}
+
+export interface IAgentRuntime extends IDatabaseAdapter {
+  // Properties
+  agentId: UUID;
+  character: Character;
+  providers: Provider[];
+  actions: Action[];
+  evaluators: Evaluator[];
+  plugins: Plugin[];
+  services: Map<ServiceTypeName, Service>;
+  events: Map<string, ((params: any) => Promise<void>)[]>;
+  fetch?: typeof fetch | null;
+  routes: Route[];
+
+  // Methods
+  registerPlugin(plugin: Plugin): Promise<void>;
+
+  initialize(): Promise<void>;
+
+  getKnowledge(message: Memory): Promise<KnowledgeItem[]>;
+  addKnowledge(
+    item: KnowledgeItem,
+    options: {
+      targetTokens: number;
+      overlap: number;
+      modelContextSize: number;
+    }
+  ): Promise<void>;
+
+  getService<T extends Service>(service: ServiceTypeName | string): T | null;
+
+  getAllServices(): Map<ServiceTypeName, Service>;
+
+  registerService(service: typeof Service): Promise<void>;
+
+  // Keep these methods for backward compatibility
+  registerDatabaseAdapter(adapter: IDatabaseAdapter): void;
+
+  setSetting(key: string, value: string | boolean | null | any, secret: boolean): void;
+
+  getSetting(key: string): string | boolean | null | any;
+
+  getConversationLength(): number;
+
+  processActions(
+    message: Memory,
+    responses: Memory[],
+    state?: State,
+    callback?: HandlerCallback
+  ): Promise<void>;
+
+  evaluate(
+    message: Memory,
+    state?: State,
+    didRespond?: boolean,
+    callback?: HandlerCallback,
+    responses?: Memory[]
+  ): Promise<Evaluator[] | null>;
+
+  registerProvider(provider: Provider): void;
+
+  registerAction(action: Action): void;
+
+  registerEvaluator(evaluator: Evaluator): void;
+
+  ensureConnection({
+    entityId,
+    roomId,
+    userName,
+    name,
+    source,
+    channelId,
+    serverId,
+    type,
+    worldId,
+    userId,
+  }: {
+    entityId: UUID;
+    roomId: UUID;
+    userName?: string;
+    name?: string;
+    source?: string;
+    channelId?: string;
+    serverId?: string;
+    type: ChannelType;
+    worldId?: UUID;
+    userId?: UUID;
+  }): Promise<void>;
+
+  ensureParticipantInRoom(entityId: UUID, roomId: UUID): Promise<void>;
+
+  ensureWorldExists(world: World): Promise<void>;
+
+  ensureRoomExists(room: Room): Promise<void>;
+
+  composeState(message: Memory, filterList?: string[], includeList?: string[]): Promise<State>;
+
+  /**
+   * Use a model with strongly typed parameters and return values based on model type
+   * @template T - The model type to use
+   * @template R - The expected return type, defaults to the type defined in ModelResultMap[T]
+   * @param {T} modelType - The type of model to use
+   * @param {ModelParamsMap[T] | any} params - The parameters for the model, typed based on model type
+   * @returns {Promise<R>} - The model result, typed based on the provided generic type parameter
+   */
+  useModel<T extends ModelTypeName, R = ModelResultMap[T]>(
+    modelType: T,
+    params: Omit<ModelParamsMap[T], 'runtime'> | any
+  ): Promise<R>;
+
+  registerModel(modelType: ModelTypeName | string, handler: (params: any) => Promise<any>): void;
+
+  getModel(
+    modelType: ModelTypeName | string
+  ): ((runtime: IAgentRuntime, params: any) => Promise<any>) | undefined;
+
+  registerEvent(event: string, handler: (params: any) => Promise<void>): void;
+
+  getEvent(event: string): ((params: any) => Promise<void>)[] | undefined;
+
+  emitEvent(event: string | string[], params: any): Promise<void>;
+
+  // In-memory task definition methods
+  registerTaskWorker(taskHandler: TaskWorker): void;
+  getTaskWorker(name: string): TaskWorker | undefined;
+
+  stop(): Promise<void>;
+
+  addEmbeddingToMemory(memory: Memory): Promise<Memory>;
+}
+
+/**
+ * Interface for settings object with key-value pairs.
+ */
+/**
+ * Interface representing settings with string key-value pairs.
+ */
+export interface RuntimeSettings {
+  [key: string]: string | undefined;
+}
+
+export type KnowledgeItem = {
+  id: UUID;
+  content: Content;
+  metadata?: MemoryMetadata;
+};
+
+export enum KnowledgeScope {
+  SHARED = 'shared',
+  PRIVATE = 'private',
+}
+
+export enum CacheKeyPrefix {
+  KNOWLEDGE = 'knowledge',
+}
+
+export interface DirectoryItem {
+  directory: string;
+  shared?: boolean;
+}
+
+export interface ChunkRow {
+  id: string;
+  // Add other properties if needed
+}
+
+export type GenerateTextParams = {
+  runtime: IAgentRuntime;
+  prompt: string;
+  modelType: ModelTypeName;
+  maxTokens?: number;
+  temperature?: number;
+  frequencyPenalty?: number;
+  presencePenalty?: number;
+  stopSequences?: string[];
+};
+
+export interface TokenizeTextParams {
+  prompt: string;
+  modelType: ModelTypeName;
+}
+
+export interface DetokenizeTextParams {
+  tokens: number[];
+  modelType: ModelTypeName;
+}
+
+export interface IVideoService extends Service {
+  isVideoUrl(url: string): boolean;
+  fetchVideoInfo(url: string): Promise<Media>;
+  downloadVideo(videoInfo: Media): Promise<string>;
+  processVideo(url: string, runtime: IAgentRuntime): Promise<Media>;
+}
+
+export interface IBrowserService extends Service {
+  getPageContent(
+    url: string,
+    runtime: IAgentRuntime
+  ): Promise<{ title: string; description: string; bodyContent: string }>;
+}
+
+export interface IPdfService extends Service {
+  convertPdfToText(pdfBuffer: Buffer): Promise<string>;
+}
+
+export interface IFileService extends Service {
+  uploadFile(
+    imagePath: string,
+    subDirectory: string,
+    useSignedUrl: boolean,
+    expiresIn: number
+  ): Promise<{
+    success: boolean;
+    url?: string;
+    error?: string;
+  }>;
+  generateSignedUrl(fileName: string, expiresIn: number): Promise<string>;
+}
+
+export interface TestCase {
+  name: string;
+  fn: (runtime: IAgentRuntime) => Promise<void> | void;
+}
+
+export interface TestSuite {
+  name: string;
+  tests: TestCase[];
+}
+
+// Represents an agent in the TeeAgent table, containing details about the agent.
+export interface TeeAgent {
+  id: string; // Primary key
+  // Allow duplicate agentId.
+  // This is to support the case where the same agentId is registered multiple times.
+  // Each time the agent restarts, we will generate a new keypair and attestation.
+  agentId: string;
+  agentName: string;
+  createdAt: number;
+  publicKey: string;
+  attestation: string;
+}
+
+export enum TEEMode {
+  OFF = 'OFF',
+  LOCAL = 'LOCAL', // For local development with simulator
+  DOCKER = 'DOCKER', // For docker development with simulator
+  PRODUCTION = 'PRODUCTION', // For production without simulator
+}
+
+export interface RemoteAttestationQuote {
+  quote: string;
+  timestamp: number;
+}
+
+export interface DeriveKeyAttestationData {
+  agentId: string;
+  publicKey: string;
+  subject?: string;
+}
+
+export interface RemoteAttestationMessage {
+  agentId: string;
+  timestamp: number;
+  message: {
+    entityId: string;
+    roomId: string;
+    content: string;
+  };
+}
+
+export enum TeeType {
+  TDX_DSTACK = 'tdx_dstack',
+}
+
+export interface TeeVendorConfig {
+  // Add vendor-specific configuration options here
+  [key: string]: unknown;
+}
+
+export interface TeePluginConfig {
+  vendor?: string;
+  vendorConfig?: TeeVendorConfig;
+}
+
+export interface TaskWorker {
+  name: string;
+  execute: (
+    runtime: IAgentRuntime,
+    options: { [key: string]: unknown },
+    task: Task
+  ) => Promise<void>;
+  validate?: (runtime: IAgentRuntime, message: Memory, state: State) => Promise<boolean>;
+}
+
+export interface Task {
+  id?: UUID;
+  name: string;
+  updatedAt?: number;
+  metadata?: {
+    updateInterval?: number;
+    options?: {
+      name: string;
+      description: string;
+    }[];
+    [key: string]: unknown;
+  };
+  description: string;
+  roomId?: UUID;
+  worldId?: UUID;
+  tags: string[];
+}
+
+export enum Role {
+  OWNER = 'OWNER',
+  ADMIN = 'ADMIN',
+  NONE = 'NONE',
+}
+
+export interface Setting {
+  name: string;
+  description: string; // Used in chat context when discussing the setting
+  usageDescription: string; // Used during settings to guide users
+  value: string | boolean | null;
+  required: boolean;
+  public?: boolean; // If true, shown in public channels
+  secret?: boolean; // If true, value is masked and only shown during settings
+  validation?: (value: any) => boolean;
+  dependsOn?: string[];
+  onSetAction?: (value: any) => string;
+  visibleIf?: (settings: { [key: string]: Setting }) => boolean;
+}
+
+export interface WorldSettings {
+  [key: string]: Setting;
+}
+
+export interface OnboardingConfig {
+  settings: {
+    [key: string]: Omit<Setting, 'value'>;
+  };
+}
+
+/**
+ * Base parameters common to all model types
+ */
+export interface BaseModelParams {
+  /** The agent runtime for accessing services and utilities */
+  runtime: IAgentRuntime;
+}
+
+/**
+ * Parameters for text generation models
+ */
+export interface TextGenerationParams extends BaseModelParams {
+  /** The prompt to generate text from */
+  prompt: string;
+  /** Model temperature (0.0 to 1.0, lower is more deterministic) */
+  temperature?: number;
+  /** Maximum number of tokens to generate */
+  maxTokens?: number;
+  /** Sequences that should stop generation when encountered */
+  stopSequences?: string[];
+  /** Frequency penalty to apply */
+  frequencyPenalty?: number;
+  /** Presence penalty to apply */
+  presencePenalty?: number;
+}
+
+/**
+ * Parameters for text embedding models
+ */
+export interface TextEmbeddingParams extends BaseModelParams {
+  /** The text to create embeddings for */
+  text: string;
+}
+
+/**
+ * Parameters for text tokenization models
+ */
+export interface TokenizeTextParams extends BaseModelParams {
+  /** The text to tokenize */
+  prompt: string;
+  /** The model type to use for tokenization */
+  modelType: ModelTypeName;
+}
+
+/**
+ * Parameters for text detokenization models
+ */
+export interface DetokenizeTextParams extends BaseModelParams {
+  /** The tokens to convert back to text */
+  tokens: number[];
+  /** The model type to use for detokenization */
+  modelType: ModelTypeName;
+}
+
+/**
+ * Parameters for image generation models
+ */
+export interface ImageGenerationParams extends BaseModelParams {
+  /** The prompt describing the image to generate */
+  prompt: string;
+  /** The dimensions of the image to generate */
+  size?: string;
+  /** Number of images to generate */
+  count?: number;
+}
+
+/**
+ * Parameters for image description models
+ */
+export interface ImageDescriptionParams extends BaseModelParams {
+  /** The URL or path of the image to describe */
+  imageUrl: string;
+  /** Optional prompt to guide the description */
+  prompt?: string;
+}
+
+/**
+ * Parameters for transcription models
+ */
+export interface TranscriptionParams extends BaseModelParams {
+  /** The URL or path of the audio file to transcribe */
+  audioUrl: string;
+  /** Optional prompt to guide transcription */
+  prompt?: string;
+}
+
+/**
+ * Parameters for text-to-speech models
+ */
+export interface TextToSpeechParams extends BaseModelParams {
+  /** The text to convert to speech */
+  text: string;
+  /** The voice to use */
+  voice?: string;
+  /** The speaking speed */
+  speed?: number;
+}
+
+/**
+ * Parameters for audio processing models
+ */
+export interface AudioProcessingParams extends BaseModelParams {
+  /** The URL or path of the audio file to process */
+  audioUrl: string;
+  /** The type of audio processing to perform */
+  processingType: string;
+}
+
+/**
+ * Parameters for video processing models
+ */
+export interface VideoProcessingParams extends BaseModelParams {
+  /** The URL or path of the video file to process */
+  videoUrl: string;
+  /** The type of video processing to perform */
+  processingType: string;
+}
+
+/**
+ * Optional JSON schema for validating generated objects
+ */
+export type JSONSchema = {
+  type: string;
+  properties?: Record<string, any>;
+  required?: string[];
+  items?: JSONSchema;
+  [key: string]: any;
+};
+
+/**
+ * Parameters for object generation models
+ * @template T - The expected return type, inferred from schema if provided
+ */
+export interface ObjectGenerationParams<T = any> extends BaseModelParams {
+  /** The prompt describing the object to generate */
+  prompt: string;
+  /** Optional JSON schema for validation */
+  schema?: JSONSchema;
+  /** Type of object to generate */
+  output?: 'object' | 'array' | 'enum';
+  /** For enum type, the allowed values */
+  enumValues?: string[];
+  /** Model type to use */
+  modelType?: ModelTypeName;
+  /** Model temperature (0.0 to 1.0) */
+  temperature?: number;
+  /** Sequences that should stop generation */
+  stopSequences?: string[];
+}
+
+/**
+ * Map of model types to their parameter types
+ */
+export interface ModelParamsMap {
+  [ModelType.TEXT_SMALL]: TextGenerationParams;
+  [ModelType.TEXT_LARGE]: TextGenerationParams;
+  [ModelType.TEXT_EMBEDDING]: TextEmbeddingParams | string | null;
+  [ModelType.TEXT_TOKENIZER_ENCODE]: TokenizeTextParams;
+  [ModelType.TEXT_TOKENIZER_DECODE]: DetokenizeTextParams;
+  [ModelType.TEXT_REASONING_SMALL]: TextGenerationParams;
+  [ModelType.TEXT_REASONING_LARGE]: TextGenerationParams;
+  [ModelType.IMAGE]: ImageGenerationParams;
+  [ModelType.IMAGE_DESCRIPTION]: ImageDescriptionParams | string;
+  [ModelType.TRANSCRIPTION]: TranscriptionParams | Buffer | string;
+  [ModelType.TEXT_TO_SPEECH]: TextToSpeechParams | string;
+  [ModelType.AUDIO]: AudioProcessingParams;
+  [ModelType.VIDEO]: VideoProcessingParams;
+  [ModelType.OBJECT_SMALL]: ObjectGenerationParams<any>;
+  [ModelType.OBJECT_LARGE]: ObjectGenerationParams<any>;
+  // Allow string index for custom model types
+  [key: string]: BaseModelParams | any;
+}
+
+/**
+ * Map of model types to their return value types
+ */
+export interface ModelResultMap {
+  [ModelType.TEXT_SMALL]: string;
+  [ModelType.TEXT_LARGE]: string;
+  [ModelType.TEXT_EMBEDDING]: number[];
+  [ModelType.TEXT_TOKENIZER_ENCODE]: number[];
+  [ModelType.TEXT_TOKENIZER_DECODE]: string;
+  [ModelType.TEXT_REASONING_SMALL]: string;
+  [ModelType.TEXT_REASONING_LARGE]: string;
+  [ModelType.IMAGE]: { url: string }[];
+  [ModelType.IMAGE_DESCRIPTION]: { title: string; description: string };
+  [ModelType.TRANSCRIPTION]: string;
+  [ModelType.TEXT_TO_SPEECH]: any | Buffer;
+  [ModelType.AUDIO]: any; // Specific return type depends on processing type
+  [ModelType.VIDEO]: any; // Specific return type depends on processing type
+  [ModelType.OBJECT_SMALL]: any;
+  [ModelType.OBJECT_LARGE]: any;
+  // Allow string index for custom model types
+  [key: string]: any;
+}
+
+/**
+ * Standard event types across all platforms
+ */
+export enum EventType {
+  // World events
+  WORLD_JOINED = 'WORLD_JOINED',
+  WORLD_CONNECTED = 'WORLD_CONNECTED',
+  WORLD_LEFT = 'WORLD_LEFT',
+
+  // Entity events
+  ENTITY_JOINED = 'ENTITY_JOINED',
+  ENTITY_LEFT = 'ENTITY_LEFT',
+  ENTITY_UPDATED = 'ENTITY_UPDATED',
+
+  // Room events
+  ROOM_JOINED = 'ROOM_JOINED',
+  ROOM_LEFT = 'ROOM_LEFT',
+
+  // Message events
+  MESSAGE_RECEIVED = 'MESSAGE_RECEIVED',
+  MESSAGE_SENT = 'MESSAGE_SENT',
+
+  // Voice events
+  VOICE_MESSAGE_RECEIVED = 'VOICE_MESSAGE_RECEIVED',
+  VOICE_MESSAGE_SENT = 'VOICE_MESSAGE_SENT',
+
+  // Interaction events
+  REACTION_RECEIVED = 'REACTION_RECEIVED',
+  POST_GENERATED = 'POST_GENERATED',
+  INTERACTION_RECEIVED = 'INTERACTION_RECEIVED',
+
+  // Run events
+  RUN_STARTED = 'RUN_STARTED',
+  RUN_ENDED = 'RUN_ENDED',
+  RUN_TIMEOUT = 'RUN_TIMEOUT',
+
+  // Action events
+  ACTION_STARTED = 'ACTION_STARTED',
+  ACTION_COMPLETED = 'ACTION_COMPLETED',
+
+  // Evaluator events
+  EVALUATOR_STARTED = 'EVALUATOR_STARTED',
+  EVALUATOR_COMPLETED = 'EVALUATOR_COMPLETED',
+}
+
+/**
+ * Platform-specific event type prefix
+ */
+export enum PlatformPrefix {
+  DISCORD = 'DISCORD',
+  TELEGRAM = 'TELEGRAM',
+  TWITTER = 'TWITTER',
+}
+
+/**
+ * Base payload interface for all events
+ */
+export interface EventPayload {
+  runtime: IAgentRuntime;
+  source: string;
+  onComplete?: () => void;
+}
+
+/**
+ * Payload for world-related events
+ */
+export interface WorldPayload extends EventPayload {
+  world: World;
+  rooms: Room[];
+  entities: Entity[];
+}
+
+/**
+ * Payload for entity-related events
+ */
+export interface EntityPayload extends EventPayload {
+  entityId: UUID;
+  worldId?: UUID;
+  roomId?: UUID;
+  metadata?: {
+    orginalId: string;
+    username: string;
+    displayName?: string;
+    [key: string]: any;
+  };
+}
+
+/**
+ * Payload for reaction-related events
+ */
+export interface MessagePayload extends EventPayload {
+  message: Memory;
+  callback?: HandlerCallback;
+  onComplete?: () => void;
+}
+
+/**
+ * Payload for events that are invoked without a message
+ */
+export interface InvokePayload extends EventPayload {
+  worldId: UUID;
+  userId: string;
+  roomId: UUID;
+  callback?: HandlerCallback;
+  source: string;
+}
+
+/**
+ * Run event payload type
+ */
+export interface RunEventPayload extends EventPayload {
+  runId: UUID;
+  messageId: UUID;
+  roomId: UUID;
+  entityId: UUID;
+  startTime: number;
+  status: 'started' | 'completed' | 'timeout';
+  endTime?: number;
+  duration?: number;
+  error?: string;
+}
+
+/**
+ * Action event payload type
+ */
+export interface ActionEventPayload extends EventPayload {
+  actionId: UUID;
+  actionName: string;
+  startTime?: number;
+  completed?: boolean;
+  error?: Error;
+}
+
+/**
+ * Evaluator event payload type
+ */
+export interface EvaluatorEventPayload extends EventPayload {
+  evaluatorId: UUID;
+  evaluatorName: string;
+  startTime?: number;
+  completed?: boolean;
+  error?: Error;
+}
+
+/**
+ * Represents the parameters for a message received handler.
+ * @typedef {Object} MessageReceivedHandlerParams
+ * @property {IAgentRuntime} runtime - The agent runtime associated with the message.
+ * @property {Memory} message - The message received.
+ * @property {HandlerCallback} callback - The callback function to be executed after handling the message.
+ */
+export type MessageReceivedHandlerParams = {
+  runtime: IAgentRuntime;
+  message: Memory;
+  callback: HandlerCallback;
+  onComplete?: () => void;
+};
+
+/**
+ * Maps event types to their corresponding payload types
+ */
+export interface EventPayloadMap {
+  [EventType.WORLD_JOINED]: WorldPayload;
+  [EventType.WORLD_CONNECTED]: WorldPayload;
+  [EventType.WORLD_LEFT]: WorldPayload;
+  [EventType.ENTITY_JOINED]: EntityPayload;
+  [EventType.ENTITY_LEFT]: EntityPayload;
+  [EventType.ENTITY_UPDATED]: EntityPayload;
+  [EventType.MESSAGE_RECEIVED]: MessagePayload;
+  [EventType.MESSAGE_SENT]: MessagePayload;
+  [EventType.REACTION_RECEIVED]: MessagePayload;
+  [EventType.POST_GENERATED]: InvokePayload;
+  [EventType.INTERACTION_RECEIVED]: MessagePayload;
+  [EventType.RUN_STARTED]: RunEventPayload;
+  [EventType.RUN_ENDED]: RunEventPayload;
+  [EventType.RUN_TIMEOUT]: RunEventPayload;
+  [EventType.ACTION_STARTED]: ActionEventPayload;
+  [EventType.ACTION_COMPLETED]: ActionEventPayload;
+  [EventType.EVALUATOR_STARTED]: EvaluatorEventPayload;
+  [EventType.EVALUATOR_COMPLETED]: EvaluatorEventPayload;
+}
+
+/**
+ * Event handler function type
+ */
+export type EventHandler<T extends keyof EventPayloadMap> = (
+  payload: EventPayloadMap[T]
+) => Promise<void>;
+
+/**
+ * Update the Plugin interface with typed events
+ */
+
+export enum SOCKET_MESSAGE_TYPE {
+  ROOM_JOINING = 1,
+  SEND_MESSAGE = 2,
+  MESSAGE = 3,
+  ACK = 4,
+  THINKING = 5,
+}
+
+/**
+ * Specialized memory type for messages with enhanced type checking
+ */
+export interface MessageMemory extends Memory {
+  metadata: MessageMetadata;
+  content: Content & {
+    text: string; // Message memories must have text content
+  };
+}
+
+/**
+ * Factory function to create a new message memory with proper defaults
+ */
+export function createMessageMemory(params: {
+  id?: UUID;
+  entityId: UUID;
+  agentId?: UUID;
+  roomId: UUID;
+  content: Content & { text: string };
+  embedding?: number[];
+}): MessageMemory {
+  return {
+    ...params,
+    createdAt: Date.now(),
+    metadata: {
+      type: MemoryType.MESSAGE,
+      timestamp: Date.now(),
+      scope: params.agentId ? 'private' : 'shared',
+    },
+  };
+}
+
+/**
+ * Generic service interface that provides better type checking for services
+ * @template ConfigType The configuration type for this service
+ * @template ResultType The result type returned by the service operations
+ */
+export interface TypedService<ConfigType = unknown, ResultType = unknown> extends Service {
+  /**
+   * The configuration for this service instance
+   */
+  config: ConfigType;
+
+  /**
+   * Process an input with this service
+   * @param input The input to process
+   * @returns A promise resolving to the result
+   */
+  process(input: unknown): Promise<ResultType>;
+}
+
+/**
+ * Generic factory function to create a typed service instance
+ * @param runtime The agent runtime
+ * @param serviceType The type of service to get
+ * @returns The service instance or null if not available
+ */
+export function getTypedService<T extends TypedService<any, any>>(
+  runtime: IAgentRuntime,
+  serviceType: ServiceTypeName
+): T | null {
+  return runtime.getService<T>(serviceType);
+}
+
+/**
+ * Type guard to check if a memory metadata is a DocumentMetadata
+ * @param metadata The metadata to check
+ * @returns True if the metadata is a DocumentMetadata
+ */
+export function isDocumentMetadata(metadata: MemoryMetadata): metadata is DocumentMetadata {
+  return metadata.type === MemoryType.DOCUMENT;
+}
+
+/**
+ * Type guard to check if a memory metadata is a FragmentMetadata
+ * @param metadata The metadata to check
+ * @returns True if the metadata is a FragmentMetadata
+ */
+export function isFragmentMetadata(metadata: MemoryMetadata): metadata is FragmentMetadata {
+  return metadata.type === MemoryType.FRAGMENT;
+}
+
+/**
+ * Type guard to check if a memory metadata is a MessageMetadata
+ * @param metadata The metadata to check
+ * @returns True if the metadata is a MessageMetadata
+ */
+export function isMessageMetadata(metadata: MemoryMetadata): metadata is MessageMetadata {
+  return metadata.type === MemoryType.MESSAGE;
+}
+
+/**
+ * Type guard to check if a memory metadata is a DescriptionMetadata
+ * @param metadata The metadata to check
+ * @returns True if the metadata is a DescriptionMetadata
+ */
+export function isDescriptionMetadata(metadata: MemoryMetadata): metadata is DescriptionMetadata {
+  return metadata.type === MemoryType.DESCRIPTION;
+}
+
+/**
+ * Type guard to check if a memory metadata is a CustomMetadata
+ * @param metadata The metadata to check
+ * @returns True if the metadata is a CustomMetadata
+ */
+export function isCustomMetadata(metadata: MemoryMetadata): metadata is CustomMetadata {
+  return (
+    metadata.type !== MemoryType.DOCUMENT &&
+    metadata.type !== MemoryType.FRAGMENT &&
+    metadata.type !== MemoryType.MESSAGE &&
+    metadata.type !== MemoryType.DESCRIPTION
+  );
+}
+
+/**
+ * Standardized service error type for consistent error handling
+ */
+export interface ServiceError {
+  code: string;
+  message: string;
+  details?: unknown;
+  cause?: Error;
+}
+
+/**
+ * Type-safe helper for accessing the video service
+ */
+export function getVideoService(runtime: IAgentRuntime): IVideoService | null {
+  return runtime.getService<IVideoService>(ServiceType.VIDEO);
+}
+
+/**
+ * Type-safe helper for accessing the browser service
+ */
+export function getBrowserService(runtime: IAgentRuntime): IBrowserService | null {
+  return runtime.getService<IBrowserService>(ServiceType.BROWSER);
+}
+
+/**
+ * Type-safe helper for accessing the PDF service
+ */
+export function getPdfService(runtime: IAgentRuntime): IPdfService | null {
+  return runtime.getService<IPdfService>(ServiceType.PDF);
+}
+
+/**
+ * Type-safe helper for accessing the file service
+ */
+export function getFileService(runtime: IAgentRuntime): IFileService | null {
+  return runtime.getService<IFileService>(ServiceType.REMOTE_FILES);
+}
+
+/**
+ * Memory type guard for document memories
+ */
+export function isDocumentMemory(
+  memory: Memory
+): memory is Memory & { metadata: DocumentMetadata } {
+  return memory.metadata?.type === MemoryType.DOCUMENT;
+}
+
+/**
+ * Memory type guard for fragment memories
+ */
+export function isFragmentMemory(
+  memory: Memory
+): memory is Memory & { metadata: FragmentMetadata } {
+  return memory.metadata?.type === MemoryType.FRAGMENT;
+}
+
+/**
+ * Safely access the text content of a memory
+ * @param memory The memory to extract text from
+ * @param defaultValue Optional default value if no text is found
+ * @returns The text content or default value
+ */
+export function getMemoryText(memory: Memory, defaultValue = ''): string {
+  return memory.content.text ?? defaultValue;
+}
+
+/**
+ * Safely create a ServiceError from any caught error
+ */
+export function createServiceError(error: unknown, code = 'UNKNOWN_ERROR'): ServiceError {
+  if (error instanceof Error) {
+    return {
+      code,
+      message: error.message,
+      cause: error,
+    };
+  }
+
+  return {
+    code,
+    message: String(error),
+  };
+}
+
+/**
+ * Replace 'any' types with more specific types
+ */
+
+// Replace 'any' in State interface components
+export type StateValue = string | number | boolean | null | StateObject | StateArray;
+export interface StateObject {
+  [key: string]: StateValue;
+}
+export type StateArray = StateValue[];
+
+/**
+ * Enhanced State interface with more specific types
+ */
+export interface EnhancedState {
+  values: StateObject;
+  data: StateObject;
+  text: string;
+  [key: string]: StateValue;
+}
+
+// Replace 'any' in component data
+export type ComponentData = Record<string, unknown>;
+
+// Replace 'any' in event handlers
+export type EventDataObject = Record<string, unknown>;
+export type TypedEventHandler = (data: EventDataObject) => Promise<void> | void;
+
+// Replace 'any' in database adapter
+export type DbConnection = unknown;
+export type MetadataObject = Record<string, unknown>;
+
+// Replace 'any' in model handlers
+export type ModelHandler = (
+  runtime: IAgentRuntime,
+  params: Record<string, unknown>
+) => Promise<unknown>;
+
+// Replace 'any' for service configurationa
+export type ServiceConfig = Record<string, unknown>;
+
+// Allowable vector dimensions
+export const VECTOR_DIMS = {
+  SMALL: 384,
+  MEDIUM: 512,
+  LARGE: 768,
+  XL: 1024,
+  XXL: 1536,
+  XXXL: 3072,
+} as const;

--- a/packages/core-plugin-v2/src/uuid.ts
+++ b/packages/core-plugin-v2/src/uuid.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+import type { UUID } from './types';
+import { validateUuid as coreValidateUuid, stringToUuid as coreStringToUuid } from '@elizaos/core';
+
+export const uuidSchema = z.string().uuid() as z.ZodType<UUID>;
+
+/**
+ * Validate if the given value is a valid UUID.
+ *
+ * @param {unknown} value - The value to be validated.
+ * @returns {UUID | null} The validated UUID value or null if validation fails.
+ */
+export function validateUuid(value: unknown): UUID | null {
+  return coreValidateUuid(value);
+}
+
+/**
+ * Converts a string or number to a UUID.
+ *
+ * @param {string | number} target - The string or number to convert to a UUID.
+ * @returns {UUID} The UUID generated from the input target.
+ * @throws {TypeError} Throws an error if the input target is not a string.
+ */
+export function stringToUuid(target: string | number): UUID {
+  return coreStringToUuid(target);
+}

--- a/packages/core-plugin-v2/tsconfig.json
+++ b/packages/core-plugin-v2/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "typeRoots": ["./node_modules/@types"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/core-plugin-v2/tsup.config.ts
+++ b/packages/core-plugin-v2/tsup.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  outDir: 'dist',
+  clean: true,
+  format: ['esm'],
+  target: 'node18',
+  dts: false,
+  external: [
+    'dotenv',
+    'fs',
+    'path',
+    'node:fs',
+    'node:path',
+    'node:crypto',
+    'node:web',
+    'node:stream',
+    'node:buffer',
+    'node:util',
+    'node:events',
+    'node:url',
+    'node:http',
+    'node:https',
+    'http',
+    'https',
+    'sharp',
+    '@solana/web3.js',
+    'zod',
+    '@hapi/shot',
+  ],
+  sourcemap: false,
+});


### PR DESCRIPTION
I'm posting this here for team review, these will be committed and maintained in a separate repo and will be submoduled in.

This establishes a V2 core specification and a V1 core specification that wrap the real internal core. 

All 1.x plugins must use core-plugin-v2 instead of `@elizaos/core`
All 0.x plugins must use core-plugin-v1 instead of `@elizaos/core`

maybe they should be v0 and v1

