### PR TITLE
fix typos gitcoin-passport.md

### DIFF
--- a/packages/docs/packages/plugins/gitcoin-passport.md
+++ b/packages/docs/packages/plugins/gitcoin-passport.md
@@ -34,5 +34,5 @@ Getting your Scorer ID
 
 ## Usage
 
-Results are saved as message and agents can retrive it from there for different use cases.
-Default passport treshold of 20 is used, but you can pick your own value and match it agains that
+Results are saved as message and agents can retrieve it from there for different use cases.
+Default passport threshold of 20 is used, but you can pick your own value and match it agains that


### PR DESCRIPTION
packages/docs/packages/plugins/gitcoin-passport.md
`treshold` - `threshold`
`retrive` - `retrieve`