### PR TITLE
fix(app-core): delegate dev-stack uiPort to resolveDesktopUiPort

### DIFF
--- a/packages/app-core/src/api/dev-stack.ts
+++ b/packages/app-core/src/api/dev-stack.ts
@@ -47,12 +47,6 @@ export type DevStackPayload = {
   hints: string[];
 };
 
-function parsePositivePort(raw: string | undefined): number | null {
-  if (raw == null || raw === "") return null;
-  const n = Number(raw);
-  return Number.isFinite(n) && n > 0 && n < 65536 ? n : null;
-}
-
 /**
  * Build the JSON body for `GET /api/dev/stack`.
  */
@@ -60,10 +54,10 @@ export function resolveDevStackFromEnv(
   env: NodeJS.ProcessEnv = process.env,
 ): DevStackPayload {
   const apiPort = resolveDesktopApiPort(env);
-  const uiPort =
-    parsePositivePort(env.ELIZA_UI_PORT) ??
-    parsePositivePort(env.ELIZA_PORT) ??
-    resolveDesktopUiPort(env);
+  // Delegate to the canonical UI-port resolver so /api/dev/stack reports the
+  // same uiPort clients actually use. The previous inline ELIZA_PORT fallback
+  // conflated the server/API-only port with the UI port.
+  const uiPort = resolveDesktopUiPort(env);
 
   const rendererUrl = env.ELIZA_RENDERER_URL?.trim() || null;
   const desktopApiBase = env.ELIZA_DESKTOP_API_BASE?.trim() || null;


### PR DESCRIPTION
## What

`resolveDevStackFromEnv` (`GET /api/dev/stack`) computed `uiPort` inline:
```
parsePositivePort(env.ELIZA_UI_PORT) ?? parsePositivePort(env.ELIZA_PORT) ?? resolveDesktopUiPort(env)
```
The extra `ELIZA_PORT` branch doesn't exist in the canonical `resolveDesktopUiPort`.

## Why

`ELIZA_PORT` is the server/API-only port in the desktop split, not the UI port. So the discovery endpoint could report a `uiPort` that **differs from what UI clients actually resolve**, pointing tools/agents that consume `/api/dev/stack` at the wrong renderer port. This delegates to `resolveDesktopUiPort(env)` so the payload matches the resolver clients use, and removes the now-unused `parsePositivePort` helper.

## Risk

Low — single source of truth for the UI port; only removes the spurious `ELIZA_PORT` conflation. `ELIZA_UI_PORT` handling is preserved (it's inside `resolveDesktopUiPort`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a single-source-of-truth bug in `resolveDevStackFromEnv`: the old inline `uiPort` computation included an `ELIZA_PORT` fallback that conflated the server/API-only port with the UI port, causing `/api/dev/stack` to potentially report a different `uiPort` than what UI clients actually resolve. The fix delegates unconditionally to `resolveDesktopUiPort(env)` and removes the now-unused local `parsePositivePort` helper.

- **Bug fixed**: `ELIZA_PORT` (API port) was used as a fallback for `uiPort` in the dev-stack payload, meaning tools/agents consuming the endpoint could be pointed at the wrong renderer port when `ELIZA_PORT` was set and `ELIZA_UI_PORT` was not.
- **Cleanup**: The local `parsePositivePort` duplicate (which also had a subtle `isFinite` vs `isInteger` discrepancy vs the canonical version in `@elizaos/shared`) is removed entirely.
- **Stale comment**: The JSDoc on `desktop.uiPort` still says "when ELIZA_PORT is set" and should be updated to reference `ELIZA_UI_PORT`.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a focused, correct fix with no new logic introduced.

The change replaces an inline three-part fallback with a single call to the canonical resolver, eliminating the ELIZA_PORT/UI port confusion. The only finding is a stale JSDoc that still references ELIZA_PORT. The fix aligns resolveDevStackFromEnv with every other place in the codebase that resolves the UI port, and the removed local parsePositivePort is a duplicate that also had a minor behavioural difference (isFinite vs isInteger). Risk of regression is very low.

No files require special attention beyond the minor JSDoc update on the uiPort field.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/app-core/src/api/dev-stack.ts | Removes local parsePositivePort helper and delegates uiPort resolution entirely to resolveDesktopUiPort(env); the JSDoc on the uiPort field still references ELIZA_PORT and should be updated. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as Tool / Agent
    participant API as GET /api/dev/stack
    participant Resolver as resolveDevStackFromEnv
    participant UiPort as resolveDesktopUiPort
    participant UiClients as UI Clients

    Note over Resolver,UiClients: Before (buggy)
    Client->>API: GET /api/dev/stack
    API->>Resolver: resolveDevStackFromEnv(env)
    Resolver->>Resolver: "uiPort = ELIZA_UI_PORT ?? ELIZA_PORT ?? resolveDesktopUiPort()"
    Note right of Resolver: ELIZA_PORT is API-only — wrong uiPort when set
    Resolver-->>Client: "{ uiPort: wrong port }"
    UiClients->>UiPort: resolveDesktopUiPort(env)
    UiPort-->>UiClients: ELIZA_UI_PORT ?? DEFAULT_DESKTOP_UI_PORT
    Note over Client,UiClients: Client and UI resolve different ports!

    Note over Resolver,UiClients: After (fixed)
    Client->>API: GET /api/dev/stack
    API->>Resolver: resolveDevStackFromEnv(env)
    Resolver->>UiPort: resolveDesktopUiPort(env)
    UiPort-->>Resolver: ELIZA_UI_PORT ?? DEFAULT_DESKTOP_UI_PORT
    Resolver-->>Client: "{ uiPort: correct port }"
    UiClients->>UiPort: resolveDesktopUiPort(env)
    UiPort-->>UiClients: ELIZA_UI_PORT ?? DEFAULT_DESKTOP_UI_PORT
    Note over Client,UiClients: Client and UI resolve the same port ✓
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app-core/src/api/dev-stack.ts`, line 29-30 ([link](https://github.com/elizaos/eliza/blob/32b4eb4945a7495dd016eb9058ea4d7f96ae3129/packages/app-core/src/api/dev-stack.ts#L29-L30)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The JSDoc for `uiPort` still says "when ELIZA_PORT is set", but after this change `ELIZA_PORT` no longer influences `uiPort` at all — only `ELIZA_UI_PORT` (via `resolveDesktopUiPort`) does. The stale reference will mislead anyone reading the type definition.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp-core%2Fsrc%2Fapi%2Fdev-stack.ts%0ALine%3A%2029-30%0A%0AComment%3A%0AThe%20JSDoc%20for%20%60uiPort%60%20still%20says%20%22when%20ELIZA_PORT%20is%20set%22%2C%20but%20after%20this%20change%20%60ELIZA_PORT%60%20no%20longer%20influences%20%60uiPort%60%20at%20all%20%E2%80%94%20only%20%60ELIZA_UI_PORT%60%20%28via%20%60resolveDesktopUiPort%60%29%20does.%20The%20stale%20reference%20will%20mislead%20anyone%20reading%20the%20type%20definition.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F**%20Dashboard%20UI%20port%20from%20ELIZA_UI_PORT%20%28desktop%20%2F%20Vite%29.%20*%2F%0A%20%20%20%20uiPort%3A%20number%20%7C%20null%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=elizaos%2Feliza&pr=8053&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22fix%2Fdev-stack-uiport-delegate%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fdev-stack-uiport-delegate%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp-core%2Fsrc%2Fapi%2Fdev-stack.ts%0ALine%3A%2029-30%0A%0AComment%3A%0AThe%20JSDoc%20for%20%60uiPort%60%20still%20says%20%22when%20ELIZA_PORT%20is%20set%22%2C%20but%20after%20this%20change%20%60ELIZA_PORT%60%20no%20longer%20influences%20%60uiPort%60%20at%20all%20%E2%80%94%20only%20%60ELIZA_UI_PORT%60%20%28via%20%60resolveDesktopUiPort%60%29%20does.%20The%20stale%20reference%20will%20mislead%20anyone%20reading%20the%20type%20definition.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F**%20Dashboard%20UI%20port%20from%20ELIZA_UI_PORT%20%28desktop%20%2F%20Vite%29.%20*%2F%0A%20%20%20%20uiPort%3A%20number%20%7C%20null%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fapp-core%2Fsrc%2Fapi%2Fdev-stack.ts%0ALine%3A%2029-30%0A%0AComment%3A%0AThe%20JSDoc%20for%20%60uiPort%60%20still%20says%20%22when%20ELIZA_PORT%20is%20set%22%2C%20but%20after%20this%20change%20%60ELIZA_PORT%60%20no%20longer%20influences%20%60uiPort%60%20at%20all%20%E2%80%94%20only%20%60ELIZA_UI_PORT%60%20%28via%20%60resolveDesktopUiPort%60%29%20does.%20The%20stale%20reference%20will%20mislead%20anyone%20reading%20the%20type%20definition.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F**%20Dashboard%20UI%20port%20from%20ELIZA_UI_PORT%20%28desktop%20%2F%20Vite%29.%20*%2F%0A%20%20%20%20uiPort%3A%20number%20%7C%20null%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=8053&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp-core%2Fsrc%2Fapi%2Fdev-stack.ts%3A29-30%0AThe%20JSDoc%20for%20%60uiPort%60%20still%20says%20%22when%20ELIZA_PORT%20is%20set%22%2C%20but%20after%20this%20change%20%60ELIZA_PORT%60%20no%20longer%20influences%20%60uiPort%60%20at%20all%20%E2%80%94%20only%20%60ELIZA_UI_PORT%60%20%28via%20%60resolveDesktopUiPort%60%29%20does.%20The%20stale%20reference%20will%20mislead%20anyone%20reading%20the%20type%20definition.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F**%20Dashboard%20UI%20port%20from%20ELIZA_UI_PORT%20%28desktop%20%2F%20Vite%29.%20*%2F%0A%20%20%20%20uiPort%3A%20number%20%7C%20null%3B%0A%60%60%60%0A%0A&repo=elizaos%2Feliza&pr=8053&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22fix%2Fdev-stack-uiport-delegate%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fdev-stack-uiport-delegate%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp-core%2Fsrc%2Fapi%2Fdev-stack.ts%3A29-30%0AThe%20JSDoc%20for%20%60uiPort%60%20still%20says%20%22when%20ELIZA_PORT%20is%20set%22%2C%20but%20after%20this%20change%20%60ELIZA_PORT%60%20no%20longer%20influences%20%60uiPort%60%20at%20all%20%E2%80%94%20only%20%60ELIZA_UI_PORT%60%20%28via%20%60resolveDesktopUiPort%60%29%20does.%20The%20stale%20reference%20will%20mislead%20anyone%20reading%20the%20type%20definition.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F**%20Dashboard%20UI%20port%20from%20ELIZA_UI_PORT%20%28desktop%20%2F%20Vite%29.%20*%2F%0A%20%20%20%20uiPort%3A%20number%20%7C%20null%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fapp-core%2Fsrc%2Fapi%2Fdev-stack.ts%3A29-30%0AThe%20JSDoc%20for%20%60uiPort%60%20still%20says%20%22when%20ELIZA_PORT%20is%20set%22%2C%20but%20after%20this%20change%20%60ELIZA_PORT%60%20no%20longer%20influences%20%60uiPort%60%20at%20all%20%E2%80%94%20only%20%60ELIZA_UI_PORT%60%20%28via%20%60resolveDesktopUiPort%60%29%20does.%20The%20stale%20reference%20will%20mislead%20anyone%20reading%20the%20type%20definition.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F**%20Dashboard%20UI%20port%20from%20ELIZA_UI_PORT%20%28desktop%20%2F%20Vite%29.%20*%2F%0A%20%20%20%20uiPort%3A%20number%20%7C%20null%3B%0A%60%60%60%0A%0A&pr=8053&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(app-core): delegate dev-stack uiPort..."](https://github.com/elizaos/eliza/commit/32b4eb4945a7495dd016eb9058ea4d7f96ae3129) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34629886)</sub>

<!-- /greptile_comment -->