### PR TITLE
Eliza342 implement auto update for eliza os cli

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -86,18 +86,14 @@ async function main() {
     .addCommand(publish)
     .addCommand(stopCommand);
 
-  // Add auto-update hook to all commands except 'update' to avoid recursion
-  program.commands.forEach((command) => {
-    if (command.name() !== 'update') {
-      command.hook('preAction', async (thisCommand, actionCommand) => {
-        const opts = program.opts();
-        // Only perform auto-update if --noupdate flag is not set
-        if (!opts.noupdate) {
-          await performAutoUpdate();
-        }
-      });
-    }
-  });
+  // Check for --noupdate flag and update command before performing auto-update
+  const hasNoUpdateFlag = process.argv.includes('--noupdate');
+  const isUpdateCommand = process.argv.includes('update');
+
+  // Perform auto-update once before parsing commands (unless disabled or running update command)
+  if (!hasNoUpdateFlag && !isUpdateCommand && process.argv.length > 2) {
+    await performAutoUpdate();
+  }
 
   // if no args are passed, display the banner
   if (process.argv.length === 2) {

--- a/packages/cli/src/utils/auto-update.ts
+++ b/packages/cli/src/utils/auto-update.ts
@@ -63,7 +63,7 @@ async function checkIfUpdateNeeded(): Promise<{
 }> {
   try {
     // Get current version
-    const { getVersion } = await import('./display-banner');
+    const { getVersion } = await import('./version');
     const currentVersion = getVersion();
 
     // Get latest version from npm

--- a/packages/cli/src/utils/auto-update.ts
+++ b/packages/cli/src/utils/auto-update.ts
@@ -12,15 +12,14 @@ async function getLatestCliVersion(): Promise<string | null> {
     const { stdout } = await execa('npm', ['view', '@elizaos/cli', 'time', '--json']);
     const timeData = JSON.parse(stdout);
 
-    // Remove metadata entries like 'created' and 'modified'
-    delete timeData.created;
-    delete timeData.modified;
-
-    // Find the most recently published version
+    // Find the most recently published version (excluding metadata entries)
     let latestVersion = '';
     let latestDate = new Date(0); // Start with epoch time
 
     for (const [version, dateString] of Object.entries(timeData)) {
+      // Skip metadata entries
+      if (version === 'created' || version === 'modified') continue;
+
       const publishDate = new Date(dateString as string);
       if (publishDate > latestDate) {
         latestDate = publishDate;

--- a/packages/cli/src/utils/auto-update.ts
+++ b/packages/cli/src/utils/auto-update.ts
@@ -1,0 +1,184 @@
+import { execa } from 'execa';
+
+// Global flag to prevent recursion
+let isUpdating = false;
+
+/**
+ * Get latest CLI version from npm
+ */
+async function getLatestCliVersion(): Promise<string | null> {
+  try {
+    // Get the time data for all published versions to find the most recent
+    const { stdout } = await execa('npm', ['view', '@elizaos/cli', 'time', '--json']);
+    const timeData = JSON.parse(stdout);
+
+    // Remove metadata entries like 'created' and 'modified'
+    delete timeData.created;
+    delete timeData.modified;
+
+    // Find the most recently published version
+    let latestVersion = '';
+    let latestDate = new Date(0); // Start with epoch time
+
+    for (const [version, dateString] of Object.entries(timeData)) {
+      const publishDate = new Date(dateString as string);
+      if (publishDate > latestDate) {
+        latestDate = publishDate;
+        latestVersion = version;
+      }
+    }
+
+    return latestVersion || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Check for CLI update and show notification (for banner display)
+ */
+export async function checkForCliUpdate(currentVersion: string): Promise<void> {
+  try {
+    const latestVersion = await getLatestCliVersion();
+
+    // If already at the latest version or couldn't determine latest, exit
+    if (!latestVersion || latestVersion === currentVersion) return;
+
+    console.log(
+      `\x1b[33m\nA new version of elizaOS CLI is available: ${latestVersion} (current: ${currentVersion})\x1b[0m`
+    );
+    console.log(`\x1b[32mUpdate with: elizaos update\x1b[0m\n`);
+  } catch {
+    /* silent: update check failure must not block banner */
+  }
+}
+
+/**
+ * Check if CLI needs update
+ */
+async function checkIfUpdateNeeded(): Promise<{
+  needsUpdate: boolean;
+  currentVersion: string;
+  latestVersion: string | null;
+}> {
+  try {
+    // Get current version
+    const { getVersion } = await import('./display-banner');
+    const currentVersion = getVersion();
+
+    // Get latest version from npm
+    const latestVersion = await getLatestCliVersion();
+
+    const needsUpdate = latestVersion && latestVersion !== currentVersion;
+
+    return {
+      needsUpdate: !!needsUpdate,
+      currentVersion,
+      latestVersion: latestVersion || null,
+    };
+  } catch {
+    return {
+      needsUpdate: false,
+      currentVersion: '',
+      latestVersion: null,
+    };
+  }
+}
+
+/**
+ * Perform automatic CLI update
+ */
+export async function performAutoUpdate(): Promise<void> {
+  // Prevent recursion
+  if (isUpdating) {
+    return;
+  }
+
+  try {
+    isUpdating = true;
+
+    const { needsUpdate, currentVersion, latestVersion } = await checkIfUpdateNeeded();
+
+    if (!needsUpdate || !latestVersion) {
+      return;
+    }
+
+    // Check installation type
+    const { isRunningViaNpx, isRunningViaBunx, isGlobalInstallation } = await import(
+      './package-manager'
+    );
+
+    // Check if we're in development mode
+    const cwd = process.cwd();
+    const isDevelopment = cwd.includes('eliza') && currentVersion.includes('beta');
+
+    // Development mode: show notification only
+    if (isDevelopment) {
+      console.log(
+        `\x1b[33m\nA new version of elizaOS CLI is available: ${latestVersion} (current: ${currentVersion})\x1b[0m`
+      );
+      console.log(`\x1b[32mTo update, run: npm install -g @elizaos/cli@beta\x1b[0m\n`);
+      return;
+    }
+
+    // npx/bunx: show notification only
+    if ((await isRunningViaNpx()) || (await isRunningViaBunx())) {
+      console.log(
+        `\x1b[33m\nA new version of elizaOS CLI is available: ${latestVersion} (current: ${currentVersion})\x1b[0m`
+      );
+      console.log(`\x1b[32mTo update, run: npm install -g @elizaos/cli@beta\x1b[0m\n`);
+      return;
+    }
+
+    const isGlobal = await isGlobalInstallation();
+
+    // Non-global: show notification only
+    if (!isGlobal) {
+      console.log(
+        `\x1b[33m\nA new version of elizaOS CLI is available: ${latestVersion} (current: ${currentVersion})\x1b[0m`
+      );
+      console.log(`\x1b[32mTo update, run: npm install -g @elizaos/cli@beta\x1b[0m\n`);
+      return;
+    }
+
+    // Global installation: perform auto-update
+    console.log(
+      `\x1b[36m\nAuto-updating elizaOS CLI from ${currentVersion} to ${latestVersion}...\x1b[0m`
+    );
+
+    try {
+      const { performCliUpdate } = await import('../commands/update');
+      const success = await performCliUpdate();
+
+      if (success) {
+        console.log(`\x1b[32m✓ Successfully updated to ${latestVersion}!\x1b[0m`);
+
+        // Re-execute the original command with the updated CLI
+        const originalArgs = process.argv.slice(2);
+        if (originalArgs.length > 0) {
+          console.log(`\x1b[36mRe-executing command with updated CLI...\x1b[0m\n`);
+
+          try {
+            await execa('elizaos', ['--noupdate', ...originalArgs], {
+              stdio: 'inherit',
+            });
+          } catch (error) {
+            console.log(`\x1b[31m✗ Failed to re-execute command: ${error.message}\x1b[0m`);
+            console.log(`\x1b[32mPlease run your command again manually.\x1b[0m\n`);
+          }
+        } else {
+          console.log(`\x1b[32mPlease restart your terminal to use the updated CLI.\x1b[0m\n`);
+        }
+
+        process.exit(0);
+      }
+    } catch (error) {
+      console.log(`\x1b[31m✗ Auto-update failed: ${error.message}\x1b[0m`);
+      console.log(`\x1b[32mPlease update manually with: elizaos update --cli\x1b[0m\n`);
+    }
+  } catch (error) {
+    // Silent failure - don't block command execution
+  } finally {
+    isUpdating = false;
+  }
+}

--- a/packages/cli/src/utils/display-banner.ts
+++ b/packages/cli/src/utils/display-banner.ts
@@ -1,44 +1,6 @@
 // Export function to display banner and version
 
-import fs from 'node:fs';
-import path, { dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-// Function to get the package version
-// --- Utility: Get local CLI version from package.json ---
-export function getVersion(): string {
-  // For ESM modules we need to use import.meta.url instead of __dirname
-  const __filename = fileURLToPath(import.meta.url);
-  const __dirname = dirname(__filename);
-
-  // Find package.json relative to the current file
-  const packageJsonPath = path.resolve(__dirname, '../package.json');
-
-  // Add a simple check in case the path is incorrect
-  let version = '0.0.0'; // Fallback version
-  if (!fs.existsSync(packageJsonPath)) {
-    console.error(`Warning: package.json not found at ${packageJsonPath}`);
-  } else {
-    try {
-      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
-      version = packageJson.version || '0.0.0';
-    } catch (error) {
-      console.error(`Error reading or parsing package.json at ${packageJsonPath}:`, error);
-    }
-  }
-  return version;
-}
-
-// --- Utility: Get install tag based on CLI version ---
-export function getCliInstallTag(): string {
-  const version = getVersion();
-  if (version.includes('-alpha')) {
-    return 'alpha';
-  } else if (version.includes('-beta')) {
-    return 'beta';
-  }
-  return ''; // Return empty string for stable or non-tagged versions (implies latest)
-}
+import { getVersion } from './version';
 
 // --- Utility: Check if terminal supports UTF-8 ---
 export function isUtf8Locale() {

--- a/packages/cli/src/utils/display-banner.ts
+++ b/packages/cli/src/utils/display-banner.ts
@@ -3,8 +3,6 @@
 import fs from 'node:fs';
 import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { execa } from 'execa';
-import { yellow } from 'yoctocolors';
 
 // Function to get the package version
 // --- Utility: Get local CLI version from package.json ---
@@ -51,40 +49,6 @@ export function isUtf8Locale() {
     }
   }
   return false;
-}
-// --- Utility: Check for latest CLI version and notify user ---
-async function checkForCliUpdate(currentVersion: string) {
-  try {
-    // Get the time data for all published versions to find the most recent
-    const { stdout } = await execa('npm', ['view', '@elizaos/cli', 'time', '--json']);
-    const timeData = JSON.parse(stdout);
-
-    // Remove metadata entries like 'created' and 'modified'
-    delete timeData.created;
-    delete timeData.modified;
-
-    // Find the most recently published version
-    let latestVersion = '';
-    let latestDate = new Date(0); // Start with epoch time
-
-    for (const [version, dateString] of Object.entries(timeData)) {
-      const publishDate = new Date(dateString as string);
-      if (publishDate > latestDate) {
-        latestDate = publishDate;
-        latestVersion = version;
-      }
-    }
-
-    // If already at the latest version or couldn't determine latest, exit
-    if (!latestVersion || latestVersion === currentVersion) return;
-
-    console.log(
-      `\x1b[33m\nA new version of elizaOS CLI is available: ${latestVersion} (current: ${currentVersion})\x1b[0m`
-    );
-    console.log(`\x1b[32mUpdate with: elizaos update\x1b[0m\n`);
-  } catch {
-    /* silent: update check failure must not block banner */
-  }
 }
 
 // --- Main: Display banner and version, then check for updates ---
@@ -171,6 +135,7 @@ ${b}⠀⠀⠀⠀⢸⣿⡦⠀⠀⠉⠛⠿⠃⠀⠀⠀ ${w} ⠀⠀⠀⠀⠀⠀⠀�
 
   // Notify user if a new CLI version is available
   try {
+    const { checkForCliUpdate } = await import('./auto-update');
     await checkForCliUpdate(version);
   } catch (error) {
     // Silently continue if update check fails

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -22,3 +22,4 @@ export * from './resolve-utils';
 export * from './run-bun';
 export * from './test-runner';
 export * from './user-environment';
+export * from './version';

--- a/packages/cli/src/utils/index.ts
+++ b/packages/cli/src/utils/index.ts
@@ -1,5 +1,6 @@
 // Core utilities
 export * from './audioBuffer';
+export * from './auto-update';
 export * from './build-project';
 export * from './cli-prompts';
 export * from './config-manager';

--- a/packages/cli/src/utils/version.ts
+++ b/packages/cli/src/utils/version.ts
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import path, { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Get the CLI version from package.json
+ */
+export function getVersion(): string {
+  // For ESM modules we need to use import.meta.url instead of __dirname
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = dirname(__filename);
+
+  // Find package.json relative to the current file
+  const packageJsonPath = path.resolve(__dirname, '../package.json');
+
+  // Add a simple check in case the path is incorrect
+  let version = '0.0.0'; // Fallback version
+  if (!fs.existsSync(packageJsonPath)) {
+    console.error(`Warning: package.json not found at ${packageJsonPath}`);
+  } else {
+    try {
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+      version = packageJson.version || '0.0.0';
+    } catch (error) {
+      console.error(`Error reading or parsing package.json at ${packageJsonPath}:`, error);
+    }
+  }
+  return version;
+}
+
+/**
+ * Get install tag based on CLI version
+ */
+export function getCliInstallTag(): string {
+  const version = getVersion();
+  if (version.includes('-alpha')) {
+    return 'alpha';
+  } else if (version.includes('-beta')) {
+    return 'beta';
+  }
+  return ''; // Return empty string for stable or non-tagged versions (implies latest)
+}


### PR DESCRIPTION
**Problem**

Users encounter issues that have already been fixed in newer versions of the elizaOS CLI, but they continue using outdated versions without realizing updates are available. This can lead to support overhead from outdated CLI versions.

**Solution**

Implement automatic CLI updates that check for new versions before running commands and auto-update global installations when newer versions are available.

**Key Features:**

Auto-update enabled by default for globally installed CLI
--noupdate flag to disable automatic updates when needed
Smart detection of installation context (development, global, npx/bunx)
Uses existing warning msg for non-global installations

**Behavior:**

Global installations: Automatically update and re-execute original command
Development mode: Show notification only (when running from eliza repo)
npx/bunx usage: Show notification with manual update instructions
Update command: Skip auto-update to prevent recursion
Details

**Implementation**

New auto-update.ts utility: Centralized update logic with version checking, installation detection, and update execution
Performance optimization: Single update check before command parsing instead of per-command hooks
Architecture improvement: Extracted version utilities to version.ts to break circular dependencies
Code cleanup: Moved CLI version checking logic out of display-banner.ts for better separation of concerns

**Potential Concerns:**

While auto-updating solves the problem of users running outdated CLIs, it introduces a new UX friction: users who want to disable auto-updates must append --noupdate to every command, which could be equally annoying.
Pro: Automatically fixes issues for users with outdated CLIs
Con: Forces users who prefer manual updates to use --noupdate repeatedly

Question: Does the benefit of automatic fixes outweigh the inconvenience for users who prefer manual control?
We're seeking feedback on whether this trade-off is acceptable or if we should explore alternative approaches (like opt-in auto-updates or persistent configuration).