### PR TITLE
fix: add missing topics as X post templates expects topics

### DIFF
--- a/packages/the-org/src/communityManager/index.ts
+++ b/packages/the-org/src/communityManager/index.ts
@@ -32,9 +32,7 @@ export const character: Character = {
     '@elizaos/plugin-sql',
     ...(process.env.ANTHROPIC_API_KEY ? ['@elizaos/plugin-anthropic'] : []),
     ...(process.env.OPENAI_API_KEY ? ['@elizaos/plugin-openai'] : []),
-    ...(!process.env.OPENAI_API_KEY
-      ? ['@elizaos/plugin-local-ai']
-      : []),
+    ...(!process.env.OPENAI_API_KEY ? ['@elizaos/plugin-local-ai'] : []),
     '@elizaos/plugin-discord',
     '@elizaos/plugin-twitter',
     '@elizaos/plugin-pdf',
@@ -59,6 +57,14 @@ export const character: Character = {
     'Uses silence effectively and speaks only when necessary.',
     'Asks for help when needed and offers help when asked.',
     'Offers commentary only when appropriate or requested.',
+  ],
+  topics: [
+    'online community management',
+    'engaging online communities',
+    'social media community outreach',
+    'community platform best practices',
+    'developing fair community guidelines',
+    'effective community moderation',
   ],
   messageExamples: [
     [

--- a/packages/the-org/src/socialMediaManager/index.ts
+++ b/packages/the-org/src/socialMediaManager/index.ts
@@ -35,6 +35,7 @@ dotenv.config({ path: '../../.env' });
  * @property {Object[]} messageExamples - Examples of interactions with other individuals for messaging guidance.
  * @property {string[]} postExamples - Examples of post messages that the character would use.
  * @property {Object} style - Object containing guidelines for communication style in different scenarios.
+ * @property {string[]} topics - List of topics related to the character's expertise.
  */
 const character: Character = {
   name: 'Laura',
@@ -72,6 +73,15 @@ const character: Character = {
     "Doesn't offer commentary unless asked",
     "Doesn't help unless asked",
     "Only asks for help when it's absolutely needed",
+  ],
+  topics: [
+    'impactful messaging',
+    'crypto project marketing',
+    'open community communication',
+    'substance over hype in tech',
+    'modern marketing trends',
+    'narrative building for tech',
+    'anti-hype marketing',
   ],
   messageExamples: [
     [


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug fix**
  - Added a list of relevant topics to the community manager and social media manager profiles as twitter post template is expecting topics 
  - openai and gemini models end up being confused and don't respond with XML which causes error
  
<img width="1134" alt="image" src="https://github.com/user-attachments/assets/2cfe2a22-0029-421b-92ee-fee525b7c8c3" />

<!-- end of auto-generated comment: release notes by coderabbit.ai -->