### PR TITLE
fix: handle GitHub issue body character limit in code quality workflow

### DIFF
--- a/.github/workflows/daily-code-quality-analysis.yml
+++ b/.github/workflows/daily-code-quality-analysis.yml
@@ -501,6 +501,16 @@ jobs:
               reportContent = 'Error reading analysis report.';
             }
 
+            // GitHub has a 65536 character limit for issue bodies
+            const maxReportLength = 50000; // Leave room for the rest of the issue body
+            let reportTruncated = false;
+            if (reportContent.length > maxReportLength) {
+              // Truncate at a line boundary to keep markdown valid
+              const truncateAt = reportContent.lastIndexOf('\n', maxReportLength);
+              reportContent = reportContent.substring(0, truncateAt > 0 ? truncateAt : maxReportLength);
+              reportTruncated = true;
+            }
+
             // Count issues for summary
             let summaryStats = {
               deadCode: 0,
@@ -545,6 +555,8 @@ jobs:
             <summary>Click to expand full analysis results</summary>
 
             ${reportContent}
+
+            ${reportTruncated ? '\n\n**Note:** The full report was truncated due to GitHub\'s character limit. View the complete report in the workflow artifacts.' : ''}
 
             </details>
 

--- a/.github/workflows/daily-code-quality-analysis.yml
+++ b/.github/workflows/daily-code-quality-analysis.yml
@@ -556,7 +556,7 @@ jobs:
 
             ${reportContent}
 
-            ${reportTruncated ? '\n\n**Note:** The full report was truncated due to GitHub\'s character limit. View the complete report in the workflow artifacts.' : ''}
+            ${reportTruncated ? '\n\n**⚠️ Report Truncated**: The full analysis exceeded GitHub\'s 65KB limit.\n\n**📥 Download Full Report:**\n1. Go to the [workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})\n2. Scroll to "Artifacts" section at the bottom\n3. Download `code-quality-analysis-${{ github.run_id }}`\n\nThe artifact contains all analysis files and is retained for 30 days.' : ''}
 
             </details>
 


### PR DESCRIPTION
## Description

This PR fixes a critical issue that was discovered after the previous PR was merged. The daily code quality analysis workflow was failing because the generated issue body exceeded GitHub's 65,536 character limit.

## Problem

The workflow failed with error:
```
Failed to create issue: Validation Failed: {"resource":"Issue","code":"custom","field":"body","message":"body is too long (maximum is 65536 characters)"}
```

This happened because the full analysis report can be very large, especially for large codebases.

## Solution

Added truncation logic to the issue creation step:

1. **Smart Truncation**: If report exceeds 50,000 characters, truncate it
2. **Line Boundary Cutting**: Truncate at the nearest line boundary to maintain valid markdown
3. **User Notification**: Add a note when truncated, directing users to workflow artifacts
4. **Safety Margin**: Truncate at 50k to leave room for the rest of issue body

## Changes

- Added character limit check before creating issue
- Implemented smart truncation at line boundaries
- Added informative message when report is truncated
- Full report remains available in workflow artifacts (30-day retention)

## Testing

- Workflow will now handle large analysis reports gracefully
- Truncated reports will display a note directing to full artifacts
- No data is lost - full report always available as downloadable artifact

Fixes the workflow failure seen in: https://github.com/elizaOS/eliza/actions/runs/16222104255/job/45804965964