### PR TITLE
chore(ci): set ELIZAOS_BUILD_APP=1 + bump heap to unstick nightly build-linux-iso

### DIFF
--- a/.github/workflows/build-linux-iso.yml
+++ b/.github/workflows/build-linux-iso.yml
@@ -91,8 +91,21 @@ jobs:
 
       - name: Build ISO (${{ matrix.arch }})
         working-directory: ${{ env.LINUX_DIR }}
+        # ELIZAOS_BUILD_APP=1 lets `just elizaos-app` (the dependency of
+        # `just build`) compile the Electrobun desktop artifact in-CI when
+        # no pre-staged ${ELIZAOS_APP_ARTIFACT} is provided. Without this
+        # flag the recipe exits before staging, so the chroot hook fails
+        # with "ERROR: /opt/elizaos-artifacts missing" — the root cause
+        # of 8+ days of nightly red on this workflow.
+        #
+        # NODE_OPTIONS lifts the V8 heap so the Vite renderer build can
+        # bundle the full elizaOS plugin graph; the default 4 GB heap
+        # OOMs on the renderer step (observed locally on a 30 GB host).
+        env:
+          ELIZAOS_BUILD_APP: 1
+          NODE_OPTIONS: --max-old-space-size=12288
         run: just build
-        timeout-minutes: 110
+        timeout-minutes: 180
 
       - name: Locate and rename ISO
         id: iso


### PR DESCRIPTION
Workflow has been failing every night for 8+ days (May 17 → today) with:
```
ERROR: /opt/elizaos-artifacts missing; objective images require real elizaOS agent artifacts.
E: config/hooks/normal/<hook>-elizaos-agent.hook.chroot failed (exit non-zero)
```

**Root cause**: `just build` depends on `just elizaos-app`, which checks `${app_out}/bin/launcher` exists OR `ELIZAOS_BUILD_APP=1` is set. CI sets neither, so the recipe exits before staging the Electrobun artifact, the chroot hook can't find `/opt/elizaos-artifacts/`, and lb build fails. Same failure across all 3 matrix archs (amd64, arm64, riscv64).

**Fix**: set `ELIZAOS_BUILD_APP=1` in the build-iso step's env. The recipe then builds the Electrobun desktop artifact in-CI (~20-30 min) before `lb build` runs.

**Also bumped V8 heap to 12 GB** — the Vite renderer step bundles the full plugin graph (20+ plugins) and OOMs on the default 4 GB heap. Observed locally on a 30 GB host. GitHub Actions ubuntu-24.04 runners have 16 GB RAM so 12 GB fits.

**Timeout bumped 110 → 180 min** to absorb the extra app-build phase.

**Verified locally**: same env produced ISO #8 (SHA256 `6019452aadc2a66f26005fb12a54aeb0d9256d8d6d58f88938db63cf6ce6f7e1`) which boots in QEMU, agent binds `127.0.0.1:31337`, all 20 plugins load with 0 failures, `/api/health` returns 200.

See `packages/os/docs/ci-cd-prod-roadmap.md` (PR #7949) for the broader Phase 1 — Phase 6 plan.

Companion PRs:
- #7947 — TDZ cascade fixes (required for the agent to come up inside the ISO without crashing)
- #7949 — CI/CD prod roadmap doc (this PR is Phase 1, action #1 of that plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the nightly ISO build that has been failing for 8+ days by setting `ELIZAOS_BUILD_APP=1` so that `just elizaos-app` actually compiles the Electrobun desktop artifact in CI, and raises `NODE_OPTIONS` heap to 12 GB to prevent the Vite renderer step from OOMing.

- **Root-cause fix**: `ELIZAOS_BUILD_APP=1` added to the \"Build ISO\" step's `env`, preventing the chroot hook from failing with \"ERROR: /opt/elizaos-artifacts missing\".
- **Heap bump**: `NODE_OPTIONS: --max-old-space-size=12288` lifts the V8 limit from the default 4 GB to fit within the 16 GB GitHub Actions runner.
- **Timeout**: The step `timeout-minutes` was raised from 110 → 180, but the job-level `timeout-minutes: 120` was not updated, so the job will still be cancelled before the step timeout can trigger on longer builds.

<h3>Confidence Score: 3/5</h3>

The fix correctly addresses the root cause but leaves the job-level timeout at 120 minutes while bumping the step timeout to 180 minutes — the job will still be cancelled before the longer build completes.

The env-var fix and heap bump are correct, but the job-level timeout-minutes: 120 was not updated alongside the step timeout. Since the new app-build phase adds 20-30 minutes, a run that previously finished near the 100-minute mark can now exceed 120 minutes and be killed by the job scheduler before the step timeout triggers.

.github/workflows/build-linux-iso.yml — specifically the job-level timeout-minutes on line 39 that needs to be raised to match the step-level change

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-linux-iso.yml | Adds ELIZAOS_BUILD_APP=1 and NODE_OPTIONS heap bump to fix nightly ISO build; step timeout raised to 180 min but the job-level timeout remains at 120 min, so the step timeout can never be reached |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Build ISO step starts] --> B{ELIZAOS_BUILD_APP=1?}
    B -- "Before PR: not set" --> C[just elizaos-app exits early\nno artifact staged]
    C --> D["chroot hook: ERROR\n/opt/elizaos-artifacts missing"]
    D --> E[lb build fails ❌]
    B -- "After PR: set" --> F[just elizaos-app builds\nElectrobun artifact ~20-30 min]
    F --> G[artifact staged to /opt/elizaos-artifacts]
    G --> H[lb build runs]
    H --> I{Build duration}
    I -- "< 120 min (job timeout)" --> J[ISO produced ✅]
    I -- "> 120 min (job timeout)" --> K[Job cancelled by\njob-level timeout ❌\nstep timeout=180 unreachable]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/build-linux-iso.yml`, line 39-40 ([link](https://github.com/elizaos/eliza/blob/c9607ad711c4478b0a76a778b13c623c6c4c4b29/.github/workflows/build-linux-iso.yml#L39-L40)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> The job-level `timeout-minutes` must also be raised. As written, the job is cancelled at 120 min regardless of the step's 180-min limit, meaning a build that takes 125+ min (likely with the new app-build phase) will still fail.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["ci(build-linux-iso): set ELIZAOS\_BUILD\_A..."](https://github.com/elizaos/eliza/commit/c9607ad711c4478b0a76a778b13c623c6c4c4b29) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33713621)</sub>

<!-- /greptile_comment -->