### PR TITLE
fix(core): bound runaway tool-arg validation loops + align stale planner-loop test

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
@@ -142,9 +142,12 @@ describe("planner-loop — user-facing tool text isolation", () => {
 		expect(result.finalMessage ?? "").not.toContain("[exit 0]");
 	});
 
-	it("does not regress evaluator's explicit messageToUser path", async () => {
-		// When evaluator provides a clean messageToUser, the tool's
-		// userFacingText is not even consulted — the evaluator wins.
+	it("uses evaluator messageToUser when the tool did not produce user-facing output", async () => {
+		// When the tool only emits an internal log (no userFacingText), the
+		// evaluator's explicit messageToUser is the authoritative reply.
+		// Note: this complements `prefers a single tool's verified user-facing
+		// text over evaluator paraphrase` in planner-happy-path.test.ts — tools
+		// that DO produce verified user-facing text win over evaluator paraphrase.
 		const evaluatorMessage = "All three counters reset to zero.";
 		const runtime = {
 			useModel: vi
@@ -167,7 +170,7 @@ describe("planner-loop — user-facing tool text isolation", () => {
 		const executeToolCall = vi.fn(async () => ({
 			success: true,
 			text: "internal log",
-			userFacingText: "tool would also have something to say",
+			// No userFacingText — tool is log-only, evaluator must speak for the user.
 		}));
 		const evaluate = vi.fn(async () => ({
 			success: true,

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -862,6 +862,79 @@ describe("v5 planner loop skeleton", () => {
 		);
 	});
 
+	it("collapses repeated parameter-validation failures on the same tool even when args vary", async () => {
+		// Regression for runaway loops where the model retries a single
+		// tool repeatedly with shifting argument shapes that every time
+		// fail `validateToolArgs`. Without canonical signing of these
+		// validation failures, the repeatKey + error message both diverge
+		// per call and `maxRepeatedFailures` never trips. Observed live as
+		// a 27-iteration runaway against TASKS where the model alternated
+		// between `action=spawn_agent` / `action=create` / `action=update`
+		// with the same set of unrecognized arguments.
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "call-1",
+							name: "TASKS",
+							arguments: { action: "spawn_agent", task: "build a site" },
+						},
+					],
+				})
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "call-2",
+							name: "TASKS",
+							arguments: { action: "create", task: "build a site" },
+						},
+					],
+				})
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "call-3",
+							name: "TASKS",
+							arguments: { action: "update", task: "build a site" },
+						},
+					],
+				}),
+		};
+		let callCount = 0;
+		const executeToolCall = vi.fn(async () => {
+			callCount++;
+			return {
+				success: false,
+				error: `Unexpected argument 'task'; action value '${callCount}' rejected`,
+				data: {
+					parameterErrors: ["Unexpected argument 'task'", "action not in enum"],
+				},
+			};
+		});
+		const evaluate = vi.fn(async () => ({
+			success: false,
+			decision: "CONTINUE" as const,
+			thought: "Retry with a different action.",
+		}));
+
+		await expect(
+			runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				config: { maxRepeatedFailures: 1 },
+				executeToolCall,
+				evaluate,
+			}),
+		).rejects.toBeInstanceOf(TrajectoryLimitExceeded);
+		// Loop must bail on the second validation rejection, not run forever.
+		expect(executeToolCall.mock.calls.length).toBeLessThanOrEqual(2);
+	});
+
 	it("compacts old assistant/tool suffixes when the planner input crosses the budget threshold", async () => {
 		const capturedMessages: ChatMessage[][] = [];
 		const longPayload = `generated file content: ${"x".repeat(20_000)}`;

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -1742,11 +1742,28 @@ async function executeQueuedToolCall(params: {
 	}
 	const endedAt = Date.now();
 
+	// Parameter-validation rejections from `validateToolArgs` set
+	// `result.data.parameterErrors`. A model that keeps the same tool but
+	// shuffles its argument shape across retries (e.g. trying `action=create`
+	// then `action=spawn_agent` then `action=update`) varies both the error
+	// string and the params JSON, so the per-call repeatKey + per-call error
+	// message both diverge and `assertRepeatedFailureLimit` never trips —
+	// even though the failure category is identical and the model is just
+	// hunting for a valid arg shape that does not exist on this action.
+	// Collapse parameter-validation failures of a tool to a single canonical
+	// signature so the existing repeated-failure guard catches that pattern.
+	const isParameterValidationFailure = Array.isArray(
+		(result.data as { parameterErrors?: unknown } | undefined)?.parameterErrors,
+	);
 	const failure = {
 		toolName: params.toolCall.name,
 		success: result.success,
-		error: result.error,
-		repeatKey: toolFailureRepeatKey(params.toolCall),
+		error: isParameterValidationFailure
+			? "parameter_validation_failed"
+			: result.error,
+		repeatKey: isParameterValidationFailure
+			? "parameter_validation"
+			: toolFailureRepeatKey(params.toolCall),
 	};
 	if (!result.success || result.error != null) {
 		params.failures.push(failure);


### PR DESCRIPTION
## Summary

Two related fixes to `runPlannerLoop` surfaced by a deep-scan of production trajectories on a downstream deployment.

1. **`test(core): align stale planner-loop regression with current precedence`** — repairs a stale unit test on `develop` that contradicts the intentional precedence flip from commit `4ba5130529` ("preserve single-tool user-facing output"). The test set both tool `userFacingText` *and* evaluator `messageToUser` then asserted the evaluator won; the new precedence in `preferredFinalMessageFromToolOrModel` deliberately prefers tool ground-truth over evaluator paraphrase (protected by the live test in `planner-happy-path.test.ts`: `prefers a single tool's verified user-facing text over evaluator paraphrase`). The fix updates the stale regression so it still verifies its actual intent — the evaluator-only path when the tool emits no user-facing output.

2. **`fix(core): bound runaway tool-arg validation loops via canonical failure signature`** — prevents the framework's `maxRepeatedFailures` guard from being silently defeated when a model retries the same tool with shifting argument shapes that each fail `validateToolArgs`. The per-call repeatKey (toolName + `JSON.stringify(params)`) and the per-call error message both diverge across attempts, so the existing failure-deduplication treats each as a fresh failure even though the failure category is identical and no valid arg shape exists.

## Evidence

Production trajectory observed in a downstream deployment, replicated from a live agent run:

```
trajectory id        tj-95869490c7a2b2
status               errored (never reached terminal)
plannerIterations    27
toolCallsExecuted    25
toolCallFailures     25  (every tool call failed validation)
evaluatorFailures    16
totalCostUsd         $1.30
finalDecision        CONTINUE
```

Root cause: Stage 1 invoked `TASKS` with `action=spawn_agent` (plus `task`, `agentType`, `workdir`, `keepAliveAfterComplete`). The `SCHEDULED_TASKS` action rejected the invocation:

```
"Unexpected argument 'task'; Unexpected argument 'agentType'; Unexpected argument 'workdir';
 Unexpected argument 'keepAliveAfterComplete';
 Argument 'action' value 'spawn_agent' is not one of: list, get, create, update, snooze, skip,
 complete, acknowledge, dismiss, cancel, reopen, history"
```

The model then cycled through `action=create` / `action=update` / `action=spawn_agent` etc. for 27 iterations, each call failing validation with a slightly different parameterErrors message, until token budget exhausted. `assertRepeatedFailureLimit` never fired because the per-call signatures all differed.

The fix collapses parameter-validation failures of a tool to a canonical signature so two consecutive validation rejections on the same tool now correctly hit `maxRepeatedFailures` (default 2) and `TrajectoryLimitExceeded({kind: "repeated_failures"})` fires — saving compute, API cost, and time.

## Behavior preserved

The existing test `does not count different failed tool parameters as the same repeated failure` still passes — failures whose `result.data` does NOT carry `parameterErrors` (runtime errors, timeouts, downstream service failures) keep the per-call repeatKey, so legitimate distinct retries against the same tool still register as distinct attempts. Only the parameter-validation category collapses.

## Validation

- `bunx @biomejs/biome check --write` — clean
- `bun vitest run` in `packages/core` — **165 test files, 1363 tests pass, 11 skipped, 0 failures** (up from 1361 on `develop` because both commits add `+1` passing test each and the previously-broken `does not regress evaluator's explicit messageToUser path` now passes)
- `bun run typecheck` — clean
- `bun run build` — clean
- New regression `collapses repeated parameter-validation failures on the same tool even when args vary` reproduces the runaway shape and asserts the loop bails inside the configured limit.

## Commits

1. `48b2deb7e0` — `test(core): align stale planner-loop regression with current precedence`
2. `48d530287f` — `fix(core): bound runaway tool-arg validation loops via canonical failure signature`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers two targeted fixes to `runPlannerLoop`: it repairs a stale unit test whose expectations contradicted an existing precedence rule (tool `userFacingText` beats evaluator `messageToUser`), and it patches a gap in the repeated-failure guard that allowed a model stuck on parameter-validation errors to run indefinitely.

- **Test alignment (`planner-loop-user-facing-text.test.ts`)**: The test was asserting that the evaluator wins when the tool *also* emits `userFacingText`, which contradicts the existing `preferredFinalMessageFromToolOrModel` logic. The fix removes `userFacingText` from the mock so the test now covers only the evaluator-only path it was originally meant to exercise.
- **Runaway-loop fix (`planner-loop.ts`)**: Parameter-validation failures now collapse to a canonical `repeatKey` and `error` string per tool, so `assertRepeatedFailureLimit` correctly triggers after `maxRepeatedFailures` consecutive validation rejections even when the model retries with different argument shapes.
- **New regression test (`planner-loop.test.ts`)**: Reproduces the production trajectory (TASKS tool, shifting `action` values, all rejected by `validateToolArgs`) and asserts the loop throws `TrajectoryLimitExceeded` within the configured limit.

<h3>Confidence Score: 4/5</h3>

The production fix is safe to merge; the canonical-signature approach is well-scoped and the guard logic in assertRepeatedFailureLimit is unchanged.

The loop-collapse logic is correct for the documented case, but isParameterValidationFailure does not check result.success, so a tool returning success: true with a non-empty parameterErrors field would have its failures incorrectly canonicalized. This is an unlikely scenario in the current codebase but leaves an unguarded path worth closing.

The isParameterValidationFailure check in planner-loop.ts around line 1755 is the only spot that benefits from a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/planner-loop.ts | Adds canonical failure signature for parameter-validation errors to prevent runaway retry loops; logic is sound but `isParameterValidationFailure` does not guard against `result.success === true` edge case. |
| packages/core/src/runtime/__tests__/planner-loop.test.ts | Adds regression test that reproduces the 27-iteration runaway trajectory and asserts the loop bails after two validation failures; well-structured and covers the exact production failure mode. |
| packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts | Repairs a stale test that was asserting evaluator-wins precedence contradicting the existing implementation; fix correctly narrows the test to the evaluator-only path (no tool userFacingText). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[executeQueuedToolCall] --> B{parameterErrors present in result.data?}
    B -- Yes --> C[Canonical signing]
    B -- No --> D[Per-call signing]
    C --> E[error set to fixed string, repeatKey set to fixed string]
    D --> F[error from result, repeatKey from toolName plus params JSON]
    E --> G{Failure condition?}
    F --> G
    G -- No --> H[No failure recorded]
    G -- Yes --> I[Push to failures list]
    I --> J[assertRepeatedFailureLimit check]
    J --> K{Count exceeds max?}
    K -- No --> L[Loop continues normally]
    K -- Yes --> M[TrajectoryLimitExceeded thrown]
```

<sub>Reviews (1): Last reviewed commit: ["fix(core): bound runaway tool-arg valida..."](https://github.com/elizaos/eliza/commit/48d530287fe08e58157a6d557cad971f74ca0762) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33622280)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->