### PR TITLE
fix(twitter): drop DM scopes from OAuth flow by default

### DIFF
--- a/packages/cloud-shared/src/lib/services/twitter-automation/index.ts
+++ b/packages/cloud-shared/src/lib/services/twitter-automation/index.ts
@@ -25,14 +25,30 @@ const TWITTER_API_SECRET_KEY = process.env.TWITTER_API_SECRET_KEY!;
 
 type TwitterOAuthFlow = "oauth1a" | "oauth2";
 
-const TWITTER_OAUTH2_SCOPES: TOAuth2Scope[] = [
-  "tweet.read",
-  "tweet.write",
-  "users.read",
-  "dm.read",
-  "dm.write",
-  "offline.access",
-];
+/**
+ * X OAuth2 scopes.
+ *
+ * `dm.read` + `dm.write` require Twitter API Pro tier ($5k/mo). Without that
+ * tier on the OAuth app, X rejects the entire authorization with a generic
+ * "Something went wrong" page. Set `TWITTER_OAUTH2_INCLUDE_DM=1` only when the
+ * configured X app actually has DM scopes enabled — otherwise the scope list
+ * stays trimmed to what the standard tier supports.
+ */
+function resolveTwitterOAuth2Scopes(): TOAuth2Scope[] {
+  const base: TOAuth2Scope[] = [
+    "tweet.read",
+    "tweet.write",
+    "users.read",
+    "offline.access",
+  ];
+  const includeDm = (process.env.TWITTER_OAUTH2_INCLUDE_DM ?? "").trim() === "1";
+  if (includeDm) {
+    base.push("dm.read", "dm.write");
+  }
+  return base;
+}
+
+const TWITTER_OAUTH2_SCOPES: TOAuth2Scope[] = resolveTwitterOAuth2Scopes();
 
 interface TwitterApiErrorShape {
   code?: number;


### PR DESCRIPTION
## Why
X's OAuth2 flow rejects the entire authorization with a generic 'Something went wrong' page when the OAuth app doesn't have entitlements for all requested scopes. `dm.read` + `dm.write` require Twitter API Pro tier (\$5k/mo) on the X app side. Without that tier, every user trying to connect their X account hits a dead end — confirmed live tonight on api.elizacloud.ai.

## What
- `packages/cloud-shared/src/lib/services/twitter-automation/index.ts`: default scopes are now `{tweet.read, tweet.write, users.read, offline.access}` — the standard-tier set
- DM scopes (`dm.read`, `dm.write`) gated behind opt-in env var `TWITTER_OAUTH2_INCLUDE_DM=1`

## Operator action after merge
Nothing required for default deploys. If your X app HAS Pro tier and you want DM functionality, set `TWITTER_OAUTH2_INCLUDE_DM=1` in production env.

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a live OAuth2 authorization failure where X rejects the entire auth flow when an app lacks Pro-tier entitlements for `dm.read`/`dm.write` scopes. The hardcoded scope array is replaced with a startup-time resolver that only adds DM scopes when `TWITTER_OAUTH2_INCLUDE_DM=1` is set.

- **Default scopes** are now `[tweet.read, tweet.write, users.read, offline.access]`, which work on the standard X API tier; DM scopes are opt-in via `TWITTER_OAUTH2_INCLUDE_DM=1`.
- The scope fallback paths in `exchangeOAuth2Token` (line 483) and `storeCredentials` (line 585) both reference `TWITTER_OAUTH2_SCOPES`, so they'll correctly reflect the resolved set at runtime.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change correctly removes DM scopes from the default OAuth flow and gates them behind an opt-in env var, fixing the live authorization failure without breaking existing functionality.

The fix is targeted and straightforward: one module-level constant replaced with a small resolver function. The only concern is that the opt-in check accepts only the literal "1", which could surprise operators who use "true" or "yes" instead — but this is a style issue and does not break anything for users who follow the documented convention.

No files require special attention beyond confirming the TWITTER_OAUTH2_INCLUDE_DM env var is documented for operators who rely on DM functionality.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cloud-shared/src/lib/services/twitter-automation/index.ts | Replaces hardcoded OAuth2 scope array with a startup-time resolver that gates dm.read/dm.write behind TWITTER_OAUTH2_INCLUDE_DM=1; logic is correct and consistent with existing env-var patterns in the file. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Op as Operator
    participant Env as Process Env
    participant Svc as TwitterAutomationService
    participant X as X OAuth2

    Op->>Env: "TWITTER_OAUTH2_INCLUDE_DM=(unset | "1")"
    Note over Env,Svc: Module load — resolveTwitterOAuth2Scopes() called once
    Env-->>Svc: "includeDm = false (default)"
    Note over Svc: TWITTER_OAUTH2_SCOPES = [tweet.read, tweet.write, users.read, offline.access]

    Svc->>X: generateOAuth2AuthLink(scopes)
    X-->>Svc: "auth URL (no dm.* in request)"
    Note over X: Standard-tier app — no "Something went wrong"

    alt "TWITTER_OAUTH2_INCLUDE_DM=1"
        Env-->>Svc: "includeDm = true"
        Note over Svc: TWITTER_OAUTH2_SCOPES += [dm.read, dm.write]
        Svc->>X: "generateOAuth2AuthLink(scopes with dm.*)"
        X-->>Svc: auth URL (Pro tier required)
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(twitter): drop DM scopes from OAuth ..."](https://github.com/elizaos/eliza/commit/660cc9acaff7bdd1cc14cb99b5a33567f4bc5a1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33629317)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->