### PR TITLE
fix(ci): remove npm cache from autodoc workflow Node.js setup

### DIFF
--- a/.github/workflows/jsdoc-automation.yml
+++ b/.github/workflows/jsdoc-automation.yml
@@ -72,7 +72,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '23.3.0'
-          cache: 'npm'
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Problem
The autodoc workflow is failing during Node.js setup with the error:
```
Error: Dependencies lock file is not found in /home/runner/work/eliza/eliza. 
Supported file patterns: package-lock.json,npm-shrinkwrap.json,yarn.lock
```

## Root Cause
The workflow specifies `cache: 'npm'` in the Node.js setup action, but ElizaOS uses **Bun** as the package manager, not npm. The project doesn't have npm lock files (package-lock.json), causing the cache lookup to fail.

## Solution
- ✅ Remove `cache: 'npm'` parameter from Node.js setup
- ✅ ElizaOS uses Bun for package management, not npm
- ✅ No caching needed for Node.js since Bun handles dependencies

## Changes Made
```yaml
# Before (causing cache lookup failure)
- name: Setup Node.js
  uses: actions/setup-node@v4
  with:
    node-version: '23.3.0'
    cache: 'npm'  # ← This fails because no package-lock.json exists

# After (clean setup without npm cache)
- name: Setup Node.js
  uses: actions/setup-node@v4
  with:
    node-version: '23.3.0'  # ← No cache parameter
```

## Testing
This fix:
- Eliminates the npm cache lookup failure
- Allows Node.js 23.3.0 to be properly installed
- Maintains compatibility with Bun package management
- Proceeds to the next workflow steps without errors

## Files Changed
- `.github/workflows/jsdoc-automation.yml` - Remove npm cache parameter

Fixes npm cache lookup error preventing autodoc workflow from progressing past Node.js setup