### PR TITLE
fix: Removes plugin-specification submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "plugin-specification"]
-	path = plugin-specification
-	url = https://github.com/elizaos/plugin-specification


### PR DESCRIPTION
Removes the plugin-specification submodule from the repository.

This change simplifies the project structure by removing an unused submodule.