### PR TITLE
fix: audit silent catch blocks

### DIFF
--- a/packages/agent/src/api/connector-routes.test.ts
+++ b/packages/agent/src/api/connector-routes.test.ts
@@ -1,0 +1,99 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { describe, expect, it, vi } from "vitest";
+import type { ConnectorRouteContext } from "./connector-routes";
+import { handleConnectorRoutes } from "./connector-routes";
+
+type CapturedResponse = {
+  status: number;
+  body: unknown;
+};
+
+function createHarness(options: {
+  method: string;
+  pathname: string;
+  body?: Record<string, unknown>;
+  state?: ConnectorRouteContext["state"];
+  saveElizaConfig?: ConnectorRouteContext["saveElizaConfig"];
+  onConnectorDisconnect?: ConnectorRouteContext["onConnectorDisconnect"];
+}) {
+  const captured: CapturedResponse = { status: 0, body: undefined };
+  const state: ConnectorRouteContext["state"] = options.state ?? {
+    config: { connectors: {} },
+  };
+  const ctx: ConnectorRouteContext = {
+    req: {} as IncomingMessage,
+    res: {} as ServerResponse,
+    method: options.method,
+    pathname: options.pathname,
+    state,
+    json: (_res, data, status = 200) => {
+      captured.status = status;
+      captured.body = data;
+    },
+    error: (_res, message, status = 500) => {
+      captured.status = status;
+      captured.body = { error: message };
+    },
+    readJsonBody: async <T extends object>() => (options.body ?? {}) as T,
+    saveElizaConfig: options.saveElizaConfig ?? vi.fn(),
+    redactConfigSecrets: (value) => value,
+    isBlockedObjectKey: (key) =>
+      key === "__proto__" || key === "constructor" || key === "prototype",
+    cloneWithoutBlockedObjectKeys: (value) => value,
+    onConnectorDisconnect: options.onConnectorDisconnect,
+  };
+
+  return { ctx, captured, state };
+}
+
+describe("connector routes", () => {
+  it("does not report connector updates as successful when config persistence fails", async () => {
+    const saveElizaConfig = vi.fn(() => {
+      throw new Error("disk denied");
+    });
+    const { ctx, captured, state } = createHarness({
+      method: "POST",
+      pathname: "/api/connectors",
+      body: { name: "slack", config: { enabled: true } },
+      saveElizaConfig,
+    });
+
+    await expect(handleConnectorRoutes(ctx)).resolves.toBe(true);
+
+    expect(captured.status).toBe(500);
+    expect(captured.body).toEqual({
+      error: "Failed to save connector config: disk denied",
+    });
+    expect(state.config.connectors).toEqual({});
+  });
+
+  it("rolls back connector deletion when config persistence fails", async () => {
+    const saveElizaConfig = vi.fn(() => {
+      throw new Error("disk denied");
+    });
+    const onConnectorDisconnect = vi.fn();
+    const config: ConnectorRouteContext["state"]["config"] = {
+      connectors: { slack: { enabled: true } },
+    };
+    (config as Record<string, unknown>).channels = { slack: { enabled: true } };
+    const { ctx, captured, state } = createHarness({
+      method: "DELETE",
+      pathname: "/api/connectors/slack",
+      state: { config },
+      saveElizaConfig,
+      onConnectorDisconnect,
+    });
+
+    await expect(handleConnectorRoutes(ctx)).resolves.toBe(true);
+
+    expect(captured.status).toBe(500);
+    expect(captured.body).toEqual({
+      error: "Failed to save connector config: disk denied",
+    });
+    expect(state.config.connectors).toEqual({ slack: { enabled: true } });
+    expect((state.config as Record<string, unknown>).channels).toEqual({
+      slack: { enabled: true },
+    });
+    expect(onConnectorDisconnect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/api/connector-routes.ts
+++ b/packages/agent/src/api/connector-routes.ts
@@ -192,13 +192,26 @@ export async function handleConnectorRoutes(
     }
     const { name: connectorName, config } = parsed.data;
     if (!state.config.connectors) state.config.connectors = {};
+    const previousConnector = state.config.connectors[connectorName];
     state.config.connectors[connectorName] = cloneWithoutBlockedObjectKeys(
       config,
     ) as ConnectorConfig;
     try {
       saveElizaConfig(state.config);
-    } catch {
-      /* test envs */
+    } catch (err) {
+      if (previousConnector === undefined) {
+        delete state.config.connectors[connectorName];
+      } else {
+        state.config.connectors[connectorName] = previousConnector;
+      }
+      error(
+        res,
+        err instanceof Error
+          ? `Failed to save connector config: ${err.message}`
+          : "Failed to save connector config",
+        500,
+      );
+      return true;
     }
     // Only treat this POST as a disconnect when the incoming payload
     // explicitly sets `enabled: false`. The second clause that read
@@ -241,25 +254,40 @@ export async function handleConnectorRoutes(
       error(res, "Missing or invalid connector name", 400);
       return true;
     }
-    if (
-      state.config.connectors &&
-      Object.hasOwn(state.config.connectors, name)
-    ) {
-      delete state.config.connectors[name];
-    }
+    const previousConnector =
+      state.config.connectors && Object.hasOwn(state.config.connectors, name)
+        ? state.config.connectors[name]
+        : undefined;
+    if (previousConnector !== undefined) delete state.config.connectors?.[name];
     const stateConfigRecord = state.config as Record<string, unknown>;
-    if (
+    const channels =
       stateConfigRecord.channels &&
-      typeof stateConfigRecord.channels === "object" &&
-      Object.hasOwn(stateConfigRecord.channels, name)
-    ) {
-      delete (stateConfigRecord.channels as Record<string, unknown>)[name];
+      typeof stateConfigRecord.channels === "object"
+        ? (stateConfigRecord.channels as Record<string, unknown>)
+        : undefined;
+    const previousChannel =
+      channels && Object.hasOwn(channels, name) ? channels[name] : undefined;
+    if (channels && previousChannel !== undefined) {
+      delete channels[name];
     }
 
     try {
       saveElizaConfig(state.config);
-    } catch {
-      /* test envs */
+    } catch (err) {
+      if (previousConnector !== undefined && state.config.connectors) {
+        state.config.connectors[name] = previousConnector;
+      }
+      if (previousChannel !== undefined && channels) {
+        channels[name] = previousChannel;
+      }
+      error(
+        res,
+        err instanceof Error
+          ? `Failed to save connector config: ${err.message}`
+          : "Failed to save connector config",
+        500,
+      );
+      return true;
     }
     try {
       await emitConnectorDisconnected(state.runtime, name);

--- a/packages/agent/src/runtime/trajectory-internals.ts
+++ b/packages/agent/src/runtime/trajectory-internals.ts
@@ -668,8 +668,12 @@ export async function flushObservationBuffer(
     }
 
     return observations;
-  } catch {
-    // Non-critical — observations are best-effort
+  } catch (err) {
+    warnRuntime(
+      runtime,
+      "[trajectory-persistence] observation flush failed",
+      err,
+    );
     return [];
   } finally {
     delete runtimeRecord.__orchestratorTrajectoryCtx;
@@ -771,7 +775,12 @@ export async function computeBySource(
       if (src) bySource[src] = toNumber(r.cnt, 0);
     }
     return bySource;
-  } catch {
+  } catch (err) {
+    warnRuntime(
+      runtime,
+      "[trajectory-persistence] source aggregation failed",
+      err,
+    );
     return {};
   }
 }
@@ -948,8 +957,12 @@ export async function ensureTrajectoriesTable(
         runtime,
         `CREATE INDEX IF NOT EXISTS idx_trajectories_scenario_id ON trajectories(scenario_id)`,
       );
-    } catch {
-      // ignore if index creation fails
+    } catch (err) {
+      warnRuntime(
+        runtime,
+        "[trajectory-persistence] scenario index creation failed",
+        err,
+      );
     }
     try {
       await executeRawSql(
@@ -964,8 +977,12 @@ export async function ensureTrajectoriesTable(
         runtime,
         `CREATE INDEX IF NOT EXISTS idx_trajectories_batch_id ON trajectories(batch_id)`,
       );
-    } catch {
-      // ignore if index creation fails
+    } catch (err) {
+      warnRuntime(
+        runtime,
+        "[trajectory-persistence] batch index creation failed",
+        err,
+      );
     }
     try {
       await executeRawSql(
@@ -1005,16 +1022,24 @@ export async function ensureTrajectoriesTable(
         runtime,
         `CREATE INDEX IF NOT EXISTS idx_trajectory_steps_trajectory_id ON trajectory_steps(trajectory_id)`,
       );
-    } catch {
-      // ignore if index creation fails
+    } catch (err) {
+      warnRuntime(
+        runtime,
+        "[trajectory-persistence] trajectory step index creation failed",
+        err,
+      );
     }
     try {
       await executeRawSql(
         runtime,
         `CREATE INDEX IF NOT EXISTS idx_trajectory_steps_ordinal ON trajectory_steps(trajectory_id, ordinal)`,
       );
-    } catch {
-      // ignore if index creation fails
+    } catch (err) {
+      warnRuntime(
+        runtime,
+        "[trajectory-persistence] trajectory step ordinal index creation failed",
+        err,
+      );
     }
 
     // One-shot forward migration from steps_json into trajectory_steps.

--- a/packages/agent/src/runtime/trajectory-observability.test.ts
+++ b/packages/agent/src/runtime/trajectory-observability.test.ts
@@ -1,0 +1,56 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { describe, expect, it, vi } from "vitest";
+import {
+  computeBySource,
+  flushObservationBuffer,
+  pushChatExchange,
+} from "./trajectory-internals";
+
+function createRuntime() {
+  const warn = vi.fn();
+  const runtime = {
+    actions: [],
+    adapter: { db: undefined },
+    logger: { warn },
+    useModel: vi.fn(async () => {
+      throw new Error("model down");
+    }),
+  } as unknown as IAgentRuntime;
+  return { runtime, warn };
+}
+
+describe("trajectory observability", () => {
+  it("logs observation flush failures before returning an empty result", async () => {
+    const { runtime, warn } = createRuntime();
+    pushChatExchange(runtime, {
+      userPrompt: "hello",
+      response: "hi",
+      trajectoryId: "trajectory-1",
+      timestamp: Date.now(),
+    });
+
+    await expect(flushObservationBuffer(runtime)).resolves.toEqual([]);
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: expect.any(Error),
+        subsystem: "trajectory-db",
+      }),
+      "[trajectory-persistence] observation flush failed",
+    );
+  });
+
+  it("logs source aggregation failures before returning an empty result", async () => {
+    const { runtime, warn } = createRuntime();
+
+    await expect(computeBySource(runtime)).resolves.toEqual({});
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        err: expect.any(Error),
+        subsystem: "trajectory-db",
+      }),
+      "[trajectory-persistence] source aggregation failed",
+    );
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/native/auth-bridge.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/auth-bridge.test.ts
@@ -1,0 +1,67 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../logger";
+import {
+  loadPersistedSession,
+  resolveAuthDir,
+  resolveSessionPath,
+} from "./auth-bridge";
+
+vi.mock("../logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const tempRoots: string[] = [];
+
+function createStateDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "desktop-auth-bridge-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+describe("desktop auth bridge", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    for (const dir of tempRoots.splice(0)) {
+      fs.rmSync(dir, { force: true, recursive: true });
+    }
+  });
+
+  it("logs malformed persisted desktop sessions before falling through", () => {
+    const stateDir = createStateDir();
+    const env = { ELIZA_STATE_DIR: stateDir };
+    fs.mkdirSync(resolveAuthDir(env), { recursive: true });
+    const sessionPath = resolveSessionPath(env);
+    fs.writeFileSync(sessionPath, "{", "utf8");
+
+    expect(loadPersistedSession(env, () => 1_700_000_000_000)).toBeNull();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[DesktopAuthBridge] Failed to parse persisted desktop session",
+      expect.objectContaining({
+        sessionPath,
+        error: expect.any(String),
+      }),
+    );
+  });
+
+  it("treats a missing persisted desktop session as normal first-run state", () => {
+    const stateDir = createStateDir();
+    const env = { ELIZA_STATE_DIR: stateDir };
+
+    expect(loadPersistedSession(env, () => 1_700_000_000_000)).toBeNull();
+
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/native/auth-bridge.ts
+++ b/packages/app-core/platforms/electrobun/src/native/auth-bridge.ts
@@ -32,6 +32,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { getBrandConfig } from "../brand-config";
+import { logger } from "../logger";
 
 export const DESKTOP_BOOTSTRAP_ENDPOINT = "/api/auth/desktop-bootstrap";
 export const SESSION_COOKIE_NAME = "eliza_session";
@@ -75,6 +76,17 @@ interface DesktopBootstrapResponseBody {
   sessionId?: string;
   csrfToken?: string;
   expiresAt?: number;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function warnAuthBridge(
+  message: string,
+  context: Record<string, unknown>,
+): void {
+  logger.warn(`[DesktopAuthBridge] ${message}`, context);
 }
 
 // ── State paths ───────────────────────────────────────────────────────────────
@@ -127,9 +139,9 @@ export function resolveSocketDir(env: NodeJS.ProcessEnv = process.env): string {
 // ── Persisted-session round-trip ─────────────────────────────────────────────
 
 /**
- * Try to load a previously-minted desktop session. Returns null on any failure
- * (missing file, wrong schema, expired, malformed JSON). Failure is silent —
- * caller is expected to fall through to `bootstrapDesktopSession`.
+ * Try to load a previously-minted desktop session. Missing files, wrong schema,
+ * and expired sessions fall through to `bootstrapDesktopSession`; unreadable or
+ * malformed files are logged before falling through.
  */
 export function loadPersistedSession(
   env: NodeJS.ProcessEnv = process.env,
@@ -141,14 +153,22 @@ export function loadPersistedSession(
   let raw: string;
   try {
     raw = fs.readFileSync(sessionPath, "utf8");
-  } catch {
+  } catch (err) {
+    warnAuthBridge("Failed to read persisted desktop session", {
+      sessionPath,
+      error: errorMessage(err),
+    });
     return null;
   }
 
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
-  } catch {
+  } catch (err) {
+    warnAuthBridge("Failed to parse persisted desktop session", {
+      sessionPath,
+      error: errorMessage(err),
+    });
     return null;
   }
 
@@ -180,8 +200,12 @@ export function persistSession(
   // Best-effort tighten in case mkdir respected an inherited umask.
   try {
     fs.chmodSync(dir, 0o700);
-  } catch {
-    /* non-fatal on platforms where chmod has no effect */
+  } catch (err) {
+    warnAuthBridge("Failed to chmod desktop auth directory", {
+      dir,
+      mode: "0700",
+      error: errorMessage(err),
+    });
   }
   const sessionPath = resolveSessionPath(env);
   const body = JSON.stringify(
@@ -197,8 +221,12 @@ export function persistSession(
   fs.writeFileSync(sessionPath, body, { encoding: "utf8", mode: 0o600 });
   try {
     fs.chmodSync(sessionPath, 0o600);
-  } catch {
-    /* non-fatal */
+  } catch (err) {
+    warnAuthBridge("Failed to chmod persisted desktop session", {
+      sessionPath,
+      mode: "0600",
+      error: errorMessage(err),
+    });
   }
 }
 
@@ -208,8 +236,11 @@ export function clearPersistedSession(
   const sessionPath = resolveSessionPath(env);
   try {
     if (fs.existsSync(sessionPath)) fs.unlinkSync(sessionPath);
-  } catch {
-    /* non-fatal */
+  } catch (err) {
+    warnAuthBridge("Failed to clear persisted desktop session", {
+      sessionPath,
+      error: errorMessage(err),
+    });
   }
 }
 
@@ -244,8 +275,12 @@ function openBootstrapSocket(
   fs.mkdirSync(socketDir, { recursive: true, mode: 0o700 });
   try {
     fs.chmodSync(socketDir, 0o700);
-  } catch {
-    /* non-fatal */
+  } catch (err) {
+    warnAuthBridge("Failed to chmod desktop auth socket directory", {
+      socketDir,
+      mode: "0700",
+      error: errorMessage(err),
+    });
   }
 
   const socketPath = path.join(socketDir, socketName);
@@ -253,8 +288,11 @@ function openBootstrapSocket(
   // Stale socket from a previous crashed run — unlink before bind.
   try {
     if (fs.existsSync(socketPath)) fs.unlinkSync(socketPath);
-  } catch {
-    /* swallowed; bind will report the real failure */
+  } catch (err) {
+    warnAuthBridge("Failed to unlink stale desktop auth socket", {
+      socketPath,
+      error: errorMessage(err),
+    });
   }
 
   let resolveConsumed: () => void = () => {};
@@ -282,8 +320,12 @@ function openBootstrapSocket(
   // is enforced; on macOS UDS permissions are advisory but still useful.
   try {
     fs.chmodSync(socketPath, 0o600);
-  } catch {
-    /* non-fatal */
+  } catch (err) {
+    warnAuthBridge("Failed to chmod desktop auth socket", {
+      socketPath,
+      mode: "0600",
+      error: errorMessage(err),
+    });
   }
 
   return {
@@ -292,13 +334,19 @@ function openBootstrapSocket(
     close: () => {
       try {
         server.close();
-      } catch {
-        /* no-op */
+      } catch (err) {
+        warnAuthBridge("Failed to close desktop auth socket server", {
+          socketPath,
+          error: errorMessage(err),
+        });
       }
       try {
         if (fs.existsSync(socketPath)) fs.unlinkSync(socketPath);
-      } catch {
-        /* no-op */
+      } catch (err) {
+        warnAuthBridge("Failed to remove desktop auth socket", {
+          socketPath,
+          error: errorMessage(err),
+        });
       }
     },
   };
@@ -321,7 +369,11 @@ function isLoopbackBase(apiBase: string): boolean {
       host === "::1" ||
       host === "[::1]"
     );
-  } catch {
+  } catch (err) {
+    warnAuthBridge("Invalid desktop auth API base", {
+      apiBase,
+      error: errorMessage(err),
+    });
     return false;
   }
 }
@@ -359,7 +411,10 @@ export async function bootstrapDesktopSession(
   let socketHandle: BootstrapSocket | null = null;
   try {
     socketHandle = openBootstrapSocket(env, secret);
-  } catch {
+  } catch (err) {
+    warnAuthBridge("Failed to open desktop auth bootstrap socket", {
+      error: errorMessage(err),
+    });
     return null;
   }
 
@@ -383,7 +438,11 @@ export async function bootstrapDesktopSession(
   // Swallow that orphaned rejection so it can't surface as an unhandled
   // rejection and crash the Electrobun worker; the awaited path on line ~388
   // still re-throws normally because `.catch()` returns a separate chain.
-  consumedOrTimeout.catch(() => {});
+  consumedOrTimeout.catch((err: unknown) => {
+    logger.debug("[DesktopAuthBridge] Bootstrap socket was not consumed", {
+      error: errorMessage(err),
+    });
+  });
 
   let body: DesktopBootstrapResponseBody | null = null;
   try {
@@ -400,19 +459,33 @@ export async function bootstrapDesktopSession(
     if (!response.ok) {
       // 404 means the backend doesn't implement the endpoint yet — flag in
       // logs but stay silent in the UX so the renderer can still log in.
+      warnAuthBridge("Desktop auth bootstrap endpoint failed", {
+        url,
+        status: response.status,
+      });
       return null;
     }
 
-    body = (await response
-      .json()
-      .catch(() => null)) as DesktopBootstrapResponseBody | null;
+    try {
+      body = (await response.json()) as DesktopBootstrapResponseBody;
+    } catch (err) {
+      warnAuthBridge("Failed to parse desktop auth bootstrap response", {
+        url,
+        error: errorMessage(err),
+      });
+      return null;
+    }
 
     // Wait for the API to actually connect to the socket before we tear it
     // down. If the API never connects we still got an HTTP response, but the
     // session it minted was based on something other than filesystem proof —
     // refuse it.
     await consumedOrTimeout;
-  } catch {
+  } catch (err) {
+    warnAuthBridge("Desktop auth bootstrap failed", {
+      url,
+      error: errorMessage(err),
+    });
     return null;
   } finally {
     socketHandle.close();
@@ -453,9 +526,11 @@ export async function loadOrCreateDesktopSession(
 
   try {
     persistSession(fresh, env);
-  } catch {
-    // Persistence is best-effort: even without it, the renderer is logged in
-    // for the lifetime of this process.
+  } catch (err) {
+    warnAuthBridge("Failed to persist desktop session", {
+      sessionPath: resolveSessionPath(env),
+      error: errorMessage(err),
+    });
   }
   return fresh;
 }
@@ -510,7 +585,11 @@ export function installDesktopSessionCookies(
     let parsed: URL;
     try {
       parsed = new URL(origin);
-    } catch {
+    } catch (err) {
+      warnAuthBridge("Invalid desktop session cookie origin", {
+        origin,
+        error: errorMessage(err),
+      });
       return;
     }
     const key = parsed.origin;

--- a/packages/app-core/platforms/electrobun/src/native/location.test.ts
+++ b/packages/app-core/platforms/electrobun/src/native/location.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { logger } from "../logger";
+import { LocationManager } from "./location";
+
+vi.mock("../logger", () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const originalFetch = globalThis.fetch;
+
+describe("LocationManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("logs failed IP geolocation providers before returning no position", async () => {
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("network down");
+    }) as typeof fetch;
+
+    await expect(
+      new LocationManager().getCurrentPosition(),
+    ).resolves.toBeNull();
+
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[Location] IP geolocation provider failed",
+      expect.objectContaining({
+        error: "network down",
+        url: expect.any(String),
+      }),
+    );
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/native/location.ts
+++ b/packages/app-core/platforms/electrobun/src/native/location.ts
@@ -1,3 +1,4 @@
+import { logger } from "../logger";
 import type { SendToWebview } from "../types.js";
 
 interface GeoPosition {
@@ -26,6 +27,10 @@ const IP_GEO_SERVICES = [
  * the Swift shell.
  */
 const IP_GEO_ACCURACY_METERS = 5000;
+
+function locationErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
 
 export class LocationManager {
   private sendToWebview: SendToWebview | null = null;
@@ -57,7 +62,12 @@ export class LocationManager {
         };
         this.lastKnown = position;
         return position;
-      } catch {}
+      } catch (err) {
+        logger.warn("[Location] IP geolocation provider failed", {
+          url,
+          error: locationErrorMessage(err),
+        });
+      }
     }
     return null;
   }

--- a/packages/app-core/platforms/electrobun/src/native/screencapture.ts
+++ b/packages/app-core/platforms/electrobun/src/native/screencapture.ts
@@ -25,7 +25,19 @@ import path from "node:path";
 import { BrowserWindow } from "electrobun/bun";
 import { getBrandConfig } from "../brand-config";
 import { DEFAULT_API_PORT } from "../constants";
+import { logger } from "../logger";
 import type { SendToWebview, WebviewEvalRpc } from "../types.js";
+
+function screenCaptureErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function warnScreenCapture(
+  message: string,
+  context: Record<string, unknown>,
+): void {
+  logger.warn(`[ScreenCapture] ${message}`, context);
+}
 
 /**
  * Allow-list for game-capture URLs.
@@ -42,7 +54,11 @@ function isAllowedCaptureUrl(url: string): boolean {
       parsed.hostname === "127.0.0.1" ||
       parsed.protocol === "file:"
     );
-  } catch {
+  } catch (err) {
+    warnScreenCapture("Invalid capture URL", {
+      url,
+      error: screenCaptureErrorMessage(err),
+    });
     return false;
   }
 }
@@ -130,7 +146,14 @@ $bmp.Dispose()`;
               stderr: "ignore",
             });
           }
-        } catch {
+        } catch (err) {
+          logger.debug(
+            "[ScreenCapture] scrot screenshot failed; trying import",
+            {
+              error: screenCaptureErrorMessage(err),
+              tmpPath,
+            },
+          );
           proc = Bun.spawn(["import", "-window", "root", tmpPath], {
             stdout: "ignore",
             stderr: "ignore",
@@ -150,13 +173,22 @@ $bmp.Dispose()`;
 
       const data = fs.readFileSync(actualPath).toString("base64");
       return { available: true, data: `data:image/png;base64,${data}` };
-    } catch {
+    } catch (err) {
+      warnScreenCapture("Screenshot capture failed", {
+        error: screenCaptureErrorMessage(err),
+        tmpPath,
+      });
       return { available: false };
     } finally {
       for (const p of [tmpPath, `${tmpPath}.png`]) {
         try {
           if (fs.existsSync(p)) fs.unlinkSync(p);
-        } catch {}
+        } catch (err) {
+          logger.debug("[ScreenCapture] Screenshot temp cleanup failed", {
+            path: p,
+            error: screenCaptureErrorMessage(err),
+          });
+        }
       }
     }
   }
@@ -186,13 +218,24 @@ $bmp.Dispose()`;
           const data = fs.readFileSync(actualPath).toString("base64");
           return { available: true, data: `data:image/png;base64,${data}` };
         }
-      } catch {
-        // Fall through to full-screen capture
+      } catch (err) {
+        warnScreenCapture(
+          "Window capture failed; falling back to full screen",
+          {
+            windowId: options.windowId,
+            error: screenCaptureErrorMessage(err),
+          },
+        );
       } finally {
         for (const p of [tmpPath, `${tmpPath}.png`]) {
           try {
             if (fs.existsSync(p)) fs.unlinkSync(p);
-          } catch {}
+          } catch (err) {
+            logger.debug("[ScreenCapture] Window capture temp cleanup failed", {
+              path: p,
+              error: screenCaptureErrorMessage(err),
+            });
+          }
         }
       }
     }
@@ -246,7 +289,11 @@ $bmp.Dispose()`;
         };
       }
       return { available: true };
-    } catch {
+    } catch (err) {
+      warnScreenCapture("Screen recording failed to start", {
+        outputPath,
+        error: screenCaptureErrorMessage(err),
+      });
       this.recordingProc = null;
       this.recordingPath = null;
       this.recordingStart = null;
@@ -263,7 +310,11 @@ $bmp.Dispose()`;
     try {
       this.recordingProc.kill("SIGTERM");
       await this.recordingProc.exited;
-    } catch {}
+    } catch (err) {
+      logger.debug("[ScreenCapture] Recording process stop failed", {
+        error: screenCaptureErrorMessage(err),
+      });
+    }
 
     this.recordingProc = null;
     this.recordingPaused = false;
@@ -288,7 +339,10 @@ $bmp.Dispose()`;
       this.recordingProc.kill("SIGSTOP");
       this.recordingPaused = true;
       return { available: true };
-    } catch {
+    } catch (err) {
+      warnScreenCapture("Screen recording pause failed", {
+        error: screenCaptureErrorMessage(err),
+      });
       return { available: false };
     }
   }
@@ -301,7 +355,10 @@ $bmp.Dispose()`;
       this.recordingProc.kill("SIGCONT");
       this.recordingPaused = false;
       return { available: true };
-    } catch {
+    } catch (err) {
+      warnScreenCapture("Screen recording resume failed", {
+        error: screenCaptureErrorMessage(err),
+      });
       return { available: false };
     }
   }
@@ -422,7 +479,14 @@ $bmp.Dispose()`;
                 stderr: "ignore",
               });
             }
-          } catch {
+          } catch (err) {
+            logger.debug(
+              "[ScreenCapture] scrot frame capture failed; trying import",
+              {
+                error: screenCaptureErrorMessage(err),
+                tmpPath,
+              },
+            );
             proc = Bun.spawn(["import", "-window", "root", tmpPath], {
               stdout: "ignore",
               stderr: "ignore",
@@ -449,16 +513,27 @@ $bmp.Dispose()`;
           method: "POST",
           headers: { "Content-Type": "image/jpeg" },
           body,
-        }).catch(() => {});
-      } catch {
-        // Skip frame on error
+        }).catch((err: unknown) => {
+          logger.debug("[ScreenCapture] Frame upload failed", {
+            endpoint,
+            error: screenCaptureErrorMessage(err),
+          });
+        });
+      } catch (err) {
+        logger.debug("[ScreenCapture] Frame capture skipped", {
+          error: screenCaptureErrorMessage(err),
+          tmpPath,
+        });
       } finally {
         // Clean up temp file (handle both possible paths from screencapture)
         for (const p of [tmpPath, `${tmpPath}.jpg`]) {
           try {
             if (fs.existsSync(p)) fs.unlinkSync(p);
-          } catch {
-            // Ignore cleanup errors
+          } catch (err) {
+            logger.debug("[ScreenCapture] Frame temp cleanup failed", {
+              path: p,
+              error: screenCaptureErrorMessage(err),
+            });
           }
         }
         skipping = false;
@@ -543,9 +618,16 @@ $bmp.Dispose()`;
             method: "POST",
             headers: { "Content-Type": "image/jpeg" },
             body,
-          }).catch(() => {});
-        } catch {
-          // Skip frame
+          }).catch((err: unknown) => {
+            logger.debug("[ScreenCapture] Game frame upload failed", {
+              endpoint,
+              error: screenCaptureErrorMessage(err),
+            });
+          });
+        } catch (err) {
+          logger.debug("[ScreenCapture] Game frame capture skipped", {
+            error: screenCaptureErrorMessage(err),
+          });
         } finally {
           skipping = false;
         }
@@ -581,7 +663,11 @@ $bmp.Dispose()`;
     if (this.frameCaptureWindow) {
       try {
         this.frameCaptureWindow.close();
-      } catch {}
+      } catch (err) {
+        warnScreenCapture("Frame capture window close failed", {
+          error: screenCaptureErrorMessage(err),
+        });
+      }
       this.frameCaptureWindow = null;
     }
 
@@ -611,7 +697,11 @@ $bmp.Dispose()`;
       const base64 = options.data.replace(/^data:[^;]+;base64,/, "");
       fs.writeFileSync(filePath, Buffer.from(base64, "base64"));
       return { available: true, path: filePath };
-    } catch {
+    } catch (err) {
+      warnScreenCapture("Saving screenshot failed", {
+        filename: options.filename ?? null,
+        error: screenCaptureErrorMessage(err),
+      });
       return { available: false };
     }
   }
@@ -635,7 +725,11 @@ $bmp.Dispose()`;
     if (this.recordingProc) {
       try {
         this.recordingProc.kill("SIGTERM");
-      } catch {}
+      } catch (err) {
+        logger.debug("[ScreenCapture] Recording process dispose failed", {
+          error: screenCaptureErrorMessage(err),
+        });
+      }
       this.recordingProc = null;
       this.recordingPath = null;
       this.recordingStart = null;


### PR DESCRIPTION
## Summary

- fail connector config saves loudly instead of treating failed persistence as success
- log desktop auth bridge, native capability, and trajectory fallback failures with structured context
- keep the audit scoped to silent catch/fallback paths

## Validation

- CodeRabbit CLI review against origin/develop: findings 0
- branch pushed to origin/codex/silent-catch-remediation-20260526

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR audits and remediates silent `catch` blocks across the agent and app-core packages. It converts silent swallows into structured `logger.warn`/`logger.debug` calls with context, and reclassifies the connector config persistence failure as a loud HTTP 500 with in-memory state rollback rather than a silent success.

- **connector-routes.ts**: POST and DELETE handlers now capture pre-mutation state, roll it back on `saveElizaConfig` failure, and return a 500 with the error message instead of silently continuing. Two new tests exercise each rollback path.
- **auth-bridge.ts / location.ts / screencapture.ts**: All previously silent `catch {}` blocks now call `logger.warn` or `logger.debug` with structured context objects. Missing session files are still handled silently via an `existsSync` guard before the warn-capable catch.
- **trajectory-internals.ts**: Five silent DB-failure catches now call `warnRuntime` with subsystem context, and two new tests verify the log output.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are mechanical error-logging improvements with well-targeted tests and correct rollback semantics.

Every changed path is covered by a new test. The connector-routes rollback logic correctly handles both new-key and existing-key cases for both the POST and DELETE handlers, and the disconnect callback is correctly gated behind a successful save. The auth-bridge missing-file path remains silent via the existsSync guard, consistent with the JSDoc and test. All other changes are pure observability additions that cannot alter runtime behavior.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/agent/src/api/connector-routes.ts | POST and DELETE handlers now roll back in-memory state and return HTTP 500 on saveElizaConfig failure; rollback logic correctly handles both new-key (delete) and existing-key (restore) cases. |
| packages/agent/src/api/connector-routes.test.ts | New test file covering saveElizaConfig failure on POST (500 + state not mutated) and DELETE (500 + full rollback including channels, disconnect callback not called). |
| packages/app-core/platforms/electrobun/src/native/auth-bridge.ts | All silent catch blocks replaced with warnAuthBridge/debug calls; missing session files handled silently via existsSync guard before the warn-capable readFileSync catch. |
| packages/app-core/platforms/electrobun/src/native/auth-bridge.test.ts | Two tests: malformed JSON triggers warn, absent session file returns null without any warn call. |
| packages/app-core/platforms/electrobun/src/native/location.ts | Empty catch on IP geolocation provider failure replaced with structured logger.warn call including url and error. |
| packages/app-core/platforms/electrobun/src/native/screencapture.ts | All ~15 silent catch blocks converted to structured warn/debug logging with appropriate severity levels. |
| packages/agent/src/runtime/trajectory-internals.ts | Five silent DB-catch blocks now call the pre-existing warnRuntime helper with subsystem context. |
| packages/agent/src/runtime/trajectory-observability.test.ts | Two new tests exercise the warn path for flushObservationBuffer and computeBySource, verifying structured log context. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;develop&#39; into codex/silent..."](https://github.com/elizaos/eliza/commit/5d565726aed8e057e46b03734534d0d738d2dd02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34075016)</sub>

<!-- /greptile_comment -->