### PR TITLE
feat: upgrades to cli agent command

### DIFF
--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -166,7 +166,7 @@ agent
   .alias('g')
   .description('Get agent details')
   .requiredOption('-n, --name <name>', 'agent id, name, or index number from list')
-  .option('-j, --json', 'output as JSON')
+  .option('-j, --json', 'display agent configuration as JSON in the console')
   .option('-o, --output <file>', 'output to file (default: {name}.json)')
   .action(async (opts) => {
     try {
@@ -190,6 +190,13 @@ agent
 
       // check if json argument is provided
       if (opts.json) {
+        // exclude id and status fields from the json
+        const { id, createdAt, updatedAt, enabled, ...agentConfig } = agent;
+        // Display JSON in console instead of saving to file
+        console.log(JSON.stringify(agentConfig, null, 2));
+      }
+
+      if (opts.output) {
         const jsonPath = opts.output || path.join(process.cwd(), `${agent.name || 'agent'}.json`);
         // exclude id and status fields from the json
         const { id, createdAt, updatedAt, enabled, ...agentConfig } = agent;

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -382,6 +382,9 @@ agent
           console.error(
             `  2. Use a remote character: elizaos agent start --remote-character https://example.com/character.json`
           );
+          console.error(
+            `  3. Create a new character from Eliza agent template: elizaos create -t agent ${agentName.toLowerCase()}`
+          );
           process.exit(1);
         } catch (listError) {
           // Fall back to basic error if we can't get the agent list

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -157,7 +157,7 @@ agent
         }
       }
 
-      process.exit(0);
+      return;
     } catch (error) {
       await checkServer(opts);
       handleError(error);
@@ -203,7 +203,7 @@ agent
         const jsonPath = path.resolve(process.cwd(), filename);
         fs.writeFileSync(jsonPath, JSON.stringify(agentConfig, null, 2));
         console.log(`Saved agent configuration to ${jsonPath}`);
-        process.exit(0);
+        return;
       }
 
       // Display agent details if not using output option
@@ -215,7 +215,7 @@ agent
         console.log(JSON.stringify(agentConfig, null, 2));
       }
 
-      process.exit(0);
+      return;
     } catch (error) {
       await checkServer(opts);
       handleError(error);
@@ -269,7 +269,8 @@ Required configuration:
             });
           }
         } catch (error) {
-          // Ignore errors when showing agents
+          await checkServer(options);
+          handleError(error);
         }
 
         // Use commander's built-in help
@@ -486,7 +487,7 @@ agent
 
       // Server returns 204 No Content for successful deletion, no need to parse response
       console.log(`Successfully removed agent ${opts.name}`);
-      process.exit(0);
+      return;
     } catch (error) {
       await checkServer(opts);
       handleError(error);

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -15,19 +15,20 @@ import path from 'node:path';
 import prompts from 'prompts';
 import colors from 'yoctocolors';
 import { z } from 'zod';
+import { character as elizaCharacter } from '@/src/characters/eliza';
 
 /**
- * This module handles creating both projects and plugins.
+ * This module handles creating projects, plugins, and agent characters.
  *
  * Previously, plugin creation was handled by the "plugins create" command,
  * but that has been unified with project creation in this single command.
  * Users are now prompted to select which type they want to create.
  *
  * The workflow includes:
- * 1. Asking if the user wants to create a project or plugin
- * 2. Getting the name and creating a directory
+ * 1. Asking if the user wants to create a project, plugin, or agent
+ * 2. Getting the name and creating a directory or file
  * 3. Setting up proper templates and configurations
- * 4. Installing dependencies
+ * 4. Installing dependencies (for projects/plugins)
  * 5. Automatically changing directory to the created project/plugin
  * 6. Showing the user the next steps
  */
@@ -35,7 +36,7 @@ import { z } from 'zod';
 const initOptionsSchema = z.object({
   dir: z.string().default('.'),
   yes: z.boolean().default(false),
-  type: z.enum(['project', 'plugin']).default('project'),
+  type: z.enum(['project', 'plugin', 'agent']).default('project'),
 });
 
 /**
@@ -177,6 +178,10 @@ export const create = new Command()
                 title: 'Plugin - Can be added to the registry and installed by others',
                 value: 'plugin',
               },
+              {
+                title: 'Agent - Character definition file for an agent',
+                value: 'agent',
+              },
             ],
             initial: 0,
           });
@@ -188,8 +193,8 @@ export const create = new Command()
         }
       } else {
         // Validate the provided type if -t was used
-        if (!['project', 'plugin'].includes(projectType)) {
-          console.error(`Invalid type: ${projectType}. Must be either 'project' or 'plugin'`);
+        if (!['project', 'plugin', 'agent'].includes(projectType)) {
+          console.error(`Invalid type: ${projectType}. Must be 'project', 'plugin', or 'agent'`);
           process.exit(1);
         }
       }
@@ -351,6 +356,41 @@ export const create = new Command()
           `\nYour plugin is ready! Here's your development workflow:\n\n[1] Development\n   cd ${cdPath}\n   ${colors.cyan('elizaos dev')}                   # Start development with hot-reloading\n\n[2] Testing\n   ${colors.cyan('elizaos test')}                  # Run automated tests\n   ${colors.cyan('elizaos start')}                 # Test in a live agent environment\n\n[3] Publishing\n   ${colors.cyan('elizaos plugin publish --test')} # Check registry requirements\n   ${colors.cyan('elizaos plugin publish')}        # Submit to registry\n\n[?] Learn more: https://eliza.how/docs/cli/plugins`
         );
         process.stdout.write(`\u001B]1337;CurrentDir=${targetDir}\u0007`);
+        return;
+      } else if (options.type === 'agent') {
+        // Agent character creation
+        let characterName = projectName || 'MyAgent';
+
+        // Start with the default Eliza character from the same source used by start.ts
+        const agentTemplate = { ...elizaCharacter };
+
+        // Update only the name property
+        agentTemplate.name = characterName;
+
+        // In messageExamples, replace "Eliza" with the new character name
+        if (agentTemplate.messageExamples) {
+          agentTemplate.messageExamples.forEach((conversation) => {
+            conversation.forEach((message) => {
+              if (message.name === 'Eliza') {
+                message.name = characterName;
+              }
+            });
+          });
+        }
+
+        // Set a simple filename - either the provided name or default
+        let filename = characterName.endsWith('.json') ? characterName : `${characterName}.json`;
+
+        // Make sure we're in the current directory
+        const fullPath = path.join(process.cwd(), filename);
+
+        // Write the character file
+        await fs.writeFile(fullPath, JSON.stringify(agentTemplate, null, 2), 'utf8');
+
+        console.log(`Agent character created successfully: ${filename}`);
+        console.info(
+          `\nYou can now use this agent with:\n  elizaos agent start --path ${filename}`
+        );
         return;
       } else {
         // Create directory if it doesn't exist

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -187,7 +187,7 @@ export const create = new Command()
           });
 
           if (!type) {
-            process.exit(0);
+            return;
           }
           projectType = type;
         }
@@ -247,7 +247,7 @@ export const create = new Command()
           });
 
           if (!nameResponse) {
-            process.exit(0);
+            return;
           }
           projectName = nameResponse;
         }
@@ -307,7 +307,8 @@ export const create = new Command()
           console.error(
             'Please choose a different name or manually remove the directory contents first.'
           );
-          process.exit(1);
+          handleError(new Error(`Directory "${projectName}" is not empty`));
+          return;
         } else {
           // Directory exists but is empty - this is fine
           console.info(
@@ -418,7 +419,8 @@ export const create = new Command()
 
         if (!database) {
           console.error('No database selected or provided');
-          process.exit(1);
+          handleError(new Error('No database selected or provided'));
+          return;
         }
 
         await copyTemplateUtil('project', targetDir, projectName);
@@ -459,7 +461,6 @@ export const create = new Command()
           `\nYour project is ready! Here\'s what you can do next:\n1. \`cd ${cdPath}\` to change into your project directory\n2. Run \`elizaos start\` to start your project\n3. Visit \`http://localhost:3000\` (or your custom port) to view your project in the browser`
         );
         process.stdout.write(`\u001B]1337;CurrentDir=${targetDir}\u0007`);
-        process.exit(0);
       }
     } catch (error) {
       handleError(error);


### PR DESCRIPTION
This PR is a focused attempt to improve the elizaos agent cli command. The changes are:


**elizaos agent get** 
-j/--json wasnt working (it was saving the file instead of of displaying in console json format)
-o/--output wasnt working (it was showing the formatted char file instead of saving the json to a given option path)

**elizaos agent start** 
- removed debugging code, added a helper message for common pitfalls

then we also introduced a new create command, elizaos create -t agent <name>, so users can do something like:

elizaos create -t project test
cd test
elizaos start/dev
elizaos create -t agent test-agent
elizaos agent start -n test-agent

previously the only way to "add" an agent if none existed was to do something like this:

elizaos create -t project test
cd test
elizaos start/dev
**default eliza agent is created**
elizaos agent set -n Eliza -f new-agent

and then configure the new-agent locally. this is kinda unintuitive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for creating new agents directly from the CLI, generating a character JSON file based on a customizable template.
  - Enhanced the agent retrieval command to allow saving agent configurations as JSON files, excluding metadata.

- **Improvements**
  - Improved error handling and user feedback for agent-related commands, providing clearer messages and help prompts.
  - Refined input validation for starting agents, ensuring users provide valid options and receive guidance if inputs are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->