### PR TITLE
feat(cloud): fleet-upgrade reconciler — blue/green swap onto the deployed image

### DIFF
--- a/packages/cloud-shared/src/db/migrations/0135_agent_sandboxes_image_digest.sql
+++ b/packages/cloud-shared/src/db/migrations/0135_agent_sandboxes_image_digest.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "agent_sandboxes"
+  ADD COLUMN IF NOT EXISTS "image_digest" text;

--- a/packages/cloud-shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud-shared/src/db/migrations/meta/_journal.json
@@ -946,6 +946,13 @@
       "when": 1779408300000,
       "tag": "0134_auth_events_retention",
       "breakpoints": true
+    },
+    {
+      "idx": 135,
+      "version": "7",
+      "when": 1779408400000,
+      "tag": "0135_agent_sandboxes_image_digest",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
@@ -179,6 +179,40 @@ export class AgentSandboxesRepository {
       .where(eq(agentSandboxes.status, "running"));
   }
 
+  /**
+   * Find running, non-deleted agents whose stored `image_digest` differs
+   * from `targetDigest` (treating NULL as different). Used by the
+   * fleet-upgrade reconciler to enqueue blue/green swaps onto the
+   * currently-deployed image. Capped by `limit` so a single cycle doesn't
+   * try to enqueue the whole fleet at once.
+   */
+  async listRunningWithDigestOtherThan(
+    targetDigest: string,
+    limit: number,
+  ): Promise<
+    Array<{ id: string; organization_id: string; user_id: string; image_digest: string | null }>
+  > {
+    return dbRead
+      .select({
+        id: agentSandboxes.id,
+        organization_id: agentSandboxes.organization_id,
+        user_id: agentSandboxes.user_id,
+        image_digest: agentSandboxes.image_digest,
+      })
+      .from(agentSandboxes)
+      .where(
+        and(
+          eq(agentSandboxes.status, "running"),
+          sql`${agentSandboxes.deleted_at} IS NULL`,
+          sql`${agentSandboxes.image_digest} IS DISTINCT FROM ${targetDigest}`,
+          // Skip pool-owned rows (warm pool entries) — they get the new
+          // image naturally on next claim, no need to disrupt them.
+          sql`${agentSandboxes.pool_status} IS NULL`,
+        ),
+      )
+      .limit(limit);
+  }
+
   async findRunningSandbox(id: string, orgId: string): Promise<AgentSandbox | undefined> {
     await ensureAgentSandboxSchema();
     // Use dbWrite (primary) for fresh read-after-write data from the VPS worker.

--- a/packages/cloud-shared/src/db/repositories/jobs.ts
+++ b/packages/cloud-shared/src/db/repositories/jobs.ts
@@ -546,6 +546,19 @@ export class JobsRepository {
   async delete(id: string): Promise<void> {
     await dbWrite.delete(jobs).where(eq(jobs.id, id));
   }
+
+  /**
+   * Count jobs of `type` that are still in flight (pending or in_progress).
+   * Used by the fleet-upgrade reconciler to enforce a rate limit on how
+   * many blue/green swaps can be in flight at once.
+   */
+  async countInFlightByType(type: string): Promise<number> {
+    const rows = await dbRead
+      .select({ count: sql<number>`count(*)::int` })
+      .from(jobs)
+      .where(and(eq(jobs.type, type), sql`${jobs.status} IN ('pending', 'in_progress')`));
+    return rows[0]?.count ?? 0;
+  }
 }
 
 // Singleton instance

--- a/packages/cloud-shared/src/db/schemas/agent-sandboxes.ts
+++ b/packages/cloud-shared/src/db/schemas/agent-sandboxes.ts
@@ -111,6 +111,15 @@ export const agentSandboxes = pgTable(
     web_ui_port: integer("web_ui_port"),
     headscale_ip: text("headscale_ip"),
     docker_image: text("docker_image"),
+    /**
+     * Registry-resolved sha256 digest of the image this agent is actually
+     * running. Stamped at provision time (and re-stamped after a successful
+     * fleet upgrade). The reconciler compares this against the current
+     * registry digest of the configured tag to decide who needs an upgrade.
+     * Null on rows provisioned before the fleet-upgrade feature shipped —
+     * those are treated as "upgrade on next cycle".
+     */
+    image_digest: text("image_digest"),
     // Billing tracking fields (mirrors containers table pattern)
     billing_status: text("billing_status").$type<AgentBillingStatus>().notNull().default("active"),
     last_billed_at: timestamp("last_billed_at", { withTimezone: true }),

--- a/packages/cloud-shared/src/lib/services/__tests__/provisioning-job-types.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/provisioning-job-types.test.ts
@@ -22,9 +22,10 @@ describe("JOB_TYPES", () => {
     expect(JOB_TYPES.AGENT_RESTART).toBe("agent_restart");
     expect(JOB_TYPES.AGENT_LOGS).toBe("agent_logs");
     expect(JOB_TYPES.AGENT_SNAPSHOT).toBe("agent_snapshot");
+    expect(JOB_TYPES.AGENT_UPGRADE).toBe("agent_upgrade");
     // Lock the size so a new entry without a matching assertion above
     // fails CI instead of being silently under-covered by tests below.
-    expect(Object.keys(JOB_TYPES)).toHaveLength(7);
+    expect(Object.keys(JOB_TYPES)).toHaveLength(8);
   });
 
   test("wire values are unique (no two symbols share a string)", () => {

--- a/packages/cloud-shared/src/lib/services/__tests__/registry-probe-edges.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/registry-probe-edges.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Boundary tests for registry-probe — complements registry-probe.test.ts by
+ * pinning down the parser's behavior on pathological refs, plus exercising
+ * the cache lifecycle across heterogeneous ref kinds (ghcr / docker.io /
+ * bare name) in a single sequence.
+ *
+ * Some of these assertions document current behavior on inputs that are
+ * unlikely in practice but worth pinning so a future refactor doesn't
+ * silently start crashing or silently start accepting garbage. Where the
+ * parser is permissive (e.g. whitespace tag), the test asserts that the
+ * downstream resolver still treats the result safely.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  clearRegistryProbeCache,
+  parseImageRef,
+  resolveImageDigest,
+} from "../containers/registry-probe";
+
+const DIGEST = "sha256:abc1234567890";
+
+function tokenResp(token = "anon-token"): Response {
+  return new Response(JSON.stringify({ token }), { status: 200 });
+}
+
+function manifestResp(digest: string | null, status = 200): Response {
+  const headers = new Headers();
+  if (digest !== null) headers.set("docker-content-digest", digest);
+  return new Response(null, { status, headers });
+}
+
+describe("parseImageRef — boundary inputs", () => {
+  test("whitespace-only tag is currently accepted by the parser", () => {
+    // The parser only checks for an empty tag string, not all-whitespace. A
+    // single space passes through. Pinning this so a future tightening is
+    // an explicit decision rather than an accidental break.
+    const parsed = parseImageRef("ghcr.io/elizaos/eliza: ");
+    expect(parsed).not.toBeNull();
+    expect(parsed?.tag).toBe(" ");
+  });
+
+  test("tag with leading and trailing dots is accepted as-is", () => {
+    // Docker spec disallows leading periods, but the probe is permissive:
+    // we'll attempt the manifest fetch and let ghcr return 404 if invalid.
+    expect(parseImageRef("ghcr.io/org/repo:.v1.")).toEqual({
+      registry: "ghcr.io",
+      repo: "org/repo",
+      tag: ".v1.",
+    });
+  });
+
+  test("repo with a leading slash (double-slash after registry) keeps the slash", () => {
+    // `ghcr.io//org/repo:tag` is malformed by Docker rules but our parser
+    // splits on the first `/` and trusts the rest. Pin the behavior so a
+    // future stricter parser is a deliberate change.
+    expect(parseImageRef("ghcr.io//org/repo:tag")).toEqual({
+      registry: "ghcr.io",
+      repo: "/org/repo",
+      tag: "tag",
+    });
+  });
+
+  test("empty registry host with port (`:8080/foo:bar`) parses without crashing", () => {
+    // Pathological: registry segment is just `:8080`. The parser keys off
+    // the colon-in-host heuristic and accepts it. Downstream this is a
+    // non-ghcr ref, so resolveImageDigest will short-circuit to null.
+    const parsed = parseImageRef(":8080/foo:bar");
+    expect(parsed).toEqual({
+      registry: ":8080",
+      repo: "foo",
+      tag: "bar",
+    });
+  });
+
+  test("unicode characters in tag are preserved", () => {
+    // The probe URL-encodes the tag before fetching, so unicode tags don't
+    // crash the parser and would round-trip through encodeURIComponent.
+    expect(parseImageRef("ghcr.io/org/repo:тэг-1")).toEqual({
+      registry: "ghcr.io",
+      repo: "org/repo",
+      tag: "тэг-1",
+    });
+  });
+
+  test("trailing slash with no tag returns null", () => {
+    // lastColon < lastSlash, so the colon-after-slash rule rejects it.
+    expect(parseImageRef("ghcr.io/elizaos/eliza/")).toBeNull();
+  });
+
+  test("digest-style ref (@sha256:...) is not a tag and returns null", () => {
+    // We don't support digest-pinned refs in the probe. The `@` doesn't
+    // count as a tag separator, so parsing produces no tag.
+    expect(parseImageRef("ghcr.io/elizaos/eliza@sha256:abc")).toEqual({
+      // The parser sees the last colon (inside the digest) and treats
+      // "abc" as the tag. Pin the current behavior — we'd want to reject
+      // `@`-refs explicitly in a future hardening.
+      registry: "ghcr.io",
+      repo: "elizaos/eliza@sha256",
+      tag: "abc",
+    });
+  });
+});
+
+describe("resolveImageDigest — pathological refs short-circuit safely", () => {
+  beforeEach(() => clearRegistryProbeCache());
+  afterEach(() => clearRegistryProbeCache());
+
+  test("`:8080/foo:bar` resolves to null without hitting the network", async () => {
+    let calls = 0;
+    const fetchFn = (async () => {
+      calls += 1;
+      throw new Error("should not fetch for non-ghcr ref");
+    }) as typeof fetch;
+    expect(await resolveImageDigest(":8080/foo:bar", { fetchFn })).toBeNull();
+    expect(calls).toBe(0);
+  });
+
+  test("whitespace tag on ghcr ref does attempt the fetch (parser is permissive)", async () => {
+    // Documents that the parser will let a whitespace tag through to the
+    // network layer. If we ever tighten the parser, flip this test.
+    let manifestCalled = false;
+    const fetchFn = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("ghcr.io/token")) return tokenResp();
+      manifestCalled = true;
+      return manifestResp(null, 404);
+    }) as typeof fetch;
+    const result = await resolveImageDigest("ghcr.io/elizaos/eliza: ", {
+      fetchFn,
+    });
+    expect(result).toBeNull();
+    expect(manifestCalled).toBe(true);
+  });
+});
+
+describe("clearRegistryProbeCache — multi-ref cache lifecycle", () => {
+  beforeEach(() => clearRegistryProbeCache());
+  afterEach(() => clearRegistryProbeCache());
+
+  test("ghcr / docker.io / bare-name entries cache independently and clear together", async () => {
+    let ghcrCalls = 0;
+    let dockerCalls = 0;
+    const fetchFn = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("ghcr.io/token")) {
+        ghcrCalls += 1;
+        return tokenResp();
+      }
+      if (url.includes("ghcr.io/v2")) {
+        ghcrCalls += 1;
+        return manifestResp(DIGEST);
+      }
+      if (url.includes("docker")) {
+        // Non-ghcr should never reach the network; record if it does so
+        // the test fails loudly on a future regression.
+        dockerCalls += 1;
+        throw new Error("docker.io should never reach the network");
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const t0 = 1_000_000;
+    const now = () => t0;
+
+    // 1. ghcr ref — hits the network, caches a real digest.
+    const ghcr1 = await resolveImageDigest("ghcr.io/elizaos/eliza:develop", {
+      fetchFn,
+      now,
+    });
+    expect(ghcr1).toBe(DIGEST);
+    expect(ghcrCalls).toBe(2); // token + manifest
+
+    // 2. docker.io ref — non-ghcr, caches null, no network calls.
+    const docker1 = await resolveImageDigest("docker.io/library/alpine:latest", {
+      fetchFn,
+      now,
+    });
+    expect(docker1).toBeNull();
+    expect(dockerCalls).toBe(0);
+
+    // 3. Bare name (no registry) — caches null, no network calls.
+    const bare1 = await resolveImageDigest("eliza-agent:prod-good", {
+      fetchFn,
+      now,
+    });
+    expect(bare1).toBeNull();
+
+    // Re-resolving each ref within TTL must NOT trigger additional fetches.
+    const ghcr2 = await resolveImageDigest("ghcr.io/elizaos/eliza:develop", {
+      fetchFn,
+      now,
+    });
+    const docker2 = await resolveImageDigest("docker.io/library/alpine:latest", {
+      fetchFn,
+      now,
+    });
+    const bare2 = await resolveImageDigest("eliza-agent:prod-good", {
+      fetchFn,
+      now,
+    });
+    expect(ghcr2).toBe(DIGEST);
+    expect(docker2).toBeNull();
+    expect(bare2).toBeNull();
+    expect(ghcrCalls).toBe(2); // unchanged — second ghcr hit was cached
+
+    // After clearing, ghcr ref re-fetches; non-ghcr refs still short-circuit
+    // (no cache hit, but the registry check is what gates the network).
+    clearRegistryProbeCache();
+    await resolveImageDigest("ghcr.io/elizaos/eliza:develop", {
+      fetchFn,
+      now,
+    });
+    expect(ghcrCalls).toBe(4); // token + manifest again after clear
+    await resolveImageDigest("docker.io/library/alpine:latest", {
+      fetchFn,
+      now,
+    });
+    await resolveImageDigest("eliza-agent:prod-good", { fetchFn, now });
+    expect(dockerCalls).toBe(0); // still never hit the network
+  });
+
+  test("re-resolving an already-cached entry never invokes fetch", async () => {
+    // Stronger version of the existing "caches successful results" test:
+    // after the initial population, replace the fetchFn with one that
+    // throws on any call. If the cache is honored, the throwing fetch is
+    // never invoked.
+    const populateFetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("ghcr.io/token")) return tokenResp();
+      return manifestResp(DIGEST);
+    }) as typeof fetch;
+
+    const t0 = 2_000_000;
+    const initial = await resolveImageDigest("ghcr.io/elizaos/eliza:develop", {
+      fetchFn: populateFetch,
+      now: () => t0,
+    });
+    expect(initial).toBe(DIGEST);
+
+    const throwingFetch = (async () => {
+      throw new Error("fetch must not be called when entry is cached");
+    }) as typeof fetch;
+
+    const cached = await resolveImageDigest("ghcr.io/elizaos/eliza:develop", {
+      fetchFn: throwingFetch,
+      now: () => t0 + 10_000,
+    });
+    expect(cached).toBe(DIGEST);
+  });
+
+  test("negative cache for non-ghcr ref is honored across calls", async () => {
+    let registryCheckCalls = 0;
+    const fetchFn = (async () => {
+      registryCheckCalls += 1;
+      throw new Error("non-ghcr should never fetch");
+    }) as typeof fetch;
+
+    const t0 = 3_000_000;
+    await resolveImageDigest("docker.io/library/alpine:latest", {
+      fetchFn,
+      now: () => t0,
+    });
+    await resolveImageDigest("docker.io/library/alpine:latest", {
+      fetchFn,
+      now: () => t0 + 30_000,
+    });
+    expect(registryCheckCalls).toBe(0);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/registry-probe.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/registry-probe.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Covers registry-probe.resolveImageDigest — the read side of fleet upgrade.
+ * Mocks fetch (the only system boundary) and clears the in-memory cache
+ * between tests so caching behavior is exercised explicitly, not implicitly.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  clearRegistryProbeCache,
+  parseImageRef,
+  resolveImageDigest,
+} from "../containers/registry-probe";
+
+const DIGEST = "sha256:abc1234567890";
+
+function makeFetch(routes: Record<string, () => Response>): typeof fetch {
+  return (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input.toString();
+    for (const [pattern, factory] of Object.entries(routes)) {
+      if (url.includes(pattern)) return factory();
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+}
+
+function tokenResp(token = "anon-token"): Response {
+  return new Response(JSON.stringify({ token }), { status: 200 });
+}
+
+function manifestResp(digest: string | null, status = 200): Response {
+  const headers = new Headers();
+  if (digest !== null) headers.set("docker-content-digest", digest);
+  return new Response(null, { status, headers });
+}
+
+describe("parseImageRef", () => {
+  test("parses a full ghcr.io reference", () => {
+    expect(parseImageRef("ghcr.io/elizaos/eliza:develop")).toEqual({
+      registry: "ghcr.io",
+      repo: "elizaos/eliza",
+      tag: "develop",
+    });
+  });
+
+  test("parses a nested repo path", () => {
+    expect(parseImageRef("ghcr.io/org/group/repo:v1.2.3")).toEqual({
+      registry: "ghcr.io",
+      repo: "org/group/repo",
+      tag: "v1.2.3",
+    });
+  });
+
+  test("returns null for bare image without registry", () => {
+    expect(parseImageRef("eliza-agent:prod-good")).toBeNull();
+  });
+
+  test("returns null when no tag", () => {
+    expect(parseImageRef("ghcr.io/elizaos/eliza")).toBeNull();
+  });
+
+  test("returns null when empty tag", () => {
+    expect(parseImageRef("ghcr.io/elizaos/eliza:")).toBeNull();
+  });
+
+  test("handles port in registry (colon before slash is not a tag)", () => {
+    // localhost:5000/repo:tag — last colon is the tag separator
+    expect(parseImageRef("localhost:5000/repo:tag")).toEqual({
+      registry: "localhost:5000",
+      repo: "repo",
+      tag: "tag",
+    });
+  });
+
+  test("returns null for malformed input", () => {
+    expect(parseImageRef("")).toBeNull();
+    expect(parseImageRef(":tag")).toBeNull();
+    expect(parseImageRef("noslash:tag")).toBeNull();
+  });
+});
+
+describe("resolveImageDigest", () => {
+  beforeEach(() => clearRegistryProbeCache());
+  afterEach(() => clearRegistryProbeCache());
+
+  test("resolves ghcr.io reference to the manifest digest", async () => {
+    const fetchFn = makeFetch({
+      "ghcr.io/token": () => tokenResp(),
+      "manifests/develop": () => manifestResp(DIGEST),
+    });
+    const result = await resolveImageDigest("ghcr.io/elizaos/eliza:develop", {
+      fetchFn,
+    });
+    expect(result).toBe(DIGEST);
+  });
+
+  test("returns null for non-ghcr registries (only ghcr supported in MVP)", async () => {
+    const fetchFn = makeFetch({
+      // Should not be called; resolver short-circuits before any network.
+      docker: () => {
+        throw new Error("docker.io should never be reached");
+      },
+    });
+    expect(await resolveImageDigest("docker.io/library/alpine:latest", { fetchFn })).toBeNull();
+  });
+
+  test("returns null for bare image names (no registry)", async () => {
+    const fetchFn = makeFetch({});
+    expect(await resolveImageDigest("eliza-agent:prod-good", { fetchFn })).toBeNull();
+  });
+
+  test("returns null on 404 manifest (tag never pushed)", async () => {
+    const fetchFn = makeFetch({
+      "ghcr.io/token": () => tokenResp(),
+      "manifests/never-pushed": () => manifestResp(null, 404),
+    });
+    expect(
+      await resolveImageDigest("ghcr.io/elizaos/eliza:never-pushed", {
+        fetchFn,
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null on 5xx (transient registry failure)", async () => {
+    const fetchFn = makeFetch({
+      "ghcr.io/token": () => tokenResp(),
+      manifests: () => manifestResp(null, 502),
+    });
+    expect(await resolveImageDigest("ghcr.io/elizaos/eliza:develop", { fetchFn })).toBeNull();
+  });
+
+  test("returns null on token endpoint failure", async () => {
+    const fetchFn = makeFetch({
+      "ghcr.io/token": () => new Response("forbidden", { status: 403 }),
+    });
+    expect(await resolveImageDigest("ghcr.io/elizaos/eliza:develop", { fetchFn })).toBeNull();
+  });
+
+  test("returns null on network error", async () => {
+    const fetchFn = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch;
+    expect(await resolveImageDigest("ghcr.io/elizaos/eliza:develop", { fetchFn })).toBeNull();
+  });
+
+  test("caches successful results for 60s", async () => {
+    let calls = 0;
+    const fetchFn = (async (input: RequestInfo | URL) => {
+      calls += 1;
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("ghcr.io/token")) return tokenResp();
+      return manifestResp(DIGEST);
+    }) as typeof fetch;
+
+    const t0 = 1_000_000;
+    await resolveImageDigest("ghcr.io/elizaos/eliza:develop", {
+      fetchFn,
+      now: () => t0,
+    });
+    // Within TTL — no extra network calls.
+    await resolveImageDigest("ghcr.io/elizaos/eliza:develop", {
+      fetchFn,
+      now: () => t0 + 30_000,
+    });
+    expect(calls).toBe(2); // 1 token + 1 manifest, no second round
+  });
+
+  test("re-fetches after TTL expiry", async () => {
+    let calls = 0;
+    const fetchFn = (async (input: RequestInfo | URL) => {
+      calls += 1;
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("ghcr.io/token")) return tokenResp();
+      return manifestResp(DIGEST);
+    }) as typeof fetch;
+
+    const t0 = 1_000_000;
+    await resolveImageDigest("ghcr.io/elizaos/eliza:develop", {
+      fetchFn,
+      now: () => t0,
+    });
+    await resolveImageDigest("ghcr.io/elizaos/eliza:develop", {
+      fetchFn,
+      now: () => t0 + 61_000, // past 60s TTL
+    });
+    expect(calls).toBe(4); // 2 token + 2 manifest
+  });
+
+  test("URL-encodes tag with special characters", async () => {
+    const seenUrls: string[] = [];
+    const fetchFn = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      seenUrls.push(url);
+      if (url.includes("ghcr.io/token")) return tokenResp();
+      return manifestResp(DIGEST);
+    }) as typeof fetch;
+
+    await resolveImageDigest("ghcr.io/elizaos/eliza:develop+latest", {
+      fetchFn,
+    });
+    const manifestUrl = seenUrls.find((u) => u.includes("/manifests/"));
+    // `+` must be percent-encoded (`%2B`) so the registry sees the literal tag.
+    expect(manifestUrl).toBe("https://ghcr.io/v2/elizaos/eliza/manifests/develop%2Blatest");
+  });
+
+  test("preserves `/` between repo segments while encoding each segment", async () => {
+    const seenUrls: string[] = [];
+    const fetchFn = (async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      seenUrls.push(url);
+      if (url.includes("ghcr.io/token")) return tokenResp();
+      return manifestResp(DIGEST);
+    }) as typeof fetch;
+
+    await resolveImageDigest("ghcr.io/org/sub/repo:v1", { fetchFn });
+    const manifestUrl = seenUrls.find((u) => u.includes("/manifests/"));
+    // Slashes between path segments are preserved (not `%2F`).
+    expect(manifestUrl).toBe("https://ghcr.io/v2/org/sub/repo/manifests/v1");
+  });
+
+  test("caches negative results too (don't hammer ghcr on 404)", async () => {
+    let calls = 0;
+    const fetchFn = (async (input: RequestInfo | URL) => {
+      calls += 1;
+      const url = typeof input === "string" ? input : input.toString();
+      if (url.includes("ghcr.io/token")) return tokenResp();
+      return manifestResp(null, 404);
+    }) as typeof fetch;
+
+    const t0 = 1_000_000;
+    const a = await resolveImageDigest("ghcr.io/elizaos/eliza:gone", {
+      fetchFn,
+      now: () => t0,
+    });
+    const b = await resolveImageDigest("ghcr.io/elizaos/eliza:gone", {
+      fetchFn,
+      now: () => t0 + 30_000,
+    });
+    expect(a).toBeNull();
+    expect(b).toBeNull();
+    expect(calls).toBe(2); // not 4 — second call hits cache
+  });
+});

--- a/packages/cloud-shared/src/lib/services/containers/registry-probe.ts
+++ b/packages/cloud-shared/src/lib/services/containers/registry-probe.ts
@@ -1,0 +1,147 @@
+/**
+ * Resolve a Docker image reference (e.g. `ghcr.io/elizaos/eliza:develop`) to
+ * its registry-side sha256 digest. The fleet-upgrade reconciler uses this to
+ * detect when a tag has been republished (i.e. a new image was pushed under
+ * the same name), and then triggers a rolling blue/green upgrade of all
+ * agents still on the old digest.
+ *
+ * Only ghcr.io is supported. Anything else — including a bare image name
+ * without a registry prefix like `eliza-agent:prod-good` — resolves to
+ * `null`, which the reconciler treats as "skip, don't know how to upgrade".
+ */
+import { logger } from "../../utils/logger";
+
+const CACHE_TTL_MS = 60_000;
+
+interface CacheEntry {
+  digest: string | null;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+interface ResolveOptions {
+  fetchFn?: typeof fetch;
+  now?: () => number;
+}
+
+export async function resolveImageDigest(
+  imageRef: string,
+  opts: ResolveOptions = {},
+): Promise<string | null> {
+  const fetchFn = opts.fetchFn ?? fetch;
+  const now = opts.now ?? Date.now;
+
+  const cached = cache.get(imageRef);
+  if (cached && cached.expiresAt > now()) return cached.digest;
+
+  const parsed = parseImageRef(imageRef);
+  if (!parsed || parsed.registry !== "ghcr.io") {
+    cache.set(imageRef, { digest: null, expiresAt: now() + CACHE_TTL_MS });
+    return null;
+  }
+
+  const digest = await fetchGhcrDigest(parsed.repo, parsed.tag, fetchFn);
+  cache.set(imageRef, { digest, expiresAt: now() + CACHE_TTL_MS });
+  return digest;
+}
+
+interface ParsedRef {
+  registry: string;
+  repo: string;
+  tag: string;
+}
+
+export function parseImageRef(ref: string): ParsedRef | null {
+  // A real Docker reference is `host[:port]/path:tag`. The tag is the
+  // substring after the last colon, but only if that colon comes after the
+  // last slash (otherwise it's a port number inside the registry host).
+  const lastColon = ref.lastIndexOf(":");
+  const lastSlash = ref.lastIndexOf("/");
+  if (lastColon === -1 || lastColon < lastSlash) return null;
+  const tag = ref.slice(lastColon + 1);
+  if (!tag) return null;
+
+  const repoFull = ref.slice(0, lastColon);
+  const firstSlash = repoFull.indexOf("/");
+  if (firstSlash === -1) return null;
+
+  const registry = repoFull.slice(0, firstSlash);
+  // Heuristic: a real registry host has either a dot (ghcr.io, docker.io) or
+  // a port. Single-token prefixes like `eliza-agent` are local image names,
+  // not registries, and `host[firstSlash]/path` would actually be the repo.
+  if (!registry.includes(".") && !registry.includes(":")) return null;
+
+  const repo = repoFull.slice(firstSlash + 1);
+  if (!repo) return null;
+
+  return { registry, repo, tag };
+}
+
+async function fetchGhcrDigest(
+  repo: string,
+  tag: string,
+  fetchFn: typeof fetch,
+): Promise<string | null> {
+  // Encode each path segment but preserve `/` between them: a Docker repo
+  // like `elizaos/eliza` is valid in the URL path, but a stray space or `?`
+  // in a segment would silently produce a malformed URL.
+  const encodedRepo = repo.split("/").map(encodeURIComponent).join("/");
+  const encodedTag = encodeURIComponent(tag);
+
+  let token: string;
+  try {
+    const tokenResp = await fetchFn(
+      `https://ghcr.io/token?scope=repository:${encodedRepo}:pull&service=ghcr.io`,
+    );
+    if (!tokenResp.ok) {
+      logger.warn(`[registry-probe] ghcr token fetch failed for ${repo}: ${tokenResp.status}`);
+      return null;
+    }
+    const tokenJson = (await tokenResp.json()) as { token?: string };
+    if (!tokenJson.token) return null;
+    token = tokenJson.token;
+  } catch (err) {
+    logger.warn(
+      `[registry-probe] ghcr token network error for ${repo}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+
+  try {
+    const manifestResp = await fetchFn(
+      `https://ghcr.io/v2/${encodedRepo}/manifests/${encodedTag}`,
+      {
+        method: "HEAD",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: [
+            "application/vnd.oci.image.index.v1+json",
+            "application/vnd.oci.image.manifest.v1+json",
+            "application/vnd.docker.distribution.manifest.list.v2+json",
+            "application/vnd.docker.distribution.manifest.v2+json",
+          ].join(", "),
+        },
+      },
+    );
+    if (!manifestResp.ok) {
+      if (manifestResp.status !== 404) {
+        logger.warn(
+          `[registry-probe] ghcr manifest fetch failed for ${repo}:${tag}: ${manifestResp.status}`,
+        );
+      }
+      return null;
+    }
+    return manifestResp.headers.get("docker-content-digest");
+  } catch (err) {
+    logger.warn(
+      `[registry-probe] ghcr manifest network error for ${repo}:${tag}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return null;
+  }
+}
+
+/** Test-only: clears the in-process cache between scenarios. */
+export function clearRegistryProbeCache(): void {
+  cache.clear();
+}

--- a/packages/cloud-shared/src/lib/services/docker-node-manager.ts
+++ b/packages/cloud-shared/src/lib/services/docker-node-manager.ts
@@ -47,6 +47,14 @@ export interface CapacitySummary {
 export interface NodeSelectionOptions {
   /** Docker image platform the selected node must be able to run. */
   requiredPlatform?: string | null;
+  /**
+   * Skip this node when picking a target. Used by the fleet-upgrade handler
+   * to force a blue/green swap onto a *different* node than the one the
+   * agent is currently on, because Docker container names are unique per
+   * docker daemon and the deterministic name `agent-${id}` would collide
+   * if the blue landed on the same node as the old.
+   */
+  excludeNodeId?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -106,6 +114,7 @@ export class DockerNodeManager {
       )
     )
       .filter((candidate) => candidate.available > 0)
+      .filter((candidate) => candidate.node.node_id !== options.excludeNodeId)
       .sort((a, b) => b.available - a.available);
 
     for (const candidate of candidates) {

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -18,6 +18,7 @@ import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { resolveServerStewardApiUrlFromEnv } from "../steward-url";
 import { logger } from "../utils/logger";
 import { getNodeAutoscaler } from "./containers/node-autoscaler";
+import { resolveImageDigest } from "./containers/registry-probe";
 import { isAlreadyGoneMessage } from "./docker-error-classifier";
 import { dockerNodeManager } from "./docker-node-manager";
 import { getUsedDockerHostPorts } from "./docker-port-allocation";
@@ -61,6 +62,13 @@ export interface DockerSandboxMetadata {
   agentId: string;
   volumePath: string;
   dockerImage: string;
+  /**
+   * Registry-resolved sha256 digest of `dockerImage` at provision time.
+   * Null when the image is not on a supported registry (e.g. a local-only
+   * name) or the registry was unreachable. The fleet-upgrade reconciler
+   * uses this to detect when the tag's digest has moved.
+   */
+  imageDigest: string | null;
   headscaleIp?: string;
 }
 
@@ -464,6 +472,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     // retry logic provide safety against concurrent capacity changes.
     let dbNode = await dockerNodeManager.getAvailableNode({
       requiredPlatform: imagePlatform,
+      excludeNodeId: config.excludeNodeId,
     });
     if (!dbNode) {
       dbNode = await this.provisionAutoscaledNodeForAgent({
@@ -495,7 +504,15 @@ export class DockerSandboxProvider implements SandboxProvider {
       logger.warn(
         "[docker-sandbox] No nodes in DB, falling back to CONTAINERS_DOCKER_NODES env var (seed-only, no load balancing)",
       );
-      const envNodes = parseDockerNodes();
+      const allEnvNodes = parseDockerNodes();
+      const envNodes = config.excludeNodeId
+        ? allEnvNodes.filter((n) => n.nodeId !== config.excludeNodeId)
+        : allEnvNodes;
+      if (envNodes.length === 0) {
+        throw new Error(
+          `[docker-sandbox] No nodes available (excludeNodeId=${config.excludeNodeId ?? "none"} filtered out all seed nodes)`,
+        );
+      }
       const envNode = envNodes[Math.floor(Math.random() * envNodes.length)]!;
       nodeId = envNode.nodeId;
       hostname = envNode.hostname;
@@ -860,6 +877,12 @@ export class DockerSandboxProvider implements SandboxProvider {
     // 10. Return handle with strongly-typed metadata
     const targetHost = headscaleIp || hostname;
 
+    // Probe ghcr.io for the image's current digest so the fleet-upgrade
+    // reconciler can detect when the tag has been republished. Returns null
+    // on bare image names or registry errors — both are treated as
+    // "unknown, leave alone" by the reconciler.
+    const imageDigest = await resolveImageDigest(resolvedImage);
+
     const metadata: DockerSandboxMetadata = {
       provider: "docker",
       nodeId,
@@ -870,6 +893,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       agentId,
       volumePath,
       dockerImage: resolvedImage,
+      imageDigest,
       headscaleIp: headscaleIp || undefined,
     };
 
@@ -950,6 +974,61 @@ export class DockerSandboxProvider implements SandboxProvider {
   // ------------------------------------------------------------------
   // stop
   // ------------------------------------------------------------------
+
+  /**
+   * Stop and remove a container on a specific node using explicit node info.
+   * Used by the fleet-upgrade handler to tear down the old container AFTER
+   * the blue/green swap has already updated the agent_sandboxes row to point
+   * at the blue — at which point `this.containers` and the DB both resolve
+   * to the blue, so the regular `stop(sandboxId)` would target the wrong
+   * container.
+   *
+   * Best-effort: a swap that already redirected traffic doesn't break if we
+   * leave a zombie on the old node; the next reconciliation pass plus the
+   * autoscaler's idle-node drain handle eventual cleanup. We still try
+   * stop+rm with graceful drain so users on websockets get a SIGTERM rather
+   * than an abrupt kill.
+   */
+  async stopOnSpecificNode(
+    node: DockerNode,
+    containerName: string,
+    gracefulSeconds = 30,
+  ): Promise<void> {
+    const ssh = DockerSSHClient.getClient(
+      node.hostname,
+      node.ssh_port ?? DEFAULT_SSH_PORT,
+      node.host_key_fingerprint ?? undefined,
+      node.ssh_user ?? DEFAULT_SSH_USERNAME,
+    );
+    try {
+      await ssh.exec(
+        `docker stop -t ${gracefulSeconds} ${shellQuote(containerName)}`,
+        DOCKER_CMD_TIMEOUT_MS,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!isAlreadyGoneMessage(msg)) {
+        logger.warn(
+          `[docker-sandbox] stopOnSpecificNode: docker stop failed for ${containerName} on ${node.node_id}: ${msg}`,
+        );
+      }
+    }
+    try {
+      await ssh.exec(`docker rm -f ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!isAlreadyGoneMessage(msg)) {
+        logger.warn(
+          `[docker-sandbox] stopOnSpecificNode: docker rm -f failed for ${containerName} on ${node.node_id}: ${msg}`,
+        );
+      }
+    }
+    await dockerNodesRepository.decrementAllocated(node.node_id).catch((err) => {
+      logger.warn(
+        `[docker-sandbox] stopOnSpecificNode: decrement allocated_count failed for ${node.node_id}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  }
 
   async stop(sandboxId: string): Promise<void> {
     const meta = await this.resolveContainer(sandboxId);

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -818,6 +818,11 @@ export class ElizaSandboxService {
           if (dockerMeta.webUiPort) updateData.web_ui_port = dockerMeta.webUiPort;
           if (dockerMeta.headscaleIp) updateData.headscale_ip = dockerMeta.headscaleIp;
           if (dockerMeta.dockerImage) updateData.docker_image = dockerMeta.dockerImage;
+          // Always overwrite the digest (including null) so a re-provision
+          // onto a different image clears any stale value. The reconciler
+          // treats null as "unknown, wait until probe succeeds before
+          // deciding", which is what we want during registry outages.
+          updateData.image_digest = dockerMeta.imageDigest;
         }
 
         const updated = await agentSandboxesRepository.update(rec.id, updateData);
@@ -2721,7 +2726,11 @@ export class ElizaSandboxService {
       await this.lockLifecycle(tx, agentId, orgId);
       const rec = await this.getAgentForLifecycleMutation(tx, agentId, orgId);
       if (!rec)
-        return { success: false, containerStopped: false, error: "Agent not found" } as const;
+        return {
+          success: false,
+          containerStopped: false,
+          error: "Agent not found",
+        } as const;
 
       const hasActiveProvisionJob = await this.hasActiveProvisionJobTx(tx, agentId, orgId);
       if (rec.status === "provisioning" || hasActiveProvisionJob) {
@@ -2866,6 +2875,193 @@ export class ElizaSandboxService {
       containerStarted: true,
       bridgeUrl: provisionResult.bridgeUrl,
       healthUrl: provisionResult.healthUrl,
+    };
+  }
+
+  /**
+   * Daemon-side handler for the `agent_upgrade` job: blue/green swap an
+   * agent onto the currently-deployed image.
+   *
+   * Flow:
+   *   1. Snapshot the agent's current node + container info.
+   *   2. Provision a fresh container (blue) on a *different* node — the
+   *      provider's container name is deterministic (`agent-${id}`), so the
+   *      blue must land on a different docker daemon. The provider's
+   *      `excludeNodeId` makes this guarantee.
+   *   3. Health-check blue. If it doesn't come up, tear it down and bail —
+   *      the agent keeps running on the old container with the old image
+   *      (auto-rollback, no operator intervention).
+   *   4. Atomic UPDATE: swap the row's bridge_url / node_id / container_name
+   *      / image_digest. New HTTP requests hit blue from this point on.
+   *   5. Best-effort SIGTERM (30s drain) on the old container, then remove
+   *      it. Already-in-flight HTTP responses on the old finish; websockets
+   *      get a clean drop and reconnect to blue.
+   */
+  async executeUpgrade(
+    agentId: string,
+    orgId: string,
+    toDigest: string,
+  ): Promise<{
+    success: boolean;
+    oldNodeId?: string;
+    oldContainerName?: string;
+    newNodeId?: string;
+    newContainerName?: string;
+    newDigest?: string | null;
+    error?: string;
+  }> {
+    const agent = await agentSandboxesRepository.findByIdAndOrg(agentId, orgId);
+    if (!agent) return { success: false, error: "Agent not found" };
+    if (agent.status !== "running") {
+      return {
+        success: false,
+        error: `Agent not running (status: ${agent.status})`,
+      };
+    }
+    if (!agent.node_id || !agent.container_name) {
+      return {
+        success: false,
+        error: "Agent has no node_id or container_name to upgrade from",
+      };
+    }
+
+    const oldNodeId = agent.node_id;
+    const oldContainerName = agent.container_name;
+    const oldNode = await dockerNodesRepository.findByNodeId(oldNodeId);
+    if (!oldNode) {
+      return {
+        success: false,
+        error: `Old node ${oldNodeId} not registered in docker_nodes`,
+      };
+    }
+
+    const provider = await this.getProvider();
+    const { DockerSandboxProvider } = await import("./docker-sandbox-provider");
+    if (!(provider instanceof DockerSandboxProvider)) {
+      return {
+        success: false,
+        error: "Fleet upgrade only supported on docker provider",
+      };
+    }
+
+    const config = {
+      agentId,
+      agentName: agent.agent_name ?? "",
+      organizationId: orgId,
+      environmentVars: agent.environment_vars ?? {},
+      excludeNodeId: oldNodeId,
+    };
+
+    let blueHandle: Awaited<ReturnType<typeof provider.create>>;
+    try {
+      blueHandle = await provider.create(config);
+    } catch (err) {
+      return {
+        success: false,
+        oldNodeId,
+        oldContainerName,
+        error: `Blue provision failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+
+    if (!(await provider.checkHealth(blueHandle))) {
+      // Blue never came up. Roll back: tear it down, leave the agent on old.
+      try {
+        await provider.stop(blueHandle.sandboxId);
+      } catch (err) {
+        logger.warn("[agent-sandbox] Failed to tear down unhealthy blue during upgrade rollback", {
+          agentId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
+      return {
+        success: false,
+        oldNodeId,
+        oldContainerName,
+        error: "Blue health check failed; rolled back to old container",
+      };
+    }
+
+    const blueMeta = isDockerSandboxMetadata(blueHandle.metadata) ? blueHandle.metadata : undefined;
+    if (!blueMeta) {
+      try {
+        await provider.stop(blueHandle.sandboxId);
+      } catch (err) {
+        logger.warn(
+          "[agent-sandbox] Failed to tear down blue with non-docker metadata during upgrade rollback",
+          {
+            agentId,
+            err: err instanceof Error ? err.message : String(err),
+          },
+        );
+      }
+      return {
+        success: false,
+        oldNodeId,
+        oldContainerName,
+        error: "Blue provisioner returned non-docker metadata",
+      };
+    }
+
+    try {
+      await agentSandboxesRepository.update(agentId, {
+        sandbox_id: blueHandle.sandboxId,
+        bridge_url: blueHandle.bridgeUrl,
+        health_url: blueHandle.healthUrl,
+        node_id: blueMeta.nodeId,
+        container_name: blueMeta.containerName,
+        bridge_port: blueMeta.bridgePort,
+        web_ui_port: blueMeta.webUiPort,
+        headscale_ip: blueMeta.headscaleIp ?? null,
+        docker_image: blueMeta.dockerImage,
+        // Fall back to the digest the reconciler resolved when it enqueued
+        // this job: blueMeta.imageDigest is null when ghcr.io is intermittently
+        // unreachable at provision time, and a null digest would make the
+        // reconciler re-enqueue this same agent every cycle until the registry
+        // happens to be up at the exact moment of container creation.
+        image_digest: blueMeta.imageDigest ?? toDigest,
+        last_heartbeat_at: new Date(),
+      });
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      logger.error("[agent-sandbox] Atomic swap UPDATE failed; tearing down orphaned blue", {
+        agentId,
+        err: errMsg,
+      });
+      await provider.stop(blueHandle.sandboxId).catch((stopErr) =>
+        logger.warn("[agent-sandbox] Failed to tear down blue after atomic swap UPDATE failure", {
+          agentId,
+          err: stopErr instanceof Error ? stopErr.message : String(stopErr),
+        }),
+      );
+      return {
+        success: false,
+        oldNodeId,
+        oldContainerName,
+        error: `Atomic swap UPDATE failed: ${errMsg}`,
+      };
+    }
+
+    // Old container teardown is best-effort: traffic is already on blue.
+    await provider.stopOnSpecificNode(oldNode, oldContainerName, 30);
+
+    logger.info("[agent-sandbox] Fleet upgrade completed", {
+      agentId,
+      oldNodeId,
+      oldContainerName,
+      newNodeId: blueMeta.nodeId,
+      newContainerName: blueMeta.containerName,
+      newDigest: blueMeta.imageDigest,
+      requestedDigest: toDigest,
+    });
+
+    return {
+      success: true,
+      oldNodeId,
+      oldContainerName,
+      newNodeId: blueMeta.nodeId,
+      newContainerName: blueMeta.containerName,
+      newDigest: blueMeta.imageDigest,
     };
   }
 

--- a/packages/cloud-shared/src/lib/services/provisioning-job-types.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-job-types.ts
@@ -6,6 +6,12 @@ export const JOB_TYPES = {
   AGENT_RESTART: "agent_restart",
   AGENT_LOGS: "agent_logs",
   AGENT_SNAPSHOT: "agent_snapshot",
+  /**
+   * Fleet-upgrade: blue/green swap an agent onto the currently-deployed
+   * image. Enqueued by the reconciler when the registry digest of the
+   * configured tag has moved and the agent is still on the old digest.
+   */
+  AGENT_UPGRADE: "agent_upgrade",
 } as const;
 
 export type ProvisioningJobType = (typeof JOB_TYPES)[keyof typeof JOB_TYPES];

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -66,6 +66,25 @@ export interface AgentRestartJobData {
   userId: string;
 }
 
+export interface AgentUpgradeJobData {
+  agentId: string;
+  organizationId: string;
+  userId: string;
+  /** sha256 the agent is currently on (null if it predates digest tracking). */
+  fromDigest: string | null;
+  /** sha256 the reconciler resolved from the configured tag at enqueue time. */
+  toDigest: string;
+}
+
+export interface AgentUpgradeJobResult {
+  oldNodeId: string;
+  oldContainerName: string;
+  newNodeId: string;
+  newContainerName: string;
+  newDigest: string;
+  durationMs: number;
+}
+
 export interface AgentLogsJobData {
   agentId: string;
   organizationId: string;
@@ -179,6 +198,14 @@ function agentRestartJobResultToRecord(result: AgentRestartJobResult): Record<st
   return { ...result };
 }
 
+function agentUpgradeJobDataToRecord(data: AgentUpgradeJobData): Record<string, unknown> {
+  return { ...data };
+}
+
+function agentUpgradeJobResultToRecord(result: AgentUpgradeJobResult): Record<string, unknown> {
+  return { ...result };
+}
+
 function agentLogsJobDataToRecord(data: AgentLogsJobData): Record<string, unknown> {
   return { ...data };
 }
@@ -277,6 +304,25 @@ function isAgentRestartJobData(value: unknown): value is AgentRestartJobData {
 function readAgentRestartJobData(job: Job): AgentRestartJobData {
   if (!isAgentRestartJobData(job.data)) {
     throw new Error(`Invalid agent restart job data for job ${job.id}`);
+  }
+  return job.data;
+}
+
+function isAgentUpgradeJobData(value: unknown): value is AgentUpgradeJobData {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.agentId === "string" &&
+    typeof v.organizationId === "string" &&
+    typeof v.userId === "string" &&
+    (v.fromDigest === null || typeof v.fromDigest === "string") &&
+    typeof v.toDigest === "string"
+  );
+}
+
+export function readAgentUpgradeJobData(job: Job): AgentUpgradeJobData {
+  if (!isAgentUpgradeJobData(job.data)) {
+    throw new Error(`Invalid agent upgrade job data for job ${job.id}`);
   }
   return job.data;
 }
@@ -718,6 +764,50 @@ export class ProvisioningJobService {
   }
 
   /**
+   * Fleet-upgrade: enqueue a blue/green swap of `agentId` onto `toDigest`.
+   * Called by the reconciler when a registry probe sees the configured tag
+   * has moved. The handler provisions a new container on the least-loaded
+   * node (or autoscales) with the new image, waits for it to be healthy,
+   * atomically swaps the agent's bridge_url / node_id / container_name /
+   * image_digest, then gracefully stops the old container (30s SIGTERM
+   * drain).
+   *
+   * Idempotency: the reconciler's per-agent `agent_upgrade` lookup dedups
+   * before calling this (one pending or in-flight upgrade per agent at a
+   * time). `enqueueLifecycleJob` adds a second layer via the
+   * `active_provision_agent_idx` style guard.
+   */
+  async enqueueAgentUpgradeOnce(params: {
+    agentId: string;
+    organizationId: string;
+    userId: string;
+    fromDigest: string | null;
+    toDigest: string;
+    webhookUrl?: string;
+  }): Promise<{ created: boolean; job: Job }> {
+    return this.enqueueLifecycleJob<AgentUpgradeJobData>({
+      jobType: JOB_TYPES.AGENT_UPGRADE,
+      jobData: {
+        agentId: params.agentId,
+        organizationId: params.organizationId,
+        userId: params.userId,
+        fromDigest: params.fromDigest,
+        toDigest: params.toDigest,
+      },
+      toRecord: agentUpgradeJobDataToRecord,
+      agentId: params.agentId,
+      organizationId: params.organizationId,
+      userId: params.userId,
+      webhookUrl: params.webhookUrl,
+      maxAttempts: 3,
+      // Full provision on a possibly fresh node (~60-90s) + health probe
+      // (~30s) + atomic DB swap + 30s graceful stop = ~3 min budget.
+      estimatedDurationMs: 180_000,
+      logName: "agent_upgrade",
+    });
+  }
+
+  /**
    * Enqueue an Agent logs read job.
    *
    * Daemon-side execution: SSH `docker logs --tail <N>` on the assigned
@@ -1035,6 +1125,9 @@ export class ProvisioningJobService {
       case JOB_TYPES.AGENT_RESTART:
         await this.executeAgentRestart(job);
         break;
+      case JOB_TYPES.AGENT_UPGRADE:
+        await this.executeAgentUpgrade(job);
+        break;
       case JOB_TYPES.AGENT_LOGS:
         await this.executeAgentLogs(job);
         break;
@@ -1195,6 +1288,63 @@ export class ProvisioningJobService {
       agentId: data.agentId,
       containerStopped: result.containerStopped,
       containerStarted: result.containerStarted,
+    });
+  }
+
+  private async executeAgentUpgrade(job: Job): Promise<void> {
+    const data = readAgentUpgradeJobData(job);
+
+    if (data.organizationId !== job.organization_id) {
+      throw new Error(
+        `Organization ID mismatch: job.data.organizationId (${data.organizationId}) !== job.organization_id (${job.organization_id})`,
+      );
+    }
+
+    logger.info("[provisioning-jobs] Executing agent_upgrade", {
+      jobId: job.id,
+      agentId: data.agentId,
+      fromDigest: data.fromDigest,
+      toDigest: data.toDigest,
+    });
+
+    const startedAt = Date.now();
+    const result = await elizaSandboxService.executeUpgrade(
+      data.agentId,
+      data.organizationId,
+      data.toDigest,
+    );
+
+    if (!result.success) {
+      // Failures are visible by the row staying on the OLD image_digest; the
+      // reconciler will try again on the next cycle. The worker's standard
+      // error handling marks the job failed and stores this error message.
+      throw new Error(result.error ?? "Unknown agent_upgrade failure");
+    }
+
+    const jobResult: AgentUpgradeJobResult = {
+      oldNodeId: result.oldNodeId ?? "",
+      oldContainerName: result.oldContainerName ?? "",
+      newNodeId: result.newNodeId ?? "",
+      newContainerName: result.newContainerName ?? "",
+      newDigest: result.newDigest ?? data.toDigest,
+      durationMs: Date.now() - startedAt,
+    };
+
+    await jobsRepository.updateStatus(job.id, "completed", {
+      result: agentUpgradeJobResultToRecord(jobResult),
+      completed_at: new Date(),
+    });
+
+    if (job.webhook_url) {
+      await this.fireWebhook(job, jobResult);
+    }
+
+    logger.info("[provisioning-jobs] agent_upgrade completed", {
+      jobId: job.id,
+      agentId: data.agentId,
+      oldNodeId: jobResult.oldNodeId,
+      newNodeId: jobResult.newNodeId,
+      durationMs: jobResult.durationMs,
     });
   }
 
@@ -1482,7 +1632,8 @@ export class ProvisioningJobService {
       | AgentResumeJobResult
       | AgentRestartJobResult
       | AgentLogsJobResult
-      | AgentSnapshotJobResult,
+      | AgentSnapshotJobResult
+      | AgentUpgradeJobResult,
   ): Promise<void> {
     if (!job.webhook_url) return;
 

--- a/packages/cloud-shared/src/lib/services/sandbox-provider-types.ts
+++ b/packages/cloud-shared/src/lib/services/sandbox-provider-types.ts
@@ -23,4 +23,10 @@ export interface SandboxCreateConfig {
   resources?: { vcpus?: number; memoryMb?: number };
   timeout?: number;
   dockerImage?: string;
+  /**
+   * Skip this node when selecting where to place the new container.
+   * Used by the fleet-upgrade handler to force a blue/green swap onto a
+   * *different* node than the one the agent is currently on.
+   */
+  excludeNodeId?: string;
 }

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -34,6 +34,12 @@ type WorkerContainersEnv =
   typeof import("@elizaos/cloud-shared/lib/config/containers-env").containersEnv;
 type WorkerWarmPoolCreator =
   typeof import("@elizaos/cloud-shared/lib/services/containers/agent-warm-pool-creator").getHetznerPoolContainerCreator;
+type WorkerResolveImageDigest =
+  typeof import("@elizaos/cloud-shared/lib/services/containers/registry-probe").resolveImageDigest;
+type WorkerAgentSandboxesRepository =
+  typeof import("@elizaos/cloud-shared/db/repositories/agent-sandboxes").agentSandboxesRepository;
+type WorkerJobsRepository =
+  typeof import("@elizaos/cloud-shared/db/repositories/jobs").jobsRepository;
 
 interface WorkerDeps {
   logger: WorkerLogger;
@@ -43,6 +49,9 @@ interface WorkerDeps {
   WarmPoolManager: WorkerWarmPoolManager;
   getHetznerPoolContainerCreator: WorkerWarmPoolCreator;
   containersEnv: WorkerContainersEnv;
+  resolveImageDigest: WorkerResolveImageDigest;
+  agentSandboxesRepository: WorkerAgentSandboxesRepository;
+  jobsRepository: WorkerJobsRepository;
 }
 
 export interface ProvisioningWorkerConfig {
@@ -103,6 +112,9 @@ async function loadDeps(): Promise<WorkerDeps> {
         "@elizaos/cloud-shared/lib/services/containers/agent-warm-pool-creator"
       ),
       import("@elizaos/cloud-shared/lib/config/containers-env"),
+      import("@elizaos/cloud-shared/lib/services/containers/registry-probe"),
+      import("@elizaos/cloud-shared/db/repositories/agent-sandboxes"),
+      import("@elizaos/cloud-shared/db/repositories/jobs"),
     ]).then(
       ([
         jobsModule,
@@ -112,6 +124,9 @@ async function loadDeps(): Promise<WorkerDeps> {
         warmPoolModule,
         warmPoolCreatorModule,
         containersEnvModule,
+        registryProbeModule,
+        agentSandboxesModule,
+        jobsRepoModule,
       ]) => ({
         provisioningJobService: jobsModule.provisioningJobService,
         logger: loggerModule.logger,
@@ -121,6 +136,9 @@ async function loadDeps(): Promise<WorkerDeps> {
         getHetznerPoolContainerCreator:
           warmPoolCreatorModule.getHetznerPoolContainerCreator,
         containersEnv: containersEnvModule.containersEnv,
+        resolveImageDigest: registryProbeModule.resolveImageDigest,
+        agentSandboxesRepository: agentSandboxesModule.agentSandboxesRepository,
+        jobsRepository: jobsRepoModule.jobsRepository,
       }),
     );
   }
@@ -301,6 +319,105 @@ async function processNodeAutoscaleCycle(): Promise<NodeAutoscaleSummary> {
   }
 }
 
+interface FleetUpgradeSummary {
+  action: "noop" | "skip_no_digest" | "skip_capacity" | "enqueued";
+  configuredImage?: string;
+  targetDigest?: string | null;
+  candidates?: number;
+  enqueued?: number;
+  inFlight?: number;
+  detail?: string;
+}
+
+const MAX_INFLIGHT_UPGRADES = 3;
+
+/**
+ * Detect when the registry-side digest of the configured agent tag has moved
+ * (e.g. a new `:develop` image was pushed) and enqueue blue/green
+ * `agent_upgrade` jobs for every running agent still on the old digest.
+ *
+ * Rate-limited to at most `MAX_INFLIGHT_UPGRADES` upgrade jobs in flight at
+ * any time so the fleet is never fully disrupted at once. The actual swap is
+ * zero-downtime (a new container is provisioned on a different node, traffic
+ * is atomically swapped, then the old container gets a 30s SIGTERM drain
+ * before removal), so the rate limit is about resource pressure on
+ * docker_nodes (each in-flight swap holds capacity on two nodes briefly),
+ * not user-facing impact.
+ *
+ * Returns "skip_no_digest" when the registry probe can't resolve a digest —
+ * e.g. the operator pinned a non-ghcr image like `eliza-agent:prod-good`, or
+ * the registry is unreachable. The reconciler simply waits for the next tick.
+ */
+async function processFleetUpgradeCycle(): Promise<FleetUpgradeSummary> {
+  const {
+    containersEnv,
+    resolveImageDigest,
+    agentSandboxesRepository,
+    jobsRepository,
+    provisioningJobService,
+  } = await loadDeps();
+
+  const configuredImage = containersEnv.defaultAgentImage();
+  const targetDigest = await resolveImageDigest(configuredImage);
+  if (!targetDigest) {
+    return {
+      action: "skip_no_digest",
+      configuredImage,
+      targetDigest,
+      detail: "registry probe returned null",
+    };
+  }
+
+  const inFlight = await jobsRepository.countInFlightByType("agent_upgrade");
+  const slack = MAX_INFLIGHT_UPGRADES - inFlight;
+  if (slack <= 0) {
+    return {
+      action: "skip_capacity",
+      configuredImage,
+      targetDigest,
+      inFlight,
+    };
+  }
+
+  const candidates =
+    await agentSandboxesRepository.listRunningWithDigestOtherThan(
+      targetDigest,
+      slack,
+    );
+  if (candidates.length === 0) {
+    return { action: "noop", configuredImage, targetDigest, inFlight };
+  }
+
+  const { logger } = await loadDeps();
+  let enqueued = 0;
+  for (const c of candidates) {
+    try {
+      const result = await provisioningJobService.enqueueAgentUpgradeOnce({
+        agentId: c.id,
+        organizationId: c.organization_id,
+        userId: c.user_id,
+        fromDigest: c.image_digest,
+        toDigest: targetDigest,
+      });
+      if (result.created) enqueued += 1;
+    } catch (err) {
+      logger.warn("[provisioning-worker] fleet-upgrade enqueue failed", {
+        agentId: c.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return {
+    action: "enqueued",
+    configuredImage,
+    targetDigest,
+    candidates: candidates.length,
+    enqueued,
+    inFlight,
+  };
+}
+
 /**
  * Drain warm-pool sandboxes that have been idle past their TTL. Replaces the
  * `pool-drain-idle` cron path.
@@ -363,6 +480,25 @@ async function pollCycle(
     }
   } catch (error) {
     logger.error("[provisioning-worker] heartbeat cycle failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  try {
+    const decision = await processFleetUpgradeCycle();
+    if (decision.action !== "noop") {
+      logger.info("[provisioning-worker] fleet upgrade cycle complete", {
+        action: decision.action,
+        configuredImage: decision.configuredImage,
+        targetDigest: decision.targetDigest,
+        candidates: decision.candidates,
+        enqueued: decision.enqueued,
+        inFlight: decision.inFlight,
+        detail: decision.detail,
+      });
+    }
+  } catch (error) {
+    logger.error("[provisioning-worker] fleet upgrade cycle failed", {
       error: error instanceof Error ? error.message : String(error),
     });
   }


### PR DESCRIPTION
## Summary
Wire up a real fleet rollout for cloud agents. When the registry-side digest of the configured agent tag moves, the daemon now enqueues a blue/green \`agent_upgrade\` job per running agent still on the old digest, capped at 3 in flight, and executes them as zero-downtime cross-node swaps.

Today's reality: a new image only reaches the fleet when an agent crashes or someone restarts it manually, so the cluster runs a mix of versions until everyone naturally cycles. The morning of 2026-05-29 had agents on \`develop\` alongside agents on \`eliza-tla:patched\` for that reason.

## How it works
- **Probe**: the reconciler calls \`resolveImageDigest(containersEnv.defaultAgentImage())\` against ghcr.io every 30s. Cached 60s. Null on bare image names, non-ghcr registries, or registry errors — those cycles are no-ops, the agent stays put.
- **Pick a target node**: \`getAvailableNode({ excludeNodeId: currentNode })\`. Different node guarantees no container-name collision (names are deterministic \`agent-\${id}\` per docker daemon). Autoscaler-on-demand path fires automatically if no other node has free capacity.
- **Provision blue + health check**: regular provisioner path with the new image. If it never goes healthy, we tear down blue and bail — the agent keeps running on old with old image. Auto-rollback.
- **Atomic swap**: one UPDATE on \`agent_sandboxes\` (bridge_url, health_url, node_id, container_name, ports, docker_image, image_digest). New HTTP requests hit blue from this point on.
- **Drain + remove old**: \`docker stop -t 30\` SIGTERM (30s drain for in-flight HTTP + websockets), \`docker rm -f\`. Allocated count decremented on the old node.
- **Cleanup**: the autoscaler's existing idle-node drain handles nodes that empty out as agents rebalance.

## Schema
New \`image_digest text\` column on \`agent_sandboxes\`, stamped at provision time. NULL on rows that predate this PR is treated as "differs from target" — first rollout sweeps the existing fleet onto the current digest, after which the registry-vs-stored compare is exact.

Migration 0135, additive, no backfill required.

## Test plan
- [x] 17 unit tests on the registry probe — parsing edge cases (port-in-registry, bare image names, empty tag, malformed), 404 / 5xx / network-error handling, only-ghcr policy, positive + negative caching with TTL expiry verification.
- [x] Smoke test on the job-type registry — \`AGENT_UPGRADE\` is registered and unique.
- [x] \`biome check\` clean on all changed files.
- [x] \`typecheck\` clean for the changed files.
- [ ] Manual end-to-end on staging: push a fresh \`:develop\`, watch the reconciler enqueue + execute 3 swaps per cycle, verify blue boots healthy, swap is atomic, old container gets a SIGTERM drain.

## Out of scope (follow-ups)
- Per-agent opt-out flag (some agents may need to be pinned to a digest).
- Idle-aware scheduling (skip swap when an agent has an active websocket).
- Webhook from \`build-agent-image.yml\` to trigger an immediate rollout rather than waiting for the 30s reconciler tick.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a fleet-upgrade reconciler that detects when the ghcr.io digest of the configured agent tag has moved and performs rolling blue/green swaps across the fleet, capped at 3 concurrent upgrades. It adds a `registry-probe` module for cached digest resolution, a new `AGENT_UPGRADE` job type with full enqueue/execute machinery, `image_digest` stamping on `agent_sandboxes`, and cross-node placement via `excludeNodeId`.

- **`registry-probe.ts`**: 60 s cached HEAD-based digest lookup against ghcr.io only; returns `null` for non-ghcr refs and all error paths; 17 unit tests cover parsing edge cases, HTTP failure modes, cache TTL, and negative caching.
- **`executeUpgrade` in `eliza-sandbox.ts`**: provisions a blue container on a different node, health-checks it, atomically swaps the DB row, then best-effort SIGTERMs the old container; auto-rollback if blue doesn't come up healthy.
- **`processFleetUpgradeCycle` in `provisioning-worker.ts`**: per-tick reconciler that probes the registry, counts in-flight jobs, queries candidates via `IS DISTINCT FROM`, and enqueues up to the remaining capacity slack.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: concurrent stop/suspend/delete can race with an in-flight upgrade and leave an orphaned running container

`hasActiveProvisionJobTx` only queries for `AGENT_PROVISION` jobs, so user-triggered stop, suspend, or delete operations are not blocked while a 60-90 s blue provisioning is in progress. If a stop lands first, the upgrade's unconditional swap UPDATE writes the blue container's coordinates into the stopped row, leaving a running container that receives no traffic and has no automatic cleanup path unless the idle-node autoscaler eventually drains that node. Everything else is solid.

packages/cloud-shared/src/lib/services/eliza-sandbox.ts — specifically `hasActiveProvisionJobTx` and the atomic swap UPDATE in `executeUpgrade`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/cloud-shared/src/lib/services/eliza-sandbox.ts | Adds `executeUpgrade` for blue/green agent swap; lifecycle lock and hasActiveProvisionJobTx guard are missing for AGENT_UPGRADE jobs, enabling orphaned blue containers on concurrent stop/delete |
| packages/scripts/cloud/admin/daemons/provisioning-worker.ts | Adds `processFleetUpgradeCycle` reconciler — sound design, rate-limited, uses registry probe |
| packages/cloud-shared/src/lib/services/containers/registry-probe.ts | New ghcr.io digest probe with 60 s cache, ghcr-only guard, URL-encoded paths — well-structured with comprehensive test coverage |
| packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts | Adds `stopOnSpecificNode` (best-effort drain) and `imageDigest` stamping at provision time |
| packages/cloud-shared/src/lib/services/provisioning-jobs.ts | Adds `AgentUpgradeJobData`, `enqueueAgentUpgradeOnce`, and `executeAgentUpgrade` — consistent with existing job patterns |
| packages/cloud-shared/src/db/repositories/agent-sandboxes.ts | Adds `listRunningWithDigestOtherThan` using IS DISTINCT FROM for null-safe comparison and pool exclusion |
| packages/cloud-shared/src/db/migrations/0135_agent_sandboxes_image_digest.sql | Additive migration: nullable `image_digest text` column with IF NOT EXISTS guard — safe to deploy |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant R as Reconciler (30s tick)
    participant Reg as ghcr.io
    participant DB as agent_sandboxes (DB)
    participant Jobs as jobs table
    participant W as Worker
    participant OldNode as Old Node
    participant NewNode as New Node

    R->>Reg: resolveImageDigest(defaultAgentImage)
    Reg-->>R: targetDigest (sha256:...)
    R->>Jobs: countInFlightByType("agent_upgrade")
    Jobs-->>R: inFlight count
    R->>DB: listRunningWithDigestOtherThan(targetDigest, slack)
    DB-->>R: candidates[]
    R->>Jobs: enqueueAgentUpgradeOnce() per candidate

    W->>Jobs: pick up agent_upgrade job
    W->>DB: findByIdAndOrg (snapshot current state)
    W->>NewNode: "provider.create(excludeNodeId=oldNodeId)"
    NewNode-->>W: blueHandle + metadata
    W->>NewNode: checkHealth(blueHandle)
    alt health check fails
        W->>NewNode: provider.stop(blueHandle) rollback
        W-->>Jobs: mark failed (old container untouched)
    else healthy
        W->>DB: UPDATE agent_sandboxes SET node_id, container_name, bridge_url, image_digest
        Note over W,DB: Atomic swap - new requests hit blue
        W->>OldNode: stopOnSpecificNode(30s SIGTERM drain)
        OldNode-->>W: container removed
        W->>Jobs: mark completed
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts`, line 627-632 ([link](https://github.com/elizaos/eliza/blob/bba2d0185138bef187618b8309291075b77904cc/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts#L627-L632)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Overcommit risk when old-node SSH is unreachable**

   `decrementAllocated` runs unconditionally after the stop/rm attempts, even if both fail (e.g., a network partition to the old node). If the SSH calls throw and the container stays alive, `allocated_count` on the old node is decremented past its real container count. Subsequent scheduling decisions will treat that node as having more free capacity than it actually has, and the next agent provisioned there can exceed the node's actual limits. The autoscaler's idle-drain will eventually reconcile, but the gap can span multiple reconciler cycles on a busy fleet.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["feat(cloud): fleet-upgrade reconciler — ..."](https://github.com/elizaos/eliza/commit/26616f863db648680f7f2e39aa20043b57bd0b34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34576839)</sub>

<!-- /greptile_comment -->