### PR TITLE
add .env to plugin-starter's .gitignore file (publishing was failing due to key presence)

### DIFF
--- a/packages/plugin-starter/.gitignore
+++ b/packages/plugin-starter/.gitignore
@@ -1,2 +1,3 @@
 dist/
 node_modules/
+.env


### PR DESCRIPTION
**Problem**

When publishing plugins to GitHub using elizaos publish, the CLI was accidentally including .env files in the initial commit. These files often contain sensitive GitHub credentials, leading to GitHub's push protection blocking the commits due to exposed tokens. This used to not occur because the .env was global (outside the repo getting pushed to gh)

**Solution**

Added .env to the default .gitignore file in the packages/plugin-starter template to ensure that:
New plugins created from this template automatically ignore environment files
GitHub tokens and other sensitive credentials are prevented from being committed
GitHub push protection doesn't block plugin publishing

This small but critical fix improves the developer experience because plugin publishing fails without it.