### PR TITLE
feat(plugin): installRemotePlugin API + first sub-agent runner (P3)

### DIFF
--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -792,6 +792,83 @@ export interface RemotePluginConfig {
 	protocol?: { methods?: string[] };
 }
 
+/**
+ * Source of the worker code for a remote-mode plugin installed at runtime
+ * via {@link IAgentRuntime.installRemotePlugin}.
+ *
+ * - `inline`: agent-authored. The plugin's source files (typically the
+ *   worker entry + a manifest) are handed over as a string map. The host
+ *   writes them to a tempdir under `~/.eliza/remote-plugins/<runtime>/
+ *   <pluginName>-<instanceId>/`, then spawns the worker from there. The
+ *   inline path is intentionally restricted: workers run as
+ *   `isolated-process` always, network defaults to `loopback`, and FS
+ *   scopes to the tempdir, regardless of what the manifest requests.
+ *
+ * - `tarball`: third-party. Downloaded + verified by `attestation`
+ *   (required for tarball installs; SHA + signature). Extracted into the
+ *   store and treated like a normal install thereafter.
+ *
+ * - `workspace`: bundled. Resolves to an existing workspace package
+ *   (e.g. `@elizaos/plugin-sub-agent-claude-code`). The host trusts these
+ *   the same way it trusts a direct-mode plugin shipped in node_modules.
+ */
+export type RemotePluginInstallSource =
+	| { kind: "inline"; files: Record<string, string> }
+	| {
+			kind: "tarball";
+			url: string;
+			attestation: { signedBy: string; signature: string };
+	  }
+	| { kind: "workspace"; pkgName: string };
+
+/** Options for {@link IAgentRuntime.installRemotePlugin}. */
+export interface RemotePluginInstallOptions {
+	source: RemotePluginInstallSource;
+	/**
+	 * Override the lifetime declared on the manifest. Default:
+	 * - `"session"` when source is `"inline"` (agent-generated).
+	 * - `"persistent"` when source is `"tarball"` or `"workspace"`.
+	 */
+	lifetime?: "session" | "persistent";
+}
+
+/** Returned by {@link IAgentRuntime.installRemotePlugin}. */
+export interface RemotePluginInstanceHandle {
+	/** The Plugin.name after install. */
+	pluginName: string;
+	/**
+	 * Per-installation id. Multiple installations of the same plugin (e.g.
+	 * two sub-agent sessions) have different instanceIds and live in
+	 * different store directories.
+	 */
+	instanceId: string;
+	/**
+	 * The granted permissions for this installation, after narrowing. May
+	 * be narrower than the requested ceiling in `plugin.remote.permissions`.
+	 */
+	grantedPermissions: RemotePluginPermissions;
+	/** Tear down: stop the worker, unregister the plugin, clean up the store dir if session-lifetime. */
+	uninstall(): Promise<void>;
+}
+
+/**
+ * Thrown by {@link IAgentRuntime.installRemotePlugin} when the plugin's
+ * requested permissions narrow to nothing for at least one critical
+ * capability (e.g. asks for `fs.readwrite` but the agent only has
+ * `fs.readonly`). Caller can catch + prompt the user for elevation.
+ */
+export class PermissionNarrowedRejection extends Error {
+	constructor(
+		message: string,
+		readonly capability: string,
+		readonly requested: unknown,
+		readonly granted: unknown,
+	) {
+		super(message);
+		this.name = "PermissionNarrowedRejection";
+	}
+}
+
 export interface Plugin {
 	name: string;
 	description: string;

--- a/packages/core/src/types/runtime.ts
+++ b/packages/core/src/types/runtime.ts
@@ -48,6 +48,8 @@ import type { PairingAllowlistEntry, PairingRequest } from "./pairing";
 import type {
 	Plugin,
 	PluginOwnership,
+	RemotePluginInstallOptions,
+	RemotePluginInstanceHandle,
 	Route,
 	RuntimeEventStorage,
 	ServiceClass,
@@ -566,6 +568,30 @@ export interface IAgentRuntime extends IDatabaseAdapter<object> {
 	registerPlugin(plugin: Plugin): Promise<void>;
 	unloadPlugin(pluginName: string): Promise<PluginOwnership | null>;
 	reloadPlugin(plugin: Plugin): Promise<void>;
+
+	/**
+	 * Install a remote-mode plugin at runtime. Used both for
+	 * agent-generated plugins (a code-agent sub-plugin writes a Plugin
+	 * object and asks the runtime to materialise it) and for
+	 * user-installed third-party remote plugins shipped as a tarball.
+	 *
+	 * @param plugin   The Plugin object. Must have mode === "remote" and
+	 *                 a valid `remote` config block. Permission requests
+	 *                 in `plugin.remote.permissions` are *ceilings*; the
+	 *                 host narrows them against `runtime.grantedPermissions`
+	 *                 and inline-source defaults at install time.
+	 * @param options  `source` controls where the worker code comes from.
+	 *                 `lifetime` controls cleanup ("session" default for
+	 *                 agent-generated; "persistent" persists across boots).
+	 *                 `attestation` is required for third-party tarballs.
+	 * @returns        A handle to the installation; call `uninstall()` to
+	 *                 tear down (worker stops, plugin unregisters,
+	 *                 store dir cleans up if `lifetime: "session"`).
+	 */
+	installRemotePlugin(
+		plugin: Plugin,
+		options?: RemotePluginInstallOptions,
+	): Promise<RemotePluginInstanceHandle>;
 	applyPluginConfig(
 		pluginName: string,
 		config: Record<string, string>,

--- a/packages/plugin-sub-agent-claude-code/package.json
+++ b/packages/plugin-sub-agent-claude-code/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@elizaos/plugin-sub-agent-claude-code",
+  "version": "0.0.1",
+  "description": "Reference remote-mode sub-agent plugin: drives the Claude Code CLI inside an isolated Bun subprocess and exposes session/prompt/output/terminate via host-callable service methods.",
+  "type": "module",
+  "main": "./dist/plugin.js",
+  "license": "MIT",
+  "private": true,
+  "files": ["dist"],
+  "scripts": {
+    "clean": "rm -rf dist",
+    "build": "rm -rf dist tsconfig.build.tsbuildinfo && tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "bun test src/",
+    "lint": "bunx @biomejs/biome check src",
+    "lint:fix": "bunx @biomejs/biome check --write src"
+  },
+  "dependencies": {
+    "@elizaos/plugin-remote-manifest": "workspace:*",
+    "@elizaos/plugin-worker-runtime": "workspace:*"
+  },
+  "devDependencies": {
+    "bun-types": "^1.3.12",
+    "typescript": "^6.0.3"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/plugin.d.ts",
+      "import": "./dist/plugin.js",
+      "default": "./dist/plugin.js"
+    },
+    "./worker": {
+      "types": "./dist/worker.d.ts",
+      "import": "./dist/worker.js",
+      "default": "./dist/worker.js"
+    }
+  }
+}

--- a/packages/plugin-sub-agent-claude-code/src/plugin.ts
+++ b/packages/plugin-sub-agent-claude-code/src/plugin.ts
@@ -1,0 +1,74 @@
+/**
+ * @elizaos/plugin-sub-agent-claude-code
+ *
+ * Reference remote-mode sub-agent plugin. Shipped as a workspace
+ * package so the agent's `installRemotePlugin(plugin, { source: {
+ * kind: "workspace", pkgName: "@elizaos/plugin-sub-agent-claude-code"
+ * } })` can drop it in without writing any worker source on the fly.
+ *
+ * The agent typically constructs the Plugin object like:
+ *
+ * ```ts
+ * import { plugin } from "@elizaos/plugin-sub-agent-claude-code";
+ * await runtime.installRemotePlugin(plugin, {
+ *   source: { kind: "workspace", pkgName: "@elizaos/plugin-sub-agent-claude-code" },
+ *   lifetime: "session",
+ * });
+ * await runtime.getService("sub-agent.claude-code").createSession({
+ *   cwd: "/path/to/project",
+ *   initialPrompt: "list files in src/",
+ * });
+ * ```
+ *
+ * The plugin opts into `role: "sub-agent"` and `isolation: "isolated-process"`
+ * so the host's AdaptiveWorkerRunner spawns it via Bun.spawn rather than as
+ * a Worker. That guarantees a crash in the Claude Code CLI doesn't bring
+ * down the agent process.
+ */
+
+import { ClaudeCodeSubAgentService } from "./sub-agent-service.ts";
+
+// We intentionally use loose typing for the Plugin shape rather than
+// pulling in @elizaos/core (which would force a heavyweight dep tree
+// onto every sub-agent runner). The runtime materialises this through
+// the worker-runtime descriptor builder, which validates structurally.
+export const plugin = {
+	name: "@elizaos/plugin-sub-agent-claude-code",
+	description:
+		"Drives the Claude Code CLI as a sub-agent inside an isolated subprocess.",
+	mode: "remote" as const,
+	services: [ClaudeCodeSubAgentService],
+	remote: {
+		role: "sub-agent" as const,
+		permissions: {
+			bun: {
+				network: "allowlist" as const,
+				networkAllowlist: ["api.anthropic.com"],
+				fs: "readwrite" as const,
+				fsAllowlist: ["."],
+				process: true,
+				env: ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"],
+			},
+			host: {
+				services: [],
+				models: [],
+				events: ["sub-agent.session.created", "sub-agent.session.terminated"],
+				memory: "none" as const,
+			},
+		},
+		isolation: "isolated-process" as const,
+		worker: { relativePath: "dist/worker.js" },
+		deployment: {
+			preferred: "auto" as const,
+			allowedTargets: ["host", "cloud"] as ("host" | "cloud")[],
+			requiresProcess: true,
+		},
+		lifetime: "session" as const,
+		subAgent: {
+			runner: "claude-code" as const,
+			promptInjection: "stdin-only" as const,
+		},
+	},
+};
+
+export default plugin;

--- a/packages/plugin-sub-agent-claude-code/src/sub-agent-service.ts
+++ b/packages/plugin-sub-agent-claude-code/src/sub-agent-service.ts
@@ -1,0 +1,200 @@
+/**
+ * ClaudeCodeSubAgentService — spawns `claude` CLI as a subprocess and
+ * exposes session/prompt/output/terminate over host-RPC.
+ *
+ * Each session is a long-lived `Bun.spawn` of the claude-code binary
+ * with stdin/stdout piped. Prompts are written to stdin; output is
+ * line-streamed back. The service caches sessions by id and tears them
+ * down on `terminate()` or worker shutdown.
+ *
+ * This is a *reference* implementation. The full real-world version
+ * needs PTY (not raw stdin/stdout) so the CLI's interactive features
+ * work; `Bun.spawn({ stdin: 'pipe', stdout: 'pipe' })` is good enough
+ * for the prompt-and-collect pattern but not for editing tools.
+ */
+
+import type { JsonValue } from "@elizaos/plugin-remote-manifest";
+
+export interface ClaudeCodeSession {
+	sessionId: string;
+	createdAt: number;
+	cwd: string;
+	model?: string;
+	binary: string;
+	proc: ReturnType<typeof Bun.spawn>;
+	output: string[];
+}
+
+export interface CreateSessionParams {
+	cwd: string;
+	model?: string;
+	/** Override the claude CLI binary name/path. Default: "claude". */
+	binary?: string;
+	/** Initial prompt to send after the session boots. */
+	initialPrompt?: string;
+}
+
+export interface SendPromptParams {
+	sessionId: string;
+	prompt: string;
+}
+
+export interface GetOutputParams {
+	sessionId: string;
+	/** Drain mode: return all output, or just the new lines since last call. */
+	mode?: "all" | "since-last";
+}
+
+export interface TerminateParams {
+	sessionId: string;
+}
+
+export class ClaudeCodeSubAgentService {
+	static readonly serviceType = "sub-agent.claude-code";
+	static readonly rpcMethods = [
+		"createSession",
+		"sendPrompt",
+		"getOutput",
+		"terminate",
+		"listSessions",
+	] as const;
+	static readonly capabilityDescription =
+		"Drives the Claude Code CLI in an isolated subprocess.";
+
+	readonly capabilityDescription = ClaudeCodeSubAgentService.capabilityDescription;
+
+	private readonly sessions = new Map<string, ClaudeCodeSession>();
+	private readonly outputCursors = new Map<string, number>();
+	private nextSessionId = 1;
+
+	static async start(_runtime: unknown): Promise<ClaudeCodeSubAgentService> {
+		return new ClaudeCodeSubAgentService();
+	}
+
+	async stop(): Promise<void> {
+		for (const session of this.sessions.values()) {
+			try {
+				session.proc.kill("SIGTERM");
+			} catch {
+				// already dead
+			}
+		}
+		this.sessions.clear();
+		this.outputCursors.clear();
+	}
+
+	async createSession(params: CreateSessionParams): Promise<JsonValue> {
+		const sessionId = `cc-${this.nextSessionId++}-${Date.now()}`;
+		const binary = params.binary ?? "claude";
+		const args = ["--print"];
+		if (params.model) args.push("--model", params.model);
+
+		const proc = Bun.spawn({
+			cmd: [binary, ...args],
+			stdin: "pipe",
+			stdout: "pipe",
+			stderr: "pipe",
+			cwd: params.cwd,
+		});
+
+		const session: ClaudeCodeSession = {
+			sessionId,
+			createdAt: Date.now(),
+			cwd: params.cwd,
+			...(params.model ? { model: params.model } : {}),
+			binary,
+			proc,
+			output: [],
+		};
+		this.sessions.set(sessionId, session);
+		this.outputCursors.set(sessionId, 0);
+
+		// Pump stdout into the session's output buffer.
+		void this.pumpStdout(session);
+
+		if (params.initialPrompt) {
+			await this.sendPrompt({ sessionId, prompt: params.initialPrompt });
+		}
+
+		return { sessionId, createdAt: session.createdAt };
+	}
+
+	async sendPrompt(params: SendPromptParams): Promise<JsonValue> {
+		const session = this.requireSession(params.sessionId);
+		const writer = session.proc.stdin as unknown as {
+			write(data: string): void;
+		};
+		writer.write(`${params.prompt}\n`);
+		return { ok: true };
+	}
+
+	async getOutput(params: GetOutputParams): Promise<JsonValue> {
+		const session = this.requireSession(params.sessionId);
+		const mode = params.mode ?? "since-last";
+		if (mode === "all") {
+			return { lines: [...session.output] };
+		}
+		const cursor = this.outputCursors.get(params.sessionId) ?? 0;
+		const newLines = session.output.slice(cursor);
+		this.outputCursors.set(params.sessionId, session.output.length);
+		return { lines: newLines };
+	}
+
+	async terminate(params: TerminateParams): Promise<JsonValue> {
+		const session = this.sessions.get(params.sessionId);
+		if (!session) return { terminated: false };
+		try {
+			session.proc.kill("SIGTERM");
+		} catch {
+			// already dead
+		}
+		this.sessions.delete(params.sessionId);
+		this.outputCursors.delete(params.sessionId);
+		return { terminated: true };
+	}
+
+	async listSessions(): Promise<JsonValue> {
+		return {
+			sessions: Array.from(this.sessions.values()).map((s) => ({
+				sessionId: s.sessionId,
+				createdAt: s.createdAt,
+				cwd: s.cwd,
+				model: s.model ?? null,
+			})),
+		};
+	}
+
+	private requireSession(id: string): ClaudeCodeSession {
+		const session = this.sessions.get(id);
+		if (!session) throw new Error(`Unknown session: ${id}`);
+		return session;
+	}
+
+	private async pumpStdout(session: ClaudeCodeSession): Promise<void> {
+		if (!session.proc.stdout) return;
+		const reader = (
+			session.proc.stdout as unknown as ReadableStream<Uint8Array>
+		).getReader();
+		const decoder = new TextDecoder();
+		let buffer = "";
+		try {
+			// eslint-disable-next-line no-constant-condition
+			while (true) {
+				const { value, done } = await reader.read();
+				if (done) break;
+				if (!value) continue;
+				buffer += decoder.decode(value, { stream: true });
+				let nl = buffer.indexOf("\n");
+				while (nl !== -1) {
+					const line = buffer.slice(0, nl);
+					buffer = buffer.slice(nl + 1);
+					session.output.push(line);
+					nl = buffer.indexOf("\n");
+				}
+			}
+			if (buffer.length > 0) session.output.push(buffer);
+		} finally {
+			reader.releaseLock?.();
+		}
+	}
+}

--- a/packages/plugin-sub-agent-claude-code/src/worker.ts
+++ b/packages/plugin-sub-agent-claude-code/src/worker.ts
@@ -1,0 +1,11 @@
+/**
+ * Worker entrypoint. Bootstrap simply hands the Plugin object to
+ * @elizaos/plugin-worker-runtime and lets the announce/dispatch loop
+ * take over. The Service inside `plugin.services[0]` is started lazily
+ * on first method invocation via the service trampoline.
+ */
+
+import { bootstrap } from "@elizaos/plugin-worker-runtime";
+import { plugin } from "./plugin.ts";
+
+await bootstrap(plugin);

--- a/packages/plugin-sub-agent-claude-code/tsconfig.build.json
+++ b/packages/plugin-sub-agent-claude-code/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "noEmit": false },
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__/**"]
+}

--- a/packages/plugin-sub-agent-claude-code/tsconfig.json
+++ b/packages/plugin-sub-agent-claude-code/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["bun-types"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": true,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
P3 of the **Plugin/mode unification**, stacked on PR #7847.

Where P0 set the vocabulary, P1 wired the runtime, and P2 added view-host shims + service/route surfaces, **P3 ships the API for agent-generated plugins** plus the first reference sub-agent runner that demonstrates the full stack working end-to-end.

## Commits

| Commit | Scope |
|---|---|
| `feat(core): runtime.installRemotePlugin API + permission types` | New types: `RemotePluginInstallSource` (inline / tarball / workspace), `RemotePluginInstallOptions`, `RemotePluginInstanceHandle`, `PermissionNarrowedRejection`. New `installRemotePlugin(plugin, options?)` method on `IAgentRuntime`. |
| `feat(plugin-sub-agent-claude-code): reference remote sub-agent runner` | Workspace package `@elizaos/plugin-sub-agent-claude-code`. Drives the `claude` CLI in an isolated Bun subprocess, exposes session/prompt/output/terminate via host-callable service methods. |

## The complete data flow this enables

Agent decides it needs a Claude Code sub-agent:

```ts
import { plugin } from \"@elizaos/plugin-sub-agent-claude-code\";

await runtime.installRemotePlugin(plugin, {
  source: { kind: \"workspace\", pkgName: \"@elizaos/plugin-sub-agent-claude-code\" },
  lifetime: \"session\",
});

const svc = runtime.getService(\"sub-agent.claude-code\");
const { sessionId } = await svc.createSession({
  cwd: \"/path/to/project\",
  initialPrompt: \"list files in src/\",
});
// later
const { lines } = await svc.getOutput({ sessionId });
await svc.terminate({ sessionId });
```

What happens under the hood, in order:

1. `installRemotePlugin` validates `mode === \"remote\"`, narrows the requested permissions against the agent's grants, picks the deployment target (local host vs Eliza Cloud container), and hands the resolved plugin to `RemotePluginHost`.
2. `AdaptiveWorkerRunner` sees `isolation: \"isolated-process\"` and uses `IsolatedProcessWorkerRunner` → `Bun.spawn` → **subprocess #1** running the worker entry.
3. Worker's `bootstrap()` walks the Plugin object, sends `worker-announce-plugin`. Bridge materialises a `RemoteServiceProxy` with methods `[createSession, sendPrompt, getOutput, terminate, listSessions]` and `runtime.registerPlugin(...)`.
4. Agent code calls `svc.createSession(...)` → bridge `worker-rpc surface=service` → worker dispatcher → `ClaudeCodeSubAgentService.createSession(params)` → **subprocess #2** = `Bun.spawn` of the `claude` CLI inside the worker's already-isolated process.

Two-tier subprocess isolation: the CLI crashing can't reach the worker; the worker crashing can't reach the agent.

## Permission narrowing

The plugin requests:

| Capability | Requested | Default for `workspace` source | Granted |
|---|---|---|---|
| `bun.network` | `allowlist` ∩ `[api.anthropic.com]` | (no extra defaults for workspace) | request as-is |
| `bun.fs` | `readwrite` ∩ `[.]` | (no extra defaults for workspace) | request as-is |
| `bun.process` | `true` | (no extra defaults for workspace) | `true` |
| `bun.env` | `[ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN]` | (no extra defaults for workspace) | request ∩ agent grant |
| `isolation` | `isolated-process` | (no extra defaults for workspace) | `isolated-process` |

If the source had been `kind: \"inline\"` (agent-generated), the defaults would tighten:
- `isolation` forced to `isolated-process` (already)
- `bun.network` defaults to `loopback` (overrides request)
- `bun.fs` defaults to tempdir-only

## Sibling sub-agent plugins

`-codex`, `-opencode`, `-eliza` follow the same template; only the CLI binary, the network allowlist, and the prompt-injection mode differ. Building them is a small follow-up — the proof of pattern is in `plugin-sub-agent-claude-code`.

## What's still TODO

- The actual `installRemotePlugin` implementation in `@elizaos/agent` (this PR ships the *type signature* on `IAgentRuntime`; a concrete `RemotePluginInstaller` class that materialises sources to disk and orchestrates `RemotePluginHost.installFromDirectory` + `RemotePluginBridge.attach` lands as a P3 follow-up).
- A PTY-backed sub-agent runner for the interactive CLIs (the current pipe-based runner is fine for `claude --print` but not for editing tools).
- The other three sub-agent runner packages.
- Cross-device deployment-target inference in `RuntimeCapabilityService` (forward decl exists in P0 — wire-up is P3 follow-up).
- Hot-reload symmetry: `unregisterPlugin` cleanup parity between direct and remote.

## Base branch

Stacked on `shaw/p2-view-host-and-surfaces` (PR #7847). Merge order: P0 (#7844) → P1 (#7846) → P2 (#7847) → this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the `installRemotePlugin` API on `IAgentRuntime` (types only; concrete implementation is deferred) and ships `@elizaos/plugin-sub-agent-claude-code`, the first reference sub-agent plugin that drives the Claude CLI as a Bun subprocess with session/prompt/output/terminate exposed over host-RPC.

- **Core types** (`plugin.ts`, `runtime.ts`): adds `RemotePluginInstallSource` (inline/tarball/workspace), `RemotePluginInstallOptions`, `RemotePluginInstanceHandle`, `PermissionNarrowedRejection`, and the `installRemotePlugin` method signature on `IAgentRuntime`.
- **Sub-agent service** (`sub-agent-service.ts`): spawns the `claude` CLI as a `Bun.spawn` child process with piped stdin/stdout, line-buffers output, and exposes `createSession / sendPrompt / getOutput / terminate / listSessions` over RPC.
- **Worker + plugin manifests**: minimal worker entrypoint delegates to `@elizaos/plugin-worker-runtime`, and the plugin object declares permissions, isolation mode, and deployment constraints.

<h3>Confidence Score: 3/5</h3>

The core type changes are safe, but the sub-agent service has a pipe-deadlock bug that will surface in real use, and the tarball attestation type is structurally incomplete for secure installs.

The stderr pipe is never drained, which will cause the Claude CLI subprocess to deadlock once it fills the OS buffer — a real, reproducible failure on any long-running or verbose session. The tarball attestation type omits the content hash field that its own JSDoc promises, meaning any implementation will silently skip hash verification.

packages/plugin-sub-agent-claude-code/src/sub-agent-service.ts needs the most attention — stderr drain, stdin null-guard, binary validation, and output buffer cap. packages/core/src/types/plugin.ts needs the sha256 field added to the tarball attestation struct.

<details open><summary><h3>Security Review</h3></summary>

- **Missing content hash in tarball attestation** (`packages/core/src/types/plugin.ts`): the `tarball` variant's `attestation` object carries only `signedBy` and `signature` — no `sha256` or equivalent hash. The JSDoc promises hash verification but the type can't represent it, meaning any concrete installer will silently omit the hash check.
- **Arbitrary binary execution via `binary` RPC parameter** (`sub-agent-service.ts`, `createSession`): the caller-supplied `binary` field is passed directly to `Bun.spawn` without any allowlist. Any RPC consumer with access to `createSession` can execute an arbitrary binary within the worker's permission context.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/plugin-sub-agent-claude-code/src/sub-agent-service.ts | Core service implementation with four defects: stderr pipe never drained (deadlock risk), unchecked binary parameter, no stdin null-guard in sendPrompt, and unbounded output buffer accumulation. |
| packages/core/src/types/plugin.ts | Adds RemotePluginInstallSource, RemotePluginInstallOptions, RemotePluginInstanceHandle, and PermissionNarrowedRejection types. Tarball attestation struct is missing a sha256 content-hash field despite the JSDoc promising SHA verification. |
| packages/core/src/types/runtime.ts | Adds installRemotePlugin method signature to IAgentRuntime interface; straightforward and correct. |
| packages/plugin-sub-agent-claude-code/src/plugin.ts | Declares the plugin manifest with permissions and remote config; looks correct. The fsAllowlist of '.' is intentionally broad for a workspace-sourced trusted plugin. |
| packages/plugin-sub-agent-claude-code/src/worker.ts | Minimal worker entrypoint; delegates everything to bootstrap — correct pattern. |
| packages/plugin-sub-agent-claude-code/package.json | Package metadata with workspace dependencies; marked private. Uses typescript ^6.0.3 which may not yet be stable — verify this is intentional. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant IAgentRuntime
    participant RemotePluginHost
    participant WorkerProcess as Worker Process (Bun.spawn #1)
    participant ClaudeCodeSubAgentService
    participant ClaudeCLI as Claude CLI (Bun.spawn #2)

    Agent->>IAgentRuntime: "installRemotePlugin(plugin, { source: workspace })"
    IAgentRuntime->>RemotePluginHost: narrow permissions, pick deployment target
    RemotePluginHost->>WorkerProcess: Bun.spawn(worker entry)
    WorkerProcess->>IAgentRuntime: worker-announce-plugin
    IAgentRuntime-->>Agent: RemotePluginInstanceHandle

    Agent->>IAgentRuntime: getService(sub-agent.claude-code).createSession(params)
    IAgentRuntime->>WorkerProcess: "RPC worker-rpc surface=service"
    WorkerProcess->>ClaudeCodeSubAgentService: createSession(params)
    ClaudeCodeSubAgentService->>ClaudeCLI: Bun.spawn([claude, --print])
    ClaudeCodeSubAgentService-->>Agent: "{ sessionId }"

    Agent->>IAgentRuntime: "svc.sendPrompt({ sessionId, prompt })"
    IAgentRuntime->>WorkerProcess: RPC
    WorkerProcess->>ClaudeCodeSubAgentService: sendPrompt
    ClaudeCodeSubAgentService->>ClaudeCLI: write to stdin pipe
    ClaudeCLI-->>ClaudeCodeSubAgentService: stdout lines (pumpStdout loop)

    Agent->>IAgentRuntime: "svc.getOutput({ sessionId })"
    IAgentRuntime->>WorkerProcess: RPC
    WorkerProcess->>ClaudeCodeSubAgentService: getOutput
    ClaudeCodeSubAgentService-->>Agent: "{ lines: [...] }"

    Agent->>IAgentRuntime: "svc.terminate({ sessionId })"
    IAgentRuntime->>WorkerProcess: RPC
    WorkerProcess->>ClaudeCodeSubAgentService: terminate
    ClaudeCodeSubAgentService->>ClaudeCLI: SIGTERM
```

<sub>Reviews (1): Last reviewed commit: ["feat(plugin-sub-agent-claude-code): refe..."](https://github.com/elizaos/eliza/commit/97340e891e917a79e10f365803adb447eebba5fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33034524)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->