### PR TITLE
fix(ci): standardize memory allocation and test execution across platforms

### DIFF
--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -150,7 +150,7 @@ jobs:
       - name: Run CLI TypeScript tests (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
         timeout-minutes: 15
-        run: cross-env NODE_OPTIONS="--max-old-space-size=4096" bun test tests/commands/ --timeout 240000; EXIT_CODE=$?; bash tests/cleanup-processes.sh; exit $EXIT_CODE
+        run: cross-env NODE_OPTIONS="--max-old-space-size=8192" bun test tests/commands/ --timeout 240000
         working-directory: packages/cli
         env:
           ELIZA_TEST_MODE: true
@@ -167,7 +167,7 @@ jobs:
       - name: Run CLI TypeScript tests (Windows)
         if: matrix.os == 'windows-latest'
         timeout-minutes: 15
-        run: cross-env NODE_OPTIONS="--max-old-space-size=4096" bun test tests/commands/ --timeout 240000
+        run: cross-env NODE_OPTIONS="--max-old-space-size=8192" bun test tests/commands/ --timeout 240000
         working-directory: packages/cli
         env:
           ELIZA_TEST_MODE: true


### PR DESCRIPTION
## Problem

Ubuntu CLI tests have been failing consistently while macOS tests pass reliably. The failures include:
- 'No agents found' errors
- 'AGENT_NOT_FOUND:Ada' errors  
- Process cleanup issues

## Root Cause Analysis

The Ubuntu CI configuration used several problematic approaches:
1. **Insufficient memory allocation**: 4GB vs 8GB on macOS
2. **Complex inline cleanup**: Aggressive process termination during test execution
3. **Inconsistent execution patterns**: Different approaches across platforms

## Solution

This PR standardizes all platforms to use the **proven macOS approach**:

### Memory Allocation 
- ✅ **Ubuntu**: 4GB → 8GB (matches macOS)
- ✅ **Windows**: 4GB → 8GB (standardized)
- ✅ **macOS**: 8GB (unchanged)

### Test Execution Pattern
- ✅ **Ubuntu**: Removed complex inline cleanup with exit code preservation
- ✅ **Ubuntu**: Now uses clean, simple test execution like macOS
- ✅ **Cleanup**: Still happens in dedicated separate step with proper error handling

### Benefits
- 🎯 **Reliability**: Ubuntu tests should now pass consistently like macOS
- 🚀 **Performance**: 8GB memory allows proper AI model loading
- 🔧 **Maintainability**: Consistent patterns across all platforms
- 🐛 **Debugging**: Easier to identify issues when they occur

## Testing
- Based on proven macOS pattern that passes consistently
- Memory increase supports AI plugin requirements
- Clean separation of test execution and cleanup phases

Fixes the Ubuntu CLI test failures by bringing the configuration on par with the reliable macOS approach.