### PR TITLE
fix(cloud-frontend): audit:cloud installs Playwright Chromium first

### DIFF
--- a/packages/cloud-frontend/package.json
+++ b/packages/cloud-frontend/package.json
@@ -14,7 +14,7 @@
     "test:e2e": "node scripts/run-e2e.mjs",
     "test:e2e:live-auth": "node scripts/run-e2e.mjs tests/e2e/live-auth-backend.spec.ts",
     "test:e2e:update": "node scripts/run-e2e.mjs --update-snapshots",
-    "audit:cloud": "node scripts/run-e2e.mjs tests/e2e/aesthetic-audit.spec.ts --project=chromium-desktop --workers=1 && node -e \"const o=require('node:child_process'); const p=require('node:path'); const f=p.resolve('aesthetic-audit-output/contact-sheet.html'); const cmd=process.platform==='darwin'?'open':process.platform==='win32'?'start':'xdg-open'; o.spawn(cmd,[f],{stdio:'ignore',detached:true}).unref();\"",
+    "audit:cloud": "bunx playwright install chromium && node scripts/run-e2e.mjs tests/e2e/aesthetic-audit.spec.ts --project=chromium-desktop --workers=1 && node -e \"const o=require('node:child_process'); const p=require('node:path'); const f=p.resolve('aesthetic-audit-output/contact-sheet.html'); const cmd=process.platform==='darwin'?'open':process.platform==='win32'?'start':'xdg-open'; o.spawn(cmd,[f],{stdio:'ignore',detached:true}).unref();\"",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write src",

--- a/packages/cloud-frontend/package.json
+++ b/packages/cloud-frontend/package.json
@@ -14,7 +14,7 @@
     "test:e2e": "node scripts/run-e2e.mjs",
     "test:e2e:live-auth": "node scripts/run-e2e.mjs tests/e2e/live-auth-backend.spec.ts",
     "test:e2e:update": "node scripts/run-e2e.mjs --update-snapshots",
-    "audit:cloud": "bunx playwright install chromium && node scripts/run-e2e.mjs tests/e2e/aesthetic-audit.spec.ts --project=chromium-desktop --workers=1 && node -e \"const o=require('node:child_process'); const p=require('node:path'); const f=p.resolve('aesthetic-audit-output/contact-sheet.html'); const cmd=process.platform==='darwin'?'open':process.platform==='win32'?'start':'xdg-open'; o.spawn(cmd,[f],{stdio:'ignore',detached:true}).unref();\"",
+    "audit:cloud": "bunx playwright install --with-deps chromium && node scripts/run-e2e.mjs tests/e2e/aesthetic-audit.spec.ts --project=chromium-desktop --workers=1 && node -e \"const o=require('node:child_process'); const p=require('node:path'); const f=p.resolve('aesthetic-audit-output/contact-sheet.html'); const cmd=process.platform==='darwin'?'open':process.platform==='win32'?'start':'xdg-open'; o.spawn(cmd,[f],{stdio:'ignore',detached:true}).unref();\"",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write src",


### PR DESCRIPTION
## Summary

`bun run --cwd packages/cloud-frontend audit:cloud` fails on first-time runs because Playwright Chromium isn't installed. Every one of the 112 test cases in [tests/e2e/aesthetic-audit.spec.ts](packages/cloud-frontend/tests/e2e/aesthetic-audit.spec.ts) fails identically at `browserType.launch`:

```
Error: browserType.launch: Executable doesn't exist at
<user>/AppData/Local/ms-playwright/chromium_headless_shell-1223/chrome-headless-shell-win64/chrome-headless-shell.exe
```

This prepends a `bunx playwright install chromium` step to the `audit:cloud` script. The install is idempotent (Playwright skips when the matching binary is already present), so subsequent runs incur ~0 overhead.

## Why

Other Playwright commands in this repo (`test:e2e`, `test:e2e:live-auth`, `test:e2e:update`) have the same prerequisite, but they're typically run inside CI environments where the binary is already cached. `audit:cloud` is documented in [packages/cloud-frontend/AGENTS.md](packages/cloud-frontend/AGENTS.md) as a workflow contributors should run locally — meaning a first-time contributor will always hit this failure with no actionable error message.

## Test plan

- [x] Clean clone, no Chromium installed → `bun run --cwd packages/cloud-frontend audit:cloud` now boots successfully, downloads ~294 MB Chrome/headless-shell, and proceeds to the spec.
- [x] Second run with binary cached → no measurable delay added.

## Context

Found while running a QA pass against the [milady-ai/milady](https://github.com/milady-ai/milady) fork. Filed as Finding #8 in https://github.com/milady-ai/milady/pull/2179 (see `qa-findings.md` in that PR).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a first-run failure for `audit:cloud` by prepending `bunx playwright install --with-deps chromium` to the script, ensuring Chromium is present before the Playwright spec runs.

- The `--with-deps` flag is already included, handling OS-level library installation on Linux in addition to the browser binary itself.
- The install command is idempotent — Playwright skips the download when the matching binary is already cached, so subsequent runs incur no meaningful overhead.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line, targeted fix to an npm script with no effect on application code or CI pipelines.

The modification only touches a package.json script. `bunx playwright install --with-deps chromium` is idempotent and well-understood; `--with-deps` correctly handles OS-level dependencies on Linux. No application logic, tests, or CI configs are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cloud-frontend/package.json | Adds `bunx playwright install --with-deps chromium` as a pre-step to the `audit:cloud` script; idempotent and cross-platform. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[bun run audit:cloud] --> B[bunx playwright install --with-deps chromium]
    B --> C{Binary already cached?}
    C -- Yes --> D[Skip download ~0 overhead]
    C -- No --> E[Download Chromium ~294 MB]
    E --> F[Install OS deps --with-deps on Linux]
    D --> G[node scripts/run-e2e.mjs\naesthetic-audit.spec.ts]
    F --> G
    G --> H[Spawn Vite dev server]
    H --> I[Wait for server ready]
    I --> J[playwright test\n112 audit cases]
    J --> K[Open contact-sheet.html\nin default browser]
```

<sub>Reviews (2): Last reviewed commit: ["fix(cloud-frontend): use \`playwright ins..."](https://github.com/elizaos/eliza/commit/8db18feffd4e1f04f1de8063d0d071a0fbc31c11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35002265)</sub>

<!-- /greptile_comment -->