### PR TITLE
fix: scroll behavior on env panel

### DIFF
--- a/packages/client/src/components/secret-panel.tsx
+++ b/packages/client/src/components/secret-panel.tsx
@@ -302,7 +302,7 @@ export function SecretPanel({ characterValue, onChange }: SecretPanelProps) {
         </div>
       )}
 
-      <div className="mt-2">
+      <div className="mt-2 overflow-y-auto max-h-72">
         {envs.map((env, index) => (
           <div
             key={index}


### PR DESCRIPTION
Currently, when importing a long list of environment variables into the secret panel, the user has to scroll all the way down to access the "Save" button.
This PR sets a maximum height and enables vertical scrolling to improve.


before: 

https://github.com/user-attachments/assets/edf205e7-4d8f-4399-8bd2-4acf0707a25c


after:


https://github.com/user-attachments/assets/3b7e8ac9-dec2-4bce-a2ab-7b79a7376540


