### PR TITLE
fix(plugin-local-inference): prefix Bun.build entrypoints with ./

### DIFF
--- a/plugins/plugin-local-inference/build.ts
+++ b/plugins/plugin-local-inference/build.ts
@@ -25,11 +25,16 @@ const start = Date.now();
 rmSync("dist", { recursive: true, force: true });
 
 const result = await Bun.build({
+	// Entrypoints MUST start with "./". Without it, Bun.build mis-roots
+	// relative-import resolution for the secondary entrypoints — the
+	// ./dflash-* imports reached via src/services/index.ts then fail with
+	// "Could not resolve" on the Linux CI runner while still building on
+	// macOS (oven-sh/bun#12734).
 	entrypoints: [
-		"src/index.ts",
-		"src/runtime/index.ts",
-		"src/routes/index.ts",
-		"src/services/index.ts",
+		"./src/index.ts",
+		"./src/runtime/index.ts",
+		"./src/routes/index.ts",
+		"./src/services/index.ts",
 	],
 	outdir: "dist",
 	target: "node",


### PR DESCRIPTION
## Summary

The agent image build (`build-agent-image.yml`) has been failing on `@elizaos/plugin-local-inference`:

```
error: Could not resolve: "./dflash-event-schema"
error: Could not resolve: "./dflash-metrics-collector"
error: Could not resolve: "./dflash-target-meta"
error: Could not resolve: "./dflash-verify-event"
error: script "build" exited with code 1
```

Root cause: `Bun.build` mis-roots relative-import resolution for **secondary** entrypoints when the entrypoint paths lack a `./` prefix ([oven-sh/bun#12734](https://github.com/oven-sh/bun/issues/12734)). `plugin-local-inference` is the only plugin with **multiple** entrypoints, so its `./dflash-*` imports — reached transitively via `src/services/index.ts` — resolved on macOS (case-insensitive / different path-walk) but failed on the Linux CI runner. Single-entrypoint plugins (`plugin-video`, `plugin-mcp`, etc.) using the same no-`./` convention were unaffected.

## Fix

Prefix all four `Bun.build` entrypoints with `./`. One-line-per-entrypoint, root-cause fix — no workflow/CI changes.

## Test plan

- [x] Builds locally with bun 1.3.8 **and** 1.3.13 (matching CI) before and after — produces `dist/` cleanly.
- [x] biome clean.
- [ ] Agent image build (`build-agent-image.yml`) goes green on this branch — was the only failing plugin.

## Context

Found while validating the cloud-agent provisioning chain after the Robot→Hetzner-Cloud control-plane migration. This unblocks the agent image build so cloud agents can be published with the boot fixes from #7981 (plugin-worker-runtime) and #7995 (server-mode TUI guard).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prefixes all four `Bun.build` entrypoints in `plugins/plugin-local-inference/build.ts` with `./` to work around a Bun path-resolution bug ([oven-sh/bun#12734](https://github.com/oven-sh/bun/issues/12734)) that caused secondary entrypoints to mis-root relative imports on Linux.

- `./src/index.ts`, `./src/runtime/index.ts`, `./src/routes/index.ts`, and `./src/services/index.ts` all receive the `./` prefix, fixing the \"Could not resolve\" errors seen on the Linux CI runner.
- A clear inline comment is added documenting the Bun bug, the macOS-vs-Linux discrepancy, and the upstream issue reference.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted string fix with no behavioural side-effects beyond restoring a working Linux build.

The only modification is adding `./` to four string literals in the entrypoints array. The inline comment accurately traces the root cause to an upstream Bun bug, and the fix is consistent with how other Bun-based build scripts handle entrypoint paths. No logic, types, runtime behavior, or other files are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-local-inference/build.ts | Four Bun.build entrypoints prefixed with `./`; well-documented with inline comment referencing the upstream Bun bug. No logic changes outside the entrypoint strings. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Bun.build called] --> B{Entrypoint has './' prefix?}
    B -- No --> C[Linux: mis-roots relative import resolution]
    B -- Yes --> D[All platforms: resolves correctly]
    C --> E["'Could not resolve: ./dflash-*' error"]
    D --> F[dist/ produced successfully]
    E --> G[CI build fails]
    F --> H[CI build passes]
```

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-local-inference): prefix Bun...."](https://github.com/elizaos/eliza/commit/9681f005b0d5218fc9dc50f62d3a38ec9b98372f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33945550)</sub>

<!-- /greptile_comment -->