### PR TITLE
fix: LLM response parsing to support custom fields and clean up empty message headers

### DIFF
--- a/packages/plugin-bootstrap/src/index.ts
+++ b/packages/plugin-bootstrap/src/index.ts
@@ -303,6 +303,7 @@ const messageReceivedHandler = async ({
           // Map parsed XML to Content type, handling potential missing fields
           if (parsedXml) {
             responseContent = {
+              ...parsedXml,
               thought: parsedXml.thought || '',
               actions: parsedXml.actions || ['IGNORE'],
               providers: parsedXml.providers || [],

--- a/packages/plugin-bootstrap/src/providers/recentMessages.ts
+++ b/packages/plugin-bootstrap/src/providers/recentMessages.ts
@@ -141,15 +141,18 @@ export const recentMessagesProvider: Provider = {
       const senderName = metaData?.entityName || 'unknown';
       const receivedMessageContent = message.content.text;
 
-      const receivedMessageHeader = addHeader(
-        '# Received Message',
-        `${senderName}: ${receivedMessageContent}`
-      );
+      const hasReceivedMessage = !!receivedMessageContent?.trim();
 
-      const focusHeader = addHeader(
-        '# ⚡ Focus your response',
-        `You are replying to the above message from **${senderName}**. Keep your answer relevant to that message. Do not repeat earlier replies unless the sender asks again.`
-      );
+      const receivedMessageHeader = hasReceivedMessage
+        ? addHeader('# Received Message', `${senderName}: ${receivedMessageContent}`)
+        : '';
+
+      const focusHeader = hasReceivedMessage
+        ? addHeader(
+            '# Focus your response',
+            `You are replying to the above message from **${senderName}**. Keep your answer relevant to that message. Do not repeat earlier replies unless the sender asks again.`
+          )
+        : '';
 
       // Preload all necessary entities for both types of interactions
       const interactionEntityMap = new Map<UUID, Entity>();


### PR DESCRIPTION
This PR addresses two issues:

1. **Bootstrap plugin response parsing**  
   Previously, the LLM response was reduced to a fixed set of keys, which discarded useful custom fields like `emote` returned by custom templates. This change spreads all fields from `parsedXml` to preserve any additional values while maintaining defaults for core keys.

2. **recentMessagesProvider header handling**  
   The `Received Message` and `Focus your response` headers were shown even when there was no actual user message. This update checks that the message content exists before including those headers, resulting in cleaner prompt formatting.