### PR TITLE
docs: Add FAQ section for common questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,77 @@ MIT — see [LICENSE](LICENSE).
 <a href="https://github.com/elizaos/eliza/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=elizaos/eliza" alt="Eliza project contributors" />
 </a>
+
+## ❓ FAQ
+
+### What is elizaOS?
+elizaOS is an all-in-one, extensible platform for building and deploying AI-powered applications. It combines a modular architecture, powerful CLI, and rich web interface to give you full control over agents' development, deployment, and management lifecycle. Works for chatbots, autonomous agents for business automation, and intelligent game NPCs.
+
+### How does elizaOS compare to other agent frameworks?
+| Feature | elizaOS | LangChain | CrewAI | AutoGen |
+|---------|---------|-----------|--------|---------|
+| Architecture | Framework + Web UI | Library | Library | Library |
+| Multi-Agent | ✅ Built-in | ⚠️ Requires setup | ✅ Role-based | ✅ Conversation-based |
+| Web UI | ✅ Modern dashboard | ❌ | ❌ | ❌ |
+| Plugin System | ✅ Rich ecosystem | ⚠️ Basic | ⚠️ Basic | ⚠️ Basic |
+| Connectivity | ✅ Discord/Telegram/Farcaster | ❌ | ❌ | ❌ |
+
+### What are the key features?
+- 🔌 **Rich Connectivity**: Discord, Telegram, Farcaster, and more connectors
+- 🧠 **Model Agnostic**: OpenAI, Gemini, Anthropic, Llama, Grok
+- 🖥️ **Modern Web UI**: Professional dashboard for agent management
+- 🤖 **Multi-Agent Architecture**: Orchestrating groups of specialized agents
+- 📄 **Document Ingestion (RAG)**: Ingest documents for Q&A
+- 🛠️ **Highly Extensible**: Powerful plugin system
+
+### What LLM providers are supported?
+elizaOS supports all major models:
+- OpenAI (GPT-4, GPT-4o, GPT-3.5)
+- Anthropic (Claude 3.5, Claude 3)
+- Google (Gemini 1.5 Pro, Gemini 1.5 Flash)
+- Llama (local via Ollama)
+- Grok (xAI)
+- Groq
+- Custom endpoints
+
+### How to get started?
+```bash
+# Quick start with npx
+npx @elizaos/cli create
+
+# Or clone and build
+git clone https://github.com/elizaOS/eliza.git
+cd eliza
+pnpm install
+pnpm start
+```
+
+### What is the plugin system?
+elizaOS has a powerful plugin system. Browse community plugins at: https://github.com/elizaOS-plugins/registry
+
+Plugins include:
+- **Connectors**: Discord, Telegram, Farcaster, Twitter, Slack
+- **Actions**: Custom agent behaviors
+- **Providers**: Data sources and services
+- **App plugins**: Runtime plugins with app surfaces
+
+### How does multi-agent architecture work?
+elizaOS is designed from the ground up for creating and orchestrating groups of specialized agents. Each agent can have specific roles, behaviors, and connections.
+
+### What is document ingestion (RAG)?
+elizaOS allows easy document ingestion. Agents can retrieve information and answer questions from your data without additional RAG setup.
+
+### What are the framework layers?
+- **Framework** (`@elizaos/core`): Runtime, agent loop, plugin model, message/memory/state primitives
+- **Project**: Deployable product workspace with branded app shell
+- **App Plugin**: Runtime plugin contributing app surface (e.g., `@elizaos/plugin-companion`)
+
+### What license does elizaOS use?
+elizaOS uses MIT License. Free for commercial and personal use.
+
+### Where can I get help?
+- 📖 Documentation: https://docs.elizaos.ai/
+- 💬 Issues: https://github.com/elizaOS/eliza/issues
+- 🔌 Plugin Registry: https://github.com/elizaOS-plugins/registry
+- 💭 Discussions: https://github.com/elizaOS/eliza/discussions
+


### PR DESCRIPTION
Fixes common questions users have about the project.

## What's added
- FAQ section covering: project overview, comparison with similar tools, key features, LLM providers, getting started, and help resources

## Why this helps
- New users can quickly understand the project
- Reduces repetitive questions in issues
- Documents key features in a scannable format

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR appends a 77-line FAQ section to the bottom of `README.md`, after the Contributors footer, to help new users understand elizaOS and reduce repetitive issues. The FAQ covers project overview, a framework comparison table, supported LLM providers, getting-started commands, the plugin system, and help resources.

- The \"How to get started?\" code block uses `npx @elizaos/cli create` and `pnpm install`/`pnpm start`, which contradict the project's own CLI quick start (the correct tool is `elizaos` installed via `bun add -g elizaos`, run with `bun run dev`). New users following these steps will encounter errors.
- Several FAQ answers duplicate existing README sections nearly verbatim (project description, key features, framework layers, license), creating a maintenance burden where the two can drift out of sync. The supported LLM model versions (GPT-4o, Claude 3.5, Gemini 1.5 Pro) are already specific version strings that will quickly become stale.

<h3>Confidence Score: 3/5</h3>

The FAQ contains incorrect getting-started commands that will mislead new users who follow them.

The "How to get started?" block instructs users to run `npx @elizaos/cli create` and `pnpm install`/`pnpm start`, but the project uses `bun` throughout and the CLI is named `elizaos` (installed via `bun add -g elizaos`). A new user following the FAQ — its primary target audience — will immediately hit errors. Beyond that, several FAQ answers are near-verbatim copies of sections already in the README, and the block is placed after the Contributors footer rather than before it.

README.md — particularly the "How to get started?" code block and the placement of the FAQ relative to the Contributors section.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds a 77-line FAQ section after the Contributors footer with incorrect getting-started commands (uses npx/@elizaos/cli and pnpm instead of bun/elizaos), duplicated content from existing sections, hard-coded model version strings that will age quickly, and a structural placement issue. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[New User Reads README] --> B[FAQ Section]
    B --> C{Which question?}
    C --> D[What is elizaOS?]
    C --> E[How to get started?]
    C --> F[Key Features / LLM Providers]
    C --> G[Plugin System]
    C --> H[Where to get help?]

    D -->|⚠️ Duplicates| D2[✨ What is Eliza? section]
    E -->|❌ Wrong commands| E2["npx @elizaos/cli / pnpm"]
    E2 -->|Should be| E3["bun add -g elizaos / bun run dev"]
    F -->|⚠️ Duplicates| F2[🚀 Key Features section]
    G -->|Links to| G2[elizaOS-plugins/registry]
    H -->|Links to| H2[docs.elizaos.ai / GitHub]
```

<sub>Reviews (1): Last reviewed commit: ["docs: Add FAQ section for common questio..."](https://github.com/elizaos/eliza/commit/cafc50923f6c72b6acda8d9b8a85698154a405ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33338075)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->