### PR TITLE
fix project loading on windows machines

### DIFF
--- a/packages/cli/src/project.ts
+++ b/packages/cli/src/project.ts
@@ -174,7 +174,11 @@ export async function loadProject(dir: string): Promise<Project> {
       if (fs.existsSync(entryPoint)) {
         try {
           const importPath = path.resolve(entryPoint);
-          projectModule = (await import(importPath)) as ProjectModule;
+          // Convert to file URL for ESM import
+          const importUrl = process.platform === 'win32'
+            ? 'file:///' + importPath.replace(/\\/g, '/')
+            : 'file://' + importPath;
+          projectModule = (await import(importUrl)) as ProjectModule;
           logger.info(`Loaded project from ${entryPoint}`);
 
           // Debug the module structure


### PR DESCRIPTION
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

[bug loading projects on windows](https://github.com/elizaOS/eliza/issues/5155)

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

run new projects template to see if it works on different host systems

# Background

## What does this PR do?

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)


## Why are we doing this? Any context or related work?
development should work on windows

# Documentation changes needed?
no

# Testing

## Where should a reviewer start?

## Detailed testing steps
- setup new project on windows
- setup new project on linux
- running it directly with bun run dev should then work on both host systems - did not work before on windows.

## Database changes
none 

## Discord username
@piffie (also on TG)