### PR TITLE
fix: resolve group chat crash and unify SplitButton corner radius

### DIFF
--- a/packages/client/src/components/chat.tsx
+++ b/packages/client/src/components/chat.tsx
@@ -1232,6 +1232,8 @@ export default function Chat({
                   ]}
                   variant="outline"
                   size="sm"
+                  mainButtonClassName="rounded-l-[12px] h-9"
+                  dropdownButtonClassName="rounded-r-[12px] h-9"
                 />
 
                 <Tooltip>

--- a/packages/client/src/components/chat.tsx
+++ b/packages/client/src/components/chat.tsx
@@ -563,7 +563,7 @@ export default function Chat({
     shouldForceNew,
     setShouldForceNew, 
     handleNewDmChannel,
-    targetAgentData.id, 
+    targetAgentData?.id, 
     latestChannel,
     latestChannelMessages,
     isLoadingLatestChannelMessages

--- a/packages/client/src/components/ui/split-button.tsx
+++ b/packages/client/src/components/ui/split-button.tsx
@@ -25,10 +25,12 @@ export interface SplitButtonProps {
   size?: 'default' | 'sm' | 'lg' | 'icon';
   disabled?: boolean;
   className?: string;
+  mainButtonClassName?: string;
+  dropdownButtonClassName?: string;
 }
 
 export const SplitButton = React.forwardRef<HTMLDivElement, SplitButtonProps>(
-  ({ mainAction, actions, variant = 'default', size = 'default', disabled, className }, ref) => {
+  ({ mainAction, actions, variant = 'default', size = 'default', disabled, className, mainButtonClassName, dropdownButtonClassName  }, ref) => {
     const containerRef = React.useRef<HTMLDivElement>(null);
     const [menuWidth, setMenuWidth] = React.useState<number>();
 
@@ -50,7 +52,8 @@ export const SplitButton = React.forwardRef<HTMLDivElement, SplitButtonProps>(
           disabled={disabled || mainAction.disabled}
           className={cn(
             'rounded-r-none flex-1',
-            variant === 'destructive' ? 'border-r border-red-700' : 'border-r-0'
+            variant === 'destructive' ? 'border-r border-red-700' : 'border-r-0',
+            mainButtonClassName
           )}
         >
           {mainAction.icon && <span className="mr-2">{mainAction.icon}</span>}
@@ -64,7 +67,10 @@ export const SplitButton = React.forwardRef<HTMLDivElement, SplitButtonProps>(
               variant={variant}
               size={size}
               disabled={disabled}
-              className="rounded-l-none px-2 flex-shrink-0"
+              className={cn(
+                'rounded-l-none px-2 flex-shrink-0',
+                dropdownButtonClassName
+              )}
             >
               <ChevronDown className="h-4 w-4" />
               <span className="sr-only">More options</span>


### PR DESCRIPTION
This PR fixes a group chat crash issue

Additionally, it unifies the corner radius for the SplitButton component across the app by:

Adding mainButtonClassName and dropdownButtonClassName props to allow per-button styling control.
