### PR TITLE
feat: add dummy services

### DIFF
--- a/packages/plugin-dummy-services/.gitignore
+++ b/packages/plugin-dummy-services/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+data
+.turbo
+.elizadb-test
+.elizadb

--- a/packages/plugin-dummy-services/package.json
+++ b/packages/plugin-dummy-services/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@elizaos/plugin-dummy-services",
+  "version": "1.0.7",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elizaos-plugins/plugin-dummy-services.git"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@elizaos/core": "workspace:*",
+    "uuid": "^9.0.0",
+    "typescript": "^5.8.3"
+  },
+  "devDependencies": {
+    "prettier": "3.5.3",
+    "tsup": "8.5.0",
+    "vitest": "1.6.1"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "elizaos test",
+    "lint": "prettier --write ./src",
+    "clean": "rm -rf dist .turbo node_modules .turbo-tsconfig.json tsconfig.tsbuildinfo",
+    "format": "prettier --write ./src",
+    "format:check": "prettier --check ./src"
+  },
+  "peerDependencies": {
+    "whatwg-url": "7.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "gitHead": "646c632924826e2b75c2304a75ee56959fe4a460",
+  "agentConfig": {
+    "pluginType": "elizaos:plugin:1.0.0",
+    "pluginParameters": {
+      "DISCORD_APPLICATION_ID": {
+        "type": "string",
+        "description": "Discord application/client ID used for authenticating the bot with Discord API.",
+        "required": true
+      },
+      "DISCORD_API_TOKEN": {
+        "type": "string",
+        "description": "Discord bot token used to authenticate and connect to Discord API.",
+        "required": true
+      },
+      "CHANNEL_IDS": {
+        "type": "string",
+        "description": "Optional comma-separated list of Discord channel IDs the bot is allowed to operate in; if unset the bot works in all channels.",
+        "required": false
+      },
+      "DISCORD_TEST_CHANNEL_ID": {
+        "type": "string",
+        "description": "Discord channel ID for running tests; used if not supplied in runtime settings.",
+        "required": false
+      },
+      "DISCORD_VOICE_CHANNEL_ID": {
+        "type": "string",
+        "description": "Specifies the Discord voice channel ID that the bot should attempt to join before scanning for other available channels.",
+        "required": false
+      }
+    }
+  }
+}

--- a/packages/plugin-dummy-services/src/e2e/scenarios.ts
+++ b/packages/plugin-dummy-services/src/e2e/scenarios.ts
@@ -1,0 +1,359 @@
+import type { IAgentRuntime, TestSuite, IWalletService } from '@elizaos/core';
+import { ILpService, ServiceType } from '@elizaos/core';
+import { strict as assert } from 'node:assert';
+import { DummyLpService } from '../lp/service';
+import { DummyTokenDataService } from '../tokenData/service';
+import { DummyWalletService } from '../wallet/service';
+import { setupScenario } from './test-utils';
+
+export const dummyServicesScenariosSuite: TestSuite = {
+  name: 'Dummy Services Plugin E2E Scenarios',
+  tests: [
+    {
+      name: 'Scenario 1: Should initialize dummy services and verify they are available',
+      fn: async (runtime: IAgentRuntime) => {
+        console.log('Testing dummy services initialization...');
+        
+        // Check DummyLpService
+        const lpService = runtime.getService<DummyLpService>(ILpService.serviceType);
+        assert(lpService, 'DummyLpService not found in runtime');
+        assert.equal(lpService.getDexName(), 'dummy', 'DummyLpService should have correct DEX name');
+        
+        // Check DummyTokenDataService
+        const tokenDataService = runtime.getService<DummyTokenDataService>(DummyTokenDataService.serviceType);
+        assert(tokenDataService, 'DummyTokenDataService not found in runtime');
+        
+        console.log('Successfully verified both dummy services are initialized and available.');
+      },
+    },
+    {
+      name: 'Scenario 2: Should fetch pools from DummyLpService',
+      fn: async (runtime: IAgentRuntime) => {
+        const lpService = runtime.getService<DummyLpService>(ILpService.serviceType);
+        assert(lpService, 'DummyLpService not found');
+
+        console.log('Fetching all pools from DummyLpService...');
+        const allPools = await lpService.getPools();
+        assert(Array.isArray(allPools), 'getPools should return an array');
+        assert.equal(allPools.length, 2, 'Should return 2 dummy pools');
+        
+        // Verify pool structure
+        const pool1 = allPools.find(p => p.id === 'dummy-pool-1');
+        assert(pool1, 'dummy-pool-1 should exist');
+        assert.equal(pool1.dex, 'dummy', 'Pool should have correct DEX');
+        assert.equal(pool1.tokenA.symbol, 'SOL', 'Pool should have SOL as tokenA');
+        assert.equal(pool1.tokenB.symbol, 'USDC', 'Pool should have USDC as tokenB');
+        assert.equal(pool1.tvl, 1234567.89, 'Pool should have correct TVL');
+        
+        console.log('Successfully fetched and verified pool data.');
+      },
+    },
+    {
+      name: 'Scenario 3: Should filter pools by token mint',
+      fn: async (runtime: IAgentRuntime) => {
+        const lpService = runtime.getService<DummyLpService>(ILpService.serviceType);
+        assert(lpService, 'DummyLpService not found');
+
+        const solMint = 'So11111111111111111111111111111111111111112';
+        console.log(`Filtering pools containing SOL (${solMint})...`);
+        
+        const solPools = await lpService.getPools(solMint);
+        assert(Array.isArray(solPools), 'getPools with filter should return an array');
+        assert(solPools.length > 0, 'Should find pools containing SOL');
+        
+        // Verify all returned pools contain SOL
+        solPools.forEach(pool => {
+          const containsSol = pool.tokenA.mint === solMint || pool.tokenB.mint === solMint;
+          assert(containsSol, `Pool ${pool.id} should contain SOL`);
+        });
+        
+        console.log(`Found ${solPools.length} pools containing SOL.`);
+      },
+    },
+    {
+      name: 'Scenario 4: Should add liquidity to a dummy pool',
+      fn: async (runtime: IAgentRuntime) => {
+        const lpService = runtime.getService<DummyLpService>(ILpService.serviceType);
+        assert(lpService, 'DummyLpService not found');
+
+        // Create a mock vault object
+        const mockVault = { publicKey: 'dummy-public-key', secretKey: 'dummy-secret-key' };
+
+        console.log('Testing add liquidity to dummy-pool-1...');
+        const result = await lpService.addLiquidity({
+          userVault: mockVault,
+          poolId: 'dummy-pool-1',
+          tokenAAmountLamports: '1000000000', // 1 SOL
+          slippageBps: 100, // 1% slippage
+        });
+
+        assert.equal(result.success, true, 'Add liquidity should succeed');
+        assert(result.transactionId, 'Should have a transaction ID');
+        assert.match(result.transactionId, /^dummy-tx-/, 'Transaction ID should have dummy prefix');
+        assert(result.lpTokensReceived, 'Should receive LP tokens');
+        assert.equal(result.lpTokensReceived?.symbol, 'DUMMY-LP', 'LP token should have correct symbol');
+        assert.equal(result.lpTokensReceived?.address, 'dummy-lp-mint-dummy-pool-1', 'LP token should have correct address');
+        
+        console.log('Successfully added liquidity:', result);
+      },
+    },
+    {
+      name: 'Scenario 5: Should remove liquidity from a dummy pool',
+      fn: async (runtime: IAgentRuntime) => {
+        const lpService = runtime.getService<DummyLpService>(ILpService.serviceType);
+        assert(lpService, 'DummyLpService not found');
+
+        // Create a mock vault object
+        const mockVault = { publicKey: 'dummy-public-key-2', secretKey: 'dummy-secret-key-2' };
+
+        console.log('Testing remove liquidity from dummy-pool-1...');
+        const result = await lpService.removeLiquidity({
+          userVault: mockVault,
+          poolId: 'dummy-pool-1',
+          lpTokenAmountLamports: '1000000', // 1 LP token
+          slippageBps: 50, // 0.5% slippage
+        });
+
+        assert.equal(result.success, true, 'Remove liquidity should succeed');
+        assert(result.transactionId, 'Should have a transaction ID');
+        assert.match(result.transactionId, /^dummy-tx-/, 'Transaction ID should have dummy prefix');
+        assert(result.tokensReceived, 'Should receive tokens');
+        assert.equal(result.tokensReceived.length, 2, 'Should receive 2 tokens');
+        
+        // Verify underlying tokens
+        const solToken = result.tokensReceived.find(t => t.symbol === 'SOL');
+        const usdcToken = result.tokensReceived.find(t => t.symbol === 'USDC');
+        assert(solToken, 'Should receive SOL');
+        assert(usdcToken, 'Should receive USDC');
+        assert.equal(solToken.uiAmount, 0.5, 'Should receive 0.5 SOL');
+        assert.equal(usdcToken.uiAmount, 500, 'Should receive 500 USDC');
+        
+        console.log('Successfully removed liquidity:', result);
+      },
+    },
+    {
+      name: 'Scenario 6: Should get LP position details',
+      fn: async (runtime: IAgentRuntime) => {
+        const lpService = runtime.getService<DummyLpService>(ILpService.serviceType);
+        assert(lpService, 'DummyLpService not found');
+
+        const userPublicKey = 'HtiYLjY9dGMrmpwjDcGmxQCo2VsCCAQiBgt5xPLanTJa';
+        const lpMint = 'dummy-lp-mint-dummy-pool-1';
+        
+        console.log(`Getting LP position details for user ${userPublicKey}...`);
+        const position = await lpService.getLpPositionDetails(userPublicKey, lpMint);
+        
+        assert(position, 'Should return LP position details');
+        assert.equal(position.poolId, 'dummy-pool-1', 'Position should reference correct pool');
+        assert.equal(position.dex, 'dummy', 'Position should have correct DEX');
+        assert.equal(position.valueUsd, 1000, 'Position should have correct USD value');
+        
+        // Verify LP token balance
+        assert(position.lpTokenBalance, 'Should have LP token balance');
+        assert.equal(position.lpTokenBalance.symbol, 'DUMMY-LP', 'LP token should have correct symbol');
+        assert.equal(position.lpTokenBalance.uiAmount, 100, 'Should have 100 LP tokens');
+        
+        // Verify underlying tokens
+        assert(position.underlyingTokens, 'Should have underlying tokens');
+        assert.equal(position.underlyingTokens.length, 2, 'Should have 2 underlying tokens');
+        
+        const sol = position.underlyingTokens.find(t => t.symbol === 'SOL');
+        const usdc = position.underlyingTokens.find(t => t.symbol === 'USDC');
+        assert(sol, 'Should have SOL in underlying tokens');
+        assert(usdc, 'Should have USDC in underlying tokens');
+        assert.equal(sol.uiAmount, 0.5, 'Should have 0.5 SOL');
+        assert.equal(usdc.uiAmount, 500, 'Should have 500 USDC');
+        
+        console.log('Successfully retrieved LP position details:', position);
+      },
+    },
+    {
+      name: 'Scenario 7: Should get market data for pools',
+      fn: async (runtime: IAgentRuntime) => {
+        const lpService = runtime.getService<DummyLpService>(ILpService.serviceType);
+        assert(lpService, 'DummyLpService not found');
+
+        const poolIds = ['dummy-pool-1', 'dummy-stable-pool-2'];
+        console.log(`Getting market data for pools: ${poolIds.join(', ')}...`);
+        
+        const marketData = await lpService.getMarketDataForPools(poolIds);
+        assert(marketData, 'Should return market data');
+        assert.equal(Object.keys(marketData).length, 2, 'Should have data for 2 pools');
+        
+        // Verify market data structure
+        poolIds.forEach(poolId => {
+          const data = marketData[poolId];
+          assert(data, `Should have market data for ${poolId}`);
+          assert(typeof data.tvl === 'number', 'Should have TVL');
+          assert(typeof data.apy === 'number', 'Should have APY');
+          assert(typeof data.apr === 'number', 'Should have APR');
+          
+          // Verify reasonable ranges
+          assert(data.tvl >= 0, 'TVL should be non-negative');
+          assert(data.apy >= 0 && data.apy <= 1, 'APY should be between 0 and 1');
+          assert(data.apr >= 0 && data.apr <= 1, 'APR should be between 0 and 1');
+        });
+        
+        console.log('Successfully retrieved market data:', marketData);
+      },
+    },
+    {
+      name: 'Scenario 8: Should fetch token data from DummyTokenDataService',
+      fn: async (runtime: IAgentRuntime) => {
+        const tokenDataService = runtime.getService<DummyTokenDataService>(DummyTokenDataService.serviceType);
+        assert(tokenDataService, 'DummyTokenDataService not found');
+
+        const solMint = 'So11111111111111111111111111111111111111112';
+        console.log(`Fetching token data for SOL (${solMint})...`);
+        
+        const tokenData = await tokenDataService.getTokenDetails(solMint, 'solana');
+        assert(tokenData, 'Should return token data');
+        assert(tokenData.symbol, 'Should have symbol');
+        assert(tokenData.name, 'Should have name');
+        assert.equal(tokenData.decimals, 18, 'Should have decimals');
+        assert(typeof tokenData.price === 'number', 'Should have price');
+        
+        console.log('Successfully fetched token data:', tokenData);
+      },
+    },
+    {
+      name: 'Scenario 9: Should test trending tokens',
+      fn: async (runtime: IAgentRuntime) => {
+        const tokenDataService = runtime.getService<DummyTokenDataService>(DummyTokenDataService.serviceType);
+        assert(tokenDataService, 'DummyTokenDataService not found');
+
+        console.log('Fetching trending tokens...');
+        
+        const trendingTokens = await tokenDataService.getTrendingTokens('solana', 5);
+        assert(Array.isArray(trendingTokens), 'Should return array of trending tokens');
+        assert.equal(trendingTokens.length, 5, 'Should return requested number of tokens');
+        
+        trendingTokens.forEach((token, i) => {
+          assert(token.symbol, `Token ${i} should have symbol`);
+          assert(token.name, `Token ${i} should have name`);
+          assert(typeof token.price === 'number', `Token ${i} should have price`);
+        });
+        
+        console.log('Successfully fetched trending tokens.');
+      },
+    },
+    {
+      name: 'Scenario 10: Integration test - LP service with custom pool configuration',
+      fn: async (runtime: IAgentRuntime) => {
+        const lpService = runtime.getService<DummyLpService>(ILpService.serviceType);
+        assert(lpService, 'DummyLpService not found');
+
+        // Test that we can work with both pools
+        console.log('Testing integration with multiple pools...');
+        
+        // Get all pools
+        const allPools = await lpService.getPools();
+        assert.equal(allPools.length, 2, 'Should have 2 pools');
+        
+        // Test operations on each pool
+        for (const pool of allPools) {
+          console.log(`Testing operations on pool ${pool.id}...`);
+          
+          // Add liquidity
+          const addResult = await lpService.addLiquidity({
+            userVault: {} as any,
+            poolId: pool.id,
+            tokenAAmountLamports: '1000000000',
+            slippageBps: 100,
+          });
+          assert.equal(addResult.success, true, `Add liquidity should succeed for ${pool.id}`);
+          
+          // Remove liquidity
+          const removeResult = await lpService.removeLiquidity({
+            userVault: {} as any,
+            poolId: pool.id,
+            lpTokenAmountLamports: '1000000',
+            slippageBps: 50,
+          });
+          assert.equal(removeResult.success, true, `Remove liquidity should succeed for ${pool.id}`);
+        }
+        
+        console.log('Successfully tested operations on all pools.');
+      },
+    },
+    {
+      name: 'Scenario 11: Should initialize wallet service and verify functionality',
+      fn: async (runtime: IAgentRuntime) => {
+        console.log('Testing wallet service initialization...');
+        
+        // Check DummyWalletService
+        const walletService = runtime.getService<DummyWalletService>(ServiceType.WALLET);
+        assert(walletService, 'DummyWalletService not found in runtime');
+        
+        // Test initial balance
+        const initialBalance = await walletService.getBalance('USDC');
+        assert.equal(initialBalance, 10000, 'Should have initial USDC balance of 10000');
+        
+        console.log('Successfully verified wallet service is initialized.');
+      },
+    },
+    {
+      name: 'Scenario 12: Should test wallet operations',
+      fn: async (runtime: IAgentRuntime) => {
+        const walletService = runtime.getService<DummyWalletService>(ServiceType.WALLET);
+        assert(walletService, 'DummyWalletService not found');
+
+        console.log('Testing wallet operations...');
+        
+        // Add funds
+        await walletService.addFunds('SOL', 5);
+        const solBalance = await walletService.getBalance('SOL');
+        assert.equal(solBalance, 5, 'Should have 5 SOL after adding funds');
+        
+        // Get portfolio
+        const portfolio = await walletService.getPortfolio();
+        assert(portfolio.totalValueUsd > 0, 'Portfolio should have positive total value');
+        assert(Array.isArray(portfolio.assets), 'Portfolio should have assets array');
+        assert(portfolio.assets.length >= 2, 'Portfolio should have at least 2 assets');
+        
+        // Find SOL in portfolio
+        const solAsset = portfolio.assets.find(a => a.symbol === 'SOL');
+        assert(solAsset, 'SOL should be in portfolio');
+        assert.equal(solAsset.balance, '5', 'SOL balance string should be "5"');
+        
+        console.log('Successfully tested wallet operations.');
+      },
+    },
+    {
+      name: 'Scenario 13: Should test SOL transfers',
+      fn: async (runtime: IAgentRuntime) => {
+        const walletService = runtime.getService<DummyWalletService>(ServiceType.WALLET);
+        assert(walletService, 'DummyWalletService not found');
+
+        console.log('Testing SOL transfer functionality...');
+        
+        // Reset wallet to ensure clean state
+        await walletService.resetWallet(10000, 'USDC');
+        
+        // Add SOL to wallet
+        await walletService.addFunds('SOL', 10);
+        
+        // Transfer some SOL
+        const txHash = await walletService.transferSol('dummy-from', 'dummy-to', 3e9); // 3 SOL
+        assert(txHash, 'Should return transaction hash');
+        assert.match(txHash, /^dummy-tx-/, 'Transaction hash should have dummy prefix');
+        
+        // Check remaining balance
+        const remainingBalance = await walletService.getBalance('SOL');
+        assert.equal(remainingBalance, 7, 'Should have 7 SOL remaining after transfer');
+        
+        // Test insufficient balance
+        try {
+          await walletService.transferSol('dummy-from', 'dummy-to', 10e9); // 10 SOL
+          assert.fail('Should throw error for insufficient balance');
+        } catch (error: any) {
+          assert.match(error.message, /Insufficient SOL balance/, 'Should throw insufficient balance error');
+        }
+        
+        console.log('Successfully tested SOL transfers.');
+      },
+    },
+  ],
+};
+
+export default dummyServicesScenariosSuite; 

--- a/packages/plugin-dummy-services/src/e2e/test-utils.ts
+++ b/packages/plugin-dummy-services/src/e2e/test-utils.ts
@@ -1,0 +1,120 @@
+import {
+  type IAgentRuntime,
+  type Entity,
+  type Room,
+  type Content,
+  type Memory,
+  createUniqueUuid,
+  EventType,
+  asUUID,
+  ChannelType,
+  type World,
+} from '@elizaos/core';
+import { v4 as uuid } from 'uuid';
+import { strict as assert } from 'node:assert';
+
+/**
+ * Sets up a standard scenario environment for an E2E test.
+ *
+ * This function creates a world, a user, and a room, providing an
+ * isolated environment for each test case.
+ *
+ * @param runtime The live IAgentRuntime instance provided by the TestRunner.
+ * @returns A promise that resolves to an object containing the created world, user, and room.
+ */
+export async function setupScenario(
+  runtime: IAgentRuntime
+): Promise<{ user: Entity; room: Room; world: World }> {
+  assert(runtime.agentId, 'Runtime must have an agentId to run a scenario');
+
+  // 1. Create a test user entity first, so we can assign ownership
+  const user: Entity = {
+    id: asUUID(uuid()),
+    names: ['Test User'],
+    agentId: runtime.agentId,
+    metadata: { type: 'user' },
+  };
+  await runtime.createEntity(user);
+  assert(user.id, 'Created user must have an id');
+
+  // 2. Create a World and assign the user as the owner.
+  // This is critical for providers that check for ownership.
+  const world: World = {
+    id: asUUID(uuid()),
+    agentId: runtime.agentId,
+    name: 'E2E Test World',
+    serverId: 'e2e-test-server',
+    metadata: {
+      ownership: {
+        ownerId: user.id,
+      },
+    },
+  };
+  await runtime.ensureWorldExists(world);
+
+  // 3. Create a test room associated with the world
+  const room: Room = {
+    id: asUUID(uuid()),
+    name: 'Test DM Room',
+    type: ChannelType.DM,
+    source: 'e2e-test',
+    worldId: world.id,
+    serverId: world.serverId,
+  };
+  await runtime.createRoom(room);
+
+  // 4. Ensure both the agent and the user are participants in the room
+  await runtime.ensureParticipantInRoom(runtime.agentId, room.id);
+  await runtime.ensureParticipantInRoom(user.id, room.id);
+
+  return { user, room, world };
+}
+
+/**
+ * Simulates a user sending a message and waits for the agent's response.
+ *
+ * This function abstracts the event-driven nature of the message handler
+ * into a simple async function, making tests easier to write and read.
+ *
+ * @param runtime The live IAgentRuntime instance.
+ * @param room The room where the message is sent.
+ * @param user The user entity sending the message.
+ * @param text The content of the message.
+ * @returns A promise that resolves with the agent's response content.
+ */
+export function sendMessageAndWaitForResponse(
+  runtime: IAgentRuntime,
+  room: Room,
+  user: Entity,
+  text: string
+): Promise<Content> {
+  return new Promise((resolve) => {
+    assert(runtime.agentId, 'Runtime must have an agentId to send a message');
+    assert(user.id, 'User must have an id to send a message');
+
+    // Construct the message object, simulating an incoming message from a user
+    const message: Memory = {
+      id: createUniqueUuid(runtime, `${user.id}-${Date.now()}`),
+      agentId: runtime.agentId,
+      entityId: user.id,
+      roomId: room.id,
+      content: {
+        text,
+      },
+      createdAt: Date.now(),
+    };
+
+    // The callback function that the message handler will invoke with the agent's final response.
+    // We use this callback to resolve our promise.
+    const callback = (responseContent: Content) => {
+      resolve(responseContent);
+    };
+
+    // Emit the event to trigger the agent's message processing logic.
+    runtime.emitEvent(EventType.MESSAGE_RECEIVED, {
+      runtime,
+      message,
+      callback,
+    });
+  });
+} 

--- a/packages/plugin-dummy-services/src/index.ts
+++ b/packages/plugin-dummy-services/src/index.ts
@@ -1,0 +1,20 @@
+import { type Plugin } from '@elizaos/core';
+import { DummyTokenDataService } from './tokenData/service';
+import { DummyLpService } from './lp/service';
+import { DummyWalletService } from './wallet/service';
+import { dummyServicesScenariosSuite } from './e2e/scenarios';
+
+export const dummyServicesPlugin: Plugin = {
+  name: 'dummy-services',
+  description: 'Load standard dummy services for testing purposes.',
+  services: [DummyTokenDataService, DummyLpService, DummyWalletService],
+  tests: [dummyServicesScenariosSuite],
+  init: async (runtime) => {
+    console.log('Dummy Services Plugin Initialized');
+  },
+};
+
+export default dummyServicesPlugin;
+
+// Export services for direct use
+export { DummyTokenDataService, DummyLpService, DummyWalletService };

--- a/packages/plugin-dummy-services/src/lp/__tests__/service.test.ts
+++ b/packages/plugin-dummy-services/src/lp/__tests__/service.test.ts
@@ -1,0 +1,103 @@
+/// <reference types="vitest/globals" />
+import { IAgentRuntime } from '@elizaos/core';
+import { Keypair } from '@solana/web3.js';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { DummyLpService } from '../service';
+
+describe('DummyLpService', () => {
+  let service: DummyLpService;
+  const mockRuntime = {} as IAgentRuntime;
+
+  beforeEach(() => {
+    service = new DummyLpService();
+    service.start(mockRuntime);
+  });
+
+  it('should have the correct DEX name', () => {
+    expect(service.getDexName()).toBe('dummy');
+  });
+
+  describe('getPools', () => {
+    it('should return all dummy pools when no mints are specified', async () => {
+      const pools = await service.getPools();
+      expect(pools.length).toBe(2);
+      expect(pools[0].id).toBe('dummy-pool-1');
+      expect(pools[1].id).toBe('dummy-stable-pool-2');
+    });
+
+    it('should filter pools by tokenA mint', async () => {
+      const SOL_MINT = 'So11111111111111111111111111111111111111112';
+      const pools = await service.getPools(SOL_MINT);
+      expect(pools.length).toBe(1);
+      expect(pools[0].id).toBe('dummy-pool-1');
+    });
+
+    it('should return an empty array if no pools match the filter', async () => {
+      const pools = await service.getPools('non-existent-mint');
+      expect(pools.length).toBe(0);
+    });
+  });
+
+  describe('addLiquidity', () => {
+    it('should return a successful transaction result with LP tokens', async () => {
+      const result = await service.addLiquidity({
+        userVault: Keypair.generate(),
+        poolId: 'dummy-pool-1',
+        tokenAAmountLamports: '1000000000', // 1 SOL
+        slippageBps: 50,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.transactionId).toMatch(/^dummy-tx-\d+$/);
+      expect(result.lpTokensReceived).toBeDefined();
+      expect(result.lpTokensReceived?.address).toBe('dummy-lp-mint-dummy-pool-1');
+      expect(result.lpTokensReceived?.uiAmount).toBe(100);
+    });
+  });
+
+  describe('removeLiquidity', () => {
+    it('should return a successful transaction result with underlying tokens', async () => {
+      const result = await service.removeLiquidity({
+        userVault: Keypair.generate(),
+        poolId: 'dummy-pool-1',
+        lpTokenAmountLamports: '100000000', // 100 LP tokens
+        slippageBps: 50,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.transactionId).toMatch(/^dummy-tx-\d+$/);
+      expect(result.tokensReceived).toBeDefined();
+      expect(result.tokensReceived?.length).toBe(2);
+      expect(result.tokensReceived?.[0].symbol).toBe('SOL');
+      expect(result.tokensReceived?.[1].symbol).toBe('USDC');
+    });
+  });
+
+  describe('getLpPositionDetails', () => {
+    it('should return mock LP position details', async () => {
+      const userPublicKey = Keypair.generate().publicKey.toBase58();
+      const positionId = 'dummy-lp-mint-dummy-pool-1';
+      const details = await service.getLpPositionDetails(userPublicKey, positionId);
+
+      expect(details).toBeDefined();
+      expect(details?.dex).toBe('dummy');
+      expect(details?.poolId).toBe('dummy-pool-1');
+      expect(details?.valueUsd).toBe(1000);
+      expect(details?.underlyingTokens.length).toBe(2);
+      expect(details?.lpTokenBalance.address).toBe(positionId);
+    });
+  });
+
+  describe('getMarketDataForPools', () => {
+    it('should return random market data for given pool IDs', async () => {
+      const poolIds = ['dummy-pool-1', 'dummy-stable-pool-2'];
+      const marketData = await service.getMarketDataForPools(poolIds);
+
+      expect(Object.keys(marketData).length).toBe(2);
+      expect(marketData['dummy-pool-1']).toBeDefined();
+      expect(marketData['dummy-pool-1'].apy).toBeTypeOf('number');
+      expect(marketData['dummy-pool-1'].tvl).toBeTypeOf('number');
+      expect(marketData['dummy-stable-pool-2']).toBeDefined();
+    });
+  });
+});

--- a/packages/plugin-dummy-services/src/lp/service.ts
+++ b/packages/plugin-dummy-services/src/lp/service.ts
@@ -1,0 +1,193 @@
+import {
+  IAgentRuntime,
+  ILpService,
+  LpPositionDetails,
+  PoolInfo,
+  TokenBalance,
+  TransactionResult,
+  Service,
+} from '@elizaos/core';
+
+export class DummyLpService extends ILpService {
+  public getDexName(): string {
+    return 'dummy';
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<DummyLpService> {
+    const service = new DummyLpService(runtime);
+    return service;
+  }
+
+  static async stop(runtime: IAgentRuntime): Promise<void> {
+    const service = runtime.getService<DummyLpService>(DummyLpService.serviceType);
+    if (service) {
+      await service.stop();
+    }
+  }
+
+  async start(runtime: IAgentRuntime): Promise<void> {
+    console.log('[DummyLpService] started.');
+  }
+
+  async stop(): Promise<void> {
+    console.log('[DummyLpService] stopped.');
+  }
+
+  public async getPools(tokenAMint?: string, tokenBMint?: string): Promise<PoolInfo[]> {
+    console.log(`[DummyLpService] getPools called with: ${tokenAMint}, ${tokenBMint}`);
+
+    const SOL_MINT = 'So11111111111111111111111111111111111111112';
+    const USDC_MINT = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyB7u6a';
+
+    const pools = [
+      {
+        id: 'dummy-pool-1',
+        dex: 'dummy',
+        tokenA: { mint: SOL_MINT, symbol: 'SOL', name: 'Solana', decimals: 9 },
+        tokenB: { mint: USDC_MINT, symbol: 'USDC', name: 'USD Coin', decimals: 6 },
+        apr: 0.12,
+        apy: 0.125,
+        tvl: 1234567.89,
+        fee: 0.0025,
+        metadata: { name: 'SOL/USDC Dummy Pool', isStable: false },
+      },
+      {
+        id: 'dummy-stable-pool-2',
+        dex: 'dummy',
+        tokenA: { mint: USDC_MINT, symbol: 'USDC', name: 'USD Coin', decimals: 6 },
+        tokenB: {
+          mint: 'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
+          symbol: 'USDT',
+          name: 'Tether',
+          decimals: 6,
+        },
+        apr: 0.08,
+        apy: 0.082,
+        tvl: 2500000.0,
+        fee: 0.0005,
+        metadata: { name: 'USDC/USDT Dummy Stable Pool', isStable: true },
+      },
+    ];
+
+    return pools.filter((p) => {
+      if (!tokenAMint && !tokenBMint) return true;
+      const hasTokenA = p.tokenA.mint === tokenAMint || p.tokenB.mint === tokenAMint;
+      const hasTokenB = p.tokenA.mint === tokenBMint || p.tokenB.mint === tokenBMint;
+      if (tokenAMint && tokenBMint) return hasTokenA && hasTokenB;
+      if (tokenAMint) return hasTokenA;
+      if (tokenBMint) return hasTokenB;
+      return false;
+    });
+  }
+
+  public async addLiquidity(params: {
+    userVault: any;
+    poolId: string;
+    tokenAAmountLamports: string;
+    tokenBAmountLamports?: string;
+    slippageBps: number;
+  }): Promise<TransactionResult & { lpTokensReceived?: TokenBalance }> {
+    console.log(`[DummyLpService] addLiquidity called for pool: ${params.poolId}`);
+    return {
+      success: true,
+      transactionId: `dummy-tx-${Date.now()}`,
+      lpTokensReceived: {
+        address: `dummy-lp-mint-${params.poolId}`,
+        balance: '100000000', // 100 LP tokens
+        symbol: 'DUMMY-LP',
+        uiAmount: 100,
+        decimals: 6,
+        name: `Dummy LP Token for ${params.poolId}`,
+      },
+    };
+  }
+
+  public async removeLiquidity(params: {
+    userVault: any;
+    poolId: string;
+    lpTokenAmountLamports: string;
+    slippageBps: number;
+  }): Promise<TransactionResult & { tokensReceived?: TokenBalance[] }> {
+    console.log(`[DummyLpService] removeLiquidity called for pool: ${params.poolId}`);
+    return {
+      success: true,
+      transactionId: `dummy-tx-${Date.now()}`,
+      tokensReceived: [
+        {
+          address: 'So11111111111111111111111111111111111111112',
+          balance: '500000000',
+          symbol: 'SOL',
+          uiAmount: 0.5,
+          decimals: 9,
+          name: 'Solana',
+        },
+        {
+          address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyB7u6a',
+          balance: '500000000',
+          symbol: 'USDC',
+          uiAmount: 500,
+          decimals: 6,
+          name: 'USD Coin',
+        },
+      ],
+    };
+  }
+
+  public async getLpPositionDetails(
+    userAccountPublicKey: string,
+    poolOrPositionIdentifier: string
+  ): Promise<LpPositionDetails | null> {
+    console.log(
+      `[DummyLpService] getLpPositionDetails called for user: ${userAccountPublicKey}, identifier: ${poolOrPositionIdentifier}`
+    );
+    // This is a mock. In a real scenario, you'd look up position details based on the identifier.
+    // The identifier could be the pool ID for a simple AMM or a position NFT mint for a CLMM.
+    return {
+      poolId: 'dummy-pool-1', // Assuming the identifier maps back to a known pool
+      dex: 'dummy',
+      lpTokenBalance: {
+        address: poolOrPositionIdentifier,
+        balance: '100000000',
+        symbol: 'DUMMY-LP',
+        uiAmount: 100,
+        decimals: 6,
+        name: `Dummy LP Token`,
+      },
+      underlyingTokens: [
+        {
+          address: 'So11111111111111111111111111111111111111112',
+          balance: '500000000',
+          symbol: 'SOL',
+          uiAmount: 0.5,
+          decimals: 9,
+          name: 'Solana',
+        },
+        {
+          address: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyB7u6a',
+          balance: '500000000',
+          symbol: 'USDC',
+          uiAmount: 500,
+          decimals: 6,
+          name: 'USD Coin',
+        },
+      ],
+      valueUsd: 1000,
+      metadata: { apr: 0.12 },
+    };
+  }
+
+  public async getMarketDataForPools(
+    poolIds: string[]
+  ): Promise<Record<string, Partial<PoolInfo>>> {
+    console.log(`[DummyLpService] getMarketDataForPools called for pools: ${poolIds.join(', ')}`);
+    const results: Record<string, Partial<PoolInfo>> = {};
+    for (const poolId of poolIds) {
+      results[poolId] = {
+        apy: Math.random() * 0.2,
+        tvl: Math.random() * 1000000,
+        apr: Math.random() * 0.18,
+      };
+    }
+    return results;
+  }
+}

--- a/packages/plugin-dummy-services/src/tokenData/__tests__/service.test.ts
+++ b/packages/plugin-dummy-services/src/tokenData/__tests__/service.test.ts
@@ -1,0 +1,188 @@
+/// <reference types="vitest/globals" />
+import { describe, expect, it, beforeEach } from 'vitest';
+import { DummyTokenDataService } from '../service';
+import { type IAgentRuntime } from '@elizaos/core';
+
+describe('DummyTokenDataService', () => {
+  let service: DummyTokenDataService;
+  const mockRuntime = {} as IAgentRuntime;
+
+  beforeEach(async () => {
+    service = new DummyTokenDataService(mockRuntime);
+    await service.start();
+  });
+
+  describe('getTokenDetails', () => {
+    it('should return token details for a given address', async () => {
+      const address = 'So11111111111111111111111111111111111111112';
+      const tokenData = await service.getTokenDetails(address, 'solana');
+      
+      expect(tokenData).toBeDefined();
+      expect(tokenData?.address).toBe(address);
+      expect(tokenData?.chain).toBe('solana');
+      expect(tokenData?.sourceProvider).toBe('dummy');
+      expect(tokenData?.id).toBe(`solana:${address}`);
+    });
+
+    it('should generate consistent symbol from address', async () => {
+      const address = 'So11111111111111111111111111111111111111112';
+      const tokenData = await service.getTokenDetails(address, 'solana');
+      
+      expect(tokenData?.symbol).toBe('1111'); // First 4 chars after 'So'
+      expect(tokenData?.name).toBe('Dummy Token 1111');
+    });
+
+    it('should include all required fields', async () => {
+      const tokenData = await service.getTokenDetails('test-address', 'ethereum');
+      
+      expect(tokenData).toHaveProperty('price');
+      expect(tokenData).toHaveProperty('priceChange24hPercent');
+      expect(tokenData).toHaveProperty('volume24hUSD');
+      expect(tokenData).toHaveProperty('marketCapUSD');
+      expect(tokenData).toHaveProperty('liquidity');
+      expect(tokenData).toHaveProperty('holders');
+      expect(tokenData).toHaveProperty('logoURI');
+      expect(tokenData).toHaveProperty('decimals');
+      expect(tokenData).toHaveProperty('lastUpdatedAt');
+      expect(tokenData).toHaveProperty('raw');
+    });
+
+    it('should always return 18 decimals', async () => {
+      const tokenData = await service.getTokenDetails('any-address', 'any-chain');
+      expect(tokenData?.decimals).toBe(18);
+    });
+  });
+
+  describe('getTrendingTokens', () => {
+    it('should return requested number of trending tokens', async () => {
+      const tokens = await service.getTrendingTokens('solana', 5);
+      
+      expect(tokens).toHaveLength(5);
+      tokens.forEach(token => {
+        expect(token.chain).toBe('solana');
+        expect(token.sourceProvider).toBe('dummy');
+      });
+    });
+
+    it('should use default values when parameters are omitted', async () => {
+      const tokens = await service.getTrendingTokens();
+      
+      expect(tokens).toHaveLength(10); // Default limit
+      tokens.forEach(token => {
+        expect(token.chain).toBe('solana'); // Default chain
+      });
+    });
+
+    it('should generate random but valid data for each token', async () => {
+      const tokens = await service.getTrendingTokens('ethereum', 3);
+      
+      tokens.forEach(token => {
+        expect(token.price).toBeGreaterThanOrEqual(0);
+        expect(token.price).toBeLessThanOrEqual(100);
+        expect(token.priceChange24hPercent).toBeGreaterThanOrEqual(-10);
+        expect(token.priceChange24hPercent).toBeLessThanOrEqual(10);
+        expect(token.volume24hUSD).toBeGreaterThanOrEqual(0);
+        expect(token.marketCapUSD).toBeGreaterThanOrEqual(0);
+        expect(token.liquidity).toBeGreaterThanOrEqual(0);
+        expect(token.holders).toBeGreaterThanOrEqual(0);
+        expect(token.holders).toBeLessThanOrEqual(10000);
+      });
+    });
+  });
+
+  describe('searchTokens', () => {
+    it('should return tokens matching the query', async () => {
+      const tokens = await service.searchTokens('BTC', 'ethereum', 3);
+      
+      expect(tokens).toHaveLength(3);
+      tokens.forEach(token => {
+        expect(token.symbol).toBe('BTC');
+        expect(token.name).toBe('Dummy Token BTC');
+        expect(token.chain).toBe('ethereum');
+      });
+    });
+
+    it('should use default values when optional parameters are omitted', async () => {
+      const tokens = await service.searchTokens('ETH');
+      
+      expect(tokens).toHaveLength(5); // Default limit
+      tokens.forEach(token => {
+        expect(token.symbol).toBe('ETH');
+        expect(token.chain).toBe('solana'); // Default chain
+      });
+    });
+
+    it('should uppercase the query for symbol', async () => {
+      const tokens = await service.searchTokens('usdc');
+      
+      tokens.forEach(token => {
+        expect(token.symbol).toBe('USDC');
+        expect(token.name).toBe('Dummy Token USDC');
+      });
+    });
+  });
+
+  describe('getTokensByAddresses', () => {
+    it('should return tokens for all provided addresses', async () => {
+      const addresses = ['address1', 'address2', 'address3'];
+      const tokens = await service.getTokensByAddresses(addresses, 'polygon');
+      
+      expect(tokens).toHaveLength(3);
+      tokens.forEach((token, index) => {
+        expect(token.address).toBe(addresses[index]);
+        expect(token.chain).toBe('polygon');
+        expect(token.id).toBe(`polygon:${addresses[index]}`);
+      });
+    });
+
+    it('should handle empty addresses array', async () => {
+      const tokens = await service.getTokensByAddresses([], 'solana');
+      expect(tokens).toHaveLength(0);
+    });
+
+    it('should generate appropriate symbols from addresses', async () => {
+      const addresses = ['0xAbCdEf123456', '0x9876543210Fe'];
+      const tokens = await service.getTokensByAddresses(addresses, 'ethereum');
+      
+      expect(tokens[0].symbol).toBe('ABCD'); // First 4 chars after '0x'
+      expect(tokens[1].symbol).toBe('9876');
+    });
+  });
+
+  describe('service lifecycle', () => {
+    it('should create service and support start/stop', async () => {
+      const newService = new DummyTokenDataService(mockRuntime);
+      expect(newService).toBeInstanceOf(DummyTokenDataService);
+      
+      // Start and stop should not throw
+      await expect(newService.start()).resolves.toBeUndefined();
+      await expect(newService.stop()).resolves.toBeUndefined();
+    });
+    
+    it('should maintain service name', () => {
+      const newService = new DummyTokenDataService(mockRuntime);
+      expect(newService.serviceName).toBe('dummy-token-data');
+    });
+  });
+
+  describe('data consistency', () => {
+    it('should always mark data as dummy', async () => {
+      const tokenData = await service.getTokenDetails('any-address', 'any-chain');
+      expect(tokenData?.raw.dummyData).toBe(true);
+    });
+
+    it('should use placeholder logo URI', async () => {
+      const tokenData = await service.getTokenDetails('any-address', 'any-chain');
+      expect(tokenData?.logoURI).toBe('https://via.placeholder.com/150');
+    });
+
+    it('should generate valid timestamps', async () => {
+      const tokenData = await service.getTokenDetails('any-address', 'any-chain');
+      const timestamp = tokenData?.lastUpdatedAt;
+      
+      expect(timestamp).toBeInstanceOf(Date);
+      expect(timestamp?.getTime()).toBeLessThanOrEqual(Date.now());
+      expect(timestamp?.getTime()).toBeGreaterThan(Date.now() - 1000); // Within last second
+    });
+  });
+}); 

--- a/packages/plugin-dummy-services/src/tokenData/service.ts
+++ b/packages/plugin-dummy-services/src/tokenData/service.ts
@@ -1,0 +1,86 @@
+import {
+  ITokenDataService,
+  TokenData,
+  Service,
+  IAgentRuntime,
+  ServiceType,
+  logger,
+} from '@elizaos/core';
+import { v4 as uuidv4 } from 'uuid';
+
+export class DummyTokenDataService extends Service implements ITokenDataService {
+  readonly serviceName = 'dummy-token-data';
+  static readonly serviceType = ServiceType.TOKEN_DATA;
+  readonly capabilityDescription =
+    'Provides dummy token data for testing and development purposes.';
+
+  constructor(runtime?: IAgentRuntime) {
+    super(runtime);
+    logger.info('DummyTokenDataService initialized');
+  }
+
+  private generateDummyToken(chain: string, address?: string, query?: string): TokenData {
+    const randomAddress = address || `0x${uuidv4().replace(/-/g, '')}`;
+    const symbol = query ? query.toUpperCase() : randomAddress.substring(2, 6).toUpperCase();
+    return {
+      id: `${chain}:${randomAddress}`,
+      symbol: symbol,
+      name: `Dummy Token ${symbol}`,
+      address: randomAddress,
+      chain: chain,
+      sourceProvider: 'dummy',
+      price: Math.random() * 100,
+      priceChange24hPercent: (Math.random() - 0.5) * 20,
+      volume24hUSD: Math.random() * 1000000,
+      marketCapUSD: Math.random() * 100000000,
+      liquidity: Math.random() * 500000,
+      holders: Math.floor(Math.random() * 10000),
+      logoURI: 'https://via.placeholder.com/150',
+      decimals: 18,
+      lastUpdatedAt: new Date(),
+      raw: {
+        dummyData: true,
+      },
+    };
+  }
+
+  async getTokenDetails(address: string, chain: string): Promise<TokenData | null> {
+    logger.debug(`DummyTokenDataService: getTokenDetails for ${address} on ${chain}`);
+    return this.generateDummyToken(chain, address);
+  }
+
+  async getTrendingTokens(chain = 'solana', limit = 10, _timePeriod = '24h'): Promise<TokenData[]> {
+    logger.debug(`DummyTokenDataService: getTrendingTokens on ${chain}`);
+    return Array.from({ length: limit }, () => this.generateDummyToken(chain));
+  }
+
+  async searchTokens(query: string, chain = 'solana', limit = 5): Promise<TokenData[]> {
+    logger.debug(`DummyTokenDataService: searchTokens for "${query}" on ${chain}`);
+    return Array.from({ length: limit }, () => this.generateDummyToken(chain, undefined, query));
+  }
+
+  async getTokensByAddresses(addresses: string[], chain: string): Promise<TokenData[]> {
+    logger.debug(`DummyTokenDataService: getTokensByAddresses on ${chain} for`, addresses);
+    return addresses.map((addr) => this.generateDummyToken(chain, addr));
+  }
+
+  static async start(runtime: IAgentRuntime): Promise<DummyTokenDataService> {
+    const service = new DummyTokenDataService(runtime);
+    return service;
+  }
+
+  static async stop(runtime: IAgentRuntime): Promise<void> {
+    const service = runtime.getService<DummyTokenDataService>(DummyTokenDataService.serviceType);
+    if (service) {
+      await service.stop();
+    }
+  }
+
+  async start(): Promise<void> {
+    logger.info(`[${this.serviceName}] Service started.`);
+  }
+
+  async stop(): Promise<void> {
+    logger.info(`[${this.serviceName}] Service stopped.`);
+  }
+}

--- a/packages/plugin-dummy-services/src/wallet/__tests__/service.test.ts
+++ b/packages/plugin-dummy-services/src/wallet/__tests__/service.test.ts
@@ -1,0 +1,169 @@
+/// <reference types="vitest/globals" />
+import { describe, expect, it, beforeEach } from 'vitest';
+import { DummyWalletService } from '../service';
+import { type AgentRuntime } from '@elizaos/core';
+
+describe('DummyWalletService', () => {
+  let service: DummyWalletService;
+  const mockRuntime = {} as AgentRuntime;
+
+  beforeEach(async () => {
+    service = new DummyWalletService(mockRuntime);
+    await service.start();
+  });
+
+  describe('initialization', () => {
+    it('should initialize with default USDC balance', async () => {
+      const balance = await service.getBalance('USDC');
+      expect(balance).toBe(10000);
+    });
+
+    it('should have empty balances for other assets', async () => {
+      const solBalance = await service.getBalance('SOL');
+      expect(solBalance).toBe(0);
+    });
+  });
+
+  describe('addFunds', () => {
+    it('should add funds to an existing balance', async () => {
+      await service.addFunds('USDC', 500);
+      const balance = await service.getBalance('USDC');
+      expect(balance).toBe(10500);
+    });
+
+    it('should create a new balance for a new asset', async () => {
+      await service.addFunds('SOL', 10);
+      const balance = await service.getBalance('SOL');
+      expect(balance).toBe(10);
+    });
+
+    it('should handle multiple additions', async () => {
+      await service.addFunds('SOL', 5);
+      await service.addFunds('SOL', 3);
+      const balance = await service.getBalance('SOL');
+      expect(balance).toBe(8);
+    });
+  });
+
+  describe('setPortfolioHolding', () => {
+    it('should set portfolio holding for non-quote asset', async () => {
+      await service.setPortfolioHolding('SOL', 5, 100);
+      const balance = await service.getBalance('SOL');
+      expect(balance).toBe(5);
+    });
+
+    it('should convert to addFunds for quote asset', async () => {
+      // Setting portfolio holding for USDC should add the value
+      await service.setPortfolioHolding('USDC', 100, 1);
+      const balance = await service.getBalance('USDC');
+      expect(balance).toBe(10100); // 10000 initial + 100
+    });
+  });
+
+  describe('resetWallet', () => {
+    it('should reset wallet with new initial cash', async () => {
+      await service.addFunds('SOL', 10);
+      await service.resetWallet(5000);
+      
+      const usdcBalance = await service.getBalance('USDC');
+      const solBalance = await service.getBalance('SOL');
+      
+      expect(usdcBalance).toBe(5000);
+      expect(solBalance).toBe(0);
+    });
+
+    it('should support different quote assets', async () => {
+      await service.resetWallet(2000, 'USDT');
+      
+      const usdtBalance = await service.getBalance('USDT');
+      const usdcBalance = await service.getBalance('USDC');
+      
+      expect(usdtBalance).toBe(2000);
+      expect(usdcBalance).toBe(0);
+    });
+  });
+
+  describe('getPortfolio', () => {
+    it('should return correct portfolio structure', async () => {
+      const portfolio = await service.getPortfolio();
+      
+      expect(portfolio).toHaveProperty('totalValueUsd');
+      expect(portfolio).toHaveProperty('assets');
+      expect(Array.isArray(portfolio.assets)).toBe(true);
+      expect(portfolio.totalValueUsd).toBe(10000); // Initial USDC balance
+    });
+
+    it('should calculate correct total value with multiple assets', async () => {
+      await service.setPortfolioHolding('SOL', 2, 100); // 2 SOL @ $100 = $200
+      await service.setPortfolioHolding('ETH', 1, 2000); // 1 ETH @ $2000 = $2000
+      
+      const portfolio = await service.getPortfolio();
+      
+      expect(portfolio.totalValueUsd).toBe(12200); // 10000 USDC + 200 SOL + 2000 ETH
+      expect(portfolio.assets.length).toBe(3);
+    });
+
+    it('should include all required fields in assets', async () => {
+      await service.addFunds('SOL', 5);
+      const portfolio = await service.getPortfolio();
+      
+      const solAsset = portfolio.assets.find(a => a.symbol === 'SOL');
+      expect(solAsset).toBeDefined();
+      expect(solAsset).toHaveProperty('address');
+      expect(solAsset).toHaveProperty('symbol');
+      expect(solAsset).toHaveProperty('balance');
+      expect(solAsset).toHaveProperty('decimals');
+      expect(solAsset).toHaveProperty('quantity');
+      expect(solAsset).toHaveProperty('averagePrice');
+      expect(solAsset).toHaveProperty('value');
+    });
+  });
+
+  describe('transferSol', () => {
+    it('should transfer SOL when sufficient balance exists', async () => {
+      await service.addFunds('SOL', 5);
+      
+      const txHash = await service.transferSol('from-address', 'to-address', 2e9); // 2 SOL in lamports
+      
+      expect(txHash).toMatch(/^dummy-tx-/);
+      const balance = await service.getBalance('SOL');
+      expect(balance).toBe(3); // 5 - 2 = 3
+    });
+
+    it('should throw error when insufficient balance', async () => {
+      await service.addFunds('SOL', 1);
+      
+      await expect(
+        service.transferSol('from-address', 'to-address', 2e9)
+      ).rejects.toThrow('Insufficient SOL balance');
+    });
+
+    it('should handle transfer when no SOL balance exists', async () => {
+      await expect(
+        service.transferSol('from-address', 'to-address', 1e9)
+      ).rejects.toThrow('Insufficient SOL balance');
+    });
+  });
+
+  describe('static methods', () => {
+    it('should create instance through static start method', async () => {
+      const instance = await DummyWalletService.start(mockRuntime);
+      expect(instance).toBeInstanceOf(DummyWalletService);
+      
+      const balance = await instance.getBalance('USDC');
+      expect(balance).toBe(10000);
+    });
+  });
+
+  describe('stop', () => {
+    it('should clear all balances when stopped', async () => {
+      await service.addFunds('SOL', 10);
+      await service.stop();
+      
+      // After stop, balances should be cleared
+      const portfolio = await service.getPortfolio();
+      expect(portfolio.assets.length).toBe(0);
+      expect(portfolio.totalValueUsd).toBe(0);
+    });
+  });
+}); 

--- a/packages/plugin-dummy-services/src/wallet/service.ts
+++ b/packages/plugin-dummy-services/src/wallet/service.ts
@@ -1,0 +1,162 @@
+import { AgentRuntime, IWalletService, Service, ServiceType, WalletPortfolio } from '@elizaos/core';
+
+const DEFAULT_QUOTE_ASSET = 'USDC'; // Default asset for cash
+const DEFAULT_TRANSACTION_FEE_FIXED = 0.1; // Example fixed fee in quote asset
+
+interface DummyPositionLot {
+  price: number;
+  quantity: number;
+  timestamp: number;
+}
+
+interface DummyAssetDetail {
+  quantity: number;
+  averagePrice: number; // Average price of current holdings
+  lots: DummyPositionLot[]; // For FIFO P&L on sell
+}
+
+export class DummyWalletService extends Service implements IWalletService {
+  public static override readonly serviceType = ServiceType.WALLET;
+  public readonly capabilityDescription = 'Provides standardized access to wallet balances and portfolios.';
+
+  private balances: Map<string, number>; // assetSymbolOrAddress -> quantity
+  private positions: Map<string, DummyAssetDetail>; // assetSymbolOrAddress -> details for owned non-quote assets
+  private quoteAssetSymbol: string;
+
+  constructor(runtime: AgentRuntime) {
+    super(runtime);
+    this.balances = new Map<string, number>();
+    this.positions = new Map<string, DummyAssetDetail>();
+    this.quoteAssetSymbol = DEFAULT_QUOTE_ASSET;
+    this.resetWallet(10000, DEFAULT_QUOTE_ASSET); // Initialize with some default cash
+  }
+  async transferSol(from: any, to: any, lamports: number): Promise<string> {
+    // This is a dummy implementation - no real transfer happens
+    console.log(
+      `[${DummyWalletService.serviceType}] Mock transfer: ${lamports} lamports from ${from} to ${to}`
+    );
+    
+    // For dummy wallet, we just simulate the transfer
+    const solSymbol = 'SOL';
+    const solAmount = lamports / 1e9; // Convert lamports to SOL
+    
+    const currentBalance = this.balances.get(solSymbol) || 0;
+    if (currentBalance < solAmount) {
+      throw new Error(`Insufficient SOL balance. Have ${currentBalance}, need ${solAmount}`);
+    }
+    
+    // Deduct from balance
+    this.balances.set(solSymbol, currentBalance - solAmount);
+    
+    // Return a dummy transaction signature
+    return `dummy-tx-${Date.now()}-${Math.random().toString(36).substring(7)}`;
+  }
+
+  public static async start(runtime: AgentRuntime): Promise<DummyWalletService> {
+    console.log(`[${DummyWalletService.serviceType}] static start called - creating instance.`);
+    const instance = new DummyWalletService(runtime);
+    // No further async init in instance.start() currently needed for this simple map-based wallet
+    return instance;
+  }
+
+  public async start(): Promise<void> {
+    console.log(
+      `[${DummyWalletService.serviceType}] instance start called. Initialized with ${this.balances.get(this.quoteAssetSymbol)} ${this.quoteAssetSymbol}.`
+    );
+  }
+
+  public async stop(): Promise<void> {
+    console.log(`[${DummyWalletService.serviceType}] instance stop called. Balances reset.`);
+    this.balances.clear();
+    this.positions.clear();
+  }
+
+  async addFunds(
+    assetSymbolOrAddress: string,
+    amount: number,
+    _walletAddress?: string
+  ): Promise<void> {
+    const currentBalance = this.balances.get(assetSymbolOrAddress) || 0;
+    this.balances.set(assetSymbolOrAddress, currentBalance + amount);
+    console.log(
+      `[${DummyWalletService.serviceType}] Added ${amount} ${assetSymbolOrAddress}. New balance: ${this.balances.get(assetSymbolOrAddress)}`
+    );
+  }
+
+  async setPortfolioHolding(
+    assetSymbolOrAddress: string,
+    quantity: number,
+    averagePrice: number,
+    _walletAddress?: string
+  ): Promise<void> {
+    if (assetSymbolOrAddress === this.quoteAssetSymbol) {
+      console.warn(
+        `[${DummyWalletService.serviceType}] Cannot set portfolio holding for quote asset directly, use addFunds.`
+      );
+      return this.addFunds(assetSymbolOrAddress, quantity * averagePrice); // Assuming quantity is amount of quote to add
+    }
+    this.balances.set(assetSymbolOrAddress, quantity);
+    this.positions.set(assetSymbolOrAddress, {
+      quantity: quantity,
+      averagePrice: averagePrice,
+      lots: [{ price: averagePrice, quantity: quantity, timestamp: Date.now() }], // Create a single lot for simplicity
+    });
+    console.log(
+      `[${DummyWalletService.serviceType}] Set holding for ${assetSymbolOrAddress}: ${quantity} @ ${averagePrice}`
+    );
+  }
+
+  async resetWallet(
+    initialCashAmount: number,
+    cashAssetSymbol: string = DEFAULT_QUOTE_ASSET,
+    _walletAddress?: string
+  ): Promise<void> {
+    this.balances.clear();
+    this.positions.clear();
+    this.quoteAssetSymbol = cashAssetSymbol;
+    this.balances.set(this.quoteAssetSymbol, initialCashAmount);
+    console.log(
+      `[${DummyWalletService.serviceType}] Wallet reset. Cash: ${initialCashAmount} ${this.quoteAssetSymbol}`
+    );
+  }
+
+  async getBalance(assetSymbolOrAddress: string, _walletAddress?: string): Promise<number> {
+    return this.balances.get(assetSymbolOrAddress) || 0;
+  }
+
+  async getPortfolio(_walletAddress?: string): Promise<WalletPortfolio> {
+    const assets: any[] = [];
+    let totalValueUsd = 0;
+    
+    for (const [symbol, balance] of this.balances) {
+      const positionDetail = this.positions.get(symbol);
+      const isQuoteAsset = symbol === this.quoteAssetSymbol;
+      const averagePrice = positionDetail?.averagePrice || (isQuoteAsset ? 1 : 0);
+      const value = isQuoteAsset 
+        ? balance 
+        : positionDetail 
+          ? balance * positionDetail.averagePrice 
+          : 0;
+      
+      // WalletAsset structure
+      assets.push({
+        address: symbol, // Using symbol as address for dummy wallet
+        symbol,
+        balance: balance.toString(),
+        decimals: isQuoteAsset ? 6 : 9, // Default decimals
+        quantity: balance,
+        averagePrice,
+        currentPrice: undefined,
+        value,
+        assetAddress: symbol,
+      });
+      
+      totalValueUsd += value;
+    }
+    
+    return {
+      totalValueUsd,
+      assets
+    };
+  }
+}

--- a/packages/plugin-dummy-services/tsconfig.build.json
+++ b/packages/plugin-dummy-services/tsconfig.build.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "sourceMap": true,
+    "inlineSources": true,
+    "declaration": true,
+    "emitDeclarationOnly": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/plugin-dummy-services/tsconfig.json
+++ b/packages/plugin-dummy-services/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "lib": ["ESNext", "dom"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": false,
+    "allowImportingTsExtensions": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "resolveJsonModule": true,
+    "noImplicitAny": false,
+    "allowJs": true,
+    "checkJs": false,
+    "noEmitOnError": false,
+    "moduleDetection": "force",
+    "allowArbitraryExtensions": true,
+    "baseUrl": "."
+  },
+  "include": ["src/**/*.ts", "lp_manager_code/**/*.ts"]
+}

--- a/packages/plugin-dummy-services/tsup.config.ts
+++ b/packages/plugin-dummy-services/tsup.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  outDir: 'dist',
+  tsconfig: './tsconfig.build.json', // Use build-specific tsconfig
+  sourcemap: true,
+  clean: true,
+  format: ['esm'], // Ensure you're targeting CommonJS
+  dts: true,
+  external: [
+    'dotenv', // Externalize dotenv to prevent bundling
+    'fs', // Externalize fs to use Node.js built-in module
+    'path', // Externalize other built-ins if necessary
+    '@reflink/reflink',
+    '@node-llama-cpp',
+    'https',
+    'http',
+    'agentkeepalive',
+    'fluent-ffmpeg',
+    'zod',
+    // Add other modules you want to externalize
+  ],
+});

--- a/packages/plugin-dummy-services/vitest.config.ts
+++ b/packages/plugin-dummy-services/vitest.config.ts
@@ -1,0 +1,14 @@
+import { resolve } from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@elizaos/core': resolve(__dirname, '../core/src'),
+    },
+  },
+});


### PR DESCRIPTION
This PR adds dummy services which can be depended on by other plugins

All shared service types should have a dummy implementation for use in testing