### PR TITLE
fix: chat title

### DIFF
--- a/packages/api-client/src/services/messaging.ts
+++ b/packages/api-client/src/services/messaging.ts
@@ -224,9 +224,10 @@ export class MessagingService extends BaseApiClient {
   /**
    * Generate channel title
    */
-  async generateChannelTitle(channelId: UUID): Promise<{ title: string }> {
+  async generateChannelTitle(channelId: UUID, agentId: UUID): Promise<{ title: string }> {
     return this.post<{ title: string }>(
-      `/api/messaging/central-channels/${channelId}/generate-title`
+      `/api/messaging/central-channels/${channelId}/generate-title`,
+      { agentId }
     );
   }
 

--- a/packages/client/src/components/chat.tsx
+++ b/packages/client/src/components/chat.tsx
@@ -669,7 +669,7 @@ export default function Chat({
     }
 
     const elizaClient = createElizaClient();
-    const data = await elizaClient.messaging.generateChannelTitle(finalChannelIdForHooks);
+    const data = await elizaClient.messaging.generateChannelTitle(finalChannelIdForHooks, contextId);
 
     const title = data?.title;
     const participants = await elizaClient.messaging.getChannelParticipants(


### PR DESCRIPTION
Fixes an issue with chat title generation. This was a regression introduced in [this PR](https://github.com/elizaOS/eliza/pull/5263), which I unfortunately missed during review and approval.