### PR TITLE
fix(service-interfaces): skip test execution for types-only package

### DIFF
--- a/packages/service-interfaces/package.json
+++ b/packages/service-interfaces/package.json
@@ -46,9 +46,9 @@
     "build": "bun run build.ts",
     "dev": "bun run build.ts --watch",
     "clean": "rm -rf dist .turbo node_modules .turbo-tsconfig.json *.tsbuildinfo",
-    "test": "bun test --coverage",
-    "test:coverage": "bun test --coverage",
-    "test:watch": "bun test --watch",
+    "test": "echo 'Skipping tests for types-only package' && exit 0",
+    "test:coverage": "echo 'Skipping tests for types-only package' && exit 0",
+    "test:watch": "echo 'Skipping tests for types-only package'",
     "format": "prettier --write ./src",
     "format:check": "prettier --check ./src",
     "lint": "prettier --write ./src"


### PR DESCRIPTION
The @elizaos/service-interfaces package contains only TypeScript interface
definitions and has no runtime logic or tests. The test script was failing
when running `bun run test` from the project root because bun test exits
with code 1 when no test files are found.

Changed the test scripts to explicitly skip test execution with a clear
message, allowing the monorepo test suite to complete successfully.