### PR TITLE
fix: CLI update, use beta versions if exact is not found

### DIFF
--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -301,17 +301,19 @@ async function updateDependencies(
 
     console.info(`Updating ${packagesNeedingUpdate.length} package(s)...`);
 
+    const isCLIBeta = latestCliVersion.includes('beta');
+    const packageTag = isCLIBeta ? 'beta' : 'latest';
+
     // Update each package to the latest CLI version
     for (const pkg of packagesNeedingUpdate) {
       try {
         console.info(`Updating ${pkg.name} to version ${latestCliVersion}...`);
         await runBunCommand(['add', `${pkg.name}@${latestCliVersion}`], cwd);
       } catch (error) {
-        console.error(`Failed to update ${pkg.name}: ${error.message}`);
-        console.info('Trying to use exact version match...');
+        console.error(`Failed to update ${pkg.name}@${latestCliVersion}: ${error.message}`);
         try {
           // If the specific version isn't available, try to find the closest version
-          await runBunCommand(['add', pkg.name], cwd);
+          await runBunCommand(['add', `${pkg.name}@${packageTag}`], cwd);
         } catch (secondError) {
           console.error(`Failed to install ${pkg.name} after retrying: ${secondError.message}`);
         }


### PR DESCRIPTION
```
elizaos update: looking for same match of versions on plugins that don't exist, we need to not hardcode versions, use latest:,
error: No version matching "1.0.0-beta.59" found for specifier "@elizaos/plugin-local-ai" (but package exists)
error: @elizaos/plugin-local-ai@1.0.0-beta.59 failed to resolve
then it tries v0 download on v1:
Trying to use exact version match...
[0.05ms] ".env"
bun add v1.2.13 (64ed68c9)

installed @elizaos/plugin-local-ai@0.25.6-alpha.1
```

When it fails to find exact version on package update, it defaults to v0 latest branches, which is wrong. This now uses `beta` for npm tag.