### PR TITLE
fix(orchestrator): use vendored OpenCode endpoint detection

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
@@ -38,10 +38,36 @@ describe("buildOpencodeSpawnConfig", () => {
     expect(result?.model).toBe("cerebras/gpt-oss-120b");
   });
 
+  it("detects Cerebras by URL host, including subdomains", () => {
+    const result = buildOpencodeSpawnConfig(runtime(), {
+      ELIZA_OPENCODE_BASE_URL: "https://gateway.cerebras.ai/v1",
+      ELIZA_OPENCODE_API_KEY: "csk-test",
+      ELIZA_OPENCODE_MODEL_POWERFUL: "gpt-oss-120b",
+    });
+    expect(result?.providerId).toBe("cerebras");
+    const config = JSON.parse(result?.configContent ?? "{}");
+    expect(config.provider.cerebras.options.baseURL).toBe(
+      "https://gateway.cerebras.ai/v1",
+    );
+  });
+
+  it("does not treat Cerebras text in a non-Cerebras URL path as Cerebras", () => {
+    const result = buildOpencodeSpawnConfig(runtime(), {
+      ELIZA_OPENCODE_BASE_URL: "https://proxy.example/v1/cerebras.ai",
+      ELIZA_OPENCODE_API_KEY: "custom-key",
+      ELIZA_OPENCODE_MODEL_POWERFUL: "gpt-oss-120b",
+    });
+    expect(result?.providerId).toBe("eliza-local");
+    const config = JSON.parse(result?.configContent ?? "{}");
+    expect(config.provider["eliza-local"].options.baseURL).toBe(
+      "https://proxy.example/v1/cerebras.ai",
+    );
+  });
+
   it("does not pass unresolved vault pointers as provider API keys", () => {
     const result = buildOpencodeSpawnConfig(runtime(), {
       ELIZA_OPENCODE_BASE_URL: "https://api.cerebras.ai/v1",
-      ELIZA_OPENCODE_API_KEY: "vault://PARALLAX_OPENCODE_API_KEY",
+      ELIZA_OPENCODE_API_KEY: "vault://ELIZA_OPENCODE_API_KEY",
       CEREBRAS_API_KEY: "csk-resolved",
       ELIZA_OPENCODE_MODEL_POWERFUL: "gpt-oss-120b",
     });

--- a/plugins/plugin-agent-orchestrator/bin/opencode
+++ b/plugins/plugin-agent-orchestrator/bin/opencode
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Shim that forwards `opencode` to the vendored elizaOS/opencode source tree.
 # plugin-agent-orchestrator's AcpService points acpx at this shim so we run
-# the PR #26763 (Cerebras reasoning fix) vendored source without needing a
-# compiled binary.
+# the vendored source with provider-specific compatibility fixes without
+# needing a compiled binary.
 SHIM_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 OC_DIR="$SHIM_DIR/../vendor/opencode/packages/opencode"
 if [ -f "$OC_DIR/src/index.ts" ]; then

--- a/plugins/plugin-agent-orchestrator/bin/opencode.cmd
+++ b/plugins/plugin-agent-orchestrator/bin/opencode.cmd
@@ -1,8 +1,8 @@
 @ECHO OFF
 REM Shim that forwards `opencode` to the vendored elizaOS/opencode source tree.
 REM plugin-agent-orchestrator's AcpService points acpx at this shim so we run
-REM the PR #26763 (Cerebras reasoning fix) vendored source without needing a
-REM compiled binary.
+REM the vendored source with provider-specific compatibility fixes without
+REM needing a compiled binary.
 SETLOCAL
 SET "OC_DIR=%~dp0..\vendor\opencode\packages\opencode"
 bun run --cwd "%OC_DIR%" --conditions=browser src/index.ts %*

--- a/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
@@ -86,7 +86,13 @@ function providerConfig(
 }
 
 function isCerebrasBaseUrl(value: string | undefined): boolean {
-  return Boolean(value && /(^|[/.])cerebras\.ai(?:\/|$)/i.test(value));
+  if (!value) return false;
+  try {
+    const hostname = new URL(value).hostname.toLowerCase();
+    return hostname === "cerebras.ai" || hostname.endsWith(".cerebras.ai");
+  } catch {
+    return false;
+  }
 }
 
 function usableApiKey(value: string | undefined): string | undefined {


### PR DESCRIPTION
## Summary
- update the vendored OpenCode submodule to include `elizaOS/opencode#3` / `5a58f5c` endpoint detection
- parse Cerebras base URLs by hostname in the orchestrator OpenCode spawn config instead of matching arbitrary URL text
- remove the stale PR-number reference from the vendored OpenCode shim comments

## Why
The orchestrator already prefers the vendored OpenCode shim before falling back to a globally installed or npm OpenCode binary. This keeps that path explicit and makes Cerebras detection general: actual Cerebras hosts such as `api.cerebras.ai` or `gateway.cerebras.ai` use the Cerebras provider, while unrelated proxy URLs that merely contain `cerebras.ai` in the path stay generic OpenAI-compatible or local config.

## Related
- OpenCode source PR: https://github.com/elizaOS/opencode/pull/3

## Validation
OpenCode vendored source:
- `bunx prettier --write packages/opencode/src/provider/provider.ts packages/opencode/src/provider/transform.ts packages/opencode/test/provider/provider.test.ts packages/opencode/test/provider/transform.test.ts`
- `bun test --timeout 30000 test/provider/provider.test.ts test/provider/transform.test.ts` -> 331 passed, 0 failed
- `bun run typecheck` was checked; current `dev` still has two baseline errors unrelated to this patch (`OPENCODE_EXPERIMENTAL_OUTPUT_TOKEN_MAX` flag typing and missing `../../src/project/with-instance` in `test/acp/event-subscription.test.ts`)

Eliza orchestrator after merging latest `origin/develop`:
- `git diff --check`
- `bunx vitest run __tests__/unit/opencode-spawn-config-auto-detect.test.ts __tests__/unit/acp-service.test.ts __tests__/unit/available-agents.test.ts` -> 43 passed, 0 failed
- `bun run typecheck && bun run build` in `plugins/plugin-agent-orchestrator` -> passed

## Notes
This PR is intentionally narrow: it keeps provider endpoint detection in URL parsing code and tests instead of adding prompt text, deployment-specific config, or substring/regex matching against arbitrary paths.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens Cerebras endpoint detection in the orchestrator's OpenCode spawn config by replacing a regex URL-text match with a proper hostname check via the `URL` API, and bumps the vendored OpenCode submodule to `5a58f5cee` which includes the same fix upstream.

- **`isCerebrasBaseUrl`** now parses the URL and checks only the `hostname` field (`cerebras.ai` or `*.cerebras.ai`), preventing false positives when `cerebras.ai` appears only in a URL path segment.
- Two new tests validate subdomain detection and the false-positive case; the stale vault-pointer test string is cleaned up.
- Shim comments in `bin/opencode` and `bin/opencode.cmd` drop the now-irrelevant PR number reference.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted, well-tested narrowing of URL matching logic with no regressions on existing paths.

The only functional change is replacing a regex with a hostname-only check using the standard URL API, wrapped in a try/catch for invalid inputs. All pre-existing tests still pass and two new tests directly exercise the corrected behavior. The submodule bump and comment cleanups carry no runtime risk.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-orchestrator/src/services/opencode-config.ts | isCerebrasBaseUrl replaced regex with URL hostname parsing; handles invalid URLs via try/catch; logic is correct and more precise |
| plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts | Two new tests cover subdomain detection and false-positive prevention for path-only matches; vault test string cleaned up |
| plugins/plugin-agent-orchestrator/vendor/opencode | Submodule pointer bumped from 8a86b585c to 5a58f5cee to pull in elizaOS/opencode#3 endpoint detection |
| plugins/plugin-agent-orchestrator/bin/opencode | Shim comment updated to remove stale PR reference; functional behavior unchanged |
| plugins/plugin-agent-orchestrator/bin/opencode.cmd | Windows shim comment updated in parallel with bash shim; no functional change |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildOpencodeSpawnConfig] --> B{llmProvider == cloud?}
    B -- yes --> C[Return elizacloud config]
    B -- no --> D[isCerebrasBaseUrl customBaseUrl]
    D --> E{hostname == cerebras.ai or *.cerebras.ai?}
    E -- yes --> F[wantsCerebras = true]
    E -- no --> G{cerebrasApiKey set?}
    G -- yes --> F
    G -- no --> H{no customBaseUrl AND opencodeApiKey AND isCerebrasBaseUrl cerebrasBaseUrl?}
    H -- yes --> F
    H -- no --> I[wantsCerebras = false]
    F --> J{wantsCerebras AND any key or URL?}
    J -- yes --> K[Return cerebras config]
    J -- no --> L{localOptIn or customBaseUrl?}
    I --> L
    L -- yes --> M[Return eliza-local config]
    L -- no --> N{powerful model set?}
    N -- yes --> O[Return user opencode.json config]
    N -- no --> P[Return null]
```

<sub>Reviews (2): Last reviewed commit: ["Merge origin/develop into vendored openc..."](https://github.com/elizaos/eliza/commit/7eb92a7447aa42b680ba02101ccf6f4baf63eb43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32927028)</sub>

<!-- /greptile_comment -->