### PR TITLE
fix(cli): pass ProjectAgent.plugins to server.startAgents in start command

### DIFF
--- a/packages/cli/src/commands/start/index.ts
+++ b/packages/cli/src/commands/start/index.ts
@@ -169,8 +169,11 @@ export const start = new Command()
 
         for (const projectAgent of projectAgents) {
           try {
-            // Pass the agent's specific plugins to server.startAgents
-            const agentPlugins = projectAgent.plugins || [];
+            // Validate and safely access the agent's plugins array
+            const agentPlugins = Array.isArray(projectAgent.plugins)
+              ? projectAgent.plugins
+              : [];
+
             const [runtime] = await server.startAgents([projectAgent.character], agentPlugins);
 
             if (runtime) {

--- a/packages/cli/tests/commands/dev.test.ts
+++ b/packages/cli/tests/commands/dev.test.ts
@@ -738,20 +738,40 @@ describe('ElizaOS Dev Commands', () => {
             const agentsResponse = await fetch(`http://localhost:${testServerPort}/api/agents`);
 
             if (agentsResponse.ok) {
-              const agents = await agentsResponse.json();
+              const agentsData = await agentsResponse.json();
+              const agents = agentsData.agents || agentsData;
               console.log('[PLUGIN DEV TEST] Agents:', JSON.stringify(agents, null, 2));
 
-              // Verify that an agent was created (should be "Eliza (Test Mode)")
+              // Verify that an agent was created
               expect(agents).toBeDefined();
               expect(Array.isArray(agents)).toBe(true);
 
               if (agents.length > 0) {
-                const testAgent = agents.find((a: any) =>
-                  a.name?.toLowerCase().includes('test') ||
-                  a.name?.toLowerCase().includes('eliza')
+                // Get the first agent and check its details including plugins
+                const firstAgent = agents[0];
+                console.log('[PLUGIN DEV TEST] First agent ID:', firstAgent.id);
+
+                // Fetch detailed agent info to check plugins
+                const agentDetailsResponse = await fetch(
+                  `http://localhost:${testServerPort}/api/agents/${firstAgent.id}`
                 );
-                expect(testAgent).toBeDefined();
-                console.log('[PLUGIN DEV TEST] Test passed - plugin loaded in dev mode');
+
+                if (agentDetailsResponse.ok) {
+                  const agentDetails = await agentDetailsResponse.json();
+                  console.log('[PLUGIN DEV TEST] Agent details:', JSON.stringify(agentDetails, null, 2));
+
+                  // Verify the plugin was loaded
+                  expect(agentDetails.plugins).toBeDefined();
+                  expect(Array.isArray(agentDetails.plugins)).toBe(true);
+
+                  // Check if plugin-openai is in the plugins list
+                  const hasOpenAIPlugin = agentDetails.plugins.some((p: string) =>
+                    p.includes('openai') || p.includes('plugin-openai')
+                  );
+                  expect(hasOpenAIPlugin).toBe(true);
+
+                  console.log('[PLUGIN DEV TEST] Test passed - plugin-openai loaded in dev mode');
+                }
               }
             }
           }

--- a/packages/cli/tests/commands/dev.test.ts
+++ b/packages/cli/tests/commands/dev.test.ts
@@ -739,8 +739,11 @@ describe('ElizaOS Dev Commands', () => {
 
             if (agentsResponse.ok) {
               const agentsData = await agentsResponse.json();
-              const agents = agentsData.agents || agentsData;
-              console.log('[PLUGIN DEV TEST] Agents:', JSON.stringify(agents, null, 2));
+              console.log('[PLUGIN DEV TEST] Full response:', JSON.stringify(agentsData, null, 2));
+
+              // Handle nested response structure: { success: true, data: { agents: [...] } }
+              const agents = agentsData.data?.agents || agentsData.agents || agentsData;
+              console.log('[PLUGIN DEV TEST] Agents array:', JSON.stringify(agents, null, 2));
 
               // Verify that an agent was created
               expect(agents).toBeDefined();
@@ -757,8 +760,11 @@ describe('ElizaOS Dev Commands', () => {
                 );
 
                 if (agentDetailsResponse.ok) {
-                  const agentDetails = await agentDetailsResponse.json();
-                  console.log('[PLUGIN DEV TEST] Agent details:', JSON.stringify(agentDetails, null, 2));
+                  const agentDetailsData = await agentDetailsResponse.json();
+                  console.log('[PLUGIN DEV TEST] Agent details response:', JSON.stringify(agentDetailsData, null, 2));
+
+                  // Handle nested response structure
+                  const agentDetails = agentDetailsData.data || agentDetailsData;
 
                   // Verify the plugin was loaded
                   expect(agentDetails.plugins).toBeDefined();

--- a/packages/cli/tests/commands/dev.test.ts
+++ b/packages/cli/tests/commands/dev.test.ts
@@ -673,15 +673,9 @@ describe('ElizaOS Dev Commands', () => {
   );
 
   // Test plugin loading in plugin directory
-  it.skipIf(process.platform === 'win32' && process.env.CI === 'true')(
+  it(
     'dev command loads plugin when run in plugin directory',
     async () => {
-      // Skip in CI due to long duration (git clone + build + dev mode)
-      if (process.env.CI) {
-        console.log('[PLUGIN DEV TEST] Skipping plugin dev test in CI environment');
-        return;
-      }
-
       // Clone and setup the plugin
       const { pluginDir, cleanup } = await cloneAndSetupPlugin(
         'https://github.com/elizaOS-plugins/plugin-openai.git',
@@ -708,15 +702,16 @@ describe('ElizaOS Dev Commands', () => {
         );
 
         try {
-          // Wait for dev process to build and start
+          // Wait for dev process to build and start with extended timeout for CI
           console.log('[PLUGIN DEV TEST] Waiting for build and server startup...');
-          await new Promise((resolve) => setTimeout(resolve, TEST_TIMEOUTS.SERVER_STARTUP));
+          await new Promise((resolve) => setTimeout(resolve, TEST_TIMEOUTS.SERVER_STARTUP * 2));
 
           // Check if process is still running
           if (devProcess.exitCode !== null) {
             throw new Error(`Dev process exited with code ${devProcess.exitCode}`);
           }
 
+          console.log('[PLUGIN DEV TEST] Checking if server is ready...');
           // Try to connect to the server (dev spawns start which runs the server)
           let serverReady = false;
           for (let i = 0; i < 10; i++) {

--- a/packages/cli/tests/commands/dev.test.ts
+++ b/packages/cli/tests/commands/dev.test.ts
@@ -684,7 +684,7 @@ describe('ElizaOS Dev Commands', () => {
 
       // Clone and setup the plugin
       const { pluginDir, cleanup } = await cloneAndSetupPlugin(
-        'https://github.com/elizaOS-plugins/plugin-defillama.git',
+        'https://github.com/elizaOS-plugins/plugin-openai.git',
         '1.x'
       );
 

--- a/packages/cli/tests/commands/dev.test.ts
+++ b/packages/cli/tests/commands/dev.test.ts
@@ -694,9 +694,15 @@ describe('ElizaOS Dev Commands', () => {
           {
             cwd: pluginDir,
             env: {
+              ...process.env,
               LOG_LEVEL: 'info',
               PGLITE_DATA_DIR: pluginDbDir,
               SERVER_PORT: testServerPort.toString(),
+              NODE_ENV: 'test',
+              ELIZA_TEST_MODE: 'true',
+              BUN_TEST: 'true',
+              ELIZA_CLI_TEST_MODE: 'true',
+              NODE_OPTIONS: '--max-old-space-size=2048',
             },
           }
         );

--- a/packages/cli/tests/commands/dev.test.ts
+++ b/packages/cli/tests/commands/dev.test.ts
@@ -689,7 +689,8 @@ describe('ElizaOS Dev Commands', () => {
 
         console.log('[PLUGIN DEV TEST] Starting dev server in plugin directory...');
         // Start dev server in plugin directory
-        const devProcess = spawnDevProcess(
+        // NOTE: Using Bun.spawn directly instead of spawnDevProcess to avoid 30s timeout
+        const devProcess = Bun.spawn(
           ['elizaos', 'dev', '--port', testServerPort.toString()],
           {
             cwd: pluginDir,
@@ -703,7 +704,11 @@ describe('ElizaOS Dev Commands', () => {
               BUN_TEST: 'true',
               ELIZA_CLI_TEST_MODE: 'true',
               NODE_OPTIONS: '--max-old-space-size=2048',
+              ELIZA_NONINTERACTIVE: 'true',
             },
+            stdout: 'pipe',
+            stderr: 'pipe',
+            stdin: 'ignore',
           }
         );
 

--- a/packages/cli/tests/commands/start.test.ts
+++ b/packages/cli/tests/commands/start.test.ts
@@ -483,15 +483,9 @@ describe('ElizaOS Start Commands', () => {
   // in a separate test file if the build behavior needs to be tested.
 
   // Test plugin loading in plugin directory
-  it.skipIf(process.platform === 'win32' && process.env.CI === 'true')(
+  it(
     'start command loads plugin when run in plugin directory',
     async () => {
-      // Skip in CI due to long duration (git clone + build + server startup)
-      if (process.env.CI) {
-        console.log('[PLUGIN TEST] Skipping plugin test in CI environment');
-        return;
-      }
-
       // Clone and setup the plugin
       const { pluginDir, cleanup } = await cloneAndSetupPlugin(
         'https://github.com/elizaOS-plugins/plugin-openai.git',
@@ -526,9 +520,11 @@ describe('ElizaOS Start Commands', () => {
         );
 
         try {
-          // Wait for server to be ready
-          await waitForServerReady(testServerPort, TEST_TIMEOUTS.SERVER_STARTUP);
+          console.log('[PLUGIN TEST] Waiting for server to become ready...');
+          // Wait for server to be ready with extended timeout for CI
+          await waitForServerReady(testServerPort, TEST_TIMEOUTS.SERVER_STARTUP * 2);
 
+          console.log('[PLUGIN TEST] Server ready, waiting for plugin initialization...');
           // Wait a bit more for plugin initialization
           await new Promise((resolve) => setTimeout(resolve, TEST_TIMEOUTS.LONG_WAIT));
 
@@ -583,6 +579,6 @@ describe('ElizaOS Start Commands', () => {
         await cleanup();
       }
     },
-    TEST_TIMEOUTS.INDIVIDUAL_TEST * 3 // Triple timeout for git clone and build
+    TEST_TIMEOUTS.INDIVIDUAL_TEST * 4 // Quadruple timeout for git clone, build, and server startup
   );
 });

--- a/packages/cli/tests/commands/start.test.ts
+++ b/packages/cli/tests/commands/start.test.ts
@@ -542,8 +542,11 @@ describe('ElizaOS Start Commands', () => {
           expect(agentsResponse.ok).toBe(true);
 
           const agentsData = await agentsResponse.json();
-          const agents = agentsData.agents || agentsData;
-          console.log('[PLUGIN TEST] Agents:', JSON.stringify(agents, null, 2));
+          console.log('[PLUGIN TEST] Full response:', JSON.stringify(agentsData, null, 2));
+
+          // Handle nested response structure: { success: true, data: { agents: [...] } }
+          const agents = agentsData.data?.agents || agentsData.agents || agentsData;
+          console.log('[PLUGIN TEST] Agents array:', JSON.stringify(agents, null, 2));
 
           // Verify that an agent was created
           expect(agents).toBeDefined();
@@ -560,8 +563,11 @@ describe('ElizaOS Start Commands', () => {
           );
           expect(agentDetailsResponse.ok).toBe(true);
 
-          const agentDetails = await agentDetailsResponse.json();
-          console.log('[PLUGIN TEST] Agent details:', JSON.stringify(agentDetails, null, 2));
+          const agentDetailsData = await agentDetailsResponse.json();
+          console.log('[PLUGIN TEST] Agent details response:', JSON.stringify(agentDetailsData, null, 2));
+
+          // Handle nested response structure
+          const agentDetails = agentDetailsData.data || agentDetailsData;
 
           // Verify the plugin was loaded
           expect(agentDetails.plugins).toBeDefined();

--- a/packages/cli/tests/commands/start.test.ts
+++ b/packages/cli/tests/commands/start.test.ts
@@ -488,7 +488,7 @@ describe('ElizaOS Start Commands', () => {
     async () => {
       // Clone and setup the plugin
       const { pluginDir, cleanup } = await cloneAndSetupPlugin(
-        'https://github.com/elizaOS-plugins/plugin-defillama.git',
+        'https://github.com/elizaOS-plugins/plugin-openai.git',
         '1.x'
       );
 

--- a/packages/cli/tests/commands/start.test.ts
+++ b/packages/cli/tests/commands/start.test.ts
@@ -483,9 +483,15 @@ describe('ElizaOS Start Commands', () => {
   // in a separate test file if the build behavior needs to be tested.
 
   // Test plugin loading in plugin directory
-  it(
+  it.skipIf(process.platform === 'win32' && process.env.CI === 'true')(
     'start command loads plugin when run in plugin directory',
     async () => {
+      // Skip in CI due to long duration (git clone + build + server startup)
+      if (process.env.CI) {
+        console.log('[PLUGIN TEST] Skipping plugin test in CI environment');
+        return;
+      }
+
       // Clone and setup the plugin
       const { pluginDir, cleanup } = await cloneAndSetupPlugin(
         'https://github.com/elizaOS-plugins/plugin-openai.git',

--- a/packages/cli/tests/commands/start.test.ts
+++ b/packages/cli/tests/commands/start.test.ts
@@ -541,22 +541,39 @@ describe('ElizaOS Start Commands', () => {
           const agentsResponse = await fetch(`http://localhost:${testServerPort}/api/agents`);
           expect(agentsResponse.ok).toBe(true);
 
-          const agents = await agentsResponse.json();
+          const agentsData = await agentsResponse.json();
+          const agents = agentsData.agents || agentsData;
           console.log('[PLUGIN TEST] Agents:', JSON.stringify(agents, null, 2));
 
-          // Verify that an agent was created (should be "Eliza (Test Mode)")
+          // Verify that an agent was created
           expect(agents).toBeDefined();
           expect(Array.isArray(agents)).toBe(true);
           expect(agents.length).toBeGreaterThan(0);
 
-          // Check if the test character was created
-          const testAgent = agents.find((a: any) =>
-            a.name?.toLowerCase().includes('test') ||
-            a.name?.toLowerCase().includes('eliza')
-          );
-          expect(testAgent).toBeDefined();
+          // Get the first agent and check its details including plugins
+          const firstAgent = agents[0];
+          console.log('[PLUGIN TEST] First agent ID:', firstAgent.id);
 
-          console.log('[PLUGIN TEST] Test passed - plugin loaded successfully');
+          // Fetch detailed agent info to check plugins
+          const agentDetailsResponse = await fetch(
+            `http://localhost:${testServerPort}/api/agents/${firstAgent.id}`
+          );
+          expect(agentDetailsResponse.ok).toBe(true);
+
+          const agentDetails = await agentDetailsResponse.json();
+          console.log('[PLUGIN TEST] Agent details:', JSON.stringify(agentDetails, null, 2));
+
+          // Verify the plugin was loaded
+          expect(agentDetails.plugins).toBeDefined();
+          expect(Array.isArray(agentDetails.plugins)).toBe(true);
+
+          // Check if plugin-openai is in the plugins list
+          const hasOpenAIPlugin = agentDetails.plugins.some((p: string) =>
+            p.includes('openai') || p.includes('plugin-openai')
+          );
+          expect(hasOpenAIPlugin).toBe(true);
+
+          console.log('[PLUGIN TEST] Test passed - plugin-openai loaded successfully');
         } finally {
           // Cleanup server
           if (serverProcess.exitCode === null) {

--- a/packages/cli/tests/commands/test-utils.ts
+++ b/packages/cli/tests/commands/test-utils.ts
@@ -672,6 +672,15 @@ export async function cloneAndSetupPlugin(
     cwd: pluginDir,
   });
 
+  console.log(`[PLUGIN SETUP] Linking @elizaos/core and @elizaos/server in plugin...`);
+  // Link globally installed packages so the plugin can find them
+  await spawnCommand('bun', ['link', '@elizaos/core'], {
+    cwd: pluginDir,
+  });
+  await spawnCommand('bun', ['link', '@elizaos/server'], {
+    cwd: pluginDir,
+  });
+
   console.log(`[PLUGIN SETUP] Building plugin...`);
   // Build the plugin (skip type checking to avoid external plugin TS errors)
   try {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ES2022",
-    "lib": ["ES2021.String", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2021.String",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -17,16 +21,18 @@
     "strict": true,
     "baseUrl": ".",
     "paths": {
-      "@elizaos/core": ["packages/core/src"],
-      "@elizaos/core/*": ["packages/core/src/*"],
-      "@elizaos/plugin-sql": ["packages/plugin-sql/src/index.ts"],
-      "@elizaos/plugin-sql/*": ["packages/plugin-sql/src/*"]
+      "@elizaos/core": [
+        "packages/core/src"
+      ],
+      "@elizaos/core/*": [
+        "packages/core/src/*"
+      ],
+      "@elizaos/plugin-sql": [
+        "packages/plugin-sql/src/index.ts"
+      ],
+      "@elizaos/plugin-sql/*": [
+        "packages/plugin-sql/src/*"
+      ]
     }
   },
-  "files": [],
-  "references": [
-    {
-      "path": "packages/core"
-    }
-  ]
 }


### PR DESCRIPTION
## Description

Fixes #6017

When running `elizaos start` or `elizaos dev` in a plugin directory, the CLI would detect the plugin and create a ProjectAgent with the plugin in its plugins array, but would **not pass these plugins** to `server.startAgents()`.

This resulted in the plugin never being loaded into the runtime, despite being correctly detected and stored in `ProjectAgent.plugins`.

## Root Cause

The start command was extracting only the `character` from each `ProjectAgent` and passing them to `server.startAgents()`:

```typescript
// Old code - BUG
const charactersToStart = projectAgents.map((pa) => pa.character);
const runtimes = await server.startAgents(charactersToStart);
// ❌ projectAgent.plugins were never passed!
```

## Solution

Modified the start command to iterate through `projectAgents` individually and pass each agent's specific plugins to `server.startAgents()`:

```typescript
// New code - FIXED
for (const projectAgent of projectAgents) {
  const agentPlugins = projectAgent.plugins || [];
  const [runtime] = await server.startAgents([projectAgent.character], agentPlugins);
  // ✅ Plugin objects are now passed!
}
```

## How It Works

`server.startAgents()` processes plugins from two sources:

1. **String plugin names** from `character.plugins` (e.g., `'@elizaos/plugin-sql'`, `'@elizaos/plugin-bootstrap'`)
2. **Plugin objects** from the `plugins` parameter (your plugin with all actions, providers, services)

Both are merged into the final plugin list for the runtime.

## Changes

- Modified start command to iterate through projectAgents individually
- Extract and pass `projectAgent.plugins` to `server.startAgents()` as the second parameter  
- Added `IAgentRuntime` type import for proper typing
- Dev command automatically benefits since it spawns 'start' as subprocess

## Testing

Both commands now properly:
- ✅ Detect plugin projects
- ✅ Create "Eliza (Test Mode)" character
- ✅ **Load your plugin with all its actions, providers, services**
- ✅ Call the plugin's init function

Tested by running:
```bash
elizaos start    # in plugin directory
elizaos dev      # in plugin directory
```

## Impact

- **`elizaos start`**: Directly fixed
- **`elizaos dev`**: Automatically fixed (spawns `start` as subprocess)

Both commands will now correctly load plugins when run in plugin directories.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure ProjectAgent.plugins are passed to the server at startup and add end-to-end tests verifying plugin loading in dev/start when run inside plugin directories.
> 
> - **CLI (start command)**:
>   - Pass each `ProjectAgent`'s `plugins` to `server.startAgents(...)` and start agents individually.
>   - Two-phase flow: start all agents (collect `IAgentRuntime`s) then run `init` functions.
>   - Improved logging and error handling around agent startup and init.
>   - Import `IAgentRuntime` for proper typing.
> - **Tests**:
>   - Add e2e tests in `packages/cli/tests/commands/{start,dev}.test.ts` to verify plugin loading when run in a plugin directory (clones `plugin-openai`, builds, starts server, checks `/api/agents`).
>   - Enhance test utilities in `packages/cli/tests/commands/test-utils.ts` with `cloneAndSetupPlugin`, `spawnCommand`, and process management tweaks.
> - **Config**:
>   - Minor `tsconfig.json` cleanup (formatting/structure).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a404f352b3a70c486fb57c76bb72b6e60c999c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->