### PR TITLE
Fix: Return success (exit code 0) when no tests are found

### DIFF
--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -78,12 +78,14 @@ function processFilterName(name?: string): string | undefined {
 /**
  * Run component tests using Vitest
  */
-async function runComponentTests(options: { name?: string; skipBuild?: boolean }) {
+async function runComponentTests(
+  options: { name?: string; skipBuild?: boolean },
+  projectInfo: DirectoryInfo
+) {
   // Build the project or plugin first unless skip-build is specified
   if (!options.skipBuild) {
     try {
       const cwd = process.cwd();
-      const projectInfo = getProjectType();
       const isPlugin = projectInfo.type === 'elizaos-plugin';
       console.info(`Building ${isPlugin ? 'plugin' : 'project'}...`);
       await buildProject(cwd, isPlugin);
@@ -134,12 +136,14 @@ async function runComponentTests(options: { name?: string; skipBuild?: boolean }
 /**
  * Function that runs the end-to-end tests.
  */
-const runE2eTests = async (options: { port?: number; name?: string; skipBuild?: boolean }) => {
+const runE2eTests = async (
+  options: { port?: number; name?: string; skipBuild?: boolean },
+  projectInfo: DirectoryInfo
+) => {
   // Build the project or plugin first unless skip-build is specified
   if (!options.skipBuild) {
     try {
       const cwd = process.cwd();
-      const projectInfo = getProjectType();
       const isPlugin = projectInfo.type === 'elizaos-plugin';
       console.info(`Building ${isPlugin ? 'plugin' : 'project'}...`);
       await buildProject(cwd, isPlugin);
@@ -510,7 +514,7 @@ const runE2eTests = async (options: { port?: number; name?: string; skipBuild?: 
             const testRunner = new TestRunner(runtime, projectAgent);
 
             // Determine what types of tests to run based on directory type
-            const currentDirInfo = getProjectType();
+            const currentDirInfo = projectInfo;
 
             // Process filter name consistently
             const processedFilter = processFilterName(options.name);
@@ -598,11 +602,12 @@ const runE2eTests = async (options: { port?: number; name?: string; skipBuild?: 
  */
 async function runAllTests(options: { port?: number; name?: string; skipBuild?: boolean }) {
   // Run component tests first
-  const componentResult = await runComponentTests(options);
+  const projectInfo = getProjectType();
+  const componentResult = await runComponentTests(options, projectInfo);
 
   // Run e2e tests with the same processed filter name
   // Skip the second build since we already built for component tests
-  const e2eResult = await runE2eTests({ ...options, skipBuild: true });
+  const e2eResult = await runE2eTests({ ...options, skipBuild: true }, projectInfo);
 
   // Return combined result
   return { failed: componentResult.failed || e2eResult.failed };
@@ -628,7 +633,8 @@ test
     console.info('Command options:', options);
 
     try {
-      const result = await runComponentTests(options);
+      const projectInfo = getProjectType();
+      const result = await runComponentTests(options, projectInfo);
       process.exit(result.failed ? 1 : 0);
     } catch (error) {
       console.error('Error running component tests:', error);
@@ -651,7 +657,8 @@ test
     console.info('Command options:', options);
 
     try {
-      const result = await runE2eTests(options);
+      const projectInfo = getProjectType();
+      const result = await runE2eTests(options, projectInfo);
       process.exit(result.failed ? 1 : 0);
     } catch (error) {
       console.error('Error running e2e tests:', error);
@@ -674,6 +681,7 @@ test
     console.info('Command options:', options);
 
     try {
+      const projectInfo = getProjectType();
       const result = await runAllTests(options);
       process.exit(result.failed ? 1 : 0);
     } catch (error) {

--- a/packages/cli/src/utils/test-runner.ts
+++ b/packages/cli/src/utils/test-runner.ts
@@ -91,9 +91,12 @@ export class TestRunner {
   private async runTestSuite(suite: TestSuite) {
     logger.info(`\nRunning test suite: ${suite.name}`);
 
+    if (suite.tests.length > 0) {
+      this.stats.hasTests = true; // Mark that we found tests
+    }
+
     for (const test of suite.tests) {
       this.stats.total++;
-      this.stats.hasTests = true; // Mark that we found and are running tests
 
       try {
         logger.info(`  Running test: ${test.name}`);
@@ -212,7 +215,7 @@ export const myPlugin = {
       }
     } else {
       // This should not happen in the new logic since we properly scope tests by directory type
-      logger.debug('Plugin tests were requested but this is not a direct plugin test');
+      logger.info('Plugin tests were requested but this is not a direct plugin test');
     }
   }
 


### PR DESCRIPTION
* DO NOT MERGE INTO #4812 UNTIL PR #4827 HAS BEEN MERGED INTO THIS ONE *

**Problem:**

elizaos test was returning exit code 1 when no test files were found, which is inconsistent with standard testing tools like Jest and vitest. This caused CI/CD pipelines to fail unnecessarily when running tests in projects or directories without test files, creating friction for developers and breaking automated workflows.

**Solution:**

Use vitest's built-in --passWithNoTests flag and standardize messaging across both component and E2E test runners to return exit code 0 when no tests are found.

**Changes Made:**

Component Tests (packages/cli/src/commands/test.ts):
- Added --passWithNoTests flag to vitest command arguments
- Removed manual handling of "No test files found" error cases
- Now leverages vitest's native behavior for this scenario

E2E Tests (packages/cli/src/utils/test-runner.ts):
- Updated "No tests found to run" message to match vitest's format: "No test files found, exiting with code 0"
- Ensures consistent messaging between component and E2E test runners

**Behavior Changes:**

✅ elizaos test now returns exit code 0 when no tests are found (previously exit code 1)
✅ Consistent messaging across component and E2E test runners
✅ Aligns with standard testing tool behavior (Jest, vitest, etc.)
✅ CI/CD pipelines no longer fail when running tests in directories without test files

**Testing:**

Verified component tests return exit code 0 with "No test files found, exiting with code 0" message
Verified E2E tests return exit code 0 with consistent messaging
Confirmed existing tests with actual test files continue to work normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved detection of project and plugin directories for more accurate test execution.
- **Bug Fixes**
	- Test commands now correctly report success when no tests are found, aligning with standard test runner behavior.
	- Enhanced filtering ensures plugin and project tests are run or skipped appropriately based on directory type.
- **Chores**
	- Updated test summary messages for clearer feedback when no tests are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->