### PR TITLE
Add supplemental unit tests for core utilities

### DIFF
--- a/packages/core/__tests__/entities-extra.test.ts
+++ b/packages/core/__tests__/entities-extra.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { createUniqueUuid, formatEntities } from '../src/entities';
+import { stringToUuid } from '../src';
+
+describe('entities extra', () => {
+  it('createUniqueUuid combines user and agent ids', () => {
+    const runtime = { agentId: 'agent' } as any;
+    const id = createUniqueUuid(runtime, 'user');
+    const expected = stringToUuid('user:agent');
+    expect(id).toBe(expected);
+  });
+
+  it('formatEntities outputs joined string', () => {
+    const entities = [
+      { id: '1', names: ['A'], metadata: {} },
+      { id: '2', names: ['B'], metadata: { extra: true } },
+    ] as any;
+    const text = formatEntities({ entities });
+    expect(text).toContain('"A"');
+    expect(text).toContain('ID: 1');
+    expect(text).toContain('ID: 2');
+  });
+});

--- a/packages/core/__tests__/instrumentation-index.test.ts
+++ b/packages/core/__tests__/instrumentation-index.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import * as instrumentation from '../src/instrumentation';
+
+describe('instrumentation index exports', () => {
+  it('exports service', () => {
+    expect(instrumentation.InstrumentationService).toBeDefined();
+  });
+});

--- a/packages/core/__tests__/instrumentation.test.ts
+++ b/packages/core/__tests__/instrumentation.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { InstrumentationService } from '../src/instrumentation/service';
+
+describe('InstrumentationService', () => {
+  it('initializes and can flush and stop', async () => {
+    const svc = new InstrumentationService({ enabled: true, serviceName: 'test' });
+    expect(svc.isEnabled()).toBe(true);
+    await svc.flush();
+    await svc.stop();
+    expect(svc.isEnabled()).toBe(false);
+  });
+
+  it('disabled service reports disabled', () => {
+    const svc = new InstrumentationService({ enabled: false, serviceName: 'x' });
+    expect(svc.isEnabled()).toBe(false);
+  });
+});

--- a/packages/core/__tests__/roles.test.ts
+++ b/packages/core/__tests__/roles.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { getUserServerRole, findWorldsForOwner } from '../src/roles';
+import { Role } from '../src/types';
+
+describe('roles utilities', () => {
+  const runtime = {
+    getWorld: async (id: string) => ({ id, metadata: { roles: { user: Role.ADMIN } } }),
+    getAllWorlds: async () => [
+      { metadata: { ownership: { ownerId: 'owner1' } } },
+      { metadata: { ownership: { ownerId: 'other' } } },
+    ],
+  } as any;
+
+  it('getUserServerRole returns role from world metadata', async () => {
+    const role = await getUserServerRole(runtime, 'user', 'server');
+    expect(role).toBe(Role.ADMIN);
+  });
+
+  it('findWorldsForOwner finds owned worlds', async () => {
+    const worlds = await findWorldsForOwner(runtime, 'owner1');
+    expect(worlds?.length).toBe(1);
+  });
+});

--- a/packages/core/__tests__/search.test.ts
+++ b/packages/core/__tests__/search.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest';
+import { BM25 } from '../src/search';
+
+describe('BM25 search', () => {
+  it('indexes documents and finds matches', () => {
+    const docs = [
+      { text: 'hello world' },
+      { text: 'another document' },
+      { text: 'world of javascript' },
+    ];
+    const bm = new BM25(docs, { fieldBoosts: { text: 1 } });
+    const results = bm.search('world');
+    expect(results[0].index).toBe(0);
+  });
+});

--- a/packages/core/__tests__/services.test.ts
+++ b/packages/core/__tests__/services.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { createService, defineService } from '../src/services';
+import { Service } from '../src/types';
+
+describe('service builder', () => {
+  it('createService builds custom class', async () => {
+    const Builder = createService('TEST')
+      .withDescription('d')
+      .withStart(
+        async () =>
+          new (class extends Service {
+            async stop() {}
+          })()
+      )
+      .build();
+    const instance = await Builder.start({} as any);
+    expect(instance).toBeInstanceOf(Service);
+    await instance.stop();
+  });
+
+  it('defineService builds from definition', async () => {
+    const Def = defineService({
+      serviceType: 'DEF' as any,
+      description: 'desc',
+      start: async () =>
+        new (class extends Service {
+          async stop() {}
+        })(),
+    });
+    const instance = await Def.start({} as any);
+    expect(instance).toBeInstanceOf(Service);
+    await instance.stop();
+  });
+});

--- a/packages/core/__tests__/settings.test.ts
+++ b/packages/core/__tests__/settings.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createSettingFromConfig,
+  encryptStringValue,
+  decryptStringValue,
+  saltSettingValue,
+  unsaltSettingValue,
+  saltWorldSettings,
+  unsaltWorldSettings,
+} from '../src/settings';
+import { getSalt } from '../src/settings';
+
+describe('settings utilities', () => {
+  it('createSettingFromConfig copies fields', () => {
+    const cfg = { name: 'a', description: 'd', required: true } as any;
+    const setting = createSettingFromConfig(cfg);
+    expect(setting.name).toBe('a');
+    expect(setting.required).toBe(true);
+    expect(setting.value).toBeNull();
+  });
+
+  it('encrypt/decrypt round trip', () => {
+    const salt = getSalt();
+    const enc = encryptStringValue('secret', salt);
+    expect(enc).not.toBe('secret');
+    const dec = decryptStringValue(enc, salt);
+    expect(dec).toBe('secret');
+  });
+
+  it('salt and unsalt setting value', () => {
+    const salt = getSalt();
+    const setting = { value: 'v', secret: true } as any;
+    const salted = saltSettingValue(setting, salt);
+    expect(salted.value).not.toBe('v');
+    const unsalted = unsaltSettingValue(salted, salt);
+    expect(unsalted.value).toBe('v');
+  });
+
+  it('salt and unsalt world settings', () => {
+    const salt = getSalt();
+    const world = { a: { value: 'x', secret: true } } as any;
+    const salted = saltWorldSettings(world, salt);
+    expect(salted.a.value).not.toBe('x');
+    const unsalted = unsaltWorldSettings(salted, salt);
+    expect(unsalted.a.value).toBe('x');
+  });
+});

--- a/packages/core/__tests__/utils-extra.test.ts
+++ b/packages/core/__tests__/utils-extra.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import {
+  addHeader,
+  composeRandomUser,
+  parseKeyValueXml,
+  safeReplacer,
+  upgradeDoubleToTriple,
+  validateUuid,
+} from '../src/utils';
+
+describe('utils extra', () => {
+  it('upgradeDoubleToTriple converts double braces to triple', () => {
+    const tpl = 'Hello {{name}} and {{#if cond}}{{value}}{{/if}}';
+    const out = upgradeDoubleToTriple(tpl);
+    expect(out).toBe('Hello {{{name}}} and {{#if cond}}{{{value}}}{{/if}}');
+  });
+
+  it('addHeader prepends header when body exists', () => {
+    expect(addHeader('Head', 'Body')).toBe('Head\nBody\n');
+    expect(addHeader('Head', '')).toBe('');
+  });
+
+  it('composeRandomUser replaces placeholders', () => {
+    const result = composeRandomUser('hi {{name1}} {{name2}}', 2);
+    expect(result).not.toContain('{{');
+  });
+
+  it('parseKeyValueXml parses simple xml block', () => {
+    const xml = '<response><key>value</key><actions>a,b</actions><simple>true</simple></response>';
+    const parsed = parseKeyValueXml(xml);
+    expect(parsed).toEqual({ key: 'value', actions: ['a', 'b'], simple: true });
+  });
+
+  it('safeReplacer handles circular objects', () => {
+    const obj: any = { a: 1 };
+    obj.self = obj;
+    const str = JSON.stringify(obj, safeReplacer());
+    expect(str).toContain('[Circular]');
+  });
+
+  it('validateUuid validates correct uuid and rejects bad values', () => {
+    const valid = validateUuid('123e4567-e89b-12d3-a456-426614174000');
+    const invalid = validateUuid('not-a-uuid');
+    expect(valid).toBe('123e4567-e89b-12d3-a456-426614174000');
+    expect(invalid).toBeNull();
+  });
+});

--- a/packages/core/__tests__/utils-prompt.test.ts
+++ b/packages/core/__tests__/utils-prompt.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as utils from '../src/utils';
+import { ModelType } from '../src/types';
+
+describe('prompt utilities', () => {
+  it('composePrompt inserts state values', () => {
+    const spy = vi.spyOn(utils, 'composeRandomUser').mockImplementation((t) => t);
+    const out = utils.composePrompt({ state: { a: 'x' }, template: 'Hello {{a}}' });
+    expect(out).toBe('Hello x');
+    spy.mockRestore();
+  });
+
+  it('composePromptFromState flattens state values', () => {
+    const spy = vi.spyOn(utils, 'composeRandomUser').mockImplementation((t) => t);
+    const out = utils.composePromptFromState({
+      state: { values: { b: 'y' }, c: 'z' },
+      template: '{{b}} {{c}}',
+    });
+    expect(out).toBe('y z');
+    spy.mockRestore();
+  });
+
+  it('formatPosts formats conversation text', () => {
+    const messages = [
+      {
+        id: '1',
+        entityId: 'e1',
+        roomId: 'r1',
+        createdAt: 1,
+        content: { text: 'hi', source: 'chat' },
+      },
+      {
+        id: '2',
+        entityId: 'e1',
+        roomId: 'r1',
+        createdAt: 2,
+        content: { text: 'there', source: 'chat' },
+      },
+    ] as any;
+    const entities = [{ id: 'e1', names: ['Alice'] }] as any;
+    const result = utils.formatPosts({ messages, entities });
+    expect(result).toContain('Conversation:');
+    expect(result).toContain('Alice');
+    expect(result).toContain('hi');
+    expect(result).toContain('there');
+  });
+
+  it('trimTokens truncates using runtime tokenizer', async () => {
+    const runtime = {
+      useModel: vi.fn(async (type: ModelType, { prompt, tokens }: any) => {
+        if (type === ModelType.TEXT_TOKENIZER_ENCODE) return prompt.split(' ');
+        if (type === ModelType.TEXT_TOKENIZER_DECODE) return tokens.join(' ');
+        return [];
+      }),
+    } as any;
+    const result = await utils.trimTokens('a b c d e', 3, runtime);
+    expect(result).toBe('c d e');
+  });
+});


### PR DESCRIPTION
## Summary
- add utility tests verifying template upgrades, header addition, random name replacement, XML parsing, circular reference handling, and UUID validation
- implement settings tests covering encryption/decryption and value salting mechanics
- add service builder tests to ensure dynamically created services start and stop correctly
- add prompt utility tests for composing prompts, formatting posts, and trimming tokens

## Testing
- `npx vitest run packages/core/__tests__ --coverage`
- `npm run lint`
