### PR TITLE
Remove REST /ping for websocket status checks in client.

### DIFF
--- a/packages/cli/__test_scripts__/test_start.bats
+++ b/packages/cli/__test_scripts__/test_start.bats
@@ -49,6 +49,9 @@ teardown() {
   done
   [ "$SERVER_UP" -eq 1 ] || { echo "Server is not responding."; exit 1; }
 
+  # Wait for agent to be ready
+  sleep 5
+
   run $ELIZAOS_CMD agent --remote-url "http://localhost:3000" list
 
   [ "$status" -eq 0 ]

--- a/packages/client/src/components/app-sidebar.tsx
+++ b/packages/client/src/components/app-sidebar.tsx
@@ -375,7 +375,7 @@ export function AppSidebar() {
           <FooterLink to="https://eliza.how/" Icon={Book} label="Documentation" />
           <FooterLink to="/logs" Icon={TerminalIcon} label="Logs" />
           <FooterLink to="/settings" Icon={Cog} label="Settings" />
-          <ConnectionStatus className="sidebar-connection-status" />
+          <ConnectionStatus />
         </SidebarMenu>
       </SidebarFooter>
     </Sidebar>

--- a/packages/client/src/components/connection-error-banner.tsx
+++ b/packages/client/src/components/connection-error-banner.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, ExternalLink, RefreshCw } from 'lucide-react';
+import { AlertCircle, ExternalLink } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useConnection } from '../context/ConnectionContext';
 
@@ -7,7 +7,7 @@ export interface ConnectionErrorBannerProps {
 }
 
 export function ConnectionErrorBanner({ className }: ConnectionErrorBannerProps) {
-  const { status, error, refetch } = useConnection();
+  const { status, error } = useConnection();
 
   const shouldShowBanner = status === 'error' || status === 'unauthorized';
 
@@ -93,18 +93,6 @@ export function ConnectionErrorBanner({ className }: ConnectionErrorBannerProps)
               <ExternalLink className="h-3 w-3 mr-1" />
               Troubleshooting Guide
             </a>
-            <button
-              onClick={refetch} // Use refetch from context
-              className={cn(
-                'text-xs flex items-center',
-                isUnauthorized
-                  ? 'hover:text-yellow-200 text-yellow-300'
-                  : 'hover:text-red-200 text-red-300'
-              )}
-            >
-              <RefreshCw className="h-3 w-3 mr-1" />
-              Retry Connection
-            </button>
           </div>
         </div>
       </div>

--- a/packages/client/src/components/connection-status.tsx
+++ b/packages/client/src/components/connection-status.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/lib/utils';
-import { AlertCircle, ExternalLink, RefreshCw, CheckCircle } from 'lucide-react';
+import { AlertCircle, CheckCircle } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { SidebarMenuButton, SidebarMenuItem } from './ui/sidebar';
 import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
@@ -12,12 +12,11 @@ export interface ConnectionStatusProps {
   [key: string]: any;
 }
 
-export default function ConnectionStatus({ className }: ConnectionStatusProps) {
-  const [isHovered, setIsHovered] = useState(false);
+export default function ConnectionStatus() {
   const { toast } = useToast();
   const [prevStatus, setPrevStatus] = useState<string | null>(null);
   const { openApiKeyDialog } = useAuth();
-  const { status, error, refetch } = useConnection();
+  const { status, error } = useConnection();
 
   // Derive states from context
   const isLoading = status === 'loading';
@@ -80,9 +79,6 @@ export default function ConnectionStatus({ className }: ConnectionStatusProps) {
     return isConnected ? 'text-green-600' : 'text-red-600';
   };
 
-  // Use the refetch function from the context
-  const refreshStatus = refetch;
-
   // Get a specific error message based on the error
   const getErrorMessage = () => {
     if (!error) return 'Connection failed'; // Use error from context
@@ -107,24 +103,16 @@ export default function ConnectionStatus({ className }: ConnectionStatusProps) {
       return 'Endpoint not found';
     }
     return error; // Return the error message directly
-
-    return 'Connection failed';
   };
 
   return (
     <SidebarMenuItem>
       <Tooltip>
         <TooltipTrigger asChild>
-          <SidebarMenuButton
-            onMouseEnter={() => setIsHovered(true)}
-            onMouseLeave={() => setIsHovered(false)}
-            onClick={refreshStatus}
-          >
+          <SidebarMenuButton>
             <div className="flex flex-col gap-1 select-none">
               <div className="flex items-center gap-1">
-                {isHovered ? (
-                  <RefreshCw className="h-3.5 w-3.5 text-muted-foreground animate-pulse" />
-                ) : showingError || isUnauthorized ? (
+                {showingError || isUnauthorized ? (
                   // Use AlertCircle for both general errors and unauthorized, but color differently
                   <AlertCircle
                     className={cn(
@@ -135,11 +123,7 @@ export default function ConnectionStatus({ className }: ConnectionStatusProps) {
                 ) : (
                   <div className={cn(['h-2.5 w-2.5 rounded-full', getStatusColor()])} />
                 )}
-                <span
-                  className={cn('text-xs', isHovered ? 'text-muted-foreground' : getTextColor())}
-                >
-                  {isHovered ? 'Refresh' : getStatusText()}
-                </span>
+                <span className={cn('text-xs', getTextColor())}>{getStatusText()}</span>
               </div>
             </div>
           </SidebarMenuButton>

--- a/packages/client/src/context/ConnectionContext.tsx
+++ b/packages/client/src/context/ConnectionContext.tsx
@@ -1,127 +1,101 @@
-import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from '@/lib/api';
-import clientLogger from '@/lib/logger';
+import { createContext, useContext, useState, ReactNode, useEffect, useRef } from 'react';
 import { useToast } from '@/hooks/use-toast';
-import { STALE_TIMES } from '@/hooks/use-query-hooks';
+import SocketIOManager from '@/lib/socketio-manager';
 
-export type ConnectionStatusType = 'loading' | 'connected' | 'error' | 'unauthorized';
+export type ConnectionStatusType =
+  | 'loading'
+  | 'connected'
+  | 'reconnecting'
+  | 'error'
+  | 'unauthorized';
 
 interface ConnectionContextType {
   status: ConnectionStatusType;
   error: string | null;
-  refetch: () => void;
 }
 
 const ConnectionContext = createContext<ConnectionContextType | undefined>(undefined);
 
 export const ConnectionProvider = ({ children }: { children: ReactNode }) => {
   const { toast } = useToast();
-  const [wasConnected, setWasConnected] = useState(false);
-  const [wasDisconnected, setWasDisconnected] = useState(false);
   const [status, setStatus] = useState<ConnectionStatusType>('loading');
   const [error, setError] = useState<string | null>(null);
-  const queryClient = useQueryClient();
+  const isFirstConnect = useRef(true);
+  const socketManager = SocketIOManager.getInstance();
 
-  const query = useQuery({
-    queryKey: ['ping'],
-    queryFn: () => apiClient.ping(),
-    refetchInterval: 5000,
-    refetchOnWindowFocus: true,
-    retry: (failureCount, error) => {
-      if (error instanceof Error && error.message.includes('Unauthorized')) {
-        return false;
-      }
-      return failureCount < 3;
-    },
-    staleTime: STALE_TIMES.FREQUENT,
-    gcTime: STALE_TIMES.NEVER,
-    throwOnError: false,
-  });
-
-  // Update status and error based on query results
   useEffect(() => {
-    let newStatus: ConnectionStatusType = 'loading';
-    let newError: string | null = null;
+    const onConnect = () => {
+      setStatus('connected');
+      setError(null);
 
-    if (query.isLoading) {
-      newStatus = 'loading';
-    } else if (query.isSuccess) {
-      newStatus = 'connected';
-      newError = null;
-    } else if (query.isError) {
-      if (query.error instanceof Error) {
-        newError = query.error.message;
-        if (newError.includes('Unauthorized') || newError.includes('401')) {
-          newStatus = 'unauthorized';
-        } else {
-          newStatus = 'error';
-        }
+      if (isFirstConnect.current) {
+        isFirstConnect.current = false;
       } else {
-        clientLogger.error('Ping query failed with non-Error type:', query.error);
-        newError = 'An unknown connection error occurred.';
-        newStatus = 'error';
-      }
-    }
-
-    setStatus(newStatus);
-    setError(newError);
-  }, [query.status, query.error, query.isLoading, query.isSuccess, query.isError]);
-
-  // Effects for toast notifications
-  useEffect(() => {
-    if (query.isSuccess && !wasConnected) {
-      setWasConnected(true);
-      setWasDisconnected(false);
-      if (wasDisconnected) {
         toast({
           title: 'Connection Restored',
           description: 'Successfully reconnected to the Eliza server.',
         });
       }
-      clientLogger.info('Successfully connected to Eliza server.');
-    } else if (query.isError && !wasDisconnected) {
-      setWasDisconnected(true);
-      setWasConnected(false);
-      if (wasConnected) {
-        toast({
-          title: 'Connection Lost',
-          description: 'Attempting to reconnect to the Eliza server...',
-          variant: 'destructive',
-        });
-      }
-      const logErrorMessage =
-        query.error instanceof Error ? query.error.message : String(query.error);
-      clientLogger.error(`Connection to Eliza server failed: ${logErrorMessage}`);
-    }
-  }, [query.isSuccess, query.isError, wasConnected, wasDisconnected, toast, query.error]);
+    };
 
-  useEffect(() => {
-    if (query.isError && query.error && !wasDisconnected) {
-      const errorMessage = query.error instanceof Error ? query.error.message : String(query.error);
-      clientLogger.error(`Connection failure detected: ${errorMessage}`);
-    } else if (!wasDisconnected && !query.isSuccess) {
-      if (wasConnected) {
-        clientLogger.warn('Connection to Eliza server lost (status unknown).');
-      }
-    }
-  }, [query.isError, query.error, query.isSuccess, wasConnected, wasDisconnected]);
+    const onDisconnect = (reason: string) => {
+      setStatus('error');
+      setError(`Connection lost: ${reason}`);
 
-  const refetch = () => {
-    queryClient.invalidateQueries({ queryKey: ['ping'] });
-  };
+      toast({
+        title: 'Connection Lost',
+        description: 'Attempting to reconnect to the Eliza server…',
+        variant: 'destructive',
+      });
+    };
+
+    const onReconnectAttempt = () => {
+      setStatus('reconnecting');
+      setError('Reconnecting...');
+    };
+
+    const onConnectError = (err: Error) => {
+      setStatus('error');
+      setError(err.message);
+    };
+
+    const onUnauthorized = (reason: string) => {
+      setStatus('unauthorized');
+      setError(`Unauthorized: ${reason}`);
+      toast({ title: 'Unauthorized', description: 'Please log in again.', variant: 'destructive' });
+    };
+
+    socketManager.on('connect', onConnect);
+    socketManager.on('disconnect', onDisconnect);
+    socketManager.on('reconnect', onConnect);
+    socketManager.on('reconnect_attempt', onReconnectAttempt);
+    socketManager.on('connect_error', onConnectError);
+    socketManager.on('unauthorized', onUnauthorized);
+
+    // trigger initial connect state
+    if (SocketIOManager.isConnected()) {
+      onConnect();
+    }
+
+    return () => {
+      socketManager.off('connect', onConnect);
+      socketManager.off('disconnect', onDisconnect);
+      socketManager.off('reconnect', onConnect);
+      socketManager.off('reconnect_attempt', onReconnectAttempt);
+      socketManager.off('connect_error', onConnectError);
+      socketManager.off('unauthorized', onUnauthorized);
+    };
+  }, [toast]);
 
   return (
-    <ConnectionContext.Provider value={{ status, error, refetch }}>
-      {children}
-    </ConnectionContext.Provider>
+    <ConnectionContext.Provider value={{ status, error }}>{children}</ConnectionContext.Provider>
   );
 };
 
 export const useConnection = () => {
-  const context = useContext(ConnectionContext);
-  if (context === undefined) {
-    throw new Error('useConnection must be used within a ConnectionProvider');
+  const ctx = useContext(ConnectionContext);
+  if (!ctx) {
+    throw new Error('useConnection must be inside ConnectionProvider');
   }
-  return context;
+  return ctx;
 };

--- a/packages/client/src/lib/socketio-manager.ts
+++ b/packages/client/src/lib/socketio-manager.ts
@@ -130,6 +130,10 @@ class SocketIOManager extends EventAdapter {
     return SocketIOManager.instance;
   }
 
+  public static isConnected(): boolean {
+    return SocketIOManager.instance?.isConnected || false;
+  }
+
   /**
    * Initialize the Socket.io connection to the server
    * @param entityId The client entity ID
@@ -161,10 +165,15 @@ class SocketIOManager extends EventAdapter {
       this.isConnected = true;
       this.resolveConnect?.();
 
-      // Rejoin any active rooms after reconnection
+      this.emit('connect');
+
       this.activeRooms.forEach((roomId) => {
         this.joinRoom(roomId);
       });
+    });
+
+    this.socket.on('unauthorized', (reason: string) => {
+      this.emit('unauthorized', reason);
     });
 
     this.socket.on('messageBroadcast', (data) => {
@@ -250,6 +259,8 @@ class SocketIOManager extends EventAdapter {
       clientLogger.info(`[SocketIO] Disconnected. Reason: ${reason}`);
       this.isConnected = false;
 
+      this.emit('disconnect', reason);
+
       // Reset connect promise for next connection
       this.connectPromise = new Promise<void>((resolve) => {
         this.resolveConnect = resolve;
@@ -260,8 +271,19 @@ class SocketIOManager extends EventAdapter {
       }
     });
 
+    this.socket.on('reconnect_attempt', (attempt) => {
+      clientLogger.info('[SocketIO] Reconnect attempt', attempt);
+      this.emit('reconnect_attempt', attempt);
+    });
+
+    this.socket.on('reconnect', (attempt) => {
+      clientLogger.info(`[SocketIO] Reconnected after ${attempt} attempts`);
+      this.emit('reconnect', attempt);
+    });
+
     this.socket.on('connect_error', (error) => {
       clientLogger.error('[SocketIO] Connection error:', error);
+      this.emit('connect_error', error);
     });
   }
 


### PR DESCRIPTION
The /pings were kinda annoying log spam and were not perfectly realtime, like a 5 second lag on connect / reconnect.
We also didn't even have a proper /ping route, it was 404 and falling back to middleware btw.

This PR changes client frontend to rely on pure websocket connect / disconnect for server status changes.

This provides instant realtime feedback, with no /ping spam.

