### PR TITLE
fix: suppress update notification during update command execution

### DIFF
--- a/packages/cli/src/commands/update/index.ts
+++ b/packages/cli/src/commands/update/index.ts
@@ -18,7 +18,7 @@ export const update = new Command()
   .option('--packages', 'Update only packages')
   .hook('preAction', async () => {
     try {
-      await displayBanner();
+      await displayBanner(true); // Skip update check during update command
     } catch {
       logger.debug('Banner display failed, continuing with update');
     }


### PR DESCRIPTION
The update command was showing 'update available' messages during execution due to displayBanner() being called without skipUpdateCheck parameter. This fix passes true to skip the update check during update command execution.

Fixes #5447

Generated with [Claude Code](https://claude.ai/code)