### PR TITLE
fix: Scope npmPackage field for registry entries

### DIFF
--- a/packages/cli/src/commands/publish/actions/npm-publish.ts
+++ b/packages/cli/src/commands/publish/actions/npm-publish.ts
@@ -15,7 +15,7 @@ export async function publishToNpm(
 
   // Update npmPackage field if it's a placeholder or not set
   if (!packageJson.npmPackage || packageJson.npmPackage === '${NPM_PACKAGE}') {
-    packageJson.npmPackage = packageJson.name;
+    packageJson.npmPackage = `@${npmUsername}/${packageJson.name}`;
     console.info(`Set npmPackage to: ${packageJson.npmPackage}`);
 
     // Save updated package.json

--- a/packages/cli/src/utils/publisher.ts
+++ b/packages/cli/src/utils/publisher.ts
@@ -28,6 +28,7 @@ interface PackageJson {
   platform?: 'node' | 'browser' | 'universal';
   packageType?: 'plugin' | 'project';
   type?: string; // 'module' or 'commonjs' for Node.js module format
+  npmPackage?: string;
 }
 
 /**
@@ -376,8 +377,8 @@ export async function publishToGitHub(
   // Update package metadata
   const packageName = packageJson.name.replace(/^@[^/]+\//, '');
 
-  // Use the actual npm package name from package.json (not @elizaos/ prefix)
-  const registryPackageName = packageJson.name;
+  // Use the actual npm package name from package.json (scoped)
+  const registryPackageName = packageJson.npmPackage || packageJson.name;
 
   if (!isTest) {
     // Update index.json with simple mapping: npm package name -> github repo


### PR DESCRIPTION
(related to issue #5813)

a bug got introduced resulting in incorrect construction of the npmPackages value. This is causing a malformed addition to the registry when users do elizaos publish, specifically, it is constructing the npmPackage without the scope:

e.g. 

"npmPackage": "plugin-test"

instead of:

"npmPackage": "@yungalgo/plugin-test"

this obviously is wrong and causes publishing to not work correctly. 

fix is to adjust the logic to construct the variable correctly with the scope.