### PR TITLE
Eliza290/cli command env

### DIFF
--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -989,7 +989,7 @@ async function showMainMenu(yes = false): Promise<void> {
         exit = !returnToMainFromLocal;
         break;
       }
-      case 'set_path':
+      case 'set_path': {
         // Prompt for a path and use the existing setEnvPath function
         const { path: customPath } = await prompts({
           type: 'text',
@@ -1001,6 +1001,7 @@ async function showMainMenu(yes = false): Promise<void> {
           await setEnvPath(customPath, yes);
         }
         break;
+      }
       case 'reset':
         await resetEnv();
         break;

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -207,14 +207,33 @@ async function listEnvVars(): Promise<void> {
     }
   }
 
-  if (localEnvPath) {
-    console.info(colors.bold('\nLocal Environment Variables:'));
-    console.info(`Path: ${localEnvPath}`);
+  // Always display local environment section regardless of whether a file exists
+  console.info(colors.bold('\nLocal Environment Variables:'));
+  const localEnvFilePath = path.join(process.cwd(), '.env');
+  console.info(`Path: ${localEnvFilePath}`);
 
-    if (!existsSync(localEnvPath)) {
+  if (!existsSync(localEnvFilePath)) {
+    // No local .env file exists, provide guidance to the user
+    console.info(colors.yellow('  No local .env file found'));
+
+    // Check if .env.example exists and suggest copying it as a starting point
+    const exampleEnvPath = path.join(process.cwd(), '.env.example');
+    if (existsSync(exampleEnvPath)) {
+      console.info(colors.red('  ✖ Missing .env file. Create one with:'));
+      console.info(`     ${colors.bold(colors.green('cp .env.example .env'))}`);
+    } else {
+      console.info(
+        colors.red(
+          '  ✖ Missing .env file. Create one in your project directory to set local environment variables.'
+        )
+      );
+    }
+  } else {
+    // .env file exists, parse and display its contents
+    const localEnvVars = await parseEnvFile(localEnvFilePath);
+    if (Object.keys(localEnvVars).length === 0) {
       console.info('  No local environment variables set');
     } else {
-      const localEnvVars = await parseEnvFile(localEnvPath);
       for (const [key, value] of Object.entries(localEnvVars)) {
         console.info(`  ${colors.green(key)}: ${maskedValue(value)}`);
       }

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -658,7 +658,7 @@ async function resetEnv(yes = false): Promise<void> {
         await safeDeleteDirectory(cacheDir, actions, 'Cache folder');
         break;
 
-      case 'globalDb':
+      case 'globalDb': {
         if (usingExternalPostgres) {
           actions.warning.push(
             'External PostgreSQL database detected. Database data cannot be reset but local database cache files will be removed.'
@@ -688,6 +688,7 @@ async function resetEnv(yes = false): Promise<void> {
           actions.skipped.push('Global database files (not found)');
         }
         break;
+      }
 
       case 'localDb':
         await safeDeleteDirectory(localDbDir, actions, 'Local database folder');

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -729,7 +729,8 @@ async function resetEnv(yes = false): Promise<void> {
 async function setEnvPath(customPath: string, autoConfirm = false): Promise<void> {
   // Expand tilde (~) in the path if present
   if (customPath.startsWith('~')) {
-    customPath = path.join(os.homedir(), customPath.substring(1));
+    // Use string concatenation instead of path.join to preserve slashes
+    customPath = os.homedir() + customPath.substring(1);
   }
 
   // Validate the path

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -582,11 +582,22 @@ export const env = new Command()
 env
   .command('list')
   .description('List all environment variables')
+  .option('--system', 'List only system information')
   .option('--global', 'List only global environment variables')
   .option('--local', 'List only local environment variables')
-  .action(async (options: { global?: boolean; local?: boolean }) => {
+  .action(async (options: { global?: boolean; local?: boolean; system?: boolean }) => {
     try {
-      if (options.local) {
+      if (options.system) {
+        // Show only system information
+        const envInfo = await UserEnvironment.getInstanceInfo();
+        console.info(colors.bold('\nSystem Information:'));
+        console.info(`  Platform: ${colors.cyan(envInfo.os.platform)} (${envInfo.os.release})`);
+        console.info(`  Architecture: ${colors.cyan(envInfo.os.arch)}`);
+        console.info(`  CLI Version: ${colors.cyan(envInfo.cli.version)}`);
+        console.info(
+          `  Package Manager: ${colors.cyan(envInfo.packageManager.name)}${envInfo.packageManager.version ? ` v${envInfo.packageManager.version}` : ''}`
+        );
+      } else if (options.local) {
         const localEnvPath = getLocalEnvPath();
         if (!localEnvPath) {
           console.error('No local .env file found in the current directory');

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -585,8 +585,8 @@ async function resetEnv(yes = false): Promise<void> {
   let selectedValues: ResetTarget[] = [];
 
   if (yes) {
-    // Use default selections if using --yes flag
-    selectedValues = resetItems.filter((item) => item.selected).map((item) => item.value);
+    // When using --yes flag, include all reset items rather than relying on selected flag
+    selectedValues = resetItems.map((item) => item.value);
   } else {
     // Prompt user to select items with styling matching interactive mode
     const { selections } = await prompts({

--- a/packages/docs/docs/cli/env.md
+++ b/packages/docs/docs/cli/env.md
@@ -18,14 +18,14 @@ elizaos env [command] [options]
 
 ## Subcommands
 
-| Subcommand        | Description                                               | Options               |
-| ----------------- | --------------------------------------------------------- | --------------------- |
-| `list`            | List all environment variables                            | `--global`, `--local` |
-| `edit-global`     | Edit global environment variables                         | `-y, --yes`           |
-| `edit-local`      | Edit local environment variables                          | `-y, --yes`           |
-| `reset`           | Reset all environment variables and wipe the cache folder | `-y, --yes`           |
-| `set-path <path>` | Set a custom path for the global environment file         | `-y, --yes`           |
-| `interactive`     | Start interactive environment variable manager            | `-y, --yes`           |
+| Subcommand        | Description                                                   | Options                           |
+| ----------------- | ------------------------------------------------------------- | --------------------------------- |
+| `list`            | List all environment variables                                | `--system`, `--global`, `--local` |
+| `edit-global`     | Edit global environment variables                             | `-y, --yes`                       |
+| `edit-local`      | Edit local environment variables                              | `-y, --yes`                       |
+| `reset`           | Reset environment variables and clean up database/cache files | `-y, --yes`                       |
+| `set-path <path>` | Set a custom path for the global environment file             | `-y, --yes`                       |
+| `interactive`     | Start interactive environment variable manager                | `-y, --yes`                       |
 
 ## Environment Levels
 
@@ -64,6 +64,14 @@ elizaos env list
 
 This will display both global and local variables (if available).
 
+You can also filter the output:
+
+```bash
+elizaos env list --system  # Show only system information
+elizaos env list --global  # Show only global environment variables
+elizaos env list --local   # Show only local environment variables
+```
+
 ### Editing Global Variables
 
 Edit the global environment variables interactively:
@@ -99,20 +107,31 @@ elizaos env set-path /path/to/custom/location
 
 If the specified path is a directory, the command will use `/path/to/custom/location/.env`.
 
-### Resetting Environment Variables
+The command supports tilde expansion, so you can use paths like `~/eliza-config/.env`.
 
-Reset all environment variables and clear the cache:
+### Resetting Environment Variables and Data
+
+Reset environment variables and optionally delete database and cache files:
 
 ```bash
 elizaos env reset
 ```
 
-This will:
+This command provides an interactive selection interface where you can choose which items to reset:
 
-1. Remove the global `.env` file
-2. Clear any custom environment path setting
-3. Wipe the cache folder
-4. Optionally reset the database folder (you'll be prompted)
+- **Global environment variables** - Clears values in global `.env` file while preserving keys
+- **Local environment variables** - Clears values in local `.env` file while preserving keys
+- **Cache folder** - Deletes the cache folder
+- **Global database files** - Deletes global database files (with special handling for PostgreSQL)
+- **Local database files** - Deletes local database files
+
+After selecting items, you'll be shown a summary and asked for confirmation before proceeding.
+
+Use the `-y, --yes` flag to automatically reset using default selections:
+
+```bash
+elizaos env reset --yes
+```
 
 ## Key Variables
 
@@ -148,6 +167,12 @@ elizaos env list
 Output example:
 
 ```
+System Information:
+  Platform: darwin (24.3.0)
+  Architecture: arm64
+  CLI Version: 1.0.0-beta.51
+  Package Manager: bun v1.2.5
+
 Global environment variables (.eliza/.env):
   OPENAI_API_KEY: sk-1234...5678
   MODEL_PROVIDER: openai
@@ -175,6 +200,16 @@ elizaos env edit-global
 
 # Edit only local variables
 elizaos env edit-local
+```
+
+### Resetting Environment
+
+```bash
+# Interactive reset with selection
+elizaos env reset
+
+# Reset with default selections
+elizaos env reset --yes
 ```
 
 ## Related Commands


### PR DESCRIPTION
**elizaos env list:**

Added warning when no local .env file exists, with guidance to create one from .env.example if available
Added --system flag to show only system information, consistent with existing --global and --local flags

**elizaos env reset:**
Transformed from a simple deletion command to an interactive selection interface
Implemented proper reset functionality that preserves keys but clears values
Added support for both global and local environment files
Added database handling with special consideration for PostgreSQL vs PGLite

**Path handling improvements:**
Fixed env set-path to properly handle tilde (~) expansion for home directories
Added better error handling and messages for invalid paths

**elizaos env interactive:**
Made "Set custom environment path" option in interactive mode work properly
Ensured consistent UI styling and user experience across commands

+ Updated documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved environment variable management in the CLI, including enhanced listing, resetting, and setting of environment variables.
  - Added interactive reset functionality, allowing users to select which items to reset with clear descriptions and warnings.
  - The `list` command now offers a `--system` option to display system information.

- **Bug Fixes**
  - Enhanced error handling and user feedback when managing environment variables and related files.

- **Documentation**
  - Updated CLI documentation to clarify new options, interactive reset behavior, and provide improved usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->