### PR TITLE
fix: envs loading on default eliza

### DIFF
--- a/packages/cli/src/commands/start/index.ts
+++ b/packages/cli/src/commands/start/index.ts
@@ -21,6 +21,9 @@ export const start = new Command()
   })
   .action(async (options: StartOptions & { character?: string[] }) => {
     try {
+      // Load env config first before any character loading
+      await loadEnvConfig();
+      
       let characters: Character[] = [];
       let projectAgents: ProjectAgent[] = [];
 
@@ -38,9 +41,6 @@ export const start = new Command()
         try {
           const cwd = process.cwd();
           const packageJsonPath = path.join(cwd, 'package.json');
-
-          // Load env config first to populate plugins.
-          await loadEnvConfig();
 
           // Check if we're in a project directory
           if (fs.existsSync(packageJsonPath)) {


### PR DESCRIPTION
Fix for envs not loading in bun run start with default character eliza.
This moves the loadEnvs function higher up since was only being called for project agents.