### PR TITLE
fix: .env hoisting in non-monorepo dirs

### DIFF
--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -22,9 +22,8 @@ export async function getGlobalEnvPath(): Promise<string> {
  * @returns The path to the local .env file or null if not found
  */
 async function getLocalEnvPath(): Promise<string | null> {
-  const envInfo = await UserEnvironment.getInstanceInfo();
-  const envPath = envInfo.paths.envFilePath;
-  return existsSync(envPath) ? envPath : null;
+  const localEnvPath = path.join(process.cwd(), '.env');
+  return existsSync(localEnvPath) ? localEnvPath : null;
 }
 
 /**

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,4 +1,4 @@
-import { character as defaultCharacter, getElizaCharacter } from '@/src/characters/eliza';
+import { getElizaCharacter } from '@/src/characters/eliza';
 import { AgentServer } from '@/src/server/index';
 import { jsonToCharacter, loadCharacterTryPath } from '@/src/server/loader';
 import {
@@ -384,7 +384,7 @@ export async function startAgent(
     settings: await loadEnvConfig(),
   });
   if (init) {
-    await init(runtime);
+    init(runtime);
   }
 
   // start services/plugins/process knowledge

--- a/packages/cli/src/utils/user-environment.ts
+++ b/packages/cli/src/utils/user-environment.ts
@@ -245,9 +245,11 @@ export class UserEnvironment {
 
   public async getPathInfo(): Promise<PathInfo> {
     const monorepoRoot = this.findMonorepoRoot(process.cwd());
-    const projectRootForPaths = monorepoRoot || process.cwd(); // Determine the correct root
-    const elizaDir = path.join(projectRootForPaths, '.eliza'); // Use the correct root for .eliza
-    const envFilePath = resolveEnvFile(projectRootForPaths); // Use the correct root for .env resolution
+    const projectRootForPaths = monorepoRoot || process.cwd();
+    const elizaDir = path.join(projectRootForPaths, '.eliza');
+
+    // Resolve .env from current working directory up to monorepo root (if any), or only cwd if not in monorepo
+    const envFilePath = resolveEnvFile(process.cwd(), monorepoRoot ?? undefined);
 
     logger.debug('[UserEnvironment] Detected monorepo root:', monorepoRoot || 'Not in monorepo');
 


### PR DESCRIPTION
Any .envs upper from the project directory would get grabbed, even not inside monorepos... now this forces .env creation and respects the project folder.