### PR TITLE
refactor: centralize directory detection with monorepo support

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,5 +1,5 @@
-import { buildProject, handleError, isMonorepoContext, UserEnvironment } from '@/src/utils';
-import { detectDirectoryType, getDirectoryTypeDescription } from '@/src/utils/directory-detection';
+import { buildProject, handleError, UserEnvironment } from '@/src/utils';
+import { detectDirectoryType } from '@/src/utils/directory-detection';
 import { validatePort } from '@/src/utils/port-validation';
 import { Command, Option } from 'commander';
 import chokidar from 'chokidar';
@@ -211,14 +211,23 @@ export const dev = new Command()
       const cwd = process.cwd();
       const directoryInfo = detectDirectoryType(cwd);
 
-      // Determine if this is a project or plugin based on directory detection
+      if (!directoryInfo) {
+        console.error('Cannot start development mode in this directory.');
+        console.info('This directory is not accessible or does not exist.');
+        process.exit(1);
+      }
+
+      // Determine if this is a project, plugin, or monorepo based on directory detection
       const isProject = directoryInfo.type === 'elizaos-project';
       const isPlugin = directoryInfo.type === 'elizaos-plugin';
+      const isMonorepo = directoryInfo.type === 'elizaos-monorepo';
 
       if (isProject) {
         console.info('Identified as an ElizaOS project package');
       } else if (isPlugin) {
         console.info('Identified as an ElizaOS plugin package');
+      } else if (isMonorepo) {
+        console.info('Identified as an ElizaOS monorepo');
       }
 
       // Prepare CLI arguments for the start command
@@ -256,9 +265,11 @@ export const dev = new Command()
 
           console.info('Rebuilding...');
 
-          const isMonorepo = await isMonorepoContext();
+          const currentDirInfo = detectDirectoryType(cwd);
+          const isInMonorepo =
+            currentDirInfo?.monorepoRoot || currentDirInfo?.type === 'elizaos-monorepo';
 
-          if (isMonorepo) {
+          if (isInMonorepo) {
             const { monorepoRoot } = await UserEnvironment.getInstance().getPathInfo();
             if (monorepoRoot) {
               const corePackages = [
@@ -309,28 +320,35 @@ export const dev = new Command()
         }
       };
 
-      if (!isProject && !isPlugin) {
+      if (!isProject && !isPlugin && !isMonorepo) {
         console.warn(
-          `Not in a recognized ElizaOS project or plugin directory. Current directory is: ${getDirectoryTypeDescription(directoryInfo)}. Running in standalone mode.`
+          `Not in a recognized ElizaOS project, plugin, or monorepo directory. Current directory is: ${directoryInfo.type}. Running in standalone mode.`
         );
       } else {
-        console.info(`Running in ${isProject ? 'project' : 'plugin'} mode`);
+        const modeDescription = isMonorepo ? 'monorepo' : isProject ? 'project' : 'plugin';
+        console.info(`Running in ${modeDescription} mode`);
 
-        // Ensure initial build is performed
-        console.info('Building project...');
-        try {
-          await buildProject(cwd, isPlugin);
-        } catch (error) {
-          console.error(`Initial build failed: ${error.message}`);
-          console.info('Continuing with dev mode anyway...');
+        // Ensure initial build is performed (skip for monorepo as it may have multiple projects)
+        if (!isMonorepo) {
+          console.info('Building project...');
+          try {
+            await buildProject(cwd, isPlugin);
+          } catch (error) {
+            console.error(`Initial build failed: ${error.message}`);
+            console.info('Continuing with dev mode anyway...');
+          }
+        } else {
+          console.info(
+            'Monorepo detected - skipping automatic build. Use specific package build commands as needed.'
+          );
         }
       }
 
       // Start the server initially
       await startServer(cliArgs);
 
-      // Set up file watching only if we're in a project or plugin directory
-      if (isProject || isPlugin) {
+      // Set up file watching if we're in a project, plugin, or monorepo directory
+      if (isProject || isPlugin || isMonorepo) {
         // Pass the rebuildAndRestart function as the onChange callback
         await watchDirectory(cwd, rebuildAndRestart);
 

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -1,7 +1,7 @@
 import { handleError, installPlugin, logHeader } from '@/src/utils';
 import { fetchPluginRegistry } from '@/src/utils/plugin-discovery';
 import { normalizePluginName } from '@/src/utils/registry';
-import { detectDirectoryType, getDirectoryTypeDescription } from '@/src/utils/directory-detection';
+import { detectDirectoryType } from '@/src/utils/directory-detection';
 import { promptForEnvVars } from '@/src/utils/env-prompt';
 import { logger } from '@elizaos/core';
 import { Command } from 'commander';
@@ -390,9 +390,9 @@ plugins
     const cwd = process.cwd();
     const directoryInfo = detectDirectoryType(cwd);
 
-    if (!directoryInfo.hasPackageJson) {
+    if (!directoryInfo || !directoryInfo.hasPackageJson) {
       logger.error(
-        `Command must be run inside an ElizaOS project directory. This directory is: ${getDirectoryTypeDescription(directoryInfo)}`
+        `Command must be run inside an ElizaOS project directory. This directory is: ${directoryInfo?.type || 'invalid or inaccessible'}`
       );
       process.exit(1);
     }
@@ -526,9 +526,9 @@ plugins
       const cwd = process.cwd();
       const directoryInfo = detectDirectoryType(cwd);
 
-      if (!directoryInfo.hasPackageJson) {
+      if (!directoryInfo || !directoryInfo.hasPackageJson) {
         console.error(
-          `Could not read or parse package.json. This directory is: ${getDirectoryTypeDescription(directoryInfo)}`
+          `Could not read or parse package.json. This directory is: ${directoryInfo?.type || 'invalid or inaccessible'}`
         );
         console.info('Please run this command from the root of an ElizaOS project.');
         process.exit(1);
@@ -573,9 +573,9 @@ plugins
       const cwd = process.cwd();
       const directoryInfo = detectDirectoryType(cwd);
 
-      if (!directoryInfo.hasPackageJson) {
+      if (!directoryInfo || !directoryInfo.hasPackageJson) {
         console.error(
-          `Could not read or parse package.json. This directory is: ${getDirectoryTypeDescription(directoryInfo)}`
+          `Could not read or parse package.json. This directory is: ${directoryInfo?.type || 'invalid or inaccessible'}`
         );
         process.exit(1);
       }

--- a/packages/cli/src/commands/publish.ts
+++ b/packages/cli/src/commands/publish.ts
@@ -12,7 +12,7 @@ import {
   saveRegistrySettings,
   validateDataDir,
 } from '@/src/utils/registry/index';
-import { detectDirectoryType, getDirectoryTypeDescription } from '@/src/utils/directory-detection';
+import { detectDirectoryType } from '@/src/utils/directory-detection';
 import { REGISTRY_REPO, REGISTRY_GITHUB_URL } from '@/src/utils/registry/constants';
 import { Command } from 'commander';
 import { execa } from 'execa';
@@ -472,9 +472,9 @@ export const publish = new Command()
       const directoryInfo = detectDirectoryType(cwd);
 
       // Validate that we're in a valid directory with package.json
-      if (!directoryInfo.hasPackageJson) {
+      if (!directoryInfo || !directoryInfo.hasPackageJson) {
         console.error(
-          `No package.json found in current directory. This directory is: ${getDirectoryTypeDescription(directoryInfo)}`
+          `No package.json found in current directory. This directory is: ${directoryInfo?.type || 'invalid or inaccessible'}`
         );
         process.exit(1);
       }
@@ -556,9 +556,7 @@ export const publish = new Command()
           detectedType = 'project';
           console.info('Detected project from package.json packageType field');
         } else {
-          console.info(
-            `Defaulting to plugin type. Directory detected as: ${getDirectoryTypeDescription(directoryInfo)}`
-          );
+          console.info(`Defaulting to plugin type. Directory detected as: ${directoryInfo.type}`);
         }
       }
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -31,7 +31,7 @@ import { Command } from 'commander';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { detectDirectoryType, getDirectoryTypeDescription } from '@/src/utils/directory-detection';
+import { detectDirectoryType } from '@/src/utils/directory-detection';
 import { validatePort } from '@/src/utils/port-validation';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -528,76 +528,78 @@ const startAgents = async (options: {
     // Use standardized directory detection
     const directoryInfo = detectDirectoryType(currentDir);
 
-    // Determine if this is a project or plugin
-    isProject = directoryInfo.type === 'elizaos-project';
-    isPlugin = directoryInfo.type === 'elizaos-plugin';
+    if (directoryInfo) {
+      // Determine if this is a project or plugin
+      isProject = directoryInfo.type === 'elizaos-project';
+      isPlugin = directoryInfo.type === 'elizaos-plugin';
 
-    if (isProject) {
-      logger.debug('Found ElizaOS project using standardized directory detection');
-    } else if (isPlugin) {
-      logger.debug('Found ElizaOS plugin using standardized directory detection');
-    }
+      if (isProject) {
+        logger.debug('Found ElizaOS project using standardized directory detection');
+      } else if (isPlugin) {
+        logger.debug('Found ElizaOS plugin using standardized directory detection');
+      }
 
-    // If we found a plugin or project, try to load it
-    if ((isProject || isPlugin) && directoryInfo.hasPackageJson) {
-      const packageJsonPath = path.join(currentDir, 'package.json');
-      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+      // If we found a plugin or project, try to load it
+      if ((isProject || isPlugin) && directoryInfo.hasPackageJson) {
+        const packageJsonPath = path.join(currentDir, 'package.json');
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
 
-      // If we found a main entry in package.json, try to load it
-      const mainEntry = packageJson.main;
-      if (mainEntry) {
-        const mainPath = path.resolve(currentDir, mainEntry);
+        // If we found a main entry in package.json, try to load it
+        const mainEntry = packageJson.main;
+        if (mainEntry) {
+          const mainPath = path.resolve(currentDir, mainEntry);
 
-        if (fs.existsSync(mainPath)) {
-          try {
-            // Try to import the module
-            const importedModule = await import(mainPath);
+          if (fs.existsSync(mainPath)) {
+            try {
+              // Try to import the module
+              const importedModule = await import(mainPath);
 
-            if (isPlugin) {
-              // Look for plugin object
-              if (
-                importedModule.default &&
-                typeof importedModule.default === 'object' &&
-                importedModule.default.name &&
-                typeof importedModule.default.init === 'function'
-              ) {
-                pluginModule = importedModule.default;
-                logger.debug(`Loaded plugin: ${pluginModule?.name || 'unnamed'}`);
-              } else {
-                logger.warn(
-                  'Plugin detected but no valid plugin export found, looking for other exports'
-                );
+              if (isPlugin) {
+                // Look for plugin object
+                if (
+                  importedModule.default &&
+                  typeof importedModule.default === 'object' &&
+                  importedModule.default.name &&
+                  typeof importedModule.default.init === 'function'
+                ) {
+                  pluginModule = importedModule.default;
+                  logger.debug(`Loaded plugin: ${pluginModule?.name || 'unnamed'}`);
+                } else {
+                  logger.warn(
+                    'Plugin detected but no valid plugin export found, looking for other exports'
+                  );
 
-                // Try to find any exported plugin object
-                for (const key in importedModule) {
-                  if (
-                    importedModule[key] &&
-                    typeof importedModule[key] === 'object' &&
-                    importedModule[key].name &&
-                    typeof importedModule[key].init === 'function'
-                  ) {
-                    pluginModule = importedModule[key];
-                    logger.debug(`Found plugin export under key: ${key}`);
-                    break;
+                  // Try to find any exported plugin object
+                  for (const key in importedModule) {
+                    if (
+                      importedModule[key] &&
+                      typeof importedModule[key] === 'object' &&
+                      importedModule[key].name &&
+                      typeof importedModule[key].init === 'function'
+                    ) {
+                      pluginModule = importedModule[key];
+                      logger.debug(`Found plugin export under key: ${key}`);
+                      break;
+                    }
                   }
                 }
+              } else if (isProject) {
+                // Look for project object
+                if (
+                  importedModule.default &&
+                  typeof importedModule.default === 'object' &&
+                  importedModule.default.agents
+                ) {
+                  projectModule = importedModule;
+                  logger.debug('Loaded project module');
+                }
               }
-            } else if (isProject) {
-              // Look for project object
-              if (
-                importedModule.default &&
-                typeof importedModule.default === 'object' &&
-                importedModule.default.agents
-              ) {
-                projectModule = importedModule;
-                logger.debug('Loaded project module');
-              }
+            } catch (importError) {
+              logger.error(`Error importing module: ${importError}`);
             }
-          } catch (importError) {
-            logger.error(`Error importing module: ${importError}`);
+          } else {
+            logger.error(`Main entry point ${mainPath} does not exist`);
           }
-        } else {
-          logger.error(`Main entry point ${mainPath} does not exist`);
         }
       }
     }

--- a/packages/cli/src/utils/build-project.ts
+++ b/packages/cli/src/utils/build-project.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { logger } from '@elizaos/core';
 import { execa } from 'execa';
-import { isMonorepoContext } from './get-package-info';
+import { detectDirectoryType } from './directory-detection';
 import { runBunCommand } from './run-bun';
 
 /**
@@ -37,8 +37,8 @@ export async function buildProject(cwd: string, isPlugin = false) {
   }
 
   // Check if we're in a monorepo
-  const inMonorepo = await isMonorepoContext();
-  if (inMonorepo) {
+  const directoryInfo = detectDirectoryType(cwd);
+  if (directoryInfo.monorepoRoot) {
     logger.debug('Detected monorepo structure, skipping install');
   }
 

--- a/packages/cli/src/utils/get-package-info.ts
+++ b/packages/cli/src/utils/get-package-info.ts
@@ -15,14 +15,6 @@ export async function getPackageVersion(packageName: string): Promise<string> {
 }
 
 /**
- * Check if we're inside a monorepo
- */
-export async function isMonorepoContext(): Promise<boolean> {
-  const { monorepoRoot } = await UserEnvironment.getInstance().getPathInfo();
-  return monorepoRoot !== null;
-}
-
-/**
  * Get local packages available in the monorepo
  */
 export async function getLocalPackages(): Promise<string[]> {

--- a/packages/cli/src/utils/load-plugin.ts
+++ b/packages/cli/src/utils/load-plugin.ts
@@ -177,9 +177,9 @@ const importStrategies: ImportStrategy[] = [
 ];
 
 /**
- * Determines if a plugin is from the ElizaOS ecosystem
+ * Determines if a package name is from the ElizaOS ecosystem
  */
-function isElizaOSPlugin(repository: string): boolean {
+function isElizaOSPackageName(repository: string): boolean {
   return repository.startsWith('@elizaos/') || repository.startsWith('@elizaos-plugins/');
 }
 
@@ -187,7 +187,7 @@ function isElizaOSPlugin(repository: string): boolean {
  * Get relevant import strategies based on plugin type
  */
 function getStrategiesForPlugin(repository: string): ImportStrategy[] {
-  const isElizaOS = isElizaOSPlugin(repository);
+  const isElizaOS = isElizaOSPackageName(repository);
 
   if (isElizaOS) {
     // ElizaOS ecosystem plugins: try all strategies
@@ -212,7 +212,7 @@ function getStrategiesForPlugin(repository: string): ImportStrategy[] {
  * @returns The loaded plugin module or null if loading fails after all attempts.
  */
 export async function loadPluginModule(repository: string): Promise<any | null> {
-  const isElizaOS = isElizaOSPlugin(repository);
+  const isElizaOS = isElizaOSPackageName(repository);
   const strategies = getStrategiesForPlugin(repository);
 
   logger.debug(

--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -1,9 +1,5 @@
-import {
-  getGitHubCredentials,
-  getLocalPackages,
-  isMonorepoContext,
-  resolveEnvFile,
-} from '@/src/utils';
+import { getGitHubCredentials, getLocalPackages, resolveEnvFile } from '@/src/utils';
+import { detectDirectoryType } from '@/src/utils/directory-detection';
 import { logger } from '@elizaos/core';
 import dotenv from 'dotenv';
 import { execa } from 'execa';
@@ -285,7 +281,8 @@ export async function getLocalRegistryIndex(): Promise<Record<string, string>> {
   }
 
   // If we're in a monorepo context, try to discover local plugins
-  if (await isMonorepoContext()) {
+  const directoryInfo = detectDirectoryType(process.cwd());
+  if (directoryInfo.monorepoRoot) {
     try {
       const localPackages = await getLocalPackages();
       const localRegistry: Record<string, string> = {};

--- a/packages/cli/test/commands/create.test.ts
+++ b/packages/cli/test/commands/create.test.ts
@@ -19,7 +19,7 @@ const {
   mockRunBunCommand,
   mockSetupPgLite,
   mockResolveEnvFile,
-  mockIsMonorepoContext,
+  mockDetectDirectoryType,
   mockCommanderInstance, // Renamed for clarity
   MockCommanderClass, // Renamed for clarity
   mockUserEnvironmentGetInstance, // For UserEnvironment.getInstance()
@@ -106,7 +106,7 @@ const {
     mockRunBunCommand: vi.fn(),
     mockSetupPgLite: vi.fn(),
     mockResolveEnvFile: vi.fn(),
-    mockIsMonorepoContext: vi.fn(),
+    mockDetectDirectoryType: vi.fn(),
     mockCommanderInstance: instance, // Store the instance
     MockCommanderClass: MockCmd, // Export the class itself
     mockUserEnvironmentGetInstance: vi.fn().mockReturnValue(userEnvInstanceMock),
@@ -138,7 +138,7 @@ vi.mock('@/src/utils', () => ({
   runBunCommand: mockRunBunCommand,
   setupPgLite: mockSetupPgLite,
   resolveEnvFile: mockResolveEnvFile, // This is the problematic one
-  isMonorepoContext: mockIsMonorepoContext,
+  detectDirectoryType: mockDetectDirectoryType,
   UserEnvironment: { getInstance: mockUserEnvironmentGetInstance }, // Mock the class with static method
   expandTildePath: vi.fn((p) => p), // from resolve-utils
   resolvePgliteDir: vi.fn().mockResolvedValue('/mock/.elizadb'), // from resolve-utils
@@ -224,7 +224,13 @@ describe('create command', () => {
     mockRunBunCommand.mockReset().mockResolvedValue({ success: true, stdout: '', stderr: '' });
     mockSetupPgLite.mockReset().mockResolvedValue(undefined);
     mockResolveEnvFile.mockReset().mockReturnValue(join(tempDir, '.env'));
-    mockIsMonorepoContext.mockReset().mockResolvedValue(false);
+    mockDetectDirectoryType.mockReset().mockReturnValue({
+      type: 'non-elizaos-dir',
+      hasPackageJson: true,
+      hasElizaOSDependencies: false,
+      elizaPackageCount: 0,
+      monorepoRoot: undefined,
+    });
   });
 
   afterEach(async () => {

--- a/packages/cli/tests/commands/update.test.ts
+++ b/packages/cli/tests/commands/update.test.ts
@@ -1,11 +1,11 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { execSync } from "child_process";
-import { mkdtemp, rm, writeFile } from "fs/promises";
-import { join } from "path";
-import { tmpdir } from "os";
-import { safeChangeDirectory, runCliCommandSilently } from "./test-utils";
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { execSync } from 'child_process';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { safeChangeDirectory, runCliCommandSilently } from './test-utils';
 
-describe("ElizaOS Update Commands", () => {
+describe('ElizaOS Update Commands', () => {
   let testTmpDir: string;
   let elizaosCmd: string;
   let originalCwd: string;
@@ -13,21 +13,21 @@ describe("ElizaOS Update Commands", () => {
   beforeEach(async () => {
     // Store original working directory
     originalCwd = process.cwd();
-    
+
     // Create temporary directory
-    testTmpDir = await mkdtemp(join(tmpdir(), "eliza-test-update-"));
+    testTmpDir = await mkdtemp(join(tmpdir(), 'eliza-test-update-'));
     process.chdir(testTmpDir);
-    
+
     // Setup CLI command
-    const scriptDir = join(__dirname, "..");
-    elizaosCmd = `bun run ${join(scriptDir, "../dist/index.js")}`;
+    const scriptDir = join(__dirname, '..');
+    elizaosCmd = `bun run ${join(scriptDir, '../dist/index.js')}`;
   });
 
   afterEach(async () => {
     // Restore original working directory (if it still exists)
     safeChangeDirectory(originalCwd);
-    
-    if (testTmpDir && testTmpDir.includes("eliza-test-update-")) {
+
+    if (testTmpDir && testTmpDir.includes('eliza-test-update-')) {
       try {
         await rm(testTmpDir, { recursive: true });
       } catch (e) {
@@ -43,130 +43,163 @@ describe("ElizaOS Update Commands", () => {
   };
 
   // --help
-  test("update --help shows usage and options", () => {
-    const result = execSync(`${elizaosCmd} update --help`, { encoding: "utf8" });
-    expect(result).toContain("Usage: elizaos update");
-    expect(result).toContain("--cli");
-    expect(result).toContain("--packages");
-    expect(result).toContain("--check");
-    expect(result).toContain("--skip-build");
+  test('update --help shows usage and options', () => {
+    const result = execSync(`${elizaosCmd} update --help`, { encoding: 'utf8' });
+    expect(result).toContain('Usage: elizaos update');
+    expect(result).toContain('--cli');
+    expect(result).toContain('--packages');
+    expect(result).toContain('--check');
+    expect(result).toContain('--skip-build');
   });
 
   // Basic runs
-  test("update runs in a valid project", async () => {
-    await makeProj("update-app");
-    
-    const result = runCliCommandSilently(elizaosCmd, "update", { timeout: 30000 });
-    
+  test('update runs in a valid project', async () => {
+    await makeProj('update-app');
+
+    const result = runCliCommandSilently(elizaosCmd, 'update', { timeout: 30000 });
+
     // Should either succeed or show success message
-    expect(result).toMatch(/(Project successfully updated|Update completed|already up to date|No updates available)/);
+    expect(result).toMatch(
+      /(Project successfully updated|Update completed|already up to date|No updates available)/
+    );
   }, 120000);
 
-  test("update --check works", async () => {
-    await makeProj("update-check-app");
-    
-    const result = runCliCommandSilently(elizaosCmd, "update --check", { timeout: 30000 });
-    
+  test('update --check works', async () => {
+    await makeProj('update-check-app');
+
+    const result = runCliCommandSilently(elizaosCmd, 'update --check', { timeout: 30000 });
+
     expect(result).toMatch(/Version: 1\.0/);
   }, 120000);
 
-  test("update --skip-build works", async () => {
-    await makeProj("update-skip-build-app");
-    
-    const result = runCliCommandSilently(elizaosCmd, "update --skip-build", { timeout: 30000 });
-    
-    expect(result).not.toContain("Building project");
+  test('update --skip-build works', async () => {
+    await makeProj('update-skip-build-app');
+
+    const result = runCliCommandSilently(elizaosCmd, 'update --skip-build', { timeout: 30000 });
+
+    expect(result).not.toContain('Building project');
   }, 120000);
 
-  test("update --packages works", async () => {
-    await makeProj("update-packages-app");
-    
-    const result = runCliCommandSilently(elizaosCmd, "update --packages", { timeout: 30000 });
-    
+  test('update --packages works', async () => {
+    await makeProj('update-packages-app');
+
+    const result = runCliCommandSilently(elizaosCmd, 'update --packages', { timeout: 30000 });
+
     // Should either succeed or show success message
-    expect(result).toMatch(/(Project successfully updated|Update completed|already up to date|No updates available)/);
+    expect(result).toMatch(
+      /(Project successfully updated|Update completed|already up to date|No updates available)/
+    );
   }, 120000);
 
-  test("update --cli works outside a project", () => {
-    const result = runCliCommandSilently(elizaosCmd, "update --cli", { timeout: 30000 });
-    
+  test('update --cli works outside a project', () => {
+    const result = runCliCommandSilently(elizaosCmd, 'update --cli', { timeout: 30000 });
+
     // Should either show success or message about installing globally
-    expect(result).toMatch(/(Project successfully updated|Update completed|already up to date|No updates available|install the CLI globally|CLI update is not available)/);
+    expect(result).toMatch(
+      /(Project successfully updated|Update completed|already up to date|No updates available|install the CLI globally|CLI update is not available)/
+    );
   }, 60000);
 
-  test("update --cli --packages works", async () => {
-    await makeProj("update-combined-app");
-    
-    const result = runCliCommandSilently(elizaosCmd, "update --cli --packages", { timeout: 30000 });
-    
+  test('update --cli --packages works', async () => {
+    await makeProj('update-combined-app');
+
+    const result = runCliCommandSilently(elizaosCmd, 'update --cli --packages', { timeout: 30000 });
+
     // Should either succeed or show success message
-    expect(result).toMatch(/(Project successfully updated|Update completed|already up to date|No updates available)/);
+    expect(result).toMatch(
+      /(Project successfully updated|Update completed|already up to date|No updates available)/
+    );
   }, 120000);
 
-  test("update succeeds outside a project (global check)", () => {
-    const result = runCliCommandSilently(elizaosCmd, "update", { timeout: 30000 });
-    
+  test('update succeeds outside a project (global check)', () => {
+    const result = runCliCommandSilently(elizaosCmd, 'update', { timeout: 30000 });
+
     // Should either show success or message about creating project
-    expect(result).toMatch(/(Project successfully updated|Update completed|already up to date|No updates available|create a new ElizaOS project|This appears to be an empty directory)/);
+    expect(result).toMatch(
+      /(Project successfully updated|Update completed|already up to date|No updates available|create a new ElizaOS project|This appears to be an empty directory)/
+    );
   }, 60000);
 
   // Non-project directory handling
-  test("update --packages shows helpful message in empty directory", () => {
-    const result = runCliCommandSilently(elizaosCmd, "update --packages", { timeout: 30000 });
-    
-    expect(result).toContain("This appears to be an empty directory");
+  test('update --packages shows helpful message in empty directory', () => {
+    const result = runCliCommandSilently(elizaosCmd, 'update --packages', { timeout: 30000 });
+
+    expect(result).toContain("This directory doesn't appear to be an ElizaOS project");
   }, 60000);
 
-  test("update --packages shows helpful message in non-elizaos project", async () => {
+  test('update --packages shows helpful message in non-elizaos project', async () => {
     // Create a non-ElizaOS package.json
-    await writeFile("package.json", JSON.stringify({
-      name: "some-other-project",
-      version: "1.0.0",
-      dependencies: {
-        express: "^4.18.0"
-      }
-    }, null, 2));
-    
-    const result = runCliCommandSilently(elizaosCmd, "update --packages", { timeout: 30000 });
-    
-    expect(result).toContain("some-other-project");
-    expect(result).toContain("elizaos create");
+    await writeFile(
+      'package.json',
+      JSON.stringify(
+        {
+          name: 'some-other-project',
+          version: '1.0.0',
+          dependencies: {
+            express: '^4.18.0',
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const result = runCliCommandSilently(elizaosCmd, 'update --packages', { timeout: 30000 });
+
+    expect(result).toContain('some-other-project');
+    expect(result).toContain('elizaos create');
   }, 60000);
 
-  test("update --packages works in elizaos project with dependencies", async () => {
-    await makeProj("update-elizaos-project");
-    
+  test('update --packages works in elizaos project with dependencies', async () => {
+    await makeProj('update-elizaos-project');
+
     // Add some ElizaOS dependencies to make it a valid project
-    await writeFile("package.json", JSON.stringify({
-      name: "test-elizaos-project",
-      version: "1.0.0",
-      dependencies: {
-        "@elizaos/core": "^1.0.0"
-      }
-    }, null, 2));
-    
-    const result = runCliCommandSilently(elizaosCmd, "update --packages --check", { timeout: 30000 });
-    
-    expect(result).toContain("ElizaOS");
+    await writeFile(
+      'package.json',
+      JSON.stringify(
+        {
+          name: 'test-elizaos-project',
+          version: '1.0.0',
+          dependencies: {
+            '@elizaos/core': '^1.0.0',
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const result = runCliCommandSilently(elizaosCmd, 'update --packages --check', {
+      timeout: 30000,
+    });
+
+    expect(result).toContain('ElizaOS');
   }, 120000);
 
-  test("update --packages shows message for project without elizaos dependencies", async () => {
-    await makeProj("update-no-deps-project");
-    
+  test('update --packages shows message for project without elizaos dependencies', async () => {
+    await makeProj('update-no-deps-project');
+
     // Create package.json without ElizaOS dependencies
-    await writeFile("package.json", JSON.stringify({
-      name: "test-project",
-      version: "1.0.0",
-      eliza: {
-        type: "project"
-      },
-      dependencies: {
-        express: "^4.18.0"
-      }
-    }, null, 2));
-    
-    const result = runCliCommandSilently(elizaosCmd, "update --packages", { timeout: 30000 });
-    
-    expect(result).toContain("No ElizaOS packages found");
+    await writeFile(
+      'package.json',
+      JSON.stringify(
+        {
+          name: 'test-project',
+          version: '1.0.0',
+          eliza: {
+            type: 'project',
+          },
+          dependencies: {
+            express: '^4.18.0',
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const result = runCliCommandSilently(elizaosCmd, 'update --packages', { timeout: 30000 });
+
+    expect(result).toContain('No ElizaOS packages found');
   }, 120000);
 });


### PR DESCRIPTION
## Problem

The ElizaOS CLI had scattered and inconsistent directory detection logic throughout the codebase:

1. **Missing monorepo structure detection** - No proper classification for subdirectories within the ElizaOS monorepo
2. **Scattered detection functions** - Multiple functions like `isMonorepoContext()` duplicated detection logic across different files
3. **Infrastructure packages misclassified** - CLI, client, and other monorepo packages were incorrectly detected as `elizaos-project` instead of infrastructure components
4. **Inconsistent detection patterns** - Different commands used different approaches to determine directory types
5. **Over-aggressive heuristics** - Dependency-based detection caused false positives for infrastructure packages within the monorepo

## Solution

Implemented a centralized, hierarchical directory detection system with a new `elizaos-subdir` type:

### New Directory Type

- Added `elizaos-subdir` type for subdirectories within the ElizaOS monorepo that aren't projects or plugins

### Simplified Logic

- **Outside monorepo**: Check if project/plugin → if not, classify as `non-elizaos-dir`
- **Inside monorepo**: Check if project/plugin → if not, classify as `elizaos-subdir`

### Conservative Detection

- Made `isElizaOSProject()` more conservative inside monorepos by only using explicit indicators
- Disabled heuristic-based detection (dependency patterns, file structure analysis) within monorepos
- Consolidated duplicate detection functions

## Details

### Core Changes

**Directory Detection (`packages/cli/src/utils/directory-detection.ts`)**

- Added `elizaos-subdir` to `DirectoryInfo` type union
- Simplified main detection logic to use clear inside/outside monorepo branching
- Made `isElizaOSProject()` accept `monorepoRoot` parameter for context-aware detection
- Disabled heuristic checks inside monorepos to prevent infrastructure package misclassification

**CLI Commands**

- All CLI commands now use the standardized `detectDirectoryType()` function
- Removed deprecated `isMonorepoContext()` function usage

**Dependencies**

- Eliminated duplicate logic in `get-package-info.ts`
- Added `monorepoRoot` property to `DirectoryInfo` for consistent access
- Updated registry logic to use consolidated detection

### Test Results

Before fix:

```bash
# CLI directory incorrectly detected as project
✅ Directory Type: elizaos-project  # ❌ Wrong

# Client directory correctly detected
✅ Directory Type: elizaos-subdir   # ✅ Correct
```

After fix (expected):

```bash
# Both CLI and client correctly detected as subdirs
✅ Directory Type: elizaos-subdir   # ✅ Correct for both
```

### Directory Type Hierarchy

1. **elizaos-monorepo** - Root of ElizaOS monorepo
2. **elizaos-project** - User projects with agents/characters
3. **elizaos-plugin** - ElizaOS plugins
4. **elizaos-subdir** - Infrastructure packages within monorepo (CLI, client, core, etc.)
5. **non-elizaos-dir** - Regular directories outside ElizaOS context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced support for ElizaOS monorepos, including improved detection, build, and update handling for monorepo and subdirectory types.

- **Bug Fixes**
  - Improved error handling and messaging for invalid or inaccessible directories across CLI commands.
  - Safer project and plugin startup with added checks and error logging.

- **Refactor**
  - Streamlined directory detection logic for more accurate classification and reduced code complexity.
  - Updated internal naming for clarity (e.g., distinguishing plugin name checks).

- **Style**
  - Standardized string quoting and formatting in test files for consistency.

- **Tests**
  - Updated tests to reflect new directory detection logic and improved error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->