### PR TITLE
fix(ci): make publish-apt-repo GPG secrets optional to unblock release workflow startup

### DIFF
--- a/.github/workflows/publish-apt-repo.yml
+++ b/.github/workflows/publish-apt-repo.yml
@@ -17,10 +17,21 @@ on:
         type: string
         default: stable
     secrets:
+      # All three GPG secrets are `required: false` — the workflow body has
+      # an early `Check GPG credentials` step that emits a warning + skips
+      # the publish path with `can_publish=false` when DEBIAN_GPG_PRIVATE_KEY
+      # is empty. Declaring them `required: true` here would fail the
+      # reusable-workflow startup validation in 0-3 seconds BEFORE any job
+      # runs — turning every release-tag of elizaos-os-full-release.yml
+      # into a startup_failure with no logs (verified 2026-05-25:
+      # v2.0.0 / v2.0.1 / v2.0.3 all startup_failure'd at 0-3 sec because
+      # the elizaOS/eliza repo doesn't have DEBIAN_GPG_PRIVATE_KEY set).
+      # `required: false` lets the body decide; the existing graceful
+      # skip then carries the rest of the release through.
       DEBIAN_GPG_PRIVATE_KEY:
-        required: true
+        required: false
       DEBIAN_GPG_KEY_ID:
-        required: true
+        required: false
       DEBIAN_GPG_PASSPHRASE:
         required: false
 
@@ -54,9 +65,17 @@ jobs:
         id: gpg_check
         env:
           DEBIAN_GPG_PRIVATE_KEY: ${{ secrets.DEBIAN_GPG_PRIVATE_KEY }}
+          DEBIAN_GPG_KEY_ID: ${{ secrets.DEBIAN_GPG_KEY_ID }}
         run: |
+          # Both PRIVATE_KEY and KEY_ID are needed to sign Release files —
+          # a half-configured repo where only one is set still can't sign,
+          # and reprepro would fail later with a less obvious error.
+          # Surface the actual gap up front.
           if [[ -z "$DEBIAN_GPG_PRIVATE_KEY" ]]; then
             echo "::warning::DEBIAN_GPG_PRIVATE_KEY not configured. Apt repo publish skipped."
+            echo "can_publish=false" >> "$GITHUB_OUTPUT"
+          elif [[ -z "$DEBIAN_GPG_KEY_ID" ]]; then
+            echo "::warning::DEBIAN_GPG_KEY_ID not configured (PRIVATE_KEY was set). Apt repo publish skipped."
             echo "can_publish=false" >> "$GITHUB_OUTPUT"
           else
             echo "can_publish=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## The bug

**\`elizaos-os-full-release.yml\` startup_failures at 0-3 seconds on every release tag.** v2.0.0 / v2.0.1 / v2.0.3 — three published tags, **zero successful runs**. No logs (because workflow doesn't even start). Net result: **no signed ISO has ever been published from this pipeline**, despite all the SLSA + SHA256SUMS + SBOM scaffolding being in place.

## Root cause

\`publish-apt-repo.yml\` (called as a reusable workflow from \`elizaos-os-full-release.yml\`) declares two secrets as **\`required: true\`**:

\`\`\`yaml
secrets:
  DEBIAN_GPG_PRIVATE_KEY:
    required: true       # ← blocks startup if unset
  DEBIAN_GPG_KEY_ID:
    required: true       # ← blocks startup if unset
\`\`\`

GitHub validates the reusable-workflow secret contract **before any job runs**. The elizaOS/eliza repo doesn't have those secrets configured (they're admin-only), so the reusable invocation aborts the entire pipeline with \`startup_failure\` at 0-3 seconds. The graceful skip in \`publish-apt-repo.yml\`'s body (which checks if the secret is empty and sets \`can_publish=false\`) never gets the chance to fire — because the secret-contract validation happens first.

## The fix (1 file, +21/-2)

Two coordinated changes:

1. **\`required: true\` → \`required: false\`** for both \`DEBIAN_GPG_PRIVATE_KEY\` and \`DEBIAN_GPG_KEY_ID\` in the \`workflow_call.secrets\` block. The reusable workflow now accepts an unset secret without aborting at startup; the body's runtime \`Check GPG credentials\` step decides whether to actually publish.

2. **Strengthen \`Check GPG credentials\`** to also test \`DEBIAN_GPG_KEY_ID\` (was only checking \`PRIVATE_KEY\`). A half-configured repo where only one is set was previously a foot-gun — \`gpg_check\` let it through and \`reprepro\` would fail downstream with a less obvious error.

## Net effect

- **Today** (without admin configuring secrets): every release-tag of \`elizaos-os-full-release.yml\` completes with a clean \`::warning::DEBIAN_GPG_PRIVATE_KEY not configured. Apt repo publish skipped.\` in place of the previous \`startup_failure\`. The rest of the release (ISO, .deb, VM image, verify, summary) runs to completion.
- **After admin configures** \`DEBIAN_GPG_PRIVATE_KEY\` + \`DEBIAN_GPG_KEY_ID\` in repo secrets: apt-repo publish lights up automatically, no further code change needed.

## Verification

- [x] YAML parses cleanly
- [x] Secrets correctly declared \`required: false\`
- [ ] Manual workflow_dispatch run after merge to confirm publish-apt-repo doesn't startup_failure when called without those secrets
- [ ] Re-tag a release after merge to confirm \`elizaos-os-full-release.yml\` runs end-to-end (without apt publish)

## Related

- packages/os/docs/ci-cd-prod-roadmap.md (PR #7949) documented this gap as one of the two scaffolded-but-broken release paths — this is the fix for the \`startup_failure (0–3 sec) on every release tag\` row.
- Once this lands + PR #7950 lands (nightly unblock), the full SLSA / SHA256SUMS / SBOM release pipeline can actually mint + publish for the first time.
- Documented in HANDOFF_2026-05-25 memory.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `startup_failure` that blocked every release-tag run of `elizaos-os-full-release.yml` by relaxing the `workflow_call.secrets` contract for `DEBIAN_GPG_PRIVATE_KEY` and `DEBIAN_GPG_KEY_ID` from `required: true` to `required: false`, allowing the workflow body's existing graceful-skip logic to run instead of failing at GitHub's pre-job secret validation.

- **Core fix**: `required: true` → `required: false` for both GPG secrets; the existing `Check GPG credentials` step already emits a warning and sets `can_publish=false` when the key is absent, so the rest of the release (ISO, .deb, VM image, verify, manifest) now completes cleanly even without GPG secrets configured.
- **Enhancement (over-reaches)**: The PR also adds `DEBIAN_GPG_KEY_ID` to the credential check as an `elif` guard, but `DEBIAN_GPG_KEY_ID` is never consumed by any subsequent step — `Import GPG key` derives the fingerprint dynamically and `distributions` uses `SignWith: default` — so this new gate will silently skip a fully-functional publish configuration if only `DEBIAN_GPG_PRIVATE_KEY` is set.

<h3>Confidence Score: 3/5</h3>

The required→optional change is correct and safe to merge; the new DEBIAN_GPG_KEY_ID guard in the credential check introduces a false gate against a working configuration.

The `DEBIAN_GPG_KEY_ID` credential check blocks publishing whenever the secret is absent, even though no downstream step (`Import GPG key`, `reprepro`, `gpg --armor --export`) actually reads it — the distributions file uses `SignWith: default` and key fingerprints are derived from the imported key. An admin who configures only `DEBIAN_GPG_PRIVATE_KEY` and `DEBIAN_GPG_PASSPHRASE` (a complete and working setup) will see apt publishing silently skipped with a misleading warning.

.github/workflows/publish-apt-repo.yml — specifically the `Check GPG credentials` step's new `elif` branch and the addition of `DEBIAN_GPG_KEY_ID` to its `env:` block.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/publish-apt-repo.yml | Correctly relaxes `required: true` → `required: false` for GPG secrets, unblocking release startup; however the new `DEBIAN_GPG_KEY_ID` guard in `Check GPG credentials` checks a secret that is never used by any downstream publish step, and will silently skip a valid publish configuration. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Release tag pushed] --> B[elizaos-os-full-release.yml starts]
    B --> C{Before PR: required: true\nvalidated by GitHub pre-job}
    C -->|DEBIAN_GPG_PRIVATE_KEY\nnot configured| D[startup_failure 0-3 sec\nno logs]
    B --> E{After PR: required: false\nworkflow body runs}
    E --> F[Check GPG credentials step]
    F -->|PRIVATE_KEY empty| G[warning + can_publish=false\nPublish skipped cleanly]
    F -->|PRIVATE_KEY set\nKEY_ID empty| H[warning + can_publish=false\nPublish skipped ⚠️\nKEY_ID unused downstream]
    F -->|Both set| I[can_publish=true]
    I --> J[Import GPG key\nfingerprint derived dynamically]
    J --> K[reprepro SignWith: default]
    K --> L[Apt repo published]
    G --> M[Rest of release: ISO .deb VM verify manifest]
    H --> M
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): make publish-apt-repo GPG secre..."](https://github.com/elizaos/eliza/commit/48d4b6d4a8be9efa4fd400e79c38c07f435bb54f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33784338)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->