### PR TITLE
fix: simplify alpha CLI tests to run basic smoke tests

### DIFF
--- a/.github/workflows/alpha-cli-tests.yml
+++ b/.github/workflows/alpha-cli-tests.yml
@@ -6,8 +6,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GH_TOKEN: ${{ secrets.GH_TOKEN }}
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
   ELIZA_NONINTERACTIVE: true
 
@@ -23,7 +21,7 @@ jobs:
     # Only run if the NPM Alpha Release workflow succeeded (or manual trigger)
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45 # Prevent job timeout from killing processes prematurely
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -38,24 +36,6 @@ jobs:
         with:
           bun-version: 1.2.21
 
-      - name: Mention Bun version
-        run: bun --version
-
-      - name: Debug Bun Setup
-        shell: bash
-        run: |
-          echo "PATH: $PATH"
-          echo "which bun: $(which bun 2>/dev/null || echo 'which not found')"
-          echo "command -v bun: $(command -v bun 2>/dev/null || echo 'command not found')"
-          if command -v bun &> /dev/null; then
-            BUN_PATH=$(which bun 2>/dev/null || command -v bun)
-            echo "Bun found at: $BUN_PATH"
-            ls -la "$BUN_PATH" 2>/dev/null || echo "Failed to ls bun"
-            file "$BUN_PATH" 2>/dev/null || echo "Failed to get bun file info"
-          else
-            echo "Bun not found in PATH"
-          fi
-
       - name: Install @elizaos/cli from npm (alpha tag)
         shell: bash
         run: |
@@ -65,22 +45,16 @@ jobs:
       - name: Verify elizaos installation
         shell: bash
         run: |
-          echo "Verifying @elizaos/cli package is available..."
-          bun pm ls -g | grep "@elizaos/cli" || echo "@elizaos/cli not found in global links"
-
           echo "Verifying elizaos command is available..."
           which elizaos || echo "elizaos not found in PATH"
           elizaos --version || echo "Failed to run elizaos --version"
 
-      - name: Verify CLI installation
+      - name: Clean test artifacts
         shell: bash
         run: |
-          echo "Checking CLI installation..."
-          elizaos --version || echo "Failed to run elizaos --version"
-
-      - name: Clean eliza projects cache
-        shell: bash
-        run: rm -rf ~/.eliza/projects
+          rm -rf ~/.eliza/projects
+          rm -rf test-new-agent
+          rm -rf plugin-test-plugin
 
       - name: Create .env file for tests
         shell: bash
@@ -88,31 +62,118 @@ jobs:
           echo "OPENAI_API_KEY=$OPENAI_API_KEY" > .env
           echo "LOG_LEVEL=info" >> .env
 
-      - name: Install cross-env globally
-        run: bun install -g cross-env
-
-      - name: Install BATS on macOS
-        if: matrix.os == 'macos-latest'
-        run: bun install -g bats
-
-      - name: Create shim so tests hit global alpha CLI
+      - name: Run Basic CLI Smoke Tests
         shell: bash
         run: |
-          mkdir -p packages/cli/dist
-          cat > packages/cli/dist/index.js <<'EOF'
-          #!/usr/bin/env bun
-          const args = process.argv.slice(2);
-          const proc = Bun.spawnSync(['elizaos', ...args], {
-            stdin: 'inherit',
-            stdout: 'inherit',
-            stderr: 'inherit',
-          });
-          process.exit(typeof proc.exitCode === 'number' ? proc.exitCode : 1);
-          EOF
-          chmod +x packages/cli/dist/index.js
-
-      - name: Run CLI TypeScript tests
-        run: cross-env bun test tests/commands/
-        working-directory: packages/cli
-        env:
-          ELIZA_TEST_MODE: true
+          set -e
+          echo "=== Running Basic CLI Smoke Tests ==="
+          
+          # Test 1: Version command
+          echo "Test 1: Testing elizaos -v"
+          elizaos -v
+          echo "✓ Version command works"
+          echo ""
+          
+          # Test 2: Create new agent
+          echo "Test 2: Creating new agent"
+          elizaos create test-new-agent -y
+          echo "✓ Agent created successfully"
+          echo ""
+          
+          # Test 3: Start agent (timeout after 30s to ensure it starts properly)
+          echo "Test 3: Starting agent"
+          cd test-new-agent
+          
+          # Create a cross-platform timeout wrapper
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            # Windows: Use PowerShell with timeout
+            powershell -Command "
+              \$process = Start-Process -FilePath 'elizaos' -ArgumentList 'start' -NoNewWindow -PassThru -RedirectStandardOutput 'start.log' -RedirectStandardError 'start-error.log'
+              \$process | Wait-Process -Timeout 30 -ErrorAction SilentlyContinue
+              if (!\$process.HasExited) { 
+                \$process | Stop-Process -Force 
+              }
+            " || true
+            cat start.log start-error.log 2>/dev/null > combined.log || cat start.log > combined.log || true
+            START_LOG="combined.log"
+          elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            # macOS: Use gtimeout if available, otherwise background process with sleep
+            if command -v gtimeout &> /dev/null; then
+              gtimeout 30s elizaos start 2>&1 | tee start.log || true
+            else
+              # Fallback: Run in background and kill after timeout
+              elizaos start > start.log 2>&1 &
+              PID=$!
+              sleep 30
+              kill $PID 2>/dev/null || true
+            fi
+            START_LOG="start.log"
+          else
+            # Linux: Use timeout command
+            timeout 30s elizaos start 2>&1 | tee start.log || true
+            START_LOG="start.log"
+          fi
+          
+          # Check for success messages from AgentServer
+          if grep -i "startup successful" "$START_LOG" || grep -i "listening on port" "$START_LOG" || grep -i "agentserver is listening" "$START_LOG" || grep -i "starting server" "$START_LOG"; then
+            echo "✓ Agent started successfully"
+          else
+            echo "✗ Agent failed to start - checking log contents:"
+            cat "$START_LOG"
+            exit 1
+          fi
+          cd ..
+          echo ""
+          
+          # Test 4: Create plugin
+          echo "Test 4: Creating plugin"
+          elizaos create -t plugin test-plugin
+          echo "✓ Plugin created successfully"
+          echo ""
+          
+          # Test 5: Run plugin dev (timeout after 30s to ensure it starts)
+          echo "Test 5: Starting plugin dev mode"
+          cd plugin-test-plugin
+          
+          # Create a cross-platform timeout wrapper
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            # Windows: Use PowerShell with timeout
+            powershell -Command "
+              \$process = Start-Process -FilePath 'elizaos' -ArgumentList 'dev' -NoNewWindow -PassThru -RedirectStandardOutput 'dev.log' -RedirectStandardError 'dev-error.log'
+              \$process | Wait-Process -Timeout 30 -ErrorAction SilentlyContinue
+              if (!\$process.HasExited) { 
+                \$process | Stop-Process -Force 
+              }
+            " || true
+            cat dev.log dev-error.log 2>/dev/null > combined-dev.log || cat dev.log > combined-dev.log || true
+            DEV_LOG="combined-dev.log"
+          elif [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            # macOS: Use gtimeout if available, otherwise background process with sleep
+            if command -v gtimeout &> /dev/null; then
+              gtimeout 30s elizaos dev 2>&1 | tee dev.log || true
+            else
+              # Fallback: Run in background and kill after timeout
+              elizaos dev > dev.log 2>&1 &
+              PID=$!
+              sleep 30
+              kill $PID 2>/dev/null || true
+            fi
+            DEV_LOG="dev.log"
+          else
+            # Linux: Use timeout command
+            timeout 30s elizaos dev 2>&1 | tee dev.log || true
+            DEV_LOG="dev.log"
+          fi
+          
+          # Check for success messages from dev server
+          if grep -i "starting server" "$DEV_LOG" || grep -i "watching" "$DEV_LOG" || grep -i "startup successful" "$DEV_LOG" || grep -i "ready" "$DEV_LOG" || grep -i "development" "$DEV_LOG"; then
+            echo "✓ Plugin dev mode started successfully"
+          else
+            echo "✗ Plugin dev mode failed to start - checking log contents:"
+            cat "$DEV_LOG"
+            exit 1
+          fi
+          cd ..
+          echo ""
+          
+          echo "=== All tests passed! ==="


### PR DESCRIPTION
## Problem

The alpha CLI tests workflow was overly complex and fragile:
- Running full TypeScript test suites that may not be compatible with the published alpha package
- Complex setup with shims and cross-env dependencies
- Tests were too comprehensive for a smoke test validation
- Excessive debugging output and unnecessary steps
- 45-minute timeout was too long for basic validation

## Solution

This PR simplifies the alpha CLI tests to focus on basic smoke tests that validate the core functionality:

### Tests Implemented
1. **Version check** - `elizaos -v` works
2. **Create agent** - `elizaos create test-new-agent -y` successfully creates project
3. **Start agent** - `cd test-new-agent && elizaos start` starts the server
4. **Create plugin** - `elizaos create -t plugin test-plugin` creates plugin
5. **Dev mode** - `cd plugin-test-plugin && elizaos dev` runs development server

### Key Improvements
- ✅ Cross-platform timeout handling for Windows/macOS/Linux
- ✅ Proper success detection based on actual AgentServer output messages
- ✅ Simplified test structure with clear pass/fail indicators
- ✅ Reduced timeout from 45 to 20 minutes
- ✅ Removed unnecessary dependencies (cross-env, BATS)
- ✅ Cleaner output with just essential information

### Testing
The tests now properly detect server startup by looking for:
- "Startup successful"
- "AgentServer is listening"
- "Starting server"
- "Watching" (for dev mode)

This ensures the alpha package is functional across all platforms before users download it.