### PR TITLE
feat(plugin-slack): role-aware outbound client routing — OWNER posts as user

### DIFF
--- a/packages/app-core/src/registry/entries/connectors/slack.json
+++ b/packages/app-core/src/registry/entries/connectors/slack.json
@@ -84,5 +84,19 @@
   "auth": {
     "kind": "oauth",
     "credentialKeys": ["SLACK_APP_TOKEN"]
+  },
+  "accounts": {
+    "owner": {
+      "supported": true,
+      "authKind": "oauth-cloud",
+      "credentialKeys": [],
+      "notes": "The user's own Slack identity (xoxp-... user token), connected via Eliza Cloud OAuth so the agent can read the user's channels, write messages as them, search their conversations, and read files they have access to."
+    },
+    "agent": {
+      "supported": true,
+      "authKind": "oauth-cloud",
+      "credentialKeys": [],
+      "notes": "The agent's own Slack bot identity (xoxb-... bot token), installed into the workspace via Eliza Cloud OAuth. Posts, mentions, replies, and DMs flow through the bot user."
+    }
   }
 }

--- a/packages/cloud-shared/src/lib/services/oauth/provider-registry.ts
+++ b/packages/cloud-shared/src/lib/services/oauth/provider-registry.ts
@@ -397,7 +397,11 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
     // Slack identity (authed_user.access_token, `xoxp-...`) can act on
     // the user's behalf — read their channels, write as them, search
     // their messages, and read files they have access to.
-    userScopes: ["chat:write", "search:read", "users:read", "files:read"],
+    // `identity.basic` is required by Slack's `users.identity` endpoint
+    // (the userInfo URL above) — without it the OWNER callback's
+    // userInfo fetch fails with `missing_scope` and `extractUserInfo`
+    // cannot resolve `user_id`.
+    userScopes: ["identity.basic", "chat:write", "search:read", "users:read", "files:read"],
     userInfoMapping: {
       id: "user_id",
       displayName: "user",

--- a/packages/cloud-shared/src/lib/services/oauth/provider-registry.ts
+++ b/packages/cloud-shared/src/lib/services/oauth/provider-registry.ts
@@ -122,6 +122,20 @@ export interface OAuthProviderConfig {
   allowedScopes?: string[];
 
   /**
+   * Default user-level OAuth scopes for providers that distinguish between
+   * bot and user scopes (e.g. Slack passes user scopes via the `user_scope`
+   * query parameter alongside the regular `scope` parameter). When set,
+   * `initiateOAuth2` adds a `user_scope` URL param so the OAuth screen
+   * prompts the user for both bot-level and user-level permissions.
+   *
+   * This is what lets the user's `authed_user.access_token` (Slack's user
+   * token, `xoxp-...`) carry meaningful permissions for OWNER-role flows
+   * — without it, the user token is functionally a bot-context token with
+   * no user-level scopes granted.
+   */
+  userScopes?: string[];
+
+  /**
    * How to extract user info from the userInfo endpoint response.
    * If not provided, uses standard OAuth2 claims.
    */
@@ -379,6 +393,11 @@ export const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
       revoke: "https://slack.com/api/auth.revoke",
     },
     defaultScopes: ["identity.basic", "users:read", "chat:write", "channels:read"],
+    // User-level scopes requested for the OWNER role so the user's own
+    // Slack identity (authed_user.access_token, `xoxp-...`) can act on
+    // the user's behalf — read their channels, write as them, search
+    // their messages, and read files they have access to.
+    userScopes: ["chat:write", "search:read", "users:read", "files:read"],
     userInfoMapping: {
       id: "user_id",
       displayName: "user",

--- a/packages/cloud-shared/src/lib/services/oauth/providers/oauth2.ts
+++ b/packages/cloud-shared/src/lib/services/oauth/providers/oauth2.ts
@@ -204,6 +204,15 @@ export async function initiateOAuth2(
     authUrl.searchParams.set("scope", scopes.join(" "));
   }
 
+  // Slack-style user/bot scope split: providers that distinguish user-level
+  // scopes from bot/app scopes (currently only Slack via the `user_scope`
+  // query parameter) declare them in `provider.userScopes`. Without this,
+  // the user token returned in `authed_user.access_token` has no granted
+  // user-level permissions and can't act on the user's behalf.
+  if (provider.userScopes && provider.userScopes.length > 0) {
+    authUrl.searchParams.set("user_scope", provider.userScopes.join(" "));
+  }
+
   authUrl.searchParams.set("state", state);
 
   // Add PKCE parameters

--- a/packages/cloud-shared/src/lib/services/oauth/providers/oauth2.ts
+++ b/packages/cloud-shared/src/lib/services/oauth/providers/oauth2.ts
@@ -87,6 +87,49 @@ interface ExtractedUserInfo {
   raw: Record<string, unknown>;
 }
 
+/**
+ * Pick the right token for the userInfo / tokenInfo lookup.
+ *
+ * For providers with a user/bot token split (Slack via `authed_user`)
+ * the OWNER flow must use the user-context token so identity lookup
+ * returns the authorizing user, not the bot. AGENT and other flows
+ * keep the bot/app token.
+ *
+ * Other providers (no `userScopes` declared) always use the standard
+ * `access_token` — the OWNER vs AGENT distinction doesn't change which
+ * token represents the identity.
+ */
+function pickUserInfoToken(
+  provider: OAuthProviderConfig,
+  tokens: TokenResponse,
+  connectionRole: OAuthStandardConnectionRole,
+): string {
+  if (
+    connectionRole !== "OWNER" ||
+    !provider.userScopes ||
+    provider.userScopes.length === 0
+  ) {
+    return tokens.access_token;
+  }
+  const authedUser = tokens.authed_user;
+  if (
+    authedUser &&
+    typeof authedUser === "object" &&
+    !Array.isArray(authedUser)
+  ) {
+    const userToken = (authedUser as Record<string, unknown>).access_token;
+    if (typeof userToken === "string" && userToken.length > 0) {
+      return userToken;
+    }
+  }
+  // Fall back to the bot token if the provider didn't return a user
+  // token (e.g. the user denied user-scope permissions on the consent
+  // screen). The caller will still hit the dedup guard, but that's the
+  // correct behavior: an OWNER connection without user-token grants
+  // isn't meaningfully distinct from an AGENT connection.
+  return tokens.access_token;
+}
+
 function getStoredConnectionRole(sourceContext: unknown): OAuthStandardConnectionRole {
   if (!sourceContext || typeof sourceContext !== "object") {
     return "OWNER";
@@ -209,7 +252,20 @@ export async function initiateOAuth2(
   // query parameter) declare them in `provider.userScopes`. Without this,
   // the user token returned in `authed_user.access_token` has no granted
   // user-level permissions and can't act on the user's behalf.
-  if (provider.userScopes && provider.userScopes.length > 0) {
+  //
+  // Only add user_scope for non-AGENT flows. The AGENT flow installs the
+  // app's bot into the workspace; surfacing personal user-level permission
+  // requests on the workspace admin's authorization screen would (a) be
+  // surprising UX for "install a bot" and (b) cause both flows' user-info
+  // lookup to resolve to the same Slack user_id (the authorizer), which
+  // the `storeConnection` dedup guard rejects with
+  // `OAUTH_ACCOUNT_ALREADY_LINKED_TO_DIFFERENT_ROLE` on the second click.
+  const normalizedRole = normalizeOAuthConnectionRole(params.connectionRole);
+  if (
+    provider.userScopes &&
+    provider.userScopes.length > 0 &&
+    normalizedRole !== "AGENT"
+  ) {
     authUrl.searchParams.set("user_scope", provider.userScopes.join(" "));
   }
 
@@ -271,12 +327,25 @@ export async function handleOAuth2Callback(
   // Exchange code for tokens
   const tokens = await exchangeCodeForTokens(provider, code, codeVerifier);
 
+  // For providers with a user/bot token split (Slack), the OWNER flow
+  // must resolve the *authorizing user's* identity via the user token
+  // — not the bot token. Otherwise `users.identity` (or equivalent)
+  // returns the same identity for both AGENT and OWNER flows (the
+  // workspace admin who clicked Authorize on both buttons), and the
+  // `storeConnection` dedup guard rejects the second connection with
+  // `OAUTH_ACCOUNT_ALREADY_LINKED_TO_DIFFERENT_ROLE`.
+  const userInfoToken = pickUserInfoToken(
+    provider,
+    tokens,
+    connectionRole,
+  );
+
   // Fetch user info: userInfo endpoint, token metadata endpoint, or from token response
   let userInfo: ExtractedUserInfo;
   if (provider.endpoints?.userInfo) {
-    userInfo = await fetchUserInfo(provider, tokens.access_token);
+    userInfo = await fetchUserInfo(provider, userInfoToken);
   } else if (provider.endpoints?.tokenInfo) {
-    userInfo = await fetchTokenInfo(provider, tokens.access_token);
+    userInfo = await fetchTokenInfo(provider, userInfoToken);
   } else {
     userInfo = extractUserInfoFromTokens(provider, tokens);
   }

--- a/packages/ui/src/components/pages/plugin-view-connectors.tsx
+++ b/packages/ui/src/components/pages/plugin-view-connectors.tsx
@@ -142,10 +142,10 @@ function buildRoleButtonLabel(
 const CLOUD_OAUTH_CONNECTORS: Record<string, CloudOAuthConnectorCopy> = {
   slack: {
     platform: "slack",
-    connectionRoles: ["agent"],
+    connectionRoles: ["agent", "owner"],
     buttonLabel: "Use Slack OAuth",
     connectedHint:
-      "Connect Slack with Eliza Cloud OAuth. Cloud stores the workspace token and the Slack plugin remains the runtime surface for messages and actions.",
+      "Connect Slack with Eliza Cloud OAuth. Use 'agent' to install the agent's own Slack bot (xoxb-... bot token) into the workspace; use 'your account' to grant the agent permission to act on your own Slack identity (xoxp-... user token) — read your channels, write as you, search your messages.",
     disconnectedHint:
       "Connect Eliza Cloud first to use Slack OAuth instead of local Socket Mode tokens.",
     successNotice: "Finish Slack OAuth in your browser, then return here.",

--- a/plugins/plugin-slack/src/accounts.test.ts
+++ b/plugins/plugin-slack/src/accounts.test.ts
@@ -1,0 +1,116 @@
+import type { Character, IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  normalizeSlackAccountRole,
+  resolveSlackAccount,
+  type SlackMultiAccountConfig,
+} from "./accounts";
+
+function createRuntime(
+  slackConfig?: SlackMultiAccountConfig,
+  envOverrides?: Record<string, string | undefined>,
+): IAgentRuntime {
+  const character: Partial<Character> = {
+    settings: slackConfig ? { slack: slackConfig } : {},
+  };
+  const env = envOverrides ?? {};
+  const runtime = {
+    agentId: "agent-1",
+    character: character as Character,
+    getSetting: vi.fn((key: string) => env[key]),
+    logger: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  };
+  return runtime as unknown as IAgentRuntime;
+}
+
+describe("normalizeSlackAccountRole", () => {
+  it("returns canonical OWNER / AGENT / TEAM for matching inputs", () => {
+    expect(normalizeSlackAccountRole("OWNER")).toBe("OWNER");
+    expect(normalizeSlackAccountRole("AGENT")).toBe("AGENT");
+    expect(normalizeSlackAccountRole("TEAM")).toBe("TEAM");
+  });
+
+  it("uppercases mixed-case input", () => {
+    expect(normalizeSlackAccountRole("owner")).toBe("OWNER");
+    expect(normalizeSlackAccountRole("Agent")).toBe("AGENT");
+    expect(normalizeSlackAccountRole(" team ")).toBe("TEAM");
+  });
+
+  it("falls back to AGENT for unknown / non-string values", () => {
+    expect(normalizeSlackAccountRole(undefined)).toBe("AGENT");
+    expect(normalizeSlackAccountRole(null)).toBe("AGENT");
+    expect(normalizeSlackAccountRole("")).toBe("AGENT");
+    expect(normalizeSlackAccountRole("admin")).toBe("AGENT");
+    expect(normalizeSlackAccountRole(42)).toBe("AGENT");
+    expect(normalizeSlackAccountRole({ role: "OWNER" })).toBe("AGENT");
+  });
+});
+
+describe("resolveSlackAccount role wiring", () => {
+  it("defaults role to AGENT when no role is configured", () => {
+    const runtime = createRuntime({
+      botToken: "xoxb-bot",
+      appToken: "xapp-app",
+    });
+    const account = resolveSlackAccount(runtime, "default");
+    expect(account.role).toBe("AGENT");
+  });
+
+  it("reads role from per-account character.settings.slack.accounts entry", () => {
+    const runtime = createRuntime({
+      accounts: {
+        owner: {
+          role: "OWNER",
+          botToken: "xoxb-bot",
+          appToken: "xapp-app",
+          userToken: "xoxp-user",
+        },
+      },
+    });
+    const account = resolveSlackAccount(runtime, "owner");
+    expect(account.role).toBe("OWNER");
+    expect(account.userToken).toBe("xoxp-user");
+  });
+
+  it("reads role from SLACK_ACCOUNT_ROLE env for the default account only", () => {
+    const runtime = createRuntime(
+      { botToken: "xoxb-bot", appToken: "xapp-app" },
+      { SLACK_ACCOUNT_ROLE: "OWNER" },
+    );
+    const account = resolveSlackAccount(runtime, "default");
+    expect(account.role).toBe("OWNER");
+  });
+
+  it("does not apply env SLACK_ACCOUNT_ROLE to non-default accounts", () => {
+    const runtime = createRuntime(
+      {
+        accounts: {
+          owner: {
+            botToken: "xoxb-bot",
+            appToken: "xapp-app",
+          },
+        },
+      },
+      { SLACK_ACCOUNT_ROLE: "OWNER" },
+    );
+    const account = resolveSlackAccount(runtime, "owner");
+    // env override only applies to the legacy/default account path, so the
+    // explicit per-account config (no role set) still falls back to AGENT
+    expect(account.role).toBe("AGENT");
+  });
+
+  it("config role wins over env role", () => {
+    const runtime = createRuntime(
+      {
+        botToken: "xoxb-bot",
+        appToken: "xapp-app",
+        accounts: {
+          default: { role: "OWNER" },
+        },
+      },
+      { SLACK_ACCOUNT_ROLE: "AGENT" },
+    );
+    const account = resolveSlackAccount(runtime, "default");
+    expect(account.role).toBe("OWNER");
+  });
+});

--- a/plugins/plugin-slack/src/accounts.ts
+++ b/plugins/plugin-slack/src/accounts.ts
@@ -1,4 +1,4 @@
-import type { IAgentRuntime } from "@elizaos/core";
+import type { ConnectorAccountRole, IAgentRuntime } from "@elizaos/core";
 
 /**
  * Default account identifier used when no specific account is configured
@@ -81,6 +81,14 @@ export interface SlackAccountConfig {
   name?: string;
   /** If false, do not start this Slack account */
   enabled?: boolean;
+  /**
+   * Account role. AGENT (the default) means outbound API calls are made
+   * with the bot token (xoxb-) and represent the agent identity. OWNER
+   * means outbound calls that have user-token coverage (chat:write user
+   * scope) are made with the xoxp- user token so the agent acts as the
+   * user who installed the integration.
+   */
+  role?: ConnectorAccountRole;
   /** Slack bot token (xoxb-...) */
   botToken?: string;
   /** Slack app-level token (xapp-...) */
@@ -138,6 +146,12 @@ export interface ResolvedSlackAccount {
   accountId: string;
   enabled: boolean;
   name?: string;
+  /**
+   * Role this account represents in OWNER+AGENT terms. Drives outbound
+   * API client selection in the runtime: AGENT → bot token, OWNER →
+   * user token for calls covered by the granted user scopes.
+   */
+  role: ConnectorAccountRole;
   botToken?: string;
   appToken?: string;
   signingSecret?: string;
@@ -188,6 +202,22 @@ export function resolveSlackAppToken(raw?: string | null): string | undefined {
  */
 export function resolveSlackUserToken(raw?: string | null): string | undefined {
   return normalizeSlackToken(raw, "xoxp-");
+}
+
+/**
+ * Normalises an inbound role string into a `ConnectorAccountRole`.
+ * Unknown values fall back to AGENT — the default for legacy single
+ * bot-token deployments where the agent IS the bot.
+ */
+export function normalizeSlackAccountRole(
+  raw: unknown,
+): ConnectorAccountRole {
+  if (typeof raw !== "string") return "AGENT";
+  const upper = raw.trim().toUpperCase();
+  if (upper === "OWNER" || upper === "AGENT" || upper === "TEAM") {
+    return upper;
+  }
+  return "AGENT";
 }
 
 /**
@@ -359,10 +389,20 @@ export function resolveSlackAccount(
   const configUserToken = resolveSlackUserToken(merged.userToken);
   const userToken = configUserToken ?? envUserToken;
 
+  // Resolve role. Precedence: per-account config role > env override
+  // (default account only) > "AGENT". AGENT is the legacy default — the
+  // agent acts as the bot identity. OWNER routes user-scope-covered
+  // outbound calls through the xoxp- user token.
+  const envRole = allowEnv
+    ? (runtime.getSetting("SLACK_ACCOUNT_ROLE") as string | undefined)
+    : undefined;
+  const role = normalizeSlackAccountRole(merged.role ?? envRole);
+
   return {
     accountId: normalizedAccountId,
     enabled,
     name: merged.name?.trim() || undefined,
+    role,
     botToken,
     appToken,
     signingSecret,

--- a/plugins/plugin-slack/src/connector-account-provider.ts
+++ b/plugins/plugin-slack/src/connector-account-provider.ts
@@ -16,6 +16,7 @@ import {
   type ConnectorAccountPatch,
   type ConnectorAccountProvider,
   type ConnectorAccountPurpose,
+  type ConnectorAccountRole,
   type ConnectorOAuthCallbackRequest,
   type ConnectorOAuthCallbackResult,
   type ConnectorOAuthStartRequest,
@@ -98,6 +99,28 @@ function nonEmptyString(value: unknown): string | undefined {
 
 function readSetting(runtime: IAgentRuntime, key: string): string | undefined {
   return nonEmptyString(runtime.getSetting(key));
+}
+
+function roleFromMetadata(metadata: unknown): ConnectorAccountRole {
+  const record =
+    metadata && typeof metadata === "object" && !Array.isArray(metadata)
+      ? (metadata as Record<string, unknown>)
+      : {};
+  // Cloud OAuth writes `connectionRole` (uppercase canonical); local UI
+  // flows pass `role`/`accountRole`/`requestedRole`. Accept all four so the
+  // role survives whichever path the OAuth start metadata came through.
+  const raw = nonEmptyString(
+    record.connectionRole ??
+      record.role ??
+      record.accountRole ??
+      record.requestedRole,
+  );
+  if (!raw) return "OWNER";
+  const normalized = raw.toUpperCase();
+  if (normalized === "OWNER" || normalized === "AGENT" || normalized === "TEAM") {
+    return normalized;
+  }
+  return "OWNER";
 }
 
 function readClientConfig(runtime: IAgentRuntime): {
@@ -361,7 +384,7 @@ export function createSlackConnectorAccountProvider(
         SLACK_SERVICE_NAME,
         {
           provider: SLACK_SERVICE_NAME,
-          role: "OWNER",
+          role: roleFromMetadata(request.flow.metadata),
           purpose: DEFAULT_PURPOSES,
           accessGate: "open",
           status: "pending",

--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -21,7 +21,7 @@ import {
   type World,
 } from "@elizaos/core";
 import { App, LogLevel } from "@slack/bolt";
-import type { WebAPICallResult } from "@slack/web-api";
+import { WebClient as SlackWebClient, type WebAPICallResult } from "@slack/web-api";
 
 type WebClient = App["client"];
 type AccountScopedTargetInfo = TargetInfo & { accountId?: string };
@@ -317,6 +317,14 @@ type SlackAccountRuntime = {
   account: ResolvedSlackAccount;
   app: App;
   client: WebClient;
+  /**
+   * Optional xoxp- user-token client. Present only when the account
+   * has a `userToken` configured. OWNER-role accounts route outbound
+   * calls covered by the granted user scopes (currently `chat:write`)
+   * through this client so the agent acts as the user; AGENT-role
+   * accounts ignore it and keep using the bot client.
+   */
+  userClient: WebClient | null;
   botUserId: string | null;
   teamId: string | null;
   settings: SlackSettings;
@@ -717,11 +725,20 @@ export class SlackService extends Service implements ISlackService {
           : {}),
       });
 
+      // User-token client (xoxp-) is outbound-only; no socket-mode
+      // session is needed. Only constructed when a user token is
+      // configured. Routing decisions in getOutboundClient() consult
+      // account.role to decide which client receives each call.
+      const userClient = account.userToken
+        ? (new SlackWebClient(account.userToken) as unknown as WebClient)
+        : null;
+
       const state: SlackAccountRuntime = {
         accountId,
         account,
         app,
         client: app.client,
+        userClient,
         botUserId: null,
         teamId: null,
         settings: this.loadSettings(account),
@@ -895,6 +912,25 @@ export class SlackService extends Service implements ISlackService {
       return this.client;
     }
     return null;
+  }
+
+  /**
+   * Returns the client that outbound user-action calls (currently
+   * chat.postMessage) should use for the given account. OWNER-role
+   * accounts with a configured xoxp- user token route through it so
+   * the agent posts as the user; everything else stays on the bot
+   * client. Falls back to `getClientForAccount` when no per-account
+   * state has been initialised yet.
+   */
+  private getOutboundClient(accountId?: string | null): WebClient | null {
+    const state = this.getAccountState(accountId);
+    if (!state) {
+      return this.getClientForAccount(accountId);
+    }
+    if (state.account.role === "OWNER" && state.userClient) {
+      return state.userClient;
+    }
+    return state.client;
   }
 
   private getSettingsForAccount(accountId?: string | null): SlackSettings {
@@ -2855,7 +2891,7 @@ export class SlackService extends Service implements ISlackService {
     options?: SlackMessageSendOptions,
     accountId?: string | null,
   ): Promise<{ ts: string; channelId: string }> {
-    const client = this.getClientForAccount(accountId);
+    const client = this.getOutboundClient(accountId);
     if (!client) {
       throw new Error("Slack client not initialized");
     }


### PR DESCRIPTION
## What

When a Slack account is configured with `role: "OWNER"` and a `userToken` (xoxp-) is present, `sendMessage` routes through a second `WebClient` bound to the user token so the agent acts as the user. AGENT-role accounts continue to use the bot client (xoxb-) unchanged.

This is the runtime-side primitive that PR #7868 sets up — that PR added the cloud OAuth `userScopes` and `authed_user.access_token` persistence; this PR turns those tokens into outbound behavior.

## Stack

Branched from `milady/plugin-slack-dual-token` (#7868). Tip is one commit ahead of #7868's tip (e57124a9cfd). When #7868 merges, this rebases onto develop cleanly.

## Changes

### `plugins/plugin-slack/src/accounts.ts`
- `SlackAccountConfig` gains an optional `role` field.
- `ResolvedSlackAccount` gains a required `role: ConnectorAccountRole`.
- `resolveSlackAccount` reads role from per-account `character.settings.slack.accounts.<id>.role` or, for the default account only, the `SLACK_ACCOUNT_ROLE` env var. Falls back to `"AGENT"`. Config role beats env role.
- New `normalizeSlackAccountRole` accepts OWNER/AGENT/TEAM (mixed case, trimmed) and defaults unknown / non-string input to AGENT.

### `plugins/plugin-slack/src/service.ts`
- `SlackAccountRuntime` gains `userClient: WebClient | null`. Constructed in `initializeAccount` only when `account.userToken` is set. Imports `WebClient` from `@slack/web-api` directly (no socket mode — outbound-only).
- New private `getOutboundClient(accountId)` selects:
  - The user client when `account.role === "OWNER"` AND `userClient` exists.
  - The bot client otherwise.
  - Falls back to `getClientForAccount` when per-account state hasn't been initialised yet.
- `sendMessage` switches from `getClientForAccount` to `getOutboundClient`. Other API call sites (`reactions.add`, `pins.add`, `files.uploadV2`, etc.) stay on the bot client — Slack's `chat:write` user scope (the only outbound write scope in #7868's `userScopes`) covers `chat.postMessage` only. Broadening to other call sites requires additional user scopes (e.g. `reactions:write`, `files:write`) and is left for a follow-up.

### `plugins/plugin-slack/src/accounts.test.ts` (new, 8 tests)
- `normalizeSlackAccountRole` canonical / mixed-case / fallback / non-string paths.
- `resolveSlackAccount` role resolution from config, env, default-account-only env scoping, and config-beats-env precedence.

## Out of scope — explicit follow-up

**Hydration of OAuth-stored credentials into the runtime account chain.** PR #7868 stores the user token at `oauth.tokens.authed_user.access_token` and tracks role on the ConnectorAccount record, but `ConnectorAccountManager` does not yet expose a read path for credential refs. Adding one is a cross-plugin runtime change that's out of scope here. Today, admins who want OWNER routing must set `role` + `userToken` in `character.settings.slack.accounts.<id>` (or the `SLACK_ACCOUNT_ROLE` + `SLACK_USER_TOKEN` env pair for the default account). Once the hydration path lands, the OWNER routing in this PR picks up the OAuth-stored xoxp- automatically — no further changes needed in plugin-slack.

## Verification

- `bunx tsc --noEmit -p plugins/plugin-slack/tsconfig.json` — clean (zero errors in touched files).
- `bunx vitest run plugins/plugin-slack/src/` — **17/17 pass** (8 new role-resolution tests + 9 existing across `connector-account-provider.test.ts` + `messageConnector.test.ts`).
- Manual scenario: configure `character.settings.slack.accounts.owner = { role: "OWNER", botToken: "xoxb-…", appToken: "xapp-…", userToken: "xoxp-…" }`. Call `sendMessage("C…", "hello", undefined, "owner")` — message appears in the channel posted by the user, not the bot.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements role-aware outbound client routing for the Slack plugin: when an account is configured with `role: \"OWNER\"` and a `userToken` (xoxp-), `sendMessage` routes through a second `WebClient` bound to the user token so the agent posts as the user rather than the bot. It also threads `userScopes` through the Cloud OAuth flow so Slack's consent screen grants the user-level permissions required by the OWNER token.

- **`plugins/plugin-slack/src/accounts.ts` + `service.ts`**: `SlackAccountConfig`/`ResolvedSlackAccount` gain a `role` field; `getOutboundClient()` selects the xoxp- client for OWNER accounts and falls back to the bot client for all others; only `sendMessage`/`chat.postMessage` is rerouted — other call sites (reactions, pins, files) stay on the bot client pending additional user scopes.
- **`packages/cloud-shared` OAuth layer**: New `userScopes` field on `OAuthProviderConfig`, `pickUserInfoToken` helper for the Slack dual-token identity lookup, and `user_scope` injection into the OWNER OAuth authorize URL so the user's `authed_user.access_token` carries meaningful permissions.
- **`plugins/plugin-slack/src/connector-account-provider.ts`**: `roleFromMetadata` replaces the hardcoded `\"OWNER\"` in `storeConnection`, reading the role from OAuth start metadata across four field aliases.

<h3>Confidence Score: 3/5</h3>

The routing logic is correct for the documented happy path, but a silent misconfiguration path and an inconsistent default in the OAuth callback layer need attention before merging.

When an operator sets `role: "OWNER"` but omits `userToken`, `getOutboundClient` silently returns the bot client with no log or error — the agent behaves exactly like an AGENT account while the config says OWNER. This is the kind of misconfiguration that will be difficult to diagnose in production. Additionally, `roleFromMetadata` defaults to `"OWNER"` on missing/corrupt OAuth state while every other role-resolution path defaults to `"AGENT"`, creating an inconsistency where an OAuth callback without metadata elevates a connection to OWNER silently.

`plugins/plugin-slack/src/service.ts` (getOutboundClient silent fallback) and `plugins/plugin-slack/src/connector-account-provider.ts` (roleFromMetadata OWNER default).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-slack/src/service.ts | Adds `userClient` to `SlackAccountRuntime` and `getOutboundClient()` to route `sendMessage` through the xoxp- client for OWNER accounts; silent fallback to bot client when OWNER has no userToken is unflagged and could silently misconfigure routing. |
| plugins/plugin-slack/src/accounts.ts | Adds `role` field to `SlackAccountConfig`/`ResolvedSlackAccount` and `normalizeSlackAccountRole` helper; role resolution precedence (config > env > AGENT default) is clean and well-tested. |
| plugins/plugin-slack/src/connector-account-provider.ts | Adds `roleFromMetadata` and wires it into `storeConnection`; however the fallback is `"OWNER"` where the rest of the PR defaults to `"AGENT"`, creating an inconsistency for corrupted/missing OAuth state. |
| packages/cloud-shared/src/lib/services/oauth/providers/oauth2.ts | Adds `pickUserInfoToken` and `user_scope` injection for OWNER flows; logic is sound and the AGENT-only guard on `user_scope` prevents the dedup collision described in the PR. |
| packages/cloud-shared/src/lib/services/oauth/provider-registry.ts | Adds `userScopes` field to `OAuthProviderConfig` and configures Slack's user-level scopes; `search:read` and `files:read` are requested but unused in the current runtime routing — reasonable as forward-looking grants. |
| plugins/plugin-slack/src/accounts.test.ts | New test file covering all 8 documented paths for `normalizeSlackAccountRole` and `resolveSlackAccount` role wiring; thorough coverage including env-scoping and config-beats-env precedence. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Admin as Admin Config
    participant Resolver as resolveSlackAccount()
    participant Init as initializeAccount()
    participant Router as getOutboundClient()
    participant BotClient as Bot WebClient
    participant UserClient as User WebClient
    participant Slack as Slack API

    Admin->>Resolver: "role=OWNER, userToken set"
    Resolver-->>Init: ResolvedSlackAccount with role and userToken
    Init->>BotClient: create via App with bot token
    Init->>UserClient: create via SlackWebClient with user token
    Init-->>Router: SlackAccountRuntime with both clients

    Note over Router: sendMessage() calls getOutboundClient()
    Router->>Router: "role === OWNER and userClient != null?"
    alt OWNER role with user token configured
        Router-->>UserClient: route to user client
        UserClient->>Slack: chat.postMessage as user identity
    else AGENT role or no user token
        Router-->>BotClient: route to bot client
        BotClient->>Slack: chat.postMessage as bot identity
    end
```

<sub>Reviews (1): Last reviewed commit: ["feat(plugin-slack): role-aware outbound ..."](https://github.com/elizaos/eliza/commit/5c91bbb78c8d9a991326cdb68043705bd62dd102) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33159773)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->