### PR TITLE
feat: plugin-specification submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "plugin-specification"]
+	path = plugin-specification
+	url = https://github.com/elizaos/plugin-specification

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "packageManager": "bun@1.2.5",
   "workspaces": [
-    "packages/*"
+    "packages/*",
     "plugin-specification/*"
   ],
   "module": "index.ts",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   "packageManager": "bun@1.2.5",
   "workspaces": [
     "packages/*"
+    "plugin-specification/*"
   ],
   "module": "index.ts",
   "type": "module",

--- a/packages/autodoc/package.json
+++ b/packages/autodoc/package.json
@@ -32,18 +32,14 @@
     "ts-node": "10.9.2",
     "tslib": "2.8.1",
     "tsup": "^8.4.0",
-    "typescript": "5.8.2",
-    "@hapi/shot": "^6.0.1",
-    "@types/hapi": "^18.0.14"
+    "typescript": "5.8.2"
   },
   "devDependencies": {
     "tsup": "8.4.0",
     "prettier": "3.5.3",
     "ts-node": "10.9.2",
     "tslib": "2.8.1",
-    "typescript": "5.8.2",
-    "@hapi/shot": "^6.0.1",
-    "@types/hapi": "^18.0.14"
+    "typescript": "5.8.2"
   },
   "gitHead": "dc32785668d1663c0e7fb81909b4b9961db6e6de"
 }


### PR DESCRIPTION
# Risks

Low

# Background

## What does this PR do?

Include the repo (via submodule) for plugin specification
Also removes hapi from autodoc

## What kind of change is this?

Improvements (misc. changes to existing features)

## Why are we doing this? Any context or related work?

# Documentation changes needed?

My changes require a change to the project documentation.

`git submodule update --init --recursive` is now require to build