### PR TITLE
fix: bootstrap plugin default

### DIFF
--- a/packages/client/src/components/agent-creator.tsx
+++ b/packages/client/src/components/agent-creator.tsx
@@ -19,7 +19,7 @@ const defaultCharacter: Partial<Agent> = getTemplateById('none')?.template || {
   bio: [] as string[],
   topics: [] as string[],
   adjectives: [] as string[],
-  plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai'],
+  plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai', '@elizaos/plugin-bootstrap'],
   settings: { secrets: {} },
 };
 

--- a/packages/client/src/config/agent-templates.ts
+++ b/packages/client/src/config/agent-templates.ts
@@ -25,7 +25,7 @@ export const agentTemplates: AgentTemplate[] = [
       bio: [],
       topics: [],
       adjectives: [],
-      plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai'],
+      plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai', '@elizaos/plugin-bootstrap'],
       settings: { secrets: {} },
     },
   },


### PR DESCRIPTION
Defaults plugin-bootstrap always activated in default: "create agent" flows in the client UI. Since without, messages do not process and confusing to users.