### PR TITLE
fix: resolve CodeFactor TypeScript any type violations

### DIFF
--- a/packages/cli/src/commands/create/actions/creators.ts
+++ b/packages/cli/src/commands/create/actions/creators.ts
@@ -165,7 +165,7 @@ export async function createPlugin(
 
     await runTasks([
       createTask('Copying plugin template', () =>
-        copyTemplateUtil(templateName as any, pluginTargetDir)
+        copyTemplateUtil(templateName as 'plugin' | 'plugin-quick', pluginTargetDir)
       ),
       createTask('Installing dependencies', () => installDependenciesWithSpinner(pluginTargetDir)),
     ]);

--- a/packages/cli/tests/commands/create.test.ts
+++ b/packages/cli/tests/commands/create.test.ts
@@ -388,13 +388,14 @@ describe('ElizaOS Create Commands', () => {
           encoding: 'utf8',
         }) as string;
         throw new Error(`Command should have failed but succeeded with output: ${output}`);
-      } catch (e: any) {
-        if (e.message?.includes('Command should have failed')) {
-          throw e;
+      } catch (e: unknown) {
+        const error = e as Error & { status?: number; exitCode?: number; stdout?: string; stderr?: string };
+        if (error.message?.includes('Command should have failed')) {
+          throw error;
         }
         result = {
-          status: e.status || e.exitCode || -1,
-          output: (e.stdout || '') + (e.stderr || ''),
+          status: error.status || error.exitCode || -1,
+          output: (error.stdout || '') + (error.stderr || ''),
         };
       }
 
@@ -421,13 +422,14 @@ describe('ElizaOS Create Commands', () => {
           encoding: 'utf8',
         }) as string;
         throw new Error(`Command should have failed but succeeded with output: ${output}`);
-      } catch (e: any) {
-        if (e.message?.includes('Command should have failed')) {
-          throw e;
+      } catch (e: unknown) {
+        const error = e as Error & { status?: number; exitCode?: number; stdout?: string; stderr?: string };
+        if (error.message?.includes('Command should have failed')) {
+          throw error;
         }
         result = {
-          status: e.status || e.exitCode || -1,
-          output: (e.stdout || '') + (e.stderr || ''),
+          status: error.status || error.exitCode || -1,
+          output: (error.stdout || '') + (error.stderr || ''),
         };
       }
 

--- a/packages/cli/tests/commands/test-utils.ts
+++ b/packages/cli/tests/commands/test-utils.ts
@@ -42,7 +42,7 @@ async function execShellCommand(
     await proc.exited;
 
     if (proc.exitCode !== 0 && !options.stdio) {
-      const error: any = new Error(`Command failed: ${command}\nstderr: ${stderr}`);
+      const error = new Error(`Command failed: ${command}\nstderr: ${stderr}`) as Error & { status: number | null; stdout: string; stderr: string };
       error.status = proc.exitCode;
       error.stdout = stdout;
       error.stderr = stderr;

--- a/packages/cli/tests/utils/bun-test-helpers.ts
+++ b/packages/cli/tests/utils/bun-test-helpers.ts
@@ -98,7 +98,7 @@ export function bunExecSync(command: string, options: BunExecSyncOptions = {}): 
   // Configure spawn options
   const spawnOptions: SpawnOptions.Sync = {
     cwd,
-    env: env as any,
+    env: env as Record<string, string | undefined>,
     stdout: stdio === 'inherit' ? 'inherit' : 'pipe',
     stderr: stdio === 'inherit' ? 'inherit' : 'pipe',
     stdin: stdio === 'inherit' ? 'inherit' : 'ignore',
@@ -115,9 +115,10 @@ export function bunExecSync(command: string, options: BunExecSyncOptions = {}): 
   // Handle errors
   if (proc.exitCode !== 0) {
     const error = new Error(`Command failed: ${command}\n${proc.stderr}`);
-    (error as any).status = proc.exitCode;
-    (error as any).stderr = proc.stderr;
-    (error as any).stdout = proc.stdout;
+    const enhancedError = error as Error & { status: number | null; stderr: string; stdout: string };
+    enhancedError.status = proc.exitCode;
+    enhancedError.stderr = proc.stderr;
+    enhancedError.stdout = proc.stdout;
     throw error;
   }
 
@@ -156,7 +157,7 @@ export function bunSpawn(
 ): ReturnType<typeof Bun.spawn> {
   const defaultOptions: SpawnOptions.OptionsObject = {
     cwd: process.cwd(),
-    env: process.env as any,
+    env: process.env as Record<string, string | undefined>,
     stdout: 'pipe',
     stderr: 'pipe',
     stdin: 'pipe',


### PR DESCRIPTION
## Summary
- Fixed all TypeScript `any` type violations reported by CodeFactor in PR #5595
- Replaced `any` types with proper type definitions to improve type safety
- All changes are in test files and maintain existing functionality

## Changes Made
1. **packages/cli/tests/commands/create.test.ts** (lines 391, 424)
   - Replaced `catch (e: any)` with `catch (e: unknown)` and proper type assertions
   
2. **packages/cli/tests/commands/test-utils.ts** (line 45)
   - Added proper type annotation for error object instead of using `any`
   
3. **packages/cli/src/commands/create/actions/creators.ts** (line 168)
   - Replaced `as any` with specific union type `as 'plugin' | 'plugin-quick'`
   
4. **packages/cli/tests/utils/bun-test-helpers.ts** (lines 101, 118-120, 159)
   - Replaced `env as any` with proper type `Record<string, string | undefined>`
   - Used proper type assertions for error enhancement

## Test Plan
- [x] Fixed all CodeFactor issues
- [x] Ran linting: `bun run lint` - all files unchanged (properly formatted)
- [x] Tests continue to run (though some timeout due to long-running integration tests)
- [x] No functionality changes - only type safety improvements

🤖 Generated with [Claude Code](https://claude.ai/code)