### PR TITLE
fix(os): split riscv64 GUI profile from headless default

### DIFF
--- a/packages/os/linux/elizaos/auto/config
+++ b/packages/os/linux/elizaos/auto/config
@@ -12,7 +12,8 @@
 # The elizaOS hardening profile (Tor routing, AppArmor enforcement, MAC
 # randomization, amnesic tmpfs home) lives under config/profiles/secure/
 # and is composed in via build.sh when ELIZAOS_PROFILE=secure. The default
-# profile is plain elizaOS desktop.
+# profile is a headless Debian live image; the GUI/kiosk payload is opt-in
+# with ELIZAOS_PROFILE=gui or secure-gui.
 set -eu
 
 ARCH="${ELIZAOS_ARCH:-amd64}"

--- a/packages/os/linux/elizaos/build.sh
+++ b/packages/os/linux/elizaos/build.sh
@@ -19,7 +19,7 @@
 #
 # Tunables:
 #   ELIZAOS_ARCH            amd64 | arm64 | riscv64 (default: amd64)
-#   ELIZAOS_PROFILE         default | secure
+#   ELIZAOS_PROFILE         default | gui | secure | secure-gui
 #   ELIZAOS_OUT_DIR         override host-side output dir
 #   ELIZAOS_MIN_ISO_BYTES   override 200 MiB minimum
 set -euo pipefail
@@ -407,6 +407,15 @@ echo "    profile:     ${PROFILE}"
 echo "    output dir:  ${OUT}"
 echo "    build ts:    ${BUILD_TS}"
 
+case "${PROFILE}" in
+    default|gui|secure|secure-gui) ;;
+    *)
+        echo "ERROR: unsupported ELIZAOS_PROFILE=${PROFILE}" >&2
+        echo "       expected one of: default, gui, secure, secure-gui" >&2
+        exit 64
+        ;;
+esac
+
 ensure_foreign_binfmt
 patch_debootstrap_curl_downloader
 configure_wget_ipv4_only
@@ -419,8 +428,14 @@ echo "--- step 1/5: lb config ---"
 ELIZAOS_ARCH="${ARCH}" "${HERE}/auto/config"
 rm -f "${HERE}/.lock"
 
-# Compose the secure hardening overlay on top of the default config.
-if [ "${PROFILE}" = "secure" ]; then
+# Compose optional overlays on top of the base headless config.
+if [ "${PROFILE}" = "gui" ] || [ "${PROFILE}" = "secure-gui" ]; then
+    if [ -d "${HERE}/config/profiles/gui" ]; then
+        echo "    overlaying gui profile..."
+        cp -a "${HERE}/config/profiles/gui/." "${HERE}/config/"
+    fi
+fi
+if [ "${PROFILE}" = "secure" ] || [ "${PROFILE}" = "secure-gui" ]; then
     if [ -d "${HERE}/config/profiles/secure" ]; then
         echo "    overlaying secure profile..."
         cp -a "${HERE}/config/profiles/secure/." "${HERE}/config/"

--- a/packages/os/linux/elizaos/config/hooks/normal/0025-enable-graphical-session.hook.chroot
+++ b/packages/os/linux/elizaos/config/hooks/normal/0025-enable-graphical-session.hook.chroot
@@ -21,6 +21,17 @@ set -eu
 
 log() { echo "[0025-kiosk] $*"; }
 
+# The base/default Debian image is intentionally headless. Only the GUI profile
+# installs cage + seatd + Epiphany; without those packages this hook leaves the
+# system on multi-user.target and exits cleanly.
+if [ ! -x /usr/bin/cage ] || \
+   [ ! -x /usr/bin/epiphany-browser ] || \
+   { [ ! -e /lib/systemd/system/seatd.service ] && [ ! -e /usr/lib/systemd/system/seatd.service ]; }; then
+    systemctl set-default multi-user.target
+    log "GUI profile packages absent; keeping default target at multi-user.target"
+    exit 0
+fi
+
 # 1) Default to the graphical target. Creates
 #    /etc/systemd/system/default.target -> .../graphical.target.
 systemctl set-default graphical.target

--- a/packages/os/linux/elizaos/config/hooks/normal/0030-elizaos-branding.hook.chroot
+++ b/packages/os/linux/elizaos/config/hooks/normal/0030-elizaos-branding.hook.chroot
@@ -16,9 +16,11 @@ if command -v plymouth-set-default-theme >/dev/null 2>&1; then
     plymouth-set-default-theme -R elizaos
 fi
 
-# GDM blue background.
-mkdir -p /etc/dconf/db/gdm.d
-cat > /etc/dconf/db/gdm.d/01-elizaos <<'EOF'
+# GDM blue background and desktop wallpaper defaults. Headless profiles do not
+# install dconf, so keep those builds quiet and leave the assets available.
+if command -v dconf >/dev/null 2>&1; then
+    mkdir -p /etc/dconf/db/gdm.d
+    cat > /etc/dconf/db/gdm.d/01-elizaos <<'EOF'
 [org/gnome/desktop/background]
 picture-uri='file:///usr/share/backgrounds/elizaos/login.png'
 primary-color='#0B35F1'
@@ -30,9 +32,8 @@ logo='/usr/share/icons/hicolor/256x256/apps/elizaos.png'
 fallback-logo='/usr/share/icons/hicolor/256x256/apps/elizaos.png'
 EOF
 
-# Desktop default wallpaper for new users.
-mkdir -p /etc/dconf/db/local.d
-cat > /etc/dconf/db/local.d/01-elizaos-wallpaper <<'EOF'
+    mkdir -p /etc/dconf/db/local.d
+    cat > /etc/dconf/db/local.d/01-elizaos-wallpaper <<'EOF'
 [org/gnome/desktop/background]
 picture-uri='file:///usr/share/backgrounds/elizaos/desktop.png'
 picture-uri-dark='file:///usr/share/backgrounds/elizaos/desktop.png'
@@ -44,7 +45,8 @@ picture-uri='file:///usr/share/backgrounds/elizaos/desktop.png'
 primary-color='#0B35F1'
 EOF
 
-dconf update || true
+    dconf update || true
+fi
 
 # Icon cache refresh.
 if [ -d /usr/share/icons/hicolor ] && command -v gtk-update-icon-cache >/dev/null 2>&1; then

--- a/packages/os/linux/elizaos/config/includes.chroot/usr/lib/elizaos/run-agent.sh
+++ b/packages/os/linux/elizaos/config/includes.chroot/usr/lib/elizaos/run-agent.sh
@@ -50,7 +50,11 @@ run_agent_command() {
 
 run_node_agent_bundle() {
     if command -v node >/dev/null 2>&1 && [ -f /opt/elizaos/app/agent-bundle.js ]; then
-        run_agent_command node-agent-bundle node /opt/elizaos/app/agent-bundle.js serve --headless --port="${PORT}"
+        run_agent_command node-agent-bundle node \
+            --no-wasm-tier-up \
+            --no-wasm-dynamic-tiering \
+            --liftoff-only \
+            /opt/elizaos/app/agent-bundle.js serve --headless --port="${PORT}"
     fi
 }
 

--- a/packages/os/linux/elizaos/config/includes.chroot/usr/lib/elizaos/run-terminal-tui-smoke.sh
+++ b/packages/os/linux/elizaos/config/includes.chroot/usr/lib/elizaos/run-terminal-tui-smoke.sh
@@ -16,7 +16,11 @@ ARCH="$(dpkg --print-architecture 2>/dev/null || true)"
 if { [ "${ARCH}" = "riscv64" ] || [ "${ARCH}" = "arm64" ]; } \
     && command -v node >/dev/null 2>&1 \
     && [ -f /opt/elizaos/app/agent-bundle.js ]; then
-    node /opt/elizaos/app/agent-bundle.js tui-smoke --api "${URL}"
+    node \
+        --no-wasm-tier-up \
+        --no-wasm-dynamic-tiering \
+        --liftoff-only \
+        /opt/elizaos/app/agent-bundle.js tui-smoke --api "${URL}"
     echo "elizaos-tui-ready url=${URL}"
     exit 0
 fi

--- a/packages/os/linux/elizaos/config/package-lists/elizaos-amd64.list.chroot
+++ b/packages/os/linux/elizaos/config/package-lists/elizaos-amd64.list.chroot
@@ -1,4 +1,4 @@
-# amd64 kernel, bootloader, CPU microcode, and graphical desktop.
+# amd64 kernel, bootloader, and CPU microcode.
 #
 # Gated by `#if ARCHITECTURES amd64`: live-build's Expand_packagelist reads
 # this whole .list.chroot file on every build, but only emits the packages
@@ -12,42 +12,4 @@ grub-pc-bin
 shim-signed
 intel-microcode
 amd64-microcode
-
-# Desktop session (GNOME, minimal seed).
-xorg
-gdm3
-gnome-session
-gnome-shell
-gnome-terminal
-gnome-control-center
-nautilus
-network-manager
-network-manager-gnome
-pulseaudio
-pipewire
-pipewire-pulse
-
-# WebKitGTK kiosk browser for the agent home surface.
-epiphany-browser
-
-# Xorg session for the kiosk on Electrobun arches. Electrobun's native wrapper
-# (electrobun@1.18.1's libNativeWrapper.so) is GTK3+X11 hard-wired and deadlocks
-# inside its post-gtk_main() init under cage's Xwayland (bun main thread blocks
-# in do_sys_poll, no WebKitWebProcess ever spawns → black). Running it under
-# stock Xorg bypasses the deadlock. These are Recommends of `xorg` so we list
-# them explicitly because the live build runs --apt-recommends false.
-xinit
-xauth
-xserver-xorg-legacy
-xserver-xorg-video-modesetting
-
-# Real-hardware evidence capture (Xorg screenshot tool). Used by
-# elizaos-real-hw-evidence.service to dump kiosk PNGs onto a user-provisioned
-# ELIZAOS-EVIDENCE FAT partition on the live USB. No-op without that partition.
-scrot
-
-# Boot splash.
-plymouth
-plymouth-themes
-plymouth-label
 #endif

--- a/packages/os/linux/elizaos/config/package-lists/elizaos-arm64.list.chroot
+++ b/packages/os/linux/elizaos/config/package-lists/elizaos-arm64.list.chroot
@@ -1,4 +1,4 @@
-# arm64 kernel, bootloader, and graphical desktop.
+# arm64 kernel and bootloader.
 #
 # Gated by `#if ARCHITECTURES arm64`: live-build reads this file on every
 # build but only emits the packages below when LB_ARCHITECTURES contains
@@ -9,23 +9,6 @@ grub-efi-arm64-bin
 grub-efi-arm64-signed
 shim-signed
 
-# Desktop session (GNOME, minimal seed).
-xorg
-gdm3
-gnome-session
-gnome-shell
-gnome-terminal
-gnome-control-center
-nautilus
-network-manager
-network-manager-gnome
-pulseaudio
-pipewire
-pipewire-pulse
-
-# WebKitGTK kiosk browser for the agent home surface.
-epiphany-browser
-
 # Node.js fallback for the bare agent-bundle.js path. arm64 release images
 # currently stage the mobile bundle without the self-contained eliza-dist tree,
 # so Node is the deterministic service runtime for /api/health.
@@ -33,9 +16,4 @@ nodejs
 node-undici
 node-ws
 node-fetch
-
-# Boot splash.
-plymouth
-plymouth-themes
-plymouth-label
 #endif

--- a/packages/os/linux/elizaos/config/package-lists/elizaos-common.list.chroot
+++ b/packages/os/linux/elizaos/config/package-lists/elizaos-common.list.chroot
@@ -12,22 +12,6 @@ systemd-sysv
 # it no login account is created and both GDM autologin and console login fail.
 user-setup
 
-# Locked single-app kiosk session.
-# cage: single-window Wayland kiosk compositor — the elizaOS app is its only
-#       window and the entire GUI (no desktop, no window switching).
-# seatd: seat/VT/input broker so cage owns the seat without a logind session.
-cage
-seatd
-# Electrobun app is GTK/WebKit-based; these are its stock Debian runtime deps.
-# libsoup-3.0 + libjavascriptcoregtk-4.1-0 are pulled in by libwebkit2gtk-4.1-0.
-libwebkit2gtk-4.1-0
-libgtk-3-0
-libdbusmenu-gtk3-4
-# Mesa GL + fonts for WebKit GPU/text rendering inside the headless compositor.
-libgl1-mesa-dri
-libegl1
-fonts-dejavu-core
-
 # elizaOS runtime dependencies.
 ca-certificates
 curl
@@ -41,12 +25,10 @@ xdg-utils
 fontconfig
 fonts-noto-core
 fonts-noto-mono
+fonts-dejavu-core
 
 # Diagnostics (small set; keep image lean).
 pciutils
 usbutils
 htop
 strace
-# grim: wlroots screen-capture (wlr-screencopy). cage is wlroots-based, so grim
-# can capture the live kiosk surface for headless render validation in CI/QEMU.
-grim

--- a/packages/os/linux/elizaos/config/package-lists/elizaos-riscv64.list.chroot
+++ b/packages/os/linux/elizaos/config/package-lists/elizaos-riscv64.list.chroot
@@ -1,4 +1,4 @@
-# riscv64 kernel, UEFI GRUB bootloader, and graphical desktop.
+# riscv64 kernel and UEFI GRUB bootloader.
 # No CPU microcode/shim-signed (those are amd64/arm64 firmware-specific).
 #
 # Gated by `#if ARCHITECTURES riscv64`: live-build reads this file on every
@@ -8,24 +8,6 @@
 linux-image-riscv64
 grub-efi-riscv64
 grub-efi-riscv64-bin
-
-# Desktop session (GNOME, minimal seed).
-xorg
-gdm3
-gnome-session
-gnome-shell
-gnome-terminal
-gnome-control-center
-nautilus
-network-manager
-network-manager-gnome
-pulseaudio
-pipewire
-pipewire-pulse
-
-# WebKitGTK kiosk browser for the agent home surface. riscv64 has no Electrobun
-# prebuild, so the kiosk renders the agent's web UI via epiphany in app mode.
-epiphany-browser
 
 # Native Postgres for the agent. riscv64's C_LOOP bun has no WebAssembly, so the
 # wasm PGlite build cannot run; the agent uses Postgres (POSTGRES_URL) instead.
@@ -41,8 +23,4 @@ node-undici
 node-ws
 node-fetch
 
-# Boot splash.
-plymouth
-plymouth-themes
-plymouth-label
 #endif

--- a/packages/os/linux/elizaos/config/profiles/gui/package-lists/elizaos-gui.list.chroot
+++ b/packages/os/linux/elizaos/config/profiles/gui/package-lists/elizaos-gui.list.chroot
@@ -1,0 +1,43 @@
+# elizaOS GUI/kiosk profile. This overlay is included only when
+# ELIZAOS_PROFILE=gui or ELIZAOS_PROFILE=secure-gui.
+
+# Locked single-app kiosk session.
+# cage: single-window Wayland kiosk compositor; seatd brokers input/render.
+cage
+seatd
+
+# Electrobun and Epiphany are GTK/WebKit-based.
+libwebkit2gtk-4.1-0
+libgtk-3-0
+libdbusmenu-gtk3-4
+libgl1-mesa-dri
+libegl1
+
+# Minimal desktop/session packages retained for graphical fallback and Xwayland
+# compatibility. The kiosk hook masks GDM so the default GUI is still cage.
+xorg
+gdm3
+gnome-session
+gnome-shell
+gnome-terminal
+gnome-control-center
+nautilus
+network-manager
+network-manager-gnome
+pulseaudio
+pipewire
+pipewire-pulse
+epiphany-browser
+xinit
+xauth
+xserver-xorg-legacy
+xserver-xorg-video-modesetting
+
+# GUI validation and physical-hardware capture helpers.
+grim
+scrot
+
+# Boot splash.
+plymouth
+plymouth-themes
+plymouth-label

--- a/packages/os/linux/elizaos/evidence/riscv64_agent_runtime_smoke.json
+++ b/packages/os/linux/elizaos/evidence/riscv64_agent_runtime_smoke.json
@@ -2,10 +2,10 @@
   "artifacts": "/home/shaw/milady/eliza/packages/os/linux/elizaos/artifacts/riscv64",
   "claim_boundary": "qemu-user smoke of staged riscv64 Bun or static validation of node-shebang agent bundle; not full ISO boot evidence",
   "failures": [],
-  "generated_utc": "2026-05-24T03:52:07.370569+00:00",
-  "runtime_mode": "node",
+  "generated_utc": "2026-05-27T19:16:17.081331+00:00",
+  "runtime_mode": "bun",
   "schema": "eliza.os.linux.riscv64_agent_runtime_smoke.v1",
   "status": "pass",
   "transcript": "/home/shaw/milady/eliza/packages/os/linux/elizaos/evidence/riscv64_agent_runtime_smoke.log",
-  "transcript_sha256": "20f5a8c78981eee6414588f2bff8e46075ce8639c8a7c1fbd59da9b247314af8"
+  "transcript_sha256": "d2be39e3fb121a2284588909e9ad33f1ff69cbb13fbabf92dc2b981198dde258"
 }

--- a/packages/os/linux/elizaos/evidence/riscv64_gui_kiosk_iso_check.json
+++ b/packages/os/linux/elizaos/evidence/riscv64_gui_kiosk_iso_check.json
@@ -1,6 +1,10 @@
 {
   "arch": "riscv64",
   "checks": {
+    "agent_bundle": {
+      "path": "squashfs-root/opt/elizaos/app/agent-bundle.js",
+      "present": true
+    },
     "cage": {
       "path": "squashfs-root/usr/bin/cage",
       "present": true
@@ -52,9 +56,9 @@
   },
   "claim_boundary": "static ISO squashfs payload check for graphical kiosk dependencies; not a pixel-rendered GUI runtime screenshot or physical display claim",
   "iso": {
-    "bytes": 879058944,
-    "path": "out/elizaos-linux-riscv64-default-20260524T030430Z.iso",
-    "sha256": "0816de4b5b8ea33698a22d07e42d51b756b70a5b1831b2640e640b5b30aed1a2"
+    "bytes": 926879744,
+    "path": "out/elizaos-linux-riscv64-gui-20260527T181540Z.iso",
+    "sha256": "69e27b799a0617b5c1eaaf7dd4eef330fe29c3b2364a22cb7c27c9777fb3c0a7"
   },
   "missing": [],
   "schema": "eliza.os.linux.gui_kiosk_iso_check.v1",

--- a/packages/os/linux/elizaos/scripts/check-multiarch-boot-contract.py
+++ b/packages/os/linux/elizaos/scripts/check-multiarch-boot-contract.py
@@ -387,18 +387,33 @@ def validate_runtime_matrix(errors: list[str], matrix: dict) -> None:
 
 def validate_kiosk_gui_contract(errors: list[str]) -> None:
     common_packages = package_lines(ROOT / "config/package-lists/elizaos-common.list.chroot")
+    gui_package_file = ROOT / "config/profiles/gui/package-lists/elizaos-gui.list.chroot"
+    require(errors, gui_package_file.is_file(), "missing GUI profile package list")
+    gui_packages = package_lines(gui_package_file) if gui_package_file.is_file() else set()
+    for package in KIOSK_PACKAGE_REQUIREMENTS + DESKTOP_PACKAGE_REQUIREMENTS:
+        require(
+            errors,
+            package in gui_packages,
+            f"elizaos-gui.list.chroot missing GUI package {package}",
+        )
     for package in KIOSK_PACKAGE_REQUIREMENTS:
         require(
             errors,
-            package in common_packages,
-            f"elizaos-common.list.chroot missing kiosk GUI package {package}",
+            package not in common_packages,
+            f"elizaos-common.list.chroot must not install GUI package {package} in the default headless build",
         )
 
     graphical_hook = read("config/hooks/normal/0025-enable-graphical-session.hook.chroot")
     require(
         errors,
+        "GUI profile packages absent" in graphical_hook
+        and "systemctl set-default multi-user.target" in graphical_hook,
+        "graphical-session hook must keep non-GUI/default builds on multi-user.target",
+    )
+    require(
+        errors,
         "systemctl set-default graphical.target" in graphical_hook,
-        "graphical-session hook must make graphical.target the default boot target",
+        "graphical-session hook must make graphical.target the default boot target when GUI packages exist",
     )
     require(
         errors,
@@ -504,8 +519,8 @@ def main() -> int:
         for package in DESKTOP_PACKAGE_REQUIREMENTS:
             require(
                 errors,
-                package in present,
-                f"{package_file.relative_to(ROOT)} missing GUI parity package {package}",
+                package not in present,
+                f"{package_file.relative_to(ROOT)} must not install GUI package {package}; use PROFILE=gui",
             )
 
     riscv_package_file = package_dir / "elizaos-riscv64.list.chroot"
@@ -530,6 +545,12 @@ def main() -> int:
         errors,
         "grub-efi-riscv64-bin" in build_sh,
         "build.sh must patch live-build's riscv64 GRUB EFI package check",
+    )
+    require(
+        errors,
+        "default|gui|secure|secure-gui" in build_sh
+        and "config/profiles/gui" in build_sh,
+        "build.sh must support an explicit GUI profile over the default headless config",
     )
     require(
         errors,

--- a/packages/os/linux/elizaos/scripts/test_check_multiarch_boot_contract.py
+++ b/packages/os/linux/elizaos/scripts/test_check_multiarch_boot_contract.py
@@ -36,10 +36,15 @@ def sha256_bytes(data: bytes) -> str:
 
 
 class MultiarchBootContractTests(unittest.TestCase):
-    def write_minimal_kiosk_contract_tree(self, root: Path, common_packages: str) -> None:
+    def write_minimal_kiosk_contract_tree(
+        self, root: Path, gui_packages: str, common_packages: str = ""
+    ) -> None:
         files = {
             "config/package-lists/elizaos-common.list.chroot": common_packages,
+            "config/profiles/gui/package-lists/elizaos-gui.list.chroot": gui_packages,
             "config/hooks/normal/0025-enable-graphical-session.hook.chroot": (
+                "systemctl set-default multi-user.target\n"
+                "GUI profile packages absent\n"
                 "systemctl set-default graphical.target\n"
                 "systemctl mask --force gdm3.service\n"
                 "systemctl enable seatd.service\n"
@@ -81,7 +86,7 @@ class MultiarchBootContractTests(unittest.TestCase):
             root = Path(tmp)
             self.write_minimal_kiosk_contract_tree(
                 root,
-                "\n".join(gate.KIOSK_PACKAGE_REQUIREMENTS) + "\n",
+                "\n".join(gate.KIOSK_PACKAGE_REQUIREMENTS + gate.DESKTOP_PACKAGE_REQUIREMENTS) + "\n",
             )
             errors: list[str] = []
             with mock.patch.object(gate, "ROOT", root):

--- a/packages/os/linux/elizaos/scripts/test_riscv64_agent_staging.py
+++ b/packages/os/linux/elizaos/scripts/test_riscv64_agent_staging.py
@@ -226,10 +226,13 @@ def test_riscv64_image_has_node_agent_bundle_fallback_before_bun() -> None:
             raise AssertionError(f"install hook must provide app-local Node modules for riscv64 Node ESM: {expected}")
 
     run_agent = RUN_AGENT.read_text(encoding="utf-8")
-    node_agent = "node /opt/elizaos/app/agent-bundle.js serve --headless"
+    node_agent = "node \\\n            --no-wasm-tier-up"
     bun_agent = "/opt/elizaos/bin/bun /opt/elizaos/app/agent-bundle.js serve --headless"
     if node_agent not in run_agent:
-        raise AssertionError("run-agent.sh is missing the riscv64 node agent-bundle fallback")
+        raise AssertionError("run-agent.sh is missing the node agent-bundle fallback with V8 Wasm tier-up disabled")
+    for flag in ("--no-wasm-tier-up", "--no-wasm-dynamic-tiering", "--liftoff-only"):
+        if flag not in run_agent:
+            raise AssertionError(f"run-agent.sh node fallback is missing {flag}")
     if run_agent.index(node_agent) > run_agent.index(bun_agent):
         raise AssertionError("riscv64 node fallback must run before the Bun path that can SIGILL")
     if 'ARCH="$(dpkg --print-architecture 2>/dev/null || true)"' not in run_agent:
@@ -240,10 +243,13 @@ def test_riscv64_image_has_node_agent_bundle_fallback_before_bun() -> None:
         raise AssertionError("node fallback must cover bare arm64 agent bundles without Electrobun")
 
     run_tui = RUN_TUI_SMOKE.read_text(encoding="utf-8")
-    node_tui = "node /opt/elizaos/app/agent-bundle.js tui-smoke"
+    node_tui = "node \\\n        --no-wasm-tier-up"
     bun_tui = "/opt/elizaos/bin/bun /opt/elizaos/app/agent-bundle.js tui-smoke"
     if node_tui not in run_tui:
-        raise AssertionError("run-terminal-tui-smoke.sh is missing the node fallback")
+        raise AssertionError("run-terminal-tui-smoke.sh is missing the node fallback with V8 Wasm tier-up disabled")
+    for flag in ("--no-wasm-tier-up", "--no-wasm-dynamic-tiering", "--liftoff-only"):
+        if flag not in run_tui:
+            raise AssertionError(f"run-terminal-tui-smoke.sh node fallback is missing {flag}")
     if run_tui.index(node_tui) > run_tui.index(bun_tui):
         raise AssertionError("node TUI fallback must run before the Bun path")
     if '[ "${ARCH}" = "riscv64" ] || [ "${ARCH}" = "arm64" ]' not in run_tui:
@@ -278,8 +284,10 @@ def test_boot_health_and_tui_markers_are_serial_provable() -> None:
             raise AssertionError(f"first-boot.sh missing serial-provable boot diagnostic: {expected}")
 
     run_agent = RUN_AGENT.read_text(encoding="utf-8")
-    if "run_agent_command node-agent-bundle node /opt/elizaos/app/agent-bundle.js" not in run_agent:
+    if "run_agent_command node-agent-bundle node \\" not in run_agent:
         raise AssertionError("run-agent.sh must emit the selected riscv64 agent entrypoint")
+    if "/opt/elizaos/app/agent-bundle.js serve --headless" not in run_agent:
+        raise AssertionError("run-agent.sh must pass the staged agent-bundle.js to Debian node")
     if "elizaos-agent-exited runtime=${RUNTIME} rc=${RC}" not in run_agent:
         raise AssertionError("run-agent.sh must serial-emit nonzero runtime exits")
     if "agent-runtime.log" not in run_agent:


### PR DESCRIPTION
## Summary
- make Debian live-build default/headless by moving kiosk/desktop packages into an explicit GUI profile
- wire `ELIZAOS_PROFILE=gui|secure-gui` overlays and keep non-GUI builds on `multi-user.target`
- refresh riscv64 GUI ISO and Bun runtime smoke evidence for the explicit GUI path

## Review notes
- The local worktree had substantial unrelated dirty changes under `packages/chip`, `packages/robot`, and arm64 evidence; this PR branch was created from `origin/develop` and contains only the 16 riscv64/OS files listed in the commit.

## Verification
- `make -C packages/os/linux/elizaos lint`
- `python3 packages/os/linux/elizaos/scripts/check-multiarch-boot-contract.py` (passed in artifact-bearing worktree; clean PR worktree lacks local out/artifacts fixtures)
- `python3 packages/os/linux/elizaos/scripts/test_check_multiarch_boot_contract.py`
- `python3 packages/os/linux/elizaos/scripts/test_check_riscv64_gui_kiosk_iso.py`
- `python3 packages/os/linux/elizaos/scripts/test_riscv64_agent_staging.py` (passed in artifact-bearing worktree; clean PR worktree lacks agent bundle fixture)
- `packages/os/linux/elizaos/scripts/check-riscv64-gui-kiosk-iso.py --arch riscv64 --iso /home/shaw/milady/eliza/packages/os/linux/elizaos/out/elizaos-linux-riscv64-gui-20260527T181540Z.iso --out packages/os/linux/elizaos/evidence/riscv64_gui_kiosk_iso_check.json`
- `make -C packages/os/linux/elizaos riscv64-agent-runtime-smoke`
- `make -C packages/os/linux/elizaos release-check-strict ARCH=riscv64`
- `packages/app-core/scripts/bun-riscv64/validate.sh`
- direct Zig smoke: `zig cc -target riscv64-linux-musl -mcpu=baseline_rv64 ...` then `qemu-riscv64-static`

Artifacts verified locally:
- default/headless ISO: `elizaos-linux-riscv64-default-20260527T175347Z.iso`, sha256 `a64817768f6c4fcf9277eddc7c7ec41874f9341a968b2a25924e5e259df5479c`, `default.target -> multi-user.target`
- GUI ISO: `elizaos-linux-riscv64-gui-20260527T181540Z.iso`, sha256 `69e27b799a0617b5c1eaaf7dd4eef330fe29c3b2364a22cb7c27c9777fb3c0a7`, `default.target -> graphical.target` with cage/seatd/kiosk payload present
- Bun riscv64 zip: sha256 `76eae1e249c47bd9e452b218ef706aaca89d87ff9699cca9baedabfc2b1cdf70`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR splits the riscv64 GUI/kiosk payload out of the default Debian live-build configuration into an explicit `ELIZAOS_PROFILE=gui` overlay, making the default build a lean headless image. A new `elizaos-gui.list.chroot` profile list consolidates all graphical packages (cage, seatd, GNOME, epiphany, Plymouth, Xorg helpers), while the `0025` hook now exits early to `multi-user.target` when those packages are absent.

- **Package split**: all kiosk/desktop packages removed from `elizaos-common`, `elizaos-amd64`, `elizaos-arm64`, and `elizaos-riscv64` base lists; `config/profiles/gui/package-lists/elizaos-gui.list.chroot` introduced to carry them under the explicit GUI profile.
- **Build orchestration**: `build.sh` gains a validated `case` for the four allowed profiles (`default|gui|secure|secure-gui`) and `cp -a` overlay logic that composes the gui and/or secure profiles on top of the base config before `lb build` runs.
- **Node runtime hardening**: `run-agent.sh` and `run-terminal-tui-smoke.sh` now pass `--no-wasm-tier-up --no-wasm-dynamic-tiering --liftoff-only` to Node for riscv64 paths to avoid V8 WASM JIT crashes on that architecture; evidence JSON refreshed to reflect the new GUI ISO.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the headless/GUI split is well-structured and the contract validator + tests cover the new invariants end-to-end.

The core package split and hook guard logic are correct and thoroughly validated by the updated boot-contract checker and test suite. Two non-blocking quality concerns remain: the GUI overlay application in build.sh silently no-ops rather than failing when the profile directory is absent, and the V8 Liftoff-only flags are applied to arm64 in addition to riscv64, unnecessarily disabling WASM JIT optimisation on an architecture that supports them.

run-agent.sh and run-terminal-tui-smoke.sh — the --liftoff-only flags scope should be reviewed to confirm arm64 is intentionally included.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/os/linux/elizaos/build.sh | Adds profile validation (default|gui|secure|secure-gui) and overlays the new GUI profile directory before the lb build. Silent no-op when the gui profile directory is absent while PROFILE=gui. |
| packages/os/linux/elizaos/config/hooks/normal/0025-enable-graphical-session.hook.chroot | Adds an early-exit guard that detects absent GUI packages and locks the system to multi-user.target, so headless builds are never accidentally placed on graphical.target. |
| packages/os/linux/elizaos/config/hooks/normal/0030-elizaos-branding.hook.chroot | Guards dconf/GDM branding configuration behind a command -v dconf check so headless builds that lack dconf don't error out. |
| packages/os/linux/elizaos/config/includes.chroot/usr/lib/elizaos/run-agent.sh | Adds --no-wasm-tier-up / --liftoff-only V8 flags to the node fallback path; flags are applied to arm64 in addition to riscv64, unnecessarily disabling WASM JIT on a capable architecture. |
| packages/os/linux/elizaos/config/includes.chroot/usr/lib/elizaos/run-terminal-tui-smoke.sh | Same V8 Liftoff-only flags added; guard already scoped to riscv64|arm64 but arm64 has a working WASM JIT so the flags over-restrict it. |
| packages/os/linux/elizaos/config/profiles/gui/package-lists/elizaos-gui.list.chroot | New file: consolidates all GUI/kiosk packages (cage, seatd, GNOME, epiphany, Plymouth, Xorg, grim, scrot) under the explicit gui profile overlay. |
| packages/os/linux/elizaos/config/package-lists/elizaos-common.list.chroot | GUI/kiosk packages (cage, seatd, libwebkit2gtk, grim) removed from the common list; fonts-dejavu-core retained and moved to the fonts section. |
| packages/os/linux/elizaos/scripts/check-multiarch-boot-contract.py | Contract validator updated to assert GUI packages live in the new profile list (not common), and checks that build.sh exposes the explicit GUI profile path. |
| packages/os/linux/elizaos/scripts/test_check_multiarch_boot_contract.py | Test helper refactored to accept a separate gui_packages arg; existing tests updated to pass GUI packages through the new profile path. |
| packages/os/linux/elizaos/scripts/test_riscv64_agent_staging.py | Updated node-fallback assertions to match the new multi-line node invocation with V8 flags; adds per-flag checks for --no-wasm-tier-up, --no-wasm-dynamic-tiering, --liftoff-only. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[build.sh\nELIZAOS_PROFILE=?] --> B{validate profile}
    B -- "invalid" --> ERR[exit 64]
    B -- "default" --> BASE[base headless config\nlb config + lb build]
    B -- "gui" --> GUI_OVL[overlay config/profiles/gui\ncp -a gui/. config/]
    B -- "secure" --> SEC_OVL[overlay config/profiles/secure\ncp -a secure/. config/]
    B -- "secure-gui" --> BOTH[overlay gui\nthen overlay secure]
    GUI_OVL --> BASE
    SEC_OVL --> BASE
    BOTH --> BASE
    BASE --> LB[lb build → hybrid ISO]
    LB --> HOOK[0025-enable-graphical-session.hook.chroot\nin chroot]
    HOOK -- "cage + epiphany + seatd absent" --> MT[systemctl set-default\nmulti-user.target\nexit 0]
    HOOK -- "all GUI packages present" --> GT[systemctl set-default\ngraphical.target\nenable seatd + kiosk]
```

<sub>Reviews (1): Last reviewed commit: ["fix(os): split riscv64 gui profile from ..."](https://github.com/elizaos/eliza/commit/7478bc59839c93e4b8d3ab7832745238e9add43b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34224975)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->