### PR TITLE
[codex] harden Steward checkout callback

### DIFF
--- a/packages/cloud-api/auth/steward-nonce-exchange/route.ts
+++ b/packages/cloud-api/auth/steward-nonce-exchange/route.ts
@@ -9,9 +9,14 @@
  * 3. This route forwards to Steward `POST /auth/oauth/exchange`, which
  *    consumes the code and returns `{ token, refreshToken, expiresAt }`.
  * 4. We verify the JWT (same path as `/api/auth/steward-session`), sync the
- *    user, set the HttpOnly cookies, and return `{ ok, userId }`.
+ *    user, set the HttpOnly cookies, and return `{ ok, userId }`. The
+ *    elizaos.ai hardware checkout origin also receives the access token so
+ *    its cross-site Stripe checkout POST can use Bearer auth; refresh stays
+ *    cookie-only.
  *
- * The access and refresh tokens never enter the browser process at any point.
+ * The refresh token never enters the browser process; the access token is
+ * returned only to the hardware checkout origin that still has to authenticate
+ * a cross-site Stripe checkout request with Bearer auth.
  *
  * Origin/Referer CSRF check mirrors `/api/auth/steward-session` exactly — the
  * route is callable from `*.elizacloud.ai` and `elizaos.ai` only (plus
@@ -97,6 +102,16 @@ function checkOrigin(
     ok: false,
     reason: `origin=${origin ?? "null"} referer=${referer ?? "null"}`,
   };
+}
+
+function shouldReturnClientToken(
+  c: { req: { header: (name: string) => string | undefined } },
+  isProduction: boolean,
+): boolean {
+  const origin =
+    originHost(c.req.header("origin")) ?? originHost(c.req.header("referer"));
+  if (origin === "elizaos.ai" || origin === "www.elizaos.ai") return true;
+  return !isProduction && origin !== null && LOCAL_DEV_ORIGIN_HOSTS.has(origin);
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
@@ -384,6 +399,7 @@ app.post("/", async (c) => {
     ok: true,
     userId: cloudUser.id,
     stewardUserId: claims.userId,
+    ...(shouldReturnClientToken(c, isProduction) ? { token } : {}),
     expiresAt: exchange.data.expiresAt,
     expiresIn: exchange.data.expiresIn,
   });

--- a/packages/os-homepage/index.html
+++ b/packages/os-homepage/index.html
@@ -13,7 +13,7 @@
     -->
     <meta name="referrer" content="no-referrer" />
     <!--
-      Snapshot then strip any `#token=...` from the URL before any other JS
+      Snapshot then strip any token-bearing hash from the URL before any other JS
       runs (React, analytics, Sentry, etc.) so the access token never reaches
       anything that might log `location.href`. Tokens are then read by
       consumeStewardTokensFromHash() from `__stewardOAuthHash`.
@@ -22,7 +22,8 @@
       (() => {
         try {
           const h = window.location.hash;
-          if (h && h.indexOf("token=") !== -1) {
+          const params = h ? new URLSearchParams(h.replace(/^#/, "")) : null;
+          if (params && (params.has("token") || params.has("access_token"))) {
             window.__stewardOAuthHash = h;
             history.replaceState(
               null,

--- a/packages/os-homepage/src/CheckoutPage.tsx
+++ b/packages/os-homepage/src/CheckoutPage.tsx
@@ -28,6 +28,11 @@ const stewardTenantId = STEWARD_TENANT_ID;
 const stewardSessionEndpoint = `${cloudApiUrl.replace(/\/$/, "")}${STEWARD_SESSION_ENDPOINT}`;
 const stewardNonceExchangeEndpoint = `${cloudApiUrl.replace(/\/$/, "")}${STEWARD_NONCE_EXCHANGE_ENDPOINT}`;
 
+type StewardTokenPayload = {
+  token: string;
+  refreshToken: string | null;
+};
+
 function getDefaultProduct(): Product {
   const fallback =
     hardwareProducts.find((product) => product.sku === "elizaos-usb") ??
@@ -66,6 +71,24 @@ function getStoredStewardToken() {
   return readStoredStewardToken();
 }
 
+function readStewardTokenParams(
+  params: URLSearchParams,
+): StewardTokenPayload | null {
+  const token = params.get("token") ?? params.get("access_token");
+  if (!token) return null;
+  return {
+    token,
+    refreshToken: params.get("refreshToken") ?? params.get("refresh_token"),
+  };
+}
+
+function removeStewardTokenParams(params: URLSearchParams): void {
+  params.delete("token");
+  params.delete("access_token");
+  params.delete("refreshToken");
+  params.delete("refresh_token");
+}
+
 function consumeStewardCodeFromQuery(): string | null {
   if (typeof window === "undefined") return null;
   const params = new URLSearchParams(window.location.search);
@@ -93,9 +116,8 @@ function consumeStewardTokensFromHash(): {
   }
   if (!hash || hash.length < 2) return null;
   const params = new URLSearchParams(hash.replace(/^#/, ""));
-  const token = params.get("token");
-  if (!token) return null;
-  const refreshToken = params.get("refreshToken");
+  const tokens = readStewardTokenParams(params);
+  if (!tokens) return null;
   if (!snapshotted) {
     window.history.replaceState(
       null,
@@ -103,7 +125,7 @@ function consumeStewardTokensFromHash(): {
       `${window.location.pathname}${window.location.search}`,
     );
   }
-  return { token, refreshToken };
+  return tokens;
 }
 
 function ProductImage({
@@ -220,8 +242,11 @@ export function CheckoutPage() {
         redirectUri: buildOAuthRedirectUri(product),
         tenantId: stewardTenantId,
       })
-        .then(() => {
-          setIsAuthed(true);
+        .then((session) => {
+          if (session.token) {
+            writeStoredStewardToken(session.token);
+          }
+          setIsAuthed(Boolean(session.token) || hasStewardAuthedCookie());
         })
         .catch((error: unknown) => {
           setMessage(
@@ -236,11 +261,9 @@ export function CheckoutPage() {
 
     const fromHash = consumeStewardTokensFromHash();
     const params = new URLSearchParams(window.location.search);
-    const queryToken = params.get("token");
-    const queryRefreshToken = params.get("refreshToken");
-    const token = fromHash?.token ?? queryToken;
-    const refreshToken =
-      fromHash?.refreshToken ?? queryRefreshToken ?? undefined;
+    const fromQuery = readStewardTokenParams(params);
+    const token = fromHash?.token ?? fromQuery?.token;
+    const refreshToken = fromHash?.refreshToken ?? fromQuery?.refreshToken;
     if (!token) {
       setIsAuthed(Boolean(getStoredStewardToken()) || hasStewardAuthedCookie());
       return;
@@ -254,9 +277,8 @@ export function CheckoutPage() {
     })
       .then(() => {
         setIsAuthed(true);
-        if (queryToken || queryRefreshToken) {
-          params.delete("token");
-          params.delete("refreshToken");
+        if (fromQuery) {
+          removeStewardTokenParams(params);
           const query = params.toString();
           window.history.replaceState(
             null,

--- a/packages/os-homepage/tests/checkout-controls.spec.ts
+++ b/packages/os-homepage/tests/checkout-controls.spec.ts
@@ -1,7 +1,11 @@
 import { expect, type Page, test } from "playwright/test";
 
 async function installCheckoutMocks(page: Page) {
-  const requests: Array<{ url: string; body: unknown }> = [];
+  const requests: Array<{
+    url: string;
+    body: unknown;
+    headers: Record<string, string>;
+  }> = [];
 
   await page.route("https://api.elizacloud.ai/**", async (route) => {
     const request = route.request();
@@ -12,11 +16,22 @@ async function installCheckoutMocks(page: Page) {
     } catch {
       body = null;
     }
-    requests.push({ url: request.url(), body });
+    requests.push({ url: request.url(), body, headers: request.headers() });
 
     if (url.pathname === "/api/auth/steward-session") {
       return route.fulfill({
         json: { success: true, user: { id: "steward-user-1" } },
+      });
+    }
+
+    if (url.pathname === "/api/auth/steward-nonce-exchange") {
+      return route.fulfill({
+        json: {
+          ok: true,
+          userId: "cloud-user-1",
+          stewardUserId: "steward-user-1",
+          token: "steward-token-from-code",
+        },
       });
     }
 
@@ -89,9 +104,65 @@ test("checkout accepts a Steward token and posts the selected product to Stripe"
     (request) =>
       new URL(request.url).pathname === "/api/stripe/create-checkout-session",
   );
+  expect(checkoutRequest?.headers.authorization).toBe(
+    "Bearer steward-token-1",
+  );
   expect(checkoutRequest?.body).toMatchObject({
     hardwareSku: "elizaos-phone",
     hardwareColor: "Blue glass",
     returnUrl: "billing",
+  });
+});
+
+test("checkout exchanges a query code and uses the returned bearer for Stripe", async ({
+  page,
+}) => {
+  const requests = await installCheckoutMocks(page);
+
+  await page.goto("/checkout?code=oauth-code-1&sku=elizaos-phone");
+  await expect(page.getByRole("button", { name: "Pay deposit" })).toBeVisible();
+  await expect(page).toHaveURL(/\/checkout\?sku=elizaos-phone$/);
+
+  const exchangeRequest = requests.find(
+    (request) =>
+      new URL(request.url).pathname === "/api/auth/steward-nonce-exchange",
+  );
+  expect(exchangeRequest?.body).toMatchObject({
+    code: "oauth-code-1",
+    redirectUri: "http://127.0.0.1:4455/checkout?sku=elizaos-phone",
+    tenantId: "elizacloud",
+  });
+
+  await page.getByRole("button", { name: "Pay deposit" }).click();
+  await expect(page).toHaveURL(/\/checkout\/success\?sku=elizaos-phone$/);
+
+  const checkoutRequest = requests.find(
+    (request) =>
+      new URL(request.url).pathname === "/api/stripe/create-checkout-session",
+  );
+  expect(checkoutRequest?.headers.authorization).toBe(
+    "Bearer steward-token-from-code",
+  );
+});
+
+test("checkout accepts OAuth-style hash token names and strips the fragment", async ({
+  page,
+}) => {
+  const requests = await installCheckoutMocks(page);
+
+  await page.goto(
+    "/checkout?sku=elizaos-phone#access_token=steward-token-2&refresh_token=refresh-token-2",
+  );
+  await expect(page.getByRole("button", { name: "Pay deposit" })).toBeVisible();
+  await expect
+    .poll(() => page.evaluate(() => window.location.hash))
+    .toBe("");
+
+  const sessionRequest = requests.find(
+    (request) => new URL(request.url).pathname === "/api/auth/steward-session",
+  );
+  expect(sessionRequest?.body).toMatchObject({
+    token: "steward-token-2",
+    refreshToken: "refresh-token-2",
   });
 });

--- a/packages/shared/src/steward-session-client/index.ts
+++ b/packages/shared/src/steward-session-client/index.ts
@@ -301,6 +301,7 @@ export interface StewardNonceExchangeRequest {
 }
 
 export interface StewardNonceExchangeResponse extends StewardSessionResponse {
+  token?: string;
   expiresIn?: number;
   expiresAt?: number;
 }
@@ -316,7 +317,8 @@ export interface ExchangeStewardCodeOpts extends SyncOpts {
  * POSTs the one-time OAuth code to the cloud-api nonce-exchange endpoint.
  * The route calls Steward `POST /auth/oauth/exchange` server-side, sets the
  * HttpOnly steward-token + steward-refresh-token cookies, and returns the
- * Eliza Cloud user id. Throws `StewardSessionError` on non-2xx.
+ * Eliza Cloud user id. Some cross-origin checkout callers may also receive a
+ * browser bearer token. Throws `StewardSessionError` on non-2xx.
  */
 export async function exchangeStewardCode(
   code: string,


### PR DESCRIPTION
## Summary
- Publish the current local branch state under a fresh Codex branch.
- Harden Steward OAuth/nonce checkout callback handling so the returned bearer is used for Stripe checkout.
- Carry forward the existing iOS local inference/onboarding and remote capability follow-up work already present in this checkout.

## Validation
- bun run --cwd packages/os-homepage test:e2e tests/checkout-controls.spec.ts (8 passed)

## Notes
- Created from local commit d9951c904c on codex/ios-kokoro-tts-onboarding.