### PR TITLE
fix: expose state cache and fix bootstrap types

### DIFF
--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -196,12 +196,12 @@ These are the actions or data provider calls that have already been used in this
 
 <keys>
 "thought" Clearly explain your reasoning for the selected providers and/or action, and how this step contributes to resolving the user's request.
-"action"  Name of the action to execute after providers return (can be null if no action is needed).
+"action"  Name of the action to execute after providers return (can be empty if no action is needed).
 "providers" List of provider names to call in this step (can be empty if none are needed).
 "isFinish" Set to true only if the task is fully complete.
 </keys>
 
-⚠️ IMPORTANT: Do **not** mark the task as \`isFinish: true\` immediately after calling an action like. Wait for the action to complete before deciding the task is finished.
+⚠️ IMPORTANT: Do **not** mark the task as \`isFinish: true\` immediately after calling an action. Wait for the action to complete before deciding the task is finished.
 
 <output>
 <response>

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -32,6 +32,7 @@ export interface IAgentRuntime extends IDatabaseAdapter {
   fetch?: typeof fetch | null;
   routes: Route[];
   logger: Logger;
+  stateCache: Map<string, State>;
 
   // Methods
   registerPlugin(plugin: Plugin): Promise<void>;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expose runtime stateCache and refactor bootstrap multistep/type usage to consume it, with minor prompt and provider access fixes.
> 
> - **Core**:
>   - Expose `stateCache: Map<string, State>` on `IAgentRuntime`.
> - **Plugin-Bootstrap**:
>   - Type fixes: import `Action`, `HandlerCallback`; add explicit param types for `runSingleShotCore`/`runMultiStepCore`; remove `MultiStepState` in favor of `State`.
>   - Multistep: read action results from `runtime.stateCache` (`${message.id}_action_results`).
>   - Providers: type `availableActions` mapping as `(a: Action) => a.name`.
>   - Data access: use `state.data.providers.RECENT_MESSAGES` instead of `state.providerData`.
>   - Error mapping: adjust provider/action error assignment to use `text` when failed.
> - **Prompts**:
>   - Clarify `"action"` key can be empty; minor wording fix in IMPORTANT note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51975c2863f62a69ca330961534f2d343f73ec95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->