### PR TITLE
feat: getServiceLoadPromise

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -309,7 +309,7 @@ export class AgentRuntime implements IAgentRuntime {
 
         // ensure we have a promise, so when it's actually loaded via registerService,
         // we can trigger the loading of service dependencies
-        if (!this.servicePromises.get(service.serviceType)) {
+        if (!this.servicePromises.has(service.serviceType)) {
           this._createServiceResolver(service.serviceType as ServiceTypeName);
         }
 
@@ -1591,10 +1591,13 @@ export class AgentRuntime implements IAgentRuntime {
   private _createServiceResolver(serviceType: ServiceTypeName) {
     // consider this in the future iterations
     // const { promise, resolve, reject } = Promise.withResolvers<T>();
-    let resolver: ServiceResolver;
+    let resolver: ServiceResolver | undefined;
     this.servicePromises.set(serviceType, new Promise<Service>(resolve => {
       resolver = resolve
     }));
+    if (!resolver) {
+      throw new Error(`Failed to create resolver for service ${serviceType}`)
+    }
     this.servicePromiseHandles.set(serviceType, resolver);
     return this.servicePromises.get(serviceType);
   }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -80,6 +80,8 @@ export class Semaphore {
   }
 }
 
+type ServiceResolver = (service: Service) => void;
+
 export class AgentRuntime implements IAgentRuntime {
   readonly #conversationLength = 32 as number;
   readonly agentId: UUID;
@@ -116,6 +118,8 @@ export class AgentRuntime implements IAgentRuntime {
   public logger;
   private settings: RuntimeSettings;
   private servicesInitQueue = new Set<typeof Service>();
+  private servicePromiseHandles = new Map<string, ServiceResolver>(); // write
+  private servicePromises = new Map<string, Promise<Service>>(); // read
   private currentRunId?: UUID; // Track the current run ID
   private currentActionContext?: {
     // Track current action execution context
@@ -302,6 +306,13 @@ export class AgentRuntime implements IAgentRuntime {
     }
     if (plugin.services) {
       for (const service of plugin.services) {
+
+        // ensure we have a promise, so when it's actually loaded via registerService,
+        // we can trigger the loading of service dependencies
+        if (!this.servicePromises.get(service.serviceType)) {
+          this._createServiceResolver(service.serviceType as ServiceTypeName);
+        }
+
         if (this.isInitialized) {
           await this.registerService(service);
         } else {
@@ -515,18 +526,19 @@ export class AgentRuntime implements IAgentRuntime {
   }
 
   registerAction(action: Action) {
-    this.logger.debug(
-      `${this.character.name}(${this.agentId}) - Registering action: ${action.name}`
-    );
     if (this.actions.find((a) => a.name === action.name)) {
       this.logger.warn(
         `${this.character.name}(${this.agentId}) - Action ${action.name} already exists. Skipping registration.`
       );
     } else {
-      this.actions.push(action);
-      this.logger.debug(
-        `${this.character.name}(${this.agentId}) - Action ${action.name} registered successfully.`
-      );
+      try {
+        this.actions.push(action);
+        this.logger.success(
+          `${this.character.name}(${this.agentId}) - Action ${action.name} registered successfully.`
+        );
+      } catch (e) {
+        console.error('Error registering action', e)
+      }
     }
   }
 
@@ -1159,7 +1171,10 @@ export class AgentRuntime implements IAgentRuntime {
         firstRoom.id
       );
       // pglite handle this at over 10k records fine though
-      await this.addParticipantsRoom(missingIdsInRoom, firstRoom.id);
+      const batches = chunkArray(missingIdsInRoom, 5000);
+      for (const batch of batches) {
+        await this.addParticipantsRoom(batch, firstRoom.id);
+      }
     }
 
     this.logger.success(`Success: Successfully connected world`);
@@ -1548,6 +1563,15 @@ export class AgentRuntime implements IAgentRuntime {
       this.services.get(serviceType)!.push(serviceInstance);
       this.serviceTypes.get(serviceType)!.push(serviceDef);
 
+      // inform everyone that's waiting for this service, that it's now available
+      // removes the need for polling and timers
+      const resolve = this.servicePromiseHandles.get(serviceType)
+      if (resolve) {
+        resolve(serviceInstance)
+      } else {
+        this.logger.debug(`${this.character.name} - Service ${serviceType} has no servicePromiseHandle`)
+      }
+
       if (typeof (serviceDef as any).registerSendHandlers === 'function') {
         (serviceDef as any).registerSendHandlers(this, serviceInstance);
       }
@@ -1561,6 +1585,29 @@ export class AgentRuntime implements IAgentRuntime {
       );
       throw error;
     }
+  }
+
+  /// ensures servicePromises & servicePromiseHandles for a serviceType
+  private _createServiceResolver(serviceType: ServiceTypeName) {
+    // consider this in the future iterations
+    // const { promise, resolve, reject } = Promise.withResolvers<T>();
+    let resolver: ServiceResolver;
+    this.servicePromises.set(serviceType, new Promise<Service>(resolve => {
+      resolver = resolve
+    }));
+    this.servicePromiseHandles.set(serviceType, resolver);
+    return this.servicePromises.get(serviceType);
+  }
+
+  /// returns a promise that's resolved once this service is loaded
+  getServiceLoadPromise(serviceType: ServiceTypeName): Promise<Service> {
+    // if this.isInitialized then the this p will exist and already be resolved
+    let p = this.servicePromises.get(serviceType);
+    if (!p) {
+      // not initalized or registered yet, registerPlugin is already smart enough to check to see if we make it here
+      p = this._createServiceResolver(serviceType);
+    }
+    return p;
   }
 
   registerModel(

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -54,7 +54,7 @@ export function getSalt(): string {
 
   const salt = secretSalt;
 
-  logger.debug(`Generated salt with length: ${salt.length} (truncated for security)`);
+  //logger.debug(`Generated salt with length: ${salt.length} (truncated for security)`);
   return salt;
 }
 

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -47,6 +47,8 @@ export interface IAgentRuntime extends IDatabaseAdapter {
 
   registerService(service: typeof Service): Promise<void>;
 
+  getServiceLoadPromise(serviceType: ServiceTypeName): Promise<Service>;
+
   getRegisteredServiceTypes(): ServiceTypeName[];
 
   hasService(serviceType: ServiceTypeName | string): boolean;

--- a/packages/plugin-bootstrap/src/index.ts
+++ b/packages/plugin-bootstrap/src/index.ts
@@ -1663,7 +1663,8 @@ export const bootstrapPlugin: Plugin = {
     providers.factsProvider,
     providers.roleProvider,
     providers.settingsProvider,
-    providers.capabilitiesProvider,
+    // there is given no reason for this - odi
+    //providers.capabilitiesProvider,
     providers.attachmentsProvider,
     providers.providersProvider,
     providers.actionsProvider,

--- a/packages/plugin-sql/src/base.ts
+++ b/packages/plugin-sql/src/base.ts
@@ -873,7 +873,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<any> {
     return this.withDatabase(async () => {
       await this.db.insert(componentTable).values({
         ...component,
-        createdAt: new Date(component.createdAt),
+        createdAt: new Date(),
       });
       return true;
     });
@@ -890,7 +890,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<any> {
         .update(componentTable)
         .set({
           ...component,
-          createdAt: new Date(component.createdAt),
+          updatedAt: new Date(),
         })
         .where(eq(componentTable.id, component.id));
     });

--- a/packages/test-utils/src/mocks/runtime.ts
+++ b/packages/test-utils/src/mocks/runtime.ts
@@ -100,6 +100,7 @@ export function createMockRuntime(overrides: MockRuntimeOverrides = {}): IAgentR
     getServicesByType: mock().mockReturnValue([]),
     getAllServices: mock().mockReturnValue(new Map()),
     registerService: mock().mockResolvedValue(undefined),
+    getServiceLoadPromise: mock().mockResolvedValue(null),
     getRegisteredServiceTypes: mock().mockReturnValue([]),
     hasService: mock().mockReturnValue(false),
     registerDatabaseAdapter: mock(),


### PR DESCRIPTION
# Risks

Low

# Background

## What does this PR do?

- add getServiceLoadPromise interface to runtime
- fix component queries in plugin-sql (was too easy for dates to get invalid, this is a more flexible set up, allowing the intended effect)
- remove bootstrap capabilities
- fixes ensureConnections large addPartipants, now does it in batches
- lower logging

## What kind of change is this?

Improvements (misc. changes to existing features)

## Why are we doing this? Any context or related work?

removes the need for polling and timers when waiting for a service to be available in initialization

# Documentation changes needed?

My changes do not require a change to the project documentation.