### PR TITLE
fix: Guarantee onComplete is always called in messageReceivedHandler

### DIFF
--- a/packages/plugin-bootstrap/src/index.ts
+++ b/packages/plugin-bootstrap/src/index.ts
@@ -982,6 +982,7 @@ const events = {
         runtime: payload.runtime,
         message: payload.message,
         callback: payload.callback,
+        onComplete: payload.onComplete,
       });
     },
   ],

--- a/packages/plugin-bootstrap/src/index.ts
+++ b/packages/plugin-bootstrap/src/index.ts
@@ -144,320 +144,324 @@ const messageReceivedHandler = async ({
   callback,
   onComplete,
 }: MessageReceivedHandlerParams): Promise<void> => {
-  logger.info(`[Bootstrap] Message received from ${message.entityId} in room ${message.roomId}`);
-  // Generate a new response ID
-  const responseId = v4();
-  // Get or create the agent-specific map
-  if (!latestResponseIds.has(runtime.agentId)) {
-    latestResponseIds.set(runtime.agentId, new Map<string, string>());
-  }
-  const agentResponses = latestResponseIds.get(runtime.agentId);
-  if (!agentResponses) {
-    throw new Error('Agent responses map not found');
-  }
-
-  // Set this as the latest response ID for this agent+room
-  agentResponses.set(message.roomId, responseId);
-
-  // Generate a unique run ID for tracking this message handler execution
-  const runId = asUUID(v4());
-  const startTime = Date.now();
-
-  // Emit run started event
-  await runtime.emitEvent(EventType.RUN_STARTED, {
-    runtime,
-    runId,
-    messageId: message.id,
-    roomId: message.roomId,
-    entityId: message.entityId,
-    startTime,
-    status: 'started',
-    source: 'messageHandler',
-  });
-
   // Set up timeout monitoring
   const timeoutDuration = 60 * 60 * 1000; // 1 hour
   let timeoutId: NodeJS.Timeout | undefined = undefined;
+  try {
+    logger.info(`[Bootstrap] Message received from ${message.entityId} in room ${message.roomId}`);
+    // Generate a new response ID
+    const responseId = v4();
+    // Get or create the agent-specific map
+    if (!latestResponseIds.has(runtime.agentId)) {
+      latestResponseIds.set(runtime.agentId, new Map<string, string>());
+    }
+    const agentResponses = latestResponseIds.get(runtime.agentId);
+    if (!agentResponses) {
+      throw new Error('Agent responses map not found');
+    }
 
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    timeoutId = setTimeout(async () => {
-      await runtime.emitEvent(EventType.RUN_TIMEOUT, {
-        runtime,
-        runId,
-        messageId: message.id,
-        roomId: message.roomId,
-        entityId: message.entityId,
-        startTime,
-        status: 'timeout',
-        endTime: Date.now(),
-        duration: Date.now() - startTime,
-        error: 'Run exceeded 60 minute timeout',
-        source: 'messageHandler',
-      });
-      reject(new Error('Run exceeded 60 minute timeout'));
-    }, timeoutDuration);
-  });
+    // Set this as the latest response ID for this agent+room
+    agentResponses.set(message.roomId, responseId);
 
-  const processingPromise = (async () => {
-    try {
-      if (message.entityId === runtime.agentId) {
-        logger.debug(`[Bootstrap] Skipping message from self (${runtime.agentId})`);
-        throw new Error('Message is from the agent itself');
-      }
+    // Generate a unique run ID for tracking this message handler execution
+    const runId = asUUID(v4());
+    const startTime = Date.now();
 
-      logger.debug(
-        `[Bootstrap] Processing message: ${truncateToCompleteSentence(message.content.text || '', 50)}...`
-      );
+    // Emit run started event
+    await runtime.emitEvent(EventType.RUN_STARTED, {
+      runtime,
+      runId,
+      messageId: message.id,
+      roomId: message.roomId,
+      entityId: message.entityId,
+      startTime,
+      status: 'started',
+      source: 'messageHandler',
+    });
 
-      // First, save the incoming message
-      logger.debug('[Bootstrap] Saving message to memory and embeddings');
-      await Promise.all([
-        runtime.addEmbeddingToMemory(message),
-        runtime.createMemory(message, 'messages'),
-      ]);
-
-      const agentUserState = await runtime.getParticipantUserState(message.roomId, runtime.agentId);
-
-      if (
-        agentUserState === 'MUTED' &&
-        !message.content.text?.toLowerCase().includes(runtime.character.name.toLowerCase())
-      ) {
-        logger.debug(`[Bootstrap] Ignoring muted room ${message.roomId}`);
-        return;
-      }
-
-      let state = await runtime.composeState(message, [
-        'ANXIETY',
-        'SHOULD_RESPOND',
-        'ENTITIES',
-        'CHARACTER',
-        'RECENT_MESSAGES',
-      ]);
-
-      // Skip shouldRespond check for DM and VOICE_DM channels
-      const room = await runtime.getRoom(message.roomId);
-      const shouldSkipShouldRespond =
-        room?.type === ChannelType.DM ||
-        room?.type === ChannelType.VOICE_DM ||
-        room?.type === ChannelType.SELF ||
-        room?.type === ChannelType.API;
-
-      let shouldRespond = true;
-
-      // Handle shouldRespond
-      if (!shouldSkipShouldRespond) {
-        const shouldRespondPrompt = composePromptFromState({
-          state,
-          template: runtime.character.templates?.shouldRespondTemplate || shouldRespondTemplate,
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(async () => {
+        await runtime.emitEvent(EventType.RUN_TIMEOUT, {
+          runtime,
+          runId,
+          messageId: message.id,
+          roomId: message.roomId,
+          entityId: message.entityId,
+          startTime,
+          status: 'timeout',
+          endTime: Date.now(),
+          duration: Date.now() - startTime,
+          error: 'Run exceeded 60 minute timeout',
+          source: 'messageHandler',
         });
+        reject(new Error('Run exceeded 60 minute timeout'));
+      }, timeoutDuration);
+    });
 
-        logger.debug(
-          `[Bootstrap] Evaluating response for ${runtime.character.name}\nPrompt: ${shouldRespondPrompt}`
-        );
-
-        const response = await runtime.useModel(ModelType.TEXT_SMALL, {
-          prompt: shouldRespondPrompt,
-        });
-
-        logger.debug(`[Bootstrap] Response evaluation for ${runtime.character.name}:\n${response}`);
-        logger.debug(`[Bootstrap] Response type: ${typeof response}`);
-
-        // Try to preprocess response by removing code blocks markers if present
-        // let processedResponse = response.replace('```json', '').replaceAll('```', '').trim(); // No longer needed for XML
-
-        const responseObject = parseKeyValueXml(response);
-        logger.debug('[Bootstrap] Parsed response:', responseObject);
-
-        shouldRespond = responseObject?.action && responseObject.action === 'RESPOND';
-      } else {
-        shouldRespond = true;
-      }
-
-      let responseMessages: Memory[] = [];
-
-      if (shouldRespond) {
-        state = await runtime.composeState(message);
-
-        const prompt = composePromptFromState({
-          state,
-          template: runtime.character.templates?.messageHandlerTemplate || messageHandlerTemplate,
-        });
-
-        let responseContent: Content | null = null;
-
-        // Retry if missing required fields
-        let retries = 0;
-        const maxRetries = 3;
-
-        while (retries < maxRetries && (!responseContent?.thought || !responseContent?.actions)) {
-          let response = await runtime.useModel(ModelType.TEXT_LARGE, {
-            prompt,
-          });
-
-          logger.debug('[Bootstrap] *** Raw LLM Response ***\n', response);
-
-          // Attempt to parse the XML response
-          const parsedXml = parseKeyValueXml(response);
-          logger.debug('[Bootstrap] *** Parsed XML Content ***\n', parsedXml);
-
-          // Map parsed XML to Content type, handling potential missing fields
-          if (parsedXml) {
-            responseContent = {
-              ...parsedXml,
-              thought: parsedXml.thought || '',
-              actions: parsedXml.actions || ['IGNORE'],
-              providers: parsedXml.providers || [],
-              text: parsedXml.text || '',
-              simple: parsedXml.simple || false,
-            };
-          } else {
-            responseContent = null;
-          }
-
-          retries++;
-          if (!responseContent?.thought || !responseContent?.actions) {
-            logger.warn(
-              '[Bootstrap] *** Missing required fields (thought or actions), retrying... ***'
-            );
-          }
+    const processingPromise = (async () => {
+      try {
+        if (message.entityId === runtime.agentId) {
+          logger.debug(`[Bootstrap] Skipping message from self (${runtime.agentId})`);
+          throw new Error('Message is from the agent itself');
         }
 
-        // Check if this is still the latest response ID for this agent+room
-        const currentResponseId = agentResponses.get(message.roomId);
-        if (currentResponseId !== responseId) {
-          logger.info(
-            `Response discarded - newer message being processed for agent: ${runtime.agentId}, room: ${message.roomId}`
-          );
+        logger.debug(
+          `[Bootstrap] Processing message: ${truncateToCompleteSentence(message.content.text || '', 50)}...`
+        );
+
+        // First, save the incoming message
+        logger.debug('[Bootstrap] Saving message to memory and embeddings');
+        await Promise.all([
+          runtime.addEmbeddingToMemory(message),
+          runtime.createMemory(message, 'messages'),
+        ]);
+
+        const agentUserState = await runtime.getParticipantUserState(
+          message.roomId,
+          runtime.agentId
+        );
+
+        if (
+          agentUserState === 'MUTED' &&
+          !message.content.text?.toLowerCase().includes(runtime.character.name.toLowerCase())
+        ) {
+          logger.debug(`[Bootstrap] Ignoring muted room ${message.roomId}`);
           return;
         }
 
-        if (responseContent && message.id) {
-          responseContent.inReplyTo = createUniqueUuid(runtime, message.id);
+        let state = await runtime.composeState(message, [
+          'ANXIETY',
+          'SHOULD_RESPOND',
+          'ENTITIES',
+          'CHARACTER',
+          'RECENT_MESSAGES',
+        ]);
 
-          const responseMesssage = {
+        // Skip shouldRespond check for DM and VOICE_DM channels
+        const room = await runtime.getRoom(message.roomId);
+        const shouldSkipShouldRespond =
+          room?.type === ChannelType.DM ||
+          room?.type === ChannelType.VOICE_DM ||
+          room?.type === ChannelType.SELF ||
+          room?.type === ChannelType.API;
+
+        let shouldRespond = true;
+
+        // Handle shouldRespond
+        if (!shouldSkipShouldRespond) {
+          const shouldRespondPrompt = composePromptFromState({
+            state,
+            template: runtime.character.templates?.shouldRespondTemplate || shouldRespondTemplate,
+          });
+
+          logger.debug(
+            `[Bootstrap] Evaluating response for ${runtime.character.name}\nPrompt: ${shouldRespondPrompt}`
+          );
+
+          const response = await runtime.useModel(ModelType.TEXT_SMALL, {
+            prompt: shouldRespondPrompt,
+          });
+
+          logger.debug(
+            `[Bootstrap] Response evaluation for ${runtime.character.name}:\n${response}`
+          );
+          logger.debug(`[Bootstrap] Response type: ${typeof response}`);
+
+          // Try to preprocess response by removing code blocks markers if present
+          // let processedResponse = response.replace('```json', '').replaceAll('```', '').trim(); // No longer needed for XML
+
+          const responseObject = parseKeyValueXml(response);
+          logger.debug('[Bootstrap] Parsed response:', responseObject);
+
+          shouldRespond = responseObject?.action && responseObject.action === 'RESPOND';
+        } else {
+          shouldRespond = true;
+        }
+
+        let responseMessages: Memory[] = [];
+
+        if (shouldRespond) {
+          state = await runtime.composeState(message);
+
+          const prompt = composePromptFromState({
+            state,
+            template: runtime.character.templates?.messageHandlerTemplate || messageHandlerTemplate,
+          });
+
+          let responseContent: Content | null = null;
+
+          // Retry if missing required fields
+          let retries = 0;
+          const maxRetries = 3;
+
+          while (retries < maxRetries && (!responseContent?.thought || !responseContent?.actions)) {
+            let response = await runtime.useModel(ModelType.TEXT_LARGE, {
+              prompt,
+            });
+
+            logger.debug('[Bootstrap] *** Raw LLM Response ***\n', response);
+
+            // Attempt to parse the XML response
+            const parsedXml = parseKeyValueXml(response);
+            logger.debug('[Bootstrap] *** Parsed XML Content ***\n', parsedXml);
+
+            // Map parsed XML to Content type, handling potential missing fields
+            if (parsedXml) {
+              responseContent = {
+                ...parsedXml,
+                thought: parsedXml.thought || '',
+                actions: parsedXml.actions || ['IGNORE'],
+                providers: parsedXml.providers || [],
+                text: parsedXml.text || '',
+                simple: parsedXml.simple || false,
+              };
+            } else {
+              responseContent = null;
+            }
+
+            retries++;
+            if (!responseContent?.thought || !responseContent?.actions) {
+              logger.warn(
+                '[Bootstrap] *** Missing required fields (thought or actions), retrying... ***'
+              );
+            }
+          }
+
+          // Check if this is still the latest response ID for this agent+room
+          const currentResponseId = agentResponses.get(message.roomId);
+          if (currentResponseId !== responseId) {
+            logger.info(
+              `Response discarded - newer message being processed for agent: ${runtime.agentId}, room: ${message.roomId}`
+            );
+            return;
+          }
+
+          if (responseContent && message.id) {
+            responseContent.inReplyTo = createUniqueUuid(runtime, message.id);
+
+            const responseMesssage = {
+              id: asUUID(v4()),
+              entityId: runtime.agentId,
+              agentId: runtime.agentId,
+              content: responseContent,
+              roomId: message.roomId,
+              createdAt: Date.now(),
+            };
+
+            responseMessages = [responseMesssage];
+          }
+
+          // Clean up the response ID
+          agentResponses.delete(message.roomId);
+          if (agentResponses.size === 0) {
+            latestResponseIds.delete(runtime.agentId);
+          }
+
+          if (responseContent?.providers?.length && responseContent?.providers?.length > 0) {
+            state = await runtime.composeState(message, responseContent?.providers || []);
+          }
+
+          if (
+            responseContent &&
+            responseContent.simple &&
+            responseContent.text &&
+            (responseContent.actions?.length === 0 ||
+              (responseContent.actions?.length === 1 &&
+                responseContent.actions[0].toUpperCase() === 'REPLY'))
+          ) {
+            await callback(responseContent);
+          } else {
+            await runtime.processActions(message, responseMessages, state, callback);
+          }
+          await runtime.evaluate(message, state, shouldRespond, callback, responseMessages);
+        } else {
+          // Handle the case where the agent decided not to respond
+          logger.debug('[Bootstrap] Agent decided not to respond (shouldRespond is false).');
+
+          // Check if we still have the latest response ID
+          const currentResponseId = agentResponses.get(message.roomId);
+          if (currentResponseId !== responseId) {
+            logger.info(
+              `Ignore response discarded - newer message being processed for agent: ${runtime.agentId}, room: ${message.roomId}`
+            );
+            return; // Stop processing if a newer message took over
+          }
+
+          if (!message.id) {
+            logger.error('[Bootstrap] Message ID is missing, cannot create ignore response.');
+            return;
+          }
+
+          // Construct a minimal content object indicating ignore, include a generic thought
+          const ignoreContent: Content = {
+            thought: 'Agent decided not to respond to this message.',
+            actions: ['IGNORE'],
+            simple: true, // Treat it as simple for callback purposes
+            inReplyTo: createUniqueUuid(runtime, message.id), // Reference original message
+          };
+
+          // Call the callback directly with the ignore content
+          await callback(ignoreContent);
+
+          // Also save this ignore action/thought to memory
+          const ignoreMemory = {
             id: asUUID(v4()),
             entityId: runtime.agentId,
             agentId: runtime.agentId,
-            content: responseContent,
+            content: ignoreContent,
             roomId: message.roomId,
             createdAt: Date.now(),
           };
+          await runtime.createMemory(ignoreMemory, 'messages');
+          logger.debug('[Bootstrap] Saved ignore response to memory', {
+            memoryId: ignoreMemory.id,
+          });
 
-          responseMessages = [responseMesssage];
+          // Clean up the response ID since we handled it
+          agentResponses.delete(message.roomId);
+          if (agentResponses.size === 0) {
+            latestResponseIds.delete(runtime.agentId);
+          }
+
+          // Optionally, evaluate the decision to ignore (if relevant evaluators exist)
+          // await runtime.evaluate(message, state, shouldRespond, callback, []);
         }
 
-        // Clean up the response ID
-        agentResponses.delete(message.roomId);
-        if (agentResponses.size === 0) {
-          latestResponseIds.delete(runtime.agentId);
-        }
-
-        if (responseContent?.providers?.length && responseContent?.providers?.length > 0) {
-          state = await runtime.composeState(message, responseContent?.providers || []);
-        }
-
-        if (
-          responseContent &&
-          responseContent.simple &&
-          responseContent.text &&
-          (responseContent.actions?.length === 0 ||
-            (responseContent.actions?.length === 1 &&
-              responseContent.actions[0].toUpperCase() === 'REPLY'))
-        ) {
-          await callback(responseContent);
-        } else {
-          await runtime.processActions(message, responseMessages, state, callback);
-        }
-        await runtime.evaluate(message, state, shouldRespond, callback, responseMessages);
-      } else {
-        // Handle the case where the agent decided not to respond
-        logger.debug('[Bootstrap] Agent decided not to respond (shouldRespond is false).');
-
-        // Check if we still have the latest response ID
-        const currentResponseId = agentResponses.get(message.roomId);
-        if (currentResponseId !== responseId) {
-          logger.info(
-            `Ignore response discarded - newer message being processed for agent: ${runtime.agentId}, room: ${message.roomId}`
-          );
-          return; // Stop processing if a newer message took over
-        }
-
-        if (!message.id) {
-          logger.error('[Bootstrap] Message ID is missing, cannot create ignore response.');
-          return;
-        }
-
-        // Construct a minimal content object indicating ignore, include a generic thought
-        const ignoreContent: Content = {
-          thought: 'Agent decided not to respond to this message.',
-          actions: ['IGNORE'],
-          simple: true, // Treat it as simple for callback purposes
-          inReplyTo: createUniqueUuid(runtime, message.id), // Reference original message
-        };
-
-        // Call the callback directly with the ignore content
-        await callback(ignoreContent);
-
-        // Also save this ignore action/thought to memory
-        const ignoreMemory = {
-          id: asUUID(v4()),
-          entityId: runtime.agentId,
-          agentId: runtime.agentId,
-          content: ignoreContent,
+        // Emit run ended event on successful completion
+        await runtime.emitEvent(EventType.RUN_ENDED, {
+          runtime,
+          runId,
+          messageId: message.id,
           roomId: message.roomId,
-          createdAt: Date.now(),
-        };
-        await runtime.createMemory(ignoreMemory, 'messages');
-        logger.debug('[Bootstrap] Saved ignore response to memory', { memoryId: ignoreMemory.id });
-
-        // Clean up the response ID since we handled it
-        agentResponses.delete(message.roomId);
-        if (agentResponses.size === 0) {
-          latestResponseIds.delete(runtime.agentId);
-        }
-
-        // Optionally, evaluate the decision to ignore (if relevant evaluators exist)
-        // await runtime.evaluate(message, state, shouldRespond, callback, []);
+          entityId: message.entityId,
+          startTime,
+          status: 'completed',
+          endTime: Date.now(),
+          duration: Date.now() - startTime,
+          source: 'messageHandler',
+        });
+      } catch (error: any) {
+        // Emit run ended event with error
+        await runtime.emitEvent(EventType.RUN_ENDED, {
+          runtime,
+          runId,
+          messageId: message.id,
+          roomId: message.roomId,
+          entityId: message.entityId,
+          startTime,
+          status: 'error',
+          endTime: Date.now(),
+          duration: Date.now() - startTime,
+          error: error.message,
+          source: 'messageHandler',
+        });
       }
+    })();
 
-      onComplete?.();
-
-      // Emit run ended event on successful completion
-      await runtime.emitEvent(EventType.RUN_ENDED, {
-        runtime,
-        runId,
-        messageId: message.id,
-        roomId: message.roomId,
-        entityId: message.entityId,
-        startTime,
-        status: 'completed',
-        endTime: Date.now(),
-        duration: Date.now() - startTime,
-        source: 'messageHandler',
-      });
-    } catch (error: any) {
-      onComplete?.();
-      // Emit run ended event with error
-      await runtime.emitEvent(EventType.RUN_ENDED, {
-        runtime,
-        runId,
-        messageId: message.id,
-        roomId: message.roomId,
-        entityId: message.entityId,
-        startTime,
-        status: 'error',
-        endTime: Date.now(),
-        duration: Date.now() - startTime,
-        error: error.message,
-        source: 'messageHandler',
-      });
-    }
-  })();
-
-  try {
     await Promise.race([processingPromise, timeoutPromise]);
   } finally {
     clearTimeout(timeoutId);
+    onComplete?.();
   }
 };
 


### PR DESCRIPTION
This PR ensures the onComplete callback is always executed, regardless of whether the message handler completes successfully, throws an error, or times out.

Key changes:
- Wrapped the entire messageReceivedHandler logic in a try-finally block
- Moved onComplete into finally to guarantee execution
- Removed redundant onComplete calls from try/catch blocks inside processingPromise
- Ensured timeout cleanup with clearTimeout in the same finally block

This prevents orphaned states or incomplete lifecycles when early errors occur during setup or long-running processes hit timeouts.