### PR TITLE
fix(plugin-sql): native cast for boolean→integer migrations

### DIFF
--- a/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/03-type-changes-with-data.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/03-type-changes-with-data.real.test.ts
@@ -348,4 +348,35 @@ describe("Schema Evolution Test: Type Changes with Data", () => {
       "110e8400-e29b-41d4-a716-446655440002",
     ]);
   });
+
+  it("should handle boolean to integer conversion with a native cast", async () => {
+    // Regression: the generic `::text::integer` bridge breaks here because
+    // Postgres rejects boolean text ('true'/'false') as integer input. The
+    // boolean→integer conversion must use the native cast (true→1, false→0).
+    const tableV1 = pgTable("flags", {
+      id: uuid("id").primaryKey().defaultRandom(),
+      active: boolean("active").notNull(),
+    });
+
+    await migrator.migrate("@elizaos/schema-evolution-test-bool-int-v1", {
+      flags: tableV1,
+    });
+
+    await db.insert(tableV1).values([{ active: true }, { active: false }]);
+
+    // V2: active becomes integer.
+    const tableV2 = pgTable("flags", {
+      id: uuid("id").primaryKey().defaultRandom(),
+      active: integer("active").notNull(),
+    });
+
+    // Must not throw — the generated ALTER carries `USING active::integer`.
+    await migrator.migrate("@elizaos/schema-evolution-test-bool-int-v1", {
+      flags: tableV2,
+    });
+
+    const after = await db.select().from(tableV2);
+    const values = after.map((r) => r.active).sort();
+    expect(values).toEqual([0, 1]);
+  });
 });

--- a/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts
+++ b/plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts
@@ -634,7 +634,7 @@ function generateAlterColumnSQL(
     if (needsUsing) {
       // For complex type changes, use USING clause like Drizzle
       statements.push(
-        `ALTER TABLE ${tableNameWithSchema} ALTER COLUMN "${column}" TYPE ${newType} USING "${column}"::text::${newType};`
+        `ALTER TABLE ${tableNameWithSchema} ALTER COLUMN "${column}" TYPE ${newType} USING ${buildUsingExpression(column, changesFromType || "", newType)};`
       );
     } else {
       statements.push(
@@ -670,6 +670,22 @@ function generateAlterColumnSQL(
   }
 
   return statements;
+}
+
+/**
+ * Build the USING expression for an ALTER COLUMN TYPE conversion.
+ *
+ * The generic `::text::<target>` bridge works for most conversions, but
+ * Postgres rejects boolean text ('true'/'false') as integer input, so
+ * boolean→integer must use the native cast (true→1, false→0) instead.
+ */
+function buildUsingExpression(column: string, fromType: string, toType: string): string {
+  const from = fromType.split("(")[0].toLowerCase().trim();
+  const to = toType.split("(")[0].toLowerCase().trim();
+  if (from === "boolean" && to === "integer") {
+    return `"${column}"::${toType}`;
+  }
+  return `"${column}"::text::${toType}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- The runtime-migrator generated `ALTER COLUMN ... USING "col"::text::integer` for **every** type change that needs a USING clause. For a boolean source column this is invalid: Postgres rejects boolean text (`'true'`/`'false'`) as integer input → `invalid input syntax for type integer: "true"`, and the migration throws.
- Routes the `boolean → integer` pair through the native cast `"col"::integer` (true→1, false→0), which is the supported Postgres path. Every other USING conversion keeps the generic `::text::<target>` bridge unchanged.

## Why
Follow-up to #8009 (which fixed `character varying → uuid`). While reviewing that USING-clause path I found this latent bug: it isn't hit by the agent's current schema, but any future `boolean → integer` column migration would fail at boot. Splitting it out so #8009 stayed minimal.

## Verified empirically (pglite / real Postgres)
- `'true'::text::integer` → **fails** (`invalid input syntax for type integer`)
- `true::integer` (native) → 1, `false::integer` → 0 ✅
- `integer → boolean` via `::text::boolean` still works (`'1'`→true, `'0'`→false), so it's left untouched.

## Test plan
- [x] New regression test: migrate a populated `boolean` column → `integer`, assert values become `[0, 1]` and no throw.
- [x] Full suite `03-type-changes-with-data.real.test.ts`: 5/5 pass (real pglite config).
- [x] `biome check` clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a latent boot-time crash in the runtime migrator: the generic `::text::integer` USING-clause bridge is invalid for boolean source columns because Postgres rejects the text representations `'true'`/`'false'` as integer input. The fix routes `boolean→integer` through the native cast (`"col"::integer`, true→1, false→0) while leaving all other conversions unchanged.

- **`sql-generator.ts`**: Extracts a new `buildUsingExpression` helper that selects `"col"::integer` for the `boolean→integer` pair and falls back to the existing `"col"::text::<type>` bridge for everything else.
- **`03-type-changes-with-data.real.test.ts`**: Adds a regression test that migrates a populated `boolean` column to `integer` and asserts the resulting values are `[0, 1]` without throwing.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it is a narrow, well-tested fix that only affects the boolean→integer USING-clause path, leaving all other migration codepaths untouched.

The fix is minimal: one new helper function, one call site changed, and a targeted regression test that exercises the exact Postgres cast that previously failed. The generic ::text::<type> bridge for every other type pair is unchanged. No existing behaviour is altered, the test suite confirms the corrected cast produces the expected values, and the PR description documents the empirical verification against both pglite and real Postgres.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-sql/src/runtime-migrator/drizzle-adapters/sql-generator.ts | Adds buildUsingExpression helper to correctly route boolean→integer casts; minimal, targeted change with no regressions for other type pairs. |
| plugins/plugin-sql/src/__tests__/migration/schema-evolution-tests/03-type-changes-with-data.real.test.ts | Adds a regression test for boolean→integer migration; inserts true/false rows, migrates schema, and asserts the resulting integer values are [0, 1]. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["generateAlterColumnSQL\nchangesFromType → newType"] --> B{"checkIfNeedsUsingClause\nfromType, toType"}
    B -- "no USING needed" --> C["SET DATA TYPE newType"]
    B -- "needs USING" --> D["buildUsingExpression\ncolumn, fromType, toType"]
    D --> E{"from === 'boolean'\nAND to === 'integer'?"}
    E -- "YES" --> F["USING col::integer\n(native cast: true→1, false→0)"]
    E -- "NO" --> G["USING col::text::toType\n(generic bridge)"]
    F --> H["ALTER TABLE … ALTER COLUMN TYPE …"]
    G --> H
    C --> H
```

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;develop&#39; into fix/plugin-s..."](https://github.com/elizaos/eliza/commit/b692dd5ae79026981bef2d46c47b0a4d6f7d57d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34060401)</sub>

<!-- /greptile_comment -->