### PR TITLE
fix(ui): bail out of startup polling if cancelled during the first-run options fetch

### DIFF
--- a/packages/ui/src/state/startup-phase-poll.test.ts
+++ b/packages/ui/src/state/startup-phase-poll.test.ts
@@ -479,3 +479,57 @@ describe("shouldFallBackToLocalOrigin", () => {
     ).toBe(false);
   });
 });
+
+describe("runPollingBackend cancellation during options fetch", () => {
+  it("bails without mutating state when cancelled mid-fetch", async () => {
+    // Regression: the post-Promise.all path (first-run options + config) had
+    // no `cancelled.current` guard, so an effect torn down while the fetch was
+    // in flight still called setFirstRunOptions and dispatched BACKEND_REACHED
+    // on a dead effect. Flip `cancelled` the instant options are fetched and
+    // assert nothing downstream fires.
+    const deps = createDeps();
+    const dispatch = vi.fn();
+    (globalThis as { window?: unknown }).window = {
+      location: { origin: "http://localhost:2138", protocol: "http:" },
+    };
+    const cancelled = { current: false };
+    clientMock.getFirstRunOptions.mockImplementation(async () => {
+      cancelled.current = true; // effect cleanup raced the in-flight fetch
+      return firstRunOptions();
+    });
+    const ctx: RestoringSessionCtx = {
+      persistedActiveServer: null,
+      restoredActiveServer: {
+        id: "local:desktop",
+        kind: "local",
+        label: "Local agent",
+        apiBase: "http://127.0.0.1:34137",
+      },
+      shouldPreserveCompletedFirstRun: false,
+      hadPriorFirstRun: false,
+    };
+
+    await runPollingBackend(
+      deps,
+      dispatch,
+      {
+        supportsLocalRuntime: true,
+        backendTimeoutMs: 1000,
+        agentReadyTimeoutMs: 1000,
+        probeForExistingInstall: true,
+        defaultTarget: "embedded-local",
+      },
+      ctx,
+      1,
+      { current: 1 },
+      cancelled,
+      { current: null },
+    );
+
+    expect(deps.setFirstRunOptions).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalledWith({
+      type: "BACKEND_REACHED",
+      firstRunComplete: false,
+    });
+  });
+});

--- a/packages/ui/src/state/startup-phase-poll.ts
+++ b/packages/ui/src/state/startup-phase-poll.ts
@@ -389,6 +389,10 @@ export async function runPollingBackend(
               client.getFirstRunOptions(),
               client.getConfig().catch(() => null),
             ]);
+            // The effect may have been torn down (unmount / re-run) while the
+            // fetch was in flight — bail before mutating state or dispatching,
+            // matching the guards after the auth/first-run awaits above.
+            if (cancelled.current) return;
             if (deps.firstRunCompletionCommittedRef.current) {
               deps.setFirstRunLoading(false);
               dispatch({ type: "FIRST_RUN_COMPLETE" });


### PR DESCRIPTION
## Problem

In `runPollingBackend`, the first-run options branch awaits
`Promise.all([client.getFirstRunOptions(), client.getConfig()])` and then
calls `setFirstRunOptions`, `applyFirstRunResumeFields`, `setSetupStep`, and
dispatches `BACKEND_REACHED` — **without** re-checking `cancelled.current`.

If the effect is torn down (component unmount, or the startup effect re-runs)
while that fetch is in flight, the resolved continuation still mutates
first-run state and dispatches on a dead effect — a classic post-unmount
state-write race. The auth-status and first-run-status awaits earlier in the
same function already guard with `if (cancelled.current) return;`; this path
was the one that missed it.

## Fix

Add the same `if (cancelled.current) return;` guard immediately after the
`Promise.all` resolves, before any state mutation.

## Test

New regression test flips `cancelled.current` the instant `getFirstRunOptions`
is invoked and asserts neither `setFirstRunOptions` nor a `BACKEND_REACHED`
dispatch fires. Full `startup-phase-poll` suite (13) passes; tsgo + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a missing `cancelled.current` guard in `runPollingBackend` immediately after the `Promise.all([getFirstRunOptions(), getConfig()])` resolves, preventing post-unmount state mutations when the startup effect is torn down mid-fetch.

- **`startup-phase-poll.ts`**: One-line cancellation guard inserted before any first-run state writes, consistent with the existing guards earlier in the same function.
- **`startup-phase-poll.test.ts`**: New regression test sets `cancelled.current` inside the `getFirstRunOptions` mock and asserts `setFirstRunOptions` and `BACKEND_REACHED` do not fire.

<h3>Confidence Score: 3/5</h3>

The core fix is correct, but the same post-unmount write race remains open at the scanProviderCredentials await that follows within the same code path.

The new guard closes the Promise.all window cleanly and the regression test validates it well. However, setFirstRunOptions is called before await scanProviderCredentials(), and there is no cancelled.current check after that second await completes. If the effect is torn down during the provider-credential scan, applyFirstRunResumeFields, setSetupStep, setFirstRunLoading, and the BACKEND_REACHED dispatch still fire on a dead effect — the same class of bug the PR set out to eliminate.

packages/ui/src/state/startup-phase-poll.ts lines 411–432 — the section after await scanProviderCredentials() needs a second cancellation guard.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/ui/src/state/startup-phase-poll.ts | Adds cancelled.current guard after Promise.all resolves in the first-run options branch; the same race window still exists around the subsequent await scanProviderCredentials() call. |
| packages/ui/src/state/startup-phase-poll.test.ts | Adds a targeted regression test that flips cancelled.current inside the getFirstRunOptions mock and asserts neither setFirstRunOptions nor BACKEND_REACHED fire; test design and assertions are correct for the specific race it covers. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[runPollingBackend enters first-run branch] --> B[await Promise.all getFirstRunOptions + getConfig]
    B --> C{cancelled.current?\n✅ NEW GUARD}
    C -- true --> D[return — no state mutation]
    C -- false --> E[setFirstRunOptions]
    E --> F{rf.firstRunProvider?}
    F -- false --> G[await scanProviderCredentials]
    G --> H[⚠️ no cancelled guard here]
    H --> I[applyFirstRunResumeFields\nsetSetupStep\nsetFirstRunLoading\ndispatch BACKEND_REACHED]
    F -- true --> I
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/ui/src/state/startup-phase-poll.ts`, line 411-432 ([link](https://github.com/elizaos/eliza/blob/ae099adec3c8581507cfe2794eece37624b27e83/packages/ui/src/state/startup-phase-poll.ts#L411-L432)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing cancellation guard after `scanProviderCredentials` await**

   The new guard at line 395 stops post-`Promise.all` mutations when the effect has already been torn down, but `setFirstRunOptions` (line 402) is called *before* the `await scanProviderCredentials()` at line 411. If the effect is cancelled during that provider-credential scan, `applyFirstRunResumeFields`, `deps.setSetupStep`, `deps.setFirstRunLoading(false)`, and `dispatch({ type: "BACKEND_REACHED" })` still execute on a dead effect — the same race the PR description calls out, just at a later await point. A `if (cancelled.current) return;` after the try/catch block at line 419 (before `applyFirstRunResumeFields`) would close this gap.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(ui): bail out of startup polling if ..."](https://github.com/elizaos/eliza/commit/ae099adec3c8581507cfe2794eece37624b27e83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34788804)</sub>

<!-- /greptile_comment -->