### PR TITLE
feat(cli): remove --dir flag from create command

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -61,7 +61,6 @@ Initialize a new project, plugin, or agent.
 - **Arguments:**
   - `[name]`: Name for the project, plugin, or agent (optional)
 - **Options:**
-  - `-d, --dir <dir>`: Installation directory (default: `.`)
   - `-y, --yes`: Skip confirmation and use defaults (default: `false`)
   - `-t, --type <type>`: Type to create: 'project', 'plugin', 'agent', or 'tee' (default: 'project')
 

--- a/packages/cli/src/commands/create/index.ts
+++ b/packages/cli/src/commands/create/index.ts
@@ -19,7 +19,6 @@ function formatProjectType(type: string): string {
 export const create = new Command('create')
   .description('Create a new ElizaOS project, plugin, agent, or TEE project')
   .argument('[name]', 'name of the project/plugin/agent to create')
-  .option('--dir <dir>', 'directory to create the project in', '.')
   .option('--yes, -y', 'skip prompts and use defaults')
   .option('--type <type>', 'type of project to create (project, plugin, agent, tee)', 'project')
   .action(async (name?: string, opts?: any) => {
@@ -138,16 +137,14 @@ export const create = new Command('create')
         clack.intro(colors.inverse(` Creating ElizaOS ${introType} `));
       }
 
-      const targetDir = options.dir;
-
       // Handle different project types
       switch (projectType) {
         case 'plugin':
-          await createPlugin(projectName!, targetDir, isNonInteractive);
+          await createPlugin(projectName!, '.', isNonInteractive);
           break;
 
         case 'agent':
-          await createAgent(projectName!, targetDir, isNonInteractive);
+          await createAgent(projectName!, '.', isNonInteractive);
           break;
 
         case 'tee': {
@@ -168,7 +165,7 @@ export const create = new Command('create')
 
           await createTEEProject(
             projectName!,
-            targetDir,
+            '.',
             database,
             aiModel,
             embeddingModel,
@@ -196,7 +193,7 @@ export const create = new Command('create')
 
           await createProject(
             projectName!,
-            targetDir,
+            '.',
             database,
             aiModel,
             embeddingModel,

--- a/packages/cli/src/commands/create/types.ts
+++ b/packages/cli/src/commands/create/types.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
  * Zod schema for create command options validation
  */
 export const initOptionsSchema = z.object({
-  dir: z.string().default('.'),
   yes: z.boolean().default(false),
   type: z.enum(['project', 'plugin', 'agent', 'tee']).default('project'),
 });

--- a/packages/docs/docs/cli/create.md
+++ b/packages/docs/docs/cli/create.md
@@ -37,7 +37,6 @@ elizaos create --help
 
 | Option              | Description                                                      |
 | ------------------- | ---------------------------------------------------------------- |
-| `-d, --dir <dir>`   | Installation directory (default: `.`)                            |
 | `-y, --yes`         | Skip confirmation and use defaults (default: `false`)            |
 | `-t, --type <type>` | Type of template to use (`project`, `plugin`, `agent`, or `tee`) |
 | `--template <name>` | Use a specific template by name (e.g., `default`, `minimal`)     |


### PR DESCRIPTION
## Description

This PR removes the `--dir` flag from the create command to simplify the command interface.

## Changes

- Remove `--dir` option from create command definition
- Update all create function calls to use current directory (`'.''`)
- Remove `dir` property from `CreateOptions` schema
- Update documentation (CLI README and docs)

## Breaking Change

⚠️ **BREAKING CHANGE**: The `--dir` flag is no longer supported. Users must navigate to their desired directory before running the create command.

### Migration Guide

**Before:**
```bash
elizaos create my-project --dir /path/to/directory
```

**After:**
```bash
cd /path/to/directory
elizaos create my-project
```

## Testing

- ✅ Built the CLI package successfully
- ✅ No TypeScript errors
- ✅ Documentation updated
- ✅ No existing examples use the removed flag

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update