### PR TITLE
fix(core/message-handler): promote to planning when candidateActions hints a tool, even if Stage 1 self-contradicts with simple=true

### DIFF
--- a/packages/core/src/runtime/__tests__/message-handler.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler.test.ts
@@ -69,6 +69,59 @@ describe("v5 message handler routing", () => {
 		}
 	});
 
+	it("plans against 'general' when candidateActions has tools, even if Stage 1 routed simple-path with requiresTool=false", () => {
+		// Live regression on 2026-05-25 (trajectories tj-c227b5bbff288a and
+		// tj-d5e298b2542aa0). Probes "find files in /etc that contain the word
+		// hostname" and "what files are in /tmp right now" produced the
+		// self-contradictory envelope:
+		//   { contexts:["simple"], requiresTool:false, candidateActions:["BASH"],
+		//     replyText:"On it." }
+		// The model claimed simple-path (so no planner ran) while ALSO naming
+		// a specific exposed tool that could fulfill the request. The user saw
+		// only "On it." and nothing else because no planner iteration ever
+		// executed BASH. Resolve the contradiction in favor of running the
+		// planner — the candidateActions hint is a concrete reference to an
+		// exposed tool and outranks the simple-path flag.
+		const output = {
+			processMessage: "RESPOND" as const,
+			thought: "Tool would help here.",
+			plan: {
+				contexts: ["simple"],
+				requiresTool: false,
+				candidateActions: ["BASH"],
+				reply: "On it.",
+			},
+		};
+
+		const route = routeMessageHandlerOutput(output);
+		expect(route.type).toBe("planning_needed");
+		if (route.type === "planning_needed") {
+			expect(route.contexts).toEqual(["general"]);
+		}
+	});
+
+	it("keeps the simple-path final-reply route when candidateActions is empty and requiresTool is false", () => {
+		// Defensive: the candidateActions-based promotion above must not
+		// accidentally drag legitimate simple-path replies into the planner.
+		// An empty/missing candidateActions field is the common case for
+		// every chat, math, recall, joke, and definition probe.
+		const output = {
+			processMessage: "RESPOND" as const,
+			thought: "Direct chat answer.",
+			plan: {
+				contexts: ["simple"],
+				requiresTool: false,
+				reply: "8 times 9 is 72.",
+			},
+		};
+
+		const route = routeMessageHandlerOutput(output);
+		expect(route.type).toBe("final_reply");
+		if (route.type === "final_reply") {
+			expect(route.reply).toBe("8 times 9 is 72.");
+		}
+	});
+
 	it("does not parse retired requiresTool from the model envelope", () => {
 		const parsed = parseMessageHandlerOutput(
 			JSON.stringify({

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -193,6 +193,8 @@ export function routeMessageHandlerOutput(
 
 	const allContexts = [...output.plan.contexts];
 	const requiresTool = output.plan.requiresTool === true;
+	const candidateActions = output.plan.candidateActions ?? [];
+	const hasCandidateActions = candidateActions.length > 0;
 
 	// `simple` is the shortcut marker. If it is the only context (or contexts
 	// is empty), Stage 1 owns the reply and we never enter the planner — unless
@@ -202,7 +204,23 @@ export function routeMessageHandlerOutput(
 		(context) => context !== SIMPLE_CONTEXT_ID,
 	);
 
-	if (requiresTool && nonSimpleContexts.length === 0) {
+	// Resolve the self-contradiction shape `simple=true + requiresTool=false +
+	// candidateActions=[BASH/SHELL/TASKS/...]` by promoting to planning. The
+	// model is signaling both "no tool needed" (simple-path) AND "this tool
+	// would fulfill the request" (candidateActions hint) — those cannot both
+	// be true. The candidateActions hint is the more reliable signal because
+	// it names a specific exposed tool; honor it and run the planner.
+	//
+	// Live regression on 2026-05-25 (trajectories tj-c227b5bbff288a,
+	// tj-d5e298b2542aa0): probes "find files in /etc that contain the word
+	// hostname" and "what files are in /tmp right now" produced
+	// `{simple=true, requiresTool=false, candidateActions=["BASH"],
+	// replyText:"On it."}` — the user saw the bare-ack and nothing else
+	// because the planner was never invoked. The Stage-1 prompt rule that
+	// bans bare-ack on simple-path is a soft contract the model occasionally
+	// violates; this structural promotion catches the violation at the
+	// routing layer.
+	if ((requiresTool || hasCandidateActions) && nonSimpleContexts.length === 0) {
 		return {
 			type: "planning_needed",
 			output,


### PR DESCRIPTION
## Summary

Live regression on 2026-05-25. Stage 1 produced the self-contradictory envelope:

\`\`\`
{
  "contexts": ["simple"],
  "requiresTool": false,
  "candidateActions": ["BASH"],
  "replyText": "On it."
}
\`\`\`

for prompts like "find files in /etc that contain the word hostname" and "what files are in /tmp right now". The model claimed simple-path (no planner needed) while ALSO naming a specific exposed tool (BASH) that would fulfill the request. **Both flags cannot be true at the same time** — candidateActions is a concrete reference to a tool, not a suggestion. \`routeMessageHandlerOutput\` honored the simple-path flag, delivered "On it." as the final reply, and the user got a bare ack with no follow-up — the planner never ran.

The Stage-1 prompt rule that bans bare-ack on simple-path is a soft contract the model occasionally violates — we can't make a prompt rule hard. This commit adds a **structural backup at the routing layer**: when \`candidateActions\` names at least one tool AND no non-simple context is selected, promote to \`planning_needed\` with \`contexts=["general"]\` the same way \`requiresTool=true\` already does. The planner then runs the tool, the user gets the real result.

This is the routing analogue of the parser-side \`planningPath\` heuristic that already lives in \`parseMessageHandlerOutput\` (\`packages/core/src/runtime/message-handler.ts:82-83\`) where candidateActions already drives the "blank out refusal text on planning path" decision. The two places now agree.

## Live verification (2026-05-25 06:38-06:39 UTC)

- "what files are in /tmp right now" → bot listed actual files in /tmp (was "On it." pre-fix). Stage 1 envelope: \`simple=true requiresTool=false candidates=["BASH"] reply="On it."\` → the routing layer promoted to planning → SHELL ran → real list delivered.
- "find files in /etc that contain the word hostname" → bot returned the actual grep output. Routing correct: SHELL ran grep, found files.

## Tests

- "plans against 'general' when candidateActions has tools, even if Stage 1 routed simple-path with requiresTool=false" — the contradiction case.
- "keeps the simple-path final-reply route when candidateActions is empty and requiresTool is false" — defensive: the common simple-path case (chat, math, recall) must NOT get dragged into planning.

**17/17 message-handler tests pass; 689/689 runtime tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a live regression where Stage 1's message-handler could emit a self-contradictory envelope (`contexts:["simple"], requiresTool:false, candidateActions:["BASH"]`), causing the routing layer to honor the simple-path flag and deliver a bare "On it." acknowledgement instead of invoking the planner to run the tool.

- **`routeMessageHandlerOutput`** now promotes to `planning_needed` with `contexts:["general"]` when `candidateActions` is non-empty and no non-simple context is present, even when `requiresTool` is false — making routing consistent with the existing `parseMessageHandlerOutput` heuristic at line 82–83 that already treated a non-empty `candidateActions` as a planning-path signal.
- **Two targeted tests** are added: one covers the contradiction case (simple+no tool flag+candidate action), and one is defensive (empty candidateActions must not drag simple-path replies into the planner).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted two-line guard at the routing layer with no effect on non-contradictory envelopes.

The routing fix is minimal, well-bounded, and consistent with the existing planningPath heuristic already present in parseMessageHandlerOutput. All edge cases route correctly, and the defensive test confirms simple-path replies with no candidateActions are unaffected.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/message-handler.ts | Core routing fix: adds hasCandidateActions guard to the planning_needed promotion condition, aligning routeMessageHandlerOutput with parseMessageHandlerOutput's existing planningPath heuristic. |
| packages/core/src/runtime/__tests__/message-handler.test.ts | Adds two regression tests: one targeting the contradiction envelope (simple+candidateActions), one defensive ensuring empty candidateActions leaves simple-path routing intact. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[routeMessageHandlerOutput] --> B{processMessage?}
    B -- IGNORE --> C[return ignored]
    B -- STOP --> D[return stopped]
    B -- RESPOND --> E[compute nonSimpleContexts]
    E --> F{requiresTool OR hasCandidateActions?}
    F -- YES --> G{nonSimpleContexts.length === 0?}
    G -- YES --> H[return planning_needed contexts=general]
    G -- NO --> I[fall-through]
    F -- NO --> I
    I --> J{nonSimpleContexts.length === 0?}
    J -- YES --> K[return final_reply]
    J -- NO --> L[return planning_needed contexts=nonSimpleContexts]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts`, line 539-556 ([link](https://github.com/elizaos/eliza/blob/60f1d87934f835d0bff3d6e8211557b7a88ace8c/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts#L539-L556)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Loopback URL redaction bypassed for `task_complete` events**

   `redactLoopbackUrls(baseText)` is stored in `text` on line 539, but for every `task_complete` event the very next block overwrites `text` with `verified.text`, which is derived from the original `baseText` passed to `annotateUnverifiedUrls`. Any loopback URL that survived URL verification will reappear in the final Discord post — exactly the regression scenario described in the PR (the `http://127.0.0.1:6900/apps/` leak). The redaction only takes effect for non-`task_complete` events (`error`, `blocked`, `QUESTION_FOR_TASK_CREATOR`, `AGENT_COORDINATION`), which is the minor code path.

   To fix, apply `redactLoopbackUrls` to `verified.text` after the verification step, e.g. `text = redactLoopbackUrls(verified.text)`, so the scrub runs on the final outgoing text for all event types.

2. `plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts`, line 938-942 ([link](https://github.com/elizaos/eliza/blob/60f1d87934f835d0bff3d6e8211557b7a88ace8c/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts#L938-L942)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Module-level `g`-flagged regex is stateful across calls**

   `LOOPBACK_URL_PATTERN` is declared at module scope with the `g` flag, so it carries mutable `lastIndex` state. The function correctly resets `lastIndex` to `0` after the `test()` call, but this pattern is fragile: if the function is ever made async (or called in a test that throws between `test()` and `lastIndex = 0`), state can bleed into the next invocation. A simpler alternative is to use `new RegExp(...)` inside the function body, or source a separate non-`g` regex for the early-return `test()` check.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(core/message-handler): promote to pl..."](https://github.com/elizaos/eliza/commit/4e0d7a3eab2b5a4e0754ed1185dec8540939bbec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33719199)</sub>

<!-- /greptile_comment -->