### PR TITLE
feat(os/linux): restore first-boot interactive setup wizard (language / timezone / persistence intent)

### DIFF
--- a/packages/os/linux/elizaos/config/hooks/normal/0010-elizaos-agent.hook.chroot
+++ b/packages/os/linux/elizaos/config/hooks/normal/0010-elizaos-agent.hook.chroot
@@ -108,7 +108,10 @@ visudo -cf "${SUDOERS}"
 
 # Enable services. First-boot is system-level; app launcher + chat
 # overlay are user units enabled by /etc/skel/.config/systemd/user
-# (created by hook 0030).
+# (created by hook 0030). The first-boot WIZARD runs before getty@tty1
+# so the locale/timezone/persistence-intent prompts land on the active
+# console before autologin grabs it.
+systemctl enable elizaos-first-boot-wizard.service || true
 systemctl enable elizaos-first-boot.service || true
 systemctl enable elizaos-agent.service || true
 systemctl enable elizaos-terminal-tui-smoke.service || true

--- a/packages/os/linux/elizaos/config/hooks/normal/0020-enable-user-units.hook.chroot
+++ b/packages/os/linux/elizaos/config/hooks/normal/0020-enable-user-units.hook.chroot
@@ -10,6 +10,7 @@
 set -eu
 
 chmod 0755 /usr/local/lib/elizaos/first-boot.sh \
+           /usr/local/lib/elizaos/first-boot-wizard.sh \
            /usr/lib/elizaos/wait-agent-health.sh \
            /usr/lib/elizaos/run-terminal-tui-smoke.sh \
            /usr/local/lib/elizaos/start-kiosk \

--- a/packages/os/linux/elizaos/config/includes.chroot/etc/systemd/system/elizaos-first-boot-wizard.service
+++ b/packages/os/linux/elizaos/config/includes.chroot/etc/systemd/system/elizaos-first-boot-wizard.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=elizaOS first-boot interactive setup wizard (language / timezone / persistence intent)
+DefaultDependencies=no
+After=systemd-tmpfiles-setup.service local-fs.target
+Before=getty@tty1.service elizaos-first-boot.service multi-user.target
+ConditionPathExists=!/var/lib/elizaos/.first-boot-wizard-complete
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/local/lib/elizaos/first-boot-wizard.sh
+StandardInput=tty
+StandardOutput=tty
+StandardError=journal+console
+TTYPath=/dev/tty1
+TTYReset=yes
+TTYVHangup=yes
+TTYVTDisallocate=yes
+# Honor the same non-interactive escape hatch the wizard itself checks for:
+# scripted builds / CI / qemu smoke tests set ELIZAOS_NONINTERACTIVE=1 (via
+# /etc/environment or the kernel cmdline → systemd ImportCredential) so the
+# wizard records defaults and exits without blocking multi-user.target.
+Environment=ELIZAOS_NONINTERACTIVE=0
+TimeoutStartSec=300
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/os/linux/elizaos/config/includes.chroot/usr/local/lib/elizaos/first-boot-wizard.sh
+++ b/packages/os/linux/elizaos/config/includes.chroot/usr/local/lib/elizaos/first-boot-wizard.sh
@@ -1,0 +1,135 @@
+#!/bin/sh
+# elizaOS first-boot interactive setup wizard.
+#
+# Runs ONCE at first boot on /dev/tty1 before getty hands the seat to
+# autologin → cage → kiosk. Surfaces three minimal setup questions:
+#
+#   1. Language       (writes /etc/locale.gen + runs locale-gen + update-locale)
+#   2. Timezone       (timedatectl set-timezone)
+#   3. Persistence    (records intent in /etc/elizaos/persistence-intent;
+#                      actual LUKS-on-USB persistence is not yet implemented
+#                      in elizaos/ — that subsystem was Tails-derived and lost
+#                      with the variants/milady-tails removal in 4c96fee98e;
+#                      recording the intent here so a future installer hook can
+#                      honor it without re-asking the user)
+#
+# Fail-closed: if whiptail / locale-gen / timedatectl are unavailable, log
+# the gap and mark the wizard complete with defaults rather than blocking
+# boot. This is a UX wizard, not a release gate.
+#
+# Non-interactive auto-skip: when ELIZAOS_NONINTERACTIVE=1 is set (CI, QEMU
+# smoke tests, scripted builds) or stdin is not a TTY, the wizard records
+# defaults (en_US.UTF-8 / UTC / persistence=disabled) without prompting and
+# exits 0. This keeps elizaos-first-boot-wizard.service from hanging
+# `multi-user.target` in any unattended boot path.
+
+set -eu
+
+STATE=/var/lib/elizaos
+ETC=/etc/elizaos
+MARK="${STATE}/.first-boot-wizard-complete"
+
+emit() {
+    echo "elizaos-first-boot-wizard: $*"
+    echo "elizaos-first-boot-wizard: $*" >/dev/kmsg 2>/dev/null || true
+}
+
+if [ -e "${MARK}" ]; then
+    emit "wizard already complete; skip"
+    exit 0
+fi
+
+mkdir -p "${STATE}" "${ETC}"
+
+write_defaults() {
+    reason="${1:-defaults}"
+    emit "applying defaults (${reason}): LANG=en_US.UTF-8 TZ=UTC persistence=disabled"
+    printf 'LANG=en_US.UTF-8\nTZ=UTC\n' >"${ETC}/locale-tz.env"
+    printf 'intent=disabled\nreason=%s\n' "${reason}" >"${ETC}/persistence-intent"
+}
+
+if [ "${ELIZAOS_NONINTERACTIVE:-0}" = "1" ] || [ ! -t 0 ]; then
+    write_defaults "non-interactive-boot"
+    touch "${MARK}"
+    exit 0
+fi
+
+if ! command -v whiptail >/dev/null 2>&1; then
+    write_defaults "whiptail-unavailable"
+    touch "${MARK}"
+    exit 0
+fi
+
+# Language menu. Keep the list small + obviously-extensible; full locale list
+# would be hundreds of entries that swamp the TUI.
+if LANG_CHOICE=$(whiptail \
+        --title "elizaOS Setup — Language" \
+        --notags --noitem \
+        --menu "Choose your language:" 16 60 6 \
+        en_US.UTF-8 "English (United States)" \
+        en_GB.UTF-8 "English (United Kingdom)" \
+        es_ES.UTF-8 "Spanish (Spain)" \
+        fr_FR.UTF-8 "French (France)" \
+        de_DE.UTF-8 "German (Germany)" \
+        ja_JP.UTF-8 "Japanese (Japan)" \
+        3>&1 1>&2 2>&3); then
+    if [ -f /etc/locale.gen ] && command -v locale-gen >/dev/null 2>&1; then
+        # Uncomment the chosen locale line (Debian's stock format is
+        # "# en_US.UTF-8 UTF-8") then generate.
+        sed -i "s|^# *${LANG_CHOICE}|${LANG_CHOICE}|" /etc/locale.gen || true
+        locale-gen >/dev/null 2>&1 || emit "locale-gen failed; default UTF-8 remains"
+        if command -v update-locale >/dev/null 2>&1; then
+            update-locale LANG="${LANG_CHOICE}" >/dev/null 2>&1 || true
+        fi
+    fi
+else
+    LANG_CHOICE="en_US.UTF-8"
+fi
+
+# Timezone menu. Same minimalism — TZ_CHOICE is fed straight to timedatectl
+# which validates against /usr/share/zoneinfo so a typo here would fail
+# cleanly rather than silently mis-set the clock.
+if TZ_CHOICE=$(whiptail \
+        --title "elizaOS Setup — Timezone" \
+        --notags --noitem \
+        --menu "Choose your timezone:" 18 60 9 \
+        America/New_York "US Eastern" \
+        America/Chicago "US Central" \
+        America/Denver "US Mountain" \
+        America/Los_Angeles "US Pacific" \
+        Europe/London "UK / Ireland" \
+        Europe/Berlin "Central Europe" \
+        Asia/Tokyo "Japan" \
+        Asia/Shanghai "China / Singapore" \
+        UTC "UTC (no offset)" \
+        3>&1 1>&2 2>&3); then
+    if command -v timedatectl >/dev/null 2>&1; then
+        timedatectl set-timezone "${TZ_CHOICE}" 2>/dev/null \
+            || emit "timedatectl rejected ${TZ_CHOICE}; UTC retained"
+    fi
+else
+    TZ_CHOICE="UTC"
+fi
+
+# Persistence intent. We DO NOT implement LUKS-on-USB persistence here —
+# that was the Tails-derived flow under variants/milady-tails/ that Shaw
+# removed in 4c96fee98e and the consolidated elizaos/ tree has not yet
+# replaced. Record the user's preference so a future install-time hook
+# (or a separate, schedulable persistence-setup pass) can honor it
+# without re-asking.
+if whiptail \
+        --title "elizaOS Setup — Encrypted persistence" \
+        --yesno "Would you like encrypted persistence on this USB?\n\nNote: the on-USB LUKS persistence subsystem is not yet shipped in the consolidated elizaos build. Your answer is recorded for a future installer pass; the system will boot read-only-with-tmpfs-state for now either way." \
+        14 70; then
+    PERSIST_INTENT=enabled
+else
+    PERSIST_INTENT=disabled
+fi
+
+printf 'LANG=%s\nTZ=%s\n' "${LANG_CHOICE}" "${TZ_CHOICE}" >"${ETC}/locale-tz.env"
+printf 'intent=%s\nreason=user-choice\nasked_at=%s\n' \
+    "${PERSIST_INTENT}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    >"${ETC}/persistence-intent"
+
+emit "wizard complete: LANG=${LANG_CHOICE} TZ=${TZ_CHOICE} persistence=${PERSIST_INTENT}"
+touch "${MARK}"

--- a/packages/os/linux/elizaos/config/package-lists/elizaos-common.list.chroot
+++ b/packages/os/linux/elizaos/config/package-lists/elizaos-common.list.chroot
@@ -28,6 +28,14 @@ libgl1-mesa-dri
 libegl1
 fonts-dejavu-core
 
+# First-boot interactive setup wizard (language / timezone / persistence
+# intent). Whiptail's pure-TUI newt-based menus work on /dev/tty1 before
+# the kiosk grabs the seat; locales generates the chosen LANG; tzdata
+# carries the zoneinfo db for timedatectl set-timezone.
+whiptail
+locales
+tzdata
+
 # elizaOS runtime dependencies.
 ca-certificates
 curl


### PR DESCRIPTION
## What

Restores the user-facing first-boot setup TUI that the milady-tails fork carried (language → timezone → optional encrypted persistence). `4c96fee98e` "os/linux: consolidate to single elizaOS multi-arch build, remove Tails fork" deleted that TUI with the rest of the Tails tree; the replacement `first-boot.sh` in `elizaos/` is non-interactive (instance-id + health-check + TUI smoke).

This PR adds it back, scoped to what's actually implementable in the consolidated tree.

## Why now

Direct DM context with @shawmakesmagic — Shaw is currently testing kiosk mode and asked "i'm not sure if this is what we want tbh". The bare kiosk-with-no-onboarding flow lands on the launcher with zero ceremony; the prior hybrid kiosk (which Shaw's consolidation partially nuked) gave the user a language/timezone/encryption-intent prompt first. This PR is the minimum restore-of-UX that doesn't require resurrecting the deleted Tails subtree.

## Files

```
packages/os/linux/elizaos/config/includes.chroot/
  usr/local/lib/elizaos/first-boot-wizard.sh                   (new)
  etc/systemd/system/elizaos-first-boot-wizard.service         (new)
packages/os/linux/elizaos/config/hooks/normal/
  0010-elizaos-agent.hook.chroot                               (enable service)
  0020-enable-user-units.hook.chroot                           (chmod +x)
packages/os/linux/elizaos/config/package-lists/
  elizaos-common.list.chroot                                   (whiptail, locales, tzdata)
```

## How it's wired

- `elizaos-first-boot-wizard.service` is `Type=oneshot`, `Before=getty@tty1.service elizaos-first-boot.service multi-user.target`, gated by `ConditionPathExists=!/var/lib/elizaos/.first-boot-wizard-complete`. It owns `/dev/tty1` via `TTYPath` + `TTYReset=yes` + `TTYVHangup=yes` so prompts paint on the active console *before* autologin + cage grab the seat.
- Wizard runs:
  1. **Language** — whiptail menu of 6 common locales → uncomments the chosen line in `/etc/locale.gen`, runs `locale-gen`, `update-locale LANG=…`.
  2. **Timezone** — whiptail menu of 9 zones → `timedatectl set-timezone …`.
  3. **Persistence intent** — yes/no → writes `/etc/elizaos/persistence-intent` with `intent=enabled|disabled` + `asked_at` timestamp.
- Marks `/var/lib/elizaos/.first-boot-wizard-complete` so re-boots skip the wizard.

## Fail-closed UX gates

| Condition | Behavior |
|---|---|
| `ELIZAOS_NONINTERACTIVE=1` env (CI/QEMU/automated builds) | Write defaults (en_US.UTF-8 / UTC / persistence=disabled), mark complete, exit 0 |
| stdin not a TTY (headless boot, scripted) | Same as above |
| `whiptail` not installed at runtime | Same as above |
| `locale-gen` / `timedatectl` failure | Log gap, continue boot — wizard is UX, not a release gate |

This is critical for the existing QEMU smoke flow (`scripts/qemu_virt_boot_riscv64.sh` → `qemu_virt_smoke.py`) which boots `-nographic`; without these escape hatches the wizard would block `multi-user.target` forever in CI.

## Scope note — encrypted persistence is a stub here

The on-USB LUKS persistence flow milady-tails shipped (`cryptsetup luksFormat` + `first_boot_repartition` + a Python `persistence-setup` helper) was hundreds of files of Tails-derived code. It cannot be restored as one PR. This wizard:

1. **Records the user's preference** in `/etc/elizaos/persistence-intent` so a future install-time pass honors it without re-prompting.
2. **Surfaces the limitation in the dialog itself** — quoting verbatim:

   > Note: the on-USB LUKS persistence subsystem is not yet shipped in the consolidated elizaos build. Your answer is recorded for a future installer pass; the system will boot read-only-with-tmpfs-state for now either way.

So the user's consent is captured truthfully (no false promise of encryption) and the file becomes the contract for whichever subsystem ends up owning persistence in the consolidated tree.

## Verified

- `sh -n first-boot-wizard.sh` → ok
- `sh -n 0010-elizaos-agent.hook.chroot` → ok
- `sh -n 0020-enable-user-units.hook.chroot` → ok
- `shellcheck first-boot-wizard.sh` → no findings
- `systemd-analyze verify .service` → only flags the ExecStart path not being executable *on the host* (expected; chroot is what runs it, and hook 0020 chmods it 0755 there)
- Every interactive prompt has a non-interactive default + early exit path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the first-boot interactive TUI wizard that was removed when the milady-tails fork was consolidated. It adds a `whiptail`-based three-step setup screen (language → timezone → persistence intent) that runs on `/dev/tty1` before getty/autologin hand off the seat to the kiosk compositor.

- `first-boot-wizard.sh` and its systemd unit are wired `Before=getty@tty1.service elizaos-first-boot.service`, gated by a completion marker, with correct non-interactive fallbacks for CI and headless QEMU boots.
- The persistence step is intentionally a stub — it records the user's preference to `/etc/elizaos/persistence-intent` for a future LUKS-on-USB installer pass rather than attempting any actual encryption.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the wizard is additive and well-guarded, with no impact on existing boot paths when the marker file is present or stdin is not a TTY.

The core non-interactive escape (TTY check) is sound and protects the QEMU smoke test path. Two small issues exist: the service unit documents /etc/environment and ImportCredential as non-interactive bypass mechanisms but the hardcoded Environment=ELIZAOS_NONINTERACTIVE=0 makes those paths non-functional; and the sed locale-uncomment uses an unescaped dot regex metacharacter. Neither affects the common interactive or QEMU headless boot paths.

first-boot-wizard.service (misleading comment about bypass mechanisms) and first-boot-wizard.sh (sed metacharacter, persistence-intent schema inconsistency).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/os/linux/elizaos/config/includes.chroot/usr/local/lib/elizaos/first-boot-wizard.sh | New TUI wizard: well-structured with correct non-interactive escapes, but uses unescaped regex metacharacter in sed locale match and produces an inconsistent persistence-intent schema between interactive and non-interactive paths. |
| packages/os/linux/elizaos/config/includes.chroot/etc/systemd/system/elizaos-first-boot-wizard.service | Service ordering and TTY setup look correct; hardcoded Environment=ELIZAOS_NONINTERACTIVE=0 contradicts the comment's claim that /etc/environment and ImportCredential are valid bypass mechanisms. |
| packages/os/linux/elizaos/config/hooks/normal/0010-elizaos-agent.hook.chroot | Adds systemctl enable for the new wizard service in the correct position (before elizaos-first-boot.service), no issues. |
| packages/os/linux/elizaos/config/hooks/normal/0020-enable-user-units.hook.chroot | Adds first-boot-wizard.sh to the chmod 0755 list alongside existing scripts; straightforward and correct. |
| packages/os/linux/elizaos/config/package-lists/elizaos-common.list.chroot | Adds whiptail, locales, and tzdata to the package list; all three are necessary for the wizard's runtime dependencies. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(os/linux): restore first-boot inter..."](https://github.com/elizaos/eliza/commit/cbd500ad62d213e390989e3c214bde637cdc872c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33632401)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->