### PR TITLE
ci(agent-image): fail the build if the cloud-agent image does not boot

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -248,6 +248,45 @@ jobs:
             type=ref,event=tag
             type=sha,prefix=sha-,format=short
 
+      # Build the image into the local Docker daemon first (load, do NOT push).
+      # The boot-verification step below runs the REAL agent entrypoint against
+      # this image; only if it boots cleanly does the push step ship it. This
+      # is the gate that stops a container which crashes on startup (missing
+      # runtime deps, broken entrypoint) from reaching ghcr. cache-to here
+      # populates the gha cache so the later push step is a near-instant
+      # re-export of identical layers rather than a second full build.
+      - id: build-local
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
+        with:
+          context: .
+          file: packages/app-core/deploy/Dockerfile.ci
+          push: false
+          load: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci-boot-verify
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify image boots (real agent entrypoint)
+        # Runs the production entrypoint (node --import tsx
+        # packages/agent/dist/bin.js start) inside the just-built image and
+        # fails RED if the agent crashes on startup, exits non-zero, logs a
+        # known crash signature (Cannot find package/module, Failed to start,
+        # crashed during init, ...), or never serves /api/health within the
+        # timeout. A failure here blocks the push below, so a non-bootable
+        # image is never published.
+        env:
+          DOCKER_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci-boot-verify
+          BOOT_VERIFY_ONLY: "true"
+          SMOKE_TIMEOUT_SEC: "180"
+          SMOKE_PORT: "32138"
+          CONTAINER_PORT: "42138"
+        run: bash packages/app-core/scripts/docker-ci-smoke.sh --boot-verify-only
+
+      # Push only runs if the boot verification above succeeded (steps run in
+      # order and a failed step fails the job). Re-exports the identical layers
+      # from the gha cache populated by build-local, so this is fast.
       - id: push
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
@@ -257,8 +296,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
+          # cache-from only: build-local already wrote the gha cache, so this
+          # step is a cache-hit re-export rather than a second full build.
           cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32

--- a/packages/app-core/scripts/docker-ci-smoke.sh
+++ b/packages/app-core/scripts/docker-ci-smoke.sh
@@ -7,24 +7,57 @@ set -Eeuo pipefail
 #   1. Installs deps with bun using the committed lockfile
 #   2. Builds required runtime/UI artifacts for Dockerfile.ci
 #   3. Builds the production image locally
-#   4. Optionally boots the container and probes /api/health or /api/status
+#   4. Boots the container running the REAL agent entrypoint and probes
+#      /api/health or /api/status, failing if the agent crashes on startup
+#
+# The boot probe runs the image's default command (APP_CMD_START =
+# `node --import tsx packages/agent/dist/bin.js start`), i.e. the actual
+# production entrypoint. It does NOT substitute a stub health server, so a
+# broken runtime dependency closure (missing zod / @elizaos/core / chalk /
+# etc.) surfaces as a RED build instead of shipping a container that crashes
+# the moment it boots in production.
 #
 # Usage:
 #   bash packages/app-core/scripts/docker-ci-smoke.sh [--tag TAG] [--version VERSION] [--skip-smoke]
+#   # Verify an already-built/pulled image without rebuilding:
+#   DOCKER_IMAGE=ghcr.io/... bash packages/app-core/scripts/docker-ci-smoke.sh --boot-verify-only
 #
 # Environment:
 #   BUN_VERSION          Bun version to install/use in CI (default: 1.3.9)
 #   SMOKE_PORT           Host port to bind for smoke boot (default: 32138)
 #   SMOKE_TIMEOUT_SEC    Max wait for boot probe (default: 420)
 #   DOCKER_IMAGE         Override image tag completely
+#   BOOT_VERIFY_ONLY     If "true", skip the build and only boot-verify
+#                        DOCKER_IMAGE (must be set). Equivalent to
+#                        --boot-verify-only.
+#   SMOKE_CHARACTER_JSON Optional minimal character JSON injected via
+#                        ELIZA_AGENT_CHARACTER_JSON for the boot.
 
 BUN_VERSION="${BUN_VERSION:-1.3.10}"
 SMOKE_PORT="${SMOKE_PORT:-32138}"
 CONTAINER_PORT="${CONTAINER_PORT:-42138}"
 SMOKE_TIMEOUT_SEC="${SMOKE_TIMEOUT_SEC:-420}"
 SKIP_SMOKE=false
+BOOT_VERIFY_ONLY="${BOOT_VERIFY_ONLY:-false}"
 TAG="docker-smoke"
 VERSION=""
+
+# Log signatures that mean the agent crashed during startup. If any of these
+# show up in the container logs we fail immediately rather than waiting out the
+# full timeout. These are the exact failure modes (missing runtime deps,
+# entrypoint blowups) that previously shipped green because the smoke step
+# booted a stub health server instead of the real entrypoint.
+BOOT_CRASH_PATTERNS=(
+  'Cannot find package'
+  'Cannot find module'
+  'ERR_MODULE_NOT_FOUND'
+  'ERR_REQUIRE_ESM'
+  'Failed to start'
+  'crashed during init'
+  'FATAL'
+  'UnhandledPromiseRejection'
+  'Cannot read properties of undefined'
+)
 
 log() {
   printf '[docker-ci-smoke] %s\n' "$*"
@@ -84,6 +117,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --skip-smoke)
       SKIP_SMOKE=true
+      shift
+      ;;
+    --boot-verify-only)
+      BOOT_VERIFY_ONLY=true
       shift
       ;;
     -h|--help)
@@ -166,9 +203,13 @@ log "Smoke port: $SMOKE_PORT"
 log "Container port override: $CONTAINER_PORT"
 log "Artifact dir: $SMOKE_ARTIFACT_DIR"
 
-command -v node >/dev/null 2>&1 || fail "node is required"
-command -v bun >/dev/null 2>&1 || fail "bun is required"
-BUN_BIN="$(command -v bun)"
+# bun/node are only needed for the build path. In boot-verify-only mode we
+# just run an already-built image, so don't hard-require them.
+if [[ "$BOOT_VERIFY_ONLY" != "true" ]]; then
+  command -v node >/dev/null 2>&1 || fail "node is required"
+  command -v bun >/dev/null 2>&1 || fail "bun is required"
+  BUN_BIN="$(command -v bun)"
+fi
 
 DOCKER_BIN="$(find_docker_bin)" || fail "docker is required"
 
@@ -203,6 +244,169 @@ cleanup() {
   fi
 }
 trap cleanup EXIT
+
+# boot_verify boots the just-built (or pre-supplied) image running the REAL
+# agent entrypoint and fails the script if the agent crashes on startup or
+# never serves health. This is the gate that stops a container that crashes on
+# boot (missing runtime deps, broken entrypoint) from shipping green.
+boot_verify() {
+  log "Starting container boot verification (real agent entrypoint)"
+  log "Command under test: ${APP_CMD_START}"
+
+  # A tiny, valid character so the agent has a concrete identity to boot with.
+  # The runtime falls back to a bundled default if this is unset, but pinning
+  # one keeps the boot deterministic across branches.
+  local character_json
+  character_json="${SMOKE_CHARACTER_JSON:-{\"name\":\"CiSmoke\",\"bio\":[\"CI boot verification agent.\"],\"system\":\"You are a CI boot probe.\"}}"
+
+  # Unique pglite data dir per run avoids the data-dir lock that makes a
+  # second container on the same host fail to acquire the store.
+  local pglite_dir="/tmp/ci-db-${RANDOM}-${RANDOM}"
+
+  "$DOCKER_BIN" rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  # NOTE: no command override here. The container runs its default CMD
+  # (APP_CMD_START = the real `node --import tsx packages/agent/dist/bin.js
+  # start`). Substituting a stub health server is exactly what let broken
+  # images ship green before; do not reintroduce it.
+  "$DOCKER_BIN" run -d \
+    --name "$CONTAINER_NAME" \
+    -e PORT="$CONTAINER_PORT" \
+    -e APP_PORT="$CONTAINER_PORT" \
+    -e ELIZA_PORT="$CONTAINER_PORT" \
+    -e ELIZA_API_PORT="$CONTAINER_PORT" \
+    -e ELIZA_AGENT_PORT="$CONTAINER_PORT" \
+    -e APP_API_BIND=0.0.0.0 \
+    -e ELIZA_API_BIND=0.0.0.0 \
+    -e AGENT_API_BIND=0.0.0.0 \
+    -e ELIZA_AGENT_CHARACTER_JSON="$character_json" \
+    -e ELIZA_STATE_DIR=/tmp/eliza-smoke/state \
+    -e ELIZA_CONFIG_DIR=/tmp/eliza-smoke/config \
+    -e ELIZA_WORKSPACE_DIR=/tmp/eliza-smoke/workspace \
+    -e ELIZA_VAULT_PASSPHRASE=docker-smoke-vault-passphrase \
+    -e PGLITE_DATA_DIR="$pglite_dir" \
+    -e ELIZA_DISABLE_LOCAL_EMBEDDINGS=1 \
+    -p "${SMOKE_PORT}:${CONTAINER_PORT}" \
+    "$DOCKER_IMAGE" >/dev/null
+
+  local status_url="http://127.0.0.1:${SMOKE_PORT}/api/status"
+  local health_url="http://127.0.0.1:${SMOKE_PORT}/api/health"
+
+  probe_ok() {
+    local url="$1"
+    local out="$2"
+    local code
+    code="$(curl -sS --connect-timeout 1 --max-time 3 -o "$out" -w '%{http_code}' "$url" || true)"
+    case "$code" in
+      200)
+        return 0
+        ;;
+      401)
+        if grep -q 'Unauthorized' "$out" 2>/dev/null; then
+          return 0
+        fi
+        ;;
+    esac
+    return 1
+  }
+
+  # Scan container logs for known crash signatures. Returns 0 (match) when the
+  # agent has crashed on startup so we can fail fast with a clear message
+  # instead of waiting out the whole timeout.
+  scan_crash() {
+    local logs_file="$1"
+    local pattern
+    for pattern in "${BOOT_CRASH_PATTERNS[@]}"; do
+      if grep -qiF "$pattern" "$logs_file" 2>/dev/null; then
+        printf '%s' "$pattern"
+        return 0
+      fi
+    done
+    return 1
+  }
+
+  # Confirm health by probing a few times in a row before declaring success,
+  # so a single transient curl failure does not flap the gate.
+  confirm_ok() {
+    local url="$1"
+    local out="$2"
+    local i
+    for i in 1 2 3; do
+      probe_ok "$url" "$out" || return 1
+      [[ "$i" -lt 3 ]] && sleep 1
+    done
+    return 0
+  }
+
+  local logs_file="$SMOKE_ARTIFACT_DIR/boot.log"
+  local deadline=$((SECONDS + SMOKE_TIMEOUT_SEC))
+  local last_log_dump=0
+  while (( SECONDS < deadline )); do
+    timeout 30 "$DOCKER_BIN" logs "$CONTAINER_NAME" >"$logs_file" 2>&1 || true
+
+    # Fail fast on a known crash signature in the logs.
+    local matched
+    if matched="$(scan_crash "$logs_file")"; then
+      log "Detected startup crash signature in container logs: '${matched}'"
+      timeout 30 "$DOCKER_BIN" logs --tail 120 "$CONTAINER_NAME" || true
+      log "Preserved failure artifacts in $SMOKE_ARTIFACT_DIR"
+      fail "Agent crashed on startup (matched '${matched}'); image is NOT bootable"
+    fi
+
+    local running_containers_file
+    running_containers_file="$(mktemp 2>/dev/null || printf '%s\n' "$SMOKE_ARTIFACT_DIR/docker-running-containers.txt")"
+    timeout 10 "$DOCKER_BIN" ps --format '{{.Names}}' >"$running_containers_file" 2>&1 || true
+    if ! grep -Fxq "$CONTAINER_NAME" "$running_containers_file" 2>/dev/null; then
+      rm -f "$running_containers_file" >/dev/null 2>&1 || true
+      local exit_code
+      exit_code="$(timeout 10 "$DOCKER_BIN" inspect -f '{{.State.ExitCode}}' "$CONTAINER_NAME" 2>/dev/null || echo '?')"
+      timeout 30 "$DOCKER_BIN" logs --tail 120 "$CONTAINER_NAME" || true
+      log "Preserved failure artifacts in $SMOKE_ARTIFACT_DIR"
+      fail "Container exited (exit code ${exit_code}) before health came up; image is NOT bootable"
+    fi
+    rm -f "$running_containers_file" >/dev/null 2>&1 || true
+
+    if (( SECONDS - last_log_dump >= 30 )); then
+      last_log_dump=$SECONDS
+      log "Container still booting; recent logs follow"
+      timeout 10 "$DOCKER_BIN" logs --tail 80 "$CONTAINER_NAME" || true
+    fi
+
+    if confirm_ok "$health_url" /tmp/eliza-docker-health.txt; then
+      log "Boot verified: health probe succeeded against the real entrypoint: $health_url"
+      cat /tmp/eliza-docker-health.txt
+      return 0
+    fi
+
+    if confirm_ok "$status_url" /tmp/eliza-docker-status.txt; then
+      log "Boot verified: status probe succeeded against the real entrypoint: $status_url"
+      cat /tmp/eliza-docker-status.txt
+      return 0
+    fi
+
+    sleep 5
+  done
+
+  timeout 30 "$DOCKER_BIN" logs --tail 120 "$CONTAINER_NAME" || true
+  log "Preserved timeout artifacts in $SMOKE_ARTIFACT_DIR"
+  fail "Timed out waiting for the real agent to serve health (${SMOKE_TIMEOUT_SEC}s); image is NOT bootable"
+}
+
+# Boot-verify-only mode: skip the entire build and just verify a pre-built
+# image (DOCKER_IMAGE must be set/pullable). Used by the build workflow to
+# verify the image it just built locally before pushing.
+if [[ "$BOOT_VERIFY_ONLY" == "true" ]]; then
+  log "Boot-verify-only mode: skipping build, verifying $DOCKER_IMAGE"
+  if ! "$DOCKER_BIN" image inspect "$DOCKER_IMAGE" >/dev/null 2>&1; then
+    log "Image $DOCKER_IMAGE not present locally; attempting pull"
+    "$DOCKER_BIN" pull "$DOCKER_IMAGE" >/dev/null 2>&1 || fail "Image $DOCKER_IMAGE not available locally and pull failed"
+  fi
+  if $SKIP_SMOKE; then
+    log "Skipping runtime boot (--skip-smoke)"
+    exit 0
+  fi
+  boot_verify
+  exit 0
+fi
 
 log "Installing dependencies"
 node "$APP_CORE_SCRIPTS_DIR/init-submodules.mjs"
@@ -438,85 +642,4 @@ if $SKIP_SMOKE; then
   exit 0
 fi
 
-log "Starting container smoke boot"
-"$DOCKER_BIN" rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
-"$DOCKER_BIN" run -d \
-  --name "$CONTAINER_NAME" \
-  -e PORT="$CONTAINER_PORT" \
-  -e APP_PORT="$CONTAINER_PORT" \
-  -e ELIZA_API_PORT="$CONTAINER_PORT" \
-  -e ELIZA_API_PORT="$CONTAINER_PORT" \
-  -e ELIZA_PORT="$CONTAINER_PORT" \
-  -e APP_API_BIND=0.0.0.0 \
-  -e ELIZA_STATE_DIR=/tmp/eliza-smoke/state \
-  -e ELIZA_STATE_DIR=/tmp/eliza-smoke/state \
-  -e ELIZA_CONFIG_DIR=/tmp/eliza-smoke/config \
-  -e ELIZA_CONFIG_DIR=/tmp/eliza-smoke/config \
-  -e ELIZA_WORKSPACE_DIR=/tmp/eliza-smoke/workspace \
-  -e ELIZA_WORKSPACE_DIR=/tmp/eliza-smoke/workspace \
-  -e ELIZA_VAULT_PASSPHRASE=docker-smoke-vault-passphrase \
-  -e PGLITE_DATA_DIR=/tmp/eliza-smoke/pglite \
-  -e ELIZA_DISABLE_LOCAL_EMBEDDINGS=1 \
-  -e ELIZA_API_BIND=0.0.0.0 \
-  -p "${SMOKE_PORT}:${CONTAINER_PORT}" \
-  "$DOCKER_IMAGE" \
-  sh -lc 'node -e '"'"'const http=require("node:http");const port=Number(process.env.PORT||process.env.APP_PORT||process.env.ELIZA_PORT||2138);http.createServer((req,res)=>{if(req.url==="/api/health"||req.url==="/api/status"){res.writeHead(200,{"content-type":"application/json"});res.end(JSON.stringify({ok:true,smoke:true}));return;}res.writeHead(404);res.end();}).listen(port,"0.0.0.0",()=>console.log(`[docker-ci-smoke] health server listening on ${port}`));'"'"'' >/dev/null
-
-status_url="http://127.0.0.1:${SMOKE_PORT}/api/status"
-health_url="http://127.0.0.1:${SMOKE_PORT}/api/health"
-
-probe_ok() {
-  local url="$1"
-  local out="$2"
-  local code
-  code="$(curl -sS --connect-timeout 1 --max-time 3 -o "$out" -w '%{http_code}' "$url" || true)"
-  case "$code" in
-    200)
-      return 0
-      ;;
-    401)
-      if grep -q 'Unauthorized' "$out" 2>/dev/null; then
-        return 0
-      fi
-      ;;
-  esac
-  return 1
-}
-
-deadline=$((SECONDS + SMOKE_TIMEOUT_SEC))
-last_log_dump=0
-while (( SECONDS < deadline )); do
-  running_containers_file="$(mktemp 2>/dev/null || printf '%s\n' "$SMOKE_ARTIFACT_DIR/docker-running-containers.txt")"
-  timeout 10 "$DOCKER_BIN" ps --format '{{.Names}}' >"$running_containers_file" 2>&1 || true
-  if ! grep -Fxq "$CONTAINER_NAME" "$running_containers_file" 2>/dev/null; then
-    rm -f "$running_containers_file" >/dev/null 2>&1 || true
-    timeout 30 "$DOCKER_BIN" logs "$CONTAINER_NAME" || true
-    log "Preserved failure artifacts in $SMOKE_ARTIFACT_DIR"
-    fail "Container exited before smoke probe succeeded"
-  fi
-  rm -f "$running_containers_file" >/dev/null 2>&1 || true
-
-  if (( SECONDS - last_log_dump >= 30 )); then
-    last_log_dump=$SECONDS
-    log "Container still booting; recent logs follow"
-    timeout 10 "$DOCKER_BIN" logs --tail 80 "$CONTAINER_NAME" || true
-  fi
-
-  if probe_ok "$health_url" /tmp/eliza-docker-health.txt; then
-    log "Health probe succeeded: $health_url"
-    cat /tmp/eliza-docker-health.txt
-    exit 0
-  fi
-
-  if probe_ok "$status_url" /tmp/eliza-docker-status.txt; then
-    log "Status probe succeeded: $status_url"
-    cat /tmp/eliza-docker-status.txt
-    exit 0
-  fi
-
-  sleep 5
-done
-
-timeout 30 "$DOCKER_BIN" logs "$CONTAINER_NAME" || true
-log "Preserved timeout artifacts in $SMOKE_ARTIFACT_DIR"
-fail "Timed out waiting for container smoke probe (${SMOKE_TIMEOUT_SEC}s)"
+boot_verify


### PR DESCRIPTION
## Problem

The `build-agent-image.yml` workflow built and pushed the cloud-agent container image with no boot verification. Separately, `packages/app-core/scripts/docker-ci-smoke.sh` had an "optional boot probe" that started a fake health server (`node -e 'http.createServer(...)'`) instead of the real agent entrypoint (`packages/agent/dist/bin.js start`).

Net effect: an image that crashes on boot (missing runtime deps like zod, @elizaos/core, chalk, and similar dependency-closure gaps) built green and shipped to ghcr. Nothing in CI ever ran the real entrypoint against the built image, so these regressions were caught only after they reached production and were fixed by hand.

## Fix

Add a real boot-verification gate so a non-bootable image never gets pushed.

**`packages/app-core/scripts/docker-ci-smoke.sh`**
- Boots the container using its real default command (`APP_CMD_START` = `node --import tsx packages/agent/dist/bin.js start`) instead of substituting a fake `http.createServer` health server.
- Adds a boot-verify-only mode (`--boot-verify-only` / `BOOT_VERIFY_ONLY=true`) that skips the build and verifies a pre-built image.
- Scans container logs for known startup-crash signatures (`Cannot find package`, `Cannot find module`, `ERR_MODULE_NOT_FOUND`, `Failed to start`, `crashed during init`, and similar) to fail fast.
- Detects non-zero container exit and reports the exit code.
- Retries the health probe a few times before declaring success to avoid flakiness.
- Keeps `--skip-smoke` as an escape hatch.

**`.github/workflows/build-agent-image.yml`**
- Builds the image into the local Docker daemon first (`load: true`, `push: false`).
- Runs the boot verification against that local image.
- Only pushes (to ghcr) if the verification passes. A failed verification fails the job, so the push step never runs.
- The push step reuses the gha cache populated by the local build, so it is a fast re-export rather than a second full build.

## How it detects a boot failure

The gate fails the build (exit 1, RED) when any of these happen:
- The container exits non-zero before health comes up.
- The container logs contain a known startup-crash signature.
- The agent never serves `/api/health` (or `/api/status`) within the timeout.

It passes (exit 0, GREEN) when the real entrypoint comes up and serves health.

## Proof

Verified locally with minimal fixture images run through the gate via `--boot-verify-only`:

- Bootable image (serves `/api/health` from its real default command): gate exits 0 (GREEN), `Boot verified: health probe succeeded`.
- Broken image (entrypoint does `require('a-package-that-does-not-exist')`): gate exits 1 (RED), `Detected startup crash signature in container logs: 'Cannot find module'`, full crash log dumped.
- Hung image (boots, stays alive, never opens the port): gate exits 1 (RED) via the health timeout.

## Note

This is independent of the dependency-closure fix and lands on its own. The dep fix makes today's image boot; this gate is what stops the breakage from coming back: from now on, any merge that breaks the image boot turns the build RED and the broken image is never pushed.

Please review and do not merge yet.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a real boot-verification gate to the `build-agent-image` workflow: the image is built into the local Docker daemon first, run against its real agent entrypoint (instead of the previous stub `http.createServer` health server), and only pushed to ghcr if the agent successfully serves `/api/health`. The smoke script is refactored into a reusable `boot_verify()` function with crash-pattern scanning and a 3-probe confirmation to reduce flakiness.

- **`docker-ci-smoke.sh`**: replaces the inline stub-health-server boot with `boot_verify()` that runs the container's default CMD, scans logs for crash signatures, and exposes a new `--boot-verify-only` / `BOOT_VERIFY_ONLY` mode for pre-built images.
- **`build-agent-image.yml`**: inserts `build-local` (load, no push) → `boot_verify` → `push` so the push step only fires after the gate passes; the push step drops `cache-to` and relies on the GHA cache populated by `build-local` for a fast re-export.

<h3>Confidence Score: 3/5</h3>

The core mechanism is sound and a significant improvement over the stub health-server approach, but two overly broad crash patterns in the smoke script can cause the gate to reject a perfectly bootable image, which would falsely block merges.

The `BOOT_CRASH_PATTERNS` array includes `FATAL` (matched case-insensitively, firing on any log line containing the word 'fatal') and `Cannot read properties of undefined` (a routine JavaScript caught-error message appearing frequently in plugin startup logs). Either match immediately fails the gate and blocks the push — meaning a working image could be permanently rejected until the false-positive log line is removed. This affects the primary new path added by the PR.

packages/app-core/scripts/docker-ci-smoke.sh — specifically the BOOT_CRASH_PATTERNS array and the -i flag in scan_crash

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/docker-ci-smoke.sh | Refactors smoke boot into a `boot_verify()` function that runs the real agent entrypoint instead of a stub health server; adds `--boot-verify-only` mode, crash-pattern scanning, and 3-probe confirmation. Two patterns in `BOOT_CRASH_PATTERNS` (`FATAL` with case-insensitive matching and `Cannot read properties of undefined`) are too broad and can produce false positives on working images. |
| .github/workflows/build-agent-image.yml | Adds a local `build-local` step (load, no push) followed by a `boot_verify` step before the final push to ghcr; the push step drops `cache-to` and relies on the GHA cache populated by `build-local`. The verified-then-push guarantee is only as strong as the GHA cache hit rate. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[push / release / workflow_dispatch] --> B[Build workspace artifacts\nbun install, build plugins, build UI]
    B --> C[build-local\ndocker build → load into local daemon\ncache-to: gha]
    C --> D[Verify image boots\ndocker-ci-smoke.sh --boot-verify-only]
    D --> E{boot_verify}
    E --> F[docker run\nreal agent entrypoint\nno CMD override]
    F --> G{scan_crash\ncheck logs every 5s}
    G -->|crash pattern matched| FAIL1[❌ FAIL\nAgent crashed on startup]
    G -->|container exited non-zero| FAIL2[❌ FAIL\nContainer exited early]
    G -->|timeout 180s| FAIL3[❌ FAIL\nTimeout waiting for health]
    G -->|confirm_ok\n3 consecutive probes| PASS[✅ PASS\nBoot verified]
    PASS --> H[push step\ncache-from: gha only\npush: true → ghcr]
    FAIL1 --> STOP[🚫 Job fails\nPush never runs]
    FAIL2 --> STOP
    FAIL3 --> STOP
    H --> I[Generate artifact attestation]
    I --> J[Make image public via GitHub API]
```

<sub>Reviews (1): Last reviewed commit: ["ci(agent-image): gate the push on a real..."](https://github.com/elizaos/eliza/commit/a589db25b96389409b660bf6d4c6a37ecfa15961) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34775980)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->