### PR TITLE
fix: duplicate plugins

### DIFF
--- a/packages/client/src/components/plugins-panel.tsx
+++ b/packages/client/src/components/plugins-panel.tsx
@@ -86,7 +86,6 @@ export default function PluginsPanel({
     return [
       ...defaultPlugins,
       ...(Array.isArray(plugins) ? plugins : Object.keys(plugins))
-        .map((name) => name.replace(/^@elizaos-plugins\//, '@elizaos/'))
         .filter((name) => !defaultPlugins.includes(name)),
     ];
   }, [plugins]);

--- a/packages/client/src/hooks/use-plugins.ts
+++ b/packages/client/src/hooks/use-plugins.ts
@@ -69,7 +69,7 @@ export function usePlugins() {
 
             return isPlugin && hasV1Support && hasV1Version;
           })
-          .map(([name]) => name)
+          .map(([name]) => name.replace(/^@elizaos-plugins\//, '@elizaos/'))
           .sort();
 
         // Process agent plugins from the parallel fetch


### PR DESCRIPTION
related: https://github.com/elizaOS/eliza/issues/5086

This issue occurs because, in the usePlugins hook, we merge agentPlugins (using the @elizaos/ prefix) with registryPlugins (using the @elizaos-plugins/ prefix). As a result, the line:

```
const allPlugins = [...new Set([...registryPlugins, ...agentPlugins])];
```

fails to deduplicate plugins correctly due to inconsistent naming formats.

This PR moves the name normalization logic from plugins-panel.tsx into the use-plugins.ts hook, ensuring that all plugin names follow a consistent format before deduplication. This fixes the duplication issue in the plugin list UI.