### PR TITLE
fix: Clarify UX by removing misleading avatar upload text

### DIFF
--- a/packages/client/src/components/avatar-panel.tsx
+++ b/packages/client/src/components/avatar-panel.tsx
@@ -121,10 +121,6 @@ export default function AvatarPanel({ characterValue, setCharacterValue }: Avata
             )}
           </div>
 
-          {hasChanged && (
-            <div className="text-sm text-blue-500 mt-1 text-center">Avatar has been updated</div>
-          )}
-
           <div className="flex items-center justify-center gap-1 text-xs text-muted-foreground mt-1">
             <Info className="w-3.5 h-3.5" />
             <span>Images greater than 300x300 will be resized</span>


### PR DESCRIPTION
This PR removes the avatar upload message shown after uploading an avatar, which previously stated that the avatar was updated even though the user still needed to click “Save Changes” to apply it.

related: https://linear.app/eliza-labs/issue/ELIZA-498/avatar-bug-in-gui

