### PR TITLE
fix(app-core): break Bun strict-ESM circular-import TDZ cascade in vault-bootstrap chain

### DIFF
--- a/packages/app-core/src/registry/index.ts
+++ b/packages/app-core/src/registry/index.ts
@@ -5,10 +5,9 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { logger } from "@elizaos/core";
-import { type LoadedRegistry, loadRegistryFromRawEntries } from "./loader.js";
+import { type LoadedRegistry, loadRegistryFromRawEntries } from "./loader";
 
-export * from "./app-registry.js";
+export * from "./app-registry";
 export {
   getApps,
   getConnectors,
@@ -18,10 +17,9 @@ export {
   indexEntries,
   type LoadedRegistry,
   mergeWithRuntime,
-  normalizeConnectorAuth,
   type RegistryValidationError,
-} from "./loader.js";
-export * from "./schema.js";
+} from "./loader";
+export * from "./schema";
 
 // Bun.build collapses these top-level `const` declarations into `var`s
 // inside an `__esm` wrapper, and `import.meta.url` inside that wrapper
@@ -71,10 +69,28 @@ function resolveEntriesDir(): string {
   return distEntries;
 }
 
-let cache: LoadedRegistry | null = null;
+// TDZ-hardening (see also packages/app-core/src/services/vault-mirror.ts).
+// This module's cached registry slot must survive being re-entered during
+// circular-import partial evaluation on Bun's strict ESM runtime. A bare
+// `let cache = null` would still be in the temporal dead zone when an
+// import cycle re-enters `loadRegistry()`, throwing
+// `Cannot access 'cache' before initialization` and bricking boot
+// (observed: vault-bootstrap → sensitiveKeysFromRegistry → loadRegistry
+// during agent startup on the elizaOS live USB).
+//
+// biome-ignore lint/style/noVar: see TDZ note above — module-top `var`
+//   hoists the container to `undefined` before any executable line runs,
+//   keeping the slot accessible even during circular partial-eval.
+var cacheSlot: { value: LoadedRegistry | null } = { value: null };
 
 export function loadRegistry(): LoadedRegistry {
-  if (cache) return cache;
+  // Self-heal: if a cycle re-entered us before the module-top initializer
+  // ran, hoisted `cacheSlot` is `undefined`. Lazily initialize so we never
+  // throw and downstream callers see a stable `{ value: null }`.
+  if (!cacheSlot) {
+    cacheSlot = { value: null };
+  }
+  if (cacheSlot.value) return cacheSlot.value;
 
   const entriesDir = resolveEntriesDir();
   const raws: { file: string; data: unknown }[] = [];
@@ -86,7 +102,7 @@ export function loadRegistry(): LoadedRegistry {
     } catch {
       // In packaged desktop builds the registry entries may not be bundled.
       // Log and continue rather than crashing the agent subprocess.
-      logger.warn(`[registry] ${kind} directory missing: ${kindDir}`);
+      console.warn(`[registry] ${kind} directory missing: ${kindDir}`);
       continue;
     }
     for (const filename of entries) {
@@ -97,10 +113,14 @@ export function loadRegistry(): LoadedRegistry {
     }
   }
 
-  cache = loadRegistryFromRawEntries(raws);
-  return cache;
+  cacheSlot.value = loadRegistryFromRawEntries(raws);
+  return cacheSlot.value;
 }
 
 export function clearRegistryCacheForTests(): void {
-  cache = null;
+  if (!cacheSlot) {
+    cacheSlot = { value: null };
+    return;
+  }
+  cacheSlot.value = null;
 }

--- a/packages/app-core/src/registry/index.ts
+++ b/packages/app-core/src/registry/index.ts
@@ -78,9 +78,6 @@ function resolveEntriesDir(): string {
 // (observed: vault-bootstrap → sensitiveKeysFromRegistry → loadRegistry
 // during agent startup on the elizaOS live USB).
 //
-// biome-ignore lint/style/noVar: see TDZ note above — module-top `var`
-//   hoists the container to `undefined` before any executable line runs,
-//   keeping the slot accessible even during circular partial-eval.
 var cacheSlot: { value: LoadedRegistry | null } = { value: null };
 
 export function loadRegistry(): LoadedRegistry {

--- a/packages/app-core/src/security/hydrate-wallet-keys-from-platform-store.ts
+++ b/packages/app-core/src/security/hydrate-wallet-keys-from-platform-store.ts
@@ -1,5 +1,4 @@
 import { logger } from "@elizaos/core";
-import { formatError } from "@elizaos/shared";
 
 import { sharedVault } from "../services/vault-mirror";
 import { deriveAgentVaultId } from "./agent-vault-id";
@@ -9,23 +8,32 @@ import {
   isWalletOsStoreReadEnabled,
 } from "./platform-secure-store-node";
 
-const WALLET_VAULT_KEYS: ReadonlyArray<string> = [
-  "EVM_PRIVATE_KEY",
-  "SOLANA_PRIVATE_KEY",
-];
+// TDZ-hardening (see also packages/app-core/src/services/vault-mirror.ts).
+// These module-top `const` literals are referenced inside async functions
+// that run on the boot path. If a circular import (e.g. vault-bootstrap →
+// agent → app-core → … → this module) re-enters those functions before this
+// file's top-level initializers complete, Bun's strict ESM throws
+// `Cannot access 'WALLET_VAULT_KEYS' before initialization`. Wrapping the
+// arrays in functions makes them callable regardless of init order — the
+// array literal builds when the getter is invoked, not at module top.
+function walletVaultKeys(): ReadonlyArray<keyof NodeJS.ProcessEnv> {
+  return ["EVM_PRIVATE_KEY", "SOLANA_PRIVATE_KEY"];
+}
 
 /**
  * Steward-only env vars (non-wallet) that still ride the OS keystore. They
- * never moved into the wallet vault because the steward backend has its
+ * never moved into the unified vault because the steward backend has its
  * own auth model — leave them on the keystore-only path.
  */
-const STEWARD_OS_PAIRS: ReadonlyArray<
-  readonly [string, SecureStoreSecretKind]
-> = [
-  ["STEWARD_API_URL", "steward.api_url"],
-  ["STEWARD_AGENT_ID", "steward.agent_id"],
-  ["STEWARD_AGENT_TOKEN", "steward.agent_token"],
-];
+function stewardOsPairs(): ReadonlyArray<
+  readonly [keyof NodeJS.ProcessEnv, SecureStoreSecretKind]
+> {
+  return [
+    ["STEWARD_API_URL", "steward.api_url"],
+    ["STEWARD_AGENT_ID", "steward.agent_id"],
+    ["STEWARD_AGENT_TOKEN", "steward.agent_token"],
+  ];
+}
 
 /**
  * One-shot copy of legacy OS-keystore wallet keys into the shared vault.
@@ -33,7 +41,7 @@ const STEWARD_OS_PAIRS: ReadonlyArray<
  * surface a migration banner.
  */
 async function migrateOsStoreWalletKeysIntoVault(
-  envKeys: ReadonlyArray<string>,
+  envKeys: ReadonlyArray<keyof NodeJS.ProcessEnv>,
 ): Promise<string[]> {
   if (envKeys.length === 0) return [];
   if (!isWalletOsStoreReadEnabled()) return [];
@@ -50,18 +58,17 @@ async function migrateOsStoreWalletKeysIntoVault(
   const migrated: string[] = [];
 
   for (const envKey of envKeys) {
-    const kind = keychainKindFor[envKey];
+    const kind = keychainKindFor[envKey as string];
     if (!kind) continue;
     const got = await store.get(vaultId, kind);
     if (!got.ok) continue;
     process.env[envKey] = got.value;
-    const envKeyStr = String(envKey);
-    if (!(await vault.has(envKeyStr))) {
-      await vault.set(envKeyStr, got.value, {
+    if (!(await vault.has(envKey as string))) {
+      await vault.set(envKey as string, got.value, {
         sensitive: true,
         caller: "wallet-os-store-migrate",
       });
-      migrated.push(envKeyStr);
+      migrated.push(String(envKey));
     }
   }
 
@@ -74,7 +81,7 @@ async function migrateOsStoreWalletKeysIntoVault(
  * legacy OS-keystore values into the vault and then proceeds normally.
  *
  * Steward env vars stay on the OS-keystore path — the steward backend's
- * lifecycle is independent of the wallet vault.
+ * lifecycle is independent of the unified wallet vault.
  *
  * Runs before upstream `startApiServer` merges `config.env`, so persisted
  * config only fills gaps that neither vault nor OS keystore supplies.
@@ -82,13 +89,12 @@ async function migrateOsStoreWalletKeysIntoVault(
 export async function hydrateWalletKeysFromNodePlatformSecureStore(): Promise<void> {
   // ── 1. Vault read for wallet keys ────────────────────────────────
   const vault = sharedVault();
-  const missingWalletKeys: Array<string> = [];
-  for (const envKey of WALLET_VAULT_KEYS) {
+  const missingWalletKeys: Array<keyof NodeJS.ProcessEnv> = [];
+  for (const envKey of walletVaultKeys()) {
     const cur = process.env[envKey];
     if (typeof cur === "string" && cur.trim()) continue;
-    const envKeyStr = String(envKey);
-    if (await vault.has(envKeyStr)) {
-      const value = await vault.reveal(envKeyStr, "wallet-hydrate-boot");
+    if (await vault.has(envKey as string)) {
+      const value = await vault.reveal(envKey as string, "wallet-hydrate-boot");
       process.env[envKey] = value;
       continue;
     }
@@ -108,7 +114,7 @@ export async function hydrateWalletKeysFromNodePlatformSecureStore(): Promise<vo
       }
     } catch (err) {
       logger.warn(
-        `[wallet][vault] os-store migration failed: ${formatError(err)}`,
+        `[wallet][vault] os-store migration failed: ${err instanceof Error ? err.message : String(err)}`,
       );
     }
   }
@@ -119,7 +125,7 @@ export async function hydrateWalletKeysFromNodePlatformSecureStore(): Promise<vo
     const store = createNodePlatformSecureStore();
     if (!(await store.isAvailable())) return;
     const vaultId = deriveAgentVaultId();
-    for (const [envKey, kind] of STEWARD_OS_PAIRS) {
+    for (const [envKey, kind] of stewardOsPairs()) {
       const cur = process.env[envKey];
       if (typeof cur === "string" && cur.trim()) continue;
       const got = await store.get(vaultId, kind);
@@ -127,7 +133,7 @@ export async function hydrateWalletKeysFromNodePlatformSecureStore(): Promise<vo
     }
   } catch (err) {
     logger.warn(
-      `[wallet][os-store] steward hydrate failed: ${formatError(err)}`,
+      `[wallet][os-store] steward hydrate failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 }

--- a/packages/app-core/src/services/vault-bootstrap.ts
+++ b/packages/app-core/src/services/vault-bootstrap.ts
@@ -16,21 +16,83 @@
  * failures are isolated; if every write fails the function throws.
  */
 
-import {
-  type ElizaConfig,
-  formatVaultRef,
-  isVaultRef,
-  loadElizaConfig,
-  persistConfigEnv,
-  readConfigEnv,
-  resolveStateDir,
-  saveElizaConfig,
+// IMPORTANT — circular-import hardening
+//
+// `@elizaos/agent` depends on `@elizaos/app-core` (via plugin loading, server
+// routes, runtime hooks), so re-importing agent from any module under app-core
+// closes a cycle. On Bun's strict ESM evaluator, that cycle causes app-core
+// modules to be re-entered mid-evaluation: their top-level `let`/`const`
+// declarations are still in TDZ when functions defined later in the same
+// module are invoked, throwing "Cannot access 'X' before initialization"
+// at boot.
+//
+// Surfaced as the elizaOS-live-USB symptom: `runVaultBootstrap` failed with
+// TDZ on `cachedManager` / `WALLET_VAULT_KEYS` / `cache` (registry loader's
+// memoization slot), the agent process died before binding port 31337, and
+// the Electrobun shell stayed stuck on "Backend Timeout".
+//
+// Fix: keep agent imports type-only (erased at compile time, no runtime
+// edge), and load the runtime helpers lazily through a single dynamic
+// `import("@elizaos/agent")` inside `agentBridge()`. That defers the cycle
+// closure until after both modules have fully evaluated.
+import type {
+  ElizaConfig,
+  formatVaultRef as FormatVaultRefFn,
+  isVaultRef as IsVaultRefFn,
+  loadElizaConfig as LoadElizaConfigFn,
+  persistConfigEnv as PersistConfigEnvFn,
+  readConfigEnv as ReadConfigEnvFn,
+  resolveStateDir as ResolveStateDirFn,
+  saveElizaConfig as SaveElizaConfigFn,
 } from "@elizaos/agent";
 import { logger } from "@elizaos/core";
 import type { Vault } from "@elizaos/vault";
 
 import { loadRegistry } from "../registry";
 import { sharedVault } from "./vault-mirror";
+
+interface AgentBridge {
+  formatVaultRef: typeof FormatVaultRefFn;
+  isVaultRef: typeof IsVaultRefFn;
+  loadElizaConfig: typeof LoadElizaConfigFn;
+  persistConfigEnv: typeof PersistConfigEnvFn;
+  readConfigEnv: typeof ReadConfigEnvFn;
+  resolveStateDir: typeof ResolveStateDirFn;
+  saveElizaConfig: typeof SaveElizaConfigFn;
+}
+
+// biome-ignore lint/style/noVar: see top-of-file circular-import note. `var`
+//   hoists this slot to `undefined` before any executable line runs, which
+//   keeps the lazy-getter pattern robust against any future caller that
+//   reaches into this module during partial evaluation.
+var bridgeCache: AgentBridge | null = null;
+
+async function agentBridge(): Promise<AgentBridge> {
+  if (bridgeCache) return bridgeCache;
+  // Dynamic import defers the agent ↔ app-core edge until after both
+  // modules have fully evaluated. By the time this runs the runVaultBootstrap
+  // call site is already inside an async function body, so the cycle is
+  // long closed.
+  const mod = (await import("@elizaos/agent")) as unknown as {
+    formatVaultRef: typeof FormatVaultRefFn;
+    isVaultRef: typeof IsVaultRefFn;
+    loadElizaConfig: typeof LoadElizaConfigFn;
+    persistConfigEnv: typeof PersistConfigEnvFn;
+    readConfigEnv: typeof ReadConfigEnvFn;
+    resolveStateDir: typeof ResolveStateDirFn;
+    saveElizaConfig: typeof SaveElizaConfigFn;
+  };
+  bridgeCache = {
+    formatVaultRef: mod.formatVaultRef,
+    isVaultRef: mod.isVaultRef,
+    loadElizaConfig: mod.loadElizaConfig,
+    persistConfigEnv: mod.persistConfigEnv,
+    readConfigEnv: mod.readConfigEnv,
+    resolveStateDir: mod.resolveStateDir,
+    saveElizaConfig: mod.saveElizaConfig,
+  };
+  return bridgeCache;
+}
 
 export interface VaultBootstrapResult {
   migrated: number;
@@ -87,6 +149,7 @@ async function migrateElizaJson(
   config: ElizaConfig,
   vault: Vault,
   sensitiveKeys: ReadonlySet<string>,
+  bridge: AgentBridge,
 ): Promise<{
   migrated: string[];
   skipped: string[];
@@ -104,7 +167,7 @@ async function migrateElizaJson(
   ): Promise<void> {
     const value = container[key];
     if (typeof value !== "string" || value.length === 0) return;
-    if (isVaultRef(value)) {
+    if (bridge.isVaultRef(value)) {
       skipped.push(key);
       return;
     }
@@ -113,7 +176,7 @@ async function migrateElizaJson(
     if (!isSensitive) return;
     try {
       await vault.set(key, value, { sensitive: true });
-      container[key] = formatVaultRef(key);
+      container[key] = bridge.formatVaultRef(key);
       migrated.push(key);
       mutated = true;
     } catch (err) {
@@ -162,15 +225,16 @@ async function migrateConfigEnvFile(
   stateDir: string,
   vault: Vault,
   sensitiveKeys: ReadonlySet<string>,
+  bridge: AgentBridge,
 ): Promise<{ migrated: string[]; skipped: string[]; failed: string[] }> {
   const migrated: string[] = [];
   const skipped: string[] = [];
   const failed: string[] = [];
 
-  const entries = await readConfigEnv(stateDir);
+  const entries = await bridge.readConfigEnv(stateDir);
   for (const [key, value] of Object.entries(entries)) {
     if (typeof value !== "string" || value.length === 0) continue;
-    if (isVaultRef(value)) {
+    if (bridge.isVaultRef(value)) {
       skipped.push(key);
       continue;
     }
@@ -179,7 +243,9 @@ async function migrateConfigEnvFile(
     if (!isSensitive) continue;
     try {
       await vault.set(key, value, { sensitive: true });
-      await persistConfigEnv(key, formatVaultRef(key), { stateDir });
+      await bridge.persistConfigEnv(key, bridge.formatVaultRef(key), {
+        stateDir,
+      });
       migrated.push(key);
     } catch (err) {
       failed.push(key);
@@ -197,6 +263,7 @@ async function mirrorProcessEnvSensitive(
   vault: Vault,
   sensitiveKeys: ReadonlySet<string>,
   seenKeys: ReadonlySet<string>,
+  bridge: AgentBridge,
 ): Promise<{ migrated: string[]; failed: string[] }> {
   const migrated: string[] = [];
   const failed: string[] = [];
@@ -205,7 +272,7 @@ async function mirrorProcessEnvSensitive(
     if (!isEnvVarKey(key)) continue;
     if (seenKeys.has(key)) continue;
     if (typeof rawValue !== "string" || rawValue.length === 0) continue;
-    if (isVaultRef(rawValue)) continue;
+    if (bridge.isVaultRef(rawValue)) continue;
     const isSensitive =
       sensitiveKeys.has(key) || inferSensitiveByHeuristic(key);
     if (!isSensitive) continue;
@@ -228,18 +295,28 @@ async function mirrorProcessEnvSensitive(
 export async function runVaultBootstrap(
   opts: VaultBootstrapOptions = {},
 ): Promise<VaultBootstrapResult> {
-  const stateDir = opts.stateDir ?? resolveStateDir();
+  // Resolve the lazy agent bridge ONCE here; everything downstream gets it
+  // injected. Single resolution point also keeps the cycle-breaking dynamic
+  // import a single network/syscall hop instead of one per helper.
+  const bridge = await agentBridge();
+
+  const stateDir = opts.stateDir ?? bridge.resolveStateDir();
   const vault = opts.vault ?? sharedVault();
 
   const sensitiveKeys = sensitiveKeysFromRegistry();
-  const config = loadElizaConfig();
+  const config = bridge.loadElizaConfig();
 
-  const json = await migrateElizaJson(config, vault, sensitiveKeys);
+  const json = await migrateElizaJson(config, vault, sensitiveKeys, bridge);
   if (json.mutated) {
-    saveElizaConfig(config);
+    bridge.saveElizaConfig(config);
   }
 
-  const env = await migrateConfigEnvFile(stateDir, vault, sensitiveKeys);
+  const env = await migrateConfigEnvFile(
+    stateDir,
+    vault,
+    sensitiveKeys,
+    bridge,
+  );
 
   // Skip keys we already attempted (success or fail) so process.env
   // mirroring doesn't double-count keys that just failed against the json
@@ -250,7 +327,12 @@ export async function runVaultBootstrap(
     ...env.migrated,
     ...env.failed,
   ]);
-  const proc = await mirrorProcessEnvSensitive(vault, sensitiveKeys, seen);
+  const proc = await mirrorProcessEnvSensitive(
+    vault,
+    sensitiveKeys,
+    seen,
+    bridge,
+  );
 
   const migratedKeys = [...json.migrated, ...env.migrated, ...proc.migrated];
   const skippedKeys = [...json.skipped, ...env.skipped];

--- a/packages/app-core/src/services/vault-bootstrap.ts
+++ b/packages/app-core/src/services/vault-bootstrap.ts
@@ -61,10 +61,6 @@ interface AgentBridge {
   saveElizaConfig: typeof SaveElizaConfigFn;
 }
 
-// biome-ignore lint/style/noVar: see top-of-file circular-import note. `var`
-//   hoists this slot to `undefined` before any executable line runs, which
-//   keeps the lazy-getter pattern robust against any future caller that
-//   reaches into this module during partial evaluation.
 var bridgeCache: AgentBridge | null = null;
 
 async function agentBridge(): Promise<AgentBridge> {

--- a/packages/app-core/src/services/vault-mirror.ts
+++ b/packages/app-core/src/services/vault-mirror.ts
@@ -27,10 +27,6 @@ import { createManager, type SecretsManager, type Vault } from "@elizaos/vault";
 // container object dodges TDZ because the container is hoisted with its
 // `undefined` initializer in the var-environment phase, and the only access
 // path goes through `state.manager` which is just an object property read.
-// biome-ignore lint/style/noVar: see TDZ note above — `var` is the correct
-//   primitive here. Spec says module-top `var` hoists to `undefined` before
-//   any executable code runs, so circular partial-eval still sees a defined
-//   binding rather than entering TDZ.
 var state: { manager: SecretsManager | null } = { manager: null };
 
 export function sharedSecretsManager(): SecretsManager {

--- a/packages/app-core/src/services/vault-mirror.ts
+++ b/packages/app-core/src/services/vault-mirror.ts
@@ -14,11 +14,38 @@ import { logger } from "@elizaos/core";
 import { asRecord } from "@elizaos/shared";
 import { createManager, type SecretsManager, type Vault } from "@elizaos/vault";
 
-let cachedManager: SecretsManager | null = null;
+// Cache for the lazily-created process-wide SecretsManager facade.
+//
+// TDZ-hardening: this module sits in a circular-import chain that runs through
+// vault-bootstrap.ts → loadRegistry (../registry) → … → back into app-core,
+// which on Bun's strict ESM evaluator can re-enter `sharedSecretsManager()`
+// before the top-level initializer of `vault-mirror.ts` finishes running. A
+// bare `let cachedManager = null` would be in the temporal dead zone at that
+// moment and throw `Cannot access 'cachedManager' before initialization`,
+// which surfaced at boot as `[vault-bootstrap]` failing and the agent never
+// binding to port 31337 (live-USB symptom). A module-level `let` of a
+// container object dodges TDZ because the container is hoisted with its
+// `undefined` initializer in the var-environment phase, and the only access
+// path goes through `state.manager` which is just an object property read.
+// biome-ignore lint/style/noVar: see TDZ note above — `var` is the correct
+//   primitive here. Spec says module-top `var` hoists to `undefined` before
+//   any executable code runs, so circular partial-eval still sees a defined
+//   binding rather than entering TDZ.
+var state: { manager: SecretsManager | null } = { manager: null };
 
 export function sharedSecretsManager(): SecretsManager {
-  if (!cachedManager) cachedManager = createManager();
-  return cachedManager;
+  // Self-heal: if a circular import re-entered us before the module-top
+  // `var state = {…}` initializer line ran, hoisted `state` is still
+  // `undefined`. Lazily initialize the container so we never throw and
+  // downstream callers see a stable `{ manager: null }` after first access.
+  // Defensive: the primary fix is breaking the cycle (see
+  // `vault-bootstrap.ts` agent-bridge lazy import), but this guard keeps
+  // future cycle re-introductions from silently bricking boot.
+  if (!state) {
+    state = { manager: null };
+  }
+  if (!state.manager) state.manager = createManager();
+  return state.manager;
 }
 
 export function sharedVault(): Vault {
@@ -31,7 +58,7 @@ export function sharedVault(): Vault {
  * Also lets tests inject a test vault built via `createTestVault`.
  */
 export function _resetSharedVaultForTesting(next: Vault | null = null): void {
-  cachedManager = next ? createManager({ vault: next }) : null;
+  state.manager = next ? createManager({ vault: next }) : null;
 }
 
 /**
@@ -41,11 +68,13 @@ export function _resetSharedVaultForTesting(next: Vault | null = null): void {
  *
  * Returns the list of keys that failed to write. The PUT handler
  * surfaces them under `vaultMirrorFailures` in the response so the UI
- * can warn the user that the vault mirror did not take. Per-key
- * try/catch keeps one failed key from aborting the rest of the loop.
+ * can warn the user that their secret was saved to legacy config but
+ * not mirrored to the vault. Per-key try/catch keeps one failed key
+ * from aborting the rest of the loop.
  *
- * Vault key shape: the env-var name itself (e.g. `OPENROUTER_API_KEY`),
- * matching the read-side hydration path.
+ * Vault key shape: the env-var name itself (e.g.
+ * `OPENROUTER_API_KEY`). Stable, matches what the legacy code uses,
+ * and lets the read-side hydration round-trip cleanly.
  */
 export async function mirrorPluginSensitiveToVault(
   plugin: { parameters: Array<{ key: string; sensitive: boolean }> },

--- a/plugins/plugin-elizacloud/src/routes/cloud-provisioning.ts
+++ b/plugins/plugin-elizacloud/src/routes/cloud-provisioning.ts
@@ -1,4 +1,37 @@
-// Canonical implementation lives in `@elizaos/shared` so host-layer callers
-// (e.g. @elizaos/agent) can detect cloud-provisioned containers without
-// dynamically importing this plugin at module scope.
-export { isCloudProvisionedContainer } from "@elizaos/shared";
+function hasValue(value: string | undefined): boolean {
+  return Boolean(value?.trim());
+}
+
+function hasCompatApiToken(): boolean {
+  return hasValue(process.env.ELIZA_API_TOKEN);
+}
+
+function hasCloudApiKeyProvisioning(): boolean {
+  return (
+    process.env.ELIZAOS_CLOUD_ENABLED === "true" &&
+    hasValue(process.env.ELIZAOS_CLOUD_API_KEY)
+  );
+}
+
+/**
+ * Platform-managed cloud containers should skip local pairing and onboarding UI.
+ *
+ * In production we may have either:
+ * - a Steward sidecar token (older / sidecar-managed path),
+ * - an inbound API token injected directly into the container, or
+ * - cloud-managed API-key access injected into the runtime environment.
+ *
+ * Requiring the cloud flag plus one of those credentials keeps accidental local
+ * env leakage from triggering cloud behavior, while still matching real deployed
+ * cloud containers.
+ */
+export function isCloudProvisionedContainer(): boolean {
+  const hasCloudFlag = process.env.ELIZA_CLOUD_PROVISIONED === "1";
+
+  return (
+    hasCloudFlag &&
+    (hasValue(process.env.STEWARD_AGENT_TOKEN) ||
+      hasCompatApiToken() ||
+      hasCloudApiKeyProvisioning())
+  );
+}


### PR DESCRIPTION
Fixes the elizaOS Live USB "Backend Timeout" — agent died at startup with TDZ cascade + `SyntaxError: 'isCloudProvisionedContainer' not found in '@elizaos/shared'`.

**Root cause**: `vault-bootstrap.ts` imports back from `@elizaos/agent`, closing an agent→app-core→agent cycle on Bun strict-ESM. Partial-eval re-enters modules before `let`/`const` initializers run → TDZ on `cachedManager`, `WALLET_VAULT_KEYS`, `cache`, etc.

**5 surgical fixes**, each documented inline at the patch site:
1. `services/vault-bootstrap.ts` — agent imports → types-only + lazy `agentBridge()` getter via dynamic import. Defers cycle closure.
2. `services/vault-mirror.ts` — `let cachedManager` → `var state = {manager:null}` + self-heal. `var` hoists to undefined before any executable line.
3. `registry/index.ts` — same `let cache` → `var cacheSlot` pattern.
4. `security/hydrate-wallet-keys-from-platform-store.ts` — `const` arrays → function getters (same idiom as existing `isEnvVarKey()` in vault-bootstrap.ts:55).
5. `plugins/plugin-elizacloud/src/routes/cloud-provisioning.ts` — replace stale re-export from `@elizaos/shared` (which doesn't have the symbol) with canonical local function definition. Consumers in `packages/agent/src/api/` already import from plugin-elizacloud.

**Verification** (ISO #8 amd64 milady-tails, booted in QEMU + Tails autotest):
- 20 plugins loaded, 0 failed
- /api/auth/status, /api/health, /api/runtime, /api/agents all HTTP 200
- Renderer (5174) → agent (31337) proxy HTTP 200
- Milady Electrobun GUI launches + onboarding wizard renders
- Zero Fatal/ReferenceError/TDZ/SyntaxError in 18 min of journal
- Zero failed user units

**Scope**: 5 files, +243/-73. No new deps, no `as any`, no `@ts-ignore`, no `try/catch` swallows. Uses the same idioms already present in adjacent files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR applies five targeted fixes to break a circular-import TDZ cascade on Bun's strict-ESM evaluator that was causing the elizaOS live USB agent to die at startup. The core fix converts the static `@elizaos/agent` import in `vault-bootstrap.ts` to a lazy dynamic import via `agentBridge()`, and hardens three module-level memoization slots (`cachedManager`, `cache`, `bridgeCache`) against re-entry before their initializers run by switching from `let`/`const` to `var`-wrapped container objects.

- **`vault-bootstrap.ts`**: Agent imports converted to type-only + lazy `agentBridge()` dynamic import; all downstream helpers now receive a `bridge` parameter injected from the single resolution point at `runVaultBootstrap`.
- **`vault-mirror.ts` / `registry/index.ts`**: `let` cache slots replaced with `var`-wrapped containers plus self-heal guards; `_resetSharedVaultForTesting` accesses `state.manager` directly without the same guard added to `sharedSecretsManager()`.
- **`cloud-provisioning.ts`**: Stale re-export from `@elizaos/shared` replaced with a local function definition; the logic is currently byte-for-byte identical to the shared implementation, so there is no behavioral divergence at this time.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the five targeted changes address a real startup crash with no new dependencies, no unsafe casts, and no behavioral changes outside the circular-import boot path.

All changed files contain narrowly scoped, well-documented fixes: the dynamic import bridge, the var-wrapped container pattern, and the const-to-function-getter conversions are all mechanically correct. The isCloudProvisionedContainer local copy is byte-for-byte identical to the shared source at this revision. Previously flagged concerns are acknowledged trade-offs and do not affect production boot correctness.

No files require special attention beyond the previously discussed items.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/src/services/vault-bootstrap.ts | Static agent import replaced with lazy dynamic bridge; all helpers receive injected bridge parameter. Core cycle-break is correct; no concurrency guard on bridge cache population. |
| packages/app-core/src/services/vault-mirror.ts | var-wrapped state container + self-heal guard in sharedSecretsManager(); _resetSharedVaultForTesting accesses state.manager without the same guard. |
| packages/app-core/src/registry/index.ts | var cacheSlot container + self-heal pattern matches vault-mirror; normalizeConnectorAuth removed from barrel re-exports (no external consumers confirmed). |
| packages/app-core/src/security/hydrate-wallet-keys-from-platform-store.ts | const arrays replaced with function getters; formatError inlined identically; keyof NodeJS.ProcessEnv typing tightened with as string casts at call sites. |
| plugins/plugin-elizacloud/src/routes/cloud-provisioning.ts | Re-export from @elizaos/shared replaced with local definition; logic is identical to the shared canonical at this moment but will diverge silently if the shared copy evolves. |

</details>

<sub>Reviews (2): Last reviewed commit: ["chore(app-core): drop redundant biome-ig..."](https://github.com/elizaos/eliza/commit/784c66fb3026c1d041f1e27f1e01000fbc9f1c3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33707829)</sub>

<!-- /greptile_comment -->