### PR TITLE
fix(ui): repair Client Tests (HomeView/DatabaseView/ChatSurface)

### DIFF
--- a/packages/ui/src/components/pages/DatabaseView.test.tsx
+++ b/packages/ui/src/components/pages/DatabaseView.test.tsx
@@ -8,6 +8,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { invalidate } from "../../hooks/resource-cache";
 import { DatabaseView } from "./DatabaseView";
 
 // DatabaseView talks to the runtime exclusively through the `client` singleton
@@ -48,6 +49,11 @@ beforeEach(() => {
   clientMock.getDatabaseTables.mockReset();
   clientMock.getDatabaseRows.mockReset();
   clientMock.executeDatabaseQuery.mockReset();
+  // DatabaseView seeds/reads the module-level resource cache. Clear it so each
+  // test starts cold and the status-gates-tables waterfall is exercised cleanly
+  // instead of hitting the warm-revisit branch with state leaked from a prior test.
+  invalidate("db:status");
+  invalidate("db:tables");
 });
 
 afterEach(() => cleanup());

--- a/packages/ui/src/components/pages/HomeView.tsx
+++ b/packages/ui/src/components/pages/HomeView.tsx
@@ -240,8 +240,9 @@ export function HomeView(): React.JSX.Element {
   const [orbExpanded, setOrbExpanded] = useState(false);
   const [orbMuted, setOrbMuted] = useState(false);
 
-  // Lifted chat expanded state — starts open; controls the apps fly-away animation.
-  const [chatOpen, setChatOpen] = useState(true);
+  // Lifted chat expanded state — starts collapsed so the homescreen shows the app
+  // grid + notifications behind a thin chat pill; opening it flies the apps away.
+  const [chatOpen, setChatOpen] = useState(false);
 
   // Transcript fade state
   const [transcriptFaded, setTranscriptFaded] = useState(false);
@@ -1015,20 +1016,18 @@ function HomeChatPill({
                   onClick={sendDraft}
                 />
               ) : (
-                <GlassIconButton
-                  icon="mic"
-                  active={controller?.recording ?? false}
+                <MicButton
+                  recording={controller?.recording ?? false}
                   disabled={!canUseComposer}
-                  label={
-                    controller?.recording
-                      ? t("homeview.composer.stopVoice", {
-                          defaultValue: "Stop voice input",
-                        })
-                      : t("homeview.composer.startVoice", {
-                          defaultValue: "Start voice input",
-                        })
-                  }
-                  onClick={() => controller?.toggleRecording()}
+                  onTap={() => controller?.toggleRecording()}
+                  onHoldStart={() => controller?.startRecording()}
+                  onHoldEnd={() => controller?.stopRecording()}
+                  startLabel={t("homeview.composer.startVoice", {
+                    defaultValue: "Start voice input",
+                  })}
+                  stopLabel={t("homeview.composer.stopVoice", {
+                    defaultValue: "Stop voice input",
+                  })}
                 />
               )}
             </div>

--- a/packages/ui/src/components/shell/__tests__/ChatSurface.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/ChatSurface.test.tsx
@@ -91,8 +91,8 @@ describe("ChatSurface", () => {
       name: /voice input/i,
     }) as HTMLButtonElement;
     expect(voiceToggle.disabled).toBe(true);
-    expect(voiceToggle.textContent).toBe("Not listening");
-    expect(voiceToggle.querySelector("svg")).toBeNull();
+    expect(voiceToggle.getAttribute("aria-label")).toBe("Start voice input");
+    expect(voiceToggle.querySelector("svg")).not.toBeNull();
   });
 
   it("enables the voice toggle and toggles voice capture when wired", () => {
@@ -109,11 +109,12 @@ describe("ChatSurface", () => {
       name: /start voice input/i,
     }) as HTMLButtonElement;
     expect(voiceToggle.disabled).toBe(false);
-    expect(voiceToggle.textContent).toBe("Not listening");
-    expect(voiceToggle.querySelector("svg")).toBeNull();
+    expect(voiceToggle.getAttribute("aria-label")).toBe("Start voice input");
+    expect(voiceToggle.querySelector("svg")).not.toBeNull();
     const input = screen.getByLabelText("Message Eliza");
+    // The mic is a trailing control: it follows the text input in the composer.
     expect(
-      voiceToggle.compareDocumentPosition(input) &
+      input.compareDocumentPosition(voiceToggle) &
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
     fireEvent.click(voiceToggle);


### PR DESCRIPTION
## Summary

Repairs the three failing files in the CI **Tests → Client Tests** job on `develop`. For each file I traced source vs. test to find the true root cause rather than weakening assertions.

### `HomeView.tsx` — SOURCE regression (fixed source)
Two real bugs:
1. The lifted chat state defaulted to **open** (`chatOpen = true`), so the homescreen booted with the chat panel expanded, the app grid flown away, and the collapsed `home-chat-pill` never rendered — breaking 7 tests that open the panel via the pill. Restored collapsed-by-default.
2. The composer mic had regressed to a tap-only `GlassIconButton`, orphaning the existing `MicButton` push-to-talk component (hold >=200ms -> `startRecording`, release -> `stopRecording`, quick tap -> `toggleRecording`). Rewired the composer to `MicButton`, restoring hold-to-record while keeping tap-to-toggle and the trailing-control layout.

### `DatabaseView.test.tsx` — STALE test (fixed test)
Source correctly gates table fetches on connection status. The failure was test isolation: `DatabaseView` seeds a module-level resource cache (`db:status`/`db:tables`), and the suite never reset it. The "disconnected" test ran after a connected test, hit the warm-revisit branch on leaked cache, and fetched tables. Added `invalidate("db:status")`/`invalidate("db:tables")` in `beforeEach` so each test starts cold.

### `ChatSurface.test.tsx` — STALE test (fixed test)
The composer intentionally uses an icon `GlassIconButton` for voice (an `<svg>` glyph, aria-label "Start voice input") as a **trailing** control after the input. The test still asserted the old text-toggle design (`textContent === "Not listening"`, no svg, voice control leading the input). Updated assertions to the current icon-button + trailing-control contract; behavior assertions (disabled state, toggle callback) are unchanged.

## Test plan
- [x] `vitest run HomeView DatabaseView ChatSurface` -> 28/28 pass
- [x] `bun run typecheck` -> no new errors in touched files (pre-existing unrelated errors remain in AccountList/DynamicViewLoader/useAccounts)

Generated with Claude Code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes three failing CI client tests by addressing a source regression in `HomeView.tsx` (incorrect `chatOpen` default and regressed mic button) and stale test isolation issues in `DatabaseView.test.tsx` and `ChatSurface.test.tsx`.

- **HomeView.tsx**: `chatOpen` initial state corrected to `false` so the collapsed pill renders on boot; mic wired to `MicButton` instead of a plain `GlassIconButton`, restoring hold-to-record (`onHoldStart`/`onHoldEnd`) alongside tap-to-toggle.
- **DatabaseView.test.tsx**: Calls `invalidate("db:status")` and `invalidate("db:tables")` in `beforeEach` to bust the module-level resource cache between tests; this fixes cross-test pollution but leaves `inflight`/`requestSeq` populated (the dedicated `__resetResourceCache()` helper covers those too).
- **ChatSurface.test.tsx**: Assertions updated from the old text-button design to the current SVG icon button; `compareDocumentPosition` direction corrected to assert the mic *trails* the text input rather than leading it.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the source fixes are correct and the test updates match the current component contracts.

All three changes are straightforward and well-reasoned. The only callout is that DatabaseView.test.tsx uses the production invalidate() API for cache teardown rather than the dedicated __resetResourceCache() test helper, which leaves inflight and requestSeq un-cleared — harmless today but could silently misdirect a future deferred-promise test.

packages/ui/src/components/pages/DatabaseView.test.tsx — the cache reset strategy could be tightened to use the existing test helper.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/components/pages/HomeView.tsx | Fixes two regressions: chatOpen default reset from true→false so the pill is rendered on load, and mic button rewired from GlassIconButton to MicButton to restore hold-to-record behavior. |
| packages/ui/src/components/pages/DatabaseView.test.tsx | Adds resource-cache invalidation in beforeEach to prevent cross-test state leakage. Uses the production invalidate() API rather than the dedicated __resetResourceCache() test helper, leaving inflight/requestSeq maps un-cleared between tests. |
| packages/ui/src/components/shell/__tests__/ChatSurface.test.tsx | Updates voice-toggle assertions to match the current GlassIconButton/SVG design, fixes the compareDocumentPosition direction to correctly assert the mic trails the text input. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HomeView mounts] --> B{chatOpen?}
    B -->|true - OLD BUG| C[Chat panel expanded\nApps fly away\nPill never rendered\n7 tests fail]
    B -->|false - FIXED| D[Chat panel collapsed\nApp grid visible\nPill rendered]
    D --> E[User clicks pill]
    E --> F[setChatOpen true\nApps animate away]
    F --> G[Composer visible]
    G --> H{hasDraft?}
    H -->|yes| I[GlassIconButton send]
    H -->|no| J[MicButton]
    J --> K[onTap → toggleRecording]
    J --> L[onHoldStart ≥200ms → startRecording]
    J --> M[onHoldEnd → stopRecording]
```

<sub>Reviews (1): Last reviewed commit: ["fix(ui): repair Client Tests (HomeView/D..."](https://github.com/elizaos/eliza/commit/009cea6807ea8813cdb126363aebca886bbd5eaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34783748)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->