### PR TITLE
fix(cloud-frontend): warm up Vite dep-optimizer before timed audit routes (#8144)

### DIFF
--- a/packages/cloud-frontend/playwright.config.ts
+++ b/packages/cloud-frontend/playwright.config.ts
@@ -13,6 +13,9 @@ const recording = !!process.env.E2E_RECORD;
 export default defineConfig({
   testDir: "./tests/e2e",
   testMatch: "**/*.spec.ts",
+  // Warm up Vite's dep optimizer before any timed test navigates. See
+  // tests/e2e/global-setup.ts for the rationale (fixes #8144).
+  globalSetup: "./tests/e2e/global-setup.ts",
   fullyParallel: true,
   reporter: [["list"], ["html", { open: "never" }]],
   expect: {

--- a/packages/cloud-frontend/tests/e2e/global-setup.ts
+++ b/packages/cloud-frontend/tests/e2e/global-setup.ts
@@ -1,0 +1,53 @@
+import type { FullConfig } from "@playwright/test";
+
+/**
+ * Warm up Vite's dev-mode dependency optimizer before any timed test runs.
+ *
+ * When the audit's webServer is the Vite dev server (not preview), the very
+ * first navigation triggers `[vite] [optimizer] scanning dependencies...
+ * bundling dependencies...`. On a cold start this delays `DOMContentLoaded`
+ * past Playwright's 60s default, so whichever route runs first
+ * (alphabetically `landing`/`/` for `tests/e2e/aesthetic-audit.spec.ts`) and
+ * any other route that touches a not-yet-optimized chunk both time out —
+ * even though the server returns 200 in milliseconds when probed directly.
+ *
+ * Issuing a single GET against the base URL here, with a longer timeout
+ * than the per-test one, lets the optimizer complete before the real run
+ * starts. Subsequent navigations hit the warm cache and finish in <1s.
+ *
+ * Skips entirely when CLOUD_E2E_LIVE_URL is set (real deployed site — no
+ * local dev server, no optimizer).
+ */
+export default async function globalSetup(_config: FullConfig): Promise<void> {
+  if (process.env.CLOUD_E2E_LIVE_URL) {
+    return;
+  }
+
+  const host = process.env.PLAYWRIGHT_HOST || "127.0.0.1";
+  const port = process.env.PLAYWRIGHT_PORT || "4173";
+  const baseUrl =
+    process.env.PLAYWRIGHT_BASE_URL || `http://${host}:${port}`;
+
+  // The optimizer can take ~15–20s on a cold first navigation. Allow up to
+  // 90s so headless Chromium on slower machines still warms up reliably.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 90_000);
+  try {
+    const response = await fetch(baseUrl, { signal: controller.signal });
+    // We don't care about the body; just consuming the stream is what
+    // forces Vite to finish optimizing imports referenced by the root
+    // module graph. Subsequent test goto()s then race nothing.
+    await response.text();
+  } catch (err) {
+    // Don't fail the whole run if warmup hits a transient issue — the
+    // tests will surface real problems with clearer errors than this
+    // would. Log so a flake is at least traceable.
+    // biome-ignore lint/suspicious/noConsole: setup diagnostics
+    console.warn(
+      `[global-setup] Vite optimizer warmup failed (${baseUrl}):`,
+      err instanceof Error ? err.message : err,
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}


### PR DESCRIPTION
Fixes #8144.

## Summary

The aesthetic audit times out on the first one or two routes whenever the Vite dev server is cold. `page.goto` is waiting for `DOMContentLoaded` while Vite is mid-way through `[optimizer] scanning dependencies... bundling dependencies...`, and 60s isn't enough under headless Chromium. Probing the same routes directly via `fetch` returns 200 in milliseconds — the timeout is purely the optimizer race on first navigation.

The lower-risk of the two fixes proposed in #8144 (option 2: warmup in `globalSetup`). Doesn't change the dev workflow, doesn't require a production build, doesn't slow down anything once warm.

## Change

- New file: [`packages/cloud-frontend/tests/e2e/global-setup.ts`](packages/cloud-frontend/tests/e2e/global-setup.ts) — fetches the base URL once, drains the response stream so Vite finishes module-graph resolution, swallows errors so a transient warmup hiccup doesn't mask real test failures.
- [`packages/cloud-frontend/playwright.config.ts`](packages/cloud-frontend/playwright.config.ts): wires `globalSetup` to the new file.

No behavior change when `CLOUD_E2E_LIVE_URL` is set (real deployed site path — no local dev server, no optimizer).

## Test plan

- [x] Manual repro pre-fix: `bun run --cwd packages/cloud-frontend audit:cloud` on a cold checkout times out on `landing` + `dashboard-billing-success` (the two alphabetically-first routes affected by the optimizer race).
- [x] With this patch applied, `globalSetup` runs once before the first test worker and the audit completes without those two timeouts.
- [x] `CLOUD_E2E_LIVE_URL` short-circuit: setting the env var skips the warmup entirely (verified by code inspection — the function returns early).

## Notes

The 90s warmup budget is intentionally larger than Playwright's per-test 60s. The optimizer takes 15-20s on a typical cold start, so 90s is comfortable headroom for slower machines (e.g. shared CI runners) without being wasteful in the warm case (the response resolves in <1s once the optimizer has already run, common when developers iterate locally).
