### PR TITLE
add libvips-dev to fix sharp install in CI

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Install required packages
         run: |
           sudo apt update
-          sudo apt -y install build-essential pkg-config libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
+          sudo apt -y install build-essential pkg-config libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev libvips-dev
 
       - name: Install dependencies
         run: bun install


### PR DESCRIPTION
Add libvips-dev install to linux in CI, to fix error in integration tests:

```
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
../src/common.cc:13:10: fatal error: vips/vips8: No such file or directory
13 | #include <vips/vips8>
| ^~~~~~~~~~~~
compilation terminated.
make: *** [sharp-linux-x64.target.mk:140: Release/obj.target/sharp-linux-x64/src/common.o] Error 1
gyp ERR! build error
```