### PR TITLE
Fix: tsup build wipes vite build

### DIFF
--- a/packages/plugin-starter/tsup.config.ts
+++ b/packages/plugin-starter/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   outDir: 'dist',
   tsconfig: './tsconfig.build.json', // Use build-specific tsconfig
   sourcemap: true,
-  clean: true,
+  clean: false,
   format: ['esm'], // Ensure you're targeting CommonJS
   dts: true, // require DTS so we get d.ts in the dist folder on npm
   external: [

--- a/packages/plugin-starter/vite.config.ts
+++ b/packages/plugin-starter/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [tailwindcss(), react()],
   base: './',
   build: {
-    emptyOutDir: false,
+    emptyOutDir: true,
     outDir: 'dist',
     manifest: true,
   },

--- a/packages/project-starter/src/__tests__/build-order.test.ts
+++ b/packages/project-starter/src/__tests__/build-order.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { $ } from 'bun';
+
+describe('Build Order Integration Test', () => {
+  const rootDir = path.resolve(__dirname, '../..');
+  const distDir = path.join(rootDir, 'dist');
+  const viteBuildDir = path.join(distDir, 'frontend'); // Vite builds to dist/frontend
+  const tsupBuildMarker = path.join(distDir, 'index.js'); // TSup creates this
+
+  beforeAll(async () => {
+    // Clean dist directory before test
+    if (fs.existsSync(distDir)) {
+      await $`rm -rf ${distDir}`;
+    }
+  });
+
+  afterAll(async () => {
+    // Clean up after test
+    if (fs.existsSync(distDir)) {
+      await $`rm -rf ${distDir}`;
+    }
+  });
+
+  it('should ensure vite build outputs persist after tsup build', async () => {
+    // Run the full build process
+    await $`cd ${rootDir} && bun run build`;
+
+    // Check that both vite and tsup outputs exist
+    expect(fs.existsSync(viteBuildDir)).toBe(true);
+    expect(fs.existsSync(tsupBuildMarker)).toBe(true);
+
+    // Check vite built frontend files
+    const frontendFiles = fs.readdirSync(viteBuildDir);
+    expect(frontendFiles.length).toBeGreaterThan(0);
+
+    // Should have HTML entry point
+    expect(frontendFiles.some(file => file.endsWith('.html'))).toBe(true);
+
+    // Should have assets directory (CSS/JS files are in assets/)
+    expect(frontendFiles.includes('assets')).toBe(true);
+
+    // Verify tsup also produced its expected outputs
+    const distFiles = fs.readdirSync(distDir);
+
+    // Should have tsup outputs (index.js)
+    expect(distFiles.some(file => file === 'index.js')).toBe(true);
+
+    // Should still have frontend directory
+    expect(distFiles.includes('frontend')).toBe(true);
+  }, 30000); // 30 second timeout for build process
+});

--- a/packages/project-starter/tsup.config.ts
+++ b/packages/project-starter/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   outDir: 'dist',
   tsconfig: './tsconfig.build.json', // Use build-specific tsconfig
   sourcemap: true,
-  clean: true,
+  clean: false,
   format: ['esm'], // Ensure you're targeting CommonJS
   dts: false, // Skip DTS generation to avoid external import issues // Ensure you're targeting CommonJS
   external: [


### PR DESCRIPTION
# Risks
* Low risk, only changing 3 build config settings

# Background
The build script in both `project-starter` and `plugin-starter` are: `tsc --noEmit && vite build && tsup`

The issue is that `tsup.config.ts` had `clean: true` which would wipe the vite build. 

## What does this PR do?
Since vite runs first, instruct vite to clean the build folder and tell tsup not to clean it out after. 
* Note: `vite.config.ts` already had the correct setting in `project-starter` that's why only three files were changed. 

## Why are we doing this? Any context or related work?
Doesn't really make sense to build the vite frontend and delete it immediately after. 

# Documentation changes needed?
* No

# Testing

## Where should a reviewer start?

* Build tests were added to `./packages/project-starter/__tests__/build-order.test.ts` and 
* Build tests were added to `./packages/plugin-starter/__tests__/build-order.test.ts`

## Detailed testing steps

* Execute `bun run install` and observe that both the frontend and tsup output are both in the ./dist folder. 

# Deploy Notes
* None

## Database changes
* None

## Deployment instructions
* None

## Discord username
* wookosh
