### PR TITLE
fix(cloud-api): cherry-pick #7992 tool_choice required fix to main

### DIFF
--- a/packages/cloud-api/__tests__/chat-completions-tool-choice.test.ts
+++ b/packages/cloud-api/__tests__/chat-completions-tool-choice.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure-helper tests for v1/chat/completions/route.ts's tool_choice + tools
+ * mappers. These exercise the AI-SDK shape conversion that runs before
+ * generateText/streamText, and prevent regressions of the
+ * `mapToolChoice("required")` crash — `"required"` is a valid OpenAI-API
+ * value (and the elizaOS planner sends it for forced-tool turns), but the
+ * pre-fix code only early-returned on "auto" / "none" and fell through to
+ * `toolChoice.function.name`, which is undefined on a string and produced
+ * a 500 with body `{"error":{"message":"Cannot read properties of
+ * undefined (reading 'name')"...}}`.
+ *
+ * Route-level happy-path / auth scenarios live in test/e2e — these are
+ * pure and run without I/O.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { __nativeToolingTestHooks } from "../v1/chat/completions/route";
+
+const { mapToolChoice, convertTools } = __nativeToolingTestHooks;
+
+describe("mapToolChoice", () => {
+  test("returns undefined when toolChoice is undefined", () => {
+    expect(mapToolChoice(undefined)).toBeUndefined();
+  });
+
+  test('returns "auto" unchanged', () => {
+    expect(mapToolChoice("auto")).toBe("auto");
+  });
+
+  test('returns "none" unchanged', () => {
+    expect(mapToolChoice("none")).toBe("none");
+  });
+
+  test('returns "required" unchanged (regression: pre-fix crashed with "Cannot read properties of undefined (reading \'name\')")', () => {
+    // This is the regression. The OpenAI API and the AI SDK both accept
+    // tool_choice: "required" to force the model to call some tool. The
+    // elizaOS planner sends it for forced-tool turns (services/message.ts).
+    // Before the fix, this fell through to `toolChoice.function.name` and
+    // crashed because `"required".function` is undefined.
+    expect(mapToolChoice("required")).toBe("required");
+  });
+
+  test("maps explicit function selection to AI-SDK { type: tool, toolName } shape", () => {
+    expect(
+      mapToolChoice({ type: "function", function: { name: "search_web" } }),
+    ).toEqual({ type: "tool", toolName: "search_web" });
+  });
+});
+
+describe("convertTools", () => {
+  test("returns undefined when tools is undefined", () => {
+    expect(convertTools(undefined)).toBeUndefined();
+  });
+
+  test("returns undefined when tools is an empty array", () => {
+    expect(convertTools([])).toBeUndefined();
+  });
+
+  test("maps a single OpenAI-shaped tool to an AI-SDK tool record keyed by name", () => {
+    const out = convertTools([
+      {
+        type: "function",
+        function: {
+          name: "search_web",
+          description: "Search the web for a query.",
+          parameters: {
+            type: "object",
+            properties: { q: { type: "string" } },
+            required: ["q"],
+          },
+        },
+      },
+    ]);
+
+    expect(out).toBeDefined();
+    const tool = out?.search_web;
+    expect(tool).toBeDefined();
+    expect(tool?.description).toBe("Search the web for a query.");
+    // inputSchema / outputSchema are AI-SDK JSONSchema wrappers; we just
+    // assert their presence rather than walk their internal shape.
+    expect(tool?.inputSchema).toBeDefined();
+    expect(tool?.outputSchema).toBeDefined();
+  });
+
+  test("omits description when tool has none", () => {
+    const out = convertTools([
+      { type: "function", function: { name: "noop" } },
+    ]);
+    expect(out?.noop).toBeDefined();
+    expect(out?.noop).not.toHaveProperty("description");
+  });
+});

--- a/packages/cloud-api/v1/chat/completions/route.ts
+++ b/packages/cloud-api/v1/chat/completions/route.ts
@@ -183,6 +183,7 @@ interface ChatRequest {
   tool_choice?:
     | "auto"
     | "none"
+    | "required"
     | { type: "function"; function: { name: string } };
   response_format?:
     | { type: "json_object" | "text" }
@@ -440,7 +441,9 @@ function mapToolChoice(
   | { type: "tool"; toolName: string }
   | undefined {
   if (!toolChoice) return undefined;
-  if (toolChoice === "auto" || toolChoice === "none") return toolChoice;
+  if (toolChoice === "auto" || toolChoice === "none" || toolChoice === "required") {
+    return toolChoice;
+  }
   return { type: "tool", toolName: toolChoice.function.name };
 }
 
@@ -1556,3 +1559,15 @@ honoRouter.post("/", rateLimit(RateLimitPresets.RELAXED), async (c) => {
   }
 });
 export default honoRouter;
+
+/**
+ * Test-only exports. Not part of the public route surface; the `__` prefix
+ * and `TestHooks` suffix make accidental third-party use obvious. Used by
+ * `__tests__/chat-completions-tool-choice.test.ts` to exercise the AI-SDK
+ * shape conversion helpers without spinning up the Hono router or hitting
+ * any model provider.
+ */
+export const __nativeToolingTestHooks = {
+  mapToolChoice,
+  convertTools,
+} as const;


### PR DESCRIPTION
## What

Cherry-pick of `3de23a6` (#7992) onto `main` to ship the production fix for the `tool_choice: "required"` 500 to `api.elizacloud.ai`.

## Why a cherry-pick

`develop` is ~42 commits ahead of `main` (1.76M lines of inserts across `packages/os`, `packages/robot`, `packages/chip`, and other heavy monorepo work). A full `develop -> main` promotion is a multi-day decision that wants Shaw in the loop. This PR ships **only** the `tool_choice` fix that's currently blocking 2-A-M's planner runs on production cloud.

Verified the diff is byte-identical to the squash-merge that landed on develop. `sha256(diff) == b839850e...`.

## What's in the diff

Same two-file delta that landed via #7992:

1. **`packages/cloud-api/v1/chat/completions/route.ts`** — adds `"required"` to `mapToolChoice`'s early-return guard + widens the `ChatRequest.tool_choice` input union. Also exports `__nativeToolingTestHooks` for the new test.
2. **`packages/cloud-api/__tests__/chat-completions-tool-choice.test.ts`** — 9 pure-helper tests covering all `mapToolChoice` branches + the `convertTools` shape. Verified passing locally: `9 pass / 0 fail / 14 expect() calls`.

## Why this is safe to admin-merge

- Diff is byte-identical to develop's `3de23a6` (verified via sha256)
- That commit was already approved + admin-merged on develop after a full review (#7992)
- The production fix is additive only: it only changes behavior for callers sending `tool_choice: "required"`, which previously crashed with a 500
- The test file was verified to load + pass after the `__nativeToolingTestHooks` export was added
- CI's `UNSTABLE` state is the same upstream develop-only breakage I've audited on every PR for the past week (TS errors in `packages/agent` + `plugin-undesirables`, biome issues in `dashboard/security/permissions/`, gitleaks findings in `packages/chip/*` and `evidence/tee/*`), none of which this diff touches

## Deploy path

Pushing to `main` triggers `Cloud CF Deploy` with `wrangler --env production`. The deploy ran cleanly on develop in ~7 min, expect the same here. Production cloud (`api.elizacloud.ai`) is currently on commit `45b4d873` (Shaw's last `cloud-*` push from 2026-05-23 PT). This cherry-pick is the first cloud-touching commit on main since then.

## Unblocks

`@2-A-M`'s 2PM container planner runs against `api.elizaos.ai` / `api.elizacloud.ai`. Currently every forced-tool turn (RESPONSE_HANDLER, PLAN_ACTIONS, facts-and-relationships) 500s.

Coordinating with @0xShadow on the merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This cherry-pick ships the `tool_choice: "required"` crash fix from `develop` to `main`, unblocking production planner runs on `api.elizacloud.ai`. The change is additive-only and only affects callers that send `tool_choice: "required"`.

- **`route.ts`**: Adds `"required"` to the `mapToolChoice` early-return guard and to the `ChatRequest.tool_choice` union type; the pre-fix code fell through to `toolChoice.function.name` on a string value, producing a `TypeError` 500. Also exports `__nativeToolingTestHooks` for the new tests.
- **`chat-completions-tool-choice.test.ts`**: Nine pure-helper tests covering every `mapToolChoice` branch and the `convertTools` output shape — no router or provider I/O required.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line guard addition with no behavioral impact on any existing code path.

The fix is surgical: it adds a single string literal to an existing equality check and widens the TypeScript union to match. All other branches of mapToolChoice are untouched. The new test file exercises every branch including the previously crashing one. No auth, billing, or model-dispatch logic is modified.

No files require special attention. Both changed files are straightforward and self-contained.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cloud-api/v1/chat/completions/route.ts | Adds "required" to mapToolChoice guard and ChatRequest union type, plus test-hooks export — minimal, correct fix for the tool_choice: "required" 500 crash. |
| packages/cloud-api/__tests__/chat-completions-tool-choice.test.ts | New pure-helper test file with 9 tests covering all mapToolChoice branches and convertTools shape; no I/O or mocking required. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming request tool_choice] --> B{mapToolChoice}
    B -->|undefined| C[return undefined]
    B -->|auto| D[return auto]
    B -->|none| E[return none]
    B -->|required NEW| F[return required]
    B -->|type:function object| G[return type:tool toolName]
    F --> I[generateText or streamText]
    G --> I
    D --> I
    E --> I
    B -->|required PRE-FIX| H[toolChoice.function.name TypeError 500]
```

<sub>Reviews (1): Last reviewed commit: ["fix(cloud-api): handle tool\_choice: &quot;req..."](https://github.com/elizaos/eliza/commit/1c2597fd3ded9a9a1c253a8f0b9e89bbc092cb82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33846652)</sub>

<!-- /greptile_comment -->