### PR TITLE
chore(vm): mint SLSA build provenance attestation for VM image

### DIFF
--- a/.github/workflows/build-vm-image.yml
+++ b/.github/workflows/build-vm-image.yml
@@ -31,7 +31,14 @@ jobs:
     timeout-minutes: 90
 
     permissions:
+      # contents: write covers the existing softprops/action-gh-release
+      # release upload + checkout.
+      # id-token + attestations are required by
+      # actions/attest-build-provenance@v2 to mint a Sigstore-signed
+      # SLSA build provenance for the .ova via GitHub OIDC.
       contents: write
+      id-token: write
+      attestations: write
 
     steps:
       - name: Checkout
@@ -142,6 +149,18 @@ jobs:
           echo "ova_sha256=$OVA_SHA256" >> "$GITHUB_OUTPUT"
           echo "ova_size=$OVA_SIZE" >> "$GITHUB_OUTPUT"
           echo "date=$DATE" >> "$GITHUB_OUTPUT"
+
+      - name: Attest SLSA build provenance for VM image
+        # Mints a Sigstore-signed in-toto/SLSA provenance attestation
+        # tied to this repo + workflow + commit, via GitHub OIDC.
+        # No long-lived secrets. Users verify with:
+        #   gh attestation verify <ova-file> --owner elizaOS
+        # Only fires when an OVA was actually produced (the convert
+        # step is gated on the format input).
+        if: steps.ova.outputs.ova_path != ''
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ steps.ova.outputs.ova_path }}
 
       - name: Upload VM artifacts
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

Same pattern as the ISO and .deb provenance PRs, applied to the VM
image build. Adds `actions/attest-build-provenance@v2` after the OVA
conversion step so every produced `.ova` carries a Sigstore-signed
SLSA provenance attestation via GitHub OIDC. Users verify with:

  gh attestation verify <ova-file> --owner elizaOS

**Zero new secrets.** Gated on the existing
`steps.ova.outputs.ova_path != ''` check so non-OVA format runs
(qcow2-only, vmdk-only) are skipped cleanly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Sigstore-signed SLSA build provenance attestation step to the VM image build workflow, mirroring the pattern used in other artifact workflows. The new step is correctly gated on OVA output, uses GitHub OIDC (no long-lived secrets), and the required `id-token: write` / `attestations: write` permissions are added at the job level only.

- Added `actions/attest-build-provenance@v2` step after the OVA conversion, gated on `steps.ova.outputs.ova_path != ''` so qcow2-only or vmdk-only runs skip it cleanly.
- `id-token: write` and `attestations: write` permissions added to the `build-vm` job; workflow-level permissions remain `contents: read`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change adds an optional, gated attestation step with no secrets and no effect on the existing build or release paths.

The only change is an additive attestation step and two narrow job-level permissions. The conditional guard correctly handles skipped-step output, OIDC is used instead of long-lived secrets, and the step cannot break the OVA build or the release upload since it runs after conversion and before artifact upload.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-vm-image.yml | Adds SLSA build provenance attestation step for the OVA artifact, plus required `id-token: write` and `attestations: write` job permissions. Conditional logic and permission scoping are correct; version pin is inconsistent with the sibling workflow (already flagged by a prior reviewer). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Workflow triggered\nworkflow_call / workflow_dispatch] --> B[Build VM base image]
    B --> C[Deploy elizaOS to VM]
    C --> D[Run VM integration tests]
    D --> E{format == ova / all / vmdk / ''}
    E -- Yes --> F[Convert to OVA\nstep id: ova]
    E -- No --> G[Skip OVA conversion\nova_path = '']
    F --> H{ova_path != ''}
    G --> H
    H -- Yes --> I[Attest SLSA build provenance\nactions/attest-build-provenance@v2\nSigstore / GitHub OIDC]
    H -- No --> J[Skip attestation]
    I --> K[Upload VM artifacts]
    J --> K
    K --> L{publish == true?}
    L -- Yes --> M[Upload to GitHub Release]
    L -- No --> N[Write summary]
    M --> N
```

<sub>Reviews (2): Last reviewed commit: ["chore(vm): mint SLSA build provenance at..."](https://github.com/elizaos/eliza/commit/f655bddc86371a3618e9110373d234540c1165f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33614349)</sub>

<!-- /greptile_comment -->