### PR TITLE
docs(os): restore packages/os/release/VERIFY.md deleted by integration merge

### DIFF
--- a/packages/os/release/VERIFY.md
+++ b/packages/os/release/VERIFY.md
@@ -1,0 +1,147 @@
+# Verifying an elizaOS release
+
+This page documents the verification stack the release pipeline ships
+and how to drive it end-to-end from a download directory.
+
+If you only want one command, run:
+
+```sh
+bash packages/os/scripts/verify-release.sh path/to/your/downloads
+```
+
+That script walks every layer below in order and exits non-zero on the
+first hard failure.
+
+---
+
+## What the release ships
+
+For a published release, the GitHub Release page contains:
+
+| File | What it is | Required? |
+| --- | --- | --- |
+| `*.raw.img.zst`, `*.qcow2.zst`, `*.utm.zip`, `*-android-*.zip` | Release artifacts | yes |
+| `SHA256SUMS` | Canonical aggregated checksums file | yes |
+| `*.spdx.json` | SPDX SBOM (Linux image only, today) | once landed |
+| `SHA256SUMS.asc` _(future)_ | Detached GPG signature on `SHA256SUMS` | once the signing-key RFC lands |
+
+Artifact filenames follow the pattern:
+
+```
+elizaos-{channel}-{date}-{platform}-{arch}.{ext}
+```
+
+For example: `elizaos-beta-2026.05.16-linux-x86_64.raw.img.zst`
+
+Per-artifact GitHub artifact attestations (SLSA build provenance via
+Sigstore) live in GitHub, not the release tarball. Verify them with the
+`gh` CLI as shown below.
+
+## Layer 1 — `SHA256SUMS` roundtrip (REQUIRED)
+
+The cheapest, most universal check. Available on any Unix.
+
+```sh
+cd path/to/your/downloads
+
+# Linux (coreutils):
+sha256sum -c SHA256SUMS --ignore-missing
+
+# macOS:
+shasum -a 256 -c SHA256SUMS --ignore-missing
+```
+
+Expected output (one line per artifact present in the directory):
+
+```
+elizaos-beta-2026.05.16-linux-x86_64.raw.img.zst: OK
+elizaos-beta-2026.05.16-vm-linux-x86_64.qcow2.zst: OK
+elizaos-beta-2026.05.16-vm-macos-silicon.utm.zip: OK
+```
+
+If any line says `FAILED`, the artifact has been modified in transit
+(or corrupted). Re-download.
+
+## Layer 2 — GitHub artifact attestations (RECOMMENDED)
+
+Each release artifact carries a Sigstore-signed SLSA build provenance
+attestation, minted at build time via GitHub OIDC. Verify with the
+[`gh` CLI](https://cli.github.com/):
+
+```sh
+gh attestation verify elizaos-beta-2026.05.16-linux-x86_64.raw.img.zst --owner elizaOS
+gh attestation verify elizaos-beta-2026.05.16-vm-linux-x86_64.qcow2.zst --owner elizaOS
+gh attestation verify SHA256SUMS                                           --owner elizaOS
+```
+
+Replace the date and channel with the actual release values. Each command
+will report the signing identity, the workflow that produced the artifact,
+the source commit, and the Sigstore Rekor entry. A passing verification
+means:
+
+- the artifact was built by the elizaOS GitHub repository
+- the build used the workflow source code at the recorded commit
+- the in-toto provenance has not been tampered with since signing
+
+If verification fails or returns "no attestations found", treat the
+download as unverified.
+
+## Layer 3 — GPG signature on `SHA256SUMS` (FUTURE)
+
+Once the [signing-key RFC](https://github.com/elizaOS/eliza) lands,
+each release will additionally ship a detached GPG signature:
+
+```sh
+# Import the elizaOS release key (one-time setup; fingerprint will be
+# published alongside the key once the RFC lands):
+gpg --import packages/os/release/keys/elizaos-release.asc
+
+# Per release:
+gpg --verify SHA256SUMS.asc SHA256SUMS
+```
+
+Until the RFC is resolved, this layer is N/A and the verification
+helper will print a `[--]` notice and skip it.
+
+## Layer 4 — SBOM inspection (OPTIONAL)
+
+Each Linux image release ships an SPDX-JSON SBOM enumerating every
+package in the image. Get a quick package count with:
+
+```sh
+jq '.packages | length' elizaos-beta-2026.05.16-linux-x86_64.spdx.json
+```
+
+For vulnerability scanning, feed the SBOM into [Grype](https://github.com/anchore/grype):
+
+```sh
+grype sbom:elizaos-beta-2026.05.16-linux-x86_64.spdx.json
+```
+
+## The one-command runner
+
+`packages/os/scripts/verify-release.sh` walks all four layers in order.
+It exits:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | every required check passed (optional layers may have been skipped) |
+| `1` | `SHA256SUMS` missing or roundtrip failed |
+| `2` | an optional layer ran and failed (invalid attestation, bad GPG sig) |
+
+It depends only on `sha256sum` (Linux) or `shasum` (macOS) for the
+required layer. `gh`, `gpg`, and `jq` enable the optional layers and
+produce notices when missing rather than failing.
+
+## Reporting verification problems
+
+If you hit a verification failure on a fresh download from an official
+release page, open an issue with:
+
+- the release tag (e.g. `v2.0.1`)
+- the failing layer (1 / 2 / 3 / 4)
+- the exact command output (truncate large logs)
+- whether you mirror-downloaded or pulled directly from GitHub
+
+False positives matter: a confirmed verification failure would be a
+serious supply-chain alert.


### PR DESCRIPTION
## What happened

PR #7909 (merged 2026-05-24 by Shaw, commit \`2312d14\`) shipped two files:
- \`packages/os/release/VERIFY.md\` (147 lines, end-user verification guide)
- \`packages/os/scripts/verify-release.sh\` (147 lines, one-command runner)

**The VERIFY.md was subsequently DELETED by the integration merge \`8114d5ad08\`** (\"merge: integrate PRs #7885, #7893, #7897, #7905, #7923, #7924, #7926 into develop\") during conflict resolution. The script survived (verified byte-for-byte against the original).

PR #7909 still shows \`state=MERGED\`, but \`git ls-tree origin/develop packages/os/release/\` only shows \`schema/\` — the doc is gone. So the end-user verify documentation got accepted, merged, and silently dropped.

## The fix (1 file, +147/-0)

Restore \`packages/os/release/VERIFY.md\` byte-for-byte from the last-known-good commit \`84e56517d1d26e50d0a72ea048f80fd6fdb4c013\` (the develop tip immediately before the \`8114d5ad08\` delete merge).

Force-add through \`.gitignore\` — \`packages/os/release/\` is ignored at line 778 (intentional for build outputs), but this file is first-class release documentation that overrides that ignore, same as the original #7909 did.

## Why this matters

The existing \`packages/os/scripts/verify-release.sh\` in develop has zero docs pointing at it from a discoverable user-facing location. The VERIFY.md is what tells a user \"download the release dir, run this one-command verify\":

\`\`\`sh
bash packages/os/scripts/verify-release.sh path/to/your/downloads
\`\`\`

Without VERIFY.md, end users have to read the script source to discover how to verify. With it restored, the four-layer trust stack documents itself.

## Pairs with

- **PR #7975** — \`packages/os/docs/verify-iso-download.md\`, the long-form per-step user guide. Complements VERIFY.md (short form, recommends the script) with deeper detail per verification step.
- **PRs #7976 + #7978 + #7980** — release pipeline startup_failure / skip-gracefully fixes that get the canonical SHA256SUMS this script verifies actually minted by CI.

## Hardening followup

The integration merge silently dropped this. A CI check "every file added by a merged PR in the last 30 days is still present in HEAD" would catch this class of regression. Worth a follow-up but not in this PR's scope.

## Verification

- [x] \`sha256sum\` confirms the file is byte-for-byte identical to the version Shaw merged at commit \`2312d14\`
- [x] verify-release.sh script that VERIFY.md references is already in develop (verified byte-for-byte vs the original)
- [x] PR diff: +147/-0, 1 file (\`packages/os/release/VERIFY.md\`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restores `packages/os/release/VERIFY.md` (147 lines), a user-facing guide documenting the four-layer release verification stack, which was silently dropped during an integration merge (`8114d5ad08`) despite PR #7909 having already been merged. The companion script `packages/os/scripts/verify-release.sh` was also referenced as restored but does not appear in this diff (it is already present in the repo).

- **VERIFY.md restored**: Documents SHA256SUMS roundtrip, GitHub artifact attestations, GPG signature verification (future), and SBOM inspection; matches the layered exit-code contract of `verify-release.sh`.
- **Minor inaccuracy**: The intro states the script "exits non-zero on the first hard failure," but the script runs all layers to completion for optional failures — only Layer 1 exits early.
- **Forward reference**: The GPG import example points to `packages/os/release/keys/elizaos-release.asc`, a path that does not yet exist in the repo.

<h3>Confidence Score: 4/5</h3>

Safe to merge — purely a documentation restoration with no logic changes to production code.

The change is a doc-only restoration. The two minor issues (misleading early-exit description and a forward-reference to a non-existent GPG key directory) do not affect runtime behaviour but could confuse users following the guide. No production code paths are touched.

packages/os/release/VERIFY.md — verify the script behaviour description and the GPG key path note before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/os/release/VERIFY.md | Restores 147-line end-user verification guide for release artifacts; one minor inaccuracy in the script behaviour description (early-exit claim vs. run-to-completion reality) and a reference to a non-existent GPG key directory. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User runs verify-release.sh DIR] --> B{SHA256SUMS present?}
    B -- No --> C[fail + exit 1]
    B -- Yes --> D{sha256sum / shasum available?}
    D -- No --> C
    D -- Yes --> E{Roundtrip OK?}
    E -- No --> C
    E -- Yes --> F[ok: Layer 1 passed]
    F --> G{gh CLI installed?}
    G -- No --> H[warn: skip attestations]
    G -- Yes --> I[gh attestation verify each artifact]
    I --> J{mixed pass/fail?}
    J -- Yes --> K[fail + EXIT=2]
    J -- No all-fail --> L[warn: no attestations verified]
    J -- all-pass --> M[ok: attestations clean]
    H & K & L & M --> N
    N{SHA256SUMS.asc / .sig present?}
    N -- No --> O[warn: skip GPG]
    N -- Yes --> P{gpg installed?}
    P -- No --> Q[warn: skip GPG]
    P -- Yes --> R{Good signature?}
    R -- No --> S[fail + EXIT=2]
    R -- Yes --> T[ok: GPG verified]
    O & Q & S & T --> U
    U{*.spdx.json present?}
    U -- No --> V[warn: skip SBOM]
    U -- Yes --> W{jq installed?}
    W -- No --> X[warn: skip SBOM]
    W -- Yes --> Y[ok: package count per SBOM]
    V & X & Y --> Z[exit EXIT]
```

<sub>Reviews (1): Last reviewed commit: ["docs(os): restore VERIFY.md + verify-rel..."](https://github.com/elizaos/eliza/commit/4fb9ba850639a48ea0be2427453c865910c63307) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33819428)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->