### PR TITLE
chore(ci): add arm64 to build-linux-iso matrix with continue-on-error

### DIFF
--- a/.github/workflows/build-linux-iso.yml
+++ b/.github/workflows/build-linux-iso.yml
@@ -37,10 +37,23 @@ jobs:
   build-iso:
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    # arm64 builds run under qemu-user-static + binfmt_misc emulation on
+    # the amd64 runner. They are 3-5× slower than native, so they are
+    # gated behind `continue-on-error: true` while the path stabilizes —
+    # the amd64 nightly is the only required check today, so an arm64
+    # failure should not turn the workflow red. The per-arch experimental
+    # flag is read by `continue-on-error` below + by per-step `if:`s
+    # downstream that only run their amd64-only steps when arch == amd64.
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64]
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            experimental: false
+          - arch: arm64
+            experimental: true
     permissions:
       # contents: write covers softprops/action-gh-release (release upload)
       #   and anchore/sbom-action (artifact attachment). The workflow-level
@@ -55,6 +68,11 @@ jobs:
     env:
       CHANNEL: ${{ inputs.channel || (github.event_name == 'release' && 'stable') || 'nightly' }}
       LINUX_DIR: packages/os/linux
+      # Picked up by packages/os/linux/build.sh + tails/auto/config to
+      # drive --platform / TARGETARCH / --architecture / --linux-flavours
+      # and the per-arch bootloader package set. Defaults to amd64 inside
+      # build.sh too, so a bare run still works.
+      ELIZAOS_ARCH: ${{ matrix.arch }}
 
     steps:
       - name: Checkout
@@ -81,6 +99,23 @@ jobs:
 
       - name: Install just
         run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends just
+
+      - name: Register qemu-user-static binfmt (non-amd64 only)
+        if: matrix.arch != 'amd64'
+        # tonistiigi/binfmt is the canonical container image for registering
+        # qemu-user-static handlers with the kernel's binfmt_misc on the
+        # GitHub Actions amd64 runner. After this step, `docker run
+        # --platform linux/${arch}` transparently emulates the target arch
+        # for everything in the container, which is what packages/os/linux/
+        # build.sh does via `docker build --platform linux/${ARCH}`.
+        # Emulated builds are 3-5× slower than native; that is why this
+        # job is gated on continue-on-error: true while it stabilizes.
+        run: |
+          docker run --rm --privileged tonistiigi/binfmt --install all
+          # Verify the handler we actually need is registered, fail fast
+          # if registration silently no-op'd.
+          test -e "/proc/sys/fs/binfmt_misc/qemu-${{ matrix.arch == 'arm64' && 'aarch64' || matrix.arch }}"
+          echo "✓ qemu-user-static registered for ${{ matrix.arch }}"
 
       - name: Verify riscv64 contract
         run: |


### PR DESCRIPTION
## Why

Phase 3a #7971 parameterized the ISO builder for amd64 / arm64 / riscv64 — proven locally with `docker build --platform linux/arm64` succeeding (grub-efi-arm64-bin installed cleanly, image sha256:`8838b97b738142…`) and the riscv64 package set resolving + downloading correctly. This wires arm64 into the nightly workflow so the build path keeps working on every develop merge.

## The change (1 file, +36/-1)

### 1. Matrix grows to amd64 + arm64
```yaml
matrix:
  arch: [amd64, arm64]
  include:
    - arch: amd64
      experimental: false
    - arch: arm64
      experimental: true
```

### 2. `continue-on-error: ${{ matrix.experimental }}` on the job
amd64 stays the required check (must pass to mark the workflow green). arm64 failure does not turn the run red while it stabilizes — this is the standard "shadow build" pattern from rustlang/rust, cpython, kubernetes etc.

### 3. New "Register qemu-user-static binfmt" step (`if: matrix.arch != 'amd64'`)
Runs `docker run --rm --privileged tonistiigi/binfmt --install all` on the amd64 GitHub Actions runner. After registration, `docker run --platform linux/arm64` transparently emulates aarch64 for everything inside the container — which is what build.sh does via `docker build --platform linux/${ARCH}`. Verifies the handler we actually need is registered (`test -e /proc/sys/fs/binfmt_misc/qemu-aarch64`) so a silent no-op fails fast instead of producing a confusing build-time error.

### 4. `ELIZAOS_ARCH: ${{ matrix.arch }}` added to job-level env
Every step sees it without per-step plumbing. `build.sh` (post-#7971) reads this and drives `docker --platform` + `TARGETARCH` off it.

## Caveats

- Emulated arm64 builds run **3-5× slower than native**. The amd64 nightly already takes ~1 hour, so an arm64 emulated build is likely 3-5 hours. The existing 110-min timeout will need a bump later; left out of this PR to keep it focused on the matrix change. For now the build will time out before completing, which `continue-on-error: true` swallows — the goal of THIS PR is just to keep the path exercised end-to-end on every develop merge.
- **riscv64 deliberately NOT in this PR.** Gated on Shaw's electrobun-riscv64 enablement patches landing first — a riscv64 ISO without a working userspace agent has no end-user value.

## Test plan

- [x] YAML parses cleanly (`python3 -c 'import yaml; yaml.safe_load(open(...))'`)
- [x] matrix.arch resolves to `['amd64', 'arm64']`, matrix.include sets the experimental flags correctly
- [x] arm64 dockerfile package set proven locally — see #7971's smoke test evidence
- [ ] First arm64 nightly run after merge — expected to time out at 110 min, soaks the path
- [ ] Follow-up PR bumps timeout when this looks healthy

## Related

- Depends on PR #7971 (Phase 3a parameterization) — should land first or together
- Depends on PR #7950 (nightly unblock with ELIZAOS_BUILD_APP=1) — without it both amd64 and arm64 nightlies fail at the same chroot hook
- Part of the Phase 2 → Phase 3 plan in HANDOFF_2026-05-25 (memory)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires `arm64` into the nightly ISO build matrix by adding it alongside `amd64`, registering QEMU binfmt handlers via `tonistiigi/binfmt`, and exposing `ELIZAOS_ARCH` as a job-level env var. The arm64 job is deliberately gated with `continue-on-error: true` (the "shadow build" pattern) because emulated builds are expected to exceed the current 110-minute timeout while the path stabilizes.

- Adds a `strategy.matrix` with `amd64`/`arm64` entries and per-arch `experimental` flags driving `continue-on-error`, keeping amd64 as the only required check.
- Introduces a "Register qemu-user-static binfmt" step (arm64 only) that runs `tonistiigi/binfmt --install all` under `--privileged` and verifies `/proc/sys/fs/binfmt_misc/qemu-aarch64` exists before proceeding.
- Existing artifact, SBOM, attestation, and smoke-test steps are already guarded with `if: matrix.arch == 'amd64'`, so they remain amd64-only without further changes.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one low-priority hardening item to address before the arm64 path matures.

The matrix expansion is structurally sound: continue-on-error is correctly tied to the experimental flag, amd64 remains the required check, and the existing amd64-only gates (SBOM, attestation, QEMU smoke test) are already guarded. The one item worth addressing is the unpinned --privileged Docker image — while tonistiigi/binfmt is a well-known image, pulling latest on every run without a digest means the runner trusts whatever the registry serves at that moment with full host privileges.

.github/workflows/build-linux-iso.yml — specifically the tonistiigi/binfmt invocation and the smoke-test-skipped condition.

<details open><summary><h3>Security Review</h3></summary>

- **Unpinned privileged container** (`.github/workflows/build-linux-iso.yml` line 114): `tonistiigi/binfmt` is pulled without a digest, so every run fetches the current `latest` tag. Because the container runs with `--privileged`, a tag mutation or upstream supply-chain compromise would grant arbitrary code full host-level access on the Actions runner. Recommend pinning to a specific SHA-256 digest.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-linux-iso.yml | Adds arm64 matrix entry with continue-on-error shadow-build pattern, QEMU binfmt registration step, and ELIZAOS_ARCH env var; two minor issues: unpinned privileged Docker image and over-broad smoke-test-skipped condition. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[build-iso job
matrix: amd64 / arm64] --> B{matrix.arch}
    B -->|amd64
experimental: false| C[continue-on-error: false
required check]
    B -->|arm64
experimental: true| D[continue-on-error: true
shadow build]
    C --> E[Restore cache]
    D --> F[Register QEMU binfmt
tonistiigi/binfmt --install all]
    F --> G{verify
/proc/.../qemu-aarch64}
    G -->|exists| H[Restore cache]
    G -->|missing| X1[fail fast]
    E --> I[Build ISO - amd64
timeout: 110 min]
    H --> J[Build ISO - arm64
timeout: 110 min
expected timeout]
    I --> K[Locate and rename ISO]
    J --> L[Locate and rename ISO]
    K --> M{matrix.arch == amd64?}
    M -->|yes| N[Smoke test / SBOM / Attest / Upload artifact]
    M -->|no| O[Upload artifact only]
    L --> O
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/build-linux-iso.yml`, line 204-206 ([link](https://github.com/elizaos/eliza/blob/107aa4d50e802af9fbc2a404ccee1941a0b057df/.github/workflows/build-linux-iso.yml#L204-L206)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **"Smoke test skipped" notice fires for arm64 too**

   The condition `steps.kvm.outputs.have_kvm != 'true'` matches arm64 matrix jobs as well (they never have a smoke test regardless of KVM). On a runner where KVM is available, arm64 will silently emit no smoke-test notice; on a runner without KVM, it emits a notice that implies the only reason for skipping is missing KVM, when for arm64 there is no smoke-test implementation at all. Adding `matrix.arch == 'amd64'` keeps the signal clear.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["ci(build-linux-iso): add arm64 to matrix..."](https://github.com/elizaos/eliza/commit/107aa4d50e802af9fbc2a404ccee1941a0b057df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33745829)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->