### PR TITLE
Remove double escaping from bunExec prompt

### DIFF
--- a/packages/plugin-training/src/cli/commands/test-fine-tuned.ts
+++ b/packages/plugin-training/src/cli/commands/test-fine-tuned.ts
@@ -157,13 +157,10 @@ export function testFineTunedCommand(program: Command) {
 
 async function testModelInference(apiKey: string, model: string, prompt: string): Promise<string> {
   try {
-    // Escape the prompt to prevent command injection
-    const escapedPrompt = prompt.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-    
-    // Use Together.ai CLI completions command with proper argument escaping
+    // Use Together.ai CLI completions command - bunExec handles argument escaping automatically
     const result = await bunExec(
       'together',
-      ['completions', '--model', model, '--max-tokens', '800', '--temperature', '0.1', escapedPrompt],
+      ['completions', '--model', model, '--max-tokens', '800', '--temperature', '0.1', prompt],
       { 
         timeout: 60000,
         env: { TOGETHER_API_KEY: apiKey }


### PR DESCRIPTION
```
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

<!-- LINK TO ISSUE OR TICKET -->

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

Low. This is a bug fix that corrects argument passing to an external command, improving correctness without introducing new vulnerabilities.

# Background

## What does this PR do?

This PR removes the manual escaping of prompt strings in the `testModelInference` function within `packages/plugin-training/src/cli/commands/test-fine-tuned.ts`.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

The `testModelInference` function was manually escaping backslashes and double quotes in the prompt before passing it to `bunExec`. Since `bunExec` takes arguments as an array and handles escaping automatically for the underlying shell command, this resulted in double-escaping. This led to malformed input being sent to the `together` CLI, causing incorrect inference results. Removing the manual escaping ensures the prompt is passed correctly, relying on `bunExec`'s built-in escaping.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/plugin-training/src/cli/commands/test-fine-tuned.ts`

## Detailed testing steps

-   Run the `test-fine-tuned` command with a prompt containing special characters, e.g., `together test-fine-tuned --model <your-model-id> --prompt "This is a test with a backslash: \\ and a quote: \"."`
-   Verify that the `together` CLI receives the prompt correctly and the inference result is as expected, without issues caused by malformed input.
-   Compare the output with the previous behavior where such prompts would likely fail or produce incorrect results due to double-escaping.

```

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-8d292f4c-4ae6-45cb-b926-827dc2e22c31) · [Cursor](https://cursor.com/background-agent?bcId=bc-8d292f4c-4ae6-45cb-b926-827dc2e22c31)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)