### PR TITLE
fix(install): build private workspace packages in postinstall (#8143)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": "24.15.0"
   },
   "scripts": {
-    "postinstall": "bun packages/scripts/patch-nested-core-dist.mjs && bun packages/scripts/patch-punycode-deprecation.mjs && bun packages/scripts/patch-llama-cpp-capacitor.mjs && bun packages/scripts/ensure-workspace-symlinks.mjs",
+    "postinstall": "bun packages/scripts/patch-nested-core-dist.mjs && bun packages/scripts/patch-punycode-deprecation.mjs && bun packages/scripts/patch-llama-cpp-capacitor.mjs && bun packages/scripts/ensure-workspace-symlinks.mjs && bun packages/scripts/build-private-workspace-packages.mjs",
     "cloud:mock": "bun scripts/cloud/mock-stack-up.mjs",
     "cloud:mock:fresh": "bun scripts/cloud/mock-stack-up.mjs --reset",
     "fix-deps": "bun packages/scripts/fix-workspace-deps.mjs",

--- a/packages/scripts/build-private-workspace-packages.mjs
+++ b/packages/scripts/build-private-workspace-packages.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * Build private/internal workspace packages whose `dist/` is referenced by
+ * other workspace packages but not produced by any other install step.
+ *
+ * Why this exists: packages like `@elizaos/plugin-remote-manifest` are
+ * `"private": true` (not published to npm) and ship dist artifacts that
+ * consumers import directly (e.g. `@elizaos/plugin-remote-manifest/rpc-mac`).
+ * On a fresh clone neither npm fetch nor the workspace symlink step produces
+ * those dist files — only the package's own `bun run build` does — and
+ * nothing wires that build into install. So:
+ *
+ *   $ git clone … && bun install && bun run dev
+ *   Error [ERR_MODULE_NOT_FOUND]: Cannot find module
+ *   '…/packages/plugin-remote-manifest/dist/rpc-mac.js'
+ *
+ * (See #8143 for the full repro and root cause.)
+ *
+ * This script builds each listed package in dependency order, idempotent:
+ * skips a build when the expected `dist` artifact already exists. Order
+ * matters because `@elizaos/plugin-remote-manifest` workspace-depends on
+ * `@elizaos/security`, and a tsc invocation for the former needs the
+ * latter's `dist/` already present so type resolution succeeds.
+ */
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../..",
+);
+
+// Dependency-ordered list. Build leaves first, then their dependents.
+// `freshnessSentinel` is the file whose existence proves the package was
+// already built; missing => run `bun run build` for that package.
+const PACKAGES = [
+  {
+    dir: "packages/security",
+    freshnessSentinel: "dist/index.js",
+  },
+  {
+    dir: "packages/plugin-remote-manifest",
+    freshnessSentinel: "dist/index.js",
+  },
+];
+
+function log(msg) {
+  process.stderr.write(`[build-private-workspace-packages] ${msg}\n`);
+}
+
+function buildPackage(pkg) {
+  const pkgDir = path.join(REPO_ROOT, pkg.dir);
+  const sentinel = path.join(pkgDir, pkg.freshnessSentinel);
+
+  if (existsSync(sentinel)) {
+    log(`skip ${pkg.dir} (already built: ${pkg.freshnessSentinel})`);
+    return;
+  }
+
+  if (!existsSync(path.join(pkgDir, "package.json"))) {
+    log(`skip ${pkg.dir} (package.json missing — workspace not checked out?)`);
+    return;
+  }
+
+  log(`building ${pkg.dir} …`);
+  const result = spawnSync("bun", ["run", "build"], {
+    cwd: pkgDir,
+    stdio: "inherit",
+    // On Windows `bun` resolves through the npm shim — let the platform
+    // PATH handle it.
+    shell: process.platform === "win32",
+  });
+
+  if (result.status !== 0) {
+    log(
+      `FAILED ${pkg.dir}: bun run build exited with ${result.status ?? result.signal ?? "?"}`,
+    );
+    process.exit(result.status ?? 1);
+  }
+
+  log(`built ${pkg.dir}`);
+}
+
+for (const pkg of PACKAGES) {
+  buildPackage(pkg);
+}


### PR DESCRIPTION
Fixes #8143.

## Summary

`@elizaos/plugin-remote-manifest` and `@elizaos/security` ship dist artifacts that other workspace packages import directly (e.g. `@elizaos/plugin-remote-manifest/rpc-mac` from `packages/plugin-worker-runtime/src/dispatch.ts`), but nothing wires their builds into install. The first is `"private": true` (never on npm), so a fresh clone is the first thing that needs the dist files and the only thing that never has them. Result:

```
$ git clone … && bun install && bun run dev
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'…/packages/plugin-remote-manifest/dist/rpc-mac.js'
imported from …/packages/plugin-worker-runtime/src/dispatch.ts
```

## Change

Add a small orchestrator script — [`packages/scripts/build-private-workspace-packages.mjs`](packages/scripts/build-private-workspace-packages.mjs) — appended to the existing postinstall chain. It iterates a small explicit list of packages, builds them with `bun run build`, in dependency order (`@elizaos/security` first because `@elizaos/plugin-remote-manifest` workspace-depends on it).

Idempotent: each entry has a `freshnessSentinel` (currently `dist/index.js`); if it's already present the package is skipped. Warm clones cost zero. Cold clones pay one tsc invocation per package, ~5–10s total.

## Why a dedicated script (not `prepare`)

- `prepare` hooks fire for both `npm install` and `npm pack`/publish. Adding one to each private package would interfere with package consumers that don't want a build step.
- A single root script keeps the policy in one place and uses the same pattern as the existing `ensure-workspace-symlinks.mjs`, `patch-nested-core-dist.mjs`, etc.

## Test plan

- [x] Cold-clone repro: with both `dist/` directories empty, the script's freshness checks correctly decide to build (verified by inspecting the output: `building packages/security …`).
- [x] Warm-clone idempotency: when `dist/index.js` exists, the script logs `skip packages/<name>` and exits 0 immediately.
- [x] Append order in `package.json` postinstall: runs after the patch + symlink steps so workspace symlinks are present when the build resolves workspace imports.

## Scope

Only the two packages explicitly named in #8143 are handled. If other private workspace packages start hitting the same `dist/`-not-present pattern, they can be added to the `PACKAGES` list — that's a one-line change per package.

## Notes

The `tsc` invocation that each package's `bun run build` calls relies on the workspace-level TypeScript dev dep that `bun install` resolves. Running this script before `bun install` finishes would still fail, which is why it's wired into postinstall (not pre-).
