### PR TITLE
feat: add character-based model configuration settings to runtime

### DIFF
--- a/packages/core/src/__tests__/runtime.test.ts
+++ b/packages/core/src/__tests__/runtime.test.ts
@@ -743,5 +743,236 @@ describe('AgentRuntime (Non-Instrumented Baseline)', () => {
         expect(capturedParams.presencePenalty).toBeUndefined();
       });
     });
+
+    describe('model settings from character configuration', () => {
+      it('should support per-model-type configuration with proper fallback chain', async () => {
+        // Create character with mixed settings: defaults, model-specific, and legacy
+        const characterWithMixedSettings: Character = {
+          ...mockCharacter,
+          settings: {
+            // Default settings (apply to all models)
+            DEFAULT_TEMPERATURE: 0.7,
+            DEFAULT_MAX_TOKENS: 2048,
+
+            // Model-specific settings (override defaults)
+            TEXT_SMALL_TEMPERATURE: 0.5,
+            TEXT_SMALL_MAX_TOKENS: 1024,
+            TEXT_LARGE_TEMPERATURE: 0.8,
+            TEXT_LARGE_FREQUENCY_PENALTY: 0.5,
+            OBJECT_SMALL_TEMPERATURE: 0.3,
+            OBJECT_LARGE_PRESENCE_PENALTY: 0.6,
+
+            // Legacy settings (should be lowest priority)
+            MODEL_TEMPERATURE: 0.9,
+            MODEL_MAX_TOKEN: 4096,
+            MODEL_FREQ_PENALTY: 0.7,
+            MODEL_PRESENCE_PENALTY: 0.8,
+          },
+        };
+
+        const runtimeWithMixedSettings = new AgentRuntime({
+          character: characterWithMixedSettings,
+          adapter: mockDatabaseAdapter,
+        });
+
+        // Mock handlers to capture params
+        let capturedTextSmall: any = null;
+        let capturedTextLarge: any = null;
+        let capturedObjectSmall: any = null;
+        let capturedObjectLarge: any = null;
+
+        const mockTextSmallHandler = mock().mockImplementation(
+          async (_runtime: any, params: any) => {
+            capturedTextSmall = params;
+            return 'text small response';
+          }
+        );
+        const mockTextLargeHandler = mock().mockImplementation(
+          async (_runtime: any, params: any) => {
+            capturedTextLarge = params;
+            return 'text large response';
+          }
+        );
+        const mockObjectSmallHandler = mock().mockImplementation(
+          async (_runtime: any, params: any) => {
+            capturedObjectSmall = params;
+            return { type: 'small' };
+          }
+        );
+        const mockObjectLargeHandler = mock().mockImplementation(
+          async (_runtime: any, params: any) => {
+            capturedObjectLarge = params;
+            return { type: 'large' };
+          }
+        );
+
+        // Register all models
+        runtimeWithMixedSettings.registerModel(
+          ModelType.TEXT_SMALL,
+          mockTextSmallHandler,
+          'test-provider'
+        );
+        runtimeWithMixedSettings.registerModel(
+          ModelType.TEXT_LARGE,
+          mockTextLargeHandler,
+          'test-provider'
+        );
+        runtimeWithMixedSettings.registerModel(
+          ModelType.OBJECT_SMALL,
+          mockObjectSmallHandler,
+          'test-provider'
+        );
+        runtimeWithMixedSettings.registerModel(
+          ModelType.OBJECT_LARGE,
+          mockObjectLargeHandler,
+          'test-provider'
+        );
+
+        // Test 1: TEXT_SMALL - should use model-specific settings, fall back to defaults/legacy
+        await runtimeWithMixedSettings.useModel(ModelType.TEXT_SMALL, {
+          prompt: 'test text small',
+        });
+
+        expect(capturedTextSmall.temperature).toBe(0.5); // Model-specific
+        expect(capturedTextSmall.maxTokens).toBe(1024); // Model-specific
+        expect(capturedTextSmall.frequencyPenalty).toBe(0.7); // Legacy fallback
+        expect(capturedTextSmall.presencePenalty).toBe(0.8); // Legacy fallback
+
+        // Test 2: TEXT_LARGE - mixed model-specific and defaults
+        await runtimeWithMixedSettings.useModel(ModelType.TEXT_LARGE, {
+          prompt: 'test text large',
+        });
+
+        expect(capturedTextLarge.temperature).toBe(0.8); // Model-specific
+        expect(capturedTextLarge.maxTokens).toBe(2048); // Default fallback
+        expect(capturedTextLarge.frequencyPenalty).toBe(0.5); // Model-specific
+        expect(capturedTextLarge.presencePenalty).toBe(0.8); // Legacy fallback
+
+        // Test 3: OBJECT_SMALL - some model-specific, rest from defaults/legacy
+        await runtimeWithMixedSettings.useModel(ModelType.OBJECT_SMALL, {
+          prompt: 'test object small',
+        });
+
+        expect(capturedObjectSmall.temperature).toBe(0.3); // Model-specific
+        expect(capturedObjectSmall.maxTokens).toBe(2048); // Default fallback
+        expect(capturedObjectSmall.frequencyPenalty).toBe(0.7); // Legacy fallback
+        expect(capturedObjectSmall.presencePenalty).toBe(0.8); // Legacy fallback
+
+        // Test 4: OBJECT_LARGE - minimal model-specific settings
+        await runtimeWithMixedSettings.useModel(ModelType.OBJECT_LARGE, {
+          prompt: 'test object large',
+        });
+
+        expect(capturedObjectLarge.temperature).toBe(0.7); // Default fallback
+        expect(capturedObjectLarge.maxTokens).toBe(2048); // Default fallback
+        expect(capturedObjectLarge.frequencyPenalty).toBe(0.7); // Legacy fallback
+        expect(capturedObjectLarge.presencePenalty).toBe(0.6); // Model-specific
+      });
+
+      it('should allow direct params to override all configuration levels', async () => {
+        const characterWithAllSettings: Character = {
+          ...mockCharacter,
+          settings: {
+            // All levels of configuration
+            DEFAULT_TEMPERATURE: 0.7,
+            TEXT_SMALL_TEMPERATURE: 0.5,
+            MODEL_TEMPERATURE: 0.9,
+          },
+        };
+
+        const runtime = new AgentRuntime({
+          character: characterWithAllSettings,
+          adapter: mockDatabaseAdapter,
+        });
+
+        let capturedParams: any = null;
+        const mockHandler = mock().mockImplementation(async (_runtime: any, params: any) => {
+          capturedParams = params;
+          return 'response';
+        });
+
+        runtime.registerModel(ModelType.TEXT_SMALL, mockHandler, 'test-provider');
+
+        // Direct params should override everything
+        await runtime.useModel(ModelType.TEXT_SMALL, {
+          prompt: 'test',
+          temperature: 0.1, // This should win
+        });
+
+        expect(capturedParams.temperature).toBe(0.1);
+      });
+
+      it('should handle models without specific configuration support', async () => {
+        const characterWithSettings: Character = {
+          ...mockCharacter,
+          settings: {
+            DEFAULT_TEMPERATURE: 0.7,
+            TEXT_SMALL_TEMPERATURE: 0.5,
+            // No specific settings for TEXT_REASONING_SMALL
+          },
+        };
+
+        const runtime = new AgentRuntime({
+          character: characterWithSettings,
+          adapter: mockDatabaseAdapter,
+        });
+
+        let capturedParams: any = null;
+        const mockHandler = mock().mockImplementation(async (_runtime: any, params: any) => {
+          capturedParams = params;
+          return 'response';
+        });
+
+        // Register a model type that doesn't have specific configuration support
+        runtime.registerModel(ModelType.TEXT_REASONING_SMALL, mockHandler, 'test-provider');
+
+        await runtime.useModel(ModelType.TEXT_REASONING_SMALL, {
+          prompt: 'test reasoning',
+        });
+
+        // Should fall back to default settings
+        expect(capturedParams.temperature).toBe(0.7);
+        expect(capturedParams.maxTokens).toBeUndefined(); // No default for this
+      });
+
+      it('should validate and ignore invalid numeric values at all configuration levels', async () => {
+        const characterWithInvalidSettings: Character = {
+          ...mockCharacter,
+          settings: {
+            // Mix of valid and invalid values at different levels
+            DEFAULT_TEMPERATURE: 'not-a-number',
+            DEFAULT_MAX_TOKENS: 2048,
+            TEXT_SMALL_TEMPERATURE: 0.5,
+            TEXT_SMALL_MAX_TOKENS: 'invalid',
+            TEXT_SMALL_FREQUENCY_PENALTY: null,
+            MODEL_TEMPERATURE: undefined,
+            MODEL_PRESENCE_PENALTY: 0.8,
+          },
+        };
+
+        const runtime = new AgentRuntime({
+          character: characterWithInvalidSettings,
+          adapter: mockDatabaseAdapter,
+        });
+
+        let capturedParams: any = null;
+        const mockHandler = mock().mockImplementation(async (_runtime: any, params: any) => {
+          capturedParams = params;
+          return 'response';
+        });
+
+        runtime.registerModel(ModelType.TEXT_SMALL, mockHandler, 'test-provider');
+
+        await runtime.useModel(ModelType.TEXT_SMALL, {
+          prompt: 'test invalid',
+        });
+
+        // Valid values should be used, invalid ones ignored
+        expect(capturedParams.temperature).toBe(0.5); // Valid model-specific
+        expect(capturedParams.maxTokens).toBe(2048); // Valid default (model-specific was invalid)
+        expect(capturedParams.frequencyPenalty).toBeUndefined(); // All invalid
+        expect(capturedParams.presencePenalty).toBe(0.8); // Valid legacy
+      });
+    });
   });
 }); // End of main describe block

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1620,35 +1620,78 @@ export class AgentRuntime implements IAgentRuntime {
   }
 
   /**
-   * Retrieves model configuration settings from character settings.
+   * Retrieves model configuration settings from character settings with support for
+   * model-specific overrides and default fallbacks.
+   *
+   * Precedence order (highest to lowest):
+   * 1. Model-specific settings (e.g., TEXT_SMALL_TEMPERATURE)
+   * 2. Default settings (e.g., DEFAULT_TEMPERATURE)
+   * 3. Legacy settings for backwards compatibility (e.g., MODEL_TEMPERATURE)
+   *
+   * @param modelType The specific model type to get settings for
    * @returns Object containing model parameters if they exist, or null if no settings are configured
    */
-  private getModelSettings(): Record<string, number> | null {
+  private getModelSettings(modelType?: ModelTypeName): Record<string, number> | null {
     const modelSettings: Record<string, number> = {};
 
-    // Read individual model settings
-    const maxTokens = this.getSetting(MODEL_SETTINGS.MAX_TOKENS);
-    const temperature = this.getSetting(MODEL_SETTINGS.TEMPERATURE);
-    const frequencyPenalty = this.getSetting(MODEL_SETTINGS.FREQUENCY_PENALTY);
-    const presencePenalty = this.getSetting(MODEL_SETTINGS.PRESENCE_PENALTY);
+    // Helper to get a setting value with fallback chain
+    const getSettingWithFallback = (
+      param: 'MAX_TOKENS' | 'TEMPERATURE' | 'FREQUENCY_PENALTY' | 'PRESENCE_PENALTY',
+      legacyKey: string
+    ): number | null => {
+      // Try model-specific setting first
+      if (modelType) {
+        const modelSpecificKey = `${modelType}_${param}`;
+        const modelValue = this.getSetting(modelSpecificKey);
+        if (modelValue !== null && modelValue !== undefined) {
+          const numValue = Number(modelValue);
+          if (!isNaN(numValue)) {
+            return numValue;
+          }
+          // If model-specific value exists but is invalid, continue to fallbacks
+        }
+      }
 
-    // Add settings if they exist and are valid numbers
-    if (maxTokens !== null) {
-      const value = Number(maxTokens);
-      if (!isNaN(value)) modelSettings.maxTokens = value;
-    }
-    if (temperature !== null) {
-      const value = Number(temperature);
-      if (!isNaN(value)) modelSettings.temperature = value;
-    }
-    if (frequencyPenalty !== null) {
-      const value = Number(frequencyPenalty);
-      if (!isNaN(value)) modelSettings.frequencyPenalty = value;
-    }
-    if (presencePenalty !== null) {
-      const value = Number(presencePenalty);
-      if (!isNaN(value)) modelSettings.presencePenalty = value;
-    }
+      // Fall back to default setting
+      const defaultKey = `DEFAULT_${param}`;
+      const defaultValue = this.getSetting(defaultKey);
+      if (defaultValue !== null && defaultValue !== undefined) {
+        const numValue = Number(defaultValue);
+        if (!isNaN(numValue)) {
+          return numValue;
+        }
+        // If default value exists but is invalid, continue to legacy
+      }
+
+      // Fall back to legacy setting for backwards compatibility
+      const legacyValue = this.getSetting(legacyKey);
+      if (legacyValue !== null && legacyValue !== undefined) {
+        const numValue = Number(legacyValue);
+        if (!isNaN(numValue)) {
+          return numValue;
+        }
+      }
+
+      return null;
+    };
+
+    // Get settings with proper fallback chain
+    const maxTokens = getSettingWithFallback('MAX_TOKENS', MODEL_SETTINGS.MODEL_MAX_TOKEN);
+    const temperature = getSettingWithFallback('TEMPERATURE', MODEL_SETTINGS.MODEL_TEMPERATURE);
+    const frequencyPenalty = getSettingWithFallback(
+      'FREQUENCY_PENALTY',
+      MODEL_SETTINGS.MODEL_FREQ_PENALTY
+    );
+    const presencePenalty = getSettingWithFallback(
+      'PRESENCE_PENALTY',
+      MODEL_SETTINGS.MODEL_PRESENCE_PENALTY
+    );
+
+    // Add settings if they exist
+    if (maxTokens !== null) modelSettings.maxTokens = maxTokens;
+    if (temperature !== null) modelSettings.temperature = temperature;
+    if (frequencyPenalty !== null) modelSettings.frequencyPenalty = frequencyPenalty;
+    if (presencePenalty !== null) modelSettings.presencePenalty = presencePenalty;
 
     // Return null if no settings were configured
     return Object.keys(modelSettings).length > 0 ? modelSettings : null;
@@ -1686,12 +1729,12 @@ export class AgentRuntime implements IAgentRuntime {
       paramsWithRuntime = params;
     } else {
       // Include model settings from character configuration if available
-      const modelSettings = this.getModelSettings();
+      const modelSettings = this.getModelSettings(modelKey);
 
       if (modelSettings) {
         // Apply model settings if configured
         paramsWithRuntime = {
-          ...modelSettings, // Apply default model settings first
+          ...modelSettings, // Apply model settings first (includes defaults and model-specific)
           ...params, // Then apply specific params (allowing overrides)
           runtime: this,
         };

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1632,11 +1632,23 @@ export class AgentRuntime implements IAgentRuntime {
     const frequencyPenalty = this.getSetting(MODEL_SETTINGS.FREQUENCY_PENALTY);
     const presencePenalty = this.getSetting(MODEL_SETTINGS.PRESENCE_PENALTY);
 
-    // Add settings if they exist
-    if (maxTokens !== null) modelSettings.maxTokens = Number(maxTokens);
-    if (temperature !== null) modelSettings.temperature = Number(temperature);
-    if (frequencyPenalty !== null) modelSettings.frequencyPenalty = Number(frequencyPenalty);
-    if (presencePenalty !== null) modelSettings.presencePenalty = Number(presencePenalty);
+    // Add settings if they exist and are valid numbers
+    if (maxTokens !== null) {
+      const value = Number(maxTokens);
+      if (!isNaN(value)) modelSettings.maxTokens = value;
+    }
+    if (temperature !== null) {
+      const value = Number(temperature);
+      if (!isNaN(value)) modelSettings.temperature = value;
+    }
+    if (frequencyPenalty !== null) {
+      const value = Number(frequencyPenalty);
+      if (!isNaN(value)) modelSettings.frequencyPenalty = value;
+    }
+    if (presencePenalty !== null) {
+      const value = Number(presencePenalty);
+      if (!isNaN(value)) modelSettings.presencePenalty = value;
+    }
 
     // Return null if no settings were configured
     return Object.keys(modelSettings).length > 0 ? modelSettings : null;

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -37,14 +37,79 @@ export const ModelType = {
 /**
  * Model configuration setting keys used in character settings.
  * These constants define the keys for accessing model parameters
- * like temperature, max tokens, etc. from character configuration.
+ * from character configuration with support for per-model-type settings.
+ *
+ * Setting Precedence (highest to lowest):
+ * 1. Parameters passed directly to useModel()
+ * 2. Model-specific settings (e.g., TEXT_SMALL_TEMPERATURE)
+ * 3. Default settings (e.g., DEFAULT_TEMPERATURE)
+ *
+ * Example character settings:
+ * ```
+ * settings: {
+ *   DEFAULT_TEMPERATURE: 0.7,              // Applies to all models
+ *   TEXT_SMALL_TEMPERATURE: 0.5,           // Overrides default for TEXT_SMALL
+ *   TEXT_LARGE_MAX_TOKENS: 4096,           // Specific to TEXT_LARGE
+ *   OBJECT_SMALL_TEMPERATURE: 0.3,         // Specific to OBJECT_SMALL
+ * }
+ * ```
  */
 export const MODEL_SETTINGS = {
-  MAX_TOKENS: 'MODEL_MAX_TOKEN',
-  TEMPERATURE: 'MODEL_TEMPERATURE',
-  FREQUENCY_PENALTY: 'MODEL_FREQ_PENALTY',
-  PRESENCE_PENALTY: 'MODEL_PRESENCE_PENALTY',
+  // Default settings - apply to all model types unless overridden
+  DEFAULT_MAX_TOKENS: 'DEFAULT_MAX_TOKENS',
+  DEFAULT_TEMPERATURE: 'DEFAULT_TEMPERATURE',
+  DEFAULT_FREQUENCY_PENALTY: 'DEFAULT_FREQUENCY_PENALTY',
+  DEFAULT_PRESENCE_PENALTY: 'DEFAULT_PRESENCE_PENALTY',
+
+  // TEXT_SMALL specific settings
+  TEXT_SMALL_MAX_TOKENS: 'TEXT_SMALL_MAX_TOKENS',
+  TEXT_SMALL_TEMPERATURE: 'TEXT_SMALL_TEMPERATURE',
+  TEXT_SMALL_FREQUENCY_PENALTY: 'TEXT_SMALL_FREQUENCY_PENALTY',
+  TEXT_SMALL_PRESENCE_PENALTY: 'TEXT_SMALL_PRESENCE_PENALTY',
+
+  // TEXT_LARGE specific settings
+  TEXT_LARGE_MAX_TOKENS: 'TEXT_LARGE_MAX_TOKENS',
+  TEXT_LARGE_TEMPERATURE: 'TEXT_LARGE_TEMPERATURE',
+  TEXT_LARGE_FREQUENCY_PENALTY: 'TEXT_LARGE_FREQUENCY_PENALTY',
+  TEXT_LARGE_PRESENCE_PENALTY: 'TEXT_LARGE_PRESENCE_PENALTY',
+
+  // OBJECT_SMALL specific settings
+  OBJECT_SMALL_MAX_TOKENS: 'OBJECT_SMALL_MAX_TOKENS',
+  OBJECT_SMALL_TEMPERATURE: 'OBJECT_SMALL_TEMPERATURE',
+  OBJECT_SMALL_FREQUENCY_PENALTY: 'OBJECT_SMALL_FREQUENCY_PENALTY',
+  OBJECT_SMALL_PRESENCE_PENALTY: 'OBJECT_SMALL_PRESENCE_PENALTY',
+
+  // OBJECT_LARGE specific settings
+  OBJECT_LARGE_MAX_TOKENS: 'OBJECT_LARGE_MAX_TOKENS',
+  OBJECT_LARGE_TEMPERATURE: 'OBJECT_LARGE_TEMPERATURE',
+  OBJECT_LARGE_FREQUENCY_PENALTY: 'OBJECT_LARGE_FREQUENCY_PENALTY',
+  OBJECT_LARGE_PRESENCE_PENALTY: 'OBJECT_LARGE_PRESENCE_PENALTY',
+
+  // Legacy keys for backwards compatibility (will be treated as defaults)
+  MODEL_MAX_TOKEN: 'MODEL_MAX_TOKEN',
+  MODEL_TEMPERATURE: 'MODEL_TEMPERATURE',
+  MODEL_FREQ_PENALTY: 'MODEL_FREQ_PENALTY',
+  MODEL_PRESENCE_PENALTY: 'MODEL_PRESENCE_PENALTY',
 } as const;
+
+/**
+ * Helper to get the model-specific setting key for a given model type and parameter.
+ * @param modelType The model type (e.g., TEXT_SMALL, TEXT_LARGE)
+ * @param param The parameter name (e.g., MAX_TOKENS, TEMPERATURE)
+ * @returns The appropriate setting key or null if not a supported model type
+ */
+export function getModelSpecificSettingKey(
+  modelType: ModelTypeName,
+  param: 'MAX_TOKENS' | 'TEMPERATURE' | 'FREQUENCY_PENALTY' | 'PRESENCE_PENALTY'
+): string | null {
+  const supportedModelTypes = ['TEXT_SMALL', 'TEXT_LARGE', 'OBJECT_SMALL', 'OBJECT_LARGE'];
+
+  if (!supportedModelTypes.includes(modelType)) {
+    return null;
+  }
+
+  return `${modelType}_${param}`;
+}
 
 /**
  * Parameters for generating text using a language model.

--- a/packages/core/src/types/model.ts
+++ b/packages/core/src/types/model.ts
@@ -35,6 +35,18 @@ export const ModelType = {
 } as const;
 
 /**
+ * Model configuration setting keys used in character settings.
+ * These constants define the keys for accessing model parameters
+ * like temperature, max tokens, etc. from character configuration.
+ */
+export const MODEL_SETTINGS = {
+  MAX_TOKENS: 'MODEL_MAX_TOKEN',
+  TEMPERATURE: 'MODEL_TEMPERATURE',
+  FREQUENCY_PENALTY: 'MODEL_FREQ_PENALTY',
+  PRESENCE_PENALTY: 'MODEL_PRESENCE_PENALTY',
+} as const;
+
+/**
  * Parameters for generating text using a language model.
  * This structure is typically passed to `AgentRuntime.useModel` when the `modelType` is one of
  * `ModelType.TEXT_SMALL`, `ModelType.TEXT_LARGE`, `ModelType.TEXT_REASONING_SMALL`,


### PR DESCRIPTION
# Relates to

Enhancement: Allow model parameters to be configured at the character level instead of hardcoded in plugins

# Risks

**Low** - Changes are backward compatible. If no model settings are configured in character, behavior remains unchanged. Settings only apply as defaults and can still be overridden per call.

# Background

## What does this PR do?

This PR adds support for configuring model parameters (temperature, maxTokens, frequencyPenalty, presencePenalty) at the character level. These settings are automatically passed as defaults to all `useModel()` calls, allowing consistent model behavior across all plugins without hardcoding values.

## What kind of change is this?

Features (non-breaking change which adds functionality)

# Documentation changes needed?

My changes require a change to the project documentation.
- Need to document the new MODEL_* settings in character configuration
- Need to update plugin documentation to note they now respect character model settings

# Testing

## Where should a reviewer start?

1. Review `packages/core/src/runtime.ts` - specifically the new `getModelSettings()` method and changes to `useModel()`
2. Review `packages/core/src/types/model.ts` - new MODEL_SETTINGS constants
3. Check plugin updates in `packages/plugin-openai`, `packages/plugin-google-genai`, and `packages/plugin-anthropic`

## Detailed testing steps

1. Create a character with model settings:
   ```typescript
   settings: {
     MODEL_MAX_TOKEN: 4096,
     MODEL_TEMPERATURE: 0.5,
     MODEL_FREQ_PENALTY: 0.8,
     MODEL_PRESENCE_PENALTY: 0.8,
   }
   ```

2. Test with OpenAI plugin:
   - Run any action that uses TEXT_SMALL or TEXT_LARGE
   - Verify the model uses the configured temperature (check logs)
   - Verify responses respect maxTokens limit

3. Test without model settings:
   - Remove/comment out MODEL_* settings from character
   - Verify plugins use their default values
   - Ensure no errors occur

4. Test override behavior:
   - With settings configured, make a direct useModel call with different params
   - Verify the explicit params override the character defaults