### PR TITLE
feat(ui/connectors): per-role cloudOAuthBusy state for OWNER+AGENT buttons

### DIFF
--- a/packages/ui/src/components/pages/plugin-view-connectors.tsx
+++ b/packages/ui/src/components/pages/plugin-view-connectors.tsx
@@ -274,7 +274,11 @@ function ConnectorPluginCard({
   const { elizaCloudConnected, setActionNotice, setState, setTab } = useApp();
   const connectorMode = useConnectorMode(plugin.id, { elizaCloudConnected });
   const [managedDiscordBusy, setManagedDiscordBusy] = useState(false);
-  const [cloudOAuthBusy, setCloudOAuthBusy] = useState(false);
+  // Keyed by role so the "agent" and "your account" buttons can each show
+  // their own loading state — clicking one no longer disables the other.
+  const [cloudOAuthBusy, setCloudOAuthBusy] = useState<
+    Partial<Record<CloudOAuthConnectionRole, boolean>>
+  >({});
   const [managedDiscordAgents, setManagedDiscordAgents] = useState<
     CloudCompatAgent[]
   >([]);
@@ -525,7 +529,7 @@ function ConnectorPluginCard({
   const handleOpenCloudOAuthConnector = async (
     connectionRole: CloudOAuthConnectionRole,
   ) => {
-    if (!cloudOAuthConnector || cloudOAuthBusy) {
+    if (!cloudOAuthConnector || cloudOAuthBusy[connectionRole]) {
       return;
     }
 
@@ -543,7 +547,7 @@ function ConnectorPluginCard({
       return;
     }
 
-    setCloudOAuthBusy(true);
+    setCloudOAuthBusy((prev) => ({ ...prev, [connectionRole]: true }));
     try {
       const redirectUrl =
         typeof window !== "undefined" ? window.location.href : undefined;
@@ -571,7 +575,7 @@ function ConnectorPluginCard({
         4200,
       );
     } finally {
-      setCloudOAuthBusy(false);
+      setCloudOAuthBusy((prev) => ({ ...prev, [connectionRole]: false }));
     }
   };
 
@@ -821,30 +825,33 @@ function ConnectorPluginCard({
             className="mb-4"
             actions={
               <div className="flex flex-wrap items-center gap-2">
-                {cloudOAuthConnector.connectionRoles.map((role) => (
-                  <Button
-                    key={role}
-                    variant="outline"
-                    size="sm"
-                    className="h-8 rounded-[var(--radius-lg)] px-4 text-xs-tight font-semibold"
-                    onClick={() => {
-                      void handleOpenCloudOAuthConnector(role);
-                    }}
-                    disabled={cloudOAuthBusy}
-                  >
-                    {cloudOAuthBusy
-                      ? "..."
-                      : elizaCloudConnected
-                        ? buildRoleButtonLabel(
-                            cloudOAuthConnector.buttonLabel,
-                            role,
-                            cloudOAuthConnector.connectionRoles.length > 1,
-                          )
-                        : t("pluginsview.OpenElizaCloud", {
-                            defaultValue: "Open Eliza Cloud",
-                          })}
-                  </Button>
-                ))}
+                {cloudOAuthConnector.connectionRoles.map((role) => {
+                  const roleBusy = cloudOAuthBusy[role] === true;
+                  return (
+                    <Button
+                      key={role}
+                      variant="outline"
+                      size="sm"
+                      className="h-8 rounded-[var(--radius-lg)] px-4 text-xs-tight font-semibold"
+                      onClick={() => {
+                        void handleOpenCloudOAuthConnector(role);
+                      }}
+                      disabled={roleBusy}
+                    >
+                      {roleBusy
+                        ? "..."
+                        : elizaCloudConnected
+                          ? buildRoleButtonLabel(
+                              cloudOAuthConnector.buttonLabel,
+                              role,
+                              cloudOAuthConnector.connectionRoles.length > 1,
+                            )
+                          : t("pluginsview.OpenElizaCloud", {
+                              defaultValue: "Open Eliza Cloud",
+                            })}
+                    </Button>
+                  );
+                })}
               </div>
             }
           >


### PR DESCRIPTION
Follow-up to #7852 addressing Greptile P2 on `plugin-view-connectors.tsx:856`.

The two-button cloud OAuth UI introduced in #7851 shared a single `cloudOAuthBusy: boolean` between both buttons. With connectors that expose both OWNER and AGENT sides (X/Twitter from #7851, Google from #7852), clicking one button immediately flipped both buttons to \`\"...\"\` and disabled both — no signal which role's OAuth flow was in flight, and no way to kick off the second flow without waiting.

Replaces the single boolean with a per-role \`Partial<Record<CloudOAuthConnectionRole, boolean>>\`:

- \`handleOpenCloudOAuthConnector(role)\` reads \`cloudOAuthBusy[role]\` for its guard, sets that role's flag on entry, and clears it in the \`finally\` block.
- The render loop reads \`cloudOAuthBusy[role] === true\` per button so disable + spinner are scoped to the clicked role.

End-state UX: clicking \"Use Google OAuth (agent)\" shows \`\"...\"\` on that button only; \"your account\" stays available. Both roles can be kicked off in parallel.

Split out of #7852 because the fix lives in the inherited #7851 render helper — not anything google-specific, and shipping it standalone keeps #7852 focused on \"register google connector\".

## Verification

- \`bunx tsc --noEmit\` in \`packages/ui\` — no errors in \`plugin-view-connectors.tsx\`
- Single-file diff: +35/-28 across one file

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces a shared `cloudOAuthBusy: boolean` with a per-role `Partial<Record<CloudOAuthConnectionRole, boolean>>` map so that each OAuth button (OWNER / AGENT) tracks its own in-flight state independently.

- State initialization changes from `false` to `{}`, the handler guard and setter now key on `connectionRole`, and the render computes `cloudOAuthBusy[role] === true` per button — correctly treating `undefined` as not-busy.
- Functional state updates (`prev => ({ ...prev, [role]: true/false })`) ensure concurrent role flows don't clobber each other's flag in React's batching model.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow, the logic is correct, and no existing behavior is broken.

The refactor touches exactly the three sites that need to change (guard, setter, render), uses functional state updates to handle concurrent role flows without clobber, and the `=== true` comparison correctly treats the `undefined` initial-entry case as not-busy. No other code paths are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/pages/plugin-view-connectors.tsx | Per-role cloudOAuthBusy state implemented correctly; functional updater pattern prevents concurrent-update races; `=== true` guard handles undefined initial entries safely. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant B_Owner as OWNER Button
    participant B_Agent as AGENT Button
    participant S as cloudOAuthBusy state
    participant API as OAuth API

    U->>B_Owner: click "Use OAuth (owner)"
    B_Owner->>S: "setCloudOAuthBusy({OWNER: true})"
    Note over B_Owner: disabled + "..."
    Note over B_Agent: still enabled (AGENT key absent)

    U->>B_Agent: click "Use OAuth (agent)"
    B_Agent->>S: "setCloudOAuthBusy({OWNER: true, AGENT: true})"
    Note over B_Agent: disabled + "..."

    B_Owner->>API: initiateCloudOauth(OWNER)
    B_Agent->>API: initiateCloudOauth(AGENT)

    API-->>B_Owner: authUrl
    B_Owner->>S: "finally → {OWNER: false, AGENT: true}"
    Note over B_Owner: re-enabled

    API-->>B_Agent: authUrl
    B_Agent->>S: "finally → {OWNER: false, AGENT: false}"
    Note over B_Agent: re-enabled
```

<sub>Reviews (1): Last reviewed commit: ["feat(ui/connectors): per-role cloudOAuth..."](https://github.com/elizaos/eliza/commit/295a7205e7646159e69f704097166ebc2d5a206a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33097085)</sub>

<!-- /greptile_comment -->