### PR TITLE
fix(secret-panel): allow editing and adding new secrets

### DIFF
--- a/packages/client/src/components/secret-panel.tsx
+++ b/packages/client/src/components/secret-panel.tsx
@@ -289,7 +289,13 @@ export function SecretPanel({ characterValue, onChange }: SecretPanelProps) {
             </div>
           </div>
         </div>
-        <Button className="shrink-0" onClick={addEnv}>
+        <Button 
+          className="shrink-0"
+          onClick={(e) => {
+            e.preventDefault();
+            addEnv();
+          }}
+        >
           Add
         </Button>
       </div>
@@ -332,7 +338,10 @@ export function SecretPanel({ characterValue, onChange }: SecretPanelProps) {
               <Button
                 variant="ghost"
                 className="p-2 text-gray-500"
-                onClick={() => setOpenIndex(openIndex === index ? null : index)}
+                onClick={(e) => {
+                  e.preventDefault();
+                  setOpenIndex(openIndex === index ? null : index);
+                }}
               >
                 <MoreVertical className="w-5 h-5" />
               </Button>


### PR DESCRIPTION
related: https://linear.app/eliza-labs/issue/ELIZA-452/unable-to-edit-agent-environment-variables-in-v109

Previously, adding or editing a secret would redirect to the main homepage without saving because it triggered the parent "Save Agent" button. This PR fixes the issue by adding preventDefault to prevent it

issue:


https://github.com/user-attachments/assets/2271d922-113d-49d6-b5eb-6ae403281f4f










