### PR TITLE
fix(core): fix bun import error by pointing to dist files

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,11 +6,11 @@
   "main": "dist/index.js",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
-  "bun": "./src/index.ts",
+  "bun": "./dist/index.js",
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "bun": "./src/index.ts",
+      "bun": "./dist/index.js",
       "import": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"


### PR DESCRIPTION
# Fix Bun import error in @elizaos/core npm package

## Problem

When plugin developers try to use `bun test` instead of `vitest` for testing their plugins, they encounter a critical error:

```
error: Cannot find module '@elizaos/core' from '/path/to/plugin/test.ts'
```

This happens because:

- The published `@elizaos/core` npm package has `"bun": "./src/index.ts"` in its package.json
- Bun prioritizes this field and tries to load from `node_modules/@elizaos/core/src/index.ts`
- However, the npm package only contains compiled files in `dist/`, not the source files
- This makes it impossible for plugins to use `bun test` when importing from `@elizaos/core`

## Solution

Update the "bun" fields in package.json to point to the compiled dist files:

- `"bun": "./src/index.ts"` → `"bun": "./dist/index.js"`

## Why This Approach

- **Minimal change**: Only updates two lines in package.json
- **No build process changes**: Continues using tsup for builds
- **Backwards compatible**: Doesn't affect existing Node.js or other runtime users
- **Future-proof**: When we eventually migrate to bun for builds, we can revisit whether to include source files or update the build process

## Impact

- ✅ Plugins can now use `bun test` for faster test execution
- ✅ Developers can choose between `vitest` and `bun test` based on their needs
- ✅ No breaking changes for existing users
- ✅ Maintains current npm package size (no source files added)

## Testing

- Verified that `bun test` works correctly in plugins after this change
- Existing vitest tests continue to work as expected
- No regression in standard Node.js imports

This is a temporary but necessary fix until we make a broader decision about migrating the build process from tsup to bun.

## Related Issues

- Fixes the "Cannot find module '@elizaos/core'" error when using Bun with the npm package
- Enables plugin developers to leverage Bun's faster test execution
