### PR TITLE
fix: Remove duplicate actionNames block from message handler template

### DIFF
--- a/packages/core/src/__tests__/prompts.test.ts
+++ b/packages/core/src/__tests__/prompts.test.ts
@@ -23,7 +23,6 @@ describe('Prompts', () => {
     it('messageHandlerTemplate should contain required placeholders and structure', () => {
       expect(messageHandlerTemplate).toContain('{{agentName}}');
       expect(messageHandlerTemplate).toContain('{{providers}}');
-      expect(messageHandlerTemplate).toContain('{{actionNames}}');
       expect(messageHandlerTemplate).toContain('<response>');
       expect(messageHandlerTemplate).toContain('</response>');
       expect(messageHandlerTemplate).toContain('<thought>');

--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -29,11 +29,6 @@ export const messageHandlerTemplate = `<task>Generate dialog and actions for the
 {{providers}}
 </providers>
 
-These are the available valid actions:
-<actionNames>
-{{actionNames}}
-</actionNames>
-
 <instructions>
 Write a thought and plan for {{agentName}} and decide what actions to take. Also include the providers that {{agentName}} will use to have the right context for responding and acting, if any.
 


### PR DESCRIPTION
The actionNames block was appearing twice in the messageHandlerTemplate: once correctly inside the <providers> section and once redundantly after it. This PR removes the duplicated block after the </providers> tag to streamline the template and prevent confusion.

<img width="576" height="602" alt="Screenshot 2025-08-25 at 11 07 54 PM" src="https://github.com/user-attachments/assets/5d699b17-7740-4aab-8d8c-0bbc5a8aa0aa" />


<img width="576" height="429" alt="Screenshot 2025-08-25 at 11 08 24 PM" src="https://github.com/user-attachments/assets/81aea391-f0c0-4644-92c3-a552d96ac4ff" />
