### PR TITLE
fix(plugin-agent-orchestrator): forward GITHUB_TOKEN to git-workspace-service

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-service.ts
@@ -354,13 +354,7 @@ export class CodingWorkspaceService {
         role: options.task?.role ?? "coding-agent",
         slug: options.task?.slug,
       },
-      userCredentials: options.userCredentials
-        ? {
-            type: options.userCredentials.type,
-            token: options.userCredentials.token ?? "",
-            provider: "github",
-          }
-        : undefined,
+      userCredentials: this.resolveUserCredentials(options.userCredentials),
     };
 
     const workspace = await this.workspaceService.provision(workspaceConfig);
@@ -764,6 +758,35 @@ export class CodingWorkspaceService {
     if (this.serviceConfig.debug) {
       logger.debug(`[CodingWorkspaceService] ${message}`);
     }
+  }
+
+  /**
+   * Resolve the credentials we hand to git-workspace-service. Callers who
+   * pass explicit credentials win; otherwise we fall back to GITHUB_TOKEN
+   * from runtime settings (which is how every dispatch from the orchestrator
+   * planner arrives — it does not pass userCredentials per-call). Without
+   * this fallback, planner-driven provisioning fires unauthenticated against
+   * private or yet-to-be-created repos and throws "requires authentication
+   * but no credentials are available", even though the orchestrator already
+   * has a working PAT loaded into a GitHubPatClient internally.
+   */
+  private resolveUserCredentials(
+    userCredentials: ProvisionWorkspaceOptions["userCredentials"],
+  ): WorkspaceConfig["userCredentials"] {
+    if (userCredentials) {
+      return {
+        type: userCredentials.type,
+        token: userCredentials.token ?? "",
+        provider: "github",
+      };
+    }
+    const githubToken = this.runtime.getSetting("GITHUB_TOKEN") as
+      | string
+      | undefined;
+    if (githubToken && githubToken.length > 0) {
+      return { type: "pat", token: githubToken, provider: "github" };
+    }
+    return undefined;
   }
 
   /** Read a key from the config file's env section (live, no restart needed). */


### PR DESCRIPTION
CodingWorkspaceService.provisionWorkspace only forwards credentials to git-workspace-service when the caller passes them in `options.userCredentials`. Every dispatch from the orchestrator planner arrives without that field (TASKS.handler does not synthesize one), so the underlying clone fires unauthenticated against private or yet-to-be-created repos and throws:

```
Repository https://github.com/foo/bar requires authentication but no credentials are available. Please provide credentials or configure OAuth.
```

This happens **even though CodingWorkspaceService already loads `GITHUB_TOKEN` into its own `GitHubPatClient` at init time**. The token is right there in the service - it just never gets handed down to the workspace clone path.

## Fix

`resolveUserCredentials()` prefers explicit `options.userCredentials`, then falls back to `runtime.getSetting("GITHUB_TOKEN")`. Net effect: when `GITHUB_TOKEN` is set (the common deployment), planner-driven provisioning Just Works against private / freshly-created repos.

## Test plan

- [ ] Verified locally: clone of a freshly-created private repo now succeeds when only GITHUB_TOKEN is in env, no per-call credentials passed
- [ ] No regression: explicit `options.userCredentials` still wins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a `resolveUserCredentials()` helper to `CodingWorkspaceService` so that planner-driven workspace provisioning automatically forwards `GITHUB_TOKEN` from runtime settings to `git-workspace-service`, fixing unauthenticated clone failures against private repos.

- Explicit `options.userCredentials` still take priority; the new fallback only kicks in when none are supplied, preserving backward compatibility.
- The fallback reads `GITHUB_TOKEN` exclusively via `runtime.getSetting`, which covers the common PAT-in-environment case but omits the `readConfigEnvKey` tier used by other settings.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it adds a targeted fallback for a missing credential-forwarding path without altering any existing behavior.

The new resolveUserCredentials helper is a small, well-scoped addition: explicit caller credentials still take priority, and the fallback only activates when none are provided. The logic is correct, TypeScript types line up, and the null/empty-string guards are sound.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-orchestrator/src/services/workspace-service.ts | Extracts inline userCredentials construction into resolveUserCredentials(), adding a fallback to runtime.getSetting(GITHUB_TOKEN) when no per-call credentials are provided. Logic is correct; explicit credentials still win. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[provisionWorkspace called] --> B{options.userCredentials?}
    B -- Yes --> C[Use explicit credentials]
    B -- No --> D[resolveUserCredentials fallback]
    D --> E{runtime.getSetting GITHUB_TOKEN?}
    E -- Present --> F[Return PAT credentials]
    E -- Not found --> G[Return undefined]
    C --> H[workspaceService.provision]
    F --> H
    G --> H
```

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;develop&#39; into milady/orch-..."](https://github.com/elizaos/eliza/commit/3e3e6ed43a24b9dbfb59f6408d5b50d2129e1d7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34033849)</sub>

<!-- /greptile_comment -->