### PR TITLE
fix: correct logger.error parameter order in imageGeneration action

### DIFF
--- a/packages/plugin-bootstrap/src/actions/imageGeneration.ts
+++ b/packages/plugin-bootstrap/src/actions/imageGeneration.ts
@@ -76,10 +76,13 @@ export const generateImageAction = {
       });
 
       if (!imageResponse || imageResponse.length === 0 || !imageResponse[0]?.url) {
-        logger.error('generateImageAction: Image generation failed - no valid response received', {
-          imageResponse,
-          imagePrompt,
-        });
+        logger.error(
+          {
+            imageResponse,
+            imagePrompt,
+          },
+          'generateImageAction: Image generation failed - no valid response received'
+        );
         return {
           text: 'Image generation failed',
           values: {
@@ -131,10 +134,13 @@ export const generateImageAction = {
       };
     } catch (error) {
       const err = error as Error;
-      logger.error('generateImageAction: Exception during image generation', {
-        message: err.message,
-        stack: err.stack,
-      });
+      logger.error(
+        {
+          message: err.message,
+          stack: err.stack,
+        },
+        'generateImageAction: Exception during image generation'
+      );
       return {
         text: 'Image generation failed',
         values: {


### PR DESCRIPTION
## Summary

Fixes TypeScript compilation errors in the `@elizaos/plugin-bootstrap` package by correcting the parameter order in `logger.error` calls.

## Changes

- Updated `logger.error` calls in `imageGeneration.ts` to use correct signature: object first, message second
- This resolves the build failures that were preventing the package from compiling

## Testing

- ✅ Build now completes successfully without TypeScript errors
- ✅ All existing functionality preserved

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Build system or external dependency change

## Files Changed

- `packages/plugin-bootstrap/src/actions/imageGeneration.ts`

## Before/After

**Before (incorrect):**
```typescript
logger.error('message', { data: 'value' });
```

**After (correct):**
```typescript
logger.error({ data: 'value' }, 'message');
```

## Why This Fix Was Needed

The ElizaOS logger interface expects:
```typescript
type LogFn = (
  obj: Record<string, unknown> | string | Error,  // First: object or string
  msg?: string,                                   // Second: optional message
  ...args: unknown[]                              // Additional args
) => void;
```

The original code was passing the message string first and the object second, causing TypeScript compilation errors.