### PR TITLE
fix: improve AI provider tests to avoid brittle patterns

### DIFF
--- a/packages/cli/tests/commands/create.test.ts
+++ b/packages/cli/tests/commands/create.test.ts
@@ -269,7 +269,7 @@ describe('ElizaOS Create Commands', () => {
   }, 60000);
 
   describe('AI Model Selection', () => {
-    it('returns a reasonable number of AI models', () => {
+    it('returns a reasonable number of AI model options', () => {
       const models = getAvailableAIModels();
 
       // Test for minimum providers instead of exact count

--- a/packages/cli/tests/commands/create.test.ts
+++ b/packages/cli/tests/commands/create.test.ts
@@ -269,16 +269,12 @@ describe('ElizaOS Create Commands', () => {
   }, 60000);
 
   describe('AI Model Selection', () => {
-    it('getAvailableAIModels includes ollama option', () => {
+    it('returns a reasonable number of AI models', () => {
       const models = getAvailableAIModels();
 
       // Test for minimum providers instead of exact count
       expect(models.length).toBeGreaterThanOrEqual(3);
       expect(models.length).toBeLessThanOrEqual(7); // reasonable upper limit
-      expect(models.map((m) => m.value)).toContain('ollama');
-
-      const ollamaModel = models.find((m) => m.value === 'ollama');
-      expect(ollamaModel).toBeDefined();
     });
 
     it('maintains core AI model options', () => {

--- a/packages/cli/tests/commands/create.test.ts
+++ b/packages/cli/tests/commands/create.test.ts
@@ -272,21 +272,48 @@ describe('ElizaOS Create Commands', () => {
     it('getAvailableAIModels includes ollama option', () => {
       const models = getAvailableAIModels();
 
-      expect(models).toHaveLength(5);
+      // Test for minimum providers instead of exact count
+      expect(models.length).toBeGreaterThanOrEqual(3);
+      expect(models.length).toBeLessThanOrEqual(7); // reasonable upper limit
       expect(models.map((m) => m.value)).toContain('ollama');
 
       const ollamaModel = models.find((m) => m.value === 'ollama');
       expect(ollamaModel).toBeDefined();
     });
 
-    it('maintains existing AI model options', () => {
+    it('maintains core AI model options', () => {
       const models = getAvailableAIModels();
       const values = models.map((m) => m.value);
 
-      expect(values).toContain('local');
-      expect(values).toContain('openai');
-      expect(values).toContain('claude');
-      expect(values).toContain('ollama');
+      // Only test for essential/core providers
+      const CORE_PROVIDERS = ['local', 'openai', 'claude', 'openrouter'];
+      CORE_PROVIDERS.forEach((provider) => {
+        expect(values).toContain(provider);
+      });
+    });
+
+    it('all AI models follow the expected contract', () => {
+      const models = getAvailableAIModels();
+
+      models.forEach((model) => {
+        // Test structure
+        expect(model).toHaveProperty('value');
+        expect(model).toHaveProperty('title');
+        expect(model).toHaveProperty('description');
+
+        // Test types
+        expect(typeof model.value).toBe('string');
+        expect(typeof model.title).toBe('string');
+        expect(typeof model.description).toBe('string');
+
+        // Test non-empty values
+        expect(model.value.length).toBeGreaterThan(0);
+        expect(model.title.length).toBeGreaterThan(0);
+        expect(model.description.length).toBeGreaterThan(0);
+
+        // Test naming conventions
+        expect(model.value).toBe(model.value.toLowerCase());
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

This PR improves the AI provider tests in `create.test.ts` to avoid the anti-pattern of needing to update tests every time a new AI provider is added.

## Changes

1. **Removed hardcoded provider count**: Changed from `expect(models).toHaveLength(5)` to a range test (3-7 providers)
2. **Removed provider-specific tests**: Removed the ollama-specific test that was redundant
3. **Test only core providers**: Now only tests for essential providers (local, openai, claude, openrouter) 
4. **Added contract tests**: New test ensures all providers follow the expected structure regardless of count
5. **Better test organization**: Count test is now separate and clearly named

## Benefits

- ✅ No more test updates needed when adding new AI providers (up to 7 total)
- ✅ Tests focus on behavior and contracts rather than implementation details
- ✅ More maintainable - only fails if core functionality breaks
- ✅ Better documentation - contract test shows what's expected of any AI provider

## Testing

All tests pass:
```
bun test tests/commands/create.test.ts --grep "AI Model Selection"
```