### PR TITLE
fix: use https for omnivoice.cpp submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -27,7 +27,7 @@
 	# build (packages/app-core/scripts/omnivoice-fuse/) grafts sources from
 	# this tree into the llama.cpp fork at fuse time.
 	path = plugins/plugin-local-inference/native/omnivoice.cpp
-	url = http://github.com/elizaOS/omnivoice.cpp
+	url = https://github.com/elizaOS/omnivoice.cpp.git
 	branch = master
 
 [submodule "plugins/plugin-local-inference/native/whisper.cpp"]


### PR DESCRIPTION
## Summary

The `omnivoice.cpp` submodule in `.gitmodules` is registered with `http://github.com/elizaOS/omnivoice.cpp` (plain HTTP, port 80). GitHub no longer accepts unencrypted HTTP, so `git submodule update --init --recursive` fails on every fresh clone:

```
fatal: unable to access 'http://github.com/elizaOS/omnivoice.cpp/':
  Failed to connect to github.com port 80 after 21083 ms
fatal: clone of 'http://github.com/elizaOS/omnivoice.cpp' into submodule path 'plugins/plugin-local-inference/native/omnivoice.cpp' failed
Failed to clone 'plugins/plugin-local-inference/native/omnivoice.cpp' a second time, aborting
```

Reproduced today running `./install --profile all` against a fresh clone — the failure surfaces inside `restore-local-eliza-workspace`'s `git submodule update --init --recursive` step.

This PR switches the URL to `https://github.com/elizaOS/omnivoice.cpp.git`, matching the style and protocol of every other submodule entry in this file (`llama.cpp`, `whisper.cpp`, `opencode`, `asimov-1`, `electrobun` — all `https://...git`).

## Test plan

- [x] `curl -sI https://github.com/elizaOS/omnivoice.cpp` → 200 (target URL exists and is reachable)
- [x] Local `.gitmodules` edited and committed
- [ ] After merge: rerun `git submodule update --init --recursive` on a fresh clone and confirm omnivoice.cpp clones cleanly alongside the other nested submodules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the `omnivoice.cpp` submodule URL in `.gitmodules` to use HTTPS and adds the `.git` suffix, resolving a connection failure that blocked `git submodule update --init --recursive` on fresh clones.

- The URL is updated from `http://github.com/elizaOS/omnivoice.cpp` to `https://github.com/elizaOS/omnivoice.cpp.git`, bringing it in line with every other submodule entry (`llama.cpp`, `whisper.cpp`, `opencode`, `asimov-1`, `electrobun`).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted URL correction with no logic or code impact.

The only change is correcting the omnivoice.cpp submodule URL from plain HTTP to HTTPS with a .git suffix. This is a direct fix for a known connection failure and exactly matches the format used by all other submodules in the file. There is no risk of regression.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .gitmodules | Fixes omnivoice.cpp submodule URL from plain HTTP to HTTPS and adds .git suffix, matching all other submodule entries in the file. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[git submodule update --init --recursive] --> B{omnivoice.cpp URL}
    B -- "Before: http://github.com/elizaOS/omnivoice.cpp" --> C[GitHub rejects plain HTTP]
    C --> D["fatal: Failed to connect to github.com port 80"]
    B -- "After: https://github.com/elizaOS/omnivoice.cpp.git" --> E[GitHub accepts HTTPS]
    E --> F[omnivoice.cpp clones successfully]
```

<sub>Reviews (1): Last reviewed commit: ["fix: use https for omnivoice.cpp submodu..."](https://github.com/elizaos/eliza/commit/0a4c20da49a95011bdc66a4bd2a1da52db2568e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33796375)</sub>

<!-- /greptile_comment -->