### PR TITLE
feat(cloud): return reachable web_ui_url from agent provisioning (pairs with #8066)

### DIFF
--- a/packages/cloud-api/v1/eliza/agents/[agentId]/provision/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/provision/route.ts
@@ -5,6 +5,7 @@ import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
 import { containersEnv } from "@/lib/config/containers-env";
 import { AGENT_PRICING } from "@/lib/constants/agent-pricing";
 import { assertSafeOutboundUrl } from "@/lib/security/outbound-url";
+import { getElizaAgentPublicWebUiUrl } from "@/lib/eliza-agent-web-ui";
 import { checkAgentCreditGate } from "@/lib/services/agent-billing-gate";
 import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
@@ -124,6 +125,7 @@ async function __hono_POST(
             status: existing.status,
             bridgeUrl: existing.bridge_url,
             healthUrl: existing.health_url,
+            webUiUrl: getElizaAgentPublicWebUiUrl(existing),
           },
         }),
         CORS_METHODS,
@@ -185,6 +187,7 @@ async function __hono_POST(
                 status: claimed.status,
                 bridgeUrl: claimed.bridge_url,
                 healthUrl: claimed.health_url,
+                webUiUrl: getElizaAgentPublicWebUiUrl(claimed),
               },
               source: "warm_pool",
             }),
@@ -238,6 +241,7 @@ async function __hono_POST(
             status: result.sandboxRecord.status,
             bridgeUrl: result.bridgeUrl,
             healthUrl: result.healthUrl,
+            webUiUrl: getElizaAgentPublicWebUiUrl(result.sandboxRecord),
           },
         }),
         CORS_METHODS,

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -16,6 +16,7 @@
 import { and, desc, eq, type SQL, sql } from "drizzle-orm";
 import { dbWrite } from "../../db/helpers";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+import { getElizaAgentPublicWebUiUrl } from "../eliza-agent-web-ui";
 import {
   hydrateJob,
   type Job,
@@ -110,6 +111,8 @@ export interface AgentProvisionJobResult {
   status: string;
   bridgeUrl?: string;
   healthUrl?: string;
+  /** Reachable per-agent HTTPS gateway URL (https://<agentId>.<domain>). */
+  webUiUrl?: string | null;
   error?: string;
 }
 
@@ -1560,6 +1563,7 @@ export class ProvisioningJobService {
       status: provResult.sandboxRecord.status,
       bridgeUrl: provResult.bridgeUrl,
       healthUrl: provResult.healthUrl,
+      webUiUrl: getElizaAgentPublicWebUiUrl(provResult.sandboxRecord),
     };
 
     await jobsRepository.updateStatus(job.id, "completed", {


### PR DESCRIPTION
## Summary — draft / proposal for the cloud team
Completes the "return a reachable agent URL from provisioning" contract. The provision endpoint + async job result currently return only the raw container `bridgeUrl` (`http://<ip>:<port>`), which a browser can't reach (firewalled to the internal network) and CSP blocks — so first-run can't connect to a freshly provisioned cloud agent.

Adds `webUiUrl` (the canonical `https://<agentId>.<domain>` gateway URL) to the three provision responses + `AgentProvisionJobResult`, computed via the **same `getElizaAgentPublicWebUiUrl()` that `toCompatAgent` already uses for `web_ui_url`** (compat-envelope.ts:34-36,81) — so it's consistent with the existing contract, not a new convention.

**Pairs with the client change in #8066**, which now prefers `webUiUrl` when present and otherwise derives it. The client already works without this PR; this makes the server the single source of truth so the client never has to derive the apex.

## Changes (additive — no behavior change for existing consumers)
- `cloud-api/v1/eliza/agents/[agentId]/provision/route.ts` — `webUiUrl` on the existing-running, warm-pool, and sync responses.
- `cloud-shared/.../provisioning-jobs.ts` — `webUiUrl?` on `AgentProvisionJobResult` (auto-serialized via the existing `{...result}`) + populated in the provision job result.

## Verification
- `cloud-shared` typecheck clean for the changed file; `cloud-api` `tsgo --noEmit` clean for the route; biome clean.
- ⚠️ **Not runtime-exercised against a live provision** (no cloud staging here) — flagged for your review.

Draft because this is your provisioning path — your call on the approach (this vs. building the gateway URL into `bridgeUrl` at source in docker-sandbox-provider).

🤖 Generated with [Claude Code](https://claude.com/claude-code)