### PR TITLE
refactor(cloud-shared): managed services enqueue jobs instead of inline shutdown()

### DIFF
--- a/packages/cloud-shared/src/lib/services/active-billing.ts
+++ b/packages/cloud-shared/src/lib/services/active-billing.ts
@@ -6,7 +6,7 @@ import { creditTransactions } from "../../db/schemas/credit-transactions";
 import { AGENT_PRICING } from "../constants/agent-pricing";
 import { calculateDailyContainerCost } from "../constants/pricing";
 import { logger } from "../utils/logger";
-import { elizaSandboxService } from "./eliza-sandbox";
+import { provisioningJobService } from "./provisioning-jobs";
 
 export type BillableResourceType = "container" | "agent_sandbox";
 export type BillableInterval = "day" | "hour";
@@ -348,6 +348,7 @@ class ActiveBillingService {
         const infrastructureAction = await cancelAgentInfrastructure(
           agent.id,
           organizationId,
+          agent.user_id,
           mode,
         );
         const unitPrice =
@@ -483,30 +484,38 @@ async function cancelContainerInfrastructure(
 async function cancelAgentInfrastructure(
   agentId: string,
   organizationId: string,
+  userId: string,
   mode: "stop" | "delete",
 ): Promise<InfrastructureCancellationAction> {
   try {
-    const result =
-      mode === "delete"
-        ? await elizaSandboxService.deleteAgent(agentId, organizationId)
-        : await elizaSandboxService.shutdown(agentId, organizationId);
-
-    if (!result.success) {
-      return {
-        attempted: true,
-        status: "failed",
-        message: result.error ?? "Agent lifecycle operation failed.",
-        error: result.error,
-      };
+    // Both the delete and stop paths SSH into the assigned core. They
+    // can't run inline here (this service is consumed from Cloudflare
+    // Workers, which have no SSH). Enqueue the appropriate job; the
+    // orchestrator daemon executes it. Status values are kept on the
+    // "outcome will be" semantics so the billing flow can finalize
+    // the subscription without waiting on the daemon.
+    if (mode === "delete") {
+      await provisioningJobService.enqueueAgentDeleteOnce({
+        agentId,
+        organizationId,
+        userId,
+      });
+    } else {
+      await provisioningJobService.enqueueAgentSuspendOnce({
+        agentId,
+        organizationId,
+        userId,
+      });
     }
+    void provisioningJobService.triggerImmediate().catch(() => {});
 
     return {
       attempted: true,
       status: mode === "delete" ? "deleted" : "stopped",
       message:
         mode === "delete"
-          ? "Managed agent runtime, database, and control-plane row were deleted."
-          : "Managed agent runtime was shut down with a pre-shutdown snapshot when available.",
+          ? "Managed agent deletion queued; the orchestrator will tear down runtime, database, and control-plane row."
+          : "Managed agent stop queued; the orchestrator will shut down the container with a pre-shutdown snapshot when available.",
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/cloud-shared/src/lib/services/agent-managed-discord.ts
+++ b/packages/cloud-shared/src/lib/services/agent-managed-discord.ts
@@ -8,7 +8,7 @@ import {
   withManagedAgentDiscordGateway,
   withoutManagedAgentDiscordBinding,
 } from "./eliza-agent-config";
-import { elizaSandboxService } from "./eliza-sandbox";
+import { provisioningJobService } from "./provisioning-jobs";
 
 const DISCORD_OWNER_USER_IDS_ENV_KEY = "AGENT_DISCORD_OWNER_USER_IDS_JSON";
 export const DISCORD_DEVELOPER_PORTAL_URL = "https://discord.com/developers/applications";
@@ -223,17 +223,18 @@ export class ManagedAgentDiscordService {
       agent_config: nextConfig,
     });
 
+    // Restart is asynchronous via the job queue (Workers can't SSH the
+    // cores). `restarted: true` means a restart job was enqueued — the
+    // daemon picks it up, stops the container, and re-provisions with
+    // the freshly-persisted agent_config above.
     let restarted = false;
     if (sandbox.status === "running") {
-      const shutdown = await elizaSandboxService.shutdown(sandbox.id, params.organizationId);
-      if (!shutdown.success) {
-        throw new Error(shutdown.error || "Failed to restart agent");
-      }
-
-      const provision = await elizaSandboxService.provision(sandbox.id, params.organizationId);
-      if (!provision.success) {
-        throw new Error(provision.error || "Failed to restart agent");
-      }
+      await provisioningJobService.enqueueAgentRestartOnce({
+        agentId: sandbox.id,
+        organizationId: params.organizationId,
+        userId: sandbox.user_id,
+      });
+      void provisioningJobService.triggerImmediate().catch(() => {});
       restarted = true;
     }
 
@@ -275,17 +276,18 @@ export class ManagedAgentDiscordService {
       agent_config: nextConfig,
     });
 
+    // Restart is asynchronous via the job queue (Workers can't SSH the
+    // cores). `restarted: true` means a restart job was enqueued — the
+    // daemon picks it up, stops the container, and re-provisions with
+    // the freshly-persisted agent_config above.
     let restarted = false;
     if (sandbox.status === "running") {
-      const shutdown = await elizaSandboxService.shutdown(sandbox.id, params.organizationId);
-      if (!shutdown.success) {
-        throw new Error(shutdown.error || "Failed to restart agent");
-      }
-
-      const provision = await elizaSandboxService.provision(sandbox.id, params.organizationId);
-      if (!provision.success) {
-        throw new Error(provision.error || "Failed to restart agent");
-      }
+      await provisioningJobService.enqueueAgentRestartOnce({
+        agentId: sandbox.id,
+        organizationId: params.organizationId,
+        userId: sandbox.user_id,
+      });
+      void provisioningJobService.triggerImmediate().catch(() => {});
       restarted = true;
     }
 

--- a/packages/cloud-shared/src/lib/services/agent-managed-github.ts
+++ b/packages/cloud-shared/src/lib/services/agent-managed-github.ts
@@ -7,8 +7,8 @@ import {
   withManagedAgentGithubBinding,
   withoutManagedAgentGithubBinding,
 } from "./eliza-agent-config";
-import { elizaSandboxService } from "./eliza-sandbox";
 import { oauthService } from "./oauth";
+import { provisioningJobService } from "./provisioning-jobs";
 
 export interface ManagedAgentGithubStatus {
   configured: boolean;
@@ -96,17 +96,18 @@ export class ManagedAgentGithubService {
       agent_config: nextConfig,
     });
 
+    // Restart is asynchronous via the job queue (Workers can't SSH the
+    // cores). `restarted: true` means a restart job was enqueued — the
+    // daemon picks it up, stops the container, and re-provisions with
+    // the freshly-persisted agent_config above.
     let restarted = false;
     if (sandbox.status === "running") {
-      const shutdown = await elizaSandboxService.shutdown(sandbox.id, params.organizationId);
-      if (!shutdown.success) {
-        throw new Error(shutdown.error || "Failed to restart agent");
-      }
-
-      const provision = await elizaSandboxService.provision(sandbox.id, params.organizationId);
-      if (!provision.success) {
-        throw new Error(provision.error || "Failed to restart agent");
-      }
+      await provisioningJobService.enqueueAgentRestartOnce({
+        agentId: sandbox.id,
+        organizationId: params.organizationId,
+        userId: sandbox.user_id,
+      });
+      void provisioningJobService.triggerImmediate().catch(() => {});
       restarted = true;
     }
 
@@ -159,17 +160,18 @@ export class ManagedAgentGithubService {
       agent_config: nextConfig,
     });
 
+    // Restart is asynchronous via the job queue (Workers can't SSH the
+    // cores). `restarted: true` means a restart job was enqueued — the
+    // daemon picks it up, stops the container, and re-provisions with
+    // the freshly-persisted agent_config above.
     let restarted = false;
     if (sandbox.status === "running") {
-      const shutdown = await elizaSandboxService.shutdown(sandbox.id, params.organizationId);
-      if (!shutdown.success) {
-        throw new Error(shutdown.error || "Failed to restart agent");
-      }
-
-      const provision = await elizaSandboxService.provision(sandbox.id, params.organizationId);
-      if (!provision.success) {
-        throw new Error(provision.error || "Failed to restart agent");
-      }
+      await provisioningJobService.enqueueAgentRestartOnce({
+        agentId: sandbox.id,
+        organizationId: params.organizationId,
+        userId: sandbox.user_id,
+      });
+      void provisioningJobService.triggerImmediate().catch(() => {});
       restarted = true;
     }
 


### PR DESCRIPTION
**Stacks on #7810.** Targets \`feat/agent-lifecycle-via-job-queue\` rather than \`develop\` because it consumes \`enqueueAgent{Restart,Suspend,Delete}Once\` which only exist on that branch. Once #7810 merges, this PR retargets to \`develop\` automatically.

## Why

Four services consumed from Cloudflare Worker routes still called \`elizaSandboxService.shutdown()\` / \`deleteAgent()\` / \`provision()\` inline:
- \`agent-managed-github.connectAgent\` / \`disconnectAgent\`
- \`agent-managed-discord.connectAgent\` / \`disconnectAgent\`
- \`active-billing.cancelAgentInfrastructure\` (stop + delete branches)

Those calls SSH the cores. **Workers can't SSH, so the calls silently no-op'd**:
- GitHub/Discord (dis)connect was supposed to restart the agent with the new config — DB updated, container kept running with old config
- Billing auto-cancel (low credit / subscription expired) was supposed to stop or delete the container — billing marked the subscription as cancelled while the container kept burning RAM

## What changed

Route through the same job queue that #7810 set up for the lifecycle routes:

| Caller | Before | After |
|---|---|---|
| github/discord (dis)connect | \`shutdown() + provision()\` inline | \`enqueueAgentRestartOnce\` |
| billing stop | \`shutdown()\` inline | \`enqueueAgentSuspendOnce\` |
| billing delete | \`deleteAgent()\` inline | \`enqueueAgentDeleteOnce\` |

\`restarted: true\` on the github/discord methods now means \"restart job enqueued\" rather than \"restart completed sync\". Cleaner than the previous \"restart pretended to complete but didn't\" semantics.

\`active-billing.cancelAgentInfrastructure\` gains a \`userId\` parameter because the enqueue methods need it for job ownership. The caller already had the agent row in scope, so the wiring is straightforward.

## Skipped on purpose

\`eliza-managed-launch.refreshSandboxEnvironment\` still calls \`shutdown()\` inline. Its post-shutdown code reads the fresh sandbox state (\`apiBase\` URL) to return the launch URL to the user. An async restart would invalidate that URL before the function returns, breaking the launch flow's UX guarantee. Needs a larger redesign (route returns 202 + jobId, frontend polls until the new bridge URL lands, then renders the launch).

## Test plan

- [ ] Link GitHub OAuth to a running managed agent → DB shows updated \`agent_config\`, a new \`agent_restart\` job row appears, daemon picks it up, container actually restarts with new env (visible via \`docker logs\`).
- [ ] Same for Discord link/unlink.
- [ ] Drain an org's credits below threshold → billing auto-cancel runs → \`agent_suspend\` or \`agent_delete\` job appears, daemon picks it up, container actually stops/disappears.
- [ ] Status enum unchanged — billing flow continues to mark subscriptions as \"deleted\" / \"stopped\" without waiting on the daemon (existing semantics: the job is queued, billing finalizes optimistically).

## Follow-up

- Migrate \`eliza-managed-launch.refreshSandboxEnvironment\` (needs frontend polling for the launch URL).
- Frontend dashboards that displayed \"Agent restarted\" toasts after (dis)connect should switch to poller-tracked status (the same useJobPoller already used elsewhere). Tracked alongside #7813.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces inline `elizaSandboxService.shutdown()` / `deleteAgent()` / `provision()` calls in three cloud-shared services with async job-queue operations (`enqueueAgentRestartOnce`, `enqueueAgentSuspendOnce`, `enqueueAgentDeleteOnce`) so that SSH-dependent work is offloaded to the orchestrator daemon rather than silently no-op-ing inside a Cloudflare Worker.

- **`active-billing.ts`**: `cancelAgentInfrastructure` now enqueues suspend/delete jobs instead of calling SSH-backed methods inline; adds a `userId` parameter threaded from the agent row at the call site.
- **`agent-managed-discord.ts` / `agent-managed-github.ts`**: `connectAgent` / `disconnectAgent` replace the two-step `shutdown + provision` sequence with `enqueueAgentRestartOnce`; the `restarted` return value now means \"restart job enqueued\" rather than \"restart completed synchronously\".

<h3>Confidence Score: 3/5</h3>

The billing stop path writes status='stopped' to the DB before the daemon actually stops the container; whether this causes a silent container leak depends on whether executeSuspend re-checks DB status before issuing the SSH stop.

The GitHub/Discord and billing delete paths are a clean and well-structured improvement. The billing suspend path has a concrete timing concern: cancelResource optimistically sets agentSandboxes.status = 'stopped' immediately after enqueuing the job, while the container is still running. If elizaSandboxService.executeSuspend guards on the DB row showing 'running' before issuing the SSH stop, it would silently skip the actual container stop — leaving containers alive indefinitely after billing is suspended.

active-billing.ts warrants a closer look at the interaction between the optimistic status='stopped' DB write and the daemon's executeSuspend implementation.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/cloud-shared/src/lib/services/active-billing.ts | Replaces inline shutdown/delete with job queue enqueue; introduces a timing issue where `agentSandboxes.status` is set to "stopped" before the daemon actually stops the container, which may cause the daemon's `executeSuspend` to skip the SSH stop if it reads DB status first. |
| packages/cloud-shared/src/lib/services/agent-managed-discord.ts | Replaces direct shutdown+provision sequence with enqueueAgentRestartOnce; `restarted: true` is now returned even when an existing in-progress job is reused, so back-to-back config changes in a short window may not apply the latest config. |
| packages/cloud-shared/src/lib/services/agent-managed-github.ts | Same restart-via-job-queue refactor as the Discord service; same idempotency race condition applies for back-to-back connects/disconnects while a restart job is already in progress. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant Worker as CF Worker
    participant DB as agentSandboxes DB
    participant Queue as Job Queue
    participant Daemon as Orchestrator Daemon

    Note over User,Daemon: GitHub / Discord connect or disconnect
    User->>Worker: connectAgent / disconnectAgent
    Worker->>DB: UPDATE agent_config (new binding)
    Worker->>Queue: enqueueAgentRestartOnce (pending/in_progress dedup)
    Worker-->>Daemon: triggerImmediate (fire-and-forget)
    Worker-->>User: "{ restarted: true }"
    Daemon->>Queue: claim agent_restart job
    Daemon->>Daemon: SSH stop → provision with latest agent_config

    Note over User,Daemon: Billing auto-cancel — stop mode
    Worker->>Queue: enqueueAgentSuspendOnce
    Worker->>DB: "SET status=stopped, billing_status=suspended (optimistic)"
    Worker-->>Daemon: triggerImmediate (fire-and-forget)
    Daemon->>Queue: claim agent_suspend job
    Daemon->>Daemon: "SSH docker stop (may see status=stopped in DB already)"

    Note over User,Daemon: Billing auto-cancel — delete mode
    Worker->>Queue: enqueueAgentDeleteOnce
    Queue->>DB: "SET status=deletion_pending (inside transaction)"
    Worker-->>Daemon: triggerImmediate (fire-and-forget)
    Daemon->>Queue: claim agent_delete job
    Daemon->>Daemon: SSH docker stop → DELETE row
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cloud-shared/src/lib/services/active-billing.ts`, line 388-403 ([link](https://github.com/elizaos/eliza/blob/d681e56debc0c28b37f1bb9aff43f14c16127145/packages/cloud-shared/src/lib/services/active-billing.ts#L388-L403)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **Premature `status="stopped"` write before daemon executes the suspend**

   `cancelAgentInfrastructure` now returns `{ status: "stopped" }` optimistically right after enqueueing the job. `cancelResource` then immediately writes `status = "stopped"` to `agentSandboxes` (line 391) while the container is still running. If `elizaSandboxService.executeSuspend` (called by the daemon) reads `sandbox.status` from the DB to determine whether it should issue the SSH stop, it will find `"stopped"` and bail early — leaving the container alive indefinitely with billing suspended. The symptom is silent resource leakage: credits stop flowing but cores keep burning compute.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["refactor(cloud-shared): managed services..."](https://github.com/elizaos/eliza/commit/d681e56debc0c28b37f1bb9aff43f14c16127145) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32907399)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->