### PR TITLE
fix: initialize runtimes with settings at creation

### DIFF
--- a/packages/core/src/elizaos.ts
+++ b/packages/core/src/elizaos.ts
@@ -69,12 +69,12 @@ export class ElizaOS extends EventTarget {
   /**
    * Add multiple agents (batch operation)
    */
-  async addAgents(agents: Array<{ character: Character; plugins?: Plugin[] }>, settings: RuntimeSettings): Promise<UUID[]> {
+  async addAgents(agents: Array<{ character: Character; plugins?: Plugin[] }>, settings?: RuntimeSettings): Promise<UUID[]> {
     const promises = agents.map(async (agent) => {
       const runtime = new AgentRuntime({
         character: agent.character,
         plugins: agent.plugins || [],
-        settings
+        ...(settings ? { settings } : {})
       });
 
       this.runtimes.set(runtime.agentId, runtime);

--- a/packages/core/src/elizaos.ts
+++ b/packages/core/src/elizaos.ts
@@ -7,6 +7,7 @@ import type {
   Memory,
   State,
   Plugin,
+  RuntimeSettings,
 } from './types';
 
 /**
@@ -68,11 +69,12 @@ export class ElizaOS extends EventTarget {
   /**
    * Add multiple agents (batch operation)
    */
-  async addAgents(agents: Array<{ character: Character; plugins?: Plugin[] }>): Promise<UUID[]> {
+  async addAgents(agents: Array<{ character: Character; plugins?: Plugin[] }>, settings: RuntimeSettings): Promise<UUID[]> {
     const promises = agents.map(async (agent) => {
       const runtime = new AgentRuntime({
         character: agent.character,
         plugins: agent.plugins || [],
+        settings
       });
 
       this.runtimes.set(runtime.agentId, runtime);

--- a/packages/core/src/elizaos.ts
+++ b/packages/core/src/elizaos.ts
@@ -69,12 +69,12 @@ export class ElizaOS extends EventTarget {
   /**
    * Add multiple agents (batch operation)
    */
-  async addAgents(agents: Array<{ character: Character; plugins?: Plugin[] }>, settings?: RuntimeSettings): Promise<UUID[]> {
+  async addAgents(agents: Array<{ character: Character; plugins?: Plugin[], settings?: RuntimeSettings }>): Promise<UUID[]> {
     const promises = agents.map(async (agent) => {
       const runtime = new AgentRuntime({
         character: agent.character,
         plugins: agent.plugins || [],
-        ...(settings ? { settings } : {})
+        settings: agent.settings || {}
       });
 
       this.runtimes.set(runtime.agentId, runtime);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -250,13 +250,14 @@ export class AgentServer {
     const settings = await this.configManager?.loadEnvConfig();
 
     // Step 1: Add all agents (create them with their plugins)
-    const agentIds = await this.elizaOS.addAgents(
-      preparations.map((p) => ({
-        character: p.character,
-        plugins: p.plugins,
-      })),
-      settings,
-    );
+    const agentConfigs = preparations.map((p) => ({
+      character: {
+        ...p.character,
+        settings: { ...((p.character as any)?.settings || {}), ...(settings || {}) },
+      },
+      plugins: p.plugins,
+    }));
+    const agentIds = await this.elizaOS.addAgents(agentConfigs);
     
     // Step 2: Start all agents (initialize them)
     await this.elizaOS.startAgents(agentIds);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -249,15 +249,13 @@ export class AgentServer {
 
     const settings = await this.configManager?.loadEnvConfig();
 
-    // Step 1: Add all agents (create them with their plugins)
-    const agentConfigs = preparations.map((p) => ({
-      character: {
-        ...p.character,
-        settings: { ...((p.character as any)?.settings || {}), ...(settings || {}) },
-      },
-      plugins: p.plugins,
-    }));
-    const agentIds = await this.elizaOS.addAgents(agentConfigs);
+    const agentIds = await this.elizaOS.addAgents(
+      preparations.map((p) => ({
+        character: p.character,
+        plugins: p.plugins,
+        settings: settings || {}
+      })),
+    );
     
     // Step 2: Start all agents (initialize them)
     await this.elizaOS.startAgents(agentIds);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -261,7 +261,7 @@ export class AgentServer {
     // Step 2: Start all agents (initialize them)
     await this.elizaOS.startAgents(agentIds);
     
-    // Step 3: Collect started runtimes and register them (settings applied at creation)
+    // Step 3: Collect started runtimes and register them
     const runtimes: IAgentRuntime[] = [];
     
     for (const id of agentIds) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -250,15 +250,18 @@ export class AgentServer {
     const settings = await this.configManager?.loadEnvConfig();
 
     // Step 1: Add all agents (create them with their plugins)
-    const agentIds = await this.elizaOS.addAgents(preparations.map(p => ({
-      character: p.character,
-      plugins: p.plugins
-    })), settings);
+    const agentIds = await this.elizaOS.addAgents(
+      preparations.map((p) => ({
+        character: p.character,
+        plugins: p.plugins,
+      })),
+      settings,
+    );
     
     // Step 2: Start all agents (initialize them)
     await this.elizaOS.startAgents(agentIds);
     
-    // Step 3: Get the created runtimes
+    // Step 3: Collect started runtimes and register them (settings applied at creation)
     const runtimes: IAgentRuntime[] = [];
     
     for (const id of agentIds) {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -246,26 +246,24 @@ export class AgentServer {
         return { character: preparedCharacter, plugins: finalPlugins };
       })
     );
-    
+
+    const settings = await this.configManager?.loadEnvConfig();
+
     // Step 1: Add all agents (create them with their plugins)
     const agentIds = await this.elizaOS.addAgents(preparations.map(p => ({
       character: p.character,
       plugins: p.plugins
-    })));
+    })), settings);
     
     // Step 2: Start all agents (initialize them)
     await this.elizaOS.startAgents(agentIds);
     
-    // Step 3: Get the created runtimes and apply settings
+    // Step 3: Get the created runtimes
     const runtimes: IAgentRuntime[] = [];
-    const settings = await this.configManager?.loadEnvConfig();
     
     for (const id of agentIds) {
       const runtime = this.elizaOS.getAgent(id);
       if (runtime) {
-        // Apply settings
-        Object.assign(runtime, { settings });
-        
         // Register the agent in the server
         await this.registerAgent(runtime);
         


### PR DESCRIPTION
issue: https://linear.app/eliza-labs/issue/ELIZA-741/unhandled-exception-when-getagents-fails-in-runtimets-missing-agents

<img width="2538" height="1670" alt="image" src="https://github.com/user-attachments/assets/ac041dab-260d-4d42-8a66-da514e540a35" />



- core: add RuntimeSettings import and accept `settings` in `ElizaOS.addAgents`

- core: pass `settings` into `AgentRuntime` constructor during agent creation

- server: load env settings once and pass to `addAgents`

- server: remove post-creation runtime mutation via Object.assign(settings)

This ensures runtimes and plugins receive configuration during initialization, avoiding late mutations and potential race conditions.


