### PR TITLE
fix: gitignores missing in plugin starter

### DIFF
--- a/packages/cli/.npmignore
+++ b/packages/cli/.npmignore
@@ -1,0 +1,23 @@
+# Ignore source files
+src/
+tests/
+scripts/
+examples/
+
+# Ignore config files
+tsconfig.json
+tsconfig.build.json
+tsup.config.ts
+run-all-tests.sh
+bunfig.toml
+.turbo
+.eliza
+
+# Explicitly include template dot files
+!dist/templates/**/.gitignore
+!dist/templates/**/.npmignore
+!dist/templates/**/.*
+
+# Keep dist and templates
+!dist/
+!templates/ 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,11 @@
   },
   "files": [
     "dist",
-    "templates"
+    "dist/**/.gitignore",
+    "dist/**/.npmignore",
+    "templates",
+    "templates/**/.gitignore",
+    "templates/**/.npmignore"
   ],
   "keywords": [],
   "type": "module",

--- a/packages/cli/src/commands/create/actions/creators.ts
+++ b/packages/cli/src/commands/create/actions/creators.ts
@@ -176,7 +176,11 @@ export async function createPlugin(
     console.info(`  bun run build   # Build the plugin`);
     console.info(`\n  Common commands:`);
     console.info(`  elizaos dev    # Start development mode with hot reloading`);
-    console.info(`  elizaos start  # Start in production mode\n`);
+    console.info(`  elizaos start  # Start in production mode`);
+    console.info(`\n${colors.yellow('⚠️')}  Security reminder:`);
+    console.info(`  - Check .gitignore is present before committing`);
+    console.info(`  - Never commit .env files or API keys`);
+    console.info(`  - Add sensitive files to .gitignore if needed\n`);
   });
 }
 

--- a/packages/plugin-quick-starter/package.json
+++ b/packages/plugin-quick-starter/package.json
@@ -36,6 +36,7 @@
     "dist",
     "README.md",
     ".npmignore",
+    ".gitignore",
     "package.json",
     "tsup.config.ts"
   ],

--- a/packages/plugin-starter/package.json
+++ b/packages/plugin-starter/package.json
@@ -36,6 +36,7 @@
     "dist",
     "README.md",
     ".npmignore",
+    ".gitignore",
     "package.json",
     "tsup.config.ts"
   ],


### PR DESCRIPTION
   ## Problem
   When creating plugins with `elizaos create`, the .gitignore file was not included in the published npm package. This could lead to accidentally committing and pushing sensitive files like .env to GitHub.

   ## Solution
   - Added .gitignore to the files array in plugin template package.json files
   - Created .npmignore for CLI to explicitly include template dot files
   - Added security warning after plugin creation
   
   ## Testing
   - Created new plugin with updated CLI
   - Verified .gitignore is included in npm package using `npm pack --dry-run`
   - Confirmed sensitive files are properly excluded from version control