### PR TITLE
fix(local-inference): Windows FFI backend, switch rollback, unload ordering, token decode

### DIFF
--- a/plugins/plugin-local-inference/src/services/active-model-switch-rollback.test.ts
+++ b/plugins/plugin-local-inference/src/services/active-model-switch-rollback.test.ts
@@ -1,0 +1,145 @@
+import type { AgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	ActiveModelCoordinator,
+	type LocalInferenceLoadArgs,
+	type LocalInferenceLoader,
+} from "./active-model";
+import type { HardwareProbe, InstalledModel } from "./types";
+
+function makeInstalledModel(id: string): InstalledModel {
+	return {
+		id,
+		displayName: id,
+		// `external-scan` ids are absent from MODEL_CATALOG, so
+		// assertModelFitsHost short-circuits and switchTo() exercises the
+		// loader path without needing on-disk weights.
+		path: `/tmp/${id}.gguf`,
+		sizeBytes: 1024,
+		installedAt: "2026-05-15T00:00:00.000Z",
+		lastUsedAt: null,
+		source: "external-scan",
+	};
+}
+
+const PROBE: HardwareProbe = {
+	totalRamGb: 64,
+	freeRamGb: 48,
+	gpu: null,
+	cpuCores: 8,
+	platform: "linux",
+	arch: "x64",
+	appleSilicon: false,
+	recommendedBucket: "mid",
+	source: "os-fallback",
+};
+
+/**
+ * Fake loader satisfying `isLoader` (loadModel/unloadModel/currentModelPath).
+ * `loadModel` rejects when `failNext` is set so we can simulate a load failure
+ * mid-switch without touching the real engine.
+ */
+class FakeLoader implements LocalInferenceLoader {
+	loaded: string | null = null;
+	failNextPaths = new Set<string>();
+	readonly loadCalls: string[] = [];
+	readonly unloadCalls: number[] = [];
+
+	async loadModel(args: LocalInferenceLoadArgs): Promise<void> {
+		this.loadCalls.push(args.modelPath);
+		if (this.failNextPaths.has(args.modelPath)) {
+			throw new Error(`simulated load failure for ${args.modelPath}`);
+		}
+		this.loaded = args.modelPath;
+	}
+
+	async unloadModel(): Promise<void> {
+		this.unloadCalls.push(this.unloadCalls.length);
+		this.loaded = null;
+	}
+
+	currentModelPath(): string | null {
+		return this.loaded;
+	}
+}
+
+function makeRuntime(loader: LocalInferenceLoader): AgentRuntime {
+	return {
+		agentId: "agent-test",
+		getService: (name: string) =>
+			name === "localInferenceLoader" ? loader : null,
+	} as unknown as AgentRuntime;
+}
+
+describe("ActiveModelCoordinator switchTo rollback (#13)", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("restores the previously-active model when a switch fails to load", async () => {
+		const loader = new FakeLoader();
+		const runtime = makeRuntime(loader);
+		const coordinator = new ActiveModelCoordinator();
+		const modelA = makeInstalledModel("model-a");
+		const modelB = makeInstalledModel("model-b");
+
+		// First load succeeds → A is the active, known-good model.
+		const first = await coordinator.switchTo(runtime, modelA, undefined, {
+			hardware: PROBE,
+		});
+		expect(first).toMatchObject({ modelId: "model-a", status: "ready" });
+		expect(loader.currentModelPath()).toBe(modelA.path);
+
+		// Switching to B fails to load. The old model must be restored, not lost.
+		loader.failNextPaths.add(modelB.path);
+		const second = await coordinator.switchTo(runtime, modelB, undefined, {
+			hardware: PROBE,
+		});
+
+		expect(second).toMatchObject({ modelId: "model-a", status: "ready" });
+		// A working model is loaded — NOT zero models, NOT an error attributed
+		// to the requested id.
+		expect(second.status).not.toBe("error");
+		expect(loader.currentModelPath()).toBe(modelA.path);
+	});
+
+	it("reports no model loaded (modelId null, error) when no prior model existed", async () => {
+		const loader = new FakeLoader();
+		const runtime = makeRuntime(loader);
+		const coordinator = new ActiveModelCoordinator();
+		const modelA = makeInstalledModel("model-a");
+
+		loader.failNextPaths.add(modelA.path);
+		const state = await coordinator.switchTo(runtime, modelA, undefined, {
+			hardware: PROBE,
+		});
+
+		expect(state.status).toBe("error");
+		// Honest: nothing is loaded, so the id is null rather than a phantom
+		// "model-a" that callers would treat as a live model.
+		expect(state.modelId).toBeNull();
+		expect(loader.currentModelPath()).toBeNull();
+	});
+
+	it("reports no model loaded when both the switch and the restore fail", async () => {
+		const loader = new FakeLoader();
+		const runtime = makeRuntime(loader);
+		const coordinator = new ActiveModelCoordinator();
+		const modelA = makeInstalledModel("model-a");
+		const modelB = makeInstalledModel("model-b");
+
+		await coordinator.switchTo(runtime, modelA, undefined, {
+			hardware: PROBE,
+		});
+
+		// Both the new load AND the restore of the old model fail.
+		loader.failNextPaths.add(modelB.path);
+		loader.failNextPaths.add(modelA.path);
+		const state = await coordinator.switchTo(runtime, modelB, undefined, {
+			hardware: PROBE,
+		});
+
+		expect(state.status).toBe("error");
+		expect(state.modelId).toBeNull();
+	});
+});

--- a/plugins/plugin-local-inference/src/services/active-model.ts
+++ b/plugins/plugin-local-inference/src/services/active-model.ts
@@ -856,6 +856,20 @@ export class ActiveModelCoordinator {
 		status: "idle",
 	};
 
+	/**
+	 * The last model that successfully reached `status: "ready"`, plus the
+	 * inputs needed to re-load it. switchTo() tears the active model down
+	 * before loading the new one (unload-then-load); if the new load fails we
+	 * restore this so a failed switch never leaves the host with zero models
+	 * loaded while a working one existed moments earlier. `null` until the
+	 * first successful load (or after an unload).
+	 */
+	private lastReady: {
+		installed: InstalledModel;
+		overrides?: LocalInferenceLoadOverrides;
+		state: ActiveModelState;
+	} | null = null;
+
 	private readonly listeners = new Set<(state: ActiveModelState) => void>();
 
 	snapshot(): ActiveModelState {
@@ -945,76 +959,126 @@ export class ActiveModelCoordinator {
 		// path for users who haven't separately enabled plugin-local-ai.
 		const loader = this.getLoader(runtime);
 
+		// Snapshot the previously-active model BEFORE the unload-then-load tears
+		// it down, so a failed switch can restore it instead of leaving zero
+		// models loaded under the requested id.
+		const previous = this.lastReady;
+
 		try {
-			// RAM-budget admission control (W10 / J1): refuse a model that won't
-			// fit this host *before* touching the loader, so we never half-load
-			// and OOM. `assertModelFitsHost` throws `ModelDoesNotFitError` with
-			// the specific numbers + the largest fitting variant of the tier.
-			const probe = opts.hardware ?? (await probeHardware());
-			const admission = assertModelFitsHost(
-				installed,
-				hostRamMbFromProbe(probe),
-			);
-			if (admission.level === "tight") {
-				console.warn(
-					`[local-inference] Loading "${installed.id}" with tight RAM headroom (~${admission.minMb} MB floor, ${admission.recommendedMb} MB recommended; ${hostRamMbFromProbe(probe)} MB host). Expect swapping under sustained load.`,
-				);
-			}
-			const resolved = await resolveLocalInferenceLoadArgs(
-				installed,
-				overrides,
-			);
-			// WS2: warn one-shot when the tier declares vision but the
-			// per-tier mmproj GGUF isn't on disk yet. The text load still
-			// proceeds; vision capability is degraded for this session
-			// (plugin-vision falls back to its Florence-2 path).
-			this.warnIfVisionDegraded(installed, resolved.mmprojPath);
-			if (loader) {
-				await loader.unloadModel();
-				await loader.loadModel(resolved);
-			} else {
-				await localInferenceEngine.load(installed.path, resolved);
-			}
-			const runtimeLoad = loader
-				? null
-				: localInferenceEngine.currentRuntimeLoadConfig();
-			// Surface the effective load config so consumers (the benchmark
-			// harness, the Settings UI, the active-model SSE) can verify the
-			// requested overrides actually took hold instead of silently
-			// falling back to a smaller context or fp16 KV.
-			this.state = {
-				modelId: installed.id,
-				loadedAt: new Date().toISOString(),
-				status: "ready",
-				loadedContextSize:
-					runtimeLoad?.contextSize ?? resolved.contextSize ?? null,
-				loadedCacheTypeK: runtimeLoad
-					? runtimeLoad.cacheTypeK
-					: (resolved.cacheTypeK ?? null),
-				loadedCacheTypeV: runtimeLoad
-					? runtimeLoad.cacheTypeV
-					: (resolved.cacheTypeV ?? null),
-				loadedGpuLayers:
-					runtimeLoad !== null
-						? runtimeLoad.gpuLayers
-						: typeof resolved.gpuLayers === "number"
-							? resolved.gpuLayers
-							: null,
-			};
+			const ready = await this.performLoad(loader, installed, overrides, opts);
+			this.state = ready;
+			this.lastReady = { installed, overrides, state: ready };
 			if (installed.source === "eliza-download") {
 				await touchElizaModel(installed.id);
 			}
 		} catch (err) {
+			const failure = err instanceof Error ? err.message : String(err);
+			// Attempt to restore the previously-active model. The unload-then-load
+			// already tore it down, so without this the host has no model loaded.
+			if (previous && previous.installed.id !== installed.id) {
+				try {
+					const restored = await this.performLoad(
+						loader,
+						previous.installed,
+						previous.overrides,
+						opts,
+					);
+					this.state = restored;
+					this.lastReady = {
+						installed: previous.installed,
+						overrides: previous.overrides,
+						state: restored,
+					};
+					console.warn(
+						`[local-inference] Failed to switch to "${installed.id}" (${failure}); restored previously-active model "${previous.installed.id}".`,
+					);
+					this.emit();
+					return this.snapshot();
+				} catch (restoreErr) {
+					const restoreFailure =
+						restoreErr instanceof Error
+							? restoreErr.message
+							: String(restoreErr);
+					console.error(
+						`[local-inference] Failed to switch to "${installed.id}" (${failure}) AND failed to restore "${previous.installed.id}" (${restoreFailure}). No model is loaded.`,
+					);
+				}
+			}
+			// No prior model to restore (or restore also failed): report honestly
+			// that nothing is loaded rather than attributing a phantom id.
+			this.lastReady = null;
 			this.state = {
-				modelId: installed.id,
+				modelId: null,
 				loadedAt: null,
 				status: "error",
-				error: err instanceof Error ? err.message : String(err),
+				error: failure,
 			};
 		}
 
 		this.emit();
 		return this.snapshot();
+	}
+
+	/**
+	 * Run the unload-then-load against the loader (or standalone engine) and
+	 * build the `status: "ready"` state. Throws on any load failure; never
+	 * mutates `this.state`/`this.lastReady` so callers control rollback.
+	 */
+	private async performLoad(
+		loader: LocalInferenceLoader | null,
+		installed: InstalledModel,
+		overrides: LocalInferenceLoadOverrides | undefined,
+		opts: { hardware?: HardwareProbe; manifestLoader?: ManifestLoader },
+	): Promise<ActiveModelState> {
+		// RAM-budget admission control (W10 / J1): refuse a model that won't
+		// fit this host *before* touching the loader, so we never half-load
+		// and OOM. `assertModelFitsHost` throws `ModelDoesNotFitError` with
+		// the specific numbers + the largest fitting variant of the tier.
+		const probe = opts.hardware ?? (await probeHardware());
+		const admission = assertModelFitsHost(installed, hostRamMbFromProbe(probe));
+		if (admission.level === "tight") {
+			console.warn(
+				`[local-inference] Loading "${installed.id}" with tight RAM headroom (~${admission.minMb} MB floor, ${admission.recommendedMb} MB recommended; ${hostRamMbFromProbe(probe)} MB host). Expect swapping under sustained load.`,
+			);
+		}
+		const resolved = await resolveLocalInferenceLoadArgs(installed, overrides);
+		// WS2: warn one-shot when the tier declares vision but the
+		// per-tier mmproj GGUF isn't on disk yet. The text load still
+		// proceeds; vision capability is degraded for this session
+		// (plugin-vision falls back to its Florence-2 path).
+		this.warnIfVisionDegraded(installed, resolved.mmprojPath);
+		if (loader) {
+			await loader.unloadModel();
+			await loader.loadModel(resolved);
+		} else {
+			await localInferenceEngine.load(installed.path, resolved);
+		}
+		const runtimeLoad = loader
+			? null
+			: localInferenceEngine.currentRuntimeLoadConfig();
+		// Surface the effective load config so consumers (the benchmark
+		// harness, the Settings UI, the active-model SSE) can verify the
+		// requested overrides actually took hold instead of silently
+		// falling back to a smaller context or fp16 KV.
+		return {
+			modelId: installed.id,
+			loadedAt: new Date().toISOString(),
+			status: "ready",
+			loadedContextSize:
+				runtimeLoad?.contextSize ?? resolved.contextSize ?? null,
+			loadedCacheTypeK: runtimeLoad
+				? runtimeLoad.cacheTypeK
+				: (resolved.cacheTypeK ?? null),
+			loadedCacheTypeV: runtimeLoad
+				? runtimeLoad.cacheTypeV
+				: (resolved.cacheTypeV ?? null),
+			loadedGpuLayers:
+				runtimeLoad !== null
+					? runtimeLoad.gpuLayers
+					: typeof resolved.gpuLayers === "number"
+						? resolved.gpuLayers
+						: null,
+		};
 	}
 
 	async unload(runtime: AgentRuntime | null): Promise<ActiveModelState> {
@@ -1039,6 +1103,10 @@ export class ActiveModelCoordinator {
 			this.emit();
 			return this.snapshot();
 		}
+		// The model was deliberately unloaded — drop the restore snapshot so a
+		// later failed switch doesn't silently re-load a model the operator
+		// asked to unload.
+		this.lastReady = null;
 		this.state = {
 			modelId: null,
 			loadedAt: null,

--- a/plugins/plugin-local-inference/src/services/desktop-ffi-backend-runtime.ts
+++ b/plugins/plugin-local-inference/src/services/desktop-ffi-backend-runtime.ts
@@ -144,8 +144,14 @@ export class DesktopFfiBackendRuntime implements FfiBackendRuntime {
 
 	async release(): Promise<void> {
 		if (!this.active) return;
-		this.active.adapter.close();
-		this.active = null;
+		// Clear `active` in a finally so a throwing native free (adapter.close()
+		// makes raw bun:ffi calls that can throw) can't leave the runtime with a
+		// stale live session that permanently blocks acquire()'s live-session guard.
+		try {
+			this.active.adapter.close();
+		} finally {
+			this.active = null;
+		}
 	}
 }
 

--- a/plugins/plugin-local-inference/src/services/desktop-llama-adapter.ts
+++ b/plugins/plugin-local-inference/src/services/desktop-llama-adapter.ts
@@ -368,9 +368,14 @@ export function resolveDesktopBinDir(
 	if (arch === null) {
 		throw new Error(`[desktop-llama] unsupported process.arch=${process.arch}`);
 	}
+	// Default backend MUST match what the build script stages on disk
+	// (packages/app-core/scripts/build-llama-cpp-desktop-dylib.mjs): darwin→metal,
+	// linux→vulkan, windows→vulkan. The build's outDir is `${platform}-${arch}-${t.backend}`
+	// and Windows hardcodes `backend: "vulkan"`, so probing `windows-x86_64-cpu` here
+	// never finds the staged dylibs and the in-process FFI path is silently skipped.
 	const backend =
 		env.ELIZA_DESKTOP_BACKEND?.trim() ||
-		(platform === "darwin" ? "metal" : platform === "linux" ? "vulkan" : "cpu");
+		(platform === "darwin" ? "metal" : "vulkan");
 	return path.join(
 		stateDir,
 		"local-inference",
@@ -652,11 +657,6 @@ function encodeCString(text: string): Uint8Array {
 	return out;
 }
 
-function decodeCStringBytes(buf: Uint8Array): string {
-	const end = buf.indexOf(0);
-	return new TextDecoder("utf-8").decode(end < 0 ? buf : buf.subarray(0, end));
-}
-
 /** Default thread count: half the logical cores (a sensible P-core proxy on Apple Silicon). */
 function defaultThreads(env: NodeJS.ProcessEnv = process.env): number {
 	const explicit = Number.parseInt(env.ELIZA_LLAMA_THREADS ?? "", 10);
@@ -738,6 +738,14 @@ interface DesktopSession {
 	// Reusable single-token buffer for stepwise decode.
 	tokenBuf: Int32Array;
 	pieceBuf: Uint8Array;
+	/**
+	 * Persistent streaming UTF-8 decoder for this session. BPE routinely splits
+	 * a multi-byte codepoint (CJK / emoji / accented Latin) across two token
+	 * pieces; decoding each piece in isolation would turn each half into U+FFFD.
+	 * Reusing one decoder with `decode(bytes, { stream: true })` carries the
+	 * trailing bytes of a split codepoint into the next piece so it reassembles.
+	 */
+	pieceDecoder: TextDecoder;
 	emittedFirstToken: boolean;
 	/** Snapshotted at openSession; nextStep never re-reads has_drafter. */
 	usingDrafter: boolean;
@@ -1595,6 +1603,7 @@ export class DesktopLlamaAdapter {
 			finished: false,
 			tokenBuf: new Int32Array(1),
 			pieceBuf: new Uint8Array(256),
+			pieceDecoder: new TextDecoder("utf-8"),
 			emittedFirstToken: false,
 			usingDrafter,
 			mtpEngine,
@@ -1763,6 +1772,51 @@ export class DesktopLlamaAdapter {
 		}
 	}
 
+	/**
+	 * Convert one sampled token id into its text piece for `sess`.
+	 *
+	 * Handles two failure modes the naive `wrote > 0` guard dropped:
+	 *   1. Negative return: llama_token_to_piece returns `-n` (the negated byte
+	 *      count it needs) when `pieceBuf` is too small. We grow `pieceBuf` to
+	 *      that size and retry once instead of silently dropping the token text.
+	 *   2. UTF-8 codepoints split across token boundaries: we feed the raw piece
+	 *      bytes through the session's persistent streaming decoder so a half
+	 *      codepoint carries into the next piece rather than decoding to U+FFFD.
+	 */
+	private tokenToText(sess: DesktopSession, token: number): string {
+		if (!this.vocabPtr)
+			throw new Error("[desktop-llama] token decode before load");
+		let wrote = this.llama.llama_token_to_piece(
+			this.vocabPtr,
+			token,
+			this.ffi.ptr(sess.pieceBuf),
+			sess.pieceBuf.length,
+			0,
+			false,
+		);
+		if (wrote < 0) {
+			// Buffer too small: -wrote is the required byte count. Grow and retry.
+			sess.pieceBuf = new Uint8Array(-wrote);
+			wrote = this.llama.llama_token_to_piece(
+				this.vocabPtr,
+				token,
+				this.ffi.ptr(sess.pieceBuf),
+				sess.pieceBuf.length,
+				0,
+				false,
+			);
+			if (wrote < 0) {
+				throw new Error(
+					`[desktop-llama] llama_token_to_piece failed after resize (rc=${wrote}) for token ${token}`,
+				);
+			}
+		}
+		if (wrote === 0) return "";
+		return sess.pieceDecoder.decode(sess.pieceBuf.subarray(0, wrote), {
+			stream: true,
+		});
+	}
+
 	private nextStep(
 		stream: LlmStreamHandle,
 		maxTokensPerStep = 32,
@@ -1798,17 +1852,7 @@ export class DesktopLlamaAdapter {
 				break;
 			}
 			this.llama.llama_sampler_accept(sess.sampler, next);
-			const wrote = this.llama.llama_token_to_piece(
-				this.vocabPtr,
-				next,
-				this.ffi.ptr(sess.pieceBuf),
-				sess.pieceBuf.length,
-				0,
-				false,
-			);
-			if (wrote > 0) {
-				text += decodeCStringBytes(sess.pieceBuf.subarray(0, wrote));
-			}
+			text += this.tokenToText(sess, next);
 			out.push(next);
 
 			// Decode the just-sampled token to advance the KV cache.
@@ -1873,17 +1917,7 @@ export class DesktopLlamaAdapter {
 			if (this.llama.llama_vocab_is_eog(this.vocabPtr as Pointer, token)) {
 				return true;
 			}
-			const wrote = this.llama.llama_token_to_piece(
-				this.vocabPtr as Pointer,
-				token,
-				this.ffi.ptr(sess.pieceBuf),
-				sess.pieceBuf.length,
-				0,
-				false,
-			);
-			if (wrote > 0) {
-				text += decodeCStringBytes(sess.pieceBuf.subarray(0, wrote));
-			}
+			text += this.tokenToText(sess, token);
 			out.push(token);
 			return false;
 		};

--- a/plugins/plugin-local-inference/src/services/desktop-llama-piece-decode.test.ts
+++ b/plugins/plugin-local-inference/src/services/desktop-llama-piece-decode.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from "vitest";
+import { DesktopLlamaAdapter } from "./desktop-llama-adapter";
+
+/**
+ * Tests for #11: llama_token_to_piece negative-return handling (resize + retry,
+ * never drop token text) and split-UTF-8 reassembly across token boundaries.
+ *
+ * The harness captures every buffer handed to `ffi.ptr` so the
+ * `llama_token_to_piece` mock can write real bytes into the adapter's
+ * `pieceBuf` and report the byte count (or a negative "buffer too small").
+ */
+function makePieceHarness(pieces: Map<number, Uint8Array>) {
+	let nextPtr = 100;
+	// Map the fake integer "pointer" back to the JS-side buffer it came from.
+	const ptrToBuf = new Map<number, Uint8Array>();
+
+	const ffi = {
+		ptr: vi.fn((buf: Uint8Array) => {
+			const p = nextPtr++;
+			if (buf instanceof Uint8Array) ptrToBuf.set(p, buf);
+			return p;
+		}),
+	};
+
+	const llama = {
+		llama_backend_init: vi.fn(),
+		llama_backend_free: vi.fn(),
+		llama_model_free: vi.fn(),
+		llama_free: vi.fn(),
+		llama_get_model: vi.fn().mockReturnValue(2),
+		llama_model_get_vocab: vi.fn().mockReturnValue(3),
+		llama_n_ctx: vi.fn().mockReturnValue(4096),
+		llama_vocab_is_eog: vi.fn().mockReturnValue(false),
+		llama_set_embeddings: vi.fn(),
+		llama_get_memory: vi.fn().mockReturnValue(4),
+		llama_memory_clear: vi.fn(),
+		llama_tokenize: vi.fn(),
+		// Write the token's bytes into the buffer behind `bufPtr`. Returns the
+		// byte count, or -byteCount when the buffer is too small (the llama.cpp
+		// contract) so we exercise the resize+retry path.
+		llama_token_to_piece: vi.fn(
+			(
+				_vocab: number,
+				token: number,
+				bufPtr: number,
+				length: number,
+				_lstrip: number,
+				_special: boolean,
+			) => {
+				const bytes = pieces.get(token) ?? new Uint8Array();
+				if (bytes.length > length) return -bytes.length;
+				const buf = ptrToBuf.get(bufPtr);
+				if (buf) buf.set(bytes.subarray(0, length));
+				return bytes.length;
+			},
+		),
+		llama_sampler_chain_add: vi.fn(),
+		llama_sampler_init_temp: vi.fn().mockReturnValue(10),
+		llama_sampler_init_top_p: vi.fn().mockReturnValue(11),
+		llama_sampler_init_top_k: vi.fn().mockReturnValue(12),
+		llama_sampler_init_dist: vi.fn().mockReturnValue(13),
+		llama_sampler_init_greedy: vi.fn().mockReturnValue(14),
+		llama_sampler_sample: vi.fn(),
+		llama_sampler_accept: vi.fn(),
+		llama_sampler_free: vi.fn(),
+		llama_state_seq_save_file: vi.fn().mockReturnValue(1),
+		llama_state_seq_load_file: vi.fn().mockReturnValue(1),
+	};
+
+	const shim = {
+		eliza_llama_model_params_default: vi.fn().mockReturnValue(20),
+		eliza_llama_model_params_free: vi.fn(),
+		eliza_llama_model_params_set_n_gpu_layers: vi.fn(),
+		eliza_llama_model_params_set_use_mmap: vi.fn(),
+		eliza_llama_model_params_set_use_mlock: vi.fn(),
+		eliza_llama_model_load_from_file: vi.fn().mockReturnValue(30),
+		eliza_llama_context_params_default: vi.fn().mockReturnValue(40),
+		eliza_llama_context_params_free: vi.fn(),
+		eliza_llama_context_params_set_n_ctx: vi.fn(),
+		eliza_llama_context_params_set_n_batch: vi.fn(),
+		eliza_llama_context_params_set_n_ubatch: vi.fn(),
+		eliza_llama_context_params_set_n_threads: vi.fn(),
+		eliza_llama_context_params_set_n_threads_batch: vi.fn(),
+		eliza_llama_context_params_set_embeddings: vi.fn(),
+		eliza_llama_context_params_set_offload_kqv: vi.fn(),
+		eliza_llama_init_from_model: vi.fn().mockReturnValue(50),
+		eliza_llama_sampler_chain_params_default: vi.fn().mockReturnValue(60),
+		eliza_llama_sampler_chain_params_free: vi.fn(),
+		eliza_llama_sampler_chain_init: vi.fn().mockReturnValue(70),
+		eliza_llama_batch_get_one: vi.fn(() => nextPtr++),
+		eliza_llama_batch_free: vi.fn(),
+		eliza_llama_decode: vi.fn().mockReturnValue(0),
+		eliza_llama_log_silence: vi.fn(),
+		eliza_llama_context_attach_drafter: vi.fn().mockReturnValue(0),
+		eliza_llama_context_detach_drafter: vi.fn(),
+		eliza_llama_context_has_drafter: vi.fn().mockReturnValue(0),
+		eliza_llama_context_set_spec_mode: vi.fn().mockReturnValue(0),
+		eliza_llama_decode_unified: vi.fn().mockReturnValue(0),
+		eliza_llama_mtp_stats: vi.fn(),
+	};
+
+	const adapter = new DesktopLlamaAdapter(
+		ffi as never,
+		llama as never,
+		shim as never,
+	);
+	adapter.loadModel({
+		modelPath: "/fake/model.gguf",
+		nBatch: 32,
+		nUBatch: 32,
+		threads: 1,
+	});
+
+	return { adapter, binding: adapter.createBinding(), llama };
+}
+
+function openStream(binding: ReturnType<DesktopLlamaAdapter["createBinding"]>) {
+	return binding.llmStreamOpen({
+		ctx: 50n,
+		config: {
+			maxTokens: 8,
+			temperature: 0,
+			topP: 1,
+			topK: 0,
+			repeatPenalty: 1,
+			slotId: 0,
+			promptCacheKey: null,
+			draftMin: 0,
+			draftMax: 0,
+			draftModelPath: null,
+		},
+	});
+}
+
+describe("DesktopLlamaAdapter token-to-piece decoding (#11)", () => {
+	it("reassembles a UTF-8 codepoint split across two token pieces", () => {
+		// "你" (U+4F60) is E4 BD A0. Split across two tokens: [E4], [BD A0].
+		// Per-piece decoding would yield two U+FFFD; streaming decode must
+		// reassemble it into the original character.
+		const pieces = new Map<number, Uint8Array>([
+			[101, new Uint8Array([0xe4])],
+			[102, new Uint8Array([0xbd, 0xa0])],
+		]);
+		const h = makePieceHarness(pieces);
+		// Emit token 101 then 102, then EOG to stop.
+		h.llama.llama_sampler_sample
+			.mockReturnValueOnce(101)
+			.mockReturnValueOnce(102);
+		h.llama.llama_vocab_is_eog
+			.mockReturnValueOnce(false)
+			.mockReturnValueOnce(false)
+			.mockReturnValue(true);
+
+		const stream = openStream(h.binding);
+		const step = h.binding.llmStreamNext({
+			stream,
+			maxTokensPerStep: 8,
+			maxTextBytes: 1024,
+		});
+
+		expect(step.text).toBe("你");
+		expect(step.text).not.toContain("�");
+		h.binding.llmStreamClose(stream);
+	});
+
+	it("resizes and retries on a negative return instead of dropping the piece", () => {
+		// A single piece larger than the default 256-byte buffer. The first
+		// call returns -length; the adapter must grow the buffer and retry.
+		const big = new TextEncoder().encode("z".repeat(300));
+		const pieces = new Map<number, Uint8Array>([[200, big]]);
+		const h = makePieceHarness(pieces);
+		h.llama.llama_sampler_sample.mockReturnValueOnce(200);
+		h.llama.llama_vocab_is_eog.mockReturnValueOnce(false).mockReturnValue(true);
+
+		const stream = openStream(h.binding);
+		const step = h.binding.llmStreamNext({
+			stream,
+			maxTokensPerStep: 8,
+			maxTextBytes: 4096,
+		});
+
+		expect(step.text).toBe("z".repeat(300));
+		// Called twice for the same token: small buffer (rejected), then resized.
+		const calls = h.llama.llama_token_to_piece.mock.calls.filter(
+			(c) => c[1] === 200,
+		);
+		expect(calls.length).toBe(2);
+		expect(calls[0][3]).toBe(256); // first attempt: default buffer length
+		expect(calls[1][3]).toBe(300); // retry: grown to required size
+		h.binding.llmStreamClose(stream);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/ffi-streaming-backend.ts
+++ b/plugins/plugin-local-inference/src/services/ffi-streaming-backend.ts
@@ -131,9 +131,19 @@ export class FfiStreamingBackend implements LocalInferenceBackend {
 	}
 
 	async unload(): Promise<void> {
-		this.session = null;
-		this.loadedPath = null;
-		await this.runtime.release();
+		// Await the native release BEFORE nulling our refs. If we null first and
+		// release() throws (a raw bun:ffi free can reject), this.session would be
+		// null while the runtime still holds a live session — the next load()
+		// would skip unload() and call acquire(), which throws on its live-session
+		// guard, wedging the backend until process restart. The finally guarantees
+		// our refs are cleared regardless so a failed release can't leave a stale
+		// "loaded" view either.
+		try {
+			await this.runtime.release();
+		} finally {
+			this.session = null;
+			this.loadedPath = null;
+		}
 	}
 
 	async generate(args: GenerateArgs): Promise<GenerateResult> {

--- a/plugins/plugin-local-inference/src/services/ffi-unload-ordering.test.ts
+++ b/plugins/plugin-local-inference/src/services/ffi-unload-ordering.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BackendPlan } from "./backend";
+import {
+	type FfiBackendRuntime,
+	type FfiBackendSession,
+	FfiStreamingBackend,
+} from "./ffi-streaming-backend";
+
+// Hoisted spy so the mock factory (also hoisted) and the test can share it.
+const adapterMock = vi.hoisted(() => ({
+	close: vi.fn(() => {
+		throw new Error("llama_backend_free segfault surrogate");
+	}),
+}));
+
+// Replace the FFI adapter module entirely so importing it never pulls bun:ffi
+// or dlopens a native library. desktop-ffi-backend-runtime.ts only value-imports
+// `loadDesktopLlama` + `desktopLlamaDylibsPresent`, so those are all we stub.
+vi.mock("./desktop-llama-adapter", () => ({
+	desktopLlamaDylibsPresent: () => true,
+	loadDesktopLlama: vi.fn(async () => ({
+		binding: {},
+		ctx: {},
+		adapter: {
+			close: adapterMock.close,
+			tokenize: () => new Int32Array(),
+			loadedDrafterPath: () => null,
+			parallelSlots: () => 1,
+		},
+	})),
+}));
+
+/**
+ * Tests for #14: unload() must await the native release BEFORE nulling the
+ * session refs, otherwise a throwing release leaves the backend wedged —
+ * session === null while the runtime still holds a live session, so the next
+ * load() skips unload(), calls acquire(), and acquire()'s live-session guard
+ * throws forever.
+ */
+
+const PLAN: BackendPlan = {
+	modelPath: "/fake/model.gguf",
+} as unknown as BackendPlan;
+
+function fakeSession(): FfiBackendSession {
+	return {
+		binding: {} as never,
+		ctx: {} as never,
+		runner: {} as never,
+		tokenize: () => new Int32Array(),
+		mtp: null,
+		draftModelPath: null,
+		mmprojPath: null,
+	};
+}
+
+/**
+ * Minimal runtime that mirrors the real acquire/release live-session guard:
+ * acquire() throws if a session is already live (exactly like
+ * DesktopFfiBackendRuntime). release() can be made to throw to simulate a
+ * native bun:ffi free rejecting.
+ */
+class GuardedRuntime implements FfiBackendRuntime {
+	private active = false;
+	releaseShouldThrow = false;
+	releaseCalls = 0;
+
+	supported(): boolean {
+		return true;
+	}
+
+	async acquire(): Promise<FfiBackendSession> {
+		if (this.active) {
+			throw new Error("acquire() called with a live session; release() first");
+		}
+		this.active = true;
+		return fakeSession();
+	}
+
+	async release(): Promise<void> {
+		this.releaseCalls += 1;
+		if (this.releaseShouldThrow) {
+			// The runtime still has a live session — a real release that throws
+			// mid-free leaves `active` set (the runtime's own finally is what
+			// clears it; here we model the throw-before-clear case).
+			throw new Error("native free rejected");
+		}
+		this.active = false;
+	}
+}
+
+describe("FfiStreamingBackend.unload() ordering (#14)", () => {
+	it("nulls session refs even when release() throws", async () => {
+		const runtime = new GuardedRuntime();
+		const backend = new FfiStreamingBackend(runtime);
+		await backend.load(PLAN);
+		expect(backend.hasLoadedModel()).toBe(true);
+
+		runtime.releaseShouldThrow = true;
+		await expect(backend.unload()).rejects.toThrow("native free rejected");
+
+		// The finally must have cleared our refs despite the throw, so the
+		// backend doesn't report a phantom loaded model.
+		expect(backend.hasLoadedModel()).toBe(false);
+		expect(backend.currentModelPath()).toBeNull();
+	});
+
+	it("awaits release before nulling refs (release observed first)", async () => {
+		const order: string[] = [];
+		const runtime: FfiBackendRuntime = {
+			supported: () => true,
+			acquire: async () => fakeSession(),
+			release: vi.fn(async () => {
+				order.push("release");
+			}),
+		};
+		const backend = new FfiStreamingBackend(runtime);
+		await backend.load(PLAN);
+		await backend.unload();
+		// hasLoadedModel reads session, which is nulled only after release.
+		order.push(backend.hasLoadedModel() ? "still-loaded" : "cleared");
+		expect(order).toEqual(["release", "cleared"]);
+	});
+});
+
+describe("DesktopFfiBackendRuntime.release() ordering (#14)", () => {
+	it("clears the active session even when adapter.close() throws", async () => {
+		const { DesktopFfiBackendRuntime } = await import(
+			"./desktop-ffi-backend-runtime"
+		);
+		const runtime = new DesktopFfiBackendRuntime();
+		await runtime.acquire(PLAN);
+
+		// close() throws, but release() must still clear `active` via its finally.
+		await expect(runtime.release()).rejects.toThrow(
+			"llama_backend_free segfault surrogate",
+		);
+		expect(adapterMock.close).toHaveBeenCalledTimes(1);
+
+		// Proof the runtime is NOT wedged: a fresh acquire() must NOT hit the
+		// "live session; release() first" guard.
+		await expect(runtime.acquire(PLAN)).resolves.toBeDefined();
+	});
+});


### PR DESCRIPTION
## What
#8 (Windows FFI backend default): In desktop-llama-adapter.ts resolveDesktopBinDir(), the runtime default backend for non-darwin/non-linux platforms was "cpu", so Windows probed local-inference/bin/llama-cpp/windows-x86_64-cpu/ while the build script (packages/app-core/scripts/build-llama-cpp-desktop-dylib.mjs line 157 + outDir at 274 using t.backend) stages dylibs under windows-x86_64-vulkan. Changed the default to `platform === "darwin" ? "metal" : "vulkan"` so Windows resolves to vulkan and the in-process FFI fast-path is found. Confirmed the build hardcodes vulkan for windows and that even ELIZA_DESKTOP_BACKEND=cuda still writes -vulkan, so vulkan is the only correct runtime default short of also changing the build's outDir scheme (out of scope for this S fix).

#13 (switchTo rollback): In active-model.ts, extracted the load logic into a private performLoad() (no state mutation) and rewrote switchTo() to snapshot the previously-ready model (new private lastReady field: installed+overrides+state) before the unload-then-load. On load failure it now re-loads the prior model and reports it as "ready"; only when there is no prior model or the restore also fails does it set status "error" with modelId null (per the fixSketch — this is a deliberate behavior change: the error state no longer attributes a phantom requested id). lastReady is cleared on deliberate unload() so a later failed switch won't resurrect an intentionally-unloaded model.

#14 (FFI unload ordering): In ffi-streaming-backend.ts FfiStreamingBackend.unload() now awaits runtime.release() first and nulls this.session/this.loadedPath in a finally, so a throwing native free can't leave the backend wedged (session null but runtime still live → next acquire() throws forever). Applied the symmetric fix in desktop-ffi-backend-runtime.ts DesktopFfiBackendRuntime.release(): adapter.close() is wrapped so this.active is cleared in a finally.

#11 (token_to_piece decoding): In desktop-llama-adapter.ts added a per-session persistent streaming TextDecoder (pieceDecoder field, initialized in openSession) and a tokenToText() helper that (a) on a negative llama_token_to_piece return grows pieceBuf to the required size and retries instead of dropping the piece, and (b) decodes via decode(bytes,{stream:true}) so multi-byte UTF-8 codepoints split across token boundaries reassemble instead of becoming U+FFFD. Replaced both call sites (nextStep and nextStepMtp) and removed the now-unused decodeCStringBytes helper.

## Confirmed findings implemented
#8, #13, #14, #11

## Testing (in-sandbox; full suites run in CI)
- **typecheck:** PASS for changed files. Ran `bun run --cwd plugins/plugin-local-inference typecheck` (tsgo project-wide). Zero errors reference any of my 4 changed source files or 3 new test files (verified by grep). The command does surface many pre-existing errors in UNRELATED packages (packages/agent, plugins/plugin-wallet, plugins/plugin-workflow: missing viem, drizzle-orm, @elizaos/plugin-* etc.) — these stem from the borrowed honesty-detectors node_modules symlink not containing those deps, not from my changes.
- **tests:** PASS. Ran `bun x vitest run` (canary) on all new + related existing tests: 5 files / 14 tests pass — active-model-switch-rollback.test.ts (3), desktop-llama-piece-decode.test.ts (2: split-UTF-8 reassembly to "你", and negative-return resize/retry recovering a 300-byte piece with calls at buffer length 256 then 300), ffi-unload-ordering.test.ts (3: refs cleared despite throwing release, release-before-null ordering, and DesktopFfiBackendRuntime not wedged when close() throws), plus the 2 pre-existing files (desktop-llama-adapter.test.ts, service.test.ts) — no regressions. NOTE: the borrowed node_modules was missing @elizaos/core's logger dep tree (adze/fast-redact/handlebars/...); even the pre-existing tests could not run until I (a) symlinked packages/core/node_modules to milady/dist/node_modules and (b) ran the core prebuild keyword generator (node packages/shared/scripts/generate-keywords.mjs --target ts) to produce the required generated file. Both are git-ignored, in my own worktree, and not part of the commit.
- **biome:** PASS. Ran `node_modules/.bin/biome check --write` then a final read-only `biome check` on all 7 files: "Checked 7 files. No fixes applied." Clean.

## Risk
- Worktree was created from origin/develop but landed at HEAD 696a5c4939 (chore: preserve local formatting changes), not the 5f70793a3c referenced in the findings; all four code sites matched the evidence exactly, so the delta is irrelevant to these fixes.
- #13 is a deliberate, finding-mandated behavior change: a failed switch now reports modelId:null (not the requested id) on the error path. Any consumer that read state.modelId from an "error" state to identify the attempted model would see null instead. Tests assert the new behavior; this matches the fixSketch and is the honest representation (nothing is loaded).
- #13 restore semantics: lastReady stores the InstalledModel + overrides and re-runs the same unload-then-load to restore. The restore itself does an unloadModel() first (idempotent, the failed load already tore the old model down) and then re-loads the known-good model. If the loader's own unloadModel throws during restore, it's caught and falls through to the error/modelId-null state.
- #11 streaming decoder: the per-session TextDecoder persists across nextStep calls so codepoints split across step boundaries also reassemble. The only edge case is a stream truncated mid-codepoint at true end-of-generation — those trailing bytes stay buffered and are dropped, which is strictly no worse than the prior U+FFFD/drop behavior (llama.cpp normally emits complete codepoints over a full generation).
- #11 resize path: pieceBuf grows to -wrote and is retained for the session (one-way grow); a pathological vocab with very large pieces would keep the bigger buffer, which is fine. A still-negative return after resize now throws an actionable error rather than silently dropping.
- Tests for #11/#13/#14 are unit-level against mocks/harnesses (no native bun:ffi or real GGUF). They verify the exact code paths changed; they do not exercise a real llama.cpp load. The #8 fix has no added test (pure default-value change in a path-resolution helper) but is verified by reading the build script's hardcoded windows vulkan target and outDir scheme.
- Environment scaffolding I added to make ANY vitest runnable in this borrowed-node_modules setup (packages/core/node_modules symlink → milady/dist/node_modules; generated i18n keyword files under packages/{core,shared}/src/i18n/generated/) is git-ignored and NOT in the commit; it lives only in my worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
