### PR TITLE
fix: resolve env command interactive mode and flag inconsistencies

### DIFF
--- a/packages/docs/docs/cli/env.md
+++ b/packages/docs/docs/cli/env.md
@@ -78,7 +78,7 @@ Path: /current/directory/.env
 # Edit local environment variables interactively
 elizaos env edit-local
 
-# Edit with automatic confirmation of prompts
+# Display variables and exit (--yes flag skips interactive editing)
 elizaos env edit-local --yes
 ```
 
@@ -89,14 +89,13 @@ The edit-local command allows you to:
 - Edit existing variables
 - Delete variables
 
+**Note**: The `--yes` flag displays current variables and exits without interactive editing, since variable modification requires user input.
+
 ### Interactive Management
 
 ```bash
 # Start interactive environment manager
 elizaos env interactive
-
-# Interactive mode with automatic confirmations
-elizaos env interactive --yes
 ```
 
 Interactive mode provides a menu with options to:
@@ -104,6 +103,8 @@ Interactive mode provides a menu with options to:
 - List environment variables
 - Edit local environment variables
 - Reset environment variables
+
+**Note**: The `--yes` flag is ignored in interactive mode since it requires user input by design.
 
 ### Resetting Environment and Data
 


### PR DESCRIPTION
### Problem

Three critical issues in `elizaos env` command causing unreliable environment management:

1. **Infinite Loop**: `elizaos env interactive -y` loops forever, requiring Ctrl+C to exit
2. **Flag Logic Bug**: `elizaos env list --local` shows system info when it should only display local variables
3. **Inconsistent -y Behavior**: `edit-local -y` prompts for input instead of auto-confirming like `reset -y`

### Solution

**Interactive Mode (-y flag handling)**

- Interactive mode now ignores `-y` flag since it requires user input by design
- Removed problematic auto-execution logic that caused infinite loops

**List --local Flag Fix**

- Fixed conditional logic to show ONLY local environment variables
- Removed system information display when `--local` flag is used
- Improved error handling for missing .env files

**Edit-local -y Standardization**

- `-y` flag now displays current variables and exits gracefully
- Consistent with other commands - no interactive prompts when `-y` specified
- Auto-skips variable addition prompts in non-interactive mode

### Implementation Details

**Files Changed:**

- `packages/cli/src/commands/env.ts` - Core logic fixes
- `packages/docs/docs/cli/env.md` - Documentation updates

**Key Changes:**

- `showMainMenu()`: Removed conditional `-y` logic, always prompts user
- `editEnvVars()`: Added early exit for `-y` flag, updated `addNewVariable()` signature
- `addNewVariable()`: Added `yes` parameter to skip prompts in auto-confirm mode
- List command: Fixed `--local` conditional to exclude system information

**Testing:**

- All existing tests pass
- Fixes verified against reported issue scenarios
- No breaking changes to existing functionality

### Expected Behavior After Fix

```bash
# No longer loops infinitely - prompts user normally
elizaos env interactive -y

# Shows ONLY local variables, no system info
elizaos env list --local

# Displays variables and exits cleanly
elizaos env edit-local -y
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for a `--yes` flag to environment variable editing and listing commands, enabling auto-confirm mode to bypass interactive prompts.
- **Improvements**
	- Enhanced handling of local environment variable listing, providing clearer output and better management of missing files.
- **Documentation**
	- Updated documentation to clarify the behavior of the `--yes` flag in environment commands, including new notes and revised examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->