### PR TITLE
chore(os): enforce 3 GiB ISO size budget in build-linux-iso

### DIFF
--- a/.github/workflows/build-linux-iso.yml
+++ b/.github/workflows/build-linux-iso.yml
@@ -79,6 +79,12 @@ jobs:
 
       - name: Locate and rename ISO
         id: iso
+        env:
+          # Fail closed if the ISO exceeds this budget. Current amd64 builds
+          # land around 1.9 GB, so 3 GiB leaves ~50% headroom without letting
+          # a silent regression bloat the image. Override via env if a build
+          # intentionally needs more room.
+          ISO_MAX_BYTES: ${{ env.ELIZAOS_ISO_MAX_BYTES || '3221225472' }}
         run: |
           set -euo pipefail
           ISO=$(find "${VARIANT_DIR}/out" -name "elizaos-linux-${{ matrix.arch }}-*.iso" | sort | tail -1)
@@ -89,12 +95,17 @@ jobs:
           DATE=$(date +%Y.%m.%d)
           DEST="elizaos-linux-${CHANNEL}-${DATE}-${{ matrix.arch }}.iso"
           cp "$ISO" "$DEST"
+          SIZE=$(stat --format=%s "$DEST")
+          if [ "$SIZE" -gt "$ISO_MAX_BYTES" ]; then
+            echo "::error::ISO above size budget: ${SIZE} bytes > ${ISO_MAX_BYTES} bytes. Set ELIZAOS_ISO_MAX_BYTES if the increase is intentional."
+            exit 1
+          fi
           sha256sum "$DEST" > "$DEST.sha256"
           {
             echo "path=$DEST"
             echo "filename=$DEST"
             echo "sha256=$(sha256sum "$DEST" | cut -d' ' -f1)"
-            echo "size=$(stat --format=%s "$DEST")"
+            echo "size=$SIZE"
           } >> "$GITHUB_OUTPUT"
 
       - name: Smoke test ISO (headless QEMU, amd64 only)


### PR DESCRIPTION
## Summary

The Linux ISO build prints the artifact size into the step summary but
never asserts a bound, so a silent regression that doubles the image
would still ship. Adds a fail-closed check inside the existing "Locate
and rename ISO" step:

  if SIZE > ISO_MAX_BYTES → ::error:: + exit 1

Default is **3 GiB** (`3221225472` bytes). Current amd64 builds land
around 1.9 GB so this leaves ~50% headroom. The cap is exposed via the
`ELIZAOS_ISO_MAX_BYTES` env var so a build that intentionally needs more
room can bump the budget without editing the workflow.

Drive-by: stores the stat'd size in a local `SIZE` variable instead of
running `stat` twice, so the GITHUB_OUTPUT line uses the cached value.

## Validation

- `actionlint -shellcheck shellcheck .github/workflows/build-linux-iso.yml`
  → clean
- Runtime-tested the size-check logic against synthetic ISO files at
  1.5 GB, 1.9 GB (typical), 3.5 GiB (over), and 3.5 GiB with the env
  override — pass / pass / fail-with-::error:: / pass respectively.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a fail-closed ISO size budget check to the `build-linux-iso` workflow, gating on 3 GiB (`3221225472` bytes) and exposing the limit via an env-override mechanism. It also eliminates a redundant `stat` call by caching the file size in a `SIZE` variable.

- **Size gate**: after copying the ISO to its final name, `stat` is called once, the result is stored in `SIZE`, and the build fails with a `::error::` annotation if `SIZE > ISO_MAX_BYTES`.
- **Cached stat**: `SIZE` is reused for the `GITHUB_OUTPUT` write, replacing the previous second `stat --format=%s` call.

<h3>Confidence Score: 4/5</h3>

The change is narrowly scoped to adding a size gate; the logic is straightforward, but the env-override mechanism documented in the error message cannot be used as implied via GitHub repository variables.

The size-check logic itself is correct and the `stat` caching is a clean improvement. The one gap is that the error message instructs users to 'Set ELIZAOS_ISO_MAX_BYTES' as if it were a repository variable, but `${{ env.ELIZAOS_ISO_MAX_BYTES }}` only resolves workflow-level `env:` values — not GitHub UI repository variables (which require `vars.*`). This means the documented escape hatch doesn't work the way it's described, which could cause confusion if a legitimate larger build needs to override the limit without touching the workflow file.

.github/workflows/build-linux-iso.yml — specifically the `ISO_MAX_BYTES` env expression and the accompanying error message.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-linux-iso.yml | Adds ISO size budget enforcement and caches the `stat` result; the env-override mechanism documented in the error message (`ELIZAOS_ISO_MAX_BYTES`) cannot be set via GitHub repository variables as implied — only via the workflow `env:` block or a prior `$GITHUB_ENV` write — but this has been flagged in a prior review thread. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Build ISO] --> B[Find & copy ISO to DEST]
    B --> C[SIZE = stat DEST]
    C --> D{SIZE > ISO_MAX_BYTES?}
    D -- yes --> E["::error:: annotation\nexit 1"]
    D -- no --> F[sha256sum DEST]
    F --> G[Write GITHUB_OUTPUT\npath / filename / sha256 / size]
    G --> H[Upload artifact / release]
    H --> I[Write step summary]

    style E fill:#ff6b6b,color:#fff
    style D fill:#ffe066
```

<sub>Reviews (2): Last reviewed commit: ["chore(os): enforce 3 GiB ISO size budget..."](https://github.com/elizaos/eliza/commit/2d15ec766d6b7f59a4b2cc6433458536ae0ec708) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33614331)</sub>

<!-- /greptile_comment -->