### PR TITLE
fix: update create command helper text + warning msg

### DIFF
--- a/packages/cli/src/commands/create/actions/creators.ts
+++ b/packages/cli/src/commands/create/actions/creators.ts
@@ -139,7 +139,6 @@ export async function createPlugin(
     console.info(`  cd ${pluginDirName}`);
     console.info(`  bun run build   # Build the plugin`);
     console.info(`\n  Common commands:`);
-    console.info(`  elizaos test   # Run tests`);
     console.info(`  elizaos dev    # Start development mode with hot reloading`);
     console.info(`  elizaos start  # Start in production mode\n`);
   });
@@ -273,7 +272,6 @@ export async function createTEEProject(
     console.info(`\nNext steps:`);
     console.info(`  cd ${projectName}`);
     console.info(`\n  Common commands:`);
-    console.info(`  elizaos test   # Run tests`);
     console.info(`  elizaos dev    # Start development mode with hot reloading`);
     console.info(`  elizaos start  # Start in production mode\n`);
   });
@@ -359,7 +357,6 @@ export async function createProject(
       console.info(`  cd ${projectName}`);
     }
     console.info(`\n  Common commands:`);
-    console.info(`  elizaos test   # Run tests`);
     console.info(`  elizaos dev    # Start development mode with hot reloading`);
     console.info(`  elizaos start  # Start in production mode\n`);
   };

--- a/packages/cli/src/commands/create/actions/creators.ts
+++ b/packages/cli/src/commands/create/actions/creators.ts
@@ -195,9 +195,9 @@ export async function createAgent(
   console.info(`Agent character created successfully at: ${agentFilePath}`);
   console.info(`\nTo use this agent:`);
   console.info(`  1. Start ElizaOS server with this character:`);
-  console.info(`     elizaos start --character ${agentName}`);
+  console.info(`     elizaos start --character ${agentFilePath}`);
   console.info(`\n  OR if a server is already running:`);
-  console.info(`     elizaos agent start --name ${agentName}`);
+  console.info(`     elizaos agent start --path ${agentFilePath}`);
 }
 
 /**

--- a/packages/cli/src/commands/create/actions/creators.ts
+++ b/packages/cli/src/commands/create/actions/creators.ts
@@ -102,6 +102,12 @@ export async function createPlugin(
   const pluginDirName = processedName.startsWith('plugin-')
     ? processedName
     : `plugin-${processedName}`;
+  
+  // Show warning if the final name differs from what the user entered
+  if (pluginDirName !== pluginName) {
+    console.info(`\n${colors.yellow(`warn: changing "${pluginName}" to "${pluginDirName}" to conform to plugin naming conventions\n`)}`);
+  }
+  
   const pluginTargetDir = join(targetDir, pluginDirName);
 
   // Validate target directory
@@ -131,8 +137,11 @@ export async function createPlugin(
     console.info(`\n${colors.green('✓')} Plugin "${pluginDirName}" created successfully!`);
     console.info(`\nNext steps:`);
     console.info(`  cd ${pluginDirName}`);
-    console.info(`  bun run build`);
-    console.info(`  elizaos dev or bun run dev\n`);
+    console.info(`  bun run build   # Build the plugin`);
+    console.info(`\n  Common commands:`);
+    console.info(`  elizaos test   # Run tests`);
+    console.info(`  elizaos dev    # Start development mode with hot reloading`);
+    console.info(`  elizaos start  # Start in production mode\n`);
   });
 }
 
@@ -186,7 +195,10 @@ export async function createAgent(
   console.info(`\n${colors.green('✓')} Agent "${agentName}" created successfully!`);
   console.info(`Agent character created successfully at: ${agentFilePath}`);
   console.info(`\nTo use this agent:`);
-  console.info(`  elizaos agent start --path ${agentFilePath}\n`);
+  console.info(`  1. Start ElizaOS server with this character:`);
+  console.info(`     elizaos start --character ${agentFilePath}`);
+  console.info(`\n  OR if a server is already running:`);
+  console.info(`     elizaos agent start --path ${agentFilePath}`);
 }
 
 /**
@@ -260,7 +272,10 @@ export async function createTEEProject(
     console.info(`\n${colors.green('✓')} TEE project "${projectName}" created successfully!`);
     console.info(`\nNext steps:`);
     console.info(`  cd ${projectName}`);
-    console.info(`  elizaos dev or bun run dev\n`);
+    console.info(`\n  Common commands:`);
+    console.info(`  elizaos test   # Run tests`);
+    console.info(`  elizaos dev    # Start development mode with hot reloading`);
+    console.info(`  elizaos start  # Start in production mode\n`);
   });
 }
 
@@ -340,8 +355,13 @@ export async function createProject(
     const displayName = projectName === '.' ? 'Project' : `Project "${projectName}"`;
     console.info(`\n${colors.green('✓')} ${displayName} initialized successfully!`);
     console.info(`\nNext steps:`);
-    console.info(`  cd ${projectName}`);
-    console.info(`  elizaos dev or bun run dev\n`);
+    if (projectName !== '.') {
+      console.info(`  cd ${projectName}`);
+    }
+    console.info(`\n  Common commands:`);
+    console.info(`  elizaos test   # Run tests`);
+    console.info(`  elizaos dev    # Start development mode with hot reloading`);
+    console.info(`  elizaos start  # Start in production mode\n`);
   };
 
   if (projectName === '.') {

--- a/packages/cli/src/commands/create/actions/creators.ts
+++ b/packages/cli/src/commands/create/actions/creators.ts
@@ -196,7 +196,7 @@ export async function createAgent(
   console.info(`Agent character created successfully at: ${agentFilePath}`);
   console.info(`\nTo use this agent:`);
   console.info(`  1. Start ElizaOS server with this character:`);
-  console.info(`     elizaos start --character ${agentFilePath}`);
+  console.info(`     elizaos start --character ${agentName}`);
   console.info(`\n  OR if a server is already running:`);
   console.info(`     elizaos agent start --name ${agentName}`);
 }

--- a/packages/cli/src/commands/create/actions/creators.ts
+++ b/packages/cli/src/commands/create/actions/creators.ts
@@ -105,7 +105,7 @@ export async function createPlugin(
   
   // Show warning if the final name differs from what the user entered
   if (pluginDirName !== pluginName) {
-    console.info(`\n${colors.yellow(`warn: changing "${pluginName}" to "${pluginDirName}" to conform to plugin naming conventions\n`)}`);
+    console.warn(`\nWarning: changing "${pluginName}" to "${pluginDirName}" to conform to plugin naming conventions\n`);
   }
   
   const pluginTargetDir = join(targetDir, pluginDirName);

--- a/packages/cli/src/commands/create/actions/creators.ts
+++ b/packages/cli/src/commands/create/actions/creators.ts
@@ -198,7 +198,7 @@ export async function createAgent(
   console.info(`  1. Start ElizaOS server with this character:`);
   console.info(`     elizaos start --character ${agentFilePath}`);
   console.info(`\n  OR if a server is already running:`);
-  console.info(`     elizaos agent start --path ${agentFilePath}`);
+  console.info(`     elizaos agent start --name ${agentName}`);
 }
 
 /**


### PR DESCRIPTION
this updates the helper text to use elizaos commands and also gives more descript instructions about what to do after creating a plugin project or agent.

it also flashes a warning in case the plugin name gets augmented so the user isnt surprised

this doesnt change code, only logs and warnings.