### PR TITLE
Remove global env support

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -82,14 +82,10 @@ Manage environment variables and secrets.
 
 - **Subcommands:**
   - `list`: List all environment variables
-    - Options: `--global`, `--local`
-  - `edit-global`: Edit global environment variables
-    - Options: `-y, --yes`
+    - Options: `--local`
   - `edit-local`: Edit local environment variables
     - Options: `-y, --yes`
   - `reset`: Reset all environment variables
-    - Options: `-y, --yes`
-  - `set-path <path>`: Set a custom path for the global environment file
     - Options: `-y, --yes`
   - `interactive`: Interactive environment variable management
     - Options: `-y, --yes`
@@ -260,19 +256,14 @@ Manage environment variables and secrets.
 
 - **Subcommands:**
   - `list`: List all environment variables
-    - Options: `--system`, `--global`, `--local`
-  - `edit-global`: Edit global environment variables
-    - Options: `-y, --yes`
+    - Options: `--system`, `--local`
   - `edit-local`: Edit local environment variables
     - Options: `-y, --yes`
   - `reset`: Reset environment variables and clean up database/cache files
     - Options: `-y, --yes`
-  - `set-path <path>`: Set a custom path for the global environment file
-    - Options: `-y, --yes`
   - `interactive`: Start interactive environment variable manager
     - Options: `-y, --yes`
 
-Global variables apply to all projects, while local variables are specific to the current directory.
 
 ### Publishing
 

--- a/packages/cli/__test_scripts__/test_env.bats
+++ b/packages/cli/__test_scripts__/test_env.bats
@@ -2,7 +2,7 @@
 
 # -----------------------------------------------------------------------------
 # env‑command tests.  These tests exercise listing, editing and resetting
-# environment variable files (.env) in both global and local scopes.
+# environment variable files (.env) in the project directory.
 # -----------------------------------------------------------------------------
 
 setup() {
@@ -34,7 +34,7 @@ teardown() {
   # First call: no local .env file present.
   run $ELIZAOS_CMD env list
   [ "$status" -eq 0 ]
-  for section in "System Information" "Global Environment Variables" "Local Environment Variables"; do
+  for section in "System Information" "Local Environment Variables"; do
     [[ "$output" == *"$section"* ]]
   done
   [[ "$output" == *"No local .env file found"* ]] || [[ "$output" == *"Missing .env file"* ]]
@@ -48,7 +48,7 @@ teardown() {
 }
 
 # -----------------------------------------------------------------------------
-# --local / --global filters
+# --local filter
 # -----------------------------------------------------------------------------
 @test "env list --local shows only local environment" {
   echo "LOCAL_TEST=local_value" > .env
@@ -56,16 +56,8 @@ teardown() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"LOCAL_TEST"* ]] && [[ "$output" == *"local_value"* ]]
   [[ "$output" != *"System Information"* ]]
-  [[ "$output" != *"Global Environment Variables"* ]]
 }
 
-@test "env list --global shows only global environment" {
-  run $ELIZAOS_CMD env list --global
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"Global environment"* ]]
-  [[ "$output" != *"Local Environment Variables"* ]]
-  [[ "$output" != *"System Information"* ]]
-}
 
 # -----------------------------------------------------------------------------
 # env edit-local (auto‑create)

--- a/packages/cli/__test_scripts__/test_env.bats
+++ b/packages/cli/__test_scripts__/test_env.bats
@@ -73,9 +73,10 @@ teardown() {
 # env reset
 # -----------------------------------------------------------------------------
 @test "env reset shows all necessary options" {
+  echo "DUMMY=value" > .env
   run $ELIZAOS_CMD env reset --yes
   [ "$status" -eq 0 ]
   [[ "$output" == *"Reset Summary"* ]]
-  [[ "$output" =~ (Global|Local) ]]
+  [[ "$output" == *"Local environment variables"* ]]
   [[ "$output" == *"Environment reset complete"* ]]
 }

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -10,113 +10,12 @@ import prompts from 'prompts';
 import { rimraf } from 'rimraf';
 import colors from 'yoctocolors';
 
-// Path to store the custom env path setting in the config.json file
-const CONFIG_FILE = path.join(os.homedir(), '.eliza', 'config.json');
-
 /**
- * Get the custom env path if one has been set
- * @returns The custom env path or null if not set
- */
-async function getCustomEnvPath(): Promise<string | null> {
-  try {
-    if (!existsSync(CONFIG_FILE)) {
-      return null;
-    }
-
-    const content = await fs.readFile(CONFIG_FILE, 'utf-8');
-    // Handle empty or malformed file
-    if (!content) return null;
-    const config = JSON.parse(content);
-    return config.envPath || null;
-  } catch (error) {
-    console.error(`Error reading custom env path from ${CONFIG_FILE}: ${error.message}`);
-    return null;
-  }
-}
-
-/**
- * Save a custom env path to the config file
- * @param customPath The path to save
- */
-async function saveCustomEnvPath(customPath: string): Promise<void> {
-  try {
-    const dir = path.dirname(CONFIG_FILE);
-    if (!existsSync(dir)) {
-      await fs.mkdir(dir, { recursive: true });
-    }
-
-    // Preserve existing config if it exists
-    let config = {};
-    if (existsSync(CONFIG_FILE)) {
-      try {
-        const content = await fs.readFile(CONFIG_FILE, 'utf-8');
-        config = JSON.parse(content);
-      } catch (e) {
-        console.warn(`Could not parse existing config file: ${e.message}`);
-      }
-    }
-
-    // Update the config with the new env path
-    config = {
-      ...config,
-      envPath: customPath,
-    };
-
-    await fs.writeFile(CONFIG_FILE, JSON.stringify(config, null, 2));
-    console.log(`Custom environment path set to: ${customPath}`);
-  } catch (error) {
-    console.error(`Error saving custom env path: ${error.message}`);
-  }
-}
-
-/**
- * Get the path to the global .env file in the user's home directory or custom location
- * @returns The path to the global .env file
+ * Get the path to the project's .env file.
+ * @returns The path to the .env file
  */
 export async function getGlobalEnvPath(): Promise<string> {
-  const customPath = await getCustomEnvPath();
-  if (customPath) {
-    // Check if the file pointed to by customPath actually exists
-    if (!existsSync(customPath)) {
-      console.warn(
-        `Custom env path specified in config (${customPath}) does not exist. Falling back to default path.`
-      );
-      // Fallback logic (same as below)
-      const homeDir = os.homedir();
-      const elizaDir = path.join(homeDir, '.eliza');
-      if (!existsSync(elizaDir)) {
-        try {
-          await fs.mkdir(elizaDir, { recursive: true });
-          console.warn(`Default config directory ${elizaDir} did not exist. Created it.`);
-        } catch (mkdirError) {
-          console.error(
-            `Failed to create default config directory ${elizaDir}: ${mkdirError.message}`
-          );
-          // If we can't create the default dir, return the problematic custom path anyway?
-          // Or throw an error? Let's return the default path for now.
-        }
-      }
-      return path.join(elizaDir, '.env');
-    }
-    // Custom path exists, return it
-    return customPath;
-  }
-
-  // No custom path set, use default
-  const homeDir = os.homedir();
-  const elizaDir = path.join(homeDir, '.eliza');
-  // Ensure the default directory exists
-  if (!existsSync(elizaDir)) {
-    try {
-      await fs.mkdir(elizaDir, { recursive: true });
-      console.warn(`Default config directory ${elizaDir} did not exist. Created it.`);
-    } catch (mkdirError) {
-      console.error(`Failed to create default config directory ${elizaDir}: ${mkdirError.message}`);
-      // Decide on error handling - maybe throw here?
-      // For now, proceed to return the path, expecting write operations might fail later.
-    }
-  }
-  return path.join(elizaDir, '.env');
+  return path.join(process.cwd(), '.env');
 }
 
 /**
@@ -177,13 +76,12 @@ async function writeEnvFile(filePath: string, envVars: Record<string, string>): 
 }
 
 /**
- * Displays system information and lists environment variables from global and local `.env` files.
+ * Displays system information and lists environment variables from the project's `.env` file.
  *
- * Prints platform, architecture, CLI version, and package manager details, followed by environment variables from the global and local scopes with sensitive values masked. Indicates if no variables are set and provides a link to the web UI for editing.
+ * Prints platform, architecture, CLI version, and package manager details, followed by environment variables with sensitive values masked. Indicates if no variables are set and provides a link to the web UI for editing.
  */
 async function listEnvVars(): Promise<void> {
   const envInfo = await UserEnvironment.getInstanceInfo();
-  const globalEnvPath = await getGlobalEnvPath();
   const localEnvPath = getLocalEnvPath();
 
   // Display system information
@@ -195,19 +93,7 @@ async function listEnvVars(): Promise<void> {
     `  Package Manager: ${colors.cyan(envInfo.packageManager.name)}${envInfo.packageManager.version ? ` v${envInfo.packageManager.version}` : ''}`
   );
 
-  console.info(colors.bold('\nGlobal Environment Variables:'));
-  console.info(`Path: ${globalEnvPath}`);
-
-  if (!existsSync(globalEnvPath)) {
-    console.info('  No global environment variables set');
-  } else {
-    const globalEnvVars = await parseEnvFile(globalEnvPath);
-    for (const [key, value] of Object.entries(globalEnvVars)) {
-      console.info(`  ${colors.green(key)}: ${maskedValue(value)}`);
-    }
-  }
-
-  // Always display local environment section regardless of whether a file exists
+  // Display local environment section
   console.info(colors.bold('\nLocal Environment Variables:'));
   const localEnvFilePath = path.join(process.cwd(), '.env');
   console.info(`Path: ${localEnvFilePath}`);
@@ -266,15 +152,15 @@ function maskedValue(value: string): string {
 
 /**
  * Edit environment variables
- * @param scope Whether to edit global or local environment variables
+ * @param scope Edit local environment variables
  * @returns A boolean indicating whether the user wants to go back to the main menu
  */
 async function editEnvVars(
-  scope: 'global' | 'local',
+  scope: 'local',
   fromMainMenu = false,
   yes = false
 ): Promise<boolean> {
-  const envPath = scope === 'global' ? await getGlobalEnvPath() : getLocalEnvPath();
+  const envPath = getLocalEnvPath();
 
   if (scope === 'local' && !envPath) {
     let createLocal = true;
@@ -469,7 +355,7 @@ async function resetEnvFile(filePath: string): Promise<boolean> {
 }
 
 // Reset operation types and helper functions
-type ResetTarget = 'globalEnv' | 'localEnv' | 'cache' | 'globalDb' | 'localDb';
+type ResetTarget = 'localEnv' | 'cache' | 'globalDb' | 'localDb';
 type ResetAction = 'reset' | 'deleted' | 'skipped' | 'warning';
 
 interface ResetItem {
@@ -518,7 +404,6 @@ async function resetEnv(yes = false): Promise<void> {
   // Get all relevant paths
   const homeDir = os.homedir();
   const elizaDir = path.join(homeDir, '.eliza');
-  const globalEnvPath = await getGlobalEnvPath();
   const cacheDir = path.join(elizaDir, 'cache');
   const projectUuid = stringToUuid(process.cwd());
   const globalDbDir = path.join(elizaDir, 'projects', projectUuid, 'db');
@@ -530,18 +415,15 @@ async function resetEnv(yes = false): Promise<void> {
   let usingExternalPostgres = false;
   let usingPglite = false;
   try {
-    const globalEnvVars = existsSync(globalEnvPath) ? await parseEnvFile(globalEnvPath) : {};
     const localEnvVars = existsSync(localEnvPath) ? await parseEnvFile(localEnvPath) : {};
 
     // Check for external Postgres
     usingExternalPostgres =
-      (globalEnvVars.POSTGRES_URL && globalEnvVars.POSTGRES_URL.trim() !== '') ||
-      (localEnvVars.POSTGRES_URL && localEnvVars.POSTGRES_URL.trim() !== '');
+      localEnvVars.POSTGRES_URL && localEnvVars.POSTGRES_URL.trim() !== '';
 
     // Check for PGLite
     usingPglite =
-      (globalEnvVars.PGLITE_DATA_DIR && globalEnvVars.PGLITE_DATA_DIR.trim() !== '') ||
-      (localEnvVars.PGLITE_DATA_DIR && localEnvVars.PGLITE_DATA_DIR.trim() !== '');
+      localEnvVars.PGLITE_DATA_DIR && localEnvVars.PGLITE_DATA_DIR.trim() !== '';
   } catch (error) {
     // Ignore errors in env parsing
     console.debug('Error checking database config:', error.message);
@@ -549,14 +431,6 @@ async function resetEnv(yes = false): Promise<void> {
 
   // Create reset item options
   const resetItems: ResetItem[] = [
-    {
-      title: 'Global environment variables',
-      value: 'globalEnv',
-      description: existsSync(globalEnvPath)
-        ? 'Reset values in global .env file'
-        : 'Global .env file not found, nothing to reset',
-      selected: existsSync(globalEnvPath),
-    },
     {
       title: 'Local environment variables',
       value: 'localEnv',
@@ -599,7 +473,6 @@ async function resetEnv(yes = false): Promise<void> {
   // Filter out non-existent items for automated selection
   const validResetItems = resetItems.filter(
     (item) =>
-      (item.value === 'globalEnv' && existsSync(globalEnvPath)) ||
       (item.value === 'localEnv' && existsSync(localEnvPath)) ||
       (item.value === 'cache' && existsSync(cacheDir)) ||
       (item.value === 'globalDb' && (existsSync(globalDbDir) || existsSync(globalPgliteDir))) ||
@@ -675,14 +548,6 @@ async function resetEnv(yes = false): Promise<void> {
   // Process each selected item
   for (const target of selectedValues) {
     switch (target) {
-      case 'globalEnv':
-        if (await resetEnvFile(globalEnvPath)) {
-          actions.reset.push('Global environment variables');
-        } else {
-          actions.skipped.push('Global environment variables (no file or empty)');
-        }
-        break;
-
       case 'localEnv':
         if (await resetEnvFile(localEnvPath)) {
           actions.reset.push('Local environment variables');
@@ -759,83 +624,6 @@ async function resetEnv(yes = false): Promise<void> {
   console.log(colors.bold('\nEnvironment reset complete'));
 }
 
-/**
- * Set a custom path for the global .env file
- * @param customPath The custom path to use
- * @param autoConfirm Automatically confirm prompts
- */
-async function setEnvPath(customPath: string, autoConfirm = false): Promise<void> {
-  // Expand tilde (~) in the path if present
-  if (customPath.startsWith('~')) {
-    // Use string concatenation instead of path.join to preserve slashes
-    customPath = os.homedir() + customPath.substring(1);
-  }
-
-  // Validate the path
-  const resolvedPath = path.resolve(customPath);
-  const isDirectory = existsSync(resolvedPath) && (await fs.stat(resolvedPath)).isDirectory();
-
-  let finalPath = resolvedPath;
-  if (isDirectory) {
-    finalPath = path.join(resolvedPath, '.env');
-    console.info(`Path is a directory. Will use ${finalPath} for environment variables.`);
-  }
-
-  // Check if parent directory exists
-  const parentDir = path.dirname(finalPath);
-  if (!existsSync(parentDir)) {
-    let createDir = autoConfirm;
-    if (!autoConfirm) {
-      const response = await prompts({
-        type: 'confirm',
-        name: 'createDir',
-        message: `Directory ${parentDir} does not exist. Create it?`,
-        initial: true,
-      });
-      createDir = response.createDir;
-    }
-
-    if (createDir) {
-      try {
-        await fs.mkdir(parentDir, { recursive: true });
-        console.log(`Created directory: ${parentDir}`);
-      } catch (error) {
-        console.error(`Failed to create directory: ${error.message}`);
-        console.info('Custom path not set');
-        return;
-      }
-    } else {
-      console.info('Custom path not set');
-      return;
-    }
-  }
-
-  // If the file doesn't exist, create an empty one
-  if (!existsSync(finalPath)) {
-    let createFile = autoConfirm;
-    if (!autoConfirm) {
-      const response = await prompts({
-        type: 'confirm',
-        name: 'createFile',
-        message: `Environment file doesn't exist at ${finalPath}. Create an empty one?`,
-        initial: true,
-      });
-      createFile = response.createFile;
-    }
-
-    if (createFile) {
-      await writeEnvFile(finalPath, {});
-      console.log(`Created empty .env file at ${finalPath}`);
-    } else if (!autoConfirm) {
-      // If user explicitly said no (and not autoConfirm), don't save the path
-      console.info('Custom path not set as file creation was declined.');
-      return;
-    }
-  }
-
-  await saveCustomEnvPath(finalPath);
-}
-
 // Create command for managing environment variables
 export const env = new Command()
   .name('env')
@@ -846,7 +634,6 @@ env
   .command('list')
   .description('List all environment variables')
   .option('--system', 'List only system information')
-  .option('--global', 'List only global environment variables')
   .option('--local', 'List only local environment variables')
   .action(async (options: { global?: boolean; local?: boolean; system?: boolean }) => {
     try {
@@ -875,22 +662,6 @@ env
             console.info(`  ${colors.green(key)}: ${maskedValue(value)}`);
           }
         }
-      } else if (options.global) {
-        const globalEnvPath = await getGlobalEnvPath();
-        const globalEnvVars = await parseEnvFile(globalEnvPath);
-        const customPath = await getCustomEnvPath();
-        const globalEnvLabel = customPath
-          ? `Global environment variables (custom path: ${customPath})`
-          : 'Global environment variables (.eliza/.env)';
-
-        console.info(colors.bold(`\n${globalEnvLabel}:`));
-        if (Object.keys(globalEnvVars).length === 0) {
-          console.info('  No global environment variables set');
-        } else {
-          for (const [key, value] of Object.entries(globalEnvVars)) {
-            console.info(`  ${colors.green(key)}: ${maskedValue(value)}`);
-          }
-        }
       } else {
         await listEnvVars();
       }
@@ -900,17 +671,6 @@ env
   });
 
 // Edit global subcommand
-env
-  .command('edit-global')
-  .description('Edit global environment variables')
-  .option('-y, --yes', 'Automatically confirm prompts')
-  .action(async (options) => {
-    try {
-      await editEnvVars('global', false, options.yes);
-    } catch (error) {
-      handleError(error);
-    }
-  });
 
 // Edit local subcommand
 env
@@ -940,19 +700,6 @@ env
     }
   });
 
-// Set custom path subcommand
-env
-  .command('set-path <path>')
-  .description('Set a custom path for the global environment file')
-  .option('-y, --yes', 'Automatically create directory and file if they do not exist')
-  .action(async (customPath: string, options: { yes?: boolean }) => {
-    try {
-      await setEnvPath(customPath, options.yes);
-    } catch (error) {
-      handleError(error);
-    }
-  });
-
 // Interactive mode
 env
   .command('interactive')
@@ -972,9 +719,7 @@ env.action(() => {
   console.log(colors.bold('\nEliza Environment Variable Manager'));
   console.log('\nAvailable commands:');
   console.log('  list                  List all environment variables');
-  console.log('  edit-global           Edit global environment variables');
   console.log('  edit-local            Edit local environment variables');
-  console.log('  set-path <path>       Set a custom path for the global environment file');
   console.log(
     '  reset                 Reset environment variables and clean up database/cache files (interactive selection)'
   );
@@ -1000,9 +745,7 @@ async function showMainMenu(yes = false): Promise<void> {
         message: 'Select an action:',
         choices: [
           { title: 'List environment variables', value: 'list' },
-          { title: 'Edit global environment variables', value: 'edit_global' },
           { title: 'Edit local environment variables', value: 'edit_local' },
-          { title: 'Set custom environment path', value: 'set_path' },
           { title: 'Reset environment variables', value: 'reset' },
           { title: 'Exit', value: 'exit' },
         ],
@@ -1017,29 +760,9 @@ async function showMainMenu(yes = false): Promise<void> {
       case 'list':
         await listEnvVars();
         break;
-      case 'edit_global': {
-        const returnToMainFromGlobal = await editEnvVars('global', true);
-        exit = !returnToMainFromGlobal;
-        break;
-      }
       case 'edit_local': {
         const returnToMainFromLocal = await editEnvVars('local', true);
         exit = !returnToMainFromLocal;
-        break;
-      }
-      case 'set_path': {
-        // Prompt for a path and use the existing setEnvPath function
-        const { path: customPath } = await prompts({
-          type: 'text',
-          name: 'path',
-          message: 'Enter custom path for global environment file:',
-          initial: await getGlobalEnvPath(), // Show current path as default
-        });
-
-        if (customPath) {
-          // Use the same implementation as the set-path command
-          await setEnvPath(customPath, yes);
-        }
         break;
       }
       case 'reset':

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -441,7 +441,7 @@ const startAgents = async (options: {
   port?: number;
   characters?: Character[];
 }) => {
-  // Load environment variables from project .env or .eliza/.env
+  // Load environment variables from project .env
   await loadEnvironment();
 
   // Configure database settings - pass reconfigure option to potentially force reconfiguration

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -72,20 +72,13 @@ const runAgentTests = async (options: {
     const homeDir = os.homedir();
     const elizaDir = path.join(homeDir, '.eliza');
     const elizaDbDir = path.join(elizaDir, 'db');
-    const envFilePath = path.join(elizaDir, '.env');
+    const envFilePath = path.join(process.cwd(), '.env');
 
     console.info('Setting up environment...');
     console.info(`Home directory: ${homeDir}`);
     console.info(`Eliza directory: ${elizaDir}`);
     console.info(`Database directory: ${elizaDbDir}`);
     console.info(`Environment file: ${envFilePath}`);
-
-    // Create .eliza directory if it doesn't exist
-    if (!fs.existsSync(elizaDir)) {
-      console.info(`Creating directory: ${elizaDir}`);
-      fs.mkdirSync(elizaDir, { recursive: true });
-      console.info(`Created directory: ${elizaDir}`);
-    }
 
     // Create db directory if it doesn't exist
     if (!fs.existsSync(elizaDbDir)) {
@@ -98,7 +91,7 @@ const runAgentTests = async (options: {
     process.env.PGLITE_DATA_DIR = elizaDbDir;
     console.info(`Using database directory: ${elizaDbDir}`);
 
-    // Load environment variables from .eliza/.env if it exists
+    // Load environment variables from project .env if it exists
     if (fs.existsSync(envFilePath)) {
       console.info(`Loading environment variables from: ${envFilePath}`);
       dotenv.config({ path: envFilePath });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,7 +29,7 @@ process.on('SIGTERM', () => process.exit(0));
  * @returns {Promise<void>}
  */
 async function main() {
-  // Load environment variables, trying project .env first, then global ~/.eliza/.env
+  // Load environment variables from the project .env file
   await loadEnvironment();
 
   // For ESM modules we need to use import.meta.url instead of __dirname

--- a/packages/cli/src/server/api/env.ts
+++ b/packages/cli/src/server/api/env.ts
@@ -1,6 +1,6 @@
 import { logger } from '@elizaos/core';
 import express from 'express';
-import { parseEnvFile, getGlobalEnvPath } from '@/src/commands/env';
+import { parseEnvFile } from '@/src/commands/env';
 import path from 'node:path';
 import { existsSync, writeFileSync } from 'fs';
 
@@ -92,64 +92,6 @@ export function envRouter(): express.Router {
     }
   });
 
-  router.get('/global', async (req, res) => {
-    try {
-      const globalEnvPath = await getGlobalEnvPath();
-      const globalEnvs = await parseEnvFile(globalEnvPath);
-
-      res.json({
-        success: true,
-        data: globalEnvs,
-      });
-    } catch (error) {
-      logger.error(`[ENVS GET] Error retrieving global envs`, error);
-      res.status(500).json({
-        success: false,
-        error: {
-          code: 'FETCH_ERROR',
-          message: 'Failed to retrieve global envs',
-          details: error.message,
-        },
-      });
-    }
-  });
-
-  router.post('/global', async (req, res) => {
-    try {
-      const { content } = req.body;
-
-      if (!content || typeof content !== 'object') {
-        res.status(400).json({
-          success: false,
-          error: {
-            code: 'INVALID_INPUT',
-            message: 'Missing or invalid "content" in request body',
-          },
-        });
-      }
-
-      const globalEnvPath = await getGlobalEnvPath();
-      if (!globalEnvPath) throw new Error('Global .env file not found');
-
-      const envString = serializeEnvObject(content);
-      writeFileSync(globalEnvPath, envString, 'utf-8');
-
-      res.json({
-        success: true,
-        message: 'Global env updated',
-      });
-    } catch (error) {
-      logger.error(`[ENVS POST] Error updating global envs`, error);
-      res.status(500).json({
-        success: false,
-        error: {
-          code: 'UPDATE_ERROR',
-          message: 'Failed to update global envs',
-          details: error.message,
-        },
-      });
-    }
-  });
 
   return router;
 }

--- a/packages/cli/src/utils/env-prompt.ts
+++ b/packages/cli/src/utils/env-prompt.ts
@@ -127,7 +127,7 @@ const ENV_VAR_CONFIGS: Record<string, EnvVarConfig[]> = {
 };
 
 /**
- * Retrieves the absolute path to the `.eliza/.env` environment file.
+ * Retrieves the absolute path to the `.env` environment file.
  *
  * @returns A promise that resolves to the full path of the environment file.
  */
@@ -137,7 +137,7 @@ export async function getEnvFilePath(): Promise<string> {
 }
 
 /**
- * Asynchronously reads environment variables from the `.eliza/.env` file and returns them as key-value pairs.
+ * Asynchronously reads environment variables from the `.env` file and returns them as key-value pairs.
  *
  * Ignores comments and empty lines. If the file does not exist or cannot be read, returns an empty object.
  *
@@ -178,7 +178,7 @@ export async function readEnvFile(): Promise<Record<string, string>> {
 }
 
 /**
- * Asynchronously writes the provided environment variables to the `.eliza/.env` file, creating the directory if it does not exist.
+ * Asynchronously writes the provided environment variables to the `.env` file, creating the directory if it does not exist.
  *
  * @param envVars - A record of environment variable key-value pairs to write.
  */

--- a/packages/cli/src/utils/get-config.ts
+++ b/packages/cli/src/utils/get-config.ts
@@ -54,7 +54,7 @@ export async function getElizaDirectories() {
 
   const elizaDir = path.join(homeDir, '.eliza');
   const elizaDbDir = path.join(process.cwd(), '.pglite/');
-  const envFilePath = path.join(elizaDir, '.env');
+  const envFilePath = path.join(process.cwd(), '.env');
 
   logger.debug('[Config] Using database directory:', elizaDbDir);
 
@@ -291,35 +291,14 @@ export async function resolveConfigPaths(cwd: string, config: RawConfig) {
 }
 
 /**
- * Load environment variables, trying project .env first, then global ~/.eliza/.env
- */
-/**
- * Loads environment variables from a project-specific or global `.env` file, creating the global file if neither exists.
+ * Load environment variables from the project `.env` file if it exists.
  *
- * If a `.env` file is present in the project directory, its variables are loaded. Otherwise, the function attempts to load from the global Eliza configuration. If neither file exists, a global `.env` file is created with a default comment.
- *
- * @param projectDir - The directory to search for a project-specific `.env` file. Defaults to the current working directory.
+ * @param projectDir - Directory containing the `.env` file. Defaults to the current working directory.
  */
 export async function loadEnvironment(projectDir: string = process.cwd()): Promise<void> {
   const projectEnvPath = path.join(projectDir, '.env');
-  const { elizaDir: globalEnvDir, envFilePath: globalEnvPath } = await getElizaDirectories();
 
-  // First try loading from project directory
   if (existsSync(projectEnvPath)) {
     dotenv.config({ path: projectEnvPath });
-    return;
   }
-
-  // If not found, try loading from global config
-  if (existsSync(globalEnvPath)) {
-    dotenv.config({ path: globalEnvPath });
-    return;
-  }
-
-  // Ensure global env directory and file exist
-  await ensureDir(globalEnvDir);
-  await ensureFile(globalEnvPath);
-  await fs.writeFile(globalEnvPath, '# Global environment variables for Eliza\n', {
-    encoding: 'utf8',
-  });
 }

--- a/packages/cli/src/utils/user-environment.ts
+++ b/packages/cli/src/utils/user-environment.ts
@@ -251,7 +251,7 @@ export class UserEnvironment {
 
     return {
       elizaDir,
-      envFilePath: path.join(elizaDir, '.env'),
+      envFilePath: path.join(process.cwd(), '.env'),
       configPath: path.join(elizaDir, 'config.json'),
       pluginsDir: path.join(elizaDir, 'plugins'),
       monorepoRoot,

--- a/packages/client/src/components/env-settings.tsx
+++ b/packages/client/src/components/env-settings.tsx
@@ -8,7 +8,6 @@ import { apiClient } from '@/lib/api';
 import { ApiKeyDialog } from './api-key-dialog';
 
 enum EnvType {
-  GLOBAL = 'global',
   LOCAL = 'local',
 }
 
@@ -19,10 +18,9 @@ export default function EnvSettings() {
   const [openIndex, setOpenIndex] = useState<number | null>(null);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
   const [editedValue, setEditedValue] = useState('');
-  const [globalEnvs, setGlobalEnvs] = useState<Record<string, string>>({});
   const [localEnvs, setLocalEnvs] = useState<Record<string, string>>({});
   const dropdownRef = useRef<HTMLDivElement>(null);
-  const [activeTab, setActiveTab] = useState(EnvType.GLOBAL);
+  const [activeTab, setActiveTab] = useState(EnvType.LOCAL);
   const [isUpdating, setIsUpdating] = useState(false);
   const [isApiKeyDialogOpen, setIsApiKeyDialogOpen] = useState(false);
 
@@ -40,14 +38,8 @@ export default function EnvSettings() {
   }, []);
 
   useEffect(() => {
-    fetchGlobalEnvs();
     fetchLocalEnvs();
   }, []);
-
-  const fetchGlobalEnvs = async () => {
-    const data = await apiClient.getGlobalEnvs();
-    setGlobalEnvs(data.data);
-  };
 
   const fetchLocalEnvs = async () => {
     const data = await apiClient.getLocalEnvs();
@@ -55,12 +47,7 @@ export default function EnvSettings() {
   };
 
   const handleReset = async () => {
-    if (activeTab === EnvType.GLOBAL) {
-      await fetchGlobalEnvs();
-    } else if (activeTab === EnvType.LOCAL) {
-      await fetchLocalEnvs();
-    }
-    // No other EnvType values exist as per the enum definition
+    await fetchLocalEnvs();
 
     setEditingIndex(null);
     setOpenIndex(null);
@@ -70,11 +57,6 @@ export default function EnvSettings() {
 
   const ENV_TABS_SCHEMA = [
     {
-      sectionTitle: 'Global Env',
-      sectionValue: EnvType.GLOBAL,
-      data: globalEnvs,
-    },
-    {
       sectionTitle: 'Local Env',
       sectionValue: EnvType.LOCAL,
       data: localEnvs,
@@ -83,14 +65,14 @@ export default function EnvSettings() {
 
   const handleEdit = (key: string) => {
     setEditingIndex(openIndex);
-    const envs = activeTab === EnvType.GLOBAL ? globalEnvs : localEnvs;
+    const envs = localEnvs;
     setEditedValue(envs[key]);
     setOpenIndex(null);
   };
 
   const handleRemove = (key: string) => {
-    const updateFn = activeTab === EnvType.GLOBAL ? setGlobalEnvs : setLocalEnvs;
-    const prevData = activeTab === EnvType.GLOBAL ? globalEnvs : localEnvs;
+    const updateFn = setLocalEnvs;
+    const prevData = localEnvs;
 
     const updatedData = { ...prevData };
     delete updatedData[key];
@@ -100,8 +82,8 @@ export default function EnvSettings() {
   };
 
   const saveEdit = (key: string) => {
-    const updateFn = activeTab === EnvType.GLOBAL ? setGlobalEnvs : setLocalEnvs;
-    const prevData = activeTab === EnvType.GLOBAL ? globalEnvs : localEnvs;
+    const updateFn = setLocalEnvs;
+    const prevData = localEnvs;
 
     updateFn({
       ...prevData,
@@ -114,8 +96,8 @@ export default function EnvSettings() {
   const addEnv = () => {
     if (!name || !value) return;
 
-    const updateFn = activeTab === EnvType.GLOBAL ? setGlobalEnvs : setLocalEnvs;
-    const prevData = activeTab === EnvType.GLOBAL ? globalEnvs : localEnvs;
+    const updateFn = setLocalEnvs;
+    const prevData = localEnvs;
 
     updateFn({
       ...prevData,
@@ -153,7 +135,7 @@ export default function EnvSettings() {
       </div>
 
       <Tabs
-        defaultValue="global"
+        defaultValue="local"
         className="w-full"
         value={activeTab}
         onValueChange={(val: any) => {
@@ -161,10 +143,7 @@ export default function EnvSettings() {
           setEditingIndex(null);
         }}
       >
-        <TabsList
-          className="grid w-full mb-6"
-          style={{ gridTemplateColumns: 'repeat(2, minmax(0, 1fr))' }}
-        >
+        <TabsList className="grid w-full mb-6" style={{ gridTemplateColumns: 'repeat(1, minmax(0, 1fr))' }}>
           {ENV_TABS_SCHEMA.map((section) => (
             <TabsTrigger key={section.sectionValue} value={section.sectionValue}>
               {section.sectionTitle}

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -559,22 +559,6 @@ export const apiClient = {
     });
   },
 
-  getGlobalEnvs: () => {
-    return fetcher({
-      url: `/envs/global`,
-      method: 'GET',
-    });
-  },
-
-  updateGlobalEnvs: (envs: Record<string, string>) => {
-    return fetcher({
-      url: `/envs/global`,
-      method: 'POST',
-      body: {
-        content: envs,
-      },
-    });
-  },
 
   // Agent Panels (public GET routes)
   getAgentPanels: (agentId: string): Promise<{ success: boolean; data: AgentPanel[] }> => {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -374,7 +374,7 @@ export class AgentRuntime implements IAgentRuntime {
             console.warn(
               'Please check your environment variables and ensure all required API keys are set.'
             );
-            console.warn('You can set these in your .eliza/.env file.');
+            console.warn('You can set these in your .env file.');
             span.addEvent('plugin_configuration_warning');
             // We don't throw here, allowing the application to continue
             // with reduced functionality

--- a/packages/docs/blog/twitter-agent-guide.mdx
+++ b/packages/docs/blog/twitter-agent-guide.mdx
@@ -58,14 +58,14 @@ Open the ElizaOS environment configuration file in a text editor:
 
 ```bash
 # Recommended: Use Cursor (https://cursor.sh)
-# Open Cursor, navigate to File > Open, and select the .env file:
-# - Windows: C:\Users\YOUR_USERNAME\.eliza\.env
-# - Mac/Linux: ~/.eliza/.env
+# Open Cursor, navigate to File > Open, and select your project's .env file:
+# - Windows: C:\path\to\your\project\.env
+# - Mac/Linux: ./path/to/your/project/.env
 
 # Alternative editors:
-# Windows: notepad C:\Users\YOUR_USERNAME\.eliza\.env
-# Mac: open -a TextEdit ~/.eliza/.env
-# Linux: gedit ~/.eliza/.env
+# Windows: notepad C:\path\to\your\project\.env
+# Mac: open -a TextEdit ./path/to/your/project/.env
+# Linux: gedit ./path/to/your/project/.env
 ```
 
 Add the following lines to the `.env` file, replacing placeholder values with your actual credentials and desired settings:

--- a/packages/docs/docs/cli/env.md
+++ b/packages/docs/docs/cli/env.md
@@ -20,22 +20,15 @@ elizaos env [command] [options]
 
 | Subcommand        | Description                                                   | Options                           |
 | ----------------- | ------------------------------------------------------------- | --------------------------------- |
-| `list`            | List all environment variables                                | `--system`, `--global`, `--local` |
-| `edit-global`     | Edit global environment variables                             | `-y, --yes`                       |
+| `list`            | List all environment variables                                | `--system`, `--local` |
 | `edit-local`      | Edit local environment variables                              | `-y, --yes`                       |
 | `reset`           | Reset environment variables and clean up database/cache files | `-y, --yes`                       |
-| `set-path <path>` | Set a custom path for the global environment file             | `-y, --yes`                       |
 | `interactive`     | Start interactive environment variable manager                | `-y, --yes`                       |
 
 ## Environment Levels
 
 ElizaOS maintains two levels of environment variables:
-
-1. **Global variables** - Stored in `~/.eliza/.env` by default or in a custom location if set
-2. **Local variables** - Stored in `.env` in your current project directory
-
-Global variables are applied to all projects, while local variables are specific to the current project.
-
+1. **Local variables** - Stored in `.env` in your current project directory
 ## Interactive Mode
 
 The interactive mode provides a user-friendly way to manage environment variables:
@@ -65,7 +58,6 @@ elizaos env list
 This will display:
 
 - System information (OS, architecture, CLI version, etc.)
-- Global environment variables from `~/.eliza/.env` or your custom path
 - Local environment variables from `./.env` in your current directory
 
 If no local `.env` file exists, the command will display a warning and instructions for creating one. This helps you quickly see if your project is missing required configuration.
@@ -83,7 +75,6 @@ elizaos env list --local   # Show only local environment variables
 Edit the global environment variables interactively:
 
 ```bash
-elizaos env edit-global
 ```
 
 This provides an interactive interface to:
@@ -108,7 +99,6 @@ If no local `.env` file exists, you will be prompted to create one. The editor w
 Set a custom location for the global environment file:
 
 ```bash
-elizaos env set-path /path/to/custom/location
 ```
 
 If the specified path is a directory, the command will use `/path/to/custom/location/.env`.
@@ -127,7 +117,6 @@ elizaos env reset
 
 This command provides an interactive selection interface where you can choose which items to reset:
 
-- **Global environment variables** - Clears values in global `.env` file while preserving keys
 - **Local environment variables** - Clears values in local `.env` file while preserving keys
 - **Cache folder** - Deletes the cache folder
 - **Global database files** - Deletes global database files (including PGLite data)
@@ -195,7 +184,6 @@ System Information:
   CLI Version: 1.0.0-beta.51
   Package Manager: bun v1.2.5
 
-Global environment variables (.eliza/.env):
   OPENAI_API_KEY: sk-1234...5678
   MODEL_PROVIDER: openai
 
@@ -217,7 +205,6 @@ Path: /current/directory/.env
 
 ```bash
 # Set a custom path for global environment variables
-elizaos env set-path ~/projects/eliza-config/.env
 ```
 
 ### Interactive Editing
@@ -227,7 +214,6 @@ elizaos env set-path ~/projects/eliza-config/.env
 elizaos env interactive
 
 # Edit only global variables
-elizaos env edit-global
 
 # Edit only local variables
 elizaos env edit-local
@@ -247,13 +233,11 @@ Example reset output:
 
 ```
 The following items will be reset:
-  • Global environment variables
   • Local environment variables
   • Cache folder
 
 Reset Summary:
   Values Cleared:
-    • Global environment variables
     • Local environment variables
   Deleted:
     • Cache folder

--- a/packages/plugin-discord/src/index.ts
+++ b/packages/plugin-discord/src/index.ts
@@ -25,7 +25,7 @@ const discordPlugin: Plugin = {
         'Discord API Token not provided - Discord plugin is loaded but will not be functional'
       );
       logger.warn(
-        'To enable Discord functionality, please provide DISCORD_API_TOKEN in your .eliza/.env file'
+        'To enable Discord functionality, please provide DISCORD_API_TOKEN in your .env file'
       );
     }
   },


### PR DESCRIPTION
## Summary
- drop global env logic from CLI and server
- update UI to only manage local envs
- rewrite docs about environment variables
- tweak plugin messages and runtime warnings

## Testing
- `bun test` *(fails: Cannot find package 'dotenv' etc.)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Environment variable management is now streamlined to use only the local project’s .env file.
- **Bug Fixes**
	- Removed all options, commands, and UI related to global environment variables to prevent confusion.
- **Documentation**
	- Updated all guides, CLI help, and in-app instructions to reference only the local .env file.
- **Refactor**
	- Simplified environment settings UI and API by removing global environment support.
- **Style**
	- Clarified warning messages and comments to reference the local .env file only.
- **Tests**
	- Updated test cases to reflect the removal of global environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->