### PR TITLE
feat(cloud): Hetzner control plane IaC + data plane naming + legacy milady-core deprecation

### DIFF
--- a/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
@@ -1,0 +1,124 @@
+# Hetzner Control Plane vs Data Plane
+
+eliza Cloud runs on a two-tier Hetzner Cloud setup. This doc nails down the
+split so we stop treating manually-created VMs as "infrastructure-by-prayer".
+
+## Layers
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Tier 1 — Control plane (static, 1-2 VMs, Terraform)        │
+│                                                              │
+│   eliza-cp-production-1   (Hetzner cpx21, fsn1)             │
+│     ├── eliza-provisioning-worker  (systemd, queue consumer)│
+│     ├── eliza-agent-router         (systemd, HTTP routing)  │
+│     ├── headscale                  (VPN mesh)               │
+│     ├── cloudflared tunnel         (public ingress)         │
+│     ├── nginx                      (reverse proxy)          │
+│     └── (optional: grafana/prometheus)                      │
+│                                                              │
+│   Lifecycle: long-lived. Replaced on demand, not autoscaled.│
+│   Cost: ~€5/mo per VM (cpx21).                              │
+└──────────────────────────────────────────────────────────────┘
+                              │ enqueue / SSH
+                              ▼
+┌──────────────────────────────────────────────────────────────┐
+│  Tier 2 — Data plane (elastic, N cores, runtime autoscale)  │
+│                                                              │
+│   eliza-core-<hex>   (Hetzner cpx32, fsn1)                  │
+│     ├── Docker daemon                                       │
+│     └── eliza-sandbox containers × N                        │
+│                                                              │
+│   Lifecycle: created/drained by node-autoscaler.ts based on │
+│   real demand. Server limit: ~25 (Hetzner default).         │
+│   Cost: elastic (~€11/mo per running cpx32).                │
+└──────────────────────────────────────────────────────────────┘
+```
+
+## Why two tiers
+
+| Concern              | Control plane          | Data plane                |
+|----------------------|------------------------|---------------------------|
+| **Provisioning**     | Terraform (one-shot)   | Runtime API (node-autoscaler.ts) |
+| **Lifecycle**        | Persistent             | Ephemeral                 |
+| **State**            | Has local state (headscale DB, cloudflared creds) | Stateless |
+| **Failure mode**     | Page someone           | Replace automatically     |
+| **Cost predictability** | Fixed monthly       | Elastic                   |
+| **What lives here**  | Orchestrator, routing, monitoring | Just Docker + agents |
+
+The split prevents the "control plane melts with the data plane during a
+traffic spike" failure mode. Pulling sandboxes off the data plane is the
+autoscaler's job; the orchestrator that issues drain commands must stay up
+to coordinate it.
+
+## Code ↔ infrastructure mapping
+
+| Component | Code | Infra |
+|---|---|---|
+| Control plane VM | [`packages/scripts/cloud/admin/daemons/provisioning-worker.ts`](../../../../scripts/cloud/admin/daemons/provisioning-worker.ts) | [Terraform: `control-plane/`](./control-plane/) |
+| Agent router | [`packages/scripts/cloud/admin/daemons/agent-router.ts`](../../../../scripts/cloud/admin/daemons/agent-router.ts) | systemd unit on control-plane VM |
+| Data plane autoscaler | [`packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts`](../../../../cloud-shared/src/lib/services/containers/node-autoscaler.ts) | Hetzner Cloud API at runtime |
+| Sandbox provisioning | [`packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts`](../../../../cloud-shared/src/lib/services/docker-sandbox-provider.ts) | SSH from control plane to data plane |
+
+## Naming convention
+
+| Layer | Prefix | Example | Where it's set |
+|---|---|---|---|
+| Control plane VM | `eliza-cp-<env>-<n>` | `eliza-cp-production-1` | Terraform `var.environment` |
+| Data plane node (NEW) | `eliza-core-<hex>` | `eliza-core-38ea87b1` | [`generateNodeId()`](../../../../cloud-shared/src/lib/services/containers/node-autoscaler.ts) |
+| Data plane node (LEGACY) | `milady-core-<n>` | `milady-core-1` | DEPRECATED — see [Legacy migration](#legacy-milady-core-migration) |
+
+## Legacy `milady-core-*` migration
+
+Pre-2026-05 the data plane was 6 manually-created `milady-core-*` VMs (Hetzner
+cpx32 in fsn1) inserted by-hand into `docker_nodes` with `capacity = 100`.
+By 2026-05-22:
+
+- All 6 cores were `status: offline` (SSH health-check failing for weeks)
+- Several user sandboxes still ran on the underlying Docker daemons
+- The cloud autoscaler couldn't account for them
+
+Migration 0132 (`0132_legacy_milady_cores_disable.sql`) flips them to
+`enabled = false` + fixes `capacity = 8`. This:
+
+1. Removes them from autoscaler capacity decisions
+2. Stops the health-check noise
+3. Lets the autoscaler spin up replacement `eliza-core-<hex>` nodes on demand
+
+Existing sandboxes keep running until next restart. On user-triggered
+restart / recreate, the daemon provisions them on a fresh autoscaled core.
+
+Once `SELECT SUM(allocated_count) FROM docker_nodes WHERE node_id LIKE 'milady-core-%'`
+is `0`, ops can:
+
+```bash
+# 1. Delete the Hetzner Cloud servers (one-time, via Hetzner console or):
+hcloud server delete milady-core-1
+hcloud server delete milady-core-2
+# ... etc.
+
+# 2. Drop the DB rows:
+DELETE FROM docker_nodes WHERE node_id LIKE 'milady-core-%';
+```
+
+## Followups (not in this initial PR)
+
+- [ ] Terraform module for headscale state (preauth keys, ACLs)
+- [ ] Terraform module for the cloudflared tunnel (currently created by-hand)
+- [ ] Terraform-apply GitHub workflow (`infra/**` path filter)
+- [ ] Move the 4 remaining cron paths off the orphan
+      `container-control-plane` service onto the daemon-queue pattern
+      (`pool-replenish`, `pool-health-check`, `pool-image-rollout`,
+      `deployment-monitor`). Once done, retire the
+      `packages/cloud-services/container-control-plane/` package entirely.
+- [ ] Raise Hetzner Cloud server limit (open ticket) to enable autoscale
+      past the default cap of ~10 servers per account.
+
+## Operator runbook
+
+See [`control-plane/README.md`](./control-plane/README.md)
+for the step-by-step:
+
+- Bootstrap a brand-new control-plane VM
+- Import the existing production VM into Terraform
+- Verify state, plan, apply

--- a/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
@@ -9,7 +9,7 @@ split so we stop treating manually-created VMs as "infrastructure-by-prayer".
 ┌──────────────────────────────────────────────────────────────┐
 │  Tier 1 — Control plane (static, 1-2 VMs, Terraform)        │
 │                                                              │
-│   eliza-cp-production-1   (Hetzner cpx21, fsn1)             │
+│   eliza-1   (Hetzner cpx21, fsn1)             │
 │     ├── eliza-provisioning-worker  (systemd, queue consumer)│
 │     ├── eliza-agent-router         (systemd, HTTP routing)  │
 │     ├── headscale                  (VPN mesh)               │
@@ -64,7 +64,7 @@ to coordinate it.
 
 | Layer | Prefix | Example | Where it's set |
 |---|---|---|---|
-| Control plane VM | `eliza-cp-<env>-<n>` | `eliza-cp-production-1` | Terraform `var.environment` |
+| Control plane VM | `eliza-<n>` | `eliza-1` | Terraform `hcloud_server.control_plane` |
 | Data plane node (NEW) | `eliza-core-<hex>` | `eliza-core-38ea87b1` | [`generateNodeId()`](../../../../cloud-shared/src/lib/services/containers/node-autoscaler.ts) |
 | Data plane node (LEGACY) | `milady-core-<n>` | `milady-core-1` | DEPRECATED — see [Legacy migration](#legacy-milady-core-migration) |
 

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/.gitignore
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/.gitignore
@@ -1,0 +1,11 @@
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.backup
+crash.log
+crash.*.log
+
+# Live tfvars contain SSH public keys + zone IDs — keep them out of git.
+# Only `.tfvars.example` lives in the repo.
+*.tfvars
+!*.tfvars.example

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
@@ -53,24 +53,15 @@ scp packages/cloud-shared/.env.local root@<vm-ip>:/opt/eliza/cloud/.env.local
 
 ## Adopt the existing production VM into Terraform
 
-The current prod manager VM (`89.167.63.246`, hostname `milady`) was
-created by-hand via `packages/scripts/cloud/admin/bootstrap-provisioning-worker-host.mjs`
-on May 7th. To bring it under Terraform without recreating it:
-
-```bash
-# 1. Look up the Hetzner Cloud server ID:
-hcloud server list  # find the one with IP 89.167.63.246
-
-# 2. Import the existing resource into state:
-terraform init -backend-config=backend-production.hcl
-terraform import \
-  -var-file=tfvars/production.tfvars \
-  'hcloud_server.control_plane["1"]' \
-  <SERVER_ID>
-
-# 3. Run `terraform plan` and adjust variables until the diff is empty.
-#    Common drift: labels, ssh_keys (manually added during initial setup).
-```
+The current prod manager VM (`89.167.63.246`, historical hostname
+`milady`) was created by hand in May 2026. To bring it under Terraform
+without recreating it, look up the Hetzner Cloud server ID
+(`hcloud server list`), then `terraform import 'hcloud_server.control_plane["1"]' <id>`
+plus a `terraform import` for each existing `hcloud_ssh_key`. The first
+plan after import shows the in-place rename `milady → eliza-1`, the new
+labels, and the Cloudflare DNS record creation; `user_data` and `image`
+diffs are suppressed by `lifecycle { ignore_changes }`. One-shot — never
+re-run.
 
 ## What this module does NOT manage (yet)
 

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
@@ -1,0 +1,97 @@
+# hetzner/control-plane — Terraform for the eliza Cloud control-plane VMs
+
+This Terraform module manages the **persistent** Hetzner Cloud VM(s) that host
+the elizaOS Cloud control-plane:
+
+- `eliza-provisioning-worker` — pulls jobs from the `jobs` table and SSHs
+  into sandbox cores
+- `eliza-agent-router` — subdomain HTTP routing
+- `cloudflared` — secure tunnel for `sandboxes.waifu.fun`
+- `headscale` — VPN mesh for cross-core agent traffic
+
+The **data plane** (the sandbox cores themselves) is **not** managed here —
+those are provisioned and drained at runtime by
+[`node-autoscaler.ts`](../../../../../cloud-shared/src/lib/services/containers/node-autoscaler.ts)
+which talks to the Hetzner Cloud API directly. See
+[`../ARCHITECTURE.md`](../ARCHITECTURE.md) for the full split.
+
+## Prerequisites
+
+1. **Hetzner Cloud project** with API token (`HCLOUD_TOKEN`).
+2. **Cloudflare account** with API token + DNS edit on `elizacloud.ai`
+   (`CLOUDFLARE_API_TOKEN`).
+3. **Cloudflare R2 bucket** `eliza-terraform-state` for remote state. Generate
+   an R2 API token, edit `backend-staging.hcl` / `backend-production.hcl`
+   with your CF account ID, then export the R2 token as
+   `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` before `terraform init`.
+4. **Terraform >= 1.5.0** locally.
+
+## Bootstrap a brand-new control-plane VM (staging)
+
+```bash
+cd packages/cloud-infra/cloud/terraform/hetzner/control-plane
+
+# 1. Pull providers + connect remote state.
+terraform init -backend-config=backend-staging.hcl
+
+# 2. Copy + fill tfvars.
+cp tfvars/staging.tfvars.example tfvars/staging.tfvars
+$EDITOR tfvars/staging.tfvars
+
+# 3. Plan + apply.
+export HCLOUD_TOKEN=...
+export CLOUDFLARE_API_TOKEN=...
+terraform plan -var-file=tfvars/staging.tfvars
+terraform apply -var-file=tfvars/staging.tfvars
+
+# 4. Output gives you the VM IP. Copy the cloud env file into place:
+scp packages/cloud-shared/.env.local root@<vm-ip>:/opt/eliza/cloud/.env.local
+
+# 5. Trigger first deploy from GitHub Actions
+#    (workflow: deploy-eliza-provisioning-worker.yml, manual dispatch).
+```
+
+## Adopt the existing production VM into Terraform
+
+The current prod manager VM (`89.167.63.246`, hostname `milady`) was
+created by-hand via `packages/scripts/cloud/admin/bootstrap-provisioning-worker-host.mjs`
+on May 7th. To bring it under Terraform without recreating it:
+
+```bash
+# 1. Look up the Hetzner Cloud server ID:
+hcloud server list  # find the one with IP 89.167.63.246
+
+# 2. Import the existing resource into state:
+terraform init -backend-config=backend-production.hcl
+terraform import \
+  -var-file=tfvars/production.tfvars \
+  'hcloud_server.control_plane["1"]' \
+  <SERVER_ID>
+
+# 3. Run `terraform plan` and adjust variables until the diff is empty.
+#    Common drift: labels, ssh_keys (manually added during initial setup).
+```
+
+## What this module does NOT manage (yet)
+
+- Headscale state (preauth keys, ACLs) — manual via `headscale` CLI.
+- Cloudflared tunnels — config lives at `/root/.cloudflared/` on the VM and
+  is created via `cloudflared tunnel create` one-shot.
+- The systemd units — installed by `deploy-eliza-provisioning-worker.yml`
+  on every push.
+- The actual eliza Cloud sandbox cores (data plane) — runtime autoscale.
+
+These are tracked as TODOs in
+[`../ARCHITECTURE.md`](../ARCHITECTURE.md#followups).
+
+## Cost
+
+| Component                    | Resource    | Monthly (€) |
+|------------------------------|-------------|-------------|
+| 1× cpx21 (3 vCPU / 4 GB)     | control VM  | ~5          |
+| 1× IPv4 + IPv6               | floating IP | included    |
+| Cloudflare R2 state          | < 100 KB    | 0           |
+| **Total per environment**    |             | **~5**      |
+
+A 2nd control-plane VM (HA, currently unused) doubles the line. The
+**data-plane autoscale** cost is separate and elastic.

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/backend-production.hcl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/backend-production.hcl
@@ -1,0 +1,9 @@
+bucket                      = "eliza-terraform-state"
+key                         = "hetzner/control-plane/production.tfstate"
+region                      = "auto"
+endpoints                   = { s3 = "https://23cf6feaeaa541f6a0675053c33da768.r2.cloudflarestorage.com" }
+skip_credentials_validation = true
+skip_metadata_api_check     = true
+skip_region_validation      = true
+skip_requesting_account_id  = true
+use_path_style              = true

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/backend-staging.hcl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/backend-staging.hcl
@@ -1,0 +1,20 @@
+# Cloudflare R2 backend (S3-compatible) for terraform state.
+#
+# Set up once per environment:
+#   1. Create R2 bucket `eliza-terraform-state` in the elizaOS CF account.
+#   2. Generate R2 API token with read/write on that bucket.
+#   3. Export AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY pointing at the
+#      R2 token before `terraform init`.
+#
+# Usage:
+#   terraform init -backend-config=backend-staging.hcl
+
+bucket                      = "eliza-terraform-state"
+key                         = "hetzner/control-plane/staging.tfstate"
+region                      = "auto"
+endpoints                   = { s3 = "https://23cf6feaeaa541f6a0675053c33da768.r2.cloudflarestorage.com" }
+skip_credentials_validation = true
+skip_metadata_api_check     = true
+skip_region_validation      = true
+skip_requesting_account_id  = true
+use_path_style              = true

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
@@ -23,12 +23,29 @@ users:
     shell: /bin/bash
     sudo: ALL=(ALL) NOPASSWD:ALL
     lock_passwd: true
+    # Mirror operator SSH keys onto the deploy user. Hetzner only injects
+    # `hcloud_ssh_key` entries into root by default, but the
+    # `.github/workflows/deploy-eliza-provisioning-worker.yml` workflow SSHes
+    # in as `deploy`. Without this list the first auto-deploy would fail.
+    ssh_authorized_keys:
+%{ for key in operator_ssh_keys ~}
+      - ${key}
+%{ endfor ~}
 
 package_update: true
 package_upgrade: false
 
+apt:
+  sources:
+    docker:
+      source: "deb [arch=amd64 signed-by=$KEY_FILE] https://download.docker.com/linux/ubuntu $RELEASE stable"
+      keyid: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+
 packages:
   - curl
+  - docker-ce
+  - docker-ce-cli
+  - containerd.io
   - git
   - jq
   - nginx
@@ -44,13 +61,21 @@ write_files:
       export ELIZA_DEPLOY_BRANCH="${deploy_branch}"
 
 runcmd:
-  # Docker (official convenience installer — pin sha if you want it
-  # auditable; we keep it simple for the bootstrap).
-  - curl -fsSL https://get.docker.com | sh
+  # Docker is installed via the `apt` block above using the official
+  # Docker apt repo (GPG-verified keyring), not `curl get.docker.com | sh`.
   - systemctl enable --now docker
 
-  # Bun runtime for the deploy user (the daemons run under bun/tsx).
-  - su - deploy -c 'curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.13"'
+  # Bun runtime for the deploy user. We download a pinned release tarball
+  # AND its SHASUMS256 manifest from the same GitHub release, then verify
+  # the binary against the published hash before extracting. This avoids
+  # the `curl bun.sh/install | bash` supply-chain pattern flagged in the
+  # PR review — we still trust GitHub's HTTPS, but the manifest commits
+  # the publisher to a specific hash that an attacker can't forge mid-flight.
+  - install -d -o deploy -g deploy /home/deploy/.bun /home/deploy/.bun/bin
+  - su - deploy -c 'curl -fsSL -o /tmp/bun.zip https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-linux-x64.zip'
+  - su - deploy -c 'curl -fsSL -o /tmp/bun-SHASUMS256.txt https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/SHASUMS256.txt'
+  - su - deploy -c 'cd /tmp && grep "bun-linux-x64.zip" bun-SHASUMS256.txt | sha256sum -c -'
+  - su - deploy -c 'cd /tmp && unzip -q bun.zip && install -m 0755 bun-linux-x64/bun /home/deploy/.bun/bin/bun && rm -rf /tmp/bun.zip /tmp/bun-linux-x64 /tmp/bun-SHASUMS256.txt'
 
   # Repo checkout — the GitHub deploy workflow then takes over for code updates.
   - mkdir -p /opt/eliza && chown deploy:deploy /opt/eliza

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
@@ -1,0 +1,60 @@
+#cloud-config
+# Cloud-init bootstrap for eliza control-plane VMs.
+#
+# At first boot:
+#   1. Install system deps (docker, nginx, node, jq, postgresql-client, ssh)
+#   2. Add a `deploy` user that the GitHub Actions workflow
+#      `.github/workflows/deploy-eliza-provisioning-worker.yml` SSHes into
+#   3. Clone the monorepo on `${deploy_branch}` to /opt/eliza
+#   4. Install systemd units for `eliza-provisioning-worker` and
+#      `eliza-agent-router`
+#
+# Secrets (DATABASE_URL, KV_REST_API_*, STEWARD_*, HCLOUD_TOKEN, etc.) are NOT
+# baked in here. The operator copies `cloud/.env.local` to `/opt/eliza/cloud/.env.local`
+# in a follow-up step (one-shot, out-of-band) using `scp` or the existing
+# `packages/scripts/cloud/admin/bootstrap-provisioning-worker-host.mjs` script.
+
+hostname: ${hostname}
+manage_etc_hosts: true
+
+users:
+  - name: deploy
+    groups: sudo, docker
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    lock_passwd: true
+
+package_update: true
+package_upgrade: false
+
+packages:
+  - curl
+  - git
+  - jq
+  - nginx
+  - postgresql-client
+  - rsync
+  - unzip
+
+write_files:
+  - path: /etc/profile.d/eliza-paths.sh
+    permissions: "0644"
+    content: |
+      export PATH="/home/deploy/.bun/bin:$PATH"
+      export ELIZA_DEPLOY_BRANCH="${deploy_branch}"
+
+runcmd:
+  # Docker (official convenience installer — pin sha if you want it
+  # auditable; we keep it simple for the bootstrap).
+  - curl -fsSL https://get.docker.com | sh
+  - systemctl enable --now docker
+
+  # Bun runtime for the deploy user (the daemons run under bun/tsx).
+  - su - deploy -c 'curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.13"'
+
+  # Repo checkout — the GitHub deploy workflow then takes over for code updates.
+  - mkdir -p /opt/eliza && chown deploy:deploy /opt/eliza
+  - su - deploy -c 'git clone --depth 200 --branch ${deploy_branch} https://github.com/elizaOS/eliza.git /opt/eliza'
+
+  # Final marker for the bootstrap-warn check that runs after this.
+  - echo "eliza-control-plane bootstrap finished $(date -u +%Y-%m-%dT%H:%M:%SZ)" > /var/log/eliza-bootstrap.log

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
@@ -1,0 +1,57 @@
+locals {
+  # Tags applied to every Hetzner Cloud resource managed here. Mirrors the
+  # data-plane convention (`managed-by: eliza-cloud`) used by the runtime
+  # autoscaler so a single search in the Hetzner Console reveals everything.
+  common_labels = {
+    "managed-by"  = "eliza-cloud"
+    "tier"        = "control-plane"
+    "environment" = var.environment
+  }
+}
+
+resource "hcloud_ssh_key" "operators" {
+  for_each = { for idx, key in var.ssh_public_keys : idx => key }
+
+  name       = "eliza-cp-${var.environment}-op-${each.key}"
+  public_key = each.value
+  labels     = local.common_labels
+}
+
+resource "hcloud_server" "control_plane" {
+  for_each = toset([for i in range(var.control_plane_count) : tostring(i + 1)])
+
+  name        = "eliza-cp-${var.environment}-${each.value}"
+  location    = var.hcloud_location
+  server_type = var.hcloud_server_type
+  image       = var.hcloud_image
+  ssh_keys    = [for k in hcloud_ssh_key.operators : k.id]
+  labels = merge(local.common_labels, {
+    "control-plane-index" = each.value
+  })
+
+  user_data = templatefile("${path.module}/cloud-init/bootstrap.yaml.tftpl", {
+    hostname      = "eliza-cp-${var.environment}-${each.value}"
+    deploy_branch = var.deploy_branch
+  })
+
+  # Keep server alive across refactors: changing labels or user_data
+  # shouldn't recreate the box, only update in place where possible.
+  lifecycle {
+    ignore_changes = [
+      user_data, # bootstrap runs once at first boot
+      image,     # updating image rebuilds — explicit `terraform taint` to opt in
+    ]
+  }
+}
+
+resource "cloudflare_dns_record" "control_plane" {
+  for_each = hcloud_server.control_plane
+
+  zone_id = var.cloudflare_zone_id
+  name    = "${var.control_plane_hostname_prefix}-${var.environment}-${each.key}.elizacloud.ai"
+  type    = "A"
+  content = each.value.ipv4_address
+  ttl     = 60
+  proxied = false
+  comment = "eliza control-plane VM ${each.value.name} (managed by terraform/hetzner/control-plane)"
+}

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
@@ -15,7 +15,7 @@ resource "hcloud_ssh_key" "operators" {
   # inserted/reordered in `var.ssh_public_keys`.
   for_each = { for key in var.ssh_public_keys : substr(sha256(key), 0, 12) => key }
 
-  name       = "eliza-cp-${var.environment}-op-${each.key}"
+  name       = "eliza-op-${var.environment}-${each.key}"
   public_key = each.value
   labels     = local.common_labels
 }
@@ -23,7 +23,12 @@ resource "hcloud_ssh_key" "operators" {
 resource "hcloud_server" "control_plane" {
   for_each = toset([for i in range(var.control_plane_count) : tostring(i + 1)])
 
-  name        = "eliza-cp-${var.environment}-${each.value}"
+  # Naming: `eliza-${index}` — short, matches the data-plane convention
+  # `eliza-core-<hex>` and supports the in-place rename from the legacy
+  # `milady` VM. The environment lives in labels, not the hostname, so the
+  # prod/staging distinction shows up in the Hetzner Console filter
+  # without bloating the hostname every operator types into SSH.
+  name        = "eliza-${each.value}"
   location    = var.hcloud_location
   server_type = var.hcloud_server_type
   image       = var.hcloud_image
@@ -33,7 +38,7 @@ resource "hcloud_server" "control_plane" {
   })
 
   user_data = templatefile("${path.module}/cloud-init/bootstrap.yaml.tftpl", {
-    hostname          = "eliza-cp-${var.environment}-${each.value}"
+    hostname          = "eliza-${each.value}"
     deploy_branch     = var.deploy_branch
     operator_ssh_keys = var.ssh_public_keys
   })

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
@@ -10,7 +10,10 @@ locals {
 }
 
 resource "hcloud_ssh_key" "operators" {
-  for_each = { for idx, key in var.ssh_public_keys : idx => key }
+  # Key the map by a short SHA-256 prefix of the public key rather than the
+  # list index — keeps Terraform plans stable when operators are
+  # inserted/reordered in `var.ssh_public_keys`.
+  for_each = { for key in var.ssh_public_keys : substr(sha256(key), 0, 12) => key }
 
   name       = "eliza-cp-${var.environment}-op-${each.key}"
   public_key = each.value
@@ -30,8 +33,9 @@ resource "hcloud_server" "control_plane" {
   })
 
   user_data = templatefile("${path.module}/cloud-init/bootstrap.yaml.tftpl", {
-    hostname      = "eliza-cp-${var.environment}-${each.value}"
-    deploy_branch = var.deploy_branch
+    hostname          = "eliza-cp-${var.environment}-${each.value}"
+    deploy_branch     = var.deploy_branch
+    operator_ssh_keys = var.ssh_public_keys
   })
 
   # Keep server alive across refactors: changing labels or user_data

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/outputs.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/outputs.tf
@@ -1,0 +1,18 @@
+output "control_plane_vms" {
+  description = "Map of control-plane VMs keyed by index, with IPv4 + hostname."
+  value = {
+    for k, v in hcloud_server.control_plane : k => {
+      name     = v.name
+      ipv4     = v.ipv4_address
+      ipv6     = v.ipv6_address
+      hostname = "${var.control_plane_hostname_prefix}-${var.environment}-${k}.elizacloud.ai"
+    }
+  }
+}
+
+output "ssh_login_commands" {
+  description = "Convenience: SSH commands the operator can copy-paste."
+  value = {
+    for k, v in hcloud_server.control_plane : k => "ssh root@${v.ipv4_address}"
+  }
+}

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/providers.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/providers.tf
@@ -1,0 +1,9 @@
+provider "hcloud" {
+  # Token comes from HCLOUD_TOKEN env var by default — never commit it.
+  # token = var.hcloud_token
+}
+
+provider "cloudflare" {
+  # Token comes from CLOUDFLARE_API_TOKEN env var by default.
+  # api_token = var.cloudflare_api_token
+}

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/tfvars/production.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/tfvars/production.tfvars.example
@@ -1,0 +1,9 @@
+environment           = "production"
+hcloud_location       = "fsn1"
+hcloud_server_type    = "cpx21"
+control_plane_count   = 1
+cloudflare_zone_id    = "<zone-id-for-elizacloud.ai>"
+
+ssh_public_keys = [
+  # "ssh-ed25519 AAAA... operator@laptop"
+]

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/tfvars/staging.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/tfvars/staging.tfvars.example
@@ -1,0 +1,12 @@
+# Copy to staging.tfvars (gitignored) and fill in real values.
+
+environment           = "staging"
+hcloud_location       = "fsn1"
+hcloud_server_type    = "cpx21"
+control_plane_count   = 1
+cloudflare_zone_id    = "<zone-id-for-elizacloud.ai>"
+
+# Operator SSH public keys (NEVER paste private keys here).
+ssh_public_keys = [
+  # "ssh-ed25519 AAAA... operator@laptop"
+]

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf
@@ -1,0 +1,59 @@
+variable "environment" {
+  description = "Deployment environment (staging, production)"
+  type        = string
+  validation {
+    condition     = contains(["staging", "production"], var.environment)
+    error_message = "Environment must be 'staging' or 'production'"
+  }
+}
+
+variable "hcloud_location" {
+  description = "Hetzner Cloud datacenter location (must match data-plane). Existing fleet runs in fsn1."
+  type        = string
+  default     = "fsn1"
+}
+
+variable "hcloud_server_type" {
+  description = "Hetzner server type for the control-plane VM. cpx21 = 3 vCPU / 4 GB / 80 GB SSD ≈ €5/mo, enough for daemon + agent-router + headscale + monitoring."
+  type        = string
+  default     = "cpx21"
+}
+
+variable "hcloud_image" {
+  description = "Base image for the control-plane VM."
+  type        = string
+  default     = "ubuntu-24.04"
+}
+
+variable "control_plane_count" {
+  description = "Number of control-plane VMs. Start with 1; bump to 2 once headscale/HA is wired."
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.control_plane_count >= 1 && var.control_plane_count <= 3
+    error_message = "control_plane_count must be between 1 and 3"
+  }
+}
+
+variable "ssh_public_keys" {
+  description = "Operator SSH public keys allowed to log into the VM as root. Provide via tfvars; never commit."
+  type        = list(string)
+  default     = []
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone for the elizacloud.ai domain — used to point control-plane DNS at the VM."
+  type        = string
+}
+
+variable "control_plane_hostname_prefix" {
+  description = "DNS subdomain prefix. Final record: <prefix>-<environment>-<n>.elizacloud.ai"
+  type        = string
+  default     = "cp"
+}
+
+variable "deploy_branch" {
+  description = "Git branch the host's auto-deploy workflow follows."
+  type        = string
+  default     = "develop"
+}

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf
@@ -47,9 +47,9 @@ variable "cloudflare_zone_id" {
 }
 
 variable "control_plane_hostname_prefix" {
-  description = "DNS subdomain prefix. Final record: <prefix>-<environment>-<n>.elizacloud.ai"
+  description = "DNS subdomain prefix. Final record: <prefix>-<environment>-<n>.elizacloud.ai (e.g. eliza-production-1.elizacloud.ai)"
   type        = string
-  default     = "cp"
+  default     = "eliza"
 }
 
 variable "deploy_branch" {

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/versions.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.63"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+
+  # State backend uses Cloudflare R2 (S3-compatible). Configure via:
+  #   terraform init -backend-config=backend-staging.hcl
+  #   terraform init -backend-config=backend-production.hcl
+  backend "s3" {}
+}

--- a/packages/cloud-shared/src/db/migrations/0132_legacy_milady_cores_disable.sql
+++ b/packages/cloud-shared/src/db/migrations/0132_legacy_milady_cores_disable.sql
@@ -1,0 +1,33 @@
+-- Disable the legacy `milady-core-*` static nodes so the autoscaler treats
+-- them as inert during the data-plane migration to fully autoscaled
+-- `eliza-core-*` cores.
+--
+-- Why:
+--   - The 6 milady-core-* rows were inserted manually in 2026-03 (0xSolace
+--     era) with `capacity = 100`, which is wildly above the realistic
+--     cpx32 limit (~8 sandboxes per node before OOM). They have been
+--     `status = 'offline'` in prod for weeks; the SSH health-check no
+--     longer reaches them.
+--   - The autoscale evaluator already filters on
+--     `enabled = true AND status = 'healthy'`, so flipping `enabled = false`
+--     removes them from capacity decisions without touching workloads that
+--     happen to still run on the underlying VMs.
+--   - Capacity is corrected to 8 for consistency with autoscaled
+--     `eliza-core-*` rows. This is informational once enabled=false.
+--
+-- Sandboxes currently allocated on these nodes:
+--   - Stay reachable while their Docker containers are alive.
+--   - On the next user-triggered restart/recreate, the daemon will
+--     provision them onto an autoscaled `eliza-core-<hex>` node.
+--
+-- Cleanup (separate, ops action — NOT in this migration):
+--   1. Once `allocated_count = 0` for all milady-core-*: delete the Hetzner
+--      Cloud servers via Cloud Console or `hcloud server delete`.
+--   2. DELETE FROM docker_nodes WHERE node_id LIKE 'milady-core-%'.
+
+UPDATE docker_nodes
+SET
+  capacity = 8,
+  enabled = false,
+  updated_at = now()
+WHERE node_id LIKE 'milady-core-%';

--- a/packages/cloud-shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud-shared/src/db/migrations/meta/_journal.json
@@ -918,6 +918,13 @@
       "when": 1778659500000,
       "tag": "0131_partial_unique_tx_hash",
       "breakpoints": true
+    },
+    {
+      "idx": 131,
+      "version": "7",
+      "when": 1779408000000,
+      "tag": "0132_legacy_milady_cores_disable",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud-shared/src/lib/config/containers-env.ts
+++ b/packages/cloud-shared/src/lib/config/containers-env.ts
@@ -184,13 +184,15 @@ export const containersEnv = {
 
   /**
    * Default Hetzner Cloud location for provisioning nodes and volumes
-   * (e.g. "ash", "hil", "fsn1"). Hetzner volumes are location-bound, so
+   * (e.g. "fsn1", "nbg1", "hel1"). Hetzner volumes are location-bound, so
    * the volume and the server it attaches to must share a location.
-   * Defaults to "ash" (Ashburn, Virginia, US).
+   * Defaults to "fsn1" (Falkenstein, DE) to match the existing prod fleet
+   * — and because Hetzner deprecated cpx32 on "ash" (Ashburn) which made
+   * the previous default fail with "unsupported location for server type".
    */
   defaultHcloudLocation(): string {
     const env = getCloudAwareEnv();
-    return pick(env.CONTAINERS_HCLOUD_LOCATION, env.HCLOUD_LOCATION) ?? "ash";
+    return pick(env.CONTAINERS_HCLOUD_LOCATION, env.HCLOUD_LOCATION) ?? "fsn1";
   },
 
   /**

--- a/packages/cloud-shared/src/lib/services/containers/node-autoscaler.test.ts
+++ b/packages/cloud-shared/src/lib/services/containers/node-autoscaler.test.ts
@@ -186,6 +186,64 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
     expect(mocks.createNode).not.toHaveBeenCalled();
   });
 
+  test("generates an eliza-core-<8hex> nodeId when none is supplied", async () => {
+    const autoscaler = new NodeAutoscaler(policy);
+    mocks.createServer.mockResolvedValue({
+      server: {
+        id: 7777,
+        name: "generated",
+        public_net: { ipv4: { ip: "203.0.113.20" }, ipv6: null },
+      },
+      rootPassword: null,
+    });
+
+    const result = await autoscaler.provisionNode(
+      {},
+      {
+        controlPlanePublicKey: "ssh-ed25519 AAAAcontrol",
+        registrationUrl: "https://cloud.example.test/register",
+        registrationSecret: "secret",
+      },
+    );
+
+    const idPattern = /^eliza-core-[0-9a-f]{8}$/;
+    expect(result.nodeId).toMatch(idPattern);
+    expect(mocks.buildUserData.mock.calls[0]?.[0]?.nodeId).toBe(result.nodeId);
+    expect(mocks.createServer.mock.calls[0]?.[0]?.name).toBe(result.nodeId);
+    expect(mocks.createServer.mock.calls[0]?.[0]?.labels?.["node-id"]).toBe(result.nodeId);
+    expect(mocks.createNode.mock.calls[0]?.[0]?.node_id).toBe(result.nodeId);
+  });
+
+  test("generated nodeIds are unique across repeated provisions", async () => {
+    const autoscaler = new NodeAutoscaler(policy);
+    const seen = new Set<string>();
+    const N = 50;
+
+    for (let i = 0; i < N; i++) {
+      mocks.createNode.mockClear();
+      mocks.createServer.mockResolvedValue({
+        server: {
+          id: 8000 + i,
+          name: "generated",
+          public_net: { ipv4: { ip: "203.0.113.30" }, ipv6: null },
+        },
+        rootPassword: null,
+      });
+      const result = await autoscaler.provisionNode(
+        {},
+        {
+          controlPlanePublicKey: "ssh-ed25519 AAAAcontrol",
+          registrationUrl: "https://cloud.example.test/register",
+          registrationSecret: "secret",
+        },
+      );
+      expect(result.nodeId).toMatch(/^eliza-core-[0-9a-f]{8}$/);
+      seen.add(result.nodeId);
+    }
+
+    expect(seen.size).toBe(N);
+  });
+
   test("scales up when there is no healthy compatible capacity", async () => {
     const autoscaler = new NodeAutoscaler(policy);
 

--- a/packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts
+++ b/packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts
@@ -424,8 +424,13 @@ export class NodeAutoscaler {
 
 function generateNodeId(): string {
   // Short hex id with a deterministic prefix — easy to scan in the dashboard.
-  const random = Math.random().toString(16).slice(2, 10);
-  return `node-${random}`;
+  // `Math.random().toString(16)` strips trailing zeros (e.g. 0.5 → "0.8"), so
+  // `.slice(2, 10)` is not guaranteed to be 8 chars. Generate 4 random bytes
+  // and hex-encode them for a stable 8-char suffix and stronger uniqueness.
+  const bytes = new Uint8Array(4);
+  crypto.getRandomValues(bytes);
+  const random = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+  return `eliza-core-${random}`;
 }
 
 function getHcloudServerId(node: DockerNode): number | undefined {


### PR DESCRIPTION
## Summary

Three coordinated changes that move the Hetzner setup from "manually-poked VMs" to a proper two-tier architecture:

1. **Terraform IaC for the control plane**: declares the persistent VM(s) that host the orchestrator daemon (`provisioning-worker`, `agent-router`, `headscale`, `cloudflared`). Uses `hetznercloud/hcloud` + `cloudflare` providers, Cloudflare R2 as S3 state backend. Includes cloud-init bootstrap, tfvars examples, and a README walkthrough for `terraform import` of the existing prod VM (`89.167.63.246`).

2. **Data-plane naming**: `node-<hex>` becomes `eliza-core-<hex>` going forward. `generateNodeId()` now sources entropy from `crypto.getRandomValues()` instead of `Math.random().toString(16).slice(2, 10)` — the latter silently strips trailing zeros and could produce short or colliding suffixes when `node_id` is UNIQUE in `docker_nodes`.

3. **Data-plane location default fixed**: Hetzner deprecated `cpx32` on `ash` (Ashburn), so `defaultHcloudLocation = "ash"` failed with "unsupported location for server type". Flipped to `fsn1` to match the actual prod fleet.

4. **Migration 0132**: disables the 6 legacy `milady-core-*` rows (`enabled=false`, `capacity=8`). They were inserted by hand in 2026-03 with `capacity=100` (unrealistic for cpx32), have been health-check offline for weeks, and are now ignored by the autoscaler. Existing sandboxes keep running on the underlying Docker daemons until their next user-triggered restart, at which point the daemon provisions a replacement on a fresh autoscaled core. Ops follow-up (delete Hetzner servers + DB rows) is documented in `ARCHITECTURE.md`.

`packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md` formalises the two-tier model (static control plane vs elastic data plane) so future ops actions have a clear runbook.

## What this PR does NOT do (followups)

- Terraform for headscale state + the cloudflared tunnel
- `terraform-apply` GitHub workflow
- Migrating the 4 remaining cron paths (`pool-replenish`, `pool-health-check`, `pool-image-rollout`, `deployment-monitor`) off the orphan `container-control-plane` service onto the daemon-queue pattern, then retiring the service entirely
- Raising the Hetzner Cloud server-count limit (ops ticket)

## Test plan

- [x] `bun test packages/cloud-shared/src/lib/services/containers/node-autoscaler.test.ts` — 5/5 pass (3 existing + 2 new for the `generateNodeId()` rename and entropy fix)
- [x] `bunx tsc --noEmit` on `packages/cloud-shared` — clean (pre-existing core/shared noise unrelated)
- [x] `terraform init -backend=false && terraform validate` on `packages/cloud-infra/cloud/terraform/hetzner/control-plane/` — success
- [x] `terraform fmt -recursive -check` — clean
- [x] R2 backend bucket `eliza-terraform-state` exists in WEUR (verified)
- [ ] After merge: import the existing prod VM into Terraform state via the steps in the README
- [ ] After merge + Hetzner limit raise: verify a fresh `eliza-core-<hex>` provisions via autoscale and milady-core-* sandboxes drain naturally on restart

## Ran the `/clean` skill on this PR

- Agent 1 (Slop & Larp): inlined a trivial `modules/manager-vm/` wrapper, removed a dead-exported helper (-87 LOC)
- Agent 2 (Types & Structure): clean, surfaced the `ash` vs `fsn1` inconsistency — fixed in this PR
- Agent 3 (Dead Code & Legacy): no leftovers
- Agent 4 (Defensive → Clean): caught the `Math.random()` slicing bug, replaced with `crypto.getRandomValues`
- Agent 5 (Tests & DRY): added the 2 missing tests for `generateNodeId()`

## Out-of-band ops actions needed for production rollout

1. Generate R2 API token (already done — bucket `eliza-terraform-state` exists)
2. Set `HETZNER_CLOUD_API_KEY` + `CONTAINERS_AUTOSCALE_PUBLIC_SSH_KEY` on the daemon (already done on staging VM at 89.167.63.246)
3. Open Hetzner ticket to raise the server-count limit past 10 so autoscale can actually create replacement cores

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR transitions the Hetzner setup to a two-tier architecture with Terraform IaC for the static control plane, fixes the `defaultHcloudLocation` fallback from the deprecated `ash` to `fsn1`, replaces `Math.random()`-based node ID generation with `crypto.getRandomValues()`, renames node IDs from `node-<hex>` to `eliza-core-<hex>`, and disables the six legacy `milady-core-*` DB rows via migration 0132.

- **Terraform control plane**: New `hetzner/control-plane/` module declares Hetzner VMs + Cloudflare DNS records backed by Cloudflare R2 state; cloud-init template handles first-boot setup of Docker, Bun, and the deploy user.
- **`generateNodeId()` fix**: 4 bytes from `crypto.getRandomValues()` hex-encoded with `padStart` guarantees exactly 8 hex characters, preventing the trailing-zero truncation bug in the previous `Math.random().toString(16).slice(2,10)` path.
- **Migration 0132**: Flips all `milady-core-*` rows to `enabled=false, capacity=8` so the autoscaler ignores them while live sandboxes drain naturally on their next restart.

<h3>Confidence Score: 3/5</h3>

The TypeScript and migration changes are safe to merge, but the Terraform module has two gaps that would prevent a usable deployment: no guard against an empty SSH key list (produces a permanently inaccessible VM) and no authorized_keys injection for the deploy user (blocks the GitHub Actions deploy workflow).

The node-autoscaler entropy fix and the milady-core migration are clean and well-tested. The defaultHcloudLocation fix is a straightforward one-liner. The risk sits entirely in the new Terraform module: applying with the default empty ssh_public_keys creates a VM nobody can access, and the deploy user created by cloud-init has no SSH authorized keys so the expected deploy workflow cannot SSH in.

variables.tf (missing SSH key validation) and cloud-init/bootstrap.yaml.tftpl (missing ssh_authorized_keys for the deploy user) need attention before the module is run against any environment.

<details open><summary><h3>Security Review</h3></summary>

- **Unverified installer scripts in cloud-init** (`bootstrap.yaml.tftpl` lines 49–53): both Docker (`curl -fsSL https://get.docker.com | sh`) and Bun (`curl -fsSL https://bun.sh/install | bash`) are fetched and executed without checksum verification. The control-plane VM holds `DATABASE_URL`, `HCLOUD_TOKEN`, Headscale state, and the cloudflared tunnel — a supply-chain or MITM attack at bootstrap time would silently compromise the entire control plane.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf | Defines all Terraform input variables; ssh_public_keys defaults to [] with no minimum-length validation, allowing a zero-key apply that produces an inaccessible VM. |
| packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl | Cloud-init bootstrap template: creates deploy user but injects no SSH authorized keys for that user, blocking the GitHub Actions deploy workflow. Uses unverified curl|sh for Docker and Bun installs on the most sensitive VM in the fleet. |
| packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf | Core Terraform resources for control-plane VMs and Cloudflare DNS records. SSH key resources use positional list indexing which causes unnecessary plan churn on key reorder. |
| packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts | Replaces Math.random().toString(16).slice(2,10) with crypto.getRandomValues() over 4 bytes; renames prefix from node- to eliza-core-. Correct and well-tested. |
| packages/cloud-shared/src/lib/services/containers/node-autoscaler.test.ts | Adds two new tests: validates eliza-core-[0-9a-f]{8} format and uniqueness across 50 consecutive provisions. Both correct. |
| packages/cloud-shared/src/db/migrations/0132_legacy_milady_cores_disable.sql | Sets enabled=false, capacity=8 for all milady-core-* rows. SQL correct; WHERE clause appropriately scoped; journal idx:131 matches the 0-based convention. |
| packages/cloud-shared/src/lib/config/containers-env.ts | Changes defaultHcloudLocation fallback from ash to fsn1, fixing provisioning failures after Hetzner deprecated cpx32 on ash. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf`, line 536-540 ([link](https://github.com/elizaos/eliza/blob/3a896d4d3db25e737e69fca00f2f5a7a72db5aff/packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf#L536-L540)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **No SSH key validation — VM becomes inaccessible on `terraform apply`**

   `var.ssh_public_keys` defaults to `[]`, and there is no `validation` block requiring at least one entry. When Hetzner creates a server, it injects the listed SSH public keys into root's `~/.ssh/authorized_keys`. With an empty list, the VM boots with no authorized key for root, and the `deploy` user also has no keys (see the cloud-init template). The only recovery is Hetzner rescue mode.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(cloud): Hetzner control plane IaC +..."](https://github.com/elizaos/eliza/commit/3a896d4d3db25e737e69fca00f2f5a7a72db5aff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33367829)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->