### PR TITLE
docs(desktop-llama-build): warn about windows MSVC/Strawberry PATH conflict + show host prereqs

### DIFF
--- a/packages/app-core/scripts/build-llama-cpp-desktop-dylib.mjs
+++ b/packages/app-core/scripts/build-llama-cpp-desktop-dylib.mjs
@@ -131,6 +131,17 @@ const TARGETS = {
         ? ["-DGGML_CUDA=ON"]
         : ["-DGGML_VULKAN=ON"]),
     ],
+    hostNote:
+      "On a Windows host this build requires MSVC's `cl.exe` first on PATH. " +
+      "If `C:\\Strawberry\\c\\bin` (Strawberry Perl) is on PATH ahead of MSVC, " +
+      "CMake auto-detects Strawberry's MinGW `gcc.exe` + `windres.exe` as the " +
+      "host compiler/resource compiler, then `nvcc` (for `ELIZA_DESKTOP_BACKEND=cuda`) " +
+      "rejects the MinGW host with `Detecting CUDA compiler ABI info - failed` / " +
+      "`broken CUDA compiler`. Fix: launch a clean shell, `call vcvars64.bat` " +
+      "first, then append CUDA / node / git / VS-bundled cmake+ninja to PATH — " +
+      "DO NOT prepend Strawberry. CUDA toolkit must be a complete install (v12.4 " +
+      "or newer); empty `v12.6` stubs without `nvcc.exe` break detection too. " +
+      "For Vulkan backend (default), install the Vulkan SDK first.",
     crossNote:
       "Cross-build from darwin host: install `mingw-w64` via brew, then pass " +
       "a toolchain file setting CMAKE_C_COMPILER=x86_64-w64-mingw32-gcc, " +
@@ -178,6 +189,9 @@ function buildTarget(targetKey) {
     die(
       `cannot build ${targetKey} on ${process.platform}/${process.arch}: ${note}`,
     );
+  }
+  if (t.hostNote) {
+    log(`[${targetKey}] host-build prerequisites:\n  ${t.hostNote}`);
   }
 
   const [platform, arch] = targetKey.split("-");


### PR DESCRIPTION
## what

\`packages/app-core/scripts/build-llama-cpp-desktop-dylib.mjs\` gets a new \`hostNote\` field on the \`windows-x86_64\` target plus a logger line in \`buildTarget()\` that prints the note before any work starts. the goal is to short-circuit ~30 min of debugging the next windows dev would otherwise spend chasing \`Detecting CUDA compiler ABI info - failed\` / \`broken CUDA compiler\`.

## why

on a fresh windows host with a Strawberry Perl install (\`C:\Strawberry\c\bin\` on PATH), CMake auto-detects Strawberry's MinGW \`gcc.exe\` + \`windres.exe\` as the host compiler / resource compiler. nvcc then refuses to run against the MinGW host. the error message points at the cmake CUDA detect step but not at the real culprit (PATH precedence).

separately, partial CUDA toolkit installs (e.g. a stub \`v12.6\` without \`nvcc.exe\`) make \`CUDAToolkit_ROOT\` resolve to the wrong dir and detection silently fails on \`Could not find nvcc executable in path specified by environment variable CUDAToolkit_ROOT\`.

both took me real time to figure out while building the desktop FFI dylibs (\`libllama.dll\` + \`libeliza-llama-shim.dll\`) on windows. the note captures the working recipe so the next person sees it immediately.

## test

ran the build with the exact recipe described in the note and got past cmake config into kernel compilation. comparing the \`-ccbin\` arg in the nvcc invocation lines confirms MSVC \`cl.exe\` is selected:

\`\`\`
"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.4\bin\nvcc.exe"
  --use-local-env
  -ccbin \"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\bin\HostX64\x64\"
  -x cu ...
\`\`\`

## scope

docs-only. zero behavior change for any non-windows host. the only runtime effect on windows is an additional \`log()\` line before the cmake step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a developer-facing `hostNote` to the `windows-x86_64` build target that is printed at the start of a Windows native build, warning about the Strawberry Perl / MSVC PATH conflict and incomplete CUDA toolkit installs that cause silent `nvcc` detection failures.

- Adds a new `hostNote` field on the `windows-x86_64` entry in `TARGETS`, capturing the working recipe (MSVC-first PATH, complete CUDA toolkit, Vulkan SDK).
- Adds a three-line guard in `buildTarget()` that calls `log()` with the note immediately after the platform check, so the guidance appears before any cmake work begins.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only change is adding a log line and a documentation string; no build logic, CMake flags, or cross-platform behaviour is touched.

The `hostNote` string is only reached after `canBuildHere()` already confirmed the process is running on Windows, so non-Windows CI paths are completely unaffected. The `log()` call itself is the same helper used throughout the file, and the string content is accurate developer guidance.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/build-llama-cpp-desktop-dylib.mjs | Adds a `hostNote` string to the `windows-x86_64` target and a log call in `buildTarget()` that prints it before any build work; no logic changes, docs-only. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildTarget called] --> B{canBuildHere?}
    B -- No --> C[die with crossNote]
    B -- Yes --> D{hostNote present?}
    D -- Yes --> E[log host-build prerequisites]
    D -- No --> F[continue build]
    E --> F
    F --> G[ensureSourceCheckout]
    G --> H[cmake configure]
    H --> I[cmake build]
```

<sub>Reviews (1): Last reviewed commit: ["docs(desktop-llama-build): warn about wi..."](https://github.com/elizaos/eliza/commit/e35b4fffcb9dc2843fd408cb6a219ca90fa7db3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33803564)</sub>

<!-- /greptile_comment -->