### PR TITLE
fix: filter for :user in client chat ignores

### DIFF
--- a/packages/plugin-bootstrap/src/index.ts
+++ b/packages/plugin-bootstrap/src/index.ts
@@ -249,7 +249,7 @@ const messageReceivedHandler = async ({
           room?.type === ChannelType.VOICE_DM ||
           room?.type === ChannelType.SELF ||
           room?.type === ChannelType.API ||
-          room?.source === 'client_chat';
+          room?.source.includes('client_chat');
 
         logger.debug(
           `[Bootstrap] Skipping shouldRespond check for ${runtime.character.name} because ${room?.type} ${room?.source}`


### PR DESCRIPTION
`content: { text: 'hello', source: 'client_chat:user' }`

Ignore was not being respected because client_chat gets `:user` appended to the string in CLI server handleSocket code.

This parses everything instead with includes.

