### PR TITLE
fix: grant Claude workflow write permissions for issues

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,11 +47,16 @@ jobs:
           # Allow Claude to run specific commands including GitHub CLI for issue management
           allowed_tools: "Bash(bun install),Bash(bun run build),Bash(bun test),Bash(bun run test),Bash(bun run lint),Bash(bun run format),Bash(gh *)"
 
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
+          # Custom instructions for Claude to handle ElizaOS standards
+          custom_instructions: |
+            Follow ElizaOS coding standards from CLAUDE.md
+            Use bun exclusively (never npm, pnpm, yarn, or npx)
+            For testing:
+            - Use bun:test for all unit tests, integration tests, and backend tests
+            - Cypress is ONLY acceptable for frontend UI testing in packages/client
+            - Never use jest, vitest, mocha, or other test frameworks except Cypress for UI
+            When creating GitHub issues, use proper labels and formatting
+            Check workflow logs using gh run view <run-id> --log for details
 
           # Optional: Custom environment variables for Claude
           # claude_env: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      issues: read
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Changes issues permission from 'read' to 'write' in Claude workflow
- Enables Claude to create GitHub issues using the gh CLI

## Problem
Claude was unable to create GitHub issues despite having `allowed_tools` configured with `gh *`. The workflow had read-only permissions for issues, preventing write operations.

## Solution
Updated the workflow permissions to grant write access for issues while keeping other permissions read-only for security.

## Test Plan
1. Merge this PR
2. Create or comment on an issue with @claude
3. Claude should now be able to create issues using `gh issue create`

## Related
- Follows up on PR #5550 which added `allowed_tools` configuration
- Addresses the issue seen in workflow run #16226049886 where Claude couldn't create issues

🤖 Generated with [Claude Code](https://claude.ai/code)