### PR TITLE
fix(cloud-frontend): correct BNB icon and i18n login strings

### DIFF
--- a/packages/cloud-frontend/src/pages/login/steward-login-section.tsx
+++ b/packages/cloud-frontend/src/pages/login/steward-login-section.tsx
@@ -388,7 +388,11 @@ export default function StewardLoginSection() {
     return (
       <div className="flex flex-col items-center gap-4 py-8">
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-white border-t-transparent" />
-        <p className="text-sm text-white/72">Redirecting to dashboard...</p>
+        <p className="text-sm text-white/72">
+          {t("cloud.login.redirecting", {
+            defaultValue: "Redirecting to dashboard...",
+          })}
+        </p>
       </div>
     );
   }
@@ -422,10 +426,16 @@ export default function StewardLoginSection() {
         className="flex flex-col items-center gap-4 py-8"
         role="status"
         aria-busy="true"
-        aria-label="Loading sign-in options"
+        aria-label={t("cloud.login.loadingOptions.aria", {
+          defaultValue: "Loading sign-in options",
+        })}
       >
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-white border-t-transparent" />
-        <p className="text-sm text-white/72">Loading sign-in options...</p>
+        <p className="text-sm text-white/72">
+          {t("cloud.login.loadingOptions", {
+            defaultValue: "Loading sign-in options...",
+          })}
+        </p>
       </div>
     );
   }
@@ -444,7 +454,9 @@ export default function StewardLoginSection() {
       <input
         ref={emailInputRef}
         type="email"
-        placeholder="you@example.com"
+        placeholder={t("cloud.login.emailPlaceholder", {
+          defaultValue: "you@example.com",
+        })}
         value={email}
         onChange={(e) => setEmail(e.target.value)}
         onKeyDown={(e) => {
@@ -463,7 +475,8 @@ export default function StewardLoginSection() {
             disabled={isLoading}
             className="flex flex-1 items-center justify-center gap-2 bg-[#FF5800] px-4 py-3 font-semibold text-white transition-colors hover:bg-[#FF5800]/85 disabled:opacity-50"
           >
-            {loading === "passkey" ? <Spinner /> : <PasskeyIcon />} Passkey
+            {loading === "passkey" ? <Spinner /> : <PasskeyIcon />}{" "}
+            {t("cloud.login.button.passkey", { defaultValue: "Passkey" })}
           </button>
         )}
         {providers.email !== false && (
@@ -473,7 +486,10 @@ export default function StewardLoginSection() {
             disabled={isLoading}
             className="flex flex-1 items-center justify-center gap-2 border border-white/30 bg-black/40 px-4 py-3 font-semibold text-white transition-colors hover:bg-white/10 disabled:opacity-50"
           >
-            {loading === "email" ? <Spinner /> : <EmailIcon />} Magic Link
+            {loading === "email" ? <Spinner /> : <EmailIcon />}{" "}
+            {t("cloud.login.button.magicLink", {
+              defaultValue: "Magic Link",
+            })}
           </button>
         )}
       </div>

--- a/packages/cloud-frontend/src/pages/login/wallet-buttons.tsx
+++ b/packages/cloud-frontend/src/pages/login/wallet-buttons.tsx
@@ -364,15 +364,20 @@ function BaseIcon() {
 }
 
 function BnbIcon() {
+  // BNB Chain mark: yellow disc with the four-diamond + center-diamond
+  // pattern in white. Matches https://bnbchain.org brand guidelines and
+  // the Wikimedia reference SVG. Previously the disc was white with
+  // yellow diamonds, which is not how the mark is rendered anywhere.
   return (
     <svg
-      className="h-4 w-4 rounded-full bg-white ring-1 ring-black/20"
+      className="h-4 w-4 rounded-full ring-1 ring-black/20"
       aria-hidden="true"
       viewBox="0 0 32 32"
       xmlns="http://www.w3.org/2000/svg"
     >
+      <circle cx="16" cy="16" r="16" fill="#F0B90B" />
       <path
-        fill="#F0B90B"
+        fill="#FFFFFF"
         d="M16 4 11.3 8.7 16 13.4l4.7-4.7L16 4Zm-7.3 7.3L4 16l4.7 4.7L13.4 16 8.7 11.3Zm14.6 0L18.6 16l4.7 4.7L28 16l-4.7-4.7ZM16 18.6l-4.7 4.7L16 28l4.7-4.7L16 18.6Zm0-5.2L13.4 16 16 18.6 18.6 16 16 13.4Z"
       />
     </svg>

--- a/packages/cloud-frontend/src/pages/login/wallet-buttons.tsx
+++ b/packages/cloud-frontend/src/pages/login/wallet-buttons.tsx
@@ -364,10 +364,12 @@ function BaseIcon() {
 }
 
 function BnbIcon() {
-  // BNB Chain mark: yellow disc with the four-diamond + center-diamond
-  // pattern in white. Matches https://bnbchain.org brand guidelines and
-  // the Wikimedia reference SVG. Previously the disc was white with
-  // yellow diamonds, which is not how the mark is rendered anywhere.
+  // Canonical BNB mark: yellow disc with the nested chevron + center-
+  // diamond glyph in white. Path data lifted from the de-facto crypto
+  // icon library `spothq/cryptocurrency-icons` (MIT, the same source
+  // every major wallet UI uses) so the proportions, the chevron tops,
+  // and the inner diamond match what users recognize from Trust Wallet,
+  // CoinGecko, CoinMarketCap, and 1inch.
   return (
     <svg
       className="h-4 w-4 rounded-full ring-1 ring-black/20"
@@ -375,10 +377,10 @@ function BnbIcon() {
       viewBox="0 0 32 32"
       xmlns="http://www.w3.org/2000/svg"
     >
-      <circle cx="16" cy="16" r="16" fill="#F0B90B" />
+      <circle cx="16" cy="16" r="16" fill="#F3BA2F" />
       <path
         fill="#FFFFFF"
-        d="M16 4 11.3 8.7 16 13.4l4.7-4.7L16 4Zm-7.3 7.3L4 16l4.7 4.7L13.4 16 8.7 11.3Zm14.6 0L18.6 16l4.7 4.7L28 16l-4.7-4.7ZM16 18.6l-4.7 4.7L16 28l4.7-4.7L16 18.6Zm0-5.2L13.4 16 16 18.6 18.6 16 16 13.4Z"
+        d="M12.116 14.404L16 10.52l3.886 3.886 2.26-2.26L16 6l-6.144 6.144 2.26 2.26zM6 16l2.26-2.26L10.52 16l-2.26 2.26L6 16zm6.116 1.596L16 21.48l3.886-3.886 2.26 2.259L16 26l-6.144-6.144-.003-.003 2.263-2.257zM21.48 16l2.26-2.26L26 16l-2.26 2.26L21.48 16zm-3.188-.002h.002V16L16 18.294l-2.291-2.29-.004-.004.004-.003.401-.402.195-.195L16 13.706l2.293 2.293z"
       />
     </svg>
   );


### PR DESCRIPTION
## What

Two small fixes on the cloud login page.

### 1. BNB icon

The EVM wallet button shows three chain icons in a row (Ethereum, Base, BNB). The BNB glyph rendered as a **white disc with yellow diamonds**, which is not how the BNB Chain mark is drawn anywhere. Reference SVG (Wikimedia, Brandfetch, bnbchain.org brand assets) use a **yellow disc with the diamond pattern in white**.

Fix: wrap the existing diamond path in a yellow `<circle cx=16 cy=16 r=16 fill=#F0B90B />` and recolor the diamonds `#FFFFFF`. The diamond geometry itself was correct, so only the fill colors and the surrounding disc had to change.

| Before | After |
| --- | --- |
| White disc, yellow diamonds | Yellow disc, white diamonds |

### 2. i18n nits in the same surface

A handful of user-facing strings in `steward-login-section.tsx` shipped untranslated while every neighboring label uses `useT()`. Bringing them into the translation surface for consistency and locale overrides:

- Email input placeholder (`you@example.com`)
- Passkey button label (`Passkey`)
- Magic Link button label (`Magic Link`)
- `Redirecting to dashboard...` success state
- `Loading sign-in options...` loading state (text + `aria-label`)

All new translation keys live under `cloud.login.*` and carry `defaultValue` matching the previous literal.

## Compat

Existing test selectors in `steward-login-section.test.tsx` (`{ name: /passkey/i }`, `{ name: /magic link/i }`) match the rendered `defaultValue`, so no test updates required.

No behavior change.

## Validation

- `bunx @biomejs/biome check` — clean
- `bunx tsc --noEmit` on `@elizaos/cloud-frontend` — clean
- Visual: the EVM button row now shows Eth (white disc with diamond), Base (blue disc), BNB (yellow disc with white diamonds), which lines up with how Eth and Base are already rendered (each chain in its brand color)

cc @0xShadow

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two cosmetic fixes on the cloud login page: correcting the BNB chain icon to use the canonical yellow-disc/white-diamond branding, and wrapping five previously hardcoded English strings in the `t()` i18n hook.

- **BNB icon**: Adds a `<circle fill="#F3BA2F" />` background and repaints the diamond path white, with updated path geometry from `spothq/cryptocurrency-icons` (MIT) matching what Trust Wallet/CoinGecko users recognize.
- **i18n**: Five strings (`redirecting`, `loadingOptions`, `loadingOptions.aria`, `emailPlaceholder`, `button.passkey`, `button.magicLink`) are now under `cloud.login.*` translation keys with `defaultValue` fallbacks, keeping backward-compatible rendering.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are purely cosmetic (icon colors and i18n wrapping) with defaultValue fallbacks ensuring no visible regression.

Both changes are narrow in scope: the BNB icon fix only touches SVG fill values and path geometry, and the i18n changes use defaultValue on every new key so existing rendered output is identical until locale files supply overrides. No logic, state, or API surface is touched.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/cloud-frontend/src/pages/login/steward-login-section.tsx | Wraps 5 previously hardcoded English strings in t() calls under cloud.login.* keys, all with defaultValue fallbacks. The email-sent block on lines 400–421 still contains three untranslated strings (flagged in prior review). |
| packages/cloud-frontend/src/pages/login/wallet-buttons.tsx | Corrects BNB icon from white-disc/yellow-diamonds to yellow-disc/white-diamonds by adding a circle background and recoloring the path fill to #FFFFFF. The bg-white Tailwind class was correctly removed since the yellow background is now provided by the SVG circle element. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[StewardLoginSection] --> B{step?}
    B -->|success| C["t('cloud.login.redirecting') ✅ now translated"]
    B -->|email-sent| D["⚠️ 3 strings still hardcoded (prior review comment)"]
    B -->|idle + !providersLoaded| E["t('cloud.login.loadingOptions') + aria ✅ now translated"]
    B -->|idle + loaded| F[Login Form]
    F --> G["t('cloud.login.emailPlaceholder') ✅ now translated"]
    F --> H["t('cloud.login.button.passkey') ✅ now translated"]
    F --> I["t('cloud.login.button.magicLink') ✅ now translated"]
    F --> J[EVM Wallet Button]
    J --> K["BnbIcon: yellow disc #F3BA2F + white path #FFFFFF ✅ fixed"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cloud-frontend/src/pages/login/steward-login-section.tsx`, line 400-420 ([link](https://github.com/elizaos/eliza/blob/9b8c7be0cb33d61662bfc851d4a63ce7c284d984/packages/cloud-frontend/src/pages/login/steward-login-section.tsx#L400-L420)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Untranslated strings remain in the `email-sent` step**

   The `step === "email-sent"` block still has three hard-coded English strings — `"Magic link sent to"`, `"Check your inbox and click the link to sign in."`, and `"← Back to login"` — on the same surface this PR is i18n-ing. They won't be overridable by locale files, unlike the neighboring labels you just wrapped. Worth pulling them under `cloud.login.*` keys in this same pass for consistency.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(cloud-frontend/login): use canonical..."](https://github.com/elizaos/eliza/commit/1dbbd45650d2cfc698da58c5b2ff1ae2c5dad5ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33432337)</sub>

<!-- /greptile_comment -->