### PR TITLE
fix: add method chaining support to EventTarget-based on() methods

### DIFF
--- a/packages/cli/src/utils/upgrade/simple-migration-agent.ts
+++ b/packages/cli/src/utils/upgrade/simple-migration-agent.ts
@@ -51,7 +51,7 @@ export class SimpleMigrationAgent extends EventTarget {
     return this.dispatchEvent(new CustomEvent(event, { detail: data }));
   }
 
-  on(event: string, handler: (data?: unknown) => void) {
+  on(event: string, handler: (data?: unknown) => void): this {
     // Check if handler is already registered
     if (!this.handlers.has(event)) {
       this.handlers.set(event, new Map());
@@ -61,7 +61,7 @@ export class SimpleMigrationAgent extends EventTarget {
 
     // If handler already exists, don't add it again
     if (eventHandlers.has(handler)) {
-      return;
+      return this;
     }
 
     // Wrap the handler to extract data from CustomEvent
@@ -77,6 +77,7 @@ export class SimpleMigrationAgent extends EventTarget {
     eventHandlers.set(handler, wrappedHandler);
 
     this.addEventListener(event, wrappedHandler);
+    return this;
   }
 
   off(event: string, handler: (data?: unknown) => void) {

--- a/packages/server/src/bus.ts
+++ b/packages/server/src/bus.ts
@@ -15,7 +15,7 @@ class InternalMessageBus extends EventTarget {
     return this.dispatchEvent(new CustomEvent(event, { detail: data }));
   }
 
-  on(event: string, handler: (data: unknown) => void) {
+  on(event: string, handler: (data: unknown) => void): this {
     // Check if handler is already registered
     if (!this.handlers.has(event)) {
       this.handlers.set(event, new Map());
@@ -25,7 +25,7 @@ class InternalMessageBus extends EventTarget {
 
     // If handler already exists, don't add it again
     if (eventHandlers.has(handler)) {
-      return;
+      return this;
     }
 
     // Wrap the handler to extract data from CustomEvent
@@ -41,6 +41,7 @@ class InternalMessageBus extends EventTarget {
     eventHandlers.set(handler, wrappedHandler);
 
     this.addEventListener(event, wrappedHandler);
+    return this;
   }
 
   off(event: string, handler: (data: unknown) => void) {


### PR DESCRIPTION
## Summary
- Fixes broken method chaining in EventTarget migration
- Both SimpleMigrationAgent and InternalMessageBus now return 'this' from on() method
- Maintains backward compatibility with EventEmitter-style chaining pattern

## Changes
- Updated SimpleMigrationAgent.on() to return 'this' 
- Updated InternalMessageBus.on() to return 'this'

## Why
The EventEmitter → EventTarget migration broke method chaining compatibility. Code that relied on chaining like `emitter.on('event1', handler1).on('event2', handler2)` would fail because the on() methods were not returning the instance.

## Testing
- Build passes successfully
- Method chaining now works as expected