### PR TITLE
fix: merge duplicate model logging into a single adapter.log call

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1293,27 +1293,6 @@ export class AgentRuntime implements IAgentRuntime {
             timestamp: Date.now(),
           });
         }
-
-        await this.adapter.log({
-          entityId: this.agentId,
-          roomId: this.agentId,
-          body: {
-            modelType,
-            modelKey,
-            prompt: promptContent,
-            runId: this.getCurrentRunId(),
-            timestamp: Date.now(),
-            executionTime: elapsedTime,
-            provider: provider || this.models.get(modelKey)?.[0]?.provider || 'unknown',
-            actionContext: this.currentActionContext
-              ? {
-                  actionName: this.currentActionContext.actionName,
-                  actionId: this.currentActionContext.actionId,
-                }
-              : undefined,
-          },
-          type: `prompt:${modelKey}`,
-        });
       }
 
       // Keep the existing model logging for backward compatibility
@@ -1327,6 +1306,17 @@ export class AgentRuntime implements IAgentRuntime {
             ...(typeof params === 'object' && !Array.isArray(params) && params ? params : {}),
             prompt: promptContent,
           },
+          prompt: promptContent,
+          runId: this.getCurrentRunId(),
+          timestamp: Date.now(),
+          executionTime: elapsedTime,
+          provider: provider || this.models.get(modelKey)?.[0]?.provider || 'unknown',
+          actionContext: this.currentActionContext
+            ? {
+                actionName: this.currentActionContext.actionName,
+                actionId: this.currentActionContext.actionId,
+              }
+            : undefined,
           response:
             Array.isArray(response) && response.every((x) => typeof x === 'number')
               ? '[array]'
@@ -1334,6 +1324,7 @@ export class AgentRuntime implements IAgentRuntime {
         },
         type: `useModel:${modelKey}`,
       });
+      
       return response as R;
     } catch (error: any) {
       throw error;


### PR DESCRIPTION
Summary
Currently, we have duplicated model logging during useModel runtime:

![image](https://github.com/user-attachments/assets/1197f735-48db-48dc-a757-432fa61e0a6f)

The first log (prompt:${modelKey}) captures the prompt but lacks detailed context.

The second log (useModel:${modelKey}) captures parameters and the response.

In practice, this results in two logs for each model call, adding unnecessary noise in the GUI while the first log does not add meaningful additional detail.

What this PR does
Merges the two logs into a single adapter.log call.

