### PR TITLE
fix: remove truncate

### DIFF
--- a/packages/plugin-bootstrap/src/index.ts
+++ b/packages/plugin-bootstrap/src/index.ts
@@ -831,10 +831,7 @@ const postGeneratedHandler = async ({
     // Fix newlines
     cleanedText = cleanedText.replaceAll(/\\n/g, '\n\n');
     cleanedText = cleanedText.replace(/([^\n])\n([^\n])/g, '$1\n\n$2');
-    // Truncate to Twitter's character limit (280)
-    if (cleanedText.length > 280) {
-      cleanedText = truncateToCompleteSentence(cleanedText, 280);
-    }
+
     return cleanedText;
   }
 


### PR DESCRIPTION
We don't need to truncate Twitter posts manually. I've already handled this in the Twitter plugin: if a post exceeds 280 characters and the account isn't premium, it falls back to truncateToCompleteSentence.


https://github.com/elizaos-plugins/plugin-twitter/blob/891433de508eb4d9ce952c8c7512942f3e26620e/src/utils.ts#L97