### PR TITLE
feat(os): parameterize ISO builder for amd64 / arm64 / riscv64

### DIFF
--- a/packages/os/linux/Dockerfile
+++ b/packages/os/linux/Dockerfile
@@ -21,6 +21,22 @@ FROM debian:trixie@sha256:e2d08da6f42ef4b09b165d55528a12727aeed8240dc9edf888e3ec
 # Don't prompt during apt operations inside the build
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Target architecture for the live-built ISO. Defaulted to amd64 so
+# every existing build keeps working untouched. arm64 + riscv64 swap
+# the bootloader packages below (x86-only isolinux / syslinux /
+# grub-pc-bin → EFI-only grub-efi-<arch>-bin) since BIOS-boot is
+# x86-only and isolinux only emits x86 boot sectors. The arg is set
+# from build.sh's --build-arg "TARGETARCH=${ARCH}" and from CI's
+# docker/build-push-action default. Validate strictly: a typo here
+# silently produces an ISO that can't boot on the intended hardware.
+ARG TARGETARCH=amd64
+RUN case "${TARGETARCH}" in \
+        amd64|arm64|riscv64) ;; \
+        *) echo "ERROR: TARGETARCH=${TARGETARCH} is not supported." >&2; \
+           echo "       Supported values: amd64 (default), arm64, riscv64." >&2; \
+           exit 1 ;; \
+    esac
+
 # ── Build dependencies ───────────────────────────────────────────────
 # This mirrors the package set Tails installs in its own builder box
 # (vagrant/definitions/tails-builder/generate-tails-builder-box.sh) —
@@ -43,6 +59,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 #   apt-cacher-ng: required, not optional — Tails' chroot hooks run
 #     apt inside a chroot whose resolv.conf is Tor-only (dead at build
 #     time). apt reaches packages via this proxy by IP. See acng.conf.
+# Common deps that exist + are needed on every supported arch.
+# Bootloader packages are NOT in this list — they're arch-specific and
+# install in the per-arch step below.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         debootstrap \
         cpio \
@@ -51,11 +70,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         parted \
         squashfs-tools \
         xorriso \
-        isolinux \
-        syslinux \
-        syslinux-common \
-        grub-pc-bin \
-        grub-efi-amd64-bin \
         grub2-common \
         rsync \
         psmisc \
@@ -93,6 +107,32 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         liblist-moreutils-perl \
         libtimedate-perl \
         libyaml-syck-perl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Per-arch bootloader packages.
+#
+# amd64 keeps the full Tails-compatible stack: BIOS (grub-pc-bin) +
+# UEFI (grub-efi-amd64-bin) + ISOLINUX/SYSLINUX for the El Torito boot
+# image. isolinux + syslinux + grub-pc-bin are x86-only and don't
+# exist as binaries for arm64 / riscv64 (the Debian source builds
+# nothing for them), so installing them on those arches errors with
+# "Unable to locate package".
+#
+# arm64 and riscv64 are UEFI-only. arm64 has the well-supported
+# grub-efi-arm64-bin; riscv64 ships grub-efi-riscv64-bin in
+# Debian trixie's riscv64 port. There is no BIOS GRUB on either —
+# everything boots via UEFI / U-Boot's EFI loader (or via direct
+# kernel boot from u-boot, which lb's `--binary-images iso` still
+# emits a usable filesystem.squashfs for).
+RUN apt-get update && case "${TARGETARCH}" in \
+        amd64) apt-get install -y --no-install-recommends \
+                   isolinux syslinux syslinux-common \
+                   grub-pc-bin grub-efi-amd64-bin ;; \
+        arm64) apt-get install -y --no-install-recommends \
+                   grub-efi-arm64-bin ;; \
+        riscv64) apt-get install -y --no-install-recommends \
+                   grub-efi-riscv64-bin ;; \
+    esac \
     && rm -rf /var/lib/apt/lists/*
 
 # ── ikiwiki from Debian forky ────────────────────────────────────────

--- a/packages/os/linux/build.sh
+++ b/packages/os/linux/build.sh
@@ -30,7 +30,26 @@ set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TAILS_SRC="${TAILS_SRC:-${HERE}/tails}"
 OUT="${HERE}/out"
-IMAGE="elizaos-builder"
+# Target architecture for the ISO. Default amd64 keeps every existing
+# call site working unchanged. arm64 + riscv64 add the per-arch bootloader
+# packages in the Dockerfile (grub-efi-arm64-bin / grub-efi-riscv64-bin
+# instead of grub-pc-bin + syslinux + isolinux, which are x86-only) and
+# switch live-build's --architecture and --linux-flavours. Both inputs
+# are tightly coupled — drive them from one source so a mismatch can't
+# silently produce an amd64 chroot inside an arm64 image.
+ARCH="${ELIZAOS_ARCH:-amd64}"
+case "${ARCH}" in
+    amd64|arm64|riscv64) ;;
+    *)
+        echo "ERROR: ELIZAOS_ARCH=${ARCH} is not supported." >&2
+        echo "       Supported values: amd64 (default), arm64, riscv64." >&2
+        exit 1
+        ;;
+esac
+# One builder image per arch — mixing them would race for the same image
+# tag. Per-arch tags also let CI keep an amd64 + arm64 builder warm in
+# the same registry.
+IMAGE="elizaos-builder-${ARCH}"
 # Persistent apt-cacher-ng cache. A Docker named volume (not a host
 # bind-mount) so it is owned correctly inside the container regardless
 # of host uid, and it survives `docker run --rm`. This is what makes
@@ -76,11 +95,15 @@ else
     git -C "${HERE}/tails-live-build" fetch --depth 1 origin "${LIVE_BUILD_REF}"
     git -C "${HERE}/tails-live-build" checkout -q FETCH_HEAD
 fi
-# Force x86_64 so the Tails-required x86-only packages (grub-pc-bin,
-# grub-efi-amd64-bin, syslinux, isolinux) resolve correctly. Without this,
-# Apple Silicon hosts pull the arm64 debian image and apt-get install
-# exits 100 with "Unable to locate package grub-pc-bin".
-docker build --platform linux/amd64 -t "${IMAGE}" "${HERE}"
+# Pin the build platform so the Dockerfile pulls the matching debian
+# base image and resolves arch-specific apt packages. For amd64 this
+# also prevents Apple Silicon hosts (default arm64) from pulling the
+# arm64 debian image when the user asked for an amd64 ISO. For
+# non-amd64 archs the host must have qemu-user-static + binfmt_misc
+# registered (Docker Desktop ships this; on bare Linux,
+# `apt-get install qemu-user-static binfmt-support` then `docker run
+# --rm --privileged tonistiigi/binfmt --install all`).
+docker build --platform "linux/${ARCH}" --build-arg "TARGETARCH=${ARCH}" -t "${IMAGE}" "${HERE}"
 rm -rf "${HERE}/tails-live-build"
 
 # Create the apt-cacher-ng cache volume on first run.
@@ -95,7 +118,12 @@ mkdir -p "${OUT}"
 docker_run_args=(
     --rm
     --privileged
-    --platform linux/amd64
+    --platform "linux/${ARCH}"
+    # Pass the target arch into the container so tails/auto/config can
+    # drive --architecture / --linux-flavours / arch-specific bootloader
+    # options off it. Defaulted to amd64 inside the script too, so a
+    # bare run still works.
+    -e "ELIZAOS_ARCH=${ARCH}"
     -e "MT_STAGE=${STAGE}"
     -e "MT_FAST=${MT_FAST:-}"
     -e "ELIZAOS_SKIP_WEBSITE=${ELIZAOS_SKIP_WEBSITE:-}"

--- a/packages/os/linux/tails/auto/config
+++ b/packages/os/linux/tails/auto/config
@@ -29,6 +29,21 @@ fi
 # get git branch or tag so we can set the basename appropriately.
 GIT_BRANCH="$(git_current_branch)"
 GIT_BASE_BRANCH_SHORT_ID="$(echo "$BASE_BRANCH_GIT_COMMIT" | head --bytes=10)"
+# Target architecture for this ISO build, driven from build.sh's
+# ELIZAOS_ARCH env (defaulted to amd64 there as well). Drives the ISO
+# filename's arch tag, the lb config --architecture / --linux-flavours,
+# the dpkg --print-architecture sanity check, and the syslinux-only
+# bootloader options. Validate it strictly so a typo in the env can't
+# silently produce an ISO with the wrong kernel/bootloader.
+ELIZAOS_ARCH="${ELIZAOS_ARCH:-amd64}"
+case "${ELIZAOS_ARCH}" in
+    amd64|arm64|riscv64) ;;
+    *)
+        fatal "ELIZAOS_ARCH=${ELIZAOS_ARCH} is not supported."\
+              "Supported values: amd64 (default), arm64, riscv64."
+        ;;
+esac
+
 if [ -n "${GIT_BRANCH}" ]; then
     CLEAN_GIT_BRANCH=$(echo "$GIT_BRANCH" | sed 's,/,_,g')
     BASE_BRANCH_PART=''
@@ -36,11 +51,11 @@ if [ -n "${GIT_BRANCH}" ]; then
         CLEAN_GIT_BASE_BRANCH=$(base_branch | sed 's,/,_,g')
         BASE_BRANCH_PART="+${CLEAN_GIT_BASE_BRANCH}@${GIT_BASE_BRANCH_SHORT_ID}"
     fi
-    BUILD_BASENAME="tails-amd64-${CLEAN_GIT_BRANCH}@${GIT_SHORT_ID}${BASE_BRANCH_PART}-${DATETIME_NOW}"
+    BUILD_BASENAME="tails-${ELIZAOS_ARCH}-${CLEAN_GIT_BRANCH}@${GIT_SHORT_ID}${BASE_BRANCH_PART}-${DATETIME_NOW}"
 else
     if git_on_a_tag; then
         CLEAN_GIT_TAG=$(git_current_tag | tr '/-' '_~')
-        BUILD_BASENAME="tails-amd64-${CLEAN_GIT_TAG}"
+        BUILD_BASENAME="tails-${ELIZAOS_ARCH}-${CLEAN_GIT_TAG}"
     else
         # this shouldn't reasonably happen (e.g. only if you checkout a
         # tag, remove the tag and then build)
@@ -62,8 +77,12 @@ if grep -qs -E '^Pin:\s+release\s+.*o=Debian Backports' \
     fatal "Found unsupported 'o=Debian Backports' syntax," \
         "in config/chroot_apt/preferences. Use o=Debian instead. Exiting."
 fi
-if [ "$(dpkg --print-architecture)" != amd64 ]; then
-    fatal "Only amd64 build systems are supported"
+if [ "$(dpkg --print-architecture)" != "${ELIZAOS_ARCH}" ]; then
+    fatal "Build host arch is $(dpkg --print-architecture) but"\
+          "ELIZAOS_ARCH=${ELIZAOS_ARCH}. Re-run build.sh — it pins"\
+          "docker --platform linux/${ELIZAOS_ARCH} so the container"\
+          "sees the right architecture (requires qemu-user-static +"\
+          "binfmt_misc on non-native hosts)."
 fi
 
 # space-separated list of additional packages debootstrap installs
@@ -114,11 +133,29 @@ else
     kernel_package=linux-image
 fi
 
+# Syslinux/isolinux are x86-only. On arm64 and riscv64 there is no
+# binary syslinux package in Debian, and passing --syslinux-* to lb
+# config makes it try to install isolinux/syslinux-common during build
+# which fails with "Unable to locate package". UEFI-only boot via
+# grub-efi-<arch>-bin is the only path on those archs, so drop the
+# syslinux args entirely there.
+case "${ELIZAOS_ARCH}" in
+    amd64)
+        SYSLINUX_ARGS="\
+            --syslinux-menu vesamenu \
+            --syslinux-splash data/splash.png \
+            --syslinux-timeout 4"
+        ;;
+    *)
+        SYSLINUX_ARGS=""
+        ;;
+esac
+
 # set general options
 $RUN_LB_CONFIG \
     --verbose \
     --apt-recommends false \
-    --architecture amd64 \
+    --architecture "${ELIZAOS_ARCH}" \
     --backports false \
     --volatile true \
     --binary-images iso \
@@ -136,7 +173,7 @@ $RUN_LB_CONFIG \
     --iso-application="elizaOS" \
     --iso-publisher="https://elizaos.ai/" \
     --iso-volume="ELIZAOS ${TAILS_FULL_VERSION}" \
-    --linux-flavours amd64 \
+    --linux-flavours "${ELIZAOS_ARCH}" \
     --memtest none \
     --mirror-binary "$DEBIAN_MIRROR" \
     --mirror-bootstrap "$DEBIAN_MIRROR" \
@@ -148,9 +185,7 @@ $RUN_LB_CONFIG \
     --packages-lists none \
     --tasks none \
     --linux-packages="$kernel_package" \
-    --syslinux-menu vesamenu \
-    --syslinux-splash data/splash.png \
-    --syslinux-timeout 4 \
+    ${SYSLINUX_ARGS} \
     --initramfs=live-boot \
     "${@}"
 


### PR DESCRIPTION
## Phase 3a — multi-arch enablement

Three coordinated changes drive the target architecture from a single \`ELIZAOS_ARCH\` env var, defaulted to amd64 so every existing call site keeps working unchanged.

### 1. \`build.sh\`
- Validate \`ELIZAOS_ARCH\` (\`amd64\` | \`arm64\` | \`riscv64\`)
- Tag the builder image per-arch (\`elizaos-builder-\${ARCH}\`) so concurrent per-arch builds don't race
- Pass \`--platform linux/\${ARCH}\` + \`--build-arg TARGETARCH=\${ARCH}\` to \`docker build\`
- Forward \`ELIZAOS_ARCH\` into the container so \`tails/auto/config\` can drive \`lb config\` off it

### 2. \`Dockerfile\`
- New \`ARG TARGETARCH=amd64\`
- Split apt install into a common-deps RUN (debootstrap, cpio, xorriso, grub2-common, …) and a per-arch bootloader RUN:
  - **amd64**: \`isolinux syslinux syslinux-common grub-pc-bin grub-efi-amd64-bin\` (full Tails BIOS+UEFI stack)
  - **arm64**: \`grub-efi-arm64-bin\` (UEFI-only; arm64 has no BIOS)
  - **riscv64**: \`grub-efi-riscv64-bin\` (Debian trixie's riscv64 port ships it)
- \`isolinux + syslinux + grub-pc-bin\` are x86-only — installing them on arm64/riscv64 errors with "Unable to locate package"

### 3. \`tails/auto/config\`
- Read + validate \`ELIZAOS_ARCH\`
- Use it in \`BUILD_BASENAME\` (\`tails-\${ARCH}-…iso\`)
- Change the \`dpkg --print-architecture\` sanity check to compare with \`ELIZAOS_ARCH\` (so the container-arch mismatch shows the actual problem instead of "Only amd64 is supported")
- Feed \`--architecture \${ARCH}\` and \`--linux-flavours \${ARCH}\` to \`lb config\`
- Conditionalize the \`--syslinux-*\` args (dropped on arm64/riscv64 because \`lb config\` otherwise tries to install syslinux during build and fails)

## Backwards-compatibility

Existing \`./build.sh\` (no env var) defaults to amd64 and produces the same artifact path as before: \`tails-amd64-…iso\`. Zero regression for current CI / nightly / dev workflows.

## What this does NOT do (next steps)

- **Run a fresh arm64 build end-to-end**. Needs \`qemu-user-static + binfmt_misc\` on the host. On bare Linux: \`apt-get install qemu-user-static binfmt-support && docker run --rm --privileged tonistiigi/binfmt --install all\`. Docker Desktop bundles it. Several hours of emulated build time the first run. Once it completes, \`qemu-system-aarch64 -M virt -bios QEMU_EFI.fd\` should boot the ISO.
- **Add arm64 to \`.github/workflows/build-linux-iso.yml\`'s matrix**. Should be \`continue-on-error: true\` initially so amd64 nightly stays green while arm64 stabilizes. Gated on local arm64 build proving the parameterization works end-to-end.
- **riscv64 userspace**. The OS-level multi-arch path is now ready, but the userspace apps still need their own arch-specific binaries — Shaw's electrobun-riscv64 enablement patches (currently only diagnostic instrumentation) + an 8-hour Bun cross-build at \`packages/app-core/scripts/bun-riscv64/\` are both pre-reqs for a usable riscv64 ISO.

## Verification

- [x] \`bash -n\` clean on build.sh; \`sh -n\` clean on \`tails/auto/config\`
- [x] Per-arch smoke: \`ELIZAOS_ARCH=arm64 build.sh\` sets \`IMAGE=elizaos-builder-arm64\`, \`ELIZAOS_ARCH=bogus\` is rejected before \`docker build\`
- [x] Dockerfile parses cleanly; the per-arch case statement installs the correct bootloader package set
- [ ] End-to-end arm64 build on a host with qemu-user-static (next session)
- [ ] arm64 ISO boot test in qemu-system-aarch64

## Related

- Part of the Phase 2 → Phase 3 plan in HANDOFF_2026-05-25 (memory)
- Phase 2 amd64 ISO is verified working end-to-end; PRs #7947, #7949, #7950, #7958, #7966, #7968 cover the boot fixes + CI fixes + UX fixes already shipped
- Phase 3b riscv64 follow-up depends on Shaw's electrobun-riscv64 patches landing

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR parameterizes the elizaOS ISO builder to support `amd64`, `arm64`, and `riscv64` via a single `ELIZAOS_ARCH` env var that defaults to `amd64`, keeping all existing call sites unchanged.

- **`build.sh`**: validates `ELIZAOS_ARCH`, uses per-arch image tags (`elizaos-builder-${ARCH}`), and forwards the arch into `docker build` (`--platform`, `--build-arg TARGETARCH`) and `docker run` (`-e ELIZAOS_ARCH`).
- **`Dockerfile`**: adds `ARG TARGETARCH=amd64` with an early validation `RUN`, splits the monolithic apt install into a common-deps layer and a per-arch bootloader layer (x86-only `isolinux`/`syslinux`/`grub-pc-bin` for amd64; EFI-only `grub-efi-<arch>-bin` for arm64/riscv64).
- **`tails/auto/config`**: validates `ELIZAOS_ARCH`, threads it into `BUILD_BASENAME`, `lb config --architecture` / `--linux-flavours`, the `dpkg --print-architecture` sanity check, and conditionalizes syslinux bootloader args (dropped on arm64/riscv64 where syslinux packages don't exist).

<h3>Confidence Score: 4/5</h3>

Safe to merge for amd64; arm64/riscv64 paths are structurally sound but untested end-to-end by design.

The three-point validation chain (build.sh → Dockerfile → tails/auto/config) is well-constructed and the amd64 default path is unchanged. The main concerns are the undocumented ELIZAOS_ARCH env var in the build.sh header (making the feature undiscoverable), a missing catch-all in the second Dockerfile case statement (could silently produce a bootloader-less image if layer caching is abused), the stale Dockerfile quick-start comment, and a shared apt-cacher-ng volume that will become a concurrency hazard when arm64 is added to the CI matrix.

packages/os/linux/build.sh (ACNG volume naming) and packages/os/linux/Dockerfile (missing fallthrough in per-arch case)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/os/linux/build.sh | Adds ELIZAOS_ARCH validation, per-arch Docker image tagging, and passes ARCH through to both docker build and docker run; logic is correct but ELIZAOS_ARCH is undocumented in the header and the shared ACNG volume name is a future footgun for parallel CI builds. |
| packages/os/linux/Dockerfile | Introduces ARG TARGETARCH with early validation and splits the apt install into a common-deps layer and a per-arch bootloader layer; the per-arch case lacks a catch-all exit, and the header quick-start comment is now stale. |
| packages/os/linux/tails/auto/config | Reads and validates ELIZAOS_ARCH, threads it into BUILD_BASENAME, lb config --architecture/--linux-flavours, the dpkg sanity check, and conditionalizes syslinux args correctly for x86-only vs. EFI-only architectures. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([User: ELIZAOS_ARCH=arm64 ./build.sh]) --> B{Validate ELIZAOS_ARCH\nbuild.sh}
    B -- invalid --> BAIL1([exit 1])
    B -- amd64 / arm64 / riscv64 --> C[Set IMAGE=elizaos-builder-ARCH]
    C --> D[docker build\n--platform linux/ARCH\n--build-arg TARGETARCH=ARCH]
    D --> E{Validate TARGETARCH\nDockerfile RUN}
    E -- invalid --> BAIL2([exit 1])
    E -- valid --> F[Install common deps\ndebootstrap, xorriso, grub2-common]
    F --> G{per-arch bootloader}
    G -- amd64 --> H[isolinux syslinux syslinux-common\ngrub-pc-bin grub-efi-amd64-bin]
    G -- arm64 --> I[grub-efi-arm64-bin]
    G -- riscv64 --> J[grub-efi-riscv64-bin]
    H & I & J --> K[docker run\n--platform linux/ARCH\n-e ELIZAOS_ARCH=ARCH]
    K --> L{Validate ELIZAOS_ARCH\ntails/auto/config}
    L -- invalid --> BAIL3([fatal])
    L -- valid --> M{dpkg --print-architecture\n== ELIZAOS_ARCH?}
    M -- no --> BAIL4([fatal])
    M -- yes --> N[lb config\n--architecture ARCH\n--linux-flavours ARCH\n+/-syslinux-args]
    N --> O([ISO: tails-ARCH-branch@hash.iso])
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (3)</h3></summary>

1. `packages/os/linux/build.sh`, line 5-26 ([link](https://github.com/elizaos/eliza/blob/61c96eee0e2999bffbd4bf727fb52240c47eea70/packages/os/linux/build.sh#L5-L26)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`ELIZAOS_ARCH` undiscoverable from the usage header**

   The header block documents every controllable env var (`MT_FAST`, `ELIZAOS_BUILD_CPUS`, `ELIZAOS_MKSQUASHFS_PROCESSORS`, `ELIZAOS_BUILD_MEMORY`, `ELIZAOS_SKIP_WEBSITE`) but omits `ELIZAOS_ARCH`. A user reading the help block has no indication the feature exists or what values are accepted.


2. `packages/os/linux/build.sh`, line 57 ([link](https://github.com/elizaos/eliza/blob/61c96eee0e2999bffbd4bf727fb52240c47eea70/packages/os/linux/build.sh#L57)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Shared `elizaos-acng` volume is a footgun for future parallel arch builds**

   `ACNG_VOLUME` is a fixed name regardless of `ARCH`. When the CI matrix is added (explicitly listed as a "next step" in the PR description), amd64 and arm64 jobs running concurrently would each start their own `apt-cacher-ng` daemon inside their respective containers — but both would point at the same cache directory on the host volume. `apt-cacher-ng` does not support two daemon instances sharing a single cache directory, so concurrent builds could corrupt the cache. Naming the volume `elizaos-acng-${ARCH}` would prevent this.


3. `packages/os/linux/Dockerfile`, line 8-12 ([link](https://github.com/elizaos/eliza/blob/61c96eee0e2999bffbd4bf727fb52240c47eea70/packages/os/linux/Dockerfile#L8-L12)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Quick-start comment is now stale**

   The header still shows `-t elizaos-builder` and omits `--build-arg TARGETARCH=<arch>`. After this PR, the canonical image tag is `elizaos-builder-<arch>` (e.g., `elizaos-builder-amd64`), so anyone following the inline comment would inadvertently diverge from the naming scheme used by `build.sh`.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["feat(os): parameterize ISO builder for a..."](https://github.com/elizaos/eliza/commit/61c96eee0e2999bffbd4bf727fb52240c47eea70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33736446)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->