### PR TITLE
fix: (cli) prevent .elizadb inheritance in nested project creation

### DIFF
--- a/packages/cli/src/commands/create/actions/creators.ts
+++ b/packages/cli/src/commands/create/actions/creators.ts
@@ -247,6 +247,9 @@ export async function createTEEProject(
   embeddingModel?: string,
   isNonInteractive = false
 ): Promise<void> {
+  // Clear any inherited PGLITE_DATA_DIR to prevent child projects from inheriting parent's database
+  delete process.env.PGLITE_DATA_DIR;
+  
   const teeTargetDir = join(targetDir, projectName);
 
   // Validate target directory
@@ -307,6 +310,9 @@ export async function createProject(
   embeddingModel?: string,
   isNonInteractive = false
 ): Promise<void> {
+  // Clear any inherited PGLITE_DATA_DIR to prevent child projects from inheriting parent's database
+  delete process.env.PGLITE_DATA_DIR;
+  
   // Handle current directory case
   const projectTargetDir = projectName === '.' ? targetDir : join(targetDir, projectName);
 


### PR DESCRIPTION
## PR Description

### Summary
Fixes a bug where creating a new ElizaOS project from within an existing project directory causes the child project to incorrectly inherit the parent's `PGLITE_DATA_DIR` environment variable, resulting in both projects sharing the same database.

### Context
Issue reported by @cjft:
> "@yung_algorithm can you take on .elizadb testing plz make sure goes in project folder, probs not terribly hard one, just double check cwd() placement, bug is when run create command cwd is not the place to put, needs to go to new folder. i think u can crush this, cli god"

### Root Cause
When creating a new project from inside an existing ElizaOS project directory, the `PGLITE_DATA_DIR` environment variable from the parent project's `.env` file is already loaded into `process.env`. This causes the child project to inherit the parent's database path instead of creating its own.

**Example scenario:**
```bash
# 1. Create first project (works correctly)
cd ~/Desktop
elizaos create project-one
# Result: project-one/.eliza/.elizadb/ ✅
# project-one/.env contains: PGLITE_DATA_DIR=/Users/user/Desktop/project-one/.eliza/.elizadb

# 2. Navigate into the first project
cd project-one

# 3. Create second project from inside the first
elizaos create project-two
# Bug: project-two/.eliza/ exists but NO .elizadb inside ❌
# The new project inherits PGLITE_DATA_DIR from parent's process.env
```

### Technical Details
The issue occurs because:
1. When inside `project-one`, its `.env` file has already set `PGLITE_DATA_DIR=/path/to/project-one/.eliza/.elizadb`
2. This environment variable persists in `process.env` throughout the CLI session
3. When `resolvePgliteDir()` is called for the new project, it checks `process.env.PGLITE_DATA_DIR` first
4. Even though the code has protection to skip loading env vars when `targetProjectDir` is provided, the variable is already in memory

### Solution
Added `delete process.env.PGLITE_DATA_DIR;` at the beginning of both `createProject()` and `createTEEProject()` functions in `packages/cli/src/commands/create/actions/creators.ts`:

```typescript
export async function createProject(
  projectName: string,
  targetDir: string,
  database: string,
  aiModel: string,
  embeddingModel?: string,
  isNonInteractive = false
): Promise<void> {
  // Clear any inherited PGLITE_DATA_DIR to prevent child projects from inheriting parent's database
  delete process.env.PGLITE_DATA_DIR;
  
  // ... rest of function
}
```

This ensures a clean environment for each new project creation, preventing the inheritance issue.

### Testing Results
- ✅ Creating project from desktop → `PGLITE_DATA_DIR` correctly set to new project's path
- ✅ Creating project from monorepo root → `PGLITE_DATA_DIR` correctly set to new project's path
- ✅ Creating project from monorepo subdirectory → `PGLITE_DATA_DIR` correctly set to new project's path
- ✅ Creating project from inside existing project → `PGLITE_DATA_DIR` now correctly set to new project's path (previously inherited parent's path)

### Impact
- **Minimal**: Only affects the project creation flow
- **Surgical**: Just 2 lines added (one in each create function)
- **Safe**: No changes to runtime behavior, path resolution logic, or existing projects
- **Backward Compatible**: Existing projects and workflows remain unaffected 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented child projects from inheriting the parent’s database directory setting by ensuring the relevant environment variable is cleared at project creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->