### PR TITLE
fix(plugin-agent-orchestrator): absorb cross-session task_complete duplicates for the same origin (closes #7967)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -529,6 +529,61 @@ describe("SubAgentRouter", () => {
     expect(handleMessage).toHaveBeenCalledTimes(2);
   });
 
+  it("absorbs cross-session task_complete for the same origin message (cascade-retry dedup)", async () => {
+    // Live regression on 2026-05-25 (issue elizaOS/eliza#7967): a single
+    // user prompt ("what is the current stable python version") fanned
+    // out into 5 sub-agent sessions (1 blocked, 1 errored, 3 task_complete)
+    // because the orchestrator auto-respawned on state_lost and verify-
+    // retry. Each task_complete posted a separate Discord message — the
+    // user saw 3 overlapping replies including a junky analytics URL
+    // pulled from python.org's page sub-resources.
+    //
+    // The dedup is keyed on (originMessageId, sessionId): a second
+    // task_complete from a DIFFERENT session for the SAME parent
+    // prompt is absorbed silently. Same-session progressive
+    // task_completes are unaffected (covered by the test above).
+    const SESSION_ID_2 = "abcdef01-2345-6789-abcd-ef0123456789";
+    const session2 = makeSession({
+      id: SESSION_ID_2,
+      name: "demo-task-retry",
+      metadata: {
+        label: "fix-bug-42-retry",
+        roomId: ROOM,
+        worldId: WORLD,
+        userId: USER,
+        messageId: PARENT_MSG,
+        source: "telegram",
+      },
+    });
+    const acp2: CapturedHandler = {};
+    const service = {
+      onSessionEvent: vi.fn((handler: typeof acp2.fn) => {
+        acp2.fn = handler;
+        return () => {
+          acp2.fn = undefined;
+        };
+      }),
+      getSession: vi.fn(async (id: string) => {
+        if (id === SESSION_ID) return session;
+        if (id === SESSION_ID_2) return session2;
+        return null;
+      }),
+      listSessions: vi.fn(async () => [session, session2]),
+    };
+    const { runtime, handleMessage } = makeRuntime({ acp: service });
+    await SubAgentRouter.start(runtime);
+
+    acp2.fn?.(SESSION_ID, "task_complete", { response: "first session done" });
+    await new Promise((r) => setImmediate(r));
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+
+    acp2.fn?.(SESSION_ID_2, "task_complete", {
+      response: "retry session also done with different text",
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("skips sessions without origin metadata (no roomId)", async () => {
     session = makeSession({ metadata: { label: "no-origin" } });
     acp = makeAcpService(session);

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -285,6 +285,42 @@ export class SubAgentRouter extends Service {
   private readonly roundTripCounts = new Map<string, number>();
   private readonly capExceededSessions = new Set<string>();
   private readonly verifyRetryHandedOffSessions = new Set<string>();
+  // Maps origin message id → the FIRST session id that posted a
+  // task_complete for it. When a later task_complete arrives for the
+  // same origin from a DIFFERENT session, we absorb it: that's a
+  // retry-cascade post (orchestrator dispatched a fresh sub-agent
+  // after the first one already shipped) and the user should see one
+  // reply, not 2-3+ overlapping messages with random page sub-
+  // resources from each retry. Issue elizaOS/eliza#7967.
+  //
+  // Same-session progressive task_completes (a sub-agent reports
+  // partial progress then completion) still post both — the dedupe
+  // key includes sessionId so it does not collapse them.
+  //
+  // The map is bounded (LRU via FIFO drop) to prevent unbounded growth
+  // across long-running sessions. 1024 origin messages is well above
+  // any reasonable workload — Discord channels typically see hundreds
+  // of message-events per hour at most.
+  private readonly originFirstPostedSession: Map<string, string> = new Map();
+  private originHasPostedFromOtherSession(
+    originMessageId: string,
+    sessionId: string,
+  ): boolean {
+    const firstSession = this.originFirstPostedSession.get(originMessageId);
+    return firstSession !== undefined && firstSession !== sessionId;
+  }
+  private markOriginCompletionPosted(
+    originMessageId: string,
+    sessionId: string,
+  ): void {
+    if (this.originFirstPostedSession.has(originMessageId)) return;
+    this.originFirstPostedSession.set(originMessageId, sessionId);
+    while (this.originFirstPostedSession.size > 1024) {
+      const oldestKey = this.originFirstPostedSession.keys().next().value;
+      if (!oldestKey) break;
+      this.originFirstPostedSession.delete(oldestKey);
+    }
+  }
   private started = false;
   private roundTripCap = DEFAULT_ROUND_TRIP_CAP;
   private bindRetryTimer: ReturnType<typeof setTimeout> | undefined;
@@ -551,6 +587,37 @@ export class SubAgentRouter extends Service {
         return;
       }
     }
+    // Origin-message dedupe: if a DIFFERENT sub-agent session for the
+    // SAME user prompt has already posted a task_complete to the user,
+    // absorb this one silently. This catches the cascade case where the
+    // orchestrator dispatched a retry sub-agent for a different reason
+    // (state_lost, blocked, transient error) after the first task_complete
+    // already shipped — without this guard the user sees 2-3+ overlapping
+    // replies with random URL leakage (issue elizaOS/eliza#7967).
+    //
+    // Same-session progressive task_completes (a sub-agent reports
+    // partial progress, then full completion) still post both — the
+    // dedupe key includes sessionId. Only cross-session retries are
+    // suppressed.
+    if (event === "task_complete" && origin.parentMessageId) {
+      if (
+        this.originHasPostedFromOtherSession(
+          origin.parentMessageId,
+          sessionId,
+        )
+      ) {
+        this.log(
+          "debug",
+          "suppressing duplicate sub-agent task_complete for origin; another session already posted for this prompt",
+          {
+            sessionId,
+            originMessageId: origin.parentMessageId,
+            event,
+          },
+        );
+        return;
+      }
+    }
     if (event === "task_complete" && verifiedUrls.length > 0) {
       text = verifiedUrlCompletionFallback(text, verifiedUrls);
     }
@@ -690,6 +757,17 @@ export class SubAgentRouter extends Service {
           source: ACPX_ROUTER_SOURCE,
         });
       }
+    }
+
+    // Record this session as the "first poster" for this origin so any
+    // later retry sub-agent (different sessionId) for the same parent
+    // prompt is absorbed silently (issue elizaOS/eliza#7967). Same-
+    // session progressive task_completes are unaffected because the
+    // dedupe check compares sessionIds. Must run AFTER the handleMessage
+    // / createMemory loop so an early failure doesn't poison future
+    // retries that might actually succeed.
+    if (event === "task_complete" && origin.parentMessageId) {
+      this.markOriginCompletionPosted(origin.parentMessageId, sessionId);
     }
   }
 


### PR DESCRIPTION
Closes #7967.

## Summary

A single user prompt fans out into multiple sub-agent sessions when the orchestrator auto-respawns (on state_lost, verify-retry, transient error, blocked) — and **every** sub-agent's \`task_complete\` event posts a separate user-facing Discord message. The user sees 2-3+ overlapping replies in 30 seconds with junk URLs, duplicates, or page sub-resources from each retry.

## Repro on 2026-05-25 07:05-07:06 UTC

Prompt: \`@bot what is the current stable python version\`

Parent emitted **one** \`TASKS:spawn_agent\` call. Sub-agent trajectories fired:
- \`tj-f3e500c94869d9\` — blocked
- \`tj-f3e1bdae0bf33b\` — error ("state was lost")
- \`tj-f4348d0432b057\` — task_complete (python.org URLs)
- \`tj-f4823d19a147b7\` — task_complete (**analytics.python.org/js/script.file-downloads.outbound-links.js** — page sub-resource leak)
- \`tj-f4b3d723dc9ee1\` — task_complete (python.org URLs)

User saw three Discord messages:
1. "I don't have live access to retrieve the latest stable Python version number right now. https://www.python.org/downloads/"
2. "https://analytics.python.org/js/script.file-downloads.outbound-links.js"
3. "https://www.python.org/downloads/"

## Fix

Track \`(originMessageId → first sessionId that posted task_complete)\` for up to 1024 origin messages (LRU FIFO drop). When a later task_complete event arrives for the SAME \`originMessageId\` from a DIFFERENT \`sessionId\`, absorb it silently with a debug log.

**Same-session progressive task_completes are unaffected** — the dedup check compares sessionIds. The existing test \`does NOT dedup task_complete with a different response\` continues to pass.

## Tests

- New regression \`absorbs cross-session task_complete for the same origin message (cascade-retry dedup)\` — two sessions sharing one originMessageId, emits task_complete for each, asserts only the first reaches handleMessage.
- All 59/59 sub-agent-router tests pass.

## Open follow-ups (not in this PR)

- Sub-agent task-report cleaning to drop tracker/analytics URLs at source.
- Investigate **WHY** the orchestrator spawns 5 sessions per prompt — the cascade is the symptom; the root respawn loop is the underlying defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a cross-session deduplication guard to `SubAgentRouter` to prevent users from seeing 2-3 overlapping replies when the orchestrator spawns multiple retry sub-agents for the same prompt. The fix tracks the first session that posted a `task_complete` for each origin message and absorbs subsequent `task_complete` events from different sessions for the same origin.

- Adds `originFirstPostedSession: Map<string, string>` (FIFO-bounded at 1024 entries) with `originHasPostedFromOtherSession` and `markOriginCompletionPosted` helpers; the dedup guard fires after URL-verification and before the `handleMessage` delivery loop.
- Adds a regression test (`absorbs cross-session task_complete for the same origin message`) that serialises two sessions sharing one `originMessageId` and asserts only the first `task_complete` reaches `handleMessage`.
- `originFirstPostedSession` is not cleared inside `stop()`, unlike every other stateful map (`delivered`, `roundTripCounts`, `capExceededSessions`, `verifyRetryHandedOffSessions`); a plugin reload or in-process restart retains old suppression entries, which can cause a legitimate first reply to be silently dropped if the map is not reset.

<h3>Confidence Score: 4/5</h3>

The dedup logic is sound for the normal path but the new map is not reset on service stop, which can cause legitimate replies to be swallowed after a restart.

The `originFirstPostedSession` map is the only stateful structure in the class that is not cleared in `stop()`. On an in-process service restart (plugin reload, test harness teardown between suites) entries from the previous lifetime persist. The next `task_complete` for any retained `originMessageId` — even the very first one from a fresh session — will be silently dropped, leaving the user with no reply. The fix is a one-liner but the defect is on the delivery path.

plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts — the `stop()` method needs `this.originFirstPostedSession.clear()` to match the cleanup pattern of every other stateful map in the class

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts | Adds `originFirstPostedSession` map and dedup logic for cross-session task_complete suppression; map is not cleared in `stop()` unlike all other stateful structures, creating a state-leakage hazard across service restarts |
| plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts | Adds cross-session cascade-retry dedup regression test; test correctly validates the happy path but cannot catch the concurrent-arrival race window because events are serialized with `setImmediate` between each fire |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User Prompt
    participant O as Orchestrator
    participant S1 as Sub-Agent Session 1
    participant S2 as Sub-Agent Session 2 (retry)
    participant R as SubAgentRouter
    participant D as Discord

    U->>O: "@bot what is the stable python version?"
    O->>S1: spawn_agent
    O->>S2: spawn_agent (retry after state_lost)

    S1->>R: task_complete (python.org URLs)
    R->>R: originHasPostedFromOtherSession? NO
    R->>D: handleMessage → user sees reply ✓
    R->>R: markOriginCompletionPosted(originMsgId, S1)

    S2->>R: task_complete (analytics URL)
    R->>R: originHasPostedFromOtherSession? YES (S1 already posted)
    R-->>R: absorb silently (debug log)
    Note over D: User sees only ONE reply
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/src/runtime/evaluator.ts`, line 391-399 ([link](https://github.com/elizaos/eliza/blob/954cd562b238b0c55c5df300f95712e18c1d99f5/packages/core/src/runtime/evaluator.ts#L391-L399)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`"success"` key causes false-positive stripping of legitimate user-facing JSON**

   The key list used to identify an evaluator envelope includes `"success"`. This string is also the most common key in API-response JSON examples ("the endpoint returns `{"success": true, "id": 42}`"). Any user-facing answer that ends with a JSON object containing `"success":` — a realistic code or API explanation — will have that trailing object stripped before it reaches the user. A safer guard would require at least two evaluator-specific keys to be present (e.g., both `"success"` and `"decision"`), since the combination is far more distinctive than either alone.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix(plugin-agent-orchestrator/sub-agent-..."](https://github.com/elizaos/eliza/commit/0105f4a16f6b7ca13aadd6d9286e4b3ad7872b68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33721018)</sub>

<!-- /greptile_comment -->