### PR TITLE
fix(ci): snap-publish secret required:false to stop release-all startup_failure

### DIFF
--- a/.github/workflows/snap-publish.yml
+++ b/.github/workflows/snap-publish.yml
@@ -19,8 +19,14 @@ on:
         required: true
         type: string
     secrets:
+      # Marked `required: false` so this reusable workflow's secret contract
+      # validates even when SNAPCRAFT_STORE_CREDENTIALS is unset. GitHub
+      # validates the contract before any job runs, so `required: true` on an
+      # unset secret aborts release-all.yml at startup with no logs. The body's
+      # creds_check guard already skips the Store upload (build still runs) when
+      # the credential is empty.
       SNAPCRAFT_STORE_CREDENTIALS:
-        required: true
+        required: false
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

Last remaining startup-failure landmine of the class fixed in #7976 / #7980 (tracked in #7837).

`snap-publish.yml` declared its `workflow_call` secret contract as:

```yaml
secrets:
  SNAPCRAFT_STORE_CREDENTIALS:
    required: true
```

`release-all.yml` calls this reusable workflow with `secrets: inherit` on every linux-OS tag (`build_linux_os == 'true'`), and `elizaOS/eliza` has **no** `SNAPCRAFT_STORE_CREDENTIALS`. GitHub validates a called workflow's secret contract *before any job runs*, so the unset `required: true` secret aborts the parent (`release-all.yml`) at startup with no logs — the exact failure mode #7976/#7980 fixed for apt / apple / android / homebrew.

## Fix

Downgrade to `required: false`. The job body already guards on empty creds:

```yaml
if [[ -z "$SNAPCRAFT_STORE_CREDENTIALS" ]]; then
  echo "::warning::SNAPCRAFT_STORE_CREDENTIALS not configured. Snap build will run but Store upload will be skipped."
```

So the snap still **builds**; only the Store upload is skipped until the credential is configured. No behavior change when the secret *is* present.

## Verification

Swept every reusable workflow's `secrets:` block — after this change, zero `required: true` secret declarations remain across `.github/workflows/`. snap was the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CI startup failure in `release-all.yml` caused by `snap-publish.yml` declaring `SNAPCRAFT_STORE_CREDENTIALS` as `required: true` — a secret that is not configured in the `elizaOS/eliza` repository. GitHub validates reusable workflow secret contracts before any job runs, so the missing required secret caused `release-all.yml` to abort at startup with no logs.

- Changes `required: true` → `required: false` for `SNAPCRAFT_STORE_CREDENTIALS` in the `workflow_call` secrets block; the job body already has a `creds_check` guard that skips the Store upload and emits a warning when the credential is absent, so snap builds continue to run.
- Adds an inline comment explaining the rationale, consistent with the pattern established by #7976/#7980 for other reusable workflows.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the one-line change correctly unblocks release-all.yml startup without removing any existing runtime guard.

The change is minimal and precisely targeted: downgrading a single secret declaration from required: true to required: false. The job already has a creds_check step that gracefully skips the Store upload when the credential is absent, so no new failure path is introduced. When the secret is present the behavior is identical to before.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/snap-publish.yml | Changes SNAPCRAFT_STORE_CREDENTIALS secret from required: true to required: false; adds explanatory comment. The existing creds_check step already handles the missing-credential case gracefully, so the fix is complete and correct. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as release-all.yml
    participant GH as GitHub Actions (secret validation)
    participant S as snap-publish.yml

    Note over R,S: Before fix (required: true)
    R->>GH: Call snap-publish.yml (secrets: inherit)
    GH-->>R: Startup failure — SNAPCRAFT_STORE_CREDENTIALS not set

    Note over R,S: After fix (required: false)
    R->>GH: Call snap-publish.yml (secrets: inherit)
    GH->>S: Secret contract validated
    S->>S: creds_check — secret empty?
    alt Secret absent
        S->>S: "Emit warning, set can_publish=false"
        S->>S: Build snap
        S->>S: Skip Publish to Snap Store step
        S->>S: Upload snap artifact
    else Secret present
        S->>S: "set can_publish=true"
        S->>S: Build snap
        S->>S: Publish to Snap Store
        S->>S: Upload snap artifact
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): snap-publish secret required:fa..."](https://github.com/elizaos/eliza/commit/3dbd402554a7f7c92e567065e480ac282aeaa1e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34506112)</sub>

<!-- /greptile_comment -->