### PR TITLE
fix(security): ComputerUse smart-approve default + MCP flag-injection hardening

### DIFF
--- a/packages/agent/src/security/mcp-server-config.ts
+++ b/packages/agent/src/security/mcp-server-config.ts
@@ -6,6 +6,10 @@
 import { lookup as dnsLookup } from "node:dns/promises";
 import net from "node:net";
 import {
+  BLOCKED_SPAWN_ENV_KEYS,
+  BLOCKED_SPAWN_ENV_PREFIXES,
+} from "@elizaos/core";
+import {
   isBlockedPrivateOrLinkLocalIp,
   normalizeHostLike,
 } from "./network-policy.ts";
@@ -40,41 +44,11 @@ const ALLOWED_MCP_COMMANDS = new Set([
   "podman",
 ]);
 
-const BLOCKED_MCP_ENV_KEYS = new Set([
-  "LD_PRELOAD",
-  "LD_LIBRARY_PATH",
-  "DYLD_INSERT_LIBRARIES",
-  "DYLD_LIBRARY_PATH",
-  "NODE_OPTIONS",
-  "NODE_EXTRA_CA_CERTS",
-  "NODE_TLS_REJECT_UNAUTHORIZED",
-  "HTTP_PROXY",
-  "HTTPS_PROXY",
-  "ALL_PROXY",
-  "NO_PROXY",
-  "NODE_PATH",
-  "SSL_CERT_FILE",
-  "SSL_CERT_DIR",
-  "CURL_CA_BUNDLE",
-  "PATH",
-  "HOME",
-  "SHELL",
-]);
-
-const BLOCKED_MCP_ENV_PREFIXES = [
-  "NPM_CONFIG_",
-  "PNPM_",
-  "YARN_",
-  "BUN_CONFIG_",
-  "UV_",
-  "PIP_",
-  "PIPX_",
-  "PYX_",
-  "DENO_",
-  "DOCKER_",
-  "PODMAN_",
-  "BASH_FUNC_",
-] as const;
+// The env denylist is a single source of truth shared with the shell/spawn
+// path. The canonical lists (BLOCKED_SPAWN_ENV_KEYS / BLOCKED_SPAWN_ENV_PREFIXES)
+// are imported from @elizaos/core and referenced inside the functions below at
+// call time (never captured at module-init) to stay robust against ESM
+// circular-import load ordering through the core barrel.
 
 const INTERPRETER_MCP_COMMANDS = new Set([
   "node",
@@ -115,25 +89,44 @@ const BLOCKED_CONTAINER_FLAGS = new Set([
   "--privileged",
   "-v",
   "--volume",
+  "--volumes-from",
   "--mount",
   "--cap-add",
   "--security-opt",
   "--pid",
   "--network",
   "--device",
+  "--device-cgroup-rule",
   "--ipc",
   "--uts",
   "--userns",
   "--cgroupns",
 ]);
 const BLOCKED_DENO_SUBCOMMANDS = new Set(["eval"]);
+// deno's capability sandbox is opt-out via these flags; block them so a stdio
+// MCP config cannot grant the spawned deno process host access (-A / --allow-*),
+// load unstable APIs, or disable its security prompts.
+const BLOCKED_DENO_FLAGS = new Set([
+  "-A",
+  "--allow-all",
+  "--allow-run",
+  "--allow-ffi",
+  "--allow-read",
+  "--allow-write",
+  "--allow-net",
+  "--allow-env",
+  "--allow-sys",
+  "--allow-import",
+  "--no-prompt",
+]);
+const BLOCKED_DENO_FLAG_PREFIXES = ["--unstable"] as const;
 const BLOCKED_MCP_REMOTE_HOST_LITERALS = new Set([
   "localhost",
   "metadata.google.internal",
 ]);
 
 function blockedMcpEnvPrefix(upperKey: string): string | null {
-  for (const prefix of BLOCKED_MCP_ENV_PREFIXES) {
+  for (const prefix of BLOCKED_SPAWN_ENV_PREFIXES) {
     if (upperKey.startsWith(prefix)) {
       return prefix;
     }
@@ -146,7 +139,7 @@ function rejectMcpEnvEntry(key: string, value: string): string | null {
     return `env key "${key}" is blocked for security reasons`;
   }
   const upper = key.toUpperCase();
-  if (BLOCKED_MCP_ENV_KEYS.has(upper)) {
+  if (BLOCKED_SPAWN_ENV_KEYS.has(upper)) {
     return `env variable "${key}" is not allowed for security reasons`;
   }
   const prefix = blockedMcpEnvPrefix(upper);
@@ -191,6 +184,37 @@ function firstPositionalArg(args: string[]): string | null {
     const trimmed = arg.trim();
     if (!trimmed || trimmed === "--" || trimmed.startsWith("-")) continue;
     return trimmed.toLowerCase();
+  }
+  return null;
+}
+
+function hasBlockedFlagPrefix(
+  args: string[],
+  blockedPrefixes: readonly string[],
+): string | null {
+  for (const arg of args) {
+    const trimmed = arg.trim().toLowerCase();
+    for (const prefix of blockedPrefixes) {
+      if (trimmed === prefix || trimmed.startsWith(`${prefix}-`)) {
+        return prefix;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Return the first positional arg that looks like an http(s) URL so deno `run`
+ * remote scripts get routed through the SSRF/private-IP guard like remote
+ * transport configs do.
+ */
+function firstRemoteUrlPositionalArg(args: string[]): string | null {
+  for (const arg of args) {
+    const trimmed = arg.trim();
+    if (!trimmed || trimmed === "--" || trimmed.startsWith("-")) continue;
+    if (/^https?:\/\//i.test(trimmed)) {
+      return trimmed;
+    }
   }
   return null;
 }
@@ -309,6 +333,22 @@ export async function validateMcpServerConfig(
         const subcommand = firstPositionalArg(args);
         if (subcommand && BLOCKED_DENO_SUBCOMMANDS.has(subcommand)) {
           return `Subcommand "${subcommand}" is not allowed for deno MCP servers`;
+        }
+        const blockedDenoFlag = hasBlockedFlag(args, BLOCKED_DENO_FLAGS);
+        if (blockedDenoFlag) {
+          return `Flag "${blockedDenoFlag}" is not allowed for deno MCP servers`;
+        }
+        const blockedDenoFlagPrefix = hasBlockedFlagPrefix(
+          args,
+          BLOCKED_DENO_FLAG_PREFIXES,
+        );
+        if (blockedDenoFlagPrefix) {
+          return `Flag "${blockedDenoFlagPrefix}" is not allowed for deno MCP servers`;
+        }
+        const remoteUrlArg = firstRemoteUrlPositionalArg(args);
+        if (remoteUrlArg) {
+          const urlRejection = await resolveMcpRemoteUrlRejection(remoteUrlArg);
+          if (urlRejection) return urlRejection;
         }
       }
     }

--- a/packages/agent/test/api/server-helpers-mcp.test.ts
+++ b/packages/agent/test/api/server-helpers-mcp.test.ts
@@ -124,3 +124,103 @@ describe("validateMcpServerConfig env hardening (GHSA-54rx-pcr9-hg9x)", () => {
     ).toBeNull();
   });
 });
+
+describe("validateMcpServerConfig container flag hardening", () => {
+  it("blocks docker host-escape flags beyond the first positional arg", async () => {
+    expect(
+      await validateMcpServerConfig(
+        stdioConfig(
+          "docker",
+          ["run", "--rm", "--device-cgroup-rule=c *:* rwm", "img"],
+          {},
+        ),
+      ),
+    ).toMatch(/--device-cgroup-rule.*not allowed/i);
+
+    expect(
+      await validateMcpServerConfig(
+        stdioConfig("docker", ["run", "--volumes-from", "other", "img"], {}),
+      ),
+    ).toMatch(/--volumes-from.*not allowed/i);
+  });
+
+  it("still blocks the pre-existing privileged/volume flags", async () => {
+    expect(
+      await validateMcpServerConfig(
+        stdioConfig("podman", ["run", "--privileged", "img"], {}),
+      ),
+    ).toMatch(/--privileged.*not allowed/i);
+    expect(
+      await validateMcpServerConfig(
+        stdioConfig("docker", ["run", "-v", "/:/host", "img"], {}),
+      ),
+    ).toMatch(/-v.*not allowed/i);
+  });
+
+  it("allows a benign docker run config", async () => {
+    expect(
+      await validateMcpServerConfig(
+        stdioConfig("docker", ["run", "--rm", "-i", "my-mcp-image"], {}),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("validateMcpServerConfig deno permission-escape hardening", () => {
+  it("blocks deno allow-all / capability flags anywhere in the args", async () => {
+    expect(
+      await validateMcpServerConfig(
+        stdioConfig("deno", ["run", "-A", "./server.ts"], {}),
+      ),
+    ).toMatch(/-A.*not allowed for deno/i);
+
+    expect(
+      await validateMcpServerConfig(
+        stdioConfig("deno", ["run", "--allow-all", "./server.ts"], {}),
+      ),
+    ).toMatch(/--allow-all.*not allowed for deno/i);
+
+    expect(
+      await validateMcpServerConfig(
+        stdioConfig("deno", ["run", "--allow-run=sh", "./server.ts"], {}),
+      ),
+    ).toMatch(/--allow-run.*not allowed for deno/i);
+  });
+
+  it("blocks deno --unstable* flag family", async () => {
+    expect(
+      await validateMcpServerConfig(
+        stdioConfig("deno", ["run", "--unstable-ffi", "./server.ts"], {}),
+      ),
+    ).toMatch(/--unstable.*not allowed for deno/i);
+  });
+
+  it("routes deno remote run scripts through the SSRF guard", async () => {
+    expect(
+      await validateMcpServerConfig(
+        stdioConfig("deno", ["run", "http://127.0.0.1/evil.ts"], {}),
+      ),
+    ).toMatch(/blocked for security reasons|resolves to blocked/i);
+    expect(
+      await validateMcpServerConfig(
+        stdioConfig("deno", ["run", "https://localhost/evil.ts"], {}),
+      ),
+    ).toMatch(/blocked for security reasons/i);
+  });
+
+  it("still blocks the deno eval subcommand", async () => {
+    expect(
+      await validateMcpServerConfig(
+        stdioConfig("deno", ["eval", "console.log(1)"], {}),
+      ),
+    ).toMatch(/eval.*not allowed for deno/i);
+  });
+
+  it("allows a benign local deno run config", async () => {
+    expect(
+      await validateMcpServerConfig(
+        stdioConfig("deno", ["run", "./mcp-server.ts"], {}),
+      ),
+    ).toBeNull();
+  });
+});

--- a/packages/core/src/security/index.ts
+++ b/packages/core/src/security/index.ts
@@ -41,6 +41,8 @@ export {
 	type SecretsRedactOptions,
 } from "./redact.js";
 export {
+	BLOCKED_SPAWN_ENV_KEYS,
+	BLOCKED_SPAWN_ENV_PREFIXES,
 	isBlockedSpawnEnvKey,
 	sanitizeSpawnEnv,
 } from "./spawn-env-policy.js";

--- a/packages/core/src/security/spawn-env-policy.ts
+++ b/packages/core/src/security/spawn-env-policy.ts
@@ -3,7 +3,12 @@
  * Shared by shell, MCP, and other spawn paths.
  */
 
-const BLOCKED_SPAWN_ENV_KEYS = new Set([
+/**
+ * Single source of truth for the spawn/MCP env denylist. Consumers that need
+ * the raw data (e.g. the agent's MCP config validator) import these directly so
+ * the lists cannot drift between the shell/spawn and MCP paths.
+ */
+export const BLOCKED_SPAWN_ENV_KEYS: ReadonlySet<string> = new Set([
 	"LD_PRELOAD",
 	"LD_LIBRARY_PATH",
 	"DYLD_INSERT_LIBRARIES",
@@ -24,7 +29,7 @@ const BLOCKED_SPAWN_ENV_KEYS = new Set([
 	"SHELL",
 ]);
 
-const BLOCKED_SPAWN_ENV_PREFIXES = [
+export const BLOCKED_SPAWN_ENV_PREFIXES = [
 	"NPM_CONFIG_",
 	"PNPM_",
 	"YARN_",

--- a/plugins/plugin-computeruse/AGENTS.md
+++ b/plugins/plugin-computeruse/AGENTS.md
@@ -162,7 +162,7 @@ All read via `runtime.getSetting()` / `process.env`. Declared in `package.json#a
 | `COMPUTER_USE_ENABLED` | boolean | `false` | No | Master toggle; also controls `autoEnable` |
 | `COMPUTER_USE_SCREENSHOT_AFTER_ACTION` | boolean | `true` | No | Auto-capture screenshot after each desktop action |
 | `COMPUTER_USE_ACTION_TIMEOUT_MS` | number | `10000` | No | Per-action timeout in ms |
-| `COMPUTER_USE_APPROVAL_MODE` | enum | `"full_control"` | No | `full_control` / `smart_approve` / `approve_all` / `off` |
+| `COMPUTER_USE_APPROVAL_MODE` | enum | `"smart_approve"` | No | `full_control` / `smart_approve` / `approve_all` / `off` |
 | `COMPUTER_USE_BROWSER_HEADLESS` | boolean | `false` | No | Headless browser (useful in CI) |
 | `ELIZA_COMPUTERUSE_DRIVER` | enum | `"nutjs"` | No | Input driver: `nutjs` (@nut-tree-fork/nut-js) or `legacy` (cliclick/xdotool/PowerShell) |
 
@@ -197,7 +197,7 @@ Call the module-level `registerCoordOcrProvider(provider)` exported from `src/mo
 
 ## Conventions / gotchas
 
-- **Approval flow**: every destructive action passes through `ComputerUseApprovalManager`. The default mode is `full_control` (auto-approve). Switch to `smart_approve` or `approve_all` via env or the `/api/computer-use/approval-mode` route. `off` denies all.
+- **Approval flow**: every destructive action passes through `ComputerUseApprovalManager`. The default mode is `smart_approve` — only read-only `SAFE_COMMANDS` auto-approve, and destructive verbs (terminal execute, file write/delete) require explicit human approval. Switch to `full_control` (auto-approve everything), `approve_all`, or `off` (deny all) via env or the `/api/computer-use/approval-mode` route.
 - **`browser_execute` is always disabled** (GHSA-rcvr-766c-4phv) — `isBrowserExecuteAllowed()` returns `false` unconditionally; no setting re-enables it. Use `dom`, `clickables`, `click`, `type`, `navigate`, `screenshot` browser subactions instead.
 - **Coordinate system**: each display has its own local coordinate space. `src/platform/coords.ts` translates local→global when needed. Always pass `displayId` when targeting a specific monitor.
 - **nutjs native bindings**: `@nut-tree-fork/nut-js` requires native compilation. If the build fails, set `ELIZA_COMPUTERUSE_DRIVER=legacy` to fall back to shell tools.

--- a/plugins/plugin-computeruse/CLAUDE.md
+++ b/plugins/plugin-computeruse/CLAUDE.md
@@ -162,7 +162,7 @@ All read via `runtime.getSetting()` / `process.env`. Declared in `package.json#a
 | `COMPUTER_USE_ENABLED` | boolean | `false` | No | Master toggle; also controls `autoEnable` |
 | `COMPUTER_USE_SCREENSHOT_AFTER_ACTION` | boolean | `true` | No | Auto-capture screenshot after each desktop action |
 | `COMPUTER_USE_ACTION_TIMEOUT_MS` | number | `10000` | No | Per-action timeout in ms |
-| `COMPUTER_USE_APPROVAL_MODE` | enum | `"full_control"` | No | `full_control` / `smart_approve` / `approve_all` / `off` |
+| `COMPUTER_USE_APPROVAL_MODE` | enum | `"smart_approve"` | No | `full_control` / `smart_approve` / `approve_all` / `off` |
 | `COMPUTER_USE_BROWSER_HEADLESS` | boolean | `false` | No | Headless browser (useful in CI) |
 | `ELIZA_COMPUTERUSE_DRIVER` | enum | `"nutjs"` | No | Input driver: `nutjs` (@nut-tree-fork/nut-js) or `legacy` (cliclick/xdotool/PowerShell) |
 
@@ -197,7 +197,7 @@ Call the module-level `registerCoordOcrProvider(provider)` exported from `src/mo
 
 ## Conventions / gotchas
 
-- **Approval flow**: every destructive action passes through `ComputerUseApprovalManager`. The default mode is `full_control` (auto-approve). Switch to `smart_approve` or `approve_all` via env or the `/api/computer-use/approval-mode` route. `off` denies all.
+- **Approval flow**: every destructive action passes through `ComputerUseApprovalManager`. The default mode is `smart_approve` — only read-only `SAFE_COMMANDS` auto-approve, and destructive verbs (terminal execute, file write/delete) require explicit human approval. Switch to `full_control` (auto-approve everything), `approve_all`, or `off` (deny all) via env or the `/api/computer-use/approval-mode` route.
 - **`browser_execute` is always disabled** (GHSA-rcvr-766c-4phv) — `isBrowserExecuteAllowed()` returns `false` unconditionally; no setting re-enables it. Use `dom`, `clickables`, `click`, `type`, `navigate`, `screenshot` browser subactions instead.
 - **Coordinate system**: each display has its own local coordinate space. `src/platform/coords.ts` translates local→global when needed. Always pass `displayId` when targeting a specific monitor.
 - **nutjs native bindings**: `@nut-tree-fork/nut-js` requires native compilation. If the build fails, set `ELIZA_COMPUTERUSE_DRIVER=legacy` to fall back to shell tools.

--- a/plugins/plugin-computeruse/package.json
+++ b/plugins/plugin-computeruse/package.json
@@ -74,7 +74,7 @@
         "type": "string",
         "description": "Approval mode for computer-use commands: full_control auto-approves everything, smart_approve auto-approves safe read-only commands, approve_all requires approval for every command, off denies all commands.",
         "required": false,
-        "default": "full_control",
+        "default": "smart_approve",
         "enum": [
           "full_control",
           "smart_approve",

--- a/plugins/plugin-computeruse/src/__tests__/security-hardening.test.ts
+++ b/plugins/plugin-computeruse/src/__tests__/security-hardening.test.ts
@@ -1,0 +1,140 @@
+import os from "node:os";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ComputerUseApprovalManager } from "../approval-manager.js";
+import { sanitizeChildEnv, validateFilePath } from "../platform/security.js";
+
+describe("validateFilePath credential blocklist (cross-home)", () => {
+  it("blocks SSH keys under any user's home, not just the current home", () => {
+    expect(validateFilePath("/root/.ssh/id_rsa", "read").allowed).toBe(false);
+    expect(
+      validateFilePath("/home/otheruser/.ssh/id_rsa", "read").allowed,
+    ).toBe(false);
+    expect(
+      validateFilePath("/home/otheruser/.aws/credentials", "read").allowed,
+    ).toBe(false);
+  });
+
+  it("blocks credential files under the current home for reads", () => {
+    const home = os.homedir().replace(/\\/g, "/");
+    expect(validateFilePath(`${home}/.aws/credentials`, "read").allowed).toBe(
+      false,
+    );
+    expect(validateFilePath(`${home}/.netrc`, "read").allowed).toBe(false);
+  });
+
+  it("allows benign files in a home directory", () => {
+    expect(validateFilePath("/home/otheruser/notes.txt", "read").allowed).toBe(
+      true,
+    );
+  });
+});
+
+describe("validateFilePath system-dir read protection (unix)", () => {
+  const original = process.platform;
+
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: original });
+  });
+
+  it("blocks reads of /etc/shadow and other auth config", () => {
+    const result = validateFilePath("/etc/shadow", "read");
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toMatch(/system auth config/i);
+  });
+
+  it("blocks reads of /proc, /sys, and /dev", () => {
+    expect(validateFilePath("/proc/1/environ", "read").allowed).toBe(false);
+    expect(validateFilePath("/sys/kernel/notes", "read").allowed).toBe(false);
+    expect(validateFilePath("/dev/sda", "read").allowed).toBe(false);
+  });
+
+  it("still allows reads outside system dirs", () => {
+    expect(validateFilePath("/tmp/output.txt", "read").allowed).toBe(true);
+  });
+});
+
+describe("sanitizeChildEnv provider-key stripping", () => {
+  const saved: Record<string, string | undefined> = {};
+  const keys = [
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "OPENROUTER_API_KEY",
+    "GROQ_API_KEY",
+    "XAI_API_KEY",
+    "DISCORD_API_TOKEN",
+    "TELEGRAM_BOT_TOKEN",
+    "AWS_SECRET_ACCESS_KEY",
+    "ELIZA_SECRET_KEY",
+    "SOME_HARMLESS_VALUE",
+  ];
+
+  beforeEach(() => {
+    for (const k of keys) {
+      saved[k] = process.env[k];
+    }
+    process.env.ANTHROPIC_API_KEY = "sk-ant-test";
+    process.env.OPENAI_API_KEY = "sk-test";
+    process.env.OPENROUTER_API_KEY = "or-test";
+    process.env.GROQ_API_KEY = "gsk-test";
+    process.env.XAI_API_KEY = "xai-test";
+    process.env.DISCORD_API_TOKEN = "discord-test";
+    process.env.TELEGRAM_BOT_TOKEN = "tg-test";
+    process.env.AWS_SECRET_ACCESS_KEY = "aws-test";
+    process.env.ELIZA_SECRET_KEY = "eliza-test";
+    process.env.SOME_HARMLESS_VALUE = "keep-me";
+  });
+
+  afterEach(() => {
+    for (const k of keys) {
+      if (saved[k] === undefined) {
+        delete process.env[k];
+      } else {
+        process.env[k] = saved[k];
+      }
+    }
+  });
+
+  it("strips provider/connector API keys from the child env", () => {
+    const env = sanitizeChildEnv();
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.OPENROUTER_API_KEY).toBeUndefined();
+    expect(env.GROQ_API_KEY).toBeUndefined();
+    expect(env.XAI_API_KEY).toBeUndefined();
+    expect(env.DISCORD_API_TOKEN).toBeUndefined();
+    expect(env.TELEGRAM_BOT_TOKEN).toBeUndefined();
+    expect(env.AWS_SECRET_ACCESS_KEY).toBeUndefined();
+    expect(env.ELIZA_SECRET_KEY).toBeUndefined();
+  });
+
+  it("keeps harmless env values", () => {
+    const env = sanitizeChildEnv();
+    expect(env.SOME_HARMLESS_VALUE).toBe("keep-me");
+  });
+});
+
+describe("ComputerUseApprovalManager default mode", () => {
+  it("defaults to smart_approve and requires approval for destructive verbs", () => {
+    // Force loadConfig to keep the default by failing the file read.
+    vi.spyOn(
+      ComputerUseApprovalManager.prototype as unknown as {
+        loadConfig: () => void;
+      },
+      "loadConfig",
+    ).mockImplementation(() => {});
+    const manager = new ComputerUseApprovalManager();
+    expect(manager.getMode()).toBe("smart_approve");
+    // Read-only safe command auto-approves.
+    expect(manager.shouldAutoApprove("screenshot")).toBe(true);
+    expect(manager.shouldAutoApprove("file_read")).toBe(true);
+    // Destructive verbs are NOT auto-approved by default.
+    expect(manager.shouldAutoApprove("execute_command")).toBe(false);
+    expect(manager.shouldAutoApprove("file_delete")).toBe(false);
+    expect(manager.shouldAutoApprove("file_write")).toBe(false);
+    vi.restoreAllMocks();
+  });
+});

--- a/plugins/plugin-computeruse/src/approval-manager.ts
+++ b/plugins/plugin-computeruse/src/approval-manager.ts
@@ -54,7 +54,7 @@ export function isApprovalMode(value: string): value is ApprovalMode {
 }
 
 export class ComputerUseApprovalManager {
-  private mode: ApprovalMode = "full_control";
+  private mode: ApprovalMode = "smart_approve";
   private pending = new Map<string, PendingApprovalRecord>();
   private listeners = new Set<ApprovalListener>();
   private readonly configPath = path.join(

--- a/plugins/plugin-computeruse/src/platform/security.ts
+++ b/plugins/plugin-computeruse/src/platform/security.ts
@@ -102,7 +102,10 @@ const STRIP_PATTERN_ENV: RegExp[] = [
   /^SUPABASE_.*(?:SERVICE_ROLE|SECRET)/i,
   /^STRIPE_.*(?:SECRET|WEBHOOK)/i,
   /^ELIZA_.*(?:SECRET|KEY|TOKEN)/i,
-  /^ELIZA_.*(?:SECRET|KEY|TOKEN)/i,
+  // LLM provider + connector credentials must not leak into spawned commands.
+  /^(?:ANTHROPIC|OPENAI|OPENROUTER|GROQ|XAI|GOOGLE|GEMINI|GOOGLE_GENERATIVE_AI|ELEVENLABS|DEEPGRAM|MISTRAL|COHERE|DISCORD|TELEGRAM|SLACK|FARCASTER|TWITTER|AWS)_.*(?:KEY|TOKEN|SECRET|PASSWORD)/i,
+  // Catch-all for credential-suffixed keys from any other provider/connector.
+  /_(?:API_KEY|SECRET|TOKEN|PASSWORD|PRIVATE_KEY)$/i,
 ];
 
 const DANGEROUS_COMMAND_PATTERNS: DangerousPattern[] = [
@@ -151,6 +154,39 @@ const DANGEROUS_COMMAND_PATTERNS: DangerousPattern[] = [
   },
 ];
 
+/**
+ * Build the set of "home-relative" candidate strings a credential pattern is
+ * tested against. The anchored CREDENTIAL_PATTERNS (e.g. `^/.ssh/...`) expect a
+ * path with the home root stripped, so we strip the agent's own home plus any
+ * `/root` or `/home/<user>` prefix. The full normalized path is always included
+ * so the non-anchored browser-store patterns continue to match anywhere.
+ */
+function credentialRelativePaths(normalized: string): string[] {
+  const candidates = new Set<string>([normalized]);
+
+  const home = os.homedir().replace(/\\/g, "/");
+  if (home && normalized.startsWith(`${home}/`)) {
+    candidates.add(normalized.slice(home.length));
+  }
+
+  // /root/... and /home/<user>/... — strip the home root so reads of other
+  // users' (and root's) credential files are caught regardless of os.homedir().
+  const otherHomeMatch = normalized.match(
+    /^\/root(?=\/)|^\/home\/[^/]+(?=\/)/i,
+  );
+  if (otherHomeMatch) {
+    candidates.add(normalized.slice(otherHomeMatch[0].length));
+  }
+
+  // /Users/<user>/... (macOS) home root.
+  const macHomeMatch = normalized.match(/^\/Users\/[^/]+(?=\/)/i);
+  if (macHomeMatch) {
+    candidates.add(normalized.slice(macHomeMatch[0].length));
+  }
+
+  return [...candidates];
+}
+
 export function validateFilePath(
   filePath: string,
   operation: "read" | "write" | "delete",
@@ -197,11 +233,11 @@ export function validateFilePath(
     }
   }
 
-  const home = os.homedir().replace(/\\/g, "/");
-  const relativeToHome = normalized.startsWith(`${home}/`)
-    ? normalized.slice(home.length)
-    : null;
-  if (relativeToHome) {
+  // Evaluate credential patterns against the path relative to ANY user's home
+  // (the agent's own home, /root, and /home/<user>), not just the current home,
+  // so reads of e.g. /root/.ssh/id_rsa or /home/other/.aws/credentials are
+  // still blocked. The anchored patterns expect a "/.ssh/..." style suffix.
+  for (const relativeToHome of credentialRelativePaths(normalized)) {
     for (const { pattern, label } of CREDENTIAL_PATTERNS) {
       if (pattern.test(relativeToHome)) {
         return {
@@ -212,18 +248,30 @@ export function validateFilePath(
     }
   }
 
-  if (operation !== "read") {
-    const patterns =
-      process.platform === "win32"
-        ? SYSTEM_DIR_PATTERNS_WIN32
-        : SYSTEM_DIR_PATTERNS_UNIX;
-
-    for (const { pattern, label } of patterns) {
+  // Sensitive UNIX system paths (/etc/shadow, /proc, /sys, /dev, …) are blocked
+  // for EVERY operation, including reads, so they cannot be exfiltrated via a
+  // read. The Windows program-directory patterns stay write/delete-only because
+  // reading config/log files there is a legitimate use case.
+  if (process.platform !== "win32") {
+    for (const { pattern, label } of SYSTEM_DIR_PATTERNS_UNIX) {
       if (pattern.test(normalized)) {
         return {
           allowed: false,
           reason: `Blocked: cannot ${operation} in ${label}.`,
         };
+      }
+    }
+  }
+
+  if (operation !== "read") {
+    if (process.platform === "win32") {
+      for (const { pattern, label } of SYSTEM_DIR_PATTERNS_WIN32) {
+        if (pattern.test(normalized)) {
+          return {
+            allowed: false,
+            reason: `Blocked: cannot ${operation} in ${label}.`,
+          };
+        }
       }
     }
 

--- a/plugins/plugin-computeruse/src/services/computer-use-service.ts
+++ b/plugins/plugin-computeruse/src/services/computer-use-service.ts
@@ -190,7 +190,7 @@ export class ComputerUseService extends Service {
     screenshotAfterAction: true,
     actionTimeoutMs: 10000,
     maxRecentActions: MAX_RECENT_ACTIONS,
-    approvalMode: "full_control",
+    approvalMode: "smart_approve",
     browserHeadless: false,
     mode: "yolo",
   };


### PR DESCRIPTION
## What
#27 (ComputerUse approval default full_control -> smart_approve): changed the default ApprovalMode in approval-manager.ts:57 (now smart_approve), computer-use-service.ts cuConfig.approvalMode (line 193), and package.json pluginParameters default for COMPUTER_USE_APPROVAL_MODE. With smart_approve only the read-only SAFE_COMMANDS auto-approve; destructive verbs (execute_command, file_delete, file_write) now require explicit human approval. Also synced the plugin CLAUDE.md/AGENTS.md (config table + Approval flow gotcha) to the new default.

#25 (Docker/Podman host-escape flag gaps): added --device-cgroup-rule (defeats the --device block) and --volumes-from (defeats the -v block) to BLOCKED_CONTAINER_FLAGS in mcp-server-config.ts. hasBlockedFlag already scans every arg, so these are caught beyond the first positional.

#28 (deno permission-escape flags + remote-URL): added a deno-specific BLOCKED_DENO_FLAGS set (-A, --allow-all, --allow-run, --allow-ffi, --allow-read/write/net/env/sys, --allow-import, --no-prompt), a --unstable* prefix block via new hasBlockedFlagPrefix(), and routing of deno `run` http(s) positional args through resolveMcpRemoteUrlRejection (SSRF/private-IP guard) via new firstRemoteUrlPositionalArg(). deno eval subcommand block is preserved.

#31 (credential/system-dir blocklist scope): credential patterns are now evaluated against the path relative to ANY user's home via new credentialRelativePaths() (strips os.homedir(), /root, /home/<user>, /Users/<user>), so reads of /root/.ssh/id_rsa and /home/other/.aws/credentials are blocked. The sensitive UNIX system-dir patterns (/etc/shadow, /proc, /sys, /dev, ...) and filesystem-root checks now apply to read ops too, not just write/delete. Windows program-dir patterns stay write/delete-only to avoid over-blocking legitimate config/log reads.

#26 (dedupe spawn-env denylist): exported the canonical BLOCKED_SPAWN_ENV_KEYS / BLOCKED_SPAWN_ENV_PREFIXES from @elizaos/core security (spawn-env-policy.ts + security/index.ts barrel) and made the agent's mcp-server-config.ts import and reference them at call time (inside rejectMcpEnvEntry/blockedMcpEnvPrefix), deleting the private byte-identical 18-key/12-prefix copy. Single source of truth, no drift.

#29 (duplicate dead regex in STRIP_PATTERN_ENV): replaced the duplicate /^ELIZA_.*(SECRET|KEY|TOKEN)/i line with the intended provider/connector credential patterns (ANTHROPIC|OPENAI|OPENROUTER|GROQ|XAI|GOOGLE|GEMINI|ELEVENLABS|DEEPGRAM|DISCORD|TELEGRAM|SLACK|AWS|... + a _(API_KEY|SECRET|TOKEN|PASSWORD|PRIVATE_KEY)$ catch-all), so provider API keys are stripped from the env of spawned terminal commands.

## Confirmed findings implemented
#27, #25, #28, #31, #26, #29

## Testing (in-sandbox; full suites run in CI)
- **typecheck:** Could NOT run the package-level `bun run typecheck` (tsgo) cleanly: the shared symlinked node_modules is only partially populated (drizzle-orm, adze, uuid, handlebars, @noble/*, etc. live under node_modules/.bun/node_modules and are not hoisted to the top level), so `packages/core` typecheck reports ~25 pre-existing TS2307 'Cannot find module' errors UNRELATED to my changes. Additionally `@elizaos/core` resolves through the symlink to a DIFFERENT, stale worktree (eliza-honesty-detectors) that lacks my new exports. As the allowed fallback I typechecked the changed files in isolation with `bun x tsc --noEmit --strict --skipLibCheck` (nodenext): packages/core/src/security/spawn-env-policy.ts -> 0 errors; plugin-computeruse security.ts + approval-manager.ts (with @types/node) -> 0 errors; agent mcp-server-config.ts + network-policy.ts (with a typed d.ts stub matching the two new core exports) -> 0 errors. All my changed files are type-clean; the package-suite failures are environmental only.
- **tests:** plugin-computeruse: ran `bun x vitest run` on the new security-hardening.test.ts plus existing security-file-target/browser-execute-security/browser-script-policy tests -> 13/13 passed. New suite covers cross-home credential blocking (/root, /home/other), /etc/shadow + /proc/sys/dev read blocking, provider/connector API-key stripping in sanitizeChildEnv, and the smart_approve default (safe cmds auto-approve, execute_command/file_delete/file_write do not). agent MCP validator: the committed server-helpers-mcp.test.ts could not load via its normal import path because server-helpers-mcp.ts transitively imports the wallet keygen (@noble/curves) and logger (adze, fast-redact) which are missing from the partial shared node_modules, AND @elizaos/core resolves to the stale honesty-detectors worktree. I verified my actual logic with a TEMPORARY direct-import test (importing validateMcpServerConfig straight from src/security/mcp-server-config.ts, with @elizaos/core stubbed to my worktree's leaf spawn-env-policy.ts to avoid the heavy logger deps): 3/3 passed — covering env-denylist via the shared core constants (LD_PRELOAD, NPM_CONFIG_ prefix, DOCKER_ prefix, benign allowed), container --device-cgroup-rule/--volumes-from blocked + benign docker run allowed, and deno -A/--allow-run/--unstable-*/remote-127.0.0.1-url/eval blocked + benign local run allowed. That temp test and its temp vitest config were removed after the run; the committed test (server-helpers-mcp.test.ts, +5 new container/deno cases) exercises the same canonical path and will pass in a fully-installed environment.
- **biome:** Ran `node_modules/.bin/biome check --write` then a final `biome check` (no write) on all 9 changed source/test files + package.json -> all clean, no fixes needed on re-check. The only diagnostic is one PRE-EXISTING warning (noUnusedPrivateClassMembers on captureScreenshotBase64 in computer-use-service.ts at line 1438) that is unrelated to my 1-line approvalMode edit in that file. security.ts was auto-reformatted by biome (cosmetic line-wrapping of a regex match, no semantic change).

## Risk
1) ENV LIMITATION (not code): the shared node_modules symlink points at the eliza-honesty-detectors worktree, which is on an older commit and is only partially populated (.bun-only deps not hoisted). This blocked the package-level typecheck and the agent MCP test from running through their normal paths. I verified all changed code via isolated tsc and direct-import vitest runs instead; honest about it above. 2) BEHAVIOR CHANGE (intended) #31: sensitive UNIX system dirs now block READS too. The fixSketch said to move the whole SYSTEM_DIR_PATTERNS_UNIX set out of the read guard, which I did — this means reads under /usr/lib, /usr/sbin, /sbin, /boot, /System are now also blocked, slightly broader than just /etc/shadow|/proc|/sys|/dev. This is more restrictive (safer) but could break an agent legitimately reading e.g. a file under /usr/lib; acceptable per the security-first intent and the OWNER-gated/opt-in nature of the plugin. I kept Windows program-dir reads allowed to avoid over-blocking. 3) #29 regex: the exact provider-key pattern is a judgment call (the original was a verbatim copy-paste bug); I used a broad provider/connector list + a credential-suffix catch-all. The catch-all /_(API_KEY|SECRET|TOKEN|PASSWORD|PRIVATE_KEY)$/i could strip an unrelated user env var ending in those suffixes from spawned terminal commands — that is the intended security posture (strip rather than leak) but is worth noting. 4) #26: mcp-server-config now imports two constants from @elizaos/core; I deliberately reference them inside functions (call time) rather than module-init to avoid ESM circular-import ordering issues, and verified the env denylist still works end-to-end against the real shared constants. 5) No push / no PR performed, per instructions; branch is 1 commit ahead of origin/develop. Generated i18n files (validation-keyword-data.*) were created to attempt the agent test run but are gitignored and were NOT committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
