### PR TITLE
feat(client): Add URL synchronization for DM channel switching and direct navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
   <a href="https://github.com/elizaos/eliza/blob/main/LICENSE"><img src="https://img.shields.io/github/license/elizaos/eliza?style=for-the-badge" alt="License"></a>
   <a href="https://www.npmjs.com/package/@elizaos/cli"><img src="https://img.shields.io/npm/v/@elizaos/cli?style=for-the-badge" alt="NPM Version"></a>
   <a href="https://docs.elizaos.ai/"><img src="https://img.shields.io/badge/Documentation-Read%20Docs-blue?style=for-the-badge" alt="Documentation"></a>
-  <a href="https://github.com/elizaos/eliza/actions/workflows/ci.yaml"><img src="https://img.shields.io/github/actions/workflow/status/elizaos/eliza/ci.yaml?branch=main&style=for-the-badge" alt="CI Status"></a>
-  <a href="https://discord.com/invite/ai16z"><img src="https://img.shields.io/discord/your-server-id?style=for-the-badge&logo=discord" alt="Discord"></a>
+  <a href="https://github.com/elizaos/eliza/actions/workflows/image.yaml"><img src="https://img.shields.io/github/actions/workflow/status/elizaos/eliza/ci.yaml?branch=main&style=for-the-badge" alt="CI Status"></a>
+  <a href="https://discord.gg/ai16z"><img src="https://img.shields.io/discord/1253563208833433701?style=for-the-badge&logo=discord" alt="Discord"></a>
 </div>
 
 ## ✨ What is Eliza?

--- a/packages/client/src/components/chat.tsx
+++ b/packages/client/src/components/chat.tsx
@@ -680,9 +680,9 @@ export default function Chat({
   
   // Function to add channelId to URL
   const addChannelIdToUrl = useCallback((channelId: UUID) => {
-    if (chatType === ChannelType.DM && contextId && channelId) {
+    if (chatType === ChannelType.DM && contextId && channelId && typeof window !== 'undefined') {
       const newPath = `/chat/${contextId}/${channelId}`;
-      if (window.location.pathname !== newPath) {
+      if (window.location.pathname !== newPath && window.history) {
         window.history.replaceState(null, '', newPath);
       }
     }
@@ -705,6 +705,14 @@ export default function Chat({
     });
 
     if (initialDmChannelId && agentDmChannels.length > 0 && !isLoadingAgentDmChannels && !hasHandledInitialUrl.current) {
+      // Validate the channel ID format first
+      const validChannelId = validateUuid(initialDmChannelId);
+      if (!validChannelId) {
+        clientLogger.warn('[Chat] Invalid channel ID format from URL:', initialDmChannelId);
+        hasHandledInitialUrl.current = true;
+        return;
+      }
+
       // Check if the channel from URL exists in user's channels
       const channelExists = agentDmChannels.some(ch => ch.id === initialDmChannelId);
       if (channelExists) {

--- a/packages/client/src/components/chat.tsx
+++ b/packages/client/src/components/chat.tsx
@@ -360,6 +360,7 @@ export default function Chat({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
   const inputDisabledRef = useRef<boolean>(false);
+  const hasHandledInitialUrl = useRef<boolean>(false);
   const chatTitleRef = useRef<string>('');
 
   // For DM, we need agent data. For GROUP, we need channel data
@@ -703,17 +704,19 @@ export default function Chat({
       currentDmChannelId: chatState.currentDmChannelId
     });
 
-    if (initialDmChannelId && agentDmChannels.length > 0 && !isLoadingAgentDmChannels && !chatState.currentDmChannelId) {
+    if (initialDmChannelId && agentDmChannels.length > 0 && !isLoadingAgentDmChannels && !hasHandledInitialUrl.current) {
       // Check if the channel from URL exists in user's channels
       const channelExists = agentDmChannels.some(ch => ch.id === initialDmChannelId);
       if (channelExists) {
         clientLogger.info('[Chat] Switching to channel from URL:', initialDmChannelId);
         updateChatState({ currentDmChannelId: initialDmChannelId });
+        hasHandledInitialUrl.current = true;
       } else {
         clientLogger.warn('[Chat] Channel from URL not found, staying with current channel', {
           initialDmChannelId,
           availableChannels: agentDmChannels.map(ch => ch.id)
         });
+        hasHandledInitialUrl.current = true;
       }
     }
   }, [initialDmChannelId, agentDmChannels, isLoadingAgentDmChannels, updateChatState]);

--- a/packages/client/src/components/chat.tsx
+++ b/packages/client/src/components/chat.tsx
@@ -676,6 +676,47 @@ export default function Chat({
       updateChatState({ currentDmChannelId: agentDmChannels[0].id });
     }
   }, [agentDmChannels, isLoadingAgentDmChannels, updateChatState]);
+  
+  // Function to add channelId to URL
+  const addChannelIdToUrl = useCallback((channelId: UUID) => {
+    if (chatType === ChannelType.DM && contextId && channelId) {
+      const newPath = `/chat/${contextId}/${channelId}`;
+      if (window.location.pathname !== newPath) {
+        window.history.replaceState(null, '', newPath);
+      }
+    }
+  }, [chatType, contextId]);
+
+  // useEffect to listen for channelId switching and append id to URL
+  useEffect(() => {
+  if (chatState.currentDmChannelId) {
+    addChannelIdToUrl(chatState.currentDmChannelId);
+  }
+  }, [chatState.currentDmChannelId, addChannelIdToUrl]);
+
+  // useEffect to handle direct URL navigation with channelId (only runs once on mount)
+  useEffect(() => {
+    clientLogger.info('[Chat] URL navigation effect triggered', {
+      initialDmChannelId,
+      agentDmChannelsLength: agentDmChannels.length,
+      isLoadingAgentDmChannels,
+      currentDmChannelId: chatState.currentDmChannelId
+    });
+
+    if (initialDmChannelId && agentDmChannels.length > 0 && !isLoadingAgentDmChannels && !chatState.currentDmChannelId) {
+      // Check if the channel from URL exists in user's channels
+      const channelExists = agentDmChannels.some(ch => ch.id === initialDmChannelId);
+      if (channelExists) {
+        clientLogger.info('[Chat] Switching to channel from URL:', initialDmChannelId);
+        updateChatState({ currentDmChannelId: initialDmChannelId });
+      } else {
+        clientLogger.warn('[Chat] Channel from URL not found, staying with current channel', {
+          initialDmChannelId,
+          availableChannels: agentDmChannels.map(ch => ch.id)
+        });
+      }
+    }
+  }, [initialDmChannelId, agentDmChannels, isLoadingAgentDmChannels, updateChatState]);
 
   // Effect to handle initial DM channel selection or creation
   useEffect(() => {


### PR DESCRIPTION
result:


https://github.com/user-attachments/assets/7f1a502b-51f6-431f-be05-dc0dccf923e8


## Summary
Implements URL synchronization for DM channels, allowing users to bookmark and share direct links to specific conversations while maintaining proper channel switching functionality.

## Changes
- **URL Updates**: Automatically updates URL when users switch between DM channels
- **Direct Navigation**: Supports direct URL navigation (e.g., `/chat/{agentId}/{channelId}`)
- **Non-blocking Implementation**: Uses `window.history.replaceState()` to avoid component re-renders
- **Conflict Resolution**: Prevents URL navigation from interfering with normal channel selection

## Technical Details
- Added `addChannelIdToUrl()` function for efficient URL updates without navigation
- Added `useEffect` to monitor `chatState.currentDmChannelId` changes
- Added `useEffect` to handle direct URL navigation with validation
- Maintains backward compatibility with existing routing structure

## Testing
- ✅ Channel selection works normally
- ✅ URL updates automatically when switching channels  
- ✅ Direct URL navigation works (paste URL in new tab)
- ✅ Graceful fallback when channel doesn't exist
- ✅ No performance impact (no re-renders)

## Benefits
- Users can bookmark specific conversations
- Shareable direct links to DM channels
- Better UX with persistent URL state
- Maintains existing functionality