### PR TITLE
fix: agent card new chat

### DIFF
--- a/packages/client/src/components/agent-card.tsx
+++ b/packages/client/src/components/agent-card.tsx
@@ -14,7 +14,7 @@ import clientLogger from '@/lib/logger';
 
 interface AgentCardProps {
   agent: Partial<AgentWithStatus>;
-  onChat: (agent: Partial<AgentWithStatus>) => void;
+  onChat: (forceNew: boolean) => void;
 }
 
 const AgentCard: React.FC<AgentCardProps> = ({ agent, onChat }) => {
@@ -71,8 +71,8 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, onChat }) => {
     stopAgent(agentForMutation);
   };
 
-  const handleNewChat = () => {
-    onChat(agent);
+  const handleNewChat = (forceNew: boolean = false) => {
+    onChat(forceNew);
   };
 
   const handleSettings = () => {
@@ -90,10 +90,14 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, onChat }) => {
   return (
     <Card
       className={cn(
-        'w-full transition-all bg-card border border-border/50 rounded-sm',
+        'w-full transition-all bg-card border border-border/50 rounded-sm hover:bg-card/50 cursor-pointer',
         isActive ? '' : 'opacity-75'
       )}
       data-testid="agent-card"
+      onClick={(e) => {
+        e.stopPropagation();
+        handleNewChat();
+      }}
     >
       <CardContent className="p-0 relative h-full">
         {/* Toggle Switch - positioned absolutely in top-right */}
@@ -157,7 +161,7 @@ const AgentCard: React.FC<AgentCardProps> = ({ agent, onChat }) => {
               size="sm"
               onClick={(e) => {
                 e.stopPropagation();
-                handleNewChat();
+                handleNewChat(true);
               }}
               className="h-8 px-2 rounded-sm bg-muted hover:bg-muted/50 cursor-pointer"
             >

--- a/packages/client/src/components/chat.tsx
+++ b/packages/client/src/components/chat.tsx
@@ -86,7 +86,6 @@ import { usePanelWidthState } from '@/hooks/use-panel-width-state';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import type { MessageChannel } from '@/types';
 import { useLocation } from 'react-router-dom';
-import { useNavigate } from 'react-router-dom';
 moment.extend(relativeTime);
 
 const DEFAULT_SERVER_ID = '00000000-0000-0000-0000-000000000000' as UUID;
@@ -270,7 +269,6 @@ export default function Chat({
     isMobile: false,
   });
 
-  const navigate = useNavigate();
   const location = useLocation();
   const state = location.state as ChatLocationState | null;
   const forceNew = state?.forceNew || false;

--- a/packages/client/src/components/chat.tsx
+++ b/packages/client/src/components/chat.tsx
@@ -85,6 +85,8 @@ import { useSidebarState } from '@/hooks/use-sidebar-state';
 import { usePanelWidthState } from '@/hooks/use-panel-width-state';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import type { MessageChannel } from '@/types';
+import { useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 moment.extend(relativeTime);
 
 const DEFAULT_SERVER_ID = '00000000-0000-0000-0000-000000000000' as UUID;
@@ -106,6 +108,10 @@ interface ChatUIState {
   currentDmChannelId: UUID | null;
   isCreatingDM: boolean;
   isMobile: boolean; // Add mobile state
+}
+
+export interface ChatLocationState {
+  forceNew?: boolean;
 }
 
 // Message content component - exported for use in ChatMessageListComponent
@@ -263,6 +269,13 @@ export default function Chat({
     isCreatingDM: false,
     isMobile: false,
   });
+
+  const navigate = useNavigate();
+  const location = useLocation();
+  const state = location.state as ChatLocationState | null;
+  const forceNew = state?.forceNew || false;
+
+  const [shouldForceNew, setShouldForceNew] = useState(forceNew);
 
   // Determine if we should use floating mode - either from width detection OR mobile
   const isFloatingMode = isFloatingModeFromWidth || chatState.isMobile;
@@ -536,6 +549,24 @@ export default function Chat({
     queryClient,
     currentClientEntityId,
   ]);
+
+  useEffect(() => {
+    if (
+      latestChannel &&
+      !isLoadingAgentDmChannels &&
+      targetAgentData.id && 
+      shouldForceNew
+    ) {
+      handleNewDmChannel(targetAgentData.id)
+      setShouldForceNew(false);
+    }
+  }, [
+    shouldForceNew,
+    setShouldForceNew, 
+    targetAgentData.id,
+    isLoadingAgentDmChannels, 
+    latestChannel,
+  ])
 
   useEffect(() => {
     inputDisabledRef.current = chatState.inputDisabled;

--- a/packages/client/src/hooks/use-dm-channels.ts
+++ b/packages/client/src/hooks/use-dm-channels.ts
@@ -184,7 +184,7 @@ export function useCreateDmChannel() {
 
       // Navigate to the new DM chat
       // data.id is the channelId, variables.agentId is the agentId (target user for DM)
-      navigate(`/chat/${variables.agentId}/${data.id}`);
+      window.history.pushState({}, '', `/chat/${variables.agentId}/${data.id}`);
     },
     onError: (error) => {
       clientLogger.error('[useCreateDmChannel] Error creating distinct DM channel:', error);

--- a/packages/client/src/routes/home.tsx
+++ b/packages/client/src/routes/home.tsx
@@ -42,10 +42,10 @@ export default function Home() {
     setOverlayOpen(false);
   };
 
-  const handleNavigateToDm = async (agent: Partial<Agent>) => {
+  const handleNavigateToDm = async (agent: Partial<Agent>, forceNew: boolean) => {
     if (!agent.id) return;
     // Navigate directly to agent chat - DM channel will be created automatically with default server
-    navigate(`/chat/${agent.id}`);
+    navigate(`/chat/${agent.id}`, { state: { forceNew } });
   };
 
   const handleCreateGroup = () => {
@@ -144,7 +144,7 @@ export default function Home() {
                           <AgentCard
                             key={agent.id}
                             agent={agent}
-                            onChat={() => handleNavigateToDm(agent as Agent)}
+                            onChat={(forceNew) => handleNavigateToDm(agent as Agent, forceNew)}
                           />
                         );
                       })}


### PR DESCRIPTION
This PR refactors Agent Card behavior to improve the chat initiation and navigation experience:

New Chat Button: Now correctly navigates to the chat page and creates a new chat with the agent.

Agent Card Click Area: Clicking anywhere on the agent area (except the new chat button) now navigates to the most recent chat with that agent for quick access.

Additionally, this PR fixes a bug where navigation to a new chat was causing the entire Chat component to rerender unnecessarily after clicking "Create New Chat", improving performance and preserving scroll position and internal refs.