### PR TITLE
fix(connectors): extract readRequestedConnectorRole helper — CodeFactor + Greptile P2 follow-up to #7820

### DIFF
--- a/packages/core/src/connectors/oauth-role.test.ts
+++ b/packages/core/src/connectors/oauth-role.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../logger";
 import { readRequestedConnectorRole } from "./oauth-role";
 
 describe("readRequestedConnectorRole", () => {
 	const src = "plugin:test:connector";
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
 
 	it("returns OWNER when metadata is undefined", () => {
 		expect(readRequestedConnectorRole(undefined, src)).toBe("OWNER");
@@ -46,9 +51,26 @@ describe("readRequestedConnectorRole", () => {
 	it("returns OWNER for empty string and does NOT trigger the debug log", () => {
 		// Empty string is an absent-but-valid state, not a misconfiguration —
 		// the helper treats it the same as `undefined` to avoid noise in
-		// development logs.
+		// development logs. Pin both halves of the contract (return value and
+		// log suppression) so the no-log behavior can't silently regress.
+		const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
 		expect(readRequestedConnectorRole({ requestedRole: "" }, src)).toBe(
 			"OWNER",
+		);
+		expect(debugSpy).not.toHaveBeenCalled();
+	});
+
+	it("emits a debug log when a non-empty unrecognised requestedRole is supplied", () => {
+		// Contrast case: an unrecognised value that IS meaningful (e.g. typoed
+		// "admin") should fire the debug log so the misconfiguration surfaces.
+		const debugSpy = vi.spyOn(logger, "debug").mockImplementation(() => {});
+		expect(readRequestedConnectorRole({ requestedRole: "admin" }, src)).toBe(
+			"OWNER",
+		);
+		expect(debugSpy).toHaveBeenCalledTimes(1);
+		expect(debugSpy).toHaveBeenCalledWith(
+			expect.objectContaining({ src, requestedRoleRaw: "admin" }),
+			expect.stringContaining("Unrecognised requestedRole"),
 		);
 	});
 


### PR DESCRIPTION
## Summary

CodeFactor failure + Greptile P2 from #7820 (which merged before this follow-up could land).

Each of Linear, Calendly, and Shopify's \`completeOAuth\` handlers carried the same 4-line role-narrowing block (\`requestedRoleRaw === \"AGENT\" || ... === \"TEAM\" ? ... : \"OWNER\"\`). CodeFactor flagged the duplication; Greptile noted that a misconfigured value (lowercase \`\"agent\"\`, \`\"admin\"\`, etc.) was silently coerced to \`\"OWNER\"\` with nothing in the logs to help diagnose it.

This change extracts a shared helper into \`@elizaos/core/connectors\`:

- \`readRequestedConnectorRole(metadata, src)\` reads \`metadata.requestedRole\`, returns OWNER/AGENT/TEAM canonically, defaults to \`\"OWNER\"\` when absent/non-string/unrecognised, and emits a \`logger.debug({ src, requestedRoleRaw }, …)\` line when a non-empty value couldn't be matched.
- The helper is re-exported from \`index.node\`, \`index.browser\`, and \`index.edge\` (logger.ts is already cross-platform).
- Linear, Calendly, and Shopify now call the helper instead of inlining the narrowing block. The duplication is gone and misconfigurations surface in development.

9/9 tests on the helper itself.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This follow-up to #7820 addresses a previous review comment by pinning the logger side-effects of `readRequestedConnectorRole` in two targeted test additions to `oauth-role.test.ts`.

- The existing empty-string test is extended with a `vi.spyOn(logger, \"debug\")` assertion confirming that `\"\"` does **not** trigger a debug log, documenting and guarding the no-noise contract.
- A new test (`\"emits a debug log when a non-empty unrecognised requestedRole is supplied\"`) verifies the opposite path: a typo like `\"admin\"` produces exactly one `logger.debug` call with the expected `{ src, requestedRoleRaw }` payload and message prefix.
- `afterEach(() => vi.restoreAllMocks())` is wired up correctly so no spy leaks between tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is test-only, targeting a single helper with no production code modifications.

Both new assertions correctly mirror the implementation's branching logic: the empty-string guard is explicitly exercised and confirmed silent, and the non-empty unrecognised-value path is confirmed to emit exactly one logger.debug call with the right payload. Spy teardown via vi.restoreAllMocks() in afterEach prevents any cross-test leakage. No production code is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/connectors/oauth-role.test.ts | Adds spy-based assertions for logger.debug to the empty-string test, and introduces a new dedicated test that verifies the debug log fires for non-empty unrecognised roles — directly addressing the previous P2 review comment. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["readRequestedConnectorRole(metadata, src)"] --> B{typeof requestedRoleRaw === 'string' AND in CANONICAL_ROLES?}
    B -- Yes --> C["return requestedRoleRaw"]
    B -- No --> D{requestedRoleRaw !== undefined AND !== null AND !== ''}
    D -- Yes --> E["logger.debug({ src, requestedRoleRaw }, 'Unrecognised requestedRole...')"]
    D -- No --> F["silent — absent-but-valid state"]
    E --> G["return 'OWNER'"]
    F --> G

    subgraph "New tests in this PR"
        T1["Test: empty string → OWNER + NO debug log"]
        T2["Test: 'admin' → OWNER + debug log fires once"]
    end

    T1 -.-> F
    T2 -.-> E
```

<sub>Reviews (4): Last reviewed commit: ["test(connectors): pin debug-log suppress..."](https://github.com/elizaos/eliza/commit/83b49e03f581566d2135059df2a30539733c29d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33005864)</sub>

<!-- /greptile_comment -->