### PR TITLE
fix(desktop-llama-build): support windows ffi build

### DIFF
--- a/packages/app-core/scripts/build-llama-cpp-desktop-dylib.mjs
+++ b/packages/app-core/scripts/build-llama-cpp-desktop-dylib.mjs
@@ -262,32 +262,46 @@ function buildTarget(targetKey) {
   }
 
   // ── Step 2: locate the built libllama.<ext> and stage it ─────────────────
+  // Naming convention: linux/macOS produce `libllama.{so,dylib}` (CMake adds
+  // the `lib` prefix on shared libs). Windows MSVC produces `llama.dll` —
+  // the `lib` prefix is dropped because PE doesn't carry it. The runtime
+  // (`desktop-llama-adapter.ts`) always looks for `libllama.{so,dylib,dll}`,
+  // so on Windows we have to find `llama.dll` from the build tree and
+  // stage it AS `libllama.dll` in the output dir.
   const libllamaName = `libllama.${t.libExt}`;
-  const candidates = [
-    path.join(buildDir, libllamaName),
-    path.join(buildDir, "bin", libllamaName),
-    path.join(buildDir, "src", libllamaName),
-  ];
+  const buildOutputNames =
+    process.platform === "win32"
+      ? [libllamaName, `llama.${t.libExt}`]
+      : [libllamaName];
+  const candidates = [];
+  for (const name of buildOutputNames) {
+    candidates.push(
+      path.join(buildDir, name),
+      path.join(buildDir, "bin", name),
+      path.join(buildDir, "bin", "Release", name),
+      path.join(buildDir, "src", name),
+      path.join(buildDir, "src", "Release", name),
+    );
+  }
   // Also walk shallow: cmake puts the shared lib in different places
-  // depending on generator (Ninja vs Make). Fall through to a find scan.
+  // depending on generator (Ninja vs Make/VS). Fall through to a find scan.
   let libllamaSrcPath = candidates.find((p) => fs.existsSync(p));
   if (!libllamaSrcPath) {
-    const found = spawnSync(
-      "find",
-      [buildDir, "-name", libllamaName, "-print"],
-      {
+    for (const name of buildOutputNames) {
+      const found = spawnSync("find", [buildDir, "-name", name, "-print"], {
         encoding: "utf8",
-      },
-    );
-    libllamaSrcPath = found.stdout.split("\n").find((s) => s.trim());
+      });
+      libllamaSrcPath = found.stdout.split("\n").find((s) => s.trim());
+      if (libllamaSrcPath) break;
+    }
   }
   if (!libllamaSrcPath) {
     die(
-      `could not locate ${libllamaName} after cmake build in ${buildDir}; ` +
-        `check that -DBUILD_SHARED_LIBS=ON took effect`,
+      `could not locate ${buildOutputNames.join(" or ")} after cmake build ` +
+        `in ${buildDir}; check that -DBUILD_SHARED_LIBS=ON took effect`,
     );
   }
-  log(`staging ${libllamaSrcPath} → ${outDir}`);
+  log(`staging ${libllamaSrcPath} → ${outDir}/${libllamaName}`);
   fs.copyFileSync(libllamaSrcPath, path.join(outDir, libllamaName));
 
   // ── Step 2b: stage libmtmd.<ext> when vision is enabled ──────────────────

--- a/packages/app-core/scripts/desktop-llama-shim/eliza_llama_shim.c
+++ b/packages/app-core/scripts/desktop-llama-shim/eliza_llama_shim.c
@@ -163,8 +163,10 @@ void eliza_llama_log_silence(void) {
 
 int32_t eliza_llama_context_attach_drafter(
     void* main_ctx, void* drafter_model,
-    uint32_t n_ctx_draft, int32_t n_gpu_layers_draft) {
-    (void)main_ctx; (void)drafter_model; (void)n_ctx_draft; (void)n_gpu_layers_draft;
+    uint32_t n_ctx_draft, int32_t n_gpu_layers_draft,
+    int32_t n_parallel) {
+    (void)main_ctx; (void)drafter_model; (void)n_ctx_draft;
+    (void)n_gpu_layers_draft; (void)n_parallel;
     return -38; // -ENOSYS
 }
 

--- a/packages/app-core/scripts/desktop-llama-shim/eliza_llama_shim.c
+++ b/packages/app-core/scripts/desktop-llama-shim/eliza_llama_shim.c
@@ -181,10 +181,51 @@ int32_t eliza_llama_decode_unified(void* ctx, void* batch) {
     return eliza_llama_decode(ctx, batch);
 }
 
+void eliza_llama_context_detach_drafter(void* main_ctx) {
+    // Stub: no-op until the C++ wrapper over common_speculative lands.
+    // The adapter calls this on context teardown; a no-op is safe because
+    // attach_drafter is itself a stub returning -ENOSYS, so there's no
+    // drafter to detach.
+    (void)main_ctx;
+}
+
+int32_t eliza_llama_context_has_drafter(void* main_ctx) {
+    // Stub: paired with attach_drafter — until that's wired, no context
+    // ever has a drafter attached.
+    (void)main_ctx;
+    return 0;
+}
+
 void eliza_llama_dflash_stats(void* ctx, int32_t* out) {
     (void)ctx;
     if (!out) return;
     out[0] = 0; out[1] = 0; out[2] = 0; out[3] = 0;
+}
+
+void eliza_llama_dflash_stats_ex(void* ctx, struct eliza_dflash_stats* out) {
+    // Stub for the extended telemetry struct (see eliza_llama_shim.h).
+    (void)ctx;
+    if (!out) return;
+    out->decoded = 0;
+    out->drafted = 0;
+    out->accepted = 0;
+    out->drafted_rejected = 0;
+    out->verify_steps = 0;
+}
+
+int32_t eliza_llama_context_handle_memory_pressure(void* main_ctx, int32_t level) {
+    // Stub: no drafter side-state to free, no KV to evict at this layer.
+    // Returns 0 (nothing freed) so memory-pressure callers fall through to
+    // their next strategy. Real wiring lands with the C++ speculative path.
+    (void)main_ctx;
+    (void)level;
+    return 0;
+}
+
+// Adapter-facing alias for dflash_stats — older adapter code calls this name.
+// Keep both symbols exported so the adapter doesn't have to track the rename.
+void eliza_llama_mtp_stats(void* ctx, int32_t* out) {
+    eliza_llama_dflash_stats(ctx, out);
 }
 
 // ─── token-tree sampler ──────────────────────────────────────────────────────


### PR DESCRIPTION
three fixes needed to land windows-x86_64 dylib builds after the server-mode → bun:ffi refactor.

## 1) build script: locate windows dll under either name

linux/macos produce `libllama.{so,dylib}` — cmake adds the `lib` prefix on shared libs. windows msvc produces `llama.dll` because pe doesn't carry the prefix. the runtime resolver in `desktop-llama-adapter.ts` always looks for `libllama.{so,dylib,dll}`, so on windows we have to find `llama.dll` in the build tree and stage it as `libllama.dll` in the output dir.

build script change: extend the candidate list + `find` fallback to look for both names on win32, and adjust the `staging` log line + error message to reflect what was actually searched.

## 2) shim source: define declared-but-undefined functions

`eliza_llama_shim.h` declares (and `desktop-llama-adapter.ts` ffi-binds) several symbols that had no definition in the .c file. on linux/macos with the default visibility / weak-link behavior this is forgiving at runtime; msvc emits hard `LNK2019` and the dll never builds.

added stub definitions for:

- `eliza_llama_context_detach_drafter` — no-op (paired with attach_drafter stub)
- `eliza_llama_context_has_drafter` — returns 0
- `eliza_llama_dflash_stats_ex` — zeros the extended telemetry struct
- `eliza_llama_context_handle_memory_pressure` — returns 0 (nothing freed at this layer)
- `eliza_llama_mtp_stats` — adapter-facing alias forwarding to `eliza_llama_dflash_stats`

each stub keeps the same contract as the existing `eliza_llama_dflash_stats` / `eliza_llama_attach_drafter` stubs so the shim links cleanly until the c++ wrapper over `common_speculative` lands.

## 3) attach_drafter signature drift with header (caught in review)

`eliza_llama_shim.h` declares `eliza_llama_context_attach_drafter` with 5 parameters (the last is `int32_t n_parallel`); the existing stub in the .c file only had 4. gcc/clang accept this with a warning, but msvc strict-c rejects it as a constraint violation. the adapter already passes 5 args at the bound binding (`n_parallel = 1` at the call site), so the .c stub now matches both the header and the ffi binding.

## verified

- built `libllama.dll` + `libeliza-llama-shim.dll` end-to-end on windows-x86_64 cuda backend (visual studio 17 2022 + cuda 12.4 + ninja)
- shim loaded into bun:ffi at runtime with all 39 symbols resolved
- model load reached the prewarm batch path before hitting a separate ggml batch-sizing assert that lives in a different layer (not introduced by this change) — tracked in #7991

context: the FFI refactor that made these gaps reachable is #7983.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two gaps that prevented the `libeliza-llama-shim.dll` from building on Windows MSVC: (1) the build script now searches for both `llama.dll` (Windows PE naming) and `libllama.dll` across additional VS/Ninja output layouts (`bin/Release`, `src/Release`) before staging it as `libllama.dll`; (2) the shim C file now provides stub definitions for five symbols that were declared in the header but had no definition, causing hard `LNK2019` linker errors on MSVC.

- **Build script** (`build-llama-cpp-desktop-dylib.mjs`): On `win32`, candidate paths now cover both the `lib`-prefixed and un-prefixed DLL names across all known CMake output subdirectories; the `find` fallback likewise iterates both names. The staging log now shows the destination filename.
- **Shim C file** (`eliza_llama_shim.c`): Adds no-op / zero-returning stubs for `eliza_llama_context_detach_drafter`, `eliza_llama_context_has_drafter`, `eliza_llama_dflash_stats_ex`, `eliza_llama_context_handle_memory_pressure`, and `eliza_llama_mtp_stats`; also fixes the `attach_drafter` signature to match the header's five-parameter declaration.

<h3>Confidence Score: 5/5</h3>

The changes are safe to merge — they add missing stub definitions that fix a real Windows linker failure and extend the build script's DLL search to cover Windows PE naming conventions.

Both changes are narrowly scoped: the C stubs are no-ops or zero-returns that match the existing stub pattern, and the build script search extension only adds more candidate paths and names on Windows. The one remaining gap — eliza_llama_mtp_stats lacking a header declaration — does not affect runtime correctness because all non-static symbols are exported by default with the GCC/Clang toolchain used for shim compilation.

No files require special attention; eliza_llama_shim.c has a minor header hygiene gap for eliza_llama_mtp_stats but no functional defects.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/build-llama-cpp-desktop-dylib.mjs | Extends libllama candidate search to include `llama.dll` (Windows PE naming) alongside `libllama.dll`, and adds `bin/Release` / `src/Release` layout paths; the `find` fallback for the unlucky case still invokes Unix `find` on Win32 (previously noted), but the static candidates now cover the common VS/Ninja layouts. |
| packages/app-core/scripts/desktop-llama-shim/eliza_llama_shim.c | Adds stub definitions for five previously-undeclared symbols (`detach_drafter`, `has_drafter`, `dflash_stats_ex`, `handle_memory_pressure`, `mtp_stats`) and fixes the `attach_drafter` parameter list to match the header's five-parameter signature; `eliza_llama_mtp_stats` is defined here but not declared in the header. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[buildTarget called] --> B[Step 1: cmake build libllama]
    B --> C{process.platform == win32?}
    C -- Yes --> D["buildOutputNames = [libllama.dll, llama.dll]"]
    C -- No --> E["buildOutputNames = [libllama.so/dylib]"]
    D --> F[Build candidates list\nbuildDir, bin/, bin/Release,\nsrc/, src/Release for each name]
    E --> F
    F --> G{candidate exists\non disk?}
    G -- Yes --> J[libllamaSrcPath = candidate]
    G -- No --> H["find fallback:\nspawnSync find for each name\n⚠ Unix find only — Windows find.exe\nsearches file content, not names"]
    H --> I{found?}
    I -- Yes --> J
    I -- No --> K[die: could not locate]
    J --> L["Stage: copy as libllama.dll/so/dylib\nto outDir"]
    L --> M[Step 3: stage headers]
    M --> N[Step 4: compile shim\ncc -shared -std=c11]
    N --> O[Step 5: nm smoke-check exports]
```

<sub>Reviews (2): Last reviewed commit: ["fix(desktop-llama-shim): align attach\_dr..."](https://github.com/elizaos/eliza/commit/1b4557216451cf9c566c8656f7bc16c8f5d1ca67) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33809997)</sub>

<!-- /greptile_comment -->