### PR TITLE
feat(training): low-VRAM smoke config for 2b SFT on 12GB consumer GPUs

### DIFF
--- a/packages/training/README.md
+++ b/packages/training/README.md
@@ -303,6 +303,62 @@ For cloud-tier runs see `scripts/train_vast.sh` and `scripts/CLOUD_VAST.md`.
 For inference see `scripts/inference/serve_vllm.py` (vLLM serve launcher) and
 `scripts/inference/serve_local.py`.
 
+## Running on a 12 GB consumer GPU (RTX 3060 / 4070 class)
+
+The registry's `qwen3.5-2b` default targets a 16 GB local GPU (seq_len=8192,
+budget=15.5 GB). On a 12 GB card that OOMs at the fp32 logits transient
+(B·S·V·4 bytes; Qwen vocab=248k makes this dominant). The `--low-vram-smoke`
+flag is a preset bundle that brings the 2B SFT path inside a 12 GB envelope
+so the train→quant→bench plumbing can be validated end-to-end on commodity
+hardware before reaching for a rented H100/H200.
+
+```bash
+uv run --extra train python scripts/train_local.py \
+    --registry-key qwen3.5-2b --low-vram-smoke
+```
+
+What the preset overrides (CLI flags the caller passes still win):
+
+- `seq_len = 2048`        (registry default 8192)
+- `per_device_batch_size = 1`
+- `gradient_accumulation_steps = 16`  (effective batch stays at 16)
+- `max_samples = 1000`
+- `epochs = 1`
+- `memory_budget_gb = 11.5`           (1.5 GB headroom under 12 GB)
+- Liger fused chunked-CE stays on (registry default; required for budget)
+- Activation checkpointing stays on (default in `train_local.py`)
+- APOLLO-Mini (registry default for 2B) remains the optimizer; rank=1
+  keeps optimizer state effectively free.
+
+**Measured on RTX 3060 (12 GB, WSL2 Ubuntu, torch 2.12.0+cu130, 314 smoke
+records in `data/final-eliza1-smoke/`):**
+
+| metric        | value           |
+|---------------|-----------------|
+| peak VRAM     | see PR body     |
+| wall-time     | see PR body     |
+| final loss    | see PR body     |
+
+**Trade-offs:**
+
+- Training context window drops from 8k to 2k. Records longer than ~2k
+  rendered chars are right-truncated by the tokenizer. The smoke
+  trajectory dataset already fits inside 2k; for the real native
+  trajectory corpus pass `--max-chars 6000` (≈3× seq_len) so the
+  char-filter rejects oversized rows up front rather than wasting them.
+- Long-context behaviors (multi-turn agent traces, long tool outputs)
+  are NOT exercised at seq_len=2048. The resulting checkpoint is for
+  smoke / path-validation only, NOT for publishing.
+- Loss numbers from the smoke are not comparable to the registry-default
+  run — the effective sequence diet is different.
+
+**If it still OOMs**: the preset's headroom is conservative but real-world
+allocator fragmentation can still tip a 12 GB card over. Drop seq_len with
+`--low-vram-smoke --max-seq-len 1536` (or 1024) and retry. The instrumentation
+callback (enabled because `--memory-budget-gb` is set) fails the run loud the
+moment `torch.cuda.max_memory_reserved()` exceeds the budget by more than
+10 %.
+
 ## Memory budgets
 
 The full quantization stack at inference is:

--- a/packages/training/README.md
+++ b/packages/training/README.md
@@ -308,40 +308,84 @@ For inference see `scripts/inference/serve_vllm.py` (vLLM serve launcher) and
 The registry's `qwen3.5-2b` default targets a 16 GB local GPU (seq_len=8192,
 budget=15.5 GB). On a 12 GB card that OOMs at the fp32 logits transient
 (B·S·V·4 bytes; Qwen vocab=248k makes this dominant). The `--low-vram-smoke`
-flag is a preset bundle that brings the 2B SFT path inside a 12 GB envelope
+flag is a preset bundle that brings the SFT path inside a 12 GB envelope
 so the train→quant→bench plumbing can be validated end-to-end on commodity
 hardware before reaching for a rented H100/H200.
 
 ```bash
+# 0.8B — the realistic tier for a 12 GB card. Smallest published eliza-1 base.
+uv run --extra train python scripts/train_local.py \
+    --registry-key qwen3.5-0.8b --low-vram-smoke
+
+# 2B — feasible inside 12 GB only with Liger + flash-linear-attention
+# kernels installed (see prerequisites below). Without those kernels the
+# 248k-vocab fp32 logits transient saturates the card and the run will
+# either OOM at the first backward pass or run unusably slowly.
 uv run --extra train python scripts/train_local.py \
     --registry-key qwen3.5-2b --low-vram-smoke
 ```
 
 What the preset overrides (CLI flags the caller passes still win):
 
-- `seq_len = 2048`        (registry default 8192)
+- `seq_len = 2048`                    (registry default 4096 for 0.8B, 8192 for 2B)
 - `per_device_batch_size = 1`
 - `gradient_accumulation_steps = 16`  (effective batch stays at 16)
 - `max_samples = 1000`
 - `epochs = 1`
 - `memory_budget_gb = 11.5`           (1.5 GB headroom under 12 GB)
-- Liger fused chunked-CE stays on (registry default; required for budget)
+- Liger fused chunked-CE stays on (registry default, when installed and
+  Triton can JIT-compile — see the System Prerequisites section)
 - Activation checkpointing stays on (default in `train_local.py`)
-- APOLLO-Mini (registry default for 2B) remains the optimizer; rank=1
-  keeps optimizer state effectively free.
+- APOLLO-Mini (registry default for 0.8B/2B/4B) remains the optimizer;
+  rank=1 keeps optimizer state effectively free.
 
-**Measured on RTX 3060 (12 GB, WSL2 Ubuntu, torch 2.12.0+cu130, 314 smoke
-records in `data/final-eliza1-smoke/`):**
+**Kernel prerequisites for the 2B path**. The preset's budget at 2B depends
+on two things being live:
+- Liger fused chunked-CE — cuts the fp32 logits transient ~4–8× on Qwen's
+  248k vocab. Requires Triton, which JIT-compiles a small CUDA helper at the
+  first kernel launch — `gcc`, `python3.x-dev`, and a CUDA toolkit Triton
+  can use must all be installed. Without them, `train_local.py` logs a
+  warning at startup and falls back to HF defaults.
+- Flash-linear-attention — the Qwen3.5 hybrid linear-attn layers (6 of 24
+  in the 0.8B/2B configs) have a fast Triton path through
+  https://github.com/fla-org/flash-linear-attention. Without it, transformers
+  falls back to a pure-PyTorch linear-attn implementation that is roughly
+  10× slower per step.
 
-| metric        | value           |
-|---------------|-----------------|
-| peak VRAM     | see PR body     |
-| wall-time     | see PR body     |
-| final loss    | see PR body     |
+When either kernel is missing, the 2B-on-12 GB path is effectively gated to
+preflight + small-step verification — full SFT will run but extremely slowly.
+The 0.8B preset is the realistic full-run option on stock WSL2 / no-toolchain
+hosts.
+
+**Verify the wiring without running SFT.** `--preflight-only` validates the
+preset's flag bundle, the dataset format, and the APOLLO classification
+without loading model weights or touching CUDA:
+
+```bash
+uv run --extra train python scripts/train_local.py \
+    --registry-key qwen3.5-2b --low-vram-smoke \
+    --train-file data/final-eliza1-smoke/train.jsonl \
+    --val-file data/final-eliza1-smoke/val.jsonl \
+    --preflight-only
+# → "low-vram-smoke preset → seq=2048 batch=1 accum=16 ... budget=11.5GB"
+# → "preflight ok: train=314/314 validation=39/39 optimizer=apollo_mini rank=1"
+```
+
+**Measured on RTX 3060 (12 GB, WSL2 Ubuntu, torch 2.12.0+cu130, no Liger
+JIT toolchain available, 314 smoke records in `data/final-eliza1-smoke/`):**
+
+| tier | preflight | peak VRAM (load + step 0) | notes                                               |
+|------|-----------|---------------------------|-----------------------------------------------------|
+| 0.8B | ok        | ~12.0 GB                  | runs to completion, but each step is slow without Liger + flash-linear-attn |
+| 2B   | ok        | ~12.0 GB                  | hits the 12 GB ceiling at the first backward without Liger; first step does not complete in a useful time window |
+
+The instrumentation callback (enabled because `--memory-budget-gb` is set)
+fails the run loud the moment `torch.cuda.max_memory_reserved()` exceeds
+the budget by more than 10 %.
 
 **Trade-offs:**
 
-- Training context window drops from 8k to 2k. Records longer than ~2k
+- Training context window drops from 4–8k to 2k. Records longer than ~2k
   rendered chars are right-truncated by the tokenizer. The smoke
   trajectory dataset already fits inside 2k; for the real native
   trajectory corpus pass `--max-chars 6000` (≈3× seq_len) so the
@@ -354,10 +398,10 @@ records in `data/final-eliza1-smoke/`):**
 
 **If it still OOMs**: the preset's headroom is conservative but real-world
 allocator fragmentation can still tip a 12 GB card over. Drop seq_len with
-`--low-vram-smoke --max-seq-len 1536` (or 1024) and retry. The instrumentation
-callback (enabled because `--memory-budget-gb` is set) fails the run loud the
-moment `torch.cuda.max_memory_reserved()` exceeds the budget by more than
-10 %.
+`--low-vram-smoke --max-seq-len 1024` (or 768) and retry. If you cannot
+install the Liger / flash-linear-attention kernels (Windows / WSL2 without
+a CUDA toolkit and Python dev headers), prefer the 0.8B tier — it is the
+smallest published eliza-1 base and validates the same end-to-end pipeline.
 
 ## Memory budgets
 

--- a/packages/training/scripts/test_train_local_low_vram_smoke.py
+++ b/packages/training/scripts/test_train_local_low_vram_smoke.py
@@ -1,0 +1,187 @@
+"""CPU-only smoke tests for the `--low-vram-smoke` preset in train_local.py.
+
+The preset is a flag bundle. It must override the registry defaults to
+fit a 12 GB consumer GPU (seq_len 2048, batch 1, grad_accum 16, memory
+budget 11.5 GB, max_samples 1000, epochs 1) while still letting any
+explicit CLI flag the caller passed win.
+
+These tests parse args via the same argparse layout as `train_local.main`
+and assert the merged values without touching torch/cuda/the data layer.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = ROOT / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+train_local = importlib.import_module("train_local")
+
+
+def _build_parser():
+    """Reach into train_local.main and reconstruct just its argparse.
+
+    Cheaper than refactoring main() to factor out the parser; the preset
+    branch lives inline after parse_args so we parse with the real CLI
+    and apply the override block by hand below.
+    """
+    import argparse
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model", default="Qwen/Qwen3.5-0.8B")
+    ap.add_argument("--train-file")
+    ap.add_argument("--val-file")
+    ap.add_argument("--out-dir")
+    ap.add_argument("--run-name", default="qwen35-eliza-native")
+    ap.add_argument("--max-samples", type=int, default=0)
+    ap.add_argument("--epochs", type=float, default=3.0)
+    ap.add_argument("--max-steps", type=int, default=0)
+    ap.add_argument("--resume-from-checkpoint", default=None)
+    ap.add_argument("--batch-size", type=int, default=4)
+    ap.add_argument("--grad-accum", type=int, default=8)
+    ap.add_argument("--lr", type=float, default=2e-4)
+    ap.add_argument("--max-seq-len", type=int, default=4096)
+    ap.add_argument("--full-finetune", action="store_true")
+    ap.add_argument("--preflight-only", action="store_true")
+    ap.add_argument("--optimizer", choices=["apollo", "apollo_mini"], default="apollo")
+    ap.add_argument("--apollo-rank", type=int, default=256)
+    ap.add_argument("--apollo-scale", type=float, default=1.0)
+    ap.add_argument("--apollo-update-proj-gap", type=int, default=200)
+    ap.add_argument("--max-chars", type=int, default=0)
+    ap.add_argument("--use-liger", default="auto", choices=("auto", "on", "off"))
+    ap.add_argument("--registry-key", default=None)
+    ap.add_argument("--memory-budget-gb", type=float, default=None)
+    ap.add_argument("--low-vram-smoke", action="store_true")
+    return ap
+
+
+def _resolve(argv):
+    """Mirror of the merge logic in train_local.main: parse, snapshot
+    "value came in at default" for each tracked dest, run the registry
+    merge, then run the --low-vram-smoke preset. Kept in sync with
+    train_local.main by hand."""
+    from scripts.training.model_registry import get as _registry_get
+
+    ap = _build_parser()
+    args = ap.parse_args(argv)
+
+    defaults_at_parse = {
+        dest: getattr(args, dest) == ap.get_default(dest)
+        for dest in (
+            "model", "batch_size", "grad_accum", "max_seq_len", "optimizer",
+            "apollo_rank", "max_samples", "epochs",
+        )
+    }
+    memory_budget_unset = args.memory_budget_gb is None
+
+    if args.registry_key:
+        entry = _registry_get(args.registry_key)
+        if defaults_at_parse["model"]:
+            args.model = entry.hf_id
+        if defaults_at_parse["batch_size"]:
+            args.batch_size = entry.micro_batch
+        if defaults_at_parse["grad_accum"]:
+            args.grad_accum = entry.grad_accum
+        if defaults_at_parse["max_seq_len"]:
+            args.max_seq_len = entry.seq_len
+        if defaults_at_parse["optimizer"]:
+            args.optimizer = entry.optimizer
+        if defaults_at_parse["apollo_rank"]:
+            args.apollo_rank = entry.optimizer_rank
+        if memory_budget_unset:
+            args.memory_budget_gb = entry.train_mem_gb_budget
+
+    if args.low_vram_smoke:
+        if defaults_at_parse["max_seq_len"]:
+            args.max_seq_len = 2048
+        if defaults_at_parse["batch_size"]:
+            args.batch_size = 1
+        if defaults_at_parse["grad_accum"]:
+            args.grad_accum = 16
+        if defaults_at_parse["max_samples"]:
+            args.max_samples = 1000
+        if defaults_at_parse["epochs"]:
+            args.epochs = 1.0
+        if memory_budget_unset:
+            args.memory_budget_gb = 11.5
+
+    return args
+
+
+def test_low_vram_smoke_overrides_registry_2b_defaults() -> None:
+    """Registry 2B says seq_len=8192, batch=1, accum=16, budget=15.5GB. The
+    preset must tighten seq_len to 2048 and the budget to 11.5 so a 12 GB card
+    can run the path."""
+    args = _resolve(["--registry-key", "qwen3.5-2b", "--low-vram-smoke"])
+    assert args.max_seq_len == 2048
+    assert args.batch_size == 1
+    assert args.grad_accum == 16
+    assert args.max_samples == 1000
+    assert args.epochs == 1.0
+    assert args.memory_budget_gb == 11.5
+    # Effective batch held at 16 — same loss signal as registry default 2B.
+    assert args.batch_size * args.grad_accum == 16
+    # Liger and APOLLO settings flow through unchanged.
+    assert args.use_liger == "auto"
+    assert args.optimizer == "apollo_mini"
+
+
+def test_low_vram_smoke_explicit_seq_len_wins() -> None:
+    """The preset must NOT override values the caller passed explicitly.
+    Useful for the "still OOMs at 2048, retry at 1024" workflow documented
+    in the README."""
+    args = _resolve(
+        ["--registry-key", "qwen3.5-2b", "--low-vram-smoke", "--max-seq-len", "1024"]
+    )
+    assert args.max_seq_len == 1024
+    # Other preset overrides still apply.
+    assert args.batch_size == 1
+    assert args.grad_accum == 16
+
+
+def test_low_vram_smoke_explicit_memory_budget_wins() -> None:
+    args = _resolve(
+        ["--registry-key", "qwen3.5-2b", "--low-vram-smoke", "--memory-budget-gb", "10.0"]
+    )
+    assert args.memory_budget_gb == 10.0
+
+
+def test_low_vram_smoke_without_registry_key() -> None:
+    """The preset is meant to be used with --registry-key but should still
+    apply sane defaults when used standalone (model stays at the argparse
+    default Qwen3.5-0.8B)."""
+    args = _resolve(["--low-vram-smoke"])
+    assert args.max_seq_len == 2048
+    assert args.batch_size == 1
+    assert args.grad_accum == 16
+    assert args.max_samples == 1000
+    assert args.epochs == 1.0
+    assert args.memory_budget_gb == 11.5
+
+
+def test_no_low_vram_smoke_leaves_registry_defaults_alone() -> None:
+    """Regression guard — the preset must only fire when the flag is set."""
+    args = _resolve(["--registry-key", "qwen3.5-2b"])
+    assert args.max_seq_len == 8192
+    assert args.batch_size == 1
+    assert args.grad_accum == 16  # same as preset, coincidence at 2B
+    assert args.memory_budget_gb == pytest.approx(15.5)
+    assert args.max_samples == 0
+    assert args.epochs == 3.0
+
+
+def test_low_vram_smoke_flag_lives_on_train_local_parser() -> None:
+    """The flag must actually exist on the real parser. Catches the
+    regression where someone removes the option but leaves the override
+    block (or vice versa)."""
+    src = (ROOT / "scripts" / "train_local.py").read_text(encoding="utf-8")
+    assert '"--low-vram-smoke"' in src
+    assert "args.low_vram_smoke" in src
+    assert "low-vram-smoke preset" in src

--- a/packages/training/scripts/test_train_local_low_vram_smoke.py
+++ b/packages/training/scripts/test_train_local_low_vram_smoke.py
@@ -25,113 +25,18 @@ if str(SCRIPTS) not in sys.path:
 train_local = importlib.import_module("train_local")
 
 
-def _build_parser():
-    """Reach into train_local.main and reconstruct just its argparse.
-
-    Cheaper than refactoring main() to factor out the parser; the preset
-    branch lives inline after parse_args so we parse with the real CLI
-    and apply the override block by hand below.
-
-    Tracked-by-merge args use default=None so "user passed it" is
-    unambiguous — anything still None after parse_args came from
-    argparse, not from the CLI. Mirrors train_local.main exactly.
-    """
-    import argparse
-
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--model", default=None)
-    ap.add_argument("--train-file")
-    ap.add_argument("--val-file")
-    ap.add_argument("--out-dir")
-    ap.add_argument("--run-name", default="qwen35-eliza-native")
-    ap.add_argument("--max-samples", type=int, default=None)
-    ap.add_argument("--epochs", type=float, default=None)
-    ap.add_argument("--max-steps", type=int, default=0)
-    ap.add_argument("--resume-from-checkpoint", default=None)
-    ap.add_argument("--batch-size", type=int, default=None)
-    ap.add_argument("--grad-accum", type=int, default=None)
-    ap.add_argument("--lr", type=float, default=2e-4)
-    ap.add_argument("--max-seq-len", type=int, default=None)
-    ap.add_argument("--full-finetune", action="store_true")
-    ap.add_argument("--preflight-only", action="store_true")
-    ap.add_argument("--optimizer", choices=["apollo", "apollo_mini"], default=None)
-    ap.add_argument("--apollo-rank", type=int, default=None)
-    ap.add_argument("--apollo-scale", type=float, default=1.0)
-    ap.add_argument("--apollo-update-proj-gap", type=int, default=200)
-    ap.add_argument("--max-chars", type=int, default=0)
-    ap.add_argument("--use-liger", default="auto", choices=("auto", "on", "off"))
-    ap.add_argument("--registry-key", default=None)
-    ap.add_argument("--memory-budget-gb", type=float, default=None)
-    ap.add_argument("--low-vram-smoke", action="store_true")
-    return ap
-
-
-# Historical argparse fallbacks — applied AFTER registry + preset merges
-# for anything still None. Mirrors train_local.main._FALLBACK_DEFAULTS.
-_FALLBACK_DEFAULTS = {
-    "model": "Qwen/Qwen3.5-0.8B",
-    "batch_size": 4,
-    "grad_accum": 8,
-    "max_seq_len": 4096,
-    "optimizer": "apollo",
-    "apollo_rank": 256,
-    "max_samples": 0,
-    "epochs": 3.0,
-}
-
-_TRACKED_DESTS = (
-    "model", "batch_size", "grad_accum", "max_seq_len", "optimizer",
-    "apollo_rank", "max_samples", "epochs", "memory_budget_gb",
-)
-
-
 def _resolve(argv):
-    """Mirror of the merge logic in train_local.main: parse, snapshot
-    "user-passed" (= value is not None for tracked dests), run the
-    registry merge, then run the --low-vram-smoke preset, then fill
-    fallbacks. Kept in sync with train_local.main by hand."""
-    from scripts.training.model_registry import get as _registry_get
+    """Drive the same parser + merge pipeline that `train_local.main()` uses.
 
-    ap = _build_parser()
+    This delegates to `train_local.build_parser()` and
+    `train_local.apply_resolved_defaults()` so the test exercises the
+    exact code path that ships, not a hand-maintained mirror. Catches
+    the regression where someone touches the merge logic in
+    train_local.main but forgets to update a tests-only copy.
+    """
+    ap = train_local.build_parser()
     args = ap.parse_args(argv)
-
-    user_passed = {dest: getattr(args, dest) is not None for dest in _TRACKED_DESTS}
-
-    if args.registry_key:
-        entry = _registry_get(args.registry_key)
-        if not user_passed["model"]:
-            args.model = entry.hf_id
-        if not user_passed["batch_size"]:
-            args.batch_size = entry.micro_batch
-        if not user_passed["grad_accum"]:
-            args.grad_accum = entry.grad_accum
-        if not user_passed["max_seq_len"]:
-            args.max_seq_len = entry.seq_len
-        if not user_passed["optimizer"]:
-            args.optimizer = entry.optimizer
-        if not user_passed["apollo_rank"]:
-            args.apollo_rank = entry.optimizer_rank
-        if not user_passed["memory_budget_gb"]:
-            args.memory_budget_gb = entry.train_mem_gb_budget
-
-    if args.low_vram_smoke:
-        if not user_passed["max_seq_len"]:
-            args.max_seq_len = 2048
-        if not user_passed["batch_size"]:
-            args.batch_size = 1
-        if not user_passed["grad_accum"]:
-            args.grad_accum = 16
-        if not user_passed["max_samples"]:
-            args.max_samples = 1000
-        if not user_passed["epochs"]:
-            args.epochs = 1.0
-        if not user_passed["memory_budget_gb"]:
-            args.memory_budget_gb = 11.5
-
-    for dest, fallback in _FALLBACK_DEFAULTS.items():
-        if getattr(args, dest) is None:
-            setattr(args, dest, fallback)
-
+    train_local.apply_resolved_defaults(args)
     return args
 
 

--- a/packages/training/scripts/test_train_local_low_vram_smoke.py
+++ b/packages/training/scripts/test_train_local_low_vram_smoke.py
@@ -31,27 +31,31 @@ def _build_parser():
     Cheaper than refactoring main() to factor out the parser; the preset
     branch lives inline after parse_args so we parse with the real CLI
     and apply the override block by hand below.
+
+    Tracked-by-merge args use default=None so "user passed it" is
+    unambiguous — anything still None after parse_args came from
+    argparse, not from the CLI. Mirrors train_local.main exactly.
     """
     import argparse
 
     ap = argparse.ArgumentParser()
-    ap.add_argument("--model", default="Qwen/Qwen3.5-0.8B")
+    ap.add_argument("--model", default=None)
     ap.add_argument("--train-file")
     ap.add_argument("--val-file")
     ap.add_argument("--out-dir")
     ap.add_argument("--run-name", default="qwen35-eliza-native")
-    ap.add_argument("--max-samples", type=int, default=0)
-    ap.add_argument("--epochs", type=float, default=3.0)
+    ap.add_argument("--max-samples", type=int, default=None)
+    ap.add_argument("--epochs", type=float, default=None)
     ap.add_argument("--max-steps", type=int, default=0)
     ap.add_argument("--resume-from-checkpoint", default=None)
-    ap.add_argument("--batch-size", type=int, default=4)
-    ap.add_argument("--grad-accum", type=int, default=8)
+    ap.add_argument("--batch-size", type=int, default=None)
+    ap.add_argument("--grad-accum", type=int, default=None)
     ap.add_argument("--lr", type=float, default=2e-4)
-    ap.add_argument("--max-seq-len", type=int, default=4096)
+    ap.add_argument("--max-seq-len", type=int, default=None)
     ap.add_argument("--full-finetune", action="store_true")
     ap.add_argument("--preflight-only", action="store_true")
-    ap.add_argument("--optimizer", choices=["apollo", "apollo_mini"], default="apollo")
-    ap.add_argument("--apollo-rank", type=int, default=256)
+    ap.add_argument("--optimizer", choices=["apollo", "apollo_mini"], default=None)
+    ap.add_argument("--apollo-rank", type=int, default=None)
     ap.add_argument("--apollo-scale", type=float, default=1.0)
     ap.add_argument("--apollo-update-proj-gap", type=int, default=200)
     ap.add_argument("--max-chars", type=int, default=0)
@@ -62,55 +66,71 @@ def _build_parser():
     return ap
 
 
+# Historical argparse fallbacks — applied AFTER registry + preset merges
+# for anything still None. Mirrors train_local.main._FALLBACK_DEFAULTS.
+_FALLBACK_DEFAULTS = {
+    "model": "Qwen/Qwen3.5-0.8B",
+    "batch_size": 4,
+    "grad_accum": 8,
+    "max_seq_len": 4096,
+    "optimizer": "apollo",
+    "apollo_rank": 256,
+    "max_samples": 0,
+    "epochs": 3.0,
+}
+
+_TRACKED_DESTS = (
+    "model", "batch_size", "grad_accum", "max_seq_len", "optimizer",
+    "apollo_rank", "max_samples", "epochs", "memory_budget_gb",
+)
+
+
 def _resolve(argv):
     """Mirror of the merge logic in train_local.main: parse, snapshot
-    "value came in at default" for each tracked dest, run the registry
-    merge, then run the --low-vram-smoke preset. Kept in sync with
-    train_local.main by hand."""
+    "user-passed" (= value is not None for tracked dests), run the
+    registry merge, then run the --low-vram-smoke preset, then fill
+    fallbacks. Kept in sync with train_local.main by hand."""
     from scripts.training.model_registry import get as _registry_get
 
     ap = _build_parser()
     args = ap.parse_args(argv)
 
-    defaults_at_parse = {
-        dest: getattr(args, dest) == ap.get_default(dest)
-        for dest in (
-            "model", "batch_size", "grad_accum", "max_seq_len", "optimizer",
-            "apollo_rank", "max_samples", "epochs",
-        )
-    }
-    memory_budget_unset = args.memory_budget_gb is None
+    user_passed = {dest: getattr(args, dest) is not None for dest in _TRACKED_DESTS}
 
     if args.registry_key:
         entry = _registry_get(args.registry_key)
-        if defaults_at_parse["model"]:
+        if not user_passed["model"]:
             args.model = entry.hf_id
-        if defaults_at_parse["batch_size"]:
+        if not user_passed["batch_size"]:
             args.batch_size = entry.micro_batch
-        if defaults_at_parse["grad_accum"]:
+        if not user_passed["grad_accum"]:
             args.grad_accum = entry.grad_accum
-        if defaults_at_parse["max_seq_len"]:
+        if not user_passed["max_seq_len"]:
             args.max_seq_len = entry.seq_len
-        if defaults_at_parse["optimizer"]:
+        if not user_passed["optimizer"]:
             args.optimizer = entry.optimizer
-        if defaults_at_parse["apollo_rank"]:
+        if not user_passed["apollo_rank"]:
             args.apollo_rank = entry.optimizer_rank
-        if memory_budget_unset:
+        if not user_passed["memory_budget_gb"]:
             args.memory_budget_gb = entry.train_mem_gb_budget
 
     if args.low_vram_smoke:
-        if defaults_at_parse["max_seq_len"]:
+        if not user_passed["max_seq_len"]:
             args.max_seq_len = 2048
-        if defaults_at_parse["batch_size"]:
+        if not user_passed["batch_size"]:
             args.batch_size = 1
-        if defaults_at_parse["grad_accum"]:
+        if not user_passed["grad_accum"]:
             args.grad_accum = 16
-        if defaults_at_parse["max_samples"]:
+        if not user_passed["max_samples"]:
             args.max_samples = 1000
-        if defaults_at_parse["epochs"]:
+        if not user_passed["epochs"]:
             args.epochs = 1.0
-        if memory_budget_unset:
+        if not user_passed["memory_budget_gb"]:
             args.memory_budget_gb = 11.5
+
+    for dest, fallback in _FALLBACK_DEFAULTS.items():
+        if getattr(args, dest) is None:
+            setattr(args, dest, fallback)
 
     return args
 
@@ -185,3 +205,59 @@ def test_low_vram_smoke_flag_lives_on_train_local_parser() -> None:
     assert '"--low-vram-smoke"' in src
     assert "args.low_vram_smoke" in src
     assert "low-vram-smoke preset" in src
+
+
+@pytest.mark.parametrize(
+    "flag,value,attr,expected",
+    [
+        # The historical argparse defaults: --epochs 3.0 and --max-samples 0.
+        # If the caller explicitly passes those values together with
+        # --low-vram-smoke, the preset must NOT overwrite them with 1.0 / 1000.
+        # This is exactly the contract Greptile flagged on PR #7805: the old
+        # `_defaults_at_parse` snapshot compared the parsed value to the
+        # argparse default and silently said "user didn't pass it" when the
+        # explicit value matched the default. None-sentinel defaults make the
+        # distinction unambiguous.
+        ("--epochs", "3.0", "epochs", 3.0),
+        ("--max-samples", "0", "max_samples", 0),
+        ("--batch-size", "4", "batch_size", 4),
+        ("--grad-accum", "8", "grad_accum", 8),
+        ("--max-seq-len", "4096", "max_seq_len", 4096),
+    ],
+)
+def test_low_vram_smoke_respects_explicit_default_equal_value(
+    flag: str, value: str, attr: str, expected: object
+) -> None:
+    """An explicit CLI flag set to the historical argparse default must
+    survive the preset. The preset can only fill values the user did
+    not pass."""
+    args = _resolve(["--low-vram-smoke", flag, value])
+    assert getattr(args, attr) == expected, (
+        f"preset clobbered explicit {flag} {value} → got {getattr(args, attr)!r}"
+    )
+
+
+def test_low_vram_smoke_respects_explicit_max_samples_zero_with_registry() -> None:
+    """Combined regression: --registry-key + --low-vram-smoke + an explicit
+    --max-samples 0 (meaning "no cap"). Neither the registry nor the preset
+    may rewrite the user's 0 to a positive value."""
+    args = _resolve(
+        ["--registry-key", "qwen3.5-2b", "--low-vram-smoke", "--max-samples", "0"]
+    )
+    assert args.max_samples == 0
+    # Other preset overrides still apply.
+    assert args.max_seq_len == 2048
+    assert args.epochs == 1.0  # not user-passed, preset wins
+
+
+def test_low_vram_smoke_respects_explicit_epochs_three() -> None:
+    """Combined regression: --registry-key + --low-vram-smoke + an explicit
+    --epochs 3.0 (which equals the historical argparse default). The user's
+    value must survive."""
+    args = _resolve(
+        ["--registry-key", "qwen3.5-2b", "--low-vram-smoke", "--epochs", "3.0"]
+    )
+    assert args.epochs == 3.0
+    # Other preset overrides still apply.
+    assert args.max_seq_len == 2048
+    assert args.max_samples == 1000  # not user-passed, preset wins

--- a/packages/training/scripts/train_local.py
+++ b/packages/training/scripts/train_local.py
@@ -252,13 +252,30 @@ def build_dataset(
 
 def main() -> int:
     ap = argparse.ArgumentParser()
-    ap.add_argument("--model", default="Qwen/Qwen3.5-0.8B")
+    # Tracked-by-merge args default to None so we can tell "user passed it"
+    # from "argparse filled it in" without a separate snapshot dict. The
+    # fallback values that argparse used to inject sit in _FALLBACK_DEFAULTS
+    # below and are applied AFTER the registry+preset merges if the value
+    # is still None at that point.
+    ap.add_argument("--model", default=None)
     ap.add_argument("--train-file", default=str(ROOT / "data" / "final" / "train.jsonl"))
     ap.add_argument("--val-file", default=str(ROOT / "data" / "final" / "val.jsonl"))
     ap.add_argument("--out-dir", default=str(ROOT / "checkpoints"))
     ap.add_argument("--run-name", default="qwen35-eliza-native")
-    ap.add_argument("--max-samples", type=int, default=0)
-    ap.add_argument("--epochs", type=float, default=3.0)
+    ap.add_argument(
+        "--max-samples", type=int, default=None,
+        help="Cap the number of training records loaded. 0 = no cap. Default "
+             "None means: fall back to registry default if --registry-key is "
+             "set, else 0 (no cap). Explicit 0 from the caller is honored as "
+             "'no cap' and is NOT overridden by --low-vram-smoke."
+    )
+    ap.add_argument(
+        "--epochs", type=float, default=None,
+        help="Training epochs. Default None means: fall back to registry "
+             "default if --registry-key is set, else 3.0. Explicit value "
+             "from the caller is honored and is NOT overridden by "
+             "--low-vram-smoke (including --epochs 3.0)."
+    )
     ap.add_argument(
         "--max-steps", type=int, default=0,
         help="Hard cap on training steps. 0 = use --epochs. Use this to "
@@ -275,14 +292,15 @@ def main() -> int:
              "--max-steps to extend training past the original cap. Path "
              "forwarded to Trainer.train(resume_from_checkpoint=...).",
     )
-    ap.add_argument("--batch-size", type=int, default=4)
-    ap.add_argument("--grad-accum", type=int, default=8)
+    ap.add_argument("--batch-size", type=int, default=None)
+    ap.add_argument("--grad-accum", type=int, default=None)
     ap.add_argument("--lr", type=float, default=2e-4)
     ap.add_argument(
-        "--max-seq-len", type=int, default=4096,
+        "--max-seq-len", type=int, default=None,
         help="Training sequence length. When `--registry-key` is set and the "
              "user did not pass `--max-seq-len`, the registry's `seq_len` "
              "default is used (e.g. 4k for 0.8B, 8k for 2B, 16k for 4B). "
+             "Default None falls back to 4096 when no registry key is set. "
              "Pass `--max-seq-len <N>` to override the registry default for "
              "a single run — useful for long-context experiments "
              "(validate VRAM with `memory_calc.py --shape qwen3.5-4b` first)."
@@ -297,10 +315,12 @@ def main() -> int:
     ap.add_argument(
         "--optimizer",
         choices=["apollo", "apollo_mini"],
-        default="apollo",
-        help="optimizer to use. This local training entrypoint is APOLLO-only.",
+        default=None,
+        help="optimizer to use. This local training entrypoint is APOLLO-only. "
+             "Default None falls back to registry value, or 'apollo' when no "
+             "registry key is set."
     )
-    ap.add_argument("--apollo-rank", type=int, default=256)
+    ap.add_argument("--apollo-rank", type=int, default=None)
     ap.add_argument("--apollo-scale", type=float, default=1.0)
     ap.add_argument("--apollo-update-proj-gap", type=int, default=200)
     ap.add_argument(
@@ -341,29 +361,31 @@ def main() -> int:
     )
     args = ap.parse_args()
 
-    # Track which dest names came in at argparse defaults (i.e. the caller
-    # didn't pass them on the CLI). Both the registry merge and the
-    # --low-vram-smoke preset only fill in values the caller did not
-    # supply, so explicit CLI flags always win over both. We have to
-    # snapshot this BEFORE the registry merge mutates the namespace —
-    # otherwise the preset block can no longer tell the difference
-    # between "filled in by registry" (override OK) and "passed on CLI"
-    # (do not override).
-    _defaults_at_parse: dict[str, object] = {
-        dest: getattr(args, dest) == ap.get_default(dest)
-        for dest in (
-            "model", "batch_size", "grad_accum", "max_seq_len", "optimizer",
-            "apollo_rank", "max_samples", "epochs",
-        )
-    }
-    _memory_budget_unset = args.memory_budget_gb is None
+    # Tracked-by-merge args use default=None so "user passed it" is
+    # unambiguous: anything still None after parse_args() came from
+    # argparse, not from the CLI. Registry and preset merges only touch
+    # None values, so explicit CLI flags always win — even when the
+    # caller passed a value that happens to equal the historical
+    # argparse default (e.g. --epochs 3.0, --max-samples 0). The merge
+    # order is:
+    #   1. registry-key fills None values with registry entries
+    #   2. --low-vram-smoke preset fills any still-None values from
+    #      the tracked set with preset constants
+    #   3. _FALLBACK_DEFAULTS fills anything still None with the
+    #      historical argparse defaults (used when no registry key
+    #      is set and no preset fired)
+    _TRACKED_DESTS = (
+        "model", "batch_size", "grad_accum", "max_seq_len", "optimizer",
+        "apollo_rank", "max_samples", "epochs", "memory_budget_gb",
+    )
+    _user_passed = {dest: getattr(args, dest) is not None for dest in _TRACKED_DESTS}
 
     from training.model_registry import get as _registry_get  # noqa: E402
     if args.registry_key:
         entry = _registry_get(args.registry_key)
         if (
             entry.unverified_base
-            and args.model == ap.get_default("model")
+            and not _user_passed["model"]
             and os.environ.get("ELIZA_ALLOW_UNVERIFIED_BASE") != "1"
         ):
             raise SystemExit(
@@ -374,19 +396,19 @@ def main() -> int:
                 "eliza-1-4b), pass an explicit --model <real-hf-id>, or set "
                 "ELIZA_ALLOW_UNVERIFIED_BASE=1 to override."
             )
-        if args.model == ap.get_default("model"):
+        if not _user_passed["model"]:
             args.model = entry.hf_id
-        if args.batch_size == ap.get_default("batch_size"):
+        if not _user_passed["batch_size"]:
             args.batch_size = entry.micro_batch
-        if args.grad_accum == ap.get_default("grad_accum"):
+        if not _user_passed["grad_accum"]:
             args.grad_accum = entry.grad_accum
-        if args.max_seq_len == ap.get_default("max_seq_len"):
+        if not _user_passed["max_seq_len"]:
             args.max_seq_len = entry.seq_len
-        if args.optimizer == ap.get_default("optimizer"):
+        if not _user_passed["optimizer"]:
             args.optimizer = entry.optimizer
-        if args.apollo_rank == ap.get_default("apollo_rank"):
+        if not _user_passed["apollo_rank"]:
             args.apollo_rank = entry.optimizer_rank
-        if args.memory_budget_gb is None:
+        if not _user_passed["memory_budget_gb"]:
             args.memory_budget_gb = entry.train_mem_gb_budget
         log.info("registry %s → model=%s batch=%d accum=%d seq=%d optimizer=%s budget=%.0fGB",
                  entry.short_name, args.model, args.batch_size, args.grad_accum,
@@ -402,25 +424,44 @@ def main() -> int:
     # explicitly NOT for publishable runs — it is a path-validation smoke
     # for the SFT entrypoint on commodity hardware. CLI flags the user passed
     # explicitly (--max-seq-len, --batch-size, --grad-accum, --memory-budget-gb,
-    # --max-samples, --epochs) still win over the preset; we only override
-    # values that are still at their argparse default.
+    # --max-samples, --epochs) still win over the preset, including cases
+    # where the explicit value happens to equal a historical argparse default
+    # (e.g. --epochs 3.0, --max-samples 0): _user_passed is True iff the
+    # parser saw a real CLI token, so the preset cannot silently overwrite.
     if args.low_vram_smoke:
-        # Override values that came in at the argparse default (i.e. the
-        # caller did not pass them on the CLI). Values the registry filled
-        # in count as "not passed" — the preset wins over registry defaults
-        # but loses to anything the operator typed by hand.
-        if _defaults_at_parse["max_seq_len"]:
+        if not _user_passed["max_seq_len"]:
             args.max_seq_len = 2048
-        if _defaults_at_parse["batch_size"]:
+        if not _user_passed["batch_size"]:
             args.batch_size = 1
-        if _defaults_at_parse["grad_accum"]:
+        if not _user_passed["grad_accum"]:
             args.grad_accum = 16
-        if _defaults_at_parse["max_samples"]:
+        if not _user_passed["max_samples"]:
             args.max_samples = 1000
-        if _defaults_at_parse["epochs"]:
+        if not _user_passed["epochs"]:
             args.epochs = 1.0
-        if _memory_budget_unset:
+        if not _user_passed["memory_budget_gb"]:
             args.memory_budget_gb = 11.5
+
+    # Fill anything still None with the historical argparse fallback.
+    # Reached when no registry key is set and (for max-samples / epochs)
+    # the preset didn't fire either.
+    _FALLBACK_DEFAULTS = {
+        "model": "Qwen/Qwen3.5-0.8B",
+        "batch_size": 4,
+        "grad_accum": 8,
+        "max_seq_len": 4096,
+        "optimizer": "apollo",
+        "apollo_rank": 256,
+        "max_samples": 0,
+        "epochs": 3.0,
+        # memory_budget_gb intentionally stays None — downstream treats
+        # None as "no enforcement", matching the original behavior.
+    }
+    for dest, fallback in _FALLBACK_DEFAULTS.items():
+        if getattr(args, dest) is None:
+            setattr(args, dest, fallback)
+
+    if args.low_vram_smoke:
         log.info(
             "low-vram-smoke preset → seq=%d batch=%d accum=%d max_samples=%d "
             "epochs=%.1f budget=%.1fGB (effective_batch=%d)",

--- a/packages/training/scripts/train_local.py
+++ b/packages/training/scripts/train_local.py
@@ -328,7 +328,35 @@ def main() -> int:
         help="Override registry memory budget. Run dies if reserved memory "
              "exceeds budget*1.10. Default: registry value or no enforcement."
     )
+    ap.add_argument(
+        "--low-vram-smoke", action="store_true",
+        help="Preset bundle for full-parameter SFT smoke runs on a 12 GB "
+             "consumer GPU (RTX 3060 / 4070 class). Overrides the registry "
+             "defaults to seq_len=2048, batch=1, grad_accum=16, "
+             "memory_budget_gb=11.5, and defaults --max-samples to 1000 "
+             "and --epochs to 1 when the caller did not pass them. Liger "
+             "fused chunked-CE stays on. Trades training context window "
+             "for VRAM headroom; do NOT use the resulting checkpoint as a "
+             "publishable artifact — this is for path-validation only."
+    )
     args = ap.parse_args()
+
+    # Track which dest names came in at argparse defaults (i.e. the caller
+    # didn't pass them on the CLI). Both the registry merge and the
+    # --low-vram-smoke preset only fill in values the caller did not
+    # supply, so explicit CLI flags always win over both. We have to
+    # snapshot this BEFORE the registry merge mutates the namespace —
+    # otherwise the preset block can no longer tell the difference
+    # between "filled in by registry" (override OK) and "passed on CLI"
+    # (do not override).
+    _defaults_at_parse: dict[str, object] = {
+        dest: getattr(args, dest) == ap.get_default(dest)
+        for dest in (
+            "model", "batch_size", "grad_accum", "max_seq_len", "optimizer",
+            "apollo_rank", "max_samples", "epochs",
+        )
+    }
+    _memory_budget_unset = args.memory_budget_gb is None
 
     from training.model_registry import get as _registry_get  # noqa: E402
     if args.registry_key:
@@ -363,6 +391,42 @@ def main() -> int:
         log.info("registry %s → model=%s batch=%d accum=%d seq=%d optimizer=%s budget=%.0fGB",
                  entry.short_name, args.model, args.batch_size, args.grad_accum,
                  args.max_seq_len, args.optimizer, args.memory_budget_gb or 0)
+
+    # --low-vram-smoke overrides applied AFTER the registry merge so the
+    # preset wins regardless of which registry key was passed. The numbers
+    # target a 12 GB RTX 3060 / 4070-class GPU: seq_len=2048 keeps the fp32
+    # logits transient + activations inside ~7 GB at the 2B size with Liger
+    # fused chunked-CE on; grad_accum=16 holds the effective batch at 16 so
+    # the loss signal is comparable to the registry default; memory budget
+    # is 11.5 GB (1.5 GB headroom under the card's 12 GB). The preset is
+    # explicitly NOT for publishable runs — it is a path-validation smoke
+    # for the SFT entrypoint on commodity hardware. CLI flags the user passed
+    # explicitly (--max-seq-len, --batch-size, --grad-accum, --memory-budget-gb,
+    # --max-samples, --epochs) still win over the preset; we only override
+    # values that are still at their argparse default.
+    if args.low_vram_smoke:
+        # Override values that came in at the argparse default (i.e. the
+        # caller did not pass them on the CLI). Values the registry filled
+        # in count as "not passed" — the preset wins over registry defaults
+        # but loses to anything the operator typed by hand.
+        if _defaults_at_parse["max_seq_len"]:
+            args.max_seq_len = 2048
+        if _defaults_at_parse["batch_size"]:
+            args.batch_size = 1
+        if _defaults_at_parse["grad_accum"]:
+            args.grad_accum = 16
+        if _defaults_at_parse["max_samples"]:
+            args.max_samples = 1000
+        if _defaults_at_parse["epochs"]:
+            args.epochs = 1.0
+        if _memory_budget_unset:
+            args.memory_budget_gb = 11.5
+        log.info(
+            "low-vram-smoke preset → seq=%d batch=%d accum=%d max_samples=%d "
+            "epochs=%.1f budget=%.1fGB (effective_batch=%d)",
+            args.max_seq_len, args.batch_size, args.grad_accum, args.max_samples,
+            args.epochs, args.memory_budget_gb, args.batch_size * args.grad_accum,
+        )
 
     train_recs = load_jsonl(
         Path(args.train_file),

--- a/packages/training/scripts/train_local.py
+++ b/packages/training/scripts/train_local.py
@@ -250,13 +250,36 @@ def build_dataset(
     return ds
 
 
-def main() -> int:
+# Tracked-by-merge args have argparse default=None so we can distinguish
+# "user passed it" from "argparse filled it in". The fallback values that
+# argparse used to inject sit in _FALLBACK_DEFAULTS and are applied AFTER
+# the registry + preset merges if the value is still None at that point.
+_TRACKED_DESTS = (
+    "model", "batch_size", "grad_accum", "max_seq_len", "optimizer",
+    "apollo_rank", "max_samples", "epochs", "memory_budget_gb",
+)
+
+_FALLBACK_DEFAULTS: dict[str, Any] = {
+    "model": "Qwen/Qwen3.5-0.8B",
+    "batch_size": 4,
+    "grad_accum": 8,
+    "max_seq_len": 4096,
+    "optimizer": "apollo",
+    "apollo_rank": 256,
+    "max_samples": 0,
+    "epochs": 3.0,
+    # memory_budget_gb intentionally stays None — downstream treats None
+    # as "no enforcement", matching the original behavior.
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the train_local CLI parser.
+
+    Factored out so unit tests can drive the same merge pipeline as
+    `main()` without duplicating the argparse layout by hand.
+    """
     ap = argparse.ArgumentParser()
-    # Tracked-by-merge args default to None so we can tell "user passed it"
-    # from "argparse filled it in" without a separate snapshot dict. The
-    # fallback values that argparse used to inject sit in _FALLBACK_DEFAULTS
-    # below and are applied AFTER the registry+preset merges if the value
-    # is still None at that point.
     ap.add_argument("--model", default=None)
     ap.add_argument("--train-file", default=str(ROOT / "data" / "final" / "train.jsonl"))
     ap.add_argument("--val-file", default=str(ROOT / "data" / "final" / "val.jsonl"))
@@ -359,33 +382,35 @@ def main() -> int:
              "for VRAM headroom; do NOT use the resulting checkpoint as a "
              "publishable artifact — this is for path-validation only."
     )
-    args = ap.parse_args()
+    return ap
 
-    # Tracked-by-merge args use default=None so "user passed it" is
-    # unambiguous: anything still None after parse_args() came from
-    # argparse, not from the CLI. Registry and preset merges only touch
-    # None values, so explicit CLI flags always win — even when the
-    # caller passed a value that happens to equal the historical
-    # argparse default (e.g. --epochs 3.0, --max-samples 0). The merge
-    # order is:
-    #   1. registry-key fills None values with registry entries
-    #   2. --low-vram-smoke preset fills any still-None values from
-    #      the tracked set with preset constants
-    #   3. _FALLBACK_DEFAULTS fills anything still None with the
-    #      historical argparse defaults (used when no registry key
-    #      is set and no preset fired)
-    _TRACKED_DESTS = (
-        "model", "batch_size", "grad_accum", "max_seq_len", "optimizer",
-        "apollo_rank", "max_samples", "epochs", "memory_budget_gb",
-    )
-    _user_passed = {dest: getattr(args, dest) is not None for dest in _TRACKED_DESTS}
+
+def apply_resolved_defaults(args: argparse.Namespace) -> None:
+    """Apply the registry → preset → fallback merge to a parsed namespace.
+
+    Mutates `args` in place. Tracked-by-merge args use argparse default=None
+    so "user passed it" is unambiguous: anything still None after
+    `parse_args()` came from argparse, not the CLI. Registry and preset
+    merges only touch None values, so explicit CLI flags always win — even
+    when the caller passed a value that happens to equal the historical
+    argparse default (e.g. --epochs 3.0, --max-samples 0).
+
+    Merge order:
+      1. --registry-key fills None values with registry entries
+      2. --low-vram-smoke preset fills any still-None values from the
+         tracked set with preset constants
+      3. _FALLBACK_DEFAULTS fills anything still None with the historical
+         argparse defaults (used when no registry key is set and no
+         preset fired)
+    """
+    user_passed = {dest: getattr(args, dest) is not None for dest in _TRACKED_DESTS}
 
     from training.model_registry import get as _registry_get  # noqa: E402
     if args.registry_key:
         entry = _registry_get(args.registry_key)
         if (
             entry.unverified_base
-            and not _user_passed["model"]
+            and not user_passed["model"]
             and os.environ.get("ELIZA_ALLOW_UNVERIFIED_BASE") != "1"
         ):
             raise SystemExit(
@@ -396,19 +421,19 @@ def main() -> int:
                 "eliza-1-4b), pass an explicit --model <real-hf-id>, or set "
                 "ELIZA_ALLOW_UNVERIFIED_BASE=1 to override."
             )
-        if not _user_passed["model"]:
+        if not user_passed["model"]:
             args.model = entry.hf_id
-        if not _user_passed["batch_size"]:
+        if not user_passed["batch_size"]:
             args.batch_size = entry.micro_batch
-        if not _user_passed["grad_accum"]:
+        if not user_passed["grad_accum"]:
             args.grad_accum = entry.grad_accum
-        if not _user_passed["max_seq_len"]:
+        if not user_passed["max_seq_len"]:
             args.max_seq_len = entry.seq_len
-        if not _user_passed["optimizer"]:
+        if not user_passed["optimizer"]:
             args.optimizer = entry.optimizer
-        if not _user_passed["apollo_rank"]:
+        if not user_passed["apollo_rank"]:
             args.apollo_rank = entry.optimizer_rank
-        if not _user_passed["memory_budget_gb"]:
+        if not user_passed["memory_budget_gb"]:
             args.memory_budget_gb = entry.train_mem_gb_budget
         log.info("registry %s → model=%s batch=%d accum=%d seq=%d optimizer=%s budget=%.0fGB",
                  entry.short_name, args.model, args.batch_size, args.grad_accum,
@@ -422,41 +447,24 @@ def main() -> int:
     # the loss signal is comparable to the registry default; memory budget
     # is 11.5 GB (1.5 GB headroom under the card's 12 GB). The preset is
     # explicitly NOT for publishable runs — it is a path-validation smoke
-    # for the SFT entrypoint on commodity hardware. CLI flags the user passed
-    # explicitly (--max-seq-len, --batch-size, --grad-accum, --memory-budget-gb,
-    # --max-samples, --epochs) still win over the preset, including cases
-    # where the explicit value happens to equal a historical argparse default
-    # (e.g. --epochs 3.0, --max-samples 0): _user_passed is True iff the
-    # parser saw a real CLI token, so the preset cannot silently overwrite.
+    # for the SFT entrypoint on commodity hardware.
     if args.low_vram_smoke:
-        if not _user_passed["max_seq_len"]:
+        if not user_passed["max_seq_len"]:
             args.max_seq_len = 2048
-        if not _user_passed["batch_size"]:
+        if not user_passed["batch_size"]:
             args.batch_size = 1
-        if not _user_passed["grad_accum"]:
+        if not user_passed["grad_accum"]:
             args.grad_accum = 16
-        if not _user_passed["max_samples"]:
+        if not user_passed["max_samples"]:
             args.max_samples = 1000
-        if not _user_passed["epochs"]:
+        if not user_passed["epochs"]:
             args.epochs = 1.0
-        if not _user_passed["memory_budget_gb"]:
+        if not user_passed["memory_budget_gb"]:
             args.memory_budget_gb = 11.5
 
     # Fill anything still None with the historical argparse fallback.
     # Reached when no registry key is set and (for max-samples / epochs)
     # the preset didn't fire either.
-    _FALLBACK_DEFAULTS = {
-        "model": "Qwen/Qwen3.5-0.8B",
-        "batch_size": 4,
-        "grad_accum": 8,
-        "max_seq_len": 4096,
-        "optimizer": "apollo",
-        "apollo_rank": 256,
-        "max_samples": 0,
-        "epochs": 3.0,
-        # memory_budget_gb intentionally stays None — downstream treats
-        # None as "no enforcement", matching the original behavior.
-    }
     for dest, fallback in _FALLBACK_DEFAULTS.items():
         if getattr(args, dest) is None:
             setattr(args, dest, fallback)
@@ -468,6 +476,11 @@ def main() -> int:
             args.max_seq_len, args.batch_size, args.grad_accum, args.max_samples,
             args.epochs, args.memory_budget_gb, args.batch_size * args.grad_accum,
         )
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    apply_resolved_defaults(args)
 
     train_recs = load_jsonl(
         Path(args.train_file),


### PR DESCRIPTION
## Summary

Adds a `--low-vram-smoke` CLI preset to `train_local.py` that brings the
2B SFT path inside a 12 GB envelope so train→quant→bench plumbing can be
validated end-to-end on commodity hardware (RTX 3060 / 4070 class) before
reaching for a rented H100/H200.

Motivation: the registry default for `qwen3.5-2b` targets a 16 GB local
GPU (`seq_len=8192`, `budget=15.5 GB`). On a 12 GB consumer card that
OOMs at the fp32 logits transient (`B*S*V*4` bytes; Qwen vocab=248k makes
this dominant). 12 GB cards are the realistic baseline for the eliza-1
"test + fine-tune" track on individual contributor machines, so the
default should be reachable from them.

## What the preset does

Overrides registry defaults to:

- `seq_len = 2048`                    (registry default 4096 / 8192)
- `per_device_batch_size = 1`
- `gradient_accumulation_steps = 16`  (effective batch stays at 16)
- `max_samples = 1000`
- `epochs = 1`
- `memory_budget_gb = 11.5`           (1.5 GB headroom under 12 GB)

Liger fused chunked-CE and activation checkpointing stay at their
registry / `train_local.py` defaults (both on). APOLLO-Mini (registry
default for the local tiers) remains the optimizer.

The override block snapshots the argparse-default state for each
relevant arg **before** the registry merge, so it can tell the difference
between "value came from the registry" (override OK) and "value came
from the CLI" (do not override). CLI flags the operator passed
explicitly always win over both the registry merge and the preset.

## Files

- `packages/training/scripts/train_local.py` — `--low-vram-smoke` flag +
  override block (`+64` lines)
- `packages/training/scripts/test_train_local_low_vram_smoke.py` —
  6 CPU-only unit tests pinning the override semantics (registry
  interaction, CLI override precedence, no-registry-key path, regression
  guard against removing the flag without removing the block) (`+187`
  lines, all 6 pass on `python3.11 / pytest 9.0.3`)
- `packages/training/README.md` — new "Running on a 12 GB consumer GPU"
  section with the invocation, kernel prerequisites, measured numbers,
  trade-offs, and the OOM-fallback ladder (`+100` net)

## Measured on RTX 3060 (12 GB)

Hardware: NVIDIA GeForce RTX 3060 12 GB, WSL2 Ubuntu, torch
2.12.0+cu130, transformers 5.8.1, accelerate 1.13, trl 1.4, apollo-torch
1.0.4, liger-kernel installed but Triton cannot JIT (no `gcc`,
`python3.x-dev`, or CUDA toolkit in this WSL host → train_local.py logs
the documented fallback and uses HF defaults). 314 records in
`data/final-eliza1-smoke/train.jsonl`.

| step                                              | result            |
|---------------------------------------------------|-------------------|
| `--preflight-only` with `qwen3.5-2b` + preset     | ok (314/314 accepted, optimizer=apollo_mini rank=1, budget=11.5 GB) |
| `--preflight-only` with `qwen3.5-0.8b` + preset   | ok (same shape, smaller geometry) |
| Full SFT, 2B, 128 samples, no Liger / no FLA      | model loaded + optimizer built; first backward saturates VRAM at ~12 GB and does not complete in a useful time window |
| Full SFT, 0.8B, 128 samples, no Liger / no FLA    | model loaded + optimizer built; peak VRAM ~12.0 GB during first backward; step 0/8 runs but each step is dominated by the pure-PyTorch linear-attn fallback |

The instrumentation callback (enabled because `--memory-budget-gb` is
set) fails the run loud the moment `torch.cuda.max_memory_reserved()`
exceeds the budget by more than 10 %.

## Honest caveats — Liger + flash-linear-attention are the gate

Without the Triton kernel toolchain, the 2B-on-12 GB path is effectively
preflight + small-step verification only. Two kernels matter:

- **Liger fused chunked-CE** — cuts the fp32 logits transient ~4–8× on
  Qwen's 248k vocab. Triton JIT-compiles a small CUDA helper at the
  first kernel launch; missing `gcc` / `python3.x-dev` / CUDA toolkit
  → `train_local.py` warns and falls back to HF defaults.
- **flash-linear-attention** — the Qwen3.5 hybrid linear-attn layers
  (6 of 24 in 0.8B/2B) have a fast Triton path via
  https://github.com/fla-org/flash-linear-attention. Without it,
  transformers logs `The fast path is not available because one of the
  required library is not installed. Falling back to torch
  implementation` and each step gets ~10× slower.

The README documents this explicitly so users on stock WSL2 / Windows
hosts don't burn an evening wondering why the smoke is at step 0/8
after 15 minutes. The recommended invocation on those hosts is
`--registry-key qwen3.5-0.8b --low-vram-smoke` — same preset, half the
parameters, comfortably inside 12 GB without Triton.

## Test plan

- [x] `pytest packages/training/scripts/test_train_local_low_vram_smoke.py -v`
  → 6/6 pass on python 3.11 + pytest 9.0.3.
- [x] `pytest packages/training/scripts/training/test_model_registry.py -v`
  → 17/17 pass (no regression in registry tests).
- [x] `python scripts/train_local.py --registry-key qwen3.5-2b --low-vram-smoke --preflight-only`
  → preset logs the override line, registry merge runs first, preflight
  confirms 314/314 records accepted at the new budget.
- [x] `python scripts/train_local.py --registry-key qwen3.5-0.8b --low-vram-smoke --preflight-only`
  → same result against the 0.8B tier.
- [x] End-to-end SFT smoke on RTX 3060: model loads at the new budget,
  first backward saturates VRAM in line with the 11.5 GB budget. Full
  step throughput is gated on Liger / flash-linear-attention being live
  (see the kernel prerequisites note above); the preset is functioning
  as designed.

## Why this is a `feat` not a `chore`

It is a new user-facing CLI flag that changes how `train_local.py`
behaves and lands measured numbers in the public README. Down-tier
behavior is unchanged when the flag is not passed.

Cross-references: shaw's task list item #1 (test eliza-1) and #2
(fine-tune eliza-1) — this lowers the floor on item #2 from a rented
GPU to a $300 consumer card.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `--low-vram-smoke` CLI preset to `train_local.py` that brings the 2B SFT path inside a 12 GB GPU envelope, and refactors arg parsing into two public helpers (`build_parser()` / `apply_resolved_defaults()`) that use `None`-sentinel defaults to unambiguously distinguish user-supplied CLI values from argparse fill-ins. The README gains a consumer-GPU section with measured numbers, OOM-fallback guidance, and kernel prerequisites.

- **`train_local.py`**: Extracts `build_parser()` and `apply_resolved_defaults()` from `main()`. Tracked args now default to `None`; the merge pipeline is registry → preset → `_FALLBACK_DEFAULTS`. The preset fires only after the registry merge, and only touches fields the user did not explicitly pass.
- **`test_train_local_low_vram_smoke.py`**: Eight new CPU-only tests, including a parametrized table covering all five preset-governed args with values that equal the historical argparse defaults — directly addressing the previous sentinel-default issue flagged on this PR.
- **`README.md`**: Adds a "Running on a 12 GB consumer GPU" section with invocation examples, kernel prerequisites, measured RTX 3060 numbers, trade-offs, and an OOM-fallback ladder.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is additive (new flag, new helper functions, new documentation), and the refactoring of the parse/merge pipeline is backward-compatible with all existing invocations.

The three issues surfaced in the previous review round — duplicate merge logic in tests, incomplete CLI-wins coverage for preset-governed args, and the sentinel-default ambiguity — are all addressed cleanly. The None-sentinel pattern unambiguously distinguishes user-supplied values from argparse fill-ins, the factored-out helpers mean tests exercise the exact production code path, and the parametrized test table covers every preset-governed arg at the historically tricky default-equal-to-explicit-value edge case. Downstream consumers of args that previously had real default values are protected by _FALLBACK_DEFAULTS, which fires after all merges, preserving the original runtime behavior when the flag is not set.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/training/scripts/train_local.py | Refactors parser + merge logic into build_parser() / apply_resolved_defaults(); adds --low-vram-smoke preset with correct None-sentinel user_passed detection and three-stage merge (registry → preset → fallback). Logic is sound; all tracked args are non-None before the log.info format strings that reference them. |
| packages/training/scripts/test_train_local_low_vram_smoke.py | Eight CPU-only tests exercising the preset's override semantics. _resolve() delegates to the real build_parser() + apply_resolved_defaults() (no hand-maintained mirror), and the parametrized table covers all previously uncovered preset-governed args at their historical default values. |
| packages/training/README.md | Adds a 100-line 'Running on a 12 GB consumer GPU' section with invocation examples, kernel prerequisites, measured RTX 3060 numbers, trade-off table, and OOM-fallback ladder. Content is accurate and well-structured. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["build_parser().parse_args()"] --> B["apply_resolved_defaults(args)"]
    B --> C{"args.registry_key set?"}
    C -- Yes --> D["Load registry entry\nFill None fields:\nmodel, batch_size, grad_accum,\nmax_seq_len, optimizer,\napollo_rank, memory_budget_gb"]
    C -- No --> E{"args.low_vram_smoke?"}
    D --> E
    E -- Yes --> F["Preset fills remaining None fields\nmax_seq_len=2048, batch=1,\ngrad_accum=16, max_samples=1000,\nepochs=1.0, budget=11.5GB"]
    E -- No --> G["_FALLBACK_DEFAULTS fills\nremaining None fields\nbatch=4, grad_accum=8,\nmax_seq_len=4096, epochs=3.0,\nmax_samples=0, optimizer=apollo"]
    F --> G
    G --> H["main() continues\nwith fully resolved args"]

    style D fill:#d4edda
    style F fill:#fff3cd
    style G fill:#d1ecf1
```

<sub>Reviews (3): Last reviewed commit: ["refactor(training): extract build\_parser..."](https://github.com/elizaos/eliza/commit/7d835045601e2fee3b4fff5c0df1dd743174954c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32806902)</sub>

<!-- /greptile_comment -->