### PR TITLE
fix(roles): re-fire ensureOwnerRole on WORLD_JOINED/WORLD_CONNECTED

### DIFF
--- a/packages/agent/src/runtime/roles/src/index.ts
+++ b/packages/agent/src/runtime/roles/src/index.ts
@@ -382,6 +382,34 @@ const rolesPlugin: Plugin = {
       }
     }
 
+    // Step 3: Re-fire the bootstrap on every world-creation event. init()
+    // runs before any connector (Discord/Telegram/etc.) has populated
+    // runtime.worlds, so ensureOwnerRole sees an empty set and the scheduled
+    // retry tail fires three times within ~10s — usually still before the
+    // connector worlds land. Without this hook the owner role never lands in
+    // world metadata, resolveStage1SenderRole forever returns USER, and
+    // every ADMIN-gated context (tasks/code/automation/connectors) stays
+    // hidden from the Stage 1 planner. Hooking WORLD_JOINED + WORLD_CONNECTED
+    // makes the bootstrap converge as soon as the first connector world
+    // appears, regardless of the initial retry-window timing.
+    const rerunOwnerBootstrap = async (label: string): Promise<void> => {
+      const ok = await ensureOwnerRole(runtime, {
+        pruneConnectorAdmins: !hasConnectorAdmins,
+      });
+      if (ok) {
+        logger.info(`[roles] Owner role re-applied after ${label}`);
+      }
+      if (hasConnectorAdmins) {
+        await applyConnectorAdminWhitelists(runtime, connectorAdmins);
+      }
+    };
+    runtime.registerEvent("WORLD_JOINED", async () => {
+      await rerunOwnerBootstrap("WORLD_JOINED");
+    });
+    runtime.registerEvent("WORLD_CONNECTED", async () => {
+      await rerunOwnerBootstrap("WORLD_CONNECTED");
+    });
+
     logger.info("[roles] Roles initialized");
   },
 };


### PR DESCRIPTION
rolesPlugin.init() runs before any connector (Discord/Telegram/etc.) has populated runtime.worlds. `ensureOwnerRole` then sees an empty worlds set, returns `true` (the for-loop is empty - no error, no role applied), and the scheduled retry tail fires three times within ~10s. On a slow connector boot the worlds still are not present at the final retry, so the owner role never lands in world metadata.

## Symptom

`resolveStage1SenderRole` falls back to USER (rank 2) for the configured owner forever. Every ADMIN-gated context in `default-contexts.ts` (tasks, code, automation, connectors, agent_internal) is hidden from the Stage 1 planner. Higher-tier actions whose `roleGate` requires those contexts (notably the orchestrator `TASKS` surface) stay invisible to the LLM, so the planner cannot dispatch them and the run terminates with a generic reply.

Reproduces on any new install where Discord is the only/first connector: roles bootstrap runs, defers because the `worlds` table is empty, retries against an empty result set, exits successfully without applying any role.

## Fix

Hook `WORLD_JOINED` and `WORLD_CONNECTED` so the bootstrap re-fires the moment the first connector world appears, regardless of how the initial retry timing lined up. The function is idempotent: `ensureOwnerRole` rewrites world metadata in-place under `updateWorldMetadata`, which short-circuits when nothing changes.

## Test plan

- [ ] Verified in production deployment: `[roles] Synced canonical OWNER ... in world ...` now fires once Discord finishes connecting; previously stayed at `[roles] Deferring owner role bootstrap` forever
- [ ] Idempotency: ensureOwnerRole returns without changes on repeated world events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a race condition where `rolesPlugin.init()` runs before any connector (Discord/Telegram/etc.) has populated `runtime.worlds`, causing `ensureOwnerRole` to iterate over an empty set and the owner role to never land in world metadata. The fix registers `WORLD_JOINED` and `WORLD_CONNECTED` event handlers that re-fire the bootstrap as soon as the first connector world appears.

- Adds a `rerunOwnerBootstrap` closure that calls `ensureOwnerRole` (and optionally `applyConnectorAdminWhitelists`) on every world-creation event, making the bootstrap converge regardless of retry-window timing.
- Event handlers are registered inside `init()`, which runs within the plugin lifecycle's `AsyncLocalStorage` capture context, so they are correctly tracked and removed on plugin teardown/hot-reload.

<h3>Confidence Score: 4/5</h3>

The change is a targeted fix for a well-understood race condition and is safe to merge; the two rough edges are a noisy log in steady state and a silent failure path for connector-admin sync inside the event handler.

The core logic — hooking world events to re-fire the bootstrap — is correct and the function is idempotent. The plugin lifecycle tracking ensures handlers are cleaned up on hot-reload. The main concerns are: `ok` is always `true` on a successful call so 'reapplied' logs on every world event even when nothing changed, and if `applyConnectorAdminWhitelists` fails inside the event handler there is no warning logged and no retry scheduled, leaving connector-admin grants silently unapplied.

packages/agent/src/runtime/roles/src/index.ts — specifically the `rerunOwnerBootstrap` closure and its error handling for `applyConnectorAdminWhitelists`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/runtime/roles/src/index.ts | Adds WORLD_JOINED and WORLD_CONNECTED event hooks to re-fire ensureOwnerRole/applyConnectorAdminWhitelists when connector worlds arrive after the initial retry window; the log fires on every event including idempotent no-ops, and connector-admin sync failures in the event handler are silent with no retry path. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Runtime
    participant rolesPlugin
    participant ensureOwnerRole
    participant Connector

    Runtime->>rolesPlugin: init()
    rolesPlugin->>ensureOwnerRole: ensureOwnerRole() [worlds empty]
    ensureOwnerRole-->>rolesPlugin: true (no worlds to process)
    rolesPlugin->>Runtime: scheduleBootstrapRetry (1.5s, 3s, 5s)
    rolesPlugin->>Runtime: registerEvent(WORLD_JOINED, rerunOwnerBootstrap)
    rolesPlugin->>Runtime: registerEvent(WORLD_CONNECTED, rerunOwnerBootstrap)

    Note over Connector: Connector boots (may be >10s)
    Connector->>Runtime: emit WORLD_JOINED / WORLD_CONNECTED

    Runtime->>rolesPlugin: rerunOwnerBootstrap("WORLD_JOINED")
    rolesPlugin->>ensureOwnerRole: ensureOwnerRole() [worlds now populated]
    ensureOwnerRole-->>rolesPlugin: true (OWNER role applied)
    rolesPlugin-->>Runtime: "[roles] Owner role re-applied after WORLD_JOINED"
```

<sub>Reviews (1): Last reviewed commit: ["fix(roles): re-fire ensureOwnerRole on W..."](https://github.com/elizaos/eliza/commit/10b69f1545653354a0be466064d18a2957f6d557) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34032551)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->