### PR TITLE
fix: Fix macOS CLI test failures by centralizing platform options

### DIFF
--- a/packages/cli/tests/commands/agent.test.ts
+++ b/packages/cli/tests/commands/agent.test.ts
@@ -4,7 +4,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { killProcessOnPort, waitForServerReady, getBunExecutable } from './test-utils';
+import { killProcessOnPort, waitForServerReady, getBunExecutable, getPlatformOptions } from './test-utils';
 import { TEST_TIMEOUTS } from '../test-timeouts';
 
 describe('ElizaOS Agent Commands', () => {
@@ -22,7 +22,7 @@ describe('ElizaOS Agent Commands', () => {
 
     // Setup CLI command with robust bun path detection
     const scriptDir = join(__dirname, '..');
-    const detectedBunPath = getBunPath();
+    const detectedBunPath = getBunExecutable();
     elizaosCmd = `${detectedBunPath} ${join(scriptDir, '../dist/index.js')}`;
     console.log(`[DEBUG] Using bun path: ${detectedBunPath}`);
     console.log(`[DEBUG] ElizaOS command: ${elizaosCmd}`);
@@ -217,12 +217,14 @@ describe('ElizaOS Agent Commands', () => {
       console.log(`[DEBUG] Loading character: ${character}`);
 
       try {
+        const platformOptions = getPlatformOptions({
+          stdio: 'pipe',
+          timeout: 30000, // 30 second timeout for loading each character
+        });
+        
         execSync(
           `${elizaosCmd} agent start --remote-url ${testServerUrl} --path ${characterPath}`,
-          {
-            stdio: 'pipe',
-            timeout: 30000, // 30 second timeout for loading each character
-          }
+          platformOptions
         );
         console.log(`[DEBUG] Successfully loaded character: ${character}`);
 

--- a/packages/cli/tests/commands/start.test.ts
+++ b/packages/cli/tests/commands/start.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { TEST_TIMEOUTS } from '../test-timeouts';
 import {
+  getPlatformOptions,
   killProcessOnPort,
   safeChangeDirectory,
   TestProcessManager,
@@ -126,12 +127,14 @@ describe('ElizaOS Start Commands', () => {
 
         for (let i = 0; i < maxRetries; i++) {
           try {
+            const platformOptions = getPlatformOptions({
+              encoding: 'utf8',
+              timeout: TEST_TIMEOUTS.STANDARD_COMMAND,
+            });
+            
             result = execSync(
               `${elizaosCmd} agent list --remote-url http://localhost:${testServerPort}`,
-              {
-                encoding: 'utf8',
-                timeout: TEST_TIMEOUTS.STANDARD_COMMAND,
-              }
+              platformOptions
             );
 
             // If we get a result, check if it contains Ada

--- a/packages/cli/tests/commands/test-utils.ts
+++ b/packages/cli/tests/commands/test-utils.ts
@@ -68,30 +68,10 @@ export function safeChangeDirectory(targetDir: string): void {
  * Helper to create a basic ElizaOS project for testing
  */
 export async function createTestProject(elizaosCmd: string, projectName: string): Promise<void> {
-  const timeout = TEST_TIMEOUTS.PROJECT_CREATION;
-
-  // Platform-specific options
-  const platformOptions: any = {
+  const platformOptions = getPlatformOptions({
     stdio: 'pipe',
-  };
-
-  if (process.platform === 'win32') {
-    platformOptions.timeout = timeout * 1.5;
-    platformOptions.killSignal = 'SIGKILL' as NodeJS.Signals;
-    platformOptions.windowsHide = true;
-  } else if (process.platform === 'darwin') {
-    // macOS specific options for project creation
-    platformOptions.timeout = timeout * 1.25;
-    platformOptions.killSignal = 'SIGTERM' as NodeJS.Signals;
-    platformOptions.env = {
-      ...process.env,
-      PATH: `/usr/local/bin:/opt/homebrew/bin:${process.env.PATH}`,
-      LANG: 'en_US.UTF-8',
-      LC_ALL: 'en_US.UTF-8',
-    };
-  } else {
-    platformOptions.timeout = timeout;
-  }
+    timeout: TEST_TIMEOUTS.PROJECT_CREATION,
+  });
 
   try {
     execSync(`${elizaosCmd} create ${projectName} --yes`, platformOptions);
@@ -116,36 +96,14 @@ export function runCliCommand(
   args: string,
   options: { timeout?: number } = {}
 ): string {
-  const timeout = options.timeout || TEST_TIMEOUTS.STANDARD_COMMAND;
-
-  // Platform-specific options
-  const platformOptions: any = {};
-
-  if (process.platform === 'win32') {
-    platformOptions.timeout = timeout * 1.5; // 50% longer timeout for Windows
-    platformOptions.killSignal = 'SIGKILL' as NodeJS.Signals;
-    platformOptions.windowsHide = true;
-  } else if (process.platform === 'darwin') {
-    // macOS specific options
-    platformOptions.timeout = timeout * 1.25; // 25% longer timeout for macOS
-    platformOptions.killSignal = 'SIGTERM' as NodeJS.Signals;
-    // Add environment variables for better macOS compatibility
-    platformOptions.env = {
-      ...process.env,
-      PATH: `/usr/local/bin:/opt/homebrew/bin:${process.env.PATH}`,
-      LANG: 'en_US.UTF-8',
-      LC_ALL: 'en_US.UTF-8',
-    };
-  } else {
-    platformOptions.timeout = timeout;
-  }
+  const platformOptions = getPlatformOptions({
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'], // Explicit stdio handling
+    timeout: options.timeout || TEST_TIMEOUTS.STANDARD_COMMAND,
+  });
 
   try {
-    return execSync(`${elizaosCmd} ${args}`, {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'pipe'], // Explicit stdio handling
-      ...platformOptions,
-    });
+    return execSync(`${elizaosCmd} ${args}`, platformOptions);
   } catch (error: any) {
     // Enhanced error reporting for debugging
     const errorDetails = {
@@ -171,35 +129,14 @@ export function runCliCommandSilently(
   args: string,
   options: { timeout?: number } = {}
 ): string {
-  const timeout = options.timeout || TEST_TIMEOUTS.STANDARD_COMMAND;
-
-  // Platform-specific options
-  const platformOptions: any = {};
-
-  if (process.platform === 'win32') {
-    platformOptions.timeout = timeout * 1.5;
-    platformOptions.killSignal = 'SIGKILL' as NodeJS.Signals;
-    platformOptions.windowsHide = true;
-  } else if (process.platform === 'darwin') {
-    // macOS specific options
-    platformOptions.timeout = timeout * 1.25; // 25% longer timeout for macOS
-    platformOptions.killSignal = 'SIGTERM' as NodeJS.Signals;
-    platformOptions.env = {
-      ...process.env,
-      PATH: `/usr/local/bin:/opt/homebrew/bin:${process.env.PATH}`,
-      LANG: 'en_US.UTF-8',
-      LC_ALL: 'en_US.UTF-8',
-    };
-  } else {
-    platformOptions.timeout = timeout;
-  }
+  const platformOptions = getPlatformOptions({
+    encoding: 'utf8',
+    stdio: 'pipe',
+    timeout: options.timeout || TEST_TIMEOUTS.STANDARD_COMMAND,
+  });
 
   try {
-    return execSync(`${elizaosCmd} ${args}`, {
-      encoding: 'utf8',
-      stdio: 'pipe',
-      ...platformOptions,
-    });
+    return execSync(`${elizaosCmd} ${args}`, platformOptions);
   } catch (error: any) {
     // Enhanced error reporting for debugging silent commands
     console.error(`[Silent CLI Command Error] ${elizaosCmd} ${args}:`, {
@@ -220,35 +157,14 @@ export function expectCliCommandToFail(
   args: string,
   options: { timeout?: number } = {}
 ): { status: number; output: string } {
-  const timeout = options.timeout || TEST_TIMEOUTS.STANDARD_COMMAND;
-
-  // Platform-specific options
-  const platformOptions: any = {};
-
-  if (process.platform === 'win32') {
-    platformOptions.timeout = timeout * 1.5;
-    platformOptions.killSignal = 'SIGKILL' as NodeJS.Signals;
-    platformOptions.windowsHide = true;
-  } else if (process.platform === 'darwin') {
-    // macOS specific options
-    platformOptions.timeout = timeout * 1.25;
-    platformOptions.killSignal = 'SIGTERM' as NodeJS.Signals;
-    platformOptions.env = {
-      ...process.env,
-      PATH: `/usr/local/bin:/opt/homebrew/bin:${process.env.PATH}`,
-      LANG: 'en_US.UTF-8',
-      LC_ALL: 'en_US.UTF-8',
-    };
-  } else {
-    platformOptions.timeout = timeout;
-  }
+  const platformOptions = getPlatformOptions({
+    encoding: 'utf8',
+    stdio: 'pipe',
+    timeout: options.timeout || TEST_TIMEOUTS.STANDARD_COMMAND,
+  });
 
   try {
-    const result = execSync(`${elizaosCmd} ${args}`, {
-      encoding: 'utf8',
-      stdio: 'pipe',
-      ...platformOptions,
-    });
+    const result = execSync(`${elizaosCmd} ${args}`, platformOptions);
     throw new Error(`Command should have failed but succeeded with output: ${result}`);
   } catch (e: any) {
     return {
@@ -611,6 +527,31 @@ export const crossPlatform = {
 
   killProcessOnPort: killProcessOnPort,
 };
+
+/**
+ * Get platform-specific options for execSync calls
+ */
+export function getPlatformOptions(baseOptions: any = {}): any {
+  const platformOptions = { ...baseOptions };
+  
+  if (process.platform === 'win32') {
+    platformOptions.timeout = (platformOptions.timeout || 30000) * 1.5;
+    platformOptions.killSignal = 'SIGKILL' as NodeJS.Signals;
+    platformOptions.windowsHide = true;
+  } else if (process.platform === 'darwin') {
+    // macOS specific options
+    platformOptions.timeout = (platformOptions.timeout || 30000) * 1.25;
+    platformOptions.killSignal = 'SIGTERM' as NodeJS.Signals;
+    platformOptions.env = {
+      ...process.env,
+      PATH: `/usr/local/bin:/opt/homebrew/bin:${process.env.PATH}`,
+      LANG: 'en_US.UTF-8',
+      LC_ALL: 'en_US.UTF-8',
+    };
+  }
+  
+  return platformOptions;
+}
 
 /**
  * Cross-platform test process manager


### PR DESCRIPTION
## Summary
- Fixed undefined function call `getBunPath()` → `getBunExecutable()` in agent.test.ts
- Centralized platform-specific options for execSync calls to fix macOS CI failures
- Added proper PATH resolution and locale settings for macOS environments

## Problem
The macOS CI tests were failing with:
1. `getBunPath is not a function` error in agent.test.ts
2. `No agents found` error in start.test.ts due to missing platform-specific environment settings

## Solution
- Created a centralized `getPlatformOptions()` function in test-utils.ts that handles platform-specific configurations
- Updated all test files to use this centralized function instead of duplicating platform logic
- Ensured proper environment variables (PATH, LANG, LC_ALL) are set for macOS

## Test plan
- [x] Run `bun test tests/commands/agent.test.ts` locally - all tests pass
- [x] Run `bun test tests/commands/start.test.ts` locally - all tests pass
- [ ] Verify macOS CI tests pass after merge

This PR should resolve the macOS-specific test failures in the CLI test suite.