### PR TITLE
feat(app-core): make run-node entry filename configurable via ELIZA_ENTRY_FILE

### DIFF
--- a/packages/app-core/scripts/run-node.mjs
+++ b/packages/app-core/scripts/run-node.mjs
@@ -173,7 +173,11 @@ const runNode = () => {
     platform: process.platform,
     explicitNodePath: process.env.ELIZA_NODE_PATH,
   });
-  const nodeProcess = spawn(execPath, ["eliza.mjs", ...args], {
+  // Forks rename `eliza.mjs` to their own entry filename (e.g. `milady.mjs`).
+  // Letting them override the spawned filename via `ELIZA_ENTRY_FILE` avoids
+  // every fork having to ship a shim at the old name.
+  const entryFile = process.env.ELIZA_ENTRY_FILE?.trim() || "eliza.mjs";
+  const nodeProcess = spawn(execPath, [entryFile, ...args], {
     cwd,
     env,
     stdio: "inherit",

--- a/packages/app-core/scripts/run-node.mjs
+++ b/packages/app-core/scripts/run-node.mjs
@@ -175,8 +175,11 @@ const runNode = () => {
   });
   // Forks rename `eliza.mjs` to their own entry filename (e.g. `milady.mjs`).
   // Letting them override the spawned filename via `ELIZA_ENTRY_FILE` avoids
-  // every fork having to ship a shim at the old name.
-  const entryFile = process.env.ELIZA_ENTRY_FILE?.trim() || "eliza.mjs";
+  // every fork having to ship a shim at the old name. Read from `env` (the
+  // local snapshot built at module load) for consistency with what the child
+  // process actually receives — `.env.worktree` overrides applied above are
+  // visible here too.
+  const entryFile = env.ELIZA_ENTRY_FILE?.trim() || "eliza.mjs";
   const nodeProcess = spawn(execPath, [entryFile, ...args], {
     cwd,
     env,


### PR DESCRIPTION
## Summary

[`packages/app-core/scripts/run-node.mjs:176`](packages/app-core/scripts/run-node.mjs#L176) hardcodes `"eliza.mjs"` as the entry filename it spawns:

```js
const nodeProcess = spawn(execPath, ["eliza.mjs", ...args], { … });
```

Forks that rename the entry file (e.g. [milady-ai/milady](https://github.com/milady-ai/milady) renames it to `milady.mjs`) currently have to ship a shim at the old `eliza.mjs` path to keep `bun run doctor` and any other script that goes through `run-node.mjs` working. From a fresh clone of a fork:

```
$ bun run doctor
…
error: Module not found "eliza.mjs"
error: script "milady:doctor" exited with code 1
```

## Change

Add an optional `ELIZA_ENTRY_FILE` env var override. When set, `run-node.mjs` spawns that filename instead of `eliza.mjs`. The default behavior — `"eliza.mjs"` for the canonical elizaOS distribution — is unchanged:

```js
const entryFile = process.env.ELIZA_ENTRY_FILE?.trim() || "eliza.mjs";
const nodeProcess = spawn(execPath, [entryFile, ...args], { … });
```

Forks then set the var in their entry runner (or in `run-eliza-app-core-script.mjs`):

```js
env: { ...process.env, ELIZA_ENTRY_FILE: "milady.mjs", ... }
```

## Test plan

- [x] Default behavior unchanged — `ELIZA_ENTRY_FILE` unset → spawns `eliza.mjs` exactly like before.
- [x] Fork override — setting `ELIZA_ENTRY_FILE=milady.mjs` makes `bun run doctor` find the fork's entry on a fresh clone (no shim needed).
- [x] Empty / whitespace-only env var falls through to the default via `?.trim() || ...`.

## Context

Found while running a QA pass against the Milady fork. Filed as Finding #1 (layer 1) in https://github.com/milady-ai/milady/pull/2179.

Companion PR also in this fork branch series: https://github.com/elizaOS/eliza/pull/8125 (cloud-frontend audit:cloud Chromium prereq).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the entry filename spawned by `run-node.mjs` configurable via the `ELIZA_ENTRY_FILE` environment variable, removing the need for forks that rename their entry file to ship a compatibility shim at the old `eliza.mjs` path.

- The override is read from `env` (the local snapshot that already includes `.env.worktree` overrides), keeping it consistent with what the child process actually receives. The fallback via `?.trim() || "eliza.mjs"` correctly handles unset, empty, and whitespace-only values, preserving identical default behavior.
- The change is confined to a single line in `run-node.mjs` with a clear inline comment explaining the design rationale.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line env-var opt-in with an unchanged default and correct fallback logic.

The only modified behavior is the entry filename passed to `spawn`. When `ELIZA_ENTRY_FILE` is unset the value resolves to exactly "eliza.mjs" as before. The `?.trim() || "eliza.mjs"` guard correctly covers the empty/whitespace edge cases called out in the test plan, and reading from `env` rather than `process.env` keeps the resolution path consistent with the rest of the file.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/app-core/scripts/run-node.mjs | Adds ELIZA_ENTRY_FILE env var override for the spawned entry filename, reading from the local `env` snapshot (consistent with how the child process receives its environment), with a safe `.trim() || "eliza.mjs"` fallback. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[run-node.mjs starts] --> B[Load .env.worktree overrides]
    B --> C[syncElizaEnvAliases]
    C --> D[Build env snapshot from process.env]
    D --> E{shouldBuild?}
    E -->|yes| F[spawn bunx tsdown]
    F --> G[writeBuildStamp]
    G --> H[runNode]
    E -->|no| H
    H --> I[chooseElizaRuntime and resolveRuntimeExecPath]
    I --> J[Read env.ELIZA_ENTRY_FILE or use eliza.mjs default]
    J --> K[spawn execPath with entryFile and args]
    K --> L{exit code?}
    L -->|75 restart| M{restart loop guard}
    M -->|ok| H
    M -->|too many| N[exit 1]
    L -->|other| O[process.exit with code]
```

<sub>Reviews (2): Last reviewed commit: ["fix(app-core): read ELIZA\_ENTRY\_FILE fro..."](https://github.com/elizaos/eliza/commit/09fd217e8e3cd107803337f559f6a5317bcae9ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35003148)</sub>

<!-- /greptile_comment -->