### PR TITLE
feat: Show correct create button label based on active tab

### DIFF
--- a/packages/client/src/routes/home.tsx
+++ b/packages/client/src/routes/home.tsx
@@ -95,7 +95,7 @@ export default function Home() {
                     </TabsTrigger>
                   </TabsList>
                   <Button
-                    variant="outline"
+                    variant="ghost"
                     onClick={() => {
                       if (activeTab === 'agents') {
                         navigate('/create')
@@ -106,6 +106,7 @@ export default function Home() {
                     className="create-agent-button"
                   >
                     <Plus className="w-4 h-4" />
+                    {activeTab === 'agents' ? "Create New Agent" : "Create New Group"}
                   </Button>
                 </div>
                 <Separator/>


### PR DESCRIPTION
Update the create button on the Home page to display “Create New Agent” when on the Agents tab and “Create New Group” when on the Groups tab for clearer user guidance.