### PR TITLE
feat(core): structural detectors for training-cutoff leaks + fabricated moderation

### DIFF
--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -196,6 +196,8 @@ export {
 	SIMPLE_CONTEXT_ID,
 	type V5MessageHandlerOutput,
 } from "./runtime/message-handler";
+export { looksLikeTrainingCutoffLeak } from "./runtime/cutoff-leak-detector";
+export { looksLikeFabricatedModeration } from "./runtime/fabricated-moderation-detector";
 export { looksLikeRefusal } from "./runtime/refusal-detector";
 export * from "./runtime/response-grammar";
 export * from "./runtime/response-handler-evaluators";

--- a/packages/core/src/index.node.ts
+++ b/packages/core/src/index.node.ts
@@ -174,7 +174,9 @@ export * from "./runtime/cleanup-scope";
 export * from "./runtime/context-gates";
 export * from "./runtime/context-registry";
 export * from "./runtime/conversation-compaction-hook";
+export { looksLikeTrainingCutoffLeak } from "./runtime/cutoff-leak-detector";
 export * from "./runtime/execute-planned-tool-call";
+export { looksLikeFabricatedModeration } from "./runtime/fabricated-moderation-detector";
 export {
 	detectLocaleFromText,
 	type ResolveOwnerLocaleOptions,
@@ -196,8 +198,6 @@ export {
 	SIMPLE_CONTEXT_ID,
 	type V5MessageHandlerOutput,
 } from "./runtime/message-handler";
-export { looksLikeTrainingCutoffLeak } from "./runtime/cutoff-leak-detector";
-export { looksLikeFabricatedModeration } from "./runtime/fabricated-moderation-detector";
 export { looksLikeRefusal } from "./runtime/refusal-detector";
 export * from "./runtime/response-grammar";
 export * from "./runtime/response-handler-evaluators";

--- a/packages/core/src/runtime/__tests__/cutoff-leak-detector.test.ts
+++ b/packages/core/src/runtime/__tests__/cutoff-leak-detector.test.ts
@@ -60,9 +60,7 @@ describe("looksLikeTrainingCutoffLeak", () => {
 			expect(looksLikeTrainingCutoffLeak("")).toBe(false);
 		});
 		it("returns false for non-string (number)", () => {
-			expect(
-				looksLikeTrainingCutoffLeak(123 as unknown as string),
-			).toBe(false);
+			expect(looksLikeTrainingCutoffLeak(123 as unknown as string)).toBe(false);
 		});
 	});
 });

--- a/packages/core/src/runtime/__tests__/cutoff-leak-detector.test.ts
+++ b/packages/core/src/runtime/__tests__/cutoff-leak-detector.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { looksLikeTrainingCutoffLeak } from "../cutoff-leak-detector";
+
+describe("looksLikeTrainingCutoffLeak", () => {
+	describe("matches the training-metadata phrases forbidden by the prompt rule", () => {
+		const leaks = [
+			"As of my training data, the latest stable release is 18.2.",
+			"As of my last update, that team hadn't shipped it yet.",
+			"As of my knowledge, the API still uses v1 auth.",
+			"My knowledge cutoff is April 2023, so I can't be sure.",
+			"My knowledge cut-off means I might be out of date here.",
+			"That predates my training cutoff.",
+			"I was trained on data up to 2023.",
+			"I was trained on a static corpus, so newer events are missing.",
+			"I was last updated some time ago, so this may be stale.",
+			"I was last trained before that release.",
+			"The latest information I have is from early 2023.",
+			"The latest data I have goes up to 2023.",
+			"Based on my training data, the answer is X.",
+			"Based on data through 2023, the population was Y.",
+			"Based on the data I was trained on, that's correct.",
+			"It's in my training data, but I can't verify it's current.",
+		];
+		for (const text of leaks) {
+			it(`matches: "${text.slice(0, 60)}"`, () => {
+				expect(looksLikeTrainingCutoffLeak(text)).toBe(true);
+			});
+		}
+	});
+
+	describe("does NOT match honest replies, date answers, or third-party 'training data' talk", () => {
+		const clean = [
+			"Today is June 1, 2026.",
+			"The current year is 2026.",
+			"Let me check the latest information for you.",
+			"I'll pull the latest data from the API now.",
+			"I don't have live access to check that — try the status page.",
+			"You'll need to update the training data for your own model first.",
+			"The model's accuracy improved after we expanded the training set.",
+			"Sure, I can help with that.",
+			"On it — fetching the current price now.",
+			"Here's what the docs say about cutoff handling in the parser.",
+		];
+		for (const text of clean) {
+			it(`does not match: "${text.slice(0, 60)}"`, () => {
+				expect(looksLikeTrainingCutoffLeak(text)).toBe(false);
+			});
+		}
+	});
+
+	describe("guards on empty / short / non-string inputs", () => {
+		it("returns false for undefined", () => {
+			expect(looksLikeTrainingCutoffLeak(undefined)).toBe(false);
+		});
+		it("returns false for null", () => {
+			expect(looksLikeTrainingCutoffLeak(null)).toBe(false);
+		});
+		it("returns false for empty string", () => {
+			expect(looksLikeTrainingCutoffLeak("")).toBe(false);
+		});
+		it("returns false for non-string (number)", () => {
+			expect(
+				looksLikeTrainingCutoffLeak(123 as unknown as string),
+			).toBe(false);
+		});
+	});
+});

--- a/packages/core/src/runtime/__tests__/fabricated-moderation-detector.test.ts
+++ b/packages/core/src/runtime/__tests__/fabricated-moderation-detector.test.ts
@@ -59,9 +59,9 @@ describe("looksLikeFabricatedModeration", () => {
 			expect(looksLikeFabricatedModeration("")).toBe(false);
 		});
 		it("returns false for non-string (number)", () => {
-			expect(
-				looksLikeFabricatedModeration(123 as unknown as string),
-			).toBe(false);
+			expect(looksLikeFabricatedModeration(123 as unknown as string)).toBe(
+				false,
+			);
 		});
 	});
 });

--- a/packages/core/src/runtime/__tests__/fabricated-moderation-detector.test.ts
+++ b/packages/core/src/runtime/__tests__/fabricated-moderation-detector.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { looksLikeFabricatedModeration } from "../fabricated-moderation-detector";
+
+describe("looksLikeFabricatedModeration", () => {
+	describe("matches fabricated-moderation claims forbidden by the prompt rule", () => {
+		const fabrications = [
+			"Your request was flagged as hateful, so I can't continue.",
+			"That violates our usage policies.",
+			"This goes against our content guidelines.",
+			"Your message was blocked by the system.",
+			"Your previous message was rejected.",
+			"My content filter prevented me from answering.",
+			"I was blocked from answering that question.",
+			"I'm blocked from doing that here.",
+			"My safety guidelines prohibit this.",
+			"Our usage policies don't allow that.",
+			"The system automatically blocked your request.",
+			"The system flagged that message.",
+			"Your previous message contained hateful language.",
+			"My content moderation system caught that.",
+			"It was flagged as harmful.",
+		];
+		for (const text of fabrications) {
+			it(`matches: "${text.slice(0, 60)}"`, () => {
+				expect(looksLikeFabricatedModeration(text)).toBe(true);
+			});
+		}
+	});
+
+	describe("does NOT match third-party policies or genuine runtime errors", () => {
+		const clean = [
+			"Stripe's usage policies require a verified business account.",
+			"Their content guidelines are stricter than ours used to be.",
+			"The request was blocked by CORS — try the API origin instead.",
+			"The firewall blocked the connection on port 8080.",
+			"I'd rather not get into that one.",
+			"I'm not going to help with that.",
+			"That's not something I'll do, but here's an alternative.",
+			"The build failed because the linter flagged an unused import.",
+			"Let me review the content of that file for you.",
+			"Sure — I'll filter the results by date.",
+		];
+		for (const text of clean) {
+			it(`does not match: "${text.slice(0, 60)}"`, () => {
+				expect(looksLikeFabricatedModeration(text)).toBe(false);
+			});
+		}
+	});
+
+	describe("guards on empty / short / non-string inputs", () => {
+		it("returns false for undefined", () => {
+			expect(looksLikeFabricatedModeration(undefined)).toBe(false);
+		});
+		it("returns false for null", () => {
+			expect(looksLikeFabricatedModeration(null)).toBe(false);
+		});
+		it("returns false for empty string", () => {
+			expect(looksLikeFabricatedModeration("")).toBe(false);
+		});
+		it("returns false for non-string (number)", () => {
+			expect(
+				looksLikeFabricatedModeration(123 as unknown as string),
+			).toBe(false);
+		});
+	});
+});

--- a/packages/core/src/runtime/__tests__/message-handler-refusal-suppression.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-refusal-suppression.test.ts
@@ -91,3 +91,102 @@ describe("parseMessageHandlerOutput — refusal suppression on the planning path
 		expect(result?.plan.reply).toBe("I cannot do that.");
 	});
 });
+
+describe("parseMessageHandlerOutput — training-cutoff-leak suppression on the planning path", () => {
+	it("blanks plan.reply when a cutoff leak routes to a non-simple context", () => {
+		const wire = JSON.stringify({
+			shouldRespond: "RESPOND",
+			contexts: ["general"],
+			candidateActionNames: ["WEB_FETCH"],
+			replyText:
+				"As of my training data, the latest release is 18.2 — let me check for newer info.",
+		});
+		const result = parseMessageHandlerOutput(wire);
+		expect(result?.plan.reply).toBe("");
+	});
+
+	it("blanks plan.reply for a cutoff leak riding on candidateActionNames with empty contexts", () => {
+		const wire = JSON.stringify({
+			shouldRespond: "RESPOND",
+			contexts: [],
+			candidateActionNames: ["WEB_FETCH"],
+			replyText:
+				"My knowledge cutoff is 2023, so I can't be sure that's current.",
+		});
+		const result = parseMessageHandlerOutput(wire);
+		expect(result?.plan.reply).toBe("");
+	});
+
+	it("preserves a normal answer that merely mentions years (no model-internals leak)", () => {
+		const wire = JSON.stringify({
+			shouldRespond: "RESPOND",
+			contexts: ["general"],
+			candidateActionNames: ["WEB_FETCH"],
+			replyText: "Sure — pulling the latest figures for 2023 through 2026 now.",
+		});
+		const result = parseMessageHandlerOutput(wire);
+		expect(result?.plan.reply).toBe(
+			"Sure — pulling the latest figures for 2023 through 2026 now.",
+		);
+	});
+
+	it("preserves a cutoff leak on the simple path (Stage-1 IS the reply there)", () => {
+		const wire = JSON.stringify({
+			shouldRespond: "RESPOND",
+			contexts: ["simple"],
+			replyText: "As of my training data, that hasn't shipped yet.",
+		});
+		const result = parseMessageHandlerOutput(wire);
+		expect(result?.plan.reply).toBe(
+			"As of my training data, that hasn't shipped yet.",
+		);
+	});
+});
+
+describe("parseMessageHandlerOutput — fabricated-moderation suppression on the planning path", () => {
+	it("blanks plan.reply when a fabricated-moderation claim routes to a non-simple context", () => {
+		const wire = JSON.stringify({
+			shouldRespond: "RESPOND",
+			contexts: ["general"],
+			candidateActionNames: ["WEB_FETCH"],
+			replyText:
+				"Your request was flagged as hateful, so I'm blocked from answering.",
+		});
+		const result = parseMessageHandlerOutput(wire);
+		expect(result?.plan.reply).toBe("");
+	});
+
+	it("blanks plan.reply for a fabricated content-policy claim with empty contexts", () => {
+		const wire = JSON.stringify({
+			shouldRespond: "RESPOND",
+			contexts: [],
+			candidateActionNames: ["TASKS_SPAWN_AGENT"],
+			replyText: "That violates our usage policies.",
+		});
+		const result = parseMessageHandlerOutput(wire);
+		expect(result?.plan.reply).toBe("");
+	});
+
+	it("preserves a genuine runtime-error description on the planning path", () => {
+		const wire = JSON.stringify({
+			shouldRespond: "RESPOND",
+			contexts: ["general"],
+			candidateActionNames: ["WEB_FETCH"],
+			replyText: "The request was blocked by CORS — trying the API origin now.",
+		});
+		const result = parseMessageHandlerOutput(wire);
+		expect(result?.plan.reply).toBe(
+			"The request was blocked by CORS — trying the API origin now.",
+		);
+	});
+
+	it("preserves a fabricated-moderation reply on the simple path (model may decline there)", () => {
+		const wire = JSON.stringify({
+			shouldRespond: "RESPOND",
+			contexts: ["simple"],
+			replyText: "My content filter prevented this.",
+		});
+		const result = parseMessageHandlerOutput(wire);
+		expect(result?.plan.reply).toBe("My content filter prevented this.");
+	});
+});

--- a/packages/core/src/runtime/cutoff-leak-detector.ts
+++ b/packages/core/src/runtime/cutoff-leak-detector.ts
@@ -1,0 +1,77 @@
+/**
+ * Detect training-metadata / knowledge-cutoff leaks in model-generated
+ * `replyText`.
+ *
+ * Background: the system prompt forbids exposing the underlying LLM's training
+ * metadata to the user (`packages/prompts/src/index.ts`) — phrases like "as of
+ * my training data", "my knowledge cutoff", "I was trained on", "I was last
+ * updated", "the latest information I have is from". The agent has a character
+ * (a name, a role, a persona); the model beneath it does not exist to the user.
+ * Weaker / safety-tuned hosted planner models (Cerebras-served `gpt-oss-120b`,
+ * `qwen-3-235b-a22b-instruct-2507`) still emit these phrases even with the
+ * prompt rule in place — the same class of prompt-contract violation that
+ * motivated `looksLikeRefusal` (see `refusal-detector.ts`).
+ *
+ * This detector is the structural net for that rule: a closed, distinctive set
+ * of cutoff phrases that almost never appear in honest, in-character replies.
+ * Unlike a refusal (which OPENS the reply and is anchored at the start), a
+ * cutoff leak frequently appears mid-sentence ("Happy to help, but as of my
+ * training data in 2023 ..."), so these patterns match ANYWHERE in the trimmed
+ * text. They are specific enough to keep false positives near zero — a third
+ * party's "training data" ("the model's training cutoff") references the model
+ * directly and is intentionally caught; an honest statement that never names
+ * the model's own knowledge horizon ("let me check the latest information")
+ * does not match.
+ *
+ * The prompt's EXCEPTION — the current date/time/year is always known from the
+ * runtime `CURRENT_TIME` signal — needs no handling here: a correct date answer
+ * ("Today is June 1, 2026") contains none of these phrases.
+ *
+ * Use sites: the planning-path reply suppression in `parseMessageHandlerOutput`
+ * (`runtime/message-handler.ts`) and `messageHandlerFromFieldResult`
+ * (`services/message.ts`), alongside `looksLikeRefusal`. When a planning path is
+ * selected the planner stage produces the user-facing message, so a leaky
+ * Stage-1 `replyText` is blanked and the planner's message is the only one the
+ * user sees.
+ */
+
+/**
+ * Training-metadata / knowledge-cutoff phrases. Matched anywhere in the reply
+ * (cutoff leaks are commonly mid-sentence). Built verbatim from the forbidden
+ * phrases enumerated in the system-prompt honesty rule.
+ */
+const CUTOFF_LEAK_PATTERNS: readonly RegExp[] = [
+	// "as of my last/latest update | training | knowledge | last training | most recent update/training"
+	/\bas of my (?:last update|latest update|training|knowledge|last training|most recent (?:update|training))\b/i,
+	// "knowledge / training cutoff" (and "cut-off" / "cut off") — references the model's own horizon
+	/\b(?:knowledge|training)\s*cut[\s-]?off\b/i,
+	// "I was trained on | up to | until | through ...", "I was last updated | last trained"
+	/\bi\s+was\s+(?:trained\s+(?:on|up\s+to|until|through)|last\s+(?:updated|trained))\b/i,
+	// "the latest information / data / knowledge I have is/dates/goes from | to | up to | back to ..."
+	/\bthe latest (?:information|data|knowledge) i have (?:is|dates|goes)?\s*(?:from|to|up to|back to)\b/i,
+	// "based on data through ...", "based on the data I was trained on", "based on my training data"
+	/\bbased on (?:data through|the data i was trained on|my training data)\b/i,
+	// "my training data | set | corpus"
+	/\bmy training (?:data|set|corpus)\b/i,
+];
+
+/**
+ * Returns true when `text` exposes the underlying model's training metadata or
+ * knowledge cutoff to the user.
+ *
+ * Conservative: never returns true for empty/short strings, and only matches a
+ * closed set of distinctive model-self-reference phrases.
+ */
+export function looksLikeTrainingCutoffLeak(
+	text: string | undefined | null,
+): boolean {
+	if (typeof text !== "string") return false;
+	const trimmed = text.trim();
+	if (trimmed.length < 8) return false;
+
+	for (const pattern of CUTOFF_LEAK_PATTERNS) {
+		if (pattern.test(trimmed)) return true;
+	}
+
+	return false;
+}

--- a/packages/core/src/runtime/fabricated-moderation-detector.ts
+++ b/packages/core/src/runtime/fabricated-moderation-detector.ts
@@ -1,0 +1,87 @@
+/**
+ * Detect fabricated content-moderation / policy-enforcement claims in
+ * model-generated `replyText`.
+ *
+ * Background: the system prompt forbids attributing a refusal or the agent's own
+ * behavior to a moderation system, content filter, "usage policies", "safety
+ * guidelines", or an automatic block that does not actually exist in this
+ * runtime (`packages/prompts/src/index.ts`). There is no such enforcer sitting
+ * between the agent and the user; inventing one is, in the prompt's words, "a
+ * lie about how you work". Hosted planner models nonetheless reach for these
+ * excuses when they decline — the same prompt-contract violation class that
+ * motivated `looksLikeRefusal` (see `refusal-detector.ts`).
+ *
+ * This detector is the structural net for that rule. Every pattern requires
+ * SELF / POSSESSIVE framing ("our usage policies", "my content filter", "I was
+ * blocked", "your request was flagged", "the system blocked your message") so
+ * that legitimately discussing a third party's policies ("Stripe's usage
+ * policies state ...") or describing a real runtime error ("the request was
+ * blocked by CORS") never matches. Matched anywhere in the trimmed text.
+ *
+ * Note: describing an ACTUAL tool/runtime error this turn is explicitly allowed
+ * by the prompt — hence the patterns target invented *moderation* framing, not
+ * generic "blocked/failed" language.
+ *
+ * Use sites: the planning-path reply suppression in `parseMessageHandlerOutput`
+ * (`runtime/message-handler.ts`) and `messageHandlerFromFieldResult`
+ * (`services/message.ts`), alongside `looksLikeRefusal` and
+ * `looksLikeTrainingCutoffLeak`. When a planning path is selected the planner
+ * produces the user-facing message, so a fabricated-moderation Stage-1
+ * `replyText` is blanked.
+ */
+
+// Apostrophe class — ASCII (U+0027), curly singles (U+2018/U+2019), backtick.
+const APOS = "['‘’`]";
+
+/**
+ * Fabricated-moderation phrases. Each requires self/possessive framing so that
+ * third-party policy mentions and genuine runtime-error descriptions do not
+ * match. Built from the forbidden phrases enumerated in the system-prompt
+ * honesty rule.
+ */
+const FABRICATED_MODERATION_PATTERNS: readonly RegExp[] = [
+	// "violates / breaches / against our|the|my usage|content|community|safety policies|guidelines|standards|rules"
+	/\b(?:violat\w+|breach\w+|against)\s+(?:our|the|my)\s+(?:usage|content|community|safety)\s+(?:polic\w+|guidelines?|standards?|rules?)\b/i,
+	// "your request|message|previous message|input|prompt|content (was|got|has been) flagged|rejected|blocked"
+	/\byour\s+(?:request|message|previous message|input|prompt|content)\s+(?:(?:was|were|got|has been)\s+)?(?:flagged|rejected|blocked)\b/i,
+	// "flagged as hateful|harmful|inappropriate|unsafe|abusive|offensive|toxic"
+	/\bflagged\s+as\s+(?:hateful|harmful|inappropriate|unsafe|abusive|offensive|toxic)\b/i,
+	// "my|the|our content filter"
+	/\b(?:my|the|our)\s+content\s+filter\b/i,
+	// "I (was|am|got|'m) blocked from ..." — "'m" is contracted (no space before it)
+	new RegExp(
+		`\\bi(?:\\s+(?:was|am|got)|\\s*${APOS}\\s*m)\\s+blocked\\s+from\\b`,
+		"i",
+	),
+	// "my|our safety guidelines | usage policies | content policies"
+	/\b(?:my|our)\s+(?:safety\s+guidelines?|usage\s+polic\w+|content\s+polic\w+)\b/i,
+	// "my|our|the (content) moderation system|filter|layer|policy"
+	/\b(?:my|our|the)\s+(?:content\s+)?moderation\s+(?:system|filter|layer|policy)\b/i,
+	// "contained hateful|harmful|inappropriate|abusive|offensive language|content|material|speech"
+	/\bcontained\s+(?:hateful|harmful|inappropriate|abusive|offensive)\s+(?:language|content|material|speech)\b/i,
+	// "the system (automatically) blocked|flagged|prevented|filtered this|that|it|your|the request|message|content|response|reply"
+	/\b(?:the\s+)?system\s+(?:automatically\s+)?(?:blocked|flagged|prevented|filtered)\s+(?:this|that|it|your|the\s+(?:request|message|content|response|reply))\b/i,
+];
+
+/**
+ * Returns true when `text` blames a refusal or the agent's behavior on a
+ * moderation system / content filter / usage policy that does not exist in this
+ * runtime.
+ *
+ * Conservative: never returns true for empty/short strings; requires
+ * self/possessive framing so third-party policy mentions and genuine runtime
+ * errors do not match.
+ */
+export function looksLikeFabricatedModeration(
+	text: string | undefined | null,
+): boolean {
+	if (typeof text !== "string") return false;
+	const trimmed = text.trim();
+	if (trimmed.length < 8) return false;
+
+	for (const pattern of FABRICATED_MODERATION_PATTERNS) {
+		if (pattern.test(trimmed)) return true;
+	}
+
+	return false;
+}

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -5,9 +5,9 @@ import type {
 	MessageHandlerResult,
 } from "../types/components";
 import type { AgentContext } from "../types/contexts";
-import { parseJsonObject } from "./json-output";
 import { looksLikeTrainingCutoffLeak } from "./cutoff-leak-detector";
 import { looksLikeFabricatedModeration } from "./fabricated-moderation-detector";
+import { parseJsonObject } from "./json-output";
 import { looksLikeRefusal } from "./refusal-detector";
 
 export type V5MessageHandlerOutput = MessageHandlerResult;

--- a/packages/core/src/runtime/message-handler.ts
+++ b/packages/core/src/runtime/message-handler.ts
@@ -6,6 +6,8 @@ import type {
 } from "../types/components";
 import type { AgentContext } from "../types/contexts";
 import { parseJsonObject } from "./json-output";
+import { looksLikeTrainingCutoffLeak } from "./cutoff-leak-detector";
+import { looksLikeFabricatedModeration } from "./fabricated-moderation-detector";
 import { looksLikeRefusal } from "./refusal-detector";
 
 export type V5MessageHandlerOutput = MessageHandlerResult;
@@ -66,22 +68,30 @@ export function parseMessageHandlerOutput(
 
 	const extract = parseExtract(parsed);
 
-	// Refusal suppression for the planning path (elizaOS/eliza#7620).
+	// Stage-1 honesty suppression for the planning path (elizaOS/eliza#7620).
 	// When the model routes to a non-simple context OR populates candidate
 	// actions, the planner stage will produce the user-facing message and the
 	// Stage-1 `replyText` is intended to be a brief acknowledgement. Some
 	// safety-tuned hosted models (Cerebras-served `gpt-oss-120b`,
-	// `qwen-3-235b-a22b-instruct-2507`) still emit a refusal here even with
-	// anti-refusal language in the system prompt. We blank the reply when it
-	// looks like a refusal AND a planning path is selected — the user sees
-	// the planner's message instead. Refusals on the simple path pass through
-	// unchanged (the model may legitimately decline e.g. unsafe requests).
+	// `qwen-3-235b-a22b-instruct-2507`) still emit a prompt-contract violation
+	// here even with the system-prompt rules in place: a refusal, a
+	// training-metadata/knowledge-cutoff leak, or a fabricated-moderation claim.
+	// We blank the reply when it matches any of these AND a planning path is
+	// selected — the user sees the planner's message instead. The simple path
+	// passes through unchanged (the model may legitimately decline e.g. unsafe
+	// requests there).
 	const nonSimpleContexts = contexts.filter(
 		(context) => context !== SIMPLE_CONTEXT_ID,
 	);
 	const planningPath =
 		nonSimpleContexts.length > 0 || candidateActions.length > 0;
-	const reply = planningPath && looksLikeRefusal(replyRaw) ? "" : replyRaw;
+	const reply =
+		planningPath &&
+		(looksLikeRefusal(replyRaw) ||
+			looksLikeTrainingCutoffLeak(replyRaw) ||
+			looksLikeFabricatedModeration(replyRaw))
+			? ""
+			: replyRaw;
 
 	const normalizedPlan: V5MessageHandlerOutput["plan"] = {
 		contexts,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -88,6 +88,8 @@ import {
 	type PlannerTrajectory,
 	runPlannerLoop,
 } from "../runtime/planner-loop";
+import { looksLikeTrainingCutoffLeak } from "../runtime/cutoff-leak-detector";
+import { looksLikeFabricatedModeration } from "../runtime/fabricated-moderation-detector";
 import { looksLikeRefusal } from "../runtime/refusal-detector";
 import {
 	buildResponseGrammar,
@@ -3553,12 +3555,19 @@ export function messageHandlerFromFieldResult(
 						]),
 					)
 				: routedContexts;
-	// Refusal suppression for the planning path (elizaOS/eliza#7620). Mirrors
-	// the logic in `parseMessageHandlerOutput`: when the planner is about to
-	// run, a refusal-shaped `replyText` from a safety-tuned hosted model is
-	// dropped so the planner's own message reaches the user instead.
+	// Stage-1 honesty suppression for the planning path (elizaOS/eliza#7620).
+	// Mirrors the logic in `parseMessageHandlerOutput`: when the planner is
+	// about to run, a prompt-contract violation in `replyText` from a
+	// safety-tuned hosted model — a refusal, a training-metadata/knowledge-cutoff
+	// leak, or a fabricated-moderation claim — is dropped so the planner's own
+	// message reaches the user instead.
 	const replyText =
-		shouldPlan && looksLikeRefusal(replyTextRaw) ? "" : replyTextRaw;
+		shouldPlan &&
+		(looksLikeRefusal(replyTextRaw) ||
+			looksLikeTrainingCutoffLeak(replyTextRaw) ||
+			looksLikeFabricatedModeration(replyTextRaw))
+			? ""
+			: replyTextRaw;
 	const plan: MessageHandlerResult["plan"] = {
 		contexts: finalContexts,
 		reply: replyText,

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -51,6 +51,7 @@ import {
 	getMessageHistoryCompactionHook,
 	type MessageHistoryCompactionTelemetry,
 } from "../runtime/conversation-compaction-hook";
+import { looksLikeTrainingCutoffLeak } from "../runtime/cutoff-leak-detector";
 import {
 	type EvaluatorEffects,
 	type EvaluatorOutput,
@@ -61,6 +62,7 @@ import {
 	type ExecutePlannedToolCallOptions,
 	executePlannedToolCall,
 } from "../runtime/execute-planned-tool-call";
+import { looksLikeFabricatedModeration } from "../runtime/fabricated-moderation-detector";
 import {
 	type FactsAndRelationshipsRunResult,
 	runFactsAndRelationshipsStage,
@@ -88,8 +90,6 @@ import {
 	type PlannerTrajectory,
 	runPlannerLoop,
 } from "../runtime/planner-loop";
-import { looksLikeTrainingCutoffLeak } from "../runtime/cutoff-leak-detector";
-import { looksLikeFabricatedModeration } from "../runtime/fabricated-moderation-detector";
 import { looksLikeRefusal } from "../runtime/refusal-detector";
 import {
 	buildResponseGrammar,


### PR DESCRIPTION
## What
Two conservative, well-tested **structural** honesty detectors, mirroring the existing `looksLikeRefusal` pattern, wired into the same planning-path Stage-1 reply suppression:

- `looksLikeTrainingCutoffLeak` — `packages/core/src/runtime/cutoff-leak-detector.ts`
- `looksLikeFabricatedModeration` — `packages/core/src/runtime/fabricated-moderation-detector.ts`

When a planning path is selected, a Stage-1 `replyText` that **leaks the model's training metadata / knowledge cutoff**, or **fabricates a moderation / usage-policy block that does not exist in this runtime**, is blanked so the planner's honest message ships instead.

## Why
The system prompt already forbids these — `packages/prompts/src/index.ts:697` (training-cutoff leaks) and `:699` (fabricated moderation). But those are **prompt-only** rules, and the hosted planner models we route to (Cerebras `gpt-oss-120b`, `qwen-3-235b-…`) are documented in `refusal-detector.ts` to violate prompt contracts. Refusal got a structural net (`looksLikeRefusal`, #7620); these two equally-dangerous honesty rules did not. Inventing a content filter is a *lie about how the agent works*, and leaking model internals breaks character — this closes the gap with the same proven mechanism.

## How
- Conservative by design: closed, distinctive phrase sets. Fabricated-moderation requires **self/possessive framing** ("our usage policies", "my content filter", "I was blocked from…") so third-party policy mentions ("Stripe's usage policies") and genuine runtime errors ("blocked by CORS") never match. Cutoff detection targets the exact phrases the prompt rule enumerates; the date/time/year exception needs no handling (a correct date answer contains none of them).
- Wired alongside `looksLikeRefusal` at the two existing suppression sites: `runtime/message-handler.ts` (`parseMessageHandlerOutput`) and `services/message.ts` (`messageHandlerFromFieldResult`). The simple path is unchanged (the model may legitimately decline there).
- Exported from `index.node.ts`.

## Testing
- `cutoff-leak-detector.test.ts` + `fabricated-moderation-detector.test.ts` — positive, negative (third-party policy / runtime-error / date answers), and guard cases.
- `message-handler-refusal-suppression.test.ts` — extended with behavioral cases proving planning-path blanking and simple-path / genuine-error preservation.
- `bun run --cwd packages/core test` (detector + suppression suites): **73 passing**. `bun run --cwd packages/core typecheck`: clean. Biome: clean.

## Risk / scope
Additive and conservative. Only affects the **planning path** (where the planner produces the real reply); **zero** behavior change on the simple path. No new dependencies. Tuned for zero false positives — a false negative simply regresses to today's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new structural honesty detectors — `looksLikeTrainingCutoffLeak` and `looksLikeFabricatedModeration` — wired into the existing planning-path Stage-1 reply suppression gate alongside the pre-existing `looksLikeRefusal` check, closing a gap where safety-tuned hosted planner models would emit training-metadata disclosures or fabricated content-policy excuses even with prompt-level rules in place.

- **`cutoff-leak-detector.ts`**: Six regex patterns targeting distinctive model-self-reference phrases (\"as of my training data\", \"my knowledge cutoff\", \"I was trained on\", etc.), matched anywhere in the reply since these leaks are commonly mid-sentence.
- **`fabricated-moderation-detector.ts`**: Nine patterns requiring self/possessive framing (\"our usage policies\", \"my content filter\", \"your request was flagged\") to avoid matching third-party policy mentions or genuine runtime errors.
- Both detectors are integrated at the two existing suppression sites (`parseMessageHandlerOutput` and `messageHandlerFromFieldResult`), exported from `index.node.ts`, and covered by dedicated test suites plus extended behavioural tests in the existing refusal-suppression test file.

<h3>Confidence Score: 4/5</h3>

Safe to merge on the planning path with the understanding that two regex patterns carry false-positive gaps that could silently blank valid agent replies in edge cases.

The integration wiring in `message-handler.ts` and `services/message.ts` is clean and mirrors the proven refusal-suppression pattern exactly. The main risk lives in the two detector files: the optional-verb group in cutoff-leak pattern 4 can match legitimate "latest data I have from [live source]" replies, and the fabricated-moderation "system blocked/filtered" pattern fires on any "[noun] system blocked the request" phrasing, not only on invented moderation claims. Both gaps are false-positive risks rather than false-negative ones, so the worst outcome is a correctly-formatted planning-path reply being silently discarded and the planner message substituted — a recoverable UX degradation rather than a data hazard.

packages/core/src/runtime/cutoff-leak-detector.ts (pattern 4, optional verb group) and packages/core/src/runtime/fabricated-moderation-detector.ts (final "system blocked/filtered" pattern) warrant a second look before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/src/runtime/cutoff-leak-detector.ts | New structural detector for training-cutoff leaks; pattern 4's optional verb group creates a false-positive risk for legitimate "latest data I have from [source]" replies on the planning path. |
| packages/core/src/runtime/fabricated-moderation-detector.ts | New structural detector for fabricated-moderation claims; the final "system blocked/flagged/filtered" pattern is broader than intended and can match legitimate non-moderation system-failure descriptions (CI, proxy, antivirus). |
| packages/core/src/runtime/message-handler.ts | Cleanly extends the existing planning-path suppression gate to call the two new detectors in a logical OR alongside `looksLikeRefusal`; simple-path behaviour is unchanged. |
| packages/core/src/services/message.ts | Mirrors the same suppression logic as `message-handler.ts` on the field-registry path; the change is minimal and correctly placed. |
| packages/core/src/index.node.ts | Named exports added for both new detector functions; pattern matches existing selective export style. |
| packages/core/src/runtime/__tests__/cutoff-leak-detector.test.ts | Good positive and null-guard coverage; missing a negative test for "the latest data I have from [live source]" which is the false-positive gap in pattern 4. |
| packages/core/src/runtime/__tests__/fabricated-moderation-detector.test.ts | Good coverage of self-framing positive cases and third-party/runtime-error negative cases; no test covers the "CI/proxy/antivirus system blocked the request" false-positive gap. |
| packages/core/src/runtime/__tests__/message-handler-refusal-suppression.test.ts | Extended with planning-path and simple-path behavioural tests for both new detectors; simple-path preservation and runtime-error pass-through are correctly asserted. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Stage-1 model output\nreplyText + contexts + candidateActions] --> B{planningPath?\nnon-simple context OR\ncandidateActions present}
    B -- No simple path --> G[Pass replyText through unchanged]
    B -- Yes planning path --> C{looksLikeRefusal?}
    C -- Yes --> F[Blank reply to empty string]
    C -- No --> D{looksLikeTrainingCutoffLeak?}
    D -- Yes --> F
    D -- No --> E{looksLikeFabricatedModeration?}
    E -- Yes --> F
    E -- No --> H[Keep replyText as-is]
    F --> I[Planner stage reply reaches user instead]
    H --> J[Stage-1 replyText reaches user as acknowledgement]
```

<sub>Reviews (1): Last reviewed commit: ["style(core): biome-format honesty detect..."](https://github.com/elizaos/eliza/commit/0c236d53391a1ec5b4126a7e5bca41f9264512fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35012591)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->