### PR TITLE
fix(cloud): bootstrap native agent sandbox routing

### DIFF
--- a/packages/app-core/deploy/Dockerfile.cloud-agent
+++ b/packages/app-core/deploy/Dockerfile.cloud-agent
@@ -5,17 +5,32 @@
 
 ARG APP_PORT=2138
 ARG APP_BRIDGE_PORT=18790
+ARG TAILSCALE_VERSION=1.90.8
 
 FROM node:24-bookworm-slim
 
 ARG APP_PORT
 ARG APP_BRIDGE_PORT
+ARG TAILSCALE_VERSION
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      curl ca-certificates && \
+      curl ca-certificates gosu && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+  case "$(dpkg --print-architecture)" in \
+    amd64) TAILSCALE_ARCH=amd64 ;; \
+    arm64) TAILSCALE_ARCH=arm64 ;; \
+    *) echo "Unsupported architecture for tailscale: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+  esac; \
+  curl -fsSL "https://pkgs.tailscale.com/stable/tailscale_${TAILSCALE_VERSION}_${TAILSCALE_ARCH}.tgz" \
+    -o /tmp/tailscale.tgz; \
+  tar -xzf /tmp/tailscale.tgz -C /tmp; \
+  install -m 0755 "/tmp/tailscale_${TAILSCALE_VERSION}_${TAILSCALE_ARCH}/tailscale" /usr/local/bin/tailscale; \
+  install -m 0755 "/tmp/tailscale_${TAILSCALE_VERSION}_${TAILSCALE_ARCH}/tailscaled" /usr/local/bin/tailscaled; \
+  rm -rf /tmp/tailscale.tgz "/tmp/tailscale_${TAILSCALE_VERSION}_${TAILSCALE_ARCH}"
 
 WORKDIR /app
 
@@ -24,6 +39,8 @@ WORKDIR /app
 # `import "./cloud-agent-shared.ts"`.
 COPY eliza/packages/app-core/deploy/cloud-agent-entrypoint.ts ./entrypoint.ts
 COPY eliza/packages/app-core/deploy/cloud-agent-shared.ts ./cloud-agent-shared.ts
+COPY eliza/packages/app-core/deploy/cloud-agent-docker-entrypoint.sh /usr/local/bin/cloud-agent-docker-entrypoint
+RUN chmod +x /usr/local/bin/cloud-agent-docker-entrypoint
 
 # Install tsx globally for running TypeScript directly
 RUN npm install -g tsx@4
@@ -52,8 +69,9 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 EXPOSE ${APP_PORT}
 EXPOSE ${APP_BRIDGE_PORT}
 
-# Security: run as non-root (after npm install which needs root)
+# Security: the container starts as root only so the entrypoint can initialize
+# Tailscale/Headscale when Cloud injects TS_AUTHKEY, then it drops to agent.
 RUN useradd -m agent && chown -R agent:agent /app
-USER agent
 
+ENTRYPOINT ["cloud-agent-docker-entrypoint"]
 CMD ["tsx", "entrypoint.ts"]

--- a/packages/app-core/deploy/cloud-agent-docker-entrypoint.sh
+++ b/packages/app-core/deploy/cloud-agent-docker-entrypoint.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env sh
+set -eu
+
+start_tailscale_if_configured() {
+  if [ -z "${TS_AUTHKEY:-}" ]; then
+    return 0
+  fi
+
+  if [ "$(id -u)" != "0" ]; then
+    echo "[cloud-agent-entrypoint] TS_AUTHKEY is set but the container did not start as root" >&2
+    exit 1
+  fi
+
+  if ! command -v tailscaled >/dev/null 2>&1 || ! command -v tailscale >/dev/null 2>&1; then
+    echo "[cloud-agent-entrypoint] TS_AUTHKEY is set but tailscale/tailscaled is not installed" >&2
+    exit 1
+  fi
+
+  ts_state_dir="${TS_STATE_DIR:-/var/lib/tailscale}"
+  ts_socket="${TS_SOCKET:-/tmp/tailscaled.sock}"
+  ts_hostname="${TS_HOSTNAME:-${SANDBOX_AGENT_ID:-${STEWARD_AGENT_ID:-$(hostname)}}}"
+  mkdir -p "$ts_state_dir"
+  rm -f "$ts_socket"
+
+  tailscaled \
+    --state="${ts_state_dir}/tailscaled.state" \
+    --socket="$ts_socket" \
+    >/tmp/tailscaled.log 2>&1 &
+
+  export TS_SOCKET="$ts_socket"
+
+  i=0
+  while [ ! -S "$ts_socket" ] && [ ! -e "$ts_socket" ] && [ "$i" -lt 50 ]; do
+    sleep 0.1
+    i=$((i + 1))
+  done
+
+  if [ ! -S "$ts_socket" ] && [ ! -e "$ts_socket" ]; then
+    echo "[cloud-agent-entrypoint] tailscaled did not create its socket; last log lines:" >&2
+    tail -n 20 /tmp/tailscaled.log >&2 || true
+    exit 1
+  fi
+
+  login_server_arg=""
+  if [ -n "${HEADSCALE_URL:-}" ]; then
+    login_server_arg="--login-server=${HEADSCALE_URL}"
+  elif [ -n "${TS_CONTROL_URL:-}" ]; then
+    login_server_arg="--login-server=${TS_CONTROL_URL}"
+  fi
+
+  # TS_EXTRA_ARGS intentionally supports multiple CLI flags, e.g. "--accept-routes".
+  # shellcheck disable=SC2086
+  tailscale --socket="$ts_socket" up \
+    --auth-key="$TS_AUTHKEY" \
+    --hostname="$ts_hostname" \
+    $login_server_arg \
+    ${TS_EXTRA_ARGS:-}
+}
+
+start_tailscale_if_configured
+
+run_as_user="${CLOUD_AGENT_RUN_AS_USER:-agent}"
+if [ "$(id -u)" = "0" ] && [ -n "$run_as_user" ]; then
+  exec gosu "$run_as_user" "$@"
+fi
+
+exec "$@"

--- a/packages/app-core/deploy/cloud-agent-shared.ts
+++ b/packages/app-core/deploy/cloud-agent-shared.ts
@@ -517,7 +517,10 @@ export function startCloudAgent(userConfig: CloudAgentConfig = {}): void {
   const HUNG_RUNTIME_THRESHOLD_MS = 10 * 60_000;
 
   const healthServer = http.createServer((req, res) => {
-    if (req.method === "GET" && req.url === "/health") {
+    if (
+      req.method === "GET" &&
+      (req.url === "/health" || req.url === "/api/health")
+    ) {
       const lastActivityAge =
         Date.now() - new Date(state.lastActivityAt).getTime();
       const possiblyHung =

--- a/packages/app-core/scripts/docker-entrypoint.test.ts
+++ b/packages/app-core/scripts/docker-entrypoint.test.ts
@@ -1,0 +1,125 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+
+const cloudAgentEntrypoint = path.resolve(
+  import.meta.dirname,
+  "../deploy/cloud-agent-docker-entrypoint.sh",
+);
+
+function runEntrypoint(
+  env: NodeJS.ProcessEnv,
+  command: string[] = ["/bin/sh", "-c", "printf app-started"],
+): { code: number | null; stdout: string; stderr: string } {
+  const child = spawnSync("/bin/sh", [cloudAgentEntrypoint, ...command], {
+    env,
+    encoding: "utf8",
+  });
+  return {
+    code: child.status,
+    stdout: child.stdout,
+    stderr: child.stderr,
+  };
+}
+
+async function writeExecutable(filePath: string, body: string) {
+  await writeFile(filePath, body, { mode: 0o755 });
+}
+
+describe("cloud-agent docker entrypoint", () => {
+  test("starts the cloud-agent command without tailscale when no auth key is configured", () => {
+    const result = runEntrypoint(
+      {
+        ...process.env,
+        TS_AUTHKEY: "",
+      },
+      ["/bin/sh", "-c", "printf cloud-started"],
+    );
+
+    expect(result).toMatchObject({
+      code: 0,
+      stdout: "cloud-started",
+    });
+  });
+
+  test("starts tailscaled, joins headscale, and drops privileges before cloud-agent startup", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "cloud-agent-entrypoint-"));
+    const binDir = path.join(root, "bin");
+    const stateDir = path.join(root, "state");
+    const socketPath = path.join(root, "tailscaled.sock");
+    const argsLog = path.join(root, "tailscale-args.log");
+    const gosuUserLog = path.join(root, "gosu-user.log");
+    await mkdir(binDir, { recursive: true });
+    await mkdir(stateDir, { recursive: true });
+
+    await writeExecutable(
+      path.join(binDir, "id"),
+      `#!/bin/sh
+if [ "$1" = "-u" ]; then
+  printf 0
+  exit 0
+fi
+exec /usr/bin/id "$@"
+`,
+    );
+
+    await writeExecutable(
+      path.join(binDir, "tailscaled"),
+      `#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    --socket=*) socket="\${arg#--socket=}" ;;
+  esac
+done
+: "\${socket:=${socketPath}}"
+mkdir -p "$(dirname "$socket")"
+: > "$socket"
+sleep 5
+`,
+    );
+
+    await writeExecutable(
+      path.join(binDir, "tailscale"),
+      `#!/bin/sh
+printf '%s\\n' "$@" > "$TAILSCALE_ARGS_LOG"
+`,
+    );
+
+    await writeExecutable(
+      path.join(binDir, "gosu"),
+      `#!/bin/sh
+printf '%s\\n' "$1" > "$GOSU_USER_LOG"
+shift
+exec "$@"
+`,
+    );
+
+    const result = runEntrypoint(
+      {
+        PATH: `${binDir}:/usr/bin:/bin`,
+        TS_AUTHKEY: "tskey-cloud-test",
+        SANDBOX_AGENT_ID: "agent-cloud-test",
+        TS_STATE_DIR: stateDir,
+        TS_SOCKET: socketPath,
+        HEADSCALE_URL: "https://headscale.example.test",
+        TS_EXTRA_ARGS: "--accept-routes",
+        TAILSCALE_ARGS_LOG: argsLog,
+        GOSU_USER_LOG: gosuUserLog,
+      },
+      ["/bin/sh", "-c", "printf cloud-started"],
+    );
+
+    expect(result).toMatchObject({ code: 0, stdout: "cloud-started" });
+
+    const args = await readFile(argsLog, "utf8");
+    expect(args).toContain(`--socket=${socketPath}`);
+    expect(args).toContain("up");
+    expect(args).toContain("--auth-key=tskey-cloud-test");
+    expect(args).toContain("--hostname=agent-cloud-test");
+    expect(args).toContain("--login-server=https://headscale.example.test");
+    expect(args).toContain("--accept-routes");
+    await expect(readFile(gosuUserLog, "utf8")).resolves.toBe("agent\n");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes native Cloud agent sandbox reachability by making the managed cloud-agent image join Headscale/Tailscale when the Docker sandbox provider injects `TS_AUTHKEY`, while preserving the existing non-VPN startup path.

The production failure mode this targets is: the provider requires a persisted `headscale_ip` for routable sandboxes, but the image did not start Tailscale, so agents could become unreachable or fail provisioning.

## Changes

- Install `tailscale`, `tailscaled`, and `gosu` in `Dockerfile.cloud-agent`.
- Add a cloud-agent-specific Docker entrypoint that starts Tailscale when `TS_AUTHKEY` is present, supports `HEADSCALE_URL` / `TS_CONTROL_URL`, then drops back to the `agent` user.
- Keep the cloud-agent health server compatible with both `/health` and the Docker sandbox provider's `/api/health` probe.
- Add focused entrypoint tests for both the non-VPN startup path and the Headscale startup path.

## Validation

- `sh -n packages/app-core/deploy/cloud-agent-docker-entrypoint.sh`
- `bun run --cwd packages/app-core test -- scripts/docker-entrypoint.test.ts`
- `docker build -f packages/app-core/deploy/Dockerfile.cloud-agent -t eliza-cloud-agent:pr-8104-smoke --platform <local-platform> /Users/symbiex/dev/elizaos`
- `docker run -d --name eliza-agent-pr-8104-smoke -p 32138:2138 eliza-cloud-agent:pr-8104-smoke`, then `curl /health` and `curl /api/health`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes cloud agent sandbox routing by making the managed `cloud-agent` Docker image join Headscale/Tailscale when `TS_AUTHKEY` is injected, while preserving the existing non-VPN startup path. It also adds an `/api/health` alias so the Docker sandbox provider's probe works without breaking existing clients.

- **Dockerfile**: Installs Tailscale binaries from pkgs.tailscale.com and `gosu` from apt, removes the static `USER agent` directive, and wires in a new shell entrypoint; the container now starts as root and the entrypoint handles privilege drop.
- **`cloud-agent-docker-entrypoint.sh`**: Conditionally starts `tailscaled` in the background, waits for its socket, calls `tailscale up` with auth key and optional control-server URL, then drops to the `agent` user via `gosu` before exec-ing the CMD.
- **`cloud-agent-shared.ts`**: Adds `/api/health` alongside `/health` in the HTTP health server with no other logic changes.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the understanding that the Tailscale binary download is unverified; adding a SHA-256 check before merging to a hardened production pipeline is strongly recommended.

The core routing fix and privilege-drop logic are correct and well-tested. The main concern is that a root-installed binary is pulled from the internet without a checksum check — if an attacker tampers with the CDN artifact at build time, the malicious binary runs as root before the gosu drop. The entrypoint script and health-endpoint changes are straightforward and low-risk.

packages/app-core/deploy/Dockerfile.cloud-agent — specifically the Tailscale tarball download block that lacks integrity verification.

<details open><summary><h3>Security Review</h3></summary>

- **Supply-chain risk — `Dockerfile.cloud-agent` lines 22-33**: The Tailscale tarball is fetched over HTTPS and installed as root without verifying its SHA-256 digest against Tailscale's published checksums (`tailscale_<ver>_<arch>.tgz.sha256`). A compromised CDN artifact or transient MITM during CI would place a malicious root-level binary into the image, which executes before the `gosu` privilege drop.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/deploy/Dockerfile.cloud-agent | Adds Tailscale + gosu installation and switches to an entrypoint-based privilege-drop model; downloads the Tailscale tarball without SHA-256 verification, which is a supply-chain risk in a root-starting container. |
| packages/app-core/deploy/cloud-agent-docker-entrypoint.sh | New sh entrypoint that conditionally starts tailscaled/tailscale and drops to the agent user via gosu; logic is correct but uses non-POSIX fractional sleep 0.1 that would break on busybox-based images. |
| packages/app-core/deploy/cloud-agent-shared.ts | Adds /api/health as an alias to the existing /health endpoint so the Docker sandbox provider's probe works without disrupting the existing health check URL. |
| packages/app-core/scripts/docker-entrypoint.test.ts | Adds two Vitest tests (non-VPN path and Headscale path) with correctly written mock stubs for tailscaled, tailscale, gosu, and id; argument capture via env-var log files is a clean approach for shell script testing. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Docker as Docker Runtime
    participant EP as cloud-agent-docker-entrypoint.sh (root)
    participant TD as tailscaled (bg)
    participant TS as tailscale CLI
    participant HC as Headscale/Tailscale Control
    participant Gosu as gosu
    participant App as tsx entrypoint.ts (agent user)

    Docker->>EP: start container (PID 1)
    alt TS_AUTHKEY is set
        EP->>TD: tailscaled --socket --state (background)
        EP->>EP: poll for socket (up to 5s)
        EP->>TS: tailscale up --auth-key --hostname [--login-server]
        TS->>HC: "authenticate & register node"
        HC-->>TS: assigned Tailscale/Headscale IP
        TS-->>EP: exit 0
    else TS_AUTHKEY not set
        EP->>EP: skip Tailscale init
    end
    EP->>Gosu: exec gosu agent tsx entrypoint.ts
    Gosu->>App: exec (drops to agent user, becomes PID 1)
    App-->>Docker: /health + /api/health responses
```

<sub>Reviews (1): Last reviewed commit: ["fix(cloud): bootstrap native agent sandb..."](https://github.com/elizaos/eliza/commit/4f4af3fb142fcb6cfe78accbdbf7b57083dc0f5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34833386)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->