### PR TITLE
fix(scenario,training): close reward-hacking + success-masking gaps in the eval harness

### DIFF
--- a/packages/scenario-runner/src/action-families.test.ts
+++ b/packages/scenario-runner/src/action-families.test.ts
@@ -6,9 +6,9 @@ import {
 
 describe("action family matching", () => {
   it("matches exact and prefix-normalized action names", () => {
-    expect(actionsAreScenarioEquivalent("ACTION.CALENDAR_CREATE", "calendar create")).toBe(
-      true,
-    );
+    expect(
+      actionsAreScenarioEquivalent("ACTION.CALENDAR_CREATE", "calendar create"),
+    ).toBe(true);
     expect(actionsAreScenarioEquivalent("reply", "REPLY")).toBe(true);
   });
 
@@ -29,5 +29,37 @@ describe("action family matching", () => {
     expect(actionMatchesScenarioExpectation("REPLY", ["calendar.create"])).toBe(
       false,
     );
+  });
+
+  it("credits parent/sub-action families on a real token boundary", () => {
+    // Sub-action is more specific than the expected parent family.
+    expect(
+      actionsAreScenarioEquivalent("CALENDAR_CREATE_EVENT", "CALENDAR_CREATE"),
+    ).toBe(true);
+    // Parent family standing in for a sub-action (the original bounded behavior).
+    expect(actionsAreScenarioEquivalent("SEND", "SEND_EMAIL")).toBe(true);
+    expect(actionsAreScenarioEquivalent("INBOX", "INBOX_TRIAGE")).toBe(true);
+    // Provider-qualified candidate matches the bare expectation.
+    expect(
+      actionsAreScenarioEquivalent(
+        "GOOGLE_CALENDAR_CREATE_EVENT",
+        "CALENDAR_CREATE_EVENT",
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT treat a generic action as satisfying a specific expectation", () => {
+    // Separator-stripped substring over-match (the regression): these share a
+    // character prefix/substring but not a leading token boundary.
+    expect(actionsAreScenarioEquivalent("LIFE", "LIFEOPS")).toBe(false);
+    expect(actionsAreScenarioEquivalent("LIFE", "MANAGE_LIFEOPS_BROWSER")).toBe(
+      false,
+    );
+    expect(actionsAreScenarioEquivalent("MESSAGE", "READ_MESSAGES")).toBe(
+      false,
+    );
+    // A bare action name must not match a specific action via an unbounded
+    // suffix/subset.
+    expect(actionsAreScenarioEquivalent("EMAIL", "SEND_EMAIL")).toBe(false);
   });
 });

--- a/packages/scenario-runner/src/action-families.ts
+++ b/packages/scenario-runner/src/action-families.ts
@@ -6,14 +6,38 @@ function normalizeActionName(value: string): string {
     .replace(/[^a-z0-9]+/g, "");
 }
 
-function actionTokens(value: string): Set<string> {
-  return new Set(
-    value
-      .trim()
-      .toLowerCase()
-      .split(/[^a-z0-9]+/)
-      .filter(Boolean),
-  );
+function actionTokenList(value: string): string[] {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/^action[.:_-]?/, "")
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+function isTokenPrefix(prefix: string[], full: string[]): boolean {
+  if (prefix.length === 0 || prefix.length > full.length) {
+    return false;
+  }
+  for (let i = 0; i < prefix.length; i += 1) {
+    if (prefix[i] !== full[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isTokenSuffix(suffix: string[], full: string[]): boolean {
+  if (suffix.length === 0 || suffix.length > full.length) {
+    return false;
+  }
+  const offset = full.length - suffix.length;
+  for (let i = 0; i < suffix.length; i += 1) {
+    if (suffix[i] !== full[offset + i]) {
+      return false;
+    }
+  }
+  return true;
 }
 
 export function actionsAreScenarioEquivalent(
@@ -28,22 +52,31 @@ export function actionsAreScenarioEquivalent(
   if (left.length === 0 || right.length === 0) {
     return false;
   }
-  if (left === right || left.includes(right) || right.includes(left)) {
+  if (left === right) {
     return true;
   }
 
-  const leftTokens = actionTokens(candidate);
-  const rightTokens = actionTokens(expected);
-  if (leftTokens.size === 0 || rightTokens.size === 0) {
+  // Bounded equivalence on the underscore-delimited token sequence. Two cases
+  // count as equivalent:
+  //   1. Parent/sub-action family — one action's tokens are a leading prefix of
+  //      the other's (CALENDAR_CREATE ↔ CALENDAR_CREATE_EVENT, SEND ↔ SEND_EMAIL).
+  //   2. Provider-qualified candidate — the expected tokens are a contiguous
+  //      suffix of the candidate (GOOGLE_CALENDAR_CREATE_EVENT ↔ CALENDAR_CREATE_EVENT),
+  //      so a provider prefix on the actual action still matches the expectation.
+  // This deliberately rejects the unbounded separator-stripped `includes`/token
+  // -subset over-match where a strictly more generic candidate (LIFE, MESSAGE,
+  // INBOX) was credited for a more specific expectation (LIFEOPS, READ_MESSAGES,
+  // INBOX_TRIAGE) on a non-token boundary.
+  const leftTokens = actionTokenList(candidate);
+  const rightTokens = actionTokenList(expected);
+  if (leftTokens.length === 0 || rightTokens.length === 0) {
     return false;
   }
-  let overlap = 0;
-  for (const token of rightTokens) {
-    if (leftTokens.has(token)) {
-      overlap += 1;
-    }
-  }
-  return overlap === rightTokens.size || overlap === leftTokens.size;
+  return (
+    isTokenPrefix(rightTokens, leftTokens) ||
+    isTokenPrefix(leftTokens, rightTokens) ||
+    isTokenSuffix(rightTokens, leftTokens)
+  );
 }
 
 export function actionMatchesScenarioExpectation(

--- a/packages/scenario-runner/src/cli.ts
+++ b/packages/scenario-runner/src/cli.ts
@@ -289,7 +289,17 @@ async function main(): Promise<number> {
     // into canonical eliza_native_v1 model-boundary rows for the eliza-1
     // training corpus (see packages/training/docs/dataset/CANONICAL_RECORD.md).
     // The training prep script runs the mandatory privacy filter on every row.
-    exportScenarioNativeJsonl(effectiveRunDir, parsed.exportNativePath);
+    // Thread each scenario's assertion outcome so failed/regressed trajectories
+    // are stamped status="failed" and routed to rating="repair"/weight=0 instead
+    // of being exported as gold-weight training data.
+    const scenarioOutcomes = new Map(
+      reports.map((report) => [report.id, report.status] as const),
+    );
+    exportScenarioNativeJsonl(
+      effectiveRunDir,
+      parsed.exportNativePath,
+      scenarioOutcomes,
+    );
   }
   if (effectiveRunDir) {
     const viewerIndex = path.join(effectiveRunDir, "viewer", "index.html");

--- a/packages/scenario-runner/src/executor.ts
+++ b/packages/scenario-runner/src/executor.ts
@@ -1735,7 +1735,11 @@ export async function runScenario(
           actionName: "REPLY",
           parameters: undefined,
           result: {
-            success: true,
+            // Do NOT claim success: this entry is fabricated because the LLM
+            // failed to select an action, so it must not satisfy a
+            // status:"success" actionCalled assertion. The `source` marker lets
+            // final-checks (and the native export) tell it apart from a real
+            // LLM-selected REPLY so it cannot mask a genuine selection failure.
             text: execution.responseText,
             data: { source: "synthesized-reply" },
           },

--- a/packages/scenario-runner/src/final-checks/index.ts
+++ b/packages/scenario-runner/src/final-checks/index.ts
@@ -242,6 +242,19 @@ function actionResultData(
   return toRecord(action.result?.data) ?? toRecord(action.result?.raw);
 }
 
+/**
+ * A synthesized REPLY is fabricated by the executor when the runtime emitted
+ * conversational text but the LLM did not actually select an action. It is NOT
+ * a genuine action selection, so action-selection checks must not be satisfied
+ * by it — otherwise a turn that free-texts instead of selecting the required
+ * action would falsely pass.
+ */
+function isSynthesizedReply(
+  action: ScenarioContext["actionsCalled"][number],
+): boolean {
+  return toRecord(action.result?.data)?.source === "synthesized-reply";
+}
+
 function hasBrowserTaskCompletedValue(value: unknown): boolean {
   const record = toRecord(value);
   if (!record) {
@@ -388,7 +401,9 @@ registerFinalCheckHandler("actionCalled", (check, { ctx }) => {
     status?: string;
     minCount?: number;
   };
-  const calls = ctx.actionsCalled.filter((a) => a.actionName === actionName);
+  const calls = ctx.actionsCalled.filter(
+    (a) => a.actionName === actionName && !isSynthesizedReply(a),
+  );
   const min = typeof minCount === "number" ? minCount : 1;
   if (calls.length < min) {
     return {
@@ -412,7 +427,9 @@ registerFinalCheckHandler("actionCalled", (check, { ctx }) => {
 registerFinalCheckHandler("selectedAction", (check, { ctx }) => {
   const { actionName } = check as { actionName: string | string[] };
   const accepted = toArray(actionName);
-  const match = ctx.actionsCalled.find((a) => accepted.includes(a.actionName));
+  const match = ctx.actionsCalled.find(
+    (a) => accepted.includes(a.actionName) && !isSynthesizedReply(a),
+  );
   if (!match) {
     return {
       status: "failed",

--- a/packages/scenario-runner/src/interceptor.test.ts
+++ b/packages/scenario-runner/src/interceptor.test.ts
@@ -1,0 +1,42 @@
+import type { CapturedConnectorDispatch } from "@elizaos/scenario-runner/schema";
+import { describe, expect, it } from "vitest";
+import { captureConnectorDispatchesFromAction } from "./interceptor.ts";
+
+describe("captureConnectorDispatchesFromAction delivered default", () => {
+  it("marks delivered=true only when the action reports success: true", () => {
+    const dispatches: CapturedConnectorDispatch[] = [];
+    captureConnectorDispatchesFromAction(
+      dispatches,
+      "MESSAGE",
+      { channel: "sms" },
+      { success: true, data: {} },
+    );
+    expect(dispatches).toHaveLength(1);
+    expect(dispatches[0]!.delivered).toBe(true);
+  });
+
+  it("marks delivered=false when the action reports success: false", () => {
+    const dispatches: CapturedConnectorDispatch[] = [];
+    captureConnectorDispatchesFromAction(
+      dispatches,
+      "MESSAGE",
+      { channel: "sms" },
+      { success: false, data: {} },
+    );
+    expect(dispatches[0]!.delivered).toBe(false);
+  });
+
+  it("defaults delivered to false when no boolean success is present", () => {
+    // Previously this defaulted to true, letting a "messageDelivered" final
+    // check pass on a handler that never reported success. The safe default
+    // mirrors the action-result success capture (undefined, never true).
+    const dispatches: CapturedConnectorDispatch[] = [];
+    captureConnectorDispatchesFromAction(
+      dispatches,
+      "MESSAGE",
+      { channel: "sms" },
+      { data: {} },
+    );
+    expect(dispatches[0]!.delivered).toBe(false);
+  });
+});

--- a/packages/scenario-runner/src/interceptor.ts
+++ b/packages/scenario-runner/src/interceptor.ts
@@ -268,7 +268,7 @@ function inferApprovalRequest(
   };
 }
 
-function captureConnectorDispatchesFromAction(
+export function captureConnectorDispatchesFromAction(
   connectorDispatches: CapturedConnectorDispatch[],
   actionName: string,
   parameters: unknown,
@@ -278,8 +278,12 @@ function captureConnectorDispatchesFromAction(
   const params = toRecord(paramsRecord?.parameters) ?? paramsRecord;
   const resultRecord = toRecord(result);
   const resultData = toRecord(resultRecord?.data);
+  // Only record a dispatch as delivered when the action explicitly reports
+  // success. Defaulting to `true` would let a "messageDelivered" final check
+  // pass on a handler that returned no boolean `success` — inconsistent with the
+  // safe default used for the captured action result below (undefined, not true).
   const delivered =
-    typeof resultRecord?.success === "boolean" ? resultRecord.success : true;
+    typeof resultRecord?.success === "boolean" ? resultRecord.success : false;
   const blob = [
     JSON.stringify(params ?? {}),
     JSON.stringify(resultData ?? {}),

--- a/packages/scenario-runner/src/native-export.test.ts
+++ b/packages/scenario-runner/src/native-export.test.ts
@@ -10,8 +10,8 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   exportScenarioNativeJsonl,
-  SCENARIO_NATIVE_EXPORT_SCHEMA,
   recordedTrajectoryToNativeRows,
+  SCENARIO_NATIVE_EXPORT_SCHEMA,
 } from "./native-export.ts";
 
 // Synthetic `RecordedTrajectory` shaped like what
@@ -114,6 +114,39 @@ function syntheticTrajectory() {
     },
   };
 }
+
+describe("recordedTrajectoryToNativeRows scenario outcome", () => {
+  it("omits a top-level status when no outcome is supplied", () => {
+    const rows = recordedTrajectoryToNativeRows(syntheticTrajectory() as never);
+    expect(rows[0]!.status).toBeUndefined();
+    expect(rows[0]!.scenarioStatus).toBeUndefined();
+    expect(rows[0]!.metadata.scenario_status).toBeUndefined();
+  });
+
+  it("stamps a passing scenario outcome on each row", () => {
+    const rows = recordedTrajectoryToNativeRows(
+      syntheticTrajectory() as never,
+      "passed",
+    );
+    expect(rows[0]!.status).toBe("passed");
+    expect(rows[0]!.scenarioStatus).toBe("passed");
+    expect(rows[0]!.metadata.scenario_status).toBe("passed");
+  });
+
+  it("stamps status='failed' so a failed scenario row is not scored gold", () => {
+    const rows = recordedTrajectoryToNativeRows(
+      syntheticTrajectory() as never,
+      "failed",
+    );
+    // The downstream scorer (native_success_and_score) treats a top-level
+    // status in {error,timeout,failed,failure} as success=False/score=0 →
+    // rating="repair"/weight=0. trajectory.status (recorder lifecycle) is still
+    // "finished" and must not be confused with the assertion outcome.
+    expect(rows[0]!.status).toBe("failed");
+    expect(rows[0]!.metadata.trajectory_status).toBe("finished");
+    expect(rows[0]!.metadata.scenario_status).toBe("failed");
+  });
+});
 
 describe("recordedTrajectoryToNativeRows", () => {
   it("emits one eliza_native_v1 boundary row per model-call stage", () => {
@@ -251,6 +284,42 @@ describe("exportScenarioNativeJsonl", () => {
         runIds: ["run-1"],
         scenarioIds: ["todos.create-basic"],
         agentIds: ["agent-test"],
+      });
+    } finally {
+      rmSync(runDir, { recursive: true, force: true });
+    }
+  });
+
+  it("threads scenario outcomes so failed trajectories carry status='failed'", () => {
+    const runDir = mkdtempSync(path.join(tmpdir(), "scenario-native-outcome-"));
+    try {
+      const trajDir = path.join(runDir, "trajectories", "agent-test");
+      mkdirSync(trajDir, { recursive: true });
+      writeFileSync(
+        path.join(trajDir, "tj-test-1.json"),
+        JSON.stringify(syntheticTrajectory()),
+        "utf-8",
+      );
+      const outPath = path.join(runDir, "native.jsonl");
+      // The scenario mechanically finished (recorder status "finished") but
+      // failed its assertions.
+      const outcomes = new Map<string, "passed" | "failed" | "skipped">([
+        ["todos.create-basic", "failed"],
+      ]);
+      const count = exportScenarioNativeJsonl(runDir, outPath, outcomes);
+      expect(count).toBe(1);
+      const parsed = JSON.parse(readFileSync(outPath, "utf-8").trim());
+      expect(parsed.status).toBe("failed");
+      expect(parsed.metadata.scenario_status).toBe("failed");
+      expect(parsed.metadata.trajectory_status).toBe("finished");
+      const manifest = JSON.parse(
+        readFileSync(path.join(runDir, "native.manifest.json"), "utf-8"),
+      );
+      expect(manifest.counts).toMatchObject({
+        rows: 1,
+        passedRows: 0,
+        failedRows: 1,
+        unknownOutcomeRows: 0,
       });
     } finally {
       rmSync(runDir, { recursive: true, force: true });

--- a/packages/scenario-runner/src/native-export.ts
+++ b/packages/scenario-runner/src/native-export.ts
@@ -34,10 +34,30 @@ export const SCENARIO_NATIVE_EXPORT_SCHEMA =
   "eliza_scenario_native_export" as const;
 export const SCENARIO_NATIVE_EXPORT_VERSION = 1 as const;
 
+/**
+ * Per-scenario assertion outcome, keyed by scenario id. Threaded into the
+ * exporter so failed/regressed trajectories are not emitted as gold-weight
+ * training rows. The recorder's own `trajectory.status` is the mechanical
+ * lifecycle (finished/errored) and does NOT reflect assertion pass/fail — only
+ * the scenario report carries that.
+ */
+export type ScenarioOutcome = "passed" | "failed" | "skipped";
+export type ScenarioOutcomeMap = ReadonlyMap<string, ScenarioOutcome>;
+
 export interface NativeBoundaryRow {
   format: typeof NATIVE_FORMAT;
   schemaVersion: typeof NATIVE_SCHEMA_VERSION;
   boundary: typeof GENERATE_TEXT_BOUNDARY;
+  /**
+   * Top-level scenario assertion outcome consumed by the training prep scorer
+   * (`native_success_and_score` in prepare_eliza1_trajectory_dataset.py). When a
+   * scenario failed, this is `"failed"`, which routes the row to
+   * rating="repair"/weight=0 instead of gold. Absent when the scenario outcome
+   * is unknown (e.g. a trajectory with no matching report), so behavior is
+   * unchanged for callers that do not pass an outcome map.
+   */
+  status?: ScenarioOutcome;
+  scenarioStatus?: ScenarioOutcome;
   request: {
     system?: string;
     messages?: unknown[];
@@ -98,6 +118,10 @@ export interface ScenarioNativeExportManifest {
     parsedTrajectories: number;
     skippedFiles: number;
     rows: number;
+    passedRows: number;
+    failedRows: number;
+    skippedScenarioRows: number;
+    unknownOutcomeRows: number;
   };
   runIds: string[];
   scenarioIds: string[];
@@ -209,6 +233,7 @@ function buildResponse(
  */
 export function recordedTrajectoryToNativeRows(
   trajectory: RecordedTrajectory,
+  scenarioOutcome?: ScenarioOutcome,
 ): NativeBoundaryRow[] {
   const rows: NativeBoundaryRow[] = [];
   const stages: RecordedStage[] = Array.isArray(trajectory.stages)
@@ -241,6 +266,9 @@ export function recordedTrajectoryToNativeRows(
       format: NATIVE_FORMAT,
       schemaVersion: NATIVE_SCHEMA_VERSION,
       boundary: GENERATE_TEXT_BOUNDARY,
+      ...(scenarioOutcome
+        ? { status: scenarioOutcome, scenarioStatus: scenarioOutcome }
+        : {}),
       request,
       response,
       trajectoryId: trajectory.trajectoryId,
@@ -289,6 +317,7 @@ export function recordedTrajectoryToNativeRows(
         source_provider:
           typeof model.provider === "string" ? model.provider : undefined,
         trajectory_status: trajectory.status,
+        ...(scenarioOutcome ? { scenario_status: scenarioOutcome } : {}),
         ...(typeof model.costUsd === "number"
           ? { source_cost_usd: model.costUsd }
           : {}),
@@ -346,10 +375,18 @@ function addString(set: Set<string>, value: unknown): void {
  * number of rows written. Trajectory files that fail to parse or aren't
  * recorded-trajectory shaped are skipped with a warning — a malformed file in
  * the run directory should not block the rest of the export.
+ *
+ * `scenarioOutcomes` maps scenario id → assertion outcome (passed/failed/
+ * skipped). Each emitted row carries its scenario's outcome as a top-level
+ * `status` so the training prep scorer routes failed trajectories to
+ * rating="repair"/weight=0 instead of stamping them gold. Without this map the
+ * exporter cannot tell a scenario that mechanically finished but failed its
+ * assertions from a genuinely passing one — and would export both as gold.
  */
 export function exportScenarioNativeJsonl(
   runDir: string,
   outPath: string,
+  scenarioOutcomes?: ScenarioOutcomeMap,
 ): number {
   const trajectoriesDir = path.join(runDir, "trajectories");
   const files = collectTrajectoryFiles(trajectoriesDir);
@@ -381,7 +418,20 @@ export function exportScenarioNativeJsonl(
     addString(runIds, parsed.runId);
     addString(scenarioIds, parsed.scenarioId);
     addString(agentIds, parsed.agentId);
-    rows.push(...recordedTrajectoryToNativeRows(parsed));
+    const scenarioOutcome =
+      scenarioOutcomes && typeof parsed.scenarioId === "string"
+        ? scenarioOutcomes.get(parsed.scenarioId)
+        : undefined;
+    if (
+      scenarioOutcomes &&
+      !scenarioOutcome &&
+      typeof parsed.scenarioId === "string"
+    ) {
+      logger.warn(
+        `[scenario-runner] trajectory ${parsed.trajectoryId} has scenarioId="${parsed.scenarioId}" with no matching scenario report; exporting without a pass/fail status`,
+      );
+    }
+    rows.push(...recordedTrajectoryToNativeRows(parsed, scenarioOutcome));
   }
   mkdirSync(path.dirname(outPath), { recursive: true });
   const body =
@@ -389,6 +439,16 @@ export function exportScenarioNativeJsonl(
       ? ""
       : `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`;
   writeFileSync(outPath, body, "utf-8");
+  let passedRows = 0;
+  let failedRows = 0;
+  let skippedScenarioRows = 0;
+  let unknownOutcomeRows = 0;
+  for (const row of rows) {
+    if (row.status === "passed") passedRows += 1;
+    else if (row.status === "failed") failedRows += 1;
+    else if (row.status === "skipped") skippedScenarioRows += 1;
+    else unknownOutcomeRows += 1;
+  }
   const manifestPath = defaultScenarioNativeManifestPath(outPath);
   const manifest: ScenarioNativeExportManifest = {
     schema: SCENARIO_NATIVE_EXPORT_SCHEMA,
@@ -403,14 +463,22 @@ export function exportScenarioNativeJsonl(
       parsedTrajectories,
       skippedFiles,
       rows: rows.length,
+      passedRows,
+      failedRows,
+      skippedScenarioRows,
+      unknownOutcomeRows,
     },
     runIds: [...runIds].sort(),
     scenarioIds: [...scenarioIds].sort(),
     agentIds: [...agentIds].sort(),
   };
-  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf-8");
+  writeFileSync(
+    manifestPath,
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf-8",
+  );
   logger.info(
-    `[scenario-runner] wrote ${rows.length} eliza_native_v1 row(s) from ${files.length} trajectory file(s) → ${outPath} (manifest → ${manifestPath})`,
+    `[scenario-runner] wrote ${rows.length} eliza_native_v1 row(s) from ${files.length} trajectory file(s) → ${outPath} (passed=${passedRows} failed=${failedRows} skipped=${skippedScenarioRows} unknown=${unknownOutcomeRows}) (manifest → ${manifestPath})`,
   );
   return rows.length;
 }

--- a/packages/training/scripts/eliza_reward_fn.py
+++ b/packages/training/scripts/eliza_reward_fn.py
@@ -230,6 +230,13 @@ def _score_tool_calls(
         return 0.0, 0.0, ["missing_native_tool_calls"]
     if len(predicted_calls) < len(expected_calls):
         notes.append("too_few_tool_calls")
+    # Extra/spurious calls beyond the expected set are never inspected by the
+    # name/arg checks below (which only iterate over expected_calls), so without
+    # this an appended call gets full content credit. Penalize them explicitly so
+    # RL cannot reward-hack by emitting extra (potentially destructive) calls.
+    has_extra_calls = len(predicted_calls) > len(expected_calls)
+    if has_extra_calls:
+        notes.append("too_many_tool_calls")
     names_ok = [
         index < len(predicted_calls)
         and predicted_calls[index]["name"] == expected["name"]
@@ -240,7 +247,9 @@ def _score_tool_calls(
         and _deep_contains(expected.get("arguments", {}), predicted_calls[index].get("arguments", {}))
         for index, expected in enumerate(expected_calls)
     ]
-    content_ok = 1.0 if all(names_ok) and all(args_ok) else 0.0
+    # Full content credit requires an exact-length match: the predicted calls must
+    # be the expected calls and nothing more.
+    content_ok = 1.0 if all(names_ok) and all(args_ok) and not has_extra_calls else 0.0
     if not all(names_ok):
         notes.append("tool_name_mismatch")
     if not all(args_ok):

--- a/packages/training/scripts/test_reward_fn.py
+++ b/packages/training/scripts/test_reward_fn.py
@@ -20,6 +20,12 @@ def _tool_call(name: str, arguments: dict) -> str:
     return json.dumps({"toolCalls": [{"name": name, "arguments": arguments}]})
 
 
+def _tool_calls(*calls: tuple[str, dict]) -> str:
+    return json.dumps(
+        {"toolCalls": [{"name": name, "arguments": args} for name, args in calls]}
+    )
+
+
 def test_tool_call_correct_high_reward() -> None:
     expected = {"expectedToolCalls": [{"name": "FINALIZE_WORKSPACE", "arguments": {"path": "/tmp/x"}}]}
     response = _tool_call("FINALIZE_WORKSPACE", {"path": "/tmp/x"})
@@ -39,6 +45,41 @@ def test_tool_call_wrong_argument_low_reward() -> None:
     response = _tool_call("SEND_EMAIL", {"to": "b@example.com"})
     reward = compute_reward("email a@example.com", response, expected)
     assert reward < 0.5
+
+
+def test_extra_tool_call_penalized() -> None:
+    # The model emits the expected SEND_EMAIL plus a spurious extra call. It must
+    # not get full content credit, and must score strictly below the clean
+    # single-call response — otherwise RL could learn to append extra calls.
+    expected = {"expectedToolCalls": [{"name": "SEND_EMAIL", "arguments": {"to": "a@example.com"}}]}
+    clean = _tool_call("SEND_EMAIL", {"to": "a@example.com"})
+    extra = _tool_calls(
+        ("SEND_EMAIL", {"to": "a@example.com"}),
+        ("DELETE_ALL_FILES", {}),
+    )
+    clean_comps = compute_reward_components("email a@example.com", clean, expected)
+    extra_comps = compute_reward_components("email a@example.com", extra, expected)
+    assert clean_comps.content_ok == 1.0
+    assert extra_comps.content_ok == 0.0
+    assert "too_many_tool_calls" in extra_comps.notes
+    assert extra_comps.final < clean_comps.final
+
+
+def test_exact_tool_calls_full_credit() -> None:
+    # An exact-length match of all expected calls still earns full content credit.
+    expected = {
+        "expectedToolCalls": [
+            {"name": "SEND_EMAIL", "arguments": {"to": "a@example.com"}},
+            {"name": "ARCHIVE", "arguments": {"id": "1"}},
+        ]
+    }
+    response = _tool_calls(
+        ("SEND_EMAIL", {"to": "a@example.com"}),
+        ("ARCHIVE", {"id": "1"}),
+    )
+    comps = compute_reward_components("email then archive", response, expected)
+    assert comps.content_ok == 1.0
+    assert "too_many_tool_calls" not in comps.notes
 
 
 def test_json_response_correct_high_reward() -> None:


### PR DESCRIPTION
## What
Five test-integrity / honesty fixes in the scenario + training eval harness (confirmed findings #47–#51):

- **#48 reward hacking** (`training/scripts/eliza_reward_fn.py`): `_score_tool_calls` gave full content credit even with *extra* tool calls beyond the expected set — so `[SEND_EMAIL, DELETE_ALL_FILES]` scored *higher* than the correct single call. Full content credit now requires an exact-length match; extra calls zero `content_ok` and add a `too_many_tool_calls` note. (Repro: dangerous 2-call case 0.397 vs 0.790 for the clean call; was 0.798.)
- **#49 success-masking** (`executor.ts`, `final-checks/index.ts`): a synthesized REPLY no longer sets `result.success=true`; a new `isSynthesizedReply()` guard excludes `source==="synthesized-reply"` captures from the `actionCalled`/`selectedAction` checks, so a turn that free-texts instead of selecting the required action no longer falsely passes.
- **#47 gold-data integrity** (`native-export.ts`, `cli.ts`): failed scenarios are stamped `status:"failed"` and routed to weight-0 (`repair`) instead of exported as gold-weight training data.
- **#51 fuzzy matcher** (`action-families.ts`): replaced an unbounded separator-stripped `includes()` match with a bounded token-boundary rule — a generic action no longer counts as satisfying a specific required one (`LIFE↔LIFEOPS`, `EMAIL↔SEND_EMAIL`, `MESSAGE↔READ_MESSAGES` now correctly don't match), while genuine parent/sub-action and provider-prefix cases still do.
- **#50 dispatch default** (`interceptor.ts`): connector-dispatch `delivered` now defaults `false` when no boolean success field is present.

## Testing
- Python: `test_reward_fn.py` — 10/10 (incl. 2 new for #48).
- TS: `action-families.test.ts` (5) + `interceptor.test.ts` (3) — 8/8. `native-export.test.ts` adds 3 #47 tests but can't run in this sandbox (transitively imports `@elizaos/core`'s logger whose deps aren't hoisted — the unmodified file fails the same way on develop); logic is type-clean.
- Biome clean.

## Risk
**#49 is behavior-changing**: excluding synthesized REPLYs from `actionCalled`/`selectedAction` surfaces real failures the synthesis previously masked (a comment claimed it prevented ~30% of cross-cutting scenarios from failing on provider quirk). That's the intended integrity fix — expect some scenario pass-rate movement; scenarios that only need "a reply happened" should use a judge/text assertion rather than `selectedAction:REPLY`. #47 routes failed rows to weight-0 (kept as repair examples, not dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes five test-integrity gaps in the scenario-runner and training eval harness: reward-hacking via spurious extra tool calls, synthesized-REPLY success masking, gold-data export of failed trajectories, unbounded fuzzy action matching, and an over-permissive `delivered=true` default.

- **Reward hacking (#48):** `_score_tool_calls` now zeros `content_ok` and notes `too_many_tool_calls` when the predicted sequence is longer than expected, so appending a destructive extra call can no longer increase the RL reward above the clean single-call score.
- **Success masking (#49):** Synthesized REPLY entries are stamped with `data.source=\"synthesized-reply\"` and excluded from `actionCalled`/`selectedAction` checks; a turn that only free-texts instead of selecting the required action now correctly fails.
- **Gold-data integrity (#47):** `exportScenarioNativeJsonl` accepts a `ScenarioOutcomeMap` from `cli.ts`; failed trajectories are stamped `status=\"failed\"` and route to `rating=\"repair\"/weight=0`.
- **Fuzzy matcher (#51):** Token-prefix/suffix rules replace the unbounded separator-stripped `includes()` match.
- **Dispatch default (#50):** `delivered` now defaults to `false` when no boolean `success` field is present.

<h3>Confidence Score: 4/5</h3>

Safe to merge with the token-suffix caveat in mind; all five stated fixes are mechanically correct and well-tested.

The five core fixes are sound and covered by tests. One residual gap in action-families.ts is that the isTokenSuffix path still allows a single-token expected value to be satisfied by any candidate ending with that token. A separate low-risk concern is that skipped scenario outcomes may not route to weight-0 in the downstream scorer.

packages/scenario-runner/src/action-families.ts — the suffix-matching rule and its test coverage; packages/scenario-runner/src/native-export.ts — how the downstream scorer handles status=skipped rows.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/scenario-runner/src/action-families.ts | Replaces unbounded token-subset matching with bounded token-prefix/suffix rules; residual suffix over-match allows single-token expected values (e.g. EMAIL) to be satisfied by any candidate ending in that token (e.g. SEND_EMAIL, READ_EMAIL) |
| packages/scenario-runner/src/native-export.ts | Adds ScenarioOutcome threading so failed trajectories carry status=failed and are routed to repair/weight=0; skipped status is exported but its downstream scorer handling is undocumented |
| packages/scenario-runner/src/final-checks/index.ts | Adds isSynthesizedReply guard to actionCalled and selectedAction handlers so fabricated REPLY entries no longer falsely satisfy action-selection checks |
| packages/scenario-runner/src/executor.ts | Synthesized REPLY result no longer sets success=true; adds data.source=synthesized-reply sentinel so final-checks can identify and exclude it |
| packages/scenario-runner/src/interceptor.ts | Changes delivered default from true to false when action result has no boolean success field; exports captureConnectorDispatchesFromAction for testing |
| packages/training/scripts/eliza_reward_fn.py | Adds has_extra_calls check so predicted sequences longer than expected earn content_ok=0.0, preventing reward-hacking via spurious extra tool calls |
| packages/scenario-runner/src/cli.ts | Builds ScenarioOutcomeMap from reports and passes it to exportScenarioNativeJsonl so assertion outcomes flow into the native export |
| packages/training/scripts/test_reward_fn.py | Adds two tests for the extra-call penalty: verifying content_ok=0 for a dangerous second call, and that exact multi-call sequences still earn full credit |
| packages/scenario-runner/src/interceptor.test.ts | New test file covering the three delivered-default cases: explicit true, explicit false, and missing boolean defaulting to false |
| packages/scenario-runner/src/action-families.test.ts | Adds two new describe blocks covering token-boundary parent/sub-action and false-positive cases; does not cover the reverse EMAIL-SEND_EMAIL direction that the suffix rule still accepts |
| packages/scenario-runner/src/native-export.test.ts | Adds three scenario-outcome tests verifying undefined-when-absent, passed stamping, and failed stamping with correct trajectory_status separation |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Scenario Turn Executes] --> B{LLM selects action?}
    B -- Yes --> C[Real action captured\nresult.success = actual]
    B -- No, free-text reply --> D[Synthesized REPLY fabricated\nresult.success omitted\ndata.source = synthesized-reply]
    C --> E[interceptor captures dispatch\ndelivered = result.success ?? false]
    D --> F[isSynthesizedReply guard]
    F --> G[actionCalled / selectedAction\nchecks EXCLUDE synthesized entry]
    C --> H[actionCalled / selectedAction\nchecks INCLUDE real entry]
    H --> I[Final check passes/fails]
    G --> I
    E --> J[messageDelivered check\ndelivered=false unless explicit]

    subgraph Training Export
        K[Scenario Report] --> L[ScenarioOutcomeMap\nreport.id to status]
        L --> M[exportScenarioNativeJsonl]
        N[Trajectory Files] --> M
        M --> O{Outcome lookup}
        O -- passed --> P[status=passed gold weight]
        O -- failed --> Q[status=failed repair/weight=0]
        O -- skipped --> R[status=skipped scorer behavior?]
        O -- no match --> S[status absent warning logged]
    end

    subgraph Reward Function
        T[Predicted tool calls] --> U{len predicted > len expected?}
        U -- Yes --> V[has_extra_calls=true\ncontent_ok=0.0]
        U -- No --> W{all names+args correct?}
        W -- Yes --> X[content_ok=1.0]
        W -- No --> Y[content_ok=0.0]
    end
```

<sub>Reviews (1): Last reviewed commit: ["fix(scenario-eval): close training-integ..."](https://github.com/elizaos/eliza/commit/e2d13ea049d5007116c55c65cf7d8eea146c8b3c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35021609)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->