### PR TITLE
fix: workspace connector account gate returns 400 not 500 on invalid partition

### DIFF
--- a/plugins/plugin-browser/src/routes/workspace.ts
+++ b/plugins/plugin-browser/src/routes/workspace.ts
@@ -295,13 +295,13 @@ export async function handleBrowserWorkspaceRoutes(
         json(res, { error: "script is required" }, 400);
         return true;
       }
-      assertBrowserWorkspaceUserScriptAllowed(body.script, "eval", "desktop");
       await assertBrowserWorkspaceTabConnectorAccountGate(
         ctx,
         tabId,
         body,
         "evaluate browser workspace tab",
       );
+      assertBrowserWorkspaceUserScriptAllowed(body.script, "eval", "desktop");
       json(res, {
         result: await evaluateBrowserWorkspaceTab({
           id: tabId,


### PR DESCRIPTION
## Root cause

The browser-workspace `POST /api/browser-workspace/tabs/:tabId/eval` handler ran the user-script security check (`assertBrowserWorkspaceUserScriptAllowed`) **before** the connector account gate.

The failing test (`workspace-account-gate.test.ts` > "routes open connector tabs with validated partitions and gate tab execution") opens a connector-bound tab (partition `persist:connector-gmail-work-*`), then sends an eval request with only `{ script }` — no `connectorProvider` / `connectorAccountId`.

Because the script check ran first, it threw a plain `Error` (the GHSA-mhhr-9ph9-64j7 "user script disabled" guard) that carries no `status` property and whose message matches no branch in `statusFromBrowserWorkspaceError`, so the catch-all returned **HTTP 500**. The test expected the connector gate's **400** (`browser_workspace_connector_account_required`, message "...requires connectorProvider and connectorAccountId").

## Fix

Reorder the eval handler so the connector account gate runs before the script-allowed check. The request-validation failure (400) now fires first, matching the route-layer-validates-input-first contract. One-line change in `plugins/plugin-browser/src/routes/workspace.ts`.

## Verification

- `bun run --cwd plugins/plugin-browser test -- workspace-account-gate` -> 7/7 pass (was 1 failing).
- `bun run --cwd plugins/plugin-browser typecheck` -> clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the eval handler in `plugins/plugin-browser/src/routes/workspace.ts` to run the connector account gate before the user-script security check. Previously, the user-script check threw a plain `Error` (no `.status` property) that `statusFromBrowserWorkspaceError` mapped to HTTP 500, hiding the intended 400 validation failure for connector-bound tabs missing `connectorProvider`/`connectorAccountId`.

- Reorders `assertBrowserWorkspaceUserScriptAllowed` to run after `assertBrowserWorkspaceTabConnectorAccountGate`, matching the \"validate request inputs first\" contract already followed by the `navigate` and `snapshot` handlers.
- No logic is added or removed; only the execution order changes, ensuring the 400 path is exercised before the security enforcement path.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a two-line reorder that restores the intended request-validation-first ordering without touching any logic, data, or security enforcement.

The only change is swapping the execution order of two independent assertions in the eval handler. The connector gate already runs first in every other tab-action handler (navigate, snapshot), so this aligns the eval path with the established pattern. No error-handling logic, data flow, or security invariant is altered.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-browser/src/routes/workspace.ts | One-line reorder: moves assertBrowserWorkspaceTabConnectorAccountGate before assertBrowserWorkspaceUserScriptAllowed in the eval handler so the 400-status connector validation fires before the plain-Error script check that was falling through to 500. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant EvalHandler as eval handler
    participant ConnectorGate as assertConnectorAccountGate
    participant ScriptCheck as assertUserScriptAllowed
    participant ErrorMapper as statusFromBrowserWorkspaceError

    Note over EvalHandler: BEFORE fix
    Client->>EvalHandler: POST /eval (connector partition, no connectorProvider)
    EvalHandler->>ScriptCheck: check script policy
    ScriptCheck-->>EvalHandler: throws plain Error (no .status)
    EvalHandler->>ErrorMapper: map error to 500
    EvalHandler-->>Client: HTTP 500

    Note over EvalHandler: AFTER fix
    Client->>EvalHandler: POST /eval (connector partition, no connectorProvider)
    EvalHandler->>ConnectorGate: gate check (partition present, missing provider/accountId)
    ConnectorGate-->>EvalHandler: throws gateError with status 400
    EvalHandler->>ErrorMapper: map error to 400
    EvalHandler-->>Client: HTTP 400
```

<sub>Reviews (1): Last reviewed commit: ["fix: workspace connector account gate re..."](https://github.com/elizaos/eliza/commit/046db01cea4d9d17e4904c90a542a1d62ab8d912) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34783649)</sub>

<!-- /greptile_comment -->