### PR TITLE
fix(orchestrator): allow read-only webfetch in opencode spawn config

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts
@@ -99,4 +99,23 @@ describe("buildOpencodeSpawnConfig", () => {
     expect(result?.model).toBe("anthropic/claude-sonnet-4-5");
     expect(result?.smallModel).toBe("openai/gpt-4.1-mini");
   });
+
+  it("allows the read-only webfetch permission for a provider config", () => {
+    const result = buildOpencodeSpawnConfig(runtime(), {
+      CEREBRAS_API_KEY: "csk-test",
+    });
+    const config = JSON.parse(result?.configContent ?? "{}");
+    expect(config.permission?.webfetch).toBe("allow");
+    // write/exec permissions stay gated by the approval preset, not granted here.
+    expect(config.permission?.bash).toBeUndefined();
+    expect(config.permission?.edit).toBeUndefined();
+  });
+
+  it("allows the read-only webfetch permission for a user-configured opencode.json", () => {
+    const result = buildOpencodeSpawnConfig(runtime(), {
+      ELIZA_OPENCODE_MODEL_POWERFUL: "anthropic/claude-sonnet-4-5",
+    });
+    const config = JSON.parse(result?.configContent ?? "{}");
+    expect(config.permission?.webfetch).toBe("allow");
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/opencode-config.ts
@@ -11,6 +11,16 @@ const OPENCODE_CEREBRAS_NPM = "@ai-sdk/cerebras";
 const CEREBRAS_DEFAULT_BASE_URL = "https://api.cerebras.ai/v1";
 const CEREBRAS_DEFAULT_MODEL = "gpt-oss-120b";
 
+// `webfetch` is a read-only HTTP GET (opencode caps the response at 5MB and
+// never mutates the workspace). opencode defaults its permission to "ask", so
+// under the acpx "standard" approval preset (which answers non-interactive
+// permission prompts with "deny") a spawned sub-agent's web fetch is silently
+// denied — and the model, unable to reach the network, tends to confabulate an
+// answer instead of fetching live data. Allowing the read-only fetch lets
+// sub-agents retrieve real live data on any provider without granting
+// write/exec (`bash`, `edit`) permissions, which stay gated by the preset.
+const OPENCODE_SPAWN_PERMISSION = { webfetch: "allow" } as const;
+
 type RuntimeLike = Pick<IAgentRuntime, "getSetting">;
 
 export interface OpencodeSpawnConfig {
@@ -75,6 +85,7 @@ function providerConfig(
     ...(fast && fast !== powerful
       ? { small_model: `${providerId}/${fast}` }
       : {}),
+    permission: OPENCODE_SPAWN_PERMISSION,
   };
   return {
     configContent: JSON.stringify(config),
@@ -178,6 +189,7 @@ export function buildOpencodeSpawnConfig(
     $schema: "https://opencode.ai/config.json",
     model: powerful,
     ...(fast ? { small_model: fast } : {}),
+    permission: OPENCODE_SPAWN_PERMISSION,
   };
   return {
     configContent: JSON.stringify(config),


### PR DESCRIPTION
## Problem

opencode's `webfetch` tool permission defaults to `"ask"`. When a sub-agent is spawned under the acpx **`standard`** approval preset — which answers non-interactive permission prompts with `deny` — every `webfetch` is silently denied. The model then can't reach the network for a live-data task (crypto price, weather, FX rate, etc.) and, rather than failing cleanly, tends to **confabulate** a plausible-but-stale answer.

## Fix

Add the read-only `webfetch` permission to the generated opencode spawn config (`buildOpencodeSpawnConfig`). `webfetch` is a read-only HTTP GET — opencode caps the body at 5MB and never mutates the workspace — so it belongs with the reads the `standard` preset already auto-approves. Write/exec permissions (`bash`, `edit`) are intentionally **not** granted here; they stay gated by the approval preset.

Applies to both config shapes the builder produces (the generated provider config and the user-configured `opencode.json` fallback).

## Security note (SSRF)

A blanket `webfetch: allow` lets a sub-agent fetch any URL, including internal/loopback/metadata hosts. opencode's `webfetch` permission is a flat action (no per-host patterns), so the host filtering belongs in the tool itself — a companion PR to `elizaOS/opencode` adds an SSRF guard to `webfetch.ts` that rejects loopback/private/link-local/metadata hosts before fetching. Deployments that run sub-agents on untrusted input should land both.

## Tests

Added assertions to `opencode-spawn-config-auto-detect.test.ts` covering the generated provider config and the user-configured fallback (both include `permission.webfetch`, neither grants `bash`/`edit`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `permission: { webfetch: "allow" }` to every opencode spawn config generated by `buildOpencodeSpawnConfig`, fixing silent denial of web fetches under the `standard` approval preset and preventing model confabulation on live-data tasks.

- **`opencode-config.ts`**: Introduces a module-level `OPENCODE_SPAWN_PERMISSION` constant (`{ webfetch: "allow" } as const`) and sets it on the `permission` field for both the generated provider config (all three provider paths via `providerConfig()`) and the user-configured opencode.json fallback path.
- **`opencode-spawn-config-auto-detect.test.ts`**: Adds two assertions covering the Cerebras provider path and the user-config fallback path, verifying `permission.webfetch === "allow"` and that `bash`/`edit` are not granted.

<h3>Confidence Score: 3/5</h3>

Safe to merge only if the companion SSRF guard in elizaOS/opencode is deployed at the same time; merging alone leaves sub-agents with unrestricted outbound HTTP access.

The in-repo code change is correct and well-tested, but it grants blanket webfetch: allow to every spawned sub-agent. The guard that would block loopback, private-range, and cloud metadata fetches lives in a different repository and is not yet part of this PR. A deployment window between the two PRs exposes any instance that processes untrusted prompts to SSRF.

Pay close attention to opencode-config.ts and the deployment coupling with the companion opencode SSRF-guard PR before merging into a production environment.

<details open><summary><h3>Security Review</h3></summary>

- **SSRF (cross-repo dependency)** in `opencode-config.ts`: `webfetch: allow` grants sub-agents unrestricted outbound HTTP access, including loopback, private-range, and cloud metadata endpoints (e.g. `169.254.169.254`). The SSRF guard lives in a companion PR to `elizaOS/opencode` and is not part of this repository. Any deployment window where this PR is live but the companion opencode guard is not creates an exploitable SSRF surface for sub-agents processing untrusted prompts.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-orchestrator/src/services/opencode-config.ts | Adds OPENCODE_SPAWN_PERMISSION and applies it to all config shapes; safe within the repo but depends on a cross-repo SSRF guard in elizaOS/opencode that is not in this PR. |
| plugins/plugin-agent-orchestrator/__tests__/unit/opencode-spawn-config-auto-detect.test.ts | Adds two new tests confirming permission.webfetch equals allow for both provider and user-configured config paths, and that bash and edit are not granted. Tests are correct and well-scoped. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): allow read-only webfe..."](https://github.com/elizaos/eliza/commit/c77c5a69fac02d14bbf198a4d9311a737424323b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34783518)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->