### PR TITLE
perf(ui): pause homescreen WebGL loop while hidden + drop dead branch

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1139,7 +1139,6 @@ function ShellContent(props: ShellContentProps): ReactNode {
   if (props.tab === "home") return <HomeShellContent />;
   const companionContent = CompanionShellContent(props);
   if (companionContent) return companionContent;
-  if (props.tab === "home") return <HomeShellContent />;
   if (props.tab === "stream") return <StreamShellContent />;
   if (props.isChatWorkspace) return <ChatWorkspaceShellContent {...props} />;
   if (props.isHeartbeats) return <HeartbeatsShellContent />;

--- a/packages/ui/src/homescreen/HomescreenCanvas.tsx
+++ b/packages/ui/src/homescreen/HomescreenCanvas.tsx
@@ -293,9 +293,20 @@ export function HomescreenCanvas({
         rafId = 0;
       };
 
-      // Animate unless the user asked for reduced motion, in which case draw a
-      // single static frame and hold there.
-      const applyMotionPreference = () => {
+      // Decide whether the render loop should run. Two reasons to hold instead
+      // of animate:
+      //  - the tab/window is hidden — a full-rate Three.js loop would otherwise
+      //    keep burning GPU/battery in the background with nothing on screen;
+      //  - the user asked for reduced motion (WCAG 2.3.3) — hold one static
+      //    frame so the sphere stays visible but frozen.
+      // Re-evaluated on mount, reduced-motion change, visibility change, and
+      // GPU context restore so the loop is never left running while hidden.
+      const applyActiveState = () => {
+        if (document.hidden) {
+          // Not visible — fully pause; there is nothing to paint.
+          stopLoop();
+          return;
+        }
         if (reducedMotion?.matches) {
           stopLoop();
           renderFrame(false);
@@ -326,8 +337,11 @@ export function HomescreenCanvas({
       const ro = new ResizeObserver(resize);
       ro.observe(container);
 
-      applyMotionPreference();
-      reducedMotion?.addEventListener("change", applyMotionPreference);
+      applyActiveState();
+      reducedMotion?.addEventListener("change", applyActiveState);
+      // Pause the render loop while the tab/window is hidden; resume on return.
+      const onVisibilityChange = () => applyActiveState();
+      document.addEventListener("visibilitychange", onVisibilityChange);
 
       // A lost GPU context (sleep/wake, driver reset, too many live contexts)
       // would otherwise leave a permanently black canvas while the loop keeps
@@ -344,14 +358,15 @@ export function HomescreenCanvas({
         currentScene = (current as SceneInstance & { __scene: THREE.Scene })
           .__scene;
         resize();
-        applyMotionPreference();
+        applyActiveState();
       };
       el.addEventListener("webglcontextlost", onContextLost);
       el.addEventListener("webglcontextrestored", onContextRestored);
 
       cleanup = () => {
         stopLoop();
-        reducedMotion?.removeEventListener("change", applyMotionPreference);
+        reducedMotion?.removeEventListener("change", applyActiveState);
+        document.removeEventListener("visibilitychange", onVisibilityChange);
         el.removeEventListener("webglcontextlost", onContextLost);
         el.removeEventListener("webglcontextrestored", onContextRestored);
         ro.disconnect();


### PR DESCRIPTION
## What
Pause the homescreen WebGL (Three.js) render loop while the surface is hidden, and drop a dead duplicate branch.

- **`HomescreenCanvas`**: the `requestAnimationFrame` loop previously only paused for `prefers-reduced-motion`, so a full-rate Three.js render kept burning GPU/battery whenever the tab/window was backgrounded (or the home stayed mounted under an overlay). The loop-gate (`applyActiveState`, renamed from `applyMotionPreference`) now also pauses on `document.hidden`, re-evaluated via a `visibilitychange` listener that's removed on unmount. Every path that decides whether to animate — initial mount, reduced-motion change, GPU context restore, visibility change — routes through the one gate, so the loop is never left running while hidden.
- **`App.tsx`**: removed an unreachable duplicate `if (props.tab === "home")` branch in `ShellContent` (the first line already returns for `home`; nothing between them changes `tab`).

## Why
Constant background GPU work is a real battery/thermal drain on desktop and mobile, and it compounds the dev experience (the home canvas keeps rendering behind overlays). The duplicate branch is dead code.

## Testing
- `packages/ui` typecheck: the two changed files are type-clean (the package has unrelated pre-existing `tsgo` errors on develop; this change adds none).
- App routing suites: `App.cloud-shell.test.tsx` (8) + `App.navigate-view-wiring.test.tsx` (3) — **11/11 pass**.
- Biome clean. `HomescreenCanvas` is a WebGL/Three component with no unit harness; the change uses standard DOM visibility APIs and is behavior-preserving when visible.

## Risk
Low. When visible, behavior is unchanged. When hidden, the loop pauses and resumes cleanly on return (and on GPU context restore / reduced-motion toggle — all via the same gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Pauses the Three.js render loop on `HomescreenCanvas` when the tab/window is hidden (via `document.visibilitychange`) and removes a dead duplicate `if (props.tab === "home")` branch in `ShellContent`. Both changes are narrowly scoped with no behavioral effect when the tab is visible.

- **`HomescreenCanvas.tsx`**: renames `applyMotionPreference` → `applyActiveState` and adds a `document.hidden` short-circuit; wires a `visibilitychange` listener that is properly torn down in the existing cleanup path alongside the `reducedMotion` and WebGL-context listeners.
- **`App.tsx`**: the second `if (props.tab === "home")` check was truly unreachable — `CompanionShellContent` never mutates `tab`, so the first guard always fires first — and is now gone.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the render loop behavior is identical when the tab is visible, and the hidden-state pause/resume paths are clean and symmetric.

Both changes are tightly scoped: the visibility guard funnels into the same applyActiveState gate already used for reduced-motion and GPU context restore, and cleanup removes all three listeners consistently. The dead-code removal in App.tsx has zero runtime impact.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/ui/src/homescreen/HomescreenCanvas.tsx | Adds document.hidden guard to the render-loop gate (applyActiveState) and wires up a visibilitychange listener that is correctly removed on unmount; one minor unnecessary wrapper function. |
| packages/ui/src/App.tsx | Removes the unreachable duplicate if (props.tab === 'home') branch — straightforward dead-code deletion with no behavioral impact. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Mount / reducedMotion change / visibilitychange / context restore] --> B{applyActiveState}
    B --> C{document.hidden?}
    C -- yes --> D[stopLoop — nothing to paint]
    C -- no --> E{reducedMotion.matches?}
    E -- yes --> F[stopLoop + renderFrame static]
    E -- no --> G[startLoop]
    D --> H((loop paused))
    F --> H
    G --> I((loop running))
    I --> J{frame tick}
    J --> K[renderFrame + requestAnimationFrame]
    K --> J
```

<sub>Reviews (1): Last reviewed commit: ["perf(ui): pause homescreen WebGL render ..."](https://github.com/elizaos/eliza/commit/bd6f7a42ab0c80ee060939137187c3a2eb0e21ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35021514)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->