### PR TITLE
fix(training): import _registry_get in train_local.py main scope

### DIFF
--- a/packages/training/scripts/train_local.py
+++ b/packages/training/scripts/train_local.py
@@ -602,6 +602,7 @@ def main() -> int:
     # cross-entropy + fused RMSNorm/SwiGLU/RoPE replace the HF defaults.
     # This is what makes the longer training seq_lens (8k–16k locally,
     # 16k+ on cloud) actually fit in VRAM.
+    from training.model_registry import get as _registry_get  # noqa: E402
     use_liger = args.use_liger == "on" or (
         args.use_liger == "auto"
         and (args.registry_key is None


### PR DESCRIPTION
## Summary

One-line fix: `_registry_get` is referenced in `main()` at line 608 but is only imported inside `_apply_resolved_args()` at line 408 as a local import. Running:

```bash
python packages/training/scripts/train_local.py \
    --registry-key qwen3.5-0.8b --low-vram-smoke \
    --train-file data/final-eliza1-smoke/train.jsonl \
    --val-file data/final-eliza1-smoke/val.jsonl \
    --max-samples 256 --epochs 1
```

crashes with `NameError: name '_registry_get' is not defined` right after the base model finishes loading, before training begins.

`--preflight-only` succeeds because it short-circuits before the `use_liger` expression evaluates — that's why CI hasn't caught this.

## Fix

Add the same lazy import in `main()` before the `use_liger` check, mirroring the pattern already used in `_apply_resolved_args`. Preserves the lazy-import style this file uses for training-only deps.

```diff
+    from training.model_registry import get as _registry_get  # noqa: E402
     use_liger = args.use_liger == "on" or (
         args.use_liger == "auto"
         and (args.registry_key is None
              or getattr(_registry_get(args.registry_key), "use_liger", True))
     )
```

## Test plan

- [x] `--preflight-only` still passes (regression check; this code path didn't fire before either)
- [x] Real training run with `--registry-key qwen3.5-0.8b --low-vram-smoke` now reaches the training loop instead of crashing at the `use_liger` resolve
- [x] Repro environment: WSL2 Ubuntu / Python 3.11.15 / torch 2.12.0+cu130 / transformers 5.8.1 / RTX 3060 12GB / no CUDA toolkit installed (so Liger correctly falls back via `_triton_runtime_ok()` once it can run)

## Repro context

Hit while running the local 0.8B SFT smoke from the train_local.py docstring as part of shaw's eliza-1 catch-up. The bug blocks anyone passing `--registry-key` on a default `--use-liger auto` setup, which is the documented usage in the file's own header.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `NameError` crash in `main()` that occurred whenever `--registry-key` was passed with the default `--use-liger auto` setting. `_registry_get` was already imported as a local (lazy) import inside `_apply_resolved_args()`, but was never brought into scope in `main()` before it was referenced in the `use_liger` expression.

- Adds `from training.model_registry import get as _registry_get` directly before the `use_liger` boolean in `main()`, matching the existing lazy-import pattern used throughout the file.
- The fix is confined to a single line; Python's module cache means the repeated lazy import has no runtime overhead.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line fix that restores a missing name binding with no logic or API changes.

The change adds one import line to `main()` that was already present in the parallel helper function. The `use_liger` expression is unchanged; only the missing name binding is supplied. There is no altered control flow, no new module dependency, and the lazy-import pattern is already established in the same file.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/training/scripts/train_local.py | Adds a missing local import of `_registry_get` in `main()` before the `use_liger` boolean is computed; mirrors the identical lazy-import already present in `_apply_resolved_args()` at line 408. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as CLI (train_local.py main)
    participant Registry as training.model_registry
    participant Model as Model loader
    participant Liger as Liger kernel

    CLI->>CLI: parse args (--registry-key, --use-liger auto)
    CLI->>Registry: _apply_resolved_args() → _registry_get(key) [local import]
    Registry-->>CLI: ModelEntry (hf_id, use_liger, …)
    CLI->>Model: AutoModelForCausalLM.from_pretrained(args.model)
    Model-->>CLI: model

    Note over CLI: BEFORE fix: NameError – _registry_get not in scope
    Note over CLI: AFTER fix: local import added here

    CLI->>Registry: _registry_get(args.registry_key) [local import – new line 605]
    Registry-->>CLI: ModelEntry.use_liger
    CLI->>Liger: "apply_liger_kernel_to_llama() (if use_liger=True)"
    Liger-->>CLI: patched model
    CLI->>CLI: begin training loop
```

<sub>Reviews (1): Last reviewed commit: ["fix(training): import \_registry\_get in t..."](https://github.com/elizaos/eliza/commit/6927a1a28765c1641a11d6b8d7289dafa36e81cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33114538)</sub>

<!-- /greptile_comment -->