### PR TITLE
fix(runtime): ground subagent completions and chat search

### DIFF
--- a/packages/core/src/features/messaging/triage/actions/searchMessages.ts
+++ b/packages/core/src/features/messaging/triage/actions/searchMessages.ts
@@ -22,6 +22,8 @@ export const searchMessagesAction: Action = {
 	descriptionCompressed:
 		"read-only search msgs; not for draft reply send unsubscribe archive trash label mutate",
 	similes: [
+		"SEARCH_MESSAGES",
+		"MESSAGE_SEARCH",
 		"SEARCH_INBOX",
 		"FIND_MESSAGE",
 		"SEARCH_EMAIL",

--- a/packages/core/src/runtime/__tests__/action-retrieval.test.ts
+++ b/packages/core/src/runtime/__tests__/action-retrieval.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { promoteSubactionsToActions } from "../../actions/promote-subactions";
+import { searchMessagesAction } from "../../features/messaging/triage/actions/searchMessages";
 import { buildActionCatalog } from "../action-catalog";
 import { retrieveActions, tokenizeActionSearchText } from "../action-retrieval";
 
@@ -308,6 +309,36 @@ describe("action catalogue and retrieval", () => {
 			name: "TASKS",
 			matchedBy: expect.arrayContaining(["bm25"]),
 		});
+	});
+
+	it("maps SEARCH_MESSAGES candidate hints to MESSAGE even when recent context is searched", () => {
+		const catalog = buildActionCatalog([
+			searchMessagesAction,
+			{
+				name: "TASKS",
+				description: "Build apps, websites, code projects, and files.",
+			},
+			{
+				name: "SHELL",
+				description: "Run local shell commands and inspect files.",
+			},
+		]);
+		const response = retrieveActions({
+			catalog,
+			messageText: "Can you find that in the chat again?",
+			candidateActions: ["SEARCH_MESSAGES"],
+			recentConversationText:
+				"Build a small app and inspect the project files.",
+		});
+
+		expect(response.query.parentActionHints).toEqual(["MESSAGE"]);
+		expect(response.results[0]).toMatchObject({
+			name: "MESSAGE",
+			score: 1,
+			matchedBy: expect.arrayContaining(["exact"]),
+		});
+		expect(searchMessagesAction.similes).toContain("SEARCH_MESSAGES");
+		expect(searchMessagesAction.similes).toContain("MESSAGE_SEARCH");
 	});
 
 	it("does not retrieve actions from context match alone", () => {

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -168,6 +168,14 @@ const RETRIEVAL_TIER_DEFAULTS: Record<
 // When `ELIZA_PROMPT_COMPRESS=1` is set we trade retrieval breadth for a
 // tighter token budget on the available-actions block.
 const COMPRESS_MODE_TOP_K_CAP = 8;
+const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, string> = {
+	SEARCH_MESSAGES: "MESSAGE",
+	MESSAGE_SEARCH: "MESSAGE",
+	SEARCH_CHATS: "MESSAGE",
+	SEARCH_CHAT: "MESSAGE",
+	FIND_MESSAGES: "MESSAGE",
+	FIND_MESSAGE: "MESSAGE",
+};
 
 function resolveTierOverridesFromEnv():
 	| { topK: number; stageWeights: Partial<Record<RetrievalStageName, number>> }
@@ -204,14 +212,24 @@ export function retrieveActions(
 	input: RetrieveActionsInput,
 ): ActionRetrievalResponse {
 	const candidateActions = dedupeNormalizedStrings(input.candidateActions);
-	const parentActionHints = dedupeNormalizedStrings(input.parentActionHints);
+	const parentActionHints = dedupeNormalizedStrings([
+		...(input.parentActionHints ?? []),
+		...candidateActions.flatMap((actionName) =>
+			parentAliasesForCandidateAction(actionName),
+		),
+	]);
 	const recentConversationText = shouldUseRecentConversationForActionSearch(
 		input.messageText ?? "",
 	)
 		? normalizeTextList(input.recentConversationText)
 		: [];
 	const candidateActionsForSearch =
-		recentConversationText.length > 0 ? [] : candidateActions;
+		recentConversationText.length > 0
+			? candidateActions.filter(
+					(actionName) =>
+						parentAliasesForCandidateAction(actionName).length > 0,
+				)
+			: candidateActions;
 	const queryText = [
 		input.messageText ?? "",
 		...recentConversationText,
@@ -702,6 +720,12 @@ function dedupeNormalizedStrings(values: string[] | undefined): string[] {
 	}
 
 	return result;
+}
+
+function parentAliasesForCandidateAction(actionName: string): string[] {
+	const normalized = normalizeActionName(actionName);
+	const parent = CANDIDATE_ACTION_PARENT_ALIASES[normalized];
+	return parent ? [parent] : [];
 }
 
 function shouldUseRecentConversationForActionSearch(

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts
@@ -446,6 +446,56 @@ describe("subAgentCompletionResponseEvaluator", () => {
     });
   });
 
+  it("does not use fabricated quantitative replies when completion has a failure marker plus unrelated listing", async () => {
+    const context = makeContext({
+      text: "[sub-agent: source count (opencode) — task_complete]\n[tool output: Find matching source files]\nNo files found\n[/tool output]\n[tool output: List project root]\nREADME.md\npackage.json\ntsconfig.json\n[/tool output]\nNo files found for the requested source-file search. The project root contains unrelated files.",
+      messageHandler: {
+        plan: {
+          contexts: ["simple"],
+          reply: "I found 3 source files.",
+          requiresTool: false,
+        },
+      },
+    });
+
+    expect(subAgentCompletionResponseEvaluator.shouldRun(context)).toBe(true);
+    expect(subAgentCompletionResponseEvaluator.evaluate(context)).toEqual({
+      requiresTool: true,
+      setContexts: ["automation"],
+      clearReply: true,
+      addCandidateActions: ["TASKS_SEND_TO_AGENT"],
+      addParentActionHints: ["TASKS"],
+      debug: [
+        "sub-agent completion contains failure markers without clear positive evidence; routing back through TASKS for grounded follow-up",
+      ],
+    });
+  });
+
+  it("allows positive quantitative completions even when phrased as a count", async () => {
+    const context = makeContext({
+      text: "[sub-agent: source count (opencode) — task_complete]\nFound 3 matching source files: src/a.ts, src/b.ts, and src/c.ts.",
+      messageHandler: {
+        plan: {
+          contexts: ["simple"],
+          reply: "Could you share the file count?",
+          requiresTool: false,
+        },
+      },
+    });
+
+    expect(subAgentCompletionResponseEvaluator.shouldRun(context)).toBe(true);
+    expect(subAgentCompletionResponseEvaluator.evaluate(context)).toEqual({
+      requiresTool: false,
+      setContexts: [SIMPLE_CONTEXT_ID],
+      clearCandidateActions: true,
+      clearParentActionHints: true,
+      reply: "Found 3 matching source files: src/a.ts, src/b.ts, and src/c.ts.",
+      debug: [
+        "verified sub-agent completion has no concrete follow-up action; using direct reply",
+      ],
+    });
+  });
+
   it("prefers a clean final answer over a raw transcript reply with incidental URLs", async () => {
     const context = makeContext({
       text: '[sub-agent: package check (opencode) — task_complete]\n[tool output: packages/core/package.json]\n{"name":"@elizaos/core","homepage":"https://github.com/elizaOS/eliza","repository":{"url":"git+https://github.com/elizaOS/eliza.git"}}\n[/tool output]@elizaos/core',

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
@@ -18,6 +18,10 @@ const EMPTY_COMPLETION_PLACEHOLDER =
 const ORCHESTRATOR_CONTEXT_ID = "automation" as AgentContext;
 const URL_IN_TEXT_RE = /https?:\/\/[^\s<>"'`)\]*]+/g;
 const TOOL_OUTPUT_END_MARKER = "[/tool output]";
+const FAILURE_MARKER_RE =
+  /\b(?:no files? found|no matching files?|no matches? found|found no files?|could not find|unable to find|nothing found)\b/i;
+const POSITIVE_QUANTITATIVE_EVIDENCE_RE =
+  /\b(?:found|located|matched|identified|listed|returned|there (?:are|were)|total(?:ed)?|count(?:\s+is)?|contains?)\s+(?:[1-9]\d*|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve)\b/i;
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value !== null && typeof value === "object"
@@ -299,6 +303,17 @@ function completionHasVerificationFailure(text: string): boolean {
   );
 }
 
+function completionHasFailureMarkerWithoutPositiveEvidence(
+  text: string,
+  verifiedUrls: readonly string[] = [],
+): boolean {
+  const body = userFacingCompletionBody(text);
+  const searchable = body || stripRouterAnnotations(text);
+  if (!FAILURE_MARKER_RE.test(searchable)) return false;
+  if (verifiedUrls.length > 0 || hasUserFacingUrl(searchable)) return false;
+  return !POSITIVE_QUANTITATIVE_EVIDENCE_RE.test(searchable);
+}
+
 function verifiedUrlsFromMetadata(message: Memory): string[] {
   return stringArrayOf(metadataRecord(message)?.subAgentVerifiedUrls);
 }
@@ -424,6 +439,14 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
     const currentReply = textOf(messageHandler.plan.reply);
     const completionText = textOf(contentRecord(message)?.text);
     const verifiedUrls = verifiedUrlsFromMetadata(message);
+    if (
+      completionHasFailureMarkerWithoutPositiveEvidence(
+        completionText,
+        verifiedUrls,
+      )
+    ) {
+      return true;
+    }
     if (hasVerifiedCompletionReply(currentReply, completionText, verifiedUrls))
       return true;
     if (hasCleanFinalProseAfterToolOutput(completionText)) return true;
@@ -440,6 +463,24 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
     const currentReply = textOf(messageHandler.plan.reply);
     const completionText = textOf(contentRecord(message)?.text);
     const verifiedUrls = verifiedUrlsFromMetadata(message);
+    if (
+      completionHasFailureMarkerWithoutPositiveEvidence(
+        completionText,
+        verifiedUrls,
+      )
+    ) {
+      return {
+        ...respondIfNeeded(messageHandler),
+        requiresTool: true,
+        setContexts: [ORCHESTRATOR_CONTEXT_ID],
+        clearReply: true,
+        addCandidateActions: ["TASKS_SEND_TO_AGENT"],
+        addParentActionHints: ["TASKS"],
+        debug: [
+          "sub-agent completion contains failure markers without clear positive evidence; routing back through TASKS for grounded follow-up",
+        ],
+      };
+    }
     const reply = cleanCompletionReply(
       replyPatchFromCompletion(
         currentReply,


### PR DESCRIPTION
Fixes #7959.
Fixes #7935.

## Summary
- route failure-marker sub-agent completions without positive evidence back through TASKS instead of accepting fabricated numeric replies
- preserve explicit chat-search candidate hints by mapping SEARCH_MESSAGES/MESSAGE_SEARCH aliases to the MESSAGE parent action
- add SEARCH_MESSAGES and MESSAGE_SEARCH similes to the message search action

## Tests
- ./node_modules/.bin/vitest run plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
- ./node_modules/.bin/vitest run packages/core/src/runtime/__tests__/action-retrieval.test.ts packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts packages/core/src/__tests__/message-runtime-stage1.test.ts packages/core/src/runtime/__tests__/planner-loop.test.ts packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts

Note: tests were run from the primary checkout because this clean PR worktree does not have its own dependency install.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR addresses two separate routing bugs: sub-agent completions containing failure markers (e.g. "No files found") were sometimes accepted as valid replies when Stage 1 fabricated a numeric count, and explicit chat-search candidate hints (`SEARCH_MESSAGES`, `MESSAGE_SEARCH`) were silently dropped when `recentConversationText` triggered the recent-context path, preventing the `MESSAGE` parent action from receiving its exact-score boost.

- Adds `FAILURE_MARKER_RE` + `POSITIVE_QUANTITATIVE_EVIDENCE_RE` heuristics to `sub-agent-completion.ts`; completions with failure phrases but no positive quantitative evidence are now re-routed through `TASKS_SEND_TO_AGENT` before a reply is emitted.
- Introduces `CANDIDATE_ACTION_PARENT_ALIASES` in `action-retrieval.ts` to preserve aliased chat-search candidate actions and inject `MESSAGE` as an exact `parentActionHint`, bypassing the recent-context candidate suppression for those tokens.
- Registers `SEARCH_MESSAGES` and `MESSAGE_SEARCH` as explicit similes on `searchMessagesAction` so the regex-scoring stage can also match them via child names.

<h3>Confidence Score: 4/5</h3>

Safe to merge; both bugs are well-targeted and the tests cover the primary regression paths.

The missing aliases for three existing similes (SEARCH_INBOX, SEARCH_EMAIL, CROSS_CHANNEL_SEARCH) and the capped word-list in POSITIVE_QUANTITATIVE_EVIDENCE_RE leave narrow but real gaps that could silently reproduce the same wrong routing for those specific inputs.

action-retrieval.ts (CANDIDATE_ACTION_PARENT_ALIASES coverage) and sub-agent-completion.ts (POSITIVE_QUANTITATIVE_EVIDENCE_RE word list)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/features/messaging/triage/actions/searchMessages.ts | Adds SEARCH_MESSAGES and MESSAGE_SEARCH as explicit similes; straightforward change that aligns the action's simile list with the new alias map. |
| packages/core/src/runtime/action-retrieval.ts | Introduces CANDIDATE_ACTION_PARENT_ALIASES to map chat-search variants to the MESSAGE parent; three existing similes (SEARCH_INBOX, SEARCH_EMAIL, CROSS_CHANNEL_SEARCH) are missing from the alias map. |
| plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts | Adds failure-marker detection to reroute sub-agent completions through TASKS when they signal failure without positive numeric evidence; POSITIVE_QUANTITATIVE_EVIDENCE_RE word list stops at twelve. |
| packages/core/src/runtime/__tests__/action-retrieval.test.ts | Adds a targeted test verifying SEARCH_MESSAGES candidate hints map to MESSAGE even when recent conversation text is present. |
| plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts | Adds two new evaluator unit tests covering fabricated-count rejection and genuine positive-count pass-through. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Sub-agent task_complete received] --> B{isSuccessfulSubAgentCompletion?}
    B -- No --> Z[Skip evaluator]
    B -- Yes --> C{completionHasFailureMarkerWithoutPositiveEvidence?}
    C -- "FAILURE_MARKER_RE matches AND no verified URL AND POSITIVE_QUANTITATIVE_EVIDENCE_RE misses" --> D[Route → TASKS_SEND_TO_AGENT\nsetContexts: automation\nclearReply: true]
    C -- No --> E{hasVerifiedCompletionReply OR hasCleanFinalProseAfterToolOutput?}
    E -- Yes --> F{reply contains URL?}
    F -- Yes --> G[Direct reply with URL]
    F -- No --> H{looksLikeCapturedToolOutput?}
    H -- Yes --> I[Route → TASKS_SEND_TO_AGENT]
    H -- No --> J{looksLikeRawToolTranscript?}
    J -- Yes --> K[Route → TASKS_SEND_TO_AGENT for summarization]
    J -- No --> L[Direct prose reply setContexts: simple]
    E -- No --> M{hasConcreteFollowUp OR hasConcreteParentHint?}
    M -- Yes --> Z2[Skip evaluator — follow-up already planned]
    M -- No --> L
```

<sub>Reviews (1): Last reviewed commit: ["fix(runtime): ground subagent completion..."](https://github.com/elizaos/eliza/commit/e8a51ce1dbc7f1fdd518263ab31367dc4787e1c5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34234088)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->