### PR TITLE
fix: correct comma placement when adding entries to registry index.json

### DIFF
--- a/packages/cli/src/utils/publisher.ts
+++ b/packages/cli/src/utils/publisher.ts
@@ -441,8 +441,32 @@ export async function publishToGitHub(
           return false;
         }
 
-        // Insert the new entry at the correct alphabetical position
-        lines.splice(insertIndex, 0, newEntry);
+        // Check if we're inserting before the closing brace (last entry)
+        const isLastEntry = lines[insertIndex].trim() === '}';
+        
+        if (isLastEntry) {
+          // Find the previous non-empty line
+          let prevLineIndex = insertIndex - 1;
+          while (prevLineIndex >= 0 && lines[prevLineIndex].trim() === '') {
+            prevLineIndex--;
+          }
+          
+          if (prevLineIndex >= 0) {
+            const prevLine = lines[prevLineIndex];
+            // Check if the previous line needs a comma
+            if (!prevLine.trim().endsWith(',')) {
+              lines[prevLineIndex] = prevLine.trimEnd() + ',';
+            }
+          }
+          
+          // Remove comma from new entry since it's the last one
+          const newEntryWithoutComma = newEntry.slice(0, -1);
+          lines.splice(insertIndex, 0, newEntryWithoutComma);
+        } else {
+          // Not the last entry, keep the comma
+          lines.splice(insertIndex, 0, newEntry);
+        }
+        
         const updatedContent = lines.join('\n');
 
         // Update index.json with minimal change - preserve original structure


### PR DESCRIPTION
## Description

### Problem
The `elizaos publish` command incorrectly handled commas when adding new plugin entries to the registry's `index.json` file:
- Did not add a comma to the previously last entry
- Incorrectly added a comma to the new entry when it became the last entry

This resulted in invalid JSON:
```json
"@elizaos/plugin-action-bench": "github:elizaos-plugins/plugin-action-bench"
"plugin-fal-ai": "github:yungalgo/plugin-fal-ai",
```

### Solution
Modified the insertion logic in `publishToGitHub` function to:
1. Detect if inserting before the closing `}` brace (last entry position)
2. When inserting as last entry:
   - Add comma to the previous entry if it doesn't have one
   - Remove comma from the new entry
3. When inserting in the middle: keep comma on new entry

### Result
Produces valid JSON:
```json
"@elizaos/plugin-action-bench": "github:elizaos-plugins/plugin-action-bench",
"plugin-fal-ai": "github:yungalgo/plugin-fal-ai"
```

### Changes
- `packages/cli/src/utils/publisher.ts`: Updated comma handling logic in lines 444-470
