### PR TITLE
fix(client): Remove redundant navigate() call in force new chat flow

### DIFF
--- a/packages/client/src/components/chat.tsx
+++ b/packages/client/src/components/chat.tsx
@@ -647,8 +647,6 @@ export default function Chat({
     ) {
       handleNewDmChannel(targetAgentData.id);
       setShouldForceNew(false);
-
-      navigate(location.pathname, { replace: true });
     }
   }, [
     shouldForceNew,


### PR DESCRIPTION
## Problem
When creating a new chat via "New Chat" button, the `navigate(location.pathname, { replace: true })` call was wiping out the channelId from the URL after `addChannelIdToUrl` had just set it, causing URL inconsistency.

## Solution
- Removed redundant `navigate()` call since `addChannelIdToUrl` already cleans the `forceNew` state via `window.history.replaceState(null, ...)`
- This prevents the channelId from being lost in the URL and maintains proper URL state

## Testing
- ✅ "New Chat" button works without recreation issues
- ✅ URL correctly shows `/chat/agentId/channelId` after channel creation
- ✅ Page refresh doesn't trigger recreation