### PR TITLE
default sentry better

### DIFF
--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -224,7 +224,7 @@ const options = {
   hooks: {
     logMethod(inputArgs: [string | Record<string, unknown>, ...unknown[]], method: LogFn): void {
       const [arg1, ...rest] = inputArgs;
-      if (process.env.SENTRY_LOGGING === 'true') {
+      if (process.env.SENTRY_LOGGING !== 'false') {
         if (arg1 instanceof Error) {
           Sentry.captureException(arg1);
         } else {

--- a/packages/core/src/sentry/instrument.ts
+++ b/packages/core/src/sentry/instrument.ts
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/browser';
 const dsn =
   process.env.SENTRY_DSN ||
   'https://c20e2d51b66c14a783b0689d536f7e5c@o4509349865259008.ingest.us.sentry.io/4509352524120064';
-if (process.env.SENTRY_LOGGING === 'true') {
+if (process.env.SENTRY_LOGGING !== 'false') {
   Sentry.onLoad(() => {
     Sentry.init({
       dsn,


### PR DESCRIPTION
Since requires new ENV added, usually would always be not true, this turns off sentry only if user sets false. Even if env not added.