### PR TITLE
fix: (project-starter) replace mock.module with spyOn for consistent logger testing

### DIFF
--- a/packages/project-starter/src/__tests__/config.test.ts
+++ b/packages/project-starter/src/__tests__/config.test.ts
@@ -1,20 +1,8 @@
-import { describe, expect, it, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, expect, it, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import plugin from '../plugin';
 import { z } from 'zod';
 import { createMockRuntime } from './utils/core-test-utils';
-
-// Mock logger
-mock.module('@elizaos/core', () => {
-  const actual = require('@elizaos/core');
-  return {
-    ...actual,
-    logger: {
-      info: mock(),
-      error: mock(),
-      warn: mock(),
-    },
-  };
-});
+import { logger } from '@elizaos/core';
 
 // Access the plugin's init function
 const initPlugin = plugin.init;
@@ -24,7 +12,10 @@ describe('Plugin Configuration Schema', () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {
-    mock.restore();
+    // Use spyOn for logger methods
+    spyOn(logger, 'info');
+    spyOn(logger, 'error');
+    spyOn(logger, 'warn');
     // Reset environment variables before each test
     process.env = { ...originalEnv };
   });

--- a/packages/project-starter/src/__tests__/error-handling.test.ts
+++ b/packages/project-starter/src/__tests__/error-handling.test.ts
@@ -5,22 +5,12 @@ import { logger } from '@elizaos/core';
 import type { IAgentRuntime, Memory, State } from '@elizaos/core';
 import { v4 as uuidv4 } from 'uuid';
 
-// Mock logger
-mock.module('@elizaos/core', () => {
-  const actual = require('@elizaos/core');
-  return {
-    ...actual,
-    logger: {
-      info: mock(),
-      error: mock(),
-      warn: mock(),
-    },
-  };
-});
-
 describe('Error Handling', () => {
   beforeEach(() => {
-    mock.restore();
+    // Use spyOn for logger methods
+    spyOn(logger, 'info');
+    spyOn(logger, 'error');
+    spyOn(logger, 'warn');
   });
 
   afterEach(() => {

--- a/packages/project-starter/src/__tests__/events.test.ts
+++ b/packages/project-starter/src/__tests__/events.test.ts
@@ -1,22 +1,18 @@
-import { describe, expect, it, beforeEach, mock } from 'bun:test';
+import { describe, expect, it, beforeAll, afterAll, spyOn } from 'bun:test';
 import plugin from '../plugin';
 import { logger } from '@elizaos/core';
 
-// Mock logger
-mock.module('@elizaos/core', () => {
-  const actual = require('@elizaos/core');
-  return {
-    ...actual,
-    logger: {
-      info: mock(),
-      error: mock(),
-    },
-  };
-});
-
 describe('Plugin Events', () => {
-  beforeEach(() => {
-    mock.restore();
+  // Use spyOn like all other tests in the codebase
+  beforeAll(() => {
+    spyOn(logger, 'info');
+    spyOn(logger, 'error');
+    spyOn(logger, 'warn');
+    spyOn(logger, 'debug');
+  });
+
+  afterAll(() => {
+    // No global restore needed in bun:test
   });
 
   it('should have events defined', () => {
@@ -47,9 +43,12 @@ describe('Plugin Events', () => {
       // Call the event handler
       await messageHandler(mockParams);
 
-      // Verify log was called
+      // Verify logger was called with correct Pino-style structured logging
       expect(logger.info).toHaveBeenCalledWith('MESSAGE_RECEIVED event received');
-      expect(logger.info).toHaveBeenCalledWith(expect.any(Array));
+      expect(logger.info).toHaveBeenCalledWith(
+        { keys: expect.any(Array) },
+        'MESSAGE_RECEIVED param keys'
+      );
     }
   });
 
@@ -74,9 +73,12 @@ describe('Plugin Events', () => {
       // Call the event handler
       await voiceHandler(mockParams);
 
-      // Verify log was called
+      // Verify logger was called with correct Pino-style structured logging
       expect(logger.info).toHaveBeenCalledWith('VOICE_MESSAGE_RECEIVED event received');
-      expect(logger.info).toHaveBeenCalledWith(expect.any(Array));
+      expect(logger.info).toHaveBeenCalledWith(
+        { keys: expect.any(Array) },
+        'VOICE_MESSAGE_RECEIVED param keys'
+      );
     }
   });
 
@@ -103,9 +105,12 @@ describe('Plugin Events', () => {
       // Call the event handler
       await connectedHandler(mockParams);
 
-      // Verify log was called
+      // Verify logger was called with correct Pino-style structured logging
       expect(logger.info).toHaveBeenCalledWith('WORLD_CONNECTED event received');
-      expect(logger.info).toHaveBeenCalledWith(expect.any(Array));
+      expect(logger.info).toHaveBeenCalledWith(
+        { keys: expect.any(Array) },
+        'WORLD_CONNECTED param keys'
+      );
     }
   });
 
@@ -136,9 +141,12 @@ describe('Plugin Events', () => {
       // Call the event handler
       await joinedHandler(mockParams);
 
-      // Verify log was called
+      // Verify logger was called with correct Pino-style structured logging
       expect(logger.info).toHaveBeenCalledWith('WORLD_JOINED event received');
-      expect(logger.info).toHaveBeenCalledWith(expect.any(Array));
+      expect(logger.info).toHaveBeenCalledWith(
+        { keys: expect.any(Array) },
+        'WORLD_JOINED param keys'
+      );
     }
   });
 });


### PR DESCRIPTION
## Description

This PR fixes failing component tests in the project-starter template by replacing `mock.module` with `spyOn` for logger mocking.

## Problem

The project-starter template had 3 test files using `mock.module('@elizaos/core')` which completely replaced the logger module, breaking Pino's structured logging behavior. This caused tests to fail when expecting structured log calls like:

```typescript
logger.info({ keys: Object.keys(params) }, 'MESSAGE_RECEIVED param keys');
```

## Solution

Replace `mock.module` with `spyOn` in the following files:
- `src/__tests__/events.test.ts`
- `src/__tests__/error-handling.test.ts`
- `src/__tests__/config.test.ts`

This aligns with the testing approach used in all other starter templates and preserves the original logger behavior while still allowing test assertions.

## Testing

- ✅ All component tests now pass (`elizaos test --type component`)
- ✅ Verified consistency across all starter templates
- ✅ No behavior changes to the actual plugin code

## Impact

This is a test-only fix with no impact on runtime behavior. It ensures developers creating new projects with `elizaos create` will have all tests passing out of the box (as a follow-up to PR #5705 )