### PR TITLE
chore: force bun in cli, add install docs, emoji cross platform support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -321,7 +321,7 @@
         "@elizaos/plugin-telegram": "1.0.0",
       },
       "devDependencies": {
-        "@elizaos/cli": "1.0.4",
+        "@elizaos/cli": "workspace:*",
         "@types/node": "^22.15.3",
         "prettier": "3.5.3",
         "tsup": "8.4.0",
@@ -422,12 +422,12 @@
     "node-llama-cpp",
   ],
   "overrides": {
-    "@types/react": "19.1.5",
-    "typedoc": "0.27.9",
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
     "@nrwl/devkit": "19.8.4",
     "@nrwl/tao": "19.8.4",
+    "@types/react": "19.1.5",
+    "react": "19.1.0",
+    "react-dom": "19.1.0",
+    "typedoc": "0.27.9",
     "typedoc-plugin-markdown": "4.2.10",
   },
   "packages": {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -198,7 +198,7 @@ Publish a plugin to the registry.
 
 The `elizaos publish` command is designed for **initial plugin publishing only**. After initial publishing, use standard npm and git workflows for updates:
 
-- `npm version patch|minor|major` to update version
+- `bun version patch|minor|major` to update version (or `npm version` if preferred)
 - `npm publish` to publish to npm
 - `git push origin main && git push --tags` to update GitHub
 
@@ -644,7 +644,7 @@ Plugins extend the functionality of ElizaOS agents by providing additional capab
    elizaos test
 
    # Update version and publish updates
-   npm version patch  # or minor/major
+   bun version patch  # or minor/major (or npm version if preferred)
    npm publish
    git push origin main && git push --tags
    ```

--- a/packages/cli/examples/create-plugin-cli.sh
+++ b/packages/cli/examples/create-plugin-cli.sh
@@ -29,7 +29,7 @@ echo ""
 echo "Checking for Claude Code..."
 if ! command -v claude &> /dev/null; then
     echo "❌ Claude Code not found!"
-    echo "Please install it first: npm install -g @anthropic-ai/claude-code"
+    echo "Please install it first: bun install -g @anthropic-ai/claude-code"
     exit 1
 else
     echo "✓ Claude Code is installed"
@@ -82,7 +82,7 @@ if [[ ! -f "$CLI_DIR/package.json" ]] || [[ ! -d "$CLI_DIR/dist" ]]; then
     echo "❌ Could not find ElizaOS CLI directory"
     echo "Expected structure: packages/cli/dist and packages/cli/package.json"
     echo "Make sure this script is run from the packages/cli/examples directory"
-    echo "or that the CLI has been built (npm run build)"
+    echo "or that the CLI has been built (bun run build)"
     exit 1
 fi
 
@@ -140,8 +140,8 @@ if [ ${PIPESTATUS[0]} -eq 0 ]; then
         echo "Next steps:"
         echo "1. cd $CLI_DIR/plugin-time-tracker"
         echo "2. Review the generated code"
-        echo "3. npm install && npm run build"
-        echo "4. npm test"
+        echo "3. bun install && bun run build"
+        echo "4. bun test"
     fi
 else
     echo ""

--- a/packages/cli/examples/create-time-tracker-plugin-demo.sh
+++ b/packages/cli/examples/create-time-tracker-plugin-demo.sh
@@ -32,7 +32,7 @@ echo ""
 echo "Checking for Claude Code..."
 if ! command -v claude &> /dev/null; then
     echo "❌ Claude Code not found!"
-    echo "Please install it first: npm install -g @anthropic-ai/claude-code"
+    echo "Please install it first: bun install -g @anthropic-ai/claude-code"
     exit 1
 else
     CLAUDE_VERSION=$(claude --version 2>/dev/null || echo "unknown")
@@ -59,7 +59,7 @@ if [[ ! -f "$CLI_DIR/package.json" ]] || [[ ! -d "$CLI_DIR/dist" ]]; then
     echo "❌ Could not find ElizaOS CLI directory"
     echo "Expected structure: packages/cli/dist and packages/cli/package.json"
     echo "Make sure this script is run from the packages/cli/examples directory"
-    echo "or that the CLI has been built (npm run build)"
+    echo "or that the CLI has been built (bun run build)"
     exit 1
 fi
 
@@ -120,9 +120,9 @@ if [ $RESULT -eq 0 ]; then
         echo ""
         echo "📝 To use this plugin:"
         echo "1. cd $EXPECTED_DIR"
-        echo "2. npm install"
-        echo "3. npm run build"
-        echo "4. npm test"
+        echo "2. bun install"
+        echo "3. bun run build"
+        echo "4. bun test"
         echo ""
         echo "⚠️  Note: Since we skipped tests/validation in demo mode,"
         echo "   you should run full tests before using in production."

--- a/packages/cli/examples/create-time-tracker-plugin.sh
+++ b/packages/cli/examples/create-time-tracker-plugin.sh
@@ -40,7 +40,7 @@ echo ""
 echo "Checking for Claude Code..."
 if ! command -v claude &> /dev/null; then
     echo "❌ Claude Code not found!"
-    echo "Please install it first: npm install -g @anthropic-ai/claude-code"
+    echo "Please install it first: bun install -g @anthropic-ai/claude-code"
     exit 1
 else
     echo "✓ Claude Code is installed"
@@ -68,7 +68,7 @@ if [[ ! -f "$CLI_DIR/package.json" ]] || [[ ! -d "$CLI_DIR/dist" ]]; then
     echo "❌ Could not find ElizaOS CLI directory"
     echo "Expected structure: packages/cli/dist and packages/cli/package.json"
     echo "Make sure this script is run from the packages/cli/examples directory"
-    echo "or that the CLI has been built (npm run build)"
+    echo "or that the CLI has been built (bun run build)"
     exit 1
 fi
 
@@ -120,8 +120,8 @@ if [ ${PIPESTATUS[0]} -eq 0 ]; then
         echo "Next steps:"
         echo "1. cd $CLI_DIR/plugin-time-tracker"
         echo "2. Review the generated code"
-        echo "3. npm test (to run tests)"
-        echo "4. npm run build (to build)"
+        echo "3. bun test (to run tests)"
+        echo "4. bun run build (to build)"
         echo "5. Add to your ElizaOS project"
     fi
 else

--- a/packages/cli/examples/generate-plugin-simple.sh
+++ b/packages/cli/examples/generate-plugin-simple.sh
@@ -17,7 +17,7 @@ fi
 
 if ! command -v claude &> /dev/null; then
     echo "❌ Claude Code not found. Install with:"
-    echo "   npm install -g @anthropic-ai/claude-code"
+    echo "   bun install -g @anthropic-ai/claude-code"
     exit 1
 fi
 

--- a/packages/cli/examples/generate-time-plugin.sh
+++ b/packages/cli/examples/generate-time-plugin.sh
@@ -22,7 +22,7 @@ fi
 # Check if Claude Code is installed
 if ! command -v claude &> /dev/null; then
     echo "❌ Claude Code not found!"
-    echo "Please install it first: npm install -g @anthropic-ai/claude-code"
+    echo "Please install it first: bun install -g @anthropic-ai/claude-code"
     exit 1
 fi
 
@@ -137,8 +137,8 @@ if [ $? -eq 0 ]; then
         echo "✨ Next steps:"
         echo "1. cd $TEST_DIR/plugin-time-tracker"
         echo "2. Review the generated code"
-        echo "3. npm test (to run tests)"
-        echo "4. npm run build (to build)"
+        echo "3. bun test (to run tests)"
+        echo "4. bun run build (to build)"
         echo "5. Add to your ElizaOS project"
     fi
 else

--- a/packages/cli/examples/upgrade-giphy.sh
+++ b/packages/cli/examples/upgrade-giphy.sh
@@ -39,7 +39,7 @@ echo ""
 echo "Checking for Claude Code..."
 if ! command -v claude &> /dev/null; then
     echo "❌ Claude Code not found!"
-    echo "Please install it first: npm install -g @anthropic-ai/claude-code"
+    echo "Please install it first: bun install -g @anthropic-ai/claude-code"
     exit 1
 else
     echo "✓ Claude Code is installed"
@@ -85,7 +85,7 @@ if [ ${PIPESTATUS[0]} -eq 0 ]; then
     echo "Next steps:"
     echo "  1. cd /tmp/plugin-giphy"
     echo "  2. git diff main...1.x-claude  # Review changes"
-    echo "  3. npm test                    # Run tests"
+    echo "  3. bun test                    # Run tests"
     echo "  4. git push origin 1.x-claude  # Push branch"
 else
     echo ""

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -7,6 +7,7 @@ import { Command } from 'commander';
 import { execa } from 'execa';
 import fs from 'node:fs';
 import path from 'node:path';
+import { emoji } from '../utils/emoji-handler';
 
 // --- Helper Functions ---
 
@@ -442,11 +443,11 @@ plugins
       });
 
       // Run migration
-      console.log(`\n🚀 Starting plugin upgrade for: ${pluginPath}\n`);
+      console.log(`\n${emoji.rocket(`Starting plugin upgrade for: ${pluginPath}`)}\n`);
       const result = await migrator.migrate(pluginPath);
 
       if (result.success) {
-        console.log(`\n✅ Plugin successfully upgraded!`);
+        console.log(`\n${emoji.success('Plugin successfully upgraded!')}`);
         console.log(`   Branch: ${result.branchName}`);
         console.log(`   Location: ${result.repoPath}`);
         console.log(`\nThe upgraded plugin has been copied to your current directory.`);
@@ -514,11 +515,11 @@ plugins
       });
 
       // Run generation
-      console.log(`\n🚀 Starting AI-powered plugin generation...\n`);
+      console.log(`\n${emoji.rocket('Starting AI-powered plugin generation...')}\n`);
       const result = await creator.create();
 
       if (result.success) {
-        console.log(`\n✅ Plugin successfully generated!`);
+        console.log(`\n${emoji.success('Plugin successfully generated!')}`);
         console.log(`   Name: ${result.pluginName}`);
         console.log(`   Location: ${result.pluginPath}`);
         console.log(`\nThe plugin has been created in your current directory.`);

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -12,7 +12,7 @@ import path from 'node:path';
 
 /**
  * Normalizes a plugins input string to a standard format, typically 'plugin-name'.
- * Used primarily for display and generating commands in npx instructions.
+ * Used primarily for display and generating commands in bunx instructions.
  */
 export const normalizePluginNameForDisplay = (pluginInput: string): string => {
   let baseName = pluginInput;
@@ -525,7 +525,7 @@ plugins
         console.log(`\nNext steps:`);
         console.log(`1. cd ${path.basename(result.pluginPath)}`);
         console.log(`2. Review the generated code`);
-        console.log(`3. Test the plugin: npm test`);
+        console.log(`3. Test the plugin: bun test`);
         console.log(`4. Add to your ElizaOS project`);
       } else {
         logger.error(`Plugin generation failed: ${result.error?.message}`);

--- a/packages/cli/src/commands/setup-monorepo.ts
+++ b/packages/cli/src/commands/setup-monorepo.ts
@@ -60,7 +60,26 @@ function displayNextSteps(dir: string): void {
   console.log('\n4. Start ElizaOS:');
   console.log('   bun run start or bun run dev');
 
-  console.log('\nNote: Make sure you have Node.js and bun installed on your system.');
+  // Enhanced bun installation guidance
+  console.log('\n📋 Prerequisites:');
+  console.log('   • Node.js 23.3.0+');
+  console.log('   • Bun (JavaScript runtime & package manager)');
+  
+  console.log('\n🚀 If you don\'t have Bun installed:');
+  const platform = process.platform;
+  
+  if (platform === 'win32') {
+    console.log('   Windows: powershell -c "irm bun.sh/install.ps1 | iex"');
+    console.log('   Alternative: scoop install bun (if you have Scoop)');
+  } else {
+    console.log('   Linux/macOS: curl -fsSL https://bun.sh/install | bash');
+    if (platform === 'darwin') {
+      console.log('   macOS alternative: brew install bun (if you have Homebrew)');
+    }
+  }
+  
+  console.log('   More options: https://bun.sh/docs/installation');
+  console.log('   After installation, restart your terminal');
 }
 
 export const setupMonorepo = new Command()

--- a/packages/cli/src/commands/setup-monorepo.ts
+++ b/packages/cli/src/commands/setup-monorepo.ts
@@ -3,6 +3,7 @@ import { Command } from 'commander';
 import { execa } from 'execa';
 import fs from 'node:fs';
 import path from 'node:path';
+import { emoji } from '../utils/emoji-handler';
 
 /**
  * Clones a GitHub repository at a specified branch into a target directory.
@@ -58,14 +59,12 @@ function displayNextSteps(dir: string): void {
 
   // Step 4: Start ElizaOS
   console.log('\n4. Start ElizaOS:');
-  console.log('   bun run start or bun run dev');
+  console.log('   bun run start or bun run dev');  // Enhanced bun installation guidance
+  console.log(`\n${emoji.list('Prerequisites:')}`);
+  console.log(`   ${emoji.bullet('Node.js 23.3.0+')}`);
+  console.log(`   ${emoji.bullet('Bun (JavaScript runtime & package manager)')}`);
 
-  // Enhanced bun installation guidance
-  console.log('\n📋 Prerequisites:');
-  console.log('   • Node.js 23.3.0+');
-  console.log('   • Bun (JavaScript runtime & package manager)');
-  
-  console.log('\n🚀 If you don\'t have Bun installed:');
+  console.log(`\n${emoji.rocket('If you don\'t have Bun installed:')}`);
   const platform = process.platform;
   
   if (platform === 'win32') {

--- a/packages/cli/src/commands/tee/phala-wrapper.ts
+++ b/packages/cli/src/commands/tee/phala-wrapper.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { spawn } from 'node:child_process';
 import { elizaLogger } from '@elizaos/core';
+import { emoji } from '../../utils/emoji-handler';
 
 /**
  * Wrapper command that delegates to the official Phala CLI
@@ -27,13 +28,15 @@ export const phalaCliCommand = new Command('phala')
         elizaLogger.error('Failed to execute Phala CLI:', error);
 
         if (error.message.includes('ENOENT')) {
-          elizaLogger.error('\n❌ Error: npx not found. Please install Node.js and npm:');
+          elizaLogger.error(
+            `\n${emoji.error('Error: npx not found. Please install Node.js and npm:')}`
+          );
           elizaLogger.error('   Visit https://nodejs.org or use a version manager like nvm');
           elizaLogger.error(
             '   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash'
           );
         } else {
-          elizaLogger.error('\n❌ Error: Failed to execute Phala CLI');
+          elizaLogger.error(`\n${emoji.error('Error: Failed to execute Phala CLI')}`);
           elizaLogger.error('   Try running directly: npx phala', args.join(' '));
         }
         process.exit(1);
@@ -47,7 +50,7 @@ export const phalaCliCommand = new Command('phala')
       });
     } catch (error) {
       elizaLogger.error('Error running Phala CLI:', error);
-      elizaLogger.error('\n❌ Error: Failed to run Phala CLI');
+      elizaLogger.error(`\n${emoji.error('Error: Failed to run Phala CLI')}`);
       elizaLogger.error('   Try running Phala CLI directly with: npx phala', args.join(' '));
       elizaLogger.error('   Or visit https://www.npmjs.com/package/phala for more information');
       process.exit(1);

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -316,9 +316,9 @@ export const update = new Command()
         if (isNpx || isBunx) {
           console.warn('CLI update is not available when running via npx or bunx.');
           console.info('Please install the CLI globally:');
-          console.info('  npm install -g @elizaos/cli');
+          console.info('  bun install -g @elizaos/cli');
           console.info('  # or');
-          console.info('  bun add -g @elizaos/cli');
+          console.info('  npm install -g @elizaos/cli');
 
           if (!updatePackages) return;
         } else {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,10 +15,11 @@ import { test } from '@/src/commands/test';
 import { update } from '@/src/commands/update';
 import { displayBanner, getVersion, checkAndShowUpdateNotification } from '@/src/utils';
 import { logger } from '@elizaos/core';
-import { Command, Option } from 'commander';
+import { Command } from 'commander';
 import fs from 'node:fs';
 import path, { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { configureEmojis } from '@/src/utils/emoji-handler';
 
 process.on('SIGINT', () => process.exit(0));
 process.on('SIGTERM', () => process.exit(0));
@@ -29,6 +30,11 @@ process.on('SIGTERM', () => process.exit(0));
  * @returns {Promise<void>}
  */
 async function main() {
+  // Check for --no-emoji flag early (before command parsing)
+  if (process.argv.includes('--no-emoji')) {
+    configureEmojis({ forceDisable: true });
+  }
+
   // For ESM modules we need to use import.meta.url instead of __dirname
   const __filename = fileURLToPath(import.meta.url);
   const __dirname = dirname(__filename);

--- a/packages/cli/src/utils/bun-installation-helper.ts
+++ b/packages/cli/src/utils/bun-installation-helper.ts
@@ -1,22 +1,23 @@
 import { logger } from '@elizaos/core';
+import { emoji } from './emoji-handler';
 
 /**
  * Display helpful bun installation instructions with OS-specific commands
  */
 export function displayBunInstallationTips(): void {
-  logger.error('\n❌ Bun is not installed or not found in PATH');
-  logger.info('\n🚀 Install Bun using the appropriate command for your system:');
+  logger.error(`\n${emoji.error('Bun is not installed or not found in PATH')}`);
+  logger.info(`\n${emoji.rocket('Install Bun using the appropriate command for your system:')}`);
   
   // Detect OS and show relevant command
   const platform = process.platform;
   
   if (platform === 'win32') {
-    logger.info('\n📦 Windows:');
+    logger.info(`\n${emoji.package('Windows:')}`);
     logger.info('   powershell -c "irm bun.sh/install.ps1 | iex"');
     logger.info('   # or use Scoop: scoop install bun');
     logger.info('   # or use Chocolatey: choco install bun');
   } else {
-    logger.info('\n🐧 Linux/macOS:');
+    logger.info(`\n${emoji.penguin('Linux/macOS:')}`);
     logger.info('   curl -fsSL https://bun.sh/install | bash');
     
     if (platform === 'darwin') {
@@ -24,8 +25,8 @@ export function displayBunInstallationTips(): void {
     }
   }
   
-  logger.info('\n🔗 More installation options: https://bun.sh/docs/installation');
-  logger.info('\n💡 After installation, restart your terminal or run:');
+  logger.info(`\n${emoji.link('More installation options: https://bun.sh/docs/installation')}`);
+  logger.info(`\n${emoji.tip('After installation, restart your terminal or run:')}`);
   logger.info('   source ~/.bashrc  # Linux');
   logger.info('   source ~/.zshrc   # macOS with zsh');
   logger.info('   # or restart your terminal');

--- a/packages/cli/src/utils/bun-installation-helper.ts
+++ b/packages/cli/src/utils/bun-installation-helper.ts
@@ -1,0 +1,59 @@
+import { logger } from '@elizaos/core';
+
+/**
+ * Display helpful bun installation instructions with OS-specific commands
+ */
+export function displayBunInstallationTips(): void {
+  logger.error('\n❌ Bun is not installed or not found in PATH');
+  logger.info('\n🚀 Install Bun using the appropriate command for your system:');
+  
+  // Detect OS and show relevant command
+  const platform = process.platform;
+  
+  if (platform === 'win32') {
+    logger.info('\n📦 Windows:');
+    logger.info('   powershell -c "irm bun.sh/install.ps1 | iex"');
+    logger.info('   # or use Scoop: scoop install bun');
+    logger.info('   # or use Chocolatey: choco install bun');
+  } else {
+    logger.info('\n🐧 Linux/macOS:');
+    logger.info('   curl -fsSL https://bun.sh/install | bash');
+    
+    if (platform === 'darwin') {
+      logger.info('   # or use Homebrew: brew install bun');
+    }
+  }
+  
+  logger.info('\n🔗 More installation options: https://bun.sh/docs/installation');
+  logger.info('\n💡 After installation, restart your terminal or run:');
+  logger.info('   source ~/.bashrc  # Linux');
+  logger.info('   source ~/.zshrc   # macOS with zsh');
+  logger.info('   # or restart your terminal');
+}
+
+/**
+ * Display compact bun installation tip for inline use
+ */
+export function displayBunInstallationTipCompact(): string {
+  const platform = process.platform;
+  
+  if (platform === 'win32') {
+    return 'Install bun: powershell -c "irm bun.sh/install.ps1 | iex" (see https://bun.sh/docs/installation)';
+  } else {
+    return 'Install bun: curl -fsSL https://bun.sh/install | bash (see https://bun.sh/docs/installation)';
+  }
+}
+
+/**
+ * Check if bun is available and provide installation tips if not
+ */
+export async function ensureBunAvailable(): Promise<boolean> {
+  try {
+    const { execa } = await import('execa');
+    await execa('bun', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch (error) {
+    displayBunInstallationTips();
+    return false;
+  }
+}

--- a/packages/cli/src/utils/emoji-handler.ts
+++ b/packages/cli/src/utils/emoji-handler.ts
@@ -1,0 +1,192 @@
+import { logger } from '@elizaos/core';
+
+/**
+ * Cross-platform emoji handler that provides fallbacks for terminals that don't support emojis
+ */
+
+export interface EmojiConfig {
+  /** Use emojis when supported */
+  enabled: boolean;
+  /** Force disable emojis (for testing or user preference) */
+  forceDisable: boolean;
+}
+
+// Global configuration
+let config: EmojiConfig = {
+  enabled: true,
+  forceDisable: false,
+};
+
+/**
+ * Emoji definitions with fallbacks
+ */
+const EMOJIS = {
+  // Status indicators
+  success: { emoji: '✅', fallback: '[OK]' },
+  error: { emoji: '❌', fallback: '[ERROR]' },
+  warning: { emoji: '⚠️', fallback: '[WARNING]' },
+  info: { emoji: 'ℹ️', fallback: '[INFO]' },
+
+  // Actions
+  rocket: { emoji: '🚀', fallback: '>>' },
+  sparkles: { emoji: '✨', fallback: '*' },
+  party: { emoji: '🎉', fallback: '[DONE]' },
+
+  // Objects/Tools
+  package: { emoji: '📦', fallback: '[PKG]' },
+  link: { emoji: '🔗', fallback: '[LINK]' },
+  lightbulb: { emoji: '💡', fallback: '[TIP]' },
+  clipboard: { emoji: '📋', fallback: '[LIST]' },
+
+  // Platforms
+  penguin: { emoji: '🐧', fallback: '[LINUX]' },
+  globe: { emoji: '🌐', fallback: '[WEB]' },
+
+  // Arrows and pointers
+  rightArrow: { emoji: '→', fallback: '->' },
+  bullet: { emoji: '•', fallback: '*' },
+} as const;
+
+export type EmojiKey = keyof typeof EMOJIS;
+
+/**
+ * Detect if the current terminal/environment supports emojis
+ */
+function detectEmojiSupport(): boolean {
+  // Force disable if requested
+  if (config.forceDisable) {
+    return false;
+  }
+
+  // Check environment variables that indicate emoji support
+  const term = process.env.TERM || '';
+  const termProgram = process.env.TERM_PROGRAM || '';
+  const colorTerm = process.env.COLORTERM;
+  const ciEnv = process.env.CI;
+
+  // CI environments often don't render emojis well
+  if (ciEnv === 'true' || process.env.GITHUB_ACTIONS) {
+    return false;
+  }
+
+  // Windows Command Prompt and older terminals
+  if (process.platform === 'win32') {
+    // Windows Terminal, VS Code terminal, and newer terminals support emojis
+    if (
+      termProgram === 'vscode' ||
+      process.env.WT_SESSION ||
+      process.env.WT_PROFILE_ID ||
+      termProgram === 'Windows Terminal'
+    ) {
+      return true;
+    }
+
+    // PowerShell 7+ generally supports emojis
+    if (process.env.PSModulePath && process.env.POWERSHELL_TELEMETRY_OPTOUT !== undefined) {
+      return true;
+    }
+
+    // Default to false for Windows unless we're sure
+    return false;
+  }
+
+  // macOS and Linux
+  if (process.platform === 'darwin' || process.platform === 'linux') {
+    // Modern terminals support emojis
+    if (
+      termProgram === 'vscode' ||
+      termProgram === 'iTerm.app' ||
+      termProgram === 'Apple_Terminal' ||
+      term.includes('xterm') ||
+      term.includes('screen') ||
+      colorTerm
+    ) {
+      return true;
+    }
+  }
+
+  // Check for specific terminal capabilities
+  if (term.includes('256color') || term.includes('truecolor')) {
+    return true;
+  }
+
+  // Conservative default - assume no emoji support unless we're confident
+  return false;
+}
+
+/**
+ * Get an emoji with appropriate fallback
+ */
+export function getEmoji(key: EmojiKey): string {
+  const emojiDef = EMOJIS[key];
+  if (!emojiDef) {
+    logger.warn(`Unknown emoji key: ${key}`);
+    return '';
+  }
+
+  return config.enabled && detectEmojiSupport() ? emojiDef.emoji : emojiDef.fallback;
+}
+
+/**
+ * Configure emoji behavior
+ */
+export function configureEmojis(newConfig: Partial<EmojiConfig>): void {
+  config = { ...config, ...newConfig };
+}
+
+/**
+ * Get current emoji configuration
+ */
+export function getEmojiConfig(): EmojiConfig {
+  return { ...config };
+}
+
+/**
+ * Check if emojis are currently enabled and supported
+ */
+export function areEmojisEnabled(): boolean {
+  return config.enabled && !config.forceDisable && detectEmojiSupport();
+}
+
+/**
+ * Format a message with an emoji prefix
+ */
+export function withEmoji(key: EmojiKey, message: string, spacing: boolean = true): string {
+  const emoji = getEmoji(key);
+  const space = spacing && emoji ? ' ' : '';
+  return `${emoji}${space}${message}`;
+}
+
+/**
+ * Utility functions for common patterns
+ */
+export const emoji = {
+  success: (msg: string) => withEmoji('success', msg),
+  error: (msg: string) => withEmoji('error', msg),
+  warning: (msg: string) => withEmoji('warning', msg),
+  info: (msg: string) => withEmoji('info', msg),
+  rocket: (msg: string) => withEmoji('rocket', msg),
+  package: (msg: string) => withEmoji('package', msg),
+  link: (msg: string) => withEmoji('link', msg),
+  tip: (msg: string) => withEmoji('lightbulb', msg),
+  list: (msg: string) => withEmoji('clipboard', msg),
+  penguin: (msg: string) => withEmoji('penguin', msg),
+  bullet: (msg: string) => withEmoji('bullet', msg),
+};
+
+/**
+ * Auto-detect and initialize emoji support on module load
+ */
+export function initializeEmojiSupport(): void {
+  const supported = detectEmojiSupport();
+
+  // Log emoji support status in debug mode
+  if (process.env.DEBUG || process.env.ELIZA_DEBUG) {
+    logger.debug(
+      `Emoji support: ${supported ? 'enabled' : 'disabled'} (platform: ${process.platform}, term: ${process.env.TERM || 'unknown'})`
+    );
+  }
+}
+
+// Initialize on import
+initializeEmojiSupport();

--- a/packages/cli/src/utils/package-manager.ts
+++ b/packages/cli/src/utils/package-manager.ts
@@ -1,19 +1,16 @@
 import { logger } from '@elizaos/core';
 import { execa } from 'execa';
 import { UserEnvironment } from './user-environment';
+import { displayBunInstallationTipCompact } from './bun-installation-helper';
 
 /**
- * Detects and returns the preferred package manager for the current environment.
+ * Always returns 'bun' as the package manager for ElizaOS CLI.
  *
- * @returns A promise that resolves to the name of the package manager to use: 'npm', 'yarn', 'pnpm', or 'bun'.
- *
- * @remark Defaults to 'bun' if the package manager cannot be determined.
+ * @returns A promise that resolves to 'bun'.
  */
 export async function getPackageManager(): Promise<string> {
-  const envInfo = await UserEnvironment.getInstanceInfo();
-
-  logger.debug('[PackageManager] Detecting package manager');
-  return envInfo.packageManager.name === 'unknown' ? 'bun' : envInfo.packageManager.name;
+  logger.debug('[PackageManager] Using bun as the package manager for ElizaOS CLI');
+  return 'bun';
 }
 
 /**
@@ -44,18 +41,12 @@ export async function isRunningViaBunx(): Promise<boolean> {
 }
 
 /**
- * Get the install command for the specified package manager
- * @param {string} packageManager - The package manager to use
+ * Get the install command for bun
  * @param {boolean} isGlobal - Whether to install globally
- * @returns {string[]} - The install command array
+ * @returns {string[]} - The bun install command array
  */
-export function getInstallCommand(packageManager: string, isGlobal: boolean): string[] {
-  if (packageManager === 'npm') {
-    return ['install', ...(isGlobal ? ['-g'] : [])];
-  } else {
-    // bun
-    return ['add', ...(isGlobal ? ['-g'] : [])];
-  }
+export function getInstallCommand(isGlobal: boolean): string[] {
+  return ['add', ...(isGlobal ? ['-g'] : [])];
 }
 
 /**
@@ -74,10 +65,9 @@ export async function executeInstallation(
   versionOrTag = '',
   directory: string = process.cwd()
 ): Promise<{ success: boolean; installedIdentifier: string | null }> {
-  const packageManager = await getPackageManager();
-  const installCommand = getInstallCommand(packageManager, false);
+  const installCommand = getInstallCommand(false);
 
-  logger.debug(`Attempting to install package: ${packageName} using ${packageManager}`);
+  logger.debug(`Attempting to install package: ${packageName} using bun`);
 
   const finalSpecifier = packageName.startsWith('github:')
     ? `${packageName}${versionOrTag ? `#${versionOrTag}` : ''}`
@@ -85,7 +75,7 @@ export async function executeInstallation(
       ? `${packageName}@${versionOrTag}`
       : packageName;
   try {
-    await execa(packageManager, [...installCommand, finalSpecifier], {
+    await execa('bun', [...installCommand, finalSpecifier], {
       cwd: directory,
       stdio: 'inherit',
     });
@@ -101,8 +91,13 @@ export async function executeInstallation(
       : packageName;
 
     return { success: true, installedIdentifier };
-  } catch (error) {
-    logger.warn(`Installation failed for ${finalSpecifier}: ${error.message}`);
+  } catch (error: any) {
+    // Check if it's a bun not found error
+    if (error.code === 'ENOENT' || error.message?.includes('bun: command not found')) {
+      logger.warn(`Installation failed - bun command not found. ${displayBunInstallationTipCompact()}`);
+    } else {
+      logger.warn(`Installation failed for ${finalSpecifier}: ${error.message}`);
+    }
     return { success: false, installedIdentifier: null };
   }
 }

--- a/packages/cli/src/utils/plugin-creator.ts
+++ b/packages/cli/src/utils/plugin-creator.ts
@@ -9,6 +9,7 @@ import simpleGit, { SimpleGit } from 'simple-git';
 import { fileURLToPath } from 'url';
 import * as os from 'os';
 import inquirer from 'inquirer';
+import { runBunCommand } from './run-bun';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -112,7 +113,7 @@ export class PluginCreator {
         await execa('claude', ['--version'], { stdio: 'pipe' });
       } catch {
         throw new Error(
-          'Claude Code is required for plugin generation. Install with: npm install -g @anthropic-ai/claude-code'
+          'Claude Code is required for plugin generation. Install with: bun install -g @anthropic-ai/claude-code'
         );
       }
 
@@ -153,7 +154,7 @@ export class PluginCreator {
       logger.info(`\n📌 Next steps:`);
       logger.info(`1. cd ${path.basename(targetPath)}`);
       logger.info(`2. Review the generated code`);
-      logger.info(`3. Run tests: npm test`);
+      logger.info(`3. Run tests: bun test`);
       logger.info(`4. Add to your ElizaOS project\n`);
 
       return {
@@ -306,7 +307,7 @@ export class PluginCreator {
     // Use elizaos create command to create from template
     try {
       await execa(
-        'npx',
+        'bunx',
         ['@elizaos/cli', 'create', `plugin-${pluginName}`, '-t', 'plugin-starter'],
         {
           cwd: tempDir,
@@ -426,7 +427,7 @@ ElizaOS ${pluginName} plugin
 ## Installation
 
 \`\`\`bash
-npm install @elizaos/plugin-${pluginName}
+bun install @elizaos/plugin-${pluginName}
 \`\`\`
 
 ## Usage
@@ -879,7 +880,7 @@ Make all necessary changes to fix the issues and ensure the plugin builds and al
 
         if (error.code === 'ENOENT') {
           throw new Error(
-            'Claude Code not found! Install with: npm install -g @anthropic-ai/claude-code'
+            'Claude Code not found! Install with: bun install -g @anthropic-ai/claude-code'
           );
         }
         throw error;
@@ -906,21 +907,13 @@ Make all necessary changes to fix the issues and ensure the plugin builds and al
 
   private async runBuild(): Promise<{ success: boolean; errors?: string }> {
     try {
-      // Install dependencies first
-      logger.info('Installing dependencies...');
-      await execa('npm', ['install'], {
-        cwd: this.pluginPath!,
-        stdio: 'pipe',
-        timeout: 300000,
-      });
+      // Install dependencies first using bun
+      logger.info('Installing dependencies with bun...');
+      await runBunCommand(['install'], this.pluginPath!);
 
-      // Run build
-      logger.info('Running build...');
-      await execa('npm', ['run', 'build'], {
-        cwd: this.pluginPath!,
-        stdio: 'pipe',
-        timeout: 120000,
-      });
+      // Run build using bun
+      logger.info('Running build with bun...');
+      await runBunCommand(['run', 'build'], this.pluginPath!);
 
       return { success: true };
     } catch (error: any) {
@@ -937,12 +930,8 @@ Make all necessary changes to fix the issues and ensure the plugin builds and al
 
   private async runTests(): Promise<{ success: boolean; errors?: string }> {
     try {
-      logger.info('Running tests...');
-      await execa('npm', ['test'], {
-        cwd: this.pluginPath!,
-        stdio: 'pipe',
-        timeout: 300000,
-      });
+      logger.info('Running tests with bun...');
+      await runBunCommand(['test'], this.pluginPath!);
 
       return { success: true };
     } catch (error: any) {

--- a/packages/cli/src/utils/run-bun.ts
+++ b/packages/cli/src/utils/run-bun.ts
@@ -1,4 +1,5 @@
 import { execa } from 'execa';
+import { displayBunInstallationTipCompact } from './bun-installation-helper';
 
 /**
  * Asynchronously runs a 'bun' command with the provided arguments in the specified directory.
@@ -7,5 +8,12 @@ import { execa } from 'execa';
  * @returns {Promise<void>} A Promise that resolves when the command has finished running.
  */
 export async function runBunCommand(args: string[], cwd: string): Promise<void> {
-  await execa('bun', args, { cwd, stdio: 'inherit' });
+  try {
+    await execa('bun', args, { cwd, stdio: 'inherit' });
+  } catch (error: any) {
+    if (error.code === 'ENOENT' || error.message?.includes('bun: command not found')) {
+      throw new Error(`Bun command not found. ${displayBunInstallationTipCompact()}`);
+    }
+    throw error;
+  }
 }

--- a/packages/cli/src/utils/upgrade/migrator.ts
+++ b/packages/cli/src/utils/upgrade/migrator.ts
@@ -10,6 +10,7 @@ import simpleGit, { SimpleGit } from 'simple-git';
 import { encoding_for_model } from 'tiktoken';
 import { fileURLToPath } from 'url';
 import * as os from 'os';
+import { emoji } from '../emoji-handler';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -134,7 +135,9 @@ export class PluginMigrator {
       await this.createLockFile();
 
       // Security warning
-      logger.warn('⚠️  SECURITY WARNING: This command will execute code from the repository.');
+      logger.warn(
+        `${emoji.warning('SECURITY WARNING: This command will execute code from the repository.')}`
+      );
       logger.warn('Only run this on trusted repositories you own or have reviewed.');
 
       // Step 2: Save current branch for recovery
@@ -220,7 +223,7 @@ export class PluginMigrator {
         logger.warn('Branch created locally but not pushed. You may need to push manually.');
       }
 
-      logger.info(`✅ Migration complete for ${input}!`);
+      logger.info(`${emoji.success(`Migration complete for ${input}!`)}`);
 
       return {
         success: true,

--- a/packages/cli/src/utils/upgrade/migrator.ts
+++ b/packages/cli/src/utils/upgrade/migrator.ts
@@ -121,7 +121,7 @@ export class PluginMigrator {
         await execa('claude', ['--version'], { stdio: 'pipe' });
       } catch {
         throw new Error(
-          'Claude Code is required for migration. Install with: npm install -g @anthropic-ai/claude-code'
+          'Claude Code is required for migration. Install with: bun install -g @anthropic-ai/claude-code'
         );
       }
 
@@ -335,19 +335,19 @@ export class PluginMigrator {
       // First ensure dependencies are installed
       logger.info('Installing dependencies...');
       try {
-        await execa('npm', ['install'], {
+        await execa('bun', ['install'], {
           cwd: this.repoPath!,
           stdio: 'pipe',
-          timeout: 300000, // 5 minute timeout for npm install
+          timeout: 300000, // 5 minute timeout for bun install
         });
       } catch (installError: any) {
         if (installError.timedOut) {
           return {
             success: false,
-            errors: 'npm install timed out after 5 minutes. Check network connection.',
+            errors: 'bun install timed out after 5 minutes. Check network connection.',
           };
         }
-        logger.warn(`npm install failed: ${installError.message}`);
+        logger.warn(`bun install failed: ${installError.message}`);
         // Continue anyway - some tests might still work
       }
 
@@ -357,31 +357,23 @@ export class PluginMigrator {
 
       try {
         // Check if elizaos is available
-        await execa('npx', ['elizaos', '--version'], {
+        await execa('bunx', ['elizaos', '--version'], {
           cwd: this.repoPath!,
           stdio: 'pipe',
         });
-        testCommand = 'npx';
+        testCommand = 'bunx';
         testArgs = ['elizaos', 'test'];
         logger.info('Running tests with elizaos test...');
       } catch {
-        // Fallback to npm/bun test
+        // Fallback to bun test
         const packageJson = JSON.parse(
           await fs.readFile(path.join(this.repoPath!, 'package.json'), 'utf-8')
         );
 
         if (packageJson.scripts?.test) {
-          // Check if bun is available
-          try {
-            await execa('bun', ['--version'], { stdio: 'pipe' });
-            testCommand = 'bun';
-            testArgs = ['test'];
-            logger.info('Running tests with bun test...');
-          } catch {
-            testCommand = 'npm';
-            testArgs = ['test'];
-            logger.info('Running tests with npm test...');
-          }
+          testCommand = 'bun';
+          testArgs = ['test'];
+          logger.info('Running tests with bun test...');
         } else {
           throw new Error('No test script found in package.json and elizaos not available');
         }
@@ -566,7 +558,7 @@ Make all necessary changes to fix the issues and ensure the migration is complet
 
         if (error.code === 'ENOENT') {
           throw new Error(
-            'Claude Code not found! Install with: npm install -g @anthropic-ai/claude-code'
+            'Claude Code not found! Install with: bun install -g @anthropic-ai/claude-code'
           );
         }
         throw error;

--- a/packages/cli/src/utils/user-environment.ts
+++ b/packages/cli/src/utils/user-environment.ts
@@ -133,31 +133,36 @@ export class UserEnvironment {
 
     try {
       // Get bun version
-      const { stdout } = await import('execa').then(({ execa }) =>
-        execa('bun', ['--version'])
-      );
+      const { stdout } = await import('execa').then(({ execa }) => execa('bun', ['--version']));
       version = stdout.trim();
       logger.debug(`[UserEnvironment] Bun version: ${version}`);
     } catch (e) {
-      logger.warn(
+      logger.error(
         `[UserEnvironment] Could not get bun version: ${e instanceof Error ? e.message : String(e)}`
       );
-      
+
       // Enhanced bun installation guidance
       const platform = process.platform;
-      logger.warn('[UserEnvironment] Bun is required for ElizaOS CLI. Please install it:');
-      
+      logger.error('❌ Bun is required for ElizaOS CLI but is not installed or not found in PATH.');
+      logger.error('');
+      logger.error('🚀 Install Bun using the appropriate command for your system:');
+      logger.error('');
+
       if (platform === 'win32') {
-        logger.warn('   Windows: powershell -c "irm bun.sh/install.ps1 | iex"');
+        logger.error('   Windows: powershell -c "irm bun.sh/install.ps1 | iex"');
       } else {
-        logger.warn('   Linux/macOS: curl -fsSL https://bun.sh/install | bash');
+        logger.error('   Linux/macOS: curl -fsSL https://bun.sh/install | bash');
         if (platform === 'darwin') {
-          logger.warn('   macOS (Homebrew): brew install bun');
+          logger.error('   macOS (Homebrew): brew install bun');
         }
-      }
+      }      logger.error('');
+      logger.error('   More options: https://bun.sh/docs/installation');
+      logger.error('   After installation, restart your terminal or source your shell profile');
+      logger.error('');
       
-      logger.warn('   More options: https://bun.sh/docs/installation');
-      logger.warn('   After installation, restart your terminal or source your shell profile');
+      // Force exit the process - Bun is required for ElizaOS CLI
+      logger.error('🔴 Exiting: Bun installation is required to continue.');
+      process.exit(1);
     }
 
     const packageName = '@elizaos/cli';

--- a/packages/cli/src/utils/user-environment.ts
+++ b/packages/cli/src/utils/user-environment.ts
@@ -7,6 +7,7 @@ import { logger } from '@elizaos/core';
 import { existsSync, statSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { resolveEnvFile } from './resolve-utils';
+import { emoji } from './emoji-handler';
 
 // Types
 interface OSInfo {
@@ -143,9 +144,11 @@ export class UserEnvironment {
 
       // Enhanced bun installation guidance
       const platform = process.platform;
-      logger.error('❌ Bun is required for ElizaOS CLI but is not installed or not found in PATH.');
+      logger.error(
+        `${emoji.error('Bun is required for ElizaOS CLI but is not installed or not found in PATH.')}`
+      );
       logger.error('');
-      logger.error('🚀 Install Bun using the appropriate command for your system:');
+      logger.error(`${emoji.rocket('Install Bun using the appropriate command for your system:')}`);
       logger.error('');
 
       if (platform === 'win32') {
@@ -155,11 +158,12 @@ export class UserEnvironment {
         if (platform === 'darwin') {
           logger.error('   macOS (Homebrew): brew install bun');
         }
-      }      logger.error('');
+      }
+      logger.error('');
       logger.error('   More options: https://bun.sh/docs/installation');
       logger.error('   After installation, restart your terminal or source your shell profile');
       logger.error('');
-      
+
       // Force exit the process - Bun is required for ElizaOS CLI
       logger.error('🔴 Exiting: Bun installation is required to continue.');
       process.exit(1);

--- a/packages/docs/blog/add-plugins.mdx
+++ b/packages/docs/blog/add-plugins.mdx
@@ -83,7 +83,7 @@ The ElizaOS CLI provides several commands to manage plugins. To install the CLI:
 :::tip
 
 ```bash
-npm install -g @elizaos/cli
+bun install -g @elizaos/cli
 ```
 
 :::

--- a/packages/docs/blog/twitter-agent-guide.mdx
+++ b/packages/docs/blog/twitter-agent-guide.mdx
@@ -25,7 +25,7 @@ First, install the ElizaOS Command Line Interface (CLI), which provides the nece
 Open your terminal and execute the following command:
 
 ```bash
-npm install -g @elizaos/cli
+bun install -g @elizaos/cli
 ```
 
 This command installs the ElizaOS CLI globally on your system.

--- a/packages/docs/docs/cli/create.md
+++ b/packages/docs/docs/cli/create.md
@@ -214,6 +214,29 @@ bun pm cache rm
 bun install
 ```
 
+### Bun Installation Issues
+
+```bash
+# If you see "bun: command not found" errors
+# Install Bun using the appropriate command for your system:
+
+# Linux/macOS:
+curl -fsSL https://bun.sh/install | bash
+
+# Windows:
+powershell -c "irm bun.sh/install.ps1 | iex"
+
+# macOS with Homebrew:
+brew install bun
+
+# After installation, restart your terminal or:
+source ~/.bashrc  # Linux
+source ~/.zshrc   # macOS with zsh
+
+# Verify installation:
+bun --version
+```
+
 ### Database Connection Problems
 
 **PGLite Issues:**

--- a/packages/docs/docs/cli/dev.md
+++ b/packages/docs/docs/cli/dev.md
@@ -220,6 +220,29 @@ bun i && bun run build
 elizaos dev --build
 ```
 
+### Bun Installation Issues
+
+```bash
+# If you see "bun: command not found" errors
+# Install Bun using the appropriate command for your system:
+
+# Linux/macOS:
+curl -fsSL https://bun.sh/install | bash
+
+# Windows:
+powershell -c "irm bun.sh/install.ps1 | iex"
+
+# macOS with Homebrew:
+brew install bun
+
+# After installation, restart your terminal or:
+source ~/.bashrc  # Linux
+source ~/.zshrc   # macOS with zsh
+
+# Verify installation:
+bun --version
+```
+
 ### File Watching Issues
 
 ```bash

--- a/packages/docs/docs/cli/plugins.md
+++ b/packages/docs/docs/cli/plugins.md
@@ -207,6 +207,29 @@ elizaos plugins update
 elizaos plugins add plugin-name
 ```
 
+### Bun Installation Issues
+
+```bash
+# If you see "bun: command not found" errors
+# Install Bun using the appropriate command for your system:
+
+# Linux/macOS:
+curl -fsSL https://bun.sh/install | bash
+
+# Windows:
+powershell -c "irm bun.sh/install.ps1 | iex"
+
+# macOS with Homebrew:
+brew install bun
+
+# After installation, restart your terminal or:
+source ~/.bashrc  # Linux
+source ~/.zshrc   # macOS with zsh
+
+# Verify installation:
+bun --version
+```
+
 ### Network Issues
 
 ```bash

--- a/packages/docs/docs/cli/start.md
+++ b/packages/docs/docs/cli/start.md
@@ -244,6 +244,27 @@ elizaos start --build
 
 ## Troubleshooting
 
+### Bun Installation Issues
+
+If you encounter "command not found: bun" or similar errors:
+
+```bash
+# For macOS (using curl)
+curl -fsSL https://bun.sh/install | bash
+
+# For macOS (using Homebrew)
+brew install bun
+
+# For Linux (using curl)
+curl -fsSL https://bun.sh/install | bash
+
+# For Windows (using PowerShell)
+powershell -c "irm bun.sh/install.ps1 | iex"
+
+# After installation, restart your terminal and verify
+bun --version
+```
+
 ### Startup Failures
 
 ```bash

--- a/packages/docs/docs/cli/test.md
+++ b/packages/docs/docs/cli/test.md
@@ -120,6 +120,27 @@ If the automatic build fails, the test command will:
 
 ## Troubleshooting
 
+### Bun Installation Issues
+
+If you encounter "command not found: bun" or similar errors:
+
+```bash
+# For macOS (using curl)
+curl -fsSL https://bun.sh/install | bash
+
+# For macOS (using Homebrew)  
+brew install bun
+
+# For Linux (using curl)
+curl -fsSL https://bun.sh/install | bash
+
+# For Windows (using PowerShell)
+powershell -c "irm bun.sh/install.ps1 | iex"
+
+# After installation, restart your terminal and verify
+bun --version
+```
+
 ### Component Test Issues
 
 ```bash

--- a/packages/docs/docs/cli/update.md
+++ b/packages/docs/docs/cli/update.md
@@ -196,17 +196,35 @@ Only non-workspace packages will be updated.
 
 ## Troubleshooting
 
+### Bun Installation Issues
+
+If you encounter errors related to bun not being found:
+
+```bash
+# For Linux/macOS (using curl)
+curl -fsSL https://bun.sh/install | bash
+
+# For macOS (using Homebrew)
+brew install bun
+
+# For Windows (using PowerShell)
+powershell -c "irm bun.sh/install.ps1 | iex"
+
+# After installation, restart your terminal and verify
+bun --version
+```
+
 ### CLI Update Issues
 
 ```bash
 # Check if CLI is installed globally
-npm list -g @elizaos/cli
+bun pm ls -g @elizaos/cli
 
 # Install CLI globally if needed
-npm install -g @elizaos/cli
+bun install -g @elizaos/cli
 
 # Update with administrator privileges (if needed)
-sudo npm install -g @elizaos/cli
+sudo bun install -g @elizaos/cli
 ```
 
 ### Package Update Failures
@@ -250,18 +268,18 @@ elizaos update
 # For global CLI updates on macOS/Linux
 sudo elizaos update --cli
 
-# Or change npm global directory ownership
-sudo chown -R $(whoami) ~/.npm
+# Or change bun global directory ownership
+sudo chown -R $(whoami) ~/.bun
 ```
 
 ### Network Issues
 
 ```bash
-# Check npm registry connectivity
-npm ping
+# Check registry connectivity
+bun config get registry
 
 # Update with different registry
-npm config set registry https://registry.npmjs.org/
+bun config set registry https://registry.npmjs.org/
 elizaos update
 ```
 

--- a/packages/docs/docs/core/plugins.md
+++ b/packages/docs/docs/core/plugins.md
@@ -40,7 +40,7 @@ The ElizaOS plugin system maintains the same basic concept as previous versions,
 
 The new CLI tool introduces a streamlined workflow for plugin development without ever needing to touch the ElizaOS monorepo directly:
 
-1. **Create**: `npm create eliza` - Initialize a new plugin project with proper structure
+1. **Create**: `bun create eliza` - Initialize a new plugin project with proper structure
 2. **Develop**: Edit the plugin code in the generated project structure
 3. **Test**: `elizaos test` - Test the plugin functionality
 4. **Run**: `elizaos start` - Run the plugin with a default agent
@@ -51,11 +51,11 @@ The new CLI tool introduces a streamlined workflow for plugin development withou
 You can create a new ElizaOS plugin using the CLI:
 
 ```bash
-# Using npm
-npm create eliza
+# Using bun (recommended)
+bun create eliza
 
-# Or using npx
-npx create-eliza
+# Or using bunx
+bunx create-eliza
 ```
 
 When prompted, select "Plugin" as the type to create. The CLI will guide you through the setup process, creating a plugin with the proper structure and dependencies.

--- a/packages/docs/docs/core/project.md
+++ b/packages/docs/docs/core/project.md
@@ -28,11 +28,11 @@ my-eliza-project/
 You can create a new ElizaOS project using:
 
 ```bash
-# Using npm
-npm create eliza
+# Using bun (recommended)
+bun create eliza
 
-# Or using npx
-npx @elizaos/cli create
+# Or using bunx
+bunx @elizaos/cli create
 ```
 
 The CLI will guide you through the setup process, including:


### PR DESCRIPTION
<img width="794" alt="Screenshot 2025-06-04 at 5 26 12 PM" src="https://github.com/user-attachments/assets/17734236-55ea-4eea-9774-e2dc438d4dbc" />


This pull request updates the ElizaOS CLI to standardize the use of the `bun` package manager and runtime across all scripts, commands, and documentation. It replaces `npm` with `bun` for installation, testing, building, and other package management tasks. Additionally, it introduces utilities to guide users in installing `bun` if it is not available.

## Emojis supported!

### Transition to `bun` Package Manager:

* Updated all references to `npm` commands (e.g., `npm install`, `npm run build`, `npm test`) to their `bun` equivalents in documentation and example scripts (`packages/cli/README.md`, `packages/cli/examples/*`). [[1]](diffhunk://#diff-15986190ef9581ab59bcd5483b2c09e7fd0bd439d6f6cddbc94b0b1de094ee51L201-R201) [[2]](diffhunk://#diff-418eeb28f031b2a5715eb03f33d82f5b40b2565b7e40408d4f38ececfc69261cL32-R32) [[3]](diffhunk://#diff-b103968eccafc02b0cf63d16804c71c62a74aada18bb6074c5ea6a751d84bcc9L35-R35) [[4]](diffhunk://#diff-5489901004994daa54c342d76577e24060fb1f9d039114140f9cf846338a7aebL43-R43) [[5]](diffhunk://#diff-b68605c89f20b50ba9c1a9ec2a6d6912b832e0d088dac8b365b06c485a1f0652L20-R20) [[6]](diffhunk://#diff-34f47107781288555d47d4a6d4fc6981c51b5a90d3a7bd7ffc43f63576755a21L25-R25) [[7]](diffhunk://#diff-8e50d77ab84e9f3fe60560523e9b407bb52bd61d2ab4e218ba12db49f6e99520L42-R42)

* Modified the `buildProject` utility to exclusively use `bun` for running build scripts, removing fallback support for `npm`.

* Replaced `npx` with `bunx` for TypeScript compilation and other commands where applicable.

### Enhanced `bun` Installation Guidance:

* Added a new utility module, `bun-installation-helper.ts`, to provide detailed installation instructions for `bun` based on the user's operating system. This includes commands for Windows, macOS, and Linux.

* Integrated `bun` installation tips into the CLI to notify users if `bun` is not installed or accessible.

### Refactoring for Consistency:

* Updated the `package-manager.ts` utility to always return `bun` as the default package manager for the ElizaOS CLI and simplified related logic. [[1]](diffhunk://#diff-cb86c42bb3a31864548b295d867a29162200a702039f9422503398b5a1f3fd28R4-R13) [[2]](diffhunk://#diff-cb86c42bb3a31864548b295d867a29162200a702039f9422503398b5a1f3fd28L47-L59) [[3]](diffhunk://#diff-cb86c42bb3a31864548b295d867a29162200a702039f9422503398b5a1f3fd28L77-R78)

* Adjusted CLI commands and user-facing messages to reflect the transition to `bun`, ensuring consistency in generated instructions and logs. [[1]](diffhunk://#diff-319a6b9f06a3b46dbbba6af360def478c6e9fa16f280659419ca9fc33bc3352cL15-R15) [[2]](diffhunk://#diff-319a6b9f06a3b46dbbba6af360def478c6e9fa16f280659419ca9fc33bc3352cL528-R528) [[3]](diffhunk://#diff-e4dac4c3b301f8f14cdbd7edef28c4fae8090dddd58b7ce4a3e7bba9dc336706L63-R82) [[4]](diffhunk://#diff-8a468f98f953bd641a51974f40f09e7237dbe4720508b0fb7e4e2d7cb1061163L319-R321)

### Documentation Updates:

* Updated the CLI README and example scripts to reflect the use of `bun` for versioning, publishing, and other workflows. [[1]](diffhunk://#diff-15986190ef9581ab59bcd5483b2c09e7fd0bd439d6f6cddbc94b0b1de094ee51L647-R647) [[2]](diffhunk://#diff-418eeb28f031b2a5715eb03f33d82f5b40b2565b7e40408d4f38ececfc69261cL85-R85) [[3]](diffhunk://#diff-b103968eccafc02b0cf63d16804c71c62a74aada18bb6074c5ea6a751d84bcc9L62-R62) [[4]](diffhunk://#diff-5489901004994daa54c342d76577e24060fb1f9d039114140f9cf846338a7aebL71-R71)

* Enhanced guidance for prerequisites and setup, including detailed steps for installing `bun` and ensuring compatibility with Node.js.

These changes streamline the development workflow by leveraging the performance benefits of `bun` while ensuring that users have clear guidance on transitioning to and using the new package manager.