### PR TITLE
chore: Add missing plugin failure test

### DIFF
--- a/packages/cli/__test_scripts__/test_plugins.bats
+++ b/packages/cli/__test_scripts__/test_plugins.bats
@@ -79,11 +79,25 @@ teardown() {
   echo "STATUS: $status"
   [ "$status" -eq 0 ]
   cd proj-mod-app
-  run $ELIZAOS_CMD plugins add @elizaos/plugin-bootstrap --no-env-prompt
+  run $ELIZAOS_CMD plugins add @elizaos/plugin-discord --no-env-prompt
   echo "STDOUT: $output"
   echo "STATUS: $status"
   [ "$status" -eq 0 ]
-  grep '@elizaos/plugin-bootstrap' package.json
+  grep '@elizaos/plugin-discord' package.json
+}
+
+# Verifies that attempting to install a plugin not listed in the registry fails.
+@test "plugins add fails for missing plugin" {
+  run $ELIZAOS_CMD create proj-missing-plugin --yes
+  echo "STDOUT: $output"
+  echo "STATUS: $status"
+  [ "$status" -eq 0 ]
+  cd proj-missing-plugin
+  run $ELIZAOS_CMD plugins add @elizaos/plugin-bootstrap --no-env-prompt
+  echo "STDOUT: $output"
+  echo "STATUS: $status"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found in registry"* ]] || [[ "$error" == *"not found in registry"* ]]
 }
 
 


### PR DESCRIPTION
## Summary
- test plugin install modifies package.json with plugin-discord
- verify missing plugin fails with registry error

## Testing
- `./run_all_bats.sh` *(fails: 'bats' not found in PATH)*