### PR TITLE
chore(deb): mint SLSA build provenance attestation for .deb

### DIFF
--- a/.github/workflows/build-debian-package.yml
+++ b/.github/workflows/build-debian-package.yml
@@ -16,7 +16,14 @@ jobs:
     timeout-minutes: 30
 
     permissions:
+      # contents: write covers the existing softprops/action-gh-release
+      # release upload + checkout.
+      # id-token + attestations are required by
+      # actions/attest-build-provenance@v2 to mint a Sigstore-signed
+      # SLSA build provenance for the .deb via GitHub OIDC.
       contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout
@@ -80,6 +87,16 @@ jobs:
           echo "deb_sha256=$DEB_SHA256" >> "$GITHUB_OUTPUT"
           echo "deb_size=$DEB_SIZE" >> "$GITHUB_OUTPUT"
           echo "Found .deb: $DEB ($DEB_SIZE bytes)"
+
+      - name: Attest SLSA build provenance for .deb
+        # Mints a Sigstore-signed in-toto/SLSA provenance attestation
+        # tied to this repo + workflow + commit, via GitHub OIDC.
+        # No long-lived secrets. Users verify with:
+        #   gh attestation verify <deb-file> --owner elizaOS
+        if: steps.find_deb.outputs.deb_path != ''
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ steps.find_deb.outputs.deb_path }}
 
       - name: Upload .deb artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

Same pattern as the ISO provenance PR, applied to the Debian package
build. Adds `actions/attest-build-provenance@v2` after find-and-checksum
so every produced `.deb` carries a Sigstore-signed SLSA provenance
attestation via GitHub OIDC. Users verify with:

  gh attestation verify <deb-file> --owner elizaOS

**Zero new secrets.** Extends the existing `permissions: contents: write`
block with `id-token: write` and `attestations: write`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Sigstore-signed SLSA build provenance attestation step for the `.deb` artifact by introducing `actions/attest-build-provenance@v2` and extending the job-level permissions with `id-token: write` and `attestations: write`.

- **New attestation step** (line 91–99): runs after `find_deb`, mints an in-toto/SLSA provenance record tied to the repo, workflow, and commit via GitHub OIDC — no long-lived secrets required.
- **Permissions expansion**: `id-token: write` and `attestations: write` are added to the job-level block, correctly scoped alongside the existing `contents: write` needed by `softprops/action-gh-release`.
- **`workflow_call` gap**: the two callers (`release-all.yml`, `elizaos-os-full-release.yml`) only grant `contents: write` / `contents: read` at the workflow level; GitHub requires the calling workflow to also declare `id-token: write` for OIDC token minting in a reusable workflow, so the attestation step will fail on those paths.

<h3>Confidence Score: 3/5</h3>

The attestation step will error out whenever this workflow is invoked via workflow_call, which covers the two main automated release paths in the repo.

Both release-all.yml and elizaos-os-full-release.yml call this workflow as a reusable workflow but neither grants id-token: write or attestations: write to the calling context. GitHub OIDC token minting in a reusable workflow requires the caller to explicitly declare id-token: write; without it the attest-build-provenance step will fail at runtime on every automated release run. Direct triggers (workflow_dispatch, release) are fine.

release-all.yml and elizaos-os-full-release.yml need id-token: write and attestations: write added to their permissions blocks before this attestation step can work on the automated release paths.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-debian-package.yml | Adds SLSA build provenance attestation for the .deb artifact using actions/attest-build-provenance@v2 with new id-token: write and attestations: write job-level permissions, but calling workflows (release-all.yml, elizaos-os-full-release.yml) don't propagate the required OIDC permissions, so attestation will fail when triggered via workflow_call. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as Calling Workflow<br/>(release-all / elizaos-os-full-release)
    participant DEB as build-debian-package.yml
    participant OIDC as GitHub OIDC
    participant Sigstore as Sigstore / Rekor

    Caller->>DEB: workflow_call (permissions: contents only)
    DEB->>DEB: build .deb
    DEB->>DEB: find and checksum .deb
    DEB->>OIDC: request id-token (id-token: write needed)
    Note over OIDC: Fails — caller did not grant id-token: write
    OIDC-->>DEB: error: permission denied
    Note over DEB: attest-build-provenance step fails

    Note over Caller,Sigstore: Direct triggers (workflow_dispatch / release) work fine
    DEB->>OIDC: request id-token
    OIDC-->>DEB: OIDC JWT
    DEB->>Sigstore: sign provenance bundle
    Sigstore-->>DEB: attestation stored
    DEB->>DEB: upload .deb + attestation
```

<sub>Reviews (2): Last reviewed commit: ["chore(deb): mint SLSA build provenance a..."](https://github.com/elizaos/eliza/commit/11c76bb61c1e843d2797b6729075f8937657e0f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33614347)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->