### PR TITLE
fix(core,sql): honor getMemories limit, dedupe long-term recall, fact metadata

### DIFF
--- a/packages/core/src/features/advanced-memory/providers/long-term-memory.ts
+++ b/packages/core/src/features/advanced-memory/providers/long-term-memory.ts
@@ -7,7 +7,10 @@ import type {
 	State,
 } from "../../../types/index.ts";
 import { addHeader } from "../../../utils.ts";
-import type { MemoryService } from "../services/memory-service.ts";
+import {
+	formatLongTermMemories,
+	type MemoryService,
+} from "../services/memory-service.ts";
 import { logAdvancedMemoryTrajectory } from "../trajectory.ts";
 
 const MAX_LONG_TERM_MEMORY_TEXT_LENGTH = 5000;
@@ -75,8 +78,11 @@ export const longTermMemoryProvider: Provider = {
 				};
 			}
 
-			const formattedMemories =
-				await memoryService.getFormattedLongTermMemories(entityId);
+			// Format from the already-fetched memories rather than re-querying
+			// (getFormattedLongTermMemories would trigger a second identity-cluster
+			// fan-out, with a mismatched limit). This keeps memoryCount and the
+			// rendered text in agreement.
+			const formattedMemories = formatLongTermMemories(memories);
 			const trimmedFormattedMemories =
 				formattedMemories.length > MAX_LONG_TERM_MEMORY_TEXT_LENGTH
 					? `${formattedMemories.slice(0, MAX_LONG_TERM_MEMORY_TEXT_LENGTH)}...`

--- a/packages/core/src/features/advanced-memory/services/memory-service.ts
+++ b/packages/core/src/features/advanced-memory/services/memory-service.ts
@@ -436,7 +436,15 @@ export class MemoryService extends Service {
 				),
 			)
 		).flat();
-		return memories
+		// The storage layer already expands the full identity cluster per entity,
+		// so fanning out across related entity IDs returns the same records N times.
+		// Dedupe by id so a cluster of N members yields `limit` distinct memories,
+		// not `limit` copies of the same one.
+		const deduped = new Map<UUID, LongTermMemory>();
+		for (const memory of memories) {
+			if (!deduped.has(memory.id)) deduped.set(memory.id, memory);
+		}
+		return [...deduped.values()]
 			.sort((left, right) => memoryCreatedAtMs(right) - memoryCreatedAtMs(left))
 			.slice(0, limit);
 	}
@@ -584,30 +592,39 @@ export class MemoryService extends Service {
 
 	async getFormattedLongTermMemories(entityId: UUID): Promise<string> {
 		const memories = await this.getLongTermMemories(entityId, undefined, 20);
-		if (memories.length === 0) return "";
-
-		const grouped = new Map<LongTermMemoryCategory, LongTermMemory[]>();
-		for (const memory of memories) {
-			const existing = grouped.get(memory.category);
-			if (existing) {
-				existing.push(memory);
-			} else {
-				grouped.set(memory.category, [memory]);
-			}
-		}
-
-		const sections: string[] = [];
-		for (const [category, categoryMemories] of grouped.entries()) {
-			const categoryName = category
-				.split("_")
-				.map((word: string) => word.charAt(0).toUpperCase() + word.slice(1))
-				.join(" ");
-			const items = categoryMemories.map((m) => `- ${m.content}`).join("\n");
-			sections.push(`**${categoryName}**:\n${items}`);
-		}
-
-		return sections.join("\n\n");
+		return formatLongTermMemories(memories);
 	}
+}
+
+/**
+ * Render long-term memories as a category-grouped markdown string. Pure helper
+ * so callers that already have the memories (e.g. the long-term provider) can
+ * format them without a second storage round-trip.
+ */
+export function formatLongTermMemories(memories: LongTermMemory[]): string {
+	if (memories.length === 0) return "";
+
+	const grouped = new Map<LongTermMemoryCategory, LongTermMemory[]>();
+	for (const memory of memories) {
+		const existing = grouped.get(memory.category);
+		if (existing) {
+			existing.push(memory);
+		} else {
+			grouped.set(memory.category, [memory]);
+		}
+	}
+
+	const sections: string[] = [];
+	for (const [category, categoryMemories] of grouped.entries()) {
+		const categoryName = category
+			.split("_")
+			.map((word: string) => word.charAt(0).toUpperCase() + word.slice(1))
+			.join(" ");
+		const items = categoryMemories.map((m) => `- ${m.content}`).join("\n");
+		sections.push(`**${categoryName}**:\n${items}`);
+	}
+
+	return sections.join("\n\n");
 }
 
 function cosineSimilarity(a: number[], b: number[]): number {

--- a/packages/core/src/runtime/__tests__/facts-and-relationships.test.ts
+++ b/packages/core/src/runtime/__tests__/facts-and-relationships.test.ts
@@ -269,6 +269,15 @@ describe("runFactsAndRelationshipsStage", () => {
 					source: "facts_and_relationships_stage",
 					tags: expect.arrayContaining(["fact", "extracted", "stage1"]),
 					keywords: expect.arrayContaining(["birthday", "march"]),
+					// Stage-1 facts are unverified single-message extractions: they
+					// must be classified as time-decaying `current` (not the reader's
+					// `durable` default) with explicit confidence/category/validAt so
+					// they never persist as permanent durable identity claims.
+					kind: "current",
+					category: "uncategorized",
+					confidence: 0.6,
+					verificationStatus: "self_reported",
+					validAt: expect.any(String),
 				}),
 			}),
 			"facts",

--- a/packages/core/src/runtime/facts-and-relationships.ts
+++ b/packages/core/src/runtime/facts-and-relationships.ts
@@ -7,7 +7,12 @@ import type {
 	MessageHandlerExtractedRelationship,
 } from "../types/components";
 import type { Relationship } from "../types/environment";
-import { type Memory, MemoryType } from "../types/memory";
+import {
+	type FactKind,
+	type FactVerificationStatus,
+	type Memory,
+	MemoryType,
+} from "../types/memory";
 import type { ChatMessage, JSONSchema, ToolDefinition } from "../types/model";
 import { ModelType } from "../types/model";
 import type { UUID } from "../types/primitives";
@@ -40,6 +45,14 @@ import { buildCanonicalSystemPrompt } from "./system-prompt";
 
 export const FACTS_AND_RELATIONSHIPS_TOOL_NAME =
 	"FACTS_AND_RELATIONSHIPS_VALIDATE";
+
+/**
+ * Confidence assigned to Stage-1 extracted facts. These are unverified,
+ * single-message extractions, so they sit below the reflection pass's
+ * confirmed-durable facts (0.7) and match the read-path default for
+ * unclassified facts (FACTS provider's DEFAULT_FACT_CONFIDENCE).
+ */
+const DEFAULT_STAGE_FACT_CONFIDENCE = 0.6;
 
 export const factsAndRelationshipsSchema: JSONSchema = {
 	type: "object",
@@ -470,6 +483,17 @@ async function persistFactsAndRelationships(
 							tags: ["fact", "extracted", "stage1"],
 							keywords,
 							extractedAt: Date.now(),
+							// Stage-1 extraction is a single-message, unverified pass.
+							// Classify as `current` (time-decaying) with default
+							// confidence so the read path treats these as transient
+							// claims rather than permanent durable identity facts (the
+							// reader otherwise defaults missing `kind` to `durable`).
+							// The reflection pass promotes confirmed facts to durable.
+							kind: "current" as FactKind,
+							category: "uncategorized",
+							confidence: DEFAULT_STAGE_FACT_CONFIDENCE,
+							verificationStatus: "self_reported" as FactVerificationStatus,
+							validAt: new Date().toISOString(),
 						},
 					} as Memory,
 					"facts",

--- a/plugins/plugin-sql/src/__tests__/integration/memory.real.test.ts
+++ b/plugins/plugin-sql/src/__tests__/integration/memory.real.test.ts
@@ -468,6 +468,35 @@ describe("Memory Integration Tests", () => {
       expect(secondPage.length).toBeGreaterThanOrEqual(memoryTestMemories.length);
     });
 
+    it("should apply a LIMIT clause when only `limit` is passed (not `count`)", async () => {
+      // Regression: getMemories previously only honored `count`, so callers that
+      // passed the canonical `limit` param (recent-messages provider, attachments,
+      // autonomy history, etc.) received the full unbounded result set.
+      for (const content of ["lim1", "lim2", "lim3", "lim4", "lim5"]) {
+        await adapter.createMemory(createTestMemory({ text: content }), "memories");
+      }
+
+      const limited = await adapter.getMemories({
+        roomId: testRoomId,
+        tableName: "memories",
+        limit: 2,
+      });
+      expect(limited).toHaveLength(2);
+
+      // `limit` should compose with `offset` just like `count` does.
+      const limitedWithOffset = await adapter.getMemories({
+        roomId: testRoomId,
+        tableName: "memories",
+        limit: 2,
+        offset: 2,
+      });
+      expect(limitedWithOffset).toHaveLength(2);
+      const firstIds = new Set(limited.map((m) => m.id));
+      for (const memory of limitedWithOffset) {
+        expect(firstIds.has(memory.id)).toBe(false);
+      }
+    });
+
     it("should retrieve memories with offset for pagination", async () => {
       // Create 5 test memories with known content
       const memoryContents = ["mem1", "mem2", "mem3", "mem4", "mem5"];

--- a/plugins/plugin-sql/src/base.ts
+++ b/plugins/plugin-sql/src/base.ts
@@ -1378,6 +1378,7 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
   async getMemories(params: {
     entityId?: UUID;
     agentId?: UUID;
+    limit?: number;
     count?: number;
     offset?: number;
     unique?: boolean;
@@ -1389,6 +1390,9 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
   }): Promise<Memory[]> {
     const { entityId, agentId, roomId, worldId, unique, start, end, offset } = params;
     const tableName = params.tableName;
+    // Honor either `limit` (canonical) or `count` (legacy) so callers that pass
+    // only `limit` still get a LIMIT clause applied (see IDatabaseAdapter.getMemories).
+    const effectiveLimit = params.limit ?? params.count;
 
     if (offset !== undefined && offset < 0) {
       throw new Error("offset must be a non-negative number");
@@ -1447,10 +1451,10 @@ export abstract class BaseDrizzleAdapter extends DatabaseAdapter<DrizzleDatabase
       // Apply limit and offset for pagination
       // Build query conditionally to maintain proper types
       const rows = await (async () => {
-        if (params.count && offset !== undefined && offset > 0) {
-          return baseQuery.limit(params.count).offset(offset);
-        } else if (params.count) {
-          return baseQuery.limit(params.count);
+        if (effectiveLimit && offset !== undefined && offset > 0) {
+          return baseQuery.limit(effectiveLimit).offset(offset);
+        } else if (effectiveLimit) {
+          return baseQuery.limit(effectiveLimit);
         } else if (offset !== undefined && offset > 0) {
           return baseQuery.offset(offset);
         } else {

--- a/plugins/plugin-sql/src/stores/memory.store.ts
+++ b/plugins/plugin-sql/src/stores/memory.store.ts
@@ -15,6 +15,7 @@ export class MemoryStore implements Store {
   async get(params: {
     entityId?: UUID;
     agentId?: UUID;
+    limit?: number;
     count?: number;
     offset?: number;
     unique?: boolean;
@@ -26,6 +27,9 @@ export class MemoryStore implements Store {
   }): Promise<Memory[]> {
     const { entityId, agentId, roomId, worldId, unique, start, end, offset } = params;
     const tableName = params.tableName;
+    // Honor either `limit` (canonical) or `count` (legacy) so callers that pass
+    // only `limit` still get a LIMIT clause applied (see IDatabaseAdapter.getMemories).
+    const effectiveLimit = params.limit ?? params.count;
 
     if (offset !== undefined && offset < 0) {
       throw new Error("offset must be a non-negative number");
@@ -66,10 +70,10 @@ export class MemoryStore implements Store {
         .orderBy(desc(memoryTable.createdAt), desc(memoryTable.id));
 
       const rows = await (async () => {
-        if (params.count && offset !== undefined && offset > 0) {
-          return baseQuery.limit(params.count).offset(offset);
-        } else if (params.count) {
-          return baseQuery.limit(params.count);
+        if (effectiveLimit && offset !== undefined && offset > 0) {
+          return baseQuery.limit(effectiveLimit).offset(offset);
+        } else if (effectiveLimit) {
+          return baseQuery.limit(effectiveLimit);
         } else if (offset !== undefined && offset > 0) {
           return baseQuery.offset(offset);
         }


### PR DESCRIPTION
## What
Implemented all four assigned memory-recall fixes as small, focused diffs. #56: BaseDrizzleAdapter.getMemories (base.ts) and MemoryStore.get (memory.store.ts) now add a `limit?` param and compute `effectiveLimit = params.limit ?? params.count`, applying the LIMIT clause when only `limit` is passed (matches InMemoryDatabaseAdapter). #58: MemoryService.getLongTermMemories now dedupes the per-cluster-member fan-out by memory.id before sort+slice, so an N-member identity cluster yields `limit` distinct memories instead of N copies. #59: extracted a pure exported `formatLongTermMemories(memories)` helper from getFormattedLongTermMemories; longTermMemoryProvider now formats from its single limit-25 fetch instead of triggering a second limit-20 cluster fan-out, aligning memoryCount with the rendered text. #57: the Stage-1 fact writer in facts-and-relationships.ts now sets explicit kind:"current" (time-decaying), category:"uncategorized", confidence:0.6, verificationStatus:"self_reported", and validAt, so transient single-message claims no longer persist as non-decaying durable identity facts (reader defaults missing kind to durable). Added/extended tests for #56 and #57.

## Confirmed findings implemented
#56, #58, #59, #57

## Testing (in-sandbox; full suites run in CI)
- **typecheck:** PARTIAL/ENVIRONMENTAL — `bun run --cwd packages/core typecheck` emits 54 errors, ALL of class TS2307 "Cannot find module" (uuid, ai, drizzle-orm, handlebars, adze, generated validation-keyword-data.ts, etc.) plus one cascading TS7006 in documents/llm.ts caused by the missing `ai` types. These are because the worktree's node_modules is a cross-worktree symlink (eliza-honesty-detectors) and @elizaos/contracts + the i18n generated file are unbuilt — not from my edits. ZERO errors reference any of my 7 changed files or the symbols I added (FactKind/FactVerificationStatus imports, effectiveLimit, formatLongTermMemories, dedup Map). tsc-on-changed-files would hit the same env module-resolution wall, so it adds no signal. The type shapes I used (FactMetadata fields, LongTermMemory.id) were verified by reading the type definitions.
- **tests:** PASS (unit) / BLOCKED (integration, environmental). Ran via /tmp/bun-canary/bin/bun x vitest run --no-coverage: facts-and-relationships.test.ts 13/13 passed (includes my extended #57 metadata assertions: kind=current, category=uncategorized, confidence=0.6, verificationStatus=self_reported, validAt). facts.test.ts (reader) 4/4 passed. The plugin-sql memory.real.test.ts (where I added the #56 limit-only LIMIT-clause test) could NOT be executed here: it is excluded from every configured vitest lane (*.real.test.ts) and only runs via the live-smoke harness with a built @elizaos/core; in this sandbox it fails at import with "Failed to resolve entry for package @elizaos/core" because core is unbuilt in the symlinked node_modules. My added test mirrors the adjacent count-based pagination tests exactly (same adapter API + createTestMemory helper), so it is structurally validated but UNRUN here.
- **biome:** PASS — biome check --write on all 7 changed files: "Checked 7 files. No fixes applied." (already conformant; plugin-sql uses 2-space, packages/core uses tabs, both matched).

## Risk
Low risk, but two honest caveats. (1) The #56 integration test I added is UNRUN in this sandbox (real-test lane needs a built @elizaos/core that the cross-worktree node_modules symlink does not provide); it is structurally identical to the existing count-based pagination tests in the same file, but has not actually executed green here — worth confirming in CI. (2) #58 fix choice: I deduped the flattened array by id rather than dropping the per-member fan-out entirely. Dedup is strictly safe (guarantees no duplicates regardless of whether storage expands the cluster) but keeps the N redundant DB round-trips — it fixes the correctness bug (duplicate recall) but not the secondary perf cost of the extra queries. The fixSketch offered either approach; I chose the robustly-correct one. #59 separately removes one of the two fan-outs (the perf win there is realized). (3) #57: I defaulted Stage-1 facts to kind:"current" with confidence 0.6 per the fixSketch's "default current so transient claims decay" option; this is a behavioral change to durable-store contents going forward (new Stage-1 facts now decay and rank below 0.7 reflection-confirmed durable facts). It does not retro-classify pre-existing rows, which the reader still treats as durable. typecheck could not be fully run due to environmental module-resolution failures (see typecheck field) — no errors attributable to my changes, but a clean full typecheck was not achievable in this sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
