### PR TITLE
chore: remove CLI tests from integration tests

### DIFF
--- a/.github/workflows/integrationTests.yaml
+++ b/.github/workflows/integrationTests.yaml
@@ -128,62 +128,11 @@ jobs:
           # Set test timeout for CI (60 seconds per test)
           export BUN_TEST_TIMEOUT=60000
 
-          # TEMPORARY: Skip hanging CLI tests, run only core and other stable packages
-          echo "Starting integration tests (excluding CLI tests that hang)..."
+          # CLI tests are handled by the dedicated cli-tests.yml workflow
+          echo "Starting integration tests (excluding CLI tests)..."
           bun test --timeout 60000 --concurrency 3 --filter='!@elizaos/cli' || {
             echo "Tests failed with exit code $?"
             echo "Checking for any hanging processes..."
             ps aux | grep -E "(bun|node)" || true
-            exit 1
-          }
-
-  # CLI tests job - separate due to hanging process issues
-  cli-tests:
-    # Skip duplicate runs: run on push to main/develop, or on pull_request events only
-    if: github.event_name == 'pull_request_target' || (github.event_name == 'push' && contains(fromJson('["main", "develop"]'), github.ref_name))
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '23'
-
-      - name: Install Bun
-        uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        env:
-          SHARP_IGNORE_GLOBAL_LIBVIPS: '1'
-        run: bun install
-
-      - name: Build packages
-        run: bun run build
-
-      - name: Run CLI tests
-        timeout-minutes: 25
-        env:
-          # Set CI-specific environment variables
-          CI: true
-          NODE_ENV: test
-          PGLITE_WASM_MODE: node
-          # Prevent interactive prompts
-          ELIZA_NONINTERACTIVE: true
-          # Set memory limits for CI
-          NODE_OPTIONS: '--max-old-space-size=2048'
-        run: |
-          # Set longer timeout for CLI tests (120 seconds per test)
-          export BUN_TEST_TIMEOUT=120000
-
-          echo "Starting CLI tests with extended timeout (120s per test)..."
-          cd packages/cli && bun test --timeout 120000 || {
-            echo "CLI tests failed with exit code $?"
-            echo "Checking for any hanging processes..."
-            ps aux | grep -E "(bun|node|elizaos)" || true
-            # Kill any remaining processes
-            pkill -f "elizaos\|bun.*test" || true
             exit 1
           }


### PR DESCRIPTION
CLI tests were running duplicate in both integration and cli workflows, not needed.