### PR TITLE
fix(shared): alias the remaining branded port/base/url env keys

### DIFF
--- a/packages/shared/src/utils/env.ts
+++ b/packages/shared/src/utils/env.ts
@@ -112,6 +112,17 @@ function buildEnvPairs(
     [prefixed("ALLOWED_HOSTS"), "ELIZA_ALLOWED_HOSTS"],
     [prefixed("ALLOW_NULL_ORIGIN"), "ELIZA_ALLOW_NULL_ORIGIN"],
     [prefixed("DISABLE_AUTO_API_TOKEN"), "ELIZA_DISABLE_AUTO_API_TOKEN"],
+    [prefixed("HOME_PORT"), "ELIZA_HOME_PORT"],
+    [prefixed("GATEWAY_PORT"), "ELIZA_GATEWAY_PORT"],
+    [prefixed("API_BASE"), "ELIZA_API_BASE"],
+    [prefixed("API_BASE_URL"), "ELIZA_API_BASE_URL"],
+    [prefixed("DESKTOP_API_BASE"), "ELIZA_DESKTOP_API_BASE"],
+    [prefixed("DESKTOP_TEST_API_BASE"), "ELIZA_DESKTOP_TEST_API_BASE"],
+    [
+      prefixed("DESKTOP_SKIP_EMBEDDED_AGENT"),
+      "ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT",
+    ],
+    [prefixed("RENDERER_URL"), "ELIZA_RENDERER_URL"],
     [
       prefixed("TASK_AGENT_AUTH_TRUSTED_HOSTS"),
       "ELIZA_TASK_AGENT_AUTH_TRUSTED_HOSTS",


### PR DESCRIPTION
## What

`buildEnvPairs()` in `packages/shared/src/utils/env.ts` mirrors `<BRAND>_*` env vars onto their `ELIZA_*` equivalents (via `syncElizaEnvAliases`). It was missing 8 keys that downstream brands (e.g. Milady) document as part of the port/connection contract:

- `<BRAND>_HOME_PORT` → `ELIZA_HOME_PORT`
- `<BRAND>_GATEWAY_PORT` → `ELIZA_GATEWAY_PORT`
- `<BRAND>_API_BASE` → `ELIZA_API_BASE`
- `<BRAND>_API_BASE_URL` → `ELIZA_API_BASE_URL`
- `<BRAND>_DESKTOP_API_BASE` → `ELIZA_DESKTOP_API_BASE`
- `<BRAND>_DESKTOP_TEST_API_BASE` → `ELIZA_DESKTOP_TEST_API_BASE`
- `<BRAND>_DESKTOP_SKIP_EMBEDDED_AGENT` → `ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT`
- `<BRAND>_RENDERER_URL` → `ELIZA_RENDERER_URL`

## Why

Runtime resolvers (`resolveDesktopApiPort`, renderer apiBase, etc.) read only the `ELIZA_*` form. A consumer that set the branded form per the documented contract had these keys **silently dropped** at runtime, while `API_PORT`/`PORT` already aliased. This adds the missing pairs so the branded alias contract is honored consistently.

## Risk

Additive only — new entries in the alias table, no behavior change for existing keys. Generic across any `brandedPrefix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds 8 missing branded-prefix → `ELIZA_*` env key aliases to `buildEnvPairs()` in `packages/shared/src/utils/env.ts`. The existing alias loop already guarded writes with `env[to] === undefined`, so the new entries slot in safely without touching existing behavior.

- Adds aliases for `HOME_PORT`, `GATEWAY_PORT`, `API_BASE`, `API_BASE_URL`, `DESKTOP_API_BASE`, `DESKTOP_TEST_API_BASE`, `DESKTOP_SKIP_EMBEDDED_AGENT`, and `RENDERER_URL` — keys that downstream brands documented but that were silently dropped at runtime.
- The change is purely additive; no existing alias pairs are modified or reordered.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive only and cannot regress any existing alias resolution.

The alias loop already guards every write with `env[to] === undefined`, so the new entries can never overwrite a value that was explicitly set. All 8 new pairs follow the identical pattern used by the existing entries, and the target `ELIZA_*` keys are distinct from each other and from all pre-existing targets.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/utils/env.ts | Adds 8 new branded-to-ELIZA alias pairs to buildEnvPairs(); purely additive, no logic changes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["syncElizaEnvAliases(options)"] --> B["normalizeBrandedPrefix(options.brandedPrefix)"]
    B --> C["buildEnvPairs(brandedPrefix)"]
    C --> D["for each [from, to] pair"]
    D --> E{"env[to] === undefined\nAND env[from] !== undefined?"}
    E -- Yes --> F["env[to] = env[from]"]
    E -- No --> G["skip (no overwrite)"]
    F --> H["ELIZA_* var is set"]

    subgraph "New pairs added (PR #8052)"
        P1["BRAND_HOME_PORT → ELIZA_HOME_PORT"]
        P2["BRAND_GATEWAY_PORT → ELIZA_GATEWAY_PORT"]
        P3["BRAND_API_BASE → ELIZA_API_BASE"]
        P4["BRAND_API_BASE_URL → ELIZA_API_BASE_URL"]
        P5["BRAND_DESKTOP_API_BASE → ELIZA_DESKTOP_API_BASE"]
        P6["BRAND_DESKTOP_TEST_API_BASE → ELIZA_DESKTOP_TEST_API_BASE"]
        P7["BRAND_DESKTOP_SKIP_EMBEDDED_AGENT → ELIZA_DESKTOP_SKIP_EMBEDDED_AGENT"]
        P8["BRAND_RENDERER_URL → ELIZA_RENDERER_URL"]
    end

    C --> P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(shared): alias the remaining branded..."](https://github.com/elizaos/eliza/commit/adbd44374eed6c6e0305d90cb8373bed0c9dbab1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34627912)</sub>

<!-- /greptile_comment -->