### PR TITLE
fix: senderName is "Unknown" in recentMessages provider

### DIFF
--- a/packages/plugin-bootstrap/src/providers/recentMessages.ts
+++ b/packages/plugin-bootstrap/src/providers/recentMessages.ts
@@ -138,7 +138,10 @@ export const recentMessagesProvider: Provider = {
       }
 
       const metaData = message.metadata as CustomMetadata;
-      const senderName = metaData?.entityName || 'unknown';
+      const senderName =
+        entitiesData.find((entity: Entity) => entity.id === message.entityId)?.names[0] ||
+        metaData?.entityName ||
+        'Unknown User';
       const receivedMessageContent = message.content.text;
 
       const hasReceivedMessage = !!receivedMessageContent?.trim();


### PR DESCRIPTION
This PR fixes an issue where the senderName was often displayed as "Unknown" in the recentMessages provider. The update changes the logic to prioritize entitiesData for resolving the sender's name based on entityId. If no match is found, it falls back to metadata.entityName, and finally defaults to "Unknown User" if neither is available. This improves the accuracy of sender name display.