### PR TITLE
fix(ui): share connector-accounts hook across OWNER+AGENT sections — Greptile P2 follow-up to #7819

### DIFF
--- a/packages/ui/src/components/connectors/ConnectorAccountList.tsx
+++ b/packages/ui/src/components/connectors/ConnectorAccountList.tsx
@@ -5,7 +5,10 @@ import type {
   ConnectorAccountRecord,
   ConnectorAccountRole,
 } from "../../api/client-agent";
-import { useConnectorAccounts } from "../../hooks/useConnectorAccounts";
+import {
+  useConnectorAccounts,
+  type UseConnectorAccountsResult,
+} from "../../hooks/useConnectorAccounts";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 import { Spinner } from "../ui/spinner";
@@ -32,6 +35,17 @@ export interface ConnectorAccountListProps {
    * "single flat list of accounts" behavior is preserved.
    */
   accountRole?: ConnectorAccountRole;
+  /**
+   * Optional pre-built `useConnectorAccounts` result. When provided, the
+   * component reuses this external hook state instead of instantiating its
+   * own — used by `OwnerAgentConnectorSetupPanel` to share a single polling
+   * instance across the OWNER and AGENT sections. The list still filters
+   * the shared `accounts` array by `accountRole` locally.
+   *
+   * When omitted, the list calls `useConnectorAccounts` internally as
+   * before, preserving the legacy single-list behavior.
+   */
+  externalAccounts?: UseConnectorAccountsResult;
 }
 
 function sortConnectorAccounts(
@@ -84,11 +98,17 @@ export function ConnectorAccountList({
   onSelectedAccountIdChange,
   onAddAccount,
   accountRole,
+  externalAccounts,
 }: ConnectorAccountListProps) {
-  const connectorAccounts = useConnectorAccounts(provider, connectorId, {
+  // When the caller hoists the accounts hook (e.g. `OwnerAgentConnectorSetupPanel`),
+  // skip the internal polling instance — Rules of Hooks require the call
+  // unconditionally, but `enabled: false` disables the network fetch + interval.
+  const internalAccounts = useConnectorAccounts(provider, connectorId, {
     pollMs,
     initialSelectedAccountId: selectedAccountId,
+    enabled: !externalAccounts,
   });
+  const connectorAccounts = externalAccounts ?? internalAccounts;
   const setConnectorSelectedAccountId = connectorAccounts.setSelectedAccountId;
   const effectiveTitle = title ?? defaultTitleForRole(accountRole);
 

--- a/packages/ui/src/components/connectors/OwnerAgentConnectorSetupPanel.tsx
+++ b/packages/ui/src/components/connectors/OwnerAgentConnectorSetupPanel.tsx
@@ -17,6 +17,7 @@
  * this component as a "AGENT-only with the future-proof shape" placeholder.
  */
 
+import { useConnectorAccounts } from "../../hooks/useConnectorAccounts";
 import { cn } from "../../lib/utils";
 import { ConnectorAccountList } from "./ConnectorAccountList";
 
@@ -46,6 +47,14 @@ export function OwnerAgentConnectorSetupPanel({
   agentTitle,
   description,
 }: OwnerAgentConnectorSetupPanelProps) {
+  // Hoist the accounts hook to the panel so both the OWNER and AGENT lists
+  // share a single polling instance + cache, instead of each calling the
+  // hook independently and double-firing `GET /api/connectors/:provider/accounts`
+  // every poll cycle.
+  const accountsHook = useConnectorAccounts(provider, connectorId ?? provider, {
+    pollMs,
+  });
+
   return (
     <div className={cn("flex flex-col gap-3", className)}>
       {description ? <p className="text-xs text-muted">{description}</p> : null}
@@ -55,7 +64,7 @@ export function OwnerAgentConnectorSetupPanel({
           connectorId={connectorId}
           accountRole="OWNER"
           title={ownerTitle}
-          pollMs={pollMs}
+          externalAccounts={accountsHook}
         />
       ) : null}
       {enableAgent ? (
@@ -64,7 +73,7 @@ export function OwnerAgentConnectorSetupPanel({
           connectorId={connectorId}
           accountRole="AGENT"
           title={agentTitle}
-          pollMs={pollMs}
+          externalAccounts={accountsHook}
         />
       ) : null}
     </div>


### PR DESCRIPTION
## Summary

Greptile P2 from #7819 (which merged before this follow-up could land).

\`OwnerAgentConnectorSetupPanel\` was rendering two \`ConnectorAccountList\` instances, each calling \`useConnectorAccounts(provider, connectorId, …)\` internally. Because the hook owns its own \`setInterval\`, the same \`GET /api/connectors/:provider/accounts\` request fired twice per poll cycle for the lifetime of the panel.

This change hoists the hook to the panel level:

- \`ConnectorAccountList\` accepts an optional \`externalAccounts: UseConnectorAccountsResult\` prop. When provided, the list reuses that hook state instead of instantiating its own; the internal hook is still called (Rules of Hooks) but with \`enabled: false\` so it neither fetches nor polls.
- \`OwnerAgentConnectorSetupPanel\` calls \`useConnectorAccounts\` once and passes the result to both the OWNER and AGENT sections. Both sections share one poll, one fetch, one cache.
- Single-list call sites — where \`externalAccounts\` is omitted — keep the previous internal-hook behavior.

Rebased onto the post-merge \`accountRole\` rename from #7819's merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hoists the `useConnectorAccounts` hook from each `ConnectorAccountList` up to the `OwnerAgentConnectorSetupPanel` level, so the OWNER and AGENT sections share one polling instance and one cache instead of independently firing the same `GET /api/connectors/:provider/accounts` request every poll cycle.

- `ConnectorAccountList` gains an optional `externalAccounts` prop; when provided, the internal hook is called with `enabled: false` (Rules of Hooks compliance) and its result is discarded in favour of the shared state.
- `OwnerAgentConnectorSetupPanel` calls `useConnectorAccounts` once and threads the result into both child lists, eliminating the double-fetch.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core de-duplication logic is correct and the change is backward-compatible for single-list call sites.

The panel-level hook hoisting works correctly and the `connectorId ?? provider` fallback is consistent with the defaults in both `ConnectorAccountList` and `useConnectorAccounts`. Two minor rough edges exist: the shared hook's error string renders independently in each section, so a fetch failure produces duplicate error banners in the panel; and `makeDefault`/`remove` inside the shared hook mutate a single `selectedAccountId` that both sections read, so a selection action in one section silently changes `effectiveAccountId` in the other. Both are contained UX issues with no data-correctness impact under current usage.

Both changed files are worth a second look — `ConnectorAccountList.tsx` for the shared error and selection-state side-effects, `OwnerAgentConnectorSetupPanel.tsx` itself is clean.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/components/connectors/ConnectorAccountList.tsx | Adds optional `externalAccounts` prop; when provided, disables the internal hook polling and delegates to the shared state. Two P2 side-effects: shared error strings render twice, and shared `selectedAccountId` mutations from one section (makeDefault, remove) are visible to the other. |
| packages/ui/src/components/connectors/OwnerAgentConnectorSetupPanel.tsx | Hoists `useConnectorAccounts` to panel level and passes the result to both child lists via `externalAccounts`, eliminating the duplicate polling. Logic is correct; `connectorId ?? provider` fallback matches the default in both `ConnectorAccountList` and `useConnectorAccounts`. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Panel as OwnerAgentConnectorSetupPanel
    participant Hook as useConnectorAccounts (shared)
    participant API as GET /api/connectors/:provider/accounts
    participant Owner as ConnectorAccountList (OWNER)
    participant Agent as ConnectorAccountList (AGENT)

    Note over Panel,Hook: Before this PR — two hooks, two polls
    Owner->>API: fetch (own interval)
    Agent->>API: fetch (own interval)

    Note over Panel,Hook: After this PR — one hook, one poll
    Panel->>Hook: "useConnectorAccounts(provider, connectorId, { pollMs })"
    Hook->>API: fetch (single interval)
    API-->>Hook: accounts[]
    Hook-->>Panel: accountsHook
    Panel-->>Owner: "externalAccounts=accountsHook"
    Panel-->>Agent: "externalAccounts=accountsHook"
    Owner->>Hook: "filter accounts where role=OWNER"
    Agent->>Hook: "filter accounts where role=AGENT"
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/ui/src/components/connectors/ConnectorAccountList.tsx`, line 195-199 ([link](https://github.com/elizaos/eliza/blob/784270149cac039b84bd5c7b9b2821a11f375753/packages/ui/src/components/connectors/ConnectorAccountList.tsx#L195-L199)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Duplicate error banner when shared hook errors**

   When `externalAccounts` is provided, both the OWNER and AGENT `ConnectorAccountList` instances render independently from the same `connectorAccounts.error` string. If the single shared fetch fails, the identical error message appears twice in the panel — once below each section header. Because neither section gates the error banner on ownership of the hook, there is no way for the panel to deduplicate it without restructuring the render.


2. `packages/ui/src/components/connectors/ConnectorAccountList.tsx`, line 134-137 ([link](https://github.com/elizaos/eliza/blob/784270149cac039b84bd5c7b9b2821a11f375753/packages/ui/src/components/connectors/ConnectorAccountList.tsx#L134-L137)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Shared `setSelectedAccountId` creates cross-section selection coupling**

   When `externalAccounts` is provided, both the OWNER and AGENT lists call `connectorAccounts.setSelectedAccountId` on the same hook instance. Mutations that update `selectedAccountId` internally — `makeDefault` (line 340 in the hook, `setSelectedAccountId(accountId)`) and `remove` (line 306, clears it on delete) — will change the shared `effectiveAccountId` seen by both sections. In the current `OwnerAgentConnectorSetupPanel` usage this is visually harmless because OWNER and AGENT accounts have distinct IDs, but if ever an account ID existed in both role buckets (e.g., after a data migration or future role expansion), the selected highlight would bleed across sections silently.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(ui): share connector-accounts hook a..."](https://github.com/elizaos/eliza/commit/784270149cac039b84bd5c7b9b2821a11f375753) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33005856)</sub>

<!-- /greptile_comment -->