### PR TITLE
fix(desktop): silence benign GLXBadWindow on Linux (dev orchestrator)

### DIFF
--- a/packages/app-core/scripts/dev-platform.mjs
+++ b/packages/app-core/scripts/dev-platform.mjs
@@ -82,6 +82,20 @@ import { formatOrchestratorDesktopDevBanner } from "./lib/orchestrator-desktop-d
 import { appIdentityEnv } from "./lib/read-app-identity.mjs";
 import { viteRendererBuildNeeded } from "./lib/vite-renderer-dist-stale.mjs";
 
+// Linux WebKitGTK: the dmabuf renderer emits a benign but noisy
+// "X11 Error: GLXBadWindow (code 168)" at webview creation on common
+// XWayland/GLX driver combos. Apply the documented workaround here in the dev
+// orchestrator — BEFORE any child (Vite / API / Electrobun) is spawned — so it
+// is present in the environment from process start. Setting it later from inside
+// the desktop entry is too late: the GLX context is already created by then.
+// Linux-only, and only when unset so an explicit override always wins.
+if (
+  process.platform === "linux" &&
+  process.env.WEBKIT_DISABLE_DMABUF_RENDERER === undefined
+) {
+  process.env.WEBKIT_DISABLE_DMABUF_RENDERER = "1";
+}
+
 const here = path.dirname(fileURLToPath(import.meta.url));
 // `_elizaRoot` is the eliza repo root itself (3 levels up from
 // scripts/). `elizaRoot` is the *wrapper* repo root (4 levels up) used


### PR DESCRIPTION
Supersedes #8041 (that approach set the env inside the desktop entry, which is too late — the GLX context is already created; verified ineffective). This sets it in the **dev:desktop orchestrator before any child is spawned**, which is in time.

## Problem
On common Linux stacks (XWayland + several Mesa/GLX drivers) the Electrobun WebKitGTK launcher logs a non-fatal but noisy line at webview creation on every desktop launch:
```
X11 Error: GLXBadWindow (code 168)
```

## Fix
Set `WEBKIT_DISABLE_DMABUF_RENDERER=1` (documented WebKitGTK workaround) at the top of `packages/app-core/scripts/dev-platform.mjs`, before Vite/API/Electrobun are spawned — so it is in the environment from process start. **Linux-only**, **only when unset** (explicit override wins), other platforms unaffected.

## Verified
GLXBadWindow count goes **1 → 0** with no other change; renderer still boots + hardware-accelerates (GNOME/Wayland + XWayland). Packaged builds need the same var exported by the launcher — an upstream electrobun concern, noted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR silences a non-fatal `X11 Error: GLXBadWindow (code 168)` on Linux by setting `WEBKIT_DISABLE_DMABUF_RENDERER=1` at the very top of the `dev:desktop` orchestrator script, before Vite, API, or Electrobun children are spawned.

- The fix is guarded to Linux-only and only applies when the variable is not already in the environment, so an explicit user override (any value, including `0`) takes precedence.
- This is a dev-time-only change; the PR description correctly notes that packaged builds require a separate upstream fix in the Electrobun launcher.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single conditional assignment in a dev-only orchestrator script with no effect on non-Linux platforms or on any user who has already set the env var.

The change is narrow: one if block at module top-level that writes a single environment variable. Both guards (platform and only when unset) are correct. Child processes inherit the env from the parent, so setting it here before any spawn calls is the right place. There are no logic paths that could misfire, and no runtime behavior changes on macOS or Windows.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/dev-platform.mjs | Adds a Linux-only, unset-only guard that sets WEBKIT_DISABLE_DMABUF_RENDERER=1 at the top of the dev orchestrator, before any child processes are spawned. The platform check and "only when unset" logic are correct and the placement is the earliest possible point in the script. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[dev-platform.mjs starts] --> B{process.platform === 'linux'?}
    B -- No --> D[Skip env var]
    B -- Yes --> C{WEBKIT_DISABLE_DMABUF_RENDERER already set?}
    C -- Yes --> D
    C -- No --> E[Set WEBKIT_DISABLE_DMABUF_RENDERER=1]
    D --> F[Spawn children: Vite / API / Electrobun]
    E --> F
    F --> G[WebKitGTK webview created with dmabuf renderer disabled]
    G --> H[No GLXBadWindow noise]
```

<sub>Reviews (2): Last reviewed commit: ["fix(desktop): silence benign GLXBadWindo..."](https://github.com/elizaos/eliza/commit/40fdd639111fbc315fc8be6751103739caaeed6f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34547692)</sub>

<!-- /greptile_comment -->