### PR TITLE
feat(ui): clouds/avatar home + opt-in os pill + chat composer visibility + startup recovery

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2797,6 +2797,15 @@
         "vitest": "^4.0.0",
       },
     },
+    "packages/workflows": {
+      "name": "@elizaos/workflows",
+      "version": "2.0.3",
+      "devDependencies": {
+        "@biomejs/biome": "^2.4.14",
+        "@types/node": "^25.1.0",
+        "typescript": "^6.0.3",
+      },
+    },
     "plugins/app-model-tester": {
       "name": "@elizaos/app-model-tester",
       "version": "2.0.3",
@@ -3872,11 +3881,7 @@
       "peerDependencies": {
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
-        "node-llama-cpp": "*",
       },
-      "optionalPeers": [
-        "node-llama-cpp",
-      ],
     },
     "plugins/plugin-local-storage": {
       "name": "@elizaos/plugin-local-storage",
@@ -5264,10 +5269,9 @@
       "name": "@elizaos/plugin-workflow",
       "version": "2.0.3",
       "dependencies": {
+        "@elizaos/workflows": "workspace:*",
         "drizzle-orm": "^0.45.1",
-        "effect": "^3.21.1",
         "quickjs-emscripten": "0.32.0",
-        "smithers-orchestrator": "0.20.4",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.14",
@@ -5930,26 +5934,6 @@
 
     "@edge-runtime/vm": ["@edge-runtime/vm@3.2.0", "", { "dependencies": { "@edge-runtime/primitives": "4.1.0" } }, "sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw=="],
 
-    "@effect/cluster": ["@effect/cluster@0.58.2", "", { "dependencies": { "kubernetes-types": "^1.30.0" }, "peerDependencies": { "@effect/platform": "^0.96.1", "@effect/rpc": "^0.75.1", "@effect/sql": "^0.51.1", "@effect/workflow": "^0.18.0", "effect": "^3.21.2" } }, "sha512-oxQ3zUhXq0mJA7Y4TliALMP39Bx0LtAIxcqOW1Bdjh6uk+nG7kul/Puw80SwlcYGv3ul50SG+gvSRUTXB8d3JQ=="],
-
-    "@effect/experimental": ["@effect/experimental@0.60.0", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/platform": "^0.96.0", "effect": "^3.21.0", "ioredis": "^5", "lmdb": "^3" }, "optionalPeers": ["ioredis", "lmdb"] }, "sha512-i5zIg7Xup2KgHyqHlYtkgqSE1bNzCL0GbbTQxrpIzKF0q/ebknOk/ox8B/gIq2vImjoEE81h/oxU+6i1NH210g=="],
-
-    "@effect/opentelemetry": ["@effect/opentelemetry@0.63.0", "", { "peerDependencies": { "@effect/platform": "^0.96.0", "@opentelemetry/api": "^1.9", "@opentelemetry/resources": "^2.0.0", "@opentelemetry/sdk-logs": ">=0.203.0 <0.300.0", "@opentelemetry/sdk-metrics": "^2.0.0", "@opentelemetry/sdk-trace-base": "^2.0.0", "@opentelemetry/sdk-trace-node": "^2.0.0", "@opentelemetry/sdk-trace-web": "^2.0.0", "@opentelemetry/semantic-conventions": "^1.33.0", "effect": "^3.21.0" } }, "sha512-2yUG2QWNATi1uKP0kwhaP5eLp+c5NDzAL3EOpIcGLBAC0cbXZrx4n9Qw/QwUKxpuV+pbhrBUPCiByyWAFKfuCw=="],
-
-    "@effect/platform": ["@effect/platform@0.96.1", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.10", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.21.2" } }, "sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A=="],
-
-    "@effect/platform-bun": ["@effect/platform-bun@0.89.0", "", { "dependencies": { "@effect/platform-node-shared": "^0.59.0", "multipasta": "^0.2.7" }, "peerDependencies": { "@effect/cluster": "^0.58.0", "@effect/platform": "^0.96.0", "@effect/rpc": "^0.75.0", "@effect/sql": "^0.51.0", "effect": "^3.21.0" } }, "sha512-ReT5f2vujJfffMOBexrgwJd2RLxgfr2G0c1FyCsoflcjdQJ7RZE3cwHDp1M3hAzmG67wWAssMHqLsX6H/n27sQ=="],
-
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@0.59.0", "", { "dependencies": { "@parcel/watcher": "^2.5.1", "multipasta": "^0.2.7", "ws": "^8.18.2" }, "peerDependencies": { "@effect/cluster": "^0.58.0", "@effect/platform": "^0.96.0", "@effect/rpc": "^0.75.0", "@effect/sql": "^0.51.0", "effect": "^3.21.0" } }, "sha512-3bq2YKKfLY7UFauZSxqZUneCXoA3SMSls82V+0RKunvRlfPuPQW0hVn6t1RkvEdh0PDoygWG2mZXYQa6Iqgp9A=="],
-
-    "@effect/rpc": ["@effect/rpc@0.75.1", "", { "dependencies": { "msgpackr": "^1.11.10" }, "peerDependencies": { "@effect/platform": "^0.96.1", "effect": "^3.21.2" } }, "sha512-8yxF8+mMGGEbF8BUCp34HjdJj7CvTpGeZxBcpsDF6v7zPiGbJL1UDLzA8ZqYjmcngBHhPecbmeONTk/LiLAaEg=="],
-
-    "@effect/sql": ["@effect/sql@0.51.1", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.1", "effect": "^3.21.2" } }, "sha512-iPDAefrJcI0HcTk9keP9Gq8Pg08K1HmpnmZZt85AqyTcvorhoNsXDFiKBbPldfV2CortwVkacX8KjO9GPpSYCA=="],
-
-    "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@0.52.0", "", { "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.0", "@effect/sql": "^0.51.0", "effect": "^3.21.0" } }, "sha512-iqQ7SvSNxq0HLjKW5IQ29FsCTzOD1CuX1wuBEuPLLgPCvuEykEHLn4zDrs2qJ+O3CBEUm4kiCy29tmfHE7uAdw=="],
-
-    "@effect/workflow": ["@effect/workflow@0.18.1", "", { "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.1", "@effect/rpc": "^0.75.1", "effect": "^3.21.2" } }, "sha512-FxsUxkyvd7CyN7tw4bQgmAJv8tf8hUwy72bwGYzKGpeuiEObiUKgO1pg8xM49gB6EtwOdVRJhytwcFc8eM/6ow=="],
-
     "@electric-sql/pglite": ["@electric-sql/pglite@0.4.5", "", {}, "sha512-aGG2zGEyZzGWKy8P+9ZoNUV0jxt1+hgbeTf+bVAYyxVZZLXg3/9aFlfLxb08AYZVAfAkQlQIysmWjhc5hwDG8g=="],
 
     "@electron/get": ["@electron/get@5.0.0", "", { "dependencies": { "debug": "^4.1.1", "env-paths": "^3.0.0", "graceful-fs": "^4.2.11", "progress": "^2.0.3", "semver": "^7.6.3", "sumchecker": "^3.0.1" }, "optionalDependencies": { "undici": "^7.24.4" } }, "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA=="],
@@ -6431,6 +6415,8 @@
     "@elizaos/vercel-edge-examples": ["@elizaos/vercel-edge-examples@workspace:packages/examples/vercel"],
 
     "@elizaos/vitest-vite": ["vite@7.3.3", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA=="],
+
+    "@elizaos/workflows": ["@elizaos/workflows@workspace:packages/workflows"],
 
     "@elysiajs/cors": ["@elysiajs/cors@1.4.2", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-FTCcbH35brTLigF1W7BYySRZomgI/dBEMK9BgK9RP9Nez7zmpGh4koL/Yr1BFv8nYz7CfhRvcM8d/c+XnwMaVQ=="],
 
@@ -7136,8 +7122,6 @@
 
     "@matrix-org/matrix-sdk-crypto-wasm": ["@matrix-org/matrix-sdk-crypto-wasm@18.3.0", "", {}, "sha512-9a4feyt8QLysARu7PHKaRWT+wcCd+IYH074LXp9QK5WqfN4zUXueRhiSSMNT18Bm+8q3sBR/4zxDxOSDR0M8Kg=="],
 
-    "@mdx-js/esbuild": ["@mdx-js/esbuild@3.1.1", "", { "dependencies": { "@mdx-js/mdx": "^3.0.0", "@types/unist": "^3.0.0", "source-map": "^0.7.0", "vfile": "^6.0.0", "vfile-message": "^4.0.0" }, "peerDependencies": { "esbuild": ">=0.14.0" } }, "sha512-NS35VhTdvKNj5/B1JSD5W3kN1R0WDHgk+zCWq+tSChQw5L2Bgeiz7yyZPFrc5LWuPVOxE1xMbJr82bO9VVzmfQ=="],
-
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@mdx-js/react": ["@mdx-js/react@3.1.1", "", { "dependencies": { "@types/mdx": "^2.0.0" }, "peerDependencies": { "@types/react": ">=16", "react": ">=16" } }, "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw=="],
@@ -7188,8 +7172,6 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0-alpha.2", "", { "dependencies": { "zod": "^4.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-gmLgdHzlYM8L7Aw/+VE0kxjT25WKamtUSLNhdOgrJq5CrESvqVSoAfWSJJeNPUXNTluQ+dYDGFbKVitdsJtbPA=="],
-
     "@moltbook/eliza-agent": ["@moltbook/eliza-agent@workspace:packages/examples/moltbook"],
 
     "@monaco-editor/loader": ["@monaco-editor/loader@1.7.0", "", { "dependencies": { "state-local": "^1.0.6" } }, "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA=="],
@@ -7215,18 +7197,6 @@
     "@motionone/vue": ["@motionone/vue@10.16.4", "", { "dependencies": { "@motionone/dom": "^10.16.4", "tslib": "^2.3.1" } }, "sha512-z10PF9JV6SbjFq+/rYabM+8CVlMokgl8RFGvieSGNTmrkQanfHn+15XBrhG3BgUfvmTeSeyShfOHpG0i9zEdcg=="],
 
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
-
-    "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
-
-    "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw=="],
-
-    "@msgpackr-extract/msgpackr-extract-linux-arm": ["@msgpackr-extract/msgpackr-extract-linux-arm@3.0.3", "", { "os": "linux", "cpu": "arm" }, "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw=="],
-
-    "@msgpackr-extract/msgpackr-extract-linux-arm64": ["@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg=="],
-
-    "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg=="],
-
-    "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
 
     "@multiformats/dns": ["@multiformats/dns@1.0.13", "", { "dependencies": { "@dnsquery/dns-packet": "^6.1.1", "@libp2p/interface": "^3.1.0", "hashlru": "^2.3.0", "p-queue": "^9.0.0", "progress-events": "^1.0.0", "uint8arrays": "^5.0.2" } }, "sha512-yr4bxtA3MbvJ+2461kYIYMsiiZj/FIqKI64hE4SdvWJUdWF9EtZLar38juf20Sf5tguXKFUruluswAO6JsjS2w=="],
 
@@ -7626,10 +7596,6 @@
 
     "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
 
-    "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@2.7.1", "", { "dependencies": { "@opentelemetry/context-async-hooks": "2.7.1", "@opentelemetry/core": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-pCpQxU68lV+I9s9svqMyVu5iHdDDUnqUpSxqwyCU8A9ejEsSnMPCbearwsUO4yk08ZJzAIUCFuReMdVQvHrdvg=="],
-
-    "@opentelemetry/sdk-trace-web": ["@opentelemetry/sdk-trace-web@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-K806OouCSOjMd8Nr7+ZCq3QT22tdAzzS/7h8vprfiKjkgFQ99/dvwU8d12WJANA6D5Qtme65hyBAqAu9CkQuxQ=="],
-
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
     "@opentelemetry/sql-common": ["@opentelemetry/sql-common@0.41.2", "", { "dependencies": { "@opentelemetry/core": "^2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0" } }, "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ=="],
@@ -7757,34 +7723,6 @@
     "@oxc-transform/binding-win32-ia32-msvc": ["@oxc-transform/binding-win32-ia32-msvc@0.111.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-A6ztCXpoSHt6PbvGAFqB0MLOcGG7ZJrrPXY1iB0zfOB1atLgI8oNePGxPl03XSbwpiTsFJ1oo8rj9DXcBzgT9g=="],
 
     "@oxc-transform/binding-win32-x64-msvc": ["@oxc-transform/binding-win32-x64-msvc@0.111.0", "", { "os": "win32", "cpu": "x64" }, "sha512-QddKW4kBH0Wof6Y65eYCNHM4iOGmCTWLLcNYY1FGswhzmTYOUVXajNROR+iCXAOFnOF0ldtsR79SyqgyHH1Bgg=="],
-
-    "@parcel/watcher": ["@parcel/watcher@2.5.6", "", { "dependencies": { "detect-libc": "^2.0.3", "is-glob": "^4.0.3", "node-addon-api": "^7.0.0", "picomatch": "^4.0.3" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.6", "@parcel/watcher-darwin-arm64": "2.5.6", "@parcel/watcher-darwin-x64": "2.5.6", "@parcel/watcher-freebsd-x64": "2.5.6", "@parcel/watcher-linux-arm-glibc": "2.5.6", "@parcel/watcher-linux-arm-musl": "2.5.6", "@parcel/watcher-linux-arm64-glibc": "2.5.6", "@parcel/watcher-linux-arm64-musl": "2.5.6", "@parcel/watcher-linux-x64-glibc": "2.5.6", "@parcel/watcher-linux-x64-musl": "2.5.6", "@parcel/watcher-win32-arm64": "2.5.6", "@parcel/watcher-win32-ia32": "2.5.6", "@parcel/watcher-win32-x64": "2.5.6" } }, "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ=="],
-
-    "@parcel/watcher-android-arm64": ["@parcel/watcher-android-arm64@2.5.6", "", { "os": "android", "cpu": "arm64" }, "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A=="],
-
-    "@parcel/watcher-darwin-arm64": ["@parcel/watcher-darwin-arm64@2.5.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA=="],
-
-    "@parcel/watcher-darwin-x64": ["@parcel/watcher-darwin-x64@2.5.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg=="],
-
-    "@parcel/watcher-freebsd-x64": ["@parcel/watcher-freebsd-x64@2.5.6", "", { "os": "freebsd", "cpu": "x64" }, "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng=="],
-
-    "@parcel/watcher-linux-arm-glibc": ["@parcel/watcher-linux-arm-glibc@2.5.6", "", { "os": "linux", "cpu": "arm" }, "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ=="],
-
-    "@parcel/watcher-linux-arm-musl": ["@parcel/watcher-linux-arm-musl@2.5.6", "", { "os": "linux", "cpu": "arm" }, "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg=="],
-
-    "@parcel/watcher-linux-arm64-glibc": ["@parcel/watcher-linux-arm64-glibc@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA=="],
-
-    "@parcel/watcher-linux-arm64-musl": ["@parcel/watcher-linux-arm64-musl@2.5.6", "", { "os": "linux", "cpu": "arm64" }, "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA=="],
-
-    "@parcel/watcher-linux-x64-glibc": ["@parcel/watcher-linux-x64-glibc@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ=="],
-
-    "@parcel/watcher-linux-x64-musl": ["@parcel/watcher-linux-x64-musl@2.5.6", "", { "os": "linux", "cpu": "x64" }, "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg=="],
-
-    "@parcel/watcher-win32-arm64": ["@parcel/watcher-win32-arm64@2.5.6", "", { "os": "win32", "cpu": "arm64" }, "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q=="],
-
-    "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.6", "", { "os": "win32", "cpu": "ia32" }, "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g=="],
-
-    "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.6", "", { "os": "win32", "cpu": "x64" }, "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw=="],
 
     "@particle-network/analytics": ["@particle-network/analytics@1.0.2", "", { "dependencies": { "hash.js": "^1.1.7", "uuidv4": "^6.2.13" } }, "sha512-E4EpTRYcfNOkxj+bgNdQydBrvdLGo4HfVStZCuOr3967dYek30r6L7Nkaa9zJXRE2eGT4lPvcAXDV2WxDZl/Xg=="],
 
@@ -8210,8 +8148,6 @@
 
     "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
 
-    "@scalar/openapi-types": ["@scalar/openapi-types@0.8.0", "", {}, "sha512-WmaxVSfvY5K/TwcG2B2TU1WOe1As1uc2s7myswtP6dBlcjU3hM08SApxv/jmyGaCE8t4gO5BBhmHY4pDUfmr2g=="],
-
     "@scarf/scarf": ["@scarf/scarf@1.4.0", "", {}, "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ=="],
 
     "@scure/base": ["@scure/base@1.2.6", "", {}, "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg=="],
@@ -8347,54 +8283,6 @@
     "@slack/types": ["@slack/types@2.21.1", "", {}, "sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ=="],
 
     "@slack/web-api": ["@slack/web-api@7.15.2", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.21.0", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.15.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-/m9qVFkiq85Oa/FSQwYIRDa/AO4qNYkDh4sRBK1WqEc2+RyG7w4tbU6rBIwUOcc/TmWOIr24Nraquxg7um5mYw=="],
-
-    "@smithers-orchestrator/accounts": ["@smithers-orchestrator/accounts@0.20.4", "", { "dependencies": { "@smithers-orchestrator/errors": "0.20.4" } }, "sha512-lF5iR0CEhxtk9tGlIF+BqfbrCn/yUR4vOpa4ZIKPrl2OJTBOU2BMeBvbJuMAHCG87jpye/ba3giLg3R++8Fmhg=="],
-
-    "@smithers-orchestrator/agents": ["@smithers-orchestrator/agents@0.20.4", "", { "dependencies": { "@ai-sdk/anthropic": "^3.0.71", "@ai-sdk/openai": "^3.0.53", "@smithers-orchestrator/driver": "0.20.4", "@smithers-orchestrator/errors": "0.20.4", "@smithers-orchestrator/observability": "0.20.4", "ai": "^6.0.168", "effect": "^3.21.1", "zod": "^4.3.6" } }, "sha512-oQxfNo+IQGV5nitQ0oGBXVfuFm9kZjRgtsRIk4bHW9dhDF/OekfWyXI1PY++yGJ4kS3wr/6okKs03NExSDuIvA=="],
-
-    "@smithers-orchestrator/cli": ["@smithers-orchestrator/cli@0.20.4", "", { "dependencies": { "@clack/prompts": "^0.10.1", "@effect/workflow": "^0.18.0", "@mdx-js/esbuild": "^3.1.1", "@modelcontextprotocol/sdk": "^1.29.0", "@smithers-orchestrator/accounts": "0.20.4", "@smithers-orchestrator/agents": "0.20.4", "@smithers-orchestrator/components": "0.20.4", "@smithers-orchestrator/db": "0.20.4", "@smithers-orchestrator/devtools": "0.20.4", "@smithers-orchestrator/driver": "0.20.4", "@smithers-orchestrator/engine": "0.20.4", "@smithers-orchestrator/errors": "0.20.4", "@smithers-orchestrator/memory": "0.20.4", "@smithers-orchestrator/observability": "0.20.4", "@smithers-orchestrator/openapi": "0.20.4", "@smithers-orchestrator/protocol": "0.20.4", "@smithers-orchestrator/scheduler": "0.20.4", "@smithers-orchestrator/server": "0.20.4", "@smithers-orchestrator/time-travel": "0.20.4", "cron-parser": "^5.5.0", "drizzle-orm": "^0.45.2", "effect": "^3.21.1", "incur": "^0.4.1", "picocolors": "^1.1.1", "react": "^19.2.5", "zod": "^4.3.6" } }, "sha512-6RcCddOc6LlSFZ3S484o6hzenUI3R6j8TenzZ54i7XLkJoeKqcriQ2xuXq0MEwVxHGiiu+RgGaEjrw9JVSs42w=="],
-
-    "@smithers-orchestrator/components": ["@smithers-orchestrator/components@0.20.4", "", { "dependencies": { "@smithers-orchestrator/agents": "0.20.4", "@smithers-orchestrator/db": "0.20.4", "@smithers-orchestrator/driver": "0.20.4", "@smithers-orchestrator/errors": "0.20.4", "@smithers-orchestrator/graph": "0.20.4", "@smithers-orchestrator/memory": "0.20.4", "@smithers-orchestrator/observability": "0.20.4", "@smithers-orchestrator/react-reconciler": "0.20.4", "@smithers-orchestrator/scheduler": "0.20.4", "bippy": "^0.5.39", "react": "^19.2.5", "react-dom": "^19.2.5", "zod": "^4.3.6" } }, "sha512-WWoYT6jGoNqXvzj1wzLFjUwRUr2jlf8++XCqWFSTrf+7ADV05LWzkj+OZeCuvJ7nWqrJAqawr9fgJ/2rUy8MaQ=="],
-
-    "@smithers-orchestrator/db": ["@smithers-orchestrator/db@0.20.4", "", { "dependencies": { "@effect/experimental": "^0.60.0", "@effect/sql": "^0.51.0", "@smithers-orchestrator/errors": "0.20.4", "@smithers-orchestrator/graph": "0.20.4", "@smithers-orchestrator/observability": "0.20.4", "@smithers-orchestrator/scheduler": "0.20.4", "drizzle-orm": "^0.45.2", "drizzle-zod": "^0.8.3", "effect": "^3.21.1", "zod": "^4.3.6" } }, "sha512-Pd3C9Dz12nfW8Prkc2f15NDXrp9Lp/XLh4gdOQ0zhLAvlG20yb2RKx9qScaCM2H0t3qy6//NVeYzR7dcHex63A=="],
-
-    "@smithers-orchestrator/devtools": ["@smithers-orchestrator/devtools@0.20.4", "", {}, "sha512-m4QWLMcytCNBhas2EKiOxnwJf7f6L1cu25CuKhVXHxKbJisEQr7Hg5k1NL0IPbdTBCMWMFyZls8vKCyKxnDxpQ=="],
-
-    "@smithers-orchestrator/driver": ["@smithers-orchestrator/driver@0.20.4", "", { "dependencies": { "@smithers-orchestrator/db": "0.20.4", "@smithers-orchestrator/errors": "0.20.4", "@smithers-orchestrator/graph": "0.20.4", "@smithers-orchestrator/observability": "0.20.4", "@smithers-orchestrator/scheduler": "0.20.4", "effect": "^3.21.1", "zod": "^4.3.6" } }, "sha512-A95NM0DZa8jHJUK8hPu7zW7BcsWr3PiUA14BEV9fvAuAHY/Vw/xySsau0Fo8Sm1yl6VRAnU2s2tZ5YUT2E6Kdw=="],
-
-    "@smithers-orchestrator/engine": ["@smithers-orchestrator/engine@0.20.4", "", { "dependencies": { "@effect/cluster": "^0.58.0", "@effect/experimental": "^0.60.0", "@effect/platform-bun": "^0.89.0", "@effect/rpc": "^0.75.0", "@effect/sql": "^0.51.0", "@effect/sql-sqlite-bun": "^0.52.0", "@effect/workflow": "^0.18.0", "@smithers-orchestrator/agents": "0.20.4", "@smithers-orchestrator/components": "0.20.4", "@smithers-orchestrator/db": "0.20.4", "@smithers-orchestrator/driver": "0.20.4", "@smithers-orchestrator/errors": "0.20.4", "@smithers-orchestrator/graph": "0.20.4", "@smithers-orchestrator/observability": "0.20.4", "@smithers-orchestrator/react-reconciler": "0.20.4", "@smithers-orchestrator/sandbox": "0.20.4", "@smithers-orchestrator/scheduler": "0.20.4", "@smithers-orchestrator/scorers": "0.20.4", "@smithers-orchestrator/time-travel": "0.20.4", "@smithers-orchestrator/vcs": "0.20.4", "diff": "^9.0.0", "drizzle-orm": "^0.45.2", "effect": "^3.21.1", "react": "^19.2.5", "react-dom": "^19.2.5", "zod": "^4.3.6" } }, "sha512-Zlf0AekhunsOZW5VqWIfS2lkAgG/HgHNK8l+79rxAjHnLvaLFiJqwitV+0aqxn7OyuyGg5Y65FKJljfntG5QPg=="],
-
-    "@smithers-orchestrator/errors": ["@smithers-orchestrator/errors@0.20.4", "", { "dependencies": { "effect": "^3.21.1" } }, "sha512-TM7TglM8cMsG6Pvsf638hMw7MFxIalI/FovQwuMTpgmlwkEzcjaHibf3k1WCmUSqR/k5co2iMnLsBz9dP6unag=="],
-
-    "@smithers-orchestrator/gateway": ["@smithers-orchestrator/gateway@0.20.4", "", {}, "sha512-rs+wYQO6eu4otjbcA2mq/hibsVof4RYe8YdTl5gFR1RtG1nvvK9Qs11tpjOOD+n9mFw9tztzRq6cTZOYOhNFAQ=="],
-
-    "@smithers-orchestrator/gateway-client": ["@smithers-orchestrator/gateway-client@0.20.4", "", { "dependencies": { "@smithers-orchestrator/gateway": "0.20.4" } }, "sha512-0tBHTBpMjii4MA9vW1MWUFb95/2NIQRaWbjDlcqE++mManm0LKZeatlMiMcg88WkpRhngcLAG3nyY8sWajmZnA=="],
-
-    "@smithers-orchestrator/gateway-react": ["@smithers-orchestrator/gateway-react@0.20.4", "", { "dependencies": { "@smithers-orchestrator/gateway": "0.20.4", "@smithers-orchestrator/gateway-client": "0.20.4" }, "peerDependencies": { "react": "^19.0.0", "react-dom": "^19.0.0" } }, "sha512-7XtGwUzU6jmPtm32eH80DQbYG0+F7fjziKcFVsWGCoUfg9wjNuGlDY8Bny/nqOij9cL8LpuxBwmTJm5QpAN+Hg=="],
-
-    "@smithers-orchestrator/graph": ["@smithers-orchestrator/graph@0.20.4", "", { "dependencies": { "@smithers-orchestrator/errors": "0.20.4", "drizzle-orm": "^0.45.2", "zod": "^4.3.6" } }, "sha512-HHd5zX7lCMhYa0Yxs1WavhwPSsUeMIDu/4cqIp32uyfZleBZ6tYsv4t23Hn7OVmHyv7GmkowS99sriLedzyRUQ=="],
-
-    "@smithers-orchestrator/memory": ["@smithers-orchestrator/memory@0.20.4", "", { "dependencies": { "@smithers-orchestrator/db": "0.20.4", "@smithers-orchestrator/errors": "0.20.4", "@smithers-orchestrator/graph": "0.20.4", "@smithers-orchestrator/observability": "0.20.4", "@smithers-orchestrator/scheduler": "0.20.4", "drizzle-orm": "^0.45.2", "effect": "^3.21.1", "zod": "^4.3.6" } }, "sha512-uEQZl0vWSy/5cYUZ/XG2Yvxh9PH24/7Z+AYKlssVCNGrZbNHwn66wNbFTtzSX35ba1RTptliAKFziy/O78z7aw=="],
-
-    "@smithers-orchestrator/observability": ["@smithers-orchestrator/observability@0.20.4", "", { "dependencies": { "@effect/opentelemetry": "^0.63.0", "@effect/platform": "^0.96.0", "@effect/platform-bun": "^0.89.0", "@smithers-orchestrator/agents": "0.20.4", "effect": "^3.21.1" } }, "sha512-F014PsC0XVjwTRk6lO/H81W7C2mkz2oN7mOTyz+MLiTziu76FEeFQjxGcMx+XjLy9H9VLBMp/+3s8ObpUHDjhg=="],
-
-    "@smithers-orchestrator/openapi": ["@smithers-orchestrator/openapi@0.20.4", "", { "dependencies": { "@smithers-orchestrator/errors": "0.20.4", "@smithers-orchestrator/observability": "0.20.4", "@smithers-orchestrator/scheduler": "0.20.4", "ai": "^6.0.168", "effect": "^3.21.1", "yaml": "^2.8.3", "zod": "^4.3.6" } }, "sha512-2zjmjGPFpm0nvMLbQGxzo2NYmOFjSwFFeWZjLO/16yPcKzeR17/PxsiAjP9zsxdLy4Lywa/bGK/P/f3P+ujdbQ=="],
-
-    "@smithers-orchestrator/protocol": ["@smithers-orchestrator/protocol@0.20.4", "", {}, "sha512-8Cyg0zRzJqBKXsoh/LRh5/zWLrhT05pucTkBLhbH+rbCoXehfJeplm36t5M71+yMdbCnhVwGxarn9GGfKetSgw=="],
-
-    "@smithers-orchestrator/react-reconciler": ["@smithers-orchestrator/react-reconciler@0.20.4", "", { "dependencies": { "@smithers-orchestrator/devtools": "0.20.4", "@smithers-orchestrator/driver": "0.20.4", "@smithers-orchestrator/errors": "0.20.4", "@smithers-orchestrator/graph": "0.20.4", "bippy": "^0.5.39", "react": "^19.2.5", "react-reconciler": "^0.33.0" } }, "sha512-9f2gG/penKZGOm0fcEmHdPjxragEwdrMvX9JoCYiHyKDdROtR1jkqa2h4FqlqXL5LfsVCb+Mh6q+PanOQOPUdA=="],
-
-    "@smithers-orchestrator/sandbox": ["@smithers-orchestrator/sandbox@0.20.4", "", { "dependencies": { "@effect/cluster": "^0.58.0", "@effect/rpc": "^0.75.0", "@smithers-orchestrator/db": "0.20.4", "@smithers-orchestrator/driver": "0.20.4", "@smithers-orchestrator/errors": "0.20.4", "@smithers-orchestrator/observability": "0.20.4", "@smithers-orchestrator/scheduler": "0.20.4", "effect": "^3.21.1" } }, "sha512-nxSg1GjAITx1axXkRj2JcXStcjNCoVe5c2jWlEf+xZR+yE9p+nQ6NVG2nYF11RvPDvlvcFylIkrhIQVRUdhYog=="],
-
-    "@smithers-orchestrator/scheduler": ["@smithers-orchestrator/scheduler@0.20.4", "", { "dependencies": { "@smithers-orchestrator/errors": "0.20.4", "@smithers-orchestrator/graph": "0.20.4", "effect": "^3.21.1" } }, "sha512-YtxHHcOovOqcoZEMU6++34IEQtQJsRSRXLTNCmJqodbC6gVgsHVLskwzy68pdFSsx0H9FDlTGvFERKZoZQ71Jw=="],
-
-    "@smithers-orchestrator/scorers": ["@smithers-orchestrator/scorers@0.20.4", "", { "dependencies": { "@smithers-orchestrator/agents": "0.20.4", "@smithers-orchestrator/db": "0.20.4", "@smithers-orchestrator/errors": "0.20.4", "@smithers-orchestrator/graph": "0.20.4", "@smithers-orchestrator/observability": "0.20.4", "@smithers-orchestrator/scheduler": "0.20.4", "drizzle-orm": "^0.45.2", "effect": "^3.21.1", "zod": "^4.3.6" } }, "sha512-rYDBtOYkBzcDkEosdAmH8i3ES537y4KWFC2wkrSEbkyJWAB7lrzHDFgX0taQJFcd/EpIFNI4n/VPIF6/jj0pNg=="],
-
-    "@smithers-orchestrator/server": ["@smithers-orchestrator/server@0.20.4", "", { "dependencies": { "@effect/workflow": "^0.18.0", "@smithers-orchestrator/components": "0.20.4", "@smithers-orchestrator/db": "0.20.4", "@smithers-orchestrator/devtools": "0.20.4", "@smithers-orchestrator/driver": "0.20.4", "@smithers-orchestrator/engine": "0.20.4", "@smithers-orchestrator/errors": "0.20.4", "@smithers-orchestrator/gateway": "0.20.4", "@smithers-orchestrator/observability": "0.20.4", "@smithers-orchestrator/protocol": "0.20.4", "@smithers-orchestrator/scheduler": "0.20.4", "@smithers-orchestrator/time-travel": "0.20.4", "cron-parser": "^5.5.0", "drizzle-orm": "^0.45.2", "effect": "^3.21.1", "hono": "^4.12.14", "ws": "^8.20.0" } }, "sha512-6t9bQjJ4I/AizF3J9COTFLJdkSSrix/oabVRc0JYJs3t+cIK2v5Iz6JkdwHi8gzFSEDxVXYyI1YdwyYj/aPD4A=="],
-
-    "@smithers-orchestrator/time-travel": ["@smithers-orchestrator/time-travel@0.20.4", "", { "dependencies": { "@effect/platform": "^0.96.0", "@effect/platform-bun": "^0.89.0", "@smithers-orchestrator/db": "0.20.4", "@smithers-orchestrator/errors": "0.20.4", "@smithers-orchestrator/observability": "0.20.4", "@smithers-orchestrator/scheduler": "0.20.4", "@smithers-orchestrator/vcs": "0.20.4", "drizzle-orm": "^0.45.2", "effect": "^3.21.1", "picocolors": "^1.1.1" } }, "sha512-Ln+1k4a5fbNc5H9Gny3JHo3baMP/k+9gzqTXlvMo1CPc7OVPIG1ssVlLQn4liAiBRHOq3UeIkRUa1eaj4ejC+w=="],
-
-    "@smithers-orchestrator/vcs": ["@smithers-orchestrator/vcs@0.20.4", "", { "dependencies": { "@effect/platform": "^0.96.0", "@smithers-orchestrator/observability": "0.20.4", "effect": "^3.21.1" } }, "sha512-Ou9NaVunuCk7ieoZJWd2YRZvhKbijE+Oi2IAFCLsF2/aCpyoyow4H2YqxJ6tSobZGoyurfUNvkDjHecio8u00w=="],
 
     "@smithy/config-resolver": ["@smithy/config-resolver@4.5.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "tslib": "^2.6.2" } }, "sha512-TpS6Am5zSEtx3ow7VynThEL7UwRM06zZZcmFaP6Ij9hqKPfsFhTYCLcgU7gjFjw9QAI2kzwXrfS7InH8BivJTA=="],
 
@@ -8987,8 +8875,6 @@
     "@tokenlens/helpers": ["@tokenlens/helpers@1.3.1", "", { "dependencies": { "@tokenlens/core": "1.3.0", "@tokenlens/fetch": "1.3.0" } }, "sha512-t6yL8N6ES8337E6eVSeH4hCKnPdWkZRFpupy9w5E66Q9IeqQ9IO7XQ6gh12JKjvWiRHuyyJ8MBP5I549Cr41EQ=="],
 
     "@tokenlens/models": ["@tokenlens/models@1.3.0", "", { "dependencies": { "@tokenlens/core": "1.3.0" } }, "sha512-9mx7ZGeewW4ndXAiD7AT1bbCk4OpJeortbjHHyNkgap+pMPPn1chY6R5zqe1ggXIUzZ2l8VOAKfPqOvpcrisJw=="],
-
-    "@toon-format/toon": ["@toon-format/toon@2.3.0", "", {}, "sha512-/Ew9etdRQKVMnm9fDaCG0JjyAOK/O7T0M97oum1aW4W+UR8ZhVVPBanIV7oWgHBiGlnVxV9M55PWQCHofDV07w=="],
 
     "@tootallnate/once": ["@tootallnate/once@2.0.0", "", {}, "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="],
 
@@ -9948,8 +9834,6 @@
 
     "bip66": ["bip66@2.0.0", "", {}, "sha512-kBG+hSpgvZBrkIm9dt5T1Hd/7xGCPEX2npoxAWZfsK1FvjgaxySEh2WizjyIstWXriKo9K9uJ4u0OnsyLDUPXQ=="],
 
-    "bippy": ["bippy@0.5.41", "", { "peerDependencies": { "react": ">=17.0.1" } }, "sha512-jCP2pXXLhXqPrAN+iSEFZmLI4uUM4fjSqajh0K+TmM062VehfDT3ZJNkrTGyN701Z5XMejs9qAudSqkMGhSMKg=="],
-
     "birpc": ["birpc@4.0.0", "", {}, "sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw=="],
 
     "bitcoin-ops": ["bitcoin-ops@1.4.1", "", {}, "sha512-pef6gxZFztEhaE9RY9HmWVmiIHqCb2OyS4HPKkpc6CIiiOa3Qmuoylxc5P2EkU3w+5eTSifI9SEZC88idAIGow=="],
@@ -10540,7 +10424,7 @@
 
     "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
 
-    "diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
+    "diff": ["diff@5.2.2", "", {}, "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A=="],
 
     "diff3": ["diff3@0.0.4", "", {}, "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg=="],
 
@@ -10592,8 +10476,6 @@
 
     "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "prisma": "*", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "prisma", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
 
-    "drizzle-zod": ["drizzle-zod@0.8.3", "", { "peerDependencies": { "drizzle-orm": ">=0.36.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-66yVOuvGhKJnTdiqj1/Xaaz9/qzOdRJADpDa68enqS6g3t0kpNkwNYjUuaeXgZfO/UWuIM9HIhSlJ6C5ZraMww=="],
-
     "dts-resolver": ["dts-resolver@3.0.0", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-1T1f+z+4tl9XD+m+0HBgWoL/nm0bOIffyWaUuUSBlFg/86IWvfx+wjNaO/ybU0AJzG9/Mi5hBUgGV6zCmWEN7Q=="],
 
     "duck": ["duck@0.1.12", "", { "dependencies": { "underscore": "^1.13.1" } }, "sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg=="],
@@ -10617,8 +10499,6 @@
     "edge-runtime": ["edge-runtime@2.5.9", "", { "dependencies": { "@edge-runtime/format": "2.2.1", "@edge-runtime/ponyfill": "2.4.2", "@edge-runtime/vm": "3.2.0", "async-listen": "3.0.1", "mri": "1.2.0", "picocolors": "1.0.0", "pretty-ms": "7.0.1", "signal-exit": "4.0.2", "time-span": "4.0.0" }, "bin": { "edge-runtime": "dist/cli/index.js" } }, "sha512-pk+k0oK0PVXdlT4oRp4lwh+unuKB7Ng4iZ2HB+EZ7QCEQizX360Rp/F4aRpgpRgdP2ufB35N+1KppHmYjqIGSg=="],
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
-
-    "effect": ["effect@3.21.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg=="],
 
     "ejs": ["ejs@5.0.1", "", { "bin": { "ejs": "bin/cli.js" } }, "sha512-COqBPFMxuPTPspXl2DkVYaDS3HtrD1GpzOGkNTJ1IYkifq/r9h8SVEFrjA3D9/VJGOEoMQcrlhpntcSUrM8k6A=="],
 
@@ -10866,8 +10746,6 @@
 
     "fancy-canvas": ["fancy-canvas@2.1.0", "", {}, "sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ=="],
 
-    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
-
     "fast-content-type-parse": ["fast-content-type-parse@3.0.0", "", {}, "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg=="],
 
     "fast-copy": ["fast-copy@3.0.2", "", {}, "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ=="],
@@ -10965,8 +10843,6 @@
     "filter-obj": ["filter-obj@1.1.0", "", {}, "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
-
-    "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -11325,8 +11201,6 @@
     "imul": ["imul@1.0.1", "", {}, "sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
-
-    "incur": ["incur@0.4.6", "", { "dependencies": { "@cfworker/json-schema": "^4.1.1", "@modelcontextprotocol/server": "^2.0.0-alpha.2", "@scalar/openapi-types": "^0.8.0", "@toon-format/toon": "^2.1.0", "tokenx": "^1.3.0", "yaml": "^2.8.2", "zod": "^4.3.6" }, "bin": { "incur": "dist/bin.js", "incur.src": "src/bin.ts" } }, "sha512-vrvmmZmfhU0OOm+KuofBClaYaioJ0JrxPn89Zfp8TDfXOBgWsDXqX5QgZS6FItvizqXEuzaoNiBiRgC5vJazDg=="],
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
@@ -11709,8 +11583,6 @@
     "kolorist": ["kolorist@1.8.0", "", {}, "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="],
 
     "kubernetes-fluent-client": ["kubernetes-fluent-client@3.11.7", "", { "dependencies": { "@kubernetes/client-node": "1.4.0", "http-status-codes": "2.3.0", "js-yaml": "4.1.1", "node-fetch": "2.7.0", "quicktype-core": "23.2.6", "tsx": "4.21.0", "undici": "7.24.6", "yargs": "18.0.0" }, "bin": { "kubernetes-fluent-client": "dist/cli.js" } }, "sha512-2ynNXX2BZIX4WnmNIm55U9QSI5vSED/rTt67M1Uuprfze5UsN67Z0p3WdyLL8DmIN5zHnE1f4MCkv70wfYcuMA=="],
-
-    "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
 
     "kubo-rpc-client": ["kubo-rpc-client@6.1.0", "", { "dependencies": { "@ipld/dag-cbor": "^9.0.0", "@ipld/dag-json": "^10.0.0", "@ipld/dag-pb": "^4.0.0", "@libp2p/crypto": "^5.0.0", "@libp2p/interface": "^3.0.2", "@libp2p/logger": "^6.0.5", "@libp2p/peer-id": "^6.0.3", "@multiformats/multiaddr": "^13.0.1", "@multiformats/multiaddr-to-uri": "^12.0.0", "any-signal": "^4.1.1", "blob-to-it": "^2.0.5", "browser-readablestream-to-it": "^2.0.5", "dag-jose": "^5.0.0", "electron-fetch": "^1.9.1", "err-code": "^3.0.1", "ipfs-unixfs": "^12.0.0", "iso-url": "^1.2.1", "it-all": "^3.0.4", "it-first": "^3.0.4", "it-glob": "^3.0.1", "it-last": "^3.0.4", "it-map": "^3.0.5", "it-peekable": "^3.0.3", "it-to-stream": "^1.0.0", "merge-options": "^3.0.4", "multiformats": "^13.1.0", "nanoid": "^5.0.7", "parse-duration": "^2.1.2", "stream-to-it": "^1.0.1", "uint8arrays": "^5.0.3", "wherearewe": "^2.0.1" } }, "sha512-CH3vcqSGlEhr/HCZYQgYpXxmwIOYhNed4BQmAYmHpX7sehTC3iKK/36x7anEdRTgmV6KB66MyOk1yuhU2HqKFw=="],
 
@@ -12216,15 +12088,9 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "msgpackr": ["msgpackr@1.11.12", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-RBdJ1Un7yGlXWajrkxcSa93nvQ0w4zBf60c0yYv7YtBelP8H2FA7XsfBbMHtXKXUMUxH7zV3Zuozh+kUQWhHvg=="],
-
-    "msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
-
     "multicast-dns": ["multicast-dns@7.2.5", "", { "dependencies": { "dns-packet": "^5.2.2", "thunky": "^1.0.2" }, "bin": { "multicast-dns": "cli.js" } }, "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg=="],
 
     "multiformats": ["multiformats@9.9.0", "", {}, "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="],
-
-    "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
 
     "murmur-128": ["murmur-128@0.2.1", "", { "dependencies": { "encode-utf8": "^1.0.2", "fmix": "^0.1.0", "imul": "^1.0.0" } }, "sha512-WseEgiRkI6aMFBbj8Cg9yBj/y+OdipwVC7zUo3W2W1JAJITwouUOtpqsmGSg67EQmwwSyod7hsVsWY5LsrfQVg=="],
 
@@ -12291,8 +12157,6 @@
     "node-gyp": ["node-gyp@12.3.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "nopt": "^9.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5", "tar": "^7.5.4", "tinyglobby": "^0.2.12", "undici": "^6.25.0", "which": "^6.0.0" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg=="],
 
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
-
-    "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
 
@@ -12744,8 +12608,6 @@
 
     "puppeteer-core": ["puppeteer-core@24.43.1", "", { "dependencies": { "@puppeteer/browsers": "2.13.2", "chromium-bidi": "14.0.0", "debug": "^4.4.3", "devtools-protocol": "0.0.1608973", "typed-query-selector": "^2.12.2", "webdriver-bidi-protocol": "0.4.1", "ws": "^8.20.0" } }, "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw=="],
 
-    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
-
     "pushdata-bitcoin": ["pushdata-bitcoin@1.0.1", "", { "dependencies": { "bitcoin-ops": "^1.3.0" } }, "sha512-hw7rcYTJRAl4olM8Owe8x0fBuJJ+WGbMhQuLWOXEMN3PxPCKQHRkhfL+XG0+iXUmSHjkMmb3Ba55Mt21cZc9kQ=="],
 
     "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
@@ -12867,8 +12729,6 @@
     "react-plaid-link": ["react-plaid-link@4.1.1", "", { "dependencies": { "prop-types": "^15.7.2" }, "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19", "react-dom": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-xzAYWQIT/gk+u6lwFAMEZ20f9+AUsCwVyfm64/iudMsyuWANta4wm3Jb7N+APSwuKIR9VUlTkYDhPjLamIGcPA=="],
 
     "react-qr-reader": ["react-qr-reader@2.2.1", "", { "dependencies": { "jsqr": "^1.2.0", "prop-types": "^15.7.2", "webrtc-adapter": "^7.2.1" }, "peerDependencies": { "react": "~16", "react-dom": "~16" } }, "sha512-EL5JEj53u2yAOgtpAKAVBzD/SiKWn0Bl7AZy6ZrSf1lub7xHwtaXe6XSx36Wbhl1VMGmvmrwYMRwO1aSCT2fwA=="],
-
-    "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
     "react-redux": ["react-redux@9.3.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g=="],
 
@@ -13210,8 +13070,6 @@
 
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
-    "smithers-orchestrator": ["smithers-orchestrator@0.20.4", "", { "dependencies": { "@mdx-js/esbuild": "^3.1.1", "@smithers-orchestrator/agents": "0.20.4", "@smithers-orchestrator/cli": "0.20.4", "@smithers-orchestrator/components": "0.20.4", "@smithers-orchestrator/db": "0.20.4", "@smithers-orchestrator/driver": "0.20.4", "@smithers-orchestrator/engine": "0.20.4", "@smithers-orchestrator/errors": "0.20.4", "@smithers-orchestrator/gateway-client": "0.20.4", "@smithers-orchestrator/gateway-react": "0.20.4", "@smithers-orchestrator/graph": "0.20.4", "@smithers-orchestrator/memory": "0.20.4", "@smithers-orchestrator/observability": "0.20.4", "@smithers-orchestrator/openapi": "0.20.4", "@smithers-orchestrator/react-reconciler": "0.20.4", "@smithers-orchestrator/sandbox": "0.20.4", "@smithers-orchestrator/scheduler": "0.20.4", "@smithers-orchestrator/scorers": "0.20.4", "@smithers-orchestrator/server": "0.20.4", "@smithers-orchestrator/time-travel": "0.20.4", "@smithers-orchestrator/vcs": "0.20.4", "ai": "^6.0.168", "diff": "^9.0.0", "drizzle-orm": "^0.45.2", "effect": "^3.21.1", "incur": "^0.4.1", "react": "^19.2.5", "zod": "^4.3.6" }, "bin": { "smithers": "src/bin/smithers.js" } }, "sha512-5HfkWZRIqErTN3xYFEgMQgxrvpkTHRYDTxnvqr+4GejVFLYu419GGqvZ//s6Ug/668fuLirfUkfTglNMcnP9Cg=="],
-
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
     "socket.io-client": ["socket.io-client@4.8.3", "", { "dependencies": { "@socket.io/component-emitter": "~3.1.0", "debug": "~4.4.1", "engine.io-client": "~6.6.1", "socket.io-parser": "~4.2.4" } }, "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g=="],
@@ -13511,8 +13369,6 @@
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
     "tokenlens": ["tokenlens@1.3.1", "", { "dependencies": { "@tokenlens/core": "1.3.0", "@tokenlens/fetch": "1.3.0", "@tokenlens/helpers": "1.3.1", "@tokenlens/models": "1.3.0" } }, "sha512-7oxmsS5PNCX3z+b+z07hL5vCzlgHKkCGrEQjQmWl5l+v5cUrtL7S1cuST4XThaL1XyjbTX8J5hfP0cjDJRkaLA=="],
-
-    "tokenx": ["tokenx@1.3.0", "", {}, "sha512-NLdXTEZkKiO0gZuLtMoZKjCXTREXeZZt8nnnNeyoXtNZAfG/GKGSbQtLU5STspc0rMSwcA+UJfWZkbNU01iKmQ=="],
 
     "toml": ["toml@3.0.0", "", {}, "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="],
 
@@ -14157,10 +14013,6 @@
     "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
 
     "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
-
-    "@effect/experimental/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
-
-    "@effect/sql/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
 
     "@electron/get/env-paths": ["env-paths@3.0.0", "", {}, "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A=="],
 
@@ -14881,8 +14733,6 @@
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@oxc-transform/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
-
-    "@parcel/watcher/node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
     "@particle-network/solana-wallet/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
@@ -16301,8 +16151,6 @@
     "minipass-sized/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
     "mocha/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
-
-    "mocha/diff": ["diff@5.2.2", "", {}, "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A=="],
 
     "mocha/escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 

--- a/packages/app-core/platforms/electrobun/src/bridge/electrobun-direct-rpc.ts
+++ b/packages/app-core/platforms/electrobun/src/bridge/electrobun-direct-rpc.ts
@@ -14,6 +14,10 @@
 import { Electroview } from "electrobun/view";
 import type { RpcMessageListener } from "../types.js";
 import { getBrowserTabsRendererImpl } from "./browser-tabs-renderer-registry.js";
+import {
+  type ElectrobunBootConfigWindow,
+  updateElectrobunBootConfig,
+} from "./electrobun-boot-config.js";
 import { ensureElectrobunGlobal } from "./electrobun-stub.js";
 
 type RendererRequestHandler = (params: unknown) => Promise<unknown>;
@@ -23,24 +27,7 @@ type RendererBridgeRpc = {
 };
 
 const listenersByRpcMessage: Record<string, Set<RpcMessageListener>> = {};
-const BOOT_CONFIG_STORE_KEY = Symbol.for("elizaos.app.boot-config");
-const BOOT_CONFIG_WINDOW_KEY = "__ELIZA_APP_BOOT_CONFIG__";
 const RENDERER_LOG_MIRROR_KEY = "__ELIZA_ELECTROBUN_LOG_MIRROR__";
-
-type BootConfig = {
-  apiBase?: string;
-  apiToken?: string;
-  [key: string]: unknown;
-};
-
-type BootConfigStore = {
-  current: BootConfig;
-};
-
-type BootConfigWindow = Window & {
-  [BOOT_CONFIG_WINDOW_KEY]?: BootConfig;
-  [BOOT_CONFIG_STORE_KEY]?: BootConfigStore;
-};
 
 function readRecord(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object") {
@@ -76,23 +63,6 @@ function readRequiredNumber(
 // If the built-in preload hasn't fired yet (rare edge case), stub it.
 ensureElectrobunGlobal();
 
-function updateBootConfig(
-  updates: Pick<BootConfig, "apiBase" | "apiToken">,
-): void {
-  const globalObject = window as BootConfigWindow;
-  const currentConfig =
-    globalObject[BOOT_CONFIG_WINDOW_KEY] ??
-    globalObject[BOOT_CONFIG_STORE_KEY]?.current ??
-    {};
-  const nextConfig = {
-    ...currentConfig,
-    ...updates,
-  };
-
-  globalObject[BOOT_CONFIG_WINDOW_KEY] = nextConfig;
-  globalObject[BOOT_CONFIG_STORE_KEY] = { current: nextConfig };
-}
-
 function dispatchMessage(messageName: string, payload: unknown): void {
   if (messageName === "apiBaseUpdate") {
     const apiBaseUpdate = payload as { base: string; token?: string };
@@ -108,7 +78,7 @@ function dispatchMessage(messageName: string, payload: unknown): void {
     // Propagate to boot config so the appClient picks up port changes.
     // We modify it directly instead of importing @elizaos/app-core
     // to prevent bundling React and the entire UI layer into the preload script.
-    updateBootConfig({
+    updateElectrobunBootConfig(window as ElectrobunBootConfigWindow, {
       apiBase: apiBaseUpdate.base,
       ...(apiBaseUpdate.token ? { apiToken: apiBaseUpdate.token } : {}),
     });

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -73,14 +73,17 @@ import {
 } from "./native/mac-window-effects";
 import { getPermissionManager } from "./native/permissions";
 import { checkWebGpuSupport } from "./native/webgpu-browser-support";
-import { createPillWindow } from "./pill-window";
+import { createPillWindow, getPillWindow } from "./pill-window";
 import { printElectrobunDevSettingsBanner } from "./print-electrobun-dev-settings-banner";
 import {
   createRendererApiProxyRequestInit,
   isRendererApiProxyPath,
   resolveRendererProxyIdleTimeoutSeconds,
 } from "./renderer-api-proxy";
-import { resolveRendererAsset } from "./renderer-static";
+import {
+  getRendererAssetContentType,
+  resolveRendererAsset,
+} from "./renderer-static";
 import {
   buildBunRpcHandlers,
   wireBrowserWorkspaceCaller,
@@ -681,23 +684,6 @@ async function startRendererServer(): Promise<string> {
 
   const port = await getPort(5174);
 
-  const mimeTypes: Record<string, string> = {
-    ".html": "text/html; charset=utf-8",
-    ".js": "application/javascript",
-    ".mjs": "application/javascript",
-    ".css": "text/css",
-    ".png": "image/png",
-    ".jpg": "image/jpeg",
-    ".svg": "image/svg+xml",
-    ".ico": "image/x-icon",
-    ".json": "application/json",
-    ".gz": "application/octet-stream",
-    ".wasm": "application/wasm",
-    ".glb": "model/gltf-binary",
-    ".gltf": "model/gltf+json",
-    ".vrm": "model/gltf-binary",
-  };
-
   // Seed the api-base-owner singleton with the initial value so the
   // HTML-inject path and the RPC push path both read the same source of
   // truth. Without this seeding, the static server would inject one value
@@ -740,7 +726,15 @@ async function startRendererServer(): Promise<string> {
         ".m4a",
         ".aac",
         ".flac",
+        ".mp4",
+        ".webm",
         ".glb",
+        ".gltf",
+        ".vrm",
+        ".woff",
+        ".woff2",
+        ".ttf",
+        ".otf",
       ].includes(mimeExt)
     ) {
       return "public, max-age=86400";
@@ -818,7 +812,7 @@ async function startRendererServer(): Promise<string> {
         }
 
         const headers: Record<string, string> = {
-          "Content-Type": mimeTypes[mimeExt] ?? "application/octet-stream",
+          "Content-Type": getRendererAssetContentType(mimeExt),
           "Access-Control-Allow-Origin": "*",
           "Cache-Control": resolveRendererCacheControl(pathname, mimeExt),
         };
@@ -1507,6 +1501,21 @@ function injectApiBase(win: BrowserWindow): void {
   setAgentReady(true);
 }
 
+function injectApiBaseIntoOpenRendererWindows(): void {
+  if (currentWindow) {
+    injectApiBase(currentWindow);
+  }
+
+  const pillWindow = getPillWindow();
+  if (pillWindow && pillWindow !== currentWindow) {
+    injectApiBase(pillWindow);
+  }
+
+  surfaceWindowManager?.forEachWindow((w) => {
+    injectApiBase(w as BrowserWindow);
+  });
+}
+
 /**
  * Push real OS permission states into the agent REST API so the renderer's
  * PermissionsSection shows correct statuses and capability toggles unlock.
@@ -1569,6 +1578,10 @@ async function _startAgent(win: BrowserWindow): Promise<void> {
       await primeDesktopSessionAuth(apiBase, rendererBase);
       const apiToken = resolveApiToken(process.env) ?? "";
       apiBaseOwner.notifyChange(win, rendererBase, apiToken);
+      const pillWindow = getPillWindow();
+      if (pillWindow && pillWindow !== win) {
+        apiBaseOwner.pushToWindow(pillWindow);
+      }
       setAgentReady(true);
       // Sync real OS permission states to the REST API so the renderer
       // can display them and capability toggles can unlock.
@@ -2191,8 +2204,8 @@ async function main(): Promise<void> {
       if (status.port) {
         // The agent rebound to a different loopback port (or recovered from a
         // crash) — the cookies we installed during _startAgent were scoped to
-        // the old origin. Re-prime so the renderer's next /api request stays
-        // authenticated.
+        // the old origin. Re-prime so every renderer's next /api request stays
+        // authenticated, including the OS-level pill window.
         markDesktopSessionStale();
         const apiBase = `http://127.0.0.1:${status.port}`;
         const rendererBase = resolveRendererFacingApiBase(
@@ -2200,12 +2213,7 @@ async function main(): Promise<void> {
           status.port,
         );
         void primeDesktopSessionAuth(apiBase, rendererBase);
-        if (currentWindow) {
-          injectApiBase(currentWindow);
-        }
-        surfaceWindowManager?.forEachWindow((w) => {
-          injectApiBase(w as BrowserWindow);
-        });
+        injectApiBaseIntoOpenRendererWindows();
       }
     }),
   );
@@ -2239,10 +2247,10 @@ async function main(): Promise<void> {
     }
     getFloatingChatManager().configure(url, preload);
     // In kiosk mode the chat pill lives in-canvas on the KioskShell, so we
-    // never spawn the separate native pill toplevel.
+    // never spawn the separate native pill toplevel. Outside kiosk, the pill
+    // loads the same renderer in chat-overlay shell mode so the assistant
+    // lives in its own OS-level window instead of inside the app.
     if (!isKioskShellMode() && shouldCreateDesktopPill()) {
-      // The pill loads the same renderer with `?shell=pill`, which routes to
-      // a minimal <VoicePill> mount in apps/app/src/main.tsx.
       try {
         createPillWindow({ rendererUrl: url, preload });
       } catch (err) {
@@ -2414,7 +2422,7 @@ async function main(): Promise<void> {
       process.env as Record<string, string | undefined>,
     );
     if (rt.mode === "external") {
-      injectApiBase(currentWindow);
+      injectApiBaseIntoOpenRendererWindows();
     } else if (rt.mode === "local") {
       logger.info("[Main] Starting embedded agent (local mode).");
       _startAgent(currentWindow).catch((err) => {

--- a/packages/app-core/platforms/electrobun/src/native/agent-env.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/agent-env.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { applyWindowsNativeInferenceDefaults } from "./agent";
+
+describe("applyWindowsNativeInferenceDefaults", () => {
+  it("sets Windows native inference guards for the child runtime", () => {
+    const env: Record<string, string> = {};
+
+    applyWindowsNativeInferenceDefaults(env, "win32");
+
+    expect(env.ELIZA_DISABLE_LOCAL_EMBEDDINGS).toBe("1");
+    expect(env.GGML_NO_BACKTRACE).toBe("1");
+  });
+
+  it("preserves an explicit GGML_NO_BACKTRACE value", () => {
+    const env: Record<string, string> = {
+      GGML_NO_BACKTRACE: "custom",
+    };
+
+    applyWindowsNativeInferenceDefaults(env, "win32");
+
+    expect(env.GGML_NO_BACKTRACE).toBe("custom");
+  });
+
+  it("does not mutate non-Windows child env", () => {
+    const env: Record<string, string> = {};
+
+    applyWindowsNativeInferenceDefaults(env, "linux");
+
+    expect(env).toEqual({});
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/native/agent.ts
+++ b/packages/app-core/platforms/electrobun/src/native/agent.ts
@@ -214,6 +214,24 @@ function applyDesktopChildStateEnv(childEnv: Record<string, string>): void {
   childEnv.ELIZA_STATE_DIR = stateDir;
 }
 
+export function applyWindowsNativeInferenceDefaults(
+  childEnv: Record<string, string>,
+  platform: NodeJS.Platform = process.platform,
+): void {
+  if (platform !== "win32") return;
+
+  // node-llama-cpp crashes Bun on Windows during packaged startup.
+  // Disable local embeddings until upstream fix lands.
+  childEnv.ELIZA_DISABLE_LOCAL_EMBEDDINGS = "1";
+
+  // The fused elizaOS llama.cpp / OmniVoice runtime can trip GGML's
+  // uncaught-exception backtrace guard inside packaged Bun unless this is set
+  // before any native GGML library is loaded.
+  if (!childEnv.GGML_NO_BACKTRACE?.trim()) {
+    childEnv.GGML_NO_BACKTRACE = "1";
+  }
+}
+
 function listStateEntries(stateDir: string): string[] {
   try {
     return fs
@@ -1458,11 +1476,7 @@ export class AgentManager {
         this.persistStartupDiagnostics();
       }
 
-      // node-llama-cpp crashes Bun on Windows during packaged startup.
-      // Disable local embeddings until upstream fix lands.
-      if (process.platform === "win32") {
-        childEnv.ELIZA_DISABLE_LOCAL_EMBEDDINGS = "1";
-      }
+      applyWindowsNativeInferenceDefaults(childEnv);
 
       if (nodePaths.length > 0) {
         childEnv.NODE_PATH = nodePaths.join(path.delimiter);
@@ -1478,9 +1492,13 @@ export class AgentManager {
       // Ensure bun's directory is on PATH so child_process.exec calls
       // (e.g. plugin-manager running `bun add ...`) can find it.
       const bunDir = path.dirname(bunExecutable);
-      const existingPath = childEnv.PATH;
+      const existingPathKey = childEnv.PATH !== undefined ? "PATH" : "Path";
+      const existingPath =
+        childEnv[existingPathKey] ?? process.env.PATH ?? process.env.Path ?? "";
       if (!existingPath.split(path.delimiter).includes(bunDir)) {
-        childEnv.PATH = bunDir + path.delimiter + existingPath;
+        childEnv[existingPathKey] = existingPath
+          ? bunDir + path.delimiter + existingPath
+          : bunDir;
         diagnosticLog(`[Agent] Prepended bun dir to child PATH: ${bunDir}`);
       }
 

--- a/packages/app-core/platforms/electrobun/src/pill-window.test.ts
+++ b/packages/app-core/platforms/electrobun/src/pill-window.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createWindow: vi.fn(),
+  getPrimaryDisplay: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("electrobun/bun", () => ({
+  BrowserWindow: class BrowserWindow {},
+  Screen: {
+    getPrimaryDisplay: mocks.getPrimaryDisplay,
+  },
+}));
+
+vi.mock("./electrobun-window-options", () => ({
+  createElectrobunBrowserWindow: mocks.createWindow,
+}));
+
+vi.mock("./logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: mocks.info,
+    success: vi.fn(),
+    warn: mocks.warn,
+  },
+}));
+
+describe("pill window", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mocks.createWindow.mockReset();
+    mocks.getPrimaryDisplay.mockReset();
+    mocks.info.mockReset();
+    mocks.warn.mockReset();
+  });
+
+  it("loads the OS pill into the live chat overlay shell route", async () => {
+    const { buildPillRendererUrl } = await import("./pill-window");
+
+    expect(buildPillRendererUrl("http://127.0.0.1:5174/home?old=1#hash")).toBe(
+      "http://127.0.0.1:5174/home?shellMode=chat-overlay",
+    );
+  });
+
+  it("creates a bottom-centered transparent always-on-top window", async () => {
+    const closeHandlers: Array<() => void> = [];
+    const setAlwaysOnTop = vi.fn();
+    const windowMock = {
+      on: vi.fn((event: string, handler: () => void) => {
+        if (event === "close") closeHandlers.push(handler);
+      }),
+      setAlwaysOnTop,
+    };
+    mocks.createWindow.mockReturnValue(windowMock);
+    mocks.getPrimaryDisplay.mockReturnValue({
+      workArea: { x: 100, y: 50, width: 1600, height: 900 },
+    });
+
+    const { createPillWindow, getPillWindow } = await import("./pill-window");
+    const win = createPillWindow({
+      rendererUrl: "http://127.0.0.1:5174/",
+      preload: "preload.js",
+    });
+
+    expect(win).toBe(windowMock);
+    expect(mocks.createWindow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Eliza Pill",
+        url: "http://127.0.0.1:5174/?shellMode=chat-overlay",
+        preload: "preload.js",
+        titleBarStyle: "hidden",
+        transparent: true,
+        activate: false,
+        frame: {
+          x: 720,
+          y: 654,
+          width: 360,
+          height: 280,
+        },
+      }),
+    );
+    expect(setAlwaysOnTop).toHaveBeenCalledWith(true);
+    expect(getPillWindow()).toBe(windowMock);
+
+    closeHandlers.forEach((handler) => handler());
+    expect(getPillWindow()).toBeNull();
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/pill-window.ts
+++ b/packages/app-core/platforms/electrobun/src/pill-window.ts
@@ -3,8 +3,8 @@
  *
  * Spawns a single borderless, transparent, always-on-top BrowserWindow
  * docked to the bottom-center of the user's primary display. The window
- * loads the same renderer bundle as the main shell with `?shell=pill`,
- * which `apps/app/src/main.tsx` routes to a minimal `<VoicePill>` mount.
+ * loads the same renderer bundle as the main shell with
+ * `?shellMode=chat-overlay`, which routes to the live assistant overlay shell.
  *
  * Lifecycle:
  *  - Created once at app boot, alongside the main window.
@@ -40,9 +40,9 @@ function resolvePillFrame(): PillWindowFrame {
   };
 }
 
-function buildPillRendererUrl(rendererUrl: string): string {
+export function buildPillRendererUrl(rendererUrl: string): string {
   const url = new URL(rendererUrl);
-  url.search = "?shell=pill";
+  url.search = "?shellMode=chat-overlay";
   url.hash = "";
   return url.toString();
 }
@@ -67,6 +67,7 @@ export function createPillWindow(args: {
     frame,
     titleBarStyle: "hidden",
     transparent: true,
+    activate: false,
   });
 
   try {

--- a/packages/app-core/platforms/electrobun/src/renderer-static.test.ts
+++ b/packages/app-core/platforms/electrobun/src/renderer-static.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   getRendererAssetContentType,
@@ -13,20 +14,20 @@ describe("renderer static assets", () => {
   });
 
   it("resolves the original MIME extension for precompressed assets", () => {
-    const files = new Set([
-      "/app/dist/index.html",
-      "/app/dist/assets/app.js.gz",
-    ]);
+    const rendererDir = path.join(path.sep, "app", "dist");
+    const indexPath = path.join(rendererDir, "index.html");
+    const gzPath = path.join(rendererDir, "assets", "app.js.gz");
+    const files = new Set([indexPath, gzPath]);
 
     const resolved = resolveRendererAsset({
-      rendererDir: "/app/dist",
+      rendererDir,
       urlPath: "/assets/app.js",
       existsSync: (filePath) => files.has(filePath),
       statSync: () => ({ isDirectory: () => false }),
     });
 
     expect(resolved).toEqual({
-      filePath: "/app/dist/assets/app.js.gz",
+      filePath: gzPath,
       isGzipped: true,
       mimeExt: ".js",
     });

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -97,7 +97,9 @@ import {
   installForceFreshOnboardingClientPatch,
 } from "@elizaos/ui/platform/onboarding-reset";
 import {
+  isChatOverlayWindowShell,
   isDetachedWindowShell,
+  isStandaloneWindowShell,
   resolveWindowShellRoute,
   shouldInstallMainWindowOnboardingPatches,
   syncDetachedShellLocation,
@@ -390,7 +392,7 @@ function getWindowUrlSearchParams(): URLSearchParams {
  */
 function shouldEnableElectrobunMacWindowDrag(): boolean {
   if (!isElectrobunRuntime() || typeof document === "undefined") return false;
-  if (isDetachedWindowShell(windowShellRoute)) return false;
+  if (isStandaloneWindowShell(windowShellRoute)) return false;
   if (typeof navigator === "undefined") return false;
   const ua = navigator.userAgent;
   return /Mac/i.test(ua) && !/(iPhone|iPad|iPod)/i.test(ua);
@@ -1565,6 +1567,10 @@ function setupPlatformStyles(): void {
     document.body.classList.add("native");
   }
 
+  const chatOverlayShell = isChatOverlayWindowShell(windowShellRoute);
+  root.classList.toggle("eliza-chat-overlay-shell", chatOverlayShell);
+  document.body.classList.toggle("eliza-chat-overlay-shell", chatOverlayShell);
+
   root.style.setProperty("--safe-area-top", "env(safe-area-inset-top, 0px)");
   root.style.setProperty(
     "--safe-area-bottom",
@@ -2176,10 +2182,12 @@ async function main(): Promise<void> {
     return;
   }
 
-  if (isDetachedWindowShell(windowShellRoute)) {
+  if (isStandaloneWindowShell(windowShellRoute)) {
     injectDetachedShellApiBase();
     applyStoredDetachedShellTheme();
-    syncDetachedShellLocation(windowShellRoute);
+    if (isDetachedWindowShell(windowShellRoute)) {
+      syncDetachedShellLocation(windowShellRoute);
+    }
     await initializeStorageBridge();
     initializeCapacitorBridge();
     mountReactApp();

--- a/packages/app/test/brand-surface.test.ts
+++ b/packages/app/test/brand-surface.test.ts
@@ -129,14 +129,17 @@ describe("brand surfaces", () => {
     expect(offenders).toEqual([]);
   });
 
-  it("desktop pill shell mounts the minimal voice pill instead of the full app", () => {
-    const src = read("src/main.tsx");
-    expect(src).toContain('getWindowUrlSearchParams().get("shell") === "pill"');
-    expect(src).toMatch(
-      /if \(isVoicePillShellMode\(\)\) \{[\s\S]*?<VoicePill[\s\S]*?return;[\s\S]*?\}/,
+  it("desktop OS pill uses the transparent chat-overlay shell", () => {
+    const mainSrc = read("src/main.tsx");
+    const stylesSrc = read("../ui/src/styles/styles.css");
+    const pillSrc = read("../app-core/platforms/electrobun/src/pill-window.ts");
+
+    expect(pillSrc).toContain('url.search = "?shellMode=chat-overlay"');
+    expect(mainSrc).toContain("isChatOverlayWindowShell");
+    expect(mainSrc).toContain(
+      'root.classList.toggle("eliza-chat-overlay-shell", chatOverlayShell)',
     );
-    expect(src).toMatch(
-      /if \(isVoicePillShellMode\(\)\) \{[\s\S]*?setupPlatformStyles\(\);[\s\S]*?mountReactApp\(\);[\s\S]*?return;[\s\S]*?\}/,
-    );
+    expect(stylesSrc).toContain("html.eliza-chat-overlay-shell #root");
+    expect(stylesSrc).toContain("background: transparent");
   });
 });

--- a/packages/ui/src/App.cloud-shell.test.tsx
+++ b/packages/ui/src/App.cloud-shell.test.tsx
@@ -81,6 +81,22 @@ import { CLOUD_BACKGROUND_ASSETS } from "@elizaos/shared/brand";
 import { CloudVideoBackground } from "./backgrounds/CloudVideoBackground";
 
 const APP_TSX = readFileSync(resolve(__dirname, "./App.tsx"), "utf8");
+const APP_MAIN_TS = readFileSync(
+  resolve(__dirname, "../../app/src/main.tsx"),
+  "utf8",
+);
+const USE_NAVIGATION_STATE_TS = readFileSync(
+  resolve(__dirname, "./state/useNavigationState.ts"),
+  "utf8",
+);
+const USE_STARTUP_COORDINATOR_TS = readFileSync(
+  resolve(__dirname, "./state/useStartupCoordinator.ts"),
+  "utf8",
+);
+const WINDOW_SHELL_TS = readFileSync(
+  resolve(__dirname, "./platform/window-shell.ts"),
+  "utf8",
+);
 
 describe("App pre-agent cloud wiring", () => {
   it("wraps the pre-agent StartupShell in a full-screen CloudVideoBackground", () => {
@@ -152,5 +168,56 @@ describe("App pre-agent cloud wiring", () => {
     expect(
       container.querySelector('[data-testid="welcome"]')?.textContent,
     ).toBe("welcome");
+  });
+
+  it("keeps the assistant pill out of the full app shell", () => {
+    expect(APP_TSX).toContain("home: <HomeView />");
+    expect(APP_TSX).toContain('shellMode === "chat-overlay"');
+    expect(APP_TSX).toContain("<ShellFoundationMount />");
+    expect(APP_TSX).toContain("pointer-events-none fixed inset-0");
+    expect(APP_TSX).not.toContain(
+      "{isCoordinatorReady && <ShellFoundationMount />}",
+    );
+    expect(APP_TSX.indexOf('shellMode === "chat-overlay"')).toBeLessThan(
+      APP_TSX.indexOf(
+        'startupCoordinator.phase !== "ready" || !onboardingComplete',
+      ),
+    );
+  });
+
+  it("classifies chat-overlay as a standalone shell, not the main app", () => {
+    expect(WINDOW_SHELL_TS).toContain('shellMode === "chat-overlay"');
+    expect(WINDOW_SHELL_TS).toContain('{ mode: "chat-overlay" }');
+    expect(WINDOW_SHELL_TS).toContain("isChatOverlayWindowShell");
+    expect(WINDOW_SHELL_TS).toContain("isStandaloneWindowShell");
+    expect(WINDOW_SHELL_TS).toContain('route.mode === "chat-overlay"');
+    expect(APP_MAIN_TS).toContain("isStandaloneWindowShell(windowShellRoute)");
+    expect(APP_MAIN_TS).toContain("isChatOverlayWindowShell(windowShellRoute)");
+  });
+
+  it("preserves chat-overlay shell mode during shell-window navigation", () => {
+    expect(USE_NAVIGATION_STATE_TS).toContain("pathWithCurrentShellMode");
+    expect(USE_NAVIGATION_STATE_TS).toContain("isDetachedShell");
+    expect(USE_NAVIGATION_STATE_TS).toContain("eliza-chat-overlay-shell");
+    expect(USE_NAVIGATION_STATE_TS).toContain(
+      "if (!isDetachedShell) return path",
+    );
+    expect(USE_NAVIGATION_STATE_TS).toContain('params.get("shellMode")');
+    expect(USE_NAVIGATION_STATE_TS).toContain('params.get("shell-mode")');
+    expect(USE_NAVIGATION_STATE_TS).toContain(
+      'window.history.pushState(null, "", pathWithCurrentShellMode(path))',
+    );
+  });
+
+  it("lets existing shell windows advance after onboarding finishes elsewhere", () => {
+    expect(USE_STARTUP_COORDINATOR_TS).toContain(
+      "ONBOARDING_COMPLETE_STORAGE_KEY",
+    );
+    expect(USE_STARTUP_COORDINATOR_TS).toContain(
+      'window.addEventListener("storage", onStorage)',
+    );
+    expect(USE_STARTUP_COORDINATOR_TS).toContain(
+      'dispatch({ type: "SPLASH_CONTINUE" })',
+    );
   });
 });

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -63,7 +63,10 @@ import { SystemWarningBanner } from "./components/shell/SystemWarningBanner";
 import { useKioskViewSurfaces } from "./components/shell/useKioskViewSurfaces";
 import { ErrorBoundary } from "./components/ui/error-boundary";
 import { VoiceWaveform } from "./components/voice/VoiceWaveform";
-import { AppWorkspaceChrome } from "./components/workspace/AppWorkspaceChrome";
+import {
+  AppWorkspaceChrome,
+  type AppWorkspaceChromeProps,
+} from "./components/workspace/AppWorkspaceChrome";
 import { useBootConfig } from "./config/boot-config-react";
 import type { CompanionShellComponentProps } from "./config/boot-config-store";
 import {
@@ -271,15 +274,11 @@ function useShellMode(): ShellMode {
  * chrome — over a transparent background.
  */
 function ChatOverlayShell() {
-  const controller = useShellControllerContext();
   return (
     <div
       data-testid="chat-overlay-shell"
-      className="fixed inset-0 flex items-end justify-center bg-transparent"
+      className="pointer-events-none fixed inset-0 flex items-end justify-center bg-transparent"
     >
-      <div className="pointer-events-none mb-20 flex items-center justify-center">
-        <VoiceWaveform mode={controller?.waveformMode ?? "idle"} size={160} />
-      </div>
       <ShellFoundationMount />
     </div>
   );
@@ -545,6 +544,7 @@ function renderStaticViewRouterTab({
   LifeOpsPageView: ComponentType | null | undefined;
 }): ReactNode {
   const directViews: Record<string, ReactNode> = {
+    home: <HomeView />,
     chat: <ChatView />,
     home: <HomeView />,
     browser: <BrowserWorkspaceView />,
@@ -1574,6 +1574,19 @@ export function App() {
           <StreamView />
         </LazyViewBoundary>
       </div>
+    );
+  }
+
+  // OS chat-overlay window — render JUST the floating assistant pill +
+  // waveform over a transparent background, no app chrome or onboarding gate.
+  if (shellMode === "chat-overlay") {
+    return (
+      <BugReportProvider value={bugReport}>
+        <ShellControllerProvider>
+          <ChatOverlayShell />
+        </ShellControllerProvider>
+        <BugReportModal />
+      </BugReportProvider>
     );
   }
 

--- a/packages/ui/src/components/composites/chat/chat-composer-shell.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer-shell.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { ChatComposerShell } from "./chat-composer-shell";
+
+afterEach(cleanup);
+
+describe("ChatComposerShell", () => {
+  it("keeps the default composer from collapsing inside flex chat layouts", () => {
+    const { container } = render(
+      <ChatComposerShell>
+        <div>Composer</div>
+      </ChatComposerShell>,
+    );
+
+    expect(container.firstElementChild?.className).toContain("shrink-0");
+  });
+
+  it("keeps the game-modal composer from collapsing inside overlay layouts", () => {
+    const { container } = render(
+      <ChatComposerShell variant="game-modal">
+        <div>Composer</div>
+      </ChatComposerShell>,
+    );
+
+    expect(container.firstElementChild?.className).toContain("shrink-0");
+  });
+});

--- a/packages/ui/src/components/composites/chat/chat-composer-shell.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer-shell.tsx
@@ -37,7 +37,7 @@ export function ChatComposerShell({
       <div
         ref={(node) => assignRef(shellRef, node)}
         className={cn(
-          "mt-auto pointer-events-auto px-1 max-[380px]:px-0.5",
+          "mt-auto shrink-0 pointer-events-auto px-1 max-[380px]:px-0.5",
           className,
         )}
         data-no-camera-drag="true"
@@ -63,7 +63,7 @@ export function ChatComposerShell({
     <div
       ref={(node) => assignRef(shellRef, node)}
       className={cn(
-        "relative min-w-0 bg-transparent px-2 pb-3 pt-3 sm:px-6 sm:pb-4 xl:px-14",
+        "relative shrink-0 min-w-0 bg-transparent px-2 pb-3 pt-3 sm:px-6 sm:pb-4 xl:px-14",
         className,
       )}
       style={{

--- a/packages/ui/src/components/composites/chat/chat-composer.test.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ChatComposer, type ChatComposerVoiceState } from "./chat-composer";
+
+afterEach(cleanup);
+
+const voice: ChatComposerVoiceState = {
+  captureMode: "idle",
+  interimTranscript: "",
+  isListening: false,
+  isSpeaking: false,
+  startListening: vi.fn(),
+  stopListening: vi.fn(),
+  supported: false,
+  toggleListening: vi.fn(),
+};
+
+function renderInlineComposer() {
+  return render(
+    <ChatComposer
+      agentVoiceEnabled={false}
+      chatInput=""
+      chatPendingImagesCount={0}
+      chatSending={false}
+      hideAttachButton
+      isAgentStarting={false}
+      isComposerLocked={false}
+      layout="inline"
+      onAttachImage={vi.fn()}
+      onChatInputChange={vi.fn()}
+      onKeyDown={vi.fn()}
+      onSend={vi.fn()}
+      onStop={vi.fn()}
+      onStopSpeaking={vi.fn()}
+      onToggleAgentVoice={vi.fn()}
+      placeholder="Message"
+      t={(key) => key}
+      textareaAriaLabel="Message"
+      textareaRef={createRef<HTMLTextAreaElement>()}
+      variant="default"
+      voice={voice}
+    />,
+  );
+}
+
+describe("ChatComposer", () => {
+  it("keeps the inline composer visible on the dark chat surface", () => {
+    renderInlineComposer();
+
+    const composer = screen
+      .getByTestId("chat-composer-textarea")
+      .closest('[data-chat-composer="true"]');
+
+    expect(composer?.className).toContain("border-[color-mix(");
+    expect(composer?.className).toContain("bg-[color-mix(");
+    expect(composer?.className).toContain("ring-white/15");
+    expect(composer?.className).toContain("shadow-[");
+    expect(composer?.className).not.toContain("border-border/35");
+    expect(composer?.className).not.toContain("bg-card/45");
+  });
+
+  it("uses a readable placeholder in the inline textarea", () => {
+    renderInlineComposer();
+
+    expect(screen.getByTestId("chat-composer-textarea").className).toContain(
+      "placeholder:text-muted-strong",
+    );
+  });
+});

--- a/packages/ui/src/components/composites/chat/chat-composer.tsx
+++ b/packages/ui/src/components/composites/chat/chat-composer.tsx
@@ -30,12 +30,15 @@ const INLINE_TEXTAREA_MAX_HEIGHT_PX = 128;
 const INLINE_STACKED_INLINE_PADDING_PX = 12;
 
 const inlineTextareaClass =
-  "block h-8 max-h-[128px] min-h-0 w-full min-w-0 resize-none overflow-y-hidden appearance-none rounded-none border-0 bg-transparent px-2 py-[6px] text-sm leading-5 text-txt shadow-none outline-none ring-0 placeholder:text-muted/60 focus:!border-0 focus:!outline-none focus:!ring-0 focus-visible:!border-0 focus-visible:!outline-none focus-visible:!ring-0 focus-visible:!ring-offset-0 focus-visible:!shadow-none";
+  "block h-8 max-h-[128px] min-h-0 w-full min-w-0 resize-none overflow-y-hidden appearance-none rounded-none border-0 bg-transparent px-2 py-[6px] text-sm leading-5 text-txt shadow-none outline-none ring-0 placeholder:text-muted-strong focus:!border-0 focus:!outline-none focus:!ring-0 focus-visible:!border-0 focus-visible:!outline-none focus-visible:!ring-0 focus-visible:!ring-offset-0 focus-visible:!shadow-none";
 
 const inlineMeasureTextareaClass = `${inlineTextareaClass} pointer-events-none fixed left-0 top-0 z-[-1] opacity-0`;
 
 const chatComposerFocusResetClass =
   "[&_button:focus]:!outline-none [&_button:focus-visible]:!outline-none [&_button:focus-visible]:!ring-0 [&_button:focus-visible]:!ring-offset-0 [&_button:focus-visible]:!shadow-none [&_textarea:focus]:!outline-none [&_textarea:focus-visible]:!outline-none [&_textarea:focus-visible]:!ring-0 [&_textarea:focus-visible]:!ring-offset-0 [&_textarea:focus-visible]:!shadow-none";
+
+const inlineComposerSurfaceClass =
+  "border-[color-mix(in_srgb,var(--border)_62%,var(--txt)_38%)] bg-[color-mix(in_srgb,var(--bg)_78%,var(--txt)_16%)] shadow-[inset_0_1px_0_rgba(255,255,255,0.12),0_12px_30px_rgba(0,0,0,0.42)] ring-1 ring-inset ring-white/15 backdrop-blur-sm";
 
 type InlineTextareaMeasurement = {
   scrollHeight: number;
@@ -521,8 +524,8 @@ export function ChatComposer({
         data-inline-layout={isInlineMultiline ? "stacked" : "single-line"}
         className={
           isInlineMultiline
-            ? `flex min-h-[64px] flex-col gap-1 rounded-[22px] border border-border/35 bg-card/45 px-1.5 py-1.5 ${chatComposerFocusResetClass}`
-            : `flex min-h-[40px] items-center gap-1 rounded-sm border border-border/35 bg-card/45 px-1 py-1 ${chatComposerFocusResetClass}`
+            ? `flex min-h-[64px] flex-col gap-1 rounded-[22px] border px-1.5 py-1.5 ${inlineComposerSurfaceClass} ${chatComposerFocusResetClass}`
+            : `flex min-h-[40px] items-center gap-1 rounded-sm border px-1 py-1 ${inlineComposerSurfaceClass} ${chatComposerFocusResetClass}`
         }
       >
         <textarea

--- a/packages/ui/src/components/pages/HomeView.tsx
+++ b/packages/ui/src/components/pages/HomeView.tsx
@@ -12,8 +12,10 @@ import { VoiceWaveform } from "../voice/VoiceWaveform";
  *
  * Renders the clouds backdrop with a centered voice-avatar waveform as the
  * assistant's presence. Home suppresses the global assistant pill and exposes
- * its own composer/mic controls; the waveform mode is driven by the shared
- * shell controller phase.
+ * its own composer/mic controls. When the desktop overlay is enabled, the pill
+ * is hosted in a separate OS-level window so the main app stays focused on the
+ * home surface. The waveform mode is driven by the shared shell controller
+ * phase.
  */
 export function HomeView(): React.JSX.Element {
   const controller = useShellControllerContext();

--- a/packages/ui/src/components/shell/AssistantOverlay.tsx
+++ b/packages/ui/src/components/shell/AssistantOverlay.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { X } from "lucide-react";
 
 import { Z_SHELL_OVERLAY } from "../../lib/floating-layers";
 import type { ShellPhase } from "./shell-state";
@@ -119,6 +120,7 @@ export function AssistantOverlay({
       // arbitrary z-index values. See packages/ui/src/lib/floating-layers.ts.
       style={{ zIndex: Z_SHELL_OVERLAY + 1 }}
       className={[
+        "shell-assistant-overlay-panel pointer-events-auto",
         // Position: bottom sheet on mobile, centered drawer on >= sm
         "fixed inset-x-0 bottom-0",
         "sm:left-1/2 sm:right-auto sm:top-1/2 sm:bottom-auto",
@@ -138,6 +140,14 @@ export function AssistantOverlay({
         "motion-safe:animate-[shell-overlay-in_220ms_ease-out]",
       ].join(" ")}
     >
+      <button
+        type="button"
+        aria-label="Close assistant"
+        onClick={onClose}
+        className="absolute right-2 top-2 z-10 grid h-8 w-8 place-items-center rounded-full bg-card/60 text-muted transition-colors hover:text-txt focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+      >
+        <X aria-hidden="true" className="h-4 w-4" />
+      </button>
       {children}
     </div>
   );

--- a/packages/ui/src/components/shell/ChatSurface.tsx
+++ b/packages/ui/src/components/shell/ChatSurface.tsx
@@ -30,6 +30,7 @@ export function ChatSurface({
   onToggleRecording,
 }: ChatSurfaceProps): React.JSX.Element {
   const [draft, setDraft] = React.useState("");
+  const scrollRef = React.useRef<HTMLDivElement | null>(null);
   const trimmed = draft.trim();
   const canSendNow = canSend && trimmed.length > 0;
 
@@ -39,9 +40,15 @@ export function ChatSurface({
     setDraft("");
   }, [canSendNow, onSend, trimmed]);
 
+  React.useEffect(() => {
+    const node = scrollRef.current;
+    if (!node) return;
+    node.scrollTop = node.scrollHeight;
+  }, [messages]);
+
   return (
     <div className="flex h-full flex-col" data-testid="shell-chat-surface">
-      <div className="flex-1 overflow-y-auto p-4">
+      <div ref={scrollRef} className="flex-1 overflow-y-auto p-4">
         {messages.length === 0 ? (
           <p className="text-sm text-muted">
             {greeting ?? "Ask Eliza anything."}

--- a/packages/ui/src/components/shell/HomePill.tsx
+++ b/packages/ui/src/components/shell/HomePill.tsx
@@ -48,11 +48,12 @@ export function HomePill({
       // sees literal class strings, so the z-index goes via inline style.
       style={{ zIndex: Z_SHELL_OVERLAY }}
       className={cn(
-        // Position
-        "fixed bottom-3 left-1/2 -translate-x-1/2",
+        // Position: ChatOverlayShell owns fixed bottom-center placement.
+        "pointer-events-auto relative mb-3",
         // Shape
         "h-10 w-32 rounded-full",
         // Default (idle) visual
+        "relative flex items-center justify-center gap-2 overflow-hidden",
         "bg-card/70 backdrop-blur-md text-txt",
         "border border-border/40",
         // Focus ring
@@ -68,6 +69,47 @@ export function HomePill({
         // Summoned: faint glow
         phase === "summoned" && "shadow-[0_0_10px_rgba(255,255,255,0.15)]",
       )}
-    />
+    >
+      <span
+        aria-hidden="true"
+        data-testid="shell-home-pill-mark"
+        className={cn(
+          "grid h-6 w-6 place-items-center rounded-full border border-accent/35 bg-accent/15",
+          phase === "booting" && "border-muted/30 bg-muted/10",
+          phase === "listening" && "border-warn/70 bg-warn/20",
+        )}
+      >
+        <span
+          className={cn(
+            "h-2.5 w-2.5 rounded-full bg-accent shadow-[0_0_12px_rgba(var(--accent-rgb),0.55)]",
+            phase === "booting" && "bg-muted shadow-none",
+            phase === "listening" &&
+              "bg-warn shadow-[0_0_12px_rgba(var(--accent-rgb),0.8)]",
+          )}
+        />
+      </span>
+      <span aria-hidden="true" className="flex h-4 items-end gap-0.5">
+        {[0, 1, 2, 3].map((index) => (
+          <span
+            key={index}
+            className={cn(
+              "block w-1 rounded-full bg-accent/75",
+              phase === "booting" && "bg-muted/60",
+              phase === "listening" && "bg-warn/90 animate-pulse",
+              phase === "responding" && "animate-pulse",
+              index === 0 && "h-2",
+              index === 1 && "h-3",
+              index === 2 && "h-4",
+              index === 3 && "h-2.5",
+            )}
+            style={
+              phase === "responding" || phase === "listening"
+                ? { animationDelay: `${index * 90}ms` }
+                : undefined
+            }
+          />
+        ))}
+      </span>
+    </button>
   );
 }

--- a/packages/ui/src/components/shell/RuntimeGate.tsx
+++ b/packages/ui/src/components/shell/RuntimeGate.tsx
@@ -442,7 +442,8 @@ function describeLocalSetupStatus(
     return {
       state: "ready",
       label: "Local bundle installed",
-      detail: "Model and voice assets are present. They load when used.",
+      detail:
+        "Model and voice assets are present. The app warms them after setup.",
       percent: 100,
     };
   }

--- a/packages/ui/src/components/shell/__tests__/AssistantOverlay.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/AssistantOverlay.test.tsx
@@ -64,6 +64,19 @@ describe("AssistantOverlay", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("offers a visible close button for pointer users", () => {
+    const onClose = vi.fn();
+    render(
+      <AssistantOverlay phase="summoned" onClose={onClose}>
+        <button type="button">inside</button>
+      </AssistantOverlay>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /close assistant/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   it("does not call onClose when Escape is pressed while phase=idle", () => {
     const onClose = vi.fn();
     render(
@@ -111,8 +124,10 @@ describe("AssistantOverlay", () => {
       </AssistantOverlay>,
     );
 
-    // Focus moves to the first focusable descendant inside the dialog.
-    expect(document.activeElement?.textContent).toBe("first-inside");
+    // Focus moves to the first focusable control inside the dialog.
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: /close assistant/i }),
+    );
 
     triggerButton.remove();
   });
@@ -129,7 +144,9 @@ describe("AssistantOverlay", () => {
       </AssistantOverlay>,
     );
 
-    expect(document.activeElement?.textContent).toBe("inside");
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: /close assistant/i }),
+    );
     unmount();
     expect(document.activeElement).toBe(triggerButton);
     triggerButton.remove();
@@ -144,12 +161,16 @@ describe("AssistantOverlay", () => {
     );
 
     // After open the first descendant has focus.
-    expect(document.activeElement?.textContent).toBe("alpha");
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: /close assistant/i }),
+    );
 
     fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
     expect(document.activeElement?.textContent).toBe("omega");
 
     fireEvent.keyDown(document, { key: "Tab" });
-    expect(document.activeElement?.textContent).toBe("alpha");
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: /close assistant/i }),
+    );
   });
 });

--- a/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/HomePill.test.tsx
@@ -13,6 +13,7 @@ describe("HomePill", () => {
     render(<HomePill phase="idle" onOpen={() => {}} onClose={() => {}} />);
     const btn = screen.getByRole("button", { name: /open eliza/i });
     expect(btn).toBeTruthy();
+    expect(screen.getByTestId("shell-home-pill-mark")).toBeTruthy();
   });
 
   it("calls onOpen when clicked from idle", () => {
@@ -20,6 +21,17 @@ describe("HomePill", () => {
     render(<HomePill phase="idle" onOpen={onOpen} onClose={() => {}} />);
     fireEvent.click(screen.getByRole("button"));
     expect(onOpen).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets the overlay shell own native-window positioning", () => {
+    render(<HomePill phase="idle" onOpen={() => {}} onClose={() => {}} />);
+    const className = screen.getByRole("button").className;
+
+    expect(className).toContain("relative");
+    expect(className).toContain("mb-3");
+    expect(className).not.toContain("fixed");
+    expect(className).not.toContain("left-1/2");
+    expect(className).not.toContain("-translate-x-1/2");
   });
 
   it("calls onClose when clicked from summoned", () => {

--- a/packages/ui/src/components/voice/VoiceWaveform.test.tsx
+++ b/packages/ui/src/components/voice/VoiceWaveform.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { VoiceWaveform } from "./VoiceWaveform";
 
@@ -20,5 +20,17 @@ describe("VoiceWaveform", () => {
     expect(screen.getByTestId("voice-waveform").getAttribute("data-mode")).toBe(
       "listening",
     );
+  });
+
+  it("does not open its own microphone by default in listening mode", () => {
+    const getUserMedia = vi.fn();
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: { getUserMedia },
+    });
+
+    render(<VoiceWaveform mode="listening" />);
+
+    expect(getUserMedia).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/voice/VoiceWaveform.tsx
+++ b/packages/ui/src/components/voice/VoiceWaveform.tsx
@@ -21,6 +21,12 @@ export interface VoiceWaveformProps {
    * The waveform never mutates or disconnects the node — it only reads.
    */
   analyser?: AnalyserNode | null;
+  /**
+   * Open a private microphone analyser when listening and no analyser is
+   * supplied. Defaults to false so shells that already own voice capture do
+   * not create a second getUserMedia session just for visualization.
+   */
+  captureMic?: boolean;
   /** Bar count. Default 24. */
   bars?: number;
   /** Diameter / square size in px. Default 220. */
@@ -94,15 +100,16 @@ async function openMicAnalyser(): Promise<MicAnalyser | null> {
  * the active mic capture (when `listening`) or TTS playback amplitude (when
  * `responding` with an analyser). Idle renders a calm breathing ring.
  *
- * Self-contained: in `listening` mode it opens its own mic analyser so the
- * visualizer works even when the capture pipeline does not expose one. The
- * node is released the moment the mode leaves `listening`.
+ * When an analyser is supplied, the visualizer reads from that audio node.
+ * Without one it uses an active fallback animation; callers can opt into a
+ * private microphone analyser with `captureMic` for standalone demos.
  *
  * Honors `prefers-reduced-motion` by rendering a single static ring.
  */
 export function VoiceWaveform({
   mode,
   analyser,
+  captureMic = false,
   bars = DEFAULT_BARS,
   size = DEFAULT_SIZE,
   className,
@@ -120,7 +127,7 @@ export function VoiceWaveform({
   // Open / close the mic analyser as the mode enters / leaves `listening`.
   React.useEffect(() => {
     let cancelled = false;
-    if (mode === "listening") {
+    if (mode === "listening" && captureMic && !externalAnalyserRef.current) {
       void openMicAnalyser().then((handle) => {
         if (cancelled || !handle) {
           handle?.stop();
@@ -134,7 +141,7 @@ export function VoiceWaveform({
       micRef.current?.stop();
       micRef.current = null;
     };
-  }, [mode]);
+  }, [captureMic, mode]);
 
   React.useEffect(() => {
     const canvas = canvasRef.current;
@@ -165,7 +172,7 @@ export function VoiceWaveform({
         modeRef.current === "responding"
           ? externalAnalyserRef.current
           : modeRef.current === "listening"
-            ? (micRef.current?.analyser ?? null)
+            ? (externalAnalyserRef.current ?? micRef.current?.analyser ?? null)
             : null;
       const out = new Float32Array(bars);
       if (active) {

--- a/packages/ui/src/navigation/index.ts
+++ b/packages/ui/src/navigation/index.ts
@@ -418,7 +418,7 @@ export function tabFromPath(pathname: string, basePath = ""): Tab | null {
   const normalized = normalizePathForLookup(pathname, basePath);
   // The root path "/" lands on the discovered main-tab app. Reads the
   // cached apps catalog synchronously and falls back to the assistant home
-  // launcher when no app declares elizaos.app.mainTab=true.
+  // (clouds/avatar surface) when no app declares elizaos.app.mainTab=true.
   if (normalized === "/") return resolveDefaultLandingTab();
 
   if (

--- a/packages/ui/src/navigation/main-tab.test.ts
+++ b/packages/ui/src/navigation/main-tab.test.ts
@@ -1,6 +1,6 @@
 import type { RegistryAppInfo } from "@elizaos/shared";
 import { describe, expect, it } from "vitest";
-import { getMainTabApp } from "./main-tab";
+import { getMainTabApp, resolveDefaultLandingTab } from "./main-tab";
 
 function buildApp(overrides: Partial<RegistryAppInfo>): RegistryAppInfo {
   return {
@@ -28,6 +28,10 @@ function buildApp(overrides: Partial<RegistryAppInfo>): RegistryAppInfo {
 }
 
 describe("getMainTabApp", () => {
+  it("falls back to the clouds/avatar home surface", () => {
+    expect(resolveDefaultLandingTab([])).toBe("home");
+  });
+
   it("returns null when no app declares mainTab", () => {
     const apps = [
       buildApp({ name: "@elizaos/app-a" }),

--- a/packages/ui/src/onboarding/auto-download-recommended.test.ts
+++ b/packages/ui/src/onboarding/auto-download-recommended.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 const mockClient = vi.hoisted(() => ({
   getLocalInferenceHub: vi.fn(),
+  setLocalInferenceActive: vi.fn(),
   startLocalInferenceDownload: vi.fn(),
 }));
 
@@ -92,5 +93,73 @@ describe("autoDownloadRecommendedLocalModelInBackground", () => {
     expect(mockClient.startLocalInferenceDownload).toHaveBeenCalledWith(
       "eliza-1-2b",
     );
+  });
+
+  it("activates an installed Eliza download bundle instead of only marking setup attempted", async () => {
+    const snapshot = simulatorSnapshot();
+    snapshot.installed = [
+      {
+        id: "eliza-1-0_8b",
+        displayName: "eliza-1-0.8B",
+        path: "/models/eliza-1-0_8b.bundle/text/eliza-1-0_8b-128k.gguf",
+        sizeBytes: 556_982_432,
+        installedAt: new Date(0).toISOString(),
+        source: "eliza-download",
+      },
+      {
+        id: "eliza-1-0_8b-drafter",
+        displayName: "eliza-1-0.8B drafter",
+        path: "/models/eliza-1-0_8b.bundle/dflash/drafter-0_8b.gguf",
+        sizeBytes: 237_637_024,
+        installedAt: new Date(0).toISOString(),
+        source: "eliza-download",
+        runtimeRole: "dflash-drafter",
+        companionFor: "eliza-1-0_8b",
+      },
+    ] as ModelHubSnapshot["installed"];
+
+    vi.stubGlobal("window", { localStorage: stubLocalStorage() });
+    fetchWithCsrfMock.mockResolvedValue(new Response("ok", { status: 200 }));
+    mockClient.getLocalInferenceHub.mockResolvedValue(snapshot);
+    mockClient.setLocalInferenceActive.mockResolvedValue({ status: "ready" });
+
+    await autoDownloadRecommendedLocalModelInBackground(
+      "http://127.0.0.1:31337",
+    );
+
+    expect(mockClient.setLocalInferenceActive).toHaveBeenCalledWith(
+      "eliza-1-0_8b",
+    );
+    expect(mockClient.startLocalInferenceDownload).not.toHaveBeenCalled();
+  });
+
+  it("does not re-activate an installed bundle that is already ready", async () => {
+    const snapshot = simulatorSnapshot();
+    snapshot.installed = [
+      {
+        id: "eliza-1-0_8b",
+        displayName: "eliza-1-0.8B",
+        path: "/models/eliza-1-0_8b.bundle/text/eliza-1-0_8b-128k.gguf",
+        sizeBytes: 556_982_432,
+        installedAt: new Date(0).toISOString(),
+        source: "eliza-download",
+      },
+    ] as ModelHubSnapshot["installed"];
+    snapshot.active = {
+      modelId: "eliza-1-0_8b",
+      loadedAt: new Date(0).toISOString(),
+      status: "ready",
+    };
+
+    vi.stubGlobal("window", { localStorage: stubLocalStorage() });
+    fetchWithCsrfMock.mockResolvedValue(new Response("ok", { status: 200 }));
+    mockClient.getLocalInferenceHub.mockResolvedValue(snapshot);
+
+    await autoDownloadRecommendedLocalModelInBackground(
+      "http://127.0.0.1:31337",
+    );
+
+    expect(mockClient.setLocalInferenceActive).not.toHaveBeenCalled();
+    expect(mockClient.startLocalInferenceDownload).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/onboarding/auto-download-recommended.ts
+++ b/packages/ui/src/onboarding/auto-download-recommended.ts
@@ -3,16 +3,16 @@
  *
  * Background-only — never blocks the UI. The user lands in chat immediately
  * via `RuntimeGate.finishAsLocal()`; this helper polls the local agent's
- * `/api/health` until the runtime is up, then enqueues a download for a
- * model that fits the device's hardware bucket. The user can interact with
- * the chat (with the composer-locked / "set up provider" placeholder) while
- * the download runs; once complete, the local-inference panel and the
- * provider selector see the new model.
+ * `/api/health` until the runtime is up, then activates an installed
+ * Eliza-1 bundle or enqueues a download for a model that fits the device's
+ * hardware bucket. The user can interact with the chat while download/warmup
+ * happens in the background; once complete, the local-inference panel and the
+ * provider selector see the ready model.
  *
  * Idempotency: a `localStorage` marker stops us from re-enqueuing on every
- * boot. The marker is set after a successful enqueue OR after we determine
- * the user already has at least one `eliza-download` model installed; the
- * Local Inference panel is the source of truth from then on.
+ * boot. The marker is set after a successful enqueue OR after an installed
+ * `eliza-download` bundle is already active/activating or successfully starts
+ * activation; the Local Inference panel is the source of truth from then on.
  *
  * Failure modes:
  *   - agent never comes up within the deadline → silent no-op, no marker.
@@ -83,6 +83,17 @@ function pickRecommendedModel(snapshot: ModelHubSnapshot): CatalogModel | null {
   );
 }
 
+function pickInstalledElizaDownloadModel(
+  snapshot: ModelHubSnapshot,
+): string | null {
+  const catalogIds = new Set(snapshot.catalog.map((model) => model.id));
+  return (
+    snapshot.installed.find(
+      (model) => model.source === "eliza-download" && catalogIds.has(model.id),
+    )?.id ?? null
+  );
+}
+
 export async function autoDownloadRecommendedLocalModelInBackground(
   apiBase: string,
 ): Promise<void> {
@@ -98,10 +109,24 @@ export async function autoDownloadRecommendedLocalModelInBackground(
     return;
   }
 
-  const alreadyHasElizaDownload = snapshot.installed.some(
-    (m) => m.source === "eliza-download",
-  );
-  if (alreadyHasElizaDownload) {
+  const installedElizaDownload = pickInstalledElizaDownloadModel(snapshot);
+  if (installedElizaDownload) {
+    if (
+      snapshot.active.modelId === installedElizaDownload &&
+      (snapshot.active.status === "ready" ||
+        snapshot.active.status === "loading")
+    ) {
+      writeMarker();
+      return;
+    }
+
+    try {
+      await client.setLocalInferenceActive(installedElizaDownload);
+    } catch {
+      // Leave the marker unset so a later boot retries activation after the
+      // local runtime stabilizes.
+      return;
+    }
     writeMarker();
     return;
   }

--- a/packages/ui/src/platform/window-shell.ts
+++ b/packages/ui/src/platform/window-shell.ts
@@ -13,6 +13,7 @@ export type WindowShellRoute =
   | { mode: "main" }
   | { mode: "settings"; tab?: string }
   | { mode: "surface"; tab: DetachedSurfaceTab }
+  | { mode: "chat-overlay" }
   | { mode: "pill" };
 
 export interface DetachedShellTarget {
@@ -23,6 +24,11 @@ export interface DetachedShellTarget {
 export function parseWindowShellRoute(search: string): WindowShellRoute {
   const params = new URLSearchParams(search);
   const shell = params.get("shell");
+  const shellMode = params.get("shellMode") ?? params.get("shell-mode");
+
+  if (shellMode === "chat-overlay") {
+    return { mode: "chat-overlay" };
+  }
 
   if (shell === "settings") {
     const tab = params.get("tab")?.trim() || undefined;
@@ -58,8 +64,27 @@ export function resolveWindowShellRoute(
 
 export function isDetachedWindowShell(
   route: WindowShellRoute,
-): route is Exclude<WindowShellRoute, { mode: "main" } | { mode: "pill" }> {
-  return route.mode !== "main" && route.mode !== "pill";
+): route is Exclude<
+  WindowShellRoute,
+  { mode: "main" } | { mode: "pill" } | { mode: "chat-overlay" }
+> {
+  return (
+    route.mode !== "main" &&
+    route.mode !== "pill" &&
+    route.mode !== "chat-overlay"
+  );
+}
+
+export function isChatOverlayWindowShell(
+  route: WindowShellRoute,
+): route is Extract<WindowShellRoute, { mode: "chat-overlay" }> {
+  return route.mode === "chat-overlay";
+}
+
+export function isStandaloneWindowShell(
+  route: WindowShellRoute,
+): route is Exclude<WindowShellRoute, { mode: "main" }> {
+  return route.mode !== "main";
 }
 
 export function isPillWindowShell(
@@ -81,8 +106,10 @@ export function resolveDetachedShellTarget(
     throw new Error("Main windows do not have a detached shell target");
   }
 
-  if (route.mode === "pill") {
-    throw new Error("Pill windows do not have a detached shell target");
+  if (route.mode === "pill" || route.mode === "chat-overlay") {
+    throw new Error(
+      `${route.mode} windows do not have a detached shell target`,
+    );
   }
 
   if (route.mode === "settings") {
@@ -117,7 +144,11 @@ export function syncDetachedShellLocation(
     href?: string;
   },
 ): boolean {
-  if (route.mode === "main" || route.mode === "pill") {
+  if (
+    route.mode === "main" ||
+    route.mode === "pill" ||
+    route.mode === "chat-overlay"
+  ) {
     return false;
   }
 

--- a/packages/ui/src/state/AppContext.tsx
+++ b/packages/ui/src/state/AppContext.tsx
@@ -164,9 +164,9 @@ export { AGENT_READY_TIMEOUT_MS } from "./types";
  * main-tab app; the wizard opens the companion overlay separately.
  *
  * Resolved synchronously from the cached apps catalog at module load.
- * Falls back to "chat" when no installed app declares
- * `elizaos.app.mainTab=true`, preserving pre-Phase-1 behavior. Phase 5
- * lands `app-chat` to claim the seam and drops the chat fallback.
+ * Falls back to "home" when no installed app declares
+ * `elizaos.app.mainTab=true`, keeping the clouds/avatar assistant surface as
+ * the default shell landing page.
  */
 const DEFAULT_LANDING_TAB: Tab = resolveDefaultLandingTab();
 

--- a/packages/ui/src/state/persistence.ts
+++ b/packages/ui/src/state/persistence.ts
@@ -337,7 +337,7 @@ export function clearPersistedOnboardingStep(): void {
 
 /* ── Onboarding completion persistence ────────────────────────────────── */
 
-const ONBOARDING_COMPLETE_STORAGE_KEY = "eliza:onboarding-complete";
+export const ONBOARDING_COMPLETE_STORAGE_KEY = "eliza:onboarding-complete";
 
 export function loadPersistedOnboardingComplete(): boolean {
   if (typeof localStorage === "undefined") {

--- a/packages/ui/src/state/startup-coordinator.ts
+++ b/packages/ui/src/state/startup-coordinator.ts
@@ -276,6 +276,13 @@ export function startupReducer(
 
     case "error":
       switch (event.type) {
+        case "BACKEND_REACHED":
+          if (event.onboardingComplete) {
+            return { phase: "starting-runtime", attempts: 0 };
+          }
+          return { phase: "onboarding-required", serverReachable: true };
+        case "AGENT_RUNNING":
+          return { phase: "hydrating" };
         case "RETRY":
           return { phase: "restoring-session" };
         default:

--- a/packages/ui/src/state/types.ts
+++ b/packages/ui/src/state/types.ts
@@ -933,9 +933,8 @@ export interface AppActions {
    * not collect provider/character info, so there is no submit payload.
    * Dispatches ONBOARDING_COMPLETE to the startup coordinator.
    *
-   * The full wizard passes `{ launchCompanionOverlay: true }` so first-time
-   * setup lands in `@elizaos/plugin-companion` at `/apps/companion`. RuntimeGate
-   * omits options and lands on chat only.
+   * The full wizard passes an explicit landing tab when needed. RuntimeGate
+   * omits options and lands on the default clouds/avatar home surface.
    */
   completeOnboarding: (
     landingTab?: Tab,

--- a/packages/ui/src/state/useApp.ts
+++ b/packages/ui/src/state/useApp.ts
@@ -1,7 +1,18 @@
 import { createContext, useContext } from "react";
 import type { AppContextValue } from "./types";
 
-export const AppContext = createContext<AppContextValue | null>(null);
+type AppContextObject = ReturnType<
+  typeof createContext<AppContextValue | null>
+>;
+
+const appContextGlobal = globalThis as typeof globalThis & {
+  __ELIZAOS_UI_APP_CONTEXT__?: AppContextObject;
+};
+
+export const AppContext =
+  appContextGlobal.__ELIZAOS_UI_APP_CONTEXT__ ??
+  (appContextGlobal.__ELIZAOS_UI_APP_CONTEXT__ =
+    createContext<AppContextValue | null>(null));
 
 export function useApp(): AppContextValue {
   const ctx = useContext(AppContext);

--- a/packages/ui/src/state/useNavigationState.ts
+++ b/packages/ui/src/state/useNavigationState.ts
@@ -27,6 +27,22 @@ import {
 import { NavigationEventHub } from "./navigation-events";
 import { getTabForShellView } from "./shell-routing";
 
+function pathWithCurrentShellMode(path: string): string {
+  if (typeof window === "undefined") return path;
+  const html = window.document?.documentElement;
+  const body = window.document?.body;
+  const isDetachedShell =
+    html?.classList.contains("eliza-chat-overlay-shell") === true ||
+    body?.classList.contains("eliza-chat-overlay-shell") === true;
+  if (!isDetachedShell) return path;
+  const params = new URLSearchParams(window.location.search);
+  const shellMode = params.get("shellMode") ?? params.get("shell-mode");
+  if (!shellMode) return path;
+  const nextParams = new URLSearchParams();
+  nextParams.set("shellMode", shellMode);
+  return `${path}?${nextParams.toString()}`;
+}
+
 // ── Hook deps ─────────────────────────────────────────────────────────────
 
 export interface NavigationStateDeps {
@@ -68,7 +84,7 @@ export function useNavigationState(deps: NavigationStateDeps) {
         if (shouldUseHashNavigation()) {
           window.location.hash = path;
         } else {
-          window.history.pushState(null, "", path);
+          window.history.pushState(null, "", pathWithCurrentShellMode(path));
         }
       } catch {
         // non-fatal: browser history update fails in restricted environments

--- a/packages/ui/src/state/useStartupCoordinator.recovery.test.ts
+++ b/packages/ui/src/state/useStartupCoordinator.recovery.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { startupReducer } from "./startup-coordinator";
+import {
+  recoverTerminalStartupError,
+  type StartupCoordinatorDeps,
+} from "./useStartupCoordinator";
+
+const clientMock = vi.hoisted(() => ({
+  getStatus: vi.fn(),
+  getOnboardingStatus: vi.fn(),
+}));
+
+vi.mock("../api", () => ({
+  client: clientMock,
+}));
+
+function createDeps() {
+  return {
+    setAgentStatus: vi.fn(),
+    setConnected: vi.fn(),
+    setStartupError: vi.fn(),
+    setOnboardingLoading: vi.fn(),
+    setOnboardingComplete: vi.fn(),
+    onboardingCompletionCommittedRef: { current: false },
+  } as unknown as StartupCoordinatorDeps;
+}
+
+describe("recoverTerminalStartupError", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("recovers a stale terminal startup error when the agent is running", async () => {
+    const status = {
+      state: "running",
+      agentName: "Eliza",
+      startup: { phase: "running", attempt: 0 },
+    };
+    clientMock.getStatus.mockResolvedValue(status);
+    clientMock.getOnboardingStatus.mockResolvedValue({ complete: true });
+    const deps = createDeps();
+    const dispatch = vi.fn();
+
+    await expect(
+      recoverTerminalStartupError(deps, dispatch, { current: false }),
+    ).resolves.toBe(true);
+
+    expect(deps.setAgentStatus).toHaveBeenCalledWith(status);
+    expect(deps.setConnected).toHaveBeenCalledWith(true);
+    expect(deps.setStartupError).toHaveBeenCalledWith(null);
+    expect(deps.setOnboardingLoading).toHaveBeenCalledWith(false);
+    expect(deps.setOnboardingComplete).toHaveBeenCalledWith(true);
+    expect(dispatch).toHaveBeenCalledWith({ type: "AGENT_RUNNING" });
+  });
+
+  it("routes a recovered but incomplete install back to onboarding", async () => {
+    clientMock.getStatus.mockResolvedValue({
+      state: "running",
+      agentName: "Eliza",
+      startup: { phase: "running", attempt: 0 },
+    });
+    clientMock.getOnboardingStatus.mockResolvedValue({ complete: false });
+    const deps = createDeps();
+    const dispatch = vi.fn();
+
+    await expect(
+      recoverTerminalStartupError(deps, dispatch, { current: false }),
+    ).resolves.toBe(true);
+
+    expect(deps.setOnboardingComplete).toHaveBeenCalledWith(false);
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "BACKEND_REACHED",
+      onboardingComplete: false,
+    });
+  });
+
+  it("does not recover while the agent is still not running", async () => {
+    clientMock.getStatus.mockResolvedValue({
+      state: "starting",
+      agentName: "Eliza",
+    });
+    const deps = createDeps();
+    const dispatch = vi.fn();
+
+    await expect(
+      recoverTerminalStartupError(deps, dispatch, { current: false }),
+    ).resolves.toBe(false);
+
+    expect(clientMock.getOnboardingStatus).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(deps.setStartupError).not.toHaveBeenCalled();
+  });
+});
+
+describe("startupReducer stale error recovery transitions", () => {
+  it("can leave error state once the agent is confirmed running", () => {
+    expect(
+      startupReducer(
+        {
+          phase: "error",
+          reason: "agent-error",
+          message: "transient",
+          timedOut: false,
+        },
+        { type: "AGENT_RUNNING" },
+      ),
+    ).toEqual({ phase: "hydrating" });
+  });
+
+  it("can return to onboarding when recovered backend is not yet onboarded", () => {
+    expect(
+      startupReducer(
+        {
+          phase: "error",
+          reason: "backend-timeout",
+          message: "transient",
+          timedOut: true,
+        },
+        { type: "BACKEND_REACHED", onboardingComplete: false },
+      ),
+    ).toEqual({ phase: "onboarding-required", serverReachable: true });
+  });
+});

--- a/packages/ui/src/state/useStartupCoordinator.ts
+++ b/packages/ui/src/state/useStartupCoordinator.ts
@@ -15,9 +15,13 @@
  */
 
 import { useCallback, useEffect, useReducer, useRef } from "react";
+import { client } from "../api";
 import { isElectrobunRuntime } from "../bridge";
 import { isAndroid, isElizaOS, isIOS, isNative } from "../platform";
-import { loadPersistedOnboardingComplete } from "./persistence";
+import {
+  loadPersistedOnboardingComplete,
+  ONBOARDING_COMPLETE_STORAGE_KEY,
+} from "./persistence";
 import {
   createAndroidPolicy,
   createDesktopPolicy,
@@ -31,6 +35,7 @@ import {
   type PlatformPolicy,
   type RuntimeTarget,
   type StartupEvent,
+  type StartupErrorReason,
   type StartupState,
   startupReducer,
   toLegacyStartupPhase,
@@ -54,6 +59,53 @@ import {
   runStartingRuntime,
   type StartingRuntimeDeps,
 } from "./startup-phase-runtime";
+
+function isRecoverableStartupErrorReason(reason: StartupErrorReason): boolean {
+  return (
+    reason === "backend-timeout" ||
+    reason === "backend-unreachable" ||
+    reason === "agent-timeout" ||
+    reason === "agent-error" ||
+    reason === "unknown"
+  );
+}
+
+export async function recoverTerminalStartupError(
+  deps: StartupCoordinatorDeps,
+  dispatch: (event: StartupEvent) => void,
+  cancelled: { current: boolean },
+): Promise<boolean> {
+  let status: Awaited<ReturnType<typeof client.getStatus>>;
+  try {
+    status = await client.getStatus();
+  } catch {
+    return false;
+  }
+  if (cancelled.current || status.state !== "running") return false;
+
+  let onboardingComplete = deps.onboardingCompletionCommittedRef.current;
+  try {
+    const onboardingStatus = await client.getOnboardingStatus();
+    onboardingComplete =
+      onboardingComplete || onboardingStatus.complete === true;
+  } catch {
+    return false;
+  }
+  if (cancelled.current) return false;
+
+  deps.setAgentStatus(status);
+  deps.setConnected(true);
+  deps.setStartupError(null);
+  deps.setOnboardingLoading(false);
+  deps.setOnboardingComplete(onboardingComplete);
+
+  if (onboardingComplete) {
+    dispatch({ type: "AGENT_RUNNING" });
+  } else {
+    dispatch({ type: "BACKEND_REACHED", onboardingComplete: false });
+  }
+  return true;
+}
 
 // ── Deps interface ──────────────────────────────────────────────────
 // Composed from per-phase slices defined in each startup-phase-*.ts module.
@@ -137,6 +189,27 @@ export function useStartupCoordinator(
       return;
     }
     dispatch({ type: "SPLASH_LOADED" });
+  }, [state.phase, depsReady]);
+
+  // Separate desktop shell windows, such as the OS chat-overlay pill, can be
+  // opened before the main app finishes onboarding. The `storage` event is how
+  // those windows learn that onboarding completed elsewhere and can continue
+  // their own startup coordinator without showing onboarding in the overlay.
+  useEffect(() => {
+    if (state.phase !== "splash") return;
+    if (!depsReady || typeof window === "undefined") return;
+
+    const onStorage = (event: StorageEvent) => {
+      if (
+        event.key === ONBOARDING_COMPLETE_STORAGE_KEY &&
+        event.newValue === "1"
+      ) {
+        dispatch({ type: "SPLASH_CONTINUE" });
+      }
+    };
+
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
   }, [state.phase, depsReady]);
 
   // ── Phase: restoring-session ────────────────────────────────────
@@ -246,6 +319,35 @@ export function useStartupCoordinator(
       cleanup();
     };
   }, [readyPhaseReached, depsReady]);
+
+  // Desktop cold starts can briefly report an agent failure while the embedded
+  // runtime is still settling, especially when the renderer loads before the
+  // health/status routes are ready. Once the backend later reports a running
+  // agent, recover automatically instead of leaving the user stuck on the
+  // startup failure card until they manually press Retry.
+  useEffect(() => {
+    if (state.phase !== "error" || !depsReady) return;
+    if (!isRecoverableStartupErrorReason(state.reason)) return;
+    if (typeof window === "undefined") return;
+
+    const currentDeps = depsRef.current;
+    if (!currentDeps) return;
+    const cancelled = { current: false };
+
+    const attemptRecovery = () => {
+      void recoverTerminalStartupError(currentDeps, dispatch, cancelled).catch(
+        () => {},
+      );
+    };
+
+    attemptRecovery();
+    const interval = window.setInterval(attemptRecovery, 2_500);
+
+    return () => {
+      cancelled.current = true;
+      window.clearInterval(interval);
+    };
+  }, [state, depsReady]);
 
   // ── Public interface ─────────────────────────────────────────────
 

--- a/packages/ui/src/styles/styles.css
+++ b/packages/ui/src/styles/styles.css
@@ -60,6 +60,27 @@ body {
   background: var(--bg);
 }
 
+html.eliza-chat-overlay-shell,
+html.eliza-chat-overlay-shell body,
+html.eliza-chat-overlay-shell #root {
+  background: transparent;
+}
+
+html.eliza-chat-overlay-shell #root {
+  pointer-events: none;
+}
+
+html.eliza-chat-overlay-shell .shell-assistant-overlay-panel {
+  top: auto !important;
+  right: 10px !important;
+  bottom: 10px !important;
+  left: 10px !important;
+  width: auto !important;
+  height: min(220px, calc(100% - 20px)) !important;
+  transform: none !important;
+  border-radius: 18px !important;
+}
+
 body.native {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## what

four chunks of desktop ux that go together because they all share the home/pill plumbing:

1. **clouds/avatar home as the post-onboarding default.** `HomeView` renders the clouds backdrop + centered voice waveform when the assistant is idle, and the typed prose + composer chrome stays inside the home surface (no extra app chrome when the OS overlay is on). `navigation/main-tab.ts` falls back to home when no plugin app declares `elizaos.app.mainTab=true`.

2. **opt-in OS pill (`ELIZA_DESKTOP_PILL=1`).** `electrobun/src/index.ts` + `pill-window.ts` spawn a separate transparent OS-level toplevel that loads the renderer with `?shellMode=chat-overlay`. the pill is gated off kiosk mode and stays opt-in until dynamic native frame sizing lands (the current native rectangle is fixed 360×280 and risks invisible click interception when always-on-top, per shaw).

3. **chat composer visibility.** `chat-composer.tsx` + `chat-composer-shell.tsx` add a real surface (border + bg color-mix + inset shadow + backdrop-blur) so the composer is visible against the dark chat backdrop. previously the composer was invisible on dark mode.

4. **startup coordinator auto-recovery.** `useStartupCoordinator.ts` adds `recoverTerminalStartupError()` that polls `/api/status` + `/api/onboarding/status` every 2.5s when the coordinator is stuck in a recoverable error state (backend-timeout, backend-unreachable, agent-timeout, agent-error, unknown). when the agent later comes back, the coordinator transitions to running without requiring a manual retry. also adds a `storage` event listener so a separate chat-overlay pill window can notice when onboarding completes in the main app.

## tests

```
ui: chat-composer, chat-composer-shell, AssistantOverlay, HomePill, App.cloud-shell, VoiceWaveform,
    main-tab, auto-download-recommended, useStartupCoordinator.recovery — 53 / 53 pass
electrobun: renderer-static, pill-window, native/agent-env — 7 / 7 pass
app/test/brand-surface — pass (after #7984 brand-surface assertion update)
```

## ci note

\`Plugin Tests\` flag the pre-existing manifest/dflash tests in \`plugin-local-inference\` that #7983 fixes. once #7983 merges, those test failures clear (they're not from this PR's changes — they're catalog + dflash eval drift that #7983 corrects). this PR's own focused tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships four coupled desktop UX features: the clouds/avatar `HomeView` as the post-onboarding default, an opt-in OS-level chat-overlay pill window (`ELIZA_DESKTOP_PILL=1`), composer surface visibility fixes for dark mode, and a 2.5 s auto-recovery polling loop that unblocks the startup coordinator from transient error states without requiring a manual retry.

- **HomeView as default shell landing**: `navigation/main-tab.ts` now resolves the default tab as `\"home\"` instead of `\"chat\"`, and the `HomePill` was redesigned with inline waveform bars — but its `position: fixed` was removed, breaking visibility in the main app shell on non-home/non-chat tabs.
- **OS pill window (`chat-overlay` mode)**: `pill-window.ts` spawns a borderless, always-on-top `BrowserWindow` at `?shellMode=chat-overlay`; `ChatOverlayShell` renders the assistant over a transparent background; `injectApiBaseIntoOpenRendererWindows()` propagates auth updates to the pill on agent restarts.
- **Startup recovery**: `recoverTerminalStartupError()` polls `/api/status` and `/api/onboarding/status` in the error phase; the `startupReducer` gains `BACKEND_REACHED` and `AGENT_RUNNING` transitions from the error phase; a `storage` event listener in the splash phase lets the pill window detect onboarding completion in the main window.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the overlay/kiosk paths; the in-app HomePill is broken on non-home tabs in the main shell and needs a follow-up before users who navigate away from home will see the assistant pill.

The clouds/avatar home surface, OS pill window, composer visibility, and startup recovery all work correctly in their intended contexts. The one concrete regression is that HomePill's position: fixed was removed, making it invisible in the main app shell when the user navigates to any tab other than home or chat — the pill renders as an inline element below the h-[100dvh] container rather than floating above the page.

packages/ui/src/components/shell/HomePill.tsx — positioning change breaks the in-app floating pill; packages/ui/src/App.tsx — ShellFoundationMount placement outside the overflow-hidden container compounds the issue.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/shell/HomePill.tsx | Redesigned pill with inline waveform bars and status indicator; removed CSS `position: fixed`, which breaks visibility in the main app shell on non-home/non-chat tabs. |
| packages/ui/src/App.tsx | Adds chat-overlay shell mode early-return path before the startup-coordinator gate; still renders ShellFoundationMount outside the h-[100dvh] container for non-home tabs, compounding the HomePill positioning issue. |
| packages/ui/src/state/useStartupCoordinator.ts | Adds storage-event cross-window sync for splash phase and a 2.5 s recovery polling loop for the error phase; recovery function unnecessarily calls getOnboardingStatus() even when local state is sufficient. |
| packages/ui/src/state/startup-coordinator.ts | Adds BACKEND_REACHED and AGENT_RUNNING transition handlers to the error phase to support auto-recovery without a RETRY cycle. |
| packages/ui/src/platform/window-shell.ts | Adds chat-overlay mode to WindowShellRoute and introduces isStandaloneWindowShell / isChatOverlayWindowShell helpers; cleanly updates exclusion lists in existing guards. |
| packages/app-core/platforms/electrobun/src/index.ts | Refactors API-base injection into injectApiBaseIntoOpenRendererWindows() to also push auth updates to the pill window; adds video/font/3D asset MIME types to the static server cache list. |
| packages/app-core/platforms/electrobun/src/native/agent.ts | Extracts Windows native inference guards into testable applyWindowsNativeInferenceDefaults(); fixes PATH key casing on Windows (PATH vs Path). |
| packages/ui/src/onboarding/auto-download-recommended.ts | Extends logic to activate an already-installed eliza-download bundle rather than always enqueuing a new download; adds Eliza-1 fast-path before the model-selection branch. |
| packages/ui/src/components/shell/ChatSurface.tsx | Adds auto-scroll-to-bottom on new messages via scrollRef; adds shrink-0 to ChatComposerShell to prevent composer squish. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[App boots] --> B{shellMode?}
    B -->|chat-overlay| C[ChatOverlayShell\nTransparent OS pill window]
    B -->|kiosk| D[KioskShell\nFixed fullscreen + bottom HomePill]
    B -->|main| E{Startup coordinator phase}
    E -->|error + recoverable| F[recoverTerminalStartupError poll 2.5s]
    F -->|/api/status running| G{/api/onboarding/status}
    G -->|complete=true| H[dispatch AGENT_RUNNING → hydrating]
    G -->|complete=false| I[dispatch BACKEND_REACHED → onboarding-required]
    G -->|exception| J[return false → retry next tick]
    E -->|splash| K{storage event\nONBOARDING_COMPLETE_STORAGE_KEY}
    K -->|newValue=1| L[dispatch SPLASH_CONTINUE]
    E -->|ready| M[Main app shell]
    M --> N{tab}
    N -->|home or chat| O[Suppress ShellFoundationMount]
    N -->|other tabs| P[Render ShellFoundationMount\n⚠️ HomePill below viewport]
    C --> Q[ShellFoundationMount\nflex items-end justify-center parent\nHomePill visible ✓]
    D --> R[ShellFoundationMount\nflex-col bottom child\nHomePill visible ✓]
```

<sub>Reviews (3): Last reviewed commit: ["ui: clouds/avatar home + opt-in os pill ..."](https://github.com/elizaos/eliza/commit/28c468b0c4776fad1ccdabeae1528887d0aabcc2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33797359)</sub>

<!-- /greptile_comment -->