### PR TITLE
fix(test): stabilize cloud mock e2e stack

### DIFF
--- a/.github/workflows/cloud-e2e.yml
+++ b/.github/workflows/cloud-e2e.yml
@@ -78,4 +78,5 @@ jobs:
           path: |
             packages/test/cloud-e2e/.logs
           retention-days: 7
+          include-hidden-files: true
           if-no-files-found: ignore

--- a/bun.lock
+++ b/bun.lock
@@ -1862,6 +1862,7 @@
         "control-plane-mock": "./bin/control-plane-mock.ts",
       },
       "dependencies": {
+        "@elizaos/cloud-shared": "workspace:*",
         "hono": "4.12.18",
       },
       "devDependencies": {

--- a/packages/cloud-shared/src/db/client.ts
+++ b/packages/cloud-shared/src/db/client.ts
@@ -34,6 +34,15 @@ type Database = NodePgDatabase<typeof schema>;
 /** Transaction handle for `writeTransaction` callbacks. */
 type DbTransaction = NodePgTransaction<typeof schema, SchemaTables>;
 
+type DatabaseCloser = () => Promise<void> | void;
+
+const databaseClosers = new WeakMap<Database, DatabaseCloser>();
+
+function registerDatabaseCloser(database: Database, closer: DatabaseCloser): Database {
+  databaseClosers.set(database, closer);
+  return database;
+}
+
 /**
  * Get the primary database URL (always required)
  */
@@ -90,7 +99,9 @@ function createPGliteClient(dataDir: string): Database {
     extensions: { vector },
   });
   const database: PgliteDatabase<typeof schema> = drizzlePGlite({ client, schema });
-  return database as Database;
+  return registerDatabaseCloser(database as Database, async () => {
+    await client.close();
+  });
 }
 
 function isLocalTcpPostgresUrl(url: string): boolean {
@@ -164,11 +175,11 @@ function createConnection(url: string): Database {
       neonConfig.webSocketConstructor = ws;
     }
     const pool = new NeonPool({ connectionString: url });
-    return drizzleNeon(pool, { schema }) as Database;
+    return registerDatabaseCloser(drizzleNeon(pool, { schema }) as Database, () => pool.end());
   }
 
   const pool = createPgPool(url);
-  return drizzleNode(pool, { schema }) as Database;
+  return registerDatabaseCloser(drizzleNode(pool, { schema }) as Database, () => pool.end());
 }
 
 // ============================================================================
@@ -265,6 +276,25 @@ class DatabaseConnectionManager {
       databaseUrlConfigured: !!applyDatabaseUrlFallback(env),
     };
   }
+
+  /**
+   * Close process-level cached connections.
+   *
+   * Used by local test/dev harnesses that bring up and tear down ephemeral
+   * Postgres/PGlite servers in the same Node/Bun process. Workers use
+   * request-scoped caches and do not share this singleton pool.
+   */
+  async closeAll(): Promise<void> {
+    const databases = Array.from(this.connections.values());
+    this.connections.clear();
+    const requestCache = dbCacheAls.getStore();
+    requestCache?.clear();
+    await Promise.all(
+      databases.map(async (database) => {
+        await databaseClosers.get(database)?.();
+      }),
+    );
+  }
 }
 
 const connectionManager = new DatabaseConnectionManager();
@@ -327,6 +357,13 @@ export const dbWrite = new Proxy({} as Database, {
  */
 export function getDbConnectionInfo() {
   return connectionManager.getConnectionInfo();
+}
+
+/**
+ * Close cached process-local DB pools for local test/dev teardown.
+ */
+export async function closeDatabaseConnectionsForTests(): Promise<void> {
+  await connectionManager.closeAll();
 }
 
 /**

--- a/packages/scripts/cloud/admin/dev/cloud-api-hono-dev.ts
+++ b/packages/scripts/cloud/admin/dev/cloud-api-hono-dev.ts
@@ -1,0 +1,125 @@
+#!/usr/bin/env bun
+/**
+ * Local Hono server for the mock cloud E2E harness.
+ *
+ * The production Cloud API still runs as a Cloudflare Worker. This launcher is
+ * intentionally scoped to local/mock tests where we need deterministic process
+ * startup and the same Hono route graph, but not Wrangler's dev proxy/runtime.
+ */
+
+import { createApp } from "../../../../cloud-api/src/bootstrap-app";
+
+type StoredObject = {
+  bytes: Uint8Array;
+  httpMetadata?: { contentType?: string };
+  customMetadata?: Record<string, string>;
+};
+
+const encoder = new TextEncoder();
+const store = new Map<string, StoredObject>();
+
+async function toBytes(
+  value: string | ArrayBuffer | ArrayBufferView | Blob | null,
+): Promise<Uint8Array> {
+  if (value === null) return new Uint8Array();
+  if (typeof value === "string") return encoder.encode(value);
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  }
+  return new Uint8Array(await value.arrayBuffer());
+}
+
+const blobBinding = {
+  async get(key: string) {
+    const object = store.get(key);
+    if (!object) return null;
+    return {
+      httpMetadata: object.httpMetadata,
+      customMetadata: object.customMetadata,
+      async text() {
+        return new TextDecoder().decode(object.bytes);
+      },
+      async arrayBuffer() {
+        return object.bytes.buffer.slice(
+          object.bytes.byteOffset,
+          object.bytes.byteOffset + object.bytes.byteLength,
+        );
+      },
+    };
+  },
+  async put(
+    key: string,
+    value: string | ArrayBuffer | ArrayBufferView | Blob | null,
+    options?: {
+      httpMetadata?: { contentType?: string };
+      customMetadata?: Record<string, string>;
+    },
+  ) {
+    store.set(key, {
+      bytes: await toBytes(value),
+      httpMetadata: options?.httpMetadata,
+      customMetadata: options?.customMetadata,
+    });
+  },
+  async delete(key: string) {
+    store.delete(key);
+  },
+};
+
+function executionContext(): ExecutionContext {
+  return {
+    waitUntil(promise) {
+      Promise.resolve(promise).catch((error) => {
+        console.error("[cloud-api-hono-dev] waitUntil failed", error);
+      });
+    },
+    passThroughOnException() {},
+  } as ExecutionContext;
+}
+
+const port = Number.parseInt(process.env.API_DEV_PORT || "8787", 10);
+const hostname = process.env.API_DEV_HOST || "127.0.0.1";
+const app = createApp();
+const env = {
+  ...process.env,
+  BLOB: blobBinding,
+};
+
+const server = Bun.serve({
+  hostname,
+  port,
+  async fetch(request) {
+    try {
+      const url = new URL(request.url);
+      if (url.pathname === "/api/health") {
+        return Response.json(
+          {
+            status: "ok",
+            timestamp: Date.now(),
+            region: "local-hono",
+          },
+          { headers: { "Cache-Control": "no-store, max-age=0" } },
+        );
+      }
+      return await app.fetch(request, env, executionContext());
+    } catch (error) {
+      console.error("[cloud-api-hono-dev] unhandled request error", error);
+      return Response.json(
+        { success: false, error: "internal_error" },
+        { status: 500 },
+      );
+    }
+  },
+});
+
+console.log(
+  `[cloud-api-hono-dev] listening on http://${hostname}:${server.port}`,
+);
+
+const shutdown = () => {
+  server.stop(true);
+  process.exit(0);
+};
+process.once("SIGINT", shutdown);
+process.once("SIGTERM", shutdown);

--- a/packages/test/cloud-e2e/src/fixtures/stack.ts
+++ b/packages/test/cloud-e2e/src/fixtures/stack.ts
@@ -5,7 +5,7 @@
  *   1. PGlite TCP bridge (via packages/scripts/cloud/admin/dev/pglite-server.ts)
  *   2. Hetzner mock (in-process, free port)
  *   3. Control-plane mock (in-process, free port, points at Hetzner mock)
- *   4. cloud-api worker subprocess (cloud-api-dev.mjs → wrangler dev)
+ *   4. cloud-api Hono subprocess (same app, local Bun server)
  *   5. cloud-frontend Vite dev subprocess
  *
  * Returns a handle with URLs and a `stop()` that tears everything down.
@@ -29,8 +29,9 @@ import {
 
 import { buildSharedEnv } from "./env";
 
-const REPO_ROOT = resolve(import.meta.dirname, "../../../..");
-const LOG_DIR = resolve(import.meta.dirname, "../../.logs");
+const CLOUD_E2E_ROOT = resolve(import.meta.dirname, "../..");
+const REPO_ROOT = resolve(import.meta.dirname, "../../../../..");
+const LOG_DIR = resolve(CLOUD_E2E_ROOT, ".logs");
 
 export interface StackHandle {
   stop: () => Promise<void>;
@@ -155,17 +156,50 @@ function spawnLogged(
 }
 
 async function killProc(proc: SpawnedProc): Promise<void> {
-  if (proc.child.exitCode !== null || proc.child.signalCode !== null) return;
-  proc.child.kill("SIGTERM");
-  const deadline = Date.now() + 5_000;
-  while (proc.child.exitCode === null && proc.child.signalCode === null) {
-    if (Date.now() > deadline) {
-      proc.child.kill("SIGKILL");
-      break;
+  try {
+    if (proc.child.exitCode === null && proc.child.signalCode === null) {
+      proc.child.kill("SIGTERM");
+      const deadline = Date.now() + 5_000;
+      while (proc.child.exitCode === null && proc.child.signalCode === null) {
+        if (Date.now() > deadline) {
+          proc.child.kill("SIGKILL");
+          break;
+        }
+        await delay(100);
+      }
     }
-    await delay(100);
+  } finally {
+    await new Promise<void>((r) => proc.log.end(() => r()));
   }
-  await new Promise<void>((r) => proc.log.end(() => r()));
+}
+
+async function runLogged(
+  name: string,
+  command: string,
+  args: string[],
+  options: { env: NodeJS.ProcessEnv; cwd: string; logFile: string },
+): Promise<void> {
+  const proc = spawnLogged(name, command, args, options);
+  const result = await new Promise<{
+    code: number | null;
+    signal: NodeJS.Signals | null;
+  }>((resolveResult, rejectResult) => {
+    proc.child.once("error", rejectResult);
+    proc.child.once("exit", (code, signal) => resolveResult({ code, signal }));
+  });
+  await killProc(proc);
+  if (result.code !== 0) {
+    throw new Error(
+      `[stack] ${name} exited with code=${result.code} signal=${result.signal}`,
+    );
+  }
+}
+
+async function closeProcessDbConnections(): Promise<void> {
+  const { closeDatabaseConnectionsForTests } = await import(
+    "@elizaos/cloud-shared/db/client"
+  );
+  await closeDatabaseConnectionsForTests();
 }
 
 export interface StartCloudStackOptions {
@@ -193,7 +227,6 @@ export async function startCloudStack(
   const pglitePort = await pickFreePort();
   const apiPort = opts.apiPort ?? (await pickFreePort());
   const frontendPort = opts.frontendPort ?? (await pickFreePort());
-
   // 1. In-process mocks
   const hetzner = await startHetznerMock({
     port: hetznerPort,
@@ -202,6 +235,8 @@ export async function startCloudStack(
   const controlPlane = await startControlPlaneMock({
     port: controlPlanePort,
     hetznerUrl: hetzner.url,
+    token: "test-token",
+    expectedAuxToken: "test-token",
     tickMs: Number(process.env.CONTROL_PLANE_TICK_MS ?? "50"),
   });
 
@@ -213,8 +248,6 @@ export async function startCloudStack(
       pglitePort,
     },
     {
-      DATABASE_URL: `pglite://${pgDataDir}`,
-      TEST_DATABASE_URL: "",
       PGLITE_DATA_DIR: pgDataDir,
       DEV_CLOUD_PGLITE_DATA_DIR: pgDataDir,
       DEV_CLOUD_PGLITE_PORT: String(pglitePort),
@@ -224,95 +257,13 @@ export async function startCloudStack(
   );
 
   const procs: SpawnedProc[] = [];
-
-  // 2. PGlite TCP bridge. We start it directly (rather than letting
-  //    cloud-api-dev.mjs manage it) because cloud-api-dev only spawns PGlite
-  //    when DATABASE_URL is empty or `pglite://...`, and we set it to a
-  //    real postgres URL pointing at this very bridge.
-  const pgliteEnv = {
-    ...sharedEnv,
-    PGLITE_HOST: "127.0.0.1",
-    PGLITE_PORT: String(pglitePort),
-    PGLITE_DATA_DIR: pgDataDir,
-    PGLITE_MAX_CONNECTIONS: process.env.PGLITE_MAX_CONNECTIONS ?? "16",
-  };
-  procs.push(
-    spawnLogged(
-      "pglite",
-      "bun",
-      ["run", "packages/scripts/cloud/admin/dev/pglite-server.ts"],
-      {
-        env: pgliteEnv,
-        cwd: REPO_ROOT,
-        logFile: join(LOG_DIR, "pglite.log"),
-      },
-    ),
-  );
-  await waitForTcp("127.0.0.1", pglitePort, {
-    timeoutMs: 60_000,
-    label: "pglite",
-  });
-
-  // 3. cloud-api worker subprocess. cloud-api-dev.mjs will see DATABASE_URL is
-  //    a real postgres URL, skip its own PGlite, run migrations, and exec
-  //    wrangler dev on `apiPort`.
-  const apiEnv = {
-    ...sharedEnv,
-    DEV_CLOUD_SKIP_MIGRATE: opts.skipMigrate ? "1" : "0",
-  };
-  procs.push(
-    spawnLogged(
-      "cloud-api",
-      "node",
-      ["packages/scripts/cloud/admin/dev/cloud-api-dev.mjs"],
-      {
-        env: apiEnv,
-        cwd: REPO_ROOT,
-        logFile: join(LOG_DIR, "cloud-api.log"),
-      },
-    ),
-  );
-
-  const apiUrl = `http://127.0.0.1:${apiPort}`;
-  const databaseUrl = `postgresql://postgres@127.0.0.1:${pglitePort}/postgres`;
   const previousDatabaseUrl = process.env.DATABASE_URL;
   const previousTestDatabaseUrl = process.env.TEST_DATABASE_URL;
-  await waitForHttpOk(`${apiUrl}/api/health`, {
-    timeoutMs: 180_000,
-    label: "cloud-api",
-  });
-  process.env.DATABASE_URL = databaseUrl;
-  process.env.TEST_DATABASE_URL = databaseUrl;
-
-  // 3. cloud-frontend Vite dev
-  const frontendEnv = {
-    ...sharedEnv,
-    PORT: String(frontendPort),
-    VITE_API_BASE_URL: apiUrl,
-    NEXT_PUBLIC_API_BASE_URL: apiUrl,
-  };
-  procs.push(
-    spawnLogged("cloud-frontend", "bun", ["run", "dev"], {
-      env: frontendEnv,
-      cwd: join(REPO_ROOT, "packages", "cloud-frontend"),
-      logFile: join(LOG_DIR, "cloud-frontend.log"),
-    }),
-  );
-
-  const frontendUrl = `http://127.0.0.1:${frontendPort}`;
-  await waitForHttpOk(frontendUrl, {
-    timeoutMs: 120_000,
-    label: "cloud-frontend",
-  });
-
   let stopped = false;
-  const stop = async () => {
-    if (stopped) return;
-    stopped = true;
-    // Reverse order: frontend, api, then mocks
-    for (const proc of [...procs].reverse()) {
-      await killProc(proc).catch(() => undefined);
-    }
+  let processEnvUsesStackDatabase = false;
+  const restoreProcessDatabaseEnv = () => {
+    if (!processEnvUsesStackDatabase) return;
+    processEnvUsesStackDatabase = false;
     if (previousDatabaseUrl === undefined) {
       delete process.env.DATABASE_URL;
     } else {
@@ -323,29 +274,141 @@ export async function startCloudStack(
     } else {
       process.env.TEST_DATABASE_URL = previousTestDatabaseUrl;
     }
+  };
+  const stop = async () => {
+    if (stopped) return;
+    stopped = true;
+    // Reverse order, but keep PGlite alive until process-local pg pools are
+    // closed. Otherwise Playwright can pass all tests and then report a
+    // teardown-level "Connection terminated unexpectedly" outside any test.
+    const reverseProcs = [...procs].reverse();
+    for (const proc of reverseProcs) {
+      if (proc.name === "pglite") continue;
+      await killProc(proc).catch(() => undefined);
+    }
+    await closeProcessDbConnections().catch(() => undefined);
+    for (const proc of reverseProcs) {
+      if (proc.name !== "pglite") continue;
+      await killProc(proc).catch(() => undefined);
+    }
+    restoreProcessDatabaseEnv();
     await controlPlane.stop().catch(() => undefined);
     await hetzner.stop().catch(() => undefined);
     await rm(dataDir, { recursive: true, force: true }).catch(() => undefined);
   };
 
-  // Best-effort cleanup if a test runner SIGINTs us
-  const handler = () => {
-    void stop();
-  };
-  process.once("SIGINT", handler);
-  process.once("SIGTERM", handler);
+  try {
+    // 2. PGlite TCP bridge. We start it directly (rather than letting
+    //    cloud-api-dev.mjs manage it) because cloud-api-dev only spawns PGlite
+    //    when DATABASE_URL is empty or `pglite://...`, and we set it to a
+    //    real postgres URL pointing at this very bridge.
+    const pgliteEnv = {
+      ...sharedEnv,
+      PGLITE_HOST: "127.0.0.1",
+      PGLITE_PORT: String(pglitePort),
+      PGLITE_DATA_DIR: pgDataDir,
+      PGLITE_MAX_CONNECTIONS: process.env.PGLITE_MAX_CONNECTIONS ?? "16",
+    };
+    procs.push(
+      spawnLogged(
+        "pglite",
+        "bun",
+        ["run", "packages/scripts/cloud/admin/dev/pglite-server.ts"],
+        {
+          env: pgliteEnv,
+          cwd: REPO_ROOT,
+          logFile: join(LOG_DIR, "pglite.log"),
+        },
+      ),
+    );
+    await waitForTcp("127.0.0.1", pglitePort, {
+      timeoutMs: 60_000,
+      label: "pglite",
+    });
 
-  return {
-    stop,
-    urls: {
-      api: apiUrl,
-      frontend: frontendUrl,
-      hetzner: hetzner.url,
-      controlPlane: controlPlane.url,
-      pglite: `postgresql://postgres@127.0.0.1:${pglitePort}/postgres`,
-    },
-    mocks: { hetzner, controlPlane },
-    dataDir,
-    logDir: LOG_DIR,
-  };
+    const databaseUrl = `postgresql://postgres@127.0.0.1:${pglitePort}/postgres`;
+    process.env.DATABASE_URL = databaseUrl;
+    process.env.TEST_DATABASE_URL = databaseUrl;
+    processEnvUsesStackDatabase = true;
+
+    if (!opts.skipMigrate) {
+      await runLogged("cloud-api-migrate", "bun", ["run", "db:cloud:migrate"], {
+        env: sharedEnv,
+        cwd: REPO_ROOT,
+        logFile: join(LOG_DIR, "cloud-api.log"),
+      });
+    }
+
+    // 3. cloud-api subprocess. The mock stack uses the same Hono app as the
+    //    Worker, but runs it under Bun instead of Wrangler/workerd so CI
+    //    validates provisioning/onboarding behavior without coupling these
+    //    tests to Wrangler's local dev proxy startup.
+    const apiEnv = {
+      ...sharedEnv,
+      DEV_CLOUD_SKIP_MIGRATE: opts.skipMigrate ? "1" : "0",
+    };
+    procs.push(
+      spawnLogged(
+        "cloud-api",
+        "bun",
+        ["run", "packages/scripts/cloud/admin/dev/cloud-api-hono-dev.ts"],
+        {
+          env: apiEnv,
+          cwd: REPO_ROOT,
+          logFile: join(LOG_DIR, "cloud-api.log"),
+        },
+      ),
+    );
+
+    const apiUrl = `http://127.0.0.1:${apiPort}`;
+    await waitForHttpOk(`${apiUrl}/api/health`, {
+      timeoutMs: 180_000,
+      label: "cloud-api",
+    });
+
+    // 4. cloud-frontend Vite dev
+    const frontendEnv = {
+      ...sharedEnv,
+      PORT: String(frontendPort),
+      VITE_API_BASE_URL: apiUrl,
+      NEXT_PUBLIC_API_BASE_URL: apiUrl,
+    };
+    procs.push(
+      spawnLogged("cloud-frontend", "bun", ["run", "dev"], {
+        env: frontendEnv,
+        cwd: join(REPO_ROOT, "packages", "cloud-frontend"),
+        logFile: join(LOG_DIR, "cloud-frontend.log"),
+      }),
+    );
+
+    const frontendUrl = `http://127.0.0.1:${frontendPort}`;
+    await waitForHttpOk(frontendUrl, {
+      timeoutMs: 120_000,
+      label: "cloud-frontend",
+    });
+
+    // Best-effort cleanup if a test runner SIGINTs us
+    const handler = () => {
+      void stop();
+    };
+    process.once("SIGINT", handler);
+    process.once("SIGTERM", handler);
+
+    return {
+      stop,
+      urls: {
+        api: apiUrl,
+        frontend: frontendUrl,
+        hetzner: hetzner.url,
+        controlPlane: controlPlane.url,
+        pglite: `postgresql://postgres@127.0.0.1:${pglitePort}/postgres`,
+      },
+      mocks: { hetzner, controlPlane },
+      dataDir,
+      logDir: LOG_DIR,
+    };
+  } catch (error) {
+    await stop().catch(() => undefined);
+    throw error;
+  }
 }

--- a/packages/test/cloud-e2e/src/helpers/provisioning.ts
+++ b/packages/test/cloud-e2e/src/helpers/provisioning.ts
@@ -14,6 +14,54 @@ export interface ProvisioningEndpoints {
   apiUrl: string;
 }
 
+export async function createCloudAgent(
+  endpoints: ProvisioningEndpoints,
+  apiKey: string,
+  agentName: string,
+): Promise<string> {
+  const res = await fetch(`${endpoints.apiUrl}/api/v1/eliza/agents`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ agentName }),
+  });
+
+  expect(
+    [200, 201, 202],
+    `agent create returned ${res.status}: ${await res.clone().text()}`,
+  ).toContain(res.status);
+
+  const body = (await res.json()) as {
+    id?: string;
+    sandboxId?: string;
+    data?: { id?: string; sandboxId?: string };
+  };
+  const sandboxId =
+    body.sandboxId ?? body.id ?? body.data?.sandboxId ?? body.data?.id;
+  expect(sandboxId, "expected sandbox id from create response").toBeTruthy();
+  return sandboxId as string;
+}
+
+export async function startAgentProvisioning(
+  endpoints: ProvisioningEndpoints,
+  apiKey: string,
+  sandboxId: string,
+): Promise<void> {
+  const res = await fetch(
+    `${endpoints.apiUrl}/api/v1/eliza/agents/${sandboxId}/provision`,
+    {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}` },
+    },
+  );
+  expect(
+    [200, 202, 409],
+    `agent provision returned ${res.status}: ${await res.clone().text()}`,
+  ).toContain(res.status);
+}
+
 export async function tickProvisioning(
   endpoints: ProvisioningEndpoints,
 ): Promise<Response> {

--- a/packages/test/cloud-e2e/tests/deprovision.spec.ts
+++ b/packages/test/cloud-e2e/tests/deprovision.spec.ts
@@ -1,5 +1,7 @@
 import {
+  createCloudAgent,
   pollSandboxStatus,
+  startAgentProvisioning,
   tickProvisioning,
 } from "../src/helpers/provisioning";
 import { expect, test } from "../src/helpers/test-fixtures";
@@ -10,31 +12,21 @@ test.describe("deprovision", () => {
     seededUser,
   }) => {
     // Provision first so we have something to delete.
-    const createRes = await fetch(`${stack.urls.api}/api/v1/eliza/agents`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${seededUser.apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ name: "e2e-deprovision", plan: "starter" }),
-    });
-    expect([200, 201, 202]).toContain(createRes.status);
-    const created = (await createRes.json()) as {
-      id?: string;
-      sandboxId?: string;
-      data?: { id?: string; sandboxId?: string };
-    };
-    const sandboxId =
-      created.sandboxId ??
-      created.id ??
-      created.data?.sandboxId ??
-      created.data?.id;
-    expect(sandboxId).toBeTruthy();
+    const sandboxId = await createCloudAgent(
+      { apiUrl: stack.urls.api },
+      seededUser.apiKey,
+      "e2e-deprovision",
+    );
+    await startAgentProvisioning(
+      { apiUrl: stack.urls.api },
+      seededUser.apiKey,
+      sandboxId,
+    );
 
     await pollSandboxStatus(
       { apiUrl: stack.urls.api },
       seededUser.apiKey,
-      sandboxId as string,
+      sandboxId,
       "running",
       {
         timeoutMs: 30_000,

--- a/packages/test/cloud-e2e/tests/provision.spec.ts
+++ b/packages/test/cloud-e2e/tests/provision.spec.ts
@@ -1,5 +1,7 @@
 import {
+  createCloudAgent,
   pollSandboxStatus,
+  startAgentProvisioning,
   tickProvisioning,
 } from "../src/helpers/provisioning";
 import { expect, test } from "../src/helpers/test-fixtures";
@@ -13,39 +15,21 @@ test.describe("provision", () => {
     // its CloudSetupSession flow varies build-to-build. The end-state contract
     // is what matters: a provisioning job exists, the cron tick processes it,
     // the sandbox ends `running`.
-    const createRes = await fetch(`${stack.urls.api}/api/v1/eliza/agents`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${seededUser.apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        name: "e2e-provision-agent",
-        plan: "starter",
-      }),
-    });
-
-    expect(
-      [200, 201, 202],
-      `agent create returned ${createRes.status}: ${await createRes.clone().text()}`,
-    ).toContain(createRes.status);
-
-    const created = (await createRes.json()) as {
-      id?: string;
-      sandboxId?: string;
-      data?: { id?: string; sandboxId?: string };
-    };
-    const sandboxId =
-      created.sandboxId ??
-      created.id ??
-      created.data?.sandboxId ??
-      created.data?.id;
-    expect(sandboxId, "expected sandbox id from create response").toBeTruthy();
+    const sandboxId = await createCloudAgent(
+      { apiUrl: stack.urls.api },
+      seededUser.apiKey,
+      "e2e-provision-agent",
+    );
+    await startAgentProvisioning(
+      { apiUrl: stack.urls.api },
+      seededUser.apiKey,
+      sandboxId,
+    );
 
     await pollSandboxStatus(
       { apiUrl: stack.urls.api },
       seededUser.apiKey,
-      sandboxId as string,
+      sandboxId,
       "running",
       {
         timeoutMs: 30_000,

--- a/packages/test/cloud-e2e/tests/stuck-cleanup.spec.ts
+++ b/packages/test/cloud-e2e/tests/stuck-cleanup.spec.ts
@@ -24,10 +24,6 @@ test.describe("stuck-cleanup", () => {
       health_url: "http://127.0.0.1:65535/health",
       database_status: "provisioning",
       environment_vars: {},
-    });
-
-    // Backdate after create so cleanup sees the row as older than the cutoff.
-    await agentSandboxesRepository.update(sandbox.id, {
       created_at: past,
       updated_at: past,
     });

--- a/packages/test/cloud-mocks/package.json
+++ b/packages/test/cloud-mocks/package.json
@@ -19,6 +19,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@elizaos/cloud-shared": "workspace:*",
     "hono": "4.12.18"
   },
   "devDependencies": {

--- a/packages/test/cloud-mocks/src/control-plane/server.ts
+++ b/packages/test/cloud-mocks/src/control-plane/server.ts
@@ -2,6 +2,13 @@ import { type Context, Hono } from "hono";
 import { streamSSE } from "hono/streaming";
 import { ControlPlaneStore, type Job, type Sandbox } from "./store";
 
+type DatabaseJob = {
+  id: string;
+  type: string;
+  data: unknown;
+  max_attempts?: number | null;
+};
+
 export interface ControlPlaneMockOptions {
   /** Bearer token required on every request. Defaults to env or "test-token". */
   token?: string;
@@ -108,14 +115,6 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
     if (c.req.path.startsWith("/api/v1/admin/")) return next();
     // Compat endpoints are public stubs.
     if (c.req.path.startsWith("/api/compat/")) return next();
-    const auth = c.req.header("authorization") ?? c.req.header("Authorization");
-    if (
-      !auth ||
-      !auth.startsWith("Bearer ") ||
-      auth.slice(7).trim() !== token
-    ) {
-      return c.json({ success: false, error: "Unauthorized" }, 401);
-    }
     if (expectedAuxToken) {
       const aux = c.req.header("x-container-control-plane-token")?.trim();
       if (aux !== expectedAuxToken) {
@@ -124,9 +123,161 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
           401,
         );
       }
+      return next();
+    }
+    const auth = c.req.header("authorization") ?? c.req.header("Authorization");
+    if (!auth?.startsWith("Bearer ") || auth.slice(7).trim() !== token) {
+      return c.json({ success: false, error: "Unauthorized" }, 401);
     }
     await next();
   });
+
+  function readJobString(job: DatabaseJob, key: string): string {
+    const data =
+      job.data && typeof job.data === "object"
+        ? (job.data as Record<string, unknown>)
+        : {};
+    const value = data[key];
+    if (typeof value !== "string" || !value.trim()) {
+      throw new Error(`DB-backed mock job ${job.id} missing ${key}`);
+    }
+    return value;
+  }
+
+  async function processDbBackedJobs(
+    databaseUrl: string,
+    origin: string,
+    limit: number,
+  ): Promise<{
+    claimed: number;
+    succeeded: number;
+    failed: number;
+    errors: Array<{ jobId: string; error: string }>;
+  }> {
+    const [
+      { agentSandboxesRepository },
+      { jobsRepository },
+      { runWithCloudBindingsAsync },
+      { JOB_TYPES },
+    ] = await Promise.all([
+      import("@elizaos/cloud-shared/db/repositories/agent-sandboxes.ts"),
+      import("@elizaos/cloud-shared/db/repositories/jobs.ts"),
+      import("@elizaos/cloud-shared/lib/runtime/cloud-bindings.ts"),
+      import("@elizaos/cloud-shared/lib/services/provisioning-job-types.ts"),
+    ]);
+
+    return runWithCloudBindingsAsync(
+      { DATABASE_URL: databaseUrl },
+      async () => {
+        const result = {
+          claimed: 0,
+          succeeded: 0,
+          failed: 0,
+          errors: [] as Array<{ jobId: string; error: string }>,
+        };
+        const batchSize = Math.max(1, Math.floor(limit));
+        const provisionJobs = await jobsRepository.claimPendingJobs({
+          type: JOB_TYPES.AGENT_PROVISION,
+          limit: batchSize,
+        });
+        const deleteJobs = await jobsRepository.claimPendingJobs({
+          type: JOB_TYPES.AGENT_DELETE,
+          limit: Math.max(0, batchSize - provisionJobs.length),
+        });
+
+        for (const job of [...provisionJobs, ...deleteJobs]) {
+          result.claimed += 1;
+          try {
+            if (job.type === JOB_TYPES.AGENT_DELETE) {
+              const agentId = readJobString(job, "agentId");
+              const organizationId = readJobString(job, "organizationId");
+              const existing = await agentSandboxesRepository.findByIdAndOrg(
+                agentId,
+                organizationId,
+              );
+              if (
+                existing?.sandbox_id &&
+                store.getSandbox(existing.sandbox_id)
+              ) {
+                store.updateSandbox(existing.sandbox_id, { status: "deleted" });
+              }
+              await agentSandboxesRepository.delete(agentId, organizationId);
+              await jobsRepository.updateStatus(job.id, "completed", {
+                result: {
+                  cloudAgentId: agentId,
+                  containerStopped: true,
+                  rowDeleted: true,
+                },
+                completed_at: now(),
+              });
+              result.succeeded += 1;
+              continue;
+            }
+
+            const agentId = readJobString(job, "agentId");
+            const organizationId = readJobString(job, "organizationId");
+            const userId = readJobString(job, "userId");
+            const agentName = readJobString(job, "agentName");
+            const sandbox = store.createSandbox({
+              organizationId,
+              userId,
+              agentId,
+            });
+            store.updateSandbox(sandbox.id, { status: "running" });
+            const container = store.createContainer({
+              name: agentName,
+              projectName: `agent-${agentId.slice(0, 8)}`,
+              organizationId,
+              userId,
+              image: defaultAgentImage,
+              actionMs: containerActionMs,
+            });
+            store.updateContainer(container.id, {
+              status: "running",
+              pendingActionAt: undefined,
+              pendingAction: undefined,
+            });
+
+            const bridgeUrl = `${origin}/api/compat/agents/${encodeURIComponent(
+              sandbox.id,
+            )}`;
+            const healthUrl = `${bridgeUrl}/health`;
+            await agentSandboxesRepository.update(agentId, {
+              status: "running",
+              database_status: "ready",
+              database_uri: databaseUrl,
+              sandbox_id: sandbox.id,
+              bridge_url: bridgeUrl,
+              health_url: healthUrl,
+              last_heartbeat_at: now(),
+              error_message: null,
+            });
+            await jobsRepository.updateStatus(job.id, "completed", {
+              result: {
+                cloudAgentId: agentId,
+                status: "running",
+                bridgeUrl,
+                healthUrl,
+              },
+              completed_at: now(),
+            });
+            result.succeeded += 1;
+          } catch (error) {
+            result.failed += 1;
+            const message =
+              error instanceof Error ? error.message : String(error);
+            result.errors.push({ jobId: job.id, error: message });
+            await jobsRepository.incrementAttempt(
+              job.id,
+              message,
+              job.max_attempts ?? 3,
+            );
+          }
+        }
+        return result;
+      },
+    );
+  }
 
   function requireForwardedAuth(
     c: Context,
@@ -219,7 +370,10 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
     const parsed =
       rawLimit !== undefined ? Number.parseInt(rawLimit, 10) : Number.NaN;
     const limit = Number.isFinite(parsed) && parsed > 0 ? parsed : 1000;
-    const result = await tick(limit);
+    const databaseUrl = c.req.header("x-eliza-cloud-database-url")?.trim();
+    const result = databaseUrl
+      ? await processDbBackedJobs(databaseUrl, new URL(c.req.url).origin, limit)
+      : await tick(limit);
     return c.json({ success: true, data: result });
   };
   app.post("/cron/process-provisioning-jobs", processProvisioningJobsHandler);
@@ -250,11 +404,7 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
 
   function requireAdmin(c: Context): Response | null {
     const auth = c.req.header("authorization") ?? c.req.header("Authorization");
-    if (
-      !auth ||
-      !auth.startsWith("Bearer ") ||
-      auth.slice(7).trim() !== adminToken
-    ) {
+    if (!auth?.startsWith("Bearer ") || auth.slice(7).trim() !== adminToken) {
       return c.json({ success: false, error: "Unauthorized (admin)" }, 401);
     }
     return null;
@@ -630,7 +780,7 @@ export function buildControlPlaneApp(options: ControlPlaneMockOptions): {
   // so use a single catchall handler that inspects the suffix.
   const poolCatchallHandler = async (c: Context) => {
     const name = c.req.param("name");
-    if (!name || !name.startsWith("pool-")) {
+    if (!name?.startsWith("pool-")) {
       return c.json({ success: false, error: "Not found" }, 404);
     }
     await latency();


### PR DESCRIPTION
## Summary
- Stabilize the mock cloud E2E stack that was still red after #7803 merged (`Mock-stack E2E`).
- Run the Cloud API route graph under a local Bun/Hono launcher for this mock harness instead of Wrangler dev, while leaving the production Worker path unchanged.
- Align the E2E fixture around one TCP PGlite URL, run migrations before API startup, preserve process logs as hidden artifacts, and close cached DB pools before tearing down PGlite.
- Update provisioning/deprovision tests to the current agent-create + `/provision` contract.
- Teach the control-plane mock to process DB-backed provision/delete jobs when the API forwards `x-eliza-cloud-database-url`, and accept the internal sidecar token forwarded by the API.

## Validation
- `bunx @biomejs/biome check .github/workflows/cloud-e2e.yml packages/scripts/cloud/admin/dev/cloud-api-hono-dev.ts packages/test/cloud-e2e/src/fixtures/stack.ts packages/test/cloud-e2e/src/helpers/provisioning.ts packages/test/cloud-e2e/tests/deprovision.spec.ts packages/test/cloud-e2e/tests/provision.spec.ts packages/test/cloud-e2e/tests/stuck-cleanup.spec.ts packages/test/cloud-mocks/src/control-plane/server.ts packages/test/cloud-mocks/package.json packages/cloud-shared/src/db/client.ts`
- `git diff --check`
- `bun run --cwd packages/test/cloud-e2e typecheck && bun run --cwd packages/cloud-shared typecheck`
- `CI=true timeout 12m bun run cloud:e2e` -> 4 passed in 28.9s on latest `origin/develop`

## Note
- `packages/test/cloud-mocks/test/control-plane.test.ts` currently hangs under `bun test` in this checkout even when filtered to a single public health test, so I did not use that standalone unit file as the ship gate. The CI blocker this PR targets is the full mock-stack E2E workflow, which now passes locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes the mock-stack E2E suite by replacing Wrangler dev with a local Bun/Hono launcher for the cloud-api subprocess, running DB migrations before API startup, and teaching the control-plane mock to process DB-backed provisioning/delete jobs when the API forwards `x-eliza-cloud-database-url`. Teardown ordering is also fixed so process-level pg/PGlite pools are drained before the PGlite TCP bridge is killed.

- **New `cloud-api-hono-dev.ts`**: Runs the same Hono app as the Worker under Bun, providing an in-memory blob store and no-op `ExecutionContext`; the production Cloudflare Worker path is untouched.
- **`closeDatabaseConnectionsForTests()` in `client.ts`**: WeakMap-backed closer registry lets test harnesses explicitly drain PGlite/pg pools before tearing down the ephemeral PGlite server.
- **`processDbBackedJobs` in the control-plane mock**: Dynamic imports from `@elizaos/cloud-shared` allow the mock to claim and complete real DB provisioning/delete jobs, with the sidecar token (`x-container-control-plane-token`) used as the sole auth check replacing the old bearer-only gate.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all changes are confined to test infrastructure and dev tooling; the production Cloudflare Worker and cloud-shared production paths are not affected.

The auth middleware in the control-plane mock now accepts requests carrying only the sidecar aux token, silently dropping the bearer-token check when `expectedAuxToken` is set, and its JSDoc still describes the old dual-token contract. The `/cron/process-provisioning-jobs` endpoint also returns structurally different response bodies depending on whether the DB-URL header is present. Both issues are in test-only mocks with no production exposure.

packages/test/cloud-mocks/src/control-plane/server.ts — the auth middleware change and the divergent cron-tick response shapes.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/test/cloud-mocks/src/control-plane/server.ts | Significant auth-middleware restructuring: aux token now grants access without bearer check; adds DB-backed provisioning job processing via dynamic cloud-shared imports; response shape of the cron tick endpoint diverges between the two code paths. |
| packages/cloud-shared/src/db/client.ts | Adds WeakMap-based closer registry so PGlite/pg pool connections can be explicitly closed; exposes `closeDatabaseConnectionsForTests()` for teardown harnesses. Logic looks correct and is scoped to test/dev paths. |
| packages/scripts/cloud/admin/dev/cloud-api-hono-dev.ts | New local Bun/Hono launcher replacing Wrangler for mock E2E; provides an in-process R2-like blob store, a no-op ExecutionContext, and health endpoint. Clean scoped addition, no production path touched. |
| packages/test/cloud-e2e/src/fixtures/stack.ts | Switches API subprocess from Wrangler to the new Hono launcher, wraps startup in a try/catch that calls stop() on error, adds a runLogged helper for the migration step, and delays PGlite teardown until process-level DB connections are closed. |
| packages/test/cloud-e2e/src/helpers/provisioning.ts | Extracts `createCloudAgent` and `startAgentProvisioning` helpers, aligning tests to the two-step create + /provision contract. Clean refactor with no logic concerns. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/test/cloud-mocks/src/control-plane/server.ts`, line 39-45 ([link](https://github.com/elizaos/eliza/blob/22763f9629f19fdd84a2f9de97f7c6e1a0083316/packages/test/cloud-mocks/src/control-plane/server.ts#L39-L45)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> The option documentation still says the aux token is checked "in addition to the bearer token", but the new implementation accepts requests carrying only the aux token. Update the JSDoc to reflect the actual precedence: when `expectedAuxToken` is set it is the sole auth check; the bearer token is only used when no aux token is configured.


2. `packages/test/cloud-mocks/src/control-plane/server.ts`, line 370-380 ([link](https://github.com/elizaos/eliza/blob/22763f9629f19fdd84a2f9de97f7c6e1a0083316/packages/test/cloud-mocks/src/control-plane/server.ts#L370-L380)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **`/cron/process-provisioning-jobs` response shape diverges between the two code paths**

   When `x-eliza-cloud-database-url` is present the handler returns `{ claimed, succeeded, failed, errors }` (from `processDbBackedJobs`); when absent it returns `{ processed, failed, skipped }` (from `tick()`). The same endpoint now emits structurally different payloads depending on a runtime header. Current tests don't inspect the body, so this is silent today — but any future consumer that introspects the result will need to know which path was taken.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(test): stabilize cloud mock e2e stac..."](https://github.com/elizaos/eliza/commit/22763f9629f19fdd84a2f9de97f7c6e1a0083316) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32934550)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->