### PR TITLE
revert: drop DM scopes from OAuth flow (#7929)

### DIFF
--- a/packages/cloud-shared/src/lib/services/twitter-automation/index.ts
+++ b/packages/cloud-shared/src/lib/services/twitter-automation/index.ts
@@ -25,30 +25,14 @@ const TWITTER_API_SECRET_KEY = process.env.TWITTER_API_SECRET_KEY!;
 
 type TwitterOAuthFlow = "oauth1a" | "oauth2";
 
-/**
- * X OAuth2 scopes.
- *
- * `dm.read` + `dm.write` require Twitter API Pro tier ($5k/mo). Without that
- * tier on the OAuth app, X rejects the entire authorization with a generic
- * "Something went wrong" page. Set `TWITTER_OAUTH2_INCLUDE_DM=1` only when the
- * configured X app actually has DM scopes enabled — otherwise the scope list
- * stays trimmed to what the standard tier supports.
- */
-function resolveTwitterOAuth2Scopes(): TOAuth2Scope[] {
-  const base: TOAuth2Scope[] = [
-    "tweet.read",
-    "tweet.write",
-    "users.read",
-    "offline.access",
-  ];
-  const includeDm = (process.env.TWITTER_OAUTH2_INCLUDE_DM ?? "").trim() === "1";
-  if (includeDm) {
-    base.push("dm.read", "dm.write");
-  }
-  return base;
-}
-
-const TWITTER_OAUTH2_SCOPES: TOAuth2Scope[] = resolveTwitterOAuth2Scopes();
+const TWITTER_OAUTH2_SCOPES: TOAuth2Scope[] = [
+  "tweet.read",
+  "tweet.write",
+  "users.read",
+  "dm.read",
+  "dm.write",
+  "offline.access",
+];
 
 interface TwitterApiErrorShape {
   code?: number;


### PR DESCRIPTION
Reverts #7929. The 'Something went wrong' X error was NOT caused by DM scopes — verified by re-testing with the trimmed scope set and getting the same error. Real cause is callback URL mismatch on the X dev app side. Restoring original scope set to keep DM features available for deploys that DO have Pro tier.

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR reverts #7929, restoring `dm.read` and `dm.write` back into the hardcoded `TWITTER_OAUTH2_SCOPES` list and removing the `resolveTwitterOAuth2Scopes` function and its `TWITTER_OAUTH2_INCLUDE_DM` environment-variable guard.

- **Scope list change**: `dm.read` and `dm.write` are added back unconditionally; the opt-in `TWITTER_OAUTH2_INCLUDE_DM=1` toggle and its surrounding documentation/code are deleted.
- **Stated rationale**: The \"Something went wrong\" X error observed after #7929 was attributed to a callback URL mismatch on the X developer app, not to the DM scopes themselves; the author verified this by reproducing the error with the trimmed scope set.

<h3>Confidence Score: 3/5</h3>

Merging this PR will break the Twitter OAuth2 flow for any deployment whose X app does not have Pro tier access, because dm.read/dm.write are now always requested with no way to opt out.

The change removes the TWITTER_OAUTH2_INCLUDE_DM guard and hardcodes DM scopes for every deployment. Twitter enforces Pro-tier access at the scope-evaluation stage during OAuth authorization, independently of redirect URI validation. Any standard-tier X app that goes through this OAuth flow will hit the generic "Something went wrong" rejection. The PR author's reasoning (callback URL mismatch was the real cause) may be correct for their specific environment, but does not address the documented tier enforcement that motivated #7929.

packages/cloud-shared/src/lib/services/twitter-automation/index.ts — the hardcoded scope list now unconditionally includes dm.read/dm.write without any escape hatch for non-Pro deployments.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cloud-shared/src/lib/services/twitter-automation/index.ts | Reverts the opt-in DM scope mechanism, hardcoding dm.read/dm.write for all deployments regardless of Pro tier availability |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User initiates Twitter OAuth2] --> B[Build scope list]
    B --> C{Before this PR: resolveTwitterOAuth2Scopes}
    C --> D{TWITTER_OAUTH2_INCLUDE_DM=1?}
    D -- Yes --> E[tweet.read, tweet.write, users.read, offline.access, dm.read, dm.write]
    D -- No --> F[tweet.read, tweet.write, users.read, offline.access]
    F --> G[X OAuth authorization - Standard tier OK]
    E --> H{X app has Pro tier?}
    H -- Yes --> I[X OAuth authorization Success]
    H -- No --> J[X: Something went wrong - Authorization rejected]
    B --> K{After this PR: hardcoded list}
    K --> L[tweet.read, tweet.write, users.read, offline.access, dm.read, dm.write]
    L --> M{X app has Pro tier?}
    M -- Yes --> N[X OAuth authorization Success]
    M -- No --> O[X: Something went wrong - Authorization rejected]
```

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;fix(twitter): drop DM scopes fro..."](https://github.com/elizaos/eliza/commit/6ea672ac98a46eda2d3bcfd43f667a708502d407) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33630210)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->