### PR TITLE
chore: handle plugin post install

### DIFF
--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -4,6 +4,9 @@ import {
   handleError,
   installPlugin,
   logHeader,
+  loadEnvironment,
+  promptForEnvVars,
+  saveConfig,
 } from '@/src/utils';
 import { getPluginRepository } from '@/src/utils/registry/index';
 import { logger } from '@elizaos/core';
@@ -228,9 +231,17 @@ plugins
           logger.info(
             `Successfully installed ${pluginNameForPostInstall} from ${githubSpecifier}.`
           );
-          // TODO: Add post-installation steps here, similar to other plugin types
-          // e.g., prompting for env vars, updating config.
-          // For now, just exit cleanly.
+
+          if (!opts.noEnvPrompt) {
+            try {
+              await loadEnvironment();
+              await promptForEnvVars(pluginNameForPostInstall);
+              await saveConfig({ lastUpdated: new Date().toISOString() });
+            } catch (postError) {
+              logger.warn(`Post-install configuration failed: ${postError}`);
+            }
+          }
+
           process.exit(0);
         } else {
           logger.error(`Failed to install plugin from ${githubSpecifier}.`);


### PR DESCRIPTION
## Summary
- prompt for env vars and update config after installing a plugin from GitHub


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - After installing a plugin from GitHub, users are now prompted to enter environment variables related to the plugin, with updates saved automatically.
- **Bug Fixes**
  - Improved error handling during post-installation steps, with warnings logged for any issues without interrupting the installation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->