### PR TITLE
fix(core): decide complete-direct-reply preference structurally, not by user-intent regex

### DIFF
--- a/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
@@ -142,6 +142,62 @@ describe("messageHandlerFromFieldResult — bogus candidate actions", () => {
 		expect(handler.plan.contexts).toEqual(["general"]);
 	});
 
+	it("answers a complete substantive reply directly even when a coding-class candidate is force-injected", () => {
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["simple"],
+				candidateActionNames: [],
+				replyText:
+					"Your app-build routing maps each request path to a static file under data/apps/<name>/index.html.",
+				intents: [],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: REAL_ACTIONS,
+				messageText:
+					"what are your app-build routing rules? answer in one sentence, do not build anything",
+			},
+		);
+
+		// "app build" trips the coding-work keyword heuristic, which force-injects
+		// a TASKS candidate. But the model returned a finished one-sentence answer
+		// with a simple context, so the complete direct reply must win — no
+		// redundant sub-agent spawn. Keyed on reply shape, not the user's text.
+		expect(handler.plan.simple).toBe(true);
+		expect(handler.plan.requiresTool).toBe(false);
+		expect(handler.plan.candidateActions ?? []).toEqual([]);
+		expect(handler.plan.contexts).toEqual(["simple"]);
+	});
+
+	it("still force-plans a genuine build ask when the model only acked", () => {
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["simple"],
+				candidateActionNames: [],
+				replyText: "On it.",
+				intents: [],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: REAL_ACTIONS,
+				messageText: "build me an app that flips a coin",
+			},
+		);
+
+		// An ack-only reply is not a finished answer, so it fails
+		// looksLikeCompleteDirectReply and the inference backstop still routes the
+		// real build request to planning. This is the structural discriminator:
+		// reply shape, not a scan of the user's intent.
+		expect(handler.plan.simple).toBe(false);
+		expect(handler.plan.requiresTool).toBe(true);
+	});
+
 	it("treats canonical control names (REPLY / IGNORE / STOP) as valid even though they aren't in runtime.actions", () => {
 		// REPLY is the planner's terminal fallback; it resolves via
 		// `canonicalPlannerControlActionName`, not the action registry.

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3422,7 +3422,6 @@ export function messageHandlerFromFieldResult(
 		requestedPlanning &&
 		shouldPreferCompleteDirectReply({
 			replyText: replyTextRaw,
-			currentMessageText,
 			candidateActions: effectiveCandidateActions,
 			contexts: routedContexts,
 		});
@@ -3543,26 +3542,26 @@ function _isSimpleMessageHandlerShortcut(
 	);
 }
 
+// Prefer a complete, substantive direct reply over force-planned action when
+// the model already answered the turn. Purely STRUCTURAL — it never scans the
+// user's text to classify intent:
+//   1. the reply reads as a finished answer, not an ack/progress/refusal/empty
+//      fragment (looksLikeCompleteDirectReply), and
+//   2. the only signals pushing toward planning are weak/injectable ones — a
+//      simple/general context plus search/shell/spawn-class candidate actions,
+//      the exact shapes the Stage-1 inference backstop force-injects
+//      (hasOnlyWeakDirectReplyPlanningSignals).
+// When the model defers to a tool it acks ("On it.") or returns an empty/refusal
+// reply, which fails (1) — so genuine web/shell/build turns still plan, while a
+// finished answer (e.g. a one-sentence policy explanation) wins directly even if
+// a coding-keyword heuristic would have force-injected a spawn over it.
 function shouldPreferCompleteDirectReply(args: {
 	replyText: string;
-	currentMessageText: string;
 	candidateActions: readonly string[];
 	contexts: readonly string[];
 }): boolean {
 	if (!looksLikeCompleteDirectReply(args.replyText)) return false;
-	if (!hasOnlyWeakDirectReplyPlanningSignals(args)) return false;
-	const normalized = args.currentMessageText
-		.toLowerCase()
-		.replace(/\s+/gu, " ")
-		.trim();
-	if (!normalized) return false;
-	if (looksLikeLocalShellRequest(normalized)) return false;
-	if (looksLikeWebSearchRequest(normalized)) return false;
-	if (looksLikeCodingWorkRequest(normalized)) return false;
-	return (
-		looksLikeActionExplanationRequest(normalized) ||
-		looksLikeCreativeWritingRequest(normalized)
-	);
+	return hasOnlyWeakDirectReplyPlanningSignals(args);
 }
 
 function shouldPreferInlineCodeSnippetDirectReply(args: {


### PR DESCRIPTION
## Problem

`shouldPreferCompleteDirectReply` decides whether a finished model reply should win over force-injected planning. It did so by scanning the **user's message text** with five intent regexes:

```ts
if (looksLikeLocalShellRequest(normalized)) return false;
if (looksLikeWebSearchRequest(normalized)) return false;
if (looksLikeCodingWorkRequest(normalized)) return false;
return (
  looksLikeActionExplanationRequest(normalized) ||
  looksLikeCreativeWritingRequest(normalized)
);
```

`looksLikeCodingWorkRequest` matches essentially any "app" near "build". So a complete one-sentence answer to a meta-question like:

> what are your app-build routing rules? answer in one sentence, do not build anything

was treated as coding work, the direct-reply preference bailed, and a redundant coding sub-agent was force-spawned **on top of** an already-correct answer. This is the classic intent-regex failure mode: a substring heuristic standing in for a routing rule, with an open-ended tail of edge cases.

## Fix

Decide on **structure**, using signals the function already computes — never the user's text:

```ts
function shouldPreferCompleteDirectReply(args): boolean {
  if (!looksLikeCompleteDirectReply(args.replyText)) return false;
  return hasOnlyWeakDirectReplyPlanningSignals(args);
}
```

- `looksLikeCompleteDirectReply(replyText)` — the reply reads as a *finished answer*, not an ack / progress / refusal / empty fragment (a check on the agent's **own** reply shape).
- `hasOnlyWeakDirectReplyPlanningSignals` — the only signals pushing toward planning are weak/injectable ones: a `simple`/`general` context plus search/shell/spawn-class candidate actions — the exact shapes the Stage-1 inference backstop force-injects.

When the model genuinely defers to a tool, it acks ("On it.") or returns an empty/refusal reply, which fails `looksLikeCompleteDirectReply` — so **real web/shell/build turns still plan**. No behavior is lost; only the substring false-positive is removed.

The five `looksLikeX` predicates remain in use by the inference/recovery paths — this only stops their **misuse as a user-intent classifier** inside the direct-reply decision.

## Tests

Adds two regression tests to `message-handler-bogus-candidates.test.ts`:
- a complete substantive reply answers directly even when a coding-class candidate is force-injected (no redundant spawn);
- an ack-only build ask still routes to planning (the inference backstop is preserved).

Full `@elizaos/core` suite green locally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the intent-regex classifier in `shouldPreferCompleteDirectReply` with a purely structural decision: a reply wins over force-planned action only when it reads as a finished answer (`looksLikeCompleteDirectReply`) and the only planning pressure comes from weak/injectable signals (`hasOnlyWeakDirectReplyPlanningSignals`). This removes the false positive where a substring match on "app" + "build" in the user's text would trigger a redundant coding sub-agent on top of an already-correct one-sentence answer.

- `shouldPreferCompleteDirectReply` drops `currentMessageText` entirely; the five `looksLikeX` predicates remain in use by the inference/recovery paths but are no longer misused as a user-intent classifier here.
- Two regression tests are added: one confirming a substantive reply wins directly when a coding-class candidate is force-injected, another confirming that a short ack (\"On it.\") still routes to planning for a genuine build request.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the structural refactor is narrowly scoped, well-documented, and backed by targeted regression tests.

The change removes a parameter and five regex guards from a single private function. The replacement logic is simpler and directly addresses the reported false-positive. Both new tests exercise the discriminating condition (reply shape vs. user-text scanning) and are correctly structured.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/services/message.ts | Removes `currentMessageText` from `shouldPreferCompleteDirectReply` and replaces five intent-regex guards with a two-step structural check; call site updated to omit the dropped parameter. |
| packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts | Adds two targeted regression tests covering the direct-reply-vs-planning decision: one for a substantive answer with a force-injected coding candidate, one for an ack-only reply that must still trigger planning. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(core): decide complete-direct-reply ..."](https://github.com/elizaos/eliza/commit/fb9856f913d21c3b8c69077985e2acec3801a0bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34761692)</sub>

<!-- /greptile_comment -->