### PR TITLE
fix: add SERVER_HOST support to dev command

### DIFF
--- a/packages/cli/src/commands/dev/actions/dev-server.ts
+++ b/packages/cli/src/commands/dev/actions/dev-server.ts
@@ -50,10 +50,11 @@ export async function startDevMode(options: DevOptions): Promise<void> {
     const parsedPort = serverPort ? Number.parseInt(serverPort, 10) : NaN;
     desiredPort = Number.isNaN(parsedPort) ? 3000 : parsedPort;
   }
+  const serverHost = process.env.SERVER_HOST || '0.0.0.0';
   let availablePort: number;
 
   try {
-    availablePort = await findNextAvailablePort(desiredPort);
+    availablePort = await findNextAvailablePort(desiredPort, serverHost);
 
     if (availablePort !== desiredPort) {
       logger.warn(`Port ${desiredPort} is in use, using port ${availablePort} instead`);

--- a/packages/cli/src/commands/scenario/src/runtime-factory.ts
+++ b/packages/cli/src/commands/scenario/src/runtime-factory.ts
@@ -31,8 +31,9 @@ function ensureEnvLoaded(): RuntimeSettings {
 /**
  * Find an available port in the given range
  */
-async function findAvailablePort(startPort: number, endPort: number): Promise<number> {
-  console.log(`🔧 [DEBUG] Searching for available port in range ${startPort}-${endPort}...`);
+async function findAvailablePort(startPort: number, endPort: number, host?: string): Promise<number> {
+  const serverHost = host || process.env.SERVER_HOST || '0.0.0.0';
+  console.log(`🔧 [DEBUG] Searching for available port in range ${startPort}-${endPort} on host ${serverHost}...`);
 
   // Try ports in random order to avoid conflicts
   const ports = Array.from({ length: endPort - startPort + 1 }, (_, i) => startPort + i);
@@ -43,7 +44,7 @@ async function findAvailablePort(startPort: number, endPort: number): Promise<nu
 
   for (const port of ports) {
     try {
-      console.log(`🔧 [DEBUG] Testing port ${port}...`);
+      console.log(`🔧 [DEBUG] Testing port ${port} on host ${serverHost}...`);
       const server = createServer();
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
@@ -51,7 +52,7 @@ async function findAvailablePort(startPort: number, endPort: number): Promise<nu
           reject(new Error('Port check timeout'));
         }, 500); // Reduced timeout
 
-        server.listen(port, () => {
+        server.listen(port, serverHost, () => {
           clearTimeout(timeout);
           server.close();
           resolve();

--- a/packages/cli/src/commands/test/actions/e2e-tests.ts
+++ b/packages/cli/src/commands/test/actions/e2e-tests.ts
@@ -143,7 +143,8 @@ export async function runE2eTests(
       logger.info('Server properties set up');
 
       const desiredPort = options.port || Number.parseInt(process.env.SERVER_PORT || '3000');
-      const serverPort = await findNextAvailablePort(desiredPort);
+      const serverHost = process.env.SERVER_HOST || '0.0.0.0';
+      const serverPort = await findNextAvailablePort(desiredPort, serverHost);
 
       if (serverPort !== desiredPort) {
         logger.warn(`Port ${desiredPort} is in use for testing, using port ${serverPort} instead.`);


### PR DESCRIPTION
# Risks                                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                         
   Low - This change only affects port binding behavior for development commands. No breaking changes to existing functionality.                                                                                                                                                                         
                                                                                                                                                                                                                                                                                                         
   # Background                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                         
   ## What does this PR do?                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                         
   Adds SERVER_HOST environment variable support to the `elizaos dev` command to allow developers to specify which network interface the development server should bind to.                                                                                                                              
                                                                                                                                                                                                                                                                                                         
   ## What kind of change is this?                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                         
   Bug fixes (non-breaking change which fixes an issue)                                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                                         
   ## Why are we doing this? Any context or related work?                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                         
   The dev command was not respecting the SERVER_HOST environment variable when checking for available ports, which could cause issues when developers need to bind to specific network interfaces (e.g., localhost only for security, or 0.0.0.0 for container environments).                           
                                                                                                                                                                                                                                                                                                         
   # Documentation changes needed?                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                         
   My changes do not require a change to the project documentation.                                                                                                                                                                                                                                      
   <!-- SERVER_HOST is already documented as an environment variable -->                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                         
   # Testing                                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                         
   ## Where should a reviewer start?                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                         
   Review the changes in `packages/cli/src/commands/dev/actions/dev-server.ts` line 53-57                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                         
   ## Detailed testing steps                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                         
   - Run `elizaos dev` without SERVER_HOST set                                                                                                                                                                                                                                                           
     - Verify server starts and binds to 0.0.0.0 (default)                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                                         
   - Run `SERVER_HOST=127.0.0.1 elizaos dev`                                                                                                                                                                                                                                                             
     - Verify server binds to localhost only                                                                                                                                                                                                                                                             
     - Verify port availability check uses 127.0.0.1                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                         
   - Run `SERVER_HOST=0.0.0.0 elizaos dev`                                                                                                                                                                                                                                                               
     - Verify server binds to all interfaces                                                                                                                                                                                                                                                             
     - Verify port availability check uses 0.0.0.0                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                        