### PR TITLE
fix: correct Google Generative AI plugin installation

### DIFF
--- a/packages/cli/src/commands/create/actions/setup.ts
+++ b/packages/cli/src/commands/create/actions/setup.ts
@@ -313,7 +313,7 @@ function resolveModelToPlugin(modelName: string): string | null {
     anthropic: 'anthropic',
     openrouter: 'openrouter',
     ollama: 'ollama',
-    google: 'google',
+    google: 'google-genai',
   };
 
   return modelToPlugin[modelName] || null;

--- a/packages/cli/src/utils/spinner-utils.ts
+++ b/packages/cli/src/utils/spinner-utils.ts
@@ -2,6 +2,7 @@ import { execa } from 'execa';
 import * as clack from '@clack/prompts';
 import colors from 'yoctocolors';
 import { parseBooleanFromText } from '@elizaos/core';
+import { logger } from '../logger';
 
 /**
  * Check if quiet mode is enabled

--- a/packages/cli/src/utils/spinner-utils.ts
+++ b/packages/cli/src/utils/spinner-utils.ts
@@ -1,8 +1,7 @@
 import { execa } from 'execa';
 import * as clack from '@clack/prompts';
 import colors from 'yoctocolors';
-import { parseBooleanFromText } from '@elizaos/core';
-import { logger } from '../logger';
+import { parseBooleanFromText, logger } from '@elizaos/core';
 
 /**
  * Check if quiet mode is enabled


### PR DESCRIPTION
## Description

This PR fixes the Google Generative AI plugin installation during the `elizaos create` command.

## Problem

When users select "Google Generative AI" during project creation:
1. The system was trying to install `@elizaos/plugin-google` instead of `@elizaos/plugin-google-genai`
2. A `ReferenceError: logger is not defined` error occurred in `spinner-utils.ts`

## Solution

1. **Fixed plugin mapping**: Changed the mapping from `google` → `google` to `google` → `google-genai` in `resolveModelToPlugin()`
2. **Added missing import**: Added the missing `logger` import in `spinner-utils.ts`

## Changes

- `packages/cli/src/commands/create/actions/setup.ts`: Updated plugin mapping
- `packages/cli/src/utils/spinner-utils.ts`: Added logger import

## Testing

After this fix:
- Running `elizaos create` and selecting "Google Generative AI" will correctly attempt to install `@elizaos/plugin-google-genai`
- No more `logger is not defined` errors during plugin installation

## Related Issue

Fixes the issue where the create command fails with wrong plugin name and missing logger import.