### PR TITLE
fix: add missing uuid dependency to plugin-sql

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -304,6 +304,7 @@
         "drizzle-kit": "^0.31.1",
         "drizzle-orm": "^0.44.2",
         "pg": "^8.13.3",
+        "uuid": "^11.0.5",
       },
       "devDependencies": {
         "@eslint/js": "^9.28.0",

--- a/packages/plugin-sql/package.json
+++ b/packages/plugin-sql/package.json
@@ -56,7 +56,8 @@
     "dotenv": "^16.4.7",
     "drizzle-kit": "^0.31.1",
     "drizzle-orm": "^0.44.2",
-    "pg": "^8.13.3"
+    "pg": "^8.13.3",
+    "uuid": "^11.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",


### PR DESCRIPTION

  # Relates to

  N/A - Bug fix discovered during testing

  # Risks

  Low - Only adds a missing dependency declaration that was already being used in the code.

  # Background

  ## What does this PR do?

  Adds the missing `uuid` package dependency to `@elizaos/plugin-sql` package.json

  ## What kind of change is this?

  Bug fixes (non-breaking change which fixes an issue)

  ## Why are we doing this? Any context or related work?

  The plugin-sql package imports and uses the uuid package (specifically in base.ts line 34: `import { v4 } from 'uuid'`) but was missing it from its dependencies. This
  caused module resolution errors when the package was installed in other projects:

  Error: Cannot find module '@elizaos/server' in project
  Original error: ResolveMessage: ENOENT while resolving package 'uuid' from '@elizaos/plugin-sql'

  # Documentation changes needed?

  My changes do not require a change to the project documentation.

  # Testing

  ## Where should a reviewer start?

  Review the changes in `packages/plugin-sql/package.json` - only one line added to dependencies.

  ## Detailed testing steps

  - Run `bun install` in the root directory
  - Run `bun run build` to verify the build completes without module resolution errors
  - The plugin-sql package should now properly resolve the uuid dependency