### PR TITLE
fix(app-core): connector accounts schema + loader — Greptile P1/P2 follow-up to #7817

### DIFF
--- a/packages/app-core/src/registry/connector-accounts.test.ts
+++ b/packages/app-core/src/registry/connector-accounts.test.ts
@@ -77,6 +77,14 @@ describe("connectorEntrySchema accounts field", () => {
     });
     expect(parsed.accounts?.agent?.credentialKeys).toEqual([]);
   });
+
+  it("rejects an empty accounts object — at least one side must be defined", () => {
+    const result = connectorEntrySchema.safeParse({
+      ...baseConnector,
+      accounts: {},
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe("normalizeConnectorAuth (legacy auth → accounts.agent)", () => {
@@ -112,17 +120,49 @@ describe("normalizeConnectorAuth (legacy auth → accounts.agent)", () => {
     expect(normalized.accounts?.agent?.authKind).toBe("none");
   });
 
-  it("leaves explicit accounts untouched even when auth is also declared", () => {
+  it("maps legacy credentials auth to accounts.agent with api-key", () => {
+    const entry = connectorEntrySchema.parse({
+      ...baseConnector,
+      auth: { kind: "credentials", credentialKeys: ["USERNAME", "PASSWORD"] },
+    });
+    const normalized = normalizeConnectorAuth(entry);
+    expect(normalized.accounts?.agent?.authKind).toBe("api-key");
+    expect(normalized.accounts?.agent?.credentialKeys).toEqual([
+      "USERNAME",
+      "PASSWORD",
+    ]);
+  });
+
+  it("preserves an explicit accounts.agent when also given legacy auth", () => {
     const entry = connectorEntrySchema.parse({
       ...baseConnector,
       auth: { kind: "oauth", credentialKeys: ["FOO_TOKEN"] },
       accounts: {
-        owner: { supported: true, authKind: "local-app" },
+        agent: { supported: true, authKind: "local-app" },
       },
     });
     const normalized = normalizeConnectorAuth(entry);
-    expect(normalized.accounts?.owner?.authKind).toBe("local-app");
-    expect(normalized.accounts?.agent).toBeUndefined();
+    expect(normalized.accounts?.agent?.authKind).toBe("local-app");
+  });
+
+  it("fills accounts.agent from legacy auth when accounts only declares owner (partial migration)", () => {
+    const entry = connectorEntrySchema.parse({
+      ...baseConnector,
+      auth: { kind: "token", credentialKeys: ["LEGACY_TOKEN"] },
+      accounts: {
+        owner: {
+          supported: true,
+          authKind: "oauth-cloud",
+          credentialKeys: [],
+        },
+      },
+    });
+    const normalized = normalizeConnectorAuth(entry);
+    expect(normalized.accounts?.owner?.authKind).toBe("oauth-cloud");
+    expect(normalized.accounts?.agent?.authKind).toBe("api-key");
+    expect(normalized.accounts?.agent?.credentialKeys).toEqual([
+      "LEGACY_TOKEN",
+    ]);
   });
 
   it("is a no-op when neither auth nor accounts is declared", () => {

--- a/packages/app-core/src/registry/loader.ts
+++ b/packages/app-core/src/registry/loader.ts
@@ -73,21 +73,24 @@ export function loadRegistryFromRawEntries(raws: RawEntry[]): LoadedRegistry {
 // Legacy `auth` → `accounts.agent` auto-mapping. Connector manifests that
 // only declared `auth` keep working without edits — the resulting `accounts`
 // shape lets the UI render a single agent section (backwards compatible) and
-// gives downstream code a uniform field to read. When a manifest already
-// declares `accounts`, the legacy `auth` is left untouched.
+// gives downstream code a uniform field to read.
+//
+// The guard checks `accounts?.agent` (not just `accounts`) so that incremental
+// migrations — a manifest that adds `accounts.owner` first while keeping
+// `auth` as the agent credential source — still get the legacy auth mapped
+// onto `accounts.agent`. A pre-existing explicit `accounts.agent` is always
+// preserved.
 export function normalizeConnectorAuth(entry: ConnectorEntry): ConnectorEntry {
-  if (!entry.auth || entry.accounts) {
+  if (!entry.auth || entry.accounts?.agent) {
     return entry;
   }
-  const authKind: AccountAuthKind =
-    entry.auth.kind === "oauth"
-      ? "oauth-cloud"
-      : entry.auth.kind === "none"
-        ? "none"
-        : "api-key";
+  const authKind: AccountAuthKind = mapLegacyAuthKindToAccountAuthKind(
+    entry.auth.kind,
+  );
   return {
     ...entry,
     accounts: {
+      ...(entry.accounts ?? {}),
       agent: {
         supported: true,
         authKind,
@@ -95,6 +98,27 @@ export function normalizeConnectorAuth(entry: ConnectorEntry): ConnectorEntry {
       },
     },
   };
+}
+
+// Maps the legacy four-value auth.kind enum onto the richer AccountAuthKind.
+// `credentials` (username + password) is materially different from `api-key`
+// (a single opaque token) but the current AccountAuthKind enum has no
+// dedicated arm — both flows land on a manual paste of secret fields in the
+// connector setup UI, so they coalesce here. Connectors with username+password
+// flows should declare `accounts.agent.authKind` explicitly in their manifest
+// when they need to distinguish, rather than relying on this auto-mapping.
+function mapLegacyAuthKindToAccountAuthKind(
+  kind: "token" | "oauth" | "credentials" | "none",
+): AccountAuthKind {
+  switch (kind) {
+    case "oauth":
+      return "oauth-cloud";
+    case "none":
+      return "none";
+    case "credentials":
+    case "token":
+      return "api-key";
+  }
 }
 
 export function indexEntries(entries: RegistryEntry[]): LoadedRegistry {

--- a/packages/app-core/src/registry/schema.ts
+++ b/packages/app-core/src/registry/schema.ts
@@ -322,6 +322,13 @@ export const connectorEntrySchema = z.object({
       owner: accountConfigSchema.optional(),
       agent: accountConfigSchema.optional(),
     })
+    .refine(
+      (val) => val.owner !== undefined || val.agent !== undefined,
+      {
+        message:
+          "accounts must define at least one of owner or agent — an empty {} prevents the legacy auth field from being mapped to accounts.agent at load time",
+      },
+    )
     .optional(),
 });
 

--- a/packages/app-core/src/registry/schema.ts
+++ b/packages/app-core/src/registry/schema.ts
@@ -326,7 +326,7 @@ export const connectorEntrySchema = z.object({
       (val) => val.owner !== undefined || val.agent !== undefined,
       {
         message:
-          "accounts must define at least one of owner or agent — an empty {} prevents the legacy auth field from being mapped to accounts.agent at load time",
+          "accounts must define at least one of owner or agent — an empty {} is meaningless and likely indicates an incomplete manifest",
       },
     )
     .optional(),


### PR DESCRIPTION
## Summary

Three Greptile findings from #7817 (which merged before the follow-ups landed):

- **P1** \`loader.ts\` — narrow the legacy-auth guard from \`entry.accounts\` to \`entry.accounts?.agent\`. A partial migration (manifest adds \`accounts.owner\` first while keeping \`auth\` as the agent credential source) now still gets the legacy auth mapped onto \`accounts.agent\` instead of silently leaving the agent side undefined.

- **P1** \`loader.ts\` — make the legacy \`auth.kind\` → \`AccountAuthKind\` mapping explicit via \`mapLegacyAuthKindToAccountAuthKind()\`. The previous ternary silently lumped \`"credentials"\` (username + password) in with \`"token"\` under \`"api-key"\`. The new exhaustive switch covers all four legacy enum values and documents that \`credentials\` and \`token\` coalesce because the UI surface is the same; connectors that need to distinguish should declare \`accounts.agent.authKind\` in their manifest.

- **P2** \`schema.ts\` — add \`.refine()\` on the \`accounts\` object to require at least one of \`owner\` / \`agent\`. An accidental \`accounts: {}\` no longer silently blocks the legacy-auth auto-mapping.

13/13 tests pass (added cases for credentials→api-key, partial-migration agent fill from legacy auth, and empty-accounts rejection).

Original PR was merged before this follow-up could land — re-shipping as a discrete change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes three follow-up findings from #7817: the legacy-auth guard is narrowed to `accounts?.agent` so partial-migration manifests (owner declared, agent still sourced from `auth`) fill the agent slot correctly; legacy `auth.kind` → `AccountAuthKind` mapping is extracted into an exhaustive switch that explicitly documents the `credentials`/`token` coalescing; and a `.refine()` on the `accounts` object rejects the meaningless `accounts: {}` shape at parse time.

- **`loader.ts`**: `normalizeConnectorAuth` now checks `accounts?.agent` instead of `accounts`, and spreads any existing `accounts` fields (e.g. `owner`) so they survive the agent-fill pass; `mapLegacyAuthKindToAccountAuthKind` is a standalone exhaustive switch covering all four legacy enum values.
- **`schema.ts`**: `.refine()` added inside the `accounts` object (before `.optional()`) so `accounts: {}` fails validation without affecting entries that omit `accounts` entirely.
- **`connector-accounts.test.ts`**: Three new test cases cover `credentials→api-key`, partial-migration owner-only fill, and empty-accounts rejection; the old test that incorrectly assumed `owner`-only blocks agent-fill is replaced.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three changes are narrowly scoped corrections to previously-merged logic, each covered by a dedicated test case.

The guard change, the explicit auth-kind mapping, and the schema refine are all straightforward and well-tested. The exhaustive switch covers every member of the legacy auth.kind union, the .optional() placement on accounts is correct so the refine only fires for explicitly-provided empty objects, and the spread correctly forwards existing owner data through the agent-fill path. No behavioural regressions were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/registry/loader.ts | Guard narrowed from `entry.accounts` to `entry.accounts?.agent` to support partial migrations; legacy-auth mapping extracted to exhaustive switch; existing owner fields now preserved via spread. |
| packages/app-core/src/registry/schema.ts | Added `.refine()` to the `accounts` object to reject `accounts: {}` at parse time; outer `.optional()` placement is correct so the refine only fires when the field is present. |
| packages/app-core/src/registry/connector-accounts.test.ts | Tests updated to match new behavior: empty-accounts rejection, credentials→api-key mapping, partial-migration owner-only case, and explicit-agent preservation all covered with clear assertions. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ConnectorEntry loaded via zod] --> B{entry.auth present?}
    B -- No --> Z[return entry unchanged]
    B -- Yes --> C{entry.accounts?.agent defined?}
    C -- Yes, explicit agent --> Z
    C -- No agent yet --> D[mapLegacyAuthKindToAccountAuthKind]
    D --> E{auth.kind}
    E -- oauth --> F[oauth-cloud]
    E -- none --> G[none]
    E -- token / credentials --> H[api-key]
    F & G & H --> I[Spread existing accounts then add accounts.agent]
    I --> J[return patched entry with accounts.owner preserved and accounts.agent filled]
```

<sub>Reviews (2): Last reviewed commit: ["fix(app-core): tighten accounts refine e..."](https://github.com/elizaos/eliza/commit/ff2f77d694451a4f24f151350a1ec486e637cd23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33005832)</sub>

<!-- /greptile_comment -->