### PR TITLE
fix(plugin-agent-orchestrator): runProvisionWorkspace honors params from planner

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -1577,7 +1577,7 @@ async function runProvisionWorkspace(
   runtime: IAgentRuntime,
   message: Memory,
   state: State | undefined,
-  _params: Record<string, unknown>,
+  params: Record<string, unknown>,
   _content: Record<string, unknown>,
   callback: HandlerCallback | undefined,
 ): Promise<ActionResult> {
@@ -1603,7 +1603,24 @@ async function runProvisionWorkspace(
     parentWorkspaceId?: string;
   };
 
-  let repo = content.repo;
+  // The planner calls TASKS via PLAN_ACTIONS with the workspace inputs in
+  // `parameters`, not in `message.content`. Treat `params` as the primary
+  // source so action-driven dispatch works; fall back to `content` only for
+  // legacy callers that stuffed the args into the message body.
+  const paramRepo =
+    typeof params.repo === "string" ? (params.repo as string) : undefined;
+  const paramBaseBranch =
+    typeof params.baseBranch === "string"
+      ? (params.baseBranch as string)
+      : undefined;
+  const paramUseWorktree =
+    params.useWorktree === true || params.useWorktree === "true";
+  const paramParentWorkspaceId =
+    typeof params.parentWorkspaceId === "string"
+      ? (params.parentWorkspaceId as string)
+      : undefined;
+
+  let repo = paramRepo ?? content.repo;
   if (!repo && content.text) {
     const urlMatch = content.text.match(
       /https?:\/\/(?:github\.com|gitlab\.com|bitbucket\.org)\/[\w.-]+\/[\w.-]+(?:\.git)?/i,
@@ -1613,7 +1630,7 @@ async function runProvisionWorkspace(
     }
   }
 
-  if (!repo && !content.useWorktree) {
+  if (!repo && !content.useWorktree && !paramUseWorktree) {
     if (callback)
       await callback({
         text: "Please specify a repository URL or use worktree mode with a parent workspace.",
@@ -1633,8 +1650,9 @@ async function runProvisionWorkspace(
     }
   }
 
-  let parentWorkspaceId = content.parentWorkspaceId;
-  if (content.useWorktree && !parentWorkspaceId) {
+  const useWorktree = paramUseWorktree || content.useWorktree === true;
+  let parentWorkspaceId = paramParentWorkspaceId ?? content.parentWorkspaceId;
+  if (useWorktree && !parentWorkspaceId) {
     if (state?.codingWorkspace) {
       parentWorkspaceId = (state.codingWorkspace as { id: string }).id;
     } else {
@@ -1650,8 +1668,8 @@ async function runProvisionWorkspace(
     const workspace: WorkspaceResult = await Promise.race([
       workspaceService.provisionWorkspace({
         repo: repo ?? "",
-        baseBranch: content.baseBranch,
-        useWorktree: content.useWorktree,
+        baseBranch: paramBaseBranch ?? content.baseBranch,
+        useWorktree,
         parentWorkspaceId,
       }),
       new Promise<never>((_, reject) =>


### PR DESCRIPTION
The PLAN_ACTIONS planner dispatches TASKS with action inputs in `parameters` (op/action, repo, baseBranch, useWorktree, parentWorkspaceId). `runProvisionWorkspace` ignored `_params` (note the underscore convention for unused args) and read everything from `message.content`, which is the original Discord/DM message body and never has repo/baseBranch keys.

## Symptom

Every planner-driven `build me X under <repo>` call returns `MISSING_REPO` even though the LLM passes the URL correctly:

```
PLAN_ACTIONS { action: "TASKS", parameters: { op: "provision_workspace", repo: "https://github.com/foo/bar", baseBranch: "main" } }
↓
runProvisionWorkspace(runtime, message, state, _params=<the params>, _content=<the content>, ...)
↓
message.content.repo === undefined → MISSING_REPO
```

## Fix

Treat `params` as the primary source; fall back to `message.content` only for legacy callers that stuffed args into the message body. Same pattern for `baseBranch`, `useWorktree`, and `parentWorkspaceId`. The handler signature drops the `_` prefix to reflect the actual usage.

## Test plan

- [ ] Verified locally: `parameters.repo` now reaches `workspaceService.provisionWorkspace` and the clone proceeds against the supplied URL
- [ ] No regression for legacy callers that pass repo in `message.content`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `runProvisionWorkspace` so it reads action parameters (`repo`, `baseBranch`, `useWorktree`, `parentWorkspaceId`) from the planner-supplied `params` argument rather than from `message.content`, which never contains those keys when dispatched via `PLAN_ACTIONS`. Legacy callers that embed args in the message body still work via `??` fallback.

- **Core fix**: renames `_params` → `params` and extracts `paramRepo`, `paramBaseBranch`, `paramUseWorktree`, and `paramParentWorkspaceId` from it, then merges with `content` using nullish coalescing.
- **Guard update**: the `MISSING_REPO` early-return now also checks `paramUseWorktree` so planner-driven worktree requests aren't rejected.
- **Provisioning call**: `baseBranch` and `useWorktree` passed to `workspaceService.provisionWorkspace` now prefer the planner values over the message body.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the stated bug fix, but the useWorktree merging logic can produce unexpected behaviour when planner and message-body values conflict.

The repo, baseBranch, and parentWorkspaceId parameters are wired correctly with proper type guards and nullish-coalescing fallbacks. The one structural gap is that useWorktree is merged with a plain || so a planner that explicitly passes useWorktree: false cannot suppress a true value already baked into the message body — this was caught in a prior review thread and has not yet been addressed.

plugins/plugin-agent-orchestrator/src/actions/tasks.ts — specifically the useWorktree merge expression noted in the previous review thread.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-orchestrator/src/actions/tasks.ts | runProvisionWorkspace now reads action inputs from params first; useWorktree merging via disjunction can allow content.useWorktree to override an explicit params.useWorktree: false from the planner (flagged in a prior review thread) |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;develop&#39; into milady/orch-..."](https://github.com/elizaos/eliza/commit/919206a9d2a5c697f64e773f8cc36b23578856cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34033144)</sub>

<!-- /greptile_comment -->