### PR TITLE
fix: only fallback ollama if nothing else exists

### DIFF
--- a/packages/cli/src/characters/eliza.ts
+++ b/packages/cli/src/characters/eliza.ts
@@ -224,8 +224,6 @@ export function getElizaCharacter(): Character {
     !process.env.GOOGLE_GENERATIVE_AI_API_KEY?.trim()
       ? ['@elizaos/plugin-ollama']
       : []),
-      
-    '@elizaos/plugin-linear',
   ];
 
   return {

--- a/packages/cli/src/characters/eliza.ts
+++ b/packages/cli/src/characters/eliza.ts
@@ -217,8 +217,15 @@ export function getElizaCharacter(): Character {
     // Bootstrap plugin
     ...(!process.env.IGNORE_BOOTSTRAP ? ['@elizaos/plugin-bootstrap'] : []),
 
-    // Always include Ollama as ultimate fallback for local AI
-    '@elizaos/plugin-ollama',
+    // Only include Ollama as fallback if no other LLM providers are configured
+    ...(!process.env.ANTHROPIC_API_KEY?.trim() &&
+    !process.env.OPENROUTER_API_KEY?.trim() &&
+    !process.env.OPENAI_API_KEY?.trim() &&
+    !process.env.GOOGLE_GENERATIVE_AI_API_KEY?.trim()
+      ? ['@elizaos/plugin-ollama']
+      : []),
+      
+    '@elizaos/plugin-linear',
   ];
 
   return {


### PR DESCRIPTION
This pull request updates the `getElizaCharacter` function in `eliza.ts` to improve plugin configuration logic. The change ensures that the `@elizaos/plugin-ollama` plugin is only included as a fallback if no other large language model (LLM) providers are configured. Additionally, the `@elizaos/plugin-linear` plugin has been added to the list.

Key changes in plugin configuration:

* [`packages/cli/src/characters/eliza.ts`](diffhunk://#diff-b1cc9842b2ffbafc6920646d7fbabdd5aad44d2589f33703fff24ba62c7dc9c6L220-R228): Modified the logic to include `@elizaos/plugin-ollama` only when no LLM provider API keys are set (`ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_GENERATIVE_AI_API_KEY`).
* [`packages/cli/src/characters/eliza.ts`](diffhunk://#diff-b1cc9842b2ffbafc6920646d7fbabdd5aad44d2589f33703fff24ba62c7dc9c6L220-R228): Added `@elizaos/plugin-linear` to the plugin list.