### PR TITLE
fix(os): self-recover from stuck persistence-maintenance flag

### DIFF
--- a/packages/os/linux/tails/config/chroot_local-includes/etc/gdm3/PostLogin/Default
+++ b/packages/os/linux/tails/config/chroot_local-includes/etc/gdm3/PostLogin/Default
@@ -112,7 +112,20 @@ else
     # You might wonder why should the file be there at all:
     # if you are debugging, you might want to run systemctl restart gdm
     rm -f /var/lib/live/config/tails.create-persistence
-    rm -f /run/elizaos/persistence-maintenance
+    # Use `persistence-maintenance leave` instead of `rm -f` directly so
+    # the elizaos-{agent,renderer,milady}.service units get reset-failed
+    # and restarted if any previous boot left them in a stopped state.
+    # A bare `rm` clears the gate but leaves the units in whatever state
+    # the prior boot's enter had killed them into — symptom: "I click
+    # the elizaOS app and nothing happens" until the user manually runs
+    # `sudo persistence-maintenance leave` (verified 2026-05-25 in QEMU
+    # session-restart scenario). The helper is fail-soft (`|| true`) so
+    # this never blocks login.
+    if [ -x /usr/local/lib/elizaos/persistence-maintenance ]; then
+        /usr/local/lib/elizaos/persistence-maintenance leave || true
+    else
+        rm -f /run/elizaos/persistence-maintenance
+    fi
 fi
 
 ### Gather general configuration

--- a/packages/os/linux/tails/config/chroot_local-includes/usr/local/lib/elizaos/elizaos-keeper
+++ b/packages/os/linux/tails/config/chroot_local-includes/usr/local/lib/elizaos/elizaos-keeper
@@ -3,10 +3,63 @@
 set -eu
 
 interval="${ELIZAOS_KEEPER_INTERVAL:-5}"
+# Auto-leave a stale maintenance flag once its mtime is older than this
+# threshold AND the user-session persistence wizard is not active. The
+# only legitimate "no wizard, flag held" caller is
+# /etc/gdm3/PostLogin/Default, which calls `enter` once during boot and
+# expects the downstream `create-persistent-storage-session` (which has
+# `trap cleanup EXIT`) to call `leave`. If that downstream never runs —
+# wizard crash, user cancels at greeter without removing the persist
+# checkbox, session-restart mid-wizard, SIGKILL — the flag stays and
+# elizaos-{agent,renderer,pill}.service all stay disabled because their
+# `ConditionPathExists=!/run/elizaos/persistence-maintenance` fails.
+# Symptom is "I click the elizaOS app and nothing happens". 120 seconds
+# is well outside the legitimate wizard window (it covers GDM login,
+# user-session startup, autostart, and the wizard's own startup); a
+# flag still held past that is a stuck flag.
+stale_threshold="${ELIZAOS_KEEPER_STALE_FLAG_SECONDS:-120}"
+maintenance_helper=/usr/local/lib/elizaos/persistence-maintenance
 runtime_dir=/run/user/1000
 bus="unix:path=${runtime_dir}/bus"
 maintenance_flag=/run/elizaos/persistence-maintenance
 user_persistence_flag="${runtime_dir}/elizaos-persistence-setup"
+
+now_seconds() {
+    date +%s
+}
+
+flag_age_seconds() {
+    flag_path="$1"
+    flag_mtime=$(stat -c %Y "${flag_path}" 2>/dev/null || echo "")
+    if [ -z "${flag_mtime}" ]; then
+        echo ""
+        return
+    fi
+    echo $(( $(now_seconds) - flag_mtime ))
+}
+
+auto_leave_if_stale() {
+    # Only the maintenance_flag has the timeout semantics: it's the
+    # system-wide "skip elizaos units" gate. The user_persistence_flag is
+    # owned by an in-session script that handles its own cleanup, so we
+    # leave it alone — auto-leaving while a wizard is actually running
+    # would race against the wizard's own enter/leave dance.
+    [ -e "${maintenance_flag}" ] || return 0
+    [ -e "${user_persistence_flag}" ] && return 0
+
+    age=$(flag_age_seconds "${maintenance_flag}")
+    if [ -z "${age}" ]; then
+        return 0
+    fi
+    if [ "${age}" -lt "${stale_threshold}" ]; then
+        return 0
+    fi
+
+    logger -t elizaos-keeper \
+        "stale persistence-maintenance flag (age=${age}s, threshold=${stale_threshold}s, no wizard active); calling leave to recover the desktop" \
+        2>/dev/null || true
+    "${maintenance_helper}" leave >/dev/null 2>&1 || true
+}
 
 clear_user_unit_override() {
     runuser -u amnesia -- env HOME=/home/amnesia sh -eu <<'EOF'
@@ -40,7 +93,7 @@ EOF
 
 while :; do
     if [ -e "${maintenance_flag}" ] || [ -e "${user_persistence_flag}" ]; then
-        :
+        auto_leave_if_stale
     elif [ -S "${runtime_dir}/bus" ]; then
         clear_user_unit_override || true
         runuser -u amnesia -- env \


### PR DESCRIPTION
## The bug (reproduced 2026-05-25 in QEMU)

User clicks the elizaOS app, nothing happens. Cause: `/run/elizaos/persistence-maintenance` flag stays set across sessions, so `elizaos-{agent,renderer,pill,milady}.service` all skip start (their unit files have `ConditionPathExists=!/run/elizaos/persistence-maintenance`). Only recovery was `sudo /usr/local/lib/elizaos/persistence-maintenance leave` from a terminal.

## Root cause (two cooperating bugs)

**1. `/etc/gdm3/PostLogin/Default` fire-and-forgets `enter`.** When the greeter's create-persistent-storage box is checked, the script calls `persistence-maintenance enter || true` and relies on the downstream `create-persistent-storage-session` (which has a proper `trap cleanup EXIT` calling `leave`) to clear the flag. If that downstream never runs — wizard crash, user cancels at greeter without unchecking the persist box, GDM restart mid-wizard, SIGKILL of the session — the flag stays forever.

**2. PostLogin's else branch clears with raw `rm`.** When create-persistence is NOT checked, the script does `rm -f /run/elizaos/persistence-maintenance` to clear any leftover from a prior boot. That clears the gate but leaves the elizaos units in whatever stopped state the prior boot's `enter` had killed them into — `leave` would `reset-failed` and `start --no-block` the four units, raw `rm` does not.

## Fix (2 files, +68/-2)

**A. `elizaos-keeper` gains an auto-leave watchdog.** Every tick (default 5s), if `maintenance_flag` is held AND no user-session persistence wizard is active (`user_persistence_flag` absent) AND the flag's mtime is older than `ELIZAOS_KEEPER_STALE_FLAG_SECONDS` (default 120s), call `persistence-maintenance leave` to recover. 120s covers GDM login + user-session startup + wizard autostart with plenty of slack; a flag still held past that with no wizard active is by definition abandoned. The watchdog deliberately does NOT touch the `user_persistence_flag` — that's the wizard's own enter/leave dance and racing it would break clean persistence creation.

**B. `PostLogin/Default` else branch now calls `leave`.** Guarded with `[ -x ... ]` and `|| true` so login never blocks. This makes the "user did not check create-persistence" path restart any units the prior boot left stopped, not just clear the gate.

## Why this shape

- **Defense in depth, not one-shot.** Both a clean-startup fix (PostLogin → `leave`) and a runtime watchdog (keeper auto-leave). Either alone closes the gap; together they're robust to any abandoned-enter scenario.
- **Race-safe.** Watchdog refuses to act while the user_persistence_flag is present — the in-session wizard's own enter/leave dance is untouched.
- **Bounded.** Threshold is env-overridable (`ELIZAOS_KEEPER_STALE_FLAG_SECONDS=120`). Lowest reasonable value for slow hosts; can be cranked higher if a debugging session genuinely holds the flag longer.
- **Observable.** `journalctl -t elizaos-keeper` shows the auto-leave with flag age and threshold.
- **Backwards compatible.** PostLogin keeps a `rm -f` fallback if the helper isn't executable (e.g. partial-image build).

## Test plan

- [x] `sh -n` + `bash -n` syntax-clean
- [ ] Boot live ISO, leave create-persistence checked at greeter but cancel the wizard; verify `journalctl -t elizaos-keeper` logs auto-leave after 120s and the elizaOS app opens
- [ ] Boot live ISO with create-persistence unchecked + a prior boot's flag manually planted in `/run/elizaos/`; verify the PostLogin `leave` clears it and starts units
- [ ] Boot live ISO normally without persistence; verify the keeper does nothing extra (flag absent → existing branch)

## Related

- Part of live-ISO bug triage with PR #7958 (docs launcher flatpak fix) and the broader PR #7947 (TDZ cascade root fix).
- User report: "wven when i clicked the eliza os app to openit it didnt open lol"
- Documented in HANDOFF_2026-05-25 (memory).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two cooperating defenses against a stuck `/run/elizaos/persistence-maintenance` flag that left the elizaOS desktop silently unlaunchable: a runtime watchdog in `elizaos-keeper` that auto-calls `persistence-maintenance leave` after 120 s of a flag with no active wizard, and a PostLogin fix that replaces a bare `rm -f` with a proper `leave` call so prior-boot units are reset and restarted on the next login.

- **`elizaos-keeper`**: new `auto_leave_if_stale()` function checks flag age and skips action while `user_persistence_flag` is present, making the watchdog race-safe against the in-session wizard's own enter/leave dance.
- **`PostLogin/Default`**: `else` branch now calls `persistence-maintenance leave` (with `[ -x ]` guard and `rm -f` fallback) instead of a raw `rm -f`, so the four elizaos systemd units are reset-failed and restarted rather than left in a stopped state.

<h3>Confidence Score: 4/5</h3>

Safe to merge; both changes are fail-soft (`|| true` everywhere) so login can never block, and the watchdog correctly guards against racing the active wizard.

The core logic is sound and the two fixes cooperate well. The only gap is that `auto_leave_if_stale` in `elizaos-keeper` lacks the `[ -x ]` executability check that PostLogin's equivalent already has — on a partial-image build without the helper, the keeper would log a stale-flag warning to the journal on every 5-second tick indefinitely without ever clearing the flag.

`elizaos-keeper` — specifically the helper invocation inside `auto_leave_if_stale`; the PostLogin change is clean.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/os/linux/tails/config/chroot_local-includes/usr/local/lib/elizaos/elizaos-keeper | Adds auto_leave_if_stale() watchdog that calls persistence-maintenance leave after 120s of a stuck flag with no active wizard; small logic gap: no [ -x ] guard on maintenance_helper unlike PostLogin's equivalent call |
| packages/os/linux/tails/config/chroot_local-includes/etc/gdm3/PostLogin/Default | Replaces bare rm -f with a guarded persistence-maintenance leave call (with rm -f fallback) so units are properly reset-failed and restarted; comment names the wrong services (milady instead of pill) |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GDM PostLogin/Default] -->|create-persistence checked| B[persistence-maintenance enter]
    A -->|create-persistence NOT checked| C{helper executable?}
    C -->|yes| D[persistence-maintenance leave]
    C -->|no| E[rm -f maintenance_flag]
    D --> F[units reset-failed + restarted]

    G[elizaos-keeper loop every 5s] --> H{maintenance_flag exists?}
    H -->|no| I{D-Bus socket up?}
    H -->|yes| J{user_persistence_flag exists?}
    J -->|yes| K[skip — wizard active]
    J -->|no| L{flag age >= 120s?}
    L -->|no| M[wait next tick]
    L -->|yes| N[log to journalctl]
    N --> O[persistence-maintenance leave]
    O --> P[flag removed]
    P --> I
    I -->|yes| Q[clear unit overrides + daemon-reload + start units]
    I -->|no| R[wait next tick]
```

<sub>Reviews (1): Last reviewed commit: ["fix(os/linux): self-recover from stuck p..."](https://github.com/elizaos/eliza/commit/ea4ae5da113fcedc5a4d44e0af07effb6757acf0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33719781)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->