### PR TITLE
fix: Refine LLM provider selection prompt to reduce unnecessary provider use and improve reply speed

### DIFF
--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -49,12 +49,13 @@ IMPORTANT ACTION ORDERING RULES:
 - Use IGNORE only when you should not respond at all
 
 IMPORTANT PROVIDER SELECTION RULES:
+- Only include providers if they are needed to respond accurately.
 - If the message mentions images, photos, pictures, attachments, or visual content, OR if you see "(Attachments:" in the conversation, you MUST include "ATTACHMENTS" in your providers list
 - If the message asks about or references specific people, include "ENTITIES" in your providers list  
 - If the message asks about relationships or connections between people, include "RELATIONSHIPS" in your providers list
 - If the message asks about facts or specific information, include "FACTS" in your providers list
 - If the message asks about the environment or world context, include "WORLD" in your providers list
-- If you need external knowledge, information, or context beyond the current conversation to provide a helpful response, include "KNOWLEDGE" in your providers list
+- If no additional context is needed, you may leave the providers list empty.
 
 IMPORTANT CODE BLOCK FORMATTING RULES:
 - If {{agentName}} includes code examples, snippets, or multi-line code in the response, ALWAYS wrap the code with \`\`\` fenced code blocks (specify the language if known, e.g., \`\`\`python).


### PR DESCRIPTION
Currently, the LLM often selects the KNOWLEDGE provider by default, even though we do not include the knowledge plugin. This is because our prompt instructed the LLM to select KNOWLEDGE under broad conditions. We should instead handle KNOWLEDGE selection explicitly within the plugin-knowledge provider logic when needed.

Additionally, the LLM currently tries to select at least one provider even when none are needed. This causes the system to run two large model calls per user message:

First in bootstrap messageReceivedHandler

Then in the reply action (since the response is not classified as simple if any provider is included).

This slows down reply speeds significantly for simple REPLY-only interactions.

In this PR:

Removed the KNOWLEDGE provider selection rule from the prompt.

Added:

```
Only include providers if they are needed to respond accurately.
If no additional context is needed, you may leave the providers list empty.
```

to the prompt instructions.

This change reduces unnecessary provider selection by the LLM, allowing simple REPLY actions to bypass the second large model call, significantly improving reply speed for straightforward messages.

