### PR TITLE
fix(facts): persist + recall durable user facts (tool-arg shape + Stage 1 FACTS provider)

### DIFF
--- a/packages/core/src/runtime/__tests__/facts-and-relationships.test.ts
+++ b/packages/core/src/runtime/__tests__/facts-and-relationships.test.ts
@@ -124,6 +124,48 @@ describe("parseFactsAndRelationshipsOutput", () => {
 		expect(result.facts).toEqual(["a"]);
 	});
 
+	it("parses AI SDK v5 / Cerebras tool-call shape (toolCalls[0].input)", () => {
+		// Live regression on 2026-05-28 (tj-80ba4e3920d7bd): the user said
+		// "my dogs name is Jeff", Stage 1 extracted the fact, and the validate
+		// model returned a correct tool call — but the args were under `input`
+		// (AI SDK v5 / Cerebras gpt-oss-120b shape), not `arguments`. The old
+		// extractText only read `arguments`, so the parse came back empty and
+		// the fact was silently dropped (written.facts=0). Nothing persisted,
+		// so cross-turn recall only worked while the source message stayed in
+		// the recent-message window. Pin all tool-arg field names.
+		const result = parseFactsAndRelationshipsOutput({
+			text: "",
+			toolCalls: [
+				{
+					type: "tool-call",
+					toolName: "FACTS_AND_RELATIONSHIPS_VALIDATE",
+					input: {
+						facts: ["my dog's name is Jeff"],
+						relationships: [
+							{ subject: "user", predicate: "has_dog_named", object: "Jeff" },
+						],
+						thought: "new, not duplicated",
+					},
+				},
+			],
+		});
+		expect(result.facts).toEqual(["my dog's name is Jeff"]);
+		expect(result.relationships).toEqual([
+			{ subject: "user", predicate: "has_dog_named", object: "Jeff" },
+		]);
+	});
+
+	it("parses tool-call args under `args` and `params` keys too", () => {
+		const viaArgs = parseFactsAndRelationshipsOutput({
+			toolCalls: [{ args: { facts: ["x"], relationships: [], thought: "" } }],
+		});
+		expect(viaArgs.facts).toEqual(["x"]);
+		const viaParams = parseFactsAndRelationshipsOutput({
+			toolCalls: [{ params: { facts: ["y"], relationships: [], thought: "" } }],
+		});
+		expect(viaParams.facts).toEqual(["y"]);
+	});
+
 	it("drops malformed relationship entries", () => {
 		const result = parseFactsAndRelationshipsOutput(
 			JSON.stringify({

--- a/packages/core/src/runtime/facts-and-relationships.ts
+++ b/packages/core/src/runtime/facts-and-relationships.ts
@@ -409,15 +409,28 @@ function extractText(raw: unknown): string {
 	if (raw && typeof raw === "object") {
 		const r = raw as {
 			text?: unknown;
-			toolCalls?: Array<{ arguments?: unknown }>;
+			toolCalls?: Array<{
+				arguments?: unknown;
+				args?: unknown;
+				input?: unknown;
+				params?: unknown;
+			}>;
 		};
 		if (typeof r.text === "string" && r.text.trim()) return r.text;
 		const tool = r.toolCalls?.[0];
-		if (tool && typeof tool.arguments === "object" && tool.arguments !== null) {
-			return JSON.stringify(tool.arguments);
+		// Tool-call args land under different keys across model providers /
+		// SDK versions: AI SDK v5 + Cerebras gpt-oss-120b use `input`, older
+		// shapes use `arguments`/`args`/`params`. Read all of them or the
+		// extracted facts get silently dropped (the validate model returns a
+		// proper tool call but `arguments` is undefined -> empty parse ->
+		// nothing persisted). Mirrors the accessor in services/message.ts.
+		const toolArgs =
+			tool?.arguments ?? tool?.args ?? tool?.input ?? tool?.params;
+		if (typeof toolArgs === "object" && toolArgs !== null) {
+			return JSON.stringify(toolArgs);
 		}
-		if (typeof tool?.arguments === "string") {
-			return tool.arguments;
+		if (typeof toolArgs === "string") {
+			return toolArgs;
 		}
 	}
 	return "";

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -836,6 +836,17 @@ const CORE_RESPONSE_STATE_PROVIDERS = [
 	"PLATFORM_CHAT_CONTEXT",
 	"PLATFORM_USER_CONTEXT",
 	"RUNTIME_MODEL_CONTEXT",
+	// FACTS is dynamic and would otherwise never run during response
+	// composition. Stage 1 keeps it rendered when present (see
+	// STAGE1_EXTRA_PROVIDER_EXCLUSIONS) precisely so durable user facts
+	// ("my dog's name is Jeff", "my car is named Bertha") persisted by the
+	// facts-and-relationships stage can be recalled on a later turn — even a
+	// simple-path turn after the source message has scrolled out of the
+	// RECENT_MESSAGES window. Without this, stored facts are written but
+	// never retrieved into the answer. FACTS content is stable across calls
+	// (refreshes only when the store changes) so it does not churn the
+	// prefix cache the way CURRENT_TIME would.
+	"FACTS",
 	// CURRENT_TIME is dynamic and would otherwise be filtered out before
 	// reaching the response handler. The wall-clock time is a baseline
 	// signal for nearly every routing decision (scheduling, freshness of


### PR DESCRIPTION
Tell the agent a durable fact ("my dog's name is Jeff") and it should save it to facts memory and recall it later from memory — not just answer while the source message is still in the recent window. Deep-scanning two-turn Milady tests (`tj-80ba4e3920d7bd` / `tj-87ea55b515d769`) found two breaks in the pipeline:

## 1. Facts never persisted
Stage 1 extracted the fact correctly and the validate model returned a proper tool call — but the args were under `input` (AI SDK v5 / Cerebras gpt-oss-120b shape) while `extractText` in `facts-and-relationships.ts` only read `arguments`. Result: empty parse, `kept=0`, `written=0` — every fact silently dropped.

**Fix:** read `arguments ?? args ?? input ?? params` (mirrors the accessor in `services/message.ts`). Verified live: `written.facts` went 0 → 1, store confirmed `facts:2`.

## 2. Facts never retrieved
Even once persisted, recall failed after the source message scrolled out of `RECENT_MESSAGES`: the FACTS provider is `dynamic` and was absent from `CORE_RESPONSE_STATE_PROVIDERS`, so Stage 1 (where simple-path recall is answered) never composed it. The Stage 1 exclusion comment already documented the intent to keep FACTS rendered — the provider was just never added to the compose list. FACTS is cache-stable (refreshes only when the store changes) so it doesn't churn the prefix cache.

## Tests
- `facts-and-relationships.test.ts` pins the `input`/`args`/`params` tool-arg shapes.
- Existing Stage 1 provider-list assertions still pass.
- Live-verified: "my dog's name is Jeff" → later → "Your dog's name is Jeff."; a fresh fact survived a 16-message flood and was recalled from the FACTS provider with the source message gone from the window.

Pairs with the durable-recall ranking fallback in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent breaks in the facts persistence-and-recall pipeline: a silent fact-drop caused by reading the wrong field name on AI SDK v5 / Cerebras tool-call shapes, and missing recall caused by the FACTS dynamic provider being absent from the Stage 1 composition list.

- **`facts-and-relationships.ts`**: `extractText` now reads `tool.arguments ?? tool.args ?? tool.input ?? tool.params` to handle divergent tool-call shapes across model providers/SDK versions. Before this fix, facts were extracted and validated but then silently dropped because `tool.arguments` was undefined on AI SDK v5 responses.
- **`message.ts`**: `"FACTS"` is added to `CORE_RESPONSE_STATE_PROVIDERS` so the FACTS dynamic provider is always composed for response context. Without it, persisted facts were never retrieved once the source message left the `RECENT_MESSAGES` window.
- **Tests**: Two new regression tests pin the `input`, `args`, and `params` tool-arg shapes to catch future silent breakage at the parse layer.

<h3>Confidence Score: 5/5</h3>

Both changes are targeted, well-commented, and consistent with patterns already used elsewhere in the codebase; the risk of regression is low.

The tool-arg accessor change is a straightforward fallback chain that degrades gracefully — if none of the four keys are present the old empty-string path is preserved. Adding FACTS to the provider list is additive and cache-stable, so it won't affect runs where no facts have been stored. The test additions directly cover the previously-broken code paths.

No files require special attention; both changed files are narrow and well-tested by the accompanying test additions.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/facts-and-relationships.ts | Extends extractText to read tool-call args from arguments ?? args ?? input ?? params, fixing silent fact-drop when AI SDK v5 / Cerebras returns args under input |
| packages/core/src/services/message.ts | Adds FACTS to CORE_RESPONSE_STATE_PROVIDERS so the dynamic FACTS provider is composed for Stage 1 response context, enabling durable fact recall after source message scrolls out of RECENT_MESSAGES |
| packages/core/src/runtime/__tests__/facts-and-relationships.test.ts | Adds regression tests pinning the input, args, and params tool-call arg shapes to prevent future silent regressions on the facts pipeline |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant S1 as Stage 1 (simple-path)
    participant FP as FACTS Provider
    participant FAR as facts-and-relationships stage
    participant M as Memory Store

    U->>S1: "My dog's name is Jeff"
    S1->>FP: compose context (FACTS in CORE_RESPONSE_STATE_PROVIDERS)
    FP->>M: fetch stored facts
    M-->>FP: (none yet)
    S1->>FAR: trigger extraction
    FAR->>FAR: validate model → tool call (args under input)
    Note over FAR: extractText reads arguments ?? args ?? input ?? params
    FAR->>M: persist fact "my dog's name is Jeff"
    S1-->>U: "Got it!"

    Note over U,M: Later turn — source message scrolled out of RECENT_MESSAGES

    U->>S1: "What's my dog's name?"
    S1->>FP: compose context (FACTS now included)
    FP->>M: fetch stored facts
    M-->>FP: ["my dog's name is Jeff"]
    FP-->>S1: FACTS block with stored fact
    S1-->>U: "Your dog's name is Jeff."
```

<sub>Reviews (1): Last reviewed commit: ["fix(core/facts): persist + recall durabl..."](https://github.com/elizaos/eliza/commit/435db9a8e06799b479f1a588cd13b591873cc7db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34466367)</sub>

<!-- /greptile_comment -->