### PR TITLE
fix(ci): downgrade required-true secrets to required-false across 3 reusable workflows

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -13,14 +13,22 @@ on:
         required: true
         type: string
     secrets:
+      # ANDROID_KEYSTORE_* are downgraded to `required: false` so the
+      # reusable-workflow secret contract does not block startup when
+      # called from release-all.yml / release-orchestrator.yml with
+      # `secrets: inherit`. The job body's signing step (gated on
+      # ANDROID_KEYSTORE_BASE64 being non-empty) skips with a clear
+      # warning when the secrets are absent, instead of aborting the
+      # whole release pipeline at workflow startup with no logs. Same
+      # pattern as publish-apt-repo.yml (PR #7976) and update-homebrew.yml.
       ANDROID_KEYSTORE_BASE64:
-        required: true
+        required: false
       ANDROID_KEYSTORE_PASSWORD:
-        required: true
+        required: false
       ANDROID_KEY_ALIAS:
-        required: true
+        required: false
       ANDROID_KEY_PASSWORD:
-        required: true
+        required: false
       PLAY_STORE_SERVICE_ACCOUNT_JSON:
         required: false
   workflow_dispatch:

--- a/.github/workflows/apple-store-release.yml
+++ b/.github/workflows/apple-store-release.yml
@@ -18,10 +18,20 @@ on:
         required: true
         type: string
     secrets:
+      # APPLE_ID, APPLE_TEAM_ID, APPLE_APP_SPECIFIC_PASSWORD are
+      # downgraded to `required: false` so this reusable workflow's
+      # secret contract does not startup_failure the parent
+      # (release-all.yml / release-orchestrator.yml) when called via
+      # `secrets: inherit` and the secrets are absent. The body's
+      # iOS-signing preflight checks for missing iOS secrets and
+      # exits with a clear ::error::, so the job still fails loudly
+      # when it can't sign — just inside the job, not at the parent
+      # workflow's startup. Same pattern as publish-apt-repo.yml
+      # (PR #7976), android-release.yml, update-homebrew.yml.
       APPLE_ID:
-        required: true
+        required: false
       APPLE_TEAM_ID:
-        required: true
+        required: false
       ITC_TEAM_ID:
         required: false
       APP_STORE_APP_ID:
@@ -33,7 +43,7 @@ on:
       MATCH_GIT_BASIC_AUTHORIZATION:
         required: false
       APPLE_APP_SPECIFIC_PASSWORD:
-        required: true
+        required: false
       MAS_CSC_LINK:
         required: false
       MAS_CSC_KEY_PASSWORD:

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -14,8 +14,14 @@ on:
         required: true
         type: string
     secrets:
+      # Marked `required: false` so this reusable workflow's secret
+      # contract does not abort the parent at startup when called via
+      # `secrets: inherit` from release-orchestrator.yml. The job body
+      # now has a Check credentials step that emits a warning + skips
+      # the dispatch when HOMEBREW_TAP_TOKEN is empty. Mirrors the
+      # pattern used in publish-apt-repo.yml (PR #7976).
       HOMEBREW_TAP_TOKEN:
-        required: true
+        required: false
   workflow_dispatch:
     inputs:
       version:
@@ -36,7 +42,20 @@ jobs:
     name: Trigger Homebrew tap update
     runs-on: ubuntu-24.04
     steps:
+      - name: Check credentials
+        id: creds
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          if [[ -z "$HOMEBREW_TAP_TOKEN" ]]; then
+            echo "::warning::HOMEBREW_TAP_TOKEN not configured. Homebrew tap update skipped."
+            echo "can_dispatch=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "can_dispatch=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Determine version
+        if: steps.creds.outputs.can_dispatch == 'true'
         id: meta
         run: |
           VERSION="${{ inputs.version }}"
@@ -45,6 +64,7 @@ jobs:
           echo "Triggering Homebrew update for version: $VERSION"
 
       - name: Dispatch to homebrew-tap
+        if: steps.creds.outputs.can_dispatch == 'true'
         uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}


### PR DESCRIPTION
## The bug

Same root cause as PR #7976. Three reusable workflows declare \`secrets: { FOO: required: true }\`. Every parent workflow that calls them via \`secrets: inherit\` and doesn't have the secret configured **startup_failures at 0-3 seconds with no logs.**

\`release-all.yml\` triggers on tag push (\`v*.*.*\`) and inherits to 5 reusable workflows. Has **3 confirmed startup_failure runs on 2026-05-20 alone**:

\`\`\`
release-all.yml: startup_failure  push  2026-05-20T10:30:52Z
                 startup_failure  push  2026-05-20T05:25:47Z
                 startup_failure  push  2026-05-20T05:24:17Z
\`\`\`

Every tag push from now until secrets are configured aborts the release at startup.

## The fix (3 files, +46/-8)

### update-homebrew.yml
- \`HOMEBREW_TAP_TOKEN\` → \`required: false\`
- **+** new \`Check credentials\` early-exit step that mirrors the publish-apt-repo.yml pattern. The body was a one-step dispatch with no existing skip path to gate on, so we add one.

### android-release.yml
- All 4 KEYSTORE secrets → \`required: false\`
- **No body change needed** — the existing "Android signing preflight" step (line 186-201) already fails the job loudly when the keystore is empty. Only the workflow_call contract needed flipping.

### apple-store-release.yml
- \`APPLE_ID\` / \`APPLE_TEAM_ID\` / \`APPLE_APP_SPECIFIC_PASSWORD\` → \`required: false\`
- **No body change needed** — the existing iOS signing preflight (line 185) emits \`::error::\` for missing iOS secrets.

## Net effect

**Before** — \`release-all.yml\` on tag push: \`startup_failure\` at 0-3 sec, no logs, no path to know what's missing without reading the callees by hand.

**After**: \`release-all.yml\` startup succeeds. Per-target jobs that lack secrets fail loudly with their existing in-job preflight error messages (or with a clear \`::warning::\` skip in the homebrew case). **Failed targets don't poison the others** — Linux ISO + Debian package release paths complete even if Android/Apple/Homebrew can't sign.

Sets the table for releases to actually publish once secrets are configured. The maintainer playbook for configuring the GPG/apt subset is in PR #7979 (\`packages/os/docs/admin-apt-repo-setup.md\`); equivalent playbooks for ANDROID_KEYSTORE_* and APPLE_* could follow if you want them.

## Verification

- [x] YAML parses cleanly on all 3 files (\`python3 -c 'import yaml; ...'\`)
- [x] Every secret in the affected workflows now reports \`required=False\` (verified via the same parse)
- [x] Bodies retain their existing in-job preflight checks — no signing actually gets attempted with empty secrets, just fails inside the job instead of at parent startup
- [ ] First post-merge tag push run on \`v*.*.*\` confirms \`release-all.yml\` startup succeeds + per-target failures are cleanly isolated

## Related

- #7976 — the parent pattern (publish-apt-repo.yml GPG fix). This PR generalizes the same fix to the remaining 3 reusable workflows that had the same bug.
- #7978 — the next-fail-mode safety net inside elizaos-os-full-release.yml's populate-and-validate-manifest job.
- #7979 — admin playbook for configuring DEBIAN_GPG_* secrets (the apt-repo half of the same pipeline).
- Documented in HANDOFF_2026-05-25 memory.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `startup_failure` issues in `release-all.yml` by downgrading `required: true` secrets to `required: false` in three reusable workflows (`android-release.yml`, `apple-store-release.yml`, `update-homebrew.yml`). When a parent workflow calls these via `secrets: inherit` and the secrets aren't configured, the result is now a controlled per-job failure (or graceful skip for Homebrew) rather than an opaque 0-3 second startup abort with no logs.

- **`android-release.yml`**: All 4 `ANDROID_KEYSTORE_*` secrets changed to `required: false`; the pre-existing \"Android signing preflight\" step still catches missing secrets inside the job with `exit 1`.
- **`apple-store-release.yml`**: `APPLE_ID`, `APPLE_TEAM_ID`, and `APPLE_APP_SPECIFIC_PASSWORD` changed to `required: false`; the pre-existing `Validate iOS secrets` step still blocks the build if signing material is absent.
- **`update-homebrew.yml`**: `HOMEBREW_TAP_TOKEN` changed to `required: false`, with a new `Check credentials` step that emits a `::warning::` and gates remaining steps on `can_dispatch == 'true'`, so the job completes cleanly when the token is unconfigured.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the secret-contract fix is correct and the new Homebrew credential gate is well-structured.

The three declarative changes are clearly correct and each file's existing in-job preflight still enforces signing requirements. The one gap worth watching is in `apple-store-release.yml`: the newly-optional `APPLE_ID`, `APPLE_TEAM_ID`, and `APPLE_APP_SPECIFIC_PASSWORD` aren't included in the `Validate iOS secrets` preflight, so a configuration missing only those three secrets will sail past the preflight and fail later at a less obvious point in the job.

`apple-store-release.yml` — the `Validate iOS secrets` step should be extended to cover the three Apple credentials now declared as optional.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/update-homebrew.yml | Adds `Check credentials` step that gates dispatch on token presence; `required: false` prevents parent startup failure. Logic is correct — `can_dispatch` output properly guards both downstream steps. |
| .github/workflows/android-release.yml | Declarative-only change: 4 keystore secrets set to `required: false`. Existing preflight still enforces them with `exit 1` inside the job. No logic change needed. |
| .github/workflows/apple-store-release.yml | Declarative-only change: APPLE_ID, APPLE_TEAM_ID, APPLE_APP_SPECIFIC_PASSWORD set to `required: false`. The existing `Validate iOS secrets` preflight does not explicitly check these three, but fails later in the job if they're absent. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[release-all.yml\ntag push v*.*.*] -->|secrets: inherit| B[update-homebrew.yml]
    A -->|secrets: inherit| C[android-release.yml]
    A -->|secrets: inherit| D[apple-store-release.yml]

    B --> B1{HOMEBREW_TAP_TOKEN\npresent?}
    B1 -->|No| B2[::warning:: skip\njob SUCCESS]
    B1 -->|Yes| B3[Dispatch to homebrew-tap\njob SUCCESS]

    C --> C1[Build Android packages...]
    C1 --> C2[Decode keystore]
    C2 --> C3{Signing secrets\npresent?}
    C3 -->|No| C4[::error:: missing secrets\nexit 1 — job FAIL]
    C3 -->|Yes| C5[Sign & publish APK/AAB\njob SUCCESS]

    D --> D1[Build iOS assets]
    D1 --> D2{Validate iOS\nsigning secrets}
    D2 -->|Missing| D3[::error:: missing secrets\nexit 1 — job FAIL]
    D2 -->|Present| D4[Sign & publish IPA\njob SUCCESS]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/apple-store-release.yml`, line 191-209 ([link](https://github.com/elizaos/eliza/blob/40c48fa44d6fb35f9cb5d1d09ded48f5196ec006/.github/workflows/apple-store-release.yml#L191-L209)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Preflight gap: APPLE_ID / APPLE_TEAM_ID / APPLE_APP_SPECIFIC_PASSWORD not validated**

   The three secrets newly downgraded to `required: false` (`APPLE_ID`, `APPLE_TEAM_ID`, `APPLE_APP_SPECIFIC_PASSWORD`) are absent from the `Validate iOS secrets` preflight check. If those are the only missing credentials, the preflight exits cleanly and the job runs into a deeper, less-obvious failure when notarization or App Store Connect submission actually tries to use them. The existing check covers `MATCH_GIT_URL`, `MATCH_PASSWORD`, `MATCH_GIT_BASIC_AUTHORIZATION`, `ITC_TEAM_ID`, and `APP_STORE_APP_ID`, but not the Apple credentials themselves. Worth adding them to the missing-list scan so the job still fails fast and loudly at the preflight step.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(ci): downgrade required-true secrets..."](https://github.com/elizaos/eliza/commit/40c48fa44d6fb35f9cb5d1d09ded48f5196ec006) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33788642)</sub>

<!-- /greptile_comment -->