### PR TITLE
feat: Auto-resize ChatInput textarea with max height for improved UX

### DIFF
--- a/packages/client/src/components/ChatInputArea.tsx
+++ b/packages/client/src/components/ChatInputArea.tsx
@@ -62,7 +62,7 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
       <form
         ref={formRef}
         onSubmit={handleSendMessage}
-        className="relative rounded-md border bg-card py-2 sm:py-3 px-4"
+        className="relative rounded-md border bg-card p-2 sm:p-3"
       >
         {selectedFiles.length > 0 && (
           <div className="flex flex-wrap gap-2 sm:gap-3 p-2 sm:p-3 pb-0 max-h-32 sm:max-h-40 overflow-y-auto">

--- a/packages/client/src/components/ChatInputArea.tsx
+++ b/packages/client/src/components/ChatInputArea.tsx
@@ -62,7 +62,7 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
       <form
         ref={formRef}
         onSubmit={handleSendMessage}
-        className="relative rounded-md border bg-card"
+        className="relative rounded-md border bg-card py-2 sm:py-3 px-4"
       >
         {selectedFiles.length > 0 && (
           <div className="flex flex-wrap gap-2 sm:gap-3 p-2 sm:p-3 pb-0 max-h-32 sm:max-h-40 overflow-y-auto">
@@ -127,13 +127,13 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
                 ? 'Type your message here...'
                 : 'Message group...'
           }
-          className="min-h-12 resize-none rounded-md bg-card border-0 p-2 sm:p-3 shadow-none focus-visible:ring-0 text-sm sm:text-base"
+          className="max-h-[none] min-h-12 resize-none rounded-none bg-card border-0 px-0 py-0 shadow-none focus-visible:ring-0 text-sm sm:text-base"
           disabled={
             inputDisabled || (chatType === ChannelType.DM && targetAgentData?.status === 'inactive')
           }
           data-testid="chat-input"
         />
-        <div className="flex items-center p-2 sm:p-3 pt-0 gap-1">
+        <div className="flex items-center pt-0 gap-1">
           <Tooltip>
             <TooltipTrigger asChild>
               <div>

--- a/packages/client/src/components/ChatInputArea.tsx
+++ b/packages/client/src/components/ChatInputArea.tsx
@@ -127,7 +127,7 @@ export const ChatInputArea: React.FC<ChatInputAreaProps> = ({
                 ? 'Type your message here...'
                 : 'Message group...'
           }
-          className="max-h-[none] min-h-12 resize-none rounded-none bg-card border-0 px-0 py-0 shadow-none focus-visible:ring-0 text-sm sm:text-base"
+          className="min-h-12 resize-none rounded-none bg-card border-0 px-0 py-0 shadow-none focus-visible:ring-0 text-sm sm:text-base"
           disabled={
             inputDisabled || (chatType === ChannelType.DM && targetAgentData?.status === 'inactive')
           }

--- a/packages/client/src/components/ui/chat/chat-input.tsx
+++ b/packages/client/src/components/ui/chat/chat-input.tsx
@@ -4,19 +4,43 @@ import * as React from 'react';
 
 interface ChatInputProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
 
+const MAX_HEIGHT = 160;
+
 const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
-  ({ className, ...props }, ref) => (
-    <Textarea
-      autoComplete="off"
-      ref={ref}
-      name="message"
-      className={cn(
-        'max-h-12 px-4 py-3 bg-background text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring disabled:cursor-not-allowed disabled:opacity-50 w-full rounded-md flex items-center h-16 resize-none',
-        className
-      )}
-      {...props}
-    />
-  )
+  ({ className, ...props }, ref) => {
+    const internalRef = React.useRef<HTMLTextAreaElement | null>(null);
+
+    const combinedRef = (node: HTMLTextAreaElement) => {
+      if (typeof ref === 'function') ref(node);
+      else if (ref) ref.current = node;
+      internalRef.current = node;
+    };
+
+    const resizeTextarea = () => {
+      const textarea = internalRef.current;
+      if (textarea) {
+        textarea.style.height = 'auto';
+        textarea.style.height = Math.min(textarea.scrollHeight, MAX_HEIGHT) + 'px';
+      }
+    };
+
+    React.useEffect(() => {
+      resizeTextarea();
+    }, [props.value]);
+
+    return (
+      <Textarea
+        autoComplete="off"
+        ref={combinedRef}
+        name="message"
+        className={cn(
+          'max-h-12 px-4 py-3 bg-background text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring disabled:cursor-not-allowed disabled:opacity-50 w-full rounded-md flex items-center h-16 resize-none',
+          className
+        )}
+        {...props}
+      />
+    )
+  }
 );
 ChatInput.displayName = 'ChatInput';
 

--- a/packages/client/src/components/ui/chat/chat-input.tsx
+++ b/packages/client/src/components/ui/chat/chat-input.tsx
@@ -34,7 +34,7 @@ const ChatInput = React.forwardRef<HTMLTextAreaElement, ChatInputProps>(
         ref={combinedRef}
         name="message"
         className={cn(
-          'max-h-12 px-4 py-3 bg-background text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring disabled:cursor-not-allowed disabled:opacity-50 w-full rounded-md flex items-center h-16 resize-none',
+          'px-4 py-3 bg-background text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring disabled:cursor-not-allowed disabled:opacity-50 w-full rounded-md flex items-center h-16 resize-none',
           className
         )}
         {...props}


### PR DESCRIPTION
# PR: Add Auto-Resizing to ChatInput

## What does this PR do?

- Adds **auto-resizing functionality** to the `ChatInput` component using `internalRef` and `resizeTextarea`.
- Dynamically adjusts the textarea height based on content while **capping at 160px (MAX_HEIGHT)** to prevent overflow.
- Improves the typing experience in chat by:
  - Removing unnecessary scrollbars.
  - Keeping multi-line messages fully visible while typing.

---

## Why do we need this?

Currently, `ChatInput` has a **fixed height**, which:

- Makes it harder to view longer messages while composing.
- Forces users to scroll within a small textarea for multi-line inputs, degrading usability.

---

By adding auto-resizing with a max height cap, we:

✅ Improve user experience during message composition.  
✅ Maintain a clean, consistent chat layout without abrupt jumps.  
✅ Avoid overflow issues while supporting multi-line messages.

---

## Notes for Reviewers

- The resize is capped at **160px** to align with design constraints.
- Does not affect mobile behavior beyond improving multi-line typing.
- Tested with:
  - Rapid typing of multi-line inputs.
  - Copy-pasting large chunks of text.
  - Switching between short and long messages seamlessly.

---

## Screenshots

https://github.com/user-attachments/assets/95f79a9b-95b0-41bc-b9db-0c8007bd6a51

