### PR TITLE
feat(ci): add concurrency control to Claude code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,5 +1,10 @@
 name: Claude Code Review
 
+# Cancel previous runs for the same PR/branch
+concurrency:
+  group: claude-code-review-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]


### PR DESCRIPTION
- Cancel previous Claude code review runs when new commits are pushed
- Prevents resource waste and ensures latest code is reviewed
- Matches concurrency behavior of other CI workflows

