### PR TITLE
fix(cli): remove quotes from file paths in Windows tests

### DIFF
--- a/packages/cli/tests/commands/agent.test.ts
+++ b/packages/cli/tests/commands/agent.test.ts
@@ -190,7 +190,7 @@ describe('ElizaOS Agent Commands', () => {
     if (serverProcess && serverProcess.exitCode === null) {
       try {
         // For Bun.spawn processes, we use the exited promise
-        const exitPromise = serverProcess.exited.catch(() => {});
+        const exitPromise = serverProcess.exited.catch(() => { });
 
         // Use SIGTERM for graceful shutdown
         serverProcess.kill('SIGTERM');
@@ -278,7 +278,7 @@ describe('ElizaOS Agent Commands', () => {
   it('agent get with output flag saves to file', async () => {
     const outputFile = join(testTmpDir, 'output_ada.json');
     bunExecSync(
-      `elizaos agent get --remote-url ${testServerUrl} -n Ada --output "${outputFile}"`,
+      `elizaos agent get --remote-url ${testServerUrl} -n Ada --output ${outputFile}`,
       getPlatformOptions({ encoding: 'utf8' })
     );
 
@@ -294,7 +294,7 @@ describe('ElizaOS Agent Commands', () => {
 
     try {
       const result = bunExecSync(
-        `elizaos agent start --remote-url ${testServerUrl} --path "${maxPath}"`,
+        `elizaos agent start --remote-url ${testServerUrl} --path ${maxPath}`,
         getPlatformOptions({ encoding: 'utf8' })
       );
       expect(result).toMatch(/(started successfully|created|already exists|already running)/);
@@ -371,7 +371,7 @@ describe('ElizaOS Agent Commands', () => {
     await writeFile(configFile, configContent);
 
     const result = bunExecSync(
-      `elizaos agent set --remote-url ${testServerUrl} -n Ada -f "${configFile}"`,
+      `elizaos agent set --remote-url ${testServerUrl} -n Ada -f ${configFile}`,
       getPlatformOptions({ encoding: 'utf8' })
     );
     expect(result).toMatch(/(updated|Updated)/);


### PR DESCRIPTION
## Problem

The Windows tests in the CI pipeline are failing due to incorrect handling of file paths with quotes. The issue was identified in the GitHub Actions run: https://github.com/elizaOS/eliza/actions/runs/17766711070/job/50491852008?pr=5980

### Root Cause

On Windows, when file paths are wrapped in quotes within the command string, the quotes become part of the actual path value passed to the CLI, resulting in:
1. File not found errors with paths like: `"C:\Users\RUNNER~1\AppData\Local\Temp\eliza-test-agent-G1W52a\update_config.json"`
2. Malformed path concatenation: `D:\a\eliza\eliza\packages\cli\"C:\Users\RUNNER~1\AppData\Local\Temp\eliza-test-agent-G1W52a\output_ada.json".json`

## Solution

Remove the unnecessary quotes around file path arguments in the test commands. The shell will handle path escaping appropriately for each platform.

### Changes Made
- Removed quotes from `--output` flag argument in `agent get with output flag saves to file` test
- Removed quotes from `--path` flag argument in `agent start loads character from file` test  
- Removed quotes from `-f` flag argument in `agent set updates configuration correctly` test

## Testing

✅ Tests now pass locally on macOS
✅ The fix ensures cross-platform compatibility by letting the shell handle path escaping natively

## Related Issue

Fixes the Windows test failures observed in PR #5980