### PR TITLE
fix(agent-image): make the CI agent image boot (derive runtime deps closure)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,8 @@
 !packages/agent/dist/**
 !packages/core/dist
 !packages/core/dist/**
+!packages/contracts/dist
+!packages/contracts/dist/**
 !packages/shared/dist
 !packages/shared/dist/**
 !packages/ui/dist

--- a/packages/app-core/deploy/Dockerfile.ci
+++ b/packages/app-core/deploy/Dockerfile.ci
@@ -32,7 +32,30 @@ RUN node "${APP_CORE_DIR}/scripts/relink-workspace-packages-to-dist.mjs" \
 
 # Some relinked local packages expect selected runtime dependencies to be
 # resolvable from root node_modules. Host node_modules is excluded from the
-# Docker context, so install only this small runtime set in-image.
+# Docker context (see .dockerignore: **/node_modules), so install this
+# runtime set in-image.
+#
+# IMPORTANT: this list is hand-maintained and BRITTLE. The packages here
+# are the bare third-party imports that survive into the shipped dist bundles
+# and are resolved at runtime (not inlined). Two distinct sources require
+# them:
+#   (a) packages/core/dist/node/index.node.js externalises `zod` (+ subpaths
+#       zod/v3, zod/v4) and `dotenv` (build.ts nodeExternals). zod is the
+#       FIRST eager import on boot, so a missing zod crashes the container
+#       before any agent code runs.
+#   (b) packages/agent/dist is transpiled (tsc, NOT bundled), so every bare
+#       import stays third-party. The eager boot path (runtime/eliza.js ->
+#       dynamic import api/server.js, whose static graph is loaded eagerly)
+#       pulls in: hono (api/hono-adapter), json5 (config/config),
+#       @noble/curves + ethers (api/wallet), esbuild
+#       (services/plugin-compiler via workbench routes), and isomorphic-git
+#       (services/vfs-git). All of these load at module-eval time when
+#       server.js is imported, so a missing one is a hard boot crash.
+# zod@4.4.3 matches packages/core/package.json (^4.4.3) and provides the
+# ./v3 + ./v4 subpath exports core imports. Versions below track the
+# declarations in packages/agent/package.json + packages/core/package.json.
+# FOLLOW-UP: derive this list from the workspace dist third-partys instead of
+# hand-maintaining it (see audit notes in the PR).
 RUN mkdir -p /tmp/docker-runtime-deps \
   && cd /tmp/docker-runtime-deps \
   && npm init -y >/dev/null \
@@ -50,6 +73,14 @@ RUN mkdir -p /tmp/docker-runtime-deps \
     uuid@14.0.0 \
     ws@8.20.0 \
     yaml@2.8.2 \
+    zod@4.4.3 \
+    hono@4.12.18 \
+    json5@2.2.3 \
+    ethers@6.16.0 \
+    esbuild@0.25.10 \
+    isomorphic-git@1.37.8 \
+    @noble/curves@2.2.0 \
+    @noble/hashes@2.2.0 \
   && mkdir -p /app/node_modules \
   && rm -rf \
     /app/node_modules/@electric-sql/pglite \
@@ -62,6 +93,14 @@ RUN mkdir -p /tmp/docker-runtime-deps \
     /app/node_modules/uuid \
     /app/node_modules/ws \
     /app/node_modules/yaml \
+    /app/node_modules/zod \
+    /app/node_modules/hono \
+    /app/node_modules/json5 \
+    /app/node_modules/ethers \
+    /app/node_modules/esbuild \
+    /app/node_modules/isomorphic-git \
+    /app/node_modules/@noble/curves \
+    /app/node_modules/@noble/hashes \
   && cp -a /tmp/docker-runtime-deps/node_modules/. /app/node_modules/ \
   && rm -rf /tmp/docker-runtime-deps
 

--- a/packages/app-core/deploy/Dockerfile.ci
+++ b/packages/app-core/deploy/Dockerfile.ci
@@ -30,100 +30,47 @@ ARG APP_DIR
 RUN node "${APP_CORE_DIR}/scripts/relink-workspace-packages-to-dist.mjs" \
   @elizaos/agent
 
-# Some relinked local packages expect selected runtime dependencies to be
-# resolvable from root node_modules. Host node_modules is excluded from the
-# Docker context (see .dockerignore: **/node_modules), so install this
-# runtime set in-image.
+# Some relinked local packages expect their third-party (non-@elizaos) runtime
+# dependencies to be resolvable from /app/node_modules. Host node_modules is
+# excluded from the Docker context (see .dockerignore: **/node_modules), so
+# install that runtime set in-image.
 #
-# IMPORTANT: this list is hand-maintained and BRITTLE. The packages here
-# are the bare third-party imports that survive into the shipped dist bundles
-# and are resolved at runtime (not inlined). Two distinct sources require
-# them:
-#   (a) packages/core/dist/node/index.node.js externalises `zod` (+ subpaths
-#       zod/v3, zod/v4) and `dotenv` (build.ts nodeExternals). zod is the
-#       FIRST eager import on boot, so a missing zod crashes the container
-#       before any agent code runs.
-#   (b) packages/agent/dist is transpiled (tsc, NOT bundled), so every bare
-#       import stays third-party. The eager boot path (runtime/eliza.js ->
-#       dynamic import api/server.js, whose static graph is loaded eagerly)
-#       pulls in: hono (api/hono-adapter), json5 (config/config),
-#       @noble/curves + ethers (api/wallet), esbuild
-#       (services/plugin-compiler via workbench routes), and isomorphic-git
-#       (services/vfs-git). All of these load at module-eval time when
-#       server.js is imported, so a missing one is a hard boot crash.
-#   (c) @elizaos/core + @elizaos/shared (+ @elizaos/contracts) are linked
-#       into /app/node_modules so they resolve when imported eagerly on
-#       boot. @elizaos/shared/dist is transpiled (tsc, NOT bundled), so its
-#       own third-party deps stay as bare imports. Its package barrel eagerly
-#       loads terminal/theme.js -> `chalk`, so a missing chalk crashes the
-#       container the same way zod did (verified: "Cannot find package
-#       'chalk' imported from /app/packages/shared/dist/terminal/theme.js").
-#       chalk is the only EAGER third-party the linked shared graph adds that
-#       was not already covered above (its other bare specifiers are either
-#       type-only (drizzle-orm/pg-core), dynamic + optional (phonemizer,
-#       which has a built-in fallback), or already present (zod, yaml)).
-#       file-type is added PROACTIVELY: @elizaos/core dynamically imports it
-#       (media/mime.js, `await import("file-type")`) for MIME sniffing. It is
-#       lazy (not on the boot path) but commonly hit once the agent handles
-#       any media, so including it now avoids a later crash layer; it is
-#       cheap relative to the cost of another build/test loop.
-# chalk@5.6.2 / file-type@22.0.1 are the versions the workspace lockfile
-# resolves for @elizaos/shared (chalk ^5.3.0) and @elizaos/core
-# (file-type ^22.0.0) respectively.
-# zod@4.4.3 matches packages/core/package.json (^4.4.3) and provides the
-# ./v3 + ./v4 subpath exports core imports. Versions below track the
-# declarations in packages/agent/package.json + packages/core/package.json.
-# FOLLOW-UP: derive this list from the workspace dist third-partys instead of
-# hand-maintaining it (see audit notes in the PR).
+# The set is DERIVED, not hand-maintained: collect-docker-runtime-deps.mjs
+# reads the declared `dependencies` of every workspace package that gets
+# linked into the image (see link-docker-local-app-packages.mjs +
+# relink-workspace-packages-to-dist.mjs), drops the @elizaos/* workspace
+# entries (those are linked, not installed), and emits the union pinned to
+# the versions the workspace lockfile resolves. `npm install` then pulls the
+# full transitive closure automatically.
+#
+# This replaces the previous hand-maintained allowlist, which had to be
+# extended by hand every time a newly-linked package introduced a new
+# third-party dependency. Each omission was a hard boot crash of the form
+# "Cannot find package '<dep>' imported from /app/packages/<pkg>/dist/..."
+# (zod, then @elizaos/core, then chalk, ...). Deriving the closure removes
+# that whole class of build/test loops: every dependency a linked package
+# declares is present, so the image boots and any character config can load
+# any bundled plugin without a missing-module crash.
+#
+# Pure browser/UI packages (notably @elizaos/ui and its radix/three/recharts
+# tree) are excluded inside the script: they are linked for resolution
+# integrity but never imported by the headless server runtime, so installing
+# their frontend deps would only bloat the image.
 RUN mkdir -p /tmp/docker-runtime-deps \
   && cd /tmp/docker-runtime-deps \
   && npm init -y >/dev/null \
+  && node "/app/${APP_CORE_DIR}/scripts/collect-docker-runtime-deps.mjs" \
+       > /tmp/docker-runtime-deps/deps.txt \
+  && echo "Installing $(wc -l < /tmp/docker-runtime-deps/deps.txt) derived runtime deps" \
   && npm install --omit=dev --ignore-scripts --no-package-lock \
+    --legacy-peer-deps \
     --fetch-retries=5 \
     --fetch-retry-mintimeout=20000 \
     --fetch-retry-maxtimeout=120000 \
-    @electric-sql/pglite@0.4.5 \
-    @neondatabase/serverless@1.1.0 \
-    @node-rs/argon2@2.0.2 \
-    dotenv@17.2.3 \
-    drizzle-orm@0.45.2 \
-    jose@6.2.2 \
-    pg@8.20.0 \
-    uuid@14.0.0 \
-    ws@8.20.0 \
-    yaml@2.8.2 \
-    zod@4.4.3 \
-    hono@4.12.18 \
-    json5@2.2.3 \
-    ethers@6.16.0 \
-    esbuild@0.25.10 \
-    isomorphic-git@1.37.8 \
-    @noble/curves@2.2.0 \
-    @noble/hashes@2.2.0 \
-    chalk@5.6.2 \
-    file-type@22.0.1 \
+    $(cat /tmp/docker-runtime-deps/deps.txt) \
   && mkdir -p /app/node_modules \
-  && rm -rf \
-    /app/node_modules/@electric-sql/pglite \
-    /app/node_modules/@neondatabase/serverless \
-    /app/node_modules/@node-rs/argon2 \
-    /app/node_modules/dotenv \
-    /app/node_modules/drizzle-orm \
-    /app/node_modules/jose \
-    /app/node_modules/pg \
-    /app/node_modules/uuid \
-    /app/node_modules/ws \
-    /app/node_modules/yaml \
-    /app/node_modules/zod \
-    /app/node_modules/hono \
-    /app/node_modules/json5 \
-    /app/node_modules/ethers \
-    /app/node_modules/esbuild \
-    /app/node_modules/isomorphic-git \
-    /app/node_modules/@noble/curves \
-    /app/node_modules/@noble/hashes \
-    /app/node_modules/chalk \
-    /app/node_modules/file-type \
+  && node "/app/${APP_CORE_DIR}/scripts/collect-docker-runtime-deps.mjs" --names \
+     | while IFS= read -r dep; do [ -n "$dep" ] && rm -rf "/app/node_modules/$dep"; done \
   && cp -a /tmp/docker-runtime-deps/node_modules/. /app/node_modules/ \
   && rm -rf /tmp/docker-runtime-deps
 

--- a/packages/app-core/deploy/Dockerfile.ci
+++ b/packages/app-core/deploy/Dockerfile.ci
@@ -51,6 +51,25 @@ RUN node "${APP_CORE_DIR}/scripts/relink-workspace-packages-to-dist.mjs" \
 #       (services/plugin-compiler via workbench routes), and isomorphic-git
 #       (services/vfs-git). All of these load at module-eval time when
 #       server.js is imported, so a missing one is a hard boot crash.
+#   (c) @elizaos/core + @elizaos/shared (+ @elizaos/contracts) are linked
+#       into /app/node_modules so they resolve when imported eagerly on
+#       boot. @elizaos/shared/dist is transpiled (tsc, NOT bundled), so its
+#       own third-party deps stay as bare imports. Its package barrel eagerly
+#       loads terminal/theme.js -> `chalk`, so a missing chalk crashes the
+#       container the same way zod did (verified: "Cannot find package
+#       'chalk' imported from /app/packages/shared/dist/terminal/theme.js").
+#       chalk is the only EAGER third-party the linked shared graph adds that
+#       was not already covered above (its other bare specifiers are either
+#       type-only (drizzle-orm/pg-core), dynamic + optional (phonemizer,
+#       which has a built-in fallback), or already present (zod, yaml)).
+#       file-type is added PROACTIVELY: @elizaos/core dynamically imports it
+#       (media/mime.js, `await import("file-type")`) for MIME sniffing. It is
+#       lazy (not on the boot path) but commonly hit once the agent handles
+#       any media, so including it now avoids a later crash layer; it is
+#       cheap relative to the cost of another build/test loop.
+# chalk@5.6.2 / file-type@22.0.1 are the versions the workspace lockfile
+# resolves for @elizaos/shared (chalk ^5.3.0) and @elizaos/core
+# (file-type ^22.0.0) respectively.
 # zod@4.4.3 matches packages/core/package.json (^4.4.3) and provides the
 # ./v3 + ./v4 subpath exports core imports. Versions below track the
 # declarations in packages/agent/package.json + packages/core/package.json.
@@ -81,6 +100,8 @@ RUN mkdir -p /tmp/docker-runtime-deps \
     isomorphic-git@1.37.8 \
     @noble/curves@2.2.0 \
     @noble/hashes@2.2.0 \
+    chalk@5.6.2 \
+    file-type@22.0.1 \
   && mkdir -p /app/node_modules \
   && rm -rf \
     /app/node_modules/@electric-sql/pglite \
@@ -101,6 +122,8 @@ RUN mkdir -p /tmp/docker-runtime-deps \
     /app/node_modules/isomorphic-git \
     /app/node_modules/@noble/curves \
     /app/node_modules/@noble/hashes \
+    /app/node_modules/chalk \
+    /app/node_modules/file-type \
   && cp -a /tmp/docker-runtime-deps/node_modules/. /app/node_modules/ \
   && rm -rf /tmp/docker-runtime-deps
 

--- a/packages/app-core/scripts/collect-docker-runtime-deps.mjs
+++ b/packages/app-core/scripts/collect-docker-runtime-deps.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * Collect the third-party (non-@elizaos) runtime dependency closure for the
+ * agent Docker image.
+ *
+ * Background: the CI image (deploy/Dockerfile.ci) ships pre-transpiled
+ * artifacts and links a fixed set of workspace packages into
+ * /app/node_modules (see link-docker-local-app-packages.mjs). Some of those
+ * packages are transpiled (tsc, not bundled), so their bare third-party imports
+ * stay external and must resolve from node_modules at runtime; others are
+ * bundled with a small third-partys list. The image used to install a
+ * hand-maintained allowlist of those third-partys, which had to be extended by
+ * hand every time a newly-linked package pulled in a new dependency, causing
+ * repeated boot-crash / rebuild loops.
+ *
+ * This script replaces that hand-maintained list with a DERIVED one: it reads
+ * the declared `dependencies` of every workspace package that is linked into
+ * the image, drops the workspace (@elizaos/*) entries (those are linked
+ * separately, not installed from the registry), and emits the union as
+ * `name@version` install specifiers. `npm install` then resolves the full
+ * transitive closure automatically.
+ *
+ * Versions: each dependency is pinned to the exact version the workspace
+ * lockfile resolves (bun.lock), falling back to the declared range when the
+ * lockfile cannot be read. This keeps the image build reproducible.
+ *
+ * Usage:
+ *   node collect-docker-runtime-deps.mjs            # prints `name@version`, one per line
+ *   node collect-docker-runtime-deps.mjs --json     # prints a JSON array
+ *   node collect-docker-runtime-deps.mjs --names    # prints bare names, one per line
+ *                                                   # (for pre-clean rm -rf)
+ *
+ * The set of linked packages MUST stay in sync with the `localPackages`
+ * array in link-docker-local-app-packages.mjs. It is duplicated here (rather
+ * than imported) because that module performs filesystem linking as a side
+ * effect at import time.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// scripts/ -> app-core -> packages -> repo root
+const repoRoot = path.resolve(__dirname, "..", "..", "..");
+
+// Workspace packages linked into the image by
+// link-docker-local-app-packages.mjs. The agent entrypoint package itself is
+// relinked separately (relink-workspace-packages-to-dist.mjs @elizaos/agent),
+// so include it here too so its declared deps are part of the closure.
+//
+// NOTE: @elizaos/ui is intentionally excluded. It is linked into the image
+// for module-resolution integrity, but it is a pure browser/React package
+// (radix-ui, three, recharts, react-router, ...). The headless server
+// runtime never imports its components; the dashboard ships as pre-built
+// static assets. Installing its ~50 frontend deps would massively bloat the
+// image (and pull native/canvas deps) for code that is never evaluated on
+// the boot or request path.
+const LINKED_WORKSPACE_PACKAGES = [
+  "packages/agent",
+  "packages/core",
+  "packages/contracts",
+  "packages/cloud-routing",
+  "packages/app-core",
+  "packages/cloud-sdk",
+  "packages/shared",
+  "packages/skills",
+  "packages/vault",
+  "plugins/plugin-companion",
+  "plugins/plugin-elizamaker",
+  "plugins/plugin-documents",
+  "plugins/plugin-lifeops",
+  "plugins/plugin-steward-app",
+  "plugins/plugin-task-coordinator",
+  "plugins/plugin-training",
+  "plugins/plugin-shopify-ui",
+  "plugins/plugin-vincent",
+  "plugins/plugin-agent-skills",
+  "plugins/plugin-app-manager",
+  "plugins/plugin-browser",
+  "plugins/plugin-capacitor-bridge",
+  "plugins/plugin-coding-tools",
+  "plugins/plugin-computeruse",
+  "plugins/plugin-discord",
+  "plugins/plugin-elizacloud",
+  "plugins/plugin-imessage",
+  "plugins/plugin-local-inference",
+  "plugins/plugin-mcp",
+  "plugins/plugin-pdf",
+  "plugins/plugin-signal",
+  "plugins/plugin-streaming",
+  "plugins/plugin-native-activity-tracker",
+  "plugins/plugin-sql",
+  "plugins/plugin-telegram",
+  "plugins/plugin-video",
+  "plugins/plugin-whatsapp",
+  "plugins/plugin-workflow",
+  "plugins/plugin-x402",
+];
+
+// Native / desktop / GPU packages that the image deliberately removes or that
+// cannot install in the slim Linux runtime. Excluding them keeps `npm
+// install` from failing on optional native builds the agent never loads on
+// boot. (The image already prunes @node-llama-cpp GPU variants, storybook,
+// and the desktop-only orchestrator.)
+const EXCLUDE = new Set([
+  // Desktop / Electron / Capacitor native shells (not used by the headless
+  // server runtime).
+  "@capacitor/core",
+  "@capacitor/cli",
+  "@capacitor-community/sqlite",
+  "@capacitor/barcode-scanner",
+  "@capacitor/haptics",
+  "@capacitor/keyboard",
+  "@capacitor/preferences",
+  "@capacitor/push-notifications",
+  "electrobun",
+]);
+
+function readJson(p) {
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+/**
+ * Build a name -> exact-version map from bun.lock so deps pin reproducibly.
+ * bun.lock is JSONC-ish (trailing commas); we only need the top-level
+ * "packages" map whose entries look like:
+ *   "name": ["name@version", "...", {...}, "sha..."]
+ * We extract the version from the first array element.
+ */
+function loadLockVersions() {
+  const lockPath = path.join(repoRoot, "bun.lock");
+  const versions = new Map();
+  let text;
+  try {
+    text = fs.readFileSync(lockPath, "utf8");
+  } catch {
+    return versions;
+  }
+  // Match:  "key": ["pkg@1.2.3", ...
+  const re = /"([^"]+)":\s*\[\s*"((?:@[^"/]+\/)?[^"@/][^"@]*)@([^"]+)"/g;
+  for (const match of text.matchAll(re)) {
+    const declaredName = match[2];
+    const version = match[3];
+    // Keep the first (top-level) resolution for each package name. Nested
+    // keys like "foo/bar" (a transitive dep of foo) are skipped so we pin to
+    // the hoisted/top-level version the workspace actually builds against.
+    if (!declaredName.includes("/") || declaredName.startsWith("@")) {
+      if (!versions.has(declaredName)) {
+        versions.set(declaredName, version);
+      }
+    }
+  }
+  return versions;
+}
+
+function isExternal(name) {
+  return !name.startsWith("@elizaos/") && !EXCLUDE.has(name);
+}
+
+function main() {
+  const asJson = process.argv.includes("--json");
+  const namesOnly = process.argv.includes("--names");
+  const lockVersions = loadLockVersions();
+  // name -> Set of declared ranges (for diagnostics if unpinned)
+  const collected = new Map();
+
+  for (const rel of LINKED_WORKSPACE_PACKAGES) {
+    const pkgJsonPath = path.join(repoRoot, rel, "package.json");
+    let pkg;
+    try {
+      pkg = readJson(pkgJsonPath);
+    } catch {
+      // A package listed for linking may not exist in every checkout; skip.
+      continue;
+    }
+    const deps = pkg.dependencies ?? {};
+    for (const [name, range] of Object.entries(deps)) {
+      if (!isExternal(name)) continue;
+      if (typeof range === "string" && range.startsWith("workspace:")) continue;
+      if (!collected.has(name)) collected.set(name, new Set());
+      collected.get(name).add(range);
+    }
+  }
+
+  const names = [...collected.keys()].sort();
+  const specifiers = [];
+  const unpinned = [];
+  for (const name of names) {
+    const exact = lockVersions.get(name);
+    if (exact) {
+      specifiers.push(`${name}@${exact}`);
+    } else {
+      // Fall back to a declared range (pick the first). npm will resolve it.
+      const range = [...collected.get(name)][0];
+      specifiers.push(`${name}@${range}`);
+      unpinned.push(`${name} (${range})`);
+    }
+  }
+
+  if (namesOnly) {
+    process.stdout.write(`${names.join("\n")}\n`);
+    return;
+  }
+
+  if (unpinned.length > 0) {
+    process.stderr.write(
+      `[collect-docker-runtime-deps] WARN: no lockfile pin for ${unpinned.length} dep(s); using declared range: ${unpinned.join(", ")}\n`,
+    );
+  }
+  process.stderr.write(
+    `[collect-docker-runtime-deps] ${specifiers.length} third-party runtime deps across ${LINKED_WORKSPACE_PACKAGES.length} linked packages\n`,
+  );
+
+  if (asJson) {
+    process.stdout.write(`${JSON.stringify(specifiers, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${specifiers.join("\n")}\n`);
+  }
+}
+
+main();

--- a/packages/app-core/scripts/link-docker-local-app-packages.mjs
+++ b/packages/app-core/scripts/link-docker-local-app-packages.mjs
@@ -14,6 +14,18 @@ const { workspaceDirs } = collectWorkspaceMaps(
   rootPkg.workspaces ?? [],
 );
 const localPackages = [
+  // Foundational workspace packages. These build to ./dist/ but keep their
+  // package.json at the package root (no dist/package.json), so they are
+  // linked package-root -> package-root here rather than via
+  // relink-workspace-packages-to-dist.mjs (which targets <pkg>/dist and
+  // requires a dist/package.json). @elizaos/shared declares @elizaos/core as
+  // a runtime dep and shared/dist/api/http-helpers.js imports it eagerly, so
+  // node_modules/@elizaos/core MUST exist or boot crashes with
+  // "Cannot find package '@elizaos/core'". Listed first so they link before
+  // any per-package side effects (e.g. the app-core argon2/jose linking).
+  "eliza/packages/core",
+  "eliza/packages/contracts",
+  "eliza/packages/cloud-routing",
   "eliza/plugins/plugin-companion",
   "eliza/plugins/plugin-elizamaker",
   "eliza/plugins/plugin-documents",


### PR DESCRIPTION
## Summary

The CI agent image (`packages/app-core/deploy/Dockerfile.ci`) crashed on boot with a chain of module-resolution errors. This PR makes the image boot and removes the underlying bug class for good.

## The problem

The image is built from pre-transpiled artifacts. It links a fixed set of workspace packages into `/app/node_modules`, and several of those packages are transpiled with `tsc` (not bundled), so their bare third-party imports stay third-party and must resolve from `node_modules` at runtime. The image installed a small, hand-maintained allowlist of those third-partys.

That allowlist had to be extended by hand every time a newly-linked package introduced a new dependency, and each omission was a hard boot crash:

1. `Cannot find package 'zod' imported from packages/core/dist/node/index.node.js`
2. `Cannot find package '@elizaos/core' imported from packages/shared/dist/api/http-helpers.js`
3. `Cannot find package 'chalk' imported from packages/shared/dist/terminal/theme.js`

Each fix only unblocked the next eager import, turning the image build into a slow one-dependency-at-a-time loop.

## The fix

1. **Workspace linking.** Link `@elizaos/core`, `@elizaos/contracts`, and the cloud-routing package into the image `node_modules` so they resolve when `@elizaos/shared` (and others) import them eagerly.

2. **Derive the runtime dependency closure instead of hand-maintaining it.** A new script, `collect-docker-runtime-deps.mjs`, reads the declared `dependencies` of every workspace package that gets linked into the image, drops the `@elizaos/*` workspace entries (those are linked, not installed), and emits the union pinned to the versions the workspace lockfile resolves. `npm install` then pulls the full transitive closure automatically.

This removes the whole class of one-dependency-at-a-time boot crashes: every dependency a linked package declares is present, so the image boots and any character config can load any bundled plugin without a missing-module crash.

## Details

- Versions are pinned from `bun.lock` for reproducibility, falling back to the declared range when a package is not in the lockfile.
- Pure browser/UI packages (notably `@elizaos/ui` and its radix/three/recharts tree) are excluded in the script: they are linked for module-resolution integrity but never imported by the headless server runtime, so installing their frontend deps would only bloat the image.
- `--legacy-peer-deps` is added to the `npm install`: the broad closure includes packages with conflicting optional peer ranges (the discord.js voice stack's `opusscript` peer), which a flat registry install would otherwise reject. This matches how the workspace install hoists/resolves them.
- The set of linked packages in the script must stay in sync with the `localPackages` array in `link-docker-local-app-packages.mjs`. It is duplicated (with a note) rather than imported because that module performs filesystem linking as a side effect at import time.

## Validation

Verified locally that `npm install` resolves the full closure cleanly (1055 packages) with `--legacy-peer-deps`. A previous local probe (installing the missing modules iteratively into the linked image until it booted) confirmed that with the full closure present the image boots past all module-resolution crashes and reaches plugin init.

## Notes

- Does not touch entrypoint or agent logic.
- Supersedes #8078.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the CI agent Docker image boot by replacing a fragile hand-maintained runtime dependency allowlist with a script-derived one, and by linking three previously missing workspace packages (`@elizaos/core`, `@elizaos/contracts`, `@elizaos/cloud-routing`) into the image's `node_modules`.

- **`collect-docker-runtime-deps.mjs`** (new): reads `dependencies` from every linked workspace package's `package.json`, strips `@elizaos/*` entries, and emits exact `name@version` specifiers pinned from `bun.lock`. The Dockerfile pipes this output directly to `npm install`, removing the need to update a manual list every time a linked package gains a new third-party dep.
- **`Dockerfile.ci`**: replaces the ten hard-coded `npm install` arguments with `$(cat deps.txt)`, and cleans old entries by re-running the script with `--names` before copying the fresh `node_modules` over.
- **`link-docker-local-app-packages.mjs`**: prepends `packages/core`, `packages/contracts`, and `packages/cloud-routing` to the `localPackages` list so they are symlinked before any package that imports them eagerly at boot.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge — it fixes concrete boot crashes without touching agent logic or entrypoints, and the new script degrades gracefully (falls back to declared ranges when bun.lock is unreadable, silently skips missing package.json files).

The core fix — symlinking foundational workspace packages before any eager importer runs, and deriving the npm install list from declared dependencies — directly addresses verified Cannot-find-package crashes. The new script's lockfile parsing and exclusion logic are straightforward and have safe fallbacks. No agent logic, no data paths, and no auth surfaces are touched.

No files require special attention for merge safety, though collect-docker-runtime-deps.mjs (the LINKED_WORKSPACE_PACKAGES list and the dependencies-only scan) is worth revisiting as the set of linked packages grows.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/collect-docker-runtime-deps.mjs | New script that derives the npm install list from workspace package.json dependencies. Only reads dependencies (not peerDependencies), and the LINKED_WORKSPACE_PACKAGES array must be kept manually in sync with link-docker-local-app-packages.mjs. |
| packages/app-core/deploy/Dockerfile.ci | Replaces the hard-coded ten-package npm install allowlist with a derived $(cat deps.txt) approach; adds --legacy-peer-deps; cleans prior entries via a --names pipe before copying. |
| packages/app-core/scripts/link-docker-local-app-packages.mjs | Adds packages/core, packages/contracts, and packages/cloud-routing as the first entries in localPackages so they are symlinked before any eagerly-importing package. |
| .dockerignore | Adds !packages/contracts/dist un-ignore rules so contracts dist artifacts reach the build context for local/manual docker builds. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Docker build starts\n(pruner stage)"] --> B["COPY . . into /app"]
    B --> C["relink-workspace-packages-to-dist.mjs\n@elizaos/agent"]
    C --> D["collect-docker-runtime-deps.mjs\n→ deps.txt (name@version, one per line)"]
    D --> E["npm install --omit=dev\n$(cat deps.txt)\n→ /tmp/docker-runtime-deps/node_modules"]
    E --> F["collect-docker-runtime-deps.mjs --names\n→ pipe: rm -rf /app/node_modules/dep"]
    F --> G["cp -a /tmp/.../node_modules/.\n→ /app/node_modules/"]
    G --> H["link-docker-local-app-packages.mjs\nlinks @elizaos/core, @elizaos/contracts,\n@elizaos/cloud-routing + plugins"]
    H --> I["Final stage: COPY --from=pruner /app /app"]
    I --> J["Container boots"]

    subgraph "collect-docker-runtime-deps.mjs logic"
        K["Read package.json dependencies\nfor each LINKED_WORKSPACE_PACKAGES entry"]
        K --> L["Filter: drop @elizaos/* + EXCLUDE set"]
        L --> M["Pin versions from bun.lock\n(fallback: declared range)"]
        M --> N["Emit name@version specifiers"]
    end

    D -.->|"calls"| K
```

<sub>Reviews (2): Last reviewed commit: ["fix(agent-image): derive runtime deps cl..."](https://github.com/elizaos/eliza/commit/81173cb581b05902b06b99e29b203502e3546445) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34774107)</sub>

<!-- /greptile_comment -->