### PR TITLE
docs: fix CLAUDE.md/AGENTS.md invariant + app-core CLI mislabel

### DIFF
--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -4,7 +4,7 @@ The runtime heart of elizaOS: `AgentRuntime`, the plugin abstractions (actions /
 
 ## Role
 
-`@elizaos/core` defines the contracts an Eliza agent runs on and the runtime that executes them. Plugins implement `Plugin` and the runtime wires their actions/providers/evaluators/services into the message-handling loop. Consumed by `@elizaos/agent` (which also hosts the HTTP API server), `@elizaos/app-core` (the CLI), and every plugin. It builds to three targets (Node, browser, edge) via conditional exports — keep Node-only code out of the browser/edge entries.
+`@elizaos/core` defines the contracts an Eliza agent runs on and the runtime that executes them. Plugins implement `Plugin` and the runtime wires their actions/providers/evaluators/services into the message-handling loop. Consumed by `@elizaos/agent` (which also hosts the HTTP API server), `@elizaos/app-core` (the API + dashboard host), and every plugin. It builds to three targets (Node, browser, edge) via conditional exports — keep Node-only code out of the browser/edge entries.
 
 ## Layout
 

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -4,7 +4,7 @@ The runtime heart of elizaOS: `AgentRuntime`, the plugin abstractions (actions /
 
 ## Role
 
-`@elizaos/core` defines the contracts an Eliza agent runs on and the runtime that executes them. Plugins implement `Plugin` and the runtime wires their actions/providers/evaluators/services into the message-handling loop. Consumed by `@elizaos/agent` (which also hosts the HTTP API server), `@elizaos/app-core` (the CLI), and every plugin. It builds to three targets (Node, browser, edge) via conditional exports — keep Node-only code out of the browser/edge entries.
+`@elizaos/core` defines the contracts an Eliza agent runs on and the runtime that executes them. Plugins implement `Plugin` and the runtime wires their actions/providers/evaluators/services into the message-handling loop. Consumed by `@elizaos/agent` (which also hosts the HTTP API server), `@elizaos/app-core` (the API + dashboard host), and every plugin. It builds to three targets (Node, browser, edge) via conditional exports — keep Node-only code out of the browser/edge entries.
 
 ## Layout
 

--- a/plugins/plugin-local-inference/native/CLAUDE.md
+++ b/plugins/plugin-local-inference/native/CLAUDE.md
@@ -1,23 +1,720 @@
-# CLAUDE.md — packages/inference
+# AGENTS.md — Eliza-1 inference (kernels + runtime)
 
-Read [`AGENTS.md`](AGENTS.md) first. It is the canonical contract for
-this directory and binds every agent (Claude or otherwise) working on
-the Eliza-1 inference stack.
+This file is the canonical contract for any agent working on the Eliza-1
+on-device inference stack. It applies to everything under
+`packages/inference/`, the runtime under
+`packages/app-core/src/services/local-inference/`, the mtp build hook
+at `packages/app-core/scripts/build-llama-cpp-mtp.mjs`, and any
+mobile/desktop bridges that consume the same artifacts.
 
-Claude-specific notes:
+The training-side companion is at [`packages/training/AGENTS.md`](../training/AGENTS.md).
+Read both before changing anything that crosses the boundary (artifacts,
+manifest, kernel ABI, GGML pin).
 
-- The repo-wide `CLAUDE.md` at the workspace root applies on top of
-  this file. Read both.
-- When in doubt about runtime mode (`local` / `cloud` / `remote`),
-  re-read AGENTS.md §1 and §5. Mode classification is a hard rule, not
-  a stylistic preference.
-- When asked to "skip" or "fall back" on an Eliza-1 optimization, push
-  back. AGENTS.md §3 is explicit: required kernels are required. If a
-  legitimate exception comes up, surface it as an architectural
-  decision, not a quiet `if (!available) return baseline()`.
-- For shader changes, never claim ✓ on the verification matrix without
-  `metal_verify` or `vulkan_verify` reporting 8/8 PASS on actual
-  hardware. README.md's matrix is the source of truth.
-- For new quantization formats, write the C reference + JSON fixture
-  first, then port to Vulkan, then port to Metal. Same pattern as the
-  existing five.
+**Fork source.** The patched llama.cpp ships in-tree as a git submodule at
+[`plugins/plugin-local-inference/native/llama.cpp`](llama.cpp) — `elizaOS/llama.cpp`
+tracking the `v1.2.0-eliza` line (gitlink currently `33c888a7b`, with
+`ce85787c` as the validated MTP/SWA build base; resolve via
+`git -C plugins/plugin-local-inference/native/llama.cpp describe --always`; the
+`v1.0.0-eliza` / `08032d57` pin documented previously is **stale** — do not copy
+that pin into new tooling or scripts). `git submodule update --init --recursive`
+(which `bun install` runs) is the canonical checkout. This is the canonical fork:
+TurboQuant (turbo3/turbo4/turbo3_tcq) + QJL
+(`block_qjl1_256`, `GGML_OP_ATTN_SCORE_QJL`, `GGML_OP_FUSED_ATTN_QJL_TBQ`) +
+PolarQuant (`block_q4_polar`, `Q4_POLAR=47`) + the eliza Metal/Vulkan/CUDA
+kernels + MTP spec-decode (`--spec-type mtp`, the `mtp-draft` GGUF arch)
++ the post-refactor `llama-server` (`server-task.cpp` / `server-common.cpp` with
+`grammar_lazy` / `json_schema` / `response_format` / `prefill_assistant`), on
+upstream b9213. Both build paths consume it: `build-llama-cpp-mtp.mjs`
+(desktop/server/Windows/iOS) and `aosp/compile-libllama.mjs` (Android) default to
+the submodule checkout. `ELIZA_MTP_LLAMA_CPP_REMOTE` / `_REF` (or `--cache-dir`
+/ `--src-dir`) still force a standalone clone for fork bisects. (The `v1.2.0-eliza`
+line tracks the prior `v1.0.0-eliza` tree forward, re-tagged on the elizaOS rename
+chain. A full rebase onto a recent upstream llama.cpp remains a **deferred**
+follow-up — not a blocker for structured output (the b9213 base already has
+`grammar_lazy` / `json_schema` / `response_format` / `prefill_assistant`); the
+conflict-prone files are the quant-slot enums in `ggml-common.h` / `ggml.h` and
+the `Q1_0` block layout, which upstream redefined incompatibly with the fork's.
+Full cost / conflict surface / trigger conditions:
+[`docs/porting/upstream-rebase-plan.md`](../../docs/porting/upstream-rebase-plan.md).)
+
+---
+
+## 1. What we are building
+
+**Eliza-1** is a single product line of on-device fused models. From the
+user's perspective there is exactly one default option per device tier;
+they pick a size, they get one bundle, it does text + voice + vision.
+Underneath it is a manifest-described bundle of GGUF/metallib/SPIR-V
+files plus kernel capability metadata. There is no "pick the text model"
+or "pick the TTS" — that is a runtime concern, not a user concern.
+
+Backbones (do not change without explicit human approval):
+
+- **Text/vision:** Qwen3.5 family for the current 0.8B/2B/4B/9B
+  release tiers, with Qwen3.6 for the active 27B family. Every active
+  Eliza-1 tier is vision-capable when its tier-matched `vision/mmproj-<tier>.gguf`
+  is present and validated. We do not name these as "Qwen" in any
+  user-facing string. Internally, manifests record the upstream lineage and
+  license; the UI shows "Eliza-1 <tier>".
+- **Voice (TTS):** Tier-aware. The active backend per tier is declared
+  in `ELIZA_1_VOICE_BACKENDS`
+  (`packages/shared/src/local-inference/catalog.ts`) and is read by the
+  runtime selector at engine arm time. Policy:
+
+  | Tier                  | Backend(s)              | Default  |
+  | --------------------- | ----------------------- | -------- |
+  | `0_8b` / `2b` / `4b`  | OmniVoice **and** Kokoro| OmniVoice|
+  | `9b`                  | OmniVoice **and** Kokoro| OmniVoice|
+  | `27b` / `27b-256k` | OmniVoice only  | OmniVoice|
+
+  - **Kokoro** = Kokoro-82M ONNX (`onnx-community/Kokoro-82M-v1.0-ONNX`,
+    ~80 MB int8). ~97ms CPU TTFB. Fixed voice packs, no per-user
+    cloning. Bundled at `tts/kokoro/{model_q4.onnx,tokenizer.json,
+    voices/<voice>.bin}` in each shipping tier. Backend implementation:
+    `plugins/plugin-local-inference/src/services/voice/kokoro/`.
+  - **OmniVoice** = Qwen3-TTS lineage. Upstream at
+    `https://github.com/ServeurpersoCom/omnivoice.cpp`, mirrored at
+    `https://github.com/elizaOS/omnivoice.cpp`. ~200ms TTFB on the
+    fused build. Per-user voice cloning, voice design via attribute
+    keywords, optional `omnivoice-singing` variant
+    (`[singing]/[happy]/[sad]/[whisper]/[angry]/[nervous]/[calm]/
+    [excited]` + non-verbals `[laughter]/[sigh]`). Bundled at
+    `tts/omnivoice-base-<quant>.gguf` + `tts/omnivoice-tokenizer-<quant>.gguf`
+    in tiers that ship it.
+
+  Per Wave-6 user direction (2026-05-10), omnivoice-singing CAN ship as
+  part of default bundles for non-commercial use (CC-compatible terms).
+  Commercial pivot requires re-training on commercially-licensed corpora
+  to clear the CC-BY-NC-SA training-data lineage (GTSinger, RAVDESS,
+  Expresso).
+
+  **Canonical voice engine: fused `libelizainference`.** The strategic
+  on-device voice engine is the fused-FFI `libelizainference` library
+  built directly from the merged llama.cpp fork tree at
+  `plugins/plugin-local-inference/native/llama.cpp/tools/omnivoice/`.
+  This is what `services/voice/` calls; this is what the manifest's
+  `voice` and `asr` entries are activated through.
+
+  **W3-3 (OmniVoice → llama.cpp literal merge, v1.0.1-eliza, 2026-05-14):**
+  the OmniVoice sources, FFI bridge, and streaming optimizations now
+  live INSIDE the fork at `tools/omnivoice/`. The pre-merge graft path
+  (clone `elizaOS/omnivoice.cpp` at build time, copy sources into
+  `omnivoice/` at fork root, append `ELIZA-OMNIVOICE-FUSION-GRAFT-V1`
+  CMake block via `packages/app-core/scripts/omnivoice-fuse/` —
+  driven by `ELIZA_FUSE_OMNIVOICE=ON`) is **deprecated** and stays for
+  ONE release as a runway. Setting `OMNIVOICE_INSIDE_LLAMA_CPP=0`
+  (build-script env) opts back into the legacy graft. The default is
+  the merged path (`OMNIVOICE_INSIDE_LLAMA_CPP=1`). The build flag is
+  now `-DLLAMA_BUILD_OMNIVOICE=ON -DOMNIVOICE_SHARED=ON`;
+  `ELIZA_FUSE_OMNIVOICE=ON` is a back-compat alias that emits a
+  deprecation warning and redirects.
+
+  After the v1.0.2-eliza release, `OMNIVOICE_INSIDE_LLAMA_CPP=0` is
+  removed and `packages/app-core/scripts/omnivoice-fuse/` is deleted.
+
+  The standalone `plugins/plugin-omnivoice/` plugin (separate ABI v2
+  `ov_*` symbols, separate `libomnivoice.{so,dylib,dll}`, separate
+  build script `native/build-omnivoice.mjs`) is **legacy** and is slated
+  for removal once the fused path covers the bring-your-own-GGUFs case
+  it was added for. Do not extend the standalone plugin; new voice code
+  goes through `libelizainference`.
+
+  Kokoro and OmniVoice both satisfy the same `OmniVoiceBackend +
+  StreamingTtsBackend` contract — the runtime selector
+  (`services/voice/kokoro/runtime-selection.ts`) picks one at arm time
+  based on the tier policy, the `ELIZA_TTS_BACKEND` env override
+  (`kokoro|omnivoice|auto`), voice-cloning requirements, and measured
+  RTF / TTFB.
+
+- **ASR:** Qwen3-ASR via the fused FFI on every tier. Source artifacts:
+  `ggml-org/Qwen3-ASR-0.6B-GGUF` for lite/mobile/desktop tiers,
+  `ggml-org/Qwen3-ASR-1.7B-GGUF` for pro/server. Bundled as
+  `asr/eliza-1-asr.gguf` + `asr/eliza-1-asr-mmproj.gguf` (mmproj
+  sidecar is REQUIRED — Qwen3-ASR is a multimodal audio-in / text-out
+  model). Activated through `libelizainference`'s
+  `eliza_pick_asr_files()`. OmniVoice has no ASR head — do not route
+  ASR through it. The standalone `plugin-omnivoice`'s
+  `ModelType.TRANSCRIPTION` handler throws
+  `OmnivoiceTranscriptionNotSupported` to make that explicit.
+
+  whisper.cpp is **not** in the contract — it vendors its own ggml,
+  violating the one-llama.cpp-build / one-GGML-pin contract in §4.
+  All historical `transcribeManager.ts` / `whisper-node` references
+  have been removed.
+- **VAD:** Silero VAD (MIT, ~2 MB ONNX). Ships in every voice-enabled
+  bundle. Drives barge-in cancellation; gates ASR to skip silent frames.
+- **Wake word:** openWakeWord (Apache-2.0, ~3 MB). Opt-in, local-mode
+  only. Hidden in cloud mode per three-mode hide-not-disable.
+- **Embedding:** `0_8b` and `2b` reuse the active text backbone with
+  `--pooling last` — no duplicate weights in the mobile/default tiers.
+  Larger tiers may ship a dedicated `embedding/` artifact (1024-dim
+  Matryoshka, 32k ctx) when the manifest records a real source artifact and
+  evidence. Do not fabricate embedding source repos, and do not silently
+  fall back on larger tiers when the manifest says a dedicated region is
+  required.
+- **Drafter:** MTP ships on 2B and larger tiers. The 0.8B tier is the
+  low-memory non-MTP path until a real drafter companion and evidence exist.
+  Where MTP is present, speculative decoding is mandatory, not optional
+  (see §3).
+
+Three runtime modes — every code path must work in all three:
+
+| Mode      | Local models? | Cloud models? | Remote control? |
+| --------- | ------------- | ------------- | --------------- |
+| `local`   | yes (default) | optional      | exposes itself  |
+| `cloud`   | hidden        | yes (default) | hidden          |
+| `remote`  | via target    | no            | yes             |
+
+Settings rules (enforce in UI + API layer, not just docs):
+- `cloud` mode hides every local-model UI surface, every
+  `ELIZA_LOCAL_*` setting, and the local-inference settings panel
+  entirely. The cloud setting page is the only model-related surface.
+- `local-only` mode (a sub-state of `local`) hides every cloud setting
+  and every cloud-routed provider. The user must not be able to
+  accidentally route a request to cloud.
+- `remote` mode connects to a *local* instance only. It must refuse to
+  point at a cloud instance. Changing cloud settings in remote mode
+  mutates the *target's* cloud settings (i.e. the local agent the
+  remote is controlling), not the remote-control client.
+
+These three modes are not feature flags or A/B variants. They are the
+top-level shape of the product. New code that adds a model surface MUST
+state explicitly which modes it lives in, and MUST be removed from
+modes where it does not belong.
+
+---
+
+## 2. Single fused bundle per device tier
+
+Eliza-1 ships as **one logical bundle per tier**. The user sees one
+download. Internally a bundle is a manifest plus several files, all
+hosted under the `elizalabs` HuggingFace org under `eliza-1`.
+
+### Tier matrix (binding)
+
+| Tier            | Tagline                       | Text  | Voice           | Vision | Context  | MTP | Quant default                   |
+| --------------- | ----------------------------- | ----- | --------------- | ------ | -------- | ------ | ------------------------------- |
+| `0_8b`       | low-RAM phones, CPU fallback   | 0.8B  | OmniVoice + Kokoro | mmproj | 128k  | no     | TurboQuant Q4 + QJL + Polar     |
+| `2b`         | modern phones                  | 2B    | OmniVoice + Kokoro | mmproj | 128k  | yes    | TurboQuant Q4 + QJL + Polar     |
+| `4b`         | flagship phones, small desktops| 4B    | OmniVoice + Kokoro | mmproj | 128k  | yes    | TurboQuant Q4 + QJL + Polar     |
+| `9b`         | desktop / midrange GPU          | 9B    | OmniVoice + Kokoro | mmproj | 128k  | yes    | TurboQuant Q4 + QJL + Polar     |
+| `27b`        | flagship GPU                    | 27B   | OmniVoice       | mmproj | 128k     | yes    | TurboQuant Q4 + QJL + Polar TCQ |
+| `27b-256k`  | long-context flagship            | 27B   | OmniVoice       | mmproj | 256k     | yes    | + turbo3_tcq                    |
+
+Context-length variants (32k / 64k / 128k / 256k) are *not* separate
+tiers — they are dimensions inside a tier. A tier's manifest lists which
+context lengths are available; the runtime picks the largest that fits
+the device's RAM budget at activation time.
+
+### Bundle layout (binding)
+
+All tiers ship in a single HuggingFace mono-repo `elizaos/eliza-1`, with
+each tier living under `bundles/<tier>/`. The manifest is the source of
+truth; never derive contents from filenames.
+
+```
+elizaos/eliza-1/
+  bundles/<tier>/
+    eliza-1.manifest.json          # canonical schema, see §6
+    text/
+      eliza-1-<tier>-<ctx>.gguf    # text (+ inline vision where supported)
+    tts/
+      # Kokoro fallback shipped on 0_8b/2b/4b/9b:
+      kokoro/model_q4.onnx
+      kokoro/tokenizer.json
+      kokoro/voices/<voice>.bin
+      # OmniVoice shipped on every active tier. Default install stages a
+      # single quant (VOICE_QUANT_BY_TIER); --include-voice-ladder at stage
+      # time emits the tier ladder so the downloader can pick the level
+      # matching the host's RAM/SoC class at install time. See
+      # `voiceQuantLadderForTier()` in
+      # packages/shared/src/local-inference/catalog.ts and
+      # docs/inference/voice-quant-matrix.md.
+      omnivoice-base-<quant>.gguf
+      omnivoice-tokenizer-<quant>.gguf
+    asr/
+      eliza-1-asr.gguf             # Qwen3-ASR text head, every tier
+      eliza-1-asr-mmproj.gguf      # mmproj audio projector sidecar, every tier
+    vad/
+      silero-vad-v5.gguf           # native silero-vad-cpp, every tier
+    vision/
+      mmproj-<tier>.gguf           # 0_8b/2b/4b/9b/27b/27b-256k
+    mtp/
+      drafter-<tier>.gguf
+      target-meta.json             # acceptance windows, kernel caps
+    cache/
+      voice-preset-default.bin     # speaker embedding + phrase cache seed
+    evals/
+      text-eval.json
+      voice-rtf.json
+      asr-wer.json
+      e2e-loop.json
+    licenses/
+      LICENSE.text
+      LICENSE.voice
+      LICENSE.asr
+      LICENSE.vad
+      LICENSE.mtp
+      LICENSE.vision
+      LICENSE.eliza-1
+    checksums/SHA256SUMS
+    evidence/release.json
+    evidence/platform/<id>.json
+    quantization/{turboquant,qjl,polarquant}.json
+  README.md                        # mono-repo overview
+```
+
+The **runtime default** voice quant per tier (the level the runtime
+selects when no device-class override applies) is the value returned by
+`voiceQuantForTier()` in `packages/shared/src/local-inference/catalog.ts`:
+`Q4_K_M` for `0_8b/2b/4b`, `Q8_0` for `9b/27b/27b-256k`.
+
+The **publish ladder** per tier (every level that gets staged when
+`--include-voice-ladder` is passed) is the value returned by
+`voiceQuantLadderForTier()`:
+
+- Mobile tiers (`0_8b/2b/4b`) publish the narrow OmniVoice ladder
+  `Q3_K_M, Q4_K_M, Q5_K_M`.
+- Larger OmniVoice-shipping tiers (`9b/27b/27b-256k`) publish
+  `Q3_K_M, Q4_K_M, Q5_K_M, Q6_K, Q8_0`.
+
+The downloader picks the level matching the host's memory class at
+install time (MAX / GOOD / OKAY / POOR per `memory-budget.ts`).
+**No silent fallback** — §3 forbids "try the next smaller one" at
+runtime; if the resolved level isn't in the bundle, the install fails
+loudly with an actionable diagnostic.
+
+#### OmniVoice quant rules (per R6 §5.6 + R8 §2)
+
+- **K-quant ladder Q3..Q8** — applies. `omnivoice.cpp/tools/quantize.cpp`
+  already supports the full Q2_K..Q8_0 set; the curated publish subset is
+  the ladder above.
+- **PolarQuant on the LM weight bank** — *applies* (OmniVoice's LM head
+  is Qwen3-shaped), but no recipe is wired yet. Landing this requires
+  either grafting `Q4_POLAR` recognition into OmniVoice's loader via
+  `omnivoice-fuse/cmake-graft.mjs`, or running PolarQuant before
+  `omnivoice.cpp/convert.py`. Gated on a measured TTS-MOS comparison.
+- **V-cache PolarQuant** — **N/A**. OmniVoice has no KV cache between
+  MaskGIT steps; there's no V-cache to compress.
+- **QJL** — *conditional, deferred*. Only matters for long-form
+  multi-chunk synth where the cumulative cache becomes large. Off the
+  Wave-2 critical path.
+- **TurboQuant V-cache** — same applicability as QJL — N/A absent a KV
+  cache.
+
+A literal single `.gguf` containing all of text + voice + ASR + vision
++ drafter is **not** the deliverable — that requires either a custom
+container format or major upstream work in llama.cpp's GGUF graph, and
+is explicitly out of scope until the bundle ships and is stable. The
+single user-visible *download action* IS the deliverable: one click,
+one progress bar, one bundle on disk.
+
+If that constraint changes (i.e. someone wants a literal one-file
+artifact later), define an `.eliza` container format with a manifest +
+multiple GGUFs concatenated, and update §6 — do not silently change the
+GGUF schema.
+
+---
+
+## 3. Mandatory optimizations (never skip, error if missing)
+
+Every Eliza-1 bundle MUST run through every applicable optimization.
+The runtime MUST refuse to load a bundle that is missing any required
+artifact for its tier. There is no "fast path that skips X" and no
+"fallback to unoptimized". A bundle that cannot satisfy the contract
+must be marked broken in `eliza-1.manifest.json` and not served from
+the recommended-models endpoint.
+
+### Required for ALL tiers
+
+1. **TurboQuant** on the text model. Q3 for `lite`, Q3/Q4 for `mobile`,
+   Q4 for `desktop`/`pro`/`server`. The KV cache MUST use TurboQuant Q3
+   or Q4 quantization. See `vulkan/turbo3.comp`, `vulkan/turbo4.comp`,
+   `vulkan/turbo3_tcq.comp`, `metal/turbo3.metal`, `metal/turbo4.metal`,
+   `metal/turbo3_tcq.metal`. Verification: `verify/metal_verify` and
+   `verify/vulkan_verify` MUST report 8/8 PASS on the target backend
+   for the bundle's `dtype` before publish.
+2. **QJL** on the K-cache when context > 8k. See `vulkan/qjl*.comp` and
+   `metal/qjl.metal`. The reference is `packages/native/plugins/qjl-cpu`.
+3. **PolarQuant** on the V-cache when context > 8k. See `vulkan/polar*.comp`
+   and `metal/polar.metal`. The reference is
+   `packages/native/plugins/polarquant-cpu`.
+4. **MTP speculative decoding** with the bundle's drafter. Always wired,
+   always running in voice mode. The MTP drafter participates in voice
+   generation — proposed text tokens that survive verification are
+   immediately handed to the TTS pipeline; rejected tokens roll back the
+   TTS chunker (see §4 for the streaming contract).
+5. **Fused kernels.** TurboQuant + QJL + Polar must compile into the same
+   shipped llama.cpp build via the patch hooks in
+   `packages/app-core/scripts/build-llama-cpp-mtp.mjs`. The runtime
+   MUST log the kernel set on startup; missing kernels = startup error.
+
+### Required for `desktop`/`pro`/`server` tiers
+
+6. **TCQ trellis-coded quantization** for desktop/pro/server and any
+   long-context text variant. `turbo3_tcq.comp` / `turbo3_tcq.metal`.
+7. **CPU-offloaded KV cache** for context > 64k where device RAM is
+   insufficient. The runtime MUST implement spill, not just refuse the
+   request.
+
+### Failure handling
+
+If a required kernel fails to load, fails verification, or is missing
+from the build:
+
+- **Build time:** `build-llama-cpp-mtp.mjs` MUST exit non-zero, and
+  the published artifact MUST NOT include a "kernels-missing" fallback
+  build. There is no fallback build.
+- **Runtime:** the engine MUST refuse to activate the bundle and surface
+  a structured error to the UI. It MUST NOT silently fall back to
+  unoptimized inference. It MUST NOT log-and-continue.
+
+The Metal and Vulkan kernel patchers run unconditionally for matching
+build targets. Build outputs can record shipped shader symbols
+separately from runtime-ready graph dispatch, but only runtime-ready
+capabilities may satisfy this contract. Treat any builder/runtime that
+disables a required patch as broken.
+
+---
+
+## 4. Fused pipeline (mic → speech, end-to-end)
+
+The streaming contract for voice mode. Every Eliza-1 runtime MUST
+implement this exact graph; integrations that need a subset (e.g.
+text-only) must reach the same nodes via the same scheduler, not via a
+parallel codepath.
+
+```
+mic / file → ASR → text tokens
+                    ↓
+                  scheduler ──→ MTP drafter (proposes N tokens)
+                                       ↓
+                                  target verifier (text model)
+                                       ↓
+                              accepted tokens → phrase chunker
+                                       ↓                       ↘
+                            speaker preset (cached)        rollback queue
+                                       ↓                       ↙
+                                  OmniVoice TTS  ←── on-reject: cancel chunk
+                                       ↓
+                                  PCM ring buffer → audio out
+```
+
+### Hard requirements
+
+- **One process, one llama.cpp build, one GGML pin.** Text and voice
+  share the same llama.cpp library. omnivoice.cpp is fused into the
+  same build at the source level (vendored, not a sidecar). If the
+  GGML version pin used by omnivoice.cpp diverges from the text model,
+  the build MUST fail.
+- **Shared KV cache scheduling, not shared KV memory.** Text and voice
+  have their own KV caches (different layer counts, different head
+  configs, different quantizations). What they share is the scheduler,
+  the mmap region for weights, the kernel set, and the memory-budget
+  policy.
+- **Streaming handoff.** When MTP + target produce an accepted
+  text token, the phrase chunker MUST hand the chunk to TTS within the
+  same scheduler tick — no buffering past phrase boundaries. Phrase
+  boundaries are punctuation + a max-N-token cap (configurable per
+  tier).
+- **Barge-in cancellation.** When the mic detects new user speech, the
+  TTS PCM ring buffer MUST drain immediately, the phrase chunker queue
+  MUST flush, and any in-flight TTS forward pass MUST be cancelled at
+  the next kernel boundary.
+- **Voice cancellation contract (W3-9).** One `VoiceCancellationToken`
+  per voice turn is the canonical handle. It lives in
+  `@elizaos/shared/voice/voice-cancellation-token`, is owned by the
+  `VoiceCancellationCoordinator` in
+  `plugins/plugin-local-inference/src/services/voice/cancellation-coordinator.ts`,
+  and is the sole legitimate way to fan an abort across these four
+  layers:
+  1. The runtime's `TurnControllerRegistry.abortTurn(roomId, reason)`
+     so the planner-loop / action handlers / streaming `useModel`
+     calls see the abort within one tick.
+  2. The LM slot — via the registered `slotAbort(slotId, reason)`
+     callback (today: HTTP-fetch close on the in-flight stream; on a
+     fork that exposes a slot-cancel REST route, the REST call).
+  3. The TTS pipeline — via the registered `ttsStop(reason)` callback
+     (today: `EngineVoiceBridge.triggerBargeIn` → audio-sink drain +
+     FFI/HTTP synthesis cancel).
+  4. Any fetch / model / FFI consumer of `token.signal` (a standard
+     `AbortSignal`).
+  The token is idempotent (first reason wins) and fires every
+  `onAbort` listener synchronously. Optimistic LM start is gated by
+  `OptimisticGenerationPolicy` — default true on plugged-in /
+  unknown, false on battery, with explicit user override.
+  Full contract: `plugins/plugin-local-inference/docs/voice-cancellation-contract.md`.
+- **Speaker preset caching.** The default voice ships as a precomputed
+  speaker embedding in `cache/voice-preset-default.bin`. Loading a
+  voice MUST NOT re-extract the embedding from raw audio on every
+  startup. A precomputed phrase cache for common assistant utterances
+  ("Sure.", "One moment.", "I can't help with that.") MUST be used as
+  a first-byte-latency win.
+- **MTP↔TTS coupling.** When MTP proposes text tokens that are
+  later rejected by the target, the TTS chunker's rollback queue MUST
+  drop the corresponding (not-yet-spoken) audio chunks. Audio that has
+  already left the ring buffer is gone — design the chunker so this is
+  rare (small chunk = low latency cost on rollback).
+
+### What we do NOT do
+
+- We do not run text and voice in two processes communicating over IPC.
+  That regresses memory and adds a 1–10ms scheduling tax per turn.
+- We do not run a "TTS-only mode" that skips MTP. MTP is always
+  on. If the user disables speculative decoding for debugging, that is
+  a developer-only flag (`ELIZA_MTP_DISABLE=1`), it is not a user
+  setting, and it MUST log a loud warning every turn.
+- We do not split voice into "fast TTS" and "high-quality TTS" tiers.
+  One voice model per tier, fused, optimized.
+
+---
+
+## 5. Three modes — code organization
+
+Every entry point that touches a model MUST be classified into one or
+more of `local`, `cloud`, `remote`. The classification lives in code,
+not in docs.
+
+- `packages/app-core/src/services/local-inference/` is the `local` and
+  `local-only` surface. It MUST have a hard import boundary against
+  cloud-only modules.
+- Cloud-routing code is in the cloud package and MUST NOT be imported
+  by the local-inference service except through a typed mode-aware
+  router that the runtime mode gates.
+- `remote` mode is implemented as a thin client over the local
+  instance's HTTP API. It does NOT have its own model surfaces — every
+  setting it changes maps to a setting on the target.
+
+Hide-not-disable rule: when a mode hides a setting, the UI must omit
+the surface entirely, the API must reject mutations to that setting
+with a 4xx, and the persisted setting must be inert (no background job
+acts on it). "Hidden" without "inert" is a leak.
+
+---
+
+## 6. Manifest schema (binding)
+
+`eliza-1.manifest.json` is the source of truth for every Eliza-1
+bundle. The runtime, the recommendation engine, the downloader, the
+mobile catalogs, and the build script all read this file. Do not let
+catalogs drift from it — generate them.
+
+```json
+{
+  "$schema": "https://elizaos.ai/schemas/eliza-1.manifest.v1.json",
+  "id": "eliza-1-4b",
+  "tier": "4b",
+  "version": "1.0.0",
+  "publishedAt": "2026-MM-DDTHH:MM:SSZ",
+  "lineage": {
+    "text": { "base": "qwen3.5-4b", "license": "..." },
+    "voice": { "base": "omnivoice-base-Q4_K_M", "license": "..." },
+    "drafter": { "base": "mtp-4b-drafter", "license": "..." }
+  },
+  "files": {
+    "text":    [{ "path": "text/eliza-1-4b-128k.gguf", "ctx": 131072, "sha256": "..." }],
+    "voice":   [{ "path": "tts/omnivoice-base-Q4_K_M.gguf",   "sha256": "..." }],
+    "asr":     [{ "path": "asr/...",                          "sha256": "..." }],
+    "vision":  [{ "path": "vision/mmproj-4b.gguf",    "sha256": "..." }],
+    "mtp":  [{ "path": "mtp/drafter-4b.gguf",   "sha256": "..." }],
+    "cache":   [{ "path": "cache/voice-preset-default.bin",   "sha256": "..." }]
+  },
+  "kernels": {
+    "required": ["turboquant_q4", "qjl", "polarquant", "mtp", "turbo3_tcq"],
+    "optional": [],
+    "verifiedBackends": {
+      "metal":  { "status": "pass", "atCommit": "...", "report": "..." },
+      "vulkan": { "status": "pass", "atCommit": "...", "report": "..." },
+      "cuda":   { "status": "pass", "atCommit": "...", "report": "..." },
+      "cpu":    { "status": "pass", "atCommit": "...", "report": "..." }
+    }
+  },
+  "evals": {
+    "textEval":      { "score": 0.0, "passed": true },
+    "voiceRtf":      { "rtf": 0.0,   "passed": true },
+    "e2eLoopOk":     true,
+    "thirtyTurnOk":  true
+  },
+  "ramBudgetMb": { "min": 7000, "recommended": 9500 },
+  "defaultEligible": true
+}
+```
+
+**Rules:**
+
+- Every published bundle MUST have `defaultEligible: true` only if every
+  required kernel is verified on every supported backend for that tier
+  AND every eval has `passed: true`. The recommendation engine MUST
+  refuse to surface a bundle with `defaultEligible: false` as a default.
+- HF-search results from outside `elizaos/eliza-1` MUST never set
+  `defaultEligible: true`. They are user-installed customs only.
+- The runtime MUST validate the manifest against `kernels.required`
+  before activating the bundle. A capability mismatch is a hard error.
+
+---
+
+## 7. HuggingFace publishing & auto-download
+
+Every Eliza-1 release lives at `https://huggingface.co/elizaos`. The
+device-side downloader MUST:
+
+1. Read the manifest from the bundle's repo before downloading any
+   weight file. Verify schema version, kernel caps against the device,
+   RAM budget against device hardware. Refuse incompatible bundles
+   with a structured error.
+2. Download every file in `manifest.files.*`. Verify `sha256` for each.
+   Resume on partial download.
+3. Check the device's available kernels (Metal/Vulkan/CUDA/CPU/MLX/NEON)
+   against `manifest.kernels.required`. If any required kernel is
+   unavailable on this device, the download MUST be aborted with a
+   structured error before any weight bytes are fetched. There is no
+   "download anyway, hope it works" path.
+4. Materialize the bundle to the local cache, run a one-time
+   verify-on-device pass (load → 1-token text generation → 1-phrase
+   voice generation → barge-in cancel test), and only then mark the
+   bundle `ready` in the local catalog.
+
+Publishing flow (training side, see [`packages/training/AGENTS.md`](../training/AGENTS.md)):
+
+- Training produces text + drafter weights.
+- Quantization recipes in `packages/training/scripts/quantization/`
+  apply TurboQuant + QJL + Polar.
+- A publish script (one of the `publish_*` scripts in
+  `packages/training/scripts/`) assembles the bundle, generates the
+  manifest, runs `verify/metal_verify` + `verify/vulkan_verify` against
+  the bundle's quantized artifacts, populates `kernels.verifiedBackends`,
+  runs the eval suite, and pushes to HF.
+- The publish script MUST refuse to upload if any required eval fails
+  or any required kernel is unverified.
+
+---
+
+## 8. Verification gates (what "done" means)
+
+A bundle is shippable when, on each supported backend:
+
+- `make -C packages/inference/verify reference-test` is clean.
+- `verify/metal_verify` reports 8/8 PASS for `turbo3`, `turbo4`,
+  `turbo3_tcq`, `qjl`, `polar` against the bundle's quantized weights
+  (not just synthetic fixtures — fixtures regenerated from the actual
+  shipped weights).
+- `verify/vulkan_verify` reports 8/8 PASS for the same set.
+- The CUDA path (where applicable) reproduces the same outputs to the
+  same numerical tolerance.
+- A 30-turn end-to-end voice loop runs without crash, without leak,
+  without exceeding `manifest.ramBudgetMb.recommended`.
+- First-token latency, first-audio latency, RTF, ASR WER, peak RSS,
+  thermal/battery (mobile), and MTP acceptance rate are recorded
+  in the manifest's `evals` block and meet tier-specific gates.
+
+A code change that touches kernels, the build script, the mtp
+server, or the bundled-models catalog MUST run the relevant subset of
+these gates locally before merge. CI runs the full set per supported
+backend nightly.
+
+---
+
+## 9. Working style
+
+- **Scope discipline.** The kernels in this directory are a contract.
+  Do not invent new quantization formats, new fusion graphs, or new
+  KV-cache layouts without a written design doc that explains why the
+  existing five (`turbo3`, `turbo4`, `turbo3_tcq`, `qjl`, `polar`) are
+  insufficient.
+- **No defensive code.** A missing kernel, a missing manifest field,
+  or a verification failure is a hard error. Do not add fallbacks. Do
+  not log-and-continue. The whole point of the contract is that we
+  ship one optimized path, not three with conditional branches.
+- **Mirror the references bit-for-bit.** Metal/Vulkan kernels MUST
+  produce numerically identical output (within published tolerance) to
+  the C reference in `packages/inference/reference/` and to the
+  upstream CUDA implementation in
+  `packages/native/plugins/{qjl-cpu,polarquant-cpu}` and the `elizaOS/llama.cpp`
+  fork. New kernels follow the same pattern: ship the C reference and
+  a JSON fixture before shipping the Vulkan/Metal port.
+- **Hardware verification is non-optional.** A "compiles cleanly"
+  badge is not a "passes" badge. The README's verification matrix
+  marks rows as `NEEDS HARDWARE` until `metal_verify` / `vulkan_verify`
+  reports 8/8 on a real device. Do not flip a row to ✓ without that
+  evidence.
+- **Stay aligned with the training side.** Quantization recipes, weight
+  layouts, and bundle structure cross the boundary between training
+  and inference. Read [`packages/training/AGENTS.md`](../training/AGENTS.md)
+  before changing the manifest schema or any quantization op.
+- **Branding.** User-facing strings and logs say `Eliza-1`. They do
+  not say `Qwen`, `Llama`, `OmniVoice`, `MTP`, or `TurboQuant`.
+  Internal logs, stack traces, and developer-mode UI surfaces may
+  reference upstream names — anywhere a user can see, the name is
+  Eliza-1.
+
+---
+
+## 10. Files to read before making changes
+
+- `packages/inference/README.md` — kernel-level technical reference and
+  current verification matrix. The single source of truth for what is
+  hardware-verified vs. compile-only.
+- `packages/app-core/src/services/local-inference/README.md` — runtime
+  contract for the engine, downloader, recommendation, and routing.
+- `packages/app-core/scripts/build-llama-cpp-mtp.mjs` — the build
+  hook. Every kernel patch lives here. It (and the AOSP cross-compile at
+  `packages/app-core/scripts/aosp/compile-libllama.mjs`) default to building
+  from the in-repo `plugins/plugin-local-inference/native/llama.cpp` submodule.
+- `packages/training/AGENTS.md` — the training-side contract, including
+  what the bundle/publish flow expects.
+- the repo-root `AGENTS.md` — repo-wide cleanup mandate and conventions
+  (port handling, scope discipline, elizaOS naming). The non-negotiable
+  architecture rules apply here too: dependencies point inward, no
+  polymorphism for runtime branching in code (kernels are a registry,
+  not an `if`), no `try/catch` that swallows.
+
+---
+
+## 11. ONNX deprecation status (updated K7, 2026-05-15)
+
+**Single on-device runtime: elizaOS llama.cpp fork. No ONNX in resolved code path
+as of K7 for: VAD, wake-word, turn-detector (preferred), Kokoro (default=fork),
+OmniVoice, ASR. Three voice classifier models remain ONNX-active, blocked on K1/K2/K3
+native ports.**
+
+**Single runtime policy:** every local-inference model path must flow through
+the elizaOS llama.cpp fork. ONNX (`onnxruntime-node` / `onnxruntime-web`) is
+deprecated and will be removed from the runtime path once all native ports land.
+
+### Completed (fork path active — no ONNX in resolved runtime)
+
+| Model | Path | Status |
+|---|---|---|
+| OmniVoice TTS | fork FFI `libelizainference` (`tools/omnivoice/`) | DONE (W3-3) |
+| Silero VAD | standalone `silero-vad-cpp` FFI `libsilero_vad` + `vad/silero-vad-v5.gguf` | DONE (I1/K7 verified) — vad.ts imports zero onnxruntime-node |
+| hey-eliza wakeword | fork FFI `eliza_inference_wakeword_*` | DONE (I1/K7 verified) — wake-word.ts imports zero onnxruntime-node |
+| ASR (Qwen3-ASR) | fork FFI `eliza_pick_asr_files()` | DONE (T-asr) |
+| MTP speculative decoding | fork `llama-server` `--spec-type mtp` | DONE |
+| Text EOT (Eliza1EotClassifier) | fork `node-llama-cpp` P(`<|im_end|>`) | DONE (preferred path when text model loaded) |
+| LiveKit EOT (GGUF) | `eot-classifier-ggml.ts::LiveKitGgmlTurnDetector` | DONE (J1.d) — preferred over ONNX when GGUF on disk |
+| Kokoro TTS | `pick-runtime.ts` defaults to `KOKORO_BACKEND=fork` → llama-server `/v1/audio/speech` | DONE (J2/K4 default) — ONNX reachable only via env override |
+
+### Compute-gated (ONNX still active in resolved runtime)
+
+| Model | Gate | Owner | Est. |
+|---|---|---|---|
+| Wav2Small emotion | `voice-classifier-cpp/src/voice_emotion_*.c` returns `-ENOSYS` | K1 | 1 worker-day |
+| WeSpeaker R34-LM | `voice-classifier-cpp/src/voice_speaker_*.c` returns `-ENOSYS` | K2 | 2 worker-days |
+| pyannote-3 diarizer | `voice-classifier-cpp/src/voice_diarizer_*.c` returns `-ENOSYS`; diarizer-ggml.ts exists but C side not implemented | K3 | 1 worker-day |
+| LiveKit EOT (ONNX last-resort) | ONNX is last-resort in engine.ts chain (Eliza1Eot → GgmlTD → OnnxTD → Heuristic); ONNX reachable when GGUF not on disk | K7/J1.d | Remove OnnxTD from chain or guarantee GGUF on all tiers |
+| Kokoro ONNX runway | `KokoroOnnxRuntime` reachable via `KOKORO_BACKEND=onnx` | K4 | Remove class after K4 GGUF lands |
+
+**Rule:** do NOT remove `onnxruntime-node` from `plugin-local-inference/package.json`
+until every compute-gated head above is replaced. Premature removal crashes the
+voice pipeline. The per-model migration protocol (flip `manifest.json` runtime field,
+rename GGML variant to canonical, delete ONNX file, run verify gate) is documented
+in `.swarm/impl/I1-single-runtime.md §F` and `.swarm/impl/K7-no-onnx.md §D`.
+
+**HF deprecation runway:** ONNX model files remain on HF alongside GGUFs for one
+release after each native port lands. Do not delete ONNX from HF until the GGUF
+path has been in production for one release cycle.
+
+**K7 tracker:** `packages/training/reports/onnx-to-ggml-tracker.json` is the
+machine-readable source of truth for which package.json entries are still justified.
+The audit script `scripts/onnx-dep-audit.mjs` enforces this at CI time.


### PR DESCRIPTION
## What
Two documentation-accuracy fixes surfaced by an independent audit of the recent docs pass:

1. **`plugins/plugin-local-inference/native/CLAUDE.md`** was a stale 23-line stub that diverged from its canonical 720-line `AGENTS.md`, breaking the repo invariant (root guide: "author CLAUDE.md, then copy it to AGENTS.md"). Made byte-identical to the current `AGENTS.md`.
2. **`packages/core/CLAUDE.md`** (and its `AGENTS.md` mirror) described `@elizaos/app-core` as "the CLI". It is the API + dashboard host; the CLI is `packages/elizaos` — as the root `CLAUDE.md` already states correctly. Corrected and re-mirrored.

## Why
The root guide makes `CLAUDE.md` ≡ `AGENTS.md` a hard invariant, and the precision pass aimed for source-accurate docs; these two slipped through. The rest of the pass verified clean.

## Testing
Docs-only, zero code impact. Verified `diff -q` shows both `CLAUDE.md`/`AGENTS.md` pairs byte-identical after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This is a documentation-only PR that corrects two accuracy issues uncovered during an audit of the recent docs pass.

- **`packages/core/CLAUDE.md` + `AGENTS.md`**: Fixes a one-word mislabel — `@elizaos/app-core` was called \"the CLI\" when it is actually the API + dashboard host; the CLI is `packages/elizaos`. The root `CLAUDE.md` already had the correct description; this brings the package-level docs in sync.
- **`plugins/plugin-local-inference/native/CLAUDE.md`**: Replaces a stale 23-line stub (which simply deferred to `AGENTS.md`) with the full 720-line canonical content, restoring the repo invariant that `CLAUDE.md` and `AGENTS.md` must be byte-identical. Both pairs are confirmed byte-identical after the change.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with zero code impact; safe to merge.

All three changed files are markdown docs with no code or configuration. The label correction in `packages/core/CLAUDE.md`/`AGENTS.md` aligns with the already-correct root `CLAUDE.md`, and the `plugin-local-inference` stub replacement is confirmed byte-identical to the existing `AGENTS.md`. No logic, types, or build artifacts are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/core/CLAUDE.md | Single-line fix correcting `@elizaos/app-core` label from "the CLI" to "the API + dashboard host", matching the root CLAUDE.md. |
| packages/core/AGENTS.md | Mirror of packages/core/CLAUDE.md; same single-line label fix applied identically, preserving byte-for-byte parity. |
| plugins/plugin-local-inference/native/CLAUDE.md | Replaced a stale 23-line stub (that redirected to AGENTS.md) with the full 720-line AGENTS.md content, making CLAUDE.md byte-identical to AGENTS.md as required by the repo invariant. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    root["Root CLAUDE.md\n(source of truth)"]
    core_claude["packages/core/CLAUDE.md\n✅ app-core = API + dashboard host"]
    core_agents["packages/core/AGENTS.md\n✅ app-core = API + dashboard host"]
    plugin_claude["plugins/plugin-local-inference/native/CLAUDE.md\n✅ Full 720-line canonical content"]
    plugin_agents["plugins/plugin-local-inference/native/AGENTS.md\n(canonical, unchanged)"]

    root -->|"invariant: CLAUDE.md ≡ AGENTS.md"| core_claude
    core_claude -.->|"byte-identical"| core_agents
    plugin_agents -.->|"byte-identical (restored)"| plugin_claude

    style core_claude fill:#d4edda,stroke:#28a745
    style core_agents fill:#d4edda,stroke:#28a745
    style plugin_claude fill:#d4edda,stroke:#28a745
    style plugin_agents fill:#d4edda,stroke:#28a745
```

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/elizaos/eliza/commit/e93933fd84710b8a89bf735ea078703566a0ba8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35013896)</sub>

<!-- /greptile_comment -->