### PR TITLE
fix: remove duplicate @elizaos/cli dependency from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,5 @@
     "protobufjs",
     "utf-8-validate"
   ],
-  "dependencies": {
-    "@elizaos/cli": "1.0.4"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
This PR fixes the bun install error caused by having `@elizaos/cli` listed as both a workspace package and a root dependency.

### Changes
- Removed `@elizaos/cli` from root `package.json` dependencies since it's already available as a workspace package

### Issue Fixed
This resolves the following error during `bun install`:
```
error: Duplicate package path
    at bun.lock:908:5
InvalidPackageKey: failed to parse lockfile: 'bun.lock'
```

### Testing
- [x] Verified `bun install` completes successfully after the change
- [x] Workspace package `@elizaos/cli` remains available through workspace configuration