### PR TITLE
feat(orchestrator): live Claude-Code-style coding workbench (streaming, diffs, stop, SSE)

### DIFF
--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -995,6 +995,12 @@ declare module "./client-base" {
       taskId: string,
       options?: { cursor?: string; limit?: number },
     ): Promise<CodingAgentTaskPage<CodingAgentTaskEventRecord>>;
+    /**
+     * Subscribe to a task's live change stream (SSE). Invokes `onChange` each
+     * time the task room mutates so the caller can refetch the tail. Returns an
+     * unsubscribe function. No-op (returns a noop) where EventSource is absent.
+     */
+    streamOrchestratorTask(taskId: string, onChange: () => void): () => void;
     updateOrchestratorTask(
       taskId: string,
       input: CodingAgentUpdateTaskInput,
@@ -3743,6 +3749,29 @@ ElizaClient.prototype.listOrchestratorTaskEvents = function (
   return this.fetch<CodingAgentTaskPage<CodingAgentTaskEventRecord>>(
     `/api/orchestrator/tasks/${encodeURIComponent(taskId)}/events${qs ? `?${qs}` : ""}`,
   );
+};
+
+ElizaClient.prototype.streamOrchestratorTask = function (
+  this: ElizaClient,
+  taskId,
+  onChange,
+) {
+  if (typeof EventSource === "undefined") return () => {};
+  const url = `${this.baseUrl || ""}/api/orchestrator/tasks/${encodeURIComponent(
+    taskId,
+  )}/stream`;
+  const source = new EventSource(url);
+  source.onmessage = (event) => {
+    try {
+      const data = JSON.parse(event.data);
+      // The stream pings `{type:"change"}` on every room mutation; the caller
+      // refetches the tail. `ready` and heartbeat comments are ignored.
+      if (data && data.type === "change") onChange();
+    } catch {
+      // ignore non-JSON frames
+    }
+  };
+  return () => source.close();
 };
 
 ElizaClient.prototype.pauseAllOrchestratorTasks = async function (

--- a/packages/ui/src/components/pages/ViewManagerPage.tsx
+++ b/packages/ui/src/components/pages/ViewManagerPage.tsx
@@ -247,7 +247,7 @@ function ViewSection({
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
         {views.map((view) => (
           <ViewCard
-            key={view.id}
+            key={`${view.viewType ?? "gui"}:${view.id}`}
             view={view}
             onClick={onViewClick}
             onPin={onViewPin}
@@ -281,7 +281,7 @@ function TopViewsSection({
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         {views.map((view) => (
           <ViewCard
-            key={view.id}
+            key={`${view.viewType ?? "gui"}:${view.id}`}
             view={view}
             onClick={onViewClick}
             onPin={onViewPin}

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/orchestrator-task-service.test.ts
@@ -421,12 +421,16 @@ describe("OrchestratorTaskService — lifecycle", () => {
     expect(await service.postUserMessage("missing", "x")).toBeNull();
   });
 
-  it("records a posted message with no forwarding when no session is live", async () => {
+  it("auto-spawns a coding agent when a message is posted with no session live", async () => {
     const acp = new FakeAcp();
     const service = makeService(acp);
     const { id } = await service.createTask(createInput());
     const result = must(await service.postUserMessage(id, "hello"), "post");
-    expect(result.forwardedTo).toEqual([]);
+    // Parity: messaging a task with no live agent "just works" — it spawns one
+    // (the default vendored opencode backend) to act on the message, rather than
+    // silently recording it with nowhere to go.
+    expect(result.forwardedTo).toEqual(["auto-spawned"]);
+    expect(acp.spawnArgs).toHaveLength(1);
     expect(acp.sent).toHaveLength(0);
   });
 
@@ -672,7 +676,9 @@ describe("OrchestratorTaskService — usage telemetry", () => {
       cacheTokens: 0,
     });
     const usage = must(await service.getUsage(taskId), "usage");
-    expect(must(usage.byProvider[0], "provider").provider).toBe("codex");
+    // The default spawn framework is the vendored opencode backend, so a
+    // usage frame that omits its provider is attributed to that session.
+    expect(must(usage.byProvider[0], "provider").provider).toBe("opencode");
   });
 
   it("ignores empty usage frames", async () => {

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -236,6 +236,44 @@ async function dispatchOrchestratorRoutes(
       return true;
     }
 
+    // GET /tasks/:taskId/stream — Server-Sent Events. Pushes a lightweight
+    // "change" ping whenever the task's room mutates (a message, tool event,
+    // status, or usage write), so the workbench refreshes live instead of
+    // polling. The client refetches the room tail on each ping.
+    if (method === "GET" && sub === "stream" && segments.length === 2) {
+      const task = await service.getTask(taskId);
+      if (!task) {
+        sendError(res, "Task not found", 404);
+        return true;
+      }
+      res.writeHead(200, {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "X-Accel-Buffering": "no",
+      });
+      const send = (payload: Record<string, unknown>) => {
+        if (!res.writableEnded)
+          res.write(`data: ${JSON.stringify(payload)}\n\n`);
+      };
+      send({ type: "ready", at: Date.now() });
+      const unsubscribe = service.subscribeTaskChanges(taskId, () =>
+        send({ type: "change", at: Date.now() }),
+      );
+      // Comment heartbeat keeps the connection alive through proxies/idle.
+      const heartbeat = setInterval(() => {
+        if (!res.writableEnded) res.write(": ping\n\n");
+      }, 20_000);
+      const cleanup = () => {
+        clearInterval(heartbeat);
+        unsubscribe();
+        if (!res.writableEnded) res.end();
+      };
+      req.on("close", cleanup);
+      req.on("error", cleanup);
+      return true;
+    }
+
     // PATCH /tasks/:taskId
     if (method === "PATCH" && segments.length === 1) {
       const body = await parseBody(req).catch(() => null);

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -51,7 +51,10 @@ import {
   type UsageState,
 } from "./orchestrator-task-types.js";
 import type { ApprovalPreset } from "./types.js";
-import { resolveAllowedWorkdir } from "./workdir-validation.js";
+import {
+  ensureTaskWorkdir,
+  resolveAllowedWorkdir,
+} from "./workdir-validation.js";
 
 type RuntimeLike = IAgentRuntime & {
   logger?: Partial<
@@ -755,6 +758,21 @@ export class OrchestratorTaskService extends Service {
           });
         }
       }
+    } else if (acp) {
+      // No active coding agent — auto-spawn one to work on the message so
+      // messaging the orchestrator "just works" (parity with claude/codex):
+      // the default framework (opencode + Cerebras) into a per-task workdir.
+      try {
+        await this.spawnAgentForTask(taskId, {
+          task: content,
+          workdir: await ensureTaskWorkdir(taskId),
+        });
+        forwardedTo.push("auto-spawned");
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        failedTo.push({ sessionId: "(auto-spawn)", error });
+        this.log("warn", "auto-spawn on user message failed", { error });
+      }
     }
     return { recorded: true, forwardedTo, failedTo };
   }
@@ -817,7 +835,10 @@ export class OrchestratorTaskService extends Service {
     });
 
     const result = await acp.spawnSession({
-      agentType: opts.framework ?? policy.preferredFramework,
+      // Default the orchestrator's coding agent to the vendored opencode
+      // backend (auto-detects the user's Cerebras key) rather than the
+      // unimplemented "elizaos" native default, which has no ACP command.
+      agentType: opts.framework ?? policy.preferredFramework ?? "opencode",
       workdir,
       initialTask: goalPrompt,
       model: opts.model ?? policy.model,

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -320,6 +320,43 @@ export class OrchestratorTaskService extends Service {
     this.started = false;
   }
 
+  // ---- live change bus ---------------------------------------------------
+  // A lightweight per-task pub/sub so the SSE stream route can push the
+  // workbench a "something changed" ping the instant a message/event/usage/
+  // status is written — replacing poll latency with near-live updates. The
+  // payload is intentionally coarse (just a ping); the client refetches the
+  // room tail, which keeps this decoupled from the record shapes.
+  private readonly changeListeners = new Map<string, Set<() => void>>();
+
+  /** Subscribe to change pings for a task. Returns an unsubscribe function. */
+  subscribeTaskChanges(taskId: string, listener: () => void): () => void {
+    let listeners = this.changeListeners.get(taskId);
+    if (!listeners) {
+      listeners = new Set();
+      this.changeListeners.set(taskId, listeners);
+    }
+    listeners.add(listener);
+    return () => {
+      const set = this.changeListeners.get(taskId);
+      if (!set) return;
+      set.delete(listener);
+      if (set.size === 0) this.changeListeners.delete(taskId);
+    };
+  }
+
+  private emitChange(taskId: string): void {
+    const listeners = this.changeListeners.get(taskId);
+    if (!listeners) return;
+    for (const listener of listeners) {
+      // A broken subscriber must never break a write path.
+      try {
+        listener();
+      } catch {
+        // ignore
+      }
+    }
+  }
+
   // ---- event bridge ------------------------------------------------------
 
   private async onSessionEvent(
@@ -341,6 +378,7 @@ export class OrchestratorTaskService extends Service {
         createdAt: nowIso(),
       });
       await this.applySessionEvent(taskId, sessionId, event, data);
+      this.emitChange(taskId);
     } catch (err) {
       this.log("warn", "failed to record session event", {
         sessionId,
@@ -511,6 +549,7 @@ export class OrchestratorTaskService extends Service {
       metadata: input.metadata ?? {},
       createdAt: nowIso(),
     });
+    this.emitChange(taskId);
   }
 
   private async resolveTaskId(sessionId: string): Promise<string | undefined> {

--- a/plugins/plugin-agent-orchestrator/src/services/workdir-validation.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/workdir-validation.ts
@@ -1,9 +1,24 @@
-import { realpath } from "node:fs/promises";
+import { mkdir, realpath } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 
 function isInside(parent: string, candidate: string): boolean {
   return candidate === parent || candidate.startsWith(`${parent}${path.sep}`);
+}
+
+/**
+ * Default per-task workdir for an auto-spawned coding agent:
+ * `~/.eliza/workspaces/<taskId>`, created if missing. Always inside the allowed
+ * workspace base (see {@link resolveAllowedWorkdir}), so messaging a task can
+ * spawn an agent without a caller-supplied workdir — the parity-with-claude/codex
+ * "just message it and it works" path relies on this.
+ */
+export async function ensureTaskWorkdir(taskId: string): Promise<string> {
+  const dir = path.resolve(
+    path.join(os.homedir(), ".eliza", "workspaces", taskId),
+  );
+  await mkdir(dir, { recursive: true });
+  return dir;
 }
 
 export async function resolveAllowedWorkdir(

--- a/plugins/plugin-agent-orchestrator/src/setup-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/setup-routes.ts
@@ -96,6 +96,7 @@ const CODING_AGENT_ROUTE_PATHS: Array<{ type: string; path: string }> = [
   { type: "POST", path: "/api/orchestrator/tasks/:taskId/messages" },
   { type: "GET", path: "/api/orchestrator/tasks/:taskId/events" },
   { type: "GET", path: "/api/orchestrator/tasks/:taskId/usage" },
+  { type: "GET", path: "/api/orchestrator/tasks/:taskId/stream" },
   { type: "POST", path: "/api/orchestrator/tasks/:taskId/agents" },
   {
     type: "POST",

--- a/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-diff.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-diff.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { lineDiff } from "../../src/orchestrator-diff";
+
+const compact = (old: string, next: string) =>
+  lineDiff(old, next).map(
+    (r) => `${r.type[0]}${r.oldLine ?? "_"}:${r.newLine ?? "_"} ${r.text}`,
+  );
+
+describe("lineDiff", () => {
+  it("marks every line context when unchanged", () => {
+    const rows = lineDiff("a\nb\nc", "a\nb\nc");
+    expect(rows.every((r) => r.type === "context")).toBe(true);
+    expect(rows.map((r) => [r.oldLine, r.newLine])).toEqual([
+      [1, 1],
+      [2, 2],
+      [3, 3],
+    ]);
+  });
+
+  it("aligns a single-line change as remove+add around shared context", () => {
+    expect(compact("a\nb\nc", "a\nB\nc")).toEqual([
+      "c1:1 a",
+      "r2:_ b",
+      "a_:2 B",
+      "c3:3 c",
+    ]);
+  });
+
+  it("represents an insertion as an addition between context lines", () => {
+    expect(compact("a\nb\nc", "a\nb\nX\nc")).toEqual([
+      "c1:1 a",
+      "c2:2 b",
+      "a_:3 X",
+      "c3:4 c",
+    ]);
+  });
+
+  it("represents a deletion as a removal between context lines", () => {
+    expect(compact("a\nb\nc", "a\nc")).toEqual(["c1:1 a", "r2:_ b", "c3:2 c"]);
+  });
+
+  it("keeps old and new line numbers independent across mixed edits", () => {
+    const rows = lineDiff(
+      "one\ntwo\nthree\nfour",
+      "one\nTWO\nthree\nfour\nfive",
+    );
+    const adds = rows.filter((r) => r.type === "add").map((r) => r.text);
+    const removes = rows.filter((r) => r.type === "remove").map((r) => r.text);
+    expect(removes).toEqual(["two"]);
+    expect(adds).toEqual(["TWO", "five"]);
+    // last context/added line carries new line number 5
+    expect(rows.at(-1)).toMatchObject({
+      type: "add",
+      newLine: 5,
+      text: "five",
+    });
+  });
+});

--- a/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
@@ -10,7 +10,6 @@ import {
   type CodingAgentTaskThreadDetail,
   type CodingAgentTaskUsageSummary,
   client,
-  EmptyWidgetState,
   useApp,
 } from "@elizaos/ui";
 import {
@@ -34,7 +33,6 @@ import {
   Gauge,
   GitFork,
   Layers,
-  ListTodo,
   type LucideIcon,
   OctagonX,
   PanelRightOpen,
@@ -680,38 +678,32 @@ function renderCost(
     : value;
 }
 
-function StatChip({
-  label,
+/** A vertical hairline divider between header summary segments (the token kit
+ * has no Separator export, so this is a thin local primitive). */
+function HeaderDivider() {
+  return <span aria-hidden className="h-3.5 w-px shrink-0 bg-border" />;
+}
+
+/** One labeled count in the header summary — a baseline-aligned number + tiny
+ * uppercase label, no pill/border (replaces the old cryptic icon chips). */
+function HeaderStat({
   value,
-  tone = "neutral",
-  icon,
+  label,
+  toneClass = "text-txt-strong",
 }: {
-  label: string;
   value: string;
-  tone?: "neutral" | "ok" | "warn" | "danger" | "accent";
-  icon?: ReactNode;
+  label: string;
+  toneClass?: string;
 }) {
-  const toneClass =
-    tone === "ok"
-      ? "text-ok"
-      : tone === "warn"
-        ? "text-warn"
-        : tone === "danger"
-          ? "text-danger"
-          : tone === "accent"
-            ? "text-accent"
-            : "text-txt";
   return (
-    <div
-      className="flex shrink-0 items-center gap-1.5 rounded-md border border-border/50 bg-bg-accent/30 px-2 py-1"
-      title={label}
-      aria-label={label}
-    >
-      {icon ? <span className="shrink-0 text-muted">{icon}</span> : null}
-      <span className={`text-xs font-semibold tabular-nums ${toneClass}`}>
+    <span className="inline-flex shrink-0 items-baseline gap-1" title={label}>
+      <span className={`text-sm font-semibold tabular-nums ${toneClass}`}>
         {value}
       </span>
-    </div>
+      <span className="text-2xs uppercase tracking-[0.08em] text-muted">
+        {label}
+      </span>
+    </span>
   );
 }
 
@@ -759,61 +751,71 @@ function WorkbenchHeader({
   const title = (
     <div className="flex shrink-0 items-center gap-2">
       <Layers className="h-4 w-4 text-accent" />
-      <span className="text-sm font-semibold text-txt">
+      <span className="text-sm font-semibold tracking-tight text-txt-strong">
         {t("orchestrator.title", { defaultValue: "Orchestrator" })}
       </span>
     </div>
   );
-  const chips = (
+  // Calm labeled summary: total tasks always, then only the non-zero semantic
+  // counts — reads "12 tasks · 1 active · 3 done", not a six-pill debug strip.
+  const summary = (
     <div
-      className="flex items-center gap-1.5"
-      style={
-        isMobile ? { overflowX: "auto" } : { flex: "1 1 0%", flexWrap: "wrap" }
-      }
+      className="flex min-w-0 items-center gap-2.5 overflow-x-auto"
+      style={isMobile ? undefined : { flex: "1 1 0%" }}
     >
-      <StatChip
-        label={t("orchestrator.stat.tasks", { defaultValue: "Tasks" })}
-        value={String(status?.taskCount ?? 0)}
-        icon={<ListTodo className="h-3 w-3" />}
-      />
-      <StatChip
-        label={t("orchestrator.stat.active", { defaultValue: "Active" })}
-        value={String(status?.activeTaskCount ?? 0)}
-        tone="ok"
-        icon={<CirclePlay className="h-3 w-3" />}
-      />
-      <StatChip
-        label={t("orchestrator.stat.blocked", { defaultValue: "Blocked" })}
-        value={String(status?.blockedTaskCount ?? 0)}
-        tone="warn"
-        icon={<OctagonX className="h-3 w-3" />}
-      />
-      <StatChip
-        label={t("orchestrator.stat.validating", {
-          defaultValue: "Validating",
-        })}
-        value={String(status?.validatingTaskCount ?? 0)}
-        tone="accent"
-        icon={<CircleDashed className="h-3 w-3" />}
-      />
-      <StatChip
-        label={t("orchestrator.stat.agents", { defaultValue: "Agents" })}
-        value={`${status?.activeSessionCount ?? 0}/${status?.sessionCount ?? 0}`}
-        icon={<Bot className="h-3 w-3" />}
-      />
-      {status ? (
-        <StatChip
-          label={t("orchestrator.stat.usage", { defaultValue: "Usage" })}
-          value={
-            isMobile
-              ? renderTokens(status.usage, t, locale)
-              : `${renderTokens(status.usage, t, locale)} · ${renderCost(status.usage, t, locale)}`
-          }
-          icon={<Gauge className="h-3 w-3" />}
-        />
+      <HeaderStat value={String(status?.taskCount ?? 0)} label="tasks" />
+      {status?.activeTaskCount ? (
+        <>
+          <HeaderDivider />
+          <HeaderStat
+            value={String(status.activeTaskCount)}
+            label="active"
+            toneClass="text-ok"
+          />
+        </>
+      ) : null}
+      {status?.blockedTaskCount ? (
+        <>
+          <HeaderDivider />
+          <HeaderStat
+            value={String(status.blockedTaskCount)}
+            label="blocked"
+            toneClass="text-warn"
+          />
+        </>
+      ) : null}
+      {status?.validatingTaskCount ? (
+        <>
+          <HeaderDivider />
+          <HeaderStat
+            value={String(status.validatingTaskCount)}
+            label="validating"
+            toneClass="text-accent"
+          />
+        </>
+      ) : null}
+      {status?.activeSessionCount ? (
+        <>
+          <HeaderDivider />
+          <HeaderStat
+            value={`${status.activeSessionCount}/${status.sessionCount}`}
+            label="agents"
+          />
+        </>
       ) : null}
     </div>
   );
+  const usageReadout = status ? (
+    <span
+      className="flex shrink-0 items-center gap-1.5 text-xs tabular-nums text-muted"
+      title={t("orchestrator.stat.usage", { defaultValue: "Usage" })}
+    >
+      <Gauge className="h-3 w-3 text-muted/70" />
+      {renderTokens(status.usage, t, locale)}
+      <span className="text-muted/50">·</span>
+      {renderCost(status.usage, t, locale)}
+    </span>
+  ) : null;
   const pauseAllLabel = t("orchestrator.action.pauseAll", {
     defaultValue: "Pause all",
   });
@@ -853,32 +855,37 @@ function WorkbenchHeader({
         size="sm"
         disabled={busy}
         onClick={onNewTask}
-        className="h-7 w-7 p-0"
+        className="h-7 gap-1.5 px-2.5 text-xs-tight font-semibold"
         aria-label={newTaskLabel}
         title={newTaskLabel}
         data-testid="orchestrator-new-task"
       >
         <Plus className="h-3.5 w-3.5" />
+        {newTaskLabel}
       </Button>
     </div>
   );
 
   if (isMobile) {
     return (
-      <header className="flex flex-col gap-2 border-b border-border/60 bg-bg px-3 py-2">
+      <header className="flex flex-col gap-2 border-b border-border/50 bg-bg px-4 py-2.5">
         <div className="flex items-center gap-2">
           {title}
           {actions}
         </div>
-        {chips}
+        <div className="flex items-center justify-between gap-2">
+          {summary}
+          {usageReadout}
+        </div>
       </header>
     );
   }
 
   return (
-    <header className="flex flex-wrap items-center gap-2 border-b border-border/60 bg-bg px-3 py-2">
+    <header className="flex items-center gap-3 border-b border-border/50 bg-bg px-4 py-2.5">
       {title}
-      {chips}
+      {summary}
+      {usageReadout}
       {actions}
     </header>
   );
@@ -946,23 +953,37 @@ function TaskRailItem({
           locale,
           t("orchestrator.unknown", { defaultValue: "—" }),
         );
+  // A left accent bar surfaces in-progress/selected at a glance without parsing
+  // the small status glyph. Idle rows are borderless (hover-fill only) so the
+  // rail reads as a list, not a stack of boxes.
+  const barTone = selected
+    ? "before:bg-accent"
+    : thread.status === "active"
+      ? "before:bg-ok"
+      : thread.status === "validating"
+        ? "before:bg-accent"
+        : thread.status === "blocked" || thread.status === "waiting_on_user"
+          ? "before:bg-warn"
+          : "before:bg-transparent";
   return (
     <div
-      className={`rounded-lg border transition-colors ${
-        selected
-          ? "border-accent/50 bg-bg-hover/70"
-          : "border-border/50 bg-bg-accent/30 hover:bg-bg-hover/40"
+      className={`relative rounded-sm transition-colors before:absolute before:inset-y-1 before:left-0 before:w-0.5 before:rounded-full before:content-[''] ${barTone} ${
+        selected ? "bg-accent-subtle" : "hover:bg-surface"
       }`}
       data-testid="orchestrator-task-item"
     >
       <button
         type="button"
         onClick={() => onSelect(thread.id)}
-        className="flex w-full flex-col gap-1 p-2.5 text-left"
+        className="flex w-full flex-col gap-0.5 px-2.5 py-2 pl-3 text-left"
       >
         <div className="flex items-center gap-1.5">
           <StatusGlyph status={thread.status} paused={thread.paused} t={t} />
-          <span className="min-w-0 flex-1 truncate text-xs font-semibold text-txt">
+          <span
+            className={`min-w-0 flex-1 truncate text-xs-tight font-medium ${
+              selected ? "text-txt-strong" : "text-txt"
+            }`}
+          >
             {thread.title}
           </span>
           {thread.paused ? (
@@ -970,13 +991,10 @@ function TaskRailItem({
           ) : null}
           <PriorityGlyph priority={thread.priority} t={t} />
         </div>
-        <div className="flex items-center gap-2.5 text-2xs text-muted">
+        <div className="flex items-center gap-2 text-2xs text-muted">
           <span className="flex items-center gap-0.5">
             <Bot className="h-3 w-3" />
             {thread.activeSessionCount}/{thread.sessionCount}
-          </span>
-          <span className="tabular-nums">
-            {renderTokens(thread.usage, t, locale)}
           </span>
           <span className="ml-auto truncate">{lastActivity}</span>
         </div>
@@ -1195,7 +1213,7 @@ function UsageSection({
 }
 
 const FIELD_CLASS =
-  "w-full rounded-md border border-border/50 bg-bg px-2 py-1.5 text-xs text-txt outline-none transition-colors placeholder:text-muted focus:border-accent/50";
+  "w-full rounded-sm border border-border bg-bg px-2.5 py-1.5 text-xs text-txt outline-none transition-colors placeholder:text-muted focus:border-accent focus:ring-1 focus:ring-accent/30";
 
 function FieldLabel({ children }: { children: ReactNode }) {
   return (
@@ -2328,12 +2346,24 @@ export function OrchestratorWorkbench() {
                   })}
                 </p>
               ) : (
-                <EmptyWidgetState
-                  icon={<Activity className="h-8 w-8" />}
-                  title={t("orchestrator.empty.title", {
-                    defaultValue: "No tasks yet",
-                  })}
-                />
+                <div className="flex flex-col items-center gap-2 px-3 py-10 text-center">
+                  <Activity className="h-7 w-7 text-muted/50" />
+                  <p className="text-xs text-muted">
+                    {t("orchestrator.empty.title", {
+                      defaultValue: "No tasks yet",
+                    })}
+                  </p>
+                  <Button
+                    size="sm"
+                    onClick={() => setCreateOpen(true)}
+                    className="h-7 gap-1.5 px-2.5 text-xs-tight font-semibold"
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                    {t("orchestrator.action.newTask", {
+                      defaultValue: "New task",
+                    })}
+                  </Button>
+                </div>
               )
             ) : (
               tasks.map((thread) => (
@@ -2371,7 +2401,7 @@ export function OrchestratorWorkbench() {
               <div
                 ref={listRef}
                 onScroll={handleListScroll}
-                className="min-h-0 flex-1 space-y-2 overflow-y-auto p-3"
+                className="min-h-0 flex-1 space-y-3 overflow-y-auto px-4 py-4"
                 data-testid="orchestrator-message-list"
               >
                 {messageCursor ? (
@@ -2431,7 +2461,7 @@ export function OrchestratorWorkbench() {
                   </button>
                 </div>
               ) : null}
-              <div className="border-t border-border/50 p-2.5">
+              <div className="border-t border-border/50 bg-bg px-4 py-3">
                 <div className="flex items-end gap-2">
                   <textarea
                     value={composer}
@@ -2498,13 +2528,31 @@ export function OrchestratorWorkbench() {
               </div>
             </>
           ) : (
-            <div className="flex flex-1 items-center justify-center p-6">
-              <EmptyWidgetState
-                icon={<Layers className="h-8 w-8" />}
-                title={t("orchestrator.noSelection", {
-                  defaultValue: "Select a task to inspect its room",
-                })}
-              />
+            <div className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+              <div className="flex h-12 w-12 items-center justify-center rounded-sm bg-accent-subtle">
+                <Layers className="h-6 w-6 text-accent" />
+              </div>
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-txt-strong">
+                  {t("orchestrator.noSelection.title", {
+                    defaultValue: "No task open",
+                  })}
+                </p>
+                <p className="max-w-xs text-xs leading-relaxed text-muted">
+                  {t("orchestrator.noSelection.hint", {
+                    defaultValue:
+                      "Pick a task from the list to inspect its room — or start a new coding task.",
+                  })}
+                </p>
+              </div>
+              <Button
+                size="sm"
+                onClick={() => setCreateOpen(true)}
+                className="h-8 gap-1.5 px-3 text-xs-tight font-semibold"
+              >
+                <Plus className="h-3.5 w-3.5" />
+                {t("orchestrator.action.newTask", { defaultValue: "New task" })}
+              </Button>
             </div>
           )}
         </main>

--- a/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
@@ -2183,13 +2183,39 @@ export function OrchestratorWorkbench() {
     });
   }, [detail, runMutation]);
 
-  // Esc interrupts the running turn from anywhere in the workbench. A ref keeps
-  // the document listener stable while always calling the latest handler.
-  const stopActiveRef = useRef(handleStopActive);
-  stopActiveRef.current = handleStopActive;
+  // Esc closes an open modal/drawer first; only when nothing is open does it
+  // interrupt the running turn. A ref keeps the document listener stable while
+  // always seeing the latest state (otherwise Esc-to-stop would trap an open
+  // dialog, blocking the whole UI).
+  const escStateRef = useRef({
+    createOpen,
+    addAgentOpen,
+    inspectorOpen,
+    stop: handleStopActive,
+  });
+  escStateRef.current = {
+    createOpen,
+    addAgentOpen,
+    inspectorOpen,
+    stop: handleStopActive,
+  };
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") stopActiveRef.current();
+      if (event.key !== "Escape") return;
+      const s = escStateRef.current;
+      if (s.createOpen) {
+        setCreateOpen(false);
+        return;
+      }
+      if (s.addAgentOpen) {
+        setAddAgentOpen(false);
+        return;
+      }
+      if (s.inspectorOpen) {
+        setInspectorOpen(false);
+        return;
+      }
+      s.stop();
     };
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);

--- a/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
@@ -2050,9 +2050,8 @@ export function OrchestratorWorkbench() {
   }, [selectedId, fetchDetail]);
 
   useEffect(() => {
-    // Poll the open task's room — fast while a working agent is live, slow when
-    // idle. Kept separate from the selection effect so a cadence change never
-    // forces a full reload of the conversation.
+    // Reconcile poll — the safety net. The SSE stream below drives near-live
+    // updates; this only covers a dropped/absent stream (reconnect fallback).
     if (!selectedId) return;
     const timer = window.setInterval(
       () => void fetchDetail(selectedId, false).catch(() => {}),
@@ -2060,6 +2059,36 @@ export function OrchestratorWorkbench() {
     );
     return () => window.clearInterval(timer);
   }, [selectedId, detailPollMs, fetchDetail]);
+
+  // Coalesce a burst of change pings into one tail refetch per ~150ms window,
+  // so live token streaming doesn't trigger a fetch storm.
+  const refetchTimerRef = useRef<number | null>(null);
+  const scheduleRefetch = useCallback(() => {
+    if (refetchTimerRef.current != null) return;
+    refetchTimerRef.current = window.setTimeout(() => {
+      refetchTimerRef.current = null;
+      const current = selectedIdRef.current;
+      if (current) void fetchDetail(current, false).catch(() => {});
+    }, 150);
+  }, [fetchDetail]);
+
+  useEffect(() => {
+    // Live push: subscribe to the task's SSE stream; each "change" ping
+    // schedules a debounced tail refetch, so messages/tool-calls/status appear
+    // ~instantly instead of on the poll boundary.
+    if (!selectedId) return;
+    const unsubscribe = client.streamOrchestratorTask(
+      selectedId,
+      scheduleRefetch,
+    );
+    return () => {
+      unsubscribe();
+      if (refetchTimerRef.current != null) {
+        window.clearTimeout(refetchTimerRef.current);
+        refetchTimerRef.current = null;
+      }
+    };
+  }, [selectedId, scheduleRefetch]);
 
   const runMutation = useCallback(
     async (fn: () => Promise<unknown>) => {

--- a/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
@@ -2116,6 +2116,38 @@ export function OrchestratorWorkbench() {
     });
   }, [composer, runMutation, t]);
 
+  // Stop every still-running coding agent on the open task — the prominent
+  // in-conversation interrupt (parity with Claude Code / Codex / opencode),
+  // also bound to Esc below.
+  const handleStopActive = useCallback(() => {
+    const current = detail;
+    if (!current) return;
+    const targets = current.sessions.filter(
+      (session) =>
+        session.sessionId &&
+        session.stoppedAt == null &&
+        session.status !== "completed",
+    );
+    if (targets.length === 0) return;
+    void runMutation(async () => {
+      for (const session of targets) {
+        await client.stopOrchestratorAgent(current.id, session.sessionId);
+      }
+    });
+  }, [detail, runMutation]);
+
+  // Esc interrupts the running turn from anywhere in the workbench. A ref keeps
+  // the document listener stable while always calling the latest handler.
+  const stopActiveRef = useRef(handleStopActive);
+  stopActiveRef.current = handleStopActive;
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") stopActiveRef.current();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, []);
+
   const handleCreate = useCallback(
     (input: {
       title: string;
@@ -2344,6 +2376,32 @@ export function OrchestratorWorkbench() {
                   ))
                 )}
               </div>
+              {detail.activeSessionCount > 0 ? (
+                <div
+                  className="flex items-center justify-between gap-2 border-t border-border/50 bg-warn/5 px-3 py-1.5"
+                  data-testid="orchestrator-running-bar"
+                >
+                  <span className="flex items-center gap-1.5 text-2xs font-medium text-warn">
+                    <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-warn" />
+                    {t("orchestrator.agentsWorking", {
+                      defaultValue: "Agent working…",
+                    })}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={handleStopActive}
+                    disabled={mutating}
+                    className="flex items-center gap-1 rounded-md border border-border/60 px-2 py-0.5 text-2xs text-txt transition-colors hover:bg-danger/10 hover:text-danger disabled:opacity-50"
+                    data-testid="orchestrator-stop-active"
+                  >
+                    <CircleStop className="h-3 w-3" />
+                    {t("orchestrator.action.stop", { defaultValue: "Stop" })}
+                    <kbd className="ml-0.5 rounded bg-bg-hover/60 px-1 text-[0.9em] text-muted">
+                      Esc
+                    </kbd>
+                  </button>
+                </div>
+              ) : null}
               <div className="border-t border-border/50 p-2.5">
                 <div className="flex items-end gap-2">
                   <textarea

--- a/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
@@ -51,6 +51,7 @@ import {
 import {
   type CSSProperties,
   type ReactNode,
+  type UIEvent,
   useCallback,
   useDeferredValue,
   useEffect,
@@ -59,12 +60,14 @@ import {
   useState,
 } from "react";
 import {
-  formatClockTime,
+  buildConversation,
+  ConversationBlockView,
+} from "./orchestrator-stream";
+import {
   formatCompactNumber,
   formatIsoRelative,
   formatRelativeTime,
   formatUsd,
-  stripAnsi,
 } from "./view-format";
 
 type Translate = (key: string, vars?: Record<string, unknown>) => string;
@@ -78,6 +81,9 @@ const fallbackTranslate: Translate = (key, vars) =>
 const TASK_LIST_LIMIT = 100;
 const TIMELINE_PAGE_LIMIT = 50;
 const POLL_INTERVAL_MS = 5_000;
+/** While a task has a working agent, poll its room fast so the conversation,
+ * tool calls, and tokens stream in near-live instead of lurching every 5s. */
+const ACTIVE_POLL_INTERVAL_MS = 1_500;
 
 const STATUS_ICON: Record<TaskStatus, LucideIcon> = {
   open: Circle,
@@ -325,13 +331,19 @@ function VerificationGlyph({
       aria-label={label}
       role="img"
     >
-      <Icon className={`h-3.5 w-3.5 ${VERIFICATION_TONE[status]}`} aria-hidden />
+      <Icon
+        className={`h-3.5 w-3.5 ${VERIFICATION_TONE[status]}`}
+        aria-hidden
+      />
     </span>
   );
 }
 
 function PlanStepGlyph({ status, t }: { status: string; t: Translate }) {
-  const key = status.trim().toLowerCase().replace(/[\s-]+/g, "_");
+  const key = status
+    .trim()
+    .toLowerCase()
+    .replace(/[\s-]+/g, "_");
   const Icon = PLAN_STEP_ICON[key] ?? Circle;
   const tone = PLAN_STEP_TONE[key] ?? "text-muted";
   const label = t(`orchestrator.planStatus.${key}`, {
@@ -756,9 +768,7 @@ function WorkbenchHeader({
     <div
       className="flex items-center gap-1.5"
       style={
-        isMobile
-          ? { overflowX: "auto" }
-          : { flex: "1 1 0%", flexWrap: "wrap" }
+        isMobile ? { overflowX: "auto" } : { flex: "1 1 0%", flexWrap: "wrap" }
       }
     >
       <StatChip
@@ -975,83 +985,6 @@ function TaskRailItem({
   );
 }
 
-function MessageEntry({
-  message,
-  senderName,
-  locale,
-}: {
-  message: CodingAgentTaskMessageRecord;
-  senderName: string;
-  locale?: string;
-}) {
-  const text = stripAnsi(message.content);
-  if (!text) return null;
-  const isUser = message.senderKind === "user";
-  // Your own messages read as "yours" by color + right-alignment, so the
-  // explicit "You" label is redundant; everyone else keeps their name.
-  const tone = isUser
-    ? "bg-accent/20"
-    : message.senderKind === "orchestrator"
-      ? "bg-bg-accent/60"
-      : "bg-bg-hover/60";
-  return (
-    <div
-      className={`flex flex-col ${isUser ? "items-end" : "items-start"}`}
-      data-testid="orchestrator-message"
-    >
-      <div
-        className={`rounded-lg px-2.5 py-1.5 ${tone}`}
-        style={{ maxWidth: "88%" }}
-      >
-        <div className="mb-0.5 flex items-center gap-2 text-2xs text-muted">
-          {isUser ? null : (
-            <span className="font-semibold tracking-tight text-txt/90">
-              {senderName}
-            </span>
-          )}
-          <span className="tabular-nums">
-            {formatClockTime(message.timestamp, locale)}
-          </span>
-        </div>
-        <pre className="whitespace-pre-wrap break-words font-sans text-xs text-txt">
-          {text}
-        </pre>
-      </div>
-    </div>
-  );
-}
-
-function EventEntry({
-  event,
-  locale,
-}: {
-  event: CodingAgentTaskEventRecord;
-  locale?: string;
-}) {
-  // Show the specific summary as the single line; the event type (e.g.
-  // "agent spawned") only restates what the summary already says ("token-
-  // exchange spawned"), so it's dropped unless there is no summary.
-  const text = event.summary?.trim() || event.eventType.replace(/_/g, " ");
-  return (
-    <div
-      className="flex items-center gap-2 px-1 text-2xs text-muted"
-      data-testid="orchestrator-event"
-    >
-      <span className="h-px flex-1 bg-border/40" />
-      <span
-        className="min-w-0 shrink truncate font-medium"
-        style={{ maxWidth: "72%" }}
-      >
-        {text}
-      </span>
-      <span className="shrink-0 tabular-nums">
-        {formatClockTime(event.timestamp, locale)}
-      </span>
-      <span className="h-px flex-1 bg-border/40" />
-    </div>
-  );
-}
-
 function SubAgentCard({
   session,
   busy,
@@ -1103,12 +1036,7 @@ function SubAgentCard({
           <span className="truncate text-warn">{session.activeTool}</span>
         ) : null}
         <span className="ml-auto tabular-nums">
-          {formatTokenCount(
-            session.usageState,
-            session.totalTokens,
-            t,
-            locale,
-          )}
+          {formatTokenCount(session.usageState, session.totalTokens, t, locale)}
         </span>
       </div>
       <div className="mt-0.5 truncate text-2xs text-muted/80">{workspace}</div>
@@ -1196,10 +1124,7 @@ function ArtifactSection({
               <span className="min-w-0 flex-1 truncate font-medium text-txt">
                 {artifact.title}
               </span>
-              <VerificationGlyph
-                status={artifact.verificationStatus}
-                t={t}
-              />
+              <VerificationGlyph status={artifact.verificationStatus} t={t} />
             </div>
             <div className="truncate text-muted">
               {artifact.artifactType}
@@ -2023,6 +1948,17 @@ export function OrchestratorWorkbench() {
   const selectedIdRef = useRef<string | null>(selectedId);
   selectedIdRef.current = selectedId;
 
+  // The conversation sticks to the newest entry, but only while the reader is
+  // already near the bottom — scrolling up to read history is never yanked by
+  // a streaming update.
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const stickToBottomRef = useRef(true);
+  const handleListScroll = useCallback((event: UIEvent<HTMLDivElement>) => {
+    const el = event.currentTarget;
+    stickToBottomRef.current =
+      el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  }, []);
+
   const fetchTasksAndStatus = useCallback(
     async (silent: boolean) => {
       if (!silent) setLoading(true);
@@ -2064,7 +2000,10 @@ export function OrchestratorWorkbench() {
       client.listOrchestratorTaskMessages(id, { limit: TIMELINE_PAGE_LIMIT }),
       client.listOrchestratorTaskEvents(id, { limit: TIMELINE_PAGE_LIMIT }),
     ]);
-    if (token !== detailReqRef.current) return;
+    // Discard if a newer fetch superseded this one, or if the selection moved on
+    // while in flight — otherwise a non-reset poll/refresh could merge one task's
+    // transcript into another task's room (cross-task contamination).
+    if (token !== detailReqRef.current || id !== selectedIdRef.current) return;
     setDetail(nextDetail);
     if (reset) {
       setMessages(mergeById([], messagePage.items));
@@ -2085,11 +2024,21 @@ export function OrchestratorWorkbench() {
     return () => window.clearInterval(timer);
   }, [fetchTasksAndStatus]);
 
+  const detailPollMs =
+    detail !== null &&
+    (detail.activeSessionCount > 0 ||
+      detail.status === "active" ||
+      detail.status === "validating")
+      ? ACTIVE_POLL_INTERVAL_MS
+      : POLL_INTERVAL_MS;
+
   useEffect(() => {
     // Reset transient per-task UI (mobile inspector drawer, add-agent form)
-    // whenever the selection changes so a freshly opened task starts clean.
+    // and load the room whenever the selection changes, so a freshly opened
+    // task starts clean and scrolled to its latest activity.
     setInspectorOpen(false);
     setAddAgentOpen(false);
+    stickToBottomRef.current = true;
     if (!selectedId) {
       setDetail(null);
       setMessages([]);
@@ -2098,12 +2047,19 @@ export function OrchestratorWorkbench() {
       return;
     }
     void fetchDetail(selectedId, true).catch(() => {});
+  }, [selectedId, fetchDetail]);
+
+  useEffect(() => {
+    // Poll the open task's room — fast while a working agent is live, slow when
+    // idle. Kept separate from the selection effect so a cadence change never
+    // forces a full reload of the conversation.
+    if (!selectedId) return;
     const timer = window.setInterval(
       () => void fetchDetail(selectedId, false).catch(() => {}),
-      POLL_INTERVAL_MS,
+      detailPollMs,
     );
     return () => window.clearInterval(timer);
-  }, [selectedId, fetchDetail]);
+  }, [selectedId, detailPollMs, fetchDetail]);
 
   const runMutation = useCallback(
     async (fn: () => Promise<unknown>) => {
@@ -2151,7 +2107,8 @@ export function OrchestratorWorkbench() {
       if (!delivered) {
         throw new Error(
           t("orchestrator.messageDeliveryFailed", {
-            defaultValue: "Message was recorded, but no active agent accepted it.",
+            defaultValue:
+              "Message was recorded, but no active agent accepted it.",
           }),
         );
       }
@@ -2182,20 +2139,6 @@ export function OrchestratorWorkbench() {
     void copyToClipboard(url);
   }, [copyToClipboard]);
 
-  const timeline = useMemo(() => {
-    const items: Array<
-      | { kind: "message"; at: number; message: CodingAgentTaskMessageRecord }
-      | { kind: "event"; at: number; event: CodingAgentTaskEventRecord }
-    > = [];
-    for (const message of messages) {
-      items.push({ kind: "message", at: message.timestamp, message });
-    }
-    for (const event of events) {
-      items.push({ kind: "event", at: event.timestamp, event });
-    }
-    return items.sort((a, b) => a.at - b.at);
-  }, [messages, events]);
-
   const sessionLabelById = useMemo(() => {
     const map = new Map<string, string>();
     for (const session of detail?.sessions ?? []) {
@@ -2204,6 +2147,39 @@ export function OrchestratorWorkbench() {
     }
     return map;
   }, [detail?.sessions]);
+
+  const finishedSessionIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const session of detail?.sessions ?? []) {
+      if (
+        session.sessionId &&
+        (session.stoppedAt != null || session.status === "completed")
+      ) {
+        ids.add(session.sessionId);
+      }
+    }
+    return ids;
+  }, [detail?.sessions]);
+
+  const conversation = useMemo(
+    () =>
+      buildConversation(
+        messages,
+        events,
+        (message) =>
+          resolveSenderName(message, sessionLabelById, mainAgentName, t),
+        finishedSessionIds,
+      ),
+    [messages, events, sessionLabelById, mainAgentName, finishedSessionIds, t],
+  );
+
+  // Re-pin to the newest entry whenever the conversation grows (subject to the
+  // near-bottom guard); `conversation` is the change trigger, not read here.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: trigger-only dep
+  useEffect(() => {
+    const el = listRef.current;
+    if (el && stickToBottomRef.current) el.scrollTop = el.scrollHeight;
+  }, [conversation]);
 
   const viewState = JSON.stringify({
     selectedId,
@@ -2332,6 +2308,8 @@ export function OrchestratorWorkbench() {
                 t={t}
               />
               <div
+                ref={listRef}
+                onScroll={handleListScroll}
                 className="min-h-0 flex-1 space-y-2 overflow-y-auto p-3"
                 data-testid="orchestrator-message-list"
               >
@@ -2350,34 +2328,20 @@ export function OrchestratorWorkbench() {
                     </button>
                   </div>
                 ) : null}
-                {timeline.length === 0 ? (
+                {conversation.length === 0 ? (
                   <p className="p-4 text-center text-xs text-muted">
                     {t("orchestrator.noMessages", {
                       defaultValue: "No messages yet.",
                     })}
                   </p>
                 ) : (
-                  timeline.map((item) =>
-                    item.kind === "message" ? (
-                      <MessageEntry
-                        key={item.message.id}
-                        message={item.message}
-                        senderName={resolveSenderName(
-                          item.message,
-                          sessionLabelById,
-                          mainAgentName,
-                          t,
-                        )}
-                        locale={locale}
-                      />
-                    ) : (
-                      <EventEntry
-                        key={item.event.id}
-                        event={item.event}
-                        locale={locale}
-                      />
-                    ),
-                  )
+                  conversation.map((block) => (
+                    <ConversationBlockView
+                      key={block.key}
+                      block={block}
+                      locale={locale}
+                    />
+                  ))
                 )}
               </div>
               <div className="border-t border-border/50 p-2.5">

--- a/plugins/plugin-task-coordinator/src/orchestrator-diff.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-diff.tsx
@@ -1,0 +1,158 @@
+import type { ReactNode } from "react";
+
+// A real, interleaved, line-aligned diff for the tool-call cards — the way
+// Claude Code / Codex / opencode render an edit. Replaces the old DiffLines,
+// which dumped all removals then all additions as two flat blocks. The tool
+// view already carries oldText/newText (parsed from the ACP tool input), so
+// this is a pure presentation concern: align the two texts and render
+// add/remove/context rows with old+new line-number gutters.
+
+export interface DiffRow {
+  type: "context" | "add" | "remove";
+  /** 1-based line number in the old text, or null for an addition. */
+  oldLine: number | null;
+  /** 1-based line number in the new text, or null for a removal. */
+  newLine: number | null;
+  text: string;
+}
+
+/** Above this combined line count the O(n·m) alignment is skipped for a flat
+ * remove-then-add render. Callers pass clamped text, so this is a backstop. */
+const MAX_ALIGN_LINES = 800;
+
+/** The minimal interleaved add/remove/context sequence aligning `oldText` to
+ * `newText`, via the classic LCS dynamic program. */
+export function lineDiff(oldText: string, newText: string): DiffRow[] {
+  const a = oldText.split("\n");
+  const b = newText.split("\n");
+  const n = a.length;
+  const m = b.length;
+
+  if (n + m > MAX_ALIGN_LINES) {
+    const flat: DiffRow[] = [];
+    for (let i = 0; i < n; i++)
+      flat.push({ type: "remove", oldLine: i + 1, newLine: null, text: a[i] });
+    for (let j = 0; j < m; j++)
+      flat.push({ type: "add", oldLine: null, newLine: j + 1, text: b[j] });
+    return flat;
+  }
+
+  // dp[i][j] = LCS length of a[i:] and b[j:].
+  const dp: number[][] = Array.from({ length: n + 1 }, () =>
+    new Array<number>(m + 1).fill(0),
+  );
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      dp[i][j] =
+        a[i] === b[j]
+          ? dp[i + 1][j + 1] + 1
+          : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+
+  const rows: DiffRow[] = [];
+  let i = 0;
+  let j = 0;
+  let oldNo = 1;
+  let newNo = 1;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      rows.push({
+        type: "context",
+        oldLine: oldNo++,
+        newLine: newNo++,
+        text: a[i],
+      });
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      rows.push({
+        type: "remove",
+        oldLine: oldNo++,
+        newLine: null,
+        text: a[i],
+      });
+      i++;
+    } else {
+      rows.push({ type: "add", oldLine: null, newLine: newNo++, text: b[j] });
+      j++;
+    }
+  }
+  while (i < n)
+    rows.push({
+      type: "remove",
+      oldLine: oldNo++,
+      newLine: null,
+      text: a[i++],
+    });
+  while (j < m)
+    rows.push({ type: "add", oldLine: null, newLine: newNo++, text: b[j++] });
+  return rows;
+}
+
+const ROW_TONE: Record<DiffRow["type"], string> = {
+  context: "text-txt/80",
+  add: "bg-ok/10 text-ok",
+  remove: "bg-danger/10 text-danger",
+};
+
+const ROW_SIGN: Record<DiffRow["type"], string> = {
+  context: " ",
+  add: "+",
+  remove: "-",
+};
+
+function Gutter({ value }: { value: number | null }): ReactNode {
+  return (
+    <span className="w-8 shrink-0 select-none px-1 text-right text-muted/50 tabular-nums">
+      {value === null ? "" : value}
+    </span>
+  );
+}
+
+/**
+ * Render an edit as an interleaved diff. When `oldText` is omitted (a file
+ * write rather than an edit) every line is shown as an addition.
+ */
+export function DiffView({
+  oldText,
+  newText,
+}: {
+  oldText?: string;
+  newText: string;
+}): ReactNode {
+  const rows: DiffRow[] =
+    oldText === undefined
+      ? newText.split("\n").map((text, idx) => ({
+          type: "add" as const,
+          oldLine: null,
+          newLine: idx + 1,
+          text,
+        }))
+      : lineDiff(oldText, newText);
+
+  return (
+    <div
+      className="overflow-auto rounded-md border border-border/40 bg-bg/60 font-mono text-2xs leading-relaxed"
+      style={{ maxHeight: "18rem" }}
+      data-testid="orchestrator-diff"
+    >
+      {rows.map((row) => (
+        // (oldLine, newLine) pairs are unique within a diff, so no index key.
+        <div
+          key={`${row.oldLine ?? "_"}:${row.newLine ?? "_"}:${row.type}`}
+          className={`flex ${ROW_TONE[row.type]}`}
+        >
+          <Gutter value={row.oldLine} />
+          <Gutter value={row.newLine} />
+          <span className="w-3 shrink-0 select-none text-center opacity-70">
+            {ROW_SIGN[row.type]}
+          </span>
+          <span className="min-w-0 flex-1 whitespace-pre-wrap break-all pr-2">
+            {row.text}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
@@ -1,0 +1,829 @@
+import type {
+  CodingAgentTaskEventRecord,
+  CodingAgentTaskMessageRecord,
+} from "@elizaos/ui";
+import {
+  Check,
+  ChevronRight,
+  Circle,
+  CircleAlert,
+  CircleCheck,
+  CircleStop,
+  CircleX,
+  FilePen,
+  FilePlus,
+  FileText,
+  Globe,
+  Loader,
+  type LucideIcon,
+  OctagonX,
+  Search,
+  Terminal,
+  Wrench,
+} from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { formatClockTime, stripAnsi } from "./view-format";
+
+// The orchestrator room renders a coding-agent session the way Claude Code /
+// Codex do: a single flowing conversation of (1) the user's prompts, (2) the
+// agent's streamed prose, and (3) the tool calls it makes — each tool shown as
+// a structured card (file diff, shell command + output, search query) rather
+// than as raw stdout. The backend already captures all of this; the work here
+// is purely turning its records into that view.
+//
+// Two backend realities drive the transform in `buildConversation`:
+//   • The agent's prose arrives as many tiny `agent_message_chunk` rows (one per
+//     token-ish), so consecutive same-sender chunks are concatenated into one
+//     turn instead of rendered as dozens of fragment bubbles.
+//   • A single tool invocation emits several `tool_running` events (in_progress
+//     → completed), so they are merged by `toolCall.id` into one card carrying
+//     the final status.
+
+type ToolStatus = "running" | "done" | "failed";
+
+export interface ToolView {
+  id: string;
+  /** The tool's own name, e.g. `write`, `bash`, `read`. */
+  title: string;
+  /** ACP tool kind, e.g. `edit`, `execute`, `read`, `search`. */
+  kind: string;
+  status: ToolStatus;
+  /** Edited/read file, relative to the session workdir when resolvable. */
+  filePath?: string;
+  /** Shell command for `execute` tools. */
+  command?: string;
+  /** New file content (write) or replacement text (edit). */
+  newText?: string;
+  /** Prior text for an edit, enabling a real +/- diff. */
+  oldText?: string;
+  /** Query/pattern for search-style tools. */
+  query?: string;
+  /** Tool result/output, ANSI-stripped. */
+  output?: string;
+}
+
+export type ConversationBlock =
+  | { kind: "user"; key: string; at: number; content: string }
+  | {
+      kind: "agent";
+      key: string;
+      at: number;
+      senderName: string;
+      content: string;
+      tone: "normal" | "error";
+    }
+  | { kind: "tool"; key: string; at: number; tool: ToolView }
+  | {
+      kind: "notice";
+      key: string;
+      at: number;
+      icon: LucideIcon;
+      tone: string;
+      text: string;
+    };
+
+/** Events whose content is already shown elsewhere (prose lives in the message
+ * stream; token usage lives in the inspector) and so would only add noise to
+ * the conversation. */
+const NOISE_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "message",
+  "usage_update",
+  "ready",
+  "available_commands_update",
+]);
+
+interface NoticeMeta {
+  icon: LucideIcon;
+  tone: string;
+  label: string;
+}
+
+const NOTICE_META: Record<string, NoticeMeta> = {
+  task_registered: { icon: Circle, tone: "text-muted", label: "Task started" },
+  task_complete: { icon: CircleCheck, tone: "text-ok", label: "Completed" },
+  stopped: { icon: CircleStop, tone: "text-muted", label: "Stopped" },
+  blocked: { icon: OctagonX, tone: "text-warn", label: "Blocked" },
+  blocked_auto_resolved: {
+    icon: Check,
+    tone: "text-muted",
+    label: "Auto-resolved",
+  },
+  escalation: { icon: CircleAlert, tone: "text-warn", label: "Escalation" },
+  error: { icon: CircleX, tone: "text-danger", label: "Error" },
+};
+
+function noticeMeta(eventType: string): NoticeMeta {
+  return (
+    NOTICE_META[eventType] ?? {
+      icon: Circle,
+      tone: "text-muted",
+      label: eventType.replace(/_/g, " "),
+    }
+  );
+}
+
+const TOOL_STATUS_FROM_RAW: Record<string, ToolStatus> = {
+  in_progress: "running",
+  pending: "running",
+  running: "running",
+  queued: "running",
+  completed: "done",
+  success: "done",
+  done: "done",
+  ok: "done",
+  failed: "failed",
+  error: "failed",
+  cancelled: "failed",
+  skipped: "failed",
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+/** First non-empty string among `keys` on `obj`. */
+function pickString(
+  obj: Record<string, unknown> | undefined,
+  ...keys: string[]
+): string | undefined {
+  if (!obj) return undefined;
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "string" && value.trim() !== "") return value;
+  }
+  return undefined;
+}
+
+/** Tool output arrives as a possibly JSON-encoded string (e.g. `"\"\""` for an
+ * empty result); decode one layer, strip ANSI, and drop if empty. */
+function normalizeOutput(value: unknown): string | undefined {
+  let text: string | undefined;
+  if (typeof value === "string") text = value;
+  else if (Array.isArray(value)) {
+    text = value
+      .map((part) => pickString(asRecord(part), "text", "content") ?? "")
+      .join("");
+  }
+  if (text === undefined) return undefined;
+  if (
+    text.length >= 2 &&
+    text.startsWith('"') &&
+    text.endsWith('"') &&
+    !text.includes("\n")
+  ) {
+    try {
+      const decoded = JSON.parse(text);
+      if (typeof decoded === "string") text = decoded;
+    } catch {
+      // keep the raw text
+    }
+  }
+  const clean = stripAnsi(text).trim();
+  return clean === "" ? undefined : clean;
+}
+
+/** The raw `data.toolCall` object the ACP service forwards (see its field
+ * mapping). Kept as an open record because adapters vary in which fields they
+ * populate (`title`/`name`, `rawInput`/`input`, `output`/`rawOutput`, …); every
+ * field is read defensively via {@link pickString} / {@link asRecord}. */
+function rawToolCall(
+  event: CodingAgentTaskEventRecord,
+): Record<string, unknown> | undefined {
+  return asRecord(event.data?.toolCall);
+}
+
+/** Merge the ordered `tool_running` events for one call into a single view:
+ * inputs from whichever event carried them, the latest status, and the latest
+ * non-empty output. */
+function toToolView(
+  id: string,
+  events: CodingAgentTaskEventRecord[],
+): ToolView {
+  let title = "tool";
+  let kind = "";
+  let status: ToolStatus = "running";
+  let rawInput: Record<string, unknown> | undefined;
+  let output: string | undefined;
+  for (const event of events) {
+    const call = rawToolCall(event);
+    if (!call) continue;
+    title = pickString(call, "title", "name", "toolName") ?? title;
+    kind = pickString(call, "kind") ?? kind;
+    const rawStatus = pickString(call, "status");
+    if (rawStatus) status = TOOL_STATUS_FROM_RAW[rawStatus] ?? status;
+    const nextInput = asRecord(call.rawInput) ?? asRecord(call.input);
+    if (nextInput) rawInput = { ...rawInput, ...nextInput };
+    const nextOutput = normalizeOutput(call.output ?? call.rawOutput);
+    if (nextOutput) output = nextOutput;
+  }
+  return {
+    id,
+    title,
+    kind,
+    status,
+    filePath: pickString(rawInput, "filePath", "file_path", "path"),
+    command: pickString(rawInput, "command", "cmd", "script"),
+    newText: pickString(
+      rawInput,
+      "content",
+      "newString",
+      "new_string",
+      "newText",
+    ),
+    oldText: pickString(rawInput, "oldString", "old_string", "oldText"),
+    query: pickString(rawInput, "pattern", "query", "regex", "glob"),
+    output,
+  };
+}
+
+type Atom =
+  | {
+      at: number;
+      order: number;
+      type: "message";
+      message: CodingAgentTaskMessageRecord;
+    }
+  | { at: number; order: number; type: "tool"; tool: ToolView }
+  | {
+      at: number;
+      order: number;
+      type: "notice";
+      eventType: string;
+      summary: string;
+    };
+
+/** The lane an agent/user message coalesces into; messages in the same lane that
+ * are adjacent in time merge into one turn. `stderr` stays in its own lane so
+ * error output never blends into normal prose. */
+function messageLane(message: CodingAgentTaskMessageRecord): string {
+  if (message.senderKind === "user") return "user";
+  const stream = message.direction === "stderr" ? "err" : "out";
+  return `${message.senderKind}:${message.sessionId ?? ""}:${stream}`;
+}
+
+/** Turn the polled message + event records into the ordered conversation the
+ * room renders. */
+export function buildConversation(
+  messages: CodingAgentTaskMessageRecord[],
+  events: CodingAgentTaskEventRecord[],
+  resolveSenderName: (message: CodingAgentTaskMessageRecord) => string,
+  finishedSessionIds: ReadonlySet<string>,
+): ConversationBlock[] {
+  const toolEvents = new Map<string, CodingAgentTaskEventRecord[]>();
+  const toolFirstSeen = new Map<string, number>();
+  const atoms: Atom[] = [];
+  let order = 0;
+
+  for (const message of messages) {
+    if (message.direction === "stdin" || message.direction === "keys") continue;
+    if (stripAnsi(message.content).trim() === "") continue;
+    atoms.push({
+      at: message.timestamp,
+      order: order++,
+      type: "message",
+      message,
+    });
+  }
+
+  for (const event of events) {
+    const call = rawToolCall(event);
+    if (call) {
+      const id =
+        pickString(call, "id", "toolCallId", "callId") ?? `tool-${event.id}`;
+      const list = toolEvents.get(id);
+      if (list) list.push(event);
+      else {
+        toolEvents.set(id, [event]);
+        toolFirstSeen.set(id, event.timestamp);
+      }
+      continue;
+    }
+    if (NOISE_EVENT_TYPES.has(event.eventType)) continue;
+    atoms.push({
+      at: event.timestamp,
+      order: order++,
+      type: "notice",
+      eventType: event.eventType,
+      summary: event.summary,
+    });
+  }
+
+  for (const [id, list] of toolEvents) {
+    const tool = toToolView(id, list);
+    // opencode never persists a tool's terminal status — its events top out at
+    // `in_progress`. Once the owning session has finished, a still-"running"
+    // tool has in fact completed, so reflect that instead of a perpetual spinner.
+    const sessionId = list[0].sessionId;
+    if (tool.status === "running" && sessionId && finishedSessionIds.has(sessionId)) {
+      tool.status = "done";
+    }
+    atoms.push({
+      at: toolFirstSeen.get(id) ?? list[0].timestamp,
+      order: order++,
+      type: "tool",
+      tool,
+    });
+  }
+
+  atoms.sort((a, b) => a.at - b.at || a.order - b.order);
+
+  const blocks: ConversationBlock[] = [];
+  let openLane: {
+    lane: string;
+    block: Extract<ConversationBlock, { kind: "user" | "agent" }>;
+  } | null = null;
+
+  for (const atom of atoms) {
+    if (atom.type === "message") {
+      const lane = messageLane(atom.message);
+      const text = stripAnsi(atom.message.content);
+      if (openLane && openLane.lane === lane) {
+        openLane.block.content += text;
+        continue;
+      }
+      if (lane === "user") {
+        const block: ConversationBlock = {
+          kind: "user",
+          key: `msg-${atom.message.id}`,
+          at: atom.at,
+          content: text,
+        };
+        blocks.push(block);
+        openLane = { lane, block };
+      } else {
+        const block: ConversationBlock = {
+          kind: "agent",
+          key: `msg-${atom.message.id}`,
+          at: atom.at,
+          senderName: resolveSenderName(atom.message),
+          content: text,
+          tone: atom.message.direction === "stderr" ? "error" : "normal",
+        };
+        blocks.push(block);
+        openLane = { lane, block };
+      }
+      continue;
+    }
+    openLane = null;
+    if (atom.type === "tool") {
+      blocks.push({
+        kind: "tool",
+        key: `tool-${atom.tool.id}`,
+        at: atom.at,
+        tool: atom.tool,
+      });
+    } else {
+      const meta = noticeMeta(atom.eventType);
+      blocks.push({
+        kind: "notice",
+        key: `evt-${atom.order}`,
+        at: atom.at,
+        icon: meta.icon,
+        tone: meta.tone,
+        text: atom.summary.trim() || meta.label,
+      });
+    }
+  }
+
+  return blocks;
+}
+
+// --- Lightweight markdown ---------------------------------------------------
+// The agent writes markdown prose; rendering it (code fences, inline code,
+// bold, lists, headings) is what makes the room read like a chat rather than a
+// log. This is deliberately small — no external markdown engine — matching the
+// in-repo precedent (config-field's preview renderer).
+
+const FENCE = /```([\w-]*)\n?([\s\S]*?)```/g;
+
+function renderInline(text: string, keyBase: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  const pattern =
+    /\*\*([^*]+)\*\*|`([^`]+)`|\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
+  let last = 0;
+  let index = 0;
+  let match = pattern.exec(text);
+  while (match !== null) {
+    if (match.index > last) nodes.push(text.slice(last, match.index));
+    if (match[1] !== undefined) {
+      nodes.push(
+        <strong key={`${keyBase}-b${index}`} className="font-semibold text-txt">
+          {match[1]}
+        </strong>,
+      );
+    } else if (match[2] !== undefined) {
+      nodes.push(
+        <code
+          key={`${keyBase}-c${index}`}
+          className="rounded bg-bg/70 px-1 py-px font-mono text-[0.95em] text-accent"
+        >
+          {match[2]}
+        </code>,
+      );
+    } else if (match[3] !== undefined) {
+      nodes.push(
+        <a
+          key={`${keyBase}-l${index}`}
+          href={match[4]}
+          target="_blank"
+          rel="noreferrer"
+          className="text-accent underline underline-offset-2"
+        >
+          {match[3]}
+        </a>,
+      );
+    }
+    last = match.index + match[0].length;
+    index += 1;
+    match = pattern.exec(text);
+  }
+  if (last < text.length) nodes.push(text.slice(last));
+  return nodes;
+}
+
+function renderProse(text: string, keyBase: string): ReactNode {
+  const lines = text.split("\n");
+  return lines.map((line, lineIndex) => {
+    const key = `${keyBase}-${lineIndex}`;
+    if (line.trim() === "") return <div key={key} className="h-2" />;
+    const heading = /^(#{1,6})\s+(.*)$/.exec(line);
+    if (heading) {
+      return (
+        <div key={key} className="mt-1 font-semibold text-txt">
+          {renderInline(heading[2], key)}
+        </div>
+      );
+    }
+    const bullet = /^\s*[-*•]\s+(.*)$/.exec(line);
+    if (bullet) {
+      return (
+        <div key={key} className="flex gap-1.5">
+          <span className="select-none text-muted">•</span>
+          <span className="min-w-0 flex-1">{renderInline(bullet[1], key)}</span>
+        </div>
+      );
+    }
+    const numbered = /^\s*(\d+)\.\s+(.*)$/.exec(line);
+    if (numbered) {
+      return (
+        <div key={key} className="flex gap-1.5">
+          <span className="select-none tabular-nums text-muted">
+            {numbered[1]}.
+          </span>
+          <span className="min-w-0 flex-1">
+            {renderInline(numbered[2], key)}
+          </span>
+        </div>
+      );
+    }
+    return (
+      <div key={key} className="break-words leading-relaxed">
+        {renderInline(line, key)}
+      </div>
+    );
+  });
+}
+
+export function MarkdownText({ text }: { text: string }): ReactNode {
+  const segments: ReactNode[] = [];
+  let last = 0;
+  let index = 0;
+  FENCE.lastIndex = 0;
+  let match = FENCE.exec(text);
+  while (match !== null) {
+    if (match.index > last) {
+      segments.push(
+        <div key={`p${index}`}>
+          {renderProse(text.slice(last, match.index), `p${index}`)}
+        </div>,
+      );
+    }
+    segments.push(
+      <CodeBlock
+        key={`f${index}`}
+        language={match[1]}
+        code={match[2].replace(/\n$/, "")}
+      />,
+    );
+    last = match.index + match[0].length;
+    index += 1;
+    match = FENCE.exec(text);
+  }
+  if (last < text.length) {
+    segments.push(
+      <div key={`p${index}`}>{renderProse(text.slice(last), `p${index}`)}</div>,
+    );
+  }
+  return <div className="space-y-0.5">{segments}</div>;
+}
+
+function CodeBlock({
+  language,
+  code,
+}: {
+  language?: string;
+  code: string;
+}): ReactNode {
+  return (
+    <div className="my-1 overflow-hidden rounded-md border border-border/50 bg-bg/80">
+      {language ? (
+        <div className="border-b border-border/40 px-2 py-0.5 font-mono text-2xs text-muted">
+          {language}
+        </div>
+      ) : null}
+      <pre className="max-h-72 overflow-auto px-2.5 py-1.5 font-mono text-2xs leading-relaxed text-txt">
+        {code}
+      </pre>
+    </div>
+  );
+}
+
+// --- Conversation block views ----------------------------------------------
+
+const TOOL_ICON_BY_KIND: Record<string, LucideIcon> = {
+  edit: FilePen,
+  read: FileText,
+  execute: Terminal,
+  search: Search,
+  fetch: Globe,
+  move: FilePen,
+  delete: FilePen,
+  think: Wrench,
+};
+
+const TOOL_ICON_BY_TITLE: Record<string, LucideIcon> = {
+  write: FilePlus,
+  edit: FilePen,
+  read: FileText,
+  bash: Terminal,
+  shell: Terminal,
+  grep: Search,
+  glob: Search,
+  list: Search,
+  webfetch: Globe,
+  fetch: Globe,
+};
+
+function toolIcon(tool: ToolView): LucideIcon {
+  return (
+    TOOL_ICON_BY_TITLE[tool.title.toLowerCase()] ??
+    TOOL_ICON_BY_KIND[tool.kind.toLowerCase()] ??
+    Wrench
+  );
+}
+
+/** The shortest meaningful one-liner about what a tool touched, shown in the
+ * collapsed header (file name, command, or query). */
+function toolTarget(tool: ToolView): string | undefined {
+  if (tool.filePath) {
+    const parts = tool.filePath.split("/");
+    return parts[parts.length - 1] || tool.filePath;
+  }
+  if (tool.command) return tool.command;
+  if (tool.query) return tool.query;
+  return undefined;
+}
+
+const STATUS_BADGE: Record<
+  ToolStatus,
+  { icon: LucideIcon; tone: string; label: string; spin?: boolean }
+> = {
+  running: { icon: Loader, tone: "text-accent", label: "Running", spin: true },
+  done: { icon: Check, tone: "text-ok", label: "Done" },
+  failed: { icon: CircleX, tone: "text-danger", label: "Failed" },
+};
+
+const MAX_BODY_CHARS = 4000;
+
+function clamp(text: string): { body: string; truncated: boolean } {
+  if (text.length <= MAX_BODY_CHARS) return { body: text, truncated: false };
+  return { body: text.slice(0, MAX_BODY_CHARS), truncated: true };
+}
+
+function DiffLines({
+  text,
+  sign,
+}: {
+  text: string;
+  sign: "+" | "-";
+}): ReactNode {
+  const tone = sign === "+" ? "bg-ok/10 text-ok" : "bg-danger/10 text-danger";
+  // One block per side (all removals, then all additions), each line prefixed
+  // with its sign — rendered as a single <pre> so there are no per-line keys to
+  // collide and the column stays aligned.
+  const body = text
+    .split("\n")
+    .map((line) => `${sign} ${line}`)
+    .join("\n");
+  return (
+    <pre className={`whitespace-pre-wrap break-words px-2 ${tone}`}>{body}</pre>
+  );
+}
+
+/** The expandable body of a tool card: a +/- diff for edits, the new content
+ * for writes, the command + output for shells, and the raw output otherwise. */
+function ToolBody({ tool }: { tool: ToolView }): ReactNode {
+  const blocks: ReactNode[] = [];
+
+  if (tool.oldText !== undefined && tool.newText !== undefined) {
+    blocks.push(
+      <div
+        key="diff"
+        className="overflow-auto rounded-md border border-border/40 bg-bg/60 py-1 font-mono text-2xs leading-relaxed"
+        style={{ maxHeight: "18rem" }}
+      >
+        <DiffLines text={clamp(tool.oldText).body} sign="-" />
+        <DiffLines text={clamp(tool.newText).body} sign="+" />
+      </div>,
+    );
+  } else if (tool.newText !== undefined) {
+    const { body, truncated } = clamp(tool.newText);
+    blocks.push(
+      <pre
+        key="content"
+        className="overflow-auto rounded-md border border-border/40 bg-bg/60 px-2.5 py-1.5 font-mono text-2xs leading-relaxed text-txt"
+        style={{ maxHeight: "18rem" }}
+      >
+        {body}
+        {truncated ? "\n… (truncated)" : ""}
+      </pre>,
+    );
+  }
+
+  if (tool.command) {
+    blocks.push(
+      <div
+        key="cmd"
+        className="rounded-md border border-border/40 bg-black/40 px-2.5 py-1 font-mono text-2xs text-txt"
+      >
+        <span className="select-none text-ok">$ </span>
+        <span className="whitespace-pre-wrap break-words">{tool.command}</span>
+      </div>,
+    );
+  }
+
+  if (tool.output) {
+    const { body, truncated } = clamp(tool.output);
+    blocks.push(
+      <pre
+        key="out"
+        className="overflow-auto rounded-md border border-border/40 bg-bg/60 px-2.5 py-1.5 font-mono text-2xs leading-relaxed text-muted"
+        style={{ maxHeight: "14rem" }}
+      >
+        {body}
+        {truncated ? "\n… (truncated)" : ""}
+      </pre>,
+    );
+  }
+
+  if (blocks.length === 0) return null;
+  return <div className="mt-1.5 space-y-1.5">{blocks}</div>;
+}
+
+function ToolCallCard({
+  tool,
+  at,
+  locale,
+}: {
+  tool: ToolView;
+  at: number;
+  locale?: string;
+}): ReactNode {
+  const Icon = toolIcon(tool);
+  const badge = STATUS_BADGE[tool.status];
+  const BadgeIcon = badge.icon;
+  const target = toolTarget(tool);
+  const hasBody = Boolean(
+    tool.newText !== undefined || tool.command || tool.output,
+  );
+  // Open by default while the agent is mid-edit so the change is visible as it
+  // streams; collapse finished read/search calls to keep the room scannable.
+  const [open, setOpen] = useState(
+    () => hasBody && tool.kind !== "read" && tool.kind !== "search",
+  );
+  return (
+    <div
+      className="rounded-md border border-border/50 bg-bg-accent/20"
+      data-testid="orchestrator-tool-call"
+    >
+      <button
+        type="button"
+        disabled={!hasBody}
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left disabled:cursor-default"
+      >
+        {hasBody ? (
+          <ChevronRight
+            className={`h-3 w-3 shrink-0 text-muted transition-transform ${open ? "rotate-90" : ""}`}
+          />
+        ) : (
+          <span className="w-3 shrink-0" />
+        )}
+        <Icon className="h-3.5 w-3.5 shrink-0 text-accent" />
+        <span className="shrink-0 font-mono text-xs font-semibold text-txt">
+          {tool.title}
+        </span>
+        {target ? (
+          <span className="min-w-0 flex-1 truncate font-mono text-2xs text-muted">
+            {target}
+          </span>
+        ) : (
+          <span className="flex-1" />
+        )}
+        <span
+          className={`flex shrink-0 items-center gap-1 text-2xs ${badge.tone}`}
+        >
+          <BadgeIcon
+            className={`h-3 w-3 ${badge.spin ? "animate-spin" : ""}`}
+          />
+          {badge.label}
+        </span>
+        <span className="shrink-0 tabular-nums text-2xs text-muted/70">
+          {formatClockTime(at, locale)}
+        </span>
+      </button>
+      {open ? (
+        <div className="px-2.5 pb-2">{<ToolBody tool={tool} />}</div>
+      ) : null}
+    </div>
+  );
+}
+
+export function ConversationBlockView({
+  block,
+  locale,
+}: {
+  block: ConversationBlock;
+  locale?: string;
+}): ReactNode {
+  if (block.kind === "user") {
+    return (
+      <div
+        className="flex flex-col items-end"
+        data-testid="orchestrator-user-message"
+      >
+        <div
+          className="rounded-lg bg-accent/20 px-2.5 py-1.5 text-xs text-txt"
+          style={{ maxWidth: "88%" }}
+        >
+          <div className="mb-0.5 text-2xs tabular-nums text-muted">
+            {formatClockTime(block.at, locale)}
+          </div>
+          <div className="whitespace-pre-wrap break-words">{block.content}</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (block.kind === "agent") {
+    return (
+      <div
+        className="flex flex-col items-start"
+        data-testid="orchestrator-agent-message"
+      >
+        <div
+          className={`rounded-lg px-2.5 py-1.5 text-xs ${
+            block.tone === "error"
+              ? "bg-danger/10 text-danger"
+              : "bg-bg-hover/60 text-txt"
+          }`}
+          style={{ maxWidth: "92%" }}
+        >
+          <div className="mb-0.5 flex items-center gap-2 text-2xs text-muted">
+            <span className="font-semibold tracking-tight text-txt/90">
+              {block.senderName}
+            </span>
+            <span className="tabular-nums">
+              {formatClockTime(block.at, locale)}
+            </span>
+          </div>
+          <MarkdownText text={block.content} />
+        </div>
+      </div>
+    );
+  }
+
+  if (block.kind === "tool") {
+    return <ToolCallCard tool={block.tool} at={block.at} locale={locale} />;
+  }
+
+  const Icon = block.icon;
+  return (
+    <div
+      className="flex items-center gap-2 px-1 text-2xs text-muted"
+      data-testid="orchestrator-notice"
+    >
+      <span className="h-px flex-1 bg-border/40" />
+      <Icon className={`h-3 w-3 shrink-0 ${block.tone}`} />
+      <span className={`min-w-0 shrink truncate font-medium ${block.tone}`}>
+        {block.text}
+      </span>
+      <span className="shrink-0 tabular-nums">
+        {formatClockTime(block.at, locale)}
+      </span>
+      <span className="h-px flex-1 bg-border/40" />
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
@@ -22,6 +22,7 @@ import {
   Wrench,
 } from "lucide-react";
 import { type ReactNode, useState } from "react";
+import { DiffView } from "./orchestrator-diff";
 import { formatClockTime, stripAnsi } from "./view-format";
 
 // The orchestrator room renders a coding-agent session the way Claude Code /
@@ -316,7 +317,11 @@ export function buildConversation(
     // `in_progress`. Once the owning session has finished, a still-"running"
     // tool has in fact completed, so reflect that instead of a perpetual spinner.
     const sessionId = list[0].sessionId;
-    if (tool.status === "running" && sessionId && finishedSessionIds.has(sessionId)) {
+    if (
+      tool.status === "running" &&
+      sessionId &&
+      finishedSessionIds.has(sessionId)
+    ) {
       tool.status = "done";
     }
     atoms.push({
@@ -602,54 +607,30 @@ function clamp(text: string): { body: string; truncated: boolean } {
   return { body: text.slice(0, MAX_BODY_CHARS), truncated: true };
 }
 
-function DiffLines({
-  text,
-  sign,
-}: {
-  text: string;
-  sign: "+" | "-";
-}): ReactNode {
-  const tone = sign === "+" ? "bg-ok/10 text-ok" : "bg-danger/10 text-danger";
-  // One block per side (all removals, then all additions), each line prefixed
-  // with its sign — rendered as a single <pre> so there are no per-line keys to
-  // collide and the column stays aligned.
-  const body = text
-    .split("\n")
-    .map((line) => `${sign} ${line}`)
-    .join("\n");
+function TruncatedNote(): ReactNode {
   return (
-    <pre className={`whitespace-pre-wrap break-words px-2 ${tone}`}>{body}</pre>
+    <div className="px-1 text-2xs text-muted/70">… (truncated for display)</div>
   );
 }
 
-/** The expandable body of a tool card: a +/- diff for edits, the new content
- * for writes, the command + output for shells, and the raw output otherwise. */
+/** The expandable body of a tool card: an interleaved diff for edits, the new
+ * content for writes, the command + output for shells, and the raw output
+ * otherwise. */
 function ToolBody({ tool }: { tool: ToolView }): ReactNode {
   const blocks: ReactNode[] = [];
 
   if (tool.oldText !== undefined && tool.newText !== undefined) {
+    const before = clamp(tool.oldText);
+    const after = clamp(tool.newText);
     blocks.push(
-      <div
-        key="diff"
-        className="overflow-auto rounded-md border border-border/40 bg-bg/60 py-1 font-mono text-2xs leading-relaxed"
-        style={{ maxHeight: "18rem" }}
-      >
-        <DiffLines text={clamp(tool.oldText).body} sign="-" />
-        <DiffLines text={clamp(tool.newText).body} sign="+" />
-      </div>,
+      <DiffView key="diff" oldText={before.body} newText={after.body} />,
     );
+    if (before.truncated || after.truncated)
+      blocks.push(<TruncatedNote key="diff-trunc" />);
   } else if (tool.newText !== undefined) {
     const { body, truncated } = clamp(tool.newText);
-    blocks.push(
-      <pre
-        key="content"
-        className="overflow-auto rounded-md border border-border/40 bg-bg/60 px-2.5 py-1.5 font-mono text-2xs leading-relaxed text-txt"
-        style={{ maxHeight: "18rem" }}
-      >
-        {body}
-        {truncated ? "\n… (truncated)" : ""}
-      </pre>,
-    );
+    blocks.push(<DiffView key="content" newText={body} />);
+    if (truncated) blocks.push(<TruncatedNote key="content-trunc" />);
   }
 
   if (tool.command) {


### PR DESCRIPTION
## What
Brings the `/orchestrator` coding workbench to live, Claude-Code/Codex-style parity, end-to-end on the **opencode + Cerebras (gpt-oss-120b)** backend. Each commit is gate-green (tsgo + biome + vitest) and proven in a real headless-Chrome session.

## Commits
1. **auto-spawn opencode+cerebras on first message** — messaging a task with no live agent now spawns one (was the unimplemented `elizaos` default → `spawn ENOENT`); default framework → vendored opencode; per-task workdir.
2. **Claude-Code-style streaming workbench view** — coalesces streamed stdout chunks into one markdown turn; renders `tool_running` events as structured tool-call cards; typed status notices; finished-session tools resolve to ✓; fixes cross-task transcript contamination.
3. **key view-manager cards by viewType+id** — removes 9 duplicate-React-key console errors.
4. **real interleaved diff viewer** — LCS line-diff with old/new gutters + +/-/context coloring (replaces the flat all-removals-then-all-additions); unit-tested.
5. **Stop / Esc interrupt** — a prominent "Agent working… / Stop (Esc)" bar; global Esc cancels the run (proven: stopped a run in ~0.5s, work halted 5/12 files).
6. **test fixes** — update two unit tests to the auto-spawn + opencode-default behavior.
7. **live SSE transport** — per-task change bus + `GET /tasks/:taskId/stream` SSE endpoint + an EventSource client; the room updates live (sub-second) instead of polling, polling kept only as reconnect fallback.

## Proof (headless Chrome, opencode+cerebras)
- Tool-call cards + coalesced markdown, **0 legacy fragments**, **0 duplicate-key console errors**.
- Real interleaved diff on a live edit (`- sugar is sweet` / `+ and so are you`).
- Esc interrupted a run mid-work (5/12 files, ~0.5s).
- SSE: `ready` + 23 `change` pings over a run; the workbench's EventSource subscribes and the conversation grows sub-second.
- `tsgo` + `biome` + `vitest` (503 plugin tests) green.

## Backend
Coding backend stays **opencode + Cerebras** (vendored, gpt-oss-120b). No Claude/Codex backend.

## Follow-ups (next PRs)
Interactive permission round-trip, live plan/todo checklist, multi-backend normalization (claude/codex), and the P1 set (changed-files nav, slash menu, @-file refs, cost meter, ANSI terminal, keyboard overlay, error/retry cards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR brings the `/orchestrator` workbench to a Claude-Code-style live coding experience: SSE-based sub-second room updates (replacing pure polling), a real interleaved LCS diff viewer, Stop/Esc interrupt, auto-spawn of an opencode+Cerebras agent on first message, tool-call cards that coalesce streamed chunks, and a fix for nine duplicate React keys.

- **SSE transport** (`GET /tasks/:taskId/stream`): a per-task change-bus in `OrchestratorTaskService` publishes pings whenever a message, event, usage or status write lands; the workbench's `EventSource` subscriber debounces these into one tail-refetch per 150 ms window, with the existing poll kept as a reconnect fallback.
- **Auto-spawn on message**: messaging a task with no live agent now triggers `spawnAgentForTask` into a per-task `~/.eliza/workspaces/<taskId>` workdir and defaults the framework to `opencode` instead of the unimplemented `elizaos` native backend.
- **Diff / stream views** (`orchestrator-diff.tsx`, `orchestrator-stream.tsx`): new files implementing the LCS diff renderer (unit-tested) and the conversation-coalescing + tool-card logic.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one targeted fix: auto-spawn failures should be surfaced to the caller rather than silently swallowed.

The central new feature — messaging a task with no live agent auto-spawns one — fails silently when the spawn throws (e.g. opencode not on PATH, filesystem error). The service catches the exception, appends it to a failedTo array, and still returns HTTP 201. The workbench only checks !delivered (always false for a 201), so the failedTo entry is never shown to the user. The rest of the PR (SSE transport, LCS diff, Stop/Esc, React key fix, streaming coalescing) is mechanically sound and well-tested.

plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts — the auto-spawn catch block around line 810 needs to propagate or surface the failure rather than only logging it.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts | Adds auto-spawn on first message, SSE change-bus (subscribeTaskChanges/emitChange), and opencode default framework. Auto-spawn failure is caught and appended to failedTo but the HTTP response stays 201, so the client never sees the error. |
| plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts | Adds GET /tasks/:taskId/stream SSE endpoint with heartbeat, per-task change-bus subscription, and dual req.on(close/error) cleanup. Cleanup is effectively called twice on TCP errors, but all operations are idempotent so no real breakage. |
| plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx | Adds SSE subscription effect, debounced scheduleRefetch, Stop/Esc interrupt handler, and updated fetchDetail/polling logic. Esc guard and ToolCallCard open-state issues already captured in prior threads. |
| plugins/plugin-task-coordinator/src/orchestrator-stream.tsx | New file implementing buildConversation, MarkdownText, ToolCallCard and ConversationBlockView; message coalescing, tool-event merging, finished-session status fixup are all well-handled. |
| plugins/plugin-task-coordinator/src/orchestrator-diff.tsx | New LCS-based interleaved diff renderer with MAX_ALIGN_LINES fallback. Algorithm and key generation are correct. Well unit-tested. |
| packages/ui/src/api/client-agent.ts | Adds streamOrchestratorTask that creates an EventSource, forwards change pings to the caller, and returns an unsubscribe function. No-ops where EventSource is unavailable. |
| packages/ui/src/components/pages/ViewManagerPage.tsx | Fixes duplicate React keys by compositing viewType+id instead of id alone. Correct and minimal change. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as OrchestratorWorkbench
    participant Client as ElizaClient (SSE)
    participant Route as GET /tasks/:id/stream
    participant Service as OrchestratorTaskService
    participant Bus as changeListeners (Map)

    UI->>Client: streamOrchestratorTask(taskId, scheduleRefetch)
    Client->>Route: EventSource connect
    Route->>Service: getTask(taskId) — verify exists
    Route->>Bus: subscribeTaskChanges(taskId, sendChange)
    Route-->>Client: "data: {type:ready}"

    Note over Service: On any write (message/event/usage/status)
    Service->>Bus: emitChange(taskId)
    Bus->>Route: "listener() → send({type:change})"
    Route-->>Client: "data: {type:change}"
    Client->>UI: onChange() → scheduleRefetch (150ms debounce)
    UI->>UI: fetchDetail(taskId, false)

    Note over Route: Every 20s (proxy keepalive)
    Route-->>Client: : ping

    Note over UI: On selectedId change / unmount
    UI->>Client: unsubscribe()
    Client->>Client: source.close()
    Route->>Bus: unsubscribe() → remove listener
    Route->>Route: clearInterval(heartbeat)
```

<sub>Reviews (8): Last reviewed commit: ["fix(orchestrator): Esc closes an open mo..."](https://github.com/elizaos/eliza/commit/badbf44af9692d76757853b0c1ded57f91ea93fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34800292)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->