### PR TITLE
fix(core): fix TypeScript declarations in npm package

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4010,6 +4010,8 @@
 
     "@elizaos/api-client/@types/node": ["@types/node@24.3.0", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow=="],
 
+    "@elizaos/api-client/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+
     "@elizaos/cli/@types/node": ["@types/node@24.3.0", "", { "dependencies": { "undici-types": "~7.10.0" } }, "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow=="],
 
     "@elizaos/cli/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],

--- a/packages/core/build.ts
+++ b/packages/core/build.ts
@@ -136,23 +136,16 @@ export * from './node/index.node.js';
 
   await fs.writeFile('dist/index.js', mainIndex);
 
-  // Create a simple index.d.ts that re-exports from the built node types by default
-  // This aligns the root types with the default runtime entry (node/bun)
+  // Create a simple index.d.ts that re-exports from the actual generated types
+  // The types directory contains the real TypeScript declarations
   const typeIndex = `// Type definitions for @elizaos/core
-// Re-export all types from the built Node entry by default
+// Re-export all types from the generated types directory
 
-export * from './node/index';
+export * from './types/index';
 `;
 
   await fs.writeFile('dist/index.d.ts', typeIndex);
 
-  // Also ensure the package.json "types" field can resolve correctly
-  // by creating fallback declaration files
-  await fs.mkdir('dist/node', { recursive: true });
-  await fs.mkdir('dist/browser', { recursive: true });
-
-  await fs.writeFile('dist/node/index.d.ts', `export * from '../../src/index.node';`);
-  await fs.writeFile('dist/browser/index.d.ts', `export * from '../../src/index.browser';`);
 
   console.log('📝 Created index files and type definitions for module resolution');
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,12 +23,12 @@
       "default": "./dist/node/index.node.js"
     },
     "./node": {
-      "types": "./dist/node/index.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/node/index.node.js",
       "default": "./dist/node/index.node.js"
     },
     "./browser": {
-      "types": "./dist/browser/index.d.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/browser/index.browser.js",
       "default": "./dist/browser/index.browser.js"
     }


### PR DESCRIPTION
Point package.json to existing generated types instead of broken re-exports to src/

  # Risks

  **Low** - This is a build configuration fix that corrects broken TypeScript declarations without changing any runtime behavior.

  # Background

  ## What does this PR do?

  Fixes broken TypeScript imports in the published `@elizaos/core@1.5.0` npm package by:
  1. Removing problematic `.d.ts` file creation that re-exports from missing `src/` directories
  2. Pointing `package.json` to the existing, properly generated TypeScript declarations
  3. Using the robust type definitions already created by the build system

  ## What kind of change is this?

  **Bug fix** (non-breaking change which fixes an issue)

  ## Why are we doing this?

  After PR #5832, consumers of the published npm package experience TypeScript compilation failures:

  ```typescript
  error TS2305: Module '"@elizaos/core"' has no exported member 'IAgentRuntime'.
  error TS2305: Module '"@elizaos/core"' has no exported member 'Plugin'.
  error TS2305: Module '"@elizaos/core"' has no exported member 'logger'.
  ```
  Root cause: The build script creates .d.ts files that reference src/ directories:
  await fs.writeFile('dist/node/index.d.ts', `export * from '../../src/index.node';`);

  However, src/ is not included in the published npm package, breaking type resolution.

#    Testing

##   Where should a reviewer start?

  1. Review the changes in packages/core/build.ts and packages/core/package.json
  2. Verify that dist/types/index.d.ts contains the actual TypeScript declarations
  3. Test that TypeScript compilation works with the fixed package

##    Detailed testing steps

  - Clone the repository and checkout this branch
  - Build the core package: cd packages/core && bun run build
  - Verify dist/types/index.d.ts exists and contains proper type definitions
  - Test in a consuming package:
  import { IAgentRuntime, Plugin, logger } from '@elizaos/core';
  // Should compile without errors
  - Run npx tsc --noEmit to verify TypeScript compilation succeeds

## Before

  error TS2305: Module '"@elizaos/core"' has no exported member 'IAgentRuntime'.
  error TS2305: Module '"@elizaos/core"' has no exported member 'Plugin'.
  error TS2305: Module '"@elizaos/core"' has no exported member 'logger'.

## After

  ✅ TypeScript compilation succeeds
  ✅ All exports properly typed
  ✅ Compatible with Node.js and browser builds