### PR TITLE
fix(release): force npm token publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,6 @@ jobs:
       contents: write
       packages: write
       issues: write
-      id-token: write
       actions: read
 
     steps:
@@ -572,6 +571,7 @@ jobs:
         id: publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "false"
         run: |
           DIST_TAG="${{ steps.release_type.outputs.dist_tag }}"
 
@@ -626,6 +626,7 @@ jobs:
         if: steps.publish.outcome == 'success'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "false"
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           DIST_TAG="${{ steps.release_type.outputs.dist_tag }}"


### PR DESCRIPTION
## Summary
- remove id-token permission from the npm release workflow so npm/lerna does not attempt trusted-publishing OIDC
- set npm provenance off for publish and dist-tag verification so NPM_TOKEN remains the auth path

## Validation
- git diff --check
- ruby YAML parse for .github/workflows/release.yaml
- node packages/scripts/restore-workspace-refs.js --dry-run

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a publish-auth regression by removing the `id-token: write` permission that caused `lerna`/npm to attempt OIDC-based trusted publishing instead of using the `NPM_TOKEN` secret, and by explicitly setting `NPM_CONFIG_PROVENANCE=false` on the relevant steps as belt-and-suspenders.

- Removes `id-token: write` from the job's permissions block so GitHub Actions no longer issues an OIDC token that npm interprets as an invitation to use provenance/trusted-publishing.
- Adds `NPM_CONFIG_PROVENANCE: \"false\"` to both the publish step and the dist-tag verification step to ensure npm does not attempt to generate provenance attestations regardless of environment state.

<h3>Confidence Score: 5/5</h3>

Targeted, low-risk CI-only change that corrects the publish authentication path.

The change touches only the workflow YAML and makes no modifications to application code, scripts, or configuration consumed at runtime. The permission removal is exactly scoped to the problem.

No files require special attention; .github/workflows/release.yaml is the only changed file and the diff is small and self-contained.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release.yaml | Removes `id-token: write` permission and explicitly sets `NPM_CONFIG_PROVENANCE=false` on the publish and dist-tag steps to force npm token authentication over OIDC trusted publishing |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant NPM as npm registry

    Note over GHA: Before fix (id-token: write present)
    GHA->>GHA: OIDC token issued automatically
    GHA->>NPM: lerna publish via OIDC/provenance path
    NPM-->>GHA: Auth failure

    Note over GHA: After fix (id-token removed)
    GHA->>GHA: No OIDC token issued
    GHA->>NPM: lerna publish with NPM_TOKEN and provenance disabled
    NPM-->>GHA: Published successfully
```

<sub>Reviews (1): Last reviewed commit: ["fix(release): force npm token publishing"](https://github.com/elizaos/eliza/commit/7127adda6a3f4e4c8ba4e060650052a18e6352b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32887202)</sub>

<!-- /greptile_comment -->