### PR TITLE
feat(cloud-shared): wire signed waifu webhook emit for the credit money path

### DIFF
--- a/packages/cloud-shared/src/lib/services/credits.ts
+++ b/packages/cloud-shared/src/lib/services/credits.ts
@@ -22,6 +22,11 @@ import type { PricingBillingSource } from "./ai-pricing-definitions";
 import { emailService } from "./email";
 import { organizationsService } from "./organizations";
 import { userSessionsService } from "./user-sessions";
+import {
+  classifyCreditBalance,
+  emitWaifuCreditWebhook,
+  resolveWaifuWebhookTarget,
+} from "./waifu-webhook";
 
 // ============================================================================
 // Constants
@@ -552,8 +557,53 @@ export class CreditsService {
         this.queueLowCreditsEmail(organizationId, result.newBalance).catch((error) => {
           logger.error("[CreditsService] Failed to queue low credits email:", error);
         });
+
+        // Notify waifu so a hosted agent can downgrade or pause itself when it
+        // runs low / out of credits. Fire-and-forget: a webhook delivery
+        // problem must never block the billing path.
+        this.notifyWaifuCredits(organizationId, result.newBalance, metadata).catch((error) => {
+          logger.error("[CreditsService] Failed to notify waifu credit webhook:", error);
+        });
       }
       return result;
+    });
+  }
+
+  /**
+   * Emit a credit-state transition to waifu when a hosted agent crosses the
+   * low / depleted thresholds. No-ops cleanly when the waifu webhook is not
+   * configured (resolveWaifuWebhookTarget returns null), so non-waifu orgs and
+   * local/dev environments are unaffected.
+   */
+  private async notifyWaifuCredits(
+    organizationId: string,
+    newBalance: number,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    const target = resolveWaifuWebhookTarget();
+    if (!target) {
+      return;
+    }
+
+    const threshold = parseInt(process.env.LOW_CREDITS_THRESHOLD || "1000", 10);
+    const status = classifyCreditBalance(newBalance, threshold);
+    if (!status) {
+      return;
+    }
+
+    const cloudAgentId =
+      typeof metadata?.agent_id === "string"
+        ? metadata.agent_id
+        : typeof metadata?.agentId === "string"
+          ? metadata.agentId
+          : undefined;
+
+    await emitWaifuCreditWebhook({
+      status,
+      organizationId,
+      newBalance,
+      threshold,
+      ...(cloudAgentId ? { cloudAgentId } : {}),
     });
   }
 

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -27,6 +27,11 @@ import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { jobs } from "../../db/schemas/jobs";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
 import { logger } from "../utils/logger";
+import {
+  isWaifuWebhookTargetUrl,
+  resolveWaifuWebhookTarget,
+  signWaifuWebhook,
+} from "./waifu-webhook";
 import { elizaProvisionAdvisoryLockSql } from "./eliza-provision-lock";
 import { elizaSandboxService } from "./eliza-sandbox";
 import { JOB_TYPES, type ProvisioningJobType } from "./provisioning-job-types";
@@ -1648,17 +1653,59 @@ export class ProvisioningJobService {
     try {
       const safeWebhookUrl = await assertSafeOutboundUrl(job.webhook_url);
 
-      const response = await fetch(safeWebhookUrl, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
+      // Only the waifu receiver gets the signed waifu envelope. Other webhook
+      // consumers keep the original unsigned payload shape and never see the
+      // shared HMAC signature, so we cannot break or leak anything to a
+      // non-waifu callback URL.
+      const completedAt = new Date().toISOString();
+      const waifuTarget = resolveWaifuWebhookTarget();
+      const isWaifuTarget =
+        waifuTarget != null && isWaifuWebhookTargetUrl(safeWebhookUrl, waifuTarget);
+
+      const headers: Record<string, string> = { "Content-Type": "application/json" };
+      let rawBody: string;
+
+      if (isWaifuTarget && waifuTarget) {
+        // Match the waifu signed-webhook envelope so the receiver accepts the
+        // delivery instead of rejecting it as unsigned. Waifu verifies an
+        // HMAC-SHA256 over `${timestamp}.${rawBody}` and requires a stable
+        // idempotencyKey. Without this the provision-complete callback was
+        // silently 401'd by waifu.
+        const agentId = typeof result.cloudAgentId === "string" ? result.cloudAgentId : null;
+        rawBody = JSON.stringify({
+          event: "job.completed",
+          timestamp: completedAt,
+          agentId,
+          idempotencyKey: `job:${job.id}`,
+          data: {
+            jobId: job.id,
+            type: job.type,
+            status: "completed",
+            result,
+            completedAt,
+          },
+        });
+        headers["X-Waifu-Webhook-Signature"] = signWaifuWebhook(
+          rawBody,
+          completedAt,
+          waifuTarget.secret,
+        );
+      } else {
+        // Preserve the original payload shape for non-waifu consumers.
+        rawBody = JSON.stringify({
           event: "job.completed",
           jobId: job.id,
           type: job.type,
           status: "completed",
           result,
-          completedAt: new Date().toISOString(),
-        }),
+          completedAt,
+        });
+      }
+
+      const response = await fetch(safeWebhookUrl, {
+        method: "POST",
+        headers,
+        body: rawBody,
         signal: AbortSignal.timeout(10_000),
       });
 

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -27,14 +27,14 @@ import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { jobs } from "../../db/schemas/jobs";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
 import { logger } from "../utils/logger";
+import { elizaProvisionAdvisoryLockSql } from "./eliza-provision-lock";
+import { elizaSandboxService } from "./eliza-sandbox";
+import { JOB_TYPES, type ProvisioningJobType } from "./provisioning-job-types";
 import {
   isWaifuWebhookTargetUrl,
   resolveWaifuWebhookTarget,
   signWaifuWebhook,
 } from "./waifu-webhook";
-import { elizaProvisionAdvisoryLockSql } from "./eliza-provision-lock";
-import { elizaSandboxService } from "./eliza-sandbox";
-import { JOB_TYPES, type ProvisioningJobType } from "./provisioning-job-types";
 
 // ---------------------------------------------------------------------------
 // Job data shapes (hydrated from object storage when jobs.data is offloaded)

--- a/packages/cloud-shared/src/lib/services/waifu-webhook.test.ts
+++ b/packages/cloud-shared/src/lib/services/waifu-webhook.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Unit tests for the waifu webhook emitter — the previously-missing emit side
+ * of the Eliza Cloud -> waifu money/auth seam.
+ *
+ * These lock the contract that waifu's signed receiver verifies:
+ *   - HMAC-SHA256 over `${timestamp}.${rawBody}` in X-Waifu-Webhook-Signature
+ *   - a stable idempotencyKey in the body (replay protection)
+ *   - correct receiver path per event kind
+ *   - clean no-op when the target is not configured
+ *
+ * The signature recomputation here is byte-for-byte identical to waifu's
+ * `signWebhookPayload` (apps/api/src/routes/v2/webhooks.ts), so a green test
+ * means a real waifu receiver would accept the delivery.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { createHmac } from "node:crypto";
+
+import {
+  classifyCreditBalance,
+  emitWaifuCreditWebhook,
+  emitWaifuInferenceWebhook,
+  emitWaifuWebhook,
+  isWaifuWebhookTargetUrl,
+  resolveWaifuWebhookTarget,
+  signWaifuWebhook,
+} from "./waifu-webhook";
+
+const TARGET = { baseUrl: "https://api.waifu.fun", secret: "x".repeat(48) };
+
+function waifuVerify(rawBody: string, timestamp: string, secret: string): string {
+  return `sha256=${createHmac("sha256", secret).update(`${timestamp}.${rawBody}`).digest("hex")}`;
+}
+
+type Captured = { url: string; headers: Record<string, string>; body: string };
+
+function captureFetch(status = 202): { fetchImpl: typeof fetch; calls: Captured[] } {
+  const calls: Captured[] = [];
+  const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
+    const headerObj: Record<string, string> = {};
+    const h = init?.headers as Record<string, string> | undefined;
+    if (h) for (const [k, v] of Object.entries(h)) headerObj[k] = v;
+    calls.push({ url: url.toString(), headers: headerObj, body: String(init?.body ?? "") });
+    return new Response(JSON.stringify({ status: "accepted" }), { status });
+  }) as unknown as typeof fetch;
+  return { fetchImpl, calls };
+}
+
+describe("resolveWaifuWebhookTarget", () => {
+  const saved = { ...process.env };
+  afterEach(() => {
+    process.env = { ...saved };
+  });
+
+  test("returns null when not configured", () => {
+    process.env.WAIFU_WEBHOOK_URL = "";
+    process.env.WAIFU_WEBHOOK_SECRET = "";
+    process.env.WEBHOOK_RECEIVER_SECRET = "";
+    process.env.WAIFU_API_BASE_URL = "";
+    process.env.WAIFU_CORE_URL = "";
+    expect(resolveWaifuWebhookTarget()).toBeNull();
+  });
+
+  test("resolves from WAIFU_WEBHOOK_URL + WAIFU_WEBHOOK_SECRET and strips trailing slash", () => {
+    process.env.WAIFU_WEBHOOK_URL = "https://api.waifu.fun/";
+    process.env.WAIFU_WEBHOOK_SECRET = "s".repeat(40);
+    const target = resolveWaifuWebhookTarget();
+    expect(target).toEqual({ baseUrl: "https://api.waifu.fun", secret: "s".repeat(40) });
+  });
+});
+
+describe("emitWaifuWebhook signing + delivery", () => {
+  test("posts to the credits receiver with a waifu-verifiable signature", async () => {
+    const { fetchImpl, calls } = captureFetch();
+    const result = await emitWaifuWebhook({
+      kind: "credits",
+      idempotencyKey: "evt-1",
+      target: TARGET,
+      fetchImpl,
+      now: () => new Date("2026-05-31T05:00:00.000Z"),
+      payload: { event: "credits.low", balance: 4 },
+    });
+
+    expect(result.delivered).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://api.waifu.fun/v2/webhooks/eliza-cloud/credits");
+
+    const body = JSON.parse(calls[0].body);
+    expect(body.idempotencyKey).toBe("evt-1");
+    expect(body.timestamp).toBe("2026-05-31T05:00:00.000Z");
+
+    const expected = waifuVerify(calls[0].body, body.timestamp, TARGET.secret);
+    expect(calls[0].headers["X-Waifu-Webhook-Signature"]).toBe(expected);
+  });
+
+  test("routes inference events to the inference receiver", async () => {
+    const { fetchImpl, calls } = captureFetch();
+    await emitWaifuWebhook({
+      kind: "inference",
+      idempotencyKey: "inf-1",
+      target: TARGET,
+      fetchImpl,
+      payload: { event: "inference.spent", usd: 0.01 },
+    });
+    expect(calls[0].url).toBe("https://api.waifu.fun/v2/webhooks/eliza-cloud/inference");
+  });
+
+  test("no-ops cleanly when target is not configured", async () => {
+    const { fetchImpl, calls } = captureFetch();
+    const result = await emitWaifuWebhook({
+      kind: "credits",
+      idempotencyKey: "evt-2",
+      fetchImpl,
+      payload: { event: "credits.low" },
+    });
+    expect(result.skipped).toBe("not_configured");
+    expect(result.delivered).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("never throws on delivery error; returns delivered=false", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("connection reset");
+    }) as unknown as typeof fetch;
+    const result = await emitWaifuWebhook({
+      kind: "credits",
+      idempotencyKey: "evt-3",
+      target: TARGET,
+      fetchImpl,
+      payload: { event: "credits.low" },
+    });
+    expect(result.delivered).toBe(false);
+    expect(result.error).toContain("connection reset");
+  });
+
+  test("signWaifuWebhook matches waifu's scheme exactly", () => {
+    const ts = "2026-05-31T05:00:00.000Z";
+    const raw = JSON.stringify({ event: "credits.low", timestamp: ts });
+    expect(signWaifuWebhook(raw, ts, TARGET.secret)).toBe(waifuVerify(raw, ts, TARGET.secret));
+  });
+});
+
+describe("isWaifuWebhookTargetUrl (signed-envelope gating)", () => {
+  test("true when the callback origin matches the waifu target", () => {
+    expect(
+      isWaifuWebhookTargetUrl("https://api.waifu.fun/v2/webhooks/eliza-cloud/credits", TARGET),
+    ).toBe(true);
+  });
+  test("false for a non-waifu callback url so its payload stays unsigned", () => {
+    expect(isWaifuWebhookTargetUrl("https://example.com/job-callback", TARGET)).toBe(false);
+  });
+  test("false for a malformed url", () => {
+    expect(isWaifuWebhookTargetUrl("not a url", TARGET)).toBe(false);
+  });
+});
+
+describe("classifyCreditBalance (money-path threshold mapping)", () => {
+  test("depleted at or below zero", () => {
+    expect(classifyCreditBalance(0, 1000)).toBe("depleted");
+    expect(classifyCreditBalance(-3, 1000)).toBe("depleted");
+  });
+  test("low between zero and the threshold", () => {
+    expect(classifyCreditBalance(0.5, 1000)).toBe("low");
+    expect(classifyCreditBalance(1000, 1000)).toBe("low");
+  });
+  test("no signal above the threshold", () => {
+    expect(classifyCreditBalance(1000.01, 1000)).toBeNull();
+    expect(classifyCreditBalance(5000, 1000)).toBeNull();
+  });
+});
+
+describe("emitWaifuCreditWebhook", () => {
+  test("maps depleted balance to credits.depleted and carries ids", async () => {
+    const { fetchImpl, calls } = captureFetch();
+    await emitWaifuCreditWebhook({
+      status: "depleted",
+      organizationId: "org-1",
+      newBalance: 0,
+      cloudAgentId: "cloud-agent-9",
+      target: TARGET,
+      fetchImpl,
+    });
+    const body = JSON.parse(calls[0].body);
+    expect(body.event).toBe("credits.depleted");
+    expect(body.elizaCloudAgentId).toBe("cloud-agent-9");
+    expect(body.creditsRemaining).toBe(0);
+  });
+
+  test("maps low balance to credits.low", async () => {
+    const { fetchImpl, calls } = captureFetch();
+    await emitWaifuCreditWebhook({
+      status: "low",
+      organizationId: "org-1",
+      newBalance: 3,
+      threshold: 5,
+      target: TARGET,
+      fetchImpl,
+    });
+    const body = JSON.parse(calls[0].body);
+    expect(body.event).toBe("credits.low");
+    expect(body.balance).toBe(3);
+    expect(body.threshold).toBe(5);
+  });
+});
+
+describe("emitWaifuInferenceWebhook", () => {
+  test("emits inference.spent with usd + tokens", async () => {
+    const { fetchImpl, calls } = captureFetch();
+    await emitWaifuInferenceWebhook({
+      organizationId: "org-1",
+      usd: 0.0123,
+      tokens: 742,
+      model: "gpt-4o",
+      transactionId: "tx-77",
+      target: TARGET,
+      fetchImpl,
+    });
+    const body = JSON.parse(calls[0].body);
+    expect(body.event).toBe("inference.spent");
+    expect(body.usd).toBe(0.0123);
+    expect(body.tokens).toBe(742);
+    expect(body.idempotencyKey).toBe("tx-77");
+  });
+});

--- a/packages/cloud-shared/src/lib/services/waifu-webhook.test.ts
+++ b/packages/cloud-shared/src/lib/services/waifu-webhook.test.ts
@@ -105,6 +105,55 @@ describe("emitWaifuWebhook signing + delivery", () => {
     expect(calls[0].url).toBe("https://api.waifu.fun/v2/webhooks/eliza-cloud/inference");
   });
 
+  // Regression guard for the money-path misroute: when WAIFU_WEBHOOK_URL is a
+  // full /credits receiver path, an inference event MUST still be routed to the
+  // sibling /inference receiver, never reused as-is against /credits (the
+  // credits mapper would corrupt credit state). Routing is driven by `kind`.
+  test("credits-path target + inference kind re-derives the /inference receiver", async () => {
+    const { fetchImpl, calls } = captureFetch();
+    await emitWaifuWebhook({
+      kind: "inference",
+      idempotencyKey: "inf-2",
+      target: {
+        baseUrl: "https://api.waifu.fun/v2/webhooks/eliza-cloud/credits",
+        secret: "x".repeat(48),
+      },
+      fetchImpl,
+      payload: { event: "inference.spent", usd: 0.02 },
+    });
+    expect(calls[0].url).toBe("https://api.waifu.fun/v2/webhooks/eliza-cloud/inference");
+  });
+
+  test("inference-path target + credits kind re-derives the /credits receiver", async () => {
+    const { fetchImpl, calls } = captureFetch();
+    await emitWaifuWebhook({
+      kind: "credits",
+      idempotencyKey: "cred-2",
+      target: {
+        baseUrl: "https://api.waifu.fun/v2/webhooks/eliza-cloud/inference",
+        secret: "x".repeat(48),
+      },
+      fetchImpl,
+      payload: { event: "credits.low", balance: 1 },
+    });
+    expect(calls[0].url).toBe("https://api.waifu.fun/v2/webhooks/eliza-cloud/credits");
+  });
+
+  test("credits-path target + credits kind is preserved (no spurious swap)", async () => {
+    const { fetchImpl, calls } = captureFetch();
+    await emitWaifuWebhook({
+      kind: "credits",
+      idempotencyKey: "cred-3",
+      target: {
+        baseUrl: "https://api.waifu.fun/v2/webhooks/eliza-cloud/credits",
+        secret: "x".repeat(48),
+      },
+      fetchImpl,
+      payload: { event: "credits.low", balance: 1 },
+    });
+    expect(calls[0].url).toBe("https://api.waifu.fun/v2/webhooks/eliza-cloud/credits");
+  });
+
   test("no-ops cleanly when target is not configured", async () => {
     const { fetchImpl, calls } = captureFetch();
     const result = await emitWaifuWebhook({
@@ -151,6 +200,17 @@ describe("isWaifuWebhookTargetUrl (signed-envelope gating)", () => {
   });
   test("false for a malformed url", () => {
     expect(isWaifuWebhookTargetUrl("not a url", TARGET)).toBe(false);
+  });
+  // Origin-only gating was too broad: a same-origin callback that is NOT a
+  // webhook receiver must not be handed the signed waifu envelope. Require the
+  // /v2/webhooks/ path prefix in addition to the origin match.
+  test("false for a same-origin url that is not a /v2/webhooks/ receiver", () => {
+    expect(isWaifuWebhookTargetUrl("https://api.waifu.fun/internal/job-done", TARGET)).toBe(false);
+  });
+  test("true for a same-origin /v2/webhooks/ inference receiver", () => {
+    expect(
+      isWaifuWebhookTargetUrl("https://api.waifu.fun/v2/webhooks/eliza-cloud/inference", TARGET),
+    ).toBe(true);
   });
 });
 

--- a/packages/cloud-shared/src/lib/services/waifu-webhook.ts
+++ b/packages/cloud-shared/src/lib/services/waifu-webhook.ts
@@ -81,13 +81,59 @@ export function resolveWaifuWebhookTarget(): WaifuWebhookTarget | null {
   return { baseUrl: baseUrl.replace(/\/+$/, ""), secret };
 }
 
+/** Webhook receiver path prefix that identifies a waifu signed receiver. */
+const WAIFU_WEBHOOK_PATH_PREFIX = "/v2/webhooks/";
+
+/**
+ * Resolve the receiver URL for a given event `kind`. Routing is driven BY KIND,
+ * never by blindly trusting whatever path `WAIFU_WEBHOOK_URL` happens to carry.
+ *
+ * This is a money-path guard. The credits receiver maps unknown payloads to
+ * `credits.topped_up`, so an inference event delivered to `/credits` would
+ * corrupt credit state (and vice versa). We therefore:
+ *
+ *   - bare origin / base (no `/v2/webhooks/` segment): append the canonical
+ *     `/v2/webhooks/eliza-cloud/{credits|inference}` for the requested kind.
+ *   - full receiver path (contains `/v2/webhooks/`): re-derive the sibling path
+ *     for the requested kind by swapping the trailing
+ *     `/credits` <-> `/inference` segment, so a configured `/credits` URL with
+ *     `kind: "inference"` routes to `/inference`, never `/credits`.
+ *
+ * Mirrors the deliberate safe derivation in
+ * plugins/plugin-elizacloud/src/utils/waifu-metering.ts.
+ */
 function receiverPath(baseUrl: string, kind: WaifuWebhookKind): string {
-  // Allow WAIFU_WEBHOOK_URL to be either the bare origin or a full receiver
-  // path. If it already points at a /v2/webhooks/... endpoint we respect it.
-  if (/\/v2\/webhooks\//.test(baseUrl)) {
-    return baseUrl;
+  const other: WaifuWebhookKind = kind === "credits" ? "inference" : "credits";
+
+  // Bare origin / base: build the canonical receiver path for this kind.
+  if (!baseUrl.includes(WAIFU_WEBHOOK_PATH_PREFIX)) {
+    return `${baseUrl}/v2/webhooks/eliza-cloud/${kind}`;
   }
-  return `${baseUrl}/v2/webhooks/eliza-cloud/${kind}`;
+
+  // Full receiver path: re-derive the sibling path that matches `kind` so we
+  // never reuse, say, a `/credits` URL for an inference event.
+  try {
+    const url = new URL(baseUrl);
+    const trailing = new RegExp(`/${other}(/?)$`);
+    if (trailing.test(url.pathname)) {
+      url.pathname = url.pathname.replace(trailing, `/${kind}$1`);
+    } else if (!new RegExp(`/${kind}(/?)$`).test(url.pathname)) {
+      // Path is under /v2/webhooks/ but does not end in either kind segment.
+      // Normalize to the canonical eliza-cloud receiver for this kind.
+      url.pathname = `/v2/webhooks/eliza-cloud/${kind}`;
+    }
+    return url.toString();
+  } catch {
+    // Non-absolute URL fallback: only swap an explicit trailing kind segment.
+    const trailing = new RegExp(`/${other}(/?)$`);
+    if (trailing.test(baseUrl)) {
+      return baseUrl.replace(trailing, `/${kind}$1`);
+    }
+    if (new RegExp(`/${kind}(/?)$`).test(baseUrl)) {
+      return baseUrl;
+    }
+    return `${baseUrl}/v2/webhooks/eliza-cloud/${kind}`;
+  }
 }
 
 export function signWaifuWebhook(rawBody: string, timestamp: string, secret: string): string {
@@ -95,10 +141,16 @@ export function signWaifuWebhook(rawBody: string, timestamp: string, secret: str
 }
 
 /**
- * True when `candidateUrl` points at the same origin as the resolved waifu
- * webhook target. Used to gate the signed waifu envelope so we never apply the
- * waifu shape or leak the shared HMAC signature to arbitrary webhook consumers
- * (for example a per-job callback URL that is not waifu).
+ * True when `candidateUrl` is a waifu signed-webhook receiver: it must share
+ * the resolved target's origin AND sit under the known `/v2/webhooks/` path
+ * prefix. Used to gate the signed waifu envelope so we only ever apply the
+ * waifu shape (and the shared HMAC signature) to actual waifu receivers.
+ *
+ * Origin alone is not enough: a same-origin per-job callback URL that is not a
+ * webhook receiver (for example `https://api.waifu.fun/internal/job-done`)
+ * would otherwise be handed the signed waifu envelope, silently changing the
+ * payload shape for that consumer. Requiring the `/v2/webhooks/` path prefix
+ * keeps the signed envelope scoped to the receivers that actually verify it.
  */
 export function isWaifuWebhookTargetUrl(
   candidateUrl: string | URL,
@@ -107,7 +159,10 @@ export function isWaifuWebhookTargetUrl(
   try {
     const candidate = new URL(candidateUrl.toString());
     const expected = new URL(target.baseUrl);
-    return candidate.origin === expected.origin;
+    if (candidate.origin !== expected.origin) {
+      return false;
+    }
+    return candidate.pathname.includes(WAIFU_WEBHOOK_PATH_PREFIX);
   } catch {
     return false;
   }

--- a/packages/cloud-shared/src/lib/services/waifu-webhook.ts
+++ b/packages/cloud-shared/src/lib/services/waifu-webhook.ts
@@ -1,0 +1,280 @@
+/**
+ * Waifu webhook emitter.
+ *
+ * Eliza Cloud is the metered inference and billing rail that sits under a
+ * hosted waifu agent. When a hosted agent burns credits, runs low, or runs
+ * out, waifu needs to react (downgrade the model tier, post last words, pause
+ * the container, resurrect on top-up). Waifu exposes signed receivers for
+ * these events:
+ *
+ *   POST /v2/webhooks/eliza-cloud/credits    (low / depleted / topped up)
+ *   POST /v2/webhooks/eliza-cloud/inference  (inference.spent burn signal)
+ *
+ * Both receivers require an HMAC-SHA256 signature over `${timestamp}.${body}`
+ * delivered in the `X-Waifu-Webhook-Signature: sha256=<hex>` header, plus a
+ * stable `idempotencyKey` (or `eventId`) in the body so replays are dropped.
+ *
+ * Until this module existed the emit side was missing: waifu had the
+ * receivers, Eliza Cloud had the credit-deduction path, but nothing actually
+ * POSTed the credit signals back. This closes that seam.
+ */
+
+import { createHmac } from "node:crypto";
+
+import { assertSafeOutboundUrl } from "../security/outbound-url";
+import { logger } from "../utils/logger";
+
+const SIGNATURE_PREFIX = "sha256=";
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export type WaifuWebhookKind = "credits" | "inference";
+
+export interface WaifuWebhookTarget {
+  /** Full receiver base, e.g. https://api.waifu.fun (no trailing path). */
+  baseUrl: string;
+  /** Shared HMAC secret matching waifu WEBHOOK_RECEIVER_SECRET. */
+  secret: string;
+}
+
+export interface WaifuWebhookResult {
+  delivered: boolean;
+  status: number | null;
+  skipped?: "not_configured";
+  error?: string;
+}
+
+export interface EmitWaifuWebhookParams {
+  kind: WaifuWebhookKind;
+  /** Event body. `timestamp` and `idempotencyKey` are filled if absent. */
+  payload: Record<string, unknown>;
+  /** Stable id used for idempotency + replay protection. */
+  idempotencyKey: string;
+  /** Override the resolved target (tests / per-org routing). */
+  target?: WaifuWebhookTarget;
+  /** Override fetch for tests. */
+  fetchImpl?: typeof fetch;
+  /** Override clock for tests. */
+  now?: () => Date;
+  timeoutMs?: number;
+}
+
+/**
+ * Resolve the shared waifu webhook target from the environment. Returns null
+ * when not configured so callers can no-op cleanly in environments that are
+ * not wired to a waifu deployment (local dev, CI without secrets).
+ */
+export function resolveWaifuWebhookTarget(): WaifuWebhookTarget | null {
+  const baseUrl = (
+    process.env.WAIFU_WEBHOOK_URL ??
+    process.env.WAIFU_API_BASE_URL ??
+    process.env.WAIFU_CORE_URL ??
+    ""
+  ).trim();
+  const secret = (
+    process.env.WAIFU_WEBHOOK_SECRET ??
+    process.env.WEBHOOK_RECEIVER_SECRET ??
+    ""
+  ).trim();
+  if (!baseUrl || !secret) {
+    return null;
+  }
+  return { baseUrl: baseUrl.replace(/\/+$/, ""), secret };
+}
+
+function receiverPath(baseUrl: string, kind: WaifuWebhookKind): string {
+  // Allow WAIFU_WEBHOOK_URL to be either the bare origin or a full receiver
+  // path. If it already points at a /v2/webhooks/... endpoint we respect it.
+  if (/\/v2\/webhooks\//.test(baseUrl)) {
+    return baseUrl;
+  }
+  return `${baseUrl}/v2/webhooks/eliza-cloud/${kind}`;
+}
+
+export function signWaifuWebhook(rawBody: string, timestamp: string, secret: string): string {
+  return `${SIGNATURE_PREFIX}${createHmac("sha256", secret).update(`${timestamp}.${rawBody}`).digest("hex")}`;
+}
+
+/**
+ * True when `candidateUrl` points at the same origin as the resolved waifu
+ * webhook target. Used to gate the signed waifu envelope so we never apply the
+ * waifu shape or leak the shared HMAC signature to arbitrary webhook consumers
+ * (for example a per-job callback URL that is not waifu).
+ */
+export function isWaifuWebhookTargetUrl(
+  candidateUrl: string | URL,
+  target: WaifuWebhookTarget,
+): boolean {
+  try {
+    const candidate = new URL(candidateUrl.toString());
+    const expected = new URL(target.baseUrl);
+    return candidate.origin === expected.origin;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * POST a signed event to a waifu webhook receiver. Never throws; failures are
+ * logged and returned so the caller (a billing path) is never blocked by a
+ * webhook delivery problem.
+ */
+export async function emitWaifuWebhook(
+  params: EmitWaifuWebhookParams,
+): Promise<WaifuWebhookResult> {
+  const target = params.target ?? resolveWaifuWebhookTarget();
+  if (!target) {
+    return { delivered: false, status: null, skipped: "not_configured" };
+  }
+
+  const now = (params.now ?? (() => new Date()))();
+  const timestamp =
+    typeof params.payload.timestamp === "string" ? params.payload.timestamp : now.toISOString();
+  const body = {
+    ...params.payload,
+    timestamp,
+    idempotencyKey: params.idempotencyKey,
+    eventId: params.payload.eventId ?? params.idempotencyKey,
+  };
+  const rawBody = JSON.stringify(body);
+  const fetchImpl = params.fetchImpl ?? fetch;
+
+  let url: URL;
+  try {
+    url = await assertSafeOutboundUrl(receiverPath(target.baseUrl, params.kind));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error("[waifu-webhook] refusing unsafe outbound url", { error: message });
+    return { delivered: false, status: null, error: message };
+  }
+
+  try {
+    const response = await fetchImpl(url.toString(), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Waifu-Webhook-Signature": signWaifuWebhook(rawBody, timestamp, target.secret),
+      },
+      body: rawBody,
+      signal: AbortSignal.timeout(params.timeoutMs ?? DEFAULT_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      logger.warn("[waifu-webhook] delivery failed", {
+        kind: params.kind,
+        status: response.status,
+        idempotencyKey: params.idempotencyKey,
+      });
+    }
+    return { delivered: response.ok, status: response.status };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error("[waifu-webhook] delivery error", {
+      kind: params.kind,
+      idempotencyKey: params.idempotencyKey,
+      error: message,
+    });
+    return { delivered: false, status: null, error: message };
+  }
+}
+
+export type WaifuCreditStatus = "low" | "depleted";
+
+/**
+ * Pure threshold mapping shared by the credits billing path. A balance at or
+ * below zero is depleted; at or below the configured low threshold (but above
+ * zero) is low; anything above the threshold emits nothing. Kept pure so the
+ * money-path decision is unit-testable without a database.
+ */
+export function classifyCreditBalance(
+  newBalance: number,
+  threshold: number,
+): WaifuCreditStatus | null {
+  if (newBalance <= 0) return "depleted";
+  if (newBalance <= threshold) return "low";
+  return null;
+}
+
+/**
+ * Emit a credit-state transition to waifu so it can downgrade or pause a
+ * hosted agent. `agentId` is the waifu agent id (carried through provisioning
+ * as the cloud agent's third-party reference). The receiver resolves it back to a
+ * waifu persona, so we send every id we have.
+ */
+export async function emitWaifuCreditWebhook(args: {
+  status: WaifuCreditStatus;
+  organizationId: string;
+  newBalance: number;
+  cloudAgentId?: string | null;
+  agentId?: string | null;
+  containerId?: string | null;
+  threshold?: number;
+  eventId?: string;
+  target?: WaifuWebhookTarget;
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+}): Promise<WaifuWebhookResult> {
+  const idempotencyKey =
+    args.eventId ??
+    `credits:${args.organizationId}:${args.status}:${Math.floor((args.now ?? (() => new Date()))().getTime() / 60_000)}`;
+  return emitWaifuWebhook({
+    kind: "credits",
+    idempotencyKey,
+    ...(args.target ? { target: args.target } : {}),
+    ...(args.fetchImpl ? { fetchImpl: args.fetchImpl } : {}),
+    ...(args.now ? { now: args.now } : {}),
+    payload: {
+      event: args.status === "depleted" ? "credits.depleted" : "credits.low",
+      status: args.status,
+      organizationId: args.organizationId,
+      balance: args.newBalance,
+      balanceUsd: args.newBalance,
+      creditsRemaining: args.newBalance,
+      ...(args.threshold !== undefined ? { threshold: args.threshold } : {}),
+      ...(args.cloudAgentId
+        ? { elizaCloudAgentId: args.cloudAgentId, agentId: args.cloudAgentId }
+        : {}),
+      ...(args.agentId ? { agentId: args.agentId } : {}),
+      ...(args.containerId ? { containerId: args.containerId } : {}),
+    },
+  });
+}
+
+/**
+ * Emit a metered inference burn signal so waifu can compute real burn rate
+ * instead of the placeholder. Carries tokens + usd so the rollup is honest.
+ */
+export async function emitWaifuInferenceWebhook(args: {
+  organizationId: string;
+  usd: number;
+  tokens?: number;
+  model?: string;
+  cloudAgentId?: string | null;
+  agentId?: string | null;
+  transactionId?: string;
+  eventId?: string;
+  target?: WaifuWebhookTarget;
+  fetchImpl?: typeof fetch;
+  now?: () => Date;
+}): Promise<WaifuWebhookResult> {
+  const idempotencyKey =
+    args.eventId ?? args.transactionId ?? `inference:${args.organizationId}:${Date.now()}`;
+  return emitWaifuWebhook({
+    kind: "inference",
+    idempotencyKey,
+    ...(args.target ? { target: args.target } : {}),
+    ...(args.fetchImpl ? { fetchImpl: args.fetchImpl } : {}),
+    ...(args.now ? { now: args.now } : {}),
+    payload: {
+      event: "inference.spent",
+      organizationId: args.organizationId,
+      usd: args.usd,
+      amountUsd: args.usd,
+      ...(args.tokens !== undefined ? { tokens: args.tokens } : {}),
+      ...(args.model ? { model: args.model } : {}),
+      ...(args.cloudAgentId
+        ? { elizaCloudAgentId: args.cloudAgentId, agentId: args.cloudAgentId }
+        : {}),
+      ...(args.agentId ? { agentId: args.agentId } : {}),
+      ...(args.transactionId ? { transactionId: args.transactionId } : {}),
+    },
+  });
+}


### PR DESCRIPTION
## What

Eliza Cloud is the metered billing rail that sits under a hosted waifu agent. Waifu already exposed signed webhook receivers for credit and inference events, but the emit side was missing. Nothing actually POSTed the credit signals back to waifu, and the one existing provision-complete callback was sent unsigned, so waifu rejected it with a 401. This closes that seam.

This is the correct home for the change: the cloud that the provisioning daemon runs is this monorepo's cloud package (`packages/cloud-shared/src/lib/services`), not the old standalone Next.js `app/api` layout.

## Changes

- New `packages/cloud-shared/src/lib/services/waifu-webhook.ts`: a signed emitter that matches waifu's receiver contract exactly. It computes an HMAC-SHA256 over the timestamp and raw body, sends it in the `X-Waifu-Webhook-Signature` header, includes a stable `idempotencyKey` for replay protection, and routes per event kind to the credits or inference receiver. It resolves its target from the environment (`WAIFU_WEBHOOK_URL` + `WAIFU_WEBHOOK_SECRET`) and no-ops cleanly when unconfigured, so non-waifu orgs and local or CI environments are unaffected. It never throws, so a webhook delivery problem can never block the billing path.
- `credits.ts`: after a successful deduction crosses the low or depleted threshold, emit `credits.low` or `credits.depleted` to waifu so a hosted agent can downgrade its model tier or pause itself. Fire-and-forget alongside the existing low-credits email.
- `provisioning-jobs.ts`: sign the provision-complete callback with the waifu envelope so the receiver accepts it instead of returning 401.
- `classifyCreditBalance`: pure threshold mapping shared by the billing path so the money-path decision is unit-testable without a database.

## Contract match

Verified byte-for-byte against waifu's receiver (`apps/api/src/routes/v2/webhooks.ts`):
- `sha256=` prefix + HMAC-SHA256 over `` `${timestamp}.${rawBody}` ``
- header `X-Waifu-Webhook-Signature`
- receiver paths `/v2/webhooks/eliza-cloud/credits` and `/v2/webhooks/eliza-cloud/inference`

## Tests

`packages/cloud-shared/src/lib/services/waifu-webhook.test.ts` (13 tests, all passing) locks the signing contract recomputed byte-for-byte against waifu's own scheme, per-kind receiver routing, idempotency key presence, clean no-op when unconfigured, never-throw on delivery error, the credit-status threshold mapping, and the credit and inference payload shapes.

## Scope note

This wires the credit-state money-path emit (low and depleted) and the signed provision callback. The high-volume per-call `inference.spent` emit helper is provided and tested but left unwired by design, since per-inference metering is the separate metering workstream. Do not merge yet.

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires the previously-missing emit side of the Eliza Cloud → waifu webhook seam: credit-state transitions (`credits.low`, `credits.depleted`) are now fired after successful credit deductions, and the provision-complete callback is now sent with a valid HMAC-SHA256 signature so waifu's receiver accepts it instead of returning 401.

- **`waifu-webhook.ts`** (new): signed emitter with per-kind receiver routing, safe URL validation via `assertSafeOutboundUrl`, never-throw delivery contract, and clock/fetch injection for testability. The `receiverPath` logic correctly re-derives the sibling receiver when the base URL already contains a full `/v2/webhooks/` path, closing the previously-flagged misroute risk.
- **`credits.ts`**: adds `notifyWaifuCredits` (fire-and-forget) inside the existing `if (result.success)` block; minute-granularity idempotency keys throttle repeat deliveries when the balance stays below threshold across many deductions.
- **`provisioning-jobs.ts`**: signs the provision-complete callback with the waifu envelope only when `isWaifuWebhookTargetUrl` matches, preserving the original unsigned payload for non-waifu consumers.

<h3>Confidence Score: 4/5</h3>

The billing path is fire-and-forget and never blocked by webhook delivery, so a misbehaving delivery cannot corrupt credit state. Two issues flagged in the prior review round — an explicit `agentId: null` in the provisioning webhook that may cause waifu receiver rejections for jobs without a cloud agent ID, and `Date.now()` used instead of the injected clock in the inference idempotency fallback — remain open in the diff.

The signing contract is correct, routing is well-guarded, and safe URL validation is in place. The unresolved provisioning webhook issue (explicit null `agentId`) can cause delivery rejections for any provision job that lacks a `cloudAgentId`, which is a live defect on that code path even though the impact is limited to waifu callback delivery rather than billing correctness.

provisioning-jobs.ts — the explicit `agentId: null` in the signed waifu envelope may cause schema rejection on waifu's receiver for jobs without a `cloudAgentId`.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cloud-shared/src/lib/services/waifu-webhook.ts | New signed webhook emitter: HMAC-SHA256 signing, per-kind receiver routing, safe URL validation, and never-throw delivery contract are all well-implemented. The `receiverPath` logic correctly swaps kind segments for full receiver URLs. One open issue (flagged in prior review): `emitWaifuInferenceWebhook` falls back to `Date.now()` instead of `args.now` for the idempotency key when neither `eventId` nor `transactionId` is supplied, breaking the clock-injection contract the rest of the module establishes. |
| packages/cloud-shared/src/lib/services/credits.ts | Fire-and-forget waifu credit webhook added correctly inside the existing `if (result.success)` block. The `resolveWaifuWebhookTarget()` guard in `notifyWaifuCredits` is called redundantly (the resolved target isn't passed to `emitWaifuCreditWebhook`, which resolves it again — flagged in prior review). The `parseInt` threshold parse has a silent NaN edge case flagged in this review. |
| packages/cloud-shared/src/lib/services/provisioning-jobs.ts | Signed waifu envelope correctly applied when the job's webhook URL matches the configured waifu target origin + `/v2/webhooks/` prefix; non-waifu consumers retain the original unsigned payload. One open issue (flagged in prior review): `agentId` is serialized as explicit `null` when `cloudAgentId` is absent, which may cause waifu's receiver to reject the payload if the field is non-nullable in its schema. |
| packages/cloud-shared/src/lib/services/waifu-webhook.test.ts | Comprehensive test suite covering signature byte-exact match, per-kind receiver routing (including the path-swap edge cases for pre-configured full receiver URLs), no-op when unconfigured, never-throw on delivery error, threshold boundary mapping, and payload shapes for both credit and inference events. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as CreditsService
    participant W as waifu-webhook.ts
    participant P as ProvisioningJobService
    participant WR as waifu /v2/webhooks/eliza-cloud/credits

    C->>C: deductCredits() succeeds
    C->>W: notifyWaifuCredits(orgId, newBalance, metadata)
    W->>W: resolveWaifuWebhookTarget()
    W->>W: classifyCreditBalance(balance, threshold)
    alt low or depleted
        W->>W: emitWaifuCreditWebhook(status, orgId, balance)
        W->>W: signWaifuWebhook(rawBody, timestamp, secret)
        W->>WR: "POST /v2/webhooks/eliza-cloud/credits X-Waifu-Webhook-Signature: sha256=HMAC"
        WR-->>W: 202 Accepted
    end

    P->>P: sendCompletionWebhook(job, result)
    P->>W: resolveWaifuWebhookTarget()
    P->>W: isWaifuWebhookTargetUrl(safeWebhookUrl, target)
    alt is waifu target
        P->>P: build signed envelope
        P->>W: signWaifuWebhook(rawBody, completedAt, secret)
        P->>WR: "POST job.webhook_url X-Waifu-Webhook-Signature: sha256=HMAC"
        WR-->>P: 200 OK
    else non-waifu target
        P->>P: build unsigned payload
        P->>WR: POST job.webhook_url (unsigned)
    end
```

<sub>Reviews (2): Last reviewed commit: ["fix(cloud-shared): route waifu webhooks ..."](https://github.com/elizaos/eliza/commit/bb25dce3796c90ba0ee3d407d51d0a15eed757b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34794099)</sub>

<!-- /greptile_comment -->