### PR TITLE
chore(cloud-shared/oauth): stop dual-writing legacy agentGoogleSide

### DIFF
--- a/packages/cloud-shared/src/lib/services/oauth/providers/oauth2.ts
+++ b/packages/cloud-shared/src/lib/services/oauth/providers/oauth2.ts
@@ -98,15 +98,14 @@ function getStoredConnectionRole(sourceContext: unknown): OAuthStandardConnectio
 function connectionSourceContext(
   connectionRole: OAuthStandardConnectionRole,
 ): PlatformCredentialSourceContext {
-  const sourceContext: PlatformCredentialSourceContext = {
-    connectionRole,
-  };
-  if (connectionRole === "OWNER") {
-    sourceContext.agentGoogleSide = "owner";
-  } else if (connectionRole === "AGENT") {
-    sourceContext.agentGoogleSide = "agent";
-  }
-  return sourceContext;
+  // We intentionally no longer write `agentGoogleSide`. `connectionRole`
+  // is the canonical field; existing rows that only have the legacy
+  // field are still readable via the fallbacks in `getStoredConnectionRole`
+  // (above, line 95), `oauth-service.ts` (`agentGoogleSide` fallback),
+  // and `connection-adapters/generic-adapter.ts`. The upsert
+  // setWhere clause below also COALESCEs both fields so a re-link
+  // matches the original row.
+  return { connectionRole };
 }
 
 function oauthSecretName(


### PR DESCRIPTION
## What

Drop the dual-write of the legacy lowercase `agentGoogleSide` field in `source_context` when persisting OAuth credentials. `connectionRole` ("OWNER" | "AGENT" | "TEAM") is the canonical field and remains the only field written by `connectionSourceContext()` after this change.

## Why

`agentGoogleSide` was kept as a transitional dual-write for older readers, but the only remaining readers already COALESCE both fields:

- `getStoredConnectionRole()` in this same file at line 95: `context.connectionRole ?? context.agentGoogleSide`
- `packages/cloud-shared/src/lib/services/oauth/oauth-service.ts:140` — same fallback
- `packages/cloud-shared/src/lib/services/oauth/connection-adapters/generic-adapter.ts:117` — same fallback
- The upsert's `setWhere` SQL (oauth2.ts:869-876) also COALESCEs both, so a re-link against a row that only has the legacy field still matches the existing row instead of creating a duplicate.

With every reader handling both shapes, the dual-write is no longer load-bearing. Existing rows that carry `agentGoogleSide` continue to resolve correctly; new rows are slimmer.

This was called out as a recommended follow-up in PR #7852 (plugin-google OWNER+AGENT, which made plugin-google's `roleFromMetadata` agnostic to the cloud-side field name).

## Scope

One-file change: `packages/cloud-shared/src/lib/services/oauth/providers/oauth2.ts` — `connectionSourceContext()` returns `{ connectionRole }` only, with an inline comment listing the read fallbacks that keep backward compat working.

## Risk

Low. No reader path changes. Both INSERT (line 860) and UPDATE (line 889) of the upsert at the bottom of `linkOAuthConnection()` flow through this function, so both sides stop writing the legacy field at the same instant — no partial-state window.

## Verification

- `git grep -n agentGoogleSide packages/cloud-shared/src/lib/services/oauth/` after the change shows ONLY the read fallbacks (`oauth-service.ts:140`, `generic-adapter.ts:117`, `oauth2.ts:95` + the SQL COALESCE at `oauth2.ts:872-873`) — zero remaining writes.
- `bunx tsc --noEmit -p packages/cloud-shared/tsconfig.json` produces no new errors in the touched file (the monorepo has pre-existing bun-only module resolution noise unrelated to this change).
- Manual: link a Google OWNER + Google AGENT pair on a fresh org, inspect `source_context` in `platform_credentials` — both should carry `connectionRole` but NOT `agentGoogleSide`. An older row created prior to this change should still resolve to the right role via the fallback chain.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the legacy `agentGoogleSide` dual-write from `connectionSourceContext()`, leaving `connectionRole` as the sole field written into `source_context` when persisting OAuth credentials.

- All three read paths (`getStoredConnectionRole` in `oauth2.ts`, `oauth-service.ts`, and `generic-adapter.ts`) already use a `connectionRole ?? agentGoogleSide` fallback, so existing rows that only carry the old field continue to resolve correctly.
- The upsert's `setWhere` SQL also COALESCEs both fields, so a re-link against a legacy row still matches the original row rather than creating a duplicate.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only change is dropping a redundant write, and every read path already has the fallback needed to handle both old and new row shapes.

The change is a single-line simplification of connectionSourceContext(). All three read sites use connectionRole ?? agentGoogleSide, the upsert setWhere COALESCEs both fields, and no new code paths are introduced. Existing rows carrying only agentGoogleSide continue to resolve correctly, and new rows will simply be a field slimmer.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cloud-shared/src/lib/services/oauth/providers/oauth2.ts | Removes legacy agentGoogleSide dual-write from connectionSourceContext(); all downstream readers and SQL upsert already carry the fallback, making the change safe. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant connectionSourceContext
    participant DB as platform_credentials (DB)
    participant Reader as getStoredConnectionRole / adapters

    Caller->>connectionSourceContext: "connectionRole (OWNER|AGENT|TEAM)"
    connectionSourceContext-->>Caller: "{ connectionRole } (no agentGoogleSide)"

    Caller->>DB: "INSERT/UPDATE source_context = { connectionRole }"

    Note over DB: Legacy rows still hold agentGoogleSide only

    Reader->>DB: read source_context
    DB-->>Reader: "{ connectionRole } OR { agentGoogleSide }"
    Reader->>Reader: context.connectionRole ?? context.agentGoogleSide
    Reader-->>Caller: resolved OAuthStandardConnectionRole
```

<sub>Reviews (1): Last reviewed commit: ["chore(cloud-shared/oauth): stop dual-wri..."](https://github.com/elizaos/eliza/commit/5eaee5cc3eaefef230ecb93c8a3f63fcd8408c9b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33149863)</sub>

<!-- /greptile_comment -->