### PR TITLE
fix(ui): make voice onboarding skippable

### DIFF
--- a/packages/ui/src/components/onboarding/VoicePrefixSteps.test.tsx
+++ b/packages/ui/src/components/onboarding/VoicePrefixSteps.test.tsx
@@ -52,6 +52,25 @@ describe("VoicePrefixSteps", () => {
     ).toContain("bg-[#0B35F1]");
   });
 
+  it("lets users skip voice setup from the welcome step without microphone access", () => {
+    const onSkipPrefix = vi.fn();
+    render(
+      <VoicePrefixSteps
+        {...baseProps}
+        step="welcome"
+        onSkipPrefix={onSkipPrefix}
+        profilesClient={makeClient()}
+      />,
+    );
+
+    expect(
+      (screen.getByTestId("voice-prefix-continue") as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+    fireEvent.click(screen.getByTestId("voice-prefix-skip-prefix"));
+    expect(onSkipPrefix).toHaveBeenCalledTimes(1);
+  });
+
   it("renders the tier banner for the chosen tier", () => {
     render(
       <VoicePrefixSteps

--- a/packages/ui/src/components/onboarding/VoicePrefixSteps.tsx
+++ b/packages/ui/src/components/onboarding/VoicePrefixSteps.tsx
@@ -180,23 +180,34 @@ export function VoicePrefixSteps(
       </main>
 
       <footer className="flex items-center justify-between">
-        {previousVoicePrefixStep(props.step, tier) ? (
-          <Button
-            variant="ghost"
-            size="sm"
-            className={ELIZAOS_GHOST_BUTTON}
-            onClick={() => {
-              const prev = previousVoicePrefixStep(props.step, tier);
-              if (prev) props.onAdvance(prev);
-              else props.onBack();
-            }}
-            data-testid="voice-prefix-back"
-          >
-            Back
-          </Button>
-        ) : (
-          <span aria-hidden="true" />
-        )}
+        <div className="flex items-center gap-2">
+          {previousVoicePrefixStep(props.step, tier) ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className={ELIZAOS_GHOST_BUTTON}
+              onClick={() => {
+                const prev = previousVoicePrefixStep(props.step, tier);
+                if (prev) props.onAdvance(prev);
+                else props.onBack();
+              }}
+              data-testid="voice-prefix-back"
+            >
+              Back
+            </Button>
+          ) : null}
+          {props.step === "welcome" && props.onSkipPrefix ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              className={ELIZAOS_GHOST_BUTTON}
+              onClick={props.onSkipPrefix}
+              data-testid="voice-prefix-skip-prefix"
+            >
+              Skip voice setup
+            </Button>
+          ) : null}
+        </div>
         <div className="flex items-center gap-2">
           {stepMeta.optional ? (
             <Button

--- a/packages/ui/src/components/onboarding/states/OnboardingAvatar.tsx
+++ b/packages/ui/src/components/onboarding/states/OnboardingAvatar.tsx
@@ -1,0 +1,21 @@
+import type { CSSProperties, JSX } from "react";
+
+import { AvatarHost } from "../../../avatar-runtime";
+
+const onboardingAvatarCanvasStyle = {
+  width: "min(270px, 78vw)",
+  height: 112,
+  pointerEvents: "none",
+} satisfies CSSProperties;
+
+export function OnboardingAvatar(): JSX.Element {
+  return (
+    <div
+      className="eliza-ob-agent-canvas"
+      style={onboardingAvatarCanvasStyle}
+      aria-hidden="true"
+    >
+      <AvatarHost />
+    </div>
+  );
+}

--- a/packages/ui/src/components/onboarding/states/StateCloudChat.tsx
+++ b/packages/ui/src/components/onboarding/states/StateCloudChat.tsx
@@ -1,6 +1,6 @@
 import type { CloudSetupSessionService } from "@elizaos/cloud-sdk/cloud-setup-session";
 import { useCloudSetupSession } from "../../../api/cloud-setup";
-import { AvatarHost } from "../../../avatar-runtime";
+import { OnboardingAvatar } from "./OnboardingAvatar";
 
 export interface CloudProvisioningProgress {
   status: "chat" | "provisioning" | "running" | "error";
@@ -33,12 +33,7 @@ export function StateCloudChat(props: StateCloudChatProps): React.JSX.Element {
       data-eliza-ob-state="cloud-chat"
     >
       <div className="eliza-ob-agent">
-        <div
-          className="eliza-ob-agent-canvas"
-          style={{ width: "min(270px, 78vw)", height: 112 }}
-        >
-          <AvatarHost />
-        </div>
+        <OnboardingAvatar />
         {service ? (
           <LiveTranscript service={service} tenantId={tenantId} />
         ) : (

--- a/packages/ui/src/components/onboarding/states/StateHello.tsx
+++ b/packages/ui/src/components/onboarding/states/StateHello.tsx
@@ -1,4 +1,4 @@
-import { AvatarHost } from "../../../avatar-runtime";
+import { OnboardingAvatar } from "./OnboardingAvatar";
 
 export interface StateHelloProps {
   transcript?: string;
@@ -10,13 +10,7 @@ export function StateHello(props: StateHelloProps): React.JSX.Element {
   return (
     <main className="eliza-ob-screen centered" data-eliza-ob-state="hello">
       <div className="eliza-ob-hello">
-        <div
-          className="eliza-ob-agent-canvas"
-          style={{ width: "min(270px, 78vw)", height: 112 }}
-          aria-hidden="true"
-        >
-          <AvatarHost />
-        </div>
+        <OnboardingAvatar />
         <h1 className="eliza-ob-hello-word">Hello</h1>
         <div
           className="eliza-ob-transcript"

--- a/packages/ui/src/components/onboarding/states/StateLocalDownload.tsx
+++ b/packages/ui/src/components/onboarding/states/StateLocalDownload.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { AvatarHost } from "../../../avatar-runtime";
+import { OnboardingAvatar } from "./OnboardingAvatar";
 
 export interface LocalDownloadProgress {
   ratio: number;
@@ -78,12 +78,7 @@ export function StateLocalDownload(
       data-eliza-ob-state="local-download"
     >
       <div className="eliza-ob-agent">
-        <div
-          className="eliza-ob-agent-canvas"
-          style={{ width: "min(270px, 78vw)", height: 112 }}
-        >
-          <AvatarHost />
-        </div>
+        <OnboardingAvatar />
         <div className="eliza-ob-transcript">
           {transcript ??
             "I need to download some models so we can chat beyond this point, I'll let you know when I'm ready."}

--- a/packages/ui/src/components/onboarding/states/StateMic.tsx
+++ b/packages/ui/src/components/onboarding/states/StateMic.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { AvatarHost } from "../../../avatar-runtime";
+import { OnboardingAvatar } from "./OnboardingAvatar";
 
 export interface AudioInputDevice {
   deviceId: string;
@@ -88,12 +88,7 @@ export function StateMic(props: StateMicProps): React.JSX.Element {
   return (
     <section className="eliza-ob-screen" data-eliza-ob-state="mic">
       <div className="eliza-ob-agent">
-        <div
-          className="eliza-ob-agent-canvas"
-          style={{ width: "min(270px, 78vw)", height: 112 }}
-        >
-          <AvatarHost />
-        </div>
+        <OnboardingAvatar />
         <div className="eliza-ob-transcript">
           {transcript ??
             "You can talk to me if you'd like. But no worries if you're shy. I get it."}

--- a/packages/ui/src/components/onboarding/states/StateProfileLocation.tsx
+++ b/packages/ui/src/components/onboarding/states/StateProfileLocation.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { AvatarHost } from "../../../avatar-runtime";
+import { OnboardingAvatar } from "./OnboardingAvatar";
 
 export interface StateProfileLocationProps {
   transcript?: string;
@@ -18,12 +18,7 @@ export function StateProfileLocation(
       data-eliza-ob-state="profile-location"
     >
       <div className="eliza-ob-agent">
-        <div
-          className="eliza-ob-agent-canvas"
-          style={{ width: "min(270px, 78vw)", height: 112 }}
-        >
-          <AvatarHost />
-        </div>
+        <OnboardingAvatar />
         <div className="eliza-ob-transcript">
           {transcript ??
             "Where do you live? I can use that to set your time and time zone."}

--- a/packages/ui/src/components/onboarding/states/StateProfileName.tsx
+++ b/packages/ui/src/components/onboarding/states/StateProfileName.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { AvatarHost } from "../../../avatar-runtime";
+import { OnboardingAvatar } from "./OnboardingAvatar";
 
 export interface StateProfileNameProps {
   transcript?: string;
@@ -18,12 +18,7 @@ export function StateProfileName(
       data-eliza-ob-state="profile-name"
     >
       <div className="eliza-ob-agent">
-        <div
-          className="eliza-ob-agent-canvas"
-          style={{ width: "min(270px, 78vw)", height: 112 }}
-        >
-          <AvatarHost />
-        </div>
+        <OnboardingAvatar />
         <div className="eliza-ob-transcript">
           {transcript ?? "Okay, can I get your name?"}
         </div>

--- a/packages/ui/src/components/onboarding/states/__tests__/onboarding-avatar.test.tsx
+++ b/packages/ui/src/components/onboarding/states/__tests__/onboarding-avatar.test.tsx
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../../avatar-runtime", () => ({
+  AvatarHost: () => <div data-testid="avatar-host" />,
+}));
+
+import { OnboardingAvatar } from "../OnboardingAvatar";
+
+afterEach(() => cleanup());
+
+describe("OnboardingAvatar", () => {
+  it("keeps the decorative avatar from intercepting onboarding controls", () => {
+    const { container } = render(<OnboardingAvatar />);
+    const wrapper = container.querySelector(".eliza-ob-agent-canvas");
+
+    expect(wrapper).toBeInstanceOf(HTMLElement);
+    expect((wrapper as HTMLElement).style.pointerEvents).toBe("none");
+    expect(wrapper?.getAttribute("aria-hidden")).toBe("true");
+  });
+});


### PR DESCRIPTION
## Summary
- add a first-step `Skip voice setup` action so users can bypass voice onboarding without granting microphone access
- move the decorative onboarding avatar into a shared wrapper with `pointer-events: none` so it cannot block onboarding controls
- cover the skip action and avatar hitbox behavior with focused UI tests

## Validation
- `bunx vitest run packages/ui/src/components/onboarding/VoicePrefixSteps.test.tsx packages/ui/src/components/onboarding/states/__tests__/onboarding-avatar.test.tsx` (10 tests passed)
- `bun run typecheck` from `packages/ui` is currently blocked by unrelated existing repo-wide plugin type errors in Discord, elizacloud, local-inference, shell, and workflow packages; no onboarding errors were surfaced before those failures.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes voice onboarding skippable by adding a "Skip voice setup" button on the welcome step, and extracts the decorative avatar into a shared `OnboardingAvatar` component with `pointer-events: none` so it can no longer block onboarding controls.

- **Skip button**: Rendered in the footer's left-side flex container only when `step === "welcome"` and the optional `onSkipPrefix` prop is supplied; `Continue` remains gated behind mic-permission resolution as before.
- **`OnboardingAvatar` refactor**: Six state screens (`StateCloudChat`, `StateHello`, `StateLocalDownload`, `StateMic`, `StateProfileLocation`, `StateProfileName`) all replace their inline avatar divs with the new shared component, which consistently sets `pointer-events: none` and `aria-hidden="true"` — both of which were missing from several screens previously.
- **Tests**: New focused tests cover the skip action (verifying `Continue` is disabled and `onSkipPrefix` fires) and the avatar hitbox fix (verifying the CSS and ARIA attributes).

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are additive and well-isolated, with the new skip path gated behind an optional prop and tested end-to-end.

The skip button is additive (opt-in via an optional prop), the OnboardingAvatar refactor is a pure extraction with no behavioral change beyond applying pointer-events:none consistently across all six screens, and the tests pass. No state management, auth, or data-flow paths are affected.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/components/onboarding/VoicePrefixSteps.tsx | Footer left-side refactored to wrap Back + new "Skip voice setup" button in a flex container; skip only renders on the "welcome" step when onSkipPrefix is provided |
| packages/ui/src/components/onboarding/states/OnboardingAvatar.tsx | New shared component encapsulating AvatarHost with pointer-events:none and aria-hidden to prevent it from blocking controls |
| packages/ui/src/components/onboarding/VoicePrefixSteps.test.tsx | New test covers skip-from-welcome flow (Continue disabled, click skip, verify callback); module-scoped vi.fn() mocks are unchanged |
| packages/ui/src/components/onboarding/states/__tests__/onboarding-avatar.test.tsx | New test verifies pointer-events:none and aria-hidden are present on the avatar wrapper |
| packages/ui/src/components/onboarding/states/StateCloudChat.tsx | Inline avatar div replaced with OnboardingAvatar; incidentally gains aria-hidden and pointer-events:none that were previously absent |
| packages/ui/src/components/onboarding/states/StateMic.tsx | Inline avatar replaced with OnboardingAvatar; no logic changes |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[VoicePrefixSteps mounted\nstep = welcome] --> B{onSkipPrefix\nprop provided?}
    B -- Yes --> C[Render 'Skip voice setup' button\nin footer left]
    B -- No --> D[Empty left container]
    C --> E{User clicks\nSkip?}
    E -- Yes --> F[onSkipPrefix called\nJump to legacy flow]
    E -- No --> G{Mic permission\nresolved?}
    G -- No --> H[Continue button disabled]
    G -- Yes --> I[Continue button enabled]
    I --> J[onAdvance to next step]
    H --> K[User clicks\n'Grant microphone access']
    K --> L[onRequestMicPermission]
    L --> G
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/ui/src/components/onboarding/VoicePrefixSteps.test.tsx`, line 26-30 ([link](https://github.com/elizaos/eliza/blob/189cd0c6d59cc0d82a0e01c656f10be8f0c81e2b/packages/ui/src/components/onboarding/VoicePrefixSteps.test.tsx#L26-L30)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Shared mocks never reset between tests**

   `baseProps` holds `onAdvance: vi.fn()` and `onBack: vi.fn()` that are constructed once at module scope and reused across all tests in this suite. The `afterEach` only calls `cleanup()`, not `vi.clearAllMocks()` or `vi.resetAllMocks()`. If a future test asserts `baseProps.onAdvance` call count, it will see accumulated calls from every previous test that spread `baseProps`. Consider either moving mock creation into a `beforeEach`, or adding `vi.clearAllMocks()` to the `afterEach`.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fix(ui): make voice onboarding skippable"](https://github.com/elizaos/eliza/commit/c115fbf5325899eb32794c8fe43cdf1ec272d6e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32954157)</sub>

<!-- /greptile_comment -->