### PR TITLE
Fix export in @elizaos/config

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -34,7 +34,8 @@
     "./typescript/tsconfig.test.json": "./src/typescript/tsconfig.test.json"
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "devDependencies": {
     "prettier": "^3.5.3",


### PR DESCRIPTION
Plugins that rely on this will fail because the files are actually in src and need to be imported