### PR TITLE
feat(plugin-google): OWNER+AGENT roles end-to-end via Eliza Cloud OAuth

### DIFF
--- a/packages/app-core/src/registry/entries/connectors/google.json
+++ b/packages/app-core/src/registry/entries/connectors/google.json
@@ -1,0 +1,74 @@
+{
+  "id": "google",
+  "name": "Google",
+  "description": "Google connector for Gmail, Calendar, Drive, and Meet through one OAuth grant. Uses Eliza Cloud OAuth by default; falls back to local OAuth2 with developer credentials when GOOGLE_CLIENT_ID/SECRET are set on the agent.",
+  "npmName": "@elizaos/plugin-google",
+  "version": "2.0.0-beta.0",
+  "source": "bundled",
+  "tags": ["connector", "productivity", "google", "gmail", "calendar", "drive", "meet"],
+  "config": {
+    "GOOGLE_CLIENT_ID": {
+      "type": "string",
+      "required": false,
+      "sensitive": false,
+      "label": "OAuth Client ID",
+      "help": "Google OAuth2 client ID for local-OAuth fallback. Not needed when using Eliza Cloud OAuth.",
+      "advanced": true
+    },
+    "GOOGLE_CLIENT_SECRET": {
+      "type": "secret",
+      "required": false,
+      "sensitive": true,
+      "label": "OAuth Client Secret",
+      "help": "Google OAuth2 client secret for local-OAuth fallback. Not needed when using Eliza Cloud OAuth.",
+      "advanced": true
+    },
+    "GOOGLE_REDIRECT_URI": {
+      "type": "url",
+      "required": false,
+      "sensitive": false,
+      "label": "Redirect URI",
+      "help": "OAuth2 redirect URI for local-OAuth fallback. A loopback URL is recommended for local auth.",
+      "advanced": true
+    }
+  },
+  "render": {
+    "visible": true,
+    "pinTo": [],
+    "style": "setup-panel",
+    "icon": "Mail",
+    "group": "connector",
+    "groupOrder": 1,
+    "actions": ["enable", "configure", "setup-guide"]
+  },
+  "resources": {
+    "homepage": "https://github.com/elizaos-plugins/plugin-google#readme",
+    "repository": "https://github.com/elizaos-plugins/plugin-google",
+    "setupGuideUrl": "https://github.com/elizaos-plugins/plugin-google#readme"
+  },
+  "dependsOn": [],
+  "kind": "connector",
+  "subtype": "email",
+  "auth": {
+    "kind": "oauth",
+    "credentialKeys": [
+      "GOOGLE_CLIENT_ID",
+      "GOOGLE_CLIENT_SECRET",
+      "GOOGLE_REDIRECT_URI"
+    ]
+  },
+  "accounts": {
+    "owner": {
+      "supported": true,
+      "authKind": "oauth-cloud",
+      "credentialKeys": [],
+      "notes": "The user's own Google account, connected via Eliza Cloud OAuth so the agent can read and act on the user's Gmail, Calendar, Drive, and Meet on the user's behalf."
+    },
+    "agent": {
+      "supported": true,
+      "authKind": "oauth-cloud",
+      "credentialKeys": [],
+      "notes": "A separate Google account that represents the agent's own identity. Same OAuth flow, different Google account at the OAuth screen."
+    }
+  }
+}

--- a/packages/ui/src/components/pages/plugin-view-connectors.tsx
+++ b/packages/ui/src/components/pages/plugin-view-connectors.tsx
@@ -107,7 +107,7 @@ interface ConnectorPluginCardProps
 }
 
 type CloudOAuthConnectorCopy = {
-  platform: "slack" | "twitter";
+  platform: "slack" | "twitter" | "google";
   /**
    * Roles the user can connect for this platform. A single-entry array
    * renders one button (legacy behavior); a two-entry array (e.g.
@@ -159,6 +159,16 @@ const CLOUD_OAUTH_CONNECTORS: Record<string, CloudOAuthConnectorCopy> = {
     disconnectedHint:
       "Connect Eliza Cloud first to use X/Twitter OAuth instead of local developer tokens.",
     successNotice: "Finish X/Twitter OAuth in your browser, then return here.",
+  },
+  google: {
+    platform: "google",
+    connectionRoles: ["agent", "owner"],
+    buttonLabel: "Use Google OAuth",
+    connectedHint:
+      "Connect Google with Eliza Cloud OAuth. Use 'agent' to link the agent's own Google account for autonomous Gmail / Calendar / Drive / Meet activity; use 'your account' to grant the agent permission to act on your own Google account.",
+    disconnectedHint:
+      "Connect Eliza Cloud first to use Google OAuth instead of local OAuth2 credentials.",
+    successNotice: "Finish Google OAuth in your browser, then return here.",
   },
 };
 

--- a/plugins/plugin-google/src/connector-account-provider.ts
+++ b/plugins/plugin-google/src/connector-account-provider.ts
@@ -165,7 +165,17 @@ function roleFromMetadata(metadata: unknown): ConnectorAccountRole {
     metadata && typeof metadata === "object" && !Array.isArray(metadata)
       ? (metadata as Record<string, unknown>)
       : {};
-  const raw = nonEmptyString(record.role ?? record.accountRole ?? record.requestedRole);
+  // Cloud OAuth writes `connectionRole` (uppercase canonical) and a legacy
+  // lowercase `agentGoogleSide`. Local UI flows pass `role`/`accountRole`/
+  // `requestedRole`. Accept all four shapes so the role survives whichever
+  // path the OAuth start metadata came through.
+  const raw = nonEmptyString(
+    record.requestedRole ??
+      record.connectionRole ??
+      record.role ??
+      record.accountRole ??
+      record.agentGoogleSide,
+  );
   if (!raw) return "OWNER";
   const normalized = raw.toUpperCase();
   if (normalized === "OWNER" || normalized === "AGENT" || normalized === "TEAM") {

--- a/plugins/plugin-google/src/connector-account-provider.ts
+++ b/plugins/plugin-google/src/connector-account-provider.ts
@@ -167,13 +167,18 @@ function roleFromMetadata(metadata: unknown): ConnectorAccountRole {
       : {};
   // Cloud OAuth writes `connectionRole` (uppercase canonical) and a legacy
   // lowercase `agentGoogleSide`. Local UI flows pass `role`/`accountRole`/
-  // `requestedRole`. Accept all four shapes so the role survives whichever
+  // `requestedRole`. Accept all five shapes so the role survives whichever
   // path the OAuth start metadata came through.
+  //
+  // Precedence: most-explicit cloud field first, then the original local
+  // fields in their original order (`role` first, `requestedRole` last so a
+  // stale earlier-step value can't override a later correction), then the
+  // legacy `agentGoogleSide` as the final fallback.
   const raw = nonEmptyString(
-    record.requestedRole ??
-      record.connectionRole ??
+    record.connectionRole ??
       record.role ??
       record.accountRole ??
+      record.requestedRole ??
       record.agentGoogleSide,
   );
   if (!raw) return "OWNER";


### PR DESCRIPTION
Lights up the OWNER side of plugin-google so users can connect both the
agent's own Google account (AGENT) and the user's own Google account
(OWNER) through the same Eliza Cloud OAuth gateway. Mirrors the
plugin-x pattern from #7851 for Gmail / Calendar / Drive / Meet.

The cloud broker has supported `connectionRole: "agent" | "owner"` on
the generic `/api/v1/oauth/initiate?provider=google` route for some
time (`cloud/packages/lib/services/oauth/provider-registry.ts:214`
registers `google` with `useGenericRoutes: true`). The missing pieces
were the manifest entry, the metadata-read in plugin-google's
connector-account-provider, and the UI surface:

- **`packages/app-core/src/registry/entries/connectors/google.json`** —
  brand-new manifest. The repo had `google-chat.json` (separate
  @elizaos/plugin-google-chat package) and `google-genai.json` (AI
  provider), but nothing for the Gmail/Calendar/Drive/Meet connector
  backed by @elizaos/plugin-google itself, so the plugin shipped
  without any registry surface. Declares the `accounts: { owner, agent }`
  block introduced by #7817's schema, with both sides using
  `authKind: \"oauth-cloud\"`.

- **`plugins/plugin-google/src/connector-account-provider.ts`** —
  extends `roleFromMetadata` to also read `connectionRole` (the field
  Eliza Cloud writes per `oauth2.ts:99`) and the legacy lowercase
  `agentGoogleSide` (per `oauth2.ts:102-105`). Without this, a user
  picking OWNER vs AGENT at the Google OAuth screen routed through
  cloud was silently dropped to the default `\"OWNER\"`.

- **`packages/ui/src/components/pages/plugin-view-connectors.tsx`** —
  adds a `google` entry to `CLOUD_OAUTH_CONNECTORS` with
  `connectionRoles: [\"agent\", \"owner\"]`, and widens the
  `CloudOAuthConnectorCopy.platform` union to include `\"google\"`. The
  existing render loop and `handleOpenCloudOAuthConnector` dispatch
  (introduced in #7851) already handle the array shape; no further
  changes needed.

End-state UX: the Google connector card shows two buttons under
\"Use Google OAuth (agent)\" and \"(your account)\". Each opens its
own OAuth tab; the resulting tokens are stored as distinct
\`platform_credentials\` rows differentiated by \`connectionRole\`.

## Stacking

This PR is stacked on **#7851 (plugin-x OWNER+AGENT)**. The third
commit relies on the \`connectionRoles[]\` array + \`buildRoleButtonLabel\`
helpers that #7851 introduces. When #7851 merges, this branch will
rebase cleanly onto develop; until then the diff is best read against
#7851's head.

## Follow-up (out of scope)

The cloud-side \`agentGoogleSide\` dual-write
(\`cloud/packages/lib/services/oauth/providers/oauth2.ts:101-105\`
and the SQL fragment at line 870, plus read fallbacks in
\`oauth-service.ts:140\` and \`generic-adapter.ts:117\`) is now
redundant — plugin-google reads both fields. A focused follow-up PR
can drop the cloud-side legacy writes (keeping read fallbacks for
existing rows to avoid a backfill migration).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds OWNER+AGENT dual-role support for the Google connector via Eliza Cloud OAuth, mirroring the same pattern introduced for X/Twitter in #7851. It wires together three changes: a new registry manifest (`google.json`), extended role-detection logic in the connector account provider, and a new entry in the UI's cloud OAuth connector table.

- **`google.json`** — new connector manifest that declares both `owner` and `agent` account kinds with `authKind: \"oauth-cloud\"` and exposes the local-OAuth fallback credentials as advanced config fields.
- **`connector-account-provider.ts`** — `roleFromMetadata` now consults `connectionRole` (canonical cloud field) first, then the original local fields in their original order, and finally the legacy `agentGoogleSide` string as a final fallback; `agentGoogleSide` is confirmed as `\"owner\" | \"agent\"` in the platform-credentials schema so `nonEmptyString` handles it correctly.
- **`plugin-view-connectors.tsx`** — adds `\"google\"` to the `CloudOAuthConnectorCopy.platform` union and registers the two-role button config, reusing the existing render loop unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge — three small, well-scoped additions that wire an existing cloud OAuth pattern to the Google connector without touching any shared infrastructure.

All three changes are additive and follow established patterns from #7851. The role-precedence ordering in connector-account-provider.ts is correct and consistent with the original behavior; agentGoogleSide is confirmed to be a string ("owner"|"agent") in the platform-credentials schema, so nonEmptyString handles it safely. The manifest is well-formed, and the UI change is a minimal extension of the existing render loop.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/registry/entries/connectors/google.json | New connector manifest — well-structured and consistent with other entries; declares both owner and agent OAuth-cloud account kinds with local-credential fallback fields marked advanced. |
| plugins/plugin-google/src/connector-account-provider.ts | Extends roleFromMetadata to read connectionRole (cloud canonical) and agentGoogleSide (legacy string "owner"|"agent"), with original local-field order preserved; nonEmptyString guard is safe for all five string fields. |
| packages/ui/src/components/pages/plugin-view-connectors.tsx | Adds "google" to the platform union type and registers a two-role entry in CLOUD_OAUTH_CONNECTORS; no logic changes required since the existing render loop already handles the array shape. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant UI as plugin-view-connectors
    participant Cloud as Eliza Cloud OAuth
    participant Provider as connector-account-provider
    participant DB as platform_credentials

    User->>UI: Click "Use Google OAuth (agent)" or "(your account)"
    UI->>Cloud: handleOpenCloudOAuthConnector(role)
    Cloud-->>User: Redirect to Google OAuth screen
    User->>Cloud: Authorize
    Cloud->>DB: Store token with connectionRole + agentGoogleSide
    Cloud-->>UI: OAuth callback

    Note over Provider: roleFromMetadata() precedence
    Provider->>Provider: 1. connectionRole (cloud canonical)
    Provider->>Provider: 2. role (local UI)
    Provider->>Provider: 3. accountRole (local UI)
    Provider->>Provider: 4. requestedRole (local UI)
    Provider->>Provider: 5. agentGoogleSide (legacy string)
    Provider->>Provider: default: OWNER
```

<sub>Reviews (2): Last reviewed commit: ["fix(plugin-google): preserve original ro..."](https://github.com/elizaos/eliza/commit/2115ee3897916aee02d096fce95667736b36ea6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33057209)</sub>

<!-- /greptile_comment -->