### PR TITLE
fix(ui): inline z-index arbitrary classes so Tailwind v4 emits them

### DIFF
--- a/packages/ui/src/components/composites/chat/chat-conversation-item.tsx
+++ b/packages/ui/src/components/composites/chat/chat-conversation-item.tsx
@@ -7,8 +7,11 @@ import {
   useRef,
   useState,
 } from "react";
-import { Z_OVERLAY } from "../../../lib/floating-layers";
 import { cn } from "../../../lib/utils";
+
+// z-[200] mirrors Z_OVERLAY in ../../../lib/floating-layers.ts.
+// Tailwind v4 cannot detect classes built from runtime template literals,
+// so the value is kept inline so the scanner emits the utility.
 import { Button } from "../../ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import type {
@@ -89,7 +92,7 @@ function TruncatingConversationTitle({
         align="start"
         sideOffset={10}
         collisionPadding={12}
-        className={`z-[${Z_OVERLAY}] max-w-[min(90vw,22rem)] whitespace-normal break-words px-3 py-2 text-sm leading-snug`}
+        className="z-[200] max-w-[min(90vw,22rem)] whitespace-normal break-words px-3 py-2 text-sm leading-snug"
       >
         {displayTitle}
       </TooltipContent>

--- a/packages/ui/src/components/shell/ConnectionFailedBanner.tsx
+++ b/packages/ui/src/components/shell/ConnectionFailedBanner.tsx
@@ -1,7 +1,9 @@
-import { Z_SYSTEM_CRITICAL } from "../../lib/floating-layers";
 import { useApp } from "../../state";
 import { Button } from "../ui/button";
 import { Spinner } from "../ui/spinner";
+
+// z-[9999] mirrors Z_SYSTEM_CRITICAL in ../../lib/floating-layers.ts.
+// Kept as a literal so Tailwind v4's source scanner emits the utility.
 
 /**
  * Banner shown during WebSocket reconnection attempts.
@@ -25,7 +27,7 @@ export function ConnectionFailedBanner() {
         role="status"
         aria-live="polite"
         data-window-titlebar-banner="true"
-        className={`shrink-0 z-[${Z_SYSTEM_CRITICAL}] flex items-center gap-3 bg-warn px-4 py-2 text-sm font-medium text-[color:var(--accent-foreground)] shadow-sm`}
+        className="shrink-0 z-[9999] flex items-center gap-3 bg-warn px-4 py-2 text-sm font-medium text-[color:var(--accent-foreground)] shadow-sm"
       >
         <Spinner
           size={16}
@@ -50,7 +52,7 @@ export function ConnectionFailedBanner() {
         role="alert"
         aria-live="assertive"
         data-window-titlebar-banner="true"
-        className={`shrink-0 z-[${Z_SYSTEM_CRITICAL}] flex items-center justify-between gap-3 bg-danger px-4 py-2 text-sm font-medium text-white shadow-sm`}
+        className="shrink-0 z-[9999] flex items-center justify-between gap-3 bg-danger px-4 py-2 text-sm font-medium text-white shadow-sm"
       >
         <span className="truncate">
           {t("connectionfailedbanner.ConnectionLostAfte")}{" "}

--- a/packages/ui/src/components/shell/RestartBanner.tsx
+++ b/packages/ui/src/components/shell/RestartBanner.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useState } from "react";
-import { Z_SYSTEM_BANNER } from "../../lib/floating-layers";
 import { useApp } from "../../state";
 import { Button } from "../ui/button";
+
+// z-[9998] mirrors Z_SYSTEM_BANNER in ../../lib/floating-layers.ts.
+// Kept as a literal so Tailwind v4's source scanner emits the utility.
 
 export function RestartBanner() {
   const {
@@ -38,7 +40,7 @@ export function RestartBanner() {
 
   return (
     <div
-      className={`fixed bottom-4 right-4 z-[${Z_SYSTEM_BANNER}] flex flex-col gap-2 rounded-lg px-4 py-3 text-sm font-medium shadow-sm`}
+      className="fixed bottom-4 right-4 z-[9998] flex flex-col gap-2 rounded-lg px-4 py-3 text-sm font-medium shadow-sm"
       style={{
         background: "color-mix(in srgb, var(--bg) 95%, var(--accent) 5%)",
         border: "1px solid color-mix(in srgb, var(--accent) 25%, transparent)",

--- a/packages/ui/src/components/shell/ShellOverlays.tsx
+++ b/packages/ui/src/components/shell/ShellOverlays.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from "react";
 import { SHARE_TARGET_EVENT } from "../../events";
-import { Z_SHELL_OVERLAY } from "../../lib/floating-layers";
 import type { ShareTargetPayload } from "../../platform/init";
+
+// z-[10000] mirrors Z_SHELL_OVERLAY in ../../lib/floating-layers.ts.
+// Kept as a literal so Tailwind v4's source scanner emits the utility.
 import type { ActionNotice } from "../../state/types";
 import { useApp } from "../../state/useApp";
 import { CompanionGlobalOverlay as GlobalEmoteOverlay } from "../companion/injected";
@@ -90,7 +92,7 @@ export function ShellOverlays({
       <GlobalEmoteOverlay />
       {actionNotice && (
         <div
-          className={`fixed bottom-6 left-1/2 -translate-x-1/2 px-5 py-2.5 rounded-lg text-sm font-medium z-[${Z_SHELL_OVERLAY}] flex items-center gap-2.5 max-w-[min(92vw,28rem)] ${
+          className={`fixed bottom-6 left-1/2 -translate-x-1/2 px-5 py-2.5 rounded-lg text-sm font-medium z-[10000] flex items-center gap-2.5 max-w-[min(92vw,28rem)] ${
             actionNotice.tone === "error"
               ? "bg-danger text-white"
               : actionNotice.tone === "success"

--- a/packages/ui/src/components/shell/SystemWarningBanner.tsx
+++ b/packages/ui/src/components/shell/SystemWarningBanner.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from "react";
-import { Z_SYSTEM_BANNER } from "../../lib/floating-layers";
 import { useApp } from "../../state";
 import { Button } from "../ui/button";
+
+// z-[9998] mirrors Z_SYSTEM_BANNER in ../../lib/floating-layers.ts.
+// Kept as a literal so Tailwind v4's source scanner emits the utility.
 
 const AUTO_DISMISS_MS = 20_000;
 
@@ -53,7 +55,7 @@ export function SystemWarningBanner() {
           role="alert"
           aria-live="assertive"
           data-window-titlebar-banner="true"
-          className={`shrink-0 z-[${Z_SYSTEM_BANNER}] flex items-center justify-between gap-3 bg-warn px-4 py-2 text-sm font-medium text-[color:var(--accent-foreground)] shadow-sm`}
+          className="shrink-0 z-[9998] flex items-center justify-between gap-3 bg-warn px-4 py-2 text-sm font-medium text-[color:var(--accent-foreground)] shadow-sm"
         >
           <span className="truncate">{message}</span>
           <Button

--- a/packages/ui/src/components/ui/dialog.tsx
+++ b/packages/ui/src/components/ui/dialog.tsx
@@ -1,8 +1,16 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 import * as React from "react";
-import { Z_DIALOG, Z_DIALOG_OVERLAY } from "../../lib/floating-layers";
 import { cn } from "../../lib/utils";
+
+// NOTE: z-index values below are kept as literal arbitrary classes
+// (`z-[160]` / `z-[170]`) so Tailwind v4's source scanner emits them.
+// A previous revision used `` z-[${Z_DIALOG_OVERLAY}] `` template-literal
+// interpolation from the floating-layers constants, but Tailwind cannot
+// resolve classes built from runtime values — the overlay/content lost
+// `position: fixed` and stacking, leaving page chrome visible through the
+// modal. Keep these in sync with packages/ui/src/lib/floating-layers.ts
+// (Z_DIALOG_OVERLAY = 160, Z_DIALOG = 170).
 
 const Dialog = DialogPrimitive.Root;
 
@@ -19,7 +27,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      `fixed inset-0 z-[${Z_DIALOG_OVERLAY}] bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`,
+      "fixed inset-0 z-[160] bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -45,7 +53,7 @@ const DialogContent = React.forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          `fixed left-[50%] top-[50%] z-[${Z_DIALOG}] grid w-[min(calc(100vw_-_1.5rem),42rem)] max-h-[min(calc(100dvh_-_1.5rem_-_var(--safe-area-top,0px)_-_var(--safe-area-bottom,0px)),44rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-sm border border-border bg-bg p-5 shadow-sm duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:p-6`,
+          "fixed left-[50%] top-[50%] z-[170] grid w-[min(calc(100vw_-_1.5rem),42rem)] max-h-[min(calc(100dvh_-_1.5rem_-_var(--safe-area-top,0px)_-_var(--safe-area-bottom,0px)),44rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded-sm border border-border bg-bg p-5 shadow-sm duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:p-6",
           "max-sm:left-1/2 max-sm:top-auto max-sm:bottom-[max(0.75rem,var(--safe-area-bottom,0px))] max-sm:max-h-[min(calc(100dvh_-_1rem_-_var(--safe-area-top,0px)_-_var(--safe-area-bottom,0px)),42rem)] max-sm:w-[min(calc(100vw_-_1rem),42rem)] max-sm:translate-y-0 max-sm:rounded-sm max-sm:data-[state=closed]:slide-out-to-bottom-6 max-sm:data-[state=open]:slide-in-from-bottom-6",
           className,
         )}

--- a/packages/ui/src/components/ui/drawer-sheet.tsx
+++ b/packages/ui/src/components/ui/drawer-sheet.tsx
@@ -1,8 +1,14 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 import * as React from "react";
-import { Z_DIALOG, Z_DIALOG_OVERLAY } from "../../lib/floating-layers";
 import { cn } from "../../lib/utils";
+
+// z-index values are kept as literal `z-[160]` / `z-[170]` classes so
+// Tailwind v4's source scanner emits them. Template-literal interpolation
+// from the floating-layers constants is invisible to the scanner and would
+// drop `position: fixed` / stacking on the sheet — see dialog.tsx for the
+// full bug history. Keep in sync with packages/ui/src/lib/floating-layers.ts
+// (Z_DIALOG_OVERLAY = 160, Z_DIALOG = 170).
 
 const DrawerSheet = DialogPrimitive.Root;
 
@@ -19,7 +25,7 @@ const DrawerSheetOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      `fixed inset-0 z-[${Z_DIALOG_OVERLAY}] bg-black/72 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0`,
+      "fixed inset-0 z-[160] bg-black/72 duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -43,7 +49,7 @@ const DrawerSheetContent = React.forwardRef<
       <DialogPrimitive.Content
         ref={ref}
         className={cn(
-          `fixed left-[max(0.5rem,var(--safe-area-left,0px))] right-[max(0.5rem,var(--safe-area-right,0px))] bottom-[max(0.5rem,var(--safe-area-bottom,0px))] z-[${Z_DIALOG}] flex max-h-[min(calc(100dvh_-_1rem_-_var(--safe-area-top,0px)_-_var(--safe-area-bottom,0px)),44rem)] flex-col overflow-hidden rounded-sm border border-border bg-bg shadow-sm duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom-6 data-[state=open]:slide-in-from-bottom-6`,
+          "fixed left-[max(0.5rem,var(--safe-area-left,0px))] right-[max(0.5rem,var(--safe-area-right,0px))] bottom-[max(0.5rem,var(--safe-area-bottom,0px))] z-[170] flex max-h-[min(calc(100dvh_-_1rem_-_var(--safe-area-top,0px)_-_var(--safe-area-bottom,0px)),44rem)] flex-col overflow-hidden rounded-sm border border-border bg-bg shadow-sm duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-bottom-6 data-[state=open]:slide-in-from-bottom-6",
           className,
         )}
         {...props}

--- a/packages/ui/src/components/ui/tooltip-extended.tsx
+++ b/packages/ui/src/components/ui/tooltip-extended.tsx
@@ -1,5 +1,8 @@
-import { Z_OVERLAY } from "../../lib/floating-layers";
 import { cn } from "../../lib/utils";
+
+// z-[200] mirrors Z_OVERLAY in ../../lib/floating-layers.ts. Tailwind v4
+// cannot detect classes built from runtime template literals, so the value
+// is kept inline so the scanner emits the utility.
 
 /**
  * Hover-only tooltip with optional shortcut hint. Used as the icon-button
@@ -27,7 +30,7 @@ export function IconTooltip({
       {children}
       <div
         className={cn(
-          `absolute px-3 py-2 bg-bg-elevated border border-border text-xs text-txt-strong rounded-sm opacity-0 invisible group-hover:opacity-100 group-hover:visible group-focus-within:opacity-100 group-focus-within:visible transition-opacity duration-200 z-[${Z_OVERLAY}] shadow-sm pointer-events-none`,
+          "absolute px-3 py-2 bg-bg-elevated border border-border text-xs text-txt-strong rounded-sm opacity-0 invisible group-hover:opacity-100 group-hover:visible group-focus-within:opacity-100 group-focus-within:visible transition-opacity duration-200 z-[200] shadow-sm pointer-events-none",
           position === "top"
             ? "bottom-full left-1/2 -translate-x-1/2 mb-2"
             : "top-full left-1/2 -translate-x-1/2 mt-2",


### PR DESCRIPTION
## Problem

The "New Agent" modal on the ElizaCloud Instances page (and likely every other Dialog/DrawerSheet/Tooltip/system banner in the app) renders without an overlay and with a transparent content body, so the page chrome behind the modal bleeds through.

Reported by @binkyfishai in #eliza-cloud with a screenshot — visible "Usage & Rates" card, pricing table, balance, and `+ New Agent` button through the open modal.

## Root cause

`packages/ui/src/components/ui/dialog.tsx` (and seven sibling primitives) build z-index utilities through template-literal interpolation of the floating-layer constants, e.g.:

```ts
className={cn(
  \`fixed inset-0 z-[\${Z_DIALOG_OVERLAY}] bg-black/80 ...\`,
  className,
)}
```

Tailwind v4's source scanner extracts class candidates by reading the raw source as text — it can't statically resolve `z-[${Z_DIALOG_OVERLAY}]`, so the utility is never emitted to the bundle. At runtime the template renders to `z-[160]` etc., but the corresponding CSS rule doesn't exist, so:

- `DialogOverlay` loses `position: fixed`, `inset-0`, and z-index — the backdrop disappears and the element collapses to inline flow.
- `DialogContent` loses `position: fixed` / `z-[170]` — modal sits inline at the bottom of the document with no stacking context.

Same shape of bug in `DrawerSheet`, `IconTooltip`, `ChatConversationItem` tooltip, and the three system banners (`SystemWarningBanner`, `ConnectionFailedBanner`, `RestartBanner`) and the `actionNotice` toast in `ShellOverlays`.

Introduced in 0c74f49c12 (`feat: add packages/app, app-core, ui, ui-stories`, May 17).

## Fix

Replace each `z-[${CONST}]` interpolation with a literal arbitrary value class mirrored from `packages/ui/src/lib/floating-layers.ts`. Each file gets a comment pinning the literal back to the source-of-truth constant so future edits stay in sync.

| Constant            | Literal class |
|---------------------|---------------|
| `Z_DIALOG_OVERLAY`  | `z-[160]`     |
| `Z_DIALOG`          | `z-[170]`     |
| `Z_OVERLAY`         | `z-[200]`     |
| `Z_SYSTEM_BANNER`   | `z-[9998]`    |
| `Z_SYSTEM_CRITICAL` | `z-[9999]`    |
| `Z_SHELL_OVERLAY`   | `z-[10000]`   |

Files touched:

- `packages/ui/src/components/ui/dialog.tsx`
- `packages/ui/src/components/ui/drawer-sheet.tsx`
- `packages/ui/src/components/ui/tooltip-extended.tsx`
- `packages/ui/src/components/composites/chat/chat-conversation-item.tsx`
- `packages/ui/src/components/shell/SystemWarningBanner.tsx`
- `packages/ui/src/components/shell/ConnectionFailedBanner.tsx`
- `packages/ui/src/components/shell/RestartBanner.tsx`
- `packages/ui/src/components/shell/ShellOverlays.tsx`

## Validation

- `bunx biome check` on the eight touched files passes clean.
- Repo-wide audit: no `z-\[\$\{` occurrences remain in `packages/ui/src`, `packages/cloud-frontend`, `packages/app`, `packages/app-core` (excluding `dist/` build artifacts and the doc comment in `dialog.tsx` explaining the bug).
- No other `[${...}]` interpolation patterns produce class candidates anywhere in `packages/ui/src` (only matches are in `RuntimeView.tsx` path/key strings and SSH host formatting, neither of which are Tailwind classes).
- Behavior change scope: pure CSS-emission fix. No runtime/JS behavior changes, no API changes, no z-index value changes.

## How to reproduce before the fix

1. Open ElizaCloud → Instances tab on production.
2. Click `+ New Agent`.
3. Modal body is transparent and there's no backdrop — page contents are fully visible behind it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Tailwind v4 CSS emission bug where z-index utility classes were built via template-literal interpolation of constants from `floating-layers.ts`. Because Tailwind v4's source scanner reads raw text and cannot resolve runtime values, those utilities were never emitted, causing modals, overlays, and banners to lose their `position: fixed` and stacking context.

- All eight affected files replace `` z-[${CONST}] `` template interpolations with literal arbitrary classes (e.g. `z-[160]`, `z-[170]`, `z-[200]`), each pinned back to the source constant with a comment.
- Every literal value was verified against `packages/ui/src/lib/floating-layers.ts` — all six constants match exactly. No z-index values were changed; this is a pure CSS-emission fix with no runtime behavior changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure CSS emission fix with no runtime logic changes, all literal values verified against the floating-layers constants.

Every replaced literal was cross-checked against `packages/ui/src/lib/floating-layers.ts` and matches exactly. The change is contained to className strings; no component logic, API surface, or z-index scale values are altered. The PR author's repo-wide audit confirms no remaining template-interpolated z-index classes in the relevant packages.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/ui/dialog.tsx | Replaces Z_DIALOG_OVERLAY (160) and Z_DIALOG (170) template interpolations with literal z-[160]/z-[170]; adds a detailed comment explaining the Tailwind v4 scanner limitation. |
| packages/ui/src/components/ui/drawer-sheet.tsx | Same fix as dialog.tsx — Z_DIALOG_OVERLAY → z-[160], Z_DIALOG → z-[170] for the sheet overlay and content. |
| packages/ui/src/components/ui/tooltip-extended.tsx | Z_OVERLAY (200) interpolation replaced with literal z-[200] on the IconTooltip content div. |
| packages/ui/src/components/composites/chat/chat-conversation-item.tsx | Z_OVERLAY (200) interpolation replaced with literal z-[200] on the TooltipContent className. |
| packages/ui/src/components/shell/ShellOverlays.tsx | Z_SHELL_OVERLAY (10000) replaced with literal z-[10000] in the actionNotice toast; template literal retained only for the conditional tone classes, which is correct. |
| packages/ui/src/components/shell/SystemWarningBanner.tsx | Z_SYSTEM_BANNER (9998) replaced with literal z-[9998]. |
| packages/ui/src/components/shell/ConnectionFailedBanner.tsx | Z_SYSTEM_CRITICAL (9999) replaced with literal z-[9999] on both reconnecting and disconnected banner states. |
| packages/ui/src/components/shell/RestartBanner.tsx | Z_SYSTEM_BANNER (9998) replaced with literal z-[9998] on the restart notification div. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["floating-layers.ts\n(source of truth)"] -->|"Z_DIALOG_OVERLAY = 160\nZ_DIALOG = 170"| B["dialog.tsx\ndrawer-sheet.tsx"]
    A -->|"Z_OVERLAY = 200"| C["tooltip-extended.tsx\nchat-conversation-item.tsx"]
    A -->|"Z_SYSTEM_BANNER = 9998"| D["SystemWarningBanner.tsx\nRestartBanner.tsx"]
    A -->|"Z_SYSTEM_CRITICAL = 9999"| E["ConnectionFailedBanner.tsx"]
    A -->|"Z_SHELL_OVERLAY = 10000"| F["ShellOverlays.tsx"]
    B -->|"Before: z-[${Z_DIALOG_OVERLAY}]\n❌ Tailwind v4 scanner misses"| G["CSS bundle missing rule\n→ no fixed positioning\n→ no stacking context"]
    B -->|"After: z-[160] literal\n✅ Scanner emits utility"| H["CSS rule emitted\n→ overlay/content render correctly"]
    C -->|"Same fix"| H
    D -->|"Same fix"| H
    E -->|"Same fix"| H
    F -->|"Same fix"| H
```

<sub>Reviews (2): Last reviewed commit: ["fix(ui): inline z-index arbitrary classe..."](https://github.com/elizaos/eliza/commit/af9ab871cad4e13cecc88b0288731e776dd727a0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32903027)</sub>

<!-- /greptile_comment -->