### PR TITLE
fix(core/planner-loop): surface captured REPLY refusal text when required-tool cap hits

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-tools-vs-schema.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-tools-vs-schema.test.ts
@@ -178,10 +178,49 @@ describe("planner-loop responseSchema/tools collision regression", () => {
 		expect(plannerCall.toolChoice).toBe("required");
 	});
 
-	it("caps required-tool planner misses", async () => {
+	it("caps required-tool planner misses and surfaces the captured refusal text instead of throwing", async () => {
+		// Live trajectory tj-3bb6dc66be0c16.json on 2026-05-25 showed that when
+		// Stage 1 set requiresTool=true but no exposed tool could fulfill the
+		// task (chat-history search with no SEARCH_MESSAGES action), the
+		// planner produced 4 valid REPLY/messageToUser refusals across
+		// iterations, and the loop threw TrajectoryLimitExceeded — the caller
+		// then surfaced a generic apology instead of the planner's real answer.
+		// The fix captures the most recent terminal-only refusal and returns
+		// it as the final message when the limit is hit.
 		const runtime = {
 			useModel: vi.fn(async () => ({
-				text: "I should answer later.",
+				text: "I don't have a way to search the message history.",
+				toolCalls: [],
+			})),
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [MOCK_TOOL],
+			requireNonTerminalToolCall: true,
+			config: { maxRequiredToolMisses: 1 },
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(
+			"I don't have a way to search the message history.",
+		);
+		// One call for the initial miss; the threshold trips on the same iter
+		// so the loop returns instead of retrying.
+		expect(runtime.useModel).toHaveBeenCalledTimes(1);
+	});
+
+	it("still throws TrajectoryLimitExceeded when the planner produces no usable refusal text", async () => {
+		// Defensive: when the planner emits neither tool calls nor any
+		// messageToUser / text across all retries, there is nothing to
+		// surface — the cap must still fire so the caller can fall back
+		// to the generic apology path rather than returning an empty reply.
+		const runtime = {
+			useModel: vi.fn(async () => ({
+				text: "",
 				toolCalls: [],
 			})),
 		};

--- a/packages/core/src/runtime/__tests__/planner-loop.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop.test.ts
@@ -501,6 +501,69 @@ describe("v5 planner loop skeleton", () => {
 		expect(result.finalMessage).toBe("Checked.");
 	});
 
+	it("surfaces captured REPLY refusal text when required-tool cap is hit, instead of throwing", async () => {
+		// Live regression: trajectory tj-3bb6dc66be0c16.json on 2026-05-25
+		// showed that when Stage 1 set requiresTool=true but no exposed tool
+		// could fulfill the task (chat-history search with no SEARCH_MESSAGES
+		// action), the planner emitted REPLY with valid honest refusals each
+		// iteration. The loop discarded every REPLY, hit maxRequiredToolMisses,
+		// threw TrajectoryLimitExceeded, and the caller emitted a generic
+		// apology ("Sorry, something went wrong—please try again"). The fix
+		// captures the most recent terminal-only refusal across iterations and
+		// returns it as the final user-facing message when the cap is reached.
+		const runtime = {
+			useModel: vi
+				.fn()
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "reply-1",
+							name: "REPLY",
+							arguments: {
+								text: "I'm not able to search the chat history directly from here.",
+							},
+						},
+					],
+				})
+				.mockResolvedValueOnce({
+					text: "",
+					toolCalls: [
+						{
+							id: "reply-2",
+							name: "REPLY",
+							arguments: {
+								text: "I don't have a way to search the Discord message history.",
+							},
+						},
+					],
+				}),
+			logger: { warn: vi.fn() },
+		};
+
+		const result = await runPlannerLoop({
+			runtime,
+			context: { id: "ctx" },
+			tools: [
+				{
+					name: "LOOKUP",
+					description: "Lookup current status.",
+				},
+			],
+			requireNonTerminalToolCall: true,
+			config: { maxRequiredToolMisses: 2 },
+			executeToolCall: vi.fn(),
+			evaluate: vi.fn(),
+		});
+
+		expect(result.status).toBe("finished");
+		expect(result.finalMessage).toBe(
+			"I don't have a way to search the Discord message history.",
+		);
+		// Two REPLY iterations; the second hits the cap and returns.
+		expect(runtime.useModel).toHaveBeenCalledTimes(2);
+	});
+
 	it("retries planner calls to tools that are not exposed this turn", async () => {
 		const runtime = {
 			useModel: vi

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -175,6 +175,14 @@ export async function runPlannerLoop(
 	// achieve the goal (e.g. read-then-act, multi-step deploy). When the
 	// field is absent the gate's other preconditions are honored as before.
 	let lastPlannerExplicitCompleted: boolean | undefined;
+	// Captures the most recent terminal-only refusal text the planner produced
+	// across iterations gated by `requireNonTerminalToolCall`. When Stage 1
+	// asserts `requiresTool=true` but no exposed tool can fulfill the request,
+	// the planner repeatedly emits REPLY (or bare messageToUser) with a valid
+	// honest refusal. Without this, the loop discards every refusal, exceeds
+	// `maxRequiredToolMisses`, throws `TrajectoryLimitExceeded`, and the
+	// caller surfaces a generic apology instead of the planner's real answer.
+	let lastTerminalRefusalText: string | undefined;
 
 	for (let iteration = 1; ; iteration++) {
 		if (trajectory.plannedQueue.length === 0) {
@@ -219,7 +227,22 @@ export async function runPlannerLoop(
 					requireNonTerminalToolCall &&
 					!hasExecutedNonTerminalTool(trajectory)
 				) {
+					const refusalCandidate = getNonEmptyString(
+						plannerOutput.messageToUser,
+					);
+					if (refusalCandidate) lastTerminalRefusalText = refusalCandidate;
 					requiredToolMisses++;
+					if (
+						requiredToolMisses >= config.maxRequiredToolMisses &&
+						lastTerminalRefusalText
+					) {
+						return finishWithCapturedRefusal({
+							trajectory,
+							iteration,
+							thought: plannerOutput.thought,
+							refusal: lastTerminalRefusalText,
+						});
+					}
 					assertTrajectoryLimit({
 						kind: "required_tool_misses",
 						max: config.maxRequiredToolMisses,
@@ -320,7 +343,23 @@ export async function runPlannerLoop(
 					requireNonTerminalToolCall &&
 					!hasExecutedNonTerminalTool(trajectory)
 				) {
+					const refusalCandidate = terminalMessageFromToolCalls(
+						plannerOutput.toolCalls,
+						plannerOutput.messageToUser,
+					);
+					if (refusalCandidate) lastTerminalRefusalText = refusalCandidate;
 					requiredToolMisses++;
+					if (
+						requiredToolMisses >= config.maxRequiredToolMisses &&
+						lastTerminalRefusalText
+					) {
+						return finishWithCapturedRefusal({
+							trajectory,
+							iteration,
+							thought: plannerOutput.thought,
+							refusal: lastTerminalRefusalText,
+						});
+					}
 					assertTrajectoryLimit({
 						kind: "required_tool_misses",
 						max: config.maxRequiredToolMisses,
@@ -2171,6 +2210,31 @@ function handleRequiredToolPlannerMiss(params: {
 			toolCalls: stringifyForModel(params.plannerOutput.toolCalls),
 		},
 	});
+}
+
+// Terminates the planner loop with a captured terminal-only refusal text in
+// place of throwing `TrajectoryLimitExceeded({kind: "required_tool_misses"})`.
+// Used when Stage 1 asserted `requiresTool=true` but no exposed tool can
+// fulfill the request: the planner produces honest REPLY refusals across
+// iterations, and surfacing the last one is materially better than the
+// generic apology the caller would otherwise emit.
+function finishWithCapturedRefusal(params: {
+	trajectory: PlannerTrajectory;
+	iteration: number;
+	thought: string | undefined;
+	refusal: string;
+}): { status: "finished"; trajectory: PlannerTrajectory; finalMessage: string | undefined } {
+	params.trajectory.steps.push({
+		iteration: params.iteration,
+		thought: params.thought,
+		terminalMessage: params.refusal,
+		terminalOnly: true,
+	});
+	return {
+		status: "finished",
+		trajectory: params.trajectory,
+		finalMessage: userSafeFinalMessage(params.refusal, params.trajectory),
+	};
 }
 
 function terminalMessageFromToolCalls(


### PR DESCRIPTION
## Summary

When Stage 1 asserts `requiresTool=true` but no exposed tool can fulfill the request (e.g. chat-history search with no `SEARCH_MESSAGES` action), the planner emits valid honest REPLY refusals each iteration. The loop previously discarded every REPLY, hit `maxRequiredToolMisses`, threw `TrajectoryLimitExceeded`, and the caller surfaced a generic apology ("Sorry, something went wrong—please try again") instead of the planner's real answer.

Live trajectory `tj-3bb6dc66be0c16.json` (probe "can you go check the history and tell me what was said about ironpike99") ran 4 iterations at \$0.087, each emitting a valid REPLY refusal, all discarded, user got the generic error.

## Fix

- Add `lastTerminalRefusalText` tracker in the planner loop.
- In both gated branches (planner emits 0 toolCalls + planner emits only-terminal toolCalls), capture the most recent refusal via `getNonEmptyString(plannerOutput.messageToUser)` and `terminalMessageFromToolCalls(...)`.
- Before throwing `TrajectoryLimitExceeded`, if `requiredToolMisses >= config.maxRequiredToolMisses` AND a refusal was captured, return via new helper `finishWithCapturedRefusal` which pushes a terminal step and returns the captured text as \`finalMessage\`.
- Defensive: cap still throws when the planner produces no usable text across all iterations, so the caller can still fall back to the generic apology path when there is genuinely nothing to surface.

## Tests

- \`planner-loop-tools-vs-schema.test.ts\`: rewrote "caps required-tool planner misses" to assert the new contract (returns the captured refusal as finalMessage); added a sibling test that asserts the cap still throws when no usable text is captured.
- \`planner-loop.test.ts\`: added regression covering the REPLY-tool branch specifically (two iterations of REPLY refusals, cap hits on the second, the captured REPLY text becomes the final message).

## Test plan

- [x] Local unit tests pass (45/45 across both planner-loop test files)
- [x] Full runtime suite passes (689/689, 2 skip, 0 fail)
- [x] Live verification on milady deployment: probe shapes that previously hit "Sorry, something went wrong" now return the planner's honest refusal text

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a production regression where the planner loop, when `requireNonTerminalToolCall=true` but no tool can fulfill the request, discarded honest REPLY refusals every iteration, hit `maxRequiredToolMisses`, threw `TrajectoryLimitExceeded`, and the caller surfaced a generic apology. The fix captures the most recent non-empty refusal text across gated iterations and returns it via a new `finishWithCapturedRefusal` helper instead of throwing when the limit is reached.

- **`planner-loop.ts`**: Adds `lastTerminalRefusalText` to track the most recent refusal across gated iterations; inserts `>= max && text` early-return checks in both the zero-toolCalls and all-terminal-toolCalls gated branches; introduces `finishWithCapturedRefusal` which pushes a terminal step and returns `finalMessage` via `userSafeFinalMessage`.
- **Tests**: Rewrites the existing \"caps required-tool planner misses\" test for the new return-instead-of-throw contract; adds a sibling test asserting the cap still throws when no text is captured; and adds a regression in `planner-loop.test.ts` covering the REPLY-tool branch through two capture-and-cap iterations.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the gated requireNonTerminalToolCall miss path and the new early-return is only reachable when refusal text has actually been captured.

The fix is well-targeted: it only alters behaviour inside the already-gated requireNonTerminalToolCall && !hasExecutedNonTerminalTool branches and the new helper's mutation to trajectory.steps mirrors what every other terminal path does. All three changed files include focused unit tests that exercise both the happy path (captured refusal returned) and the defensive path (cap still throws when no text). No existing test assertions were silently deleted — the old 'caps required-tool planner misses' test was explicitly rewritten and its contract documented. The asymmetry between the >= early-return threshold and the > assertTrajectoryLimit threshold is tested and benign.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/planner-loop.ts | Adds lastTerminalRefusalText tracker and finishWithCapturedRefusal helper to surface honest refusals instead of throwing TrajectoryLimitExceeded; logic is sound but the new helper has a subtle off-by-one compared to assertTrajectoryLimit (returns at >= max vs throws at > max) which is tested but may surprise future maintainers. |
| packages/core/src/runtime/__tests__/planner-loop-tools-vs-schema.test.ts | Rewrites the 'caps required-tool planner misses' test for the new return-instead-of-throw contract and adds a sibling test that ensures the cap still throws when no refusal text is captured; coverage is thorough. |
| packages/core/src/runtime/__tests__/planner-loop.test.ts | Adds a regression test for the REPLY-tool branch (two iterations of REPLY refusals, cap hits on the second, captured text becomes the final message); correctly exercises the terminalMessageFromToolCalls path and verifies exact call counts. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Planner iteration] --> B{toolCalls.length == 0?}
    B -- Yes --> C{requireNonTerminalToolCall && !hasExecutedNonTerminalTool?}
    B -- No --> D{all toolCalls terminal?}
    D -- Yes --> E{requireNonTerminalToolCall && !hasExecutedNonTerminalTool?}
    D -- No --> F[Execute non-terminal tool calls]
    C -- Yes --> G[Capture messageToUser as refusalCandidate
update lastTerminalRefusalText if non-empty
requiredToolMisses++]
    E -- Yes --> H[Capture terminalMessageFromToolCalls
update lastTerminalRefusalText if non-empty
requiredToolMisses++]
    G --> I{misses >= max && lastTerminalRefusalText?}
    H --> I
    I -- Yes --> J[finishWithCapturedRefusal
push step, return finalMessage]
    I -- No --> K[assertTrajectoryLimit
throws if misses > max]
    K --> L[handleRequiredToolPlannerMiss
add retry instruction to context]
    L --> M[continue]
    C -- No --> N[Normal terminal path
appendTerminalPlannerOutputEvent
return or evaluate]
    E -- No --> O[Normal terminal tool path
run evaluator, return]
```

<sub>Reviews (2): Last reviewed commit: ["fix(core/planner-loop): surface captured..."](https://github.com/elizaos/eliza/commit/fc2526377db8101ee85404e1dbd0408273c48f2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33719034)</sub>

<!-- /greptile_comment -->