### PR TITLE
fix(facts): surface durable facts on direct recall when BM25 misses

### DIFF
--- a/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.test.ts
@@ -114,6 +114,36 @@ describe("factsProvider keyword retrieval", () => {
 		expect(result.text).toContain("the user prefers aisle seats");
 	});
 
+	it("surfaces a durable fact on direct recall even when keywords do not BM25-match", async () => {
+		// Live regression on 2026-05-28 (tj-8e3d5c79321002): user stored
+		// "my car's name is Bertha" then later asked "whats my cars name?".
+		// BM25 scored 0 (no stemming for cars->car, and the only shared term
+		// "name" had ~0 IDF across the small fact pool), so the durable fact
+		// was filtered out and the bot answered "I don't have any info about a
+		// car name for you." Durable identity facts are few and high-value;
+		// when relevance ranking surfaces none, fall back to recent durable
+		// facts so direct recall works.
+		const runtime = makeRuntime({
+			facts: [
+				memory("fact-1", "my car's name is Bertha, a 1998 Civic", {
+					kind: "durable",
+					category: "identity",
+					confidence: 0.9,
+					keywords: ["car", "name", "bertha", "civic"],
+				}),
+			],
+		});
+
+		const result = await factsProvider.get(
+			runtime,
+			memory("msg-current", "whats my cars name?"),
+			{ values: {}, data: {}, text: "" },
+		);
+
+		expect(result.text).toContain("Bertha");
+		expect(result.text).not.toContain("No facts available");
+	});
+
 	it("applies current-fact time weighting after keyword relevance", async () => {
 		// bun's vitest compat layer doesn't implement vi.useFakeTimers /
 		// vi.setSystemTime, so pin Date.now() directly. This is the only

--- a/packages/core/src/features/advanced-capabilities/providers/facts.ts
+++ b/packages/core/src/features/advanced-capabilities/providers/facts.ts
@@ -287,12 +287,31 @@ const factsProvider: Provider = {
 				partitionByKind(dedupedPool);
 
 			const nowMs = Date.now();
-			const durableFacts = rankByKeywordScore(
+			let durableFacts = rankByKeywordScore(
 				durableCandidates,
 				"durable",
 				queryText,
 				nowMs,
 			).slice(0, TOP_PER_KIND);
+			// Durable facts are identity-level claims ("my dog's name is Jeff",
+			// "my car is named Bertha") and few in number. Keyword/BM25 ranking
+			// against the current message drops them whenever the question does
+			// not lexically overlap the stored fact — e.g. "whats my cars name?"
+			// vs "my car's name is Bertha" (no stemming for cars->car, and the
+			// shared term "name" has ~0 IDF across a small pool), which scores 0
+			// and hides a fact the user is directly asking to recall. When
+			// relevance ranking surfaces no durable facts, fall back to the most
+			// recent durable facts so direct recall still works. Bounded to
+			// TOP_PER_KIND, so this never floods the prompt.
+			if (durableFacts.length === 0 && durableCandidates.length > 0) {
+				durableFacts = [...durableCandidates]
+					.sort(
+						(left, right) =>
+							(readEffectiveTimestampMs(right) ?? 0) -
+							(readEffectiveTimestampMs(left) ?? 0),
+					)
+					.slice(0, TOP_PER_KIND);
+			}
 			const currentFacts = rankByKeywordScore(
 				currentCandidates,
 				"current",


### PR DESCRIPTION
Completes the persist+recall fix (pairs with the FACTS-provider PR). With facts now persisted and the provider composed into Stage 1, recall still failed: "my car's name is Bertha" was stored (verified `facts:2`, retrievable by `getMemories(roomId)`) but asking "what's my car's name?" returned "No facts available." (`tj-8e3d5c79321002`).

**Root cause:** the FACTS provider ranks the candidate pool by BM25 keyword relevance against the current message and drops anything scoring 0. For a direct recall question the score is 0 — no stemming maps "cars" → "car", and the only shared term "name" has ~0 IDF across a small fact pool — so a durable fact the user is literally asking about gets filtered out.

**Fix:** durable facts are identity-level claims and few in number. When relevance ranking surfaces none, fall back to the most recent durable facts (bounded to `TOP_PER_KIND` so the prompt never floods). Keyword ranking is unchanged when it does match, so query-targeted retrieval still narrows results.

## Tests
- `facts.test.ts` pins the fallback (durable fact surfaces on a non-matching recall query) and confirms the existing keyword-narrowing behavior is preserved.
- Live-verified: "what is my car's name again?" (stored 20 min + 30 messages earlier) → "Your car's name is Bertha."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a recency-based fallback in the FACTS provider so that durable facts are surfaced when BM25 keyword scoring returns zero results — fixing a live regression where "my car's name is Bertha" was stored but "what's my car's name?" returned "No facts available."

- **`facts.ts`**: When `rankByKeywordScore` produces zero durable facts but candidates exist, the fallback sorts all `durableCandidates` by effective timestamp (newest first) and slices to `TOP_PER_KIND` (6). The BM25 path is unchanged when it does match.
- **`facts.test.ts`**: Adds a regression test for the Bertha/recall scenario and preserves the existing keyword-narrowing test, confirming the fallback does not activate when BM25 returns results.

<h3>Confidence Score: 3/5</h3>

The fallback solves the reported regression but introduces a boundary condition: users with more than 6 stored durable facts can still lose older facts from recall, silently, once they pass the cap.

The recency-based fallback is bounded by TOP_PER_KIND=6, which is the same cap applied to the BM25 path. For users who accumulate more than 6 durable facts over time, the oldest fact relevant to a query can still be omitted — the exact failure mode the PR is fixing. The fix reliably closes the regression for the narrow scenario described but makes an unenforced assumption about fact count that degrades silently in production.

The core logic change in facts.ts — specifically the TOP_PER_KIND cap inside the fallback branch — deserves a second look to decide whether the fallback path warrants a higher or uncapped limit.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/features/advanced-capabilities/providers/facts.ts | Adds a recency-based fallback when BM25 returns zero durable facts; the logic is correct for the narrow case but the TOP_PER_KIND=6 cap means the relevant fact can still be missed for users with > 6 stored durable facts |
| packages/core/src/features/advanced-capabilities/providers/facts.test.ts | Adds a regression test that pins the Bertha/recall scenario and verifies the fallback; existing keyword-narrowing test is preserved and still guards against false positives |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Query arrives] --> B[Build BM25 queryText]
    B --> C[Fetch roomFacts + entityFacts]
    C --> D[dedupeById]
    D --> E[partitionByKind: durable / current]
    E --> F[rankByKeywordScore durable]
    F --> G{durableFacts.length == 0\nAND durableCandidates.length > 0?}
    G -- No: BM25 matched --> H[slice to TOP_PER_KIND=6]
    G -- Yes: BM25 missed all --> I[Sort durableCandidates by recency\nslice to TOP_PER_KIND=6]
    H --> J[rankByKeywordScore current slice to TOP_PER_KIND]
    I --> J
    J --> K{allFacts.length == 0?}
    K -- Yes --> L[Return No facts available.]
    K -- No --> M[Format and return durable + current sections]
```

<sub>Reviews (1): Last reviewed commit: ["fix(core/facts-provider): surface durabl..."](https://github.com/elizaos/eliza/commit/1aa66e81dfc5648b122284fada8ddd74eadb6564) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34466422)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->