### PR TITLE
fix(agent): wait for cloud capability readiness

### DIFF
--- a/packages/agent/src/services/remote-capability-cloud-sandbox.cloud-smoke.test.ts
+++ b/packages/agent/src/services/remote-capability-cloud-sandbox.cloud-smoke.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   installRemoteCapabilityEndpoint,
   provisionCloudCapabilitySandbox,
+  waitForCloudCapabilityEndpointAvailability,
 } from "./remote-capability-cloud-sandbox.ts";
 import { assertRemoteCapabilityEndpointConformance } from "./remote-capability-endpoint-conformance.ts";
 import {
@@ -32,8 +33,12 @@ const cloudProvisionTimeoutMs = readPositiveIntegerEnv(
   "ELIZA_REMOTE_CAPABILITY_CLOUD_PROVISION_TIMEOUT_MS",
   600_000,
 );
+const cloudAvailabilityTimeoutMs = readPositiveIntegerEnv(
+  "ELIZA_REMOTE_CAPABILITY_CLOUD_AVAILABILITY_TIMEOUT_MS",
+  300_000,
+);
 const cloudLiveTestTimeoutMs = Math.max(
-  cloudProvisionTimeoutMs + 120_000,
+  cloudProvisionTimeoutMs + cloudAvailabilityTimeoutMs + 120_000,
   720_000,
 );
 const registeredPluginNames: string[] = [];
@@ -76,6 +81,19 @@ describe("cloud capability sandbox live smoke", () => {
           },
         });
         agentId = provisioned.agentId;
+
+        await waitForCloudCapabilityEndpointAvailability({
+          endpoint: provisioned.endpoint,
+          timeoutMs: cloudAvailabilityTimeoutMs,
+          pollIntervalMs: 5_000,
+          requestTimeoutMs: 60_000,
+          onProgress: (detail) => {
+            console.log(`[cloud-capability-live] availability: ${detail}`);
+          },
+        });
+        console.log(
+          `[cloud-capability-live] availability: endpoint ${provisioned.endpoint.id} reports plugin capability.`,
+        );
 
         installRemoteCapabilityEndpoint(runtime, {
           enabled: true,

--- a/packages/agent/src/services/remote-capability-cloud-sandbox.test.ts
+++ b/packages/agent/src/services/remote-capability-cloud-sandbox.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   connectCloudCapabilitySandbox,
   provisionCloudCapabilitySandbox,
+  waitForCloudCapabilityEndpointAvailability,
 } from "./remote-capability-cloud-sandbox.ts";
 import type { RemoteCapabilityRouterService } from "./remote-capability-router.ts";
 
@@ -149,6 +150,69 @@ describe("cloud capability sandbox provisioner", () => {
         token: "override-token",
       },
     });
+  });
+
+  it("waits until a cloud capability endpoint reports plugin availability", async () => {
+    const progress: string[] = [];
+    const fetchMock = vi.fn(async () => {
+      const attempt = fetchMock.mock.calls.length;
+      if (attempt === 1) {
+        return jsonResponse({
+          available: false,
+          capabilities: { plugin: false },
+        });
+      }
+      return jsonResponse({ available: true, capabilities: { plugin: true } });
+    });
+
+    await expect(
+      waitForCloudCapabilityEndpointAvailability({
+        endpoint: {
+          id: "cloud-capability",
+          baseUrl: "https://capability.example.test",
+          token: "capability-token",
+        },
+        timeoutMs: 1_000,
+        pollIntervalMs: 1,
+        requestTimeoutMs: 1_000,
+        fetch: fetchMock as unknown as typeof fetch,
+        onProgress: (detail) => progress.push(detail),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]?.[0]).toEqual(
+      new URL("https://capability.example.test/v1/capabilities"),
+    );
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      method: "GET",
+      headers: {
+        accept: "application/json",
+        authorization: "Bearer capability-token",
+      },
+    });
+    expect(progress[0]).toContain("unexpected availability payload");
+  });
+
+  it("reports the last readiness failure when cloud availability never starts", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ error: "not ready" }, 503),
+    );
+
+    await expect(
+      waitForCloudCapabilityEndpointAvailability({
+        endpoint: {
+          id: "cloud-capability",
+          baseUrl: "https://capability.example.test",
+        },
+        timeoutMs: 1,
+        pollIntervalMs: 1,
+        requestTimeoutMs: 1_000,
+        fetch: fetchMock as unknown as typeof fetch,
+      }),
+    ).rejects.toThrow(
+      'Cloud capability endpoint cloud-capability did not report plugin availability within 1ms. Last error: HTTP 503: {"error":"not ready"}',
+    );
   });
 
   it("fails when provisioning completes without an endpoint", async () => {

--- a/packages/agent/src/services/remote-capability-cloud-sandbox.ts
+++ b/packages/agent/src/services/remote-capability-cloud-sandbox.ts
@@ -34,6 +34,15 @@ export type CloudCapabilitySandboxProvisionResult = {
   jobId?: string;
 };
 
+export type WaitForCloudCapabilityEndpointAvailabilityOptions = {
+  endpoint: RemoteCapabilityEndpointConfig;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  requestTimeoutMs?: number;
+  fetch?: typeof fetch;
+  onProgress?: (detail: string) => void;
+};
+
 export type ConnectCloudCapabilitySandboxOptions =
   CloudCapabilitySandboxProvisionOptions & {
     unloadMissing?: boolean;
@@ -244,6 +253,99 @@ export async function connectCloudCapabilitySandbox(
     ...(result.jobId === undefined ? {} : { jobId: result.jobId }),
     sync: result.sync,
   };
+}
+
+export async function waitForCloudCapabilityEndpointAvailability(
+  options: WaitForCloudCapabilityEndpointAvailabilityOptions,
+): Promise<void> {
+  const request = options.fetch ?? fetch;
+  const timeoutMs = options.timeoutMs ?? 120_000;
+  const pollIntervalMs = options.pollIntervalMs ?? 5_000;
+  const requestTimeoutMs = options.requestTimeoutMs ?? 60_000;
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "availability was not checked";
+
+  while (Date.now() < deadline) {
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
+      try {
+        const response = await request(
+          new URL("/v1/capabilities", options.endpoint.baseUrl),
+          {
+            method: "GET",
+            headers: {
+              accept: "application/json",
+              ...(options.endpoint.token
+                ? { authorization: `Bearer ${options.endpoint.token}` }
+                : {}),
+            },
+            signal: controller.signal,
+          },
+        );
+        const text = await response.text();
+        if (!response.ok) {
+          lastError = `HTTP ${response.status}: ${text.slice(0, 500)}`;
+        } else {
+          const availability = JSON.parse(text) as {
+            available?: unknown;
+            capabilities?: { plugin?: unknown };
+          };
+          if (
+            availability.available === true &&
+            availability.capabilities?.plugin === true
+          ) {
+            return;
+          }
+          lastError = `unexpected availability payload: ${text.slice(0, 500)}`;
+        }
+      } finally {
+        clearTimeout(timeout);
+      }
+    } catch (error) {
+      lastError = describeAvailabilityError(error);
+    }
+    options.onProgress?.(
+      `waiting for endpoint ${options.endpoint.id}: ${lastError}`,
+    );
+    await sleep(pollIntervalMs);
+  }
+
+  throw new Error(
+    `Cloud capability endpoint ${options.endpoint.id} did not report plugin availability within ${timeoutMs}ms. Last error: ${lastError}`,
+  );
+}
+
+function describeAvailabilityError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  const cause = (error as Error & { cause?: unknown }).cause;
+  if (cause instanceof Error) {
+    return `${error.message}: ${cause.message}`;
+  }
+  if (cause && typeof cause === "object") {
+    const detail = cause as {
+      code?: unknown;
+      errno?: unknown;
+      syscall?: unknown;
+      hostname?: unknown;
+      address?: unknown;
+      port?: unknown;
+    };
+    const parts = [
+      detail.code,
+      detail.errno,
+      detail.syscall,
+      detail.hostname,
+      detail.address,
+      detail.port,
+    ]
+      .filter((value) => typeof value === "string" || typeof value === "number")
+      .map(String);
+    if (parts.length > 0) {
+      return `${error.message}: ${parts.join(" ")}`;
+    }
+  }
+  return error.message;
 }
 
 export {


### PR DESCRIPTION
<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

<!-- LINK TO ISSUE OR TICKET -->

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `waitForCloudCapabilityEndpointAvailability`, a new polling helper that repeatedly queries a cloud sandbox's `/v1/capabilities` endpoint and blocks until both `available` and `capabilities.plugin` are `true` (or the configurable timeout expires). It is wired into the cloud smoke test between provisioning and endpoint installation to prevent the test from connecting to a sandbox that has not finished initialising its plugin layer.

- **New function** (`remote-capability-cloud-sandbox.ts`): poll loop with per-request `AbortController` timeout, structured error descriptions via `describeAvailabilityError`, and a configurable `onProgress` callback; exported for external use.
- **Unit tests** (`remote-capability-cloud-sandbox.test.ts`): cover the retry-until-success path (URL, auth header, progress messages) and the deadline-exceeded path with the last HTTP error in the thrown message.
- **Smoke test** (`remote-capability-cloud-sandbox.cloud-smoke.test.ts`): reads `ELIZA_REMOTE_CAPABILITY_CLOUD_AVAILABILITY_TIMEOUT_MS` from the environment, calls the new helper after provision, and widens the overall test deadline by the availability timeout.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the new polling function is well-structured and the smoke test integration is correct.

The implementation is clean and the test coverage is solid. Two things worth a second look: `JSON.parse` in the 2xx branch is unguarded, so a proxy returning an HTML 200 produces an opaque SyntaxError in `lastError` instead of a body snippet; and the higher-level `connectCloudCapabilitySandbox` doesn't integrate the availability wait, so callers of that API still connect before the plugin layer is ready.

packages/agent/src/services/remote-capability-cloud-sandbox.ts — specifically the JSON.parse in the success branch and the absence of an availability wait in connectCloudCapabilitySandbox.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agent/src/services/remote-capability-cloud-sandbox.ts | Adds `waitForCloudCapabilityEndpointAvailability` — a polling loop that checks `/v1/capabilities` until `available` and `capabilities.plugin` are both true. Logic and error handling are solid; two minor concerns: JSON.parse in the 2xx path is unguarded, and the higher-level `connectCloudCapabilitySandbox` doesn't integrate the new wait step. |
| packages/agent/src/services/remote-capability-cloud-sandbox.test.ts | Adds unit tests for the new availability poller: covers the success-after-retry path (verifying URL, auth header, and progress messages) and the timeout-with-last-error path. Coverage is good. |
| packages/agent/src/services/remote-capability-cloud-sandbox.cloud-smoke.test.ts | Integrates `waitForCloudCapabilityEndpointAvailability` into the live smoke test between provisioning and endpoint installation, with a configurable env-var timeout that extends the overall test deadline accordingly. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Smoke Test
    participant Provision as provisionCloudCapabilitySandbox
    participant Wait as waitForCloudCapabilityEndpointAvailability
    participant API as Cloud API
    participant Sandbox as Cloud Sandbox /v1/capabilities

    Test->>Provision: provision(options)
    Provision->>API: POST /api/v1/eliza/agents
    API-->>Provision: agentId
    Provision->>API: "POST /api/v1/eliza/agents/{id}/provision"
    API-->>Provision: jobId / endpoint
    loop Poll until completed
        Provision->>API: "GET /api/v1/jobs/{jobId}"
        API-->>Provision: status
    end
    Provision-->>Test: "{ agentId, endpoint }"

    Test->>Wait: waitForCloudCapabilityEndpointAvailability(endpoint, timeoutMs)
    loop Poll until available or timeout
        Wait->>Sandbox: GET /v1/capabilities (Bearer token, AbortController)
        Sandbox-->>Wait: "{ available, capabilities }"
        alt "available=true AND capabilities.plugin=true"
            Wait-->>Test: resolve
        else not ready
            Wait->>Wait: sleep(pollIntervalMs)
        end
    end

    Test->>Test: installRemoteCapabilityEndpoint(runtime, endpoint)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/agent/src/services/remote-capability-cloud-sandbox.ts`, line 232-256 ([link](https://github.com/elizaos/eliza/blob/f0397a290dbdf6b21aa5f494008df0ecb57fca12/packages/agent/src/services/remote-capability-cloud-sandbox.ts#L232-L256)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> `connectCloudCapabilitySandbox` not wiring the availability wait

   `connectCloudCapabilitySandbox` is the higher-level API that provisions and wires up the cloud sandbox in one call. It provisions via `connectRemoteCapabilityEndpointProvider` and then immediately returns, without calling `waitForCloudCapabilityEndpointAvailability`. Any caller that uses this function (rather than the manual smoke-test sequence of `provision → wait → install`) will still connect before the plugin capability is ready. Is it intentional to leave the availability wait out of this path, or should `ConnectCloudCapabilitySandboxOptions` also accept an `availabilityTimeoutMs` field so the wait is wired in here?

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(agent): wait for cloud capability re..."](https://github.com/elizaos/eliza/commit/f0397a290dbdf6b21aa5f494008df0ecb57fca12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32965210)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->