### PR TITLE
fix(os): route docs launcher file:// URIs around Tor Browser flatpak sandbox

### DIFF
--- a/packages/os/linux/tails/config/chroot_local-includes/usr/local/bin/tails-documentation
+++ b/packages/os/linux/tails/config/chroot_local-includes/usr/local/bin/tails-documentation
@@ -88,6 +88,26 @@ def main():
         print(uri)
         return
 
+    # file:// URIs go to the elizaOS WebKit shell, not Tor Browser.
+    #
+    # Tor Browser runs inside a flatpak sandbox that has no read access to
+    # /usr/share/doc/, so routing offline help through it produces a
+    # "Access to the file was denied" error page (reproduced 2026-05-25 in
+    # QEMU: clicking the elizaOS Documentation launcher loads the URI in
+    # Tor Browser and the flatpak sandbox refuses the read). The fix is
+    # not to weaken the Tor Browser sandbox; it is to route local help
+    # through a different WebKit instance. elizaos-webkit-shell is the
+    # same WebKit2GTK widget the main Milady app uses, already runs as
+    # the amnesia user, and has full file:// access.
+    #
+    # Remote https:// URIs continue to go through Tor Browser so external
+    # documentation links keep their privacy guarantee.
+    if uri.startswith("file://"):
+        os.execv(
+            "/usr/local/lib/elizaos/elizaos-webkit-shell",
+            ["/usr/local/lib/elizaos/elizaos-webkit-shell", uri],
+        )
+
     os.environ["TOR_BROWSER_SKIP_OFFLINE_WARNING"] = "yes"
     # Some of our callers capture the stderr of the
     # tails-documentation command, which, if we did not use

--- a/packages/os/linux/tails/config/chroot_local-includes/usr/local/bin/tails-documentation
+++ b/packages/os/linux/tails/config/chroot_local-includes/usr/local/bin/tails-documentation
@@ -103,6 +103,14 @@ def main():
     # Remote https:// URIs continue to go through Tor Browser so external
     # documentation links keep their privacy guarantee.
     if uri.startswith("file://"):
+        # Distinguish the docs window from the main agent shell in the
+        # taskbar / Alt-Tab. ELIZAOS_SHELL_TITLE was added in PR #7972
+        # specifically for this — without it, both windows render as
+        # "elizaOS" and users cannot tell them apart (the wm_class stays
+        # "elizaOS" intentionally so GNOME keeps them grouped under the
+        # same .desktop icon). WebKit may replace this title from the
+        # loaded HTML <title> once the page renders; that is expected.
+        os.environ["ELIZAOS_SHELL_TITLE"] = "elizaOS — Documentation"
         os.execv(
             "/usr/local/lib/elizaos/elizaos-webkit-shell",
             ["/usr/local/lib/elizaos/elizaos-webkit-shell", uri],


### PR DESCRIPTION
## The bug (reproduced 2026-05-25 in QEMU with screenshot proof)

Clicking the **elizaOS Documentation** launcher (`tails-documentation.desktop` → `/usr/local/bin/tails-documentation doc`) opens Tor Browser to the doc URI `file:///usr/share/doc/elizaos/website/doc.en.html`, but Tor Browser shows:

> **Problem loading page — Access to the file was denied**
> The file at /usr/share/doc/elizaos/website/doc.en.html is not readable. It may have been removed, moved, or file permissions may be preventing access.

Plus a notification: *"System was put in unsafe mode — Apps now have unrestricted access"*.

The file IS present and root-readable (3417 bytes, mode 0644). The sandbox is the issue.

## Root cause

`tails-documentation` execs `gtk-abspath-launch /usr/share/applications/org.boum.tails.TorBrowser.desktop <uri>`. The desktop file's handler falls back to `/usr/local/lib/tails-run-tor-browser-in-flatpak`, so the URI loads in **Tor Browser running inside a flatpak sandbox**. The sandbox has no read access to /usr/share/doc/, so file:// loads fail with the page above.

Journal evidence (live ISO, amnesia user session):
\`\`\`
gtk-abspath-launch[]: Call failed: The name org.boum.tails.TorBrowser was not provided by any .service files
sudo[]: amnesia : PWD=/home/amnesia ; USER=root ; COMMAND=/usr/local/lib/tails-run-tor-browser-in-flatpak /usr/share/doc/elizaos/website/doc.en.html
\`\`\`

Window list (gnome-shell D-Bus):
\`\`\`json
[{\"wm_class\":\"elizaos-webkit-shell\",\"title\":\"elizaOS\"},
 {\"wm_class\":\"Tor Browser\",\"title\":\"Problem loading page — Tor Browser\"}]
\`\`\`

## Fix (1 file, +20 lines)

In \`tails-documentation\`, route \`file://\` URIs to \`/usr/local/lib/elizaos/elizaos-webkit-shell\` instead of Tor Browser. That shell is the same WebKit2GTK widget the main Milady app uses, already runs as amnesia, and has full file:// access — no sandbox restrictions.

Remote \`https://\` URIs continue to use Tor Browser so external documentation links keep their privacy guarantee.

## Why this is the right shape

- **Minimum blast radius**: 20 lines, one file. No new browser dependency (the shell is already installed and powers the main app). Online-docs codepath unchanged.
- **Does not weaken the Tor Browser sandbox.** The sandbox stays as restrictive as upstream Tails set it.
- **Same WebKit version as the rest of the OS**: visual + behavior continuity for users.
- **Fail-closed**: \`file://\` URIs are local-only by definition; routing them around the privacy-hardened browser doesn't leak anything.

## Test plan

- [x] Python syntax + structure verified locally
- [ ] Build + boot in QEMU, click elizaOS Documentation launcher, confirm a WebKit window loads the doc with the elizaOS branding (next ISO build)
- [ ] Confirm \`tails-documentation https://elizaos.ai/contribute\` still opens in Tor Browser

## Related

- Part of the live-ISO bug triage from PR #7947 (TDZ cascade fix). The user-visible symptom was reported as "elizaos documentation app file is nonexistent so website doesn't load". Documented at HANDOFF_2026-05-25 (memory).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a reproducible bug where the elizaOS Documentation launcher routes local doc files through Tor Browser's flatpak sandbox, which has no read access to `/usr/share/doc/`, causing an "Access to the file was denied" error page. The fix intercepts `file://` URIs before reaching the Tor Browser exec path and sends them to `elizaos-webkit-shell` — a WebKit2GTK widget already present in the OS that runs as the `amnesia` user with full filesystem access.

- Adds a 28-line block in `tails-documentation` to route `file://` URIs to `/usr/local/lib/elizaos/elizaos-webkit-shell`, avoiding the flatpak sandbox entirely.
- Sets `ELIZAOS_SHELL_TITLE` in the environment before `os.execv` so the docs window appears with a distinct title in the taskbar (dependent on PR #7972 for the shell to honour it).
- The existing Tor Browser exec path (lines 119–137) is structurally preserved but note: because `uri` is unconditionally hardcoded to `file://` on line 82, the `if uri.startswith("file://")` branch is always taken; the Tor Browser path cannot be reached under any current invocation.

<h3>Confidence Score: 4/5</h3>

The routing change is mechanically correct and fixes the reproduced flatpak sandbox bug, but the Tor Browser fallback path is structurally dead and the WebKit exec has no error recovery, both of which previous reviewers have flagged and remain unaddressed.

The new os.execv call correctly propagates the modified environment (including ELIZAOS_SHELL_TITLE) to the WebKit shell, and the file:// guard is logically sound given the current URI construction. However, two open concerns from earlier review rounds have not been resolved: the Tor Browser code path after the new block can never execute under any current invocation of the script, and a missing elizaos-webkit-shell binary will surface as an unhandled Python traceback with no user-visible error message or graceful fallback.

packages/os/linux/tails/config/chroot_local-includes/usr/local/bin/tails-documentation — the Tor Browser exec block (lines 119–137) is unreachable and the WebKit exec lacks an exception handler.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/os/linux/tails/config/chroot_local-includes/usr/local/bin/tails-documentation | Adds file:// routing to elizaos-webkit-shell before the Tor Browser exec path; the branch is always taken because uri is hardcoded to a file:// value on line 82, making the Tor Browser path structurally unreachable. The os.execv call has no exception handler, so a missing binary produces an unhandled Python traceback rather than a graceful error message. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Launcher as tails-documentation.desktop
    participant Script as tails-documentation
    participant WebKit as elizaos-webkit-shell
    participant TorBrowser as Tor Browser flatpak
    participant FS as /usr/share/doc/

    Launcher->>Script: exec tails-documentation doc
    Script->>Script: "uri = file:///usr/share/doc/elizaos/website/doc.en.html"
    Script->>Script: uri.startswith(file://) is always True
    Script->>Script: set ELIZAOS_SHELL_TITLE env var
    Script->>WebKit: os.execv replaces process
    WebKit->>FS: read doc.en.html (mode 0644, no sandbox)
    FS-->>WebKit: 3417 bytes OK
    WebKit-->>Launcher: Renders documentation page

    note over TorBrowser: Never reached - os.execv either replaces the process or raises OSError
```

<sub>Reviews (2): Last reviewed commit: ["fix(os): set distinct window title on do..."](https://github.com/elizaos/eliza/commit/29e8e4a38fe41f58f55114a4c3e75f4d12d89373) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33719319)</sub>

<!-- /greptile_comment -->