### PR TITLE
Ci/green and hetzner e2e

### DIFF
--- a/packages/app-core/packaging/snap/snapcraft.yaml
+++ b/packages/app-core/packaging/snap/snapcraft.yaml
@@ -511,12 +511,6 @@ parts:
         --filter=@elizaos/plugin-wallet-ui \
         --filter=@elizaos/plugin-wechat \
         --filter=@elizaos/plugin-whatsapp \
-        --filter=@elizaos/capacitor-contacts \
-        --filter=@elizaos/capacitor-phone \
-        --filter=@elizaos/capacitor-wifi \
-        --filter=@elizaos/capacitor-appblocker \
-        --filter=@elizaos/capacitor-mobile-signals \
-        --filter=@elizaos/native-activity-tracker \
         --filter=@elizaos/scenario-schema
       rm -rf node_modules/@types
       rm -rf "$SNAP_BUILD_TYPES_DIR"

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -4698,22 +4698,31 @@ export class AgentRuntime implements IAgentRuntime {
 				usage?: unknown;
 				providerMetadata?: unknown;
 			};
+			// Only wrap into a GenerateText-shape result when the provider
+			// actually surfaced native tool calls; otherwise preserve the
+			// historical bare-string return so plain text streams keep matching
+			// the documented `result === text` contract.
 			const hasToolCallsField = "toolCalls" in streamRaw;
-			const hasFinishReasonField = "finishReason" in streamRaw;
-			if (hasToolCallsField || hasFinishReasonField) {
-				const resolvedToolCalls = hasToolCallsField
-					? await Promise.resolve(streamRaw.toolCalls).catch(() => [])
-					: [];
-				const resolvedFinishReason = hasFinishReasonField
-					? await Promise.resolve(streamRaw.finishReason).catch(() => undefined)
-					: undefined;
+			const resolvedToolCalls = hasToolCallsField
+				? await Promise.resolve(streamRaw.toolCalls).catch(() => [])
+				: [];
+			const toolCallsArr = Array.isArray(resolvedToolCalls)
+				? resolvedToolCalls
+				: [];
+			if (toolCallsArr.length > 0) {
+				const resolvedFinishReason =
+					"finishReason" in streamRaw
+						? await Promise.resolve(streamRaw.finishReason).catch(
+								() => undefined,
+							)
+						: undefined;
 				const resolvedUsage =
 					"usage" in streamRaw
 						? await Promise.resolve(streamRaw.usage).catch(() => undefined)
 						: undefined;
 				resultRef.current = {
 					text: streamedText,
-					toolCalls: Array.isArray(resolvedToolCalls) ? resolvedToolCalls : [],
+					toolCalls: toolCallsArr,
 					finishReason: resolvedFinishReason,
 					usage: resolvedUsage,
 					providerMetadata: streamRaw.providerMetadata,

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -109,11 +109,6 @@ interface RawPlannerOutput {
 	toolCalls?: unknown;
 	messageToUser?: unknown;
 	text?: unknown;
-	// Optional explicit completion signal. When emitted as a boolean,
-	// `tryGateEvaluator` honors `completed=false` to fall through to the
-	// full evaluator instead of synthesizing a FINISH. See gate
-	// preconditions in `tryGateEvaluator`.
-	completed?: unknown;
 }
 
 export async function runPlannerLoop(
@@ -131,6 +126,8 @@ export async function runPlannerLoop(
 	const failures: FailureLike[] = [];
 	let terminalOnlyContinuations = 0;
 	let requiredToolMisses = 0;
+	let unavailableToolCallRetries = 0;
+	let silentFailedFinishRecoveries = 0;
 	const requireNonTerminalToolCall =
 		params.requireNonTerminalToolCall === true &&
 		hasExposedNonTerminalTool(params.tools);
@@ -166,13 +163,6 @@ export async function runPlannerLoop(
 	// rather than a final answer). The gate refuses ambiguous signals to avoid
 	// surfacing a thought as the user-facing reply.
 	let lastPlannerExplicitMessageToUser: string | undefined;
-	// Tracks the most recent planner output's explicit `completed` flag, when
-	// emitted as a boolean. The gate (`tryGateEvaluator`) treats
-	// `completed === false` as a hard veto on synthesizing a FINISH — the
-	// planner is explicitly signaling that this turn's tool calls do not yet
-	// achieve the goal (e.g. read-then-act, multi-step deploy). When the
-	// field is absent the gate's other preconditions are honored as before.
-	let lastPlannerExplicitCompleted: boolean | undefined;
 
 	for (let iteration = 1; ; iteration++) {
 		if (trajectory.plannedQueue.length === 0) {
@@ -203,14 +193,6 @@ export async function runPlannerLoop(
 				typeof explicit === "string" && explicit.trim().length > 0
 					? explicit
 					: undefined;
-			// Capture the planner's explicit `completed` boolean when present.
-			// Any non-boolean (string "false", number, null, missing) is treated
-			// as "unspecified" and does not influence the gate — only an actual
-			// `false` boolean blocks. This keeps backward compat with planner
-			// outputs that don't carry the field.
-			const completedRaw = plannerOutput.raw.completed;
-			lastPlannerExplicitCompleted =
-				typeof completedRaw === "boolean" ? completedRaw : undefined;
 
 			if (plannerOutput.toolCalls.length === 0) {
 				if (
@@ -218,27 +200,19 @@ export async function runPlannerLoop(
 					!hasExecutedNonTerminalTool(trajectory)
 				) {
 					requiredToolMisses++;
-					if (requiredToolMisses > config.maxRequiredToolMisses) {
-						params.runtime.logger?.warn?.(
-							{
-								src: "planner-loop",
-								iteration,
-								misses: requiredToolMisses,
-								max: config.maxRequiredToolMisses,
-								messageToUser: plannerOutput.messageToUser,
-							},
-							"required_tool_misses budget exhausted; honoring planner's terminal reply instead of throwing",
-						);
-					} else {
-						handleRequiredToolPlannerMiss({
-							trajectory,
-							iteration,
-							plannerOutput,
-							reason: "no_tool_calls",
-							logger: params.runtime.logger,
-						});
-						continue;
-					}
+					assertTrajectoryLimit({
+						kind: "required_tool_misses",
+						max: config.maxRequiredToolMisses,
+						observed: requiredToolMisses,
+					});
+					handleRequiredToolPlannerMiss({
+						trajectory,
+						iteration,
+						plannerOutput,
+						reason: "no_tool_calls",
+						logger: params.runtime.logger,
+					});
+					continue;
 				}
 				trajectory.steps.push({
 					iteration,
@@ -326,27 +300,19 @@ export async function runPlannerLoop(
 					!hasExecutedNonTerminalTool(trajectory)
 				) {
 					requiredToolMisses++;
-					if (requiredToolMisses > config.maxRequiredToolMisses) {
-						params.runtime.logger?.warn?.(
-							{
-								src: "planner-loop",
-								iteration,
-								misses: requiredToolMisses,
-								max: config.maxRequiredToolMisses,
-								messageToUser: plannerOutput.messageToUser,
-							},
-							"required_tool_misses budget exhausted; honoring planner's terminal tool-call reply instead of throwing",
-						);
-					} else {
-						handleRequiredToolPlannerMiss({
-							trajectory,
-							iteration,
-							plannerOutput,
-							reason: "terminal_only_tool_calls",
-							logger: params.runtime.logger,
-						});
-						continue;
-					}
+					assertTrajectoryLimit({
+						kind: "required_tool_misses",
+						max: config.maxRequiredToolMisses,
+						observed: requiredToolMisses,
+					});
+					handleRequiredToolPlannerMiss({
+						trajectory,
+						iteration,
+						plannerOutput,
+						reason: "terminal_only_tool_calls",
+						logger: params.runtime.logger,
+					});
+					continue;
 				}
 				const finalMessage = terminalMessageFromToolCalls(
 					plannerOutput.toolCalls,
@@ -359,24 +325,28 @@ export async function runPlannerLoop(
 					terminalOnly: true,
 				});
 				const terminalEvaluator = terminalToolCallFinish(finalMessage);
+				const shouldRecordTerminalEvaluation =
+					trajectory.evaluatorOutputs.length > 0;
 				trajectory.evaluatorOutputs.push(terminalEvaluator);
 				trajectory.context = appendEvaluationEvent({
 					context: trajectory.context,
 					iteration,
 					evaluator: terminalEvaluator,
 				});
-				const terminalEvalStartedAt = Date.now();
-				await recordGatedEvaluationStage({
-					recorder: params.recorder,
-					trajectoryId: params.trajectoryId,
-					parentStageId: params.parentStageId,
-					iteration,
-					startedAt: terminalEvalStartedAt,
-					endedAt: Date.now(),
-					output: terminalEvaluator,
-					reason: "terminal_tool_call",
-					logger: params.runtime.logger,
-				});
+				if (shouldRecordTerminalEvaluation) {
+					const terminalEvalStartedAt = Date.now();
+					await recordGatedEvaluationStage({
+						recorder: params.recorder,
+						trajectoryId: params.trajectoryId,
+						parentStageId: params.parentStageId,
+						iteration,
+						startedAt: terminalEvalStartedAt,
+						endedAt: Date.now(),
+						output: terminalEvaluator,
+						reason: "terminal_tool_call",
+						logger: params.runtime.logger,
+					});
+				}
 				return {
 					status: "finished",
 					trajectory,
@@ -388,12 +358,43 @@ export async function runPlannerLoop(
 			const nonTerminalCalls = plannerOutput.toolCalls
 				.filter((toolCall) => !isTerminalToolCall(toolCall))
 				.map((toolCall, index) => ensureToolCallId(toolCall, iteration, index));
-			trajectory.plannedQueue.push(...nonTerminalCalls);
+			const unavailable = splitUnavailableToolCalls(
+				nonTerminalCalls,
+				params.tools,
+			);
+			if (unavailable.invalid.length > 0) {
+				params.runtime.logger?.warn?.(
+					{
+						iteration,
+						invalidToolCalls: unavailable.invalid.map(
+							(toolCall) => toolCall.name,
+						),
+					},
+					"Planner called unavailable tools; retrying without executing them",
+				);
+				trajectory.context = appendUnavailableToolCallEvent({
+					context: trajectory.context,
+					iteration,
+					invalidToolCalls: unavailable.invalid,
+					tools: params.tools,
+				});
+				if (unavailable.valid.length === 0) {
+					unavailableToolCallRetries++;
+					assertTrajectoryLimit({
+						kind: "unavailable_tool_calls",
+						max: config.maxUnavailableToolCallRetries,
+						observed: unavailableToolCallRetries,
+					});
+					continue;
+				}
+			}
+			const validNonTerminalCalls = unavailable.valid;
+			trajectory.plannedQueue.push(...validNonTerminalCalls);
 			trajectory.context = {
 				...trajectory.context,
 				plannedQueue: [
 					...(trajectory.context.plannedQueue ?? []),
-					...nonTerminalCalls.map((toolCall) => ({
+					...validNonTerminalCalls.map((toolCall) => ({
 						id: toolCall.id,
 						name: toolCall.name,
 						args: stringifyForModel(toolCall.params ?? {}),
@@ -402,7 +403,7 @@ export async function runPlannerLoop(
 					})),
 				],
 			};
-			for (const toolCall of nonTerminalCalls) {
+			for (const toolCall of validNonTerminalCalls) {
 				trajectory.context = appendContextEvent(trajectory.context, {
 					id: `queue:${toolCall.id ?? toolCall.name}:${iteration}`,
 					type: "planned_tool_call",
@@ -468,7 +469,6 @@ export async function runPlannerLoop(
 			trajectory,
 			failures,
 			lastPlannerExplicitMessageToUser,
-			lastPlannerExplicitCompleted,
 		});
 		if (gated) {
 			trajectory.evaluatorOutputs.push(gated);
@@ -503,12 +503,32 @@ export async function runPlannerLoop(
 		appendEvaluatorContextEvent(trajectory, evaluator, iteration);
 
 		if (evaluator.decision === "FINISH") {
+			if (
+				shouldRecoverSilentFailedFinish({
+					evaluator,
+					trajectory,
+					recoveryCount: silentFailedFinishRecoveries,
+				})
+			) {
+				silentFailedFinishRecoveries++;
+				trajectory.context = appendSilentFailedFinishRecoveryEvent({
+					context: trajectory.context,
+					iteration,
+					evaluator,
+					trajectory,
+				});
+				continue;
+			}
 			return {
 				status: "finished",
 				trajectory,
 				evaluator,
 				finalMessage: userSafeFinalMessage(
-					evaluator.messageToUser ?? latestToolResultText(trajectory),
+					evaluator.messageToUser ??
+						latestToolResultText(trajectory) ??
+						(evaluator.success === false
+							? failedToolFallbackMessage(trajectory)
+							: undefined),
 					trajectory,
 				),
 			};
@@ -725,6 +745,9 @@ export function parsePlannerOutput(raw: string | GenerateTextResult): {
 
 	const nativeToolCalls = normalizeToolCalls(raw.toolCalls);
 	const text = getNonEmptyString(raw.text);
+	const explicitMessageToUser = getNonEmptyString(
+		(raw as unknown as Record<string, unknown>).messageToUser,
+	);
 
 	// gpt-oss-class models narrate planner calls in the text channel. There
 	// are two observed shapes:
@@ -768,10 +791,13 @@ export function parsePlannerOutput(raw: string | GenerateTextResult): {
 		messageToUser:
 			textRecoveredCalls.length > 0
 				? terminalMessageFromToolCalls(toolCalls)
-				: text,
+				: (explicitMessageToUser ?? text),
 		raw: {
 			text: raw.text,
 			toolCalls: raw.toolCalls,
+			...(explicitMessageToUser
+				? { messageToUser: explicitMessageToUser }
+				: {}),
 			...(recoverySource ? { textRecoverySource: recoverySource } : {}),
 		} as Record<string, unknown>,
 	};
@@ -1586,6 +1612,67 @@ function appendTerminalContinuationEvent(args: {
 	});
 }
 
+function appendUnavailableToolCallEvent(args: {
+	context: ContextObject;
+	iteration: number;
+	invalidToolCalls: readonly PlannerToolCall[];
+	tools?: ToolDefinition[];
+}): ContextObject {
+	const createdAt = Date.now();
+	const exposed = Array.from(exposedToolNameSet(args.tools) ?? []).sort();
+	const invalid = args.invalidToolCalls.map((toolCall) => toolCall.name);
+	const content = [
+		"planner_retry_instruction:",
+		`unavailable_tool_calls: ${JSON.stringify(invalid)}`,
+		`available_tools: ${JSON.stringify(exposed)}`,
+		"The previous planner output called tools that were not exposed for this turn. Retry using only available_tools, or return a terminal REPLY if no exposed tool fits.",
+	].join("\n");
+	return appendContextEvent(args.context, {
+		id: `unavailable-tool-call-retry:${args.iteration}:${createdAt}`,
+		type: "instruction",
+		source: "planner-loop",
+		createdAt,
+		content,
+		metadata: {
+			iteration: args.iteration,
+			invalidToolCalls: invalid,
+			availableTools: exposed,
+		},
+	});
+}
+
+function appendSilentFailedFinishRecoveryEvent(args: {
+	context: ContextObject;
+	iteration: number;
+	evaluator: EvaluatorOutput;
+	trajectory: PlannerTrajectory;
+}): ContextObject {
+	const createdAt = Date.now();
+	const failedStep = latestFailedToolStep(args.trajectory);
+	const failedToolName = failedStep?.toolCall?.name;
+	const content = [
+		"planner_retry_instruction:",
+		"silent_failed_finish: true",
+		failedToolName ? `failed_tool: ${failedToolName}` : null,
+		"The latest tool step failed, and the evaluator finished without a user-visible message. Retry once with a different available approach if possible; otherwise return a concise user-visible blocker instead of ending silently.",
+	]
+		.filter((line): line is string => line !== null)
+		.join("\n");
+	return appendContextEvent(args.context, {
+		id: `silent-failed-finish-retry:${args.iteration}:${createdAt}`,
+		type: "instruction",
+		source: "planner-loop",
+		createdAt,
+		content,
+		metadata: {
+			iteration: args.iteration,
+			evaluatorDecision: args.evaluator.decision,
+			evaluatorSuccess: args.evaluator.success,
+			failedToolName,
+		},
+	});
+}
+
 async function executeQueuedToolCall(params: {
 	params: PlannerLoopParams;
 	trajectory: PlannerTrajectory;
@@ -1636,6 +1723,7 @@ async function executeQueuedToolCall(params: {
 		toolName: params.toolCall.name,
 		success: result.success,
 		error: result.error,
+		repeatKey: toolFailureRepeatKey(params.toolCall),
 	};
 	if (!result.success || result.error != null) {
 		params.failures.push(failure);
@@ -1688,6 +1776,10 @@ async function executeQueuedToolCall(params: {
 		endedAt,
 		logger: params.params.runtime.logger,
 	});
+}
+
+function toolFailureRepeatKey(toolCall: PlannerToolCall): string {
+	return `${toolCall.name}:${stringifyForModel(toolCall.params ?? {})}`;
 }
 
 async function recordToolStage(args: {
@@ -1978,6 +2070,35 @@ function hasExposedNonTerminalTool(
 	);
 }
 
+function exposedToolNameSet(
+	tools: ToolDefinition[] | undefined,
+): Set<string> | null {
+	if (!Array.isArray(tools) || tools.length === 0) return null;
+	const names = tools
+		.map(getToolDefinitionName)
+		.filter((name): name is string => Boolean(name))
+		.map((name) => name.toUpperCase());
+	return names.length > 0 ? new Set(names) : null;
+}
+
+function splitUnavailableToolCalls(
+	toolCalls: PlannerToolCall[],
+	tools: ToolDefinition[] | undefined,
+): { valid: PlannerToolCall[]; invalid: PlannerToolCall[] } {
+	const exposed = exposedToolNameSet(tools);
+	if (!exposed) return { valid: toolCalls, invalid: [] };
+	const valid: PlannerToolCall[] = [];
+	const invalid: PlannerToolCall[] = [];
+	for (const toolCall of toolCalls) {
+		if (exposed.has(toolCall.name.toUpperCase())) {
+			valid.push(toolCall);
+		} else {
+			invalid.push(toolCall);
+		}
+	}
+	return { valid, invalid };
+}
+
 function hasExecutedNonTerminalTool(trajectory: PlannerTrajectory): boolean {
 	return trajectory.steps.some(
 		(step) => step.toolCall && !isTerminalToolCall(step.toolCall),
@@ -2067,6 +2188,32 @@ function latestToolResultText(
 	return undefined;
 }
 
+function latestFailedToolStep(
+	trajectory: PlannerTrajectory,
+): PlannerStep | undefined {
+	return [...trajectory.steps]
+		.reverse()
+		.find((step) => step.result && step.result.success === false);
+}
+
+function shouldRecoverSilentFailedFinish(args: {
+	evaluator: EvaluatorOutput;
+	trajectory: PlannerTrajectory;
+	recoveryCount: number;
+}): boolean {
+	if (args.recoveryCount >= 1) return false;
+	if (args.evaluator.success !== false) return false;
+	if (getNonEmptyString(args.evaluator.messageToUser)) return false;
+	return latestFailedToolStep(args.trajectory) !== undefined;
+}
+
+function failedToolFallbackMessage(
+	trajectory: PlannerTrajectory,
+): string | undefined {
+	if (!latestFailedToolStep(trajectory)) return undefined;
+	return "I tried to complete that, but the available runtime step failed before it produced a usable result.";
+}
+
 /**
  * Decide whether the planner-loop can synthesize a FINISH evaluator output and
  * skip ONLY the in-loop LLM trajectory-decision call (`runEvaluator`) for the
@@ -2100,15 +2247,6 @@ function latestToolResultText(
  *   5. That `messageToUser` is not a tool/function-syntax leak (the evaluator's
  *      own prompt rules say leaked syntax should force CONTINUE; we honor the
  *      same constraint by reusing `isUnsafeUserVisibleText`).
- *   6. The planner did NOT explicitly set `completed: false` on this output.
- *      When that flag is present and false, the planner is signaling that
- *      this turn's tool calls do not yet achieve the goal (read-then-act,
- *      multi-step deploy, verification pending) — and `messageToUser` is
- *      a pre-tool intent rather than a final answer. We fall through to
- *      the full evaluator so it can decide CONTINUE vs FINISH from the
- *      actual tool result rather than synthesizing a FINISH the planner
- *      explicitly disclaimed. Absent or `true` preserves the gate's
- *      original behavior (backward compat).
  *
  * On any single ambiguity the function returns `null` and the caller falls
  * through to the full evaluator path. Returning a synthesized `EvaluatorOutput`
@@ -2129,7 +2267,6 @@ function tryGateEvaluator(args: {
 	trajectory: PlannerTrajectory;
 	failures: readonly FailureLike[];
 	lastPlannerExplicitMessageToUser: string | undefined;
-	lastPlannerExplicitCompleted: boolean | undefined;
 }): EvaluatorOutput | null {
 	const latestStep = args.trajectory.steps[args.trajectory.steps.length - 1];
 	const latestResult = latestStep?.result;
@@ -2139,8 +2276,6 @@ function tryGateEvaluator(args: {
 	const message = args.lastPlannerExplicitMessageToUser?.trim();
 	if (!message) return null;
 	if (isUnsafeUserVisibleText(message)) return null;
-	// Precondition 6: respect the planner's own completion disclaimer.
-	if (args.lastPlannerExplicitCompleted === false) return null;
 
 	return {
 		success: true,

--- a/packages/scripts/run-live-scenarios.mjs
+++ b/packages/scripts/run-live-scenarios.mjs
@@ -38,6 +38,7 @@ import { fileURLToPath } from "node:url";
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   "..",
+  "..",
 );
 const SCENARIO_CLI = path.join(
   REPO_ROOT,


### PR DESCRIPTION
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

<!-- LINK TO ISSUE OR TICKET -->

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `REPO_ROOT` path bug in the live-scenario runner, removes Capacitor package filters from the snap build, and makes several planner-loop behavioural changes: adding unavailable-tool-call retry logic, a silent-failed-finish recovery, and aligning stream-result wrapping to emit the `GenerateTextResult` shape only when native tool calls are present.

- **`run-live-scenarios.mjs`**: One missing `\"..\"` caused `REPO_ROOT` to resolve to `packages/` instead of the repo root, making all downstream paths wrong; the fix adds the correct second level.
- **`planner-loop.ts`**: Removes the `completed` flag, introduces `splitUnavailableToolCalls` to silently drop hallucinated tool names and retry the planner, and adds a one-shot `shouldRecoverSilentFailedFinish` path; `required_tool_misses` is promoted from a soft warn-and-continue to a hard `TrajectoryLimitExceeded` throw, removing the previous intentional fallback of honoring the planner's last message.
- **`runtime.ts`**: Stream results are now wrapped into a `GenerateTextResult` object only when non-empty tool calls are present, preserving the bare-string contract for plain-text responses.

<h3>Confidence Score: 3/5</h3>

The planner-loop changes introduce useful new recovery paths but also convert an intentional graceful-degradation branch into a hard throw, which could produce user-visible failures in cases that previously resolved cleanly.

The `required_tool_misses` path was deliberately designed to honor the planner's last message after the budget was exhausted rather than throw. Replacing that soft path with `assertTrajectoryLimit` changes the contract for every caller on that branch — if the exception bubbles up without a clean user-facing handler, turns that would have produced a valid answer will instead surface an error.

packages/core/src/runtime/planner-loop.ts deserves the most scrutiny, specifically the `required_tool_misses` branches and the `shouldRecordTerminalEvaluation` gate; packages/core/src/runtime/runtime.ts warrants a quick check of downstream callers that read `finishReason`/`usage` on text-only streaming responses.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/planner-loop.ts | Major refactor: removes `completed` flag support, adds unavailable-tool-call retry handling, adds silent-failed-finish recovery, and changes `required_tool_misses` from a soft fallback to a hard-throwing limit — the last change removes an intentional degradation path and could cause hard failures where the old code honored the planner's terminal reply. |
| packages/core/src/runtime/runtime.ts | Changes the stream-result wrapping condition from `hasToolCallsField || hasFinishReasonField` to `toolCallsArr.length > 0`, so plain-text responses with a `finishReason` are no longer wrapped into a `GenerateTextResult` shape; intentional per the added comment but silently affects any caller that inspects those fields on text-only responses. |
| packages/scripts/run-live-scenarios.mjs | Bug fix: adds a second `".."` to `REPO_ROOT` resolution so the path correctly resolves to the repository root instead of `packages/`. |
| packages/app-core/packaging/snap/snapcraft.yaml | Removes six `--filter` entries for Capacitor/native packages from the snap build script; straightforward cleanup. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Planner produces output] --> B{Tool calls?}
    B -- none --> C{requireNonTerminalToolCall?}
    C -- yes --> D[requiredToolMisses++]
    D --> E{observed > max?}
    E -- yes --> F[throw TrajectoryLimitExceeded]
    E -- no --> G[handleRequiredToolPlannerMiss + continue]
    C -- no --> H[Push terminal step]
    B -- all terminal --> C
    B -- has non-terminal --> J[splitUnavailableToolCalls]
    J --> K{Any invalid?}
    K -- all invalid --> L[unavailableToolCallRetries++ assertLimit continue]
    K -- some valid --> M[queue valid calls execute]
    M --> N[tryGateEvaluator]
    N -- gated --> O[FINISH]
    N -- pass-through --> P[runEvaluator]
    P --> Q{decision}
    Q -- FINISH --> R{shouldRecoverSilentFailedFinish?}
    R -- yes once --> S[appendRecoveryEvent continue]
    R -- no --> T[FINISH with fallback message]
    Q -- CONTINUE --> A
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): live-scenarios path + drop snap..."](https://github.com/elizaos/eliza/commit/01ced73fdbb3a9815cab225cd643300b25fa428d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32726343)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->