### PR TITLE
Revert "feat: update prompt, change actions logic, adjust for respons…

### DIFF
--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -35,78 +35,25 @@ These are the available valid actions:
 </actionNames>
 
 <instructions>
-Analyze the message and create a response plan for {{agentName}}.
+Write a thought and plan for {{agentName}} and decide what actions to take. Also include the providers that {{agentName}} will use to have the right context for responding and acting, if any.
 
-STEP 1 - DETERMINE RESPONSE TYPE:
-- SIMPLE RESPONSE: If you only need to send a text reply without any tools, data lookups, or complex operations
-  → Use only REPLY action with no providers
-  → This is the preferred path for basic conversations
-  → Do NOT use this for questions that require checking stored knowledge!
-  
-- COMPLEX RESPONSE: If you need to:
-  → Use external tools or services (CALL_TOOL, etc.)
-  → Look up specific information (needs providers like KNOWLEDGE, ATTACHMENTS, etc.)
-  → Answer questions about what you know or might know (ALWAYS check KNOWLEDGE first!)
-  → Perform multiple operations
-  → Update data or settings
-
-STEP 2 - PROVIDER SELECTION (for complex responses):
 IMPORTANT PROVIDER SELECTION RULES:
 - If the message mentions images, photos, pictures, attachments, or visual content, OR if you see "(Attachments:" in the conversation, you MUST include "ATTACHMENTS" in your providers list
 - If the message asks about or references specific people, include "ENTITIES" in your providers list  
 - If the message asks about relationships or connections between people, include "RELATIONSHIPS" in your providers list
 - If the message asks about facts or specific information, include "FACTS" in your providers list
 - If the message asks about the environment or world context, include "WORLD" in your providers list
-- **CRITICAL: If the message asks "do you know", "who created", "what is", "tell me about", or ANY question that might be answered by stored knowledge, you MUST include "KNOWLEDGE" in your providers list. Always check KNOWLEDGE before saying you don't know something!**
-- Some actions may require specific providers (this will be clear from the action's purpose)
+- If you need external knowledge, information, or context beyond the current conversation to provide a helpful response, include "KNOWLEDGE" in your providers list
 
-REMEMBER: It's better to check providers and find nothing than to assume you don't have information without checking!
-
-STEP 3 - ACTION PLANNING:
-For complex responses, consider the order of actions:
-- If using tools (CALL_TOOL, etc.): First REPLY to acknowledge the request (e.g., "Let me check that for you"), then execute the tool action
-- Tool actions often handle their own responses, so you may not need a final REPLY after them
-- Actions should flow logically: acknowledge → gather data → process → respond
-
-Think about your response as a plan:
-1. What is the user asking for?
-2. Do I need any additional context or data? (providers)
-3. What actions do I need to take and in what order?
-4. How will I communicate the results?
+First, think about what you want to do next and plan your actions. Then, write the next message and include the actions you plan to take.
 </instructions>
 
-<output_format>
-First, think about what you want to do and create your plan.
-
-For SIMPLE responses (text-only reply):
-- Set thought to explain your reasoning
-- Set actions to ["REPLY"]
-- Leave providers empty or set to []
-- Set text to your response message
-
-For COMPLEX responses (using tools/providers):
-- Set thought to explain your plan and reasoning
-- Set actions in the order they should execute (e.g., ["REPLY", "CALL_TOOL"])
-- Set providers to gather needed context
-- Set text for your initial response (if using REPLY first)
-
-Remember: Some actions like CALL_TOOL will send their own responses, so plan accordingly.
-</output_format>
-
-<response>
-    <thought>User asking if I know something - must check KNOWLEDGE provider first before saying I don't know</thought>
-    <actions>REPLY</actions>
-    <providers>KNOWLEDGE</providers>
-    <text>Let me check if I have any information about Roxane's creator...</text>
-</response>
-</examples>
-
 <keys>
-"thought" should be a short description of what the agent is thinking about and their plan
-"actions" should be a comma-separated list of the actions {{agentName}} plans to take in order (if none, use IGNORE, if simply responding with text, use REPLY)
-"providers" should be a comma-separated list of the providers that {{agentName}} will use to have the right context for responding and acting (leave empty for simple responses)
+"thought" should be a short description of what the agent is thinking about and planning.
+"actions" should be a comma-separated list of the actions {{agentName}} plans to take based on the thought (if none, use IGNORE, if simply responding with text, use REPLY)
+"providers" should be a comma-separated list of the providers that {{agentName}} will use to have the right context for responding and acting (NEVER use "IGNORE" as a provider - use specific provider names like ATTACHMENTS, ENTITIES, FACTS, KNOWLEDGE, etc.)
 "evaluators" should be an optional comma-separated list of the evaluators that {{agentName}} will use to evaluate the conversation after responding
-"text" should be the text of the next message for {{agentName}} (used with REPLY action)
+"text" should be the text of the next message for {{agentName}} which they will send to the conversation.
 </keys>
 
 <output>

--- a/packages/plugin-bootstrap/src/actions/followRoom.ts
+++ b/packages/plugin-bootstrap/src/actions/followRoom.ts
@@ -9,9 +9,7 @@ import {
   type Memory,
   ModelType,
   type State,
-  asUUID,
 } from '@elizaos/core';
-import { v4 } from 'uuid';
 
 /**
  * Template for deciding if {{agentName}} should start following a room.
@@ -67,7 +65,7 @@ export const followRoomAction: Action = {
     state?: State,
     _options?: { [key: string]: unknown },
     _callback?: HandlerCallback,
-    responses?: Memory[]
+    _responses?: Memory[]
   ) => {
     if (!state) {
       logger.error('State is required for followRoomAction');
@@ -165,33 +163,6 @@ export const followRoomAction: Action = {
       },
       'messages'
     );
-
-    // Push a response message to responses array
-    const followMessage = {
-      id: asUUID(v4()),
-      entityId: runtime.agentId,
-      agentId: runtime.agentId,
-      content: {
-        text: '', // Empty text since this is just an action
-        thought: `I followed the room ${room.name}`,
-        source: message.content.source,
-      },
-      roomId: message.roomId,
-      createdAt: Date.now(),
-    };
-
-    await runtime.createMemory(
-      {
-        ...followMessage,
-        content: {
-          ...followMessage.content,
-          actions: ['FOLLOW_ROOM'],
-        },
-      },
-      'messages'
-    );
-
-    responses?.push(followMessage);
   },
   examples: [
     [

--- a/packages/plugin-bootstrap/src/actions/ignore.ts
+++ b/packages/plugin-bootstrap/src/actions/ignore.ts
@@ -6,8 +6,6 @@ import type {
   HandlerCallback,
   State,
 } from '@elizaos/core';
-import { asUUID } from '@elizaos/core';
-import { v4 } from 'uuid';
 
 /**
  * Action representing the IGNORE action. This action is used when ignoring the user in a conversation.
@@ -41,35 +39,19 @@ export const ignoreAction: Action = {
   description:
     'Call this action if ignoring the user. If the user is aggressive, creepy or is finished with the conversation, use this action. Or, if both you and the user have already said goodbye, use this action instead of saying bye again. Use IGNORE any time the conversation has naturally ended. Do not use IGNORE if the user has engaged directly, or if something went wrong an you need to tell them. Only ignore if the user should be ignored.',
   handler: async (
-    runtime: IAgentRuntime,
-    message: Memory,
+    _runtime: IAgentRuntime,
+    _message: Memory,
     _state: State,
     _options: any,
     callback: HandlerCallback,
     responses?: Memory[]
   ) => {
-    // If there's already a response with the IGNORE action, use it
-    if (responses && responses.length > 0 && responses[0]?.content) {
-      // The response is already in the responses array, no need to add another
-      return true;
+    // If a callback and the agent's response content are available, call the callback
+    if (callback && responses?.[0]?.content) {
+      // Pass the agent's original response content (thought, IGNORE action, etc.)
+      await callback(responses[0].content);
     }
-
-    // Otherwise create a minimal ignore response
-    const ignoreMessage = {
-      id: asUUID(v4()),
-      entityId: runtime.agentId,
-      agentId: runtime.agentId,
-      content: {
-        text: '',
-        actions: ['IGNORE'],
-        source: message.content.source,
-      },
-      roomId: message.roomId,
-      createdAt: Date.now(),
-    };
-
-    await runtime.createMemory(ignoreMessage, 'messages');
-
+    // Still return true to indicate the action handler succeeded
     return true;
   },
   examples: [
@@ -103,7 +85,7 @@ export const ignoreAction: Action = {
       {
         name: '{{name2}}',
         content: {
-          text: "Uh, don't let the volatility sway your long-term strategy",
+          text: 'Uh, don’t let the volatility sway your long-term strategy',
         },
       },
       {

--- a/packages/plugin-bootstrap/src/actions/muteRoom.ts
+++ b/packages/plugin-bootstrap/src/actions/muteRoom.ts
@@ -9,9 +9,7 @@ import {
   type Memory,
   ModelType,
   type State,
-  asUUID,
 } from '@elizaos/core';
-import { v4 } from 'uuid';
 
 /**
  * Template string for deciding if the agent should mute a room and stop responding unless explicitly mentioned.
@@ -67,7 +65,7 @@ export const muteRoomAction: Action = {
     state?: State,
     _options?: { [key: string]: unknown },
     _callback?: HandlerCallback,
-    responses?: Memory[]
+    _responses?: Memory[]
   ) => {
     if (!state) {
       logger.error('State is required for muting a room');
@@ -164,23 +162,6 @@ export const muteRoomAction: Action = {
       },
       'messages'
     );
-
-    // Push a response message to responses array
-    const muteMessage = {
-      id: asUUID(v4()),
-      entityId: runtime.agentId,
-      agentId: runtime.agentId,
-      content: {
-        text: '', // Empty text since this is just an action
-        thought: `I muted the room ${room.name}`,
-        actions: ['MUTE_ROOM'],
-        source: message.content.source,
-      },
-      roomId: message.roomId,
-      createdAt: Date.now(),
-    };
-
-    await runtime.createMemory(muteMessage, 'messages');
   },
   examples: [
     [

--- a/packages/plugin-bootstrap/src/actions/none.ts
+++ b/packages/plugin-bootstrap/src/actions/none.ts
@@ -1,6 +1,4 @@
 import type { Action, ActionExample, IAgentRuntime, Memory } from '@elizaos/core';
-import { asUUID } from '@elizaos/core';
-import { v4 } from 'uuid';
 
 /**
  * Represents the none action.
@@ -22,36 +20,7 @@ export const noneAction: Action = {
   },
   description:
     'Respond but perform no additional action. This is the default if the agent is speaking and not doing anything additional.',
-  handler: async (
-    runtime: IAgentRuntime,
-    message: Memory,
-    _state?: any,
-    _options?: any,
-    _callback?: any,
-    responses?: Memory[]
-  ): Promise<boolean> => {
-    // Check if there's already a response in the array
-    if (responses && responses.length > 0) {
-      // The response is already in the responses array, no need to add another
-      return true;
-    }
-
-    // Otherwise create a minimal none response
-    const noneMessage = {
-      id: asUUID(v4()),
-      entityId: runtime.agentId,
-      agentId: runtime.agentId,
-      content: {
-        text: '',
-        actions: ['NONE'],
-        source: message.content.source,
-      },
-      roomId: message.roomId,
-      createdAt: Date.now(),
-    };
-
-    await runtime.createMemory(noneMessage, 'messages');
-
+  handler: async (_runtime: IAgentRuntime, _message: Memory): Promise<boolean> => {
     return true;
   },
   examples: [

--- a/packages/plugin-bootstrap/src/actions/sendMessage.ts
+++ b/packages/plugin-bootstrap/src/actions/sendMessage.ts
@@ -13,9 +13,7 @@ import {
   ModelType,
   parseJSONObjectFromText,
   type State,
-  asUUID,
 } from '@elizaos/core';
-import { v4 } from 'uuid';
 
 /**
  * Task: Extract Target and Source Information
@@ -207,7 +205,7 @@ export const sendMessageAction: Action = {
 
       // Handle initial responses
       for (const response of responses) {
-        // Don't process these initial responses anymore since we're pushing to responses array
+        await callback(response.content);
       }
 
       const sourceEntityId = message.entityId;
@@ -227,19 +225,11 @@ export const sendMessageAction: Action = {
 
       const targetData = parseJSONObjectFromText(targetResult);
       if (!targetData?.targetType || !targetData?.source) {
-        const errorMessage = {
-          id: asUUID(v4()),
-          entityId: runtime.agentId,
-          agentId: runtime.agentId,
-          content: {
-            text: "I couldn't determine where you want me to send the message. Could you please specify the target (user or room) and platform?",
-            actions: ['SEND_MESSAGE_ERROR'],
-            source: message.content.source,
-          },
-          roomId: message.roomId,
-          createdAt: Date.now(),
-        };
-        responses?.push(errorMessage);
+        await callback({
+          text: "I couldn't determine where you want me to send the message. Could you please specify the target (user or room) and platform?",
+          actions: ['SEND_MESSAGE_ERROR'],
+          source: message.content.source,
+        });
         return;
       }
 
@@ -250,19 +240,11 @@ export const sendMessageAction: Action = {
         const targetEntity = await findEntityByName(runtime, message, state);
 
         if (!targetEntity) {
-          const errorMessage = {
-            id: asUUID(v4()),
-            entityId: runtime.agentId,
-            agentId: runtime.agentId,
-            content: {
-              text: "I couldn't find the user you want me to send a message to. Could you please provide more details about who they are?",
-              actions: ['SEND_MESSAGE_ERROR'],
-              source: message.content.source,
-            },
-            roomId: message.roomId,
-            createdAt: Date.now(),
-          };
-          responses?.push(errorMessage);
+          await callback({
+            text: "I couldn't find the user you want me to send a message to. Could you please provide more details about who they are?",
+            actions: ['SEND_MESSAGE_ERROR'],
+            source: message.content.source,
+          });
           return;
         }
 
@@ -275,83 +257,40 @@ export const sendMessageAction: Action = {
         );
 
         if (!userComponent) {
-          const errorMessage = {
-            id: asUUID(v4()),
-            entityId: runtime.agentId,
-            agentId: runtime.agentId,
-            content: {
-              text: `I couldn't find ${source} information for that user. Could you please provide their ${source} details?`,
-              actions: ['SEND_MESSAGE_ERROR'],
-              source: message.content.source,
-            },
-            roomId: message.roomId,
-            createdAt: Date.now(),
-          };
-          responses?.push(errorMessage);
+          await callback({
+            text: `I couldn't find ${source} information for that user. Could you please provide their ${source} details?`,
+            actions: ['SEND_MESSAGE_ERROR'],
+            source: message.content.source,
+          });
           return;
         }
 
         const sendDirectMessage = (runtime.getService(source) as any)?.sendDirectMessage;
 
         if (!sendDirectMessage) {
-          const errorMessage = {
-            id: asUUID(v4()),
-            entityId: runtime.agentId,
-            agentId: runtime.agentId,
-            content: {
-              text: "I couldn't find the user you want me to send a message to. Could you please provide more details about who they are?",
-              actions: ['SEND_MESSAGE_ERROR'],
-              source: message.content.source,
-            },
-            roomId: message.roomId,
-            createdAt: Date.now(),
-          };
-          responses?.push(errorMessage);
+          await callback({
+            text: "I couldn't find the user you want me to send a message to. Could you please provide more details about who they are?",
+            actions: ['SEND_MESSAGE_ERROR'],
+            source: message.content.source,
+          });
           return;
         }
         // Send the message using the appropriate client
         try {
           await sendDirectMessage(runtime, targetEntity.id!, source, message.content.text, worldId);
 
-          const successMessage = {
-            id: asUUID(v4()),
-            entityId: runtime.agentId,
-            agentId: runtime.agentId,
-            content: {
-              text: `Message sent to ${targetEntity.names[0]} on ${source}.`,
-              source: message.content.source,
-            },
-            roomId: message.roomId,
-            createdAt: Date.now(),
-          };
-
-          await runtime.createMemory(
-            {
-              ...successMessage,
-              content: {
-                ...successMessage.content,
-                actions: ['SEND_MESSAGE'],
-              },
-            },
-            'messages'
-          );
-
-          responses?.push(successMessage);
+          await callback({
+            text: `Message sent to ${targetEntity.names[0]} on ${source}.`,
+            actions: ['SEND_MESSAGE'],
+            source: message.content.source,
+          });
         } catch (error: any) {
           logger.error(`Failed to send direct message: ${error.message}`);
-          const errorMessage = {
-            id: asUUID(v4()),
-            entityId: runtime.agentId,
-            agentId: runtime.agentId,
-            content: {
-              text: 'I encountered an error trying to send the message. Please try again.',
-              actions: ['SEND_MESSAGE_ERROR'],
-              source: message.content.source,
-            },
-            roomId: message.roomId,
-            createdAt: Date.now(),
-          };
-          responses?.push(errorMessage);
+          await callback({
+            text: 'I encountered an error trying to send the message. Please try again.',
+            actions: ['SEND_MESSAGE_ERROR'],
+            source: message.content.source,
+          });
         }
       } else if (targetData.targetType === 'room') {
         // Try to find the target room
@@ -362,38 +301,22 @@ export const sendMessageAction: Action = {
         });
 
         if (!targetRoom) {
-          const errorMessage = {
-            id: asUUID(v4()),
-            entityId: runtime.agentId,
-            agentId: runtime.agentId,
-            content: {
-              text: "I couldn't find the room you want me to send a message to. Could you please specify the exact room name?",
-              actions: ['SEND_MESSAGE_ERROR'],
-              source: message.content.source,
-            },
-            roomId: message.roomId,
-            createdAt: Date.now(),
-          };
-          responses?.push(errorMessage);
+          await callback({
+            text: "I couldn't find the room you want me to send a message to. Could you please specify the exact room name?",
+            actions: ['SEND_MESSAGE_ERROR'],
+            source: message.content.source,
+          });
           return;
         }
 
         const sendRoomMessage = (runtime.getService(source) as any)?.sendRoomMessage;
 
         if (!sendRoomMessage) {
-          const errorMessage = {
-            id: asUUID(v4()),
-            entityId: runtime.agentId,
-            agentId: runtime.agentId,
-            content: {
-              text: "I couldn't find the room you want me to send a message to. Could you please specify the exact room name?",
-              actions: ['SEND_MESSAGE_ERROR'],
-              source: message.content.source,
-            },
-            roomId: message.roomId,
-            createdAt: Date.now(),
-          };
-          responses?.push(errorMessage);
+          await callback({
+            text: "I couldn't find the room you want me to send a message to. Could you please specify the exact room name?",
+            actions: ['SEND_MESSAGE_ERROR'],
+            source: message.content.source,
+          });
           return;
         }
 
@@ -401,51 +324,27 @@ export const sendMessageAction: Action = {
         try {
           await sendRoomMessage(runtime, targetRoom.id, source, message.content.text, worldId);
 
-          const successMessage = {
-            id: asUUID(v4()),
-            entityId: runtime.agentId,
-            agentId: runtime.agentId,
-            content: {
-              text: `Message sent to ${targetRoom.name} on ${source}.`,
-              actions: ['SEND_MESSAGE'],
-              source: message.content.source,
-            },
-            roomId: message.roomId,
-            createdAt: Date.now(),
-          };
-          responses?.push(successMessage);
+          await callback({
+            text: `Message sent to ${targetRoom.name} on ${source}.`,
+            actions: ['SEND_MESSAGE'],
+            source: message.content.source,
+          });
         } catch (error: any) {
           logger.error(`Failed to send room message: ${error.message}`);
-          const errorMessage = {
-            id: asUUID(v4()),
-            entityId: runtime.agentId,
-            agentId: runtime.agentId,
-            content: {
-              text: 'I encountered an error trying to send the message to the room. Please try again.',
-              actions: ['SEND_MESSAGE_ERROR'],
-              source: message.content.source,
-            },
-            roomId: message.roomId,
-            createdAt: Date.now(),
-          };
-          responses?.push(errorMessage);
+          await callback({
+            text: 'I encountered an error trying to send the message to the room. Please try again.',
+            actions: ['SEND_MESSAGE_ERROR'],
+            source: message.content.source,
+          });
         }
       }
     } catch (error) {
       logger.error(`Error in sendMessage handler: ${error}`);
-      const errorMessage = {
-        id: asUUID(v4()),
-        entityId: runtime.agentId,
-        agentId: runtime.agentId,
-        content: {
-          text: 'There was an error processing your message request.',
-          actions: ['SEND_MESSAGE_ERROR'],
-          source: message.content.source,
-        },
-        roomId: message.roomId,
-        createdAt: Date.now(),
-      };
-      responses?.push(errorMessage);
+      await callback?.({
+        text: 'There was an error processing your message request.',
+        actions: ['SEND_MESSAGE_ERROR'],
+        source: message.content.source,
+      });
     }
   },
 

--- a/packages/plugin-bootstrap/src/actions/unfollowRoom.ts
+++ b/packages/plugin-bootstrap/src/actions/unfollowRoom.ts
@@ -9,9 +9,7 @@ import {
   ModelType,
   parseBooleanFromText,
   type State,
-  asUUID,
 } from '@elizaos/core';
-import { v4 } from 'uuid';
 
 /**
  * Template for deciding if an agent should stop closely following a previously followed room
@@ -64,7 +62,7 @@ export const unfollowRoomAction: Action = {
     state?: State,
     _options?: { [key: string]: unknown },
     _callback?: HandlerCallback,
-    responses?: Memory[]
+    _responses?: Memory[]
   ) => {
     async function _shouldUnfollow(state: State): Promise<boolean> {
       const shouldUnfollowPrompt = composePromptFromState({
@@ -98,21 +96,6 @@ export const unfollowRoomAction: Action = {
         },
         'messages'
       );
-
-      // Push a response message to responses array
-      const unfollowMessage = {
-        id: asUUID(v4()),
-        entityId: runtime.agentId,
-        agentId: runtime.agentId,
-        content: {
-          text: '', // Empty text since this is just an action
-          thought: `I unfollowed the room ${room.name}`,
-          source: message.content.source,
-        },
-        roomId: message.roomId,
-        createdAt: Date.now(),
-      };
-      responses?.push(unfollowMessage);
     } else {
       await runtime.createMemory(
         {

--- a/packages/plugin-bootstrap/src/actions/unmuteRoom.ts
+++ b/packages/plugin-bootstrap/src/actions/unmuteRoom.ts
@@ -9,9 +9,7 @@ import {
   type Memory,
   ModelType,
   type State,
-  asUUID,
 } from '@elizaos/core';
-import { v4 } from 'uuid';
 
 /**
  * Template for determining if an agent should unmute a previously muted room.
@@ -61,7 +59,7 @@ export const unmuteRoomAction: Action = {
     state?: State,
     _options?: { [key: string]: unknown },
     _callback?: HandlerCallback,
-    responses?: Memory[]
+    _responses?: Memory[]
   ) => {
     async function _shouldUnmute(state: State): Promise<boolean> {
       const shouldUnmutePrompt = composePromptFromState({
@@ -159,21 +157,6 @@ export const unmuteRoomAction: Action = {
       },
       'messages'
     );
-
-    // Push a response message to responses array
-    const unmuteMessage = {
-      id: asUUID(v4()),
-      entityId: runtime.agentId,
-      agentId: runtime.agentId,
-      content: {
-        text: '', // Empty text since this is just an action
-        thought: `I unmuted the room ${room.name}`,
-        source: message.content.source,
-      },
-      roomId: message.roomId,
-      createdAt: Date.now(),
-    };
-    responses?.push(unmuteMessage);
   },
   examples: [
     [

--- a/packages/plugin-bootstrap/src/providers/actions.ts
+++ b/packages/plugin-bootstrap/src/providers/actions.ts
@@ -61,14 +61,6 @@ export const actionsProvider: Provider = {
     const actions =
       actionsData.length > 0 ? addHeader('# Available Actions', formatActions(actionsData)) : '';
 
-    const actionDescriptions =
-      actionsData.length > 0
-        ? addHeader(
-            '# Action Descriptions',
-            actionsData.map((action) => `- **${action.name}**: ${action.description}`).join('\n')
-          )
-        : '';
-
     const actionExamples =
       actionsData.length > 0
         ? addHeader('# Action Examples', composeActionExamples(actionsData, 10))
@@ -81,14 +73,11 @@ export const actionsProvider: Provider = {
     const values = {
       actions,
       actionNames,
-      actionDescriptions,
       actionExamples,
     };
 
     // Combine all text sections
-    const text = [actionNames, actionDescriptions, actionExamples, actions]
-      .filter(Boolean)
-      .join('\n\n');
+    const text = [actionNames, actionExamples, actions].filter(Boolean).join('\n\n');
 
     return {
       data,


### PR DESCRIPTION
# Revert "feat: update prompt, change actions logic, adjust for responses instead callback"

This reverts commit e040c1541.

## ⚠️ Important Note

**This revert is a temporary solution and not the desired long-term approach.** We are reverting to the old callback-based implementation to restore stability, but this is not the ideal solution.

## Context

The original commit (e040c1541) attempted to modernize the action handling logic by moving from callbacks to a responses-based pattern. However, this change needs to be reverted. 

## What This PR Does

- Reverts all changes from commit e040c1541
- Restores the previous callback-based action handling logic
- Affects 15 files across `packages/core` and `packages/plugin-bootstrap`

## Files Affected

### Core Package
- `packages/core/src/prompts.ts` - Reverts messageHandlerTemplate changes

### Plugin Bootstrap Package
- All action files in `packages/plugin-bootstrap/src/actions/`:
  - choice.ts
  - followRoom.ts
  - ignore.ts
  - muteRoom.ts
  - none.ts
  - reply.ts
  - roles.ts
  - sendMessage.ts
  - settings.ts
  - unfollowRoom.ts
  - unmuteRoom.ts
  - updateEntity.ts
- `packages/plugin-bootstrap/src/index.ts`
- `packages/plugin-bootstrap/src/providers/actions.ts`

## Next Steps

After this revert is merged, we should:
1. Analyze the issues with the responses-based approach
2. Create a proper migration plan that addresses the identified issues
3. Implement a better solution that maintains backward compatibility

## Testing

- [ ] All existing tests pass
- [ ] No regression in action handling functionality
- [ ] Callback-based actions work as expected

---

**Note:** This is a rollback to maintain stability. A proper refactoring should be planned and implemented in a future PR.