### PR TITLE
fix(orchestrator): completion-URL SSRF guard, cred-bridge ownership, session-limit race

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -1375,4 +1375,48 @@ describe("AcpService.runHealthCheck state_lost guards", () => {
     const after = await service.getSession(id);
     expect(after?.status).toBe("errored");
   });
+
+  it("enforces ELIZA_ACP_MAX_SESSIONS atomically under concurrent spawns", async () => {
+    // Native transport: each spawn resolves to an active ("ready") session
+    // without the proc-mock dance, so we can fire many in parallel and let the
+    // check-and-reserve race. Before the fix, the limit check (list) and the
+    // insert (create) were separate awaited ops, so N concurrent spawns could
+    // all pass the check before any inserted and overshoot the cap.
+    const service = new AcpService(
+      runtime({
+        ELIZA_ACP_TRANSPORT: undefined,
+        ELIZA_ACP_MAX_SESSIONS: "2",
+      }),
+    );
+    await service.start();
+
+    const results = await Promise.allSettled(
+      Array.from({ length: 6 }, (_, i) =>
+        service.spawnSession({
+          name: `concurrent-${i}`,
+          workdir: "/tmp/acp-test",
+        }),
+      ),
+    );
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    // The cap must hold exactly: 2 succeed, the rest reject with the limit error.
+    expect(fulfilled).toHaveLength(2);
+    expect(rejected.length).toBe(4);
+    for (const r of rejected) {
+      expect((r as PromiseRejectedResult).reason).toBeInstanceOf(Error);
+      expect(((r as PromiseRejectedResult).reason as Error).message).toContain(
+        "max session limit reached",
+      );
+    }
+
+    // And the store agrees: only 2 active sessions exist.
+    const sessions = await service.listSessions();
+    const active = sessions.filter(
+      (s) =>
+        !["stopped", "errored", "completed", "cancelled"].includes(s.status),
+    );
+    expect(active).toHaveLength(2);
+  });
 });

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/bridge-routes.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/bridge-routes.test.ts
@@ -81,13 +81,23 @@ function makeAdapter(
   };
 }
 
-function makeCtx(adapter: BridgeCredentialAdapter | null): RouteContext {
+function makeCtx(
+  adapter: BridgeCredentialAdapter | null,
+  // The POST ownership gate resolves the session via acpService.getSession.
+  // Default to an active session so the existing happy-path tests pass; pass
+  // `null`/a terminal status to exercise the rejection paths.
+  sessionStatus: string | null = "running",
+): RouteContext {
+  const acpService =
+    sessionStatus === null
+      ? { getSession: () => null }
+      : { getSession: (id: string) => ({ id, status: sessionStatus }) };
   return {
     runtime: {
       getService: (name: string) =>
         name === "SubAgentCredentialBridgeAdapter" ? adapter : null,
     } as unknown as RouteContext["runtime"],
-    acpService: null,
+    acpService: acpService as unknown as RouteContext["acpService"],
     workspaceService: null,
   };
 }
@@ -159,6 +169,45 @@ describe("bridge-routes — credential bridge", () => {
     );
     expect(status()).toBe(400);
     expect((body() as { code: string }).code).toBe("invalid_credential_keys");
+  });
+
+  it("POST rejects an unknown sessionId before issuing a request", async () => {
+    const adapter = makeAdapter();
+    const req = fakeRequest({
+      method: "POST",
+      url: "/api/coding-agents/not-a-real-session/credentials/request",
+      body: { credentialKeys: ["OPENAI_API_KEY"] },
+    });
+    const { res, status, body } = fakeResponse();
+    await handleBridgeRoutes(
+      req,
+      res,
+      "/api/coding-agents/not-a-real-session/credentials/request",
+      makeCtx(adapter, null),
+    );
+    expect(status()).toBe(410);
+    expect((body() as { code: string }).code).toBe("session_not_active");
+    // The owner-facing approval flow must NOT be triggered for an unowned id.
+    expect(adapter.requestCredentials).not.toHaveBeenCalled();
+  });
+
+  it("POST rejects a terminal (stopped) session", async () => {
+    const adapter = makeAdapter();
+    const req = fakeRequest({
+      method: "POST",
+      url: "/api/coding-agents/pty-1-abc/credentials/request",
+      body: { credentialKeys: ["OPENAI_API_KEY"] },
+    });
+    const { res, status, body } = fakeResponse();
+    await handleBridgeRoutes(
+      req,
+      res,
+      "/api/coding-agents/pty-1-abc/credentials/request",
+      makeCtx(adapter, "stopped"),
+    );
+    expect(status()).toBe(410);
+    expect((body() as { code: string }).code).toBe("session_not_active");
+    expect(adapter.requestCredentials).not.toHaveBeenCalled();
   });
 
   it("GET /credentials/:key returns the value when adapter resolves ready", async () => {

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/ssrf-guard.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/ssrf-guard.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertHostAllowed,
+  assertUrlAllowed,
+  classifyIpLiteral,
+  SsrfBlockedError,
+} from "../../src/services/ssrf-guard.ts";
+
+describe("ssrf-guard — classifyIpLiteral", () => {
+  it("treats loopback IPv4 as loopback (allowed for local verification)", () => {
+    expect(classifyIpLiteral("127.0.0.1")).toBe("loopback");
+    expect(classifyIpLiteral("127.1.2.3")).toBe("loopback");
+  });
+
+  it("treats ::1 and IPv4-mapped loopback as loopback", () => {
+    expect(classifyIpLiteral("::1")).toBe("loopback");
+    expect(classifyIpLiteral("::ffff:127.0.0.1")).toBe("loopback");
+  });
+
+  it("blocks the cloud-metadata IP and link-local range", () => {
+    expect(classifyIpLiteral("169.254.169.254")).toBe("blocked");
+    expect(classifyIpLiteral("169.254.0.1")).toBe("blocked");
+  });
+
+  it("blocks RFC1918 private ranges", () => {
+    expect(classifyIpLiteral("10.0.0.1")).toBe("blocked");
+    expect(classifyIpLiteral("172.16.5.4")).toBe("blocked");
+    expect(classifyIpLiteral("172.31.255.255")).toBe("blocked");
+    expect(classifyIpLiteral("192.168.1.1")).toBe("blocked");
+  });
+
+  it("does not block public IPv4 just outside private ranges", () => {
+    expect(classifyIpLiteral("172.15.0.1")).toBe("allowed");
+    expect(classifyIpLiteral("172.32.0.1")).toBe("allowed");
+    expect(classifyIpLiteral("8.8.8.8")).toBe("allowed");
+    expect(classifyIpLiteral("1.1.1.1")).toBe("allowed");
+  });
+
+  it("blocks CGNAT, this-network, and reserved/multicast ranges", () => {
+    expect(classifyIpLiteral("0.0.0.0")).toBe("blocked");
+    expect(classifyIpLiteral("100.64.0.1")).toBe("blocked");
+    expect(classifyIpLiteral("224.0.0.1")).toBe("blocked");
+    expect(classifyIpLiteral("255.255.255.255")).toBe("blocked");
+  });
+
+  it("blocks IPv6 ULA, link-local, and metadata", () => {
+    expect(classifyIpLiteral("fd00::1")).toBe("blocked");
+    expect(classifyIpLiteral("fc00::1")).toBe("blocked");
+    expect(classifyIpLiteral("fe80::1")).toBe("blocked");
+    expect(classifyIpLiteral("fd00:ec2::254")).toBe("blocked");
+    expect(classifyIpLiteral("::")).toBe("blocked");
+  });
+
+  it("allows a public IPv6 address", () => {
+    expect(classifyIpLiteral("2606:4700:4700::1111")).toBe("allowed");
+  });
+});
+
+describe("ssrf-guard — assertHostAllowed", () => {
+  it("allows localhost without a DNS round-trip", async () => {
+    await expect(assertHostAllowed("localhost")).resolves.toBeUndefined();
+  });
+
+  it("allows a loopback IP literal", async () => {
+    await expect(assertHostAllowed("127.0.0.1")).resolves.toBeUndefined();
+  });
+
+  it("rejects the cloud-metadata IP literal", async () => {
+    await expect(assertHostAllowed("169.254.169.254")).rejects.toBeInstanceOf(
+      SsrfBlockedError,
+    );
+  });
+
+  it("rejects an RFC1918 IP literal", async () => {
+    await expect(assertHostAllowed("10.1.2.3")).rejects.toBeInstanceOf(
+      SsrfBlockedError,
+    );
+  });
+});
+
+describe("ssrf-guard — assertUrlAllowed", () => {
+  it("rejects non-http(s) protocols", async () => {
+    await expect(assertUrlAllowed("file:///etc/passwd")).rejects.toBeInstanceOf(
+      SsrfBlockedError,
+    );
+  });
+
+  it("rejects a URL pointing directly at the metadata endpoint", async () => {
+    await expect(
+      assertUrlAllowed("http://169.254.169.254/latest/meta-data/"),
+    ).rejects.toBeInstanceOf(SsrfBlockedError);
+  });
+
+  it("allows a loopback build URL", async () => {
+    await expect(
+      assertUrlAllowed("http://127.0.0.1:8080/index.html"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import type { Content, HandlerCallback, Memory } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setHostResolver } from "../../src/services/ssrf-guard.js";
 import {
   extractSubResources,
   normalizeUrlsInText,
@@ -188,6 +189,16 @@ describe("SubAgentRouter", () => {
   beforeEach(() => {
     session = makeSession();
     acp = makeAcpService(session);
+    // The SSRF guard resolves hostnames before fetching. URL-verification
+    // tests probe reserved (`*.test`) hosts against a stubbed `fetch`, which
+    // would NXDOMAIN under the real resolver. Map any non-loopback host to a
+    // public address so the guard passes and the stubbed fetch is exercised;
+    // loopback hosts are classified without DNS and need no mapping.
+    setHostResolver(async () => [{ address: "93.184.216.34" }]);
+  });
+
+  afterEach(() => {
+    setHostResolver();
   });
 
   it("posts a synthetic memory back to the origin room on task_complete", async () => {
@@ -803,6 +814,70 @@ describe("SubAgentRouter", () => {
     // first delivers, second triggers cap-exceeded notice (and stop), third is suppressed.
     expect(handleMessage).toHaveBeenCalledTimes(2);
     expect(stopSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not count cross-session-suppressed task_completes against the cap", async () => {
+    // Regression for the round-trip miscount: the counter incremented before
+    // the cross-session completion-dedupe suppression `return`, so a session
+    // whose every task_complete is absorbed (because another session already
+    // posted for the lineage) still climbed toward — and could spuriously trip
+    // — the runaway-loop cap, even though it never posted a single inbound.
+    const SESSION_ID_2 = "abcdef01-2345-6789-abcd-ef0123456789";
+    const session2 = makeSession({
+      id: SESSION_ID_2,
+      name: "demo-task-retry",
+      metadata: {
+        label: "fix-bug-42-retry",
+        roomId: ROOM,
+        worldId: WORLD,
+        userId: USER,
+        messageId: PARENT_MSG,
+        source: "telegram",
+      },
+    });
+    const stopSession = vi.fn(async () => undefined);
+    const acp2: CapturedHandler = {};
+    const service = {
+      onSessionEvent: vi.fn((handler: typeof acp2.fn) => {
+        acp2.fn = handler;
+        return () => {
+          acp2.fn = undefined;
+        };
+      }),
+      getSession: vi.fn(async (id: string) => {
+        if (id === SESSION_ID) return session;
+        if (id === SESSION_ID_2) return session2;
+        return null;
+      }),
+      listSessions: vi.fn(async () => [session, session2]),
+      stopSession,
+    };
+    // Cap of 1: a single counted round-trip would trip it.
+    const { runtime, handleMessage } = makeRuntime({
+      acp: service,
+      setting: { ACPX_SUB_AGENT_ROUND_TRIP_CAP: "1" },
+    });
+    await SubAgentRouter.start(runtime);
+
+    // Session A posts once for the lineage.
+    acp2.fn?.(SESSION_ID, "task_complete", { response: "first session done" });
+    await new Promise((r) => setImmediate(r));
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+
+    // Session B emits several DISTINCT task_completes, all absorbed by the
+    // cross-session completion dedupe. None post. With the rollback, B's count
+    // never climbs past 0, so its cap (1) is never tripped — no force-stop.
+    for (let i = 0; i < 4; i++) {
+      acp2.fn?.(SESSION_ID_2, "task_complete", {
+        response: `retry done ${i}`,
+      });
+      await new Promise((r) => setImmediate(r));
+    }
+
+    expect(handleMessage).toHaveBeenCalledTimes(1);
+    // The suppressed session must not have been force-stopped for tripping the
+    // cap on events that never posted.
+    expect(stopSession).not.toHaveBeenCalledWith(SESSION_ID_2);
   });
 
   describe("verify-retry on incomplete builds", () => {

--- a/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/bridge-routes.ts
@@ -27,6 +27,8 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { SessionInfo } from "../services/types.js";
+import { TERMINAL_SESSION_STATUSES } from "../services/types.js";
 import type { RouteContext } from "./route-utils.js";
 import { parseBody, sendJson } from "./route-utils.js";
 
@@ -106,6 +108,26 @@ function getAdapter(ctx: RouteContext): BridgeCredentialAdapter | null {
     null) as BridgeCredentialAdapter | null;
 }
 
+/**
+ * Verify the sessionId names a real, active sub-agent session owned by this
+ * parent runtime before issuing a credential request for it.
+ *
+ * Without this, the POST only gated on loopback — so ANY local process could
+ * trigger the owner-facing REQUEST_SECRET approval flow (and mint a scopedToken)
+ * for an arbitrary, attacker-chosen sessionId. Mirrors the read-only
+ * parent-context bridge's getSession/isActiveSession gate so the credential
+ * POST can only act on a session that genuinely exists and is still running.
+ */
+async function resolveActiveSession(
+  ctx: RouteContext,
+  sessionId: string,
+): Promise<SessionInfo | null> {
+  const session = (await ctx.acpService?.getSession(sessionId)) ?? null;
+  if (!session) return null;
+  if (TERMINAL_SESSION_STATUSES.has(String(session.status))) return null;
+  return session;
+}
+
 async function handlePost(
   req: IncomingMessage,
   res: ServerResponse,
@@ -118,6 +140,22 @@ async function handlePost(
       res,
       { error: "credential bridge unavailable", code: "no_adapter" },
       503,
+    );
+    return;
+  }
+  // Ownership gate: only issue a credential request for a session that is real
+  // and active in this parent runtime. Loopback alone does not prove the caller
+  // owns the session — without this, any local process could trigger the
+  // owner-facing approval flow for an arbitrary sessionId.
+  const session = await resolveActiveSession(ctx, sessionId);
+  if (!session) {
+    sendJson(
+      res,
+      {
+        error: "no active sub-agent session for this id in this parent runtime",
+        code: "session_not_active",
+      },
+      410,
     );
     return;
   }

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -157,6 +157,11 @@ export class AcpService extends Service {
   private readonly transportMode: "native" | "cli";
   private readonly defaultAgent: AgentType;
   private readonly maxSessions: number;
+  // Serializes the session-limit check-and-reserve so concurrent spawns can't
+  // each pass the limit check before any has inserted (which would overshoot
+  // ELIZA_ACP_MAX_SESSIONS). A promise-chain mutex: each reservation awaits the
+  // previous one's completion. See reserveSessionSlot.
+  private spawnReservationLock: Promise<void> = Promise.resolve();
   private readonly sessionTimeoutMs?: number;
   private readonly sessionCallbacks: SessionEventCallback[] = [];
   private readonly acpCallbacks: AcpEventCallback[] = [];
@@ -473,7 +478,6 @@ export class AcpService extends Service {
         DEFAULT_WORKDIR_ROOT,
     );
     await mkdir(workdir, { recursive: true });
-    await this.enforceSessionLimit();
 
     // Record the workspace HEAD + already-dirty files at spawn so the change
     // set captured at task_complete is scoped to exactly what this sub-agent
@@ -503,7 +507,10 @@ export class AcpService extends Service {
           }
         : opts.metadata,
     };
-    await this.store.create(session);
+    // Atomic check-and-reserve: enforces the session limit and inserts under a
+    // single mutex so concurrent spawns can't overshoot maxSessions (the old
+    // separate enforceSessionLimit()/store.create() left a read-then-act race).
+    await this.reserveSessionSlot(session);
 
     if (this.transportMode === "native") {
       const result = await this.spawnNativeSession(id, session, opts);
@@ -1795,6 +1802,36 @@ export class AcpService extends Service {
     );
     if (active.length >= this.maxSessions)
       throw new Error(`acpx max session limit reached (${this.maxSessions})`);
+  }
+
+  /**
+   * Atomically enforce the session limit and reserve the slot by inserting the
+   * session. Wrapping the check (`enforceSessionLimit`) and the insert
+   * (`store.create`) in a single mutex-guarded critical section makes them one
+   * indivisible operation, so N concurrent spawns can't all pass the limit
+   * check before any has inserted and overshoot `maxSessions`.
+   *
+   * The mutex is a promise chain: each call awaits the previous reservation's
+   * settlement (success OR failure) before running its own check+insert, so
+   * the count observed by `enforceSessionLimit` always includes every
+   * already-reserved session. Errors propagate to the caller; the chain itself
+   * never rejects (we swallow on the tail) so one failed reservation doesn't
+   * wedge the lock for later spawns.
+   */
+  private async reserveSessionSlot(session: SessionInfo): Promise<void> {
+    const previous = this.spawnReservationLock;
+    let release!: () => void;
+    this.spawnReservationLock = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    // Wait for the prior reservation to finish before observing the count.
+    await previous.catch(() => {});
+    try {
+      await this.enforceSessionLimit();
+      await this.store.create(session);
+    } finally {
+      release();
+    }
   }
 
   private async stopTrackedProcess(sessionId: string): Promise<void> {

--- a/plugins/plugin-agent-orchestrator/src/services/ssrf-guard.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/ssrf-guard.ts
@@ -1,0 +1,274 @@
+/**
+ * SSRF guard for the completion-URL verifier.
+ *
+ * The verifier in `sub-agent-router.ts` GET-probes every http(s) URL it
+ * extracts from *sub-agent narration* — model-controlled, untrusted text. A
+ * prompt-injected or compromised sub-agent can therefore steer the parent
+ * orchestrator into fetching arbitrary hosts: cloud metadata endpoints
+ * (169.254.169.254), RFC1918 internal services, link-local addresses, etc.
+ * That is server-side request forgery.
+ *
+ * This module rejects fetches whose target resolves to a non-public address,
+ * with one deliberate carve-out: *loopback* (127.0.0.0/8, ::1, `localhost`) is
+ * allowed. The verifier exists precisely to confirm a sub-agent's local build
+ * is reachable, and those builds are served on loopback — blocking it would
+ * break the feature. Everything else off the public Internet (private,
+ * link-local, ULA, carrier-grade NAT, multicast, the cloud-metadata IP) is
+ * blocked.
+ *
+ * Two attack vectors are closed:
+ *   1. Direct fetch of an internal host — `assertUrlAllowed` resolves the
+ *      hostname and rejects if *any* resolved address is in a blocked range
+ *      (so DNS rebinding to an internal IP cannot slip through).
+ *   2. Redirect-based bypass — `safeFetch` uses `redirect: "manual"` and
+ *      re-validates each hop's Location host before following it, so a public
+ *      page cannot 302 the verifier into an internal/metadata endpoint.
+ */
+
+import { lookup as dnsLookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
+const MAX_REDIRECTS = 5;
+
+/**
+ * Resolves a hostname to its addresses. Injectable so tests (which probe
+ * unresolvable reserved hostnames like `*.test` against a stubbed `fetch`) can
+ * supply a deterministic resolver without real DNS. Defaults to the system
+ * resolver. Production code never overrides this.
+ */
+export type HostResolver = (host: string) => Promise<{ address: string }[]>;
+
+let hostResolver: HostResolver = (host) => dnsLookup(host, { all: true });
+
+/** Override the DNS resolver (test seam). Pass no argument to reset. */
+export function setHostResolver(resolver?: HostResolver): void {
+  hostResolver = resolver ?? ((host) => dnsLookup(host, { all: true }));
+}
+
+/** Reason a URL was rejected; surfaced as the probe "status" string. */
+export class SsrfBlockedError extends Error {
+  readonly host: string;
+  constructor(host: string, detail: string) {
+    super(`SSRF blocked: ${detail}`);
+    this.name = "SsrfBlockedError";
+    this.host = host;
+  }
+}
+
+function parseIpv4Octets(addr: string): number[] | null {
+  const parts = addr.split(".");
+  if (parts.length !== 4) return null;
+  const octets: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const n = Number(part);
+    if (n > 255) return null;
+    octets.push(n);
+  }
+  return octets;
+}
+
+/**
+ * Is this IPv4 literal a loopback address (127.0.0.0/8)? Loopback is the one
+ * non-public range the verifier is allowed to probe.
+ */
+function isLoopbackIpv4(octets: number[]): boolean {
+  return octets[0] === 127;
+}
+
+/**
+ * Is this IPv4 literal off the public Internet (and not loopback)? Covers the
+ * IANA special-use ranges an SSRF would target: RFC1918 private, link-local
+ * (incl. the 169.254.169.254 cloud-metadata IP), CGNAT, "this network",
+ * benchmarking, documentation, multicast, and reserved/broadcast space.
+ */
+function isBlockedIpv4(octets: number[]): boolean {
+  const [a, b] = octets;
+  if (a === 0) return true; // 0.0.0.0/8 "this network"
+  if (a === 10) return true; // 10.0.0.0/8 private
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local + metadata
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
+  if (a === 192 && b === 0 && octets[2] === 0) return true; // 192.0.0.0/24
+  if (a === 192 && b === 0 && octets[2] === 2) return true; // 192.0.2.0/24 TEST-NET-1
+  if (a === 192 && b === 88 && octets[2] === 99) return true; // 6to4 relay anycast
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
+  if (a === 198 && (b === 18 || b === 19)) return true; // 198.18.0.0/15 benchmarking
+  if (a === 198 && b === 51 && octets[2] === 100) return true; // TEST-NET-2
+  if (a === 203 && b === 0 && octets[2] === 113) return true; // TEST-NET-3
+  if (a >= 224) return true; // 224.0.0.0/4 multicast + 240.0.0.0/4 reserved + 255.* broadcast
+  return false;
+}
+
+function normalizeIpv6(addr: string): string {
+  // Strip zone id (e.g. fe80::1%eth0) and lowercase.
+  return addr.split("%")[0].toLowerCase();
+}
+
+/**
+ * Is this IPv6 literal a loopback address (::1)? Also treats IPv4-mapped
+ * loopback (::ffff:127.x.x.x) as loopback.
+ */
+function isLoopbackIpv6(addr: string): boolean {
+  const norm = normalizeIpv6(addr);
+  if (norm === "::1") return true;
+  const mapped = ipv4MappedAddress(norm);
+  if (mapped) {
+    const octets = parseIpv4Octets(mapped);
+    return octets ? isLoopbackIpv4(octets) : false;
+  }
+  return false;
+}
+
+/** Extract the embedded IPv4 from an IPv4-mapped/compat IPv6 address. */
+function ipv4MappedAddress(addr: string): string | null {
+  const m = addr.match(/^::(?:ffff:)?(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  return m ? m[1] : null;
+}
+
+/**
+ * Is this IPv6 literal off the public Internet (and not loopback)? Covers the
+ * unspecified address, ULA (fc00::/7), link-local (fe80::/10), the IPv6
+ * cloud-metadata addresses (fd00:ec2::254), and IPv4-mapped addresses that
+ * embed a blocked IPv4.
+ */
+function isBlockedIpv6(addr: string): boolean {
+  const norm = normalizeIpv6(addr);
+  if (norm === "::" || norm === "::0") return true; // unspecified
+  // IPv4-mapped / -compatible: defer to the IPv4 classifier.
+  const mapped = ipv4MappedAddress(norm);
+  if (mapped) {
+    const octets = parseIpv4Octets(mapped);
+    if (octets) return isBlockedIpv4(octets);
+  }
+  const head = norm.replace(/^\[|\]$/g, "");
+  // Unique local addresses fc00::/7 (fc.. and fd..).
+  if (/^f[cd][0-9a-f]{0,2}:/.test(head)) return true;
+  // Link-local fe80::/10 (fe8.., fe9.., fea.., feb..).
+  if (/^fe[89ab][0-9a-f]?:/.test(head)) return true;
+  // Multicast ff00::/8.
+  if (/^ff[0-9a-f]{2}:/.test(head)) return true;
+  return false;
+}
+
+/** Classify an IP literal. Returns "loopback", "blocked", or "allowed". */
+export function classifyIpLiteral(
+  addr: string,
+): "loopback" | "blocked" | "allowed" {
+  const family = isIP(addr);
+  if (family === 4) {
+    const octets = parseIpv4Octets(addr);
+    if (!octets) return "blocked";
+    if (isLoopbackIpv4(octets)) return "loopback";
+    return isBlockedIpv4(octets) ? "blocked" : "allowed";
+  }
+  if (family === 6) {
+    if (isLoopbackIpv6(addr)) return "loopback";
+    return isBlockedIpv6(addr) ? "blocked" : "allowed";
+  }
+  return "blocked";
+}
+
+/**
+ * Resolve `hostname` and assert every resolved address is fetch-safe
+ * (loopback or public). Throws `SsrfBlockedError` if the host is, or resolves
+ * to, a blocked (non-public, non-loopback) address. Checking *all* resolved
+ * addresses defeats DNS rebinding to an internal IP.
+ */
+export async function assertHostAllowed(hostname: string): Promise<void> {
+  const host = hostname.replace(/^\[|\]$/g, "");
+  // `localhost` is loopback by convention; allow without a DNS round-trip.
+  if (host.toLowerCase() === "localhost") return;
+
+  // IP literal: classify directly, no DNS.
+  if (isIP(host) !== 0) {
+    const verdict = classifyIpLiteral(host);
+    if (verdict === "blocked") {
+      throw new SsrfBlockedError(host, `non-public address ${host}`);
+    }
+    return;
+  }
+
+  // Hostname: resolve to all addresses and reject if any is blocked.
+  let records: { address: string }[];
+  try {
+    records = await hostResolver(host);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new SsrfBlockedError(
+      host,
+      `DNS resolution failed for ${host}: ${reason}`,
+    );
+  }
+  if (records.length === 0) {
+    throw new SsrfBlockedError(host, `no addresses resolved for ${host}`);
+  }
+  for (const { address } of records) {
+    if (classifyIpLiteral(address) === "blocked") {
+      throw new SsrfBlockedError(
+        host,
+        `${host} resolves to non-public address ${address}`,
+      );
+    }
+  }
+}
+
+/** Assert the full URL's host is fetch-safe. */
+export async function assertUrlAllowed(url: string | URL): Promise<void> {
+  let parsed: URL;
+  try {
+    parsed = typeof url === "string" ? new URL(url) : url;
+  } catch {
+    throw new SsrfBlockedError(String(url), `unparseable URL ${String(url)}`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new SsrfBlockedError(
+      parsed.hostname,
+      `unsupported protocol ${parsed.protocol}`,
+    );
+  }
+  await assertHostAllowed(parsed.hostname);
+}
+
+/**
+ * SSRF-safe replacement for `fetch(url, { redirect: "follow" })`.
+ *
+ * Validates the host before the initial request, then follows redirects
+ * *manually* — re-validating each hop's Location host with `assertUrlAllowed`
+ * before fetching it — so a public page cannot redirect the verifier into an
+ * internal or cloud-metadata endpoint. Caps redirects at `MAX_REDIRECTS`.
+ *
+ * Throws `SsrfBlockedError` if any hop targets a blocked host; otherwise
+ * behaves like `fetch` and returns the final `Response`.
+ */
+export async function safeFetch(
+  url: string,
+  init: Omit<RequestInit, "redirect"> = {},
+): Promise<Response> {
+  let current = url;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    await assertUrlAllowed(current);
+    const res = await fetch(current, { ...init, redirect: "manual" });
+    if (res.status < 300 || res.status >= 400) {
+      return res;
+    }
+    const location = res.headers.get("location");
+    if (!location) {
+      // A 3xx with no Location — nothing to follow; hand it back as-is.
+      return res;
+    }
+    let next: URL;
+    try {
+      next = new URL(location, current);
+    } catch {
+      throw new SsrfBlockedError(
+        current,
+        `unparseable redirect target ${location}`,
+      );
+    }
+    // Drain the redirect body so the socket can be reused.
+    await res.body?.cancel().catch(() => {});
+    current = next.toString();
+  }
+  throw new SsrfBlockedError(url, `too many redirects (> ${MAX_REDIRECTS})`);
+}

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -10,6 +10,7 @@ import type {
 } from "@elizaos/core";
 import { Service } from "@elizaos/core";
 import type { AcpService } from "./acp-service.js";
+import { SsrfBlockedError, safeFetch } from "./ssrf-guard.js";
 import type { SessionEventName, SessionInfo } from "./types.js";
 import {
   captureChangeSet,
@@ -570,6 +571,18 @@ export class SubAgentRouter extends Service {
 
     const nextCount = (this.roundTripCounts.get(sessionId) ?? 0) + 1;
     this.roundTripCounts.set(sessionId, nextCount);
+    // Roll the round-trip counter back when a task_complete event is
+    // suppressed downstream (verify-retry handoff, stale continuation, or
+    // cross-session completion dedupe). Those events never post a synthetic
+    // inbound, so counting them against the runaway-loop cap miscounts real
+    // round-trips and can trip the force-stop early. Only decrement if our
+    // increment is still the current value (no later event has advanced it).
+    const rollbackRoundTrip = (): void => {
+      if (this.roundTripCounts.get(sessionId) === nextCount) {
+        if (nextCount <= 1) this.roundTripCounts.delete(sessionId);
+        else this.roundTripCounts.set(sessionId, nextCount - 1);
+      }
+    };
     const capExceeded = nextCount > this.roundTripCap;
     if (capExceeded) {
       if (this.capExceededSessions.has(sessionId)) {
@@ -709,6 +722,7 @@ export class SubAgentRouter extends Service {
       const retried = await this.retryIncompleteBuild(session, deadUrls);
       if (retried) {
         this.verifyRetryHandedOffSessions.add(sessionId);
+        rollbackRoundTrip();
         return;
       }
       if (await this.hasNewerContinuation(session, origin)) {
@@ -717,6 +731,7 @@ export class SubAgentRouter extends Service {
           "suppressing stale verification failure; newer continuation exists",
           { sessionId, deadCount: deadUrls.length },
         );
+        rollbackRoundTrip();
         return;
       }
     }
@@ -745,6 +760,7 @@ export class SubAgentRouter extends Service {
             event,
           },
         );
+        rollbackRoundTrip();
         return;
       }
     }
@@ -1749,9 +1765,12 @@ export async function annotateUnverifiedUrls(
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 4000);
     try {
-      const res = await fetch(url, {
+      // SSRF guard: the URL comes from untrusted sub-agent narration. Resolve
+      // and reject non-public (private/link-local/metadata) hosts, and follow
+      // redirects manually so a public page can't 302 us into an internal
+      // endpoint. Loopback is allowed — local build verification depends on it.
+      const res = await safeFetch(url, {
         method: "GET",
-        redirect: "follow",
         signal: controller.signal,
       });
       // 405/501 mean the server IS reachable — it just won't serve a GET.
@@ -1792,7 +1811,14 @@ export async function annotateUnverifiedUrls(
       }
       return { status: null, servedLive: true };
     } catch (err) {
-      const reason = err instanceof Error ? err.name : "unreachable";
+      // A blocked non-public host is not a reachable artifact; report it as
+      // such (it must never be surfaced to the user as "live").
+      const reason =
+        err instanceof SsrfBlockedError
+          ? "blocked (non-public host)"
+          : err instanceof Error
+            ? err.name
+            : "unreachable";
       log?.(`[verify] probe ${url} → ${reason} @ ${new Date().toISOString()}`);
       return { status: reason, servedLive: false };
     } finally {
@@ -2048,9 +2074,11 @@ async function detectCachedMiss(
   // headers. A same-URL cache-bust probe distinguishes that case from a real
   // missing file without treating arbitrary non-404 failures as cache issues.
   busted.searchParams.set("__eliza_verify", Date.now().toString(36));
-  const bustedRes = await fetch(busted, {
+  // Same SSRF guard as the primary probe: the host is unchanged from the
+  // already-validated URL, but route through safeFetch so a redirect on the
+  // cache-bust probe can't reach an internal host either.
+  const bustedRes = await safeFetch(busted.toString(), {
     method: "GET",
-    redirect: "follow",
     signal,
   }).catch(() => null);
   if (!bustedRes) return null;


### PR DESCRIPTION
## What
Implemented all four assigned orchestrator findings as real, focused fixes matching package style (2-space, ESM, logger). #16 SSRF: new src/services/ssrf-guard.ts resolves the target host and blocks non-public addresses (RFC1918, link-local incl. 169.254.169.254, ULA, CGNAT, multicast/reserved, IPv6 fc00::/7, fe80::/10) while ALLOWING loopback (local build verification depends on it), and follows redirects manually (redirect:"manual") re-validating each hop so a public page cannot 302 the verifier into an internal/metadata endpoint; both verifier fetch sites in sub-agent-router.ts (probeOnce, detectCachedMiss) now route through safeFetch; a blocked host surfaces as a non-reachable "dead" URL. The DNS resolver is injectable (setHostResolver) as a test seam. #17 credential bridge: added an ownership gate to the POST handler (resolveActiveSession) that rejects with 410 when ctx.acpService.getSession(sessionId) is missing or terminal, mirroring the read-only parent-context bridge — so loopback-local processes can no longer trigger the owner REQUEST_SECRET flow / mint a scopedToken for arbitrary attacker-chosen sessionIds. #18 session-limit race: wrapped enforceSessionLimit + store.create in a per-service promise-chain mutex (reserveSessionSlot) so check-and-reserve is atomic and concurrent spawns cannot overshoot ELIZA_ACP_MAX_SESSIONS. #19 round-trip cap: added rollbackRoundTrip() applied before the three task_complete suppression returns (verify-retry handoff, stale continuation, cross-session dedupe) so suppressed events that never post no longer count against the runaway-loop cap. Added tests for each. Committed to nubs/fix-orchestrator.

## Confirmed findings implemented
#16, #17, #18, #19

## Testing (in-sandbox; full suites run in CI)
- **typecheck:** PASS for changed files. `bun run --cwd plugins/plugin-agent-orchestrator typecheck` (tsgo) reports ZERO errors in any of my 8 changed source/test files (grep-filtered). The command does emit many errors, but all are pre-existing dependency-resolution failures unrelated to this work (e.g. git-workspace-service, coding-agent-adapters, drizzle-orm, uuid, dotenv, adze not resolvable via the symlinked node_modules) — they affect untouched files. Also standalone `tsc --noEmit --strict` on the new ssrf-guard.ts exits 0.
- **tests:** PARTIAL — environment-limited, reported honestly. ssrf-guard.test.ts: PASS 15/15 (validates finding #16 guard logic in full: loopback allowed; RFC1918/link-local/metadata/ULA/CGNAT/multicast blocked; non-http(s) and direct-metadata URLs rejected). The other three test files (bridge-routes #17, acp-service #18, sub-agent-router #19) CANNOT run in this worktree: they transitively import @elizaos/core, which has no built dist/ here and cannot be built (its transitive deps yaml/drizzle-orm/uuid are absent from the symlinked node_modules), so vite fails to resolve the package entry. I confirmed this is PRE-EXISTING by stashing my changes and running the untouched baseline bridge-routes.test.ts — it fails identically with the same @elizaos/core resolution error. My new tests for #17/#18/#19 are written and type-clean (zero tsgo errors), but I could not execute them in this environment.
- **biome:** PASS. `biome check --write` formatted 4 files (import ordering/wrapping only); a final `biome check` (no-write) over all 8 changed files reports clean ("Checked 8 files. No fixes applied.").

## Risk
SSRF guard (#16): loopback is intentionally ALLOWED (not blocked) because the verifier's whole purpose is confirming a sub-agent's local build is reachable on 127.0.0.1/localhost — this is correct per the codebase, but means the guard mitigates internal-network/private-range/metadata reach, not loopback-port scanning of the orchestrator host itself (which the feature legitimately needs). DNS resolution adds a lookup per distinct host before each probe; the redirect:"manual" loop caps at 5 hops. The injectable resolver is a test seam only (production never overrides it). #17: the production SubAgentCredentialBridgeAdapter is not wired anywhere in-repo (getAdapter returns null, POST 503s) so this path is currently dormant — the gate is correct and matches the sibling route, but I could not exercise it against a real adapter. I implemented only the session-ownership/activeness half of the fixSketch; the per-session bridge-token half would require spawn-time token minting into the child's sealed env, which is out of scope for the route layer and the unwired adapter. #18: the mutex serializes ALL spawn reservations (one in-flight at a time) — the critical section is just the limit check + store.create insert (baseline git captures stay outside the lock), so added latency is the store list+create, negligible. The chain swallows tail rejections so one failed reservation cannot wedge later spawns. #19: rollback only decrements if the counter still equals this event's value (guards against a concurrently-incrementing later event); handleEvent is dispatched fire-and-forget so concurrency is possible, but these are terminal task_complete events and the guarded decrement is safe. Main caveat: only the ssrf-guard tests could actually run here (see tests field) — the #17/#18/#19 tests are written and type-clean but unexecuted due to @elizaos/core not being built in this worktree (pre-existing, baseline-confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
