### PR TITLE
Remove link with duplicated id from sidebars

### DIFF
--- a/packages/docs/sidebars.ts
+++ b/packages/docs/sidebars.ts
@@ -34,10 +34,6 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: '🧠 Core Concepts',
       collapsed: false,
-      link: {
-        type: 'doc',
-        id: 'core/overview',
-      },
       items: [
         {
           type: 'doc',


### PR DESCRIPTION
This PR fixes the Next navigation button bug in the Core Concepts - Overview section which pointed to the same page instead of Core Concepts - Actions by removing the unnecessary link section.