### PR TITLE
fix: use findNearestEnvFile(), etc to lookup github creds, before was…

### DIFF
--- a/packages/cli/src/utils/publisher.ts
+++ b/packages/cli/src/utils/publisher.ts
@@ -10,6 +10,7 @@ import {
   forkExists,
   forkRepository,
   getFileContent,
+  getGitHubCredentials,
   updateFile,
   ensureDirectory,
   createGitHubRepository,
@@ -123,13 +124,14 @@ export async function testPublishToGitHub(
   username: string
 ): Promise<boolean> {
   try {
-    // Check GitHub token
-    const token = await getGitHubToken();
-    if (!token) {
-      logger.error('GitHub token not found');
+    // Get GitHub credentials using getGitHubCredentials which will prompt if needed
+    const credentials = await getGitHubCredentials();
+    if (!credentials) {
+      logger.error('Failed to get GitHub credentials');
       return false;
     }
-    logger.info('✓ GitHub token found');
+    const token = credentials.token;
+    logger.info('✓ GitHub credentials found');
 
     // Validate token permissions
     const response = await fetch('https://api.github.com/user', {
@@ -275,11 +277,13 @@ export async function publishToGitHub(
   skipRegistry = false,
   isTest = false
 ): Promise<boolean | { success: boolean; prUrl?: string }> {
-  const token = await getGitHubToken();
-  if (!token) {
-    logger.error('GitHub token not found. Please set it using the login command.');
+  // Get GitHub credentials using getGitHubCredentials which will prompt if needed
+  const credentials = await getGitHubCredentials();
+  if (!credentials) {
+    logger.error('Failed to get GitHub credentials');
     return false;
   }
+  const token = credentials.token;
 
   // Validate required package type
   if (!packageJson.packageType) {

--- a/packages/plugin-starter/.gitignore
+++ b/packages/plugin-starter/.gitignore
@@ -1,2 +1,3 @@
 dist/
 node_modules/
+.env


### PR DESCRIPTION
elizaos publish -t was failing with:

✔ Enter your GitHub username: … yungalgo
✔ Enter your GitHub Personal Access Token (with repo, read:org, and workflow scopes): … ****************************************
[2025-05-22 03:52:59] WARN: Missing environment variables: GITHUB_TOKEN
Failed to validate credentials after saving.

upon looking into it, i realized that it was just hardcoded-looking for .env in global location only instead of employing the start-local-go-global .env lookup approach employed in env-utils.ts. so i made it look for .env in that way.