### PR TITLE
docs(os-release): add VERIFY.md + verify-release.sh helper

### DIFF
--- a/packages/os/release/VERIFY.md
+++ b/packages/os/release/VERIFY.md
@@ -1,0 +1,135 @@
+# Verifying an elizaOS release
+
+This page documents the verification stack the release pipeline ships
+and how to drive it end-to-end from a download directory.
+
+If you only want one command, run:
+
+```sh
+bash packages/os/scripts/verify-release.sh path/to/your/downloads
+```
+
+That script walks every layer below in order and exits non-zero on the
+first hard failure.
+
+---
+
+## What the release ships
+
+For a published release, the GitHub Release page contains:
+
+| File | What it is | Required? |
+| --- | --- | --- |
+| `*.iso`, `*.deb`, `*.ova`, `*.qcow2` | Release artifacts | yes |
+| `*.sha256` | Per-artifact SHA-256 (legacy convenience) | yes |
+| `SHA256SUMS` | Canonical aggregated checksums file | once landed |
+| `*.spdx.json` | SPDX SBOM (Linux ISO only, today) | once landed |
+| `SHA256SUMS.asc` _(future)_ | Detached GPG signature on `SHA256SUMS` | once the signing-key RFC lands |
+
+Per-artifact GitHub artifact attestations (SLSA build provenance via
+Sigstore) live in GitHub, not the release tarball. Verify them with the
+`gh` CLI as shown below.
+
+## Layer 1 — `SHA256SUMS` roundtrip (REQUIRED)
+
+The cheapest, most universal check. Available on any Unix.
+
+```sh
+cd path/to/your/downloads
+sha256sum -c SHA256SUMS --ignore-missing
+```
+
+Expected output:
+
+```
+elizaos-linux-stable-2026.05.23-amd64.iso: OK
+elizaos_2.0.1_amd64.deb: OK
+elizaos-vm-2026.05.23.ova: OK
+```
+
+If any line says `FAILED`, the artifact has been modified in transit
+(or corrupted). Re-download.
+
+## Layer 2 — GitHub artifact attestations (RECOMMENDED)
+
+Each release artifact (ISO, .deb, .ova) carries a Sigstore-signed SLSA
+build provenance attestation, minted at build time via GitHub OIDC.
+Verify with the [`gh` CLI](https://cli.github.com/):
+
+```sh
+gh attestation verify elizaos-linux-stable-2026.05.23-amd64.iso --owner elizaOS
+gh attestation verify elizaos_2.0.1_amd64.deb                    --owner elizaOS
+gh attestation verify elizaos-vm-2026.05.23.ova                  --owner elizaOS
+gh attestation verify SHA256SUMS                                  --owner elizaOS
+```
+
+Each command will report the signing identity, the workflow that
+produced the artifact, the source commit, and the Sigstore Rekor entry.
+A passing verification means:
+
+- the artifact was built by the elizaOS GitHub repository
+- the build used the workflow source code at the recorded commit
+- the in-toto provenance has not been tampered with since signing
+
+If verification fails or returns "no attestations found", treat the
+download as unverified.
+
+## Layer 3 — GPG signature on `SHA256SUMS` (FUTURE)
+
+Once the [signing-key RFC](https://github.com/elizaOS/eliza) lands,
+each release will additionally ship a detached GPG signature:
+
+```sh
+# Import the elizaOS release key (one-time setup; fingerprint will be
+# published alongside the key once the RFC lands):
+gpg --import packages/os/release/keys/elizaos-release.asc
+
+# Per release:
+gpg --verify SHA256SUMS.asc SHA256SUMS
+```
+
+Until the RFC is resolved, this layer is N/A and the verification
+helper will print a `[--]` notice and skip it.
+
+## Layer 4 — SBOM inspection (OPTIONAL)
+
+Each ISO release ships an SPDX-JSON SBOM enumerating every Debian
+package in the live image. Get a quick package count with:
+
+```sh
+jq '.packages | length' elizaos-linux-stable-2026.05.23-amd64.spdx.json
+```
+
+For vulnerability scanning, feed the SBOM into [Grype](https://github.com/anchore/grype):
+
+```sh
+grype sbom:elizaos-linux-stable-2026.05.23-amd64.spdx.json
+```
+
+## The one-command runner
+
+`packages/os/scripts/verify-release.sh` walks all four layers in order.
+It exits:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | every required check passed (optional layers may have been skipped) |
+| `1` | `SHA256SUMS` missing or roundtrip failed |
+| `2` | an optional layer ran and failed (invalid attestation, bad GPG sig) |
+
+It depends only on coreutils for the required layer. `gh`, `gpg`, and
+`jq` enable the optional layers and produce notices when missing rather
+than failing.
+
+## Reporting verification problems
+
+If you hit a verification failure on a fresh download from an official
+release page, open an issue with:
+
+- the release tag (e.g. `v2.0.1`)
+- the failing layer (1 / 2 / 3 / 4)
+- the exact command output (truncate large logs)
+- whether you mirror-downloaded or pulled directly from GitHub
+
+False positives matter: a confirmed verification failure would be a
+serious supply-chain alert.

--- a/packages/os/scripts/verify-release.sh
+++ b/packages/os/scripts/verify-release.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# elizaOS release verification helper.
+#
+# Walks the layered trust stack that the OS release pipeline ships:
+#
+#   1. SHA256SUMS roundtrip            (required; uses coreutils sha256sum)
+#   2. GitHub artifact attestations    (optional; uses gh CLI)
+#   3. GPG signature on SHA256SUMS     (optional; uses gpg)
+#   4. SBOM summary                    (optional; uses jq)
+#
+# Each optional layer is skipped with a notice if its tool is missing —
+# the script is useful even with only coreutils installed. Every layer
+# runs to completion so the user sees the full picture before the
+# script exits.
+#
+# Usage:
+#   verify-release.sh [DIR]
+#     DIR  Directory containing downloaded release artifacts + SHA256SUMS.
+#          Defaults to the current directory.
+#
+# Exit codes:
+#   0  every required check passed (optional layers may have been
+#      skipped or warned)
+#   1  SHA256SUMS missing or roundtrip failed
+#   2  an optional layer detected real corruption / tampering
+#      (e.g. a mix of valid and invalid attestations, or a bad GPG
+#      signature). Pure-absence does NOT trigger exit 2.
+set -uo pipefail
+
+DIR="${1:-.}"
+cd "$DIR" || { echo "ERROR: cannot enter $DIR" >&2; exit 1; }
+
+note() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+ok()   { printf '\033[1;32m[OK]\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[--]\033[0m %s\n' "$*"; }
+fail() { printf '\033[1;31m[XX]\033[0m %s\n' "$*"; }
+
+EXIT=0
+
+# ---- 1. SHA256SUMS ---------------------------------------------------------
+note "Checking SHA256SUMS"
+if [ ! -f SHA256SUMS ]; then
+  fail "SHA256SUMS not found in $(pwd)"
+  exit 1
+fi
+if sha256sum -c SHA256SUMS --ignore-missing --quiet; then
+  ok "SHA256SUMS roundtrip verified ($(grep -cE '^[a-f0-9]{64}' SHA256SUMS) entries)"
+else
+  fail "SHA256SUMS roundtrip FAILED — re-download required"
+  exit 1
+fi
+
+# ---- 2. GitHub attestations ------------------------------------------------
+if command -v gh >/dev/null 2>&1; then
+  note "Checking GitHub artifact attestations (gh attestation verify)"
+  attest_pass=0
+  attest_fail=0
+  while IFS= read -r line; do
+    case "$line" in '' | '#'*) continue ;; esac
+    file=$(printf '%s\n' "$line" | awk '{print $2}' | sed 's|^\*||')
+    [ -z "$file" ] && continue
+    [ -f "$file" ] || continue
+    if gh attestation verify "$file" --owner elizaOS >/dev/null 2>&1; then
+      ok "attestation valid: $file"
+      attest_pass=$((attest_pass + 1))
+    else
+      fail "attestation NOT verified: $file"
+      attest_fail=$((attest_fail + 1))
+    fi
+  done < SHA256SUMS
+  note "attestations: ${attest_pass} valid, ${attest_fail} not verified"
+  # Classification:
+  #   pass>0, fail>0  : mixed — likely tampering or pipeline issue. Exit 2.
+  #   pass=0, fail>0  : either pre-attestation release OR full-on tampering.
+  #                     Cannot distinguish from this client. Warn, do not
+  #                     exit 2, so users get the rest of the report.
+  #   pass>0, fail=0  : clean.
+  if [ "$attest_pass" -gt 0 ] && [ "$attest_fail" -gt 0 ]; then
+    fail "mixed attestation results — some valid, some not. Investigate."
+    EXIT=2
+  elif [ "$attest_pass" -eq 0 ] && [ "$attest_fail" -gt 0 ]; then
+    warn "no artifact attestations verified. Expected for releases predating attestation rollout; treat as untrusted otherwise."
+  fi
+else
+  warn "skipping GitHub attestation verification (gh CLI not installed)"
+fi
+
+# ---- 3. GPG signature on SHA256SUMS ---------------------------------------
+SIG=""
+[ -f SHA256SUMS.asc ] && SIG=SHA256SUMS.asc
+[ -z "$SIG" ] && [ -f SHA256SUMS.sig ] && SIG=SHA256SUMS.sig
+if [ -n "$SIG" ]; then
+  if command -v gpg >/dev/null 2>&1; then
+    note "Checking GPG signature on SHA256SUMS"
+    if gpg --verify "$SIG" SHA256SUMS 2>&1 | grep -q "Good signature"; then
+      ok "GPG signature verified"
+    else
+      fail "GPG signature FAILED — output:"
+      gpg --verify "$SIG" SHA256SUMS 2>&1 | sed 's/^/    /'
+      EXIT=2
+    fi
+  else
+    warn "${SIG} present but gpg is not installed; skipping"
+  fi
+else
+  warn "no SHA256SUMS.asc or .sig found; skipping GPG verification (release may not be GPG-signed yet)"
+fi
+
+# ---- 4. SBOM summary -------------------------------------------------------
+shopt -s nullglob
+sboms=( *.spdx.json )
+shopt -u nullglob
+if [ "${#sboms[@]}" -gt 0 ]; then
+  if command -v jq >/dev/null 2>&1; then
+    note "SBOM summary (jq)"
+    for sbom in "${sboms[@]}"; do
+      count=$(jq '.packages | length' "$sbom" 2>/dev/null || echo "?")
+      ok "${sbom}: ${count} packages"
+    done
+  else
+    warn "${#sboms[@]} SBOM file(s) found but jq is not installed; skipping package count"
+  fi
+else
+  warn "no .spdx.json SBOM found in $(pwd); skipping SBOM summary"
+fi
+
+note "Verification complete."
+exit "$EXIT"


### PR DESCRIPTION
## Summary

Ships a layered release verification helper that complements the
in-progress signing / attestation / SBOM work:

- `packages/os/release/VERIFY.md` — user-facing verification doc
- `packages/os/scripts/verify-release.sh` — one-command runner

The script walks four layers in order against a downloaded release dir:

1. `SHA256SUMS` roundtrip            — required (coreutils only)
2. GitHub artifact attestations      — optional (gh CLI)
3. GPG signature on `SHA256SUMS`     — optional (gpg)
4. SBOM summary                      — optional (jq)

Each optional layer is **skipped with a notice** when its tool is
missing, so the script is useful out of the box on any Unix.

## Exit codes

| Code | Meaning |
| --- | --- |
| `0` | every required check passed (optional layers may have been skipped or warned) |
| `1` | SHA256SUMS missing or roundtrip failed |
| `2` | an optional layer detected real corruption / tampering (mixed valid+invalid attestations, or a bad GPG sig). Pure absence is NOT treated as tampering. |

## Validation

- `shellcheck packages/os/scripts/verify-release.sh` → clean
- 5-case test matrix:
  1. **clean dir** → exit 0 (SHA256SUMS OK; attestations not yet
     rolled out so warned, not failed)
  2. **corrupted artifact** → exit 1 with SHA256SUMS `FAILED` line
  3. **missing SHA256SUMS** → exit 1
  4. **bad GPG sig file** → exit 2 with `gpg --verify` failure printed
  5. **SHA256SUMS with header comments** (mirrors the format produced
     by the in-repo `generate-release-checksums.mjs` script) → exit 0;
     comment lines correctly tolerated by `sha256sum -c`

## Open questions

- The script defaults to `--owner elizaOS` for `gh attestation verify`.
  If the org name moves, that's a one-line change.
- The "no attestations verified" case is treated as a warning, not a
  failure, so users running this against pre-attestation releases get
  a clean exit. Once attestation rollout is universal, this could be
  tightened to fail-closed.
- VERIFY.md references the future `SHA256SUMS.asc` GPG flow. If the
  signing-key RFC lands a different path (e.g. cosign-only), the doc
  needs a minor edit.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships two new files that add a layered release-verification helper for elizaOS OS packages: a user-facing `VERIFY.md` guide and a `verify-release.sh` script that walks SHA256SUMS integrity, GitHub artifact attestations, GPG signature, and SBOM inspection in order.

- **`verify-release.sh`** — drives all four layers, uses `EXIT` accumulation so optional-layer failures don't short-circuit the report, and exits 0/1/2 based on required vs. optional layer outcomes.
- **`VERIFY.md`** — documents each layer with manual commands and maps exit codes; references a future GPG signing-key RFC and future SBOM/attestation rollout.

<h3>Confidence Score: 3/5</h3>

Safe to land as documentation/tooling, but logic gaps in the attestation loop and GPG check mean the script can report a clean result when no artifacts were actually verified.

The attestation loop silently produces '0 valid, 0 not verified' with no warning when all referenced artifact files are absent from disk. Combined with the already-flagged --ignore-missing Layer 1 pass, a directory containing only SHA256SUMS and no artifacts receives a clean report from both layers without a single file being checked. The GPG check also uses locale-dependent grep instead of the gpg exit code.

packages/os/scripts/verify-release.sh — the attestation result classification logic (lines 78–83) and the GPG check (line 95) both need attention before the script can be relied upon for release verification.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/os/scripts/verify-release.sh | New 4-layer verification script; attestation loop has a silent 0/0 edge case (no files on disk), the GPG check uses locale-dependent grep rather than gpg exit code, and Layer 1 passes with --ignore-missing when no artifacts are present. |
| packages/os/release/VERIFY.md | New user-facing verification guide; Layer 1 description claims sha256sum --ignore-missing works on any Unix (GNU coreutils only), and Layer 2 manual example includes SHA256SUMS itself which the automated script does not attest. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(os-release): add VERIFY.md + verify..."](https://github.com/elizaos/eliza/commit/f97d565c1ea48966c47b2de38122c47a76a27188) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33614352)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->