### PR TITLE
chore: auto install bun in CLI

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,6 +8,27 @@ The ElizaOS CLI provides a comprehensive set of commands to manage your ElizaOS 
 bun install -g @elizaos/cli
 ```
 
+### Automatic Bun Installation
+
+The ElizaOS CLI requires [Bun](https://bun.sh) as its package manager. If Bun is not installed when you run the CLI, it will attempt to automatically install it for you.
+
+**Auto-installation features:**
+- ✅ Detects when Bun is missing
+- ✅ Downloads and installs Bun automatically on Windows, macOS, and Linux  
+- ✅ Updates PATH for the current session
+- ✅ Falls back to manual installation instructions if auto-install fails
+- ✅ Skips auto-installation in CI environments
+- ✅ Can be disabled with `--no-auto-install` flag
+
+**To disable auto-installation:**
+```bash
+# Global flag (applies to all commands)
+elizaos --no-auto-install create my-project
+
+# Environment variable
+ELIZA_NO_AUTO_INSTALL=true elizaos create my-project
+```
+
 ### Alternative usage with npx
 
 You can also run the CLI directly without installation using npx:
@@ -17,6 +38,24 @@ npx @elizaos/cli [command]
 ```
 
 This is useful for trying out commands without installing the CLI globally.
+
+## Global Options
+
+The following options are available for all ElizaOS CLI commands:
+
+- `--no-emoji`: Disable emoji output for better compatibility with certain terminals or scripts
+- `--no-auto-install`: Disable automatic Bun installation (useful in CI environments or when you prefer manual control)
+- `-v, --version`: Show the CLI version number
+- `-h, --help`: Display help information
+
+**Example usage:**
+```bash
+# Disable auto-installation and emojis
+elizaos --no-auto-install --no-emoji create my-project
+
+# Just show version
+elizaos --version
+```
 
 ## Commands
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,6 +35,11 @@ async function main() {
     configureEmojis({ forceDisable: true });
   }
 
+  // Check for --no-auto-install flag early (before command parsing)
+  if (process.argv.includes('--no-auto-install')) {
+    process.env.ELIZA_NO_AUTO_INSTALL = 'true';
+  }
+
   // For ESM modules we need to use import.meta.url instead of __dirname
   const __filename = fileURLToPath(import.meta.url);
   const __dirname = dirname(__filename);
@@ -68,7 +73,9 @@ async function main() {
 
   const program = new Command()
     .name('elizaos')
-    .version(version, '-v, --version', 'output the version number');
+    .version(version, '-v, --version', 'output the version number')
+    .option('--no-emoji', 'Disable emoji output')
+    .option('--no-auto-install', 'Disable automatic Bun installation');
 
   // Add global options but hide them from global help
   // They will still be passed to all commands for backward compatibility

--- a/packages/cli/src/utils/auto-install-bun.ts
+++ b/packages/cli/src/utils/auto-install-bun.ts
@@ -1,0 +1,101 @@
+import { logger } from '@elizaos/core';
+import { execa } from 'execa';
+import { emoji } from './emoji-handler';
+
+/**
+ * Automatically install Bun if it's not available
+ * @returns {Promise<boolean>} - Whether Bun is now available
+ */
+export async function autoInstallBun(): Promise<boolean> {
+  const platform = process.platform;
+  
+  try {
+    // First check if bun is already available
+    await execa('bun', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    // Bun is not available, attempt auto-installation
+  }
+
+  logger.info(`${emoji.rocket('Bun is required for ElizaOS CLI. Installing automatically...')}`);
+  
+  try {
+    if (platform === 'win32') {
+      // Windows installation
+      logger.info('Installing Bun on Windows...');
+      await execa('powershell', [
+        '-c',
+        'irm bun.sh/install.ps1 | iex'
+      ], {
+        stdio: 'inherit'
+      });
+    } else {
+      // Linux/macOS installation
+      logger.info('Installing Bun on Linux/macOS...');
+      
+      // Use shell to execute the curl | bash command directly
+      await execa('sh', [
+        '-c',
+        'curl -fsSL https://bun.sh/install | bash'
+      ], {
+        stdio: 'inherit'
+      });
+    }
+
+    // Add bun to PATH for current session
+    const bunPath = platform === 'win32' 
+      ? `${process.env.USERPROFILE}\\.bun\\bin`
+      : `${process.env.HOME}/.bun/bin`;
+    
+    if (bunPath && !process.env.PATH?.includes(bunPath)) {
+      process.env.PATH = `${bunPath}${platform === 'win32' ? ';' : ':'}${process.env.PATH}`;
+    }
+
+    // Verify installation worked
+    await execa('bun', ['--version'], { stdio: 'ignore' });
+    logger.success(`${emoji.success('Bun installed successfully!')}`);
+    
+    return true;
+  } catch (error) {
+    logger.error(`${emoji.error('Failed to automatically install Bun:')}`);
+    logger.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    
+    // Fall back to manual installation instructions
+    logger.info(`\n${emoji.info('Please install Bun manually:')}`);
+    if (platform === 'win32') {
+      logger.info('   Windows: powershell -c "irm bun.sh/install.ps1 | iex"');
+    } else {
+      logger.info('   Linux/macOS: curl -fsSL https://bun.sh/install | bash');
+      if (platform === 'darwin') {
+        logger.info('   macOS (Homebrew): brew install bun');
+      }
+    }
+    logger.info(`\n${emoji.link('More options: https://bun.sh/docs/installation')}`);
+    logger.info(`\n${emoji.tip('After installation, restart your terminal or source your shell profile')}`);
+    
+    return false;
+  }
+}
+
+/**
+ * Check if auto-installation should be attempted
+ * @returns {boolean} - Whether to attempt auto-installation
+ */
+export function shouldAutoInstall(): boolean {
+  // Don't auto-install in CI environments
+  if (process.env.CI === 'true' || process.env.CI === '1') {
+    return false;
+  }
+  
+  // Don't auto-install if explicitly disabled
+  if (process.env.ELIZA_NO_AUTO_INSTALL === 'true') {
+    return false;
+  }
+  
+  // Check for --no-auto-install flag (backup check)
+  if (process.argv.includes('--no-auto-install')) {
+    return false;
+  }
+  
+  return true;
+}

--- a/packages/cli/src/utils/user-environment.ts
+++ b/packages/cli/src/utils/user-environment.ts
@@ -155,7 +155,11 @@ export class UserEnvironment {
             version = stdout.trim();
             logger.debug(`[UserEnvironment] Bun version after auto-install: ${version}`);
           } catch (retryError) {
-            logger.error('Failed to verify Bun installation after auto-install');
+            logger.error(
+              `Failed to verify Bun installation after auto-install: ${
+                retryError instanceof Error ? retryError.message : String(retryError)
+              }`
+            );
             // Continue to manual installation instructions
           }
         }

--- a/packages/cli/src/utils/user-environment.ts
+++ b/packages/cli/src/utils/user-environment.ts
@@ -8,6 +8,7 @@ import { existsSync, statSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { resolveEnvFile } from './resolve-utils';
 import { emoji } from './emoji-handler';
+import { autoInstallBun, shouldAutoInstall } from './auto-install-bun';
 
 // Types
 interface OSInfo {
@@ -138,35 +139,55 @@ export class UserEnvironment {
       version = stdout.trim();
       logger.debug(`[UserEnvironment] Bun version: ${version}`);
     } catch (e) {
-      logger.error(
+      logger.debug(
         `[UserEnvironment] Could not get bun version: ${e instanceof Error ? e.message : String(e)}`
       );
 
-      // Enhanced bun installation guidance
-      const platform = process.platform;
-      logger.error(
-        `${emoji.error('Bun is required for ElizaOS CLI but is not installed or not found in PATH.')}`
-      );
-      logger.error('');
-      logger.error(`${emoji.rocket('Install Bun using the appropriate command for your system:')}`);
-      logger.error('');
-
-      if (platform === 'win32') {
-        logger.error('   Windows: powershell -c "irm bun.sh/install.ps1 | iex"');
-      } else {
-        logger.error('   Linux/macOS: curl -fsSL https://bun.sh/install | bash');
-        if (platform === 'darwin') {
-          logger.error('   macOS (Homebrew): brew install bun');
+      // Attempt auto-installation if conditions are met
+      if (shouldAutoInstall()) {
+        logger.info(`${emoji.info('Attempting to automatically install Bun...')}`);
+        const installSuccess = await autoInstallBun();
+        
+        if (installSuccess) {
+          // Try to get version again after installation
+          try {
+            const { stdout } = await import('execa').then(({ execa }) => execa('bun', ['--version']));
+            version = stdout.trim();
+            logger.debug(`[UserEnvironment] Bun version after auto-install: ${version}`);
+          } catch (retryError) {
+            logger.error('Failed to verify Bun installation after auto-install');
+            // Continue to manual installation instructions
+          }
         }
       }
-      logger.error('');
-      logger.error('   More options: https://bun.sh/docs/installation');
-      logger.error('   After installation, restart your terminal or source your shell profile');
-      logger.error('');
 
-      // Force exit the process - Bun is required for ElizaOS CLI
-      logger.error('🔴 Exiting: Bun installation is required to continue.');
-      process.exit(1);
+      // If auto-installation failed or was not attempted, show manual instructions
+      if (!version) {
+        const platform = process.platform;
+        logger.error(
+          `${emoji.error('Bun is required for ElizaOS CLI but is not installed or not found in PATH.')}`
+        );
+        logger.error('');
+        logger.error(`${emoji.rocket('Install Bun using the appropriate command for your system:')}`);
+        logger.error('');
+
+        if (platform === 'win32') {
+          logger.error('   Windows: powershell -c "irm bun.sh/install.ps1 | iex"');
+        } else {
+          logger.error('   Linux/macOS: curl -fsSL https://bun.sh/install | bash');
+          if (platform === 'darwin') {
+            logger.error('   macOS (Homebrew): brew install bun');
+          }
+        }
+        logger.error('');
+        logger.error('   More options: https://bun.sh/docs/installation');
+        logger.error('   After installation, restart your terminal or source your shell profile');
+        logger.error('');
+
+        // Force exit the process - Bun is required for ElizaOS CLI
+        logger.error('🔴 Exiting: Bun installation is required to continue.');
+        process.exit(1);
+      }
     }
 
     const packageName = '@elizaos/cli';


### PR DESCRIPTION
<img width="718" alt="Screenshot 2025-06-05 at 7 13 31 AM" src="https://github.com/user-attachments/assets/baeea5a9-8095-4af9-b9ad-a8dd0897cfb2" />

This pull request introduces a new feature for the ElizaOS CLI: automatic installation of the Bun package manager if it is not already installed. Additionally, it adds new global options for enhanced user control and updates the CLI's internal logic to support these features.

### New Features and Enhancements:

#### Automatic Bun Installation:
* Added a mechanism to detect if Bun is missing and attempt automatic installation across Windows, macOS, and Linux. This includes updating the `PATH` environment variable for the current session and providing fallback manual installation instructions if the process fails. (`packages/cli/src/utils/auto-install-bun.ts`, [packages/cli/src/utils/auto-install-bun.tsR1-R101](diffhunk://#diff-4ff8b4129e7f36e6f88bfd288743b82c46872fee51fb4eb858511ba03e0cf512R1-R101))
* Integrated the auto-installation logic into the `UserEnvironment` class, ensuring Bun is installed or providing guidance before proceeding with CLI commands. (`packages/cli/src/utils/user-environment.ts`, [[1]](diffhunk://#diff-8a935fe1173cf471d81a99c3c9e47119864077e19ab03497bdd768ffd3ef8deeL141-R165) [[2]](diffhunk://#diff-8a935fe1173cf471d81a99c3c9e47119864077e19ab03497bdd768ffd3ef8deeR191)
* Introduced a `--no-auto-install` flag and `ELIZA_NO_AUTO_INSTALL` environment variable to disable automatic installation. (`packages/cli/src/index.ts`, [[1]](diffhunk://#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cR38-R42) [[2]](diffhunk://#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cL71-R78)

#### Global Options:
* Added new global options to the CLI:
  - `--no-emoji`: Disables emoji output.
  - `--no-auto-install`: Disables automatic Bun installation.
  - `-v, --version`: Displays the CLI version.
  - `-h, --help`: Displays help information. (`packages/cli/src/index.ts`, [packages/cli/src/index.tsL71-R78](diffhunk://#diff-2fb448d11702324cc59d657d5945d59cd325540eb87b71f2e66a5bc01ada834cL71-R78))

### Documentation Updates:
* Updated the `README.md` to document the automatic Bun installation feature, including how to disable it using flags or environment variables. (`packages/cli/README.md`, [packages/cli/README.mdR11-R31](diffhunk://#diff-15986190ef9581ab59bcd5483b2c09e7fd0bd439d6f6cddbc94b0b1de094ee51R11-R31))
* Added a section on global options with examples of their usage. (`packages/cli/README.md`, [packages/cli/README.mdR42-R59](diffhunk://#diff-15986190ef9581ab59bcd5483b2c09e7fd0bd439d6f6cddbc94b0b1de094ee51R42-R59))