### PR TITLE
fix: make Cerebras BYOK answer end-to-end (gpt-oss-120b)

### DIFF
--- a/packages/agent/src/runtime/operations/manager.ts
+++ b/packages/agent/src/runtime/operations/manager.ts
@@ -135,10 +135,17 @@ export class DefaultRuntimeOperationManager implements RuntimeOperationManager {
       return { kind: "rejected-busy", activeOperationId: active.id };
     }
 
+    // Snapshot the classify context BEFORE prepare() runs: prepare() mutates
+    // the live config to the target provider, so reading currentProvider after
+    // it would always equal the target → every provider-switch would classify
+    // as "hot" and a not-yet-loaded provider plugin (e.g. switching elizacloud
+    // → cerebras, or onboarding a first provider) would never get the cold
+    // restart that actually loads it, leaving the runtime with no provider.
+    const ctxBeforePrepare = this.classifyContext();
     const prepareResult = req.prepare ? await req.prepare() : undefined;
     const preparedIntent =
       prepareResult === undefined ? req.intent : prepareResult;
-    const tier = this.classifier(preparedIntent, this.classifyContext());
+    const tier = this.classifier(preparedIntent, ctxBeforePrepare);
     const now = Date.now();
     const op: RuntimeOperation = {
       id: crypto.randomUUID(),

--- a/packages/agent/test/runtime/operations/classify-ordering.test.ts
+++ b/packages/agent/test/runtime/operations/classify-ordering.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Regression: the manager must classify a provider-switch using the provider
+ * state that existed BEFORE `prepare()` runs.
+ *
+ * The provider-switch route's `prepare()` mutates the live config to the
+ * target provider. If the manager snapshots the classify context AFTER
+ * prepare(), `currentProvider` always equals the target → every switch
+ * collapses to "hot". A hot reload only notifies already-loaded plugins, so
+ * switching to a provider whose plugin was never loaded (e.g. elizacloud →
+ * cerebras, or onboarding the very first provider) would leave the runtime
+ * with no provider registered until a full restart.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgentRuntime } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { defaultClassifier } from "../../../src/runtime/operations/classifier.js";
+import { HealthChecker } from "../../../src/runtime/operations/health.js";
+import { DefaultRuntimeOperationManager } from "../../../src/runtime/operations/manager.js";
+import { FilesystemRuntimeOperationRepository } from "../../../src/runtime/operations/repository.js";
+import type {
+  ProviderSwitchIntent,
+  ReloadStrategy,
+  ReloadTier,
+} from "../../../src/runtime/operations/types.js";
+
+let stateDir: string;
+let repo: FilesystemRuntimeOperationRepository;
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), "classify-ordering-"));
+  repo = new FilesystemRuntimeOperationRepository(stateDir, {
+    retentionMs: 365 * 24 * 60 * 60 * 1000,
+    maxRecords: 1000,
+  });
+});
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+function stubStrategy(tier: ReloadTier): ReloadStrategy {
+  return { tier, apply: async () => ({}) as unknown as AgentRuntime };
+}
+
+describe("manager classifies provider-switch from the pre-prepare provider", () => {
+  test("elizacloud → cerebras stays cold even though prepare() rewrites currentProvider to the target", async () => {
+    // The live provider before the switch.
+    let currentProvider = "elizacloud";
+
+    const intent: ProviderSwitchIntent = {
+      kind: "provider-switch",
+      provider: "cerebras",
+    };
+
+    const manager = new DefaultRuntimeOperationManager({
+      repository: repo,
+      runtime: () => ({}) as unknown as AgentRuntime,
+      // Reads the live provider at call time — exactly like the real
+      // server closure that reads from `state.config`.
+      classifyContext: () => ({ currentProvider }),
+      classifier: defaultClassifier,
+      healthChecker: new HealthChecker(),
+      strategies: { cold: stubStrategy("cold"), hot: stubStrategy("hot") },
+    });
+
+    const outcome = await manager.start({
+      intent,
+      // Mirrors the route: prepare() applies the target provider to config,
+      // which the classify context reads from.
+      prepare: async () => {
+        currentProvider = "cerebras";
+        return intent;
+      },
+    });
+
+    expect(outcome.kind).toBe("accepted");
+    if (outcome.kind !== "accepted") return;
+    // Pre-prepare provider was elizacloud (different family) → cold restart,
+    // which actually loads the cerebras plugin. The bug would yield "hot".
+    expect(outcome.operation.tier).toBe("cold");
+  });
+
+  test("same-provider key swap still collapses to hot", async () => {
+    let currentProvider = "openai";
+    const intent: ProviderSwitchIntent = {
+      kind: "provider-switch",
+      provider: "openai",
+    };
+    const manager = new DefaultRuntimeOperationManager({
+      repository: repo,
+      runtime: () => ({}) as unknown as AgentRuntime,
+      classifyContext: () => ({ currentProvider }),
+      classifier: defaultClassifier,
+      healthChecker: new HealthChecker(),
+      strategies: { cold: stubStrategy("cold"), hot: stubStrategy("hot") },
+    });
+    const outcome = await manager.start({
+      intent,
+      prepare: async () => {
+        currentProvider = "openai";
+        return intent;
+      },
+    });
+    expect(outcome.kind).toBe("accepted");
+    if (outcome.kind !== "accepted") return;
+    expect(outcome.operation.tier).toBe("hot");
+  });
+});

--- a/plugins/plugin-openai/__tests__/reasoning-effort.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/reasoning-effort.shape.test.ts
@@ -71,6 +71,47 @@ describe("OPENAI_REASONING_EFFORT env-var forwarding", () => {
   });
 });
 
+describe("Cerebras default reasoning effort", () => {
+  // CEREBRAS_API_KEY set with no OPENAI_API_KEY / OPENAI_BASE_URL ⇒ Cerebras mode.
+  it("defaults to 'low' in Cerebras mode when OPENAI_REASONING_EFFORT is unset", () => {
+    const runtime = buildRuntime({ CEREBRAS_API_KEY: "csk-test" });
+    const opts = __INTERNAL_resolveProviderOptions({ prompt: "hi" } as never, runtime);
+    expect(
+      (opts as { openai?: { reasoningEffort?: string } } | undefined)?.openai?.reasoningEffort
+    ).toBe("low");
+  });
+
+  it("lets an explicit valid OPENAI_REASONING_EFFORT override the Cerebras default", () => {
+    const runtime = buildRuntime({ CEREBRAS_API_KEY: "csk-test", OPENAI_REASONING_EFFORT: "high" });
+    const opts = __INTERNAL_resolveProviderOptions({ prompt: "hi" } as never, runtime);
+    expect(
+      (opts as { openai?: { reasoningEffort?: string } } | undefined)?.openai?.reasoningEffort
+    ).toBe("high");
+  });
+
+  it("falls back to the Cerebras default 'low' when the explicit value is invalid", () => {
+    const runtime = buildRuntime({
+      CEREBRAS_API_KEY: "csk-test",
+      OPENAI_REASONING_EFFORT: "extreme",
+    });
+    const opts = __INTERNAL_resolveProviderOptions({ prompt: "hi" } as never, runtime);
+    expect(
+      (opts as { openai?: { reasoningEffort?: string } } | undefined)?.openai?.reasoningEffort
+    ).toBe("low");
+  });
+
+  it("lets caller-supplied providerOptions.openai.reasoningEffort beat the Cerebras default", () => {
+    const runtime = buildRuntime({ CEREBRAS_API_KEY: "csk-test" });
+    const opts = __INTERNAL_resolveProviderOptions(
+      { prompt: "hi", providerOptions: { openai: { reasoningEffort: "medium" } } } as never,
+      runtime
+    );
+    expect(
+      (opts as { openai?: { reasoningEffort?: string } } | undefined)?.openai?.reasoningEffort
+    ).toBe("medium");
+  });
+});
+
 describe("strip reasoning-content from outbound assistant messages", () => {
   it("drops `type: reasoning` parts from a content array (tool-call branch)", () => {
     const normalized = __INTERNAL_normalizeNativeMessages([

--- a/plugins/plugin-openai/models/text.ts
+++ b/plugins/plugin-openai/models/text.ts
@@ -244,8 +244,13 @@ function resolvePromptCacheOptions(params: GenerateTextParams): OpenAIPromptCach
  * `max_tokens`, which is the failure mode on Cerebras gpt-oss-120b when
  * left unset.
  *
- * Returns `undefined` when the setting is unset or invalid, so non-
- * reasoning models pay no overhead and the wire stays clean.
+ * In Cerebras mode the field defaults to `"low"` when unset: gpt-oss-120b
+ * emits a separate reasoning channel and, left unbounded, spends the whole
+ * token budget reasoning — returning empty visible content, which makes the
+ * agent fall back to "I don't have a reply for that". `"low"` keeps reasoning
+ * short so a reply always materializes. For non-Cerebras models an unset/
+ * invalid value yields `undefined`, so they pay no overhead and the wire
+ * stays clean. An explicit valid `OPENAI_REASONING_EFFORT` always wins.
  *
  * Valid values follow the OpenAI spec exactly: `minimal`, `low`,
  * `medium`, `high`. Anything else is logged and ignored.
@@ -256,15 +261,21 @@ const VALID_REASONING_EFFORTS: readonly ReasoningEffort[] = ["minimal", "low", "
 
 function resolveReasoningEffort(runtime: IAgentRuntime): ReasoningEffort | undefined {
   const raw = runtime.getSetting("OPENAI_REASONING_EFFORT");
-  if (typeof raw !== "string") return undefined;
-  const normalized = raw.trim().toLowerCase();
-  if (!normalized) return undefined;
-  if ((VALID_REASONING_EFFORTS as readonly string[]).includes(normalized)) {
-    return normalized as ReasoningEffort;
+  const normalized = typeof raw === "string" ? raw.trim().toLowerCase() : "";
+  if (normalized) {
+    if ((VALID_REASONING_EFFORTS as readonly string[]).includes(normalized)) {
+      return normalized as ReasoningEffort;
+    }
+    logger.warn(
+      `[OpenAI] OPENAI_REASONING_EFFORT=${raw} is not a valid reasoning effort; ignoring. Expected one of: ${VALID_REASONING_EFFORTS.join(", ")}.`
+    );
   }
-  logger.warn(
-    `[OpenAI] OPENAI_REASONING_EFFORT=${raw} is not a valid reasoning effort; ignoring. Expected one of: ${VALID_REASONING_EFFORTS.join(", ")}.`
-  );
+  // gpt-oss-120b on Cerebras returns empty content when reasoning runs
+  // unbounded; default to "low" so a visible reply always fits. An explicit
+  // valid value above wins over this default.
+  if (isCerebrasMode(runtime)) {
+    return "low";
+  }
   return undefined;
 }
 
@@ -275,13 +286,13 @@ function resolveProviderOptions(
   const withOpenAIOptions = params as GenerateTextParamsWithOpenAIOptions;
   const rawProviderOptions = withOpenAIOptions.providerOptions;
   const promptCacheOptions = resolvePromptCacheOptions(params);
-  const reasoningEffortFromEnv = resolveReasoningEffort(runtime);
+  const reasoningEffort = resolveReasoningEffort(runtime);
 
   if (
     !rawProviderOptions &&
     !promptCacheOptions.promptCacheKey &&
     !promptCacheOptions.promptCacheRetention &&
-    !reasoningEffortFromEnv
+    !reasoningEffort
   ) {
     return undefined;
   }
@@ -313,11 +324,11 @@ function resolveProviderOptions(
     ...(!skipCacheRetention && promptCacheOptions.promptCacheRetention
       ? { promptCacheRetention: promptCacheOptions.promptCacheRetention }
       : {}),
-    // The caller's explicit `reasoningEffort` wins over the env-var default
-    // — this matches the precedence pattern used for promptCacheKey above.
+    // The caller's explicit `reasoningEffort` wins over the resolved default
+    // (env var, or Cerebras "low") — same precedence pattern as promptCacheKey.
     ...((sanitizedRawOpenAIOptions as { reasoningEffort?: unknown } | undefined)
-      ?.reasoningEffort === undefined && reasoningEffortFromEnv
-      ? { reasoningEffort: reasoningEffortFromEnv }
+      ?.reasoningEffort === undefined && reasoningEffort
+      ? { reasoningEffort }
       : {}),
   };
 


### PR DESCRIPTION
## Problem

With a Cerebras key configured via **Settings → Providers** (the OpenAI-compatible direct-account path), the agent reached Cerebras but never produced a usable reply:

1. **Empty replies.** `gpt-oss-120b` emits a separate reasoning channel and, left unbounded, spends its whole token budget reasoning — returning empty visible `content`. The chat pipeline then falls back to *"I don't have a reply for that — try rephrasing?"*. `plugin-openai` already documents this exact failure and supports a `reasoning_effort` knob, but never defaulted it.

2. **Provider not registered after a switch.** Switching to a provider whose plugin wasn't already loaded (e.g. onboarding on Eliza Cloud, then switching to Cerebras) left the runtime with `NO_PROVIDER_REGISTERED` until a full restart. The runtime-operations manager ran the switch's `prepare()` — which writes the target provider into the live config — *before* snapshotting the classify context, so `currentProvider` always equalled the target → every provider-switch collapsed to a "hot" reload, which only notifies already-loaded plugins (it can't load a new one).

## Fixes

- **`plugin-openai`:** default `reasoning_effort` to `"low"` whenever Cerebras mode is active and the value is unset/invalid, so a visible reply always materializes. An explicit valid `OPENAI_REASONING_EFFORT` (or a caller-supplied `providerOptions.openai.reasoningEffort`) still wins.
- **`runtime-ops`:** snapshot the classify context **before** `prepare()` runs, so a first-time / cross-family provider switch correctly classifies "cold" and actually loads the new provider plugin.

## Verification

Drove the real agent runtime (not mocks): configured Cerebras via `/api/provider/switch`, restarted, and sent chat messages. A TLS-SNI packet capture confirmed the agent's only LLM host was `api.cerebras.ai` (model `gpt-oss-120b`), and it returned real answers ("red, blue, and yellow", "100", "Paris, and 68.") instead of the empty fallback — with **no** `OPENAI_REASONING_EFFORT` override set, i.e. the new default doing the work.

- `plugin-openai`: `tsgo` + biome clean; reasoning-effort shape tests (incl. 4 new Cerebras-default cases) pass.
- `runtime-ops`: `manager.ts` `tsgo` clean; new `classify-ordering` regression test + existing operations tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent bugs in the Cerebras BYOK path: a missing `reasoning_effort` default causing empty replies from `gpt-oss-120b`, and a provider-switch misclassification that prevented first-time provider plugins from loading without a restart.

- **`plugin-openai/models/text.ts`**: `resolveReasoningEffort` now defaults to `"low"` when `isCerebrasMode` is active and no explicit `OPENAI_REASONING_EFFORT` is set (or the set value is invalid), ensuring `gpt-oss-120b`'s reasoning channel doesn't consume the entire token budget. Explicit env-var and caller-supplied `providerOptions` still take precedence.
- **`packages/agent/src/runtime/operations/manager.ts`**: `classifyContext()` is now snapshotted *before* `req.prepare()` runs, so the classifier correctly sees the pre-mutation provider (e.g. `elizacloud`) and classifies a cross-family switch as "cold" rather than "hot", enabling the new provider plugin to be loaded.

<h3>Confidence Score: 4/5</h3>

Both targeted fixes are correct and well-tested; the only open question is whether Cerebras's API gracefully ignores reasoning_effort on non-reasoning models.

The manager.ts ordering fix is airtight — the snapshot is taken inside the serialized startChain so no concurrent interleaving can occur, and the new regression test directly exercises the before/after mutation boundary. The reasoning_effort default is correct for gpt-oss-120b but unconditionally applied to all Cerebras requests regardless of model; if a user configures a non-reasoning Cerebras model (e.g. a Llama variant), the injected parameter may trigger an API rejection since those models don't accept it.

plugins/plugin-openai/models/text.ts — the reasoning_effort default is applied whenever isCerebrasMode is true, with no check on whether the active model actually supports the parameter.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-openai/models/text.ts | Adds Cerebras-mode default of "low" for reasoning_effort in resolveReasoningEffort; applied to all Cerebras requests regardless of model, which may inject the parameter into non-reasoning model calls. |
| packages/agent/src/runtime/operations/manager.ts | Snapshots classifyContext before prepare() to fix the provider-switch misclassification bug; logic is correct and safe given startChain serialization. |
| packages/agent/test/runtime/operations/classify-ordering.test.ts | New regression test covering the pre/post-prepare classify ordering bug; tests both cross-family (cold) and same-provider (hot) cases correctly. |
| plugins/plugin-openai/__tests__/reasoning-effort.shape.test.ts | Adds 4 new Cerebras-specific tests for reasoning_effort defaulting; well-structured, uses accurate mock of isCerebrasMode detection via CEREBRAS_API_KEY. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Route as Route Layer
    participant Manager as OperationManager.start()
    participant Repo as OperationRepository
    participant Classifier as defaultClassifier
    participant Prepare as req.prepare()

    Route->>Manager: start(req)
    Manager->>Repo: findByIdempotencyKey (dedup check)
    Manager->>Repo: findActive (busy check)
    Note over Manager: BUG (before fix): classifyContext() called HERE after prepare() mutates currentProvider
    Manager->>Manager: "ctxBeforePrepare = classifyContext()"
    Manager->>Prepare: await req.prepare()
    Note over Prepare: Writes target provider into live config
    Prepare-->>Manager: preparedIntent
    Manager->>Classifier: classify(preparedIntent, ctxBeforePrepare)
    Note over Classifier: Sees pre-mutation provider - elizacloud ≠ cerebras → cold
    Classifier-->>Manager: "tier = cold"
    Manager->>Repo: create(op)
    Manager-->>Route: accepted, tier: cold
    Manager->>Manager: scheduleExecution (async)
```

<sub>Reviews (1): Last reviewed commit: ["fix(runtime-ops): classify provider-swit..."](https://github.com/elizaos/eliza/commit/543060267cb355d0461e5a28ba73bddadf5cdd00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34787437)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->