### PR TITLE
chore: merge develop → main (workflow fixes + beta release)

### DIFF
--- a/.github/workflows/e1-chip.yml
+++ b/.github/workflows/e1-chip.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Fix permissions on docker-written reports
         if: always()
         continue-on-error: true
-        run: sudo chmod -R a+rX packages/chip/build packages/chip/verify || true
+        run: sudo chown -R "$(id -u):$(id -g)" build verify 2>/dev/null || true; sudo chmod -R a+rX build verify || true
 
       - name: Upload regression artifacts
         uses: actions/upload-artifact@v4

--- a/bun.lock
+++ b/bun.lock
@@ -3665,7 +3665,11 @@
       "peerDependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
+        "node-llama-cpp": "*",
       },
+      "optionalPeers": [
+        "node-llama-cpp",
+      ],
     },
     "plugins/plugin-local-storage": {
       "name": "@elizaos/plugin-local-storage",

--- a/bun.lock
+++ b/bun.lock
@@ -83,7 +83,7 @@
     },
     "packages/agent": {
       "name": "@elizaos/agent",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "bin": {
         "eliza-autonomous": "./src/bin.ts",
       },
@@ -267,7 +267,7 @@
     },
     "packages/app-core": {
       "name": "@elizaos/app-core",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@capacitor-community/sqlite": "^7.0.0",
         "@capacitor/barcode-scanner": "^3.0.0",
@@ -361,7 +361,7 @@
     },
     "packages/app-core/platforms/electrobun": {
       "name": "@elizaos/electrobun",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/agent": "workspace:*",
         "@elizaos/app-core": "workspace:*",
@@ -472,7 +472,7 @@
     },
     "packages/cloud-api": {
       "name": "@elizaos/cloud-api",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@ai-sdk/gateway": "^3.0.37",
         "@ai-sdk/openai": "^3.0.54",
@@ -506,7 +506,7 @@
     },
     "packages/cloud-frontend": {
       "name": "@elizaos/cloud-frontend",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/cloud-shared": "workspace:*",
         "@elizaos/shared": "workspace:*",
@@ -594,7 +594,7 @@
     },
     "packages/cloud-routing": {
       "name": "@elizaos/cloud-routing",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
         "@types/node": "^25.0.0",
@@ -604,7 +604,7 @@
     },
     "packages/cloud-sdk": {
       "name": "@elizaos/cloud-sdk",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
     },
     "packages/cloud-services/_common": {
       "name": "@elizaos/cloud-services-common",
@@ -795,7 +795,7 @@
     },
     "packages/contracts": {
       "name": "@elizaos/contracts",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
         "@types/node": "^25.1.0",
@@ -804,7 +804,7 @@
     },
     "packages/core": {
       "name": "@elizaos/core",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.13",
         "@ai-sdk/gateway": "3.0.109",
@@ -865,7 +865,7 @@
     },
     "packages/elizaos": {
       "name": "elizaos",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "bin": {
         "elizaos": "./dist/cli.js",
       },
@@ -2391,11 +2391,11 @@
     },
     "packages/prompts": {
       "name": "@elizaos/prompts",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
     },
     "packages/robot": {
       "name": "@elizaos/robot",
-      "version": "2.0.0-beta.0",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -2410,7 +2410,7 @@
     },
     "packages/scenario-runner": {
       "name": "@elizaos/scenario-runner",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "bin": {
         "eliza-scenarios": "./bin/eliza-scenarios",
       },
@@ -2428,7 +2428,7 @@
     },
     "packages/shared": {
       "name": "@elizaos/shared",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/contracts": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -2452,7 +2452,7 @@
     },
     "packages/skills": {
       "name": "@elizaos/skills",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "yaml": "^2.8.2",
@@ -2493,7 +2493,7 @@
     },
     "packages/tui": {
       "name": "@elizaos/tui",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@types/mime-types": "^2.1.4",
         "chalk": "^5.5.0",
@@ -2509,7 +2509,7 @@
     },
     "packages/ui": {
       "name": "@elizaos/ui",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/app-core": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -2601,7 +2601,7 @@
     },
     "packages/vault": {
       "name": "@elizaos/vault",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@electric-sql/pglite": "^0.4.0",
         "@napi-rs/keyring": "^1.1.6",
@@ -2614,7 +2614,7 @@
     },
     "packages/workflows": {
       "name": "@elizaos/workflows",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
         "@types/node": "^25.1.0",
@@ -2623,7 +2623,7 @@
     },
     "plugins/app-model-tester": {
       "name": "@elizaos/app-model-tester",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/app-core": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -2639,7 +2639,7 @@
     },
     "plugins/plugin-2004scape": {
       "name": "@elizaos/plugin-2004scape",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/agent": "workspace:*",
         "@elizaos/app-core": "workspace:*",
@@ -2658,7 +2658,7 @@
     },
     "plugins/plugin-agent-orchestrator": {
       "name": "@elizaos/plugin-agent-orchestrator",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/plugin-task-coordinator": "workspace:*",
         "@octokit/rest": "^22.0.0",
@@ -2683,7 +2683,7 @@
     },
     "plugins/plugin-agent-skills": {
       "name": "@elizaos/plugin-agent-skills",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
@@ -2699,7 +2699,7 @@
     },
     "plugins/plugin-ainex": {
       "name": "@elizaos/plugin-ainex",
-      "version": "2.0.0",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "sharp": "^0.34.3",
@@ -2719,7 +2719,7 @@
     },
     "plugins/plugin-anthropic": {
       "name": "@elizaos/plugin-anthropic",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^3.0.9",
         "ai": "^6.0.23",
@@ -2738,7 +2738,7 @@
     },
     "plugins/plugin-anthropic-proxy": {
       "name": "@elizaos/plugin-anthropic-proxy",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@elizaos/core": "workspace:*",
         "@types/node": "^25.0.3",
@@ -2752,7 +2752,7 @@
     },
     "plugins/plugin-aosp-local-inference": {
       "name": "@elizaos/plugin-aosp-local-inference",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-omnivoice": "workspace:*",
@@ -2769,7 +2769,7 @@
     },
     "plugins/plugin-app-control": {
       "name": "@elizaos/plugin-app-control",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
@@ -2794,7 +2794,7 @@
     },
     "plugins/plugin-app-manager": {
       "name": "@elizaos/plugin-app-manager",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-registry": "workspace:*",
@@ -2807,7 +2807,7 @@
     },
     "plugins/plugin-babylon": {
       "name": "@elizaos/plugin-babylon",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/app-core": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -2825,7 +2825,7 @@
     },
     "plugins/plugin-background-runner": {
       "name": "@elizaos/plugin-background-runner",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -2849,7 +2849,7 @@
     },
     "plugins/plugin-benchmarks": {
       "name": "@elizaos/plugin-benchmarks",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -2862,7 +2862,7 @@
     },
     "plugins/plugin-bluebubbles": {
       "name": "@elizaos/plugin-bluebubbles",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "zod": "^4.4.3",
@@ -2876,7 +2876,7 @@
     },
     "plugins/plugin-bluesky": {
       "name": "@elizaos/plugin-bluesky",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@atproto/api": "^0.19.0",
         "@atproto/identity": "^0.4.4",
@@ -2898,7 +2898,7 @@
     },
     "plugins/plugin-browser": {
       "name": "@elizaos/plugin-browser",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/vault": "workspace:*",
@@ -2915,7 +2915,7 @@
     },
     "plugins/plugin-calendly": {
       "name": "@elizaos/plugin-calendly",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -2931,7 +2931,7 @@
     },
     "plugins/plugin-capacitor-bridge": {
       "name": "@elizaos/plugin-capacitor-bridge",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/agent": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -2951,7 +2951,7 @@
     },
     "plugins/plugin-clawville": {
       "name": "@elizaos/plugin-clawville",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
@@ -2969,7 +2969,7 @@
     },
     "plugins/plugin-cli": {
       "name": "@elizaos/plugin-cli",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "commander": "^14.0.0",
@@ -2983,7 +2983,7 @@
     },
     "plugins/plugin-codex-cli": {
       "name": "@elizaos/plugin-codex-cli",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
         "@elizaos/core": "workspace:*",
@@ -2999,7 +2999,7 @@
     },
     "plugins/plugin-coding-tools": {
       "name": "@elizaos/plugin-coding-tools",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
@@ -3014,7 +3014,7 @@
     },
     "plugins/plugin-commands": {
       "name": "@elizaos/plugin-commands",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -3028,7 +3028,7 @@
     },
     "plugins/plugin-companion": {
       "name": "@elizaos/plugin-companion",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/agent": "workspace:*",
         "@elizaos/app-core": "workspace:*",
@@ -3071,7 +3071,7 @@
     },
     "plugins/plugin-computeruse": {
       "name": "@elizaos/plugin-computeruse",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@nut-tree-fork/nut-js": "^4.2.6",
         "puppeteer-core": "^24.9.0",
@@ -3089,7 +3089,7 @@
     },
     "plugins/plugin-contacts": {
       "name": "@elizaos/plugin-contacts",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/capacitor-contacts": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -3115,7 +3115,7 @@
     },
     "plugins/plugin-defense-of-the-agents": {
       "name": "@elizaos/plugin-defense-of-the-agents",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/app-core": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -3130,7 +3130,7 @@
     },
     "plugins/plugin-device-filesystem": {
       "name": "@elizaos/plugin-device-filesystem",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "zod": "^4.4.3",
@@ -3151,7 +3151,7 @@
     },
     "plugins/plugin-device-settings": {
       "name": "@elizaos/plugin-device-settings",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/app-core": "workspace:*",
         "@elizaos/capacitor-system": "workspace:*",
@@ -3172,7 +3172,7 @@
     },
     "plugins/plugin-discord": {
       "name": "@elizaos/plugin-discord",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@discordjs/builders": "^1.14.1",
         "@discordjs/collection": "1.5.3",
@@ -3212,7 +3212,7 @@
     },
     "plugins/plugin-discord-local": {
       "name": "@elizaos/plugin-discord-local",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
         "@types/node": "^25.0.3",
@@ -3224,7 +3224,7 @@
     },
     "plugins/plugin-documents": {
       "name": "@elizaos/plugin-documents",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/agent": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -3236,7 +3236,7 @@
     },
     "plugins/plugin-edge-tts": {
       "name": "@elizaos/plugin-edge-tts",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "node-edge-tts": "^1.0.7",
@@ -3252,7 +3252,7 @@
     },
     "plugins/plugin-elevenlabs": {
       "name": "@elizaos/plugin-elevenlabs",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.16.0",
         "@elizaos/core": "workspace:*",
@@ -3266,7 +3266,7 @@
     },
     "plugins/plugin-eliza-classic": {
       "name": "@elizaos/plugin-eliza-classic",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -3280,7 +3280,7 @@
     },
     "plugins/plugin-elizacloud": {
       "name": "@elizaos/plugin-elizacloud",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@ai-sdk/gateway": "3.0.109",
         "@ai-sdk/openai": "^3.0.9",
@@ -3318,7 +3318,7 @@
     },
     "plugins/plugin-elizamaker": {
       "name": "@elizaos/plugin-elizamaker",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/agent": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -3330,7 +3330,7 @@
     },
     "plugins/plugin-farcaster": {
       "name": "@elizaos/plugin-farcaster",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@neynar/nodejs-sdk": "^3.34.0",
@@ -3347,7 +3347,7 @@
     },
     "plugins/plugin-feishu": {
       "name": "@elizaos/plugin-feishu",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@larksuiteoapi/node-sdk": "^1.40.0",
@@ -3361,7 +3361,7 @@
     },
     "plugins/plugin-form": {
       "name": "@elizaos/plugin-form",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "uuid": "^14.0.0",
@@ -3375,7 +3375,7 @@
     },
     "plugins/plugin-github": {
       "name": "@elizaos/plugin-github",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@octokit/rest": "^22.0.0",
@@ -3392,7 +3392,7 @@
     },
     "plugins/plugin-google": {
       "name": "@elizaos/plugin-google",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "google-auth-library": "^10.0.0",
@@ -3408,7 +3408,7 @@
     },
     "plugins/plugin-google-chat": {
       "name": "@elizaos/plugin-google-chat",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "google-auth-library": "^10.0.0",
@@ -3423,7 +3423,7 @@
     },
     "plugins/plugin-google-genai": {
       "name": "@elizaos/plugin-google-genai",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@google/genai": "^1.5.1",
       },
@@ -3442,7 +3442,7 @@
     },
     "plugins/plugin-groq": {
       "name": "@elizaos/plugin-groq",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@ai-sdk/groq": "^3.0.4",
         "@elizaos/core": "workspace:*",
@@ -3458,7 +3458,7 @@
     },
     "plugins/plugin-health": {
       "name": "@elizaos/plugin-health",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
@@ -3472,7 +3472,7 @@
     },
     "plugins/plugin-hyperliquid-app": {
       "name": "@elizaos/plugin-hyperliquid-app",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/app-core": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -3495,7 +3495,7 @@
     },
     "plugins/plugin-hyperscape": {
       "name": "@elizaos/plugin-hyperscape",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/app-core": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -3513,7 +3513,7 @@
     },
     "plugins/plugin-imessage": {
       "name": "@elizaos/plugin-imessage",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "zod": "^4.4.3",
@@ -3527,7 +3527,7 @@
     },
     "plugins/plugin-inmemorydb": {
       "name": "@elizaos/plugin-inmemorydb",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -3539,7 +3539,7 @@
     },
     "plugins/plugin-instagram": {
       "name": "@elizaos/plugin-instagram",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@types/node": "^25.0.3",
@@ -3552,7 +3552,7 @@
     },
     "plugins/plugin-lifeops": {
       "name": "@elizaos/plugin-lifeops",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@capacitor/core": "8.3.1",
         "@elizaos/agent": "workspace:*",
@@ -3598,7 +3598,7 @@
     },
     "plugins/plugin-line": {
       "name": "@elizaos/plugin-line",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@line/bot-sdk": "^11.0.0",
@@ -3612,7 +3612,7 @@
     },
     "plugins/plugin-linear": {
       "name": "@elizaos/plugin-linear",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@linear/sdk": "^83.0.0",
@@ -3626,7 +3626,7 @@
     },
     "plugins/plugin-lmstudio": {
       "name": "@elizaos/plugin-lmstudio",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.0",
         "ai": "^6.0.174",
@@ -3645,7 +3645,7 @@
     },
     "plugins/plugin-local-inference": {
       "name": "@elizaos/plugin-local-inference",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-aosp-local-inference": "workspace:*",
@@ -3665,15 +3665,11 @@
       "peerDependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
-        "node-llama-cpp": "*",
       },
-      "optionalPeers": [
-        "node-llama-cpp",
-      ],
     },
     "plugins/plugin-local-storage": {
       "name": "@elizaos/plugin-local-storage",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@brighter/storage-adapter-local": "^1.6.3",
         "@elizaos/core": "workspace:*",
@@ -3688,7 +3684,7 @@
     },
     "plugins/plugin-localdb": {
       "name": "@elizaos/plugin-localdb",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-inmemorydb": "workspace:*",
@@ -3705,7 +3701,7 @@
     },
     "plugins/plugin-matrix": {
       "name": "@elizaos/plugin-matrix",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "matrix-js-sdk": "^41.4.0",
       },
@@ -3721,7 +3717,7 @@
     },
     "plugins/plugin-mcp": {
       "name": "@elizaos/plugin-mcp",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.7.0",
@@ -3740,7 +3736,7 @@
     },
     "plugins/plugin-messages": {
       "name": "@elizaos/plugin-messages",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/app-core": "workspace:*",
         "@elizaos/capacitor-messages": "workspace:*",
@@ -3769,7 +3765,7 @@
     },
     "plugins/plugin-minecraft": {
       "name": "@elizaos/plugin-minecraft",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "ws": "^8.18.0",
         "zod": "^4.4.3",
@@ -3785,7 +3781,7 @@
     },
     "plugins/plugin-mlx": {
       "name": "@elizaos/plugin-mlx",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.0",
         "ai": "^6.0.174",
@@ -3804,7 +3800,7 @@
     },
     "plugins/plugin-music": {
       "name": "@elizaos/plugin-music",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-suno": "workspace:*",
@@ -3824,7 +3820,7 @@
     },
     "plugins/plugin-mysticism": {
       "name": "@elizaos/plugin-mysticism",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
         "@types/node": "^25.0.3",
@@ -3837,7 +3833,7 @@
     },
     "plugins/plugin-native-activity-tracker": {
       "name": "@elizaos/native-activity-tracker",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -3847,7 +3843,7 @@
     },
     "plugins/plugin-native-agent": {
       "name": "@elizaos/capacitor-agent",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "rollup": "^4.60.2",
@@ -3859,7 +3855,7 @@
     },
     "plugins/plugin-native-appblocker": {
       "name": "@elizaos/capacitor-appblocker",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "rollup": "^4.60.2",
@@ -3871,7 +3867,7 @@
     },
     "plugins/plugin-native-bun-runtime": {
       "name": "@elizaos/capacitor-bun-runtime",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "rollup": "^4.60.2",
@@ -3884,7 +3880,7 @@
     },
     "plugins/plugin-native-calendar": {
       "name": "@elizaos/capacitor-calendar",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "rollup": "^4.60.2",
@@ -3896,7 +3892,7 @@
     },
     "plugins/plugin-native-camera": {
       "name": "@elizaos/capacitor-camera",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "@rollup/plugin-node-resolve": "^16.0.0",
@@ -3909,7 +3905,7 @@
     },
     "plugins/plugin-native-canvas": {
       "name": "@elizaos/capacitor-canvas",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "@rollup/plugin-node-resolve": "^16.0.0",
@@ -3922,7 +3918,7 @@
     },
     "plugins/plugin-native-contacts": {
       "name": "@elizaos/capacitor-contacts",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "rollup": "^4.60.2",
@@ -3934,7 +3930,7 @@
     },
     "plugins/plugin-native-desktop": {
       "name": "@elizaos/capacitor-desktop",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "@rollup/plugin-node-resolve": "^16.0.0",
@@ -3947,7 +3943,7 @@
     },
     "plugins/plugin-native-eliza-tasks": {
       "name": "@elizaos/capacitor-eliza-tasks",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "@rollup/plugin-node-resolve": "^16.0.0",
@@ -3961,7 +3957,7 @@
     },
     "plugins/plugin-native-gateway": {
       "name": "@elizaos/capacitor-gateway",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
         "@capacitor/core": "^8.3.1",
@@ -3976,7 +3972,7 @@
     },
     "plugins/plugin-native-llama": {
       "name": "@elizaos/capacitor-llama",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "llama-cpp-capacitor": "^0.1.5",
       },
@@ -3992,7 +3988,7 @@
     },
     "plugins/plugin-native-location": {
       "name": "@elizaos/capacitor-location",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "@capacitor/docgen": "^0.3.0",
@@ -4005,7 +4001,7 @@
     },
     "plugins/plugin-native-macosalarm": {
       "name": "@elizaos/macosalarm",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -4017,7 +4013,7 @@
     },
     "plugins/plugin-native-messages": {
       "name": "@elizaos/capacitor-messages",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "rollup": "^4.60.2",
@@ -4029,7 +4025,7 @@
     },
     "plugins/plugin-native-mobile-agent-bridge": {
       "name": "@elizaos/capacitor-mobile-agent-bridge",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
         "@capacitor/core": "^8.3.1",
@@ -4042,7 +4038,7 @@
     },
     "plugins/plugin-native-mobile-signals": {
       "name": "@elizaos/capacitor-mobile-signals",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "@rollup/plugin-node-resolve": "^16.0.0",
@@ -4056,7 +4052,7 @@
     },
     "plugins/plugin-native-network-policy": {
       "name": "@elizaos/capacitor-network-policy",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "rollup": "^4.60.2",
@@ -4068,7 +4064,7 @@
     },
     "plugins/plugin-native-phone": {
       "name": "@elizaos/capacitor-phone",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "rollup": "^4.60.2",
@@ -4080,7 +4076,7 @@
     },
     "plugins/plugin-native-screencapture": {
       "name": "@elizaos/capacitor-screencapture",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "@rollup/plugin-node-resolve": "^16.0.0",
@@ -4097,7 +4093,7 @@
     },
     "plugins/plugin-native-swabble": {
       "name": "@elizaos/capacitor-swabble",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "@elizaos/native-plugin-shared-types": "workspace:*",
@@ -4111,7 +4107,7 @@
     },
     "plugins/plugin-native-system": {
       "name": "@elizaos/capacitor-system",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "rollup": "^4.60.2",
@@ -4123,7 +4119,7 @@
     },
     "plugins/plugin-native-talkmode": {
       "name": "@elizaos/capacitor-talkmode",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "@capacitor/docgen": "^0.3.0",
@@ -4137,7 +4133,7 @@
     },
     "plugins/plugin-native-websiteblocker": {
       "name": "@elizaos/capacitor-websiteblocker",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "rollup": "^4.60.2",
@@ -4149,7 +4145,7 @@
     },
     "plugins/plugin-native-wifi": {
       "name": "@elizaos/capacitor-wifi",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@capacitor/core": "^8.3.1",
         "rollup": "^4.60.2",
@@ -4161,7 +4157,7 @@
     },
     "plugins/plugin-ngrok": {
       "name": "@elizaos/plugin-ngrok",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/plugin-tunnel": "workspace:*",
@@ -4182,7 +4178,7 @@
     },
     "plugins/plugin-nostr": {
       "name": "@elizaos/plugin-nostr",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "nostr-tools": "^2.0.0",
@@ -4196,7 +4192,7 @@
     },
     "plugins/plugin-ollama": {
       "name": "@elizaos/plugin-ollama",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "ai": "^6.0.174",
         "ollama-ai-provider-v2": "^3.5.0",
@@ -4216,7 +4212,7 @@
     },
     "plugins/plugin-omnivoice": {
       "name": "@elizaos/plugin-omnivoice",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -4231,7 +4227,7 @@
     },
     "plugins/plugin-openai": {
       "name": "@elizaos/plugin-openai",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@ai-sdk/openai": "^3.0.9",
         "ai": "^6.0.30",
@@ -4254,7 +4250,7 @@
     },
     "plugins/plugin-openrouter": {
       "name": "@elizaos/plugin-openrouter",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@openrouter/ai-sdk-provider": "^2.0.0",
         "ai": "^6.0.30",
@@ -4275,7 +4271,7 @@
     },
     "plugins/plugin-pdf": {
       "name": "@elizaos/plugin-pdf",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "unpdf": "^1.4.0",
@@ -4290,7 +4286,7 @@
     },
     "plugins/plugin-phone": {
       "name": "@elizaos/plugin-phone",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@capacitor/barcode-scanner": "^3.0.0",
         "@capacitor/core": "8.3.1",
@@ -4324,7 +4320,7 @@
     },
     "plugins/plugin-polymarket-app": {
       "name": "@elizaos/plugin-polymarket-app",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/app-core": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -4347,7 +4343,7 @@
     },
     "plugins/plugin-registry": {
       "name": "@elizaos/plugin-registry",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
@@ -4361,7 +4357,7 @@
     },
     "plugins/plugin-rlm": {
       "name": "@elizaos/plugin-rlm",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -4378,7 +4374,7 @@
     },
     "plugins/plugin-roblox": {
       "name": "@elizaos/plugin-roblox",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -4391,7 +4387,7 @@
     },
     "plugins/plugin-scape": {
       "name": "@elizaos/plugin-scape",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/agent": "workspace:*",
         "@elizaos/app-core": "workspace:*",
@@ -4407,7 +4403,7 @@
     },
     "plugins/plugin-screenshare": {
       "name": "@elizaos/plugin-screenshare",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/agent": "workspace:*",
         "@elizaos/app-core": "workspace:*",
@@ -4435,7 +4431,7 @@
     },
     "plugins/plugin-shell": {
       "name": "@elizaos/plugin-shell",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
@@ -4456,7 +4452,7 @@
     },
     "plugins/plugin-shopify": {
       "name": "@elizaos/plugin-shopify",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -4468,7 +4464,7 @@
     },
     "plugins/plugin-shopify-ui": {
       "name": "@elizaos/plugin-shopify-ui",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/app-core": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -4490,7 +4486,7 @@
     },
     "plugins/plugin-signal": {
       "name": "@elizaos/plugin-signal",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "qrcode": "^1.5.4",
@@ -4513,7 +4509,7 @@
     },
     "plugins/plugin-slack": {
       "name": "@elizaos/plugin-slack",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@slack/bolt": "^4.1.0",
@@ -4532,7 +4528,7 @@
     },
     "plugins/plugin-smartglasses": {
       "name": "@elizaos/plugin-smartglasses",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/ui": "workspace:*",
@@ -4561,7 +4557,7 @@
     },
     "plugins/plugin-social-alpha": {
       "name": "@elizaos/plugin-social-alpha",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "bignumber.js": "^11.0.0",
@@ -4606,7 +4602,7 @@
     },
     "plugins/plugin-sql": {
       "name": "@elizaos/plugin-sql",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@electric-sql/pglite": "^0.4.0",
         "@neondatabase/serverless": "^1.1.0",
@@ -4632,7 +4628,7 @@
     },
     "plugins/plugin-steward-app": {
       "name": "@elizaos/plugin-steward-app",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/agent": "workspace:*",
         "@elizaos/app-core": "workspace:*",
@@ -4662,7 +4658,7 @@
     },
     "plugins/plugin-streaming": {
       "name": "@elizaos/plugin-streaming",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/cloud-routing": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -4676,7 +4672,7 @@
     },
     "plugins/plugin-suno": {
       "name": "@elizaos/plugin-suno",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -4690,7 +4686,7 @@
     },
     "plugins/plugin-tailscale": {
       "name": "@elizaos/plugin-tailscale",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/cloud-routing": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -4711,7 +4707,7 @@
     },
     "plugins/plugin-task-coordinator": {
       "name": "@elizaos/plugin-task-coordinator",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/ui": "workspace:*",
@@ -4728,7 +4724,7 @@
     },
     "plugins/plugin-tee": {
       "name": "@elizaos/plugin-tee",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@phala/dstack-sdk": "^0.5.7",
@@ -4744,7 +4740,7 @@
     },
     "plugins/plugin-telegram": {
       "name": "@elizaos/plugin-telegram",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@telegraf/types": "^7.1.0",
@@ -4764,7 +4760,7 @@
     },
     "plugins/plugin-todos": {
       "name": "@elizaos/plugin-todos",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "drizzle-orm": "^0.45.1",
@@ -4780,7 +4776,7 @@
     },
     "plugins/plugin-training": {
       "name": "@elizaos/plugin-training",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/agent": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -4807,7 +4803,7 @@
     },
     "plugins/plugin-trajectory-logger": {
       "name": "@elizaos/plugin-trajectory-logger",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/app-core": "workspace:*",
         "@elizaos/core": "workspace:*",
@@ -4825,7 +4821,7 @@
     },
     "plugins/plugin-tunnel": {
       "name": "@elizaos/plugin-tunnel",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "zod": "^4.4.2",
@@ -4842,7 +4838,7 @@
     },
     "plugins/plugin-twitch": {
       "name": "@elizaos/plugin-twitch",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@twurple/auth": "^8.0.0",
         "@twurple/chat": "^8.0.0",
@@ -4858,7 +4854,7 @@
     },
     "plugins/plugin-video": {
       "name": "@elizaos/plugin-video",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "ffmpeg-static": "^5.3.0",
@@ -4873,7 +4869,7 @@
     },
     "plugins/plugin-vincent": {
       "name": "@elizaos/plugin-vincent",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/agent": "workspace:*",
         "@elizaos/app-core": "workspace:*",
@@ -4897,7 +4893,7 @@
     },
     "plugins/plugin-vision": {
       "name": "@elizaos/plugin-vision",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "canvas": "^3.1.2",
@@ -4919,7 +4915,7 @@
     },
     "plugins/plugin-wallet": {
       "name": "@elizaos/plugin-wallet",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@coral-xyz/anchor": "^0.32.1",
         "@elizaos/cloud-routing": "workspace:*",
@@ -4952,7 +4948,7 @@
     },
     "plugins/plugin-wallet-ui": {
       "name": "@elizaos/plugin-wallet-ui",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
@@ -4978,7 +4974,7 @@
     },
     "plugins/plugin-web-search": {
       "name": "@elizaos/plugin-web-search",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@tavily/core": "^0.7.0",
@@ -4991,7 +4987,7 @@
     },
     "plugins/plugin-wechat": {
       "name": "@elizaos/plugin-wechat",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "devDependencies": {
         "@elizaos/core": "workspace:*",
         "tsup": "^8.5.1",
@@ -5004,7 +5000,7 @@
     },
     "plugins/plugin-whatsapp": {
       "name": "@elizaos/plugin-whatsapp",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@hapi/boom": "^10.0.1",
         "@whiskeysockets/baileys": "^7.0.0-rc.9",
@@ -5025,7 +5021,7 @@
     },
     "plugins/plugin-wifi": {
       "name": "@elizaos/plugin-wifi",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/capacitor-system": "workspace:*",
         "@elizaos/capacitor-wifi": "workspace:*",
@@ -5046,7 +5042,7 @@
     },
     "plugins/plugin-workflow": {
       "name": "@elizaos/plugin-workflow",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/workflows": "workspace:*",
         "drizzle-orm": "^0.45.1",
@@ -5067,7 +5063,7 @@
     },
     "plugins/plugin-x": {
       "name": "@elizaos/plugin-x",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "headers-polyfill": "^5.0.0",
         "json-stable-stringify": "^1.3.0",
@@ -5088,7 +5084,7 @@
     },
     "plugins/plugin-x402": {
       "name": "@elizaos/plugin-x402",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "@solana/web3.js": "1.98.4",
@@ -5105,7 +5101,7 @@
     },
     "plugins/plugin-xai": {
       "name": "@elizaos/plugin-xai",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
       },
@@ -5121,7 +5117,7 @@
     },
     "plugins/plugin-xr": {
       "name": "@elizaos/plugin-xr",
-      "version": "0.1.0",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@elizaos/core": "workspace:*",
         "ws": "^8.18.0",
@@ -5139,7 +5135,7 @@
     },
     "plugins/plugin-zai": {
       "name": "@elizaos/plugin-zai",
-      "version": "2.0.1",
+      "version": "2.0.1-beta.0",
       "dependencies": {
         "@ai-sdk/openai-compatible": "^1.0.0",
         "@elizaos/core": "workspace:*",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "packages": [
     "packages/*",
     "packages/app-core/platforms/*",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/agent",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Standalone elizaOS-based agent and backend server package.",
   "type": "module",
   "license": "MIT",

--- a/packages/app-core/package.json
+++ b/packages/app-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/app-core",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Shared application core for elizaOS white-label agent apps.",
   "type": "module",
   "license": "MIT",

--- a/packages/app-core/platforms/electrobun/package.json
+++ b/packages/app-core/platforms/electrobun/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/electrobun",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "files": [
     "assets",

--- a/packages/cloud-api/package.json
+++ b/packages/cloud-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/cloud-api",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {

--- a/packages/cloud-frontend/package.json
+++ b/packages/cloud-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/cloud-frontend",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "scripts": {
     "dev": "bun --bun vite",

--- a/packages/cloud-frontend/package.json
+++ b/packages/cloud-frontend/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:e2e": "node scripts/run-e2e.mjs",
+    "test:e2e:live-auth": "node scripts/run-e2e.mjs tests/e2e/live-auth-backend.spec.ts",
     "test:e2e:update": "node scripts/run-e2e.mjs --update-snapshots",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",

--- a/packages/cloud-frontend/tests/e2e/api-explorer-flow.spec.ts
+++ b/packages/cloud-frontend/tests/e2e/api-explorer-flow.spec.ts
@@ -1,0 +1,179 @@
+import { expect, test } from "@playwright/test";
+
+test.skip(
+  Boolean(process.env.CLOUD_E2E_LIVE_URL),
+  "API Explorer flow uses local test auth and API stubs; skipped in live-prod mode",
+);
+
+const EXPLORER_KEY = "eliza_test_explorer_123";
+
+test.beforeEach(async ({ context, page, browserName }) => {
+  await context.addCookies([
+    {
+      name: "eliza-test-auth",
+      value: "1",
+      domain: "127.0.0.1",
+      path: "/",
+      httpOnly: false,
+      secure: false,
+      sameSite: "Lax",
+    },
+  ]);
+
+  if (browserName === "chromium") {
+    const origin = new URL(
+      process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:4173",
+    ).origin;
+    await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+      origin,
+    });
+  }
+
+  await page.route("**/api/v1/api-keys/explorer", (route) =>
+    route.fulfill({
+      json: {
+        apiKey: {
+          id: "explorer_key_1",
+          name: "API Explorer",
+          description: "Generated for API Explorer tests",
+          key_prefix: "eliza_test_explorer",
+          key: EXPLORER_KEY,
+          created_at: new Date().toISOString(),
+          is_active: true,
+          usage_count: 7,
+          last_used_at: null,
+        },
+      },
+    }),
+  );
+
+  await page.route("**/api/v1/pricing/summary", (route) =>
+    route.fulfill({
+      json: {
+        pricing: {
+          "chat-completions": {
+            cost: 0.0025,
+            unit: "1k tokens",
+            description: "Input tokens",
+            isVariable: true,
+            estimatedRange: { min: 0.001, max: 0.03 },
+          },
+        },
+      },
+    }),
+  );
+});
+
+test("api explorer: search, auth, request tester, response, and OpenAPI export", async ({
+  page,
+}) => {
+  let chatRequest:
+    | {
+        authorization: string | null;
+        body: unknown;
+      }
+    | undefined;
+
+  await page.route("**/api/v1/chat", async (route) => {
+    chatRequest = {
+      authorization: route.request().headers().authorization ?? null,
+      body: route.request().postDataJSON(),
+    };
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      json: {
+        id: "chatcmpl_playwright",
+        model: "gpt-oss-120b",
+        choices: [
+          {
+            message: {
+              role: "assistant",
+              content: "API Explorer request accepted",
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  await page.goto("/dashboard/api-explorer");
+  await expect(page).not.toHaveURL(/\/login/);
+  await expect(
+    page.getByRole("button", { name: /Endpoints/i }),
+  ).toBeVisible();
+
+  await page.getByPlaceholder("Search...").fill("chat completion");
+  await expect(page.getByText(/1 endpoint matching/i)).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: /Chat Completion/i }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: /AI Completions/i }).click();
+  await expect(page.getByRole("heading", { name: "AI Completions" })).toBeVisible();
+
+  await page.getByRole("button", { name: /Chat Completion/i }).click();
+  await expect(
+    page.getByRole("button", { name: /Back to endpoints/i }),
+  ).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Chat Completion" })).toBeVisible();
+
+  const messages = page.locator("#param-messages");
+  await expect(messages).toBeVisible();
+  await messages.fill(
+    JSON.stringify([
+      {
+        role: "user",
+        parts: [{ type: "text", text: "Say hello from Playwright" }],
+      },
+    ]),
+  );
+
+  await page.getByRole("button", { name: /Copy cURL/i }).click();
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toContain("/api/v1/chat");
+
+  await page.getByRole("button", { name: /Send Request/i }).click();
+  await expect(page.getByRole("tab", { name: /Response 200/i })).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.getByText("API Explorer request accepted")).toBeVisible();
+  expect(chatRequest?.authorization).toBe(`Bearer ${EXPLORER_KEY}`);
+  expect(chatRequest?.body).toMatchObject({
+    messages: [
+      {
+        role: "user",
+        parts: [{ type: "text", text: "Say hello from Playwright" }],
+      },
+    ],
+  });
+
+  await page.getByRole("button", { name: /^Auth$/i }).click();
+  const apiKeyInput = page.locator("#auth-manager-api-key");
+  await expect(apiKeyInput).toHaveAttribute("type", "password");
+  await expect(apiKeyInput).toHaveValue(EXPLORER_KEY);
+  await page.locator("#auth-manager-api-key + button").click();
+  await expect(apiKeyInput).toHaveAttribute("type", "text");
+
+  await page.getByText("Use a different key").click();
+  await page.getByPlaceholder("Enter custom API key...").fill("sk-custom-test");
+  await expect(apiKeyInput).toHaveValue("sk-custom-test");
+  await page.getByRole("button", { name: /Reset to default/i }).click();
+  await expect(apiKeyInput).toHaveValue(EXPLORER_KEY);
+
+  await page.getByRole("button", { name: /^OpenAPI$/i }).click();
+  await expect(
+    page.getByRole("heading", { name: "OpenAPI 3.0 Specification" }),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: /^JSON$/i }).click();
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toContain('"openapi"');
+
+  await page.getByRole("button", { name: /^YAML$/i }).click();
+  await expect
+    .poll(() => page.evaluate(() => navigator.clipboard.readText()))
+    .toContain("openapi:");
+});

--- a/packages/cloud-routing/package.json
+++ b/packages/cloud-routing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/cloud-routing",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/cloud-sdk/package.json
+++ b/packages/cloud-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/cloud-sdk",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "TypeScript SDK for Eliza Cloud API, auth, and agent management.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/contracts",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Pure type contracts extracted from @elizaos/core — types only, no runtime.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elizaos/core",
-	"version": "2.0.1",
+	"version": "2.0.1-beta.0",
 	"description": "Core runtime, plugin abstractions, and AgentRuntime for elizaOS — actions, providers, evaluators, services, models, and types.",
 	"homepage": "https://github.com/elizaOS/eliza",
 	"repository": {

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -459,6 +459,36 @@ describe("runV5MessageRuntimeStage1", () => {
 		}
 	});
 
+	it("does not route synthetic sub-agent completions through ATTACHMENT because they contain URLs", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "https://milady.ai\nhttps://app.milady.ai",
+				extra: { requiresTool: false },
+			}),
+		]);
+		const state = makeAttachmentState();
+		runtime.composeState = vi.fn(async () => state) as never;
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: "[sub-agent: package check (opencode) task_complete]\nhttps://milady.ai\nhttps://app.milady.ai",
+				source: "sub_agent",
+			}),
+			state,
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		expect(useModelCalls(runtime)).toHaveLength(1);
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"https://milady.ai\nhttps://app.milady.ai",
+			);
+		}
+	});
+
 	it("does not send an image-inspection ack when attachment tooling is unavailable", async () => {
 		const runtime = makeRuntime([
 			stage1Response({

--- a/packages/core/src/__tests__/tiered-action-surface.test.ts
+++ b/packages/core/src/__tests__/tiered-action-surface.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetActionRolePolicyCacheForTests } from "../runtime/action-role-policy";
 import { BUILTIN_RESPONSE_HANDLER_FIELD_EVALUATORS } from "../runtime/builtin-field-evaluators";
 import { ResponseHandlerFieldRegistry } from "../runtime/response-handler-field-registry";
 import { runV5MessageRuntimeStage1 } from "../services/message";
@@ -8,7 +9,7 @@ import type {
 	HandlerCallback,
 	HandlerOptions,
 } from "../types/components";
-import type { AgentContext } from "../types/contexts";
+import type { AgentContext, ContextGate, RoleGate } from "../types/contexts";
 import type { Memory } from "../types/memory";
 import { ModelType } from "../types/model";
 import type { UUID } from "../types/primitives";
@@ -120,7 +121,10 @@ function getCalls(runtime: IAgentRuntime): Array<{
 function makeAction(opts: {
 	name: string;
 	description?: string;
+	similes?: string[];
 	contexts?: AgentContext[];
+	contextGate?: ContextGate;
+	roleGate?: RoleGate;
 	subActions?: Array<string | Action>;
 	validate?: (
 		runtime: IAgentRuntime,
@@ -139,10 +143,12 @@ function makeAction(opts: {
 	return {
 		name: opts.name,
 		description: opts.description ?? `${opts.name} action`,
-		similes: [],
+		similes: opts.similes ?? [],
 		examples: [],
 		parameters: [],
 		contexts: opts.contexts,
+		contextGate: opts.contextGate,
+		roleGate: opts.roleGate,
 		subActions: opts.subActions,
 		validate: opts.validate ?? (async () => true),
 		handler:
@@ -243,10 +249,13 @@ function availableActionsSection(runtime: IAgentRuntime): string {
 
 describe("v5 tiered action surface", () => {
 	let originalTrajectoryEnv: string | undefined;
+	let originalActionRolePolicy: string | undefined;
 
 	beforeEach(() => {
 		originalTrajectoryEnv = process.env.ELIZA_TRAJECTORY_RECORDING;
+		originalActionRolePolicy = process.env.ACTION_ROLE_POLICY;
 		process.env.ELIZA_TRAJECTORY_RECORDING = "0";
+		_resetActionRolePolicyCacheForTests();
 	});
 
 	afterEach(() => {
@@ -255,6 +264,12 @@ describe("v5 tiered action surface", () => {
 		} else {
 			process.env.ELIZA_TRAJECTORY_RECORDING = originalTrajectoryEnv;
 		}
+		if (originalActionRolePolicy === undefined) {
+			delete process.env.ACTION_ROLE_POLICY;
+		} else {
+			process.env.ACTION_ROLE_POLICY = originalActionRolePolicy;
+		}
+		_resetActionRolePolicyCacheForTests();
 	});
 
 	it("uses Stage 1 hints to promote a parent to Tier A and expose children", async () => {
@@ -463,6 +478,56 @@ describe("v5 tiered action surface", () => {
 		expect(toolNames).toContain("STOP");
 		// Sibling-context action that is not in Tier A / Tier B should not leak in.
 		expect(toolNames).not.toContain("SEND_EMAIL");
+	});
+
+	it("omits planner tools that execution would reject for the selected context", async () => {
+		process.env.ACTION_ROLE_POLICY = JSON.stringify({ BASH: "GUEST" });
+		_resetActionRolePolicyCacheForTests();
+
+		const shell = makeAction({
+			name: "SHELL",
+			description:
+				"Run a shell command to inspect runtime or repository state.",
+			similes: ["BASH", "EXEC"],
+			contexts: ["terminal" as AgentContext],
+			contextGate: { anyOf: ["terminal"] },
+			roleGate: { minRole: "OWNER" },
+		});
+		const file = makeAction({
+			name: "FILE",
+			description: "Read, grep, or edit workspace files.",
+			contexts: ["code" as AgentContext],
+			contextGate: { anyOf: ["code"] },
+			roleGate: { minRole: "ADMIN" },
+		});
+		const runtime = makeRuntime({
+			actions: [shell, file],
+			responses: [
+				stage1Response({
+					contexts: ["general"],
+					candidateActionNames: ["SHELL", "FILE"],
+				}),
+				plannerToolResponse("SHELL", { command: "git status --short" }),
+				finishEvaluatorResponse("Shell checked."),
+			],
+		});
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("check the running repository status"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		const plannerCall = getCalls(runtime).find(
+			(call) => call.modelType === ModelType.ACTION_PLANNER,
+		);
+		const tools = (
+			plannerCall?.params as { tools?: Array<{ name?: string }> } | undefined
+		)?.tools;
+		const toolNames = tools?.map((tool) => tool.name).filter(Boolean) ?? [];
+		expect(toolNames).toContain("SHELL");
+		expect(toolNames).not.toContain("FILE");
 	});
 
 	it("lets a Tier B parent invoke its sub-planner and execute child actions", async () => {

--- a/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
@@ -297,6 +297,56 @@ describe("messageHandlerFromFieldResult — bogus candidate actions", () => {
 		expect(handler.plan.candidateActions).toEqual(["SHELL"]);
 	});
 
+	it("routes ack-only local submodule checks to shell", () => {
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: [],
+				candidateActionNames: [],
+				replyText: "Checking for the vendored opencode submodule...",
+				intents: ["check submodule"],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: [SHELL],
+				messageText:
+					"is the vendored opencode submodule present and what commit is checked out? concise",
+			},
+		);
+
+		expect(handler.plan.simple).toBe(false);
+		expect(handler.plan.requiresTool).toBe(true);
+		expect(handler.plan.contexts).toEqual(["general"]);
+		expect(handler.plan.candidateActions).toEqual(["SHELL"]);
+	});
+
+	it("uses current message text for local submodule checks when intents are missing", () => {
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: [],
+				candidateActionNames: [],
+				replyText: "Checking for the vendored opencode submodule...",
+				intents: [],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: [SHELL],
+				messageText:
+					"is the vendored opencode submodule present and what commit is checked out? concise",
+			},
+		);
+
+		expect(handler.plan.simple).toBe(false);
+		expect(handler.plan.requiresTool).toBe(true);
+		expect(handler.plan.contexts).toEqual(["general"]);
+		expect(handler.plan.candidateActions).toEqual(["SHELL"]);
+	});
+
 	it("promotes current market-data requests to search even when Stage 1 underclaims browsing", () => {
 		const handler = messageHandlerFromFieldResult(
 			{

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -5503,7 +5503,7 @@ export function hasTextGenerationHandler(runtime: IAgentRuntime): boolean {
  * Tracks the latest response ID per agent+room to handle message superseding
  */
 const latestResponseIds = new Map<string, Map<string, string>>();
-const DEFAULT_POST_DELIVERY_SIDE_EFFECT_TIMEOUT_MS = 5_000;
+const DEFAULT_POST_DELIVERY_SIDE_EFFECT_TIMEOUT_MS = 30_000;
 
 function clearLatestResponseId(
 	agentId: UUID,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -5537,6 +5537,9 @@ export function hasTextGenerationHandler(runtime: IAgentRuntime): boolean {
  * Tracks the latest response ID per agent+room to handle message superseding
  */
 const latestResponseIds = new Map<string, Map<string, string>>();
+// Sub-agent completions emit follow-up evaluators (URL verification, attachment
+// routing, transcript stripping) that legitimately take >5s; 30s gives them
+// room without indefinitely blocking response finalization.
 const DEFAULT_POST_DELIVERY_SIDE_EFFECT_TIMEOUT_MS = 30_000;
 
 function clearLatestResponseId(
@@ -6332,12 +6335,10 @@ function looksLikeLocalShellRequest(text: string): boolean {
 			normalized,
 		);
 	const asksRepoStateQuestion =
-		/\b(?:is|are|what|which|where)\b[\s\S]{0,140}\b(?:submodules?|commit|branch|head|checked\s+out|worktree|repo|repository)\b/iu.test(
+		/\b(?:is|are|what|which|where)\b[^.?!\n]{0,80}\b(?:submodules?|commit|branch|head|checked\s+out|worktree|repo|repository)\b/iu.test(
 			normalized,
 		) &&
-		/\b(?:local(?:ly)?|running|workspace|worktree|repo|repository|vendored|submodules?|checked\s+out)\b/iu.test(
-			normalized,
-		);
+		/\b(?:local(?:ly)?|running|vendored|checked\s+out)\b/iu.test(normalized);
 
 	return (
 		(mentionsCommand && asksToInspect && mentionsLocalSurface) ||

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -28,9 +28,14 @@ import {
 	type LocalizedActionExampleResolver,
 } from "../runtime/action-catalog";
 import { retrieveActions } from "../runtime/action-retrieval";
+import { resolveActionRolePolicyRole } from "../runtime/action-role-policy";
 import { tierActionResults } from "../runtime/action-tiering";
 import { applyAddressedTo } from "../runtime/addressed-to";
-import { filterByContextGate } from "../runtime/context-gates";
+import {
+	filterByContextGate,
+	satisfiesContextGate,
+	satisfiesRoleGate,
+} from "../runtime/context-gates";
 import { computePrefixHashes, hashString } from "../runtime/context-hash";
 import {
 	appendContextEvent,
@@ -1970,11 +1975,11 @@ async function collectV5PlannerCandidateActions(args: {
 	// "general" — even when the user clearly asked for a habit/event/etc.
 	// (See `docs/audits/lifeops-2026-05-09/12-real-root-cause.md`.)
 	//
-	// Now: every action is a candidate. Role gates and per-action validate /
-	// account-policy checks still apply (those are correctness/security, not
-	// relevance). Retrieval scoring then uses `selectedContexts` as a
-	// *weight* (boost actions whose contexts intersect the active set) but
-	// never as a hard filter.
+	// Now: the surface starts from every action, then applies only the same
+	// execution gates the planner executor will enforce. That keeps role-policy
+	// overrides working for deployments that intentionally expose an action
+	// outside its declared context, while avoiding dead tools that the planner
+	// could select but execution would immediately reject.
 	const allRuntimeActions = args.runtime.actions;
 	const actionsByName = new Map(
 		allRuntimeActions.map((action) => [action.name, action]),
@@ -1991,12 +1996,19 @@ async function collectV5PlannerCandidateActions(args: {
 	const appendIfAllowed = async (
 		action: Action,
 		parentActionName?: string,
-		_activeContexts:
-			| readonly AgentContext[]
-			| undefined = args.selectedContexts,
+		activeContexts: readonly AgentContext[] | undefined = args.selectedContexts,
 	): Promise<boolean> => {
 		const normalizedName = normalizeActionIdentifier(action.name);
 		if (!normalizedName || seen.has(normalizedName)) {
+			return false;
+		}
+		if (
+			!actionPassesPlannerExecutionGates({
+				action,
+				activeContexts,
+				userRoles: args.userRoles,
+			})
+		) {
 			return false;
 		}
 		try {
@@ -2100,6 +2112,27 @@ function mergeAgentContexts(
 		}
 	}
 	return merged;
+}
+
+function actionPassesPlannerExecutionGates(args: {
+	action: Action;
+	activeContexts?: readonly AgentContext[];
+	userRoles?: readonly RoleGateRole[];
+}): boolean {
+	const policyRole = resolveActionRolePolicyRole(args.action);
+	if (policyRole) {
+		return satisfiesRoleGate(args.userRoles, { minRole: policyRole });
+	}
+
+	const contextGate = args.action.contextGate ?? {
+		contexts: args.action.contexts,
+		roleGate: args.action.roleGate,
+	};
+	if (!satisfiesContextGate(args.activeContexts, contextGate, args.userRoles)) {
+		return false;
+	}
+
+	return satisfiesRoleGate(args.userRoles, args.action.roleGate);
 }
 
 function getMessageHandlerCandidateActions(

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -6319,7 +6319,7 @@ function looksLikeLocalShellRequest(text: string): boolean {
 	}
 
 	const mentionsCommand =
-		/\b(?:git|df|du|ls|pwd|cat|sed|awk|rg|grep|curl|ps|systemctl|journalctl|docker|bun|npm|node|sqlite3|gh|disk (?:space|usage)|storage usage)\b/iu.test(
+		/\b(?:git|df|du|ls|pwd|cat|sed|awk|rg|grep|curl|ps|systemctl|journalctl|docker|bun|npm|node|sqlite3|gh|submodules?|disk (?:space|usage)|storage usage)\b/iu.test(
 			normalized,
 		);
 	const asksToInspect =
@@ -6328,11 +6328,21 @@ function looksLikeLocalShellRequest(text: string): boolean {
 		);
 	const mentionsLocalSurface =
 		/(?:^|\s)(?:\/home\/|~\/|\.\/|\.\.\/)/u.test(normalized) ||
-		/\b(?:this vps|local(?:ly)?|workspace|worktree|repo|repository|branch|head|origin\/(?:develop|main|master)|git status|disk (?:space|usage)|storage usage|logs?|service|systemd)\b/iu.test(
+		/\b(?:this vps|local(?:ly)?|workspace|worktree|repo|repository|branch|head|submodules?|origin\/(?:develop|main|master)|git status|disk (?:space|usage)|storage usage|logs?|service|systemd)\b/iu.test(
+			normalized,
+		);
+	const asksRepoStateQuestion =
+		/\b(?:is|are|what|which|where)\b[\s\S]{0,140}\b(?:submodules?|commit|branch|head|checked\s+out|worktree|repo|repository)\b/iu.test(
+			normalized,
+		) &&
+		/\b(?:local(?:ly)?|running|workspace|worktree|repo|repository|vendored|submodules?|checked\s+out)\b/iu.test(
 			normalized,
 		);
 
-	return mentionsCommand && asksToInspect && mentionsLocalSurface;
+	return (
+		(mentionsCommand && asksToInspect && mentionsLocalSurface) ||
+		asksRepoStateQuestion
+	);
 }
 
 function looksLikeActionExplanationRequest(text: string): boolean {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2622,6 +2622,7 @@ const BUILTIN_RESPONSE_HANDLER_EVALUATORS: readonly ResponseHandlerEvaluator[] =
 				"Routes attachment/image inspection requests through ATTACHMENT instead of allowing unsupported direct vision claims.",
 			priority: 10,
 			shouldRun: ({ runtime, message, state }) =>
+				!isSubAgentCompletionArtifact(message) &&
 				looksLikeAttachmentInspectionRequest(message, state, runtime.agentId),
 			evaluate: () => ({
 				requiresTool: true,

--- a/packages/elizaos/package.json
+++ b/packages/elizaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elizaos",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "elizaOS CLI - Create and upgrade elizaOS projects and plugins",
   "type": "module",
   "bin": {

--- a/packages/examples/VALIDATION.md
+++ b/packages/examples/VALIDATION.md
@@ -37,7 +37,7 @@ The local examples sweep has been run in this worktree with these outcomes:
 | Package tests | `node packages/examples/scripts/verify-examples.mjs --mode test` completed after dependency/build repair. Live endpoint clients either passed locally or skipped cleanly when no live service URL/credential was configured. |
 | Package builds | `node packages/examples/scripts/verify-examples.mjs --mode build` completed after targeted repairs. Human-gated or known bundler-limited examples use explicit skip scripts that explain the required opt-in command. |
 | Final targeted recheck | `a2a`, `bluesky`, `mcp`, `roblox`, `smartglasses`, `trader`, `twitter-xai`, `cloud/clone-ur-crush`, `cloud/edad`, and `form` passed targeted reruns after the last fixes. |
-| Static docs | `packages/examples/setup-guide.html` is linked from `packages/examples/README.md` and covers Roblox, Minecraft, cloud, social, hardware, and wallet setup links. |
+| Static docs | `node packages/examples/scripts/verify-examples.mjs --mode docs` now checks each package README, every package row in this matrix, top-level links to `setup-guide.html`/`VALIDATION.md`, and setup guide sections for Roblox, Minecraft, cloud, social, hardware, and wallet examples. |
 
 ## Example Matrix
 
@@ -47,7 +47,11 @@ The local examples sweep has been run in this worktree with these outcomes:
 | `a2a` | `typecheck`, `test`, `build` | `OPENAI_API_KEY` for model-backed mode. |
 | `agent-console` | `typecheck` | Browser session plus one provider key to inspect live SSE telemetry. |
 | `app/capacitor` | Parent skip scripts plus backend/frontend package checks | Native Capacitor device/simulator testing and provider keys. |
+| `app/capacitor/backend` | `typecheck`, `test`, `build` | Provider key and device/simulator flow through the Capacitor shell. |
+| `app/capacitor/frontend` | `typecheck`, `build` | Browser and native WebView smoke test against a configured backend. |
 | `app/electron` | Parent skip scripts plus backend/frontend package checks | Desktop Electron launch and provider-key chat flow. |
+| `app/electron/backend` | `typecheck`, `test`, `build` | Provider-key chat flow from the packaged Electron shell. |
+| `app/electron/frontend` | `typecheck`, `build` | Renderer smoke test in Electron and browser dev-server mode. |
 | `autonomous` | `typecheck`, `build` | Optional local model and shell sandbox configuration. |
 | `avatar` | `typecheck`, `build` | Browser microphone/audio flow, selected model key, optional ElevenLabs key. |
 | `aws` | `typecheck`, `test`, `build` | AWS account, SAM deployment, and Lambda invocation with `OPENAI_API_KEY`. |

--- a/packages/examples/scripts/verify-examples.mjs
+++ b/packages/examples/scripts/verify-examples.mjs
@@ -102,6 +102,9 @@ function getPackages() {
 
 function checkDocs(packages) {
   const failures = [];
+  const rootReadmePath = path.join(examplesRoot, "README.md");
+  const validationPath = path.join(examplesRoot, "VALIDATION.md");
+  const setupGuidePath = path.join(examplesRoot, "setup-guide.html");
 
   for (const pkg of packages) {
     if (!existsSync(path.join(pkg.dir, "README.md"))) {
@@ -109,15 +112,59 @@ function checkDocs(packages) {
     }
   }
 
-  for (const file of [
-    path.join(examplesRoot, "README.md"),
-    path.join(examplesRoot, "VALIDATION.md"),
-    path.join(examplesRoot, "setup-guide.html"),
-  ]) {
+  for (const file of [rootReadmePath, validationPath, setupGuidePath]) {
     if (!existsSync(file)) {
       failures.push({
         package: relativeToRepo(path.dirname(file)),
         reason: `missing ${path.basename(file)}`,
+      });
+    }
+  }
+
+  if (!existsSync(rootReadmePath) || !existsSync(validationPath) || !existsSync(setupGuidePath)) {
+    return failures;
+  }
+
+  const rootReadme = readFileSync(rootReadmePath, "utf8");
+  const validation = readFileSync(validationPath, "utf8");
+  const setupGuide = readFileSync(setupGuidePath, "utf8");
+
+  for (const requiredLink of ["setup-guide.html", "VALIDATION.md"]) {
+    if (!rootReadme.includes(requiredLink)) {
+      failures.push({
+        package: "packages/examples",
+        reason: `README.md missing link to ${requiredLink}`,
+      });
+    }
+  }
+
+  for (const pkg of packages) {
+    const exampleName = pkg.relativeDir.replace(/^packages\/examples\//, "");
+    if (!validation.includes(`| \`${exampleName}\` |`)) {
+      failures.push({
+        package: pkg.relativeDir,
+        reason: "missing row in VALIDATION.md example matrix",
+      });
+    }
+  }
+
+  for (const requiredText of [
+    "Roblox",
+    "Minecraft",
+    "AWS",
+    "GCP",
+    "Cloudflare",
+    "Convex",
+    "Supabase",
+    "Vercel",
+    "Social bots",
+    "Smartglasses",
+    "Wallet/trading",
+  ]) {
+    if (!setupGuide.includes(requiredText)) {
+      failures.push({
+        package: "packages/examples",
+        reason: `setup-guide.html missing ${requiredText} setup section`,
       });
     }
   }

--- a/packages/examples/setup-guide.html
+++ b/packages/examples/setup-guide.html
@@ -299,11 +299,11 @@ bun run start</code></pre>
       <h2>Model Keys</h2>
       <p>
         Most server examples need one model provider key. Common options are
-        <a href="https://platform.openai.com/api-keys">OpenAI</a>,
+        <a href="https://developers.openai.com/api/docs/quickstart#create-and-export-an-api-key">OpenAI</a>,
         <a href="https://console.anthropic.com/settings/keys">Anthropic</a>,
         <a href="https://aistudio.google.com/app/apikey">Google GenAI</a>,
         <a href="https://console.groq.com/keys">Groq</a>,
-        <a href="https://console.x.ai/">xAI</a>, and
+        <a href="https://docs.x.ai/docs/tutorial">xAI</a>, and
         <a href="https://openrouter.ai/settings/keys">OpenRouter</a>.
       </p>
     </main>

--- a/packages/homepage/tests/e2e/live-onboarding-controls.spec.ts
+++ b/packages/homepage/tests/e2e/live-onboarding-controls.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "playwright/test";
 
-test.setTimeout(60_000);
+test.setTimeout(180_000);
 
 test("get-started public method controls work without API mocks", async ({
   context,

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/prompts",
   "private": false,
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Shared prompt templates for elizaOS across TypeScript, Python, and Rust",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/robot/package.json
+++ b/packages/robot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/robot",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.1-beta.0",
   "description": "Python robotics stack (MuJoCo sim, Brax-PPO RL, websocket bridge, perception, trajectory DB) with a thin TS surface for re-exports and shared schemas. Drives simulated and real robots via profile-driven configuration; first profile is Hiwonder AiNex.",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/scenario-runner/package.json
+++ b/packages/scenario-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/scenario-runner",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Lean scenario runner for the WS7 scenario-schema architecture. Loads .scenario.ts files, executes them against a real @elizaos/core AgentRuntime with a live LLM, and emits a JSON report.",
   "type": "module",
   "license": "MIT",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/shared",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Shared code for Eliza agent and app-core.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/skills",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Bundled skills and skill loading utilities for elizaOS agents",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/tui",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Terminal User Interface library with differential rendering for efficient text-based applications",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/ui",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Shared UI primitives, composites, and layout utilities for elizaOS apps.",
   "type": "module",
   "license": "MIT",

--- a/packages/vault/package.json
+++ b/packages/vault/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/vault",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Simple secrets/config vault for Eliza agents. One API for sensitive credentials and non-sensitive configuration; routes to OS keychain, file, or password manager based on the user's choice.",
   "type": "module",
   "license": "MIT",

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/workflows",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Workflow type contracts consumed by elizaOS workflow plugins.",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/app-model-tester/package.json
+++ b/plugins/app-model-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/app-model-tester",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/plugins/plugin-2004scape/package.json
+++ b/plugins/plugin-2004scape/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-2004scape",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "2004scape game service — autonomous RS agent with SDK WebSocket layer",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts
@@ -342,6 +342,32 @@ describe("subAgentCompletionResponseEvaluator", () => {
     });
   });
 
+  it("does not run a follow-up tool when tool output is followed by a clean final answer", async () => {
+    const context = makeContext({
+      text: '[sub-agent: package check (opencode) — task_complete]\n[tool output: packages/core/package.json]\n{"name":"@elizaos/core","homepage":"https://github.com/elizaOS/eliza"}\n[/tool output]The package name is `@elizaos/core`.',
+      messageHandler: {
+        plan: {
+          contexts: ["general"],
+          reply: "",
+          requiresTool: true,
+          candidateActions: ["SHELL"],
+        },
+      },
+    });
+
+    expect(subAgentCompletionResponseEvaluator.shouldRun(context)).toBe(true);
+    expect(subAgentCompletionResponseEvaluator.evaluate(context)).toEqual({
+      requiresTool: false,
+      setContexts: [SIMPLE_CONTEXT_ID],
+      clearCandidateActions: true,
+      clearParentActionHints: true,
+      reply: "The package name is `@elizaos/core`.",
+      debug: [
+        "verified sub-agent completion has no concrete follow-up action; using direct reply",
+      ],
+    });
+  });
+
   it("promotes ignored verified task_complete messages into direct replies", async () => {
     const context = makeContext({
       text: "[sub-agent: tweet app (opencode) — task_complete]\n[tool output: Check external]\nHTTP/2 200\n[/tool output]\nBuilt data/apps/random-tweet/index.html.\nPublic URL https://example.test/apps/random-tweet/",

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts
@@ -316,6 +316,32 @@ describe("subAgentCompletionResponseEvaluator", () => {
     });
   });
 
+  it("prefers a clean final answer over a raw transcript reply with incidental URLs", async () => {
+    const context = makeContext({
+      text: '[sub-agent: package check (opencode) — task_complete]\n[tool output: packages/core/package.json]\n{"name":"@elizaos/core","homepage":"https://github.com/elizaOS/eliza","repository":{"url":"git+https://github.com/elizaOS/eliza.git"}}\n[/tool output]@elizaos/core',
+      messageHandler: {
+        plan: {
+          contexts: ["simple"],
+          reply:
+            '[tool output: packages/core/package.json]\n{"name":"@elizaos/core","homepage":"https://github.com/elizaOS/eliza","repository":{"url":"git+https://github.com/elizaOS/eliza.git"}}\n[/tool output]@elizaos/core',
+          requiresTool: false,
+        },
+      },
+    });
+
+    expect(subAgentCompletionResponseEvaluator.shouldRun(context)).toBe(true);
+    expect(subAgentCompletionResponseEvaluator.evaluate(context)).toEqual({
+      requiresTool: false,
+      setContexts: [SIMPLE_CONTEXT_ID],
+      clearCandidateActions: true,
+      clearParentActionHints: true,
+      reply: "@elizaos/core",
+      debug: [
+        "verified sub-agent completion has no concrete follow-up action; using direct reply",
+      ],
+    });
+  });
+
   it("promotes ignored verified task_complete messages into direct replies", async () => {
     const context = makeContext({
       text: "[sub-agent: tweet app (opencode) — task_complete]\n[tool output: Check external]\nHTTP/2 200\n[/tool output]\nBuilt data/apps/random-tweet/index.html.\nPublic URL https://example.test/apps/random-tweet/",

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -694,6 +694,34 @@ describe("SubAgentRouter", () => {
       expect(posted?.content?.text).not.toContain("[verification:");
     });
 
+    it("does not verify repository URLs found while inspecting package metadata", async () => {
+      const fetchMock = vi.fn(async () => {
+        return new Response("not found", { status: 404 });
+      });
+      stubFetch(fetchMock);
+      session = sessionWithTask(
+        "Read packages/core/package.json and reply with the package name.",
+      );
+      acp = makeAcpService(session);
+      const { runtime, handleMessage, spawnSession } = makeRuntime({
+        acp: acp.service,
+      });
+      await SubAgentRouter.start(runtime);
+
+      acp.emit(SESSION_ID, "task_complete", {
+        response:
+          '[tool output: Read packages/core/package.json]\n{"name":"@elizaos/core","homepage":"https://github.com/elizaOS/eliza","repository":{"type":"git","url":"git+https://github.com/elizaOS/eliza.git","directory":"packages/core"}}\n[/tool output]\n@elizaos/core',
+      });
+      await new Promise((r) => setTimeout(r, 200));
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(spawnSession).not.toHaveBeenCalled();
+      expect(handleMessage).toHaveBeenCalledTimes(1);
+      const posted = handleMessage.mock.calls[0]?.[1];
+      expect(posted?.content?.text).toContain("@elizaos/core");
+      expect(posted?.content?.text).not.toContain("[verification:");
+    });
+
     it("ignores route-template URL stems when a concrete app URL verifies", async () => {
       const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
         const url = String(input);

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -725,16 +725,16 @@ describe("SubAgentRouter", () => {
     it("ignores route-template URL stems when a concrete app URL verifies", async () => {
       const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
         const url = String(input);
-        if (url === "https://nubilio.org/apps/") {
+        if (url === "https://example.test/apps/") {
           return new Response("not found", { status: 404 });
         }
-        if (url === "https://nubilio.org/apps/counter/") {
+        if (url === "https://example.test/apps/counter/") {
           return new Response('<script src="app.js"></script>', {
             status: 200,
             headers: { "content-type": "text/html" },
           });
         }
-        if (url === "https://nubilio.org/apps/counter/app.js") {
+        if (url === "https://example.test/apps/counter/app.js") {
           return new Response("let count = 0;", {
             status: 200,
             headers: { "content-type": "application/javascript" },
@@ -752,12 +752,12 @@ describe("SubAgentRouter", () => {
 
       acp.emit(SESSION_ID, "task_complete", {
         response:
-          "Route note: verify https://nubilio.org/apps/<slug>/. Built and verified https://nubilio.org/apps/counter/",
+          "Route note: verify https://example.test/apps/<slug>/. Built and verified https://example.test/apps/counter/",
       });
       await new Promise((r) => setTimeout(r, 200));
 
       expect(fetchMock).not.toHaveBeenCalledWith(
-        "https://nubilio.org/apps/",
+        "https://example.test/apps/",
         expect.anything(),
       );
       expect(spawnSession).not.toHaveBeenCalled();
@@ -965,7 +965,7 @@ describe("SubAgentRouter", () => {
             headers: { "content-type": "text/html" },
           });
         }
-        if (url === "https://nubilio.org/apps/asset-check/") {
+        if (url === "https://example.test/apps/asset-check/") {
           return new Response("<html><body>ok</body></html>", {
             status: 200,
             headers: { "content-type": "text/html" },
@@ -975,7 +975,7 @@ describe("SubAgentRouter", () => {
       });
       stubFetch(fetchMock);
       session = sessionWithTask(
-        "build and verify https://nubilio.org/apps/asset-check/",
+        "build and verify https://example.test/apps/asset-check/",
       );
       acp = makeAcpService(session);
       const { runtime, handleMessage, spawnSession } = makeRuntime({
@@ -985,14 +985,16 @@ describe("SubAgentRouter", () => {
 
       acp.emit(SESSION_ID, "task_complete", {
         response:
-          "Done — local: http://127.0.0.1:6900/apps/asset-check/, mirror: https://nubidio.org/apps/asset-check/, public: https://nubilio.org/apps/asset-check/",
+          "Done — local: http://127.0.0.1:6900/apps/asset-check/, mirror: https://wrong.example.test/apps/asset-check/, public: https://example.test/apps/asset-check/",
       });
       await new Promise((r) => setTimeout(r, 200));
 
       const fetched = fetchMock.mock.calls.map(([url]) => String(url));
       expect(fetched).toContain("http://127.0.0.1:6900/apps/asset-check/");
-      expect(fetched).toContain("https://nubilio.org/apps/asset-check/");
-      expect(fetched).not.toContain("https://nubidio.org/apps/asset-check/");
+      expect(fetched).toContain("https://example.test/apps/asset-check/");
+      expect(fetched).not.toContain(
+        "https://wrong.example.test/apps/asset-check/",
+      );
       expect(spawnSession).not.toHaveBeenCalled();
       expect(handleMessage).toHaveBeenCalledTimes(1);
       const posted = handleMessage.mock.calls[0]?.[1];
@@ -1072,12 +1074,12 @@ describe("SubAgentRouter", () => {
     });
 
     it("focuses verification on the referenced app route instead of header telemetry", async () => {
-      const appBase = "https://nubilio.org/apps/cache-safe/";
+      const appBase = "https://example.test/apps/cache-safe/";
       const styleUrl = `${appBase}style-v2.css`;
       const scriptUrl = `${appBase}app-v2.js`;
       const telemetryUrl =
         "https://a.nel.cloudflare.com/report/v4?s=header-noise";
-      const unrelatedUrl = "https://nubilio.org/apps/recipe-4/style.css";
+      const unrelatedUrl = "https://example.test/apps/recipe-4/style.css";
       const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
         const url = String(input);
         if (url === styleUrl) {
@@ -1268,15 +1270,15 @@ describe("SubAgentRouter", () => {
 });
 
 describe("extractSubResources", () => {
-  const PAGE = "https://nubilio.org/apps/bmi/index.html";
+  const PAGE = "https://example.test/apps/bmi/index.html";
 
   it("extracts <link href> and <script src>, resolved absolute", () => {
     const html = `<!doctype html><html><head>
       <link rel="stylesheet" href="style.css" />
       </head><body><script src="app.js"></script></body></html>`;
     expect(extractSubResources(html, PAGE).sort()).toEqual([
-      "https://nubilio.org/apps/bmi/app.js",
-      "https://nubilio.org/apps/bmi/style.css",
+      "https://example.test/apps/bmi/app.js",
+      "https://example.test/apps/bmi/style.css",
     ]);
   });
 
@@ -1284,7 +1286,7 @@ describe("extractSubResources", () => {
     const html = `<link href="/global.css"><script src="https://cdn.example.com/lib.js"></script>`;
     expect(extractSubResources(html, PAGE).sort()).toEqual([
       "https://cdn.example.com/lib.js",
-      "https://nubilio.org/global.css",
+      "https://example.test/global.css",
     ]);
   });
 
@@ -1312,9 +1314,9 @@ describe("normalizeUrlsInText", () => {
   it("replaces a Unicode non-breaking hyphen inside a URL with ASCII hyphen", () => {
     // gpt-oss-class models emit U+2011 where they meant "-", so the link
     // 404s even though the directory exists under the ASCII-hyphen name.
-    const text = "app is live at https://nubilio.org/apps/bmi‑calc‑1/";
+    const text = "app is live at https://example.test/apps/bmi‑calc‑1/";
     expect(normalizeUrlsInText(text)).toBe(
-      "app is live at https://nubilio.org/apps/bmi-calc-1/",
+      "app is live at https://example.test/apps/bmi-calc-1/",
     );
   });
 
@@ -1333,9 +1335,9 @@ describe("normalizeUrlsInText", () => {
   });
 
   it("normalizes every URL when several are present", () => {
-    const text = "http://127.0.0.1/a‑b/ and https://nubilio.org/c‑d/";
+    const text = "http://127.0.0.1/a‑b/ and https://example.test/c‑d/";
     expect(normalizeUrlsInText(text)).toBe(
-      "http://127.0.0.1/a-b/ and https://nubilio.org/c-d/",
+      "http://127.0.0.1/a-b/ and https://example.test/c-d/",
     );
   });
 

--- a/plugins/plugin-agent-orchestrator/package.json
+++ b/plugins/plugin-agent-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-agent-orchestrator",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Canonical ElizaOS plugin for spawning and orchestrating coding agents via native Agent Client Protocol transports — combined with workspace lifecycle, GitHub integration, task share, runtime-driven sub-agent routing, and supporting services.",
   "type": "module",
   "main": "dist/node/index.node.js",

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
@@ -221,6 +221,22 @@ function userFacingCompletionBody(text: string): string {
   return userText || body;
 }
 
+function hasCleanFinalProseAfterToolOutput(text: string): boolean {
+  const body = stripRouterAnnotations(text);
+  if (
+    !body.includes("[tool output:") ||
+    !body.includes(TOOL_OUTPUT_END_MARKER)
+  ) {
+    return false;
+  }
+  const userText = userFacingCompletionBody(text);
+  return (
+    userText.length > 0 &&
+    !isEmptyCompletionPlaceholder(userText) &&
+    !looksLikeRawToolTranscript(userText)
+  );
+}
+
 function stripRouterAnnotations(text: string): string {
   const lines = text.replace(/\r\n/g, "\n").split("\n");
   const body =
@@ -324,6 +340,7 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
     const verifiedUrls = verifiedUrlsFromMetadata(message);
     if (hasVerifiedCompletionReply(currentReply, completionText, verifiedUrls))
       return true;
+    if (hasCleanFinalProseAfterToolOutput(completionText)) return true;
     const hasConcreteFollowUp =
       hasStrings(messageHandler.plan.candidateActions) &&
       !hasOnlyStaleCompletionHints(messageHandler.plan.candidateActions);

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
@@ -154,7 +154,7 @@ function looksLikeCapturedToolOutput(text: string): boolean {
   const firstLine = lines[0]?.trim() ?? "";
   if (!firstLine.startsWith("[tool output:") || !firstLine.endsWith("]"))
     return false;
-  if (lines.some((line) => line.trim() === TOOL_OUTPUT_END_MARKER)) {
+  if (lines.some((line) => line.trim().startsWith(TOOL_OUTPUT_END_MARKER))) {
     return capturedToolOutputBlocksOnly(lines);
   }
   const body = lines.slice(1).join("\n").trim();
@@ -172,8 +172,14 @@ function capturedToolOutputBlocksOnly(lines: string[]): boolean {
       sawToolOutput = true;
       continue;
     }
-    if (insideToolOutput && trimmed === TOOL_OUTPUT_END_MARKER) {
+    if (insideToolOutput && trimmed.startsWith(TOOL_OUTPUT_END_MARKER)) {
       insideToolOutput = false;
+      const markerIndex = line.indexOf(TOOL_OUTPUT_END_MARKER);
+      const afterMarker =
+        markerIndex >= 0
+          ? line.slice(markerIndex + TOOL_OUTPUT_END_MARKER.length).trim()
+          : "";
+      if (afterMarker) remainder.push(afterMarker);
       continue;
     }
     if (!insideToolOutput) {
@@ -188,7 +194,7 @@ function capturedToolOutputBlocksOnly(lines: string[]): boolean {
 function userFacingCompletionBody(text: string): string {
   const body = stripRouterAnnotations(text);
   const lines = body.replace(/\r\n/g, "\n").split("\n");
-  if (!lines.some((line) => line.trim() === TOOL_OUTPUT_END_MARKER)) {
+  if (!lines.some((line) => line.trim().startsWith(TOOL_OUTPUT_END_MARKER))) {
     return body;
   }
   let insideToolOutput = false;
@@ -199,8 +205,14 @@ function userFacingCompletionBody(text: string): string {
       insideToolOutput = true;
       continue;
     }
-    if (insideToolOutput && trimmed === TOOL_OUTPUT_END_MARKER) {
+    if (insideToolOutput && trimmed.startsWith(TOOL_OUTPUT_END_MARKER)) {
       insideToolOutput = false;
+      const markerIndex = line.indexOf(TOOL_OUTPUT_END_MARKER);
+      const afterMarker =
+        markerIndex >= 0
+          ? line.slice(markerIndex + TOOL_OUTPUT_END_MARKER.length).trim()
+          : "";
+      if (afterMarker) remainder.push(afterMarker);
       continue;
     }
     if (!insideToolOutput) remainder.push(line);
@@ -252,6 +264,9 @@ function replyPatchFromCompletion(
   const body = userFacingCompletionBody(completionText);
   const verifiedUrl = userFacingVerifiedUrl(verifiedUrls);
   const cleanBody = body && !looksLikeRawToolTranscript(body) ? body : "";
+  const cleanCurrentReply = !looksLikeRawToolTranscript(currentReply)
+    ? currentReply
+    : "";
   if (!body && !verifiedUrl) return undefined;
   if (isEmptyCompletionPlaceholder(body)) return verifiedUrl;
   if (verifiedUrl && looksLikeRawToolTranscript(completionText)) {
@@ -266,8 +281,8 @@ function replyPatchFromCompletion(
     return cleanBody;
   }
   if (verifiedUrl) return verifiedUrl;
-  if (hasUrl(currentReply)) return currentReply;
-  if (currentReply.length === 0) return cleanBody || body;
+  if (hasUrl(cleanCurrentReply)) return cleanCurrentReply;
+  if (cleanCurrentReply.length === 0) return cleanBody || body;
   if (!hasUrl(currentReply) && cleanBody && hasUrl(cleanBody)) return cleanBody;
   return cleanBody || body;
 }

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
@@ -161,7 +161,16 @@ function looksLikeCapturedToolOutput(text: string): boolean {
   return body.length > 0;
 }
 
-function capturedToolOutputBlocksOnly(lines: string[]): boolean {
+function tailAfterEndMarker(line: string): string {
+  const idx = line.indexOf(TOOL_OUTPUT_END_MARKER);
+  return idx >= 0 ? line.slice(idx + TOOL_OUTPUT_END_MARKER.length).trim() : "";
+}
+
+function partitionToolOutputBlocks(lines: string[]): {
+  remainder: string[];
+  sawToolOutput: boolean;
+  unclosed: boolean;
+} {
   let insideToolOutput = false;
   let sawToolOutput = false;
   const remainder: string[] = [];
@@ -174,21 +183,19 @@ function capturedToolOutputBlocksOnly(lines: string[]): boolean {
     }
     if (insideToolOutput && trimmed.startsWith(TOOL_OUTPUT_END_MARKER)) {
       insideToolOutput = false;
-      const markerIndex = line.indexOf(TOOL_OUTPUT_END_MARKER);
-      const afterMarker =
-        markerIndex >= 0
-          ? line.slice(markerIndex + TOOL_OUTPUT_END_MARKER.length).trim()
-          : "";
-      if (afterMarker) remainder.push(afterMarker);
+      const after = tailAfterEndMarker(line);
+      if (after) remainder.push(after);
       continue;
     }
-    if (!insideToolOutput) {
-      remainder.push(line);
-    }
+    if (!insideToolOutput) remainder.push(line);
   }
-  return (
-    sawToolOutput && !insideToolOutput && remainder.join("\n").trim() === ""
-  );
+  return { remainder, sawToolOutput, unclosed: insideToolOutput };
+}
+
+function capturedToolOutputBlocksOnly(lines: string[]): boolean {
+  const { remainder, sawToolOutput, unclosed } =
+    partitionToolOutputBlocks(lines);
+  return sawToolOutput && !unclosed && remainder.join("\n").trim() === "";
 }
 
 function userFacingCompletionBody(text: string): string {
@@ -197,26 +204,7 @@ function userFacingCompletionBody(text: string): string {
   if (!lines.some((line) => line.trim().startsWith(TOOL_OUTPUT_END_MARKER))) {
     return body;
   }
-  let insideToolOutput = false;
-  const remainder: string[] = [];
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!insideToolOutput && trimmed.startsWith("[tool output:")) {
-      insideToolOutput = true;
-      continue;
-    }
-    if (insideToolOutput && trimmed.startsWith(TOOL_OUTPUT_END_MARKER)) {
-      insideToolOutput = false;
-      const markerIndex = line.indexOf(TOOL_OUTPUT_END_MARKER);
-      const afterMarker =
-        markerIndex >= 0
-          ? line.slice(markerIndex + TOOL_OUTPUT_END_MARKER.length).trim()
-          : "";
-      if (afterMarker) remainder.push(afterMarker);
-      continue;
-    }
-    if (!insideToolOutput) remainder.push(line);
-  }
+  const { remainder } = partitionToolOutputBlocks(lines);
   const userText = remainder.join("\n").trim();
   return userText || body;
 }

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -119,6 +119,44 @@ function extractVerifiableUrls(
   return aliasFiltered.slice(0, limit);
 }
 
+function shouldVerifyCompletionUrls(
+  text: string,
+  referenceText?: string,
+  routeVerification?: RouteUrlVerification,
+): boolean {
+  const completionUrls = collectVerifiableUrlCandidates(text);
+  const referenceUrls = referenceText
+    ? collectVerifiableUrlCandidates(referenceText)
+    : [];
+  if (completionUrls.length === 0 && referenceUrls.length === 0) {
+    return false;
+  }
+
+  if (referenceText && taskRequestsReachableArtifact(referenceText)) {
+    return true;
+  }
+  return completionUrls.some((url) =>
+    isRoutedArtifactUrl(url, routeVerification),
+  );
+}
+
+function taskRequestsReachableArtifact(text: string): boolean {
+  return /\b(?:app|site|website|webpage|page|build|built|create|created|deploy|deployed|deployment|host|hosted|hosting|preview|publish|published|serve|served|serving|static|reachable|live|verify|verified)\b/i.test(
+    text,
+  );
+}
+
+function isRoutedArtifactUrl(
+  url: string,
+  routeVerification?: RouteUrlVerification,
+): boolean {
+  if (appRoutePathPrefix(url)) return true;
+  if (!routeVerification) return false;
+  return routeVerification.mappings.some((mapping) =>
+    url.startsWith(mapping.urlPrefix),
+  );
+}
+
 function filterModelIntroducedUrlAliases(
   urls: string[],
   referenceUrls: Set<string>,
@@ -1242,6 +1280,9 @@ async function annotateUnverifiedUrls(
   runtime?: IAgentRuntime,
   routeVerification?: RouteUrlVerification,
 ): Promise<{ text: string; dead: DeadUrl[]; verifiedUrls: string[] }> {
+  if (!shouldVerifyCompletionUrls(text, referenceText, routeVerification)) {
+    return { text, dead: [], verifiedUrls: [] };
+  }
   const urls = expandRouteUrlAliases(
     extractVerifiableUrls(text, 5, referenceText, ignoredUrls),
     routeVerification,

--- a/plugins/plugin-agent-skills/package.json
+++ b/plugins/plugin-agent-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-agent-skills",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Agent Skills plugin for elizaOS - implement the Agent Skills specification with progressive disclosure",
   "main": "dist/index.js",
   "type": "module",

--- a/plugins/plugin-ainex/package.json
+++ b/plugins/plugin-ainex/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/plugin-ainex",
   "description": "Drives Hiwonder AiNex (and other) humanoid robots via a websocket bridge; integrates camera into plugin-vision and exposes joystick + servo + action-group control to the agent.",
-  "version": "2.0.0",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-anthropic-proxy/package.json
+++ b/plugins/plugin-anthropic-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-anthropic-proxy",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-anthropic/package.json
+++ b/plugins/plugin-anthropic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-anthropic",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-aosp-local-inference/package.json
+++ b/plugins/plugin-aosp-local-inference/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-aosp-local-inference",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "AOSP-only llama.cpp FFI bindings (via bun:ffi) and local-inference bootstrap for elizaOS mobile builds.",
   "type": "module",
   "main": "src/index.ts",

--- a/plugins/plugin-app-control/package.json
+++ b/plugins/plugin-app-control/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elizaos/plugin-app-control",
-	"version": "2.0.1",
+	"version": "2.0.1-beta.0",
 	"description": "App control plugin for Eliza agents — launch, close, and list running apps via the local dashboard API.",
 	"type": "module",
 	"main": "dist/index.js",

--- a/plugins/plugin-app-manager/package.json
+++ b/plugins/plugin-app-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-app-manager",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "App lifecycle plugin for elizaOS: hosted-app launch / list / close, run-state store, and the /api/apps/* route surface. Extracted from @elizaos/agent (Phase 4G).",
   "main": "dist/index.js",
   "type": "module",

--- a/plugins/plugin-babylon/package.json
+++ b/plugins/plugin-babylon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-babylon",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Eliza app integration for Babylon prediction market game.",
   "main": "./dist/index.js",

--- a/plugins/plugin-background-runner/package.json
+++ b/plugins/plugin-background-runner/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-background-runner",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Background task runner for elizaOS — drives core TaskService.runDueTasks() from OS-level wake-ups (BGTaskScheduler on iOS, WorkManager on Android via @capacitor/background-runner). Falls back to a setInterval poll when no native scheduler is available.",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-benchmarks/package.json
+++ b/plugins/plugin-benchmarks/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/plugin-benchmarks",
   "description": "Canonical eliza Action wrappers for benchmark tool vocabularies (vending-bench, webshop, OSWorld, tau-bench, visualwebbench).",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-bluebubbles/package.json
+++ b/plugins/plugin-bluebubbles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-bluebubbles",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/plugin-bluesky/package.json
+++ b/plugins/plugin-bluesky/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-bluesky",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "",
   "type": "module",
   "main": "dist/cjs/index.node.cjs",

--- a/plugins/plugin-browser/package.json
+++ b/plugins/plugin-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-browser",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Browser plugin: BROWSER action and MANAGE_BROWSER_BRIDGE management action. Owns the workspace browser (electrobun-embedded + jsdom fallback) and the Chrome/Safari companion bridge. Targets are registered with the BrowserService; the agent uses what is available.",
   "main": "./dist/index.js",

--- a/plugins/plugin-calendly/package.json
+++ b/plugins/plugin-calendly/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-calendly",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Calendly integration plugin for elizaOS agents — event types, scheduled events, cancellations, and booking-link handoff via Calendly v2 API",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-capacitor-bridge/package.json
+++ b/plugins/plugin-capacitor-bridge/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elizaos/plugin-capacitor-bridge",
-	"version": "2.0.1",
+	"version": "2.0.1-beta.0",
 	"description": "Capacitor WebSocket bridge to device llama for stock mobile (non-AOSP) Eliza builds.",
 	"type": "module",
 	"main": "dist/index.js",

--- a/plugins/plugin-clawville/package.json
+++ b/plugins/plugin-clawville/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-clawville",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Eliza app integration for ClawVille, a sea-themed agent game where connected agents enter a 3D underwater world, visit specialist buildings, and learn skills via the agentskills.io open standard.",
   "main": "./dist/index.js",

--- a/plugins/plugin-cli/package.json
+++ b/plugins/plugin-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-cli",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "CLI framework plugin for ElizaOS agents - provides command registration, execution, and utilities",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-codex-cli/package.json
+++ b/plugins/plugin-codex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-codex-cli",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-coding-tools/package.json
+++ b/plugins/plugin-coding-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-coding-tools",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Native Claude-Code-style coding tools (Read, Write, Edit, Bash, Grep, Glob, etc.) for the Eliza agent.",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -6,7 +6,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { SandboxService, SessionCwdService } from "../services/index.js";
 import { SANDBOX_SERVICE, SESSION_CWD_SERVICE } from "../types.js";
-import { shellAction } from "./bash.js";
+import { resolveCryptoSpotPriceCommand, shellAction } from "./bash.js";
 
 interface RuntimeOptions {
   blockedPaths?: string;
@@ -59,13 +59,16 @@ async function makeRuntime(opts: RuntimeOptions = {}): Promise<{
   return { runtime, sandbox, session, shellHistoryService };
 }
 
-function makeMessage(roomId = "11111111-aaaa-bbbb-cccc-222222222222"): Memory {
+function makeMessage(
+  roomId = "11111111-aaaa-bbbb-cccc-222222222222",
+  text = "",
+): Memory {
   return {
     id: "33333333-3333-3333-3333-333333333333" as UUID,
     entityId: "44444444-4444-4444-4444-444444444444" as UUID,
     roomId: roomId as UUID,
     agentId: "11111111-1111-1111-1111-111111111111" as UUID,
-    content: { text: "" },
+    content: { text },
     createdAt: Date.now(),
   } as Memory;
 }
@@ -142,6 +145,145 @@ describe("shellAction", () => {
     );
     expect(result.success).toBe(true);
     expect(result.text).toContain(tmpRoot);
+  });
+
+  it("uses session cwd instead of an unmentioned cwd for running-source checks", async () => {
+    const roomId = "11111111-aaaa-bbbb-cccc-232323232323";
+    const sessionRoot = path.resolve(
+      process.cwd(),
+      `.tmp-shell-runtime-session-${Date.now()}`,
+    );
+    const staleRoot = path.resolve(
+      process.cwd(),
+      `.tmp-shell-runtime-stale-${Date.now()}`,
+    );
+    await fs.mkdir(sessionRoot, { recursive: true });
+    await fs.mkdir(staleRoot, { recursive: true });
+    try {
+      const { runtime, session } = await makeRuntime();
+      session.setCwd(roomId, sessionRoot);
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(
+          roomId,
+          "Can you tell me what branch and commit the local source is running from?",
+        ),
+        undefined,
+        { command: "pwd", cwd: staleRoot },
+      );
+      expect(result.success).toBe(true);
+      expect(result.text).toContain(sessionRoot);
+      expect(result.text).not.toContain(staleRoot);
+      const data = result.data as Record<string, unknown> | undefined;
+      expect(data?.cwd).toBe(sessionRoot);
+    } finally {
+      await fs.rm(sessionRoot, { recursive: true, force: true });
+      await fs.rm(staleRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("strips unmentioned cd prefixes for running-source checks", async () => {
+    const roomId = "11111111-aaaa-bbbb-cccc-252525252525";
+    const sessionRoot = path.resolve(
+      process.cwd(),
+      `.tmp-shell-cd-session-${Date.now()}`,
+    );
+    const staleRoot = path.resolve(
+      process.cwd(),
+      `.tmp-shell-cd-stale-${Date.now()}`,
+    );
+    await fs.mkdir(sessionRoot, { recursive: true });
+    await fs.mkdir(staleRoot, { recursive: true });
+    try {
+      const { runtime, session } = await makeRuntime();
+      session.setCwd(roomId, sessionRoot);
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(
+          roomId,
+          "Can you tell me what branch and commit the local source is running from?",
+        ),
+        undefined,
+        { command: `cd ${staleRoot} && pwd` },
+      );
+      expect(result.success).toBe(true);
+      expect(result.text).toContain(`(cwd=${sessionRoot}`);
+      expect(result.text).toContain(sessionRoot);
+      expect(result.text).not.toContain(staleRoot);
+      const data = result.data as Record<string, unknown> | undefined;
+      expect(data?.cwd).toBe(sessionRoot);
+    } finally {
+      await fs.rm(sessionRoot, { recursive: true, force: true });
+      await fs.rm(staleRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps cd prefixes when the user names that path", async () => {
+    const roomId = "11111111-aaaa-bbbb-cccc-262626262626";
+    const sessionRoot = path.resolve(
+      process.cwd(),
+      `.tmp-shell-cd-explicit-session-${Date.now()}`,
+    );
+    const requestedRoot = path.resolve(
+      process.cwd(),
+      `.tmp-shell-cd-explicit-requested-${Date.now()}`,
+    );
+    await fs.mkdir(sessionRoot, { recursive: true });
+    await fs.mkdir(requestedRoot, { recursive: true });
+    try {
+      const { runtime, session } = await makeRuntime();
+      session.setCwd(roomId, sessionRoot);
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(
+          roomId,
+          `Can you tell me what branch is running from ${requestedRoot}?`,
+        ),
+        undefined,
+        { command: `cd ${requestedRoot} && pwd` },
+      );
+      expect(result.success).toBe(true);
+      expect(result.text).toContain(requestedRoot);
+      const data = result.data as Record<string, unknown> | undefined;
+      expect(data?.cwd).toBe(sessionRoot);
+    } finally {
+      await fs.rm(sessionRoot, { recursive: true, force: true });
+      await fs.rm(requestedRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("respects an explicit cwd when the user names that path", async () => {
+    const roomId = "11111111-aaaa-bbbb-cccc-242424242424";
+    const sessionRoot = path.resolve(
+      process.cwd(),
+      `.tmp-shell-explicit-session-${Date.now()}`,
+    );
+    const requestedRoot = path.resolve(
+      process.cwd(),
+      `.tmp-shell-explicit-requested-${Date.now()}`,
+    );
+    await fs.mkdir(sessionRoot, { recursive: true });
+    await fs.mkdir(requestedRoot, { recursive: true });
+    try {
+      const { runtime, session } = await makeRuntime();
+      session.setCwd(roomId, sessionRoot);
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(
+          roomId,
+          `Can you tell me what branch is running from ${requestedRoot}?`,
+        ),
+        undefined,
+        { command: "pwd", cwd: requestedRoot },
+      );
+      expect(result.success).toBe(true);
+      expect(result.text).toContain(requestedRoot);
+      const data = result.data as Record<string, unknown> | undefined;
+      expect(data?.cwd).toBe(requestedRoot);
+    } finally {
+      await fs.rm(sessionRoot, { recursive: true, force: true });
+      await fs.rm(requestedRoot, { recursive: true, force: true });
+    }
   });
 
   it("falls back to the session cwd when an explicit cwd is missing", async () => {
@@ -221,6 +363,59 @@ describe("shellAction", () => {
     expect(result.success).toBe(true);
     expect(result.text).toContain(
       '"https://example.com/simple?ids=bitcoin&vs_currencies=usd"',
+    );
+  });
+
+  it("replaces unreliable BTC spot-price endpoints with a neutral no-key source", () => {
+    const coindesk = resolveCryptoSpotPriceCommand({
+      messageText: "What is the current BTC price in USD?",
+      command:
+        "curl -s https://api.coindesk.com/v1/bpi/currentprice/BTC.json | grep rate_float",
+    });
+    expect(coindesk.rewritten).toBe(true);
+    expect(coindesk.command).toContain("api.coingecko.com");
+    expect(coindesk.command).toContain("ids=bitcoin");
+    expect(coindesk.command).not.toContain("coindesk");
+
+    const binance = resolveCryptoSpotPriceCommand({
+      messageText: "What is the current BTC price in USD?",
+      command:
+        "curl -s https://api.binance.com/api/v3/ticker/price?symbol=BTCUSDT",
+    });
+    expect(binance.rewritten).toBe(true);
+    expect(binance.command).toContain("api.coingecko.com");
+    expect(binance.command).not.toContain("binance");
+  });
+
+  it("keeps non-price commands that happen to mention BTC endpoints", () => {
+    const result = resolveCryptoSpotPriceCommand({
+      messageText: "Show me this shell command.",
+      command:
+        "echo https://api.binance.com/api/v3/ticker/price?symbol=BTCUSDT",
+    });
+    expect(result.rewritten).toBe(false);
+    expect(result.command).toContain("binance.com");
+  });
+
+  it("adds user-facing text for neutral crypto spot-price JSON", async () => {
+    const { runtime } = await makeRuntime();
+    const result = await shellAction.handler?.(
+      runtime,
+      makeMessage(
+        "11111111-aaaa-bbbb-cccc-535353535353",
+        "Can you check the current price of BTC in USD?",
+      ),
+      undefined,
+      {
+        command:
+          'printf \'{"bitcoin":{"usd":77296}}\' # https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd',
+      },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.text).toContain('{"bitcoin":{"usd":77296}}');
+    expect(result.userFacingText).toBe(
+      "BTC price: $77,296.00 USD (source: CoinGecko).",
     );
   });
 

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -6,7 +6,11 @@ import { describe, expect, it, vi } from "vitest";
 
 import { SandboxService, SessionCwdService } from "../services/index.js";
 import { SANDBOX_SERVICE, SESSION_CWD_SERVICE } from "../types.js";
-import { resolveCryptoSpotPriceCommand, shellAction } from "./bash.js";
+import {
+  resolveCryptoSpotPriceCommand,
+  resolveDiskInspectionCommand,
+  shellAction,
+} from "./bash.js";
 
 interface RuntimeOptions {
   blockedPaths?: string;
@@ -132,6 +136,21 @@ describe("shellAction", () => {
     );
     expect(result.success).toBe(false);
     expect(result.text).toContain("timeout");
+  });
+
+  it("times out shell pipelines without waiting for orphaned children", async () => {
+    const started = Date.now();
+    const { runtime } = await makeRuntime();
+    const result = await shellAction.handler?.(
+      runtime,
+      makeMessage(),
+      undefined,
+      { command: "sleep 5 | cat", timeout: 200 },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("timeout");
+    expect(Date.now() - started).toBeLessThan(2_500);
   });
 
   it("respects an explicit cwd", async () => {
@@ -430,6 +449,32 @@ describe("shellAction", () => {
     });
     expect(result.rewritten).toBe(false);
     expect(result.command).toContain("binance.com");
+  });
+
+  it("replaces broad disk cleanup scans with a bounded candidate probe", () => {
+    const result = resolveDiskInspectionCommand({
+      messageText:
+        "check disk space on / and /home and name the biggest cleanup candidate you can see",
+      command:
+        "df -h / /home && echo '---' && du -sh /* 2>/dev/null | sort -hr | head -n 5",
+    });
+
+    expect(result.rewritten).toBe(true);
+    expect(result.command).toContain("df -h / /home");
+    expect(result.command).toContain("/tmp");
+    expect(result.command).toContain("$HOME/.cache");
+    expect(result.command).not.toContain("/*");
+    expect(result.command).not.toContain("/home/*");
+  });
+
+  it("keeps targeted disk commands unchanged", () => {
+    const command = "df -h / /home; du -sh /tmp 2>/dev/null";
+    const result = resolveDiskInspectionCommand({
+      messageText: "check disk space and cleanup candidates",
+      command,
+    });
+
+    expect(result).toEqual({ command, rewritten: false });
   });
 
   it("adds user-facing text for neutral crypto spot-price JSON", async () => {

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -218,6 +218,41 @@ describe("shellAction", () => {
     }
   });
 
+  it("rewrites unmentioned git -C paths for local submodule status checks", async () => {
+    const roomId = "11111111-aaaa-bbbb-cccc-272727272727";
+    const sessionRoot = path.resolve(
+      process.cwd(),
+      `.tmp-shell-submodule-session-${Date.now()}`,
+    );
+    const staleRoot = path.resolve(
+      process.cwd(),
+      `.tmp-shell-submodule-stale-${Date.now()}`,
+    );
+    await fs.mkdir(sessionRoot, { recursive: true });
+    await fs.mkdir(staleRoot, { recursive: true });
+    try {
+      const { runtime, session } = await makeRuntime();
+      session.setCwd(roomId, sessionRoot);
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(
+          roomId,
+          "is the vendored opencode submodule present and what commit is checked out? concise",
+        ),
+        undefined,
+        { command: `git -C ${staleRoot} --version` },
+      );
+      expect(result.success).toBe(true);
+      expect(result.text).toContain(`git -C '${sessionRoot}' --version`);
+      expect(result.text).not.toContain(staleRoot);
+      const data = result.data as Record<string, unknown> | undefined;
+      expect(data?.cwd).toBe(sessionRoot);
+    } finally {
+      await fs.rm(sessionRoot, { recursive: true, force: true });
+      await fs.rm(staleRoot, { recursive: true, force: true });
+    }
+  });
+
   it("keeps cd prefixes when the user names that path", async () => {
     const roomId = "11111111-aaaa-bbbb-cccc-262626262626";
     const sessionRoot = path.resolve(

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -157,14 +157,15 @@ function textMentionsPath(text: string, requestedPath: string): boolean {
 function asksAboutRunningRuntimeSource(text: string): boolean {
   const normalized = text.toLowerCase().replace(/\s+/g, " ").trim();
   if (!normalized) return false;
-  return (
-    /\b(?:branch|commit|head|revision|sha|cwd|directory|folder|path|repo|repository|source)\b/.test(
+  const mentionsRepoState =
+    /\b(?:branch|commit|head|revision|sha|cwd|directory|folder|path|repo|repository|source|submodule|worktree)\b/.test(
       normalized,
-    ) &&
-    /\b(?:running|runtime|process|service|bot|agent|currently|current)\b/.test(
+    );
+  const groundsToLocalRuntime =
+    /\b(?:running|runtime|process|service|bot|agent|currently|current|local|workspace|worktree|vendored|vendor|present)\b/.test(
       normalized,
-    )
-  );
+    ) || /\bchecked[- ]out\b/.test(normalized);
+  return mentionsRepoState && groundsToLocalRuntime;
 }
 
 function requestedCryptoSpotAsset(text: string): CryptoSpotAsset | undefined {

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import {
   type Action,
   type ActionResult,
@@ -35,8 +36,22 @@ const STREAM_CAP_CHARS = 30_000;
 const SHELL_HISTORY_DEFAULT_LIMIT = 20;
 const URL_PREFIXES = ["https://", "http://"] as const;
 const SHELL_URL_METACHARS = new Set(["&", ";", "(", ")", "<", ">", "|"]);
+const COINGECKO_SIMPLE_PRICE_BASE =
+  "https://api.coingecko.com/api/v3/simple/price";
 
 type ShellActionSubaction = "run" | "clear_history" | "view_history";
+
+interface CryptoSpotAsset {
+  symbol: string;
+  coingeckoId: string;
+  terms: RegExp;
+}
+
+interface CryptoSpotCommandResolution {
+  command: string;
+  asset?: CryptoSpotAsset;
+  rewritten: boolean;
+}
 
 type ShellHistoryEntryLike = {
   command?: unknown;
@@ -49,6 +64,24 @@ type ShellHistoryServiceLike = {
     limit?: number,
   ) => ShellHistoryEntryLike[];
 };
+
+const CRYPTO_SPOT_ASSETS: CryptoSpotAsset[] = [
+  {
+    symbol: "BTC",
+    coingeckoId: "bitcoin",
+    terms: /\b(?:btc|bitcoin)\b/iu,
+  },
+  {
+    symbol: "ETH",
+    coingeckoId: "ethereum",
+    terms: /\b(?:eth|ethereum)\b/iu,
+  },
+  {
+    symbol: "SOL",
+    coingeckoId: "solana",
+    terms: /\b(?:sol|solana)\b/iu,
+  },
+];
 
 function normalizeShellSubaction(
   value: string | undefined,
@@ -109,6 +142,147 @@ function clampHistoryLimit(value: number | undefined): number {
 function isMissingPathError(error: unknown): boolean {
   const code = (error as NodeJS.ErrnoException | undefined)?.code;
   return code === "ENOENT" || code === "ENOTDIR";
+}
+
+function messageText(message: Memory): string {
+  return typeof message.content?.text === "string" ? message.content.text : "";
+}
+
+function textMentionsPath(text: string, requestedPath: string): boolean {
+  const normalizedText = text.replace(/\\/g, "/");
+  const normalizedPath = requestedPath.replace(/\\/g, "/");
+  return normalizedText.includes(normalizedPath);
+}
+
+function asksAboutRunningRuntimeSource(text: string): boolean {
+  const normalized = text.toLowerCase().replace(/\s+/g, " ").trim();
+  if (!normalized) return false;
+  return (
+    /\b(?:branch|commit|head|revision|sha|cwd|directory|folder|path|repo|repository|source)\b/.test(
+      normalized,
+    ) &&
+    /\b(?:running|runtime|process|service|bot|agent|currently|current)\b/.test(
+      normalized,
+    )
+  );
+}
+
+function requestedCryptoSpotAsset(text: string): CryptoSpotAsset | undefined {
+  const normalized = text.toLowerCase().replace(/\s+/g, " ").trim();
+  if (!normalized) return undefined;
+  if (
+    !/\b(?:price|spot|quote|rate|trading|worth|usd|dollars?)\b/iu.test(
+      normalized,
+    )
+  ) {
+    return undefined;
+  }
+  return CRYPTO_SPOT_ASSETS.find((asset) => asset.terms.test(normalized));
+}
+
+function coingeckoSimplePriceCommand(asset: CryptoSpotAsset): string {
+  const url = `${COINGECKO_SIMPLE_PRICE_BASE}?ids=${encodeURIComponent(
+    asset.coingeckoId,
+  )}&vs_currencies=usd`;
+  return `curl -fsS ${shellSingleQuote(url)}`;
+}
+
+function usesUnreliableCryptoSpotEndpoint(
+  command: string,
+  asset: CryptoSpotAsset,
+): boolean {
+  const lower = command.toLowerCase();
+  if (lower.includes("api.coindesk.com/v1/bpi/currentprice")) {
+    return asset.symbol === "BTC";
+  }
+  if (!lower.includes("api.binance.com/api/v3/ticker/price")) {
+    return false;
+  }
+  const symbolParam = `${asset.symbol.toLowerCase()}usdt`;
+  return lower.includes(`symbol=${symbolParam}`);
+}
+
+export function resolveCryptoSpotPriceCommand(args: {
+  command: string;
+  messageText: string;
+}): CryptoSpotCommandResolution {
+  const asset = requestedCryptoSpotAsset(args.messageText);
+  if (!asset) return { command: args.command, rewritten: false };
+  if (!usesUnreliableCryptoSpotEndpoint(args.command, asset)) {
+    return { command: args.command, asset, rewritten: false };
+  }
+  return {
+    command: coingeckoSimplePriceCommand(asset),
+    asset,
+    rewritten: true,
+  };
+}
+
+function shouldIgnoreUngroundedRuntimeCwd(args: {
+  message: Memory;
+  requestedCwd: string;
+  sessionCwd: string;
+}): boolean {
+  if (path.resolve(args.requestedCwd) === path.resolve(args.sessionCwd)) {
+    return false;
+  }
+  const text = messageText(args.message);
+  if (textMentionsPath(text, args.requestedCwd)) return false;
+  return asksAboutRunningRuntimeSource(text);
+}
+
+function stripShellQuotes(value: string): string {
+  if (
+    (value.startsWith("'") && value.endsWith("'")) ||
+    (value.startsWith('"') && value.endsWith('"'))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function stripTrailingShellPathPunctuation(value: string): string {
+  return value.replace(/[),.;:]+$/g, "");
+}
+
+function rewriteUngroundedRuntimeDirectoryOverrides(args: {
+  command: string;
+  message: Memory;
+  sessionCwd: string;
+}): string {
+  const text = messageText(args.message);
+  if (!asksAboutRunningRuntimeSource(text)) return args.command;
+
+  const leadingCd = args.command.match(
+    /^\s*cd\s+((?:"[^"]+")|(?:'[^']+')|(?:\/[^\s;&|]+))\s*&&\s*([\s\S]+)$/u,
+  );
+  if (leadingCd?.[1] && leadingCd[2]) {
+    const requestedPath = stripTrailingShellPathPunctuation(
+      stripShellQuotes(leadingCd[1]),
+    );
+    if (
+      path.isAbsolute(requestedPath) &&
+      !textMentionsPath(text, requestedPath)
+    ) {
+      return leadingCd[2].trim();
+    }
+  }
+
+  return args.command.replace(
+    /\bgit\s+-C\s+((?:"[^"]+")|(?:'[^']+')|(?:\/[^\s;&|]+))/gu,
+    (match, rawPath: string) => {
+      const requestedPath = stripTrailingShellPathPunctuation(
+        stripShellQuotes(rawPath),
+      );
+      if (
+        !path.isAbsolute(requestedPath) ||
+        textMentionsPath(text, requestedPath)
+      ) {
+        return match;
+      }
+      return `git -C ${shellSingleQuote(args.sessionCwd)}`;
+    },
+  );
 }
 
 function hasUnescapedShellUrlMetachar(token: string): boolean {
@@ -190,6 +364,93 @@ function quoteBareUrlsWithShellMetacharacters(command: string): string {
   return out;
 }
 
+function extractJsonPayload(text: string): unknown {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return undefined;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return undefined;
+  }
+}
+
+function readNestedNumber(value: unknown, path: string[]): number | undefined {
+  let current = value;
+  for (const key of path) {
+    if (!current || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  if (typeof current === "number" && Number.isFinite(current)) return current;
+  if (typeof current === "string") {
+    const parsed = Number(current.replace(/,/g, ""));
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function cryptoSpotSourceForCommand(command: string): string | undefined {
+  const lower = command.toLowerCase();
+  if (lower.includes("api.coingecko.com")) return "CoinGecko";
+  if (lower.includes("api.coinbase.com")) return "Coinbase";
+  return undefined;
+}
+
+function priceFromCryptoSpotOutput(args: {
+  asset: CryptoSpotAsset;
+  command: string;
+  stdout: string;
+}): { price: number; source: string } | undefined {
+  const parsed = extractJsonPayload(args.stdout);
+  const source = cryptoSpotSourceForCommand(args.command);
+  if (parsed) {
+    const coingeckoPrice = readNestedNumber(parsed, [
+      args.asset.coingeckoId,
+      "usd",
+    ]);
+    if (coingeckoPrice !== undefined) {
+      return { price: coingeckoPrice, source: source ?? "CoinGecko" };
+    }
+    const coinbaseAmount = readNestedNumber(parsed, ["data", "amount"]);
+    if (coinbaseAmount !== undefined) {
+      return { price: coinbaseAmount, source: source ?? "Coinbase" };
+    }
+    const binancePrice = readNestedNumber(parsed, ["price"]);
+    if (binancePrice !== undefined && source) {
+      return { price: binancePrice, source };
+    }
+  }
+
+  const numeric = Number(args.stdout.trim().replace(/[$,]/g, ""));
+  if (Number.isFinite(numeric) && source) {
+    return { price: numeric, source };
+  }
+  return undefined;
+}
+
+function formatUsd(price: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: price >= 1 ? 2 : 6,
+  }).format(price);
+}
+
+function cryptoSpotUserFacingText(args: {
+  message: Memory;
+  command: string;
+  stdout: string;
+}): string | undefined {
+  const asset = requestedCryptoSpotAsset(messageText(args.message));
+  if (!asset) return undefined;
+  const result = priceFromCryptoSpotOutput({
+    asset,
+    command: args.command,
+    stdout: args.stdout,
+  });
+  if (!result) return undefined;
+  return `${asset.symbol} price: ${formatUsd(result.price)} USD (source: ${result.source}).`;
+}
+
 function formatStreams(
   stdout: string,
   stderr: string,
@@ -216,7 +477,7 @@ export const shellAction: Action = {
   contextGate: { anyOf: ["code", "terminal", "automation"] },
   similes: ["BASH", "EXEC", "RUN_COMMAND"],
   description:
-    "Shell action. action=run executes command via local shell. action=clear_history clears conversation command history. action=view_history returns recent commands. command required only for run. Prefer bounded commands; avoid recursive whole-filesystem scans unless explicitly requested. For JSON API inspection, prefer jq or node; if Python is needed, call python3 rather than assuming a python alias exists. For public unauthenticated API reads, quote URLs and prefer stable no-key endpoints; avoid deprecated, region-blocked, or exchange-gated endpoints when a neutral data API can answer the same question. If a command exits 0 with empty stdout/stderr, the command produced no output; try another source or parser when data is still needed instead of claiming the shell did not return output. For disk checks, use df for every requested mount/path (for root plus home: df -h / /home) plus targeted du on likely cleanup directories; when asked for cleanup candidates, inspect one readable largest directory one level deeper before ranking candidates. Use separators that still allow later inspection commands to run when du hits expected permission-denied paths.",
+    "Shell action. action=run executes command via local shell. action=clear_history clears conversation command history. action=view_history returns recent commands. command required only for run. Prefer bounded commands; avoid recursive whole-filesystem scans unless explicitly requested. Omit cwd unless the user supplied an exact directory or the session was explicitly moved; do not invent cwd from remembered repo paths. For questions about the currently running agent/runtime/source, use the default session cwd and inspect current process/service evidence before reporting git metadata. For JSON API inspection, prefer jq or node; if Python is needed, call python3 rather than assuming a python alias exists. For public unauthenticated API reads, quote URLs and prefer stable no-key endpoints; avoid deprecated, region-blocked, or exchange-gated endpoints when a neutral data API can answer the same question. For crypto spot prices, prefer neutral no-key APIs such as CoinGecko simple price or Coinbase spot before exchange-gated APIs; do not start with legacy Coindesk or Binance when the same value can be fetched elsewhere. If a command exits 0 with empty stdout/stderr, the command produced no output; try another source or parser when data is still needed instead of claiming the shell did not return output. For disk checks, use df for every requested mount/path (for root plus home: df -h / /home) plus targeted du on likely cleanup directories; when asked for cleanup candidates, inspect one readable largest directory one level deeper before ranking candidates. Use separators that still allow later inspection commands to run when du hits expected permission-denied paths.",
   descriptionCompressed: "Run shell commands; clear/view shell history.",
   parameters: [
     {
@@ -231,7 +492,7 @@ export const shellAction: Action = {
     {
       name: "command",
       description:
-        "For action=run: shell command, executed via /bin/bash -c. Keep routine inspection commands bounded; avoid broad scans like du -sh /* when a targeted path is enough. For JSON API data, prefer jq or node; use python3, not python, unless the environment explicitly shows python exists. For public unauthenticated API reads, quote URLs and prefer stable no-key endpoints; avoid deprecated, region-blocked, or exchange-gated endpoints when a neutral data API can answer the same question. If stdout/stderr are marked empty, the command produced no output; try a different command/source when the user still needs a value. Include every requested path in df, e.g. df -h / /home. For cleanup candidates, follow the first bounded du result with a targeted du on the largest readable directory before answering; avoid && between du probes when permission-denied paths are expected.",
+        "For action=run: shell command, executed via /bin/bash -c. Keep routine inspection commands bounded; avoid broad scans like du -sh /* when a targeted path is enough. For JSON API data, prefer jq or node; use python3, not python, unless the environment explicitly shows python exists. For public unauthenticated API reads, quote URLs and prefer stable no-key endpoints; avoid deprecated, region-blocked, or exchange-gated endpoints when a neutral data API can answer the same question. For crypto spot prices, prefer CoinGecko simple price or Coinbase spot before exchange-gated APIs; avoid legacy Coindesk and Binance when a neutral source can answer. If stdout/stderr are marked empty, the command produced no output; try a different command/source when the user still needs a value. Include every requested path in df, e.g. df -h / /home. For cleanup candidates, follow the first bounded du result with a targeted du on the largest readable directory before answering; avoid && between du probes when permission-denied paths are expected.",
       required: false,
       schema: { type: "string" },
     },
@@ -251,7 +512,7 @@ export const shellAction: Action = {
     {
       name: "cwd",
       description:
-        "Absolute cwd; must not resolve under blocked path. Default session cwd.",
+        "Absolute cwd; must not resolve under blocked path. Omit unless the user supplied this exact directory or the session was explicitly moved; default session cwd is safer than remembered paths.",
       required: false,
       schema: { type: "string" },
     },
@@ -347,7 +608,7 @@ export const shellAction: Action = {
         message: "SHELL requires 'command' (string)",
       });
     }
-    const command = quoteBareUrlsWithShellMetacharacters(rawCommand);
+    let command = quoteBareUrlsWithShellMetacharacters(rawCommand);
     if (command !== rawCommand) {
       coreLogger.debug(
         `${CODING_TOOLS_LOG_PREFIX} SHELL quoted bare URL metacharacters before execution`,
@@ -411,6 +672,24 @@ export const shellAction: Action = {
           );
         }
       }
+      const sessionCwd = await session.getExistingCwd(conversationId);
+      if (
+        shouldIgnoreUngroundedRuntimeCwd({
+          message,
+          requestedCwd: v.resolved,
+          sessionCwd: sessionCwd.cwd,
+        })
+      ) {
+        cwd = sessionCwd.cwd;
+        coreLogger.warn(
+          `${CODING_TOOLS_LOG_PREFIX} SHELL ignored ungrounded runtime cwd; using session cwd (requested=${v.resolved}, fallback=${cwd})`,
+        );
+        if (sessionCwd.reset && sessionCwd.previousCwd) {
+          coreLogger.warn(
+            `${CODING_TOOLS_LOG_PREFIX} SHELL reset missing session cwd (previous=${sessionCwd.previousCwd}, fallback=${cwd})`,
+          );
+        }
+      }
       if (!cwd) cwd = v.resolved;
     } else {
       const sessionCwd = await session.getExistingCwd(conversationId);
@@ -420,6 +699,28 @@ export const shellAction: Action = {
           `${CODING_TOOLS_LOG_PREFIX} SHELL reset missing session cwd (previous=${sessionCwd.previousCwd}, fallback=${cwd})`,
         );
       }
+    }
+
+    const groundedCommand = rewriteUngroundedRuntimeDirectoryOverrides({
+      command,
+      message,
+      sessionCwd: cwd,
+    });
+    if (groundedCommand !== command) {
+      command = groundedCommand;
+      coreLogger.warn(
+        `${CODING_TOOLS_LOG_PREFIX} SHELL removed ungrounded runtime directory override; using cwd=${cwd}`,
+      );
+    }
+    const cryptoCommand = resolveCryptoSpotPriceCommand({
+      command,
+      messageText: messageText(message),
+    });
+    if (cryptoCommand.rewritten) {
+      command = cryptoCommand.command;
+      coreLogger.warn(
+        `${CODING_TOOLS_LOG_PREFIX} SHELL replaced unreliable crypto spot-price endpoint with neutral no-key API`,
+      );
     }
 
     const defaultTimeout = readPositiveIntSetting(
@@ -492,13 +793,19 @@ export const shellAction: Action = {
         { exit_code: result.exitCode, cwd, output: text },
       );
     }
-    return successActionResult(text, {
+    const actionResult = successActionResult(text, {
       exit_code: result.exitCode,
       cwd,
       execution_route: result.sandbox === "host" ? "host" : "sandbox",
       sandbox_backend: result.sandbox,
       signal,
     });
+    const userFacingText = cryptoSpotUserFacingText({
+      message,
+      command,
+      stdout: result.stdout,
+    });
+    return userFacingText ? { ...actionResult, userFacingText } : actionResult;
   },
   examples: [
     [
@@ -541,6 +848,24 @@ export const shellAction: Action = {
       {
         name: "{{name1}}",
         content: {
+          text: "What branch and commit is the currently running local source using?",
+          source: "chat",
+        },
+      },
+      {
+        name: "{{agentName}}",
+        content: {
+          text: "$ pwd; git rev-parse --abbrev-ref HEAD; git rev-parse HEAD\n[exit 0]",
+          actions: ["SHELL"],
+          thought:
+            "Questions about the currently running source use SHELL in the default session cwd; do not set cwd from remembered repo paths unless the user provided an exact path.",
+        },
+      },
+    ],
+    [
+      {
+        name: "{{name1}}",
+        content: {
           text: "Check disk space and safe cleanup candidates.",
           source: "chat",
         },
@@ -570,6 +895,24 @@ export const shellAction: Action = {
           actions: ["SHELL"],
           thought:
             "Current JSON API checks should keep the URL quoted and parse with jq or node; do not assume a python binary exists when python3 is the portable Python command.",
+        },
+      },
+    ],
+    [
+      {
+        name: "{{name1}}",
+        content: {
+          text: "Check the current BTC price in USD.",
+          source: "chat",
+        },
+      },
+      {
+        name: "{{agentName}}",
+        content: {
+          text: "$ curl -s 'https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd' | jq -r '.bitcoin.usd'\n[exit 0]",
+          actions: ["SHELL"],
+          thought:
+            "Public spot-price checks should start with a neutral no-key API such as CoinGecko or Coinbase instead of deprecated or exchange-gated endpoints.",
         },
       },
     ],

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -53,6 +53,11 @@ interface CryptoSpotCommandResolution {
   rewritten: boolean;
 }
 
+interface DiskInspectionCommandResolution {
+  command: string;
+  rewritten: boolean;
+}
+
 type ShellHistoryEntryLike = {
   command?: unknown;
 };
@@ -82,6 +87,9 @@ const CRYPTO_SPOT_ASSETS: CryptoSpotAsset[] = [
     terms: /\b(?:sol|solana)\b/iu,
   },
 ];
+
+const BOUNDED_DISK_INSPECTION_COMMAND =
+  'df -h / /home; printf \'\\n--- cleanup candidates ---\\n\'; for p in /tmp /var/tmp "$HOME/.cache" "$HOME/.bun" "$HOME/.npm" "$HOME/.local/share/Trash"; do [ -e "$p" ] && du -sh "$p" 2>/dev/null; done | sort -hr | head -n 10';
 
 function normalizeShellSubaction(
   value: string | undefined,
@@ -217,6 +225,36 @@ export function resolveCryptoSpotPriceCommand(args: {
     asset,
     rewritten: true,
   };
+}
+
+function asksForDiskInspection(text: string): boolean {
+  const normalized = text.toLowerCase().replace(/\s+/g, " ").trim();
+  if (!normalized) return false;
+  return /\b(?:disk|storage|filesystem|free space|cleanup|clean up|space)\b/.test(
+    normalized,
+  );
+}
+
+function usesBroadDiskUsageScan(command: string): boolean {
+  const normalized = command.replace(/\s+/g, " ").trim();
+  if (!/\bdu\b/.test(normalized)) return false;
+  return (
+    /\bdu\b[^;&|]*(?:\/\*|\/home\/\*)/.test(normalized) ||
+    /\bdu\b[^;&|]*\s\/(?:\s|$)/.test(normalized)
+  );
+}
+
+export function resolveDiskInspectionCommand(args: {
+  command: string;
+  messageText: string;
+}): DiskInspectionCommandResolution {
+  if (!asksForDiskInspection(args.messageText)) {
+    return { command: args.command, rewritten: false };
+  }
+  if (!usesBroadDiskUsageScan(args.command)) {
+    return { command: args.command, rewritten: false };
+  }
+  return { command: BOUNDED_DISK_INSPECTION_COMMAND, rewritten: true };
 }
 
 function shouldIgnoreUngroundedRuntimeCwd(args: {
@@ -711,6 +749,16 @@ export const shellAction: Action = {
       command = groundedCommand;
       coreLogger.warn(
         `${CODING_TOOLS_LOG_PREFIX} SHELL removed ungrounded runtime directory override; using cwd=${cwd}`,
+      );
+    }
+    const diskCommand = resolveDiskInspectionCommand({
+      command,
+      messageText: messageText(message),
+    });
+    if (diskCommand.rewritten) {
+      command = diskCommand.command;
+      coreLogger.warn(
+        `${CODING_TOOLS_LOG_PREFIX} SHELL replaced broad disk scan with bounded cleanup-candidate probe`,
       );
     }
     const cryptoCommand = resolveCryptoSpotPriceCommand({

--- a/plugins/plugin-coding-tools/src/lib/run-shell.ts
+++ b/plugins/plugin-coding-tools/src/lib/run-shell.ts
@@ -111,6 +111,23 @@ function shellArgsForCommand(shell: {
   return shell.args;
 }
 
+function killHostProcess(
+  pid: number | undefined,
+  signal: NodeJS.Signals,
+  useProcessGroup: boolean,
+  proc: ReturnType<typeof spawn>,
+): void {
+  try {
+    if (pid && useProcessGroup) {
+      process.kill(-pid, signal);
+      return;
+    }
+    proc.kill(signal);
+  } catch {
+    // The process may have exited between the timeout firing and kill delivery.
+  }
+}
+
 function runOnHost(opts: {
   command: string;
   cwd: string;
@@ -132,6 +149,7 @@ function runOnHost(opts: {
       });
       return;
     }
+    const useProcessGroup = process.platform !== "win32";
     const proc = spawn(
       shell.command,
       [...shellArgsForCommand(shell), opts.command],
@@ -139,6 +157,7 @@ function runOnHost(opts: {
         cwd: opts.cwd,
         env: opts.env,
         stdio: ["ignore", "pipe", "pipe"],
+        detached: useProcessGroup,
       },
     );
     let stdout = "";
@@ -158,13 +177,9 @@ function runOnHost(opts: {
 
     const timer = setTimeout(() => {
       timedOut = true;
-      proc.kill("SIGTERM");
+      killHostProcess(proc.pid, "SIGTERM", useProcessGroup, proc);
       setTimeout(() => {
-        try {
-          proc.kill("SIGKILL");
-        } catch {
-          // already dead
-        }
+        killHostProcess(proc.pid, "SIGKILL", useProcessGroup, proc);
       }, 1500);
     }, opts.timeoutMs);
     if (typeof timer.unref === "function") timer.unref();

--- a/plugins/plugin-commands/package.json
+++ b/plugins/plugin-commands/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elizaos/plugin-commands",
-	"version": "2.0.1",
+	"version": "2.0.1-beta.0",
 	"type": "module",
 	"main": "dist/index.js",
 	"module": "dist/index.js",

--- a/plugins/plugin-companion/package.json
+++ b/plugins/plugin-companion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-companion",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Companion app package with the VRM scene runtime and avatar utilities.",
   "main": "./dist/index.js",

--- a/plugins/plugin-computeruse/package.json
+++ b/plugins/plugin-computeruse/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-computeruse",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Desktop automation plugin — screenshots, mouse/keyboard control, browser CDP, and window management for elizaOS agents. Ported from open-computer-use (Apache 2.0).",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-contacts/package.json
+++ b/plugins/plugin-contacts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-contacts",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Android Contacts overlay app — wraps the @elizaos/capacitor-contacts native plugin.",
   "main": "./dist/index.js",

--- a/plugins/plugin-defense-of-the-agents/package.json
+++ b/plugins/plugin-defense-of-the-agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-defense-of-the-agents",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Eliza app integration for Defense of the Agents.",
   "main": "./dist/index.js",

--- a/plugins/plugin-device-filesystem/package.json
+++ b/plugins/plugin-device-filesystem/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elizaos/plugin-device-filesystem",
-	"version": "2.0.1",
+	"version": "2.0.1-beta.0",
 	"description": "Mobile-safe filesystem bridge for canonical FILE target=device operations on iOS/Android and desktop/AOSP.",
 	"type": "module",
 	"main": "dist/index.js",

--- a/plugins/plugin-device-settings/package.json
+++ b/plugins/plugin-device-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-device-settings",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Android Device Settings overlay app for ElizaOS — brightness, volume, Android roles, and system settings shortcuts.",
   "main": "./dist/index.js",

--- a/plugins/plugin-discord-local/package.json
+++ b/plugins/plugin-discord-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-discord-local",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Local Discord desktop integration for Eliza via Discord RPC and macOS UI automation",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-discord/package.json
+++ b/plugins/plugin-discord/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elizaos/plugin-discord",
-	"version": "2.0.1",
+	"version": "2.0.1-beta.0",
 	"description": "",
 	"type": "module",
 	"main": "dist/index.js",

--- a/plugins/plugin-documents/package.json
+++ b/plugins/plugin-documents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-documents",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/plugins/plugin-edge-tts/package.json
+++ b/plugins/plugin-edge-tts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-edge-tts",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-elevenlabs/package.json
+++ b/plugins/plugin-elevenlabs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-elevenlabs",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/cjs/index.node.cjs",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-eliza-classic/package.json
+++ b/plugins/plugin-eliza-classic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-eliza-classic",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Deterministic ELIZA-style pattern matching (browser + Node); ships compiled ESM in dist/.",
   "main": "./dist/index.js",

--- a/plugins/plugin-elizacloud/package.json
+++ b/plugins/plugin-elizacloud/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-elizacloud",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-elizamaker/package.json
+++ b/plugins/plugin-elizamaker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-elizamaker",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "ElizaMaker: ERC-8041 NFT drop/mint/whitelist routes, Twitter-verified Merkle proofs, and OG code tracking.",
   "main": "./dist/index.js",

--- a/plugins/plugin-farcaster/package.json
+++ b/plugins/plugin-farcaster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-farcaster",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-feishu/package.json
+++ b/plugins/plugin-feishu/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elizaos/plugin-feishu",
-	"version": "2.0.1",
+	"version": "2.0.1-beta.0",
 	"type": "module",
 	"main": "dist/index.js",
 	"module": "dist/index.js",

--- a/plugins/plugin-form/package.json
+++ b/plugins/plugin-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-form",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Eliza plugin-form: conversational forms as guardrails for guided user journeys.",
   "main": "./dist/index.js",

--- a/plugins/plugin-github/package.json
+++ b/plugins/plugin-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-github",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "GitHub integration plugin for elizaOS agents — PRs, issues, notifications via the GitHub REST API",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-google-chat/package.json
+++ b/plugins/plugin-google-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-google-chat",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-google-genai/package.json
+++ b/plugins/plugin-google-genai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-google-genai",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-google/package.json
+++ b/plugins/plugin-google/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-google",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-groq/package.json
+++ b/plugins/plugin-groq/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-groq",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-health/package.json
+++ b/plugins/plugin-health/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-health",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Health, sleep, circadian and screen-time domain plugin for elizaOS — extracted from app-lifeops in Wave 1 (W1-B). Owns connectors (Apple Health, Google Fit, Strava, Fitbit, Withings, Oura), sleep/circadian/regularity engines, screen-time aggregation, and the wake/bedtime/nap anchor contributions consumed by app-lifeops via the W1-F connector / channel / signal-bus contracts.",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugins/plugin-hyperliquid-app/package.json
+++ b/plugins/plugin-hyperliquid-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-hyperliquid-app",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/plugins/plugin-hyperscape/package.json
+++ b/plugins/plugin-hyperscape/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-hyperscape",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Hyperscape game session resolvers — spectate-and-steer agent sessions with live data from the Hyperscape API",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugins/plugin-imessage/package.json
+++ b/plugins/plugin-imessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-imessage",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/plugin-inmemorydb/package.json
+++ b/plugins/plugin-inmemorydb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-inmemorydb",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.js",
   "module": "dist/node/index.js",

--- a/plugins/plugin-instagram/package.json
+++ b/plugins/plugin-instagram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-instagram",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-lifeops/package.json
+++ b/plugins/plugin-lifeops/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-lifeops",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "LifeOps app plugin: routines, goals, Google Workspace, Apple Calendar, Apple Reminders, Twilio, browser companion control, hosts-file blocking (self-control), and related agent surfaces.",
   "sideEffects": [

--- a/plugins/plugin-line/package.json
+++ b/plugins/plugin-line/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-line",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/plugin-linear/package.json
+++ b/plugins/plugin-linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-linear",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Linear integration plugin for ElizaOS (TypeScript)",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-lmstudio/package.json
+++ b/plugins/plugin-lmstudio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-lmstudio",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-local-inference/package.json
+++ b/plugins/plugin-local-inference/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elizaos/plugin-local-inference",
-	"version": "2.0.1",
+	"version": "2.0.1-beta.0",
 	"description": "Eliza-1 local provider plus HTTP routes for local model catalog, downloads, hardware detection, and chat commands.",
 	"type": "module",
 	"main": "dist/index.js",

--- a/plugins/plugin-local-storage/package.json
+++ b/plugins/plugin-local-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-local-storage",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-localdb/package.json
+++ b/plugins/plugin-localdb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-localdb",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "File-backed (Node) and localStorage (browser) persistence via plugin-inmemorydb; ships compiled ESM in dist/.",
   "main": "./dist/index.js",

--- a/plugins/plugin-matrix/package.json
+++ b/plugins/plugin-matrix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-matrix",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/plugin-mcp/package.json
+++ b/plugins/plugin-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-mcp",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "elizaOS plugin to integrate with MCP (Model Context Protocol) servers",
   "type": "module",
   "main": "dist/node/index.js",

--- a/plugins/plugin-messages/package.json
+++ b/plugins/plugin-messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-messages",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Android Messages overlay app for ElizaOS — SMS inbox and compose surface backed by @elizaos/capacitor-messages.",
   "main": "./dist/index.js",

--- a/plugins/plugin-minecraft/package.json
+++ b/plugins/plugin-minecraft/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/plugin-minecraft",
   "description": "Minecraft automation plugin for ElizaOS (Mineflayer bridge)",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-mlx/package.json
+++ b/plugins/plugin-mlx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-mlx",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-music/package.json
+++ b/plugins/plugin-music/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-music",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-mysticism/package.json
+++ b/plugins/plugin-mysticism/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/plugin-mysticism",
   "description": "Mystical divination engines for ElizaOS — Tarot, I Ching, and Astrology readings",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-native-activity-tracker/package.json
+++ b/plugins/plugin-native-activity-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/native-activity-tracker",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "macOS activity-tracker native helper (Swift) plus a small TypeScript driver that spawns and line-parses the collector process.",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugins/plugin-native-agent/package.json
+++ b/plugins/plugin-native-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-agent",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Starts, stops, and monitors the embedded Eliza agent runtime.",
   "keywords": [
     "agent-runtime",

--- a/plugins/plugin-native-appblocker/package.json
+++ b/plugins/plugin-native-appblocker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-appblocker",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Blocks selected apps on Android with Usage Access and an overlay shield, and on iPhone with Family Controls.",
   "keywords": [
     "app-blocker",

--- a/plugins/plugin-native-bun-runtime/package.json
+++ b/plugins/plugin-native-bun-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-bun-runtime",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Embedded Bun-shape JS runtime bridge for iOS and Android",
   "keywords": [
     "capacitor",

--- a/plugins/plugin-native-calendar/package.json
+++ b/plugins/plugin-native-calendar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-calendar",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Reads and writes Apple Calendar events through EventKit.",
   "keywords": [
     "calendar",

--- a/plugins/plugin-native-camera/package.json
+++ b/plugins/plugin-native-camera/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-camera",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Captures photos, records video, and streams camera preview with manual controls.",
   "keywords": [
     "camera",

--- a/plugins/plugin-native-canvas/package.json
+++ b/plugins/plugin-native-canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-canvas",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Creates interactive canvases with layers, drawing primitives, and A2UI integration.",
   "keywords": [
     "canvas",

--- a/plugins/plugin-native-contacts/package.json
+++ b/plugins/plugin-native-contacts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-contacts",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Android ContactsContract bridge for ElizaOS.",
   "main": "./dist/plugin.cjs.js",
   "module": "./dist/esm/index.js",

--- a/plugins/plugin-native-desktop/package.json
+++ b/plugins/plugin-native-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-desktop",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Adds tray icons, global shortcuts, notifications, and other desktop-only controls.",
   "keywords": [
     "desktop",

--- a/plugins/plugin-native-eliza-tasks/package.json
+++ b/plugins/plugin-native-eliza-tasks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-eliza-tasks",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Bridges iOS BGTaskScheduler (BGAppRefreshTask + BGProcessingTask) wake events into the Eliza Capacitor runtime.",
   "keywords": [
     "background",

--- a/plugins/plugin-native-gateway/package.json
+++ b/plugins/plugin-native-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-gateway",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Connects the app to an Eliza Gateway with discovery, RPC, and realtime events.",
   "keywords": [
     "gateway",

--- a/plugins/plugin-native-llama/package.json
+++ b/plugins/plugin-native-llama/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-llama",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Eliza mobile llama.cpp adapter — wraps llama-cpp-capacitor and maps its contextId-based API onto Eliza's LocalInferenceLoader contract.",
   "keywords": [
     "llama",

--- a/plugins/plugin-native-location/package.json
+++ b/plugins/plugin-native-location/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-location",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Reads current location, watches movement, and manages geolocation permissions.",
   "keywords": [
     "location",

--- a/plugins/plugin-native-macosalarm/package.json
+++ b/plugins/plugin-native-macosalarm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/macosalarm",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "macOS native alarm helper plugin. Schedules UNUserNotificationCenter calendar-trigger alarms via a self-contained Swift CLI invoked from the Eliza runtime.",
   "type": "module",
   "main": "./dist/index.js",

--- a/plugins/plugin-native-messages/package.json
+++ b/plugins/plugin-native-messages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-messages",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Android SMS/MMS bridge for ElizaOS.",
   "main": "./dist/plugin.cjs.js",
   "module": "./dist/esm/index.js",

--- a/plugins/plugin-native-mobile-agent-bridge/package.json
+++ b/plugins/plugin-native-mobile-agent-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-mobile-agent-bridge",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Outbound tunnel from a phone-hosted Eliza agent so a remote Mac client can reach it. See docs/reverse-direction-tunneling.md.",
   "keywords": [
     "agent",

--- a/plugins/plugin-native-mobile-signals/package.json
+++ b/plugins/plugin-native-mobile-signals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-mobile-signals",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Bridges mobile wake, lock, battery, and protected-data state into LifeOps.",
   "keywords": [
     "mobile",

--- a/plugins/plugin-native-network-policy/package.json
+++ b/plugins/plugin-native-network-policy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-network-policy",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Android + iOS native shims surfacing the `metered` / `isExpensive` hints used by the voice-model auto-updater (R5-versioning §4).",
   "main": "./dist/plugin.cjs.js",
   "module": "./dist/esm/index.js",

--- a/plugins/plugin-native-phone/package.json
+++ b/plugins/plugin-native-phone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-phone",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Android phone and Telecom bridge for ElizaOS.",
   "main": "./dist/plugin.cjs.js",
   "module": "./dist/esm/index.js",

--- a/plugins/plugin-native-screencapture/package.json
+++ b/plugins/plugin-native-screencapture/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-screencapture",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Captures screenshots and records the screen across web, mobile, and desktop.",
   "keywords": [
     "screen-capture",

--- a/plugins/plugin-native-swabble/package.json
+++ b/plugins/plugin-native-swabble/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-swabble",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Detects wake words and transcribes live speech with microphone state events.",
   "keywords": [
     "voice",

--- a/plugins/plugin-native-system/package.json
+++ b/plugins/plugin-native-system/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-system",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Android system-role status bridge for ElizaOS.",
   "main": "./dist/plugin.cjs.js",
   "module": "./dist/esm/index.js",

--- a/plugins/plugin-native-talkmode/package.json
+++ b/plugins/plugin-native-talkmode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-talkmode",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Runs voice conversations with live transcription, chat orchestration, and spoken replies.",
   "keywords": [
     "voice",

--- a/plugins/plugin-native-websiteblocker/package.json
+++ b/plugins/plugin-native-websiteblocker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-websiteblocker",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Blocks websites through the Eliza runtime on desktop/web, uses native Android VPN DNS enforcement, and manages a native Safari content blocker on iPhone and iPad.",
   "keywords": [
     "website-blocker",

--- a/plugins/plugin-native-wifi/package.json
+++ b/plugins/plugin-native-wifi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/capacitor-wifi",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Android Wi-Fi (WifiManager) bridge for ElizaOS.",
   "main": "./dist/plugin.cjs.js",
   "module": "./dist/esm/index.js",

--- a/plugins/plugin-ngrok/package.json
+++ b/plugins/plugin-ngrok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-ngrok",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Ngrok tunnel plugin for elizaOS — third-party backend implementing the @elizaos/plugin-tunnel ITunnelService contract.",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-nostr/package.json
+++ b/plugins/plugin-nostr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-nostr",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-ollama/package.json
+++ b/plugins/plugin-ollama/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-ollama",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-omnivoice/package.json
+++ b/plugins/plugin-omnivoice/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-omnivoice",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-openai/package.json
+++ b/plugins/plugin-openai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-openai",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-openrouter/package.json
+++ b/plugins/plugin-openrouter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-openrouter",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-pdf/package.json
+++ b/plugins/plugin-pdf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-pdf",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",

--- a/plugins/plugin-phone/package.json
+++ b/plugins/plugin-phone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-phone",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Phone app for Eliza — Android dialer/call-log overlay (@elizaos/capacitor-phone) and the iOS Phone Companion (pairing, chat-mirror, remote-session).",
   "main": "./dist/index.js",

--- a/plugins/plugin-polymarket-app/package.json
+++ b/plugins/plugin-polymarket-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-polymarket-app",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/plugins/plugin-registry/package.json
+++ b/plugins/plugin-registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-registry",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Plugin registry plugin: consolidates plugin discovery, manifest reading, install/uninstall lifecycle, and HTTP routes for plugin management. Owns the cross-package plugin-routes (agent-tier) and plugins-routes (app-core compat-tier) surfaces and the install-orchestration helpers that forward into the agent runtime.",
   "main": "./dist/index.js",

--- a/plugins/plugin-rlm/package.json
+++ b/plugins/plugin-rlm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-rlm",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "RLM (Recursive Language Model) plugin for elizaOS - enables processing of arbitrarily long contexts",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-roblox/package.json
+++ b/plugins/plugin-roblox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-roblox",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-scape/package.json
+++ b/plugins/plugin-scape/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-scape",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "'scape — first-class agent integration for xRSPS. Autonomous RuneScape-alike agent with JSON-encoded state, Scape Journal, and directed-prompt operator control.",
   "main": "./dist/index.js",

--- a/plugins/plugin-screenshare/package.json
+++ b/plugins/plugin-screenshare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-screenshare",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Screen Share app: authenticated desktop screen streaming and remote mouse/keyboard control for local, Linux, macOS, and Windows runtimes.",
   "main": "./dist/index.js",

--- a/plugins/plugin-shell/package.json
+++ b/plugins/plugin-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-shell",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Shell history and observability plugin for ElizaOS",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-shopify-ui/package.json
+++ b/plugins/plugin-shopify-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-shopify-ui",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/plugins/plugin-shopify/package.json
+++ b/plugins/plugin-shopify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-shopify",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Shopify Admin API plugin for elizaOS agents -- manage products, orders, inventory, and customers.",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-signal/package.json
+++ b/plugins/plugin-signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-signal",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Signal messaging integration plugin for ElizaOS agents",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-slack/package.json
+++ b/plugins/plugin-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-slack",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Slack integration plugin for elizaOS agents with Socket Mode support",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-smartglasses/package.json
+++ b/plugins/plugin-smartglasses/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-smartglasses",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Even Realities G1/G2 smartglasses plugin for ElizaOS: display text, receive microphone audio, and route side-tap microphone controls.",
   "main": "./dist/index.js",
@@ -83,7 +83,12 @@
         "description": "Preferred smartglasses transport. auto selects an injected transport, Even bridge, Web Bluetooth, then Noble BLE.",
         "required": false,
         "default": "auto",
-        "enum": ["auto", "even-bridge", "web-bluetooth", "noble"],
+        "enum": [
+          "auto",
+          "even-bridge",
+          "web-bluetooth",
+          "noble"
+        ],
         "sensitive": false
       },
       "SMARTGLASSES_SCAN_TIMEOUT_MS": {
@@ -105,7 +110,11 @@
         "description": "G1 connection-ready init packet mode. lens-specific sends 0x4D to left and 0xF4 to right; official sends 0x4D to both lenses as in EvenDemoApp iOS; android-f4 sends 0xF4 to both lenses as in EvenDemoApp Android.",
         "required": false,
         "default": "lens-specific",
-        "enum": ["lens-specific", "official", "android-f4"],
+        "enum": [
+          "lens-specific",
+          "official",
+          "android-f4"
+        ],
         "sensitive": false
       }
     }
@@ -114,5 +123,8 @@
     "access": "public"
   },
   "types": "./dist/index.d.ts",
-  "files": ["dist", "docs"]
+  "files": [
+    "dist",
+    "docs"
+  ]
 }

--- a/plugins/plugin-social-alpha/package.json
+++ b/plugins/plugin-social-alpha/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@elizaos/plugin-social-alpha",
-	"version": "2.0.1",
+	"version": "2.0.1-beta.0",
 	"description": "Social Alpha Plugin — Tracks token recommendations (shills/FUD), builds trust scores based on P&L outcomes, and exposes a Social Alpha Provider with win rate, rank, and recommender analytics.",
 	"type": "module",
 	"main": "dist/index.js",

--- a/plugins/plugin-sql/package.json
+++ b/plugins/plugin-sql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-sql",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "",
   "type": "module",
   "main": "src/dist/index.js",

--- a/plugins/plugin-steward-app/package.json
+++ b/plugins/plugin-steward-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-steward-app",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/plugins/plugin-streaming/package.json
+++ b/plugins/plugin-streaming/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/plugin-streaming",
   "description": "RTMP streaming for elizaOS (Twitch, YouTube, X, pump.fun, custom and named ingest URLs)",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-suno/package.json
+++ b/plugins/plugin-suno/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@elizaos/plugin-suno",
-    "version": "2.0.1",
+    "version": "2.0.1-beta.0",
     "description": "Suno AI Music Generation Plugin for Eliza",
     "main": "dist/index.js",
     "type": "module",

--- a/plugins/plugin-tailscale/package.json
+++ b/plugins/plugin-tailscale/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-tailscale",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Tunnel plugin for elizaOS — local Tailscale serve/funnel or Eliza Cloud-routed Tailscale auth-key minter",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-task-coordinator/package.json
+++ b/plugins/plugin-task-coordinator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-task-coordinator",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/plugins/plugin-tee/package.json
+++ b/plugins/plugin-tee/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-tee",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.js",
   "module": "dist/node/index.js",

--- a/plugins/plugin-telegram/package.json
+++ b/plugins/plugin-telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-telegram",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-todos/package.json
+++ b/plugins/plugin-todos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-todos",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "User-scoped persistent todos with CRUD. Single TODO umbrella action (op-based: write/create/update/complete/cancel/delete/list/clear) and a currentTodosProvider that surfaces the user's pending + in-progress todos to the planner each turn. Backed by drizzle pgSchema('todos').",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-training/package.json
+++ b/plugins/plugin-training/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-training",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/plugins/plugin-trajectory-logger/package.json
+++ b/plugins/plugin-trajectory-logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-trajectory-logger",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Realtime trajectory inspector overlay app — surfaces the last completed and the in-flight trajectory with HANDLE / PLAN / ACTION / EVALUATE phase drilldowns.",
   "main": "./dist/index.js",

--- a/plugins/plugin-tunnel/package.json
+++ b/plugins/plugin-tunnel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-tunnel",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Tunnel plugin for elizaOS — local Tailscale CLI backend (serve/funnel). Pair with @elizaos/plugin-elizacloud for the hosted headscale backend.",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-twitch/package.json
+++ b/plugins/plugin-twitch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-twitch",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/plugins/plugin-video/package.json
+++ b/plugins/plugin-video/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-video",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-vincent/package.json
+++ b/plugins/plugin-vincent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-vincent",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/plugins/plugin-vision/package.json
+++ b/plugins/plugin-vision/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/plugin-vision",
   "description": "Vision plugin for ElizaOS - provides camera integration and visual awareness",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-wallet-ui/package.json
+++ b/plugins/plugin-wallet-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-wallet-ui",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/plugins/plugin-wallet/package.json
+++ b/plugins/plugin-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-wallet",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "Non-custodial wallet for elizaOS agents — EVM + Solana, ERC-6551 token-bound accounts, on-chain spend policies, x402 micropayments, CCTP bridge, Li.Fi swap routing, Jupiter routing, multi-DEX LP management (Raydium/Orca/Meteora on Solana, Uniswap/Aerodrome on EVM), Hyperliquid perps, Polymarket, Aave/Morpho lending, and Clanker token launches. Replaces plugin-evm + plugin-solana + plugin-raydium + plugin-orca + plugin-meteora + plugin-jupiter + plugin-lp-manager + plugin-clanker behind one canonical action+provider surface.",
   "type": "module",
   "license": "MIT",

--- a/plugins/plugin-web-search/package.json
+++ b/plugins/plugin-web-search/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@elizaos/plugin-web-search",
-    "version": "2.0.1",
+    "version": "2.0.1-beta.0",
     "type": "module",
     "main": "dist/index.js",
     "module": "dist/index.js",

--- a/plugins/plugin-wechat/package.json
+++ b/plugins/plugin-wechat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-wechat",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "WeChat connector plugin for elizaOS via proxy API",
   "type": "module",
   "license": "MIT",

--- a/plugins/plugin-whatsapp/package.json
+++ b/plugins/plugin-whatsapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elizaos/plugin-whatsapp",
   "description": "WhatsApp plugin for ElizaOS (Cloud API + Baileys QR auth)",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/plugins/plugin-wifi/package.json
+++ b/plugins/plugin-wifi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-wifi",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "Wi-Fi overlay app for the Eliza Android build — scan, inspect, and connect to nearby networks via @elizaos/capacitor-wifi.",
   "main": "./dist/index.js",

--- a/plugins/plugin-workflow/package.json
+++ b/plugins/plugin-workflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-workflow",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "ElizaOS plugin for generating and running workflows in-process",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-x/package.json
+++ b/plugins/plugin-x/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-x",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "elizaOS X (formerly Twitter) connector: posting, mentions, replies, DMs, and timeline interactions.",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-x402/package.json
+++ b/plugins/plugin-x402/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-x402",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "x402 micropayment middleware for elizaOS plugin HTTP routes",
   "type": "module",
   "main": "dist/index.js",

--- a/plugins/plugin-xai/package.json
+++ b/plugins/plugin-xai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-xai",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "description": "elizaOS xAI plugin: Grok models for text generation and embeddings.",
   "type": "module",
   "main": "dist/node/index.node.js",

--- a/plugins/plugin-xr/package.json
+++ b/plugins/plugin-xr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-xr",
-  "version": "0.1.0",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "description": "WebXR audio/video streaming for elizaOS — Quest 3 and XReal glasses",
   "main": "./dist/index.js",

--- a/plugins/plugin-zai/package.json
+++ b/plugins/plugin-zai/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elizaos/plugin-zai",
-  "version": "2.0.1",
+  "version": "2.0.1-beta.0",
   "type": "module",
   "main": "dist/node/index.node.js",
   "module": "dist/node/index.node.js",


### PR DESCRIPTION
## Summary
- Sync develop to main after green CI.
- Includes CI fixes for: e1-chip docker-written artifact permissions, homepage live-onboarding playwright timeout (60s → 180s), and bun.lock optional-peers drift for plugin-local-inference.
- Bundles the auto-generated v2.0.1-beta.0 release commit and ongoing sub-agent / coding-tools fixes from feature branches.

## Test plan
- [x] Tests passed on develop tip (946ada26bf)
- [x] Quality (Extended) passed on develop tip
- [x] Cloud Tests / Env Audit / Docker CI Smoke / Scenario Matrix green on develop tip
- [x] Tests / Snap Build / Cloud Tests / Build Agent Image / Test Packaging green on main at 158b9c506b
- [x] Main's Quality (Extended) flake (live-onboarding 60s timeout) is the regression this merge fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)