### PR TITLE
feat(plugin-x): OWNER+AGENT roles end-to-end via Eliza Cloud OAuth

### DIFF
--- a/packages/app-core/src/registry/entries/connectors/x.json
+++ b/packages/app-core/src/registry/entries/connectors/x.json
@@ -213,5 +213,25 @@
       "TWITTER_BROKER_URL",
       "TWITTER_BROKER_TOKEN"
     ]
+  },
+  "accounts": {
+    "owner": {
+      "supported": true,
+      "authKind": "oauth-cloud",
+      "credentialKeys": [
+        "TWITTER_BROKER_URL",
+        "TWITTER_BROKER_TOKEN"
+      ],
+      "notes": "The user's own X account, connected via Eliza Cloud OAuth so the agent can post / reply / DM on the user's behalf."
+    },
+    "agent": {
+      "supported": true,
+      "authKind": "oauth-cloud",
+      "credentialKeys": [
+        "TWITTER_BROKER_URL",
+        "TWITTER_BROKER_TOKEN"
+      ],
+      "notes": "A separate X account that represents the agent's own identity. Same OAuth flow, different X account at the OAuth screen."
+    }
   }
 }

--- a/packages/ui/src/components/pages/plugin-view-connectors.tsx
+++ b/packages/ui/src/components/pages/plugin-view-connectors.tsx
@@ -108,17 +108,41 @@ interface ConnectorPluginCardProps
 
 type CloudOAuthConnectorCopy = {
   platform: "slack" | "twitter";
-  connectionRole: CloudOAuthConnectionRole;
+  /**
+   * Roles the user can connect for this platform. A single-entry array
+   * renders one button (legacy behavior); a two-entry array (e.g.
+   * `["agent", "owner"]`) renders one button per role so the user can
+   * connect the agent's own account AND their own platform account
+   * independently. The cloud OAuth callback honors `connectionRole` and
+   * stores each grant under the right role in `platform_credentials`.
+   */
+  connectionRoles: CloudOAuthConnectionRole[];
   buttonLabel: string;
   connectedHint: string;
   disconnectedHint: string;
   successNotice: string;
 };
 
+const ROLE_BUTTON_SUFFIX: Record<CloudOAuthConnectionRole, string> = {
+  agent: "(agent)",
+  owner: "(your account)",
+};
+
+function buildRoleButtonLabel(
+  baseLabel: string,
+  role: CloudOAuthConnectionRole,
+  showRoleSuffix: boolean,
+): string {
+  if (!showRoleSuffix) {
+    return baseLabel;
+  }
+  return `${baseLabel} ${ROLE_BUTTON_SUFFIX[role]}`;
+}
+
 const CLOUD_OAUTH_CONNECTORS: Record<string, CloudOAuthConnectorCopy> = {
   slack: {
     platform: "slack",
-    connectionRole: "agent",
+    connectionRoles: ["agent"],
     buttonLabel: "Use Slack OAuth",
     connectedHint:
       "Connect Slack with Eliza Cloud OAuth. Cloud stores the workspace token and the Slack plugin remains the runtime surface for messages and actions.",
@@ -128,10 +152,10 @@ const CLOUD_OAUTH_CONNECTORS: Record<string, CloudOAuthConnectorCopy> = {
   },
   twitter: {
     platform: "twitter",
-    connectionRole: "agent",
+    connectionRoles: ["agent", "owner"],
     buttonLabel: "Use X/Twitter OAuth",
     connectedHint:
-      "Connect X/Twitter with Eliza Cloud OAuth so agent posts, mentions, replies, and DMs use the plugin through cloud-held tokens.",
+      "Connect X/Twitter with Eliza Cloud OAuth. Use 'agent' to link the agent's own X account for autonomous posts and DMs; use 'your account' to grant the agent permission to act on your own X account.",
     disconnectedHint:
       "Connect Eliza Cloud first to use X/Twitter OAuth instead of local developer tokens.",
     successNotice: "Finish X/Twitter OAuth in your browser, then return here.",
@@ -498,7 +522,9 @@ function ConnectorPluginCard({
       setManagedDiscordBusy(false);
     }
   };
-  const handleOpenCloudOAuthConnector = async () => {
+  const handleOpenCloudOAuthConnector = async (
+    connectionRole: CloudOAuthConnectionRole,
+  ) => {
     if (!cloudOAuthConnector || cloudOAuthBusy) {
       return;
     }
@@ -525,11 +551,11 @@ function ConnectorPluginCard({
         cloudOAuthConnector.platform === "twitter"
           ? await client.initiateCloudTwitterOauth({
               redirectUrl,
-              connectionRole: cloudOAuthConnector.connectionRole,
+              connectionRole,
             })
           : await client.initiateCloudOauth(cloudOAuthConnector.platform, {
               redirectUrl,
-              connectionRole: cloudOAuthConnector.connectionRole,
+              connectionRole,
             });
 
       await handleOpenPluginExternalUrl(oauthResponse.authUrl);
@@ -794,23 +820,32 @@ function ConnectorPluginCard({
             tone="default"
             className="mb-4"
             actions={
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-8 rounded-[var(--radius-lg)] px-4 text-xs-tight font-semibold"
-                onClick={() => {
-                  void handleOpenCloudOAuthConnector();
-                }}
-                disabled={cloudOAuthBusy}
-              >
-                {cloudOAuthBusy
-                  ? "..."
-                  : elizaCloudConnected
-                    ? cloudOAuthConnector.buttonLabel
-                    : t("pluginsview.OpenElizaCloud", {
-                        defaultValue: "Open Eliza Cloud",
-                      })}
-              </Button>
+              <div className="flex flex-wrap items-center gap-2">
+                {cloudOAuthConnector.connectionRoles.map((role) => (
+                  <Button
+                    key={role}
+                    variant="outline"
+                    size="sm"
+                    className="h-8 rounded-[var(--radius-lg)] px-4 text-xs-tight font-semibold"
+                    onClick={() => {
+                      void handleOpenCloudOAuthConnector(role);
+                    }}
+                    disabled={cloudOAuthBusy}
+                  >
+                    {cloudOAuthBusy
+                      ? "..."
+                      : elizaCloudConnected
+                        ? buildRoleButtonLabel(
+                            cloudOAuthConnector.buttonLabel,
+                            role,
+                            cloudOAuthConnector.connectionRoles.length > 1,
+                          )
+                        : t("pluginsview.OpenElizaCloud", {
+                            defaultValue: "Open Eliza Cloud",
+                          })}
+                  </Button>
+                ))}
+              </div>
             }
           >
             {elizaCloudConnected


### PR DESCRIPTION
## Summary

Lights up the OWNER side of plugin-x so users can connect both the agent's own X account (AGENT, existing behavior) and the user's own X account (OWNER, new) through the same Eliza Cloud OAuth gateway. This is the first per-plugin migration to the OWNER+AGENT registry schema (#7838 follow-up to #7817) and the dual-button UI pattern that the rest of the connectors will follow.

The cloud side has already accepted \`connectionRole: \"agent\" | \"owner\"\` on \`/api/v1/twitter/connect\` for some time. plugin-x's \`connector-account-provider.ts\` already reads the role from OAuth metadata via its existing \`roleFromMetadata\` helper (lines 202-222). The missing pieces were the manifest declaration and the UI surface.

### Files changed

- **\`packages/app-core/src/registry/entries/connectors/x.json\`** — adds the \`accounts: { owner, agent }\` block introduced by the registry schema. Both sides use the \`oauth-cloud\` auth kind through the same broker; the distinction is purely which X account the user signs in with at the OAuth screen.

- **\`packages/ui/src/components/pages/plugin-view-connectors.tsx\`** — promotes \`connectionRole\` from a single hardcoded value to a \`connectionRoles: CloudOAuthConnectionRole[]\` array. The render path maps over the roles and emits one button per role, with a suffix (\`(agent)\` / \`(your account)\`) when more than one is present. Slack keeps a single-button render until plugin-slack lands its bot+user-token split (separate PR coming). \`handleOpenCloudOAuthConnector\` now takes a \`connectionRole\` argument so each click routes the right role into \`client.initiateCloudTwitterOauth\` and the resulting connection lands under the correct role in \`platform_credentials\`.

End-state UX: the X connector card shows two buttons \`Use X/Twitter OAuth (agent)\` and \`(your account)\`. Each opens its own OAuth tab; the resulting tokens are stored as distinct connections, queryable via the connector account manager by \`role\`.

## Test plan

- [x] Typecheck clean for both modified files (no errors against the rest of the monorepo's pre-existing issues)
- [ ] Functional verification: with #7838 (schema), #7839 (UI partition), and #7841 (OAuth role helper) merged, walking through the X connector card on Eliza Cloud should now expose two buttons, and clicking each lands a distinct \`platform_credentials\` row with the expected \`source_context.connectionRole\` value.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up the OWNER role for the X connector end-to-end: the registry manifest gains an `accounts` block declaring both `owner` and `agent` connections, and the UI promotes `connectionRole` to a `connectionRoles` array so the connector card renders one OAuth button per role with appropriate suffix labels.

- **`x.json`** — adds `accounts.owner` and `accounts.agent` entries, both pointing at the same `oauth-cloud` auth kind and broker credential keys, aligning with the schema introduced in #7838.
- **`plugin-view-connectors.tsx`** — replaces the single hardcoded `connectionRole` with a `connectionRoles` array, maps over it to render per-role buttons, introduces `buildRoleButtonLabel` for suffix display, and threads the chosen role into `initiateCloudTwitterOauth` / `initiateCloudOauth` so each grant lands under the correct role in `platform_credentials`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changed paths are additive and the OAuth routing logic is straightforward.

The registry change is purely additive JSON with no runtime risk. The UI change correctly threads the chosen role into the OAuth call. Two edge cases worth a follow-up: when not yet connected to Eliza Cloud both buttons render with the same "Open Eliza Cloud" label (harmless but confusing), and the shared busy flag blankets both buttons with "..." so the user can't tell which role's flow is in progress.

packages/ui/src/components/pages/plugin-view-connectors.tsx — the disconnected-state button labels and busy-state attribution are worth a second look before extending the multi-role pattern to other connectors.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/pages/plugin-view-connectors.tsx | Promotes `connectionRole` to a `connectionRoles` array, maps over roles to render one button each, and adds `buildRoleButtonLabel` for role suffixing. Two UX edge cases: both buttons show identical "Open Eliza Cloud" labels when not connected, and the shared `cloudOAuthBusy` flag doesn't distinguish which role is in flight. |
| packages/app-core/src/registry/entries/connectors/x.json | Adds the `accounts` block with `owner` and `agent` entries, both using `oauth-cloud` auth kind and the same broker credential keys. Schema addition looks correct and consistent with the existing `auth` block. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant UI as plugin-view-connectors
    participant Cloud as Eliza Cloud OAuth
    participant Broker as Twitter Broker
    participant DB as platform_credentials

    User->>UI: Click "Use X/Twitter OAuth (agent)"
    UI->>Cloud: "initiateCloudTwitterOauth({ connectionRole: "agent" })"
    Cloud-->>UI: "{ authUrl }"
    UI->>User: Open OAuth tab
    User->>Cloud: Complete X login (agent account)
    Cloud->>Broker: Exchange code, store token
    Broker->>DB: "Upsert row (role=agent)"
    Cloud-->>UI: Redirect back

    User->>UI: Click "Use X/Twitter OAuth (your account)"
    UI->>Cloud: "initiateCloudTwitterOauth({ connectionRole: "owner" })"
    Cloud-->>UI: "{ authUrl }"
    UI->>User: Open OAuth tab
    User->>Cloud: Complete X login (personal account)
    Cloud->>Broker: Exchange code, store token
    Broker->>DB: "Upsert row (role=owner)"
    Cloud-->>UI: Redirect back
```

<sub>Reviews (1): Last reviewed commit: ["feat(plugin-x): OWNER+AGENT roles end-to..."](https://github.com/elizaos/eliza/commit/fa7a63afd6a0c1c7c95f909843a172c998e54daa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33038257)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->