### PR TITLE
feat: remove automatic merge to develop from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -204,17 +204,3 @@ jobs:
             git commit -m "chore(release): bump versions to v${{ env.VERSION }}"
             git push origin main
           fi
-
-      - name: Merge main to develop
-        run: |
-          # Fetch the latest develop branch
-          git fetch origin develop:develop
-
-          # Checkout develop branch
-          git checkout develop
-
-          # Merge main into develop
-          git merge main --no-ff -m "chore: merge main to develop for v${{ env.VERSION }} release"
-
-          # Push the updated develop branch
-          git push origin develop


### PR DESCRIPTION
## Summary

This PR removes the automatic merge from main to develop that was happening at the end of the release workflow.

## Changes

- Removed the 'Merge main to develop' step from 
- This step was automatically merging main into develop after each release

## Rationale

- Manual control over develop branch merges may be preferred
- Allows for more deliberate management of the develop branch
- Reduces potential conflicts or issues with automatic merges

## Testing

- Workflow changes can be verified by examining the modified YAML file
- No functional code changes that require testing