### PR TITLE
fix(local-inference): chunk desktop ffi prewarm

### DIFF
--- a/plugins/plugin-local-inference/src/services/desktop-llama-adapter.test.ts
+++ b/plugins/plugin-local-inference/src/services/desktop-llama-adapter.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import { DesktopLlamaAdapter } from "./desktop-llama-adapter";
+
+function makeAdapterHarness(nBatch: number) {
+	let nextPtr = 100;
+	const decodeBatchSizes: number[] = [];
+	const configuredBatchSizes: number[] = [];
+
+	const ffi = {
+		ptr: vi.fn(() => nextPtr++),
+	};
+
+	const llama = {
+		llama_backend_init: vi.fn(),
+		llama_backend_free: vi.fn(),
+		llama_model_free: vi.fn(),
+		llama_free: vi.fn(),
+		llama_get_model: vi.fn().mockReturnValue(2),
+		llama_model_get_vocab: vi.fn().mockReturnValue(3),
+		llama_n_ctx: vi.fn().mockReturnValue(4096),
+		llama_vocab_is_eog: vi.fn().mockReturnValue(false),
+		llama_set_embeddings: vi.fn(),
+		llama_get_memory: vi.fn().mockReturnValue(4),
+		llama_memory_clear: vi.fn(),
+		llama_tokenize: vi.fn(),
+		llama_token_to_piece: vi.fn(),
+		llama_sampler_chain_add: vi.fn(),
+		llama_sampler_init_temp: vi.fn().mockReturnValue(10),
+		llama_sampler_init_top_p: vi.fn().mockReturnValue(11),
+		llama_sampler_init_top_k: vi.fn().mockReturnValue(12),
+		llama_sampler_init_dist: vi.fn().mockReturnValue(13),
+		llama_sampler_init_greedy: vi.fn().mockReturnValue(14),
+		llama_sampler_sample: vi.fn().mockReturnValue(15),
+		llama_sampler_accept: vi.fn(),
+		llama_sampler_free: vi.fn(),
+		llama_state_seq_save_file: vi.fn().mockReturnValue(1),
+		llama_state_seq_load_file: vi.fn().mockReturnValue(1),
+	};
+
+	const shim = {
+		eliza_llama_model_params_default: vi.fn().mockReturnValue(20),
+		eliza_llama_model_params_free: vi.fn(),
+		eliza_llama_model_params_set_n_gpu_layers: vi.fn(),
+		eliza_llama_model_params_set_use_mmap: vi.fn(),
+		eliza_llama_model_params_set_use_mlock: vi.fn(),
+		eliza_llama_model_load_from_file: vi.fn().mockReturnValue(30),
+		eliza_llama_context_params_default: vi.fn().mockReturnValue(40),
+		eliza_llama_context_params_free: vi.fn(),
+		eliza_llama_context_params_set_n_ctx: vi.fn(),
+		eliza_llama_context_params_set_n_batch: vi.fn((_, value: number) => {
+			configuredBatchSizes.push(value);
+		}),
+		eliza_llama_context_params_set_n_ubatch: vi.fn(),
+		eliza_llama_context_params_set_n_threads: vi.fn(),
+		eliza_llama_context_params_set_n_threads_batch: vi.fn(),
+		eliza_llama_context_params_set_embeddings: vi.fn(),
+		eliza_llama_context_params_set_offload_kqv: vi.fn(),
+		eliza_llama_init_from_model: vi.fn().mockReturnValue(50),
+		eliza_llama_sampler_chain_params_default: vi.fn().mockReturnValue(60),
+		eliza_llama_sampler_chain_params_free: vi.fn(),
+		eliza_llama_sampler_chain_init: vi.fn().mockReturnValue(70),
+		eliza_llama_batch_get_one: vi.fn((_, tokenCount: number) => {
+			if (tokenCount > nBatch) {
+				throw new Error(`batch too large: ${tokenCount} > ${nBatch}`);
+			}
+			decodeBatchSizes.push(tokenCount);
+			return nextPtr++;
+		}),
+		eliza_llama_batch_free: vi.fn(),
+		eliza_llama_decode: vi.fn().mockReturnValue(0),
+		eliza_llama_log_silence: vi.fn(),
+		eliza_llama_context_attach_drafter: vi.fn().mockReturnValue(0),
+		eliza_llama_context_detach_drafter: vi.fn(),
+		eliza_llama_context_has_drafter: vi.fn().mockReturnValue(0),
+		eliza_llama_context_set_spec_mode: vi.fn().mockReturnValue(0),
+		eliza_llama_decode_unified: vi.fn().mockReturnValue(0),
+		eliza_llama_mtp_stats: vi.fn(),
+	};
+
+	const adapter = new DesktopLlamaAdapter(
+		ffi as never,
+		llama as never,
+		shim as never,
+	);
+	adapter.loadModel({
+		modelPath: "/fake/model.gguf",
+		nBatch,
+		nUBatch: nBatch,
+		threads: 1,
+	});
+
+	return {
+		adapter,
+		binding: adapter.createBinding(),
+		decodeBatchSizes,
+		configuredBatchSizes,
+	};
+}
+
+describe("DesktopLlamaAdapter prefill", () => {
+	it("chunks prefill decode calls so no batch exceeds configured nBatch", () => {
+		const h = makeAdapterHarness(4);
+		const stream = h.binding.llmStreamOpen({
+			ctx: 50n,
+			config: {
+				maxTokens: 0,
+				temperature: 0,
+				topP: 1,
+				topK: 0,
+				repeatPenalty: 1,
+				slotId: 0,
+				promptCacheKey: null,
+				draftMin: 0,
+				draftMax: 0,
+				draftModelPath: null,
+			},
+		});
+
+		h.binding.llmStreamPrefill({
+			stream,
+			tokens: new Int32Array([1, 2, 3, 4, 5, 6, 7, 8, 9]),
+		});
+
+		expect(h.configuredBatchSizes).toContain(4);
+		expect(h.decodeBatchSizes).toEqual([4, 4, 1]);
+		h.binding.llmStreamClose(stream);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/desktop-llama-adapter.ts
+++ b/plugins/plugin-local-inference/src/services/desktop-llama-adapter.ts
@@ -583,6 +583,12 @@ function defaultThreads(env: NodeJS.ProcessEnv = process.env): number {
 	}
 }
 
+function normalizeBatchSize(value: number | undefined): number {
+	if (value === undefined) return 256;
+	const normalized = Math.floor(value);
+	return Number.isFinite(normalized) && normalized > 0 ? normalized : 1;
+}
+
 // === Adapter ===============================================================
 
 export interface DesktopLlamaLoadOptions {
@@ -896,7 +902,7 @@ export class DesktopLlamaAdapter {
 				let nextCtx: Pointer;
 				try {
 					const ctxSize = this.loadOpts.contextSize ?? 4096;
-					const nBatch = this.loadOpts.nBatch ?? 256;
+					const nBatch = normalizeBatchSize(this.loadOpts.nBatch);
 					const threads = this.loadOpts.threads ?? defaultThreads();
 					this.shim.eliza_llama_context_params_set_n_ctx(cp, ctxSize);
 					this.shim.eliza_llama_context_params_set_n_batch(cp, nBatch);
@@ -1014,7 +1020,7 @@ export class DesktopLlamaAdapter {
 		const cp = this.shim.eliza_llama_context_params_default();
 		try {
 			const ctxSize = opts.contextSize ?? 4096;
-			const nBatch = opts.nBatch ?? 256;
+			const nBatch = normalizeBatchSize(opts.nBatch);
 			const threads = opts.threads ?? defaultThreads();
 			this.shim.eliza_llama_context_params_set_n_ctx(cp, ctxSize);
 			this.shim.eliza_llama_context_params_set_n_batch(cp, nBatch);
@@ -1415,23 +1421,30 @@ export class DesktopLlamaAdapter {
 		const sess = this.requireSession(stream);
 		const ctx = this.ctxPool[sess.ctxIdx];
 		if (!ctx) throw new Error("[desktop-llama] ctx gone mid-prefill");
-		// Copy into a session-owned buffer so the FFI batch ptr stays valid
-		// for the lifetime of `eliza_llama_decode`.
-		const owned = new Int32Array(tokens.length);
-		owned.set(tokens);
-		const batch = this.shim.eliza_llama_batch_get_one(
-			this.ffi.ptr(owned),
-			owned.length,
-		);
-		try {
-			const rc = this.shim.eliza_llama_decode(ctx, batch);
-			if (rc !== 0) {
-				throw new Error(`[desktop-llama] prefill decode rc=${rc}`);
+		const nBatch = normalizeBatchSize(this.loadOpts?.nBatch);
+		for (let offset = 0; offset < tokens.length; offset += nBatch) {
+			const chunk = tokens.subarray(
+				offset,
+				Math.min(offset + nBatch, tokens.length),
+			);
+			// Copy into a session-owned buffer so the FFI batch ptr stays valid
+			// for the lifetime of `eliza_llama_decode`.
+			const owned = new Int32Array(chunk.length);
+			owned.set(chunk);
+			const batch = this.shim.eliza_llama_batch_get_one(
+				this.ffi.ptr(owned),
+				owned.length,
+			);
+			try {
+				const rc = this.shim.eliza_llama_decode(ctx, batch);
+				if (rc !== 0) {
+					throw new Error(`[desktop-llama] prefill decode rc=${rc}`);
+				}
+			} finally {
+				this.shim.eliza_llama_batch_free(batch);
 			}
-			this.hasDecodedFlags[sess.ctxIdx] = true;
-		} finally {
-			this.shim.eliza_llama_batch_free(batch);
 		}
+		if (tokens.length > 0) this.hasDecodedFlags[sess.ctxIdx] = true;
 	}
 
 	private nextStep(

--- a/plugins/plugin-local-inference/src/services/ffi-streaming-runner.test.ts
+++ b/plugins/plugin-local-inference/src/services/ffi-streaming-runner.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import { FfiStreamingRunner } from "./ffi-streaming-runner";
+import type {
+	LlmCtxHandle,
+	LlmStreamingBinding,
+} from "./llm-streaming-binding";
+import type { LlmStreamHandle } from "./voice/ffi-bindings";
+
+describe("FfiStreamingRunner prewarm", () => {
+	it("treats maxTokens: 0 as prefill-only and never calls next-token generation", async () => {
+		const stream = 7n as LlmStreamHandle;
+		const binding: LlmStreamingBinding = {
+			llmStreamSupported: () => true,
+			llmStreamOpen: vi.fn().mockReturnValue(stream),
+			llmStreamPrefill: vi.fn(),
+			llmStreamNext: vi.fn().mockReturnValue({
+				tokens: [1],
+				text: "x",
+				done: true,
+				drafterDrafted: 0,
+				drafterAccepted: 0,
+			}),
+			llmStreamCancel: vi.fn(),
+			llmStreamClose: vi.fn(),
+		};
+		const onTextChunk = vi.fn();
+		const runner = new FfiStreamingRunner(binding, 1n as LlmCtxHandle);
+		const promptTokens = new Int32Array([11, 12, 13]);
+
+		const result = await runner.generateWithUsage({
+			promptTokens,
+			slotId: 0,
+			maxTokens: 0,
+			temperature: 0,
+			topP: 1,
+			topK: 0,
+			repeatPenalty: 1,
+			draftMin: 0,
+			draftMax: 0,
+			draftModelPath: null,
+			onTextChunk,
+		});
+
+		expect(binding.llmStreamOpen).toHaveBeenCalledTimes(1);
+		expect(binding.llmStreamPrefill).toHaveBeenCalledWith({
+			stream,
+			tokens: promptTokens,
+		});
+		expect(binding.llmStreamNext).not.toHaveBeenCalled();
+		expect(onTextChunk).not.toHaveBeenCalled();
+		expect(binding.llmStreamClose).toHaveBeenCalledWith(stream);
+		expect(result).toEqual({
+			text: "",
+			slotId: 0,
+			firstTokenMs: null,
+			drafted: 0,
+			accepted: 0,
+		});
+	});
+});

--- a/plugins/plugin-local-inference/src/services/ffi-streaming-runner.ts
+++ b/plugins/plugin-local-inference/src/services/ffi-streaming-runner.ts
@@ -277,6 +277,9 @@ export class FfiStreamingRunner {
 
 		try {
 			this.ffi.llmStreamPrefill({ stream, tokens: args.promptTokens });
+			if (args.maxTokens <= 0) {
+				return;
+			}
 
 			let tokenIndex = 0;
 			while (true) {


### PR DESCRIPTION
## Summary
- chunk desktop llama prefill batches by configured nBatch so prewarm cannot exceed llama.cpp cparams.n_batch
- make maxTokens: 0 FFI prewarm prefill-only instead of calling next-token generation
- add focused fake-binding/fake-shim regressions for both paths

Fixes #7991

## Tests
- /Users/shawwalters/eliza-workspace/milady/eliza/node_modules/.bin/vitest run plugins/plugin-local-inference/src/services/ffi-streaming-runner.test.ts plugins/plugin-local-inference/src/services/desktop-llama-adapter.test.ts (passed in main checkout)
- Worktree rerun was blocked by dependency resolution in /tmp worktree (missing adze from symlinked node_modules), so the authoritative pass is from the primary checkout.

## Residual verification
- Native Windows CUDA activation against eliza-1-0_8b still needs hardware verification.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two llama.cpp FFI prewarm bugs: over-sized prefill batches that could exceed `cparams.n_batch`, and prewarm calls that incorrectly triggered next-token generation when only KV-cache warming was intended. Both paths now have focused regression tests using fake shim/binding harnesses.

- `prefillSession` in `desktop-llama-adapter.ts` now chunks the input `Int32Array` into ≤nBatch slices using the new `normalizeBatchSize` helper, ensuring each `eliza_llama_decode` call stays within the configured batch limit.
- `runGenerateInner` in `ffi-streaming-runner.ts` returns immediately after prefill when `maxTokens <= 0`, relying on the existing `finally` block to close the stream cleanly without ever entering the next-token loop.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the chunking loop is correct, the early return is properly guarded by the existing `finally` cleanup, and both changed behaviours have targeted regression tests.

The logic changes are narrow and well-tested. Chunking via `subarray`+`owned` copy is correct, `normalizeBatchSize` handles all edge cases, and the `hasDecodedFlags` update is moved to the right place after the full loop. If a mid-loop chunk decode fails, the context has been partially populated but `hasDecodedFlags` stays `false`; this is pre-existing behaviour and sessions are expected to be closed on error anyway.

desktop-llama-adapter.ts — the partial-decode failure path leaves the context partially filled with `hasDecodedFlags` still `false`, which could confuse downstream state if the session is ever reused after an error without an explicit memory clear.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-local-inference/src/services/desktop-llama-adapter.ts | Adds `normalizeBatchSize` helper and chunks prefill decode into ≤nBatch slices to stay within llama.cpp's `cparams.n_batch` limit; `hasDecodedFlags` is now set only after the full loop succeeds. |
| plugins/plugin-local-inference/src/services/ffi-streaming-runner.ts | Adds an early return after prefill when `maxTokens <= 0`, skipping next-token generation; the existing `finally` block correctly closes the stream and removes the abort listener. |
| plugins/plugin-local-inference/src/services/desktop-llama-adapter.test.ts | New test using fake FFI/shim bindings verifies that a 9-token prefill with nBatch=4 produces decode calls of [4, 4, 1], confirming the chunking invariant. |
| plugins/plugin-local-inference/src/services/ffi-streaming-runner.test.ts | New test confirms that `maxTokens: 0` triggers prefill-only behavior — `llmStreamNext` and `onTextChunk` are never called, and the stream is closed with an empty result. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller
    participant R as FfiStreamingRunner
    participant B as LlmStreamingBinding
    participant A as DesktopLlamaAdapter.prefillSession

    C->>R: "generateWithUsage({maxTokens: 0, ...})"
    R->>B: "llmStreamOpen({ctx, config})"
    B-->>R: stream handle
    R->>B: "llmStreamPrefill({stream, tokens})"
    B->>A: prefillSession(stream, tokens[0..N])
    loop "for each chunk of size <= nBatch"
        A->>A: eliza_llama_batch_get_one(chunk)
        A->>A: eliza_llama_decode(ctx, batch)
        A->>A: eliza_llama_batch_free(batch)
    end
    A-->>B: (done)
    B-->>R: (done)
    note over R: maxTokens <= 0 - return early, llmStreamNext never called
    R->>B: llmStreamClose(stream) via finally
    R-->>C: "{text:"", firstTokenMs:null, drafted:0, accepted:0}"
```

<sub>Reviews (1): Last reviewed commit: ["fix(local-inference): chunk desktop ffi ..."](https://github.com/elizaos/eliza/commit/6a886f9807ce7810a5cc5a8a7c28a64527c2222b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34236230)</sub>

<!-- /greptile_comment -->