### PR TITLE
feat: Add graph view for memories and knowledge

### DIFF
--- a/packages/cli/src/server/api/agent.ts
+++ b/packages/cli/src/server/api/agent.ts
@@ -1729,6 +1729,7 @@ export function agentRouter(
         ? Number.parseInt(req.query.before as string, 10)
         : Date.now();
       const _worldId = req.query.worldId as string;
+      const includeEmbedding = req.query.includeEmbedding === 'true';
 
       const memories = await runtime.getMemories({
         tableName: 'messages',
@@ -1737,12 +1738,12 @@ export function agentRouter(
         end: before,
       });
 
-      const cleanMemories = memories.map((memory) => {
-        return {
-          ...memory,
-          embedding: undefined,
-        };
-      });
+      const cleanMemories = includeEmbedding
+        ? memories
+        : memories.map((memory) => ({
+            ...memory,
+            embedding: undefined,
+          }));
 
       res.json({
         success: true,
@@ -1794,18 +1795,19 @@ export function agentRouter(
 
     // Get tableName from query params, default to "messages"
     const tableName = (req.query.tableName as string) || 'messages';
+    const includeEmbedding = req.query.includeEmbedding === 'true';
 
     const memories = await runtime.getMemories({
       agentId,
       tableName,
     });
 
-    const cleanMemories = memories.map((memory) => {
-      return {
-        ...memory,
-        embedding: undefined,
-      };
-    });
+    const cleanMemories = includeEmbedding
+      ? memories
+      : memories.map((memory) => ({
+          ...memory,
+          embedding: undefined,
+        }));
 
     res.json({
       success: true,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -63,6 +63,7 @@
     "socket.io-client": "^4.8.1",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "react-force-graph": "^1.51.0",
     "vite-plugin-compression": "^0.5.1",
     "vite-plugin-node-polyfills": "^0.23.0"
   },

--- a/packages/client/src/components/memory-graph.tsx
+++ b/packages/client/src/components/memory-graph.tsx
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import ForceGraph2D from 'react-force-graph-2d';
+import type { Memory } from '@elizaos/core';
+import { computePca } from '@/lib/pca';
+
+export default function MemoryGraph({
+  memories,
+  onSelect,
+}: {
+  memories: Memory[];
+  onSelect: (m: Memory) => void;
+}) {
+  const data = useMemo(() => {
+    const embeddings = memories
+      .map((m) => m.embedding)
+      .filter((e): e is number[] => Array.isArray(e));
+    if (embeddings.length === 0) return { nodes: [], links: [] };
+    const coords = computePca(embeddings, 2);
+    const nodes = memories.map((m, i) => ({
+      id: m.id || String(i),
+      memory: m,
+      fx: coords[i][0],
+      fy: coords[i][1],
+    }));
+    return { nodes, links: [] };
+  }, [memories]);
+
+  return (
+    <ForceGraph2D
+      graphData={data}
+      nodeLabel={(node) =>
+        (node as any).memory?.metadata?.title ||
+        (node as any).memory?.content?.text ||
+        (node as any).id
+      }
+      onNodeClick={(node) => onSelect((node as any).memory)}
+    />
+  );
+}

--- a/packages/client/src/hooks/use-query-hooks.ts
+++ b/packages/client/src/hooks/use-query-hooks.ts
@@ -573,15 +573,20 @@ export function useDeleteLog() {
 /**
  * Fetches memories for a specific agent, optionally filtered by room
  */
-export function useAgentMemories(agentId: UUID, tableName?: string, roomId?: UUID) {
+export function useAgentMemories(
+  agentId: UUID,
+  tableName?: string,
+  roomId?: UUID,
+  includeEmbedding = false
+) {
   const queryKey = roomId
-    ? ['agents', agentId, 'rooms', roomId, 'memories', tableName]
-    : ['agents', agentId, 'memories', tableName];
+    ? ['agents', agentId, 'rooms', roomId, 'memories', tableName, includeEmbedding]
+    : ['agents', agentId, 'memories', tableName, includeEmbedding];
 
   return useQuery({
     queryKey,
     queryFn: async () => {
-      const result = await apiClient.getAgentMemories(agentId, roomId, tableName);
+      const result = await apiClient.getAgentMemories(agentId, roomId, tableName, includeEmbedding);
       return result.data || [];
     },
     staleTime: 1000,

--- a/packages/client/src/lib/api.ts
+++ b/packages/client/src/lib/api.ts
@@ -500,12 +500,18 @@ export const apiClient = {
   },
 
   // Method to get all memories for an agent, optionally filtered by room
-  getAgentMemories: (agentId: UUID, roomId?: UUID, tableName?: string) => {
+  getAgentMemories: (
+    agentId: UUID,
+    roomId?: UUID,
+    tableName?: string,
+    includeEmbedding = false
+  ) => {
     const params = new URLSearchParams();
     if (tableName) params.append('tableName', tableName);
+    if (includeEmbedding) params.append('includeEmbedding', 'true');
 
     const url = roomId
-      ? `/agents/${agentId}/rooms/${roomId}/memories`
+      ? `/agents/${agentId}/rooms/${roomId}/memories?${params.toString()}`
       : `/agents/${agentId}/memories${params.toString() ? `?${params.toString()}` : ''}`;
 
     return fetcher({

--- a/packages/client/src/lib/pca.test.ts
+++ b/packages/client/src/lib/pca.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { computePca } from './pca';
+
+describe('computePca', () => {
+  it('projects 3D vectors to 2D deterministically', () => {
+    const data = [
+      [1, 0, 0],
+      [0, 1, 0],
+      [0, 0, 1],
+    ];
+    const result = computePca(data, 2);
+    expect(result.length).toBe(3);
+    // first vector should have positive coordinates
+    expect(result[0][0]).toBeGreaterThan(0);
+    expect(result[0][1]).toBeDefined();
+  });
+});

--- a/packages/client/src/lib/pca.ts
+++ b/packages/client/src/lib/pca.ts
@@ -1,0 +1,52 @@
+export function computePca(data: number[][], dims = 2): number[][] {
+  if (data.length === 0) return [];
+  const dim = data[0].length;
+  const mean = Array(dim).fill(0);
+  for (const vec of data) {
+    for (let i = 0; i < dim; i++) mean[i] += vec[i];
+  }
+  for (let i = 0; i < dim; i++) mean[i] /= data.length;
+  const centered = data.map((v) => v.map((val, idx) => val - mean[idx]));
+  // covariance matrix
+  const cov = Array.from({ length: dim }, () => Array(dim).fill(0));
+  for (const vec of centered) {
+    for (let i = 0; i < dim; i++) {
+      for (let j = 0; j < dim; j++) {
+        cov[i][j] += vec[i] * vec[j];
+      }
+    }
+  }
+  for (let i = 0; i < dim; i++) {
+    for (let j = 0; j < dim; j++) {
+      cov[i][j] /= data.length - 1;
+    }
+  }
+  const eigenvectors: number[][] = [];
+  let matrix = cov.map((row) => row.slice());
+  for (let k = 0; k < dims; k++) {
+    // start with a deterministic unit vector for stability
+    let vec = Array(dim).fill(1 / Math.sqrt(dim));
+    for (let iter = 0; iter < 50; iter++) {
+      const next = multiplyMatrixVector(matrix, vec);
+      const norm = Math.sqrt(next.reduce((a, b) => a + b * b, 0));
+      if (norm === 0) break;
+      vec = next.map((v) => v / norm);
+    }
+    eigenvectors.push(vec.slice());
+    const lambda = dot(vec, multiplyMatrixVector(matrix, vec));
+    for (let i = 0; i < dim; i++) {
+      for (let j = 0; j < dim; j++) {
+        matrix[i][j] -= lambda * vec[i] * vec[j];
+      }
+    }
+  }
+  return centered.map((vec) => eigenvectors.map((ev) => dot(vec, ev)));
+}
+
+function multiplyMatrixVector(mat: number[][], vec: number[]): number[] {
+  return mat.map((row) => row.reduce((sum, val, i) => sum + val * vec[i], 0));
+}
+
+function dot(a: number[], b: number[]): number {
+  return a.reduce((sum, val, i) => sum + val * b[i], 0);
+}


### PR DESCRIPTION
## Summary
- expose embeddings via API with `includeEmbedding` flag
- add PCA implementation and simple force graph
- integrate graph toggle for memory and knowledge views
- add unit test for PCA

## Testing
- `bun test` *(fails: vi.resetAllMocks is not a function)*