### PR TITLE
fix: remove node-fetch dependency for Bun compatibility

### DIFF
--- a/packages/cli/src/utils/registry/index.ts
+++ b/packages/cli/src/utils/registry/index.ts
@@ -600,7 +600,7 @@ export async function getPackageDetails(packageName: string): Promise<{
     // Use agent only if https_proxy is defined
     const requestOptions: RequestInit = {};
     if (process.env.https_proxy) {
-      // @ts-ignore - HttpsProxyAgent is not in the RequestInit type, but is used by node-fetch
+      // @ts-ignore - HttpsProxyAgent is not in the RequestInit type
       requestOptions.agent = new HttpsProxyAgent(process.env.https_proxy);
     }
 

--- a/packages/plugin-bootstrap/src/index.ts
+++ b/packages/plugin-bootstrap/src/index.ts
@@ -44,7 +44,6 @@ export * from './actions/index.ts';
 export * from './evaluators/index.ts';
 export * from './providers/index.ts';
 
-import fetch from 'node-fetch';
 
 /**
  * Represents media data containing a buffer of data and the media type.
@@ -175,7 +174,8 @@ export async function processAttachments(
           const res = await fetch(url);
           if (!res.ok) throw new Error(`Failed to fetch image: ${res.statusText}`);
 
-          const buffer = await res.buffer();
+          const arrayBuffer = await res.arrayBuffer();
+          const buffer = Buffer.from(arrayBuffer);
           const contentType = res.headers.get('content-type') || 'application/octet-stream';
           imageUrl = `data:${contentType};base64,${buffer.toString('base64')}`;
         }


### PR DESCRIPTION
## Summary
- Remove node-fetch import from bootstrap plugin to use Bun's native fetch
- Fix compatibility issue where messages weren't sent when using npm bootstrap in Bun environments
- Update deprecated node-fetch buffer() method to native fetch arrayBuffer()

## Problem
When using the npm-installed bootstrap plugin in a Bun environment, the GET_PRICE action (and potentially other actions) would fetch data successfully but fail to send the response back to the chat. This was due to conflicts between node-fetch and Bun's native fetch implementation.

## Solution
- Removed `import fetch from 'node-fetch'` from `packages/plugin-bootstrap/src/index.ts`
- Updated `res.buffer()` to use native fetch's `res.arrayBuffer()` followed by `Buffer.from()`
- Updated comment in CLI registry utils to remove node-fetch reference

## Testing
- Built all packages successfully with `bun run build`
- Bootstrap plugin builds without errors
- Native fetch API now used throughout the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)