### PR TITLE
feat: Add target to Content

### DIFF
--- a/packages/core/src/types/primitives.ts
+++ b/packages/core/src/types/primitives.ts
@@ -34,6 +34,9 @@ export interface Content {
   /** Optional source/origin of the content */
   source?: string;
 
+  /** Optional target/destination for responses */
+  target?: string;
+  
   /** URL of the original message/post (e.g. tweet URL, Discord message link) */
   url?: string;
 


### PR DESCRIPTION
# Risks

Low

# Background

## What does this PR do?

add an optional target to Content type

## What kind of change is this?

Improvements (misc. changes to existing features)

## Why are we doing this? Any context or related work?

So we have a clear way for plugin to describe when a response should be sent over DM

# Documentation changes needed?

My changes do not require a change to the project documentation.