### PR TITLE
fix: delete agents that have been in room

### DIFF
--- a/packages/plugin-sql/src/schema/log.ts
+++ b/packages/plugin-sql/src/schema/log.ts
@@ -24,7 +24,7 @@ export const logTable = pgTable(
     type: text('type').notNull(),
     roomId: uuid('roomId')
       .notNull()
-      .references(() => roomTable.id),
+      .references(() => roomTable.id, { onDelete: 'cascade' }),
   },
   (table) => [
     foreignKey({


### PR DESCRIPTION
## PR Summary: Fix Foreign Key Constraint Violation on Agent Deletion

[Linear](https://linear.app/eliza-labs/issue/ELIZA-271/if-agent-has-been-in-a-room-it-cant-be-deleted)

**Problem:**
Attempting to delete an agent resulted in a database error: `update or delete on table "rooms" violates foreign key constraint "logs_roomId_rooms_id_fk" on table "logs"`. This occurred because `rooms` associated with the agent were being deleted, but the `logs` table had a foreign key constraint (`logs_roomId_rooms_id_fk`) on `rooms.id` with `ON DELETE NO ACTION`. This prevented the deletion of `rooms` if any `logs` referenced them.

**Solution:**
**Schema Update:** Modified the Drizzle schema definition in [packages/plugin-sql/src/schema/log.ts](cci:7://file:///Users/studio/Documents/GitHub/eliza/packages/plugin-sql/src/schema/log.ts:0:0-0:0). The `roomId` column in `logTable`, which references `roomTable.id`, was updated to explicitly include `onDelete: 'cascade'`.
    ```typescript
    // packages/plugin-sql/src/schema/log.ts
    export const logTable = pgTable(
      // ...
      {
        // ...
        roomId: uuid('roomId')
          .notNull()
          .references(() => roomTable.id, { onDelete: 'cascade' }), // <-- Added onDelete: 'cascade'
      },
      // ...
    );
    ```