### PR TITLE
minor fix: remove banner display + have -h, --help show on same line

### DIFF
--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -107,17 +107,10 @@ export const findPluginPackageName = (
 export const plugins = new Command()
   .name('plugins')
   .description('Manage ElizaOS plugins')
-  .option('--help', 'Show help for plugins command')
+  .option('-h, --help', 'Show help for plugins command')
   .action(function () {
-    // Display banner before showing help
-    displayBanner()
-      .then(() => {
-        this.help();
-      })
-      .catch((err) => {
-        // Silently continue if banner display fails
-        this.help();
-      });
+    // Just show help without displaying banner
+    this.help();
   });
 
 export const pluginsCommand = plugins


### PR DESCRIPTION
**NO LOGIC OR FUNCTIONALITY CHANGES**

in order to keep the cli helper text ux uniform and consistent, i made these two minor changes:

- removed the displayBanner(), kinda random to show it in elizaos plugins -- this is mostly called during a more main action like updating cli, creating an agent/project/plugin, or starting a server or test server

- right now -h and --help are showing up on two lines but they are the same command and on every other cli command its on a single line