### PR TITLE
fix: env settings scroll

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -178,7 +178,7 @@ function AppContent() {
               <Route
                 path="settings/"
                 element={
-                  <div className="flex w-full justify-center">
+                  <div className="flex w-full justify-center overflow-y-auto">
                     <div className="w-full md:max-w-4xl">
                       <EnvSettings />
                     </div>


### PR DESCRIPTION
This PR fixes an issue where the environment settings page would get stuck and prevent scrolling.

Related: [ELIZA-499](https://linear.app/eliza-labs/issue/ELIZA-499/cant-scroll-down-in-gui)