### PR TITLE
fix(plugin-slack): drop unnecessary as-unknown cast on user WebClient — Greptile P2 (post-merge)

### DIFF
--- a/plugins/plugin-slack/src/service.ts
+++ b/plugins/plugin-slack/src/service.ts
@@ -732,8 +732,12 @@ export class SlackService extends Service implements ISlackService {
       // session is needed. Only constructed when a user token is
       // configured. Routing decisions in getOutboundClient() consult
       // account.role to decide which client receives each call.
+      // `WebClient` is the alias for `App["client"]`, which is the
+      // same `@slack/web-api` `WebClient` class imported here as
+      // `SlackWebClient` — a direct `as WebClient` cast is correct
+      // and a future type divergence will surface as an error here.
       const userClient = account.userToken
-        ? (new SlackWebClient(account.userToken) as unknown as WebClient)
+        ? (new SlackWebClient(account.userToken) as WebClient)
         : null;
 
       const state: SlackAccountRuntime = {


### PR DESCRIPTION
## What

One-line type cleanup. `new SlackWebClient(account.userToken) as unknown as WebClient` becomes `new SlackWebClient(account.userToken) as WebClient`.

## Why

In `service.ts` line 26, `WebClient` is aliased to `App["client"]`, which is the same `@slack/web-api` `WebClient` class imported (under a different name, `SlackWebClient`) on line 25. The two are structurally identical — a direct `as WebClient` is the right cast. The `as unknown as WebClient` indirection masked, rather than bridged, that fact. If Bolt ever wraps its client into a subtype, we want the cast site to surface the divergence as a type error instead of swallowing it silently.

Added a comment recording the invariant so the next person who sees the cast doesn't reintroduce the `unknown` step.

## Stack / context

Greptile P2 #3 on PR #7876 (`feat(plugin-slack): role-aware outbound client routing`), posted just before merge. The P1 (warn log when OWNER lacks userToken) and P2 #1 (`roleFromMetadata` AGENT default) from the same review landed on develop overnight via `947d609c5d7` (shaw) and `f0662431eae`. This PR closes the remaining P2.

Off `origin/develop`; no stacking.

## Verification

- `bunx tsc --noEmit -p plugins/plugin-slack/tsconfig.json` — clean.
- `bunx vitest run plugins/plugin-slack/src/` — 17/17 pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the `as unknown as WebClient` double-cast in `service.ts` when constructing the user-scoped `SlackWebClient`, replacing it with a direct `as WebClient` cast. An inline comment is added to document that `WebClient` (aliased from `App["client"]`) and `SlackWebClient` (imported directly from `@slack/web-api`) are the same underlying class, making the `unknown` indirection unnecessary.

- **Type cast cleanup**: `new SlackWebClient(account.userToken) as unknown as WebClient` → `new SlackWebClient(account.userToken) as WebClient`. TypeScript accepts this without `as unknown`, confirmed by a clean `tsc --noEmit` run.
- **Comment added**: The new comment records the invariant so future maintainers understand the cast without needing to trace the two import aliases.

<h3>Confidence Score: 5/5</h3>

This is a pure TypeScript type-layer change with no runtime impact; safe to merge.

The change removes an `as unknown` escape hatch that was masking the fact that `SlackWebClient` and the `WebClient` alias resolve to the same `@slack/web-api` class. TypeScript accepting the direct `as WebClient` cast (verified by `tsc --noEmit`) confirms structural identity. No logic, no runtime behavior, and no API surface is touched.

No files require special attention — the single changed file has a well-scoped, type-only edit.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-slack/src/service.ts | Drops the `as unknown` escape-hatch in the user WebClient cast and adds an inline comment documenting why the direct `as WebClient` cast is valid. No logic changes. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant service.ts
    participant SlackWebClient as SlackWebClient (@slack/web-api WebClient)
    participant WebClient as WebClient (App["client"] alias)

    service.ts->>SlackWebClient: new SlackWebClient(account.userToken)
    note over service.ts,WebClient: Before: as unknown as WebClient (escape hatch)
    note over service.ts,WebClient: After: as WebClient (direct cast — types are structurally identical)
    SlackWebClient-->>WebClient: cast result stored as userClient
```

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-slack): drop unnecessary as-u..."](https://github.com/elizaos/eliza/commit/36dd40e92a801bef78940f049374bb6443cb937b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33233874)</sub>

<!-- /greptile_comment -->