### PR TITLE
fix: starter avatar

### DIFF
--- a/packages/cli/src/characters/eliza.ts
+++ b/packages/cli/src/characters/eliza.ts
@@ -1,14 +1,4 @@
 import type { Character } from '@elizaos/core';
-import { existsSync, readFileSync } from 'node:fs';
-import { resolve, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const imagePath = resolve(__dirname, './elizaos-avatar.png');
-const avatar = existsSync(imagePath)
-  ? `data:image/png;base64,${readFileSync(imagePath).toString('base64')}`
-  : '';
 
 /**
  * Base character object representing Eliza - a versatile, helpful AI assistant.
@@ -19,7 +9,7 @@ const baseCharacter: Character = {
   plugins: ['@elizaos/plugin-sql', '@elizaos/plugin-bootstrap'],
   secrets: {},
   settings: {
-    avatar,
+    avatar: 'https://elizaos.github.io/eliza-avatars/Eliza/portrait.png',
   },
   system:
     'Respond to all messages in a helpful, conversational manner. Provide assistance on a wide range of topics, using knowledge when needed. Be concise but thorough, friendly but professional. Use humor when appropriate and be empathetic to user needs. Provide valuable information and insights when questions are asked.',

--- a/packages/project-starter/src/character.ts
+++ b/packages/project-starter/src/character.ts
@@ -41,6 +41,7 @@ export const character: Character = {
   ],
   settings: {
     secrets: {},
+    avatar: 'https://elizaos.github.io/eliza-avatars/Eliza/portrait.png',
   },
   system:
     'Respond to all messages in a helpful, conversational manner. Provide assistance on a wide range of topics, using knowledge when needed. Be concise but thorough, friendly but professional. Use humor when appropriate and be empathetic to user needs. Provide valuable information and insights when questions are asked.',


### PR DESCRIPTION
PR Description:
This PR fixes the starter project’s missing Eliza avatar by replacing the previous local image bundling method with a direct hosted image approach.

✅ Created a dedicated repo ([elizaOS/eliza-avatars](https://github.com/elizaOS/eliza-avatars)) to host agent avatars publicly.
✅ Replaced the monorepo’s local fs-based avatar loading with a direct URL reference to the hosted Eliza avatar.
✅ Removes unnecessary copying of avatar images into dist during builds.
✅ Simplifies the code and ensures new projects always have the Eliza avatar available without extra setup or local bundling.
✅ Keeps consistent behavior across local development, deployment, and all environments.

This improves consistency across the starter, monorepo, and deployment workflows while reducing code complexity.