### PR TITLE
fix: change SECRET_SALT log level from error to warning

### DIFF
--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -62,7 +62,7 @@ export function getSalt(): string {
   const secretSalt = getEnv('SECRET_SALT', 'secretsalt') || 'secretsalt';
 
   if (secretSalt === 'secretsalt' && !saltErrorLogged) {
-    logger.error('SECRET_SALT is not set or using default value');
+    logger.warn('SECRET_SALT is not set or using default value');
     saltErrorLogged = true;
   }
 


### PR DESCRIPTION
## Problem

The SECRET_SALT environment variable validation was logging an **error** when the default value was being used. This created confusion as error-level logs typically indicate critical failures that prevent the system from functioning properly.

## Root Cause

The current implementation treats missing SECRET_SALT as an error, but the system continues to function normally using the default value. This is misleading for developers and operators monitoring logs.

## Solution

Changed  to  for the SECRET_SALT default value message.

## Why This Change?

- **Appropriate Log Level**: A warning is more suitable since the system remains fully functional
- **Better UX**: Developers won't think something is broken when seeing this message
- **Semantic Correctness**: Errors should indicate actual failures, warnings for suboptimal configurations
- **Production Clarity**: Operators can better distinguish between real issues and configuration recommendations

## Impact

- No functional changes to the system
- Better log level semantics
- Clearer distinction between actual errors and configuration warnings
- Maintains existing behavior while improving developer experience

## Files Changed

- : Changed log level from error to warning

## Testing

The system continues to work exactly as before, just with more appropriate log levels.