### PR TITLE
fix: remove unused PDF.js imports causing CLI DOMMatrix runtime error

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -6,14 +6,6 @@ import pkg from 'stream-browserify';
 
 import { names, uniqueNamesGenerator } from 'unique-names-generator';
 import { z } from 'zod';
-import * as pdfjsLib from 'pdfjs-dist/legacy/build/pdf.mjs';
-
-// Explicitly set the workerSrc.
-// This tells pdf.js where to load its worker script from.
-// Your application's build process (e.g., for packages/cli) must ensure that
-// 'pdf.worker.mjs' is available at a path relative to the main script or application root.
-// A common setup is to copy 'node_modules/pdfjs-dist/legacy/build/pdf.worker.mjs' to the output directory.
-pdfjsLib.GlobalWorkerOptions.workerSrc = './pdf.worker.mjs';
 
 import logger from './logger';
 import type { Content, Entity, IAgentRuntime, Memory, State, TemplateType } from './types';


### PR DESCRIPTION
**## Problem**
CLI commands fail with `ReferenceError: Can't find variable: DOMMatrix` when running in environments without DOM support (like Node.js/Bun).

**## Root Cause**  
`packages/core/src/utils.ts` imports `pdfjs-dist` at the top level but never uses it. This causes CLI bundling to include PDF.js dependencies that require DOM APIs.

**## Solution**
Remove the unused PDF.js imports from `core/src/utils.ts` since no functions in the file actually use PDF.js functionality.

**## Testing**
- ✅ CLI `create` command works without DOMMatrix errors
- ✅ Core package builds successfully 
- ✅ No functionality lost (PDF.js wasn't used)

Fixes CLI runtime errors like:

ReferenceError: Can't find variable: DOMMatrix
at /Users/.../node_modules/pdfjs-dist/legacy/build/pdf.mjs:12495:26