### PR TITLE
fix(cloud): route agent bridge through sandbox service

### DIFF
--- a/packages/cloud-api/__tests__/agent-bridge-runtime-routing.test.ts
+++ b/packages/cloud-api/__tests__/agent-bridge-runtime-routing.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeAll, describe, expect, mock, test } from "bun:test";
+
+const requireAuthOrApiKeyWithOrg =
+  mock<
+    () => Promise<{
+      user: { id: string; organization_id: string };
+    }>
+  >();
+const bridge =
+  mock<(agentId: string, orgId: string, body: unknown) => Promise<unknown>>();
+const bridgeStream =
+  mock<(agentId: string, orgId: string, body: unknown) => Promise<Response>>();
+
+mock.module("@/lib/auth", () => ({
+  requireAuthOrApiKeyWithOrg,
+}));
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: {
+    bridge,
+    bridgeStream,
+  },
+}));
+
+mock.module("@/lib/services/proxy/cors", () => ({
+  applyCorsHeaders: (response: Response) => response,
+  handleCorsOptions: () => new Response(null, { status: 204 }),
+}));
+
+let bridgeRoute: typeof import("../v1/eliza/agents/[agentId]/bridge/route");
+let streamRoute: typeof import("../v1/eliza/agents/[agentId]/stream/route");
+
+const originalFetch = globalThis.fetch;
+const deadControlPlaneFetch = mock(async (input: RequestInfo | URL) => {
+  throw new Error(`unexpected control-plane fetch: ${String(input)}`);
+});
+
+beforeAll(async () => {
+  bridgeRoute = await import("../v1/eliza/agents/[agentId]/bridge/route");
+  streamRoute = await import("../v1/eliza/agents/[agentId]/stream/route");
+});
+
+afterEach(() => {
+  requireAuthOrApiKeyWithOrg.mockReset();
+  bridge.mockReset();
+  bridgeStream.mockReset();
+  deadControlPlaneFetch.mockClear();
+  globalThis.fetch = originalFetch;
+});
+
+function makeJsonRequest(path: string, body: unknown) {
+  return new Request(`https://api.test${path}`, {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer user-api-key",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function staleControlPlaneContext() {
+  return {
+    env: {
+      CONTAINER_CONTROL_PLANE_URL: "https://dead-control-plane.test",
+      CONTAINER_SIDECAR_URL: "https://dead-sidecar.test",
+      HETZNER_CONTAINER_CONTROL_PLANE_URL: "https://dead-hetzner.test",
+      CONTAINER_CONTROL_PLANE_TOKEN: "stale-token",
+      DATABASE_URL: "postgres://stale-db",
+    },
+  } as never;
+}
+
+describe("agent bridge runtime routing", () => {
+  test("bridge ignores stale control-plane env and uses sandbox service", async () => {
+    globalThis.fetch = deadControlPlaneFetch as unknown as typeof fetch;
+    requireAuthOrApiKeyWithOrg.mockResolvedValue({
+      user: { id: "user-1", organization_id: "org-1" },
+    });
+    bridge.mockResolvedValue({
+      jsonrpc: "2.0",
+      id: "rpc-1",
+      result: { text: "pong" },
+    });
+
+    const rpcRequest = {
+      jsonrpc: "2.0",
+      id: "rpc-1",
+      method: "heartbeat",
+      params: {},
+    };
+    const response = await bridgeRoute.__agentBridgeTestHooks.handlePost(
+      makeJsonRequest("/api/v1/eliza/agents/agent-1/bridge", rpcRequest),
+      { params: Promise.resolve({ agentId: "agent-1" }) },
+      staleControlPlaneContext(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      jsonrpc: "2.0",
+      id: "rpc-1",
+      result: { text: "pong" },
+    });
+    expect(deadControlPlaneFetch).not.toHaveBeenCalled();
+    expect(bridge).toHaveBeenCalledWith("agent-1", "org-1", rpcRequest);
+  });
+
+  test("stream ignores stale control-plane env and uses sandbox service", async () => {
+    globalThis.fetch = deadControlPlaneFetch as unknown as typeof fetch;
+    requireAuthOrApiKeyWithOrg.mockResolvedValue({
+      user: { id: "user-1", organization_id: "org-1" },
+    });
+    bridgeStream.mockResolvedValue(
+      new Response(
+        'event: done\ndata: {"messageId":"msg-1","text":"hello"}\n\n',
+        { headers: { "Content-Type": "text/event-stream" } },
+      ),
+    );
+
+    const rpcRequest = {
+      jsonrpc: "2.0",
+      id: "rpc-2",
+      method: "message.send",
+      params: { text: "say hello", roomId: "room-1" },
+    };
+    const response = await streamRoute.__agentStreamTestHooks.handlePost(
+      makeJsonRequest("/api/v1/eliza/agents/agent-1/stream", rpcRequest),
+      { params: Promise.resolve({ agentId: "agent-1" }) },
+      staleControlPlaneContext(),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toContain("event: done");
+    expect(deadControlPlaneFetch).not.toHaveBeenCalled();
+    expect(bridgeStream).toHaveBeenCalledWith("agent-1", "org-1", rpcRequest);
+    expect(bridge).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/bridge/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/bridge/route.ts
@@ -16,59 +16,6 @@ const bridgeRequestSchema = z.object({
   params: z.record(z.string(), z.unknown()).optional(),
 });
 
-const CONTROL_PLANE_URL_KEYS = [
-  "CONTAINER_CONTROL_PLANE_URL",
-  "CONTAINER_SIDECAR_URL",
-  "HETZNER_CONTAINER_CONTROL_PLANE_URL",
-] as const;
-
-function readControlPlaneEnv(
-  c: AppContext | undefined,
-  keys: readonly string[],
-): string | null {
-  if (!c?.env) return null;
-  for (const key of keys) {
-    const value = c.env[key];
-    if (typeof value === "string" && value.trim()) return value.trim();
-  }
-  return null;
-}
-
-async function forwardBridgeToControlPlane(params: {
-  ctx?: AppContext;
-  request: Request;
-  agentId: string;
-  user: { id: string; organization_id: string };
-  body: BridgeRequest;
-}): Promise<Response | null> {
-  const baseUrl = readControlPlaneEnv(params.ctx, CONTROL_PLANE_URL_KEYS);
-  if (!baseUrl) return null;
-
-  const target = new URL(baseUrl);
-  target.pathname = `/api/v1/eliza/agents/${encodeURIComponent(params.agentId)}/bridge`;
-
-  const headers = new Headers(params.request.headers);
-  headers.delete("host");
-  const internalToken = readControlPlaneEnv(params.ctx, [
-    "CONTAINER_CONTROL_PLANE_TOKEN",
-  ]);
-  if (internalToken)
-    headers.set("x-container-control-plane-token", internalToken);
-  const databaseUrl = readControlPlaneEnv(params.ctx, ["DATABASE_URL"]);
-  if (databaseUrl) headers.set("x-eliza-cloud-database-url", databaseUrl);
-  headers.set("content-type", "application/json");
-  headers.set("x-eliza-user-id", params.user.id);
-  headers.set("x-eliza-organization-id", params.user.organization_id);
-
-  return fetch(target, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(params.body),
-    redirect: "manual",
-    signal: AbortSignal.timeout(120_000),
-  });
-}
-
 /**
  * POST /api/v1/eliza/agents/[agentId]/bridge
  * Forward a JSON-RPC request to the sandbox bridge server.
@@ -81,7 +28,7 @@ async function forwardBridgeToControlPlane(params: {
 async function __hono_POST(
   request: Request,
   { params }: { params: Promise<{ agentId: string }> },
-  ctx?: AppContext,
+  _ctx?: AppContext,
 ) {
   try {
     const { user } = await requireAuthOrApiKeyWithOrg(request);
@@ -104,17 +51,6 @@ async function __hono_POST(
     }
 
     const rpcRequest = parsed.data as BridgeRequest;
-    const forwarded = await forwardBridgeToControlPlane({
-      ctx,
-      request,
-      agentId,
-      user,
-      body: rpcRequest,
-    });
-    if (forwarded) {
-      return applyCorsHeaders(forwarded, CORS_METHODS);
-    }
-
     const response = await elizaSandboxService.bridge(
       agentId,
       user.organization_id,
@@ -137,3 +73,7 @@ __hono_app.post("/", async (c) =>
   ),
 );
 export default __hono_app;
+
+export const __agentBridgeTestHooks = {
+  handlePost: __hono_POST,
+};

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/stream/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/stream/route.ts
@@ -30,24 +30,6 @@ const streamRequestSchema = z.object({
     .passthrough(),
 });
 
-const CONTROL_PLANE_URL_KEYS = [
-  "CONTAINER_CONTROL_PLANE_URL",
-  "CONTAINER_SIDECAR_URL",
-  "HETZNER_CONTAINER_CONTROL_PLANE_URL",
-] as const;
-
-function readControlPlaneEnv(
-  c: AppContext | undefined,
-  keys: readonly string[],
-): string | null {
-  if (!c?.env) return null;
-  for (const key of keys) {
-    const value = c.env[key];
-    if (typeof value === "string" && value.trim()) return value.trim();
-  }
-  return null;
-}
-
 function buildNoReplyFallbackText(body: BridgeRequest): string | null {
   const params =
     body.params && typeof body.params === "object" ? body.params : {};
@@ -103,42 +85,6 @@ async function createFallbackStreamIfRunning(params: {
   return createSseTextResponse(fallbackText);
 }
 
-async function forwardStreamToControlPlane(params: {
-  ctx?: AppContext;
-  request: Request;
-  agentId: string;
-  user: { id: string; organization_id: string };
-  body: BridgeRequest;
-}): Promise<Response | null> {
-  const baseUrl = readControlPlaneEnv(params.ctx, CONTROL_PLANE_URL_KEYS);
-  if (!baseUrl) return null;
-
-  const target = new URL(baseUrl);
-  target.pathname = `/api/v1/eliza/agents/${encodeURIComponent(params.agentId)}/stream`;
-
-  const headers = new Headers(params.request.headers);
-  headers.delete("host");
-  const internalToken = readControlPlaneEnv(params.ctx, [
-    "CONTAINER_CONTROL_PLANE_TOKEN",
-  ]);
-  if (internalToken)
-    headers.set("x-container-control-plane-token", internalToken);
-  const databaseUrl = readControlPlaneEnv(params.ctx, ["DATABASE_URL"]);
-  if (databaseUrl) headers.set("x-eliza-cloud-database-url", databaseUrl);
-  headers.set("content-type", "application/json");
-  headers.set("accept", "text/event-stream");
-  headers.set("x-eliza-user-id", params.user.id);
-  headers.set("x-eliza-organization-id", params.user.organization_id);
-
-  return fetch(target, {
-    method: "POST",
-    headers,
-    body: JSON.stringify(params.body),
-    redirect: "manual",
-    signal: AbortSignal.timeout(130_000),
-  });
-}
-
 /**
  * POST /api/v1/eliza/agents/[agentId]/stream
  * Forward a message to the sandbox and stream the response as SSE events.
@@ -152,7 +98,7 @@ async function forwardStreamToControlPlane(params: {
 async function __hono_POST(
   request: Request,
   { params }: { params: Promise<{ agentId: string }> },
-  ctx?: AppContext,
+  _ctx?: AppContext,
 ) {
   try {
     const { user } = await requireAuthOrApiKeyWithOrg(request);
@@ -177,17 +123,6 @@ async function __hono_POST(
     }
 
     const rpcRequest = parsed.data as BridgeRequest;
-
-    const forwarded = await forwardStreamToControlPlane({
-      ctx,
-      request,
-      agentId,
-      user,
-      body: rpcRequest,
-    });
-    if (forwarded) {
-      return applyCorsHeaders(forwarded, CORS_METHODS);
-    }
 
     // Get the raw SSE stream from the sandbox
     const upstreamResponse = await elizaSandboxService.bridgeStream(
@@ -254,3 +189,7 @@ __hono_app.post("/", async (c) =>
   ),
 );
 export default __hono_app;
+
+export const __agentStreamTestHooks = {
+  handlePost: __hono_POST,
+};


### PR DESCRIPTION
## Summary
- remove legacy control-plane forwarding from the Cloud API agent bridge and stream routes
- route `/api/v1/eliza/agents/:agentId/bridge` and `/stream` through `elizaSandboxService`, matching the current queue/orchestrator sandbox service path
- add regression coverage proving stale `CONTAINER_CONTROL_PLANE_URL`, `CONTAINER_SIDECAR_URL`, and `HETZNER_CONTAINER_CONTROL_PLANE_URL` env values are ignored by the runtime bridge routes

## Root Cause
After the Hetzner queue/orchestrator cutover, the old HTTP control-plane forwarding path is no longer the intended runtime path. The agent bridge and stream API routes still preferred legacy control-plane env values when present, which could short-circuit around the sandbox service and leave otherwise-running agents unreachable through the public API.

Upstream `develop` now already contains the separate agent-router Headscale target fix, so this PR is narrowed to the remaining Cloud API bridge/stream route boundary.

## Validation
- `bun test --coverage-reporter=lcov packages/cloud-api/__tests__/agent-bridge-runtime-routing.test.ts packages/scripts/cloud/admin/daemons/agent-router.test.ts`
- `bun run --cwd packages/cloud-api typecheck`
- `bun run --cwd packages/cloud-api lint`
- `git diff --check`
- `ELIZA_KMS_BACKEND=memory bun run cloud:e2e`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the control-plane forwarding layer (`forwardBridgeToControlPlane` / `forwardStreamToControlPlane`) from the cloud-api bridge and stream routes, making both handlers route exclusively through `elizaSandboxService` instead of conditionally proxying to `CONTAINER_CONTROL_PLANE_URL` / `CONTAINER_SIDECAR_URL` when those env vars are set.

- **`bridge/route.ts` & `stream/route.ts`**: ~55 lines of control-plane env-reading and HTTP-forwarding code removed from each file; `ctx` parameter renamed to `_ctx` since it is now fully unused.
- **`agent-bridge-runtime-routing.test.ts`**: New regression test that poisons `globalThis.fetch` with a throwing mock and asserts the routes complete successfully via the mocked sandbox service without ever calling the former control-plane URLs.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change removes a conditional control-plane forwarding layer and routes all traffic through the sandbox service, which is the canonical path.

The deletion removes a concrete mismatch between the documented routing contract and the former runtime behavior. The replacement logic is simple, organization_id scoping is preserved in the direct elizaSandboxService call, and the new regression tests correctly guard against the removed forwarding path being reintroduced.

No files require special attention. The CONTAINER_CONTROL_PLANE_URL, CONTAINER_SIDECAR_URL, and HETZNER_CONTAINER_CONTROL_PLANE_URL env vars are now dead configuration in these two route files and can be cleaned up from deployment manifests.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cloud-api/v1/eliza/agents/[agentId]/bridge/route.ts | Removes forwardBridgeToControlPlane and its env-reading helpers; routes all requests directly through elizaSandboxService.bridge. ctx renamed to _ctx since it is now unused. |
| packages/cloud-api/v1/eliza/agents/[agentId]/stream/route.ts | Mirrors the bridge route change: removes forwardStreamToControlPlane and env helpers, always delegates to elizaSandboxService.bridgeStream. Fallback SSE path and error handling are preserved unchanged. |
| packages/cloud-api/__tests__/agent-bridge-runtime-routing.test.ts | New regression test file; replaces globalThis.fetch with a guard that throws on any outbound HTTP call, then asserts both bridge and stream handlers succeed using only the mocked sandbox service and never reach the former control-plane URLs. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant BridgeRoute as bridge/stream route
    participant OldForwarder as forwardToControlPlane (removed)
    participant ControlPlane as Control-Plane URL
    participant SandboxSvc as elizaSandboxService

    Note over BridgeRoute,ControlPlane: Before this PR
    Client->>BridgeRoute: POST /agents/:id/bridge
    BridgeRoute->>OldForwarder: readControlPlaneEnv()
    OldForwarder->>ControlPlane: fetch() if env set
    ControlPlane-->>BridgeRoute: response (returned early)
    BridgeRoute->>SandboxSvc: bridge() only if no control-plane URL

    Note over BridgeRoute,SandboxSvc: After this PR
    Client->>BridgeRoute: POST /agents/:id/bridge (or /stream)
    BridgeRoute->>SandboxSvc: bridge() / bridgeStream() always
    SandboxSvc-->>BridgeRoute: response
    BridgeRoute-->>Client: JSON / SSE response
```

<sub>Reviews (3): Last reviewed commit: ["fix(cloud): route agent bridge through s..."](https://github.com/elizaos/eliza/commit/704f028e551c66f8d5700f79bca234808d521ca0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34290842)</sub>

<!-- /greptile_comment -->