### PR TITLE
feat(desktop): add opt-in cloud-only first-run mode

### DIFF
--- a/packages/app-core/platforms/electrobun/src/api-base.test.ts
+++ b/packages/app-core/platforms/electrobun/src/api-base.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveDesktopRuntimeMode,
+  resolveDesktopRuntimeModeSignal,
+} from "./api-base";
+
+describe("resolveDesktopRuntimeModeSignal", () => {
+  it("returns null by default (no cloud-only opt-in)", () => {
+    expect(resolveDesktopRuntimeModeSignal({})).toBeNull();
+    expect(
+      resolveDesktopRuntimeModeSignal({
+        ELIZA_DESKTOP_RUNTIME_MODE: "external",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns 'cloud' when ELIZA_DESKTOP_RUNTIME_MODE is cloud/elizacloud", () => {
+    expect(
+      resolveDesktopRuntimeModeSignal({ ELIZA_DESKTOP_RUNTIME_MODE: "cloud" }),
+    ).toBe("cloud");
+    expect(
+      resolveDesktopRuntimeModeSignal({
+        ELIZA_DESKTOP_RUNTIME_MODE: "  ElizaCloud ",
+      }),
+    ).toBe("cloud");
+  });
+
+  it("returns 'cloud' for the ELIZA_DESKTOP_CLOUD_ONLY boolean flag", () => {
+    for (const v of ["1", "true", "yes", "on"]) {
+      expect(
+        resolveDesktopRuntimeModeSignal({ ELIZA_DESKTOP_CLOUD_ONLY: v }),
+      ).toBe("cloud");
+    }
+    expect(
+      resolveDesktopRuntimeModeSignal({ ELIZA_DESKTOP_CLOUD_ONLY: "0" }),
+    ).toBeNull();
+  });
+
+  it("does not change where-the-agent-runs (resolveDesktopRuntimeMode) — orthogonal", () => {
+    // The cloud-only opt-in must NOT flip the agent topology; the loopback agent
+    // still runs (as the cloud-login proxy) under cloud-only mode.
+    const cloudEnv = { ELIZA_DESKTOP_CLOUD_ONLY: "1" };
+    expect(resolveDesktopRuntimeMode(cloudEnv).mode).toBe("local");
+    expect(
+      resolveDesktopRuntimeMode({
+        ...cloudEnv,
+        ELIZA_DESKTOP_API_BASE: "http://127.0.0.1:31337",
+      }).mode,
+    ).toBe("external");
+  });
+});

--- a/packages/app-core/platforms/electrobun/src/api-base.ts
+++ b/packages/app-core/platforms/electrobun/src/api-base.ts
@@ -85,6 +85,25 @@ export function resolveDesktopRuntimeMode(
   return { mode: "local", externalApi };
 }
 
+/**
+ * Desktop cloud-only opt-in. Returns `"cloud"` when the desktop shell should run
+ * cloud-only — cloud model providers only (no local model/embedding warmup) and a
+ * cloud-only first-run UI. This is ORTHOGONAL to {@link resolveDesktopRuntimeMode}
+ * (external/local/disabled, i.e. *where* the agent runs): in cloud-only mode the
+ * loopback agent still runs and serves the cloud-login proxy + becomes cloud-backed
+ * after sign-in; only its model sourcing and the renderer's first-run UI change.
+ * Returns `null` (the default) when no cloud-only opt-in is present, so existing
+ * desktop/mobile/web behavior is unchanged.
+ */
+export function resolveDesktopRuntimeModeSignal(
+  env: Record<string, string | undefined>,
+): "cloud" | null {
+  const explicit = env.ELIZA_DESKTOP_RUNTIME_MODE?.trim().toLowerCase();
+  if (explicit === "cloud" || explicit === "elizacloud") return "cloud";
+  if (isEnabledFlag(env.ELIZA_DESKTOP_CLOUD_ONLY)) return "cloud";
+  return null;
+}
+
 export function resolveInitialApiBase(
   env: Record<string, string | undefined>,
 ): string | null {

--- a/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.ts
+++ b/packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.ts
@@ -29,7 +29,10 @@
  * see two sources of truth.
  */
 
-import { pushApiBaseToRenderer } from "../api-base";
+import {
+  pushApiBaseToRenderer,
+  resolveDesktopRuntimeModeSignal,
+} from "../api-base";
 
 interface ApiBaseSnapshot {
   base: string | null;
@@ -82,7 +85,16 @@ export function injectIntoHtml(html: string): string {
     ? `Object.defineProperty(window,"__ELIZA_API_TOKEN__",{value:${tokenLiteral},configurable:true,writable:true,enumerable:false});`
     : "";
   const bootConfigInject = `(function(){var k=Symbol.for("elizaos.app.boot-config"),w=window,prev=w.__ELIZAOS_APP_BOOT_CONFIG__||w.__ELIZA_APP_BOOT_CONFIG__||(w[k]&&w[k].current)||{},next=Object.assign({},prev,{apiBase:${baseLiteral}${tokenLiteral ? `,apiToken:${tokenLiteral}` : ""}});w.__ELIZAOS_APP_BOOT_CONFIG__=next;w.__ELIZA_APP_BOOT_CONFIG__=next;w[k]={current:next};})();`;
-  const script = `<script>window.__ELIZA_API_BASE__=${baseLiteral};${tokenInject}${bootConfigInject}</script>`;
+  // Desktop cloud-only opt-in: expose the runtime-mode signal as a window global
+  // before any renderer JS runs, so the renderer's cloud-only branding
+  // (shouldUseCloudOnlyBranding) resolves correctly at module-eval time. Only
+  // injected when explicitly cloud, so the default desktop/web behavior is
+  // unchanged.
+  const runtimeModeSignal = resolveDesktopRuntimeModeSignal(process.env);
+  const runtimeModeInject = runtimeModeSignal
+    ? `window.__ELIZA_DESKTOP_RUNTIME_MODE__=${safeJsonForHtml(runtimeModeSignal)};`
+    : "";
+  const script = `<script>window.__ELIZA_API_BASE__=${baseLiteral};${runtimeModeInject}${tokenInject}${bootConfigInject}</script>`;
   if (html.includes("</head>")) {
     return html.replace("</head>", `${script}</head>`);
   }

--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -323,17 +323,40 @@ function getInjectedAppApiBase(): string | undefined {
   );
 }
 
+// Resolve the desktop "cloud-only" runtime-mode signal from whichever path is
+// available before React boots. Undefined on web/mobile and on default desktop.
+//   - Packaged desktop (electrobun static server): a window global is injected
+//     ahead of renderer JS by api-base-owner.injectIntoHtml.
+//   - Dev (`dev:desktop`, Vite) and cloud-only renderer builds: exposed as the
+//     `VITE_ELIZA_DESKTOP_RUNTIME_MODE` build env, since Vite serves index.html
+//     directly and the static-server inject never runs.
+function getInjectedDesktopRuntimeMode(): string | undefined {
+  if (typeof window !== "undefined") {
+    const injected: unknown = Reflect.get(
+      window,
+      "__ELIZA_DESKTOP_RUNTIME_MODE__",
+    );
+    if (typeof injected === "string" && injected) return injected;
+  }
+  const fromEnv = (import.meta.env as Record<string, string | undefined>)
+    .VITE_ELIZA_DESKTOP_RUNTIME_MODE;
+  return typeof fromEnv === "string" && fromEnv ? fromEnv : undefined;
+}
+
 const APP_BRANDING: Partial<BrandingConfig> = {
   ...APP_BRANDING_BASE,
   theme: ELIZA_DEFAULT_THEME,
   // The hosted web bundle stays cloud-only in production. Desktop shells and
   // other hosts inject an explicit API base before React boots, and that host
-  // backend should control first-run capabilities instead.
+  // backend should control first-run capabilities instead — UNLESS the desktop
+  // shell explicitly opted into cloud-only mode (desktopRuntimeMode === "cloud"),
+  // which forces cloud-only regardless of the injected loopback proxy base.
   cloudOnly: shouldUseCloudOnlyBranding({
     isDev: import.meta.env.DEV ?? false,
     injectedApiBase:
       typeof window === "undefined" ? undefined : getInjectedAppApiBase(),
     isNativePlatform: Capacitor.isNativePlatform(),
+    desktopRuntimeMode: getInjectedDesktopRuntimeMode(),
   }),
 };
 

--- a/packages/shared/src/config/__tests__/cloud-only.test.ts
+++ b/packages/shared/src/config/__tests__/cloud-only.test.ts
@@ -49,4 +49,42 @@ describe("shouldUseCloudOnlyBranding", () => {
       }),
     ).toBe(true);
   });
+
+  it("forces cloud-only on a desktop 'cloud' runtime mode even in dev with an injected loopback backend", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: true,
+        injectedApiBase: "http://127.0.0.1:31337",
+        isNativePlatform: false,
+        desktopRuntimeMode: "cloud",
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts the elizacloud alias for the desktop cloud runtime mode", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: false,
+        injectedApiBase: "http://127.0.0.1:31337",
+        desktopRuntimeMode: "elizacloud",
+      }),
+    ).toBe(true);
+  });
+
+  it("leaves desktop behavior unchanged when the runtime mode is absent or non-cloud", () => {
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: true,
+        injectedApiBase: "http://127.0.0.1:31337",
+        desktopRuntimeMode: undefined,
+      }),
+    ).toBe(false);
+    expect(
+      shouldUseCloudOnlyBranding({
+        isDev: false,
+        injectedApiBase: "http://127.0.0.1:31337",
+        desktopRuntimeMode: "external",
+      }),
+    ).toBe(false);
+  });
 });

--- a/packages/shared/src/config/cloud-only.ts
+++ b/packages/shared/src/config/cloud-only.ts
@@ -3,7 +3,18 @@ export function shouldUseCloudOnlyBranding(options: {
   injectedApiBase?: string | null;
   isNativePlatform?: boolean;
   nativeRuntimeMode?: string | null;
+  desktopRuntimeMode?: string | null;
 }): boolean {
+  // An explicit desktop "cloud" runtime mode forces cloud-only regardless of
+  // dev mode or an injected loopback backend. The desktop shell deliberately
+  // runs cloud-only and keeps the loopback agent solely as the cloud-login
+  // proxy, so this opt-in must win over the isDev / injectedApiBase fall-throughs
+  // below (both of which are true on a desktop dev build).
+  const desktopRuntimeMode = options.desktopRuntimeMode?.trim().toLowerCase();
+  if (desktopRuntimeMode === "cloud" || desktopRuntimeMode === "elizacloud") {
+    return true;
+  }
+
   if (options.isDev) return false;
 
   // Desktop shells and hybrid/native builds inject or select a backend before

--- a/packages/ui/src/components/shell/FirstRunShell.tsx
+++ b/packages/ui/src/components/shell/FirstRunShell.tsx
@@ -25,6 +25,7 @@ export interface FirstRunShellProps {
   step: FirstRunStep;
   draft: FirstRunProfileDraft;
   localRuntimeAvailable: boolean;
+  cloudOnly: boolean;
   elizaCloudConnected: boolean;
   submitting: boolean;
   busyText: string | null;
@@ -349,6 +350,7 @@ function FirstRunControls(props: {
   step: FirstRunStep;
   draft: FirstRunProfileDraft;
   localRuntimeAvailable: boolean;
+  cloudOnly: boolean;
   elizaCloudConnected: boolean;
   submitting: boolean;
   primaryLabel: string;
@@ -450,18 +452,20 @@ function FirstRunControls(props: {
           </div>
         ) : null}
 
-        <RuntimeCard
-          active={props.draft.runtime === "remote"}
-          icon={Network}
-          label="Use as remote"
-          emphasis="muted"
-          testId="first-run-runtime-remote"
-          detail="Connect to your local machine from another device."
-          onClick={() => {
-            props.updateDraft("runtime", "remote");
-            props.setStep("remote");
-          }}
-        />
+        {props.cloudOnly ? null : (
+          <RuntimeCard
+            active={props.draft.runtime === "remote"}
+            icon={Network}
+            label="Use as remote"
+            emphasis="muted"
+            testId="first-run-runtime-remote"
+            detail="Connect to your local machine from another device."
+            onClick={() => {
+              props.updateDraft("runtime", "remote");
+              props.setStep("remote");
+            }}
+          />
+        )}
       </div>
       <GlassButton
         variant="primary"
@@ -479,6 +483,7 @@ export function FirstRunShell({
   step,
   draft,
   localRuntimeAvailable,
+  cloudOnly,
   elizaCloudConnected,
   submitting,
   busyText,
@@ -553,6 +558,7 @@ export function FirstRunShell({
                 step={step}
                 draft={draft}
                 localRuntimeAvailable={localRuntimeAvailable}
+                cloudOnly={cloudOnly}
                 elizaCloudConnected={elizaCloudConnected}
                 submitting={submitting}
                 primaryLabel={primaryLabel}

--- a/packages/ui/src/components/shell/__tests__/FirstRunShell.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/FirstRunShell.test.tsx
@@ -25,6 +25,7 @@ function props(
       useLocalEmbeddings: true,
     },
     localRuntimeAvailable: true,
+    cloudOnly: false,
     elizaCloudConnected: false,
     submitting: false,
     busyText: null,
@@ -112,6 +113,20 @@ describe("FirstRunShell", () => {
     expect(screen.getByTestId("first-run-runtime-cloud")).toBeTruthy();
     expect(screen.getByTestId("first-run-runtime-remote")).toBeTruthy();
     expect(screen.queryByTestId("first-run-runtime-local")).toBeNull();
+  });
+
+  it("shows only the Cloud card in cloud-only mode (hides Local and Remote)", async () => {
+    vi.useFakeTimers();
+    render(
+      <FirstRunShell
+        {...props({ cloudOnly: true, localRuntimeAvailable: false })}
+      />,
+    );
+    await revealPrompt();
+
+    expect(screen.getByTestId("first-run-runtime-cloud")).toBeTruthy();
+    expect(screen.queryByTestId("first-run-runtime-local")).toBeNull();
+    expect(screen.queryByTestId("first-run-runtime-remote")).toBeNull();
   });
 
   it("exposes the local inference sub-choice only when Local is selected", async () => {

--- a/packages/ui/src/first-run/use-first-run-controller.ts
+++ b/packages/ui/src/first-run/use-first-run-controller.ts
@@ -80,6 +80,7 @@ export interface FirstRunController {
   step: FirstRunStep;
   draft: FirstRunProfileDraft;
   localRuntimeAvailable: boolean;
+  cloudOnly: boolean;
   elizaCloudConnected: boolean;
   submitting: boolean;
   busyText: string | null;
@@ -253,6 +254,12 @@ export function useFirstRunController(): FirstRunController {
     uiLanguage,
   } = useApp();
   const initialRuntimeTarget = React.useMemo(readFirstRunRuntimeTarget, []);
+  // Desktop cloud-only opt-in: branding.cloudOnly is set from the injected
+  // __ELIZA_DESKTOP_RUNTIME_MODE__ signal (api-base-owner → main.tsx branding).
+  // When on, the runtime is forced to cloud and the Local/Remote options are
+  // hidden. Off (the default) everywhere else, so web/mobile/default-desktop are
+  // unchanged.
+  const cloudOnly = Boolean(getBootConfig().branding?.cloudOnly);
   const initialDraft = React.useMemo<FirstRunProfileDraft>(
     () => ({
       agentName: normalizeFirstRunName(firstRunName) || "Eliza",
@@ -271,12 +278,18 @@ export function useFirstRunController(): FirstRunController {
   );
   const [step, setStepState] = React.useState<FirstRunStep>(() => {
     if (persistedFirstRunState) return persistedFirstRunState.step;
-    if (initialRuntimeTarget === "remote") return "remote";
+    if (!cloudOnly && initialRuntimeTarget === "remote") return "remote";
     return "runtime";
   });
-  const localRuntimeAvailable = React.useMemo(canSelectLocalRuntime, []);
+  const localRuntimeAvailable =
+    React.useMemo(canSelectLocalRuntime, []) && !cloudOnly;
   const [draft, setDraft] = React.useState<FirstRunProfileDraft>(() => {
     const resolved = persistedFirstRunState?.draft ?? initialDraft;
+    // Cloud-only desktop: the only valid runtime is cloud, so coerce any
+    // persisted/forced local-or-remote choice back to cloud.
+    if (cloudOnly && resolved.runtime !== "cloud") {
+      return { ...resolved, runtime: "cloud" };
+    }
     if (!localRuntimeAvailable && resolved.runtime === "local") {
       return { ...resolved, runtime: "cloud" };
     }
@@ -879,6 +892,7 @@ export function useFirstRunController(): FirstRunController {
     step,
     draft,
     localRuntimeAvailable,
+    cloudOnly,
     elizaCloudConnected,
     submitting,
     busyText,


### PR DESCRIPTION
## What

Adds an **opt-in, default-off** desktop "cloud-only" first-run mode for the Electrobun build: cloud-first onboarding (Eliza Cloud browser sign-in + cloud model providers) with the Local/Remote runtime options hidden. Web, mobile, and the **default desktop build are unchanged**.

Enable with `ELIZA_DESKTOP_CLOUD_ONLY=1` (or `ELIZA_DESKTOP_RUNTIME_MODE=cloud`); in `dev:desktop`/Vite use `VITE_ELIZA_DESKTOP_RUNTIME_MODE=cloud`.

## Why

The desktop cloud sign-in flow already works end-to-end (pick Cloud → Connect → system browser → sign in → the loopback agent becomes cloud-backed via `/api/cloud/login`). This adds a way to make a desktop build present that as the *only* path — no local model selection — which several deployments want. It builds directly on the recent cloud-default first-run shell (#`adc2de444b`).

## How (all additive / gated; default-off)

- **`shared/config/cloud-only`**: `shouldUseCloudOnlyBranding` gains an optional `desktopRuntimeMode`; `"cloud"`/`"elizacloud"` forces cloud-only *before* the dev/injected-backend fall-throughs (the desktop deliberately runs cloud-only and keeps the loopback agent only as the cloud-login proxy).
- **`electrobun/api-base`**: `resolveDesktopRuntimeModeSignal(env)` reads the opt-in. **Orthogonal** to `resolveDesktopRuntimeMode` (where the agent runs) — the agent still runs as the cloud-login proxy.
- **`electrobun/api-base-owner`**: injects `window.__ELIZA_DESKTOP_RUNTIME_MODE__` before renderer JS (packaged static-server path); `main.tsx` also reads `VITE_ELIZA_DESKTOP_RUNTIME_MODE` (Vite dev/build path) and feeds the signal into the `cloudOnly` branding decision.
- **`ui/first-run`**: the controller reads `branding.cloudOnly`, forces the cloud runtime + disables the local gate; `FirstRunShell` hides the Remote card (Local is already gated by `localRuntimeAvailable`).

## Tests

- `cloud-only.test.ts` — branding param (cloud-only forced even in dev/injected; default unchanged).
- `api-base.test.ts` — signal parsing + that it does **not** change agent topology.
- `FirstRunShell.test.tsx` — cloud-only renders **only** the Cloud card (hides Local + Remote).
- Full `typecheck` (shared/app-core/ui/app) + `biome` clean; renderer builds + boots cleanly.

The final interactive Eliza Cloud sign-in is a manual step (real OAuth). Note: a live desktop run should also include #8039 (the renderer fetch-recursion fix) so the renderer doesn't OOM before reaching first-run — these two PRs are independent but both wanted for a clean desktop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an opt-in, default-off cloud-only first-run mode for the Electrobun desktop build. When enabled via `ELIZA_DESKTOP_CLOUD_ONLY=1` or `ELIZA_DESKTOP_RUNTIME_MODE=cloud`, the first-run UI presents only the Cloud sign-in card and hides Local/Remote options. Web, mobile, and the default desktop build are completely unaffected.

- **`resolveDesktopRuntimeModeSignal`** (new function in `api-base.ts`) reads the opt-in env vars and is orthogonal to the existing `resolveDesktopRuntimeMode` (which controls agent topology, unchanged).
- **`api-base-owner.injectIntoHtml`** injects `window.__ELIZA_DESKTOP_RUNTIME_MODE__` into the renderer HTML before any JS runs (packaged path); `main.tsx` reads either that global or `VITE_ELIZA_DESKTOP_RUNTIME_MODE` (Vite dev path) and feeds it into `shouldUseCloudOnlyBranding` before React boots.
- **`use-first-run-controller`** and **`FirstRunShell`** gate all local/remote options behind the `cloudOnly` flag, coercing any persisted `runtime` back to `\"cloud\"` on load.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive and gated behind a default-off opt-in; web, mobile, and default desktop builds are unaffected.

The opt-in is fully gated (env var, default null/false), the cloud-only logic is isolated to new functions and new branches, and the existing test suite covers the main signal-resolution and UI paths. The two concerns flagged in earlier review threads (persisted step surviving into cloud-only mode, and the Keep embeddings local checkbox) are confined to edge cases in the first-run flow.

packages/ui/src/first-run/use-first-run-controller.ts — the persisted-step coercion is the main open item from earlier review threads.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/shared/src/config/cloud-only.ts | Adds desktopRuntimeMode parameter to shouldUseCloudOnlyBranding; check correctly placed before isDev early-return so it wins on dev desktop builds too. |
| packages/app-core/platforms/electrobun/src/api-base.ts | New resolveDesktopRuntimeModeSignal function cleanly separated from resolveDesktopRuntimeMode; correctly normalises both env-var forms and the boolean flag. |
| packages/app-core/platforms/electrobun/src/lifecycle/api-base-owner.ts | Injects window.__ELIZA_DESKTOP_RUNTIME_MODE__ into static-server HTML using existing safeJsonForHtml helper; noop when no cloud-only opt-in is present. |
| packages/app/src/main.tsx | New getInjectedDesktopRuntimeMode() helper correctly reads the window global (packaged path) then the Vite env (dev path), with proper type-guards against empty strings. |
| packages/ui/src/first-run/use-first-run-controller.ts | Derives cloudOnly from boot config, coerces persisted runtime to cloud, and gates localRuntimeAvailable; persisted step from a prior non-cloud session survives untouched (flagged in prior thread). |
| packages/ui/src/components/shell/FirstRunShell.tsx | Adds cloudOnly prop and hides the Remote card when true; Keep embeddings local checkbox remains visible with no cloudOnly guard (flagged as prior outside-diff comment). |
| packages/app-core/platforms/electrobun/src/api-base.test.ts | Comprehensive unit tests covering default-null, cloud/elizacloud aliases, boolean flag variants, and orthogonality with agent-topology resolution. |
| packages/ui/src/components/shell/__tests__/FirstRunShell.test.tsx | New cloud-only test correctly asserts only the Cloud card is rendered; consistent with existing test patterns. |
| packages/shared/src/config/__tests__/cloud-only.test.ts | Covers the three new cases: cloud forced in dev+loopback, elizacloud alias, and no change when mode is absent or non-cloud. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Env as process.env / VITE env
    participant Owner as api-base-owner (main process)
    participant HTML as Static HTML
    participant Main as main.tsx (renderer init)
    participant Branding as shouldUseCloudOnlyBranding
    participant Controller as useFirstRunController
    participant Shell as FirstRunShell

    Note over Env,Shell: Packaged desktop path (ELIZA_DESKTOP_CLOUD_ONLY=1)
    Owner->>Env: resolveDesktopRuntimeModeSignal(process.env)
    Env-->>Owner: cloud
    Owner->>HTML: "inject window.__ELIZA_DESKTOP_RUNTIME_MODE__=cloud"
    HTML->>Main: renderer boots, reads window global
    Main->>Branding: "shouldUseCloudOnlyBranding({desktopRuntimeMode:cloud,...})"
    Branding-->>Main: true (wins before isDev check)
    Main->>Main: "APP_BRANDING.cloudOnly = true"
    Main->>Controller: "getBootConfig().branding.cloudOnly = true"
    Controller->>Controller: coerce draft.runtime to cloud
    Controller->>Controller: "localRuntimeAvailable = false"
    Controller->>Shell: "cloudOnly=true, localRuntimeAvailable=false"
    Shell->>Shell: hide Remote card (cloudOnly guard)
    Shell->>Shell: "hide Local card (localRuntimeAvailable=false)"
    Shell->>Shell: render Cloud card only

    Note over Env,Shell: Dev path (VITE_ELIZA_DESKTOP_RUNTIME_MODE=cloud)
    Main->>Main: getInjectedDesktopRuntimeMode() reads import.meta.env
    Main->>Branding: "shouldUseCloudOnlyBranding({desktopRuntimeMode:cloud, isDev:true})"
    Branding-->>Main: true (desktopRuntimeMode check before isDev)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/ui/src/components/shell/FirstRunShell.tsx`, line 440-453 ([link](https://github.com/elizaos/eliza/blob/41ac4e52dce3dc73891fc5a3592634293094d5fc/packages/ui/src/components/shell/FirstRunShell.tsx#L440-L453)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **"Keep embeddings local" option exposed in cloud-only mode**

   In cloud-only mode `draft.runtime` is always `"cloud"`, so the "Keep embeddings local" checkbox is unconditionally visible. If a user enables it (or has it persisted from a previous session, since the cloud-only coercion only resets `runtime` and not `useLocalEmbeddings`), first-run completes with `useLocalEmbeddings: true`. The PR description calls out "no local model/embedding warmup" as the intent of cloud-only mode — this option contradicts that goal. Consider hiding the checkbox (or coercing `useLocalEmbeddings: false` in the draft) when `cloudOnly` is true.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["feat(desktop): add opt-in cloud-only fir..."](https://github.com/elizaos/eliza/commit/89d61866a5055c50e0573e5566260dd1e3dec8d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34545289)</sub>

<!-- /greptile_comment -->