### PR TITLE
fix: avatar

### DIFF
--- a/packages/client/src/components/agent-card.tsx
+++ b/packages/client/src/components/agent-card.tsx
@@ -101,51 +101,7 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, onChat }) => {
       onClick={handleCardClick}
       data-testid="agent-card"
     >
-      <CardContent className="flex-grow flex items-center justify-center p-0 overflow-hidden">
-        {avatarUrl ? (
-          <img
-            src={avatarUrl}
-            alt={agentName}
-            className={cn(
-              'w-full aspect-square object-cover rounded-lg',
-              isActive ? '' : 'grayscale'
-            )}
-          />
-        ) : (
-          <div className="w-full h-full flex items-center rounded-lg justify-center bg-secondary text-2xl font-semibold text-muted-foreground">
-            {formatAgentName(agentName)}
-          </div>
-        )}
-        <div className="absolute bottom-4 right-4">
-          {isActive ? (
-            <Button
-              onClick={handleChatClick}
-              className=""
-              variant="default"
-              size="sm"
-              disabled={isStopping || isStarting} /* Also disable if starting */
-            >
-              <MessageSquare className="h-4 w-4" />
-            </Button>
-          ) : (
-            <Button
-              onClick={handleStart}
-              disabled={isStarting || isStopping}
-              className=""
-              variant="outline"
-              size="sm"
-            >
-              {isStarting ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Play className="h-4 w-4" />
-              )}
-              {isStarting ? 'Starting...' : 'Start'}
-            </Button>
-          )}
-        </div>
-      </CardContent>
-      <CardHeader className="flex flex-row items-center gap-3 absolute w-full h-16">
+      <CardHeader className="flex flex-row items-center gap-3 absolute w-full h-16 z-10">
         <Avatar className="h-10 w-10 border">
           <AvatarImage src={avatarUrl} alt={agentName} />
           {/* Fallback can be initials or generic icon */}
@@ -200,6 +156,50 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, onChat }) => {
           {isStopping && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
         </div>
       </CardHeader>
+      <CardContent className="flex-grow flex items-center justify-center p-0 overflow-hidden">
+        {avatarUrl ? (
+          <img
+            src={avatarUrl}
+            alt={agentName}
+            className={cn(
+              'w-full aspect-square object-cover rounded-lg',
+              isActive ? '' : 'grayscale'
+            )}
+          />
+        ) : (
+          <div className="w-full h-full flex items-center rounded-lg justify-center bg-secondary text-2xl font-semibold text-muted-foreground">
+            {formatAgentName(agentName)}
+          </div>
+        )}
+        <div className="absolute bottom-4 right-4">
+          {isActive ? (
+            <Button
+              onClick={handleChatClick}
+              className=""
+              variant="default"
+              size="sm"
+              disabled={isStopping || isStarting} /* Also disable if starting */
+            >
+              <MessageSquare className="h-4 w-4" />
+            </Button>
+          ) : (
+            <Button
+              onClick={handleStart}
+              disabled={isStarting || isStopping}
+              className=""
+              variant="outline"
+              size="sm"
+            >
+              {isStarting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Play className="h-4 w-4" />
+              )}
+              {isStarting ? 'Starting...' : 'Start'}
+            </Button>
+          )}
+        </div>
+      </CardContent>
     </Card>
   );
 };

--- a/packages/client/src/components/agent-card.tsx
+++ b/packages/client/src/components/agent-card.tsx
@@ -101,6 +101,50 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, onChat }) => {
       onClick={handleCardClick}
       data-testid="agent-card"
     >
+      <CardContent className="flex-grow flex items-center justify-center p-0 overflow-hidden">
+        {avatarUrl ? (
+          <img
+            src={avatarUrl}
+            alt={agentName}
+            className={cn(
+              'w-full aspect-square object-cover rounded-lg',
+              isActive ? '' : 'grayscale'
+            )}
+          />
+        ) : (
+          <div className="w-full h-full flex items-center rounded-lg justify-center bg-secondary text-2xl font-semibold text-muted-foreground">
+            {formatAgentName(agentName)}
+          </div>
+        )}
+        <div className="absolute bottom-4 right-4">
+          {isActive ? (
+            <Button
+              onClick={handleChatClick}
+              className=""
+              variant="default"
+              size="sm"
+              disabled={isStopping || isStarting} /* Also disable if starting */
+            >
+              <MessageSquare className="h-4 w-4" />
+            </Button>
+          ) : (
+            <Button
+              onClick={handleStart}
+              disabled={isStarting || isStopping}
+              className=""
+              variant="outline"
+              size="sm"
+            >
+              {isStarting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Play className="h-4 w-4" />
+              )}
+              {isStarting ? 'Starting...' : 'Start'}
+            </Button>
+          )}
+        </div>
+      </CardContent>
       <CardHeader className="flex flex-row items-center gap-3 absolute w-full h-16">
         <Avatar className="h-10 w-10 border">
           <AvatarImage src={avatarUrl} alt={agentName} />
@@ -156,50 +200,6 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, onChat }) => {
           {isStopping && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
         </div>
       </CardHeader>
-      <CardContent className="flex-grow flex items-center justify-center p-0 overflow-hidden">
-        {avatarUrl ? (
-          <img
-            src={avatarUrl}
-            alt={agentName}
-            className={cn(
-              'w-full aspect-square object-cover rounded-lg',
-              isActive ? '' : 'grayscale'
-            )}
-          />
-        ) : (
-          <div className="w-full h-full flex items-center rounded-lg justify-center bg-secondary text-2xl font-semibold text-muted-foreground">
-            {formatAgentName(agentName)}
-          </div>
-        )}
-        <div className="absolute bottom-4 right-4">
-          {isActive ? (
-            <Button
-              onClick={handleChatClick}
-              className=""
-              variant="default"
-              size="sm"
-              disabled={isStopping || isStarting} /* Also disable if starting */
-            >
-              <MessageSquare className="h-4 w-4" />
-            </Button>
-          ) : (
-            <Button
-              onClick={handleStart}
-              disabled={isStarting || isStopping}
-              className=""
-              variant="outline"
-              size="sm"
-            >
-              {isStarting ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Play className="h-4 w-4" />
-              )}
-              {isStarting ? 'Starting...' : 'Start'}
-            </Button>
-          )}
-        </div>
-      </CardContent>
     </Card>
   );
 };

--- a/packages/client/src/components/ui/avatar.tsx
+++ b/packages/client/src/components/ui/avatar.tsx
@@ -29,7 +29,7 @@ const AvatarImage = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
-    className={cn('aspect-square h-full w-full', className)}
+    className={cn('aspect-square h-full w-full object-cover', className)}
     data-testid={props['data-testid'] || 'avatar-image'}
     {...props}
   />

--- a/packages/client/src/constants.ts
+++ b/packages/client/src/constants.ts
@@ -2,7 +2,7 @@ export const USER_NAME = 'user';
 export const CHAT_SOURCE = 'client_chat';
 export const GROUP_CHAT_SOURCE = 'client_group_chat';
 
-export const AVATAR_IMAGE_MAX_SIZE = 300;
+export const AVATAR_IMAGE_MAX_SIZE = 1024;
 
 export enum FIELD_REQUIREMENT_TYPE {
   REQUIRED = 'required',


### PR DESCRIPTION
This PR includes the following improvements:

1. Increase avatar upload threshold to 1024
Per request by @borisudovicic, the allowed avatar upload size limit is now increased to 1024 to support higher-quality avatars.

2. Fix avatar image display with object-cover
Ensures avatar images maintain correct aspect ratio without stretching, providing a consistent and polished appearance.

before: 

<img width="271" alt="Screenshot 2025-06-30 at 10 34 35 PM" src="https://github.com/user-attachments/assets/6dc8c144-3cb3-43f6-88f7-219f72631bfb" />

after:

<img width="288" alt="Screenshot 2025-06-30 at 10 33 57 PM" src="https://github.com/user-attachments/assets/632b42e0-7985-4497-b226-31d9ad31fa92" />



3. Fix header being covered by avatar image
Previously, when an avatar image was uploaded, it visually covered the header due to layering, which prevented users from clicking header buttons like Settings and Chat. This PR resolves the issue by switching the CardHeader and CardContent order, ensuring the header remains visible.

before:

<img width="1122" alt="Screenshot 2025-06-30 at 10 42 30 PM" src="https://github.com/user-attachments/assets/a4b44f25-f821-401c-ac32-aa36c01ad979" />


after:

<img width="1133" alt="Screenshot 2025-06-30 at 10 43 25 PM" src="https://github.com/user-attachments/assets/27720c66-ec56-432c-93d9-0c36c3987633" />


