### PR TITLE
fix(vault): self-heal stale PGlite lock so an unclean shutdown can't brick boot

### DIFF
--- a/packages/vault/src/pglite-vault.ts
+++ b/packages/vault/src/pglite-vault.ts
@@ -76,6 +76,63 @@ export interface PgliteVaultOptions {
   readonly logger?: VaultLogger;
 }
 
+/**
+ * Outcome of inspecting a PGlite data dir's `postmaster.pid`. `cleared-*`
+ * means a provably-stale lock was removed and the open may be retried;
+ * `active` means a live process owns the dir; `missing` / `unconfirmed` mean
+ * there is nothing safe to remove.
+ */
+export type PglitePidStatus =
+  | "missing"
+  | "cleared-stale"
+  | "cleared-malformed"
+  | "active"
+  | "unconfirmed";
+
+/**
+ * Inspect (and remove, if provably stale) a PGlite data dir's
+ * `postmaster.pid`. An unclean exit (crash, OOM, SIGKILL, power loss) leaves
+ * the lock behind; if its owner is gone the file is stale and safe to remove
+ * so the dir can be reopened. A live owner (`active`) or an unprovable owner
+ * (`unconfirmed` — e.g. EPERM) is left untouched.
+ */
+export async function reconcileStalePglitePid(
+  dataDir: string,
+): Promise<PglitePidStatus> {
+  const pidPath = join(dataDir, "postmaster.pid");
+  let content: string;
+  try {
+    content = await fs.readFile(pidPath, "utf8");
+  } catch {
+    return "missing";
+  }
+  // Mobile embedded modes are single-tenant — each app launch is a fresh
+  // process, so any leftover pid is stale and the process.kill heuristic below
+  // false-positives (reused host PID / EPERM). Clear unconditionally.
+  if (
+    process.env.ELIZA_IOS_LOCAL_BACKEND === "1" ||
+    process.env.ELIZA_ANDROID_LOCAL_BACKEND === "1"
+  ) {
+    await fs.unlink(pidPath).catch(() => {});
+    return "cleared-stale";
+  }
+  const pid = Number.parseInt(content.split("\n")[0]?.trim() ?? "", 10);
+  if (!Number.isInteger(pid) || pid <= 0) {
+    await fs.unlink(pidPath).catch(() => {});
+    return "cleared-malformed";
+  }
+  try {
+    process.kill(pid, 0); // signal 0 probes liveness; throws ESRCH if gone
+    return "active";
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ESRCH") {
+      await fs.unlink(pidPath).catch(() => {});
+      return "cleared-stale";
+    }
+    return "unconfirmed"; // EPERM etc. — can't prove it's dead; leave it
+  }
+}
+
 export class PgliteVaultImpl implements Vault {
   private cachedKey: Buffer | null = null;
   private dbPromise: Promise<PGlite> | null = null;
@@ -308,7 +365,16 @@ export class PgliteVaultImpl implements Vault {
         );
       }
       const masterKey = await this.loadMasterKey();
-      return decrypt(masterKey, row.ciphertext, key);
+      try {
+        return decrypt(masterKey, row.ciphertext, key);
+      } catch (err) {
+        throw new Error(
+          `vault: failed to decrypt ${JSON.stringify(key)} (wrong master key or corrupt ciphertext): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          { cause: err },
+        );
+      }
     }
     if (
       (row.ref_source !== "1password" && row.ref_source !== "protonpass") ||
@@ -326,13 +392,30 @@ export class PgliteVaultImpl implements Vault {
 
   private async loadMasterKey(): Promise<Buffer> {
     if (this.cachedKey) return this.cachedKey;
-    this.cachedKey = await this.opts.masterKey.load();
+    try {
+      this.cachedKey = await this.opts.masterKey.load();
+    } catch (err) {
+      // Without the master key every secret read/write fails — surface a
+      // clear remediation path instead of a bare resolver error.
+      throw new Error(
+        `vault: master key unavailable (${this.opts.masterKey.describe()}): ${
+          err instanceof Error ? err.message : String(err)
+        }. On a desktop session ensure the OS keychain (gnome-keyring / kwallet / Keychain) is reachable; on a headless host set ELIZA_VAULT_PASSPHRASE (≥12 chars) and restart.`,
+        { cause: err },
+      );
+    }
     return this.cachedKey;
   }
 
   private async db(): Promise<PGlite> {
     if (!this.dbPromise) {
-      this.dbPromise = this.openDb();
+      // Never cache a rejected open: a transient failure (e.g. a stale lock a
+      // later attempt can clear) must not brick the vault for the rest of the
+      // process lifetime. Drop the cache on failure so callers can retry.
+      this.dbPromise = this.openDb().catch((err) => {
+        this.dbPromise = null;
+        throw err;
+      });
     }
     return this.dbPromise;
   }
@@ -340,12 +423,49 @@ export class PgliteVaultImpl implements Vault {
   private async openDb(): Promise<PGlite> {
     const dataDir = this.opts.dataDir ?? defaultPgliteVaultDataDir();
     await fs.mkdir(dataDir, { recursive: true, mode: 0o700 });
-    const db = await PGlite.create(dataDir);
+    const db = await this.createPglite(dataDir);
     await db.exec(SCHEMA_SETUP);
     if (this.opts.legacyStorePath) {
       await this.maybeMigrateFromFile(db, this.opts.legacyStorePath);
     }
     return db;
+  }
+
+  /**
+   * Open the PGlite data dir, self-healing a stale lock left by an unclean
+   * shutdown. An abrupt exit (crash, OOM, SIGKILL, power loss) leaves a
+   * `postmaster.pid` behind; PGlite then refuses — or WASM-aborts — the next
+   * open. Because the vault opens early at startup (wallet-key hydration),
+   * that would brick the agent at boot. If the leftover lock is provably
+   * stale we remove it and retry once; a live owner or a persistent failure
+   * surfaces a clear, actionable error. Parallels plugin-sql's
+   * PGliteClientManager reconciliation (the runtime DB already self-heals).
+   */
+  private async createPglite(dataDir: string): Promise<PGlite> {
+    try {
+      return await PGlite.create(dataDir);
+    } catch (initErr) {
+      const status = await reconcileStalePglitePid(dataDir);
+      if (status === "active") {
+        throw new Error(
+          `vault: PGlite data dir ${dataDir} is in use by another live Eliza process. Stop it, then retry.`,
+          { cause: initErr },
+        );
+      }
+      if (status !== "cleared-stale" && status !== "cleared-malformed") {
+        throw new Error(
+          `vault: failed to open ${dataDir} (no stale lock to clear): ${
+            initErr instanceof Error ? initErr.message : String(initErr)
+          }. If this persists the dir may be corrupt — stop Eliza, then move or remove ${dataDir} and restart.`,
+          { cause: initErr },
+        );
+      }
+      this.opts.logger?.warn(
+        "vault: cleared a stale PGlite lock left by an unclean shutdown; retrying open",
+        { dataDir, status },
+      );
+      return await PGlite.create(dataDir);
+    }
   }
 
   /**

--- a/packages/vault/test/pglite-vault.test.ts
+++ b/packages/vault/test/pglite-vault.test.ts
@@ -5,13 +5,17 @@
  * isolated tmp directory + in-memory master key, so concurrent tests
  * never collide on the PGlite single-writer constraint.
  */
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { encrypt, generateMasterKey } from "../src/crypto.js";
 import { inMemoryMasterKey } from "../src/master-key.js";
-import { PgliteVaultImpl } from "../src/pglite-vault.js";
+import {
+  PgliteVaultImpl,
+  reconcileStalePglitePid,
+} from "../src/pglite-vault.js";
 import { VaultMissError } from "../src/vault.js";
 import { runtimeVaultCaller } from "./vitest-assertion-shim.js";
 
@@ -315,5 +319,57 @@ describe("PgliteVaultImpl", () => {
       await rm(pgDir, { recursive: true, force: true });
       await rm(legacyDir, { recursive: true, force: true });
     });
+  });
+});
+
+describe("reconcileStalePglitePid (unclean-shutdown self-heal)", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "vault-pid-"));
+    await mkdir(dir, { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  const pidPath = () => join(dir, "postmaster.pid");
+  const exists = async (p: string) =>
+    access(p).then(
+      () => true,
+      () => false,
+    );
+
+  it("returns 'missing' when there is no postmaster.pid", async () => {
+    expect(await reconcileStalePglitePid(dir)).toBe("missing");
+  });
+
+  it("clears a malformed pid file", async () => {
+    await writeFile(pidPath(), "not-a-pid\n/data\n", "utf8");
+    expect(await reconcileStalePglitePid(dir)).toBe("cleared-malformed");
+    expect(await exists(pidPath())).toBe(false);
+  });
+
+  it("leaves an active pid (owned by a live process) untouched", async () => {
+    // process.pid is alive (this test runner) → must be treated as active.
+    await writeFile(pidPath(), `${process.pid}\n/data\n`, "utf8");
+    expect(await reconcileStalePglitePid(dir)).toBe("active");
+    expect(await exists(pidPath())).toBe(true);
+  });
+
+  it("clears a stale pid whose owning process has exited", async () => {
+    // Spawn a child, capture its pid, kill it, and wait for the OS to reap it
+    // so the pid is provably dead (process.kill(pid, 0) → ESRCH).
+    const child = spawn(process.execPath, [
+      "-e",
+      "setTimeout(() => {}, 60000)",
+    ]);
+    const pid = child.pid as number;
+    await new Promise<void>((resolve) => {
+      child.once("exit", () => resolve());
+      child.kill("SIGKILL");
+    });
+    await writeFile(pidPath(), `${pid}\n/data\n`, "utf8");
+    expect(await reconcileStalePglitePid(dir)).toBe("cleared-stale");
+    expect(await exists(pidPath())).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

`PgliteVaultImpl` opens its **own** PGlite store (`<state>/.vault-pglite`) very early at startup — during wallet-key hydration — yet it had none of the resilience the runtime DB (`plugin-sql`'s `PGliteClientManager`) already has:

1. **No stale-lock recovery.** `openDb()` called `PGlite.create()` directly. An unclean shutdown (crash, OOM, SIGKILL, power loss) leaves a `postmaster.pid` behind; on the next boot `PGlite.create()` fails — or WASM-`Aborted()`s — and since the vault opens before anything else, **the agent is bricked at boot** with no recovery. (Observed firsthand.)
2. **Permanent poisoning on transient failure.** `db()` cached the *rejected* open promise (`this.dbPromise = this.openDb()`), so a single transient failure made every subsequent vault operation fail for the entire process lifetime.
3. **Opaque failures.** Master-key load failures and decrypt failures propagated as bare errors with no remediation context.

## Fixes

- **Self-heal the stale lock** (`reconcileStalePglitePid`): if `PGlite.create()` fails, inspect `postmaster.pid` — remove a provably-stale lock (dead pid via `process.kill(pid,0)`→`ESRCH`, or a malformed pid; mobile embedded modes clear unconditionally) and **retry once**. A live owner or a persistent failure throws a clear, actionable error ("move or remove the dir"). Mirrors `plugin-sql`.
- **Don't cache a rejected open**: drop `dbPromise` on failure so callers can retry.
- **Contextual errors**: `loadMasterKey()` adds keychain/passphrase guidance; `decrypt()` names the key that failed.

## Tests

`reconcileStalePglitePid` is unit-tested across all four outcomes — `missing`, `cleared-malformed`, `active` (live `process.pid`, file kept), and `cleared-stale` (a spawned-then-killed child's dead pid, file removed). Full `pglite-vault` suite: 22 passing. tsgo + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds stale-lock self-healing to `PgliteVaultImpl` so an unclean shutdown (crash, OOM, SIGKILL) can no longer brick the agent at boot. It also fixes a long-standing bug where a rejected `openDb()` promise was cached indefinitely, preventing any future vault access within the same process.

- **Stale-lock recovery** (`reconcileStalePglitePid`): on `PGlite.create` failure, inspects `postmaster.pid`, removes provably-dead locks (dead PID via ESRCH, malformed PID, or mobile single-tenant mode), and retries once; live owners or ambiguous cases surface clear, actionable errors.
- **Don't cache rejection** (`db()`): the `.catch` handler nulls `this.dbPromise` so callers can retry after a transient failure instead of receiving the same rejection forever.
- **Contextual error wrapping**: `loadMasterKey()` and `decrypt()` now re-throw with keychain/passphrase guidance and the failing key name, respectively.

<h3>Confidence Score: 4/5</h3>

The core self-heal logic is correct and well-tested; the main gap is that the retry path after lock removal propagates a raw PGlite error with no user-facing remediation hint.

The stale-lock recovery, cached-rejection fix, and error-context improvements are all sound. The one missing piece is that createPglite's second PGlite.create call does not wrap its own failure with the move-or-remove guidance present everywhere else. A user hitting a corrupt directory after lock recovery will see a cryptic WASM error. All other findings are message-quality suggestions.

packages/vault/src/pglite-vault.ts — specifically the retry path inside createPglite after stale lock removal

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/vault/src/pglite-vault.ts | Adds stale-lock self-heal via reconcileStalePglitePid, fixes cached-rejected-promise bug, and improves error contextualisation; two minor observability gaps noted. |
| packages/vault/test/pglite-vault.test.ts | Adds four focused unit tests for reconcileStalePglitePid covering missing, malformed, active, and cleared-stale outcomes; all existing tests preserved. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["db() called"] --> B{"dbPromise set?"}
    B -- "yes" --> C["await existing promise"]
    B -- "no" --> D["openDb()"]
    D --> E["createPglite(dataDir)"]
    E --> F["PGlite.create(dataDir) — first attempt"]
    F -- "success" --> G["schema setup → return db"]
    F -- "failure" --> H["reconcileStalePglitePid(dataDir)"]
    H --> I{"status?"}
    I -- "active" --> J["throw: dir in use by live process"]
    I -- "unconfirmed" --> K["throw: EPERM, can't probe owner"]
    I -- "missing" --> L["throw: no stale lock to clear"]
    I -- "cleared-stale / cleared-malformed" --> M["log warn; retry PGlite.create()"]
    M -- "success" --> G
    M -- "failure" --> N["throw raw PGlite error (no wrapping)"]
    G --> O["dbPromise resolves"]
    J & K & L & N --> P["dbPromise rejects → dbPromise = null"]
    P --> Q["callers may retry db()"]
```

<sub>Reviews (1): Last reviewed commit: ["fix(vault): self-heal stale PGlite lock ..."](https://github.com/elizaos/eliza/commit/217178e451de24cb6128d8bf25ed5894c1f075b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34788563)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->