### PR TITLE
fix(test): allowlist known service type migrations

### DIFF
--- a/packages/app-core/scripts/build-llama-cpp-dflash-targets.test.mjs
+++ b/packages/app-core/scripts/build-llama-cpp-dflash-targets.test.mjs
@@ -3,16 +3,17 @@ import { it as test } from "vitest";
 
 import { formatHelpText, parseArgs } from "./build-llama-cpp-dflash.mjs";
 
-test("help advertises supported fused targets but not Android fused targets", () => {
+test("help advertises supported fused targets but not mobile fused targets", () => {
   const helpText = formatHelpText();
   assert.match(helpText, /linux-aarch64-cuda-fused/);
-  assert.match(helpText, /ios-arm64-metal-fused/);
-  assert.match(helpText, /ios-arm64-simulator-metal-fused/);
+  assert.match(helpText, /darwin-arm64-metal-fused/);
   assert.doesNotMatch(helpText, /android-arm64-cpu-fused/);
   assert.doesNotMatch(helpText, /android-x86_64-cpu-fused/);
+  assert.doesNotMatch(helpText, /ios-arm64-metal-fused/);
+  assert.doesNotMatch(helpText, /ios-arm64-simulator-metal-fused/);
 });
 
-test("unsupported Android fused targets fail closed with explicit diagnostics", () => {
+test("unsupported mobile fused targets fail closed with explicit diagnostics", () => {
   const cases = [
     ["android-arm64-cpu-fused", /Android fused FFI is not wired/],
     ["android-arm64-vulkan-fused", /Android fused FFI is not wired/],
@@ -24,6 +25,8 @@ test("unsupported Android fused targets fail closed with explicit diagnostics", 
       "android-x86_64-vulkan-fused",
       /Android x86_64 fused FFI is not a dflash target/,
     ],
+    ["ios-arm64-metal-fused", /iOS fused FFI is not wired/],
+    ["ios-arm64-simulator-metal-fused", /iOS fused FFI is not wired/],
   ];
 
   for (const [target, pattern] of cases) {

--- a/packages/app-core/vitest.config.ts
+++ b/packages/app-core/vitest.config.ts
@@ -7,10 +7,6 @@ const fileDir = path.dirname(fileURLToPath(import.meta.url));
 const monorepoRoot = path.resolve(fileDir, "../..");
 const appCoreSrc = path.join(fileDir, "src");
 const agentSrc = path.join(monorepoRoot, "packages/agent/src");
-const pluginWorkerRuntimeSrc = path.join(
-  monorepoRoot,
-  "packages/plugin-worker-runtime/src",
-);
 const uiDir = path.join(monorepoRoot, "packages/ui");
 const sharedSrc = path.join(monorepoRoot, "packages/shared/src");
 const coreSrc = path.join(monorepoRoot, "packages/core/src");
@@ -475,14 +471,6 @@ export default defineConfig({
       {
         find: /^@elizaos\/plugin-x402$/,
         replacement: path.join(pluginX402Src, "index.ts"),
-      },
-      {
-        find: /^@elizaos\/plugin-worker-runtime$/,
-        replacement: path.join(pluginWorkerRuntimeSrc, "index.ts"),
-      },
-      {
-        find: /^@elizaos\/plugin-worker-runtime\/(.+)$/,
-        replacement: path.join(pluginWorkerRuntimeSrc, "$1"),
       },
       {
         find: /^@elizaos\/plugin-browser$/,

--- a/packages/core/src/__tests__/service-type-collisions.test.ts
+++ b/packages/core/src/__tests__/service-type-collisions.test.ts
@@ -62,6 +62,18 @@ const duplicateServiceTypeAllowlist = new Map<string, AllowlistEntry>([
 		},
 	],
 	[
+		"capability-router",
+		{
+			reason:
+				"Capability routing is mid-migration: the core canonical service and the legacy agent remote/E2B routers share the slot until callers finish moving to RuntimeCapabilityService.",
+			classes: new Set([
+				"packages/core/src/services/runtime-capability-service.ts:RuntimeCapabilityService",
+				"packages/agent/src/services/e2b-capability-router.ts:E2BRemoteCapabilityRouterService",
+				"packages/agent/src/services/remote-capability-router.ts:RemoteCapabilityRouterService",
+			]),
+		},
+	],
+	[
 		"discord-local",
 		{
 			reason:
@@ -82,6 +94,17 @@ const duplicateServiceTypeAllowlist = new Map<string, AllowlistEntry>([
 				"plugins/plugin-tailscale/src/services/CloudTailscaleService.ts:CloudTailscaleService",
 				"plugins/plugin-tailscale/src/services/LocalTailscaleService.ts:LocalTailscaleService",
 				"plugins/plugin-tunnel/src/services/LocalTunnelService.ts:LocalTunnelService",
+			]),
+		},
+	],
+	[
+		"xr-session",
+		{
+			reason:
+				"Hearwear and XR expose the same session service contract while those plugins converge; they are alternative providers, not services enabled together.",
+			classes: new Set([
+				"plugins/plugin-hearwear/src/services/xr-session-service.ts:XRSessionService",
+				"plugins/plugin-xr/src/services/xr-session-service.ts:XRSessionService",
 			]),
 		},
 	],


### PR DESCRIPTION
## Summary
- allowlist the current `capability-router` service type migration while `RuntimeCapabilityService` coexists with the legacy remote/E2B routers
- allowlist the `xr-session` duplicate while Hearwear and XR provide alternative implementations of the same session contract
- remove duplicate app-core Vitest aliases introduced by the landed Windows desktop packaging patch so the release contract suite can load its config
- align the dflash fused-target test with the script contract: desktop/server fused targets are advertised, while mobile fused targets fail closed with explicit diagnostics

## Verification
- `node packages/scripts/run-vitest.mjs run --config packages/core/vitest.config.ts packages/core/src/__tests__/service-type-collisions.test.ts`
- `node packages/scripts/run-vitest.mjs run --config packages/app-core/vitest.config.ts packages/app-core/platforms/electrobun/src/electrobun-config.test.ts`
- direct `build-llama-cpp-dflash.mjs` import check for fused help output and unsupported mobile fused diagnostics
- `node ../../packages/scripts/run-vitest.mjs run --config vitest.config.ts src/actions/enter-worktree.test.ts src/actions/exit-worktree.test.ts src/actions/ls.test.ts src/actions/read.test.ts src/actions/write.test.ts src/lib/run-shell.test.ts` from `plugins/plugin-coding-tools`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR unblocks three test suites that were failing due to legitimate code-state mismatches rather than actual bugs. All changes are test/config fixes with no production logic touched.

- **`service-type-collisions.test.ts`**: Adds `capability-router` (3 classes: `RuntimeCapabilityService`, `E2BRemoteCapabilityRouterService`, `RemoteCapabilityRouterService`) and `xr-session` (2 classes: Hearwear and XR `XRSessionService`) to the duplicate allowlist. All referenced paths and service-type string values were verified against the live source files.
- **`vitest.config.ts`**: Removes a duplicate variable declaration and alias pair for `@elizaos/plugin-worker-runtime` that were introduced by the Windows desktop packaging patch; an identical definition already exists later in the file, so resolution is unaffected.
- **`build-llama-cpp-dflash-targets.test.mjs`**: Aligns help-text assertions with the actual `SUPPORTED_TARGETS` / `FUSED_TARGETS` arrays — replaces the incorrect `ios-arm64-metal-fused` match with `darwin-arm64-metal-fused`, moves iOS fused variants to `doesNotMatch`, and adds them to the fail-closed error-message cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are test and config corrections with no production logic modified.

Every allowlist class path and service-type string was cross-checked against the live source. The vitest alias removal is non-breaking because an identical alias survives lower in the file. The build-script test corrections precisely match the actual SUPPORTED_TARGETS and fail-closed map in the build script.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/__tests__/service-type-collisions.test.ts | Adds two well-justified allowlist entries (capability-router and xr-session) for known in-flight service-type migrations; all referenced class paths and service type string values verified against existing source files. |
| packages/app-core/vitest.config.ts | Removes a duplicate @elizaos/plugin-worker-runtime variable declaration and its corresponding alias entries; an identical declaration and pair of aliases remain lower in the file, so nothing breaks. |
| packages/app-core/scripts/build-llama-cpp-dflash-targets.test.mjs | Corrects help-text assertions to match actual SUPPORTED_TARGETS/FUSED_TARGETS arrays: replaces wrong ios-arm64-metal-fused match with darwin-arm64-metal-fused, moves iOS fused variants to doesNotMatch, and adds them to the fail-closed error-message test cases. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(test): allowlist known service type ..."](https://github.com/elizaos/eliza/commit/ff890cc7ae860477376bc1513d18c2d5aa4fba23) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33189812)</sub>

<!-- /greptile_comment -->