### PR TITLE
Version Bump to 1.5.5-alpha.1

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,8 @@
 {
-  "version": "1.4.3-alpha.6",
-  "packages": ["packages/*"],
+  "version": "1.5.5-alpha.1",
+  "packages": [
+    "packages/*"
+  ],
   "npmClient": "bun",
   "command": {
     "publish": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/api-client",
-  "version": "1.4.3-alpha.6",
+  "version": "1.5.5-alpha.1",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "module": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/cli",
-  "version": "1.4.3-alpha.6",
+  "version": "1.5.5-alpha.1",
   "description": "elizaOS CLI - Manage your AI agents and plugins",
   "publishConfig": {
     "access": "public",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/config",
   "description": "Shared configuration for ElizaOS projects and plugins",
-  "version": "1.4.3-alpha.6",
+  "version": "1.5.5-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/core",
-  "version": "1.4.3-alpha.6",
+  "version": "1.5.5-alpha.1",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/plugin-bootstrap/package.json
+++ b/packages/plugin-bootstrap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-bootstrap",
-  "version": "1.4.3-alpha.6",
+  "version": "1.5.5-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/plugin-dummy-services/package.json
+++ b/packages/plugin-dummy-services/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-dummy-services",
-  "version": "1.4.3-alpha.6",
+  "version": "1.5.5-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/plugin-sql/package.json
+++ b/packages/plugin-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-sql",
-  "version": "1.4.3-alpha.6",
+  "version": "1.5.5-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/server",
-  "version": "1.4.3-alpha.6",
+  "version": "1.5.5-alpha.1",
   "description": "ElizaOS Server - Core server infrastructure for ElizaOS agents",
   "publishConfig": {
     "access": "public",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/test-utils",
   "description": "Utilities and objects for unit testing",
-  "version": "1.4.3-alpha.6",
+  "version": "1.5.5-alpha.1",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
This PR bumps the version across the entire monorepo from 1.4.3-alpha.6 to 1.5.5-alpha.1.

## Changes Made

### Version Updates
- Updated version in  from 1.4.3-alpha.6 to 1.5.5-alpha.1
- Updated version in all package.json files across the monorepo:
  - 
  - 
  - 
  - 
  - 
  - 
  - 
  - 
  - 

### Formatting Improvements
- Updated  packages array format for better consistency
- Ensured consistent formatting and newlines across all package.json files

## Issue Context

This version bump represents a significant update across the entire monorepo, moving from version 1.4.3-alpha.6 to 1.5.5-alpha.1. This change ensures all packages are aligned with the new version and maintains consistency across the project.

## Testing

All package versions have been updated consistently across the monorepo. The changes only affect version numbers and minor formatting improvements, so no functional changes are expected.