### PR TITLE
fix: add explicit boolean conversion for environment variable checks

### DIFF
--- a/packages/cli/src/characters/eliza.ts
+++ b/packages/cli/src/characters/eliza.ts
@@ -197,13 +197,13 @@ export function getElizaCharacter(): Character {
     '@elizaos/plugin-sql',
 
     // Text-only plugins (no embedding support)
-    ...(process.env.ANTHROPIC_API_KEY ? ['@elizaos/plugin-anthropic'] : []),
-    ...(process.env.OPENROUTER_API_KEY ? ['@elizaos/plugin-openrouter'] : []),
+    ...(!!process.env.ANTHROPIC_API_KEY ? ['@elizaos/plugin-anthropic'] : []),
+    ...(!!process.env.OPENROUTER_API_KEY ? ['@elizaos/plugin-openrouter'] : []),
 
     // Embedding-capable plugins last (lowest priority for embedding fallback)
-    ...(process.env.OPENAI_API_KEY ? ['@elizaos/plugin-openai'] : []),
-    ...(process.env.OLLAMA_API_ENDPOINT ? ['@elizaos/plugin-ollama'] : []),
-    ...(process.env.GOOGLE_GENERATIVE_AI_API_KEY ? ['@elizaos/plugin-google-genai'] : []),
+    ...(!!process.env.OPENAI_API_KEY ? ['@elizaos/plugin-openai'] : []),
+    ...(!!process.env.OLLAMA_API_ENDPOINT ? ['@elizaos/plugin-ollama'] : []),
+    ...(!!process.env.GOOGLE_GENERATIVE_AI_API_KEY ? ['@elizaos/plugin-google-genai'] : []),
     ...(!process.env.GOOGLE_GENERATIVE_AI_API_KEY &&
     !process.env.OLLAMA_API_ENDPOINT &&
     !process.env.OPENAI_API_KEY


### PR DESCRIPTION
## Summary

This PR adds explicit boolean conversion using the `!!` operator for environment variable checks in the eliza character configuration.

## Changes

- Added `!!` operator to convert environment variables to boolean values explicitly
- Affected environment variables:
  - `ANTHROPIC_API_KEY`
  - `OPENROUTER_API_KEY`
  - `OPENAI_API_KEY`
  - `OLLAMA_API_ENDPOINT`
  - `GOOGLE_GENERATIVE_AI_API_KEY`

## Motivation

- Ensures consistent behavior across different environments
- Prevents potential issues with truthy/falsy values
- Makes the boolean conversion explicit and more readable

## Testing

The changes are straightforward boolean conversions that maintain the existing logic while making it more explicit.