### PR TITLE
feat(plugin-discord): Windows port for Discord Desktop CDP control + OWNER+AGENT manifest

### DIFF
--- a/packages/app-core/src/registry/entries/connectors/discord.json
+++ b/packages/app-core/src/registry/entries/connectors/discord.json
@@ -100,5 +100,20 @@
   "auth": {
     "kind": "oauth",
     "credentialKeys": ["DISCORD_API_TOKEN"]
+  },
+  "accounts": {
+    "agent": {
+      "supported": true,
+      "authKind": "api-key",
+      "credentialKeys": ["DISCORD_API_TOKEN"],
+      "notes": "The agent's own Discord bot identity. Paste a bot token from the Discord Developer Portal; posts, mentions, replies, slash commands, and voice all run through the bot user."
+    },
+    "owner": {
+      "supported": true,
+      "authKind": "local-app",
+      "credentialKeys": [],
+      "osSupport": ["darwin", "win32"],
+      "notes": "The user's own Discord identity, driven via Discord Desktop's Chrome DevTools Protocol port. Eliza relaunches the local Discord client with --remote-debugging-port and reads/writes through the user's logged-in session — useful for DMs the agent's bot has no access to. macOS uses osascript/open -a; Windows uses taskkill/Discord.exe from %LOCALAPPDATA%\\Discord\\app-*. Linux is not supported yet."
+    }
   }
 }

--- a/plugins/plugin-discord/user-account-scraper/discord-desktop-cdp.ts
+++ b/plugins/plugin-discord/user-account-scraper/discord-desktop-cdp.ts
@@ -3,7 +3,16 @@
 // Chrome DevTools Protocol port exposed (e.g. relaunched by Eliza). Sends
 // and probes go through the same scraper primitives but over CDP rather
 // than the workspace bridge.
+//
+// Platform support: macOS and Windows. Discord Desktop on both OSes
+// accepts the Electron `--remote-debugging-port` flag (empirically
+// verified against Discord 1.0.9237 / Electron 37.6.0 on Windows; same
+// flag has been the macOS path since this file's introduction). Linux
+// support is not implemented yet — the desktop control surface there
+// would need a separate process-detection + launch path.
 import { execFile } from "node:child_process";
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import {
   buildDiscordProbeScript,
@@ -110,13 +119,88 @@ function execFileAsync(
   });
 }
 
+function isDiscordDesktopSupportedPlatform(
+  platform: NodeJS.Platform,
+): platform is "darwin" | "win32" {
+  return platform === "darwin" || platform === "win32";
+}
+
 async function discordAppRunning(): Promise<boolean> {
   try {
-    await execFileAsync("/usr/bin/pgrep", ["-x", "Discord"], 1_000);
-    return true;
+    if (process.platform === "darwin") {
+      await execFileAsync("/usr/bin/pgrep", ["-x", "Discord"], 1_000);
+      return true;
+    }
+    if (process.platform === "win32") {
+      // `tasklist /FI "IMAGENAME eq Discord.exe"` returns the header
+      // "INFO: No tasks are running which match the specified criteria."
+      // when no process is found, and a table row per match otherwise.
+      // Use CSV + no-header so the presence of any output line means
+      // Discord.exe is running.
+      const { stdout } = await execFileAsync(
+        "tasklist",
+        ["/FI", "IMAGENAME eq Discord.exe", "/FO", "CSV", "/NH"],
+        2_000,
+      );
+      return /Discord\.exe/i.test(stdout);
+    }
+    return false;
   } catch {
     return false;
   }
+}
+
+/**
+ * Locate the latest installed Discord.exe under `%LOCALAPPDATA%\Discord`.
+ *
+ * Discord on Windows is squirrel-installed per-user, with each release
+ * unpacked into its own `app-<version>` folder alongside an `Update.exe`
+ * shim. We pick the highest-versioned `app-*` directory's `Discord.exe`
+ * so an in-flight self-update doesn't strand us on an old executable.
+ *
+ * Falls back to `null` when no install is found; the caller surfaces a
+ * helpful lastError instead of throwing.
+ */
+async function findDiscordExeWindows(): Promise<string | null> {
+  const localAppData = process.env.LOCALAPPDATA;
+  if (!localAppData) {
+    return null;
+  }
+  const discordRoot = join(localAppData, "Discord");
+  let entries: string[];
+  try {
+    entries = await readdir(discordRoot);
+  } catch {
+    return null;
+  }
+  const appVersions = entries
+    .filter((name) => name.startsWith("app-"))
+    .map((name) => ({
+      name,
+      // Parse "app-1.0.9237" → [1, 0, 9237] for numeric sort. Non-numeric
+      // segments fall back to comparing the raw string segment so a build
+      // tag like "app-1.0.9237-canary" stays comparable.
+      parts: name
+        .slice("app-".length)
+        .split(".")
+        .map((segment) => {
+          const num = Number.parseInt(segment, 10);
+          return Number.isFinite(num) ? num : Number.NEGATIVE_INFINITY;
+        }),
+    }))
+    .sort((a, b) => {
+      const maxLen = Math.max(a.parts.length, b.parts.length);
+      for (let i = 0; i < maxLen; i++) {
+        const av = a.parts[i] ?? 0;
+        const bv = b.parts[i] ?? 0;
+        if (av !== bv) return bv - av;
+      }
+      return 0;
+    });
+  if (appVersions.length === 0) {
+    return null;
+  }
+  return join(discordRoot, appVersions[0].name, "Discord.exe");
 }
 
 async function fetchJson<T>(url: string, timeoutMs: number): Promise<T> {
@@ -309,9 +393,10 @@ export async function getDiscordDesktopCdpStatus(
 ): Promise<DiscordDesktopCdpStatus> {
   const platform = process.platform;
   const port = configuredDiscordDesktopCdpPort(env);
+  const platformSupported = isDiscordDesktopSupportedPlatform(platform);
   if (discordDesktopCdpDisabled(env)) {
     return {
-      supported: platform === "darwin",
+      supported: platformSupported,
       platform,
       port,
       appRunning: false,
@@ -324,8 +409,8 @@ export async function getDiscordDesktopCdpStatus(
       lastError: "Discord Desktop CDP disabled by environment.",
     };
   }
-  const appRunning = platform === "darwin" ? await discordAppRunning() : false;
-  if (platform !== "darwin") {
+  const appRunning = platformSupported ? await discordAppRunning() : false;
+  if (!platformSupported) {
     return {
       supported: false,
       platform,
@@ -337,7 +422,8 @@ export async function getDiscordDesktopCdpStatus(
       targetTitle: null,
       webSocketDebuggerUrl: null,
       probe: null,
-      lastError: "Discord Desktop control is currently supported on macOS.",
+      lastError:
+        "Discord Desktop control is currently supported on macOS and Windows.",
     };
   }
 
@@ -671,28 +757,62 @@ export async function relaunchDiscordDesktopForCdp(
     return current;
   }
 
-  if (current.appRunning) {
+  const port = configuredDiscordDesktopCdpPort(env);
+  const cdpArgs = [
+    `--remote-debugging-port=${port}`,
+    `--remote-debugging-address=${DISCORD_DESKTOP_CDP_HOST}`,
+    "--remote-allow-origins=*",
+  ];
+
+  if (process.platform === "darwin") {
+    if (current.appRunning) {
+      await execFileAsync(
+        "/usr/bin/osascript",
+        ["-e", 'quit app "Discord"'],
+        5_000,
+      );
+      await waitForDiscordToQuit();
+    }
     await execFileAsync(
-      "/usr/bin/osascript",
-      ["-e", 'quit app "Discord"'],
+      "/usr/bin/open",
+      ["-a", "Discord", "--args", ...cdpArgs],
       5_000,
     );
-    await waitForDiscordToQuit();
+  } else if (process.platform === "win32") {
+    if (current.appRunning) {
+      // `/F` force-kills, `/T` walks the process tree (Discord spawns
+      // multiple Electron helpers). Discord ignores SIGTERM-equivalents
+      // and stays in the tray otherwise.
+      await execFileAsync(
+        "taskkill",
+        ["/F", "/T", "/IM", "Discord.exe"],
+        5_000,
+      );
+      await waitForDiscordToQuit();
+    }
+    const exePath = await findDiscordExeWindows();
+    if (!exePath) {
+      throw new Error(
+        "Discord.exe not found under %LOCALAPPDATA%\\Discord — is Discord Desktop installed?",
+      );
+    }
+    // `start` returns immediately (Discord keeps running in the
+    // background after we hand off). `""` is the required (empty)
+    // window title for cmd `start` when the next arg is a quoted path.
+    await execFileAsync(
+      "cmd",
+      ["/d", "/s", "/c", "start", "", exePath, ...cdpArgs],
+      5_000,
+    );
+  } else {
+    // Defensive: getDiscordDesktopCdpStatus already returns supported=false
+    // for non-darwin/non-win32 platforms, so this branch shouldn't be
+    // reached. Throw rather than silently no-op so a misconfigured caller
+    // surfaces immediately.
+    throw new Error(
+      `Discord Desktop relaunch not supported on ${process.platform}.`,
+    );
   }
-
-  const port = configuredDiscordDesktopCdpPort(env);
-  await execFileAsync(
-    "/usr/bin/open",
-    [
-      "-a",
-      "Discord",
-      "--args",
-      `--remote-debugging-port=${port}`,
-      `--remote-debugging-address=${DISCORD_DESKTOP_CDP_HOST}`,
-      "--remote-allow-origins=*",
-    ],
-    5_000,
-  );
 
   return waitForDiscordCdpReady(env);
 }


### PR DESCRIPTION
Lifts the three macOS-only guards in plugin-discord's user-account-scraper Discord Desktop CDP fallback so the local-desktop-control path works on Windows too, and adds the \`accounts: { owner, agent }\` manifest block introduced by #7817's schema.

## Empirical verification

The user's PR plan flagged: \"Discord may have stripped \`--remote-debugging-port\` from production Windows builds.\" Tested empirically against Discord 1.0.9237 / Electron 37.6.0 on Windows 10:

- \`Discord.exe --remote-debugging-port=9224 --remote-debugging-address=127.0.0.1 --remote-allow-origins=*\` launches successfully
- \`GET http://127.0.0.1:9224/json/version\` returns \`Chrome/138.0.7204.251\` with the Discord User-Agent
- \`GET http://127.0.0.1:9224/json/list\` exposes the channels page target (\`https://discord.com/channels/@me\`, type \"page\", with webSocketDebuggerUrl) — exactly the shape the existing macOS pickDiscordTarget helper consumes

So **Windows CDP works end-to-end** with the same flag set. Each command path used by the new Windows branch (\`tasklist\`, \`taskkill\`, \`cmd /d /s /c start\`, CDP probe on port 9224) is empirically verified separately too.

## Three macOS-only sites lifted

- **\`discordAppRunning()\`** — branches on \`process.platform\`. macOS keeps \`pgrep -x Discord\`; Windows uses \`tasklist /FI \"IMAGENAME eq Discord.exe\" /FO CSV /NH\` and tests output for \`Discord.exe\` (returns false on \"INFO: No tasks are running...\", true when the CSV row appears).

- **\`getDiscordDesktopCdpStatus()\`** — the \`platform === \"darwin\"\` guards are replaced with a single \`isDiscordDesktopSupportedPlatform()\` predicate that accepts both \`\"darwin\"\` and \`\"win32\"\`. The lastError for unsupported platforms now reads \"macOS and Windows\".

- **\`relaunchDiscordDesktopForCdp()\`** — branches on platform for both quit and launch:
  - macOS: \`osascript -e 'quit app \"Discord\"'\` + \`open -a Discord --args ...\` (unchanged)
  - Windows: \`taskkill /F /T /IM Discord.exe\` (force-kills the whole tree; Discord otherwise stays in the tray) + \`cmd /d /s /c start \"\" <exe> ...args\` (parent returns immediately while Discord keeps running)

- **\`findDiscordExeWindows()\`** (new helper) — globs \`%LOCALAPPDATA%\Discord\app-*\Discord.exe\` and picks the highest numeric version. Discord on Windows is squirrel-installed per-user with each release unpacked into its own \`app-<version>\` folder; this avoids stranding on a stale executable during an in-flight self-update.

## Manifest

Adds \`accounts: { owner, agent }\` to discord.json:

- \`accounts.agent\` (authKind: \`api-key\`) — bot token path, all OSes
- \`accounts.owner\` (authKind: \`local-app\`, \`osSupport: [\"darwin\", \"win32\"]\`) — desktop CDP control path, restricted to the OSes where the relaunch code actually works

\`local-app\` rather than \`oauth-cloud\` because Discord doesn't expose user-token OAuth for third-party apps — the only way to act as the user's identity is by driving their logged-in desktop client.

## Out of scope (future work)

- **Linux support.** \`getDiscordDesktopCdpStatus\` returns \`supported: false\` on linux with a \"macOS and Windows\" lastError. Linux Discord is a different distribution path (deb/rpm vs squirrel), and Electron's CDP behavior on linux Discord builds isn't verified.
- **UI registration in \`CLOUD_OAUTH_CONNECTORS\`.** The Discord OWNER side doesn't go through cloud OAuth, so it doesn't belong in that map. Surfacing the local-app account in the connectors UI is a separate concern — the manifest declaration above is the substrate; the UI work is a follow-up.

## Verification

- \`packages/app-core\` schema tests: 13/13 pass
- \`bunx tsc --noEmit\` clean on \`discord-desktop-cdp.ts\` (pre-existing noise in unrelated cross-package types)
- \`discord.json\` validates against \`connectorEntrySchema\` (osSupport correctly typed as \`(\"darwin\" | \"win32\" | \"linux\")[]\`)
- Manual launch + CDP probe against Discord 1.0.9237 on Windows 10

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends `discord-desktop-cdp.ts`'s macOS-only CDP control surface to also run on Windows by branching `discordAppRunning`, `getDiscordDesktopCdpStatus`, and `relaunchDiscordDesktopForCdp` on `process.platform`, and adds a new `findDiscordExeWindows` helper that locates the highest-versioned squirrel-installed `Discord.exe` under `%LOCALAPPDATA%\\Discord`. The `discord.json` manifest gains an `accounts` block declaring `agent` (api-key) and `owner` (local-app, darwin+win32) identity slots matching the schema introduced by #7817.

- **Windows CDP path**: `discordAppRunning` queries `tasklist /FI \"IMAGENAME eq Discord.exe\"`, the relaunch path uses `taskkill /F /T /IM Discord.exe` + `cmd /d /s /c start \"\" <exePath> <cdpArgs>`, and `findDiscordExeWindows` picks the newest `app-*` subdirectory from `%LOCALAPPDATA%\\Discord`.
- **Manifest**: `accounts.owner` carries `osSupport: [\"darwin\", \"win32\"]` and `authKind: \"local-app\"`, correctly excluding Linux where the CDP path is unverified.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the Windows branch is logically sound and well-guarded, with no issues that would cause incorrect behavior on the established macOS path.

The Windows CDP control path is solid and empirically verified. Three small issues exist: Windows system binaries are resolved via PATH rather than full System32 paths; findDiscordExeWindows returns a path without confirming Discord.exe exists in the candidate directory; and an inline comment misstates the version-sort fallback behavior.

plugins/plugin-discord/user-account-scraper/discord-desktop-cdp.ts — specifically the new Windows helpers discordAppRunning, findDiscordExeWindows, and the relaunchDiscordDesktopForCdp win32 branch.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-discord/user-account-scraper/discord-desktop-cdp.ts | Lifts macOS-only guards to support Windows CDP control: adds `discordAppRunning` Windows branch via `tasklist`, new `findDiscordExeWindows` helper for squirrel-installed Discord, and a refactored `relaunchDiscordDesktopForCdp` with platform-branched kill/launch logic. Three minor issues: Windows system binaries invoked by name rather than full path, `findDiscordExeWindows` returns a path without verifying `Discord.exe` exists in the selected directory, and a misleading inline comment on the version-sort logic. |
| packages/app-core/src/registry/entries/connectors/discord.json | Adds `accounts.agent` (api-key) and `accounts.owner` (local-app, osSupport darwin+win32) manifest blocks; both match the `accountConfigSchema` shape and the `local-app` authKind defined in schema.ts. No issues found. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[relaunchDiscordDesktopForCdp] --> B{getDiscordDesktopCdpStatus}
    B --> C{platformSupported?}
    C -- No --> D[throw: unsupported platform]
    C -- Yes --> E{cdpAvailable?}
    E -- Yes --> F[return current status]
    E -- No --> G{process.platform}
    G -- darwin --> H{appRunning?}
    H -- Yes --> I[osascript: quit app Discord]
    I --> J[waitForDiscordToQuit]
    J --> K[open -a Discord --args cdpArgs]
    H -- No --> K
    G -- win32 --> L{appRunning?}
    L -- Yes --> M[taskkill /F /T /IM Discord.exe]
    M --> N[waitForDiscordToQuit]
    N --> O[findDiscordExeWindows]
    L -- No --> O
    O --> P{exePath found?}
    P -- No --> Q[throw: Discord.exe not found]
    P -- Yes --> R[cmd /d /s /c start exePath cdpArgs]
    G -- other --> S[throw: not supported]
    K --> T[waitForDiscordCdpReady]
    R --> T
    T --> U[poll getDiscordDesktopCdpStatus every 500ms]
    U --> V{cdpAvailable?}
    V -- Yes --> W[return status]
    V -- No, timeout --> X[throw: timeout]
    V -- No --> U
```

<sub>Reviews (1): Last reviewed commit: ["feat(plugin-discord): register Discord c..."](https://github.com/elizaos/eliza/commit/5fee5e408744ce4b0ebd36dcb7c110e0b364eccf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33127383)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->