### PR TITLE
fix(os-rv64): make release gate deps fail closed

### DIFF
--- a/packages/os/linux/variants/elizaos-debian-riscv64/Makefile
+++ b/packages/os/linux/variants/elizaos-debian-riscv64/Makefile
@@ -30,8 +30,9 @@ IMAGE_TAG ?= elizaos-debian-riscv64-builder
 
 CHECK_SCRIPT := $(SCRIPTS)/check_release_manifest.py
 BRING_UP_STATUS_SCRIPT := $(SCRIPTS)/bring_up_status.py
+REQUIREMENTS := $(HERE)requirements.txt
 
-.PHONY: help build-image build \
+.PHONY: help deps build-image build \
         qemu-boot qemu-virt-boot qemu-virt-boot-docker qemu-virt-boot-evidence qemu-virt-boot-test \
         release-check release-check-strict release-check-test \
         bring-up-status
@@ -39,6 +40,7 @@ BRING_UP_STATUS_SCRIPT := $(SCRIPTS)/bring_up_status.py
 help:
 	@echo "elizaOS Debian RISC-V 64 — make targets"
 	@echo
+	@echo "  deps                   Install variant Python validation dependencies."
 	@echo "  build-image            Build the Docker builder image ($(IMAGE_TAG))."
 	@echo "  build                  Run the builder to produce out/elizaos-debian-riscv64-<ts>.iso."
 	@echo "  qemu-boot              Boot the newest ISO under qemu-system-riscv64 -M virt."
@@ -57,6 +59,9 @@ help:
 	@echo "  IMAGE_TAG=$(IMAGE_TAG)"
 	@echo "  OUT_DIR=$(OUT_DIR)"
 	@echo "  EVIDENCE_DIR=$(EVIDENCE_DIR)"
+
+deps:
+	$(PYTHON) -m pip install -r $(REQUIREMENTS)
 
 build-image:
 	$(DOCKER) build -t $(IMAGE_TAG) $(HERE)

--- a/packages/os/linux/variants/elizaos-debian-riscv64/docs/e2e-qemu-virt.md
+++ b/packages/os/linux/variants/elizaos-debian-riscv64/docs/e2e-qemu-virt.md
@@ -42,7 +42,18 @@ The build is containerised; the qemu boot is not. You need:
 The validator script (`scripts/check_release_manifest.py`) only depends
 on `jsonschema` from the Python standard ecosystem and on the standard
 library. The unit-test file additionally uses `hypothesis`; both are
-already pinned in the repo's Python tooling.
+pinned in this variant's `requirements.txt`.
+
+Install those optional validation dependencies when you want full schema
+validation and property tests:
+
+```sh
+make -C packages/os/linux/variants/elizaos-debian-riscv64 deps
+```
+
+Without those dependencies, the release gate does not crash: missing
+`jsonschema` is reported as `BLOCKED` evidence infrastructure, and the
+Hypothesis mutation tests are skipped with an explicit message.
 
 ## Step 0 — sanity check
 

--- a/packages/os/linux/variants/elizaos-debian-riscv64/requirements.txt
+++ b/packages/os/linux/variants/elizaos-debian-riscv64/requirements.txt
@@ -1,0 +1,2 @@
+jsonschema>=4,<5
+hypothesis>=6,<7

--- a/packages/os/linux/variants/elizaos-debian-riscv64/scripts/check_release_manifest.py
+++ b/packages/os/linux/variants/elizaos-debian-riscv64/scripts/check_release_manifest.py
@@ -36,7 +36,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-import jsonschema
+try:
+    import jsonschema
+except ModuleNotFoundError:
+    jsonschema = None
 
 VARIANT_DIR = Path(__file__).resolve().parents[1]
 REPO_ROOT = VARIANT_DIR.parents[4]
@@ -184,6 +187,15 @@ def _select_manifest(variant_dir: Path) -> tuple[Path, dict, bool]:
 
 def check_schema(manifest: dict, schema: dict) -> list[GateResult]:
     """Validate the variant manifest as a single ``artifacts[]`` entry."""
+    if jsonschema is None:
+        return [
+            GateResult(
+                "BLOCKED",
+                "python dependency missing: jsonschema; run "
+                "`python3 -m pip install -r packages/os/linux/variants/"
+                "elizaos-debian-riscv64/requirements.txt`",
+            )
+        ]
     artifact_schema = _artifact_schema(schema)
     validator = jsonschema.Draft202012Validator(artifact_schema)
     errors = sorted(validator.iter_errors(manifest), key=lambda err: list(err.path))

--- a/packages/os/linux/variants/elizaos-debian-riscv64/scripts/test_check_release_manifest.py
+++ b/packages/os/linux/variants/elizaos-debian-riscv64/scripts/test_check_release_manifest.py
@@ -18,8 +18,13 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from hypothesis import HealthCheck, given, settings
-from hypothesis import strategies as st
+try:
+    from hypothesis import HealthCheck, given, settings
+    from hypothesis import strategies as st
+
+    HAS_HYPOTHESIS = True
+except ModuleNotFoundError:
+    HAS_HYPOTHESIS = False
 
 THIS_DIR = Path(__file__).resolve().parent
 if str(THIS_DIR) not in sys.path:
@@ -156,7 +161,9 @@ class _Sandbox:
         self.evidence_path = self.tmpdir / "evidence" / "qemu_virt_boot.json"
         self.evidence_payload = _good_evidence(self.iso_path, self.transcript_path)
         self.evidence_path.write_text(json.dumps(self.evidence_payload))
-        self.grub_evidence_path = self.tmpdir / "evidence" / "grub_efi_riscv64_boot.json"
+        self.grub_evidence_path = (
+            self.tmpdir / "evidence" / "grub_efi_riscv64_boot.json"
+        )
         self.grub_evidence_payload = _good_grub_evidence(
             self.iso_path, self.transcript_path
         )
@@ -192,6 +199,22 @@ def _run(sandbox: _Sandbox) -> tuple[gate.Status, list[gate.GateResult]]:
     return status, results
 
 
+class DependencyTests(unittest.TestCase):
+    def test_missing_jsonschema_blocks_instead_of_crashing(self) -> None:
+        original = gate.jsonschema
+        try:
+            gate.jsonschema = None
+            results = gate.check_schema({}, {})
+        finally:
+            gate.jsonschema = original
+        self.assertEqual(results[0].status, "BLOCKED")
+        self.assertIn("jsonschema", results[0].message)
+
+
+@unittest.skipUnless(
+    gate.jsonschema is not None,
+    "jsonschema is required for full release-manifest validation; install requirements.txt",
+)
 class FixedPathTests(unittest.TestCase):
     def setUp(self) -> None:
         self.sandbox = _Sandbox()
@@ -265,7 +288,9 @@ class FixedPathTests(unittest.TestCase):
         status, results = _run(self.sandbox)
         self.assertEqual(status, "FAIL")
         self.assertTrue(
-            any("GRUB transcript missing required marker" in r.message for r in results),
+            any(
+                "GRUB transcript missing required marker" in r.message for r in results
+            ),
             msg=[(r.status, r.message) for r in results],
         )
 
@@ -334,76 +359,88 @@ class FixedPathTests(unittest.TestCase):
         self.assertEqual(status, "FAIL")
 
 
-class MutationFuzz(unittest.TestCase):
-    """Hypothesis-driven mutations covering every top-level required field."""
+if HAS_HYPOTHESIS:
 
-    # Top-level required fields per the umbrella schema's artifacts[] items.
-    _REQUIRED_TOP_LEVEL = (
-        "id",
-        "kind",
-        "target",
-        "filename",
-        "downloadUrl",
-        "status",
-        "sizeBytes",
-        "sha256",
-        "validation",
-    )
+    class MutationFuzz(unittest.TestCase):
+        """Hypothesis-driven mutations covering every top-level required field."""
 
-    def setUp(self) -> None:
-        self.sandbox = _Sandbox()
-
-    def tearDown(self) -> None:
-        self.sandbox.cleanup()
-
-    @settings(
-        deadline=None,
-        max_examples=25,
-        suppress_health_check=[HealthCheck.function_scoped_fixture],
-    )
-    @given(field=st.sampled_from(_REQUIRED_TOP_LEVEL))
-    def test_dropping_required_field_fails(self, field: str) -> None:
-        payload = json.loads(json.dumps(self.sandbox.manifest_payload))
-        payload.pop(field, None)
-        self.sandbox.write_manifest(payload)
-        status, results = _run(self.sandbox)
-        self.assertIn(
-            status,
-            ("FAIL", "BLOCKED"),
-            msg=f"dropping {field} produced {status} {[(r.status, r.message) for r in results]}",
+        # Top-level required fields per the umbrella schema's artifacts[] items.
+        _REQUIRED_TOP_LEVEL = (
+            "id",
+            "kind",
+            "target",
+            "filename",
+            "downloadUrl",
+            "status",
+            "sizeBytes",
+            "sha256",
+            "validation",
         )
-        # Dropping a structural field must surface as FAIL, never silently PASS.
-        self.assertNotEqual(status, "PASS")
 
-    @settings(
-        deadline=None,
-        max_examples=25,
-        suppress_health_check=[HealthCheck.function_scoped_fixture],
-    )
-    @given(garbage=st.text(min_size=1, max_size=16))
-    def test_garbage_sha256_fails(self, garbage: str) -> None:
-        payload = json.loads(json.dumps(self.sandbox.manifest_payload))
-        payload["sha256"] = garbage
-        self.sandbox.write_manifest(payload)
-        status, _results = _run(self.sandbox)
-        # Either the schema (regex) or the cross-check catches it; PASS is illegal.
-        self.assertNotEqual(status, "PASS")
+        def setUp(self) -> None:
+            self.sandbox = _Sandbox()
 
-    @settings(
-        deadline=None,
-        max_examples=10,
-        suppress_health_check=[HealthCheck.function_scoped_fixture],
-    )
-    @given(
-        bad_status=st.sampled_from(["missing", "waived", "not-required"]),
-    )
-    def test_promoted_with_uncollected_row_fails(self, bad_status: str) -> None:
-        payload = json.loads(json.dumps(self.sandbox.manifest_payload))
-        payload["status"] = "candidate"
-        payload["validation"]["evidence"][1]["status"] = bad_status
-        self.sandbox.write_manifest(payload)
-        status, results = _run(self.sandbox)
-        self.assertEqual(status, "FAIL", msg=[(r.status, r.message) for r in results])
+        def tearDown(self) -> None:
+            self.sandbox.cleanup()
+
+        @settings(
+            deadline=None,
+            max_examples=25,
+            suppress_health_check=[HealthCheck.function_scoped_fixture],
+        )
+        @given(field=st.sampled_from(_REQUIRED_TOP_LEVEL))
+        def test_dropping_required_field_fails(self, field: str) -> None:
+            payload = json.loads(json.dumps(self.sandbox.manifest_payload))
+            payload.pop(field, None)
+            self.sandbox.write_manifest(payload)
+            status, results = _run(self.sandbox)
+            self.assertIn(
+                status,
+                ("FAIL", "BLOCKED"),
+                msg=f"dropping {field} produced {status} {[(r.status, r.message) for r in results]}",
+            )
+            # Dropping a structural field must surface as FAIL, never silently PASS.
+            self.assertNotEqual(status, "PASS")
+
+        @settings(
+            deadline=None,
+            max_examples=25,
+            suppress_health_check=[HealthCheck.function_scoped_fixture],
+        )
+        @given(garbage=st.text(min_size=1, max_size=16))
+        def test_garbage_sha256_fails(self, garbage: str) -> None:
+            payload = json.loads(json.dumps(self.sandbox.manifest_payload))
+            payload["sha256"] = garbage
+            self.sandbox.write_manifest(payload)
+            status, _results = _run(self.sandbox)
+            # Either the schema (regex) or the cross-check catches it; PASS is illegal.
+            self.assertNotEqual(status, "PASS")
+
+        @settings(
+            deadline=None,
+            max_examples=10,
+            suppress_health_check=[HealthCheck.function_scoped_fixture],
+        )
+        @given(
+            bad_status=st.sampled_from(["missing", "waived", "not-required"]),
+        )
+        def test_promoted_with_uncollected_row_fails(self, bad_status: str) -> None:
+            payload = json.loads(json.dumps(self.sandbox.manifest_payload))
+            payload["status"] = "candidate"
+            payload["validation"]["evidence"][1]["status"] = bad_status
+            self.sandbox.write_manifest(payload)
+            status, results = _run(self.sandbox)
+            self.assertEqual(
+                status, "FAIL", msg=[(r.status, r.message) for r in results]
+            )
+
+else:
+
+    class MutationFuzz(unittest.TestCase):
+        def test_hypothesis_dependency_missing(self) -> None:
+            self.skipTest(
+                "hypothesis is required for mutation fuzz tests; install requirements.txt"
+            )
 
 
 class AggregationTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Add variant-local Python validation requirements for the Debian RISC-V 64 release gate (`jsonschema`, `hypothesis`).
- Make `check_release_manifest.py` fail closed when `jsonschema` is missing instead of crashing at import time.
- Make release-manifest tests usable on fresh hosts: fixed-path schema tests skip explicitly when `jsonschema` is absent, and Hypothesis mutation tests skip explicitly when `hypothesis` is absent.
- Add `make deps` and update the qemu/release docs so operators have a first-class setup path for full validation.

## Validation

Fresh host / no dependency mode:

- `make -C packages/os/linux/variants/elizaos-debian-riscv64 release-check`
  - exits 0 with `STATUS: BLOCKED`, including `python dependency missing: jsonschema`
- `make -C packages/os/linux/variants/elizaos-debian-riscv64 release-check-strict`
  - exits non-zero as expected because BLOCKED counts as release-blocking under strict mode
- `make -C packages/os/linux/variants/elizaos-debian-riscv64 release-check-test`
  - passes with explicit skips for full schema/property tests when deps are absent

Full dependency mode:

- `make -C packages/os/linux/variants/elizaos-debian-riscv64 PYTHON=/home/nubs/Git/iqlabs/elizaos-riscv-help/.venv/bin/python release-check-test`
  - ran 22 tests, all passing
- `make -C packages/os/linux/variants/elizaos-debian-riscv64 PYTHON=/home/nubs/Git/iqlabs/elizaos-riscv-help/.venv/bin/python release-check`
  - schema check passes, remaining missing artifact rows correctly report `STATUS: BLOCKED`

Other checks:

- `make -C packages/os/linux/variants/elizaos-debian-riscv64 qemu-virt-boot-test`
- `/home/nubs/Git/iqlabs/elizaos-riscv-help/.venv/bin/ruff format --check packages/os/linux/variants/elizaos-debian-riscv64/scripts/check_release_manifest.py packages/os/linux/variants/elizaos-debian-riscv64/scripts/test_check_release_manifest.py`
- `/home/nubs/Git/iqlabs/elizaos-riscv-help/.venv/bin/ruff check packages/os/linux/variants/elizaos-debian-riscv64/scripts/check_release_manifest.py packages/os/linux/variants/elizaos-debian-riscv64/scripts/test_check_release_manifest.py`
- `python3 -m py_compile packages/os/linux/variants/elizaos-debian-riscv64/scripts/check_release_manifest.py packages/os/linux/variants/elizaos-debian-riscv64/scripts/test_check_release_manifest.py`
- `git diff --check`

## Claim Boundary

This PR does not claim an OS RV64 ISO, qemu boot, GRUB boot, agent health, or hardware boot. It only ensures the release gate and its tests degrade to explicit BLOCKED/skipped states when optional Python validation dependencies are absent, and documents the setup path for full validation.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the Debian RISC-V 64 release gate so that missing optional Python dependencies (`jsonschema`, `hypothesis`) produce explicit, graceful outcomes rather than import-time crashes or opaque failures.

- `check_release_manifest.py` now wraps the `jsonschema` import in a try/except; `check_schema()` returns a `BLOCKED` result (instead of crashing) when the module is absent, leaving all other gate checks active.
- `test_check_release_manifest.py` adds a `DependencyTests` class to cover the new BLOCKED path, guards `FixedPathTests` with `@unittest.skipUnless(gate.jsonschema is not None, …)`, and splits `MutationFuzz` into a real class (when `hypothesis` is present) and a `skipTest` stub (when absent) — keeping `unittest` output clean with explicit skip messages in both cases.
- A new `requirements.txt` pins `jsonschema>=4,<5` and `hypothesis>=6,<7`, and a `make deps` target provides a first-class install path documented in `docs/e2e-qemu-virt.md`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are confined to a single variant's release-gate tooling and tests, with no impact on the build pipeline or other packages.

The logic is sound and well-tested. The one issue is that `make deps` calls `pip install` without `--user`, which will fail on any modern Debian/Ubuntu host whose Python is externally managed — the documented `make deps` example doesn't mention needing a virtual environment. This is a usability rough edge for new operators, but it doesn't affect the gate's correctness or the rest of the codebase.

The `Makefile` `deps` target is the only spot that warrants a second look; all other changed files are clean.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/os/linux/variants/elizaos-debian-riscv64/Makefile | Adds REQUIREMENTS variable, `deps` .PHONY target, and help text; target runs pip install without --user which can fail on externally-managed Python environments |
| packages/os/linux/variants/elizaos-debian-riscv64/requirements.txt | New file pinning jsonschema>=4,<5 and hypothesis>=6,<7; version ranges are appropriate for the APIs used |
| packages/os/linux/variants/elizaos-debian-riscv64/scripts/check_release_manifest.py | Converts hard jsonschema import to soft try/except; check_schema returns BLOCKED instead of crashing when module is absent; logic and guard placement are correct |
| packages/os/linux/variants/elizaos-debian-riscv64/scripts/test_check_release_manifest.py | Converts hypothesis import to soft try/except; adds DependencyTests for the new BLOCKED behavior; FixedPathTests guarded with @unittest.skipUnless; MutationFuzz split into real/stub branches; all test assertions remain valid under both dependency modes |
| packages/os/linux/variants/elizaos-debian-riscv64/docs/e2e-qemu-virt.md | Updated to document requirements.txt location, make deps command, and degraded-mode behavior; accurate and consistent with the code changes |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[make release-check] --> B[check_release_manifest.py]
    B --> C{jsonschema\navailable?}
    C -- No --> D["check_schema → BLOCKED\n(python dependency missing)"]
    C -- Yes --> E[check_schema → PASS / FAIL]
    D --> F[remaining checks run normally]
    E --> F
    F --> G[aggregate results]
    G --> H{aggregate\nstatus?}
    H -- PASS --> I[exit 0]
    H -- BLOCKED --> J{--strict\nflag?}
    H -- FAIL --> K[exit 1]
    J -- No --> I
    J -- Yes --> K
```

<sub>Reviews (1): Last reviewed commit: ["fix(os-rv64): make release gate deps fai..."](https://github.com/elizaos/eliza/commit/e0dc28116d210a9176198a92a00a2e5dc4555aa8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33150494)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->