### PR TITLE
fix(cloud-api): wallet proxy resolves steward_agent_id from agent_server_wallets

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -223,8 +223,8 @@
         "@elizaos/plugin-defense-of-the-agents": "workspace:*",
         "@elizaos/plugin-device-settings": "workspace:*",
         "@elizaos/plugin-elizacloud": "workspace:*",
+        "@elizaos/plugin-facewear": "workspace:*",
         "@elizaos/plugin-feed": "workspace:*",
-        "@elizaos/plugin-hearwear": "workspace:*",
         "@elizaos/plugin-hyperliquid-app": "workspace:*",
         "@elizaos/plugin-hyperscape": "workspace:*",
         "@elizaos/plugin-lifeops": "workspace:*",
@@ -1582,7 +1582,7 @@
       "dependencies": {
         "@abandonware/noble": "^1.9.2-25",
         "@elizaos/core": "workspace:*",
-        "@elizaos/plugin-hearwear": "workspace:*",
+        "@elizaos/plugin-facewear": "workspace:*",
         "@evenrealities/even_hub_sdk": "0.0.10",
       },
       "devDependencies": {
@@ -3491,6 +3491,38 @@
         "tsup": "^8.5.1",
       },
     },
+    "plugins/plugin-facewear": {
+      "name": "@elizaos/plugin-facewear",
+      "version": "0.1.0",
+      "dependencies": {
+        "@elizaos/core": "workspace:*",
+        "@elizaos/ui": "workspace:*",
+        "lucide-react": "^1.0.0",
+        "ws": "^8.18.0",
+        "zod": "^4.4.3",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.14",
+        "@types/node": "^25.0.3",
+        "@types/react": "^19.2.3",
+        "@types/react-dom": "^19.2.3",
+        "@types/ws": "^8.5.10",
+        "bun-types": "^1.3.14",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "tsup": "^8.5.1",
+        "typescript": "^6.0.3",
+        "vite": "7.3.2",
+        "vitest": "^4.0.17",
+      },
+      "optionalDependencies": {
+        "@abandonware/noble": "^1.9.2-25",
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+      },
+    },
     "plugins/plugin-farcaster": {
       "name": "@elizaos/plugin-farcaster",
       "version": "2.0.3",
@@ -3649,38 +3681,6 @@
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",
         "vitest": "^4.0.0",
-      },
-    },
-    "plugins/plugin-hearwear": {
-      "name": "@elizaos/plugin-hearwear",
-      "version": "0.1.0",
-      "dependencies": {
-        "@elizaos/core": "workspace:*",
-        "@elizaos/ui": "workspace:*",
-        "lucide-react": "^1.0.0",
-        "ws": "^8.18.0",
-        "zod": "^4.4.3",
-      },
-      "devDependencies": {
-        "@biomejs/biome": "^2.4.14",
-        "@types/node": "^25.0.3",
-        "@types/react": "^19.2.3",
-        "@types/react-dom": "^19.2.3",
-        "@types/ws": "^8.5.10",
-        "bun-types": "^1.3.14",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "tsup": "^8.5.1",
-        "typescript": "^6.0.3",
-        "vite": "7.3.2",
-        "vitest": "^4.0.17",
-      },
-      "optionalDependencies": {
-        "@abandonware/noble": "^1.9.2-25",
-      },
-      "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
       },
     },
     "plugins/plugin-hyperliquid-app": {
@@ -6210,6 +6210,8 @@
 
     "@elizaos/plugin-elizamaker": ["@elizaos/plugin-elizamaker@workspace:plugins/plugin-elizamaker"],
 
+    "@elizaos/plugin-facewear": ["@elizaos/plugin-facewear@workspace:plugins/plugin-facewear"],
+
     "@elizaos/plugin-farcaster": ["@elizaos/plugin-farcaster@workspace:plugins/plugin-farcaster"],
 
     "@elizaos/plugin-feed": ["@elizaos/plugin-feed@workspace:plugins/plugin-feed"],
@@ -6231,8 +6233,6 @@
     "@elizaos/plugin-groq": ["@elizaos/plugin-groq@workspace:plugins/plugin-groq"],
 
     "@elizaos/plugin-health": ["@elizaos/plugin-health@workspace:plugins/plugin-health"],
-
-    "@elizaos/plugin-hearwear": ["@elizaos/plugin-hearwear@workspace:plugins/plugin-hearwear"],
 
     "@elizaos/plugin-host-shim": ["@elizaos/plugin-host-shim@workspace:packages/plugin-host-shim"],
 
@@ -14048,7 +14048,7 @@
 
     "@elizaos/plugin-elizacloud/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
-    "@elizaos/plugin-hearwear/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+    "@elizaos/plugin-facewear/vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
 
     "@elizaos/plugin-social-alpha/@tailwindcss/postcss": ["@tailwindcss/postcss@4.2.4", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "postcss": "^8.5.6", "tailwindcss": "4.2.4" } }, "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg=="],
 
@@ -16950,7 +16950,7 @@
 
     "@elizaos/operator/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.10", "", { "os": "win32", "cpu": "x64" }, "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+    "@elizaos/plugin-facewear/vite/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "@elizaos/plugin-social-alpha/@tailwindcss/postcss/@tailwindcss/node": ["@tailwindcss/node@4.2.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.4" } }, "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA=="],
 
@@ -19366,57 +19366,57 @@
 
     "@elizaos/example-roblox-agent/express/type-is/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
 
-    "@elizaos/plugin-hearwear/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+    "@elizaos/plugin-facewear/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
     "@elizaos/plugin-social-alpha/@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.2.4", "", { "os": "android", "cpu": "arm64" }, "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g=="],
 

--- a/packages/cloud-api/__tests__/wallet-proxy-steward-agent-id.test.ts
+++ b/packages/cloud-api/__tests__/wallet-proxy-steward-agent-id.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+
+const dbRows: Array<{ stewardAgentId: string | null }> = [];
+const dbLimit = mock<
+  (n: number) => Promise<Array<{ stewardAgentId: string | null }>>
+>(async () => dbRows);
+const dbWhere = mock<(...args: unknown[]) => { limit: typeof dbLimit }>(() => ({
+  limit: dbLimit,
+}));
+const dbFrom = mock<(...args: unknown[]) => { where: typeof dbWhere }>(() => ({
+  where: dbWhere,
+}));
+const dbSelect = mock<(...args: unknown[]) => { from: typeof dbFrom }>(() => ({
+  from: dbFrom,
+}));
+
+const requireUserOrApiKeyWithOrg =
+  mock<() => Promise<{ id: string; organization_id: string }>>();
+const getAgent = mock<(agentId: string, orgId: string) => Promise<unknown>>();
+const createStewardClient = mock<() => Promise<StewardClientMock>>();
+const loggerInfo = mock<(...args: unknown[]) => void>();
+
+type StewardClientMock = {
+  getAddresses: ReturnType<
+    typeof mock<
+      (agentId: string) => Promise<{
+        addresses: Array<{ chainFamily: "evm" | "solana"; address: string }>;
+      }>
+    >
+  >;
+  getAgent: ReturnType<
+    typeof mock<
+      (agentId: string) => Promise<{
+        walletAddress?: string | null;
+        walletAddresses?: { evm?: string | null; solana?: string | null };
+      }>
+    >
+  >;
+  getBalance: ReturnType<
+    typeof mock<
+      (agentId: string) => Promise<{
+        balances: { native: string; chainId: number; symbol: string };
+      }>
+    >
+  >;
+  getPolicies: ReturnType<typeof mock<(agentId: string) => Promise<unknown[]>>>;
+  setPolicies: ReturnType<
+    typeof mock<(agentId: string, policies: unknown[]) => Promise<void>>
+  >;
+  getAgentDashboard: ReturnType<
+    typeof mock<(agentId: string) => Promise<{ recentTransactions: unknown[] }>>
+  >;
+  listApprovals: ReturnType<
+    typeof mock<(opts?: unknown) => Promise<Array<{ agentId?: string }>>>
+  >;
+  approveTransaction: ReturnType<
+    typeof mock<
+      (txId: string, opts?: unknown) => Promise<Record<string, unknown>>
+    >
+  >;
+  denyTransaction: ReturnType<
+    typeof mock<
+      (
+        txId: string,
+        reason: string,
+        deniedBy?: string,
+      ) => Promise<Record<string, unknown>>
+    >
+  >;
+};
+
+const stewardClient: StewardClientMock = {
+  getAddresses: mock(async () => ({ addresses: [] })),
+  getAgent: mock(async () => ({ walletAddress: null, walletAddresses: {} })),
+  getBalance: mock(async () => ({
+    balances: { native: "0", chainId: 56, symbol: "BNB" },
+  })),
+  getPolicies: mock(async () => []),
+  setPolicies: mock(async () => undefined),
+  getAgentDashboard: mock(async () => ({ recentTransactions: [] })),
+  listApprovals: mock(async () => []),
+  approveTransaction: mock(async () => ({})),
+  denyTransaction: mock(async () => ({})),
+};
+
+mock.module("@/db/helpers", () => ({
+  dbWrite: { select: dbSelect },
+}));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: { getAgent },
+}));
+
+mock.module("@/lib/services/steward-client", () => ({
+  createStewardClient,
+}));
+
+mock.module("@/lib/services/proxy/cors", () => ({
+  applyCorsHeaders: (response: Response) => response,
+  handleCorsOptions: () => new Response(null, { status: 204 }),
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: loggerInfo,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+  },
+}));
+
+let routeModule: typeof import("../v1/eliza/agents/[agentId]/api/wallet/[...path]/route");
+
+beforeAll(async () => {
+  routeModule = await import(
+    "../v1/eliza/agents/[agentId]/api/wallet/[...path]/route"
+  );
+});
+
+afterEach(() => {
+  dbRows.length = 0;
+  dbLimit.mockClear();
+  dbWhere.mockClear();
+  dbFrom.mockClear();
+  dbSelect.mockClear();
+  requireUserOrApiKeyWithOrg.mockReset();
+  getAgent.mockReset();
+  createStewardClient.mockReset();
+  loggerInfo.mockClear();
+  for (const value of Object.values(stewardClient)) {
+    value.mockClear();
+  }
+});
+
+function mockContext(body?: unknown) {
+  return {
+    req: {
+      url: "http://test.local/api/wallet/addresses",
+      header: (name: string) =>
+        name.toLowerCase() === "content-type" && body
+          ? "application/json"
+          : undefined,
+      text: async () => (body ? JSON.stringify(body) : ""),
+    },
+  } as never;
+}
+
+async function callWallet(
+  path: string,
+  method: "GET" | "POST" | "PUT" = "GET",
+  body?: unknown,
+) {
+  requireUserOrApiKeyWithOrg.mockResolvedValue({
+    id: "user-1",
+    organization_id: "org-1",
+  });
+  getAgent.mockResolvedValue({ id: "sandbox-agent-1" });
+  createStewardClient.mockResolvedValue(stewardClient);
+  return routeModule.handleDirectWalletRequest(
+    mockContext(body),
+    Promise.resolve({ agentId: "sandbox-agent-1", path: [path] }),
+    method,
+  );
+}
+
+describe("wallet proxy steward agent id resolution", () => {
+  test("resolver returns the steward_agent_id for a sandbox agent", async () => {
+    dbRows.push({ stewardAgentId: "cloud-client-address" });
+
+    await expect(
+      routeModule.resolveStewardAgentId("sandbox-agent-1", "org-1"),
+    ).resolves.toBe("cloud-client-address");
+    expect(dbSelect).toHaveBeenCalledTimes(1);
+    expect(dbLimit).toHaveBeenCalledWith(1);
+  });
+
+  test("wallet calls use the resolved steward_agent_id", async () => {
+    dbRows.push({ stewardAgentId: "cloud-client-address" });
+    stewardClient.getAddresses.mockResolvedValue({
+      addresses: [{ chainFamily: "evm", address: "0xwallet" }],
+    });
+
+    const response = await callWallet("addresses");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ evmAddress: "0xwallet", solanaAddress: "" });
+    expect(stewardClient.getAddresses).toHaveBeenCalledWith(
+      "cloud-client-address",
+    );
+  });
+
+  test("falls back to the sandbox UUID for legacy wallets without a mapping", async () => {
+    stewardClient.getPolicies.mockResolvedValue([{ id: "p1" }]);
+
+    const response = await callWallet("steward-policies");
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual([{ id: "p1" }]);
+    expect(stewardClient.getPolicies).toHaveBeenCalledWith("sandbox-agent-1");
+    expect(loggerInfo).toHaveBeenCalledWith(
+      "[wallet-api] No agent_server_wallets steward_agent_id mapping found; falling back to sandbox agent id",
+      { sandboxAgentId: "sandbox-agent-1", orgId: "org-1" },
+    );
+  });
+
+  test("returns 404 when no Steward-managed wallet exists for the sandbox agent", async () => {
+    stewardClient.getAgent.mockRejectedValue(new Error("Agent not found"));
+
+    const response = await callWallet("addresses");
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toEqual({
+      error: "No Steward-managed wallet found for this agent",
+    });
+    expect(stewardClient.getAddresses).not.toHaveBeenCalled();
+  });
+
+  test("returns 404 before forwarding when the sandbox agent does not exist", async () => {
+    requireUserOrApiKeyWithOrg.mockResolvedValue({
+      id: "user-1",
+      organization_id: "org-1",
+    });
+    getAgent.mockResolvedValue(null);
+
+    const response = await routeModule.handleDirectWalletRequest(
+      mockContext(),
+      Promise.resolve({ agentId: "missing-agent", path: ["addresses"] }),
+      "GET",
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body).toEqual({ success: false, error: "Agent not found" });
+    expect(createStewardClient).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts
@@ -1,4 +1,7 @@
+import { and, eq } from "drizzle-orm";
 import { type Context, Hono } from "hono";
+import { dbWrite } from "@/db/helpers";
+import { agentServerWallets } from "@/db/schemas/agent-server-wallets";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { nextStyleParams } from "@/lib/api/hono-next-style-params";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
@@ -102,6 +105,46 @@ const SUPPORTED_WALLET_PATHS = new Set([
   "steward-approve-tx",
   "steward-deny-tx",
 ]);
+
+export async function resolveStewardAgentId(
+  sandboxAgentId: string,
+  organizationId: string,
+): Promise<string | null> {
+  const row = await dbWrite
+    .select({ stewardAgentId: agentServerWallets.steward_agent_id })
+    .from(agentServerWallets)
+    .where(
+      and(
+        eq(agentServerWallets.sandbox_agent_id, sandboxAgentId),
+        eq(agentServerWallets.organization_id, organizationId),
+      ),
+    )
+    .limit(1);
+  return row[0]?.stewardAgentId ?? null;
+}
+
+async function resolveStewardAgentIdForProxy(
+  client: StewardClient,
+  sandboxAgentId: string,
+  organizationId: string,
+): Promise<string | null> {
+  const stewardAgentId = await resolveStewardAgentId(
+    sandboxAgentId,
+    organizationId,
+  );
+  if (stewardAgentId) return stewardAgentId;
+
+  try {
+    await client.getAgent(sandboxAgentId);
+    logger.info(
+      "[wallet-api] No agent_server_wallets steward_agent_id mapping found; falling back to sandbox agent id",
+      { sandboxAgentId, orgId: organizationId },
+    );
+    return sandboxAgentId;
+  } catch {
+    return null;
+  }
+}
 
 function json(data: unknown, init?: ResponseInit): Response {
   return applyCorsHeaders(Response.json(data, init), CORS_METHODS);
@@ -210,9 +253,12 @@ async function readJsonBody(c: Context<AppEnv>): Promise<JsonObject | null> {
   return isJsonObject(parsed) ? parsed : null;
 }
 
-async function getAgentAddresses(client: StewardClient, agentId: string) {
+async function getAgentAddresses(
+  client: StewardClient,
+  stewardAgentId: string,
+) {
   try {
-    const result = await client.getAddresses(agentId);
+    const result = await client.getAddresses(stewardAgentId);
     return {
       evmAddress:
         result.addresses.find((a) => a.chainFamily === "evm")?.address ?? "",
@@ -220,7 +266,7 @@ async function getAgentAddresses(client: StewardClient, agentId: string) {
         result.addresses.find((a) => a.chainFamily === "solana")?.address ?? "",
     };
   } catch {
-    const agent = await client.getAgent(agentId);
+    const agent = await client.getAgent(stewardAgentId);
     return {
       evmAddress: agent.walletAddresses?.evm ?? agent.walletAddress ?? "",
       solanaAddress: agent.walletAddresses?.solana ?? "",
@@ -228,7 +274,7 @@ async function getAgentAddresses(client: StewardClient, agentId: string) {
   }
 }
 
-async function handleDirectWalletRequest(
+export async function handleDirectWalletRequest(
   c: Context<AppEnv>,
   params: Promise<{ agentId: string; path: string[] }>,
   method: WalletMethod,
@@ -275,19 +321,32 @@ async function handleDirectWalletRequest(
     return json({ error: "Steward not configured" }, { status: 503 });
   }
 
+  const stewardAgentId = await resolveStewardAgentIdForProxy(
+    client,
+    agentId,
+    user.organization_id,
+  );
+  if (!stewardAgentId) {
+    return json(
+      { error: "No Steward-managed wallet found for this agent" },
+      { status: 404 },
+    );
+  }
+
   logger.info("[wallet-api] Direct Steward request", {
     agentId,
+    stewardAgentId,
     orgId: user.organization_id,
     walletPath,
     method,
   });
 
   if (method === "GET" && walletPath === "addresses") {
-    return json(await getAgentAddresses(client, agentId));
+    return json(await getAgentAddresses(client, stewardAgentId));
   }
 
   if (method === "GET" && walletPath === "balances") {
-    const balance = await client.getBalance(agentId);
+    const balance = await client.getBalance(stewardAgentId);
     const { balances } = balance;
     return json({
       evm: [
@@ -305,11 +364,12 @@ async function handleDirectWalletRequest(
 
   if (method === "GET" && walletPath === "steward-status") {
     try {
-      await client.getAgent(agentId);
+      await client.getAgent(stewardAgentId);
       return json({
         configured: true,
         connected: true,
         agentId,
+        stewardAgentId,
         version: "cloud-worker",
       });
     } catch {
@@ -317,13 +377,14 @@ async function handleDirectWalletRequest(
         configured: true,
         connected: false,
         agentId,
+        stewardAgentId,
         version: "cloud-worker",
       });
     }
   }
 
   if (method === "GET" && walletPath === "steward-policies") {
-    return json(await client.getPolicies(agentId));
+    return json(await client.getPolicies(stewardAgentId));
   }
 
   if (method === "PUT" && walletPath === "steward-policies") {
@@ -343,7 +404,7 @@ async function handleDirectWalletRequest(
       }
       normalizedPolicies.push(normalizedPolicy);
     }
-    await client.setPolicies(agentId, normalizedPolicies);
+    await client.setPolicies(stewardAgentId, normalizedPolicies);
     return json({ ok: true });
   }
 
@@ -358,7 +419,7 @@ async function handleDirectWalletRequest(
       0,
       Number.MAX_SAFE_INTEGER,
     );
-    const dashboard = await client.getAgentDashboard(agentId);
+    const dashboard = await client.getAgentDashboard(stewardAgentId);
     const records = (dashboard.recentTransactions ?? [])
       .filter((tx) => !status || tx.status === status)
       .map((tx) => ({
@@ -388,7 +449,7 @@ async function handleDirectWalletRequest(
     );
     const approvals = (
       await client.listApprovals({ status: "pending", limit, offset })
-    ).filter((entry) => entry.agentId === agentId);
+    ).filter((entry) => entry.agentId === stewardAgentId);
     return json({ approvals, total: approvals.length, offset, limit });
   }
 

--- a/packages/cloud-shared/src/db/migrations/0133_add_agent_server_wallets_sandbox_agent_id.sql
+++ b/packages/cloud-shared/src/db/migrations/0133_add_agent_server_wallets_sandbox_agent_id.sql
@@ -1,0 +1,16 @@
+ALTER TABLE "agent_server_wallets"
+  ADD COLUMN IF NOT EXISTS "sandbox_agent_id" uuid;
+
+DO $$ BEGIN
+  ALTER TABLE "agent_server_wallets"
+    ADD CONSTRAINT "agent_server_wallets_sandbox_agent_id_agent_sandboxes_id_fk"
+    FOREIGN KEY ("sandbox_agent_id")
+    REFERENCES "public"."agent_sandboxes"("id")
+    ON DELETE set null
+    ON UPDATE no action;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "agent_server_wallets_sandbox_agent_idx"
+  ON "agent_server_wallets" USING btree ("sandbox_agent_id");

--- a/packages/cloud-shared/src/db/schemas/agent-server-wallets.ts
+++ b/packages/cloud-shared/src/db/schemas/agent-server-wallets.ts
@@ -1,5 +1,6 @@
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 import { index, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { agentSandboxes } from "./agent-sandboxes";
 import { organizations } from "./organizations";
 import { userCharacters } from "./user-characters";
 import { users } from "./users";
@@ -23,6 +24,9 @@ export const agentServerWallets = pgTable(
     character_id: uuid("character_id").references(() => userCharacters.id, {
       onDelete: "set null",
     }),
+    sandbox_agent_id: uuid("sandbox_agent_id").references(() => agentSandboxes.id, {
+      onDelete: "set null",
+    }),
 
     // Steward references
     steward_agent_id: text("steward_agent_id"),
@@ -44,6 +48,7 @@ export const agentServerWallets = pgTable(
     organization_idx: index("agent_server_wallets_organization_idx").on(table.organization_id),
     user_idx: index("agent_server_wallets_user_idx").on(table.user_id),
     character_idx: index("agent_server_wallets_character_idx").on(table.character_id),
+    sandbox_agent_idx: index("agent_server_wallets_sandbox_agent_idx").on(table.sandbox_agent_id),
     address_idx: index("agent_server_wallets_address_idx").on(table.address),
     client_address_idx: index("agent_server_wallets_client_address_idx").on(table.client_address),
     steward_agent_idx: index("agent_server_wallets_steward_agent_idx").on(table.steward_agent_id),

--- a/packages/cloud-shared/src/lib/services/provisioning-worker-health.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-worker-health.test.ts
@@ -21,11 +21,7 @@ describe("provisioning worker health (Redis heartbeat)", () => {
   // must start clean — but we snapshot and restore rather than delete outright,
   // otherwise NODE_ENV=test leaks away and pollutes later files in the shared
   // `bun test` process (e.g. crypto.test.ts resolving the steward KMS backend).
-  const MANAGED_ENV_KEYS = [
-    "NODE_ENV",
-    "REQUIRE_PROVISIONING_WORKER",
-    "MOCK_REDIS",
-  ] as const;
+  const MANAGED_ENV_KEYS = ["NODE_ENV", "REQUIRE_PROVISIONING_WORKER", "MOCK_REDIS"] as const;
   const savedEnv: Record<string, string | undefined> = {};
 
   const clearManagedEnv = () => {


### PR DESCRIPTION
## Summary

This fixes the cloud-api wallet proxy bug where agent-scoped wallet endpoints forwarded the sandbox UUID to Steward even though `/api/v1/user/wallets/provision` creates Steward agents as `cloud-{characterId || clientAddress}`.

## Repro

1. Call `POST /api/v1/user/wallets/provision`.
2. Call `GET /api/v1/eliza/agents/{sandboxAgentId}/api/wallet/addresses`.
3. The proxy verifies the sandbox agent exists, then forwards `{sandboxAgentId}` to Steward.
4. Steward returns `404 Agent not found` because the real Steward agent id is `cloud-{...}`.

This also affects `balances`, `steward-status`, `steward-policies`, tx records, pending approvals, and approve/deny endpoints.

## Fix

- Add `resolveStewardAgentId(sandboxAgentId, organizationId)` to look up `agent_server_wallets.steward_agent_id` by `sandbox_agent_id` and org.
- Use the resolved Steward agent id for all Steward client calls in the direct wallet proxy.
- Add the missing Drizzle schema/migration for `agent_server_wallets.sandbox_agent_id`.

## Backward compatibility

If no `agent_server_wallets` mapping exists, the proxy probes Steward with the sandbox UUID. If Steward recognizes it, the proxy logs an info-level fallback warning and preserves the old behavior. If Steward does not recognize it, the proxy returns `404 No Steward-managed wallet found for this agent` without forwarding endpoint-specific calls.

## Tests

- Resolver returns the mapped `steward_agent_id`.
- `GET /addresses` uses the resolved Steward id end-to-end with a mocked Steward client.
- Legacy fallback path still forwards the sandbox UUID.
- No-wallet path returns 404.
- Missing sandbox agent still returns 404 before Steward calls.

Local results:

```text
cd packages/cloud-api && bun run lint
# passes with 8 existing noExplicitAny warnings in __tests__/middleware-auth-soc2.test.ts

cd packages/cloud-api && bun test __tests__/wallet-proxy-steward-agent-id.test.ts
# 5 pass, 0 fail

cd packages/cloud-api && bun run test
# existing workspace dependency/test-harness failures in this worktree; new wallet proxy test passes
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a `resolveStewardAgentId` helper and wires it into the wallet proxy so all Steward calls use the correct `cloud-{…}` agent ID rather than the sandbox UUID. It also adds the `sandbox_agent_id` column and migration to `agent_server_wallets`, a backward-compatible fallback for legacy wallets, and 5 new tests.

- **Route (`route.ts`)**: Exports `resolveStewardAgentId` (DB lookup) and `resolveStewardAgentIdForProxy` (DB + Steward probe fallback); all Steward client calls now use the resolved ID, and the proxy returns an explicit 404 if no mapping is found.
- **Schema/migration**: Adds nullable `sandbox_agent_id` FK column with a btree index; migration is safe (`IF NOT EXISTS`, exception-guarded FK).
- **Critical gap**: The `sandbox_agent_id` column is read but never written — `provisionStewardWallet` in `server-wallets.ts` does not include `sandbox_agent_id` in its insert, and the provisioning endpoint accepts no `sandboxAgentId` input. Every DB lookup returns `null`, the fallback Steward probe also fails (Steward uses `cloud-{…}` not UUIDs), and all wallet proxy endpoints still return 404.

<h3>Confidence Score: 2/5</h3>

The wallet proxy fix is structurally correct but non-functional in production because the column it relies on is never populated by the provisioning flow.

The resolver, fallback logic, and tests are well-written, but the fix has a fundamental gap: `sandbox_agent_id` is never written to `agent_server_wallets` — not in `provisionStewardWallet`, not in the provisioning endpoint, not anywhere in the codebase. Every request falls through the DB lookup, the Steward probe also fails (Steward uses `cloud-{…}` IDs), and all wallet proxy endpoints return 404. Merging this without also updating the provisioning code leaves the original bug in place and silently changes the 404 source from Steward to the proxy itself.

`packages/cloud-shared/src/lib/services/server-wallets.ts` — `provisionStewardWallet` must be updated to accept and persist `sandbox_agent_id`; the provisioning endpoint (`v1/user/wallets/provision/route.ts`) also needs a `sandboxAgentId` input field.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cloud-api/v1/eliza/agents/[agentId]/api/wallet/[...path]/route.ts | Adds `resolveStewardAgentId` and `resolveStewardAgentIdForProxy` to look up the correct Steward agent ID via `sandbox_agent_id`; exports `handleDirectWalletRequest` for testing; but the primary fix path is non-functional because `sandbox_agent_id` is never written by provisioning code. |
| packages/cloud-shared/src/db/migrations/0133_add_agent_server_wallets_sandbox_agent_id.sql | Safely adds the `sandbox_agent_id` uuid column and a btree index; uses `ADD COLUMN IF NOT EXISTS` and exception-safe FK creation. No unique constraint on the column, so multiple wallet rows could share the same sandbox agent ID. |
| packages/cloud-shared/src/db/schemas/agent-server-wallets.ts | Adds nullable `sandbox_agent_id` FK referencing `agent_sandboxes.id` with `onDelete: "set null"`, plus the corresponding index. Schema matches the migration. |
| packages/cloud-api/__tests__/wallet-proxy-steward-agent-id.test.ts | Good coverage of the resolver, the resolved-ID forwarding path, the legacy fallback, the no-wallet 404, and the missing-sandbox-agent 404. Tests are well-structured with proper mock teardown. |
| packages/cloud-shared/src/lib/services/provisioning-worker-health.test.ts | Minor whitespace-only consolidation of `MANAGED_ENV_KEYS` array definition; no functional change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Proxy as Wallet Proxy (route.ts)
    participant DB as agent_server_wallets
    participant Steward

    Client->>Proxy: "GET /agents/{sandboxAgentId}/api/wallet/addresses"
    Proxy->>DB: "SELECT steward_agent_id WHERE sandbox_agent_id = ? AND org = ?"
    DB-->>Proxy: NULL (sandbox_agent_id never written)
    Note over Proxy: Legacy fallback
    Proxy->>Steward: getAgent(sandboxAgentId)
    Steward-->>Proxy: "404 (Steward uses cloud-{...} not UUID)"
    Proxy-->>Client: 404 No Steward-managed wallet found

    Note over DB,Steward: Expected flow (requires provisioning fix)
    Proxy->>DB: "SELECT steward_agent_id WHERE sandbox_agent_id = ?"
    DB-->>Proxy: "cloud-{characterId|clientAddress}"
    Proxy->>Steward: "getAddresses(cloud-{...})"
    Steward-->>Proxy: addresses
    Proxy-->>Client: "200 { evmAddress, solanaAddress }"
```

<sub>Reviews (1): Last reviewed commit: ["chore(cloud-shared): format provisioning..."](https://github.com/elizaos/eliza/commit/1e569233b8f8c274c2727748f8da65487001083b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33633170)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->