### PR TITLE
fix(core): bound stateCache, dedupe provider registration, cap http body read, gate WEB_FETCH

### DIFF
--- a/packages/agent/src/runtime/actions/web-fetch.test.ts
+++ b/packages/agent/src/runtime/actions/web-fetch.test.ts
@@ -32,14 +32,31 @@ async function runHandler(
 }
 
 describe("WEB_FETCH action", () => {
+  const originalWebFetchEnv = process.env.ELIZA_WEB_FETCH;
+
   afterEach(() => {
     __setPinnedFetchImplForTests(null);
+    if (originalWebFetchEnv === undefined) {
+      delete process.env.ELIZA_WEB_FETCH;
+    } else {
+      process.env.ELIZA_WEB_FETCH = originalWebFetchEnv;
+    }
   });
 
-  it("is always available (no key/service required)", async () => {
+  it("is available by default (no key/service required)", async () => {
+    delete process.env.ELIZA_WEB_FETCH;
     expect(await webFetch.validate({} as IAgentRuntime, {} as Memory)).toBe(
       true,
     );
+  });
+
+  it("is gated off when ELIZA_WEB_FETCH disables the capability", async () => {
+    for (const value of ["0", "false", "off"]) {
+      process.env.ELIZA_WEB_FETCH = value;
+      expect(await webFetch.validate({} as IAgentRuntime, {} as Memory)).toBe(
+        false,
+      );
+    }
   });
 
   it("returns the fetched text snippet and fires the callback", async () => {
@@ -57,6 +74,21 @@ describe("WEB_FETCH action", () => {
       url: TEST_URL,
       value: "hello world",
     });
+  });
+
+  it("caps an oversized response body (streaming read, not full buffer)", async () => {
+    // Body far larger than the 4 000-char snippet cap. The guarded reader
+    // stops streaming once the cap is reached rather than buffering all of it.
+    const huge = "x".repeat(50_000);
+    __setPinnedFetchImplForTests(
+      async () => new Response(huge, { status: 200 }),
+    );
+
+    const { result } = await runHandler({ url: TEST_URL });
+
+    expect(result.success).toBe(true);
+    expect(result.text).toBeDefined();
+    expect((result.text ?? "").length).toBe(4_000);
   });
 
   it("extracts a JSON path when extract is provided", async () => {

--- a/packages/agent/src/runtime/actions/web-fetch.ts
+++ b/packages/agent/src/runtime/actions/web-fetch.ts
@@ -8,8 +8,10 @@
  * picks it up with no core change, so non-Anthropic models can answer
  * live-info questions inline instead of force-delegating to a coding agent.
  *
- * Always available (validate => true). The fetch itself is hardened by the
- * shared SSRF-guarded, https-only, GET-only helper.
+ * Enabled by default; `validate` honors the same `ELIZA_WEB_FETCH=0|false|off`
+ * capability gate as registration, so a disabled capability never runs. The
+ * fetch itself is hardened by the shared SSRF-guarded, https-only, GET-only
+ * helper.
  *
  * @module runtime/actions/web-fetch
  */
@@ -28,6 +30,18 @@ import { performGuardedHttpGet } from "../custom-actions.ts";
 
 /** Max characters of fetched text we return when no extract path matches. */
 const WEB_FETCH_SNIPPET_CHARS = 4_000;
+
+/**
+ * Capability gate: WEB_FETCH is enabled by default and opted out with
+ * `ELIZA_WEB_FETCH=0|false|off`, mirroring the registration-time check in
+ * `eliza.ts` and the `ELIZA_WEB_SEARCH` convention in `web-search-tools.ts`.
+ * Checked at `validate` time (not just registration) so a disabled capability
+ * never runs even when the action is registered by another path.
+ */
+function isWebFetchEnabled(): boolean {
+  const raw = process.env.ELIZA_WEB_FETCH?.toLowerCase();
+  return !(raw === "0" || raw === "false" || raw === "off");
+}
 
 interface WebFetchParams {
   url?: string;
@@ -109,7 +123,7 @@ export const webFetch: Action & Record<string, unknown> = {
     },
   ],
 
-  validate: async (): Promise<boolean> => true,
+  validate: async (): Promise<boolean> => isWebFetchEnabled(),
 
   handler: async (
     _runtime: IAgentRuntime,

--- a/packages/agent/src/runtime/custom-actions.ts
+++ b/packages/agent/src/runtime/custom-actions.ts
@@ -505,6 +505,39 @@ async function fetchWithPinnedTarget(
 /** Hard cap on the response body we read from a guarded GET. */
 const GUARDED_GET_MAX_BYTES = 256 * 1024;
 
+/** Hard cap on the response body we read from a legacy `http` custom action. */
+const CUSTOM_ACTION_HTTP_MAX_CHARS = 4_000;
+
+/**
+ * Read a fetch response body as text, streaming and stopping once `maxChars`
+ * characters have been collected. Avoids buffering an unbounded (or hostile)
+ * response into memory the way `response.text()` would before any slice.
+ */
+async function readBodyTextCapped(
+  response: Response,
+  maxChars: number,
+): Promise<string> {
+  if (!response.body) return "";
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let text = "";
+  try {
+    while (text.length < maxChars) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      text += decoder.decode(value, { stream: true });
+      if (text.length >= maxChars) {
+        text = text.slice(0, maxChars);
+        await reader.cancel();
+        break;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return text;
+}
+
 export interface GuardedHttpGetOptions {
   /** Request timeout in milliseconds. Defaults to the custom-action cap. */
   timeoutMs?: number;
@@ -570,25 +603,7 @@ export async function performGuardedHttpGet(
     return { ok: false, status: response.status, text: "", blocked: true };
   }
 
-  let text = "";
-  if (response.body) {
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    try {
-      while (text.length < maxChars) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        text += decoder.decode(value, { stream: true });
-        if (text.length >= maxChars) {
-          text = text.slice(0, maxChars);
-          await reader.cancel();
-          break;
-        }
-      }
-    } finally {
-      reader.releaseLock();
-    }
-  }
+  const text = await readBodyTextCapped(response, maxChars);
   return {
     ok: response.ok,
     status: response.status,
@@ -659,8 +674,11 @@ function buildHandler(
               "Blocked: redirects are not allowed for HTTP custom actions",
           };
         }
-        const text = await response.text();
-        return { ok: response.ok, output: text.slice(0, 4000) };
+        const text = await readBodyTextCapped(
+          response,
+          CUSTOM_ACTION_HTTP_MAX_CHARS,
+        );
+        return { ok: response.ok, output: text };
       };
 
     case "shell":

--- a/packages/core/src/__tests__/runtime-register-provider.test.ts
+++ b/packages/core/src/__tests__/runtime-register-provider.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { AgentRuntime } from "../runtime";
+import type { Character, Provider } from "../types";
+
+function makeProvider(name: string, text: string): Provider {
+	return {
+		name,
+		get: async () => ({ text, values: {}, data: {} }),
+	};
+}
+
+describe("AgentRuntime.registerProvider deduplication", () => {
+	it("does not register two providers with the same name", () => {
+		const runtime = new AgentRuntime({
+			character: { name: "provider-dedupe-test" } as Character,
+		});
+
+		const before = runtime.providers.length;
+		runtime.registerProvider(makeProvider("DUP", "first"));
+		runtime.registerProvider(makeProvider("DUP", "second"));
+
+		const matches = runtime.providers.filter((p) => p.name === "DUP");
+		expect(matches).toHaveLength(1);
+		// First registration wins; the duplicate is skipped, not swapped in.
+		expect(runtime.providers.length).toBe(before + 1);
+	});
+
+	it("still registers distinctly-named providers", () => {
+		const runtime = new AgentRuntime({
+			character: { name: "provider-distinct-test" } as Character,
+		});
+
+		const before = runtime.providers.length;
+		runtime.registerProvider(makeProvider("ALPHA", "a"));
+		runtime.registerProvider(makeProvider("BETA", "b"));
+
+		expect(runtime.providers.length).toBe(before + 2);
+		expect(runtime.providers.some((p) => p.name === "ALPHA")).toBe(true);
+		expect(runtime.providers.some((p) => p.name === "BETA")).toBe(true);
+	});
+});

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -1655,8 +1655,24 @@ export class AgentRuntime implements IAgentRuntime {
 			}
 		}
 		if (pluginToRegister.providers) {
+			const existingProviderNames = new Set(
+				this.providers.map((provider) => provider.name),
+			);
 			for (const provider of pluginToRegister.providers) {
+				if (existingProviderNames.has(provider.name)) {
+					this.logger.debug(
+						{
+							src: "agent",
+							agentId: this.agentId,
+							provider: provider.name,
+							plugin: pluginToRegister.name,
+						},
+						"Skipping duplicate plugin provider",
+					);
+					continue;
+				}
 				this.registerProvider(provider);
+				existingProviderNames.add(provider.name);
 			}
 		}
 		if (pluginToRegister.evaluators) {
@@ -2680,6 +2696,13 @@ export class AgentRuntime implements IAgentRuntime {
 
 	registerProvider(provider: Provider) {
 		const canonical = withCanonicalProviderDocs(provider);
+		if (this.providers.find((p) => p.name === canonical.name)) {
+			this.logger.debug(
+				{ src: "agent", agentId: this.agentId, provider: canonical.name },
+				"Provider already registered, skipping",
+			);
+			return;
+		}
 		this.providers.push(canonical);
 		this.logger.debug(
 			{ src: "agent", agentId: this.agentId, provider: canonical.name },

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -9210,7 +9210,15 @@ export class DefaultMessageService implements IMessageService {
 					// threw before reaching its own cleanup at the end of the method.
 					clearLatestResponseId(runtime.agentId, message.roomId, responseId);
 					if (message.id) {
+						// Evict both per-turn stateCache entries for this message:
+						// the action-results scratch key AND the base composed-state
+						// key set by composeState (runtime.ts). Without deleting the
+						// base key here it is only cleared when an
+						// `incoming_before_compose` pipeline hook happens to be
+						// registered, so in the common (no-hook) path the Map grew
+						// unbounded — one stale State per processed message.
 						runtime.stateCache.delete(`${message.id}_action_results`);
+						runtime.stateCache.delete(message.id);
 					}
 				}
 			},


### PR DESCRIPTION
## What
All four issues verified against code FIRST, then fixed. (a) stateCache base message.id leak: runtime.ts:3678 sets stateCache[message.id] in composeState, but the per-turn finally in message.ts only deleted the `_action_results` suffix; the base key was only evicted when an `incoming_before_compose` pipeline hook was registered (runtime.ts:1390, conditional on hasHooks). In the common no-hook path the Map grew one stale State per message. Fixed by also deleting the base key in the message.ts finally (chose this targeted eviction over LRU-bounding since the existing per-turn cleanup pattern already covers it). (b) registerProvider had NO dup-check unlike registerAction/registerEvaluator, and registerPlugin's providers loop skipped the dedupe that actions/evaluators have. Added a name guard inside registerProvider (single source of truth, mirroring registerEvaluator) AND the explicit existing-names pre-filter in registerPlugin to match the action/evaluator pattern + debug log. (c) legacy http custom-action read the full body via `await response.text()` before slicing to 4000; extracted the bounded streaming read from performGuardedHttpGet into a shared `readBodyTextCapped` helper and used it in both places (cap 4000 chars for the custom action). (d) WEB_FETCH.validate always returned true; now honors the same ELIZA_WEB_FETCH=0|false|off gate used at registration (eliza.ts:4433) and by ELIZA_WEB_SEARCH, as defense-in-depth at validate time. Added tests for provider dedup, the WEB_FETCH gate, and the body cap.

## Confirmed findings implemented
(verified against code first — see summary)

## Testing (in-sandbox; full suites run in CI)
- **typecheck:** PARTIAL/ENVIRONMENT-LIMITED. The symlinked node_modules (eliza-honesty-detectors) is a pruned install with only 46 top-level packages, missing runtime deps (adze, uuid, handlebars, drizzle-orm, etc.). `bun run --cwd packages/core typecheck` and `packages/agent typecheck` therefore emit hundreds of TS2307 "Cannot find module" errors repo-wide that are unrelated to my edits. I filtered to my changed files: core runtime.ts/message.ts and the new provider test have ZERO non-TS2307 errors; agent custom-actions.ts/web-fetch.ts have ZERO errors (the @elizaos/core import resolves via the workspace symlink). I did catch and fix one real type error my own test introduced (web-fetch.test.ts:90 result.text possibly undefined) — re-verified clean after fixing. Ran core prebuild first (built @elizaos/contracts + generated validation-keyword-data.ts) as required.
- **tests:** PASS. Ran vitest via /tmp/bun-canary/bin/bun x vitest run --no-coverage. To work around the pruned shared node_modules I built a non-destructive overlay node_modules (real dir of symlinks combining the shared install's vitest/@elizaos workspace with the fuller milady/dist/node_modules for adze/uuid/handlebars/etc.), ran tests, then restored the original symlink (node_modules is gitignored, nothing leaked into the commit). Results: web-fetch.test.ts 8/8 (incl. 2 new: capability-gate off, body-cap); runtime-register-provider.test.ts 2/2 (new). Regression: runtime-settings + evaluator 9/9; message-runtime-stage1 + message-action-dedupe 71/71 (confirms the stateCache eviction change does not break the message loop).
- **biome:** PASS

## Risk
Low risk; small focused diffs. (a) Deleting the base message.id stateCache key in finally is safe: it runs only after processMessage returns/throws, and the more-live `_action_results` key was already deleted there; 71 message-loop tests pass unchanged. Note this is a per-turn eviction, not a hard Map bound — if a future code path retains message.ids without going through this finally a leak could recur, but it matches the existing cleanup contract. (b) Dedup keeps FIRST registration (consistent with registerAction/registerEvaluator "skipping" semantics); if any caller relied on a later provider silently replacing an earlier same-named one, behavior changes (no such reliance found). (c)/(d) behavior-preserving for normal inputs. UNVERIFIED: full-package typecheck and the full test suite could not run to completion due to the pruned shared node_modules (missing adze/uuid/handlebars/etc.) — I verified my changed files are error-free modulo those environment-only TS2307s and ran the directly-relevant test files via an overlay node_modules. Generated prebuild artifacts (validation-keyword-data.ts, contracts/dist) are gitignored and not in the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
