### PR TITLE
chore(ci): split deploy-eliza-provisioning-worker by env (staging/prod)

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -9,7 +9,7 @@ name: Deploy Eliza Provisioning Worker
 
 on:
   push:
-    branches: [develop]
+    branches: [develop, main]
     paths:
       - '.github/workflows/deploy-eliza-provisioning-worker.yml'
       - 'packages/scripts/cloud/admin/daemons/provisioning-worker.ts'
@@ -24,9 +24,20 @@ on:
       - 'packages/core/**'
       - 'plugins/plugin-sql/**'
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment (host + secrets resolved from this)'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - production
 
+# Per-env concurrency: a develop push (staging) and a main push (production)
+# can deploy in parallel without one cancelling the other.
 concurrency:
-  group: deploy-eliza-provisioning-worker
+  group: deploy-eliza-provisioning-worker-${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'production' || 'staging') }}
   cancel-in-progress: false
 
 # Default to least privilege. Override per-job where needed.
@@ -34,16 +45,38 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
-    name: Deploy worker to Hetzner host
+  determine-env:
+    name: Determine environment
     runs-on: ubuntu-latest
-    environment: production
+    outputs:
+      environment: ${{ steps.env.outputs.environment }}
+      branch: ${{ steps.env.outputs.branch }}
+    steps:
+      - id: env
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            env="${{ github.event.inputs.environment }}"
+          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            env="production"
+          else
+            env="staging"
+          fi
+          branch=$([ "$env" = "production" ] && echo "main" || echo "develop")
+          echo "environment=$env" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch"   >> "$GITHUB_OUTPUT"
+          echo "Resolved: environment=$env branch=$branch"
+
+  deploy:
+    name: Deploy worker to Hetzner host (${{ needs.determine-env.outputs.environment }})
+    runs-on: ubuntu-latest
+    needs: determine-env
+    environment: ${{ needs.determine-env.outputs.environment }}
     timeout-minutes: 15
     env:
       SYSTEMD_UNIT: eliza-provisioning-worker.service
       DEPLOY_HOST: ${{ secrets.ELIZA_PROVISIONING_HOST }}
       DEPLOY_SSH_KEY: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
-      DEPLOY_BRANCH: develop
+      DEPLOY_BRANCH: ${{ needs.determine-env.outputs.branch }}
     steps:
       - name: Check deploy configuration
         id: deploy_config

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/.gitignore
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/.gitignore
@@ -9,3 +9,4 @@ crash.*.log
 # Only `.tfvars.example` lives in the repo.
 *.tfvars
 !*.tfvars.example
+.envrc

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
@@ -28,7 +28,7 @@ resource "hcloud_server" "control_plane" {
   # `milady` VM. The environment lives in labels, not the hostname, so the
   # prod/staging distinction shows up in the Hetzner Console filter
   # without bloating the hostname every operator types into SSH.
-  name        = "eliza-${each.value}"
+  name        = "eliza-${var.environment}-${each.value}"
   location    = var.hcloud_location
   server_type = var.hcloud_server_type
   image       = var.hcloud_image
@@ -38,7 +38,7 @@ resource "hcloud_server" "control_plane" {
   })
 
   user_data = templatefile("${path.module}/cloud-init/bootstrap.yaml.tftpl", {
-    hostname          = "eliza-${each.value}"
+    hostname          = "eliza-${var.environment}-${each.value}"
     deploy_branch     = var.deploy_branch
     operator_ssh_keys = var.ssh_public_keys
   })
@@ -49,6 +49,8 @@ resource "hcloud_server" "control_plane" {
     ignore_changes = [
       user_data, # bootstrap runs once at first boot
       image,     # updating image rebuilds — explicit `terraform taint` to opt in
+      name,      # legacy VMs may not follow the env-prefixed naming convention; renaming is out of band
+      ssh_keys,  # operator key rotations don't recreate the box (keys are baked into authorized_keys at boot)
     ]
   }
 }


### PR DESCRIPTION
Fixes the env mismatch where pushes to `develop` deployed to the `production` GitHub Environment.

## What

- Triggers added: now fires on push to both `develop` AND `main` (was just develop)
- New `determine-env` job resolves env + branch from trigger:
  - push to `main` → production env, branch=main
  - push to `develop` → staging env, branch=develop
  - workflow_dispatch → user picks env, branch follows
- Deploy job uses `environment: ${{ needs.determine-env.outputs.environment }}` so it pulls the correct env-scoped `ELIZA_PROVISIONING_HOST` + `ELIZA_PROVISIONING_SSH_KEY`
- Concurrency keyed by env so develop + main can ship in parallel

## Also

TF `hcloud_server` `lifecycle.ignore_changes` extended with `name` + `ssh_keys` so:
- legacy VMs not following the new `eliza-${env}-N` naming convention don't get destroyed on next apply
- operator-key rotations don't force VM recreation (keys are baked into authorized_keys at boot)

## Validation

- Staging env now has `ELIZA_PROVISIONING_HOST=46.224.1.246` + `ELIZA_PROVISIONING_SSH_KEY` set (eliza-staging-1 VM, TF-managed, cpx22 fsn1)
- Production env still has its existing secrets for eliza-1 (88.99.82.102)
- Next develop push → deploy targets staging, prod stays put
- Next main push → deploy targets prod

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an environment mismatch where pushes to `develop` were deploying to the `production` GitHub Environment. It introduces a `determine-env` job that dynamically resolves the target environment and branch from the trigger, and extends the Terraform `lifecycle.ignore_changes` to prevent VM recreation for legacy naming and key rotations.

- Workflow now triggers on both `develop` and `main`; a new `determine-env` job maps `main` → production and `develop` → staging, with `workflow_dispatch` allowing manual selection. Concurrency is keyed per env so staging and production deploys no longer block each other.
- Terraform `hcloud_server` gains `name` and `ssh_keys` in `lifecycle.ignore_changes`, protecting existing VMs from recreation when the new env-prefixed naming convention is adopted or operator keys are rotated.
- Two leftover hardcoded values remain: Discord notifications still say `Branch: develop` regardless of which branch triggered the deploy, and the missing-secrets step summary still references `` `production` `` by name even when the staging env is the one unconfigured.

<h3>Confidence Score: 3/5</h3>

Safe to merge for functional correctness — the staging/production routing is fixed — but production deploys will emit misleading Discord notifications that report the wrong branch name until the hardcoded strings are corrected.

The core routing fix works correctly. The remaining hardcoded 'Branch: develop' strings in both Discord notification steps mean every production deploy will be reported in Discord as a staging/develop deploy, making it harder to audit which branch reached production and potentially masking a mistaken production deploy.

The Discord notification steps and the missing-secrets step summary in `.github/workflows/deploy-eliza-provisioning-worker.yml` still carry hardcoded values from before the split.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-eliza-provisioning-worker.yml | Adds determine-env job to split staging/production routing correctly, but Discord notifications still hardcode 'Branch: develop' and the skip-deploy summary hardcodes the environment name as 'production'. |
| packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf | Extends lifecycle.ignore_changes with name and ssh_keys to prevent VM recreation for legacy naming and key rotations; adds env prefix to resource names for new servers. |
| packages/cloud-infra/cloud/terraform/hetzner/control-plane/.gitignore | Adds .envrc to .gitignore to prevent local direnv files from being committed. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Event
    participant DE as determine-env job
    participant DJ as deploy job
    participant H as Hetzner Host
    participant D as Discord

    GH->>DE: push to develop / push to main / workflow_dispatch
    DE->>DE: "resolve environment (staging|production) + branch (develop|main)"
    DE-->>DJ: outputs.environment, outputs.branch

    DJ->>DJ: fetch secrets for resolved GitHub Environment
    DJ->>DJ: check ELIZA_PROVISIONING_HOST + ELIZA_PROVISIONING_SSH_KEY
    alt secrets missing (push)
        DJ-->>GH: warning + step summary (skip)
    else secrets missing (workflow_dispatch)
        DJ-->>GH: error + exit 1
    end

    DJ->>H: SSH → git fetch + checkout DEPLOY_BRANCH
    H->>H: bun install + build
    H->>H: systemctl restart provisioning-worker + agent-router
    DJ->>H: SSH health check (18 × 5s polls)
    H-->>DJ: both daemons stable + /healthz OK

    DJ->>D: Notify success/failure (branch hardcoded as 'develop' ⚠️)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `.github/workflows/deploy-eliza-provisioning-worker.yml`, line 291-315 ([link](https://github.com/elizaos/eliza/blob/cf750b41cf5ab24114bfd028d11b6f9265c539db/.github/workflows/deploy-eliza-provisioning-worker.yml#L291-L315)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> The Discord notification descriptions hardcode `Branch: develop` for both the success and failure notifications. When this workflow fires on a `main` push and deploys to production, both notifications will report the wrong branch, silently making production deploys look like staging deploys in the Discord channel.


2. `.github/workflows/deploy-eliza-provisioning-worker.yml`, line 90 ([link](https://github.com/elizaos/eliza/blob/cf750b41cf5ab24114bfd028d11b6f9265c539db/.github/workflows/deploy-eliza-provisioning-worker.yml#L90)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The step summary message hardcodes `production` as the GitHub environment name. If the staging environment is missing its secrets, the operator will see a message saying the `production` environment is unconfigured, which is misleading and will send them looking in the wrong place.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["ci(deploy-eliza-provisioning-worker): sp..."](https://github.com/elizaos/eliza/commit/cf750b41cf5ab24114bfd028d11b6f9265c539db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34903363)</sub>

<!-- /greptile_comment -->