### PR TITLE
feat: allow world selection in message API

### DIFF
--- a/packages/cli/src/server/api/agent.ts
+++ b/packages/cli/src/server/api/agent.ts
@@ -129,6 +129,9 @@ export function agentRouter(
 
     const entityId = req.body.entityId as UUID;
     const roomId = req.body.roomId as UUID;
+    const worldId =
+      (validateUuid(req.query.worldId as string) ||
+        ('00000000-0000-0000-0000-000000000000' as UUID)) as UUID;
 
     const source = req.body.source;
     const text = req.body.text.trim();
@@ -147,7 +150,7 @@ export function agentRouter(
         name: req.body.name,
         source: 'api-message',
         type: ChannelType.API,
-        worldId: createUniqueUuid(runtime, 'api-message'),
+        worldId,
         worldName: 'api-message',
       });
 
@@ -163,6 +166,7 @@ export function agentRouter(
         id: incomingMessageVirtualId, // Use a consistent ID for the incoming message
         entityId,
         roomId,
+        worldId,
         agentId: runtime.agentId, // The agent this message is directed to
         content,
         createdAt: Date.now(),
@@ -194,6 +198,7 @@ export function agentRouter(
               inReplyTo: userMessageMemory.id,
             },
             roomId: roomId,
+            worldId,
             createdAt: Date.now(),
           };
 

--- a/packages/docs/docs/rest/send-message.api.mdx
+++ b/packages/docs/docs/rest/send-message.api.mdx
@@ -45,6 +45,12 @@ Sends a message to an agent and receives a response
       schema: { type: 'string', format: 'uuid' },
       description: 'ID of the agent',
     },
+    {
+      name: 'worldId',
+      in: 'query',
+      schema: { type: 'string', format: 'uuid' },
+      description: 'ID of the world (defaults to 00000000-0000-0000-0000-000000000000)',
+    },
   ]}
 ></ParamsDetails>
 

--- a/packages/docs/src/openapi/eliza-v1.yaml
+++ b/packages/docs/src/openapi/eliza-v1.yaml
@@ -565,6 +565,12 @@ paths:
             type: string
             format: uuid
           description: ID of the agent
+        - name: worldId
+          in: query
+          schema:
+            type: string
+            format: uuid
+          description: ID of the world (defaults to zero UUID)
         - name: roomId
           in: query
           schema:
@@ -1181,6 +1187,12 @@ paths:
             type: string
             format: uuid
           description: ID of the agent
+        - name: worldId
+          in: query
+          schema:
+            type: string
+            format: uuid
+          description: ID of the world (defaults to zero UUID)
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Summary
- add optional `worldId` query param for `/agents/:agentId/message`
- record `worldId` in created memories
- document new query parameter in OpenAPI & docs

## Testing
- `bun test` *(fails: Cannot find module '@playwright/test')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an optional world ID parameter to several agent-related API endpoints, allowing users to specify or filter by a world context.
- **Documentation**
  - Updated API documentation to describe the new world ID parameter for relevant endpoints, including its format, usage, and default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->