### PR TITLE
fix: auto-install AI model plugins on project creation

### DIFF
--- a/packages/cli/src/commands/create/actions/setup.ts
+++ b/packages/cli/src/commands/create/actions/setup.ts
@@ -324,6 +324,28 @@ export async function setupEmbeddingModelConfig(
 }
 
 /**
+ * Helper function to install a model plugin with error handling
+ */
+async function installModelPlugin(
+  modelName: string,
+  targetDir: string,
+  purpose: string = ''
+): Promise<void> {
+  // For claude, the plugin name is 'anthropic'
+  const pluginName = modelName === 'claude' ? 'anthropic' : modelName;
+  const purposeText = purpose ? ` ${purpose}` : '';
+  
+  try {
+    console.info(`\n📦 Installing ${pluginName} plugin${purposeText}...`);
+    await installPlugin(pluginName, targetDir);
+    console.info(`✅ Installed plugin successfully!`);
+  } catch (error) {
+    console.warn(`⚠️  Could not install plugin automatically: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    console.info(`💡 You can install it manually with: elizaos plugins add ${pluginName}`);
+  }
+}
+
+/**
  * Installs dependencies for the specified target directory.
  */
 export async function installDependencies(targetDir: string): Promise<void> {
@@ -368,27 +390,11 @@ export async function setupProjectEnvironment(
 
   // Install AI model plugin (skip for local AI)
   if (aiModel !== 'local') {
-    try {
-      // For claude, the plugin name is 'anthropic'
-      const pluginName = aiModel === 'claude' ? 'anthropic' : aiModel;
-      console.info(`\n📦 Installing ${aiModel} plugin...`);
-      await installPlugin(pluginName, targetDir);
-      console.info(`✅ Installed plugin successfully!`);
-    } catch (error) {
-      console.warn(`⚠️  Could not install plugin automatically: ${error instanceof Error ? error.message : 'Unknown error'}`);
-      console.info(`💡 You can install it manually with: elizaos plugins add ${aiModel}`);
-    }
+    await installModelPlugin(aiModel, targetDir);
   }
 
   // Install embedding model plugin if different from AI model
   if (embeddingModel && embeddingModel !== 'local' && embeddingModel !== aiModel) {
-    try {
-      console.info(`\n📦 Installing ${embeddingModel} plugin for embeddings...`);
-      await installPlugin(embeddingModel, targetDir);
-      console.info(`✅ Installed plugin successfully!`);
-    } catch (error) {
-      console.warn(`⚠️  Could not install plugin automatically: ${error instanceof Error ? error.message : 'Unknown error'}`);
-      console.info(`💡 You can install it manually with: elizaos plugins add ${embeddingModel}`);
-    }
+    await installModelPlugin(embeddingModel, targetDir, 'for embeddings');
   }
 }

--- a/packages/cli/src/commands/create/actions/setup.ts
+++ b/packages/cli/src/commands/create/actions/setup.ts
@@ -11,6 +11,7 @@ import {
   promptAndStoreOpenRouterKey,
   runBunCommand,
   setupPgLite,
+  installPlugin,
 } from '@/src/utils';
 
 /**
@@ -363,5 +364,31 @@ export async function setupProjectEnvironment(
   // Set up embedding model configuration if needed
   if (embeddingModel) {
     await setupEmbeddingModelConfig(embeddingModel, envFilePath, isNonInteractive);
+  }
+
+  // Install AI model plugin (skip for local AI)
+  if (aiModel !== 'local') {
+    try {
+      // For claude, the plugin name is 'anthropic'
+      const pluginName = aiModel === 'claude' ? 'anthropic' : aiModel;
+      console.info(`\n📦 Installing ${aiModel} plugin...`);
+      await installPlugin(pluginName, targetDir);
+      console.info(`✅ Installed plugin successfully!`);
+    } catch (error) {
+      console.warn(`⚠️  Could not install plugin automatically: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      console.info(`💡 You can install it manually with: elizaos plugins add ${aiModel}`);
+    }
+  }
+
+  // Install embedding model plugin if different from AI model
+  if (embeddingModel && embeddingModel !== 'local' && embeddingModel !== aiModel) {
+    try {
+      console.info(`\n📦 Installing ${embeddingModel} plugin for embeddings...`);
+      await installPlugin(embeddingModel, targetDir);
+      console.info(`✅ Installed plugin successfully!`);
+    } catch (error) {
+      console.warn(`⚠️  Could not install plugin automatically: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      console.info(`💡 You can install it manually with: elizaos plugins add ${embeddingModel}`);
+    }
   }
 }


### PR DESCRIPTION
## Problem

When creating a new project with `elizaos create`, selecting an AI model (e.g., OpenAI, Claude) would:
- ✅ Store the API key in `.env`
- ✅ Report successful configuration
- ❌ **NOT** install the corresponding plugin package
- ❌ **NOT** add the plugin to `package.json` dependencies

This left users with a broken setup where the agent couldn't actually use the selected AI model.

## Solution

This PR adds automatic plugin installation during project creation by calling the existing `installPlugin` utility after AI model configuration.

**Key changes:**
- Added ~15 lines of code to `setup.ts` 
- Reuses existing `installPlugin` function from utils
- Handles the special case where `claude` maps to `@elizaos/plugin-anthropic`
- Installs embedding model plugin if different from main AI model

## Replaces PR #5330

This is a simpler alternative to #5330 that accomplishes the same goal with significantly less code by leveraging existing infrastructure instead of creating new mapping files and detection logic.

## Testing

Tested with:
- `elizaos create --type project` selecting OpenAI ✅
- `elizaos create --type project` selecting Claude ✅
- `elizaos create --type project` selecting Claude + OpenAI embeddings ✅
- Non-interactive mode with `--yes` flag ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic installation of AI model plugins during project setup, including support for embedding models.
  * Clear messages are provided for both successful and failed plugin installations, with guidance for manual installation if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->