### PR TITLE
Add bootstrap e2e tests and docs

### DIFF
--- a/packages/docs/docs/core/testing.md
+++ b/packages/docs/docs/core/testing.md
@@ -1,0 +1,74 @@
+---
+sidebar_position: 12
+title: Testing Providers, Actions & Evaluators
+description: Learn how to write component and end-to-end tests for ElizaOS primitives
+keywords: [testing, providers, actions, evaluators, vitest, e2e]
+image: /img/cli.jpg
+---
+
+# 🧪 Testing Core Primitives
+
+ElizaOS encourages thorough testing of providers, actions and evaluators. Component tests use **Vitest**, while scenario tests run through the ElizaOS runtime.
+
+## Component Tests
+
+For unit style tests, import helpers from the bootstrap plugin test utilities
+and call the primitive directly.
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { timeProvider } from '@elizaos/plugin-bootstrap';
+import {
+  createMockRuntime,
+  createMockMemory,
+} from '@elizaos/plugin-bootstrap/__tests__/test-utils';
+
+describe('time provider', () => {
+  it('returns a time string', async () => {
+    const runtime = createMockRuntime();
+    const msg = createMockMemory();
+    const result = await timeProvider.get(runtime as any, msg as any);
+    expect(result.values.time).toBeDefined();
+  });
+});
+```
+
+## End-to-End Tests
+
+Scenario tests use a `TestSuite` loaded by the CLI `test` command. Each test
+receives a running `IAgentRuntime` instance.
+
+```ts
+import type { TestSuite } from '@elizaos/core';
+import { bootstrapPlugin } from '@elizaos/plugin-bootstrap';
+
+export class BootstrapSuite implements TestSuite {
+  name = 'bootstrap_example';
+  tests = [
+    {
+      name: 'reply action works',
+      fn: async (runtime) => {
+        const action = runtime.actions.find((a) => a.name === 'REPLY');
+        if (!action) throw new Error('action missing');
+        await action.handler(
+          runtime,
+          { content: { text: 'hi' } } as any,
+          { values: {} } as any,
+          {},
+          () => {}
+        );
+      },
+    },
+  ];
+}
+export default new BootstrapSuite();
+```
+
+Run all tests with:
+
+```bash
+elizaos test
+```
+
+Component and e2e tests can be filtered using `--name` and built beforehand with
+`bun run build`.

--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -109,6 +109,11 @@ const sidebars: SidebarsConfig = {
           id: 'core/worlds',
           label: 'Worlds',
         },
+        {
+          type: 'doc',
+          id: 'core/testing',
+          label: 'Testing',
+        },
       ],
     },
     {

--- a/packages/plugin-bootstrap/e2e/bootstrap-plugin.test.ts
+++ b/packages/plugin-bootstrap/e2e/bootstrap-plugin.test.ts
@@ -1,0 +1,112 @@
+import { bootstrapPlugin } from '../src/index';
+import {
+  createMockRuntime,
+  createMockMemory,
+  createMockState,
+  setupActionTest,
+} from '../__tests__/test-utils';
+import type { TestSuite } from '@elizaos/core';
+
+export class BootstrapPluginTestSuite implements TestSuite {
+  name = 'bootstrap_plugin_e2e';
+  description = 'E2E tests for bootstrap plugin primitives';
+
+  tests = [
+    {
+      name: 'loads expected primitives',
+      fn: async () => {
+        const expectedActions = [
+          'REPLY',
+          'FOLLOW_ROOM',
+          'UNFOLLOW_ROOM',
+          'IGNORE',
+          'NONE',
+          'MUTE_ROOM',
+          'UNMUTE_ROOM',
+          'SEND_MESSAGE',
+          'UPDATE_ENTITY',
+          'CHOOSE_OPTION',
+          'UPDATE_ROLE',
+          'UPDATE_SETTINGS',
+        ];
+        for (const name of expectedActions) {
+          if (!bootstrapPlugin.actions?.some((a) => a.name === name)) {
+            throw new Error(`Missing action ${name}`);
+          }
+        }
+
+        const expectedProviders = [
+          'EVALUATORS',
+          'ANXIETY',
+          'TIME',
+          'ENTITIES',
+          'RELATIONSHIPS',
+          'CHOICE',
+          'FACTS',
+          'ROLES',
+          'SETTINGS',
+          'CAPABILITIES',
+          'ATTACHMENTS',
+          'PROVIDERS',
+          'ACTIONS',
+          'CHARACTER',
+          'RECENT_MESSAGES',
+          'WORLD',
+          'SHOULD_RESPOND',
+        ];
+        for (const name of expectedProviders) {
+          if (!bootstrapPlugin.providers?.some((p) => p.name === name)) {
+            throw new Error(`Missing provider ${name}`);
+          }
+        }
+
+        if (!bootstrapPlugin.evaluators?.some((e) => e.name === 'REFLECTION')) {
+          throw new Error('Reflection evaluator missing');
+        }
+      },
+    },
+    {
+      name: 'time provider returns time text',
+      fn: async () => {
+        const runtime = createMockRuntime();
+        const message = createMockMemory();
+        const provider = bootstrapPlugin.providers?.find((p) => p.name === 'TIME');
+        if (!provider) throw new Error('TIME provider not found');
+        const result = await provider.get(runtime as any, message as any, {} as any);
+        if (!result.text) {
+          throw new Error('TIME provider returned empty text');
+        }
+      },
+    },
+    {
+      name: 'reply action produces a response',
+      fn: async () => {
+        const { mockRuntime, mockMessage, mockState, callbackFn } = setupActionTest();
+        const action = bootstrapPlugin.actions?.find((a) => a.name === 'REPLY');
+        if (!action) throw new Error('REPLY action not found');
+        await action.handler(
+          mockRuntime as any,
+          mockMessage as any,
+          mockState as any,
+          {},
+          callbackFn,
+          []
+        );
+        if (!callbackFn.mock.calls.length) {
+          throw new Error('Reply action did not invoke callback');
+        }
+      },
+    },
+    {
+      name: 'reflection evaluator runs',
+      fn: async () => {
+        const evaluator = bootstrapPlugin.evaluators?.find((e) => e.name === 'REFLECTION');
+        if (!evaluator) throw new Error('Reflection evaluator not found');
+        const { mockRuntime, mockMessage, mockState } = setupActionTest();
+        await evaluator.handler(mockRuntime as any, mockMessage as any, mockState as any);
+      },
+    },
+  ];
+}
+
+export default new BootstrapPluginTestSuite();

--- a/packages/plugin-bootstrap/vitest.config.ts
+++ b/packages/plugin-bootstrap/vitest.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
+    exclude: ['**/e2e/**', '**/dist/**', '**/node_modules/**'],
     coverage: {
       reporter: ['text', 'json', 'html'],
     },


### PR DESCRIPTION
## Summary
- add e2e TestSuite for bootstrap plugin
- document how to test providers, actions and evaluators
- link testing doc in sidebar
- ignore e2e folder in plugin-bootstrap vitest config
- tidy wording in testing docs

## Testing
- `bun run test`
- `node packages/cli/dist/index.js test e2e --name bootstrap_plugin_e2e --skip-build` *(fails: attempts to install plugins without network)*