### PR TITLE
Fix: Postgres migration schema selection

### DIFF
--- a/packages/plugin-sql/src/custom-migrator.ts
+++ b/packages/plugin-sql/src/custom-migrator.ts
@@ -951,10 +951,12 @@ export class PluginNamespaceManager {
         const result = await this.db.execute(sql.raw('SHOW search_path'));
         if (result.rows && result.rows.length > 0) {
           const searchPath = (result.rows[0] as any).search_path;
-          // The search_path can be a comma-separated list, take the first one.
-          const firstSchema = searchPath.split(',')[0].trim();
-          if (firstSchema && firstSchema !== '"$user"') {
-            return firstSchema;
+          // The search_path can be a comma-separated list, iterate to find the first valid schema
+          const schemas = searchPath.split(',').map((s: string) => s.trim());
+          for (const schema of schemas) {
+            if (schema && !schema.includes('$user')) {
+              return schema;
+            }
           }
         }
       } catch (e) {


### PR DESCRIPTION
# Risks: Low; not worse than what it was ;-)

# Background

This bug fixes a Postgresql migration issue:
If the first entry in the postgres search path is '\$user' (which it often is), it would wrongly return that entry due to wrong quotes.
The intention was to use 'public' or some other _valid_ custom schema.

This bugfix:
* correctly ignores values that _include_ '$user' (avoid exact matches that may or may not have quotes etc)
* will continue to iterate over the next values instead of directly using 'public'. 

E.g. previously if the search path was 

`"\$user", my_schema, public, extensions` , it would have wrongly returned "\$user"; and had it correctly recognized and ignored "\$user" it would have returned 'public', but should return my_schema.

# Reproduction:
This consistently happens on a fresh or existing supabase postgres database.
 
## Discord username
der.jogi