### PR TITLE
Feat: initPromise & always include runtime in emitted events

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -121,6 +121,8 @@ export class AgentRuntime implements IAgentRuntime {
   private servicesInitQueue = new Set<typeof Service>();
   private servicePromiseHandles = new Map<string, ServiceResolver>(); // write
   private servicePromises = new Map<string, Promise<Service>>(); // read
+  public initPromise;
+  private initResolver;
   private currentRunId?: UUID; // Track the current run ID
   private currentActionContext?: {
     // Track current action execution context
@@ -151,6 +153,10 @@ export class AgentRuntime implements IAgentRuntime {
       stringToUuid(opts.character?.name ?? uuidv4() + opts.character?.username);
     this.character = opts.character as Character;
     const logLevel = process.env.LOG_LEVEL || 'info';
+
+    this.initPromise = new Promise(resolve => {
+      this.initResolver = resolve
+    })
 
     // Create the logger with appropriate level - only show debug logs when explicitly configured
     this.logger = createLogger({
@@ -441,6 +447,7 @@ export class AgentRuntime implements IAgentRuntime {
       await this.registerService(service);
     }
     this.isInitialized = true;
+    this.initResolver() // resolve initPromise
   }
 
   async runPluginMigrations(): Promise<void> {
@@ -1905,7 +1912,7 @@ export class AgentRuntime implements IAgentRuntime {
         continue;
       }
       try {
-        await Promise.all(eventHandlers.map((handler) => handler(params)));
+        await Promise.all(eventHandlers.map((handler) => handler({...params, runtime: this })));
       } catch (error) {
         this.logger.error(`Error during emitEvent for ${eventName} (handler execution): ${error}`);
         // throw error; // Re-throw if necessary

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1912,7 +1912,11 @@ export class AgentRuntime implements IAgentRuntime {
         continue;
       }
       try {
-        await Promise.all(eventHandlers.map((handler) => handler({...params, runtime: this })));
+        let paramsWithRuntime = { runtime: this }
+        if (typeof(params) === 'object') {
+          paramsWithRuntime = {...params, ...paramsWithRuntime }
+        }
+        await Promise.all(eventHandlers.map((handler) => handler(paramsWithRuntime)));
       } catch (error) {
         this.logger.error(`Error during emitEvent for ${eventName} (handler execution): ${error}`);
         // throw error; // Re-throw if necessary

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1913,7 +1913,7 @@ export class AgentRuntime implements IAgentRuntime {
       }
       try {
         let paramsWithRuntime = { runtime: this }
-        if (typeof(params) === 'object') {
+        if (typeof(params) === 'object' && params) {
           paramsWithRuntime = {...params, ...paramsWithRuntime }
         }
         await Promise.all(eventHandlers.map((handler) => handler(paramsWithRuntime)));


### PR DESCRIPTION
# Risks

Low

# Background

## What does this PR do?

- creates an initPromise property
- ensures runtime is always in emitted events

## What kind of change is this?

Updates (new versions of included code)

## Why are we doing this? Any context or related work?

Before any plugin init() can delete tasks, adapter has to be ready

# Documentation changes needed?

My changes do not require a change to the project documentation.