### PR TITLE
chore(infra): close staging VM bootstrap gaps (node, swap, symlink)

### DIFF
--- a/.github/workflows/deploy-eliza-provisioning-worker.yml
+++ b/.github/workflows/deploy-eliza-provisioning-worker.yml
@@ -103,6 +103,49 @@ jobs:
           fi
           echo "configured=true" >> "$GITHUB_OUTPUT"
 
+      - name: Ensure host prereqs (Node 24, swap, bunx symlink)
+        if: steps.deploy_config.outputs.configured == 'true'
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
+        with:
+          host: ${{ env.DEPLOY_HOST }}
+          username: deploy
+          key: ${{ env.DEPLOY_SSH_KEY }}
+          command_timeout: 5m
+          script: |
+            set -euo pipefail
+            # Idempotent safety net for hosts provisioned BEFORE the cloud-init
+            # template that pre-installs these. Each block is a no-op if already
+            # set up — runs on every deploy so any host drift self-heals.
+
+            # Node 24: the systemd unit calls `tsx` which spawns a Node process.
+            # New cloud-init template installs it via NodeSource; older hosts
+            # (eliza-staging-1 from the first TF apply) lack it.
+            if ! command -v node >/dev/null 2>&1; then
+              echo "[host-prereqs] installing Node 24"
+              curl -fsSL https://deb.nodesource.com/setup_24.x | sudo bash -
+              sudo apt-get install -y nodejs
+            fi
+
+            # Swap: smaller shapes (cpx22, cax11) OOM during `turbo run build`.
+            # 8 GB swap once and forever; harmless on bigger shapes.
+            if [ ! -f /swapfile ]; then
+              echo "[host-prereqs] adding 8GB swap"
+              sudo fallocate -l 8G /swapfile
+              sudo chmod 600 /swapfile
+              sudo mkswap /swapfile
+              sudo swapon /swapfile
+              grep -q '^/swapfile ' /etc/fstab || echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab >/dev/null
+            fi
+
+            # bunx symlink: the canary `bun.sh/install` tarball stopped shipping
+            # bunx as a separate binary at some point; build scripts that call
+            # `bunx tsc` etc. then fail with `bun: command not found: bunx`.
+            # `bunx` is just `bun` reading argv[0] — a symlink is sufficient.
+            if [ ! -e /home/deploy/.bun/bin/bunx ] && [ -e /home/deploy/.bun/bin/bun ]; then
+              echo "[host-prereqs] creating bunx symlink"
+              ln -sf bun /home/deploy/.bun/bin/bunx
+            fi
+
       - name: Deploy and restart worker
         if: steps.deploy_config.outputs.configured == 'true'
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
@@ -198,6 +241,17 @@ jobs:
             rm -rf plugins/plugin-sql/node_modules/@elizaos/core
             ln -s ../../../../packages/core plugins/plugin-sql/node_modules/@elizaos/core
             bun run --cwd plugins/plugin-sql build
+
+            # Defensive workspace symlinks: `bun install` should create these
+            # automatically for any workspace package the root or a sibling
+            # depends on, but the daemon (in packages/scripts/, which has NO
+            # package.json and so is invisible to bun's workspace graph)
+            # imports `@elizaos/cloud-shared` at runtime. On a fresh host the
+            # symlink was missing — daemon then crashes with
+            # `Cannot find package '@elizaos/cloud-shared'`. Recreate it here
+            # idempotently after `bun install` is done.
+            mkdir -p node_modules/@elizaos
+            ln -sfn ../../packages/cloud-shared node_modules/@elizaos/cloud-shared
 
             # Install/refresh both systemd units (provisioning worker + agent router).
             sudo install -m 0644 \

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
@@ -52,11 +52,9 @@ packages:
   - postgresql-client
   - rsync
   - unzip
-  # Node 24 for the daemon (systemd unit calls `tsx` which is a Node process).
-  # The NodeSource setup script below pins to Node 24 and refreshes the apt
-  # source list; the actual `nodejs` package is then pulled by `package_upgrade`
-  # / the apt run that follows runcmd. Listed here for the audit trail; the
-  # version is enforced via the NodeSource setup script (see runcmd).
+  # nodejs is installed from the NodeSource apt repo in runcmd below, not from
+  # this package list — we need Node 24, and Ubuntu 24.04's default nodejs is
+  # older. See the NodeSource setup_24.x call in runcmd.
 
 write_files:
   - path: /etc/profile.d/eliza-paths.sh

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
@@ -52,6 +52,11 @@ packages:
   - postgresql-client
   - rsync
   - unzip
+  # Node 24 for the daemon (systemd unit calls `tsx` which is a Node process).
+  # The NodeSource setup script below pins to Node 24 and refreshes the apt
+  # source list; the actual `nodejs` package is then pulled by `package_upgrade`
+  # / the apt run that follows runcmd. Listed here for the audit trail; the
+  # version is enforced via the NodeSource setup script (see runcmd).
 
 write_files:
   - path: /etc/profile.d/eliza-paths.sh
@@ -65,6 +70,28 @@ runcmd:
   # Docker apt repo (GPG-verified keyring), not `curl get.docker.com | sh`.
   - systemctl enable --now docker
 
+  # Node 24 for the daemon. The systemd unit calls
+  # `node_modules/.bin/tsx --tsconfig ... daemon.ts` which spawns a Node
+  # process. Without this, the first deploy fails with
+  # `/usr/bin/env: 'node': No such file or directory`. NodeSource setup
+  # script refreshes the apt index for Node 24, then `apt-get install`
+  # pulls it. Pinned to the major version so a future Node 26 jump is
+  # explicit; the apt repo stays on the LTS line within Node 24.
+  - curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
+  - apt-get install -y nodejs
+
+  # Swap: the staging cpx32 / cpx22 / cax11 shapes are too small to run
+  # `turbo run build --filter=@elizaos/...` (19+ packages in parallel)
+  # without OOM-killing one of the workspace builds. 8 GB swap is enough
+  # headroom that the build completes even under memory pressure; on
+  # bigger control-plane shapes (cax21 8 GB) this is unused. Persists
+  # across reboots via /etc/fstab.
+  - test -f /swapfile || fallocate -l 8G /swapfile
+  - chmod 600 /swapfile
+  - mkswap /swapfile || true
+  - swapon /swapfile || true
+  - grep -q '^/swapfile ' /etc/fstab || echo '/swapfile none swap sw 0 0' >> /etc/fstab
+
   # Bun runtime for the deploy user. We download a pinned release tarball
   # AND its SHASUMS256 manifest from the same GitHub release, then verify
   # the binary against the published hash before extracting. This avoids
@@ -76,6 +103,12 @@ runcmd:
   - su - deploy -c 'curl -fsSL -o /tmp/bun-SHASUMS256.txt https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/SHASUMS256.txt'
   - su - deploy -c 'cd /tmp && grep "bun-linux-x64.zip" bun-SHASUMS256.txt | sha256sum -c -'
   - su - deploy -c 'cd /tmp && unzip -q bun.zip && install -m 0755 bun-linux-x64/bun /home/deploy/.bun/bin/bun && rm -rf /tmp/bun.zip /tmp/bun-linux-x64 /tmp/bun-SHASUMS256.txt'
+
+  # The `bunx` invocation used by some workspace build scripts is a separate
+  # binary (or symlink) alongside `bun`. Older release tarballs ship it; the
+  # canary release the deploy workflow upgrades to during first deploy does
+  # NOT, so we recreate it here as a symlink. Cheap and idempotent.
+  - su - deploy -c 'ln -sf bun /home/deploy/.bun/bin/bunx'
 
   # Repo checkout — the GitHub deploy workflow then takes over for code updates.
   - mkdir -p /opt/eliza && chown deploy:deploy /opt/eliza


### PR DESCRIPTION
## Why

When eliza-staging-1 came up for the first time today, the daemon needed 3 manual fixes before it would run. Each is a gap in either the cloud-init template (one-shot at first boot) or the deploy workflow (idempotent each push). Closing both layers so the next staging VM bootstrap is one-shot.

## Cloud-init template

- **Node 24 via NodeSource.** The systemd unit calls `tsx` which spawns a Node process. Without node, the daemon fatals with `/usr/bin/env: 'node': No such file or directory`.
- **8 GB swap, persistent via fstab.** Smaller shapes (cpx22, cax11) OOM during `turbo run build --filter=@elizaos/...` on 19 packages; swap pushes the build through without a VM resize.
- **bunx symlink.** The canary `bun.sh/install` tarball stopped shipping bunx; build scripts that call `bunx tsc` then fail. `bunx` is just `bun` reading argv[0], so a symlink is sufficient.

## Deploy workflow — idempotent safety net for existing hosts

- New `Ensure host prereqs` step doing the same Node / swap / bunx setup if missing. Catches eliza-1 and eliza-staging-1 as they exist today (both provisioned before this cloud-init template). Each block is a no-op if already set up.
- Defensive workspace symlink for `@elizaos/cloud-shared` post-`bun install`: the daemon lives in `packages/scripts/` (no package.json) so bun's workspace graph never includes it; the global symlink would never be created automatically.

## Validation

- eliza-staging-1 daemon NRestarts=0 since 13:16 UTC BEFORE this commit lands (manually patched in-place earlier today). This PR codifies those 3 manual fixes.
- eliza-1 (prod) heartbeats remained clean throughout — unaffected, will re-run the prereqs idempotently on next deploy.

## Commits

1. `84f49c677e` — bootstrap gaps
2. `30a6465cb9` — corrects a misleading comment in the cloud-init nodejs section (self-review pass)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes three bootstrap gaps found when `eliza-staging-1` came up for the first time: missing Node 24, no swap space (causing OOM during builds), and a missing `bunx` symlink. The fixes are applied at two layers — the cloud-init template (one-shot at first boot for new VMs) and a new idempotent "Ensure host prereqs" deploy workflow step (self-healing for hosts provisioned before this template).

- **Cloud-init template** (`bootstrap.yaml.tftpl`): adds NodeSource Node 24 install, 8 GB swap creation with fstab persistence, and a `bunx → bun` symlink after the pinned bun binary is installed.
- **Deploy workflow** (`deploy-eliza-provisioning-worker.yml`): adds a new pre-deploy SSH step that idempotently checks and applies the same three prereqs, plus a post-`bun install` symlink for `@elizaos/cloud-shared` (invisible to bun's workspace graph because `packages/scripts/` has no `package.json`).

<h3>Confidence Score: 4/5</h3>

Safe to merge — the changes are additive, well-commented, and fix documented production failures with no impact on the runtime application code.

The dual-layer approach (cloud-init + idempotent workflow step) is sound, and all three prereq blocks in the workflow are correctly guarded. Two small gaps: the cloud-init swap section runs chmod/mkswap/swapon outside the fallocate guard (diverging from the workflow's safer pattern), and the bunx check in the workflow could miss hosts where a canary bun upgrade during the same deploy drops bunx again.

The swap commands in bootstrap.yaml.tftpl and the bunx guard in the workflow prereqs step deserve a second look before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-eliza-provisioning-worker.yml | Adds idempotent 'Ensure host prereqs' step (Node 24, swap, bunx symlink) and a defensive cloud-shared workspace symlink post-bun-install; all new blocks are well-guarded. |
| packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl | Adds Node 24 via NodeSource, 8 GB swap, and bunx symlink to the first-boot template; swap sub-commands (chmod/mkswap/swapon) run unconditionally outside the fallocate guard, unlike the more defensive workflow version. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[New VM boots] -->|cloud-init runs once| B[Install Docker]
    B --> C[Install Node 24 via NodeSource]
    C --> D[Create 8 GB swapfile + fstab]
    D --> E[Install pinned bun v1.3.13]
    E --> F[Create bunx symlink]
    F --> G[Clone eliza repo]
    G --> H[VM ready for first deploy]

    I[Git push to develop/main] -->|Workflow triggers| J[Ensure host prereqs step]
    J --> K{node installed?}
    K -->|No| L[Install Node 24 via NodeSource]
    K -->|Yes| M{/swapfile exists?}
    L --> M
    M -->|No| N[Create 8 GB swapfile + fstab]
    M -->|Yes| O{bunx symlink exists?}
    N --> O
    O -->|No, bun present| P[Create bunx symlink]
    O -->|Yes| Q[Deploy and restart worker]
    P --> Q
    Q --> R[bun install with retry]
    R --> S[build:core + plugin-sql]
    S --> T[Create cloud-shared symlink]
    T --> U[Install systemd units]
    U --> V[Restart daemons]
    V --> W[Health check]
```

<sub>Reviews (1): Last reviewed commit: ["chore(infra): correct misleading comment..."](https://github.com/elizaos/eliza/commit/30a6465cb9ec8aba3514886403a7569cd4165a14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34914613)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->