### PR TITLE
feat: API endpoint for creating new rooms

### DIFF
--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -379,6 +379,25 @@ export const apiClient = {
     });
   },
 
+  // Create a room for a specific agent
+  createRoom: (
+    agentId: string,
+    params: {
+      name: string;
+      type?: string;
+      source?: string;
+      worldId?: string;
+      serverId?: string;
+      metadata?: Record<string, any>;
+    }
+  ) => {
+    return fetcher({
+      url: `/agents/${agentId}/rooms`,
+      method: 'POST',
+      body: params,
+    });
+  },
+
   getLogs: ({
     level,
     agentName,


### PR DESCRIPTION
Currently we dont have API endpoint to create new rooms, so I added this feature in PR. 

Did some tests, rooms are created and IDs returned. Adding screenshots from tests

<img width="845" alt="image" src="https://github.com/user-attachments/assets/a9d21ce0-2150-4de2-83c8-56dd3fbbc1b8" />
