### PR TITLE
fix(test): resolve @elizaos/shared subpath imports in vitest workspace aliases

### DIFF
--- a/packages/test/vitest/workspace-aliases.ts
+++ b/packages/test/vitest/workspace-aliases.ts
@@ -343,6 +343,14 @@ export function getSharedSourceAliases(
 
   return [
     ...getWorkspacePackageExportAliases("shared", packageRoot),
+    {
+      // Subpath imports (e.g. @elizaos/shared/contracts/first-run-options) must
+      // map to source files; without this the bare-string alias below
+      // prefix-replaces them into "<src>/index.ts/<subpath>" -> ENOTDIR.
+      // Mirrors the agent/app-core/ui subpath aliases above.
+      find: /^@elizaos\/shared\/(.+)$/,
+      replacement: path.join(sourceRoot, "$1"),
+    },
     ...getPackageSourceAliases("shared", sourceRoot, {
       includeElizaAlias: options.includeElizaAlias,
       rootReplacement: path.join(sourceRoot, "index.ts"),


### PR DESCRIPTION
## What
`getSharedSourceAliases()` in `packages/test/vitest/workspace-aliases.ts` only had the **bare-string** alias `find: '@elizaos/shared'`. `@rollup/plugin-alias` prefix-replaces bare strings, so a subpath import like `@elizaos/shared/contracts/first-run-options` was rewritten to `<src>/index.ts/contracts/first-run-options` → **ENOTDIR**, breaking the Server Tests suites that import shared subpaths.

## Fix
Add the subpath regex `{ find: /^@elizaos\/shared\/(.+)$/, replacement: <sourceRoot>/$1 }` **before** the bare source-alias entry — exactly mirroring the existing `agent`, `app-core`, and `ui` source-alias blocks in the same file.

## Risk
Minimal — additive alias, scoped to test resolution; the bare `@elizaos/shared` exact import still resolves via the existing entry. Matches the established sibling pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a broken test-time module resolution for `@elizaos/shared` subpath imports (e.g. `@elizaos/shared/contracts/first-run-options`) by inserting a regex alias before the bare-string alias in `getSharedSourceAliases`. Without it, Vite's string alias performs prefix replacement, turning subpath imports into invalid paths like `<src>/index.ts/<subpath>` that trigger ENOTDIR.

- Adds `{ find: /^@elizaos\\/shared\\/(.+)$/, replacement: path.join(sourceRoot, \"$1\") }` immediately after `getWorkspacePackageExportAliases` and before `getPackageSourceAliases`, consistent with the ordering used by `getAppCoreSourceAliases` and `getUiSourceAliases`.
- The change is purely additive and scoped to test-time alias resolution; the existing bare-string `@elizaos/shared` alias for the root import remains in place and unaffected.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive, test-scoped, and consistent with the existing sibling alias pattern.

The fix inserts a single, well-understood regex alias that exactly mirrors what getAppCoreSourceAliases and getUiSourceAliases already do. The ordering is correct (workspace export aliases first, subpath regex second, bare exact-match last), so no existing resolution paths are disturbed. There is no risk of production impact since these aliases only affect Vitest test runs.

No files require special attention — the single changed file is a test utility and the change is minimal.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/test/vitest/workspace-aliases.ts | Adds a regex subpath alias for `@elizaos/shared` before the bare-string alias in `getSharedSourceAliases`, mirroring the existing `app-core` and `ui` patterns to prevent ENOTDIR resolution errors on subpath imports. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Import: @elizaos/shared/subpath"] --> B["getWorkspacePackageExportAliases"]
    B -- "exact export found" --> C["Resolved via package.json export"]
    B -- "no match" --> D["NEW regex alias for subpaths"]
    D -- "subpath captured" --> E["Resolved: sourceRoot/subpath"]
    D -- "bare root import only" --> F["bare-string alias: @elizaos/shared"]
    F --> H["Resolved: sourceRoot/index.ts"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(test): map @elizaos/shared subpath i..."](https://github.com/elizaos/eliza/commit/05cb18d5370ef7eff1fbe4299b7a7d661e680229) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34642284)</sub>

<!-- /greptile_comment -->