### PR TITLE
fix(cloud-frontend): track async job ids for suspend/snapshot/restart toasts

### DIFF
--- a/packages/cloud-frontend/src/dashboard/containers/_components/agent-actions.tsx
+++ b/packages/cloud-frontend/src/dashboard/containers/_components/agent-actions.tsx
@@ -82,21 +82,19 @@ export function ElizaAgentActions({ agentId, status }: ElizaAgentActionsProps) {
       });
 
       const data = await res.json().catch(() => ({}));
+      const jobId = (data as { data?: { jobId?: string } }).data?.jobId;
 
-      if (
-        (action === "provision" || action === "resume") &&
-        res.status === 409
-      ) {
-        const jobId = (data as { data?: { jobId?: string } }).data?.jobId;
-        if (jobId) {
-          poller.track(agentId, jobId);
-          toast.info(
-            t("cloud.containers.agentActions.alreadyProvisioning", {
-              defaultValue: "Provisioning already in progress",
-            }),
-          );
-          return;
-        }
+      // 409 + jobId — operation already in flight, attach to the existing
+      // job so the toast resolves when it actually completes.
+      if (res.status === 409 && jobId) {
+        poller.track(agentId, jobId);
+        toast.info(
+          t("cloud.containers.agentActions.actionAlreadyInProgress", {
+            defaultValue: "{action} already in progress",
+            action,
+          }),
+        );
+        return;
       }
 
       if (!res.ok) {
@@ -115,30 +113,40 @@ export function ElizaAgentActions({ agentId, status }: ElizaAgentActionsProps) {
         return;
       }
 
-      if (
-        (action === "provision" || action === "resume") &&
-        res.status === 202
-      ) {
-        const jobId = (data as { data?: { jobId?: string } }).data?.jobId;
-        if (jobId) {
-          poller.track(agentId, jobId);
-          toast.success(
-            t("cloud.containers.agentActions.provisioningQueued", {
-              defaultValue: "Agent provisioning queued",
-            }),
-          );
-          return;
-        }
-
-        toast.success(
-          t("cloud.containers.agentActions.provisioningStarted", {
-            defaultValue: "Agent provisioning started",
+      // 202 + jobId — the backend enqueued a job; track it and tell the
+      // user it's running. Avoids the toast lying ("Snapshot saved")
+      // before the daemon actually finished.
+      if (res.status === 202 && jobId) {
+        poller.track(agentId, jobId);
+        const queuedMessages: Record<string, string> = {
+          provision: t("cloud.containers.agentActions.provisioningQueued", {
+            defaultValue: "Agent provisioning queued",
           }),
+          resume: t("cloud.containers.agentActions.resumeQueued", {
+            defaultValue: "Agent resume queued",
+          }),
+          snapshot: t("cloud.containers.agentActions.snapshotQueued", {
+            defaultValue: "Snapshot queued",
+          }),
+          suspend: t("cloud.containers.agentActions.suspendQueued", {
+            defaultValue: "Suspend queued",
+          }),
+          shutdown: t("cloud.containers.agentActions.suspendQueued", {
+            defaultValue: "Suspend queued",
+          }),
+        };
+        toast.success(
+          queuedMessages[action] ??
+            t("cloud.containers.agentActions.actionQueued", {
+              defaultValue: "{action} queued",
+              action,
+            }),
         );
-        window.location.reload();
         return;
       }
 
+      // Fallback: synchronous success (no jobId returned). Legacy
+      // endpoints that still complete inline land here.
       const messages: Record<string, string> = {
         provision: t("cloud.containers.agentActions.provisioningStarted", {
           defaultValue: "Agent provisioning started",

--- a/packages/cloud-frontend/src/dashboard/containers/_components/eliza-agents-table.tsx
+++ b/packages/cloud-frontend/src/dashboard/containers/_components/eliza-agents-table.tsx
@@ -420,11 +420,24 @@ export function ElizaAgentsTable({
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ action: "suspend" }),
       });
-      if (!res.ok) {
+      if (!res.ok && res.status !== 202) {
         // Revert optimistic update
         void refreshData();
         throw new Error("Suspend failed");
       }
+
+      // 202 + jobId: the daemon executes the suspend asynchronously.
+      // Track the job so the table reflects the real completion (and
+      // the success toast doesn't lie before the container actually
+      // stops).
+      const data = await res.json().catch(() => ({}));
+      const jobId = (data as { data?: { jobId?: string } }).data?.jobId;
+      if (res.status === 202 && jobId) {
+        poller.track(id, jobId);
+        toast.success("Suspend queued");
+        return;
+      }
+
       toast.success("Agent suspended (snapshot saved)");
       void refreshData();
     } catch {


### PR DESCRIPTION
## Why

Backend lifecycle ops moved to the job queue in #7810: suspend, restart, snapshot, logs all return 202 + jobId instead of completing inline.

The frontend was still firing the success toast immediately on 2xx and reloading the page, which **lied** about the operation being done. \"Snapshot saved\" appeared in < 1s while the daemon had just started a 30s job.

## What changed

\`packages/cloud-frontend/src/dashboard/containers/_components/agent-actions.tsx\`:
- Detection of 202 + jobId is now generic (any action), not hardcoded to provision/resume.
- New \"queued\" toast variants for snapshot / suspend / shutdown.
- For queued ops, the existing \`useJobPoller\` already handles \`onComplete\` / \`onFailed\` toasts + auto-refresh — no \`window.location.reload()\` needed on the queued path.

\`packages/cloud-frontend/src/dashboard/containers/_components/eliza-agents-table.tsx\`:
- \`handleSuspend\` now reads 202 + jobId and \`poller.track()\`s it (same hook the provision flow uses).

## Test plan

- [ ] Click Suspend in the agents table → toast says \"Suspend queued\" → after ~5s of polling, table updates to stopped + toast \"Agent provisioning completed\" (provision-completed name is misleading but the hook fires it; copy can be tweaked later).
- [ ] Click Save Snapshot in agent detail → \"Snapshot queued\" toast → poller resolves with onComplete callback.
- [ ] Click Restart (if exposed via UI) → \"Restart queued\" → resolves.
- [ ] Provision/Resume still work as before (no regression).
- [ ] 409 path still tracked via existing fallback message.

## Depends on

#7810 (backend routes returning 202 + jobId). Mergeable in any order — without #7810 the frontend changes are dead code paths (no route returns 202 + jobId for those actions yet), but they don't break anything.

## Follow-up

- Generic poller toast copy currently says \"Provisioning completed\" / \"Provisioning failed\" regardless of which op finished. Untangle by passing the action name through \`useJobPoller\` and templating the toast.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes premature \"success\" toasts for async lifecycle operations (suspend, snapshot, restart) by detecting the 202+jobId response pattern — previously used only for provision/resume — and routing those actions through `useJobPoller` instead of resolving immediately.

- **`agent-actions.tsx`**: 202+jobId detection is generalised to any action with per-action queued toast messages; the premature `window.location.reload()` on the 202 path is removed (reload still happens after the job completes via `autoRefresh`). The 409+jobId path is also generalised.
- **`eliza-agents-table.tsx`**: `handleSuspend` now reads the response body for 202+jobId and calls `poller.track()`, matching the pattern `handleProvision` already used. However, unlike `agent-actions.tsx`, the 409+jobId case is not handled — a concurrent suspend attempt throws a false error instead of attaching to the existing job.

<h3>Confidence Score: 3/5</h3>

Safe for most flows, but the table's suspend handler has an incomplete edge-case that produces a visible false error toast for concurrent suspend attempts.

The core fix (routing 202+jobId through the job poller) is sound and the happy path works correctly. The table's handleSuspend does not handle the 409+jobId case that agent-actions.tsx now covers — if a suspend is already running and the user clicks suspend again from the table, they see "Suspend failed" and the optimistic status reverts, even though the daemon is healthy. The completion toasts ("Agent provisioning completed") are also incorrect for suspend and snapshot operations, which is a user-visible lie each time those jobs finish.

eliza-agents-table.tsx needs the 409+jobId guard added to handleSuspend to match the pattern in agent-actions.tsx.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/cloud-frontend/src/dashboard/containers/_components/agent-actions.tsx | Generalises 202+jobId tracking to all actions (not just provision/resume), adds per-action queued toast messages, and removes premature window.location.reload() on the async path. Minor issues: shutdown reuses the suspendQueued i18n key, and onComplete/onFailed messages still say "provisioning" for non-provisioning operations. |
| packages/cloud-frontend/src/dashboard/containers/_components/eliza-agents-table.tsx | handleSuspend updated to read 202+jobId and call poller.track(), but misses the 409+jobId case that agent-actions.tsx now handles — a concurrent suspend attempt shows a false "Suspend failed" error instead of attaching to the in-flight job. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant FE as Frontend (agent-actions / table)
    participant API as Backend API
    participant P as useJobPoller
    participant J as /api/v1/jobs/:id

    U->>FE: Click Suspend / Snapshot / Restart
    FE->>API: PATCH/POST action
    alt 409 + jobId (already in flight)
        API-->>FE: "409 { data: { jobId } }"
        FE->>P: poller.track(agentId, jobId)
        FE-->>U: "toast.info("{action} already in progress")"
    else 202 + jobId (newly queued)
        API-->>FE: "202 { data: { jobId } }"
        FE->>P: poller.track(agentId, jobId)
        FE-->>U: "toast.success("{action} queued")"
    else 2xx no jobId (legacy inline)
        API-->>FE: "200 {}"
        FE-->>U: "toast.success("{action} done")"
        FE->>FE: window.location.reload()
    else error
        API-->>FE: 4xx/5xx
        FE-->>U: toast.error("Action failed: ...")
    end

    loop Every 5s while job active
        P->>J: GET /api/v1/jobs/:jobId
        J-->>P: "{ status, error }"
        alt completed
            P->>FE: onComplete() → toast "Agent provisioning completed"
            P->>FE: window.location.reload()
        else failed
            P->>FE: onFailed() → toast.error(job.error)
            P->>FE: window.location.reload()
        else timed out
            P->>FE: onFailed("Timed out waiting...")
        end
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cloud-frontend/src/dashboard/containers/_components/agent-actions.tsx`, line 34-48 ([link](https://github.com/elizaos/eliza/blob/42a089d76f5c065f328a33d114ebb6becc46c5b8/packages/cloud-frontend/src/dashboard/containers/_components/agent-actions.tsx#L34-L48)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Generic `onComplete`/`onFailed` messages are wrong for all newly-tracked actions**

   The PR extends job tracking to `snapshot`, `suspend`, and `shutdown`, but the `useJobPoller` callbacks remain hardcoded to "Agent provisioning completed" / "Provisioning failed". A user who clicks "Save Snapshot" sees "Snapshot queued", waits ~30 s, and then receives "Agent provisioning completed" — which directly contradicts the earlier toast. The same problem applies to suspend and shutdown in both this file and `eliza-agents-table.tsx` (line 278–286). The follow-up mentioned in the PR description would need to pass an action-to-message map into `useJobPoller` or use per-action pollers to fix this.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(cloud-frontend): track async job ids..."](https://github.com/elizaos/eliza/commit/42a089d76f5c065f328a33d114ebb6becc46c5b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32901826)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->