### PR TITLE
Add Windows support to CLI tests

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -11,7 +11,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -29,9 +33,11 @@ jobs:
 
       - name: Mention Bun version
         run: bun --version
+        shell: bash
 
       - name: Install dependencies
         run: bun install
+        shell: bash
 
       - name: Setup Turbo Cache
         uses: actions/cache@v3
@@ -43,12 +49,15 @@ jobs:
 
       - name: Build all packages
         run: bun turbo run build --filter=!@elizaos/docs
+        shell: bash
 
       - name: Install bats (npm)
         run: npm install -g bats
+        shell: bash
 
       - name: Clean eliza projects cache
         run: rm -rf ~/.eliza/projects
+        shell: bash
 
       - name: Download models
         run: |
@@ -79,10 +88,13 @@ jobs:
               echo "$name already exists, skipping."
             fi
           done
+        shell: bash
 
       - name: Make test scripts executable
         run: chmod +x packages/cli/__test_scripts__/*.bats packages/cli/__test_scripts__/*.sh
+        shell: bash
 
       - name: Run CLI shell tests
         run: ./run_all_bats.sh
         working-directory: packages/cli/__test_scripts__
+        shell: bash


### PR DESCRIPTION
## Summary
- run CLI tests on windows-latest in addition to ubuntu
- ensure bash shell is used on Windows

## Testing
- `bun run test` *(fails: turbo: command not found)*