### PR TITLE
fix(agent-image): bundle yaml + build plugin-edge-tts

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -162,9 +162,10 @@ jobs:
         run: |
           for plugin in plugin-sql plugin-video plugin-agent-skills plugin-pdf \
             plugin-browser plugin-capacitor-bridge plugin-coding-tools \
-            plugin-computeruse plugin-discord plugin-elizacloud plugin-imessage \
-            plugin-local-inference plugin-mcp plugin-signal plugin-streaming \
-            plugin-telegram plugin-whatsapp plugin-workflow plugin-x402; do
+            plugin-computeruse plugin-discord plugin-edge-tts plugin-elizacloud \
+            plugin-imessage plugin-local-inference plugin-mcp plugin-signal \
+            plugin-streaming plugin-telegram plugin-whatsapp plugin-workflow \
+            plugin-x402; do
             plugin_dir="plugins/$plugin"
             if [[ -f "$plugin_dir/package.json" ]] && jq -e '.scripts.build' "$plugin_dir/package.json" >/dev/null; then
               echo "::group::Building @elizaos/$plugin"

--- a/packages/app-core/deploy/Dockerfile.ci
+++ b/packages/app-core/deploy/Dockerfile.ci
@@ -46,6 +46,7 @@ RUN mkdir -p /tmp/docker-runtime-deps \
     pg@8.20.0 \
     uuid@14.0.0 \
     ws@8.20.0 \
+    yaml@2.8.2 \
   && mkdir -p /app/node_modules \
   && rm -rf \
     /app/node_modules/@electric-sql/pglite \
@@ -57,6 +58,7 @@ RUN mkdir -p /tmp/docker-runtime-deps \
     /app/node_modules/pg \
     /app/node_modules/uuid \
     /app/node_modules/ws \
+    /app/node_modules/yaml \
   && cp -a /tmp/docker-runtime-deps/node_modules/. /app/node_modules/ \
   && rm -rf /tmp/docker-runtime-deps
 


### PR DESCRIPTION
## Summary

Two **non-fatal** image-completeness gaps surfaced while validating cloud-agent boot after the Robot→Cloud migration. A provisioned agent loads **14/16** plugins instead of 16/16:

```
Error [eliza] Failed to load core plugin @elizaos/plugin-agent-skills: Cannot find package 'yaml' imported from /app/packages/skills/dist/frontmatter.js
Info  [eliza] Failed plugins: @elizaos/plugin-agent-skills (...yaml...), @elizaos/plugin-edge-tts (no valid Plugin export)
```

The agent runs fine without them (server boots, HTTP listens) — these just restore the two plugins.

## Root causes + fixes

1. **yaml** — `packages/skills` builds with `tsc --noCheck` (no bundling), so `dist/frontmatter.js` keeps a runtime `import "yaml"`. `Dockerfile.ci` excludes host `node_modules` and re-adds only an explicit runtime-dep allowlist to `/app/node_modules`; `yaml` wasn't in it. → Add `yaml@2.8.2` (matches skills' `^2.8.2`) to the install + rm-rf list.

2. **plugin-edge-tts** — listed in `packages/agent` `core-plugins.ts` (the agent loads it) and has a `build.ts`, but was missing from `build-agent-image.yml`'s plugin build loop → no `dist/` → "no valid Plugin export". → Add it to the loop.

## Test plan

- [x] yaml@2.8.2 matches `packages/skills` declared range.
- [x] plugin-edge-tts has a `build.ts` and is referenced in `core-plugins.ts`.
- [ ] Post-merge develop build → boot a provisioned agent → `plugin resolution complete: 16/16 loaded`.

## Context

Companion to the agent-boot chain (#7981 plugin-worker-runtime, #7995 server-mode TUI guard, #7997 Bun entrypoints). Those were fatal boot crashes; these two are non-fatal plugin-load failures batched together.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two plugin-load failures that prevented a cloud-agent from loading 16/16 plugins after the Robot→Cloud migration: `yaml` was missing from the Dockerfile's runtime-dep allowlist (causing `plugin-agent-skills` to fail on `import "yaml"`), and `plugin-edge-tts` was absent from the GHA plugin build loop (leaving it with no `dist/` and thus "no valid Plugin export").

- **`Dockerfile.ci`**: adds `yaml@2.8.2` to the `npm install` allowlist and the corresponding rm-rf/replace block, matching the `^2.8.2` range declared by `packages/skills/package.json`.
- **`build-agent-image.yml`**: inserts `plugin-edge-tts` into the workspace plugin build loop in alphabetical order (between `plugin-discord` and `plugin-elizacloud`); `plugin-edge-tts/package.json` confirms a `build` script backed by `build.ts`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; both changes are small, targeted, and follow the existing patterns in the Dockerfile and workflow.

The yaml version pin matches the declared semver range in packages/skills, and the plugin-edge-tts entry is correctly placed and backed by a real build.ts. The only gap is that plugins/plugin-edge-tts/** was not added to the workflow on.push.paths filter, so future changes to that plugin won't trigger an automatic image rebuild.

.github/workflows/build-agent-image.yml — consider adding plugins/plugin-edge-tts/** to the path triggers alongside the existing plugins/plugin-sql/** and plugins/plugin-elizacloud/** entries.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-agent-image.yml | Adds plugin-edge-tts to the workspace plugin build loop in alphabetical order between plugin-discord and plugin-elizacloud; no path trigger added for plugins/plugin-edge-tts/** |
| packages/app-core/deploy/Dockerfile.ci | Adds yaml@2.8.2 to the runtime npm install block and the corresponding rm-rf/replace pattern, matching the ^2.8.2 range declared by packages/skills/package.json |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/build-agent-image.yml`, line 11-23 ([link](https://github.com/elizaos/eliza/blob/7440badd4339867d8ea698b313fd274997c9b3e6/.github/workflows/build-agent-image.yml#L11-L23)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing path trigger for plugin-edge-tts**

   The `on.push.paths` filter includes entries for `plugins/plugin-sql/**` and `plugins/plugin-elizacloud/**`, but not `plugins/plugin-edge-tts/**`. Now that `plugin-edge-tts` is part of the build loop and baked into the image, a source change to that plugin won't trigger an image rebuild automatically — the fix would be silently skipped until a push on another watched path or a manual `workflow_dispatch`.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(agent-image): bundle yaml + build pl..."](https://github.com/elizaos/eliza/commit/7440badd4339867d8ea698b313fd274997c9b3e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34027961)</sub>

<!-- /greptile_comment -->