### PR TITLE
feat: enhance Claude workflows with full command access and PR commit triggers

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, synchronize]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -75,5 +75,5 @@ jobs:
 
             Skip explanations. List issues with fixes.
 
-          # Allow Claude to run bun commands during review
-          allowed_tools: 'Bash(bun install),Bash(bun run build),Bash(bun test),Bash(bun run lint),Bash(bun run format)'
+          # Allow Claude to run all bash and gh commands during review
+          allowed_tools: 'Bash(*),Bash(gh *)'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,8 +44,8 @@ jobs:
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
 
-          # Allow Claude to run specific commands including GitHub CLI for issue management
-          allowed_tools: 'Bash(bun install),Bash(bun run build),Bash(bun test),Bash(bun run test),Bash(bun run lint),Bash(bun run format),Bash(gh *)'
+          # Allow Claude to run all bash and GitHub CLI commands
+          allowed_tools: 'Bash(*),Bash(gh *)'
 
           # Custom instructions for Claude to handle ElizaOS standards
           custom_instructions: |


### PR DESCRIPTION
## Summary
- Enable Claude code review workflow to run on every commit to PRs (not just on open/ready)
- Grant full bash and GitHub CLI command access to both Claude workflows
- Closes #5564

## Changes
1. **Claude Code Review Workflow (`claude-code-review.yml`)**:
   - Added `synchronize` event type to trigger on each new commit to PRs
   - Updated `allowed_tools` from specific commands to `Bash(*)` and `Bash(gh *)` for full access

2. **Claude Interactive Workflow (`claude.yml`)**:
   - Updated `allowed_tools` from specific commands to `Bash(*)` and `Bash(gh *)` for full access

## Test plan
- [ ] Create a test PR and verify Claude review runs on initial creation
- [ ] Push a new commit to the test PR and verify Claude review runs again
- [ ] Test @claude mentions in issues/PRs to verify full command access works
- [ ] Verify both bash and gh commands execute successfully in workflows

🤖 Generated with Claude Code