### PR TITLE
docs(os): add end-user guide for verifying downloaded Live ISOs

### DIFF
--- a/packages/os/docs/verify-iso-download.md
+++ b/packages/os/docs/verify-iso-download.md
@@ -1,0 +1,184 @@
+# Verify an elizaOS Live ISO download
+
+When you download an elizaOS Live ISO from a GitHub Release, you should
+verify that the file you received is the file elizaOS actually built
+and signed — before you flash it to a USB stick and boot from it. This
+guide walks through the three checks every release publishes (once the
+release pipeline is green; see [ci-cd-prod-roadmap.md](./ci-cd-prod-roadmap.md)
+for the current status).
+
+## What ships with each release
+
+Every elizaOS Live release on https://github.com/elizaOS/eliza/releases
+includes these files per architecture:
+
+| File | Purpose |
+| --- | --- |
+| `elizaos-live-<channel>-<date>-<arch>.iso` | The ISO image you flash to USB. |
+| `elizaos-live-<channel>-<date>-<arch>.iso.sha256` | SHA-256 checksum of the ISO. |
+| `elizaos-live-<channel>-<date>-<arch>.iso.spdx.json` | SPDX 2.3 SBOM listing every Debian package inside the ISO. |
+| Sigstore in-toto attestation | Mintable via GitHub OIDC; verify with `gh attestation verify` (no separate file). |
+
+`<channel>` is `nightly`, `beta`, or `stable`. `<arch>` is `amd64`
+(and `arm64` once Phase 3a stabilizes; see [PR #7971](https://github.com/elizaOS/eliza/pull/7971)).
+
+## Step 1 — Verify the SHA-256 checksum
+
+This catches a corrupted download or an obvious wrong-file mistake.
+It does **not** prove the ISO came from elizaOS — see Step 2 for that.
+
+```sh
+# Download the ISO + its .sha256 sidecar from the release page first.
+sha256sum -c elizaos-live-stable-2026.05.25-amd64.iso.sha256
+```
+
+Expected output:
+
+```
+elizaos-live-stable-2026.05.25-amd64.iso: OK
+```
+
+If you see `FAILED` instead, the file is corrupted (re-download) or
+tampered (do not flash; report it on the issue tracker).
+
+## Step 2 — Verify the SLSA build provenance with `gh attestation verify`
+
+This is the cryptographic proof that elizaOS's official CI built this
+exact ISO. Every nightly + release run mints a [SLSA build
+provenance](https://slsa.dev/spec/v1.0/provenance) attestation, signed
+via GitHub's OIDC token to [Sigstore](https://www.sigstore.dev/) (no
+long-lived keys, no PGP key management). The attestation binds the ISO
+file's SHA-256 to the repo + workflow + commit that produced it.
+
+You need [GitHub CLI](https://cli.github.com/) (`gh`) ≥ 2.49.0:
+
+```sh
+gh attestation verify elizaos-live-stable-2026.05.25-amd64.iso \
+    --owner elizaOS
+```
+
+Expected output:
+
+```
+Loaded digest sha256:6019452a... for file://elizaos-live-stable-2026.05.25-amd64.iso
+Loaded 1 attestation from GitHub API
+
+The following policy criteria will be enforced:
+- OIDC Issuer must match:................... https://token.actions.githubusercontent.com
+- Source Repository Owner URI must match:... https://github.com/elizaOS
+- Predicate type must match:................ https://slsa.dev/provenance/v1
+- Subject Alternative Name must match regex: (?i)^https://github.com/elizaOS/
+
+✓ Verification succeeded!
+
+sha256:6019452a... was attested by:
+REPO          PREDICATE_TYPE                  WORKFLOW
+elizaOS/eliza https://slsa.dev/provenance/v1  .github/workflows/build-linux-iso.yml@refs/heads/develop
+```
+
+The `WORKFLOW` field tells you exactly which workflow + branch built
+the ISO. Cross-check it against
+https://github.com/elizaOS/eliza/blob/develop/.github/workflows/build-linux-iso.yml
+to confirm the build pipeline you trust matches the build pipeline
+that produced your download.
+
+### Locking down the verification further
+
+For higher assurance, pin the workflow path + ref:
+
+```sh
+gh attestation verify elizaos-live-stable-2026.05.25-amd64.iso \
+    --owner elizaOS \
+    --source-ref refs/tags/v2.0.4 \
+    --signer-workflow elizaOS/eliza/.github/workflows/build-linux-iso.yml@refs/tags/v2.0.4
+```
+
+This rejects any attestation that came from a different branch, a
+different workflow file, or a fork. Recommended for security-sensitive
+deployments.
+
+### Offline verification
+
+`gh attestation verify` can also work offline if you pre-downloaded
+the attestation:
+
+```sh
+# Online: download the attestation JSON once
+gh attestation download elizaos-live-stable-2026.05.25-amd64.iso \
+    --owner elizaOS \
+    --output-file attestation.json
+
+# Offline: verify against the local bundle
+gh attestation verify elizaos-live-stable-2026.05.25-amd64.iso \
+    --owner elizaOS \
+    --bundle attestation.json
+```
+
+This is useful when flashing on an air-gapped machine.
+
+## Step 3 — Inspect the SBOM (optional but recommended)
+
+The `.spdx.json` file lists every Debian package baked into the ISO,
+including the apt cache snapshot date that fixed package versions.
+This is what you would feed into your own vulnerability scanner if
+you run one:
+
+```sh
+# Quick: how many packages?
+jq '.packages | length' elizaos-live-stable-2026.05.25-amd64.iso.spdx.json
+
+# All package names + versions
+jq -r '.packages[] | "\(.name) \(.versionInfo)"' \
+    elizaos-live-stable-2026.05.25-amd64.iso.spdx.json | sort
+
+# Feed into Grype for CVE scan (one-time install: brew install grype OR
+# `curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh`)
+grype sbom:elizaos-live-stable-2026.05.25-amd64.iso.spdx.json
+```
+
+The SBOM is generated by [anchore/sbom-action](https://github.com/anchore/sbom-action)
+(driving [syft](https://github.com/anchore/syft) under the hood) from
+the Debian package database inside the ISO's squashfs root.
+
+## What "verified" actually guarantees
+
+Pass all three checks above and you know:
+
+1. The ISO bytes are exactly what elizaOS published (SHA-256 match).
+2. Those bytes came from a build run inside the elizaOS GitHub
+   organization, executed by the public workflow at the SHA recorded
+   in the attestation (SLSA provenance).
+3. The package set inside the ISO is exactly what the SBOM declares,
+   pinned to the build's APT snapshot date.
+
+It does **not** guarantee:
+
+- That GitHub Actions or Sigstore are themselves uncompromised (those
+  are the trust roots). Pin to a known-good attestation date if you
+  want to mitigate.
+- That the bundled application code is bug-free or contains no
+  vulnerabilities. Run the Grype scan above for CVE coverage of the
+  Debian package set; for elizaOS app-layer issues, see
+  https://github.com/elizaOS/eliza/security.
+
+## When verification fails
+
+| Failure | Cause | Fix |
+| --- | --- | --- |
+| `gh attestation verify` returns "no attestations found" | Release predates the SLSA pipeline going green (pre-2026-05). | Use SHA-256 check only; or wait for a re-built release. |
+| `--owner elizaOS` policy fails | You're pointing at a fork's release, not elizaOS/eliza. | Download from https://github.com/elizaOS/eliza/releases — not a fork. |
+| Workflow name doesn't match `.github/workflows/build-linux-iso.yml` | The ISO came from a different CI job (e.g. `elizaos-os-full-release.yml`). | That's currently expected for tag-triggered releases; the workflow you trust depends on which channel you downloaded. Open an issue if unsure. |
+| SHA-256 mismatch but attestation verifies | The `.sha256` sidecar was tampered. The attestation has the real hash inside it. | Use the hash from `gh attestation verify` output as the source of truth. |
+| Everything passes but the ISO won't boot | Verification only proves provenance, not bootability. | Try a known-good USB flasher (the `dd` recipe in README); confirm BIOS/UEFI mode matches your hardware. |
+
+## Related
+
+- [ci-cd-prod-roadmap.md](./ci-cd-prod-roadmap.md) — why some of the
+  scaffolding above doesn't yet produce releases (8+ days of nightly
+  red as of 2026-05-25; PR #7950 unblocks).
+- [actions/attest-build-provenance](https://github.com/actions/attest-build-provenance)
+  — what the workflow uses to mint attestations.
+- [SLSA v1.0 spec](https://slsa.dev/spec/v1.0/) — the threat model
+  the attestation actually defends against.
+- [Sigstore docs](https://docs.sigstore.dev/) — keyless signing
+  background.


### PR DESCRIPTION
## Why

When users download an elizaOS Live ISO from GitHub Releases they need a single canonical guide for verifying provenance + integrity before flashing. Today the verify instructions are scattered across the CI/CD roadmap doc, action README comments, and Sigstore upstream — users with no security background hit a wall.

## The change (1 file, +153 / -0)

New \`packages/os/docs/verify-iso-download.md\` covers:

- **What every release ships** — \`.iso\` + \`.iso.sha256\` + \`.iso.spdx.json\` + the GitHub-OIDC Sigstore attestation (no separate file needed)
- **Three-step verify**, each with exact commands + expected output:
  1. \`sha256sum -c\` for integrity
  2. \`gh attestation verify --owner elizaOS\` for SLSA provenance
  3. Optional \`syft\` / \`grype\` SBOM scan for CVE coverage
- **Hardened verify** with \`--source-ref\` + \`--signer-workflow\` for security-sensitive deployments (rejects forks, rejects different workflows)
- **Offline verify** path via \`gh attestation download\` then \`gh attestation verify --bundle\` (useful when flashing on an air-gapped machine)
- **Honest disclosure** of what verification does NOT guarantee (GitHub Actions / Sigstore being uncompromised, app-layer bugs)
- **Failure-mode → fix table** for the common cases (release predates the SLSA pipeline, wrong owner, fork download, attestation exists but workflow mismatch, etc.)

## Why this shape

- **One canonical doc.** No more "where do I copy the verify command from" — link to one URL from release notes / README / Twitter / Discord.
- **Honest about scope.** The "what verification does NOT guarantee" + "when verification fails" sections set the right trust model up front.
- **Future-proof.** Works for amd64 today, arm64 once Phase 3a (#7971) lands, riscv64 when Shaw's enablement gets there. No arch-specific instructions needed.

## Related

- [ci-cd-prod-roadmap.md](packages/os/docs/ci-cd-prod-roadmap.md) (PR #7949) — why these attestations don't yet ship on every release (nightly red 8+ days, PR #7950 unblocks)
- [.github/workflows/build-linux-iso.yml](.github/workflows/build-linux-iso.yml) — the workflow that mints the SLSA attestation (PR #7950 + PR #7973 wire it correctly)
- Documented in HANDOFF_2026-05-25 memory

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new end-user guide (`packages/os/docs/verify-iso-download.md`) for verifying elizaOS Live ISO downloads using SHA-256 checksums, `gh attestation verify` (SLSA provenance via Sigstore/GitHub OIDC), and optional SBOM scanning with Grype. The guide is well-structured and the SHA-256 and standard online-verification steps are correct.

- The offline verification section uses `--output-file attestation.json` with `gh attestation download`, a flag that does not exist; the CLI writes bundles as `sha256:<digest>.jsonl` automatically, so both the download and subsequent `--bundle attestation.json` commands will fail.
- The expected output for a `stable` ISO shows a `@refs/heads/develop` workflow ref, but a release-triggered build attests against a tag ref, which will confuse users cross-checking a real stable release.
- The SPDX SBOM is only generated for `amd64` in the workflow, but the artifact table implies it ships for all architectures.

<h3>Confidence Score: 3/5</h3>

The offline verification flow contains broken commands that will fail for users who follow them; a fix is needed before this ships in release notes.

The core SHA-256 and online attestation steps are accurate, but the offline section uses --output-file attestation.json with gh attestation download — a flag the CLI does not recognize. Any user following that path will hit an error and be left without a working air-gap verification procedure. The expected-output example also shows a develop-branch ref for a file labelled as a stable release, which could undermine trust in legitimate downloads.

packages/os/docs/verify-iso-download.md — the offline verification commands and the expected-output example both need correction before this guide is linked from release notes or README

<details open><summary><h3>Security Review</h3></summary>

- The Grype installation suggestion in Step 3 (`curl -sSfL .../install.sh | sh`) pipes an unverified remote script into a shell, directly contradicting the provenance-verification intent of this guide. Recommend replacing with a link to signed release binaries or a package-manager install (`brew install grype`).
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/os/docs/verify-iso-download.md | New end-user verification guide covering SHA-256, SLSA provenance, and SBOM scanning; the offline verification section uses a non-existent --output-file flag for gh attestation download, which will cause the commands to fail for users following that path. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Download ISO from GitHub Releases] --> B[Step 1: sha256sum -c]
    B -->|FAILED| C[Re-download or report tampering]
    B -->|OK| D[Step 2: gh attestation verify --owner elizaOS]
    D -->|No attestations found| E[Pre-pipeline release — SHA-256 only]
    D -->|Policy fails| F[Wrong owner / fork download]
    D -->|Verification succeeded| G{Need offline?}
    G -->|Yes| H[gh attestation download --owner elizaOS]
    H --> I[Bundle saved as sha256:digest.jsonl]
    I --> J[gh attestation verify --bundle sha256:digest.jsonl]
    G -->|No| K[Step 3: Optional SBOM scan]
    J --> K
    K --> L[jq package count / grype CVE scan]
    L --> M[Verified — safe to flash]
```

<sub>Reviews (1): Last reviewed commit: ["docs(os): add end-user guide for verifyi..."](https://github.com/elizaos/eliza/commit/19b773d6eff295401399f15a95df5f3f9203e579) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33783672)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->