### PR TITLE
fix(lifeops): keep proactive digests to personal inboxes

### DIFF
--- a/plugins/plugin-lifeops/src/activity-profile/proactive-inbox-digest.ts
+++ b/plugins/plugin-lifeops/src/activity-profile/proactive-inbox-digest.ts
@@ -1,0 +1,20 @@
+import type { GetLifeOpsInboxRequest } from "@elizaos/shared";
+
+const PROACTIVE_INBOX_DIGEST_REQUEST = {
+  limit: 24,
+  // Chat connector memories do not carry reliable per-owner read state yet;
+  // the inbox layer conservatively marks them unread so explicit inbox views
+  // can still triage them. Proactive digests should only summarize channels
+  // with personal inbox semantics until chat read/mention state is grounded.
+  channels: ["gmail", "x_dm", "imessage", "whatsapp", "sms"],
+  groupByThread: true,
+  missedOnly: true,
+  sortByPriority: true,
+} satisfies GetLifeOpsInboxRequest;
+
+export function proactiveInboxDigestRequest(): GetLifeOpsInboxRequest {
+  return {
+    ...PROACTIVE_INBOX_DIGEST_REQUEST,
+    channels: [...(PROACTIVE_INBOX_DIGEST_REQUEST.channels ?? [])],
+  };
+}

--- a/plugins/plugin-lifeops/src/activity-profile/proactive-worker.ts
+++ b/plugins/plugin-lifeops/src/activity-profile/proactive-worker.ts
@@ -22,6 +22,7 @@ import { ensureRuntimeAgentRecord } from "../lifeops/runtime.js";
 import { LifeOpsService, LifeOpsServiceError } from "../lifeops/service.js";
 import { parseJsonModelRecord } from "../utils/json-model-output.js";
 import { resolveEffectiveDayKey } from "./analyzer.js";
+import { proactiveInboxDigestRequest } from "./proactive-inbox-digest.js";
 import {
   type CalendarEventSlim,
   type GoalSlim,
@@ -738,7 +739,9 @@ async function loadInboxDigest(
   runtime: IAgentRuntime,
 ): Promise<InboxDigestSlim | null> {
   try {
-    const inbox = await new LifeOpsService(runtime).getInbox({ limit: 24 });
+    const inbox = await new LifeOpsService(runtime).getInbox(
+      proactiveInboxDigestRequest(),
+    );
     const unreadCount = Object.values(inbox.channelCounts).reduce(
       (sum, count) => sum + count.unread,
       0,

--- a/plugins/plugin-lifeops/test/proactive-worker.test.ts
+++ b/plugins/plugin-lifeops/test/proactive-worker.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { proactiveInboxDigestRequest } from "../src/activity-profile/proactive-inbox-digest.js";
+
+describe("proactive activity worker", () => {
+  it("uses only personal inbox channels for proactive digests", () => {
+    const request = proactiveInboxDigestRequest();
+
+    expect(request).toMatchObject({
+      limit: 24,
+      groupByThread: true,
+      missedOnly: true,
+      sortByPriority: true,
+    });
+    expect(request.channels).toEqual([
+      "gmail",
+      "x_dm",
+      "imessage",
+      "whatsapp",
+      "sms",
+    ]);
+    expect(request.channels).not.toContain("discord");
+    expect(request.channels).not.toContain("telegram");
+    expect(request.channels).not.toContain("signal");
+  });
+});


### PR DESCRIPTION
## Summary

Prevents proactive LifeOps GM/GN inbox digests from summarizing chat connector memories as unread personal inbox items.

## Why

During live local-source testing, the proactive worker sent a night summary DM that included stale Discord test-channel messages as "unread" inbox highlights. The root cause is that chat connector memories do not yet carry reliable per-owner read state; the inbox layer conservatively marks those cached chat items unread so explicit inbox views can still triage them. Proactive digests should not use that same broad channel set for unsolicited owner DMs.

## Change

- Adds a small `proactiveInboxDigestRequest()` policy helper for the proactive worker.
- Keeps proactive inbox digests scoped to channels with personal inbox semantics: Gmail, X DMs, iMessage, WhatsApp, and SMS.
- Preserves explicit inbox behavior for chat connectors; this only changes the proactive digest query.

## Validation

- `bunx @biomejs/biome check --write src/activity-profile/proactive-worker.ts src/activity-profile/proactive-inbox-digest.ts test/proactive-worker.test.ts --no-errors-on-unmatched`
- `bun test --timeout 30000 test/proactive-worker.test.ts`
- `bun run build`
- Live mitigation verified locally: after setting `ELIZA_DISABLE_PROACTIVE_AGENT=1` and restarting, logs show `[proactive] Proactive agent task skipped — ELIZA_DISABLE_PROACTIVE_AGENT=1` and no new GN digest fired after restart.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Scopes proactive GM/GN inbox digests to personal messaging channels only (Gmail, X DMs, iMessage, WhatsApp, SMS) to prevent stale chat-connector memories (Discord, Telegram, Signal) from surfacing as "unread" highlights in unsolicited owner DMs.

- Extracts the channel-filter policy into a new `proactiveInboxDigestRequest()` helper in `proactive-inbox-digest.ts`, replacing the bare `{ limit: 24 }` call in `loadInboxDigest`.
- Adds `missedOnly: true`, `groupByThread: true`, and `sortByPriority: true` alongside the explicit channel allow-list; the `resolveInboxRequest` path in `service-mixin-inbox.ts` correctly falls back to all channels when `channels` is omitted, so explicit inbox views are unaffected.
- Ships a unit test that pins the exact channel list and verifies that chat connectors are excluded.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is narrowly scoped to the proactive digest path and does not touch explicit inbox views or shared data structures.

The fix is correct and well-contained. The only open question is whether `signal` belongs in the personal-channel allow-list alongside iMessage and WhatsApp — its omission could silently suppress Signal DMs from proactive digests if the connector is in use.

The new `proactive-inbox-digest.ts` file deserves a quick check on the `signal` channel exclusion decision.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-lifeops/src/activity-profile/proactive-inbox-digest.ts | New policy helper that restricts proactive inbox digests to personal channels (gmail, x_dm, imessage, whatsapp, sms). Dead `?? []` fallback on a non-optional field and the intentional omission of `signal` are worth a second look. |
| plugins/plugin-lifeops/src/activity-profile/proactive-worker.ts | Single call-site change: `loadInboxDigest` now uses `proactiveInboxDigestRequest()` instead of the bare `{ limit: 24 }` object, correctly delegating channel scoping to the new policy helper. |
| plugins/plugin-lifeops/test/proactive-worker.test.ts | New unit test that validates the channel list and base parameters. The three `not.toContain` assertions are redundant given the prior `toEqual` check. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant PW as proactive-worker
    participant PID as proactiveInboxDigestRequest()
    participant SVC as LifeOpsService.getInbox()
    participant RIR as resolveInboxRequest()

    PW->>PID: call proactiveInboxDigestRequest()
    PID-->>PW: "{ limit:24, channels:[gmail,x_dm,imessage,whatsapp,sms], missedOnly:true }"
    PW->>SVC: getInbox(request)
    SVC->>RIR: resolveInboxRequest(request)
    RIR-->>SVC: "allowed = Set{gmail, x_dm, imessage, whatsapp, sms}"
    Note over RIR: chat channels (discord, telegram, signal) NOT in allowed set
    SVC-->>PW: LifeOpsInbox (personal channels only)
    PW->>PW: build InboxDigestSlim for GM/GN DM
```

<sub>Reviews (1): Last reviewed commit: ["fix(lifeops): keep proactive digests to ..."](https://github.com/elizaos/eliza/commit/841917b124924fca7616c51924bddbadd185a4d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33364156)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->