### PR TITLE
fix(discord): Enable image generation in Discord channels

### DIFF
--- a/packages/plugin-bootstrap/src/actions/imageGeneration.ts
+++ b/packages/plugin-bootstrap/src/actions/imageGeneration.ts
@@ -115,7 +115,14 @@ export const generateImageAction = {
         text: imagePrompt,
       };
 
-      await callback(responseContent);
+      await callback(responseContent, [
+        {
+          id: v4(),
+          attachment: imageUrl,
+          name: 'Generated_Image.png',
+          contentType: ContentType.IMAGE,
+        },
+      ]); 
 
       return {
         text: 'Generated image',

--- a/packages/plugin-bootstrap/src/index.ts
+++ b/packages/plugin-bootstrap/src/index.ts
@@ -628,10 +628,10 @@ const messageReceivedHandler = async ({
               // without actions there can't be more than one message
               await callback(responseContent);
             } else if (mode === 'actions') {
-              await runtime.processActions(message, responseMessages, state, async (content) => {
-                runtime.logger.debug({ content }, 'action callback');
+              await runtime.processActions(message, responseMessages, state, async (content, files) => {
+                runtime.logger.debug({ content, files }, 'action callback');
                 responseContent!.actionCallbacks = content;
-                return callback(content);
+                return callback(content, files);
               });
             }
           }


### PR DESCRIPTION
related: https://github.com/elizaOS/eliza/issues/5809

result:


<img width="917" height="668" alt="Screenshot 2025-09-02 at 12 15 04 AM" src="https://github.com/user-attachments/assets/c90d8494-eeec-4353-b633-91e4fc824c5d" />


# Fix Discord Image Generation

## Problem

When users requested image generation in Discord, the bot would generate images but fail to send them to Discord at all. The `files` parameter was undefined in the callback chain, resulting in no images being displayed in Discord channels despite successful generation.

## Solution

This PR fixes the image generation functionality for Discord by ensuring generated images are sent as proper Discord file attachments that display inline.

### Changes Made

#### 1. **Updated Image Generation Action** (`packages/plugin-bootstrap/src/actions/imageGeneration.ts`)
- Modified the image generation callback to include file attachments
- Now sends generated images as proper Discord attachments with metadata:
  ```typescript
  await callback(responseContent, [
    {
      id: v4(),
      attachment: imageUrl,
      name: 'Generated_Image.png',
      contentType: ContentType.IMAGE,
    },
  ]);
  ```

#### 2. **Enhanced Action Processing System** (`packages/plugin-bootstrap/src/index.ts`)
- Updated action callback handling to properly pass file attachments:
  ```typescript
  await runtime.processActions(message, responseMessages, state, async (content, files) => {
    runtime.logger.debug({ content, files }, 'action callback');
    responseContent!.actionCallbacks = content;
    return callback(content, files);
  });
  ```

## Impact

❌ **Before**: Image generation requests resulted in no images being sent to Discord  
✅ **After**: Generated images display as proper inline Discord attachments

This enables image generation functionality in Discord for the first time, allowing users to request and view AI-generated images directly in Discord channels.

## Technical Details

The Discord plugin infrastructure already supported file attachments via:
- `sendMessageInChunks()` function with `files` parameter
- `HandlerCallback` interface accepting file attachments

However, the image generation action was not passing the `files` parameter, causing it to be undefined throughout the callback chain. This fix connects the image generation action to the existing Discord attachment infrastructure.

## Testing

- [x] Image generation works in Discord channels
- [x] Generated images display as inline attachments
- [x] Existing functionality remains unaffected
- [x] File attachment handling works correctly


