### PR TITLE
Add memory graph view

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -31,8 +31,9 @@
 		"react-aiwriter": "^1.0.0",
 		"react-dom": "^19.0.0",
 		"react-router": "^7.1.1",
-		"react-router-dom": "^7.1.1",
-		"semver": "^7.6.3",
+                "react-router-dom": "^7.1.1",
+                "react-force-graph": "^1.45.0",
+                "semver": "^7.6.3",
 		"tailwind-merge": "^2.6.0",
 		"tailwindcss-animate": "^1.0.7",
 		"vite-plugin-compression": "^0.5.1"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { Toaster } from "./components/ui/toaster";
 import { BrowserRouter, Route, Routes } from "react-router";
 import Chat from "./routes/chat";
 import Overview from "./routes/overview";
+import Memories from "./routes/memories";
 import Home from "./routes/home";
 import useVersion from "./hooks/use-version";
 
@@ -43,6 +44,10 @@ function App() {
                                         <Route
                                             path="settings/:agentId"
                                             element={<Overview />}
+                                        />
+                                        <Route
+                                            path="memories/:agentId"
+                                            element={<Memories />}
                                         />
                                     </Routes>
                                 </div>

--- a/client/src/components/app-sidebar.tsx
+++ b/client/src/components/app-sidebar.tsx
@@ -75,21 +75,24 @@ export function AppSidebar() {
                                     {agents?.map(
                                         (agent: { id: UUID; name: string }) => (
                                             <SidebarMenuItem key={agent.id}>
-                                                <NavLink
-                                                    to={`/chat/${agent.id}`}
-                                                >
+                                                <NavLink to={`/chat/${agent.id}`}>
                                                     <SidebarMenuButton
-                                                        isActive={location.pathname.includes(
-                                                            agent.id
-                                                        )}
+                                                        isActive={location.pathname.includes(`chat/${agent.id}`)}
                                                     >
                                                         <User />
-                                                        <span>
-                                                            {agent.name}
-                                                        </span>
+                                                        <span>{agent.name}</span>
                                                     </SidebarMenuButton>
                                                 </NavLink>
                                             </SidebarMenuItem>
+                                            <SidebarMenuSub>
+                                                <SidebarMenuSubItem>
+                                                    <NavLink to={`/memories/${agent.id}`}>
+                                                        <SidebarMenuSubButton size="sm" isActive={location.pathname.includes(`memories/${agent.id}`)}>
+                                                            Graph
+                                                        </SidebarMenuSubButton>
+                                                    </NavLink>
+                                                </SidebarMenuSubItem>
+                                            </SidebarMenuSub>
                                         )
                                     )}
                                 </div>

--- a/client/src/components/memory/graph-view.tsx
+++ b/client/src/components/memory/graph-view.tsx
@@ -1,0 +1,34 @@
+import { ForceGraph2D, NodeObject } from "react-force-graph";
+import React from "react";
+import { computePCA } from "./pca";
+
+export interface MemoryItem {
+    id: string;
+    content: { text: string };
+    embedding?: number[];
+}
+
+export default function GraphView({ memories, onSelect }: { memories: MemoryItem[]; onSelect: (m: MemoryItem) => void; }) {
+    const graphData = React.useMemo(() => {
+        const embed = memories
+            .filter((m) => m.embedding)
+            .map((m) => m.embedding as number[]);
+        const coords = computePCA(embed, 2);
+        const nodes = memories.map((m, i) => ({
+            id: m.id,
+            memory: m,
+            x: coords[i]?.[0] || 0,
+            y: coords[i]?.[1] || 0,
+        }));
+        return { nodes, links: [] as any[] };
+    }, [memories]);
+
+    return (
+        <ForceGraph2D
+            graphData={graphData}
+            nodeAutoColorBy="id"
+            nodeLabel={(node: NodeObject) => (node as any).memory.content.text}
+            onNodeClick={(node) => onSelect((node as any).memory)}
+        />
+    );
+}

--- a/client/src/components/memory/list-view.tsx
+++ b/client/src/components/memory/list-view.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { MemoryItem } from "./graph-view";
+
+export default function ListView({ memories, onSelect }: { memories: MemoryItem[]; onSelect: (m: MemoryItem) => void }) {
+    return (
+        <div className="space-y-2 overflow-auto">
+            {memories.map((m) => (
+                <div key={m.id} className="p-2 border rounded" onClick={() => onSelect(m)}>
+                    {m.content.text}
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/client/src/components/memory/memory-tab.tsx
+++ b/client/src/components/memory/memory-tab.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+import ListView from "./list-view";
+import GraphView, { MemoryItem } from "./graph-view";
+
+export default function MemoryTab({ memories }: { memories: MemoryItem[] }) {
+    const [selected, setSelected] = React.useState<MemoryItem | null>(null);
+    return (
+        <Tabs defaultValue="list" className="h-full w-full">
+            <div className="p-2 flex flex-col gap-2">
+                {selected ? (
+                    <div className="p-2 border rounded bg-muted">
+                        <div className="font-bold">{selected.content.text}</div>
+                    </div>
+                ) : (
+                    <div className="p-2 border rounded bg-muted">Select a node</div>
+                )}
+            </div>
+            <TabsList>
+                <TabsTrigger value="list">List</TabsTrigger>
+                <TabsTrigger value="graph">Graph</TabsTrigger>
+            </TabsList>
+            <TabsContent value="list" className="h-[calc(100%-4rem)] overflow-auto">
+                <ListView memories={memories} onSelect={setSelected} />
+            </TabsContent>
+            <TabsContent value="graph" className="h-[calc(100%-4rem)] overflow-auto">
+                <GraphView memories={memories} onSelect={setSelected} />
+            </TabsContent>
+        </Tabs>
+    );
+}

--- a/client/src/components/memory/pca.ts
+++ b/client/src/components/memory/pca.ts
@@ -1,0 +1,73 @@
+export function computePCA(data: number[][], components = 2): number[][] {
+    if (!data.length) return [];
+    const dim = data[0].length;
+    const mean = new Array(dim).fill(0);
+    for (const row of data) {
+        for (let i = 0; i < dim; i++) {
+            mean[i] += row[i];
+        }
+    }
+    for (let i = 0; i < dim; i++) {
+        mean[i] /= data.length;
+    }
+    const centered = data.map((row) => row.map((v, i) => v - mean[i]));
+    const cov = Array.from({ length: dim }, () => new Array(dim).fill(0));
+    for (const row of centered) {
+        for (let i = 0; i < dim; i++) {
+            for (let j = i; j < dim; j++) {
+                cov[i][j] += row[i] * row[j];
+            }
+        }
+    }
+    for (let i = 0; i < dim; i++) {
+        for (let j = i; j < dim; j++) {
+            cov[i][j] /= data.length - 1;
+            cov[j][i] = cov[i][j];
+        }
+    }
+    function multiplyMatrixVector(m: number[][], v: number[]): number[] {
+        const res = new Array(m.length).fill(0);
+        for (let i = 0; i < m.length; i++) {
+            let sum = 0;
+            for (let j = 0; j < v.length; j++) {
+                sum += m[i][j] * v[j];
+            }
+            res[i] = sum;
+        }
+        return res;
+    }
+    function dot(a: number[], b: number[]): number {
+        let sum = 0;
+        for (let i = 0; i < a.length; i++) sum += a[i] * b[i];
+        return sum;
+    }
+    function norm(v: number[]): number {
+        return Math.sqrt(dot(v, v));
+    }
+    function powerIteration(A: number[][], iterations = 100): { eigenvalue: number; eigenvector: number[] } {
+        let b = new Array(A.length).fill(1 / Math.sqrt(A.length));
+        for (let i = 0; i < iterations; i++) {
+            const Ab = multiplyMatrixVector(A, b);
+            const n = norm(Ab);
+            b = Ab.map((v) => v / n);
+        }
+        const eigenvalue = dot(multiplyMatrixVector(A, b), b);
+        return { eigenvalue, eigenvector: b };
+    }
+    let A = cov.map((row) => [...row]);
+    const componentsVec: number[][] = [];
+    for (let k = 0; k < components; k++) {
+        const { eigenvalue, eigenvector } = powerIteration(A);
+        componentsVec.push(eigenvector);
+        // deflate
+        for (let i = 0; i < A.length; i++) {
+            for (let j = 0; j < A.length; j++) {
+                A[i][j] -= eigenvalue * eigenvector[i] * eigenvector[j];
+            }
+        }
+    }
+    const result: number[][] = centered.map((row) =>
+        componentsVec.map((vec) => dot(row, vec))
+    );
+    return result;
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -112,4 +112,6 @@ export const apiClient = {
             body: formData,
         });
     },
+    getMemories: (agentId: string, roomId: string) =>
+        fetcher({ url: `/agents/${agentId}/${roomId}/memories` }),
 };

--- a/client/src/routes/memories.tsx
+++ b/client/src/routes/memories.tsx
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "@/lib/api";
+import { useParams } from "react-router";
+import MemoryTab from "@/components/memory/memory-tab";
+import type { UUID } from "@elizaos/core";
+
+export default function MemoriesRoute() {
+    const { agentId } = useParams<{ agentId: UUID }>();
+    const roomId = agentId ?? "";
+
+    const query = useQuery({
+        queryKey: ["memories", agentId, roomId],
+        queryFn: () => apiClient.getMemories(agentId ?? "", roomId),
+        enabled: Boolean(agentId),
+    });
+
+    const memories = query.data?.memories || [];
+
+    if (!agentId) return <div>No agent selected.</div>;
+
+    return (
+        <div className="h-full p-4">
+            <MemoryTab memories={memories} />
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add memory graph route in the client
- implement small PCA helper and graph/list views
- fetch memories from server
- expose new link in sidebar

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm)*