### PR TITLE
fix: improve client path resolution for global CLI installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+bun.lock
 /out
 
 .env
@@ -176,5 +177,5 @@ tasks/
 **/.roo/
 **/.roomodes/
 **/.taskmaster/
-**/.windsurfrules/ 
+**/.windsurfrules/
 .roomodes


### PR DESCRIPTION
## Description

Fixes 'Client application not found' error when running ElizaOS from global CLI installation.

## Problem

When ElizaOS is installed globally via `bun install -g @elizaos/cli`, the server cannot find the client dist files because it only looks for them relative to the server package location, which doesn't work for global installations.

## Solution

1. Added multiple path resolution strategies:
   - First tries the development path (relative to server package)
   - Falls back to using `require.resolve('@elizaos/cli/package.json')` to find the CLI package in global installations
   
2. Applied the same logic to both:
   - Static file serving middleware
   - SPA catch-all route handler

## Testing

1. Install CLI globally: `bun install -g @elizaos/cli`
2. Run `elizaos` command
3. Navigate to http://localhost:3000/chat
4. Refresh the page - should load correctly without 'Client application not found' error

## Changes

- Enhanced path resolution in `packages/server/src/index.ts` to support global installations