### PR TITLE
fix(first-run): stop onboarding render loop on agent start

### DIFF
--- a/packages/ui/src/components/shell/FirstRunShell.tsx
+++ b/packages/ui/src/components/shell/FirstRunShell.tsx
@@ -387,9 +387,18 @@ export function FirstRunShell({
   const { rendered: renderedPrompt, complete: promptComplete } =
     useTypedPrompt(promptText);
 
+  // `onPromptReady` calls setVoice, which re-renders this component. Its
+  // identity is unstable (it ultimately derives from app-context callbacks like
+  // completeFirstRun, which change when first-run state churns during agent
+  // start). Depending on it here would re-fire the effect on every such render,
+  // re-entering setVoice → re-render → infinite loop that freezes onboarding.
+  // The intent is "fire once when the typed prompt finishes, keyed on its
+  // text", so call the latest handler through a ref and gate on the prompt.
+  const onPromptReadyRef = React.useRef(onPromptReady);
+  onPromptReadyRef.current = onPromptReady;
   React.useEffect(() => {
-    if (promptComplete) onPromptReady(promptText);
-  }, [onPromptReady, promptComplete, promptText]);
+    if (promptComplete) onPromptReadyRef.current(promptText);
+  }, [promptComplete, promptText]);
 
   return (
     <div


### PR DESCRIPTION
## Summary
- Fixes an infinite React render loop that froze the first-run onboarding screen ("Where should Eliza run?") the moment the user clicked **Start** to launch the agent. The renderer pegged at ~100% CPU (looked like an OOM); render telemetry named `FirstRunScreen` as the runaway component.
- Root cause in `FirstRunShell`: the prompt-ready effect depended on `onPromptReady`, whose `useCallback` identity flips whenever first-run app state churns (e.g. `completeFirstRun` re-derives when `firstRunDetectedProviders` changes during agent start). Since `onPromptReady` calls `setVoice`, the effect re-fired on every resulting render → `setVoice` → re-render → loop.
- Fix: invoke the latest handler through a ref and gate the effect on `[promptComplete, promptText]` only — its actual intent (announce the prompt once when typing finishes) — so it no longer re-fires on unrelated identity changes.

## Test plan
- [x] `FirstRunShell` unit tests pass (vitest)
- [ ] Manually: reset to onboarding, click **Start** with the Local runtime — onboarding proceeds instead of freezing; render telemetry stays below threshold

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an infinite render loop in `FirstRunShell` that froze the first-run onboarding screen when the user clicked Start. The root cause was `onPromptReady` being listed as an effect dependency — its identity was unstable because it derived from context callbacks that churned during agent start, causing a `setVoice → re-render → re-fire` loop.

- **Fix**: the latest `onPromptReady` is now forwarded through a `useRef` and the effect is gated solely on `[promptComplete, promptText]`, matching the actual intent (fire once when typing finishes). This is the idiomatic "latest-ref" pattern for stabilising effect callbacks in React.
- **Pre-existing edge case** (not introduced here): when a step advances, `promptText` changes while `promptComplete` is still `true` (the `useTypedPrompt` reset lands one render later), so the handler may be called twice — once prematurely on step advance and once when the new prompt finishes typing. Worth tracking with a `lastFiredTextRef` guard in a follow-up.
- **Test gap**: the existing tests only cover voice-toggle UI; a test that verifies `onPromptReady` fires exactly once after `promptComplete` becomes `true` would prevent regressions on the deps array.

<h3>Confidence Score: 4/5</h3>

The fix is safe to merge — it corrects a clear, reproducible freeze in the first-run onboarding UI with an idiomatic React ref pattern.

The ref-forwarding change is minimal, well-commented, and correctly removes `onPromptReady` from the effect deps without introducing new state bugs. The only open questions are a pre-existing double-fire edge case on step advance and the absence of a regression test for the exact loop scenario, neither of which blocks the fix.

packages/ui/src/components/shell/FirstRunShell.tsx — the double-call edge case on step advance and the missing `onPromptReady` call-count test are worth a follow-up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/shell/FirstRunShell.tsx | Replaces `onPromptReady` as an effect dependency with a ref-forwarding pattern to break the infinite render loop; logic is sound but a subtle timing edge case exists when `promptText` changes while `promptComplete` is still `true`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Parent as FirstRunApp (context)
    participant Shell as FirstRunShell
    participant TP as useTypedPrompt
    participant Effect as useEffect([promptComplete, promptText])
    participant Ref as onPromptReadyRef

    Note over Parent,Shell: Before fix — identity churn triggered loop
    Parent->>Shell: re-render (completeFirstRun identity changes)
    Shell->>Effect: deps changed (onPromptReady identity)
    Effect->>Shell: onPromptReady(promptText) → setVoice()
    Shell->>Shell: re-render (voice state)
    Shell->>Effect: deps changed again → loop

    Note over Parent,Shell: After fix — ref pattern breaks the loop
    Parent->>Shell: re-render (any props)
    Shell->>Ref: "onPromptReadyRef.current = onPromptReady (latest)"
    Shell->>TP: useTypedPrompt(promptText)
    TP-->>Shell: rendered, complete: false
    Note over TP: typing animation...
    TP-->>Shell: rendered: full, complete: true
    Shell->>Effect: promptComplete changed to true
    Effect->>Ref: onPromptReadyRef.current(promptText)
    Ref->>Shell: setVoice() → re-render
    Shell->>Effect: promptComplete still true, promptText unchanged → no re-fire
```

<sub>Reviews (1): Last reviewed commit: ["fix(first-run): stop onboarding render l..."](https://github.com/elizaos/eliza/commit/fd1582dd47b61826a05f9d9ec772b0697364a67c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34532020)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->