### PR TITLE
fix: remove skip-verification flag from plugin test commands

### DIFF
--- a/packages/cli/tests/commands/plugins.test.ts
+++ b/packages/cli/tests/commands/plugins.test.ts
@@ -106,14 +106,11 @@ describe('ElizaOS Plugin Commands', () => {
     'plugins add installs a plugin',
     async () => {
       try {
-        execSync(
-          `${elizaosCmd} plugins add @elizaos/plugin-xmtp --skip-env-prompt --skip-verification`,
-          {
-            stdio: 'pipe',
-            timeout: TEST_TIMEOUTS.PLUGIN_INSTALLATION,
-            cwd: projectDir,
-          }
-        );
+        execSync(`${elizaosCmd} plugins add @elizaos/plugin-xmtp --skip-env-prompt`, {
+          stdio: 'pipe',
+          timeout: TEST_TIMEOUTS.PLUGIN_INSTALLATION,
+          cwd: projectDir,
+        });
 
         const packageJson = await readFile(join(projectDir, 'package.json'), 'utf8');
         expect(packageJson).toContain('@elizaos/plugin-xmtp');
@@ -131,14 +128,11 @@ describe('ElizaOS Plugin Commands', () => {
     'plugins install alias works',
     async () => {
       try {
-        execSync(
-          `${elizaosCmd} plugins install @elizaos/plugin-mcp --skip-env-prompt --skip-verification`,
-          {
-            stdio: 'pipe',
-            timeout: TEST_TIMEOUTS.PLUGIN_INSTALLATION,
-            cwd: projectDir,
-          }
-        );
+        execSync(`${elizaosCmd} plugins install @elizaos/plugin-mcp --skip-env-prompt`, {
+          stdio: 'pipe',
+          timeout: TEST_TIMEOUTS.PLUGIN_INSTALLATION,
+          cwd: projectDir,
+        });
 
         const packageJson = await readFile(join(projectDir, 'package.json'), 'utf8');
         expect(packageJson).toContain('@elizaos/plugin-mcp');
@@ -156,14 +150,11 @@ describe('ElizaOS Plugin Commands', () => {
     'plugins add supports third-party plugins',
     async () => {
       try {
-        execSync(
-          `${elizaosCmd} plugins add @fleek-platform/eliza-plugin-mcp --skip-env-prompt --skip-verification`,
-          {
-            stdio: 'pipe',
-            timeout: TEST_TIMEOUTS.PLUGIN_INSTALLATION,
-            cwd: projectDir,
-          }
-        );
+        execSync(`${elizaosCmd} plugins add @fleek-platform/eliza-plugin-mcp --skip-env-prompt`, {
+          stdio: 'pipe',
+          timeout: TEST_TIMEOUTS.PLUGIN_INSTALLATION,
+          cwd: projectDir,
+        });
 
         const packageJson = await readFile(join(projectDir, 'package.json'), 'utf8');
         expect(packageJson).toContain('@fleek-platform/eliza-plugin-mcp');
@@ -183,7 +174,7 @@ describe('ElizaOS Plugin Commands', () => {
       try {
         // First GitHub URL install
         execSync(
-          `${elizaosCmd} plugins add https://github.com/elizaos-plugins/plugin-video-understanding --skip-env-prompt --skip-verification`,
+          `${elizaosCmd} plugins add https://github.com/elizaos-plugins/plugin-video-understanding --skip-env-prompt`,
           {
             stdio: 'pipe',
             timeout: TEST_TIMEOUTS.PLUGIN_INSTALLATION,
@@ -196,7 +187,7 @@ describe('ElizaOS Plugin Commands', () => {
 
         // Second GitHub URL install with shorthand syntax
         execSync(
-          `${elizaosCmd} plugins add github:elizaos-plugins/plugin-openrouter#1.x --skip-env-prompt --skip-verification`,
+          `${elizaosCmd} plugins add github:elizaos-plugins/plugin-openrouter#1.x --skip-env-prompt`,
           {
             stdio: 'pipe',
             timeout: TEST_TIMEOUTS.PLUGIN_INSTALLATION,
@@ -232,14 +223,11 @@ describe('ElizaOS Plugin Commands', () => {
     'plugins remove uninstalls a plugin',
     async () => {
       try {
-        execSync(
-          `${elizaosCmd} plugins add @elizaos/plugin-elevenlabs --skip-env-prompt --skip-verification`,
-          {
-            stdio: 'pipe',
-            timeout: TEST_TIMEOUTS.PLUGIN_INSTALLATION,
-            cwd: projectDir,
-          }
-        );
+        execSync(`${elizaosCmd} plugins add @elizaos/plugin-elevenlabs --skip-env-prompt`, {
+          stdio: 'pipe',
+          timeout: TEST_TIMEOUTS.PLUGIN_INSTALLATION,
+          cwd: projectDir,
+        });
 
         let packageJson = await readFile(join(projectDir, 'package.json'), 'utf8');
         expect(packageJson).toContain('@elizaos/plugin-elevenlabs');
@@ -274,7 +262,7 @@ describe('ElizaOS Plugin Commands', () => {
 
         // Add all plugins first
         for (const plugin of plugins) {
-          execSync(`${elizaosCmd} plugins add ${plugin} --skip-env-prompt --skip-verification`, {
+          execSync(`${elizaosCmd} plugins add ${plugin} --skip-env-prompt`, {
             stdio: 'pipe',
             timeout: TEST_TIMEOUTS.PLUGIN_INSTALLATION,
             cwd: projectDir,
@@ -330,7 +318,7 @@ describe('ElizaOS Plugin Commands', () => {
     async () => {
       try {
         execSync(
-          `${elizaosCmd} plugins add github:elizaos-plugins/plugin-farcaster#1.x --skip-env-prompt --skip-verification`,
+          `${elizaosCmd} plugins add github:elizaos-plugins/plugin-farcaster#1.x --skip-env-prompt`,
           {
             stdio: 'pipe',
             timeout: TEST_TIMEOUTS.PLUGIN_INSTALLATION,


### PR DESCRIPTION
This PR removes the --skip-verification flag from all plugin test commands in the plugins.test.ts file. The flag appears to be no longer needed or recognized in the current version of the CLI.