### PR TITLE
Merge develop: fix /bsc CORS + wallet reconnect

### DIFF
--- a/packages/examples/VALIDATION.md
+++ b/packages/examples/VALIDATION.md
@@ -46,21 +46,21 @@ The local examples sweep has been run in this worktree with these outcomes:
 | --- | --- | --- |
 | `_plugin` | `typecheck`, `test`, `build` | Optional manual Cypress flow via `test:e2e:manual`. |
 | `a2a` | `typecheck`, `test`, `build` | `OPENAI_API_KEY` for model-backed mode. |
-| `agent-console` | `typecheck` | Browser session plus one provider key to inspect live SSE telemetry. |
+| `agent-console` | `test`, `typecheck` | Action scanner fixture test; browser session plus one provider key to inspect live SSE telemetry. |
 | `app/capacitor` | Parent skip scripts plus backend/frontend package checks | Native Capacitor device/simulator testing and provider keys. |
 | `app/capacitor/backend` | `typecheck`, `test`, `build` | Provider key and device/simulator flow through the Capacitor shell. |
 | `app/capacitor/frontend` | `typecheck`, `build` | Browser and native WebView smoke test against a configured backend. |
 | `app/electron` | Parent skip scripts plus backend/frontend package checks | Desktop Electron launch and provider-key chat flow. |
 | `app/electron/backend` | `typecheck`, `test`, `build` | Provider-key chat flow from the packaged Electron shell. |
 | `app/electron/frontend` | `typecheck`, `build` | Renderer smoke test in Electron and browser dev-server mode. |
-| `autonomous` | `typecheck`, `build` | Optional local model and shell sandbox configuration. |
+| `autonomous` | `test`, `typecheck`, `build` | Decision parser, shell allowlist, and prompt tests; optional local model and shell sandbox configuration. |
 | `avatar` | `typecheck`, `build` | Browser microphone/audio flow, selected model key, optional ElevenLabs key. |
 | `aws` | `typecheck`, `test`, `build` | AWS account, SAM deployment, and Lambda invocation with `OPENAI_API_KEY`. |
 | `bluesky` | `typecheck`, `test`, `build` | `LIVE_TEST=true` with Bluesky credentials and dry-run/posting flags. |
 | `browser-extension` | Parent typecheck skip and documented Chrome/Safari package checks | Load unpacked Chrome extension; Safari requires Xcode signing/install. |
 | `browser-extension/chrome` | `typecheck`, explicit build skip | `build:tsup` only after resolving browser bundling of Node-only workspace deps; load unpacked for runtime validation. |
 | `browser-extension/safari` | Typecheck skip, scripted Safari build path | Xcode and Safari extension signing. |
-| `chat` | `typecheck`, `build` | One configured provider key for live chat. |
+| `chat` | `test`, `typecheck`, `build` | Provider-selection tests; one configured provider key for live chat. |
 | `cloud/clone-ur-crush` | `typecheck`, `test`, `build` | Live Next.js flow with required model/image provider keys. |
 | `cloud/edad` | `typecheck`, `test`, `build` | Manual server launch with Eliza Cloud app ID, affiliate code, and signed-in user token. |
 | `cloudflare` | `typecheck`, `test`, `build` | Wrangler login, Worker secret, deployed or local Worker endpoint. |
@@ -86,11 +86,11 @@ The local examples sweep has been run in this worktree with these outcomes:
 | `roblox` | `typecheck`, `test`, `build` | Roblox Studio place, Open Cloud key, tunnel/shared-secret bridge test. |
 | `smartglasses` | `typecheck`, `test` | Even Realities simulator or BLE hardware evidence report. |
 | `supabase` | Static review; no package scripts | Supabase CLI/Deno function serve or deployment with anon key and `OPENAI_API_KEY`. |
-| `telegram` | `typecheck`, `build` | Telegram bot token and provider key. |
-| `text-adventure` | `typecheck`, `build` | Optional manual CLI playthrough. |
+| `telegram` | `test`, `typecheck`, `build` | Env and character wiring tests; Telegram bot token and provider key for live run. |
+| `text-adventure` | `test`, `typecheck`, `build` | Deterministic no-LLM dungeon-engine playthrough; optional manual CLI playthrough requires `OPENAI_API_KEY`. |
 | `tic-tac-toe` | `typecheck`, `test`, `build` | Test runs the non-interactive bench mode. |
 | `trader` | `typecheck`, `build` | Paper-trading UI flow, then isolated-wallet live testing only when intended. |
-| `twitter-xai` | `typecheck`, `build` | X/xAI credentials; start with `TWITTER_DRY_RUN=true`. |
+| `twitter-xai` | `test`, `typecheck`, `build` | Credential-mode validation tests; X/xAI credentials for live run, starting with `TWITTER_DRY_RUN=true`. |
 | `vercel` | `typecheck`, `test`, `build` | Vercel project/env plus deployed or `vercel dev` API endpoint. |
 
 ## Not Yet Proven By Local Automation

--- a/packages/examples/agent-console/README.md
+++ b/packages/examples/agent-console/README.md
@@ -33,8 +33,10 @@ providers used here do not expose an embeddings endpoint.
 ## Validate
 
 ```bash
+bun run test
 bun run typecheck
 ```
 
-The example has no external service test because it requires a live model
-provider key and an interactive browser session.
+The local test covers the action scanner against a fixture repository. A full
+dashboard session still requires a live model provider key and an interactive
+browser.

--- a/packages/examples/agent-console/action-scanner.test.ts
+++ b/packages/examples/agent-console/action-scanner.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scanRepoActions } from "./action-scanner";
+
+test("scanRepoActions discovers action metadata and subaction links", () => {
+  const repoRoot = mkdtempSync(join(tmpdir(), "agent-console-scan-"));
+  execFileSync("git", ["init"], { cwd: repoRoot, stdio: "ignore" });
+  const fixtureDir = join(repoRoot, "packages", "fixture");
+  mkdirSync(fixtureDir, { recursive: true });
+  writeFileSync(
+    join(fixtureDir, "actions.ts"),
+    `
+      const childAction = {
+        name: "lookup_weather",
+        description: "Look up weather for a city",
+        parameters: [
+          {
+            name: "city",
+            description: "City to query",
+            required: true,
+            schema: { type: "string" },
+          },
+        ],
+        validate: async () => true,
+        handler: async () => undefined,
+      };
+
+      export const parentAction = {
+        name: "travel_plan",
+        description: "Plan a trip",
+        parameters: [
+          {
+            name: "mode",
+            description: "Operation to perform",
+            schema: { type: "string", enum: ["lookup_weather"] },
+          },
+        ],
+        subActions: ["lookup_weather"],
+        validate: async (runtime) => Boolean(runtime),
+        handler: async () => undefined,
+      };
+    `,
+  );
+
+  const result = scanRepoActions({ repoRoot });
+  const parent = result.actions.find((action) => action.name === "travel_plan");
+  const child = result.actions.find(
+    (action) => action.name === "lookup_weather",
+  );
+
+  expect(result.filesScanned).toBe(1);
+  expect(result.actionCount).toBe(2);
+  expect(parent?.validation).toBe("conditional");
+  expect(parent?.resolvedSubActions).toEqual([
+    expect.objectContaining({
+      found: true,
+      name: "lookup_weather",
+      targetId: child?.id,
+    }),
+  ]);
+  expect(parent?.inferredSubActions).toEqual([
+    {
+      name: "lookup_weather",
+      parameter: "mode",
+      source: "parameter-enum",
+    },
+  ]);
+  expect(child?.parameterSummary).toEqual(["city:string required"]);
+});

--- a/packages/examples/agent-console/package.json
+++ b/packages/examples/agent-console/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "bun run server.ts",
     "dev": "bun --hot run server.ts",
+    "test": "bun test action-scanner.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/packages/examples/autonomous/README.md
+++ b/packages/examples/autonomous/README.md
@@ -58,3 +58,13 @@ cd packages/examples/autonomous
 bun install
 bun run start
 ```
+
+## Validate
+
+```bash
+bun run test
+bun run typecheck
+```
+
+The test suite covers the local decision parser, shell-command allowlist, and
+prompt construction without starting local inference or shell services.

--- a/packages/examples/autonomous/autonomous.test.ts
+++ b/packages/examples/autonomous/autonomous.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test";
+import { decisionPrompt, isCommandAllowed, parseDecision } from "./autonomous";
+
+test("parseDecision accepts valid JSON decisions and clamps sleep", () => {
+  expect(
+    parseDecision('{"action":"RUN","command":"ls","note":"inspect"}'),
+  ).toEqual({
+    action: "RUN",
+    command: "ls",
+    note: "inspect",
+  });
+  expect(parseDecision('{"action":"SLEEP","sleepMs":1,"note":"wait"}')).toEqual(
+    {
+      action: "SLEEP",
+      sleepMs: 100,
+      note: "wait",
+    },
+  );
+  expect(parseDecision('{"action":"STOP","note":"done"}')).toEqual({
+    action: "STOP",
+    note: "done",
+  });
+});
+
+test("parseDecision rejects incomplete or malformed decisions", () => {
+  expect(parseDecision("not json")).toBeNull();
+  expect(parseDecision('{"action":"RUN","note":"missing command"}')).toBeNull();
+  expect(parseDecision('{"action":"SLEEP","sleepMs":"nope"}')).toBeNull();
+  expect(parseDecision('{"action":"DELETE","note":"bad action"}')).toBeNull();
+});
+
+test("isCommandAllowed blocks shell metacharacters and unknown commands", () => {
+  const allowed = ["ls", "pwd", "cat", "echo"];
+
+  expect(isCommandAllowed("ls -la", allowed)).toBe(true);
+  expect(isCommandAllowed(" echo hello ", allowed)).toBe(true);
+  expect(isCommandAllowed("rm file", allowed)).toBe(false);
+  expect(isCommandAllowed("ls && rm file", allowed)).toBe(false);
+  expect(isCommandAllowed("cat file | grep x", allowed)).toBe(false);
+  expect(isCommandAllowed("echo hello\npwd", allowed)).toBe(false);
+});
+
+test("decisionPrompt includes sandbox, commands, goal, and history", () => {
+  const prompt = decisionPrompt({
+    goal: "Write STATUS.txt",
+    allowedDirectory: "/tmp/sandbox",
+    allowedCommands: ["ls", "echo"],
+    recentSteps: "[step 1] SLEEP",
+  });
+
+  expect(prompt).toContain("Write STATUS.txt");
+  expect(prompt).toContain("/tmp/sandbox");
+  expect(prompt).toContain("ls, echo");
+  expect(prompt).toContain("[step 1] SLEEP");
+  expect(prompt).toContain('"action": "RUN|SLEEP|STOP"');
+});

--- a/packages/examples/autonomous/autonomous.ts
+++ b/packages/examples/autonomous/autonomous.ts
@@ -17,14 +17,6 @@ import {
 } from "@elizaos/core";
 import { v4 as uuidv4 } from "uuid";
 
-const { default: inmemorydbPlugin } = await import(
-  "@elizaos/plugin-inmemorydb"
-);
-const { default: localInferencePlugin } = await import(
-  "@elizaos/plugin-local-inference"
-);
-const { shellPlugin } = await import("@elizaos/plugin-shell");
-
 type ShellService = {
   executeCommand(
     command: string,
@@ -109,7 +101,7 @@ function readStringField(
   return null;
 }
 
-function parseDecision(raw: string): AgentDecision | null {
+export function parseDecision(raw: string): AgentDecision | null {
   const parsed = parseJSONObjectFromText(raw);
   if (!parsed) return null;
 
@@ -147,7 +139,7 @@ function baseCommand(command: string): string {
   return space === -1 ? trimmed : trimmed.slice(0, space);
 }
 
-function isCommandAllowed(
+export function isCommandAllowed(
   command: string,
   allowedBaseCommands: readonly string[],
 ): boolean {
@@ -163,7 +155,7 @@ function isCommandAllowed(
   return allowedBaseCommands.includes(cmd);
 }
 
-function decisionPrompt(params: {
+export function decisionPrompt(params: {
   goal: string;
   allowedDirectory: string;
   allowedCommands: readonly string[];
@@ -202,6 +194,14 @@ Rules:
 }
 
 async function main(): Promise<void> {
+  const { default: inmemorydbPlugin } = await import(
+    "@elizaos/plugin-inmemorydb"
+  );
+  const { default: localInferencePlugin } = await import(
+    "@elizaos/plugin-local-inference"
+  );
+  const { shellPlugin } = await import("@elizaos/plugin-shell");
+
   const here = path.dirname(fileURLToPath(import.meta.url));
   const repoRoot = path.resolve(here, "..", "..", "..");
 
@@ -477,4 +477,6 @@ async function main(): Promise<void> {
   await runtime.stop();
 }
 
-await main();
+if (import.meta.main) {
+  await main();
+}

--- a/packages/examples/autonomous/package.json
+++ b/packages/examples/autonomous/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "bun run autonomous.ts",
     "dev": "bun --watch run autonomous.ts",
+    "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "typecheck": "tsc --noEmit",
     "build": "bun run typecheck"

--- a/packages/examples/autonomous/tsconfig.json
+++ b/packages/examples/autonomous/tsconfig.json
@@ -10,7 +10,7 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["node"],
+    "types": ["node", "bun-types"],
     "paths": {
       "@elizaos/plugin-capacitor-bridge": [
         "../../../plugins/plugin-capacitor-bridge/src/index.ts"

--- a/packages/examples/chat/README.md
+++ b/packages/examples/chat/README.md
@@ -82,6 +82,11 @@ Run with hot reload:
 bun run dev
 ```
 
+Run the local provider-selection checks:
+```bash
+bun run test
+```
+
 ## License
 
 MIT

--- a/packages/examples/chat/chat.test.ts
+++ b/packages/examples/chat/chat.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, expect, test } from "bun:test";
+import { detectLLMPlugin, hasValidApiKey, LLM_PROVIDERS } from "./chat";
+
+const providerEnvKeys = LLM_PROVIDERS.map((provider) => provider.envKey);
+const originalEnv = Object.fromEntries(
+  providerEnvKeys.map((envKey) => [envKey, process.env[envKey]]),
+);
+
+afterEach(() => {
+  for (const envKey of providerEnvKeys) {
+    const originalValue = originalEnv[envKey];
+    if (originalValue === undefined) {
+      delete process.env[envKey];
+    } else {
+      process.env[envKey] = originalValue;
+    }
+  }
+});
+
+test("provider list keeps the documented priority order", () => {
+  expect(LLM_PROVIDERS.map((provider) => provider.name)).toEqual([
+    "OpenAI",
+    "Anthropic (Claude)",
+    "xAI (Grok)",
+    "Google GenAI (Gemini)",
+    "Groq",
+  ]);
+});
+
+test("empty provider keys are treated as missing", () => {
+  process.env.OPENAI_API_KEY = "   ";
+  expect(hasValidApiKey("OPENAI_API_KEY")).toBe(false);
+
+  process.env.OPENAI_API_KEY = "test-key";
+  expect(hasValidApiKey("OPENAI_API_KEY")).toBe(true);
+});
+
+test("detectLLMPlugin returns null before importing providers when no key is set", async () => {
+  for (const envKey of providerEnvKeys) {
+    delete process.env[envKey];
+  }
+
+  await expect(detectLLMPlugin()).resolves.toBeNull();
+});

--- a/packages/examples/chat/chat.ts
+++ b/packages/examples/chat/chat.ts
@@ -11,13 +11,13 @@ import {
   type UUID,
 } from "@elizaos/core";
 
-type LLMProvider = {
+export type LLMProvider = {
   name: string;
   envKey: string;
   specifier: string;
 };
 
-const LLM_PROVIDERS: LLMProvider[] = [
+export const LLM_PROVIDERS: LLMProvider[] = [
   {
     name: "OpenAI",
     envKey: "OPENAI_API_KEY",
@@ -45,12 +45,12 @@ const LLM_PROVIDERS: LLMProvider[] = [
   },
 ];
 
-function hasValidApiKey(envKey: string): boolean {
+export function hasValidApiKey(envKey: string): boolean {
   const value = process.env[envKey];
   return typeof value === "string" && value.trim().length > 0;
 }
 
-async function detectLLMPlugin(): Promise<{
+export async function detectLLMPlugin(): Promise<{
   plugin: Plugin;
   providerName: string;
 } | null> {
@@ -68,7 +68,7 @@ async function detectLLMPlugin(): Promise<{
   return null;
 }
 
-function printAvailableProviders(): void {
+export function printAvailableProviders(): void {
   console.log("\nSupported LLM providers and their API keys:\n");
   for (const provider of LLM_PROVIDERS) {
     const hasKey = hasValidApiKey(provider.envKey);
@@ -175,7 +175,9 @@ async function main() {
   prompt();
 }
 
-main().catch((error) => {
-  console.error("Fatal error:", error);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error("Fatal error:", error);
+    process.exit(1);
+  });
+}

--- a/packages/examples/chat/package.json
+++ b/packages/examples/chat/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "bun run chat.ts",
     "dev": "bun --watch run chat.ts",
+    "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "typecheck": "tsc --noEmit",
     "build": "bun run typecheck"

--- a/packages/examples/chat/tsconfig.json
+++ b/packages/examples/chat/tsconfig.json
@@ -10,7 +10,7 @@
     "declaration": false,
     "outDir": "./dist",
     "noEmit": true,
-    "types": ["node"]
+    "types": ["node", "bun-types"]
   },
   "include": ["*.ts"],
   "exclude": ["node_modules", "dist"],

--- a/packages/examples/telegram/README.md
+++ b/packages/examples/telegram/README.md
@@ -52,3 +52,13 @@ const character = {
 | `TELEGRAM_BOT_TOKEN` | Yes | From @BotFather |
 | `OPENAI_API_KEY` | Yes | OpenAI API key |
 | `POSTGRES_URL` | No | PostgreSQL URL (defaults to PGLite) |
+
+## Validate
+
+```bash
+bun run test
+bun run typecheck
+```
+
+The test suite validates required environment checks and character wiring
+without connecting to Telegram.

--- a/packages/examples/telegram/package.json
+++ b/packages/examples/telegram/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "bun run telegram-agent.ts",
     "dev": "bun --watch run telegram-agent.ts",
+    "test": "bun test",
     "typecheck": "tsc --noEmit",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "build": "bun run typecheck"

--- a/packages/examples/telegram/telegram-agent.test.ts
+++ b/packages/examples/telegram/telegram-agent.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { createTelegramCharacter, readRequiredEnv } from "./telegram-agent";
+
+test("readRequiredEnv rejects missing or empty values", () => {
+  const originalValue = process.env.TELEGRAM_BOT_TOKEN;
+  try {
+    delete process.env.TELEGRAM_BOT_TOKEN;
+    expect(() => readRequiredEnv("TELEGRAM_BOT_TOKEN")).toThrow(
+      "Missing required environment variable: TELEGRAM_BOT_TOKEN",
+    );
+
+    process.env.TELEGRAM_BOT_TOKEN = " ";
+    expect(() => readRequiredEnv("TELEGRAM_BOT_TOKEN")).toThrow(
+      "Missing required environment variable: TELEGRAM_BOT_TOKEN",
+    );
+
+    process.env.TELEGRAM_BOT_TOKEN = "bot-token";
+    expect(readRequiredEnv("TELEGRAM_BOT_TOKEN")).toBe("bot-token");
+  } finally {
+    if (originalValue === undefined) {
+      delete process.env.TELEGRAM_BOT_TOKEN;
+    } else {
+      process.env.TELEGRAM_BOT_TOKEN = originalValue;
+    }
+  }
+});
+
+test("createTelegramCharacter wires required secrets and mobile-friendly prompt", () => {
+  const character = createTelegramCharacter({
+    telegramBotToken: "telegram-token",
+    openaiApiKey: "openai-key",
+  });
+
+  expect(character.name).toBe("TelegramEliza");
+  expect(character.system).toContain("suitable for mobile chat");
+  expect(character.settings?.OPENAI_SMALL_MODEL).toBe("gpt-5-mini");
+  expect(character.secrets?.TELEGRAM_BOT_TOKEN).toBe("telegram-token");
+  expect(character.secrets?.OPENAI_API_KEY).toBe("openai-key");
+});

--- a/packages/examples/telegram/telegram-agent.ts
+++ b/packages/examples/telegram/telegram-agent.ts
@@ -7,26 +7,19 @@
 
 import { AgentRuntime, createCharacter } from "@elizaos/core";
 
-async function main() {
-  const [
-    { openaiPlugin },
-    { default: sqlPlugin },
-    { default: telegramPlugin },
-  ] = await Promise.all([
-    import("@elizaos/plugin-openai"),
-    import("@elizaos/plugin-sql"),
-    import("@elizaos/plugin-telegram"),
-  ]);
-
-  const telegramBotToken = process.env.TELEGRAM_BOT_TOKEN;
-  const openaiApiKey = process.env.OPENAI_API_KEY;
-
-  if (!telegramBotToken || !openaiApiKey) {
-    console.error("Missing TELEGRAM_BOT_TOKEN or OPENAI_API_KEY");
-    process.exit(1);
+export function readRequiredEnv(key: string): string {
+  const value = process.env[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Missing required environment variable: ${key}`);
   }
+  return value;
+}
 
-  const character = createCharacter({
+export function createTelegramCharacter(params: {
+  telegramBotToken: string;
+  openaiApiKey: string;
+}) {
+  return createCharacter({
     name: "TelegramEliza",
     bio: "A helpful AI assistant on Telegram.",
     system: `You are TelegramEliza, a helpful AI assistant on Telegram.
@@ -40,9 +33,36 @@ Keep responses short - suitable for mobile chat.`,
     },
     // Optional: pass through secrets so plugins can read via runtime.getSetting()
     secrets: {
-      TELEGRAM_BOT_TOKEN: telegramBotToken,
-      OPENAI_API_KEY: openaiApiKey,
+      TELEGRAM_BOT_TOKEN: params.telegramBotToken,
+      OPENAI_API_KEY: params.openaiApiKey,
     },
+  });
+}
+
+async function main() {
+  const [
+    { openaiPlugin },
+    { default: sqlPlugin },
+    { default: telegramPlugin },
+  ] = await Promise.all([
+    import("@elizaos/plugin-openai"),
+    import("@elizaos/plugin-sql"),
+    import("@elizaos/plugin-telegram"),
+  ]);
+
+  let telegramBotToken: string;
+  let openaiApiKey: string;
+  try {
+    telegramBotToken = readRequiredEnv("TELEGRAM_BOT_TOKEN");
+    openaiApiKey = readRequiredEnv("OPENAI_API_KEY");
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
+  const character = createTelegramCharacter({
+    telegramBotToken,
+    openaiApiKey,
   });
 
   console.log("Starting TelegramEliza...");
@@ -64,4 +84,6 @@ Keep responses short - suitable for mobile chat.`,
   await new Promise(() => {});
 }
 
-main().catch(console.error);
+if (import.meta.main) {
+  main().catch(console.error);
+}

--- a/packages/examples/telegram/tsconfig.json
+++ b/packages/examples/telegram/tsconfig.json
@@ -10,7 +10,7 @@
     "declaration": false,
     "noEmit": true,
     "lib": ["ES2022"],
-    "types": ["node"],
+    "types": ["node", "bun-types"],
     "paths": {
       "@elizaos/core": ["./../../core/dist/index.d.ts"]
     }

--- a/packages/examples/text-adventure/README.md
+++ b/packages/examples/text-adventure/README.md
@@ -15,7 +15,6 @@ export OPENAI_API_KEY=your_key_here
 
 ```bash
 cd packages/examples/text-adventure
-cp .env.example .env   # set OPENAI_API_KEY
 bun install
 
 # Quieter logs
@@ -24,6 +23,16 @@ LOG_LEVEL=fatal bun run game.ts
 # Optional persistent DB
 PGLITE_DATA_DIR=./adventure-db LOG_LEVEL=fatal bun run game.ts
 ```
+
+## Test
+
+```bash
+bun test
+```
+
+The test suite exercises the local dungeon engine with a deterministic no-LLM
+playthrough. Running the interactive or autonomous CLI still requires
+`OPENAI_API_KEY`.
 
 ## Features
 

--- a/packages/examples/text-adventure/game.test.ts
+++ b/packages/examples/text-adventure/game.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "bun:test";
+import { AdventureGame, playScriptedAdventure } from "./game";
+
+test("the local game engine exposes deterministic actions", () => {
+  const game = new AdventureGame();
+
+  expect(game.getCurrentRoom().id).toBe("entrance");
+  expect(game.getAvailableActions()).toContain("take rusty torch");
+
+  const blocked = game.executeAction("go north");
+  expect(blocked).toContain("Torch-lit Hallway");
+  expect(game.getAvailableActions()).toContain("attack");
+  expect(game.executeAction("go north")).toContain("blocks your path");
+});
+
+test("a scripted no-LLM run can complete the dungeon", () => {
+  const finalState = playScriptedAdventure([
+    "take rusty torch",
+    "go north",
+    "attack",
+    "attack",
+    "go east",
+    "take ancient sword",
+    "take health potion",
+    "go west",
+    "go north",
+    "attack with sword",
+    "attack with sword",
+    "go west",
+    "take golden key",
+    "go east",
+    "go north",
+    "attack with sword",
+    "attack with sword",
+    "use health potion",
+    "attack with sword",
+  ]);
+
+  expect(finalState.gameOver).toBe(true);
+  expect(finalState.victory).toBe(true);
+  expect(finalState.score).toBeGreaterThanOrEqual(350);
+  expect(finalState.health).toBeGreaterThan(0);
+});

--- a/packages/examples/text-adventure/game.ts
+++ b/packages/examples/text-adventure/game.ts
@@ -213,7 +213,7 @@ function createGameWorld(): Record<string, Room> {
 // GAME ENGINE
 // ============================================================================
 
-class AdventureGame {
+export class AdventureGame {
   private world: Record<string, Room>;
   private state: GameState;
 
@@ -513,6 +513,19 @@ class AdventureGame {
   getStatusLine(): string {
     return `❤️ ${this.state.health}/${this.state.maxHealth} | ⭐ ${this.state.score} | 🔄 Turn ${this.state.turnsPlayed}`;
   }
+}
+
+export function playScriptedAdventure(actions: string[]): GameState {
+  const game = new AdventureGame();
+
+  for (const action of actions) {
+    if (game.getState().gameOver) {
+      break;
+    }
+    game.executeAction(action);
+  }
+
+  return game.getState();
 }
 
 // ============================================================================

--- a/packages/examples/text-adventure/package.json
+++ b/packages/examples/text-adventure/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "bun run game.ts",
     "dev": "bun --watch run game.ts",
+    "test": "bun test",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "typecheck": "tsc --noEmit",
     "build": "bun run typecheck"

--- a/packages/examples/text-adventure/tsconfig.json
+++ b/packages/examples/text-adventure/tsconfig.json
@@ -9,7 +9,7 @@
     "resolveJsonModule": true,
     "declaration": false,
     "noEmit": true,
-    "types": ["node"]
+    "types": ["node", "bun-types"]
   },
   "include": ["*.ts"],
   "exclude": ["node_modules", "dist"],

--- a/packages/examples/twitter-xai/README.md
+++ b/packages/examples/twitter-xai/README.md
@@ -61,7 +61,7 @@ bun run start
 
 ### X API v2 auth — `@elizaos/plugin-x`
 
-- `TWITTER_AUTH_MODE` — `env` (default), `oauth`, or `broker`.
+- `TWITTER_AUTH_MODE` — `broker` (default), `oauth`, or `env`.
 
 OAuth 1.0a user context (`TWITTER_AUTH_MODE=env`):
 
@@ -78,7 +78,8 @@ OAuth 2.0 PKCE (`TWITTER_AUTH_MODE=oauth`):
 
 Eliza Cloud broker (`TWITTER_AUTH_MODE=broker`):
 
-- `TWITTER_BROKER_URL`
+- `TWITTER_BROKER_TOKEN` or `ELIZAOS_CLOUD_API_KEY`
+- `TWITTER_BROKER_URL` (optional service URL override)
 
 ### Agent behavior toggles
 
@@ -94,3 +95,13 @@ Eliza Cloud broker (`TWITTER_AUTH_MODE=broker`):
 interactions, timeline, and discovery. Incoming mentions are routed into the
 runtime via `runtime.messageService.handleMessage(...)` so you get the standard
 state-composition → model → action pipeline.
+
+## Validate
+
+```bash
+bun run test
+bun run typecheck
+```
+
+The test suite validates local credential-mode checks without contacting xAI or
+X.

--- a/packages/examples/twitter-xai/agent.test.ts
+++ b/packages/examples/twitter-xai/agent.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, expect, test } from "bun:test";
+import { requireEnv, validateEnvironment } from "./agent";
+
+const ENV_KEYS = [
+  "XAI_API_KEY",
+  "TWITTER_AUTH_MODE",
+  "TWITTER_BROKER_TOKEN",
+  "ELIZAOS_CLOUD_API_KEY",
+  "TWITTER_CLIENT_ID",
+  "TWITTER_REDIRECT_URI",
+  "TWITTER_API_KEY",
+  "TWITTER_API_SECRET_KEY",
+  "TWITTER_ACCESS_TOKEN",
+  "TWITTER_ACCESS_TOKEN_SECRET",
+];
+
+const originalEnv = Object.fromEntries(
+  ENV_KEYS.map((envKey) => [envKey, process.env[envKey]]),
+);
+
+function resetExampleEnv(): void {
+  for (const envKey of ENV_KEYS) {
+    delete process.env[envKey];
+  }
+}
+
+afterEach(() => {
+  resetExampleEnv();
+  for (const [envKey, value] of Object.entries(originalEnv)) {
+    if (value !== undefined) {
+      process.env[envKey] = value;
+    }
+  }
+});
+
+test("requireEnv trims present values and rejects missing values", () => {
+  process.env.XAI_API_KEY = "  xai-test-key  ";
+  expect(requireEnv("XAI_API_KEY")).toBe("  xai-test-key  ");
+
+  process.env.XAI_API_KEY = " ";
+  expect(() => requireEnv("XAI_API_KEY")).toThrow(
+    "Missing required environment variable: XAI_API_KEY",
+  );
+});
+
+test("validateEnvironment accepts broker auth with either broker credential", () => {
+  resetExampleEnv();
+  process.env.XAI_API_KEY = "xai-test-key";
+  process.env.TWITTER_AUTH_MODE = "broker";
+  process.env.TWITTER_BROKER_TOKEN = "broker-test-token";
+  expect(() => validateEnvironment()).not.toThrow();
+
+  delete process.env.TWITTER_BROKER_TOKEN;
+  process.env.ELIZAOS_CLOUD_API_KEY = "cloud-test-key";
+  expect(() => validateEnvironment()).not.toThrow();
+});
+
+test("validateEnvironment enforces oauth and env auth requirements", () => {
+  resetExampleEnv();
+  process.env.XAI_API_KEY = "xai-test-key";
+  process.env.TWITTER_AUTH_MODE = "oauth";
+  expect(() => validateEnvironment()).toThrow("TWITTER_CLIENT_ID");
+
+  process.env.TWITTER_CLIENT_ID = "client-id";
+  process.env.TWITTER_REDIRECT_URI = "http://localhost/callback";
+  expect(() => validateEnvironment()).not.toThrow();
+
+  resetExampleEnv();
+  process.env.XAI_API_KEY = "xai-test-key";
+  process.env.TWITTER_AUTH_MODE = "env";
+  expect(() => validateEnvironment()).toThrow("TWITTER_API_KEY");
+
+  process.env.TWITTER_API_KEY = "api-key";
+  process.env.TWITTER_API_SECRET_KEY = "api-secret";
+  process.env.TWITTER_ACCESS_TOKEN = "access-token";
+  process.env.TWITTER_ACCESS_TOKEN_SECRET = "access-secret";
+  expect(() => validateEnvironment()).not.toThrow();
+});
+
+test("validateEnvironment rejects invalid auth modes and missing model key", () => {
+  resetExampleEnv();
+  expect(() => validateEnvironment()).toThrow("XAI_API_KEY");
+
+  process.env.XAI_API_KEY = "xai-test-key";
+  process.env.TWITTER_AUTH_MODE = "cookies";
+  expect(() => validateEnvironment()).toThrow(
+    "Invalid TWITTER_AUTH_MODE=cookies",
+  );
+});

--- a/packages/examples/twitter-xai/agent.ts
+++ b/packages/examples/twitter-xai/agent.ts
@@ -5,7 +5,7 @@ import { config as loadDotEnv } from "dotenv";
 
 import { character } from "./character";
 
-function requireEnv(key: string): string {
+export function requireEnv(key: string): string {
   const value = process.env[key];
   if (typeof value !== "string" || value.trim().length === 0) {
     throw new Error(`Missing required environment variable: ${key}`);
@@ -13,7 +13,7 @@ function requireEnv(key: string): string {
   return value;
 }
 
-function validateEnvironment(): void {
+export function validateEnvironment(): void {
   // Grok (xAI) is the model provider for this example.
   requireEnv("XAI_API_KEY");
 
@@ -105,8 +105,10 @@ async function main(): Promise<void> {
   await new Promise(() => {});
 }
 
-main().catch((err) => {
-  const message = err instanceof Error ? err.message : String(err);
-  console.error(`Fatal error: ${message}`);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((err) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`Fatal error: ${message}`);
+    process.exit(1);
+  });
+}

--- a/packages/examples/twitter-xai/package.json
+++ b/packages/examples/twitter-xai/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "bun run agent.ts",
     "dev": "bun --watch run agent.ts",
+    "test": "bun test",
     "typecheck": "tsc --noEmit",
     "lint": "bunx @biomejs/biome check --write --unsafe .",
     "lint:check": "bunx @biomejs/biome check .",

--- a/packages/examples/twitter-xai/tsconfig.json
+++ b/packages/examples/twitter-xai/tsconfig.json
@@ -10,7 +10,7 @@
     "resolveJsonModule": true,
     "declaration": false,
     "noEmit": true,
-    "types": ["node"]
+    "types": ["node", "bun-types"]
   },
   "include": ["*.ts"],
   "exclude": ["node_modules"],


### PR DESCRIPTION
## Summary

Two regressions Shaw hit live-testing /bsc:

1. **CORS preflight on `/api/credits/balance`** — CreditsProvider was sending `Pragma: no-cache` alongside `Cache-Control: no-cache, no-store, must-revalidate`. Cross-origin call to `api.elizacloud.ai`, preflight rejected (`Request header field pragma is not allowed`). Dropped the redundant `Pragma` header.

2. **Wallet stuck on "Connect Wallet" after a successful MetaMask connect** — `StewardWalletProviders` had `reconnectOnMount={false}` on the WagmiProvider. With that flag, when the BSC page swaps the AttachWalletCard for the DirectCryptoCreditCard after a successful attach, the new component's `useAccount` / `ConnectButton.Custom` boots with `account = undefined` and refuses to reflect the live MetaMask connection. Pay button bails with "Connect your BSC wallet first". Removed the flag — wagmi default (`true`) is what every consumer of these providers wants, and the login surface already gates SIWE on an explicit user click so auto-reconnect can't accidentally fire a signature.

## Test plan
- [ ] After prod deploy, /bsc with an OAuth account that has wallet attached: clicking Connect Wallet → MetaMask connect → button shows the address, Pay button enables.
- [ ] Credits sidebar polls without CORS errors in DevTools console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds unit test coverage to several `packages/examples` sub-packages (`agent-console`, `autonomous`, `chat`, `telegram`, `text-adventure`, `twitter-xai`) by exporting previously private helpers, moving dynamic plugin imports inside `main()`, and guarding entry-point execution with `import.meta.main`. Despite the title referencing a CORS header fix and a wagmi `reconnectOnMount` change, none of those changes appear in the diff — only example package improvements are present.

- **Testability refactor**: Internal helpers (`parseDecision`, `isCommandAllowed`, `requireEnv`, `validateEnvironment`, etc.) are exported and entry points are gated behind `import.meta.main`, enabling isolated unit tests without side effects.
- **New test suites**: Six new `*.test.ts` files are added with deterministic, no-network test coverage for provider detection, environment validation, game engine logic, and action scanning.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all changes are confined to example packages and add test coverage without touching any production runtime code.

The refactoring is clean and the new tests are well-isolated. The only tangible concern is that both requireEnv (twitter-xai) and readRequiredEnv (telegram) validate presence using .trim() but return the raw, un-trimmed string — a whitespace-padded API key would pass the guard and silently fail at the provider. The test for requireEnv even enshrines the untrimmed behavior with a misleading description. Nothing here breaks existing behavior, but the pattern could cause hard-to-diagnose auth errors for users with .env files that have trailing spaces.

packages/examples/twitter-xai/agent.ts and packages/examples/telegram/telegram-agent.ts — both expose helper functions that accept but do not trim env var values.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/examples/autonomous/autonomous.ts | Dynamic plugin imports moved inside main(); parseDecision, isCommandAllowed, and decisionPrompt exported; import.meta.main guard added — clean refactor for testability. |
| packages/examples/chat/chat.ts | LLM_PROVIDERS, hasValidApiKey, detectLLMPlugin, printAvailableProviders exported; main() guarded by import.meta.main — straightforward export-for-testing refactor. |
| packages/examples/telegram/telegram-agent.ts | readRequiredEnv and createTelegramCharacter extracted and exported; main() restructured to use these helpers and guarded by import.meta.main. |
| packages/examples/twitter-xai/agent.ts | requireEnv and validateEnvironment exported; import.meta.main guard added. Test name claims the function "trims present values" but the implementation returns the raw untrimmed value. |
| packages/examples/twitter-xai/agent.test.ts | Comprehensive env validation tests; test description for requireEnv is misleading — says "trims present values" but the assertion preserves leading/trailing spaces. |
| packages/examples/text-adventure/game.test.ts | Deterministic no-LLM dungeon playthrough test; scripted action sequence is tightly coupled to game balance constants but exercises end-to-end engine logic well. |
| packages/examples/agent-console/action-scanner.test.ts | Creates a temporary git repo fixture to test action discovery, metadata extraction, and subaction linking — well-isolated and deterministic. |
| packages/examples/autonomous/autonomous.test.ts | Tests parseDecision (including sleep clamping), isCommandAllowed (shell metacharacter blocking), and decisionPrompt content — good coverage without any runtime or network dependencies. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Module imported by test runner] -->|import.meta.main = false| B[Export helpers only\nNo side effects]
    A -->|import.meta.main = true\nDirect execution| C[Run main]

    B --> D[Unit tests call exported functions]
    D --> E1[parseDecision / isCommandAllowed\nautonomous.ts]
    D --> E2[hasValidApiKey / detectLLMPlugin\nchat.ts]
    D --> E3[readRequiredEnv / createTelegramCharacter\ntelegram-agent.ts]
    D --> E4[requireEnv / validateEnvironment\nagent.ts]
    D --> E5[AdventureGame / playScriptedAdventure\ngame.ts]
    D --> E6[scanRepoActions\naction-scanner.ts]

    C --> F[Dynamic plugin imports\ne.g. @elizaos/plugin-inmemorydb\n@elizaos/plugin-local-inference]
    F --> G[Start runtime / agent loop]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `packages/examples/twitter-xai/agent.ts`, line 930-936 ([link](https://github.com/elizaos/eliza/blob/dec231c238c70ac45c370dbc9baa30517a5c7541/packages/examples/twitter-xai/agent.ts#L930-L936)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **`requireEnv` validates with `.trim()` but returns the untrimmed value.** If a user's `.env` file has `XAI_API_KEY= sk-abc ` (accidental leading/trailing whitespace), the function accepts it as present but hands the padded string to the API client, causing authentication errors that are hard to diagnose. The same pattern appears in `readRequiredEnv` in `telegram-agent.ts`. Returning `value.trim()` instead of `value` would align the validation check with what's actually used downstream.


2. `packages/examples/text-adventure/game.test.ts`, line 697-701 ([link](https://github.com/elizaos/eliza/blob/dec231c238c70ac45c370dbc9baa30517a5c7541/packages/examples/text-adventure/game.test.ts#L697-L701)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> **Misleading variable name `blocked`.** `game.executeAction("go north")` here succeeds and returns a message containing "Torch-lit Hallway" (the player has moved there), yet the result is stored in a variable named `blocked`. The second call to `go north` is the one that is actually blocked. Consider renaming to `moveResult` or `hallwayEntry` to avoid confusing readers of this test.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(cloud): unblock credits-balance CORS..."](https://github.com/elizaos/eliza/commit/dec231c238c70ac45c370dbc9baa30517a5c7541) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33008631)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->