### PR TITLE
Enforce Typescript on /cli and  /plugin-sql, fix missing DB functions.

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -539,20 +539,20 @@
     "bufferutil",
   ],
   "overrides": {
-    "@metaplex-foundation/umi": "0.9.2",
     "@nrwl/devkit": "19.8.13",
     "@nrwl/tao": "19.8.13",
-    "@solana/spl-token": "0.4.9",
-    "buffer": "6.0.3",
+    "zod": "3.24.1",
     "eslint": "9.22.0",
-    "form-data": "4.0.2",
-    "got": "12.6.1",
     "react": "19.0.0",
     "react-dom": "19.0.0",
-    "solana-bankrun": "0.3.1",
-    "typedoc-plugin-markdown": "4.2.10",
     "vitest": "3.0.5",
-    "zod": "3.24.1",
+    "@metaplex-foundation/umi": "0.9.2",
+    "typedoc-plugin-markdown": "4.2.10",
+    "buffer": "6.0.3",
+    "@solana/spl-token": "0.4.9",
+    "solana-bankrun": "0.3.1",
+    "got": "12.6.1",
+    "form-data": "4.0.2",
   },
   "packages": {
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.0", "", {}, "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg=="],
@@ -2043,7 +2043,7 @@
 
     "@types/boom": ["@types/boom@7.3.5", "", {}, "sha512-jBS0kU2s9W2sx+ILEyO4kxqIYLllqcUXTaVrBctvGptZ+4X3TWkkgY9+AmxdMPKrgiDDdLcfsaQCTu7bniLvgw=="],
 
-    "@types/bun": ["@types/bun@1.2.12", "", { "dependencies": { "bun-types": "1.2.12" } }, "sha512-lY/GQTXDGsolT/TiH72p1tuyUORuRrdV7VwOTOjDOt8uTBJQOJc5zz3ufwwDl0VBaoxotSk4LdP0hhjLJ6ypIQ=="],
+    "@types/bun": ["@types/bun@1.2.13", "", { "dependencies": { "bun-types": "1.2.13" } }, "sha512-u6vXep/i9VBxoJl3GjZsl/BFIsvML8DfVDO0RYLEwtSZSp981kEO1V5NwRcO1CPJ7AmvpbnDCiMKo3JvbDEjAg=="],
 
     "@types/catbox": ["@types/catbox@10.0.9", "", {}, "sha512-4qXm1SmZurBMNFc/536+7gfbOlN43fWyoo4O0bdLqtpDK/cpuCYnEDou0Cl4naaMwuJ19rEwnuscR7tetGnTDA=="],
 
@@ -2631,7 +2631,7 @@
 
     "bun": ["bun@1.2.13", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.2.13", "@oven/bun-darwin-x64": "1.2.13", "@oven/bun-darwin-x64-baseline": "1.2.13", "@oven/bun-linux-aarch64": "1.2.13", "@oven/bun-linux-aarch64-musl": "1.2.13", "@oven/bun-linux-x64": "1.2.13", "@oven/bun-linux-x64-baseline": "1.2.13", "@oven/bun-linux-x64-musl": "1.2.13", "@oven/bun-linux-x64-musl-baseline": "1.2.13", "@oven/bun-windows-x64": "1.2.13", "@oven/bun-windows-x64-baseline": "1.2.13" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bun.exe" } }, "sha512-EhP1MhFbicqtaRSFCbEZdkcFco8Ov47cNJcB9QmKS8U4cojKHfLU+dQR14lCvLYmtBvGgwv/Lp+9SSver2OPzQ=="],
 
-    "bun-types": ["bun-types@1.2.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-tvWMx5vPqbRXgE8WUZI94iS1xAYs8bkqESR9cxBB1Wi+urvfTrF1uzuDgBHFAdO0+d2lmsbG3HmeKMvUyj6pWA=="],
+    "bun-types": ["bun-types@1.2.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-rRjA1T6n7wto4gxhAO/ErZEtOXyEZEmnIHQfl0Dt1QQSB4QV0iP6BZ9/YB5fZaHFQ2dwHFrmPaRQ9GGMX01k9Q=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
@@ -3975,7 +3975,7 @@
 
     "langium": ["langium@3.3.1", "", { "dependencies": { "chevrotain": "~11.0.3", "chevrotain-allstar": "~0.3.0", "vscode-languageserver": "~9.0.1", "vscode-languageserver-textdocument": "~1.0.11", "vscode-uri": "~3.0.8" } }, "sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w=="],
 
-    "langsmith": ["langsmith@0.3.27", "", { "dependencies": { "@types/uuid": "^10.0.0", "chalk": "^4.1.2", "console-table-printer": "^2.12.1", "p-queue": "^6.6.2", "p-retry": "4", "semver": "^7.6.3", "uuid": "^10.0.0" }, "peerDependencies": { "openai": "*" }, "optionalPeers": ["openai"] }, "sha512-JZx922Z87kKK4I1EwrohdqlbuxCHb1AFhbrHbSQFNrXvtmilTKnmmgZwahf+e1tA3WHXuIsLeu8KMrBojHnnkA=="],
+    "langsmith": ["langsmith@0.3.28", "", { "dependencies": { "@types/uuid": "^10.0.0", "chalk": "^4.1.2", "console-table-printer": "^2.12.1", "p-queue": "^6.6.2", "p-retry": "4", "semver": "^7.6.3", "uuid": "^10.0.0" }, "peerDependencies": { "openai": "*" }, "optionalPeers": ["openai"] }, "sha512-Vq8n0zJ9MhDMhwkOhmOEb/rl/8jpm0LnAF4dE5TEXMdLmhJ784gcrWOghnFh7Qs5B4DY2Bdz3OKxIevkGKn5xg=="],
 
     "language-subtag-registry": ["language-subtag-registry@0.3.23", "", {}, "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ=="],
 
@@ -5139,7 +5139,7 @@
 
     "sandwich-stream": ["sandwich-stream@2.0.2", "", {}, "sha512-jLYV0DORrzY3xaz/S9ydJL6Iz7essZeAfnAavsJ+zsJGZ1MOnsS52yRjU3uF3pJa/lla7+wisp//fxOwOH8SKQ=="],
 
-    "sass": ["sass@1.87.0", "", { "dependencies": { "chokidar": "^4.0.0", "immutable": "^5.0.2", "source-map-js": ">=0.6.2 <2.0.0" }, "optionalDependencies": { "@parcel/watcher": "^2.4.1" }, "bin": { "sass": "sass.js" } }, "sha512-d0NoFH4v6SjEK7BoX810Jsrhj7IQSYHAHLi/iSpgqKc7LaIDshFRlSg5LOymf9FqQhxEHs2W5ZQXlvy0KD45Uw=="],
+    "sass": ["sass@1.88.0", "", { "dependencies": { "chokidar": "^4.0.0", "immutable": "^5.0.2", "source-map-js": ">=0.6.2 <2.0.0" }, "optionalDependencies": { "@parcel/watcher": "^2.4.1" }, "bin": { "sass": "sass.js" } }, "sha512-sF6TWQqjFvr4JILXzG4ucGOLELkESHL+I5QJhh7CNaE+Yge0SI+ehCatsXhJ7ymU1hAFcIS3/PBpjdIbXoyVbg=="],
 
     "sass-loader": ["sass-loader@16.0.5", "", { "dependencies": { "neo-async": "^2.6.2" }, "peerDependencies": { "@rspack/core": "0.x || 1.x", "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0", "sass": "^1.3.0", "sass-embedded": "*", "webpack": "^5.0.0" }, "optionalPeers": ["@rspack/core", "node-sass", "sass", "sass-embedded", "webpack"] }, "sha512-oL+CMBXrj6BZ/zOq4os+UECPL+bWqt6OAC6DWS8Ln8GZRcMDjlJ4JC3FBDuHJdYaFWIdKNIBYmtZtK2MaMkNIw=="],
 
@@ -6639,8 +6639,6 @@
 
     "make-fetch-happen/minipass": ["minipass@5.0.0", "", {}, "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="],
 
-    "make-fetch-happen/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
-
     "make-fetch-happen/ssri": ["ssri@10.0.6", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ=="],
 
     "mdast-util-definitions/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
@@ -6873,7 +6871,7 @@
 
     "node-gyp/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
-    "node-opus/commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
+    "node-opus/commander": ["commander@2.15.1", "", {}, "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="],
 
     "nodemon/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
 
@@ -8031,8 +8029,6 @@
 
     "node-gyp/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
-    "node-gyp/make-fetch-happen/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
-
     "node-gyp/make-fetch-happen/ssri": ["ssri@10.0.6", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-MGrFH9Z4NP9Iyhqn16sDtBpRRNJ0Y2hNa6D65h736fVSaPCHr4DM4sWUNvVaSuC+0OBGhwsrydQwmgfg5LncqQ=="],
 
     "node-gyp/nopt/abbrev": ["abbrev@2.0.0", "", {}, "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="],
@@ -8725,8 +8721,6 @@
 
     "pacote/npm-packlist/ignore-walk/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "pacote/npm-registry-fetch/make-fetch-happen/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
-
     "pacote/read-package-json/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "pacote/read-package-json/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
@@ -8947,8 +8941,6 @@
 
     "pacote/read-package-json/normalize-package-data/hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
-    "pacote/sigstore/@sigstore/sign/make-fetch-happen/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
-
     "pacote/sigstore/@sigstore/tuf/tuf-js/@tufjs/models": ["@tufjs/models@2.0.1", "", { "dependencies": { "@tufjs/canonical-json": "2.0.0", "minimatch": "^9.0.4" } }, "sha512-92F7/SFyufn4DXsha9+QfKnN03JGqtMFMXgSHbZOo8JG59WkTni7UzAouNQDf7AuP9OAMxVOPQcqG3sB7w+kkg=="],
 
     "pacote/sigstore/@sigstore/tuf/tuf-js/make-fetch-happen": ["make-fetch-happen@13.0.1", "", { "dependencies": { "@npmcli/agent": "^2.0.0", "cacache": "^18.0.0", "http-cache-semantics": "^4.1.1", "is-lambda": "^1.0.1", "minipass": "^7.0.2", "minipass-fetch": "^3.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^0.6.3", "proc-log": "^4.2.0", "promise-retry": "^2.0.1", "ssri": "^10.0.0" } }, "sha512-cKTUFc/rbKUd/9meOvgrpJ2WrNzymt6jfRDdwg5UCnVzv9dTpEj9JS5m3wtziXVCjluIXyL8pcaukYqezIzZQA=="],
@@ -9018,8 +9010,6 @@
     "pacote/sigstore/@sigstore/tuf/tuf-js/@tufjs/models/@tufjs/canonical-json": ["@tufjs/canonical-json@2.0.0", "", {}, "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA=="],
 
     "pacote/sigstore/@sigstore/tuf/tuf-js/@tufjs/models/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "pacote/sigstore/@sigstore/tuf/tuf-js/make-fetch-happen/negotiator": ["negotiator@0.6.4", "", {}, "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="],
 
     "pkg-dir/find-up/locate-path/p-locate/p-limit/p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -153,7 +153,7 @@ const runAgentTests = async (options: {
         const checkInterval = setInterval(async () => {
           try {
             // Check if the database is already initialized
-            if (server.database?.isInitialized) {
+            if (await server.database?.getConnection()) {
               clearInterval(checkInterval);
               resolve();
               return;
@@ -174,7 +174,7 @@ const runAgentTests = async (options: {
 
               // Check if we've reached the maximum attempts
               if (initializationAttempts >= maxAttempts) {
-                if (server.database?.connection) {
+                if (await server.database?.getConnection()) {
                   // If we have a connection, consider it good enough even with migration errors
                   console.warn(
                     'Max initialization attempts reached, but database connection exists. Proceeding anyway.'
@@ -200,9 +200,9 @@ const runAgentTests = async (options: {
         }, 1000);
 
         // Timeout after 30 seconds
-        setTimeout(() => {
+        setTimeout(async () => {
           clearInterval(checkInterval);
-          if (server.database?.connection) {
+          if (await server.database?.getConnection()) {
             // If we have a connection, consider it good enough even with initialization issues
             console.warn(
               'Database initialization timeout, but connection exists. Proceeding anyway.'

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   clean: true,
   entry: ['src/index.ts', 'src/commands/*.ts'],
   format: ['esm'],
-  dts: false,
+  dts: true,
   sourcemap: false,
   external: ['@electric-sql/pglite', 'zod', '@elizaos/core'],
   noExternal: [/^(?!(@electric-sql\/pglite|zod)).*/],

--- a/packages/core/src/database.ts
+++ b/packages/core/src/database.ts
@@ -13,6 +13,8 @@ import type {
   UUID,
   World,
 } from './types';
+import { type Pool as PgPool } from 'pg';
+import { PGlite } from '@electric-sql/pglite';
 
 /**
  * An abstract class representing a database adapter for managing various entities
@@ -42,6 +44,12 @@ export abstract class DatabaseAdapter<DB = unknown> implements IDatabaseAdapter 
    * @returns A Promise that resolves when closing is complete.
    */
   abstract close(): Promise<void>;
+
+  /**
+   * Retrieves a connection to the database.
+   * @returns A Promise that resolves to the database connection.
+   */
+  abstract getConnection(): Promise<PGlite | PgPool>;
 
   /**
    * Retrieves an account by its ID.

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -42,6 +42,8 @@ import type {
 } from './types';
 import { EventType, type MessagePayload } from './types';
 import { stringToUuid } from './uuid';
+import { PGlite } from '@electric-sql/pglite';
+import { Pool } from 'pg';
 
 /**
  * Represents a collection of settings grouped by namespace.
@@ -654,6 +656,13 @@ export class AgentRuntime implements IAgentRuntime {
 
       span.addEvent('initialization_completed');
     });
+  }
+
+  async getConnection(): Promise<PGlite | Pool> {
+    if (!this.adapter) {
+      throw new Error('Database adapter not registered');
+    }
+    return this.adapter.getConnection();
   }
 
   private async handleProcessingError(error: any, context: string) {
@@ -2352,6 +2361,10 @@ export class AgentRuntime implements IAgentRuntime {
     return await this.adapter.getWorld(id);
   }
 
+  async removeWorld(worldId: UUID): Promise<void> {
+    await this.adapter.removeWorld(worldId);
+  }
+
   async getAllWorlds(): Promise<World[]> {
     return await this.adapter.getAllWorlds();
   }
@@ -2378,6 +2391,10 @@ export class AgentRuntime implements IAgentRuntime {
 
   async deleteRoom(roomId: UUID): Promise<void> {
     await this.adapter.deleteRoom(roomId);
+  }
+
+  async deleteRoomsByServerId(serverId: UUID): Promise<void> {
+    await this.adapter.deleteRoomsByServerId(serverId);
   }
 
   async updateRoom(room: Room): Promise<void> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,6 @@
+import { type Pool as PgPool } from 'pg';
+import { PGlite } from '@electric-sql/pglite';
+
 /**
  * Type definition for a Universally Unique Identifier (UUID) using a specific format.
  * @typedef {`${string}-${string}-${string}-${string}-${string}`} UUID
@@ -706,6 +709,8 @@ export interface IDatabaseAdapter {
   /** Close database connection */
   close(): Promise<void>;
 
+  getConnection(): Promise<PGlite | PgPool>;
+
   getAgent(agentId: UUID): Promise<Agent | null>;
 
   /** Get all agents */
@@ -828,6 +833,8 @@ export interface IDatabaseAdapter {
 
   getWorld(id: UUID): Promise<World | null>;
 
+  removeWorld(id: UUID): Promise<void>;
+
   getAllWorlds(): Promise<World[]>;
 
   updateWorld(world: World): Promise<void>;
@@ -837,6 +844,8 @@ export interface IDatabaseAdapter {
   createRoom({ id, name, source, type, channelId, serverId, worldId }: Room): Promise<UUID>;
 
   deleteRoom(roomId: UUID): Promise<void>;
+
+  deleteRoomsByServerId(serverId: UUID): Promise<void>;
 
   updateRoom(room: Room): Promise<void>;
 
@@ -993,6 +1002,8 @@ export interface IAgentRuntime extends IDatabaseAdapter {
   registerPlugin(plugin: Plugin): Promise<void>;
 
   initialize(): Promise<void>;
+
+  getConnection(): Promise<PGlite | PgPool>;
 
   getKnowledge(
     message: Memory,

--- a/packages/plugin-sql/src/base.ts
+++ b/packages/plugin-sql/src/base.ts
@@ -204,6 +204,7 @@ export abstract class BaseDrizzleAdapter<
       const row = rows[0];
       return {
         ...row,
+        username: row.username || '',
         id: row.id as UUID,
       };
     });

--- a/packages/plugin-sql/src/pg/adapter.ts
+++ b/packages/plugin-sql/src/pg/adapter.ts
@@ -3,6 +3,7 @@ import { type NodePgDatabase, drizzle } from 'drizzle-orm/node-postgres';
 import { BaseDrizzleAdapter } from '../base';
 import { DIMENSION_MAP, type EmbeddingDimensionColumn } from '../schema/embedding';
 import type { PostgresConnectionManager } from './manager';
+import { type Pool as PgPool } from 'pg';
 
 /**
  * Adapter class for interacting with a PostgreSQL database.
@@ -68,5 +69,14 @@ export class PgDatabaseAdapter extends BaseDrizzleAdapter<NodePgDatabase> {
    */
   async close(): Promise<void> {
     await this.manager.close();
+  }
+
+  /**
+   * Asynchronously retrieves the connection from the manager.
+   *
+   * @returns {Promise<PgPool>} A Promise that resolves with the connection.
+   */
+  async getConnection() {
+    return this.manager.getConnection();
   }
 }

--- a/packages/plugin-sql/src/pglite/adapter.ts
+++ b/packages/plugin-sql/src/pglite/adapter.ts
@@ -72,4 +72,13 @@ export class PgliteDatabaseAdapter extends BaseDrizzleAdapter<PgliteDatabase> {
   async close() {
     await this.manager.close();
   }
+
+  /**
+   * Asynchronously retrieves the connection from the manager.
+   *
+   * @returns {Promise<PGlite>} A Promise that resolves with the connection.
+   */
+  async getConnection() {
+    return this.manager.getConnection();
+  }
 }

--- a/packages/plugin-sql/tsconfig.build.json
+++ b/packages/plugin-sql/tsconfig.build.json
@@ -6,7 +6,8 @@
     "sourceMap": true,
     "inlineSources": true,
     "declaration": true,
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "paths": {}
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]

--- a/packages/plugin-sql/tsup.config.ts
+++ b/packages/plugin-sql/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   format: ['esm'], // Ensure you're targeting CommonJS
-  dts: false, // Skip DTS generation to avoid external import issues
+  dts: true, // Skip DTS generation to avoid external import issues
   tsconfig: './tsconfig.build.json', // Use build-specific tsconfig
   external: [
     'dotenv', // Externalize dotenv to prevent bundling

--- a/packages/plugin-sql/tsup.config.ts
+++ b/packages/plugin-sql/tsup.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   sourcemap: true,
   clean: true,
   format: ['esm'], // Ensure you're targeting CommonJS
-  dts: true, // Skip DTS generation to avoid external import issues
+  dts: true,
   tsconfig: './tsconfig.build.json', // Use build-specific tsconfig
   external: [
     'dotenv', // Externalize dotenv to prevent bundling


### PR DESCRIPTION
This PR:

- Turns on `dts: true` in both CLI and plugin-sql packages.

- This exposed missing: `connection` which was being used in tests but didn't actually exist.

- Implemented `getConnection()` for realsies in DB adapters to satisfy usage.

- Also found `deleteRoomsByServerId` and `removeWorld` not implemented in AgentRuntime. Added them.