### PR TITLE
perf(app/dev): stop watching ~45k files + full-reloading on every workspace source edit

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1333,9 +1333,36 @@ function watchWorkspacePackagesPlugin(): Plugin {
     configureServer(server) {
       const watcherStartedAt = Date.now();
       const seenMtimes = new Map<string, number>();
-      server.watcher.add(path.resolve(elizaRoot, "packages"));
-      server.watcher.add(nativePluginsRoot);
+      // Watch ONLY workspace package.json manifests — an alias/dependency change
+      // there needs a full Vite restart. We deliberately do NOT add the entire
+      // packages/ + plugins/ trees: that re-globbed ~45k files (including ~1GB of
+      // benchmarks/os), bypassed server.watch.ignored, risked exhausting
+      // fs.inotify watches, and — via the old blanket full-reload below — turned
+      // every workspace source edit into a full page reload instead of HMR.
+      // Imported workspace *source* is already watched through Vite's module
+      // graph, so React Fast Refresh / HMR handles those edits natively.
+      const workspaceManifests: string[] = [];
+      for (const root of [
+        path.resolve(elizaRoot, "packages"),
+        nativePluginsRoot,
+      ]) {
+        let entries: fs.Dirent[];
+        try {
+          entries = fs.readdirSync(root, { withFileTypes: true });
+        } catch {
+          continue;
+        }
+        for (const entry of entries) {
+          if (!entry.isDirectory()) continue;
+          const manifest = path.join(root, entry.name, "package.json");
+          if (fs.existsSync(manifest)) workspaceManifests.push(manifest);
+        }
+      }
+      server.watcher.add(workspaceManifests);
       server.watcher.on("change", (file) => {
+        // Source edits are handled by Vite's own HMR / Fast Refresh; only a
+        // workspace manifest change forces a full server restart.
+        if (!file.endsWith("package.json")) return;
         const normalizedFile = file.split(path.sep).join("/");
         if (isIgnoredWorkspaceGeneratedOutput(normalizedFile)) return;
         const stat = fs.statSync(file, { throwIfNoEntry: false });
@@ -1343,14 +1370,7 @@ function watchWorkspacePackagesPlugin(): Plugin {
         if (stat.mtimeMs < watcherStartedAt - 1000) return;
         if (seenMtimes.get(normalizedFile) === stat.mtimeMs) return;
         seenMtimes.set(normalizedFile, stat.mtimeMs);
-        if (file.includes("/packages/")) {
-          if (file.endsWith("package.json")) {
-            server.restart();
-          } else {
-            // Force a full reload on any other package file change (e.g. ts/tsx files)
-            server.hot.send({ type: "full-reload" });
-          }
-        }
+        server.restart();
       });
     },
   };


### PR DESCRIPTION
## What
`watchWorkspacePackagesPlugin` in `packages/app/vite.config.ts` did two expensive things every dev session:

1. **Watched the entire `packages/` + `plugins/` trees** via `server.watcher.add(...)` — ~45k files including ~1GB of `packages/benchmarks` + `packages/os`. This bypasses the carefully-built `server.watch.ignored` globs and can exhaust `fs.inotify.max_user_watches` on Linux (the exact failure the ignore list exists to avoid).
2. **Forced a full page reload on every workspace `.ts/.tsx` edit.** Since all `@elizaos/*` packages are aliased to source in dev, editing essentially any shared file (a UI component, app-core, a plugin) reloaded the whole ~1200-module app instead of a React Fast Refresh / HMR patch — the single biggest "dev feels slow/janky on every save" symptom.

(It also grew an unbounded `seenMtimes` Map keyed by every changed path.)

## Fix
Watch **only** the workspace `package.json` manifests (~200 files, enumerated from `packages/` + `plugins/`) — an alias/dependency change there still triggers a full Vite restart. Imported workspace **source** is already watched through Vite's module graph, so React Fast Refresh / HMR handles those edits natively. Source edits no longer force a full reload; `seenMtimes` is now bounded to the manifest set.

## Impact
- Stops watching ~45k irrelevant files → faster dev startup, lower idle CPU, no inotify exhaustion.
- Workspace source edits hot-update via HMR instead of full-reloading the app on every save.

Complementary to (and independent of) the recent dev-perf work on develop (serving the `@elizaos/core` browser bundle, dep pre-bundling, boot-graph warmup, V8 bytecode cache) — this targets the file-watch + edit-reload loop those didn't touch.

## Testing
- Biome clean; the changed file is type-clean (the `packages/app` typecheck errors are all pre-existing/unrelated dep-resolution noise in the sandbox).
- Behavioral verification needs a running dev server (not possible in-sandbox): on a real `bun run dev`, edit a `packages/ui/src` component → expect an HMR patch (not a full reload), and inotify pressure drops. The package's `test:hmr` smoke suite covers this path.

## Risk
Low–medium: HMR-vs-full-reload is a behavior change. Modules without an HMR boundary still full-reload their importers natively (Vite's own behavior) — we just stop forcing it for everything. Manifest changes still restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
