### PR TITLE
fix(orchestrator): preserve JSON-RPC error.data on ACP request failures

### DIFF
--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -632,9 +632,47 @@ function ensureResolvedInsideRoot(
   }
 }
 
+class AcpRequestError extends Error {
+  readonly code?: number;
+  readonly data?: unknown;
+
+  constructor(message: string, code?: number, data?: unknown) {
+    super(message);
+    this.name = "AcpRequestError";
+    this.code = code;
+    this.data = data;
+  }
+}
+
 function jsonRpcError(error: unknown): Error {
   const record = asRecord(error);
-  return new Error(stringValue(record?.message) ?? "ACP request failed");
+  const baseMessage = stringValue(record?.message) ?? "ACP request failed";
+  const code = numberValue(record?.code);
+  const data = record?.data;
+  // JSON-RPC error.data carries the diagnostic detail (e.g. a ZodError for
+  // -32602 "Invalid params"). Surface a compact form of it in the message so
+  // failures stay debuggable, and keep the structured value on the error.
+  if (data === undefined) {
+    return new AcpRequestError(baseMessage, code);
+  }
+  const detail = compactJson(data);
+  const message = detail ? `${baseMessage} (data: ${detail})` : baseMessage;
+  return new AcpRequestError(message, code, data);
+}
+
+function compactJson(value: unknown): string | undefined {
+  try {
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined) {
+      return undefined;
+    }
+    const limit = 2000;
+    return serialized.length > limit
+      ? `${serialized.slice(0, limit)}…`
+      : serialized;
+  } catch {
+    return undefined;
+  }
 }
 
 function extractAgentSessionId(meta: unknown): string | undefined {


### PR DESCRIPTION
Closes #8101

ACP -32602 "Invalid params" errors carry the failing-field detail in the JSON-RPC `error.data` field (e.g. a `ZodError.format()` from the agent side), but `jsonRpcError()` in `acp-native-transport.ts` only read `error.message` and discarded `error.data` entirely. That left "Invalid params" failures undiagnosable (relevant to debugging an ACP "Invalid params" issue).

This surfaces it:

- Adds a typed `AcpRequestError extends Error` carrying optional `code` and `data` (the structured value stays attached, no `any`).
- When `error.data` is present, appends a compact, length-bounded JSON form to the Error message: `... (data: {...})`. The `errorMessage()` helper in `acp-service.ts` reads `err.message`, so the enriched detail flows through the existing catch (~acp-service.ts:1187) and into the session error/event with no further changes.
- Safe: JSON.stringify is guarded (try/catch + undefined check) and truncated to 2000 chars to avoid huge/circular payloads.

Verification: targeted typecheck of `@elizaos/plugin-agent-orchestrator` (tsgo --noEmit) is clean for the touched files; remaining diagnostics are pre-existing core codegen artifacts unrelated to this change.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes JSON-RPC `error.data` being silently discarded when an ACP request fails, making `-32602 "Invalid params"` errors (and any other errors carrying structured diagnostic context) diagnosable. A new `AcpRequestError` class carries the typed `code` and `data` fields, and the `jsonRpcError` helper is updated to serialize `data` compactly into the message string so the existing `errorMessage(err)` path in `acp-service.ts` naturally picks it up without further changes.

- Adds `AcpRequestError extends Error` with readonly `code?: number` and `data?: unknown`, correctly targeting ESNext so no `Object.setPrototypeOf` workaround is needed.
- Adds `compactJson` with a `try/catch` guard and a 2000-character truncation cap to prevent circular-reference or oversized payloads from escaping into the message string.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is narrowly scoped to error-path enrichment with no effect on the happy path.

The `AcpRequestError` class and `compactJson` helper are both well-guarded — try/catch, truncation, and the early `undefined` exit in `jsonRpcError` cover the edge cases. The only notable item is that the `serialized === undefined` guard in `compactJson` is typed as unreachable (TypeScript says `JSON.stringify` returns `string`), though it is harmless at runtime. The enriched message flows correctly through the existing `err.message` → `errorMessage()` → session-error chain without touching any other code path.

No files require special attention; the single touched file is a self-contained helper used only on the error-response path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts | Adds AcpRequestError class and updates jsonRpcError to preserve error.data from JSON-RPC responses; logic is correct, one minor defensive check deserves a note |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as ACP Agent (acpx)
    participant Transport as acp-native-transport.ts
    participant Service as acp-service.ts

    Agent->>Transport: "JSON-RPC error response {code: -32602, message: Invalid params, data: {ZodError}}"
    Transport->>Transport: jsonRpcError(error) read message, code, data
    Transport->>Transport: compactJson(data) safe JSON.stringify + truncate
    Transport->>Transport: new AcpRequestError(message + data detail, code, data)
    Transport->>Service: Promise.reject(AcpRequestError)
    Service->>Service: catch(err) errorMessage(err) returns err.message with enriched detail
    Service->>Service: store.updateStatus / emitSessionEvent with enriched error message
```

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): preserve json-rpc err..."](https://github.com/elizaos/eliza/commit/4d6b1658fab87ff1881547dcc59372c62bbf5c7a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34814518)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->
