### PR TITLE
fix: tweak ui and fix agent card padding issue

### DIFF
--- a/packages/client/src/components/agent-card.tsx
+++ b/packages/client/src/components/agent-card.tsx
@@ -7,7 +7,7 @@ import { Switch } from '@/components/ui/switch';
 import { formatAgentName, cn } from '@/lib/utils';
 import type { Agent } from '@elizaos/core';
 import { AgentStatus as CoreAgentStatus } from '@elizaos/core';
-import { MessageSquare, Settings, Loader2 } from 'lucide-react';
+import { Settings } from 'lucide-react';
 import { useAgentManagement } from '@/hooks/use-agent-management';
 import type { AgentWithStatus } from '@/types';
 import clientLogger from '@/lib/logger';
@@ -33,9 +33,9 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, onChat }) => {
   const agentIdForNav = agent.id;
   const agentName = agent.name || 'Unnamed Agent';
   const avatarUrl = typeof agent.settings?.avatar === 'string' ? agent.settings.avatar : undefined;
-  const description =
-    (typeof agent.bio === 'string' && agent.bio.trim()) ||
-    'Engages with all types of questions and conversations';
+  const description = (
+      Array.isArray(agent.bio) && agent.bio.filter(Boolean).join(' ').trim()
+  ) || 'Engages with all types of questions and conversations';
   const isActive = agent.status === CoreAgentStatus.ACTIVE;
   const isStarting = isAgentStarting(agent.id);
   const isStopping = isAgentStopping(agent.id);
@@ -94,7 +94,7 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, onChat }) => {
       )}
       data-testid="agent-card"
     >
-      <CardContent className="p-0 relative">
+      <CardContent className="p-0 relative h-full">
         {/* Toggle Switch - positioned absolutely in top-right */}
         <div className="absolute top-3 right-3">
           <Switch
@@ -108,13 +108,13 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, onChat }) => {
             aria-label={`Toggle ${agentName}`}
             disabled={isStarting || isStopping}
             className={cn(
-              isActive ? 'data-[state=checked]:!bg-green-600' : 'data-[state=unchecked]:!bg-red-600'
+              isActive ? 'data-[state=checked]:!bg-green-600' : 'data-[state=unchecked]:!bg-gray-500/80'
             )}
           />
         </div>
 
-        <div className="flex flex-col justify-between">
-          <div className="flex items-center gap-4 p-2">
+        <div className="flex flex-col justify-between h-full">
+          <div className="flex items-center gap-4 p-2 h-[90%]">
             {/* Avatar */}
             <Avatar className="h-16 w-16 flex-shrink-0 rounded-sm">
               <AvatarImage src={avatarUrl} alt={agentName} />
@@ -158,7 +158,6 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, onChat }) => {
               }}
               className="h-8 px-2 rounded-sm bg-muted hover:bg-muted-foreground cursor-pointer"
             >
-              <MessageSquare/>
               New Chat
             </Button>
           </div>

--- a/packages/client/src/routes/home.tsx
+++ b/packages/client/src/routes/home.tsx
@@ -75,11 +75,15 @@ export default function Home() {
                     className="relative rounded-full data-[state=active]:border-b-0 data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:font-bold cursor-pointer text-lg py-1"
                   >
                     Agents
-                    {activeAgentsCount > 0 && (
-                      <span className="absolute -top-2.5 right-0 inline-flex items-center justify-center h-5 w-5 rounded-full bg-blue-600 text-white text-[8px] font-semibold border border-black">
-                        {activeAgentsCount}
-                      </span>
-                    )}
+                    <span
+                      className={`
+                        absolute -top-2.5 right-0 inline-flex items-center justify-center h-5 w-5 rounded-full bg-blue-600 text-white text-[8px] font-semibold border border-black
+                        transition-all duration-300 ease-in-out
+                        ${activeTab === 'agents' && activeAgentsCount > 0 ? 'opacity-100 scale-100' : 'opacity-0 scale-75 pointer-events-none'}
+                      `}
+                    >
+                      {activeAgentsCount}
+                    </span>
                   </TabsTrigger>
                   <TabsTrigger
                     value="groups"

--- a/packages/client/src/routes/home.tsx
+++ b/packages/client/src/routes/home.tsx
@@ -72,20 +72,18 @@ export default function Home() {
                 <TabsList className="h-auto p-0 bg-transparent border-0 border-b-0 gap-2 w-auto">
                   <TabsTrigger
                     value="agents"
-                    className="data-[state=active]:border-blue-600 cursor-pointer text-lg data-[state=active]:font-black py-1"
+                    className="relative rounded-full data-[state=active]:border-b-0 data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:font-bold cursor-pointer text-lg py-1"
                   >
-                    <div className='relative'>
-                      Agents
-                      {activeAgentsCount > 0 && (
-                        <span className="absolute -top-1.5 -right-4 inline-flex items-center justify-center h-4 w-4 rounded-full bg-blue-600 text-white text-[8px] font-semibold">
-                          {activeAgentsCount}
-                        </span>
-                      )}
-                    </div>
+                    Agents
+                    {activeAgentsCount > 0 && (
+                      <span className="absolute -top-2.5 right-0 inline-flex items-center justify-center h-5 w-5 rounded-full bg-blue-600 text-white text-[8px] font-semibold border border-black">
+                        {activeAgentsCount}
+                      </span>
+                    )}
                   </TabsTrigger>
                   <TabsTrigger
                     value="groups"
-                    className="data-[state=active]:border-blue-600 cursor-pointer text-lg data-[state=active]:font-black py-1"
+                    className="rounded-full data-[state=active]:border-b-0 data-[state=active]:bg-white data-[state=active]:text-black data-[state=active]:font-bold cursor-pointer text-lg py-1"
                   >
                     Groups
                   </TabsTrigger>


### PR DESCRIPTION
This PR updates the UI based on @wtfsayo requirements:

- Updates the switch off button to gray color.

- Removes the message icon from the “New Chat” button.

- Adds background color to the tabs that switch between group chat and DM chat views.

Additionally, this PR fixes two issues:

- The agent card content now maintains consistent height across different cards.

- Fixes the issue where all agent cards were displaying the same bio for different agents. Previously, we were checking if the agent bio was a string, but the agent bio is actually an array, which caused it to always fall back to the default text.