### PR TITLE
chore(cloud): post-merge /clean follow-up on lifecycle job code

### DIFF
--- a/packages/cloud-api/v1/agents/[agentId]/logs/route.ts
+++ b/packages/cloud-api/v1/agents/[agentId]/logs/route.ts
@@ -37,7 +37,7 @@ app.get("/", async (c) => {
       identity.organizationId,
     );
     if (!agent) {
-      return c.json({ error: "Agent not found" }, 404);
+      return c.json({ success: false, error: "Agent not found" }, 404);
     }
 
     const rawTail = parseInt(c.req.query("tail") ?? "100", 10);

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/resume/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/resume/route.ts
@@ -174,11 +174,9 @@ async function __hono_POST(
     }
 
     try {
-      // Distinct from `agent_provision` so the daemon can tell a user-
-      // initiated resume from a fresh provision in audit logs, and so a
-      // future `docker start` fast path can hook in without touching
-      // the route. Today executeResume always re-provisions to restore
-      // bridge/health URLs via the sandbox handle.
+      // Distinct job type from `agent_provision` so the daemon can
+      // tell a user-initiated resume from a fresh provision in audit
+      // logs.
       const { job, created } =
         await provisioningJobService.enqueueAgentResumeOnce({
           agentId,

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/route.ts
@@ -355,9 +355,6 @@ app.delete("/", async (c) => {
       202,
     );
   } catch (error) {
-    if (error instanceof Error && error.message === "Agent not found") {
-      return c.json({ success: false, error: "Agent not found" }, 404);
-    }
     logger.error("[agent-api] DELETE /agents/:agentId error", { error });
     return failureResponse(c, error);
   }

--- a/packages/cloud-shared/src/lib/services/__tests__/provisioning-job-types.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/provisioning-job-types.test.ts
@@ -22,6 +22,9 @@ describe("JOB_TYPES", () => {
     expect(JOB_TYPES.AGENT_RESTART).toBe("agent_restart");
     expect(JOB_TYPES.AGENT_LOGS).toBe("agent_logs");
     expect(JOB_TYPES.AGENT_SNAPSHOT).toBe("agent_snapshot");
+    // Lock the size so a new entry without a matching assertion above
+    // fails CI instead of being silently under-covered by tests below.
+    expect(Object.keys(JOB_TYPES)).toHaveLength(7);
   });
 
   test("wire values are unique (no two symbols share a string)", () => {

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -977,7 +977,7 @@ export class ProvisioningJobService {
             await agentSandboxesRepository.update(data.agentId, {
               status: "error",
               error_message: `Provisioning permanently failed after ${job.max_attempts} attempts: ${errorMsg}`,
-            } as Parameters<typeof agentSandboxesRepository.update>[1]);
+            });
             logger.warn("[provisioning-jobs] Marked sandbox as error after permanent failure", {
               jobId: job.id,
               agentId: data.agentId,
@@ -1001,7 +1001,7 @@ export class ProvisioningJobService {
             await agentSandboxesRepository.update(data.agentId, {
               status: "deletion_failed",
               error_message: `Deletion permanently failed after ${job.max_attempts} attempts: ${errorMsg}`,
-            } as Parameters<typeof agentSandboxesRepository.update>[1]);
+            });
             logger.warn(
               "[provisioning-jobs] Marked sandbox as deletion_failed after permanent failure",
               { jobId: job.id, agentId: data.agentId },
@@ -1387,18 +1387,16 @@ export class ProvisioningJobService {
     const provResult = await elizaSandboxService.provision(data.agentId, data.organizationId);
 
     if (!provResult.success) {
-      // Store partial result for debugging
       await jobsRepository.update(job.id, {
-        result: {
+        result: agentProvisionJobResultToRecord({
           cloudAgentId: data.agentId,
           status: provResult.sandboxRecord?.status ?? "error",
           error: provResult.error,
-        },
+        }),
       });
       throw new Error(provResult.error);
     }
 
-    // Mark completed with result
     const jobResult: AgentProvisionJobResult = {
       cloudAgentId: data.agentId,
       status: provResult.sandboxRecord.status,
@@ -1411,7 +1409,6 @@ export class ProvisioningJobService {
       completed_at: new Date(),
     });
 
-    // Fire webhook if configured
     if (job.webhook_url) {
       await this.fireWebhook(job, jobResult);
     }
@@ -1508,7 +1505,7 @@ export class ProvisioningJobService {
 
       await jobsRepository.update(job.id, {
         webhook_status: response.ok ? "delivered" : `failed_${response.status}`,
-      } as Partial<Job>);
+      });
 
       if (!response.ok) {
         logger.warn("[provisioning-jobs] Webhook delivery failed", {
@@ -1525,7 +1522,7 @@ export class ProvisioningJobService {
 
       await jobsRepository.update(job.id, {
         webhook_status: "error",
-      } as Partial<Job>);
+      });
     }
   }
 }


### PR DESCRIPTION
Five small wins surfaced by a second \`/clean\` pass after the lifecycle queue stack merged: #7810, #7813, #7815, #7816.

## What changed (-5 LOC, 5 files)

**\`provisioning-jobs.ts\`**
- Drop 4 redundant type casts. \`status: \"error\"\`, \`\"deletion_failed\"\`, and the \`webhook_status\` updates are all literals already matching the inferred parameter type — the \`as Parameters<typeof agentSandboxesRepository.update>[1]\` / \`as Partial<Job>\` casts added nothing.
- \`executeAgentProvision\` failure path now uses \`agentProvisionJobResultToRecord({...})\` like every other executor, preserving the typed-serialization-boundary pattern the file otherwise enforces consistently.
- Drop 3 obvious comments (\`// Store partial result for debugging\`, \`// Mark completed with result\`, \`// Fire webhook if configured\`) to match the comment-free shape of the 6 sibling \`executeAgent*\` methods.

**\`v1/eliza/agents/[id]/route.ts\` (DELETE)**
- Drop the redundant \`instanceof Error && error.message === \"Agent not found\"\` branch. \`failureResponse()\` already maps any \"not found\" error to 404 via downstream string match.

**\`v1/agents/[id]/logs/route.ts\`**
- Add \`success: false\` to the 404 response body to match the response shape every sibling route uses.

**\`v1/eliza/agents/[id]/resume/route.ts\`**
- Trim a forward-looking comment about a \"future docker start fast path\" — belongs in a ticket, not the route. Kept the audit-log rationale.

**\`__tests__/provisioning-job-types.test.ts\`**
- Lock the registry size with \`expect(Object.keys(JOB_TYPES)).toHaveLength(7)\`. A new entry added to \`JOB_TYPES\` without a matching wire-value assertion now fails CI instead of being silently under-covered by the snake-case / uniqueness tests below.

## Why now

The lifecycle stack landed in one big push at 02:09 UTC. Post-merge I ran a second \`/clean\` pass to surface anything that slipped through the per-PR reviews. These are the 5 high-confidence wins. Nothing behavioral — type cast removal compiles to the same JS; the response-shape fix in the logs 404 matches what \`failureResponse\` already emits elsewhere; the test additionnal assertion is purely a CI guardrail.

## Test plan

- [x] \`tsc --noEmit\` clean on cloud-shared (touched files only)
- [x] \`bun test packages/cloud-shared/src/lib/services/__tests__/provisioning-job-types.test.ts\` → 4 pass, 17 assertions
- [x] biome check clean on all 5 touched files

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Post-merge cleanup pass across five files in the lifecycle job stack: removes redundant type casts, normalizes the `executeAgentProvision` failure path to use the typed serializer, drops stale comments, and adds a CI guard on the `JOB_TYPES` registry size.

- **`provisioning-jobs.ts`**: four unnecessary `as Parameters<…>[1]` / `as Partial<Job>` casts removed; the `executeAgentProvision` failure path now routes through `agentProvisionJobResultToRecord` for consistency with all other executors; three self-evident inline comments dropped.
- **`route.ts` (DELETE)**: the hand-rolled "Agent not found" → 404 branch is removed; `failureResponse` already reaches 404 via `inferStatusFromLegacyError`'s `message.includes("not found")` check — the response now also carries `code: "resource_not_found"` which was previously absent.
- **`logs/route.ts` & `resume/route.ts`**: 404 response body aligned with sibling routes (`success: false` added); forward-looking docker comment trimmed.

<h3>Confidence Score: 5/5</h3>

All five changes are non-behavioral: type cast removal compiles to identical JS, the response-shape additions are purely additive, and the test change only tightens an existing assertion.

Every change is either a TypeScript-only cast removal (zero JS delta), an additive response field (adds `code: "resource_not_found"` where it was absent before — no client would break on an extra field), a comment edit, or a test guardrail. The `agentProvisionJobResultToRecord` normalization on the failure path is functionally identical because the serializer is a plain object spread. `tsc --noEmit` and biome are reported clean across all touched files.

No files require special attention. The DELETE route behavior change (response now includes `code`) is worth confirming against any clients that strictly parse the 404 body, but it is purely additive.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cloud-shared/src/lib/services/provisioning-jobs.ts | Removes 4 redundant type casts and normalizes the failure path in executeAgentProvision to use the typed agentProvisionJobResultToRecord serializer; drops 3 obvious inline comments. No behavioral change. |
| packages/cloud-api/v1/eliza/agents/[agentId]/route.ts | Removes the redundant explicit "Agent not found" → 404 branch; failureResponse already maps error messages containing "not found" to 404 via inferStatusFromLegacyError. New response shape adds a code: "resource_not_found" field that was previously absent — additive only. |
| packages/cloud-api/v1/agents/[agentId]/logs/route.ts | Adds success: false to the 404 response body for agent-not-found, aligning it with the shape every sibling route already emits. |
| packages/cloud-api/v1/eliza/agents/[agentId]/resume/route.ts | Trims the forward-looking "future docker start fast path" clause from a block comment, keeping only the audit-log rationale that is currently true. |
| packages/cloud-shared/src/lib/services/__tests__/provisioning-job-types.test.ts | Adds a toHaveLength(7) guard to the "includes every registered job type" test, making the registry size an explicit CI contract so new entries without matching assertions fail immediately. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[executeAgentProvision] --> B{provResult.success?}
    B -- No --> C[agentProvisionJobResultToRecord with error]
    C --> D[jobsRepository.update result]
    D --> E[throw Error]
    B -- Yes --> F[build AgentProvisionJobResult]
    F --> G[agentProvisionJobResultToRecord]
    G --> H[jobsRepository.updateStatus completed]
    H --> I{job.webhook_url?}
    I -- Yes --> J[fireWebhook]
    I -- No --> K[Done]
    J --> K
```

<sub>Reviews (1): Last reviewed commit: ["chore(cloud): post-merge /clean follow-u..."](https://github.com/elizaos/eliza/commit/773511ddc0339a19ccd838ae7eaf41c9b4ab7920) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33017094)</sub>

<!-- /greptile_comment -->