### PR TITLE
docs: Fix outdated link in changelog.md

### DIFF
--- a/docs/notes/changelog.md
+++ b/docs/notes/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 ## v0.25.8 (February 24, 2025)
 
-#### Major changes since [v0.25.6-alpha.1]()
+#### Major changes since v0.25.6-alpha.1
 
 #### Features
 

--- a/docs/notes/changelog.md
+++ b/docs/notes/changelog.md
@@ -1,7 +1,7 @@
 # Changelog
 ## v0.25.8 (February 24, 2025)
 
-#### Major changes since [v0.25.6-alpha.1](https://github.com/elizaOS/eliza/releases/tag/v0.25.6-alpha.1)
+#### Major changes since [v0.25.6-alpha.1]()
 
 #### Features
 


### PR DESCRIPTION
The old link led to a 404 error (page not found).
To avoid confusion and broken navigation for readers, the link has been temporarily cleared.


