### PR TITLE
chore(deb): actually invoke lintian on the produced .deb

### DIFF
--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -81,6 +81,38 @@ jobs:
           echo "deb_size=$DEB_SIZE" >> "$GITHUB_OUTPUT"
           echo "Found .deb: $DEB ($DEB_SIZE bytes)"
 
+      - name: Lint .deb with lintian
+        # lintian is installed in the "Install Debian build tools" step
+        # above but currently never invoked. Run it on the produced .deb
+        # and surface findings as GitHub annotations. Findings do NOT
+        # fail the build — this is a visibility step, not a gate. A
+        # follow-up PR can flip to fail-on-error once the noise level
+        # is acceptable.
+        if: steps.find_deb.outputs.deb_path != ''
+        run: |
+          set +e
+          lintian -i -I --pedantic "${{ steps.find_deb.outputs.deb_path }}" > lintian.log 2>&1
+          LINTIAN_EXIT=$?
+          set -e
+          while IFS= read -r line; do
+            case "$line" in
+              E:*) echo "::warning::lintian (error): $line" ;;
+              W:*) echo "::warning::lintian (warning): $line" ;;
+              I:*) echo "::notice::lintian (info): $line" ;;
+              P:*) echo "::notice::lintian (pedantic): $line" ;;
+            esac
+          done < lintian.log
+          echo "lintian exit code: $LINTIAN_EXIT (annotations only; not failing build)"
+
+      - name: Upload lintian log
+        if: always() && steps.find_deb.outputs.deb_path != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: elizaos-debian-lintian-log
+          path: lintian.log
+          if-no-files-found: ignore
+          retention-days: 30
+
       - name: Upload .deb artifact
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary

The package step installs `lintian` alongside `dpkg-dev` / `debhelper`
but never runs it. Add a step right after find-and-checksum that runs:

  lintian -i -I --pedantic <deb>

and forwards each finding into a GitHub annotation:

  E:  →  ::warning::lintian (error): ...
  W:  →  ::warning::lintian (warning): ...
  I:  →  ::notice::lintian (info): ...
  P:  →  ::notice::lintian (pedantic): ...

**Annotations only — never fails the build.** A follow-up can flip the
policy to fail-on-error once the noise level is acceptable.

Also uploads the full `lintian.log` as a workflow artifact for forensic
inspection (30 day retention, matches the `.deb` artifact retention).

No new tools installed (lintian is already part of the existing
"Install Debian build tools" step).

## Validation

- `actionlint -shellcheck shellcheck .github/workflows/build-debian-package.yml`
  → clean
- Ran the exact step logic locally against a real `.deb`
  (`tree_2.3.2-1_amd64.deb`, downloaded via `apt-get download`):
  lintian exit 0, summary `E=0 W=0 I=0 P=0`, step exit 0.
- Synthetic test against a fake `lintian.log` with one of each severity
  (E/W/I/P): all four annotation lines emitted correctly, counts match.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `Lint .deb with lintian` step to the Debian package build workflow that runs `lintian -i -I --pedantic` on the produced `.deb`, emits findings as GitHub annotations (never failing the build), and uploads the full `lintian.log` as a 30-day workflow artifact. No new tooling is required since `lintian` was already installed in the existing build-tools step.

- Adds annotation emission for all four lintian severity levels (`E:`, `W:`, `I:`, `P:`) via a `case` loop over `lintian.log`, using `::warning::` / `::notice::` GitHub workflow commands.
- Adds a `Upload lintian log` step with `if-no-files-found: ignore` so a missing log (when `find_deb` produces no path) is handled silently.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change adds a visibility-only lintian step that cannot fail the build and touches no production code paths.

The added steps are strictly additive and annotation-only. The set +e / set -e pattern correctly prevents lintian's exit code from failing the job. The while IFS= read -r loop over lintian.log is correct, and the case patterns accurately match lintian's finding-line prefixes. The upload step's if-no-files-found: ignore safely handles the case where lintian never ran. No production behavior changes.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-debian-package.yml | Adds lintian invocation step with annotation emission and log upload; annotation-only design (no build gate) is consistent with the PR intent and the existing workflow structure. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Install Debian build tools\nlintian installed here] --> B[Build .deb package]
    B --> C[Find and checksum .deb\nid: find_deb]
    C -->|deb_path != ''| D[Lint .deb with lintian\nNEW STEP]
    C -->|deb_path == ''| E[Skip lintian]
    D --> F[set +e\nlintian -i -I --pedantic deb_path\n→ lintian.log\nset -e]
    F --> G[Parse lintian.log\ncase loop]
    G -->|E:*| H[::warning:: lintian error]
    G -->|W:*| I[::warning:: lintian warning]
    G -->|I:*| J[::notice:: lintian info]
    G -->|P:*| K[::notice:: lintian pedantic]
    H & I & J & K --> L[Upload lintian log\nNEW STEP\nalways + deb_path != '']
    L --> M[Upload .deb artifact]
    M --> N[Upload to GitHub Release\non release event]
```

<sub>Reviews (2): Last reviewed commit: ["chore(deb): actually invoke lintian on t..."](https://github.com/elizaos/eliza/commit/2d7dda043bcf352aae4f4af4c7549d3fa16d84b3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33614345)</sub>

<!-- /greptile_comment -->