### PR TITLE
chore: Refactor CLI fs operations

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -9,7 +9,7 @@ import {
   setupPgLite,
 } from '@/src/utils';
 import { Command } from 'commander';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import prompts from 'prompts';
@@ -216,12 +216,16 @@ export const create = new Command()
 
       while (depth < maxDepth && currentPath.includes(path.sep)) {
         if (existsSync(currentPath)) {
-          const env = readFileSync(currentPath, 'utf8');
-          const envVars = env.split('\n').filter((line) => line.trim() !== '');
-          const postgresUrlLine = envVars.find((line) => line.startsWith('POSTGRES_URL='));
-          if (postgresUrlLine) {
-            postgresUrl = postgresUrlLine.split('=')[1].trim();
-            break;
+          try {
+            const env = await fs.readFile(currentPath, 'utf8');
+            const envVars = env.split('\n').filter((line) => line.trim() !== '');
+            const postgresUrlLine = envVars.find((line) => line.startsWith('POSTGRES_URL='));
+            if (postgresUrlLine) {
+              postgresUrl = postgresUrlLine.split('=')[1].trim();
+              break;
+            }
+          } catch (error) {
+            console.error(`Failed to read ${currentPath}: ${(error as Error).message}`);
           }
         }
 

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -9,25 +9,25 @@ import { getPluginRepository } from '@/src/utils/registry/index';
 import { logger } from '@elizaos/core';
 import { Command } from 'commander';
 import { execa } from 'execa';
-import fs from 'node:fs';
+import fs, { existsSync, promises as fsPromises } from 'node:fs';
 import path from 'node:path';
 
 // --- Helper Functions ---
 
 /** Reads and parses package.json, returning dependencies. */
-export const readPackageJson = (
+export const readPackageJson = async (
   cwd: string
-): {
+): Promise<{
   dependencies: Record<string, string>;
   devDependencies: Record<string, string>;
   allDependencies: Record<string, string>;
-} | null => {
+} | null> => {
   const packageJsonPath = path.join(cwd, 'package.json');
-  if (!fs.existsSync(packageJsonPath)) {
+  if (!existsSync(packageJsonPath)) {
     return null;
   }
   try {
-    const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf-8');
+    const packageJsonContent = await fsPromises.readFile(packageJsonPath, 'utf-8');
     const packageJson = JSON.parse(packageJsonContent);
     const dependencies = packageJson.dependencies || {};
     const devDependencies = packageJson.devDependencies || {};
@@ -174,7 +174,7 @@ plugins
   .option('-T, --tag <tagname>', 'Specify a tag to install (e.g., beta)')
   .action(async (pluginArg, opts) => {
     const cwd = process.cwd();
-    const pkgData = readPackageJson(cwd);
+    const pkgData = await readPackageJson(cwd);
 
     if (!pkgData) {
       logger.error(
@@ -322,7 +322,7 @@ plugins
   .action(async () => {
     try {
       const cwd = process.cwd();
-      const pkgData = readPackageJson(cwd);
+      const pkgData = await readPackageJson(cwd);
 
       if (!pkgData) {
         console.error('Could not read or parse package.json.');
@@ -362,7 +362,7 @@ plugins
     try {
       const cwd = process.cwd();
 
-      const pkgData = readPackageJson(cwd);
+      const pkgData = await readPackageJson(cwd);
       if (!pkgData) {
         console.error(
           'Could not read or parse package.json. Cannot determine which package to remove.'

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -26,7 +26,8 @@ import {
   type Plugin,
 } from '@elizaos/core';
 import { Command, Option } from 'commander';
-import fs from 'node:fs';
+import fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -331,7 +332,7 @@ export async function startAgent(
       while (currentDir !== path.parse(currentDir).root) {
         const envPath = path.join(currentDir, '.env');
 
-        if (fs.existsSync(envPath)) {
+        if (existsSync(envPath)) {
           return envPath;
         }
 
@@ -341,7 +342,7 @@ export async function startAgent(
 
       // Check root directory as well
       const rootEnvPath = path.join(path.parse(currentDir).root, '.env');
-      return fs.existsSync(rootEnvPath) ? rootEnvPath : null;
+      return existsSync(rootEnvPath) ? rootEnvPath : null;
     }
 
     // Node.js environment: load from .env file
@@ -517,9 +518,9 @@ const startAgents = async (options: {
     // Check if we're in a project with a package.json
     const packageJsonPath = path.join(process.cwd(), 'package.json');
 
-    if (fs.existsSync(packageJsonPath)) {
+    if (existsSync(packageJsonPath)) {
       // Read and parse package.json to check if it's a project or plugin
-      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+      const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
 
       // Check if this is a plugin (package.json contains 'eliza' section with type='plugin')
       if (packageJson.eliza?.type && packageJson.eliza.type === 'plugin') {
@@ -547,7 +548,7 @@ const startAgents = async (options: {
       if (mainEntry) {
         const mainPath = path.resolve(process.cwd(), mainEntry);
 
-        if (fs.existsSync(mainPath)) {
+        if (existsSync(mainPath)) {
           try {
             // Try to import the module
             const importedModule = await import(mainPath);
@@ -741,7 +742,7 @@ const startAgents = async (options: {
     let clientPath = path.join(__dirname, '../../client');
 
     // If not found, fall back to the old relative path for development
-    if (!fs.existsSync(clientPath)) {
+    if (!existsSync(clientPath)) {
       clientPath = path.join(__dirname, '../../../..', 'client/dist');
     }
   }

--- a/packages/cli/src/commands/tee/phala.ts
+++ b/packages/cli/src/commands/tee/phala.ts
@@ -1,4 +1,4 @@
-import fs from 'node:fs';
+import fs from 'node:fs/promises';
 import os from 'node:os';
 import {
   type DeployOptions,
@@ -37,7 +37,13 @@ const parseEnv = (envs: string[], envFile: string): Env[] => {
   }
 
   if (envFile) {
-    const envFileContent = fs.readFileSync(envFile, 'utf8');
+    let envFileContent = '';
+    try {
+      envFileContent = await fs.readFile(envFile, 'utf8');
+    } catch (error) {
+      console.error(`Failed to read ${envFile}: ${(error as Error).message}`);
+      envFileContent = '';
+    }
     for (const line of envFileContent.split('\n')) {
       if (line.includes('=')) {
         const [key, value] = line.split('=');


### PR DESCRIPTION
## Summary
- replace sync fs reads/writes in CLI commands with async equivalents
- use `fs.promises` with proper error handling

## Testing
- `bun run test` *(fails: turbo: command not found)*
- `bun run scripts/pre-commit-lint.js` *(fails: prettier not found)*