### PR TITLE
fix(cloud-api): add security response headers to the Worker

### DIFF
--- a/packages/cloud-api/src/bootstrap-app.ts
+++ b/packages/cloud-api/src/bootstrap-app.ts
@@ -8,6 +8,7 @@ import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import { logger as honoLogger } from "hono/logger";
 import { requestId } from "hono/request-id";
+import { secureHeaders } from "hono/secure-headers";
 import { runWithDbCacheAsync } from "@/db/client";
 import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
 import { corsMiddleware } from "@/lib/cors/cloud-api-hono-cors";
@@ -41,6 +42,49 @@ export function createApp(): Hono<AppEnv> {
 
   app.use("*", requestId());
   app.use("*", corsMiddleware);
+
+  // Security response headers for every API response. The SPA already ships
+  // these via Pages `_headers`, but the Worker (api.elizacloud.ai) shipped
+  // none — a ZAP scan flagged the missing X-Content-Type-Options and HSTS.
+  // Registered right after CORS: `credentials: true` makes the CORS middleware
+  // touch `c.res` on every request, so Hono re-wraps handler responses with a
+  // fresh (mutable) Headers — safe even for the raw `fetch()` passthrough
+  // routes (agent bridge/stream) whose upstream headers are otherwise frozen.
+  app.use(
+    "*",
+    secureHeaders({
+      xContentTypeOptions: "nosniff",
+      // Match the SPA's HSTS policy (2y + preload).
+      strictTransportSecurity: "max-age=63072000; includeSubDomains; preload",
+      // A JSON API must never be framed.
+      xFrameOptions: "DENY",
+      referrerPolicy: "strict-origin-when-cross-origin",
+      // OG images at /og are embedded cross-origin (<img>); the default
+      // `same-origin` CORP would block them.
+      crossOriginResourcePolicy: "cross-origin",
+      // No HTML is served, so a CSP adds breakage risk on the OpenAPI/OG
+      // surface with no benefit; COEP/COOP are meaningless for a windowless
+      // JSON API. Leave them off. `removePoweredBy` (default) drops X-Powered-By.
+      crossOriginEmbedderPolicy: false,
+      crossOriginOpenerPolicy: false,
+    }),
+  );
+
+  // Default unset JSON responses to `no-store` so dynamic/authenticated
+  // payloads aren't cached by proxies (ZAP "storable content" / cache-control
+  // findings). Routes that opt into caching (jwks, agent-card, openapi, og)
+  // already set their own Cache-Control and are left untouched.
+  app.use("*", async (c, next) => {
+    await next();
+    const headers = c.res.headers;
+    if (
+      !headers.has("Cache-Control") &&
+      headers.get("Content-Type")?.includes("application/json")
+    ) {
+      headers.set("Cache-Control", "no-store");
+    }
+  });
+
   app.use("*", honoLogger());
   app.use("*", async (c, next) => {
     c.set("requestId", c.get("requestId") ?? crypto.randomUUID());


### PR DESCRIPTION
## What

The Cloud API Worker (`api.elizacloud.ai`) shipped **no** security response headers, while the SPA already sets them via Pages `_headers`. A ZAP scan flagged the gap. This adds Hono's `secureHeaders` middleware (+ a Cache-Control default) right after the CORS middleware in `bootstrap-app.ts`.

## ZAP findings addressed

| Finding | Sev | Fix |
|---|---|---|
| X-Content-Type-Options missing | Info | `nosniff` on every response |
| Strict-Transport-Security not set | Info | HSTS `max-age=63072000; includeSubDomains; preload` (matches the SPA) |
| HTTPS content available via HTTP | Info | HSTS forces HTTPS (+ CF "Always Use HTTPS") |
| Re-examine Cache-Control / Storable content | Info/Low | unset JSON responses default to `Cache-Control: no-store` |
| Proxy disclosure | Low | `X-Powered-By` dropped (`removePoweredBy`) |

Also sets `X-Frame-Options: DENY` and `Referrer-Policy: strict-origin-when-cross-origin`.

## Deliberately not changed

- **CORS** (findings #1/#3): the middleware is already allowlist-based (no wildcard, reflects only approved origins, `null` for the rest) — not a real misconfig.
- **SRI missing** (#5): it's the Cloudflare Web Analytics beacon auto-injected by CF; there's no external `<script src>` in `index.html` to pin.
- Timestamp / suspicious comments / "Modern Web Application": ZAP informational noise.

## Safety notes

- Registered **after** CORS on purpose. CORS runs with `credentials: true`, so it touches `c.res` on every request → Hono re-wraps handler responses with a fresh mutable `Headers` before `secureHeaders` writes to them. This keeps the raw `fetch()` passthrough routes (agent `bridge`/`stream`, whose upstream headers are frozen on the Workers runtime) from throwing.
- `Cross-Origin-Resource-Policy: cross-origin` so the embeddable `/og` images keep loading cross-origin (the default `same-origin` would break them).
- `Cache-Control` default only applies when **absent** and Content-Type is JSON — the cacheable routes (`jwks`, `agent-card`, `openapi`, `og`) already set their own and are untouched.
- CSP/COEP/COOP intentionally left off: the API serves JSON (no browsing context), so they'd add breakage risk with no benefit.

## Verification

`bun run --cwd packages/cloud-api typecheck` → clean (0 errors). The immutable-headers edge case only manifests on the Workers runtime (not in `bun test`), so verify on the preview deploy:

```
curl -sI https://<preview>/api/health | grep -iE 'x-content-type-options|strict-transport-security|x-frame-options'
curl -sI https://<preview>/og/... | grep -i cross-origin-resource-policy   # expect cross-origin, image still 200
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Hono's `secureHeaders` middleware plus a custom `Cache-Control: no-store` default to the Cloud API Worker (`bootstrap-app.ts`), addressing several informational/low findings from a ZAP scan. The headers mirror the SPA's existing `_headers` policy and are carefully ordered after the CORS middleware to avoid immutable-header issues on the Workers runtime.

- `secureHeaders` is registered immediately after `corsMiddleware` so CORS's `credentials: true` path has already re-wrapped handler responses with mutable headers, preventing TypeErrors on frozen `fetch()` passthrough routes (agent bridge/stream).
- `crossOriginResourcePolicy: "cross-origin"` is intentionally set globally (not only for `/og`) because the API serves cross-origin `fetch()` clients and the CORS middleware is the real access-control gatekeeper; COEP/COOP are explicitly disabled as this Worker serves no browsing context.
- The `Cache-Control: no-store` middleware guards only unset JSON responses, leaving explicitly-cached routes (`jwks`, `agent-card`, `openapi`, `og`) untouched.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is additive and well-scoped to response headers only, with no modifications to auth, routing, or data handling.

The middleware ordering decision (post-CORS to avoid frozen-headers on passthrough routes) is correctly reasoned, Hono v4 ensures post-next code runs even through onError so error responses also receive the security headers and Cache-Control no-store, and the secureHeaders options match the stated ZAP findings without over-reaching into COEP/COOP. No functional regressions were identified.

No files require special attention; packages/cloud-api/src/bootstrap-app.ts is the only changed file and the changes are straightforward.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cloud-api/src/bootstrap-app.ts | Adds secureHeaders middleware and a custom Cache-Control default after CORS; ordering and options are well-justified; no logic errors found |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant CF as Cloudflare Worker
    participant MW as Middleware Chain
    participant Handler

    Client->>CF: HTTP Request
    CF->>MW: requestId()
    MW->>MW: corsMiddleware (sets mutable headers)
    MW->>MW: secureHeaders pre-next
    MW->>MW: cache-control pre-next
    MW->>MW: honoLogger
    MW->>MW: authMiddleware
    MW->>Handler: route handler
    Handler-->>MW: Response set on c.res
    MW-->>MW: authMiddleware post-next
    MW-->>MW: honoLogger post-next
    MW-->>MW: cache-control post-next adds no-store if JSON
    MW-->>MW: secureHeaders post-next adds security headers
    MW-->>MW: corsMiddleware post-next
    CF-->>Client: Response with all security headers
```

<sub>Reviews (1): Last reviewed commit: ["fix(cloud-api): add security response he..."](https://github.com/elizaos/eliza/commit/b87753ea741469565a95fe1916cfad5ba8054a16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33940460)</sub>

<!-- /greptile_comment -->