### PR TITLE
fix: action text in example should not be inline with action field

### DIFF
--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -74,17 +74,8 @@ const formatSelectedExamples = (examples: ActionExample[][]): string => {
       // Format the conversation
       const conversation = example
         .map((message) => {
-          // Build the base message
+          // Build the base message - only include the text, no action info
           let messageText = `${message.name}: ${message.content.text}`;
-
-          // Add action information if present
-          if (message.content.action) {
-            messageText += ` (action: ${message.content.action})`;
-          }
-
-          if (message.content.actions?.length) {
-            messageText += ` (actions: ${message.content.actions.join(', ')})`;
-          }
 
           // Replace name placeholders
           for (let i = 0; i < randomNames.length; i++) {


### PR DESCRIPTION
Small update action examples are confusing as text and action fields are inline and agent does mistake when choosing action in XML format by adding it inline with text. 

Bad example: 

```
assistant: I'll help you transfer 1 ETH to 0x742d35Cc6634C0532925a3b844Bc454e4438f44e (action: EVM_TRANSFER_TOKENS)
user: Transfer 1 ETH to 0x742d35Cc6634C0532925a3b844Bc454e4438f44e (action: EVM_TRANSFER_TOKENS)
```