### PR TITLE
chore(os): mint SLSA build provenance attestation for ISO

### DIFF
--- a/.github/workflows/build-linux-iso.yml
+++ b/.github/workflows/build-linux-iso.yml
@@ -45,6 +45,15 @@ jobs:
     # arm64/riscv64 build under qemu-user-static and have no validated
     # artifact yet — surface failures without blocking the amd64 gate.
     continue-on-error: ${{ matrix.arch != 'amd64' }}
+    permissions:
+      # contents: write covers checkout (read) + the existing
+      #   softprops/action-gh-release release upload (write).
+      # id-token + attestations are required by
+      #   actions/attest-build-provenance@v2 to mint a Sigstore-signed
+      #   SLSA build provenance for the ISO via GitHub OIDC.
+      contents: write
+      id-token: write
+      attestations: write
     env:
       CHANNEL: ${{ inputs.channel || (github.event_name == 'release' && 'stable') || 'nightly' }}
       VARIANT_DIR: packages/os/linux/elizaos
@@ -120,6 +129,18 @@ jobs:
       - name: Smoke test skipped (no KVM or non-amd64)
         if: matrix.arch != 'amd64' || steps.kvm.outputs.have_kvm != 'true'
         run: echo "::notice::Boot smoke test runs only on amd64 with KVM; skipped for ${{ matrix.arch }}."
+
+      - name: Attest SLSA build provenance for ISO
+        # Mints a Sigstore-signed in-toto/SLSA provenance attestation
+        # tied to this repo + workflow + commit, via GitHub OIDC.
+        # No long-lived secrets. Users verify with:
+        #   gh attestation verify <iso-file> --owner elizaOS
+        # Gated on amd64 because that's the only arch with a validated
+        # artifact today — same gate as the QEMU smoke test.
+        if: matrix.arch == 'amd64'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ steps.iso.outputs.path }}
 
       - name: Upload ISO artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

Adds `actions/attest-build-provenance@v2` to the Linux ISO build,
producing a Sigstore-signed in-toto/SLSA provenance attestation that
is automatically stored against the repo via GitHub's attestation API.
Users verify with:

  gh attestation verify elizaos-linux-<channel>-<date>-amd64.iso \
    --owner elizaOS

**Zero new secrets** — uses the GitHub OIDC token already issued to the
workflow. No external trust dependencies beyond the public-good
Sigstore Rekor instance.

Gated on amd64 (same gate as the QEMU smoke test) — arm64 and riscv64
are still `continue-on-error` and have no validated artifact to attest
yet.

The `build-iso` job now declares its own permissions block:
`contents: write` (covers checkout + the existing softprops release
upload), `id-token: write` (OIDC token), `attestations: write` (writes
the attestation). The workflow-level default of `contents: read` is
left intact for any future job that doesn't need write.

## Validation

- `actionlint -shellcheck shellcheck .github/workflows/build-linux-iso.yml`
  → clean
- The action itself cannot be simulated locally (requires the GitHub
  OIDC token), but the YAML / inputs / permissions wiring is the
  documented standard pattern from
  `github.com/actions/attest-build-provenance`.

## Open question for maintainers

The choice of where to put the attestation step is between (a) immediately
after the ISO build (this PR — fastest signal) and (b) after the SBOM
step (so attestation covers both artifacts). Easy to move.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Sigstore-signed SLSA build provenance attestation step to the Linux ISO build workflow using `actions/attest-build-provenance@v2`, keyed on the GitHub OIDC token with no new secrets. It also introduces a job-level permissions block (`contents: write`, `id-token: write`, `attestations: write`) to satisfy the action's requirements.

- The attestation step is gated on `matrix.arch == 'amd64'` and runs after the smoke test, before the artifact upload steps.
- The job-level `contents: write` permission also implicitly enables the existing `softprops/action-gh-release` release-upload step for all matrix legs, not just amd64.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one condition worth resolving: the attestation gate is looser than the smoke-test gate, so an unvalidated ISO can be attested on amd64 runners that lack KVM.

The attestation step fires whenever `matrix.arch == 'amd64'`, but the smoke test that validates the ISO requires the additional `steps.kvm.outputs.have_kvm == 'true'` condition. On a GitHub-hosted runner where KVM is absent, the smoke test is silently skipped while the attestation still runs — producing a cryptographically signed provenance claim for a build that was never actually boot-tested. Depending on how strictly the team wants 'attested == validated,' this gap is worth closing before the feature is relied upon by downstream users.

`.github/workflows/build-linux-iso.yml` — specifically the `if:` condition on the attestation step relative to the smoke-test condition.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-linux-iso.yml | Adds job-level permissions block and SLSA attestation step for amd64 ISO; attestation gate (`matrix.arch == 'amd64'`) is weaker than the smoke-test gate (`&& steps.kvm.outputs.have_kvm == 'true'`), allowing unvalidated artifacts to be attested when KVM is absent. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Runner as GH Runner (matrix)
    participant Docker as Docker Builder
    participant OIDC as GitHub OIDC
    participant Sigstore as Sigstore / Rekor
    participant GHAttest as GitHub Attestation API
    participant Release as GitHub Release

    Runner->>Docker: "make build ARCH=arch"
    Docker-->>Runner: "elizaOS-linux-arch-*.iso"
    Runner->>Runner: Locate and rename ISO
    alt "matrix.arch == 'amd64' and have_kvm == 'true'"
        Runner->>Runner: QEMU smoke test
    end
    alt "matrix.arch == 'amd64'"
        Runner->>OIDC: Request OIDC token
        OIDC-->>Runner: JWT
        Runner->>Sigstore: Sign in-toto/SLSA provenance
        Sigstore-->>Runner: Transparency log entry
        Runner->>GHAttest: Store attestation
    end
    Runner->>Runner: Upload artifact
    opt "publish == true or release event"
        Runner->>Release: Upload ISO + sha256
    end
```

<sub>Reviews (2): Last reviewed commit: ["chore(os): mint SLSA build provenance at..."](https://github.com/elizaos/eliza/commit/7938baba4dd704270b2595f9cb73e186d09fec50) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33614346)</sub>

<!-- /greptile_comment -->