### PR TITLE
fix: remove shortcut

### DIFF
--- a/packages/plugin-bootstrap/src/actions/reply.ts
+++ b/packages/plugin-bootstrap/src/actions/reply.ts
@@ -36,28 +36,6 @@ Response format should be formatted in a valid JSON block like this:
 
 Your response should include the valid JSON block and nothing else.`;
 
-function getFirstAvailableField(obj: Record<string, any>, fields: string[]): string | null {
-  for (const field of fields) {
-    if (typeof obj[field] === 'string' && obj[field].trim() !== '') {
-      return obj[field];
-    }
-  }
-  return null;
-}
-
-function extractReplyContent(response: Memory, replyFieldKeys: string[]): Content | null {
-  const hasReplyAction = response.content.actions?.includes('REPLY');
-  const text = getFirstAvailableField(response.content, replyFieldKeys);
-
-  if (!hasReplyAction || !text) return null;
-
-  return {
-    ...response.content,
-    thought: response.content.thought,
-    text,
-    actions: ['REPLY'],
-  };
-}
 
 /**
  * Represents an action that allows the agent to reply to the current conversation with a generated message.
@@ -88,22 +66,8 @@ export const replyAction = {
     callback: HandlerCallback,
     responses?: Memory[]
   ) => {
-    const replyFieldKeys = ['message', 'text'];
-
-    const existingReplies =
-      responses
-        ?.map((r) => extractReplyContent(r, replyFieldKeys))
-        .filter((reply): reply is Content => reply !== null) ?? [];
-
     // Check if any responses had providers associated with them
     const allProviders = responses?.flatMap((res) => res.content?.providers ?? []) ?? [];
-
-    if (existingReplies.length > 0 && allProviders.length === 0) {
-      for (const reply of existingReplies) {
-        await callback(reply);
-      }
-      return;
-    }
 
     // Only generate response using LLM if no suitable response was found
     state = await runtime.composeState(message, [...(allProviders ?? []), 'RECENT_MESSAGES']);


### PR DESCRIPTION
This code was initially implemented to handle cases where the agent's response is not a simple reply action. In such cases, the reply action checks if dynamic providers are missing, and if so, it simply calls back the response message using the bootstrap's receiveMessageHandler:
[bootstrap/src/index.ts#L463](https://github.com/elizaOS/eliza/blob/979b8e41beac634e0159f0bab6ab50ca0ec0df0f/packages/plugin-bootstrap/src/index.ts#L463)

However, if receiveMessageHandler returns multiple reply actions—like [reply, hardThing, secondHardThing, followUp, reply]—it would still call back the same message multiple times. This PR removes that shortcut to prevent such duplicate callbacks.