### PR TITLE
Fix/agent cli json and error handling

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -13,14 +13,16 @@ bun install -g @elizaos/cli
 The ElizaOS CLI requires [Bun](https://bun.sh) as its package manager. If Bun is not installed when you run the CLI, it will attempt to automatically install it for you.
 
 **Auto-installation features:**
+
 - ✅ Detects when Bun is missing
-- ✅ Downloads and installs Bun automatically on Windows, macOS, and Linux  
+- ✅ Downloads and installs Bun automatically on Windows, macOS, and Linux
 - ✅ Updates PATH for the current session
 - ✅ Falls back to manual installation instructions if auto-install fails
 - ✅ Skips auto-installation in CI environments
 - ✅ Can be disabled with `--no-auto-install` flag
 
 **To disable auto-installation:**
+
 ```bash
 # Global flag (applies to all commands)
 elizaos --no-auto-install create my-project
@@ -49,6 +51,7 @@ The following options are available for all ElizaOS CLI commands:
 - `-h, --help`: Display help information
 
 **Example usage:**
+
 ```bash
 # Disable auto-installation and emojis
 elizaos --no-auto-install --no-emoji create my-project
@@ -185,7 +188,6 @@ Manage ElizaOS agents.
   - `start` (alias: `s`): Start an agent
     - Options:
       - `-n, --name <name>`: Name of an existing agent to start
-      - `-j, --json <json>`: Character JSON configuration string
       - `--path <path>`: Local path to character JSON file
       - `--remote-character <url>`: URL to remote character JSON file
       - `-r, --remote-url <url>`: URL of the remote agent runtime

--- a/packages/cli/src/commands/agent.ts
+++ b/packages/cli/src/commands/agent.ts
@@ -225,7 +225,6 @@ agent
   .alias('s')
   .description('Start an agent with a character profile')
   .option('-n, --name <name>', 'Name of an existing agent to start')
-  .option('-j, --json <json>', 'Character JSON configuration string')
   .option('--path <path>', 'Path to local character JSON file')
   .option('--remote-character <url>', 'URL to remote character JSON file')
   .option('-r, --remote-url <url>', 'URL of the remote agent runtime')
@@ -242,7 +241,7 @@ To create a new agent:
   $ elizaos create -t agent my-agent-name   Create a new agent using Eliza template
 
 Required configuration:
-  You must provide one of these options: --name, --path, --json, or --remote-character
+  You must provide one of these options: --name, --path, or --remote-character
 `
   )
   .action(async (options) => {
@@ -252,8 +251,7 @@ Required configuration:
       const hasValidInput =
         options.path ||
         options.remoteCharacter ||
-        (options.name && options.name !== true && options.name !== '') ||
-        options.json;
+        (options.name && options.name !== true && options.name !== '');
 
       if (!hasValidInput) {
         // Show error and use commander's built-in help
@@ -326,20 +324,6 @@ Required configuration:
           } catch (error) {
             console.error('Error reading or parsing local JSON file:', error);
             throw new Error(`Failed to read or parse local JSON file: ${error.message}`);
-          }
-        }
-
-        // Then handle other options
-        if (options.json) {
-          try {
-            payload.characterJson = JSON.parse(options.json);
-            characterName = await createCharacter(payload);
-            if (!characterName) {
-              logger.error('Failed to create character from JSON. Check server logs for details.');
-            }
-          } catch (error) {
-            console.error('Error parsing JSON string:', error);
-            throw new Error(`Failed to parse JSON string: ${error.message}`);
           }
         }
 

--- a/packages/docs/docs/cli/agent.md
+++ b/packages/docs/docs/cli/agent.md
@@ -18,14 +18,14 @@ elizaos agent [options] [command]
 
 ## Subcommands
 
-| Subcommand | Aliases | Description                             | Required Options                                                   | Additional Options                                                    |
-| ---------- | ------- | --------------------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------- |
-| `list`     | `ls`    | List available agents                   |                                                                    | `-j, --json`, `-r, --remote-url <url>`, `-p, --port <port>`           |
-| `get`      | `g`     | Get agent details                       | `-n, --name <name>`                                                | `-j, --json`, `-o, --output [file]`, `-r, --remote-url`, `-p, --port` |
-| `start`    | `s`     | Start an agent with a character profile | One of: `-n, --name`, `-j, --json`, `--path`, `--remote-character` | `-r, --remote-url <url>`, `-p, --port <port>`                         |
-| `stop`     | `st`    | Stop an agent                           | `-n, --name <name>`                                                | `-r, --remote-url <url>`, `-p, --port <port>`                         |
-| `remove`   | `rm`    | Remove an agent                         | `-n, --name <name>`                                                | `-r, --remote-url <url>`, `-p, --port <port>`                         |
-| `set`      |         | Update agent configuration              | `-n, --name <name>` AND one of: `-c, --config` OR `-f, --file`     | `-r, --remote-url <url>`, `-p, --port <port>`                         |
+| Subcommand | Aliases | Description                             | Required Options                                               | Additional Options                                                    |
+| ---------- | ------- | --------------------------------------- | -------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `list`     | `ls`    | List available agents                   |                                                                | `-j, --json`, `-r, --remote-url <url>`, `-p, --port <port>`           |
+| `get`      | `g`     | Get agent details                       | `-n, --name <name>`                                            | `-j, --json`, `-o, --output [file]`, `-r, --remote-url`, `-p, --port` |
+| `start`    | `s`     | Start an agent with a character profile | One of: `-n, --name`, `--path`, `--remote-character`           | `-r, --remote-url <url>`, `-p, --port <port>`                         |
+| `stop`     | `st`    | Stop an agent                           | `-n, --name <name>`                                            | `-r, --remote-url <url>`, `-p, --port <port>`                         |
+| `remove`   | `rm`    | Remove an agent                         | `-n, --name <name>`                                            | `-r, --remote-url <url>`, `-p, --port <port>`                         |
+| `set`      |         | Update agent configuration              | `-n, --name <name>` AND one of: `-c, --config` OR `-f, --file` | `-r, --remote-url <url>`, `-p, --port <port>`                         |
 
 ## Options Reference
 
@@ -47,7 +47,6 @@ elizaos agent [options] [command]
 ### Start Specific Options
 
 - `-n, --name <name>`: Name of an existing agent to start
-- `-j, --json <json>`: Character JSON configuration string
 - `--path <path>`: Path to local character JSON file
 - `--remote-character <url>`: URL to remote character JSON file
 
@@ -116,9 +115,6 @@ elizaos agent start --name eliza
 # Start with local character file
 elizaos agent start --path ./characters/eliza.json
 
-# Start with JSON configuration string
-elizaos agent start --json '{"name":"eliza","system":"You are a helpful assistant"}'
-
 # Start from remote character file
 elizaos agent start --remote-character https://example.com/characters/eliza.json
 
@@ -130,7 +126,7 @@ elizaos agent start --path ./eliza.json --port 4000
 ```
 
 **Required Configuration:**
-You must provide one of these options: `--name`, `--path`, `--json`, or `--remote-character`
+You must provide one of these options: `--name`, `--path`, or `--remote-character`
 
 ### Stopping Agents
 


### PR DESCRIPTION
- tiny pr to cleanup agent command with an unecessary --json option on the agent start subcommand.
- updated agent.md doc
- updated cli doc to not include this option

unaffected:

elizaos agent get --json
elizaos agent list --json