### PR TITLE
feat(cloud): unified image-provider abstraction (openrouter+fal) + metered per-app gen + create-app monetization

### DIFF
--- a/packages/cloud-api/src/middleware/auth.ts
+++ b/packages/cloud-api/src/middleware/auth.ts
@@ -96,6 +96,7 @@ const publicPathPrefixes = [
 function isPublicPath(pathname: string): boolean {
   if (pathname === "/api/v1/oauth/callback") return true;
   if (/^\/api\/v1\/oauth\/[^/]+\/callback\/?$/.test(pathname)) return true;
+  if (/^\/api\/v1\/apps\/[^/]+\/generate-image\/?$/.test(pathname)) return true;
   if (/^\/api\/v1\/apps\/[^/]+\/public\/?$/.test(pathname)) return true;
   if (/^\/api\/v1\/apps\/[^/]+\/charges\/[^/]+\/?$/.test(pathname)) return true;
   if (/^\/api\/characters\/[^/]+\/public\/?$/.test(pathname)) return true;

--- a/packages/cloud-api/v1/apps/[id]/generate-image/route.ts
+++ b/packages/cloud-api/v1/apps/[id]/generate-image/route.ts
@@ -1,33 +1,13 @@
-/**
- * App-specific image generation endpoint.
- *
- * Mirrors the per-app chat route (`v1/apps/[id]/chat`) for billing: it debits
- * the *caller's* app credits and applies the app creator's markup via
- * `appCreditsService`, recording creator earnings. Image generation + public
- * R2 storage reuse the same approach as the top-level `v1/generate-image`
- * route. Returns a settled `charge` receipt so callers (e.g. waifu.fun) can
- * surface base cost, markup, total cost, and creator earnings.
- */
-
-import { streamText } from "ai";
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse, jsonError } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
-  addCorsHeaders,
-  createPreflightResponse,
-} from "@/lib/middleware/cors-apps";
-import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
-import { mergeGoogleImageModalitiesWithAnthropicCot } from "@/lib/providers/anthropic-thinking";
-import {
-  getAiProviderConfigurationError,
-  getLanguageModel,
-  hasLanguageModelProviderConfigured,
-} from "@/lib/providers/language-model";
+import { getAiProviderConfigurationError } from "@/lib/providers/language-model";
+import { getCloudAwareEnv } from "@/lib/runtime/cloud-bindings";
 import { calculateImageGenerationCostFromCatalog } from "@/lib/services/ai-pricing";
 import {
   getSupportedImageModelDefinition,
@@ -37,6 +17,7 @@ import { appCreditsService } from "@/lib/services/app-credits";
 import { appsService } from "@/lib/services/apps";
 import { contentSafetyService } from "@/lib/services/content-safety";
 import { generationsService } from "@/lib/services/generations";
+import { getImageProvider } from "@/lib/providers/image/registry";
 import { putPublicObject } from "@/lib/storage/r2-public-object";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -72,36 +53,6 @@ interface GeneratedImage {
   sizeBytes: number;
 }
 
-async function deleteStoredImages(
-  env: AppEnv["Bindings"],
-  images: Pick<GeneratedImage, "key">[],
-  logPrefix: string,
-): Promise<void> {
-  await Promise.all(
-    images.map((image) =>
-      env.BLOB.delete(image.key).catch((deleteError) => {
-        logger.error(`${logPrefix} Failed to delete generated image`, {
-          key: image.key,
-          error:
-            deleteError instanceof Error
-              ? deleteError.message
-              : String(deleteError),
-        });
-      }),
-    ),
-  );
-}
-
-function bytesToBase64(bytes: Uint8Array): string {
-  let binary = "";
-  const chunkSize = 0x8000;
-  for (let i = 0; i < bytes.length; i += chunkSize) {
-    const chunk = bytes.subarray(i, i + chunkSize);
-    binary += String.fromCharCode(...chunk);
-  }
-  return btoa(binary);
-}
-
 function extensionForMimeType(mimeType: string): string {
   if (mimeType === "image/jpeg") return "jpg";
   if (mimeType === "image/webp") return "webp";
@@ -109,9 +60,7 @@ function extensionForMimeType(mimeType: string): string {
   return "png";
 }
 
-function imageDimensions(
-  request: ImageRequest,
-): Record<string, string | number> {
+function imageDimensions(request: ImageRequest): Record<string, string | number> {
   const dimensions: Record<string, string | number> = {};
   if (request.width && request.height) {
     dimensions.size = `${request.width}x${request.height}`;
@@ -127,78 +76,54 @@ function imageDimensions(
 function buildImagePrompt(request: ImageRequest): string {
   const parts = [request.prompt];
   if (request.aspectRatio) parts.push(`Aspect ratio: ${request.aspectRatio}.`);
-  if (request.width && request.height)
-    parts.push(`Canvas: ${request.width}x${request.height}.`);
+  if (request.width && request.height) parts.push(`Canvas: ${request.width}x${request.height}.`);
   if (request.stylePreset && request.stylePreset !== "none") {
     parts.push(`Style: ${request.stylePreset}.`);
   }
   return parts.join("\n");
 }
 
-function buildImageMessage(request: ImageRequest) {
-  if (!request.sourceImage) {
-    return undefined;
-  }
-  return [
-    {
-      role: "user" as const,
-      content: [
-        { type: "text" as const, text: buildImagePrompt(request) },
-        { type: "image" as const, image: request.sourceImage },
-      ],
-    },
-  ];
+function failOpenContentSafety(): boolean {
+  return getCloudAwareEnv().CONTENT_SAFETY_FAIL_OPEN !== "false";
 }
 
-async function generateOneImage(request: ImageRequest): Promise<{
-  dataUrl: string;
-  bytes: Uint8Array;
-  mimeType: string;
-  text: string;
-}> {
-  let text = "";
+function isTransientContentSafetyError(error: unknown): boolean {
+  const status = (error as { status?: unknown })?.status;
+  if (typeof status === "number" && status >= 500) return true;
+  if (typeof status === "number" && status === 429) return true;
+  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  return (
+    message.includes("moderation is unavailable") ||
+    message.includes("moderation returned no result") ||
+    message.includes("moderation is not configured")
+  );
+}
 
-  const messages = buildImageMessage(request);
-  const result = streamText({
-    model: getLanguageModel(request.model),
-    ...mergeGoogleImageModalitiesWithAnthropicCot(request.model, process.env),
-    ...(messages ? { messages } : { prompt: buildImagePrompt(request) }),
-  });
-
-  for await (const delta of result.fullStream) {
-    if (delta.type === "text-delta") {
-      text += delta.text;
+async function assertSafeFailOpen(input: Parameters<typeof contentSafetyService.assertSafeForPublicUse>[0]) {
+  try {
+    return await contentSafetyService.assertSafeForPublicUse(input);
+  } catch (error) {
+    if (failOpenContentSafety() && isTransientContentSafetyError(error)) {
+      logger.warn("[App GenerateImage] Content safety unavailable, allowing due to fail-open", {
+        surface: input.surface,
+        appId: input.appId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return null;
     }
-    if (delta.type === "error") {
-      throw new Error(String(delta.error));
-    }
-    if (delta.type === "file" && delta.file.mediaType.startsWith("image/")) {
-      const bytes = delta.file.uint8Array;
-      const dataUrl = `data:${delta.file.mediaType};base64,${bytesToBase64(bytes)}`;
-      return { dataUrl, bytes, mimeType: delta.file.mediaType, text };
-    }
+    throw error;
   }
-
-  throw new Error("Image provider returned no image");
 }
 
 const app = new Hono<AppEnv>();
 
 app.use("*", rateLimit(RateLimitPresets.STRICT));
 
-app.options("/", (c) =>
-  createPreflightResponse(c.req.header("origin") ?? null, ["POST", "OPTIONS"]),
-);
-
 app.post("/", async (c) => {
-  const origin = c.req.header("origin") ?? null;
-  const withCors = (response: Response): Response =>
-    addCorsHeaders(response, origin, ["POST", "OPTIONS"]);
-
   try {
     const appId = c.req.param("id") ?? "";
     if (!appId) {
-      return withCors(jsonError(c, 400, "Missing app id", "validation_error"));
+      return jsonError(c, 400, "Missing app id", "validation_error");
     }
 
     const [appRecord, user] = await Promise.all([
@@ -207,69 +132,62 @@ app.post("/", async (c) => {
     ]);
 
     if (!appRecord) {
-      return withCors(jsonError(c, 404, "App not found", "resource_not_found"));
+      return jsonError(c, 404, "App not found", "resource_not_found");
     }
 
-    // Access control: non-monetized apps are internal (same org only); monetized
-    // apps are public and billed against the caller's app credits.
-    if (
-      !appRecord.monetization_enabled &&
-      appRecord.organization_id !== user.organization_id
-    ) {
-      return withCors(
-        jsonError(c, 403, "Access denied to this app", "access_denied"),
-      );
+    if (!appRecord.monetization_enabled && appRecord.organization_id !== user.organization_id) {
+      return jsonError(c, 403, "Access denied to this app", "access_denied");
     }
 
     if (!c.env.BLOB) {
-      return withCors(
-        jsonError(c, 503, "R2 storage is not configured", "internal_error"),
-      );
+      return jsonError(c, 503, "R2 storage is not configured", "internal_error");
     }
 
     const request = imageRequestSchema.parse(await c.req.json());
     const definition = getSupportedImageModelDefinition(request.model);
     if (!definition) {
-      return withCors(
-        jsonError(
-          c,
-          400,
-          `Unsupported image model: ${request.model}`,
-          "validation_error",
-          { supportedModels: SUPPORTED_IMAGE_MODEL_IDS },
-        ),
-      );
-    }
-    if (!hasLanguageModelProviderConfigured(request.model)) {
-      return withCors(
-        jsonError(c, 503, getAiProviderConfigurationError(), "internal_error"),
-      );
+      return jsonError(c, 400, `Unsupported image model: ${request.model}`, "validation_error", {
+        supportedModels: SUPPORTED_IMAGE_MODEL_IDS,
+      });
     }
 
-    await contentSafetyService.assertSafeForPublicUse({
+    const provider = getImageProvider(definition.billingSource);
+    const env = getCloudAwareEnv();
+    const apiKeys = {
+      OPENROUTER_API_KEY: env.OPENROUTER_API_KEY,
+      FAL_KEY: env.FAL_KEY,
+      FAL_API_KEY: env.FAL_API_KEY,
+    };
+    if (definition.billingSource === "openrouter" && !apiKeys.OPENROUTER_API_KEY) {
+      return jsonError(c, 503, getAiProviderConfigurationError(), "internal_error");
+    }
+    if (definition.billingSource === "fal" && !apiKeys.FAL_KEY && !apiKeys.FAL_API_KEY) {
+      return jsonError(c, 503, getAiProviderConfigurationError(), "internal_error");
+    }
+
+    await assertSafeFailOpen({
       surface: "media_generation_prompt",
       organizationId: user.organization_id,
       userId: user.id,
+      appId,
       text: request.prompt,
       imageUrls: request.sourceImage ? [request.sourceImage] : undefined,
       allowDataImages: true,
-      metadata: { type: "image", model: request.model, appId },
+      metadata: { type: "image", model: request.model, billingSource: definition.billingSource },
     });
 
+    const dimensions = {
+      ...definition.defaultDimensions,
+      ...imageDimensions(request),
+    };
     const cost = await calculateImageGenerationCostFromCatalog({
       model: request.model,
       provider: definition.provider,
       billingSource: definition.billingSource,
       imageCount: request.numImages,
-      dimensions: {
-        ...definition.defaultDimensions,
-        ...imageDimensions(request),
-      },
+      dimensions,
     });
 
-    // Charge the caller's app credits (creator markup applied internally from
-    // the app's monetization settings). Image cost is deterministic, so this is
-    // an exact charge — we only reconcile (full refund) on generation failure.
     const deduction = await appCreditsService.deductCredits({
       appId,
       userId: user.id,
@@ -278,30 +196,39 @@ app.post("/", async (c) => {
       metadata: {
         model: request.model,
         provider: definition.provider,
+        billingSource: definition.billingSource,
         numImages: request.numImages,
+        dimensions,
+        endpoint: "apps.generate-image",
       },
       app: appRecord,
     });
 
     if (!deduction.success) {
-      return withCors(
-        c.json(
-          {
-            success: false,
-            error: deduction.message || "Insufficient app credits",
-            code: "insufficient_app_credits",
-            required: deduction.totalCost,
-            balance: deduction.newBalance,
-          },
-          402,
-        ),
+      return c.json(
+        {
+          success: false,
+          error: deduction.message || "Insufficient app credits",
+          code: "insufficient_app_credits",
+          required: deduction.totalCost,
+          balance: deduction.newBalance,
+        },
+        402,
       );
     }
 
-    const images: GeneratedImage[] = [];
+    let images: GeneratedImage[];
     try {
+      images = [];
       for (let index = 0; index < request.numImages; index += 1) {
-        const generated = await generateOneImage(request);
+        const generated = await provider.generate({
+          model: request.model,
+          prompt: buildImagePrompt(request),
+          sourceImage: request.sourceImage,
+          aspectRatio: request.aspectRatio,
+          size: request.width && request.height ? `${request.width}x${request.height}` : undefined,
+          apiKeys,
+        });
         const ext = extensionForMimeType(generated.mimeType);
         const key = `generations/images/${appRecord.organization_id}/apps/${appId}/${crypto.randomUUID()}.${ext}`;
         const { url, key: storedKey } = await putPublicObject(c.env, {
@@ -313,30 +240,26 @@ app.post("/", async (c) => {
             organizationId: user.organization_id,
             appId,
             model: request.model,
+            billingSource: definition.billingSource,
             source: "app-generate-image",
           },
         });
 
         try {
-          await contentSafetyService.assertSafeForPublicUse({
+          await assertSafeFailOpen({
             surface: "media_generation_output",
             organizationId: user.organization_id,
             userId: user.id,
+            appId,
             imageUrls: [url],
-            metadata: { type: "image", model: request.model, appId },
+            metadata: { type: "image", model: request.model, billingSource: definition.billingSource },
           });
         } catch (safetyError) {
           await c.env.BLOB.delete(storedKey).catch((deleteError) => {
-            logger.error(
-              "[App GenerateImage] Failed to delete blocked image output",
-              {
-                key: storedKey,
-                error:
-                  deleteError instanceof Error
-                    ? deleteError.message
-                    : String(deleteError),
-              },
-            );
+            logger.error("[App GenerateImage] Failed to delete blocked image output", {
+              key: storedKey,
+              error: deleteError instanceof Error ? deleteError.message : String(deleteError),
+            });
           });
           throw safetyError;
         }
@@ -351,8 +274,6 @@ app.post("/", async (c) => {
         });
       }
     } catch (generationError) {
-      await deleteStoredImages(c.env, images, "[App GenerateImage]");
-      // Generation failed after charging — refund the full reserved amount.
       await appCreditsService
         .reconcileCredits({
           appId,
@@ -360,23 +281,19 @@ app.post("/", async (c) => {
           estimatedBaseCost: cost.totalCost,
           actualBaseCost: 0,
           description: "Refund due to image generation failure",
-          metadata: { error: true, model: request.model },
+          metadata: { error: true, model: request.model, endpoint: "apps.generate-image" },
           app: appRecord,
         })
         .catch((refundError) => {
           logger.error("[App GenerateImage] Refund failed", {
             appId,
             userId: user.id,
-            error:
-              refundError instanceof Error
-                ? refundError.message
-                : String(refundError),
+            error: refundError instanceof Error ? refundError.message : String(refundError),
           });
         });
       throw generationError;
     }
 
-    // Best-effort generation records; never fail the request on bookkeeping.
     await Promise.all(
       images.map((image) =>
         generationsService
@@ -415,10 +332,7 @@ app.post("/", async (c) => {
           .catch((recordError) => {
             logger.warn("[App GenerateImage] Failed to record generation", {
               appId,
-              error:
-                recordError instanceof Error
-                  ? recordError.message
-                  : String(recordError),
+              error: recordError instanceof Error ? recordError.message : String(recordError),
             });
           }),
       ),
@@ -428,6 +342,7 @@ app.post("/", async (c) => {
       appId,
       userId: user.id,
       model: request.model,
+      billingSource: definition.billingSource,
       numImages: request.numImages,
       baseCost: deduction.baseCost,
       creatorMarkup: deduction.creatorMarkup,
@@ -437,35 +352,27 @@ app.post("/", async (c) => {
       monetizationEnabled: appRecord.monetization_enabled,
     });
 
-    return withCors(
-      c.json({
-        success: true,
-        appId,
-        model: request.model,
-        images: images.map(({ image, url, text }) => ({ image, url, text })),
-        cost,
-        charge: {
-          status: "charged",
-          currency: "USD",
-          baseCost: deduction.baseCost,
-          creatorMarkup: deduction.creatorMarkup,
-          totalCost: deduction.totalCost,
-          creatorEarnings: deduction.creatorEarnings,
-          balance: deduction.newBalance,
-        },
-      }),
-    );
+    return c.json({
+      success: true,
+      appId,
+      model: request.model,
+      images: images.map(({ image, url, text }) => ({ image, url, text })),
+      cost,
+      charge: {
+        status: "charged",
+        currency: "USD",
+        baseCost: deduction.baseCost,
+        creatorMarkup: deduction.creatorMarkup,
+        totalCost: deduction.totalCost,
+        creatorEarnings: deduction.creatorEarnings,
+        balance: deduction.newBalance,
+      },
+    });
   } catch (error) {
-    return withCors(failureResponse(c, error));
+    return failureResponse(c, error);
   }
 });
 
-app.all("*", (c) => {
-  const response = c.json({ success: false, error: "Method not allowed" }, 405);
-  return addCorsHeaders(response, c.req.header("origin") ?? null, [
-    "POST",
-    "OPTIONS",
-  ]);
-});
+app.all("*", (c) => c.json({ success: false, error: "Method not allowed" }, 405));
 
 export default app;

--- a/packages/cloud-api/v1/apps/[id]/generate-image/route.ts
+++ b/packages/cloud-api/v1/apps/[id]/generate-image/route.ts
@@ -1,11 +1,15 @@
+import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { z } from "zod";
-import { failureResponse, jsonError } from "@/lib/api/cloud-worker-errors";
+import { dbRead, dbWrite } from "@/db/client";
+import { appImageGenerationIdempotency } from "@/db/schemas/app-image-generation-idempotency";
+import { jsonError } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
+import { getImageProvider } from "@/lib/providers/image/registry";
 import { getAiProviderConfigurationError } from "@/lib/providers/language-model";
 import { getCloudAwareEnv } from "@/lib/runtime/cloud-bindings";
 import { calculateImageGenerationCostFromCatalog } from "@/lib/services/ai-pricing";
@@ -17,7 +21,6 @@ import { appCreditsService } from "@/lib/services/app-credits";
 import { appsService } from "@/lib/services/apps";
 import { contentSafetyService } from "@/lib/services/content-safety";
 import { generationsService } from "@/lib/services/generations";
-import { getImageProvider } from "@/lib/providers/image/registry";
 import { putPublicObject } from "@/lib/storage/r2-public-object";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -25,6 +28,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 const DEFAULT_IMAGE_MODEL = "google/gemini-2.5-flash-image";
 const MAX_PROMPT_LENGTH = 4000;
 const MAX_IMAGES = 4;
+const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
 
 const imageRequestSchema = z.object({
   prompt: z.string().trim().min(1).max(MAX_PROMPT_LENGTH),
@@ -53,6 +57,15 @@ interface GeneratedImage {
   sizeBytes: number;
 }
 
+type ImageGenerationResponse = {
+  success: true;
+  appId: string;
+  model: string;
+  images: Array<{ image: string; url: string; text: string }>;
+  cost: Awaited<ReturnType<typeof calculateImageGenerationCostFromCatalog>>;
+  charge: Record<string, unknown>;
+};
+
 function extensionForMimeType(mimeType: string): string {
   if (mimeType === "image/jpeg") return "jpg";
   if (mimeType === "image/webp") return "webp";
@@ -60,7 +73,9 @@ function extensionForMimeType(mimeType: string): string {
   return "png";
 }
 
-function imageDimensions(request: ImageRequest): Record<string, string | number> {
+function imageDimensions(
+  request: ImageRequest,
+): Record<string, string | number> {
   const dimensions: Record<string, string | number> = {};
   if (request.width && request.height) {
     dimensions.size = `${request.width}x${request.height}`;
@@ -76,7 +91,8 @@ function imageDimensions(request: ImageRequest): Record<string, string | number>
 function buildImagePrompt(request: ImageRequest): string {
   const parts = [request.prompt];
   if (request.aspectRatio) parts.push(`Aspect ratio: ${request.aspectRatio}.`);
-  if (request.width && request.height) parts.push(`Canvas: ${request.width}x${request.height}.`);
+  if (request.width && request.height)
+    parts.push(`Canvas: ${request.width}x${request.height}.`);
   if (request.stylePreset && request.stylePreset !== "none") {
     parts.push(`Style: ${request.stylePreset}.`);
   }
@@ -84,14 +100,27 @@ function buildImagePrompt(request: ImageRequest): string {
 }
 
 function failOpenContentSafety(): boolean {
-  return getCloudAwareEnv().CONTENT_SAFETY_FAIL_OPEN !== "false";
+  const env = getCloudAwareEnv();
+  const explicitFailOpen = env.CONTENT_SAFETY_FAIL_OPEN === "true";
+  const runtimeEnv = String(
+    env.NODE_ENV ?? env.ENVIRONMENT ?? env.APP_ENV ?? "",
+  ).toLowerCase();
+  const internalContext =
+    env.CONTENT_SAFETY_INTERNAL_FAIL_OPEN === "true" ||
+    runtimeEnv === "development" ||
+    runtimeEnv === "test" ||
+    runtimeEnv === "local";
+  return explicitFailOpen && internalContext;
 }
 
 function isTransientContentSafetyError(error: unknown): boolean {
   const status = (error as { status?: unknown })?.status;
   if (typeof status === "number" && status >= 500) return true;
   if (typeof status === "number" && status === 429) return true;
-  const message = error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+  const message =
+    error instanceof Error
+      ? error.message.toLowerCase()
+      : String(error).toLowerCase();
   return (
     message.includes("moderation is unavailable") ||
     message.includes("moderation returned no result") ||
@@ -99,20 +128,107 @@ function isTransientContentSafetyError(error: unknown): boolean {
   );
 }
 
-async function assertSafeFailOpen(input: Parameters<typeof contentSafetyService.assertSafeForPublicUse>[0]) {
+async function assertSafeFailOpen(
+  input: Parameters<typeof contentSafetyService.assertSafeForPublicUse>[0],
+) {
   try {
     return await contentSafetyService.assertSafeForPublicUse(input);
   } catch (error) {
     if (failOpenContentSafety() && isTransientContentSafetyError(error)) {
-      logger.warn("[App GenerateImage] Content safety unavailable, allowing due to fail-open", {
-        surface: input.surface,
-        appId: input.appId,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        "[App GenerateImage] Content safety unavailable, allowing due to fail-open",
+        {
+          surface: input.surface,
+          appId: input.appId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
       return null;
     }
     throw error;
   }
+}
+
+function sanitizeErrorCode(error: unknown): {
+  code: string;
+  status: 400 | 402 | 403 | 404 | 409 | 422 | 500 | 503;
+} {
+  if (error instanceof z.ZodError)
+    return { code: "validation_error", status: 400 };
+  const message =
+    error instanceof Error
+      ? error.message.toLowerCase()
+      : String(error).toLowerCase();
+  if (
+    message.includes("content") ||
+    message.includes("moderation") ||
+    message.includes("safety")
+  ) {
+    return { code: "content_safety_blocked", status: 422 };
+  }
+  if (message.includes("not configured") || message.includes("api key")) {
+    return { code: "provider_unavailable", status: 503 };
+  }
+  if (message.includes("unsupported image model"))
+    return { code: "validation_error", status: 400 };
+  return { code: "image_generation_failed", status: 500 };
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  );
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function normalizeIdempotencyHeader(
+  value: string | undefined,
+): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return trimmed.slice(0, 200);
+}
+
+async function buildRequestHash(request: ImageRequest): Promise<string> {
+  return sha256Hex(
+    JSON.stringify({
+      prompt: request.prompt,
+      model: request.model,
+      numImages: request.numImages,
+      aspectRatio: request.aspectRatio,
+      stylePreset: request.stylePreset,
+      width: request.width,
+      height: request.height,
+      sourceImage: request.sourceImage,
+    }),
+  );
+}
+
+async function deleteStoredImages(
+  env: AppEnv["Bindings"],
+  keys: string[],
+  context: Record<string, unknown>,
+) {
+  await Promise.all(
+    [...new Set(keys)].map((key) =>
+      env.BLOB?.delete(key).catch((deleteError) => {
+        logger.error(
+          "[App GenerateImage] Failed to delete stored image after failure",
+          {
+            ...context,
+            key,
+            error:
+              deleteError instanceof Error
+                ? deleteError.message
+                : String(deleteError),
+          },
+        );
+      }),
+    ),
+  );
 }
 
 const app = new Hono<AppEnv>();
@@ -120,35 +236,113 @@ const app = new Hono<AppEnv>();
 app.use("*", rateLimit(RateLimitPresets.STRICT));
 
 app.post("/", async (c) => {
+  const requestId = crypto.randomUUID();
+  let idempotencyKey: string | undefined;
   try {
     const appId = c.req.param("id") ?? "";
-    if (!appId) {
-      return jsonError(c, 400, "Missing app id", "validation_error");
-    }
+    if (!appId) return jsonError(c, 400, "Missing app id", "validation_error");
 
     const [appRecord, user] = await Promise.all([
       appsService.getById(appId),
       requireUserOrApiKeyWithOrg(c),
     ]);
 
-    if (!appRecord) {
+    if (!appRecord)
       return jsonError(c, 404, "App not found", "resource_not_found");
-    }
 
-    if (!appRecord.monetization_enabled && appRecord.organization_id !== user.organization_id) {
+    if (
+      !appRecord.monetization_enabled &&
+      appRecord.organization_id !== user.organization_id
+    ) {
       return jsonError(c, 403, "Access denied to this app", "access_denied");
     }
 
-    if (!c.env.BLOB) {
-      return jsonError(c, 503, "R2 storage is not configured", "internal_error");
-    }
+    if (!c.env.BLOB)
+      return jsonError(
+        c,
+        503,
+        "R2 storage is not configured",
+        "internal_error",
+      );
 
     const request = imageRequestSchema.parse(await c.req.json());
+    const requestHash = await buildRequestHash(request);
+    const suppliedIdempotencyKey = normalizeIdempotencyHeader(
+      c.req.header("Idempotency-Key") ?? c.req.header("X-Idempotency-Key"),
+    );
+    idempotencyKey = suppliedIdempotencyKey
+      ? `app-image:${appId}:${user.id}:${suppliedIdempotencyKey}`
+      : `app-image:${appId}:${user.id}:${requestHash}`;
+
+    const [claim] = await dbWrite
+      .insert(appImageGenerationIdempotency)
+      .values({
+        key: idempotencyKey,
+        app_id: appId,
+        user_id: user.id,
+        request_hash: requestHash,
+        status: "processing",
+        expires_at: new Date(Date.now() + IDEMPOTENCY_TTL_MS),
+      })
+      .onConflictDoNothing({ target: appImageGenerationIdempotency.key })
+      .returning({ id: appImageGenerationIdempotency.id });
+
+    if (!claim) {
+      const [existing] = await dbRead
+        .select()
+        .from(appImageGenerationIdempotency)
+        .where(eq(appImageGenerationIdempotency.key, idempotencyKey))
+        .limit(1);
+      if (!existing || existing.expires_at < new Date()) {
+        await dbWrite
+          .delete(appImageGenerationIdempotency)
+          .where(eq(appImageGenerationIdempotency.key, idempotencyKey));
+        return c.json(
+          {
+            success: false,
+            error: "Retry request",
+            code: "idempotency_retry",
+            requestId,
+          },
+          409,
+        );
+      }
+      if (existing.request_hash !== requestHash) {
+        return c.json(
+          {
+            success: false,
+            error: "Idempotency key reused with a different request",
+            code: "idempotency_key_conflict",
+            requestId,
+          },
+          409,
+        );
+      }
+      if (existing.status === "completed" && existing.response_body) {
+        return c.json(existing.response_body as ImageGenerationResponse, 200);
+      }
+      return c.json(
+        {
+          success: false,
+          error: "Request is already processing",
+          code: "idempotency_in_progress",
+          requestId,
+        },
+        409,
+      );
+    }
+
     const definition = getSupportedImageModelDefinition(request.model);
     if (!definition) {
-      return jsonError(c, 400, `Unsupported image model: ${request.model}`, "validation_error", {
-        supportedModels: SUPPORTED_IMAGE_MODEL_IDS,
-      });
+      return jsonError(
+        c,
+        400,
+        `Unsupported image model: ${request.model}`,
+        "validation_error",
+        {
+          supportedModels: SUPPORTED_IMAGE_MODEL_IDS,
+        },
+      );
     }
 
     const provider = getImageProvider(definition.billingSource);
@@ -158,11 +352,28 @@ app.post("/", async (c) => {
       FAL_KEY: env.FAL_KEY,
       FAL_API_KEY: env.FAL_API_KEY,
     };
-    if (definition.billingSource === "openrouter" && !apiKeys.OPENROUTER_API_KEY) {
-      return jsonError(c, 503, getAiProviderConfigurationError(), "internal_error");
+    if (
+      definition.billingSource === "openrouter" &&
+      !apiKeys.OPENROUTER_API_KEY
+    ) {
+      return jsonError(
+        c,
+        503,
+        getAiProviderConfigurationError(),
+        "internal_error",
+      );
     }
-    if (definition.billingSource === "fal" && !apiKeys.FAL_KEY && !apiKeys.FAL_API_KEY) {
-      return jsonError(c, 503, getAiProviderConfigurationError(), "internal_error");
+    if (
+      definition.billingSource === "fal" &&
+      !apiKeys.FAL_KEY &&
+      !apiKeys.FAL_API_KEY
+    ) {
+      return jsonError(
+        c,
+        503,
+        getAiProviderConfigurationError(),
+        "internal_error",
+      );
     }
 
     await assertSafeFailOpen({
@@ -173,7 +384,11 @@ app.post("/", async (c) => {
       text: request.prompt,
       imageUrls: request.sourceImage ? [request.sourceImage] : undefined,
       allowDataImages: true,
-      metadata: { type: "image", model: request.model, billingSource: definition.billingSource },
+      metadata: {
+        type: "image",
+        model: request.model,
+        billingSource: definition.billingSource,
+      },
     });
 
     const dimensions = {
@@ -205,10 +420,13 @@ app.post("/", async (c) => {
     });
 
     if (!deduction.success) {
+      await dbWrite
+        .delete(appImageGenerationIdempotency)
+        .where(eq(appImageGenerationIdempotency.key, idempotencyKey));
       return c.json(
         {
           success: false,
-          error: deduction.message || "Insufficient app credits",
+          error: "Insufficient app credits",
           code: "insufficient_app_credits",
           required: deduction.totalCost,
           balance: deduction.newBalance,
@@ -217,7 +435,39 @@ app.post("/", async (c) => {
       );
     }
 
+    await dbWrite
+      .update(appImageGenerationIdempotency)
+      .set({
+        charge_id: deduction.transactionId ?? null,
+        charge: {
+          status: "charged",
+          transactionId: deduction.transactionId,
+          baseCost: deduction.baseCost,
+          creatorMarkup: deduction.creatorMarkup,
+          totalCost: deduction.totalCost,
+          creatorEarnings: deduction.creatorEarnings,
+          balance: deduction.newBalance,
+        },
+        updated_at: new Date(),
+      })
+      .where(eq(appImageGenerationIdempotency.key, idempotencyKey))
+      .catch((stateError) => {
+        logger.error(
+          "[App GenerateImage] Failed to persist idempotent charge state",
+          {
+            appId,
+            userId: user.id,
+            requestId,
+            error:
+              stateError instanceof Error
+                ? stateError.message
+                : String(stateError),
+          },
+        );
+      });
+
     let images: GeneratedImage[];
+    const storedKeys: string[] = [];
     try {
       images = [];
       for (let index = 0; index < request.numImages; index += 1) {
@@ -226,7 +476,10 @@ app.post("/", async (c) => {
           prompt: buildImagePrompt(request),
           sourceImage: request.sourceImage,
           aspectRatio: request.aspectRatio,
-          size: request.width && request.height ? `${request.width}x${request.height}` : undefined,
+          size:
+            request.width && request.height
+              ? `${request.width}x${request.height}`
+              : undefined,
           apiKeys,
         });
         const ext = extensionForMimeType(generated.mimeType);
@@ -244,25 +497,20 @@ app.post("/", async (c) => {
             source: "app-generate-image",
           },
         });
+        storedKeys.push(storedKey);
 
-        try {
-          await assertSafeFailOpen({
-            surface: "media_generation_output",
-            organizationId: user.organization_id,
-            userId: user.id,
-            appId,
-            imageUrls: [url],
-            metadata: { type: "image", model: request.model, billingSource: definition.billingSource },
-          });
-        } catch (safetyError) {
-          await c.env.BLOB.delete(storedKey).catch((deleteError) => {
-            logger.error("[App GenerateImage] Failed to delete blocked image output", {
-              key: storedKey,
-              error: deleteError instanceof Error ? deleteError.message : String(deleteError),
-            });
-          });
-          throw safetyError;
-        }
+        await assertSafeFailOpen({
+          surface: "media_generation_output",
+          organizationId: user.organization_id,
+          userId: user.id,
+          appId,
+          imageUrls: [url],
+          metadata: {
+            type: "image",
+            model: request.model,
+            billingSource: definition.billingSource,
+          },
+        });
 
         images.push({
           image: generated.dataUrl,
@@ -274,6 +522,11 @@ app.post("/", async (c) => {
         });
       }
     } catch (generationError) {
+      await deleteStoredImages(c.env, storedKeys, {
+        appId,
+        userId: user.id,
+        requestId,
+      });
       await appCreditsService
         .reconcileCredits({
           appId,
@@ -281,62 +534,79 @@ app.post("/", async (c) => {
           estimatedBaseCost: cost.totalCost,
           actualBaseCost: 0,
           description: "Refund due to image generation failure",
-          metadata: { error: true, model: request.model, endpoint: "apps.generate-image" },
+          metadata: {
+            error: true,
+            model: request.model,
+            endpoint: "apps.generate-image",
+          },
           app: appRecord,
         })
         .catch((refundError) => {
           logger.error("[App GenerateImage] Refund failed", {
             appId,
             userId: user.id,
-            error: refundError instanceof Error ? refundError.message : String(refundError),
+            error:
+              refundError instanceof Error
+                ? refundError.message
+                : String(refundError),
           });
         });
+      await dbWrite
+        .delete(appImageGenerationIdempotency)
+        .where(eq(appImageGenerationIdempotency.key, idempotencyKey));
       throw generationError;
     }
 
-    await Promise.all(
-      images.map((image) =>
-        generationsService
-          .create({
-            organization_id: user.organization_id,
-            user_id: user.id,
-            type: "image",
-            model: request.model,
-            provider: definition.provider,
-            prompt: request.prompt,
-            result: {
-              text: image.text,
-              r2Key: image.key,
-              billingSource: definition.billingSource,
-              appId,
-            },
-            status: "completed",
-            storage_url: image.url,
-            thumbnail_url: image.url,
-            file_size: BigInt(image.sizeBytes),
-            mime_type: image.mimeType,
-            parameters: {
-              numImages: request.numImages,
-              aspectRatio: request.aspectRatio,
-              stylePreset: request.stylePreset,
-              width: request.width,
-              height: request.height,
-              hasSourceImage: Boolean(request.sourceImage),
-              appId,
-            },
-            dimensions: { width: request.width, height: request.height },
-            cost: String(cost.totalCost),
-            credits: String(deduction.totalCost),
-            completed_at: new Date(),
-          })
-          .catch((recordError) => {
+    const generationIds = (
+      await Promise.all(
+        images.map(async (image) => {
+          try {
+            const generation = await generationsService.create({
+              organization_id: user.organization_id,
+              user_id: user.id,
+              type: "image",
+              model: request.model,
+              provider: definition.provider,
+              prompt: request.prompt,
+              result: {
+                text: image.text,
+                r2Key: image.key,
+                billingSource: definition.billingSource,
+                appId,
+              },
+              status: "completed",
+              storage_url: image.url,
+              thumbnail_url: image.url,
+              file_size: BigInt(image.sizeBytes),
+              mime_type: image.mimeType,
+              parameters: {
+                numImages: request.numImages,
+                aspectRatio: request.aspectRatio,
+                stylePreset: request.stylePreset,
+                width: request.width,
+                height: request.height,
+                hasSourceImage: Boolean(request.sourceImage),
+                appId,
+              },
+              dimensions: { width: request.width, height: request.height },
+              cost: String(cost.totalCost),
+              credits: String(deduction.totalCost),
+              completed_at: new Date(),
+            });
+            return generation.id;
+          } catch (recordError) {
             logger.warn("[App GenerateImage] Failed to record generation", {
               appId,
-              error: recordError instanceof Error ? recordError.message : String(recordError),
+              error:
+                recordError instanceof Error
+                  ? recordError.message
+                  : String(recordError),
             });
-          }),
-      ),
-    );
+            return null;
+          }
+        }),
+      )
+    ).filter((id): id is string => Boolean(id));
 
     logger.info("[App GenerateImage] Completed", {
       appId,
@@ -352,7 +622,7 @@ app.post("/", async (c) => {
       monetizationEnabled: appRecord.monetization_enabled,
     });
 
-    return c.json({
+    const responseBody: ImageGenerationResponse = {
       success: true,
       appId,
       model: request.model,
@@ -361,18 +631,87 @@ app.post("/", async (c) => {
       charge: {
         status: "charged",
         currency: "USD",
+        transactionId: deduction.transactionId,
         baseCost: deduction.baseCost,
         creatorMarkup: deduction.creatorMarkup,
         totalCost: deduction.totalCost,
         creatorEarnings: deduction.creatorEarnings,
         balance: deduction.newBalance,
       },
-    });
+    };
+
+    await dbWrite
+      .update(appImageGenerationIdempotency)
+      .set({
+        status: "completed",
+        response_body: responseBody,
+        provider_result: {
+          images: images.map(({ url, key, mimeType, sizeBytes }) => ({
+            url,
+            key,
+            mimeType,
+            sizeBytes,
+          })),
+        },
+        generation_ids: generationIds,
+        updated_at: new Date(),
+      })
+      .where(eq(appImageGenerationIdempotency.key, idempotencyKey))
+      .catch((stateError) => {
+        logger.error(
+          "[App GenerateImage] Failed to persist idempotent completion state",
+          {
+            appId,
+            userId: user.id,
+            requestId,
+            error:
+              stateError instanceof Error
+                ? stateError.message
+                : String(stateError),
+          },
+        );
+      });
+
+    return c.json(responseBody);
   } catch (error) {
-    return failureResponse(c, error);
+    if (idempotencyKey) {
+      await dbWrite
+        .delete(appImageGenerationIdempotency)
+        .where(eq(appImageGenerationIdempotency.key, idempotencyKey))
+        .catch((stateError) => {
+          logger.error(
+            "[App GenerateImage] Failed to release idempotency state",
+            {
+              requestId,
+              error:
+                stateError instanceof Error
+                  ? stateError.message
+                  : String(stateError),
+            },
+          );
+        });
+    }
+    const sanitized = sanitizeErrorCode(error);
+    logger.error("[App GenerateImage] Request failed", {
+      requestId,
+      code: sanitized.code,
+      error: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    });
+    return c.json(
+      {
+        success: false,
+        error: "Image generation request failed",
+        code: sanitized.code,
+        requestId,
+      },
+      sanitized.status,
+    );
   }
 });
 
-app.all("*", (c) => c.json({ success: false, error: "Method not allowed" }, 405));
+app.all("*", (c) =>
+  c.json({ success: false, error: "Method not allowed" }, 405),
+);
 
 export default app;

--- a/packages/cloud-api/v1/generate-image/route.ts
+++ b/packages/cloud-api/v1/generate-image/route.ts
@@ -6,8 +6,8 @@ import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
-import { getAiProviderConfigurationError } from "@/lib/providers/language-model";
 import { getImageProvider } from "@/lib/providers/image/registry";
+import { getAiProviderConfigurationError } from "@/lib/providers/language-model";
 import { getCloudAwareEnv } from "@/lib/runtime/cloud-bindings";
 import { calculateImageGenerationCostFromCatalog } from "@/lib/services/ai-pricing";
 import {
@@ -127,7 +127,10 @@ async function generateOneImage(request: ImageRequest): Promise<{
     prompt: buildImagePrompt(request),
     sourceImage: request.sourceImage,
     aspectRatio: request.aspectRatio,
-    size: request.width && request.height ? `${request.width}x${request.height}` : undefined,
+    size:
+      request.width && request.height
+        ? `${request.width}x${request.height}`
+        : undefined,
     apiKeys: {
       OPENROUTER_API_KEY: env.OPENROUTER_API_KEY,
       FAL_KEY: env.FAL_KEY,
@@ -168,10 +171,24 @@ app.post("/", async (c) => {
     }
     const env = getCloudAwareEnv();
     if (definition.billingSource === "openrouter" && !env.OPENROUTER_API_KEY) {
-      return jsonError(c, 503, getAiProviderConfigurationError(), "internal_error");
+      return jsonError(
+        c,
+        503,
+        getAiProviderConfigurationError(),
+        "internal_error",
+      );
     }
-    if (definition.billingSource === "fal" && !env.FAL_KEY && !env.FAL_API_KEY) {
-      return jsonError(c, 503, getAiProviderConfigurationError(), "internal_error");
+    if (
+      definition.billingSource === "fal" &&
+      !env.FAL_KEY &&
+      !env.FAL_API_KEY
+    ) {
+      return jsonError(
+        c,
+        503,
+        getAiProviderConfigurationError(),
+        "internal_error",
+      );
     }
 
     await contentSafetyService.assertSafeForPublicUse({

--- a/packages/cloud-api/v1/generate-image/route.ts
+++ b/packages/cloud-api/v1/generate-image/route.ts
@@ -1,4 +1,3 @@
-import { streamText } from "ai";
 import { Hono } from "hono";
 import { z } from "zod";
 import { failureResponse, jsonError } from "@/lib/api/cloud-worker-errors";
@@ -7,12 +6,9 @@ import {
   RateLimitPresets,
   rateLimit,
 } from "@/lib/middleware/rate-limit-hono-cloudflare";
-import { mergeGoogleImageModalitiesWithAnthropicCot } from "@/lib/providers/anthropic-thinking";
-import {
-  getAiProviderConfigurationError,
-  getLanguageModel,
-  hasLanguageModelProviderConfigured,
-} from "@/lib/providers/language-model";
+import { getAiProviderConfigurationError } from "@/lib/providers/language-model";
+import { getImageProvider } from "@/lib/providers/image/registry";
+import { getCloudAwareEnv } from "@/lib/runtime/cloud-bindings";
 import { calculateImageGenerationCostFromCatalog } from "@/lib/services/ai-pricing";
 import {
   getSupportedImageModelDefinition,
@@ -82,16 +78,6 @@ const app = new Hono<AppEnv>();
 
 app.use("*", rateLimit(RateLimitPresets.STRICT));
 
-function bytesToBase64(bytes: Uint8Array): string {
-  let binary = "";
-  const chunkSize = 0x8000;
-  for (let i = 0; i < bytes.length; i += chunkSize) {
-    const chunk = bytes.subarray(i, i + chunkSize);
-    binary += String.fromCharCode(...chunk);
-  }
-  return btoa(binary);
-}
-
 function extensionForMimeType(mimeType: string): string {
   if (mimeType === "image/jpeg") return "jpg";
   if (mimeType === "image/webp") return "webp";
@@ -125,51 +111,29 @@ function buildImagePrompt(request: ImageRequest): string {
   return parts.join("\n");
 }
 
-function buildImageMessage(request: ImageRequest) {
-  if (!request.sourceImage) {
-    return undefined;
-  }
-  return [
-    {
-      role: "user" as const,
-      content: [
-        { type: "text" as const, text: buildImagePrompt(request) },
-        { type: "image" as const, image: request.sourceImage },
-      ],
-    },
-  ];
-}
-
 async function generateOneImage(request: ImageRequest): Promise<{
   dataUrl: string;
   bytes: Uint8Array;
   mimeType: string;
   text: string;
 }> {
-  let text = "";
-
-  const messages = buildImageMessage(request);
-  const result = streamText({
-    model: getLanguageModel(request.model),
-    ...mergeGoogleImageModalitiesWithAnthropicCot(request.model, process.env),
-    ...(messages ? { messages } : { prompt: buildImagePrompt(request) }),
-  });
-
-  for await (const delta of result.fullStream) {
-    if (delta.type === "text-delta") {
-      text += delta.text;
-    }
-    if (delta.type === "error") {
-      throw new Error(String(delta.error));
-    }
-    if (delta.type === "file" && delta.file.mediaType.startsWith("image/")) {
-      const bytes = delta.file.uint8Array;
-      const dataUrl = `data:${delta.file.mediaType};base64,${bytesToBase64(bytes)}`;
-      return { dataUrl, bytes, mimeType: delta.file.mediaType, text };
-    }
+  const definition = getSupportedImageModelDefinition(request.model);
+  if (!definition) {
+    throw new Error(`Unsupported image model: ${request.model}`);
   }
-
-  throw new Error("Image provider returned no image");
+  const env = getCloudAwareEnv();
+  return await getImageProvider(definition.billingSource).generate({
+    model: request.model,
+    prompt: buildImagePrompt(request),
+    sourceImage: request.sourceImage,
+    aspectRatio: request.aspectRatio,
+    size: request.width && request.height ? `${request.width}x${request.height}` : undefined,
+    apiKeys: {
+      OPENROUTER_API_KEY: env.OPENROUTER_API_KEY,
+      FAL_KEY: env.FAL_KEY,
+      FAL_API_KEY: env.FAL_API_KEY,
+    },
+  });
 }
 
 app.post("/", async (c) => {
@@ -202,13 +166,12 @@ app.post("/", async (c) => {
         },
       );
     }
-    if (!hasLanguageModelProviderConfigured(request.model)) {
-      return jsonError(
-        c,
-        503,
-        getAiProviderConfigurationError(),
-        "internal_error",
-      );
+    const env = getCloudAwareEnv();
+    if (definition.billingSource === "openrouter" && !env.OPENROUTER_API_KEY) {
+      return jsonError(c, 503, getAiProviderConfigurationError(), "internal_error");
+    }
+    if (definition.billingSource === "fal" && !env.FAL_KEY && !env.FAL_API_KEY) {
+      return jsonError(c, 503, getAiProviderConfigurationError(), "internal_error");
     }
 
     await contentSafetyService.assertSafeForPublicUse({

--- a/packages/cloud-shared/src/db/migrations/0135_app_image_generation_idempotency.sql
+++ b/packages/cloud-shared/src/db/migrations/0135_app_image_generation_idempotency.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS app_image_generation_idempotency (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  key text NOT NULL,
+  app_id uuid NOT NULL REFERENCES apps(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  request_hash text NOT NULL,
+  status text NOT NULL DEFAULT 'processing',
+  charge_id uuid,
+  charge jsonb,
+  provider_result jsonb,
+  generation_ids jsonb NOT NULL DEFAULT '[]'::jsonb,
+  response_body jsonb,
+  error_code text,
+  expires_at timestamp NOT NULL,
+  created_at timestamp NOT NULL DEFAULT now(),
+  updated_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS app_image_generation_idempotency_key_idx
+  ON app_image_generation_idempotency(key);
+CREATE INDEX IF NOT EXISTS app_image_generation_idempotency_app_user_idx
+  ON app_image_generation_idempotency(app_id, user_id);
+CREATE INDEX IF NOT EXISTS app_image_generation_idempotency_expires_idx
+  ON app_image_generation_idempotency(expires_at);
+CREATE INDEX IF NOT EXISTS app_image_generation_idempotency_status_idx
+  ON app_image_generation_idempotency(status);

--- a/packages/cloud-shared/src/db/schemas/app-image-generation-idempotency.ts
+++ b/packages/cloud-shared/src/db/schemas/app-image-generation-idempotency.ts
@@ -1,0 +1,43 @@
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { index, jsonb, pgTable, text, timestamp, uniqueIndex, uuid } from "drizzle-orm/pg-core";
+import { apps } from "./apps";
+import { users } from "./users";
+
+export const appImageGenerationIdempotency = pgTable(
+  "app_image_generation_idempotency",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    key: text("key").notNull(),
+    app_id: uuid("app_id")
+      .notNull()
+      .references(() => apps.id, { onDelete: "cascade" }),
+    user_id: uuid("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    request_hash: text("request_hash").notNull(),
+    status: text("status").notNull().default("processing"),
+    charge_id: uuid("charge_id"),
+    charge: jsonb("charge").$type<Record<string, unknown>>(),
+    provider_result: jsonb("provider_result").$type<Record<string, unknown>>(),
+    generation_ids: jsonb("generation_ids").$type<string[]>().default([]).notNull(),
+    response_body: jsonb("response_body").$type<Record<string, unknown>>(),
+    error_code: text("error_code"),
+    expires_at: timestamp("expires_at").notNull(),
+    created_at: timestamp("created_at").notNull().defaultNow(),
+    updated_at: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => ({
+    key_unique: uniqueIndex("app_image_generation_idempotency_key_idx").on(table.key),
+    app_user_idx: index("app_image_generation_idempotency_app_user_idx").on(
+      table.app_id,
+      table.user_id,
+    ),
+    expires_idx: index("app_image_generation_idempotency_expires_idx").on(table.expires_at),
+    status_idx: index("app_image_generation_idempotency_status_idx").on(table.status),
+  }),
+);
+
+export type AppImageGenerationIdempotency = InferSelectModel<typeof appImageGenerationIdempotency>;
+export type NewAppImageGenerationIdempotency = InferInsertModel<
+  typeof appImageGenerationIdempotency
+>;

--- a/packages/cloud-shared/src/db/schemas/index.ts
+++ b/packages/cloud-shared/src/db/schemas/index.ts
@@ -30,6 +30,7 @@ export * from "./app-credit-balances";
 export * from "./app-databases";
 export * from "./app-domains";
 export * from "./app-earnings";
+export * from "./app-image-generation-idempotency";
 export * from "./apps";
 export * from "./auth-events";
 export * from "./cli-auth-sessions";

--- a/packages/cloud-shared/src/lib/providers/image/fal-image-generation.ts
+++ b/packages/cloud-shared/src/lib/providers/image/fal-image-generation.ts
@@ -1,6 +1,9 @@
 import { getAiProviderConfigurationError } from "../language-model";
 import type { GeneratedImage, ImageGenRequest, ImageProvider } from "./types";
 
+const FAL_IMAGE_DOWNLOAD_TIMEOUT_MS = 30_000;
+const FAL_IMAGE_MAX_BYTES = 20 * 1024 * 1024;
+
 function bytesToBase64(bytes: Uint8Array): string {
   let binary = "";
   const chunkSize = 0x8000;
@@ -11,14 +14,56 @@ function bytesToBase64(bytes: Uint8Array): string {
   return btoa(binary);
 }
 
+async function readImageWithLimit(response: Response): Promise<Uint8Array> {
+  const declaredLength = Number(response.headers.get("content-length") ?? "0");
+  if (declaredLength > FAL_IMAGE_MAX_BYTES) {
+    throw new Error("fal image download exceeded maximum size");
+  }
+
+  if (!response.body) {
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > FAL_IMAGE_MAX_BYTES) {
+      throw new Error("fal image download exceeded maximum size");
+    }
+    return new Uint8Array(buffer);
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    received += value.byteLength;
+    if (received > FAL_IMAGE_MAX_BYTES) {
+      await reader.cancel().catch(() => undefined);
+      throw new Error("fal image download exceeded maximum size");
+    }
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
 async function imageUrlToGeneratedImage(url: string, text = ""): Promise<GeneratedImage> {
-  const response = await fetch(url);
+  const response = await fetch(url, { signal: AbortSignal.timeout(FAL_IMAGE_DOWNLOAD_TIMEOUT_MS) });
   if (!response.ok) {
     throw new Error(`fal image download failed: ${response.status}`);
   }
 
-  const bytes = new Uint8Array(await response.arrayBuffer());
-  const mimeType = response.headers.get("content-type")?.split(";")[0] || "image/png";
+  const mimeType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase();
+  if (!mimeType?.startsWith("image/")) {
+    throw new Error("fal image download returned non-image content");
+  }
+
+  const bytes = await readImageWithLimit(response);
   const dataUrl = `data:${mimeType};base64,${bytesToBase64(bytes)}`;
   return { dataUrl, bytes, mimeType, text };
 }

--- a/packages/cloud-shared/src/lib/providers/image/fal-image-generation.ts
+++ b/packages/cloud-shared/src/lib/providers/image/fal-image-generation.ts
@@ -1,0 +1,74 @@
+import { getAiProviderConfigurationError } from "../language-model";
+import type { GeneratedImage, ImageGenRequest, ImageProvider } from "./types";
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+async function imageUrlToGeneratedImage(url: string, text = ""): Promise<GeneratedImage> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`fal image download failed: ${response.status}`);
+  }
+
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  const mimeType = response.headers.get("content-type")?.split(";")[0] || "image/png";
+  const dataUrl = `data:${mimeType};base64,${bytesToBase64(bytes)}`;
+  return { dataUrl, bytes, mimeType, text };
+}
+
+function extractFalImageUrl(payload: Record<string, unknown>): { url: string; text: string } {
+  const images = Array.isArray(payload.images) ? payload.images : [];
+  const firstImage = images[0] as { url?: unknown } | undefined;
+  const url = typeof firstImage?.url === "string" ? firstImage.url : undefined;
+  if (!url) {
+    throw new Error("fal image provider returned no image url");
+  }
+
+  const text = typeof payload.description === "string" ? payload.description : "";
+  return { url, text };
+}
+
+export async function generateFalImage(request: ImageGenRequest): Promise<GeneratedImage> {
+  const apiKey = request.apiKeys.FAL_KEY ?? request.apiKeys.FAL_API_KEY;
+  if (!apiKey) {
+    throw new Error(getAiProviderConfigurationError());
+  }
+
+  const response = await fetch(`https://fal.run/${request.model}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Key ${apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      prompt: request.prompt,
+      ...(request.sourceImage ? { image_url: request.sourceImage } : {}),
+      ...(request.aspectRatio ? { aspect_ratio: request.aspectRatio } : {}),
+      ...(request.size ? { image_size: request.size } : {}),
+    }),
+  });
+
+  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!response.ok) {
+    const detail = typeof payload.detail === "string" ? payload.detail : undefined;
+    throw new Error(detail ?? `fal image generation failed: ${response.status}`);
+  }
+
+  const { url, text } = extractFalImageUrl(payload);
+  return await imageUrlToGeneratedImage(url, text);
+}
+
+export const falImageProvider: ImageProvider = {
+  billingSource: "fal",
+  generate: generateFalImage,
+  async healthCheck() {
+    return true;
+  },
+};

--- a/packages/cloud-shared/src/lib/providers/image/openrouter-image-generation.ts
+++ b/packages/cloud-shared/src/lib/providers/image/openrouter-image-generation.ts
@@ -1,0 +1,104 @@
+import { getAiProviderConfigurationError } from "../language-model";
+import type { GeneratedImage, ImageGenRequest, ImageProvider } from "./types";
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function dataUrlToImage(dataUrl: string): { bytes: Uint8Array; mimeType: string } {
+  const match = /^data:([^;,]+);base64,(.+)$/s.exec(dataUrl);
+  if (!match) {
+    throw new Error("Image provider returned an invalid image data URL");
+  }
+  return { mimeType: match[1], bytes: base64ToBytes(match[2]) };
+}
+
+function buildOpenRouterMessages(request: ImageGenRequest) {
+  if (!request.sourceImage) {
+    return [{ role: "user", content: request.prompt }];
+  }
+
+  return [
+    {
+      role: "user",
+      content: [
+        { type: "text", text: request.prompt },
+        { type: "image_url", image_url: { url: request.sourceImage } },
+      ],
+    },
+  ];
+}
+
+function extractOpenRouterImage(payload: Record<string, unknown>): {
+  dataUrl: string;
+  text: string;
+} {
+  const choices = Array.isArray(payload.choices) ? payload.choices : [];
+  const message = (choices[0] as { message?: Record<string, unknown> } | undefined)?.message;
+  const images = Array.isArray(message?.images) ? message.images : [];
+  const firstImage = images[0] as { image_url?: string | { url?: string } } | undefined;
+  const imageUrl = firstImage?.image_url;
+  const dataUrl = typeof imageUrl === "string" ? imageUrl : imageUrl?.url;
+  if (!dataUrl) {
+    throw new Error("Image provider returned no image");
+  }
+
+  const content = message?.content;
+  const text = typeof content === "string" ? content : "";
+  return { dataUrl, text };
+}
+
+export async function generateOpenRouterImage(request: ImageGenRequest): Promise<GeneratedImage> {
+  const apiKey = request.apiKeys.OPENROUTER_API_KEY;
+  if (!apiKey) {
+    throw new Error(getAiProviderConfigurationError());
+  }
+
+  const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+      "http-referer": "https://elizacloud.ai",
+      "x-title": "Eliza Cloud Image Generation",
+    },
+    body: JSON.stringify({
+      model: request.model,
+      messages: buildOpenRouterMessages(request),
+      modalities: ["image", "text"],
+      ...(request.aspectRatio || request.size
+        ? {
+            image_config: {
+              ...(request.aspectRatio ? { aspect_ratio: request.aspectRatio } : {}),
+              ...(request.size ? { size: request.size } : {}),
+            },
+          }
+        : {}),
+    }),
+  });
+
+  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!response.ok) {
+    const error = payload.error as { message?: string; code?: string } | undefined;
+    const message = error?.message ?? `OpenRouter image generation failed: ${response.status}`;
+    const code = error?.code ? ` (${error.code})` : "";
+    throw new Error(`${message}${code}`);
+  }
+
+  const { dataUrl, text } = extractOpenRouterImage(payload);
+  const { bytes, mimeType } = dataUrlToImage(dataUrl);
+  return { dataUrl, bytes, mimeType, text };
+}
+
+export const openRouterImageProvider: ImageProvider = {
+  billingSource: "openrouter",
+  generate: generateOpenRouterImage,
+  async healthCheck() {
+    return true;
+  },
+};

--- a/packages/cloud-shared/src/lib/providers/image/registry.ts
+++ b/packages/cloud-shared/src/lib/providers/image/registry.ts
@@ -1,0 +1,16 @@
+import type { PricingBillingSource } from "../../services/ai-pricing-definitions";
+import type { ImageProvider } from "./types";
+
+const PROVIDERS = new Map<PricingBillingSource, ImageProvider>();
+
+export function registerImageProvider(provider: ImageProvider) {
+  PROVIDERS.set(provider.billingSource, provider);
+}
+
+export function getImageProvider(billingSource: PricingBillingSource): ImageProvider {
+  const provider = PROVIDERS.get(billingSource);
+  if (!provider) {
+    throw new Error(`No image provider registered for billing source: ${billingSource}`);
+  }
+  return provider;
+}

--- a/packages/cloud-shared/src/lib/providers/image/registry.ts
+++ b/packages/cloud-shared/src/lib/providers/image/registry.ts
@@ -1,4 +1,5 @@
 import type { PricingBillingSource } from "../../services/ai-pricing-definitions";
+import { falImageProvider } from "./fal-image-generation";
 import { openRouterImageProvider } from "./openrouter-image-generation";
 import type { ImageProvider } from "./types";
 
@@ -17,3 +18,4 @@ export function getImageProvider(billingSource: PricingBillingSource): ImageProv
 }
 
 registerImageProvider(openRouterImageProvider);
+registerImageProvider(falImageProvider);

--- a/packages/cloud-shared/src/lib/providers/image/registry.ts
+++ b/packages/cloud-shared/src/lib/providers/image/registry.ts
@@ -1,4 +1,5 @@
 import type { PricingBillingSource } from "../../services/ai-pricing-definitions";
+import { openRouterImageProvider } from "./openrouter-image-generation";
 import type { ImageProvider } from "./types";
 
 const PROVIDERS = new Map<PricingBillingSource, ImageProvider>();
@@ -14,3 +15,5 @@ export function getImageProvider(billingSource: PricingBillingSource): ImageProv
   }
   return provider;
 }
+
+registerImageProvider(openRouterImageProvider);

--- a/packages/cloud-shared/src/lib/providers/image/types.ts
+++ b/packages/cloud-shared/src/lib/providers/image/types.ts
@@ -1,0 +1,23 @@
+import type { PricingBillingSource } from "../../services/ai-pricing-definitions";
+
+export interface ImageGenRequest {
+  model: string;
+  prompt: string;
+  sourceImage?: string;
+  aspectRatio?: string;
+  size?: string;
+  apiKeys: Record<string, string | undefined>;
+}
+
+export interface GeneratedImage {
+  dataUrl: string;
+  bytes: Uint8Array;
+  mimeType: string;
+  text: string;
+}
+
+export interface ImageProvider {
+  billingSource: PricingBillingSource;
+  generate(req: ImageGenRequest): Promise<GeneratedImage>;
+  healthCheck?(): Promise<boolean>;
+}

--- a/packages/cloud-shared/src/lib/services/ai-pricing-definitions.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing-definitions.ts
@@ -120,7 +120,7 @@ export const PRICING_LEGACY_IDS_BY_TARGET = buildPricingLegacyIdsByTarget(PRICIN
 export interface SupportedImageModelDefinition {
   modelId: string;
   provider: string;
-  billingSource: "openrouter";
+  billingSource: PricingBillingSource;
   label: string;
   sourceUrl: string;
   defaultDimensions?: Record<string, string | number | boolean | null>;
@@ -239,6 +239,22 @@ export const SUPPORTED_IMAGE_MODELS: SupportedImageModelDefinition[] = [
     label: "GPT-5 Image",
     sourceUrl: "https://openrouter.ai/api/v1/models",
     defaultDimensions: { size: "1024x1024", quality: "high" },
+  },
+  {
+    modelId: "fal-ai/flux/schnell",
+    provider: "fal",
+    billingSource: "fal",
+    label: "FLUX.1 Schnell",
+    sourceUrl: "https://fal.ai/models/fal-ai/flux/schnell",
+    defaultDimensions: { image_size: "square_hd" },
+  },
+  {
+    modelId: "fal-ai/flux/dev",
+    provider: "fal",
+    billingSource: "fal",
+    label: "FLUX.1 Dev",
+    sourceUrl: "https://fal.ai/models/fal-ai/flux/dev",
+    defaultDimensions: { image_size: "square_hd" },
   },
 ] as const;
 

--- a/packages/cloud-shared/src/lib/services/ai-pricing/providers/fal.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/providers/fal.ts
@@ -3,7 +3,9 @@ import type { PricingDimensions } from "../../../../db/schemas/ai-pricing";
 import { logger } from "../../../utils/logger";
 import {
   type PricingChargeUnit,
+  SUPPORTED_IMAGE_MODELS,
   SUPPORTED_VIDEO_MODELS,
+  type SupportedImageModelDefinition,
   type SupportedVideoModelDefinition,
 } from "../../ai-pricing-definitions";
 import { getCachedExternalEntries } from "../cache";
@@ -47,6 +49,47 @@ export function buildFalEntry(
     staleAfter: new Date(fetchedAt.getTime() + EXTERNAL_CACHE_TTL_MS),
     metadata,
   };
+}
+
+function buildFalImageEntry(
+  model: SupportedImageModelDefinition,
+  unitPrice: number,
+  metadata?: Record<string, unknown>,
+): PreparedPricingEntry {
+  const fetchedAt = new Date();
+  return {
+    billingSource: "fal",
+    provider: model.provider,
+    model: model.modelId,
+    productFamily: "image",
+    chargeType: "generation",
+    unit: "image",
+    unitPrice,
+    dimensions: model.defaultDimensions,
+    sourceKind: "fal_model_page",
+    sourceUrl: model.sourceUrl,
+    fetchedAt,
+    staleAfter: new Date(fetchedAt.getTime() + EXTERNAL_CACHE_TTL_MS),
+    metadata,
+  };
+}
+
+function buildFalImageSnapshotEntries(): PreparedPricingEntry[] {
+  const priceByModel: Record<string, number> = {
+    "fal-ai/flux/schnell": 0.003,
+    "fal-ai/flux/dev": 0.025,
+  };
+
+  return SUPPORTED_IMAGE_MODELS.filter((model) => model.billingSource === "fal").flatMap((model) => {
+    const unitPrice = priceByModel[model.modelId];
+    if (unitPrice === undefined) return [];
+    return [
+      buildFalImageEntry(model, unitPrice, {
+        tier: "manual_override_recommended",
+        note: "Manual fal image pricing seed. Refresh with account-specific pricing before production if needed.",
+      }),
+    ];
+  });
 }
 
 export function parseFalPricingEntries(
@@ -317,6 +360,10 @@ export async function fetchFalCatalogEntries(): Promise<PreparedPricingEntry[]> 
       }),
     );
 
-    return [...entryArrays.flat(), ...buildMusicSnapshotEntries("fal", "fal_model_page")];
+    return [
+      ...entryArrays.flat(),
+      ...buildFalImageSnapshotEntries(),
+      ...buildMusicSnapshotEntries("fal", "fal_model_page"),
+    ];
   });
 }

--- a/packages/cloud-shared/src/lib/services/ai-pricing/providers/fal.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/providers/fal.ts
@@ -80,16 +80,18 @@ function buildFalImageSnapshotEntries(): PreparedPricingEntry[] {
     "fal-ai/flux/dev": 0.025,
   };
 
-  return SUPPORTED_IMAGE_MODELS.filter((model) => model.billingSource === "fal").flatMap((model) => {
-    const unitPrice = priceByModel[model.modelId];
-    if (unitPrice === undefined) return [];
-    return [
-      buildFalImageEntry(model, unitPrice, {
-        tier: "manual_override_recommended",
-        note: "Manual fal image pricing seed. Refresh with account-specific pricing before production if needed.",
-      }),
-    ];
-  });
+  return SUPPORTED_IMAGE_MODELS.filter((model) => model.billingSource === "fal").flatMap(
+    (model) => {
+      const unitPrice = priceByModel[model.modelId];
+      if (unitPrice === undefined) return [];
+      return [
+        buildFalImageEntry(model, unitPrice, {
+          tier: "manual_override_recommended",
+          note: "Manual fal image pricing seed. Refresh with account-specific pricing before production if needed.",
+        }),
+      ];
+    },
+  );
 }
 
 export function parseFalPricingEntries(

--- a/packages/cloud-shared/src/lib/services/app-credits.ts
+++ b/packages/cloud-shared/src/lib/services/app-credits.ts
@@ -149,6 +149,7 @@ export interface AppCreditDeductionResult {
   totalCost: number;
   creatorEarnings: number;
   newBalance: number;
+  transactionId?: string;
   message?: string;
 }
 
@@ -447,33 +448,62 @@ export class AppCreditsService {
       };
     }
 
-    // Track app user activity (creates/updates app_users record)
-    await this.trackAppUserActivity(app, userId, totalCost.toFixed(4), metadata);
+    try {
+      // Track app user activity (creates/updates app_users record)
+      await this.trackAppUserActivity(app, userId, totalCost.toFixed(4), metadata);
 
-    if (app.monetization_enabled && creatorMarkup > 0) {
-      await this.recordCreatorEarnings(
+      if (app.monetization_enabled && creatorMarkup > 0) {
+        await this.recordCreatorEarnings(
+          appId,
+          userId,
+          "inference_markup",
+          creatorMarkup,
+          {
+            baseCost,
+            markupPercentage,
+            totalCost,
+            description,
+            chargeTransactionId: orgDeduct.transaction?.id,
+            ...metadata,
+          },
+          app, // Pass app to avoid N+1 query
+        );
+
+        await dbWrite
+          .update(apps)
+          .set({
+            total_creator_earnings: sql`${apps.total_creator_earnings} + ${creatorMarkup}`,
+            total_platform_revenue: sql`${apps.total_platform_revenue} + ${baseCost}`,
+            updated_at: new Date(),
+          })
+          .where(eq(apps.id, appId));
+      }
+    } catch (postDebitError) {
+      logger.error("[AppCredits] Post-debit accounting failed, compensating charge", {
         appId,
         userId,
-        "inference_markup",
+        baseCost,
         creatorMarkup,
-        {
+        totalCost,
+        chargeTransactionId: orgDeduct.transaction?.id,
+        error: postDebitError instanceof Error ? postDebitError.message : String(postDebitError),
+      });
+      await creditsService.addCredits({
+        organizationId: user.organization_id,
+        amount: totalCost,
+        description: `Compensation refund for failed app inference (${app.name ?? appId})`,
+        metadata: {
+          appId,
+          userId,
           baseCost,
-          markupPercentage,
+          creatorMarkup,
           totalCost,
-          description,
+          originalChargeTransactionId: orgDeduct.transaction?.id,
+          reason: "post_debit_accounting_failed",
           ...metadata,
         },
-        app, // Pass app to avoid N+1 query
-      );
-
-      await dbWrite
-        .update(apps)
-        .set({
-          total_creator_earnings: sql`${apps.total_creator_earnings} + ${creatorMarkup}`,
-          total_platform_revenue: sql`${apps.total_platform_revenue} + ${baseCost}`,
-          updated_at: new Date(),
-        })
-        .where(eq(apps.id, appId));
+      });
+      throw postDebitError;
     }
 
     logger.info("[AppCredits] Deducted credits", {
@@ -492,6 +522,7 @@ export class AppCreditsService {
       totalCost,
       creatorEarnings: creatorMarkup,
       newBalance: orgDeduct.newBalance,
+      transactionId: orgDeduct.transaction?.id,
     };
   }
 


### PR DESCRIPTION
## What this does
Supersedes #8048 and #8059 by combining both behind a clean image-provider abstraction, so adding a new image/inference provider (fal, Atlas Cloud, etc.) is a one-file change with zero route edits.

### The abstraction
- `packages/cloud-shared/src/lib/providers/image/types.ts` — `ImageProvider` interface (billingSource + generate() + optional healthCheck), `ImageGenRequest`, `GeneratedImage`.
- `.../image/registry.ts` — `registerImageProvider` / `getImageProvider` keyed by `PricingBillingSource`.
- `.../image/openrouter-image-generation.ts` — OpenRouter executor (from #8048).
- `.../image/fal-image-generation.ts` + `ai-pricing/providers/fal.ts` — fal executor + catalog/pricing rows. Proves the abstraction: a new provider is one file + one register line + catalog rows.

### Routes
- `v1/apps/[id]/generate-image/route.ts` — unified metered per-app route: validates model -> resolves billingSource -> dispatches via registry -> bills via appCredits with creator markup -> returns settled charge. (resolves the #8048/#8059 conflict)
- `v1/generate-image/route.ts` — base route now routes through the registry too.
- `v1/apps/route.ts` — keeps #8059's create-app one-call monetization (monetization_enabled + inference_markup_percentage).

### How to add a provider (e.g. Atlas Cloud)
1. Write `image/atlas-image-generation.ts` implementing `ImageProvider`.
2. `registerImageProvider(atlasProvider)`.
3. Add the Atlas image models to `SUPPORTED_IMAGE_MODELS` with `billingSource: "atlas"` + pricing rows.
No route changes.

Supersedes #8048 and #8059.

Co-authored-by: lalalune <lalalune@users.noreply.github.com>
Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a unified `ImageProvider` abstraction (types, registry, fal + OpenRouter executors) so future providers require only a new file and a `registerImageProvider` call. It also rewrites the per-app generate-image route with idempotency via a new `app_image_generation_idempotency` table, migrates both routes away from the AI SDK's `streamText` to direct provider calls, adds fal FLUX Schnell/Dev models with pricing seeds, and hardens `app-credits.ts` post-debit accounting with a compensation-refund catch block.

- **Provider abstraction**: `ImageProvider` interface + registry pattern; fal and OpenRouter executors replace the inline `streamText` calls in both route files.
- **Idempotency**: New DB table and route logic claim, track, and release idempotency slots; completed responses are cached and replayed on retry.
- **app-credits.ts**: Post-debit bookkeeping (`recordCreatorEarnings` + `apps.update`) is now wrapped in a try/catch that compensates the caller on failure and exposes `transactionId` in the return value.

<h3>Confidence Score: 3/5</h3>

Not ready to merge: billing-correctness issues from prior reviews remain unaddressed, and both new inference providers lack request timeouts that could leave users charged without a refund path.

The per-app route still performs a full credit refund with actualBaseCost=0 even when some images were already stored to R2, idempotency rows are left in processing on early validation exits that bypass the catch block, and images are made publicly accessible before the output safety check completes. Both new provider files issue their upstream inference fetch calls with no AbortSignal timeout — if inference stalls until Cloudflare terminates the worker, the catch block never runs, credits are not refunded, and the idempotency slot stays locked.

packages/cloud-api/v1/apps/[id]/generate-image/route.ts (idempotency cleanup on early returns, partial refund logic), packages/cloud-shared/src/lib/providers/image/fal-image-generation.ts and openrouter-image-generation.ts (inference call timeouts), packages/cloud-shared/src/lib/services/app-credits.ts (creator earnings ordering)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/cloud-api/src/middleware/auth.ts | Adds /api/v1/apps/:id/generate-image to isPublicPath, bypassing global auth middleware for a billing-sensitive endpoint (previously flagged). |
| packages/cloud-api/v1/apps/[id]/generate-image/route.ts | Major rewrite: adds idempotency, provider registry routing, fail-open content safety, and structured error sanitization. Several issues from prior reviews remain unaddressed. |
| packages/cloud-api/v1/generate-image/route.ts | Migrates generateOneImage from inline streamText to the provider registry; logic otherwise unchanged. |
| packages/cloud-shared/src/db/migrations/0135_app_image_generation_idempotency.sql | New migration creates app_image_generation_idempotency with FK cascades and covering indexes. |
| packages/cloud-shared/src/db/schemas/app-image-generation-idempotency.ts | Drizzle schema mirrors the SQL migration exactly. |
| packages/cloud-shared/src/lib/providers/image/fal-image-generation.ts | New fal provider: CDN download has a 30s timeout and 20MB cap, but the fal.run inference call has no timeout. |
| packages/cloud-shared/src/lib/providers/image/openrouter-image-generation.ts | New OpenRouter provider: replaces AI-SDK streamText with direct fetch but omits AbortSignal timeout on the inference call. |
| packages/cloud-shared/src/lib/providers/image/registry.ts | Minimal Map-based registry; both providers registered at module-init time. |
| packages/cloud-shared/src/lib/providers/image/types.ts | Well-typed ImageProvider interface with billingSource, generate, and optional healthCheck. |
| packages/cloud-shared/src/lib/services/ai-pricing-definitions.ts | Widens billingSource type and adds fal FLUX Schnell/Dev model entries. |
| packages/cloud-shared/src/lib/services/ai-pricing/providers/fal.ts | Adds manually seeded per-image pricing entries for fal FLUX models. |
| packages/cloud-shared/src/lib/services/app-credits.ts | Wraps post-debit accounting in a compensation-refund try/catch and exposes transactionId. Creator-earnings inconsistency from prior reviews persists. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Caller
    participant R as Route
    participant DB as Database
    participant CR as AppCreditsService
    participant P as ImageProvider
    participant R2 as R2 Storage
    participant CS as ContentSafety

    C->>R: POST /api/v1/apps/:id/generate-image
    R->>DB: auth + getApp + claim idempotency row
    R->>CS: assertSafeFailOpen prompt
    R->>CR: deductCredits upfront
    CR-->>R: transactionId baseCost totalCost
    R->>DB: UPDATE idempotency charged
    loop for each image
        R->>P: provider.generate
        P-->>R: dataUrl bytes mimeType
        R->>R2: putPublicObject
        R->>CS: assertSafeFailOpen output
    end
    R->>DB: UPDATE idempotency completed
    R-->>C: success images cost charge
    alt generation error
        R->>R2: deleteStoredImages
        R->>CR: reconcileCredits full refund
        R->>DB: DELETE idempotency row
        R-->>C: error
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cloud-api/src/middleware/auth.ts`, line 75 ([link](https://github.com/elizaos/eliza/blob/0d5b27966398f10078186fcf770b5151cc5c6bcc/packages/cloud-api/src/middleware/auth.ts#L75)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Billing endpoint bypasses global auth middleware**

   `/api/v1/apps/:id/generate-image` is added to `isPublicPath`, which skips the global auth middleware entirely. The route handler does call `requireUserOrApiKeyWithOrg` internally, but bypassing the central middleware removes any defense-in-depth measures it provides — session invalidation checks, token blacklisting, or standardized auth error handling that may differ from what `requireUserOrApiKeyWithOrg` alone provides. For an endpoint that deducts credits and triggers paid inference, this is worth aligning with how other billing-sensitive routes are protected (none of the other credit/billing endpoints are in `isPublicPath`).
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["style(cloud): biome organize-imports + f..."](https://github.com/elizaos/eliza/commit/7d5935ee22c99b9b2f741b035bcb9218dde77c57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34703719)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->