### PR TITLE
feat: add V1 to V2 character conversion on import with plugin matching

### DIFF
--- a/packages/client/src/components/character-form.tsx
+++ b/packages/client/src/components/character-form.tsx
@@ -8,7 +8,7 @@ import { AVATAR_IMAGE_MAX_SIZE, FIELD_REQUIREMENT_TYPE, FIELD_REQUIREMENTS } fro
 import { useToast } from '@/hooks/use-toast';
 import { exportCharacterAsJson } from '@/lib/export-utils';
 import { compressImage } from '@/lib/utils';
-import type { Agent } from '@elizaos/core';
+import type { Agent, Character } from '@elizaos/core';
 import type React from 'react';
 import {
   type FormEvent,
@@ -111,7 +111,7 @@ export type CharacterFormProps = {
     addArrayItem?: <T>(path: string, item: T) => void;
     removeArrayItem?: (path: string, index: number) => void;
     updateSetting?: (path: string, value: any) => void;
-    importAgent?: (value: Agent) => void;
+    importAgent?: (value: Character) => void;
     [key: string]: any;
   };
   onTemplateChange?: () => void;
@@ -755,7 +755,7 @@ export default function CharacterForm({
 
     try {
       const text = await file.text();
-      let json: Agent = JSON.parse(text);
+      let json: Character = JSON.parse(text);
 
       if (isV1Character(json)) {
         json = convertCharacter(json);
@@ -856,7 +856,7 @@ export default function CharacterForm({
       const template = getTemplateById(templateId);
       if (template && setCharacterValue.importAgent) {
         // Use the importAgent function to set all template values at once
-        setCharacterValue.importAgent(template.template as Agent);
+        setCharacterValue.importAgent(template.template as Character);
         // Notify parent of template change
         onTemplateChange?.();
       }

--- a/packages/client/src/hooks/use-agent-update.ts
+++ b/packages/client/src/hooks/use-agent-update.ts
@@ -1,5 +1,5 @@
 import { usePartialUpdate } from '@/hooks/use-partial-update';
-import type { Agent } from '@elizaos/core';
+import type { Agent, Character } from '@elizaos/core';
 import { useCallback, useRef } from 'react';
 
 /**
@@ -30,7 +30,7 @@ export function useAgentUpdate(initialAgent: Agent) {
    * @param templateAgent The agent template to import
    */
   const importAgent = useCallback(
-    (templateAgent: Agent) => {
+    (templateAgent: Character) => {
       // For each top-level property in the template, update it in the current agent
       Object.entries(templateAgent).forEach(([key, value]) => {
         if (key === 'settings' && value) {

--- a/packages/client/src/hooks/use-character-convert.ts
+++ b/packages/client/src/hooks/use-character-convert.ts
@@ -1,4 +1,4 @@
-import { Agent, Content } from '@elizaos/core';
+import { Character, Content } from '@elizaos/core';
 import { usePlugins } from '@/hooks/use-plugins';
 
 const PROVIDER_PLUGIN_MAPPINGS: Record<string, string> = {
@@ -13,7 +13,7 @@ const CLIENT_PLUGIN_MAPPINGS: Record<string, string> = {
 
 const ESSENTIAL_PLUGINS = ['@elizaos/plugin-sql', '@elizaos/plugin-bootstrap'];
 
-export interface V1Character extends Agent {
+export interface V1Character extends Character {
     name: string;
     lore?: string[];
     clients?: string[];
@@ -91,7 +91,6 @@ export function useConvertCharacter() {
     ) ?? [];
 
     const plugins = matchPlugins(v1);
-    const now = Date.now();
     const v2 = {
       name: v1.name,
       username: v1.username,
@@ -104,8 +103,6 @@ export function useConvertCharacter() {
       adjectives: v1.adjectives,
       messageExamples,
       postExamples: v1.postExamples,
-      createdAt: now,
-      updatedAt: now
     };
 
     return v2;

--- a/packages/client/src/hooks/use-character-convert.ts
+++ b/packages/client/src/hooks/use-character-convert.ts
@@ -1,0 +1,115 @@
+import { Agent, Content } from '@elizaos/core';
+import { usePlugins } from '@/hooks/use-plugins';
+
+const PROVIDER_PLUGIN_MAPPINGS: Record<string, string> = {
+  google: '@elizaos/plugin-google-genai',
+  llama_local: '@elizaos/plugin-local-ai',
+  // extend as needed
+};
+
+const CLIENT_PLUGIN_MAPPINGS: Record<string, string> = {
+  // add as needed
+};
+
+const ESSENTIAL_PLUGINS = ['@elizaos/plugin-sql', '@elizaos/plugin-bootstrap'];
+
+export interface V1Character extends Agent {
+    name: string;
+    lore?: string[];
+    clients?: string[];
+    modelProvider?: string;
+}
+
+export function useConvertCharacter() {
+  const { data: availablePlugins = [] } = usePlugins();
+
+  const matchPlugins = (v1: V1Character): string[] => {
+    const matched = new Set<string>();
+
+    // Clients
+    if (Array.isArray(v1.clients)) {
+      for (const client of v1.clients) {
+        const lower = client.toLowerCase();
+        const mapped = CLIENT_PLUGIN_MAPPINGS[lower];
+        if (mapped && availablePlugins.includes(mapped)) {
+          matched.add(mapped);
+        } else {
+          const constructed = `@elizaos/plugin-${lower}`;
+          if (availablePlugins.includes(constructed)) {
+            matched.add(constructed);
+          }
+        }
+      }
+    }
+
+    // Model provider
+    if (typeof v1.modelProvider === 'string') {
+      const lower = v1.modelProvider.toLowerCase();
+      const mapped = PROVIDER_PLUGIN_MAPPINGS[lower];
+      if (mapped && availablePlugins.includes(mapped)) {
+        matched.add(mapped);
+      } else {
+        const constructed = `@elizaos/plugin-${lower}`;
+        if (availablePlugins.includes(constructed)) {
+          matched.add(constructed);
+        } else {
+          matched.add('@elizaos/plugin-openai'); // safe fallback
+        }
+      }
+    } else {
+      matched.add('@elizaos/plugin-openai'); // fallback if none specified
+    }
+
+    // Add essential plugins
+    for (const plugin of ESSENTIAL_PLUGINS) {
+      matched.add(plugin);
+    }
+
+    return Array.from(matched).sort();
+  };
+
+  function isV1MessageExampleFormat(
+    example: any
+  ): example is { user: string; content: Content } {
+    return typeof example === 'object' && example !== null && 'user' in example;
+  }
+
+  const convertCharacter = (v1: V1Character): V1Character => {
+    const bio = [...(v1.bio ?? []), ...(v1.lore ?? [])];
+
+    const messageExamples =
+    (v1.messageExamples ?? []).map((thread) =>
+      thread.map((msg) => {
+        if (isV1MessageExampleFormat(msg)) {
+          return {
+            name: msg.user,
+            content: msg.content,
+          };
+        }
+        return msg;
+      })
+    ) ?? [];
+
+    const plugins = matchPlugins(v1);
+    const now = Date.now();
+    const v2 = {
+      name: v1.name,
+      username: v1.username,
+      system: v1.system,
+      settings: v1.settings,
+      plugins,
+      bio,
+      topics: v1.topics,
+      style: v1.style,
+      adjectives: v1.adjectives,
+      messageExamples,
+      postExamples: v1.postExamples,
+      createdAt: now,
+      updatedAt: now
+    };
+
+    return v2;
+  };
+
+  return { convertCharacter };
+}


### PR DESCRIPTION
# Character V1 ➔ V2 Import Conversion

## Summary

Implements **automatic V1 ➔ V2 character conversion during JSON import** for seamless backward compatibility

## What’s added

- `useConvertCharacter` hook:
  - Detects V1 characters via `lore`, `clients`, `modelProvider`.
  - Merges `bio` and `lore`.
  - Normalizes `messageExamples` to V2 format.
  - Automatically matches appropriate plugins based on `modelProvider`, `clients`, with fallback to `@elizaos/plugin-openai`.

- `handleImportJSON` updated:
  - Auto-detects V1 character JSON.
  - Converts to V2 before import.
  - Validates required fields cleanly.
  - Preserves consistent import flow.

## Why

- Allows users to import older V1 character files without manual intervention.
- Keeps plugin infrastructure consistent with the ElizaOS plugin system.
- Provides a smooth transition path for creators migrating characters to the V2 schema.
