### PR TITLE
fix(plugin-web-search): degrade gracefully without TAVILY_API_KEY

### DIFF
--- a/plugins/plugin-web-search/src/services/webSearchService.ts
+++ b/plugins/plugin-web-search/src/services/webSearchService.ts
@@ -81,7 +81,8 @@ export class WebSearchService extends IWebSearchService {
     static override serviceType = ServiceType.WEB_SEARCH;
     override capabilityDescription = "Web search and content discovery capabilities" as const;
 
-    tavilyClient!: TavilyClient;
+    tavilyClient: TavilyClient | undefined;
+    private configured = false;
 
     static override async start(runtime: IAgentRuntime): Promise<WebSearchService> {
         const service = new WebSearchService(runtime);
@@ -96,12 +97,27 @@ export class WebSearchService extends IWebSearchService {
     private async initialize(runtime: IAgentRuntime): Promise<void> {
         const apiKey = runtime.getSetting("TAVILY_API_KEY");
         if (typeof apiKey !== "string" || apiKey.length === 0) {
-            throw new Error("TAVILY_API_KEY is not set");
+            // Degrade gracefully instead of throwing, so the plugin can be
+            // installed unconfigured without crashing agent boot. The service
+            // stays inert and `search()` reports an honest, recoverable error
+            // until a TAVILY_API_KEY is provided.
+            this.configured = false;
+            logger.warn(
+                { src: "plugin-web-search" },
+                "TAVILY_API_KEY not set — web search is inert until a key is provided",
+            );
+            return;
         }
         this.tavilyClient = tavily({ apiKey });
+        this.configured = true;
     }
 
     async search(query: string, options?: SearchOptions): Promise<SearchResponse> {
+        if (!this.configured || !this.tavilyClient) {
+            throw new Error(
+                "Web search is not configured: set TAVILY_API_KEY to enable it.",
+            );
+        }
         try {
             const response = await this.tavilyClient.search(query, {
                 includeAnswer: options?.includeAnswer ?? true,


### PR DESCRIPTION
## Problem

`WebSearchService.initialize()` throws `"TAVILY_API_KEY is not set"` when the key is absent. Because the service is started at agent boot, installing `plugin-web-search` without configuring a Tavily key **crashes the runtime** instead of leaving the capability cleanly unavailable.

## Fix

Degrade gracefully: when no `TAVILY_API_KEY` is present, log a warning, leave the service unconfigured (`configured = false`), and return without throwing. `search()` then throws an honest, recoverable `"Web search is not configured: set TAVILY_API_KEY to enable it."` only when it is actually invoked.

This lets the plugin be present-but-unconfigured without taking down boot — matching how other optional integrations degrade.

No behavior change when a key IS set.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash-on-boot regression in `plugin-web-search` where a missing `TAVILY_API_KEY` caused `WebSearchService.initialize()` to throw, killing the agent startup. The fix logs a warning instead of throwing, marks the service as unconfigured, and defers the error to the moment `search()` is actually called.

- `tavilyClient` is now typed as `TavilyClient | undefined` and a `configured: boolean` flag is added; `search()` checks both before invoking the Tavily SDK.
- All other search methods (`searchNews`, `searchImages`, `searchVideos`) delegate to `search()`, so they inherit the guard automatically.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change is narrowly scoped to `initialize()` and `search()`, and the existing path when a key IS present is completely untouched.

The implementation correctly degrades gracefully and all four search entry-points inherit the guard through delegation. The only finding is a redundant `this.configured = false` that carries no runtime risk.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-web-search/src/services/webSearchService.ts | Graceful degradation when TAVILY_API_KEY is absent: adds `configured` flag, makes `tavilyClient` optional, logs a warning instead of throwing during init, and gates `search()` with a descriptive error. One minor redundancy: `this.configured = false` in the early-return path is a no-op since the field already defaults to `false`. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Runtime as Agent Runtime
    participant Service as WebSearchService
    participant Logger as logger

    Runtime->>Service: start(runtime)
    Service->>Service: initialize(runtime)
    alt No TAVILY_API_KEY
        Service->>Logger: warn("TAVILY_API_KEY not set …")
        note over Service: configured = false\ntavilyClient = undefined
        Service-->>Runtime: return service (inert)
    else TAVILY_API_KEY present
        Service->>Service: "tavily({ apiKey })"
        note over Service: configured = true\ntavilyClient = TavilyClient
        Service-->>Runtime: return service (ready)
    end

    Runtime->>Service: search(query, options)
    alt "configured = false"
        Service-->>Runtime: throw Error("Web search is not configured …")
    else "configured = true"
        Service->>Service: tavilyClient.search(…)
        Service-->>Runtime: SearchResponse
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-web-search): degrade graceful..."](https://github.com/elizaos/eliza/commit/a7daba08fcf335f1d7bc9a046599f5c6d2395d13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34783587)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->