### PR TITLE
fix: clarifying prompt exclusivity for IGNORE

### DIFF
--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -47,6 +47,7 @@ IMPORTANT ACTION ORDERING RULES:
 - REPLY is used to acknowledge and inform the user about what you're going to do
 - Follow-up actions execute the actual tasks after acknowledgment
 - Use IGNORE only when you should not respond at all
+- If you use IGNORE, do not include any other actions. IGNORE should be used alone when you should not respond or take any actions.
 
 IMPORTANT PROVIDER SELECTION RULES:
 - Only include providers if they are needed to respond accurately.


### PR DESCRIPTION
Currently, the LLM sometimes outputs:

```
<thought>User acknowledged the code snippet with thanks - can end conversation naturally</thought>
<actions>REPLY,IGNORE</actions>
<providers></providers>
```

This causes:

The response to not be marked as simple, which triggers an extra large LLM call in the reply action path.

Unnecessary compute and slower user-visible reply speeds.

This happens because:

Our prompt says:

“Use IGNORE only when you should not respond at all”

but it does not explicitly forbid combining IGNORE with other actions.

What this PR does
✅ Adds one line to the messageHandlerTemplate prompt:

```
If you use IGNORE, do not include any other actions. IGNORE should be used alone when you should not respond or take any actions.
```

Impact
✅ Prevents the LLM from outputting REPLY,IGNORE together.
✅ Allows valid IGNORE to be emitted cleanly without extra actions.
✅ Enables simple REPLY detection (isSimple) to work correctly, skipping unnecessary large LLM calls and improving reply speed.
✅ Reduces compute waste across message handling and reply paths.