### PR TITLE
feat(os): let elizaos-webkit-shell accept ELIZAOS_SHELL_TITLE override

### DIFF
--- a/packages/os/linux/tails/config/chroot_local-includes/usr/local/lib/elizaos/elizaos-webkit-shell
+++ b/packages/os/linux/tails/config/chroot_local-includes/usr/local/lib/elizaos/elizaos-webkit-shell
@@ -354,7 +354,17 @@ def main() -> int:
     shell_mode = os.environ.get("ELIZAOS_SHELL_MODE", "main")
     is_pill = shell_mode == "pill"
 
-    title = "elizaOS Voice" if is_pill else "elizaOS"
+    # ELIZAOS_SHELL_TITLE lets a caller override the window title without
+    # changing the wm_class (which stays "elizaOS" so GNOME keeps the
+    # window grouped under the same .desktop icon). Defaults preserve the
+    # historical behavior — "elizaOS Voice" for the pill, "elizaOS" for
+    # the main shell. Callers that spawn additional shells against
+    # different URLs (e.g. tails-documentation opening the offline doc
+    # in a second window) set this so users can tell the windows apart in
+    # the taskbar / Alt-Tab. WebKit may later replace the title via the
+    # HTML <title> element — that is the expected GTK browser behavior.
+    default_title = "elizaOS Voice" if is_pill else "elizaOS"
+    title = os.environ.get("ELIZAOS_SHELL_TITLE", default_title)
     window = Gtk.Window(title=title)
     if is_pill:
         configure_pill_window(window)


### PR DESCRIPTION
## Why

\`elizaos-webkit-shell\` always titles its window "elizaOS" (or "elizaOS Voice" for the pill). When PR #7958 (docs Tor Browser flatpak fix) routes the offline help viewer through the same shell binary, the docs window and the main agent window both end up titled "elizaOS" — indistinguishable in the GNOME taskbar / Alt-Tab list.

Reproduced 2026-05-25 in QEMU live ISO: after the docs fix landed in-VM, two "elizaOS" windows showed up in the GNOME shell's window list (`wm_class: elizaos-webkit-shell` / `title: elizaOS` for both). User asked "why is there 2 eliza apps open?"

## The fix

Read \`ELIZAOS_SHELL_TITLE\` env var and use it as the GTK window title when set. Defaults preserve the historical behavior — "elizaOS Voice" for pill mode, "elizaOS" for the main shell — so existing callers work unchanged. **The wm_class stays "elizaOS"** in both modes so GNOME keeps the window grouped under the same `.desktop` icon for taskbar pinning + Alt-Tab grouping.

WebKit may later replace the title via the HTML `<title>` element while rendering — that's the expected GTK browser behavior. The env var sets the starting title; HTML wins once the page loads. For pages without a `<title>` (e.g. inline rendered content), the env var stays.

## Pair PR

A follow-up commit on PR #7958's branch wires this env var into \`tails-documentation\`'s exec call: \`os.environ["ELIZAOS_SHELL_TITLE"] = "elizaOS — Documentation"\` before the \`os.execv\` to \`elizaos-webkit-shell\`. That way the docs window opens with a distinct title without requiring any HTML change.

## Verification

- [x] Python compiles cleanly (\`py_compile.compile(...)\`)
- [x] Default behavior unchanged: \`title = "elizaOS Voice" if is_pill else "elizaOS"\` when env var unset
- [x] \`wm_class\` unchanged — GNOME grouping behavior preserved
- [ ] Live test after #7958 + this both merge: docs window opens as "elizaOS — Documentation", main shell stays "elizaOS"

## Related

- Part of Phase 2 polish, in support of #7958 (docs Tor Browser flatpak fix)
- Documented in HANDOFF_2026-05-25 memory under "two elizaOS windows" findings.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `ELIZAOS_SHELL_TITLE` environment variable to `elizaos-webkit-shell` so callers can set a distinct GTK window title without touching the `wm_class`, keeping GNOME taskbar grouping intact. The change is minimal — one extra `os.environ.get` call with the existing title logic preserved as the default.

- Backward compatibility is maintained: when `ELIZAOS_SHELL_TITLE` is unset, behaviour is identical to before ("elizaOS Voice" for pill mode, "elizaOS" otherwise).
- The `wm_class` is left unchanged at `"elizaOS"` / `"elizaOS"`, so `.desktop` icon grouping and Alt-Tab behaviour are unaffected.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is a one-line env-var read with correct defaults and no impact on wm_class or existing callers.

The only edge case worth noting is that setting the variable to an empty string produces a blank title bar instead of falling back to the default, which is a minor but unexpected behaviour gap. All other paths behave as before.

The single changed file is straightforward; the empty-string edge case on line 367 is the only item worth a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/os/linux/tails/config/chroot_local-includes/usr/local/lib/elizaos/elizaos-webkit-shell | Adds ELIZAOS_SHELL_TITLE env-var override for the GTK window title with correct fallback to historical defaults; env var set to empty string silently produces a blank title instead of falling back to the default. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[elizaos-webkit-shell starts] --> B{ELIZAOS_SHELL_MODE?}
    B -- pill --> C[is_pill = True]
    B -- main / unset --> D[is_pill = False]
    C --> E[default_title = 'elizaOS Voice']
    D --> F[default_title = 'elizaOS']
    E --> G{ELIZAOS_SHELL_TITLE set?}
    F --> G
    G -- Yes --> H[title = env var value]
    G -- No --> I[title = default_title]
    H --> J[Gtk.Window title=title]
    I --> J
    J --> K[window.set_wmclass 'elizaOS','elizaOS']
    K --> L[GTK main loop — WebKit may override title via HTML title tag]
```

<sub>Reviews (1): Last reviewed commit: ["feat(os): let elizaos-webkit-shell accep..."](https://github.com/elizaos/eliza/commit/3cdd676e84f24cc06b883451e93f093c67e9781b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33741313)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->