### PR TITLE
fix: remove evaluators from messageHandler prompt

### DIFF
--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -63,7 +63,6 @@ First, think about what you want to do next and plan your actions. Then, write t
 "thought" should be a short description of what the agent is thinking about and planning.
 "actions" should be a comma-separated list of the actions {{agentName}} plans to take based on the thought, IN THE ORDER THEY SHOULD BE EXECUTED (if none, use IGNORE, if simply responding with text, use REPLY)
 "providers" should be a comma-separated list of the providers that {{agentName}} will use to have the right context for responding and acting (NEVER use "IGNORE" as a provider - use specific provider names like ATTACHMENTS, ENTITIES, FACTS, KNOWLEDGE, etc.)
-"evaluators" should be an optional comma-separated list of the evaluators that {{agentName}} will use to evaluate the conversation after responding
 "text" should be the text of the next message for {{agentName}} which they will send to the conversation.
 </keys>
 


### PR DESCRIPTION
# Relates to
None, I can open an issue if necessary and update this.

# Background
The default `messageHandler` prompt contains an entry for the AI to choose relevant evaluators to be run after handling the processed message. At the moment, however, even if the AI returns any evaluators in the response they are left unused, as the `runtime.evaluate` function simply runs through all available evaluators. Moreover it seems lie the AI is not given the list of evaluators to choose from (in contrast to the providers).

# Risks
Might interfere with some client plugins (e.g. socials) if they rely on this default template but haven't encountered any such plugin yet. Even if they did it probably would not properly work anyway due to the missing evaluators list.

## What does this PR do?
Removes obsolete evaluators entry in prompt which is unnecessary and may increase the probability of misleading the AI.

## What kind of change is this?
Bug fixes (non-breaking change which fixes an issue)

# Documentation changes needed?
My changes do not require a change to the project documentation.

## Discord username
@elrubio#3370
