### PR TITLE
fix: prevent infinite recursion in JSON sanitizer by detecting circular re…

### DIFF
--- a/packages/plugin-sql/src/base.ts
+++ b/packages/plugin-sql/src/base.ts
@@ -1518,39 +1518,49 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<any> {
    * @param value - The value to sanitize
    * @returns The sanitized value
    */
-  private sanitizeJsonObject(value: unknown): unknown {
+  private sanitizeJsonObject(
+    value: unknown,
+    seen: WeakSet<object> = new WeakSet(),
+    path: string = 'root'
+  ): unknown {
     if (value === null || value === undefined) {
       return value;
     }
-
+  
     if (typeof value === 'string') {
-      // Handle multiple cases that can cause PostgreSQL/PgLite JSON parsing errors:
-      // 1. Remove null bytes (U+0000) which are not allowed in PostgreSQL text fields
-      // 2. Escape single backslashes that might be interpreted as escape sequences
-      // 3. Fix broken Unicode escape sequences (\u not followed by 4 hex digits)
       return value
-        .replace(/\u0000/g, '') // Remove null bytes
-        .replace(/\\(?!["\\/bfnrtu])/g, '\\\\') // Escape single backslashes not part of valid escape sequences
-        .replace(/\\u(?![0-9a-fA-F]{4})/g, '\\\\u'); // Fix malformed Unicode escape sequences
+        .replace(/\u0000/g, '')
+        .replace(/\\(?!["\\/bfnrtu])/g, '\\\\')
+        .replace(/\\u(?![0-9a-fA-F]{4})/g, '\\\\u');
     }
-
+  
     if (typeof value === 'object') {
+      if (seen.has(value as object)) {
+        return null;
+      } else {
+        seen.add(value as object);
+      }
+  
       if (Array.isArray(value)) {
-        return value.map((item) => this.sanitizeJsonObject(item));
+        return (value as unknown[]).map((item, index) =>
+          this.sanitizeJsonObject(item, seen, `${path}[${index}]`)
+        );
       } else {
         const result: Record<string, unknown> = {};
-        for (const [key, val] of Object.entries(value)) {
-          // Also sanitize object keys
-          const sanitizedKey =
-            typeof key === 'string'
-              ? key.replace(/\u0000/g, '').replace(/\\u(?![0-9a-fA-F]{4})/g, '\\\\u')
-              : key;
-          result[sanitizedKey] = this.sanitizeJsonObject(val);
+        for (const [key, val] of Object.entries(value as object)) {
+          const sanitizedKey = key
+            .replace(/\u0000/g, '')
+            .replace(/\\u(?![0-9a-fA-F]{4})/g, '\\\\u');
+          result[sanitizedKey] = this.sanitizeJsonObject(
+            val,
+            seen,
+            `${path}.${sanitizedKey}`
+          );
         }
         return result;
       }
     }
-
+  
     return value;
   }
 


### PR DESCRIPTION
This PR fixes the issue shown in the following screenshot:

<img width="863" alt="Screenshot 2025-06-17 at 1 07 49 PM" src="https://github.com/user-attachments/assets/eee5a561-11d1-408c-b7c1-fbd75706e0a2" />

We were encountering the error:

```
RangeError: Maximum call stack size exceeded
```

This happened because the sanitizeJsonObject method recursively traverses input objects without checking for circular references. When a cyclic structure is passed, the recursion becomes infinite, eventually exhausting the call stack.