### PR TITLE
fix: Ensure waitForServer uses SERVER_PORT env if provided

### DIFF
--- a/scripts/dev-watch.js
+++ b/scripts/dev-watch.js
@@ -114,7 +114,10 @@ function startCliServer() {
         const serverProcess = await startActualCliServer();
         if (serverProcess) {
           // Wait for server to be ready before starting frontend
-          const ready = await waitForServer();
+          
+          const port = process.env.SERVER_PORT || 3000;
+          const url = `http://localhost:${port}/api/ping`;
+          const ready = await waitForServer(url);
           if (ready && !isShuttingDown) {
             serverReady = true;
             log('DEV', '🔧 Backend server is ready!');

--- a/scripts/dev-watch.js
+++ b/scripts/dev-watch.js
@@ -114,10 +114,10 @@ function startCliServer() {
         const serverProcess = await startActualCliServer();
         if (serverProcess) {
           // Wait for server to be ready before starting frontend
-          
           const port = process.env.SERVER_PORT || 3000;
           const url = `http://localhost:${port}/api/ping`;
           const ready = await waitForServer(url);
+          
           if (ready && !isShuttingDown) {
             serverReady = true;
             log('DEV', '🔧 Backend server is ready!');


### PR DESCRIPTION
I ran into this issue on a port other than 3000 (in my case, 3050). 
This happened because the waitForServer() function was hardcoded to check http://localhost:3000/api/ping, ignoring the SERVER_PORT environment variable.

This PR updates the script to dynamically build the health check URL using SERVER_PORT env


<img width="879" alt="Screenshot 2025-06-10 at 12 30 31 PM" src="https://github.com/user-attachments/assets/0eec2099-546c-4ae8-85e1-6c92320b0a3a" />
