### PR TITLE
refactor(core): make runtime initialization idempotent and improve service registration coordination

### DIFF
--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -443,14 +443,6 @@ export class AgentRuntime implements IAgentRuntime {
     } else {
       await this.ensureEmbeddingDimension();
     }
-
-    // Resolve embedding promise after embedding system is fully ready (or confirmed absent)
-    // This allows all waiting services to proceed
-    if (this.embeddingModelResolver) {
-      console.log(`Resolving embedding promise - embedding system is ready`);
-      this.embeddingModelResolver();
-      this.embeddingModelResolver = undefined;
-    }
   }
 
   async runPluginMigrations(): Promise<void> {

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1656,9 +1656,9 @@ export class AgentRuntime implements IAgentRuntime {
     try {
       // ALL services wait for initialization to complete
       // This ensures services start after all plugins are registered and runtime is ready
-      console.log(`Service ${serviceType} waiting for initialization...`);
+      this.logger.debug(`Service ${serviceType} waiting for initialization...`);
       await this.initPromise;
-      console.log(`Service ${serviceType} proceeding - initialization complete`);
+      this.logger.debug(`Service ${serviceType} proceeding - initialization complete`);
 
       const serviceInstance = await serviceDef.start(this);
 

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -124,7 +124,7 @@ export class AgentRuntime implements IAgentRuntime {
   private settings: RuntimeSettings;
   private servicePromiseHandles = new Map<string, ServiceResolver>(); // write
   private servicePromises = new Map<string, Promise<Service>>(); // read
-  public initPromise;
+  public initPromise: Promise<void>;
   private initResolver: ((value?: unknown) => void) | undefined;
   private migratedPlugins = new Set<string>();
   private currentRunId?: UUID; // Track the current run ID
@@ -1641,7 +1641,6 @@ export class AgentRuntime implements IAgentRuntime {
   }
 
   async registerService(serviceDef: typeof Service): Promise<void> {
-    console.log('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! [registerService] Registering service', serviceDef.name);
     const serviceType = serviceDef.serviceType as ServiceTypeName;
     if (!serviceType) {
       this.logger.warn(
@@ -1736,7 +1735,6 @@ export class AgentRuntime implements IAgentRuntime {
     provider: string,
     priority?: number
   ) {
-    console.log('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! [registerModel] Registering model', modelType, handler, provider, priority);
     const modelKey = typeof modelType === 'string' ? modelType : ModelType[modelType];
     if (!this.models.has(modelKey)) {
       this.models.set(modelKey, []);

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -323,7 +323,9 @@ export class AgentRuntime implements IAgentRuntime {
           this._createServiceResolver(service.serviceType as ServiceTypeName);
         }
 
-        this.registerService(service); // Fire and forget - don't block plugin registration
+        this.registerService(service).catch(error => {
+          this.logger.error(`Service registration failed for ${service.serviceType}:`, error);
+        });
       }
     }
   }

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -125,7 +125,7 @@ export class AgentRuntime implements IAgentRuntime {
   private servicePromiseHandles = new Map<string, ServiceResolver>(); // write
   private servicePromises = new Map<string, Promise<Service>>(); // read
   public initPromise: Promise<void>;
-  private initResolver: ((value?: unknown) => void) | undefined;
+  private initResolver: ((value?: void | PromiseLike<void>) => void) | undefined;
   private migratedPlugins = new Set<string>();
   private currentRunId?: UUID; // Track the current run ID
   private currentActionContext?: {


### PR DESCRIPTION
# Core Cleanup: Remove legacy service initialization code

## Problem Statement

Part of Core Cleanup #5911:
- Remove legacy code paths (double-inits, redundant type guards)
- Audit and refactor type definitions across runtime
- Clean up redundant initialization patterns

Previously, we had two separate but related requirements:

1. **Services need to wait for embedding model** - Services (like Twitter plugin) must wait for embedding model availability, otherwise the app would crash
2. **Contributors wanted to register plugins after runtime startup** - This required distinguishing between initial registration vs. post-startup registration

The solution was:
- **Service queue (`servicesInitQueue`)** - Services were queued and only registered after embedding model was ready
- **`isInitialized` flag** - Used to distinguish: if runtime is initialized, register service immediately; otherwise, push to queue for later registration

## Solution

Clean up legacy initialization patterns and make operations idempotent:

- **Remove redundant `isInitialized` flag** - Legacy double-init protection
- **Remove `servicesInitQueue`** - Simplify to direct promise-based waiting
- **Add proper type annotation** - `initPromise: Promise<void>`
- **Make operations idempotent** - Prevent duplicate migrations and adapter init
- **Simplify service registration** - Services wait for `initPromise` directly

## Key Changes

- Remove legacy `isInitialized` flag and associated guard logic
- Remove `servicesInitQueue` - services now wait for `initPromise` directly  
- Add proper TypeScript typing for `initPromise`
- Make `adapter.init()` and `runPluginMigrations()` idempotent
- Add migration tracking with `migratedPlugins` set

## Files Changed

- `packages/core/src/runtime.ts` - Legacy code cleanup and type improvements

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make runtime initialization and plugin migrations idempotent, remove legacy init flags/queues, and gate service startup on initPromise.
> 
> - **Core Runtime**:
>   - **Initialization**: Make `adapter.init()` idempotent via `adapter.isReady()`; resolve `initPromise` once and remove `isInitialized` and `servicesInitQueue`.
>   - **Service Coordination**: Register services immediately but have `registerService` await `initPromise`; add error logging on failed registration.
>   - **Plugin Migrations**: Add `migratedPlugins` tracking to run migrations only once.
>   - **Types**: Tighten typings for `initPromise` and its resolver.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23490e75920d99a67e27d89765421a509cfc63cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->