### PR TITLE
test(elizaos): smoke global package install

### DIFF
--- a/packages/elizaos/scripts/packaged-smoke.mjs
+++ b/packages/elizaos/scripts/packaged-smoke.mjs
@@ -18,6 +18,8 @@ const shouldInstallGeneratedFullstack =
 const shouldSmokeEject = process.env.ELIZAOS_SMOKE_EJECT === "1";
 const shouldUseRemoteUpstream =
   process.env.ELIZAOS_SMOKE_REMOTE_UPSTREAM === "1";
+const shouldSkipGlobalInstall =
+  process.env.ELIZAOS_SMOKE_SKIP_GLOBAL_INSTALL === "1";
 const npmCommand = process.platform === "win32" ? "npm.cmd" : "npm";
 const bunCommand = process.platform === "win32" ? "bun.exe" : "bun";
 const elizaosBinName = process.platform === "win32" ? "elizaos.cmd" : "elizaos";
@@ -81,6 +83,31 @@ function installCliPackage(smokeDir, tarballPath) {
   run(bunCommand, ["add", tarballPath], { cwd: smokeDir });
 }
 
+function installCliPackageGlobally(prefixDir, tarballPath) {
+  if (commandExists(npmCommand)) {
+    run(npmCommand, [
+      "install",
+      "--global",
+      "--prefix",
+      prefixDir,
+      "--no-audit",
+      "--no-fund",
+      tarballPath,
+    ]);
+    return;
+  }
+
+  if (!commandExists(bunCommand)) {
+    throw new Error(
+      "Neither npm nor bun is available for global packaged smoke test",
+    );
+  }
+
+  run(bunCommand, ["add", "--global", tarballPath], {
+    env: { ...process.env, BUN_INSTALL: prefixDir },
+  });
+}
+
 function getTarballName(output) {
   const lines = output
     .split(/\r?\n/)
@@ -99,6 +126,14 @@ function getInstalledCli(smokeDir) {
   return path.join(smokeDir, "node_modules", ".bin", elizaosBinName);
 }
 
+function getGloballyInstalledCli(prefixDir) {
+  const binPath =
+    process.platform === "win32"
+      ? elizaosBinName
+      : path.join("bin", elizaosBinName);
+  return path.join(prefixDir, binPath);
+}
+
 function assertPathExists(targetPath) {
   if (!fs.existsSync(targetPath)) {
     throw new Error(`Expected path to exist: ${targetPath}`);
@@ -115,6 +150,20 @@ function runCli(smokeDir, cwd, args) {
   return run(getInstalledCli(smokeDir), args, { cwd, env: cliEnv });
 }
 
+function runGlobalCli(prefixDir, cwd, args) {
+  return run(getGloballyInstalledCli(prefixDir), args, { cwd, env: cliEnv });
+}
+
+function smokeGlobalInstall(tarballPath) {
+  const prefixDir = path.join(tmpRoot, "global");
+  fs.mkdirSync(prefixDir, { recursive: true });
+  installCliPackageGlobally(prefixDir, tarballPath);
+
+  const globalCli = getGloballyInstalledCli(prefixDir);
+  assertPathExists(globalCli);
+  runGlobalCli(prefixDir, tmpRoot, ["--version"]);
+}
+
 function main() {
   let passed = false;
 
@@ -126,6 +175,11 @@ function main() {
     const tarballPath = path.isAbsolute(tarballName)
       ? tarballName
       : path.join(tmpRoot, tarballName);
+
+    if (!shouldSkipGlobalInstall) {
+      smokeGlobalInstall(tarballPath);
+    }
+
     const smokeDir = path.join(tmpRoot, "smoke");
     fs.mkdirSync(smokeDir, { recursive: true });
     fs.writeFileSync(


### PR DESCRIPTION
# Relates to

Fixes/prevents regression for #8000

# Risks

Low. This only extends the existing packaged CLI smoke test to also install the packed tarball globally into an isolated temporary npm prefix before running the generated `elizaos` bin.

# Background
## What does this PR do?

Adds a sandboxed global-install smoke step to `packages/elizaos/scripts/packaged-smoke.mjs`:

- `npm pack` still creates the tarball under the existing temp root.
- The tarball is installed with `npm install --global --prefix <tmp>/global` (or Bun global install fallback when npm is unavailable).
- The globally installed `<prefix>/bin/elizaos --version` must run successfully before the existing local-install/project scaffold smoke continues.

Develop no longer has the old `elizaos` alias shim from `1.7.2`, but this catches the same class of package-bin/export-map regression before publish.

## What kind of change is this?

Bug fix / regression test coverage.

# Documentation changes needed?

My changes do not require a change to the project documentation.

# Testing
## Where should a reviewer start?

`packages/elizaos/scripts/packaged-smoke.mjs`

## Detailed testing steps

- `cd packages/elizaos && bun run build`
- `cd packages/elizaos && bun run test:packaged`
- `cd packages/elizaos && bun run lint:check`
- `cd packages/elizaos && bun run test`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends the existing `packaged-smoke.mjs` script to run a sandboxed global-install smoke test — packing the tarball, installing it with `npm install --global --prefix` (or bun `BUN_INSTALL` as a fallback), and verifying the resulting `elizaos --version` binary executes successfully before the rest of the local-install flow.

- Adds `installCliPackageGlobally` / `smokeGlobalInstall` helpers and gates the new step on the `ELIZAOS_SMOKE_SKIP_GLOBAL_INSTALL` env flag, keeping CI opt-out easy.
- `getGloballyInstalledCli` correctly resolves `<prefix>/bin/elizaos` on Unix for both npm and bun, but on Windows the path omits the `bin` subdirectory — which is right for npm's `--prefix` layout but wrong for Bun's `BUN_INSTALL` layout, so the bun fallback on Windows would fail the `assertPathExists` check before ever running the binary.

<h3>Confidence Score: 4/5</h3>

Safe to merge for Unix/macOS CI; the Windows+bun-fallback path would mislocate the installed binary and break the new smoke step, but that combination is unlikely in practice since npm is nearly always present on Windows.

The global-install flow is straightforward and the Unix code path (both npm and bun) is correct. The one concrete issue is that getGloballyInstalledCli on Windows skips the bin subdirectory unconditionally, which diverges from where bun actually places its shims. Everything else — cleanup, env threading, flag gating — looks sound.

packages/elizaos/scripts/packaged-smoke.mjs — specifically the getGloballyInstalledCli Windows branch and how the bun-vs-npm choice is threaded through to it.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/elizaos/scripts/packaged-smoke.mjs | Adds a sandboxed global-install smoke step (npm --prefix / bun BUN_INSTALL fallback) before the existing local-install flow. Path resolution for the globally installed binary is correct on every platform-tool combination except Windows + bun fallback, where the bin subdirectory is omitted. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[main] --> B[bun run build]
    B --> C[packCliPackage → tarball]
    C --> D{shouldSkipGlobalInstall?}
    D -- No --> E[smokeGlobalInstall]
    E --> E1[mkdirSync tmpRoot/global]
    E1 --> E2{npm available?}
    E2 -- Yes --> E3[npm install --global --prefix prefixDir tarball]
    E2 -- No --> E4{bun available?}
    E4 -- Yes --> E5[bun add --global tarball BUN_INSTALL=prefixDir]
    E4 -- No --> E6[throw Error]
    E3 --> E7[assertPathExists globalCli]
    E5 --> E7
    E7 --> E8[runGlobalCli -- --version]
    D -- Yes --> F[installCliPackage smokeDir]
    E8 --> F
    F --> G[runCli info]
    G --> H[elizaos create plugin-demo]
    H --> I[elizaos create project-demo]
    I --> J[passed = true / cleanup]
```

<sub>Reviews (1): Last reviewed commit: ["test(elizaos): smoke global package inst..."](https://github.com/elizaos/eliza/commit/d92d5388088ecf7e0e77af8ddd0d179f847d4bf7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34767218)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->