### PR TITLE
fix(app-core/ensure-vision-deps): skip apt-get install when sudo would prompt and stdin is not a TTY

### DIFF
--- a/packages/app-core/scripts/ensure-vision-deps.mjs
+++ b/packages/app-core/scripts/ensure-vision-deps.mjs
@@ -133,6 +133,25 @@ function installLinux() {
     return;
   }
 
+  // `sudo apt-get install` will hang waiting for a password when stdin
+  // is not a TTY (Docker, WSL with no askpass, CI runners). Probe for a
+  // non-interactive sudo first; if it would prompt, warn and skip rather
+  // than block the dev orchestrator.
+  let canSudoNonInteractively = false;
+  try {
+    execSync("sudo -n true", { stdio: "ignore" });
+    canSudoNonInteractively = true;
+  } catch (_err) {
+    canSudoNonInteractively = false;
+  }
+
+  if (!canSudoNonInteractively && !process.stdout.isTTY) {
+    console.warn(
+      `  ${orange(logPrefix)} ${dim("fswebcam missing; skipping install (sudo needs a password and stdin is not a TTY). Install manually with: sudo apt-get install -y fswebcam — or set ELIZA_NO_VISION_DEPS=1 to silence this check.")}`,
+    );
+    return;
+  }
+
   console.log(`  ${green(logPrefix)} Installing fswebcam via apt-get...`);
   try {
     execSync("sudo apt-get install -y fswebcam", { stdio: "inherit" });

--- a/packages/app-core/scripts/ensure-vision-deps.mjs
+++ b/packages/app-core/scripts/ensure-vision-deps.mjs
@@ -145,7 +145,7 @@ function installLinux() {
     canSudoNonInteractively = false;
   }
 
-  if (!canSudoNonInteractively && !process.stdout.isTTY) {
+  if (!canSudoNonInteractively && !process.stdin.isTTY) {
     console.warn(
       `  ${orange(logPrefix)} ${dim("fswebcam missing; skipping install (sudo needs a password and stdin is not a TTY). Install manually with: sudo apt-get install -y fswebcam — or set ELIZA_NO_VISION_DEPS=1 to silence this check.")}`,
     );


### PR DESCRIPTION
## Summary

`installLinux()` in `packages/app-core/scripts/ensure-vision-deps.mjs` unconditionally runs:

```js
execSync("sudo apt-get install -y fswebcam", { stdio: "inherit" });
```

When the dev orchestrator runs outside a TTY (Docker `docker run -d`, headless WSL with no askpass helper, CI runners that lack a NOPASSWD entry), `sudo` blocks waiting for a password on a stdin that no human is attached to. The dev server hangs indefinitely at:

```
  [eliza] Installing fswebcam via apt-get...
```

I hit this trying to bring up the runtime headless in WSL2 Ubuntu. The orchestrator hung for minutes with no output until I killed it.

## Fix

Probe with `sudo -n true` before invoking `sudo apt-get`. If sudo would prompt **and** stdin is not a TTY, print a warning with the manual install command + the existing `ELIZA_NO_VISION_DEPS=1` env var, and return.

Interactive desktop runs are unaffected (TTY available → prompt works). NOPASSWD-configured CI is unaffected (`sudo -n` succeeds). Headless dev paths no longer hang.

## Test plan

- [x] Manual: in a non-TTY environment without passwordless sudo, the script now warns and exits 0 instead of hanging.
- [x] Manual: in an interactive shell with sudo password prompt, behavior is unchanged (still prompts).
- [x] Manual: in a NOPASSWD-configured environment, behavior is unchanged (silent install).

## Related

Discovered while bringing up a Milady (downstream) runtime in WSL2 headless mode. Same root cause should apply to anyone running the dev orchestrator inside Docker without an interactive shell.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a non-interactive sudo probe (`sudo -n true`) in `installLinux()` before attempting `sudo apt-get install -y fswebcam`, then skips the install with a warning when passwordless sudo is unavailable and stdin is not a TTY — preventing the dev orchestrator from hanging indefinitely in headless environments such as Docker, WSL2 without an askpass helper, or CI runners.

- **Hang fix**: The guard correctly covers the reported scenario (headless + no NOPASSWD); interactive sessions and NOPASSWD-configured CI are unaffected.
- **Probe safety**: The `sudo -n true` probe has no `timeout` option, leaving a theoretical residual hang risk on systems with slow network-based PAM/sssd auth; a short timeout (e.g. 5 s) would make it fully robust.
- **Probe ordering**: The subprocess probe runs even in interactive TTY sessions where it is not needed; gating it behind `!process.stdin.isTTY` would avoid the extra fork on dev machines.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a well-scoped guard around a single execSync call and cannot regress existing interactive or NOPASSWD-configured paths.

The fix is a small, defensive addition to a startup helper script. The guard logic correctly handles all four combinations of passwordless-sudo availability and TTY presence. No existing code paths are altered.

No files require special attention beyond the single changed script.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/ensure-vision-deps.mjs | Adds a `sudo -n true` probe before the `apt-get` install to detect whether passwordless sudo is available; if not and stdin is not a TTY, warns and exits instead of hanging. The core logic is sound, but the probe itself lacks a timeout and runs even in interactive sessions where no probe is needed. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[installLinux called] --> B{fswebcam already installed?}
    B -- Yes --> C[log installed, return]
    B -- No --> D{apt-get available?}
    D -- No --> E[warn: install manually, return]
    D -- Yes --> F[execSync sudo -n true]
    F -- exit 0 --> G[canSudoNonInteractively = true]
    F -- exit non-0 --> H[canSudoNonInteractively = false]
    G --> I{!canSudo && !stdin.isTTY?}
    H --> I
    I -- false --> J[sudo apt-get install -y fswebcam]
    I -- true --> K[warn: skipping, install manually, return]
    J -- success --> L[log installed successfully]
    J -- failure --> M[log error]
```

<sub>Reviews (2): Last reviewed commit: ["fix(app-core/ensure-vision-deps): gate o..."](https://github.com/elizaos/eliza/commit/1776ccf284ca0d4b2ae5d2777e90c7eaefe3a045) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33676780)</sub>

<!-- /greptile_comment -->