### PR TITLE
allow iframes when web ui is enabled in production

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -362,7 +362,7 @@ export class AgentServer {
                   connectSrc: ["'self'", 'ws:', 'wss:', 'https:', 'http:'],
                   mediaSrc: ["'self'", 'blob:', 'data:'],
                   objectSrc: ["'none'"],
-                  frameSrc: ["'none'"],
+                  frameSrc: [this.isWebUIEnabled ? "'self'" : "'none'"],
                   baseUri: ["'self'"],
                   formAction: ["'self'"],
                   // upgrade-insecure-requests is added by helmet automatically


### PR DESCRIPTION
# Risks

- Low: Allows iframes from self if web ui is enabled in production.

# Background

Currently in production, any panels exposed by plugins are blocked. This is because plugin panels are exposed using an iframe. with frame-src = 'none' these panels do not work. 

If the Web UI is enabled, the admin needs iframes to expose panels provided by plugins. using frame-src = 'self' allows iframes only from the same domain. 

## What does this PR do?

- This PR checks if the web ui is enabled in production, and if it is, allow iframes to come from self to unblock plugin panels.

## Why are we doing this? Any context or related work?
- Obviously if a user has explicitly enabled the web ui using `ELIZA_UI_ENABLE` they want the web ui exposed and if they want the ui exposed, they will also implicitly want all their plugins to work as well. 

# Documentation changes needed?

- no documentation changes required

# Testing

## Where should a reviewer start?

## Detailed testing steps

1) in your `.env` file, set the following:
NODE_ENV=production
ELIZA_UI_ENABLE=true

2) install any plugin that exposes a panel in the admin such as `@elizaos/plugin-knowledge`
3) Observe that the panel is accessible


## Discord username
wookosh
