### PR TITLE
fix(cli): prevent infinite dev restart loop when client is missing

### DIFF
--- a/packages/cli/src/commands/dev/actions/__tests__/recursion-prevention.test.ts
+++ b/packages/cli/src/commands/dev/actions/__tests__/recursion-prevention.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -20,6 +20,27 @@ describe('Dev Server Recursion Prevention', () => {
         }
     });
 
+    /**
+     * Helper function to check if dev server should be skipped due to recursion
+     */
+    const checkShouldSkipRecursion = (testDir: string): boolean => {
+        const packageJsonPath = join(testDir, 'package.json');
+        if (existsSync(packageJsonPath)) {
+            try {
+                const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+                const devScript = pkg.scripts?.['dev:client'] || pkg.scripts?.['dev'];
+
+                // If the dev script would run elizaos dev, skip to prevent recursion
+                if (devScript && devScript.includes('elizaos dev')) {
+                    return true; // Should skip
+                }
+            } catch (error) {
+                return true; // Should skip on error
+            }
+        }
+        return false;
+    };
+
     it('should detect recursive elizaos dev in dev script', () => {
         // Create package.json with recursive dev script
         const packageJson = {
@@ -30,25 +51,7 @@ describe('Dev Server Recursion Prevention', () => {
         writeFileSync(join(testDir, 'package.json'), JSON.stringify(packageJson, null, 2));
         writeFileSync(join(testDir, 'vite.config.ts'), 'export default {}');
 
-        // Simulate the logic from startClientDevServer
-        const shouldSkip = (() => {
-            const packageJsonPath = join(testDir, 'package.json');
-            if (existsSync(packageJsonPath)) {
-                try {
-                    const pkg = JSON.parse(require('fs').readFileSync(packageJsonPath, 'utf-8'));
-                    const devScript = pkg.scripts?.['dev:client'] || pkg.scripts?.['dev'];
-
-                    // If the dev script would run elizaos dev, skip to prevent recursion
-                    if (devScript && devScript.includes('elizaos dev')) {
-                        return true; // Should skip
-                    }
-                } catch (error) {
-                    return true; // Should skip on error
-                }
-            }
-            return false;
-        })();
-
+        const shouldSkip = checkShouldSkipRecursion(testDir);
         expect(shouldSkip).toBe(true);
     });
 
@@ -62,25 +65,7 @@ describe('Dev Server Recursion Prevention', () => {
         writeFileSync(join(testDir, 'package.json'), JSON.stringify(packageJson, null, 2));
         writeFileSync(join(testDir, 'vite.config.ts'), 'export default {}');
 
-        // Simulate the logic from startClientDevServer
-        const shouldSkip = (() => {
-            const packageJsonPath = join(testDir, 'package.json');
-            if (existsSync(packageJsonPath)) {
-                try {
-                    const pkg = JSON.parse(require('fs').readFileSync(packageJsonPath, 'utf-8'));
-                    const devScript = pkg.scripts?.['dev:client'] || pkg.scripts?.['dev'];
-
-                    // If the dev script would run elizaos dev, skip to prevent recursion
-                    if (devScript && devScript.includes('elizaos dev')) {
-                        return true; // Should skip
-                    }
-                } catch (error) {
-                    return true; // Should skip on error
-                }
-            }
-            return false;
-        })();
-
+        const shouldSkip = checkShouldSkipRecursion(testDir);
         expect(shouldSkip).toBe(false);
     });
 
@@ -95,25 +80,7 @@ describe('Dev Server Recursion Prevention', () => {
         writeFileSync(join(testDir, 'package.json'), JSON.stringify(packageJson, null, 2));
         writeFileSync(join(testDir, 'vite.config.ts'), 'export default {}');
 
-        // Simulate the logic from startClientDevServer
-        const shouldSkip = (() => {
-            const packageJsonPath = join(testDir, 'package.json');
-            if (existsSync(packageJsonPath)) {
-                try {
-                    const pkg = JSON.parse(require('fs').readFileSync(packageJsonPath, 'utf-8'));
-                    const devScript = pkg.scripts?.['dev:client'] || pkg.scripts?.['dev'];
-
-                    // If the dev script would run elizaos dev, skip to prevent recursion
-                    if (devScript && devScript.includes('elizaos dev')) {
-                        return true; // Should skip
-                    }
-                } catch (error) {
-                    return true; // Should skip on error
-                }
-            }
-            return false;
-        })();
-
+        const shouldSkip = checkShouldSkipRecursion(testDir);
         expect(shouldSkip).toBe(false); // Should not skip because dev:client is safe
     });
 
@@ -122,25 +89,7 @@ describe('Dev Server Recursion Prevention', () => {
         writeFileSync(join(testDir, 'package.json'), '{ invalid json }');
         writeFileSync(join(testDir, 'vite.config.ts'), 'export default {}');
 
-        // Simulate the logic from startClientDevServer
-        const shouldSkip = (() => {
-            const packageJsonPath = join(testDir, 'package.json');
-            if (existsSync(packageJsonPath)) {
-                try {
-                    const pkg = JSON.parse(require('fs').readFileSync(packageJsonPath, 'utf-8'));
-                    const devScript = pkg.scripts?.['dev:client'] || pkg.scripts?.['dev'];
-
-                    // If the dev script would run elizaos dev, skip to prevent recursion
-                    if (devScript && devScript.includes('elizaos dev')) {
-                        return true; // Should skip
-                    }
-                } catch (error) {
-                    return true; // Should skip on error
-                }
-            }
-            return false;
-        })();
-
+        const shouldSkip = checkShouldSkipRecursion(testDir);
         expect(shouldSkip).toBe(true); // Should skip due to parse error
     });
 });

--- a/packages/cli/src/commands/dev/actions/__tests__/recursion-prevention.test.ts
+++ b/packages/cli/src/commands/dev/actions/__tests__/recursion-prevention.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+/**
+ * Test the recursion prevention logic from startClientDevServer
+ */
+describe('Dev Server Recursion Prevention', () => {
+    let testDir: string;
+
+    beforeEach(() => {
+        testDir = join(tmpdir(), `eliza-recursion-test-${Date.now()}`);
+        mkdirSync(testDir, { recursive: true });
+    });
+
+    afterEach(() => {
+        if (existsSync(testDir)) {
+            rmSync(testDir, { recursive: true, force: true });
+        }
+    });
+
+    it('should detect recursive elizaos dev in dev script', () => {
+        // Create package.json with recursive dev script
+        const packageJson = {
+            scripts: {
+                dev: 'elizaos dev'
+            }
+        };
+        writeFileSync(join(testDir, 'package.json'), JSON.stringify(packageJson, null, 2));
+        writeFileSync(join(testDir, 'vite.config.ts'), 'export default {}');
+
+        // Simulate the logic from startClientDevServer
+        const shouldSkip = (() => {
+            const packageJsonPath = join(testDir, 'package.json');
+            if (existsSync(packageJsonPath)) {
+                try {
+                    const pkg = JSON.parse(require('fs').readFileSync(packageJsonPath, 'utf-8'));
+                    const devScript = pkg.scripts?.['dev:client'] || pkg.scripts?.['dev'];
+
+                    // If the dev script would run elizaos dev, skip to prevent recursion
+                    if (devScript && devScript.includes('elizaos dev')) {
+                        return true; // Should skip
+                    }
+                } catch (error) {
+                    return true; // Should skip on error
+                }
+            }
+            return false;
+        })();
+
+        expect(shouldSkip).toBe(true);
+    });
+
+    it('should allow safe dev scripts', () => {
+        // Create package.json with safe dev script
+        const packageJson = {
+            scripts: {
+                dev: 'vite'
+            }
+        };
+        writeFileSync(join(testDir, 'package.json'), JSON.stringify(packageJson, null, 2));
+        writeFileSync(join(testDir, 'vite.config.ts'), 'export default {}');
+
+        // Simulate the logic from startClientDevServer
+        const shouldSkip = (() => {
+            const packageJsonPath = join(testDir, 'package.json');
+            if (existsSync(packageJsonPath)) {
+                try {
+                    const pkg = JSON.parse(require('fs').readFileSync(packageJsonPath, 'utf-8'));
+                    const devScript = pkg.scripts?.['dev:client'] || pkg.scripts?.['dev'];
+
+                    // If the dev script would run elizaos dev, skip to prevent recursion
+                    if (devScript && devScript.includes('elizaos dev')) {
+                        return true; // Should skip
+                    }
+                } catch (error) {
+                    return true; // Should skip on error
+                }
+            }
+            return false;
+        })();
+
+        expect(shouldSkip).toBe(false);
+    });
+
+    it('should prefer dev:client over dev script', () => {
+        // Create package.json with both scripts
+        const packageJson = {
+            scripts: {
+                'dev:client': 'vite --port 5173',
+                dev: 'elizaos dev'
+            }
+        };
+        writeFileSync(join(testDir, 'package.json'), JSON.stringify(packageJson, null, 2));
+        writeFileSync(join(testDir, 'vite.config.ts'), 'export default {}');
+
+        // Simulate the logic from startClientDevServer
+        const shouldSkip = (() => {
+            const packageJsonPath = join(testDir, 'package.json');
+            if (existsSync(packageJsonPath)) {
+                try {
+                    const pkg = JSON.parse(require('fs').readFileSync(packageJsonPath, 'utf-8'));
+                    const devScript = pkg.scripts?.['dev:client'] || pkg.scripts?.['dev'];
+
+                    // If the dev script would run elizaos dev, skip to prevent recursion
+                    if (devScript && devScript.includes('elizaos dev')) {
+                        return true; // Should skip
+                    }
+                } catch (error) {
+                    return true; // Should skip on error
+                }
+            }
+            return false;
+        })();
+
+        expect(shouldSkip).toBe(false); // Should not skip because dev:client is safe
+    });
+
+    it('should skip on malformed package.json', () => {
+        // Create malformed package.json
+        writeFileSync(join(testDir, 'package.json'), '{ invalid json }');
+        writeFileSync(join(testDir, 'vite.config.ts'), 'export default {}');
+
+        // Simulate the logic from startClientDevServer
+        const shouldSkip = (() => {
+            const packageJsonPath = join(testDir, 'package.json');
+            if (existsSync(packageJsonPath)) {
+                try {
+                    const pkg = JSON.parse(require('fs').readFileSync(packageJsonPath, 'utf-8'));
+                    const devScript = pkg.scripts?.['dev:client'] || pkg.scripts?.['dev'];
+
+                    // If the dev script would run elizaos dev, skip to prevent recursion
+                    if (devScript && devScript.includes('elizaos dev')) {
+                        return true; // Should skip
+                    }
+                } catch (error) {
+                    return true; // Should skip on error
+                }
+            }
+            return false;
+        })();
+
+        expect(shouldSkip).toBe(true); // Should skip due to parse error
+    });
+});


### PR DESCRIPTION
## Summary

Fixes infinite dev restart loop when client is missing by adding proper recursion prevention logic.

## Changes

- Added check to prevent recursive execution when  would call itself
- Improved client directory detection logic in dev server
- Added safeguards to prevent infinite restart loops when client dependencies are missing

## Problem

The CLI dev command was getting stuck in infinite restart loops when the client was missing or when running from directories with vite config that would cause recursive execution.

## Solution

Added detection logic to:
1. Check if dev script would run  to prevent recursion  
2. Validate client directory existence before attempting to start client server
3. Skip client startup when it would cause infinite loops

Based on commits:
- 89ab5119c7 Merge branch 'fix/cli-dev-missing-client-loop' of https://github.com/elizaOS/eliza into fix/cli-dev-missing-client-loop