### PR TITLE
fix: release versioning in client

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:core": "turbo run build --filter=@elizaos/core --no-cache",
     "lint": "turbo run lint --filter=./packages/* && prettier --write . && prettier --check .",
     "pre-commit": "bun run scripts/pre-commit-lint.js",
-    "release": "bun run build && bun lint && lerna publish --no-private --force-publish && bun lint",
+    "release": "lerna version --no-private --force-publish --no-push --no-git-tag-version && bun run build && bun lint && lerna publish from-package --no-private --force-publish && bun lint",
     "release:alpha": "lerna publish prerelease --preid alpha --dist-tag alpha --no-private --force-publish --loglevel verbose",
     "migrate": "turbo run migrate --filter=./packages/plugin-sql --force",
     "migrate:generate": "turbo run migrate:generate --filter=./packages/plugin-sql",

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -19,17 +19,26 @@ interface CustomUserConfig extends UserConfig {
 // Function to get version and write info.json
 const getVersionAndWriteInfo = () => {
   const lernaPath = path.resolve(__dirname, '../../lerna.json');
+  const packageJsonPath = path.resolve(__dirname, '../../package.json');
   const infoJsonDir = path.resolve(__dirname, 'src/lib');
   const infoJsonPath = path.resolve(infoJsonDir, 'info.json');
   let version = '0.0.0-error'; // Default/fallback version
 
   try {
+    // First try to get version from lerna.json
     if (fs.existsSync(lernaPath)) {
       const lernaContent = fs.readFileSync(lernaPath, 'utf-8');
       const lernaConfig = JSON.parse(lernaContent);
       version = lernaConfig.version || version;
     } else {
-      console.warn(`Warning: ${lernaPath} does not exist. Using fallback version.`);
+      console.warn(`Warning: ${lernaPath} does not exist. Trying package.json...`);
+
+      // Fallback to main package.json if lerna.json doesn't exist
+      if (fs.existsSync(packageJsonPath)) {
+        const packageContent = fs.readFileSync(packageJsonPath, 'utf-8');
+        const packageConfig = JSON.parse(packageContent);
+        version = packageConfig.version || version;
+      }
     }
 
     if (!fs.existsSync(infoJsonDir)) {


### PR DESCRIPTION
This pull request introduces changes to the build and release process as well as enhancements to the versioning logic in the codebase. The most significant updates include modifying the `release` script in `package.json` to improve versioning and publishing workflows, and adding a fallback mechanism to retrieve the version from `package.json` if `lerna.json` is unavailable.

### Build and Release Process Improvements:
* **Updated `release` script in `package.json`:** The `release` script now uses `lerna version` with additional flags (`--no-push` and `--no-git-tag-version`) before building, linting, and publishing packages. This change ensures better control over versioning and avoids automatic pushing and tagging during the process.

### Versioning Logic Enhancements:
* **Added fallback to `package.json` for version retrieval:** In the `vite.config.ts` file, the `getVersionAndWriteInfo` function now attempts to read the version from `package.json` if `lerna.json` is not found. This provides a more robust mechanism to determine the project version.