### PR TITLE
chore: Optimize plugin loading to reduce startup log spam

### DIFF
--- a/packages/cli/src/utils/load-plugin.ts
+++ b/packages/cli/src/utils/load-plugin.ts
@@ -58,14 +58,17 @@ async function readPackageJson(repository: string): Promise<PackageJson | null> 
 async function tryImporting(
   importPath: string,
   strategy: string,
-  repository: string
+  repository: string,
+  silentFailure = false
 ): Promise<any | null> {
   try {
     const module = await import(importPath);
     logger.success(`Successfully loaded plugin '${repository}' using ${strategy} (${importPath})`);
     return module;
   } catch (error) {
-    logger.debug(`Import failed using ${strategy} ('${importPath}'):`, error);
+    if (!silentFailure) {
+      logger.debug(`Import failed using ${strategy} ('${importPath}'):`, error);
+    }
     return null;
   }
 }
@@ -74,28 +77,7 @@ async function tryImporting(
  * Collection of import strategies
  */
 const importStrategies: ImportStrategy[] = [
-  {
-    name: 'direct path',
-    tryImport: async (repository: string) => tryImporting(repository, 'direct path', repository),
-  },
-  {
-    name: 'local node_modules',
-    tryImport: async (repository: string) =>
-      tryImporting(resolveNodeModulesPath(repository), 'local node_modules', repository),
-  },
-  {
-    name: 'global node_modules',
-    tryImport: async (repository: string) => {
-      const globalPath = path.resolve(getGlobalNodeModulesPath(), repository);
-      if (!fs.existsSync(path.dirname(globalPath))) {
-        logger.debug(
-          `Global node_modules directory not found at ${path.dirname(globalPath)}, skipping for ${repository}`
-        );
-        return null;
-      }
-      return tryImporting(globalPath, 'global node_modules', repository);
-    },
-  },
+  // Most likely to succeed for installed packages - check package.json entry first
   {
     name: 'package.json entry',
     tryImport: async (repository: string) => {
@@ -106,10 +88,12 @@ const importStrategies: ImportStrategy[] = [
       return tryImporting(
         resolveNodeModulesPath(repository, entryPoint),
         `package.json entry (${entryPoint})`,
-        repository
+        repository,
+        true
       );
     },
   },
+  // Second most common - standard dist/index.js pattern
   {
     name: 'common dist pattern',
     tryImport: async (repository: string) => {
@@ -119,22 +103,87 @@ const importStrategies: ImportStrategy[] = [
       return tryImporting(
         resolveNodeModulesPath(repository, DEFAULT_ENTRY_POINT),
         'common dist pattern',
-        repository
+        repository,
+        true
       );
+    },
+  },
+  // Try local node_modules directory import (for packages without explicit entry)
+  {
+    name: 'local node_modules',
+    tryImport: async (repository: string) =>
+      tryImporting(resolveNodeModulesPath(repository), 'local node_modules', repository, true),
+  },
+  // Direct path import (for relative/absolute paths)
+  {
+    name: 'direct path',
+    tryImport: async (repository: string) => tryImporting(repository, 'direct path', repository, true),
+  },
+  // Least likely - global node_modules (usually for globally installed packages)
+  {
+    name: 'global node_modules',
+    tryImport: async (repository: string) => {
+      const globalPath = path.resolve(getGlobalNodeModulesPath(), repository);
+      if (!fs.existsSync(path.dirname(globalPath))) {
+        return null;
+      }
+      return tryImporting(globalPath, 'global node_modules', repository, true);
     },
   },
 ];
 
 /**
+ * Determines the optimal import strategy based on what's available
+ */
+async function getOptimalStrategy(repository: string): Promise<ImportStrategy | null> {
+  const packageJson = await readPackageJson(repository);
+  
+  if (packageJson) {
+    const entryPoint = packageJson.module || packageJson.main || DEFAULT_ENTRY_POINT;
+    const entryPath = resolveNodeModulesPath(repository, entryPoint);
+    
+    if (fs.existsSync(entryPath)) {
+      return {
+        name: `package.json entry (${entryPoint})`,
+        tryImport: async () => tryImporting(entryPath, `package.json entry (${entryPoint})`, repository)
+      };
+    }
+  }
+  
+  const commonDistPath = resolveNodeModulesPath(repository, DEFAULT_ENTRY_POINT);
+  if (fs.existsSync(commonDistPath)) {
+    return {
+      name: 'common dist pattern',
+      tryImport: async () => tryImporting(commonDistPath, 'common dist pattern', repository)
+    };
+  }
+  
+  const localNodeModulesPath = resolveNodeModulesPath(repository);
+  if (fs.existsSync(localNodeModulesPath)) {
+    return {
+      name: 'local node_modules',
+      tryImport: async () => tryImporting(localNodeModulesPath, 'local node_modules', repository)
+    };
+  }
+  
+  return null;
+}
+
+/**
  * Attempts to load a plugin module using various strategies.
- * It tries direct import, local node_modules, global node_modules,
- * package.json entry points, and common dist patterns.
+ * First tries to find the optimal path, then falls back to trying all strategies.
  *
  * @param repository - The plugin repository/package name to load.
  * @returns The loaded plugin module or null if loading fails after all attempts.
  */
 export async function loadPluginModule(repository: string): Promise<any | null> {
   //logger.debug(`Attempting to load plugin module: ${repository}`);
+
+  const optimalStrategy = await getOptimalStrategy(repository);
+  if (optimalStrategy) {
+    const result = await optimalStrategy.tryImport(repository);
+    if (result) return result;
+  }
 
   for (const strategy of importStrategies) {
     const result = await strategy.tryImport(repository);


### PR DESCRIPTION
## Summary
- Implement smart strategy selection that checks file existence before attempting imports to find optimal path in one shot
- Reorder import strategies to prioritize most likely successful paths (package.json entry first, then common dist pattern)
- Make fallback strategy failures silent to reduce debug log noise while maintaining robust fallback system

## Problem
During elizaOS startup, the plugin loading system generates excessive debug logs and errors as it tries multiple import strategies sequentially before finding the correct one. This creates log spam and slower startup times with messages like:

```
[2025-06-01 13:42:55] DEBUG: Import failed using direct path ('@elizaos/plugin-bootstrap'):
[2025-06-01 13:42:55] DEBUG: Import failed using local node_modules ('/Users/studio/Documents/agi2/node_modules/@elizaos/plugin-bootstrap'):
[2025-06-01 13:42:55] DEBUG: Global node_modules directory not found...
[2025-06-01 13:42:55] DEBUG: Import failed using common dist pattern...
[2025-06-01 13:43:00] SUCCESS: Successfully loaded plugin '@elizaos/plugin-bootstrap' using package.json entry (dist/index.js)
```

## Solution
1. **Smart Strategy Selection**: Added `getOptimalStrategy()` function that checks file existence before attempting imports
2. **Optimized Strategy Order**: Reordered strategies to prioritize most likely successful paths:
   - package.json entry (most common for installed packages)
   - common dist pattern (dist/index.js)
   - local node_modules directory
   - direct path
   - global node_modules (least likely)
3. **Silent Fallback Failures**: Made fallback strategy failures silent to reduce log noise

## Test plan
- [ ] Test plugin loading with existing installed plugins (should succeed on first attempt)
- [ ] Test plugin auto-installation workflow still works
- [ ] Verify fallback strategies still work for edge cases
- [ ] Confirm log output is significantly reduced during startup
