### PR TITLE
Patch git-workspace-service ESM require shim

### DIFF
--- a/packages/app-core/scripts/lib/patch-bun-exports.mjs
+++ b/packages/app-core/scripts/lib/patch-bun-exports.mjs
@@ -1122,6 +1122,7 @@ const PTY_MANAGER_ESM_CREATE_REQUIRE_MARKER =
   "const __require = createRequire(import.meta.url);";
 const PTY_MANAGER_ESM_DIRNAME_MARKER =
   "const __dirname = dirname(fileURLToPath(import.meta.url));";
+const ESM_DYNAMIC_REQUIRE_IMPORT = 'import { createRequire } from "module";';
 const CODEX_TRUST_PROMPT_PATTERN_FROM =
   "do.?you.?trust.?the.?contents|trust.?this.?directory|yes,?.?continue|prompt.?injection";
 const CODEX_TRUST_PROMPT_PATTERN_TO =
@@ -1137,6 +1138,79 @@ const PTY_MANAGER_ESM_REQUIRE_PROLOGUE = `var __require = /* @__PURE__ */ ((x) =
   throw Error('Dynamic require of "' + x + '" is not supported');
 });
 `;
+const ESM_DYNAMIC_REQUIRE_PATTERN =
+  /var __require = \/\* @__PURE__ \*\/ \(\(x\) => typeof require !== "undefined" \? require :[\s\S]*?throw Error\('Dynamic require of "' \+ x \+ '" is not supported'\);\n}\);\n/;
+
+/**
+ * Some Bun-built ESM bundles keep a generated __require shim that only works
+ * when a global CommonJS require already exists. Under Node ESM / tsx it
+ * catches as a fake "missing dependency" error even when the dependency is
+ * installed. Replace that shim with createRequire(import.meta.url).
+ */
+export function applyEsmDynamicRequireCompat(filePath) {
+  if (!existsSync(filePath)) return false;
+
+  const compatSource = readFileSync(filePath, "utf8");
+  if (compatSource.includes(PTY_MANAGER_ESM_CREATE_REQUIRE_MARKER)) {
+    return false;
+  }
+  if (
+    !compatSource.includes(PTY_MANAGER_ESM_REQUIRE_PROLOGUE) &&
+    !ESM_DYNAMIC_REQUIRE_PATTERN.test(compatSource)
+  ) {
+    return false;
+  }
+
+  let next = compatSource.includes(PTY_MANAGER_ESM_REQUIRE_PROLOGUE)
+    ? compatSource.replace(
+        PTY_MANAGER_ESM_REQUIRE_PROLOGUE,
+        `${PTY_MANAGER_ESM_CREATE_REQUIRE_MARKER}\n`,
+      )
+    : compatSource.replace(
+        ESM_DYNAMIC_REQUIRE_PATTERN,
+        `${PTY_MANAGER_ESM_CREATE_REQUIRE_MARKER}\n`,
+      );
+  if (!next.includes(ESM_DYNAMIC_REQUIRE_IMPORT)) {
+    next = `${ESM_DYNAMIC_REQUIRE_IMPORT}\n${next}`;
+  }
+
+  if (next === compatSource) return false;
+  writeFileSync(filePath, next, "utf8");
+  return true;
+}
+
+/**
+ * git-workspace-service's ESM bundle uses the generated __require shim for
+ * @octokit/rest. Node/tsx loads the ESM entry for TS services, so GitHub
+ * workspace startup fails unless this bundle receives the createRequire patch.
+ */
+export function patchGitWorkspaceServiceEsmRequireCompat(
+  root,
+  log = console.log,
+) {
+  const searchRoots = dedupeRealPaths(
+    [root, resolve(root, "eliza")].filter((candidate) => existsSync(candidate)),
+  );
+  const candidates = dedupeRealPaths(
+    searchRoots.flatMap((searchRoot) =>
+      findPackageFilePaths(
+        searchRoot,
+        "git-workspace-service",
+        "dist/index.js",
+      ),
+    ),
+  );
+  let patched = false;
+  for (const filePath of candidates) {
+    if (applyEsmDynamicRequireCompat(filePath)) {
+      patched = true;
+      log(
+        `[patch-deps] Patched git-workspace-service ESM dynamic require compatibility: ${filePath}`,
+      );
+    }
+  }
+  return patched;
+}
 
 /**
  * pty-manager's published ESM bundle references __dirname but never defines it.
@@ -1170,7 +1244,7 @@ export function applyPtyManagerEsmDirnameCompat(filePath) {
   if (next.includes(PTY_MANAGER_ESM_REQUIRE_PROLOGUE)) {
     next = next.replace(
       PTY_MANAGER_ESM_REQUIRE_PROLOGUE,
-      `${moduleImport}\n${PTY_MANAGER_ESM_CREATE_REQUIRE_MARKER}\n`,
+      `${ESM_DYNAMIC_REQUIRE_IMPORT}\n${PTY_MANAGER_ESM_CREATE_REQUIRE_MARKER}\n`,
     );
   } else if (!next.includes(PTY_MANAGER_ESM_CREATE_REQUIRE_MARKER)) {
     next = `${moduleImport}\n${PTY_MANAGER_ESM_CREATE_REQUIRE_MARKER}\n${next}`;

--- a/packages/app-core/scripts/lib/patch-bun-exports.test.mjs
+++ b/packages/app-core/scripts/lib/patch-bun-exports.test.mjs
@@ -1,0 +1,79 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  applyEsmDynamicRequireCompat,
+  patchGitWorkspaceServiceEsmRequireCompat,
+} from "./patch-bun-exports.mjs";
+
+describe("patch-bun-exports", () => {
+  it("applyEsmDynamicRequireCompat replaces generated require shims", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "patch-bun-exports-test-"));
+    try {
+      const target = join(tmp, "index.js");
+      writeFileSync(
+        target,
+        [
+          'import pino from "pino";',
+          'var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : x)(function(x) {',
+          '  if (typeof require !== "undefined") return require.apply(this, arguments);',
+          `  throw Error('Dynamic require of "' + x + '" is not supported');`,
+          "});",
+          'const { Octokit } = __require("@octokit/rest");',
+        ].join("\n"),
+        "utf8",
+      );
+
+      expect(applyEsmDynamicRequireCompat(target)).toBe(true);
+
+      const updated = readFileSync(target, "utf8");
+      expect(updated).toContain('import { createRequire } from "module";');
+      expect(updated).toContain(
+        "const __require = createRequire(import.meta.url);",
+      );
+      expect(updated).not.toContain("Dynamic require of");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("patchGitWorkspaceServiceEsmRequireCompat patches installed ESM bundles", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "patch-bun-exports-test-"));
+    try {
+      const pkgDir = join(tmp, "node_modules", "git-workspace-service", "dist");
+      const target = join(pkgDir, "index.js");
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(
+        target,
+        [
+          'import pino from "pino";',
+          'var __require = /* @__PURE__ */ ((x) => typeof require !== "undefined" ? require : x)(function(x) {',
+          '  if (typeof require !== "undefined") return require.apply(this, arguments);',
+          `  throw Error('Dynamic require of "' + x + '" is not supported');`,
+          "});",
+          'const { Octokit } = __require("@octokit/rest");',
+        ].join("\n"),
+        "utf8",
+      );
+
+      const logs = [];
+      expect(
+        patchGitWorkspaceServiceEsmRequireCompat(tmp, (msg) => logs.push(msg)),
+      ).toBe(true);
+      expect(readFileSync(target, "utf8")).toContain(
+        "const __require = createRequire(import.meta.url);",
+      );
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toContain("git-workspace-service");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/app-core/scripts/patch-deps.mjs
+++ b/packages/app-core/scripts/patch-deps.mjs
@@ -35,6 +35,7 @@ import {
   patchBrokenElizaCoreRuntimeDists,
   patchCodexFolderApprovalPromptCompat,
   patchExtensionlessJsExports,
+  patchGitWorkspaceServiceEsmRequireCompat,
   patchNobleHashesCompat,
   patchPtyManagerCursorPositionCompat,
   patchPtyManagerEsmDirnameCompat,
@@ -94,6 +95,7 @@ patchCodexFolderApprovalPromptCompat(root);
 patchBrokenElizaCoreRuntimeDists(root);
 patchPtyManagerEsmDirnameCompat(root);
 patchPtyManagerCursorPositionCompat(root);
+patchGitWorkspaceServiceEsmRequireCompat(root);
 // @elizaos/agent and @elizaos/ui ship exports maps where glob targets still
 // carry the source extension (e.g. "./packages/agent/src/runtime/*.ts.js").
 // Bun fails to resolve those because the actual emitted dist files are *.js.


### PR DESCRIPTION
## Summary
- Patch generated dynamic `require` shims in the installed `git-workspace-service` ESM bundle
- Reuse `createRequire(import.meta.url)` so ESM runtime paths can load CommonJS dependencies safely
- Run the compatibility patch from the dependency postinstall patch pipeline
- Add focused coverage for the shim rewrite and installed-bundle patch path

## Testing
- `bun run --cwd packages/app-core test -- scripts/lib/patch-bun-exports.test.mjs`
- `bunx @biomejs/biome check packages/app-core/scripts/lib/patch-bun-exports.mjs packages/app-core/scripts/lib/patch-bun-exports.test.mjs packages/app-core/scripts/patch-deps.mjs`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds ESM `__require` shim patching for `git-workspace-service` bundles, which use a slimmer Bun-generated shim (no `Proxy` branch) that breaks under Node ESM/tsx when `@octokit/rest` is loaded.

- Introduces `applyEsmDynamicRequireCompat` — a generic shim replacer that handles both the full `PTY_MANAGER_ESM_REQUIRE_PROLOGUE` form and a new regex (`ESM_DYNAMIC_REQUIRE_PATTERN`) for the simpler form used by `git-workspace-service`.
- Adds `patchGitWorkspaceServiceEsmRequireCompat` as the orchestrator and wires it into `patch-deps.mjs`; also promotes the repeated import string to a shared `ESM_DYNAMIC_REQUIRE_IMPORT` constant used in `applyPtyManagerEsmDirnameCompat`, though the `else if` branch of that function still references a local alias with the same value.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the change adds an isolated postinstall patch step that only writes to the installed `git-workspace-service` bundle and falls back gracefully when the file is absent or already patched.

The logic is correct and the tests cover the two primary cases. The only issue is a cosmetic inconsistency in `applyPtyManagerEsmDirnameCompat` where the `else if` branch still uses the now-redundant local `moduleImport` variable instead of the new module-level `ESM_DYNAMIC_REQUIRE_IMPORT` constant.

No files require special attention; both the new function and its integration in `patch-deps.mjs` follow the existing pattern faithfully.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/lib/patch-bun-exports.mjs | Adds `applyEsmDynamicRequireCompat` (shared regex-based shim replacer) and `patchGitWorkspaceServiceEsmRequireCompat` (orchestrator); also promotes the `moduleImport` literal to the module-level `ESM_DYNAMIC_REQUIRE_IMPORT` constant in the `PTY_MANAGER_ESM_REQUIRE_PROLOGUE` branch of `applyPtyManagerEsmDirnameCompat`, but leaves the local `moduleImport` variable in the `else if` branch unchanged |
| packages/app-core/scripts/lib/patch-bun-exports.test.mjs | New test file covering both `applyEsmDynamicRequireCompat` (regex branch) and `patchGitWorkspaceServiceEsmRequireCompat` (directory scan + patch) using temp directories; both happy-path scenarios are well-modelled |
| packages/app-core/scripts/patch-deps.mjs | Imports and calls `patchGitWorkspaceServiceEsmRequireCompat(root)` in the correct position in the postinstall pipeline; minimal, correct change |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[applyEsmDynamicRequireCompat\nfilePath] --> B{file exists?}
    B -- no --> Z[return false]
    B -- yes --> C{already contains\nPTY_MANAGER_ESM_CREATE_REQUIRE_MARKER?}
    C -- yes --> Z
    C -- no --> D{contains PTY_MANAGER_ESM_REQUIRE_PROLOGUE\nOR matches ESM_DYNAMIC_REQUIRE_PATTERN?}
    D -- no --> Z
    D -- yes --> E{contains\nPTY_MANAGER_ESM_REQUIRE_PROLOGUE?}
    E -- yes --> F[replace exact prologue string\nwith createRequire marker]
    E -- no --> G[replace via ESM_DYNAMIC_REQUIRE_PATTERN\nregex with createRequire marker]
    F --> H{contains\nESM_DYNAMIC_REQUIRE_IMPORT?}
    G --> H
    H -- no --> I[prepend import createRequire from module]
    H -- yes --> J{next === compatSource?}
    I --> J
    J -- yes --> Z
    J -- no --> K[writeFileSync + return true]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/app-core/scripts/lib/patch-bun-exports.mjs`, line 1233-1234 ([link](https://github.com/elizaos/eliza/blob/f19a61ef69bbb9ff2aa9330199181c52e4e736e7/packages/app-core/scripts/lib/patch-bun-exports.mjs#L1233-L1234)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The `else if` branch of `applyPtyManagerEsmDirnameCompat` still uses the local `moduleImport` variable, while the `if` branch was updated in this PR to use the new module-level `ESM_DYNAMIC_REQUIRE_IMPORT` constant. Both hold the identical string, so there's no functional difference, but the inconsistency within the same function could cause confusion for future maintainers who assume the constant is the canonical reference.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix(app-core): patch git-workspace-servi..."](https://github.com/elizaos/eliza/commit/f19a61ef69bbb9ff2aa9330199181c52e4e736e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34868347)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->