### PR TITLE
docs(agent): replace -t with --type in CLI examples

### DIFF
--- a/packages/docs/docs/cli/agent.md
+++ b/packages/docs/docs/cli/agent.md
@@ -249,10 +249,10 @@ elizaos agent list --port 4000
 
 ```bash
 # Create character file
-elizaos create -t agent eliza
+elizaos create -type agent eliza
 
 # Or create project with character
-elizaos create -t project my-project
+elizaos create -type project my-project
 ```
 
 ### 2. Start Agent Runtime


### PR DESCRIPTION
The “Create Agent character” examples still used the deprecated short flag `-t`:

    elizaos create -t agent eliza

Recent versions of the CLI reject that flag with:

    error: unknown option '-t'

All examples now use the long-form flag:

    elizaos create --type agent eliza
    elizaos create --type project my-project

For reference, the current `elizaos create --help` output shows `--type` as the only valid option:

```bash
Usage: elizaos create [options] [name]

Create a new ElizaOS project, plugin, agent, or TEE project

Options:
  --dir <dir>    directory to create the project in (default: ".")
  --yes, -y      skip prompts and use defaults
  --type <type>  type of project to create (project, plugin, agent, tee)
  -h, --help     display help for command
```


This update brings the documentation in line with the current CLI behaviour and prevents new users from encountering the “unknown option ‘-t’” error.
