### PR TITLE
chore: refine chat opening toasts for clarity

### DIFF
--- a/packages/client/src/components/chat.tsx
+++ b/packages/client/src/components/chat.tsx
@@ -421,9 +421,22 @@ export default function Chat({
           const isEmpty = (latestMessages?.messages?.length ?? 0) === 0;
 
           if (hasAutoName && isEmpty) {
-            clientLogger.info(
-              '[Chat] Latest DM channel is empty with auto-generated name or has no messages, reusing instead of creating.'
-            );
+            const isAlreadyInLatest =
+            chatState.currentDmChannelId === latestChannel.id;
+
+            if (isAlreadyInLatest) {
+              toast({
+                title: `Already in a fresh chat`,
+                description: `You're already in a new chat with ${targetAgentData?.name || 'the agent'}.`,
+              });
+            } else {
+              updateChatState({ currentDmChannelId: latestChannel.id });
+              toast({
+                title: `Chat opened`,
+                description: `You can now start chatting with ${targetAgentData?.name || 'the agent'}.`,
+              });
+            }
+            
             updateChatState({ currentDmChannelId: latestChannel.id });
             return;
           } else {
@@ -457,6 +470,10 @@ export default function Chat({
         updateChatState({ currentDmChannelId: null, input: '' });
       } finally {
         updateChatState({ isCreatingDM: false });
+        toast({
+          title: `Chat opened`,
+          description: `You can now start chatting with ${targetAgentData?.name || 'the agent'}.`,
+        });
       }
     },
     [chatType, createDmChannelMutation, updateChatState, safeScrollToBottom, latestChannel]


### PR DESCRIPTION
### Changes
- Adds clear toast feedback when opening or reusing a fresh DM channel:
  - Shows "Already in a fresh chat" if the user is already in the latest empty DM channel.
  - Shows "Chat opened" if switching to a fresh empty DM channel automatically.
- Helps users understand chat state transitions without ambiguity.
- Keeps UX clean and warm without noisy or redundant toasts.
