### PR TITLE
fix: gui stuck issue

### DIFF
--- a/packages/client/src/components/chat.tsx
+++ b/packages/client/src/components/chat.tsx
@@ -100,6 +100,7 @@ interface ChatUIState {
   showGroupEditPanel: boolean;
   showProfileOverlay: boolean;
   input: string;
+  inputDisabled: boolean;
   selectedGroupAgentId: UUID | null;
   currentDmChannelId: UUID | null;
   isCreatingDM: boolean;
@@ -277,6 +278,7 @@ export default function Chat({
     showGroupEditPanel: false,
     showProfileOverlay: false,
     input: '',
+    inputDisabled: false,
     selectedGroupAgentId: null,
     currentDmChannelId: null,
     isCreatingDM: false,
@@ -499,6 +501,10 @@ export default function Chat({
     currentClientEntityId,
   ]);
 
+  useEffect(() => {
+    inputDisabledRef.current = chatState.inputDisabled;
+  }, [chatState.inputDisabled])
+
   // Effect to handle initial DM channel selection or creation
   useEffect(() => {
     if (chatType === ChannelType.DM && targetAgentData?.id) {
@@ -663,7 +669,7 @@ export default function Chat({
       // Clear the local message list immediately for instant UI response
       clearMessages();
     },
-    onInputDisabledChange: (disabled: boolean) => {inputDisabledRef.current = disabled},
+    onInputDisabledChange: (disabled: boolean) => updateChatState({ inputDisabled: disabled }),
   });
 
   const {
@@ -723,7 +729,7 @@ export default function Chat({
           description: 'Failed to create chat channel. Please try again.',
           variant: 'destructive',
         });
-        inputDisabledRef.current = false;
+        updateChatState({ inputDisabled: false });
         return;
       }
     }
@@ -738,11 +744,10 @@ export default function Chat({
     )
       return;
 
-    inputDisabledRef.current = true;
     const tempMessageId = randomUUID() as UUID;
     let messageText = chatState.input.trim();
     const currentInputVal = chatState.input;
-    updateChatState({ input: '' });
+    updateChatState({ input: '', inputDisabled: true });
     const currentSelectedFiles = [...selectedFiles];
     clearFiles();
     formRef.current?.reset();
@@ -796,7 +801,7 @@ export default function Chat({
       const finalTextContent =
         messageText || (finalAttachments.length > 0 ? `Shared content.` : '');
       if (!finalTextContent.trim() && finalAttachments.length === 0) {
-        inputDisabledRef.current = false;
+        updateChatState({ inputDisabled: false });
         removeMessage(tempMessageId);
         return;
       }
@@ -821,7 +826,7 @@ export default function Chat({
         text: `${optimisticUiMessage.text || 'Attachment(s)'} (Failed to send)`,
       });
       // Re-enable input on error
-      inputDisabledRef.current = false;
+      updateChatState({ inputDisabled: false });
     } finally {
       // Let the server control input state via control messages
       // Only focus the input, don't re-enable it
@@ -844,7 +849,7 @@ export default function Chat({
     if (inputDisabledRef.current || (!message.text?.trim() && message.attachments?.length === 0)) {
       return;
     }
-    inputDisabledRef.current = true;
+    updateChatState({ inputDisabled: true });
     const retryMessageId = randomUUID() as UUID;
     const finalTextContent = message.text?.trim() || `Shared ${message.attachments?.length} file(s).`;
   
@@ -886,7 +891,7 @@ export default function Chat({
         isLoading: false,
         text: `${optimisticUiMessage.text || 'Attachment(s)'} (Failed to send)`,
       });
-      inputDisabledRef.current = false;
+      updateChatState({ inputDisabled: false });
     }
     
   };
@@ -1326,7 +1331,7 @@ export default function Chat({
                 <ChatInputArea
                   input={chatState.input}
                   setInput={(value) => updateChatState({ input: value })}
-                  inputDisabled={inputDisabledRef.current}
+                  inputDisabled={chatState.inputDisabled}
                   selectedFiles={selectedFiles}
                   removeFile={removeFile}
                   handleFileChange={handleFileChange}
@@ -1394,7 +1399,7 @@ export default function Chat({
                       <ChatInputArea
                         input={chatState.input}
                         setInput={(value) => updateChatState({ input: value })}
-                        inputDisabled={inputDisabledRef.current}
+                        inputDisabled={chatState.inputDisabled}
                         selectedFiles={selectedFiles}
                         removeFile={removeFile}
                         handleFileChange={handleFileChange}

--- a/packages/server/src/api/messaging/core.ts
+++ b/packages/server/src/api/messaging/core.ts
@@ -92,6 +92,33 @@ export function createMessagingCoreRouter(serverInstance: AgentServer): express.
     }
   });
 
+  // Endpoint to notify that a message is complete (e.g., agent finished responding)
+  (router as any).post('/complete', async (req: express.Request, res: express.Response) => {
+    const { channel_id, server_id } = req.body;
+
+    if (!validateUuid(channel_id) || !validateUuid(server_id)) {
+      return res.status(400).json({
+        success: false,
+        error: 'Missing or invalid fields: channel_id, server_id',
+      });
+    }
+    
+    try {
+      if (serverInstance.socketIO) {
+        serverInstance.socketIO.to(channel_id).emit('messageComplete', {
+          channelId: channel_id,
+          serverId: server_id,
+        });
+      }
+
+      res.status(200).json({ success: true, message: 'Completion event emitted' });
+    } catch (error) {
+      logger.error('[Messages Router /notify-complete] Error notifying message complete:', error);
+      res.status(500).json({ success: false, error: 'Failed to notify message completion' });
+    }
+  });
+  
+
   // Endpoint for INGESTING messages from EXTERNAL platforms (e.g., Discord plugin)
   (router as any).post('/ingest-external', async (req: express.Request, res: express.Response) => {
     const messagePayload = req.body as Partial<MessageService>; // Partial because ID, created_at will be generated

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -569,51 +569,49 @@ export class MessageBusService extends Service {
     originalMessage?: MessageServiceMessage
   ) {
     try {
-      // Check if the agent decided to IGNORE the message
-      if (content.actions && content.actions.includes('IGNORE')) {
-        logger.info(
-          `[${this.runtime.character.name}] MessageBusService: Agent chose to IGNORE message, not sending response to central server`
-        );
-        return;
-      }
-
-      // Also check if there's no text content
-      if (!content.text || content.text.trim() === '') {
-        logger.info(
-          `[${this.runtime.character.name}] MessageBusService: No text content in response, not sending to central server`
-        );
-        return;
-      }
-
       const room = await this.runtime.getRoom(agentRoomId);
       const world = await this.runtime.getWorld(agentWorldId);
-
+  
       const channelId = room?.channelId as UUID;
       const serverId = world?.serverId as UUID;
-
+  
       if (!channelId || !serverId) {
-        logger.error(
-          `[${this.runtime.character.name}] MessageBusService: Cannot map agent room/world to central IDs for response. AgentRoomID: ${agentRoomId}, AgentWorldID: ${agentWorldId}. Room or World object missing, or channelId/serverId not found on them.`
-        );
+        logger.error(`[${this.runtime.character.name}] MessageBusService: Missing channelId or serverId for Room ID ${agentRoomId} or World ID ${agentWorldId}`);
+        await this.notifyMessageComplete(channelId, serverId);
         return;
       }
-
-      let centralInReplyToRootMessageId: UUID | undefined = undefined;
-      if (inReplyToAgentMemoryId) {
-        const originalAgentMemory = await this.runtime.getMemoryById(inReplyToAgentMemoryId);
-        if (originalAgentMemory?.metadata?.sourceId) {
-          centralInReplyToRootMessageId = originalAgentMemory.metadata.sourceId as UUID;
-        }
+  
+      // If agent decides to IGNORE or has no valid text, notify completion and skip sending response
+      const shouldSkip =
+        content.actions?.includes('IGNORE') ||
+        !content.text ||
+        content.text.trim() === '';
+  
+      if (shouldSkip) {
+        logger.info(`[${this.runtime.character.name}] MessageBusService: Skipping response (reason: ${content.actions?.includes('IGNORE') ? 'IGNORE action' : 'No text'})`);
+        await this.notifyMessageComplete(channelId, serverId);
+        return;
       }
-
+  
+      // Resolve reply-to message ID from agent memory metadata
+      let centralInReplyToRootMessageId: UUID | undefined;
+      if (inReplyToAgentMemoryId) {
+        const memory = await this.runtime.getMemoryById(inReplyToAgentMemoryId);
+        centralInReplyToRootMessageId = memory?.metadata?.sourceId as UUID;
+      }
+  
       const payloadToServer = {
         channel_id: channelId,
         server_id: serverId,
-        author_id: this.runtime.agentId, // This needs careful consideration: is it the agent's core ID or a specific central identity for the agent?
+        author_id: this.runtime.agentId,
         content: content.text,
         in_reply_to_message_id: centralInReplyToRootMessageId,
         source_type: 'agent_response',
-        raw_message: { text: content.text, thought: content.thought, actions: content.actions },
+        raw_message: {
+          text: content.text,
+          thought: content.thought,
+          actions: content.actions,
+        },
         metadata: {
           agent_id: this.runtime.agentId,
           agentName: this.runtime.character.name,
@@ -624,36 +622,40 @@ export class MessageBusService extends Service {
             (originalMessage?.metadata?.channelType || room?.type) === ChannelType.DM,
         },
       };
-
-      logger.info(
-        `[${this.runtime.character.name}] MessageBusService: Sending payload to central server API endpoint (/api/messaging/submit):`,
-        payloadToServer
-      );
-
-      // Actual fetch to the central server API
-      const baseUrl = this.getCentralMessageServerUrl();
-      // Use URL constructor for safe URL building
-      const submitUrl = new URL('/api/messaging/submit', baseUrl);
-      const serverApiUrl = submitUrl.toString();
-      const response = await fetch(serverApiUrl, {
+  
+      logger.info(`[${this.runtime.character.name}] MessageBusService: Sending message to central server`, payloadToServer);
+  
+      const submitUrl = new URL('/api/messaging/submit', this.getCentralMessageServerUrl());
+      const response = await fetch(submitUrl.toString(), {
         method: 'POST',
         headers: this.getAuthHeaders(),
         body: JSON.stringify(payloadToServer),
       });
-
+  
       if (!response.ok) {
-        logger.error(
-          `[${this.runtime.character.name}] MessageBusService: Error sending response to central server: ${response.status} ${await response.text()}`
-        );
+        logger.error(`[${this.runtime.character.name}] MessageBusService: Failed to submit message: ${response.status} ${await response.text()}`);
       }
     } catch (error) {
-      logger.error(
-        `[${this.runtime.character.name}] MessageBusService: Error sending agent response to bus:`,
-        error
-      );
+      logger.error(`[${this.runtime.character.name}] MessageBusService: Unexpected error:`, error);
     }
   }
+  
 
+  private async notifyMessageComplete(channelId?: UUID, serverId?: UUID) {
+    if (!channelId || !serverId) return;
+  
+    try {
+      const completeUrl = new URL('/api/messaging/complete', this.getCentralMessageServerUrl());
+      await fetch(completeUrl.toString(), {
+        method: 'POST',
+        headers: this.getAuthHeaders(),
+        body: JSON.stringify({ channel_id: channelId, server_id: serverId }),
+      });
+    } catch (error) {
+      logger.warn(`[${this.runtime.character.name}] MessageBusService: Failed to notify completion`, error);
+    }
+  }
+  
   private getAuthHeaders(): Record<string, string> {
     const headers: Record<string, string> = {
       'Content-Type': 'application/json'

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -632,18 +632,27 @@ export class MessageBusService extends Service {
         payloadToServer
       );
 
-      const submitUrl = new URL('/api/messaging/submit', this.getCentralMessageServerUrl());
-      const response = await fetch(submitUrl.toString(), {
+      // Actual fetch to the central server API
+      const baseUrl = this.getCentralMessageServerUrl();
+      // Use URL constructor for safe URL building
+      const submitUrl = new URL('/api/messaging/submit', baseUrl);
+      const serverApiUrl = submitUrl.toString();
+      const response = await fetch(serverApiUrl, {
         method: 'POST',
         headers: this.getAuthHeaders(),
         body: JSON.stringify(payloadToServer),
       });
   
       if (!response.ok) {
-        logger.error(`[${this.runtime.character.name}] MessageBusService: Failed to submit message: ${response.status} ${await response.text()}`);
+        logger.error(
+          `[${this.runtime.character.name}] MessageBusService: Error sending response to central server: ${response.status} ${await response.text()}`
+        );
       }
     } catch (error) {
-      logger.error(`[${this.runtime.character.name}] MessageBusService: Unexpected error:`, error);
+      logger.error(
+        `[${this.runtime.character.name}] MessageBusService: Error sending agent response to bus:`,
+        error
+      );
     }
   }
   

--- a/packages/server/src/services/message.ts
+++ b/packages/server/src/services/message.ts
@@ -603,7 +603,7 @@ export class MessageBusService extends Service {
       const payloadToServer = {
         channel_id: channelId,
         server_id: serverId,
-        author_id: this.runtime.agentId,
+        author_id: this.runtime.agentId, // This needs careful consideration: is it the agent's core ID or a specific central identity for the agent?
         content: content.text,
         in_reply_to_message_id: centralInReplyToRootMessageId,
         source_type: 'agent_response',


### PR DESCRIPTION
Currently, if an agent chooses to ignore the user (either by selecting the IGNORE action or sending an empty text response), the chat UI gets stuck displaying "agent is thinking". This blocks the user from sending any further messages unless the page is refreshed.

This happens because the chat interface only unlocks when it receives the next agent message. However, in these cases, no message is sent—so the UI remains in a loading state indefinitely.

Changes in this PR:
Added a complete API endpoint that notifies the client when message processing is finished—even if the agent ignored the message or an error occurred.

Ensures the chat UI is unblocked and responsive even when no message is returned by the agent.


