### PR TITLE
fix: Fix multi-step action result handling to properly pass values between steps

### DIFF
--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -169,7 +169,9 @@ In each step, decide:
 
 1. **Which providers (if any)** should be called to gather necessary data.
 2. **Which action (if any)** should be executed after providers return.
-3. Whether the task is now complete — if so, mark it as finished.
+3. Decide whether the task is complete. If so, set \`isFinish: true\`. Do not select the \`REPLY\` action; replies are handled separately after task completion.
+
+⚠️ IMPORTANT: Do **not** mark the task as \`isFinish: true\` immediately after calling an action like. Wait for the action to complete before deciding the task is finished.
 
 You can select **multiple providers** and at most **one action** per step.
 

--- a/packages/plugin-bootstrap/src/index.ts
+++ b/packages/plugin-bootstrap/src/index.ts
@@ -1077,7 +1077,7 @@ async function runMultiStepCore({ runtime, message, state, callback }): Promise<
           data: { actionName: action },
           success,
           text: result?.text,
-          values: result.values,
+          values: result?.values,
           error: success ? undefined : result?.text,
         });
       }

--- a/packages/plugin-bootstrap/src/index.ts
+++ b/packages/plugin-bootstrap/src/index.ts
@@ -68,6 +68,7 @@ interface MultiStepActionResult {
   success: boolean;
   text?: string;
   error?: string | Error;
+  values?: Record<string, any>;
 }
 
 /**
@@ -1076,6 +1077,7 @@ async function runMultiStepCore({ runtime, message, state, callback }): Promise<
           data: { actionName: action },
           success,
           text: result?.text,
+          values: result.values,
           error: success ? undefined : result?.text,
         });
       }


### PR DESCRIPTION
# Fix Multi-Step Action Result Handling

## What Changed

### Core Fix
- **Fixed multi-step action result handling** to properly pass `values` between action steps
- Added `values?: Record<string, any>` to `MultiStepActionResult` interface
- Updated `runMultiStepCore` to include `values: result.values` when storing action results

### Prompt Improvements
- **Clarified task completion logic** in multi-step action prompts
- Added explicit instruction: "Do **not** mark the task as `isFinish: true` immediately after calling an action"
- Emphasized waiting for action completion before marking tasks as finished

## Why This Matters

The main issue was that multi-step actions weren't properly passing `values` between steps, which caused:
- **Image generation actions** to only return action text instead of the final image result
- **Data loss** between action steps in complex workflows
- **Incomplete results** when actions needed to build upon previous step outputs

before:

<img width="1213" height="846" alt="Screenshot 2025-08-28 at 3 58 21 PM" src="https://github.com/user-attachments/assets/f585552c-48ce-4c82-a5dd-9a04a96d5a83" />


after:

<img width="1214" height="766" alt="Screenshot 2025-08-28 at 3 58 11 PM" src="https://github.com/user-attachments/assets/65bae039-cae3-42e4-9a25-f723867f27bf" />

