### PR TITLE
test: extra windows ci install time

### DIFF
--- a/packages/cli/tests/commands/plugins.test.ts
+++ b/packages/cli/tests/commands/plugins.test.ts
@@ -122,7 +122,7 @@ describe('ElizaOS Plugin Commands', () => {
         throw error;
       }
     },
-    TEST_TIMEOUTS.INDIVIDUAL_TEST
+    TEST_TIMEOUTS.PLUGIN_INSTALLATION + 30000 // Add extra buffer for Windows CI
   );
 
   it(
@@ -147,7 +147,7 @@ describe('ElizaOS Plugin Commands', () => {
         throw error;
       }
     },
-    TEST_TIMEOUTS.INDIVIDUAL_TEST
+    TEST_TIMEOUTS.PLUGIN_INSTALLATION + 30000 // Add extra buffer for Windows CI
   );
 
   it(
@@ -172,7 +172,7 @@ describe('ElizaOS Plugin Commands', () => {
         throw error;
       }
     },
-    TEST_TIMEOUTS.INDIVIDUAL_TEST
+    TEST_TIMEOUTS.PLUGIN_INSTALLATION + 30000 // Add extra buffer for Windows CI
   );
 
   it(
@@ -211,7 +211,7 @@ describe('ElizaOS Plugin Commands', () => {
         throw error;
       }
     },
-    TEST_TIMEOUTS.INDIVIDUAL_TEST
+    TEST_TIMEOUTS.PLUGIN_INSTALLATION + 30000 // Add extra buffer for Windows CI
   );
 
   // installed-plugins list tests
@@ -222,7 +222,7 @@ describe('ElizaOS Plugin Commands', () => {
       // Should show previously installed plugins from other tests
       expect(result).toMatch(/@elizaos\/plugin-|github:/);
     },
-    TEST_TIMEOUTS.INDIVIDUAL_TEST
+    TEST_TIMEOUTS.PLUGIN_INSTALLATION + 30000 // Add extra buffer for Windows CI
   );
 
   // remove / aliases tests
@@ -257,7 +257,7 @@ describe('ElizaOS Plugin Commands', () => {
         throw error;
       }
     },
-    TEST_TIMEOUTS.INDIVIDUAL_TEST
+    TEST_TIMEOUTS.PLUGIN_INSTALLATION + 30000 // Add extra buffer for Windows CI
   );
 
   it(
@@ -300,7 +300,7 @@ describe('ElizaOS Plugin Commands', () => {
         throw error;
       }
     },
-    TEST_TIMEOUTS.INDIVIDUAL_TEST
+    TEST_TIMEOUTS.PLUGIN_INSTALLATION + 30000 // Add extra buffer for Windows CI
   );
 
   // Negative case tests
@@ -320,7 +320,7 @@ describe('ElizaOS Plugin Commands', () => {
         expect(output).toMatch(/not found in registry/);
       }
     },
-    TEST_TIMEOUTS.INDIVIDUAL_TEST
+    TEST_TIMEOUTS.PLUGIN_INSTALLATION + 30000 // Add extra buffer for Windows CI
   );
 
   it(
@@ -345,6 +345,6 @@ describe('ElizaOS Plugin Commands', () => {
         throw error;
       }
     },
-    TEST_TIMEOUTS.INDIVIDUAL_TEST
+    TEST_TIMEOUTS.PLUGIN_INSTALLATION + 30000 // Add extra buffer for Windows CI
   );
 });


### PR DESCRIPTION
This pull request adjusts the timeout settings for multiple test cases in the `ElizaOS Plugin Commands` test suite to improve reliability, particularly in Windows CI environments.

Test timeout adjustments:

* [`packages/cli/tests/commands/plugins.test.ts`](diffhunk://#diff-f375d68c04c129221417b38ab1b6678b5f76f51f6814f86d15390740ee316442L125-R125): Replaced `TEST_TIMEOUTS.INDIVIDUAL_TEST` with `TEST_TIMEOUTS.PLUGIN_INSTALLATION + 30000` to add an extra buffer for Windows CI across various test cases. [[1]](diffhunk://#diff-f375d68c04c129221417b38ab1b6678b5f76f51f6814f86d15390740ee316442L125-R125) [[2]](diffhunk://#diff-f375d68c04c129221417b38ab1b6678b5f76f51f6814f86d15390740ee316442L150-R150) [[3]](diffhunk://#diff-f375d68c04c129221417b38ab1b6678b5f76f51f6814f86d15390740ee316442L175-R175) [[4]](diffhunk://#diff-f375d68c04c129221417b38ab1b6678b5f76f51f6814f86d15390740ee316442L214-R214) [[5]](diffhunk://#diff-f375d68c04c129221417b38ab1b6678b5f76f51f6814f86d15390740ee316442L225-R225) [[6]](diffhunk://#diff-f375d68c04c129221417b38ab1b6678b5f76f51f6814f86d15390740ee316442L260-R260) [[7]](diffhunk://#diff-f375d68c04c129221417b38ab1b6678b5f76f51f6814f86d15390740ee316442L303-R303) [[8]](diffhunk://#diff-f375d68c04c129221417b38ab1b6678b5f76f51f6814f86d15390740ee316442L323-R323) [[9]](diffhunk://#diff-f375d68c04c129221417b38ab1b6678b5f76f51f6814f86d15390740ee316442L348-R348)