### PR TITLE
fix(desktop): stop infinite fetch recursion in local-agent IPC bridge

### DIFF
--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -43,6 +43,28 @@
       const ipcPathPrefix = `//${ipcHost}`;
       const localAgentPort = '31337';
 
+      // The loopback (127.0.0.1:31337) → native-IPC rewrite below is only
+      // correct on a NATIVE Capacitor platform (iOS/Android), where the
+      // in-process local agent has no directly-reachable TCP port and
+      // `Agent.request` resolves to a NATIVE plugin. On any non-native host
+      // (Electrobun desktop, plain web) there is no native Agent plugin, so
+      // `Agent.request` falls back to the web implementation, which fetches
+      // `${apiBase}${path}` — the same loopback URL — and re-enters this bridge,
+      // recursing forever (renderer OOM). Gate the rewrite on a positive
+      // native-platform check so loopback fetches hit the real server directly
+      // everywhere else. Capacitor sets window.Capacitor on every platform and
+      // this runs at fetch time (after modules load), so the check is reliable.
+      function isNativeCapacitorAgentHost() {
+        try {
+          const cap = window.Capacitor;
+          if (!cap || typeof cap.getPlatform !== 'function') return false;
+          const p = cap.getPlatform();
+          return p === 'ios' || p === 'android';
+        } catch (_) {
+          return false;
+        }
+      }
+
       function rawUrl(input) {
         try {
           return input && typeof input === 'object' && 'url' in input ? input.url : String(input);
@@ -64,6 +86,7 @@
         try {
           const url = new URL(trimmed, window.location?.href ? window.location.href : 'https://eliza.app');
           if (
+            isNativeCapacitorAgentHost() &&
             url.protocol === 'http:' &&
             url.port === localAgentPort &&
             (url.hostname === '127.0.0.1' || url.hostname === 'localhost' || url.hostname === '[::1]' || url.hostname === '::1')


### PR DESCRIPTION
## Problem

On Electrobun **desktop** (and any non-mobile host pointed at a loopback local agent) the renderer's WebKit web process climbs ~140 MB/s to OOM during startup. The splash appears frozen (main thread saturated) and the OS kills the app ("device memory nearly full").

## Root cause — infinite `fetch` recursion

`packages/app/index.html` installs an inline `window.fetch` override (`elizaAndroidIpcFetchBridge`) **unconditionally on every platform**. Its `ipcPath()` rewrites any `http://127.0.0.1:31337/*` request into a native `Agent.request({ path })` call. That rewrite is only correct on a **native Capacitor platform** (iOS/Android), where the in-process local agent has no directly-reachable TCP port and `Agent.request` resolves to a *native* plugin.

On a non-native host there is no native Agent plugin, so Capacitor resolves `Agent.request` to the **web fallback** `AgentWeb.request` (`plugins/plugin-native-agent/src/web.ts`), which does `fetch(`${apiBase}${path}`)` — the *same* `http://127.0.0.1:31337/...` URL — back through the bridged `window.fetch`:

```
fetch(:31337/api/...) → bridge → Agent.request → AgentWeb.request → fetch(:31337/api/...) → bridge → ∞
```

The loop never yields (no delay), allocating Promise/Response objects on the renderer main thread until OOM. Observed: `/api/vincent/status` fetched hundreds of thousands of times per run.

## Fix

Gate the loopback→IPC rewrite behind a **positive** `isNativeCapacitorAgentHost()` check (`window.Capacitor.getPlatform()` ∈ `{ios, android}`), so the rewrite runs only where a native Agent plugin actually exists. Non-native hosts (desktop, plain web) fall through to the real `fetch` and hit the backend directly.

- Mobile behaviour unchanged (rewrite stays on for iOS/Android).
- The `eliza-local-agent://` protocol branch is untouched (loop-safe: `AgentWeb` returns 503 for it, never re-fetches).
- The check runs at fetch time (after modules load), so `window.Capacitor` is reliably present.

## Verification

- Renderer (WebKitGTK) RSS holds **flat at ~350 MB for 4+ minutes** (was 140 MB/s → OOM); `/api/vincent/status` fetched once instead of hundreds of thousands of times.
- `bun run test:dev-startup` smoke gate passes (dev stack ready ~25s).
- `biome check` clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an infinite `fetch` recursion that caused the Electrobun desktop renderer (WebKitGTK) to OOM during startup by gating the loopback→native IPC rewrite on a positive `isNativeCapacitorAgentHost()` check (`ios` or `android`). Non-native hosts (desktop, plain web) now fall through directly to `originalFetch`, while iOS/Android behaviour is unchanged.

- Adds `isNativeCapacitorAgentHost()` that reads `window.Capacitor.getPlatform()` at fetch time (after modules load, so Capacitor is reliably initialised) and returns `true` only for `ios` or `android`.
- Inserts a single `&&` guard in `ipcPath()` so loopback (`127.0.0.1:31337`) URLs are only redirected to `Agent.request` when a native plugin actually exists; the `eliza-local-agent://` protocol branch is unchanged and was already loop-safe.

<h3>Confidence Score: 5/5</h3>

Single-file, minimally invasive fix that breaks an infinite recursion loop with a well-placed platform guard; mobile paths are unchanged.

The change adds one function and one && guard to ipcPath(). The fix is logically sound: loopback-to-IPC rewriting now only activates on ios/android where the native plugin actually exists, and isNativeCapacitorAgentHost() correctly short-circuits when window.Capacitor is absent or reports a non-native platform. No data is mutated, no new async paths are introduced, and the guard is evaluated at fetch time after Capacitor initialises so no race exists.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app/index.html | Adds `isNativeCapacitorAgentHost()` guard in `ipcPath()` to prevent loopback→IPC rewrite on non-native platforms, eliminating the infinite fetch recursion and OOM crash on desktop. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(desktop): stop infinite fetch recurs..."](https://github.com/elizaos/eliza/commit/53f212b0ade3730d0cfdb8205d8c2e316e779794) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34538149)</sub>

<!-- /greptile_comment -->