### PR TITLE
fix(chip): address greptile P1+P2 findings from PR #7893 review

### DIFF
--- a/packages/chip/scripts/check_cva6_boot_substrate.py
+++ b/packages/chip/scripts/check_cva6_boot_substrate.py
@@ -114,8 +114,7 @@ def _parse_results() -> tuple[bool, str]:
             return False, f"test skipped: {case.get('name')}"
         if failure is not None or error is not None:
             node = failure if failure is not None else error
-            if node is None:
-                continue
+            assert node is not None  # narrowed by the guard above
             msg = (node.get("message") or node.text or "assertion failed").strip()
             return False, f"{case.get('name')}: {msg[:400]}"
     if seen == 0:
@@ -203,15 +202,24 @@ def main() -> int:
         print(f"FAIL: {reason}")
         return 1
 
-    _write("PASS", None, None, evidence + [
-        "verify/cocotb/integration/Makefile.cva6-dram-boot",
-        "build/reports/cva6_boot_substrate.sim.log",
-    ], extra={
-        "proof": "CVA6 elaborated + bare-metal image executed through the RTL "
-                 "DRAM path (markers + timer trap asserted)",
-    })
-    print("PASS: CVA6 elaborated and the bare-metal image provably executed "
-          "through the RTL DRAM path (DRAM markers + CLINT timer trap asserted).")
+    _write(
+        "PASS",
+        None,
+        None,
+        evidence
+        + [
+            "verify/cocotb/integration/Makefile.cva6-dram-boot",
+            "build/reports/cva6_boot_substrate.sim.log",
+        ],
+        extra={
+            "proof": "CVA6 elaborated + bare-metal image executed through the RTL "
+            "DRAM path (markers + timer trap asserted)",
+        },
+    )
+    print(
+        "PASS: CVA6 elaborated and the bare-metal image provably executed "
+        "through the RTL DRAM path (DRAM markers + CLINT timer trap asserted)."
+    )
     _write(
         "PASS",
         None,

--- a/packages/chip/scripts/check_e1_soc_pd_input_contract.py
+++ b/packages/chip/scripts/check_e1_soc_pd_input_contract.py
@@ -366,7 +366,10 @@ def build_report() -> dict[str, Any]:
     if isinstance(expected_clock_period_raw, (int, float, str)):
         try:
             expected_clock_period = float(expected_clock_period_raw)
-        except (TypeError, ValueError):
+        except ValueError:
+            # The isinstance guard above already excludes types that would
+            # raise TypeError; only ValueError (bad numeric string like "abc")
+            # remains.
             expected_clock_period = None
     if expected_clock_period is None:
         # CLOCK_PERIOD missing or unparseable in config — fail closed as a

--- a/packages/chip/scripts/check_e1_soc_pd_input_contract.py
+++ b/packages/chip/scripts/check_e1_soc_pd_input_contract.py
@@ -362,16 +362,27 @@ def build_report() -> dict[str, Any]:
             }
         )
     expected_clock_period_raw = config.get("CLOCK_PERIOD")
-    expected_clock_period = (
-        float(expected_clock_period_raw)
-        if isinstance(expected_clock_period_raw, (int, float, str))
-        else None
-    )
-    if clock_period != expected_clock_period:
+    expected_clock_period: float | None = None
+    if isinstance(expected_clock_period_raw, (int, float, str)):
+        try:
+            expected_clock_period = float(expected_clock_period_raw)
+        except (TypeError, ValueError):
+            expected_clock_period = None
+    if expected_clock_period is None:
+        # CLOCK_PERIOD missing or unparseable in config — fail closed as a
+        # config error rather than masquerading as an SDC mismatch.
+        sdc_semantic_failures.append(
+            {
+                "id": "clock_period_config_missing_or_invalid",
+                "config_value": expected_clock_period_raw,
+                "sdc_value": clock_period,
+            }
+        )
+    elif clock_period != expected_clock_period:
         sdc_semantic_failures.append(
             {
                 "id": "clock_period_mismatch",
-                "expected": config.get("CLOCK_PERIOD"),
+                "expected": expected_clock_period,
                 "actual": clock_period,
             }
         )


### PR DESCRIPTION
## What

Two real bugs greptile flagged on PR #7893 that landed in `develop` via the merge integration commit `8114d5ad08`:

### `check_cva6_boot_substrate.py` — P2 unreachable null guard

```py
if failure is not None or error is not None:
    node = failure if failure is not None else error
    if node is None:        # ← dead code: outer guard ensures non-None
        continue
```

The defensive `if node is None: continue` is unreachable. The outer guard ensures at least one of `failure`/`error` is non-None, and the conditional expression then resolves `node` to that non-None value. Replaced with an explicit `assert node is not None  # narrowed by the guard above` that documents the narrowing for readers and type-checkers.

### `check_e1_soc_pd_input_contract.py` — P1 silent clock_period mismatch

```py
expected_clock_period = (
    float(expected_clock_period_raw)
    if isinstance(expected_clock_period_raw, (int, float, str)) else None
)
if clock_period != expected_clock_period:
    sdc_semantic_failures.append({"id": "clock_period_mismatch", ...})
```

When `CLOCK_PERIOD` is missing or unparseable in config, `expected_clock_period` is `None`. `clock_period != None` is always `True` for any float, so every run with missing config reported a `clock_period_mismatch` that wasn't actually a mismatch with anything.

Fix:
- A missing/unparseable config value now fails closed as a distinct `clock_period_config_missing_or_invalid` (config error, surfaced separately so the operator knows to fix the config).
- `clock_period_mismatch` only fires when both sides are valid floats and disagree.
- Wrapped `float()` in `try/except` since `str` inputs like `"abc"` would have crashed the older path with `ValueError`.

## Scope note

The diff includes a few `ruff format` cosmetic changes in `_write("PASS", ...)` / `print(...)` calls inside `main()` of `check_cva6_boot_substrate.py` — develop's current version had those calls in a non-ruff-canonical form, and `ruff format --check` would have flagged them on this PR. Pure formatting, no semantic change.

## Verified

- `python3 -c "import ast; ast.parse(open(f).read())"` on both files → no syntax errors
- `ruff check` → clean
- `ruff format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two real bugs in the `packages/chip` verification scripts that were identified in a prior review of PR #7893. Both fixes tighten the error-handling logic so that configuration problems produce distinct, actionable failure codes rather than silent wrong behavior.

- **`check_cva6_boot_substrate.py`**: Replaces an unreachable `if node is None: continue` guard (which could silently swallow a test failure if the invariant ever broke) with `assert node is not None`, and reformats two call sites to pass `ruff format --check`.
- **`check_e1_soc_pd_input_contract.py`**: The `clock_period_mismatch` check previously fired on every run where `CLOCK_PERIOD` was absent or unparseable in config because `float_value != None` is always `True`; the fix introduces a dedicated `clock_period_config_missing_or_invalid` failure and wraps `float()` in `try/except ValueError` to handle non-numeric strings without crashing.

<h3>Confidence Score: 5/5</h3>

Both changes are targeted, well-reasoned bug fixes with no collateral risk; safe to merge.

The two changes address clearly identified correctness issues — dead code replaced by a documenting assert, and a false-positive failure report eliminated by distinguishing config errors from actual clock-period mismatches. The logic in both files is straightforward, the diff is small, and the PR description provides accurate analysis of each fix. No new code paths introduce risk.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/chip/scripts/check_cva6_boot_substrate.py | Replaces an unreachable `if node is None: continue` dead-code guard with an `assert node is not None` that documents the narrowing invariant; also reformats two `_write`/`print` call sites to satisfy `ruff format`. |
| packages/chip/scripts/check_e1_soc_pd_input_contract.py | Fixes a silent false-positive where a missing/unparseable `CLOCK_PERIOD` config caused `clock_period != None` to always fire as a mismatch; now emits a distinct `clock_period_config_missing_or_invalid` failure and wraps the `float()` conversion in `try/except ValueError` to handle bad numeric strings. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[config.get CLOCK_PERIOD] --> B{isinstance int/float/str?}
    B -- No --> E[expected_clock_period = None]
    B -- Yes --> C[float conversion]
    C -- ValueError --> E
    C -- Success --> D[expected_clock_period = float value]
    E --> F[Append clock_period_config_missing_or_invalid]
    D --> G{clock_period != expected?}
    G -- Yes --> H[Append clock_period_mismatch]
    G -- No --> I[No SDC failure]
```

<sub>Reviews (2): Last reviewed commit: ["fix(chip): drop dead TypeError branch in..."](https://github.com/elizaos/eliza/commit/5a936496fb2fe2b13b363ff689bc30acf340b78d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33628646)</sub>

<!-- /greptile_comment -->