### PR TITLE
fix(cloud-api): unblock Deploy API Worker — import StewardPolicyRule + type test policies

### DIFF
--- a/packages/cloud-api/__tests__/erc8004-identity-policy.test.ts
+++ b/packages/cloud-api/__tests__/erc8004-identity-policy.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, test } from "bun:test";
 import { ERC8004_IDENTITY_REGISTRY_ADDRESSES } from "@/lib/services/erc8004/identity-client";
-import { policiesAllowRegister } from "../v1/eliza/agents/[agentId]/api/identity/policy";
+import {
+  policiesAllowRegister,
+  type StewardPolicyRule,
+} from "../v1/eliza/agents/[agentId]/api/identity/policy";
 
 const registry = ERC8004_IDENTITY_REGISTRY_ADDRESSES[56];
 
-function policies(opts: { chain?: string; address?: string }) {
+function policies(opts: {
+  chain?: string;
+  address?: string;
+}): StewardPolicyRule[] {
   return [
     {
       id: "allowed-chains",

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/common.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/common.ts
@@ -21,7 +21,8 @@ import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 import { resolveStewardAgentId } from "../wallet/[...path]/route";
 
-export { policiesAllowRegister } from "./policy";
+import type { StewardPolicyRule } from "./policy";
+export { policiesAllowRegister, type StewardPolicyRule } from "./policy";
 
 export const CORS_METHODS = "GET, POST, PUT, OPTIONS";
 export const STANDARD = "erc-8004";


### PR DESCRIPTION
## Summary

PR #7937 introduced two TS errors that block \`Cloud CF Deploy → Deploy API Worker\` on develop, so the Worker hasn't shipped since 2026-05-24 06:24 UTC (last green deploy was for #7894).

This is a 2-line type fix, no behavioural change.

## Changes

- \`packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/common.ts\` — local interface references \`StewardPolicyRule\` but only re-exports it via \`policy.ts\`. Add an explicit \`import type\` so the symbol resolves at line 30.
- \`packages/cloud-api/__tests__/erc8004-identity-policy.test.ts\` — the inferred union for the two policy literals has \`config.chainIds?: undefined\` branches that are not assignable to \`StewardPolicyRule.config\` (JsonObject). Annotate the return type as \`StewardPolicyRule[]\` so TS widens the literals to the shared shape.

## Test plan

- [x] \`bun run --cwd packages/cloud-api typecheck\` — no errors in the two files (transitive \`../shared/...\` errors are pre-existing develop noise).
- [ ] Cloud CF Deploy run green after merge → cloud-api Worker ships → unblocks the rest of the pipeline (incl. provisioning-gate fix from #7899)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two TypeScript errors introduced by #7937 that blocked the Cloud CF Deploy → Deploy API Worker pipeline. Both changes are purely type-level with no behavioural impact.

- **`common.ts`**: adds `import type { StewardPolicyRule }` so the type is in local scope for the `StewardIdentityClient` interface (a `type-only re-export` from line 25 alone does not bring the symbol into the file's local namespace), then also includes it in the re-export.
- **`erc8004-identity-policy.test.ts`**: annotates the `policies()` helper with `: StewardPolicyRule[]` so TypeScript widens the two object literals' `config` shapes to `JsonObject` instead of inferring a narrow literal union that cannot be assigned to the interface.

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are type-only annotations with no runtime behaviour altered.

The two changes are minimal and correct: adding a missing import type for a symbol already used in the same file, and annotating a test helper's return type to guide type widening. No logic, no data flow, and no public API contracts are modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cloud-api/v1/eliza/agents/[agentId]/api/identity/common.ts | Adds explicit `import type { StewardPolicyRule }` for local use in the `StewardIdentityClient` type and adds the type to the re-export — correct fix since a type-only re-export does not bring the symbol into local scope. |
| packages/cloud-api/__tests__/erc8004-identity-policy.test.ts | Annotates the `policies()` helper return type as `StewardPolicyRule[]` to force TypeScript to widen inferred literal types to the shared `JsonObject` config shape; no test logic changed. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["policy.ts\n(StewardPolicyRule, policiesAllowRegister)"]
    B["common.ts\nimport type StewardPolicyRule\nexport policiesAllowRegister + StewardPolicyRule"]
    C["StewardIdentityClient type\n(local usage in common.ts)"]
    D["erc8004-identity-policy.test.ts\npolicies(): StewardPolicyRule[]"]

    A -->|"import type + re-export"| B
    B --> C
    A -->|"import type"| D
```

<sub>Reviews (1): Last reviewed commit: ["fix(cloud-api): import StewardPolicyRule..."](https://github.com/elizaos/eliza/commit/bad7b9506cd703c280376f512367aeba2dbda2c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33665395)</sub>

<!-- /greptile_comment -->