### PR TITLE
fix(catalog): restore DFlash drafter companions (findable, not published)

### DIFF
--- a/packages/shared/src/local-inference/catalog.ts
+++ b/packages/shared/src/local-inference/catalog.ts
@@ -573,6 +573,66 @@ function blurbForTier(id: Eliza1TierId): string {
   return exhaustive;
 }
 
+const drafterId = (id: Eliza1TierId): `${Eliza1TierId}-drafter` =>
+  `${id}-drafter`;
+
+// DFlash speculative-decoding draft companions published under each tier's
+// HuggingFace bundle (elizaos/eliza-1 -> bundles/<slug>/dflash/drafter-<slug>.gguf).
+// Sizes are the published gguf byte sizes verified against the HF repo (2026-05);
+// params/minRamGb are companion metadata (these are hidden, runtimeRole-gated).
+const TIER_DRAFTERS: Partial<
+  Record<
+    Eliza1TierId,
+    {
+      ggufRel: string;
+      params: CatalogModel["params"];
+      sizeGb: number;
+      minRamGb: number;
+      bucket: CatalogModel["bucket"];
+    }
+  >
+> = {
+  "eliza-1-0_8b": {
+    ggufRel: "dflash/drafter-0_8b.gguf",
+    params: "0.5B",
+    sizeGb: 0.24,
+    minRamGb: 2,
+    bucket: "small",
+  },
+  "eliza-1-2b": {
+    ggufRel: "dflash/drafter-2b.gguf",
+    params: "0.8B",
+    sizeGb: 0.68,
+    minRamGb: 4,
+    bucket: "small",
+  },
+};
+
+function drafterCompanion(id: Eliza1TierId): CatalogModel {
+  const drafter = TIER_DRAFTERS[id];
+  if (!drafter) {
+    throw new Error(`No DFlash drafter spec for tier ${id}`);
+  }
+  return {
+    id: drafterId(id),
+    displayName: `${tierDisplayName(id)} drafter`,
+    hfRepo: ELIZA_1_HF_REPO,
+    hfPathPrefix: bundleRemotePrefix(id),
+    ggufFile: bundlePath(id, drafter.ggufRel),
+    params: drafter.params,
+    quant: "Eliza-1 DFlash drafter companion",
+    sizeGb: drafter.sizeGb,
+    minRamGb: drafter.minRamGb,
+    category: "chat",
+    bucket: drafter.bucket,
+    tokenizerFamily: "qwen35",
+    hiddenFromCatalog: true,
+    runtimeRole: "mtp-drafter",
+    companionForModelId: id,
+    blurb: "DFlash speculative-decoding draft companion.",
+  };
+}
+
 function chatTier(id: Eliza1TierId): CatalogModel {
   const spec = TIER_SPECS[id];
   return {
@@ -609,8 +669,19 @@ export const MODEL_CATALOG: CatalogModel[] = ELIZA_1_TIER_IDS.map((id) =>
   chatTier(id),
 );
 
+// DFlash speculative-decoding drafter companions. Findable by id (installer
+// companion download + registry self-heal via findCatalogModel) but
+// intentionally NOT part of the published hub catalog (MODEL_CATALOG) — they are
+// hidden, mtp-drafter companion entries keyed to their parent tier.
+const DRAFTER_COMPANIONS: CatalogModel[] = ELIZA_1_TIER_IDS.filter(
+  (id) => TIER_DRAFTERS[id],
+).map((id) => drafterCompanion(id));
+
 export function findCatalogModel(id: string): CatalogModel | undefined {
-  return MODEL_CATALOG.find((m) => m.id === id);
+  return (
+    MODEL_CATALOG.find((m) => m.id === id) ??
+    DRAFTER_COMPANIONS.find((m) => m.id === id)
+  );
 }
 
 export function buildHuggingFaceResolveUrlForPath(


### PR DESCRIPTION
## What
The 2B/0.8B speculative-decoding **DFlash draft companions** (`eliza-1-2b-drafter`, `eliza-1-0_8b-drafter`) were dropped from the catalog in a refactor, but the `registry`/`readiness` self-heal tests and the installer still require them findable via `findCatalogModel`. Verified on HuggingFace `elizaos/eliza-1`:

- `bundles/2b/dflash/drafter-2b.gguf` — 679,630,464 B (sha256 `a7fcb5b3…`)
- `bundles/0_8b/dflash/drafter-0_8b.gguf` — 237,637,024 B

## Fix
Restore via a `drafterCompanion()` builder + `TIER_DRAFTERS` map (HF-verified `ggufFile` + byte sizes) as **hidden `mtp-drafter` companions** keyed to their parent tier (`companionForModelId`). They live in a separate `DRAFTER_COMPANIONS` list that `findCatalogModel()` searches, but are intentionally **NOT** in the published `MODEL_CATALOG` hub — satisfying both contracts: "drafter is findable (self-heal)" and "no external drafter/companion entries published".

## Verification (local)
- ui local-inference suite: **66/66 pass** (registry + readiness self-heal, catalog hub/published contracts)
- shared catalog test: **12/12**
- shared `tsc --noEmit`: **0 errors**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR restores two DFlash speculative-decoding drafter companion entries (`eliza-1-0_8b-drafter`, `eliza-1-2b-drafter`) that were removed in a prior refactor, reintroducing them as hidden, non-published `mtp-drafter` companions that the installer and self-heal registry can locate via `findCatalogModel`.

- Adds `TIER_DRAFTERS` (HF-verified `ggufFile` paths and byte sizes) and a `drafterCompanion()` builder that produces fully-specified `CatalogModel` entries with `hiddenFromCatalog: true`, `runtimeRole: \"mtp-drafter\"`, and `companionForModelId` set to the parent tier.
- Populates a module-private `DRAFTER_COMPANIONS` list and extends `findCatalogModel` to search it as a `??` fallback, satisfying \"drafter is findable (self-heal)\" while leaving `MODEL_CATALOG` (the published hub) unchanged.
- The `drafterId` helper that derives drafter IDs is not exported; callers that need to construct a drafter ID must replicate the pattern independently — a divergence is already visible in `voice-interactive.mjs`, which accesses the non-existent `runtime.mtp.drafterModelId` field instead.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is narrowly scoped to restoring two static catalog entries and adding a ?? fallback in findCatalogModel; no production data paths are altered.

The catalog entries are correct and well-verified against the published HF byte sizes, the MODEL_CATALOG / DRAFTER_COMPANIONS separation is clean, and the existing test suite contracts all hold. The one notable gap is that drafterId is unexported, so callers independently replicate the pattern — voice-interactive.mjs already shows this drift by accessing a non-existent runtime.mtp.drafterModelId field and silently getting undefined.

The single changed file packages/shared/src/local-inference/catalog.ts is straightforward; the unexported drafterId function (line 576) is worth a second look if any new caller needs to construct drafter IDs.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/shared/src/local-inference/catalog.ts | Adds TIER_DRAFTERS map, drafterCompanion() builder, and a module-level DRAFTER_COMPANIONS list to restore findability of 0.8B and 2B DFlash drafter models; extends findCatalogModel to search the new list as a fallback so the entries are discoverable by ID but remain excluded from the published MODEL_CATALOG. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["findCatalogModel(id)"] --> B{"MODEL_CATALOG\n.find(m => m.id === id)"}
    B -->|found| C["Return chat tier entry\n(published, visible)"]
    B -->|undefined| D{"DRAFTER_COMPANIONS\n.find(m => m.id === id)"}
    D -->|found| E["Return drafter companion\nhiddenFromCatalog: true\nruntimeRole: mtp-drafter"]
    D -->|undefined| F["Return undefined"]

    subgraph Build ["Module init (static)"]
        G["ELIZA_1_TIER_IDS.map(chatTier)"] --> H["MODEL_CATALOG\n(6 visible tiers)"]
        I["ELIZA_1_TIER_IDS\n.filter(id => TIER_DRAFTERS[id])\n.map(drafterCompanion)"] --> J["DRAFTER_COMPANIONS\n(0_8b-drafter, 2b-drafter)"]
    end

    H --> B
    J --> D
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fshared%2Fsrc%2Flocal-inference%2Fcatalog.ts%3A576-577%0A**%60drafterId%60%20is%20not%20exported%20%E2%80%94%20callers%20must%20independently%20re-implement%20the%20ID%20pattern**%0A%0AAny%20consumer%20that%20needs%20to%20resolve%20a%20drafter%20catalog%20entry%20%28installer%2C%20self-heal%20tests%2C%20%60voice-interactive.mjs%60%29%20must%20independently%20construct%20the%20ID%20%60%22%24%7BtierId%7D-drafter%22%60%20since%20this%20utility%20function%20is%20module-private.%20%60voice-interactive.mjs%60%20already%20shows%20the%20divergence%20risk%20%E2%80%94%20it%20attempts%20%60catalogEntry%3F.runtime%3F.mtp%3F.drafterModelId%60%20%28a%20field%20that%20does%20not%20exist%20on%20%60LocalRuntimeAcceleration.mtp%60%29%20rather%20than%20using%20this%20pattern%2C%20so%20%60drafterEntry%60%20is%20always%20%60null%60%20in%20that%20script.%20Exporting%20%60drafterId%60%20%28or%20a%20thin%20%60drafterModelIdFor%28tierId%29%60%20helper%29%20would%20give%20all%20callers%20a%20single%20canonical%20source%20of%20truth%20and%20surface%20type-errors%20when%20the%20pattern%20drifts.%0A%0A&repo=elizaos%2Feliza&pr=8060&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22fix%2Frestore-dflash-drafter-catalog%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Frestore-dflash-drafter-catalog%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fshared%2Fsrc%2Flocal-inference%2Fcatalog.ts%3A576-577%0A**%60drafterId%60%20is%20not%20exported%20%E2%80%94%20callers%20must%20independently%20re-implement%20the%20ID%20pattern**%0A%0AAny%20consumer%20that%20needs%20to%20resolve%20a%20drafter%20catalog%20entry%20%28installer%2C%20self-heal%20tests%2C%20%60voice-interactive.mjs%60%29%20must%20independently%20construct%20the%20ID%20%60%22%24%7BtierId%7D-drafter%22%60%20since%20this%20utility%20function%20is%20module-private.%20%60voice-interactive.mjs%60%20already%20shows%20the%20divergence%20risk%20%E2%80%94%20it%20attempts%20%60catalogEntry%3F.runtime%3F.mtp%3F.drafterModelId%60%20%28a%20field%20that%20does%20not%20exist%20on%20%60LocalRuntimeAcceleration.mtp%60%29%20rather%20than%20using%20this%20pattern%2C%20so%20%60drafterEntry%60%20is%20always%20%60null%60%20in%20that%20script.%20Exporting%20%60drafterId%60%20%28or%20a%20thin%20%60drafterModelIdFor%28tierId%29%60%20helper%29%20would%20give%20all%20callers%20a%20single%20canonical%20source%20of%20truth%20and%20surface%20type-errors%20when%20the%20pattern%20drifts.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fshared%2Fsrc%2Flocal-inference%2Fcatalog.ts%3A576-577%0A**%60drafterId%60%20is%20not%20exported%20%E2%80%94%20callers%20must%20independently%20re-implement%20the%20ID%20pattern**%0A%0AAny%20consumer%20that%20needs%20to%20resolve%20a%20drafter%20catalog%20entry%20%28installer%2C%20self-heal%20tests%2C%20%60voice-interactive.mjs%60%29%20must%20independently%20construct%20the%20ID%20%60%22%24%7BtierId%7D-drafter%22%60%20since%20this%20utility%20function%20is%20module-private.%20%60voice-interactive.mjs%60%20already%20shows%20the%20divergence%20risk%20%E2%80%94%20it%20attempts%20%60catalogEntry%3F.runtime%3F.mtp%3F.drafterModelId%60%20%28a%20field%20that%20does%20not%20exist%20on%20%60LocalRuntimeAcceleration.mtp%60%29%20rather%20than%20using%20this%20pattern%2C%20so%20%60drafterEntry%60%20is%20always%20%60null%60%20in%20that%20script.%20Exporting%20%60drafterId%60%20%28or%20a%20thin%20%60drafterModelIdFor%28tierId%29%60%20helper%29%20would%20give%20all%20callers%20a%20single%20canonical%20source%20of%20truth%20and%20surface%20type-errors%20when%20the%20pattern%20drifts.%0A%0A&pr=8060&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(catalog): restore DFlash drafter com..."](https://github.com/elizaos/eliza/commit/b1a83c7e227f32bdff17b1db03aa6f77e162fd4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34659050)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->