### PR TITLE
feat: mark bootstrap plugin as essential

### DIFF
--- a/packages/client/src/components/plugins-panel.tsx
+++ b/packages/client/src/components/plugins-panel.tsx
@@ -59,6 +59,11 @@ const ESSENTIAL_PLUGINS: Record<string, EssentialPluginInfo> = {
     description:
       'Provides language model access. If removed, replace with another LLM plugin or your agent may fail to function properly.',
   },
+  '@elizaos/plugin-bootstrap': {
+    title: 'Essential Plugin: Bootstrap',
+    description:
+      'Provides default message processing, event handling, and attachment workflows for your agent. If removed, ensure you have a custom plugin handling these responsibilities, or your agent may not process events or respond to messages as expected.',
+  },  
 };
 
 export default function PluginsPanel({


### PR DESCRIPTION
This PR marks @elizaos/plugin-bootstrap as an essential plugin within the PluginsPanel

related: https://linear.app/eliza-labs/issue/ELIZA-504/bootstrap-needs-to-be-marked-blue-in-gui