### PR TITLE
fix(ui): self-heal onboarding when pinned to the agent's raw loopback port

### DIFF
--- a/packages/ui/src/components/shell/ComputerUseApprovalOverlay.tsx
+++ b/packages/ui/src/components/shell/ComputerUseApprovalOverlay.tsx
@@ -104,7 +104,10 @@ export function ComputerUseApprovalOverlay() {
     };
   }, [refresh]);
 
-  const visibleApprovals = snapshot.pendingApprovals;
+  // Defensive: the snapshot can be partially populated during reconnect/
+  // recovery windows, so `pendingApprovals` may be momentarily undefined.
+  // Never crash the whole app on it — render no cards until it's an array.
+  const visibleApprovals = snapshot.pendingApprovals ?? [];
   const approvalCards = useMemo(
     () =>
       visibleApprovals.map((approval) => ({

--- a/packages/ui/src/state/startup-phase-poll.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FirstRunOptions } from "../api";
 import { clearPersistedActiveServer } from "./persistence";
 import {
+  isRecoverableRemoteBase,
   type PollingBackendDeps,
   runPollingBackend,
   shouldFallBackToLocalOrigin,
@@ -361,6 +362,74 @@ describe("runPollingBackend", () => {
     });
   });
 
+  it("recovers from a loopback base pinned at the agent's raw port (dev-in-browser 401 dead-end)", async () => {
+    // The user's exact case: pinned to 127.0.0.1:31337 (the agent's raw port),
+    // which 401s the cross-origin browser request -> required:true +
+    // pairingEnabled:false. Loopback bases were previously skipped by
+    // isRecoverableRemoteBase; the auth-walled path now recovers (allowLoopback)
+    // to the same-origin proxy that actually serves this page.
+    const deps = createDeps();
+    const dispatch = vi.fn();
+    (globalThis as { window?: unknown }).window = {
+      location: { origin: "http://localhost:2138", protocol: "http:" },
+    };
+    clientMock.getBaseUrl.mockReturnValue("http://127.0.0.1:31337");
+    clientMock.hasToken.mockReturnValue(false);
+    clientMock.getAuthStatus.mockReset();
+    clientMock.getAuthStatus
+      .mockResolvedValueOnce({
+        required: true,
+        authenticated: false,
+        pairingEnabled: false,
+        expiresAt: null,
+      })
+      .mockResolvedValue({
+        required: false,
+        authenticated: false,
+        pairingEnabled: false,
+        expiresAt: null,
+      });
+    const rawPort = {
+      id: "remote:raw-agent-port",
+      kind: "remote" as const,
+      label: "Raw agent port",
+      apiBase: "http://127.0.0.1:31337",
+    };
+    const ctx: RestoringSessionCtx = {
+      persistedActiveServer: rawPort,
+      restoredActiveServer: rawPort,
+      shouldPreserveCompletedFirstRun: false,
+      hadPriorFirstRun: true,
+    };
+
+    await runPollingBackend(
+      deps,
+      dispatch,
+      {
+        supportsLocalRuntime: true,
+        backendTimeoutMs: 1000,
+        agentReadyTimeoutMs: 1000,
+        probeForExistingInstall: true,
+        defaultTarget: "embedded-local",
+      },
+      ctx,
+      1,
+      { current: 1 },
+      { current: false },
+      { current: null },
+    );
+
+    expect(clearPersistedActiveServer).toHaveBeenCalledTimes(1);
+    expect(clientMock.setBaseUrl).toHaveBeenCalledWith(null);
+    expect(dispatch).not.toHaveBeenCalledWith({
+      type: "BACKEND_AUTH_REQUIRED",
+    });
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "BACKEND_REACHED",
+      firstRunComplete: false,
+    });
+  });
+
   it("does NOT auto-recover when pairing is ENABLED (the user can actually pair)", async () => {
     // Guard: recovery is only for the pairing-DISABLED dead end. When pairing is
     // enabled there is a real way forward (pair this device), so keep the gate
@@ -476,6 +545,45 @@ describe("shouldFallBackToLocalOrigin", () => {
   it("does not fall back off a web origin (e.g. a desktop custom scheme)", () => {
     expect(
       shouldFallBackToLocalOrigin({ ...eligible, pageProtocol: "views:" }),
+    ).toBe(false);
+  });
+});
+
+describe("isRecoverableRemoteBase — allowLoopback", () => {
+  const base = {
+    pageOrigin: "http://localhost:2138",
+    pageProtocol: "http:" as string | null,
+    isNativeMobile: false,
+  };
+
+  it("leaves a loopback base alone by default (connection-error path: local agent still booting)", () => {
+    expect(
+      isRecoverableRemoteBase({
+        ...base,
+        clientBaseUrl: "http://127.0.0.1:31337",
+      }),
+    ).toBe(false);
+  });
+
+  it("recovers from a cross-port loopback base when allowLoopback (auth-walled raw agent port)", () => {
+    // The dev-in-browser case: pinned to the agent's raw 127.0.0.1:31337 which
+    // 401s the browser cross-origin; the same-origin proxy escapes it.
+    expect(
+      isRecoverableRemoteBase({
+        ...base,
+        clientBaseUrl: "http://127.0.0.1:31337",
+        allowLoopback: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("never recovers to the page's own origin, even with allowLoopback (no self-loop)", () => {
+    expect(
+      isRecoverableRemoteBase({
+        ...base,
+        clientBaseUrl: "http://localhost:2138",
+        allowLoopback: true,
+      }),
     ).toBe(false);
   });
 });

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -89,6 +89,16 @@ export function isRecoverableRemoteBase(args: {
   pageOrigin: string | null;
   pageProtocol: string | null;
   isNativeMobile: boolean;
+  /**
+   * Allow recovering from a loopback base that is NOT this page's origin.
+   * The connection-error path leaves loopback alone (a loopback that won't
+   * connect is the local agent still booting). The auth-walled path passes
+   * true: a loopback agent that *answered* with a pairing-disabled gate is a
+   * real dead end — e.g. dev-in-browser pinned to the agent's raw port
+   * (127.0.0.1:31337) which the agent 401s as a cross-origin request, while
+   * the same-origin proxy serving this page reaches it with localAccess.
+   */
+  allowLoopback?: boolean;
 }): boolean {
   if (args.isNativeMobile) return false;
   if (args.pageProtocol !== "http:" && args.pageProtocol !== "https:") {
@@ -98,10 +108,13 @@ export function isRecoverableRemoteBase(args: {
   if (!base) return false; // already same-origin / local
   try {
     const url = new URL(base);
+    // Never recover to where we already are (no pointless self-recovery loop).
     if (args.pageOrigin && url.origin === args.pageOrigin) return false;
-    const host = url.hostname.toLowerCase();
-    if (host === "127.0.0.1" || host === "localhost" || host === "::1") {
-      return false;
+    if (!args.allowLoopback) {
+      const host = url.hostname.toLowerCase();
+      if (host === "127.0.0.1" || host === "localhost" || host === "::1") {
+        return false;
+      }
     }
   } catch {
     return false;
@@ -306,14 +319,16 @@ export async function runPollingBackend(
         // user can do on this server. Recover to the local origin instead of
         // stranding them, whether or not they completed a prior first-run — a
         // returning user who lost their token re-connects through onboarding,
-        // which is strictly better than a wall. `isRecoverableRemoteBase` still
-        // guards against same-origin/loopback bases (no pointless self-recovery
-        // loop), and pairing-ENABLED remotes keep the pairing gate so users can
-        // actually pair.
+        // which is strictly better than a wall. allowLoopback: a base pinned at
+        // the agent's raw loopback port (e.g. dev-in-browser at 127.0.0.1:31337)
+        // 401s the browser cross-origin and lands here too — recover to the
+        // same-origin proxy that serves this page. `isRecoverableRemoteBase`
+        // still refuses to recover to the page's own origin (no self-loop), and
+        // pairing-ENABLED remotes keep the pairing gate so users can pair.
         if (
           !fellBackToLocal &&
           !auth.pairingEnabled &&
-          isRecoverableRemoteBase(recoveryEnv())
+          isRecoverableRemoteBase({ ...recoveryEnv(), allowLoopback: true })
         ) {
           recoverToLocalOrigin(
             "saved remote requires auth but pairing is disabled (dead end)",


### PR DESCRIPTION
## Problem
A client whose saved server points at the agent's **raw loopback port** (e.g. `127.0.0.1:31337`, the dev-in-browser default) gets a **401** on the cross-origin browser request and lands on the **"Pairing is not enabled on this server"** dead end. Reloading doesn't help — auto-recovery skipped it because `isRecoverableRemoteBase` treats *every* loopback base as the healthy local agent. Users were stranded (recurring pairing wall during onboarding).

## Fix
1. **`allowLoopback`** on the auth-walled recovery path: a loopback agent that *answered* with a pairing-disabled gate is a real dead end the same-origin proxy escapes. The connection-error path keeps the loopback guard (a loopback that won't connect is the local agent still booting). Recovery still refuses to target the page's own origin (no self-loop); pairing-ENABLED remotes keep the pairing gate.
2. **`ComputerUseApprovalOverlay`** no longer crashes the whole app when `snapshot.pendingApprovals` is momentarily `undefined` during the reconnect/recovery window (`?? []`). That crash — *"Cannot read properties of undefined (reading 'map')"* — was what turned recovery into a blank/error screen.

## Verification
- Real headless browser: a saved server at a loopback raw agent port returning `pairingEnabled:false` now **auto-recovers to onboarding — no click, no crash**.
- Unit tests: `isRecoverableRemoteBase` allowLoopback behavior + the loopback `runPollingBackend` recovery path (16/16 startup-poll tests green); tsgo + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a "Pairing is not enabled on this server" dead-end that stranded users whose saved server was pinned to the agent's raw loopback port (e.g. `127.0.0.1:31337`), and separately prevents a whole-app crash in `ComputerUseApprovalOverlay` when `pendingApprovals` is absent from the snapshot during a recovery window.

- **`isRecoverableRemoteBase`** gains an `allowLoopback` flag; the auth-walled dead-end path passes `true` so a loopback base that _answered_ with `pairingEnabled:false` is treated as recoverable (same-origin proxy rescues it), while the connection-error path keeps its existing loopback guard unchanged.
- **`ComputerUseApprovalOverlay`** adds a `?? []` null-coalescing guard on `snapshot.pendingApprovals` to avoid crashing when the server returns a partial snapshot during reconnect — this was the blank/error screen that turned recovery into an unusable state.
- New tests cover `isRecoverableRemoteBase`'s `allowLoopback` behaviour and a full `runPollingBackend` integration scenario for the loopback raw-port recovery path.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the recovery logic is well-guarded against self-loops and only activates on the narrow auth-walled, pairing-disabled dead-end path.

Both changes are small, targeted, and backed by new tests that pass. The only observation is that the ComputerUseApprovalSnapshot TypeScript type doesn't declare pendingApprovals as optional, so the ?? [] defensive guard is invisible to future callers of the interface — no incorrect runtime behaviour exists today, but a later consumer could re-introduce the crash.

packages/ui/src/api/client-computeruse.ts — the pendingApprovals field could be made optional to match the runtime behaviour the overlay now defends against.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/shell/ComputerUseApprovalOverlay.tsx | Adds ?? [] null-coalescing guard on snapshot.pendingApprovals to prevent a crash when the server returns a snapshot without the field during recovery windows. Minor type-definition mismatch worth noting. |
| packages/ui/src/state/startup-phase-poll.ts | Adds allowLoopback flag to isRecoverableRemoteBase so the auth-walled dead-end path can recover from a loopback address pinned to the agent's raw port, while the connection-error path continues to treat loopback as the local agent still booting. |
| packages/ui/src/state/startup-phase-poll.test.ts | Exports isRecoverableRemoteBase for direct testing and adds a full runPollingBackend integration test for the loopback raw-agent-port recovery scenario, plus unit tests for the new allowLoopback behaviours. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runPollingBackend starts] --> B[getAuthStatus]
    B -->|throws / network error| C{shouldFallBackToLocalOrigin\nallowLoopback: false}
    C -->|non-loopback remote| D[recoverToLocalOrigin\ncontinue loop]
    C -->|loopback or same-origin| E[retry with backoff]
    B -->|required:true\nauthenticated:false\nno token| F{bootstrapRequired?}
    F -->|yes| G[dispatch BACKEND_REACHED\nfirstRunComplete:false]
    F -->|no| H{!pairingEnabled AND\nisRecoverableRemoteBase\nallowLoopback: true}
    H -->|true — loopback raw port\nor non-loopback remote| D
    H -->|false — same-origin\nor pairingEnabled| I[dispatch BACKEND_AUTH_REQUIRED]
    D --> B
    E --> B
```

<sub>Reviews (1): Last reviewed commit: ["fix(ui): self-heal onboarding when pinne..."](https://github.com/elizaos/eliza/commit/a2c765097c8f136ab772e27dcf9b1a0b9c92c937) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34779099)</sub>

<!-- /greptile_comment -->