### PR TITLE
feat: add tee starter project create cli 

### DIFF
--- a/packages/cli/scripts/copy-templates.js
+++ b/packages/cli/scripts/copy-templates.js
@@ -62,6 +62,12 @@ async function copyTemplates() {
   await copyDir(projectStarterSrc, projectStarterDest);
   console.log('✅ Copied project-starter template');
 
+  // Copy project-tee-starter template
+  const projectTeeStarterSrc = path.join(rootDir, 'packages/project-tee-starter');
+  const projectTeeStarterDest = path.join(templatesDir, 'project-tee-starter');
+  await copyDir(projectTeeStarterSrc, projectTeeStarterDest);
+  console.log('✅ Copied project-tee-starter template');
+
   // Copy plugin-starter template
   const pluginStarterSrc = path.join(rootDir, 'packages/plugin-starter');
   const pluginStarterDest = path.join(templatesDir, 'plugin-starter');

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -38,6 +38,7 @@ const initOptionsSchema = z.object({
   dir: z.string().default('.'),
   yes: z.boolean().default(false),
   type: z.enum(['project', 'plugin', 'agent']).default('project'),
+  tee: z.boolean().default(false),
 });
 
 /**
@@ -132,6 +133,7 @@ export const create = new Command()
   .option('-d, --dir <dir>', 'installation directory', '.')
   .option('-y, --yes', 'skip confirmation', false)
   .option('-t, --type <type>', 'type to create (project, plugin, or agent)', 'project')
+  .option('--tee', 'create a TEE starter project', false)
   .argument('[name]', 'name for the project, plugin, or agent')
   .action(async (name, opts) => {
     // Set non-interactive mode if environment variable is set or if -y/--yes flag is present in process.argv
@@ -158,6 +160,7 @@ export const create = new Command()
         dir: opts.dir || '.',
         yes: opts.yes, // Already properly converted to boolean above
         type: opts.type || '',
+        tee: opts.tee || false,
       };
 
       // Determine project type, respecting -y
@@ -410,7 +413,14 @@ export const create = new Command()
           return;
         }
 
-        await copyTemplateUtil('project', targetDir, projectName);
+        // Determine which template to use based on --tee flag
+        const template = options.tee ? 'project-tee-starter' : 'project-starter';
+
+        if (options.tee) {
+          console.info('Creating TEE-enabled project with TEE capabilities...');
+        }
+
+        await copyTemplateUtil(template, targetDir, projectName);
 
         await createIgnoreFiles(targetDir);
 

--- a/packages/cli/src/scripts/copy-templates.ts
+++ b/packages/cli/src/scripts/copy-templates.ts
@@ -75,6 +75,11 @@ async function main() {
         dest: path.resolve(TEMPLATES_DIR, 'project-starter'),
       },
       {
+        name: 'project-tee-starter',
+        src: path.resolve(ROOT_DIR, 'packages/project-tee-starter'),
+        dest: path.resolve(TEMPLATES_DIR, 'project-tee-starter'),
+      },
+      {
         name: 'plugin-starter',
         src: path.resolve(ROOT_DIR, 'packages/plugin-starter'),
         dest: path.resolve(TEMPLATES_DIR, 'plugin-starter'),

--- a/packages/cli/src/utils/copy-template.ts
+++ b/packages/cli/src/utils/copy-template.ts
@@ -54,44 +54,52 @@ export async function copyDir(src: string, dest: string, exclude: string[] = [])
 }
 
 /**
+ * Map template types to actual package names
+ */
+function getPackageName(templateType: string): string {
+  switch (templateType) {
+    case 'project-tee-starter':
+      return 'project-tee-starter';
+    case 'plugin':
+      return 'plugin-starter';
+    case 'project':
+    case 'project-starter':
+    default:
+      return 'project-starter';
+  }
+}
+
+/**
  * Copy a project or plugin template to target directory
  */
 export async function copyTemplate(
-  templateType: 'project' | 'plugin',
+  templateType: 'project-starter' | 'project-tee-starter' | 'plugin',
   targetDir: string,
   name: string
 ) {
-  // In development mode, use the actual packages
-  let templateDir;
+  const packageName = getPackageName(templateType);
   const userEnv = UserEnvironment.getInstance();
   const pathsInfo = await userEnv.getPathInfo();
 
+  let templateDir: string;
   if (process.env.NODE_ENV === 'development' && pathsInfo.monorepoRoot) {
     // Use monorepoRoot if in development and monorepoRoot is found
     logger.debug(
       `Development mode: Using monorepo root at ${pathsInfo.monorepoRoot} to find templates.`
     );
-    templateDir = path.resolve(
-      pathsInfo.monorepoRoot,
-      'packages',
-      templateType === 'project' ? 'project-starter' : 'plugin-starter'
-    );
+    templateDir = path.resolve(pathsInfo.monorepoRoot, 'packages', packageName);
   } else if (process.env.NODE_ENV === 'development') {
     // Fallback for development if monorepoRoot is not found (e.g., running CLI from a strange location)
     logger.warn(
       'Development mode: monorepoRoot not found. Falling back to process.cwd() for template path. This might be unreliable.'
     );
-    templateDir = path.resolve(
-      process.cwd(),
-      'packages',
-      templateType === 'project' ? 'project-starter' : 'plugin-starter'
-    );
+    templateDir = path.resolve(process.cwd(), 'packages', packageName);
   } else {
     // In production, use the templates directory from the CLI package
     templateDir = path.resolve(
       path.dirname(require.resolve('@elizaos/cli/package.json')),
       'templates',
-      templateType === 'project' ? 'project-starter' : 'plugin-starter'
+      packageName
     );
   }
 


### PR DESCRIPTION
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

<!-- LINK TO ISSUE OR TICKET -->

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background
Currently, the create command will give options for project or plugin when creating from a template. This adds the option for TEE project starter with a TEE. Logic only affects type `project` when choosing between basic template vs tee template
## What does this PR do?
This PR allows for TEE starter project template to be generated with a boolean flag `--tee`. Set to `false` by default.
## What kind of change is this?
feature
<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?
Build the ElizaOS CLI then execute:
```
npx @elizaos/cli create test-project --tee
```
## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->

## Screenshots
### Before
### After

https://github.com/user-attachments/assets/80885607-f2b1-4e49-be39-145028d6fd7e




<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/elizaOS and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->
