### PR TITLE
fix(plugin-sql): emit USING clause for character varying→uuid migrations

### DIFF
--- a/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/03-type-changes-with-data.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/03-type-changes-with-data.real.test.ts
@@ -1,4 +1,4 @@
-import { boolean, integer, jsonb, pgTable, text, uuid } from "drizzle-orm/pg-core";
+import { boolean, integer, jsonb, pgTable, text, uuid, varchar } from "drizzle-orm/pg-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { RuntimeMigrator } from "../../../runtime-migrator/runtime-migrator";
 import type { DrizzleDB } from "../../../runtime-migrator/types";
@@ -305,5 +305,47 @@ describe("Schema Evolution Test: Type Changes with Data", () => {
     expect(afterTextData[0].enabled).toBe("true");
     expect(afterTextData[1].enabled).toBe("false");
     expect(afterTextData[2].active).toBeNull();
+  });
+
+  it("should handle varchar to uuid conversion with a USING clause", async () => {
+    // Regression: Postgres introspects `varchar` as "character varying".
+    // The USING-clause check missed that spelling, so an
+    // `ALTER COLUMN ref_id TYPE uuid` was emitted without a USING clause and
+    // Postgres rejected it ("cannot be cast automatically"). This is the
+    // exact failure that blocked agent boots whose memory tables predated
+    // the uuid id migration.
+    const tableV1 = pgTable("ref_rows", {
+      id: uuid("id").primaryKey().defaultRandom(),
+      ref_id: varchar("ref_id", { length: 36 }).notNull(),
+    });
+
+    await migrator.migrate("@elizaos/schema-evolution-test-varchar-uuid-v1", {
+      ref_rows: tableV1,
+    });
+
+    await db
+      .insert(tableV1)
+      .values([
+        { ref_id: "110e8400-e29b-41d4-a716-446655440001" },
+        { ref_id: "110e8400-e29b-41d4-a716-446655440002" },
+      ]);
+
+    // V2: ref_id becomes uuid.
+    const tableV2 = pgTable("ref_rows", {
+      id: uuid("id").primaryKey().defaultRandom(),
+      ref_id: uuid("ref_id").notNull(),
+    });
+
+    // Must not throw — the generated ALTER carries `USING ref_id::text::uuid`.
+    await migrator.migrate("@elizaos/schema-evolution-test-varchar-uuid-v1", {
+      ref_rows: tableV2,
+    });
+
+    const after = await db.select().from(tableV2);
+    const refs = after.map((r) => r.ref_id).sort();
+    expect(refs).toEqual([
+      "110e8400-e29b-41d4-a716-446655440001",
+      "110e8400-e29b-41d4-a716-446655440002",
+    ]);
   });
 });

--- a/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts
@@ -688,16 +688,16 @@ function checkIfNeedsUsingClause(fromType: string, toType: string): boolean {
   // normalize to "varchar" so the pairs below (e.g. varchar→uuid) match.
   // Without this, an ALTER COLUMN id TYPE uuid is emitted without a USING
   // clause and Postgres rejects it ("cannot be cast automatically").
-  const normalizeType = (t: string) =>
-    t.split("(")[0].toLowerCase().trim() === "character varying"
-      ? "varchar"
-      : t.split("(")[0].toLowerCase().trim();
+  const normalizeType = (t: string) => {
+    const base = t.split("(")[0].toLowerCase().trim();
+    return base === "character varying" ? "varchar" : base;
+  };
   const fromBase = normalizeType(fromType);
   const toBase = normalizeType(toType);
 
   // Text/varchar to JSONB always needs USING
   if (
-    (fromBase === "text" || fromBase === "varchar" || fromBase === "character varying") &&
+    (fromBase === "text" || fromBase === "varchar") &&
     (toBase === "jsonb" || toBase === "json")
   ) {
     return true;
@@ -719,8 +719,6 @@ function checkIfNeedsUsingClause(fromType: string, toType: string): boolean {
     ["varchar", "uuid"],
     ["varchar", "jsonb"],
     ["varchar", "json"],
-    ["character varying", "jsonb"],
-    ["character varying", "json"],
     // Add more as needed based on PostgreSQL casting rules
   ];
 

--- a/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts
@@ -684,8 +684,16 @@ function checkIfNeedsUsingClause(fromType: string, toType: string): boolean {
     return true;
   }
 
-  const fromBase = fromType.split("(")[0].toLowerCase();
-  const toBase = toType.split("(")[0].toLowerCase();
+  // Postgres introspection reports the canonical "character varying";
+  // normalize to "varchar" so the pairs below (e.g. varchar→uuid) match.
+  // Without this, an ALTER COLUMN id TYPE uuid is emitted without a USING
+  // clause and Postgres rejects it ("cannot be cast automatically").
+  const normalizeType = (t: string) =>
+    t.split("(")[0].toLowerCase().trim() === "character varying"
+      ? "varchar"
+      : t.split("(")[0].toLowerCase().trim();
+  const fromBase = normalizeType(fromType);
+  const toBase = normalizeType(toType);
 
   // Text/varchar to JSONB always needs USING
   if (


### PR DESCRIPTION
## Summary

The runtime migrator generates `ALTER COLUMN ... SET DATA TYPE uuid` **without** a `USING` clause when an existing `varchar`/`character varying` column is migrated to `uuid`, so Postgres rejects it:

```
Failed query: ALTER TABLE "public"."session_summaries" ALTER COLUMN "id" SET DATA TYPE uuid;
ERROR: column "id" cannot be cast automatically to type uuid
```

`checkIfNeedsUsingClause` lists the `["varchar","uuid"]` pair, but Postgres introspection reports the canonical spelling **`character varying`**, which the pair list only covers for `jsonb`/`json` — not `uuid` (nor integer/numeric/boolean). So the USING branch was skipped and the bare `SET DATA TYPE` failed.

This fails the migration on **every agent boot** against a database whose memory tables (`session_summaries`, `long_term_memories`, …) predate the uuid-id schema — i.e. any existing/shared agent DB. A fresh empty DB works because the schema is `CREATE`d, not `ALTER`ed.

## Fix

Normalize `"character varying"` → `"varchar"` before the conversion-pair lookup, so the existing `varchar→uuid` (and `varchar→integer/numeric/boolean/jsonb`) pairs match the introspected type. The migrator then emits:

```sql
ALTER TABLE ... ALTER COLUMN "id" TYPE uuid USING "id"::text::uuid;
```

## Test plan

- [x] New regression test in `03-type-changes-with-data.real.test.ts`: a `varchar(36)` column holding UUID-format strings migrated to `uuid` — succeeds and preserves values. **4/4** tests pass in the suite (pglite, real config).
- [x] Without the fix, the new test fails with the `cannot be cast automatically` error.
- [x] biome clean.

## Context

Final blocker found while validating cloud-agent boot end-to-end after the Robot→Cloud migration. Companion to the boot-crash chain (#7981 plugin-worker-runtime, #7995 server-mode TUI guard, #7997 Bun entrypoints, #8002 yaml/edge-tts). With this, a `:develop` agent boots cleanly against the existing shared agent DB instead of crash-looping on the failed migration.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a migration failure in `plugin-sql` where Postgres introspects `varchar` columns as `"character varying"` (the SQL-standard canonical name), which wasn't matched against the `"varchar"` entries in the `needsUsingPairs` lookup — causing `ALTER COLUMN ... SET DATA TYPE uuid` to be emitted without a `USING` clause and rejected by Postgres on any existing database.

- Introduces `normalizeType` in `checkIfNeedsUsingClause` to fold `"character varying"` → `"varchar"` before the pair lookup, so all `varchar→uuid`, `varchar→integer`, `varchar→jsonb`, etc. pairs fire correctly; the now-redundant `"character varying"` entries and branch are removed.
- Adds a regression test that creates a `varchar(36)` column, inserts UUID-format strings, migrates to the `uuid` type, and asserts the values survive the conversion.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted normalization in one function, backed by a direct regression test that reproduces the exact failure scenario.

The normalization is minimal and correct: it only touches the character varying → varchar alias mismatch that caused the cast failure, removes the now-redundant dead branches, and the new regression test exercises the exact Postgres code path (varchar→uuid via USING clause) that was broken in production.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts | Adds normalizeType helper to canonicalize "character varying" → "varchar" before the USING-clause pair lookup; removes now-dead "character varying" pairs and condition branch. |
| plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/03-type-changes-with-data.real.test.ts | Adds regression test: varchar(36) column holding UUID-format strings is migrated to uuid type via a USING clause, verifying values are preserved after migration. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["checkIfNeedsUsingClause(fromType, toType)"] --> B{Contains 'enum'?}
    B -- Yes --> C[return true]
    B -- No --> D["normalizeType: split on '(', lowercase, trim\n'character varying' → 'varchar'"]
    D --> E{fromBase is text/varchar\nAND toBase is jsonb/json?}
    E -- Yes --> C
    E -- No --> F{fromBase+toBase in needsUsingPairs?\ne.g. varchar→uuid, varchar→integer, text→uuid, …}
    F -- Yes --> C
    F -- No --> G[return false]
    G --> H["Emit: ALTER COLUMN ... SET DATA TYPE uuid\n(no USING — safe cast exists)"]
    C --> I["Emit: ALTER COLUMN ... TYPE uuid\nUSING col::text::uuid"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts`, line 700-723 ([link](https://github.com/elizaos/eliza/blob/948cd0c191d031187b3d5c7bec2aa196a979b8fc/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts#L700-L723)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dead `"character varying"` references after normalization**

   After `normalizeType` runs, `fromBase` and `toBase` can never equal `"character varying"` — the normalization unconditionally converts that spelling to `"varchar"`. This leaves two dead-code paths: the `fromBase === "character varying"` branch in the `if` on line 700, and the `["character varying", "jsonb"]` / `["character varying", "json"]` entries in `needsUsingPairs`. Their coverage is already provided by the existing `["varchar", "jsonb"]` and `["varchar", "json"]` pairs, so they can be removed without any loss of functionality.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["refactor(plugin-sql): drop now-dead char..."](https://github.com/elizaos/eliza/commit/34572deda015a90b2bb1e4578c78366791edb2d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34041220)</sub>

<!-- /greptile_comment -->