### PR TITLE
fix(chip): classify missing RISC-V evidence as blocked

### DIFF
--- a/packages/chip/docs/project/prototype-status-dashboard.md
+++ b/packages/chip/docs/project/prototype-status-dashboard.md
@@ -8,24 +8,24 @@ Snapshot: updated after 2026-05-19 PD closure retry and local tool recovery.
 | --- | --- | --- | --- |
 | docs-and-project-plan | `PASS` | `command_pass` | `none` |
 | architecture-docs | `PASS` | `command_pass` | `none` |
-| toolchain-fast-path | `PASS` | `tool_available` | `none` |
+| toolchain-fast-path | `BLOCK` | `tool_blocker` | `scripts/check_tools.sh && scripts/tool_versions.sh` |
 | platform-contract | `PASS` | `command_pass` | `none` |
 | linux-boot-prerequisites | `PASS` | `command_pass` | `none` |
 | software-bsp | `BLOCK` | `scaffold_only` | `make software-bsp-evidence-check` |
 | real-world-release-gates | `PASS` | `command_pass` | `none` |
 | rtl-source | `PASS` | `source_present` | `none` |
-| synthesis | `PASS` | `generated_artifact` | `none` |
-| cocotb | `PASS` | `generated_artifact` | `none` |
-| verilator | `PASS` | `generated_artifact` | `none` |
-| formal | `PASS` | `generated_artifact` | `none` |
-| qemu | `PASS` | `generated_artifact` | `none` |
-| renode | `PASS` | `generated_artifact` | `none` |
+| synthesis | `BLOCK` | `tool_blocker` | `make synth` |
+| cocotb | `BLOCK` | `regen_required` | `make cocotb cocotb-npu cocotb-contract cocotb-cpu` |
+| verilator | `BLOCK` | `tool_blocker` | `make verilator` |
+| formal | `BLOCK` | `tool_blocker` | `make formal inside Docker/Nix` |
+| qemu | `BLOCK` | `tool_blocker` | `make qemu-check` |
+| renode | `BLOCK` | `tool_blocker` | `make renode-check` |
 | npu-ml-proof | `PASS` | `generated_artifact` | `none` |
 | minimum-linux-npu-target | `BLOCK` | `tool_blocker` | `make minimum-linux-npu-target-strict` |
 | pd-contract | `PASS` | `command_pass` | `none` |
 | product-package | `BLOCK` | `release_blocker` | `close package/FPGA/KiCad/PD/manufacturing release blockers or keep product claim below fabrication` |
-| benchmarks | `BLOCK` | `scaffold_only` | `python3 benchmarks/run_benchmarks.py run --metadata benchmarks/metadata/strict-blocked-template.json --strict-missing` |
-| release-pipeline | `PASS` | `generated_artifact` | `none` |
+| benchmarks | `BLOCK` | `regen_required` | `make benchmarks-dry-run or run the final-macbook-host-smoke benchmark set` |
+| release-pipeline | `BLOCK` | `regen_required` | `make tool-versions pipeline-check` |
 
 ## Workstream Dashboard
 

--- a/packages/chip/scripts/check_chipyard_generated_linux_contract.py
+++ b/packages/chip/scripts/check_chipyard_generated_linux_contract.py
@@ -48,9 +48,10 @@ def require(condition: bool, message: str, failures: list[str]) -> None:
         failures.append(message)
 
 
-def load_json(path: Path, failures: list[str]) -> dict:
+def load_json(path: Path, failures: list[str], blockers: list[str] | None = None) -> dict:
     if not path.is_file():
-        failures.append(f"missing {rel(path)}")
+        target = blockers if blockers is not None else failures
+        target.append(f"missing {rel(path)}")
         return {}
     try:
         data = json.loads(read(path))
@@ -73,9 +74,10 @@ def mem_region(memmap: dict, name: str) -> tuple[int, int] | None:
     return None
 
 
-def check_dts(failures: list[str]) -> None:
+def check_dts(failures: list[str], blockers: list[str]) -> None:
     for path in (DTS, GEN_DTS):
-        require(path.is_file(), f"missing generated DTS: {rel(path)}", failures)
+        if not path.is_file():
+            blockers.append(f"missing generated DTS: {rel(path)}")
     if not DTS.is_file():
         return
 
@@ -109,8 +111,8 @@ def check_dts(failures: list[str]) -> None:
     )
 
 
-def check_memmap(failures: list[str]) -> None:
-    memmap = load_json(MEMMAP, failures)
+def check_memmap(failures: list[str], blockers: list[str]) -> None:
+    memmap = load_json(MEMMAP, failures, blockers)
     if not memmap:
         return
 
@@ -131,7 +133,7 @@ def check_memmap(failures: list[str]) -> None:
         )
 
 
-def check_regmaps(failures: list[str]) -> None:
+def check_regmaps(failures: list[str], blockers: list[str]) -> None:
     required_by_regmap = {
         "boot_address": ["bitWidth"],
         "clint": ["msip_0", "mtimecmp_0", "mtime_0"],
@@ -139,7 +141,7 @@ def check_regmaps(failures: list[str]) -> None:
         "uart": ["txdata", "rxdata", "txctrl", "rxen", "ie", "ip", "div"],
     }
     for name, path in REGMAPS.items():
-        data = load_json(path, failures)
+        data = load_json(path, failures, blockers)
         if not data:
             continue
         text = json.dumps(data)
@@ -159,9 +161,9 @@ def bootrom_bytes_from_fir(path: Path) -> bytes:
     return bytes(image)
 
 
-def check_embedded_bootrom_dtb(failures: list[str]) -> None:
-    require(GEN_FIR.is_file(), f"missing generated FIR: {rel(GEN_FIR)}", failures)
+def check_embedded_bootrom_dtb(failures: list[str], blockers: list[str]) -> None:
     if not GEN_FIR.is_file():
+        blockers.append(f"missing generated FIR: {rel(GEN_FIR)}")
         return
 
     image = bootrom_bytes_from_fir(GEN_FIR)
@@ -202,7 +204,8 @@ def check_embedded_bootrom_dtb(failures: list[str]) -> None:
 
 
 def check_import_state(failures: list[str], blockers: list[str]) -> None:
-    require(VERILOG.is_file(), f"missing generated Verilog: {rel(VERILOG)}", failures)
+    if not VERILOG.is_file():
+        blockers.append(f"missing generated Verilog: {rel(VERILOG)}")
     if VERILOG.is_file():
         text = read(VERILOG)
         require(
@@ -240,24 +243,25 @@ def main() -> int:
 
     failures: list[str] = []
     blockers: list[str] = []
-    check_dts(failures)
-    check_memmap(failures)
-    check_regmaps(failures)
-    check_embedded_bootrom_dtb(failures)
+    check_dts(failures, blockers)
+    check_memmap(failures, blockers)
+    check_regmaps(failures, blockers)
+    check_embedded_bootrom_dtb(failures, blockers)
     check_import_state(failures, blockers)
 
     if failures:
         print("STATUS: FAIL chipyard.generated_linux_contract")
         for failure in failures:
             print(f"  - {failure}")
+        if blockers:
+            print("  blocked follow-up artifacts/evidence:")
+            for blocker in blockers:
+                print(f"    - {blocker}")
         return 1
 
-    print(
-        "STATUS: PASS chipyard.generated_linux_contract - generated DTS/memmap/regmaps expose minimum Linux launch nodes"
-    )
     if blockers:
         print(
-            "STATUS: BLOCKED chipyard.generated_linux_boot - generated AP is not boot-evidence complete:"
+            "STATUS: BLOCKED chipyard.generated_linux_contract - generated AP artifacts/evidence are not complete:"
         )
         for blocker in blockers:
             print(f"  - {blocker}")
@@ -269,6 +273,9 @@ def main() -> int:
         )
         return 1 if args.require_boot_evidence else 0
 
+    print(
+        "STATUS: PASS chipyard.generated_linux_contract - generated DTS/memmap/regmaps expose minimum Linux launch nodes"
+    )
     print("STATUS: PASS chipyard.generated_linux_boot")
     return 0
 

--- a/packages/chip/scripts/check_minimum_linux_target.py
+++ b/packages/chip/scripts/check_minimum_linux_target.py
@@ -105,6 +105,21 @@ def check_evidence(path: Path) -> dict[str, Any]:
             "blocked_marker": rel(blocked),
             "reason": text.splitlines()[0] if text else "",
         }
+    status_report = path.with_suffix(".json")
+    report = load_json(status_report)
+    if report.get("status") == "blocked":
+        blockers = report.get("blockers")
+        reason = ""
+        if isinstance(blockers, list) and blockers:
+            reason = str(blockers[0])
+        elif isinstance(report.get("progress"), dict):
+            reason = str(report["progress"].get("next_step", ""))
+        return {
+            "status": "blocked",
+            "path": rel(path),
+            "blocked_report": rel(status_report),
+            "reason": reason or "companion status report is blocked",
+        }
     return {"status": "missing", "path": rel(path), "blocked_marker": rel(blocked)}
 
 

--- a/packages/chip/scripts/run_qemu.sh
+++ b/packages/chip/scripts/run_qemu.sh
@@ -120,17 +120,38 @@ find_toolchain() {
         fi
     done
 
-    for cc in /opt/homebrew/opt/llvm/bin/clang clang; do
+    clang_candidates=${RISCV_CLANG_CANDIDATES:-"/opt/homebrew/opt/llvm/bin/clang clang"}
+    for cc in $clang_candidates; do
         if command -v "$cc" >/dev/null 2>&1; then
-            if "$cc" --target=riscv64-unknown-elf -fuse-ld=lld -x assembler -c /dev/null -o /tmp/eliza-riscv-toolchain-test.o >/dev/null 2>&1; then
-                rm -f /tmp/eliza-riscv-toolchain-test.o
+            if clang_can_link_riscv_elf "$cc"; then
                 printf '%s\n' "$cc"
                 return 0
             fi
-            rm -f /tmp/eliza-riscv-toolchain-test.o
         fi
     done
 
+    return 1
+}
+
+clang_can_link_riscv_elf() {
+    cc=$1
+    test_base="${TMPDIR:-/tmp}/eliza-riscv-toolchain-test.$$"
+    test_src="${test_base}.S"
+    test_elf="${test_base}.elf"
+    cat >"$test_src" <<'EOF'
+.section .text
+.globl _start
+_start:
+    j _start
+EOF
+    if "$cc" --target=riscv64-unknown-elf -fuse-ld=lld \
+        -nostdlib -nostartfiles -ffreestanding \
+        -march=rv64imac -mabi=lp64 \
+        -x assembler "$test_src" -o "$test_elf" >/dev/null 2>&1; then
+        rm -f "$test_src" "$test_elf"
+        return 0
+    fi
+    rm -f "$test_src" "$test_elf"
     return 1
 }
 

--- a/packages/chip/scripts/test_qemu_smoke_status.py
+++ b/packages/chip/scripts/test_qemu_smoke_status.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import stat
 import subprocess
 import tempfile
@@ -26,6 +27,14 @@ QEMU_OS_ATTEMPT_MANIFEST = ROOT / "build/reports/qemu_os_boot_attempt.json"
 def write_executable(path: Path, text: str) -> None:
     path.write_text(text)
     path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def link_host_tools(bindir: Path, *names: str) -> None:
+    for name in names:
+        host_tool = shutil.which(name)
+        if host_tool is None:
+            raise AssertionError(f"missing host tool required by test: {name}")
+        (bindir / name).symlink_to(host_tool)
 
 
 def run_check(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
@@ -98,6 +107,35 @@ def test_build_failure_is_fail() -> None:
             f"expected build failure to exit 1, got {result.returncode}\n{result.stdout}"
         )
     assert_contains(result.stdout, "STATUS: FAIL qemu.build")
+
+
+def test_autodetected_clang_without_lld_is_blocked() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        bindir = Path(td)
+        link_host_tools(bindir, "cat", "dirname", "grep", "mkdir", "rm", "rmdir", "sh")
+        clang = bindir / "clang"
+        write_executable(
+            clang,
+            "#!/bin/sh\n"
+            'case "$*" in\n'
+            "  *-fuse-ld=lld*) echo 'clang: error: invalid linker name in argument' >&2; exit 1 ;;\n"
+            "  *) exit 0 ;;\n"
+            "esac\n",
+        )
+        result = run_check(
+            {
+                "PATH": str(bindir),
+                "RISCV_CC": "",
+                "RISCV_CLANG_CANDIDATES": "clang",
+                "REQUIRE_QEMU": "0",
+            }
+        )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"expected missing lld to be non-strict BLOCKED, got {result.returncode}\n{result.stdout}"
+        )
+    assert_contains(result.stdout, "STATUS: PASS qemu.semantic")
+    assert_contains(result.stdout, "STATUS: BLOCKED qemu.build")
 
 
 def test_fake_toolchain_and_qemu_pass() -> None:
@@ -275,6 +313,7 @@ def main() -> int:
         test_missing_toolchain_is_non_strict_blocked,
         test_missing_toolchain_is_strict_blocked,
         test_build_failure_is_fail,
+        test_autodetected_clang_without_lld_is_blocked,
         test_fake_toolchain_and_qemu_pass,
         test_os_boot_check_blocks_without_payloads,
         test_os_boot_check_fails_on_kernel_panic,

--- a/packages/chip/verify/ai_eda/coverage_bins/e1_interrupt_reset_edges.yaml
+++ b/packages/chip/verify/ai_eda/coverage_bins/e1_interrupt_reset_edges.yaml
@@ -6,7 +6,7 @@ source_ids:
 dut: e1_linux_soc_contract
 scope: >
   Dry-run coverage targets for future AI-assisted cocotb stimulus proposals
-  against interrupt-controller, CLINT placeholder, and reset-domain edges.
+  against interrupt-controller, future CLINT, and reset-domain edges.
   Candidate tests are not evidence until accepted into source and passing the
   named cocotb gates.
 required_followup_gates:
@@ -34,6 +34,6 @@ bins:
       - verify/cocotb/test_reset_domain_cleanup.py::reset_clears_handshake_signals
   - id: clint_future_timer_irq_contract
     description: Future CLINT timer interrupt contract must elaborate even while skipped.
-    required_observation: skipped scaffold remains discoverable until CLINT lands in the SoC contract
+    required_observation: fail-closed skipped contract remains discoverable until CLINT lands in the SoC contract
     existing_reference:
       - verify/cocotb/test_clint_timer_irq.py::clint_timer_irq_fires_when_mtime_ge_mtimecmp


### PR DESCRIPTION
## Summary

- Treat absent generated Chipyard/AP Linux artifacts as `BLOCKED` evidence work instead of source-contract `FAIL` in the generated Linux contract gate.
- Let the minimum Linux target gate consume companion blocked Verilator smoke JSON when the transcript has not been captured yet.
- Fix QEMU toolchain detection so auto-detected clang without a working `ld.lld` is reported as `BLOCKED`, not a build regression.
- Add a hermetic qemu-status regression test that isolates the clang path with `RISCV_CLANG_CANDIDATES`, without falling through to host RISC-V GCC toolchains.
- Refresh the prototype status dashboard to match current MVP gate output and remove silent placeholder wording from the AI EDA coverage-bin file.
- Address Greptile follow-ups: collapse the duplicate `GEN_FIR.is_file()` check and print blocked follow-up artifacts/evidence alongside hard failures.

## Validation

- `python3 verify/check_stub_audit.py`
- `python3 scripts/check_prototype_status_dashboard.py`
- `make qemu-status-test`
- `make chipyard-generated-linux-contract-check`
- `.venv/bin/ruff format --check packages/chip/scripts/test_qemu_smoke_status.py packages/chip/scripts/check_chipyard_generated_linux_contract.py packages/chip/scripts/check_minimum_linux_target.py`
- `.venv/bin/ruff check packages/chip/scripts/test_qemu_smoke_status.py packages/chip/scripts/check_chipyard_generated_linux_contract.py packages/chip/scripts/check_minimum_linux_target.py`
- `sh -n packages/chip/scripts/run_qemu.sh`
- `python3 -m py_compile packages/chip/scripts/test_qemu_smoke_status.py packages/chip/scripts/check_chipyard_generated_linux_contract.py`
- `git diff --check`
- `python3 scripts/test_minimum_linux_npu_target.py`
- `python3 scripts/test_cpu_ap_boot_readiness.py`

## CI / Remaining Noise

- PR is mergeable and the production Docker image smoke now passes on this branch.
- The current broad CI failures are not caused by this diff: repo-wide server/client/plugin/Electrobun failures, homepage Biome formatting drift, and `docker-regression` broad `packages/chip` ruff/format failures in existing chip scripts outside this PR's changed files.
- A local broad readiness rollup on this host reports `PASS=41 FAIL=1 BLOCKED=29`; the lone `FAIL` is `os-rv64-release-check` failing before gate logic because the active interpreter lacks `jsonschema`. That is a separate reproducible-deps cleanup candidate, not a RISC-V evidence-classification claim from this PR.

## Claim Boundary

This PR does not claim RISC-V Linux, AOSP, generated AP, board, or silicon boot. The remaining items are still blocked on real generated artifacts, toolchains, and boot transcripts; this only fixes classification so missing evidence is not reported as checked-in source failure.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the classification of missing Chipyard/AP Linux artifacts from `FAIL` (source contract violation) to `BLOCKED` (absent evidence) across three Python gate scripts, and fixes QEMU toolchain detection so a `clang`-without-`lld` situation is also reported as `BLOCKED` rather than a build regression.

- **`check_chipyard_generated_linux_contract.py`**: All four artifact-presence checks now funnel into a shared `blockers` list; when failures and blockers coexist the FAIL branch additionally prints the blocked items so engineers see the full picture in one run.
- **`check_minimum_linux_target.py`**: `check_evidence` gains a companion-JSON fallback so a sibling `.json` status report with `status: "blocked"` is consumed instead of reporting the log file as "missing" (an error).
- **`run_qemu.sh` / `test_qemu_smoke_status.py`**: `clang_can_link_riscv_elf` is extracted into its own function, `RISCV_CLANG_CANDIDATES` allows test injection, and a new test isolates the detection path by restricting `PATH` to a minimal fake `bindir`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes narrow the classification of missing evidence from FAIL to BLOCKED, which is strictly less alarming and matches the stated claim boundary.

The logic changes are additive: a new blockers path is threaded through existing check functions without altering the success or real-failure paths. The companion-JSON check in check_minimum_linux_target is guarded by an explicit status comparison and falls through to the previous "missing" result for any other status value. The clang toolchain refactor is exercised by a new test that correctly isolates the detection path. No data is lost and no check is silently weakened.

No files require special attention; the style-only redundancies in check_chipyard_generated_linux_contract.py and run_qemu.sh do not affect runtime behaviour.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/chip/scripts/check_chipyard_generated_linux_contract.py | Refactored check_* functions to accept a blockers list; missing generated artifacts now route to BLOCKED instead of FAIL. Double is_file() pattern in check_import_state is a minor redundancy. |
| packages/chip/scripts/check_minimum_linux_target.py | Adds companion .json status-report check so verilator-smoke and similar log evidence can be classified BLOCKED (not missing/error) when the report file says blocked. |
| packages/chip/scripts/run_qemu.sh | Extracts clang_can_link_riscv_elf into its own function and adds RISCV_CLANG_CANDIDATES env-var override. Word-splitting of the variable is intentional but undocumented. |
| packages/chip/scripts/test_qemu_smoke_status.py | Adds link_host_tools helper and test_autodetected_clang_without_lld_is_blocked; PATH is restricted to bindir, correctly isolating the clang detection path from system GCC tools. |
| packages/chip/docs/project/prototype-status-dashboard.md | Dashboard refreshed to align with current gate output — several items corrected from PASS to BLOCK with updated reason codes and commands. |
| packages/chip/verify/ai_eda/coverage_bins/e1_interrupt_reset_edges.yaml | Minor wording cleanup: removes placeholder language from the coverage-bin scope and CLINT bin description. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(chip): classify missing riscv eviden..."](https://github.com/elizaos/eliza/commit/6856e829afb9f5c52b3c412acfe9f167ca2bcf72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33141675)</sub>

<!-- /greptile_comment -->