### PR TITLE
chore(connectors): unhardcode role: "OWNER" in OAuth callbacks for Linear, Calendly, Shopify

### DIFF
--- a/plugins/plugin-calendly/src/connector-account-provider.ts
+++ b/plugins/plugin-calendly/src/connector-account-provider.ts
@@ -343,11 +343,19 @@ export function createCalendlyConnectorAccountProvider(
         expiresAt,
         oauthCredentialVersion,
       };
+      const flowMetadata =
+        (request.flow.metadata as Record<string, unknown> | undefined) ?? {};
+      const requestedRoleRaw = flowMetadata.requestedRole;
+      const role: "OWNER" | "AGENT" | "TEAM" =
+        requestedRoleRaw === "AGENT" || requestedRoleRaw === "TEAM"
+          ? requestedRoleRaw
+          : "OWNER";
+
       const pendingAccount = await manager.upsertAccount(
         CALENDLY_PROVIDER_NAME,
         {
           provider: CALENDLY_PROVIDER_NAME,
-          role: "OWNER",
+          role,
           purpose: DEFAULT_PURPOSES,
           accessGate: "open",
           status: "pending",

--- a/plugins/plugin-linear/src/connector-account-provider.ts
+++ b/plugins/plugin-linear/src/connector-account-provider.ts
@@ -270,9 +270,17 @@ export function createLinearConnectorAccountProvider(
         throw new Error("Linear viewer payload did not include an organization id or urlKey.");
       }
 
+      const flowMetadata =
+        (request.flow.metadata as Record<string, unknown> | undefined) ?? {};
+      const requestedRoleRaw = flowMetadata.requestedRole;
+      const role: "OWNER" | "AGENT" | "TEAM" =
+        requestedRoleRaw === "AGENT" || requestedRoleRaw === "TEAM"
+          ? requestedRoleRaw
+          : "OWNER";
+
       const accountPatch: ConnectorAccountPatch & { provider: string } = {
         provider: LINEAR_PROVIDER_NAME,
-        role: "OWNER",
+        role,
         purpose: DEFAULT_PURPOSES,
         accessGate: "open",
         status: "connected",

--- a/plugins/plugin-shopify/src/connector-account-provider.ts
+++ b/plugins/plugin-shopify/src/connector-account-provider.ts
@@ -313,9 +313,15 @@ export function createShopifyConnectorAccountProvider(
         );
       }
 
+      const requestedRoleRaw = flowMetadata.requestedRole;
+      const role: "OWNER" | "AGENT" | "TEAM" =
+        requestedRoleRaw === "AGENT" || requestedRoleRaw === "TEAM"
+          ? requestedRoleRaw
+          : "OWNER";
+
       const accountPatch: ConnectorAccountPatch & { provider: string } = {
         provider: SHOPIFY_PROVIDER_NAME,
-        role: "OWNER",
+        role,
         purpose: DEFAULT_PURPOSES,
         accessGate: "open",
         status: "connected",


### PR DESCRIPTION
## Summary

Each plugin's \`completeOAuth\` handler was assigning \`role: \"OWNER\"\` to the upserted account record regardless of what the OAuth start flow requested. That made the new role-aware connector account UI (\`ConnectorAccountList\` with a \`role\` prop in #7819, threading \`requestedRole\` through OAuth start metadata) a no-op for these three plugins — any "Add AGENT account" attempt would silently land as an OWNER account.

Each handler now reads \`requestedRole\` from \`request.flow.metadata\` and falls back to \`\"OWNER\"\` when it's unset (so single-section legacy callers keep getting the same default). Only \`\"AGENT\"\` and \`\"TEAM\"\` are accepted as alternatives — any other value defaults to OWNER.

### Files changed

- \`plugins/plugin-linear/src/connector-account-provider.ts\` (line 275)
- \`plugins/plugin-calendly/src/connector-account-provider.ts\` (line 350)
- \`plugins/plugin-shopify/src/connector-account-provider.ts\` (line 318)

## Scope notes

The connector audit ([\`packages/docs/connectors/owner-vs-agent-audit.md\`](https://github.com/elizaOS/eliza/pull/7817) in #7817) flagged several other plugins with hardcoded \`role: "OWNER"\`. They fall into two categories not addressed here:

- **Bot-only / device-paired plugins** (Telegram, Signal) — already default to the correct role for their platform constraints; the \`addAccount\` patch path already respects \`input.role\`.
- **Config-driven synthesizers** (Bluesky, Farcaster, Nostr, Matrix) — derive the account record from character config, not from OAuth start metadata. Splitting these into OWNER/AGENT requires extending each plugin's per-account config type with a \`role\` field — deferred to the per-plugin migration PRs (which also touch service-layer auth resolution).

## Test plan

- [x] Diff inspection — each handler now reads from the same \`request.flow.metadata\` it was already accessing for other fields; the role extraction is a 4-line block of literal-string narrowing
- [ ] Functional verification once #7817 and #7819 land — call \`startOAuth({ metadata: { requestedRole: "AGENT" } })\` against any of these three providers and confirm the resulting \`platform_credentials.source_context.connectionRole\` is \`"AGENT"\` rather than \`"OWNER"\`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes OAuth callback handlers in the Linear, Calendly, and Shopify plugins so that the account `role` is taken from `request.flow.metadata.requestedRole` rather than being hardcoded to `"OWNER"`, enabling the role-aware connector UI introduced in #7819 to work correctly for these providers.

- **Linear & Calendly**: a new `flowMetadata` cast block is introduced (mirroring the Shopify pattern already in place) and the narrowed `role` value replaces the literal `"OWNER"` in the account patch.
- **Shopify**: reuses the pre-existing `flowMetadata` variable; only the `requestedRole` extraction and `role` constant are new.
- All three handlers fall back to `"OWNER"` for unrecognised or absent values, preserving backward compatibility with legacy callers.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all three handlers use the same well-tested pattern already established in the Shopify plugin, the fallback to 'OWNER' keeps legacy callers unaffected, and there are no structural changes outside the role-resolution block.

The role-extraction block is a straightforward literal-string narrowing with a safe default; the only missing piece is a diagnostic log when an unexpected value silently falls back to OWNER, which could obscure misconfiguration in development but does not affect correctness in production.

No files require special attention; the Calendly two-step upsert correctly carries the role through the pending-account spread, and the Shopify file reuses an existing, already-typed variable.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-linear/src/connector-account-provider.ts | Adds `flowMetadata` extraction and role narrowing before `upsertAccount`; pattern mirrors existing Shopify approach; logic is correct. |
| plugins/plugin-calendly/src/connector-account-provider.ts | Same role-extraction block added before the two-step upsert; role is set on `pendingAccount` and carried through the spread into the final `accountPatch`, so the correct role propagates to the returned account. |
| plugins/plugin-shopify/src/connector-account-provider.ts | Reuses the pre-existing `flowMetadata` variable (already cast and initialized earlier in the same handler) to extract `requestedRole`; minimal, safe change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as ConnectorAccountList
    participant S as startOAuth handler
    participant F as OAuth Flow (state)
    participant C as completeOAuth handler
    participant DB as upsertAccount

    UI->>S: "startOAuth({ metadata: { requestedRole: "AGENT" } })"
    S->>F: "store flow.metadata = { ...request.metadata, redirectUri, ... }"
    Note over F: requestedRole preserved via ...request.metadata spread

    F-->>C: OAuth callback with flow.metadata
    C->>C: read flowMetadata.requestedRole
    C->>C: "narrow to "OWNER" | "AGENT" | "TEAM" (fallback to "OWNER")"
    C->>DB: "upsertAccount({ role: "AGENT", ... })"
    DB-->>C: account record
    C-->>UI: "{ account: { role: "AGENT" }, flow: { status: "completed" } }"
```

<sub>Reviews (1): Last reviewed commit: ["chore(connectors): unhardcode role: &quot;OWN..."](https://github.com/elizaos/eliza/commit/19560dc084a1d020b7572d95fa7b532bd4209f47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32916048)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->