### PR TITLE
fix(ci): make missing release manifest a clear skip, not an opaque ENOENT

### DIFF
--- a/.github/workflows/elizaos-os-full-release.yml
+++ b/.github/workflows/elizaos-os-full-release.yml
@@ -121,7 +121,25 @@ jobs:
         with:
           path: ./_artifacts
           merge-multiple: true
+      - name: Check manifest file exists
+        id: manifest_check
+        # The manifest file is hand-maintained per beta cycle. If it is
+        # missing (or got renamed without this workflow being updated)
+        # every downstream step would fail with ENOENT inside a Node
+        # readFileSync — a confusing 1-2 min failure with no clear call
+        # to action. Surface it explicitly so the maintainer either adds
+        # the manifest, updates this hardcoded path, or accepts the skip.
+        env:
+          MANIFEST_PATH: packages/os/release/beta-2026-05-16/manifest.json
+        run: |
+          if [ -f "$MANIFEST_PATH" ]; then
+            echo "can_validate_manifest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Release manifest $MANIFEST_PATH not found. Manifest population + canonical SHA256SUMS + SLSA-over-SHA256SUMS attestation skipped. Per-artifact SLSA attestations from build-linux-iso.yml / build-debian-package.yml / build-vm-image.yml still mint correctly."
+            echo "can_validate_manifest=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Populate manifest with real sha256 + sizes
+        if: steps.manifest_check.outputs.can_validate_manifest == 'true'
         # Discovery is driven by the *manifest filename* — each entry's
         # `filename` is searched verbatim under ./_artifacts. This keeps
         # the workflow and manifest in lock-step: rename in the manifest,
@@ -159,6 +177,7 @@ jobs:
           done <<< "$ids"
 
       - name: Gate on publishable checksums (before status promotion)
+        if: steps.manifest_check.outputs.can_validate_manifest == 'true'
         # Status promotion is gated on strict validation. If any artifact
         # is missing a real checksum, the release stays "candidate" and
         # this job fails — no half-published manifest.
@@ -168,6 +187,7 @@ jobs:
             --require-publishable-checksums
 
       - name: Generate canonical SHA256SUMS via the in-repo tool
+        if: steps.manifest_check.outputs.can_validate_manifest == 'true'
         # Runs BEFORE manifest promotion so that any failure here prevents
         # the "available" status from being set and uploaded. SHA256SUMS
         # generation is a hard prerequisite for promotion — closing the
@@ -189,6 +209,7 @@ jobs:
           cat ./_artifacts/SHA256SUMS
 
       - name: Attest SLSA build provenance over SHA256SUMS
+        if: steps.manifest_check.outputs.can_validate_manifest == 'true'
         # Mints a single Sigstore-signed in-toto/SLSA provenance
         # attestation that covers every release artifact via its hash,
         # by attesting the canonical SHA256SUMS file generated above.
@@ -202,6 +223,7 @@ jobs:
           subject-path: ./_artifacts/SHA256SUMS
 
       - name: Upload SHA256SUMS artifact
+        if: steps.manifest_check.outputs.can_validate_manifest == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: elizaos-release-checksums
@@ -209,6 +231,7 @@ jobs:
           retention-days: 90
 
       - name: Promote release status to available
+        if: steps.manifest_check.outputs.can_validate_manifest == 'true'
         run: |
           set -euo pipefail
           node -e '
@@ -220,6 +243,7 @@ jobs:
           '
 
       - name: Upload populated manifest
+        if: steps.manifest_check.outputs.can_validate_manifest == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: elizaos-os-release-manifest-published
@@ -227,7 +251,7 @@ jobs:
           retention-days: 90
 
       - name: Attach SHA256SUMS to release
-        if: github.event_name == 'release'
+        if: github.event_name == 'release' && steps.manifest_check.outputs.can_validate_manifest == 'true'
         uses: softprops/action-gh-release@v3
         with:
           files: ./_artifacts/SHA256SUMS


### PR DESCRIPTION
## The bug (latent — would surface as soon as #7976 lands)

\`populate-and-validate-manifest\` in \`elizaos-os-full-release.yml\` hardcodes the manifest path \`packages/os/release/beta-2026-05-16/manifest.json\` — and **that file does not exist** in develop (only \`packages/os/release/schema/\` does). Today this is masked by #7976's startup_failure (the workflow never starts so it never gets here). Once #7976 lands and the workflow actually runs, this job will fail at ~1-2 min with a Node ENOENT inside \`JSON.parse(readFileSync(MANIFEST))\` — confusing for the maintainer triaging the new failure.

## The fix (1 file, +25/-1)

Add an explicit \`Check manifest file exists\` step at the top of the job, then gate every downstream step that reads/writes the manifest or its SHA256SUMS derivative on the resulting \`can_validate_manifest\` output. Mirrors the same pattern the GPG-secrets-optional fix uses in #7976.

### Net behaviour

**Manifest file present** → Job runs end to end as designed: populates checksums, generates canonical SHA256SUMS, mints SLSA-over-SHA256SUMS attestation, uploads the populated manifest, optionally attaches to GitHub release.

**Manifest file absent (today's state)** → Job emits one \`::warning::\` explaining what was skipped and why, then completes green. **Per-artifact SLSA attestations from \`build-linux-iso.yml\` / \`build-debian-package.yml\` / \`build-vm-image.yml\` still mint correctly** — only the cross-artifact SHA256SUMS bundle is skipped.

### Steps gated (all share the same \`if:\` for one source of truth)

- Populate manifest with real sha256 + sizes
- Gate on publishable checksums (before status promotion)
- Generate canonical SHA256SUMS via the in-repo tool
- Attest SLSA build provenance over SHA256SUMS
- Upload SHA256SUMS artifact
- Promote release status to available
- Upload populated manifest
- Attach SHA256SUMS to release

## What's NOT in this PR

The manifest path stays hardcoded — separate question of whether to parameterize it by release tag (e.g. \`packages/os/release/\${tag}/manifest.json\`), owned by whoever decides the release cadence. This PR is the safety net so the release pipeline doesn't trip on missing manifest before that decision lands.

## Verification

- [x] YAML parses cleanly
- [x] All 8 manifest-touching steps gated on \`steps.manifest_check.outputs.can_validate_manifest == 'true'\` (verified via grep)
- [ ] First post-#7976 release-tag run confirms the warning-and-continue path works

## Related

- #7976 — release workflow startup_failure fix (must land first or together; this PR is the next-fail-mode-safety-net)
- packages/os/docs/ci-cd-prod-roadmap.md (PR #7949) — broader release-pipeline plan
- Documented in HANDOFF_2026-05-25 memory

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a pre-flight existence check for the hardcoded release manifest and gates all 8 downstream manifest-touching steps on the result, turning a confusing Node ENOENT into a structured `::warning::` skip. The logic mirrors the GPG-optional pattern from #7976.

- **New guard step** (`Check manifest file exists`, id: `manifest_check`) checks for `packages/os/release/beta-2026-05-16/manifest.json` after checkout and sets `can_validate_manifest` to `true`/`false`; every subsequent step that reads or writes the manifest or its SHA256SUMS derivative is now gated on `steps.manifest_check.outputs.can_validate_manifest == 'true'`.
- **Absent-manifest path** emits a single `::warning::` noting what was skipped, then exits green — per-artifact SLSA attestations from the individual build workflows are unaffected.
- **Present-manifest path** is unchanged end-to-end: populate checksums → gate → generate SHA256SUMS → SLSA attestation → upload → promote status → attach to release.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the guard behaves correctly for both the manifest-present and manifest-absent cases, and no existing happy-path behavior changes.

The step-scoped MANIFEST_PATH env var in the check step is not reused by the 5 downstream steps, all of which independently hardcode the same path. If a maintainer updates MANIFEST_PATH for the next release cycle but misses a downstream reference, the guard opens the gate while the downstream readFileSync still hits ENOENT — recreating the failure this PR is designed to prevent. Otherwise the change is mechanical and well-structured.

.github/workflows/elizaos-os-full-release.yml — specifically the 6 separate hardcoded copies of the manifest path that must stay in sync when the release cycle changes

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/elizaos-os-full-release.yml | Adds an explicit manifest-existence guard step and gates all 8 manifest-touching steps on its output; the manifest path is correctly checked but remains decoupled across 6 separate hardcoded references |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[actions/checkout] --> B[Download all release artifacts]
    B --> C{Check manifest file exists\npackages/os/release/beta-2026-05-16/manifest.json}
    C -- "can_validate_manifest=false\n::warning:: emitted" --> Z[Job completes green\nno manifest steps run]
    C -- "can_validate_manifest=true" --> D[Populate manifest with real sha256 + sizes]
    D --> E[Gate on publishable checksums]
    E --> F[Generate canonical SHA256SUMS]
    F --> G[Attest SLSA build provenance over SHA256SUMS]
    G --> H[Upload SHA256SUMS artifact]
    H --> I[Promote release status to available]
    I --> J[Upload populated manifest]
    J --> K{github.event_name == 'release'?}
    K -- Yes --> L[Attach SHA256SUMS to release]
    K -- No --> M[Done]
    L --> M
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): make missing release manifest a..."](https://github.com/elizaos/eliza/commit/bdbbe6675645b2d071aa0aa9c28114634193173e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33786253)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->