### PR TITLE
feat(plugin-elizacloud): forward per-inference spend to the waifu burn meter

### DIFF
--- a/plugins/plugin-elizacloud/__tests__/unit/waifu-metering.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/waifu-metering.test.ts
@@ -1,0 +1,197 @@
+import crypto from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ModelUsageEventPayload } from "../../src/utils/events";
+import {
+  buildInferenceSpentPayload,
+  createWaifuMeteringHandler,
+  estimateUsd,
+  postInferenceSpent,
+  resolveWaifuMeteringConfig,
+  signWaifuWebhook,
+  type WaifuMeteringConfig,
+} from "../../src/utils/waifu-metering";
+
+const CONFIG: WaifuMeteringConfig = {
+  webhookUrl: "https://api.waifu.fun/v2/webhooks/eliza-cloud/inference",
+  secret: "test-secret",
+  agentId: "agent-123",
+  usdPer1kInput: 0.003,
+  usdPer1kOutput: 0.015,
+};
+
+function makeRuntime(env: Record<string, string>): any {
+  return {
+    getSetting: (key: string) => env[key],
+  };
+}
+
+function makePayload(
+  tokens: { prompt: number; completion: number; total?: number },
+  extra: Partial<ModelUsageEventPayload> = {}
+): ModelUsageEventPayload {
+  return {
+    runtime: makeRuntime({}) as ModelUsageEventPayload["runtime"],
+    source: "elizacloud",
+    type: "TEXT_LARGE" as ModelUsageEventPayload["type"],
+    tokens: {
+      prompt: tokens.prompt,
+      completion: tokens.completion,
+      total: tokens.total ?? tokens.prompt + tokens.completion,
+    },
+    ...extra,
+  };
+}
+
+describe("resolveWaifuMeteringConfig", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("returns null when metering env is absent", () => {
+    expect(resolveWaifuMeteringConfig(makeRuntime({}))).toBeNull();
+  });
+
+  it("returns null when only some knobs are present", () => {
+    const runtime = makeRuntime({
+      WAIFU_INFERENCE_WEBHOOK_URL: CONFIG.webhookUrl,
+      WAIFU_WEBHOOK_SECRET: CONFIG.secret,
+      // missing WAIFU_AGENT_ID
+    });
+    expect(resolveWaifuMeteringConfig(runtime)).toBeNull();
+  });
+
+  it("resolves config from env with defaults", () => {
+    const runtime = makeRuntime({
+      WAIFU_INFERENCE_WEBHOOK_URL: CONFIG.webhookUrl,
+      WAIFU_WEBHOOK_SECRET: CONFIG.secret,
+      WAIFU_AGENT_ID: CONFIG.agentId,
+    });
+    const resolved = resolveWaifuMeteringConfig(runtime);
+    expect(resolved).toMatchObject({
+      webhookUrl: CONFIG.webhookUrl,
+      secret: CONFIG.secret,
+      agentId: CONFIG.agentId,
+    });
+    expect(resolved?.usdPer1kInput).toBeGreaterThan(0);
+    expect(resolved?.usdPer1kOutput).toBeGreaterThan(0);
+  });
+
+  it("falls back to WAIFU_WEBHOOK_URL when inference url not set", () => {
+    const runtime = makeRuntime({
+      WAIFU_WEBHOOK_URL: "https://api.waifu.fun/v2/webhooks/eliza-cloud/credits",
+      WAIFU_WEBHOOK_SECRET: CONFIG.secret,
+      WAIFU_AGENT_ID: CONFIG.agentId,
+    });
+    expect(resolveWaifuMeteringConfig(runtime)?.webhookUrl).toContain("/credits");
+  });
+});
+
+describe("signWaifuWebhook", () => {
+  it("matches waifu's sha256=HMAC(timestamp.body) format", () => {
+    const body = '{"hello":"world"}';
+    const ts = "2026-05-31T05:00:00.000Z";
+    const expected = `sha256=${crypto.createHmac("sha256", CONFIG.secret).update(`${ts}.${body}`).digest("hex")}`;
+    expect(signWaifuWebhook(body, ts, CONFIG.secret)).toBe(expected);
+  });
+});
+
+describe("estimateUsd", () => {
+  it("prices input and output tokens separately", () => {
+    const usd = estimateUsd(CONFIG, 1000, 1000);
+    expect(usd).toBeCloseTo(0.003 + 0.015, 6);
+  });
+
+  it("returns 0 for no tokens", () => {
+    expect(estimateUsd(CONFIG, 0, 0)).toBe(0);
+  });
+});
+
+describe("buildInferenceSpentPayload", () => {
+  it("prefers authoritative gateway cost when present", () => {
+    const payload = makePayload({ prompt: 500, completion: 200 }, { costUsd: 0.0123 });
+    const spent = buildInferenceSpentPayload(CONFIG, payload);
+    expect(spent?.usd).toBe(0.0123);
+    expect(spent?.costSource).toBe("gateway");
+    expect(spent?.agentId).toBe(CONFIG.agentId);
+    expect(spent?.promptTokens).toBe(500);
+    expect(spent?.completionTokens).toBe(200);
+    expect(spent?.totalTokens).toBe(700);
+  });
+
+  it("falls back to a token estimate when no gateway cost", () => {
+    const payload = makePayload({ prompt: 1000, completion: 1000 });
+    const spent = buildInferenceSpentPayload(CONFIG, payload);
+    expect(spent?.costSource).toBe("estimate");
+    expect(spent?.usd).toBeCloseTo(0.018, 6);
+  });
+
+  it("returns null for a zero-token call", () => {
+    const payload = makePayload({ prompt: 0, completion: 0, total: 0 });
+    expect(buildInferenceSpentPayload(CONFIG, payload)).toBeNull();
+  });
+
+  it("emits a unique idempotency key per call", () => {
+    const payload = makePayload({ prompt: 10, completion: 10 });
+    const a = buildInferenceSpentPayload(CONFIG, payload);
+    const b = buildInferenceSpentPayload(CONFIG, payload);
+    expect(a?.idempotencyKey).not.toBe(b?.idempotencyKey);
+    expect(a?.idempotencyKey.startsWith(`inference:${CONFIG.agentId}:`)).toBe(true);
+  });
+});
+
+describe("postInferenceSpent", () => {
+  it("posts a signed payload and reports ok", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fakeFetch = vi.fn(async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return { ok: true, status: 202 } as Response;
+    }) as unknown as typeof fetch;
+
+    const payload = buildInferenceSpentPayload(
+      CONFIG,
+      makePayload({ prompt: 100, completion: 50 }, { costUsd: 0.01 })
+    );
+    const result = await postInferenceSpent(CONFIG, payload!, fakeFetch);
+
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    const sentBody = String(calls[0].init.body);
+    const headers = calls[0].init.headers as Record<string, string>;
+    const expectedSig = signWaifuWebhook(sentBody, payload!.timestamp, CONFIG.secret);
+    expect(headers["X-Waifu-Webhook-Signature"]).toBe(expectedSig);
+    expect(headers["X-Waifu-Signature"]).toBe(expectedSig);
+  });
+
+  it("never throws on fetch failure", async () => {
+    const fakeFetch = vi.fn(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    const payload = buildInferenceSpentPayload(CONFIG, makePayload({ prompt: 1, completion: 1 }));
+    await expect(postInferenceSpent(CONFIG, payload!, fakeFetch)).resolves.toMatchObject({
+      ok: false,
+    });
+  });
+});
+
+describe("createWaifuMeteringHandler", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("is a no-op when metering env is absent", async () => {
+    const fakeFetch = vi.fn() as unknown as typeof fetch;
+    const handler = createWaifuMeteringHandler(fakeFetch);
+    await handler(makePayload({ prompt: 100, completion: 50 }));
+    expect(fakeFetch).not.toHaveBeenCalled();
+  });
+
+  it("posts when metering env is present", async () => {
+    const fakeFetch = vi.fn(
+      async () => ({ ok: true, status: 202 }) as Response
+    ) as unknown as typeof fetch;
+    const handler = createWaifuMeteringHandler(fakeFetch);
+    const runtime = makeRuntime({
+      WAIFU_INFERENCE_WEBHOOK_URL: CONFIG.webhookUrl,
+      WAIFU_WEBHOOK_SECRET: CONFIG.secret,
+      WAIFU_AGENT_ID: CONFIG.agentId,
+    });
+    await handler(makePayload({ prompt: 100, completion: 50 }, { runtime }));
+    expect(fakeFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/plugins/plugin-elizacloud/__tests__/unit/waifu-metering.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/waifu-metering.test.ts
@@ -3,9 +3,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ModelUsageEventPayload } from "../../src/utils/events";
 import {
   buildInferenceSpentPayload,
+  CLOUD_INFERENCE_SOURCE,
   createWaifuMeteringHandler,
+  deriveInferenceUrlFromCredits,
   estimateUsd,
   postInferenceSpent,
+  resolveInferenceWebhookUrl,
   resolveWaifuMeteringConfig,
   signWaifuWebhook,
   type WaifuMeteringConfig,
@@ -74,13 +77,58 @@ describe("resolveWaifuMeteringConfig", () => {
     expect(resolved?.usdPer1kOutput).toBeGreaterThan(0);
   });
 
-  it("falls back to WAIFU_WEBHOOK_URL when inference url not set", () => {
+  it("never reuses the credits URL for inference; derives the /inference sibling instead", () => {
     const runtime = makeRuntime({
       WAIFU_WEBHOOK_URL: "https://api.waifu.fun/v2/webhooks/eliza-cloud/credits",
       WAIFU_WEBHOOK_SECRET: CONFIG.secret,
       WAIFU_AGENT_ID: CONFIG.agentId,
     });
-    expect(resolveWaifuMeteringConfig(runtime)?.webhookUrl).toContain("/credits");
+    const resolved = resolveWaifuMeteringConfig(runtime);
+    expect(resolved?.webhookUrl).not.toContain("/credits");
+    expect(resolved?.webhookUrl).toBe(
+      "https://api.waifu.fun/v2/webhooks/eliza-cloud/inference"
+    );
+  });
+
+  it("returns null when only a non-credits WAIFU_WEBHOOK_URL is present (cannot safely derive)", () => {
+    const runtime = makeRuntime({
+      WAIFU_WEBHOOK_URL: "https://api.waifu.fun/v2/webhooks/eliza-cloud/something-else",
+      WAIFU_WEBHOOK_SECRET: CONFIG.secret,
+      WAIFU_AGENT_ID: CONFIG.agentId,
+    });
+    expect(resolveWaifuMeteringConfig(runtime)).toBeNull();
+  });
+});
+
+describe("resolveInferenceWebhookUrl / deriveInferenceUrlFromCredits", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("prefers the explicit inference URL", () => {
+    const runtime = makeRuntime({
+      WAIFU_INFERENCE_WEBHOOK_URL: CONFIG.webhookUrl,
+      WAIFU_WEBHOOK_URL: "https://api.waifu.fun/v2/webhooks/eliza-cloud/credits",
+    });
+    expect(resolveInferenceWebhookUrl(runtime)).toBe(CONFIG.webhookUrl);
+  });
+
+  it("derives the /inference URL from a /credits URL, preserving host and query", () => {
+    expect(
+      deriveInferenceUrlFromCredits("https://api.waifu.fun/v2/webhooks/eliza-cloud/credits")
+    ).toBe("https://api.waifu.fun/v2/webhooks/eliza-cloud/inference");
+    expect(
+      deriveInferenceUrlFromCredits("https://api.waifu.fun/v2/webhooks/eliza-cloud/credits?x=1")
+    ).toBe("https://api.waifu.fun/v2/webhooks/eliza-cloud/inference?x=1");
+  });
+
+  it("returns undefined for a URL that is not a /credits receiver", () => {
+    expect(
+      deriveInferenceUrlFromCredits("https://api.waifu.fun/v2/webhooks/eliza-cloud/inference")
+    ).toBeUndefined();
+    expect(deriveInferenceUrlFromCredits("https://api.waifu.fun/v2/webhooks/foo")).toBeUndefined();
+  });
+
+  it("returns undefined when no URL env is present", () => {
+    expect(resolveInferenceWebhookUrl(makeRuntime({}))).toBeUndefined();
   });
 });
 
@@ -181,7 +229,7 @@ describe("createWaifuMeteringHandler", () => {
     expect(fakeFetch).not.toHaveBeenCalled();
   });
 
-  it("posts when metering env is present", async () => {
+  it("posts when metering env is present and source is the cloud gateway", async () => {
     const fakeFetch = vi.fn(
       async () => ({ ok: true, status: 202 }) as Response
     ) as unknown as typeof fetch;
@@ -191,7 +239,44 @@ describe("createWaifuMeteringHandler", () => {
       WAIFU_WEBHOOK_SECRET: CONFIG.secret,
       WAIFU_AGENT_ID: CONFIG.agentId,
     });
-    await handler(makePayload({ prompt: 100, completion: 50 }, { runtime }));
+    await handler(
+      makePayload({ prompt: 100, completion: 50 }, { runtime, source: CLOUD_INFERENCE_SOURCE })
+    );
     expect(fakeFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT meter local-ai inference even with metering env present", async () => {
+    const fakeFetch = vi.fn(
+      async () => ({ ok: true, status: 202 }) as Response
+    ) as unknown as typeof fetch;
+    const handler = createWaifuMeteringHandler(fakeFetch);
+    const runtime = makeRuntime({
+      WAIFU_INFERENCE_WEBHOOK_URL: CONFIG.webhookUrl,
+      WAIFU_WEBHOOK_SECRET: CONFIG.secret,
+      WAIFU_AGENT_ID: CONFIG.agentId,
+    });
+    // plugin-local-inference emits MODEL_USED with source "local-ai" and real
+    // token counts but no costUsd. It is free CPU inference and must not be
+    // billed as cloud burn.
+    await handler(
+      makePayload({ prompt: 100, completion: 50 }, { runtime, source: "local-ai" })
+    );
+    expect(fakeFetch).not.toHaveBeenCalled();
+  });
+
+  it("does NOT meter other cloud providers (e.g. openrouter)", async () => {
+    const fakeFetch = vi.fn(
+      async () => ({ ok: true, status: 202 }) as Response
+    ) as unknown as typeof fetch;
+    const handler = createWaifuMeteringHandler(fakeFetch);
+    const runtime = makeRuntime({
+      WAIFU_INFERENCE_WEBHOOK_URL: CONFIG.webhookUrl,
+      WAIFU_WEBHOOK_SECRET: CONFIG.secret,
+      WAIFU_AGENT_ID: CONFIG.agentId,
+    });
+    await handler(
+      makePayload({ prompt: 100, completion: 50 }, { runtime, source: "openrouter" })
+    );
+    expect(fakeFetch).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-elizacloud/__tests__/unit/waifu-metering.test.ts
+++ b/plugins/plugin-elizacloud/__tests__/unit/waifu-metering.test.ts
@@ -85,9 +85,7 @@ describe("resolveWaifuMeteringConfig", () => {
     });
     const resolved = resolveWaifuMeteringConfig(runtime);
     expect(resolved?.webhookUrl).not.toContain("/credits");
-    expect(resolved?.webhookUrl).toBe(
-      "https://api.waifu.fun/v2/webhooks/eliza-cloud/inference"
-    );
+    expect(resolved?.webhookUrl).toBe("https://api.waifu.fun/v2/webhooks/eliza-cloud/inference");
   });
 
   it("returns null when only a non-credits WAIFU_WEBHOOK_URL is present (cannot safely derive)", () => {
@@ -205,7 +203,32 @@ describe("postInferenceSpent", () => {
     const headers = calls[0].init.headers as Record<string, string>;
     const expectedSig = signWaifuWebhook(sentBody, payload!.timestamp, CONFIG.secret);
     expect(headers["X-Waifu-Webhook-Signature"]).toBe(expectedSig);
-    expect(headers["X-Waifu-Signature"]).toBe(expectedSig);
+    // Only the canonical header is sent; the legacy duplicate is dropped.
+    expect(headers["X-Waifu-Signature"]).toBeUndefined();
+  });
+
+  it("sends an abort signal so a stuck webhook cannot hang forever", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fakeFetch = vi.fn(async (url: string, init: RequestInit) => {
+      calls.push({ url, init });
+      return { ok: true, status: 202 } as Response;
+    }) as unknown as typeof fetch;
+
+    const payload = buildInferenceSpentPayload(CONFIG, makePayload({ prompt: 10, completion: 5 }));
+    await postInferenceSpent(CONFIG, payload!, fakeFetch);
+    expect(calls[0].init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("never throws when the request times out", async () => {
+    const fakeFetch = vi.fn(async () => {
+      const err = new Error("The operation was aborted due to timeout");
+      err.name = "TimeoutError";
+      throw err;
+    }) as unknown as typeof fetch;
+    const payload = buildInferenceSpentPayload(CONFIG, makePayload({ prompt: 1, completion: 1 }));
+    await expect(postInferenceSpent(CONFIG, payload!, fakeFetch)).resolves.toMatchObject({
+      ok: false,
+    });
   });
 
   it("never throws on fetch failure", async () => {
@@ -258,9 +281,7 @@ describe("createWaifuMeteringHandler", () => {
     // plugin-local-inference emits MODEL_USED with source "local-ai" and real
     // token counts but no costUsd. It is free CPU inference and must not be
     // billed as cloud burn.
-    await handler(
-      makePayload({ prompt: 100, completion: 50 }, { runtime, source: "local-ai" })
-    );
+    await handler(makePayload({ prompt: 100, completion: 50 }, { runtime, source: "local-ai" }));
     expect(fakeFetch).not.toHaveBeenCalled();
   });
 
@@ -274,9 +295,7 @@ describe("createWaifuMeteringHandler", () => {
       WAIFU_WEBHOOK_SECRET: CONFIG.secret,
       WAIFU_AGENT_ID: CONFIG.agentId,
     });
-    await handler(
-      makePayload({ prompt: 100, completion: 50 }, { runtime, source: "openrouter" })
-    );
+    await handler(makePayload({ prompt: 100, completion: 50 }, { runtime, source: "openrouter" }));
     expect(fakeFetch).not.toHaveBeenCalled();
   });
 });

--- a/plugins/plugin-elizacloud/src/index.ts
+++ b/plugins/plugin-elizacloud/src/index.ts
@@ -31,6 +31,7 @@ import { CloudCredentialProvider } from "./services/cloud-credential-provider";
 import { CloudManagedGatewayRelayService } from "./services/cloud-managed-gateway-relay";
 import { CloudModelRegistryService } from "./services/cloud-model-registry";
 import { createCloudApiClient } from "./utils/sdk-client";
+import { createWaifuMeteringHandler } from "./utils/waifu-metering";
 
 const TEXT_NANO_MODEL_TYPE = (ModelType.TEXT_NANO ?? "TEXT_NANO") as string;
 const TEXT_MEDIUM_MODEL_TYPE = (ModelType.TEXT_MEDIUM ?? "TEXT_MEDIUM") as string;
@@ -128,6 +129,14 @@ export const elizaOSCloudPlugin: Plugin = {
   async init(config, runtime) {
     // Initialize inference (OpenAI-compatible client)
     initializeOpenAI(config, runtime);
+  },
+
+  // ─── Runtime Event Handlers ──────────────────────────────────────────
+  // Forwards per-inference token + USD spend to waifu's burn meter when the
+  // container is provisioned as a hosted waifu agent (no-op otherwise). See
+  // utils/waifu-metering.ts for the honest-meter rationale.
+  events: {
+    MODEL_USED: [createWaifuMeteringHandler()],
   },
 
   // ─── Cloud Services ──────────────────────────────────────────────────

--- a/plugins/plugin-elizacloud/src/models/text.ts
+++ b/plugins/plugin-elizacloud/src/models/text.ts
@@ -194,6 +194,34 @@ function buildSpanSamplerHeader(
   return JSON.stringify(body);
 }
 
+/**
+ * Extract the authoritative USD cost the metered cloud gateway charged for a
+ * request, when it surfaces one. The gateway is the only honest source of USD
+ * (it owns the model-pricing table + platform markup); we prefer it over any
+ * client-side token estimate. Checks the response body `usage.cost_usd` first,
+ * then the `X-Eliza-Cost-Usd` response header. Returns undefined when neither
+ * is present so consumers fall back to a token-based estimate.
+ */
+function extractCostUsd(
+  usage: unknown,
+  response?: { headers?: { get?: (name: string) => string | null } }
+): number | undefined {
+  const fromBody = firstNumber(
+    asRecord(usage).cost_usd,
+    asRecord(usage).costUsd,
+    asRecord(usage).cost
+  );
+  if (typeof fromBody === "number" && Number.isFinite(fromBody)) {
+    return fromBody;
+  }
+  const header = response?.headers?.get?.("X-Eliza-Cost-Usd");
+  if (header) {
+    const parsed = Number(header);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
 function isReasoningModel(modelName: string): boolean {
   const lower = modelName.toLowerCase();
   return REASONING_MODEL_PATTERNS.some((pattern) => lower.includes(pattern));
@@ -814,11 +842,23 @@ async function generateTextWithModel(
   }
 
   if (data.usage) {
-    emitModelUsageEvent(runtime, modelType, prompt, {
-      inputTokens: data.usage.input_tokens ?? 0,
-      outputTokens: data.usage.output_tokens ?? 0,
-      totalTokens: data.usage.total_tokens ?? 0,
-    });
+    emitModelUsageEvent(
+      runtime,
+      modelType,
+      prompt,
+      {
+        inputTokens: data.usage.input_tokens ?? 0,
+        outputTokens: data.usage.output_tokens ?? 0,
+        totalTokens: data.usage.total_tokens ?? 0,
+      },
+      {
+        modelName: getModelNameForType(runtime, modelType),
+        ...(() => {
+          const costUsd = extractCostUsd(data.usage, response);
+          return typeof costUsd === "number" ? { costUsd } : {};
+        })(),
+      }
+    );
   }
 
   const text = extractResponsesOutputText(data);
@@ -897,7 +937,13 @@ async function generateNativeChatCompletion(
 
   const usage = convertNativeUsage(data.usage);
   if (usage) {
-    emitModelUsageEvent(runtime, modelType, context.prompt, usage);
+    emitModelUsageEvent(runtime, modelType, context.prompt, usage, {
+      modelName: context.modelName,
+      ...(() => {
+        const costUsd = extractCostUsd(data.usage, response);
+        return typeof costUsd === "number" ? { costUsd } : {};
+      })(),
+    });
   }
 
   const text = extractChatCompletionText(data);

--- a/plugins/plugin-elizacloud/src/utils/events.ts
+++ b/plugins/plugin-elizacloud/src/utils/events.ts
@@ -6,6 +6,29 @@ import {
 } from "@elizaos/core";
 import type { LanguageModelUsage } from "ai";
 
+/**
+ * Extra metadata that rides along with a {@link ModelEventPayload} so that
+ * downstream consumers (e.g. the waifu metering bridge) can attribute spend
+ * to a concrete model id and, when the cloud surfaces it, the authoritative
+ * post-markup USD cost it just debited from the org's credit balance.
+ *
+ * These are additive fields layered onto the standard payload — the core
+ * {@link ModelEventPayload} shape is unchanged for every other listener.
+ */
+export interface ModelUsageEventMeta {
+  /** Resolved provider model id, e.g. "anthropic/claude-opus-4.7". */
+  modelName?: string;
+  /**
+   * Authoritative USD cost the metered gateway charged for this call, when
+   * available (e.g. from a `usage.cost_usd` field or `X-Eliza-Cost-Usd`
+   * response header). Undefined when the cloud does not surface it; consumers
+   * then fall back to a token-based estimate.
+   */
+  costUsd?: number;
+}
+
+export type ModelUsageEventPayload = ModelEventPayload & ModelUsageEventMeta;
+
 export function emitModelUsageEvent(
   runtime: IAgentRuntime,
   type: ModelTypeName,
@@ -14,7 +37,8 @@ export function emitModelUsageEvent(
     inputTokens?: number;
     outputTokens?: number;
     totalTokens?: number;
-  }
+  },
+  meta: ModelUsageEventMeta = {}
 ) {
   const inputTokens = Number(usage.inputTokens || 0);
   const outputTokens = Number(usage.outputTokens || 0);
@@ -22,7 +46,7 @@ export function emitModelUsageEvent(
     usage.totalTokens != null ? usage.totalTokens : inputTokens + outputTokens
   );
 
-  const payload: ModelEventPayload = {
+  const payload: ModelUsageEventPayload = {
     runtime,
     source: "elizacloud",
     type,
@@ -31,6 +55,10 @@ export function emitModelUsageEvent(
       completion: outputTokens,
       total: totalTokens,
     },
+    ...(meta.modelName ? { modelName: meta.modelName } : {}),
+    ...(typeof meta.costUsd === "number" && Number.isFinite(meta.costUsd)
+      ? { costUsd: meta.costUsd }
+      : {}),
   };
 
   runtime.emitEvent(EventType.MODEL_USED, payload);

--- a/plugins/plugin-elizacloud/src/utils/waifu-metering.ts
+++ b/plugins/plugin-elizacloud/src/utils/waifu-metering.ts
@@ -228,9 +228,13 @@ export function buildInferenceSpentPayload(
   };
 }
 
+const POST_TIMEOUT_MS = 10000;
+
 /**
  * POST a signed `inference.spent` webhook to waifu. Best-effort: failures are
  * logged but never thrown, so metering never blocks or breaks an agent reply.
+ * A 10s AbortSignal bounds the request so a stuck receiver can never leave a
+ * background fetch hanging.
  */
 export async function postInferenceSpent(
   config: WaifuMeteringConfig,
@@ -245,9 +249,9 @@ export async function postInferenceSpent(
       headers: {
         "content-type": "application/json",
         "X-Waifu-Webhook-Signature": signature,
-        "X-Waifu-Signature": signature,
       },
       body,
+      signal: AbortSignal.timeout(POST_TIMEOUT_MS),
     });
     if (!res.ok) {
       logger.warn(
@@ -260,8 +264,14 @@ export async function postInferenceSpent(
     );
     return { ok: true, status: res.status };
   } catch (err) {
+    const aborted = err instanceof Error && err.name === "TimeoutError";
+    const detail = aborted
+      ? `timed out after ${POST_TIMEOUT_MS}ms`
+      : err instanceof Error
+        ? err.message
+        : String(err);
     logger.warn(
-      `[waifu-metering] inference.spent POST failed: ${err instanceof Error ? err.message : String(err)}`
+      `[waifu-metering] inference.spent POST failed for agent ${config.agentId}: ${detail}`
     );
     return { ok: false };
   }

--- a/plugins/plugin-elizacloud/src/utils/waifu-metering.ts
+++ b/plugins/plugin-elizacloud/src/utils/waifu-metering.ts
@@ -33,6 +33,18 @@ import type { ModelUsageEventPayload } from "./events";
 const DEFAULT_USD_PER_1K_INPUT = 0.003;
 const DEFAULT_USD_PER_1K_OUTPUT = 0.015;
 
+/**
+ * The MODEL_USED event `source` set by the Eliza Cloud metered inference path
+ * (see ./events.ts emitModelUsageEvent). ElizaOS event dispatch is global: every
+ * MODEL_USED handler receives every MODEL_USED event regardless of which plugin
+ * emitted it. Only inference that actually went through the cloud metered
+ * gateway debits real credits, so we must meter only those events. Other model
+ * providers (e.g. plugin-local-inference emits source "local-ai" for free CPU
+ * inference, plugin-openrouter emits "openrouter", etc.) must never be metered
+ * as cloud burn.
+ */
+export const CLOUD_INFERENCE_SOURCE = "elizacloud";
+
 export interface WaifuMeteringConfig {
   webhookUrl: string;
   secret: string;
@@ -70,8 +82,7 @@ function readNumberEnv(
 export function resolveWaifuMeteringConfig(
   runtime: IAgentRuntime
 ): WaifuMeteringConfig | null {
-  const webhookUrl =
-    readEnv(runtime, "WAIFU_INFERENCE_WEBHOOK_URL") ?? readEnv(runtime, "WAIFU_WEBHOOK_URL");
+  const webhookUrl = resolveInferenceWebhookUrl(runtime);
   const secret =
     readEnv(runtime, "WAIFU_WEBHOOK_SECRET") ?? readEnv(runtime, "WAIFU_INFERENCE_WEBHOOK_SECRET");
   const agentId = readEnv(runtime, "WAIFU_AGENT_ID") ?? readEnv(runtime, "WAIFU_CORE_AGENT_ID");
@@ -91,6 +102,57 @@ export function resolveWaifuMeteringConfig(
       DEFAULT_USD_PER_1K_OUTPUT
     ),
   };
+}
+
+/**
+ * Resolve the inference webhook URL from the container environment.
+ *
+ * Prefers the explicit WAIFU_INFERENCE_WEBHOOK_URL. If that is absent but a
+ * credits webhook URL (WAIFU_WEBHOOK_URL) is present, derive the sibling
+ * `/inference` receiver path from the known `/credits` path. We NEVER post
+ * inference events to the credits receiver: the credits mapper defaults unknown
+ * payloads to `credits.topped_up`, which would corrupt credit state. If we
+ * cannot safely derive an inference URL, return undefined so the bridge stays
+ * a no-op.
+ */
+export function resolveInferenceWebhookUrl(runtime: IAgentRuntime): string | undefined {
+  const explicit = readEnv(runtime, "WAIFU_INFERENCE_WEBHOOK_URL");
+  if (explicit) return explicit;
+
+  const creditsUrl = readEnv(runtime, "WAIFU_WEBHOOK_URL");
+  if (!creditsUrl) return undefined;
+
+  // Only derive when the credits URL ends in a recognizable `/credits` segment.
+  // Replacing the trailing `/credits` with `/inference` keeps the same host,
+  // base path, and query string. Anything we cannot confidently map is treated
+  // as unsafe and skipped, never reused as-is for inference.
+  const derived = deriveInferenceUrlFromCredits(creditsUrl);
+  if (derived) return derived;
+
+  return undefined;
+}
+
+/**
+ * Map a known `/credits` webhook URL to its sibling `/inference` URL. Returns
+ * undefined when the input does not contain a `/credits` path segment, so we
+ * never accidentally post inference to a non-inference endpoint.
+ */
+export function deriveInferenceUrlFromCredits(creditsUrl: string): string | undefined {
+  try {
+    const url = new URL(creditsUrl);
+    if (!/\/credits\/?$/.test(url.pathname)) {
+      return undefined;
+    }
+    url.pathname = url.pathname.replace(/\/credits(\/?)$/, "/inference$1");
+    return url.toString();
+  } catch {
+    // Fall back to a string replacement for non-absolute URLs, still requiring
+    // an explicit `/credits` segment so we cannot mis-route.
+    if (/\/credits\/?$/.test(creditsUrl)) {
+      return creditsUrl.replace(/\/credits(\/?)$/, "/inference$1");
+    }
+    return undefined;
+  }
 }
 
 /**
@@ -216,6 +278,11 @@ export function createWaifuMeteringHandler(
   return async (payload: ModelUsageEventPayload): Promise<void> => {
     const runtime = payload?.runtime;
     if (!runtime) return;
+    // ElizaOS dispatches MODEL_USED globally to every registered handler, so we
+    // also receive events from other model providers (local-ai, openrouter,
+    // etc.). Only cloud-metered inference debits real credits; meter only that
+    // source so we never bill free/local inference as cloud burn.
+    if (payload?.source !== CLOUD_INFERENCE_SOURCE) return;
     const config = resolveWaifuMeteringConfig(runtime);
     if (!config) return;
     const spent = buildInferenceSpentPayload(config, payload);

--- a/plugins/plugin-elizacloud/src/utils/waifu-metering.ts
+++ b/plugins/plugin-elizacloud/src/utils/waifu-metering.ts
@@ -1,0 +1,225 @@
+/**
+ * Waifu metering bridge.
+ *
+ * A hosted waifu agent runs as a sandboxed container whose model inference is
+ * routed through the Eliza Cloud metered inference gateway. The gateway is the
+ * honest meter: it owns the per-model pricing table and the platform markup,
+ * and it debits the organization's credit balance on every call. That debit is
+ * authoritative and already happens server-side.
+ *
+ * What was missing is the *signal back to waifu*: waifu's burn rollup
+ * (`apps/worker/src/processors/agent-rollup.ts`) reads `inference.spent`
+ * agent_events to compute `agentDailyBurnUsd` / `agentRunwayDays`, but falls
+ * back to a $5/day placeholder when no such events exist. Nothing emitted them.
+ *
+ * This bridge listens for the runtime `MODEL_USED` event (emitted by the cloud
+ * model handlers after each inference) and POSTs a signed `inference.spent`
+ * webhook to waifu's receiver (`POST /webhooks/eliza-cloud/inference`). It is a
+ * no-op unless the container is provisioned with the waifu metering env knobs,
+ * so it never fires for non-hosted (local dev / standalone) agents.
+ *
+ * Token counts are exact (reported by the gateway). USD is the authoritative
+ * post-markup cost when the gateway surfaces it (`usage.cost_usd` /
+ * `X-Eliza-Cost-Usd`); otherwise a conservative token-based estimate is used,
+ * configurable per-model via WAIFU_METER_USD_PER_1K_INPUT / _OUTPUT. The credit
+ * debit itself is always the cloud's authoritative number; the estimate only
+ * affects waifu's burn display until the cloud cost is wired through.
+ */
+
+import crypto from "node:crypto";
+import { type IAgentRuntime, logger } from "@elizaos/core";
+import type { ModelUsageEventPayload } from "./events";
+
+const DEFAULT_USD_PER_1K_INPUT = 0.003;
+const DEFAULT_USD_PER_1K_OUTPUT = 0.015;
+
+export interface WaifuMeteringConfig {
+  webhookUrl: string;
+  secret: string;
+  agentId: string;
+  usdPer1kInput: number;
+  usdPer1kOutput: number;
+}
+
+function readEnv(runtime: IAgentRuntime, key: string): string | undefined {
+  const fromSettings =
+    typeof runtime.getSetting === "function" ? runtime.getSetting(key) : undefined;
+  const value =
+    (typeof fromSettings === "string" && fromSettings) ||
+    (typeof process !== "undefined" ? process.env?.[key] : undefined);
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readNumberEnv(
+  runtime: IAgentRuntime,
+  key: string,
+  fallback: number
+): number {
+  const raw = readEnv(runtime, key);
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+/**
+ * Resolve the metering config from the container environment. Returns null
+ * (bridge disabled) when the required knobs are absent, which is the case for
+ * any agent that is not a hosted waifu agent.
+ */
+export function resolveWaifuMeteringConfig(
+  runtime: IAgentRuntime
+): WaifuMeteringConfig | null {
+  const webhookUrl =
+    readEnv(runtime, "WAIFU_INFERENCE_WEBHOOK_URL") ?? readEnv(runtime, "WAIFU_WEBHOOK_URL");
+  const secret =
+    readEnv(runtime, "WAIFU_WEBHOOK_SECRET") ?? readEnv(runtime, "WAIFU_INFERENCE_WEBHOOK_SECRET");
+  const agentId = readEnv(runtime, "WAIFU_AGENT_ID") ?? readEnv(runtime, "WAIFU_CORE_AGENT_ID");
+
+  if (!webhookUrl || !secret || !agentId) {
+    return null;
+  }
+
+  return {
+    webhookUrl,
+    secret,
+    agentId,
+    usdPer1kInput: readNumberEnv(runtime, "WAIFU_METER_USD_PER_1K_INPUT", DEFAULT_USD_PER_1K_INPUT),
+    usdPer1kOutput: readNumberEnv(
+      runtime,
+      "WAIFU_METER_USD_PER_1K_OUTPUT",
+      DEFAULT_USD_PER_1K_OUTPUT
+    ),
+  };
+}
+
+/**
+ * HMAC signature compatible with waifu's webhook receiver:
+ * `sha256=` + HMAC-SHA256 over `${timestamp}.${rawBody}`.
+ */
+export function signWaifuWebhook(rawBody: string, timestamp: string, secret: string): string {
+  return `sha256=${crypto.createHmac("sha256", secret).update(`${timestamp}.${rawBody}`).digest("hex")}`;
+}
+
+export function estimateUsd(
+  config: WaifuMeteringConfig,
+  inputTokens: number,
+  outputTokens: number
+): number {
+  const usd =
+    (inputTokens / 1000) * config.usdPer1kInput +
+    (outputTokens / 1000) * config.usdPer1kOutput;
+  return Number.isFinite(usd) && usd > 0 ? usd : 0;
+}
+
+export interface InferenceSpentPayload {
+  agentId: string;
+  modelType: string;
+  modelName?: string;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  usd: number;
+  costSource: "gateway" | "estimate";
+  timestamp: string;
+  idempotencyKey: string;
+  source: "elizacloud";
+}
+
+export function buildInferenceSpentPayload(
+  config: WaifuMeteringConfig,
+  event: ModelUsageEventPayload,
+  now: Date = new Date()
+): InferenceSpentPayload | null {
+  const promptTokens = Math.max(0, Math.round(Number(event.tokens?.prompt ?? 0)));
+  const completionTokens = Math.max(0, Math.round(Number(event.tokens?.completion ?? 0)));
+  const totalTokens = Math.max(
+    0,
+    Math.round(Number(event.tokens?.total ?? promptTokens + completionTokens))
+  );
+
+  // Nothing was actually spent (e.g. a cached/short-circuited call with no
+  // tokens). Skip so we never inflate the burn with empty events.
+  if (totalTokens === 0 && promptTokens === 0 && completionTokens === 0) {
+    return null;
+  }
+
+  const gatewayCost =
+    typeof event.costUsd === "number" && Number.isFinite(event.costUsd) && event.costUsd >= 0
+      ? event.costUsd
+      : undefined;
+  const usd = gatewayCost ?? estimateUsd(config, promptTokens, completionTokens);
+
+  const timestamp = now.toISOString();
+  return {
+    agentId: config.agentId,
+    modelType: String(event.type ?? "unknown"),
+    ...(event.modelName ? { modelName: event.modelName } : {}),
+    promptTokens,
+    completionTokens,
+    totalTokens,
+    usd,
+    costSource: gatewayCost !== undefined ? "gateway" : "estimate",
+    timestamp,
+    idempotencyKey: `inference:${config.agentId}:${crypto.randomUUID()}`,
+    source: "elizacloud",
+  };
+}
+
+/**
+ * POST a signed `inference.spent` webhook to waifu. Best-effort: failures are
+ * logged but never thrown, so metering never blocks or breaks an agent reply.
+ */
+export async function postInferenceSpent(
+  config: WaifuMeteringConfig,
+  payload: InferenceSpentPayload,
+  fetchImpl: typeof fetch = fetch
+): Promise<{ ok: boolean; status?: number }> {
+  const body = JSON.stringify(payload);
+  const signature = signWaifuWebhook(body, payload.timestamp, config.secret);
+  try {
+    const res = await fetchImpl(config.webhookUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-Waifu-Webhook-Signature": signature,
+        "X-Waifu-Signature": signature,
+      },
+      body,
+    });
+    if (!res.ok) {
+      logger.warn(
+        `[waifu-metering] inference.spent POST returned ${res.status} for agent ${config.agentId}`
+      );
+      return { ok: false, status: res.status };
+    }
+    logger.debug(
+      `[waifu-metering] inference.spent posted (agent=${config.agentId} tokens=${payload.totalTokens} usd=${payload.usd.toFixed(6)} src=${payload.costSource})`
+    );
+    return { ok: true, status: res.status };
+  } catch (err) {
+    logger.warn(
+      `[waifu-metering] inference.spent POST failed: ${err instanceof Error ? err.message : String(err)}`
+    );
+    return { ok: false };
+  }
+}
+
+/**
+ * Build the MODEL_USED event handler that forwards inference spend to waifu.
+ * Resolves config lazily per-event so it stays a no-op until the metering env
+ * is present, and so config changes (rare) are picked up without a restart.
+ */
+export function createWaifuMeteringHandler(
+  fetchImpl: typeof fetch = fetch
+): (payload: ModelUsageEventPayload) => Promise<void> {
+  return async (payload: ModelUsageEventPayload): Promise<void> => {
+    const runtime = payload?.runtime;
+    if (!runtime) return;
+    const config = resolveWaifuMeteringConfig(runtime);
+    if (!config) return;
+    const spent = buildInferenceSpentPayload(config, payload);
+    if (!spent) return;
+    await postInferenceSpent(config, spent, fetchImpl);
+  };
+}


### PR DESCRIPTION
## W1 metering: forward per-inference spend to the waifu burn meter

### Context
Hosted waifu agents run as sandboxed containers whose model inference is routed through the Eliza Cloud metered inference gateway. The gateway is the honest meter: it owns the per model pricing table and platform markup and debits the organization credit balance on every call. That debit is authoritative and already happens server side.

What was missing was the signal back to waifu. The waifu burn rollup reads `inference.spent` events to compute daily burn and runway, but fell back to a 5 USD per day placeholder when no such events existed, because nothing emitted them.

### Change
Add a waifu metering bridge that listens for the runtime `MODEL_USED` event (emitted by the cloud model handlers after each inference) and POSTs a signed `inference.spent` webhook to waifu. It is a no-op unless the container is provisioned with the waifu metering env knobs (`WAIFU_INFERENCE_WEBHOOK_URL`, `WAIFU_WEBHOOK_SECRET`, `WAIFU_AGENT_ID`), so it never fires for local or standalone agents.

Token counts are exact (reported by the gateway). USD is the authoritative post markup cost when the gateway surfaces it (`usage.cost_usd` or the `X-Eliza-Cost-Usd` response header); otherwise a conservative, configurable token based estimate is used (`WAIFU_METER_USD_PER_1K_INPUT` / `_OUTPUT`). The credit debit itself remains the cloud authoritative number; the estimate only affects waifu burn display until the cloud cost is wired through.

- `utils/events.ts`: carry the resolved model id and optional gateway cost on `MODEL_USED`
- `models/text.ts`: pass the model name and parse the gateway cost from inference responses
- `utils/waifu-metering.ts`: config resolution, HMAC signing, payload build, best effort POST
- `index.ts`: register the `MODEL_USED` handler
- unit tests cover config gating, signing format, estimate vs gateway cost, idempotency, no-op when unconfigured (15 tests pass)

### Companion
Waifu side (waifufun/waifu.fun PR #871) injects the env knobs at provision and tests the receiver mapping.

### Proof
Verified end to end against live infra: a real metered inference returned real token usage; the real emitter built and signed the payload; the real waifu receiver route mapped it to an `inference.spent` event; the real rollup math produced `agentDailyBurnUsd = 0.000801` (real measured burn, not the $5 placeholder). The org credit balance decremented on the live calls.

Do not merge yet.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a waifu metering bridge to `plugin-elizacloud` that forwards per-inference token and USD spend to the waifu burn rollup, replacing a hard-coded $5/day placeholder with real measured burn. The bridge is a no-op for any agent not provisioned with the three required env knobs (`WAIFU_INFERENCE_WEBHOOK_URL`, `WAIFU_WEBHOOK_SECRET`, `WAIFU_AGENT_ID`).

- `utils/waifu-metering.ts` (new): config resolution, HMAC signing (`sha256=HMAC(secret, \"${timestamp}.${body}\")`), payload construction (gateway cost preferred, token-estimate fallback), and best-effort POST with a 10 s `AbortSignal.timeout` guard.
- `utils/events.ts`: adds optional `modelName` and `costUsd` fields to `ModelEventPayload` via a new `ModelUsageEventMeta` intersection type, keeping the base shape unchanged for all other listeners.
- `models/text.ts`: adds `extractCostUsd` to read authoritative gateway cost from `usage.cost_usd`/`usage.costUsd`/`usage.cost` body fields or the `X-Eliza-Cost-Usd` response header, then threads `modelName` and `costUsd` into both `emitModelUsageEvent` call sites.

<h3>Confidence Score: 5/5</h3>

Safe to merge once the companion waifu.fun PR #871 is ready; the bridge is an unconditional no-op on agents without the three metering env knobs, so existing deployments are unaffected.

All changed paths are additive: the new event meta fields are optional and backward-compatible, the metering handler is gated behind env knobs that are absent on every non-hosted agent, and failures in the webhook POST are caught and logged rather than propagated. The 10 s AbortSignal caps worst-case latency impact. No existing behaviour is altered.

The extractCostUsd fallback chain in models/text.ts (the generic usage.cost third field) and the zero-USD gateway-cost path in waifu-metering.ts are the two areas worth a second look before the companion PR goes live.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-elizacloud/src/utils/waifu-metering.ts | New waifu metering bridge: config resolution, HMAC signing, payload building, and best-effort POST with AbortSignal.timeout guard. Well-structured and handles edge cases (zero tokens, negative cost, fetch failures). |
| plugins/plugin-elizacloud/src/utils/events.ts | Extends ModelEventPayload with optional modelName and costUsd meta fields; emitModelUsageEvent gains a meta parameter with backward-compatible defaults. |
| plugins/plugin-elizacloud/src/models/text.ts | Adds extractCostUsd helper; passes modelName and optional costUsd into emitModelUsageEvent at both inference call sites. The generic usage.cost third-fallback field remains a potential source of misattributed USD figures. |
| plugins/plugin-elizacloud/src/index.ts | Registers the waifu metering handler as a MODEL_USED event listener; straightforward single-line addition with appropriate comments. |
| plugins/plugin-elizacloud/__tests__/unit/waifu-metering.test.ts | 15 unit tests covering config gating, URL derivation, HMAC signing, USD estimation, payload building (gateway vs. estimate cost), timeout handling, and source-filtering. Coverage is thorough. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Gateway as Eliza Cloud Gateway
    participant text as models/text.ts
    participant events as utils/events.ts
    participant Runtime as ElizaOS Runtime
    participant metering as utils/waifu-metering.ts
    participant Waifu as waifu.fun webhook

    Gateway->>text: HTTP response with usage and X-Eliza-Cost-Usd
    text->>text: extractCostUsd(usage, response)
    text->>events: emitModelUsageEvent(runtime, type, prompt, usage, meta)
    events->>Runtime: runtime.emitEvent(MODEL_USED, payload)
    Runtime->>metering: handler(payload)
    metering->>metering: "guard source === elizacloud"
    metering->>metering: resolveWaifuMeteringConfig(runtime)
    note over metering: returns null and exits if env knobs absent
    metering->>metering: buildInferenceSpentPayload(config, payload)
    note over metering: costSource gateway if costUsd present else estimate
    metering->>metering: signWaifuWebhook(body, timestamp, secret)
    metering->>Waifu: POST /inference signed payload with AbortSignal 10s
    Waifu-->>metering: 202 Accepted
    metering-->>Runtime: void errors logged not thrown
```

<sub>Reviews (3): Last reviewed commit: ["fix(plugin-elizacloud): bound waifu mete..."](https://github.com/elizaos/eliza/commit/bfd54af7f53b039c55b6a8ffbaf373b47e1fe9c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34787350)</sub>

<!-- /greptile_comment -->