### PR TITLE
fix: update attachment formatting to use comma-separated list

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -273,7 +273,10 @@ export const formatMessages = ({
                 if (media.description) lines.push(`Description: ${media.description}`);
                 return lines.join('\n');
               })
-              .join(', ')})`
+              .join(
+                // Use comma separator only if all attachments are single-line (no text/description)
+                attachments.every((media) => !media.text && !media.description) ? ', ' : '\n'
+              )})`
           : null;
 
       const messageTime = new Date(message.createdAt);

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -273,9 +273,8 @@ export const formatMessages = ({
                 if (media.description) lines.push(`Description: ${media.description}`);
                 return lines.join('\n');
               })
-              .join('\n')})`
+              .join(', ')})`
           : null;
-
 
       const messageTime = new Date(message.createdAt);
       const hours = messageTime.getHours().toString().padStart(2, '0');


### PR DESCRIPTION
## Summary
This PR fixes a failing test in the core package by implementing intelligent attachment formatting in the `formatMessages` utility function that handles both simple and complex attachments correctly.

## Problem
The test `Utils Comprehensive Tests > formatMessages > should handle attachments` was failing because it expected simple attachments to be formatted as a comma-separated list:
```
(Attachments: [att-1 - Image (http://example.com/img.jpg)], [att-2 - Document (http://example.com/doc.pdf)])
```

But the implementation was using newline separation for all attachments:
```
(Attachments: [att-1 - Image (http://example.com/img.jpg)]
[att-2 - Document (http://example.com/doc.pdf)])
```

## Root Cause Analysis
The issue was more complex than initially apparent. Attachments can have additional `text` and `description` fields that span multiple lines. A naive comma-separated approach would create malformed output like:
```
(Attachments: [att-1 - Image (http://example.com/img.jpg)]
Text: some description, [att-2 - Document (http://example.com/doc.pdf)])
```

## Solution
Implemented intelligent formatting logic that:
1. **Detects attachment complexity**: Checks if any attachment has `text` or `description` fields
2. **Simple attachments**: Uses comma separator (`, `) when all attachments are single-line
3. **Complex attachments**: Uses newline separator (`\n`) when any attachment spans multiple lines
4. **Preserves formatting**: Maintains proper multi-line structure for complex attachments

```javascript
.join(
  // Use comma separator only if all attachments are single-line (no text/description)
  attachments.every((media) => !media.text && !media.description) ? ', ' : '\n'
)
```

## Testing
- ✅ The previously failing test now passes (simple attachments → comma separated)
- ✅ All other core message tests continue to pass
- ✅ V2 spec message tests continue to pass
- ✅ Backward compatibility maintained for complex attachments

## Related Issue
Fixes the failing test from GitHub Actions run: https://github.com/elizaOS/eliza/actions/runs/15857976044/job/44707925030

## Benefits
- **Fixes test failure**: Resolves the failing CI test
- **Maintains compatibility**: Doesn't break existing functionality
- **Future-proof**: Handles both current and future attachment types correctly
- **Clean output**: Produces properly formatted attachment lists in both scenarios