### PR TITLE
ci(agent-image): harden boot gate (push verified image, post-health window)

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -250,11 +250,13 @@ jobs:
 
       # Build the image into the local Docker daemon first (load, do NOT push).
       # The boot-verification step below runs the REAL agent entrypoint against
-      # this image; only if it boots cleanly does the push step ship it. This
-      # is the gate that stops a container which crashes on startup (missing
-      # runtime deps, broken entrypoint) from reaching ghcr. cache-to here
-      # populates the gha cache so the later push step is a near-instant
-      # re-export of identical layers rather than a second full build.
+      # this exact image, and the push step ships these same loaded bytes by
+      # digest. This is the gate that stops a container which crashes on
+      # startup (missing runtime deps, broken entrypoint) from reaching ghcr.
+      # `provenance: false` keeps the loaded image a single-platform image so
+      # `docker push` of the retagged local image publishes the same content
+      # that was verified (no second build, no "latest yt-dlp" drift between
+      # the verified and published image).
       - id: build-local
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
@@ -262,6 +264,7 @@ jobs:
           file: packages/app-core/deploy/Dockerfile.ci
           push: false
           load: true
+          provenance: false
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci-boot-verify
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
@@ -284,23 +287,35 @@ jobs:
           CONTAINER_PORT: "42138"
         run: bash packages/app-core/scripts/docker-ci-smoke.sh --boot-verify-only
 
-      # Push only runs if the boot verification above succeeded (steps run in
-      # order and a failed step fails the job). Re-exports the identical layers
-      # from the gha cache populated by build-local, so this is fast.
+      # Push the EXACT verified image. This runs only if the boot verification
+      # above succeeded (steps run in order; a failed step fails the job). We
+      # retag the locally-loaded :ci-boot-verify image to each computed tag and
+      # `docker push` it, so the published bytes are byte-for-byte the image
+      # that just booted cleanly. No rebuild means no chance of shipping a
+      # different image than the one that was verified.
       - id: push
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
-        with:
-          context: .
-          file: packages/app-core/deploy/Dockerfile.ci
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
-          # cache-from only: build-local already wrote the gha cache, so this
-          # step is a cache-hit re-export rather than a second full build.
-          cache-from: type=gha
+        env:
+          LOCAL_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci-boot-verify
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            echo "Tagging $LOCAL_IMAGE as $tag and pushing"
+            docker tag "$LOCAL_IMAGE" "$tag"
+            docker push "$tag"
+          done <<< "$TAGS"
+          # Resolve the published digest from the repo-qualified pushed image
+          # so the attestation step below can reference it.
+          digest="$(docker inspect --format '{{ index .RepoDigests 0 }}' "$LOCAL_IMAGE" 2>/dev/null | sed 's/.*@//' || true)"
+          if [ -z "$digest" ]; then
+            first_tag="$(printf '%s\n' "$TAGS" | head -n1)"
+            digest="$(docker inspect --format '{{ index .RepoDigests 0 }}' "$first_tag" 2>/dev/null | sed 's/.*@//' || true)"
+          fi
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
 
       - name: Generate artifact attestation
+        if: ${{ steps.push.outputs.digest != '' }}
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}

--- a/packages/app-core/scripts/docker-ci-smoke.sh
+++ b/packages/app-core/scripts/docker-ci-smoke.sh
@@ -47,16 +47,19 @@ VERSION=""
 # full timeout. These are the exact failure modes (missing runtime deps,
 # entrypoint blowups) that previously shipped green because the smoke step
 # booted a stub health server instead of the real entrypoint.
+#
+# Kept deliberately specific to module-resolution failures and explicit
+# fatal-startup markers so a benign warning that merely contains a generic
+# word does not flap the gate. The container-exit and health-timeout checks
+# below are the backstops for any crash that does not print one of these.
 BOOT_CRASH_PATTERNS=(
   'Cannot find package'
   'Cannot find module'
   'ERR_MODULE_NOT_FOUND'
   'ERR_REQUIRE_ESM'
+  'MODULE_NOT_FOUND'
   'Failed to start'
   'crashed during init'
-  'FATAL'
-  'UnhandledPromiseRejection'
-  'Cannot read properties of undefined'
 )
 
 log() {
@@ -337,6 +340,35 @@ boot_verify() {
     return 0
   }
 
+  # Post-health observation window: after health first comes up, keep watching
+  # the container for a short window so a crash that happens just AFTER the
+  # server binds (async plugin/runtime init blowing up post-listen) still
+  # turns the gate RED instead of slipping through. Returns non-zero if the
+  # container dies or logs a crash signature during the window.
+  confirm_stable() {
+    local window="${BOOT_STABLE_WINDOW_SEC:-15}"
+    local stable_logs="$SMOKE_ARTIFACT_DIR/post-health.log"
+    local stable_deadline=$((SECONDS + window))
+    while (( SECONDS < stable_deadline )); do
+      timeout 30 "$DOCKER_BIN" logs "$CONTAINER_NAME" >"$stable_logs" 2>&1 || true
+      local m
+      if m="$(scan_crash "$stable_logs")"; then
+        log "Crash signature appeared after health came up: '${m}'"
+        timeout 30 "$DOCKER_BIN" logs --tail 120 "$CONTAINER_NAME" || true
+        return 1
+      fi
+      if ! timeout 10 "$DOCKER_BIN" ps --format '{{.Names}}' 2>/dev/null | grep -Fxq "$CONTAINER_NAME"; then
+        local code
+        code="$(timeout 10 "$DOCKER_BIN" inspect -f '{{.State.ExitCode}}' "$CONTAINER_NAME" 2>/dev/null || echo '?')"
+        log "Container exited (exit code ${code}) during the post-health window"
+        timeout 30 "$DOCKER_BIN" logs --tail 120 "$CONTAINER_NAME" || true
+        return 1
+      fi
+      sleep 3
+    done
+    return 0
+  }
+
   local logs_file="$SMOKE_ARTIFACT_DIR/boot.log"
   local deadline=$((SECONDS + SMOKE_TIMEOUT_SEC))
   local last_log_dump=0
@@ -372,15 +404,17 @@ boot_verify() {
     fi
 
     if confirm_ok "$health_url" /tmp/eliza-docker-health.txt; then
-      log "Boot verified: health probe succeeded against the real entrypoint: $health_url"
+      log "Health probe succeeded against the real entrypoint: $health_url"
       cat /tmp/eliza-docker-health.txt
-      return 0
+      confirm_stable && { log "Boot verified: agent stayed up after health came up"; return 0; }
+      fail "Agent served health then crashed during the post-health window; image is NOT bootable"
     fi
 
     if confirm_ok "$status_url" /tmp/eliza-docker-status.txt; then
-      log "Boot verified: status probe succeeded against the real entrypoint: $status_url"
+      log "Status probe succeeded against the real entrypoint: $status_url"
       cat /tmp/eliza-docker-status.txt
-      return 0
+      confirm_stable && { log "Boot verified: agent stayed up after status came up"; return 0; }
+      fail "Agent served status then crashed during the post-health window; image is NOT bootable"
     fi
 
     sleep 5


### PR DESCRIPTION
## Follow-up to #8081

#8081 landed the boot-verification gate (build the image locally, run the real agent entrypoint against it, only push if it boots). It was merged before this hardening commit landed on the branch, so this PR carries the hardening on its own. It applies cleanly on top of current develop.

## What this hardens

- **Push the exact verified image.** The workflow now retags the locally-loaded `:ci-boot-verify` image (the one that just booted) and `docker push`es it, instead of running a second build-push. This removes the risk that a `cache-from` miss or a network-dependent Dockerfile step (fetching the latest `yt-dlp`) publishes a different image than the one that was verified. `provenance: false` keeps the loaded image single-platform so the retag-push ships identical content.
- **Post-health observation window.** A new `confirm_stable` keeps watching the container for a short window after health first comes up, so a crash that happens just after the server binds (async runtime/plugin init blowing up post-listen) still turns the gate RED instead of slipping through.
- **Tighter crash-signature list.** Narrowed to module-resolution and explicit fatal-startup markers (`Cannot find package/module`, `ERR_MODULE_NOT_FOUND`, `MODULE_NOT_FOUND`, `Failed to start`, `crashed during init`); dropped the over-broad `FATAL` and `Cannot read properties of undefined` so a benign log line cannot flap the gate. The container-exit and health-timeout checks remain the backstops.

## Proof

Re-verified locally via `--boot-verify-only` against fixture images:

GREEN on a bootable image:
```
[docker-ci-smoke] Health probe succeeded against the real entrypoint: .../api/health
{"ready":true,"runtime":"ok"}
[docker-ci-smoke] Boot verified: agent stayed up after health came up
GOOD_EXIT=0
```

RED on a broken image:
```
[docker-ci-smoke] Detected startup crash signature in container logs: 'Cannot find module'
[docker-ci-smoke] ERROR: Agent crashed on startup (matched 'Cannot find module'); image is NOT bootable
BROKEN_EXIT=1
```

Please review and do not merge yet.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the boot-verification gate introduced in #8081: instead of running a second `docker/build-push-action` after verification, it retags the locally-loaded `:ci-boot-verify` image and `docker push`es it directly, guaranteeing the published bytes are byte-for-byte what was tested. It also adds a 15-second post-health observation window (`confirm_stable`) so crashes that occur just after the server binds are still caught, and tightens the crash-pattern list to module-resolution and explicit fatal-startup markers.

- **Retag-and-push**: `provenance: false` keeps the loaded image single-platform; a shell loop tags and pushes each computed tag; digest is extracted from the first pushed tag for attestation.
- **`confirm_stable`**: nested function inside `boot_verify` that polls container liveness and scans logs for a configurable window (default 15 s) after health is first confirmed; `BOOT_STABLE_WINDOW_SEC` is not explicitly set in the workflow env.
- **Crash-pattern list**: `FATAL`, `UnhandledPromiseRejection`, and `Cannot read properties of undefined` removed; `MODULE_NOT_FOUND` added alongside the existing module-resolution patterns.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the retag-and-push path correctly ships the verified image, and the post-health window adds a meaningful stability check.

The core retag-and-push logic correctly ships the verified image with no chance of a second build introducing drift. confirm_stable reads the full container log history rather than only post-health output, so a pre-health Failed-to-start entry that fell into the timing gap between the main loop's last log read and confirm_ok could flip the gate RED on a false positive. The primary digest extraction path (docker inspect LOCAL_IMAGE) is dead code since the ci-boot-verify tag was never pushed; the code always relies on the first_tag fallback. Both findings affect edge-case reliability and code clarity, not the correctness of the image that gets published.

Both changed files warrant a second look: docker-ci-smoke.sh for the full-history log scan in confirm_stable, and build-agent-image.yml for the digest-resolution fallback path.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-agent-image.yml | Replaces second build-push with a shell retag+push loop over the verified local image; adds provenance: false to keep single-platform load; digest resolution always falls through to the first_tag fallback (primary LOCAL_IMAGE path is dead); attestation is conditionally guarded on non-empty digest. |
| packages/app-core/scripts/docker-ci-smoke.sh | Adds confirm_stable post-health observation window (default 15 s), narrows crash patterns to module-resolution and explicit fatal-startup markers, removes FATAL/UnhandledPromiseRejection/Cannot-read-properties; confirm_stable scans full log history which can false-positive on pre-health log entries that narrowly missed the main loop scan. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[docker/build-push-action\nload=true, push=false\nprovenance=false\ntag: :ci-boot-verify] --> B[docker-ci-smoke.sh\n--boot-verify-only]
    B --> C{scan_crash in boot loop}
    C -- match found --> FAIL1[fail: crash signature]
    C -- no match --> D{container alive?}
    D -- no --> FAIL2[fail: container exited]
    D -- yes --> E{confirm_ok /api/health or /api/status}
    E -- timeout --> FAIL3[fail: timed out]
    E -- health served --> F[confirm_stable 15s window]
    F --> G{container alive AND no crash in logs?}
    G -- crash or exit --> FAIL4[fail: post-health crash]
    G -- stable --> H[Boot verified]
    H --> I[push step: retag and docker push each tag]
    I --> J[resolve digest via docker inspect first_tag]
    J --> K{digest non-empty?}
    K -- yes --> L[actions/attest-build-provenance]
    K -- no --> M[attestation skipped]
    L --> N[Make image public via GHCR API]
    M --> N
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/build-agent-image.yml`, line 282-288 ([link](https://github.com/elizaos/eliza/blob/d43507a45b29f08ad4cfb060a2e0d3e682e024e7/.github/workflows/build-agent-image.yml#L282-L288)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`BOOT_STABLE_WINDOW_SEC` is unset; `confirm_stable` exceeds `SMOKE_TIMEOUT_SEC`**

   `SMOKE_TIMEOUT_SEC: "180"` only governs the poll loop that waits for health to first appear; `confirm_stable` runs after health is confirmed and adds up to `BOOT_STABLE_WINDOW_SEC` seconds (default 15 s) beyond that. A run where health arrives close to the 180 s mark can therefore run for ~195 s before the smoke step exits. The job has a 60-minute cap so there is no practical breakage, but explicitly setting `BOOT_STABLE_WINDOW_SEC` alongside the other env vars would make the actual upper bound visible and override-able.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["ci(agent-image): harden boot gate (push ..."](https://github.com/elizaos/eliza/commit/d43507a45b29f08ad4cfb060a2e0d3e682e024e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34782075)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->