### PR TITLE
fix(docs): update ElizaOS documentation link to new official URL

### DIFF
--- a/packages/docs/partners/eliza/index.mdx
+++ b/packages/docs/partners/eliza/index.mdx
@@ -84,7 +84,7 @@ Key differentiators:
 
 - **Website**: https://elizawakesup.ai
 - **GitHub**: https://github.com/elizaOS
-- **Documentation**: https://elizaos.github.io/docs
+- **Documentation**: https://eliza.how/docs/intro
 - **Twitter**: https://x.com/elizawakesup
 - **Plugin Registry**: https://github.com/elizaos-plugins
 - **Discord Community**: https://discord.gg/elizaos


### PR DESCRIPTION
Replaced the outdated ElizaOS documentation link (https://elizaos.github.io/docs) with the current official documentation URL (https://eliza.how/docs/intro) in the Eliza partner page. This ensures users are directed to the latest and most accurate resources.
Reference: https://eliza.how/docs/intro