### PR TITLE
fix: (cli) resolve plugin template dependencies and publish command issues

### DIFF
--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -198,7 +198,15 @@ export const publish = new Command()
       console.info('Updating package.json with actual values...');
 
       const placeholderReplacements: Record<string, PlaceholderReplacement> = {
-        // Name placeholders
+        // Template default name replacement
+        'elizaos-plugin-starter': {
+          check: () => packageJson.name === '@elizaos/plugin-starter',
+          replace: () => {
+            packageJson.name = `@${npmUsername}/${pluginDirName}`;
+            console.info(`Set package name: ${packageJson.name}`);
+          },
+        },
+        // Name placeholders (for custom templates)
         'npm-username': {
           check: () => packageJson.name.includes('npm-username'),
           replace: () => {

--- a/packages/cli/src/commands/publish/index.ts
+++ b/packages/cli/src/commands/publish/index.ts
@@ -244,7 +244,7 @@ export const publish = new Command()
               packageJson.repository = { type: 'git', url: '' };
             }
             if (credentials) {
-              packageJson.repository.url = `github:${credentials.username}/${pluginDirName}`;
+              packageJson.repository.url = `git+https://github.com/${credentials.username}/${pluginDirName}.git`;
               console.info(`Set repository: ${packageJson.repository.url}`);
             }
           },

--- a/packages/cli/src/utils/copy-template.ts
+++ b/packages/cli/src/utils/copy-template.ts
@@ -177,7 +177,7 @@ export async function copyTemplate(
 }
 
 /**
- * Replace hardcoded "plugin-starter" strings in TypeScript files with the actual plugin name
+ * Replace hardcoded "plugin-starter" strings in source files with the actual plugin name
  */
 async function replacePluginNameInFiles(targetDir: string, pluginName: string): Promise<void> {
   const filesToProcess = [
@@ -185,7 +185,7 @@ async function replacePluginNameInFiles(targetDir: string, pluginName: string): 
     '__tests__/plugin.test.ts',
     'e2e/starter-plugin.test.ts',
     'README.md',
-    // Note: package.json excluded to maintain npm package structure
+    // package.json name is handled by the publish command
   ];
 
   // Process files in parallel
@@ -201,7 +201,7 @@ async function replacePluginNameInFiles(targetDir: string, pluginName: string): 
       ) {
         let content = await fs.readFile(fullPath, 'utf8');
 
-        // Replace the hardcoded plugin name
+        // Replace the hardcoded plugin name in source files
         content = content.replace(/plugin-starter/g, pluginName);
 
         await fs.writeFile(fullPath, content, 'utf8');

--- a/packages/plugin-starter/package.json
+++ b/packages/plugin-starter/package.json
@@ -41,12 +41,9 @@
   ],
   "dependencies": {
     "@elizaos/core": "^1.0.0",
-    "@tailwindcss/vite": "^4.1.10",
     "@tanstack/react-query": "^5.80.7",
-    "@vitejs/plugin-react-swc": "^3.10.2",
     "clsx": "^2.1.1",
     "tailwindcss": "^4.1.10",
-    "tailwindcss-animate": "^1.0.7",
     "tailwind-merge": "^3.3.1",
     "vite": "^6.3.5",
     "zod": "3.24.2"
@@ -55,10 +52,13 @@
   "devDependencies": {
     "@cypress/react": "^9.0.1",
     "@elizaos/cli": "^1.0.0",
+    "@tailwindcss/vite": "^4.1.10",
     "@testing-library/cypress": "^10.0.3",
+    "@vitejs/plugin-react-swc": "^3.10.2",
     "cypress": "^14.4.1",
     "dotenv": "16.4.5",
     "prettier": "3.5.3",
+    "tailwindcss-animate": "^1.0.7",
     "tsup": "8.5.0",
     "typescript": "5.8.2",
     "vitest": "3.1.4"

--- a/packages/plugin-starter/package.json
+++ b/packages/plugin-starter/package.json
@@ -41,7 +41,13 @@
   ],
   "dependencies": {
     "@elizaos/core": "^1.0.0",
+    "@tailwindcss/vite": "^4.1.10",
+    "@tanstack/react-query": "^5.80.7",
+    "@vitejs/plugin-react-swc": "^3.10.2",
+    "clsx": "^2.1.1",
     "tailwindcss": "^4.1.10",
+    "tailwindcss-animate": "^1.0.7",
+    "tailwind-merge": "^3.3.1",
     "vite": "^6.3.5",
     "zod": "3.24.2"
   },


### PR DESCRIPTION
# Fix Plugin Template Dependencies and Publish Command Issues

## Problem

Users were encountering build failures when creating and publishing ElizaOS plugins using `elizaos create --type plugin` and `elizaos publish`. The errors manifested in two main areas:

### 1. Missing Frontend Dependencies

When attempting to build or publish plugins, users were getting errors like:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@tailwindcss/vite' imported from vite.config.ts
Cannot find module 'clsx' or its corresponding type declarations
Cannot find module '@tanstack/react-query' or its corresponding type declarations
```

### 2. Package Name Namespace Issues

The publish command was failing with permission errors:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@elizaos%2fplugin-starter
npm error 404 '@elizaos/plugin-starter@0.1.0' is not in this registry
```

This occurred because the template package.json maintained the default `@elizaos/plugin-starter` name, but users don't have permission to publish to the `@elizaos` namespace.

## Solution

### 1. Added Missing Dependencies to Plugin Template

The plugin template (`packages/plugin-starter`) was referencing frontend dependencies in its code but missing them from `package.json`:

- **`@tailwindcss/vite`** - Referenced in `vite.config.ts`
- **`@tanstack/react-query`** - Used in `src/frontend/index.tsx` and test files
- **`@vitejs/plugin-react-swc`** - Referenced in `vite.config.ts`
- **`clsx` & `tailwind-merge`** - Used in `src/frontend/utils.ts`
- **`tailwindcss-animate`** - Referenced in `tailwind.config.js`

### 2. Enhanced Publish Command Template Detection

Added logic to the publish command to automatically detect and replace the default template package name:

- Detects when `package.json` name is still `@elizaos/plugin-starter`
- Automatically replaces with `@{npmUsername}/{pluginDirName}`
- Provides clear feedback: `Set package name: @username/plugin-name`

### 3. Fixed Repository URL Format

Updated the repository URL format to use the standard git format that npm expects, eliminating normalization warnings.

## Changes Made

### `packages/plugin-starter/package.json`

- Added missing frontend dependencies that were referenced in template code
- Ensures both monorepo builds and user plugin creation work correctly

### `packages/cli/src/commands/publish/index.ts`

- Added `elizaos-plugin-starter` placeholder replacement logic
- Enhanced repository URL format to use proper git URL structure
- Improved user feedback during package name replacement

### `packages/cli/src/utils/copy-template.ts`

- Simplified replacement logic to focus on source files only
- Removed complex package.json handling (now handled by publish command)
- Updated comments to reflect cleaner separation of concerns

## Impact

✅ **Plugin Creation**: `elizaos create --type plugin` now produces templates that build successfully out of the box

✅ **Monorepo Builds**: `bun run build` from root no longer fails on plugin-starter package

✅ **Plugin Publishing**: `elizaos publish` correctly handles template names and publishes to user namespaces

✅ **Developer Experience**: Clear error messages and automatic package name resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved placeholder replacements for package name and repository URL when publishing plugins, providing more accurate and standardized values.

- **Documentation**
  - Clarified comments in template utility functions to better describe file processing behavior.

- **Chores**
  - Added new dependencies to the plugin starter package, including support for Tailwind CSS, React Query, and related utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->