### PR TITLE
fix(local-inference): resolve glslc to absolute path before passing to CMake

### DIFF
--- a/packages/app-core/scripts/build-llama-cpp-dflash.mjs
+++ b/packages/app-core/scripts/build-llama-cpp-dflash.mjs
@@ -438,7 +438,16 @@ function findAndroidVulkanInclude(ndk) {
 // Locate a glslc usable for the host. The Android NDK ships its own glslc
 // under shader-tools/<host>/glslc.
 function findGlslc(ndk) {
-  if (has("glslc")) return "glslc";
+  if (has("glslc")) {
+    // Resolve to absolute path. CMake interprets the bare string "glslc"
+    // as a relative FILEPATH against the source dir, which silently breaks
+    // vulkan-shaders-gen on Linux hosts where glslc lives at /usr/bin/glslc.
+    try {
+      const out = spawnSync("which", ["glslc"], { encoding: "utf8" }).stdout?.trim();
+      if (out) return out;
+    } catch {}
+    return "glslc";
+  }
   if (ndk) {
     const hostDirs = ["linux-x86_64", "darwin-x86_64", "windows-x86_64"];
     for (const host of hostDirs) {


### PR DESCRIPTION
## Problem

\`findGlslc\` in \`packages/app-core/scripts/build-llama-cpp-dflash.mjs:563\` returns the bare string \`"glslc"\` when the binary is on the host PATH. The script then passes this verbatim to CMake as \`-DVulkan_GLSLC_EXECUTABLE=glslc\`, which CMake stores as a relative \`FILEPATH\` resolved against the source dir (the llama.cpp checkout).

On a stock Debian/Ubuntu host where \`glslc\` lives at \`/usr/bin/glslc\`, the resulting cache value is:

\`\`\`
Vulkan_GLSLC_EXECUTABLE:FILEPATH=/home/.../inference/llama.cpp/glslc
\`\`\`

That path does not exist. \`vulkan-shaders-gen\` is then invoked without a usable glslc, silently produces **zero \`.spv\` files**, and writes an \`.hpp\` header with \`extern const\` declarations whose \`_data\` / \`_len\` symbols are never defined. Link fails with ~2,000 undefined references:

\`\`\`
/usr/bin/x86_64-linux-gnu-ld.bfd: ../../bin/libggml-vulkan.so.0.9.7: undefined reference to \`add_f16_f16_f32_rte_len\`
/usr/bin/x86_64-linux-gnu-ld.bfd: ../../bin/libggml-vulkan.so.0.9.7: undefined reference to \`matmul_id_subgroup_q5_1_q8_1_data\`
... ~2000 more
\`\`\`

The build itself reports as exited but the resulting \`libggml-vulkan.so\` is unlinkable, so \`llama-server\` / \`llama-cli\` never produced.

## Fix

Resolve \`glslc\` via \`which\` before returning, so CMake receives an absolute path and the shader-gen step actually invokes glslc:

\`\`\`diff
 function findGlslc(ndk) {
-  if (has("glslc")) return "glslc";
+  if (has("glslc")) {
+    // Resolve to absolute path. CMake interprets the bare string "glslc"
+    // as a relative FILEPATH against the source dir, which silently breaks
+    // vulkan-shaders-gen on Linux hosts where glslc lives at /usr/bin/glslc.
+    try {
+      const out = spawnSync("which", ["glslc"], { encoding: "utf8" }).stdout?.trim();
+      if (out) return out;
+    } catch {}
+    return "glslc";
+  }
   if (ndk) { ... }
\`\`\`

Android NDK path is unaffected — it already returns an absolute path via \`path.join(ndk, "shader-tools", host, "glslc")\`. The fallback \`return "glslc"\` keeps existing behavior on hosts where \`which\` fails for any reason.

## Verification

On Intel Core Ultra 7 258V (Lunar Lake) with Arc Graphics 140V iGPU, after the fix, \`linux-x64-vulkan\` build produces **2,203 SPV blobs** and a working \`llama-server\`. The Vulkan runtime correctly detects the GPU with KHR_coopmat / XMX matrix cores active:

\`\`\`
ggml_vulkan: Found 1 Vulkan devices:
ggml_vulkan: 0 = Intel(R) Graphics (LNL) (Intel open-source Mesa driver) | uma: 1 | fp16: 1 | bf16: 1 | warp size: 32 | shared memory: 49152 | int dot: 1 | matrix cores: KHR_coopmat
\`\`\`

\`llama-bench\` on Llama-3.1-8B-Instruct Q4_K_M (all 33 layers offloaded to Vulkan):

\`\`\`
| model                          |       size |     params | backend    | ngl | threads |            test |                  t/s |
| ------------------------------ | ---------: | ---------: | ---------- | --: | ------: | --------------: | -------------------: |
| llama 8B Q4_K - Medium         |   4.58 GiB |     8.03 B | Vulkan     |  99 |       8 |            pp64 |        172.93 ± 5.23 |
| llama 8B Q4_K - Medium         |   4.58 GiB |     8.03 B | Vulkan     |  99 |       8 |            tg32 |          5.73 ± 3.48 |
\`\`\`

vs CPU baseline on the same machine (\`linux-x64-cpu\` target): 1.42 t/s prompt eval, 0.60 t/s decode — so this fix unlocks ~121× prompt-eval speedup and ~9.5× decode speedup. Tool-calling end-to-end via \`/v1/chat/completions\` also verified working (Llama-3.1's \`<|python_tag|>\` parser path).

## Test plan

- [x] Rebuilt \`linux-x64-vulkan\` target on a host where the previous build had failed → succeeds now
- [x] \`Vulkan_GLSLC_EXECUTABLE\` in CMakeCache.txt is \`/usr/bin/glslc\` (was \`/llama.cpp/glslc\`)
- [x] 2,203 SPV files generated in \`vulkan-shaders.spv/\` (was 0)
- [x] \`llama-server\` boots, all layers offload to GPU, KHR_coopmat active
- [x] Functional: chat completes, tool calls parsed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent build failure on Linux when building the `linux-x64-vulkan` target: `findGlslc` was returning the bare string `"glslc"` which CMake stores as a relative `FILEPATH` resolved against the llama.cpp source directory, causing `vulkan-shaders-gen` to produce zero `.spv` files and a broken `libggml-vulkan.so`. The fix shells out to `which` to resolve the absolute path before returning it to CMake.

- **`findGlslc` patched** to call `spawnSync("which", ["glslc"])` and return the absolute path (e.g. `/usr/bin/glslc`) when found; falls back to the bare `"glslc"` string on systems where `which` is unavailable (Windows, minimal containers), preserving prior behavior on those hosts.
- **NDK and null paths unaffected** — the Android NDK branch already constructs an absolute path via `path.join`, and the `return null` path is unchanged.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is narrow, targets a well-understood CMake path-resolution bug, and the fallback preserves existing behavior on Windows and minimal Linux environments.

The fix is correct and well-reasoned. The only cosmetic issue is the `try/catch` wrapper around `spawnSync`, which does not actually intercept `spawnSync` failures (those surface as `result.error`, not thrown exceptions); the real guard is the `if (out)` null check. This is a style concern with no functional impact.

No files require special attention; the single-function change in `build-llama-cpp-dflash.mjs` is self-contained.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/build-llama-cpp-dflash.mjs | Resolves `glslc` to an absolute path via `which` before passing to CMake, preventing a silent shader-gen failure where CMake would interpret the bare string as a relative path. Logic is correct; the `try/catch` is cosmetically misleading but harmless. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(local-inference): resolve glslc to a..."](https://github.com/elizaos/eliza/commit/566dae0ff706574f2cc67f82e115fbb3921c0156) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31842199)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->