### PR TITLE
fix: choice action null check

### DIFF
--- a/packages/plugin-bootstrap/src/actions/choice.ts
+++ b/packages/plugin-bootstrap/src/actions/choice.ts
@@ -138,6 +138,11 @@ export const choiceAction: Action = {
 
     const room = state.data.room ?? (await runtime.getRoom(message.roomId));
 
+    if (!room || !room.serverId) {
+      logger.error('Room or room.serverId is missing');
+      throw new Error('Room or room.serverId is required for validating the action');
+    }
+
     const userRole = await getUserServerRole(runtime, message.entityId, room.serverId);
 
     if (userRole !== 'OWNER' && userRole !== 'ADMIN') {


### PR DESCRIPTION
Fixes a bug in CHOOSE_OPTION action validation where room.serverId could be null, causing a TypeError.

![image](https://github.com/user-attachments/assets/67d5abd5-b9ec-4215-8462-42b8cd761cdd)
