### PR TITLE
fix(core): bound runaway tool-arg validation loops via canonical failure signature

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -862,6 +862,79 @@ describe("v5 planner loop skeleton", () => {
 		);
 	});
 
+	it("collapses repeated parameter-validation failures on the same tool even when args vary", async () => {
+		// Regression for runaway loops where the model retries a single
+		// tool repeatedly with shifting argument shapes that every time
+		// fail `validateToolArgs`. Without canonical signing of these
+		// validation failures, the repeatKey + error message both diverge
+		// per call and `maxRepeatedFailures` never trips. Observed live as
+		// a 27-iteration runaway against TASKS where the model alternated
+		// between `action=spawn_agent` / `action=create` / `action=update`
+		// with the same set of unrecognized arguments.
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "call-1",
+							name: "TASKS",
+							arguments: { action: "spawn_agent", task: "build a site" },
+						},
+					],
+				})
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "call-2",
+							name: "TASKS",
+							arguments: { action: "create", task: "build a site" },
+						},
+					],
+				})
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "call-3",
+							name: "TASKS",
+							arguments: { action: "update", task: "build a site" },
+						},
+					],
+				}),
+		};
+		let callCount = 0;
+		const executeToolCall = vi.fn(async () => {
+			callCount++;
+			return {
+				success: false,
+				error: `Unexpected argument 'task'; action value '${callCount}' rejected`,
+				data: {
+					parameterErrors: ["Unexpected argument 'task'", "action not in enum"],
+				},
+			};
+		});
+		const evaluate = vi.fn(async () => ({
+			success: false,
+			decision: "CONTINUE" as const,
+			thought: "Retry with a different action.",
+		}));
+
+		await expect(
+			runPlannerLoop({
+				runtime,
+				context: { id: "ctx" },
+				config: { maxRepeatedFailures: 1 },
+				executeToolCall,
+				evaluate,
+			}),
+		).rejects.toBeInstanceOf(TrajectoryLimitExceeded);
+		// Loop must bail on the second validation rejection, not run forever.
+		expect(executeToolCall.mock.calls.length).toBeLessThanOrEqual(2);
+	});
+
 	it("compacts old assistant/tool suffixes when the planner input crosses the budget threshold", async () => {
 		const capturedMessages: ChatMessage[][] = [];
 		const longPayload = `generated file content: ${"x".repeat(20_000)}`;

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -1742,11 +1742,28 @@ async function executeQueuedToolCall(params: {
 	}
 	const endedAt = Date.now();
 
+	// Parameter-validation rejections from `validateToolArgs` set
+	// `result.data.parameterErrors`. A model that keeps the same tool but
+	// shuffles its argument shape across retries (e.g. trying `action=create`
+	// then `action=spawn_agent` then `action=update`) varies both the error
+	// string and the params JSON, so the per-call repeatKey + per-call error
+	// message both diverge and `assertRepeatedFailureLimit` never trips —
+	// even though the failure category is identical and the model is just
+	// hunting for a valid arg shape that does not exist on this action.
+	// Collapse parameter-validation failures of a tool to a single canonical
+	// signature so the existing repeated-failure guard catches that pattern.
+	const isParameterValidationFailure = Array.isArray(
+		(result.data as { parameterErrors?: unknown } | undefined)?.parameterErrors,
+	);
 	const failure = {
 		toolName: params.toolCall.name,
 		success: result.success,
-		error: result.error,
-		repeatKey: toolFailureRepeatKey(params.toolCall),
+		error: isParameterValidationFailure
+			? "parameter_validation_failed"
+			: result.error,
+		repeatKey: isParameterValidationFailure
+			? "parameter_validation"
+			: toolFailureRepeatKey(params.toolCall),
 	};
 	if (!result.success || result.error != null) {
 		params.failures.push(failure);


### PR DESCRIPTION
## Summary

Prevent the framework's `maxRepeatedFailures` guard from being silently defeated when a model retries the same tool with shifting argument shapes that each fail `validateToolArgs`.

## Background

The per-call repeatKey (`toolName + JSON.stringify(params)`) and the per-call error message both diverge across attempts when the model shuffles its arg shape between retries, so the existing failure-deduplication treats each as a fresh failure even though the failure category is identical and no valid arg shape exists for the action being called.

## Live evidence

Production trajectory observed on a downstream deployment, replicated from a live agent run:

```
trajectory id        tj-95869490c7a2b2
status               errored (never reached terminal)
plannerIterations    27
toolCallsExecuted    25
toolCallFailures     25  (every tool call failed validation)
evaluatorFailures    16
totalCostUsd         $1.30
finalDecision        CONTINUE
```

Root cause: Stage 1 invoked `TASKS` with `action=spawn_agent` (plus `task`, `agentType`, `workdir`, `keepAliveAfterComplete`). The `SCHEDULED_TASKS` action rejected the invocation:

```
"Unexpected argument 'task'; Unexpected argument 'agentType'; Unexpected argument 'workdir';
 Unexpected argument 'keepAliveAfterComplete';
 Argument 'action' value 'spawn_agent' is not one of: list, get, create, update, snooze, skip,
 complete, acknowledge, dismiss, cancel, reopen, history"
```

The model then cycled through `action=create` / `action=update` / `action=spawn_agent` etc. for 27 iterations, each call failing validation with a slightly different parameterErrors message, until token budget exhausted. `assertRepeatedFailureLimit` never fired because the per-call signatures all differed.

## Fix

When `result.data.parameterErrors` is set, both the failure error string and the repeatKey collapse to canonical values (`"parameter_validation_failed"` and `"parameter_validation"`), so two consecutive validation rejections of the same tool now correctly hit the existing `maxRepeatedFailures` (default 2) and `TrajectoryLimitExceeded({kind: "repeated_failures"})` fires.

## Behavior preserved

The existing test `does not count different failed tool parameters as the same repeated failure` still passes — failures whose `result.data` does NOT carry `parameterErrors` (runtime errors, timeouts, downstream service failures) keep the per-call repeatKey, so legitimate distinct retries against the same tool with the same runtime error still register as distinct attempts. Only the parameter-validation category collapses.

## Validation

- `bunx @biomejs/biome check --write` — clean
- `bun vitest run` in `packages/core` — 34/34 planner-loop tests pass (was 33, +1 new)
- `bun run typecheck` — clean
- `bun run build` — clean
- New regression `collapses repeated parameter-validation failures on the same tool even when args vary` reproduces the runaway shape and asserts the loop bails inside the configured limit.

## Related

Independent from #7897 (which restores the evaluator `messageToUser` precedence via `verifiedUserFacing` opt-in) — that PR fixes the user-facing-text resolution; this PR fixes the failure-deduplication that lets the loop keep retrying ineligible argument shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a runaway planner-loop where a model cycling through invalid argument shapes for the same tool was never stopped by `assertRepeatedFailureLimit`, because each attempt produced a unique `repeatKey` and error string. The fix canonicalises both fields to stable values when `result.data.parameterErrors` is set, so consecutive parameter-validation failures on the same tool now count as the same repeated failure.

- `planner-loop.ts`: detects `result.data.parameterErrors` and substitutes a canonical `error` and `repeatKey` into the failure record before it reaches `assertRepeatedFailureLimit`; the original `result` is still written unmodified to the trajectory steps, so model context is unchanged.
- `planner-loop.test.ts`: adds a regression that replays the three-arg-shape runaway from the live trajectory and asserts the loop throws `TrajectoryLimitExceeded` after at most two tool calls.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is narrowly scoped to parameter-validation failures and does not affect trajectory recording or model context.

The implementation correctly collapses error and repeatKey only when result.data.parameterErrors is present, and the trajectory step still stores the raw result. The one minor gap is that Array.isArray([]) satisfies the guard, meaning an empty parameterErrors array would activate the canonical path unnecessarily — this is unlikely in practice but worth hardening.

The 10-line change in planner-loop.ts around line 1755 is the only place that warrants a second look, specifically the Array.isArray guard without a length check.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/planner-loop.ts | Collapses parameter-validation failures for the same tool into a canonical error/repeatKey so `assertRepeatedFailureLimit` correctly counts them as repeated — no change to trajectory recording or model context. |
| packages/core/src/runtime/__tests__/planner-loop.test.ts | Adds a regression test that replays the 27-iteration runaway pattern with shifting arg shapes and verifies the loop throws `TrajectoryLimitExceeded` within the configured limit. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[executeQueuedToolCall] --> B[executeToolCall returns result]
    B --> C{parameterErrors present\nand non-empty?}
    C -- Yes --> D[Use canonical failure signature\nfor this tool]
    C -- No --> E[Use per-call failure signature\nfor this tool]
    D --> H{failure condition\nmet?}
    E --> H
    H -- No --> K[Write original result to trajectory]
    H -- Yes --> I[Push to failures list]
    I --> J[assertRepeatedFailureLimit]
    J --> L{Repeated count\nexceeds max?}
    L -- Yes --> M[throw TrajectoryLimitExceeded]
    L -- No --> K
```

<sub>Reviews (1): Last reviewed commit: ["fix(core): bound runaway tool-arg valida..."](https://github.com/elizaos/eliza/commit/5e0387c359786741afbe3780c5a44eda50b217ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33622756)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->