### PR TITLE
Correct dataset path for HuggingFace upload

### DIFF
--- a/packages/plugin-training/src/actions/start-training.ts
+++ b/packages/plugin-training/src/actions/start-training.ts
@@ -84,7 +84,7 @@ export const startTrainingAction: Action = {
       });
 
       // Check if we need to extract data first
-      const datasetPath = state?.values?.datasetPath;
+      let datasetPath = state?.values?.datasetPath;
       if (!datasetPath) {
         elizaLogger.info('No existing dataset found, extracting training data first');
 
@@ -98,6 +98,9 @@ export const startTrainingAction: Action = {
         const newDatasetPath = await trainingService.prepareDataset(conversations, config);
 
         elizaLogger.info(`Dataset prepared at: ${newDatasetPath}`);
+        
+        // Update datasetPath with the newly prepared dataset path
+        datasetPath = newDatasetPath;
       }
 
       // Upload to Hugging Face if configured


### PR DESCRIPTION
```
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

<!-- LINK TO ISSUE OR TICKET -->

# Risks

Low. This is a bug fix that corrects a variable assignment, ensuring the correct path is used for subsequent operations.

# Background

## What does this PR do?

This PR fixes a bug where the `datasetPath` variable was not updated with the path of a newly prepared dataset (`newDatasetPath`). It ensures that the correct file path is used for subsequent HuggingFace uploads.

## What kind of change is this?

Bug fixes (non-breaking change which fixes an issue)

## Why are we doing this? Any context or related work?

Previously, when a new training dataset was extracted and prepared, its path was stored in `newDatasetPath`. However, the `datasetPath` variable, used for the subsequent HuggingFace upload, was not updated. This led to the upload attempting to use an undefined `datasetPath`, which then incorrectly fell back to `config.huggingFaceConfig.datasetName` (a dataset name, not a file path), causing the upload to fail. This PR ensures `datasetPath` is correctly updated.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing

## Where should a reviewer start?

`packages/plugin-training/src/actions/start-training.ts`

## Detailed testing steps

-   Ensure your environment is configured for training and HuggingFace uploads.
-   Start a training process where no existing dataset path is provided (forcing the system to extract and prepare a new dataset).
-   Verify that the dataset preparation completes successfully.
-   Verify that the subsequent HuggingFace upload step successfully uses the newly prepared dataset's file path and completes without errors related to an incorrect path.
-   (Optional) Test with an existing dataset path configured to ensure that scenario still functions correctly.
```

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-7950457e-cd54-4e9c-8226-5703494bf665) · [Cursor](https://cursor.com/background-agent?bcId=bc-7950457e-cd54-4e9c-8226-5703494bf665)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)