### PR TITLE
feat(ui): connector account list role-aware + OwnerAgent dual-section setup panel

### DIFF
--- a/packages/app-core/src/registry/connector-accounts.test.ts
+++ b/packages/app-core/src/registry/connector-accounts.test.ts
@@ -1,0 +1,151 @@
+// Tests for the OWNER+AGENT connector schema extension and the
+// `normalizeConnectorAuth` legacy-auto-map. Backwards compat: existing
+// manifests that only declare `auth` must keep loading and end up with a
+// populated `accounts.agent`.
+
+import { describe, expect, it } from "vitest";
+import { loadRegistryFromRawEntries, normalizeConnectorAuth } from "./loader";
+import {
+  type AccountConfig,
+  type ConnectorEntry,
+  connectorEntrySchema,
+} from "./schema";
+
+const baseConnector = {
+  id: "test-connector",
+  name: "Test Connector",
+  kind: "connector" as const,
+  subtype: "messaging" as const,
+  source: "bundled" as const,
+  tags: [],
+  config: {},
+  render: {
+    visible: true,
+    pinTo: [],
+    style: "card" as const,
+    group: "messaging",
+    actions: [],
+  },
+  resources: {},
+  dependsOn: [],
+};
+
+describe("connectorEntrySchema accounts field", () => {
+  it("accepts an entry with no accounts block", () => {
+    const parsed = connectorEntrySchema.parse(baseConnector);
+    expect(parsed.accounts).toBeUndefined();
+  });
+
+  it("accepts an entry with both owner and agent sides", () => {
+    const parsed = connectorEntrySchema.parse({
+      ...baseConnector,
+      accounts: {
+        owner: {
+          supported: true,
+          authKind: "oauth-cloud",
+          credentialKeys: ["MY_OWNER_TOKEN"],
+          osSupport: ["darwin", "win32"],
+        },
+        agent: {
+          supported: true,
+          authKind: "api-key",
+          credentialKeys: ["MY_AGENT_TOKEN"],
+        },
+      },
+    });
+    expect(parsed.accounts?.owner?.authKind).toBe("oauth-cloud");
+    expect(parsed.accounts?.agent?.authKind).toBe("api-key");
+    expect(parsed.accounts?.owner?.osSupport).toEqual(["darwin", "win32"]);
+  });
+
+  it("rejects an unknown authKind", () => {
+    const result = connectorEntrySchema.safeParse({
+      ...baseConnector,
+      accounts: {
+        agent: { supported: true, authKind: "not-a-real-kind" },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("defaults credentialKeys to [] when omitted", () => {
+    const parsed = connectorEntrySchema.parse({
+      ...baseConnector,
+      accounts: {
+        agent: { supported: true, authKind: "none" },
+      },
+    });
+    expect(parsed.accounts?.agent?.credentialKeys).toEqual([]);
+  });
+});
+
+describe("normalizeConnectorAuth (legacy auth → accounts.agent)", () => {
+  it("maps legacy oauth auth to accounts.agent with oauth-cloud", () => {
+    const entry = connectorEntrySchema.parse({
+      ...baseConnector,
+      auth: { kind: "oauth", credentialKeys: ["FOO_TOKEN"] },
+    });
+    const normalized = normalizeConnectorAuth(entry);
+    expect(normalized.accounts?.agent).toEqual<AccountConfig>({
+      supported: true,
+      authKind: "oauth-cloud",
+      credentialKeys: ["FOO_TOKEN"],
+    });
+  });
+
+  it("maps legacy token auth to accounts.agent with api-key", () => {
+    const entry = connectorEntrySchema.parse({
+      ...baseConnector,
+      auth: { kind: "token", credentialKeys: ["BAR_TOKEN"] },
+    });
+    const normalized = normalizeConnectorAuth(entry);
+    expect(normalized.accounts?.agent?.authKind).toBe("api-key");
+    expect(normalized.accounts?.agent?.credentialKeys).toEqual(["BAR_TOKEN"]);
+  });
+
+  it("maps legacy none auth to accounts.agent with none", () => {
+    const entry = connectorEntrySchema.parse({
+      ...baseConnector,
+      auth: { kind: "none", credentialKeys: [] },
+    });
+    const normalized = normalizeConnectorAuth(entry);
+    expect(normalized.accounts?.agent?.authKind).toBe("none");
+  });
+
+  it("leaves explicit accounts untouched even when auth is also declared", () => {
+    const entry = connectorEntrySchema.parse({
+      ...baseConnector,
+      auth: { kind: "oauth", credentialKeys: ["FOO_TOKEN"] },
+      accounts: {
+        owner: { supported: true, authKind: "local-app" },
+      },
+    });
+    const normalized = normalizeConnectorAuth(entry);
+    expect(normalized.accounts?.owner?.authKind).toBe("local-app");
+    expect(normalized.accounts?.agent).toBeUndefined();
+  });
+
+  it("is a no-op when neither auth nor accounts is declared", () => {
+    const entry = connectorEntrySchema.parse(baseConnector);
+    const normalized = normalizeConnectorAuth(entry);
+    expect(normalized.accounts).toBeUndefined();
+  });
+});
+
+describe("loadRegistryFromRawEntries applies normalizeConnectorAuth", () => {
+  it("populates accounts.agent for legacy-auth connectors at load time", () => {
+    const registry = loadRegistryFromRawEntries([
+      {
+        file: "test/legacy.json",
+        data: {
+          ...baseConnector,
+          id: "legacy-connector",
+          auth: { kind: "oauth", credentialKeys: ["LEGACY_TOKEN"] },
+        },
+      },
+    ]);
+    const entry = registry.byId.get("legacy-connector") as ConnectorEntry;
+    expect(entry.accounts?.agent?.authKind).toBe("oauth-cloud");
+    expect(entry.accounts?.agent?.credentialKeys).toEqual(["LEGACY_TOKEN"]);
+  });
+});

--- a/packages/app-core/src/registry/index.ts
+++ b/packages/app-core/src/registry/index.ts
@@ -18,6 +18,7 @@ export {
   indexEntries,
   type LoadedRegistry,
   mergeWithRuntime,
+  normalizeConnectorAuth,
   type RegistryValidationError,
 } from "./loader.js";
 export * from "./schema.js";

--- a/packages/app-core/src/registry/loader.ts
+++ b/packages/app-core/src/registry/loader.ts
@@ -8,6 +8,7 @@
 // running process.
 
 import {
+  type AccountAuthKind,
   type AppEntry,
   type ConnectorEntry,
   type PluginEntry,
@@ -52,7 +53,10 @@ export function loadRegistryFromRawEntries(raws: RawEntry[]): LoadedRegistry {
       throw new RegistryValidationError(file, parsed.error);
     }
 
-    const entry = parsed.data;
+    const entry =
+      parsed.data.kind === "connector"
+        ? normalizeConnectorAuth(parsed.data)
+        : parsed.data;
     if (seenIds.has(entry.id)) {
       throw new RegistryValidationError(
         file,
@@ -64,6 +68,33 @@ export function loadRegistryFromRawEntries(raws: RawEntry[]): LoadedRegistry {
   }
 
   return indexEntries(all);
+}
+
+// Legacy `auth` → `accounts.agent` auto-mapping. Connector manifests that
+// only declared `auth` keep working without edits — the resulting `accounts`
+// shape lets the UI render a single agent section (backwards compatible) and
+// gives downstream code a uniform field to read. When a manifest already
+// declares `accounts`, the legacy `auth` is left untouched.
+export function normalizeConnectorAuth(entry: ConnectorEntry): ConnectorEntry {
+  if (!entry.auth || entry.accounts) {
+    return entry;
+  }
+  const authKind: AccountAuthKind =
+    entry.auth.kind === "oauth"
+      ? "oauth-cloud"
+      : entry.auth.kind === "none"
+        ? "none"
+        : "api-key";
+  return {
+    ...entry,
+    accounts: {
+      agent: {
+        supported: true,
+        authKind,
+        credentialKeys: entry.auth.credentialKeys,
+      },
+    },
+  };
 }
 
 export function indexEntries(entries: RegistryEntry[]): LoadedRegistry {

--- a/packages/app-core/src/registry/schema.ts
+++ b/packages/app-core/src/registry/schema.ts
@@ -273,6 +273,39 @@ export const pluginEntrySchema = z.object({
   subtype: pluginSubtype,
 });
 
+// ---------------------------------------------------------------------------
+// Per-account auth config. Connectors can declare an OWNER side (the user's
+// own platform account — e.g. user's Gmail, user's Discord) and/or an AGENT
+// side (a separate identity the agent operates — e.g. a bot Gmail, a Discord
+// bot). Auth method, credential keys, and OS support are independent per side.
+//
+// Purely additive over `auth`. When a manifest only declares `auth`, the
+// loader auto-maps it to `accounts.agent` (see loader.ts:normalizeConnectorAuth).
+// ---------------------------------------------------------------------------
+
+const accountAuthKind = z.enum([
+  "oauth-cloud", // "Log in with X" routed through Eliza Cloud
+  "oauth-local", // local-only OAuth (e.g. per-homeserver Matrix)
+  "qr", // QR-pairing (WhatsApp Baileys, Signal device-link)
+  "local-app", // local-app inspection (Discord-CDP, iMessage chat.db)
+  "browser-extension", // browser companion
+  "api-key", // manual paste of bot token / API key
+  "none",
+]);
+
+const accountOsSupport = z.enum(["darwin", "win32", "linux"]);
+
+export const accountConfigSchema = z.object({
+  supported: z.boolean().default(true),
+  authKind: accountAuthKind,
+  credentialKeys: z.array(z.string()).default([]),
+  osSupport: z.array(accountOsSupport).optional(),
+  notes: z.string().optional(),
+});
+
+export type AccountConfig = z.infer<typeof accountConfigSchema>;
+export type AccountAuthKind = z.infer<typeof accountAuthKind>;
+
 export const connectorEntrySchema = z.object({
   ...commonFields,
   kind: z.literal("connector"),
@@ -281,6 +314,12 @@ export const connectorEntrySchema = z.object({
     .object({
       kind: z.enum(["token", "oauth", "credentials", "none"]),
       credentialKeys: z.array(z.string()).default([]),
+    })
+    .optional(),
+  accounts: z
+    .object({
+      owner: accountConfigSchema.optional(),
+      agent: accountConfigSchema.optional(),
     })
     .optional(),
 });

--- a/packages/docs/connectors/owner-vs-agent-audit.md
+++ b/packages/docs/connectors/owner-vs-agent-audit.md
@@ -1,0 +1,115 @@
+# OWNER vs AGENT — Connector Audit
+
+Every connector in elizaOS can — in principle — be configured against two
+distinct platform accounts:
+
+- **OWNER** — the user's own account (e.g. the user's Gmail, the user's
+  Discord profile, the user's iMessage). Lets the agent act on behalf of the
+  user: read their inbox, see their DMs, forward an email to itself.
+- **AGENT** — a separate identity the agent operates as itself (e.g. a
+  dedicated agent Gmail address, a Discord bot, a Slack app). Acts under its
+  own name and is subject to the platform's bot/app rules.
+
+End-state behavior: the user forwards an email from their OWNER inbox to the
+agent's AGENT inbox, and the agent receives it and responds — both sides
+connected on the same platform.
+
+The OWNER role is well-defined elsewhere: it is the entity bound to the
+device during onboarding and gates privileged runtime actions (see
+[`agents/owner-role.md`](../agents/owner-role.md)). This document covers the
+**connector-level** OWNER/AGENT distinction — auth methods, platform
+constraints, and the per-connector status of OWNER/AGENT support today.
+
+Where the platform offers proper user OAuth (X, Google, Slack, GitHub, …),
+**Eliza Cloud OAuth is the default "Log in with X" path**. Manual API-key
+paste is the last-resort fallback. Where the platform forbids user-account
+automation (Discord, Instagram personal, WeChat personal), OWNER mode either
+relies on local-app inspection hacks (Discord CDP, iMessage `chat.db`) or is
+flagged platform-impossible.
+
+---
+
+## Per-connector matrix
+
+Legend: ✅ wired · ⚠️ partial / hardcoded role · ❌ missing · 🚫
+platform-impossible
+
+| Connector | AGENT today | OWNER today | Cloud OAuth | OWNER feasible | Critical gap |
+|---|---|---|---|---|---|
+| **Discord** (`plugin-discord`, `plugin-discord-local`) | ✅ bot token | ⚠️ macOS RPC+AppleScript + macOS CDP relaunch (port 9224) | ❌ bot-install only, NOT in generic OAuth provider registry | ⚠️ macOS today; Windows port unverified | Windows CDP port + add user-login OAuth route |
+| **Telegram** | ✅ bot token | ✅ `my.telegram.org` + StringSession | 🚫 Telegram has no third-party OAuth | ✅ | Session health check; plaintext session storage; account-ban risk on aggressive use |
+| **WhatsApp** | ✅ Cloud API token | ✅ Baileys QR pairing | ❌ Meta Graph OAuth not registered | ✅ | Cloud API + Baileys can't coexist per character; no TOS disclaimer |
+| **iMessage / BlueBubbles** | 🚫 | ✅ macOS `chat.db` + BlueBubbles relay | 🚫 Apple offers no third-party OAuth | ⚠️ mac-only by definition | Document the "Windows operator + remote Mac BlueBubbles" setup |
+| **Slack** | ✅ `xoxb-` bot token + cloud OAuth | ⚠️ `SLACK_USER_TOKEN` env recognized but cloud OAuth requests **bot scopes only**; `authed_user` from response not consumed | ⚠️ generic-routes, bot-only scopes | ✅ | Add user scopes (`chat:write:user`, `search:read`, `files:read`, `users:read`) and hydrate user token from OAuth response |
+| **X / Twitter** | ✅ OAuth1.0a app + OAuth2 PKCE | ✅ OAuth2 PKCE end-to-end (`connectionRole: "agent"|"owner"` already on callback) | ✅ both flows wired | ✅ | Frontend never passes `connectionRole`; OAuth2 refresh hangs interactively in headless agents |
+| **Google** (Gmail/Calendar/Drive/Chat) | ⚠️ user OAuth only (no service account) | ✅ OAuth2 + PKCE + `offline_access` + `prompt=consent` | ✅ 7 scopes wired in registry | ✅ | Two role representations coexist (legacy `agentGoogleSide` + new `connectionRole`); no scope-revocation detection |
+| **Microsoft** (Outlook/Calendar) | ⚠️ delegated only (no client-credentials) | ✅ OAuth2 against `/consumers/` only | ⚠️ personal accounts only — work/school accounts excluded; no OneDrive/Teams scopes | ⚠️ personal only | Switch tenant to `/common/`; add `Files.ReadWrite.All` and Teams scopes |
+| **GitHub** | ⚠️ PAT only (no GitHub App) | ✅ OAuth2 user-scope (role `OWNER` hardcoded) | ✅ user-scoped OAuth | ✅ | GitHub Apps (cleanest AGENT path) unimplemented; `refresh_token` captured but never rotated |
+| **LinkedIn** | ❌ no plugin | ⚠️ cloud OAuth with `w_member_social` scope (approval status unknown) | ✅ cloud-only, no plugin | ⚠️ approval-gated | Add agent-side plugin; verify LinkedIn app review approval |
+| **Instagram / Meta** | ⚠️ username/password (TOS-violating) | ❌ | ❌ Meta absent from provider registry | ⚠️ Business accounts only | Add Meta OAuth provider; declare personal Instagram out of scope |
+| **Signal** | ⚠️ signal-cli only; `role` hardcoded `"OWNER"` | ⚠️ device-link to user's primary phone; loss of primary phone disconnects the agent | 🚫 Signal has no OAuth | ⚠️ tied to user's primary device | AGENT mode via separate bot phone number; auto-recover on daemon crash |
+| **Matrix** | ✅ access token (any homeserver) | ✅ access token (same shape) | 🚫 per-homeserver, no central OAuth | ✅ | All accounts hardcoded `role: "OWNER"`; no password-login UI; full-sync only |
+| **Email (IMAP/SMTP)** | ❌ no plugin | ❌ | n/a | ❌ | Plugin doesn't exist; cloud has outbound-only SMTP. Self-hosted / Fastmail / ProtonMail users unsupported |
+| **Bluesky** | ✅ app password | ✅ app password (same shape) | 🚫 self-custodied | ✅ | `connector-account-provider.ts` hardcodes `role: "OWNER"` |
+| **Farcaster** | ✅ Neynar signer | ✅ Neynar signer | 🚫 (Neynar API key gated) | ✅ | Hardcoded `role: "OWNER"`; centralized on Neynar |
+| **Nostr** | ✅ nsec | ✅ nsec | 🚫 | ✅ | Hardcoded `role: "OWNER"` |
+| **WeChat** | ✅ proxy API (third-party) | 🚫 personal WeChat TOS-forbidden | ❌ not in registry | 🚫 | Proxy supply-chain risk; document TOS posture |
+| **Feishu / Lark** | ✅ app credentials | ❌ user delegation not wired | ❌ not in registry | ⚠️ | Add Feishu OAuth provider (user delegation exists) |
+| **Line** | ✅ bot token | ❌ LINE Login imported but unused | ❌ not in registry | ⚠️ | Wire LINE Login OAuth — already in dependencies |
+| **KakaoTalk** | ❌ no plugin | ❌ | ❌ | n/a | Add plugin if Asia-market deployments matter |
+| **Linear** | ✅ API key + OAuth | ✅ OAuth (cloud-wired in plugin) | ✅ | ✅ | No `refresh_token` handling; no OWNER/AGENT split (hardcoded `"OWNER"`) |
+| **Notion** | ❌ no plugin | ⚠️ cloud-only via OAuth | ✅ wired in registry | ✅ | No plugin; user info path workspace-scoped |
+| **Asana** | ❌ no plugin | ⚠️ cloud-only OAuth | ✅ wired | ✅ | No plugin; no PAT path |
+| **Jira** | ❌ no plugin | ⚠️ cloud-only OAuth (`auth.atlassian.com` hardcoded) | ✅ wired | ⚠️ cloud Atlassian only | No plugin; self-hosted Jira unsupported; no API-token path |
+| **HubSpot / Salesforce / Airtable / Dropbox** | ❌ no plugins | ⚠️ cloud OAuth only | ✅ all four wired (Salesforce/Airtable use PKCE) | ✅ | No plugin code consuming these tokens |
+| **Zoom** | ❌ no plugin | ❌ | ✅ in registry | ⚠️ | Plugin missing |
+| **Calendly** | ✅ OAuth + PAT | ✅ OAuth (role hardcoded `"OWNER"`) | ✅ | ✅ | No refresh-token; no AGENT path |
+| **Twilio** | ✅ Account SID + Auth Token (LifeOps-only) | ✅ same (subaccounts possible but unrouted) | n/a (api_key) | ✅ | No multi-account routing; no ConnectorAccountManager integration |
+| **Shopify** | ✅ OAuth per-store | ✅ OAuth per-store | ❌ not in registry (plugin-owned OAuth) | ⚠️ | Hardcoded `role: "OWNER"`; no staff-account / AGENT delegation |
+| **Duffel** | ✅ API key (LifeOps-only) | n/a | n/a | n/a | Single integration key; read-only |
+
+---
+
+## Cross-cutting findings
+
+- **The data model already supports OWNER+AGENT.** Cloud OAuth tracks
+  `connectionRole: "OWNER" | "AGENT" | "TEAM"` in `source_context` of the
+  `platform_credentials` table. What's missing is **plugin manifest
+  declarations of which sides are supported, UI partitioning of the two
+  sections, and removal of hardcoded `role: "OWNER"` in
+  `connector-account-provider.ts` across many plugins**.
+- **17 providers in the cloud OAuth registry**: google, microsoft, linear,
+  notion, github, slack, hubspot, asana, dropbox, salesforce, airtable, zoom,
+  jira, linkedin, twitter, twilio, blooio. Discord has separate
+  (bot-install-only) routes outside the generic registry.
+- **Many connector-account-providers hardcode `role: "OWNER"`** — Bluesky,
+  Farcaster, Nostr, Calendly, Shopify, Signal, Matrix, GitHub user, Linear,
+  Telegram. These need role parameterization to respect the OWNER vs AGENT
+  distinction the cloud has been carrying all along.
+- **Single hardcoded `redirect_uri` per provider** in cloud OAuth. Multi-instance
+  dev/prod cannot share the same OAuth client credentials — each instance
+  needs its own.
+- **Two role representations still coexist**: legacy
+  `agentGoogleSide: "owner"|"agent"` (lowercase) and new
+  `connectionRole: "OWNER"|"AGENT"|"TEAM"` (uppercase). A read-through
+  normalizer exists; a write-through migration is outstanding.
+
+## Schema entrypoint
+
+The connector registry expresses OWNER+AGENT as the optional
+`accounts: { owner?, agent? }` block on
+[`connectorEntrySchema`](../../../packages/app-core/src/registry/schema.ts).
+Each side declares its own `authKind`, `credentialKeys`, and optional
+`osSupport` hints. When a manifest only declares the legacy `auth` field,
+the loader auto-maps it to `accounts.agent` via `normalizeConnectorAuth()`,
+so existing manifests keep working without edits.
+
+## Out of scope here
+
+- LifeOps grant store changes (the LifeOps repository already carries
+  `side: "owner" | "agent"`).
+- Per-instance `redirect_uri` support for multi-tenant OAuth deployments.
+- Adding new cloud OAuth providers (Feishu, LINE Login, Meta, KakaoTalk).
+- Adding plugin shells for cloud-only providers (Notion, Asana, Jira,
+  HubSpot, Salesforce, Airtable, Dropbox, Zoom).
+- iMessage on non-mac — platform-impossible.

--- a/packages/ui/src/components/connectors/ConnectorAccountList.tsx
+++ b/packages/ui/src/components/connectors/ConnectorAccountList.tsx
@@ -3,6 +3,7 @@ import { useEffect, useMemo } from "react";
 import type {
   ConnectorAccountCreateInput,
   ConnectorAccountRecord,
+  ConnectorAccountRole,
 } from "../../api/client-agent";
 import { useConnectorAccounts } from "../../hooks/useConnectorAccounts";
 import { cn } from "../../lib/utils";
@@ -22,6 +23,15 @@ export interface ConnectorAccountListProps {
     | Promise<ConnectorAccountCreateInput | undefined>
     | ConnectorAccountCreateInput
     | undefined;
+  /**
+   * When set, this list represents accounts for a single connector role:
+   * `OWNER` shows only the user's own account(s); `AGENT` shows only the
+   * agent's separate identity account(s). Filters the rendered accounts and
+   * threads the role into the OAuth start request so the cloud stores the
+   * resulting connection under the correct role. When omitted, the legacy
+   * "single flat list of accounts" behavior is preserved.
+   */
+  role?: ConnectorAccountRole;
 }
 
 function sortConnectorAccounts(
@@ -51,21 +61,36 @@ function openConnectorAuthUrl(authUrl: string | undefined): void {
   window.open(authUrl, "_blank", "noopener,noreferrer");
 }
 
+function defaultTitleForRole(role: ConnectorAccountRole | undefined): string {
+  switch (role) {
+    case "OWNER":
+      return "Owner accounts";
+    case "AGENT":
+      return "Agent accounts";
+    case "TEAM":
+      return "Team accounts";
+    default:
+      return "Connector accounts";
+  }
+}
+
 export function ConnectorAccountList({
   provider,
   connectorId = provider,
-  title = "Connector accounts",
+  title,
   className,
   pollMs,
   selectedAccountId,
   onSelectedAccountIdChange,
   onAddAccount,
+  role,
 }: ConnectorAccountListProps) {
   const connectorAccounts = useConnectorAccounts(provider, connectorId, {
     pollMs,
     initialSelectedAccountId: selectedAccountId,
   });
   const setConnectorSelectedAccountId = connectorAccounts.setSelectedAccountId;
+  const effectiveTitle = title ?? defaultTitleForRole(role);
 
   useEffect(() => {
     if (selectedAccountId !== undefined) {
@@ -73,14 +98,15 @@ export function ConnectorAccountList({
     }
   }, [selectedAccountId, setConnectorSelectedAccountId]);
 
-  const sortedAccounts = useMemo(
-    () =>
-      sortConnectorAccounts(
-        connectorAccounts.accounts,
-        connectorAccounts.defaultAccountId,
-      ),
-    [connectorAccounts.accounts, connectorAccounts.defaultAccountId],
-  );
+  const sortedAccounts = useMemo(() => {
+    const filtered = role
+      ? connectorAccounts.accounts.filter((account) => account.role === role)
+      : connectorAccounts.accounts;
+    return sortConnectorAccounts(
+      filtered,
+      connectorAccounts.defaultAccountId,
+    );
+  }, [connectorAccounts.accounts, connectorAccounts.defaultAccountId, role]);
 
   const handleSelect = (accountId: string) => {
     setConnectorSelectedAccountId(accountId);
@@ -94,10 +120,11 @@ export function ConnectorAccountList({
       await connectorAccounts.add(body);
       return;
     }
+    const requestedRole: ConnectorAccountRole = role ?? "OWNER";
     const result = await connectorAccounts.startOAuth({
       metadata: {
-        requestedRole: "OWNER",
-        privacy: "owner_only",
+        requestedRole,
+        privacy: requestedRole === "OWNER" ? "owner_only" : "team_visible",
       },
     });
     openConnectorAuthUrl(result.authUrl);
@@ -116,7 +143,7 @@ export function ConnectorAccountList({
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <h3 className="text-xs font-semibold uppercase tracking-wider text-muted">
-          {title} ({sortedAccounts.length})
+          {effectiveTitle} ({sortedAccounts.length})
         </h3>
         <Button
           type="button"

--- a/packages/ui/src/components/connectors/OwnerAgentConnectorSetupPanel.tsx
+++ b/packages/ui/src/components/connectors/OwnerAgentConnectorSetupPanel.tsx
@@ -1,0 +1,74 @@
+/**
+ * OwnerAgentConnectorSetupPanel — dual-section setup UI for connectors that
+ * support both OWNER and AGENT accounts.
+ *
+ * Renders two `ConnectorAccountList`s stacked: one filtered to the user's
+ * own account(s) on the platform (OWNER), one to the agent's separate
+ * identity account(s) (AGENT). Each section has its own "Add account"
+ * button that threads the appropriate `requestedRole` through the OAuth
+ * start request.
+ *
+ * Plugins opt into this layout by registering it for their connector ID
+ * via `registerConnectorSetupPanel("plugin-x", () => <OwnerAgentConnectorSetupPanel ... />)`
+ * inside the plugin's UI registration entry point.
+ *
+ * Falls back to a single-section list when a side is explicitly disabled
+ * (`enableOwner: false` or `enableAgent: false`), so a plugin can also use
+ * this component as a "AGENT-only with the future-proof shape" placeholder.
+ */
+
+import { cn } from "../../lib/utils";
+import { ConnectorAccountList } from "./ConnectorAccountList";
+
+export interface OwnerAgentConnectorSetupPanelProps {
+  provider: string;
+  connectorId?: string;
+  className?: string;
+  pollMs?: number;
+  /** When false, the OWNER section is hidden (e.g. agent-only connector). */
+  enableOwner?: boolean;
+  /** When false, the AGENT section is hidden (e.g. owner-only connector). */
+  enableAgent?: boolean;
+  ownerTitle?: string;
+  agentTitle?: string;
+  /** Optional help text rendered above the two sections. */
+  description?: string;
+}
+
+export function OwnerAgentConnectorSetupPanel({
+  provider,
+  connectorId,
+  className,
+  pollMs,
+  enableOwner = true,
+  enableAgent = true,
+  ownerTitle,
+  agentTitle,
+  description,
+}: OwnerAgentConnectorSetupPanelProps) {
+  return (
+    <div className={cn("flex flex-col gap-3", className)}>
+      {description ? (
+        <p className="text-xs text-muted">{description}</p>
+      ) : null}
+      {enableOwner ? (
+        <ConnectorAccountList
+          provider={provider}
+          connectorId={connectorId}
+          role="OWNER"
+          title={ownerTitle}
+          pollMs={pollMs}
+        />
+      ) : null}
+      {enableAgent ? (
+        <ConnectorAccountList
+          provider={provider}
+          connectorId={connectorId}
+          role="AGENT"
+          title={agentTitle}
+          pollMs={pollMs}
+        />
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Builds on the OWNER+AGENT registry schema from #7817 by making the connector setup UI partition-ready.

**\`ConnectorAccountList\`** gains an optional \`role?: ConnectorAccountRole\` prop. When set:

- Accounts are filtered to those matching the role (only the user's OWNER account shown in the OWNER section; only the agent's identity in the AGENT section).
- The "Add account" button threads \`requestedRole\` through the OAuth start request so the cloud stores the resulting connection under the correct role — today the button hardcodes \`"OWNER"\` regardless of intent.
- Default title and privacy default track the role.

When the prop is omitted, the previous single-flat-list behavior is preserved — every existing caller keeps working unchanged.

**\`OwnerAgentConnectorSetupPanel\`** (new) composes two \`ConnectorAccountList\`s — one filtered to OWNER, one to AGENT — for connectors that declare both sides in their registry manifest. Includes \`enableOwner\` / \`enableAgent\` overrides for connectors that only support one side, and a \`description\` slot for per-platform setup guidance.

This is foundation for the per-plugin migrations: X, Google, Slack, and Discord will register this panel via \`registerConnectorSetupPanel\` in follow-up PRs once their manifests declare \`accounts.owner\` / \`accounts.agent\`.

### Files changed

- \`packages/ui/src/components/connectors/ConnectorAccountList.tsx\` — role-aware filtering, OAuth metadata threading, role-derived title and privacy
- \`packages/ui/src/components/connectors/OwnerAgentConnectorSetupPanel.tsx\` — new dual-section composer

## Stacking

Stacks on #7817 (depends on \`ConnectorAccountRole\` shape which is unchanged by that PR — UI changes are independent and can land in either order, but the intended consumer flow assumes both PRs in develop).

## Test plan

- [x] Typecheck clean for both changed files
- [x] Existing \`ConnectorAccountList\` callers compile unchanged (the new prop is optional and the legacy single-list code path is untouched)
- [ ] Functional verification when a pilot plugin (PR 3+) registers \`OwnerAgentConnectorSetupPanel\` and the two sections render distinctly in \`bun run dev:desktop:watch\`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `ConnectorAccountList` role-aware and introduces `OwnerAgentConnectorSetupPanel`, a dual-section composer stacking OWNER and AGENT account lists. It also adds the `accounts: { owner?, agent? }` schema field, a `normalizeConnectorAuth` legacy-compat loader function, and a comprehensive OWNER/AGENT audit document.

- **`ConnectorAccountList`**: The `role` prop is fully opt-in; all existing callers compile unchanged.
- **`OwnerAgentConnectorSetupPanel`**: Composes two `ConnectorAccountList` instances with `role="OWNER"` and `role="AGENT"`, including `enableOwner`/`enableAgent` escape-hatches and a description slot.
- **`normalizeConnectorAuth`**: Auto-maps legacy `auth` to `accounts.agent` at registry load time; skips mapping when `accounts` is already present.

<h3>Confidence Score: 4/5</h3>

Safe to merge with no functional regressions — all new behaviour is opt-in and existing callers are unchanged.

The role-filtering, OAuth metadata threading, schema additions, and legacy normalizer are all well-tested and backwards-compatible. The two items worth watching before the per-plugin follow-up PRs land: the dual-poll behaviour in OwnerAgentConnectorSetupPanel and the normalizer early-return when accounts is only partially declared alongside auth.

packages/app-core/src/registry/loader.ts (normalizeConnectorAuth guard) and packages/ui/src/components/connectors/OwnerAgentConnectorSetupPanel.tsx (dual-poll) are worth revisiting before the pilot plugin PRs land.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/connectors/ConnectorAccountList.tsx | Adds optional `role` prop for role-aware filtering and OAuth metadata threading. The role-based filtering relies on `account.role`, which the client-side normalizer always populates (defaulting to OWNER for legacy accounts), so filtering is safe. The legacy codepath (no `role` prop) is unchanged. |
| packages/ui/src/components/connectors/OwnerAgentConnectorSetupPanel.tsx | New dual-section composer. Two `ConnectorAccountList` instances share the same provider/connectorId, each creating an independent poll loop — doubling API requests for the lifetime of the panel. |
| packages/app-core/src/registry/loader.ts | Adds `normalizeConnectorAuth` for legacy `auth` → `accounts.agent` mapping. The guard `entry.accounts` (truthy for any partial accounts block) silently skips agent normalization when only `accounts.owner` is declared alongside `auth`. |
| packages/app-core/src/registry/schema.ts | Adds `accountConfigSchema` with `AccountConfig`/`AccountAuthKind` types and wires the new `accounts: { owner?, agent? }` field onto `connectorEntrySchema`. Purely additive, no breaking changes. |
| packages/app-core/src/registry/connector-accounts.test.ts | New test file covering schema validation, legacy-auth normalization, and registry loading. Tests cover the expected 'partial accounts skips agent mapping' behavior, confirming it is intentional. |
| packages/app-core/src/registry/index.ts | Exports `normalizeConnectorAuth` from `loader.ts` so external consumers can call it directly without going through the full registry load flow. |
| packages/docs/connectors/owner-vs-agent-audit.md | New audit document summarizing per-connector OWNER/AGENT status and cross-cutting findings. Documentation-only; no runtime impact. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(ui): connector account list role-aw..."](https://github.com/elizaos/eliza/commit/1da94858f8a61a2a6e60c935949d15fb45a0c021) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32915409)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->