### PR TITLE
fix: duplicate memory

### DIFF
--- a/packages/client/src/components/chat.tsx
+++ b/packages/client/src/components/chat.tsx
@@ -517,8 +517,6 @@ export default function Chat({
     initialDmChannelId,
     updateChatState,
     handleNewDmChannel,
-    autoCreatedDmRef,
-    agentDmChannels.length,
   ]);
 
   // Cleanup timeout on unmount or when agentDmChannels appears


### PR DESCRIPTION
fix the issue that when the last memory is removed or a new agent is created, two memory entries appear in the dropdown:

![image](https://github.com/user-attachments/assets/3505a117-2977-4762-b735-e30ea87b2ce0)
