### PR TITLE
API - return ID of newly created agent

### DIFF
--- a/packages/cli/src/server/api/agent.ts
+++ b/packages/cli/src/server/api/agent.ts
@@ -381,11 +381,12 @@ export function agentRouter(
         character.settings.secrets = encryptObjectValues(character.settings.secrets, salt);
       }
 
-      await db.ensureAgentExists(character);
+      const createdAgent = await db.ensureAgentExists(character);
 
       res.status(201).json({
         success: true,
         data: {
+          id: createdAgent.id,
           character: character,
         },
       });


### PR DESCRIPTION
When using API calls and creating AGENT it very useful to have returned ID on first API call, so there are not needed subsequent calls after it just to find ID, which is crucial for other types of API calls.

So I added ID in return data so it can be used.