### PR TITLE
Fix: prevent setState on unmounted component

### DIFF
--- a/packages/client/src/components/chat.tsx
+++ b/packages/client/src/components/chat.tsx
@@ -367,7 +367,8 @@ export default function Chat({ chatType, contextId, serverId, initialDmChannelId
           handleNewDmChannel(targetAgentData.id); // This will navigate and set currentDmChannelId
         }
       }
-    } else if (chatType !== 'DM') {
+    } else if (chatType !== 'DM' && chatState.currentDmChannelId !== null) {
+      // Only reset if necessary
       updateChatState({ currentDmChannelId: null });
     }
   }, [


### PR DESCRIPTION
Group chat caused a React error due to a premature state reset (`currentDmChannelId = null`).

![image](https://github.com/user-attachments/assets/db7032e7-2e51-400c-a2d2-77d202993e32)
