### PR TITLE
fix: refactor misc cli commands to reuse directory detection util

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,4 +1,5 @@
 import { buildProject, handleError, isMonorepoContext, UserEnvironment } from '@/src/utils';
+import { detectDirectoryType, getDirectoryTypeDescription } from '@/src/utils/directory-detection';
 import { Command, Option } from 'commander';
 import chokidar from 'chokidar';
 import type { ChildProcess } from 'node:child_process';
@@ -73,79 +74,6 @@ async function startServer(args: string[] = []): Promise<void> {
     console.error(`Server process error: ${err.message}`);
     serverProcess = null;
   });
-}
-
-/**
- * Determines whether the current working directory represents a project or a plugin.
- *
- * Examines `package.json` fields, naming conventions, keywords, and source exports to heuristically identify if the directory is an Eliza project or plugin.
- *
- * @returns An object indicating whether the directory is a project (`isProject`) or a plugin (`isPlugin`).
- */
-async function determineProjectType(): Promise<{ isProject: boolean; isPlugin: boolean }> {
-  const cwd = process.cwd();
-  const packageJsonPath = path.join(cwd, 'package.json');
-  const isMonorepo = await isMonorepoContext();
-
-  let isProject = false;
-  let isPlugin = false;
-
-  if (fs.existsSync(packageJsonPath)) {
-    try {
-      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
-
-      // Explicitly exclude the CLI package itself
-      if (packageJson.name === '@elizaos/cli') {
-        return { isProject: false, isPlugin: false };
-      }
-
-      // More specific check for plugins - must have one of these explicit indicators
-      if (
-        packageJson.eliza?.type === 'plugin' ||
-        packageJson.name?.includes('plugin-') ||
-        (packageJson.keywords &&
-          Array.isArray(packageJson.keywords) &&
-          packageJson.keywords.some((k: string) => k === 'elizaos-plugin' || k === 'eliza-plugin'))
-      ) {
-        isPlugin = true;
-        console.info('Identified as a plugin package');
-      }
-
-      // More specific check for projects
-      if (
-        packageJson.eliza?.type === 'project' ||
-        (packageJson.name &&
-          (packageJson.name.includes('project-') || packageJson.name.includes('-org'))) ||
-        (packageJson.keywords &&
-          Array.isArray(packageJson.keywords) &&
-          packageJson.keywords.some(
-            (k: string) => k === 'elizaos-project' || k === 'eliza-project'
-          ))
-      ) {
-        isProject = true;
-        console.info('Identified as a project package');
-      }
-
-      // If still not identified, check if it has src/index.ts with a Project export
-      if (!isProject && !isPlugin) {
-        const indexPath = path.join(cwd, 'src', 'index.ts');
-        if (fs.existsSync(indexPath)) {
-          const indexContent = fs.readFileSync(indexPath, 'utf-8');
-          if (
-            indexContent.includes('export const project') ||
-            (indexContent.includes('export default') && indexContent.includes('Project'))
-          ) {
-            isProject = true;
-            console.info('Identified as a project by src/index.ts export');
-          }
-        }
-      }
-    } catch (error) {
-      console.warn(`Error parsing package.json: ${error}`);
-    }
-  }
-
-  return { isProject, isPlugin };
 }
 
 /**
@@ -280,7 +208,17 @@ export const dev = new Command()
   .action(async (options) => {
     try {
       const cwd = process.cwd();
-      const { isProject, isPlugin } = await determineProjectType();
+      const directoryInfo = detectDirectoryType(cwd);
+
+      // Determine if this is a project or plugin based on directory detection
+      const isProject = directoryInfo.type === 'elizaos-project';
+      const isPlugin = directoryInfo.type === 'elizaos-plugin';
+
+      if (isProject) {
+        console.info('Identified as an ElizaOS project package');
+      } else if (isPlugin) {
+        console.info('Identified as an ElizaOS plugin package');
+      }
 
       // Prepare CLI arguments for the start command
       const cliArgs: string[] = [];
@@ -372,7 +310,7 @@ export const dev = new Command()
 
       if (!isProject && !isPlugin) {
         console.warn(
-          'Not in a recognized project or plugin directory. Running in standalone mode.'
+          `Not in a recognized ElizaOS project or plugin directory. Current directory is: ${getDirectoryTypeDescription(directoryInfo)}. Running in standalone mode.`
         );
       } else {
         console.info(`Running in ${isProject ? 'project' : 'plugin'} mode`);

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -115,7 +115,6 @@ export const pluginsCommand = plugins
   .option('--v0', 'List only v0.x compatible plugins')
   .action(async (opts: { all?: boolean; v0?: boolean }) => {
     try {
-      logHeader('Listing available plugins from registry...');
       const cachedRegistry = await fetchPluginRegistry();
 
       if (


### PR DESCRIPTION
**Overview**

This PR refactors the ElizaOS CLI codebase to use a standardized directory detection utility (directory-detection.ts) instead of multiple custom directory detection functions scattered across different files.

**Key Improvements**

Eliminated Duplicate Code
- Removed readPackageJson() function from plugins.ts (35 lines)
- Removed determineProjectType() function from dev.ts (73 lines)
- Removed extensive custom detection logic from publish.ts (~80 lines)
- Removed custom directory detection from start.ts

Standardized Detection Logic
- All commands now use the same detection functions:
- detectDirectoryType(dir: string): DirectoryInfo
- getDirectoryTypeDescription(info: DirectoryInfo): string


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Unified and centralized project and plugin detection using a standardized directory detection utility across multiple commands.
	- Simplified and improved logging messages to provide clearer feedback on directory type and issues encountered.
	- Enhanced error handling for missing or unreadable configuration files, with more descriptive directory type information.
- **Bug Fixes**
	- Improved reliability and accuracy in identifying projects and plugins, reducing false positives from heuristic checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->