### PR TITLE
fix: make environment loading lazy to prevent warnings during CLI startup

### DIFF
--- a/packages/cli/src/commands/scenario/src/runtime-factory.ts
+++ b/packages/cli/src/commands/scenario/src/runtime-factory.ts
@@ -10,12 +10,18 @@ import path from 'node:path';
 import { createServer } from 'node:net';
 import { processManager } from './process-manager';
 
-// --- Start of Pre-emptive Environment Loading ---
-loadEnvironmentVariables();
+// Lazy initialization of environment settings
+let envSettings: RuntimeSettings | null = null;
+let envLoaded = false;
 
-// Get the loaded environment settings
-const envSettings = process.env as RuntimeSettings;
-// --- End of Pre-emptive Environment Loading ---
+function ensureEnvLoaded(): RuntimeSettings {
+  if (!envLoaded) {
+    loadEnvironmentVariables();
+    envSettings = process.env as RuntimeSettings;
+    envLoaded = true;
+  }
+  return envSettings!;
+}
 
 /**
  * Find an available port in the given range
@@ -182,7 +188,7 @@ export async function createScenarioAgent(
     plugins: pluginNames,
     settings: {
       secrets: {
-        ...envSettings,
+        ...ensureEnvLoaded(),
       },
     },
     // Always respond: set system prompt and template to ensure reply

--- a/packages/cli/src/commands/scenario/src/runtime-factory.ts
+++ b/packages/cli/src/commands/scenario/src/runtime-factory.ts
@@ -20,7 +20,12 @@ function ensureEnvLoaded(): RuntimeSettings {
     envSettings = process.env as RuntimeSettings;
     envLoaded = true;
   }
-  return envSettings!;
+
+  if (!envSettings) {
+    throw new Error('Failed to load environment settings');
+  }
+
+  return envSettings;
 }
 
 /**


### PR DESCRIPTION
## Problem

When running any ElizaOS CLI command (like `elizaos create`), users see confusing environment warnings:

```
[ENV] No .env file found in any of the expected locations
[ENV] ⚠️ OPENAI_API_KEY not found in process.env
[ENV] Safe env preview: {"NODE_ENV":"<missing>","OPENAI_API_KEY":"<missing>"}
```

These warnings appear even for commands that don't need environment variables, like `elizaos create` which is setting up a new project that doesn't have a `.env` file yet.

## Root Cause

The issue was in `packages/cli/src/commands/scenario/src/runtime-factory.ts`:
- The module had a top-level call to `loadEnvironmentVariables()` that executed immediately when the module was imported
- The CLI's main entry point imports all commands at startup, including the scenario command
- The scenario command imports `runtime-factory.ts`
- This caused environment checking to happen for every CLI command, not just when needed

## Solution

Made the environment loading lazy by:
1. Removing the top-level `loadEnvironmentVariables()` call
2. Creating an `ensureEnvLoaded()` function that loads environment variables only when first accessed
3. Updating the code to use `ensureEnvLoaded()` instead of directly accessing `envSettings`

## Testing

Tested both:
- `elizaos create` - No environment warnings appear ✅
- `bun run packages/cli/dist/index.js create` - No environment warnings appear ✅

The environment variables are still loaded correctly when actually needed by the scenario command.