### PR TITLE
chore: Keep user on agent settings page after saving changes instead of redirecting to dashboard

### DIFF
--- a/packages/client/src/routes/agent-settings.tsx
+++ b/packages/client/src/routes/agent-settings.tsx
@@ -44,9 +44,7 @@ export default function AgentSettingsRoute() {
         <AgentSettings
           agent={agent}
           agentId={agentId as UUID}
-          onSaveComplete={() => {
-            navigate('/');
-          }}
+          onSaveComplete={() => {}}
         />
       </div>
     </div>


### PR DESCRIPTION
This PR keeps the user on the agent settings page after saving changes instead of redirecting to the dashboard. This improves UX by allowing users to continue adjusting settings without interruption, as requested by @borisudovicic.