### PR TITLE
feat(deploy): bare-metal systemd bundle for Linux VPS / local Linux (matches the doc)

### DIFF
--- a/deploy/systemd/README.md
+++ b/deploy/systemd/README.md
@@ -1,0 +1,61 @@
+# Eliza bare-metal systemd bundle
+
+Run Eliza directly on a Linux host as **systemd user services** — no Docker,
+no container-in-container. Best for **one bot on one VPS** (or a local Linux
+box) against a personal Claude Max subscription, where you want PTY subagents
+and OAuth to use the same `~/.claude` credentials the `claude` CLI created.
+
+Full guide: **[`/deployment-bare-metal`](../../packages/docs/deployment-bare-metal.mdx)**.
+For Docker / multi-tenant / API-key-first deployments, use the
+[Deployment Guide](../../packages/docs/deployment.mdx) instead.
+
+## Layout
+
+```
+deploy/systemd/
+  install.sh                  idempotent installer (user services)
+  eliza.env.example           env template -> ~/.config/eliza/env on first install
+  units/
+    eliza.service             the bot: Restart=always, OAuth refresh before launch
+    eliza-refresh.{service,timer}   roll the OAuth token every 6h
+    eliza-probe.{service,timer}     health probe every 5 min (restart on failure)
+  bin/
+    eliza-refresh-oauth.sh    refresh only when the token is near expiry; never runs a model
+    eliza-health-probe.sh     /api/health + agentState + auth-log check; restart-on-failure
+```
+
+## Prerequisites
+
+- Linux host with systemd (user sessions + linger). Any modern distro.
+- `bun` on the installing user's `PATH`.
+- `claude` CLI installed and logged in once (`claude auth login`).
+- Run as your normal user — **not** root.
+
+## Install
+
+```bash
+git clone https://github.com/elizaOS/eliza.git
+cd eliza
+./deploy/systemd/install.sh            # or: ./deploy/systemd/install.sh /opt/eliza
+```
+
+The installer substitutes the resolved workdir, your `bun` path, and the log
+path into the unit templates, writes them to `~/.config/systemd/user/`, copies
+the helper scripts to `~/bin/`, seeds `~/.config/eliza/env` on first run,
+enables linger, and starts the service + timers.
+
+## Uninstall
+
+```bash
+systemctl --user disable --now eliza.service eliza-refresh.timer eliza-probe.timer
+rm -f ~/.config/systemd/user/eliza{,-refresh,-probe}.{service,timer}
+rm -f ~/bin/eliza-refresh-oauth.sh ~/bin/eliza-health-probe.sh
+systemctl --user daemon-reload
+loginctl disable-linger "$USER"   # optional
+```
+
+> **Not yet smoke-tested on a fresh host in CI.** The unit/script contract is
+> verified against the running agent (`/api/health` returns
+> `"agentState":"running"`, API on `ELIZA_API_PORT`, OAuth creds at
+> `~/.claude/.credentials.json`), but a first-boot run on a clean VPS should be
+> exercised before this is relied on for production.

--- a/deploy/systemd/bin/eliza-health-probe.sh
+++ b/deploy/systemd/bin/eliza-health-probe.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# eliza-health-probe.sh — active health check; restart the bot if unhealthy.
+#
+# Checks, every run (driven by eliza-probe.timer):
+#   1. GET /api/health responds within 5s,
+#   2. the body reports "agentState":"running",
+#   3. the last 50 bot-log lines contain no "Authentication failed".
+# Any failure triggers `systemctl --user restart eliza.service`. The probe
+# itself always exits 0 — a restart is normal recovery, not a unit failure.
+set -uo pipefail
+
+PORT="${ELIZA_API_PORT:-31337}"
+LOG="${ELIZA_PROBE_LOG:-$HOME/.local/share/eliza/probe.log}"
+BOTLOG="${ELIZA_LOG:-$HOME/.local/share/eliza/bot.log}"
+
+mkdir -p "$(dirname "$LOG")"
+log() { printf '%s %s\n' "$(date -Is)" "$1" >>"$LOG"; }
+restart() {
+  log "UNHEALTHY: $1 — restarting eliza.service"
+  systemctl --user restart eliza.service || log "WARN: restart command failed"
+  exit 0
+}
+
+body="$(curl -fsS -m 5 "http://127.0.0.1:${PORT}/api/health" 2>/dev/null || true)"
+[[ -z "$body" ]] && restart "no /api/health response within 5s"
+
+# Tolerant of whitespace in the JSON body.
+if ! printf '%s' "$body" | tr -d '[:space:]' | grep -q '"agentState":"running"'; then
+  restart "agentState not running"
+fi
+
+if [[ -r "$BOTLOG" ]] && tail -n 50 "$BOTLOG" 2>/dev/null | grep -q "Authentication failed"; then
+  restart "Authentication failed in recent logs"
+fi
+
+# Sparse heartbeat: one line near the top of each hour so the log isn't silent.
+if (( 10#$(date +%M) < 5 )); then
+  log "healthy"
+fi
+exit 0

--- a/deploy/systemd/bin/eliza-refresh-oauth.sh
+++ b/deploy/systemd/bin/eliza-refresh-oauth.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# eliza-refresh-oauth.sh — keep the Claude Code OAuth refresh token rolling.
+#
+# Claude Code OAuth uses rolling refresh tokens: as long as the token is
+# exercised periodically it never expires. This reads the `expiresAt` field in
+# ~/.claude/.credentials.json and only calls `claude auth status` (which hits
+# the auth endpoint and rolls the refresh token) when fewer than
+# ELIZA_OAUTH_REFRESH_THRESHOLD_SECS remain. Otherwise it is a no-op. It never
+# invokes a model.
+#
+# If the refresh token itself has expired (bot offline for a long time), this
+# cannot help — run `claude auth login` once interactively.
+set -euo pipefail
+
+CRED="$HOME/.claude/.credentials.json"
+THRESHOLD="${ELIZA_OAUTH_REFRESH_THRESHOLD_SECS:-3600}"
+LOG="${ELIZA_OAUTH_LOG:-$HOME/.local/share/eliza/oauth-refresh.log}"
+
+mkdir -p "$(dirname "$LOG")"
+log() { printf '%s %s\n' "$(date -Is)" "$1" >>"$LOG"; }
+
+refresh() {
+  if command -v claude >/dev/null 2>&1; then
+    claude auth status --json >/dev/null 2>&1 || log "WARN: 'claude auth status' failed"
+  else
+    log "WARN: 'claude' CLI not on PATH; cannot refresh"
+  fi
+}
+
+if [[ ! -r "$CRED" ]]; then
+  log "no credentials at $CRED — run 'claude auth login' once. skipping."
+  exit 0
+fi
+
+# Read expiresAt (epoch milliseconds). Prefer jq; fall back to a tolerant grep.
+expires_ms=""
+if command -v jq >/dev/null 2>&1; then
+  expires_ms="$(jq -r '.. | .expiresAt? // empty' "$CRED" 2>/dev/null | head -1 || true)"
+fi
+if [[ -z "${expires_ms:-}" || ! "$expires_ms" =~ ^[0-9]+$ ]]; then
+  expires_ms="$(grep -oE '"expiresAt"[[:space:]]*:[[:space:]]*[0-9]+' "$CRED" 2>/dev/null | grep -oE '[0-9]+$' | head -1 || true)"
+fi
+
+if [[ -z "${expires_ms:-}" || ! "$expires_ms" =~ ^[0-9]+$ ]]; then
+  log "could not read expiresAt; refreshing to be safe."
+  refresh
+  exit 0
+fi
+
+now_s="$(date +%s)"
+remaining_s=$(( expires_ms / 1000 - now_s ))
+if (( remaining_s < THRESHOLD )); then
+  log "token expires in ${remaining_s}s (< ${THRESHOLD}s); refreshing."
+  refresh
+else
+  log "token healthy (${remaining_s}s remaining); no-op."
+fi

--- a/deploy/systemd/eliza.env.example
+++ b/deploy/systemd/eliza.env.example
@@ -1,0 +1,17 @@
+# Eliza bare-metal systemd deployment — environment.
+#
+# On first install this file is copied to ~/.config/eliza/env. Edit THAT copy
+# (not this template); the bot and helper scripts read it on every start.
+# Lines are KEY=VALUE (systemd EnvironmentFile format) — no shell expansion.
+
+# Port the bot's HTTP API listens on. The health probe and any clients use it.
+ELIZA_API_PORT=31337
+
+# Absolute path to the bot's log file. The eliza.service unit appends stdout
+# and stderr here; the installer substitutes a default of
+# ~/.local/share/eliza/bot.log when this is unset at install time.
+# ELIZA_LOG=/home/youruser/.local/share/eliza/bot.log
+
+# Refresh the Claude OAuth token when fewer than this many seconds remain
+# before it expires. Default 3600 (1h).
+ELIZA_OAUTH_REFRESH_THRESHOLD_SECS=3600

--- a/deploy/systemd/install.sh
+++ b/deploy/systemd/install.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# install.sh — install Eliza as systemd *user* services (bot + OAuth refresh +
+# health probe). Idempotent: safe to re-run after a git pull to pick up changes.
+#
+# Usage:
+#   ./deploy/systemd/install.sh [WORKDIR]
+#
+# WORKDIR defaults to the repo root that contains this script. Pass an absolute
+# path if the checkout you want the service to run lives elsewhere (e.g.
+# /opt/eliza).
+#
+# See docs: /deployment-bare-metal  (packages/docs/deployment-bare-metal.mdx)
+set -euo pipefail
+
+# --- resolve paths ------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+WORKDIR="${1:-$REPO_ROOT}"
+WORKDIR="$(cd "$WORKDIR" && pwd)"  # normalize to absolute
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  echo "Refusing to run as root — these are user-level services. Run as your normal user." >&2
+  exit 1
+fi
+
+BUN_BIN="$(command -v bun || true)"
+if [[ -z "$BUN_BIN" ]]; then
+  echo "bun not found on PATH. Install bun and re-run." >&2
+  exit 1
+fi
+
+LOG_PATH="${ELIZA_LOG:-$HOME/.local/share/eliza/bot.log}"
+
+UNIT_DIR="$HOME/.config/systemd/user"
+BIN_DIR="$HOME/bin"
+ENV_DIR="$HOME/.config/eliza"
+STATE_DIR="$HOME/.local/share/eliza"
+
+echo "Installing Eliza systemd user services"
+echo "  workdir : $WORKDIR"
+echo "  bun     : $BUN_BIN"
+echo "  log     : $LOG_PATH"
+
+mkdir -p "$UNIT_DIR" "$BIN_DIR" "$ENV_DIR" "$STATE_DIR" "$(dirname "$LOG_PATH")"
+
+# --- helper scripts -----------------------------------------------------------
+install -m 0755 "$SCRIPT_DIR/bin/eliza-refresh-oauth.sh" "$BIN_DIR/eliza-refresh-oauth.sh"
+install -m 0755 "$SCRIPT_DIR/bin/eliza-health-probe.sh"  "$BIN_DIR/eliza-health-probe.sh"
+
+# --- environment (first install only; never clobber the operator's edits) -----
+if [[ ! -f "$ENV_DIR/env" ]]; then
+  cp "$SCRIPT_DIR/eliza.env.example" "$ENV_DIR/env"
+  echo "  wrote   : $ENV_DIR/env (from template — edit to taste)"
+else
+  echo "  kept    : $ENV_DIR/env (already present)"
+fi
+
+# --- units: substitute placeholders, write to the user unit dir ---------------
+render_unit() {
+  local src="$1" dst="$2"
+  sed -e "s|__WORKDIR__|$WORKDIR|g" \
+      -e "s|__BUN__|$BUN_BIN|g" \
+      -e "s|__LOG__|$LOG_PATH|g" \
+      "$src" > "$dst"
+}
+
+render_unit "$SCRIPT_DIR/units/eliza.service"          "$UNIT_DIR/eliza.service"
+render_unit "$SCRIPT_DIR/units/eliza-refresh.service"  "$UNIT_DIR/eliza-refresh.service"
+render_unit "$SCRIPT_DIR/units/eliza-refresh.timer"    "$UNIT_DIR/eliza-refresh.timer"
+render_unit "$SCRIPT_DIR/units/eliza-probe.service"    "$UNIT_DIR/eliza-probe.service"
+render_unit "$SCRIPT_DIR/units/eliza-probe.timer"      "$UNIT_DIR/eliza-probe.timer"
+
+# --- linger so user services survive logout / run at boot ---------------------
+if ! loginctl show-user "$USER" --property=Linger 2>/dev/null | grep -q "Linger=yes"; then
+  echo "  enabling linger (may prompt for sudo)…"
+  loginctl enable-linger "$USER" 2>/dev/null \
+    || sudo loginctl enable-linger "$USER" \
+    || echo "  WARN: could not enable linger; services won't run when logged out." >&2
+fi
+
+# --- (re)load + start ---------------------------------------------------------
+systemctl --user daemon-reload
+systemctl --user enable --now eliza.service eliza-refresh.timer eliza-probe.timer
+
+echo
+echo "Done. Useful commands:"
+echo "  systemctl --user status eliza.service"
+echo "  journalctl --user -u eliza.service -f"
+echo "  systemctl --user list-timers 'eliza*'"

--- a/deploy/systemd/units/eliza-probe.service
+++ b/deploy/systemd/units/eliza-probe.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Eliza — active health probe
+Documentation=https://github.com/elizaOS/eliza
+
+[Service]
+Type=oneshot
+EnvironmentFile=-%h/.config/eliza/env
+ExecStart=%h/bin/eliza-health-probe.sh
+SyslogIdentifier=eliza-probe

--- a/deploy/systemd/units/eliza-probe.timer
+++ b/deploy/systemd/units/eliza-probe.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Probe Eliza health every 5 min
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/units/eliza-refresh.service
+++ b/deploy/systemd/units/eliza-refresh.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Eliza — roll the Claude OAuth refresh token
+Documentation=https://github.com/elizaOS/eliza
+
+[Service]
+Type=oneshot
+EnvironmentFile=-%h/.config/eliza/env
+ExecStart=%h/bin/eliza-refresh-oauth.sh
+SyslogIdentifier=eliza-refresh

--- a/deploy/systemd/units/eliza-refresh.timer
+++ b/deploy/systemd/units/eliza-refresh.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Refresh the Eliza Claude OAuth token every 6h
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=6h
+# Catch up a missed run (e.g. host asleep) on next wake.
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/units/eliza.service
+++ b/deploy/systemd/units/eliza.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Eliza bot (bare-metal systemd deployment)
+Documentation=https://github.com/elizaOS/eliza
+After=network-online.target
+Wants=network-online.target
+# Cap the restart burst so a hard-failing bot can't hot-loop forever.
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+Type=simple
+WorkingDirectory=__WORKDIR__
+EnvironmentFile=-%h/.config/eliza/env
+# Roll the Claude OAuth token before launch so a freshly (re)started bot always
+# has a valid access token. Leading '-' => a refresh hiccup never blocks start.
+ExecStartPre=-%h/bin/eliza-refresh-oauth.sh
+ExecStart=__BUN__ run start
+Restart=always
+RestartSec=5
+StandardOutput=append:__LOG__
+StandardError=append:__LOG__
+SyslogIdentifier=eliza
+
+[Install]
+WantedBy=default.target

--- a/packages/docs/deployment-bare-metal.mdx
+++ b/packages/docs/deployment-bare-metal.mdx
@@ -8,7 +8,8 @@ The Docker-based deployment in [Deployment Guide](/deployment) is the
 right default for most operators. Bare-metal systemd is the better fit
 when:
 
-- You run **one bot on one VPS** against a personal Claude Max
+- You run **one bot on one always-on Linux host** — a VPS *or* a local
+  machine (home server, workstation) — against a personal Claude Max
   subscription (the Anthropic plan that includes `claude` CLI access),
   and you want the bot to use the same OAuth credentials the `claude`
   CLI creates when you log in.
@@ -17,6 +18,11 @@ when:
 
 For multi-tenant hosts, managed cloud containers (ECS, Cloud Run), or
 API-key-first deployments, stay with Docker.
+
+These are systemd **user** services and depend on nothing VPS-specific, so the
+same bundle runs on a local Linux box. See
+[Running on a local Linux machine](#running-on-a-local-linux-machine-not-a-vps)
+below for the one or two things that differ from a VPS.
 
 ## What the bundle installs
 
@@ -63,6 +69,24 @@ On first install it also copies `eliza.env.example` to
 `~/.config/eliza/env`. Edit that file to change port, log path, or the
 OAuth refresh threshold — the bot and helpers read from it on every
 start.
+
+## Running on a local Linux machine (not a VPS)
+
+The bundle is distro-agnostic systemd **user** services, so the install steps
+above are identical on a laptop, workstation, or home server. Only two things
+differ from a VPS:
+
+- **Reach it at `localhost`.** A local install listens on
+  `http://127.0.0.1:$ELIZA_API_PORT` (default 31337). You don't need a public
+  IP, a domain, or an open firewall port unless you specifically want to reach
+  the bot from another device.
+- **Linger is optional on a workstation.** `install.sh` enables
+  `loginctl enable-linger` so the services start at boot and survive logout
+  (what you want on a VPS). On a personal machine you can skip it
+  (`loginctl disable-linger "$USER"`) if you'd rather the bot run only while
+  you're logged in.
+
+Everything else — OAuth refresh, the health probe, logs — behaves identically.
 
 ## OAuth refresh behavior
 

--- a/packages/docs/deployment.mdx
+++ b/packages/docs/deployment.mdx
@@ -7,7 +7,7 @@ description: Deploy Eliza using Docker, Docker Compose, or cloud containers. Cov
 Eliza supports multiple deployment strategies: standalone Docker containers, Docker Compose orchestration, and cloud-managed containers for Eliza Cloud (AWS ECS).
 
 <Warning>
-The Docker deployment files referenced below (`deploy/Dockerfile`, `docker-setup.sh`) live in the `eliza/` submodule. You must initialize it first with `bun run setup:upstreams` or `git submodule update --init --recursive` before following these instructions. The `deploy/` directory in the repo root contains only `Dockerfile.ci` (CI-specific image for pre-built artifacts) and supporting config files.
+The Docker deployment toolkit lives at `packages/app-core/deploy/` in this repo — `docker-setup.sh`, `docker-compose.yml`, `Dockerfile.ci` (image for prebuilt artifacts), `Dockerfile.cloud`, `deploy.defaults.env`, and the rollout scripts. The example commands below use `eliza/packages/app-core/deploy/...` paths, which apply when a downstream app vendors this repo under an `eliza/` subdirectory; working **inside** this repo, drop the `eliza/` prefix and run them from `packages/app-core/deploy/` directly.
 </Warning>
 
 ## Quick Start with Docker Compose
@@ -15,18 +15,18 @@ The Docker deployment files referenced below (`deploy/Dockerfile`, `docker-setup
 The fastest way to deploy Eliza is using the included setup script, which builds the image, generates authentication tokens, runs interactive onboarding, and starts the gateway.
 
 <Note>
-The Docker deployment files live in the upstream elizaOS toolkit. Initialize the submodule first:
-```bash
-bun run setup:upstreams
-```
+Run from a checkout of this repo. Inside the repo the toolkit is at `packages/app-core/deploy/`; a downstream app that vendors eliza under `eliza/` uses the `../eliza/packages/app-core/deploy/...` paths.
 </Note>
 
 ```bash
-cd deploy
-bash ../eliza/packages/app-core/deploy/docker-setup.sh
+# Inside this repo:
+bash packages/app-core/deploy/docker-setup.sh
+
+# Or, from a downstream app that vendors eliza under eliza/:
+cd deploy && bash ../eliza/packages/app-core/deploy/docker-setup.sh
 ```
 
-Eliza-specific overrides (image name, ports, state paths) are in `deploy/deploy.env` and automatically merged with the upstream defaults.
+App-specific overrides (image name, ports, state paths) go in a repo-root `deploy/deploy.env`, merged over `deploy.defaults.env` (see `packages/app-core/deploy/README.md`).
 
 The setup script performs the following steps:
 
@@ -44,7 +44,7 @@ The setup script requires Docker and Docker Compose to be installed. It will exi
 
 ### CI Dockerfile
 
-The primary Dockerfile (`eliza/packages/app-core/deploy/Dockerfile`) builds a production image from source:
+The CI Dockerfile (`eliza/packages/app-core/deploy/Dockerfile.ci`) builds a production image from prebuilt artifacts:
 
 ```dockerfile
 FROM node:22-slim AS pruner
@@ -88,7 +88,7 @@ The CI image is built by the GitHub Actions release pipeline. To run it locally 
 docker build \
   --build-arg ELIZA_DOCKER_APT_PACKAGES="ffmpeg imagemagick" \
   -t eliza:local \
-  -f eliza/packages/app-core/deploy/Dockerfile \
+  -f eliza/packages/app-core/deploy/Dockerfile.ci \
   .
 ```
 
@@ -140,7 +140,7 @@ ELIZAOS_CLOUD_API_KEY=eliza_xxx
 
 ### Eliza Cloud (AWS ECS)
 
-The `Dockerfile.cloud-agent` (in the elizaOS submodule deploy directory) builds a slim container for deploying agents to Eliza Cloud:
+The `Dockerfile.cloud-agent` (in `packages/app-core/deploy/`) builds a slim container for deploying agents to Eliza Cloud:
 
 ```dockerfile
 FROM node:22-bookworm-slim


### PR DESCRIPTION
## Summary
Adds the `deploy/systemd/` bundle that `packages/docs/deployment-bare-metal.mdx` already documents but that was **never committed** — following the doc hit "no such file" at `./deploy/systemd/install.sh`. This makes the documented Linux VPS (and local-Linux) setup real and accurate.

## What's in here
- `deploy/systemd/install.sh` — idempotent installer (systemd **user** services; refuses to run as root; renders unit templates, installs helpers, seeds env, enables linger, starts service+timers).
- `units/eliza.service` + `eliza-refresh.{service,timer}` + `eliza-probe.{service,timer}`.
- `bin/eliza-refresh-oauth.sh` (rolls the Claude OAuth token near expiry; never runs a model), `bin/eliza-health-probe.sh` (`/api/health` + `agentState` + auth-log check, restart-on-failure).
- `eliza.env.example`, `README.md`.
- `deployment-bare-metal.mdx` — broadened beyond "VPS" + a **"Running on a local Linux machine (not a VPS)"** section.

## Verification
- Contract verified against a live agent: `/api/health` → `"agentState":"running"`, API on `ELIZA_API_PORT` (31337), OAuth creds at `~/.claude/.credentials.json`.
- Scripts pass `bash -n` + shellcheck.
- ⚠️ **Not yet smoke-tested on a fresh host** (no VPS available here) — flagged in the bundle README; exercise a first-boot run on a clean machine before relying on it in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the `deploy/systemd/` bundle that the bare-metal deployment docs already referenced but never committed, making the documented Linux VPS / local-Linux setup functional. It also corrects `deployment.mdx` to reflect the current `packages/app-core/deploy/` path layout instead of the old submodule structure.

- **`deploy/systemd/`**: `install.sh` (idempotent, user-services), five systemd unit files (bot + OAuth-refresh timer + health-probe timer), two helper scripts (`eliza-refresh-oauth.sh`, `eliza-health-probe.sh`), and an env example.
- **Health probe design issue**: `eliza-health-probe.sh` calls `systemctl --user restart eliza.service` any time `/api/health` is down — this includes intentional stops (no maintenance-mode guard) and also resets systemd's `StartLimitBurst` counter, effectively bypassing the hot-crash protection configured in `eliza.service`.
- **Docs**: `deployment-bare-metal.mdx` is expanded to cover local Linux machines; `deployment.mdx` path corrections are accurate against the repo.

<h3>Confidence Score: 3/5</h3>

The systemd unit files and installer are well-structured, but the health probe has two design flaws that will cause unexpected behavior in normal operations.

The probe unconditionally restarts eliza.service whenever the HTTP health check fails — including after a deliberate systemctl --user stop. An operator stopping the bot for maintenance will find it restarted within 5 minutes. Separately, the probe's systemctl --user restart resets systemd's start-limit counter, so StartLimitBurst=5 in eliza.service never actually halts a bot that crashes on every launch — it keeps getting restarted every probe cycle indefinitely.

deploy/systemd/bin/eliza-health-probe.sh and deploy/systemd/units/eliza.service need the most attention; the interaction between the probe's explicit restart and the service's burst-limit configuration should be resolved before this is used in production.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| deploy/systemd/bin/eliza-health-probe.sh | Health probe with two issues: (1) unconditionally restarts eliza.service on any health failure, including intentional stops — no maintenance-mode guard; (2) explicit systemctl restart resets StartLimitBurst counter, nullifying the burst-protection in eliza.service for hard-crash loops. |
| deploy/systemd/units/eliza.service | Main bot unit with Restart=always and StartLimitBurst=5 burst protection; however, the probe's explicit restart bypasses the burst limit. Log append without rotation will grow unbounded. |
| deploy/systemd/bin/eliza-refresh-oauth.sh | OAuth token refresh script; reads expiresAt from ~/.claude/.credentials.json and calls claude auth status near expiry. jq/grep dual-path parsing is sound; missing final exit 0 can cause eliza-refresh.service to report failure. |
| deploy/systemd/install.sh | Idempotent installer for systemd user services; renders unit templates via sed, copies helpers to ~/bin, seeds env on first run, enables linger and starts services. Minor risk if WORKDIR/BUN_BIN/LOG_PATH contain the sed delimiter |. |
| packages/docs/deployment-bare-metal.mdx | Broadens the bare-metal guide from VPS-only to any always-on Linux host and adds a local Linux machine section; changes are accurate and consistent with the bundle. |
| packages/docs/deployment.mdx | Corrects Docker deployment paths from a now-removed submodule layout to packages/app-core/deploy/ (verified to exist) and fixes Dockerfile → Dockerfile.ci references. Tangential to the systemd bundle but accurate. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant install as install.sh
    participant systemd as systemd (user)
    participant eliza as eliza.service
    participant probe as eliza-probe.timer
    participant refresh as eliza-refresh.timer
    participant oauth as eliza-refresh-oauth.sh
    participant health as eliza-health-probe.sh
    participant claude as ~/.claude/.credentials.json

    install->>systemd: render + install units
    install->>systemd: daemon-reload
    install->>systemd: enable --now eliza.service + timers

    systemd->>oauth: ExecStartPre (leading -)
    oauth->>claude: read expiresAt
    oauth-->>systemd: exit 0 (refresh or no-op)
    systemd->>eliza: ExecStart: bun run start

    loop Every 6h
        refresh->>oauth: run eliza-refresh-oauth.sh
        oauth->>claude: jq / grep expiresAt
        alt token near expiry
            oauth->>oauth: claude auth status --json
        end
    end

    loop Every 5min
        probe->>health: run eliza-health-probe.sh
        health->>eliza: GET /api/health
        alt healthy
            health-->>probe: exit 0
        else unhealthy
            health->>systemd: systemctl --user restart eliza.service
            note over systemd,eliza: resets StartLimitBurst counter
        end
    end
```

<sub>Reviews (1): Last reviewed commit: ["docs(deployment): correct the Docker gui..."](https://github.com/elizaos/eliza/commit/35372cdf1ed004c3e121988e5d7fad4bb9e80754) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34764170)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->