### PR TITLE
fix(desktop): silence benign GLXBadWindow on Linux WebKitGTK

### DIFF
--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -1,3 +1,6 @@
+// Side-effect import: must run before `electrobun/bun` (native WebKitGTK) so the
+// Linux dmabuf-renderer workaround is set before the web process spawns.
+import "./linux-webkit-env";
 import fs from "node:fs";
 import { createServer as createNetServer } from "node:net";
 import os from "node:os";

--- a/packages/app-core/platforms/electrobun/src/linux-webkit-env.ts
+++ b/packages/app-core/platforms/electrobun/src/linux-webkit-env.ts
@@ -1,0 +1,23 @@
+// Linux WebKitGTK startup hardening — imported for its side effect BEFORE any
+// `electrobun/bun` (native WebKitGTK) code runs, so the setting is in place
+// before the web process spawns.
+//
+// On common Linux stacks (notably XWayland + several Mesa/GLX driver combos)
+// WebKitGTK's dmabuf renderer emits a non-fatal but noisy
+//   `X11 Error: GLXBadWindow (code 168)`
+// at webview creation. Disabling the dmabuf renderer is the documented
+// WebKitGTK workaround and removes the error with no functional change to
+// rendering (WebKitGTK still hardware-accelerates via the standard path).
+//
+// Only applied on Linux, and only when the variable is unset — so any explicit
+// `WEBKIT_DISABLE_DMABUF_RENDERER` from the environment (e.g. a user who wants
+// dmabuf re-enabled for their stack) always wins.
+if (
+  typeof process !== "undefined" &&
+  process.platform === "linux" &&
+  process.env.WEBKIT_DISABLE_DMABUF_RENDERER === undefined
+) {
+  process.env.WEBKIT_DISABLE_DMABUF_RENDERER = "1";
+}
+
+export {};


### PR DESCRIPTION
## Problem

On common Linux stacks (XWayland + several Mesa/GLX driver combos) the Electrobun WebKitGTK launcher logs a non-fatal but noisy error at webview creation:

```
X11 Error: GLXBadWindow (code 168)
```

It does not crash or affect rendering, but it's a confusing line on every desktop launch and blocks a truly clean startup log.

## Fix

Set `WEBKIT_DISABLE_DMABUF_RENDERER=1` (the documented WebKitGTK workaround for this class of dmabuf/GLX issue) from a tiny side-effect module imported **before** `electrobun/bun` in the desktop entry, so it is in place before the web process spawns.

- **Linux-only** (`process.platform === 'linux'`).
- **Only when unset** — an explicit `WEBKIT_DISABLE_DMABUF_RENDERER` from the environment always wins (re-enable dmabuf if your stack prefers it).
- macOS/Windows/web unaffected.

## Verified

With the flag set, the `GLXBadWindow` line is gone and the renderer still boots and hardware-accelerates normally (confirmed on GNOME/Wayland + XWayland). WebKitGTK falls back to its standard accelerated path; no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR silences the non-fatal `X11 Error: GLXBadWindow (code 168)` logged on Linux at webview creation by setting `WEBKIT_DISABLE_DMABUF_RENDERER=1` before the Electrobun/WebKitGTK web process spawns.

- A new side-effect module `linux-webkit-env.ts` sets the variable on Linux only, and only when it is not already in the environment; it is imported as the very first entry in `index.ts` to guarantee the env var is present before `electrobun/bun` is evaluated.
- The escape-hatch comment in the new module is slightly misleading: because WebKitGTK checks for the variable's *presence* (any non-null value), setting `WEBKIT_DISABLE_DMABUF_RENDERER=0` would still disable the dmabuf renderer — users who want dmabuf must *unset* the variable entirely rather than setting it to a different value.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is minimal, platform-scoped, and does not affect macOS, Windows, or any non-Electrobun path.

The implementation is correct and intentionally narrow. The only issue is a misleading doc comment about how to re-enable dmabuf — the code logic itself is sound.

packages/app-core/platforms/electrobun/src/linux-webkit-env.ts — the escape-hatch comment should clarify that users must unset the variable, not set it to "0".

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/platforms/electrobun/src/linux-webkit-env.ts | New side-effect module that sets WEBKIT_DISABLE_DMABUF_RENDERER=1 on Linux when unset; the escape-hatch comment is potentially misleading about how users can re-enable dmabuf |
| packages/app-core/platforms/electrobun/src/index.ts | Adds import of linux-webkit-env as the very first import, ensuring the env var is set before electrobun/bun initializes WebKitGTK |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant OS as OS Environment
    participant Entry as index.ts (entry)
    participant Env as linux-webkit-env.ts
    participant Electrobun as electrobun/bun
    participant WK as WebKitGTK

    Entry->>Env: import (side-effect, evaluated first)
    Env->>OS: "process.platform === "linux"?"
    alt Linux and var unset
        Env->>OS: "set WEBKIT_DISABLE_DMABUF_RENDERER=1"
    else non-Linux or var already set
        Env-->>Entry: no-op
    end
    Entry->>Electrobun: import Electrobun from "electrobun/bun"
    Electrobun->>WK: spawn web process (inherits env)
    WK-->>WK: dmabuf renderer disabled, no GLXBadWindow error
```

<sub>Reviews (1): Last reviewed commit: ["fix(desktop): silence benign GLXBadWindo..."](https://github.com/elizaos/eliza/commit/f4dce76976709e94d511f2391a5731456e10b6a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34546171)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->