### PR TITLE
fix(plugin-wallet): guard undefined token name/symbol in birdeye label sanitizer

### DIFF
--- a/plugins/plugin-wallet/src/analytics/birdeye/utils.ts
+++ b/plugins/plugin-wallet/src/analytics/birdeye/utils.ts
@@ -510,8 +510,8 @@ export const formatTokenInfo = (
     ? `${Math.floor((Date.now() - new Date(token.creation_time).getTime()) / (1000 * 60 * 60 * 24))}d`
     : "N/A";
 
-  const safeName = sanitizeWalletDisplayLabel(token.name);
-  const safeSymbol = sanitizeWalletDisplayLabel(token.symbol);
+  const safeName = sanitizeWalletDisplayLabel(token.name || "unknown");
+  const safeSymbol = sanitizeWalletDisplayLabel(token.symbol || "unknown");
 
   let output =
     `🪙 ${safeName} @ ${safeSymbol}\n` +


### PR DESCRIPTION
## Problem

`formatTokenInfo` (birdeye analytics) passes `token.name` and `token.symbol` — both typed `string | undefined` — straight into `sanitizeWalletDisplayLabel(label: string)`, which calls `label.replace(...)`:

```ts
const safeName = sanitizeWalletDisplayLabel(token.name);
const safeSymbol = sanitizeWalletDisplayLabel(token.symbol);
```

This is a `tsgo` error (`TS2345`, surfaced via `packages/agent`'s project references) **and** a latent runtime crash (`Cannot read properties of undefined (reading 'replace')`) for tokens with missing name/symbol metadata. Introduced by #8076 (the security-hardening commit that added `sanitizeWalletDisplayLabel`).

## Fix

Fall back to `"unknown"`, matching the existing `sanitizeWalletDisplayLabel(item.symbol || "unknown")` calls in `portfolio-factory.ts` (same file's established convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two calls to `sanitizeWalletDisplayLabel` in `formatTokenInfo` that passed `token.name` and `token.symbol` directly despite both fields being typed `string | undefined`. The fix adds `|| "unknown"` fallbacks, matching the identical guard already used in `portfolio-factory.ts`.

- **Runtime crash prevented**: Without this guard, any token missing `name` or `symbol` in the Birdeye API response would cause `Cannot read properties of undefined (reading 'replace')` at the `.replace(...)` call inside `sanitizeWalletDisplayLabel`.
- **TypeScript error resolved**: The `TS2345` error surfaced via `packages/agent` project references is eliminated by narrowing the argument type from `string | undefined` to `string` before the call.
- **Convention consistent**: The fallback value `"unknown"` mirrors lines 84 and 127 of `portfolio-factory.ts`, the established pattern in this same codebase.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a two-line guard that prevents a latent crash and aligns with the existing convention in the same file tree.

The fix is minimal, targeted, and correct. Both token.name and token.symbol are typed string | undefined in TokenResult, and the || 'unknown' fallback keeps behaviour consistent with the identical pattern already used in portfolio-factory.ts lines 84 and 127. No new logic is introduced, and the change cannot regress any existing path.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-wallet/src/analytics/birdeye/utils.ts | Guards two sanitizeWalletDisplayLabel calls against undefined token.name / token.symbol by falling back to "unknown", eliminating a TS2345 compile error and potential runtime crash. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[formatTokenInfo called with TokenResult] --> B{token.name defined?}
    B -- yes --> C[use token.name]
    B -- no --> D[fallback: 'unknown']
    C --> E[sanitizeWalletDisplayLabel name]
    D --> E
    A --> F{token.symbol defined?}
    F -- yes --> G[use token.symbol]
    F -- no --> H[fallback: 'unknown']
    G --> I[sanitizeWalletDisplayLabel symbol]
    H --> I
    E --> J[safeName]
    I --> K[safeSymbol]
    J --> L[format output string]
    K --> L
```

<sub>Reviews (1): Last reviewed commit: ["fix(plugin-wallet): guard undefined toke..."](https://github.com/elizaos/eliza/commit/4337c8dd45d395bf8c6f314e0935812951523593) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34787558)</sub>

<!-- /greptile_comment -->