### PR TITLE
feat: improving typing

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ export * from './logger';
 export * from './prompts';
 export * from './roles';
 export * from './runtime';
-export * from './search';
+// search doesn't need to be exported
 export * from './settings';
 export * from './utils';
 export * from './services';

--- a/packages/core/src/search.ts
+++ b/packages/core/src/search.ts
@@ -991,7 +991,7 @@ class Tokenizer {
  * BM25 Options Interface.
  * Extends TokenizerOptions and adds BM25 specific parameters.
  */
-export interface BM25Options extends TokenizerOptions {
+interface BM25Options extends TokenizerOptions {
   /**
    * Term frequency saturation parameter (k1). Controls how quickly term frequency
    * saturates. Higher values mean TF contributes more significantly even for high counts.
@@ -1015,7 +1015,7 @@ export interface BM25Options extends TokenizerOptions {
 /**
  * Represents a search result item.
  */
-export interface SearchResult {
+interface SearchResult {
   /** The index of the matching document in the original document array. */
   index: number;
   /** The BM25 relevance score for the document. Higher scores indicate better relevance. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2153,11 +2153,14 @@ export function createMessageMemory(params: {
  * @template ConfigType The configuration type for this service
  * @template ResultType The result type returned by the service operations
  */
-export interface TypedService<ConfigType = unknown, ResultType = unknown> extends Service {
+export interface TypedService<
+  ConfigType extends { [key: string]: any } = { [key: string]: any },
+  ResultType = unknown,
+> extends Service {
   /**
    * The configuration for this service instance
    */
-  config: ConfigType;
+  config?: ConfigType;
 
   /**
    * Process an input with this service


### PR DESCRIPTION
# Risks

Low

# Background

## What does this PR do?

- make strict typing pass
- don't export BM25 outside npm (we only use it in runtime)

## What kind of change is this?

Updates (new versions of included code)

## Why are we doing this? Any context or related work?

improve what we have to lock down in specification and give core as much freedom as possible.

# Documentation changes needed?

My changes do not require a change to the project documentation.
