### PR TITLE
fix(core): preserve speaker context + prevent Stage 1 phantom action claims

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -411,6 +411,120 @@ describe("runV5MessageRuntimeStage1", () => {
 		}
 	});
 
+	it("routes short chat-entity identity lookups through recall instead of simple guessing", async () => {
+		const runtime = makeRuntime([
+			JSON.stringify({
+				processMessage: "RESPOND",
+				plan: {
+					contexts: ["simple"],
+					reply: "Queuebot is just the same assistant you've seen before.",
+					simple: true,
+					requiresTool: false,
+				},
+				extract: {
+					facts: [],
+					relationships: [],
+					addressedTo: [],
+				},
+			}),
+			JSON.stringify({
+				thought: "Identity lookup should be grounded in recalled chat context.",
+				toolCalls: [],
+				messageToUser:
+					"I don't have enough recalled chat context to identify queuebot.",
+			}),
+		]);
+		runtime.actions = [
+			{
+				name: "MESSAGE",
+				contexts: ["messaging", "memory"],
+				description: "Search and inspect stored conversation messages.",
+				validate: async () => true,
+				handler: async () => ({ success: true }),
+			},
+		] as never;
+		runtime.composeState = vi.fn(async () => ({
+			values: { availableContexts: "simple, general, memory, messaging" },
+			data: {
+				providers: {
+					RECENT_MESSAGES: {
+						text: "# Conversation Messages\nrecent provider text",
+						providerName: "RECENT_MESSAGES",
+					},
+				},
+			},
+			text: "",
+		})) as never;
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: [
+					"[Recent channel context]",
+					"e2e: queuebot came up earlier in the channel.",
+					"",
+					"[Discord #general | NUBot test server] @e2e (Sat 05/23/2026 10:25 UTC): assistant (@1490833425802854491) who is queuebot?",
+				].join("\n"),
+				source: "discord",
+			}),
+			state: {
+				values: { availableContexts: "simple, general, memory, messaging" },
+				data: {},
+				text: "",
+			},
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("planned_reply");
+		const plannerCall = useModelCalls(runtime)[1]?.[1] as {
+			messages?: Array<{ role?: string; content?: string | null }>;
+		};
+		const plannerUserContent = plannerCall.messages?.[1]?.content ?? "";
+		expect(plannerUserContent).toContain("identity_lookup_policy");
+		expect(plannerUserContent).toContain('"candidateActions":["MESSAGE"]');
+		expect(plannerUserContent).toContain("routing through recall context");
+		expect(plannerUserContent).not.toContain(
+			"Queuebot is just the same assistant",
+		);
+		if (result.kind === "planned_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"I don't have enough recalled chat context to identify queuebot.",
+			);
+		}
+	});
+
+	it("does not reroute ordinary public identity questions through recall", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "Barack Obama is a former U.S. president.",
+				extra: { requiresTool: false },
+			}),
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: "assistant (@1490833425802854491) who is obama?",
+				source: "discord",
+			}),
+			state: {
+				values: { availableContexts: "simple, general, memory, messaging" },
+				data: {},
+				text: "",
+			},
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"Barack Obama is a former U.S. president.",
+			);
+		}
+		expect(useModelCalls(runtime)).toHaveLength(1);
+	});
+
 	it("does not treat the agent's own attachment ack as a user follow-up anchor", async () => {
 		const runtime = makeRuntime([
 			stage1Response({

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -2100,6 +2100,98 @@ android smoke model works`,
 		);
 	});
 
+	it("keeps speaker names on structured prior dialogue", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "I see the prior chat context.",
+				extra: { requiresTool: false },
+			}),
+		]);
+		const state: State = {
+			values: {
+				availableContexts: "simple, general",
+			},
+			data: {
+				providers: {
+					RECENT_MESSAGES: {
+						text: "# Conversation Messages\nprovider text should not render",
+						data: {
+							recentMessages: [
+								{
+									id: "00000000-0000-0000-0000-00000000bb01" as UUID,
+									entityId: "00000000-0000-0000-0000-00000000bb11" as UUID,
+									agentId: runtime.agentId,
+									roomId: "00000000-0000-0000-0000-000000001111" as UUID,
+									createdAt: 1,
+									content: {
+										text: "Hey, nice to meet shebotdick.",
+										source: "discord",
+									},
+									metadata: {
+										type: "message",
+										sender: {
+											id: "discord-botdick",
+											name: "botdick",
+											username: "botdick",
+										},
+									},
+								},
+								{
+									id: "00000000-0000-0000-0000-00000000bb02" as UUID,
+									entityId: "00000000-0000-0000-0000-00000000bb12" as UUID,
+									agentId: runtime.agentId,
+									roomId: "00000000-0000-0000-0000-000000001111" as UUID,
+									createdAt: 2,
+									content: {
+										text: "i was asking about shedick",
+										source: "discord",
+									},
+									metadata: {
+										type: "message",
+										sender: {
+											id: "discord-1gig",
+											name: "1gig",
+											username: "1gig",
+										},
+									},
+								},
+							],
+						},
+						providerName: "RECENT_MESSAGES",
+					},
+				},
+			},
+			text: "fallback text should not be needed",
+		};
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: "whats the compatibility between her and botdick",
+			}),
+			state,
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		const firstCall = useModelCalls(runtime)[0];
+		const params = firstCall?.[1] as {
+			messages?: Array<{ role?: string; content?: string | null }>;
+		};
+		const userContent = params.messages?.[1]?.content ?? "";
+		expect(userContent).not.toContain("# Conversation Messages");
+		expect(userContent).not.toContain("provider text should not render");
+		expect(userContent).toContain(
+			"prior_message:user:\nbotdick: Hey, nice to meet shebotdick.",
+		);
+		expect(userContent).toContain(
+			"prior_message:user:\n1gig: i was asking about shedick",
+		);
+		expect(userContent).toContain(
+			"message:user:\nwhats the compatibility between her and botdick",
+		);
+	});
+
 	it("recomposes planner state with selected context providers but excludes catalogs", async () => {
 		const runtime = makeRuntime([
 			stage1Response({

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -2936,4 +2936,33 @@ android smoke model works`,
 		});
 		expect(runtime.useModel).toHaveBeenCalledTimes(1);
 	});
+
+	it("renders direct-message instructions that forbid ungrounded simple replies and phantom action claims", async () => {
+		const runtime = makeRuntime([
+			stage1Response({
+				contexts: ["simple"],
+				replyText: "Hi.",
+			}),
+		]);
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({ channelType: ChannelType.DM }),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		const firstCall = useModelCalls(runtime)[0];
+		const params = firstCall?.[1] as {
+			messages?: Array<{ role?: string; content?: string | null }>;
+		};
+		const systemContent =
+			params.messages?.find((m) => m.role === "system")?.content ?? "";
+		expect(systemContent).toContain(
+			'Only use "simple" when you can answer directly from your static knowledge or the visible prior_message / reply_reference context.',
+		);
+		expect(systemContent).toContain(
+			"Never write replyText that claims you have searched, scanned, checked, looked up, recalled, or remembered anything unless an actual tool call this turn returned that content.",
+		);
+	});
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2724,6 +2724,44 @@ const BUILTIN_RESPONSE_HANDLER_EVALUATORS: readonly ResponseHandlerEvaluator[] =
 				],
 			}),
 		},
+		{
+			name: "core.contextual_identity_lookup_requires_recall",
+			description:
+				"Routes short chat-entity identity lookups through memory/messaging instead of letting Stage 1 guess from the simple shortcut.",
+			priority: 20,
+			shouldRun: ({ message, messageHandler }) =>
+				!isSubAgentCompletionArtifact(message) &&
+				isSimpleMessageHandlerShortcut(messageHandler) &&
+				extractContextualIdentityLookupSubject(
+					getUserMessageText(message) ?? "",
+				) !== null,
+			evaluate: ({ runtime, message }) => {
+				const subject = extractContextualIdentityLookupSubject(
+					getUserMessageText(message) ?? "",
+				);
+				const messageAction = findRuntimeActionByNames(runtime, ["MESSAGE"]);
+				return {
+					setContexts: ["general", "memory", "messaging"],
+					...(messageAction
+						? {
+								addCandidateActions: [messageAction.name],
+							}
+						: {}),
+					clearReply: true,
+					addContextSlices: [
+						[
+							"identity_lookup_policy:",
+							`The current user is asking who/what "${subject ?? "the named subject"}" is in context.`,
+							"Ground the answer in recent messages, memory, or message-search results before identifying the subject.",
+							"If recalled context does not identify a chat-local subject, say that plainly instead of inventing a relationship; only use public knowledge when the subject is clearly a public entity.",
+						].join("\n"),
+					],
+					debug: [
+						`short identity lookup for "${subject ?? "unknown"}"; routing through recall context before answering`,
+					],
+				};
+			},
+		},
 	];
 
 /**
@@ -3488,6 +3526,122 @@ function looksLikeCompleteDirectReply(replyText: string): boolean {
 	return (
 		/[.!?。！？]$/u.test(normalized) || normalized.split(/\s+/u).length >= 8
 	);
+}
+
+function isSimpleMessageHandlerShortcut(
+	messageHandler: MessageHandlerResult,
+): boolean {
+	if (messageHandler.processMessage !== "RESPOND") return false;
+	if (messageHandler.plan.requiresTool === true) return false;
+	const contexts = messageHandler.plan.contexts ?? [];
+	const nonSimpleContexts = contexts.filter(
+		(context) => context !== SIMPLE_CONTEXT_ID,
+	);
+	return (
+		nonSimpleContexts.length === 0 &&
+		(messageHandler.plan.candidateActions?.length ?? 0) === 0
+	);
+}
+
+const CONTEXTUAL_IDENTITY_LOOKUP_PREFIXES = [
+	"who is ",
+	"who are ",
+	"who was ",
+	"who were ",
+	"who's ",
+	"whos ",
+	"what is ",
+	"what was ",
+	"what's ",
+	"whats ",
+	"tell me about ",
+	"do you know ",
+	"do you remember ",
+	"what do you know about ",
+] as const;
+
+const CONTEXTUAL_IDENTITY_PRONOUN_SUBJECTS = new Set([
+	"he",
+	"her",
+	"him",
+	"i",
+	"it",
+	"me",
+	"she",
+	"that",
+	"them",
+	"they",
+	"this",
+	"us",
+	"we",
+	"you",
+]);
+
+function removeLeadingPlatformAddress(text: string): string {
+	let cleaned = text
+		.replace(/<@!?\d+>/gu, " ")
+		.replace(/\s+/gu, " ")
+		.trim();
+	const displayAddressRe = /(?:^|[\s:])[^:\n]{0,96}\(@\d+\)\s+/gu;
+	let displayAddressEnd = -1;
+	for (
+		let displayAddressMatch = displayAddressRe.exec(cleaned);
+		displayAddressMatch !== null;
+		displayAddressMatch = displayAddressRe.exec(cleaned)
+	) {
+		displayAddressEnd = displayAddressRe.lastIndex;
+	}
+	if (displayAddressEnd > 0) {
+		cleaned = cleaned.slice(displayAddressEnd).trim();
+	}
+	return cleaned;
+}
+
+function cleanContextualLookupSubject(subject: string): string {
+	return subject
+		.replace(/[\s?.!]+$/gu, "")
+		.replace(/^["'`“”‘’]+|["'`“”‘’]+$/gu, "")
+		.replace(
+			/\s+(?:in|from|on)\s+(?:this\s+)?(?:chat|channel|thread|server)$/iu,
+			"",
+		)
+		.trim();
+}
+
+function isShortContextualLookupSubject(subject: string): boolean {
+	const normalized = subject.toLowerCase();
+	if (!normalized || CONTEXTUAL_IDENTITY_PRONOUN_SUBJECTS.has(normalized)) {
+		return false;
+	}
+	const words = normalized.split(/\s+/u).filter(Boolean);
+	if (words.length === 0 || words.length > 3) return false;
+	if (subject.length > 48) return false;
+	if (/^[0-9\s.,:+*/=()-]+$/u.test(subject)) return false;
+	const looksLikeLocalName =
+		/[@_\-0-9]/u.test(subject) ||
+		/\b(?:bot|agent|ai)\b/iu.test(subject) ||
+		/^[a-z][a-z0-9_-]{6,}$/u.test(subject);
+	return looksLikeLocalName;
+}
+
+function lastNonEmptyLine(text: string): string {
+	const lines = text.replace(/\r\n/g, "\n").split("\n");
+	for (let index = lines.length - 1; index >= 0; index -= 1) {
+		const line = lines[index]?.trim();
+		if (line) return line;
+	}
+	return text.trim();
+}
+
+function extractContextualIdentityLookupSubject(text: string): string | null {
+	const cleaned = removeLeadingPlatformAddress(lastNonEmptyLine(text));
+	const lower = cleaned.toLowerCase();
+	for (const prefix of CONTEXTUAL_IDENTITY_LOOKUP_PREFIXES) {
+		if (!lower.startsWith(prefix)) continue;
+		const subject = cleanContextualLookupSubject(cleaned.slice(prefix.length));
+		return isShortContextualLookupSubject(subject) ? subject : null;
+	}
+	return null;
 }
 
 function shouldPreferCompleteDirectReply(args: {
@@ -5168,11 +5322,17 @@ export async function runV5MessageRuntimeStage1(args: {
 			preselectedActions: exposedPlannerActions,
 			actionSurface,
 		});
+		const responseHandlerContextSlices = stringArrayProperty(
+			(messageHandler.plan as { contextSlices?: unknown }).contextSlices,
+		);
 		const plannerContextWithDecision = appendContextEvent(plannerContext, {
 			id: `message-handler:${messageHandlerEndedAt}`,
 			type: "message_handler",
 			source: "message-service",
 			createdAt: messageHandlerEndedAt,
+			...(responseHandlerContextSlices.length > 0
+				? { content: responseHandlerContextSlices.join("\n\n") }
+				: {}),
 			metadata: {
 				processMessage: messageHandler.processMessage,
 				plan: {
@@ -5182,6 +5342,9 @@ export async function runV5MessageRuntimeStage1(args: {
 						: {}),
 					candidateActions: getMessageHandlerCandidateActions(messageHandler),
 					parentActionHints: getMessageHandlerParentActionHints(messageHandler),
+					...(responseHandlerContextSlices.length > 0
+						? { contextSlices: responseHandlerContextSlices }
+						: {}),
 					...(messageHandler.plan.reply !== undefined
 						? { reply: messageHandler.plan.reply }
 						: {}),

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2805,6 +2805,8 @@ direct/private rules:
 - Ordinary chat, static knowledge, creative writing, rewriting, translation, brainstorming, and short explanations should use contexts=["simple"] and put the final answer in replyText.
 - For simple requests, replyText must be a natural user-facing answer; avoid single-token fragments or placeholder text unless the user explicitly asked for a terse form.
 - Use a non-simple context or candidateActionNames only when the request needs tools, current/live facts, private state, files, web, shell, side effects, scheduling, memory, settings, secrets, wallet/finance, media, or device/app control.
+- Only use "simple" when you can answer directly from your static knowledge or the visible prior_message / reply_reference context. If the message refers to a specific name, person, nickname, or thing you cannot identify from the visible context, choose a non-simple context (such as general or memory) instead of guessing.
+- Never write replyText that claims you have searched, scanned, checked, looked up, recalled, or remembered anything unless an actual tool call this turn returned that content. If you cannot ground the answer from the visible context, say so plainly.
 - For tool/planning paths, replyText is only a brief ack ("On it.", "Looking into it."). Never refuse because tools may run after this stage.
 - If schema omits shouldRespond, do not invent it.
 - contexts must be ids from available_contexts. If a needed tool context is unclear, use ["general"].

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -1599,6 +1599,61 @@ function asProviderRecord(value: unknown):
 	};
 }
 
+function asPlainRecord(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) {
+		return undefined;
+	}
+	return value as Record<string, unknown>;
+}
+
+function cleanPriorDialogueSpeakerName(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const normalized = value.trim().split(/\s+/).join(" ");
+	if (!normalized) return undefined;
+	return normalized.length > 80 ? `${normalized.slice(0, 77)}...` : normalized;
+}
+
+function senderIdentityName(value: unknown): string | undefined {
+	const record = asPlainRecord(value);
+	if (!record) return undefined;
+	return (
+		cleanPriorDialogueSpeakerName(record.name) ??
+		cleanPriorDialogueSpeakerName(record.username) ??
+		cleanPriorDialogueSpeakerName(record.tag)
+	);
+}
+
+function priorDialogueSpeakerName(memory: Memory): string | undefined {
+	const metadata = asPlainRecord(memory.metadata);
+	const content = asPlainRecord(memory.content);
+	const contentMetadata = asPlainRecord(content?.metadata);
+	const sender =
+		senderIdentityName(metadata?.sender) ??
+		senderIdentityName(contentMetadata?.sender);
+	if (sender) return sender;
+	for (const record of [metadata, contentMetadata, content]) {
+		const name =
+			cleanPriorDialogueSpeakerName(record?.entityName) ??
+			cleanPriorDialogueSpeakerName(record?.senderName) ??
+			cleanPriorDialogueSpeakerName(record?.authorName) ??
+			cleanPriorDialogueSpeakerName(record?.displayName) ??
+			cleanPriorDialogueSpeakerName(record?.userName) ??
+			cleanPriorDialogueSpeakerName(record?.username) ??
+			cleanPriorDialogueSpeakerName(record?.name);
+		if (name) return name;
+	}
+	return undefined;
+}
+
+function priorDialogueContent(text: string, speaker?: string): string {
+	if (!speaker) return text;
+	const trimmedStart = text.trimStart();
+	if (trimmedStart.toLowerCase().startsWith(`${speaker.toLowerCase()}:`)) {
+		return text;
+	}
+	return `${speaker}: ${text}`;
+}
+
 function appendPriorDialogueEvents(
 	events: ContextEvent[],
 	runtime: IAgentRuntime,
@@ -1657,6 +1712,7 @@ function appendPriorDialogueEvents(
 	for (const memory of dialogue) {
 		const text = getUserMessageText(memory);
 		if (!text) continue;
+		const speakerName = priorDialogueSpeakerName(memory);
 		events.push({
 			id: `history:${memory.id}`,
 			type: "segment",
@@ -1665,11 +1721,12 @@ function appendPriorDialogueEvents(
 			segment: {
 				id: `history:${memory.id}`,
 				label: "prior_message:user",
-				content: text,
+				content: priorDialogueContent(text, speakerName),
 				stable: false,
 				metadata: {
 					roomId: memory.roomId,
 					entityId: memory.entityId,
+					...(speakerName ? { speakerName } : {}),
 				},
 			},
 		});

--- a/packages/prompts/src/index.ts
+++ b/packages/prompts/src/index.ts
@@ -688,6 +688,8 @@ simple shortcut: choose contexts=["simple"] when the user is asking for a direct
 
 For simple requests, replyText is the final answer itself, not a description of what the user asked for and not an internal plan. Write a natural user-facing answer; avoid single-token fragments or placeholder text unless the user explicitly asked for a terse form.
 
+Never write replyText that claims you have searched, scanned, checked, looked up, recalled, or remembered anything unless an actual tool call this turn returned that content. If you cannot ground the answer from the visible prior_message / reply_reference / provider context, say so plainly instead of fabricating an action.
+
 Platform mention/reply target/channel/room/connector alone can still be simple when only chat reply needed.
 
 Never simple when message:

--- a/packages/prompts/test/prompts.test.js
+++ b/packages/prompts/test/prompts.test.js
@@ -86,6 +86,33 @@ describe("prompt templates (src/index.ts)", () => {
       `src/index.ts has unbalanced delimiters: ${opens} {{ vs ${closes} }}`,
     );
   });
+
+  it("messageHandlerTemplate forbids phantom action claims in replyText", () => {
+    // Regression coverage for the structural rule that prevents Stage 1
+    // from writing "I scanned/searched/checked/looked up/recalled/remembered"
+    // prose when no tool call this turn actually retrieved that content.
+    // Originally observed in production as the bot replying "I've scanned
+    // the recent chat..." with plannerIterations=0 and toolCallsExecuted=0.
+    const src = readSrc();
+    const messageHandlerTemplateRe =
+      /export const messageHandlerTemplate = `([^`]+)`/;
+    const match = src.match(messageHandlerTemplateRe);
+    assert.ok(
+      match,
+      "messageHandlerTemplate string literal should be findable",
+    );
+    const body = match[1];
+    assert.match(
+      body,
+      /Never write replyText that claims you have searched, scanned, checked, looked up, recalled, or remembered anything/,
+      "messageHandlerTemplate should carry the phantom-action-claim rule",
+    );
+    assert.match(
+      body,
+      /unless an actual tool call this turn returned that content/,
+      "phantom-action-claim rule should bind the prohibition to actual tool execution this turn",
+    );
+  });
 });
 
 describe("build scripts", () => {


### PR DESCRIPTION
## Summary

Four commits addressing a class of Stage 1 failures observed on a downstream Discord deployment where the agent answered questions about chat-local entities (names, nicknames, references) by either fabricating identities, claiming to have searched the chat when no tool ran, or losing speaker attribution in the prior dialogue context.

```
456674e5d4 test(prompts): pin phantom-action-claim rule in messageHandlerTemplate
3569ea21e0 fix(core,prompts): forbid ungrounded simple replies and phantom action claims
b2d62be0cd fix(core): route local identity lookups through planner
847f6f6198 fix(core): preserve speaker names in prior dialogue context
```

Purely additive at the framework prompt-template layer. No regex on user input or bot output, no phrase lists, no per-shape pattern matching beyond the narrow deterministic backstop for the original `who is X?` failure shape.

## The class of failures

Three distinct failure modes observed in live Discord trajectories on a `gpt-oss-120b` planner:

**1. Speaker attribution stripped from prior dialogue.** Connector-provided sender names on `prior_message:user:` blocks were rendered anonymously, so the model saw "X said Y" content without the X attribution. Follow-up questions like "look in the chat" or "her and botdick" failed because the model could not bind references to participants. Fix: `847f6f6198` reads the existing `metadata.sender` / entity-name fields connectors already write and prefixes prior dialogue content with the sender name.

**2. Stage 1 fabricating chat-local identities.** Asked "who is shebotdick?" the agent guessed `shebotdick == botdick` from nearby chat context, with `plannerIterations=0, toolCallsExecuted=0`. Fix: `b2d62be0cd` adds the deterministic `core.contextual_identity_lookup_requires_recall` evaluator that catches a narrow set of "who is X" / "tell me about X" interrogatives, clears the simple-shortcut reply, and routes through the planner with `general/memory/messaging` context plus a `MESSAGE` action hint when the runtime exposes it.

**3. Stage 1 hallucinating tool-call claims in replyText.** Asked "look in the chat bozo" the agent replied `"I've scanned the recent chat, but there's no mention of who 'her' or 'botdick' are..."` with `plan.simple=true, plan.requiresTool=false, plannerIterations=0, toolCallsExecuted=0, toolSearchCount=0` — no tool ever fired, yet the reply asserts a scan happened. Fix: `3569ea21e0` adds two structural rules to the framework-shared Stage 1 task templates (`packages/prompts/src/index.ts:messageHandlerTemplate` for non-DM, `packages/core/src/services/message.ts:DIRECT_MESSAGE_HANDLER_TEMPLATE` for DM):

> Only use "simple" when you can answer directly from your static knowledge or the visible prior_message / reply_reference context. If the message refers to a specific name, person, nickname, or thing you cannot identify from the visible context, choose a non-simple context (such as general or memory) instead of guessing.
>
> Never write replyText that claims you have searched, scanned, checked, looked up, recalled, or remembered anything unless an actual tool call this turn returned that content. If you cannot ground the answer from the visible context, say so plainly.

`456674e5d4` pins the second rule into `messageHandlerTemplate` with a static regression in `packages/prompts/test/prompts.test.js` so a future edit can't quietly drop it.

## Why prompt-template layer, not another evaluator

The deterministic regex evaluator in `b2d62be0cd` catches one specific intent shape. Stacking a second evaluator with phrase lists for `look in the chat`, `search the messages`, `i was asking about X`, etc. would generalize poorly to novel phrasings and is exactly the regex-on-LLM-text pattern this project structurally avoids. Placing the broader rule in the Stage 1 task template instead applies framework-wide to every shape — known and unknown — and enforces it at the source of the behavior (the model's instruction contract), not after the fact via output pattern matching. The narrow regex evaluator stays as a deterministic backstop for the one shape it has proven coverage for; the prompt rule does the broader behavioral work. Defense in depth, each layer narrow.

## Live evidence after the fix

Test channel probes with a novel name `ironpegasus42` that has never appeared anywhere in the bot's chat history:

| Prompt | Reply (new behavior) | Phantom-action verb |
|---|---|---|
| `look in the chat for any mention of ironpegasus42` | `"I didn't find any mention of ironpegasus42 in the recent chat messages."` | none |
| `search the messages for ironpegasus42 and tell me what they said` | `"I looked through the recent chat history you provided and didn't find any messages mentioning ironpegasus42."` | none |
| `i was asking about ironpegasus42` | `"I don't see any messages mentioning ironpegasus42 in the visible chat history."` | none |
| `who is obama?` (negative control) | full bio from static knowledge unchanged | none |

Compare to the original `"I've scanned the recent chat..."` — the bot now bounds its claims to "**visible** chat history" / "the chat messages **you provided**", rather than asserting an unbounded retrieval that didn't happen.

## Validation

- `bunx @biomejs/biome check` — clean
- `bun vitest run` in `packages/core` (focused) — 67/67 pass
- `bun test ./test` in `packages/prompts` — 11/11 pass
- `bun run typecheck` — clean
- `bun run build` — clean
- Full `bun vitest run` in `packages/core`: 1365/1377 pass with 11 skipped and 1 pre-existing failure on `develop` (`planner-loop-user-facing-text.test.ts > does not regress evaluator's explicit messageToUser path` — separately fixed in a companion PR; not introduced by this PR, verified against a fresh checkout of `fa83ddee6f`).

## Branch state

`0 behind / 4 ahead` of `origin/develop`. Purely additive diff across `packages/core/src/services/message.ts`, `packages/core/src/__tests__/message-runtime-stage1.test.ts`, `packages/prompts/src/index.ts`, and `packages/prompts/test/prompts.test.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses three live production failure modes in Stage 1 of the message-handling pipeline: missing speaker attribution on prior dialogue blocks, phantom "I scanned the chat" claims when no tool actually ran, and identity guesses for chat-local names made without any recall. The fixes are spread across a new evaluator, speaker-name injection into prior dialogue context events, and additive prompt-template rules.

- **Speaker attribution** (`priorDialogueSpeakerName` + `priorDialogueContent`): reads `metadata.sender` / entity-name fields already written by connectors and prefixes each `prior_message:user:` block with `<speaker>: ` so the model can bind pronoun/nickname references to real participants.
- **Phantom action claims** (`messageHandlerTemplate` + `DIRECT_MESSAGE_HANDLER_TEMPLATE`): adds a structural instruction forbidding `replyText` that asserts a search/scan/recall happened unless an actual tool call returned content this turn; a companion regression test pins the rule text so it cannot be quietly deleted.
- **Identity lookup evaluator** (`core.contextual_identity_lookup_requires_recall`): catches `who is X` / `what is X` interrogatives where the simple-shortcut was chosen, clears the speculative reply, and routes through `general/memory/messaging` with an `identity_lookup_policy` context slice injected into the planner event.

<h3>Confidence Score: 4/5</h3>

The change is purely additive — new functions, a new evaluator, and extra prompt-rule text — and does not modify any existing call sites in ways that could break currently working paths. The speaker-attribution code degrades gracefully to the original behavior when no sender metadata is present.

The `isShortContextualLookupSubject` heuristic's third branch matches any all-lowercase word of 7+ characters, which unintentionally includes many well-known technology/brand names when written in lowercase (e.g. `discord`, `ethereum`, `twitter`). Those queries get routed through recall instead of answered directly from static knowledge. The LLM has a fallback instruction to use public knowledge for clearly public entities, so responses should still be correct, but the routing is wasteful and can produce awkward preambles. Everything else in the diff — the speaker-name attribution, the DM template rule, and the regression tests — is straightforward and correct.

The `isShortContextualLookupSubject` function in `packages/core/src/services/message.ts` deserves a second look; the test fragility in `packages/core/src/__tests__/message-runtime-stage1.test.ts` is minor but worth addressing.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/services/message.ts | Adds speaker-name attribution for prior dialogue, a new `core.contextual_identity_lookup_requires_recall` evaluator, and context-slice injection into the planner event; the heuristic function `isShortContextualLookupSubject` has an overly broad third condition that can produce false positives for lowercase public-entity names. |
| packages/prompts/src/index.ts | Adds a single phantom-action-claim rule to messageHandlerTemplate; additive, self-contained, no control-flow change. |
| packages/core/src/__tests__/message-runtime-stage1.test.ts | Adds four new test cases covering the three bug fixes and the DM template rule; one assertion checks an exact JSON serialization fragment, which is fragile if whitespace in the serialized output ever changes. |
| packages/prompts/test/prompts.test.js | Adds a regression test that pins the phantom-action-claim rule text in messageHandlerTemplate; straightforward static-text assertion. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Incoming message"] --> B["Stage 1: message handler\n(simple shortcut decision)"]
    B --> C{"isSimpleMessageHandlerShortcut?"}
    C -- No --> D["Normal planning path"]
    C -- Yes --> E{"extractContextualIdentityLookupSubject\nreturns non-null?"}
    E -- No --> F{"Simple reply OK"}
    F -- Yes --> G["Direct reply (simple=true)"]
    E -- Yes --> H["core.contextual_identity_lookup_requires_recall\nevaluator fires"]
    H --> I["setContexts: general/memory/messaging\nclearReply: true\naddContextSlices: identity_lookup_policy\naddCandidateActions: MESSAGE (if available)"]
    I --> J["Planner stage 2 with enriched context event"]
    J --> K["Grounded reply or honest 'I don't know'"]
    B --> L["appendPriorDialogueEvents"]
    L --> M{"priorDialogueSpeakerName\nfound in metadata?"}
    M -- Yes --> N["prior_message:user:\nspeaker: text"]
    M -- No --> O["prior_message:user:\ntext only (unchanged)"]
```

<sub>Reviews (1): Last reviewed commit: ["test(prompts): pin phantom-action-claim ..."](https://github.com/elizaos/eliza/commit/456674e5d46c9a9cd8b9b9225f2ace03160ab8c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33622743)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->