### PR TITLE
fix(agent-image): build plugin-worker-runtime so cloud agents boot

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -129,7 +129,9 @@ jobs:
           (cd packages/contracts && bun run build)
           node packages/shared/scripts/generate-keywords.mjs --target ts
           (cd packages/core && bun run build.ts --node-only)
-          for pkg in packages/shared packages/cloud-sdk packages/cloud-routing packages/skills packages/ui; do
+          # security → plugin-remote-manifest → plugin-worker-runtime: ordered by
+          # build-time type deps; agent boot ERR_MODULE_NOT_FOUNDs without their dist.
+          for pkg in packages/shared packages/cloud-sdk packages/cloud-routing packages/skills packages/ui packages/security packages/plugin-remote-manifest packages/plugin-worker-runtime; do
             if [[ -f "$pkg/package.json" ]] && jq -e '.scripts.build' "$pkg/package.json" >/dev/null; then
               echo "::group::Building $pkg"
               (cd "$pkg" && bun install --no-frozen-lockfile --ignore-scripts && bun run build)

--- a/packages/agent/src/services/remote-plugin-bridge.ts
+++ b/packages/agent/src/services/remote-plugin-bridge.ts
@@ -39,7 +39,12 @@ import type {
   WorkerRpcMessage,
   WorkerRpcResultMessage,
 } from "@elizaos/plugin-remote-manifest";
-import { fromWireError, toWireError } from "@elizaos/plugin-worker-runtime";
+// ./error subpath, not the barrel: the barrel eagerly loads ./bootstrap's heavy
+// runtime chain, which crashed agent boot in the cloud image.
+import {
+  fromWireError,
+  toWireError,
+} from "@elizaos/plugin-worker-runtime/error";
 
 /** Transport contract the bridge talks to. */
 export interface BridgeChannel {

--- a/packages/plugin-worker-runtime/package.json
+++ b/packages/plugin-worker-runtime/package.json
@@ -29,6 +29,11 @@
     "typescript": "^6.0.3"
   },
   "exports": {
+    "./error": {
+      "types": "./dist/error.d.ts",
+      "import": "./dist/error.js",
+      "default": "./dist/error.js"
+    },
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",


### PR DESCRIPTION
## Summary

Every provisioned cloud agent crashes at boot:

```
[eliza-autonomous] Failed to start: ERR_MODULE_NOT_FOUND
Cannot find module '.../plugin-worker-runtime/dist/index.js'
```

Root cause: the cloud agent image (`:stable`, built from `Dockerfile.ci` via `build-agent-image.yml`) never built `packages/plugin-worker-runtime` — it was absent from the workflow's workspace build loop, so no `dist/` shipped. `packages/agent` statically imports it from `remote-plugin-bridge`, so the missing module takes down the whole agent process.

Found while validating end-to-end provisioning after the Robot→Cloud control-plane migration: the container now provisions correctly (cloud config + per-agent key injected, `plugin-elizacloud` loaded), but the agent process itself crashed on this import.

## Changes

1. **`build-agent-image.yml`** — add `security → plugin-remote-manifest → plugin-worker-runtime` to the build loop, ordered by build-time type deps (`plugin-remote-manifest` needs `security`'s dist; `tsconfig.build` has `paths:{}` so it resolves deps via `node_modules`).
2. **`plugin-worker-runtime/package.json`** — expose a `./error` subpath. `dist/error.js` is self-contained (only type-imports, zero runtime `@elizaos` deps).
3. **`remote-plugin-bridge.ts`** — import `fromWireError`/`toWireError` from `./error` instead of the barrel, which eagerly loads `./bootstrap`'s heavy runtime chain. The bridge only needs wire-error (de)serialization.

## Test plan

- [x] Built `security`, `plugin-remote-manifest`, `plugin-worker-runtime` in order locally → `dist/error.{js,d.ts}` produced.
- [x] `dist/error.js` has zero runtime imports (`grep import/require` empty) → safe subpath.
- [x] biome clean on changed files.
- [ ] Post-merge to main: `:stable` rebuilds with the dist → provision a cloud agent → it boots past the bridge import and reaches healthy (no ERR_MODULE_NOT_FOUND).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a production boot crash in all cloud agents (`ERR_MODULE_NOT_FOUND` for `plugin-worker-runtime/dist/index.js`) by ensuring the three required packages are built before the Docker image is assembled, and by switching the `remote-plugin-bridge` import to a lightweight subpath that avoids eager-loading the full bootstrap chain.

- **`build-agent-image.yml`**: Appends `packages/security → packages/plugin-remote-manifest → packages/plugin-worker-runtime` to the build loop in correct dependency order, so `dist/` artifacts are present in the image.
- **`packages/plugin-worker-runtime/package.json`**: Adds a `./error` subpath export backed by `dist/error.js`, which compiles to a zero-runtime-dep module (only a `type`-import from `plugin-remote-manifest` that TypeScript erases at emit).
- **`packages/agent/src/services/remote-plugin-bridge.ts`**: Switches the `fromWireError`/`toWireError` import to `@elizaos/plugin-worker-runtime/error` to avoid pulling in the bootstrap chain on agent startup.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all three changes are tightly scoped to the boot crash fix and don't touch agent logic.

The workflow and import changes are correct and well-ordered. The only gap is that the workflow path filter doesn't yet include the three newly-built packages, so future changes to those packages alone won't trigger a rebuild.

.github/workflows/build-agent-image.yml — the on.push.paths filter should be extended to cover the three packages now part of the build loop.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-agent-image.yml | Adds packages/security, packages/plugin-remote-manifest, and packages/plugin-worker-runtime to the build loop in correct dependency order; fixes ERR_MODULE_NOT_FOUND at agent boot. The paths filter is missing these new packages, so future changes to them won't auto-trigger a rebuild. |
| packages/agent/src/services/remote-plugin-bridge.ts | Import changed from the barrel (@elizaos/plugin-worker-runtime) to the targeted subpath (/error) to avoid eagerly loading bootstrap's heavy runtime chain; functional logic unchanged. |
| packages/plugin-worker-runtime/package.json | New ./error subpath export added, pointing to dist/error.js and dist/error.d.ts; the source file uses only type-only imports so the compiled output is runtime-dependency-free. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph CI["build-agent-image.yml — Build loop (after fix)"]
        C[packages/contracts] --> CORE[packages/core]
        CORE --> LOOP
        subgraph LOOP["for-loop"]
            S1[packages/shared]
            S2[packages/cloud-sdk]
            S3[packages/cloud-routing]
            S4[packages/skills]
            S5[packages/ui]
            S6[packages/security]:::new
            S7[packages/plugin-remote-manifest]:::new
            S8[packages/plugin-worker-runtime]:::new
        end
    end

    subgraph IMPORT["remote-plugin-bridge.ts import (after fix)"]
        RB["remote-plugin-bridge.ts"]
        RB -->|"@elizaos/plugin-worker-runtime/error"| ERR["dist/error.js\n(standalone, zero runtime deps)"]:::new
        RB -. "avoided: barrel → bootstrap\n→ heavy runtime chain" .-> BOOT["bootstrap chain"]:::old
    end

    classDef new fill:#d4edda,stroke:#28a745
    classDef old fill:#f8d7da,stroke:#dc3545,stroke-dasharray:4
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/build-agent-image.yml`, line 14-24 ([link](https://github.com/elizaos/eliza/blob/32ff7b40fa9ebf05e3672330af73e50c965ed6ef/.github/workflows/build-agent-image.yml#L14-L24)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The three newly-built packages (`packages/security`, `packages/plugin-remote-manifest`, `packages/plugin-worker-runtime`) are absent from the workflow's `on.push.paths` filter. A change scoped to only those packages — say, a patch to `error.ts` or a security dependency bump — won't trigger the image rebuild, silently shipping stale artifacts.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(agent-image): build plugin-worker-ru..."](https://github.com/elizaos/eliza/commit/32ff7b40fa9ebf05e3672330af73e50c965ed6ef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33791363)</sub>

<!-- /greptile_comment -->