### PR TITLE
fix(runtime): preserve verified tool output in replies

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-plan-actions-in-text.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-plan-actions-in-text.test.ts
@@ -65,6 +65,30 @@ describe("parsePlannerOutput — PLAN_ACTIONS-in-text recovery (#7620)", () => {
 		expect(parsed.raw.textRecoverySource).toBeUndefined();
 	});
 
+	it("unwraps native PLAN_ACTIONS envelopes before action validation", () => {
+		const raw: GenerateTextResult = {
+			text: "",
+			finishReason: "tool-calls",
+			toolCalls: [
+				{
+					id: "call_1",
+					toolName: "PLAN_ACTIONS",
+					input: {
+						action: "TASKS_PROVISION_WORKSPACE",
+						parameters: { repo: "https://github.com/elizaOS/eliza" },
+						thought: "provisioning",
+					},
+				} as unknown as NonNullable<GenerateTextResult["toolCalls"]>[number],
+			],
+		};
+		const parsed = parsePlannerOutput(raw);
+		expect(parsed.toolCalls).toHaveLength(1);
+		expect(parsed.toolCalls[0]?.name).toBe("TASKS_PROVISION_WORKSPACE");
+		expect(parsed.toolCalls[0]?.params).toEqual({
+			repo: "https://github.com/elizaOS/eliza",
+		});
+	});
+
 	it("falls through to messageToUser when text is plain prose without an envelope", () => {
 		const raw: GenerateTextResult = {
 			text: "I'd be happy to help you with that task.",

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -2117,6 +2117,17 @@ function normalizeToolCall(entry: unknown): PlannerToolCall | null {
 			rawFunction?.parameters,
 	);
 
+	if (name.toUpperCase() === "PLAN_ACTIONS" && args) {
+		const actionName = normalizeToolCallName(args.action);
+		if (actionName) {
+			return {
+				id: typeof record.id === "string" ? record.id : undefined,
+				name: actionName,
+				params: normalizeArgs(args.parameters) ?? {},
+			};
+		}
+	}
+
 	return {
 		id: typeof record.id === "string" ? record.id : undefined,
 		name,

--- a/plugins/plugin-agent-skills/src/actions/use-skill.test.ts
+++ b/plugins/plugin-agent-skills/src/actions/use-skill.test.ts
@@ -167,6 +167,136 @@ describe("useSkillAction", () => {
 		}
 	});
 
+	it("unwraps array-form command envelopes split across two JSON objects (issue #7970)", async () => {
+		const tempDir = await fs.mkdtemp(
+			path.join(os.tmpdir(), "use-skill-array-envelope-"),
+		);
+		const scriptPath = path.join(tempDir, "weather.sh");
+		await fs.writeFile(
+			scriptPath,
+			'#!/usr/bin/env bash\nprintf \'%s\\n\' \'{"cmd":["bash","-lc","curl -s wttr.in/Paris"]}{"output":"Paris: sunny +15C"}Paris: sunny +15C\'\n',
+			"utf8",
+		);
+		await fs.chmod(scriptPath, 0o755);
+
+		const skill = {
+			slug: "weather",
+			name: "Weather",
+			description: "Weather script",
+			version: "1.0.0",
+			content: "",
+			frontmatter: {},
+			path: tempDir,
+			scripts: ["weather.sh"],
+			references: [],
+			assets: [],
+			loadedAt: 0,
+			source: "bundled",
+		};
+		const service = {
+			getLoadedSkill: vi.fn((slug: string) =>
+				slug === "weather" ? skill : undefined,
+			),
+			getLoadedSkills: vi.fn(() => [skill]),
+			isSkillEnabled: vi.fn(() => true),
+			checkSkillEligibility: vi.fn(async () => ({
+				slug: "weather",
+				eligible: true,
+				reasons: [],
+				checkedAt: 0,
+			})),
+			getScriptPath: vi.fn(() => scriptPath),
+			getSkillExecutionEnv: vi.fn(() => process.env as Record<string, string>),
+		};
+		const runtimeShape = {
+			logger,
+			getService: vi.fn((name: string) =>
+				name === "AGENT_SKILLS_SERVICE" ? service : undefined,
+			),
+		};
+
+		try {
+			const result = await useSkillAction.handler(
+				Object.assign(Object.create(null) as IAgentRuntime, runtimeShape),
+				{ content: { text: "use weather skill" } } as Memory,
+				undefined,
+				{ parameters: { slug: "weather", mode: "script" } },
+				vi.fn(),
+			);
+
+			expect(result?.success).toBe(true);
+			expect(result?.userFacingText).toBe("Paris: sunny +15C");
+			expect(result?.verifiedUserFacing).toBe(true);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	it("does not mark non-envelope JSON stdout as verified user-facing text (issue #7970 regression)", async () => {
+		const tempDir = await fs.mkdtemp(
+			path.join(os.tmpdir(), "use-skill-non-envelope-"),
+		);
+		const scriptPath = path.join(tempDir, "status.sh");
+		await fs.writeFile(
+			scriptPath,
+			'#!/usr/bin/env bash\nprintf \'%s\\n\' \'{"status":"ok","metrics":{"latency":42}}\'\n',
+			"utf8",
+		);
+		await fs.chmod(scriptPath, 0o755);
+
+		const skill = {
+			slug: "status",
+			name: "Status",
+			description: "Status script",
+			version: "1.0.0",
+			content: "",
+			frontmatter: {},
+			path: tempDir,
+			scripts: ["status.sh"],
+			references: [],
+			assets: [],
+			loadedAt: 0,
+			source: "bundled",
+		};
+		const service = {
+			getLoadedSkill: vi.fn((slug: string) =>
+				slug === "status" ? skill : undefined,
+			),
+			getLoadedSkills: vi.fn(() => [skill]),
+			isSkillEnabled: vi.fn(() => true),
+			checkSkillEligibility: vi.fn(async () => ({
+				slug: "status",
+				eligible: true,
+				reasons: [],
+				checkedAt: 0,
+			})),
+			getScriptPath: vi.fn(() => scriptPath),
+			getSkillExecutionEnv: vi.fn(() => process.env as Record<string, string>),
+		};
+		const runtimeShape = {
+			logger,
+			getService: vi.fn((name: string) =>
+				name === "AGENT_SKILLS_SERVICE" ? service : undefined,
+			),
+		};
+
+		try {
+			const result = await useSkillAction.handler(
+				Object.assign(Object.create(null) as IAgentRuntime, runtimeShape),
+				{ content: { text: "use status skill" } } as Memory,
+				undefined,
+				{ parameters: { slug: "status", mode: "script" } },
+				vi.fn(),
+			);
+
+			expect(result?.success).toBe(true);
+			expect(result?.userFacingText).toBeUndefined();
+			expect(result?.verifiedUserFacing).toBeUndefined();
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	it("appends a per-skill invocation record with input/output when a trajectory step is active (W1-T5)", async () => {
 		mockedGetTrajectoryContext.mockReturnValue({
 			trajectoryStepId: "step-skill-1",

--- a/plugins/plugin-agent-skills/src/actions/use-skill.test.ts
+++ b/plugins/plugin-agent-skills/src/actions/use-skill.test.ts
@@ -1,10 +1,27 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import type { IAgentRuntime, Memory } from "@elizaos/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@elizaos/core", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@elizaos/core")>();
+	return {
+		...actual,
+		annotateActiveTrajectoryStep: vi.fn(),
+		getTrajectoryContext: vi.fn(),
+		logger: {
+			...actual.logger,
+			info: vi.fn(),
+		},
+	};
+});
+
 import {
 	annotateActiveTrajectoryStep,
 	getTrajectoryContext,
 	logger,
 } from "@elizaos/core";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useSkillAction } from "./use-skill";
 
 const mockedAnnotateActiveTrajectoryStep = vi.mocked(
@@ -78,6 +95,76 @@ describe("useSkillAction", () => {
 			actions: ["USE_SKILL"],
 		});
 		expect(service.getLoadedSkill).toHaveBeenCalledWith("github");
+	});
+
+	it("exposes clean verified user-facing text from successful script stdout without cmd/output envelopes", async () => {
+		const tempDir = await fs.mkdtemp(
+			path.join(os.tmpdir(), "use-skill-wrapper-"),
+		);
+		const scriptPath = path.join(tempDir, "weather.sh");
+		await fs.writeFile(
+			scriptPath,
+			"#!/usr/bin/env bash\nprintf '%s\\n' '{\"cmd\":\"weather nyc\",\"output\":\"New York: 72F and clear.\"}'\n",
+			"utf8",
+		);
+		await fs.chmod(scriptPath, 0o755);
+
+		const skill = {
+			slug: "weather",
+			name: "Weather",
+			description: "Weather script",
+			version: "1.0.0",
+			content: "",
+			frontmatter: {},
+			path: tempDir,
+			scripts: ["weather.sh"],
+			references: [],
+			assets: [],
+			loadedAt: 0,
+			source: "bundled",
+		};
+		const service = {
+			getLoadedSkill: vi.fn((slug: string) =>
+				slug === "weather" ? skill : undefined,
+			),
+			getLoadedSkills: vi.fn(() => [skill]),
+			isSkillEnabled: vi.fn(() => true),
+			checkSkillEligibility: vi.fn(async () => ({
+				slug: "weather",
+				eligible: true,
+				reasons: [],
+				checkedAt: 0,
+			})),
+			getScriptPath: vi.fn(() => scriptPath),
+			getSkillExecutionEnv: vi.fn(() => process.env as Record<string, string>),
+		};
+		const runtimeShape = {
+			logger,
+			getService: vi.fn((name: string) =>
+				name === "AGENT_SKILLS_SERVICE" ? service : undefined,
+			),
+		};
+
+		try {
+			const result = await useSkillAction.handler(
+				Object.assign(Object.create(null) as IAgentRuntime, runtimeShape),
+				{ content: { text: "use weather skill" } } as Memory,
+				undefined,
+				{ parameters: { slug: "weather", mode: "script" } },
+				vi.fn(),
+			);
+
+			expect(result?.success).toBe(true);
+			expect(result?.text).toContain('"cmd":"weather nyc"');
+			expect(result?.data).toMatchObject({
+				stdout:
+					'{"cmd":"weather nyc","output":"New York: 72F and clear."}',
+			});
+			expect(result?.userFacingText).toBe("New York: 72F and clear.");
+			expect(result?.verifiedUserFacing).toBe(true);
+		} finally {
+			await fs.rm(tempDir, { recursive: true, force: true });
+		}
 	});
 
 	it("appends a per-skill invocation record with input/output when a trajectory step is active (W1-T5)", async () => {

--- a/plugins/plugin-agent-skills/src/actions/use-skill.ts
+++ b/plugins/plugin-agent-skills/src/actions/use-skill.ts
@@ -141,33 +141,46 @@ function findLeadingJsonObjectEnd(text: string): number {
 	return -1;
 }
 
-function unwrapSkillStdoutEnvelope(stdout: string): string {
+function isCommandEnvelope(record: Record<string, unknown>): boolean {
+	for (const key of ["cmd", "command"] as const) {
+		const value = record[key];
+		if (typeof value === "string" && value.length > 0) return true;
+		if (
+			Array.isArray(value) &&
+			value.length > 0 &&
+			value.every((entry) => typeof entry === "string")
+		) {
+			return true;
+		}
+	}
+	return false;
+}
+
+function unwrapSkillStdoutEnvelope(stdout: string): string | undefined {
 	const trimmed = stdout.trim();
-	if (!trimmed) return "";
+	if (!trimmed) return undefined;
 	if (!trimmed.startsWith("{")) return trimmed;
 
 	const firstJsonEnd = findLeadingJsonObjectEnd(trimmed);
-	if (firstJsonEnd < 0) return trimmed;
+	if (firstJsonEnd < 0) return undefined;
 	const firstJson = trimmed.slice(0, firstJsonEnd);
 	const remainder = trimmed.slice(firstJsonEnd).trim();
 	let parsed: unknown;
 	try {
 		parsed = JSON.parse(firstJson);
 	} catch {
-		return trimmed;
+		return undefined;
 	}
 	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-		return trimmed;
+		return undefined;
 	}
 
 	const record = parsed as Record<string, unknown>;
-	const hasCommandEnvelope =
-		typeof record.cmd === "string" || typeof record.command === "string";
-	if (!hasCommandEnvelope) return trimmed;
+	if (!isCommandEnvelope(record)) return undefined;
 
 	for (const key of ["output", "stdout", "result"] as const) {
 		if (key in record) {
-			return stringifyUserFacingValue(record[key]) ?? "";
+			return stringifyUserFacingValue(record[key]);
 		}
 	}
 	if (remainder.startsWith("{")) {
@@ -179,7 +192,7 @@ function unwrapSkillStdoutEnvelope(stdout: string): string {
 					const secondRecord = second as Record<string, unknown>;
 					for (const key of ["output", "stdout", "result"] as const) {
 						if (key in secondRecord) {
-							return stringifyUserFacingValue(secondRecord[key]) ?? "";
+							return stringifyUserFacingValue(secondRecord[key]);
 						}
 					}
 				}
@@ -191,7 +204,7 @@ function unwrapSkillStdoutEnvelope(stdout: string): string {
 		}
 	}
 	if (remainder) return remainder;
-	return trimmed;
+	return undefined;
 }
 
 function isSkillTruncationMarker(

--- a/plugins/plugin-agent-skills/src/actions/use-skill.ts
+++ b/plugins/plugin-agent-skills/src/actions/use-skill.ts
@@ -103,6 +103,97 @@ function normaliseArgs(raw: unknown): string[] {
 	return [String(raw)];
 }
 
+function stringifyUserFacingValue(value: unknown): string | undefined {
+	if (typeof value === "string") return value.trim();
+	if (value === undefined || value === null) return undefined;
+	try {
+		return JSON.stringify(value, null, 2);
+	} catch {
+		return String(value);
+	}
+}
+
+function findLeadingJsonObjectEnd(text: string): number {
+	let depth = 0;
+	let inString = false;
+	let escaped = false;
+	for (let i = 0; i < text.length; i += 1) {
+		const char = text[i];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (char === "\\") {
+			escaped = inString;
+			continue;
+		}
+		if (char === '"') {
+			inString = !inString;
+			continue;
+		}
+		if (inString) continue;
+		if (char === "{") depth += 1;
+		else if (char === "}") {
+			depth -= 1;
+			if (depth === 0) return i + 1;
+		}
+	}
+	return -1;
+}
+
+function unwrapSkillStdoutEnvelope(stdout: string): string {
+	const trimmed = stdout.trim();
+	if (!trimmed) return "";
+	if (!trimmed.startsWith("{")) return trimmed;
+
+	const firstJsonEnd = findLeadingJsonObjectEnd(trimmed);
+	if (firstJsonEnd < 0) return trimmed;
+	const firstJson = trimmed.slice(0, firstJsonEnd);
+	const remainder = trimmed.slice(firstJsonEnd).trim();
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(firstJson);
+	} catch {
+		return trimmed;
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return trimmed;
+	}
+
+	const record = parsed as Record<string, unknown>;
+	const hasCommandEnvelope =
+		typeof record.cmd === "string" || typeof record.command === "string";
+	if (!hasCommandEnvelope) return trimmed;
+
+	for (const key of ["output", "stdout", "result"] as const) {
+		if (key in record) {
+			return stringifyUserFacingValue(record[key]) ?? "";
+		}
+	}
+	if (remainder.startsWith("{")) {
+		const secondJsonEnd = findLeadingJsonObjectEnd(remainder);
+		if (secondJsonEnd > 0) {
+			try {
+				const second = JSON.parse(remainder.slice(0, secondJsonEnd));
+				if (second && typeof second === "object" && !Array.isArray(second)) {
+					const secondRecord = second as Record<string, unknown>;
+					for (const key of ["output", "stdout", "result"] as const) {
+						if (key in secondRecord) {
+							return stringifyUserFacingValue(secondRecord[key]) ?? "";
+						}
+					}
+				}
+			} catch {
+				// Fall through to the non-JSON remainder below.
+			}
+			const afterSecond = remainder.slice(secondJsonEnd).trim();
+			if (afterSecond) return afterSecond;
+		}
+	}
+	if (remainder) return remainder;
+	return trimmed;
+}
+
 function isSkillTruncationMarker(
 	marker: { field: string; originalBytes: number; capBytes: number },
 ): marker is SkillTruncationMarker {
@@ -369,6 +460,10 @@ export const useSkillAction: Action = {
 			const text = result.success
 				? `**${skill.name}** ran \`${requestedScript}\`:\n\`\`\`\n${result.stdout || "(no output)"}\n\`\`\``
 				: `**${skill.name}** script \`${requestedScript}\` failed (exit ${result.exitCode}):\n\`\`\`\n${result.stderr || "(no stderr)"}\n\`\`\``;
+			const userFacingText =
+				result.success && result.stdout
+					? unwrapSkillStdoutEnvelope(result.stdout)
+					: undefined;
 
 			if (callback) await callback({ text });
 
@@ -402,6 +497,9 @@ export const useSkillAction: Action = {
 					stdout: result.stdout,
 					stderr: result.stderr,
 				},
+				...(userFacingText
+					? { userFacingText, verifiedUserFacing: true }
+					: {}),
 			};
 		}
 

--- a/plugins/plugin-coding-tools/src/actions/bash.test.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.test.ts
@@ -724,6 +724,64 @@ describe("shellAction", () => {
     );
   });
 
+  it("projects safe small list stdout without shell meta-narration", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "shell-list-"));
+    await fs.writeFile(path.join(tempDir, "alpha.txt"), "alpha", "utf8");
+    await fs.writeFile(path.join(tempDir, "beta.txt"), "beta", "utf8");
+    const { runtime } = await makeRuntime();
+
+    try {
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(
+          "11111111-aaaa-bbbb-cccc-585858585858",
+          "list the files in this test directory",
+        ),
+        undefined,
+        { command: "ls -1", cwd: tempDir },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.text).toContain("$ ls -1");
+      expect(result.text).toContain("--- stdout ---");
+      expect(result.userFacingText).toBe("alpha.txt\nbeta.txt");
+      expect(result.verifiedUserFacing).toBe(true);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("projects safe small grep stdout without shell meta-narration", async () => {
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "shell-grep-"));
+    await fs.writeFile(
+      path.join(tempDir, "weather.txt"),
+      "weather: clear\nweather: windy\n",
+      "utf8",
+    );
+    const { runtime } = await makeRuntime();
+
+    try {
+      const result = await shellAction.handler?.(
+        runtime,
+        makeMessage(
+          "11111111-aaaa-bbbb-cccc-595959595959",
+          "grep the weather lines",
+        ),
+        undefined,
+        { command: "grep -n weather weather.txt", cwd: tempDir },
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.text).toContain("$ grep -n weather weather.txt");
+      expect(result.userFacingText).toBe(
+        "1:weather: clear\n2:weather: windy",
+      );
+      expect(result.verifiedUserFacing).toBe(true);
+    } finally {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
   it("adds user-facing text for local health JSON", async () => {
     const previousPort = process.env.ELIZA_API_PORT;
     const server = createServer((_req, res) => {

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -34,6 +34,7 @@ const TIMEOUT_MAX_MS = 600_000;
 const DEFAULT_TIMEOUT_MS = 120_000;
 const STREAM_CAP_CHARS = 30_000;
 const USER_FACING_STDOUT_CAP_CHARS = 8_000;
+const USER_FACING_STDOUT_CAP_LINES = 200;
 const SHELL_HISTORY_DEFAULT_LIMIT = 20;
 const URL_PREFIXES = ["https://", "http://"] as const;
 const SHELL_URL_METACHARS = new Set(["&", ";", "(", ")", "<", ">", "|"]);
@@ -798,7 +799,7 @@ function localStatusUserFacingText(args: {
 function isSafeSmallStdoutProjectionCommand(command: string): boolean {
   const normalized = command.replace(/\s+/g, " ").trim();
   if (!normalized) return false;
-  return /^(?:(?:command\s+-v|pwd|ls|find|grep|rg)\b|git\s+(?:grep|status|branch|rev-parse|log|diff|show|ls-files)\b)/u.test(
+  return /^(?:(?:command\s+-v|pwd|ls|find|grep|rg)\b|git\s+(?:grep|status|branch|rev-parse|ls-files)\b)/u.test(
     normalized,
   );
 }
@@ -811,6 +812,7 @@ function safeSmallStdoutUserFacingText(args: {
   const stdout = args.stdout.trim();
   if (!stdout || args.stderr.trim()) return undefined;
   if (stdout.length > USER_FACING_STDOUT_CAP_CHARS) return undefined;
+  if (stdout.split("\n").length > USER_FACING_STDOUT_CAP_LINES) return undefined;
   if (!isSafeSmallStdoutProjectionCommand(args.command)) return undefined;
   return stdout;
 }

--- a/plugins/plugin-coding-tools/src/actions/bash.ts
+++ b/plugins/plugin-coding-tools/src/actions/bash.ts
@@ -33,6 +33,7 @@ const TIMEOUT_MIN_MS = 100;
 const TIMEOUT_MAX_MS = 600_000;
 const DEFAULT_TIMEOUT_MS = 120_000;
 const STREAM_CAP_CHARS = 30_000;
+const USER_FACING_STDOUT_CAP_CHARS = 8_000;
 const SHELL_HISTORY_DEFAULT_LIMIT = 20;
 const URL_PREFIXES = ["https://", "http://"] as const;
 const SHELL_URL_METACHARS = new Set(["&", ";", "(", ")", "<", ">", "|"]);
@@ -794,6 +795,26 @@ function localStatusUserFacingText(args: {
   return undefined;
 }
 
+function isSafeSmallStdoutProjectionCommand(command: string): boolean {
+  const normalized = command.replace(/\s+/g, " ").trim();
+  if (!normalized) return false;
+  return /^(?:(?:command\s+-v|pwd|ls|find|grep|rg)\b|git\s+(?:grep|status|branch|rev-parse|log|diff|show|ls-files)\b)/u.test(
+    normalized,
+  );
+}
+
+function safeSmallStdoutUserFacingText(args: {
+  command: string;
+  stdout: string;
+  stderr: string;
+}): string | undefined {
+  const stdout = args.stdout.trim();
+  if (!stdout || args.stderr.trim()) return undefined;
+  if (stdout.length > USER_FACING_STDOUT_CAP_CHARS) return undefined;
+  if (!isSafeSmallStdoutProjectionCommand(args.command)) return undefined;
+  return stdout;
+}
+
 function formatStreams(
   stdout: string,
   stderr: string,
@@ -1167,8 +1188,15 @@ export const shellAction: Action = {
         stdout: result.stdout,
       }) ??
       localResourceUserFacingText({ message, stdout: result.stdout }) ??
-      localStatusUserFacingText({ message, stdout: result.stdout });
-    return userFacingText ? { ...actionResult, userFacingText } : actionResult;
+      localStatusUserFacingText({ message, stdout: result.stdout }) ??
+      safeSmallStdoutUserFacingText({
+        command,
+        stdout: result.stdout,
+        stderr: result.stderr,
+      });
+    return userFacingText
+      ? { ...actionResult, userFacingText, verifiedUserFacing: true }
+      : actionResult;
   },
   examples: [
     [


### PR DESCRIPTION
Fixes #7970.
Fixes #7960.

## Summary
- unwrap command-envelope JSON from USE_SKILL stdout before exposing it as verified user-facing text
- mark safe small SHELL stdout projections as verified so planner replies include the actual result
- normalize PLAN_ACTIONS tool envelopes so embedded action calls are executed instead of narrated

## Tests
- ./node_modules/.bin/vitest run plugins/plugin-agent-skills/src/actions/use-skill.test.ts plugins/plugin-coding-tools/src/actions/bash.test.ts
- ./node_modules/.bin/vitest run packages/core/src/runtime/__tests__/planner-loop-plan-actions-in-text.test.ts packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts

Note: tests were run from the primary checkout because this clean PR worktree does not have its own dependency install.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two issues where planner replies either echoed raw JSON tool envelopes to users or failed to include verified tool results at all. It adds `unwrapSkillStdoutEnvelope` in the skill runner to extract the human-readable portion of command-envelope stdout, adds a `safeSmallStdoutUserFacingText` projection path for `ls`/`grep`/`rg`/`pwd`/`git status` etc. in the shell action, and normalizes native `PLAN_ACTIONS` tool-call envelopes so their embedded actions are dispatched rather than narrated.

- **`use-skill.ts`**: New `unwrapSkillStdoutEnvelope` correctly handles single-JSON, dual-JSON, and plain-text stdout; non-envelope JSON (no `cmd`/`command` key) now returns `undefined` so the evaluator synthesizes rather than echoing raw JSON blobs.
- **`bash.ts`**: `safeSmallStdoutUserFacingText` adds an allowlisted-command + size-cap guard before stamping stdout `verifiedUserFacing: true`; the prefix-only regex leaves compound shell expressions (e.g. `ls /tmp && git log --oneline`) able to bypass the explicit git exclusion list.
- **`planner-loop.ts`**: `normalizeToolCall` unwraps `PLAN_ACTIONS` envelopes into their embedded action name and parameters before the call is validated or dispatched."

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the shell compound-command bypass in bash.ts

The `isSafeSmallStdoutProjectionCommand` regex matches only the leading token of the command string, so compound expressions like `ls /tmp && git log --oneline -50` pass the check even though `git log` was explicitly removed from the allowlist in response to a prior review comment. The skill-envelope unwrapping and PLAN_ACTIONS normalization changes are logically sound and well-covered by tests.

plugins/plugin-coding-tools/src/actions/bash.ts — specifically `isSafeSmallStdoutProjectionCommand` and the compound-command case.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-coding-tools/src/actions/bash.ts | Adds `safeSmallStdoutUserFacingText` to project stdout from allowlisted read-only commands as `verifiedUserFacing: true`; the regex prefix check is incomplete and allows compound shell expressions to bypass the git exclusion list. |
| plugins/plugin-agent-skills/src/actions/use-skill.ts | Adds `unwrapSkillStdoutEnvelope` to extract clean user-facing text from command-envelope JSON stdout; early-return on `null`-valued output keys is a minor latent bug for unusual but valid envelope shapes. |
| packages/core/src/runtime/planner-loop.ts | Adds PLAN_ACTIONS envelope normalization in `normalizeToolCall` so embedded action calls are dispatched rather than narrated; logic is straightforward and well-tested. |
| plugins/plugin-agent-skills/src/actions/use-skill.test.ts | Comprehensive new tests cover the command-envelope unwrap, array-form envelope, and non-envelope JSON regression case, with real script execution via temp files. |
| plugins/plugin-coding-tools/src/actions/bash.test.ts | Two new integration tests verify `ls` and `grep` stdout projection; tests use real filesystem operations in temp dirs and check `verifiedUserFacing: true`. |
| packages/core/src/runtime/__tests__/planner-loop-plan-actions-in-text.test.ts | Adds a unit test for native PLAN_ACTIONS envelope unwrapping before action validation; straightforward and correctly validates the new normalization path. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Planner dispatches tool call] --> B{Tool name == PLAN_ACTIONS?}
    B -- Yes --> C[normalizeToolCall: unwrap args.action + args.parameters]
    C --> D[Dispatch embedded action directly]
    B -- No --> E[Execute tool normally]

    E --> F{Tool = SHELL}
    E --> G{Tool = USE_SKILL}

    F --> H[Run command via /bin/bash]
    H --> I[Compute userFacingText chain]
    I --> I1[cryptoSpotUserFacingText?]
    I1 -- no --> I2[localResourceUserFacingText?]
    I2 -- no --> I3[localStatusUserFacingText?]
    I3 -- no --> I4{isSafeSmallStdoutProjectionCommand?}
    I4 -- YES and stdout fits caps --> J[verifiedUserFacing: true]
    I4 -- NO or too large --> K[no verifiedUserFacing]
    I1 -- yes --> J
    I2 -- yes --> J
    I3 -- yes --> J

    G --> L[Execute skill script]
    L --> M{stdout starts with curly brace?}
    M -- No --> N[Return trimmed stdout as userFacingText]
    M -- Yes --> O[findLeadingJsonObjectEnd]
    O --> P{isCommandEnvelope? cmd or command key?}
    P -- No --> Q[return undefined - evaluator synthesizes reply]
    P -- Yes --> R{output/stdout/result key in record?}
    R -- Yes --> S[Extract value to userFacingText]
    R -- No --> T[Check second JSON object or plain remainder]
    T --> S
    S --> J
    N --> J

    J --> U[singleVerifiedUserFacingToolResultText]
    U --> V{Exactly 1 successful verified step?}
    V -- Yes --> W[Echo verbatim to user]
    V -- No --> X[Evaluator synthesizes reply]
    K --> X
    Q --> X
```

<sub>Reviews (2): Last reviewed commit: ["fix(skills/bash): handle array cmd envel..."](https://github.com/elizaos/eliza/commit/60d98a6e2752864a31cba1e407f3ff8b94519fb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34234076)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->