### PR TITLE
fix(core/runtime/evaluator): strip trailing JSON envelope from recovered user-facing prose

### DIFF
--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -500,14 +500,63 @@ function recoverEvaluatorTextOutput(
 	if (!hasSuccessfulToolResult(trajectory)) return output;
 	if (!looksLikeUserFacingAnswer(text)) return output;
 
+	const userFacing = stripTrailingEvaluatorEnvelope(text);
+
 	return {
 		success: true,
 		decision: "FINISH",
 		thought:
 			"Recovered user-facing evaluator prose after a successful tool result.",
-		messageToUser: text,
+		messageToUser: userFacing,
 		raw: { recoverySource: "prose_after_successful_tool" },
 	};
+}
+
+// When the evaluator model emits user-facing prose followed by the
+// structured envelope (e.g. shell output ... then `{"success":true,
+// "decision":"FINISH","thought":"..."}`) the strict JSON parser
+// rejects the whole response. The recovery path above then uses the
+// raw text as the user reply — and without this strip, the JSON
+// envelope leaks into Discord.
+//
+// Live regression on 2026-05-25 (trajectory tj-b224d87039960b.json):
+// user asked "use shell to show disk space" — the evaluator model
+// emitted the actual `df -h` table prose immediately followed by a
+// JSON object `{"success":true,"decision":"FINISH","thought":...}`
+// and that object was published verbatim to the user's Discord
+// channel underneath the table.
+//
+// The strip is conservative: it only removes a trailing balanced
+// `{...}` block whose body contains at least one evaluator-shaped
+// key (`success`/`decision`/`thought`/`messageToUser`/`nextTool`/...)
+// so a legitimate user-asked-for trailing JSON (e.g. a code answer
+// that ends with a JSON example) is left untouched.
+function stripTrailingEvaluatorEnvelope(text: string): string {
+	const trimmed = text.trimEnd();
+	if (!trimmed.endsWith("}")) return text;
+	let depth = 0;
+	let start = -1;
+	for (let i = trimmed.length - 1; i >= 0; i--) {
+		const c = trimmed[i];
+		if (c === "}") depth++;
+		else if (c === "{") {
+			depth--;
+			if (depth === 0) {
+				start = i;
+				break;
+			}
+		}
+	}
+	if (start < 0) return text;
+	const candidate = trimmed.slice(start);
+	if (
+		!/"\s*(?:success|decision|thought|messageToUser|nextTool|nextRecommendedTool|copyToClipboard|recommendedToolCallId|route)"\s*:/.test(
+			candidate,
+		)
+	) {
+		return text;
+	}
+	return trimmed.slice(0, start).trimEnd();
 }
 
 function rawText(raw: string | { text?: string; object?: unknown }): string {


### PR DESCRIPTION
## Summary

Live regression on 2026-05-25 05:53-05:55 UTC. Probe "use shell to show disk space" returned the real \`df -h\` output to the user **PLUS** the structured evaluator envelope concatenated underneath:

\`\`\`
Filesystem      Size  Used Avail Use% Mounted on
tmpfs           3.2G  2.4M  3.2G   1% /run
/dev/sda1       387G  251G  137G  65% /
[...full df output...]

{
  "success": true,
  "decision": "FINISH",
  "thought": "Displayed disk usage using df -h and provided the output as the response."
}
\`\`\`

**Root cause**: the evaluator model emits prose-then-JSON when responding under structured-output mode after a successful tool result. Strict JSON parsing rejects the response, the strict path returns a parse error, and \`recoverEvaluatorTextOutput\` then takes the WHOLE raw response (including the trailing envelope) as \`messageToUser\`, which is published verbatim to Discord. Trajectory \`tj-b224d87039960b.json\`.

## Fix

\`stripTrailingEvaluatorEnvelope\` walks backwards from the final \`}\` to its matching \`{\`, and if the resulting object contains any evaluator-shaped key (\`success\`/\`decision\`/\`thought\`/\`messageToUser\`/\`nextTool\`/\`copyToClipboard\`/\`recommendedToolCallId\`/\`route\`), strips it from the recovered text before assignment. **Conservative on purpose**: trailing JSON without those keys (e.g. a user-asked-for code example that ends with a JSON literal) is left untouched.

## Live verification (2026-05-25 05:59-06:00 UTC)

Same probe "use shell to show disk space" returned a clean human-readable bullet list, no envelope trailer, iters=1 tools=1 single REPLY.

## Test plan

- [x] 689/689 core/runtime tests pass, including the existing 16 evaluator tests covering the recovery path
- [x] The JSON-strip is a pre-assignment transform that does not change any of the existing branch conditions
- [x] Live verification: shell + evaluator flows now post clean prose-only reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a live regression where the evaluator model's raw structured-output envelope (`{"success":true,"decision":"FINISH","thought":"…"}`) was being appended verbatim to user-facing Discord replies. The root cause is that when the model emits prose then JSON, strict parsing fails and the whole raw response—including the envelope—was used as `messageToUser`.

- Adds `stripTrailingEvaluatorEnvelope`, a conservative backward brace-walker that removes a trailing `{…}` block only when it contains at least one evaluator-specific key (`success`, `decision`, `thought`, `messageToUser`, `nextTool`, `copyToClipboard`, `recommendedToolCallId`, `route`), leaving user-requested JSON examples untouched.
- The strip is applied as a pre-assignment transform inside `recoverEvaluatorTextOutput`, so it does not affect any of the existing branch conditions or recovery logic.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the target regression; the strip is non-destructive by default, but a few discriminator keys are generic enough to silently trim legitimate trailing JSON in edge cases.

The change is narrow and well-guarded — it only activates when strict JSON parsing already failed, a successful tool result exists, and the text passes `looksLikeUserFacingAnswer`. The brace-walker's string-blindness means responses whose thought value contains an unbalanced `}` silently fall through without stripping, which is a safe failure mode. The main residual concern is that `success`, `route`, and `decision` are common API-response field names that could cause a legitimate inline JSON example to be silently dropped.

packages/core/src/runtime/evaluator.ts — specifically the discriminator key list in `stripTrailingEvaluatorEnvelope`

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/evaluator.ts | Adds `stripTrailingEvaluatorEnvelope` to remove the evaluator JSON envelope leaked into user-facing prose during the recovery path; brace-walker is not string-aware (noted in prior review) and some discriminator keys (`success`, `route`, `decision`) are common enough to cause rare false-positive strips on legitimate inline JSON examples |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runEvaluator: strict JSON parse] -->|parse succeeds| B[Normal EvaluatorOutput]
    A -->|parse fails| C[recoverEvaluatorTextOutput]
    C -->|containsToolAttemptObject| D[Return CONTINUE / replan]
    C -->|no successful tool result| E[Return parse-error output unchanged]
    C -->|not user-facing answer| E
    C -->|passes all guards| F[stripTrailingEvaluatorEnvelope]
    F -->|text does not end with brace| G[Return text unchanged]
    F -->|brace-walk finds no outer block| G
    F -->|trailing block has no evaluator key| G
    F -->|trailing block contains evaluator key| H[Trim envelope, return prose only]
    H --> I[messageToUser = stripped prose]
    G --> J[messageToUser = full recovered text]
    I --> K[Return FINISH EvaluatorOutput]
    J --> K
```

<sub>Reviews (2): Last reviewed commit: ["fix(core/runtime/evaluator): strip trail..."](https://github.com/elizaos/eliza/commit/04ba6221317726b26fe77d6e904bd35a49e37e76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33719193)</sub>

<!-- /greptile_comment -->