### PR TITLE
fix(core): recover truncated stage1 and inline code replies

### DIFF
--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -209,6 +209,7 @@ describe("runV5MessageRuntimeStage1", () => {
 		const firstCall = useModelCalls(runtime)[0];
 		const params = firstCall?.[1] as {
 			tools?: Array<{ name?: string; parameters?: { required?: string[] } }>;
+			messages?: Array<{ content?: unknown }>;
 			toolChoice?: string;
 			maxTokens?: number;
 			responseSchema?: unknown;
@@ -230,8 +231,89 @@ describe("runV5MessageRuntimeStage1", () => {
 			guidedDecode: true,
 			thinking: "off",
 		});
+		const systemMessage = params.messages?.[0] as
+			| { content?: unknown }
+			| undefined;
+		expect(String(systemMessage?.content ?? "")).toContain(
+			"prioritize syntactically valid runnable code",
+		);
 		if (result.kind === "direct_reply") {
 			expect(result.result.responseContent?.text).toBe("Hello.");
+		}
+	});
+
+	it("recovers a completed replyText when Stage 1 hits the completion cap with truncated JSON", async () => {
+		const runtime = makeRuntime([
+			{
+				text: [
+					'{"shouldRespond":"RESPOND","contexts":["simple"],',
+					'"replyText":"```python\\ndef fibonacci(n):\\n    a, b = 0, 1\\n    for _ in range(n):\\n        a, b = b, a + b\\n    return a\\n```",',
+					'"facts":[',
+				].join(""),
+				finishReason: "length",
+				usage: {
+					promptTokens: 100,
+					completionTokens: 2048,
+					totalTokens: 2148,
+				},
+			},
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: "write a 5-line python function that returns fibonacci",
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toContain(
+				"def fibonacci(n):",
+			);
+			expect(result.result.responseContent?.text).not.toContain(
+				"That answer got cut off",
+			);
+		}
+		expect(runtime.logger.warn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				src: "service:message",
+				finishReason: "length",
+				maxTokens: 2048,
+			}),
+			"[message] Stage 1 hit the completion-token limit",
+		);
+	});
+
+	it("surfaces a clear reply when Stage 1 truncates before a reply can be recovered", async () => {
+		const runtime = makeRuntime([
+			{
+				text: '{"shouldRespond":"RESPOND","contexts":["simple"],"replyText":"```python\\ndef fib',
+				finishReason: "length",
+				usage: {
+					promptTokens: 100,
+					completionTokens: 2048,
+					totalTokens: 2148,
+				},
+			},
+		]);
+
+		const result = await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage({
+				text: "write a 5-line python function that returns fibonacci",
+			}),
+			state: makeState(),
+			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
+		});
+
+		expect(result.kind).toBe("direct_reply");
+		if (result.kind === "direct_reply") {
+			expect(result.result.responseContent?.text).toBe(
+				"That answer got cut off before I could finish it. Please try again with a shorter request or ask for a narrower format.",
+			);
 		}
 	});
 

--- a/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
@@ -546,6 +546,79 @@ describe("messageHandlerFromFieldResult — bogus candidate actions", () => {
 		expect(handler.plan.candidateActions).toEqual(["TASKS_SPAWN_AGENT"]);
 	});
 
+	it("keeps trivial inline hello-world code requests on the simple path despite TASKS hints", () => {
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["general"],
+				candidateActionNames: ["TASKS_SPAWN_AGENT"],
+				replyText: "",
+				intents: ["write small python code snippet"],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: [TASKS_SPAWN_AGENT],
+				messageText: "write a code block in python that prints hello world",
+			},
+		);
+
+		expect(handler.plan.simple).toBe(true);
+		expect(handler.plan.requiresTool).toBe(false);
+		expect(handler.plan.contexts).toEqual(["simple"]);
+		expect(handler.plan.candidateActions).toBeUndefined();
+	});
+
+	it("keeps tight-line fibonacci snippets simple so direct reply can prioritize valid syntax", () => {
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["general"],
+				candidateActionNames: ["TASKS_SPAWN_AGENT"],
+				replyText: "```python\ndef fib(n):\n    return n\n```",
+				intents: ["write small python function"],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: [TASKS_SPAWN_AGENT],
+				messageText: "give me a 3-line python fibonacci function",
+			},
+		);
+
+		expect(handler.plan.simple).toBe(true);
+		expect(handler.plan.requiresTool).toBe(false);
+		expect(handler.plan.contexts).toEqual(["simple"]);
+		expect(handler.plan.candidateActions).toBeUndefined();
+	});
+
+	it("still routes explicit sub-agent coding requests to TASKS", () => {
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: [],
+				candidateActionNames: ["TASKS_SPAWN_AGENT"],
+				replyText: "On it.",
+				intents: [],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: [TASKS_SPAWN_AGENT],
+				messageText:
+					"spawn a sub-agent to build a complete Discord bot in Python",
+			},
+		);
+
+		expect(handler.plan.simple).toBe(false);
+		expect(handler.plan.requiresTool).toBe(true);
+		expect(handler.plan.contexts).toEqual(["general"]);
+		expect(handler.plan.candidateActions).toEqual(["TASKS_SPAWN_AGENT"]);
+	});
+
 	it("adds a real lookup action when Stage 1 emits only a synthetic current-price candidate", () => {
 		const handler = messageHandlerFromFieldResult(
 			{

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -224,6 +224,10 @@ const PLANNER_CONTROL_ACTIONS = new Set(
 const DIRECT_CHANNEL_STAGE1_MAX_TOKENS = 384;
 const DIRECT_REPLY_FAST_PATH_MAX_TOKENS = 96;
 const DEFAULT_STAGE1_MAX_TOKENS = 2048;
+const STAGE1_TRUNCATION_REPLY =
+	"That answer got cut off before I could finish it. Please try again with a shorter request or ask for a narrower format.";
+const CODE_SNIPPET_VALIDITY_INSTRUCTION =
+	"For code snippets, prioritize syntactically valid runnable code over impossible formatting constraints. If a tight line count would require invalid syntax, provide a valid version and briefly note the constraint tradeoff.";
 const DIRECT_CHANNEL_OMITTED_RESPONSE_FIELDS = new Set([
 	"shouldRespond",
 	"facts",
@@ -2634,6 +2638,7 @@ const RESPONSE_TASK_BASELINE_INSTRUCTIONS = [
 	"rules:",
 	"- answer directly in the agent's voice",
 	"- when the user asks for exact words, output only those exact words",
+	`- ${CODE_SNIPPET_VALIDITY_INSTRUCTION}`,
 	"- do not select actions or tools",
 	"- do not include internal reasoning",
 	"- high-stakes personal crisis/legal/medical/self-harm/police/CPS: no tactical concealment/evasion/testimony/contraband advice; direct to qualified help, and for imminent danger prioritize emergency services, poison control, or a crisis hotline",
@@ -2769,6 +2774,7 @@ async function generateDirectReplyOnce(args: {
 function shouldRegenerateStage1ReplyText(reply: string | undefined): boolean {
 	const trimmed = typeof reply === "string" ? reply.trim() : "";
 	if (!trimmed) return true;
+	if (/^```[a-z0-9_-]*\s+/iu.test(trimmed)) return false;
 	if (/^[\s{}[\]":,]+$/.test(trimmed)) return true;
 	if (/^\d+$/.test(trimmed)) return true;
 	if (/(.)\1{4,}/u.test(trimmed)) return true;
@@ -2887,11 +2893,19 @@ function renderMessageHandlerInstructions(
 		},
 		template: baseline,
 	}).trim();
+	const renderedWithSharedRules = options?.directMessage
+		? rendered
+		: [
+				rendered,
+				"",
+				"## Shared Response Quality Rules",
+				`- ${CODE_SNIPPET_VALIDITY_INSTRUCTION}`,
+			].join("\n");
 	if (!options?.responseHandlerFields?.trim()) {
-		return rendered;
+		return renderedWithSharedRules;
 	}
 	return [
-		rendered,
+		renderedWithSharedRules,
 		"",
 		"## Response Handler Fields",
 		"Populate every registered field. Use empty value when not applicable.",
@@ -3299,20 +3313,32 @@ export function messageHandlerFromFieldResult(
 			candidateActions: effectiveCandidateActions,
 			contexts: routedContexts,
 		});
+	const preferInlineCodeSnippetDirectReply =
+		!preemptDirect &&
+		requestedPlanning &&
+		shouldPreferInlineCodeSnippetDirectReply({
+			currentMessageText,
+			candidateActions: effectiveCandidateActions,
+			contexts: routedContexts,
+		});
 	const shouldPlan =
-		!preemptDirect && requestedPlanning && !preferCompleteDirectReply;
-	const finalContexts = preferCompleteDirectReply
-		? [SIMPLE_CONTEXT_ID]
-		: shouldPlan && initialPlanningContexts.length === 0
-			? Array.from(
-					new Set([
-						...routedContexts.filter(
-							(context) => context !== SIMPLE_CONTEXT_ID,
-						),
-						"general",
-					]),
-				)
-			: routedContexts;
+		!preemptDirect &&
+		requestedPlanning &&
+		!preferCompleteDirectReply &&
+		!preferInlineCodeSnippetDirectReply;
+	const finalContexts =
+		preferCompleteDirectReply || preferInlineCodeSnippetDirectReply
+			? [SIMPLE_CONTEXT_ID]
+			: shouldPlan && initialPlanningContexts.length === 0
+				? Array.from(
+						new Set([
+							...routedContexts.filter(
+								(context) => context !== SIMPLE_CONTEXT_ID,
+							),
+							"general",
+						]),
+					)
+				: routedContexts;
 	// Refusal suppression for the planning path (elizaOS/eliza#7620). Mirrors
 	// the logic in `parseMessageHandlerOutput`: when the planner is about to
 	// run, a refusal-shaped `replyText` from a safety-tuned hosted model is
@@ -3325,7 +3351,11 @@ export function messageHandlerFromFieldResult(
 		simple: preemptDirect ? true : !shouldPlan,
 		requiresTool: shouldPlan,
 	};
-	if (!preferCompleteDirectReply && effectiveCandidateActions.length > 0) {
+	if (
+		!preferCompleteDirectReply &&
+		!preferInlineCodeSnippetDirectReply &&
+		effectiveCandidateActions.length > 0
+	) {
 		plan.candidateActions = effectiveCandidateActions;
 	}
 	const extract =
@@ -3422,6 +3452,15 @@ function shouldPreferCompleteDirectReply(args: {
 		looksLikeActionExplanationRequest(normalized) ||
 		looksLikeCreativeWritingRequest(normalized)
 	);
+}
+
+function shouldPreferInlineCodeSnippetDirectReply(args: {
+	currentMessageText: string;
+	candidateActions: readonly string[];
+	contexts: readonly string[];
+}): boolean {
+	if (!looksLikeInlineCodeSnippetRequest(args.currentMessageText)) return false;
+	return hasOnlyWeakDirectReplyPlanningSignals(args);
 }
 
 const WEAK_DIRECT_REPLY_OVERRIDE_ACTIONS = new Set(
@@ -3927,6 +3966,98 @@ function parseMessageHandlerModelOutput(
 	return (
 		parseMessageHandlerOutput(raw) ?? synthesizeSimpleReplyFromPlainText(raw)
 	);
+}
+
+function getStage1FinishReason(raw: string | GenerateTextResult): string {
+	if (typeof raw === "string") return "";
+	return typeof raw.finishReason === "string" ? raw.finishReason : "";
+}
+
+function stage1HitCompletionLimit(
+	raw: string | GenerateTextResult,
+	maxTokens: number,
+): boolean {
+	if (typeof raw === "string") return false;
+	const finishReason = getStage1FinishReason(raw).toLowerCase();
+	if (
+		/\b(?:length|max[-_\s]?tokens?|token[-_\s]?limit|output[-_\s]?limit)\b/u.test(
+			finishReason,
+		)
+	) {
+		return true;
+	}
+	const completionTokens = raw.usage?.completionTokens;
+	return (
+		typeof completionTokens === "number" &&
+		Number.isFinite(completionTokens) &&
+		completionTokens >= maxTokens
+	);
+}
+
+function extractJsonStringField(
+	text: string,
+	fieldName: string,
+): string | null {
+	const pattern = new RegExp(
+		`"${fieldName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"\\s*:\\s*"`,
+		"u",
+	);
+	const match = pattern.exec(text);
+	if (!match) return null;
+	const valueStart = match.index + match[0].length;
+	let escaped = false;
+	for (let i = valueStart; i < text.length; i++) {
+		const ch = text[i];
+		if (escaped) {
+			escaped = false;
+			continue;
+		}
+		if (ch === "\\") {
+			escaped = true;
+			continue;
+		}
+		if (ch === '"') {
+			try {
+				return JSON.parse(`"${text.slice(valueStart, i)}"`) as string;
+			} catch {
+				return null;
+			}
+		}
+	}
+	return null;
+}
+
+function recoverStage1TruncatedMessageHandler(
+	raw: string | GenerateTextResult,
+): MessageHandlerResult | null {
+	const text = getV5ModelText(raw);
+	const replyText = extractJsonStringField(text, "replyText")?.trim();
+	if (!replyText) return null;
+	return {
+		processMessage: "RESPOND",
+		thought:
+			"Stage 1 hit the completion limit; recovered a completed replyText field from the truncated envelope.",
+		plan: {
+			contexts: [SIMPLE_CONTEXT_ID],
+			reply: stripReasoningBlocks(replyText),
+			simple: true,
+			requiresTool: false,
+		},
+	};
+}
+
+function synthesizeStage1TruncationReply(): MessageHandlerResult {
+	return {
+		processMessage: "RESPOND",
+		thought:
+			"Stage 1 hit the completion limit and no complete replyText field could be recovered.",
+		plan: {
+			contexts: [SIMPLE_CONTEXT_ID],
+			reply: STAGE1_TRUNCATION_REPLY,
+			simple: true,
+			requiresTool: false,
+		},
+	};
 }
 
 /**
@@ -4780,6 +4911,30 @@ export async function runV5MessageRuntimeStage1(args: {
 		if (!messageHandler) {
 			messageHandler = parseMessageHandlerModelOutput(rawMessageHandler);
 		}
+		const stage1CompletionLimitHit = stage1HitCompletionLimit(
+			rawMessageHandler,
+			stage1ModelParams.maxTokens,
+		);
+		if (stage1CompletionLimitHit) {
+			args.runtime.logger?.warn?.(
+				{
+					src: "service:message",
+					finishReason: getStage1FinishReason(rawMessageHandler),
+					usage:
+						typeof rawMessageHandler === "string"
+							? undefined
+							: rawMessageHandler.usage,
+					maxTokens: stage1ModelParams.maxTokens,
+					recovered: Boolean(messageHandler),
+				},
+				"[message] Stage 1 hit the completion-token limit",
+			);
+		}
+		if (!messageHandler && stage1CompletionLimitHit) {
+			messageHandler =
+				recoverStage1TruncatedMessageHandler(rawMessageHandler) ??
+				synthesizeStage1TruncationReply();
+		}
 		if (
 			!messageHandler &&
 			isEmptyStage1Result(rawMessageHandler) &&
@@ -5373,6 +5528,7 @@ async function recordMessageHandlerStage(args: {
 				response: responseText,
 				toolCalls: extractMessageHandlerToolCalls(args.raw),
 				usage,
+				finishReason: getStage1FinishReason(args.raw) || undefined,
 			},
 			cache: args.prefixHash
 				? {
@@ -6528,6 +6684,9 @@ function looksLikeCodingWorkRequest(text: string): boolean {
 		/\b(?:sub[- ]?agent|task[- ]?agent|coding agent|opencode|codex|claude)\b[\s\S]{0,80}\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|verify)\b/iu.test(
 			normalized,
 		);
+	if (!asksDelegation && looksLikeInlineCodeSnippetRequest(normalized)) {
+		return false;
+	}
 	const asksCodingWork =
 		/\b(?:build|create|make|implement|write|scaffold|fix|edit|modify|verify)\b[\s\S]{0,160}\b(?:app|site|page|code|file|files|project|cli|script|backend|frontend|repo|feature|bug|url)\b/iu.test(
 			normalized,
@@ -6536,6 +6695,29 @@ function looksLikeCodingWorkRequest(text: string): boolean {
 			normalized,
 		);
 	return asksDelegation || asksCodingWork;
+}
+
+function looksLikeInlineCodeSnippetRequest(text: string): boolean {
+	const normalized = text.toLowerCase();
+	if (
+		/\b(?:file|files|repo|repository|project|app|site|page|backend|frontend|deploy|build|run|execute|install|test|verify|fix|edit|modify|save|write\s+(?:to|in)\s+(?:\/|\.\/|[a-z]:\\))\b/iu.test(
+			normalized,
+		)
+	) {
+		return false;
+	}
+	const asksForSnippet =
+		/\b(?:write|give me|show me|generate|provide|create|make)\b[\s\S]{0,80}\b(?:code block|snippet|function|class|method|example|program|one[- ]?liner|hello world|fibonacci)\b/iu.test(
+			normalized,
+		) ||
+		/\b(?:code block|snippet|function|class|method|example|program|one[- ]?liner|hello world|fibonacci)\b[\s\S]{0,80}\b(?:in|using|for)\s+(?:python|javascript|typescript|java|go|rust|ruby|bash|shell|c\+\+|c#|c\b|php|swift|kotlin)\b/iu.test(
+			normalized,
+		);
+	const hasSmallScope =
+		/\b(?:hello world|fibonacci|fib|single|simple|short|small|tiny|example|snippet|function|code block|one[- ]?liner|\d+\s*[- ]?line)\b/iu.test(
+			normalized,
+		);
+	return asksForSnippet && hasSmallScope;
 }
 
 function looksLikeCreativeWritingRequest(text: string): boolean {


### PR DESCRIPTION
Fixes #7963.
Fixes #7964.
Fixes #7962.

## Summary
- detect Stage 1 completion-token cutoff by finish reason or completion token usage
- recover complete `replyText` from truncated envelopes, or return an explicit cutoff message instead of dropping the reply
- add code validity guidance and keep tight line-count requests syntactically valid
- prefer direct replies for inline trivial code snippet requests when only weak planning signals are present

## Tests
- ./node_modules/.bin/vitest run packages/core/src/runtime/__tests__/action-retrieval.test.ts packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts packages/core/src/__tests__/message-runtime-stage1.test.ts packages/core/src/runtime/__tests__/planner-loop.test.ts packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts

Note: tests were run from the primary checkout because this clean PR worktree does not have its own dependency install.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three issues with Stage 1 (the response-handler model call): it detects when the model hits its completion-token limit, attempts to extract a complete `replyText` from the truncated JSON envelope, and falls back to an explicit user-facing cutoff message instead of silently dropping the reply. It also adds a code-validity instruction to Stage 1 and Stage 2 prompts, and adds a heuristic (`looksLikeInlineCodeSnippetRequest`) to keep small, self-contained code snippet requests on the fast direct-reply path even when Stage 1 suggests a TASKS planning action.

- **Truncation recovery**: `stage1HitCompletionLimit` detects cutoff by `finishReason` or token count equality; `extractJsonStringField` then tries to pull a complete `replyText` string from the partial JSON; on failure `synthesizeStage1TruncationReply` returns the cutoff message.
- **Inline-snippet routing**: `looksLikeInlineCodeSnippetRequest` + `hasOnlyWeakDirectReplyPlanningSignals` short-circuits the planning path for trivial code requests, and the `shouldRegenerateStage1ReplyText` guard is updated to not strip code-block replies.
- **Code-validity instruction**: injected into both the `RESPONSE_TASK_BASELINE_INSTRUCTIONS` (Stage 2) and `renderMessageHandlerInstructions` (Stage 1) so models prioritize syntactically valid code over impossible formatting constraints.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the truncation-recovery path is additive and falls back to a neutral cutoff message, so the worst-case regression is a user-visible cut-off message instead of a silent drop.

The recovery logic and routing changes are well-tested. The main concern is that the recovered log field is evaluated before the recovery attempt runs, making it misleading in production log queries. The exclusion of run, test, and fix in the inline snippet detector can also push some clearly trivial requests onto the planning path. Neither issue affects correctness of the reply delivered to the user.

packages/core/src/services/message.ts — the stage1CompletionLimitHit warning block and the looksLikeInlineCodeSnippetRequest exclusion list are worth a second look before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/services/message.ts | Core changes: adds Stage 1 truncation detection/recovery, inline code snippet routing, and code-validity instructions; the recovered log field is semantically inverted at the point it is emitted |
| packages/core/src/__tests__/message-runtime-stage1.test.ts | Adds tests for truncation recovery (complete replyText, truncated replyText) and code-validity system message injection; coverage is solid for the two main paths |
| packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts | Adds three tests for inline-code-snippet routing: hello-world, fibonacci, and explicit sub-agent delegation; all test the new shouldPreferInlineCodeSnippetDirectReply branch |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Stage 1 model output] --> B{rawFieldParsed?}
    B -- yes --> C[Field dispatch]
    B -- no --> D[parseMessageHandlerModelOutput]
    C --> E{messageHandler set?}
    D --> E
    E -- yes --> F{stage1CompletionLimitHit?}
    E -- no --> F
    F -- yes --> G[warn log]
    G --> H{messageHandler still null?}
    F -- no --> I[Continue normal flow]
    H -- yes --> J[recoverStage1TruncatedMessageHandler]
    J --> K{replyText extractable?}
    K -- yes --> L[recovered replyText]
    K -- no --> M[synthesizeStage1TruncationReply]
    H -- no --> I
    L --> I
    M --> I
    I --> N{preferInlineCodeSnippet?}
    N -- yes --> O[simple direct reply]
    N -- no --> P{shouldPlan?}
    P -- yes --> Q[planning path]
    P -- no --> O
```

<sub>Reviews (1): Last reviewed commit: ["fix(core): recover truncated stage1 and ..."](https://github.com/elizaos/eliza/commit/22a47809b915fc82da1b5b2be967cbe1d77bb96b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34234083)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->