### PR TITLE
ci: guard against dangling electrobun submodule pins

### DIFF
--- a/.github/workflows/electrobun-submodule-guard.yml
+++ b/.github/workflows/electrobun-submodule-guard.yml
@@ -1,0 +1,65 @@
+# Electrobun Submodule Guard
+#
+# Fails fast when the `upstreams/electrobun` submodule gitlink points at a commit
+# that is NOT fetchable from its configured remote — the recurring "dangling
+# pointer" that breaks `git submodule update` for every fresh clone and CI run.
+#
+# History of this bug (each a commit that pinned an unfetchable SHA):
+#   db785c6dc6 -> fixed by 2881d83894 -> regressed to 6bedce8261 (evil merge
+#   f5ae5dfed5) -> root cause finally fixed by d32749acdc, which repointed the
+#   submodule URL at the elizaOS/electrobun fork (where the real, ahead-of-public
+#   electrobun development actually lives) instead of upstream blackboardsh/electrobun.
+#
+# This guard keeps it from regressing: any PR/push that moves the gitlink or the
+# URL must leave a pin that the remote can actually serve.
+name: Electrobun Submodule Guard
+
+on:
+  pull_request:
+    paths:
+      - "upstreams/electrobun"
+      - ".gitmodules"
+  push:
+    branches: [develop, main]
+    paths:
+      - "upstreams/electrobun"
+      - ".gitmodules"
+
+permissions:
+  contents: read
+
+jobs:
+  verify-electrobun-pin:
+    name: electrobun gitlink is fetchable
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout (no submodules)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          submodules: false
+
+      - name: Verify the electrobun pin is fetchable from its remote
+        run: |
+          set -euo pipefail
+          url=$(git config -f .gitmodules submodule.upstreams/electrobun.url || true)
+          sha=$(git ls-tree HEAD upstreams/electrobun | awk '{print $3}' || true)
+          echo "configured url: ${url:-<none>}"
+          echo "pinned commit:  ${sha:-<none>}"
+          if [ -z "${url}" ] || [ -z "${sha}" ]; then
+            echo "::error::Could not read the electrobun submodule URL or pinned commit from .gitmodules / the tree."
+            exit 1
+          fi
+          # Mirror exactly what `git submodule update` does: fetch that exact commit.
+          # GitHub serves any commit reachable from a ref (allowReachableSHA1InWant);
+          # a dangling/unpushed commit fails here just as it would for a fresh clone.
+          tmp=$(mktemp -d)
+          git init -q "${tmp}"
+          if git -C "${tmp}" fetch -q --depth=1 "${url}" "${sha}" 2>/dev/null; then
+            echo "OK: ${sha} is fetchable from ${url}"
+          else
+            echo "::error::electrobun submodule pin ${sha} is NOT fetchable from ${url}."
+            echo "::error::A fresh 'git submodule update' will fail ('not our ref') — this is the recurring dangling-gitlink bug."
+            echo "::error::Fix: push that electrobun commit to the configured remote, or repoint the pin/URL to a commit the remote serves (e.g. the elizaOS/electrobun develop or main HEAD)."
+            exit 1
+          fi


### PR DESCRIPTION
## Why

The `upstreams/electrobun` submodule gitlink has repeatedly been pinned to commits that aren't fetchable from its configured remote, breaking `git submodule update` for every fresh clone / CI run ("not our ref"). It recurred several times (`db785c6dc6`, `6bedce8261` via the evil merge `f5ae5dfed5`, …).

**Root cause:** electrobun is developed on the **`elizaOS/electrobun` fork** (its `develop` runs ~31 commits ahead of public `blackboardsh/electrobun` `main`), but the submodule URL pointed at upstream `blackboardsh`, where those commits don't exist — so every pin recorded from the fork was dangling for everyone else. That root cause was fixed by `d32749acdc` (repointing the URL at the fork).

## What

A small, fast CI guard so it can't regress: on any PR/push that touches `upstreams/electrobun` or `.gitmodules`, fetch the pinned commit from the configured remote (exactly what `git submodule update` does). If it isn't fetchable, fail with an actionable message.

- Triggered only on changes to the submodule pin / `.gitmodules` (cheap).
- `submodules: false` checkout; ~seconds.
- Mirrors the real failure mode (`allowReachableSHA1InWant` fetch by SHA).

No-op on a healthy pin (verified against current develop's `4fdf47488c`, which is fetchable from the fork).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a focused CI workflow that guards against the recurring `upstreams/electrobun` dangling-submodule bug by attempting a real `git fetch` of the pinned commit from its configured remote on any PR or push that touches the submodule path or `.gitmodules`.

- **Guard logic**: reads the submodule URL from `.gitmodules` and the pinned SHA from `git ls-tree`, then mirrors what `git submodule update` does by fetching that exact SHA with `--depth=1` from a fresh, temporary repo — failing with an actionable error if the commit isn't reachable.
- **Scope**: triggered only on relevant path changes, runs in ~seconds with `submodules: false`, and carries a `timeout-minutes: 5` ceiling; permissions are minimal (`contents: read`).
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the workflow correctly mirrors the real failure mode and only runs on relevant path changes.

The guard's core logic is sound: it reads the URL and SHA from the repo tree and does a real shallow fetch from the configured remote, exactly as git submodule update would. Suppressing stderr on the fetch step means transient network errors and the actual dangling-ref error produce identical output, which can make future CI failures harder to diagnose.

The single changed file .github/workflows/electrobun-submodule-guard.yml is worth a second look at line 58 where 2>/dev/null discards Git's error output.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/electrobun-submodule-guard.yml | New CI guard that fetches the pinned electrobun submodule SHA from its configured remote on any PR touching the submodule path or .gitmodules; logic is sound with two minor style/debuggability gaps (suppressed stderr on fetch, missing version comment on pinned action SHA). |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant PR as PR / Push
    participant GHA as GitHub Actions
    participant Repo as elizaos/eliza
    participant Remote as Configured Submodule Remote

    PR->>GHA: paths match upstreams/electrobun or .gitmodules
    GHA->>Repo: actions/checkout (submodules: false)
    GHA->>GHA: git config -f .gitmodules url
    GHA->>GHA: git ls-tree HEAD upstreams/electrobun sha
    GHA->>GHA: git init tmp/
    GHA->>Remote: "git fetch --depth=1 url sha"
    alt SHA is reachable
        Remote-->>GHA: pack data (shallow)
        GHA-->>PR: OK pin is fetchable
    else SHA is dangling / not on any ref
        Remote-->>GHA: error not our ref
        GHA-->>PR: FAIL actionable error message
    end
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Felectrobun-submodule-guard.yml%3A58%0ASuppressing%20stderr%20hides%20transient%20failures%20%28network%20blip%2C%20rate-limiting%2C%20invalid%20URL%29%20behind%20the%20same%20%22dangling-gitlink%20bug%22%20message%2C%20making%20those%20failures%20indistinguishable%20from%20the%20actual%20problem%20this%20guard%20is%20designed%20to%20catch.%20Dropping%20%602%3E%2Fdev%2Fnull%60%20while%20keeping%20%60-q%60%20still%20suppresses%20normal%20progress%20output%20but%20lets%20real%20Git%20errors%20appear%20in%20the%20log.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20if%20git%20-C%20%22%24%7Btmp%7D%22%20fetch%20-q%20--depth%3D1%20%22%24%7Burl%7D%22%20%22%24%7Bsha%7D%22%3B%20then%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Felectrobun-submodule-guard.yml%3A38%0AOther%20workflows%20in%20the%20repo%20%28e.g.%2C%20%60verify-patches.yml%60%29%20add%20a%20comment%20above%20pinned%20action%20SHAs%20indicating%20the%20corresponding%20tag%20%28%60%23%20actions%2Fcheckout%40v4%60%29.%20Without%20it%2C%20future%20maintainers%20can't%20tell%20at%20a%20glance%20which%20version%20this%20SHA%20represents%20or%20whether%20it%20needs%20updating.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23%20actions%2Fcheckout%40v4%0A%20%20%20%20%20%20%20%20uses%3A%20actions%2Fcheckout%40de0fac2e4500dabe0009e67214ff5f5447ce83dd%0A%60%60%60%0A%0A&repo=elizaos%2Feliza&pr=8102&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22elizaos%2Feliza%22%20on%20the%20existing%20branch%20%22fix%2Felectrobun-pin-and-guard%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Felectrobun-pin-and-guard%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Felectrobun-submodule-guard.yml%3A58%0ASuppressing%20stderr%20hides%20transient%20failures%20%28network%20blip%2C%20rate-limiting%2C%20invalid%20URL%29%20behind%20the%20same%20%22dangling-gitlink%20bug%22%20message%2C%20making%20those%20failures%20indistinguishable%20from%20the%20actual%20problem%20this%20guard%20is%20designed%20to%20catch.%20Dropping%20%602%3E%2Fdev%2Fnull%60%20while%20keeping%20%60-q%60%20still%20suppresses%20normal%20progress%20output%20but%20lets%20real%20Git%20errors%20appear%20in%20the%20log.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20if%20git%20-C%20%22%24%7Btmp%7D%22%20fetch%20-q%20--depth%3D1%20%22%24%7Burl%7D%22%20%22%24%7Bsha%7D%22%3B%20then%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Felectrobun-submodule-guard.yml%3A38%0AOther%20workflows%20in%20the%20repo%20%28e.g.%2C%20%60verify-patches.yml%60%29%20add%20a%20comment%20above%20pinned%20action%20SHAs%20indicating%20the%20corresponding%20tag%20%28%60%23%20actions%2Fcheckout%40v4%60%29.%20Without%20it%2C%20future%20maintainers%20can't%20tell%20at%20a%20glance%20which%20version%20this%20SHA%20represents%20or%20whether%20it%20needs%20updating.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23%20actions%2Fcheckout%40v4%0A%20%20%20%20%20%20%20%20uses%3A%20actions%2Fcheckout%40de0fac2e4500dabe0009e67214ff5f5447ce83dd%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Felectrobun-submodule-guard.yml%3A58%0ASuppressing%20stderr%20hides%20transient%20failures%20%28network%20blip%2C%20rate-limiting%2C%20invalid%20URL%29%20behind%20the%20same%20%22dangling-gitlink%20bug%22%20message%2C%20making%20those%20failures%20indistinguishable%20from%20the%20actual%20problem%20this%20guard%20is%20designed%20to%20catch.%20Dropping%20%602%3E%2Fdev%2Fnull%60%20while%20keeping%20%60-q%60%20still%20suppresses%20normal%20progress%20output%20but%20lets%20real%20Git%20errors%20appear%20in%20the%20log.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20if%20git%20-C%20%22%24%7Btmp%7D%22%20fetch%20-q%20--depth%3D1%20%22%24%7Burl%7D%22%20%22%24%7Bsha%7D%22%3B%20then%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Felectrobun-submodule-guard.yml%3A38%0AOther%20workflows%20in%20the%20repo%20%28e.g.%2C%20%60verify-patches.yml%60%29%20add%20a%20comment%20above%20pinned%20action%20SHAs%20indicating%20the%20corresponding%20tag%20%28%60%23%20actions%2Fcheckout%40v4%60%29.%20Without%20it%2C%20future%20maintainers%20can't%20tell%20at%20a%20glance%20which%20version%20this%20SHA%20represents%20or%20whether%20it%20needs%20updating.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%23%20actions%2Fcheckout%40v4%0A%20%20%20%20%20%20%20%20uses%3A%20actions%2Fcheckout%40de0fac2e4500dabe0009e67214ff5f5447ce83dd%0A%60%60%60%0A%0A&pr=8102&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["ci: guard against dangling electrobun su..."](https://github.com/elizaos/eliza/commit/4ff6d9f92c0f25f2c4bc092b2177e20ce6d1a3cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34822736)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->