### PR TITLE
fix: foreign key issue in chat messages

### DIFF
--- a/packages/cli/src/server/api/messages.ts
+++ b/packages/cli/src/server/api/messages.ts
@@ -199,6 +199,7 @@ export function MessagesRouter(serverInstance: AgentServer): express.Router {
         // Auto-create the channel if it doesn't exist
         try {
           const channelData = {
+            id: channelIdParam as UUID, // Use the specific channel ID from the URL
             messageServerId: server_id as UUID,
             name: `Chat ${channelIdParam.substring(0, 8)}`, // Default name
             type: ChannelType.GROUP, // Default to GROUP type

--- a/packages/cli/src/server/index.ts
+++ b/packages/cli/src/server/index.ts
@@ -736,7 +736,7 @@ export class AgentServer {
   }
 
   async createChannel(
-    data: Omit<MessageChannel, 'id' | 'createdAt' | 'updatedAt'>,
+    data: Omit<MessageChannel, 'id' | 'createdAt' | 'updatedAt'> & { id?: UUID },
     participantIds?: UUID[]
   ): Promise<MessageChannel> {
     return (this.database as any).createChannel(data, participantIds);

--- a/packages/cli/src/server/socketio/index.ts
+++ b/packages/cli/src/server/socketio/index.ts
@@ -174,6 +174,7 @@ export class SocketIORouter {
         // Auto-create the channel if it doesn't exist
         try {
           const channelData = {
+            id: channelId as UUID, // Use the specific channel ID from the client
             messageServerId: serverId as UUID,
             name: `Chat ${channelId.substring(0, 8)}`, // Default name
             type: ChannelType.GROUP, // Default to GROUP type

--- a/packages/plugin-sql/src/base.ts
+++ b/packages/plugin-sql/src/base.ts
@@ -2942,6 +2942,7 @@ export abstract class BaseDrizzleAdapter<
    */
   async createChannel(
     data: {
+      id?: UUID; // Allow passing a specific ID
       messageServerId: UUID;
       name: string;
       type: string;
@@ -2964,7 +2965,7 @@ export abstract class BaseDrizzleAdapter<
     updatedAt: Date;
   }> {
     return this.withDatabase(async () => {
-      const newId = v4() as UUID;
+      const newId = data.id || (v4() as UUID);
       const now = new Date();
       const channelToInsert = {
         id: newId,


### PR DESCRIPTION
Chat messages were broken on send. channeld was not being passed through.


```
[2025-06-03 04:38:22] ERROR: [SocketIO -e53_zI1X1FYfB4MAAAF] Error during central submission for message: insert or update on table "central_messages" violates foreign key constraint "central_messages_channel_id_channels_id_fk"
    message: "(error) insert or update on table \"central_messages\" violates foreign key constraint \"central_messages_channel_id_channels_id_fk\""
    stack: [
      "error: in
```