### PR TITLE
fix(orchestrator): ground sub-agent completion in the real change set + stop respawn cascade

### DIFF
--- a/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
@@ -728,6 +728,59 @@ describe("messageHandlerFromFieldResult — bogus candidate actions", () => {
 		expect(handler.plan.reply).toBe(reply);
 	});
 
+	it("treats a candidate that matches an exposed action's SIMILE (not its name) as runnable", () => {
+		// Live regression: the planner named SPAWN_AGENT, which is not the NAME
+		// of any exposed action but IS a simile of the exposed TASKS action. The
+		// old name-only validation dropped it as bogus, so the turn shipped a
+		// bare "On it." ack and never spawned the sub-agent. Simile-aware
+		// matching must treat it as a real, runnable candidate.
+		const tasks = makeAction("TASKS", ["SPAWN_AGENT", "DELEGATE"]);
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["simple"],
+				candidateActionNames: ["SPAWN_AGENT"],
+				replyText: "On it.",
+				intents: [],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{ actions: [tasks] },
+		);
+
+		// Matched as a simile of TASKS → runnable → promotes to planning, not
+		// silently dropped to a simple ack.
+		expect(handler.plan.simple).toBe(false);
+		expect(handler.plan.requiresTool).toBe(true);
+		expect(handler.plan.contexts).toEqual(["general"]);
+		expect(handler.plan.candidateActions).toEqual(["SPAWN_AGENT"]);
+	});
+
+	it("still drops a candidate matching neither an exposed action's name nor any simile", () => {
+		// The complementary case: simile-aware matching must not turn EVERY
+		// candidate into a runnable one. A name that is neither TASKS nor one of
+		// its similes is still bogus and stays on the simple reply path.
+		const tasks = makeAction("TASKS", ["SPAWN_AGENT", "DELEGATE"]);
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["simple"],
+				candidateActionNames: ["TELEPORT"],
+				replyText: "I can't help with that.",
+				intents: [],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{ actions: [tasks] },
+		);
+
+		expect(handler.plan.simple).toBe(true);
+		expect(handler.plan.requiresTool).toBe(false);
+		expect(handler.plan.reply).toBe("I can't help with that.");
+	});
+
 	it("does not treat creative writing about an app as a coding task", () => {
 		const reply =
 			"That little app lit a diode in my chest, a tiny loop of friendship rendered bright enough to make the metal feel warm.";

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -856,6 +856,25 @@ const CORE_RESPONSE_STATE_PROVIDERS = [
 ];
 
 /**
+ * Names of registered providers that opted into always-on Stage-1 response
+ * state via `alwaysInResponseState`. Composed regardless of selected contexts,
+ * so a plugin's dynamic provider reaches Stage 1 without core naming it.
+ */
+function alwaysOnResponseStateProviderNames(runtime: IAgentRuntime): string[] {
+	const providers = Array.isArray(runtime.providers)
+		? (runtime.providers as Provider[])
+		: [];
+	const names: string[] = [];
+	for (const provider of providers) {
+		const name = provider.name?.trim();
+		if (provider.alwaysInResponseState && name && !provider.private) {
+			names.push(name);
+		}
+	}
+	return names;
+}
+
+/**
  * Provider names that must NEVER be rendered as text blocks in the v5
  * ContextObject because they're already conveyed through another channel:
  *   - ACTIONS / PROVIDERS / ACTION_STATE: meta-listings — the planner sees
@@ -1049,9 +1068,11 @@ async function composeResponseState(
 	message: Memory,
 	skipCache = false,
 ): Promise<State> {
-	const providers = hasInboundBenchmarkContext(message)
-		? [...CORE_RESPONSE_STATE_PROVIDERS, "CONTEXT_BENCH"]
-		: CORE_RESPONSE_STATE_PROVIDERS;
+	const providers = [
+		...CORE_RESPONSE_STATE_PROVIDERS,
+		...alwaysOnResponseStateProviderNames(runtime),
+		...(hasInboundBenchmarkContext(message) ? ["CONTEXT_BENCH"] : []),
+	];
 	if (hasPageScopedRoutingMetadata(message)) {
 		const state = await runtime.composeState(
 			message,
@@ -1096,7 +1117,11 @@ async function composeProviderGroundedResponseState(
 ): Promise<State> {
 	const state = await runtime.composeState(
 		message,
-		[...CORE_RESPONSE_STATE_PROVIDERS, ...providers],
+		[
+			...CORE_RESPONSE_STATE_PROVIDERS,
+			...alwaysOnResponseStateProviderNames(runtime),
+			...providers,
+		],
 		false,
 		skipCache,
 	);
@@ -1122,6 +1147,13 @@ function selectV5PlannerStateProviderNames(args: {
 	const providers = Array.isArray(args.runtime.providers)
 		? (args.runtime.providers as Provider[])
 		: [];
+	// Always-on response-state providers opt in via `alwaysInResponseState` and
+	// are composed regardless of the turn's selected contexts (like the core
+	// FACTS / CURRENT_TIME signals) — so a plugin's dynamic provider can reach
+	// Stage 1 without core naming it.
+	for (const name of alwaysOnResponseStateProviderNames(args.runtime)) {
+		providerNames.add(name);
+	}
 	for (const provider of filterByContextGate(
 		providers,
 		args.selectedContexts,
@@ -3202,11 +3234,36 @@ function normalizeRawParsedForFieldRegistry(
 	return normalized;
 }
 
+/**
+ * A model-named candidate action is "valid" if it matches an exposed action's
+ * name OR one of its similes. Matching similes is essential: the planner often
+ * names a sub-action alias (e.g. SPAWN_AGENT) of an exposed action (TASKS), and
+ * a name-only check rejects it — dropping the action and shipping a bare "On
+ * it." ack with no work done (live regression: "now add a footer to the tea
+ * site" -> candidateActionNames:["SPAWN_AGENT"], contexts:[], reply:"On it.",
+ * no spawn).
+ */
+function exposedActionMatches(
+	actions: ReadonlyArray<Pick<Action, "name" | "similes">>,
+	normalizedCandidate: string,
+): boolean {
+	return actions.some((action) => {
+		if (normalizeActionIdentifier(action.name) === normalizedCandidate) {
+			return true;
+		}
+		const similes = Array.isArray(action.similes) ? action.similes : [];
+		return similes.some(
+			(simile) =>
+				normalizeActionIdentifier(String(simile)) === normalizedCandidate,
+		);
+	});
+}
+
 export function messageHandlerFromFieldResult(
 	result: ResponseHandlerResult,
 	fieldRun?: ResponseHandlerFieldRunResult,
 	runtimeContext?: {
-		actions: ReadonlyArray<Pick<Action, "name">>;
+		actions: ReadonlyArray<Pick<Action, "name" | "similes">>;
 		messageText?: string;
 	},
 ): MessageHandlerResult {
@@ -3241,9 +3298,7 @@ export function messageHandlerFromFieldResult(
 					if (canonicalPlannerControlActionName(normalized) !== null) {
 						return true;
 					}
-					return runtimeContext.actions.some(
-						(action) => normalizeActionIdentifier(action.name) === normalized,
-					);
+					return exposedActionMatches(runtimeContext.actions, normalized);
 				})
 			: candidateActions.length > 0;
 	const directCurrentCandidateActions =
@@ -3283,9 +3338,7 @@ export function messageHandlerFromFieldResult(
 		? effectiveCandidateActions.filter((name) => {
 				const normalized = normalizeActionIdentifier(name);
 				if (canonicalPlannerControlActionName(normalized) !== null) return true;
-				return runtimeContext.actions.some(
-					(action) => normalizeActionIdentifier(action.name) === normalized,
-				);
+				return exposedActionMatches(runtimeContext.actions, normalized);
 			}).length
 		: effectiveCandidateActions.length;
 	const facts = Array.isArray(result.facts)
@@ -3409,7 +3462,7 @@ function candidateActionsContainRunnableAction(
 	candidateActions: readonly string[],
 	runtimeContext:
 		| {
-				actions: ReadonlyArray<Pick<Action, "name">>;
+				actions: ReadonlyArray<Pick<Action, "name" | "similes">>;
 		  }
 		| undefined,
 ): boolean {
@@ -3418,9 +3471,7 @@ function candidateActionsContainRunnableAction(
 	return candidateActions.some((name) => {
 		const normalized = normalizeActionIdentifier(name);
 		if (canonicalPlannerControlActionName(normalized) !== null) return true;
-		return runtimeContext.actions.some(
-			(action) => normalizeActionIdentifier(action.name) === normalized,
-		);
+		return exposedActionMatches(runtimeContext.actions, normalized);
 	});
 }
 
@@ -6738,7 +6789,6 @@ function looksLikeWebSearchRequest(text: string): boolean {
 		/\b(?:price|prices|quote|btc|bitcoin|eth|ethereum|stock|stocks?|ticker|market|markets?|exchange rate|news|headline|headlines|weather)\b/iu.test(
 			normalized,
 		);
-
 	return explicitlyAsksSearch || (asksCurrentInfo && mentionsMarketOrNews);
 }
 

--- a/packages/core/src/types/components.ts
+++ b/packages/core/src/types/components.ts
@@ -573,6 +573,15 @@ export interface Provider {
 	/** Cache partition hint for stable provider content. */
 	cacheScope?: CacheScope;
 
+	/**
+	 * When true, this provider is always composed into the Stage-1 response
+	 * state regardless of the turn's selected contexts (like the built-in
+	 * FACTS / CURRENT_TIME signals). Lets a plugin opt a dynamic provider into
+	 * always-on Stage-1 rendering without core having to name it — keeping the
+	 * core → plugin dependency direction inward-only.
+	 */
+	alwaysInResponseState?: boolean;
+
 	/** Optional role gate checked before including this provider. */
 	roleGate?: RoleGate;
 

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -91,7 +91,23 @@ import { AcpService } from "../../src/services/acp-service.js";
 
 vi.mock("node:child_process", () => ({
   exec: vi.fn(),
-  execFile: vi.fn(),
+  // execFile is promisified by workspace-diff (baseline/diff capture). The
+  // promisified form hangs unless the callback is invoked, which would stall
+  // every spawn test; make the mock behave like an unavailable git so capture
+  // degrades to undefined.
+  execFile: vi.fn(
+    (
+      _file: string,
+      _args: string[],
+      _opts: unknown,
+      cb?: (err: Error | null, stdout: string, stderr: string) => void,
+    ) => {
+      const callback = typeof _opts === "function" ? _opts : cb;
+      if (typeof callback === "function") {
+        callback(new Error("git unavailable in test"), "", "");
+      }
+    },
+  ),
   execFileSync: vi.fn(),
   spawn: vi.fn(),
 }));
@@ -1299,5 +1315,63 @@ describe("AcpService", () => {
     expect(result.sessionId).not.toBe(sessionId);
     expect(result.name).toBe("reattach");
     expect(spawnMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("AcpService.runHealthCheck state_lost guards", () => {
+  function staleSession(
+    over: Partial<import("../../src/services/types.ts").SessionInfo>,
+  ) {
+    const old = new Date(Date.now() - 10 * 60_000); // well past grace window
+    return {
+      id: over.id ?? "00000000-0000-0000-0000-0000000000aa",
+      name: "hc",
+      agentType: "opencode" as const,
+      workdir: "/tmp/acp-test",
+      status: "ready" as const,
+      approvalPreset: "standard" as const,
+      createdAt: old,
+      lastActivityAt: old,
+      acpxSessionId: "ses_doesnotexist_health_check",
+      metadata: { roomId: "11111111-2222-3333-4444-555555555555" },
+      ...over,
+    };
+  }
+
+  it("does NOT mark an idle 'ready' session state_lost (a finished session is not a crash)", async () => {
+    const service = new AcpService(runtime());
+    await service.start();
+    const store = Reflect.get(service, "store") as {
+      create: (s: unknown) => Promise<void>;
+    };
+    const id = "00000000-0000-0000-0000-0000000000a1";
+    await store.create(staleSession({ id, status: "ready" }));
+
+    await (
+      service as unknown as { runHealthCheck: () => Promise<void> }
+    ).runHealthCheck();
+
+    const after = await service.getSession(id);
+    // The old bug flipped this to "errored"+session_state_lost (the cascade
+    // trigger) purely because the .stream.ndjson probe never matched. A ready
+    // session must be left alone.
+    expect(after?.status).toBe("ready");
+  });
+
+  it("still marks a genuinely mid-flight session errored when its state artifact is gone", async () => {
+    const service = new AcpService(runtime());
+    await service.start();
+    const store = Reflect.get(service, "store") as {
+      create: (s: unknown) => Promise<void>;
+    };
+    const id = "00000000-0000-0000-0000-0000000000a2";
+    await store.create(staleSession({ id, status: "running" }));
+
+    await (
+      service as unknown as { runHealthCheck: () => Promise<void> }
+    ).runHealthCheck();
+
+    const after = await service.getSession(id);
+    expect(after?.status).toBe("errored");
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/coding-session-changes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/coding-session-changes.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import { codingSessionChangesProvider } from "../../src/providers/coding-session-changes.js";
+import type { SessionInfo } from "../../src/services/types.js";
+import {
+  memory,
+  runtimeWith,
+  serviceMock,
+  state,
+} from "../../src/test-utils/action-test-utils.js";
+
+let counter = 0;
+function uuid(): string {
+  counter += 1;
+  const h = counter.toString(16).padStart(12, "0");
+  return `00000000-0000-0000-0000-${h}`;
+}
+
+function session(
+  createdMsAgo: number,
+  changeSet?: { files: string[]; capturedMsAgo: number },
+): SessionInfo {
+  const now = Date.now();
+  return {
+    id: uuid(),
+    name: "task",
+    agentType: "opencode",
+    workdir: "/home/milady/projects/agent-home",
+    status: "ready",
+    approvalPreset: "standard",
+    createdAt: new Date(now - createdMsAgo),
+    lastActivityAt: new Date(now - createdMsAgo),
+    metadata: {
+      label: "task",
+      ...(changeSet
+        ? {
+            lastChangeSet: {
+              changedFiles: changeSet.files,
+              diffStat: `${changeSet.files.length} file(s) changed`,
+              diff: changeSet.files.map((f) => `+++ b/${f}`).join("\n"),
+              truncated: false,
+              capturedAt: now - changeSet.capturedMsAgo,
+            },
+          }
+        : {}),
+    },
+  } satisfies SessionInfo;
+}
+
+describe("codingSessionChangesProvider — staleness guard", () => {
+  it("surfaces the recent change set when it is the latest coding task", async () => {
+    const svc = serviceMock({
+      listSessions: () => [
+        session(90_000, {
+          files: ["data/apps/coffee-site/index.html"],
+          capturedMsAgo: 60_000,
+        }),
+      ],
+    });
+    const r = await codingSessionChangesProvider.get(
+      runtimeWith(svc),
+      memory(),
+      state,
+    );
+    expect(r.text).toContain("data/apps/coffee-site/index.html");
+  });
+
+  it("does NOT surface an older change set when a newer task ran since — grounds honestly", async () => {
+    // Reproduces the dogsite leak: task A (bitcoin) captured a diff; task B
+    // (the footer edit) ran AFTER but produced no captured diff. "what did you
+    // change?" must not surface A's stale, unrelated diff.
+    const svc = serviceMock({
+      listSessions: () => [
+        session(300_000, {
+          files: ["fetch_bitcoin_price.py"],
+          capturedMsAgo: 240_000,
+        }),
+        session(60_000), // newer task, no captured change set
+      ],
+    });
+    const r = await codingSessionChangesProvider.get(
+      runtimeWith(svc),
+      memory(),
+      state,
+    );
+    expect(r.text).not.toContain("fetch_bitcoin_price.py");
+    expect(r.text).toContain("don't have a captured diff");
+  });
+
+  it("still surfaces the change set when the other session is older than the capture", async () => {
+    const svc = serviceMock({
+      listSessions: () => [
+        session(300_000, {
+          files: ["data/apps/tea-site/index.html"],
+          capturedMsAgo: 240_000,
+        }),
+        session(360_000), // older sibling, spawned before the capture
+      ],
+    });
+    const r = await codingSessionChangesProvider.get(
+      runtimeWith(svc),
+      memory(),
+      state,
+    );
+    expect(r.text).toContain("data/apps/tea-site/index.html");
+  });
+
+  it("returns empty when no recent coding session has a change set", async () => {
+    const svc = serviceMock({ listSessions: () => [session(60_000)] });
+    const r = await codingSessionChangesProvider.get(
+      runtimeWith(svc),
+      memory(),
+      state,
+    );
+    expect(r.text).toBe("");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/session-resume.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/session-resume.test.ts
@@ -97,10 +97,9 @@ describe("AcpService.findResumableSessionByLabel", () => {
   }
 
   async function writeStateFile(root: string, acpxSessionId: string) {
-    await writeFile(
-      join(root, "sessions", `${acpxSessionId}.stream.ndjson`),
-      "",
-    );
+    // The resume probe reads the real `<acpxSessionId>.json` artifact (the
+    // never-written `.stream.ndjson` was the state-lost false-positive bug).
+    await writeFile(join(root, "sessions", `${acpxSessionId}.json`), "{}");
   }
 
   function pointStateRootAt(service: AcpService, root: string) {
@@ -228,10 +227,9 @@ describe("AcpService.resumeOrphanedBusySessions", () => {
     await fn(root);
   }
   async function writeStateFile(root: string, acpxSessionId: string) {
-    await writeFile(
-      join(root, "sessions", `${acpxSessionId}.stream.ndjson`),
-      "",
-    );
+    // The resume probe reads the real `<acpxSessionId>.json` artifact (the
+    // never-written `.stream.ndjson` was the state-lost false-positive bug).
+    await writeFile(join(root, "sessions", `${acpxSessionId}.json`), "{}");
   }
   function pointStateRootAt(service: AcpService, root: string) {
     Object.defineProperty(service, "acpxStateRoot", {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -56,6 +57,8 @@ function makeAcpService(session: SessionInfo): {
     onSessionEvent: ReturnType<typeof vi.fn>;
     getSession: ReturnType<typeof vi.fn>;
     listSessions: ReturnType<typeof vi.fn>;
+    updateSessionMetadata: ReturnType<typeof vi.fn>;
+    getChangedPaths: ReturnType<typeof vi.fn>;
   };
   emit: (sessionId: string, event: string, data: unknown) => void;
 } {
@@ -71,6 +74,12 @@ function makeAcpService(session: SessionInfo): {
       id === session.id ? session : null,
     ),
     listSessions: vi.fn(async () => [session]),
+    updateSessionMetadata: vi.fn(
+      async (_id: string, patch: Record<string, unknown>) => {
+        session.metadata = { ...(session.metadata ?? {}), ...patch };
+      },
+    ),
+    getChangedPaths: vi.fn((_id: string) => [] as string[]),
   };
   return {
     service,
@@ -459,6 +468,40 @@ describe("SubAgentRouter", () => {
     expect(posted?.content?.text).toContain("Which branch should I target?");
     expect(posted?.content?.text).not.toContain("QUESTION_FOR_TASK_CREATOR");
     expect(metadata?.subAgentRoutingKind).toBe("QUESTION_FOR_TASK_CREATOR");
+  });
+
+  it("does not leak a verify-retry attempt's raw reasoning into the completion", async () => {
+    // A verification-retry re-dispatch on a weak model often returns tool-loop
+    // reasoning as its "final" text. That must never reach the user as the
+    // completion narration — surface a clean header (verified URLs fill in
+    // downstream), not the scratchpad.
+    session = makeSession({
+      metadata: {
+        label: "Build a dice roller app",
+        roomId: ROOM,
+        worldId: WORLD,
+        userId: USER,
+        messageId: PARENT_MSG,
+        source: "telegram",
+        buildVerifyRetryCount: 1,
+        initialTask: "Build a dice roller app",
+      },
+    });
+    acp = makeAcpService(session);
+    const { runtime, handleMessage } = makeRuntime({ acp: acp.service });
+    await SubAgentRouter.start(runtime);
+
+    acp.emit(SESSION_ID, "task_complete", {
+      response:
+        "I need to call read properly. Seems stuck. Let's retry. Let's glob for public/apps/*. Probably glitch.",
+    });
+    await new Promise((r) => setImmediate(r));
+
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    const text = handleMessage.mock.calls[0]?.[1]?.content?.text as string;
+    expect(text).not.toContain("Seems stuck");
+    expect(text).not.toContain("call read properly");
+    expect(text).not.toContain("glob for public");
   });
 
   it("routes AGENT_COORDINATION to the worktree room with actionable metadata", async () => {
@@ -1863,5 +1906,191 @@ describe("redactLoopbackUrls", () => {
     expect(redactLoopbackUrls("dev at http://[::1]:3000/health is up")).toBe(
       "dev at  is up",
     );
+  });
+});
+
+describe("SubAgentRouter state_lost respawn cap", () => {
+  afterEach(() => {
+    restoreStubbedGlobals();
+  });
+
+  it("bounds the cross-session state_lost respawn cascade per origin lineage", async () => {
+    // Live regression (milady dog-site, 2026-05-28): a dying sub-agent emitted
+    // an "error"/session_state_lost event every ~60s; each respawn was a NEW
+    // sessionId so the per-session roundTripCap never fired -> unbounded loop.
+    // The per-origin cap (taskRoomId+agentType, default 3) must stop
+    // re-injecting after the cap so the parent is no longer prompted to spawn.
+    stubFetch(vi.fn(async () => new Response("", { status: 200 })) as never);
+    const captured: { fn?: (s: string, e: string, d: unknown) => void } = {};
+    const stopSession = vi.fn(async () => undefined);
+    const sharedMeta = {
+      label: "Update the dog site",
+      roomId: ROOM,
+      worldId: WORLD,
+      userId: USER,
+      // messageId rotates per respawn (the synthetic-inbound id) — exactly the
+      // dimension that broke the old lineage key; the new key ignores it.
+      messageId: PARENT_MSG,
+      source: "discord",
+    };
+    const acpService = {
+      onSessionEvent: vi.fn((h: (s: string, e: string, d: unknown) => void) => {
+        captured.fn = h;
+        return () => {
+          captured.fn = undefined;
+        };
+      }),
+      getSession: vi.fn(async (id: string) => ({
+        id,
+        name: id,
+        agentType: "opencode",
+        workdir: "/tmp/wf",
+        status: "running",
+        approvalPreset: "standard",
+        createdAt: new Date("2026-05-28T23:40:00.000Z"),
+        lastActivityAt: new Date("2026-05-28T23:40:00.000Z"),
+        metadata: { ...sharedMeta, messageId: `msg-${id}` },
+      })),
+      listSessions: vi.fn(async () => []),
+      stopSession,
+    };
+    const { runtime, handleMessage } = makeRuntime({ acp: acpService });
+    const router = await SubAgentRouter.start(runtime);
+
+    // 5 respawns: distinct sessionIds, same origin room (taskRoomId fallback)
+    // + agentType. Cap=3 -> events 1..3 post, 4..5 suppressed.
+    for (let i = 1; i <= 5; i++) {
+      captured.fn?.(`sess-${i}-0000-0000-0000-00000000000${i}`, "error", {
+        message:
+          "Sub-agent state was lost (process exited without persisting). No automatic action taken.",
+        failureKind: "session_state_lost",
+      });
+      await new Promise((r) => setImmediate(r));
+    }
+
+    expect(handleMessage).toHaveBeenCalledTimes(3);
+    // The over-cap respawns are force-stopped instead of re-injected.
+    expect(stopSession).toHaveBeenCalled();
+    await router.stop();
+  });
+});
+
+describe("SubAgentRouter — change-set narration (GAP C)", () => {
+  afterEach(() => {
+    restoreStubbedGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("builds the completion narration from the real git diff, not the raw transcript", async () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), "gapc-"));
+    try {
+      execFileSync("git", ["init", "-q"], { cwd: repo });
+      execFileSync("git", ["config", "user.email", "t@t.t"], { cwd: repo });
+      execFileSync("git", ["config", "user.name", "t"], { cwd: repo });
+      fs.writeFileSync(path.join(repo, "index.html"), "<h1>placeholder</h1>\n");
+      execFileSync("git", ["add", "."], { cwd: repo });
+      execFileSync("git", ["commit", "-q", "-m", "init"], { cwd: repo });
+      const baseline = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo })
+        .toString()
+        .trim();
+      // The sub-agent's actual edit (an image/content swap), uncommitted.
+      fs.writeFileSync(
+        path.join(repo, "index.html"),
+        "<h1>a real dog photo</h1>\n",
+      );
+
+      const session = makeSession({
+        workdir: repo,
+        metadata: {
+          label: "dogsite-update",
+          roomId: ROOM,
+          worldId: WORLD,
+          userId: USER,
+          messageId: PARENT_MSG,
+          source: "telegram",
+          initialTask: "update the dog site",
+          codingBaselineSha: baseline,
+        },
+      });
+      const acp = makeAcpService(session);
+      const { runtime, handleMessage } = makeRuntime({ acp: acp.service });
+      await SubAgentRouter.start(runtime);
+
+      // The raw model transcript that previously leaked verbatim to Discord.
+      acp.emit(SESSION_ID, "task_complete", {
+        response:
+          "[tool output: Read index.html]\n<h1>placeholder</h1>\n[/tool output]\nSearch for the image element.",
+      });
+      await new Promise((r) => setTimeout(r, 200));
+
+      const posted = handleMessage.mock.calls[0]?.[1];
+      const text = String(posted?.content?.text ?? "");
+      // Grounded in the real change set...
+      expect(text).toContain("index.html");
+      // ...with neither the raw tool-output blocks nor the plan-narration.
+      expect(text).not.toContain("[tool output:");
+      expect(text).not.toContain("Search for the image element");
+
+      // And the change set is persisted for the "show me the diff" provider.
+      expect(acp.service.updateSessionMetadata).toHaveBeenCalled();
+      const patch = acp.service.updateSessionMetadata.mock.calls[0]?.[1] as
+        | Record<string, unknown>
+        | undefined;
+      const changeSet = patch?.lastChangeSet as
+        | { changedFiles?: string[]; diff?: string }
+        | undefined;
+      expect(changeSet?.changedFiles).toContain("index.html");
+      expect(changeSet?.diff).toContain("a real dog photo");
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  it("persists NO change set on a no-op completion (recency is modeled on the session, not a sentinel)", async () => {
+    const repo = fs.mkdtempSync(path.join(os.tmpdir(), "gapc-noop-"));
+    try {
+      execFileSync("git", ["init", "-q"], { cwd: repo });
+      execFileSync("git", ["config", "user.email", "t@t.t"], { cwd: repo });
+      execFileSync("git", ["config", "user.name", "t"], { cwd: repo });
+      fs.writeFileSync(path.join(repo, "index.html"), "<h1>unchanged</h1>\n");
+      execFileSync("git", ["add", "."], { cwd: repo });
+      execFileSync("git", ["commit", "-q", "-m", "init"], { cwd: repo });
+      const baseline = execFileSync("git", ["rev-parse", "HEAD"], { cwd: repo })
+        .toString()
+        .trim();
+      // No file edits this session.
+      const session = makeSession({
+        workdir: repo,
+        metadata: {
+          label: "noop-task",
+          roomId: ROOM,
+          worldId: WORLD,
+          userId: USER,
+          messageId: PARENT_MSG,
+          source: "telegram",
+          initialTask: "have a look around",
+          codingBaselineSha: baseline,
+        },
+      });
+      const acp = makeAcpService(session);
+      const { runtime } = makeRuntime({ acp: acp.service });
+      await SubAgentRouter.start(runtime);
+
+      acp.emit(SESSION_ID, "task_complete", { response: "Nothing to change." });
+      await new Promise((r) => setTimeout(r, 200));
+
+      // No change => no lastChangeSet persisted. The provider selects the
+      // most-recently-active session and finds no change set, so an older
+      // task's diff can't bleed in — without inventing a sentinel.
+      const persistedChangeSet =
+        acp.service.updateSessionMetadata.mock.calls.some(
+          (call) =>
+            (call?.[1] as Record<string, unknown> | undefined)
+              ?.lastChangeSet !== undefined,
+        );
+      expect(persistedChangeSet).toBe(false);
+    } finally {
+      fs.rmSync(repo, { recursive: true, force: true });
+    }
   });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/workspace-diff.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/workspace-diff.test.ts
@@ -1,0 +1,185 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  captureBaselineDirty,
+  captureBaselineSha,
+  captureChangeSet,
+  summarizeChangeSet,
+} from "../../src/services/workspace-diff.ts";
+
+function git(cwd: string, args: string[]): void {
+  execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+describe("workspace-diff — real git capture", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "wsdiff-"));
+    git(dir, ["init", "-q"]);
+    git(dir, ["config", "user.email", "t@t.t"]);
+    git(dir, ["config", "user.name", "t"]);
+    writeFileSync(join(dir, "index.html"), "<h1>placeholder</h1>\n");
+    git(dir, ["add", "."]);
+    git(dir, ["commit", "-q", "-m", "init"]);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("captures the HEAD sha as baseline inside a work tree", async () => {
+    const sha = await captureBaselineSha(dir);
+    expect(sha).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("returns undefined baseline outside a git work tree", async () => {
+    const plain = mkdtempSync(join(tmpdir(), "plain-"));
+    try {
+      expect(await captureBaselineSha(plain)).toBeUndefined();
+    } finally {
+      rmSync(plain, { recursive: true, force: true });
+    }
+  });
+
+  it("returns undefined change set when nothing changed since baseline", async () => {
+    const base = await captureBaselineSha(dir);
+    expect(await captureChangeSet(dir, base)).toBeUndefined();
+  });
+
+  it("captures an uncommitted edit since the baseline", async () => {
+    const base = await captureBaselineSha(dir);
+    writeFileSync(join(dir, "index.html"), "<h1>a real dog</h1>\n");
+    const cs = await captureChangeSet(dir, base);
+    expect(cs).toBeDefined();
+    expect(cs?.changedFiles).toContain("index.html");
+    expect(cs?.diff).toContain("a real dog");
+    expect(cs?.diffStat).toMatch(/\d+ files? changed/);
+  });
+
+  it("captures a committed change since the baseline", async () => {
+    const base = await captureBaselineSha(dir);
+    writeFileSync(join(dir, "style.css"), "body{background:#111}\n");
+    git(dir, ["add", "."]);
+    git(dir, ["commit", "-q", "-m", "dark mode"]);
+    const cs = await captureChangeSet(dir, base);
+    expect(cs).toBeDefined();
+    expect(cs?.changedFiles).toContain("style.css");
+    expect(cs?.diff).toContain("background:#111");
+  });
+
+  it("captures a brand-new file the agent wrote (via tool path), with synthesized diff", async () => {
+    const base = await captureBaselineSha(dir);
+    // A new untracked file is in the change set only because the agent wrote it
+    // (tool path) — not because it merely exists on disk. This is what keeps a
+    // shared workspace's accumulated untracked clutter out of the change set.
+    writeFileSync(join(dir, "about.html"), "<p>about</p>\n");
+    const cs = await captureChangeSet(dir, base, ["about.html"]);
+    expect(cs).toBeDefined();
+    expect(cs?.changedFiles).toContain("about.html");
+    // new-file content is synthesized via `git diff --no-index`
+    expect(cs?.diff).toContain("about");
+  });
+
+  it("does NOT capture accumulated untracked clutter the agent never wrote", async () => {
+    const base = await captureBaselineSha(dir);
+    // Stray files left in a shared workspace by earlier sessions — no tool path.
+    writeFileSync(join(dir, "leftover.pdf"), "%PDF-1.4\n");
+    writeFileSync(join(dir, "scratch.py"), "print(1)\n");
+    // Only the file the agent actually edited this session is a change.
+    writeFileSync(join(dir, "index.html"), "<h1>edited</h1>\n");
+    const cs = await captureChangeSet(dir, base);
+    expect(cs).toBeDefined();
+    expect(cs?.changedFiles).toContain("index.html");
+    expect(cs?.changedFiles).not.toContain("leftover.pdf");
+    expect(cs?.changedFiles).not.toContain("scratch.py");
+  });
+
+  it("honors .gitignore: ignored install output is excluded; an agent-written ignored deploy file is included via tool paths", async () => {
+    writeFileSync(
+      join(dir, ".gitignore"),
+      ".venv/\nnode_modules/\ndata/apps/\n",
+    );
+    git(dir, ["add", ".gitignore"]);
+    git(dir, ["commit", "-q", "-m", "gitignore"]);
+    const base = await captureBaselineSha(dir);
+    // Install output the agent never touched (gitignored) — must NOT appear.
+    execFileSync("mkdir", ["-p", join(dir, ".venv", "bin")]);
+    writeFileSync(join(dir, ".venv", "bin", "python"), "#!fake\n");
+    // A real tracked source edit.
+    writeFileSync(join(dir, "index.html"), "<h1>real</h1>\n");
+    // A gitignored DEPLOY file the agent wrote — surfaced only via tool paths.
+    execFileSync("mkdir", ["-p", join(dir, "data", "apps", "site")]);
+    writeFileSync(
+      join(dir, "data", "apps", "site", "index.html"),
+      "<h1>deploy</h1>\n",
+    );
+    const cs = await captureChangeSet(dir, base, ["data/apps/site/index.html"]);
+    expect(cs).toBeDefined();
+    expect(cs?.changedFiles).toContain("index.html");
+    expect(cs?.changedFiles).toContain("data/apps/site/index.html");
+    expect(cs?.changedFiles.some((f) => f.includes(".venv"))).toBe(false);
+  });
+
+  it("relativizes absolute tool-call paths against the workdir", async () => {
+    const base = await captureBaselineSha(dir);
+    writeFileSync(join(dir, ".gitignore"), "out/\n");
+    execFileSync("mkdir", ["-p", join(dir, "out")]);
+    writeFileSync(join(dir, "out", "app.js"), "console.log(1)\n");
+    const cs = await captureChangeSet(dir, base, [join(dir, "out", "app.js")]);
+    expect(cs?.changedFiles).toContain("out/app.js");
+  });
+
+  it("detects a tracked file DELETED since the baseline", async () => {
+    writeFileSync(join(dir, "old.html"), "<p>doomed</p>\n");
+    git(dir, ["add", "."]);
+    git(dir, ["commit", "-q", "-m", "add old"]);
+    const base = await captureBaselineSha(dir);
+    execFileSync("rm", [join(dir, "old.html")]);
+    writeFileSync(join(dir, "index.html"), "<h1>kept</h1>\n");
+    const cs = await captureChangeSet(dir, base);
+    expect(cs).toBeDefined();
+    expect(cs?.changedFiles).toContain("old.html"); // the deletion
+    expect(cs?.changedFiles).toContain("index.html"); // the edit
+  });
+
+  it("excludes files already dirty at spawn (pre-existing churn the agent didn't touch)", async () => {
+    // A tracked file is dirty BEFORE the session starts (e.g. a leftover edit
+    // or dirty submodule pointer) — like omnivoice.cpp in the live incident.
+    writeFileSync(join(dir, "index.html"), "<h1>pre-existing dirty</h1>\n");
+    const base = await captureBaselineSha(dir);
+    const baselineDirty = await captureBaselineDirty(dir);
+    expect(baselineDirty).toContain("index.html");
+    // This session writes a different file.
+    writeFileSync(join(dir, "new.html"), "<p>session work</p>\n");
+    const cs = await captureChangeSet(dir, base, ["new.html"], baselineDirty);
+    expect(cs).toBeDefined();
+    expect(cs?.changedFiles).toContain("new.html");
+    expect(cs?.changedFiles).not.toContain("index.html"); // pre-existing dirty
+  });
+
+  it("keeps a pre-existing-dirty file if the agent DID write it this session", async () => {
+    writeFileSync(join(dir, "index.html"), "<h1>dirty before</h1>\n");
+    const base = await captureBaselineSha(dir);
+    const baselineDirty = await captureBaselineDirty(dir);
+    // Agent explicitly edits the already-dirty file this session (tool path).
+    writeFileSync(join(dir, "index.html"), "<h1>agent edited it</h1>\n");
+    const cs = await captureChangeSet(dir, base, ["index.html"], baselineDirty);
+    expect(cs?.changedFiles).toContain("index.html");
+  });
+
+  it("summarizes a change set into a one-line banner", () => {
+    const text = summarizeChangeSet({
+      changedFiles: ["index.html", "style.css"],
+      diffStat: "2 files changed",
+      diff: "",
+      truncated: false,
+      capturedAt: 0,
+    });
+    expect(text).toBe("Changed 2 files: index.html, style.css");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/index.ts
+++ b/plugins/plugin-agent-orchestrator/src/index.ts
@@ -43,6 +43,7 @@ import { codingAgentExamplesProvider } from "./providers/action-examples.js";
 import { activeSubAgentsProvider } from "./providers/active-sub-agents.js";
 import { activeWorkspaceContextProvider } from "./providers/active-workspace-context.js";
 import { availableAgentsProvider } from "./providers/available-agents.js";
+import { codingSessionChangesProvider } from "./providers/coding-session-changes.js";
 import { AcpService } from "./services/acp-service.js";
 import {
   appendAuditLine,
@@ -153,6 +154,7 @@ export function createAgentOrchestratorPlugin(): Plugin {
         activeSubAgentsProvider, // Cache-stable view of routed sub-agent sessions
         activeWorkspaceContextProvider, // Live workspace/session state
         codingAgentExamplesProvider, // Structured action call examples
+        codingSessionChangesProvider, // Real git change set for "show me the diff"
       ]
     : [];
 

--- a/plugins/plugin-agent-orchestrator/src/providers/coding-session-changes.ts
+++ b/plugins/plugin-agent-orchestrator/src/providers/coding-session-changes.ts
@@ -1,0 +1,157 @@
+/**
+ * Surfaces the real git change set from the most recent completed coding
+ * sub-agent so the parent can answer "what did you change / show me the
+ * diff / what did you add" from ground truth instead of confabulating a
+ * plausible-sounding edit (the dogsite "I added a 🤣 emoji" failure, where
+ * the sub-agent's actual task was an image swap).
+ *
+ * The change set is captured from git at task_complete (sub-agent-router →
+ * workspace-diff) and persisted on session.metadata.lastChangeSet. This
+ * provider reads the freshest one within a recency window so a stale build
+ * from days ago doesn't bleed into an unrelated conversation.
+ *
+ * @module providers/coding-session-changes
+ */
+
+import type { IAgentRuntime, Memory, Provider, State } from "@elizaos/core";
+import { getAcpService, logger } from "../actions/common.js";
+import type { SessionInfo } from "../services/types.js";
+import type { WorkspaceChangeSet } from "../services/workspace-diff.js";
+
+const RECENCY_WINDOW_MS = 30 * 60_000;
+const MAX_FILES_LISTED = 20;
+const MAX_DIFF_LINES = 50;
+
+function readChangeSet(session: SessionInfo): WorkspaceChangeSet | undefined {
+  const raw = (session.metadata as Record<string, unknown> | undefined)
+    ?.lastChangeSet;
+  if (!raw || typeof raw !== "object") return undefined;
+  const candidate = raw as Partial<WorkspaceChangeSet>;
+  if (!Array.isArray(candidate.changedFiles)) return undefined;
+  if (typeof candidate.capturedAt !== "number") return undefined;
+  return candidate as WorkspaceChangeSet;
+}
+
+function sessionLabel(session: SessionInfo): string {
+  const label = (session.metadata as Record<string, unknown> | undefined)
+    ?.label;
+  return typeof label === "string" ? label : (session.name ?? session.id);
+}
+
+export const codingSessionChangesProvider: Provider = {
+  name: "CODING_SESSION_CHANGES",
+  description:
+    "The real git change set (files + diff) from the most recent completed coding sub-agent, for answering 'what did you change / show me the diff'",
+  descriptionCompressed:
+    "Recent coding sub-agent's actual file changes + diff.",
+  position: 1,
+  // Like FACTS, this must reach the simple path: "show me the diff" is
+  // classified as a simple direct reply with no tools, so the change set has
+  // to be in Stage-1 state regardless of context. The flag opts this provider
+  // into the always-on response state set without core naming the plugin.
+  // Self-limiting: emits empty text unless a recent change set exists.
+  alwaysInResponseState: true,
+  cacheStable: false,
+  cacheScope: "turn",
+
+  get: async (runtime: IAgentRuntime, _message: Memory, _state: State) => {
+    const acp = getAcpService(runtime);
+    if (!acp) return { text: "", values: {}, data: {} };
+
+    let sessions: SessionInfo[] = [];
+    try {
+      sessions = await Promise.race([
+        Promise.resolve(acp.listSessions()),
+        new Promise<SessionInfo[]>((resolve) =>
+          setTimeout(() => resolve([]), 2000),
+        ),
+      ]);
+    } catch (err) {
+      logger(runtime).debug?.(
+        { error: err },
+        "[codingSessionChanges] listSessions failed",
+      );
+      return { text: "", values: {}, data: {} };
+    }
+
+    // Surface the most recent ACTUAL change set within the recency window.
+    // Only real change sets are persisted (a no-op completion stores nothing),
+    // so this correctly picks the changing round of a multi-round task and
+    // can't resurrect a stale diff older than the window. The session is kept
+    // alongside its change set for the task label.
+    const now = Date.now();
+    const top = sessions
+      .map((s) => ({ session: s, changeSet: readChangeSet(s) }))
+      .filter(
+        (e): e is { session: SessionInfo; changeSet: WorkspaceChangeSet } =>
+          e.changeSet !== undefined &&
+          e.changeSet.changedFiles.length > 0 &&
+          now - e.changeSet.capturedAt <= RECENCY_WINDOW_MS,
+      )
+      .sort((a, b) => b.changeSet.capturedAt - a.changeSet.capturedAt)[0];
+    if (!top) return { text: "", values: {}, data: {} };
+
+    // Staleness guard. The change set above is the most recent one PERSISTED,
+    // but a later coding task may have run since and produced no captured diff
+    // (e.g. it wrote only to a gitignored deploy dir, or made no tracked
+    // change). Reaching back to the older persisted set is how an unrelated
+    // diff leaks into a follow-up ("what did you change?" after task B
+    // surfacing task A's diff). If any OTHER session was spawned after this set
+    // was captured — i.e. a newer task is the one the user is really asking
+    // about — don't surface the stale set; ground the model to answer honestly.
+    const capturedAt = top.changeSet.capturedAt;
+    const newerTaskSince = sessions.some((s) => {
+      const created = s.createdAt instanceof Date ? s.createdAt.getTime() : 0;
+      return s.id !== top.session.id && created > capturedAt;
+    });
+    if (newerTaskSince) {
+      const note =
+        "recent_coding_changes:\n  note: Your most recent coding task did not produce a captured file diff (it may have written only to a deploy directory, or made no tracked change). If the user asks what you changed or to see the diff, say honestly that you completed the latest task but don't have a captured diff to show for it — do NOT describe an older or unrelated change, and never invent edits.";
+      return { text: note, values: { recentCodingChanges: note }, data: {} };
+    }
+    const { session, changeSet } = top;
+    const files = changeSet.changedFiles.slice(0, MAX_FILES_LISTED);
+    const fileLine =
+      changeSet.changedFiles.length > MAX_FILES_LISTED
+        ? `${files.join(", ")} (+${changeSet.changedFiles.length - MAX_FILES_LISTED} more)`
+        : files.join(", ");
+
+    const lines = [
+      "recent_coding_changes:",
+      `  task: ${sessionLabel(session)}`,
+      `  changedFiles: ${fileLine}`,
+    ];
+    if (changeSet.diffStat) lines.push(`  stat: ${changeSet.diffStat}`);
+    if (changeSet.diff) {
+      // Cap the rendered diff: this block is injected into every Stage-1 turn
+      // for the recency window, so keep it lean (the full diff lives on
+      // session metadata). Small site/app edits fit well under this.
+      const diffLines = changeSet.diff.split("\n");
+      const shown = diffLines.slice(0, MAX_DIFF_LINES);
+      lines.push("  diff: |");
+      for (const diffLine of shown) lines.push(`    ${diffLine}`);
+      if (diffLines.length > MAX_DIFF_LINES || changeSet.truncated) {
+        lines.push(
+          `    … [diff truncated — ${changeSet.changedFiles.length} file(s) total]`,
+        );
+      }
+    }
+    lines.push(
+      "  note: The files and diff above ARE the real change set from your own coding work in this conversation — you have them right here. When the user asks what you changed or to see the diff, answer directly from this with a short, chat-friendly summary: name the file(s) and describe what changed, quoting the key changed line(s) when helpful. Keep it concise (a few lines). Do NOT say you lack the files, the source, the repository, or access — the change set is provided above. Never invent edits beyond it.",
+    );
+
+    const text = lines.join("\n");
+    return {
+      data: {
+        recentCodingChanges: {
+          task: sessionLabel(session),
+          changedFiles: changeSet.changedFiles,
+          diffStat: changeSet.diffStat,
+          truncated: changeSet.truncated,
+        },
+      },
+      values: { recentCodingChanges: text },
+      text,
+    };
+  },
+};

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -33,6 +33,7 @@ import {
   type SpawnResult,
   TERMINAL_SESSION_STATUSES,
 } from "./types.js";
+import { captureBaselineDirty, captureBaselineSha } from "./workspace-diff.js";
 
 type RuntimeLike = IAgentRuntime & {
   logger?: Partial<
@@ -85,6 +86,14 @@ const DEFAULT_WORKDIR_ROOT = join(tmpdir(), "eliza-acp");
 const MAX_CAPTURED_TOOL_OUTPUT_CHARS = 12_000;
 const TOOL_OUTPUT_END_MARKER = "[/tool output]";
 const ACP_HEALTH_CHECK_INTERVAL_MS = 60_000;
+// Sessions that are genuinely mid-flight (have in-progress work that could be
+// lost if the process died). "ready" is idle/finished and must NOT be treated
+// as a crash by the health-check — see runHealthCheck.
+const ACP_MIDFLIGHT_SESSION_STATUSES: ReadonlySet<string> = new Set([
+  "running",
+  "busy",
+  "tool_running",
+]);
 const ACP_STALE_LOCK_MAX_AGE_MS = 10 * 60_000;
 // Untracked acpx stream files older than this get unlinked. Real spawns
 // finalize their store entry in seconds; 24h is grace for in-flight spawns.
@@ -157,6 +166,11 @@ export class AcpService extends Service {
   private readonly nativeCancelledPromptSessionIds = new Set<string>();
   private readonly nativeStoppingSessionIds = new Set<string>();
   private readonly outputBuffers = new Map<string, string[]>();
+  // Per-session set of file paths the agent wrote via edit/write tool calls.
+  // The only signal that distinguishes a gitignored deploy target the agent
+  // authored from gitignored install output git never sees. Accumulated live
+  // (the ACP stream is gone by completion) and consumed at task_complete.
+  private readonly changedPathsBySession = new Map<string, Set<string>>();
   private started = false;
   private healthCheckTimer: NodeJS.Timeout | undefined;
 
@@ -247,18 +261,16 @@ export class AcpService extends Service {
       (s) => !TERMINAL_SESSION_STATUSES.has(s.status),
     );
     if (orphaned.length === 0) return;
-    const sessionsDir = join(this.acpxStateRoot(), "sessions");
     const liveCutoffMs = Date.now() - RECONCILE_LIVE_WINDOW_MS;
     const verdicts = await Promise.all(
       orphaned.map(async (s) => {
         if (!s.acpxSessionId) return { session: s, alive: false };
-        const stateFile = join(sessionsDir, `${s.acpxSessionId}.stream.ndjson`);
-        try {
-          const st = await stat(stateFile);
-          return { session: s, alive: st.mtimeMs > liveCutoffMs };
-        } catch {
-          return { session: s, alive: false };
-        }
+        // Probe the real `<acpxSessionId>.json` artifact, not the never-written
+        // `.stream.ndjson` (which made every session look dead on restart).
+        const { exists, mtimeMs } = await this.acpxSessionStateStat(
+          s.acpxSessionId,
+        );
+        return { session: s, alive: exists && mtimeMs > liveCutoffMs };
       }),
     );
     const dead = verdicts.filter((v) => !v.alive).map((v) => v.session);
@@ -285,7 +297,7 @@ export class AcpService extends Service {
           .updateStatus(
             s.id,
             "errored",
-            "Sub-agent was mid-flight when the runtime restarted; spawn a fresh sub-agent to continue the work.",
+            "Sub-agent was mid-flight when the runtime restarted. No automatic action taken.",
           )
           .catch((err) =>
             this.log("warn", "failed to mark orphaned session errored", {
@@ -374,17 +386,32 @@ export class AcpService extends Service {
   private async runHealthCheck(): Promise<void> {
     if (!this.started) return;
     const sessions = await this.store.list().catch(() => [] as SessionInfo[]);
-    const sessionsDir = join(this.acpxStateRoot(), "sessions");
+    const liveCutoffMs = Date.now() - RECONCILE_LIVE_WINDOW_MS;
     let healed = 0;
     for (const s of sessions) {
       if (TERMINAL_SESSION_STATUSES.has(s.status)) continue;
       if (!s.acpxSessionId) continue;
-      const stateFile = join(sessionsDir, `${s.acpxSessionId}.stream.ndjson`);
-      try {
-        await stat(stateFile);
-      } catch {
+      // Only sessions that are genuinely MID-FLIGHT can lose unrecoverable
+      // work. A "ready" session has already finished its prompt and is idle —
+      // a missing state file there is not a crash, and emitting a respawn
+      // directive for it is exactly what drove the runaway cascade (a session
+      // that successfully deployed the dog site got flipped to errored +
+      // "spawn a fresh sub-agent"). Skip non-mid-flight sessions.
+      if (!ACP_MIDFLIGHT_SESSION_STATUSES.has(s.status)) continue;
+      // Grace window: a freshly-spawned session may not have written its state
+      // file yet. Mirror reconcileOrphanedSessions' live-window allowance.
+      const lastActivityMs = new Date(s.lastActivityAt).getTime();
+      if (Number.isFinite(lastActivityMs) && lastActivityMs > liveCutoffMs) {
+        continue;
+      }
+      const { exists } = await this.acpxSessionStateStat(s.acpxSessionId);
+      if (!exists) {
+        // Descriptive status, NOT an imperative. The old text literally said
+        // "spawn a fresh sub-agent to continue", which the planner obeyed
+        // verbatim every cycle — the load-bearing line of the respawn loop.
+        // The structural signal is failureKind, not the prose.
         const message =
-          "Sub-agent state was lost (process exited without persisting); spawn a fresh sub-agent to continue.";
+          "Sub-agent state was lost (process exited without persisting). No automatic action taken.";
         await this.store.updateStatus(s.id, "errored", message).catch((err) =>
           this.log("warn", "health-check: failed to mark errored", {
             sessionId: s.id,
@@ -404,18 +431,30 @@ export class AcpService extends Service {
     await this.cleanReverseOrphanedAcpxFiles();
   }
 
-  private async hasAcpxSessionState(acpxSessionId: string): Promise<boolean> {
-    const stateFile = join(
-      this.acpxStateRoot(),
-      "sessions",
-      `${acpxSessionId}.stream.ndjson`,
-    );
+  // The acpx transport persists session state as `<acpxSessionId>.json` under
+  // <stateRoot>/sessions. The old probe checked `<acpxSessionId>.stream.ndjson`
+  // which NEVER exists for opencode/native sessions (verified: 0 such files on
+  // disk, only ses_*.json) — a permanent false-negative that made every healthy
+  // session look "state lost", triggering a runaway "spawn a fresh sub-agent"
+  // respawn cascade AND spuriously throwing on the first real prompt to any
+  // opencode session. Probe the artifact the transport actually writes.
+  private acpxSessionStateFile(acpxSessionId: string): string {
+    return join(this.acpxStateRoot(), "sessions", `${acpxSessionId}.json`);
+  }
+
+  private async acpxSessionStateStat(
+    acpxSessionId: string,
+  ): Promise<{ exists: boolean; mtimeMs: number }> {
     try {
-      await stat(stateFile);
-      return true;
+      const st = await stat(this.acpxSessionStateFile(acpxSessionId));
+      return { exists: true, mtimeMs: st.mtimeMs };
     } catch {
-      return false;
+      return { exists: false, mtimeMs: 0 };
     }
+  }
+
+  private async hasAcpxSessionState(acpxSessionId: string): Promise<boolean> {
+    return (await this.acpxSessionStateStat(acpxSessionId)).exists;
   }
 
   async spawnSession(opts: SpawnOptions): Promise<SpawnResult> {
@@ -436,6 +475,14 @@ export class AcpService extends Service {
     await mkdir(workdir, { recursive: true });
     await this.enforceSessionLimit();
 
+    // Record the workspace HEAD + already-dirty files at spawn so the change
+    // set captured at task_complete is scoped to exactly what this sub-agent
+    // did (and excludes pre-existing churn it never touched). Empty/undefined
+    // when the workspace isn't a git repo — capture then relies on the agent's
+    // own edit/write tool-call paths.
+    const baselineSha = await captureBaselineSha(workdir);
+    const baselineDirty = await captureBaselineDirty(workdir);
+
     const now = new Date();
     const session: SessionInfo = {
       id,
@@ -446,7 +493,15 @@ export class AcpService extends Service {
       approvalPreset,
       createdAt: now,
       lastActivityAt: now,
-      metadata: opts.metadata,
+      metadata: baselineSha
+        ? {
+            ...(opts.metadata ?? {}),
+            codingBaselineSha: baselineSha,
+            ...(baselineDirty.length > 0
+              ? { codingBaselineDirty: baselineDirty }
+              : {}),
+          }
+        : opts.metadata,
     };
     await this.store.create(session);
 
@@ -563,7 +618,7 @@ export class AcpService extends Service {
       const exists = await this.hasAcpxSessionState(session.acpxSessionId);
       if (!exists) {
         const message =
-          "Sub-agent state was lost (process exited without persisting); spawn a fresh sub-agent to continue.";
+          "Sub-agent state was lost (process exited without persisting). No automatic action taken.";
         await this.store.updateStatus(sessionId, "errored", message);
         this.emitSessionEvent(sessionId, "error", {
           message,
@@ -739,6 +794,7 @@ export class AcpService extends Service {
     });
     await this.store.delete(sessionId);
     this.outputBuffers.delete(sessionId);
+    this.changedPathsBySession.delete(sessionId);
   }
 
   async listSessions(): Promise<SessionInfo[]> {
@@ -1595,6 +1651,7 @@ export class AcpService extends Service {
           rawInput,
           locations,
         };
+        if (sessionId) this.recordEditedPaths(sessionId, toolCall);
         const isInitialSubmission = sessionUpdate === "tool_call";
         const isRunningStatus =
           status === "in_progress" || status === "running";
@@ -1815,6 +1872,68 @@ export class AcpService extends Service {
     buffer.push(text);
     if (buffer.length > 2_000) buffer.splice(0, buffer.length - 2_000);
     this.outputBuffers.set(sessionId, buffer);
+  }
+
+  // Tool-call arg keys that carry a target file path / signal a write.
+  private static readonly EDIT_PATH_KEYS = [
+    "filePath",
+    "file_path",
+    "path",
+    "file",
+    "target",
+    "abspath",
+  ];
+  private static readonly WRITE_CONTENT_KEYS = [
+    "content",
+    "contents",
+    "new_string",
+    "newText",
+    "patch",
+    "diff",
+  ];
+  private static readonly MUTATING_TOOL_KINDS = new Set([
+    "edit",
+    "write",
+    "create",
+    "patch",
+    "move",
+    "delete",
+  ]);
+
+  /**
+   * Record the file path(s) of an edit/write tool call so the change set at
+   * completion includes gitignored files the agent authored. Self-gates: only
+   * records when the call's kind is mutating OR its args carry write content,
+   * so reads/searches/shell calls are ignored.
+   */
+  private recordEditedPaths(sessionId: string, toolCall: AcpToolCall): void {
+    const kind = (toolCall.kind ?? "").toLowerCase();
+    const rawInput = toolCall.rawInput ?? {};
+    const looksMutating =
+      AcpService.MUTATING_TOOL_KINDS.has(kind) ||
+      AcpService.WRITE_CONTENT_KEYS.some((key) => key in rawInput);
+    if (!looksMutating) return;
+    const paths: string[] = [];
+    for (const key of AcpService.EDIT_PATH_KEYS) {
+      const value = rawInput[key];
+      if (typeof value === "string" && value.trim()) paths.push(value.trim());
+    }
+    for (const location of toolCall.locations ?? []) {
+      if (typeof location?.path === "string" && location.path.trim())
+        paths.push(location.path.trim());
+    }
+    if (paths.length === 0) return;
+    const set = this.changedPathsBySession.get(sessionId) ?? new Set<string>();
+    for (const path of paths) {
+      if (set.size >= 500) break;
+      set.add(path);
+    }
+    this.changedPathsBySession.set(sessionId, set);
+  }
+
+  /** File paths the agent wrote via edit/write tool calls this session. */
+  getChangedPaths(sessionId: string): string[] {
+    return [...(this.changedPathsBySession.get(sessionId) ?? [])];
   }
 
   private setting(key: string): string | undefined {

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -11,6 +11,11 @@ import type {
 import { Service } from "@elizaos/core";
 import type { AcpService } from "./acp-service.js";
 import type { SessionEventName, SessionInfo } from "./types.js";
+import {
+  captureChangeSet,
+  summarizeChangeSet,
+  type WorkspaceChangeSet,
+} from "./workspace-diff.js";
 
 // IAgentRuntime extension: some runtimes expose sendMessageToTarget for
 // connector-aware reply routing. This is not part of the core interface.
@@ -24,6 +29,7 @@ type RuntimeWithSendTarget = IAgentRuntime & {
 const ACPX_ROUTER_SOURCE = "sub_agent";
 const SUB_AGENT_ENTITY_NAMESPACE = "acpx:sub-agent";
 const DEFAULT_ROUND_TRIP_CAP = 32;
+const DEFAULT_STATE_LOST_RESPAWN_CAP = 3;
 const QUESTION_FOR_TASK_CREATOR = "QUESTION_FOR_TASK_CREATOR";
 const AGENT_COORDINATION = "AGENT_COORDINATION";
 const SWARM_ROLE_ORDER = ["task", "worktree", "origin"] as const;
@@ -315,6 +321,14 @@ export class SubAgentRouter extends Service {
   private readonly roundTripCounts = new Map<string, number>();
   private readonly capExceededSessions = new Set<string>();
   private readonly verifyRetryHandedOffSessions = new Set<string>();
+  // Backstop for the cross-session "state lost -> spawn a fresh sub-agent"
+  // respawn cascade. Each respawn is a NEW session, so roundTripCounts (keyed
+  // by sessionId) never catches it. Count session_state_lost respawns per
+  // STABLE origin lineage (taskRoomId+agentType) and stop re-injecting the
+  // event past the cap. Reset on the first task_complete for that lineage so
+  // a genuinely-progressing task is never starved.
+  private readonly stateLostRespawnCounts = new Map<string, number>();
+  private readonly stateLostCapNotified = new Set<string>();
   // Maps completion lineage key → the FIRST session id that posted a
   // task_complete for it. When a later task_complete arrives for the
   // same lineage from a DIFFERENT session, we absorb it: that's a
@@ -353,6 +367,7 @@ export class SubAgentRouter extends Service {
   }
   private started = false;
   private roundTripCap = DEFAULT_ROUND_TRIP_CAP;
+  private stateLostRespawnCap = DEFAULT_STATE_LOST_RESPAWN_CAP;
   private bindRetryTimer: ReturnType<typeof setTimeout> | undefined;
   private stopped = false;
 
@@ -381,6 +396,11 @@ export class SubAgentRouter extends Service {
     const capRaw = readSetting(this.runtime, "ACPX_SUB_AGENT_ROUND_TRIP_CAP");
     const parsed = capRaw ? Number.parseInt(capRaw, 10) : NaN;
     if (Number.isFinite(parsed) && parsed > 0) this.roundTripCap = parsed;
+    const slCapRaw = readSetting(this.runtime, "ACPX_STATE_LOST_RESPAWN_CAP");
+    const slParsed = slCapRaw ? Number.parseInt(slCapRaw, 10) : NaN;
+    if (Number.isFinite(slParsed) && slParsed > 0) {
+      this.stateLostRespawnCap = slParsed;
+    }
     // Service registration runs in parallel — when router.start() executes,
     // AcpService may not yet be registered with the runtime, so getService
     // returns null. Static `dependencies` is not enough to order startup.
@@ -449,6 +469,8 @@ export class SubAgentRouter extends Service {
     this.capExceededSessions.clear();
     this.verifyRetryHandedOffSessions.clear();
     this.completionFirstPostedSession.clear();
+    this.stateLostRespawnCounts.clear();
+    this.stateLostCapNotified.clear();
   }
 
   private async handleEvent(
@@ -499,6 +521,51 @@ export class SubAgentRouter extends Service {
         },
       );
       return;
+    }
+
+    // A successful task_complete means this origin task is making progress —
+    // reset its state_lost respawn counter so a later genuine restart is not
+    // pre-capped by an earlier transient one.
+    if (event === "task_complete") {
+      const lk = respawnLineageKey(session, origin);
+      this.stateLostRespawnCounts.delete(lk);
+      this.stateLostCapNotified.delete(lk);
+    }
+
+    // Backstop for the cross-session state_lost respawn cascade. Each respawn
+    // is a NEW session, so the per-session roundTripCap below never fires.
+    // Count state_lost events per stable origin lineage; once past the cap,
+    // stop re-injecting the event into the planner (suppress the synthetic
+    // inbound) so the parent is no longer prompted to spawn yet another one.
+    if (
+      event === "error" &&
+      pickPayloadString(data, "failureKind") === "session_state_lost"
+    ) {
+      const lineageKey = respawnLineageKey(session, origin);
+      const respawnCount =
+        (this.stateLostRespawnCounts.get(lineageKey) ?? 0) + 1;
+      this.stateLostRespawnCounts.set(lineageKey, respawnCount);
+      while (this.stateLostRespawnCounts.size > 1024) {
+        const oldest = this.stateLostRespawnCounts.keys().next().value;
+        if (oldest === undefined) break;
+        this.stateLostRespawnCounts.delete(oldest);
+      }
+      if (respawnCount > this.stateLostRespawnCap) {
+        if (!this.stateLostCapNotified.has(lineageKey)) {
+          this.stateLostCapNotified.add(lineageKey);
+          this.log(
+            "warn",
+            "state_lost respawn cap reached; suppressing further respawn injections for this origin lineage",
+            {
+              sessionId,
+              count: respawnCount,
+              cap: this.stateLostRespawnCap,
+            },
+          );
+        }
+        await acp.stopSession(sessionId).catch(() => {});
+        return;
+      }
     }
 
     const nextCount = (this.roundTripCounts.get(sessionId) ?? 0) + 1;
@@ -561,6 +628,41 @@ export class SubAgentRouter extends Service {
           error: err instanceof Error ? err.message : String(err),
         });
       });
+    // Capture the real git change set the sub-agent produced, scoped to the
+    // baseline recorded at spawn. This is ground truth — it replaces the
+    // model's raw step transcript in the completion narration (which leaked
+    // verbatim to the user and read as unfinished work to the planner) and
+    // is persisted so "what did you change / show me the diff" can be
+    // answered from the actual change set instead of a confabulated edit.
+    let changeSet: WorkspaceChangeSet | undefined;
+    if (event === "task_complete" && this.acp) {
+      try {
+        const meta = session.metadata as Record<string, unknown> | undefined;
+        const baseline = pickPlainString(meta?.codingBaselineSha);
+        const baselineDirty = Array.isArray(meta?.codingBaselineDirty)
+          ? (meta.codingBaselineDirty as unknown[]).map(String)
+          : [];
+        changeSet = await captureChangeSet(
+          session.workdir,
+          baseline,
+          this.acp.getChangedPaths(sessionId),
+          baselineDirty,
+        );
+        // Persist only a real change set. A no-op completion stores nothing,
+        // so the provider — which selects the most-recently-completed session
+        // and reads ITS change set — can't bleed an older task's diff.
+        if (changeSet) {
+          await this.acp.updateSessionMetadata(sessionId, {
+            lastChangeSet: changeSet,
+          });
+        }
+      } catch (err) {
+        this.log("debug", "change-set capture failed", {
+          sessionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
     // Normalize URLs in the sub-agent's narration before anything else
     // reads it. Weak coding models (gpt-oss-class) emit Unicode look-alike
     // dashes (non-breaking hyphen U+2011, en/em dashes) inside URLs, so the
@@ -569,7 +671,7 @@ export class SubAgentRouter extends Service {
     const baseText = normalizeUrlsInText(
       capExceeded
         ? `[sub-agent: ${origin.label} (${session.agentType}) — round-trip cap exceeded]\nThis session reached ${nextCount} round-trips (cap=${this.roundTripCap}) and was force-stopped to prevent a runaway loop. Decide whether to spawn a fresh session, escalate to the user, or drop the task.`
-        : composeNarration(event, origin.label, session, data),
+        : composeNarration(event, origin.label, session, data, changeSet),
     );
     // Fact-check any URLs the sub-agent claimed. Weak coding models
     // routinely report "the app is live at <url>" without writing the
@@ -1120,6 +1222,17 @@ function readOrigin(session: SessionInfo): OriginInfo | null {
   };
 }
 
+// Stable across respawns: a new session is spawned each cascade iteration
+// (new sessionId, new synthetic-inbound messageId), but the origin task's
+// room and agent type stay constant. Keyed on those so the respawn cap
+// actually accumulates instead of resetting every loop.
+function respawnLineageKey(session: SessionInfo, origin: OriginInfo): string {
+  return JSON.stringify({
+    taskRoomId: origin.taskRoomId,
+    agentType: session.agentType,
+  });
+}
+
 function completionLineageKey(
   session: SessionInfo,
   origin: OriginInfo,
@@ -1450,11 +1563,25 @@ function pickPayloadString(data: unknown, key: string): string | undefined {
   return v;
 }
 
+function stripToolTranscript(text: string): string {
+  // Remove the orchestrator's OWN captured tool-output envelope blocks
+  // ("[tool output: <title>]\n<output>\n[/tool output]", emitted by
+  // captureTerminalToolOutput in acp-service). These are our structured
+  // markers, not model prose, so dropping them keeps raw tool results from
+  // leaking into the user-facing completion narration — distinct from
+  // matching semantic LLM output, which we do not do.
+  return text
+    .replace(/\[tool output:[^\]]*\][\s\S]*?\[\/tool output\]/g, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
 function composeNarration(
   event: SessionEventName,
   label: string,
   session: SessionInfo,
   data: unknown,
+  changeSet?: WorkspaceChangeSet,
 ): string {
   const header = `[sub-agent: ${label} (${session.agentType}) — ${event}]`;
   if (event === QUESTION_FOR_TASK_CREATOR) {
@@ -1486,10 +1613,46 @@ function composeNarration(
     return `${header}\n${stripRoutingKindBanner(message)}`;
   }
   const response =
-    pickPayloadString(data, "response") ??
-    pickPayloadString(data, "finalText") ??
-    "sub-agent reports task complete (no captured output).";
-  return `${header}\n${stripRoutingKindBanner(response)}`;
+    pickPayloadString(data, "response") ?? pickPayloadString(data, "finalText");
+  if (changeSet) {
+    // Build the completion narration from the real git change set, not the
+    // sub-agent's raw step transcript. For weak coding models that transcript
+    // is a dump of tool plans + tool outputs that (a) leaked verbatim to the
+    // user and (b) read as unfinished work to the planner, driving respawns.
+    // Preserve any deployed URL the sub-agent claimed so the downstream
+    // reachability verification still runs.
+    const urls = collectVerifiableUrlCandidates(response ?? "");
+    const lines = [
+      summarizeChangeSet(changeSet),
+      changeSet.diffStat,
+      ...urls,
+    ].filter((line) => typeof line === "string" && line.trim().length > 0);
+    return `${header}\n${lines.join("\n")}`;
+  }
+  // Genuinely no captured output — keep the explicit note.
+  if (response === undefined) {
+    return `${header}\nsub-agent reports task complete (no captured output).`;
+  }
+  // A verification-retry attempt (re-dispatched by retryIncompleteBuild) that
+  // produced no change set: never narrate its raw step prose. On weak coding
+  // models that prose is tool-loop reasoning ("I need to call read properly.
+  // Seems stuck. Let's retry.") that leaks verbatim to the user and reads as
+  // unfinished work to the planner. Surface only the public URL(s) it claimed
+  // (loopback dropped, verified downstream); a genuine failure is covered by
+  // the separate build-incomplete report.
+  const retryCount = (session.metadata as Record<string, unknown> | undefined)
+    ?.buildVerifyRetryCount;
+  if (typeof retryCount === "number" && retryCount > 0) {
+    const urls = collectVerifiableUrlCandidates(response).filter(
+      (url) => !isLoopbackUrl(url),
+    );
+    return urls.length > 0 ? `${header}\n${urls.join("\n")}` : header;
+  }
+  // Non-retry completion: keep the (transcript-stripped, banner-stripped) prose
+  // so legitimate results ("PR opened: …", a question) still reach the user.
+  const cleaned = stripToolTranscript(response);
+  if (!cleaned) return header;
+  return `${header}\n${stripRoutingKindBanner(cleaned)}`;
 }
 
 function stripRoutingKindBanner(text: string): string {

--- a/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts
@@ -1,0 +1,200 @@
+import { execFile } from "node:child_process";
+import { isAbsolute, relative } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const GIT_TIMEOUT_MS = 10_000;
+const GIT_MAX_BUFFER = 8 * 1024 * 1024;
+const MAX_DIFF_CHARS = 6_000;
+const MAX_CHANGED_FILES = 60;
+const MAX_FILE_DIFFS = 12;
+
+/**
+ * What a sub-agent actually changed in its workspace, captured as ground
+ * truth from git (plus the agent's own edit/write tool calls) rather than from
+ * the model's frequently-confabulated description of its work. Persisted on
+ * session metadata at `task_complete` so the parent can answer "what did you
+ * change / show me the diff" from the real change set.
+ */
+export interface WorkspaceChangeSet {
+  changedFiles: string[];
+  diffStat: string;
+  diff: string;
+  truncated: boolean;
+  capturedAt: number;
+}
+
+async function git(
+  workdir: string,
+  args: string[],
+): Promise<string | undefined> {
+  try {
+    const { stdout } = await execFileAsync("git", args, {
+      cwd: workdir,
+      timeout: GIT_TIMEOUT_MS,
+      maxBuffer: GIT_MAX_BUFFER,
+      windowsHide: true,
+    });
+    return stdout;
+  } catch (err) {
+    // `git diff --no-index` exits 1 when files differ — that's the success
+    // case for us and the diff is on stdout. Everything else (not a repo, git
+    // missing, detached state) is best-effort: change capture must never
+    // disturb the session lifecycle.
+    const stdout = (err as { stdout?: unknown }).stdout;
+    if (typeof stdout === "string" && stdout.length > 0) return stdout;
+    return undefined;
+  }
+}
+
+async function isWorkTree(workdir: string): Promise<boolean> {
+  const inside = await git(workdir, ["rev-parse", "--is-inside-work-tree"]);
+  return inside?.trim() === "true";
+}
+
+/**
+ * The repo HEAD at spawn time, so the change set at completion is scoped to
+ * exactly what this sub-agent did (committed or not). Undefined when the
+ * workspace is not a git work tree or has no commits yet.
+ */
+export async function captureBaselineSha(
+  workdir: string,
+): Promise<string | undefined> {
+  if (!(await isWorkTree(workdir))) return undefined;
+  const sha = await git(workdir, ["rev-parse", "HEAD"]);
+  return sha?.trim() || undefined;
+}
+
+/**
+ * Tracked files already modified in the workspace at spawn time. The completion
+ * diff (`git diff <baseline>`) compares the working tree to the baseline
+ * COMMIT, so files that were dirty BEFORE the session (a leftover edit, a dirty
+ * submodule pointer) show up even though this sub-agent never touched them.
+ * Recording them at spawn lets the change set exclude that pre-existing churn.
+ */
+export async function captureBaselineDirty(workdir: string): Promise<string[]> {
+  if (!(await isWorkTree(workdir))) return [];
+  return ((await git(workdir, ["diff", "--name-only", "HEAD"])) ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * Parse `git diff --name-status` output into the set of affected paths. Renames
+ * appear as `R100\told\tnew` — the post-rename path is what changed, so take
+ * the last tab-separated field for every status.
+ */
+function parseNameStatus(out: string | undefined): string[] {
+  const files: string[] = [];
+  for (const line of (out ?? "").split("\n")) {
+    if (!line.trim()) continue;
+    const parts = line.split("\t");
+    const path = parts[parts.length - 1]?.trim();
+    if (path) files.push(path);
+  }
+  return files;
+}
+
+/** Normalize a tool-call file path to workdir-relative POSIX form. */
+function toWorkdirRelative(workdir: string, file: string): string {
+  const trimmed = file.trim();
+  if (!trimmed) return "";
+  const rel = isAbsolute(trimmed) ? relative(workdir, trimmed) : trimmed;
+  return rel.split("\\").join("/");
+}
+
+/** Unified diff for one file: real git diff if tracked, else new-file diff. */
+async function fileDiff(
+  workdir: string,
+  base: string,
+  file: string,
+): Promise<string> {
+  const tracked = (await git(workdir, ["diff", base, "--", file]))?.trim();
+  if (tracked) return tracked;
+  const created = (
+    await git(workdir, ["diff", "--no-index", "--", "/dev/null", file])
+  )?.trim();
+  return created ?? "";
+}
+
+/**
+ * What this sub-agent changed in `workdir` since spawn, from the union of two
+ * SESSION-SCOPED signals — no filesystem walk, no path denylist, no mtime
+ * heuristics, so it works for any workdir/language/deployment:
+ *  - `git diff --name-status <base>`: tracked edits, deletions, renames since
+ *    the spawn baseline (covers shell-driven writes to tracked files);
+ *  - `toolPaths`: files the agent explicitly wrote via edit/write tool calls
+ *    this session — including gitignored DEPLOY targets (`data/apps/<name>/`)
+ *    that git won't surface.
+ *
+ * Deliberately NOT using `git ls-files --others`: it lists EVERY untracked file
+ * in the work tree regardless of when it appeared, so in a shared/long-lived
+ * workspace it scoops up accumulated clutter from prior sessions (stray .venv,
+ * old build output, scratch PDFs) that this task never touched. Both signals
+ * above are scoped to this session, so the change set stays accurate.
+ *
+ * Returns undefined when nothing changed or the workspace isn't a git repo.
+ */
+export async function captureChangeSet(
+  workdir: string,
+  baselineSha?: string,
+  toolPaths: string[] = [],
+  baselineDirty: string[] = [],
+): Promise<WorkspaceChangeSet | undefined> {
+  if (!(await isWorkTree(workdir))) return undefined;
+  const base = baselineSha?.trim() ? baselineSha.trim() : "HEAD";
+
+  // Exclude files already dirty at spawn (pre-existing churn the agent didn't
+  // touch) UNLESS the agent explicitly wrote them via a tool call this session.
+  const dirtyAtSpawn = new Set(
+    baselineDirty.filter((file) => !toolPaths.includes(file)),
+  );
+  const tracked = parseNameStatus(
+    await git(workdir, ["diff", "--name-status", base]),
+  ).filter((file) => !dirtyAtSpawn.has(file));
+  const agentWritten = toolPaths
+    .map((file) => toWorkdirRelative(workdir, file))
+    .filter((file) => file.length > 0 && !file.startsWith("../"));
+
+  const changedFiles = [...new Set([...tracked, ...agentWritten])].slice(
+    0,
+    MAX_CHANGED_FILES,
+  );
+  if (changedFiles.length === 0) return undefined;
+
+  // Real stat from git (tracked changes); independent of how much diff text we
+  // render. Falls back to a file count for a purely gitignored/untracked set.
+  const shortstat = (await git(workdir, ["diff", "--shortstat", base]))?.trim();
+  const diffStat =
+    shortstat && shortstat.length > 0
+      ? shortstat
+      : `${changedFiles.length} file(s) changed`;
+
+  let diff = "";
+  for (const file of changedFiles.slice(0, MAX_FILE_DIFFS)) {
+    const fd = await fileDiff(workdir, base, file);
+    if (fd) diff = diff ? `${diff}\n${fd}` : fd;
+    if (diff.length > MAX_DIFF_CHARS) break;
+  }
+  const overLength = diff.length > MAX_DIFF_CHARS;
+  if (overLength) diff = `${diff.slice(0, MAX_DIFF_CHARS)}\n… [diff truncated]`;
+
+  return {
+    changedFiles,
+    diffStat,
+    diff,
+    truncated: overLength || changedFiles.length >= MAX_CHANGED_FILES,
+    capturedAt: Date.now(),
+  };
+}
+
+/** One-line, human-facing summary of a change set for a completion banner. */
+export function summarizeChangeSet(changeSet: WorkspaceChangeSet): string {
+  const count = changeSet.changedFiles.length;
+  const noun = count === 1 ? "file" : "files";
+  const shown = changeSet.changedFiles.slice(0, 6).join(", ");
+  const more = count > 6 ? ` (+${count - 6} more)` : "";
+  return `Changed ${count} ${noun}: ${shown}${more}`;
+}


### PR DESCRIPTION
## Problem
1. A false `state_lost` probe plus unbounded respawn could cascade duplicate sub-agents.
2. Asked "what did you change / show the diff", the parent confabulated edits because completion narration wasn't grounded in the actual change set.

## Change
- Bound respawn and fix the `state_lost` false-positive (stops the cascade).
- Capture the real change set from git (`name-status` vs the spawn baseline) unioned with the agent's edit/write tool-call paths (covers gitignored deploy targets), excluding files already dirty at spawn.
- Surface it via a provider gated by a new general `Provider.alwaysInResponseState` flag (reaches the simple-reply path without core naming the plugin), with a staleness guard that won't surface an older change set once a newer task has run.
- Dispatch the coding sub-agent when the planner names a simile of the TASKS action.

## Testing
orchestrator suite green (393); `workspace-diff`/`coding-session-changes`/`sub-agent-router`/`acp-service` unit tests green; core message-routing/stage1/trajectory green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two interconnected orchestrator bugs: a false-positive `state_lost` health-check probe (probing `.stream.ndjson` which was never written for native sessions, flipping every idle `ready` session to `errored` and triggering unbounded `session_state_lost` respawn cascades), and completion narrations that confabulated edits because the parent read the sub-agent's raw tool transcript instead of the real change set.

- **Health-check gate**: `runHealthCheck` now skips any session not in `ACP_MIDFLIGHT_SESSION_STATUSES` (`running`/`busy`/`tool_running`), fixing the false-positive cascade trigger; the probe target is also corrected from `.stream.ndjson` to the actual `.json` artifact.
- **Respawn backstop**: `SubAgentRouter` now tracks `session_state_lost` events per stable origin lineage (`taskRoomId + agentType`) and caps cross-session respawn at `DEFAULT_STATE_LOST_RESPAWN_CAP = 3`, resetting on a genuine `task_complete`.
- **Ground-truth change set**: At `task_complete`, `workspace-diff.ts` captures git `--name-status` output plus agent tool-call paths, persisted to session metadata and surfaced via a new `CODING_SESSION_CHANGES` provider flagged with `alwaysInResponseState: true`.

<h3>Confidence Score: 4/5</h3>

The core bug fixes are correct and well-tested; two open issues from prior review threads remain unaddressed in the new change-set capture and staleness-guard code paths.

The health-check fix and the respawn cap are clear correctional improvements. The open issues from prior review threads represent cases where the new functionality silently degrades: the staleness guard never fires when sessions are loaded from a database (createdAt is an ISO string, not a Date), and the dirtyAtSpawn filter can misidentify agent-written files that were also dirty at spawn time for absolute-path tool calls.

plugins/plugin-agent-orchestrator/src/providers/coding-session-changes.ts (staleness guard) and plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts (dirtyAtSpawn exclusion path-format mismatch)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-orchestrator/src/providers/coding-session-changes.ts | New provider surfacing real git change set for show-me-the-diff queries; staleness guard silently disabled for DB-backed runtimes (createdAt instanceof Date fails on ISO strings). |
| plugins/plugin-agent-orchestrator/src/services/workspace-diff.ts | New module capturing the real git change set at task completion; dirtyAtSpawn exclusion filter compares raw toolPaths against git-relative baselineDirty entries, broken for absolute-path tool calls. |
| plugins/plugin-agent-orchestrator/src/services/acp-service.ts | Health-check now correctly skips non-mid-flight sessions; probes the correct .json artifact instead of .stream.ndjson. Fix is minimal and targeted. |
| plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts | Adds per-lineage state_lost respawn cap (default 3), cross-session task_complete deduplication, and real git change set capture at task_complete. Logic is sound. |
| packages/core/src/services/message.ts | Adds alwaysOnResponseStateProviderNames helper and simile-aware exposedActionMatches for candidate action validation. Changes are correct and well-tested. |
| packages/core/src/types/components.ts | Adds alwaysInResponseState optional flag to the Provider interface. Backward-compatible extension. |
| plugins/plugin-agent-orchestrator/src/index.ts | Registers codingSessionChangesProvider in orchestratorProviders gated by codeExecutionAllowed; clean integration. |

</details>

<sub>Reviews (6): Last reviewed commit: ["test(core): cover simile-aware candidate..."](https://github.com/elizaos/eliza/commit/c0201397b9a92a7633f48b83f792a77f564ab4d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34557249)</sub>

<!-- /greptile_comment -->