### PR TITLE
fix: fix BOOTSTRAP_KEEP_RESP

### DIFF
--- a/packages/plugin-bootstrap/src/index.ts
+++ b/packages/plugin-bootstrap/src/index.ts
@@ -627,6 +627,9 @@ const messageReceivedHandler = async ({
         let responseContent: Content | null = null;
         let responseMessages: Memory[] = [];
 
+        // helpful for swarms
+        const keepResp = parseBooleanFromText(runtime.getSetting('BOOTSTRAP_KEEP_RESP'));
+        
         if (shouldRespondToMessage) {
           const result = useMultiStep
             ? await runMultiStepCore({ runtime, message, state, callback })
@@ -638,7 +641,7 @@ const messageReceivedHandler = async ({
 
           // Race check before we send anything
           const currentResponseId = agentResponses.get(message.roomId);
-          if (currentResponseId !== responseId) {
+          if (currentResponseId !== responseId && !keepResp) {
             runtime.logger.info(
               `Response discarded - newer message being processed for agent: ${runtime.agentId}, room: ${message.roomId}`
             );
@@ -687,8 +690,6 @@ const messageReceivedHandler = async ({
 
           // Check if we still have the latest response ID
           const currentResponseId = agentResponses.get(message.roomId);
-          // helpful for swarms
-          const keepResp = parseBooleanFromText(runtime.getSetting('BOOTSTRAP_KEEP_RESP'));
           if (currentResponseId !== responseId && !keepResp) {
             runtime.logger.info(
               `Ignore response discarded - newer message being processed for agent: ${runtime.agentId}, room: ${message.roomId}`


### PR DESCRIPTION
make sure BOOTSTRAP_KEEP_RESP works even if not ignored

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Applies `BOOTSTRAP_KEEP_RESP` to both reply and ignore paths to prevent discarding responses when newer messages arrive.
> 
> - **Message handling (`packages/plugin-bootstrap/src/index.ts`)**:
>   - Respect `BOOTSTRAP_KEEP_RESP` during race checks for both reply and ignore flows by adding `&& !keepResp` to `currentResponseId !== responseId` conditions.
>   - Centralize `keepResp` parsing before response generation; remove duplicate parsing in the ignore branch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 964799d4366b6958f416aecf5951c0541b9d1509. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->