### PR TITLE
fix(cloud): ensure agent bridge network exists before docker create

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/docker-ensure-network.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/docker-ensure-network.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Covers buildEnsureNetworkCmd — the idempotent, race-safe command the
+ * provisioner runs before `docker create --network` so a node missing the
+ * shared bridge network (Robot cores, pruned networks) self-heals instead of
+ * failing every provision with "network not found".
+ */
+import { describe, expect, test } from "bun:test";
+import { buildEnsureNetworkCmd } from "../docker-sandbox-utils";
+
+describe("buildEnsureNetworkCmd", () => {
+  test("inspects first, creates only if missing", () => {
+    const cmd = buildEnsureNetworkCmd("containers-isolated");
+    expect(cmd).toBe(
+      "docker network inspect 'containers-isolated' >/dev/null 2>&1 || " +
+        "docker network create --driver bridge 'containers-isolated' >/dev/null 2>&1 || " +
+        "docker network inspect 'containers-isolated' >/dev/null 2>&1",
+    );
+  });
+
+  test("re-inspects after create to survive a concurrent create race", () => {
+    const cmd = buildEnsureNetworkCmd("net");
+    // inspect ... || create ... || inspect ...  → three clauses
+    expect(cmd.split("||").length).toBe(3);
+    expect(cmd.startsWith("docker network inspect")).toBe(true);
+    expect(cmd.trim().endsWith("docker network inspect 'net' >/dev/null 2>&1")).toBe(true);
+  });
+
+  test("only ever creates a plain bridge network (no implicit subnet)", () => {
+    const cmd = buildEnsureNetworkCmd("net");
+    expect(cmd).toContain("docker network create --driver bridge 'net'");
+    expect(cmd).not.toContain("--subnet");
+  });
+
+  test("shell-escapes the network name", () => {
+    const cmd = buildEnsureNetworkCmd("a'b");
+    // single quote is closed/escaped/reopened, never left bare
+    expect(cmd).toContain(`'a'"'"'b'`);
+    expect(cmd).not.toContain(" a'b ");
+  });
+});

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -25,6 +25,7 @@ import {
   allocatePort,
   BRIDGE_PORT_MAX,
   BRIDGE_PORT_MIN,
+  buildEnsureNetworkCmd,
   dockerPlatformFlag,
   extractDockerCreateContainerId,
   getContainerName,
@@ -719,6 +720,12 @@ export class DockerSandboxProvider implements SandboxProvider {
         envFlags,
         shellQuote(resolvedImage),
       ].join(" ");
+
+      // Self-heal nodes missing the shared bridge network (Robot cores never
+      // run the cloud-init bootstrap; the network can also be pruned away).
+      // Without this, `docker create --network` below fails with an opaque
+      // "network not found" and the provision retries forever.
+      await ssh.exec(buildEnsureNetworkCmd(DOCKER_NETWORK), DOCKER_CMD_TIMEOUT_MS);
 
       const containerId = extractDockerCreateContainerId(
         await ssh.exec(dockerCreateCmd, DOCKER_CMD_TIMEOUT_MS),

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-utils.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-utils.ts
@@ -46,6 +46,27 @@ export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
+/**
+ * Idempotent, race-safe shell command that guarantees the shared agent bridge
+ * network exists on a node before a container is attached to it.
+ *
+ * `node-bootstrap.ts` creates this network in cloud-init, but only for nodes
+ * provisioned through the Hetzner Cloud autoscaler. Hetzner Robot cores (and
+ * any node whose network was removed out-of-band) never run that bootstrap, so
+ * `docker create --network <net>` fails with an opaque "network <net> not
+ * found" and the provision retries forever. Running this first lets the
+ * provisioner self-heal that drift.
+ *
+ * The final `inspect` covers the create-create race when two provisions land on
+ * the same node simultaneously: the loser's `create` fails ("already exists"),
+ * then the re-`inspect` confirms the winner's network and the command still
+ * exits 0.
+ */
+export function buildEnsureNetworkCmd(network: string): string {
+  const net = shellQuote(network);
+  return `docker network inspect ${net} >/dev/null 2>&1 || docker network create --driver bridge ${net} >/dev/null 2>&1 || docker network inspect ${net} >/dev/null 2>&1`;
+}
+
 // ---------------------------------------------------------------------------
 // Platform / Architecture helpers
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The provisioner ran `docker create --network containers-isolated` on the target node assuming the network already existed. It didn't always: cloud-init `node-bootstrap.ts` creates it, but **only for Hetzner Cloud autoscaled nodes**. Hetzner Robot cores (and any node whose network was pruned out-of-band) never run that bootstrap → `docker create` fails with an opaque `network containers-isolated not found`, the agent never starts, and the provisioner retries forever with no auto-heal.
- Adds an idempotent, race-safe `docker network inspect || create --driver bridge || inspect` run on the node right **before** container creation, so the provisioner self-heals that drift. Extracted as `buildEnsureNetworkCmd` (mirrors the canonical `node-bootstrap.ts` pattern) with unit tests.

## Why
Found live this session: a real user agent was stuck in a permanent provision/crash loop because it landed on a core that was missing `containers-isolated` (a Robot core never covered by cloud-init). Creating the network by hand fixed it immediately — this makes the fix automatic and durable.

The third `inspect` clause handles the create-create race when two provisions hit the same node at once: the loser's `create` errors (`already exists`), the re-`inspect` confirms the winner's network, and the command still exits 0.

## Test plan
- [x] `bun test docker-ensure-network.test.ts` — 4/4 (exact command, 3-clause race-safety, plain bridge / no implicit subnet, shell-escaping).
- [x] `biome check` clean on all 3 files.
- [x] `typecheck` clean for the changed files.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a production issue where agents on Hetzner Robot cores got stuck in a permanent provision loop because the `containers-isolated` Docker network was missing — Robot cores don't run the cloud-init `node-bootstrap.ts` that creates it. The fix adds an idempotent `inspect || create || inspect` shell command executed over SSH before `docker create`, letting the provisioner self-heal that drift automatically.

- **`docker-sandbox-utils.ts`**: Adds `buildEnsureNetworkCmd`, a pure function that emits the three-clause race-safe shell command, reusing the existing `shellQuote` helper.
- **`docker-sandbox-provider.ts`**: Calls `buildEnsureNetworkCmd(DOCKER_NETWORK)` via `ssh.exec` immediately before `docker create --network`, so the network is guaranteed present on the target node.
- **`docker-ensure-network.test.ts`**: Four unit tests covering the exact command shape, race-safety clause count, absence of `--subnet`, and correct single-quote shell escaping.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is a targeted self-heal injected at a single well-understood point in the provision flow, with no effect on the happy path when the network already exists.

The three-clause idempotent pattern is correct and the shell escaping is verified by tests. The one thing worth noting is that stderr is suppressed on the final `inspect`, so if both the create and the re-inspect fail (daemon issue, permission error, etc.), the provisioner log will only show a generic exit-code failure with no Docker error detail — making unusual failure modes harder to diagnose.

The suppressed stderr on the last `docker network inspect` in `docker-sandbox-utils.ts` is the only line worth revisiting.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cloud-shared/src/lib/services/docker-sandbox-utils.ts | Adds `buildEnsureNetworkCmd` — a pure, well-documented function with correct shell quoting; no issues found. |
| packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts | Adds one `ssh.exec` call before container creation; all error paths propagate correctly, though stderr suppression on the final `inspect` can obscure the root cause when the ensure command fails. |
| packages/cloud-shared/src/lib/services/__tests__/docker-ensure-network.test.ts | Four targeted unit tests covering command shape, race-safety, `--driver bridge` only, and single-quote escaping — all correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant P as Provisioner
    participant SSH as SSH (target node)
    participant D as Docker daemon

    P->>SSH: buildEnsureNetworkCmd(DOCKER_NETWORK)
    SSH->>D: docker network inspect 'containers-isolated'
    alt network exists
        D-->>SSH: 0 (exit)
        SSH-->>P: success (done)
    else network missing
        D-->>SSH: 1 (not found, stderr suppressed)
        SSH->>D: docker network create --driver bridge 'containers-isolated'
        alt create succeeds
            D-->>SSH: 0 (created)
            SSH-->>P: success (done)
        else concurrent create race (already exists)
            D-->>SSH: 1 (stderr suppressed)
            SSH->>D: docker network inspect 'containers-isolated'
            D-->>SSH: 0 (winner's network confirmed)
            SSH-->>P: success (done)
        end
    end

    P->>SSH: docker create --network 'containers-isolated' ...
    SSH->>D: docker create
    D-->>SSH: container ID
    SSH-->>P: containerId
    P->>SSH: docker start container
```

<sub>Reviews (1): Last reviewed commit: ["fix(cloud): ensure the agent bridge netw..."](https://github.com/elizaos/eliza/commit/27dadf9c9b03a1e5d9b29f8e6b9c92b12486056f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34151742)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->