### PR TITLE
chore(os): aggregate SHA256SUMS across full-release artifacts

### DIFF
--- a/.github/workflows/elizaos-os-full-release.yml
+++ b/.github/workflows/elizaos-os-full-release.yml
@@ -102,6 +102,8 @@ jobs:
     needs: [verify-artifacts]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -175,6 +177,37 @@ jobs:
           name: elizaos-os-release-manifest-published
           path: packages/os/release/beta-2026-05-16/manifest.json
           retention-days: 90
+
+      - name: Generate canonical SHA256SUMS via the in-repo tool
+        # Calls packages/os/scripts/generate-release-checksums.mjs (which
+        # already exists, has unit tests under __tests__, and is the
+        # repo's canonical checksum tool) against the populated manifest
+        # + downloaded artifacts. Produces sha256sum -c compatible output
+        # mirroring the Debian / Fedora / Tails / Arch convention.
+        run: |
+          set -euo pipefail
+          node packages/os/scripts/generate-release-checksums.mjs \
+            --manifest packages/os/release/beta-2026-05-16/manifest.json \
+            --artifact-root ./_artifacts \
+            --output ./_artifacts/SHA256SUMS
+          echo "Generated SHA256SUMS:"
+          cat ./_artifacts/SHA256SUMS
+
+      - name: Upload SHA256SUMS artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: elizaos-release-checksums
+          path: ./_artifacts/SHA256SUMS
+          retention-days: 90
+
+      - name: Attach SHA256SUMS to release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v3
+        with:
+          files: ./_artifacts/SHA256SUMS
+          tag_name: ${{ github.event.release.tag_name || github.ref_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-apt:
     needs: [prepare, trigger-debian-package, verify-artifacts]


### PR DESCRIPTION
## Summary

Wires the existing `packages/os/scripts/generate-release-checksums.mjs`
(which already has unit tests under `__tests__/` and is the repo's
canonical checksum tool) into the `populate-and-validate-manifest`
job so every release ships a single canonical `SHA256SUMS` file
alongside the populated manifest.

The script reads the manifest, finds each artifact under
`--artifact-root` (the same `./_artifacts` directory the job already
populates), computes sha256 of each file, and writes
`sha256sum -c`-compatible output. Mirrors the convention every major
distro (Debian, Fedora, Tails, Arch) ships next to its downloads —
users verify all downloads from one file:

  sha256sum -c SHA256SUMS --ignore-missing

No signing in this PR — that's a separate proposal once the key
strategy is agreed. This change is purely the file format every other
major distro uses.

## Why fold into `populate-and-validate-manifest`?

That job already runs `actions/download-artifact@v8` with
`merge-multiple: true` to populate manifest checksums, so the artifacts
are local on disk for free. A separate job would download them again
(multiple GB per release). The trade-off is one new `permissions:
contents: write` declaration at the job scope.

## Why call the existing script instead of inlining bash?

`packages/os/scripts/generate-release-checksums.mjs` already exists,
has unit tests, and produces the correct format. An earlier draft
of this PR re-implemented its logic in bash (find + sha256sum) but
that duplicated existing functionality and bypassed the manifest-driven
artifact discovery the rest of the workflow uses. Calling the script
keeps SHA256SUMS coverage in lockstep with the manifest.

## Validation

- `actionlint -shellcheck shellcheck .github/workflows/elizaos-os-full-release.yml` → clean
- Ran the script locally against synthetic artifacts that matched the
  filenames in `packages/os/release/beta-2026-05-16/manifest.json`:
  produced a 5-entry `SHA256SUMS` file (header comments + entries) that
  `sha256sum -c --ignore-missing` validated cleanly.

Happy to split, rework, or drop entirely if there's a better mechanism
I missed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires `packages/os/scripts/generate-release-checksums.mjs` into the `populate-and-validate-manifest` job so that every release produces a single `SHA256SUMS` file alongside the populated manifest, avoiding a redundant multi-GB artifact re-download in a separate job.

- Adds `permissions: contents: write` at the job scope so `softprops/action-gh-release@v3` can attach `SHA256SUMS` to the GitHub release; this action is already used across six other workflows in the repo.
- Adds three new steps: generate `SHA256SUMS` via the existing tested script, upload it as a workflow artifact (`elizaos-release-checksums`), and attach it to the GitHub release on `release` events only.
- The new steps run after status is promoted to \"available\" and the manifest artifact is uploaded, so a failure in SHA256SUMS generation leaves the manifest artifact in an inconsistent \"available\" state (minor ordering concern).

<h3>Confidence Score: 4/5</h3>

Safe to merge; the logic is sound and the new action is already used in six other workflows. Two minor issues — step ordering and an unreachable fallback — do not affect correctness under normal release conditions.

The SHA256SUMS generation runs after the manifest is already promoted and uploaded, so a late-stage failure leaves a published 'available' manifest with no SHA256SUMS counterpart. In practice this is unlikely because all artifacts are already proven present by the validation gate, but the ordering leaves a window for inconsistency.

.github/workflows/elizaos-os-full-release.yml — specifically the ordering of the SHA256SUMS steps relative to manifest promotion and upload.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/elizaos-os-full-release.yml | Adds SHA256SUMS generation, upload, and release-attachment steps to the populate-and-validate-manifest job, plus the required contents:write job-level permission; two minor ordering and style issues noted. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Download all release artifacts
to ./_artifacts] --> B[Populate manifest
with real sha256 + sizes]
    B --> C[Gate on publishable checksums
--require-publishable-checksums]
    C -->|pass| D[Promote release status
to 'available']
    C -->|fail| FAIL1[Job fails]
    D --> E[Upload populated manifest
elizaos-release-manifest-published]
    E --> F[Generate SHA256SUMS
generate-release-checksums.mjs]
    F -->|error| FAIL2[Job fails
manifest already uploaded as 'available']
    F -->|success| G[Upload SHA256SUMS artifact
elizaos-release-checksums]
    G --> H{github.event_name
== 'release'?}
    H -->|yes| I[Attach SHA256SUMS to
GitHub release via
softprops/action-gh-release@v3]
    H -->|no| END[Done]
    I --> END
```

<sub>Reviews (1): Last reviewed commit: ["chore(os): aggregate SHA256SUMS across f..."](https://github.com/elizaos/eliza/commit/8277989fd07cc0dc63787692a610b5b3ea06a37b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33614329)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->