### PR TITLE
fix: plugin route handler intercepting agent API routes

### DIFF
--- a/packages/cli/src/server/api/index.ts
+++ b/packages/cli/src/server/api/index.ts
@@ -511,6 +511,14 @@ export function createPluginRouteHandler(agents: Map<UUID, IAgentRuntime>): expr
       query: req.query,
     });
 
+    // Skip standard agent API routes - these should be handled by agentRouter
+    // Pattern: /agents/{uuid}/... but NOT /agents/{uuid}/plugins/{pluginName}/...
+    const agentApiRoutePattern = /^\/agents\/[a-f0-9-]{36}\/(?!plugins\/)/i;
+    if (agentApiRoutePattern.test(req.path)) {
+      logger.debug(`Skipping agent API route in plugin handler: ${req.path}`);
+      return next();
+    }
+
     // Debug output for JavaScript requests
     if (
       req.path.endsWith('.js') ||


### PR DESCRIPTION
## Problem

The plugin route handler was incorrectly trying to handle standard agent API routes, causing debug messages like:

```
[2025-06-04 08:57:23] DEBUG: No valid agentId in query. Trying global match for path: /api/agents/b850bc30-45f8-0041-a00a-83df46d8555d/logs
[2025-06-04 08:57:23] DEBUG: No plugin route handled GET /api/agents/b850bc30-45f8-0041-a00a-83df46d8555d/logs, passing to next middleware.
```

## Root Cause

The issue occurs in the `createPluginRouteHandler` function when:

1. A request comes in for `/api/agents/{uuid}/logs`
2. The plugin handler checks for `agentId` in query parameters (but agent routes use path parameters)
3. Since there's no `agentId` query param, it falls through to "global plugin route matching"
4. It tries to match the agent API route against plugin routes from all agents
5. This fails and generates unnecessary debug logs

The route should be handled by the agent router at `/agents/:agentId/logs`, not the plugin handler.

## Solution

Added a pattern check in the plugin route handler to skip standard agent API routes:

```typescript
// Skip standard agent API routes - these should be handled by agentRouter
// Pattern: /agents/{uuid}/... but NOT /agents/{uuid}/plugins/{pluginName}/...
const agentApiRoutePattern = /^\/agents\/[a-f0-9-]{36}\/(?\!plugins\/)/i;
if (agentApiRoutePattern.test(req.path)) {
  logger.debug(`Skipping agent API route in plugin handler: ${req.path}`);
  return next();
}
```

This ensures:
- ✅ `/agents/{uuid}/logs` → skips plugin handler (goes to agent router)
- ✅ `/agents/{uuid}/rooms` → skips plugin handler (goes to agent router)  
- ✅ `/agents/{uuid}/memories` → skips plugin handler (goes to agent router)
- ❌ `/agents/{uuid}/plugins/{pluginName}/...` → handled by plugin handler

## Testing

The fix can be verified by:
1. Making requests to `/api/agents/{uuid}/logs`
2. Confirming no more "No valid agentId in query" debug messages
3. Ensuring the logs endpoint still works correctly
4. Verifying plugin routes still work for `/api/agents/{uuid}/plugins/{name}/...`