### PR TITLE
fix(core): preserve speaker names in prior dialogue context

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -411,6 +411,120 @@ describe("runV5MessageRuntimeStage1", () => {
 		}
 	});
 
+	it("routes short chat-entity identity lookups through recall instead of simple guessing", async () => {
+		const runtime = makeRuntime([
+			JSON.stringify({
+				processMessage: "RESPOND",
+				plan: {
+					contexts: ["simple"],
+					reply: "Queuebot is just the same assistant you've seen before.",
+					simple: true,
+					requiresTool: false,
+				},
+				extract: {
+					facts: [],
+					relationships: [],
+					addressedTo: [],
+				},
+			}),
+			JSON.stringify({
+				thought: "Identity lookup should be grounded in recalled chat context.",
+				toolCalls: [],
+				messageToUser:
+					"I don't have enough recalled chat context to identify queuebot.",
+			}),
+		]);
+		runtime.actions = [
+			{
+				name: "MESSAGE",
+				contexts: ["messaging", "memory"],
+				description: "Search and inspect stored conversation messages.",
+				validate: async () => true,
+				handler: async () => ({ success: true }),
+			},
+		] as never;
+		runtime.composeState = vi.fn(async () => ({
+			values: { availableContexts: "simple, general, memory, messaging" },
+			data: {
+				providers: {
+					RECENT_MESSAGES: {
+						text: "# Conversation Messages\nrecent provider text",
+						providerName: "RECENT_MESSAGES",
+					},
+				},
+			},
+			text: "",
+		})) as never;
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: [
+					"[Recent channel context]",
+					"e2e: queuebot came up earlier in the channel.",
+					"",
+					"[Discord #general | NUBot test server] @e2e (Sat 05/23/2026 10:25 UTC): assistant (@1490833425802854491) who is queuebot?",
+				].join("\n"),
+				source: "discord",
+			}),
+			state: {
+				values: { availableContexts: "simple, general, memory, messaging" },
+				data: {},
+				text: "",
+			},
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		const plannerCall = useModelCalls(runtime)[1]?.[1] as {
+			messages?: Array<{ role?: string; content?: string | null }>;
+		};
+		const plannerUserContent = plannerCall.messages?.[1]?.content ?? "";
+		expect(plannerUserContent).toContain("identity_lookup_policy");
+		expect(plannerUserContent).toContain('"candidateActions":["MESSAGE"]');
+		expect(plannerUserContent).toContain("routing through recall context");
+		expect(plannerUserContent).not.toContain(
+			"Queuebot is just the same assistant",
+		);
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"I don't have enough recalled chat context to identify queuebot.",
+			);
+		}
+	});
+
+	it("does not reroute ordinary public identity questions through recall", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "Barack Obama is a former U.S. president.",
+				extra: { requiresTool: false },
+			}),
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: "assistant (@1490833425802854491) who is obama?",
+				source: "discord",
+			}),
+			state: {
+				values: { availableContexts: "simple, general, memory, messaging" },
+				data: {},
+				text: "",
+			},
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"Barack Obama is a former U.S. president.",
+			);
+		}
+		expect(useModelCalls(runtime)).toHaveLength(1);
+	});
+
 	it("does not treat the agent's own attachment ack as a user follow-up anchor", async () => {
 		const runtime = makeRuntime([
 			stage1Response({

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -2100,6 +2100,98 @@ android smoke model works`,
 		);
 	});
 
+	it("keeps speaker names on structured prior dialogue", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "I see the prior chat context.",
+				extra: { requiresTool: false },
+			}),
+		]);
+		const state: State = {
+			values: {
+				availableContexts: "simple, general",
+			},
+			data: {
+				providers: {
+					RECENT_MESSAGES: {
+						text: "# Conversation Messages\nprovider text should not render",
+						data: {
+							recentMessages: [
+								{
+									id: "00000000-0000-0000-0000-00000000bb01" as UUID,
+									entityId: "00000000-0000-0000-0000-00000000bb11" as UUID,
+									agentId: runtime.agentId,
+									roomId: "00000000-0000-0000-0000-000000001111" as UUID,
+									createdAt: 1,
+									content: {
+										text: "Hey, nice to meet shebotdick.",
+										source: "discord",
+									},
+									metadata: {
+										type: "message",
+										sender: {
+											id: "discord-botdick",
+											name: "botdick",
+											username: "botdick",
+										},
+									},
+								},
+								{
+									id: "00000000-0000-0000-0000-00000000bb02" as UUID,
+									entityId: "00000000-0000-0000-0000-00000000bb12" as UUID,
+									agentId: runtime.agentId,
+									roomId: "00000000-0000-0000-0000-000000001111" as UUID,
+									createdAt: 2,
+									content: {
+										text: "i was asking about shedick",
+										source: "discord",
+									},
+									metadata: {
+										type: "message",
+										sender: {
+											id: "discord-1gig",
+											name: "1gig",
+											username: "1gig",
+										},
+									},
+								},
+							],
+						},
+						providerName: "RECENT_MESSAGES",
+					},
+				},
+			},
+			text: "fallback text should not be needed",
+		};
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: "whats the compatibility between her and botdick",
+			}),
+			state,
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		const firstCall = useModelCalls(runtime)[0];
+		const params = firstCall?.[1] as {
+			messages?: Array<{ role?: string; content?: string | null }>;
+		};
+		const userContent = params.messages?.[1]?.content ?? "";
+		expect(userContent).not.toContain("# Conversation Messages");
+		expect(userContent).not.toContain("provider text should not render");
+		expect(userContent).toContain(
+			"prior_message:user:\nbotdick: Hey, nice to meet shebotdick.",
+		);
+		expect(userContent).toContain(
+			"prior_message:user:\n1gig: i was asking about shedick",
+		);
+		expect(userContent).toContain(
+			"message:user:\nwhats the compatibility between her and botdick",
+		);
+	});
+
 	it("recomposes planner state with selected context providers but excludes catalogs", async () => {
 		const runtime = makeRuntime([
 			stage1Response({

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -2936,4 +2936,33 @@ android smoke model works`,
 		});
 		expect(runtime.useModel).toHaveBeenCalledTimes(1);
 	});
+
+	it("renders direct-message instructions that forbid ungrounded simple replies and phantom action claims", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "Hi.",
+			}),
+		]);
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ channelType: ChannelType.DM }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		const firstCall = useModelCalls(runtime)[0];
+		const params = firstCall?.[1] as {
+			messages?: Array<{ role?: string; content?: string | null }>;
+		};
+		const systemContent =
+			params.messages?.find((m) => m.role === "system")?.content ?? "";
+		expect(systemContent).toContain(
+			'Only use "simple" when you can answer directly from your static knowledge or the visible prior_message / reply_reference context.',
+		);
+		expect(systemContent).toContain(
+			"Never write replyText that claims you have searched, scanned, checked, looked up, recalled, or remembered anything unless an actual tool call this turn returned that content.",
+		);
+	});
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2724,6 +2724,44 @@ const BUILTIN_RESPONSE_HANDLER_EVALUATORS: readonly ResponseHandlerEvaluator[] =
 				],
 			}),
 		},
+		{
+			name: "core.contextual_identity_lookup_requires_recall",
+			description:
+				"Routes short chat-entity identity lookups through memory/messaging instead of letting Stage 1 guess from the simple shortcut.",
+			priority: 20,
+			shouldRun: ({ message, messageHandler }) =>
+				!isSubAgentCompletionArtifact(message) &&
+				isSimpleMessageHandlerShortcut(messageHandler) &&
+				extractContextualIdentityLookupSubject(
+					getUserMessageText(message) ?? "",
+				) !== null,
+			evaluate: ({ runtime, message }) => {
+				const subject = extractContextualIdentityLookupSubject(
+					getUserMessageText(message) ?? "",
+				);
+				const messageAction = findRuntimeActionByNames(runtime, ["MESSAGE"]);
+				return {
+					setContexts: ["general", "memory", "messaging"],
+					...(messageAction
+						? {
+								addCandidateActions: [messageAction.name],
+							}
+						: {}),
+					clearReply: true,
+					addContextSlices: [
+						[
+							"identity_lookup_policy:",
+							`The current user is asking who/what "${subject ?? "the named subject"}" is in context.`,
+							"Ground the answer in recent messages, memory, or message-search results before identifying the subject.",
+							"If recalled context does not identify a chat-local subject, say that plainly instead of inventing a relationship; only use public knowledge when the subject is clearly a public entity.",
+						].join("\n"),
+					],
+					debug: [
+						`short identity lookup for "${subject ?? "unknown"}"; routing through recall context before answering`,
+					],
+				};
+			},
+		},
 	];
 
 /**
@@ -3488,6 +3526,122 @@ function looksLikeCompleteDirectReply(replyText: string): boolean {
 	return (
 		/[.!?。！？]$/u.test(normalized) || normalized.split(/\s+/u).length >= 8
 	);
+}
+
+function isSimpleMessageHandlerShortcut(
+	messageHandler: MessageHandlerResult,
+): boolean {
+	if (messageHandler.processMessage !== "RESPOND") return false;
+	if (messageHandler.plan.requiresTool === true) return false;
+	const contexts = messageHandler.plan.contexts ?? [];
+	const nonSimpleContexts = contexts.filter(
+		(context) => context !== SIMPLE_CONTEXT_ID,
+	);
+	return (
+		nonSimpleContexts.length === 0 &&
+		(messageHandler.plan.candidateActions?.length ?? 0) === 0
+	);
+}
+
+const CONTEXTUAL_IDENTITY_LOOKUP_PREFIXES = [
+	"who is ",
+	"who are ",
+	"who was ",
+	"who were ",
+	"who's ",
+	"whos ",
+	"what is ",
+	"what was ",
+	"what's ",
+	"whats ",
+	"tell me about ",
+	"do you know ",
+	"do you remember ",
+	"what do you know about ",
+] as const;
+
+const CONTEXTUAL_IDENTITY_PRONOUN_SUBJECTS = new Set([
+	"he",
+	"her",
+	"him",
+	"i",
+	"it",
+	"me",
+	"she",
+	"that",
+	"them",
+	"they",
+	"this",
+	"us",
+	"we",
+	"you",
+]);
+
+function removeLeadingPlatformAddress(text: string): string {
+	let cleaned = text
+		.replace(/<@!?\d+>/gu, " ")
+		.replace(/\s+/gu, " ")
+		.trim();
+	const displayAddressRe = /(?:^|[\s:])[^:\n]{0,96}\(@\d+\)\s+/gu;
+	let displayAddressEnd = -1;
+	for (
+		let displayAddressMatch = displayAddressRe.exec(cleaned);
+		displayAddressMatch !== null;
+		displayAddressMatch = displayAddressRe.exec(cleaned)
+	) {
+		displayAddressEnd = displayAddressRe.lastIndex;
+	}
+	if (displayAddressEnd > 0) {
+		cleaned = cleaned.slice(displayAddressEnd).trim();
+	}
+	return cleaned;
+}
+
+function cleanContextualLookupSubject(subject: string): string {
+	return subject
+		.replace(/[\s?.!]+$/gu, "")
+		.replace(/^["'`“”‘’]+|["'`“”‘’]+$/gu, "")
+		.replace(
+			/\s+(?:in|from|on)\s+(?:this\s+)?(?:chat|channel|thread|server)$/iu,
+			"",
+		)
+		.trim();
+}
+
+function isShortContextualLookupSubject(subject: string): boolean {
+	const normalized = subject.toLowerCase();
+	if (!normalized || CONTEXTUAL_IDENTITY_PRONOUN_SUBJECTS.has(normalized)) {
+		return false;
+	}
+	const words = normalized.split(/\s+/u).filter(Boolean);
+	if (words.length === 0 || words.length > 3) return false;
+	if (subject.length > 48) return false;
+	if (/^[0-9\s.,:+*/=()-]+$/u.test(subject)) return false;
+	const looksLikeLocalName =
+		/[@_\-0-9]/u.test(subject) ||
+		/\b(?:bot|agent|ai)\b/iu.test(subject) ||
+		/^[a-z][a-z0-9_-]{6,}$/u.test(subject);
+	return looksLikeLocalName;
+}
+
+function lastNonEmptyLine(text: string): string {
+	const lines = text.replace(/\r\n/g, "\n").split("\n");
+	for (let index = lines.length - 1; index >= 0; index -= 1) {
+		const line = lines[index]?.trim();
+		if (line) return line;
+	}
+	return text.trim();
+}
+
+function extractContextualIdentityLookupSubject(text: string): string | null {
+	const cleaned = removeLeadingPlatformAddress(lastNonEmptyLine(text));
+	const lower = cleaned.toLowerCase();
+	for (const prefix of CONTEXTUAL_IDENTITY_LOOKUP_PREFIXES) {
+		if (!lower.startsWith(prefix)) continue;
+		const subject = cleanContextualLookupSubject(cleaned.slice(prefix.length));
+		return isShortContextualLookupSubject(subject) ? subject : null;
+	}
+	return null;
 }
 
 function shouldPreferCompleteDirectReply(args: {
@@ -5168,11 +5322,17 @@ export async function runV5MessageRuntimeStage1(args: {
 			preselectedActions: exposedPlannerActions,
 			actionSurface,
 		});
+		const responseHandlerContextSlices = stringArrayProperty(
+			(messageHandler.plan as { contextSlices?: unknown }).contextSlices,
+		);
 		const plannerContextWithDecision = appendContextEvent(plannerContext, {
 			id: `message-handler:${messageHandlerEndedAt}`,
 			type: "message_handler",
 			source: "message-service",
 			createdAt: messageHandlerEndedAt,
+			...(responseHandlerContextSlices.length > 0
+				? { content: responseHandlerContextSlices.join("\n\n") }
+				: {}),
 			metadata: {
 				processMessage: messageHandler.processMessage,
 				plan: {
@@ -5182,6 +5342,9 @@ export async function runV5MessageRuntimeStage1(args: {
 						: {}),
 					candidateActions: getMessageHandlerCandidateActions(messageHandler),
 					parentActionHints: getMessageHandlerParentActionHints(messageHandler),
+					...(responseHandlerContextSlices.length > 0
+						? { contextSlices: responseHandlerContextSlices }
+						: {}),
 					...(messageHandler.plan.reply !== undefined
 						? { reply: messageHandler.plan.reply }
 						: {}),

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2805,6 +2805,8 @@ direct/private rules:
 - Ordinary chat, static knowledge, creative writing, rewriting, translation, brainstorming, and short explanations should use contexts=["simple"] and put the final answer in replyText.
 - For simple requests, replyText must be a natural user-facing answer; avoid single-token fragments or placeholder text unless the user explicitly asked for a terse form.
 - Use a non-simple context or candidateActionNames only when the request needs tools, current/live facts, private state, files, web, shell, side effects, scheduling, memory, settings, secrets, wallet/finance, media, or device/app control.
+- Only use "simple" when you can answer directly from your static knowledge or the visible prior_message / reply_reference context. If the message refers to a specific name, person, nickname, or thing you cannot identify from the visible context, choose a non-simple context (such as general or memory) instead of guessing.
+- Never write replyText that claims you have searched, scanned, checked, looked up, recalled, or remembered anything unless an actual tool call this turn returned that content. If you cannot ground the answer from the visible context, say so plainly.
 - For tool/planning paths, replyText is only a brief ack ("On it.", "Looking into it."). Never refuse because tools may run after this stage.
 - If schema omits shouldRespond, do not invent it.
 - contexts must be ids from available_contexts. If a needed tool context is unclear, use ["general"].

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1599,6 +1599,61 @@ function asProviderRecord(value: unknown):
 	};
 }
 
+function asPlainRecord(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	return value as Record<string, unknown>;
+}
+
+function cleanPriorDialogueSpeakerName(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.trim().split(/\s+/).join(" ");
+	if (!normalized) return undefined;
+	return normalized.length > 80 ? `${normalized.slice(0, 77)}...` : normalized;
+}
+
+function senderIdentityName(value: unknown): string | undefined {
+	const record = asPlainRecord(value);
+	if (!record) return undefined;
+	return (
+		cleanPriorDialogueSpeakerName(record.name) ??
+		cleanPriorDialogueSpeakerName(record.username) ??
+		cleanPriorDialogueSpeakerName(record.tag)
+	);
+}
+
+function priorDialogueSpeakerName(memory: Memory): string | undefined {
+	const metadata = asPlainRecord(memory.metadata);
+	const content = asPlainRecord(memory.content);
+	const contentMetadata = asPlainRecord(content?.metadata);
+	const sender =
+		senderIdentityName(metadata?.sender) ??
+		senderIdentityName(contentMetadata?.sender);
+	if (sender) return sender;
+	for (const record of [metadata, contentMetadata, content]) {
+		const name =
+			cleanPriorDialogueSpeakerName(record?.entityName) ??
+			cleanPriorDialogueSpeakerName(record?.senderName) ??
+			cleanPriorDialogueSpeakerName(record?.authorName) ??
+			cleanPriorDialogueSpeakerName(record?.displayName) ??
+			cleanPriorDialogueSpeakerName(record?.userName) ??
+			cleanPriorDialogueSpeakerName(record?.username) ??
+			cleanPriorDialogueSpeakerName(record?.name);
+		if (name) return name;
+	}
+	return undefined;
+}
+
+function priorDialogueContent(text: string, speaker?: string): string {
+	if (!speaker) return text;
+	const trimmedStart = text.trimStart();
+	if (trimmedStart.toLowerCase().startsWith(`${speaker.toLowerCase()}:`)) {
+		return text;
+	}
+	return `${speaker}: ${text}`;
+}
+
 function appendPriorDialogueEvents(
 	events: ContextEvent[],
 	runtime: IAgentRuntime,
@@ -1657,6 +1712,7 @@ function appendPriorDialogueEvents(
 	for (const memory of dialogue) {
 		const text = getUserMessageText(memory);
 		if (!text) continue;
+		const speakerName = priorDialogueSpeakerName(memory);
 		events.push({
 			id: `history:${memory.id}`,
 			type: "segment",
@@ -1665,11 +1721,12 @@ function appendPriorDialogueEvents(
 			segment: {
 				id: `history:${memory.id}`,
 				label: "prior_message:user",
-				content: text,
+				content: priorDialogueContent(text, speakerName),
 				stable: false,
 				metadata: {
 					roomId: memory.roomId,
 					entityId: memory.entityId,
+					...(speakerName ? { speakerName } : {}),
 				},
 			},
 		});

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -688,6 +688,8 @@ simple shortcut: choose contexts=["simple"] when the user is asking for a direct
 
 For simple requests, replyText is the final answer itself, not a description of what the user asked for and not an internal plan. Write a natural user-facing answer; avoid single-token fragments or placeholder text unless the user explicitly asked for a terse form.
 
+Never write replyText that claims you have searched, scanned, checked, looked up, recalled, or remembered anything unless an actual tool call this turn returned that content. If you cannot ground the answer from the visible prior_message / reply_reference / provider context, say so plainly instead of fabricating an action.
+
 Platform mention/reply target/channel/room/connector alone can still be simple when only chat reply needed.
 
 Never simple when message:

--- a/packages/prompts/test/prompts.test.js
+++ b/packages/prompts/test/prompts.test.js
@@ -86,6 +86,33 @@ describe("prompt templates (src/index.ts)", () => {
       `src/index.ts has unbalanced delimiters: ${opens} {{ vs ${closes} }}`,
     );
   });
+
+  it("messageHandlerTemplate forbids phantom action claims in replyText", () => {
+    // Regression coverage for the structural rule that prevents Stage 1
+    // from writing "I scanned/searched/checked/looked up/recalled/remembered"
+    // prose when no tool call this turn actually retrieved that content.
+    // Originally observed in production as the bot replying "I've scanned
+    // the recent chat..." with plannerIterations=0 and toolCallsExecuted=0.
+    const src = readSrc();
+    const messageHandlerTemplateRe =
+      /export const messageHandlerTemplate = `([^`]+)`/;
+    const match = src.match(messageHandlerTemplateRe);
+    assert.ok(
+      match,
+      "messageHandlerTemplate string literal should be findable",
+    );
+    const body = match[1];
+    assert.match(
+      body,
+      /Never write replyText that claims you have searched, scanned, checked, looked up, recalled, or remembered anything/,
+      "messageHandlerTemplate should carry the phantom-action-claim rule",
+    );
+    assert.match(
+      body,
+      /unless an actual tool call this turn returned that content/,
+      "phantom-action-claim rule should bind the prohibition to actual tool execution this turn",
+    );
+  });
 });
 
 describe("build scripts", () => {


### PR DESCRIPTION
## Summary
- preserves connector-provided sender names when RECENT_MESSAGES history is rendered as structured `prior_message:user` blocks
- keeps the existing provider-text dedupe behavior, so full `# Conversation Messages` provider text still stays out of Stage 1 prompts
- adds a regression test for the Discord failure shape where a later turn asks about a named participant from earlier chat context

## Why
A live Discord exchange showed Remilio/Nubilio losing speaker attribution after earlier chat context was converted into anonymous `prior_message:user` blocks. The model saw prior text, but not who said it, so it failed follow-up questions like "look in the chat" / "her and botdick" even though the relevant messages were present.

This patch is connector-agnostic: it reads the existing `metadata.sender` / entity-name fields already written by connectors and prefixes prior dialogue content with the sender name. Reply references already use this shape.

## Validation
- Synced branch to latest `origin/develop` (`fa83ddee6f`) via fast-forward before patching
- `bun vitest run src/__tests__/message-runtime-stage1.test.ts src/features/basic-capabilities/providers/recentMessages.test.ts src/runtime/__tests__/planner-loop.test.ts` from `packages/core`: 94 tests passed
- `bun run typecheck` from `packages/core`: passed
- `bun run build` from `packages/core`: passed
- Baseline after sync before patch:
  - core focused suite: 119 tests passed
  - orchestrator focused suite: 120 tests passed
- Live Discord smoke after restart from local source:
  - setup message: `1507674411552084059`
  - prompt: `1507674422939750474`
  - bot reply: `1507674432225939507`
  - trajectory: `tj-224f2528525703`
  - model: `gpt-oss-120b`
  - tool calls: 0, failures: 0
  - result: answered the shebotdick/botdick compatibility question using the recent channel context instead of claiming missing information

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes speaker-name attribution in prior dialogue context blocks and adds a heuristic evaluator that reroutes chat-local identity lookups through memory recall instead of allowing Stage 1 to guess from its simple shortcut. It also adds a prompt rule that forbids `replyText` from claiming prior search or recall actions when no tool call was actually made.

- `priorDialogueSpeakerName` extracts sender identity from `metadata.sender` / flat metadata fields and prefixes prior-dialogue content with `\"name: text\"`, preserving attribution across all connectors.
- `core.contextual_identity_lookup_requires_recall` evaluator detects short chat-local identity queries (via prefix + heuristic checks), clears the simple reply, and injects an `identity_lookup_policy` context slice to ground the answer in recall before falling back to public knowledge.
- The phantom-action-claim rule (`\"Never write replyText that claims you have searched…\"`) is added to both `DIRECT_MESSAGE_HANDLER_TEMPLATE` and `messageHandlerTemplate`, with a structural test verifying the rule is present.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the speaker-name extraction and identity-routing paths are well-tested and the only noted issues are non-blocking observations.

The speaker-name fix is narrow, connector-agnostic, and gated by a clear null-check. The new evaluator only fires when Stage 1 already chose the simple shortcut, so the worst-case for a false positive is an extra planner round-trip, not a wrong answer. All core paths are covered by the added regression tests, typecheck, and build pass.

packages/core/src/services/message.ts — the dead `content` field on `message_handler` events and the broad 7-char regex in `isShortContextualLookupSubject` are both worth a second look before extending this evaluator further.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/services/message.ts | Core changes: adds speaker-name extraction/prefixing for prior dialogue events, adds `core.contextual_identity_lookup_requires_recall` evaluator with detection logic, extends prompt rules, and wires `contextSlices` into the planner context. The dead `content` field on message_handler events and the broad heuristic regex are both non-blocking. |
| packages/core/src/__tests__/message-runtime-stage1.test.ts | Adds regression tests: speaker-name preservation in prior dialogue, identity-lookup routing, no-reroute for public figures, DM phantom-action-claim rule, and direct-message instructions. Tests are well-structured and cover the primary scenarios. |
| packages/prompts/src/index.ts | Adds a one-line rule to `messageHandlerTemplate` prohibiting replyText that claims prior search/recall actions without an actual tool call. Straightforward and well-scoped. |
| packages/prompts/test/prompts.test.js | Adds a structural test that verifies the phantom-action-claim rule is present in `messageHandlerTemplate`. Simple and correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Message] --> B[Stage 1: messageHandler\nrunResponseHandlerEvaluators]
    B --> C{isSimpleMessageHandlerShortcut?}
    C -- No --> D[Normal planner path]
    C -- Yes --> E{extractContextualIdentityLookupSubject\nnot null?}
    E -- No --> F[Keep simple reply\ndirect_reply]
    E -- Yes --> G[core.contextual_identity_lookup_requires_recall\nfires]
    G --> H[clearReply\nsetContexts: general/memory/messaging\naddContextSlices: identity_lookup_policy]
    H --> I[contextSlices → metadata.plan.contextSlices]
    I --> J[Planner context rendered\nvia textFromUnknown plan]
    J --> K[Planner turn\nMemory / MESSAGE search]
    K --> L[Ground answer in recall\nor use public knowledge]

    M[appendPriorDialogueEvents] --> N[For each Memory in recentMessages]
    N --> O[priorDialogueSpeakerName\nreads metadata.sender / flat fields]
    O --> P[priorDialogueContent\nprepends speaker: text]
    P --> Q[prior_message:user segment\nin planner context]
```

<sub>Reviews (4): Last reviewed commit: ["test(prompts): pin phantom-action-claim ..."](https://github.com/elizaos/eliza/commit/456674e5d46c9a9cd8b9b9225f2ace03160ab8c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33576167)</sub>

<!-- /greptile_comment -->