### PR TITLE
fix: add missing logger property to MockRuntime for bootstrap tests

### DIFF
--- a/packages/plugin-bootstrap/src/__tests__/attachments.test.ts
+++ b/packages/plugin-bootstrap/src/__tests__/attachments.test.ts
@@ -175,7 +175,7 @@ describe('processAttachments', () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]).toEqual(imageAttachment); // Should return original
-    expect(logger.warn).toHaveBeenCalledWith(
+    expect(mockRuntime.logger.warn).toHaveBeenCalledWith(
       '[Bootstrap] Failed to parse XML response for image description'
     );
   });
@@ -209,9 +209,9 @@ describe('processAttachments', () => {
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual(attachments[0]); // First image unchanged due to error
     expect(result[1].description).toBe('Description of second image');
-    expect(logger.error).toHaveBeenCalledWith(
-      '[Bootstrap] Error generating image description:',
-      expect.any(Error)
+    expect(mockRuntime.logger.error).toHaveBeenCalledWith(
+      { error: expect.any(Error) },
+      '[Bootstrap] Error generating image description:'
     );
   });
 

--- a/packages/plugin-bootstrap/src/__tests__/evaluators.test.ts
+++ b/packages/plugin-bootstrap/src/__tests__/evaluators.test.ts
@@ -638,8 +638,8 @@ describe('Multiple Prompt Evaluator Factory', () => {
 
     // Check the warning was logged
     expect(logger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Error in prompt'),
-      expect.any(Error)
+      { error: expect.any(Error) },
+      expect.stringContaining('Error in prompt')
     );
 
     // The result should include the successful prompt's response and an error for the failed one

--- a/packages/plugin-bootstrap/src/__tests__/services.test.ts
+++ b/packages/plugin-bootstrap/src/__tests__/services.test.ts
@@ -223,8 +223,8 @@ describe('TaskService', () => {
 
     // Verify error was logged
     expect(logger.error).toHaveBeenCalledWith(
-      `[Bootstrap] Error executing task ${testTask.id}:`,
-      expect.any(Error)
+      { error: expect.any(Error), taskId: testTask.id },
+      `[Bootstrap] Error executing task ${testTask.id}:`
     );
 
     // Verify error was handled gracefully (original assertions removed as they don't match current executeTask)

--- a/packages/plugin-bootstrap/src/__tests__/test-utils.ts
+++ b/packages/plugin-bootstrap/src/__tests__/test-utils.ts
@@ -46,6 +46,12 @@ export function createMockRuntime(overrides: Partial<MockRuntime> = {}): MockRun
     services: new Map(),
     events: new Map(),
     routes: [],
+    logger: {
+      debug: mock(),
+      warn: mock(),
+      error: mock(),
+      info: mock(),
+    },
 
     // Core methods
     registerPlugin: mock().mockResolvedValue(undefined),
@@ -142,6 +148,9 @@ export function createMockRuntime(overrides: Partial<MockRuntime> = {}): MockRun
       serverId: 'test-server-id',
     }),
     getRooms: mock().mockResolvedValue([
+      { id: 'room-id', name: 'Test Room', worldId: 'test-world-id', serverId: 'test-server-id' },
+    ]),
+    getRoomsByIds: mock().mockResolvedValue([
       { id: 'room-id', name: 'Test Room', worldId: 'test-world-id', serverId: 'test-server-id' },
     ]),
     getWorld: mock().mockResolvedValue({
@@ -379,6 +388,12 @@ export type MockRuntime = Partial<IAgentRuntime & IDatabaseAdapter> & {
   services: Map<string, Service>;
   events: Map<string, ((params: any) => Promise<void>)[]>;
   routes: Route[];
+  logger: {
+    debug: ReturnType<typeof mock>;
+    warn: ReturnType<typeof mock>;
+    error: ReturnType<typeof mock>;
+    info: ReturnType<typeof mock>;
+  };
 
   // Additional properties and methods commonly used in tests
   useModel: ReturnType<typeof mock>;
@@ -387,6 +402,7 @@ export type MockRuntime = Partial<IAgentRuntime & IDatabaseAdapter> & {
   createMemory: ReturnType<typeof mock>;
   getRoom: ReturnType<typeof mock>;
   getRooms: ReturnType<typeof mock>;
+  getRoomsByIds: ReturnType<typeof mock>;
   getWorld: ReturnType<typeof mock>;
   addEmbeddingToMemory: ReturnType<typeof mock>;
   createRelationship: ReturnType<typeof mock>;


### PR DESCRIPTION
## Problem
The failing GitHub Actions test (https://github.com/elizaOS/eliza/actions/runs/17020769599/job/48249463787) was caused by:
- Missing `logger` property in MockRuntime for plugin-bootstrap tests
- Test expectations using old logging format instead of structured logging
- Missing `getRoomsByIds` method in MockRuntime

## Solution
✅ **Added logger to MockRuntime**:
- Added `logger` property to the `MockRuntime` type definition with mock functions for `debug`, `warn`, `error`, and `info`
- Added the logger implementation to the `createMockRuntime` function

✅ **Fixed test expectations for structured logging**:
- Updated attachment tests to check `mockRuntime.logger.warn` instead of imported `logger.warn`
- Updated evaluators test to expect structured logging format: `{ error: expect.any(Error) }, 'message'`
- Updated services test to expect structured logging format for task execution errors

✅ **Added missing methods**:
- Added `getRoomsByIds` method to both the MockRuntime type and implementation

## Results
- **Before**: 10 errors, 1 failing test
- **After**: 126 pass, 0 fail - All tests passing! ✅

## Testing
Verified all tests pass locally:
```
cd packages/plugin-bootstrap && bun test
126 pass, 0 fail
```

This resolves the GitHub Actions failure and ensures the mock runtime properly matches the `IAgentRuntime` interface.