### PR TITLE
fix(persistence): atomic localdb flush, PGlite lock release+staleness, RLS param, vault key zeroize

### DIFF
--- a/packages/vault/src/pglite-vault.ts
+++ b/packages/vault/src/pglite-vault.ts
@@ -333,6 +333,14 @@ export class PgliteVaultImpl implements Vault {
 
   /** Close the underlying PGlite connection. Tests + graceful shutdown only. */
   async close(): Promise<void> {
+    // Zero and drop the cached plaintext master key so it does not stay
+    // resident for the rest of the process lifetime. Defense-in-depth only:
+    // V8's GC may have copied the Buffer, so this cannot guarantee full
+    // scrubbing, but it removes the long-lived live reference.
+    if (this.cachedKey) {
+      this.cachedKey.fill(0);
+      this.cachedKey = null;
+    }
     if (!this.dbPromise) return;
     const db = await this.dbPromise;
     this.dbPromise = null;

--- a/packages/vault/test/pglite-vault.test.ts
+++ b/packages/vault/test/pglite-vault.test.ts
@@ -55,6 +55,24 @@ describe("PgliteVaultImpl", () => {
     );
   });
 
+  it("close zeroes the cached master key", async () => {
+    // inMemoryMasterKey.load() returns the same Buffer the vault caches, so a
+    // fill(0) on close is observable on the buffer this test holds a ref to.
+    const keyBuf = generateMasterKey();
+    const v = new PgliteVaultImpl({
+      dataDir: join(workDir, ".vault-pglite-zero"),
+      masterKey: inMemoryMasterKey(keyBuf),
+      auditPath: join(workDir, "audit", "vault.jsonl"),
+    });
+    // Touch a sensitive value so the master key is loaded + cached.
+    await v.set("k", "secret", { sensitive: true });
+    expect(await v.get("k")).toBe("secret");
+    expect(keyBuf.some((b) => b !== 0)).toBe(true);
+
+    await v.close();
+    expect(keyBuf.every((b) => b === 0)).toBe(true);
+  });
+
   it("has returns true/false correctly", async () => {
     expect(await vault.has("k")).toBe(false);
     await vault.set("k", "v");

--- a/plugins/plugin-localdb/index.ts
+++ b/plugins/plugin-localdb/index.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import type {
   IAgentRuntime,
@@ -24,6 +24,7 @@ class FileStorage implements IStorage {
   private collections = new Map<string, Map<string, unknown>>();
   private ready = false;
   private readonly filePath: string;
+  private writeChain: Promise<void> = Promise.resolve();
 
   constructor(dataDir: string) {
     this.filePath = join(dataDir, "localdb.json");
@@ -62,11 +63,29 @@ class FileStorage implements IStorage {
   }
 
   private async flush(): Promise<void> {
+    // Serialize all flushes through a single chained promise so independently
+    // scheduled async mutations cannot interleave writes to the same file.
+    // Snapshot the live data at enqueue time so the write reflects state at
+    // the moment this mutation completed.
     const out: Record<string, Record<string, unknown>> = {};
     for (const [collection, entries] of this.collections) {
       out[collection] = Object.fromEntries(entries);
     }
-    await writeFile(this.filePath, JSON.stringify(out, null, 2), "utf8");
+    const payload = JSON.stringify(out, null, 2);
+
+    const run = this.writeChain.then(() => this.writeAtomic(payload));
+    // Keep the chain alive even if a write rejects, so a single failure does
+    // not permanently break serialization for subsequent flushes.
+    this.writeChain = run.catch(() => {});
+    await run;
+  }
+
+  private async writeAtomic(payload: string): Promise<void> {
+    // Write to a sibling temp file then rename for an atomic replace, so a
+    // crash mid-write can never truncate or garble the live localdb.json.
+    const tmpPath = `${this.filePath}.tmp.${process.pid}`;
+    await writeFile(tmpPath, payload, "utf8");
+    await rename(tmpPath, this.filePath);
   }
 
   async get<T>(collection: string, id: string): Promise<T | null> {

--- a/plugins/plugin-sql/src/__tests__/integration/postgres/pglite-manager-lock.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/postgres/pglite-manager-lock.real.test.ts
@@ -1,9 +1,11 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { PGLITE_ERROR_CODES } from "../../../pglite/errors";
 import { PGliteClientManager } from "../../../pglite/manager";
+
+const lockPathFor = (dataDir: string) => path.join(dataDir, "eliza-pglite.lock");
 
 describe("PGliteClientManager file lock", () => {
   const tempDirs: string[] = [];
@@ -34,5 +36,42 @@ describe("PGliteClientManager file lock", () => {
 
     const second = new PGliteClientManager({ dataDir });
     await second.close();
+  });
+
+  it("reclaims a stale lock whose recorded createdAt is older than the staleness window", async () => {
+    // Simulate a hard crash that left a lock recording THIS process's PID
+    // (the PID-reuse worst case) but an ancient createdAt. The liveness probe
+    // sees the PID alive, so without staleness checking it would falsely brick
+    // boot. The createdAt window must let a fresh manager reclaim it.
+    const dataDir = mkdtempSync(path.join(tmpdir(), "eliza-pglite-lock-"));
+    tempDirs.push(dataDir);
+
+    const ancientCreatedAt = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+    writeFileSync(
+      lockPathFor(dataDir),
+      `${JSON.stringify({ pid: process.pid, createdAt: ancientCreatedAt, dataDir })}\n`
+    );
+
+    const manager = new PGliteClientManager({ dataDir });
+    await manager.close();
+  });
+
+  it("reclaims a lock owned by a non-running PID", async () => {
+    const dataDir = mkdtempSync(path.join(tmpdir(), "eliza-pglite-lock-"));
+    tempDirs.push(dataDir);
+
+    // PID that cannot exist on Linux/macOS (above the configured pid_max).
+    writeFileSync(
+      lockPathFor(dataDir),
+      `${JSON.stringify({
+        pid: 2_147_483_646,
+        createdAt: new Date().toISOString(),
+        dataDir,
+      })}\n`
+    );
+
+    const manager = new PGliteClientManager({ dataDir });
+    await manager.close();
+    expect(existsSync(lockPathFor(dataDir))).toBe(false);
   });
 });

--- a/plugins/plugin-sql/src/__tests__/integration/postgres/rls-entity.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/postgres/rls-entity.real.test.ts
@@ -16,10 +16,12 @@ import { bootstrapPostgresRlsSchema, toPostgresSuperuserUrl } from "./rls-test-h
  * - Entity-level isolation (user privacy)
  * - Participant-based access control (room membership)
  * - Entity RLS works with Server RLS (double isolation)
- * - withEntityContext() correctly sets entity context (regression test for sql.raw fix)
+ * - withEntityContext() correctly sets entity context (regression test for the
+ *   parameterized set_config() RLS context)
  *
  * IMPORTANT: Uses PostgresConnectionManager.withEntityContext() to test the actual
- * production code path. This ensures the Drizzle sql.raw() fix is tested (no $1 error).
+ * production code path. This exercises the parameterized set_config('app.entity_id', $1, true)
+ * form (transaction-scoped), so the entity context applies without raw interpolation.
  */
 
 // Skip these tests if POSTGRES_URL is not set (e.g., in CI without PostgreSQL)

--- a/plugins/plugin-sql/src/pg/manager.ts
+++ b/plugins/plugin-sql/src/pg/manager.ts
@@ -104,7 +104,11 @@ export class PostgresConnectionManager {
         }
 
         try {
-          await tx.execute(sql.raw(`SET LOCAL app.entity_id = '${entityId}'`));
+          // Use parameterized set_config() (transaction-scoped via is_local=true)
+          // instead of string-interpolated SET LOCAL, matching the Neon adapter.
+          // SET LOCAL cannot take a bind parameter; set_config() can, removing
+          // the only interpolated SQL in the RLS path.
+          await tx.execute(sql`SELECT set_config('app.entity_id', ${entityId}, true)`);
           logger.debug(`[Entity Context] Set app.entity_id = ${entityId}`);
         } catch (error) {
           const errorMessage = error instanceof Error ? error.message : String(error);

--- a/plugins/plugin-sql/src/pglite/manager.ts
+++ b/plugins/plugin-sql/src/pglite/manager.ts
@@ -23,6 +23,12 @@ type PglitePidFileStatus =
   | "check-failed";
 
 export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
+  // A lock whose PID is alive but whose recorded createdAt is older than this
+  // window is treated as stale (likely PID reuse), so a recycled PID cannot
+  // permanently brick boot. 7 days comfortably exceeds any real session while
+  // still bounding the false-positive blast radius.
+  private static readonly LOCK_STALE_MS = 7 * 24 * 60 * 60 * 1000;
+
   private client: PGlite;
   private options: PGliteOptions;
   private shuttingDown = false;
@@ -34,8 +40,17 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
   constructor(options: PGliteOptions) {
     this.options = options;
     this.acquireDataDirLockIfNeeded();
-    this.client = this.createClient(options);
-    this.setupShutdownHandlers();
+    try {
+      this.client = this.createClient(options);
+      this.setupShutdownHandlers();
+    } catch (err) {
+      // If client creation (WASM/FS init) throws, no reference to this manager
+      // escapes the constructor, so close() can never run. Release the data-dir
+      // lock here so the open fd and on-disk lock file don't leak — otherwise a
+      // same-process retry would self-deadlock on its own (still-running) PID.
+      this.releaseDataDirLock();
+      throw err;
+    }
   }
 
   public getConnection(): PGlite {
@@ -120,23 +135,52 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
     return `${dataDir}/eliza-pglite.lock`;
   }
 
-  private getLockPid(lockPath: string): number | null {
+  private getLockInfo(lockPath: string): { pid: number | null; createdAt: number | null } {
     try {
       const raw = readFileSync(lockPath, "utf-8");
-      const parsed = JSON.parse(raw) as { pid?: unknown };
-      return typeof parsed.pid === "number" && parsed.pid > 0 ? parsed.pid : null;
+      const parsed = JSON.parse(raw) as { pid?: unknown; createdAt?: unknown };
+      const pid = typeof parsed.pid === "number" && parsed.pid > 0 ? parsed.pid : null;
+      const createdAtMs = typeof parsed.createdAt === "string" ? Date.parse(parsed.createdAt) : NaN;
+      const createdAt = Number.isNaN(createdAtMs) ? null : createdAtMs;
+      return { pid, createdAt };
     } catch {
-      return null;
+      return { pid: null, createdAt: null };
     }
   }
 
-  private isPidRunning(pid: number): boolean {
+  /**
+   * Decide whether an existing lock should be honored as held by a live owner.
+   * A bare `process.kill(pid, 0)` liveness probe is vulnerable to PID reuse:
+   * on Linux a recycled PID owned by an unrelated process makes a stale lock
+   * look active and can falsely brick boot. To harden this we only honor the
+   * lock when the PID is confirmed running AND the recorded creation time is
+   * recent (within LOCK_STALE_MS). An older lock — or one whose liveness we
+   * cannot positively confirm (EPERM and other non-ESRCH errors, which a
+   * recycled cross-user PID produces) — is treated as stale and reclaimed.
+   */
+  private isLockActive(pid: number, createdAt: number | null): boolean {
+    // ESRCH => definitely gone. Anything else (EPERM, etc.) cannot positively
+    // confirm the PID belongs to a live Eliza process (a recycled cross-user
+    // PID produces EPERM), so do not treat it as active.
+    let running = false;
     try {
       process.kill(pid, 0);
-      return true;
-    } catch (err) {
-      return (err as NodeJS.ErrnoException).code !== "ESRCH";
+      running = true;
+    } catch {
+      running = false;
     }
+    if (!running) {
+      return false;
+    }
+
+    // A confirmed-running PID could still be a recycled, unrelated process.
+    // Ignore locks older than the staleness window so an aliased PID cannot
+    // permanently block boot. Missing/unparseable createdAt is treated as
+    // stale (legacy/corrupt lock) rather than blocking indefinitely.
+    if (createdAt === null) {
+      return false;
+    }
+    return Date.now() - createdAt < PGliteClientManager.LOCK_STALE_MS;
   }
 
   private acquireDataDirLockIfNeeded(): void {
@@ -167,8 +211,8 @@ export class PGliteClientManager implements IDatabaseClientManager<PGlite> {
           throw this.createActiveLockError(dataDir, err);
         }
 
-        const pid = this.getLockPid(lockPath);
-        if (pid && this.isPidRunning(pid)) {
+        const { pid, createdAt } = this.getLockInfo(lockPath);
+        if (pid && this.isLockActive(pid, createdAt)) {
           throw this.createActiveLockError(
             dataDir,
             new Error(`PGlite lock file is held by running process ${pid}`)


### PR DESCRIPTION
## What
Implemented all 5 assigned persistence findings as minimal, style-matched diffs. #39 plugin-localdb: FileStorage.flush() now writes to a sibling temp file + atomic rename, and serializes all flushes through a single chained promise (chain kept alive on rejection) so crashes/concurrency can't corrupt localdb.json. #42 plugin-sql/pglite: constructor wraps client creation in try/catch that calls releaseDataDirLock() and rethrows, closing the leaked fd + removing the lock file so a same-process retry no longer self-deadlocks. #41 plugin-sql/pglite: replaced the bare process.kill(pid,0) liveness check with isLockActive(pid,createdAt) — a lock is only honored when the PID is confirmed running AND createdAt is within a 7-day staleness window; EPERM/non-ESRCH and missing/old createdAt are treated as stale and reclaimed (removed now-dead getLockPid/isPidRunning helpers). #43 plugin-sql/pg: swapped raw-interpolated `SET LOCAL app.entity_id='${entityId}'` for the parameterized `set_config('app.entity_id', ${entityId}, true)` form already used by the Neon adapter, eliminating the only interpolated SQL in the RLS path (still behind the unconditional validateUuid gate). #44 vault: close() now fills(0) and nulls the cached master-key Buffer before closing PGlite. Added regression tests for the vault key-zeroing and PGlite stale-lock reclamation.

## Confirmed findings implemented
#39, #42, #41, #43, #44

## Testing (in-sandbox; full suites run in CI)
- **typecheck:** UNVERIFIED (environmental). `bun run --cwd plugins/plugin-sql typecheck` fails ONLY with TS2307 "Cannot find module" for @elizaos/core, drizzle-orm, dotenv, etc. The symlinked node_modules (eliza-honesty-detectors) is a partial install missing drizzle-orm/dotenv and lacks built workspace dist for @elizaos/core, so no full typecheck or tsc-on-file is possible here. The changes are type-safe by inspection: pg/manager.ts uses the same drizzle `sql` tagged-template already used by neon/manager.ts with the validated UUID string; pglite/manager.ts is pure Node fs/process logic with a new {pid,createdAt} helper and a number constant; vault uses Buffer.fill(0) + null on an existing `Buffer|null` field.
- **tests:** PARTIAL PASS. (1) Vault: `bun x vitest run test/pglite-vault.test.ts` => 23/23 pass, including the new "close zeroes the cached master key" test (verbose output confirms it ran). (2) localdb #39: package has no test runner ("test":"echo No tests", no vitest config) and its workspace dep @elizaos/plugin-inmemorydb is unresolvable here, so no in-repo unit test could be added; validated the exact atomic+serialized flush algorithm via a faithful standalone bun script — 200 overlapping writes produced valid JSON, all 200 keys present, zero leftover .tmp files. (3) plugin-sql lock tests (#41/#42): the new + existing real.test.ts cannot run here (vitest config excludes **/*.real.test.ts, and even forced runs fail to load @elizaos/core under vite); validated the patched lock seam via a faithful standalone bun script — all 6 assertions pass: throw-in-constructor releases lock + same-process retry succeeds (#42), stale old-createdAt live-PID lock reclaimed, fresh live lock still honored, dead-PID lock reclaimed (#41). Added committed regression tests to pglite-manager-lock.real.test.ts that will run in CI where deps resolve.
- **biome:** PASS. `biome check --write` then `biome check` (no-write) on all 7 changed files: "Checked 7 files. No fixes applied." Two files were auto-formatted during the --write pass (pglite/manager.ts, pglite-manager-lock.real.test.ts) and committed in their formatted form.

## Risk
Behavioral notes: (#39) all flushes share one temp path `localdb.json.tmp.<pid>`, which is collision-free precisely BECAUSE writes are serialized (only one writeAtomic runs at a time); the snapshot is taken at enqueue time so ordering matches mutation completion. (#41) chose a 7-day createdAt staleness window — a confirmed-live, freshly-created lock is still honored, preserving the existing "rejects a second manager" test contract; the only behavior change is that an old lock whose PID happens to be alive (PID-reuse case) is now reclaimed instead of bricking boot. The reconcilePglitePidFile path (separate postmaster.pid safeguard) was left untouched per finding scope. (#43) functionally equivalent to SET LOCAL (transaction-scoped via is_local=true); updated the rls-entity.real.test.ts header comment that referenced the old sql.raw approach. (#44) defense-in-depth only — V8 GC may retain copies; after close() a subsequent secret read transparently re-loads the key (no regression). Main caveat: package typecheck and the plugin-sql real.test.ts suite could not be executed in this sandbox due to a partial/symlinked node_modules missing drizzle-orm/dotenv and unbuilt workspace dist; correctness was instead confirmed via faithful standalone runtime reproductions of each seam (all passed) plus the runnable vault vitest suite (23/23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
