### PR TITLE
fix: use pglite in target dir with create command or inline env

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -416,7 +416,7 @@ export const create = new Command()
         await getElizaDirectories();
 
         if (database === 'pglite') {
-          const projectPgliteDbDir = path.join(targetDir, '.pglite');
+          const projectPgliteDbDir = process.env.PGLITE_DATA_DIR ?? path.join(targetDir, '.pglite');
           await setupPgLite(projectPgliteDbDir, projectEnvFilePath);
           console.debug(
             `PGLite database will be stored in project directory: ${projectPgliteDbDir}`

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -410,14 +410,20 @@ export const create = new Command()
 
         await createIgnoreFiles(targetDir);
 
-        const { elizaDbDir, envFilePath } = await getElizaDirectories();
+        // Define project-specific .env file path, this will be created if it doesn't exist by downstream functions.
+        const projectEnvFilePath = path.join(targetDir, '.env');
+
+        await getElizaDirectories();
+
         if (database === 'pglite') {
-          await setupPgLite(process.env.PGLITE_DATA_DIR || elizaDbDir, envFilePath);
+          const projectPgliteDbDir = path.join(targetDir, '.pglite');
+          await setupPgLite(projectPgliteDbDir, projectEnvFilePath);
           console.debug(
-            `Using PGLite database directory: ${process.env.PGLITE_DATA_DIR || elizaDbDir}`
+            `PGLite database will be stored in project directory: ${projectPgliteDbDir}`
           );
         } else if (database === 'postgres' && !postgresUrl) {
-          postgresUrl = await promptAndStorePostgresUrl(envFilePath);
+          // Store Postgres URL in the project's .env file.
+          postgresUrl = await promptAndStorePostgresUrl(projectEnvFilePath);
         }
 
         const srcDir = path.join(targetDir, 'src');

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -429,7 +429,7 @@ const startAgents = async (options: {
   const postgresUrl = await configureDatabaseSettings(options.configure);
 
   // Get PGLite data directory from environment (may have been set during configuration)
-  const pgliteDataDir = process.env.PGLITE_DATA_DIR;
+  const pgliteDataDir = process.env.PGLITE_DATA_DIR ?? path.join(process.cwd(), '.pglite');
 
   // Load existing configuration
   const existingConfig = await loadConfig();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Environment and database configuration files are now stored within the project directory, ensuring localized setup for each project.
  - The database directory for PGLite will default to a project-specific location if not specified in the environment.
  - Debug messages updated to reflect the new directory structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->