### PR TITLE
feat(server): auto-install missing plugins in PluginLoader

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -67,6 +67,7 @@
         "@clack/prompts": "^0.11.0",
         "@elizaos/api-client": "workspace:*",
         "@elizaos/core": "workspace:*",
+        "@elizaos/plugin-anthropic": "^1.0.6",
         "@elizaos/plugin-bootstrap": "workspace:*",
         "@elizaos/plugin-openai": "1.0.11",
         "@elizaos/plugin-sql": "workspace:*",
@@ -468,6 +469,8 @@
 
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@1.2.12", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ=="],
+
     "@ai-sdk/openai": ["@ai-sdk/openai@1.3.24", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
@@ -563,6 +566,8 @@
     "@elizaos/config": ["@elizaos/config@workspace:packages/config"],
 
     "@elizaos/core": ["@elizaos/core@workspace:packages/core"],
+
+    "@elizaos/plugin-anthropic": ["@elizaos/plugin-anthropic@1.0.6", "", { "dependencies": { "@ai-sdk/anthropic": "^1.2.11", "@ai-sdk/ui-utils": "^1.2.11", "@elizaos/core": "^1.0.0", "ai": "4.3.15", "jsonrepair": "^3.12.0" } }, "sha512-uMvhN7FRyu6VT1F/LOjcEnMMxzylB3AhgSYtODP9jZi+COIoAYTadhk1Qf5uoID5YbJdyz169EKw5B8PbZsp0w=="],
 
     "@elizaos/plugin-bootstrap": ["@elizaos/plugin-bootstrap@workspace:packages/plugin-bootstrap"],
 
@@ -1516,7 +1521,7 @@
 
     "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
 
-    "ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
+    "ai": ["ai@4.3.15", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-TYKRzbWg6mx/pmTadlAEIhuQtzfHUV0BbLY72+zkovXwq/9xhcH24IlQmkyBpElK6/4ArS0dHdOOtR1jOPVwtg=="],
 
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
@@ -2601,6 +2606,8 @@
     "jsonparse": ["jsonparse@1.3.1", "", {}, "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="],
 
     "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
+
+    "jsonrepair": ["jsonrepair@3.13.1", "", { "bin": { "jsonrepair": "bin/cli.js" } }, "sha512-WJeiE0jGfxYmtLwBTEk8+y/mYcaleyLXWaqp5bJu0/ZTSeG0KQq/wWQ8pmnkKenEdN6pdnn6QtcoSUkbqDHWNw=="],
 
     "jsprim": ["jsprim@2.0.2", "", { "dependencies": { "assert-plus": "1.0.0", "extsprintf": "1.3.0", "json-schema": "0.4.0", "verror": "1.10.0" } }, "sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ=="],
 
@@ -3850,6 +3857,8 @@
 
     "@elizaos/core/typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
+    "@elizaos/plugin-anthropic/@elizaos/core": ["@elizaos/core@1.5.10", "", { "dependencies": { "adze": "^2.2.5", "crypto-browserify": "^3.12.0", "dotenv": "16.5.0", "glob": "11.0.3", "handlebars": "^4.7.8", "langchain": "^0.3.15", "pdfjs-dist": "^5.2.133", "unique-names-generator": "4.7.1", "uuid": "11.1.0", "zod": "^3.24.4" } }, "sha512-Ojihe2w9tT2lh9ZaJ0ShxOOtD5GzHrHmUH8WW33GeipUesEZKE4iRxfuKc72c1yXAj3LJtINuw5li4B27BwUiA=="],
+
     "@elizaos/plugin-bootstrap/@types/node": ["@types/node@22.18.6", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ=="],
 
     "@elizaos/plugin-bootstrap/typescript": ["typescript@5.8.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="],
@@ -3862,11 +3871,15 @@
 
     "@elizaos/plugin-openai/@elizaos/core": ["@elizaos/core@1.5.11", "", { "dependencies": { "adze": "^2.2.5", "crypto-browserify": "^3.12.0", "dotenv": "16.5.0", "glob": "11.0.3", "handlebars": "^4.7.8", "langchain": "^0.3.15", "pdfjs-dist": "^5.2.133", "unique-names-generator": "4.7.1", "uuid": "11.1.0", "zod": "4.1.11" } }, "sha512-8iGlitk8SWd0B2tcBA6nQbtZf9uGMKX09rqSOBi2M7EelCTCPhD27UdqchxdyNK8vuPUD2tkGdIbTZN3pTMWxQ=="],
 
+    "@elizaos/plugin-openai/ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
+
     "@elizaos/plugin-quick-starter/dotenv": ["dotenv@16.4.5", "", {}, "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg=="],
 
     "@elizaos/plugin-quick-starter/typescript": ["typescript@5.8.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ=="],
 
     "@elizaos/plugin-redpill/@elizaos/core": ["@elizaos/core@1.5.11", "", { "dependencies": { "adze": "^2.2.5", "crypto-browserify": "^3.12.0", "dotenv": "16.5.0", "glob": "11.0.3", "handlebars": "^4.7.8", "langchain": "^0.3.15", "pdfjs-dist": "^5.2.133", "unique-names-generator": "4.7.1", "uuid": "11.1.0", "zod": "4.1.11" } }, "sha512-8iGlitk8SWd0B2tcBA6nQbtZf9uGMKX09rqSOBi2M7EelCTCPhD27UdqchxdyNK8vuPUD2tkGdIbTZN3pTMWxQ=="],
+
+    "@elizaos/plugin-redpill/ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
 
     "@elizaos/plugin-redpill/tsup": ["tsup@8.4.0", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.25.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "0.8.0-beta.0", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-b+eZbPCjz10fRryaAA7C8xlIHnf8VnsaRqydheLIqwG/Mcpfk8Z5zp3HayX7GaTygkigHl5cBUs+IhcySiIexQ=="],
 
@@ -4441,6 +4454,10 @@
     "@elizaos/client/eslint/file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
     "@elizaos/client/eslint/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
+
+    "@elizaos/plugin-anthropic/@elizaos/core/dotenv": ["dotenv@16.5.0", "", {}, "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg=="],
+
+    "@elizaos/plugin-anthropic/@elizaos/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@elizaos/plugin-bootstrap/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 

--- a/packages/server/src/managers/PluginInstaller.ts
+++ b/packages/server/src/managers/PluginInstaller.ts
@@ -1,0 +1,77 @@
+import { logger } from '@elizaos/core';
+
+/**
+ * Handles on-demand plugin installation using Bun.
+ * Provides environment guards and single-attempt tracking per process.
+ */
+export class PluginInstaller {
+    private attempted = new Set<string>();
+
+    async tryInstall(pluginName: string): Promise<boolean> {
+        try {
+            if (!this.isAllowed()) {
+                logger.debug(
+                    `Auto-install disabled or not allowed in this environment. Skipping install for ${pluginName}.`
+                );
+                return false;
+            }
+
+            if (this.attempted.has(pluginName)) {
+                logger.debug(`Auto-install already attempted for ${pluginName}. Skipping.`);
+                return false;
+            }
+            this.attempted.add(pluginName);
+
+            // Verify Bun availability
+            try {
+                const check = Bun.spawn(['bun', '--version'], { stdout: 'pipe', stderr: 'pipe' });
+                const code = await check.exited;
+                if (code !== 0) {
+                    logger.warn(
+                        `Bun not available on PATH. Cannot auto-install ${pluginName}. Please run: bun add ${pluginName}`
+                    );
+                    return false;
+                }
+            } catch {
+                logger.warn(
+                    `Bun not available on PATH. Cannot auto-install ${pluginName}. Please run: bun add ${pluginName}`
+                );
+                return false;
+            }
+
+            logger.info(`Attempting to auto-install missing plugin: ${pluginName}`);
+            const install = Bun.spawn(['bun', 'add', pluginName], {
+                cwd: process.cwd(),
+                env: process.env as Record<string, string>,
+                stdout: 'inherit',
+                stderr: 'inherit',
+            });
+            const exit = await install.exited;
+
+            if (exit === 0) {
+                logger.info(`Successfully installed ${pluginName}. Retrying import...`);
+                return true;
+            }
+
+            logger.error(`bun add ${pluginName} failed with exit code ${exit}. Please install manually.`);
+            return false;
+        } catch (e) {
+            const message = e instanceof Error ? e.message : String(e);
+            logger.error(`Unexpected error during auto-install of ${pluginName}: ${message}`);
+            return false;
+        }
+    }
+
+    private isAllowed(): boolean {
+        if (process.env.ELIZA_NO_AUTO_INSTALL === 'true') return false;
+        if (process.env.ELIZA_NO_PLUGIN_AUTO_INSTALL === 'true') return false;
+        if (process.env.CI === 'true') return false;
+        if (process.env.ELIZA_TEST_MODE === 'true') return false;
+        if (process.env.NODE_ENV === 'test') return false;
+        return true;
+    }
+}
+
+export const pluginInstaller = new PluginInstaller();
+
+

--- a/packages/server/src/managers/PluginLoader.ts
+++ b/packages/server/src/managers/PluginLoader.ts
@@ -1,9 +1,11 @@
 import { logger, type Plugin } from '@elizaos/core';
+import { pluginInstaller } from './PluginInstaller';
 
 /**
  * Manages plugin loading and dependency resolution
  */
 export class PluginLoader {
+
   /**
    * Check if an object has a valid plugin shape
    */
@@ -26,16 +28,16 @@ export class PluginLoader {
    */
   validatePlugin(plugin: any): { isValid: boolean; errors: string[] } {
     const errors: string[] = [];
-    
+
     if (!plugin) {
       errors.push('Plugin is null or undefined');
       return { isValid: false, errors };
     }
-    
+
     if (!plugin.name) {
       errors.push('Plugin must have a name');
     }
-    
+
     if (plugin.actions) {
       if (!Array.isArray(plugin.actions)) {
         errors.push('Plugin actions must be an array');
@@ -47,13 +49,13 @@ export class PluginLoader {
         }
       }
     }
-    
+
     if (plugin.services) {
       if (!Array.isArray(plugin.services)) {
         errors.push('Plugin services must be an array');
       } else {
         // Check if services contain non-objects/non-constructors
-        const invalidServices = plugin.services.filter((s: any) => 
+        const invalidServices = plugin.services.filter((s: any) =>
           typeof s !== 'function' && (typeof s !== 'object' || !s)
         );
         if (invalidServices.length > 0) {
@@ -61,15 +63,15 @@ export class PluginLoader {
         }
       }
     }
-    
+
     if (plugin.providers && !Array.isArray(plugin.providers)) {
       errors.push('Plugin providers must be an array');
     }
-    
+
     if (plugin.evaluators && !Array.isArray(plugin.evaluators)) {
       errors.push('Plugin evaluators must be an array');
     }
-    
+
     return {
       isValid: errors.length === 0,
       errors
@@ -83,13 +85,26 @@ export class PluginLoader {
     try {
       // Try to load the plugin module
       let pluginModule: any;
-      
+
       try {
         // Attempt to dynamically import the plugin
         pluginModule = await import(pluginName);
       } catch (error) {
         logger.error(`Failed to load plugin ${pluginName}: ${error}`);
-        return null;
+        // Attempt auto-install if allowed and not already attempted
+        const attempted = await pluginInstaller.tryInstall(pluginName);
+        if (!attempted) {
+          return null;
+        }
+        // Retry import once after successful installation attempt
+        try {
+          pluginModule = await import(pluginName);
+        } catch (secondError) {
+          logger.error(
+            `Auto-install attempted for ${pluginName} but import still failed: ${secondError}`
+          );
+          return null;
+        }
       }
 
       if (!pluginModule) {
@@ -133,6 +148,7 @@ export class PluginLoader {
       return null;
     }
   }
+
 
   /**
    * Resolve plugin dependencies with circular dependency detection

--- a/packages/server/src/managers/__tests__/PluginInstaller.test.ts
+++ b/packages/server/src/managers/__tests__/PluginInstaller.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { PluginInstaller } from '../PluginInstaller';
+
+function delay(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('PluginInstaller', () => {
+    const originalSpawn = (Bun as any).spawn;
+    const originalEnv = { ...process.env } as Record<string, string>;
+
+    beforeEach(() => {
+        // Reset environment to allow auto-install
+        process.env = { ...originalEnv } as any;
+        process.env.NODE_ENV = 'development';
+        delete process.env.CI;
+        delete process.env.ELIZA_TEST_MODE;
+        delete process.env.ELIZA_NO_AUTO_INSTALL;
+        delete process.env.ELIZA_NO_PLUGIN_AUTO_INSTALL;
+    });
+
+    afterEach(() => {
+        (Bun as any).spawn = originalSpawn;
+        process.env = { ...originalEnv } as any;
+    });
+
+    test('returns false when auto-install disallowed by env', async () => {
+        const installer = new PluginInstaller();
+        process.env.ELIZA_NO_PLUGIN_AUTO_INSTALL = 'true';
+
+        let called = 0;
+        (Bun as any).spawn = ((cmd: any[]) => {
+            called += 1;
+            return { exited: Promise.resolve(0) } as any;
+        }) as any;
+
+        const result = await installer.tryInstall('@elizaos/plugin-demo');
+        expect(result).toBe(false);
+        expect(called).toBe(0);
+    });
+
+    test('succeeds when bun present and bun add exits 0', async () => {
+        const installer = new PluginInstaller();
+        const calls: any[] = [];
+
+        (Bun as any).spawn = ((args: any[]) => {
+            calls.push(args);
+            // First call is bun --version, second is bun add <pkg>
+            const isVersion = Array.isArray(args) && args[1] === '--version';
+            const exitCode = isVersion ? 0 : 0;
+            return { exited: Promise.resolve(exitCode) } as any;
+        }) as any;
+
+        const result = await installer.tryInstall('@elizaos/plugin-demo');
+        expect(result).toBe(true);
+        expect(calls.length).toBe(2);
+        expect(calls[0]).toEqual(['bun', '--version']);
+        expect(calls[1]).toEqual(['bun', 'add', '@elizaos/plugin-demo']);
+    });
+
+    test('fails when bun --version exits non-zero', async () => {
+        const installer = new PluginInstaller();
+        let versionCalls = 0;
+        (Bun as any).spawn = ((args: any[]) => {
+            if (Array.isArray(args) && args[1] === '--version') {
+                versionCalls += 1;
+                return { exited: Promise.resolve(1) } as any;
+            }
+            // would be bun add; should not be called
+            return { exited: Promise.resolve(0) } as any;
+        }) as any;
+
+        const result = await installer.tryInstall('@elizaos/plugin-demo');
+        expect(result).toBe(false);
+        expect(versionCalls).toBe(1);
+    });
+
+    test('fails when bun add exits non-zero', async () => {
+        const installer = new PluginInstaller();
+        const calls: any[] = [];
+        (Bun as any).spawn = ((args: any[]) => {
+            calls.push(args);
+            const isVersion = Array.isArray(args) && args[1] === '--version';
+            return { exited: Promise.resolve(isVersion ? 0 : 1) } as any;
+        }) as any;
+
+        const result = await installer.tryInstall('@elizaos/plugin-demo');
+        expect(result).toBe(false);
+        expect(calls.length).toBe(2);
+    });
+
+    test('only attempts install once per plugin name', async () => {
+        const installer = new PluginInstaller();
+        let spawnCount = 0;
+        (Bun as any).spawn = ((args: any[]) => {
+            spawnCount += 1;
+            const isVersion = Array.isArray(args) && args[1] === '--version';
+            return { exited: Promise.resolve(isVersion ? 0 : 0) } as any;
+        }) as any;
+
+        const p = '@elizaos/plugin-demo';
+        const first = await installer.tryInstall(p);
+        const second = await installer.tryInstall(p);
+        expect(first).toBe(true);
+        expect(second).toBe(false);
+        // First attempt uses 2 spawns (version + add); second attempt uses none
+        expect(spawnCount).toBe(2);
+    });
+
+    test('awaits process completion before returning', async () => {
+        const installer = new PluginInstaller();
+        let versionResolved = false;
+        let addResolved = false;
+        (Bun as any).spawn = ((args: any[]) => {
+            const isVersion = Array.isArray(args) && args[1] === '--version';
+            return {
+                exited: (async () => {
+                    await delay(isVersion ? 25 : 50);
+                    if (isVersion) versionResolved = true; else addResolved = true;
+                    return 0;
+                })(),
+            } as any;
+        }) as any;
+
+        const result = await installer.tryInstall('@elizaos/plugin-demo');
+        expect(result).toBe(true);
+        expect(versionResolved).toBe(true);
+        expect(addResolved).toBe(true);
+    });
+});
+
+


### PR DESCRIPTION
This PR introduces safe, on-demand plugin auto-installation for the server PluginLoader.\n\nProblem\n- Missing server plugins cause runtime failures when a project references external plugins not pre-installed.\n- Operators often need to manually run `bun add <package>` after the runtime crashes.\n\nSolution\n- Add `PluginInstaller` which guards via environment checks (disabled in CI/test, opt-out via `ELIZA_NO_AUTO_INSTALL`, `ELIZA_NO_PLUGIN_AUTO_INSTALL`).\n- On import failure, attempt `bun add <plugin>` once per process, then retry import.\n- Uses Bun subprocess to avoid Node-only assumptions; logs clearly on failure without crashing.\n\nFiles Changed\n- `packages/server/src/managers/PluginLoader.ts`: Integrate auto-install retry path.\n- `packages/server/src/managers/PluginInstaller.ts`: New installer with guards and single-attempt tracking.\n- `bun.lock`: Updated due to added dependencies.\n\nRisk & Mitigation\n- Auto-install is disabled in test/CI and behind env guards.\n- Only triggers on precise missing-module errors; otherwise no behavior change.\n\nTesting\n- Local: remove a plugin, start server, observe auto-install and successful import.\n- CI: assert no auto-install attempts when `CI=true`.\n\nFollow-ups\n- Consider surfacing a CLI prompt or server setting to confirm auto-install in interactive environments.