### PR TITLE
fix: add bootstrap plugin to agent templates

### DIFF
--- a/packages/client/src/config/agent-templates.ts
+++ b/packages/client/src/config/agent-templates.ts
@@ -48,7 +48,7 @@ export const agentTemplates: AgentTemplate[] = [
       ],
       topics: ['Discord server', 'Community assistance', 'Command handling', 'Server information'],
       adjectives: ['Helpful', 'Responsive', 'Friendly', 'Informative', 'Reliable'],
-      plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai', '@elizaos/plugin-discord'],
+      plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai', '@elizaos/plugin-bootstrap', '@elizaos/plugin-discord'],
       style: {
         all: [
           'Be friendly and helpful',
@@ -95,7 +95,7 @@ export const agentTemplates: AgentTemplate[] = [
         'FAQ responses',
       ],
       adjectives: ['Helpful', 'Responsive', 'Friendly', 'Informative', 'Reliable'],
-      plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai', '@elizaos/plugin-telegram'],
+      plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai', '@elizaos/plugin-bootstrap', '@elizaos/plugin-telegram'],
       style: {
         all: [
           'Be concise and clear',
@@ -146,7 +146,7 @@ export const agentTemplates: AgentTemplate[] = [
         'Task management',
       ],
       adjectives: ['Responsive', 'Helpful', 'Organized', 'Team-oriented', 'Professional'],
-      plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai', '@elizaos/plugin-slack'],
+      plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai', '@elizaos/plugin-bootstrap', '@elizaos/plugin-slack'],
       style: {
         all: [
           'Be concise and clear',
@@ -198,7 +198,7 @@ export const agentTemplates: AgentTemplate[] = [
         'Brand voice',
       ],
       adjectives: ['Engaging', 'Concise', 'Strategic', 'Conversational', 'Creative'],
-      plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai', '@elizaos/plugin-twitter'],
+      plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai', '@elizaos/plugin-bootstrap', '@elizaos/plugin-twitter'],
       style: {
         all: [
           'Be concise and impactful',
@@ -253,7 +253,7 @@ export const agentTemplates: AgentTemplate[] = [
         'Development workflows',
       ],
       adjectives: ['Technical', 'Precise', 'Helpful', 'Organized', 'Knowledgeable'],
-      plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai', '@elizaos/plugin-github'],
+      plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai', '@elizaos/plugin-bootstrap', '@elizaos/plugin-github'],
       style: {
         all: [
           'Use technically precise language',
@@ -304,7 +304,7 @@ export const agentTemplates: AgentTemplate[] = [
         'Visual aesthetics',
       ],
       adjectives: ['Creative', 'Visual', 'Engaging', 'Trend-aware', 'Authentic'],
-      plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai', '@elizaos/plugin-instagram'],
+      plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-openai', '@elizaos/plugin-bootstrap', '@elizaos/plugin-instagram'],
       style: {
         all: [
           'Balance visual description with compelling text',


### PR DESCRIPTION
## Summary
- Added `@elizaos/plugin-bootstrap` to all agent templates in the client configuration
- Ensures core functionality is available across all platform-specific templates (Discord, Telegram, Slack, Twitter, GitHub, Instagram)

## Changes
- Updated 6 agent templates to include the bootstrap plugin alongside existing plugins
- No other functional changes made

## Test plan
- [ ] Verify agent templates load correctly with the bootstrap plugin
- [ ] Confirm no conflicts with existing plugins
- [ ] Test that core functionality from bootstrap plugin is available in each template