### PR TITLE
fix: cleanup DB in E2E tests, make fresh unique DB, PGLITE_WASM_MODE: node

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,7 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
       TURBO_REMOTE_ONLY: true
+      PGLITE_WASM_MODE: node
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2

--- a/packages/cli/src/commands/test.ts
+++ b/packages/cli/src/commands/test.ts
@@ -164,7 +164,11 @@ const runE2eTests = async (
 
     // Set up standard paths and load .env
     const elizaDir = path.join(process.cwd(), '.eliza');
-    const elizaDbDir = await resolvePgliteDir();
+    // Create unique database directory for each test run to avoid conflicts
+    const packageName = path.basename(process.cwd());
+    const timestamp = Date.now();
+    const uniqueDbDir = path.join(process.cwd(), '.elizadb-test', `${packageName}-${timestamp}`);
+    const elizaDbDir = uniqueDbDir;
     const envInfo = await UserEnvironment.getInstanceInfo();
     const envFilePath = envInfo.paths.envFilePath;
 
@@ -172,17 +176,28 @@ const runE2eTests = async (
     console.info(`Eliza directory: ${elizaDir}`);
     console.info(`Database directory: ${elizaDbDir}`);
     console.info(`Environment file: ${envFilePath}`);
+    console.info(`Package name: ${packageName}, Timestamp: ${timestamp}`);
 
-    // Create db directory if it doesn't exist
-    if (!fs.existsSync(elizaDbDir)) {
-      console.info(`Creating database directory: ${elizaDbDir}`);
-      fs.mkdirSync(elizaDbDir, { recursive: true });
-      console.info(`Created database directory: ${elizaDbDir}`);
+    // Clean up any existing database directory to prevent corruption
+    if (fs.existsSync(elizaDbDir)) {
+      console.info(`Cleaning up existing database directory: ${elizaDbDir}`);
+      try {
+        fs.rmSync(elizaDbDir, { recursive: true, force: true });
+        console.info(`Successfully cleaned up existing database directory`);
+      } catch (error) {
+        console.warn(`Failed to clean up existing database directory: ${error}`);
+        // Continue anyway, the initialization might handle it
+      }
     }
 
-    // Set the database directory in environment variables
+    // Create fresh db directory
+    console.info(`Creating fresh database directory: ${elizaDbDir}`);
+    fs.mkdirSync(elizaDbDir, { recursive: true });
+    console.info(`Created database directory: ${elizaDbDir}`);
+
+    // Set the database directory in environment variables to ensure it's used
     process.env.PGLITE_DATA_DIR = elizaDbDir;
-    console.info(`Using database directory: ${elizaDbDir}`);
+    console.info(`Set PGLITE_DATA_DIR to: ${elizaDbDir}`);
 
     // Load environment variables from project .env if it exists
     if (fs.existsSync(envFilePath)) {
@@ -563,6 +578,23 @@ const runE2eTests = async (
           }
         }
         return { failed: true };
+      } finally {
+        // Clean up database directory after tests complete
+        try {
+          if (fs.existsSync(elizaDbDir)) {
+            console.info(`Cleaning up test database directory: ${elizaDbDir}`);
+            fs.rmSync(elizaDbDir, { recursive: true, force: true });
+            console.info(`Successfully cleaned up test database directory`);
+          }
+          // Also clean up the parent test directory if it's empty
+          const testDir = path.dirname(elizaDbDir);
+          if (fs.existsSync(testDir) && fs.readdirSync(testDir).length === 0) {
+            fs.rmSync(testDir, { recursive: true, force: true });
+          }
+        } catch (cleanupError) {
+          console.warn(`Failed to clean up test database directory: ${cleanupError}`);
+          // Don't fail the test run due to cleanup issues
+        }
       }
     } catch (error) {
       console.error('Error in runE2eTests:', error);


### PR DESCRIPTION
This pull request introduces changes to improve the handling of database directories during end-to-end (E2E) tests and updates the CI workflow configuration. The key changes include ensuring unique and clean database directories for each test run, adding cleanup logic after tests, and introducing a new environment variable in the CI workflow.

### Improvements to E2E Test Database Handling:
* Modified `runE2eTests` to create a unique database directory for each test run using the package name and a timestamp, preventing conflicts between test runs. (`packages/cli/src/commands/test.ts`, [packages/cli/src/commands/test.tsL167-R200](diffhunk://#diff-1e127a5e0035493241bed339c064acd5235272cf6841f1e539240118da2133eaL167-R200))
* Added logic to clean up existing database directories before initializing a new one to avoid potential corruption. (`packages/cli/src/commands/test.ts`, [packages/cli/src/commands/test.tsL167-R200](diffhunk://#diff-1e127a5e0035493241bed339c064acd5235272cf6841f1e539240118da2133eaL167-R200))
* Introduced a cleanup process in the `finally` block to remove the test database directory and its parent if empty after tests complete, ensuring no leftover files. (`packages/cli/src/commands/test.ts`, [packages/cli/src/commands/test.tsR581-R597](diffhunk://#diff-1e127a5e0035493241bed339c064acd5235272cf6841f1e539240118da2133eaR581-R597))

### CI Workflow Update:
* Added the `PGLITE_WASM_MODE` environment variable with the value `node` to the CI workflow configuration, likely to ensure compatibility with the testing environment. (`.github/workflows/ci.yaml`, [.github/workflows/ci.yamlR15](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR15))