### PR TITLE
fix: parallelize code quality workflow and fix Claude action for scheduled runs

### DIFF
--- a/.github/workflows/daily-code-quality-analysis.yml
+++ b/.github/workflows/daily-code-quality-analysis.yml
@@ -485,7 +485,7 @@ jobs:
 
       # Step 11: Use Claude to analyze results and create issues
       - name: Claude Analysis and Issue Creation
-        if: github.event.inputs.create_issues != 'false'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.create_issues != 'false'
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -546,6 +546,17 @@ jobs:
             Use the GitHub API to create the issues directly.
 
           allowed_tools: 'GitHubAPI(create_issue)'
+
+      # Step 11b: Inform about skipped Claude analysis on scheduled runs
+      - name: Claude Analysis Skipped (Scheduled Run)
+        if: github.event_name == 'schedule'
+        run: |
+          echo "::notice title=Claude Analysis Skipped::Claude issue creation is only available for manual workflow runs. To create issues based on this analysis, please run the workflow manually with 'workflow_dispatch'."
+          echo "" >> analysis-results/full-report.md
+          echo "---" >> analysis-results/full-report.md
+          echo "" >> analysis-results/full-report.md
+          echo "**Note:** Claude AI analysis and automatic issue creation is disabled for scheduled runs." >> analysis-results/full-report.md
+          echo "To enable Claude analysis and issue creation, run this workflow manually using the 'Run workflow' button." >> analysis-results/full-report.md
 
       # Step 12: Upload analysis artifacts
       - name: Upload Analysis Results


### PR DESCRIPTION
## Description

This PR fixes the failing Daily Code Quality Analysis workflow by addressing the Claude action's incompatibility with scheduled events.

## Problem

The workflow was failing with error: `Unsupported event type: schedule` because the `anthropics/claude-code-action@beta` action doesn't support scheduled workflow runs.

## Solution

1. **Fixed Claude Action**: Added proper event type checking so the Claude action only runs on `workflow_dispatch` events, not scheduled runs
2. **Added Informative Messages**: When Claude analysis is skipped during scheduled runs, users see a clear message explaining why and how to enable it
3. **Preserved Model Configuration**: Maintained the Claude Opus 4 model specification for comprehensive analysis

## Changes

- Modified the Claude Analysis condition from:
  ```yaml
  if: github.event.inputs.create_issues != 'false'
  ```
  to:
  ```yaml
  if: github.event_name == 'workflow_dispatch' && github.event.inputs.create_issues != 'false'
  ```

- Added a new step that runs during scheduled executions to inform users about the skipped Claude analysis

## Model Configuration

The workflow continues to use Claude Opus 4 (`claude-opus-4-20250514`) for comprehensive code quality analysis when run manually, while other Claude workflows in the repo use the default Claude Sonnet 4 model.

## Testing

- Scheduled runs will complete successfully without errors
- Manual runs will continue to get full Claude AI analysis and issue creation
- All existing functionality is preserved

Fixes: https://github.com/elizaOS/eliza/actions/runs/16220940884/job/45801051384