### PR TITLE
fix(os-homepage): biome format playwright.config.ts outputDir multiline

### DIFF
--- a/packages/os-homepage/playwright.config.ts
+++ b/packages/os-homepage/playwright.config.ts
@@ -6,7 +6,10 @@ const recording = !!process.env.E2E_RECORD;
 export default defineConfig({
   testDir: "./tests",
   outputDir: recording
-    ? path.resolve(import.meta.dirname, "../../e2e-recordings/os-homepage/test-results")
+    ? path.resolve(
+        import.meta.dirname,
+        "../../e2e-recordings/os-homepage/test-results",
+      )
     : "./test-results",
   expect: {
     toHaveScreenshot: { maxDiffPixelRatio: 0.02 },


### PR DESCRIPTION
## What

Single-file biome format fix for `packages/os-homepage/playwright.config.ts`. The `outputDir` ternary was on one long line; biome wants it broken across multiple lines per the printWidth rule.

## Why this matters now

This violation is blocking the `Validate OS release surfaces` → `Validate OS homepage` workflow on **every PR that touches `packages/os/`** — including PRs that don't modify `packages/os-homepage` at all (e.g. PR #7926 hit this even though it only deleted files under `packages/os/linux/variants/milady-tails/`).

## Diff

```diff
   outputDir: recording
-    ? path.resolve(import.meta.dirname, "../../e2e-recordings/os-homepage/test-results")
+    ? path.resolve(
+        import.meta.dirname,
+        "../../e2e-recordings/os-homepage/test-results",
+      )
     : "./test-results",
```

Zero semantic change — `outputDir` still resolves to the same path.

## Verified

- `cd packages/os-homepage && bunx @biomejs/biome check .` → `Checked 25 files in 75ms. No fixes applied.` ✅
- Auto-generated by `bunx @biomejs/biome check --write .` per the project's own tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Splits a single long `path.resolve(...)` argument line in `packages/os-homepage/playwright.config.ts` across three lines to satisfy Biome's `printWidth` rule. The `outputDir` value is functionally identical before and after the change.

- **Formatting only**: The `outputDir` ternary resolves to exactly the same path at runtime; no logic, config, or dependency is altered.
- **CI unblock**: This formatting violation was causing the `Validate OS homepage` workflow to fail on every PR touching `packages/os/`, even those with no changes to this package.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a mechanical formatter rewrite with no runtime effect.

The only change is whitespace: a single path.resolve() call is broken across multiple lines to satisfy the Biome printWidth rule. The resolved path, Playwright config values, and all runtime behavior are unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/os-homepage/playwright.config.ts | Pure Biome formatting fix: splits the `outputDir` ternary's long `path.resolve(...)` call across multiple lines; no semantic change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["CI: Validate OS homepage"] --> B{"Biome format check"}
    B -- "Before PR (long line)" --> C["❌ Format violation\n(printWidth exceeded)"]
    B -- "After PR (multiline)" --> D["✅ No fixes applied\n(25 files checked)"]
    C --> E["Workflow fails on all\nPRs touching packages/os/"]
    D --> F["Workflow passes"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(os-homepage): biome format playwrigh..."](https://github.com/elizaos/eliza/commit/a47ba38e69b73dc01e6bede8a506afe2230c0a6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33628486)</sub>

<!-- /greptile_comment -->