### PR TITLE
fix(agent-image): add zod + eager-boot third-partys so the CI agent image boots

### DIFF
--- a/packages/app-core/deploy/Dockerfile.ci
+++ b/packages/app-core/deploy/Dockerfile.ci
@@ -32,7 +32,30 @@ RUN node "${APP_CORE_DIR}/scripts/relink-workspace-packages-to-dist.mjs" \
 
 # Some relinked local packages expect selected runtime dependencies to be
 # resolvable from root node_modules. Host node_modules is excluded from the
-# Docker context, so install only this small runtime set in-image.
+# Docker context (see .dockerignore: **/node_modules), so install this
+# runtime set in-image.
+#
+# IMPORTANT: this list is hand-maintained and BRITTLE. The packages here
+# are the bare third-party imports that survive into the shipped dist bundles
+# and are resolved at runtime (not inlined). Two distinct sources require
+# them:
+#   (a) packages/core/dist/node/index.node.js externalises `zod` (+ subpaths
+#       zod/v3, zod/v4) and `dotenv` (build.ts nodeExternals). zod is the
+#       FIRST eager import on boot, so a missing zod crashes the container
+#       before any agent code runs.
+#   (b) packages/agent/dist is transpiled (tsc, NOT bundled), so every bare
+#       import stays third-party. The eager boot path (runtime/eliza.js ->
+#       dynamic import api/server.js, whose static graph is loaded eagerly)
+#       pulls in: hono (api/hono-adapter), json5 (config/config),
+#       @noble/curves + ethers (api/wallet), esbuild
+#       (services/plugin-compiler via workbench routes), and isomorphic-git
+#       (services/vfs-git). All of these load at module-eval time when
+#       server.js is imported, so a missing one is a hard boot crash.
+# zod@4.4.3 matches packages/core/package.json (^4.4.3) and provides the
+# ./v3 + ./v4 subpath exports core imports. Versions below track the
+# declarations in packages/agent/package.json + packages/core/package.json.
+# FOLLOW-UP: derive this list from the workspace dist third-partys instead of
+# hand-maintaining it (see audit notes in the PR).
 RUN mkdir -p /tmp/docker-runtime-deps \
   && cd /tmp/docker-runtime-deps \
   && npm init -y >/dev/null \
@@ -50,6 +73,14 @@ RUN mkdir -p /tmp/docker-runtime-deps \
     uuid@14.0.0 \
     ws@8.20.0 \
     yaml@2.8.2 \
+    zod@4.4.3 \
+    hono@4.12.18 \
+    json5@2.2.3 \
+    ethers@6.16.0 \
+    esbuild@0.25.10 \
+    isomorphic-git@1.37.8 \
+    @noble/curves@2.2.0 \
+    @noble/hashes@2.2.0 \
   && mkdir -p /app/node_modules \
   && rm -rf \
     /app/node_modules/@electric-sql/pglite \
@@ -62,6 +93,14 @@ RUN mkdir -p /tmp/docker-runtime-deps \
     /app/node_modules/uuid \
     /app/node_modules/ws \
     /app/node_modules/yaml \
+    /app/node_modules/zod \
+    /app/node_modules/hono \
+    /app/node_modules/json5 \
+    /app/node_modules/ethers \
+    /app/node_modules/esbuild \
+    /app/node_modules/isomorphic-git \
+    /app/node_modules/@noble/curves \
+    /app/node_modules/@noble/hashes \
   && cp -a /tmp/docker-runtime-deps/node_modules/. /app/node_modules/ \
   && rm -rf /tmp/docker-runtime-deps
 


### PR DESCRIPTION
## Problem

The CI agent image (`packages/app-core/deploy/Dockerfile.ci`) crashes on boot:

```
Cannot find package 'zod' imported from /app/packages/core/dist/node/index.node.js
```

Exit 1, before any agent code runs. This affects the `:develop` image and every new build. It is a pre-existing packaging regression (not related to any in-flight feature work).

## Root cause

`.dockerignore` excludes `**/node_modules`, so the only runtime deps in the final image are:
1. a hand-maintained allowlist installed by the `npm install` RUN block in `Dockerfile.ci`,
2. relinked workspace packages, and
3. whatever the dist bundles inline.

`packages/core/dist/node/index.node.js` third-partyises `zod` (per `packages/core/build.ts` `nodeExternals = ["dotenv","sharp","zod","@hapi/shot"]`) and imports it eagerly (35 static top-level `import ... from "zod"`). `zod` was absent from the allowlist, so it never landed in the image, and the container crashed on the very first module load.

## Fix

**Part 1 — the boot crash:** add `zod@4.4.3` (matches `packages/core/package.json` `^4.4.3`; provides the `./v3` and `./v4` subpath exports core imports).

**Part 2 — audit so the next boot does not hit a different missing dep:** `packages/agent/dist` is transpiled with `tsc` (NOT bundled), so every bare import stays third-party and must resolve at runtime. Traced the eager boot path: `runtime/eliza.js` dynamically imports `api/server.js`, whose static import graph loads eagerly at module-eval. Beyond `zod`, that graph pulls in non-allowlist third-partys that would each be the next hard boot crash:

| package | reached via |
|---|---|
| `hono` | `api/hono-adapter` (HTTP server) |
| `json5` | `config/config` |
| `@noble/curves` | `api/wallet` (`/secp256k1.js`) |
| `ethers` | `api/wallet` |
| `esbuild` | `services/plugin-compiler` (via workbench routes) |
| `isomorphic-git` | `services/vfs-git` |

Added all of these (plus `@noble/hashes`, a `@noble/curves` dependency, for safety) to **both** the `npm install` list and the `rm -rf` pre-clean list. Versions track the declarations in `packages/agent/package.json`.

## Verification

- Confirmed `zod` is statically imported (eager) 35x in `core/dist/node/index.node.js` and 0 dynamic imports → always crashes on first load.
- Confirmed the only non-node static third-party in `core/dist/node/index.node.js` is `zod` (+ `zod/v3`, `zod/v4` subpaths).
- Traced the eager static graph of `api/server.js` (the boot HTTP path) for the full external set.
- `npm install` of the full new set succeeds together cleanly (71 packages added).
- Each new package imports without error; `zod/v3`, `zod/v4`, and `@noble/curves/secp256k1.js` subpaths resolve.

## Notes / follow-up

The allowlist is hand-maintained and brittle. Documented the boot-path reasoning inline in `Dockerfile.ci` and flagged deriving the list from the workspace dist third-partys as a follow-up. `esbuild` is installed with `--ignore-scripts` (matching the existing block), so its native binary is not fetched; this is fine for boot survival because the `esbuild` import is eager but `esbuild.build()` is lazy. If the plugin-compiler path is ever exercised at runtime, the binary will need to be provided separately.

Does not touch the entrypoint or agent logic — dependency packaging only.

Co-authored-by: wakesync <shadow@shad0w.xyz>