### PR TITLE
chore(ci): add cloud-sdk path triggers + drop dead develop-cf branch

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -20,6 +20,7 @@ on:
       - "packages/core/**"
       - "packages/app/**"
       - "packages/app-core/**"
+      - "packages/cloud-sdk/**"
       - ".github/workflows/build-agent-image.yml"
       - ".dockerignore"
   release:

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -13,20 +13,22 @@ name: Cloud CF Deploy
 
 on:
   push:
-    branches: [main, develop, develop-cf]
+    branches: [main, develop]
     paths:
       - "packages/cloud-api/**"
       - "packages/cloud-frontend/**"
       - "packages/cloud-shared/**"
       - "packages/cloud-services/**"
+      - "packages/cloud-sdk/**"
       - ".github/workflows/cloud-cf-deploy.yml"
   pull_request:
-    branches: [main, develop, develop-cf]
+    branches: [main, develop]
     paths:
       - "packages/cloud-api/**"
       - "packages/cloud-frontend/**"
       - "packages/cloud-shared/**"
       - "packages/cloud-services/**"
+      - "packages/cloud-sdk/**"
       - ".github/workflows/cloud-cf-deploy.yml"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/cloud-deploy-backend.yml
+++ b/.github/workflows/cloud-deploy-backend.yml
@@ -11,6 +11,7 @@ on:
       - 'packages/cloud-frontend/**'
       - 'packages/cloud-shared/**'
       - 'packages/cloud-services/**'
+      - 'packages/cloud-sdk/**'
   workflow_dispatch:
     inputs:
       environment:

--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -21,6 +21,7 @@ on:
       - 'packages/cloud-shared/src/lib/services/eliza-sandbox.ts'
       - 'packages/cloud-shared/src/db/repositories/agent-sandboxes.ts'
       - 'packages/cloud-shared/**'
+      - 'packages/cloud-sdk/**'
       - 'packages/core/**'
       - 'plugins/plugin-sql/**'
   workflow_dispatch:


### PR DESCRIPTION
Closes 2 gaps surfaced by a fresh CI audit:

## 1. `packages/cloud-sdk/**` missing from 4 deploy workflows

The cloud-sdk is a typed RPC surface consumed by the cloud-api Worker, the cloud-frontend SPA, the provisioning-worker daemon, and the agent image (via plugin-elizacloud). A change to it would land on develop without triggering any of:
- `cloud-deploy-backend.yml` (Worker + Pages deploy)
- `cloud-cf-deploy.yml` (CF Workers + Pages)
- `deploy-eliza-provisioning-worker.yml` (Hetzner daemon)
- `build-agent-image.yml` (GHCR image)

Each workflow's path filter now includes `packages/cloud-sdk/**`.

## 2. `develop-cf` branch in cloud-cf-deploy.yml triggers

Branch never existed remotely (`gh api repos/elizaOS/eliza/branches/develop-cf` -> 404). Dropping it removes a placeholder that would have deployed to staging on a future accidental push.

## No behavior change for legitimate develop/main pushes

The 4 workflows already correctly route develop -> staging and main -> production via their respective `determine-env` jobs (or, for build-agent-image, via tag mapping). This PR only widens the triggers; it doesn't alter any deploy logic.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes two CI gaps identified in an audit: adds `packages/cloud-sdk/**` path triggers to four deploy workflows that were missing it, and removes the non-existent `develop-cf` branch from `cloud-cf-deploy.yml`. No deploy logic is changed.

- **Path trigger gaps closed**: `build-agent-image.yml`, `cloud-cf-deploy.yml`, `cloud-deploy-backend.yml`, and `deploy-eliza-provisioning-worker.yml` now all fire on `cloud-sdk` changes, matching the fact that the SDK is a build-time dependency in each workflow's build chain.
- **Dead branch removed**: `develop-cf` is dropped from `cloud-cf-deploy.yml`'s `push` and `pull_request` branch filters, eliminating a placeholder that could have unexpectedly triggered a staging deploy on a future accidental push to that name.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive path filters and a dead-branch removal with no impact on deploy logic.

Each change is a targeted, one-line addition to an existing paths: list in a workflow trigger, or a branch name removal confirmed to be a 404 in the remote. The deploy jobs themselves are untouched, and each workflow already had the correct develop→staging / main→production routing before this PR.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build-agent-image.yml | Adds packages/cloud-sdk/** to the push path filter; consistent with the workflow already building cloud-sdk as part of its core dependency chain. |
| .github/workflows/cloud-cf-deploy.yml | Drops the non-existent develop-cf branch from both push and pull_request triggers, and adds packages/cloud-sdk/** to both path filter sets. |
| .github/workflows/cloud-deploy-backend.yml | Adds packages/cloud-sdk/** to the push path filter; this workflow has no pull_request trigger so no corresponding PR filter is needed. |
| .github/workflows/deploy-eliza-provisioning-worker.yml | Adds packages/cloud-sdk/** to the push path filter, following the same pattern as the existing packages/cloud-shared/** glob. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    push["Push to develop / main"]
    sdk["packages/cloud-sdk/** change"]
    
    push --> sdk

    sdk --> A["build-agent-image.yml\n✅ now triggered"]
    sdk --> B["cloud-cf-deploy.yml\n✅ now triggered"]
    sdk --> C["cloud-deploy-backend.yml\n✅ now triggered"]
    sdk --> D["deploy-eliza-provisioning-worker.yml\n✅ now triggered"]

    A --> imgGHCR["GHCR agent image push"]
    B --> cfWorker["Cloudflare Workers + Pages deploy"]
    C --> backendDeploy["DB migrate + VPS deploy"]
    D --> hetznerDeploy["Hetzner provisioning daemon restart"]

    style sdk fill:#f4a261,stroke:#e76f51,color:#000
```

<sub>Reviews (1): Last reviewed commit: ["chore(ci): add cloud-sdk path triggers +..."](https://github.com/elizaos/eliza/commit/18694beeab83772c2d91dccb5ece51fe6f91904c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34910339)</sub>

<!-- /greptile_comment -->