### PR TITLE
fix: resolve deploy-cli workflow publishing failures

### DIFF
--- a/.github/workflows/deploy-cli.yml
+++ b/.github/workflows/deploy-cli.yml
@@ -54,6 +54,6 @@ jobs:
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
           # Publish without pushing to git
-          npx lerna publish prerelease --preid beta --dist-tag beta --no-private --force-publish --loglevel verbose --yes --no-push --no-git-tag-version --ignore create-eliza --ignore @npm-username/plugin-name
+          npx lerna publish prerelease --preid beta --dist-tag beta --no-private --force-publish --loglevel verbose --yes --no-push --no-git-tag-version --ignore create-eliza --ignore plugin-starter
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deploy-cli.yml
+++ b/.github/workflows/deploy-cli.yml
@@ -54,6 +54,6 @@ jobs:
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
           # Publish without pushing to git
-          npx lerna publish prerelease --preid beta --dist-tag beta --no-private --force-publish --loglevel verbose --yes --no-push --no-git-tag-version
+          npx lerna publish prerelease --preid beta --dist-tag beta --no-private --force-publish --loglevel verbose --yes --no-push --no-git-tag-version --ignore create-eliza
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deploy-cli.yml
+++ b/.github/workflows/deploy-cli.yml
@@ -54,6 +54,6 @@ jobs:
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
           # Publish without pushing to git
-          npx lerna publish prerelease --preid beta --dist-tag beta --no-private --force-publish --loglevel verbose --yes --no-push --no-git-tag-version --ignore create-eliza
+          npx lerna publish prerelease --preid beta --dist-tag beta --no-private --force-publish --loglevel verbose --yes --no-push --no-git-tag-version --ignore create-eliza --ignore @npm-username/plugin-name
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/plugin-starter/package.json
+++ b/packages/plugin-starter/package.json
@@ -2,7 +2,6 @@
   "name": "@npm-username/plugin-name",
   "description": "${PLUGINDESCRIPTION}",
   "version": "1.0.0-beta.74",
-  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/plugin-starter/package.json
+++ b/packages/plugin-starter/package.json
@@ -2,6 +2,7 @@
   "name": "@npm-username/plugin-name",
   "description": "${PLUGINDESCRIPTION}",
   "version": "1.0.0-beta.74",
+  "private": true,
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary
- Fix E404 and E403 publishing errors in deploy-cli workflow
- Add lerna ignore flags for template packages that shouldn't be published
- Exclude both `create-eliza` and `plugin-starter` via workflow ignore flags

## Changes
- Add `--ignore create-eliza --ignore plugin-starter` to lerna publish command
- Keep plugin-starter as a regular package but exclude it from publishing via workflow

## Test plan
- [ ] Verify workflow runs without permission errors
- [ ] Confirm only intended packages are published
- [ ] Ensure template packages are properly excluded