### PR TITLE
fix: ensure CLI build depends on client build to prevent 'Client UI not available' errors

### DIFF
--- a/packages/cli/src/utils/copy-template.ts
+++ b/packages/cli/src/utils/copy-template.ts
@@ -286,7 +286,8 @@ export async function copyClientDist() {
 
   if (!existsSync(indexSrc)) {
     logger.error(`index.html not found at ${indexSrc} after ${maxRetries} attempts`);
-    return;
+    logger.error('Client package must be built before CLI package. Run: bun run build:client');
+    throw new Error('Client dist files not found - build the client package first');
   }
 
   // Copy everything
@@ -295,8 +296,10 @@ export async function copyClientDist() {
   // Verify it made it into CLI dist
   if (!existsSync(indexDest)) {
     logger.error(`index.html missing in CLI dist at ${indexDest}`);
-    return;
+    throw new Error('Failed to copy client files to CLI dist directory');
   }
+
+  logger.info('✅ Client files successfully copied to CLI package');
 
   logger.success('Client dist files copied successfully');
 }

--- a/turbo.json
+++ b/turbo.json
@@ -6,6 +6,11 @@
       "env": ["LOG_LEVEL"],
       "outputs": ["dist/**"]
     },
+    "@elizaos/cli#build": {
+      "dependsOn": ["@elizaos/client#build", "^build"],
+      "env": ["LOG_LEVEL"],
+      "outputs": ["dist/**"]
+    },
     "lint": {
       "outputs": [".eslintcache"]
     },


### PR DESCRIPTION
## Problem

Recent deployments have been experiencing "Client UI not available" errors when accessing the frontend. This happens when the CLI package is built without the client package being built first, resulting in missing client dist files that the server needs to serve the UI.

## Root Cause

The issue was introduced by commit 9f50fda322 which added dynamic client path resolution to the server. However, the build process didn't guarantee that client files would be available when the CLI tried to copy them.

## Solution

### 1. Fixed Turbo Dependencies
- Added explicit dependency in `turbo.json` for `@elizaos/cli#build` to depend on `@elizaos/client#build`
- This ensures turbo automatically builds the client before building the CLI

### 2. Improved Error Handling
- Made CLI build fail fast with clear error message if client files are missing
- Prevents silent failures that lead to missing client UI files in production

## Benefits

✅ **Automatic build ordering** - turbo handles dependencies declaratively  
✅ **Better caching** - turbo won't rebuild client if unchanged  
✅ **Clear error messages** - immediate failure if dependencies aren't met  
✅ **Works everywhere** - CI, local dev, production deployments  
✅ **No manual intervention** - no need for complex build scripts  

## Testing

Tested the fix by:
1. Removing client and CLI dist directories
2. Running `turbo run build --filter=@elizaos/cli`
3. Verified that client builds first, then CLI copies files successfully
4. Confirmed `index.html` and other client assets are properly available

## Files Changed

- `turbo.json`: Added CLI → client build dependency
- `packages/cli/src/utils/copy-template.ts`: Improved error handling with clear messages

Fixes the "Client UI not available" error permanently by ensuring proper build order.