### PR TITLE
fix(cloud-frontend): rename landing button to Dashboard

### DIFF
--- a/packages/cloud-frontend/src/components/layout/landing-header.tsx
+++ b/packages/cloud-frontend/src/components/layout/landing-header.tsx
@@ -18,8 +18,8 @@ export default function LandingHeader() {
 
   const openDashboard = () => navigate("/login?intent=dashboard");
 
-  const devDashboardLabel = t("cloud.landing.developerDashboard", {
-    defaultValue: "Developer Dashboard",
+  const dashboardLabel = t("cloud.landing.dashboard", {
+    defaultValue: "Dashboard",
   });
 
   return (
@@ -41,7 +41,7 @@ export default function LandingHeader() {
                 to="/dashboard"
                 className="inline-flex min-h-10 items-center justify-center rounded-[3px] bg-white px-5 text-sm font-medium text-black transition-colors hover:bg-black hover:text-white sm:min-h-11"
               >
-                {devDashboardLabel}
+                {dashboardLabel}
               </Link>
               <UserMenu />
             </>
@@ -53,7 +53,7 @@ export default function LandingHeader() {
               disabled={!ready}
               type="button"
             >
-              {devDashboardLabel}
+              {dashboardLabel}
             </button>
           )}
         </div>

--- a/packages/ui/src/i18n/locales/en.json
+++ b/packages/ui/src/i18n/locales/en.json
@@ -3379,7 +3379,7 @@
   "cloud.header.signUpFree": "Sign Up Free",
   "cloud.header.signUp": "Sign Up",
   "cloud.landing.launchEliza": "Launch Eliza",
-  "cloud.landing.developerDashboard": "Developer Dashboard",
+  "cloud.landing.dashboard": "Dashboard",
   "cloud.landing.heroTitle": "Your Agent. Anywhere.",
   "cloud.landing.heroSubtitle": "Hosting, APIs and commerce tools for agents.",
   "cloud.landing.opening": "Opening Eliza Cloud…",

--- a/packages/ui/src/i18n/locales/es.json
+++ b/packages/ui/src/i18n/locales/es.json
@@ -3379,7 +3379,7 @@
   "cloud.header.signUpFree": "Regístrate gratis",
   "cloud.header.signUp": "Regístrate",
   "cloud.landing.launchEliza": "Lanzar Eliza",
-  "cloud.landing.developerDashboard": "Panel de desarrolladores",
+  "cloud.landing.dashboard": "Panel",
   "cloud.landing.heroTitle": "Lanza Eliza.",
   "cloud.landing.heroSubtitle": "Tu agente, siempre en línea.",
   "cloud.landing.opening": "Abriendo Eliza Cloud…",

--- a/packages/ui/src/i18n/locales/ja.json
+++ b/packages/ui/src/i18n/locales/ja.json
@@ -3379,7 +3379,7 @@
   "cloud.header.signUpFree": "無料で登録",
   "cloud.header.signUp": "登録",
   "cloud.landing.launchEliza": "Eliza を起動",
-  "cloud.landing.developerDashboard": "デベロッパーダッシュボード",
+  "cloud.landing.dashboard": "ダッシュボード",
   "cloud.landing.heroTitle": "Eliza を起動。",
   "cloud.landing.heroSubtitle": "あなたのエージェント、いつでもオンライン。",
   "cloud.landing.opening": "Eliza Cloud を開いています…",

--- a/packages/ui/src/i18n/locales/ko.json
+++ b/packages/ui/src/i18n/locales/ko.json
@@ -3379,7 +3379,7 @@
   "cloud.header.signUpFree": "무료 가입",
   "cloud.header.signUp": "가입하기",
   "cloud.landing.launchEliza": "Eliza 실행",
-  "cloud.landing.developerDashboard": "개발자 대시보드",
+  "cloud.landing.dashboard": "대시보드",
   "cloud.landing.heroTitle": "Eliza 실행.",
   "cloud.landing.heroSubtitle": "네 에이전트, 항상 온라인.",
   "cloud.landing.opening": "Eliza Cloud 여는 중…",

--- a/packages/ui/src/i18n/locales/pt.json
+++ b/packages/ui/src/i18n/locales/pt.json
@@ -3379,7 +3379,7 @@
   "cloud.header.signUpFree": "Cadastre-se grátis",
   "cloud.header.signUp": "Cadastre-se",
   "cloud.landing.launchEliza": "Lançar Eliza",
-  "cloud.landing.developerDashboard": "Painel do desenvolvedor",
+  "cloud.landing.dashboard": "Painel",
   "cloud.landing.heroTitle": "Lance a Eliza.",
   "cloud.landing.heroSubtitle": "Seu agente, sempre online.",
   "cloud.landing.opening": "Abrindo Eliza Cloud…",

--- a/packages/ui/src/i18n/locales/tl.json
+++ b/packages/ui/src/i18n/locales/tl.json
@@ -3379,7 +3379,7 @@
   "cloud.header.signUpFree": "Mag-sign Up Libre",
   "cloud.header.signUp": "Mag-sign Up",
   "cloud.landing.launchEliza": "I-launch ang Eliza",
-  "cloud.landing.developerDashboard": "Developer Dashboard",
+  "cloud.landing.dashboard": "Dashboard",
   "cloud.landing.heroTitle": "I-launch ang Eliza.",
   "cloud.landing.heroSubtitle": "Ang agent mo, palaging online.",
   "cloud.landing.opening": "Binubuksan ang Eliza Cloud…",

--- a/packages/ui/src/i18n/locales/vi.json
+++ b/packages/ui/src/i18n/locales/vi.json
@@ -3379,7 +3379,7 @@
   "cloud.header.signUpFree": "Đăng ký miễn phí",
   "cloud.header.signUp": "Đăng ký",
   "cloud.landing.launchEliza": "Khởi chạy Eliza",
-  "cloud.landing.developerDashboard": "Developer Dashboard",
+  "cloud.landing.dashboard": "Bảng điều khiển",
   "cloud.landing.heroTitle": "Khởi chạy Eliza.",
   "cloud.landing.heroSubtitle": "Agent của bạn, luôn online.",
   "cloud.landing.opening": "Đang mở Eliza Cloud…",

--- a/packages/ui/src/i18n/locales/zh-CN.json
+++ b/packages/ui/src/i18n/locales/zh-CN.json
@@ -3379,7 +3379,7 @@
   "cloud.header.signUpFree": "免费注册",
   "cloud.header.signUp": "注册",
   "cloud.landing.launchEliza": "启动 Eliza",
-  "cloud.landing.developerDashboard": "开发者仪表盘",
+  "cloud.landing.dashboard": "仪表盘",
   "cloud.landing.heroTitle": "启动 Eliza。",
   "cloud.landing.heroSubtitle": "你的智能体,始终在线。",
   "cloud.landing.opening": "正在打开 Eliza Cloud…",


### PR DESCRIPTION
Shaw flagged that the front-page button labeled "Developer Dashboard" on https://elizacloud.ai should just read "Dashboard".

## Changes
- Renames i18n key `cloud.landing.developerDashboard` → `cloud.landing.dashboard` across all 8 locales (en, es, ja, ko, pt, tl, vi, zh-CN) and shortens values to the local equivalent of "Dashboard".
- Updates the lone consumer (`packages/cloud-frontend/src/components/layout/landing-header.tsx`) to read the new key and renames the local variable from `devDashboardLabel` → `dashboardLabel`.

## Verification
- `grep developerDashboard packages/` returns no matches under cloud-frontend or ui locales after the change.
- All locale JSONs revalidated via `json.load`.
- Behavior unchanged — same button, same target route (`/dashboard` for auth, `/login?intent=dashboard` for unauth), just a copy fix.

Requested by @shawmakesmagic in #milady.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a straightforward copy fix that renames the landing page button label from "Developer Dashboard" to "Dashboard" across all 8 supported locales and updates the single component that consumes the i18n key.

- Renames the i18n key `cloud.landing.developerDashboard` → `cloud.landing.dashboard` in all locale files (en, es, ja, ko, pt, tl, vi, zh-CN) and shortens translated values accordingly.
- Updates `landing-header.tsx` to use the new key and renames the local variable from `devDashboardLabel` → `dashboardLabel`; both render sites (authenticated `<Link>` and unauthenticated `<button>`) are correctly updated.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely a copy/label change with no behavioral impact.

The change touches only i18n string values and a single variable name in one component. The button's target routes, authentication logic, and all surrounding UI are untouched. The old key has been removed from every locale file and the sole consumer has been updated, so there is no risk of a missing-key fallback rendering at runtime.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cloud-frontend/src/components/layout/landing-header.tsx | Renames variable `devDashboardLabel` → `dashboardLabel` and switches i18n key from `cloud.landing.developerDashboard` to `cloud.landing.dashboard`; both button render sites updated correctly. |
| packages/ui/src/i18n/locales/en.json | Old key `cloud.landing.developerDashboard` replaced with `cloud.landing.dashboard: "Dashboard"` — clean rename. |
| packages/ui/src/i18n/locales/es.json | Key renamed; value shortened from "Panel de desarrolladores" to "Panel". |
| packages/ui/src/i18n/locales/ja.json | Key renamed; value shortened from "デベロッパーダッシュボード" to "ダッシュボード". |
| packages/ui/src/i18n/locales/ko.json | Key renamed; value shortened from "개발자 대시보드" to "대시보드". |
| packages/ui/src/i18n/locales/pt.json | Key renamed; value shortened from "Painel do desenvolvedor" to "Painel". |
| packages/ui/src/i18n/locales/tl.json | Key renamed; value unchanged ("Dashboard" — Tagalog uses the English word). |
| packages/ui/src/i18n/locales/vi.json | Key renamed; value changed from English "Developer Dashboard" to localized "Bảng điều khiển" — this also corrects a previously untranslated entry. |
| packages/ui/src/i18n/locales/zh-CN.json | Key renamed; value shortened from "开发者仪表盘" to "仪表盘". |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LandingHeader renders] --> B{User authenticated?}
    B -- Yes --> C["Link to /dashboard\ndashboardLabel"]
    B -- No --> D["button onClick openDashboard\ndashboardLabel"]
    D --> E["navigate /login?intent=dashboard"]
    G["t(cloud.landing.dashboard)"] --> H[dashboardLabel]
    H --> C
    H --> D
```

<sub>Reviews (1): Last reviewed commit: ["fix(cloud-frontend): rename landing butt..."](https://github.com/elizaos/eliza/commit/b4f93c1420baa0a2484dfea6532b061db76efb51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33301652)</sub>

<!-- /greptile_comment -->