### PR TITLE
build(dflash): add linux-x64-openvino target (Intel CPU + iGPU + NPU) + submodule bump

### DIFF
--- a/packages/app-core/scripts/build-llama-cpp-dflash.mjs
+++ b/packages/app-core/scripts/build-llama-cpp-dflash.mjs
@@ -150,6 +150,31 @@ const SUPPORTED_TARGETS = [
   "linux-x64-cuda",
   "linux-x64-rocm",
   "linux-x64-vulkan",
+  // Intel OpenVINO backend on Linux x64 (ggml-org/llama.cpp PR #15307,
+  // merged into upstream master on 2026-04-08; this fork cherry-picks
+  // the ggml-openvino/ directory). Builds a single llama-server binary
+  // that can target the Intel CPU, Intel iGPU/dGPU (Arc / Xe / Lunar
+  // Lake / Meteor Lake / Panther Lake), OR the Intel NPU (Lunar Lake AI
+  // Boost ~48 TOPS, Meteor Lake NCE, Arrow Lake) — the device is
+  // selected at RUNTIME via `GGML_OPENVINO_DEVICE={CPU,GPU,NPU,GPU.0,
+  // GPU.1}`. NPU coverage is the unique value here: SYCL/Vulkan/CUDA do
+  // not cover the NPU, OpenVINO does, and NPU inference draws ~2-3 W
+  // vs ~15-25 W for the iGPU on the same model. Requires the OpenVINO
+  // Runtime (`apt install openvino-2026.x.x` from
+  // https://apt.repos.intel.com/openvino, or extract the tarball under
+  // /opt/intel/openvino_2026/); `source
+  // /opt/intel/openvino_2026/setupvars.sh` exports `OpenVINO_DIR` and
+  // `LD_LIBRARY_PATH` so CMake's `find_package(OpenVINO)` succeeds and
+  // the runtime can dlopen `libopenvino.so` at execution time. The
+  // W4-B custom kernels (turbo3 / turbo4 / turbo3_tcq / qjl /
+  // polarquant / dflash) do NOT have an OpenVINO backend — those are
+  // CUDA / Vulkan / Metal / CPU only — so this target runs plain ggml
+  // ops translated to OpenVINO compute graphs. The kernel-patches
+  // dispatch in patchAllKernels() correctly no-ops for `backend ===
+  // "openvino"` (the per-backend branches around line 1490 only match
+  // cuda/vulkan/metal). Supported quantizations: FP16, Q8_0, Q4_0,
+  // Q4_1, Q4_K, Q4_K_M (with runtime conversion for Q5_K / Q6_K).
+  "linux-x64-openvino",
   // Linux aarch64. Required for the `server-h200` tier (GH200 = aarch64
   // host + H100/H200 GPU) and for Ampere Altra / AWS Graviton CPU-only
   // deployments. Both targets require a real arm64 Linux host (or a
@@ -880,6 +905,11 @@ function cmakeFlagsForTarget(target, ctx) {
   //     existing `backend === "cpu" && arch === "x64"` / `arm64` blocks
   //     in the `platform === "windows"` section (and a new linux-cpu
   //     block here if a non-native pin is ever needed).
+  //   * OPENVINO-AGENT TODO: extra flags for `linux-x64-openvino` (and
+  //     future `windows-x64-openvino`) go in the `backend ===
+  //     "openvino"` branch below. Eliza-kernel OpenVINO backends, if
+  //     they're ever written, would plug into the same branch alongside
+  //     an entry in patchAllKernels() at the bottom of this file.
   // ──────────────────────────────────────────────────────────────────
   const { platform, arch, backend, isSimulator } = parseTarget(target);
   const flags = ["-DLLAMA_BUILD_TESTS=OFF", "-DLLAMA_BUILD_EXAMPLES=ON"];
@@ -888,7 +918,13 @@ function cmakeFlagsForTarget(target, ctx) {
   flags.push(`-DGGML_NATIVE=${isCross ? "OFF" : "ON"}`);
 
   // Disable backends we don't want by default; flip the chosen one back on.
-  const offByDefault = ["GGML_METAL", "GGML_CUDA", "GGML_HIP", "GGML_VULKAN"];
+  const offByDefault = [
+    "GGML_METAL",
+    "GGML_CUDA",
+    "GGML_HIP",
+    "GGML_VULKAN",
+    "GGML_OPENVINO",
+  ];
   for (const name of offByDefault) flags.push(`-D${name}=OFF`);
 
   if (backend === "metal") {
@@ -935,6 +971,30 @@ function cmakeFlagsForTarget(target, ctx) {
     // narrow/extend with ELIZA_DFLASH_CMAKE_FLAGS; those flags append
     // after this list and win on a CMake conflict.
     flags.push(hipArchListFlag());
+  } else if (backend === "openvino") {
+    // Intel OpenVINO backend. Builds plain ggml-openvino from the
+    // cherry-picked upstream tree (no Eliza kernel patches — those
+    // branches in patch*Kernels() only match cuda/vulkan/metal).
+    // Operator must source the OpenVINO setupvars script (e.g.
+    // `source /opt/intel/openvino_2026/setupvars.sh`) so OpenVINO_DIR
+    // / INTEL_OPENVINO_DIR and LD_LIBRARY_PATH are set before this
+    // script runs. CMake then resolves `find_package(OpenVINO)` from
+    // those env vars.
+    flags[flags.indexOf("-DGGML_OPENVINO=OFF")] = "-DGGML_OPENVINO=ON";
+    // Pass OpenVINO_DIR explicitly when present — find_package() will
+    // honor it. Some OpenVINO tarballs install to non-standard paths
+    // (/opt/intel/openvino_<ver>/runtime/cmake) which CMake's default
+    // search heuristics miss.
+    const openvinoDir =
+      process.env.OpenVINO_DIR || process.env.INTEL_OPENVINO_DIR;
+    if (openvinoDir) {
+      // INTEL_OPENVINO_DIR points at /opt/intel/openvino_<ver>/, but
+      // find_package() wants the runtime/cmake subdirectory. Normalize.
+      const cmakeDir = openvinoDir.endsWith("/cmake")
+        ? openvinoDir
+        : path.join(openvinoDir, "runtime", "cmake");
+      flags.push(`-DOpenVINO_DIR=${cmakeDir}`);
+    }
   } else if (backend === "vulkan") {
     flags[flags.indexOf("-DGGML_VULKAN=OFF")] = "-DGGML_VULKAN=ON";
     if (ctx.glslc) flags.push(`-DVulkan_GLSLC_EXECUTABLE=${ctx.glslc}`);
@@ -1189,6 +1249,16 @@ function targetCompatibility(target, ctx) {
   }
   if (backend === "vulkan" && !ctx.glslc) {
     return { ok: false, reason: "no glslc (Vulkan shader compiler)" };
+  }
+  if (
+    backend === "openvino" &&
+    !(process.env.OpenVINO_DIR || process.env.INTEL_OPENVINO_DIR)
+  ) {
+    return {
+      ok: false,
+      reason:
+        "no OpenVINO_DIR / INTEL_OPENVINO_DIR — source /opt/intel/openvino_<ver>/setupvars.sh first",
+    };
   }
   if (backend === "metal" && process.platform !== "darwin") {
     return { ok: false, reason: "metal requires macOS" };


### PR DESCRIPTION
## Summary

Adds a Linux x64 OpenVINO build target to `packages/app-core/scripts/build-llama-cpp-dflash.mjs` and bumps the llama.cpp submodule to `elizaOS/llama.cpp#1` (which cherry-picks ggml-org/llama.cpp's OpenVINO backend).

Result: a single `llama-server` / `llama-cli` binary that runs GGUF models on **the Intel CPU, the Intel iGPU/dGPU, OR the Intel NPU** with runtime device selection via `GGML_OPENVINO_DEVICE={CPU,GPU,NPU,GPU.0,GPU.1}`.

## Motivation

This is the only llama.cpp path that targets the Intel NPU (Lunar Lake AI Boost ~48 TOPS, Meteor Lake NCE, Arrow Lake, Panther Lake). NPU inference draws ~2-3 W vs ~15-25 W for the iGPU on the same model — a step-change for any battery-bound use case and the canonical setup for voice agents (Whisper on NPU + LLM on iGPU concurrently).

Distinct from `linux-x64-sycl` (#7628):
- SYCL covers Intel CPU + iGPU, but **not the NPU**.
- OpenVINO covers CPU + iGPU + NPU through one runtime.

The W4-B custom kernels (`turbo3` / `turbo4` / `turbo3_tcq` / `qjl_full` / `polarquant` / `dflash`) have no OpenVINO backend in this fork today (CUDA / Vulkan / Metal / CPU only), so this target runs plain GGML ops translated to OpenVINO compute graphs. The kernel-patches dispatch in `patchAllKernels()` correctly no-ops for `backend === "openvino"`.

## Changes (build script)

- `SUPPORTED_TARGETS` gains `"linux-x64-openvino"` with a comment block detailing target hardware, runtime device selection, and why kernel patches do not apply yet.
- `cmakeFlagsForTarget` grows a `backend === "openvino"` branch that:
  - sets `-DGGML_OPENVINO=ON`
  - forwards `OpenVINO_DIR` / `INTEL_OPENVINO_DIR` from the environment as `-DOpenVINO_DIR=${INSTALLDIR}/runtime/cmake` (CMake's default `find_package(OpenVINO)` search misses the tarball-install layout)
- `GGML_OPENVINO` joins the `offByDefault` list so non-OpenVINO targets explicitly disable it (parity with METAL / CUDA / HIP / VULKAN).
- `targetCompatibility` returns a graceful "no OpenVINO_DIR / INTEL_OPENVINO_DIR" skip when the operator forgot to source `setupvars.sh`, instead of crashing inside CMake.
- The `TODO ANCHORS` comment grows an `OPENVINO-AGENT TODO` line for future kernel work.

## Changes (submodule)

- `packages/inference/llama.cpp` bumps from `a61c93aaa5` (v1.2.0-eliza) to `bafc862bf` on `elizaOS/llama.cpp#nubs/openvino-backend-import`. Range adds three upstream commits (`53281e98d` + `1ebe824a0` + `bafc862bf`) cherry-picked cleanly. Companion PR: [elizaOS/llama.cpp#1](https://github.com/elizaOS/llama.cpp/pull/1).

## Verification

Dispatch path:

```
$ node packages/app-core/scripts/build-llama-cpp-dflash.mjs --target linux-x64-openvino --jobs 1
[dflash-build] target linux-x64-openvino is not buildable: no OpenVINO_DIR / INTEL_OPENVINO_DIR — source /opt/intel/openvino_<ver>/setupvars.sh first
```

Build (Linux x64 + Lunar Lake host, OpenVINO 2026.1.0 tarball under `~/.local/openvino_2026/`):

```bash
source ~/.local/openvino_2026/setupvars.sh
ELIZA_DFLASH_CMAKE_FLAGS="-DOpenCL_INCLUDE_DIR=$HOME/.local/include -DOpenCL_LIBRARY=$HOME/.local/lib/libOpenCL.so" \
node packages/app-core/scripts/build-llama-cpp-dflash.mjs --target linux-x64-openvino --jobs 8
```

Output: `libggml-openvino.so` (33 MB) + the standard llama-cli / llama-server / llama-speculative-simple / llama-mtmd-cli set in `~/.eliza/local-inference/bin/dflash/linux-x64-openvino/`.

End-to-end test results (Llama-3.1-8B-Instruct Q4_K_M on Intel Core Ultra 7 258V / Arc 140V / 48 TOPS NPU) being captured now; will land as a follow-up comment.

## Runtime requirements

- OpenVINO Runtime 2026.1.x — install via:
  - **Apt:** `apt install openvino-2026.x` from `https://apt.repos.intel.com/openvino`
  - **Tarball:** download `openvino_toolkit_ubuntu24_2026.x.x.x_x86_64.tgz` from `https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.1/linux/`, extract under `/opt/intel/openvino_<ver>/` or `~/.local/openvino_<ver>/`, source `setupvars.sh`.
- OpenCL ICD loader + Khronos OpenCL-Headers + OpenCL-CLHPP (OpenVINO's iGPU plugin links `OpenCL::OpenCL` even for CPU/NPU device builds; can't opt out at the cmake level today):
  - **Apt:** `apt install opencl-headers ocl-icd-opencl-dev intel-opencl-icd`
  - **Manual:** extract Khronos `OpenCL-Headers` + `OpenCL-CLHPP` releases under a prefix and pass `-DOpenCL_INCLUDE_DIR=...` / `-DOpenCL_LIBRARY=...` via `ELIZA_DFLASH_CMAKE_FLAGS`

## Related

- [elizaOS/llama.cpp#1](https://github.com/elizaOS/llama.cpp/pull/1) — submodule companion PR
- #7626 — glslc absolute-path fix
- #7628 — `linux-x64-sycl` target (parallel Intel CPU/iGPU path, no NPU)
- #7630 — submodule bump to v1.2.0-eliza (base for this branch)

## Out of scope

- Real W4-B kernel ports to OpenVINO.
- Eliza/Milady runtime wiring — `LocalRuntimeKernel` enum extension + hardware probe + env-var plumbing. Separate RFC issue to follow.
- AMD XDNA / Qualcomm Hexagon NPU paths.

## Test plan

- [x] `node --check` on the modified file
- [x] Dispatch dry-run without OpenVINO → graceful skip with the expected reason string
- [x] Full build on Lunar Lake host
- [ ] Llama-3.1-8B Q4_K_M tg numbers on `GGML_OPENVINO_DEVICE=CPU` (in progress)
- [ ] Llama-3.1-8B Q4_K_M tg numbers on `GGML_OPENVINO_DEVICE=GPU` (next)
- [ ] Llama-3.1-8B Q4_K_M tg numbers on `GGML_OPENVINO_DEVICE=NPU` (last — the headline result)
- [ ] Confirm Vulkan target (with W4-B kernels) still builds byte-identical on the bumped submodule

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `linux-x64-openvino` build target to the dflash build script, enabling `llama-server`/`llama-cli` binaries to dispatch at runtime to the Intel CPU, iGPU, or NPU via `GGML_OPENVINO_DEVICE`, and bumps the `packages/inference/llama.cpp` submodule to pick up three upstream OpenVINO backend cherry-picks.

- **New build target**: `SUPPORTED_TARGETS` gains `"linux-x64-openvino"`; `cmakeFlagsForTarget` adds a `backend === "openvino"` branch that enables `-DGGML_OPENVINO=ON` and resolves `-DOpenVINO_DIR` from `OpenVINO_DIR` / `INTEL_OPENVINO_DIR` env vars; `GGML_OPENVINO` is added to `offByDefault` so all other targets explicitly disable it.
- **Pre-flight guard**: `targetCompatibility` returns a human-readable skip message when neither OpenVINO env var is set, preventing a cryptic CMake failure.
- **Submodule bump**: `packages/inference/llama.cpp` advances from `9bb08843` to `bafc862b`, adding the `ggml-openvino/` directory from upstream.

<h3>Confidence Score: 4/5</h3>

The build script change is well-structured and follows existing backend patterns; the one path-normalisation issue in the OpenVINO_DIR resolution can produce a silently wrong cmake dir on environments where the env var carries a trailing slash.

The `endsWith("/cmake")` guard in `cmakeFlagsForTarget` does not strip a possible trailing slash before comparing, so an `OpenVINO_DIR` value like `/opt/intel/openvino_2026/runtime/cmake/` would bypass the guard and have `runtime/cmake` appended again, giving CMake a non-existent path. Everything else — the `offByDefault` entry, the `targetCompatibility` guard, the general platform check at line 1195, and the submodule pointer — looks correct.

packages/app-core/scripts/build-llama-cpp-dflash.mjs — specifically the `openvinoDir` normalisation block around line 993

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/build-llama-cpp-dflash.mjs | Adds linux-x64-openvino target with cmake flag generation, targetCompatibility guard, and offByDefault entry — one path-normalization edge case in the OpenVINO_DIR heuristic |
| packages/inference/llama.cpp | Submodule bumped from 9bb08843 to bafc862b to include three upstream OpenVINO backend cherry-picks; straightforward pointer update |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[build-llama-cpp-dflash.mjs\n--target linux-x64-openvino] --> B{targetCompatibility}
    B -->|OpenVINO_DIR or\nINTEL_OPENVINO_DIR set?| C[ok: true]
    B -->|neither set| D[skip: no OpenVINO_DIR /\nINTEL_OPENVINO_DIR]
    C --> E[cmakeFlagsForTarget]
    E --> F[GGML_OPENVINO=OFF → ON]
    E --> G{openvinoDir\nresolution}
    G -->|OpenVINO_DIR set| H[use OpenVINO_DIR\nif ends with /cmake]
    G -->|INTEL_OPENVINO_DIR set| I[append runtime/cmake]
    H --> J[-DOpenVINO_DIR=…/runtime/cmake]
    I --> J
    J --> K[cmake configure\nGGML_OPENVINO=ON]
    K --> L[libggml-openvino.so\nllama-server / llama-cli]
    L --> M{GGML_OPENVINO_DEVICE}
    M --> N[CPU]
    M --> O[GPU / iGPU / Arc]
    M --> P[NPU — Lunar Lake AI Boost\nMeteor Lake NCE]
```

<sub>Reviews (1): Last reviewed commit: ["build(dflash): add linux-x64-openvino ta..."](https://github.com/elizaos/eliza/commit/58af42f562c3db99298094865774dc252a51ab29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31875484)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->