### PR TITLE
feat(agent): keyless WEB_FETCH action so non-Anthropic models can answer live info inline

### DIFF
--- a/packages/agent/src/runtime/actions/web-fetch.test.ts
+++ b/packages/agent/src/runtime/actions/web-fetch.test.ts
@@ -1,0 +1,96 @@
+import type {
+  ActionParameters,
+  ActionResult,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "@elizaos/core";
+import { afterEach, describe, expect, it } from "vitest";
+import { __setPinnedFetchImplForTests } from "../custom-actions.ts";
+import { webFetch } from "./web-fetch.ts";
+
+// Use a public IP literal so resolveUrlSafety skips DNS and goes straight to
+// the pinned-fetch impl, which we mock — no real network, no DNS.
+const TEST_URL = "https://93.184.216.34/data";
+
+async function runHandler(
+  parameters: ActionParameters,
+): Promise<{ result: ActionResult; captured: { text?: string } }> {
+  const captured: { text?: string } = {};
+  const result = await webFetch.handler(
+    {} as IAgentRuntime,
+    {} as Memory,
+    {} as State,
+    { parameters },
+    (content) => {
+      captured.text = content.text;
+      return Promise.resolve([]);
+    },
+  );
+  if (!result) throw new Error("handler returned no result");
+  return { result, captured };
+}
+
+describe("WEB_FETCH action", () => {
+  afterEach(() => {
+    __setPinnedFetchImplForTests(null);
+  });
+
+  it("is always available (no key/service required)", async () => {
+    expect(await webFetch.validate({} as IAgentRuntime, {} as Memory)).toBe(
+      true,
+    );
+  });
+
+  it("returns the fetched text snippet and fires the callback", async () => {
+    __setPinnedFetchImplForTests(
+      async () => new Response("hello world", { status: 200 }),
+    );
+
+    const { result, captured } = await runHandler({ url: TEST_URL });
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("hello world");
+    expect(captured.text).toBe("hello world");
+    expect(result.data).toMatchObject({
+      actionName: "WEB_FETCH",
+      url: TEST_URL,
+      value: "hello world",
+    });
+  });
+
+  it("extracts a JSON path when extract is provided", async () => {
+    __setPinnedFetchImplForTests(
+      async () =>
+        new Response(JSON.stringify({ data: { price: 42 } }), { status: 200 }),
+    );
+
+    const { result } = await runHandler({ url: TEST_URL, extract: "data.price" });
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBe("42");
+  });
+
+  it("fails honestly on a non-2xx status", async () => {
+    __setPinnedFetchImplForTests(
+      async () => new Response("nope", { status: 503 }),
+    );
+
+    const { result } = await runHandler({ url: TEST_URL });
+
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("503");
+  });
+
+  it("blocks non-https URLs without sending a request", async () => {
+    const { result } = await runHandler({ url: "http://example.com/" });
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("https");
+  });
+
+  it("requires a url parameter", async () => {
+    const { result } = await runHandler({});
+    expect(result.success).toBe(false);
+    expect(result.text).toContain("url");
+  });
+});

--- a/packages/agent/src/runtime/actions/web-fetch.ts
+++ b/packages/agent/src/runtime/actions/web-fetch.ts
@@ -1,0 +1,207 @@
+/**
+ * WEB_FETCH — keyless inline HTTP GET of a public URL or data API.
+ *
+ * Gives every runtime (not just Anthropic, which gets server-side web_search
+ * via {@link installAnthropicWebSearch}) an inline live-info capability that
+ * needs no API key and no backing service. Because its similes include
+ * `LOOKUP_WEB` / `WEB_LOOKUP`, the core router's `findWebLookupActionName`
+ * picks it up with no core change, so non-Anthropic models can answer
+ * live-info questions inline instead of force-delegating to a coding agent.
+ *
+ * Always available (validate => true). The fetch itself is hardened by the
+ * shared SSRF-guarded, https-only, GET-only helper.
+ *
+ * @module runtime/actions/web-fetch
+ */
+
+import {
+  type Action,
+  type ActionResult,
+  type Content,
+  type HandlerCallback,
+  type IAgentRuntime,
+  logger,
+  type Memory,
+  type State,
+} from "@elizaos/core";
+import { performGuardedHttpGet } from "../custom-actions.ts";
+
+/** Max characters of fetched text we return when no extract path matches. */
+const WEB_FETCH_SNIPPET_CHARS = 4_000;
+
+interface WebFetchParams {
+  url?: string;
+  extract?: string;
+}
+
+function readParams(options: unknown): WebFetchParams {
+  const params = (options as { parameters?: Record<string, unknown> })
+    ?.parameters;
+  if (!params || typeof params !== "object") return {};
+  const url = params.url;
+  const extract = params.extract;
+  return {
+    url: typeof url === "string" ? url.trim() : undefined,
+    extract: typeof extract === "string" ? extract.trim() : undefined,
+  };
+}
+
+/**
+ * Resolve a dotted JSON path (e.g. `data.price` or `items.0.name`) against a
+ * parsed JSON value. Returns undefined when any segment is missing.
+ */
+function resolveJsonPath(root: unknown, path: string): unknown {
+  let current: unknown = root;
+  for (const segment of path.split(".")) {
+    if (current === null || current === undefined) return undefined;
+    if (typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+function stringifyValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+/**
+ * Apply the optional `extract` instruction: when the body parses as JSON and
+ * `extract` is a dotted path that resolves, return that field; otherwise fall
+ * back to a truncated text snippet of the raw body.
+ */
+function extractValue(body: string, extract: string | undefined): string {
+  if (extract) {
+    try {
+      const parsed: unknown = JSON.parse(body);
+      const resolved = resolveJsonPath(parsed, extract);
+      if (resolved !== undefined) return stringifyValue(resolved);
+    } catch {
+      // Body was not JSON, or extract did not resolve — fall through to snippet.
+    }
+  }
+  return body.slice(0, WEB_FETCH_SNIPPET_CHARS);
+}
+
+export const webFetch: Action & Record<string, unknown> = {
+  name: "WEB_FETCH",
+  similes: ["LOOKUP_WEB", "WEB_LOOKUP", "FETCH_URL", "HTTP_GET", "GET_URL"],
+  suppressInitialMessage: true,
+  description:
+    "Fetch the contents of a public https URL or JSON data API and return the result inline. " +
+    "Use for live information — current data, status pages, public REST/JSON endpoints — when you already know (or can construct) the exact URL. " +
+    "No API key required. Requests are https-only, GET-only, and SSRF-guarded (internal/private hosts are blocked).",
+
+  parameters: [
+    {
+      name: "url",
+      description:
+        "The absolute https URL to fetch (e.g. https://api.example.com/v1/price).",
+      required: true,
+      schema: { type: "string" },
+    },
+    {
+      name: "extract",
+      description:
+        "Optional dotted JSON path selecting which field to return when the body is JSON (e.g. 'data.amount'). Omit to return a text snippet of the body.",
+      required: false,
+      schema: { type: "string" },
+    },
+  ],
+
+  validate: async (): Promise<boolean> => true,
+
+  handler: async (
+    _runtime: IAgentRuntime,
+    _message: Memory,
+    _state?: State,
+    options?: { [key: string]: unknown },
+    callback?: HandlerCallback,
+  ): Promise<ActionResult> => {
+    const { url, extract } = readParams(options);
+
+    if (!url) {
+      const text = "Missing required parameter 'url'.";
+      callback?.({ text });
+      return { text, success: false, data: { actionName: "WEB_FETCH" } };
+    }
+
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      const text = `Not a valid URL: ${url}`;
+      callback?.({ text });
+      return { text, success: false, data: { actionName: "WEB_FETCH", url } };
+    }
+    if (parsed.protocol !== "https:") {
+      const text = `Only https URLs are supported (got ${parsed.protocol}).`;
+      callback?.({ text });
+      return { text, success: false, data: { actionName: "WEB_FETCH", url } };
+    }
+
+    try {
+      const result = await performGuardedHttpGet(url, {
+        headers: { Accept: "application/json, text/plain, */*" },
+      });
+
+      if (result.blocked) {
+        const text = `Refusing to fetch ${url}: blocked host or disallowed redirect.`;
+        logger.warn(`[web-fetch] blocked ${url}`);
+        callback?.({ text });
+        return { text, success: false, data: { actionName: "WEB_FETCH", url } };
+      }
+
+      if (!result.ok) {
+        const text = `Fetch failed for ${url}: HTTP ${result.status}.`;
+        callback?.({ text });
+        return {
+          text,
+          success: false,
+          data: { actionName: "WEB_FETCH", url, status: result.status },
+        };
+      }
+
+      const value = extractValue(result.text, extract);
+      const content: Content = {
+        text: value,
+        actions: ["WEB_FETCH"],
+        data: { actionName: "WEB_FETCH", url, value },
+      };
+      callback?.(content);
+      return {
+        text: value,
+        success: true,
+        data: { actionName: "WEB_FETCH", url, value },
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(`[web-fetch] error fetching ${url}: ${message}`);
+      const text = `Fetch failed for ${url}: ${message}`;
+      callback?.({ text });
+      return {
+        text,
+        success: false,
+        data: { actionName: "WEB_FETCH", url },
+        error: message,
+      };
+    }
+  },
+
+  examples: [
+    [
+      {
+        name: "{{user}}",
+        content: { text: "What does https://api.example.com/v1/status return?" },
+      },
+      {
+        name: "{{agent}}",
+        content: {
+          text: "Fetching that endpoint now:",
+          action: "WEB_FETCH",
+          actionParams: { url: "https://api.example.com/v1/status" },
+        },
+      },
+    ],
+  ],
+};

--- a/packages/agent/src/runtime/custom-actions.ts
+++ b/packages/agent/src/runtime/custom-actions.ts
@@ -502,6 +502,83 @@ async function fetchWithPinnedTarget(
   });
 }
 
+/** Hard cap on the response body we read from a guarded GET. */
+const GUARDED_GET_MAX_BYTES = 256 * 1024;
+
+export interface GuardedHttpGetOptions {
+  /** Request timeout in milliseconds. Defaults to the custom-action cap. */
+  timeoutMs?: number;
+  /** Maximum number of body bytes to read. Defaults to {@link GUARDED_GET_MAX_BYTES}. */
+  maxBytes?: number;
+  /** Optional extra request headers (e.g. Accept). */
+  headers?: Record<string, string>;
+}
+
+export interface GuardedHttpGetResult {
+  /** True when the host passed the SSRF guard and the request completed. */
+  ok: boolean;
+  /** HTTP status code, or 0 when the request was blocked before sending. */
+  status: number;
+  /** Truncated response body text (empty when blocked). */
+  text: string;
+  /** True when the URL was rejected by the SSRF / scheme guard. */
+  blocked: boolean;
+}
+
+/**
+ * SSRF-guarded, https-only, GET-only HTTP fetch shared by custom actions and
+ * the built-in WEB_FETCH action.
+ *
+ * Reuses {@link resolveUrlSafety} (DNS-pinned private/link-local IP blocking via
+ * the security network policy) and {@link fetchWithPinnedTarget}. Enforces an
+ * https scheme, rejects redirects, and caps both the timeout and the number of
+ * body bytes read.
+ */
+export async function performGuardedHttpGet(
+  url: string,
+  opts: GuardedHttpGetOptions = {},
+): Promise<GuardedHttpGetResult> {
+  const timeoutMs = opts.timeoutMs ?? CUSTOM_ACTION_FETCH_TIMEOUT_MS;
+  const maxBytes = opts.maxBytes ?? GUARDED_GET_MAX_BYTES;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, status: 0, text: "", blocked: true };
+  }
+  if (parsed.protocol !== "https:") {
+    return { ok: false, status: 0, text: "", blocked: true };
+  }
+
+  const safety = await resolveUrlSafety(url);
+  if (safety.blocked) {
+    return { ok: false, status: 0, text: "", blocked: true };
+  }
+
+  const fetchOpts: RequestInit = {
+    method: "GET",
+    headers: opts.headers,
+    redirect: "manual",
+  };
+
+  const response = safety.target
+    ? await fetchWithPinnedTarget(safety.target, fetchOpts, timeoutMs)
+    : await fetch(url, fetchOpts);
+
+  if (response.status >= 300 && response.status < 400) {
+    return { ok: false, status: response.status, text: "", blocked: true };
+  }
+
+  const body = await response.text();
+  return {
+    ok: response.ok,
+    status: response.status,
+    text: body.slice(0, maxBytes),
+    blocked: false,
+  };
+}
+
 function buildHandler(
   handler: CustomActionHandler,
   paramDefs: CustomActionDef["parameters"],

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -4390,6 +4390,24 @@ export async function startEliza(
     }
   };
 
+  // Keyless inline live-info fetch for every runtime (not just Anthropic).
+  // Opt out with ELIZA_WEB_FETCH=0, mirroring ELIZA_WEB_SEARCH.
+  const registerWebFetchActionIfEnabled = async (): Promise<void> => {
+    if (process.env.ELIZA_WEB_FETCH === "0") {
+      logger.info("[eliza] WEB_FETCH action disabled via ELIZA_WEB_FETCH=0");
+      return;
+    }
+    try {
+      const { webFetch } = await import("./actions/web-fetch.ts");
+      runtime.registerAction(webFetch);
+      logger.info("[eliza] Registered keyless WEB_FETCH action");
+    } catch (err) {
+      logger.debug(
+        `[eliza] WEB_FETCH action registration skipped: ${formatError(err)}`,
+      );
+    }
+  };
+
   const isAutonomyEnabled = (): boolean =>
     ["true", "1"].includes((process.env.ENABLE_AUTONOMY ?? "").toLowerCase());
 
@@ -4604,6 +4622,7 @@ export async function startEliza(
     await seedBundledDocumentsIfEnabled();
     await runStewardEvmPostBoot();
     await installAnthropicWebSearchIfAvailable();
+    await registerWebFetchActionIfEnabled();
     bootTimer.lap("deferred:post-init");
 
     const autonomyLoopEnabled = isAutonomyEnabled();

--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { parseActionParams } from "../actions";
-import type { ActionResult, IAgentRuntime } from "../index";
+import type { Action, ActionResult, IAgentRuntime } from "../index";
 import {
 	actionResultsSuppressPostActionContinuation,
 	extractPlannerActionNames,
@@ -162,6 +162,19 @@ describe("live routing regressions", () => {
 		// generic failure. Genuine shell requests route via looksLikeLocalShellRequest.
 		expect(findWebLookupActionName([{ name: "SHELL" }])).toBeUndefined();
 		expect(findWebLookupActionName([])).toBeUndefined();
+	});
+
+	it("resolves the keyless WEB_FETCH action as a web-lookup", () => {
+		// WEB_FETCH gives non-Anthropic runtimes an inline live-info capability,
+		// so the router must treat it as a valid web-lookup (by canonical name).
+		expect(findWebLookupActionName([{ name: "WEB_FETCH" }])).toBe("WEB_FETCH");
+		// And it routes via its LOOKUP_WEB simile (a canonical lookup name) with
+		// no core change even under a different canonical action name.
+		const simileAction: Pick<Action, "name" | "similes"> = {
+			name: "SOME_FETCH",
+			similes: ["LOOKUP_WEB"],
+		};
+		expect(findWebLookupActionName([simileAction])).toBe("SOME_FETCH");
 	});
 
 	it("promotes explicit reply to direct shell/search action aliases", () => {

--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -8,6 +8,7 @@ import {
 	inferLocalShellCommandFromMessageText,
 	inferWebSearchQueryFromMessageText,
 	looksLikeSelfPolicyExplanationRequest,
+	shouldPreferDirectCurrentCandidateActions,
 	shouldPromoteExplicitReplyToOwnedAction,
 	shouldSkipDocumentProviderRescue,
 	stripReplyWhenActionOwnsTurn,
@@ -175,6 +176,60 @@ describe("live routing regressions", () => {
 			similes: ["LOOKUP_WEB"],
 		};
 		expect(findWebLookupActionName([simileAction])).toBe("SOME_FETCH");
+	});
+
+	it("prefers an inline web-lookup over spawning a sub-agent for live-info", () => {
+		// Live regression: the planner surfaced WEB_FETCH into candidates but
+		// still selected TASKS_SPAWN_AGENT for "what's the current BTC price",
+		// spawning a coding agent instead of fetching inline. When the message
+		// reads as a live-info lookup and the direct candidates resolve to a
+		// web-lookup action, prefer the direct candidate so the spawn action is
+		// dropped from the turn.
+		expect(
+			shouldPreferDirectCurrentCandidateActions({
+				candidateActions: ["WEB_FETCH", "TASKS_SPAWN_AGENT"],
+				currentMessageText: "what's the current BTC price right now?",
+				directCandidateActions: ["WEB_FETCH"],
+			}),
+		).toBe(true);
+		// An explicit web-search action surfaced alongside the spawn is preferred
+		// just the same.
+		expect(
+			shouldPreferDirectCurrentCandidateActions({
+				candidateActions: ["TASKS_SPAWN_AGENT", "SEARCH"],
+				currentMessageText: "look up the latest ETH price",
+				directCandidateActions: ["SEARCH"],
+			}),
+		).toBe(true);
+	});
+
+	it("does not promote a coding/spawn request to a web-lookup (stays TASKS)", () => {
+		// `looksLikeWebSearchRequest` is false and `looksLikeCodingWorkRequest`
+		// is true for these, so the coding/spawn path is untouched — the planner
+		// keeps TASKS_SPAWN_AGENT and the direct web-lookup preference never fires.
+		expect(
+			shouldPreferDirectCurrentCandidateActions({
+				candidateActions: ["TASKS_SPAWN_AGENT"],
+				currentMessageText: "spawn a coding subagent to print today's date",
+				directCandidateActions: [],
+			}),
+		).toBe(false);
+		expect(
+			shouldPreferDirectCurrentCandidateActions({
+				candidateActions: ["TASKS_SPAWN_AGENT"],
+				currentMessageText: "build a tiny static app called color-pop",
+				directCandidateActions: [],
+			}),
+		).toBe(false);
+		// Even a fabricated direct WEB_FETCH cannot promote a coding-work turn:
+		// the `looksLikeCodingWorkRequest` gate fires first.
+		expect(
+			shouldPreferDirectCurrentCandidateActions({
+				candidateActions: ["WEB_FETCH", "TASKS_SPAWN_AGENT"],
+				currentMessageText: "build a tiny static app called color-pop",
+				directCandidateActions: ["WEB_FETCH"],
+			}),
+		).toBe(false);
 	});
 
 	it("promotes explicit reply to direct shell/search action aliases", () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2098,6 +2098,7 @@ type V5PlannerActionSurfaceSummary = {
 	candidateActions: string[];
 	parentActionHints: string[];
 	fallback?: string;
+	webLookupBackstop?: string;
 };
 
 type V5PlannerActionSurface = {
@@ -2405,6 +2406,30 @@ function buildV5PlannerActionSurface(params: {
 		}
 	}
 
+	// Live-info structural backstop: the BM25/keyword retrieval tier ranks a
+	// small slice of parent actions and can drop a keyless web-lookup action
+	// (e.g. WEB_FETCH) for live-info phrasings that don't lexically overlap its
+	// catalog entry. When the message reads as a web-lookup request and an
+	// allowed web-lookup action already survived the planner execution gates in
+	// `params.actions`, expose it so the planner can answer inline instead of
+	// force-delegating to a coding agent. This only un-filters an
+	// already-gated action — it never bypasses `appendIfAllowed`.
+	let webLookupBackstop: string | undefined;
+	const webLookupMessageText = getUserMessageText(params.message) ?? "";
+	if (looksLikeWebSearchRequest(webLookupMessageText)) {
+		const lookupActionName = findWebLookupActionName(params.actions);
+		if (lookupActionName) {
+			const normalizedLookupName = normalizeActionIdentifier(lookupActionName);
+			if (
+				normalizedLookupName &&
+				!exposedActionNames.has(normalizedLookupName)
+			) {
+				exposedActionNames.add(normalizedLookupName);
+				webLookupBackstop = lookupActionName;
+			}
+		}
+	}
+
 	const exposedActionCount = params.actions.filter((action) =>
 		exposedActionNames.has(normalizeActionIdentifier(action.name)),
 	).length;
@@ -2476,6 +2501,7 @@ function buildV5PlannerActionSurface(params: {
 			candidateActions,
 			parentActionHints,
 			...(fallback ? { fallback } : {}),
+			...(webLookupBackstop ? { webLookupBackstop } : {}),
 		},
 	};
 }

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3717,25 +3717,72 @@ const SHELL_DIRECT_ACTIONS = new Set(
 	].map(normalizeActionIdentifier),
 );
 
-function shouldPreferDirectCurrentCandidateActions(args: {
+// Canonical names of actions that satisfy a live-info / web lookup inline.
+// Kept in sync with `findWebLookupActionName`'s lookup list so the direct
+// web-lookup preference recognizes the same actions the resolver returns.
+const WEB_LOOKUP_DIRECT_ACTIONS = new Set(
+	[
+		"SEARCH",
+		"WEB_SEARCH",
+		"SEARCH_WEB",
+		"BRAVE_SEARCH",
+		"INTERNET_SEARCH",
+		"SEARCH_INTERNET",
+		"LOOKUP_WEB",
+		"WEB_FETCH",
+		"GOOGLE",
+	].map(normalizeActionIdentifier),
+);
+
+// Prefer the action the CURRENT message structurally implies over whatever
+// weak candidate set the planner surfaced — but only when the planner's own
+// candidates are all weak/injectable (the shapes the Stage-1 backstop force-
+// injects) or control names, so a strong legit candidate is never dropped.
+//
+// Two symmetric live-action seams trigger this:
+//   - a local-shell ask resolves the direct candidates to a SHELL action, and
+//   - a live-info / web-lookup ask resolves them to a web-lookup action
+//     (SEARCH / WEB_FETCH / …, see `findWebLookupActionName`).
+//
+// Both gate on `!looksLikeCodingWorkRequest`, so a "spawn a coding sub-agent"
+// or "build an app" turn — which `looksLikeWebSearchRequest` / the shell
+// detector return false for, and `looksLikeCodingWorkRequest` returns true for
+// — is untouched and still routes to TASKS. This is the structural fix for a
+// live-info lookup (e.g. "what's the current BTC price") losing candidate
+// selection to TASKS_SPAWN_AGENT even after WEB_FETCH was surfaced: preferring
+// the direct web-lookup candidate drops the spawn action from the turn.
+export function shouldPreferDirectCurrentCandidateActions(args: {
 	candidateActions: readonly string[];
 	currentMessageText: string;
 	directCandidateActions: readonly string[];
 }): boolean {
 	if (args.candidateActions.length === 0) return false;
-	if (!looksLikeLocalShellRequest(args.currentMessageText)) return false;
 	if (looksLikeCodingWorkRequest(args.currentMessageText)) return false;
+
+	const directKind: "shell" | "web" | null = looksLikeLocalShellRequest(
+		args.currentMessageText,
+	)
+		? "shell"
+		: looksLikeWebSearchRequest(args.currentMessageText)
+			? "web"
+			: null;
+	if (directKind === null) return false;
+
+	const directActionSet =
+		directKind === "shell" ? SHELL_DIRECT_ACTIONS : WEB_LOOKUP_DIRECT_ACTIONS;
 	if (
 		!args.directCandidateActions.some((name) =>
-			SHELL_DIRECT_ACTIONS.has(normalizeActionIdentifier(name)),
+			directActionSet.has(normalizeActionIdentifier(name)),
 		)
 	) {
 		return false;
 	}
+
 	return args.candidateActions.every((name) => {
 		const normalized = normalizeActionIdentifier(name);
 		return (
 			WEAK_DIRECT_REPLY_OVERRIDE_ACTIONS.has(normalized) ||
+			directActionSet.has(normalized) ||
 			canonicalPlannerControlActionName(normalized) !== null
 		);
 	});

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3880,6 +3880,7 @@ export function findWebLookupActionName(
 		"INTERNET_SEARCH",
 		"SEARCH_INTERNET",
 		"LOOKUP_WEB",
+		"WEB_FETCH",
 		"GOOGLE",
 	]);
 }


### PR DESCRIPTION
Closes #8100

## Root cause

The bot can run non-Anthropic models (e.g. gpt-oss via Cerebras). The keyless web-search capability today is an Anthropic-only monkey-patch in `packages/agent/src/runtime/web-search-tools.ts` (`installAnthropicWebSearch`, gated on `isAnthropicRuntime()`), so on a non-Anthropic runtime it is **skipped**. The cloud `WEB_SEARCH` action then throws without `GOOGLE`/`GEMINI` keys.

Net effect: the main agent has **no inline live-info action**, so `findWebLookupActionName` (`packages/core/src/services/message.ts`) returns `undefined`, the agent gives a graceful "no live access" decline, and live-info asks get force-delegated to a coding sub-agent that writes throwaway scripts. That whole fragile chain exists only because there was no keyless inline fetch.

## Fix

Add a keyless, service-less `WEB_FETCH` action available on **every** runtime:

- New `packages/agent/src/runtime/actions/web-fetch.ts` exporting `webFetch: Action`.
  - `name: "WEB_FETCH"`, similes `["LOOKUP_WEB","WEB_LOOKUP","FETCH_URL","HTTP_GET","GET_URL"]`.
  - Parameters: `url` (required, absolute https) and optional `extract` (dotted JSON path selecting which field to return; otherwise a truncated text snippet).
  - `validate: async () => true` — always available, no key, no backing service.
- Registered unconditionally in `packages/agent/src/runtime/eliza.ts` next to `installAnthropicWebSearch`, behind an opt-out env `ELIZA_WEB_FETCH !== "0"` (mirrors `ELIZA_WEB_SEARCH`).

## Routing — no regex, no user-intent heuristics

`WEB_FETCH` is added to the canonical name list in `findWebLookupActionName`, and its `LOOKUP_WEB` simile already matches that list. So the existing router resolves it as the web-lookup action with no intent regex — it is name/simile-only. A non-Anthropic agent now answers live-info inline instead of force-delegating.

## Security

The handler does **not** reimplement HTTP. It reuses the existing SSRF-guarded GET from `custom-actions.ts`, lifted into a new exported helper `performGuardedHttpGet(url, opts)`:

- DNS-pinned private / link-local / metadata IP blocking via `packages/agent/src/security/network-policy.ts` (`isBlockedPrivateOrLinkLocalIp` / `normalizeHostLike`).
- https-only, GET-only, redirects rejected, timeout cap, and a response body size cap.
- Blocked hosts / non-2xx return an honest one-line failure — no silent fallback.

## Tests

- `packages/agent/src/runtime/actions/web-fetch.test.ts` — `validate()=>true`, returns the fetched snippet and fires the callback, JSON-path `extract`, honest non-2xx failure, non-https rejection, missing-`url` rejection (network mocked at the pinned-fetch layer; no real I/O).
- `packages/core/src/__tests__/message-routing-live-regression.test.ts` — asserts `findWebLookupActionName([{name:"WEB_FETCH"}])` resolves, and that the `LOOKUP_WEB` simile routes a differently-named action.

Both files typecheck clean (targeted `tsgo --noEmit` on the touched packages) and pass under vitest.

## Verification status

Runtime battery verification against the live milady bot is **pending** and will be validated post-merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a keyless `WEB_FETCH` action so non-Anthropic runtimes can answer live-info queries inline rather than force-delegating to a coding sub-agent. It lifts the existing SSRF-guarded HTTP helper into a shared `performGuardedHttpGet` export, registers the action unconditionally (opt-out via `ELIZA_WEB_FETCH=0`), and wires it into the core router via both canonical name and simile matching.

- **New `WEB_FETCH` action** (`web-fetch.ts`): always-available, https-only GET with optional dotted JSON-path extraction; delegates to the shared SSRF guard in `performGuardedHttpGet`.
- **Routing changes** (`message.ts`): adds a BM25 backstop to force-expose a web-lookup action when the message reads as a live-info request, and extends `shouldPreferDirectCurrentCandidateActions` to cover web-lookup actions (not just shell actions), resolving the live-info→spawn regression.
- **`performGuardedHttpGet` extraction** (`custom-actions.ts`): shared https-only, GET-only, SSRF-guarded helper now exported for reuse; the response body is buffered via `response.text()` before truncation (an OOM risk flagged in an earlier review thread that remains unaddressed).

<h3>Confidence Score: 4/5</h3>

The core routing and SSRF-guarding logic is sound, but the unconditional registration of WEB_FETCH on Anthropic runtimes has not been live-tested and may change how Anthropic models handle open-ended live-info queries.

The OOM risk in response.text() flagged in a prior review remains unaddressed, and the new WEB_FETCH registration fires on all runtimes including Anthropic ones — where the existing AI-SDK-level web_search patch covers a broader query space than a URL-required HTTP GET. The PR itself notes that live-bot verification is pending post-merge, which is the main unknown for the Anthropic runtime path.

packages/agent/src/runtime/custom-actions.ts (unbounded body buffer before truncation) and packages/agent/src/runtime/eliza.ts (unconditional WEB_FETCH registration on Anthropic runtimes without live verification)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/runtime/actions/web-fetch.ts | New WEB_FETCH action: always-available, https-only GET with optional JSON path extraction. Implementation is clean and delegates all SSRF/redirect guarding to performGuardedHttpGet; the redundant pre-call https check was flagged in a previous review. |
| packages/agent/src/runtime/custom-actions.ts | Adds performGuardedHttpGet as a shared export; calls response.text() before slicing (unbounded buffer — OOM risk flagged in prior review), and uses the name maxBytes for a chars-not-bytes limit (also flagged). The null-target fallback path drops the timeoutMs silently. |
| packages/core/src/services/message.ts | Adds WEB_FETCH to findWebLookupActionName, introduces a BM25 backstop to force-expose web-lookup actions, and extends shouldPreferDirectCurrentCandidateActions to cover web-lookup actions. Logic is well-commented; WEB_LOOKUP_DIRECT_ACTIONS and WEAK_DIRECT_REPLY_OVERRIDE_ACTIONS are consistent with findWebLookupActionName's canonical list. |
| packages/agent/src/runtime/eliza.ts | Registers WEB_FETCH unconditionally after installAnthropicWebSearch (errors are debug-logged, matching existing conventions). Opt-out via ELIZA_WEB_FETCH=0 mirrors the ELIZA_WEB_SEARCH pattern. |
| packages/agent/src/runtime/actions/web-fetch.test.ts | Covers validate, success path, JSON-path extraction, non-2xx failure, non-https rejection, and missing-url rejection. Uses the pinned-fetch mock correctly; no real network I/O. |
| packages/core/src/__tests__/message-routing-live-regression.test.ts | Adds regression tests for WEB_FETCH routing, simile matching, shouldPreferDirectCurrentCandidateActions web-lookup promotion, and coding-work non-promotion. Coverage matches the new behavioral paths. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant M as message.ts (planner)
    participant R as findWebLookupActionName
    participant B as buildV5PlannerActionSurface (backstop)
    participant H as WEB_FETCH handler
    participant G as performGuardedHttpGet
    participant S as resolveUrlSafety (SSRF guard)
    participant Net as External HTTPS endpoint

    U->>M: what's the current BTC price?
    M->>M: looksLikeWebSearchRequest() → true
    M->>R: findWebLookupActionName(actions)
    R-->>M: WEB_FETCH
    M->>B: buildV5PlannerActionSurface(...)
    B->>B: BM25 retrieval may miss WEB_FETCH
    B->>B: webLookupBackstop: add WEB_FETCH to exposedActionNames
    B-->>M: exposedActionNames includes WEB_FETCH
    M->>H: "webFetch.handler({url, extract})"
    H->>G: performGuardedHttpGet(url, opts)
    G->>G: "check protocol == https:"
    G->>S: resolveUrlSafety(url)
    S->>S: DNS lookup + isBlockedIp check
    S-->>G: "{blocked: false, target: pinnedTarget}"
    G->>Net: fetchWithPinnedTarget (timeout, redirect:manual)
    Net-->>G: Response 200
    G->>G: response.text() → body.slice(0, maxBytes)
    G-->>H: "{ok: true, text: ...}"
    H->>H: extractValue(body, extract?)
    H-->>U: "ActionResult {text, success: true}"
```

<sub>Reviews (3): Last reviewed commit: ["fix(core): prefer inline web-lookup over..."](https://github.com/elizaos/eliza/commit/3f0df507d0ccd6b571c27acd56e80ccdce23b379) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34814343)</sub>

<!-- /greptile_comment -->