### PR TITLE
feat(cloud): replace HTTP control-plane health probe with Redis heartbeat

### DIFF
--- a/packages/cloud-shared/src/lib/services/provisioning-worker-health.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-worker-health.test.ts
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { runWithCloudBindingsAsync } from "../runtime/cloud-bindings";
 import {
   checkProvisioningWorkerHealth,
-  publishProvisioningWorkerHeartbeat,
   PROVISIONING_WORKER_HEARTBEAT_KEY,
+  publishProvisioningWorkerHeartbeat,
 } from "./provisioning-worker-health";
 
 const TEST_ENV = {
@@ -12,10 +12,7 @@ const TEST_ENV = {
   MOCK_REDIS: "1",
 };
 
-async function withEnv<T>(
-  extra: Record<string, string>,
-  fn: () => Promise<T>,
-): Promise<T> {
+async function withEnv<T>(extra: Record<string, string>, fn: () => Promise<T>): Promise<T> {
   return runWithCloudBindingsAsync({ ...TEST_ENV, ...extra }, fn);
 }
 
@@ -33,9 +30,7 @@ describe("provisioning worker health (Redis heartbeat)", () => {
   });
 
   it("returns unhealthy when no heartbeat has been published", async () => {
-    const result = await withEnv({}, () =>
-      checkProvisioningWorkerHealth(),
-    );
+    const result = await withEnv({}, () => checkProvisioningWorkerHealth());
     expect(result.ok).toBe(false);
     if (result.ok === false) {
       expect(result.code).toBe("PROVISIONING_WORKER_UNHEALTHY");
@@ -67,16 +62,13 @@ describe("provisioning worker health (Redis heartbeat)", () => {
   });
 
   it("publish returns false when redis is not configured", async () => {
-    const wrote = await runWithCloudBindingsAsync(
-      { NODE_ENV: "production" },
-      () => publishProvisioningWorkerHeartbeat(),
+    const wrote = await runWithCloudBindingsAsync({ NODE_ENV: "production" }, () =>
+      publishProvisioningWorkerHeartbeat(),
     );
     expect(wrote).toBe(false);
   });
 
   it("uses a stable redis key for observability", () => {
-    expect(PROVISIONING_WORKER_HEARTBEAT_KEY).toBe(
-      "provisioning_worker:health",
-    );
+    expect(PROVISIONING_WORKER_HEARTBEAT_KEY).toBe("provisioning_worker:health");
   });
 });

--- a/packages/cloud-shared/src/lib/services/provisioning-worker-health.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-worker-health.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { runWithCloudBindingsAsync } from "../runtime/cloud-bindings";
+import {
+  checkProvisioningWorkerHealth,
+  publishProvisioningWorkerHeartbeat,
+  PROVISIONING_WORKER_HEARTBEAT_KEY,
+} from "./provisioning-worker-health";
+
+const TEST_ENV = {
+  NODE_ENV: "production",
+  REQUIRE_PROVISIONING_WORKER: "true",
+  MOCK_REDIS: "1",
+};
+
+async function withEnv<T>(
+  extra: Record<string, string>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return runWithCloudBindingsAsync({ ...TEST_ENV, ...extra }, fn);
+}
+
+describe("provisioning worker health (Redis heartbeat)", () => {
+  beforeEach(() => {
+    delete process.env.NODE_ENV;
+    delete process.env.REQUIRE_PROVISIONING_WORKER;
+    delete process.env.MOCK_REDIS;
+  });
+
+  afterEach(() => {
+    delete process.env.NODE_ENV;
+    delete process.env.REQUIRE_PROVISIONING_WORKER;
+    delete process.env.MOCK_REDIS;
+  });
+
+  it("returns unhealthy when no heartbeat has been published", async () => {
+    const result = await withEnv({}, () =>
+      checkProvisioningWorkerHealth(),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.code).toBe("PROVISIONING_WORKER_UNHEALTHY");
+      expect(result.status).toBe(503);
+    }
+  });
+
+  it("returns healthy after the daemon publishes a heartbeat", async () => {
+    await withEnv({}, async () => {
+      await publishProvisioningWorkerHeartbeat();
+      const result = await checkProvisioningWorkerHealth();
+      expect(result.ok).toBe(true);
+      if (result.ok === true) {
+        expect(result.required).toBe(true);
+        expect(typeof result.lastHeartbeatAt).toBe("string");
+      }
+    });
+  });
+
+  it("returns not-required when the env flag is off", async () => {
+    const result = await runWithCloudBindingsAsync(
+      { NODE_ENV: "development", MOCK_REDIS: "1" },
+      () => checkProvisioningWorkerHealth(),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok === true) {
+      expect(result.required).toBe(false);
+    }
+  });
+
+  it("publish returns false when redis is not configured", async () => {
+    const wrote = await runWithCloudBindingsAsync(
+      { NODE_ENV: "production" },
+      () => publishProvisioningWorkerHeartbeat(),
+    );
+    expect(wrote).toBe(false);
+  });
+
+  it("uses a stable redis key for observability", () => {
+    expect(PROVISIONING_WORKER_HEARTBEAT_KEY).toBe(
+      "provisioning_worker:health",
+    );
+  });
+});

--- a/packages/cloud-shared/src/lib/services/provisioning-worker-health.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-worker-health.ts
@@ -14,8 +14,7 @@ import { getCloudAwareEnv } from "../runtime/cloud-bindings";
  * share an Upstash/Redis instance via `buildRedisClient`, so this is
  * cheaper than a Neon round-trip and gives self-healing via TTL.
  */
-export const PROVISIONING_WORKER_HEARTBEAT_KEY =
-  "provisioning_worker:health";
+export const PROVISIONING_WORKER_HEARTBEAT_KEY = "provisioning_worker:health";
 
 /**
  * How long a single heartbeat is valid. The daemon refreshes every ~15s
@@ -73,9 +72,7 @@ export async function checkProvisioningWorkerHealth(): Promise<ProvisioningWorke
 
   let raw: string | null;
   try {
-    raw = (await redis.get(PROVISIONING_WORKER_HEARTBEAT_KEY)) as
-      | string
-      | null;
+    raw = (await redis.get(PROVISIONING_WORKER_HEARTBEAT_KEY)) as string | null;
   } catch (error) {
     return {
       ok: false,
@@ -95,8 +92,7 @@ export async function checkProvisioningWorkerHealth(): Promise<ProvisioningWorke
       required: true,
       status: 503,
       code: "PROVISIONING_WORKER_UNHEALTHY",
-      error:
-        "Provisioning worker has not reported a heartbeat in the last 60 seconds.",
+      error: "Provisioning worker has not reported a heartbeat in the last 60 seconds.",
     };
   }
 

--- a/packages/cloud-shared/src/lib/services/provisioning-worker-health.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-worker-health.ts
@@ -1,16 +1,35 @@
+import {
+  buildRedisClient,
+  type CompatibleRedis,
+  type RedisFactoryEnv,
+} from "../cache/redis-factory";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 
-const CONTROL_PLANE_URL_KEYS = [
-  "CONTAINER_CONTROL_PLANE_URL",
-  "CONTAINER_SIDECAR_URL",
-  "HETZNER_CONTAINER_CONTROL_PLANE_URL",
-] as const;
+/**
+ * Redis key the provisioning-worker daemon SETs with a short TTL every
+ * cycle. When the key is missing the daemon is considered unhealthy
+ * (either down or paused).
+ *
+ * The daemon writes; the cloud-api Worker reads. Both processes already
+ * share an Upstash/Redis instance via `buildRedisClient`, so this is
+ * cheaper than a Neon round-trip and gives self-healing via TTL.
+ */
+export const PROVISIONING_WORKER_HEARTBEAT_KEY =
+  "provisioning_worker:health";
+
+/**
+ * How long a single heartbeat is valid. The daemon refreshes every ~15s
+ * (cycle interval), so 60s leaves room for 4 missed cycles before the
+ * gate trips. Keep in sync with `PROVISIONING_WORKER_HEARTBEAT_TTL_S` on
+ * the daemon side.
+ */
+export const PROVISIONING_WORKER_HEARTBEAT_TTL_S = 60;
 
 export type ProvisioningWorkerHealth =
   | {
       ok: true;
       required: boolean;
-      url?: string;
+      lastHeartbeatAt?: string;
     }
   | {
       ok: false;
@@ -23,67 +42,40 @@ export type ProvisioningWorkerHealth =
       error: string;
     };
 
-function readEnvValue(keys: readonly string[]): string | undefined {
-  const env = getCloudAwareEnv();
-  for (const key of keys) {
-    const value = env[key];
-    if (typeof value === "string" && value.trim()) return value.trim();
-  }
-  return undefined;
-}
-
 function isProvisioningWorkerRequired(): boolean {
   const env = getCloudAwareEnv();
   return env.NODE_ENV === "production" || env.REQUIRE_PROVISIONING_WORKER === "true";
 }
 
-function healthUrlFor(baseUrl: string): string {
-  const url = new URL(baseUrl);
-  url.pathname = "/health";
-  url.search = "";
-  return url.toString();
+function getRedis(): CompatibleRedis | null {
+  const env = getCloudAwareEnv() as unknown as RedisFactoryEnv;
+  return buildRedisClient(env);
 }
 
-export async function checkProvisioningWorkerHealth(
-  timeoutMs = 3000,
-): Promise<ProvisioningWorkerHealth> {
+export async function checkProvisioningWorkerHealth(): Promise<ProvisioningWorkerHealth> {
   const required = isProvisioningWorkerRequired();
-  const baseUrl = readEnvValue(CONTROL_PLANE_URL_KEYS);
+  const redis = getRedis();
 
   if (!required) {
-    return { ok: true, required: false, ...(baseUrl ? { url: baseUrl } : {}) };
+    return { ok: true, required: false };
   }
 
-  if (!baseUrl) {
+  if (!redis) {
     return {
       ok: false,
       required: true,
       status: 503,
       code: "PROVISIONING_WORKER_NOT_CONFIGURED",
       error:
-        "Agent provisioning worker is not configured. Set CONTAINER_CONTROL_PLANE_URL before accepting provisioning requests.",
+        "Redis is not configured. Set REDIS_URL or KV_REST_API_URL/KV_REST_API_TOKEN so the provisioning worker can publish heartbeats.",
     };
   }
 
-  const headers = new Headers({ Accept: "application/json" });
-  const token = readEnvValue(["CONTAINER_CONTROL_PLANE_TOKEN"]);
-  if (token) headers.set("x-container-control-plane-token", token);
-
+  let raw: string | null;
   try {
-    const response = await fetch(healthUrlFor(baseUrl), {
-      headers,
-      signal: AbortSignal.timeout(timeoutMs),
-    });
-    if (!response.ok) {
-      return {
-        ok: false,
-        required: true,
-        status: 503,
-        code: "PROVISIONING_WORKER_UNHEALTHY",
-        error: `Agent provisioning worker health check failed with HTTP ${response.status}.`,
-      };
-    }
-    return { ok: true, required, url: baseUrl };
+    raw = (await redis.get(PROVISIONING_WORKER_HEARTBEAT_KEY)) as
+      | string
+      | null;
   } catch (error) {
     return {
       ok: false,
@@ -92,10 +84,23 @@ export async function checkProvisioningWorkerHealth(
       code: "PROVISIONING_WORKER_UNREACHABLE",
       error:
         error instanceof Error
-          ? `Agent provisioning worker is unreachable: ${error.message}`
-          : "Agent provisioning worker is unreachable.",
+          ? `Failed to read provisioning worker heartbeat from Redis: ${error.message}`
+          : "Failed to read provisioning worker heartbeat from Redis.",
     };
   }
+
+  if (!raw) {
+    return {
+      ok: false,
+      required: true,
+      status: 503,
+      code: "PROVISIONING_WORKER_UNHEALTHY",
+      error:
+        "Provisioning worker has not reported a heartbeat in the last 60 seconds.",
+    };
+  }
+
+  return { ok: true, required: true, lastHeartbeatAt: raw };
 }
 
 export function provisioningWorkerFailureBody(
@@ -107,4 +112,23 @@ export function provisioningWorkerFailureBody(
     error: health.error,
     retryable: true,
   };
+}
+
+/**
+ * Called by the provisioning-worker daemon (Bun on the orchestrator VM)
+ * at the start of every poll cycle. Stores `now` in Redis with a 60s
+ * TTL so `checkProvisioningWorkerHealth()` reads a fresh value.
+ *
+ * Returns true if the heartbeat was written; false if Redis is not
+ * configured. Surface failures via the returned promise — the daemon
+ * decides whether to log loudly or swallow.
+ */
+export async function publishProvisioningWorkerHeartbeat(): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+  const timestamp = new Date().toISOString();
+  await redis.set(PROVISIONING_WORKER_HEARTBEAT_KEY, timestamp, {
+    ex: PROVISIONING_WORKER_HEARTBEAT_TTL_S,
+  });
+  return true;
 }

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -317,10 +317,24 @@ async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function publishHeartbeat(logger: WorkerLogger): Promise<void> {
+  try {
+    const { publishProvisioningWorkerHeartbeat } = await import(
+      "@elizaos/cloud-shared/lib/services/provisioning-worker-health"
+    );
+    await publishProvisioningWorkerHeartbeat();
+  } catch (error) {
+    logger.warn("[provisioning-worker] heartbeat publish failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 async function pollCycle(
   logger: WorkerLogger,
   config: ProvisioningWorkerConfig,
 ): Promise<void> {
+  await publishHeartbeat(logger);
   try {
     const result = await processProvisioningWorkerCycle(config.batchSize);
     if (result.claimed > 0 || result.failed > 0) {

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -286,7 +286,10 @@ async function processNodeAutoscaleCycle(): Promise<NodeAutoscaleSummary> {
   // Scale down path. Drain only the first candidate per cycle to avoid
   // draining the whole pool on a single cron tick if multiple nodes show
   // up as idle simultaneously.
-  const target = decision.shouldScaleDownNodeIds[0]!;
+  const target = decision.shouldScaleDownNodeIds[0];
+  if (!target) {
+    return { action: "noop" };
+  }
   try {
     await autoscaler.drainNode(target, { deprovision: true });
     return { action: "scale_down", detail: target };


### PR DESCRIPTION
## Summary

The cloud-api Worker guarded 5 agent routes with a synchronous HTTP probe to a `container-control-plane` sidecar that no longer exists post-cutover. The probe was failing in production with `PROVISIONING_WORKER_NOT_CONFIGURED` / `UNREACHABLE`, so create-agent / resume requests dropped on the floor and left rows stuck in `pending`.

Switch the gate to Redis (already provisioned via Upstash, shared with rate limiting / credit events).

## How it works

- **Daemon** (`packages/scripts/cloud/admin/daemons/provisioning-worker.ts`): publishes `provisioning_worker:health` = ISO timestamp with 60s TTL at the start of every poll cycle.
- **Worker** (`packages/cloud-shared/src/lib/services/provisioning-worker-health.ts`): reads the key on each gated request. Missing/expired → 503 `PROVISIONING_WORKER_UNHEALTHY`. Present → proceed.

Self-healing via TTL: daemon outage trips the gate within 60s, recovery closes it on the next cycle without any manual reconciliation.

## Why this is cleaner

- Removes dependency on a sidecar HTTP service that was never deployed in the post-cutover architecture.
- Reuses the Redis infra already shared by Worker (`KV_REST_API_URL`/`KV_REST_API_TOKEN`) and daemon (`REDIS_URL`).
- Zero new network paths, zero new services to host.
- Symmetric publisher/consumer in the same file so the wire contract is single-source-of-truth.

## Test plan

- [x] Unit tests in `provisioning-worker-health.test.ts` (5/5 pass with `MOCK_REDIS=1`)
- [x] `bun run --cwd packages/cloud-shared typecheck` clean on new files
- [x] `bun run --cwd packages/cloud-api typecheck` clean on new files
- [ ] Post-deploy: create an agent via dashboard → daemon picks up the `agent_provision` job → row goes pending → provisioning → running

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces a synchronous HTTP probe to a now-defunct `container-control-plane` sidecar with a Redis TTL-based heartbeat, unblocking create-agent and resume requests that were failing with `PROVISIONING_WORKER_NOT_CONFIGURED`/`UNREACHABLE`. The self-healing design (60 s TTL, daemon writes at the top of every cycle) means outages are detected and recovered automatically without manual reconciliation.

- **`provisioning-worker-health.ts`**: exports `publishProvisioningWorkerHeartbeat` (daemon-side SET with TTL) and updates `checkProvisioningWorkerHealth` to read the key from Redis instead of making an HTTP call; the existing error-code contract (`NOT_CONFIGURED`, `UNHEALTHY`, `UNREACHABLE`) is preserved.
- **`provisioning-worker.ts`**: adds `publishHeartbeat` called at the start of every `pollCycle`; also fixes a non-null assertion (`!`) on the autoscale scale-down candidate with an explicit null guard.
- **`provisioning-worker-health.test.ts`**: 5 new unit tests covering the unhealthy, healthy, not-required, unconfigured-Redis, and stable-key cases using an in-memory mock Redis.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change removes a broken HTTP sidecar dependency and replaces it with a well-understood Redis TTL pattern already in use across the codebase.

The core logic is correct: the daemon writes an ISO timestamp with a 60 s TTL, the worker reads it, and the existing failure-code contract is unchanged. The null-safety fix on the autoscale scale-down path is a bonus improvement. The only findings are a stale comment on the refresh interval and a test-isolation concern that does not affect production behaviour.

No files require special attention for merging. The test isolation note in provisioning-worker-health.test.ts is worth a follow-up but does not block the change.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cloud-shared/src/lib/services/provisioning-worker-health.ts | Replaces the HTTP sidecar probe with a Redis TTL-based heartbeat; logic is correct and well-structured, with a minor comment inaccuracy on the refresh interval (30 s default vs "~15s" claimed). |
| packages/cloud-shared/src/lib/services/provisioning-worker-health.test.ts | New unit tests cover the five key scenarios; test isolation is fragile because beforeEach/afterEach only clear env vars, not the shared ioredis-mock backing store. |
| packages/scripts/cloud/admin/daemons/provisioning-worker.ts | Adds publishHeartbeat helper that fires at the top of every poll cycle; also fixes a non-null assertion on the autoscale scale-down candidate with an explicit null guard and early return. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant D as Provisioning Daemon
    participant R as Redis (Upstash/KV)
    participant W as Cloud-API Worker
    participant C as Client

    loop Every poll cycle (~30 s)
        D->>R: "SET provisioning_worker:health = ISO timestamp (EX 60)"
        D->>D: processProvisioningWorkerCycle()
        D->>D: processHeartbeatCycle()
    end

    C->>W: POST /create-agent (or resume)
    W->>+R: GET provisioning_worker:health
    alt Key present (daemon alive)
        R-->>W: ISO timestamp
        W-->>C: 200 OK – proceed
    else Key missing or expired
        R-->>W: null
        W-->>C: 503 PROVISIONING_WORKER_UNHEALTHY
    else Redis unreachable
        R-->>W: error
        W-->>C: 502 PROVISIONING_WORKER_UNREACHABLE
    end
```

<sub>Reviews (2): Last reviewed commit: ["chore: appease biome on changed files"](https://github.com/elizaos/eliza/commit/543c9d79e6b6ecf1784a766d6aeece07c7e14bea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33601415)</sub>

<!-- /greptile_comment -->