### PR TITLE
fix(agent): move plugin-google and plugin-lifeops to optional so the default image boots

### DIFF
--- a/packages/agent/src/runtime/core-plugins.test.ts
+++ b/packages/agent/src/runtime/core-plugins.test.ts
@@ -1,12 +1,27 @@
 import { describe, expect, it } from "vitest";
 
-import { CORE_PLUGINS } from "./core-plugins.ts";
+import {
+  CORE_PLUGINS,
+  DEFERRED_CORE_PLUGINS,
+  OPTIONAL_CORE_PLUGINS,
+} from "./core-plugins.ts";
 
 describe("CORE_PLUGINS", () => {
-  it("registers the Google connector before LifeOps uses it", () => {
-    expect(CORE_PLUGINS).toContain("@elizaos/plugin-google");
-    expect(CORE_PLUGINS.indexOf("@elizaos/plugin-google")).toBeLessThan(
-      CORE_PLUGINS.indexOf("@elizaos/plugin-lifeops"),
-    );
+  it("does not load plugin-google or plugin-lifeops by default", () => {
+    // These two plugins pull in heavy native/cloud deps (googleapis and
+    // @capacitor/core) that the slim Docker runtime image intentionally does
+    // not bundle. Loading them by default crashed the boot smoke / boot gate
+    // (#8081) with "Cannot find package 'googleapis' / @capacitor/core". They
+    // require explicit configuration (Google OAuth, LifeOps enablement), so
+    // they belong in OPTIONAL_CORE_PLUGINS, never the default core load set.
+    expect(CORE_PLUGINS).not.toContain("@elizaos/plugin-google");
+    expect(CORE_PLUGINS).not.toContain("@elizaos/plugin-lifeops");
+    expect(DEFERRED_CORE_PLUGINS).not.toContain("@elizaos/plugin-google");
+    expect(DEFERRED_CORE_PLUGINS).not.toContain("@elizaos/plugin-lifeops");
+  });
+
+  it("exposes plugin-google and plugin-lifeops as optional, explicitly-enabled plugins", () => {
+    expect(OPTIONAL_CORE_PLUGINS).toContain("@elizaos/plugin-google");
+    expect(OPTIONAL_CORE_PLUGINS).toContain("@elizaos/plugin-lifeops");
   });
 });

--- a/packages/agent/src/runtime/core-plugins.ts
+++ b/packages/agent/src/runtime/core-plugins.ts
@@ -92,8 +92,6 @@ export const CORE_PLUGINS: readonly string[] = [
   "@elizaos/plugin-coding-tools", // native FILE/SHELL/WORKTREE coding tools (desktop-only
   "@elizaos/plugin-agent-skills", // skill execution and marketplace runtime
   "@elizaos/plugin-commands", // slash command handling (skills auto-register as /commands)
-  "@elizaos/plugin-google", // Google Workspace connector service required by LifeOps
-  "@elizaos/plugin-lifeops", // LifeOps: personal ops — tasks, goals, calendar, inbox, website blocking
   "@elizaos/plugin-browser", // Browser workspace and Chrome/Safari companion bridge.
   "@elizaos/plugin-video", // Video download / transcription (managed yt-dlp + ffmpeg with auto-update on extractor failure)
   // Built-in runtime capabilities (no longer external plugins):
@@ -131,6 +129,8 @@ export const DEFERRED_CORE_PLUGINS: readonly string[] = CORE_PLUGINS.filter(
 export const OPTIONAL_CORE_PLUGINS: readonly string[] = [
   // plugin-manager, secrets (SECRETS), trust: now built-in core capabilities
   // Enable via character settings: ENABLE_PLUGIN_MANAGER, ENABLE_SECRETS_MANAGER, ENABLE_TRUST
+  "@elizaos/plugin-google", // Google Workspace connector (requires googleapis + explicit OAuth config); only loaded when LifeOps/Google is enabled
+  "@elizaos/plugin-lifeops", // LifeOps: personal ops - tasks, goals, calendar, inbox, website blocking (requires @capacitor/core + plugin-google); enable explicitly
   "@elizaos/plugin-pdf", // PDF processing (published bundle broken in alpha.15)
   "@elizaos/plugin-cua", // CUA computer-use agent (cloud sandbox automation)
   "@elizaos/plugin-obsidian", // Obsidian vault CLI integration

--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -513,12 +513,6 @@ const CORE_STATIC_PLUGIN_REGISTRATIONS: readonly CoreStaticPluginRegistration[] 
       load: () => getOptionalPlugin("@elizaos/plugin-openai"),
     },
     {
-      packageName: "@elizaos/plugin-google",
-      phase: "deferred",
-      required: false,
-      load: () => getOptionalPlugin("@elizaos/plugin-google"),
-    },
-    {
       packageName: "@elizaos/plugin-gitpathologist",
       phase: "deferred",
       required: false,


### PR DESCRIPTION
## Summary

Fixes the agent-image boot regression failing the boot gate (#8081), which was blocking every fresh image build (and hosted-agent provisioning). Confirmed failing on `develop` across multiple commits (`2c8f4e0c`, `b63ad103`, `4ead44a8`), so this is a develop regression, not a single PR.

## The bug

The Docker boot smoke serves health, loads 10/12 plugins, then crashes during the post-health window with:

- `Failed to load core plugin @elizaos/plugin-google: Cannot find package 'googleapis'`
- `Failed to load core plugin @elizaos/plugin-lifeops: Cannot find package '@capacitor/core'`

The image is then declared NOT bootable.

## Root cause

- `packages/agent/src/runtime/core-plugins.ts` listed `@elizaos/plugin-google` and `@elizaos/plugin-lifeops` in `CORE_PLUGINS`, so `collectPluginNames()` seeded them into the default deferred load set. As core plugins (`isCore=true`), a failed import is fatal (re-thrown by the plugin error boundary), and `plugin-resolver.ts` logs `Failed to load core plugin ...`.
- `packages/app-core/scripts/collect-docker-runtime-deps.mjs` deliberately excludes their heavy native deps from the image: `@capacitor/core` is in the `EXCLUDE` set, and `googleapis` is not in any linked workspace package's `dependencies` (plugin-google is not in `LINKED_WORKSPACE_PACKAGES`). The exclusion is intentional ("plugins the agent never loads by default"), but that assumption was false once both plugins were in `CORE_PLUGINS`.

Net: the two plugins loaded by default, but their packages were not in the image, so boot crashed and the boot gate failed.

## The fix (Option A, surgical)

Both plugins require explicit configuration (Google OAuth, LifeOps enablement) and platform-specific native deps, so they fit `OPTIONAL_CORE_PLUGINS` exactly.

- Removed `@elizaos/plugin-google` and `@elizaos/plugin-lifeops` from `CORE_PLUGINS` and added them to `OPTIONAL_CORE_PLUGINS`. They now load only when explicitly enabled; the default hosted-agent image boots clean, and any later missing-package failure is treated as a benign optional-plugin skip (they are in the resolver's `optionalPluginNames` set) instead of a fatal core failure.
- Removed the eager deferred static registration for `plugin-google` in `eliza.ts` so boot no longer attempts to `import()` it (and emit googleapis warnings) by default. Explicit enablement still resolves it via the normal optional-plugin path (`importOfficialPluginFromNodeModules` / `loadOptionalPlugin`), consistent with every other `OPTIONAL_CORE_PLUGINS` entry that has no static registration.

The `lifeops -> google` boot dependency hint and the runtime-app subpath / dynamic-import references (`permissions-routes.ts`, `binance-skill-helpers.ts`, `plugin-resolver.ts`) are unaffected: they are config/runtime-gated, not part of the default boot load set.

## Verification

- Rewrote `core-plugins.test.ts` to assert plugin-google and plugin-lifeops are OPTIONAL (and absent from `CORE_PLUGINS` and `DEFERRED_CORE_PLUGINS`). 2/2 pass.
- biome 2.4.15 clean on all changed files.
- `tsgo` typecheck of `packages/agent`: no errors from the changed lines (remaining output is pre-existing unbuilt-workspace module-resolution noise unrelated to this change).
- The default agent image no longer seeds these two plugins, so the boot gate should load the remaining core set with the two now simply absent rather than failed.

**The real green light is the Build Agent Image workflow passing on this commit.** I cannot run the full Docker build locally; please confirm the workflow goes green before merging.

## Notes

- Do not merge until the Build Agent Image workflow is green on this commit.

Co-authored-by: wakesync <shadow@shad0w.xyz>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Docker boot regression (#8081) by moving `@elizaos/plugin-google` and `@elizaos/plugin-lifeops` from `CORE_PLUGINS` to `OPTIONAL_CORE_PLUGINS`, and removing the eager deferred static registration for `plugin-google` in `eliza.ts`. Both plugins depend on native packages (`googleapis`, `@capacitor/core`) that the slim Docker runtime image intentionally omits, so loading them by default was fatal.

- **`core-plugins.ts`**: Both plugins removed from `CORE_PLUGINS` and added at the top of `OPTIONAL_CORE_PLUGINS` (in correct google-before-lifeops order to preserve the boot dependency).
- **`eliza.ts`**: Static registration entry for `plugin-google` removed from `CORE_STATIC_PLUGIN_REGISTRATIONS`; the lifeops->google dependency hint in `CORE_PLUGIN_BOOT_DEPENDENCIES` is untouched.
- **`core-plugins.test.ts`**: Tests rewritten to assert absence from the default load set and presence in the optional set; the google-before-lifeops ordering assertion is not carried over.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge once the Build Agent Image workflow passes; the two-line removal from CORE_PLUGINS and matching addition to OPTIONAL_CORE_PLUGINS is minimal and well-scoped.

The core change is correct and the static registration removal in eliza.ts is consistent with every other optional-only plugin. The only gap is that the rewritten test dropped the ordering assertion for google-before-lifeops — the ordering is still correct in the list today, but it is no longer guarded by a test.

packages/agent/src/runtime/core-plugins.test.ts — the ordering assertion for the lifeops→google dependency should be re-added.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/agent/src/runtime/core-plugins.ts | Removed plugin-google and plugin-lifeops from CORE_PLUGINS and placed them at the top of OPTIONAL_CORE_PLUGINS; preserves correct google-before-lifeops ordering in the optional list. |
| packages/agent/src/runtime/eliza.ts | Removes the deferred static registration entry for plugin-google, consistent with all other OPTIONAL_CORE_PLUGINS entries that have no static registration path. |
| packages/agent/src/runtime/core-plugins.test.ts | Rewrites the single ordering test into two membership tests; correctly asserts absence from CORE_PLUGINS/DEFERRED_CORE_PLUGINS and presence in OPTIONAL_CORE_PLUGINS, but drops the google-before-lifeops ordering assertion that guarded the lifeops->google boot dependency. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Agent Boot] --> B{collectPluginNames}
    B --> C[CORE_PLUGINS]
    B --> D[OPTIONAL_CORE_PLUGINS]
    C --> E[plugin-sql]
    C --> F[plugin-local-inference]
    C --> G[plugin-browser]
    C --> H[... other core plugins ...]
    D --> I["plugin-google ✅ moved here"]
    D --> J["plugin-lifeops ✅ moved here"]
    D --> K[plugin-pdf, plugin-cua, ...]
    I -.->|"requires googleapis (not in Docker image)"| L[Only loaded when explicitly enabled]
    J -.->|"requires @capacitor/core (not in Docker image)"| L
    style I fill:#90EE90,stroke:#228B22
    style J fill:#90EE90,stroke:#228B22
    style L fill:#FFD700,stroke:#B8860B
```

<sub>Reviews (1): Last reviewed commit: ["fix(agent): move plugin-google and plugi..."](https://github.com/elizaos/eliza/commit/fe48b62bae5b90681910020404b014b3b867ba77) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34833385)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->