### PR TITLE
fix: add commit sha to CLI cache action

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .turbo
-          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          key: ${{ runner.os }}-turbo-${{ github.event.pull_request.head.sha || github.sha }}
           restore-keys: |
             ${{ runner.os }}-turbo-
 


### PR DESCRIPTION
Attempt to fix PRs in CLI tests randomly failing but passing on local and for pushes.

Adds SHA hash from github commit to bust cache better.