### PR TITLE
fix(cli): handle monorepo version in update command

### DIFF
--- a/packages/cli/src/commands/update/utils/version-utils.ts
+++ b/packages/cli/src/commands/update/utils/version-utils.ts
@@ -2,6 +2,7 @@ import { logger } from '@elizaos/core';
 import { bunExecSimple } from '@/src/utils/bun-exec';
 import * as semver from 'semver';
 import { UserEnvironment } from '@/src/utils/user-environment';
+import { detectDirectoryType } from '@/src/utils/directory-detection';
 import { VersionCheckResult } from '../types';
 
 // Constants
@@ -14,8 +15,24 @@ export const FALLBACK_VERSION = '0.0.0';
  */
 export async function getVersion(): Promise<string> {
   try {
+    // Check if we're in the monorepo context using standard pattern
+    const directoryInfo = detectDirectoryType(process.cwd());
+    const isMonorepo = directoryInfo.type === 'elizaos-monorepo';
+
+    if (isMonorepo) {
+      // We're in the monorepo, return 'monorepo' as version
+      return 'monorepo';
+    }
+
     const envInfo = await UserEnvironment.getInstance().getInfo();
-    return envInfo.cli.version;
+    const version = envInfo.cli.version;
+
+    // In case version is still workspace:*, return 'monorepo'
+    if (isWorkspaceVersion(version)) {
+      return 'monorepo';
+    }
+
+    return version;
   } catch (error) {
     logger.error('Error getting CLI version:', error);
     return FALLBACK_VERSION;

--- a/packages/cli/tests/commands/update.test.ts
+++ b/packages/cli/tests/commands/update.test.ts
@@ -73,7 +73,9 @@ describe('ElizaOS Update Commands', () => {
 
       const result = bunExecSync('elizaos update --check', { encoding: 'utf8' });
 
-      expect(result).toMatch(/Version: 1\.[2-9]\.\d+/); // Support 1.2.x through 1.9.x versions
+      // In monorepo context, version will be "monorepo"
+      // In published packages, it will be a semantic version
+      expect(result).toMatch(/Version: (monorepo|1\.[2-9]\.\d+)/); // Support monorepo or 1.2.x through 1.9.x versions
     },
     TEST_TIMEOUTS.INDIVIDUAL_TEST
   );


### PR DESCRIPTION
## Summary

This PR fixes the failing CLI test `update --check works` that was failing in CI due to version handling in monorepo context.

## Problem

The test was expecting a semantic version pattern (e.g., `1.2.0`) but was receiving `workspace:*` because the CLI's package.json in the monorepo uses workspace protocol.

## Solution

- Updated `getVersion()` in `version-utils.ts` to detect monorepo context using the standard `detectDirectoryType` pattern
- Returns `'monorepo'` instead of `'workspace:*'` when running in monorepo context
- Updated the test regex to accept both `'monorepo'` and semantic versions
- Follows existing patterns used throughout the codebase (e.g., in `dev-server.ts`, `build-utils.ts`)

## Changes

1. **packages/cli/src/commands/update/utils/version-utils.ts**
   - Added import for `detectDirectoryType`
   - Check for monorepo using `directoryInfo.type === 'elizaos-monorepo'`
   - Return `'monorepo'` when in monorepo context or when version is `workspace:*`

2. **packages/cli/tests/commands/update.test.ts**
   - Updated test regex to accept both `monorepo` and semantic versions
   - Added comment explaining the expected behavior

## Testing

- Manually tested `elizaos update --check` command - correctly returns `Version: monorepo`
- Test should now pass in CI environment

Fixes the workflow failure seen in: https://github.com/elizaOS/eliza/actions/runs/16808774401/job/47608279198