### PR TITLE
fix(agent-image): link @elizaos/core + contracts + cloud-routing into image node_modules

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,8 @@
 !packages/agent/dist/**
 !packages/core/dist
 !packages/core/dist/**
+!packages/contracts/dist
+!packages/contracts/dist/**
 !packages/shared/dist
 !packages/shared/dist/**
 !packages/ui/dist

--- a/packages/app-core/deploy/Dockerfile.ci
+++ b/packages/app-core/deploy/Dockerfile.ci
@@ -32,7 +32,30 @@ RUN node "${APP_CORE_DIR}/scripts/relink-workspace-packages-to-dist.mjs" \
 
 # Some relinked local packages expect selected runtime dependencies to be
 # resolvable from root node_modules. Host node_modules is excluded from the
-# Docker context, so install only this small runtime set in-image.
+# Docker context (see .dockerignore: **/node_modules), so install this
+# runtime set in-image.
+#
+# IMPORTANT: this list is hand-maintained and BRITTLE. The packages here
+# are the bare third-party imports that survive into the shipped dist bundles
+# and are resolved at runtime (not inlined). Two distinct sources require
+# them:
+#   (a) packages/core/dist/node/index.node.js externalises `zod` (+ subpaths
+#       zod/v3, zod/v4) and `dotenv` (build.ts nodeExternals). zod is the
+#       FIRST eager import on boot, so a missing zod crashes the container
+#       before any agent code runs.
+#   (b) packages/agent/dist is transpiled (tsc, NOT bundled), so every bare
+#       import stays third-party. The eager boot path (runtime/eliza.js ->
+#       dynamic import api/server.js, whose static graph is loaded eagerly)
+#       pulls in: hono (api/hono-adapter), json5 (config/config),
+#       @noble/curves + ethers (api/wallet), esbuild
+#       (services/plugin-compiler via workbench routes), and isomorphic-git
+#       (services/vfs-git). All of these load at module-eval time when
+#       server.js is imported, so a missing one is a hard boot crash.
+# zod@4.4.3 matches packages/core/package.json (^4.4.3) and provides the
+# ./v3 + ./v4 subpath exports core imports. Versions below track the
+# declarations in packages/agent/package.json + packages/core/package.json.
+# FOLLOW-UP: derive this list from the workspace dist third-partys instead of
+# hand-maintaining it (see audit notes in the PR).
 RUN mkdir -p /tmp/docker-runtime-deps \
   && cd /tmp/docker-runtime-deps \
   && npm init -y >/dev/null \
@@ -50,6 +73,14 @@ RUN mkdir -p /tmp/docker-runtime-deps \
     uuid@14.0.0 \
     ws@8.20.0 \
     yaml@2.8.2 \
+    zod@4.4.3 \
+    hono@4.12.18 \
+    json5@2.2.3 \
+    ethers@6.16.0 \
+    esbuild@0.25.10 \
+    isomorphic-git@1.37.8 \
+    @noble/curves@2.2.0 \
+    @noble/hashes@2.2.0 \
   && mkdir -p /app/node_modules \
   && rm -rf \
     /app/node_modules/@electric-sql/pglite \
@@ -62,6 +93,14 @@ RUN mkdir -p /tmp/docker-runtime-deps \
     /app/node_modules/uuid \
     /app/node_modules/ws \
     /app/node_modules/yaml \
+    /app/node_modules/zod \
+    /app/node_modules/hono \
+    /app/node_modules/json5 \
+    /app/node_modules/ethers \
+    /app/node_modules/esbuild \
+    /app/node_modules/isomorphic-git \
+    /app/node_modules/@noble/curves \
+    /app/node_modules/@noble/hashes \
   && cp -a /tmp/docker-runtime-deps/node_modules/. /app/node_modules/ \
   && rm -rf /tmp/docker-runtime-deps
 

--- a/packages/app-core/scripts/link-docker-local-app-packages.mjs
+++ b/packages/app-core/scripts/link-docker-local-app-packages.mjs
@@ -14,6 +14,18 @@ const { workspaceDirs } = collectWorkspaceMaps(
   rootPkg.workspaces ?? [],
 );
 const localPackages = [
+  // Foundational workspace packages. These build to ./dist/ but keep their
+  // package.json at the package root (no dist/package.json), so they are
+  // linked package-root -> package-root here rather than via
+  // relink-workspace-packages-to-dist.mjs (which targets <pkg>/dist and
+  // requires a dist/package.json). @elizaos/shared declares @elizaos/core as
+  // a runtime dep and shared/dist/api/http-helpers.js imports it eagerly, so
+  // node_modules/@elizaos/core MUST exist or boot crashes with
+  // "Cannot find package '@elizaos/core'". Listed first so they link before
+  // any per-package side effects (e.g. the app-core argon2/jose linking).
+  "eliza/packages/core",
+  "eliza/packages/contracts",
+  "eliza/packages/cloud-routing",
   "eliza/plugins/plugin-companion",
   "eliza/plugins/plugin-elizamaker",
   "eliza/plugins/plugin-documents",


### PR DESCRIPTION
## Iteration 2 of the agent-image boot loop

Stacks on #8077 (branch `path-a-image-boot-fix`, the zod + eager-boot third-partys fix). **Do not merge** until Sol's image build + boot test on milady-core-6 passes.

### The crash (image sha-e5bc5b7, post-zod-fix)
```
Cannot find package '@elizaos/core' imported from /app/packages/shared/dist/api/http-helpers.js
(exit 1)
```

### Root cause
The Docker build context excludes `node_modules` (`.dockerignore` `**/node_modules`), so the `@elizaos/*` workspace symlinks must be recreated in-image by `relink-workspace-packages-to-dist.mjs` and `link-docker-local-app-packages.mjs`. The relink step only runs for `@elizaos/agent`, and the link-docker `localPackages` list omitted `@elizaos/core`, `@elizaos/contracts`, and `@elizaos/cloud-routing`. So `node_modules/@elizaos/core` never existed, and `@elizaos/shared` (which declares `@elizaos/core` as a runtime dep and imports it eagerly from `http-helpers.js`) could not resolve it.

### Why these go in link-docker, not relink-to-dist
`core`, `contracts`, and `cloud-routing` build to `./dist/` but keep their `package.json` at the package root (no `dist/package.json`). `relink-workspace-packages-to-dist.mjs` targets `<pkg>/dist` and requires a `dist/package.json` (true for `agent`, `shared`, `ui`, `app-core`). The dist-package-json-less packages belong in link-docker's package-root linking list. Added them first so they link before any per-package side effects (the app-core argon2/jose linking).

### Import-graph audit (eager boot path)
Traced real `@elizaos/*` import specifiers across all built `dist/*.js`. Eager-path packages and their node_modules entry status after this fix:

- `@elizaos/core` (1136 refs) - **was MISSING, now linked** (the crash)
- `@elizaos/shared` (335) - already shimmed
- `@elizaos/ui` (169) - already shimmed
- `@elizaos/agent` (58) - relinked to dist
- `@elizaos/vault` (18) - already shimmed
- `@elizaos/plugin-sql` (5) - already linked
- `@elizaos/cloud-routing` (5) - **added** (lazy trading plugins only; proactive)
- `@elizaos/skills` (3), `@elizaos/cloud-sdk` (3), `@elizaos/app-core` (2) - already linked
- `@elizaos/contracts` - bundler-inlined (no runtime import) but **added** as a declared-dep safety net; also un-ignored its `dist` in `.dockerignore`

`contracts` and `prompts` have no real runtime import specifier in any dist (fully inlined by tsdown), so they were not the crash, but contracts is added for safety since both core and shared declare it.

### Changes
- `link-docker-local-app-packages.mjs`: add `core`, `contracts`, `cloud-routing` to `localPackages`
- `.dockerignore`: un-ignore `packages/contracts/dist` (core/shared/cloud-routing dist were already un-ignored)

### Verification
Built a simulated Docker build context (repo minus node_modules/dist, plus the un-ignored dist artifacts), ran both linking scripts, and confirmed `@elizaos/core` now resolves from `node_modules/@elizaos/shared/dist/api/http-helpers.js` (the exact crashing import). All eager-path foundational packages present.

### Scope
Touches only workspace-package linking. Does not modify entrypoint/agent logic or the existing agent/plugin symlinks or the zod-deps fix.

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Docker boot crash (`Cannot find package '@elizaos/core'`) by adding `@elizaos/core`, `@elizaos/contracts`, and `@elizaos/cloud-routing` to the workspace-package linking script (`link-docker-local-app-packages.mjs`), and un-ignoring `packages/contracts/dist` in `.dockerignore`. It also extends the hand-maintained in-image `npm install` step with 8 additional third-party packages (`zod`, `hono`, `json5`, `ethers`, `esbuild`, `isomorphic-git`, `@noble/curves`, `@noble/hashes`) needed by the eager boot path of the tsc-transpiled `@elizaos/agent`.

- **`link-docker-local-app-packages.mjs`**: `core`, `contracts`, `cloud-routing` prepended to `localPackages` so they are symlinked into `node_modules/@elizaos/` before any plugin entries. The existing `resolveLocalPackageDir` / `rewriteDistExportsToSource` logic handles them correctly (dist files exist in context, so exports are not rewritten to source paths).
- **`Dockerfile.ci`**: New runtime packages added with matching `rm -rf` guards. A long comment block explains the two-source model and the version-pinning rationale; an inline `FOLLOW-UP` note acknowledges the maintenance burden.
- **`.dockerignore`**: `packages/contracts/dist` un-ignored in line with all other workspace package dist directories.

<h3>Confidence Score: 4/5</h3>

Safe to merge once the stacked PR (#8077) is merged and the image build + boot test on milady-core-6 passes, as the changes are narrowly scoped to workspace linking and in-image dep installation.

The three-file change is well-reasoned and matches the described crash: `packages/core` was never linked into `node_modules/@elizaos/`, so any import of `@elizaos/core` from a dist bundle failed at boot. The fix correctly uses the existing package-root linking path. The Dockerfile third-party version list is explicitly marked BRITTLE with a FOLLOW-UP note; pinned versions are consistent with workspace `package.json` declarations. No changes to entrypoint logic, agent code, or existing symlinks.

The `Dockerfile.ci` hand-maintained runtime-dep version list will need to stay in sync with workspace `package.json` files as the monorepo evolves — especially `zod`, `ethers`, and `esbuild`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/link-docker-local-app-packages.mjs | Adds `@elizaos/core`, `@elizaos/contracts`, and `@elizaos/cloud-routing` to the top of `localPackages`, fixing the "Cannot find package '@elizaos/core'" boot crash; ordering is deliberate (before plugin entries that may trigger side effects). |
| packages/app-core/deploy/Dockerfile.ci | Adds 8 new runtime third-party packages (`zod`, `hono`, `json5`, `ethers`, `esbuild`, `isomorphic-git`, `@noble/curves`, `@noble/hashes`) to the hand-maintained in-image install step, plus a detailed comment block explaining the two-source model (bundled core vs tsc-transpiled agent). BRITTLE notice is in-code. |
| .dockerignore | Un-ignores `packages/contracts/dist` so the contracts build artifact is included in the Docker context and available when the linking script runs; consistent with how `core`, `shared`, `cloud-routing`, etc. are already handled. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Docker build COPY . .<br/>(using .dockerignore)"] --> B["packages/core/dist ✓<br/>packages/contracts/dist ✓ NEW<br/>packages/cloud-routing/dist ✓<br/>packages/shared/dist ✓<br/>packages/agent/dist ✓"]
    B --> C["relink-workspace-packages-to-dist.mjs<br/>@elizaos/agent only<br/>(requires dist/package.json)"]
    C --> D["npm install runtime deps<br/>zod, hono, json5, ethers,<br/>esbuild, isomorphic-git,<br/>@noble/curves, @noble/hashes + existing"]
    D --> E["link-docker-local-app-packages.mjs"]
    E --> F["node_modules/@elizaos/core → packages/core ✓ NEW<br/>node_modules/@elizaos/contracts → packages/contracts ✓ NEW<br/>node_modules/@elizaos/cloud-routing → packages/cloud-routing ✓ NEW<br/>node_modules/@elizaos/shared ... (existing)"]
    F --> G["Agent boot<br/>shared/dist/api/http-helpers.js<br/>import '@elizaos/core' → resolves ✓"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(agent-image): link @elizaos/core + c..."](https://github.com/elizaos/eliza/commit/32ea34b9f3d92f989070bb38a5b41b366e475a5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34771694)</sub>

<!-- /greptile_comment -->