### PR TITLE
chore: clean .elizadb and .eliza on bun run clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:client": "turbo run build --filter=@elizaos/client",
     "format": "turbo run format --filter=./packages/*",
     "format:check": "turbo run format:check --filter=./packages/*",
-    "clean": "turbo run clean --filter=./packages/* && rm -rf dist .turbo node_modules .turbo-tsconfig.json tsconfig.tsbuildinfo bun.lock*",
+    "clean": "turbo run clean --filter=./packages/* && rm -rf dist .turbo node_modules .turbo-tsconfig.json tsconfig.tsbuildinfo bun.lock* .eliza .elizadb",
     "build:cli": "turbo run build --filter=@elizaos/cli --no-cache",
     "build:core": "turbo run build --filter=@elizaos/core --no-cache",
     "lint": "turbo run lint --filter=./packages/* && prettier --write . && prettier --check .",


### PR DESCRIPTION
Getting errors like:

```
[2025-06-03 16:47:43] ERROR: Failed to run database migrations (pglite):
    message: "(RuntimeError) unreachable"
    stack: [
      "RuntimeError: unreachable",
      "at wasm://wasm/01edd1ba:wasm-function[3611]:0x262a57",
      "at wasm://wasm/01edd1ba:wasm-function[3610]:0x2627f9",
      "at wasm://wasm/01edd1ba:wasm-function[7801]:0x3e3502",
      "at wasm://wasm/01edd1ba:wasm-function[2533]:0x1c1034",
      "at Module._pg_initdb (file:///Users/cjft/Documents/git/eliza/eliza/node_modules/@electric-sql/pglite/dist/index.js:3:124284)",
      "at pe.qe (file:///Users/cjft/Documents/git/eliza/eliza/node_modules/@electric-sql/pglite/dist/index.js:3:243608)",
      "at async pe._checkReady (file:///Users/cjft/Documents/git/eliza/eliza/node_modules/@electric-sql/pglite/dist/index.js:3:238920)",
      "at async pe.query (file:///Users/cjft/Documents/git/eliza/eliza/node_modules/@electric-sql/pglite/dist/chunk-A7RFOIQ7.js:8:255)",
      "at async PgDialect.migrate (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:95929:5)",
      "at async migrate (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:99192:3)",
      "at async PGliteClientManager.runMigrations (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:99608:7)",
      "at async PgliteDatabaseAdapter.init (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:102291:7)",
      "at async AgentServer.initialize (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:108941:7)",
      "at async startAgents (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:109670:3)",
      "at async _Command.<anonymous> (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:109919:5)",
      "at async _Command.parseAsync (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-5J7S2CSH.js:1721:9)",
      "at async main (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/index.js:101:3)"
    ]
[2025-06-03 16:47:43] ERROR: An error occurred:
    message: "(RuntimeError) unreachable"
    stack: [
      "RuntimeError: unreachable",
      "at wasm://wasm/01edd1ba:wasm-function[3611]:0x262a57",
      "at wasm://wasm/01edd1ba:wasm-function[3610]:0x2627f9",
      "at wasm://wasm/01edd1ba:wasm-function[7801]:0x3e3502",
      "at wasm://wasm/01edd1ba:wasm-function[2533]:0x1c1034",
      "at Module._pg_initdb (file:///Users/cjft/Documents/git/eliza/eliza/node_modules/@electric-sql/pglite/dist/index.js:3:124284)",
      "at pe.qe (file:///Users/cjft/Documents/git/eliza/eliza/node_modules/@electric-sql/pglite/dist/index.js:3:243608)",
      "at async pe._checkReady (file:///Users/cjft/Documents/git/eliza/eliza/node_modules/@electric-sql/pglite/dist/index.js:3:238920)",
      "at async pe.query (file:///Users/cjft/Documents/git/eliza/eliza/node_modules/@electric-sql/pglite/dist/chunk-A7RFOIQ7.js:8:255)",
      "at async PgDialect.migrate (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:95929:5)",
      "at async migrate (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:99192:3)",
      "at async PGliteClientManager.runMigrations (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:99608:7)",
      "at async PgliteDatabaseAdapter.init (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:102291:7)",
      "at async AgentServer.initialize (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:108941:7)",
      "at async startAgents (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:109670:3)",
      "at async _Command.<anonymous> (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:109919:5)",
      "at async _Command.parseAsync (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-5J7S2CSH.js:1721:9)",
      "at async main (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/index.js:101:3)"
    ]
[2025-06-03 16:47:43] ERROR: Error details: unreachable
[2025-06-03 16:47:43] ERROR: Stack trace: RuntimeError: unreachable
    at wasm://wasm/01edd1ba:wasm-function[3611]:0x262a57
    at wasm://wasm/01edd1ba:wasm-function[3610]:0x2627f9
    at wasm://wasm/01edd1ba:wasm-function[7801]:0x3e3502
    at wasm://wasm/01edd1ba:wasm-function[2533]:0x1c1034
    at Module._pg_initdb (file:///Users/cjft/Documents/git/eliza/eliza/node_modules/@electric-sql/pglite/dist/index.js:3:124284)
    at pe.qe (file:///Users/cjft/Documents/git/eliza/eliza/node_modules/@electric-sql/pglite/dist/index.js:3:243608)
    at async pe._checkReady (file:///Users/cjft/Documents/git/eliza/eliza/node_modules/@electric-sql/pglite/dist/index.js:3:238920)
    at async pe.query (file:///Users/cjft/Documents/git/eliza/eliza/node_modules/@electric-sql/pglite/dist/chunk-A7RFOIQ7.js:8:255)
    at async PgDialect.migrate (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:95929:5)
    at async migrate (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:99192:3)
    at async PGliteClientManager.runMigrations (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:99608:7)
    at async PgliteDatabaseAdapter.init (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:102291:7)
    at async AgentServer.initialize (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:108941:7)
    at async startAgents (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:109670:3)
    at async _Command.<anonymous> (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-6TGI7OF4.js:109919:5)
    at async _Command.parseAsync (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/chunk-5J7S2CSH.js:1721:9)
    at async main (file:///Users/cjft/Documents/git/eliza/eliza/packages/cli/dist/index.js:101:3)
[2025-06-03 10:47:43.154 -0600] ERROR: Failed to create agent entity: unreachable
```

Need to wipe DB on clean, if start from scratch. Common issue.