### PR TITLE
Fix import/export button order and icons in character form

### DIFF
--- a/packages/client/src/components/character-form.tsx
+++ b/packages/client/src/components/character-form.tsx
@@ -957,13 +957,13 @@ export default function CharacterForm({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" side="top">
-              <DropdownMenuItem onClick={handleExportJSON}>
-                <ArrowUpFromLine className="h-4 w-4 mr-2" />
-                Export
-              </DropdownMenuItem>
               <DropdownMenuItem onClick={handleImportClick}>
-                <ArrowDownToLine className="h-4 w-4 mr-2" />
+                <ArrowUpFromLine className="h-4 w-4 mr-2" />
                 Import
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={handleExportJSON}>
+                <ArrowDownToLine className="h-4 w-4 mr-2" />
+                Export
               </DropdownMenuItem>
               {stopDeleteOptions.length > 0 && <DropdownMenuSeparator />}
               {stopDeleteOptions.length > 0 &&


### PR DESCRIPTION
## Description

This PR fixes the reversed import/export buttons in the character form dropdown menu.

## Changes Made

1. **Fixed icon orientation**: 
   - Export button now uses  (data flowing down from app to file)
   - Import button now uses  (data flowing up from file to app)

2. **Reordered menu items**:
   - Import button now appears first in the dropdown
   - Export button now appears second in the dropdown

## Why This Change?

The previous implementation had:
- Reversed icons that didn't match the logical data flow direction
- Reversed button order where export came before import

This fix ensures:
- Icons correctly represent the direction of data flow
- Menu order follows logical user workflow (import first, then export)

## Testing

- [x] Verified icons display correctly
- [x] Verified button order is correct
- [x] Verified functionality remains unchanged

## Files Changed

- 