### PR TITLE
fix: docs deploy workflow

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -3,13 +3,6 @@ name: Deploy Documentation
 on:
   push:
     branches:
-      - main
-      - v2-develop
-    paths:
-      - 'packages/docs/**'
-  pull_request:
-    branches:
-      - main
       - v2-develop
     paths:
       - 'packages/docs/**'
@@ -29,7 +22,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '23'
-          cache: 'npm'
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
fixes npm cache since doesn't exist for docs package, removes PR runs, should only happen on pushes.