### PR TITLE
fix: add __dirname for ES modules in copy-template utility

### DIFF
--- a/packages/cli/src/utils/copy-template.ts
+++ b/packages/cli/src/utils/copy-template.ts
@@ -1,7 +1,12 @@
 import { existsSync } from 'node:fs';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { logger } from '@elizaos/core';
+
+// Define __dirname for ES modules
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 /**
  * Copy a directory recursively


### PR DESCRIPTION
This PR fixes an issue where the `elizaos create` command was not properly copying templates due to missing `__dirname` in ES module context.

## Changes
- Added `fileURLToPath` import from `node:url`
- Defined `__filename` and `__dirname` for ES module compatibility in `copy-template.ts`

## Issue
The `elizaos create` command was failing to copy templates because `__dirname` is not available in ES modules by default.

## Solution
This fix properly defines `__dirname` using the ES module-compatible approach with `import.meta.url`.