### PR TITLE
fix: update TypeScript return types for strict compliance

### DIFF
--- a/packages/plugin-starter/src/plugin.ts
+++ b/packages/plugin-starter/src/plugin.ts
@@ -1,6 +1,7 @@
 import type { Plugin } from '@elizaos/core';
 import {
   type Action,
+  type ActionResult,
   type Content,
   type GenerateTextParams,
   type HandlerCallback,
@@ -69,11 +70,11 @@ const helloWorldAction: Action = {
     _options: any,
     callback?: HandlerCallback,
     _responses?: Memory[]
-  ) => {
+  ): Promise<ActionResult> => {
     try {
       logger.info('Handling HELLO_WORLD action');
 
-      // Simple response content
+      // Simple response content for callback
       const responseContent: Content = {
         text: 'hello world!',
         actions: ['HELLO_WORLD'],
@@ -85,10 +86,21 @@ const helloWorldAction: Action = {
         await callback(responseContent);
       }
 
-      return responseContent;
+      // Return ActionResult
+      return {
+        text: 'hello world!',
+        success: true,
+        data: {
+          actions: ['HELLO_WORLD'],
+          source: message.content.source,
+        },
+      };
     } catch (error) {
       logger.error('Error in HELLO_WORLD action:', error);
-      throw error;
+      return {
+        success: false,
+        error: error instanceof Error ? error : new Error(String(error)),
+      };
     }
   },
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -476,22 +476,25 @@ export class AgentServer {
       // Agent-specific media serving - only serve files from agent-specific directories
       this.app.get(
         '/media/uploads/agents/:agentId/:filename',
-        (req: express.Request, res: express.Response) => {
+        (req: express.Request, res: express.Response): void => {
           const agentId = req.params.agentId as string;
           const filename = req.params.filename as string;
           const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
           if (!uuidRegex.test(agentId)) {
-            return res.status(400).json({ error: 'Invalid agent ID format' });
+            res.status(400).json({ error: 'Invalid agent ID format' });
+            return;
           }
           const sanitizedFilename = basename(filename);
           const agentUploadsPath = join(uploadsBasePath, agentId);
           const filePath = join(agentUploadsPath, sanitizedFilename);
           if (!filePath.startsWith(agentUploadsPath)) {
-            return res.status(403).json({ error: 'Access denied' });
+            res.status(403).json({ error: 'Access denied' });
+            return;
           }
 
           if (!fs.existsSync(filePath)) {
-            return res.status(404).json({ error: 'File does not exist!!!!!!!' });
+            res.status(404).json({ error: 'File does not exist!!!!!!!' });
+            return;
           }
 
           res.sendFile(sanitizedFilename, { root: agentUploadsPath }, (err) => {
@@ -511,18 +514,23 @@ export class AgentServer {
 
       this.app.get(
         '/media/generated/:agentId/:filename',
-        (req: express.Request<{ agentId: string; filename: string }>, res: express.Response) => {
+        (
+          req: express.Request<{ agentId: string; filename: string }>,
+          res: express.Response
+        ): void => {
           const agentId = req.params.agentId;
           const filename = req.params.filename;
           const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
           if (!uuidRegex.test(agentId)) {
-            return res.status(400).json({ error: 'Invalid agent ID format' });
+            res.status(400).json({ error: 'Invalid agent ID format' });
+            return;
           }
           const sanitizedFilename = basename(filename);
           const agentGeneratedPath = join(generatedBasePath, agentId);
           const filePath = join(agentGeneratedPath, sanitizedFilename);
           if (!filePath.startsWith(agentGeneratedPath)) {
-            return res.status(403).json({ error: 'Access denied' });
+            res.status(403).json({ error: 'Access denied' });
+            return;
           }
           res.sendFile(filePath, (err) => {
             if (err) {


### PR DESCRIPTION
## Summary
- Update action handlers to return `Promise<ActionResult>` for proper type compliance
- Fix Express route handlers to have explicit `void` return type
- Add proper error handling with ActionResult type structure

## Changes
- `packages/plugin-starter/src/plugin.ts`: Updated helloWorldAction handler to return Promise<ActionResult> with proper success/error handling
- `packages/server/src/index.ts`: Fixed Express route handlers to have void return type and removed implicit returns

## Test Plan
- [ ] Build passes with `bun run build`
- [ ] Type checking passes with `bun run typecheck`
- [ ] All tests pass with `bun test`