### PR TITLE
docs: fix broken link to ELIZA demo (ai16z → elizaos)

### DIFF
--- a/i18n/readme/README_PTBR.md
+++ b/i18n/readme/README_PTBR.md
@@ -44,7 +44,7 @@ cp .env.example .env
 pnpm i && pnpm build && pnpm start
 ```
 
-Leia a [Documentação](https://ai16z.github.io/eliza/) para aprender como customizar a sua Eliza.
+Leia a [Documentação](https://elizaos.github.io/eliza/) para aprender como customizar a sua Eliza.
 
 ### Executando Eliza manualmente (Recomendado apenas se você souber o que está fazendo)
 


### PR DESCRIPTION
Hey team—noticed a dead link, replaced it with a working URL. Thanks!

https://ai16z.github.io/eliza/ -- old link
https://elizaos.github.io/eliza/ -- new link