### PR TITLE
feat(plugin-slack): OWNER+AGENT dual bot+user token via Eliza Cloud OAuth

### DIFF
--- a/packages/app-core/src/registry/entries/connectors/slack.json
+++ b/packages/app-core/src/registry/entries/connectors/slack.json
@@ -84,5 +84,19 @@
   "auth": {
     "kind": "oauth",
     "credentialKeys": ["SLACK_APP_TOKEN"]
+  },
+  "accounts": {
+    "owner": {
+      "supported": true,
+      "authKind": "oauth-cloud",
+      "credentialKeys": [],
+      "notes": "The user's own Slack identity (xoxp-... user token), connected via Eliza Cloud OAuth so the agent can read the user's channels, write messages as them, search their conversations, and read files they have access to."
+    },
+    "agent": {
+      "supported": true,
+      "authKind": "oauth-cloud",
+      "credentialKeys": [],
+      "notes": "The agent's own Slack bot identity (xoxb-... bot token), installed into the workspace via Eliza Cloud OAuth. Posts, mentions, replies, and DMs flow through the bot user."
+    }
   }
 }

--- a/packages/cloud-shared/src/lib/services/oauth/provider-registry.ts
+++ b/packages/cloud-shared/src/lib/services/oauth/provider-registry.ts
@@ -397,7 +397,11 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
     // Slack identity (authed_user.access_token, `xoxp-...`) can act on
     // the user's behalf — read their channels, write as them, search
     // their messages, and read files they have access to.
-    userScopes: ["chat:write", "search:read", "users:read", "files:read"],
+    // `identity.basic` is required by Slack's `users.identity` endpoint
+    // (the userInfo URL above) — without it the OWNER callback's
+    // userInfo fetch fails with `missing_scope` and `extractUserInfo`
+    // cannot resolve `user_id`.
+    userScopes: ["identity.basic", "chat:write", "search:read", "users:read", "files:read"],
     userInfoMapping: {
       id: "user_id",
       displayName: "user",

--- a/packages/cloud-shared/src/lib/services/oauth/provider-registry.ts
+++ b/packages/cloud-shared/src/lib/services/oauth/provider-registry.ts
@@ -122,6 +122,20 @@ export interface OAuthProviderConfig {
   allowedScopes?: string[];
 
   /**
+   * Default user-level OAuth scopes for providers that distinguish between
+   * bot and user scopes (e.g. Slack passes user scopes via the `user_scope`
+   * query parameter alongside the regular `scope` parameter). When set,
+   * `initiateOAuth2` adds a `user_scope` URL param so the OAuth screen
+   * prompts the user for both bot-level and user-level permissions.
+   *
+   * This is what lets the user's `authed_user.access_token` (Slack's user
+   * token, `xoxp-...`) carry meaningful permissions for OWNER-role flows
+   * — without it, the user token is functionally a bot-context token with
+   * no user-level scopes granted.
+   */
+  userScopes?: string[];
+
+  /**
    * How to extract user info from the userInfo endpoint response.
    * If not provided, uses standard OAuth2 claims.
    */
@@ -379,6 +393,11 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       revoke: "https://slack.com/api/auth.revoke",
     },
     defaultScopes: ["identity.basic", "users:read", "chat:write", "channels:read"],
+    // User-level scopes requested for the OWNER role so the user's own
+    // Slack identity (authed_user.access_token, `xoxp-...`) can act on
+    // the user's behalf — read their channels, write as them, search
+    // their messages, and read files they have access to.
+    userScopes: ["chat:write", "search:read", "users:read", "files:read"],
     userInfoMapping: {
       id: "user_id",
       displayName: "user",

--- a/packages/cloud-shared/src/lib/services/oauth/providers/oauth2.ts
+++ b/packages/cloud-shared/src/lib/services/oauth/providers/oauth2.ts
@@ -204,6 +204,15 @@ export async function initiateOAuth2(
     authUrl.searchParams.set("scope", scopes.join(" "));
   }
 
+  // Slack-style user/bot scope split: providers that distinguish user-level
+  // scopes from bot/app scopes (currently only Slack via the `user_scope`
+  // query parameter) declare them in `provider.userScopes`. Without this,
+  // the user token returned in `authed_user.access_token` has no granted
+  // user-level permissions and can't act on the user's behalf.
+  if (provider.userScopes && provider.userScopes.length > 0) {
+    authUrl.searchParams.set("user_scope", provider.userScopes.join(" "));
+  }
+
   authUrl.searchParams.set("state", state);
 
   // Add PKCE parameters

--- a/packages/cloud-shared/src/lib/services/oauth/providers/oauth2.ts
+++ b/packages/cloud-shared/src/lib/services/oauth/providers/oauth2.ts
@@ -87,6 +87,49 @@ interface ExtractedUserInfo {
   raw: Record<string, unknown>;
 }
 
+/**
+ * Pick the right token for the userInfo / tokenInfo lookup.
+ *
+ * For providers with a user/bot token split (Slack via `authed_user`)
+ * the OWNER flow must use the user-context token so identity lookup
+ * returns the authorizing user, not the bot. AGENT and other flows
+ * keep the bot/app token.
+ *
+ * Other providers (no `userScopes` declared) always use the standard
+ * `access_token` — the OWNER vs AGENT distinction doesn't change which
+ * token represents the identity.
+ */
+function pickUserInfoToken(
+  provider: OAuthProviderConfig,
+  tokens: TokenResponse,
+  connectionRole: OAuthStandardConnectionRole,
+): string {
+  if (
+    connectionRole !== "OWNER" ||
+    !provider.userScopes ||
+    provider.userScopes.length === 0
+  ) {
+    return tokens.access_token;
+  }
+  const authedUser = tokens.authed_user;
+  if (
+    authedUser &&
+    typeof authedUser === "object" &&
+    !Array.isArray(authedUser)
+  ) {
+    const userToken = (authedUser as Record<string, unknown>).access_token;
+    if (typeof userToken === "string" && userToken.length > 0) {
+      return userToken;
+    }
+  }
+  // Fall back to the bot token if the provider didn't return a user
+  // token (e.g. the user denied user-scope permissions on the consent
+  // screen). The caller will still hit the dedup guard, but that's the
+  // correct behavior: an OWNER connection without user-token grants
+  // isn't meaningfully distinct from an AGENT connection.
+  return tokens.access_token;
+}
+
 function getStoredConnectionRole(sourceContext: unknown): OAuthStandardConnectionRole {
   if (!sourceContext || typeof sourceContext !== "object") {
     return "OWNER";
@@ -209,7 +252,20 @@ export async function initiateOAuth2(
   // query parameter) declare them in `provider.userScopes`. Without this,
   // the user token returned in `authed_user.access_token` has no granted
   // user-level permissions and can't act on the user's behalf.
-  if (provider.userScopes && provider.userScopes.length > 0) {
+  //
+  // Only add user_scope for non-AGENT flows. The AGENT flow installs the
+  // app's bot into the workspace; surfacing personal user-level permission
+  // requests on the workspace admin's authorization screen would (a) be
+  // surprising UX for "install a bot" and (b) cause both flows' user-info
+  // lookup to resolve to the same Slack user_id (the authorizer), which
+  // the `storeConnection` dedup guard rejects with
+  // `OAUTH_ACCOUNT_ALREADY_LINKED_TO_DIFFERENT_ROLE` on the second click.
+  const normalizedRole = normalizeOAuthConnectionRole(params.connectionRole);
+  if (
+    provider.userScopes &&
+    provider.userScopes.length > 0 &&
+    normalizedRole !== "AGENT"
+  ) {
     authUrl.searchParams.set("user_scope", provider.userScopes.join(" "));
   }
 
@@ -271,12 +327,25 @@ export async function handleOAuth2Callback(
   // Exchange code for tokens
   const tokens = await exchangeCodeForTokens(provider, code, codeVerifier);
 
+  // For providers with a user/bot token split (Slack), the OWNER flow
+  // must resolve the *authorizing user's* identity via the user token
+  // — not the bot token. Otherwise `users.identity` (or equivalent)
+  // returns the same identity for both AGENT and OWNER flows (the
+  // workspace admin who clicked Authorize on both buttons), and the
+  // `storeConnection` dedup guard rejects the second connection with
+  // `OAUTH_ACCOUNT_ALREADY_LINKED_TO_DIFFERENT_ROLE`.
+  const userInfoToken = pickUserInfoToken(
+    provider,
+    tokens,
+    connectionRole,
+  );
+
   // Fetch user info: userInfo endpoint, token metadata endpoint, or from token response
   let userInfo: ExtractedUserInfo;
   if (provider.endpoints?.userInfo) {
-    userInfo = await fetchUserInfo(provider, tokens.access_token);
+    userInfo = await fetchUserInfo(provider, userInfoToken);
   } else if (provider.endpoints?.tokenInfo) {
-    userInfo = await fetchTokenInfo(provider, tokens.access_token);
+    userInfo = await fetchTokenInfo(provider, userInfoToken);
   } else {
     userInfo = extractUserInfoFromTokens(provider, tokens);
   }

--- a/packages/ui/src/components/pages/plugin-view-connectors.tsx
+++ b/packages/ui/src/components/pages/plugin-view-connectors.tsx
@@ -142,10 +142,10 @@ function buildRoleButtonLabel(
 const CLOUD_OAUTH_CONNECTORS: Record<string, CloudOAuthConnectorCopy> = {
   slack: {
     platform: "slack",
-    connectionRoles: ["agent"],
+    connectionRoles: ["agent", "owner"],
     buttonLabel: "Use Slack OAuth",
     connectedHint:
-      "Connect Slack with Eliza Cloud OAuth. Cloud stores the workspace token and the Slack plugin remains the runtime surface for messages and actions.",
+      "Connect Slack with Eliza Cloud OAuth. Use 'agent' to install the agent's own Slack bot (xoxb-... bot token) into the workspace; use 'your account' to grant the agent permission to act on your own Slack identity (xoxp-... user token) — read your channels, write as you, search your messages.",
     disconnectedHint:
       "Connect Eliza Cloud first to use Slack OAuth instead of local Socket Mode tokens.",
     successNotice: "Finish Slack OAuth in your browser, then return here.",

--- a/plugins/plugin-slack/src/connector-account-provider.ts
+++ b/plugins/plugin-slack/src/connector-account-provider.ts
@@ -16,6 +16,7 @@ import {
   type ConnectorAccountPatch,
   type ConnectorAccountProvider,
   type ConnectorAccountPurpose,
+  type ConnectorAccountRole,
   type ConnectorOAuthCallbackRequest,
   type ConnectorOAuthCallbackResult,
   type ConnectorOAuthStartRequest,
@@ -98,6 +99,28 @@ function nonEmptyString(value: unknown): string | undefined {
 
 function readSetting(runtime: IAgentRuntime, key: string): string | undefined {
   return nonEmptyString(runtime.getSetting(key));
+}
+
+function roleFromMetadata(metadata: unknown): ConnectorAccountRole {
+  const record =
+    metadata && typeof metadata === "object" && !Array.isArray(metadata)
+      ? (metadata as Record<string, unknown>)
+      : {};
+  // Cloud OAuth writes `connectionRole` (uppercase canonical); local UI
+  // flows pass `role`/`accountRole`/`requestedRole`. Accept all four so the
+  // role survives whichever path the OAuth start metadata came through.
+  const raw = nonEmptyString(
+    record.connectionRole ??
+      record.role ??
+      record.accountRole ??
+      record.requestedRole,
+  );
+  if (!raw) return "OWNER";
+  const normalized = raw.toUpperCase();
+  if (normalized === "OWNER" || normalized === "AGENT" || normalized === "TEAM") {
+    return normalized;
+  }
+  return "OWNER";
 }
 
 function readClientConfig(runtime: IAgentRuntime): {
@@ -361,7 +384,7 @@ export function createSlackConnectorAccountProvider(
         SLACK_SERVICE_NAME,
         {
           provider: SLACK_SERVICE_NAME,
-          role: "OWNER",
+          role: roleFromMetadata(request.flow.metadata),
           purpose: DEFAULT_PURPOSES,
           accessGate: "open",
           status: "pending",


### PR DESCRIPTION
Lights up the OWNER side of plugin-slack so users can connect both the
agent's own Slack bot identity (AGENT, \`xoxb-...\` bot token) and their
own Slack identity (OWNER, \`xoxp-...\` user token) through the same
Eliza Cloud OAuth gateway. Mirrors the plugin-x (#7851) and
plugin-google (#7852) patterns, plus a small cloud-shared addition for
Slack's user/bot scope split.

## What was missing

plugin-slack already extracted \`authed_user.access_token\` from the
OAuth response and persisted it alongside the bot token. But three
things were missing:

1. **Cloud didn't request user scopes.** Slack splits OAuth permissions
   into a regular \`scope\` parameter (bot/app scopes) and a separate
   \`user_scope\` parameter (user-level scopes). Without \`user_scope\`,
   the \`authed_user.access_token\` was a bot-context token with no
   user-level permissions granted — functionally useless for OWNER.

2. **plugin-slack hardcoded \`role: \"OWNER\"\`** in the OAuth callback
   (lines 387, now fixed). Whichever role the user clicked, the
   resulting account was pinned to OWNER. Same hardcode pattern that
   PR #7820 fixed for Linear/Calendly/Shopify — Slack was missed in
   the batch.

3. **No \`accounts\` manifest block, no two-button UI.** The connector
   card only showed a single \"Use Slack OAuth\" button bound to the
   AGENT role.

## What this PR changes

- **\`packages/cloud-shared/src/lib/services/oauth/provider-registry.ts\`**
  Adds a \`userScopes?: string[]\` field to \`OAuthProviderConfig\` and
  populates it on the Slack entry with \`[\"chat:write\", \"search:read\",
  \"users:read\", \"files:read\"]\`. Purely additive — other providers
  without \`userScopes\` get exactly the same auth URL as before.

- **\`packages/cloud-shared/src/lib/services/oauth/providers/oauth2.ts\`**
  When \`provider.userScopes\` is non-empty, the auth URL gets a
  \`user_scope\` parameter alongside the regular \`scope\`. Slack is the
  only consumer today.

- **\`plugins/plugin-slack/src/connector-account-provider.ts\`** Adds a
  \`roleFromMetadata\` helper (same shape as plugin-google's) and
  replaces the hardcoded \`role: \"OWNER\"\` in \`completeOAuth\` with
  \`role: roleFromMetadata(request.flow.metadata)\`. The
  \`synthesizeAccount\` helper for env-only configs is intentionally
  left unchanged — env setups don't go through OAuth and the role
  doesn't carry meaningful semantics there.

- **\`packages/app-core/src/registry/entries/connectors/slack.json\`**
  Adds the \`accounts: { owner, agent }\` block with \`authKind:
  \"oauth-cloud\"\` on both sides.

- **\`packages/ui/src/components/pages/plugin-view-connectors.tsx\`**
  Slack entry upgraded from \`connectionRoles: [\"agent\"]\` to
  \`[\"agent\", \"owner\"]\`. Connected-hint copy updated to explain the
  bot vs user token distinction.

## End-state UX

The Slack connector card shows two buttons under \"Use Slack OAuth
(agent)\" and \"(your account)\". Each opens its own OAuth tab; the
resulting tokens land as distinct \`platform_credentials\` rows
differentiated by \`connectionRole\` (AGENT or OWNER).

## Verification

- \`packages/app-core\` connector-accounts schema tests: 13/13 pass
- \`plugin-slack\` connector-account-provider tests (vitest): 4/4 pass
- \`bunx tsc --noEmit\` clean on \`provider-registry.ts\`, \`oauth2.ts\`,
  \`plugin-slack/connector-account-provider.ts\`, and
  \`plugin-view-connectors.tsx\` (other pre-existing typecheck noise in
  cloud-shared/contracts/i18n unrelated to this PR)
- slack.json validates against \`connectorEntrySchema\`

## Follow-ups

- plugin-slack's local OAuth path (\`startOAuth\` at line ~258) builds
  its own auth URL and doesn't yet pass \`user_scope\`. Out of scope —
  cloud OAuth is the default/recommended path, local is a fallback.
- SlackService doesn't yet route API calls to the user token when
  account role is OWNER. The user token is persisted in credentials
  (\`oauth.tokens.authed_user.access_token\`); follow-up work in
  \`accounts.ts\` and \`service.ts\` can pick the right token based on
  role.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables dual OWNER+AGENT Slack OAuth via Eliza Cloud by fixing three missing pieces: the `user_scope` parameter was never sent, the role was hardcoded to OWNER in the callback, and the connector card only showed a single AGENT button. The changes are additive and mirror the established pattern from plugin-x and plugin-google.

- Adds `userScopes` to `OAuthProviderConfig` and populates it for Slack; `initiateOAuth2` appends `user_scope` only for non-AGENT flows, preventing the workspace admin's bot-install screen from showing personal permission requests and avoiding the `OAUTH_ACCOUNT_ALREADY_LINKED_TO_DIFFERENT_ROLE` dedup collision.
- Introduces `pickUserInfoToken` so the OWNER callback resolves identity via the user token (`xoxp-`) rather than the shared bot token, and replaces the hardcoded `role: \"OWNER\"` with `roleFromMetadata` that reads `connectionRole`/`role`/`accountRole`/`requestedRole` from flow metadata with an OWNER default.
- Updates `slack.json` with the `accounts` block and `plugin-view-connectors.tsx` with two-button copy.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it is additive and all three previously identified blocking issues have been addressed in this revision.

The two issues flagged in the prior review cycle — `user_scope` being added unconditionally regardless of role and `identity.basic` missing from `userScopes` causing every OWNER callback to fail — are both resolved. The new `pickUserInfoToken` function correctly threads the user token through the OWNER identity lookup while leaving the AGENT path unchanged. The `roleFromMetadata` helper replaces the hardcoded `"OWNER"` and follows the same pattern already used in plugin-google and plugin-x.

No files require special attention for merging; the `startOAuth` metadata gap in `connector-account-provider.ts` is a minor local-path edge case.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/cloud-shared/src/lib/services/oauth/providers/oauth2.ts | Adds `pickUserInfoToken` helper and role-gated `user_scope` injection; logic is sound and well-documented with the dedup rationale. |
| packages/cloud-shared/src/lib/services/oauth/provider-registry.ts | Adds optional `userScopes` field to `OAuthProviderConfig` and populates it for Slack with `identity.basic` included (fixing the previously flagged missing-scope OWNER failure). |
| plugins/plugin-slack/src/connector-account-provider.ts | Adds `roleFromMetadata` and replaces hardcoded `"OWNER"` in `completeOAuth`; `startOAuth` does not yet forward `connectionRole` into returned metadata, so local-path AGENT flows fall back to the OWNER default. |
| packages/app-core/src/registry/entries/connectors/slack.json | Adds `accounts.owner` and `accounts.agent` blocks with `authKind: "oauth-cloud"` and empty `credentialKeys`, consistent with the cloud-OAuth pattern used by other connectors. |
| packages/ui/src/components/pages/plugin-view-connectors.tsx | Upgrades Slack connector to `connectionRoles: ["agent", "owner"]` and updates the `connectedHint` copy to explain the bot vs user token distinction. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant UI as plugin-view-connectors
    participant Cloud as initiateOAuth2
    participant Slack as Slack OAuth
    participant CB as handleOAuth2Callback
    participant Plugin as completeOAuth (plugin-slack)

    User->>UI: Click "Use Slack OAuth (agent)"
    UI->>Cloud: "initiateOAuth2(connectionRole=AGENT)"
    Note over Cloud: normalizedRole=AGENT<br/>user_scope NOT added<br/>scope=defaultScopes only
    Cloud->>Slack: "auth URL (scope=bot scopes)"
    Slack-->>CB: "code + state (role=AGENT in state)"
    CB->>CB: pickUserInfoToken → tokens.access_token (bot)
    CB->>Slack: users.identity with bot token
    Slack-->>CB: bot user identity
    CB->>CB: "storeConnection(AGENT, platform_user_id=botId)"

    User->>UI: Click "Use Slack OAuth (your account)"
    UI->>Cloud: "initiateOAuth2(connectionRole=OWNER)"
    Note over Cloud: normalizedRole=OWNER<br/>user_scope=identity.basic chat:write...<br/>added alongside scope
    Cloud->>Slack: auth URL (scope + user_scope)
    Slack-->>CB: "code + state (role=OWNER in state)"
    CB->>CB: pickUserInfoToken → authed_user.access_token (xoxp-)
    CB->>Slack: users.identity with user token
    Slack-->>CB: user identity (different ID from bot)
    CB->>CB: "storeConnection(OWNER, platform_user_id=userId)"
    CB->>Plugin: completeOAuth callback
    Plugin->>Plugin: roleFromMetadata → OWNER
    Plugin->>Plugin: "upsertAccount(role=OWNER, externalId=teamId)"
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plugins/plugin-slack/src/connector-account-provider.ts`, line 298-305 ([link](https://github.com/elizaos/eliza/blob/b64bd4fe7359034116b0b6a296a6ea5c52d644a0/plugins/plugin-slack/src/connector-account-provider.ts#L298-L305)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=8" align="top"></a> The Slack `roleFromMetadata` checks `connectionRole` first (the canonical cloud key), which is an improvement over the Google version. However the plugin's `startOAuth` does not inject `connectionRole` into its returned `metadata` block, so a locally-initiated AGENT OAuth flow would fall through all four keys and default to `"OWNER"`. Adding `connectionRole` to the returned `startOAuth` metadata (mirroring the cloud's practice) ensures the role survives any path.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["fix(cloud-shared/oauth): add identity.ba..."](https://github.com/elizaos/eliza/commit/e57124a9cfdff9fb26b004293ea298cb7a368442) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33117037)</sub>

<!-- /greptile_comment -->