### PR TITLE
feat(app-core): connector registry OWNER+AGENT accounts schema + audit

### DIFF
--- a/packages/app-core/src/registry/connector-accounts.test.ts
+++ b/packages/app-core/src/registry/connector-accounts.test.ts
@@ -1,0 +1,151 @@
+// Tests for the OWNER+AGENT connector schema extension and the
+// `normalizeConnectorAuth` legacy-auto-map. Backwards compat: existing
+// manifests that only declare `auth` must keep loading and end up with a
+// populated `accounts.agent`.
+
+import { describe, expect, it } from "vitest";
+import { loadRegistryFromRawEntries, normalizeConnectorAuth } from "./loader";
+import {
+  type AccountConfig,
+  type ConnectorEntry,
+  connectorEntrySchema,
+} from "./schema";
+
+const baseConnector = {
+  id: "test-connector",
+  name: "Test Connector",
+  kind: "connector" as const,
+  subtype: "messaging" as const,
+  source: "bundled" as const,
+  tags: [],
+  config: {},
+  render: {
+    visible: true,
+    pinTo: [],
+    style: "card" as const,
+    group: "messaging",
+    actions: [],
+  },
+  resources: {},
+  dependsOn: [],
+};
+
+describe("connectorEntrySchema accounts field", () => {
+  it("accepts an entry with no accounts block", () => {
+    const parsed = connectorEntrySchema.parse(baseConnector);
+    expect(parsed.accounts).toBeUndefined();
+  });
+
+  it("accepts an entry with both owner and agent sides", () => {
+    const parsed = connectorEntrySchema.parse({
+      ...baseConnector,
+      accounts: {
+        owner: {
+          supported: true,
+          authKind: "oauth-cloud",
+          credentialKeys: ["MY_OWNER_TOKEN"],
+          osSupport: ["darwin", "win32"],
+        },
+        agent: {
+          supported: true,
+          authKind: "api-key",
+          credentialKeys: ["MY_AGENT_TOKEN"],
+        },
+      },
+    });
+    expect(parsed.accounts?.owner?.authKind).toBe("oauth-cloud");
+    expect(parsed.accounts?.agent?.authKind).toBe("api-key");
+    expect(parsed.accounts?.owner?.osSupport).toEqual(["darwin", "win32"]);
+  });
+
+  it("rejects an unknown authKind", () => {
+    const result = connectorEntrySchema.safeParse({
+      ...baseConnector,
+      accounts: {
+        agent: { supported: true, authKind: "not-a-real-kind" },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("defaults credentialKeys to [] when omitted", () => {
+    const parsed = connectorEntrySchema.parse({
+      ...baseConnector,
+      accounts: {
+        agent: { supported: true, authKind: "none" },
+      },
+    });
+    expect(parsed.accounts?.agent?.credentialKeys).toEqual([]);
+  });
+});
+
+describe("normalizeConnectorAuth (legacy auth → accounts.agent)", () => {
+  it("maps legacy oauth auth to accounts.agent with oauth-cloud", () => {
+    const entry = connectorEntrySchema.parse({
+      ...baseConnector,
+      auth: { kind: "oauth", credentialKeys: ["FOO_TOKEN"] },
+    });
+    const normalized = normalizeConnectorAuth(entry);
+    expect(normalized.accounts?.agent).toEqual<AccountConfig>({
+      supported: true,
+      authKind: "oauth-cloud",
+      credentialKeys: ["FOO_TOKEN"],
+    });
+  });
+
+  it("maps legacy token auth to accounts.agent with api-key", () => {
+    const entry = connectorEntrySchema.parse({
+      ...baseConnector,
+      auth: { kind: "token", credentialKeys: ["BAR_TOKEN"] },
+    });
+    const normalized = normalizeConnectorAuth(entry);
+    expect(normalized.accounts?.agent?.authKind).toBe("api-key");
+    expect(normalized.accounts?.agent?.credentialKeys).toEqual(["BAR_TOKEN"]);
+  });
+
+  it("maps legacy none auth to accounts.agent with none", () => {
+    const entry = connectorEntrySchema.parse({
+      ...baseConnector,
+      auth: { kind: "none", credentialKeys: [] },
+    });
+    const normalized = normalizeConnectorAuth(entry);
+    expect(normalized.accounts?.agent?.authKind).toBe("none");
+  });
+
+  it("leaves explicit accounts untouched even when auth is also declared", () => {
+    const entry = connectorEntrySchema.parse({
+      ...baseConnector,
+      auth: { kind: "oauth", credentialKeys: ["FOO_TOKEN"] },
+      accounts: {
+        owner: { supported: true, authKind: "local-app" },
+      },
+    });
+    const normalized = normalizeConnectorAuth(entry);
+    expect(normalized.accounts?.owner?.authKind).toBe("local-app");
+    expect(normalized.accounts?.agent).toBeUndefined();
+  });
+
+  it("is a no-op when neither auth nor accounts is declared", () => {
+    const entry = connectorEntrySchema.parse(baseConnector);
+    const normalized = normalizeConnectorAuth(entry);
+    expect(normalized.accounts).toBeUndefined();
+  });
+});
+
+describe("loadRegistryFromRawEntries applies normalizeConnectorAuth", () => {
+  it("populates accounts.agent for legacy-auth connectors at load time", () => {
+    const registry = loadRegistryFromRawEntries([
+      {
+        file: "test/legacy.json",
+        data: {
+          ...baseConnector,
+          id: "legacy-connector",
+          auth: { kind: "oauth", credentialKeys: ["LEGACY_TOKEN"] },
+        },
+      },
+    ]);
+    const entry = registry.byId.get("legacy-connector") as ConnectorEntry;
+    expect(entry.accounts?.agent?.authKind).toBe("oauth-cloud");
+    expect(entry.accounts?.agent?.credentialKeys).toEqual(["LEGACY_TOKEN"]);
+  });
+});

--- a/packages/app-core/src/registry/index.ts
+++ b/packages/app-core/src/registry/index.ts
@@ -18,6 +18,7 @@ export {
   indexEntries,
   type LoadedRegistry,
   mergeWithRuntime,
+  normalizeConnectorAuth,
   type RegistryValidationError,
 } from "./loader.js";
 export * from "./schema.js";

--- a/packages/app-core/src/registry/loader.ts
+++ b/packages/app-core/src/registry/loader.ts
@@ -8,6 +8,7 @@
 // running process.
 
 import {
+  type AccountAuthKind,
   type AppEntry,
   type ConnectorEntry,
   type PluginEntry,
@@ -52,7 +53,10 @@ export function loadRegistryFromRawEntries(raws: RawEntry[]): LoadedRegistry {
       throw new RegistryValidationError(file, parsed.error);
     }
 
-    const entry = parsed.data;
+    const entry =
+      parsed.data.kind === "connector"
+        ? normalizeConnectorAuth(parsed.data)
+        : parsed.data;
     if (seenIds.has(entry.id)) {
       throw new RegistryValidationError(
         file,
@@ -64,6 +68,33 @@ export function loadRegistryFromRawEntries(raws: RawEntry[]): LoadedRegistry {
   }
 
   return indexEntries(all);
+}
+
+// Legacy `auth` → `accounts.agent` auto-mapping. Connector manifests that
+// only declared `auth` keep working without edits — the resulting `accounts`
+// shape lets the UI render a single agent section (backwards compatible) and
+// gives downstream code a uniform field to read. When a manifest already
+// declares `accounts`, the legacy `auth` is left untouched.
+export function normalizeConnectorAuth(entry: ConnectorEntry): ConnectorEntry {
+  if (!entry.auth || entry.accounts) {
+    return entry;
+  }
+  const authKind: AccountAuthKind =
+    entry.auth.kind === "oauth"
+      ? "oauth-cloud"
+      : entry.auth.kind === "none"
+        ? "none"
+        : "api-key";
+  return {
+    ...entry,
+    accounts: {
+      agent: {
+        supported: true,
+        authKind,
+        credentialKeys: entry.auth.credentialKeys,
+      },
+    },
+  };
 }
 
 export function indexEntries(entries: RegistryEntry[]): LoadedRegistry {

--- a/packages/app-core/src/registry/schema.ts
+++ b/packages/app-core/src/registry/schema.ts
@@ -273,6 +273,39 @@ export const pluginEntrySchema = z.object({
   subtype: pluginSubtype,
 });
 
+// ---------------------------------------------------------------------------
+// Per-account auth config. Connectors can declare an OWNER side (the user's
+// own platform account — e.g. user's Gmail, user's Discord) and/or an AGENT
+// side (a separate identity the agent operates — e.g. a bot Gmail, a Discord
+// bot). Auth method, credential keys, and OS support are independent per side.
+//
+// Purely additive over `auth`. When a manifest only declares `auth`, the
+// loader auto-maps it to `accounts.agent` (see loader.ts:normalizeConnectorAuth).
+// ---------------------------------------------------------------------------
+
+const accountAuthKind = z.enum([
+  "oauth-cloud", // "Log in with X" routed through Eliza Cloud
+  "oauth-local", // local-only OAuth (e.g. per-homeserver Matrix)
+  "qr", // QR-pairing (WhatsApp Baileys, Signal device-link)
+  "local-app", // local-app inspection (Discord-CDP, iMessage chat.db)
+  "browser-extension", // browser companion
+  "api-key", // manual paste of bot token / API key
+  "none",
+]);
+
+const accountOsSupport = z.enum(["darwin", "win32", "linux"]);
+
+export const accountConfigSchema = z.object({
+  supported: z.boolean().default(true),
+  authKind: accountAuthKind,
+  credentialKeys: z.array(z.string()).default([]),
+  osSupport: z.array(accountOsSupport).optional(),
+  notes: z.string().optional(),
+});
+
+export type AccountConfig = z.infer<typeof accountConfigSchema>;
+export type AccountAuthKind = z.infer<typeof accountAuthKind>;
+
 export const connectorEntrySchema = z.object({
   ...commonFields,
   kind: z.literal("connector"),
@@ -281,6 +314,12 @@ export const connectorEntrySchema = z.object({
     .object({
       kind: z.enum(["token", "oauth", "credentials", "none"]),
       credentialKeys: z.array(z.string()).default([]),
+    })
+    .optional(),
+  accounts: z
+    .object({
+      owner: accountConfigSchema.optional(),
+      agent: accountConfigSchema.optional(),
     })
     .optional(),
 });

--- a/packages/docs/connectors/owner-vs-agent-audit.md
+++ b/packages/docs/connectors/owner-vs-agent-audit.md
@@ -1,0 +1,115 @@
+# OWNER vs AGENT — Connector Audit
+
+Every connector in elizaOS can — in principle — be configured against two
+distinct platform accounts:
+
+- **OWNER** — the user's own account (e.g. the user's Gmail, the user's
+  Discord profile, the user's iMessage). Lets the agent act on behalf of the
+  user: read their inbox, see their DMs, forward an email to itself.
+- **AGENT** — a separate identity the agent operates as itself (e.g. a
+  dedicated agent Gmail address, a Discord bot, a Slack app). Acts under its
+  own name and is subject to the platform's bot/app rules.
+
+End-state behavior: the user forwards an email from their OWNER inbox to the
+agent's AGENT inbox, and the agent receives it and responds — both sides
+connected on the same platform.
+
+The OWNER role is well-defined elsewhere: it is the entity bound to the
+device during onboarding and gates privileged runtime actions (see
+[`agents/owner-role.md`](../agents/owner-role.md)). This document covers the
+**connector-level** OWNER/AGENT distinction — auth methods, platform
+constraints, and the per-connector status of OWNER/AGENT support today.
+
+Where the platform offers proper user OAuth (X, Google, Slack, GitHub, …),
+**Eliza Cloud OAuth is the default "Log in with X" path**. Manual API-key
+paste is the last-resort fallback. Where the platform forbids user-account
+automation (Discord, Instagram personal, WeChat personal), OWNER mode either
+relies on local-app inspection hacks (Discord CDP, iMessage `chat.db`) or is
+flagged platform-impossible.
+
+---
+
+## Per-connector matrix
+
+Legend: ✅ wired · ⚠️ partial / hardcoded role · ❌ missing · 🚫
+platform-impossible
+
+| Connector | AGENT today | OWNER today | Cloud OAuth | OWNER feasible | Critical gap |
+|---|---|---|---|---|---|
+| **Discord** (`plugin-discord`, `plugin-discord-local`) | ✅ bot token | ⚠️ macOS RPC+AppleScript + macOS CDP relaunch (port 9224) | ❌ bot-install only, NOT in generic OAuth provider registry | ⚠️ macOS today; Windows port unverified | Windows CDP port + add user-login OAuth route |
+| **Telegram** | ✅ bot token | ✅ `my.telegram.org` + StringSession | 🚫 Telegram has no third-party OAuth | ✅ | Session health check; plaintext session storage; account-ban risk on aggressive use |
+| **WhatsApp** | ✅ Cloud API token | ✅ Baileys QR pairing | ❌ Meta Graph OAuth not registered | ✅ | Cloud API + Baileys can't coexist per character; no TOS disclaimer |
+| **iMessage / BlueBubbles** | 🚫 | ✅ macOS `chat.db` + BlueBubbles relay | 🚫 Apple offers no third-party OAuth | ⚠️ mac-only by definition | Document the "Windows operator + remote Mac BlueBubbles" setup |
+| **Slack** | ✅ `xoxb-` bot token + cloud OAuth | ⚠️ `SLACK_USER_TOKEN` env recognized but cloud OAuth requests **bot scopes only**; `authed_user` from response not consumed | ⚠️ generic-routes, bot-only scopes | ✅ | Add user scopes (`chat:write:user`, `search:read`, `files:read`, `users:read`) and hydrate user token from OAuth response |
+| **X / Twitter** | ✅ OAuth1.0a app + OAuth2 PKCE | ✅ OAuth2 PKCE end-to-end (`connectionRole: "agent"|"owner"` already on callback) | ✅ both flows wired | ✅ | Frontend never passes `connectionRole`; OAuth2 refresh hangs interactively in headless agents |
+| **Google** (Gmail/Calendar/Drive/Chat) | ⚠️ user OAuth only (no service account) | ✅ OAuth2 + PKCE + `offline_access` + `prompt=consent` | ✅ 7 scopes wired in registry | ✅ | Two role representations coexist (legacy `agentGoogleSide` + new `connectionRole`); no scope-revocation detection |
+| **Microsoft** (Outlook/Calendar) | ⚠️ delegated only (no client-credentials) | ✅ OAuth2 against `/consumers/` only | ⚠️ personal accounts only — work/school accounts excluded; no OneDrive/Teams scopes | ⚠️ personal only | Switch tenant to `/common/`; add `Files.ReadWrite.All` and Teams scopes |
+| **GitHub** | ⚠️ PAT only (no GitHub App) | ✅ OAuth2 user-scope (role `OWNER` hardcoded) | ✅ user-scoped OAuth | ✅ | GitHub Apps (cleanest AGENT path) unimplemented; `refresh_token` captured but never rotated |
+| **LinkedIn** | ❌ no plugin | ⚠️ cloud OAuth with `w_member_social` scope (approval status unknown) | ✅ cloud-only, no plugin | ⚠️ approval-gated | Add agent-side plugin; verify LinkedIn app review approval |
+| **Instagram / Meta** | ⚠️ username/password (TOS-violating) | ❌ | ❌ Meta absent from provider registry | ⚠️ Business accounts only | Add Meta OAuth provider; declare personal Instagram out of scope |
+| **Signal** | ⚠️ signal-cli only; `role` hardcoded `"OWNER"` | ⚠️ device-link to user's primary phone; loss of primary phone disconnects the agent | 🚫 Signal has no OAuth | ⚠️ tied to user's primary device | AGENT mode via separate bot phone number; auto-recover on daemon crash |
+| **Matrix** | ✅ access token (any homeserver) | ✅ access token (same shape) | 🚫 per-homeserver, no central OAuth | ✅ | All accounts hardcoded `role: "OWNER"`; no password-login UI; full-sync only |
+| **Email (IMAP/SMTP)** | ❌ no plugin | ❌ | n/a | ❌ | Plugin doesn't exist; cloud has outbound-only SMTP. Self-hosted / Fastmail / ProtonMail users unsupported |
+| **Bluesky** | ✅ app password | ✅ app password (same shape) | 🚫 self-custodied | ✅ | `connector-account-provider.ts` hardcodes `role: "OWNER"` |
+| **Farcaster** | ✅ Neynar signer | ✅ Neynar signer | 🚫 (Neynar API key gated) | ✅ | Hardcoded `role: "OWNER"`; centralized on Neynar |
+| **Nostr** | ✅ nsec | ✅ nsec | 🚫 | ✅ | Hardcoded `role: "OWNER"` |
+| **WeChat** | ✅ proxy API (third-party) | 🚫 personal WeChat TOS-forbidden | ❌ not in registry | 🚫 | Proxy supply-chain risk; document TOS posture |
+| **Feishu / Lark** | ✅ app credentials | ❌ user delegation not wired | ❌ not in registry | ⚠️ | Add Feishu OAuth provider (user delegation exists) |
+| **Line** | ✅ bot token | ❌ LINE Login imported but unused | ❌ not in registry | ⚠️ | Wire LINE Login OAuth — already in dependencies |
+| **KakaoTalk** | ❌ no plugin | ❌ | ❌ | n/a | Add plugin if Asia-market deployments matter |
+| **Linear** | ✅ API key + OAuth | ✅ OAuth (cloud-wired in plugin) | ✅ | ✅ | No `refresh_token` handling; no OWNER/AGENT split (hardcoded `"OWNER"`) |
+| **Notion** | ❌ no plugin | ⚠️ cloud-only via OAuth | ✅ wired in registry | ✅ | No plugin; user info path workspace-scoped |
+| **Asana** | ❌ no plugin | ⚠️ cloud-only OAuth | ✅ wired | ✅ | No plugin; no PAT path |
+| **Jira** | ❌ no plugin | ⚠️ cloud-only OAuth (`auth.atlassian.com` hardcoded) | ✅ wired | ⚠️ cloud Atlassian only | No plugin; self-hosted Jira unsupported; no API-token path |
+| **HubSpot / Salesforce / Airtable / Dropbox** | ❌ no plugins | ⚠️ cloud OAuth only | ✅ all four wired (Salesforce/Airtable use PKCE) | ✅ | No plugin code consuming these tokens |
+| **Zoom** | ❌ no plugin | ❌ | ✅ in registry | ⚠️ | Plugin missing |
+| **Calendly** | ✅ OAuth + PAT | ✅ OAuth (role hardcoded `"OWNER"`) | ✅ | ✅ | No refresh-token; no AGENT path |
+| **Twilio** | ✅ Account SID + Auth Token (LifeOps-only) | ✅ same (subaccounts possible but unrouted) | n/a (api_key) | ✅ | No multi-account routing; no ConnectorAccountManager integration |
+| **Shopify** | ✅ OAuth per-store | ✅ OAuth per-store | ❌ not in registry (plugin-owned OAuth) | ⚠️ | Hardcoded `role: "OWNER"`; no staff-account / AGENT delegation |
+| **Duffel** | ✅ API key (LifeOps-only) | n/a | n/a | n/a | Single integration key; read-only |
+
+---
+
+## Cross-cutting findings
+
+- **The data model already supports OWNER+AGENT.** Cloud OAuth tracks
+  `connectionRole: "OWNER" | "AGENT" | "TEAM"` in `source_context` of the
+  `platform_credentials` table. What's missing is **plugin manifest
+  declarations of which sides are supported, UI partitioning of the two
+  sections, and removal of hardcoded `role: "OWNER"` in
+  `connector-account-provider.ts` across many plugins**.
+- **17 providers in the cloud OAuth registry**: google, microsoft, linear,
+  notion, github, slack, hubspot, asana, dropbox, salesforce, airtable, zoom,
+  jira, linkedin, twitter, twilio, blooio. Discord has separate
+  (bot-install-only) routes outside the generic registry.
+- **Many connector-account-providers hardcode `role: "OWNER"`** — Bluesky,
+  Farcaster, Nostr, Calendly, Shopify, Signal, Matrix, GitHub user, Linear,
+  Telegram. These need role parameterization to respect the OWNER vs AGENT
+  distinction the cloud has been carrying all along.
+- **Single hardcoded `redirect_uri` per provider** in cloud OAuth. Multi-instance
+  dev/prod cannot share the same OAuth client credentials — each instance
+  needs its own.
+- **Two role representations still coexist**: legacy
+  `agentGoogleSide: "owner"|"agent"` (lowercase) and new
+  `connectionRole: "OWNER"|"AGENT"|"TEAM"` (uppercase). A read-through
+  normalizer exists; a write-through migration is outstanding.
+
+## Schema entrypoint
+
+The connector registry expresses OWNER+AGENT as the optional
+`accounts: { owner?, agent? }` block on
+[`connectorEntrySchema`](../../../packages/app-core/src/registry/schema.ts).
+Each side declares its own `authKind`, `credentialKeys`, and optional
+`osSupport` hints. When a manifest only declares the legacy `auth` field,
+the loader auto-maps it to `accounts.agent` via `normalizeConnectorAuth()`,
+so existing manifests keep working without edits.
+
+## Out of scope here
+
+- LifeOps grant store changes (the LifeOps repository already carries
+  `side: "owner" | "agent"`).
+- Per-instance `redirect_uri` support for multi-tenant OAuth deployments.
+- Adding new cloud OAuth providers (Feishu, LINE Login, Meta, KakaoTalk).
+- Adding plugin shells for cloud-only providers (Notion, Asana, Jira,
+  HubSpot, Salesforce, Airtable, Dropbox, Zoom).
+- iMessage on non-mac — platform-impossible.


### PR DESCRIPTION
## Summary

Adds an optional `accounts: { owner?, agent? }` block to `connectorEntrySchema` so connectors can declare two independent identities:

- **OWNER** — the user's own platform account (e.g. their Gmail, their Discord)
- **AGENT** — a separate identity the agent operates as itself (e.g. a bot Gmail, a Discord bot)

Each side carries its own `authKind` (one of `oauth-cloud`, `oauth-local`, `qr`, `local-app`, `browser-extension`, `api-key`, `none`), its own `credentialKeys`, and optional `osSupport` hints. The cloud OAuth pipeline already distinguishes `connectionRole: "OWNER" | "AGENT" | "TEAM"` end-to-end — this PR brings the registry side of the contract in line with that, so plugin manifests can finally express which sides they support.

The change is **purely additive** over the existing `auth` field. A new `normalizeConnectorAuth()` helper auto-maps legacy `auth` to `accounts.agent` at registry load time — every existing manifest keeps loading without edits.

This is the foundation for follow-up work that surfaces OWNER+AGENT as two distinct sections in the connector setup UI and migrates pilot plugins (X, Google, Slack, Discord) to the new shape.

### Files changed

- \`packages/app-core/src/registry/schema.ts\` — new \`accountConfigSchema\`, \`accounts\` field on \`connectorEntrySchema\`, exported \`AccountConfig\` / \`AccountAuthKind\` types
- \`packages/app-core/src/registry/loader.ts\` — \`normalizeConnectorAuth()\` auto-maps legacy \`auth\` → \`accounts.agent\`, wired into \`loadRegistryFromRawEntries\`
- \`packages/app-core/src/registry/index.ts\` — re-exports the helper
- \`packages/app-core/src/registry/connector-accounts.test.ts\` — new (10 tests, covers parse, default credentialKeys, unknown authKind rejection, legacy auto-map for all three auth kinds, explicit-accounts pass-through, load-time application)
- \`packages/docs/connectors/owner-vs-agent-audit.md\` — new (per-connector OWNER vs AGENT matrix across 30+ platforms, cross-cutting findings, schema entrypoint)

## Test plan

- [x] \`bun test src/registry/connector-accounts.test.ts\` — 10/10 pass
- [x] \`tsc --noEmit\` clean for \`packages/app-core/src/registry/\` (pre-existing typecheck errors elsewhere in the monorepo are unrelated — capacitor / onnxruntime / cloud-routing imports)
- [x] Existing connector manifests load unchanged (the \`auth\` field is preserved; \`accounts.agent\` is added by the loader)
- [x] Audit doc renders cleanly as Markdown

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an optional `accounts: { owner?, agent? }` block to `connectorEntrySchema`, letting connector manifests declare independent OWNER and AGENT identities with separate auth kinds, credential keys, and OS support hints. A `normalizeConnectorAuth()` helper at load time auto-maps the legacy `auth` field to `accounts.agent` for backwards compatibility.

- **`schema.ts`** — adds `accountConfigSchema`, `AccountAuthKind`, and the `accounts` field to `connectorEntrySchema`; the legacy `auth` field is preserved in place.
- **`loader.ts`** — adds `normalizeConnectorAuth()` and wires it into `loadRegistryFromRawEntries` for every connector entry; two edge cases need attention (see inline comments).
- **`connector-accounts.test.ts` + audit doc** — 10 new tests and a 30+-connector OWNER/AGENT audit matrix.

<h3>Confidence Score: 3/5</h3>

The schema and index changes are safe; the normalization helper has two correctness gaps that affect how legacy connector manifests are translated to the new shape.

The `credentials` auth kind falls through the else-branch and is silently mapped to `api-key`, which is conceptually wrong for username/password auth and untested. The early-return guard checks for any truthy `entry.accounts` value rather than specifically `entry.accounts.agent`, so a connector that declares only an `accounts.owner` side while keeping a legacy `auth` field will never get its agent side populated.

packages/app-core/src/registry/loader.ts — both the `credentials` mapping and the partial-accounts guard need a closer look before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/registry/loader.ts | Adds `normalizeConnectorAuth()` helper and wires it into `loadRegistryFromRawEntries`; two logic issues: `credentials` auth kind silently maps to `api-key`, and partial `accounts` declarations (owner-only) prevent agent normalization. |
| packages/app-core/src/registry/schema.ts | Adds `accountConfigSchema`, `AccountConfig`, `AccountAuthKind` types and the optional `accounts` field to `connectorEntrySchema`; schema permits a semantically empty `accounts: {}` object with no validation guard. |
| packages/app-core/src/registry/connector-accounts.test.ts | 10 tests covering schema parsing, legacy auth mapping, and load-time normalization; missing test for `credentials` auth kind normalizing to `api-key`. |
| packages/app-core/src/registry/index.ts | Re-exports `normalizeConnectorAuth` from `loader.ts`; trivial one-line addition, no issues. |
| packages/docs/connectors/owner-vs-agent-audit.md | New documentation auditing 30+ connectors across the OWNER/AGENT dimension; content-only, no code issues. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[loadRegistryFromRawEntries] --> B{entry.kind === connector?}
    B -- yes --> C[normalizeConnectorAuth]
    B -- no --> G[indexEntries]
    C --> D{entry.auth present?}
    D -- no --> G
    D -- yes --> E{entry.accounts present?}
    E -- yes, returns early --> G
    E -- no --> F[Build accounts.agent from auth]
    F --> F1{auth.kind?}
    F1 -- oauth --> F2[authKind = oauth-cloud]
    F1 -- none --> F3[authKind = none]
    F1 -- token OR credentials --> F4[authKind = api-key ⚠️ credentials silently maps here]
    F2 --> G
    F3 --> G
    F4 --> G
    G[indexEntries — byId / byKind / byGroup / byNpmName]
```

<sub>Reviews (1): Last reviewed commit: ["feat(app-core): connector registry OWNER..."](https://github.com/elizaos/eliza/commit/d01d24203f0c677b841221a96000589b822e3e2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32914700)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->