### PR TITLE
fix: reply action to skip LLM call if existing REPLY response is found

### DIFF
--- a/packages/plugin-bootstrap/src/actions/reply.ts
+++ b/packages/plugin-bootstrap/src/actions/reply.ts
@@ -1,3 +1,4 @@
+import { Content } from '@elizaos/core';
 import {
   type Action,
   type ActionExample,
@@ -35,6 +36,29 @@ Response format should be formatted in a valid JSON block like this:
 
 Your response should include the valid JSON block and nothing else.`;
 
+function getFirstAvailableField(obj: Record<string, any>, fields: string[]): string | null {
+  for (const field of fields) {
+    if (typeof obj[field] === 'string' && obj[field].trim() !== '') {
+      return obj[field];
+    }
+  }
+  return null;
+}
+
+function extractReplyContent(response: Memory, replyFieldKeys: string[]): Content | null {
+  const hasReplyAction = response.content.actions?.includes('REPLY');
+  const text = getFirstAvailableField(response.content, replyFieldKeys);
+
+  if (!hasReplyAction || !text) return null;
+
+  return {
+    ...response.content,
+    thought: response.content.thought,
+    text,
+    actions: ['REPLY'],
+  };
+}
+
 /**
  * Represents an action that allows the agent to reply to the current conversation with a generated message.
  *
@@ -64,20 +88,16 @@ export const replyAction = {
     callback: HandlerCallback,
     responses?: Memory[]
   ) => {
-    // Find all responses with REPLY action and text
-    const existingResponses = responses?.filter(
-      (response) => response.content.actions?.includes('REPLY') && response.content.message
-    );
+    const replyFieldKeys = ['message', 'text'];
 
-    // If we found any existing responses, use them and skip LLM
-    if (existingResponses && existingResponses.length > 0) {
-      for (const response of existingResponses) {
-        const responseContent = {
-          thought: response.content.thought || 'Using provided text for reply',
-          text: response.content.message as string,
-          actions: ['REPLY'],
-        };
-        await callback(responseContent);
+    const existingReplies =
+      responses
+        ?.map((r) => extractReplyContent(r, replyFieldKeys))
+        .filter((reply): reply is Content => reply !== null) ?? [];
+
+    if (existingReplies.length > 0) {
+      for (const reply of existingReplies) {
+        await callback(reply);
       }
       return;
     }


### PR DESCRIPTION
Previously, the REPLY action was designed to skip the LLM call if an existing response with a REPLY action was found. However, recent changes to the message handler's template prompt caused the LLM to return the response with the `text` field instead of `message`.

This PR makes the reply field configurable (e.g., ['message', 'text']) to support both field formats. With this fix, we can correctly detect LLM responses even if the field name changes, and avoid unnecessary duplicate LLM calls in `messageReceivedHandler`.

