### PR TITLE
fix: port validate

### DIFF
--- a/packages/cli/src/commands/start/index.ts
+++ b/packages/cli/src/commands/start/index.ts
@@ -158,8 +158,23 @@ export const start = new Command()
         postgresUrl: process.env.POSTGRES_URL,
       });
 
-      // Start HTTP server
-      const port = options.port || parseInt(process.env.SERVER_PORT || '3000', 10);
+      // Start HTTP server with robust port resolution
+      let port: number;
+      if (typeof options.port === 'number' && Number.isFinite(options.port)) {
+        port = options.port;
+      } else {
+        const envPort = process.env.SERVER_PORT;
+        if (envPort) {
+          try {
+            port = validatePort(envPort);
+          } catch {
+            logger.warn(`Invalid SERVER_PORT "${envPort}", falling back to 3000`);
+            port = 3000;
+          }
+        } else {
+          port = 3000;
+        }
+      }
       await server.start(port);
 
       // Handle project agents with their init functions

--- a/packages/cli/src/commands/start/index.ts
+++ b/packages/cli/src/commands/start/index.ts
@@ -160,7 +160,8 @@ export const start = new Command()
 
       // Start HTTP server with robust port resolution
       let port: number;
-      if (typeof options.port === 'number' && Number.isFinite(options.port)) {
+      if (options.port !== undefined) {
+        // Already validated by Commander using validatePort
         port = options.port;
       } else {
         const envPort = process.env.SERVER_PORT;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improve port resolution in `start` by validating CLI `--port`, parsing `SERVER_PORT` with `validatePort`, and falling back to `3000` with a warning if invalid.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a40f4d5b2d06994a7f029190cfd5eab244f6c691. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->