### PR TITLE
fix: Smooth progressive reveal with cap, remove AIWriter swap causing hiccups

### DIFF
--- a/packages/client/src/components/ui/chat/animated-markdown.tsx
+++ b/packages/client/src/components/ui/chat/animated-markdown.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import * as React from 'react';
-import AIWriter from 'react-aiwriter';
 import { Markdown } from './markdown';
 
 interface AnimatedMarkdownProps {
@@ -10,6 +9,7 @@ interface AnimatedMarkdownProps {
   variant?: 'user' | 'agent';
   shouldAnimate?: boolean;
   messageId?: string;
+  maxDurationMs?: number; // Optional prop to control cap duration
 }
 
 export const AnimatedMarkdown: React.FC<AnimatedMarkdownProps> = ({
@@ -18,38 +18,38 @@ export const AnimatedMarkdown: React.FC<AnimatedMarkdownProps> = ({
   variant = 'agent',
   shouldAnimate = false,
   messageId,
+  maxDurationMs = 10000,
 }) => {
-  const [animationComplete, setAnimationComplete] = React.useState(!shouldAnimate);
+  const [visibleText, setVisibleText] = React.useState(shouldAnimate ? '' : children);
 
-  // Reset animation state when message changes
   React.useEffect(() => {
-    if (shouldAnimate) {
-      setAnimationComplete(false);
-      // Estimate animation time based on text length (50ms per character roughly)
-      const estimatedTime = Math.min(children.length * 50, 3000);
-      const timer = setTimeout(() => {
-        setAnimationComplete(true);
-      }, estimatedTime);
-
-      return () => clearTimeout(timer);
-    } else {
-      setAnimationComplete(true);
+    if (!shouldAnimate) {
+      setVisibleText(children);
+      return;
     }
-  }, [children, shouldAnimate, messageId]);
 
-  // If not animating or animation is complete, render markdown
-  if (!shouldAnimate || animationComplete) {
-    return (
-      <Markdown className={className} variant={variant}>
-        {children}
-      </Markdown>
-    );
-  }
+    const TYPING_INTERVAL = 20;
+    const totalChars = children.length;
+    const totalSteps = Math.ceil(maxDurationMs / TYPING_INTERVAL);
+    const charsPerStep = Math.max(1, Math.ceil(totalChars / totalSteps));
 
-  // During animation, show AIWriter with plain text
+    let i = 0;
+    const interval = setInterval(() => {
+      i += charsPerStep;
+      if (i >= totalChars) {
+        setVisibleText(children);
+        clearInterval(interval);
+      } else {
+        setVisibleText(children.slice(0, i));
+      }
+    }, TYPING_INTERVAL);
+
+    return () => clearInterval(interval);
+  }, [children, shouldAnimate, messageId, maxDurationMs]);
+
   return (
-    <div className={className}>
-      <AIWriter>{children}</AIWriter>
-    </div>
+    <Markdown className={className} variant={variant}>
+      {visibleText}
+    </Markdown>
   );
 };

--- a/packages/client/src/components/ui/chat/animated-markdown.tsx
+++ b/packages/client/src/components/ui/chat/animated-markdown.tsx
@@ -23,31 +23,29 @@ export const AnimatedMarkdown: React.FC<AnimatedMarkdownProps> = ({
   const [visibleText, setVisibleText] = React.useState(shouldAnimate ? '' : children);
 
   React.useEffect(() => {
-    if (
-      !shouldAnimate || 
-      !children || 
-      children.length === 0 ||
-      maxDurationMs <= 0
-    ) {
+    if (!shouldAnimate || !children.trim()) {
       setVisibleText(children);
       return;
     }
+  
+    const safeDuration = Math.max(1000, maxDurationMs);
 
     setVisibleText('');
 
     const TYPING_INTERVAL = 20;
     const totalChars = children.length;
-    const totalSteps = Math.ceil(maxDurationMs / TYPING_INTERVAL);
+    const totalSteps = Math.ceil(safeDuration / TYPING_INTERVAL);
     const charsPerStep = Math.max(1, Math.ceil(totalChars / totalSteps));
 
-    let i = 0;
+
+    let visibleCharCount = 0;
     const interval = setInterval(() => {
-      i += charsPerStep;
-      if (i >= totalChars) {
+      visibleCharCount += charsPerStep;
+      if (visibleCharCount >= totalChars) {
         setVisibleText(children);
         clearInterval(interval);
       } else {
-        setVisibleText(children.slice(0, i));
+        setVisibleText(children.slice(0, visibleCharCount));
       }
     }, TYPING_INTERVAL);
 

--- a/packages/client/src/components/ui/chat/animated-markdown.tsx
+++ b/packages/client/src/components/ui/chat/animated-markdown.tsx
@@ -23,7 +23,12 @@ export const AnimatedMarkdown: React.FC<AnimatedMarkdownProps> = ({
   const [visibleText, setVisibleText] = React.useState(shouldAnimate ? '' : children);
 
   React.useEffect(() => {
-    if (!shouldAnimate || children.length === 0 || maxDurationMs <= 0) {
+    if (
+      !shouldAnimate || 
+      !children || 
+      children.length === 0 ||
+      maxDurationMs <= 0
+    ) {
       setVisibleText(children);
       return;
     }

--- a/packages/client/src/components/ui/chat/animated-markdown.tsx
+++ b/packages/client/src/components/ui/chat/animated-markdown.tsx
@@ -23,10 +23,12 @@ export const AnimatedMarkdown: React.FC<AnimatedMarkdownProps> = ({
   const [visibleText, setVisibleText] = React.useState(shouldAnimate ? '' : children);
 
   React.useEffect(() => {
-    if (!shouldAnimate) {
+    if (!shouldAnimate || children.length === 0 || maxDurationMs <= 0) {
       setVisibleText(children);
       return;
     }
+
+    setVisibleText('');
 
     const TYPING_INTERVAL = 20;
     const totalChars = children.length;


### PR DESCRIPTION
Summary
This PR refactors AnimatedMarkdown to replace the previous AIWriter + Markdown swap-based animation with a smooth, consistent, progressive reveal using Markdown alone, while capping animation duration for long texts.

Previous Implementation Recap:
Used:

<AIWriter> for animated typing effect.

Switched to <Markdown> after an estimated time (message length * 50ms, capped at 3000ms) via a setTimeout.

Issues:

Visible hiccup/jump when swapping from AIWriter to Markdown due to DOM replacement and different rendering structures.

Estimated duration was imprecise, relying on a fixed guess that could mismatch actual animation length.

For long messages, either animation ran too long or felt inconsistent, leading to delays in user reading.

Increased complexity with managing animationComplete and swap logic.

Changes in this PR:
✅ 1️⃣ Replaces AIWriter with Markdown consistently.

Avoids swapping DOM elements, eliminating layout reflow hiccups.

✅ 2️⃣ Implements a smooth, progressive reveal animation inside Markdown.

Reveals characters at a controlled rate (20ms interval).

✅ 3️⃣ Caps animation duration for long texts.

Adds maxDurationMs (default 10000ms).

Dynamically calculates charsPerStep:

Ensures all text is revealed within max duration.

Allows long texts to animate quickly without blocking user reading.

✅ 4️⃣ Removes unused animationComplete and estimatedTime guesswork.

Simplifies state management.

Ensures accurate, reliable animation lifecycle.

