### PR TITLE
fix(ci): bootable tsx loader path + lowercase docker tag

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -231,6 +231,14 @@ jobs:
             env.BUILDKIT_STEP_LOG_MAX_SIZE=10485760
             env.BUILDKIT_STEP_LOG_MAX_SPEED=10485760
 
+      # github.repository preserves the org's casing (elizaOS/eliza), but
+      # Docker tags must be all-lowercase. metadata-action lowercases for the
+      # push tags, but the raw ci-boot-verify tag below needs an explicit
+      # lowercased image name or the build-local step fails with
+      # "repository name must be lowercase".
+      - id: image
+        run: echo "name=${REGISTRY}/${IMAGE_NAME,,}" >> "$GITHUB_OUTPUT"
+
       - id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
         with:
@@ -262,7 +270,7 @@ jobs:
           file: packages/app-core/deploy/Dockerfile.ci
           push: false
           load: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci-boot-verify
+          tags: ${{ steps.image.outputs.name }}:ci-boot-verify
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
           cache-from: type=gha
@@ -277,7 +285,7 @@ jobs:
         # timeout. A failure here blocks the push below, so a non-bootable
         # image is never published.
         env:
-          DOCKER_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ci-boot-verify
+          DOCKER_IMAGE: ${{ steps.image.outputs.name }}:ci-boot-verify
           BOOT_VERIFY_ONLY: "true"
           SMOKE_TIMEOUT_SEC: "180"
           SMOKE_PORT: "32138"

--- a/packages/app-core/deploy/deploy.defaults.env
+++ b/packages/app-core/deploy/deploy.defaults.env
@@ -2,7 +2,11 @@
 
 APP_NAME=eliza
 APP_ENTRYPOINT=packages/agent/dist/bin.js
-APP_CMD_START="node --import tsx packages/agent/dist/bin.js start"
+# tsx is installed at /opt/tsx in the deploy images (Dockerfile.ci /
+# Dockerfile.cloud), not at the workspace root, so the loader must be
+# referenced by absolute path. A bare `--import tsx` fails at runtime with
+# ERR_MODULE_NOT_FOUND ("Cannot find package 'tsx' imported from /app/").
+APP_CMD_START="node --import /opt/tsx/node_modules/tsx/dist/loader.mjs packages/agent/dist/bin.js start"
 APP_IMAGE=eliza:local
 APP_REGISTRY=
 APP_PORT=2138

--- a/packages/app-core/scripts/docker-ci-smoke.sh
+++ b/packages/app-core/scripts/docker-ci-smoke.sh
@@ -178,7 +178,7 @@ load_env_file "deploy/deploy.env"
 
 APP_IMAGE="${APP_IMAGE:-eliza/agent}"
 APP_ENTRYPOINT="${APP_ENTRYPOINT:-$AGENT_DIR/dist/bin.js}"
-APP_CMD_START="${APP_CMD_START:-node --import tsx ${APP_ENTRYPOINT} start}"
+APP_CMD_START="${APP_CMD_START:-node --import /opt/tsx/node_modules/tsx/dist/loader.mjs ${APP_ENTRYPOINT} start}"
 APP_PORT="${APP_PORT:-2138}"
 APP_API_BIND="${APP_API_BIND:-127.0.0.1}"
 OCI_SOURCE="${OCI_SOURCE:-}"


### PR DESCRIPTION
## Summary

Fixes two pre-existing, develop-red CI failures (both reproduce on the current develop HEAD, independent of any in-flight feature work):

- **Docker CI Smoke** crashed on boot with `ERR_MODULE_NOT_FOUND: Cannot find package 'tsx' imported from /app/`. `docker-ci-smoke.sh` loads `deploy.defaults.env`, whose `APP_CMD_START` used a bare `--import tsx`, then forwards it as the `APP_CMD_START` build-arg — overriding `Dockerfile.ci`'s correct default. tsx is installed at `/opt/tsx` in the image and is not resolvable as a bare specifier from `/app`, so the boot probe died. Now points at the absolute loader path in both `deploy.defaults.env` and the script's fallback default.
- **Build Agent Image** failed with `invalid tag "ghcr.io/elizaOS/eliza:ci-boot-verify": repository name must be lowercase`. `IMAGE_NAME = github.repository` preserves the org's casing (`elizaOS/eliza`); `metadata-action` lowercases the push tags, but the raw `ci-boot-verify` tag did not. Added a lowercased image-name step and use it for the `build-local` + boot-verify tags.

## Test plan

- [ ] Docker CI Smoke boots the image and serves `/api/health` (no `Cannot find package 'tsx'`).
- [ ] Build Agent Image's `build-local` step accepts the lowercase `ghcr.io/elizaos/eliza:ci-boot-verify` tag.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent CI regressions on the `develop` branch: a boot-time `ERR_MODULE_NOT_FOUND` caused by `deploy.defaults.env` forwarding a bare `--import tsx` specifier that the container cannot resolve from `/app/`, and an invalid Docker tag caused by `github.repository` preserving org casing (`elizaOS/eliza`) while Docker requires all-lowercase names.

- **tsx loader path**: `deploy.defaults.env` and the smoke-script fallback now use the absolute path `/opt/tsx/node_modules/tsx/dist/loader.mjs`, matching the path installed in `Dockerfile.ci` and `Dockerfile.cloud`.
- **Lowercase image name**: A new `image` step uses Bash `${IMAGE_NAME,,}` expansion to produce a lowercase tag; the `build-local` and boot-verify steps now reference `steps.image.outputs.name` instead of the raw `env.IMAGE_NAME`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; both fixes are well-scoped and correct, with the absolute tsx loader path confirmed against Dockerfile.ci.

Both fixes are precise and verifiable against the Dockerfile: the absolute loader path matches exactly what Dockerfile.ci installs and uses as its own default, and the Bash lowercase expansion is the standard idiom for this GitHub Actions pattern. The only finding is a stale comment in the workflow that still references the old bare-tsx invocation.

.github/workflows/build-agent-image.yml has a stale comment on the boot-verify step; no files have functional concerns.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/build-agent-image.yml | Adds a lowercase-image-name step using Bash `${IMAGE_NAME,,}` expansion and uses it for both the `build-local` tag and the `DOCKER_IMAGE` env var; fixes the "repository name must be lowercase" CI failure. One stale comment still cites the old bare-tsx invocation. |
| packages/app-core/deploy/deploy.defaults.env | Replaces bare `--import tsx` with the absolute loader path `/opt/tsx/node_modules/tsx/dist/loader.mjs`, matching the path installed in the CI/cloud Docker images; adds explanatory comment. |
| packages/app-core/scripts/docker-ci-smoke.sh | Updates the fallback default for `APP_CMD_START` to use the same absolute tsx loader path, consistent with `deploy.defaults.env` and `Dockerfile.ci`. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[push / release / dispatch] --> B[checkout + setup buildx]
    B --> C["image step\n${REGISTRY}/${IMAGE_NAME,,}"]
    C --> D["build-local\ntags: steps.image.outputs.name:ci-boot-verify"]
    D --> E["docker-ci-smoke.sh --boot-verify-only\nAPP_CMD_START uses /opt/tsx/node_modules/tsx/dist/loader.mjs"]
    E -->|boot OK| F[push to ghcr.io with metadata-action tags]
    E -->|crash / timeout| G[job fails — image NOT pushed]
    F --> H[attest provenance]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/build-agent-image.yml`, line 280-282 ([link](https://github.com/elizaos/eliza/blob/d6c4ab6be818a5c357f1e1eef3271a9c6b9bcd48/.github/workflows/build-agent-image.yml#L280-L282)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale comment still references bare `tsx` loader**

   The inline comment on the "Verify image boots" step still says `node --import tsx packages/agent/dist/bin.js start`, which is exactly the broken invocation this PR is fixing. After this change the actual command is `node --import /opt/tsx/node_modules/tsx/dist/loader.mjs ...`, so the comment is now misleading for anyone reading the workflow later.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(ci): bootable tsx loader path + lowe..."](https://github.com/elizaos/eliza/commit/d6c4ab6be818a5c357f1e1eef3271a9c6b9bcd48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34782978)</sub>

<!-- /greptile_comment -->