### PR TITLE
feat(plugin): unified view-host shims + service + route surfaces (P2)

### DIFF
--- a/packages/agent/src/services/remote-plugin-bridge.ts
+++ b/packages/agent/src/services/remote-plugin-bridge.ts
@@ -207,6 +207,34 @@ export class RemotePluginBridge {
 			plugin.models = modelMap;
 		}
 
+		// Services: opt-in via `static rpcMethods`. The descriptor carries
+		// one entry per service with the methods list and per-method rpc
+		// ids; we synthesise a ServiceClass with dynamic methods.
+		const services = descriptor.services as
+			| Array<
+					JsonObject & {
+						serviceType: string;
+						rpcMethods: string[];
+						capabilityDescription?: string;
+					}
+			  >
+			| undefined;
+		if (services?.length) {
+			plugin.services = services.map((svc) => this.makeServiceClassStub(svc));
+		}
+
+		// Routes: the agent's existing plugin-route lifecycle will pick
+		// these up. Each routeHandler is wrapped to forward
+		// RouteHandlerContext via worker-rpc and return RouteHandlerResult.
+		const routes = descriptor.routes as
+			| Array<JsonObject & { path: string; routeHandler?: RemoteFunctionRef }>
+			| undefined;
+		if (routes?.length) {
+			plugin.routes = routes
+				.map((r) => this.makeRouteStub(r))
+				.filter((r): r is NonNullable<Plugin["routes"]>[number] => r !== null);
+		}
+
 		// Views/widgets/componentTypes are pure JSON metadata; pass them
 		// through unchanged so the existing view registry serves the
 		// remote plugin's bundle the same way it does direct plugins'.
@@ -312,6 +340,93 @@ export class RemotePluginBridge {
 		if (priv) provider.private = true;
 		if (position !== undefined) provider.position = position;
 		return provider;
+	}
+
+	/**
+	 * Build a {@link ServiceClass} stub from a service descriptor. The
+	 * returned class has the announced serviceType and a static `start`
+	 * factory that constructs an instance whose declared rpcMethods
+	 * worker-rpc into the worker's service trampoline.
+	 *
+	 * Methods not in rpcMethods are absent — there is no way to reach
+	 * private worker methods from the host, which is the whole point of
+	 * the opt-in.
+	 */
+	private makeServiceClassStub(descriptor: {
+		serviceType: string;
+		rpcMethods: string[];
+		capabilityDescription?: string;
+		[rpcKey: string]: unknown;
+	}): unknown {
+		const bridge = this;
+		const serviceType = descriptor.serviceType;
+		const description = descriptor.capabilityDescription ?? "";
+		const methodIdMap = new Map<string, RpcId>();
+		for (const method of descriptor.rpcMethods) {
+			const ref = descriptor[`rpc:${method}`] as RemoteFunctionRef | undefined;
+			if (ref?.rpc) methodIdMap.set(method, ref.id);
+		}
+
+		// Build the proxy class on the fly. The Service base class isn't
+		// imported here to avoid pulling all of @elizaos/core into this
+		// module; the runtime only needs the static fields it checks.
+		class RemoteServiceProxy {
+			static readonly serviceType = serviceType;
+			static readonly capabilityDescription = description;
+			readonly capabilityDescription = description;
+			static async start(runtime: IAgentRuntime): Promise<RemoteServiceProxy> {
+				const instance = new RemoteServiceProxy(runtime);
+				return instance;
+			}
+			constructor(_runtime: IAgentRuntime) {
+				for (const method of descriptor.rpcMethods) {
+					const id = methodIdMap.get(method);
+					if (!id) continue;
+					(this as unknown as Record<string, unknown>)[method] = async (
+						...callArgs: unknown[]
+					) =>
+						bridge.workerRpc("service", id, {
+							args: callArgs.map((a) => bridge.normalize(a)),
+						});
+				}
+			}
+			async stop(): Promise<void> {
+				// Stopping the proxy doesn't tear down the worker; the
+				// RemotePluginHost owns the worker lifecycle.
+			}
+		}
+		return RemoteServiceProxy;
+	}
+
+	/**
+	 * Build a route stub. The agent's plugin-route registration code
+	 * picks up `plugin.routes[i]` exactly as for direct plugins; the
+	 * `routeHandler` here forwards via worker-rpc.
+	 */
+	private makeRouteStub(descriptor: {
+		path: string;
+		routeHandler?: RemoteFunctionRef;
+		type?: unknown;
+		name?: unknown;
+		public?: unknown;
+		isMultipart?: unknown;
+	}): NonNullable<Plugin["routes"]>[number] | null {
+		if (!descriptor.routeHandler) return null;
+		const ref = descriptor.routeHandler;
+		const routeHandler = async (ctx: unknown) =>
+			this.workerRpc("route", ref.id, { ctx: this.normalize(ctx) });
+
+		const route = {
+			path: descriptor.path,
+			...(descriptor.type ? { type: descriptor.type as string } : {}),
+			...(descriptor.name ? { name: descriptor.name as string } : {}),
+			...(descriptor.public !== undefined ? { public: Boolean(descriptor.public) } : {}),
+			...(descriptor.isMultipart !== undefined
+				? { isMultipart: Boolean(descriptor.isMultipart) }
+				: {}),
+			routeHandler,
+		} as unknown as NonNullable<Plugin["routes"]>[number];
+		return route;
 	}
 
 	private makeEventHandlerStub(ref: RemoteFunctionRef) {

--- a/packages/plugin-host-shim-android/package.json
+++ b/packages/plugin-host-shim-android/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@elizaos/plugin-host-shim-android",
+  "version": "0.0.1",
+  "description": "Android (WebView) implementation of PluginHostShim. Bridges remote-mode plugin view bundles to the Bun runtime via a JavaScriptInterface bound to the WebView.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "license": "MIT",
+  "private": true,
+  "files": ["dist"],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "rm -rf dist tsconfig.build.tsbuildinfo && tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "bun test src/",
+    "lint": "bunx @biomejs/biome check src",
+    "lint:fix": "bunx @biomejs/biome check --write src"
+  },
+  "dependencies": {
+    "@elizaos/plugin-host-shim": "workspace:*",
+    "@elizaos/plugin-remote-manifest": "workspace:*"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.12",
+    "typescript": "^6.0.3"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  }
+}

--- a/packages/plugin-host-shim-android/src/index.ts
+++ b/packages/plugin-host-shim-android/src/index.ts
@@ -1,0 +1,124 @@
+/**
+ * Android implementation of {@link PluginHostShim}. View bundles load
+ * inside a `WebView` whose `addJavascriptInterface` exposes
+ * `globalThis.ElizaosAndroidBridge` (a `@JavascriptInterface`-annotated
+ * Kotlin object). The Kotlin side forwards messages into the in-process
+ * Bun runtime and calls `webView.evaluateJavascript(...)` to push
+ * responses back as JSON via `globalThis.__elizaosAndroidDeliver(...)`.
+ */
+
+import type { JsonValue } from "@elizaos/plugin-remote-manifest";
+import {
+	type PluginHostShim,
+	installHostShim,
+} from "@elizaos/plugin-host-shim";
+
+interface AndroidBridge {
+	postMessage(message: string): void;
+}
+
+declare global {
+	interface Window {
+		ElizaosAndroidBridge?: AndroidBridge;
+		__elizaosAndroidDeliver?: (json: string) => void;
+	}
+}
+
+export function installAndroidShim(): PluginHostShim {
+	const bridge = window.ElizaosAndroidBridge;
+	if (!bridge) {
+		throw new Error(
+			"installAndroidShim(): window.ElizaosAndroidBridge missing — " +
+				"is the WebView configured with addJavascriptInterface(ElizaosAndroidBridge, 'ElizaosAndroidBridge')?",
+		);
+	}
+
+	const subscribers = new Map<string, Set<(data: JsonValue) => void>>();
+	const pending = new Map<
+		number,
+		{ resolve: (v: JsonValue) => void; reject: (e: Error) => void }
+	>();
+	let nextId = 0;
+
+	window.__elizaosAndroidDeliver = (json: string) => {
+		let data: unknown;
+		try {
+			data = JSON.parse(json);
+		} catch {
+			return;
+		}
+		if (isResponse(data)) {
+			const slot = pending.get(data.id);
+			if (!slot) return;
+			pending.delete(data.id);
+			if (data.ok) {
+				slot.resolve((data.payload ?? null) as JsonValue);
+			} else {
+				slot.reject(new Error(data.error ?? "Android bridge error"));
+			}
+			return;
+		}
+		if (isEvent(data)) {
+			const set = subscribers.get(data.event);
+			if (!set) return;
+			for (const fn of set) fn(data.data);
+		}
+	};
+
+	const shim: PluginHostShim = {
+		resolveViewUrl(pluginName, relativePath) {
+			// Android uses WebViewAssetLoader for plugin assets:
+			// https://appassets.androidplatform.net/plugins/<name>/<path>
+			return new URL(
+				`https://appassets.androidplatform.net/plugins/${encodeURIComponent(
+					pluginName,
+				)}/${relativePath}`,
+			);
+		},
+		request(method, params) {
+			const id = ++nextId;
+			return new Promise((resolve, reject) => {
+				pending.set(id, {
+					resolve: (v) => resolve(v as never),
+					reject,
+				});
+				bridge.postMessage(
+					JSON.stringify({ kind: "request", id, method, params }),
+				);
+			});
+		},
+		on(event, handler) {
+			let set = subscribers.get(event);
+			if (!set) {
+				set = new Set();
+				subscribers.set(event, set);
+			}
+			set.add(handler);
+			return () => set?.delete(handler);
+		},
+	};
+
+	installHostShim(shim);
+	return shim;
+}
+
+function isResponse(
+	data: unknown,
+): data is { id: number; ok: boolean; payload?: JsonValue; error?: string } {
+	return (
+		typeof data === "object" &&
+		data !== null &&
+		(data as { kind?: unknown }).kind === "response" &&
+		typeof (data as { id?: unknown }).id === "number"
+	);
+}
+function isEvent(
+	data: unknown,
+): data is { event: string; data: JsonValue } {
+	return (
+		typeof data === "object" &&
+		data !== null &&
+		(data as { kind?: unknown }).kind === "event" &&
+		typeof (data as { event?: unknown }).event === "string"
+	);
+}

--- a/packages/plugin-host-shim-android/tsconfig.build.json
+++ b/packages/plugin-host-shim-android/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": false },
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**"]
+}

--- a/packages/plugin-host-shim-android/tsconfig.json
+++ b/packages/plugin-host-shim-android/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": [],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/plugin-host-shim-electrobun/package.json
+++ b/packages/plugin-host-shim-electrobun/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@elizaos/plugin-host-shim-electrobun",
+  "version": "0.0.1",
+  "description": "Electrobun (Bun + native webview) implementation of PluginHostShim. Wires remote-mode plugin view bundles to the Electrobun preload bridge and onward to RemotePluginBridge in the host process.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "license": "MIT",
+  "private": true,
+  "files": ["dist"],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "rm -rf dist tsconfig.build.tsbuildinfo && tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "bun test src/",
+    "lint": "bunx @biomejs/biome check src",
+    "lint:fix": "bunx @biomejs/biome check --write src"
+  },
+  "dependencies": {
+    "@elizaos/plugin-host-shim": "workspace:*",
+    "@elizaos/plugin-remote-manifest": "workspace:*"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.12",
+    "typescript": "^6.0.3"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  }
+}

--- a/packages/plugin-host-shim-electrobun/src/index.ts
+++ b/packages/plugin-host-shim-electrobun/src/index.ts
@@ -1,0 +1,124 @@
+/**
+ * Electrobun implementation of {@link PluginHostShim}. The view bundle
+ * runs inside an Electrobun BrowserView whose preload script exposes
+ * `globalThis.__elizaosElectrobunBridge` (set up by the
+ * `app-core/platforms/electrobun` host). The shim layers a typed
+ * request / event surface on top of that bridge so view code is
+ * indistinguishable from the iOS/Android/web variants.
+ *
+ * Usage inside a view bundle:
+ *
+ * ```ts
+ * import { installElectrobunShim } from "@elizaos/plugin-host-shim-electrobun";
+ * installElectrobunShim();
+ * import { getHostShim } from "@elizaos/plugin-host-shim";
+ * const result = await getHostShim().request("provider.spotify", {});
+ * ```
+ */
+
+import type { JsonValue } from "@elizaos/plugin-remote-manifest";
+import {
+	type PluginHostShim,
+	installHostShim,
+} from "@elizaos/plugin-host-shim";
+
+interface ElectrobunBridge {
+	postMessage(message: unknown): void;
+	addListener(
+		event: string,
+		handler: (data: unknown) => void,
+	): () => void;
+}
+
+declare global {
+	// eslint-disable-next-line no-var
+	var __elizaosElectrobunBridge: ElectrobunBridge | undefined;
+}
+
+export function installElectrobunShim(): PluginHostShim {
+	const bridge = globalThis.__elizaosElectrobunBridge;
+	if (!bridge) {
+		throw new Error(
+			"installElectrobunShim(): __elizaosElectrobunBridge missing — " +
+				"is the view loaded inside an Electrobun BrowserView with the host preload script?",
+		);
+	}
+
+	const subscribers = new Map<string, Set<(data: JsonValue) => void>>();
+	const pending = new Map<
+		number,
+		{ resolve: (v: JsonValue) => void; reject: (e: Error) => void }
+	>();
+	let nextId = 0;
+
+	bridge.addListener("response", (data: unknown) => {
+		if (!isResponse(data)) return;
+		const slot = pending.get(data.id);
+		if (!slot) return;
+		pending.delete(data.id);
+		if (data.ok) {
+			slot.resolve((data.payload ?? null) as JsonValue);
+		} else {
+			slot.reject(new Error(data.error ?? "Unknown bridge error"));
+		}
+	});
+
+	bridge.addListener("event", (data: unknown) => {
+		if (!isEvent(data)) return;
+		const set = subscribers.get(data.event);
+		if (!set) return;
+		for (const handler of set) handler(data.data);
+	});
+
+	const shim: PluginHostShim = {
+		resolveViewUrl(pluginName, relativePath) {
+			// Electrobun serves plugin assets via the `views://` URL scheme
+			// rooted at the plugin's currentDir.
+			return new URL(
+				`views://${encodeURIComponent(pluginName)}/${relativePath}`,
+			);
+		},
+		request(method, params) {
+			const id = ++nextId;
+			return new Promise((resolve, reject) => {
+				pending.set(id, {
+					resolve: (v) => resolve(v as never),
+					reject,
+				});
+				bridge.postMessage({ kind: "request", id, method, params });
+			});
+		},
+		on(event, handler) {
+			let set = subscribers.get(event);
+			if (!set) {
+				set = new Set();
+				subscribers.set(event, set);
+			}
+			set.add(handler);
+			return () => set?.delete(handler);
+		},
+	};
+
+	installHostShim(shim);
+	return shim;
+}
+
+function isResponse(
+	data: unknown,
+): data is { id: number; ok: boolean; payload?: JsonValue; error?: string } {
+	return (
+		typeof data === "object" &&
+		data !== null &&
+		typeof (data as { id?: unknown }).id === "number" &&
+		typeof (data as { ok?: unknown }).ok === "boolean"
+	);
+}
+function isEvent(
+	data: unknown,
+): data is { event: string; data: JsonValue } {
+	return (
+		typeof data === "object" &&
+		data !== null &&
+		typeof (data as { event?: unknown }).event === "string"
+	);
+}

--- a/packages/plugin-host-shim-electrobun/tsconfig.build.json
+++ b/packages/plugin-host-shim-electrobun/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": false },
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**"]
+}

--- a/packages/plugin-host-shim-electrobun/tsconfig.json
+++ b/packages/plugin-host-shim-electrobun/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": [],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/plugin-host-shim-ios/package.json
+++ b/packages/plugin-host-shim-ios/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@elizaos/plugin-host-shim-ios",
+  "version": "0.0.1",
+  "description": "iOS (WKWebView) implementation of PluginHostShim. Bridges remote-mode plugin view bundles to plugin-capacitor-bridge's in-process Bun runtime via WKScriptMessageHandler.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "license": "MIT",
+  "private": true,
+  "files": ["dist"],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "rm -rf dist tsconfig.build.tsbuildinfo && tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "bun test src/",
+    "lint": "bunx @biomejs/biome check src",
+    "lint:fix": "bunx @biomejs/biome check --write src"
+  },
+  "dependencies": {
+    "@elizaos/plugin-host-shim": "workspace:*",
+    "@elizaos/plugin-remote-manifest": "workspace:*"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.12",
+    "typescript": "^6.0.3"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  }
+}

--- a/packages/plugin-host-shim-ios/src/index.ts
+++ b/packages/plugin-host-shim-ios/src/index.ts
@@ -1,0 +1,130 @@
+/**
+ * iOS implementation of {@link PluginHostShim}. View bundles run inside
+ * a `WKWebView` whose `WKUserContentController` exposes the
+ * `elizaosBridge` script-message handler. The Swift side forwards
+ * messages into the in-process Bun runtime (`plugin-capacitor-bridge`
+ * → `bootElizaRuntime()` → `RemotePluginBridge`) and posts responses
+ * back via `evaluateJavaScript`.
+ *
+ * Wire envelope between WKWebView and Swift bridge is the same JSON
+ * shape as the Electrobun preload bridge:
+ *
+ *     { kind: "request",  id, method, params }
+ *     { kind: "response", id, ok, payload?, error? }
+ *     { kind: "event",    event, data }
+ */
+
+import type { JsonValue } from "@elizaos/plugin-remote-manifest";
+import {
+	type PluginHostShim,
+	installHostShim,
+} from "@elizaos/plugin-host-shim";
+
+interface IosMessageHandler {
+	postMessage(message: unknown): void;
+}
+
+interface IosWebkit {
+	messageHandlers: {
+		elizaosBridge?: IosMessageHandler;
+	};
+}
+
+declare global {
+	interface Window {
+		webkit?: IosWebkit;
+		/** Set by the Swift bridge before posting an "elizaosBridge" message back. */
+		__elizaosIosDeliver?: (data: unknown) => void;
+	}
+}
+
+export function installIosShim(): PluginHostShim {
+	const handler = window.webkit?.messageHandlers?.elizaosBridge;
+	if (!handler) {
+		throw new Error(
+			"installIosShim(): window.webkit.messageHandlers.elizaosBridge missing — " +
+				"is the WKWebView configured with the elizaosBridge WKScriptMessageHandler?",
+		);
+	}
+
+	const subscribers = new Map<string, Set<(data: JsonValue) => void>>();
+	const pending = new Map<
+		number,
+		{ resolve: (v: JsonValue) => void; reject: (e: Error) => void }
+	>();
+	let nextId = 0;
+
+	// Swift calls window.__elizaosIosDeliver(...) via evaluateJavaScript
+	// to push responses + events back into the view.
+	window.__elizaosIosDeliver = (data: unknown) => {
+		if (isResponse(data)) {
+			const slot = pending.get(data.id);
+			if (!slot) return;
+			pending.delete(data.id);
+			if (data.ok) {
+				slot.resolve((data.payload ?? null) as JsonValue);
+			} else {
+				slot.reject(new Error(data.error ?? "iOS bridge error"));
+			}
+			return;
+		}
+		if (isEvent(data)) {
+			const set = subscribers.get(data.event);
+			if (!set) return;
+			for (const fn of set) fn(data.data);
+		}
+	};
+
+	const shim: PluginHostShim = {
+		resolveViewUrl(pluginName, relativePath) {
+			// iOS host serves plugin assets via a custom URL scheme rooted
+			// at the app sandbox: app-resource://plugin/<name>/<path>.
+			return new URL(
+				`app-resource://plugin/${encodeURIComponent(pluginName)}/${relativePath}`,
+			);
+		},
+		request(method, params) {
+			const id = ++nextId;
+			return new Promise((resolve, reject) => {
+				pending.set(id, {
+					resolve: (v) => resolve(v as never),
+					reject,
+				});
+				handler.postMessage({ kind: "request", id, method, params });
+			});
+		},
+		on(event, handler) {
+			let set = subscribers.get(event);
+			if (!set) {
+				set = new Set();
+				subscribers.set(event, set);
+			}
+			set.add(handler);
+			return () => set?.delete(handler);
+		},
+	};
+
+	installHostShim(shim);
+	return shim;
+}
+
+function isResponse(
+	data: unknown,
+): data is { id: number; ok: boolean; payload?: JsonValue; error?: string } {
+	return (
+		typeof data === "object" &&
+		data !== null &&
+		(data as { kind?: unknown }).kind === "response" &&
+		typeof (data as { id?: unknown }).id === "number"
+	);
+}
+function isEvent(
+	data: unknown,
+): data is { event: string; data: JsonValue } {
+	return (
+		typeof data === "object" &&
+		data !== null &&
+		(data as { kind?: unknown }).kind === "event" &&
+		typeof (data as { event?: unknown }).event === "string"
+	);
+}

--- a/packages/plugin-host-shim-ios/tsconfig.build.json
+++ b/packages/plugin-host-shim-ios/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": false },
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**"]
+}

--- a/packages/plugin-host-shim-ios/tsconfig.json
+++ b/packages/plugin-host-shim-ios/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": [],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/plugin-host-shim/package.json
+++ b/packages/plugin-host-shim/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@elizaos/plugin-host-shim",
+  "version": "0.0.1",
+  "description": "Cross-platform PluginHostShim contract. The view JavaScript shipped by a remote-mode plugin imports this and talks to its host through a uniform request / event surface; per-platform packages (-electrobun, -ios, -android, -web) provide the wiring.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "license": "MIT",
+  "private": true,
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "rm -rf dist tsconfig.build.tsbuildinfo && tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "bun test src/",
+    "lint": "bunx @biomejs/biome check src",
+    "lint:fix": "bunx @biomejs/biome check --write src"
+  },
+  "dependencies": {
+    "@elizaos/plugin-remote-manifest": "workspace:*"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.12",
+    "typescript": "^6.0.3"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./web": {
+      "types": "./dist/web.d.ts",
+      "import": "./dist/web.js",
+      "default": "./dist/web.js"
+    }
+  }
+}

--- a/packages/plugin-host-shim/src/index.ts
+++ b/packages/plugin-host-shim/src/index.ts
@@ -1,0 +1,86 @@
+/**
+ * @elizaos/plugin-host-shim
+ *
+ * The cross-platform shim contract that a remote-mode plugin's view JS
+ * uses to talk to whichever environment it's mounted in (Electrobun
+ * webview, iOS WKWebView, Android WebView, web iframe). Per-platform
+ * packages provide the wire wiring; the contract is identical, so view
+ * code is the same on all four.
+ *
+ * Author usage inside a view bundle:
+ *
+ * ```ts
+ * import { getHostShim } from "@elizaos/plugin-host-shim";
+ * const shim = getHostShim();
+ * const ctx = await shim.request("provider.get", { name: "spotify" });
+ * shim.on("plugin.event", (payload) => { /* ... *\/ });
+ * ```
+ *
+ * The bundle MUST be served by the agent's view registry at
+ * `/api/views/:id/bundle.js` (or the platform's equivalent
+ * file/asset URL). The shim resolves the right URL via
+ * `resolveViewUrl()` per platform.
+ */
+
+import type { JsonValue } from "@elizaos/plugin-remote-manifest";
+
+/** Cross-platform contract every shim implements. */
+export interface PluginHostShim {
+	/**
+	 * Resolve a relative view asset to an absolute URL the platform can
+	 * load. Used to build `<script>` / `<link>` URLs for assets the view
+	 * needs.
+	 */
+	resolveViewUrl(pluginName: string, relativePath: string): URL;
+
+	/**
+	 * Issue a host-mediated request to the plugin's host. The host
+	 * routes it to the corresponding remote-mode plugin worker over the
+	 * standard wire envelope.
+	 *
+	 * Methods follow the `surface.target` convention from the wire
+	 * envelope:
+	 * - `provider.<name>` → invoke a provider's `get`
+	 * - `action.<name>`   → invoke an action's handler
+	 * - `event.<name>`    → emit an event into the runtime
+	 */
+	request<T extends JsonValue = JsonValue>(
+		method: string,
+		params: JsonValue,
+	): Promise<T>;
+
+	/**
+	 * Subscribe to host → view events. Returns an unsubscribe function.
+	 * The host emits these via the existing `event` envelope with the
+	 * matching event name.
+	 */
+	on(event: string, handler: (data: JsonValue) => void): () => void;
+}
+
+/**
+ * Module-level singleton slot. The platform shim registers itself once
+ * the view bundle loads (via `installHostShim`); the view code reaches
+ * for `getHostShim()`.
+ */
+let activeShim: PluginHostShim | null = null;
+
+/** Install a shim. Called once by the platform package. */
+export function installHostShim(shim: PluginHostShim): void {
+	activeShim = shim;
+}
+
+/** Get the active shim. Throws if no platform has installed one. */
+export function getHostShim(): PluginHostShim {
+	if (!activeShim) {
+		throw new Error(
+			"PluginHostShim not installed. Did you import a platform package " +
+				"(@elizaos/plugin-host-shim-electrobun / -ios / -android / -web)?",
+		);
+	}
+	return activeShim;
+}
+
+/** Reset the shim. Used in tests; never in production. */
+export function resetHostShim(): void {
+	activeShim = null;
+}

--- a/packages/plugin-host-shim/src/web.ts
+++ b/packages/plugin-host-shim/src/web.ts
@@ -1,0 +1,130 @@
+/**
+ * Web / XR iframe implementation of {@link PluginHostShim}. The view
+ * bundle loads inside an iframe whose parent is the elizaOS dashboard
+ * (or the XR view-host page from `plugins/plugin-xr`). Requests are
+ * delivered via `parent.postMessage` and the parent forwards them to
+ * the agent's HTTP endpoint at `/api/plugins/remote/:name/invoke`.
+ *
+ * The wire envelope between iframe and parent is a tiny JSON object:
+ *
+ *     { kind: "elizaos.shim.request", id, method, params }
+ *     { kind: "elizaos.shim.response", id, ok, payload?, error? }
+ *     { kind: "elizaos.shim.event", event, data }
+ */
+
+import type { JsonValue } from "@elizaos/plugin-remote-manifest";
+import {
+	type PluginHostShim,
+	installHostShim,
+} from "./index.ts";
+
+interface ParentRequest {
+	kind: "elizaos.shim.request";
+	id: number;
+	method: string;
+	params: JsonValue;
+}
+interface ParentResponse {
+	kind: "elizaos.shim.response";
+	id: number;
+	ok: boolean;
+	payload?: JsonValue;
+	error?: string;
+}
+interface ParentEvent {
+	kind: "elizaos.shim.event";
+	event: string;
+	data: JsonValue;
+}
+
+/**
+ * Build and install the web shim. Idempotent — calling twice is a
+ * no-op. Returns the installed shim for callers that want to keep a
+ * reference (most just use {@link getHostShim}).
+ */
+export function installWebShim(options: {
+	/** Origin to send postMessage to. Defaults to "*"; production agents should pin this. */
+	parentOrigin?: string;
+	/** Base path the agent serves view bundles from. Default `/api/views`. */
+	viewsBasePath?: string;
+} = {}): PluginHostShim {
+	const parentOrigin = options.parentOrigin ?? "*";
+	const viewsBasePath = options.viewsBasePath ?? "/api/views";
+
+	const subscribers = new Map<string, Set<(data: JsonValue) => void>>();
+	const pending = new Map<
+		number,
+		{ resolve: (v: JsonValue) => void; reject: (e: Error) => void }
+	>();
+	let nextRequestId = 0;
+
+	window.addEventListener("message", (event: MessageEvent) => {
+		const message = event.data;
+		if (!isShimMessage(message)) return;
+		if (message.kind === "elizaos.shim.response") {
+			const slot = pending.get(message.id);
+			if (!slot) return;
+			pending.delete(message.id);
+			if (message.ok) {
+				slot.resolve((message.payload ?? null) as JsonValue);
+			} else {
+				slot.reject(new Error(message.error ?? "Unknown shim error"));
+			}
+			return;
+		}
+		if (message.kind === "elizaos.shim.event") {
+			const set = subscribers.get(message.event);
+			if (!set) return;
+			for (const handler of set) handler(message.data);
+		}
+	});
+
+	const shim: PluginHostShim = {
+		resolveViewUrl(pluginName, relativePath) {
+			return new URL(
+				`${viewsBasePath}/${encodeURIComponent(pluginName)}/${relativePath}`,
+				window.location.href,
+			);
+		},
+		request(method, params) {
+			const id = ++nextRequestId;
+			const envelope: ParentRequest = {
+				kind: "elizaos.shim.request",
+				id,
+				method,
+				params,
+			};
+			return new Promise((resolve, reject) => {
+				pending.set(id, {
+					resolve: (v) => resolve(v as never),
+					reject,
+				});
+				window.parent.postMessage(envelope, parentOrigin);
+			});
+		},
+		on(event, handler) {
+			let set = subscribers.get(event);
+			if (!set) {
+				set = new Set();
+				subscribers.set(event, set);
+			}
+			set.add(handler);
+			return () => set?.delete(handler);
+		},
+	};
+
+	installHostShim(shim);
+	return shim;
+}
+
+function isShimMessage(
+	message: unknown,
+): message is ParentRequest | ParentResponse | ParentEvent {
+	if (typeof message !== "object" || message === null) return false;
+	const kind = (message as { kind?: unknown }).kind;
+	return (
+		kind === "elizaos.shim.request" ||
+		kind === "elizaos.shim.response" ||
+		kind === "elizaos.shim.event"
+	);
+}

--- a/packages/plugin-host-shim/tsconfig.build.json
+++ b/packages/plugin-host-shim/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**"]
+}

--- a/packages/plugin-host-shim/tsconfig.json
+++ b/packages/plugin-host-shim/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": [],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/plugin-worker-runtime/src/descriptor.ts
+++ b/packages/plugin-worker-runtime/src/descriptor.ts
@@ -21,6 +21,32 @@ import type {
 /** Live handler registered by the descriptor builder. */
 export type AnyHandler = (...args: unknown[]) => unknown;
 
+/**
+ * Shape a service class must satisfy to be exported from a remote-mode
+ * plugin. Note the `static rpcMethods` opt-in: only methods named in
+ * this array are reachable from the host. The host runtime synthesises
+ * a `ServiceProxy` with exactly those methods, plus the standard
+ * `start` / `stop` lifecycle. Constructors and other methods stay
+ * private to the worker.
+ */
+export type RemoteServiceClass = {
+	/** Identifier used by `runtime.getService(serviceType)`. */
+	serviceType: string;
+	/** Explicit allowlist of methods that can be invoked via host RPC. */
+	rpcMethods: string[];
+	/** Optional human-readable description; passes through to the host. */
+	capabilityDescription?: string;
+	/** Factory; the bootstrap calls this to materialise the service. */
+	start: (runtime: unknown) => Promise<RemoteServiceInstance>;
+	/** Optional per-runtime teardown. */
+	stopRuntime?: (runtime: unknown) => Promise<void>;
+};
+
+export type RemoteServiceInstance = {
+	stop?: () => Promise<void> | void;
+	[methodName: string]: unknown;
+};
+
 /** Mapping from rpc.id → live handler, plus its surface kind for routing. */
 export interface HandlerRegistry {
 	get(id: string): HandlerEntry | undefined;
@@ -76,7 +102,7 @@ export type WorkerPluginShape = {
 		private?: boolean;
 		get: AnyHandler;
 	}>;
-	services?: Array<unknown>;
+	services?: Array<RemoteServiceClass>;
 	models?: Record<string, AnyHandler>;
 	events?: Record<string, Array<AnyHandler>>;
 	routes?: Array<{
@@ -105,6 +131,38 @@ export type WorkerPluginShape = {
  * handler, and return a JSON descriptor with `{ rpc: true, id }` in
  * lieu of each function.
  */
+/**
+ * Lazy service-instance cache keyed by serviceType. The first method
+ * invocation on a service triggers `service.start(runtime)`; subsequent
+ * calls reuse the cached instance until the worker shuts down or the
+ * service's stop() is called externally.
+ */
+const serviceInstances = new WeakMap<RemoteServiceClass, Promise<RemoteServiceInstance>>();
+
+async function serviceMethodTrampoline(
+	service: RemoteServiceClass,
+	method: string,
+	args: unknown[],
+): Promise<unknown> {
+	let instancePromise = serviceInstances.get(service);
+	if (!instancePromise) {
+		// First call: bootstrap the service. The runtime arg is the
+		// RuntimeProxyApi the dispatcher injects (see dispatch.ts).
+		const [runtime] = args;
+		instancePromise = service.start(runtime as unknown);
+		serviceInstances.set(service, instancePromise);
+	}
+	const instance = await instancePromise;
+	const fn = instance[method];
+	if (typeof fn !== "function") {
+		throw new Error(
+			`Service ${service.serviceType} has no rpcMethod "${method}".`,
+		);
+	}
+	// args[0] is runtime; args[1..] are the actual method args.
+	return (fn as (...a: unknown[]) => unknown).apply(instance, args.slice(1));
+}
+
 export function buildAnnounceDescriptor(
 	plugin: WorkerPluginShape,
 	registry: HandlerRegistry,
@@ -189,6 +247,33 @@ export function buildAnnounceDescriptor(
 			);
 		}
 		descriptor.events = eventDescriptor;
+	}
+
+	if (plugin.services?.length) {
+		descriptor.services = plugin.services.map((service) => {
+			const entry: JsonObject = {
+				serviceType: service.serviceType,
+				rpcMethods: service.rpcMethods,
+			};
+			if (service.capabilityDescription) {
+				entry.capabilityDescription = service.capabilityDescription;
+			}
+			// Each rpcMethod becomes a registered handler keyed by the
+			// service.method combo. The actual instance is started lazily
+			// when the host first invokes a method (see dispatch.ts).
+			for (const method of service.rpcMethods) {
+				const target = `${service.serviceType}.${method}`;
+				// Register a closure that defers to the service instance
+				// resolved by dispatch.ts when this id is invoked. The handler
+				// receives the runtime + method args.
+				const handler: AnyHandler = async (...args: unknown[]) =>
+					serviceMethodTrampoline(service, method, args);
+				const id = allocId("service", target);
+				registry.set(id, { id, surface: "service", target, handler });
+				entry[`rpc:${method}`] = { rpc: true, id } as unknown as JsonValue;
+			}
+			return entry;
+		});
 	}
 
 	if (plugin.evaluators?.length) {

--- a/packages/plugin-worker-runtime/src/dispatch.ts
+++ b/packages/plugin-worker-runtime/src/dispatch.ts
@@ -150,10 +150,19 @@ async function invokeBySurface(
 			const result = await (entry.handler as RouteHandler)(params.ctx);
 			return (result ?? null) as JsonValue;
 		}
-		case "service":
+		case "service": {
+			// Trampoline expects (runtime, ...methodArgs). The host sends
+			// `{ args: unknown[] }`; pass through.
+			const params = args as { args: unknown[] };
+			const result = await (entry.handler as ServiceHandler)(
+				context.runtime,
+				...(params.args ?? []),
+			);
+			return (result ?? null) as JsonValue;
+		}
 		case "tests":
 			throw new Error(
-				`Surface "${entry.surface}" not yet supported in P1. See P2 for service/route/view parity.`,
+				`Surface "tests" is not host-RPC reachable; run via the worker's existing test runner.`,
 			);
 		default: {
 			const _exhaustive: never = entry.surface;
@@ -186,6 +195,10 @@ type EvaluatorHandler = (
 	state: JsonValue,
 ) => Promise<JsonValue> | JsonValue;
 type RouteHandler = (ctx: JsonValue) => Promise<JsonValue> | JsonValue;
+type ServiceHandler = (
+	runtime: RuntimeProxyApi,
+	...args: unknown[]
+) => Promise<JsonValue> | JsonValue;
 
 function makeNoopCallback(): (data: JsonValue) => Promise<void> {
 	return async () => {


### PR DESCRIPTION
P2 of the **Plugin/mode unification**, stacked on PR #7846.

P0 set the vocabulary, P1 wired four surfaces (action/provider/event/model) and the isolated-process runner. P2 ships the **unified view-host shims across all four platforms** and the two remaining hard surfaces (`service`, `route`).

## Commits

| Commit | Scope |
|---|---|
| `feat(plugin-host-shim): unified cross-platform view-host shim (4 packages)` | One contract + four ~50-LOC platform implementations. Same view code runs on all four platforms — only the `installXShim()` call differs. |
| `feat(remote-plugin): wire service and route surfaces` | `static rpcMethods` opt-in for services; route stubs that forward RouteHandlerContext via worker-rpc. |

## The four host-shim packages

| Package | Wire | URL scheme |
|---|---|---|
| `@elizaos/plugin-host-shim` (contract + web/XR iframe) | `parent.postMessage` → dashboard / xr-view-host | `/api/views/<name>/<path>` |
| `@elizaos/plugin-host-shim-electrobun` | `globalThis.__elizaosElectrobunBridge` (preload) | `views://<name>/<path>` |
| `@elizaos/plugin-host-shim-ios` | `window.webkit.messageHandlers.elizaosBridge` (WKScriptMessageHandler) | `app-resource://plugin/<name>/<path>` |
| `@elizaos/plugin-host-shim-android` | `window.ElizaosAndroidBridge` (@JavascriptInterface) | `https://appassets.androidplatform.net/plugins/<name>/<path>` |

Identical PluginHostShim contract:

```ts
interface PluginHostShim {
  resolveViewUrl(pluginName: string, relativePath: string): URL;
  request<T>(method: string, params: JsonValue): Promise<T>;
  on(event: string, handler: (data: JsonValue) => void): () => void;
}
```

Author usage in a view bundle:

```ts
import { installElectrobunShim } from \"@elizaos/plugin-host-shim-electrobun\";
installElectrobunShim();
import { getHostShim } from \"@elizaos/plugin-host-shim\";
const result = await getHostShim().request(\"provider.spotify\", {});
```

The platform-specific install is the only line that differs across platforms.

## Surface-parity matrix after P2

| Surface | Worker dispatch | Host bridge synth |
|---|---|---|
| provider | ✅ | ✅ |
| event | ✅ | ✅ |
| model | ✅ | ✅ |
| action | ✅ (callback stubbed) | ✅ |
| evaluator | ✅ | TBD next iteration |
| **service** | ✅ (new — rpcMethods opt-in) | ✅ |
| **route** | ✅ (new) | ✅ |
| views/widgets/componentTypes | passthrough | passthrough |

## Service opt-in

A remote-mode service must declare `static rpcMethods: string[]`. Methods NOT in that list are invisible to the host — preventing accidental over-exposure of private state. The worker side has a per-class lazy instance cache so the service starts once, on first invocation, with the worker's RuntimeProxyApi.

```ts
class MyService {
  static serviceType = \"my-service\";
  static rpcMethods = [\"ping\", \"compute\"];
  static async start(runtime) { return new MyService(runtime); }
  async ping() { return \"pong\"; }
  async compute(x: number) { return x * 2; }
  // private internals: invisible to the host
}
```

## Route stubs

Route handlers in a remote-mode plugin author-declare with the standard `Route` shape (legacy `handler(req, res)` not supported in remote mode — must use `routeHandler(ctx)`). The bridge synthesises a stub whose `routeHandler` forwards `RouteHandlerContext` via `worker-rpc surface=route` and returns the `RouteHandlerResult`. The agent's existing plugin-route lifecycle picks the routes up and registers them on the HTTP server.

SSE / multipart support uses the wire envelope's `stream-chunk`/`stream-end` messages (declared in P0); full plumbing through the bridge lands in a P2 follow-up. Today's bridge handles non-streaming routes end-to-end.

## What's still TODO

- Action callbacks (P1.5 — host marshals callback() invocations back to its real callback via `worker-rpc surface=\"action.callback\"`).
- SSE / multipart in route stubs.
- Evaluator stubs in the bridge.
- `runtime.installRemotePlugin(plugin, source)` API (P3).

## Base branch

Stacked on `shaw/p1-remote-plugin-runtime` (PR #7846). Merge order: P0 (#7844) → P1 (#7846) → this PR → P3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers the P2 layer of the plugin/mode unification stack: four platform-specific `PluginHostShim` packages (web/XR iframe, Electrobun, iOS, Android) that give remote-mode view bundles a uniform `request`/`on`/`resolveViewUrl` surface, plus wiring for the two remaining hard surfaces — `service` (opt-in via `static rpcMethods`) and `route` (non-streaming, `routeHandler`-only).

- **Host shims** (`plugin-host-shim`, `-electrobun`, `-ios`, `-android`): Each ~120-LOC package implements the same `PluginHostShim` contract; only the native bridge call differs per platform.
- **Service surface** (`descriptor.ts`): A module-level `WeakMap` lazily starts services on first RPC invocation and caches the instance; `rpcMethods` act as an explicit allowlist so private state is never reachable from the host.
- **Route surface** (`remote-plugin-bridge.ts`, `dispatch.ts`): `makeRouteStub` synthesises a `routeHandler` that serialises `RouteHandlerContext` over worker-rpc; SSE/multipart and action-callback plumbing are deferred to later iterations.

<h3>Confidence Score: 3/5</h3>

The new code is not safe to merge as-is: the web shim accepts responses from any origin, and a permanently-cached rejected service-start promise can make a service unreachable for the lifetime of the worker.

The web shim's message handler never checks event.origin, so a same-origin sibling frame can inject fake RPC responses. The service trampoline caches a rejected start() Promise forever, meaning a single transient startup failure permanently prevents any rpcMethod on that service from succeeding without a full worker restart. The false idempotency claim in installWebShim would cause silent request leaks in hot-reload scenarios.

packages/plugin-host-shim/src/web.ts needs origin validation and idempotency fixes; packages/plugin-worker-runtime/src/descriptor.ts needs the rejected-promise cleanup in the service trampoline.

<details open><summary><h3>Security Review</h3></summary>

- **Cross-origin response injection** (`packages/plugin-host-shim/src/web.ts`): The `window.addEventListener(\"message\", ...)` handler does not validate `event.origin`. Any frame with a JS reference to the view's window (e.g., a same-origin sibling iframe) can post a crafted `elizaos.shim.response` with a guessable incrementing `id` and resolve a pending RPC call with attacker-controlled data. The `parentOrigin` option only guards outgoing messages.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/plugin-host-shim/src/web.ts | Web/XR iframe shim — missing `event.origin` validation on incoming messages (security), and falsely documented as idempotent when it leaks event listeners on repeated calls. |
| packages/plugin-worker-runtime/src/descriptor.ts | Adds service descriptor building and lazy startup trampoline; rejected `service.start()` Promises are cached permanently in the WeakMap, permanently bricking the service until worker restart. |
| packages/plugin-host-shim-electrobun/src/index.ts | Electrobun shim is structurally sound; `isResponse` omits `kind` check present in the other three platform shims, a minor inconsistency. |
| packages/agent/src/services/remote-plugin-bridge.ts | Adds service-class stub synthesis and route stub forwarding; both are straightforward and well-contained additions to the existing bridge wiring pattern. |
| packages/plugin-host-shim-ios/src/index.ts | iOS WKWebView shim; protocol guards include `kind` check, structure mirrors Android cleanly. |
| packages/plugin-host-shim-android/src/index.ts | Android WebView shim; message dispatch and subscriber model are consistent with iOS. |
| packages/plugin-host-shim/src/index.ts | Core contract module — `PluginHostShim` interface, singleton slot, `installHostShim`/`getHostShim`/`resetHostShim`; clean and minimal. |
| packages/plugin-worker-runtime/src/dispatch.ts | Wires the `service` dispatch case; correctly passes `context.runtime` as the first arg to the trampoline and falls back to `[]` for empty method args. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant View as View Bundle
    participant Shim as PluginHostShim
    participant Host as RemotePluginBridge
    participant Worker as Plugin Worker
    participant Service as ServiceMethodTrampoline

    Note over View,Shim: installXShim() called once at bundle load

    View->>Shim: shim.request(method, params)
    Shim->>Host: "postMessage { kind: request, id, method, params }"
    Host->>Worker: workerRpc(surface, rpcId, params)
    Worker-->>Host: JsonValue result
    Host-->>Shim: "{ kind: response, id, ok, payload }"
    Shim-->>View: Promise resolves

    Note over Host,Service: Service surface new in P2

    Host->>Worker: workerRpc(service, rpcId, args)
    Worker->>Service: serviceMethodTrampoline(svc, method, args)
    Note over Service: Lazy start on first call
    Service-->>Worker: method result
    Worker-->>Host: JsonValue

    Note over Host,Worker: Route surface new in P2

    Host->>Worker: workerRpc(route, rpcId, ctx)
    Worker-->>Host: RouteHandlerResult
```

<sub>Reviews (1): Last reviewed commit: ["feat(remote-plugin): wire service and ro..."](https://github.com/elizaos/eliza/commit/141dbc0ca660691e080a4cc77f7839a4bb2044c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33033054)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->