### PR TITLE
fix: Enable JSON imports in project-starter and project-tee-starter templates

### DIFF
--- a/packages/project-starter/tsconfig.json
+++ b/packages/project-starter/tsconfig.json
@@ -30,7 +30,7 @@
       "@elizaos/core/*": ["../../core/src/*"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json", "*.json"],
   "exclude": [
     "dist",
     "node_modules",

--- a/packages/project-tee-starter/tsconfig.json
+++ b/packages/project-tee-starter/tsconfig.json
@@ -26,6 +26,6 @@
       "@elizaos/core/*": ["../../core/src/*"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json", "*.json"],
   "exclude": ["dist", "node_modules", "src/__tests__/**/*", "**/*.test.ts", "**/*.spec.ts"]
 }


### PR DESCRIPTION
## Problem
Project templates generated by `elizaos create` fail to compile when users import JSON files (e.g., character files) due to TypeScript configuration excluding JSON files from compilation, despite having `resolveJsonModule: true` enabled.

## Solution
Add `"src/**/*.json"` and `"*.json"` to the `include` array in both `project-starter` and `project-tee-starter` template tsconfig.json files to enable JSON imports throughout the project structure.

## Context
Users commonly need to import character JSON files in ElizaOS projects. This fix ensures the templates work out-of-the-box for this common use case without requiring manual tsconfig modifications.

**Templates updated:**
- `packages/project-starter/tsconfig.json`
- `packages/project-tee-starter/tsconfig.json`