### PR TITLE
fix(core/services/message): allow recall questions to read from visible prior_message context

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -1916,6 +1916,39 @@ android smoke model works`,
 		});
 	});
 
+	it("current_turn_boundary allows recall questions to read from visible prior_message blocks", async () => {
+		// Live regression: on 2026-05-25 the bot replied "I'm not able to
+		// search the Discord channel history directly — there's no tool for
+		// that in this environment" when asked about a token that WAS in
+		// prior_message context (trajectory tj-b1ee98c2593f97.json). Root
+		// cause: the current_turn_boundary rule explicitly forbade merging
+		// prior_message context into the current task, with no exception for
+		// recall questions. The fix carves out an exception for
+		// who-mentioned-X / did-anyone-bring-up-Y / what-was-said-about-Z
+		// queries, bounded to what is literally visible in the rendered
+		// prior_message blocks (so the model cannot fabricate a search
+		// across messages it can't see).
+		const sourceText = await readFile(
+			join(import.meta.dirname, "..", "services", "message.ts"),
+			"utf-8",
+		);
+		expect(sourceText).toContain(
+			"Exception for visible-context recall: when the final message asks a recall question",
+		);
+		expect(sourceText).toContain(
+			"who mentioned X, did anyone bring up Y, what did I say about Z, what was the last message",
+		);
+		expect(sourceText).toContain(
+			"you may scan the prior_message blocks above and answer from what is literally visible there",
+		);
+		expect(sourceText).toContain(
+			"If the asked-about token does not appear in any visible prior_message block, say so plainly",
+		);
+		expect(sourceText).toContain(
+			"there is no separate chat-history search tool",
+		);
+	});
+
 	it("renders platform reply references as current-turn context", async () => {
 		const runtime = makeRuntime([
 			stage1Response({

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2446,7 +2446,7 @@ async function createV5MessageContextObject(args: {
 		source: "message-service",
 		stable: false,
 		content:
-			"current_turn_boundary: The prior_message blocks above are context only. If a reply_reference block follows, it is the platform message that the final message:user is replying to; use it only to resolve references such as this/that/it. Execute and answer only the final message:user below. Do not merge separate prior requests into the current task unless the final message explicitly references them.",
+			"current_turn_boundary: The prior_message blocks above are context only. If a reply_reference block follows, it is the platform message that the final message:user is replying to; use it only to resolve references such as this/that/it. Execute and answer only the final message:user below. Do not merge separate prior requests into the current task unless the final message explicitly references them. Exception for visible-context recall: when the final message asks a recall question about what was said in this conversation (who mentioned X, did anyone bring up Y, what did I say about Z, what was the last message), you may scan the prior_message blocks above and answer from what is literally visible there. If the asked-about token does not appear in any visible prior_message block, say so plainly (\"I don't see X in the recent messages I can see\") rather than claiming you searched beyond the visible window or fabricating an action — the prior_message blocks are the only window you have, and there is no separate chat-history search tool.",
 	});
 
 	const replyReferenceEvent = replyReferenceEventForContext(args.message);


### PR DESCRIPTION
## Summary

The \`current_turn_boundary\` instruction told the model that prior_message blocks were "context only" and to "not merge separate prior requests into the current task unless the final message explicitly references them." This blocked all recall questions ("did anyone bring up X", "what did I say about Y", "who mentioned Z") — even when the asked-about token was literally visible in a rendered prior_message block — and left the model with no tool to fall back on, since there is no SEARCH_MESSAGES action exposed.

Live trajectory \`tj-b1ee98c2593f97.json\` showed the bot replying *"I'm not able to search the Discord channel history directly - there's no tool for that in this environment"* when asked about a token that **was** in visible context. The model followed the rule correctly; the rule was the bug.

## Fix

Append one sentence carving out an exception for recall questions, strictly bounded to "what is literally visible" in the prior_message blocks. If the asked-about token is not visible, the model is instructed to say so plainly (*"I don't see X in the recent messages I can see"*) rather than fabricate an action — keeping it aligned with the existing phantom-action-claim rule.

## Live verification (2026-05-25)

13 probes, all simple-path, iters=0, \$0.0038-\$0.0042 each:
- *"my dog's name is zephyrloom" → "what's my dog's name"* → "Your dog's name is Zephyrloom." (uses visible context)
- *"did anyone ever mention obsidianvale"* → "I don't see any mention of obsidianvale in the recent messages I can view." (honest refusal when not visible)
- *"please go through the whole channel and find every mention of saltspire"* → "I don't see any mention of 'saltspire' in the recent messages I can see." (no phantom claim of channel-wide search)
- *"list every name or token i mentioned to you recently"* → returned actual visible tokens

## Tests

Regression test in \`message-runtime-stage1.test.ts\` pins each clause of the new exception so a future edit can't quietly remove the carve-out.

## Test plan

- [x] stage1 tests pass (52/52)
- [x] Full runtime suite passes (689/689)
- [x] Live verification: 13 probes with prep+recall pairs all return correct grounded answers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR appends a single exception sentence to the `current_turn_boundary` system instruction in `message.ts`, carving out a scoped allowance for recall questions to read from visible `prior_message` blocks, and adds a regression test that pins the new clause via raw-source substring assertions.

- **`packages/core/src/services/message.ts`**: One-line prompt-instruction change that adds the recall-question exception, bounded to "what is literally visible" in prior_message blocks and with an explicit fallback for missing tokens.
- **`packages/core/src/__tests__/message-runtime-stage1.test.ts`**: New `it` block that reads `message.ts` as raw UTF-8 and asserts five exact substring literals are present.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single prompt-instruction string extension with a well-bounded recall exception and an explicit honest-refusal fallback.

The only code touched is the current_turn_boundary constant string in message.ts and a new substring-assertion test. No logic paths, APIs, or data flows are modified. The exception clause is bounded to what is literally visible in prior_message blocks and includes an explicit fallback, matching the intent of the existing phantom-action-claim rule. Live probes in the PR description confirm the fix behaves as intended.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/services/message.ts | Single-line prompt-instruction change appending a scoped recall exception to current_turn_boundary; no logic or control-flow changes, low regression risk. |
| packages/core/src/__tests__/message-runtime-stage1.test.ts | New substring-based snapshot test reads message.ts as raw UTF-8 to pin the recall exception text; functional but brittle to formatting changes. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Final message:user arrives] --> B{Recall question?\ne.g. who mentioned X}
    B -- No --> C[Execute only the final message\nIgnore prior_message as task input]
    B -- Yes --> D[Scan prior_message blocks\nfor the asked-about token]
    D --> E{Token visible in\nprior_message blocks?}
    E -- Yes --> F[Answer from literally visible context]
    E -- No --> G[Reply plainly: I don't see X\nin the recent messages I can see]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/src/__tests__/message-runtime-stage1.test.ts`, line 21-39 ([link](https://github.com/elizaos/eliza/blob/b4577e03559c074e41bae8d9af8159a0545275d8/packages/core/src/__tests__/message-runtime-stage1.test.ts#L21-L39)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Source-text snapshot test is brittle**

   The test reads `message.ts` as raw UTF-8 and asserts that exact string literals are present. Any reformatting of the `current_turn_boundary` string constant — whitespace normalisation, quote style change, line-break insertion, or a tooling-driven auto-wrap — will silently break all five assertions even though the runtime behaviour is unchanged. The same invariant is far more durable expressed as a unit test over `createV5MessageContextObject` (or whatever function emits the `current_turn_boundary` event) where the actual `content` field can be inspected on the parsed output.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(core/services/message): allow recall..."](https://github.com/elizaos/eliza/commit/61cafc6a0def0fef658b32cb27af985d156e3cf2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33719133)</sub>

<!-- /greptile_comment -->