### PR TITLE
fix: Prevent excessive SECRET_SALT error logging

### DIFF
--- a/packages/core/src/__tests__/settings.test.ts
+++ b/packages/core/src/__tests__/settings.test.ts
@@ -3,6 +3,7 @@ import { mock, spyOn } from 'bun:test';
 import {
   createSettingFromConfig,
   getSalt,
+  clearSaltCache,
   encryptStringValue,
   decryptStringValue,
   saltSettingValue,
@@ -171,6 +172,7 @@ describe('settings utilities', () => {
     it('should use default salt when env variable is not set', () => {
       delete process.env.SECRET_SALT;
       getEnvironment().clearCache(); // Clear cache after deleting env var
+      clearSaltCache(); // Clear salt cache to ensure fresh read
       const salt = getSalt();
       expect(salt).toBe('secretsalt');
     });

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -35,22 +35,55 @@ export function createSettingFromConfig(configSetting: Omit<Setting, 'value'>): 
   };
 }
 
+// Cache for salt value with TTL
+interface SaltCache {
+  value: string;
+  timestamp: number;
+}
+
+let saltCache: SaltCache | null = null;
+let saltErrorLogged = false;
+const SALT_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes TTL
+
 /**
- * Retrieves the salt based on env variable SECRET_SALT
+ * Gets the salt for the agent.
  *
  * @returns {string} The salt for the agent.
  */
 export function getSalt(): string {
+  // Check if cached value exists and is still valid
+  if (saltCache !== null) {
+    const now = Date.now();
+    if (now - saltCache.timestamp < SALT_CACHE_TTL_MS) {
+      return saltCache.value;
+    }
+  }
+
   const secretSalt = getEnv('SECRET_SALT', 'secretsalt') || 'secretsalt';
 
-  if (secretSalt === 'secretsalt') {
+  if (secretSalt === 'secretsalt' && !saltErrorLogged) {
     logger.error('SECRET_SALT is not set or using default value');
+    saltErrorLogged = true;
   }
 
   const salt = secretSalt;
 
+  // Cache the salt with current timestamp
+  saltCache = {
+    value: salt,
+    timestamp: Date.now(),
+  };
+
   //logger.debug(`Generated salt with length: ${salt.length} (truncated for security)`);
   return salt;
+}
+
+/**
+ * Clears the salt cache - useful for tests or when environment changes
+ */
+export function clearSaltCache(): void {
+  saltCache = null;
+  saltErrorLogged = false;
 }
 
 /**


### PR DESCRIPTION
## Problem

The application was logging 'SECRET_SALT is not set or using default value' error multiple times during startup, causing excessive log noise. This happens because:

1. The `getSalt()` function logs an error every time it's called when SECRET_SALT isn't configured
2. `getSetting()` in AgentRuntime calls `getSalt()` for every setting retrieval that needs decryption
3. During startup, multiple settings are retrieved, causing repeated error logs

## Solution

Implemented a TTL-based caching mechanism for the salt value with the following features:

- **Cache with TTL**: Salt value is cached for 5 minutes to prevent repeated environment reads
- **One-time error logging**: Error is logged only once per application lifecycle
- **Cache invalidation**: Added `clearSaltCache()` function for tests and environment changes
- **Maintains functionality**: Salt value can still be updated by clearing cache or waiting for TTL expiry

## Changes

1. Added `SaltCache` interface to store salt value with timestamp
2. Implemented 5-minute TTL for cached salt values
3. Added `saltErrorLogged` flag to prevent duplicate error messages
4. Created `clearSaltCache()` function for test cleanup
5. Updated tests to use cache clearing for proper isolation

## Testing

- All existing tests pass
- Cache behavior verified with TTL expiry
- Error is now logged only once during application startup