### PR TITLE
chore(os): attest SLSA build provenance over SHA256SUMS

### DIFF
--- a/.github/workflows/elizaos-os-full-release.yml
+++ b/.github/workflows/elizaos-os-full-release.yml
@@ -102,6 +102,15 @@ jobs:
     needs: [verify-artifacts]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      # id-token + attestations required by
+      # actions/attest-build-provenance@v2 to mint a Sigstore-signed
+      # SLSA provenance attestation over the SHA256SUMS file via
+      # GitHub OIDC. contents: read is sufficient — this job does not
+      # push to the release directly.
+      contents: read
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -175,6 +184,24 @@ jobs:
           name: elizaos-os-release-manifest-published
           path: packages/os/release/beta-2026-05-16/manifest.json
           retention-days: 90
+
+      - name: Attest SLSA build provenance over SHA256SUMS
+        # Mints a single Sigstore-signed in-toto/SLSA provenance
+        # attestation that covers every release artifact via its hash,
+        # by attesting the canonical SHA256SUMS manifest produced in
+        # the SHA256SUMS-aggregation PR. Users verify with:
+        #
+        #   gh attestation verify SHA256SUMS --owner elizaOS
+        #   gpg --verify SHA256SUMS.asc SHA256SUMS  # once GPG signing lands
+        #   sha256sum -c SHA256SUMS --ignore-missing
+        #
+        # DEPENDENCY: requires the SHA256SUMS-aggregation PR to be
+        # merged first. If this PR lands first, the action errors on
+        # missing subject-path — that's the correct signal that the
+        # PRs were taken out of order.
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ./_artifacts/SHA256SUMS
 
   publish-apt:
     needs: [prepare, trigger-debian-package, verify-artifacts]


### PR DESCRIPTION
## Summary

Adds `actions/attest-build-provenance@v2` in the
`populate-and-validate-manifest` job to mint a single Sigstore-signed
in-toto/SLSA provenance attestation over the canonical `SHA256SUMS`
manifest.

This is the **umbrella attestation**: by signing the `SHA256SUMS` file,
the attestation transitively covers every release artifact via its
hash. Users verify with:

  gh attestation verify SHA256SUMS --owner elizaOS

Combined with per-artifact provenance on the ISO, .deb, and .ova,
reviewers get a single high-level signed manifest that can be
independently verified before any GPG-based signing strategy is
decided.

Job declares `contents: read` + `id-token: write` + `attestations: write`
at job scope. Workflow-level `contents: read` default is left intact for
other jobs.

## DEPENDENCY

**Requires the SHA256SUMS-aggregation PR (`nubs/os-sha256sums-aggregation`)
to land first.** If merged in the wrong order, the action errors on
missing `subject-path: ./_artifacts/SHA256SUMS` — the right failure mode
(loud, clear, doesn't half-publish).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Sigstore-signed SLSA build provenance attestation (`actions/attest-build-provenance@v2`) to the `populate-and-validate-manifest` job, scoped to the canonical `SHA256SUMS` manifest so the attestation transitively covers every release artifact via its hash.

- Adds `id-token: write` and `attestations: write` permissions at job scope, correctly isolating them from other jobs that only need `contents: read`.
- The attestation step is positioned as the final step in the job — after the manifest has already been promoted to `available` and uploaded — which means a failed attestation (e.g., missing SHA256SUMS due to merge-order dependency) does not prevent the `elizaos-os-release-manifest-published` artifact from existing with `status: "available"`.

<h3>Confidence Score: 4/5</h3>

Safe to merge with a step-ordering fix: the attestation step currently runs after manifest promotion and upload, so a failure leaves the artifact in an inconsistent state.

The attestation step is the last thing in the job. If it fails — because the SHA256SUMS file is absent when this PR lands before the aggregation PR — the promoted manifest artifact (`elizaos-os-release-manifest-published`) already exists in the workflow with `status: "available"`. Workflow artifacts survive a job failure, so any downstream process that downloads the manifest will see a release that looks ready but has no corresponding provenance record. Moving the attestation before the promotion/upload steps would close this gap.

.github/workflows/elizaos-os-full-release.yml — specifically the ordering of the attestation step relative to manifest promotion and upload.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/elizaos-os-full-release.yml | Adds SLSA provenance attestation over SHA256SUMS to the populate-and-validate-manifest job, but the step is ordered after manifest promotion and upload, meaning a failed attestation leaves the manifest in an "available" state without a corresponding provenance record. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant VA as verify-artifacts
    participant PAV as populate-and-validate-manifest
    participant GH as GitHub Artifact Store
    participant SIG as Sigstore / GitHub OIDC

    VA->>PAV: job starts (needs: [verify-artifacts])
    PAV->>GH: download-artifact (all, incl. SHA256SUMS if aggregation PR merged)
    PAV->>PAV: populate manifest checksums
    PAV->>PAV: gate on publishable checksums
    PAV->>PAV: promote status → "available"
    PAV->>GH: "upload elizaos-os-release-manifest-published (status=available)"
    Note over PAV,GH: manifest already uploaded here ↑
    PAV->>SIG: "attest-build-provenance@v2 (subject: ./_artifacts/SHA256SUMS)"
    alt SHA256SUMS exists
        SIG-->>PAV: attestation minted and stored
        PAV-->>GH: attestation record written
    else SHA256SUMS missing (aggregation PR not merged)
        SIG-->>PAV: action errors — job fails
        Note over GH: manifest artifact still exists with status=available
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/elizaos-os-full-release.yml`, line 170-204 ([link](https://github.com/elizaos/eliza/blob/b8c46d27c5220cdab336d0075846cb29844e2079/.github/workflows/elizaos-os-full-release.yml#L170-L204)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Attestation placed after manifest promotion — "no half-published manifest" guarantee is broken**

   The attestation step fires as the last step, after "Promote release status to available" (line 170) and "Upload populated manifest" (line 181). If `actions/attest-build-provenance@v2` fails — e.g., because the SHA256SUMS-aggregation PR hasn't landed and `./_artifacts/SHA256SUMS` is missing — the `elizaos-os-release-manifest-published` artifact has already been uploaded with `status: "available"`. Workflow artifacts are retained even when the job subsequently fails, so any downstream consumer polling or downloading that artifact will see a promoted manifest with no corresponding provenance attestation. The step should be moved above "Promote release status to available" so attestation is a hard prerequisite for the `available` state.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["chore(os): attest SLSA build provenance ..."](https://github.com/elizaos/eliza/commit/b8c46d27c5220cdab336d0075846cb29844e2079) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33614350)</sub>

<!-- /greptile_comment -->