### PR TITLE
fix(mobile): derive local-agent loopback port from DEFAULT_DESKTOP_API_PORT

### DIFF
--- a/packages/app-core/src/api/ios-local-agent-transport.ts
+++ b/packages/app-core/src/api/ios-local-agent-transport.ts
@@ -9,6 +9,7 @@ import { isStoreBuild } from "@elizaos/ui/build-variant";
 import {
   isMobileLocalAgentUrl as isConfiguredMobileLocalAgentUrl,
   isMobileLocalAgentIpcUrl,
+  MOBILE_LOCAL_AGENT_PORT,
   mobileLocalAgentPathFromUrl,
 } from "@elizaos/ui/first-run/mobile-runtime-mode";
 
@@ -239,7 +240,7 @@ function isLoopbackLocalAgentUrl(value: string): boolean {
     const hostname = parsed.hostname || "";
     return (
       parsed.protocol === "http:" &&
-      parsed.port === "31337" &&
+      parsed.port === MOBILE_LOCAL_AGENT_PORT &&
       (hostname === "127.0.0.1" ||
         hostname.startsWith("127.") ||
         hostname === "localhost" ||

--- a/packages/ui/src/first-run/mobile-runtime-mode.ts
+++ b/packages/ui/src/first-run/mobile-runtime-mode.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_DESKTOP_API_PORT } from "@elizaos/shared";
 import { dispatchAppEvent, MOBILE_RUNTIME_MODE_CHANGED_EVENT } from "../events";
 import type { FirstRunRuntimeTarget } from "./runtime-target";
 
@@ -12,12 +13,12 @@ export const MOBILE_RUNTIME_MODE_STORAGE_KEY = "eliza:mobile-runtime-mode";
  * Android service implementation detail used by the current native bridge
  * and simulator harness until the route kernel moves behind Binder/stdio IPC.
  */
-export const MOBILE_LOCAL_AGENT_API_BASE = "http://127.0.0.1:31337";
+export const MOBILE_LOCAL_AGENT_API_BASE = `http://127.0.0.1:${DEFAULT_DESKTOP_API_PORT}`;
 export const MOBILE_LOCAL_AGENT_IPC_BASE = "eliza-local-agent://ipc";
 export const IOS_LOCAL_AGENT_IPC_BASE = MOBILE_LOCAL_AGENT_IPC_BASE;
 export const MOBILE_LOCAL_AGENT_SERVER_ID = "local:mobile";
 export const MOBILE_LOCAL_AGENT_LABEL = "On-device agent";
-export const MOBILE_LOCAL_AGENT_PORT = "31337";
+export const MOBILE_LOCAL_AGENT_PORT = String(DEFAULT_DESKTOP_API_PORT);
 
 export const ANDROID_LOCAL_AGENT_API_BASE = MOBILE_LOCAL_AGENT_API_BASE;
 export const ANDROID_LOCAL_AGENT_IPC_BASE = MOBILE_LOCAL_AGENT_IPC_BASE;


### PR DESCRIPTION
## What

The mobile on-device agent loopback hardcoded `31337` in three places:
- `MOBILE_LOCAL_AGENT_API_BASE = "http://127.0.0.1:31337"`
- `MOBILE_LOCAL_AGENT_PORT = "31337"`
- `isLoopbackLocalAgentUrl`'s `parsed.port === "31337"` string guard (ios-local-agent-transport)

Now all derive from `@elizaos/shared`'s `DEFAULT_DESKTOP_API_PORT`, and the iOS guard compares against `MOBILE_LOCAL_AGENT_PORT`.

## Why

If the on-device agent ever binds a non-31337 port (collision, API-port override), the WebView dialed the wrong port and the loopback guard misclassified the URL. One constant now moves all mobile loopback wiring, matching the rest of the port-resolution contract.

## Risk

Low — `DEFAULT_DESKTOP_API_PORT` is `31337`, so behavior is identical today; this just removes the duplicated literals. `packages/ui` already depends on `@elizaos/shared`, and the iOS transport already imports from `mobile-runtime-mode`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR removes three hard-coded `31337` port literals from the mobile loopback path and replaces them with expressions derived from `DEFAULT_DESKTOP_API_PORT` in `@elizaos/shared`, so that the iOS transport guard and the `MOBILE_LOCAL_AGENT_*` constants all move together when the port changes.

- `mobile-runtime-mode.ts`: `MOBILE_LOCAL_AGENT_API_BASE` and `MOBILE_LOCAL_AGENT_PORT` now use `DEFAULT_DESKTOP_API_PORT` (a `number`), with `String()` cast for the port constant used in `URL.port` string comparisons.
- `ios-local-agent-transport.ts`: `isLoopbackLocalAgentUrl` imports and uses `MOBILE_LOCAL_AGENT_PORT` instead of an inline `\"31337\"` literal.
- Two related hardcoded `31337` values remain in `voice-readiness.ts` and `probe-local-agent.ts` and were not addressed by this PR.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the effective port value is unchanged today and all three previously-literal sites now track the shared constant correctly.

The two changed files are minimal and mechanically correct: DEFAULT_DESKTOP_API_PORT is 31337 (a number), the String() cast produces the right type for URL.port comparisons, and the template literal builds the same URL as before. Two related hardcoded 31337 values in voice-readiness.ts and probe-local-agent.ts were not included in this PR and would still dial the wrong port in a hypothetical port-override scenario.

packages/ui/src/first-run/voice-readiness.ts and packages/ui/src/first-run/probe-local-agent.ts still contain hardcoded port literals that weren't addressed here.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/ui/src/first-run/mobile-runtime-mode.ts | Replaces the two hardcoded "31337" literals with expressions derived from DEFAULT_DESKTOP_API_PORT; logic and exports are unchanged. |
| packages/app-core/src/api/ios-local-agent-transport.ts | Imports MOBILE_LOCAL_AGENT_PORT and uses it in isLoopbackLocalAgentUrl instead of the inline "31337" string literal; no behavioural change today. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["DEFAULT_DESKTOP_API_PORT (number 31337)\n@elizaos/shared"] --> B["MOBILE_LOCAL_AGENT_PORT\nString(DEFAULT_DESKTOP_API_PORT)"]
    A --> C["MOBILE_LOCAL_AGENT_API_BASE\nhttp://127.0.0.1:PORT"]
    B --> D["isMobileLocalAgentUrl"]
    B --> E["mobileLocalAgentPathFromUrl"]
    B --> F["isLoopbackLocalAgentUrl\nios-local-agent-transport.ts"]
    C --> G["ANDROID_LOCAL_AGENT_API_BASE"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mobile): derive the local-agent loop..."](https://github.com/elizaos/eliza/commit/7c0b4faf096d44398c2693c857f372d34957b210) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34632015)</sub>

<!-- /greptile_comment -->