### PR TITLE
ELIZA290/part-1-global-options-create-and-setup-monorepo-commands

### DIFF
--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -1,7 +1,7 @@
 import { checkServer, displayAgent, handleError } from '@/src/utils';
 import type { Agent } from '@elizaos/core';
 import { logger } from '@elizaos/core';
-import { Command, OptionValues } from 'commander';
+import { Command, OptionValues, Option } from 'commander';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -87,7 +87,13 @@ async function resolveAgentId(idOrNameOrIndex: string, opts: OptionValues): Prom
   console.error(`Agent not found: ${idOrNameOrIndex}`);
 }
 
-export const agent = new Command().name('agent').description('Manage ElizaOS agents');
+export const agent = new Command()
+  .name('agent')
+  .description('Manage ElizaOS agents')
+  .addOption(new Option('-r, --remote-url <url>', 'URL of the remote agent runtime'))
+  .addOption(
+    new Option('-p, --port <port>', 'Port to listen on').argParser((val) => Number.parseInt(val))
+  );
 
 /**
  * Interface representing the payload sent when starting an agent.

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,5 +1,5 @@
 import { buildProject, handleError, isMonorepoContext, UserEnvironment } from '@/src/utils';
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import { execa } from 'execa';
 import type { ChildProcess } from 'node:child_process';
 import { spawn } from 'node:child_process';
@@ -319,6 +319,9 @@ export const dev = new Command()
     'Path or URL to character file to use instead of default'
   )
   .option('-b, --build', 'Build the project before starting')
+  .addOption(
+    new Option('-p, --port <port>', 'Port to listen on').argParser((val) => Number.parseInt(val))
+  )
   .action(async (options) => {
     try {
       const cwd = process.cwd();

--- a/packages/cli/src/commands/setup-monorepo.ts
+++ b/packages/cli/src/commands/setup-monorepo.ts
@@ -22,6 +22,16 @@ async function cloneRepository(repo: string, branch: string, destination: string
 
     console.log('Repository cloned successfully');
   } catch (error) {
+    // Check for branch not found error
+    if (
+      error.message &&
+      error.message.includes('Remote branch') &&
+      error.message.includes('not found')
+    ) {
+      throw new Error(
+        `Branch '${branch}' doesn't exist in the ElizaOS repository. \nCheck https://github.com/elizaOS/eliza/branches for a list of branches.`
+      );
+    }
     throw new Error(`Failed to clone repository: ${error.message}`);
   }
 }
@@ -58,11 +68,9 @@ export const setupMonorepo = new Command()
   .option('-d, --dir <directory>', 'Destination directory', './eliza')
   .action(async (options) => {
     try {
-      const { repo, branch, dir } = {
-        repo: 'elizaOS/eliza',
-        branch: 'v2-develop',
-        dir: './eliza',
-      };
+      const repo = 'elizaOS/eliza';
+      const branch = options.branch || 'v2-develop';
+      const dir = options.dir || './eliza';
 
       // Create destination directory if it doesn't exist
       const destinationDir = path.resolve(process.cwd(), dir);

--- a/packages/cli/src/commands/setup-monorepo.ts
+++ b/packages/cli/src/commands/setup-monorepo.ts
@@ -22,15 +22,16 @@ async function cloneRepository(repo: string, branch: string, destination: string
 
     console.log('Repository cloned successfully');
   } catch (error) {
-    // Check for branch not found error
-    if (
-      error.message &&
-      error.message.includes('Remote branch') &&
-      error.message.includes('not found')
-    ) {
-      throw new Error(
-        `Branch '${branch}' doesn't exist in the ElizaOS repository. \nCheck https://github.com/elizaOS/eliza/branches for a list of branches.`
+    // Special handling for likely branch errors
+    if (error.message && error.message.includes('exit code 128')) {
+      console.error(`\n❌ Branch '${branch}' doesn't exist in the ElizaOS repository.`);
+      console.error(`Please specify a valid branch name. Common branches include:`);
+      console.error(`  • main - The main branch`);
+      console.error(`  • v2-develop - The development branch (default)`);
+      console.error(
+        `\nFor a complete list of branches, visit: https://github.com/elizaOS/eliza/branches`
       );
+      throw new Error(`Branch '${branch}' not found`);
     }
     throw new Error(`Failed to clone repository: ${error.message}`);
   }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -25,7 +25,7 @@ import {
   type IAgentRuntime,
   type Plugin,
 } from '@elizaos/core';
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -797,9 +797,13 @@ export const start = new Command()
     '-chars, --characters <paths>',
     'multiple character configuration files separated by commas'
   )
+  .addOption(
+    new Option('-p, --port <port>', 'Port to listen on').argParser((val) => Number.parseInt(val))
+  )
+  .hook('preAction', async () => {
+    await displayBanner();
+  })
   .action(async (options) => {
-    displayBanner();
-
     try {
       // Build the project first unless skip-build is specified
       if (options.build) {

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -3,7 +3,7 @@ import { AgentServer } from '@/src/server/index';
 import { jsonToCharacter, loadCharacterTryPath } from '@/src/server/loader';
 import { TestRunner, buildProject, promptForEnvVars } from '@/src/utils';
 import { type IAgentRuntime, type ProjectAgent } from '@elizaos/core';
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import * as dotenv from 'dotenv';
 import * as fs from 'node:fs';
 import { existsSync } from 'node:fs';
@@ -433,7 +433,9 @@ const runAgentTests = async (options: {
 export const test = new Command()
   .name('test')
   .description('Run tests for Eliza agent plugins')
-  .option('-p, --port <port>', 'Port to listen on', (val) => Number.parseInt(val))
+  .addOption(
+    new Option('-p, --port <port>', 'Port to listen on').argParser((val) => Number.parseInt(val))
+  )
   .option('-pl, --plugin <name>', 'Name of plugin to test')
   .option('-sp, --skip-plugins', 'Skip plugin tests')
   .option('-spt, --skip-project-tests', 'Skip project tests')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,7 +16,7 @@ import { update } from '@/src/commands/update';
 import { updateCLI } from '@/src/commands/update-cli';
 import { displayBanner, loadEnvironment } from '@/src/utils';
 import { logger } from '@elizaos/core';
-import { Command } from 'commander';
+import { Command, Option } from 'commander';
 import fs from 'node:fs';
 import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -50,10 +50,15 @@ async function main() {
 
   const program = new Command().name('elizaos').version(version).alias('-v');
 
-  // Add global options
+  // Add global options but hide them from global help
+  // They will still be passed to all commands for backward compatibility
   program
-    .option('-r, --remote-url <url>', 'URL of the remote agent runtime')
-    .option('-p, --port <port>', 'Port to listen on', (val) => Number.parseInt(val));
+    .addOption(new Option('-r, --remote-url <url>', 'URL of the remote agent runtime').hideHelp())
+    .addOption(
+      new Option('-p, --port <port>', 'Port to listen on')
+        .argParser((val) => Number.parseInt(val))
+        .hideHelp()
+    );
 
   // Create a stop command for testing purposes
   const stopCommand = new Command('stop')

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -48,7 +48,9 @@ async function main() {
     version = packageJson.version;
   }
 
-  const program = new Command().name('elizaos').version(version).alias('-v');
+  const program = new Command()
+    .name('elizaos')
+    .version(version, '-v, --version', 'output the version number');
 
   // Add global options but hide them from global help
   // They will still be passed to all commands for backward compatibility


### PR DESCRIPTION
This PR addresses several issues with the ElizaOS CLI to improve user experience and align functionality with documentation. It is part of a multi-pr (probably 3 prs or so more) effort to get the cli comprehensively tested (ELIZA-290) so we can write updated docs for it.

**Global Options Cleanup:** 

Moved --remote-url and --port from global help text to specific command help texts where they're actually usable, improving clarity while maintaining backward compatibility.

**Setup-Monorepo Command Fix:** 

Resolved a critical bug where user-specified branch and directory options were ignored in favor of hardcoded values. Added enhanced error handling for non-existent branches with user-friendly messages.

**Usage Text Fix:** 

Corrected a display issue where help text incorrectly showed |-v in the usage line.

**Create Command Validation:** 

Thoroughly tested the create command with all flag permutations, confirming it works correctly with different directory flag positions, path formats, and nesting levels.


These changes ensure the CLI behaves as documented and aims to prepare the CLI for final documentation writing.