### PR TITLE
feat(cloud-api): ERC-8004 register-identity endpoint + TS client

### DIFF
--- a/packages/cloud-api/__tests__/erc8004-identity-policy.test.ts
+++ b/packages/cloud-api/__tests__/erc8004-identity-policy.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { ERC8004_IDENTITY_REGISTRY_ADDRESSES } from "@/lib/services/erc8004/identity-client";
+import { policiesAllowRegister } from "../v1/eliza/agents/[agentId]/api/identity/policy";
+
+const registry = ERC8004_IDENTITY_REGISTRY_ADDRESSES[56];
+
+function policies(opts: { chain?: string; address?: string }) {
+  return [
+    {
+      id: "allowed-chains",
+      type: "allowed-chains",
+      enabled: true,
+      config: { chainIds: [opts.chain ?? "56"] },
+    },
+    {
+      id: "approved-addresses",
+      type: "approved-addresses",
+      enabled: true,
+      config: { addresses: [opts.address ?? registry] },
+    },
+  ];
+}
+
+describe("ERC-8004 Steward policy gate", () => {
+  test("allows register when chain and registry are approved", () => {
+    expect(policiesAllowRegister(policies({}), 56, registry)).toEqual({
+      allowed: true,
+    });
+  });
+
+  test("returns 403-equivalent denial reason when policy denies the chain", () => {
+    expect(
+      policiesAllowRegister(policies({ chain: "97" }), 56, registry),
+    ).toEqual({
+      allowed: false,
+      reason: "chain 56 is not allowed by Steward policy",
+    });
+  });
+
+  test("returns 403-equivalent denial reason when registry is not allowlisted", () => {
+    expect(
+      policiesAllowRegister(
+        policies({ address: "0x0000000000000000000000000000000000000001" }),
+        56,
+        registry,
+      ),
+    ).toEqual({
+      allowed: false,
+      reason: "IdentityRegistry address is not approved by Steward policy",
+    });
+  });
+});

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/common.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/common.ts
@@ -1,0 +1,287 @@
+import { and, eq } from "drizzle-orm";
+import type { Context } from "hono";
+import { type Address, encodeFunctionData, type Hash, isAddress } from "viem";
+import { bscTestnet } from "viem/chains";
+import { dbWrite } from "@/db/helpers";
+import { agentIdentities } from "@/db/schemas/agent-identities";
+import { agentServerWallets } from "@/db/schemas/agent-server-wallets";
+import { failureResponse } from "@/lib/api/cloud-worker-errors";
+import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import { resolveEvmRpc } from "@/lib/config/evm-rpc";
+import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
+import {
+  ERC8004_IDENTITY_REGISTRY_ADDRESSES,
+  type ERC8004ChainId,
+  ERC8004IdentityClient,
+  identityRegistryAbi,
+} from "@/lib/services/erc8004/identity-client";
+import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
+import { createStewardClient } from "@/lib/services/steward-client";
+import { logger } from "@/lib/utils/logger";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import { resolveStewardAgentId } from "../wallet/[...path]/route";
+
+export { policiesAllowRegister } from "./policy";
+
+export const CORS_METHODS = "GET, POST, PUT, OPTIONS";
+export const STANDARD = "erc-8004";
+
+type StewardIdentityClient = {
+  getPolicies(agentId: string): Promise<StewardPolicyRule[]>;
+  signTransaction?: (
+    agentId: string,
+    tx: { to: string; value: string; data: string; chainId: number },
+  ) => Promise<unknown>;
+};
+
+export function optionsResponse() {
+  return handleCorsOptions(CORS_METHODS);
+}
+
+export function json(data: unknown, init?: ResponseInit): Response {
+  return applyCorsHeaders(Response.json(data, init), CORS_METHODS);
+}
+
+export function clearDbDependencyError(error: unknown): Response | null {
+  const message = error instanceof Error ? error.message : String(error);
+  if (
+    /agent_identities|relation .* does not exist|column .* does not exist/i.test(
+      message,
+    )
+  ) {
+    return json(
+      {
+        success: false,
+        error:
+          "agent_identities table is not available yet; apply Track 1A migration before enabling ERC-8004 identity endpoints",
+      },
+      { status: 503 },
+    );
+  }
+  return null;
+}
+
+export function rpcUrlForChain(chainId: ERC8004ChainId): string {
+  if (chainId === 56) return resolveEvmRpc("bnb").url;
+  return bscTestnet.rpcUrls.default.http[0];
+}
+
+export function normalizeChainId(value: unknown): ERC8004ChainId | null {
+  return value === 56 || value === 97 ? value : null;
+}
+
+export function defaultRegistry(chainId: ERC8004ChainId): Address {
+  return ERC8004_IDENTITY_REGISTRY_ADDRESSES[chainId];
+}
+
+export function extractTxHash(result: unknown): Hash | null {
+  if (typeof result === "string" && result.startsWith("0x"))
+    return result as Hash;
+  if (result && typeof result === "object") {
+    const record = result as Record<string, unknown>;
+    for (const key of ["txHash", "hash", "transactionHash"]) {
+      const value = record[key];
+      if (typeof value === "string" && value.startsWith("0x"))
+        return value as Hash;
+    }
+  }
+  return null;
+}
+
+export async function requireAgent(c: Context<AppEnv>, agentId: string) {
+  const user = await requireUserOrApiKeyWithOrg(c);
+  const agent = await elizaSandboxService.getAgent(
+    agentId,
+    user.organization_id,
+  );
+  if (!agent) {
+    return {
+      response: json(
+        { success: false, error: "Agent not found" },
+        { status: 404 },
+      ),
+    };
+  }
+  return { user, agent };
+}
+
+export async function getCurrentIdentity(
+  sandboxAgentId: string,
+  organizationId: string,
+) {
+  const rows = await dbWrite
+    .select()
+    .from(agentIdentities)
+    .where(
+      and(
+        eq(agentIdentities.sandbox_agent_id, sandboxAgentId),
+        eq(agentIdentities.organization_id, organizationId),
+        eq(agentIdentities.standard, STANDARD),
+      ),
+    )
+    .limit(1);
+  return rows[0] ?? null;
+}
+
+export function serializeIdentity(row: typeof agentIdentities.$inferSelect) {
+  return {
+    id: row.id,
+    agentId: row.sandbox_agent_id,
+    agentIdOnchain: row.token_id,
+    chainId: row.chain_id,
+    registry: row.registry_address,
+    uri: row.agent_uri,
+    uriIpfs: row.uri_ipfs,
+    owner: row.owner_wallet_address,
+    txHash: row.tx_hash,
+    blockNumber: row.block_number,
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+async function getWalletRecord(sandboxAgentId: string, organizationId: string) {
+  const exact = await dbWrite
+    .select()
+    .from(agentServerWallets)
+    .where(
+      and(
+        eq(agentServerWallets.sandbox_agent_id, sandboxAgentId),
+        eq(agentServerWallets.organization_id, organizationId),
+        eq(agentServerWallets.chain_type, "evm"),
+      ),
+    )
+    .limit(1);
+  if (exact[0]) return exact[0];
+
+  const orgWallets = await dbWrite
+    .select()
+    .from(agentServerWallets)
+    .where(
+      and(
+        eq(agentServerWallets.organization_id, organizationId),
+        eq(agentServerWallets.chain_type, "evm"),
+      ),
+    )
+    .limit(2);
+  return orgWallets.length === 1 ? orgWallets[0] : null;
+}
+
+export async function resolveStewardWallet(params: {
+  sandboxAgentId: string;
+  organizationId: string;
+}): Promise<
+  | {
+      stewardAgentId: string;
+      owner: Address;
+      client: StewardIdentityClient;
+    }
+  | Response
+> {
+  const stewardAgentId = await resolveStewardAgentId(
+    params.sandboxAgentId,
+    params.organizationId,
+  );
+  const walletRecord = await getWalletRecord(
+    params.sandboxAgentId,
+    params.organizationId,
+  );
+  const effectiveStewardAgentId =
+    stewardAgentId ?? walletRecord?.steward_agent_id ?? null;
+  if (
+    !effectiveStewardAgentId ||
+    !walletRecord?.address ||
+    !isAddress(walletRecord.address)
+  ) {
+    return json(
+      { error: "No Steward-managed EVM wallet found for this agent" },
+      { status: 404 },
+    );
+  }
+
+  let client: StewardIdentityClient;
+  try {
+    client = (await createStewardClient({
+      organizationId: params.organizationId,
+      tenantId: walletRecord.steward_tenant_id ?? undefined,
+    })) as StewardIdentityClient;
+  } catch (error) {
+    logger.warn("[identity-api] Steward tenant config unavailable", {
+      agentId: params.sandboxAgentId,
+      orgId: params.organizationId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return json({ error: "Steward not configured" }, { status: 503 });
+  }
+
+  return {
+    stewardAgentId: effectiveStewardAgentId,
+    owner: walletRecord.address as Address,
+    client,
+  };
+}
+
+export async function stewardSendContractTx(params: {
+  client: StewardIdentityClient;
+  stewardAgentId: string;
+  registry: Address;
+  chainId: ERC8004ChainId;
+  functionName: "register" | "setAgentURI";
+  args: readonly unknown[];
+}): Promise<Hash | Response> {
+  if (typeof params.client.signTransaction !== "function") {
+    return json(
+      {
+        success: false,
+        error: "Steward signing not yet wired for ERC-8004 register-identity",
+        detail:
+          "Expected @stwd/sdk StewardClient.signTransaction(agentId, tx) to sign and broadcast eth_sendTransaction.",
+      },
+      { status: 501 },
+    );
+  }
+
+  const data = encodeFunctionData({
+    abi: identityRegistryAbi,
+    functionName: params.functionName,
+    args: params.args,
+  });
+  const result = await params.client.signTransaction(params.stewardAgentId, {
+    to: params.registry,
+    value: "0",
+    data,
+    chainId: params.chainId,
+  });
+  const txHash = extractTxHash(result);
+  if (!txHash) {
+    return json(
+      {
+        success: false,
+        error: "Steward signing returned no transaction hash",
+        detail:
+          "If Steward returns signed-but-unbroadcast transactions, add a broadcast step before enabling ERC-8004 registration.",
+      },
+      { status: 501 },
+    );
+  }
+  return txHash;
+}
+
+export function identityClient(chainId: ERC8004ChainId, registry: Address) {
+  return new ERC8004IdentityClient({
+    chainId,
+    registryAddress: registry,
+    rpcUrl: rpcUrlForChain(chainId),
+  });
+}
+
+export async function routeError(
+  c: Context<AppEnv>,
+  error: unknown,
+): Promise<Response> {
+  const dependency = clearDbDependencyError(error);
+  if (dependency) return dependency;
+  logger.error("[identity-api] request failed", error);
+  return failureResponse(c, error);
+}

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/onchain/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/onchain/route.ts
@@ -1,0 +1,97 @@
+import { type Context, Hono } from "hono";
+import { type Address, isAddress } from "viem";
+import { nextStyleParams } from "@/lib/api/hono-next-style-params";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import {
+  defaultRegistry,
+  getCurrentIdentity,
+  identityClient,
+  json,
+  normalizeChainId,
+  optionsResponse,
+  requireAgent,
+  routeError,
+} from "../common";
+
+function __next_OPTIONS() {
+  return optionsResponse();
+}
+
+export async function handleGetOnchainIdentity(
+  c: Context<AppEnv>,
+  paramsPromise: Promise<{ agentId: string }>,
+): Promise<Response> {
+  try {
+    const { agentId } = await paramsPromise;
+    const auth = await requireAgent(c, agentId);
+    if ("response" in auth && auth.response) return auth.response;
+    const url = new URL(c.req.url);
+    const dbIdentity = await getCurrentIdentity(
+      agentId,
+      auth.user.organization_id,
+    ).catch(() => null);
+    const chainId = normalizeChainId(
+      Number(url.searchParams.get("chainId")) || dbIdentity?.chain_id || 56,
+    );
+    if (!chainId)
+      return json(
+        { success: false, error: "chainId must be 56 or 97" },
+        { status: 400 },
+      );
+    const registryParam = url.searchParams.get("registry");
+    const registry =
+      registryParam && isAddress(registryParam)
+        ? (registryParam as Address)
+        : ((dbIdentity?.registry_address as Address | undefined) ??
+          defaultRegistry(chainId));
+    const onchainId =
+      url.searchParams.get("agentIdOnchain") ?? dbIdentity?.token_id;
+    if (!onchainId)
+      return json(
+        { success: false, error: "Identity not found" },
+        { status: 404 },
+      );
+    const tokenId = BigInt(onchainId);
+    const client = identityClient(chainId, registry);
+    try {
+      const [owner, uri] = await Promise.all([
+        client.getOwner(tokenId),
+        client.getAgentURI(tokenId),
+      ]);
+      return json({
+        success: true,
+        data: {
+          exists: true,
+          agentIdOnchain: tokenId.toString(),
+          owner,
+          uri,
+          chainId,
+          registry,
+        },
+      });
+    } catch (error) {
+      return json({
+        success: true,
+        data: {
+          exists: false,
+          agentIdOnchain: tokenId.toString(),
+          chainId,
+          registry,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      });
+    }
+  } catch (error) {
+    return routeError(c, error);
+  }
+}
+
+const app = new Hono<AppEnv>();
+app.options("/", () => __next_OPTIONS());
+app.get("/", (c) =>
+  handleGetOnchainIdentity(
+    c,
+    nextStyleParams(c, [{ name: "agentId", splat: false }] as const).params,
+  ),
+);
+export default app;

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/policy.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/policy.ts
@@ -1,0 +1,69 @@
+import type { Address } from "viem";
+import type { ERC8004ChainId } from "@/lib/services/erc8004/identity-client";
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+type JsonObject = { [key: string]: JsonValue };
+
+export type StewardPolicyRule = {
+  id: string;
+  type: string;
+  enabled: boolean;
+  config?: JsonObject;
+};
+
+function arrayFromConfig(
+  config: JsonObject | undefined,
+  keys: string[],
+): string[] {
+  if (!config) return [];
+  for (const key of keys) {
+    const value = config[key];
+    if (Array.isArray(value))
+      return value.filter((item): item is string => typeof item === "string");
+  }
+  return [];
+}
+
+export function policiesAllowRegister(
+  policies: StewardPolicyRule[],
+  chainId: ERC8004ChainId,
+  registry: Address,
+): { allowed: boolean; reason?: string } {
+  const enabled = policies.filter((policy) => policy.enabled);
+  const allowedChains = enabled.find(
+    (policy) => policy.type === "allowed-chains",
+  );
+  if (!allowedChains)
+    return { allowed: false, reason: "missing allowed-chains policy" };
+  const chains = arrayFromConfig(allowedChains.config, [
+    "chainIds",
+    "chains",
+    "allowedChains",
+  ]);
+  if (!chains.map(String).includes(String(chainId))) {
+    return {
+      allowed: false,
+      reason: `chain ${chainId} is not allowed by Steward policy`,
+    };
+  }
+
+  const approvedAddresses = enabled.find(
+    (policy) => policy.type === "approved-addresses",
+  );
+  if (!approvedAddresses)
+    return { allowed: false, reason: "missing approved-addresses policy" };
+  const addresses = arrayFromConfig(approvedAddresses.config, [
+    "addresses",
+    "approvedAddresses",
+    "allowlist",
+    "allowedAddresses",
+  ]).map((address) => address.toLowerCase());
+  if (!addresses.includes(registry.toLowerCase())) {
+    return {
+      allowed: false,
+      reason: "IdentityRegistry address is not approved by Steward policy",
+    };
+  }
+  return { allowed: true };
+}

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/register/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/register/route.ts
@@ -1,0 +1,161 @@
+import { type Context, Hono } from "hono";
+import { type Address, isAddress } from "viem";
+import { dbWrite } from "@/db/helpers";
+import { agentIdentities } from "@/db/schemas/agent-identities";
+import { nextStyleParams } from "@/lib/api/hono-next-style-params";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import {
+  defaultRegistry,
+  getCurrentIdentity,
+  identityClient,
+  json,
+  normalizeChainId,
+  optionsResponse,
+  policiesAllowRegister,
+  requireAgent,
+  resolveStewardWallet,
+  routeError,
+  serializeIdentity,
+  stewardSendContractTx,
+} from "../common";
+
+function __next_OPTIONS() {
+  return optionsResponse();
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+export async function handleRegisterIdentity(
+  c: Context<AppEnv>,
+  paramsPromise: Promise<{ agentId: string }>,
+): Promise<Response> {
+  try {
+    const { agentId } = await paramsPromise;
+    const auth = await requireAgent(c, agentId);
+    if ("response" in auth && auth.response) return auth.response;
+
+    const existing = await getCurrentIdentity(
+      agentId,
+      auth.user.organization_id,
+    );
+    if (existing) {
+      return json({
+        success: true,
+        data: { ...serializeIdentity(existing), idempotent: true },
+      });
+    }
+
+    const body = (await c.req.json().catch(() => null)) as unknown;
+    if (!isObject(body))
+      return json(
+        { success: false, error: "Invalid JSON body" },
+        { status: 400 },
+      );
+    const chainId = normalizeChainId(body.chainId);
+    if (!chainId)
+      return json(
+        { success: false, error: "chainId must be 56 or 97" },
+        { status: 400 },
+      );
+    const agentURI =
+      typeof body.agentURI === "string" && body.agentURI.trim()
+        ? body.agentURI.trim()
+        : null;
+    if (!agentURI)
+      return json(
+        { success: false, error: "agentURI is required" },
+        { status: 400 },
+      );
+    const registry =
+      typeof body.registry === "string" && isAddress(body.registry)
+        ? (body.registry as Address)
+        : defaultRegistry(chainId);
+    const uriIpfs = typeof body.uriIpfs === "string" ? body.uriIpfs : null;
+
+    const wallet = await resolveStewardWallet({
+      sandboxAgentId: agentId,
+      organizationId: auth.user.organization_id,
+    });
+    if (wallet instanceof Response) return wallet;
+
+    const policies = await wallet.client.getPolicies(wallet.stewardAgentId);
+    const policy = policiesAllowRegister(policies, chainId, registry);
+    if (!policy.allowed) {
+      return json(
+        {
+          success: false,
+          error: "Steward policy denied ERC-8004 register",
+          reason: policy.reason,
+        },
+        { status: 403 },
+      );
+    }
+
+    const txHashOrResponse = await stewardSendContractTx({
+      client: wallet.client,
+      stewardAgentId: wallet.stewardAgentId,
+      registry,
+      chainId,
+      functionName: "register",
+      args: [agentURI],
+    });
+    if (txHashOrResponse instanceof Response) return txHashOrResponse;
+
+    const client = identityClient(chainId, registry);
+    const receipt = await client.publicClient.waitForTransactionReceipt({
+      hash: txHashOrResponse,
+      timeout: 60_000,
+    });
+    const agentIdOnchain = await client.getAgentId(txHashOrResponse);
+    const [owner, agentUriOnchain] = await Promise.all([
+      client.getOwner(agentIdOnchain),
+      client.getAgentURI(agentIdOnchain),
+    ]);
+
+    const inserted = await dbWrite
+      .insert(agentIdentities)
+      .values({
+        organization_id: auth.user.organization_id,
+        sandbox_agent_id: agentId,
+        standard: "erc-8004",
+        chain_id: chainId,
+        registry_address: registry,
+        token_id: agentIdOnchain.toString(),
+        agent_uri: agentURI,
+        uri_ipfs: uriIpfs,
+        owner_wallet_address: owner,
+        tx_hash: txHashOrResponse,
+        block_number: receipt.blockNumber?.toString(),
+        status: "confirmed",
+      })
+      .returning();
+
+    return json({
+      success: true,
+      data: {
+        agentId: inserted[0]?.sandbox_agent_id ?? agentId,
+        agentIdOnchain: agentIdOnchain.toString(),
+        txHash: txHashOrResponse,
+        owner,
+        chainId,
+        registry,
+        uri: agentURI,
+        agentUriOnchain,
+      },
+    });
+  } catch (error) {
+    return routeError(c, error);
+  }
+}
+
+const app = new Hono<AppEnv>();
+app.options("/", () => __next_OPTIONS());
+app.post("/", (c) =>
+  handleRegisterIdentity(
+    c,
+    nextStyleParams(c, [{ name: "agentId", splat: false }] as const).params,
+  ),
+);
+export default app;

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/route.ts
@@ -1,0 +1,48 @@
+import { type Context, Hono } from "hono";
+import { nextStyleParams } from "@/lib/api/hono-next-style-params";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import {
+  getCurrentIdentity,
+  json,
+  optionsResponse,
+  requireAgent,
+  routeError,
+  serializeIdentity,
+} from "./common";
+
+function __next_OPTIONS() {
+  return optionsResponse();
+}
+
+export async function handleGetIdentity(
+  c: Context<AppEnv>,
+  paramsPromise: Promise<{ agentId: string }>,
+): Promise<Response> {
+  try {
+    const { agentId } = await paramsPromise;
+    const auth = await requireAgent(c, agentId);
+    if ("response" in auth && auth.response) return auth.response;
+    const identity = await getCurrentIdentity(
+      agentId,
+      auth.user.organization_id,
+    );
+    if (!identity)
+      return json(
+        { success: false, error: "Identity not found" },
+        { status: 404 },
+      );
+    return json({ success: true, data: serializeIdentity(identity) });
+  } catch (error) {
+    return routeError(c, error);
+  }
+}
+
+const app = new Hono<AppEnv>();
+app.options("/", () => __next_OPTIONS());
+app.get("/", (c) =>
+  handleGetIdentity(
+    c,
+    nextStyleParams(c, [{ name: "agentId", splat: false }] as const).params,
+  ),
+);
+export default app;

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/uri/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/uri/route.ts
@@ -1,0 +1,113 @@
+import { eq } from "drizzle-orm";
+import { type Context, Hono } from "hono";
+import { dbWrite } from "@/db/helpers";
+import { agentIdentities } from "@/db/schemas/agent-identities";
+import { nextStyleParams } from "@/lib/api/hono-next-style-params";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import {
+  getCurrentIdentity,
+  identityClient,
+  json,
+  optionsResponse,
+  policiesAllowRegister,
+  requireAgent,
+  resolveStewardWallet,
+  routeError,
+  stewardSendContractTx,
+} from "../common";
+
+function __next_OPTIONS() {
+  return optionsResponse();
+}
+function isObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+export async function handlePutIdentityUri(
+  c: Context<AppEnv>,
+  paramsPromise: Promise<{ agentId: string }>,
+): Promise<Response> {
+  try {
+    const { agentId } = await paramsPromise;
+    const auth = await requireAgent(c, agentId);
+    if ("response" in auth && auth.response) return auth.response;
+    const existing = await getCurrentIdentity(
+      agentId,
+      auth.user.organization_id,
+    );
+    if (!existing)
+      return json(
+        { success: false, error: "Identity not found" },
+        { status: 404 },
+      );
+    const body = (await c.req.json().catch(() => null)) as unknown;
+    if (!isObject(body) || typeof body.uri !== "string" || !body.uri.trim()) {
+      return json(
+        { success: false, error: "uri is required" },
+        { status: 400 },
+      );
+    }
+    const chainId =
+      existing.chain_id === 56 || existing.chain_id === 97
+        ? existing.chain_id
+        : 56;
+    const registry = existing.registry_address as `0x${string}`;
+    const wallet = await resolveStewardWallet({
+      sandboxAgentId: agentId,
+      organizationId: auth.user.organization_id,
+    });
+    if (wallet instanceof Response) return wallet;
+    const policies = await wallet.client.getPolicies(wallet.stewardAgentId);
+    const policy = policiesAllowRegister(policies, chainId, registry);
+    if (!policy.allowed)
+      return json(
+        {
+          success: false,
+          error: "Steward policy denied ERC-8004 URI update",
+          reason: policy.reason,
+        },
+        { status: 403 },
+      );
+    const txHashOrResponse = await stewardSendContractTx({
+      client: wallet.client,
+      stewardAgentId: wallet.stewardAgentId,
+      registry,
+      chainId,
+      functionName: "setAgentURI",
+      args: [BigInt(existing.token_id), body.uri.trim()],
+    });
+    if (txHashOrResponse instanceof Response) return txHashOrResponse;
+    const client = identityClient(chainId, registry);
+    await client.publicClient.waitForTransactionReceipt({
+      hash: txHashOrResponse,
+      timeout: 60_000,
+    });
+    const agentUriOnchain = await client.getAgentURI(BigInt(existing.token_id));
+    await dbWrite
+      .update(agentIdentities)
+      .set({ agent_uri: body.uri.trim(), updated_at: new Date() })
+      .where(eq(agentIdentities.id, existing.id));
+    return json({
+      success: true,
+      data: {
+        agentId,
+        agentIdOnchain: existing.token_id,
+        txHash: txHashOrResponse,
+        uri: body.uri.trim(),
+        agentUriOnchain,
+      },
+    });
+  } catch (error) {
+    return routeError(c, error);
+  }
+}
+
+const app = new Hono<AppEnv>();
+app.options("/", () => __next_OPTIONS());
+app.put("/", (c) =>
+  handlePutIdentityUri(
+    c,
+    nextStyleParams(c, [{ name: "agentId", splat: false }] as const).params,
+  ),
+);
+export default app;

--- a/packages/cloud-shared/src/db/schemas/agent-identities.ts
+++ b/packages/cloud-shared/src/db/schemas/agent-identities.ts
@@ -1,0 +1,46 @@
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { index, integer, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { agentSandboxes } from "./agent-sandboxes";
+import { organizations } from "./organizations";
+
+export const agentIdentities = pgTable(
+  "agent_identities",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    organization_id: uuid("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    sandbox_agent_id: uuid("sandbox_agent_id")
+      .notNull()
+      .references(() => agentSandboxes.id, { onDelete: "cascade" }),
+    standard: text("standard").notNull().default("erc-8004"),
+    chain_id: integer("chain_id").notNull(),
+    registry_address: text("registry_address").notNull(),
+    token_id: text("token_id").notNull(),
+    agent_uri: text("agent_uri").notNull(),
+    uri_ipfs: text("uri_ipfs"),
+    owner_wallet_address: text("owner_wallet_address").notNull(),
+    tx_hash: text("tx_hash").notNull(),
+    block_number: text("block_number"),
+    status: text("status").notNull().default("confirmed"),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    sandbox_idx: index("agent_identities_sandbox_idx").on(table.sandbox_agent_id),
+    organization_idx: index("agent_identities_organization_idx").on(table.organization_id),
+    token_unique: uniqueIndex("agent_identities_chain_registry_token_unique").on(
+      table.chain_id,
+      table.registry_address,
+      table.token_id,
+    ),
+    sandbox_standard_unique: uniqueIndex("agent_identities_sandbox_standard_chain_unique").on(
+      table.sandbox_agent_id,
+      table.standard,
+      table.chain_id,
+    ),
+  }),
+);
+
+export type AgentIdentity = InferSelectModel<typeof agentIdentities>;
+export type NewAgentIdentity = InferInsertModel<typeof agentIdentities>;

--- a/packages/cloud-shared/src/db/schemas/index.ts
+++ b/packages/cloud-shared/src/db/schemas/index.ts
@@ -12,6 +12,7 @@ export * from "./admin-users";
 export * from "./affiliates";
 export * from "./agent-budgets";
 export * from "./agent-events";
+export * from "./agent-identities";
 export * from "./agent-pairing-tokens";
 export * from "./agent-phone-contacts";
 export * from "./agent-phone-numbers";

--- a/packages/cloud-shared/src/lib/services/erc8004/abis/IdentityRegistry.json
+++ b/packages/cloud-shared/src/lib/services/erc8004/abis/IdentityRegistry.json
@@ -1,0 +1,1044 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "target",
+        "type": "address"
+      }
+    ],
+    "name": "AddressEmptyCode",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ECDSAInvalidSignature",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "length",
+        "type": "uint256"
+      }
+    ],
+    "name": "ECDSAInvalidSignatureLength",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "ECDSAInvalidSignatureS",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "ERC1967InvalidImplementation",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ERC1967NonPayable",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721IncorrectOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC721InsufficientApproval",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "approver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721InvalidApprover",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721InvalidOperator",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721InvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "receiver",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721InvalidReceiver",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "ERC721InvalidSender",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ERC721NonexistentToken",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "FailedCall",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidInitialization",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NotInitializing",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableInvalidOwner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OwnableUnauthorizedAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "UUPSUnauthorizedCallContext",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "slot",
+        "type": "bytes32"
+      }
+    ],
+    "name": "UUPSUnsupportedProxiableUUID",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "approved",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "ApprovalForAll",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_fromTokenId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_toTokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "BatchMetadataUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "EIP712DomainChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "version",
+        "type": "uint64"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "agentId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "string",
+        "name": "indexedMetadataKey",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "metadataKey",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "metadataValue",
+        "type": "bytes"
+      }
+    ],
+    "name": "MetadataSet",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "MetadataUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "agentId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "agentURI",
+        "type": "string"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "Registered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "agentId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "newURI",
+        "type": "string"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "updatedBy",
+        "type": "address"
+      }
+    ],
+    "name": "URIUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "Upgraded",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "UPGRADE_INTERFACE_VERSION",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "eip712Domain",
+    "outputs": [
+      {
+        "internalType": "bytes1",
+        "name": "fields",
+        "type": "bytes1"
+      },
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "verifyingContract",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "salt",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "extensions",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "agentId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getAgentWallet",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getApproved",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "agentId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "metadataKey",
+        "type": "string"
+      }
+    ],
+    "name": "getMetadata",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getVersion",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      }
+    ],
+    "name": "isApprovedForAll",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "ownerOf",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proxiableUUID",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "register",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "agentId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "agentURI",
+        "type": "string"
+      },
+      {
+        "components": [
+          {
+            "internalType": "string",
+            "name": "metadataKey",
+            "type": "string"
+          },
+          {
+            "internalType": "bytes",
+            "name": "metadataValue",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct IdentityRegistryUpgradeable.MetadataEntry[]",
+        "name": "metadata",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "register",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "agentId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "agentURI",
+        "type": "string"
+      }
+    ],
+    "name": "register",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "agentId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "safeTransferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "agentId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "newURI",
+        "type": "string"
+      }
+    ],
+    "name": "setAgentURI",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "agentId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "newWallet",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "deadline",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "signature",
+        "type": "bytes"
+      }
+    ],
+    "name": "setAgentWallet",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "operator",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "approved",
+        "type": "bool"
+      }
+    ],
+    "name": "setApprovalForAll",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "agentId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "metadataKey",
+        "type": "string"
+      },
+      {
+        "internalType": "bytes",
+        "name": "metadataValue",
+        "type": "bytes"
+      }
+    ],
+    "name": "setMetadata",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenURI",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "agentId",
+        "type": "uint256"
+      }
+    ],
+    "name": "unsetAgentWallet",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "upgradeToAndCall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]

--- a/packages/cloud-shared/src/lib/services/erc8004/identity-client.test.ts
+++ b/packages/cloud-shared/src/lib/services/erc8004/identity-client.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, mock, test } from "bun:test";
+import { type Hash } from "viem";
+import { ERC8004_IDENTITY_REGISTRY_ADDRESSES, ERC8004IdentityClient } from "./identity-client";
+
+const registry = ERC8004_IDENTITY_REGISTRY_ADDRESSES[97];
+const txHash = `0x${"1".repeat(64)}` as Hash;
+
+function mockClient() {
+  const state = { uri: "ipfs://old", owner: "0x000000000000000000000000000000000000dEaD" };
+  const registered = {
+    data: "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000c697066733a2f2f6167656e740000000000000000000000000000000000",
+    topics: [
+      "0xca52e62c367d81bb2e328eb795f7c7ba24afb478408a26c0e201d155c449bc4a",
+      "0x00000000000000000000000000000000000000000000000000000000000004d2",
+      "0x000000000000000000000000000000000000000000000000000000000000dead",
+    ],
+  };
+  const publicClient = {
+    waitForTransactionReceipt: mock(async () => ({
+      logs: [{ address: registry, data: registered.data, topics: registered.topics }],
+    })),
+    readContract: mock(async ({ functionName }: { functionName: string }) => {
+      if (functionName === "ownerOf") return state.owner;
+      if (functionName === "tokenURI") return state.uri;
+      throw new Error(`unexpected read ${functionName}`);
+    }),
+  };
+  const walletClient = {
+    account: state.owner,
+    chain: undefined,
+    writeContract: mock(
+      async ({ functionName, args }: { functionName: string; args: unknown[] }) => {
+        if (functionName === "setAgentURI") state.uri = args[1] as string;
+        return txHash;
+      },
+    ),
+  };
+  return { state, publicClient, walletClient };
+}
+
+describe("ERC8004IdentityClient", () => {
+  test("register returns agentId parsed from Registered event", async () => {
+    const { publicClient, walletClient } = mockClient();
+    const client = new ERC8004IdentityClient({
+      chainId: 97,
+      registryAddress: registry,
+      rpcUrl: "http://127.0.0.1:8545",
+      publicClient: publicClient as never,
+    });
+
+    await expect(
+      client.register({ agentURI: "ipfs://agent", signer: walletClient as never }),
+    ).resolves.toEqual({
+      agentId: 1234n,
+      txHash,
+    });
+    expect(walletClient.writeContract).toHaveBeenCalledWith(
+      expect.objectContaining({ functionName: "register", args: ["ipfs://agent"] }),
+    );
+  });
+
+  test("reads ownerOf", async () => {
+    const { publicClient, walletClient } = mockClient();
+    const client = new ERC8004IdentityClient({
+      chainId: 97,
+      registryAddress: registry,
+      rpcUrl: "http://127.0.0.1:8545",
+      publicClient: publicClient as never,
+    });
+
+    await expect(client.getOwner(1234n)).resolves.toBe(walletClient.account);
+  });
+
+  test("URI read/write round-trip", async () => {
+    const { publicClient, walletClient } = mockClient();
+    const client = new ERC8004IdentityClient({
+      chainId: 97,
+      registryAddress: registry,
+      rpcUrl: "http://127.0.0.1:8545",
+      publicClient: publicClient as never,
+    });
+
+    await expect(client.getAgentURI(1234n)).resolves.toBe("ipfs://old");
+    await expect(
+      client.setAgentURI({ agentId: 1234n, uri: "ipfs://new", signer: walletClient as never }),
+    ).resolves.toBe(txHash);
+    await expect(client.getAgentURI(1234n)).resolves.toBe("ipfs://new");
+  });
+});

--- a/packages/cloud-shared/src/lib/services/erc8004/identity-client.ts
+++ b/packages/cloud-shared/src/lib/services/erc8004/identity-client.ts
@@ -1,0 +1,129 @@
+import {
+  type Address,
+  createPublicClient,
+  decodeEventLog,
+  type Hash,
+  type Hex,
+  http,
+  type PublicClient,
+  type WalletClient,
+} from "viem";
+import { bsc, bscTestnet } from "viem/chains";
+import IdentityRegistryAbi from "./abis/IdentityRegistry.json";
+
+export const identityRegistryAbi = IdentityRegistryAbi;
+
+export type ERC8004ChainId = 56 | 97;
+
+export const ERC8004_IDENTITY_REGISTRY_ADDRESSES: Record<ERC8004ChainId, Address> = {
+  56: "0x8004A169FB4a3325136EB29fA0ceB6D2e539a432",
+  97: "0x8004A818BFB912233c491871b3d84c89A494BD9e",
+};
+
+export class ERC8004IdentityClient {
+  readonly chainId: ERC8004ChainId;
+  readonly registryAddress: Address;
+  readonly publicClient: PublicClient;
+
+  constructor(opts: {
+    chainId: ERC8004ChainId;
+    registryAddress: Address;
+    rpcUrl: string;
+    publicClient?: PublicClient;
+  }) {
+    this.chainId = opts.chainId;
+    this.registryAddress = opts.registryAddress;
+    this.publicClient =
+      opts.publicClient ??
+      createPublicClient({
+        chain: opts.chainId === 56 ? bsc : bscTestnet,
+        transport: http(opts.rpcUrl),
+      });
+  }
+
+  async register(opts: {
+    agentURI: string;
+    signer: WalletClient;
+  }): Promise<{ agentId: bigint; txHash: Hash }> {
+    const txHash = await opts.signer.writeContract({
+      address: this.registryAddress,
+      abi: IdentityRegistryAbi,
+      functionName: "register",
+      args: [opts.agentURI],
+      chain: opts.signer.chain ?? (this.chainId === 56 ? bsc : bscTestnet),
+      account: opts.signer.account!,
+    });
+    const agentId = await this.getAgentId(txHash);
+    return { agentId, txHash };
+  }
+
+  async getAgentId(txHash: Hash): Promise<bigint> {
+    const receipt = await this.publicClient.waitForTransactionReceipt({ hash: txHash });
+    for (const log of receipt.logs) {
+      if (log.address.toLowerCase() !== this.registryAddress.toLowerCase()) continue;
+      try {
+        const decoded = decodeEventLog({
+          abi: IdentityRegistryAbi,
+          data: log.data,
+          topics: log.topics,
+        });
+        if (decoded.eventName === "Registered") {
+          const args = decoded.args as { agentId?: bigint } | readonly unknown[];
+          if (Array.isArray(args)) {
+            return args[0] as bigint;
+          }
+          const namedArgs = args as { agentId?: bigint };
+          if (typeof namedArgs.agentId === "bigint") return namedArgs.agentId;
+        }
+      } catch {
+        // Not an IdentityRegistry event; skip it.
+      }
+    }
+    throw new Error(`Registered event not found for transaction ${txHash}`);
+  }
+
+  async getOwner(agentId: bigint): Promise<Address> {
+    return (await this.publicClient.readContract({
+      address: this.registryAddress,
+      abi: IdentityRegistryAbi,
+      functionName: "ownerOf",
+      args: [agentId],
+    })) as Address;
+  }
+
+  async getAgentURI(agentId: bigint): Promise<string> {
+    return (await this.publicClient.readContract({
+      address: this.registryAddress,
+      abi: IdentityRegistryAbi,
+      functionName: "tokenURI",
+      args: [agentId],
+    })) as string;
+  }
+
+  async setAgentURI(opts: { agentId: bigint; uri: string; signer: WalletClient }): Promise<Hash> {
+    return opts.signer.writeContract({
+      address: this.registryAddress,
+      abi: IdentityRegistryAbi,
+      functionName: "setAgentURI",
+      args: [opts.agentId, opts.uri],
+      chain: opts.signer.chain ?? (this.chainId === 56 ? bsc : bscTestnet),
+      account: opts.signer.account!,
+    });
+  }
+
+  async setMetadata(opts: {
+    agentId: bigint;
+    key: string;
+    value: Hex;
+    signer: WalletClient;
+  }): Promise<Hash> {
+    return opts.signer.writeContract({
+      address: this.registryAddress,
+      abi: IdentityRegistryAbi,
+      functionName: "setMetadata",
+      args: [opts.agentId, opts.key, opts.value],
+      chain: opts.signer.chain ?? (this.chainId === 56 ? bsc : bscTestnet),
+      account: opts.signer.account!,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Add a viem-based ERC-8004 IdentityRegistry client and copy BNBAgent IdentityRegistry ABI.
- Add Eliza Cloud agent identity endpoints for register, current identity, URI update, and on-chain state lookup.
- Add `agent_identities` Drizzle schema mapping for Track 1A's migration/table.
- Gate register/update through Steward policies (`allowed-chains` + `approved-addresses`) before asking Steward to sign.

## Steward signing / safety

This uses the existing Steward SDK `signTransaction(agentId, tx)` path with encoded IdentityRegistry calldata. If Steward is not wired or returns a signed-but-unbroadcast payload without a tx hash, the route returns `501` instead of guessing/broadcasting incorrectly.

No mainnet registration was executed.

Before first Sol registration, Steward policy must explicitly allow:

- chain `56`
- IdentityRegistry `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`

## Tests

```bash
bun test packages/cloud-shared/src/lib/services/erc8004/identity-client.test.ts \
  packages/cloud-api/__tests__/erc8004-identity-policy.test.ts

bunx turbo run lint --filter=@elizaos/cloud-api --filter=@elizaos/cloud-shared
```

Note: root `bun run lint` currently fails in unrelated packages (`@elizaos/cloud-frontend`, then `@elizaos/app-core`) on pre-existing formatting/lint issues outside this branch.

## Deployment dependency

Depends on Track 1A applying the `agent_identities` table migration. If missing at runtime, the endpoint returns a clear 503.

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires up ERC-8004 on-chain agent identity registration on BNB Chain by adding a viem-based `ERC8004IdentityClient`, four new Hono route handlers (register, current identity, URI update, on-chain lookup), a Drizzle `agent_identities` schema, and Steward policy gating.

- `POST …/register` encodes `register(agentURI)` calldata, asks Steward to sign and broadcast, waits for the receipt, parses the `Registered` event, and persists the identity record in the DB.
- `PUT …/uri` and `GET …/onchain` follow the same auth + Steward policy pattern; `GET …/identity` is a pure DB read.
- The `agent_identities` schema is intentionally migration-less here (Track 1A dependency) and protected by a 503 guard if the table is absent at runtime.

<h3>Confidence Score: 3/5</h3>

Not safe to merge without addressing the reverted-transaction handling and the TOCTOU registration race; both can silently leave the system in an inconsistent state between on-chain state and the DB.

The register and URI-update routes never inspect `receipt.status`, so a reverted on-chain transaction causes the code to proceed into event-parsing, fail with a generic 500, and — in the URI route — may write the new URI to the DB even though the chain still holds the old value. There is also no coordination primitive between the existence check and the on-chain broadcast, meaning two concurrent requests can each mint a token and only the first DB insert survives, leaving an orphaned on-chain identity. The `getAgentId` method adds a second `waitForTransactionReceipt` with no timeout after the first (60-second) call already confirmed the tx, which could hang on a flaky node. These three issues all live on the critical registration path.

`register/route.ts` and `uri/route.ts` need the revert-check and race-condition fixes before going to production; `identity-client.ts` should be updated to accept an optional pre-fetched receipt in `getAgentId`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/register/route.ts | Core registration handler: submits on-chain tx via Steward, waits for receipt, then parses agentId — but never checks receipt.status, calls waitForTransactionReceipt a second time (no timeout) inside getAgentId, and has a TOCTOU race that can cause double on-chain registrations. |
| packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/uri/route.ts | URI update handler: same missing receipt.status check as register route; policy gate is correct; DB update can write the new URI even when the on-chain tx reverted. |
| packages/cloud-shared/src/lib/services/erc8004/identity-client.ts | ERC8004IdentityClient wraps viem for registry interactions; getAgentId always calls waitForTransactionReceipt internally even when the receipt is already available to callers, and has no timeout. |
| packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/common.ts | Shared helpers for auth, wallet resolution, Steward client, and tx dispatch; extractTxHash and stewardSendContractTx are sound; rpcUrlForChain hardcodes the BSC testnet public RPC URL. |
| packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/onchain/route.ts | GET on-chain state lookup; silently swallows all DB errors with .catch(() => null), masking migration-not-applied errors as 404s instead of 503s. |
| packages/cloud-shared/src/db/schemas/agent-identities.ts | New Drizzle schema for agent identities; uniqueIndex on (sandbox_agent_id, standard, chain_id) and (chain_id, registry_address, token_id) are correctly scoped. No migration file included (expected from Track 1A). |
| packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/policy.ts | Steward policy gate; correctly normalises addresses to lowercase and chains to strings; tests cover all three branches. |
| packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/route.ts | GET current identity; auth-guarded and delegates to common helpers cleanly. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client
    participant R as register/route.ts
    participant DB as Drizzle (agentIdentities)
    participant S as Steward SDK
    participant Chain as BNB Chain RPC

    C->>R: "POST /identity/register {chainId, agentURI}"
    R->>DB: getCurrentIdentity() → null (idempotency check)
    R->>S: getPolicies(stewardAgentId) → policy rules
    R->>R: policiesAllowRegister() → allowed
    R->>S: "signTransaction(stewardAgentId, {to: registry, data: register(agentURI)})"
    S-->>R: txHash
    R->>Chain: waitForTransactionReceipt(txHash, 60s)
    Chain-->>R: receipt ⚠️ status unchecked
    R->>Chain: getAgentId(txHash) → waitForTransactionReceipt again (no timeout)
    Chain-->>R: Registered event → agentIdOnchain
    R->>Chain: getOwner(agentId) + getAgentURI(agentId)
    Chain-->>R: owner, uri
    R->>DB: INSERT agent_identities
    DB-->>R: inserted row
    R-->>C: "200 {agentIdOnchain, txHash, owner, ...}"
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/register/route.ts`, line 574-683 ([link](https://github.com/elizaos/eliza/blob/658319478ec0163d07b8c18f1b3300d17d681fa5/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/register/route.ts#L574-L683)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **TOCTOU race allows double on-chain registration**

   There is no lock between the `getCurrentIdentity` existence check and the on-chain `register` transaction. Two concurrent POST requests for the same `agentId` + `chainId` will both find `existing === null`, both pass the policy gate, and both broadcast a `register` call to the contract — minting two separate token IDs and charging gas twice. The second `dbWrite.insert` then fails on `agent_identities_sandbox_standard_chain_unique`, so the caller gets an error even though an on-chain identity was created. The orphaned token has no DB record.

   Consider taking a DB advisory lock (e.g. `SELECT pg_advisory_xact_lock`) keyed on `(organizationId, sandboxAgentId, chainId)` before issuing the on-chain transaction, or using an `INSERT … ON CONFLICT DO NOTHING` with a pre-insert rather than a read-then-write pattern.


2. `packages/cloud-shared/src/lib/services/erc8004/identity-client.ts`, line 2144-2167 ([link](https://github.com/elizaos/eliza/blob/658319478ec0163d07b8c18f1b3300d17d681fa5/packages/cloud-shared/src/lib/services/erc8004/identity-client.ts#L2144-L2167)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`getAgentId` calls `waitForTransactionReceipt` a second time with no timeout**

   In `register/route.ts`, `waitForTransactionReceipt` is already called (with `timeout: 60_000`) before `getAgentId` is invoked, yet `getAgentId` issues its own `waitForTransactionReceipt` call with no `timeout`. If the RPC node hasn't indexed the receipt yet (rare but possible on load-balanced nodes), this second call can hang indefinitely. The logs decoded inside `getAgentId` come from this second receipt, not from the one used to obtain `blockNumber`, creating a subtle divergence.

   Consider accepting an optional `receipt` parameter so callers that already have the confirmed receipt can skip the second RPC round-trip.


3. `packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/onchain/route.ts`, line 386-389 ([link](https://github.com/elizaos/eliza/blob/658319478ec0163d07b8c18f1b3300d17d681fa5/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/onchain/route.ts#L386-L389)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **DB errors silently swallowed on the onchain GET route**

   `.catch(() => null)` discards all DB errors including `agent_identities table not available` (the migration-not-applied case). When the table is missing, `dbIdentity` becomes `null`, the fallback chain resolves `chainId = 56`, and if `agentIdOnchain` is also absent from the query string the request returns a 404 instead of the 503 with the descriptive message that `clearDbDependencyError` would produce. The other routes correctly surface this via `routeError`.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(cloud-api): add ERC-8004 identity r..."](https://github.com/elizaos/eliza/commit/658319478ec0163d07b8c18f1b3300d17d681fa5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33637981)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->