### PR TITLE
fix(plugin-agent-orchestrator): stop sub-agents from leaking routing-kind banners into user prose

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts
@@ -163,6 +163,22 @@ describe("TASKS:spawn_agent", () => {
     expect(initialTask).toContain("AGENT_COORDINATION");
     expect(initialTask).toContain(TASK_ROOM);
     expect(initialTask).toContain(WORKTREE_ROOM);
+    // Regression for elizaOS/eliza#7935: the prompt must instruct the
+    // sub-agent NOT to write routing-kind labels as markdown banners in
+    // its prose. The original instruction said "report it with routing
+    // kind QUESTION_FOR_TASK_CREATOR" which sub-agents (opencode)
+    // interpreted as "write **QUESTION_FOR_TASK_CREATOR** as the first
+    // line of the reply text", leaking the framework's routing-kind
+    // constant into the user-visible Discord message. Routing is
+    // classified from the session event by the router; the sub-agent's
+    // prose must not duplicate it.
+    expect(initialTask).toContain(
+      "Do not prefix the reply with routing-kind labels",
+    );
+    expect(initialTask).toContain("no markdown banners");
+    expect(initialTask).toContain(
+      "the orchestrator classifies routing from the session event, not your prose",
+    );
   });
 
   it("keeps both swarm roles when task room and worktree room are the same", async () => {

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -376,8 +376,8 @@ function taskWithResolvedRoute(
     rooms
       ? `Known swarm rooms:\n${rooms}`
       : "Known swarm rooms: task room only.",
-    "If you are blocked, need user input, or must ask the task creator a question, report it with routing kind QUESTION_FOR_TASK_CREATOR.",
-    "If you may conflict with another agent, are editing shared files, or need to share progress with peer agents, report it with routing kind AGENT_COORDINATION.",
+    "If you are blocked, need user input, or must ask the task creator a question, write the question as your reply text and stop. Do not prefix the reply with routing-kind labels (no QUESTION_FOR_TASK_CREATOR / AGENT_COORDINATION headers, no markdown banners) — the orchestrator classifies routing from the session event, not your prose.",
+    "If you may conflict with another agent, are editing shared files, or need to share progress with peer agents, write the coordination note as your reply text. Same rule: no routing-kind labels or banners in the text itself.",
     "When you finish, include what changed, tests run, remaining risks, and whether any peer coordination is still needed.",
     "--- User Task ---",
     task,


### PR DESCRIPTION
## Summary

Closes the second dimension of #7935. The first dimension (planner SHELL-fallback for chat-recall) is fixed in #7942. Together those two PRs cover #7935.

## The bug

`plugins/plugin-agent-orchestrator/src/actions/tasks.ts` told sub-agents:

> - If you are blocked, need user input, or must ask the task creator a question, **report it with routing kind QUESTION_FOR_TASK_CREATOR**.
> - If you may conflict with another agent, are editing shared files, or need to share progress with peer agents, **report it with routing kind AGENT_COORDINATION**.

Sub-agents (`opencode` in particular) interpreted that as *"write the routing-kind constant as the first line of the reply text"* and produced replies like:

```
**QUESTION_FOR_TASK_CREATOR**
To locate messages containing "emberblitz" in the Discord #general channel, I need access to the Discord data source. Please provide one of the following:
1. An API token...
```

That entire markdown-banner reply got forwarded verbatim to the user channel — leaking the framework's internal routing-kind constants as user-visible text. Live trajectory `tj-93f4cb96d33b4b` captured this on `find any messages talking about emberblitz`.

## Why this happened structurally

The framework classifies routing-kind from the **session event** (`acp_blocked` / `acp_request` / etc.), not from the sub-agent's prose. The mapping is in `services/sub-agent-router.ts:routingKindForEvent`. The sub-agent doesn't actually have a structural mechanism to emit the routing kind — it just emits text, and the router infers the kind from the event type. So the original instruction to "report it with routing kind X" was unfulfillable by the sub-agent in any way other than writing the constant as text.

## The fix

Replaces the two instruction lines with prose that:

1. Tells the sub-agent the behavioral pattern (write the question / coordination note as reply text and stop)
2. Explicitly forbids prefixing with routing-kind labels or markdown banners
3. Still mentions both constants by name (so existing test coverage that checks for `QUESTION_FOR_TASK_CREATOR` and `AGENT_COORDINATION` presence still passes)
4. Names the structural mechanism the framework uses (*"the orchestrator classifies routing from the session event, not your prose"*) so the sub-agent understands why

New text:

> - If you are blocked, need user input, or must ask the task creator a question, write the question as your reply text and stop. Do not prefix the reply with routing-kind labels (no QUESTION_FOR_TASK_CREATOR / AGENT_COORDINATION headers, no markdown banners) — the orchestrator classifies routing from the session event, not your prose.
> - If you may conflict with another agent, are editing shared files, or need to share progress with peer agents, write the coordination note as your reply text. Same rule: no routing-kind labels or banners in the text itself.

## Regression test

Three new assertions in `__tests__/unit/spawn-agent.test.ts > builds initialTask with swarm context`:

```ts
expect(initialTask).toContain("Do not prefix the reply with routing-kind labels");
expect(initialTask).toContain("no markdown banners");
expect(initialTask).toContain("the orchestrator classifies routing from the session event, not your prose");
```

The pre-existing assertions for `QUESTION_FOR_TASK_CREATOR` and `AGENT_COORDINATION` presence still pass — both constants appear by name in the new instruction.

## Diff size

`+18 / -2 lines` across `src/actions/tasks.ts` (2 lines changed) and `__tests__/unit/spawn-agent.test.ts` (16 new lines including the regression comment).

## Validation

- `bunx @biomejs/biome check` — clean
- `bunx vitest run` in `plugins/plugin-agent-orchestrator` — **32 test files, 338 tests pass, 8 skipped, 0 failures**
- `tsc --noEmit` — clean
- `bun run build` — clean

## What's not in this PR (deliberately)

Defensive sanitization that strips any leftover `**QUESTION_FOR_TASK_CREATOR**` / `**AGENT_COORDINATION**` markdown banners from sub-agent prose, in case a future or third-party sub-agent ignores the instruction. The prompt-contract fix is the structural cure; defensive stripping would be belt-and-suspenders. Skipped here to keep the diff minimal — happy to add it if maintainers prefer that posture.

## Related

- Parent issue #7935 (planner-recall quality — this PR + #7942 together cover it)
- #7942 (open) — planner SHELL-fallback ban for chat-recall

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a UX leak in the agent-orchestrator plugin where sub-agents were writing internal routing-kind constants (`QUESTION_FOR_TASK_CREATOR`, `AGENT_COORDINATION`) as visible markdown banners in user-facing replies, because the original prompt phrasing was ambiguous about what "report it with routing kind X" meant structurally.

- **`src/actions/tasks.ts`**: Two instruction strings are reworded to tell sub-agents to write plain reply text, explicitly prohibit routing-kind labels and markdown banners, and explain that the orchestrator infers routing from the session event — not the reply prose.
- **`__tests__/unit/spawn-agent.test.ts`**: Three new regression assertions verify the updated phrasing is present in the generated prompt; pre-existing constant-presence assertions continue to pass.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is a two-line prompt rewrite with matching regression tests and no logic or structural risk.

The reworded instructions correct the root cause of the banner-leakage bug and the new test assertions lock in the fix. The only open question — whether to also add defensive sanitization in the router for non-compliant sub-agents — is a deliberate deferral acknowledged in the PR description, not an oversight.

No files require special attention; both changed files are small and narrowly scoped.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-orchestrator/src/actions/tasks.ts | Two prompt-instruction strings replaced: old wording told sub-agents to "report it with routing kind X", new wording explicitly prohibits routing-kind labels/banners in reply prose and explains the structural mechanism |
| plugins/plugin-agent-orchestrator/__tests__/unit/spawn-agent.test.ts | Three new regression assertions added to the existing swarm-context test to verify the anti-banner instructions are present in the generated prompt; pre-existing assertions for both routing-kind constants still pass |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Orchestrator
    participant SubAgent
    participant Router as sub-agent-router

    User->>Orchestrator: task request
    Orchestrator->>SubAgent: spawnSession(initialTask)
    Note over SubAgent: Prompt now says:<br/>"write question as reply text,<br/>NO routing-kind banners"

    alt Sub-agent is blocked (before fix)
        SubAgent-->>Router: "**QUESTION_FOR_TASK_CREATOR**\nI need access to..."
        Router->>Orchestrator: forward prose verbatim
        Orchestrator->>User: "leaks **QUESTION_FOR_TASK_CREATOR** banner"
    end

    alt Sub-agent is blocked (after fix)
        SubAgent-->>Router: "I need access to Discord..."
        Router->>Router: routingKindForEvent(acp_blocked) → QUESTION_FOR_TASK_CREATOR
        Router->>Orchestrator: route to task creator
        Orchestrator->>User: clean question text only
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-agent-orchestrator): stop sub..."](https://github.com/elizaos/eliza/commit/2e0d5f4a568b14d41e0a94c53b5a7a12b91a071b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33681139)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->