### PR TITLE
fix: handle string and array types in bio for backward compatibility

### DIFF
--- a/packages/client/src/components/agent-card.tsx
+++ b/packages/client/src/components/agent-card.tsx
@@ -34,8 +34,10 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, onChat }) => {
   const agentName = agent.name || 'Unnamed Agent';
   const avatarUrl = typeof agent.settings?.avatar === 'string' ? agent.settings.avatar : undefined;
   const description =
-    (Array.isArray(agent.bio) && agent.bio.filter(Boolean).join(' ').trim()) ||
-    'Engages with all types of questions and conversations';
+    Array.isArray(agent.bio)
+        ? agent.bio.filter(Boolean).join(' ').trim()
+        : (typeof agent.bio === 'string' && agent.bio.trim()) ||
+          'Engages with all types of questions and conversations';
   const isActive = agent.status === CoreAgentStatus.ACTIVE;
   const isStarting = isAgentStarting(agent.id);
   const isStopping = isAgentStopping(agent.id);


### PR DESCRIPTION
Previously, the bio handling logic assumed `agent.bio` was always an array, causing existing agents with string-based bios to fallback to the default description, hiding their actual bio.

This fix adds type checks to gracefully handle both string and array forms of `agent.bio`, preserving backward compatibility and ensuring existing agent bios are displayed correctly.

related:

https://github.com/elizaOS/eliza/pull/5385#pullrequestreview-2984281045