### PR TITLE
fix(core): expose keyless web-fetch in the v5 planner action surface for live-info

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -4,6 +4,7 @@ import type { Action, ActionResult, IAgentRuntime } from "../index";
 import {
 	actionResultsSuppressPostActionContinuation,
 	extractPlannerActionNames,
+	findCanonicalWebLookupActionName,
 	findWebLookupActionName,
 	inferLocalShellCommandFromMessageText,
 	inferWebSearchQueryFromMessageText,
@@ -176,6 +177,41 @@ describe("live routing regressions", () => {
 			similes: ["LOOKUP_WEB"],
 		};
 		expect(findWebLookupActionName([simileAction])).toBe("SOME_FETCH");
+	});
+
+	it("resolves the keyless web-lookup action by canonical name, not a SEARCH simile collision", () => {
+		// Live regression: the v5 planner action-surface backstop used
+		// `findWebLookupActionName`, which returns the first action whose name OR
+		// simile matches any lookup name. An unrelated action that merely carries a
+		// "SEARCH" simile (CONTACT_SEARCH) sorted ahead of WEB_FETCH and won,
+		// force-exposing the wrong action and never exposing WEB_FETCH — so
+		// live-info still spawned a coding agent. `findCanonicalWebLookupActionName`
+		// matches by canonical NAME only and prefers WEB_FETCH.
+		const actions: Array<Pick<Action, "name" | "similes">> = [
+			{ name: "CONTACT_SEARCH", similes: ["SEARCH"] },
+			{ name: "TASKS", similes: [] },
+			{ name: "WEB_FETCH", similes: ["LOOKUP_WEB"] },
+		];
+		expect(findCanonicalWebLookupActionName(actions)).toBe("WEB_FETCH");
+		// The simile-based resolver mis-resolves the same set to CONTACT_SEARCH,
+		// which is exactly the bug the canonical resolver guards against.
+		expect(findWebLookupActionName(actions)).toBe("CONTACT_SEARCH");
+		// When a real web-search action exists but no WEB_FETCH, the canonical
+		// resolver still returns it (never the SEARCH-simile collision).
+		expect(
+			findCanonicalWebLookupActionName([
+				{ name: "CONTACT_SEARCH", similes: ["SEARCH"] },
+				{ name: "WEB_SEARCH", similes: [] },
+			]),
+		).toBe("WEB_SEARCH");
+		// And when nothing canonical is present, it declines (no false positive on
+		// a bare SEARCH-simile action), letting callers fall back deliberately.
+		expect(
+			findCanonicalWebLookupActionName([
+				{ name: "CONTACT_SEARCH", similes: ["SEARCH"] },
+				{ name: "TASKS", similes: [] },
+			]),
+		).toBeUndefined();
 	});
 
 	it("prefers an inline web-lookup over spawning a sub-agent for live-info", () => {

--- a/packages/core/src/__tests__/tiered-action-surface.test.ts
+++ b/packages/core/src/__tests__/tiered-action-surface.test.ts
@@ -600,4 +600,111 @@ describe("v5 tiered action surface", () => {
 			),
 		).toHaveLength(2);
 	});
+
+	it("force-includes the keyless WEB_FETCH action in the planner surface for a live-info turn", async () => {
+		// Live regression (the 4th and final live-info gate): WEB_FETCH is
+		// registered without declared contexts, so registration stamps it with the
+		// default ["general"] context. When the turn routes to a non-general
+		// context, the context gate drops WEB_FETCH from the candidate set, it
+		// never reaches the action catalog, and the planner is left with only
+		// TASKS — force-spawning a coding agent for an inline lookup. The
+		// `looksLikeWebSearchRequest` force-include pulls WEB_FETCH back into the
+		// surface so the planner can answer inline.
+		const webFetch = makeAction({
+			name: "WEB_FETCH",
+			description: "Fetch a public https URL or JSON data API inline.",
+			similes: ["LOOKUP_WEB", "WEB_LOOKUP"],
+			contexts: ["general" as AgentContext],
+		});
+		const tasks = makeAction({
+			name: "TASKS",
+			description: "Spawn and manage coding sub-agents.",
+			contexts: ["coding" as AgentContext],
+			contextGate: { anyOf: ["coding"] },
+		});
+		const runtime = makeRuntime({
+			actions: [webFetch, tasks],
+			responses: [
+				// Stage 1 routes the live-info ask to the coding context (which is
+				// what drops WEB_FETCH's general-only gate in the wild).
+				stage1Response({
+					contexts: ["coding"],
+					candidateActionNames: ["MESSAGE_SEARCH"],
+				}),
+				plannerToolResponse("WEB_FETCH", {
+					url: "https://api.coinbase.com/v2/prices/BTC-USD/spot",
+				}),
+				finishEvaluatorResponse("Bitcoin is about $X."),
+			],
+		});
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage("whats the current price of bitcoin?"),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		const plannerCall = getCalls(runtime).find(
+			(call) => call.modelType === ModelType.ACTION_PLANNER,
+		);
+		const toolNames =
+			(
+				plannerCall?.params as { tools?: Array<{ name?: string }> } | undefined
+			)?.tools
+				?.map((tool) => tool.name)
+				.filter(Boolean) ?? [];
+		expect(toolNames).toContain("WEB_FETCH");
+	});
+
+	it("does not force-include WEB_FETCH for a spawn/build turn", async () => {
+		// `looksLikeWebSearchRequest` is false for coding-work phrasings, so the
+		// force-include never fires and the spawn path is untouched. WEB_FETCH is
+		// general-only, the turn routes to the coding context, so it stays gated
+		// out and the planner only sees TASKS.
+		const webFetch = makeAction({
+			name: "WEB_FETCH",
+			description: "Fetch a public https URL or JSON data API inline.",
+			similes: ["LOOKUP_WEB", "WEB_LOOKUP"],
+			contexts: ["general" as AgentContext],
+		});
+		const tasks = makeAction({
+			name: "TASKS",
+			description: "Spawn and manage coding sub-agents.",
+			contexts: ["coding" as AgentContext],
+			contextGate: { anyOf: ["coding"] },
+		});
+		const runtime = makeRuntime({
+			actions: [webFetch, tasks],
+			responses: [
+				stage1Response({
+					contexts: ["coding"],
+					candidateActionNames: ["TASKS"],
+				}),
+				plannerToolResponse("TASKS", {}),
+				finishEvaluatorResponse("Spawning a sub-agent."),
+			],
+		});
+
+		await runV5MessageRuntimeStage1({
+			runtime,
+			message: makeMessage(
+				"spawn a coding subagent to print todays date in python and tell me the output",
+			),
+			state: makeState(),
+			responseId: RESPONSE_ID,
+		});
+
+		const plannerCall = getCalls(runtime).find(
+			(call) => call.modelType === ModelType.ACTION_PLANNER,
+		);
+		const toolNames =
+			(
+				plannerCall?.params as { tools?: Array<{ name?: string }> } | undefined
+			)?.tools
+				?.map((tool) => tool.name)
+				.filter(Boolean) ?? [];
+		expect(toolNames).toContain("TASKS");
+		expect(toolNames).not.toContain("WEB_FETCH");
+	});
 });

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2228,6 +2228,45 @@ async function collectV5PlannerCandidateActions(args: {
 		}
 	}
 
+	// Live-info force-include: the keyless web-lookup action (WEB_FETCH) is
+	// registered without declared contexts, so `applyEffectiveActionAccess`
+	// stamps it with the default `["general"]` context at registration time.
+	// When the current turn routes to a non-general context, the context gate in
+	// `appendIfAllowed` drops WEB_FETCH from the candidate set entirely — so it
+	// never reaches the action catalog, never gets ranked, and the planner is
+	// left with only TASKS, force-spawning a coding agent for what is an inline
+	// lookup ("what's the current BTC price"). When the message reads as a
+	// web-lookup request, pull the canonical web-lookup action straight from the
+	// runtime and append it with its own contexts as the active set, bypassing
+	// only the turn's context mismatch (role + connector + validate gates still
+	// apply via `appendIfAllowed`). `looksLikeWebSearchRequest` is false for
+	// spawn/build turns, so coding delegation is untouched.
+	if (looksLikeWebSearchRequest(getUserMessageText(args.message) ?? "")) {
+		const webLookupName = findCanonicalWebLookupActionName(allRuntimeActions);
+		if (webLookupName) {
+			const normalized = normalizeActionIdentifier(webLookupName);
+			if (normalized && !seen.has(normalized)) {
+				const webLookupAction =
+					actionsByName.get(webLookupName) ??
+					actionsByNormalizedName.get(normalized);
+				if (webLookupAction) {
+					// Use the action's own contexts as the active set so the context
+					// gate is self-satisfied (the goal is to bypass the *turn* context
+					// mismatch, not the action's own gate). Role / connector / validate
+					// gates still run inside `appendIfAllowed`.
+					await appendIfAllowed(
+						webLookupAction,
+						undefined,
+						mergeAgentContexts(
+							args.selectedContexts,
+							webLookupAction.contexts,
+						),
+					);
+				}
+			}
+		}
+	}
+
 	return selectedActions;
 }
 
@@ -2407,17 +2446,28 @@ function buildV5PlannerActionSurface(params: {
 	}
 
 	// Live-info structural backstop: the BM25/keyword retrieval tier ranks a
-	// small slice of parent actions and can drop a keyless web-lookup action
-	// (e.g. WEB_FETCH) for live-info phrasings that don't lexically overlap its
-	// catalog entry. When the message reads as a web-lookup request and an
-	// allowed web-lookup action already survived the planner execution gates in
-	// `params.actions`, expose it so the planner can answer inline instead of
-	// force-delegating to a coding agent. This only un-filters an
-	// already-gated action — it never bypasses `appendIfAllowed`.
+	// small slice of parent catalog actions and never exposes a keyless
+	// web-lookup action (e.g. WEB_FETCH) for live-info phrasings that don't
+	// lexically overlap its catalog entry — a "current BTC price" query scores 0
+	// on WEB_FETCH, so the tiering omits it and the planner is left with only
+	// TASKS, forcing a coding-agent spawn for what is an inline lookup.
+	//
+	// When the message reads as a web-lookup request and an allowed web-lookup
+	// action already survived the planner execution gates in `params.actions`,
+	// expose it so the planner can answer inline. We resolve the action by its
+	// canonical NAME (WEB_LOOKUP_DIRECT_ACTIONS) first and only fall back to the
+	// simile-based resolver — `findWebLookupActionName` returns the first action
+	// whose name OR simile matches, which lets an unrelated action that merely
+	// carries a "SEARCH" simile (e.g. CONTACT_SEARCH) win over WEB_FETCH by array
+	// order. This only un-filters an already-gated action — it never bypasses
+	// `appendIfAllowed`. `looksLikeWebSearchRequest` is false for spawn/build
+	// turns, so coding delegation is untouched.
 	let webLookupBackstop: string | undefined;
 	const webLookupMessageText = getUserMessageText(params.message) ?? "";
 	if (looksLikeWebSearchRequest(webLookupMessageText)) {
-		const lookupActionName = findWebLookupActionName(params.actions);
+		const lookupActionName =
+			findCanonicalWebLookupActionName(params.actions) ??
+			findWebLookupActionName(params.actions);
 		if (lookupActionName) {
 			const normalizedLookupName = normalizeActionIdentifier(lookupActionName);
 			if (
@@ -3733,6 +3783,45 @@ const WEB_LOOKUP_DIRECT_ACTIONS = new Set(
 		"GOOGLE",
 	].map(normalizeActionIdentifier),
 );
+
+// Resolve a web-lookup action by its canonical NAME only (no simile matching),
+// scanning WEB_LOOKUP_DIRECT_ACTIONS in priority order. Unlike
+// `findWebLookupActionName` — which returns the first action whose name OR
+// simile matches and can therefore mis-resolve to an unrelated action that
+// merely carries a "SEARCH" simile (e.g. CONTACT_SEARCH) — this only returns an
+// action whose own normalized name is a real web-lookup action. Returns
+// undefined when no such action survived the planner gates, so callers fall
+// back to the simile-based resolver.
+const WEB_LOOKUP_DIRECT_ACTION_PRIORITY = [
+	"WEB_FETCH",
+	"SEARCH",
+	"WEB_SEARCH",
+	"SEARCH_WEB",
+	"BRAVE_SEARCH",
+	"INTERNET_SEARCH",
+	"SEARCH_INTERNET",
+	"LOOKUP_WEB",
+	"GOOGLE",
+].map(normalizeActionIdentifier);
+
+export function findCanonicalWebLookupActionName(
+	actions: ReadonlyArray<Pick<Action, "name">>,
+): string | undefined {
+	const byNormalizedName = new Map<string, string>();
+	for (const action of actions) {
+		const normalized = normalizeActionIdentifier(action.name);
+		if (normalized && !byNormalizedName.has(normalized)) {
+			byNormalizedName.set(normalized, action.name);
+		}
+	}
+	for (const wanted of WEB_LOOKUP_DIRECT_ACTION_PRIORITY) {
+		const match = byNormalizedName.get(wanted);
+		if (match) {
+			return match;
+		}
+	}
+	return undefined;
+}
 
 // Prefer the action the CURRENT message structurally implies over whatever
 // weak candidate set the planner surfaced — but only when the planner's own


### PR DESCRIPTION
Closes #8108

Follow-up to #8097 (merged). That PR registered the keyless `WEB_FETCH` action and surfaced it into `findWebLookupActionName`, but live-info queries ("what's the current price of bitcoin?") still spawned an opencode sub-agent instead of answering inline.

## Root cause (the last gate)

`WEB_FETCH` is registered without declared `contexts`, so `applyEffectiveActionAccess` (plugin-lifecycle) stamps it with the default `["general"]` context at registration time. When a turn's messageHandler routes to a non-general context (e.g. `coding`), the context gate in `collectV5PlannerCandidateActions` → `actionPassesPlannerExecutionGates` drops `WEB_FETCH` from the planner candidate set entirely. It then never reaches `buildActionCatalog`, never gets ranked by `retrieveActions`, and the planner is left with only `TASKS` — force-spawning a coding agent for what is an inline lookup.

The existing live-info backstop in `buildV5PlannerActionSurface` was also ineffective: it called `findWebLookupActionName(params.actions)`, which returns the first action whose name **or simile** matches any lookup name — so an unrelated action carrying a `SEARCH` simile (e.g. `CONTACT_SEARCH`) won by array order and was force-exposed instead of `WEB_FETCH`.

Confirmed live from trajectories: the planner's exposed tool list for a BTC-price query was `[CONTACT_SEARCH, LOGS_SEARCH, MEMORY_SEARCH, TASKS + children, SKILL_SEARCH, CREDENTIALS_SEARCH, REPLY/IGNORE/STOP]` — `WEB_FETCH` absent — and the planner selected `TASKS`.

## Fix (structural, no new intent regex)

1. `collectV5PlannerCandidateActions`: when `looksLikeWebSearchRequest(messageText)` is true, force-include the canonical web-lookup action (pulled straight from `runtime.actions`) using its own contexts as the active set — bypassing only the turn's context mismatch. Role / connector / validate gates still run. Reuses the existing detector, so spawn/build turns (where `looksLikeWebSearchRequest` is false) are untouched.
2. New `findCanonicalWebLookupActionName` resolves the web-lookup action by canonical **name** only (priority order, `WEB_FETCH` first), never a `SEARCH`-simile collision. The `buildV5PlannerActionSurface` backstop now prefers it, falling back to the simile-based resolver.

## Tests

- `tiered-action-surface.test.ts`: a live-info turn routed to a non-general context exposes `WEB_FETCH` in the planner surface; a spawn turn does not (stays `TASKS`).
- `message-routing-live-regression.test.ts`: `findCanonicalWebLookupActionName` prefers `WEB_FETCH` over a `CONTACT_SEARCH`-with-`SEARCH`-simile collision and declines when no canonical web-lookup action is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the final gate that was preventing `WEB_FETCH` from reaching the v5 planner surface on live-info queries (e.g. \"what's the current BTC price?\") when the turn was routed to a non-general context such as `coding`. It also replaces the simile-based web-action resolver in the planner backstop with a new canonical-name resolver (`findCanonicalWebLookupActionName`) that avoids mis-resolving to an unrelated action that merely carries a `SEARCH` simile.

- **`collectV5PlannerCandidateActions`**: when `looksLikeWebSearchRequest` is true, the canonical web-lookup action is pulled from `runtime.actions` and re-submitted through `appendIfAllowed` with its own contexts merged in, bypassing only the turn-context mismatch while leaving role/connector/validate gates intact.
- **`buildV5PlannerActionSurface` backstop**: now prefers `findCanonicalWebLookupActionName` over the simile-based `findWebLookupActionName`, falling back to the simile resolver only when no canonical action name is present.
- **New `WEB_LOOKUP_DIRECT_ACTION_PRIORITY` list**: backs the canonical resolver with `WEB_FETCH` ranked first, but must be kept in sync with the existing `WEB_LOOKUP_DIRECT_ACTIONS` set — currently without any shared source of truth.

<h3>Confidence Score: 3/5</h3>

Safe to merge for its primary goal, but two structural gaps in message.ts leave edge-case routing more fragile than the PR description implies.

The force-include runs after the subActions expansion loop has finished, so any future web-lookup action that declares subActions would silently expose a partial surface. Separately, looksLikeWebSearchRequest can return true for queries that also satisfy looksLikeCodingWorkRequest, causing WEB_FETCH to be injected into the candidate set for a coding-intent turn. The dual-list maintenance gap adds ongoing sync risk without enforcement.

packages/core/src/services/message.ts — the post-subActions-loop force-include block and the two independent action-name lists.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/src/services/message.ts | Two structural additions: (1) force-include logic that re-adds the web-lookup action after the subActions loop, creating a gap where that action's own subActions would not be expanded; (2) a new findCanonicalWebLookupActionName backed by WEB_LOOKUP_DIRECT_ACTION_PRIORITY, a second ordered list that must stay in sync with the existing WEB_LOOKUP_DIRECT_ACTIONS set with no enforcement. |
| packages/core/src/__tests__/tiered-action-surface.test.ts | Adds two integration tests for the force-include path: positive case (live-info query routes to non-general context, WEB_FETCH must appear in planner tools) and negative case (coding delegation query must not force-include WEB_FETCH). |
| packages/core/src/__tests__/message-routing-live-regression.test.ts | Adds unit tests for findCanonicalWebLookupActionName verifying it prefers WEB_FETCH by canonical name over a SEARCH-simile collision, and returns undefined when no canonical web action is present. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming message] --> B{looksLikeWebSearchRequest?}
    B -- No --> C[Normal gate loop]
    B -- Yes --> D[findCanonicalWebLookupActionName from allRuntimeActions]
    D -- found + not seen --> E[appendIfAllowed with mergedContexts]
    D -- not found --> C
    E -- passes gates --> F[WEB_FETCH added to selectedActions]
    E -- rejected --> C
    C --> G[subActions expansion loop]
    F --> G
    G --> H[buildV5PlannerActionSurface BM25 tiered retrieval]
    H --> I{WEB_FETCH in tiered surface?}
    I -- Yes --> J[Planner sees WEB_FETCH]
    I -- No backstop fires --> K{findCanonicalWebLookupActionName from params.actions}
    K -- found --> J
    K -- not found --> L{findWebLookupActionName simile fallback}
    L -- found --> J
    L -- not found --> M[Planner falls back to TASKS]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/core/src/services/message.ts`, line 3770-3805 ([link](https://github.com/elizaos/eliza/blob/d121e147df7e36771680e2ba9bf41d30392e758a/packages/core/src/services/message.ts#L3770-L3805)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Two independent lists of the same 9 action names with no shared source of truth**

   `WEB_LOOKUP_DIRECT_ACTIONS` (a `Set`) and the new `WEB_LOOKUP_DIRECT_ACTION_PRIORITY` (an ordered array) contain identical entries but in different sequences. `findCanonicalWebLookupActionName` reads only from `WEB_LOOKUP_DIRECT_ACTION_PRIORITY`, while other call sites read from `WEB_LOOKUP_DIRECT_ACTIONS`. The comment on `WEB_LOOKUP_DIRECT_ACTIONS` still says only "Kept in sync with `findWebLookupActionName`'s lookup list" — it does not mention the new priority array. A contributor adding `WEB_BROWSE` to `WEB_LOOKUP_DIRECT_ACTIONS` following the existing comment would leave `findCanonicalWebLookupActionName` blind to it. Consider making `WEB_LOOKUP_DIRECT_ACTION_PRIORITY` the single source and deriving the Set from it (e.g. `const WEB_LOOKUP_DIRECT_ACTIONS = new Set(WEB_LOOKUP_DIRECT_ACTION_PRIORITY)`), and updating the comment.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(core): expose keyless web-fetch in t..."](https://github.com/elizaos/eliza/commit/d121e147df7e36771680e2ba9bf41d30392e758a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34834822)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->
