### PR TITLE
fix: (cli) resolve ts compilation errors during build in scenario command

### DIFF
--- a/packages/cli/src/commands/scenario/src/ConversationEvaluators.ts
+++ b/packages/cli/src/commands/scenario/src/ConversationEvaluators.ts
@@ -12,8 +12,7 @@ import { Evaluation as EvaluationSchema } from './schema';
 export class ConversationLengthEvaluator implements Evaluator {
     async evaluate(
         params: EvaluationSchema,
-        runResult: ExecutionResult,
-        runtime: AgentRuntime
+        runResult: ExecutionResult
     ): Promise<EvaluationResult> {
         const metadata = (runResult as any).conversationMetadata;
         if (!metadata) {
@@ -124,7 +123,7 @@ export class ConversationFlowEvaluator implements Evaluator {
             'escalation_pattern': 'Does the conversation include appropriate escalation when needed?'
         };
 
-        const prompt = patternPrompts[pattern];
+        const prompt = (patternPrompts as Record<string, string>)[pattern];
         if (!prompt) {
             console.warn(`[ConversationFlowEvaluator] Unknown pattern: ${pattern}`);
             return false;

--- a/packages/cli/src/commands/scenario/src/ConversationManager.ts
+++ b/packages/cli/src/commands/scenario/src/ConversationManager.ts
@@ -273,7 +273,7 @@ export class ConversationManager {
     private async executeTurn(
         userInput: string,
         turnNumber: number,
-        config: ConversationConfig,
+        _config: ConversationConfig,
         _previousTurns: ConversationTurn[]
     ): Promise<ConversationTurn> {
         const turnStartTime = Date.now();

--- a/packages/cli/src/commands/scenario/src/TrajectoryReconstructor.ts
+++ b/packages/cli/src/commands/scenario/src/TrajectoryReconstructor.ts
@@ -252,7 +252,6 @@ export class TrajectoryReconstructor {
 
       // Determine if this is an agent message or user message
       const isAgentMessage = content?.type === 'agent' || (content?.thought && content?.actions);
-      const isUserMessage = content?.type === 'user' || content?.source === 'scenario_message';
 
       // Create thought step from agent messages
       if (isAgentMessage && content?.thought) {

--- a/packages/cli/src/commands/scenario/src/UserSimulator.ts
+++ b/packages/cli/src/commands/scenario/src/UserSimulator.ts
@@ -93,7 +93,7 @@ export class UserSimulator {
   private buildSimulationPrompt(
     history: ConversationTurn[],
     agentResponse: string,
-    context: SimulationContext
+    _context: SimulationContext
   ): string {
     const { persona, objective, style, constraints, emotional_state, knowledge_level } = this.config;
 
@@ -158,7 +158,7 @@ Respond as the user (20-100 words, natural conversation):`;
    * Generate a fallback response when LLM fails
    * @private
    */
-  private generateFallbackResponse(agentResponse: string, context: SimulationContext): string {
+  private generateFallbackResponse(_agentResponse: string, context: SimulationContext): string {
     const { persona, objective } = this.config;
 
     // Simple fallback responses based on persona type


### PR DESCRIPTION
## Problem
The CLI build was failing TypeScript declaration generation due to compilation errors in the scenario command files:
- Unused `runtime` parameter in ConversationLengthEvaluator
- Type indexing issue in ConversationFlowEvaluator pattern access
- Unused `config` parameter in ConversationManager  
- Unused `isUserMessage` variable in TrajectoryReconstructor
- Unused parameters in UserSimulator methods

## Solution
- Removed unused `runtime` parameter from `ConversationLengthEvaluator.evaluate()`
- Added explicit type assertion for `patternPrompts[pattern]` access
- Prefixed unused parameters with underscore to indicate intentional non-usage
- Removed unused variable declarations

## Impact
- ✅ TypeScript declarations now generate successfully
- ✅ Build completes without compilation errors  
- ✅ No functional changes to runtime behavior