### PR TITLE
Fix advisory lock acquisition bug

### DIFF
--- a/packages/plugin-sql/src/migration-service.ts
+++ b/packages/plugin-sql/src/migration-service.ts
@@ -82,7 +82,7 @@ export class DatabaseMigrationService {
         const result = await this.db.execute(
           `SELECT pg_try_advisory_lock(${MIGRATION_LOCK_ID}) AS acquired`
         );
-        return result[0]?.acquired === true;
+        return result.rows[0]?.acquired === true;
       }
     } catch (error) {
       logger.debug('Advisory lock not supported or failed, proceeding without lock:', error);


### PR DESCRIPTION
# Relates to

<!-- No explicit issue/ticket provided -->

# Risks

Low. This is a targeted bug fix correcting data access, unlikely to introduce regressions.

# Background

## What does this PR do?

This PR fixes a bug in the `acquireAdvisoryLock` method where it incorrectly accessed the return format from `this.db.execute()`. Previously, it attempted to access `result[0]?.acquired`, but `this.db.execute()` returns an object with a `rows` property (e.g., `{ rows: [...] }`).

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The previous incorrect access to the `execute()` result meant that the advisory lock acquisition always failed when using this path, potentially leading to unnecessary lock waiting or timeouts. This fix ensures the lock acquisition logic functions as intended.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/plugin-sql/src/migration-service.ts` line 86.

## Detailed testing steps

None: Automated tests are acceptable.
The fix was verified by confirming the `this.db.execute()` mock setup in existing tests (`packages/plugin-sql/src/migration-service.test.ts` line 37), which expects an object with a `rows` property.