### PR TITLE
fix bootstrap evaluator callbacks

### DIFF
--- a/packages/plugin-bootstrap/src/index.ts
+++ b/packages/plugin-bootstrap/src/index.ts
@@ -537,15 +537,7 @@ const messageReceivedHandler = async ({
           } else {
             await runtime.processActions(message, responseMessages, state, callback);
           }
-          await runtime.evaluate(
-            message,
-            state,
-            shouldRespond,
-            async (memory: Content) => {
-              return [];
-            },
-            responseMessages
-          );
+          await runtime.evaluate(message, state, shouldRespond, callback, responseMessages);
         } else {
           // Handle the case where the agent decided not to respond
           logger.debug('[Bootstrap] Agent decided not to respond (shouldRespond is false).');


### PR DESCRIPTION
Evaluator callbacks seem unhandled.

This PR forwards the callback handler to `runtime.evaluate()` in favor of passing an empty closure