### PR TITLE
fix(server): downgrade plugin import failure from error to warn

### DIFF
--- a/packages/server/src/managers/PluginLoader.ts
+++ b/packages/server/src/managers/PluginLoader.ts
@@ -90,7 +90,7 @@ export class PluginLoader {
         // Attempt to dynamically import the plugin
         pluginModule = await import(pluginName);
       } catch (error) {
-        logger.error(`Failed to load plugin ${pluginName}: ${error}`);
+        logger.warn(`Failed to load plugin ${pluginName}: ${error}`);
         // Attempt auto-install if allowed and not already attempted
         const attempted = await pluginInstaller.tryInstall(pluginName);
         if (!attempted) {


### PR DESCRIPTION
### Summary
- Downgrade log level from error to warn on failed dynamic import in `packages/server/src/managers/PluginLoader.ts`.
- Rationale: initial import failure is frequently recoverable (auto-install/optional deps). Logging as error is noisy and suggests server fault. Warn is more appropriate while retaining retry/fallback.

### Issue
When a plugin is not yet installed or has an optional peer dependency missing, the first dynamic import commonly fails, but the loader immediately attempts `pluginInstaller.tryInstall(pluginName)`. Emitting an error-level log at this initial failure confuses operators and log monitors, making healthy self-healing flows look like incidents.

### Change
- Error → Warn for first import failure:
  - before: `logger.error("Failed to load plugin ${pluginName}: ${error}")`
  - after: `logger.warn("Failed to load plugin ${pluginName}: ${error}")`
- No behavior changes to install/retry/fallback flow.

### Testing
- Manual test by simulating missing plugin; verified warn log and installer path executed.
- No API changes; unit scope trivial.

### Risk
- Low. Only log level change.

### Affected files
- `packages/server/src/managers/PluginLoader.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Downgrades the first dynamic import failure in `PluginLoader.loadAndPreparePlugin` from error to warn without changing install/retry behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cf81c172df7f17e748fa244f8fd60abc0069581. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->