### PR TITLE
fix: (cli) show correct type in create command messages

### DIFF
--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -206,7 +206,7 @@ export const create = new Command('create')
     } catch (error) {
       if (!opts?.yes) {
         // Dynamic error message based on project type
-        const errorType = projectType || 'project';
+        const errorType = formatProjectType(projectType || 'project');
         clack.cancel(`Failed to create ${errorType}.`);
       }
       logger.error('Create command failed:', error);

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -9,6 +9,14 @@ import { selectDatabase, selectAIModel, selectEmbeddingModel } from './utils';
 import { createProject, createPlugin, createAgent, createTEEProject } from './actions';
 import type { CreateOptions } from './types';
 
+/**
+ * Formats the project type for display in messages
+ */
+function formatProjectType(type: string): string {
+  return type === 'tee' ? 'TEE Project' : 
+         type.charAt(0).toUpperCase() + type.slice(1);
+}
+
 export const create = new Command('create')
   .description('Create a new ElizaOS project, plugin, agent, or TEE project')
   .argument('[name]', 'name of the project/plugin/agent to create')
@@ -40,8 +48,7 @@ export const create = new Command('create')
       if (!isNonInteractive) {
         await displayBanner();
         // Use projectType if already set from options, otherwise show generic message
-        const introType = options.type === 'tee' ? 'TEE Project' : 
-                          options.type.charAt(0).toUpperCase() + options.type.slice(1);
+        const introType = formatProjectType(options.type);
         clack.intro(colors.inverse(` Creating ElizaOS ${introType} `));
       }
 
@@ -193,8 +200,8 @@ export const create = new Command('create')
 
       if (!isNonInteractive) {
         // Dynamic outro message based on project type
-        const typeLabel = projectType === 'tee' ? 'TEE project' : projectType;
-        clack.outro(colors.green(`${typeLabel.charAt(0).toUpperCase() + typeLabel.slice(1)} created successfully! 🎉`));
+        const typeLabel = formatProjectType(projectType);
+        clack.outro(colors.green(`${typeLabel} created successfully! 🎉`));
       }
     } catch (error) {
       if (!opts?.yes) {

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -16,6 +16,8 @@ export const create = new Command('create')
   .option('--yes, -y', 'skip prompts and use defaults')
   .option('--type <type>', 'type of project to create (project, plugin, agent, tee)', 'project')
   .action(async (name?: string, opts?: any) => {
+    let projectType: string | undefined; // Declare outside try block for catch access
+    
     try {
       // Set non-interactive mode if environment variable is set or if -y/--yes flag is present in process.argv
       if (
@@ -37,10 +39,13 @@ export const create = new Command('create')
 
       if (!isNonInteractive) {
         await displayBanner();
-        clack.intro(colors.inverse(' Creating ElizaOS Project '));
+        // Use projectType if already set from options, otherwise show generic message
+        const introType = options.type === 'tee' ? 'TEE Project' : 
+                          options.type.charAt(0).toUpperCase() + options.type.slice(1);
+        clack.intro(colors.inverse(` Creating ElizaOS ${introType} `));
       }
 
-      let projectType = options.type;
+      projectType = options.type;
       let projectName = name;
 
       // If no name provided, prompt for type first then name
@@ -187,11 +192,15 @@ export const create = new Command('create')
       }
 
       if (!isNonInteractive) {
-        clack.outro(colors.green('Project created successfully! 🎉'));
+        // Dynamic outro message based on project type
+        const typeLabel = projectType === 'tee' ? 'TEE project' : projectType;
+        clack.outro(colors.green(`${typeLabel.charAt(0).toUpperCase() + typeLabel.slice(1)} created successfully! 🎉`));
       }
     } catch (error) {
       if (!opts?.yes) {
-        clack.cancel('Failed to create project.');
+        // Dynamic error message based on project type
+        const errorType = projectType || 'project';
+        clack.cancel(`Failed to create ${errorType}.`);
       }
       logger.error('Create command failed:', error);
       handleError(error);

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -47,9 +47,6 @@ export const create = new Command('create')
 
       if (!isNonInteractive) {
         await displayBanner();
-        // Use projectType if already set from options, otherwise show generic message
-        const introType = formatProjectType(options.type);
-        clack.intro(colors.inverse(` Creating ElizaOS ${introType} `));
       }
 
       projectType = options.type;
@@ -93,6 +90,12 @@ export const create = new Command('create')
           projectType = selectedType as 'project' | 'plugin' | 'agent' | 'tee';
         }
 
+        // Show intro message after type is determined
+        if (!isNonInteractive) {
+          const introType = formatProjectType(projectType);
+          clack.intro(colors.inverse(` Creating ElizaOS ${introType} `));
+        }
+
         // Prompt for name
         if (!isNonInteractive) {
           const nameInput = await clack.text({
@@ -128,6 +131,12 @@ export const create = new Command('create')
         if (!nameValidation.isValid) {
           throw new Error(nameValidation.error);
         }
+      }
+
+      // Show intro message now that we have both type and name
+      if (!isNonInteractive && name) {
+        const introType = formatProjectType(projectType);
+        clack.intro(colors.inverse(` Creating ElizaOS ${introType} `));
       }
 
       const targetDir = options.dir;


### PR DESCRIPTION
## Description

Updates the CLI create command to display the correct type (Plugin/Agent/TEE Project) in prompts instead of always showing "Project".

## Changes

- Dynamic intro message based on `--type` flag
- Type-specific success messages
- Proper error messages that match the creation type

## Before & After

### Before

┌ Creating ElizaOS Project
│
◇ Create plugin "plugin-labubu" in Desktop?

### After

┌ Creating ElizaOS Plugin
│
◇ Create plugin "plugin-labubu" in Desktop?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved command messages to dynamically display and format the project type throughout the creation process, including success and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->