### PR TITLE
fix(config): remove invalid project references from root tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ES2022",
-    "lib": ["ES2021.String", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2021.String",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "moduleResolution": "node",
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -17,16 +21,18 @@
     "strict": true,
     "baseUrl": ".",
     "paths": {
-      "@elizaos/core": ["packages/core/src"],
-      "@elizaos/core/*": ["packages/core/src/*"],
-      "@elizaos/plugin-sql": ["packages/plugin-sql/src/index.ts"],
-      "@elizaos/plugin-sql/*": ["packages/plugin-sql/src/*"]
+      "@elizaos/core": [
+        "packages/core/src"
+      ],
+      "@elizaos/core/*": [
+        "packages/core/src/*"
+      ],
+      "@elizaos/plugin-sql": [
+        "packages/plugin-sql/src/index.ts"
+      ],
+      "@elizaos/plugin-sql/*": [
+        "packages/plugin-sql/src/*"
+      ]
     }
   },
-  "files": [],
-  "references": [
-    {
-      "path": "packages/core"
-    }
-  ]
 }


### PR DESCRIPTION
## Issue

TypeScript was throwing an error:
```
File '/Users/studio/Documents/GitHub/eliza/packages/core' not found.
```

## Root Cause

The root `tsconfig.json` had a `references` array pointing to `packages/core`, but TypeScript project references require a `tsconfig.json` file in the referenced directory with `composite: true`. The `packages/core` directory only contains `tsconfig.declarations.json`, which is not a valid project reference target.

## Solution

Removed the invalid `references` array and `files` array from the root `tsconfig.json`. The path mappings for `@elizaos/core` are still present and functional, so imports will continue to work correctly.

## Testing

- Verified TypeScript no longer throws the file not found error
- Path mappings remain intact for module resolution

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove invalid project references and files from root tsconfig; reformat arrays.
> 
> - **Config**:
>   - `tsconfig.json`:
>     - Remove `references` and `files` from root config.
>     - Preserve `paths` mappings; no module resolution changes.
>     - Reformat `lib` and `paths` arrays to multi-line.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b5a88eaf8c95139d1f13f95a2dab10f806942da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->