### PR TITLE
fix(ci): reconcile release-check contract with canary + electrobun-fork migrations

### DIFF
--- a/packages/app-core/scripts/release-check.ts
+++ b/packages/app-core/scripts/release-check.ts
@@ -87,7 +87,7 @@ function resolveOrchestratorPluginPackageJsonPath() {
   return resolveExistingPath(orchestratorPluginPackageJsonPathCandidates);
 }
 const requiredWorkflowSnippets = [
-  'BUN_VERSION: "1.3.14"',
+  'BUN_VERSION: "canary"',
   "workflow_call:",
   "name: Validate Release Inputs",
   "Manual branch dispatches must provide inputs.tag; refusing to derive a release tag from package.json.",
@@ -216,7 +216,7 @@ const requiredWorkflowSnippets = [
   "bun run test:desktop:playwright",
 ];
 const _requiredPatchedElectrobunCliSnippets = [
-  "https://github.com/blackboardsh/electrobun.git",
+  "https://github.com/elizaOS/electrobun.git",
   '"sparse-checkout", "set", "package"',
   'writeGitHubEnv("ELECTROBUN_RCEDIT_PACKAGE_JSON", resolvedRceditPackageJson);',
   'const overridePackageJson = process.env["ELECTROBUN_RCEDIT_PACKAGE_JSON"];',
@@ -273,7 +273,7 @@ const requiredElectrobunPrWorkflowSnippets = [
   "workflow_dispatch:",
   "permissions:",
   "contents: read",
-  'BUN_VERSION: "1.3.14"',
+  'BUN_VERSION: "canary"',
   "name: Release Workflow Contract",
   "bun install --ignore-scripts",
   'run-postinstall: "true"',


### PR DESCRIPTION
## Problem

`release-check.ts` (the **Release Workflow Contract**) asserts release wiring via exact string snippets. Two snippets are stale relative to recent, deliberate, repo-wide migrations, so the contract fails on every PR / develop:

1. **Bun version** — the contract requires `BUN_VERSION: "1.3.14"`, but `release-electrobun.yml` and `test-electrobun-release.yml` (and 8+ other workflows) were moved to `BUN_VERSION: "canary"` in the repo-wide canary migration (`a39d90a833`, and the documented *"Rust-rewrite canary runtime (repo-wide migration 2026-05-30)"* comment in `release-electrobun.yml`).
2. **Electrobun source** — the contract requires the patched-CLI helper to clone `https://github.com/blackboardsh/electrobun.git`, but `build-patched-electrobun-cli.mjs` was changed to build from the elizaOS fork `https://github.com/elizaOS/electrobun.git` (`7feed47862` *"build the electrobun CLI from the elizaOS fork"*). The rcedit **releases API** snippet still points at `blackboardsh` and is intentionally left unchanged.

`release-check.ts` does `process.exit(1)` per check, so only the first drift (`BUN_VERSION`) surfaced in CI logs; the electrobun drift is the next assertion in sequence.

## Fix

Realign the three stale snippet strings with the actual, deliberately-migrated workflow + helper state. No behavior change — this only updates the contract's assertions to match the code they validate.

## Verification

`bun run test:release:contract` now passes locally end-to-end (previously exited `1` at the `BUN_VERSION` assertion, then would have failed at the electrobun assertion). Confirmed the rcedit releases-API snippet and all other required snippets still match.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates three stale string assertions in `release-check.ts` to match the actual, already-landed state of the workflow and build-helper files after two deliberate repo-wide migrations (canary Bun runtime and the elizaOS electrobun fork).

- Updates `BUN_VERSION` assertions in both `requiredWorkflowSnippets` and `requiredElectrobunPrWorkflowSnippets` from `"1.3.14"` to `"canary"`, matching the live value in `release-electrobun.yml` and `test-electrobun-release.yml`.
- Updates the electrobun clone URL assertion in `_requiredPatchedElectrobunCliSnippets` from `blackboardsh/electrobun.git` to `elizaOS/electrobun.git`, matching `ELECTROBUN_FORK_URL` in `build-patched-electrobun-cli.mjs`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the three changed string literals now match the actual content of the files they assert against, restoring a previously broken CI contract gate.

All three string updates were verified against the live workflow and build-helper files in the repo: both workflow files contain BUN_VERSION: canary and the helper uses https://github.com/elizaOS/electrobun.git. No logic, behavior, or execution path changes are involved — this is purely a contract string realignment that unblocks CI.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/release-check.ts | Three string literals updated to re-align the release contract with already-migrated workflow and helper files; no logic changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bun run test:release:contract] --> B[assertReleaseWorkflowHasNotaryWrapper]
    B --> C{requiredWorkflowSnippets\nmatch release-electrobun.yml?}
    C -- BUN_VERSION canary ✓ --> D[Check _requiredPatchedElectrobunCliSnippets\nagainst build-patched-electrobun-cli.mjs]
    D --> E{elizaOS/electrobun.git ✓}
    E --> F[assertElectrobunPrWorkflowExists]
    F --> G{requiredElectrobunPrWorkflowSnippets\nmatch test-electrobun-release.yml?}
    G -- BUN_VERSION canary ✓ --> H[... remaining assertions ...]
    H --> I[✅ Contract passes]

    C -- OLD: BUN_VERSION 1.3.14 ✗ --> X[process.exit 1]
    E -- OLD: blackboardsh/electrobun.git ✗ --> X
    G -- OLD: BUN_VERSION 1.3.14 ✗ --> X
```

<sub>Reviews (1): Last reviewed commit: ["fix(ci): reconcile release-check contrac..."](https://github.com/elizaos/eliza/commit/cd00baa76a4ac6103018c35fda2c9ba93a9c2fda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34764161)</sub>

<!-- /greptile_comment -->