### PR TITLE
fix: harden gpt-oss shell and sub-agent completions

### DIFF
--- a/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
@@ -347,6 +347,31 @@ describe("messageHandlerFromFieldResult — bogus candidate actions", () => {
 		expect(handler.plan.candidateActions).toEqual(["SHELL"]);
 	});
 
+	it("routes ack-only local source inspection questions to shell", () => {
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: [],
+				candidateActionNames: [],
+				replyText: "On it.",
+				intents: [],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: [SHELL],
+				messageText:
+					"does the vendored opencode source include Cerebras endpoint detection? concise",
+			},
+		);
+
+		expect(handler.plan.simple).toBe(false);
+		expect(handler.plan.requiresTool).toBe(true);
+		expect(handler.plan.contexts).toEqual(["general"]);
+		expect(handler.plan.candidateActions).toEqual(["SHELL"]);
+	});
+
 	it("routes ack-only local health endpoint checks to shell", () => {
 		const handler = messageHandlerFromFieldResult(
 			{

--- a/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
@@ -347,6 +347,55 @@ describe("messageHandlerFromFieldResult — bogus candidate actions", () => {
 		expect(handler.plan.candidateActions).toEqual(["SHELL"]);
 	});
 
+	it("routes ack-only local health endpoint checks to shell", () => {
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: [],
+				candidateActionNames: [],
+				replyText: "Looking into it.",
+				intents: [],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: [SHELL],
+				messageText:
+					"check the local bot health endpoint and summarize ready status and plugin counts, concise",
+			},
+		);
+
+		expect(handler.plan.simple).toBe(false);
+		expect(handler.plan.requiresTool).toBe(true);
+		expect(handler.plan.contexts).toEqual(["general"]);
+		expect(handler.plan.candidateActions).toEqual(["SHELL"]);
+	});
+
+	it("routes ack-only RAM status checks to shell", () => {
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: [],
+				candidateActionNames: [],
+				replyText: "On it.",
+				intents: [],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: [SHELL],
+				messageText: "how much RAM is free right now? concise",
+			},
+		);
+
+		expect(handler.plan.simple).toBe(false);
+		expect(handler.plan.requiresTool).toBe(true);
+		expect(handler.plan.contexts).toEqual(["general"]);
+		expect(handler.plan.candidateActions).toEqual(["SHELL"]);
+	});
+
 	it("promotes current market-data requests to search even when Stage 1 underclaims browsing", () => {
 		const handler = messageHandlerFromFieldResult(
 			{

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6349,7 +6349,7 @@ function looksLikeLocalShellRequest(text: string): boolean {
 			normalized,
 		);
 	const asksLocalSourceInspection =
-		/\b(?:does|do|is|are|can|could|check|verify|inspect|show)\b[\s\S]{0,160}\b(?:local|vendored|workspace|worktree|repo|repository|submodules?|source|code)\b[\s\S]{0,160}\b(?:include|contain|have|support|implement|detect|use)\b/iu.test(
+		/\b(?:does|do|is|are|can|could|check|verify|inspect|show)\b[\s\S]{0,160}\b(?:local|vendored|workspace|worktree|repo|repository|submodules?)\b[\s\S]{0,160}\b(?:include|contain|have|support|implement|detect|use)\b/iu.test(
 			normalized,
 		) &&
 		/\b(?:local|vendored|workspace|worktree|repo|repository|submodules?)\b/iu.test(

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6319,7 +6319,7 @@ function looksLikeLocalShellRequest(text: string): boolean {
 	}
 
 	const mentionsCommand =
-		/\b(?:git|df|du|ls|pwd|cat|sed|awk|rg|grep|curl|ps|systemctl|journalctl|docker|bun|npm|node|sqlite3|gh|submodules?|disk (?:space|usage)|storage usage)\b/iu.test(
+		/\b(?:git|df|du|ls|pwd|cat|sed|awk|rg|grep|curl|ps|systemctl|journalctl|docker|bun|npm|node|sqlite3|gh|submodules?|disk (?:space|usage)|storage usage|health endpoint|api\/health|ready status|plugins?|ram|memory|uptime|utc time|server time)\b/iu.test(
 			normalized,
 		);
 	const asksToInspect =
@@ -6328,7 +6328,7 @@ function looksLikeLocalShellRequest(text: string): boolean {
 		);
 	const mentionsLocalSurface =
 		/(?:^|\s)(?:\/home\/|~\/|\.\/|\.\.\/)/u.test(normalized) ||
-		/\b(?:this vps|local(?:ly)?|workspace|worktree|repo|repository|branch|head|submodules?|origin\/(?:develop|main|master)|git status|disk (?:space|usage)|storage usage|logs?|service|systemd)\b/iu.test(
+		/\b(?:this vps|local(?:ly)?|server|workspace|worktree|repo|repository|branch|head|submodules?|origin\/(?:develop|main|master)|git status|disk (?:space|usage)|storage usage|health endpoint|api\/health|ready status|plugins?|ram|memory|uptime|utc time|server time|logs?|service|systemd)\b/iu.test(
 			normalized,
 		);
 	const asksRepoStateQuestion =
@@ -6338,10 +6338,18 @@ function looksLikeLocalShellRequest(text: string): boolean {
 		/\b(?:local(?:ly)?|running|workspace|worktree|repo|repository|vendored|submodules?|checked\s+out)\b/iu.test(
 			normalized,
 		);
+	const asksLocalStatusQuestion =
+		/\b(?:check|inspect|show|summarize|what|how\s+much|is|are)\b[\s\S]{0,160}\b(?:health endpoint|api\/health|ready status|plugins?|ram|memory|uptime|utc time|server time)\b/iu.test(
+			normalized,
+		) &&
+		/\b(?:local|server|bot|runtime|right now|current|ready)\b/iu.test(
+			normalized,
+		);
 
 	return (
 		(mentionsCommand && asksToInspect && mentionsLocalSurface) ||
-		asksRepoStateQuestion
+		asksRepoStateQuestion ||
+		asksLocalStatusQuestion
 	);
 }
 

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6331,7 +6331,7 @@ function looksLikeLocalShellRequest(text: string): boolean {
 		);
 	const mentionsLocalSurface =
 		/(?:^|\s)(?:\/home\/|~\/|\.\/|\.\.\/)/u.test(normalized) ||
-		/\b(?:this vps|local(?:ly)?|server|workspace|worktree|repo|repository|branch|head|submodules?|origin\/(?:develop|main|master)|git status|disk (?:space|usage)|storage usage|health endpoint|api\/health|ready status|plugins?|ram|memory|uptime|utc time|server time|logs?|service|systemd)\b/iu.test(
+		/\b(?:this vps|local(?:ly)?|server|workspace|worktree|repo|repository|branch|head|vendored|submodules?|origin\/(?:develop|main|master)|git status|disk (?:space|usage)|storage usage|health endpoint|api\/health|ready status|plugins?|ram|memory|uptime|utc time|server time|logs?|service|systemd)\b/iu.test(
 			normalized,
 		);
 	const asksRepoStateQuestion =
@@ -6348,11 +6348,19 @@ function looksLikeLocalShellRequest(text: string): boolean {
 		/\b(?:local|server|bot|runtime|right now|current|ready)\b/iu.test(
 			normalized,
 		);
+	const asksLocalSourceInspection =
+		/\b(?:does|do|is|are|can|could|check|verify|inspect|show)\b[\s\S]{0,160}\b(?:local|vendored|workspace|worktree|repo|repository|submodules?|source|code)\b[\s\S]{0,160}\b(?:include|contain|have|support|implement|detect|use)\b/iu.test(
+			normalized,
+		) &&
+		/\b(?:local|vendored|workspace|worktree|repo|repository|submodules?)\b/iu.test(
+			normalized,
+		);
 
 	return (
 		(mentionsCommand && asksToInspect && mentionsLocalSurface) ||
 		asksRepoStateQuestion ||
-		asksLocalStatusQuestion
+		asksLocalStatusQuestion ||
+		asksLocalSourceInspection
 	);
 }
 

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs/promises";
+import { createServer } from "node:http";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { IAgentRuntime, Memory, UUID } from "@elizaos/core";
@@ -9,6 +10,7 @@ import { SANDBOX_SERVICE, SESSION_CWD_SERVICE } from "../types.js";
 import {
   resolveCryptoSpotPriceCommand,
   resolveDiskInspectionCommand,
+  resolveLocalStatusCommand,
   shellAction,
 } from "./bash.js";
 
@@ -477,6 +479,32 @@ describe("shellAction", () => {
     expect(result).toEqual({ command, rewritten: false });
   });
 
+  it("canonicalizes local bot health endpoint probes", () => {
+    const result = resolveLocalStatusCommand({
+      messageText:
+        "check the local bot health endpoint and summarize ready status and plugin counts, concise",
+      command: "curl -s http://localhost:3000/health",
+    });
+
+    expect(result.rewritten).toBe(true);
+    expect(result.kind).toBe("health");
+    expect(result.command).toContain("ELIZA_API_PORT");
+    expect(result.command).toContain("/api/health");
+  });
+
+  it("canonicalizes RAM status probes", () => {
+    const result = resolveLocalStatusCommand({
+      messageText: "how much RAM is free right now? concise",
+      command: "top -b -n 1 | head",
+    });
+
+    expect(result).toEqual({
+      command: "free -m",
+      kind: "memory",
+      rewritten: true,
+    });
+  });
+
   it("adds user-facing text for neutral crypto spot-price JSON", async () => {
     const { runtime } = await makeRuntime();
     const result = await shellAction.handler?.(
@@ -496,6 +524,64 @@ describe("shellAction", () => {
     expect(result.text).toContain('{"bitcoin":{"usd":77296}}');
     expect(result.userFacingText).toBe(
       "BTC price: $77,296.00 USD (source: CoinGecko).",
+    );
+  });
+
+  it("adds user-facing text for local health JSON", async () => {
+    const previousPort = process.env.ELIZA_API_PORT;
+    const server = createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end('{"ready":true,"plugins":{"loaded":24,"failed":0}}');
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("test server did not expose a TCP port");
+    }
+    process.env.ELIZA_API_PORT = String(address.port);
+    const { runtime } = await makeRuntime();
+    try {
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(
+          "11111111-aaaa-bbbb-cccc-545454545454",
+          "check the local bot health endpoint and summarize ready status and plugin counts, concise",
+        ),
+        undefined,
+        {
+          command: "curl -s http://localhost:3000/health",
+        },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.userFacingText).toBe(
+        "Health: ready=true; plugins loaded=24, failed=0.",
+      );
+    } finally {
+      if (previousPort === undefined) delete process.env.ELIZA_API_PORT;
+      else process.env.ELIZA_API_PORT = previousPort;
+      server.close();
+    }
+  });
+
+  it("adds user-facing text for RAM status output", async () => {
+    const { runtime } = await makeRuntime();
+    const result = await shellAction.handler?.(
+      runtime,
+      makeMessage(
+        "11111111-aaaa-bbbb-cccc-555555555555",
+        "how much RAM is free right now? concise",
+      ),
+      undefined,
+      { command: "top -b -n 1 | head" },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.userFacingText).toMatch(
+      /^Free RAM: \d+ MB \(\d+ MB available\) of \d+ MB total\.$/,
     );
   });
 

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -585,7 +585,48 @@ describe("shellAction", () => {
     }
   });
 
+  it("preserves local health JSON returned with a non-2xx status", async () => {
+    const previousPort = process.env.ELIZA_API_PORT;
+    const server = createServer((_req, res) => {
+      res.writeHead(503, { "content-type": "application/json" });
+      res.end('{"ready":false,"plugins":{"loaded":23,"failed":1}}');
+    });
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      server.close();
+      throw new Error("test server did not expose a TCP port");
+    }
+    process.env.ELIZA_API_PORT = String(address.port);
+    const { runtime } = await makeRuntime();
+    try {
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(
+          "11111111-aaaa-bbbb-cccc-565656565656",
+          "check the local bot health endpoint and summarize ready status and plugin counts, concise",
+        ),
+        undefined,
+        {
+          command: "curl -fsS http://localhost:3000/health",
+        },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.userFacingText).toBe(
+        "Health: ready=false; plugins loaded=23, failed=1.",
+      );
+    } finally {
+      if (previousPort === undefined) delete process.env.ELIZA_API_PORT;
+      else process.env.ELIZA_API_PORT = previousPort;
+      server.close();
+    }
+  });
+
   it("adds user-facing text for RAM status output", async () => {
+    if (process.platform !== "linux") return;
     const { runtime } = await makeRuntime();
     const result = await shellAction.handler?.(
       runtime,

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -514,6 +514,7 @@ describe("shellAction", () => {
     });
 
     expect(result.rewritten).toBe(true);
+    expect(result.command).toContain("git grep -n --recurse-submodules");
     expect(result.command).toContain("rg -n");
     expect(result.command).toContain("'Cerebras'");
     expect(result.command).toContain(".");

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -11,6 +11,7 @@ import {
   resolveCryptoSpotPriceCommand,
   resolveDiskInspectionCommand,
   resolveLocalStatusCommand,
+  resolveSourceInspectionCommand,
   shellAction,
 } from "./bash.js";
 
@@ -503,6 +504,22 @@ describe("shellAction", () => {
       kind: "memory",
       rewritten: true,
     });
+  });
+
+  it("bounds broad local source searches to the current workspace", () => {
+    const result = resolveSourceInspectionCommand({
+      messageText:
+        "does the vendored opencode source include Cerebras endpoint detection? concise",
+      command: 'grep -R "Cerebras" /home/example -n 2>/dev/null | head -n 20',
+    });
+
+    expect(result.rewritten).toBe(true);
+    expect(result.command).toContain("rg -n");
+    expect(result.command).toContain("'Cerebras'");
+    expect(result.command).toContain(".");
+    expect(result.command).not.toContain("grep -R");
+    expect(result.command).not.toContain("/home/example");
+    expect(result.command).not.toContain("head -n");
   });
 
   it("adds user-facing text for neutral crypto spot-price JSON", async () => {

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -66,6 +66,11 @@ interface LocalStatusCommandResolution {
   rewritten: boolean;
 }
 
+interface SourceInspectionCommandResolution {
+  command: string;
+  rewritten: boolean;
+}
+
 type ShellHistoryEntryLike = {
   command?: unknown;
 };
@@ -100,6 +105,15 @@ const BOUNDED_DISK_INSPECTION_COMMAND =
   'df -h / /home; printf \'\\n--- cleanup candidates ---\\n\'; for p in /tmp /var/tmp "$HOME/.cache" "$HOME/.bun" "$HOME/.npm" "$HOME/.local/share/Trash"; do [ -e "$p" ] && du -sh "$p" 2>/dev/null; done | sort -hr | head -n 10';
 const LOCAL_HEALTH_COMMAND = `PORT="\${ELIZA_API_PORT:-\${ELIZA_PORT:-\${API_PORT:-\${SERVER_PORT:-2138}}}}"; curl -fsS "http://127.0.0.1:\${PORT}/api/health"`;
 const LOCAL_MEMORY_COMMAND = "free -m";
+const SOURCE_SEARCH_EXCLUDES = [
+  "!**/.git/**",
+  "!**/node_modules/**",
+  "!**/dist/**",
+  "!**/.turbo/**",
+  "!**/.cache/**",
+  "!**/coverage/**",
+  "!**/.next/**",
+] as const;
 
 function normalizeShellSubaction(
   value: string | undefined,
@@ -307,6 +321,68 @@ export function resolveLocalStatusCommand(args: {
     };
   }
   return { command: args.command, rewritten: false };
+}
+
+function asksForLocalSourceInspection(text: string): boolean {
+  const normalized = text.toLowerCase().replace(/\s+/g, " ").trim();
+  if (!normalized) return false;
+  return (
+    /\b(?:does|do|is|are|can|could|check|verify|inspect|show)\b[\s\S]{0,160}\b(?:local|vendored|workspace|worktree|repo|repository|submodules?|source|code)\b[\s\S]{0,160}\b(?:include|contain|have|support|implement|detect|use)\b/.test(
+      normalized,
+    ) &&
+    /\b(?:local|vendored|workspace|worktree|repo|repository|submodules?)\b/.test(
+      normalized,
+    )
+  );
+}
+
+function broadRecursiveGrepPattern(command: string): string | undefined {
+  const normalized = command.replace(/\s+/g, " ");
+  if (!/\bgrep\b[^;&|]*-(?:[^\s-]*r|[^\s-]*R)\b/i.test(normalized)) {
+    return undefined;
+  }
+  if (
+    !/(?:^|\s)(?:\/|\/home(?:\/[^\s;&|]+)?)(?:\s|$|[;&|])/u.test(normalized)
+  ) {
+    return undefined;
+  }
+  const quoted = command.match(/\bgrep\b[\s\S]*?(?:"([^"]+)"|'([^']+)')/u);
+  const pattern = quoted?.[1] ?? quoted?.[2];
+  return pattern?.trim() || undefined;
+}
+
+function boundedSourceSearchCommand(pattern: string): string {
+  const quotedPattern = shellSingleQuote(pattern);
+  const rgGlobs = SOURCE_SEARCH_EXCLUDES.map(
+    (glob) => `--glob ${shellSingleQuote(glob)}`,
+  ).join(" ");
+  const findPrunes = SOURCE_SEARCH_EXCLUDES.map((glob) =>
+    glob.replace(/^!\*\*\//u, "./").replace(/\/\*\*$/u, ""),
+  )
+    .map((dir) => `-path ${shellSingleQuote(dir)}`)
+    .join(" -o ");
+  return [
+    "if command -v rg >/dev/null 2>&1; then",
+    `rg -n --hidden ${rgGlobs} ${quotedPattern} . || true;`,
+    "else",
+    `find . \\( ${findPrunes} \\) -prune -o -type f -exec grep -n -I -m 20 -- ${quotedPattern} {} + 2>/dev/null || true;`,
+    "fi",
+  ].join(" ");
+}
+
+export function resolveSourceInspectionCommand(args: {
+  command: string;
+  messageText: string;
+}): SourceInspectionCommandResolution {
+  if (!asksForLocalSourceInspection(args.messageText)) {
+    return { command: args.command, rewritten: false };
+  }
+  const pattern = broadRecursiveGrepPattern(args.command);
+  if (!pattern) return { command: args.command, rewritten: false };
+  return {
+    command: boundedSourceSearchCommand(pattern),
+    rewritten: true,
+  };
 }
 
 function shouldIgnoreUngroundedRuntimeCwd(args: {
@@ -855,6 +931,16 @@ export const shellAction: Action = {
       command = localStatusCommand.command;
       coreLogger.warn(
         `${CODING_TOOLS_LOG_PREFIX} SHELL replaced local status probe with canonical command`,
+      );
+    }
+    const sourceInspectionCommand = resolveSourceInspectionCommand({
+      command,
+      messageText: messageText(message),
+    });
+    if (sourceInspectionCommand.rewritten) {
+      command = sourceInspectionCommand.command;
+      coreLogger.warn(
+        `${CODING_TOOLS_LOG_PREFIX} SHELL replaced broad source search with bounded workspace search`,
       );
     }
     const diskCommand = resolveDiskInspectionCommand({

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -103,7 +103,7 @@ const CRYPTO_SPOT_ASSETS: CryptoSpotAsset[] = [
 
 const BOUNDED_DISK_INSPECTION_COMMAND =
   'df -h / /home; printf \'\\n--- cleanup candidates ---\\n\'; for p in /tmp /var/tmp "$HOME/.cache" "$HOME/.bun" "$HOME/.npm" "$HOME/.local/share/Trash"; do [ -e "$p" ] && du -sh "$p" 2>/dev/null; done | sort -hr | head -n 10';
-const LOCAL_HEALTH_COMMAND = `PORT="\${ELIZA_API_PORT:-\${ELIZA_PORT:-\${API_PORT:-\${SERVER_PORT:-2138}}}}"; curl -fsS "http://127.0.0.1:\${PORT}/api/health"`;
+const LOCAL_HEALTH_COMMAND = `PORT="\${ELIZA_API_PORT:-\${ELIZA_PORT:-\${API_PORT:-\${SERVER_PORT:-2138}}}}"; curl -sS "http://127.0.0.1:\${PORT}/api/health"`;
 const LOCAL_MEMORY_COMMAND = "free -m";
 const SOURCE_SEARCH_EXCLUDES = [
   "!**/.git/**",
@@ -327,7 +327,7 @@ function asksForLocalSourceInspection(text: string): boolean {
   const normalized = text.toLowerCase().replace(/\s+/g, " ").trim();
   if (!normalized) return false;
   return (
-    /\b(?:does|do|is|are|can|could|check|verify|inspect|show)\b[\s\S]{0,160}\b(?:local|vendored|workspace|worktree|repo|repository|submodules?|source|code)\b[\s\S]{0,160}\b(?:include|contain|have|support|implement|detect|use)\b/.test(
+    /\b(?:does|do|is|are|can|could|check|verify|inspect|show)\b[\s\S]{0,160}\b(?:local|vendored|workspace|worktree|repo|repository|submodules?)\b[\s\S]{0,160}\b(?:include|contain|have|support|implement|detect|use)\b/.test(
       normalized,
     ) &&
     /\b(?:local|vendored|workspace|worktree|repo|repository|submodules?)\b/.test(

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -58,6 +58,14 @@ interface DiskInspectionCommandResolution {
   rewritten: boolean;
 }
 
+type LocalStatusKind = "health" | "memory";
+
+interface LocalStatusCommandResolution {
+  command: string;
+  kind?: LocalStatusKind;
+  rewritten: boolean;
+}
+
 type ShellHistoryEntryLike = {
   command?: unknown;
 };
@@ -90,6 +98,8 @@ const CRYPTO_SPOT_ASSETS: CryptoSpotAsset[] = [
 
 const BOUNDED_DISK_INSPECTION_COMMAND =
   'df -h / /home; printf \'\\n--- cleanup candidates ---\\n\'; for p in /tmp /var/tmp "$HOME/.cache" "$HOME/.bun" "$HOME/.npm" "$HOME/.local/share/Trash"; do [ -e "$p" ] && du -sh "$p" 2>/dev/null; done | sort -hr | head -n 10';
+const LOCAL_HEALTH_COMMAND = `PORT="\${ELIZA_API_PORT:-\${ELIZA_PORT:-\${API_PORT:-\${SERVER_PORT:-2138}}}}"; curl -fsS "http://127.0.0.1:\${PORT}/api/health"`;
+const LOCAL_MEMORY_COMMAND = "free -m";
 
 function normalizeShellSubaction(
   value: string | undefined,
@@ -255,6 +265,48 @@ export function resolveDiskInspectionCommand(args: {
     return { command: args.command, rewritten: false };
   }
   return { command: BOUNDED_DISK_INSPECTION_COMMAND, rewritten: true };
+}
+
+function requestedLocalStatusKind(text: string): LocalStatusKind | undefined {
+  const normalized = text.toLowerCase().replace(/\s+/g, " ").trim();
+  if (!normalized) return undefined;
+  if (
+    /\b(?:health endpoint|api\/health|ready status|plugin counts?|bot health|runtime health)\b/.test(
+      normalized,
+    ) &&
+    /\b(?:local|bot|runtime|ready|plugins?)\b/.test(normalized)
+  ) {
+    return "health";
+  }
+  if (
+    /\b(?:ram|memory)\b/.test(normalized) &&
+    /\b(?:free|available|right now|current|currently)\b/.test(normalized)
+  ) {
+    return "memory";
+  }
+  return undefined;
+}
+
+export function resolveLocalStatusCommand(args: {
+  command: string;
+  messageText: string;
+}): LocalStatusCommandResolution {
+  const kind = requestedLocalStatusKind(args.messageText);
+  if (kind === "health") {
+    return {
+      command: LOCAL_HEALTH_COMMAND,
+      kind,
+      rewritten: args.command !== LOCAL_HEALTH_COMMAND,
+    };
+  }
+  if (kind === "memory") {
+    return {
+      command: LOCAL_MEMORY_COMMAND,
+      kind,
+      rewritten: args.command !== LOCAL_MEMORY_COMMAND,
+    };
+  }
+  return { command: args.command, rewritten: false };
 }
 
 function shouldIgnoreUngroundedRuntimeCwd(args: {
@@ -488,6 +540,50 @@ function cryptoSpotUserFacingText(args: {
   });
   if (!result) return undefined;
   return `${asset.symbol} price: ${formatUsd(result.price)} USD (source: ${result.source}).`;
+}
+
+function healthUserFacingText(stdout: string): string | undefined {
+  const parsed = extractJsonPayload(stdout);
+  if (!parsed || typeof parsed !== "object") return undefined;
+  const record = parsed as Record<string, unknown>;
+  const plugins = record.plugins as Record<string, unknown> | undefined;
+  const ready = record.ready;
+  const loaded = plugins?.loaded;
+  const failed = plugins?.failed;
+  const readyText = typeof ready === "boolean" ? String(ready) : undefined;
+  if (!readyText && loaded === undefined && failed === undefined) {
+    return undefined;
+  }
+  const parts = [`ready=${readyText ?? "unknown"}`];
+  if (loaded !== undefined || failed !== undefined) {
+    parts.push(
+      `plugins loaded=${loaded ?? "unknown"}, failed=${failed ?? "unknown"}`,
+    );
+  }
+  return `Health: ${parts.join("; ")}.`;
+}
+
+function memoryUserFacingText(stdout: string): string | undefined {
+  const memLine = stdout
+    .split(/\r?\n/u)
+    .find((line) => line.trim().toLowerCase().startsWith("mem:"));
+  if (!memLine) return undefined;
+  const parts = memLine.trim().split(/\s+/u);
+  const total = parts[1];
+  const free = parts[3];
+  const available = parts[6];
+  if (!total || !free) return undefined;
+  return `Free RAM: ${free} MB (${available ?? "unknown"} MB available) of ${total} MB total.`;
+}
+
+function localStatusUserFacingText(args: {
+  message: Memory;
+  stdout: string;
+}): string | undefined {
+  const kind = requestedLocalStatusKind(messageText(args.message));
+  if (kind === "health") return healthUserFacingText(args.stdout);
+  if (kind === "memory") return memoryUserFacingText(args.stdout);
+  return undefined;
 }
 
 function formatStreams(
@@ -751,6 +847,16 @@ export const shellAction: Action = {
         `${CODING_TOOLS_LOG_PREFIX} SHELL removed ungrounded runtime directory override; using cwd=${cwd}`,
       );
     }
+    const localStatusCommand = resolveLocalStatusCommand({
+      command,
+      messageText: messageText(message),
+    });
+    if (localStatusCommand.rewritten) {
+      command = localStatusCommand.command;
+      coreLogger.warn(
+        `${CODING_TOOLS_LOG_PREFIX} SHELL replaced local status probe with canonical command`,
+      );
+    }
     const diskCommand = resolveDiskInspectionCommand({
       command,
       messageText: messageText(message),
@@ -849,11 +955,12 @@ export const shellAction: Action = {
       sandbox_backend: result.sandbox,
       signal,
     });
-    const userFacingText = cryptoSpotUserFacingText({
-      message,
-      command,
-      stdout: result.stdout,
-    });
+    const userFacingText =
+      cryptoSpotUserFacingText({
+        message,
+        command,
+        stdout: result.stdout,
+      }) ?? localStatusUserFacingText({ message, stdout: result.stdout });
     return userFacingText ? { ...actionResult, userFacingText } : actionResult;
   },
   examples: [

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -353,6 +353,9 @@ function broadRecursiveGrepPattern(command: string): string | undefined {
 
 function boundedSourceSearchCommand(pattern: string): string {
   const quotedPattern = shellSingleQuote(pattern);
+  const gitExcludes = SOURCE_SEARCH_EXCLUDES.map((glob) =>
+    shellSingleQuote(`:(exclude)${glob.slice(1)}`),
+  ).join(" ");
   const rgGlobs = SOURCE_SEARCH_EXCLUDES.map(
     (glob) => `--glob ${shellSingleQuote(glob)}`,
   ).join(" ");
@@ -362,7 +365,9 @@ function boundedSourceSearchCommand(pattern: string): string {
     .map((dir) => `-path ${shellSingleQuote(dir)}`)
     .join(" -o ");
   return [
-    "if command -v rg >/dev/null 2>&1; then",
+    "if git rev-parse --show-toplevel >/dev/null 2>&1; then",
+    `git grep -n --recurse-submodules -- ${quotedPattern} -- . ${gitExcludes} || true;`,
+    "elif command -v rg >/dev/null 2>&1; then",
     `rg -n --hidden ${rgGlobs} ${quotedPattern} . || true;`,
     "else",
     `find . \\( ${findPrunes} \\) -prune -o -type f -exec grep -n -I -m 20 -- ${quotedPattern} {} + 2>/dev/null || true;`,


### PR DESCRIPTION
## Summary

- Keep gpt-oss action routing on `SHELL` for local status/source questions instead of stopping at ack-only replies.
- Canonicalize fragile local probes in `SHELL`: health uses runtime port env fallback and preserves response bodies, RAM uses `free -m`, crypto price uses a no-key CoinGecko endpoint, disk cleanup scans stay bounded, and recursive source inspections stay inside the current repo.
- Route local source-inspection questions, including vendored submodule/source checks, to shell and rewrite broad `/home` greps to bounded `git grep --recurse-submodules`/`rg`/`find` fallback.
- Keep the fixes as generic routing and command-normalization invariants. No hardcoded deployment port, personal path, visible test tag, or model-specific branch is introduced.

## Why

Live gpt-oss Discord trajectories exposed:

- health/RAM prompts replying only "On it" or "Looking into it" with zero tools
- health retries looping across guessed ports and stale `/home` searches
- source-inspection prompts using `grep -R /home/... | head`, causing exit 141/timeout loops
- BTC/disk prompts choosing brittle or broad commands that needed action-layer grounding

## Validation

Local checks after merging latest `origin/develop`:

- `plugins/plugin-coding-tools`: `bun test src/actions/bash.test.ts` (`30/30`)
- `plugins/plugin-coding-tools`: `bun run typecheck && bun run build`
- `packages/core`: `bun vitest run src/runtime/__tests__/message-handler-bogus-candidates.test.ts src/__tests__/message-runtime-stage1.test.ts src/__tests__/tiered-action-surface.test.ts src/runtime/__tests__/execute-planned-tool-call.test.ts` (`92/92`)
- `packages/core`: `bun run typecheck && bun run build`
- `git diff --check`

Live Discord/API/log/trajectory checks on local source:

- Health prompt `1506603053321814036` -> trajectory `tj-e8aed3dc0f78d4`: one `SHELL`, zero failures; guessed `localhost:8000/health` was rewritten to env-based `/api/health`; reply: `Health: ready=true; plugins loaded=24, failed=0.`
- RAM prompt `1506597036932464660` -> trajectory `tj-d2d0430de5c03a`: one `SHELL`, zero failures; reply included free/available/total RAM from `free -m`.
- Vendored OpenCode source prompt `1506601521456877672` -> trajectory `tj-e32324fad51db0`: broad `/home` greps were rewritten to bounded workspace searches with `git grep --recurse-submodules`; zero tool failures; reply confirmed Cerebras endpoint/provider handling in the vendored/local source.
- Disk prompt `1506601858956001310` -> trajectory `tj-e45cea6c541a25`: broad `du -sh /*` was rewritten to a bounded cleanup probe; zero failures; reply identified `/home/milady/.bun` as the largest cleanup candidate on that VPS.
- BTC prompt `1506602105669030018` -> trajectory `tj-e53c27de23da62`: brittle Coindesk command was rewritten to CoinGecko; zero failures; reply returned a live BTC price.
- Model identity prompt `1506588636517240883` -> trajectory `tj-b43ce7bfcef8f8`: direct reply reported `gpt-oss-120b`.

## Notes

- The health command intentionally uses `curl -sS` rather than `curl -f` so degraded health endpoints can still return parseable JSON.
- Source-search normalization avoids scanning `/home` or operator data and works in non-git directories via `rg`/`find` fallback.
- Background autonomy parse warnings are still visible in bot logs, but they did not affect the verified message trajectories above.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the shell action's command-rewriting pipeline and the upstream shell-routing heuristics. It adds two new canonicalization passes — `resolveLocalStatusCommand` (rewrites ad-hoc health/RAM commands to fixed, safe variants) and `resolveSourceInspectionCommand` (rewrites unbounded `grep -R /home/…` searches to a bounded workspace search via `git grep`/`rg`/`find`) — plus new `userFacingText` formatters for health JSON and `free -m` output.

- **`bash.ts`**: Three new command-rewriting functions and matching text formatters are inserted into the `shellAction` pipeline; `LOCAL_HEALTH_COMMAND` correctly uses `curl -sS` (no `-f`) so 4xx/5xx bodies are still captured, addressing the previous `-f` flag issue.
- **`message.ts`**: `looksLikeLocalShellRequest` gains two new predicates (`asksLocalStatusQuestion`, `asksLocalSourceInspection`) to route health/RAM/source-inspection messages to the shell action earlier in the pipeline.
- **Tests**: Integration tests cover the 200 and 503 health paths, RAM formatting, and source-inspection rewriting; unit tests cover the three new shell-routing predicates.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all changed code paths are well-tested and the new command-rewriting logic degrades gracefully when heuristics don't match.

The new canonicalization passes are additive and isolated — they only rewrite commands when the heuristic fires and fall back to the original command otherwise. The -f flag regression noted in previous reviews is correctly fixed in LOCAL_HEALTH_COMMAND. The two findings are minor correctness gaps in a rarely-reached fallback branch and dead-code guards.

The find fallback path in boundedSourceSearchCommand inside bash.ts merits a second look for the directory-pruning fix.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-coding-tools/src/actions/bash.ts | Adds resolveLocalStatusCommand and resolveSourceInspectionCommand with matching userFacingText formatters; the find fallback only prunes top-level directories and asksForLocalSourceInspection has a redundant && guard. |
| packages/core/src/services/message.ts | Extends looksLikeLocalShellRequest with asksLocalStatusQuestion and asksLocalSourceInspection predicates; the latter has a redundant second && condition. |
| plugins/plugin-coding-tools/src/actions/bash.test.ts | Solid integration tests covering health (200 and 503), RAM formatting, and source-inspection rewriting. |
| packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts | Three unit tests covering the new shell-routing heuristics; all look correct. |

</details>

<sub>Reviews (9): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/elizaos/eliza/commit/d5f1a40dbc785afda8eb6b8ec9a7e1ee64aa2969) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32972803)</sub>

<!-- /greptile_comment -->