### PR TITLE
fix: agent card responsive issue

### DIFF
--- a/packages/client/src/components/agent-card.tsx
+++ b/packages/client/src/components/agent-card.tsx
@@ -106,8 +106,8 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, onChat }) => {
           <AvatarImage src={avatarUrl} alt={agentName} />
           {/* Fallback can be initials or generic icon */}
         </Avatar>
-        <div className="flex-1">
-          <CardTitle className="text-lg truncate" title={agentName}>
+        <div className="overflow-hidden">
+          <CardTitle className="text-lg truncate overflow-hidden whitespace-nowrap text-ellipsis" title={agentName}>
             {agentName}
           </CardTitle>
           <div className="flex items-center gap-1.5 mt-1">


### PR DESCRIPTION
Right now, the AgentCard is not fully responsive — if the agent name is too long, it causes the other elements (like settings and stop icons) to get squeezed or overflow outside the card.

This update allow the name to shorten gracefully while preserving the space for other UI elements.

before:

<img width="1102" alt="Screenshot 2025-06-20 at 4 41 16 PM" src="https://github.com/user-attachments/assets/31cc01f1-69c6-4885-acf6-df894406c485" />


after:


https://github.com/user-attachments/assets/77b994cc-b07d-4cb9-9ac0-a6f83f07891e

