### PR TITLE
fix: add bun.lock to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+bun.lock
 /out
 
 .env
@@ -176,5 +177,5 @@ tasks/
 **/.roo/
 **/.roomodes/
 **/.taskmaster/
-**/.windsurfrules/ 
+**/.windsurfrules/
 .roomodes


### PR DESCRIPTION
This PR adds `bun.lock` to the .gitignore file to prevent the Bun package manager lock file from being tracked in version control.

## Changes
- Added `bun.lock` to .gitignore

## Why?
Lock files for package managers should typically be ignored in git repositories to avoid merge conflicts and unnecessary version control tracking of dependency resolution states.