### PR TITLE
chore(os): tier the ISO boot smoke against real elizaOS service markers

### DIFF
--- a/.github/workflows/build-linux-iso.yml
+++ b/.github/workflows/build-linux-iso.yml
@@ -108,8 +108,23 @@ jobs:
             -enable-kvm -cdrom "${{ steps.iso.outputs.path }}" -boot d \
             -m 2G -smp 2 -display none -vga none \
             -serial "file:$SERIAL_LOG" -no-reboot -nographic 2>/dev/null || true
-          if grep -qi "elizaOS\|eliza\|login:" "$SERIAL_LOG" 2>/dev/null; then
-            echo "ISO smoke test: boot strings found"
+          # Tiered match: a strong signal proves elizaOS-specific services
+          # came up; a generic match proves the kernel/userspace booted but
+          # the agent stack did not (surfaced as a warning so the build
+          # doesn't regress while the issue is investigated).
+          #
+          # Strong regex covers two formats:
+          #   1. Description-based "(Starting|Started) elizaOS <word>..."
+          #      — what modern systemd (v245+, Debian trixie ships v257)
+          #      prints because every elizaos-*.service has
+          #      Description=elizaOS <...>.
+          #   2. Unit-name "elizaos-<name>.service" — appears in service
+          #      exit / failure lines and on older systemd.
+          if grep -qE '(Starting|Started) elizaOS [A-Za-z]|elizaos-(agent|launcher|first-boot|chat-overlay|terminal-tui-smoke)\.service' "$SERIAL_LOG" 2>/dev/null; then
+            echo "ISO smoke test: elizaOS service markers detected"
+          elif grep -qi 'elizaOS\|eliza\|login:' "$SERIAL_LOG" 2>/dev/null; then
+            echo "::warning::Boot reached generic strings but no elizaos-*.service marker detected — verify the agent stack started."
+            echo "ISO smoke test: weak match (boot OK, elizaOS service markers missing)"
           else
             echo "ERROR: boot strings not detected"
             tail -200 "$SERIAL_LOG" || true


### PR DESCRIPTION
## Summary

The current smoke grep matches `elizaOS|eliza|login:` which would pass
on any Debian boot that prints a login prompt. A plain debootstrap with
a hostname containing "eliza" would satisfy it. That's a false-positive
risk for a release gate.

Replace with a tiered check whose STRONG arm covers both the
Description-based output modern systemd (v245+, Debian trixie
ships v257) prints and the unit-name output older systemd uses:

  STRONG — grep for either
             `(Starting|Started) elizaOS <Word>...`
             — what `Description=elizaOS <...>` in every elizaos-*.service
               unit produces on modern systemd
           OR
             `elizaos-{agent,launcher,first-boot,chat-overlay,
              terminal-tui-smoke}.service`
             — what older systemd uses + what appears in service
               exit / failure lines

  WEAK   — fall back to the previous generic grep. Boot happened but
           no elizaOS service marker — emit a `::warning::` and still
           pass so the build does not regress while the issue is
           investigated.

  FAIL   — neither matched: same hard failure as before.

**Strict superset of the old behavior**: anything the old grep passed
still passes (possibly with a warning); anything it failed still
fails. No new failure modes introduced.

## Validation

- `actionlint -shellcheck shellcheck .github/workflows/build-linux-iso.yml`
  → clean
- 15-case table test on the tiered grep, all PASS:
  - 4× unit-name `systemd[1]: Started elizaos-<name>.service` → STRONG
  - 5× Description-form (the actual modern systemd output):
    - `Started elizaOS first-boot bootstrap.` → STRONG
    - `Started elizaOS local agent runtime (system-wide).` → STRONG
    - `Started elizaOS application launcher (home surface).` → STRONG
    - `Starting elizaOS terminal TUI boot smoke...` → STRONG
    - `Started elizaOS global chat overlay.` → STRONG
  - 2× false-positive sanity (must stay WEAK, not be misread as STRONG):
    - bare `Welcome to elizaOS!` (motd) → WEAK
    - `Setting hostname elizaOS.local` → WEAK
  - generic-only (no service marker, just "elizaOS" mention) → WEAK
  - Debian boot strings only → WEAK
  - kernel panic / no boot → HARD_FAIL
  - both strong-and-weak strings present → STRONG (precedence verified)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the ISO boot smoke test from a single `grep` that could pass on any Debian boot with a matching hostname into a three-tier check: a STRONG arm that requires real elizaOS systemd service markers (either the Description-based `Starting|Started elizaOS <word>` form for modern systemd, or the explicit unit-name form for older systemd), a WEAK fallback that mirrors the original grep and emits a `::warning::` instead of failing, and an unchanged HARD FAIL path when nothing matches.

- **Strong arm** covers both the Description-based journal output modern systemd (v245+) produces and the unit-name output used by older systemd and service-failure log lines.
- **Backward-compatible**: every case the old grep accepted still passes (possibly with a warning), so no existing build regressions are introduced.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is limited to a single CI workflow step and is strictly backward-compatible with the existing smoke-test behavior.

The diff touches only the QEMU serial-log grep block in the smoke-test step. The tiered logic is straightforward shell, the strong regex has been manually validated against 15 representative cases (per PR description), and actionlint --shellcheck was reported clean. No runtime code, no data paths, and no external dependencies are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-linux-iso.yml | Replaces single-pass smoke grep with a tiered STRONG/WEAK/FAIL check; logic is correct and shell syntax was validated with actionlint+shellcheck |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[QEMU boot 180s timeout] --> B[SERIAL_LOG written]
    B --> C{Strong grep -E\nDescription-form OR unit-name form}
    C -->|match| D["STRONG: elizaOS service markers detected"]
    C -->|no match| E{Weak grep -qi\nelizaOS or eliza or login colon}
    E -->|match| F["WEAK warning: Boot OK but no service marker"]
    E -->|no match| G["HARD FAIL: exit 1"]
```

<sub>Reviews (2): Last reviewed commit: ["chore(os): tier the ISO boot smoke again..."](https://github.com/elizaos/eliza/commit/efc3a5517b245cf43dfcf909f7513f1f34e9e4bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33614337)</sub>

<!-- /greptile_comment -->