### PR TITLE
fix: resolve E2E test compilation failures

### DIFF
--- a/packages/project-starter/e2e/starter-plugin.test.ts
+++ b/packages/project-starter/e2e/starter-plugin.test.ts
@@ -1,4 +1,4 @@
-import { character } from '../dist/index.js';
+import { character } from '../src/index.js';
 import { v4 as uuidv4 } from 'uuid';
 
 // Define a minimal TestSuite interface that matches what's needed

--- a/packages/project-starter/package.json
+++ b/packages/project-starter/package.json
@@ -4,8 +4,8 @@
   "version": "0.1.0",
   "type": "module",
   "private": true,
-  "main": "dist/index.js",
-  "module": "dist/index.js",
+  "main": "dist/src/index.js",
+  "module": "dist/src/index.js",
   "types": "dist/index.d.ts",
   "keywords": [
     "project",
@@ -20,7 +20,7 @@
     ".": {
       "import": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/index.js"
+        "default": "./dist/src/index.js"
       }
     }
   },

--- a/packages/project-starter/tsup.config.ts
+++ b/packages/project-starter/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'e2e/**/*.test.ts'],
   outDir: 'dist',
   tsconfig: './tsconfig.build.json', // Use build-specific tsconfig
   sourcemap: true,


### PR DESCRIPTION
**Problem (Fail Case)**

E2E tests failed with "Unknown file extension .ts" errors
TestRunner couldn't import uncompiled TypeScript test files
Build process didn't compile E2E tests to dist/e2e/

**Solution**

Add E2E test compilation to tsup config
Fix circular dependency in test imports
Update package.json entry points

**Details**

Include e2e/**/*.test.ts in tsup entry points
Change E2E imports from ../dist/ to ../src/
Update main/module fields to dist/src/index.js

**Results** 

E2E tests in project-starter now compile and run successfully (6 passed, 0 failed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated entry point paths in package settings to improve module resolution.
  - Adjusted build configuration to include end-to-end test files in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->