### PR TITLE
fix(desktop): bundle runtime packages for Windows

### DIFF
--- a/packages/agent/src/runtime/release-plugin-policy.test.ts
+++ b/packages/agent/src/runtime/release-plugin-policy.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BASELINE_BUNDLED_RUNTIME_PACKAGES,
+  classifyRegistryPluginRelease,
+  getBundledRuntimePluginIds,
+  getBundledRuntimePackages,
+} from "./release-plugin-policy.ts";
+
+describe("release plugin policy", () => {
+  it("ships runtime support packages without marking them as bundled registry plugins", () => {
+    const availableDependencies = [
+      "@elizaos/plugin-remote-manifest",
+      "@elizaos/plugin-worker-runtime",
+      "@elizaos/plugin-app-manager",
+      "@elizaos/plugin-openai",
+    ];
+
+    expect(BASELINE_BUNDLED_RUNTIME_PACKAGES).toEqual(
+      expect.arrayContaining([
+        "@elizaos/plugin-remote-manifest",
+        "@elizaos/plugin-worker-runtime",
+      ]),
+    );
+    expect(getBundledRuntimePackages(availableDependencies)).toEqual(
+      expect.arrayContaining([
+        "@elizaos/plugin-remote-manifest",
+        "@elizaos/plugin-worker-runtime",
+        "@elizaos/plugin-app-manager",
+        "@elizaos/plugin-openai",
+      ]),
+    );
+
+    const bundledPluginIds = new Set(
+      getBundledRuntimePluginIds(availableDependencies),
+    );
+
+    expect([...bundledPluginIds]).toEqual(["openai"]);
+    expect(
+      classifyRegistryPluginRelease({
+        packageName: "@elizaos/plugin-openai",
+        bundledPluginIds,
+      }).releaseAvailability,
+    ).toBe("bundled");
+    expect(
+      classifyRegistryPluginRelease({
+        packageName: "@elizaos/plugin-remote-manifest",
+        bundledPluginIds: new Set(["remote-manifest"]),
+      }).releaseAvailability,
+    ).toBe("post-release");
+  });
+});

--- a/packages/agent/src/runtime/release-plugin-policy.ts
+++ b/packages/agent/src/runtime/release-plugin-policy.ts
@@ -3,6 +3,8 @@ import { CORE_PLUGINS, OPTIONAL_CORE_PLUGINS } from "./core-plugins.ts";
 const BASELINE_RUNTIME_SUPPORT_PACKAGES = [
   "@elizaos/core",
   "@elizaos/prompts",
+  "@elizaos/plugin-remote-manifest",
+  "@elizaos/plugin-worker-runtime",
 ] as const;
 
 const BASELINE_PROVIDER_PLUGINS = [
@@ -12,12 +14,31 @@ const BASELINE_PROVIDER_PLUGINS = [
   "@elizaos/plugin-ollama",
 ] as const;
 
+// Desktop loads this through the legacy "agent-orchestrator" compatibility id,
+// but the implementation ships as the scoped package below.
+const BASELINE_DESKTOP_RUNTIME_PLUGINS = [
+  "@elizaos/plugin-agent-orchestrator",
+] as const;
+
+// These are implementation dependencies of bundled core plugins. They need
+// to ship in the runtime bundle, but are not auto-loaded by collectPluginNames.
+const BASELINE_PLUGIN_SUPPORT_PACKAGES = [
+  "@elizaos/plugin-calendly",
+  "@elizaos/plugin-health",
+  "@elizaos/plugin-app-manager",
+  "@elizaos/plugin-registry",
+  "@elizaos/plugin-wallet-ui",
+  "@elizaos/plugin-wallet",
+] as const;
+
 const DESKTOP_RUNTIME_ONLY_PLUGINS = new Set<string>([
+  "@elizaos/plugin-agent-orchestrator",
   "@elizaos/plugin-browser",
   "@elizaos/plugin-computeruse",
 ]);
 
 const LOCAL_RUNTIME_ONLY_PLUGINS = new Set<string>([
+  "@elizaos/plugin-agent-orchestrator",
   "@elizaos/plugin-browser",
   "@elizaos/plugin-computeruse",
 ]);
@@ -36,6 +57,15 @@ export interface RegistryPluginReleaseCompatibility {
 
 export const BASELINE_BUNDLED_RUNTIME_PACKAGES: readonly string[] = [
   ...BASELINE_RUNTIME_SUPPORT_PACKAGES,
+  ...BASELINE_DESKTOP_RUNTIME_PLUGINS,
+  ...CORE_PLUGINS,
+  ...OPTIONAL_CORE_PLUGINS,
+  ...BASELINE_PLUGIN_SUPPORT_PACKAGES,
+  ...BASELINE_PROVIDER_PLUGINS,
+];
+
+const BASELINE_REGISTRY_BUNDLED_PLUGIN_PACKAGES: readonly string[] = [
+  ...BASELINE_DESKTOP_RUNTIME_PLUGINS,
   ...CORE_PLUGINS,
   ...OPTIONAL_CORE_PLUGINS,
   ...BASELINE_PROVIDER_PLUGINS,
@@ -47,6 +77,10 @@ export function derivePluginIdFromPackageName(packageName: string): string {
     .replace(/^@[^/]+\//, "")
     .replace(/^plugin-/, "");
 }
+
+const BASELINE_REGISTRY_BUNDLED_PLUGIN_IDS = new Set(
+  BASELINE_REGISTRY_BUNDLED_PLUGIN_PACKAGES.map(derivePluginIdFromPackageName),
+);
 
 export function getBundledRuntimePackages(
   availableDependencies: Iterable<string>,
@@ -60,7 +94,10 @@ export function getBundledRuntimePackages(
 export function getBundledRuntimePluginIds(
   availableDependencies: Iterable<string>,
 ): string[] {
-  return getBundledRuntimePackages(availableDependencies)
+  const available = new Set(availableDependencies);
+  return BASELINE_REGISTRY_BUNDLED_PLUGIN_PACKAGES.filter((packageName) =>
+    available.has(packageName),
+  )
     .map(derivePluginIdFromPackageName)
     .filter((pluginId) => pluginId.length > 0)
     .sort();
@@ -85,7 +122,9 @@ export function classifyRegistryPluginRelease(params: {
   }
 
   const pluginId = derivePluginIdFromPackageName(packageName);
-  const bundled = bundledPluginIds.has(pluginId);
+  const bundled =
+    BASELINE_REGISTRY_BUNDLED_PLUGIN_IDS.has(pluginId) &&
+    bundledPluginIds.has(pluginId);
   const requiresDesktopRuntime = DESKTOP_RUNTIME_ONLY_PLUGINS.has(packageName);
   const requiresLocalRuntime = LOCAL_RUNTIME_ONLY_PLUGINS.has(packageName);
 

--- a/packages/app-core/platforms/electrobun/electrobun.config.ts
+++ b/packages/app-core/platforms/electrobun/electrobun.config.ts
@@ -342,6 +342,9 @@ export function resolveElectrobunCopyMap({
     if (fs.existsSync(path.join(repoRoot, "plugins.json"))) {
       copy[repoPluginsJsonPath] = `${runtimeDistDir}/plugins.json`;
     }
+    if (fs.existsSync(path.join(electrobunDir, "remotes"))) {
+      copy["remotes"] = "remotes";
+    }
     copy[repoPackageJsonPath] = `${runtimeDistDir}/package.json`;
   }
 

--- a/packages/app-core/platforms/electrobun/src/electrobun-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/electrobun-config.test.ts
@@ -15,6 +15,7 @@ describe("Electrobun Store packaging", () => {
     expect(
       Object.values(copy).some((target) => target.startsWith("eliza-dist/")),
     ).toBe(false);
+    expect(Object.values(copy)).not.toContain("remotes");
   });
 
   it("keeps the embedded runtime tree for direct desktop builds", () => {
@@ -25,6 +26,7 @@ describe("Electrobun Store packaging", () => {
 
     expect(Object.values(copy)).toContain("eliza-dist");
     expect(Object.values(copy)).toContain("eliza-dist/package.json");
+    expect(copy.remotes).toBe("remotes");
   });
 
   it("omits the embedded runtime tree for external API desktop builds", () => {
@@ -38,6 +40,7 @@ describe("Electrobun Store packaging", () => {
 
     expect(Object.values(copy)).not.toContain("eliza-dist");
     expect(Object.values(copy)).not.toContain("eliza-dist/package.json");
+    expect(Object.values(copy)).not.toContain("remotes");
   });
 
   it("keeps the embedded runtime tree when external API env is invalid", () => {

--- a/packages/app-core/scripts/assert-required-bundled-packages.test.ts
+++ b/packages/app-core/scripts/assert-required-bundled-packages.test.ts
@@ -3,11 +3,12 @@
  *
  * The function fails the desktop build when any package marked
  * `alwaysBundled` (CORE_PLUGINS / OPTIONAL_CORE_PLUGINS / BASELINE_*) is
- * missing its `package.json` in `dist/node_modules/` after the copy + prune
- * phases. Companion safety net to the transitive-walk filter introduced
- * with the fresh-clone build fixes — if a future refactor accidentally
- * excludes a required package, the build fails loudly here instead of
- * shipping a broken bundle.
+ * missing its `package.json`, or a baseline package is missing its declared
+ * runtime entrypoint, in `dist/node_modules/` after the copy + prune phases.
+ * Companion safety net to the transitive-walk filter introduced with the
+ * fresh-clone build fixes — if a future refactor accidentally excludes a
+ * required package, the build fails loudly here instead of shipping a broken
+ * bundle.
  */
 
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -15,20 +16,30 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { assertRequiredBundledPackagesLanded } from "./copy-runtime-node-modules";
+import {
+  assertRequiredBundledPackagesLanded,
+  getRuntimeDependencies,
+  selectCopyTargetNodeModules,
+  shouldCopyPackageEntry,
+  shouldSkipPackagedDependency,
+} from "./copy-runtime-node-modules";
 
 let tmpDir: string;
 let nodeModulesDir: string;
 
-function writePackageJson(name: string): void {
+function writePackageJson(
+  name: string,
+  manifest: Record<string, unknown> = {},
+): string {
   const dir = name.startsWith("@")
     ? path.join(nodeModulesDir, ...name.split("/"))
     : path.join(nodeModulesDir, name);
   mkdirSync(dir, { recursive: true });
   writeFileSync(
     path.join(dir, "package.json"),
-    JSON.stringify({ name }, null, 2),
+    JSON.stringify({ name, ...manifest }, null, 2),
   );
+  return dir;
 }
 
 describe("assertRequiredBundledPackagesLanded", () => {
@@ -122,6 +133,237 @@ describe("assertRequiredBundledPackagesLanded", () => {
         new Set(["@elizaos/plugin-sql"]),
       ),
     ).toThrowError(/@elizaos\/plugin-sql/);
+  });
+
+  it("throws when a baseline package main entrypoint was not copied", () => {
+    writePackageJson("@elizaos/core", { main: "./dist/index.js" });
+
+    expect(() =>
+      assertRequiredBundledPackagesLanded(
+        nodeModulesDir,
+        new Set(["@elizaos/core"]),
+      ),
+    ).toThrowError(/missing runtime entry .*dist[\\/]index\.js/);
+  });
+
+  it("throws when a baseline package module entrypoint was pruned", () => {
+    writePackageJson("@elizaos/core", { module: "./dist/index.mjs" });
+
+    expect(() =>
+      assertRequiredBundledPackagesLanded(
+        nodeModulesDir,
+        new Set(["@elizaos/core"]),
+      ),
+    ).toThrowError(/missing runtime entry .*dist[\\/]index\.mjs/);
+  });
+
+  it("checks baseline package runtime export targets but ignores type-only exports", () => {
+    const packageRoot = writePackageJson("@elizaos/core", {
+      exports: {
+        ".": {
+          import: "./dist/index.js",
+          require: "./dist/index.cjs",
+          types: "./dist/index.d.ts",
+        },
+      },
+    });
+    mkdirSync(path.join(packageRoot, "dist"), { recursive: true });
+    writeFileSync(path.join(packageRoot, "dist", "index.d.ts"), "");
+
+    try {
+      assertRequiredBundledPackagesLanded(
+        nodeModulesDir,
+        new Set(["@elizaos/core"]),
+      );
+      throw new Error("expected throw");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message).toContain(path.join(packageRoot, "dist", "index.js"));
+      expect(message).toContain(path.join(packageRoot, "dist", "index.cjs"));
+      expect(message).not.toContain("index.d.ts");
+    }
+  });
+
+  it("passes when a baseline package manifest entrypoint exists", () => {
+    const packageRoot = writePackageJson("@elizaos/core", {
+      main: "./dist/index.js",
+      exports: {
+        ".": {
+          import: "./dist/index.js",
+          types: "./dist/index.d.ts",
+        },
+      },
+    });
+    mkdirSync(path.join(packageRoot, "dist"), { recursive: true });
+    writeFileSync(path.join(packageRoot, "dist", "index.js"), "");
+
+    expect(() =>
+      assertRequiredBundledPackagesLanded(
+        nodeModulesDir,
+        new Set(["@elizaos/core"]),
+      ),
+    ).not.toThrow();
+  });
+
+  it("does not entrypoint-check non-baseline always-bundled packages", () => {
+    writePackageJson("react", { main: "./index.js" });
+
+    expect(() =>
+      assertRequiredBundledPackagesLanded(nodeModulesDir, new Set(["react"])),
+    ).not.toThrow();
+  });
+
+  it("keeps bundled skill markdown payloads", () => {
+    const packageRoot = path.join(tmpDir, "skills-package");
+    const skillDir = path.join(packageRoot, "skills", "example-skill");
+    const referenceDir = path.join(skillDir, "references");
+    mkdirSync(referenceDir, { recursive: true });
+
+    const skillFile = path.join(skillDir, "SKILL.md");
+    const referenceFile = path.join(referenceDir, "usage.md");
+    const packageReadme = path.join(packageRoot, "README.md");
+    writeFileSync(skillFile, "# Example\n");
+    writeFileSync(referenceFile, "# Usage\n");
+    writeFileSync(packageReadme, "# Package readme\n");
+
+    expect(
+      shouldCopyPackageEntry(skillFile, "@elizaos/skills", packageRoot),
+    ).toBe(true);
+    expect(
+      shouldCopyPackageEntry(referenceFile, "@elizaos/skills", packageRoot),
+    ).toBe(true);
+    expect(
+      shouldCopyPackageEntry(packageReadme, "@elizaos/skills", packageRoot),
+    ).toBe(false);
+  });
+
+  it("keeps documented runtime assets for packages that load them dynamically", () => {
+    const googleapisRoot = path.join(tmpDir, "googleapis");
+    const googleDocsApiFile = path.join(
+      googleapisRoot,
+      "build",
+      "src",
+      "apis",
+      "docs",
+      "v1.js",
+    );
+    const googleReadme = path.join(googleapisRoot, "README.md");
+    mkdirSync(path.dirname(googleDocsApiFile), { recursive: true });
+    writeFileSync(googleDocsApiFile, "");
+    writeFileSync(googleReadme, "# Google APIs\n");
+
+    expect(
+      shouldCopyPackageEntry(googleDocsApiFile, "googleapis", googleapisRoot),
+    ).toBe(true);
+    expect(
+      shouldCopyPackageEntry(googleReadme, "googleapis", googleapisRoot),
+    ).toBe(false);
+
+    const threeRoot = path.join(tmpDir, "three");
+    const threeExampleFile = path.join(
+      threeRoot,
+      "examples",
+      "jsm",
+      "loaders",
+      "GLTFLoader.js",
+    );
+    mkdirSync(path.dirname(threeExampleFile), { recursive: true });
+    writeFileSync(threeExampleFile, "");
+
+    expect(shouldCopyPackageEntry(threeExampleFile, "three", threeRoot)).toBe(
+      true,
+    );
+
+    const uiRoot = path.join(tmpDir, "ui");
+    const uiDocsFile = path.join(
+      uiRoot,
+      "dist",
+      "cloud-ui",
+      "components",
+      "docs",
+      "usage.md",
+    );
+    const uiReadme = path.join(uiRoot, "README.md");
+    mkdirSync(path.dirname(uiDocsFile), { recursive: true });
+    writeFileSync(uiDocsFile, "# Usage\n");
+    writeFileSync(uiReadme, "# UI\n");
+
+    expect(shouldCopyPackageEntry(uiDocsFile, "@elizaos/ui", uiRoot)).toBe(
+      true,
+    );
+    expect(shouldCopyPackageEntry(uiReadme, "@elizaos/ui", uiRoot)).toBe(false);
+  });
+
+  it("uses the top-level Octokit peer for git-workspace-service", () => {
+    expect(
+      shouldSkipPackagedDependency("git-workspace-service", "@octokit/rest"),
+    ).toBe(true);
+    expect(
+      shouldSkipPackagedDependency(
+        "git-workspace-service",
+        "@octokit/auth-app",
+      ),
+    ).toBe(false);
+    expect(
+      shouldSkipPackagedDependency(
+        "@elizaos/plugin-agent-orchestrator",
+        "@octokit/rest",
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps lucide-react as a runtime dependency", () => {
+    const packageRoot = path.join(tmpDir, "icon-consumer");
+    mkdirSync(packageRoot, { recursive: true });
+    writeFileSync(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify(
+        {
+          dependencies: {
+            "lucide-react": "^1.0.0",
+            typescript: "^5.0.0",
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    expect(getRuntimeDependencies(path.join(packageRoot, "package.json"))).toEqual([
+      "lucide-react",
+    ]);
+  });
+
+  it("hoists Solana packages when a compatible top-level copy exists", () => {
+    const rootDestDir = path.join(tmpDir, "dist");
+    const targetNodeModules = path.join(rootDestDir, "node_modules");
+    const requesterDestDir = path.join(
+      targetNodeModules,
+      "@elizaos",
+      "plugin-wallet",
+    );
+
+    expect(
+      selectCopyTargetNodeModules({
+        name: "@solana/web3.js",
+        requesterDestDir,
+        rootDestDir,
+        targetNodeModules,
+        topLevelVersions: new Map([["@solana/web3.js", "1.98.0"]]),
+        resolvedVersion: "2.0.0",
+      }),
+    ).toBe(targetNodeModules);
+
+    expect(
+      selectCopyTargetNodeModules({
+        name: "@example/nested-only",
+        requesterDestDir,
+        rootDestDir,
+        targetNodeModules,
+        topLevelVersions: new Map([["@example/nested-only", "1.0.0"]]),
+        resolvedVersion: "2.0.0",
+      }),
+    ).toBe(path.join(requesterDestDir, "node_modules"));
   });
 
   it("error message points to the expected on-disk path so ops can investigate", () => {

--- a/packages/app-core/scripts/build-llama-cpp-dflash-targets.test.mjs
+++ b/packages/app-core/scripts/build-llama-cpp-dflash-targets.test.mjs
@@ -3,15 +3,16 @@ import { it as test } from "vitest";
 
 import { formatHelpText, parseArgs } from "./build-llama-cpp-dflash.mjs";
 
-test("help advertises linux aarch64 CUDA fused but not mobile fused targets", () => {
+test("help advertises supported fused targets but not Android fused targets", () => {
   const helpText = formatHelpText();
   assert.match(helpText, /linux-aarch64-cuda-fused/);
+  assert.match(helpText, /ios-arm64-metal-fused/);
+  assert.match(helpText, /ios-arm64-simulator-metal-fused/);
   assert.doesNotMatch(helpText, /android-arm64-cpu-fused/);
   assert.doesNotMatch(helpText, /android-x86_64-cpu-fused/);
-  assert.doesNotMatch(helpText, /ios-arm64-metal-fused/);
 });
 
-test("mobile fused targets fail closed with explicit diagnostics", () => {
+test("unsupported Android fused targets fail closed with explicit diagnostics", () => {
   const cases = [
     ["android-arm64-cpu-fused", /Android fused FFI is not wired/],
     ["android-arm64-vulkan-fused", /Android fused FFI is not wired/],
@@ -23,7 +24,6 @@ test("mobile fused targets fail closed with explicit diagnostics", () => {
       "android-x86_64-vulkan-fused",
       /Android x86_64 fused FFI is not a dflash target/,
     ],
-    ["ios-arm64-metal-fused", /iOS fused FFI is not wired or verifier-covered/],
   ];
 
   for (const [target, pattern] of cases) {

--- a/packages/app-core/scripts/copy-runtime-node-modules.ts
+++ b/packages/app-core/scripts/copy-runtime-node-modules.ts
@@ -55,9 +55,15 @@ const TRACKED_PACKAGE_CACHE = path.join(
 const PUBLISHED_PACKAGE_FETCH_TIMEOUT_MS = 10_000;
 const ALLOW_REGISTRY_FETCH =
   process.env.ELIZA_RUNTIME_COPY_ALLOW_REGISTRY_FETCH === "1";
-const DEP_SKIP = new Set(["typescript", "@types/node", "lucide-react"]);
-const ALWAYS_HOISTED_PACKAGES = new Set(["@elizaos/core"]);
-const PACKAGED_DEPENDENCY_SKIPS = new Map<string, Set<string>>();
+const DEP_SKIP = new Set(["typescript", "@types/node"]);
+const ALWAYS_HOISTED_PACKAGES = new Set(["@elizaos/core", "commander"]);
+const PACKAGED_DEPENDENCY_SKIPS = new Map<string, Set<string>>([
+  // git-workspace-service declares @octokit/rest as both a dependency (^20)
+  // and a peer (>=20). Desktop bundles it via plugin-agent-orchestrator,
+  // which ships @octokit/rest@22 at the runtime root. Re-copying the private
+  // Bun fallback produces tar-unsafe nested paths on Windows.
+  ["git-workspace-service", new Set(["@octokit/rest"])],
+]);
 const RUNTIME_COPY_PRUNED_DIR_NAMES = new Set([
   ".git",
   ".gradle",
@@ -582,11 +588,48 @@ function shouldPreservePrunedPackageEntry(
   packageDir: string | undefined,
   entryPath: string,
 ): boolean {
+  const relativePath = packageDir
+    ? toPosixPath(path.relative(packageDir, entryPath))
+    : "";
+  if (
+    packageName === "@elizaos/skills" &&
+    relativePath.startsWith("skills/") &&
+    /\.(?:md|markdown)$/i.test(relativePath)
+  ) {
+    return true;
+  }
+
+  if (
+    packageName === "googleapis" &&
+    (relativePath === "build/src/apis/docs" ||
+      relativePath.startsWith("build/src/apis/docs/"))
+  ) {
+    return true;
+  }
+
+  if (
+    packageName === "three" &&
+    (relativePath === "examples" ||
+      relativePath === "examples/jsm" ||
+      relativePath.startsWith("examples/jsm/") ||
+      relativePath === "examples/fonts" ||
+      relativePath.startsWith("examples/fonts/"))
+  ) {
+    return true;
+  }
+
+  if (
+    packageName === "@elizaos/ui" &&
+    (relativePath === "dist/cloud-ui/components/docs" ||
+      relativePath.startsWith("dist/cloud-ui/components/docs/"))
+  ) {
+    return true;
+  }
+
   if (packageName !== "@elevenlabs/elevenlabs-js" || !packageDir) {
     return false;
   }
 
-  const relativePath = toPosixPath(path.relative(packageDir, entryPath));
   return (
     relativePath === "api/resources/conversationalAi/resources/tests" ||
     relativePath.startsWith(
@@ -642,7 +685,8 @@ function pruneCopiedPackageDir(name: string, packageDir: string): void {
 
       if (
         entry.isFile() &&
-        RUNTIME_COPY_PRUNED_FILE_EXTENSIONS.has(path.extname(entry.name))
+        RUNTIME_COPY_PRUNED_FILE_EXTENSIONS.has(path.extname(entry.name)) &&
+        !shouldPreservePrunedPackageEntry(name, packageDir, entryPath)
       ) {
         fs.rmSync(entryPath, { force: true });
         continue;
@@ -753,6 +797,8 @@ function shouldSkipPackagedAppCoreEntry(relativeEntry: string): boolean {
 
 type PackageJsonManifest = {
   exports?: Record<string, unknown>;
+  main?: string;
+  module?: string;
 };
 
 type AgentDeepImportExportEntry = {
@@ -1113,7 +1159,10 @@ export function shouldCopyPackageEntry(
   ) {
     return false;
   }
-  if (RUNTIME_COPY_PRUNED_FILE_EXTENSIONS.has(path.extname(entry))) {
+  if (
+    RUNTIME_COPY_PRUNED_FILE_EXTENSIONS.has(path.extname(entry)) &&
+    !shouldPreservePrunedPackageEntry(packageName, packageRoot, entry)
+  ) {
     return false;
   }
   if (entry.endsWith(".d.ts") || entry.endsWith(".d.ts.map")) {
@@ -1366,6 +1415,21 @@ export function isPackageCompatibleWithCurrentPlatform(
   );
 }
 
+function hasRootPackageOverride(name: string): boolean {
+  try {
+    const manifest = readJson<{
+      overrides?: Record<string, unknown>;
+      resolutions?: Record<string, unknown>;
+    }>(PACKAGE_JSON_PATH);
+    return (
+      Object.prototype.hasOwnProperty.call(manifest.overrides ?? {}, name) ||
+      Object.prototype.hasOwnProperty.call(manifest.resolutions ?? {}, name)
+    );
+  } catch {
+    return false;
+  }
+}
+
 function collectInstalledPackageDirs(
   name: string,
   requesterDir: string,
@@ -1385,6 +1449,13 @@ function collectInstalledPackageDirs(
     for (const candidate of workspacePackageIndex.get(name) ?? []) {
       addCandidate(candidate.sourceDir);
     }
+  }
+
+  // Root overrides/resolutions are the package manager's answer for peers.
+  // Prefer that install over requester-local Bun store fallbacks so runtime
+  // packaging follows the same graph used by app-core builds.
+  if (hasRootPackageOverride(name)) {
+    addCandidate(packagePath(name, ROOT_NODE_MODULES));
   }
 
   let dir = requesterDir;
@@ -1550,6 +1621,10 @@ export function getRuntimeDependencies(pkgPath: string): string[] {
   return getRuntimeDependencyEntries(pkgPath).map((entry) => entry.name);
 }
 
+function shouldHoistRuntimePackage(name: string): boolean {
+  return ALWAYS_HOISTED_PACKAGES.has(name) || name.startsWith("@solana/");
+}
+
 type CopyTargetOptions = {
   name: string;
   requesterDestDir: string;
@@ -1571,7 +1646,7 @@ export function selectCopyTargetNodeModules({
     return targetNodeModules;
   }
 
-  if (ALWAYS_HOISTED_PACKAGES.has(name) && topLevelVersions.has(name)) {
+  if (shouldHoistRuntimePackage(name) && topLevelVersions.has(name)) {
     return targetNodeModules;
   }
 
@@ -1609,35 +1684,133 @@ function copyPgliteCompatibilityAssets(targetDist: string): void {
   }
 }
 
+function isRuntimeManifestEntryPath(value: string): boolean {
+  if (!value.startsWith("./") || value.includes("*")) {
+    return false;
+  }
+  if (/\.(?:d\.)?ts$/i.test(value) || /\.d\.[cm]?ts$/i.test(value)) {
+    return false;
+  }
+  return true;
+}
+
+function runtimeManifestEntryExists(
+  packageDir: string,
+  entryPath: string,
+): boolean {
+  const resolved = path.resolve(packageDir, entryPath);
+  const relative = path.relative(packageDir, resolved);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return false;
+  }
+
+  if (fs.existsSync(resolved)) {
+    return true;
+  }
+
+  if (!path.extname(resolved)) {
+    return [
+      ".js",
+      ".mjs",
+      ".cjs",
+      "/index.js",
+      "/index.mjs",
+      "/index.cjs",
+    ].some((suffix) => fs.existsSync(`${resolved}${suffix}`));
+  }
+
+  return false;
+}
+
+function collectRuntimeExportEntryPaths(value: unknown): string[] {
+  if (typeof value === "string") {
+    return isRuntimeManifestEntryPath(value) ? [value] : [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => collectRuntimeExportEntryPaths(entry));
+  }
+
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>);
+  const hasSubpathKeys = entries.some(
+    ([key]) => key === "." || key.startsWith("./"),
+  );
+  if (hasSubpathKeys) {
+    return entries.flatMap(([, entry]) => collectRuntimeExportEntryPaths(entry));
+  }
+
+  return entries.flatMap(([condition, entry]) => {
+    if (condition === "types" || condition === "typings") {
+      return [];
+    }
+    return collectRuntimeExportEntryPaths(entry);
+  });
+}
+
+function getRequiredRuntimeEntryPaths(pkgJsonPath: string): string[] {
+  const manifest = readJson<PackageJsonManifest>(pkgJsonPath);
+  const entries = new Set<string>();
+
+  for (const entry of [manifest.main, manifest.module]) {
+    if (typeof entry === "string" && isRuntimeManifestEntryPath(entry)) {
+      entries.add(entry);
+    }
+  }
+
+  for (const entry of collectRuntimeExportEntryPaths(manifest.exports)) {
+    entries.add(entry);
+  }
+
+  return [...entries].sort();
+}
+
 // Post-copy assertion: missingAlwaysBundled catches resolve failures, but
 // can't catch a transitive-walk filter silently skipping a CORE plugin or
-// pruneCopiedPackageDir removing a load-bearing package.json.
+// pruneCopiedPackageDir removing a load-bearing package.json or entrypoint.
 export function assertRequiredBundledPackagesLanded(
   targetNodeModules: string,
   alwaysBundled: ReadonlySet<string>,
 ): void {
   const missing: string[] = [];
+  const missingEntrypoints: string[] = [];
+  const baselinePackages = new Set(BASELINE_BUNDLED_RUNTIME_PACKAGES);
   for (const name of alwaysBundled) {
     if (!isPackageNameCompatibleWithCurrentPlatform(name)) continue;
-    const pkgJsonPath = path.join(
-      packagePath(name, targetNodeModules),
-      "package.json",
-    );
+    const packageDir = packagePath(name, targetNodeModules);
+    const pkgJsonPath = path.join(packageDir, "package.json");
     if (!fs.existsSync(pkgJsonPath)) {
       missing.push(name);
+      continue;
+    }
+
+    if (!baselinePackages.has(name)) {
+      continue;
+    }
+
+    for (const entryPath of getRequiredRuntimeEntryPaths(pkgJsonPath)) {
+      if (!runtimeManifestEntryExists(packageDir, entryPath)) {
+        missingEntrypoints.push(
+          `${name}  (missing runtime entry ${path.join(packageDir, entryPath)})`,
+        );
+      }
     }
   }
-  if (missing.length === 0) return;
+  if (missing.length === 0 && missingEntrypoints.length === 0) return;
   throw new Error(
     [
-      `[runtime-copy] ${missing.length} required runtime package(s) failed to land in the bundle after copy + prune:`,
+      `[runtime-copy] ${missing.length + missingEntrypoints.length} required runtime package check(s) failed after copy + prune:`,
       ...missing
         .sort()
         .map(
           (n) =>
             `  ${n}  (missing ${path.join(packagePath(n, targetNodeModules), "package.json")})`,
         ),
-      "This usually means a filter in the transitive-walk or a rule in pruneCopiedPackageDir accidentally excluded a required package. Bundle is unsafe to ship.",
+      ...missingEntrypoints.sort().map((entry) => `  ${entry}`),
+      "This usually means a filter in the transitive-walk, build output, or a rule in pruneCopiedPackageDir accidentally excluded a required package entry. Bundle is unsafe to ship.",
     ].join("\n"),
   );
 }

--- a/packages/app-core/scripts/desktop-build.mjs
+++ b/packages/app-core/scripts/desktop-build.mjs
@@ -58,10 +58,28 @@ function resolveWorkspacePackageDir(packageDirName) {
   );
 }
 
+function resolveWorkspacePluginDir(pluginDirName) {
+  const candidates = [
+    path.join(ROOT, "plugins", pluginDirName),
+    path.join(ROOT, "eliza", "plugins", pluginDirName),
+  ];
+  return (
+    candidates.find((candidate) =>
+      fs.existsSync(path.join(candidate, "package.json")),
+    ) ?? candidates[0]
+  );
+}
+
 const APP_CORE_PACKAGE_DIR = resolveWorkspacePackageDir("app-core");
 const CORE_PACKAGE_DIR = resolveWorkspacePackageDir("core");
+const PLUGIN_AGENT_ORCHESTRATOR_PACKAGE_DIR = resolveWorkspacePluginDir(
+  "plugin-agent-orchestrator",
+);
 const PLUGIN_REMOTE_MANIFEST_PACKAGE_DIR =
   resolveWorkspacePackageDir("plugin-remote-manifest");
+const PLUGIN_WORKER_RUNTIME_PACKAGE_DIR = resolveWorkspacePackageDir(
+  "plugin-worker-runtime",
+);
 const SHARED_PACKAGE_DIR = resolveWorkspacePackageDir("shared");
 const UI_PACKAGE_DIR = resolveWorkspacePackageDir("ui");
 const VAULT_PACKAGE_DIR = resolveWorkspacePackageDir("vault");
@@ -639,6 +657,14 @@ function ensureWorkspaceRuntimePackagesBuilt() {
   ensureWorkspaceRuntimePackageBuilt(
     "@elizaos/plugin-remote-manifest",
     PLUGIN_REMOTE_MANIFEST_PACKAGE_DIR,
+  );
+  ensureWorkspaceRuntimePackageBuilt(
+    "@elizaos/plugin-agent-orchestrator",
+    PLUGIN_AGENT_ORCHESTRATOR_PACKAGE_DIR,
+  );
+  ensureWorkspaceRuntimePackageBuilt(
+    "@elizaos/plugin-worker-runtime",
+    PLUGIN_WORKER_RUNTIME_PACKAGE_DIR,
   );
   ensureWorkspaceRuntimePackageBuilt("@elizaos/app-core", APP_CORE_PACKAGE_DIR);
 }

--- a/packages/app-core/src/runtime/platform-policy-docs.test.ts
+++ b/packages/app-core/src/runtime/platform-policy-docs.test.ts
@@ -20,7 +20,9 @@ describe("platform policy docs", () => {
     expect(sandboxDoc).toContain("@elizaos/plugin-coding-tools");
     expect(sandboxDoc).toContain("agent-orchestrator");
 
-    expect(mobileDoc).toMatch(/do\s+not run a local Bun backend/);
+    expect(mobileDoc).toMatch(
+      /WebView does not open a TCP\s+connection to the full-Bun backend/,
+    );
     expect(mobileDoc).toContain("bun run build:android:cloud");
     expect(mobileDoc).toContain("bun run build:android:system");
 

--- a/packages/app-core/vitest.config.ts
+++ b/packages/app-core/vitest.config.ts
@@ -91,6 +91,14 @@ const pluginAgentOrchestratorSrc = path.join(
   monorepoRoot,
   "plugins/plugin-agent-orchestrator/src",
 );
+const pluginRemoteManifestSrc = path.join(
+  monorepoRoot,
+  "packages/plugin-remote-manifest/src",
+);
+const pluginWorkerRuntimeSrc = path.join(
+  monorepoRoot,
+  "packages/plugin-worker-runtime/src",
+);
 const pluginWorkflowSrc = path.join(
   monorepoRoot,
   "plugins/plugin-workflow/src",
@@ -439,6 +447,22 @@ export default defineConfig({
       {
         find: /^@elizaos\/plugin-agent-orchestrator\/(.+)$/,
         replacement: path.join(pluginAgentOrchestratorSrc, "$1"),
+      },
+      {
+        find: /^@elizaos\/plugin-remote-manifest$/,
+        replacement: path.join(pluginRemoteManifestSrc, "index.ts"),
+      },
+      {
+        find: /^@elizaos\/plugin-remote-manifest\/(.+)$/,
+        replacement: path.join(pluginRemoteManifestSrc, "$1"),
+      },
+      {
+        find: /^@elizaos\/plugin-worker-runtime$/,
+        replacement: path.join(pluginWorkerRuntimeSrc, "index.ts"),
+      },
+      {
+        find: /^@elizaos\/plugin-worker-runtime\/(.+)$/,
+        replacement: path.join(pluginWorkerRuntimeSrc, "$1"),
       },
       {
         find: /^@elizaos\/plugin-workflow$/,

--- a/packages/core/src/__tests__/service-type-collisions.test.ts
+++ b/packages/core/src/__tests__/service-type-collisions.test.ts
@@ -62,6 +62,18 @@ const duplicateServiceTypeAllowlist = new Map<string, AllowlistEntry>([
 		},
 	],
 	[
+		"capability-router",
+		{
+			reason:
+				"Capability routing is mid-migration: the core canonical service and the legacy agent remote/E2B routers share the slot until callers finish moving to RuntimeCapabilityService.",
+			classes: new Set([
+				"packages/core/src/services/runtime-capability-service.ts:RuntimeCapabilityService",
+				"packages/agent/src/services/e2b-capability-router.ts:E2BRemoteCapabilityRouterService",
+				"packages/agent/src/services/remote-capability-router.ts:RemoteCapabilityRouterService",
+			]),
+		},
+	],
+	[
 		"discord-local",
 		{
 			reason:
@@ -82,6 +94,17 @@ const duplicateServiceTypeAllowlist = new Map<string, AllowlistEntry>([
 				"plugins/plugin-tailscale/src/services/CloudTailscaleService.ts:CloudTailscaleService",
 				"plugins/plugin-tailscale/src/services/LocalTailscaleService.ts:LocalTailscaleService",
 				"plugins/plugin-tunnel/src/services/LocalTunnelService.ts:LocalTunnelService",
+			]),
+		},
+	],
+	[
+		"xr-session",
+		{
+			reason:
+				"Hearwear and XR expose the same session service contract while those plugins converge; they are alternative providers, not services enabled together.",
+			classes: new Set([
+				"plugins/plugin-hearwear/src/services/xr-session-service.ts:XRSessionService",
+				"plugins/plugin-xr/src/services/xr-session-service.ts:XRSessionService",
 			]),
 		},
 	],


### PR DESCRIPTION
## Summary
- bundle runtime support packages required by the embedded desktop agent (`plugin-worker-runtime`, `plugin-remote-manifest`, and desktop `plugin-agent-orchestrator`)
- copy Electrobun `remotes/` into direct embedded desktop packages so first-party remotes have their `plugin.json`
- keep runtime payload files that are loaded dynamically, including bundled skill markdown, and add package entrypoint assertions so unsafe bundles fail during packaging
- avoid Windows tar-unsafe nested Octokit paths by using the top-level peer supplied by the bundled orchestrator graph

## Verification
- `node packages/scripts/run-vitest.mjs run --config packages/agent/vitest.config.ts packages/agent/src/runtime/release-plugin-policy.test.ts`
- `node packages/scripts/run-vitest.mjs run --config packages/app-core/vitest.config.ts packages/app-core/scripts/assert-required-bundled-packages.test.ts packages/app-core/platforms/electrobun/src/electrobun-config.test.ts`
- Windows local-source package build from Milady wrapper completed successfully with `MILADY_ELIZA_SOURCE=local`
- Packaged runtime contained required files:
  - `eliza-dist/node_modules/@elizaos/plugin-agent-orchestrator/dist/index.js`
  - `eliza-dist/node_modules/@elizaos/plugin-worker-runtime/dist/bootstrap.js`
  - `eliza-dist/node_modules/@elizaos/plugin-remote-manifest/dist/index.js`
  - `eliza-dist/node_modules/@elizaos/skills/skills/task-agent-eliza-bridge/SKILL.md`
  - `remotes/runtime/plugin.json`
- Packaged Windows app launched, `/api/health` reported `ready: true` and `plugins.failed: 0`
- First-run onboarding smoke passed in packaged CEF: skip voice setup -> local setup -> `/chat`
- Main UI smoke passed: Views, Character, Browser, Automations, Chat tabs rendered; chat returned `Echo: hello from final latest package`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Windows desktop build by ensuring `plugin-worker-runtime`, `plugin-remote-manifest`, and `plugin-agent-orchestrator` are built and bundled into the packaged runtime, and copies Electrobun `remotes/` so first-party remote plugins carry their `plugin.json`.

- **Policy split**: `BASELINE_BUNDLED_RUNTIME_PACKAGES` now includes the new runtime-support packages for filesystem bundling, but a separate `BASELINE_REGISTRY_BUNDLED_PLUGIN_PACKAGES` list keeps them out of the registry "bundled" classification; `classifyRegistryPluginRelease` is tightened to require both a static whitelist check and a runtime-availability check before marking a plugin as bundled.
- **Asset preservation**: `shouldPreservePrunedPackageEntry` gains explicit rules to retain skill markdown files, `googleapis` docs API files, `three.js` JSM/fonts examples, and `@elizaos/ui` component docs that are loaded dynamically at runtime.
- **Windows tar-safety fix**: `@octokit/rest` is skipped when bundling `git-workspace-service`'s transitive deps, relying on the top-level peer supplied by `plugin-agent-orchestrator` to avoid deeply-nested Windows-unsafe paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are build-tooling and policy metadata with no modifications to runtime logic or data paths.

All changes are confined to the desktop packaging pipeline and release-policy classification. The new preservation rules and entrypoint assertions are well-covered by the added tests, the Windows tar-path fix is correctly scoped to the one package that triggers the problem, and the policy split between bundled-for-filesystem and bundled-for-registry correctly prevents runtime-support packages from being surfaced as user-installable plugins.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/runtime/release-plugin-policy.ts | Splits BASELINE_BUNDLED_RUNTIME_PACKAGES from BASELINE_REGISTRY_BUNDLED_PLUGIN_PACKAGES so runtime-support packages (plugin-remote-manifest, plugin-worker-runtime) ship in the bundle but are excluded from "bundled" registry classification; classifyRegistryPluginRelease now requires both static and dynamic checks. |
| packages/app-core/scripts/copy-runtime-node-modules.ts | Adds shouldPreservePrunedPackageEntry rules for skill markdown, googleapis docs, three.js jsm/fonts examples, and @elizaos/ui docs; adds @octokit/rest skip for git-workspace-service to fix Windows tar-unsafe nested paths; adds commander to ALWAYS_HOISTED_PACKAGES; extends assertRequiredBundledPackagesLanded to also verify declared runtime entrypoints. |
| packages/app-core/platforms/electrobun/electrobun.config.ts | Copies the electrobunDir's remotes/ directory into the packaged app for direct desktop builds so first-party remote plugins have their plugin.json; correctly skipped for Store and external-API builds. |
| packages/app-core/scripts/desktop-build.mjs | Adds build steps for plugin-agent-orchestrator and plugin-worker-runtime before packaging; uses a new resolveWorkspacePluginDir helper that searches plugins/ before eliza/plugins/, falling back with a clear fail() error if the package.json is missing. |
| packages/app-core/vitest.config.ts | Adds Vite resolve aliases for @elizaos/plugin-remote-manifest and @elizaos/plugin-worker-runtime source directories to enable test-time type resolution without a build step. |
| packages/core/src/__tests__/service-type-collisions.test.ts | Adds two new allowlist entries for capability-router (mid-migration, three co-existing services) and xr-session (alternative providers) service type duplicates. |
| packages/app-core/scripts/assert-required-bundled-packages.test.ts | Extensive new test coverage for entrypoint existence checks, skill markdown preservation, dynamic asset preservation for googleapis/three/ui, Solana hoisting, Octokit skip, and getRuntimeDependencies lucide-react retention. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[desktop-build.mjs] --> B[Build core + shared + vault]
    A --> C[Build plugin-remote-manifest]
    A --> D[Build plugin-agent-orchestrator NEW]
    A --> E[Build plugin-worker-runtime NEW]
    A --> F[Build app-core]

    G[copy-runtime-node-modules] --> H{shouldSkipPackagedDependency?}
    H -->|git-workspace-service and octokit-rest| I[Skip - use root peer]
    H -->|other deps| J[selectCopyTargetNodeModules]
    J -->|solana or ALWAYS_HOISTED| K[Root node_modules]
    J -->|version matches top-level| K
    J -->|version mismatch| L[Nested node_modules]

    M[pruneCopiedPackageDir] --> N{shouldPreservePrunedPackageEntry?}
    N -->|skills markdown| O[Keep SKILL.md]
    N -->|googleapis docs api| P[Keep docs API files]
    N -->|three jsm and fonts| Q[Keep runtime loaders]
    N -->|elizaos-ui component docs| R[Keep component docs]
    N -->|other pruned entries| S[Delete]

    T[assertRequiredBundledPackagesLanded] --> U{package.json exists?}
    U -->|No| V[FAIL missing package]
    U -->|Yes baseline package| W{entrypoints exist?}
    W -->|No| X[FAIL missing runtime entry]
    W -->|Yes| Y[PASS]
```

<sub>Reviews (4): Last reviewed commit: ["fix(test): allowlist known service type ..."](https://github.com/elizaos/eliza/commit/fd785be466808d8b3325561a836effdaa29914ce) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33182326)</sub>

<!-- /greptile_comment -->