### PR TITLE
fix: recording icon padding

### DIFF
--- a/packages/client/src/components/audio-recorder.tsx
+++ b/packages/client/src/components/audio-recorder.tsx
@@ -225,7 +225,7 @@ export const AudioRecorder = ({ className, timerClassName, agentId, onChange }: 
         </div>
       ) : null}
 
-      <div className="flex items-center">
+      <div className="flex items-center gap-2">
         {/* ========== Delete recording button ========== */}
         {isRecording ? (
           <Tooltip>


### PR DESCRIPTION
Issue:
The recording icon has no padding, causing it to appear cramped.


![image](https://github.com/user-attachments/assets/5c96b07f-b5e8-45f9-abb5-74c8b558c0a3)

Fix:

Added padding to the recording icon to improve visual balance and alignment.