### PR TITLE
fix: CLI update, use beta versions if exact is not found

### DIFF
--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -336,6 +336,7 @@ async function updateDependencies(
     }
   } catch (error) {
     console.error(`Error updating dependencies: ${error.message}`);
+    throw error; // Rethrow the error to be handled by the caller
   }
 }
 


### PR DESCRIPTION
```
Error updating dependencies: Could not determine how to build the project
Project successfully updated to the latest ElizaOS packages
```

If deps install fails, we were still saying Success, because the try-catch scoping was not being thrown.