### PR TITLE
fix(vault): add eliza-source export condition so it resolves from source

### DIFF
--- a/packages/vault/package.json
+++ b/packages/vault/package.json
@@ -27,6 +27,11 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "eliza-source": {
+        "types": "./src/index.ts",
+        "import": "./src/index.ts",
+        "default": "./src/index.ts"
+      },
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
@@ -34,6 +39,11 @@
     "./*.css": "./dist/*.css",
     "./*": {
       "types": "./dist/*.d.ts",
+      "eliza-source": {
+        "types": "./src/*.ts",
+        "import": "./src/*.ts",
+        "default": "./src/*.ts"
+      },
       "import": "./dist/*.js",
       "default": "./dist/*.js"
     }


### PR DESCRIPTION
## What
`@elizaos/vault`'s `package.json` `exports` only mapped to `./dist/*`, unlike every other workspace package (`@elizaos/core`, `@elizaos/shared`, …) which expose an **`eliza-source`** condition pointing at `./src`.

The monorepo resolves workspace packages under the **`eliza-source`** condition in dev/test (e.g. the scenario-runner). vault was the only package lacking it, so it could not resolve without a prior `dist` build — producing `Cannot find module '@elizaos/vault'` from `plugin-browser/src/actions/browser-autofill-login.ts` in the **Zero-Key Deterministic E2E**.

## Fix
Add the `eliza-source` condition to `.` and `./*` pointing at `./src` (and `./src/*.ts`), matching `@elizaos/core` / `@elizaos/shared`. **Additive** — `default`/`dist` resolution is unchanged for normal consumers.

## Verification (local)
`bun --conditions eliza-source` now resolves `@elizaos/vault` → `packages/vault/src/index.ts` from `plugin-browser` (previously failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds the `eliza-source` custom export condition to `packages/vault/package.json`, enabling the monorepo's dev/test tooling (e.g. scenario-runner with `bun --conditions eliza-source`) to resolve `@elizaos/vault` directly from `./src` without requiring a prior `dist` build.

- Adds `eliza-source` sub-conditions to both the `.` (root) and `./*` (wildcard) export entries, pointing at `./src/index.ts` and `./src/*.ts` — exactly matching the pattern in `@elizaos/core` and `@elizaos/shared`.
- The change is purely additive: the `types`, `import`, and `default` entries that map to `./dist` are unchanged, so published consumers and CI builds that don't use the `eliza-source` condition are unaffected.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive and does not alter any existing resolution paths.

The only modified file is `packages/vault/package.json`. The new `eliza-source` entries are inserted before the existing `import`/`default` entries (correct condition ordering), target files that are confirmed to exist in `./src`, and mirror the identical structure already in use by `@elizaos/core`. No logic, runtime behaviour, or published output is changed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/vault/package.json | Adds `eliza-source` export condition to `.` and `./*` entries, pointing at `./src/index.ts` and `./src/*.ts` respectively — matching the pattern used by `@elizaos/core` and other workspace packages. Purely additive; existing `dist`-based resolution is untouched. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Import @elizaos/vault] --> B{Export condition?}
    B -->|eliza-source| C[./src/index.ts\nDev / E2E / scenario-runner]
    B -->|node / browser / default| D[./dist/index.js\nPublished / CI / runtime]
    C --> E[TypeScript source\nno build needed]
    D --> F[Compiled JS\nrequires dist build]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(vault): add eliza-source export cond..."](https://github.com/elizaos/eliza/commit/421f3a6974270e7feee526aba6d01cc5f3a5834b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34654401)</sub>

<!-- /greptile_comment -->