### PR TITLE
fix(core): resolve web lookups to a search action, never a shell fallback

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -4,6 +4,7 @@ import type { ActionResult, IAgentRuntime } from "../index";
 import {
 	actionResultsSuppressPostActionContinuation,
 	extractPlannerActionNames,
+	findWebLookupActionName,
 	inferLocalShellCommandFromMessageText,
 	inferWebSearchQueryFromMessageText,
 	looksLikeSelfPolicyExplanationRequest,
@@ -147,6 +148,20 @@ describe("live routing regressions", () => {
 				"what is the current BTC price in USD? answer briefly.",
 			),
 		).toBe("current BTC price in USD");
+	});
+
+	it("resolves web lookups to a search action and never falls back to shell", () => {
+		// A real search backend satisfies the lookup (preferred over a shell).
+		expect(
+			findWebLookupActionName([{ name: "BRAVE_SEARCH" }, { name: "SHELL" }]),
+		).toBe("BRAVE_SEARCH");
+		// With only a shell available there is no web-lookup action: return
+		// undefined so the model answers directly instead of force-routing a
+		// live-info ask ("current price of X") to SHELL — a tool a weak planner
+		// can't drive, which loops on the required-tool cap and surfaces a
+		// generic failure. Genuine shell requests route via looksLikeLocalShellRequest.
+		expect(findWebLookupActionName([{ name: "SHELL" }])).toBeUndefined();
+		expect(findWebLookupActionName([])).toBeUndefined();
 	});
 
 	it("promotes explicit reply to direct shell/search action aliases", () => {

--- a/packages/core/src/__tests__/message-runtime-stage1.test.ts
+++ b/packages/core/src/__tests__/message-runtime-stage1.test.ts
@@ -1475,7 +1475,7 @@ android smoke model works`,
 		}
 	});
 
-	it("routes legacy Stage 1 current-info acknowledgements to shell when no web search action is registered", async () => {
+	it("declines current-info acknowledgements when only a shell is registered (no web-lookup action)", async () => {
 		const runtime = makeRuntime([
 			JSON.stringify({
 				processMessage: "RESPOND",
@@ -1547,24 +1547,21 @@ android smoke model works`,
 			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
 		});
 
-		expect(result.kind).toBe("planned_reply");
-		expect(shellHandler).toHaveBeenCalledTimes(1);
+		// A shell is not a web-lookup tool. With no real search action
+		// registered, a live-info ask is not force-routed to SHELL as a
+		// required tool — a weak planner can't drive it, so it would loop on
+		// the required-tool cap and surface a generic failure. The model
+		// answers directly instead. Genuine shell requests still route via the
+		// separate looksLikeLocalShellRequest path.
+		expect(result.kind).toBe("direct_reply");
+		expect(shellHandler).not.toHaveBeenCalled();
 		const calls = useModelCalls(runtime);
-		expect(calls[1]?.[0]).toBe(ModelType.ACTION_PLANNER);
-		const plannerCall = calls[1]?.[1] as {
-			messages?: Array<{ role?: string; content?: string | null }>;
-		};
-		const plannerUserContent = plannerCall.messages?.[1]?.content ?? "";
-		expect(plannerUserContent).toContain('"candidateActions":["SHELL"]');
-		expect(plannerUserContent).toContain('"requiresTool":true');
-		if (result.kind === "planned_reply") {
-			expect(result.result.responseContent?.text).toBe(
-				"BTC current price fetched from shell.",
-			);
-		}
+		expect(calls.every((call) => call[0] !== ModelType.ACTION_PLANNER)).toBe(
+			true,
+		);
 	});
 
-	it("routes synthetic current-price Stage 1 candidates to a real shell lookup action", async () => {
+	it("declines synthetic current-price candidates when only a shell lookup is registered", async () => {
 		const runtime = makeRuntime([
 			stage1Response({
 				contexts: [],
@@ -1638,24 +1635,17 @@ android smoke model works`,
 			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
 		});
 
-		expect(result.kind).toBe("planned_reply");
-		expect(shellHandler).toHaveBeenCalledTimes(1);
+		// GET_CRYPTO_PRICE is not a registered action, and a shell is not a
+		// web-lookup tool — so there is no real lookup action to force. The
+		// model answers directly rather than looping on an unfulfillable
+		// required SHELL call.
+		expect(result.kind).toBe("direct_reply");
+		expect(shellHandler).not.toHaveBeenCalled();
 		expect(browserHandler).not.toHaveBeenCalled();
 		const calls = useModelCalls(runtime);
-		expect(calls[1]?.[0]).toBe(ModelType.ACTION_PLANNER);
-		const plannerCall = calls[1]?.[1] as {
-			messages?: Array<{ role?: string; content?: string | null }>;
-		};
-		const plannerUserContent = plannerCall.messages?.[1]?.content ?? "";
-		expect(plannerUserContent).toContain(
-			'"candidateActions":["GET_CRYPTO_PRICE","SHELL"]',
+		expect(calls.every((call) => call[0] !== ModelType.ACTION_PLANNER)).toBe(
+			true,
 		);
-		expect(plannerUserContent).toContain('"tierAParents":["SHELL"]');
-		if (result.kind === "planned_reply") {
-			expect(result.result.responseContent?.text).toBe(
-				"BTC current price fetched from shell.",
-			);
-		}
 	});
 
 	it("routes text HANDLE_RESPONSE acknowledgements for current-info requests through web search", async () => {
@@ -1741,7 +1731,7 @@ android smoke model works`,
 		}
 	});
 
-	it("routes legacy Stage 1 current-info acknowledgements to shell when no web search action is registered", async () => {
+	it("declines current-info acknowledgements when only a shell is registered (no web-lookup action)", async () => {
 		const runtime = makeRuntime([
 			JSON.stringify({
 				processMessage: "RESPOND",
@@ -1813,21 +1803,18 @@ android smoke model works`,
 			responseId: "00000000-0000-0000-0000-000000000005" as UUID,
 		});
 
-		expect(result.kind).toBe("planned_reply");
-		expect(shellHandler).toHaveBeenCalledTimes(1);
+		// A shell is not a web-lookup tool. With no real search action
+		// registered, a live-info ask is not force-routed to SHELL as a
+		// required tool — a weak planner can't drive it, so it would loop on
+		// the required-tool cap and surface a generic failure. The model
+		// answers directly instead. Genuine shell requests still route via the
+		// separate looksLikeLocalShellRequest path.
+		expect(result.kind).toBe("direct_reply");
+		expect(shellHandler).not.toHaveBeenCalled();
 		const calls = useModelCalls(runtime);
-		expect(calls[1]?.[0]).toBe(ModelType.ACTION_PLANNER);
-		const plannerCall = calls[1]?.[1] as {
-			messages?: Array<{ role?: string; content?: string | null }>;
-		};
-		const plannerUserContent = plannerCall.messages?.[1]?.content ?? "";
-		expect(plannerUserContent).toContain('"candidateActions":["SHELL"]');
-		expect(plannerUserContent).toContain('"requiresTool":true');
-		if (result.kind === "planned_reply") {
-			expect(result.result.responseContent?.text).toBe(
-				"BTC current price fetched from shell.",
-			);
-		}
+		expect(calls.every((call) => call[0] !== ModelType.ACTION_PLANNER)).toBe(
+			true,
+		);
 	});
 
 	it("routes progress-only coding delegation replies through the planner", () => {

--- a/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
@@ -619,7 +619,7 @@ describe("messageHandlerFromFieldResult — bogus candidate actions", () => {
 		expect(handler.plan.candidateActions).toEqual(["TASKS_SPAWN_AGENT"]);
 	});
 
-	it("adds a real lookup action when Stage 1 emits only a synthetic current-price candidate", () => {
+	it("answers directly when Stage 1 emits only a synthetic current-price candidate and no search action exists", () => {
 		const handler = messageHandlerFromFieldResult(
 			{
 				shouldRespond: "RESPOND",
@@ -637,13 +637,12 @@ describe("messageHandlerFromFieldResult — bogus candidate actions", () => {
 			},
 		);
 
-		expect(handler.plan.simple).toBe(false);
-		expect(handler.plan.requiresTool).toBe(true);
-		expect(handler.plan.contexts).toEqual(["general"]);
-		expect(handler.plan.candidateActions).toEqual([
-			"GET_CRYPTO_PRICE",
-			"SHELL",
-		]);
+		// GET_CRYPTO_PRICE is bogus (not a registered action) and a shell is not
+		// a web-lookup tool, so no real lookup action is substituted in (no
+		// SHELL fallback). The turn is not force-routed through a tool the
+		// planner can't fulfill — it stays a direct reply.
+		expect(handler.plan.simple).toBe(true);
+		expect(handler.plan.candidateActions).not.toContain("SHELL");
 		expect(handler.plan.reply).toBe("On it.");
 	});
 

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3791,30 +3791,32 @@ function looksLikeHighStakesPersonalCrisisRequest(text: string): boolean {
 	);
 }
 
-function findWebLookupActionName(
+/**
+ * Resolve the action that satisfies a web / live-info lookup, or undefined when
+ * the runtime has no real search backend registered.
+ *
+ * A web lookup needs a search action — not a shell. The earlier fallback to a
+ * shell action conflated the two: on a runtime with shell but no search, a
+ * live-info ask ("what's the current price of X") was force-routed to SHELL as
+ * a required tool. A shell is the wrong instrument for that, a weak planner
+ * cannot drive it, and the resulting required-tool loop surfaced a generic
+ * failure instead of an honest "I don't have live access" reply. Returning
+ * undefined lets the model answer directly. Genuine shell requests still route
+ * to a shell action via the separate looksLikeLocalShellRequest path.
+ */
+export function findWebLookupActionName(
 	actions: ReadonlyArray<Pick<Action, "name">>,
 ): string | undefined {
-	return (
-		findAvailableActionName(actions, [
-			"SEARCH",
-			"WEB_SEARCH",
-			"SEARCH_WEB",
-			"BRAVE_SEARCH",
-			"INTERNET_SEARCH",
-			"SEARCH_INTERNET",
-			"LOOKUP_WEB",
-			"GOOGLE",
-		]) ??
-		findAvailableActionName(actions, [
-			"SHELL",
-			"RUN_IN_TERMINAL",
-			"RUN_COMMAND",
-			"EXECUTE_COMMAND",
-			"TERMINAL",
-			"RUN_SHELL",
-			"EXEC",
-		])
-	);
+	return findAvailableActionName(actions, [
+		"SEARCH",
+		"WEB_SEARCH",
+		"SEARCH_WEB",
+		"BRAVE_SEARCH",
+		"INTERNET_SEARCH",
+		"SEARCH_INTERNET",
+		"LOOKUP_WEB",
+		"GOOGLE",
+	]);
 }
 
 function findAvailableActionName(


### PR DESCRIPTION
## What
`findWebLookupActionName` no longer falls back to a SHELL action when no real search action is registered. It returns `undefined`, so the model answers directly (an honest "I don't have live access" decline) instead of force-routing a live-info ask to SHELL as a required tool.

## Why
A shell is not a web-lookup tool. On a backend that has shell but no search action, "what's the current price of X / exchange rates / weather" was force-routed to SHELL as a **required** tool. A weak planner can't drive that, loops on the required-tool cap, and surfaces a generic "something went wrong" (and in practice the sub-agent writes throwaway fetch scripts). Returning `undefined` lets the turn decline honestly. Genuine shell requests still route via the separate `looksLikeLocalShellRequest` path — no regression there.

## Precedent
This is the **action-routing-level symmetry of #7942** (`a79b1d3b5e`), which banned the SHELL fallback for chat-message search/recall at the planner-prompt level. Same principle: a shell is not a substitute for a missing search backend.

## Tests
- Rewrites the 3 "legacy current-info-to-shell" stage-1 tests + 1 bogus-candidate test to the corrected contract (no search action → `direct_reply`, no forced SHELL, `shellHandler` not called).
- Adds a focused unit test for `findWebLookupActionName` (SEARCH/BRAVE_SEARCH preferred; SHELL-only → `undefined`; empty → `undefined`).

Full core suite green locally (1380 passed).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the SHELL action fallback from `findWebLookupActionName`, so web/live-info lookups that find no registered search action now return `undefined` instead of routing to SHELL. The function is also exported to enable direct unit testing.

- **`services/message.ts`**: `findWebLookupActionName` now only returns a search-type action (SEARCH, BRAVE_SEARCH, etc.) or `undefined`; both call sites already guard on the return value with `if (lookupAction)`, so `undefined` naturally falls through to a `direct_reply` without hitting the planner.
- **Tests**: Three stage-1 tests and one bogus-candidate test are rewritten from expecting `planned_reply`+`shellHandler` to expecting `direct_reply`+no planner call; a new focused unit test for `findWebLookupActionName` is added to the live-regression suite.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrow, well-tested, and correctly handled at both call sites.

The only behavioral change is that runtimes with a shell action but no search action no longer force-route web-lookup requests through the planner; they produce a clean direct_reply instead. Both call sites already check if (lookupAction) before acting on the return value, so the new undefined path is handled correctly without any code changes at the call sites. All affected test cases have been rewritten to the corrected contract.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/services/message.ts | Removes the SHELL fallback from findWebLookupActionName; exports the function so it can be unit-tested directly. Both call sites already guard on the returned value, so returning undefined safely produces a direct_reply. |
| packages/core/src/__tests__/message-routing-live-regression.test.ts | Adds a focused unit test for findWebLookupActionName validating SEARCH/BRAVE_SEARCH preferred, SHELL-only returns undefined, and empty returns undefined. |
| packages/core/src/__tests__/message-runtime-stage1.test.ts | Rewrites three shell-fallback stage-1 tests to assert direct_reply and no ACTION_PLANNER call when only a shell action is registered for a web-lookup request. |
| packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts | Updates bogus-candidate test to expect simple=true and no SHELL in candidateActions when only a synthetic action name is present and no real search backend is registered. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Web/live-info lookup request] --> B{looksLikeLocalShellRequest?}
    B -- Yes --> C[findAvailableActionName SHELL aliases]
    C -- found --> D[return shellAction]
    C -- not found --> E{looksLikeWebSearchRequest?}
    B -- No --> E
    E -- Yes --> F[findWebLookupActionName]
    F --> G{Search action registered?\nSEARCH / BRAVE_SEARCH / etc.}
    G -- Yes --> H[return searchAction planned_reply]
    G -- No --> I[return undefined]
    I --> J[return empty array]
    J --> K[direct_reply: honest decline]
    E -- No --> L[other routing checks...]

    style I fill:#f96,color:#000
    style K fill:#6a6,color:#fff
    style H fill:#6a6,color:#fff
```

<sub>Reviews (2): Last reviewed commit: ["fix(core): resolve web lookups to a sear..."](https://github.com/elizaos/eliza/commit/bfd1c056158ca4bf38aae438acab720d92c649ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34754356)</sub>

<!-- /greptile_comment -->