### PR TITLE
fix: incorrecly scoped plugin name

### DIFF
--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -387,16 +387,13 @@ export function normalizePluginName(pluginName: string): string[] {
   // Remove any existing prefixes
   baseName = baseName.replace(/^plugin-/, '');
 
-  // Generate all possible formats to try
+  // Generate all possible formats to try (removed duplicates and incorrect namespace)
   return [
     pluginName, // Original input
     baseName, // Just the base name
     `plugin-${baseName}`, // With plugin- prefix
     `@elizaos/${baseName}`, // Scoped with elizaos
     `@elizaos/plugin-${baseName}`, // Scoped with elizaos and plugin prefix
-    `@elizaos/${baseName}`, // Scoped with elizaos-plugins
-    `@elizaos/plugin-${baseName}`, // Scoped with elizaos-plugins and plugin prefix
-    `@elizaos-plugins/plugin-${baseName}`, // Scoped with elizaos-plugins and plugin prefix
   ];
 }
 

--- a/packages/cli/tests/commands/plugins.test.ts
+++ b/packages/cli/tests/commands/plugins.test.ts
@@ -95,14 +95,14 @@ describe('ElizaOS Plugin Commands', () => {
     'plugins add installs a plugin',
     async () => {
       try {
-        execSync(`${elizaosCmd} plugins add @elizaos/plugin-telegram --skip-env-prompt`, {
+        execSync(`${elizaosCmd} plugins add @elizaos/plugin-google-genai --skip-env-prompt`, {
           stdio: 'pipe',
           timeout: TEST_TIMEOUTS.PLUGIN_INSTALLATION,
           cwd: projectDir,
         });
 
         const packageJson = await readFile(join(projectDir, 'package.json'), 'utf8');
-        expect(packageJson).toContain('@elizaos/plugin-telegram');
+        expect(packageJson).toContain('@elizaos/plugin-google-genai');
       } catch (error: any) {
         console.error('[ERROR] Plugin installation failed:', error.message);
         console.error('[ERROR] stdout:', error.stdout?.toString() || 'none');


### PR DESCRIPTION
This pull request refines the `normalizePluginName` function in `packages/cli/src/utils/registry/index.ts` by removing duplicate and incorrect namespace formats from the list of generated plugin name variations.

Key change:

* [`normalizePluginName`](diffhunk://#diff-ab81a7f856a44c5b61c0792337ded8ecfcf3960da121c0fcfd7fdb913a0625e1L390-L399): Removed redundant entries (`@elizaos/${baseName}`, `@elizaos/plugin-${baseName}`, `@elizaos-plugins/plugin-${baseName}`) from the list of possible plugin name formats, ensuring no duplicates or incorrect namespaces are included.