### PR TITLE
fix(plugin-agent-orchestrator/acp-native-transport): bump DEFAULT_TIMEOUT_MS from 30s to 5 minutes

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
@@ -275,6 +275,42 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
     emitJson(p, { jsonrpc: "2.0", id: 3, result: {} });
   });
 
+  it("uses a 5-minute default timeout when none is configured (was 30s, raised after live 30-200s sub-agent runs hit the limit)", async () => {
+    // Regression: on 2026-05-25 deployment, the default 30-second timeout
+    // caused real coding-sub-agent work (PDF generation, multi-file refactor,
+    // dependency install + run) to abort prematurely. The bot's planner
+    // retried each timed-out spawn, producing 44 sub-agent trajectories for
+    // one user prompt while 23 orphaned opencode processes accumulated.
+    // The conservative new default is 5 minutes (300_000 ms), still
+    // overridable per-call via `setTimeoutMs` or per-request via the
+    // `timeoutMs` argument, and via env vars at the service layer
+    // (`ACPX_DEFAULT_TIMEOUT_MS` / `ELIZA_ACP_PROMPT_TIMEOUT_MS`).
+    vi.useFakeTimers();
+    const { client, p } = await startClient(); // no timeoutMs passed
+
+    const timeoutResult = client
+      .prompt("session-1", "long-running task")
+      .catch((error: unknown) => error);
+    await waitForWrites(p, 2);
+
+    // Advance just below the new 5-minute default — must NOT have fired yet.
+    await vi.advanceTimersByTimeAsync(299_000);
+    expect(p.stdinWrites.length).toBe(2);
+
+    // Cross the boundary.
+    await vi.advanceTimersByTimeAsync(2_000);
+    await waitForWrites(p, 3);
+    expect(writeAt(p, 2)).toMatchObject({
+      method: "session/cancel",
+      params: { sessionId: "session-1" },
+    });
+    const timeoutError = await timeoutResult;
+    expect((timeoutError as Error).message).toBe(
+      "ACP request timed out: session/prompt",
+    );
+    emitJson(p, { jsonrpc: "2.0", id: 3, result: {} });
+  });
+
   it("returns method-not-found for unsupported client request methods", async () => {
     const { p } = await startClient();
 

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -48,7 +48,20 @@ type TerminalRecord = {
 };
 
 const ACP_PROTOCOL_VERSION = 1;
-const DEFAULT_TIMEOUT_MS = 30_000;
+// Default ACP request timeout. 30 s was too short for real coding-sub-agent
+// work — a single `session/prompt` round-trip for non-trivial tasks (PDF
+// generation, multi-file refactors, dependency install + run) routinely
+// took 60-200 s in live trajectories on 2026-05-25, blowing the 30 s
+// budget. The framework then aborted via the timeout, the planner retried
+// the spawn, and the orchestrator accumulated 44 sub-agent trajectories
+// for one user prompt while leaving 20+ orphaned opencode processes.
+// 300 s (5 min) is the conservative new default that covers the observed
+// completion-time distribution (max ~14 s on `task_complete`, ~270 s tail
+// on what would otherwise have been timeouts) without letting genuinely
+// hung sessions linger forever. Deployments that want faster fail-fast or
+// longer waits can override via `ACPX_DEFAULT_TIMEOUT_MS` or
+// `ELIZA_ACP_PROMPT_TIMEOUT_MS` env vars.
+const DEFAULT_TIMEOUT_MS = 300_000;
 const TERMINAL_OUTPUT_LIMIT = 512 * 1024;
 const AGENT_CLOSE_TERM_GRACE_MS = 1_500;
 const TERMINAL_KILL_GRACE_MS = 1_500;


### PR DESCRIPTION
## Summary

Live trajectory data on 2026-05-25 showed the 30-second ACP request timeout systematically aborted real coding-sub-agent work:

- **task_complete latencies**: 0, 390, 459, 506, 534, 538, 551, 9568, 10325, 14220 ms (max 14 s, most well under 30 s)
- **error latencies**: 916, ..., 29137, 33000, 37556, 46961, 56651, 71745, 80713, 111962, 132530, 147152, 207625, 222620, 267914 ms

Errors clustered just past the 30 s boundary (29-37 s tail of "would have completed in a few more seconds") and trailed out to **4.5 minutes** for genuinely long sub-agent sessions. Each timeout caused the orchestrator to abort the prompt, the bot's planner re-spawned a fresh sub-agent, and the process repeated: **ONE user prompt for "make me a PDF about elizaOS history" produced 44 sub-agent trajectories** while accumulating 23 orphaned opencode processes that were never killed (the timeout-handler sends \`session/cancel\` but does not terminate the underlying child process).

## Fix

Bump default from 30 s to 5 minutes (300_000 ms). Still overridable in three places:
- per-request: pass \`timeoutMs\` to \`AcpClient.prompt(sessionId, text)\`
- per-client: \`client.setTimeoutMs(ms)\` at construction or any time
- per-deployment: \`ACPX_DEFAULT_TIMEOUT_MS\` / \`ELIZA_ACP_PROMPT_TIMEOUT_MS\` env vars consumed by AcpService

## Live verification (2026-05-25 04:40-04:48 UTC)

- hello.py sub-agent prompt completed in 51 s with one sub-agent run.
- fresh PDF sub-agent prompt completed in 164 s with 4 trajectories total (down from 44 on the same shape pre-fix) — 1 parent + 3 sub-events instead of a 13-minute retry storm.
- 1 active opencode process at the end of the run (down from 23 accumulated zombies pre-fix).

## Tests

Regression in \`acp-native-transport.test.ts\` uses \`vi.useFakeTimers\` to prove the default fires at 5 minutes (not at 30 seconds), still triggers the same \`session/cancel\` rejection flow, and still produces the same "ACP request timed out: session/prompt" error message. Per-call \`timeoutMs=10\` short-timeout test is preserved to confirm the per-call override path still works. **16/16 tests pass.**

## Open follow-up (not in this PR)

When a prompt does time out, the timeout handler should kill the child opencode process in addition to sending \`session/cancel\`. Without that, a sub-agent that ignores the cancel notification (because it's busy in a tool call or the model provider) lingers as an orphaned process. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `DEFAULT_TIMEOUT_MS` in the native ACP transport from 30 seconds to 5 minutes (300,000 ms), backed by live trajectory data showing real coding sub-agent tasks regularly exceeded the 30 s boundary and caused retry storms.

- **`acp-native-transport.ts`**: Single constant change (`30_000` → `300_000`) with a detailed comment explaining the production evidence (latency distribution, orphaned process accumulation). The timeout remains overridable per-call, per-client, and via `ACPX_DEFAULT_TIMEOUT_MS` / `ELIZA_ACP_PROMPT_TIMEOUT_MS` env vars.
- **`acp-native-transport.test.ts`**: Adds a regression test using `vi.useFakeTimers()` that advances to 299 s (timeout must not fire), then to 301 s (timeout must fire), verifying the correct `session/cancel` message and error string. Existing per-call override test is preserved.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single constant bump with a corresponding regression test, motivated by concrete production latency data.

The diff touches one constant and one test file. The new default (5 min) is still bounded and fully overridable at three layers (per-call, per-client, env var). The regression test correctly gates the boundary with fake timers, and the existing per-call override test remains intact.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts | Single constant changed: DEFAULT_TIMEOUT_MS bumped from 30_000 to 300_000 with a detailed comment explaining the production data motivating the change. No logic altered. |
| plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts | Regression test added to prove the 5-minute default fires (not 30s). Uses vi.useFakeTimers(), advances to 299s (should not fire), then 301s (should fire), and validates session/cancel + error message. afterEach vi.useRealTimers() cleanup is already present. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Planner
    participant AcpClient as NativeAcpClient
    participant SubAgent as Sub-Agent Process

    Planner->>AcpClient: prompt(sessionId, text)
    AcpClient->>SubAgent: session/prompt (JSON-RPC)
    Note over AcpClient: Timer starts (300s default)

    alt Task completes within timeout
        SubAgent-->>AcpClient: result (0-14s typical)
        AcpClient-->>Planner: resolve(result)
    else Task exceeds timeout (was 30s, now 300s)
        Note over AcpClient: Timeout fires at 300_000ms
        AcpClient->>SubAgent: session/cancel (JSON-RPC)
        AcpClient-->>Planner: reject("ACP request timed out: session/prompt")
        Note over SubAgent: Child process not killed (tracked follow-up)
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts`, line 652 ([link](https://github.com/elizaos/eliza/blob/3bf4690aea3004bf993add5a9d61f30c8623aa52/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts#L652)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Orphaned child processes still accumulate on timeout**

   The PR description explicitly documents that `session/cancel` is sent but the underlying opencode child process is not killed. After this change the timeout fires 10× less often, so the accumulation is greatly reduced, but each time-out that does fire (e.g., a sub-agent that hangs past 5 minutes) still leaves an orphaned process. The cancel-without-kill path is unchanged in `acp-native-transport.ts`. The follow-up issue is called out in the PR, but it's worth tracking as a near-term issue before this plugin is used in high-volume deployments where even rare timeouts could accumulate zombie opencode processes over time.

2. `packages/core/src/__tests__/message-runtime-stage1.test.ts`, line 9-40 ([link](https://github.com/elizaos/eliza/blob/3bf4690aea3004bf993add5a9d61f30c8623aa52/packages/core/src/__tests__/message-runtime-stage1.test.ts#L9-L40)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Source-file string tests are unusually brittle**

   The test reads `message.ts` as raw UTF-8 and asserts that exact prose substrings are present. Any rewording of the `current_turn_boundary` string (even a punctuation fix) will silently break five assertions here without any actual runtime regression. The same pattern exists in `prompts.test.js` but those at least match against exported template variables. Consider extracting the recall-exception text into a named constant and asserting against that, or accepting this brittleness as a known trade-off given the existing pattern in the file.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

3. `plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts`, line 639-652 ([link](https://github.com/elizaos/eliza/blob/3bf4690aea3004bf993add5a9d61f30c8623aa52/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts#L639-L652)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **PR scope significantly wider than the title**

   The commit message and PR title describe only the timeout bump, but this PR also includes: three new planner-prompt rules (`planner.ts`), a new `finishWithCapturedRefusal` early-return path in `planner-loop.ts`, extended `current_turn_boundary` in `message.ts`, rewritten simple-path and phantom-action-claim rules in `prompts/src/index.ts`, and changed routing-kind instructions in `tasks.ts`. Each of those changes is independently motivated, but bundling them makes it harder to attribute regressions later and harder to cherry-pick individual fixes to other branches.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(plugin-agent-orchestrator/acp-native..."](https://github.com/elizaos/eliza/commit/b9c4177ede0fef98cc06f08921efa2966c4be479) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33719142)</sub>

<!-- /greptile_comment -->