### PR TITLE
fix: grant Claude workflow permissions for bun and GitHub CLI commands

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,8 +44,8 @@ jobs:
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
 
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
+          # Allow Claude to run specific commands including GitHub CLI for issue management
+          allowed_tools: "Bash(bun install),Bash(bun run build),Bash(bun test),Bash(bun run test),Bash(bun run lint),Bash(bun run format),Bash(gh *)"
 
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |


### PR DESCRIPTION
## Summary
- Enables Claude to use bun commands in GitHub Actions workflow
- Grants full GitHub CLI access for issue and PR management
- Fixes permission errors when Claude tries to create issues from code quality analysis

## Changes
- Updated  to include `allowed_tools` configuration
- Added permissions for:
  - `bun install`, `bun run build`, `bun test`, `bun run test`
  - `bun run lint`, `bun run format`
  - All GitHub CLI commands via `gh *`

## Context
The daily code quality analysis workflow creates issues that tag @claude, asking it to analyze findings and create follow-up issues. However, Claude was unable to execute bash commands (specifically `gh issue create`) because the workflow didn't have `allowed_tools` configured.

This PR fixes that by explicitly granting Claude the necessary permissions.

## Test Plan
1. Wait for the next daily code quality analysis run (or trigger manually)
2. When it creates an issue tagging @claude, verify Claude can:
   - Use `gh run view` to check workflow logs
   - Use `gh issue create` to create follow-up issues
   - Execute bun commands if needed

🤖 Generated with [Claude Code](https://claude.ai/code)