### PR TITLE
fix: send-message-api

### DIFF
--- a/packages/cli/src/server/api/agent.ts
+++ b/packages/cli/src/server/api/agent.ts
@@ -16,7 +16,6 @@ import {
   MemoryType,
   ModelType,
   composePrompt,
-  composePromptFromState,
   createUniqueUuid,
   encryptObjectValues,
   encryptStringValue,
@@ -111,6 +110,119 @@ export function agentRouter(
 ): express.Router {
   const router = express.Router();
   const db = server?.database;
+
+  // Message handler
+  const handleAgentMessage = async (req: CustomRequest, res: express.Response) => {
+    logger.debug('[MESSAGES CREATE] Creating new message');
+    const agentId = validateUuid(req.params.agentId);
+    if (!agentId) {
+      sendError(res, 400, 'INVALID_ID', 'Invalid agent ID format');
+      return;
+    }
+
+    // get runtime
+    const runtime = agents.get(agentId);
+    if (!runtime) {
+      sendError(res, 404, 'NOT_FOUND', 'Agent not found');
+      return;
+    }
+
+    const entityId = req.body.entityId as UUID;
+    const roomId = req.body.roomId as UUID;
+
+    const source = req.body.source;
+    const text = req.body.text.trim();
+
+    const channelType = req.body.channelType;
+    const incomingMessageVirtualId = createUniqueUuid(
+      runtime,
+      `${roomId}-${entityId}-${Date.now()}`
+    );
+
+    try {
+      await runtime.ensureConnection({
+        entityId,
+        roomId,
+        userName: req.body.userName,
+        name: req.body.name,
+        source: 'api-message',
+        type: ChannelType.API,
+        worldId: createUniqueUuid(runtime, 'api-message'),
+        worldName: 'api-message',
+      });
+
+      const content: Content = {
+        text,
+        attachments: [],
+        source,
+        inReplyTo: undefined, // Handled by response memory if needed
+        channelType: channelType || ChannelType.API,
+      };
+
+      const userMessageMemory: Memory = {
+        id: incomingMessageVirtualId, // Use a consistent ID for the incoming message
+        entityId,
+        roomId,
+        agentId: runtime.agentId, // The agent this message is directed to
+        content,
+        createdAt: Date.now(),
+      };
+
+      // Define the callback for sending the HTTP response
+      const apiCallback: HandlerCallback = async (responseContent: Content) => {
+        let sentMemory: Memory | null = null;
+        if (!res.headersSent) {
+          res.status(201).json({
+            success: true,
+            data: {
+              message: responseContent,
+              messageId: userMessageMemory.id,
+              name: runtime.character.name,
+              roomId: req.body.roomId,
+              source,
+            },
+          });
+
+          // Construct Memory for the agent's HTTP response
+          sentMemory = {
+            id: createUniqueUuid(runtime, `api-response-${userMessageMemory.id}-${Date.now()}`),
+            entityId: runtime.agentId, // Agent is the sender
+            agentId: runtime.agentId,
+            content: {
+              ...responseContent,
+              text: responseContent.text || '',
+              inReplyTo: userMessageMemory.id,
+            },
+            roomId: roomId,
+            createdAt: Date.now(),
+          };
+
+          await runtime.createMemory(sentMemory, 'messages');
+        }
+        return sentMemory ? [sentMemory] : [];
+      };
+
+      // Emit event for message processing
+      await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
+        runtime,
+        message: userMessageMemory,
+        callback: apiCallback,
+        onComplete: () => {
+          if (!res.headersSent) {
+            logger.warn(
+              '[MESSAGES CREATE] API Callback was not called by a handler. Responding with 204 No Content.'
+            );
+            res.status(204).send(); // Send 204 No Content
+          }
+        },
+      });
+    } catch (error) {
+      logger.error('Error processing message:', error.message);
+      if (!res.headersSent) {
+        sendError(res, 500, 'PROCESSING_ERROR', 'Error processing message', error.message);
+      }
+    }
+  };
 
   // List all agents with minimal details
   router.get('/', async (_, res) => {
@@ -918,7 +1030,7 @@ export function agentRouter(
         };
 
         // Reuse the message endpoint logic
-        await this.post('/:agentId/message')(messageRequest, res);
+        await handleAgentMessage(messageRequest as CustomRequest, res);
       } catch (error) {
         logger.error('[AUDIO MESSAGE] Error processing audio:', error);
         res.status(500).json({
@@ -1391,136 +1503,7 @@ export function agentRouter(
     }
   });
 
-  router.post('/:agentId/message', async (req: CustomRequest, res) => {
-    logger.debug('[MESSAGES CREATE] Creating new message');
-    const agentId = validateUuid(req.params.agentId);
-    if (!agentId) {
-      res.status(400).json({
-        success: false,
-        error: {
-          code: 'INVALID_ID',
-          message: 'Invalid agent ID format',
-        },
-      });
-      return;
-    }
-
-    // get runtime
-    const runtime = agents.get(agentId);
-    if (!runtime) {
-      res.status(404).json({
-        success: false,
-        error: {
-          code: 'NOT_FOUND',
-          message: 'Agent not found',
-        },
-      });
-      return;
-    }
-
-    const entityId = req.body.entityId as UUID;
-    const roomId = req.body.roomId as UUID;
-
-    const source = req.body.source;
-    const text = req.body.text.trim();
-
-    const channelType = req.body.channelType;
-    const incomingMessageVirtualId = createUniqueUuid(
-      runtime,
-      `${roomId}-${entityId}-${Date.now()}`
-    );
-
-    try {
-      await runtime.ensureConnection({
-        entityId,
-        roomId,
-        userName: req.body.userName,
-        name: req.body.name,
-        source: 'api-message',
-        type: ChannelType.API,
-        worldId: createUniqueUuid(runtime, 'api-message'),
-        worldName: 'api-message',
-      });
-
-      const content: Content = {
-        text,
-        attachments: [],
-        source,
-        inReplyTo: undefined, // Handled by response memory if needed
-        channelType: channelType || ChannelType.API,
-      };
-
-      const userMessageMemory: Memory = {
-        id: incomingMessageVirtualId, // Use a consistent ID for the incoming message
-        entityId,
-        roomId,
-        agentId: runtime.agentId, // The agent this message is directed to
-        content,
-        createdAt: Date.now(),
-      };
-
-      // Define the callback for sending the HTTP response
-      const apiCallback: HandlerCallback = async (responseContent: Content) => {
-        let sentMemory: Memory | null = null;
-        if (!res.headersSent) {
-          res.status(201).json({
-            success: true,
-            data: {
-              message: responseContent,
-              messageId: userMessageMemory.id,
-              name: runtime.character.name,
-              roomId: req.body.roomId,
-              source,
-            },
-          });
-
-          // Construct Memory for the agent's HTTP response
-          sentMemory = {
-            id: createUniqueUuid(runtime, `api-response-${userMessageMemory.id}-${Date.now()}`),
-            entityId: runtime.agentId, // Agent is the sender
-            agentId: runtime.agentId,
-            content: {
-              ...responseContent,
-              text: responseContent.text || '',
-              inReplyTo: userMessageMemory.id,
-            },
-            roomId: roomId,
-            createdAt: Date.now(),
-          };
-
-          await runtime.createMemory(sentMemory, 'messages');
-        }
-        return sentMemory ? [sentMemory] : [];
-      };
-
-      // Emit event for message processing
-      await runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
-        runtime,
-        message: userMessageMemory,
-        callback: apiCallback,
-        onComplete: () => {
-          if (!res.headersSent) {
-            logger.warn(
-              '[MESSAGES CREATE] API Callback was not called by a handler. Responding with 204 No Content.'
-            );
-            res.status(204).send(); // Send 204 No Content
-          }
-        },
-      });
-    } catch (error) {
-      logger.error('Error processing message:', error.message);
-      if (!res.headersSent) {
-        res.status(500).json({
-          success: false,
-          error: {
-            code: 'PROCESSING_ERROR',
-            message: 'Error processing message',
-            details: error.message,
-          },
-        });
-      }
-    }
-  });
+  router.post('/:agentId/message', handleAgentMessage);
 
   // get all memories for an agent
   router.get('/:agentId/memories', async (req, res) => {

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -1056,7 +1056,7 @@ export class BM25 {
   termToIndex: Map<string, number>;
   /** Array storing the document frequency (number of docs containing the term) for each term index. */
   documentFrequency: Uint32Array; // DF for each term index
-  /** Map from term index to another map storing { docIndex: termFrequencyInDoc }. */
+  /** Map from term index to another map storing */
   termFrequencies: Map<number, Map<number, number>>; // TermIndex -> { DocIndex -> TF }
   /** Boost factors for different fields within documents. */
   readonly fieldBoosts: { [key: string]: number };

--- a/packages/docs/docs/rest/send-message.api.mdx
+++ b/packages/docs/docs/rest/send-message.api.mdx
@@ -57,11 +57,21 @@ Sends a message to an agent and receives a response
         schema: {
           type: 'object',
           properties: {
-            senderId: { type: 'string', description: 'ID of the sender' },
-            roomId: { type: 'string', description: 'ID of the room' },
+            entityId: {
+              type: 'string',
+              format: 'uuid',
+              description: 'ID of the entity sending the message',
+            },
+            roomId: { type: 'string', format: 'uuid', description: 'ID of the room' },
+            source: { type: 'string', description: 'Source of the message (e.g., curl-test)' },
             text: { type: 'string', description: 'Message text' },
-            source: { type: 'string', description: 'Source of the message' },
+            channelType: {
+              type: 'string',
+              enum: ['API', 'VOICE', 'DM', 'GROUP', 'FEED', 'SELF', 'SYSTEM'],
+              description: 'Type of the channel',
+            },
           },
+          required: ['entityId', 'roomId', 'text', 'channelType'],
         },
       },
     },
@@ -86,33 +96,44 @@ Sends a message to an agent and receives a response
                   message: {
                     type: 'object',
                     properties: {
-                      text: { type: 'string', description: 'Text content of the message' },
-                      thought: { type: 'string', description: "Agent's internal thought process" },
-                      plan: { type: 'string', description: "Agent's plan or reasoning" },
+                      text: { type: 'string', description: "Text content of the agent's response" },
+                      thought: {
+                        type: 'string',
+                        description: "Agent's internal thought process for the response",
+                      },
                       actions: {
                         type: 'array',
                         items: { type: 'string' },
-                        description: 'Actions the agent wants to take',
-                      },
-                      source: { type: 'string', description: 'Source of the message' },
-                      inReplyTo: {
-                        type: 'string',
-                        format: 'uuid',
-                        description: 'ID of the message this is in reply to',
+                        description: 'Actions the agent decided on (e.g., [\"REPLY\"])',
                       },
                     },
-                    title: 'Content',
+                    title: 'AgentResponseContent',
                   },
-                  messageId: { type: 'string', format: 'uuid' },
-                  name: { type: 'string' },
-                  roomId: { type: 'string' },
-                  source: { type: 'string' },
+                  messageId: {
+                    type: 'string',
+                    format: 'uuid',
+                    description: "ID of the user's incoming message that was processed",
+                  },
+                  name: { type: 'string', description: 'Name of the agent that responded' },
+                  roomId: {
+                    type: 'string',
+                    format: 'uuid',
+                    description: 'ID of the room where the interaction occurred',
+                  },
+                  source: {
+                    type: 'string',
+                    description: "Original source from the user's request",
+                  },
                 },
               },
             },
           },
         },
       },
+    },
+    '204': {
+      description:
+        'Message processed successfully, but the agent chose not to reply or no textual reply was generated. This can happen if the agent decides to IGNORE or perform a non-reply action.',
     },
     '400': {
       description: 'Invalid agent ID or request body',


### PR DESCRIPTION
# Release Notes

## New Features
- Enhanced message processing with an event-driven, asynchronous flow for agent message handling
- Added support for new response scenarios where the agent may choose not to reply

## Bug Fixes
- Corrected the audio message endpoint route for consistency

## Documentation
- Updated API documentation to clarify request and response schemas, including new required fields and response codes
- Improved descriptions and examples for API responses

## Testing
Use Postman or curl for testing:

```bash
curl -X POST \
  -H "Content-Type: application/json" \
  -d '{
    "entityId": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
    "roomId": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
    "source": "curl-test",
    "text": "How does rag knowledge works in elizaos",
    "channelType": "API"
  }' \
  http://localhost:3000/api/agents/1ee9e4ad-f1a9-0946-8498-edce550b222c/message
```