### PR TITLE
Guard local dev builds against invalid Node runtimes

### DIFF
--- a/packages/app-core/platforms/electrobun/electrobun.config.ts
+++ b/packages/app-core/platforms/electrobun/electrobun.config.ts
@@ -173,7 +173,17 @@ export function resolveElectrobunRepoRoot(startDir: string): string {
 }
 
 const repoRoot = resolveElectrobunRepoRoot(electrobunDir);
-const sharedSourceDir = path.join(repoRoot, "packages/shared/src");
+const workspacePackagesRoot = fs.existsSync(
+  path.join(repoRoot, "packages", "shared", "src"),
+)
+  ? path.join(repoRoot, "packages")
+  : path.join(repoRoot, "eliza", "packages");
+const sharedSourceDir = path.join(workspacePackagesRoot, "shared", "src");
+const coreNodeEntry = fs.existsSync(
+  path.join(workspacePackagesRoot, "core", "dist", "node", "index.node.js"),
+)
+  ? path.join(workspacePackagesRoot, "core", "dist", "node", "index.node.js")
+  : path.join(workspacePackagesRoot, "core", "src", "index.node.ts");
 const rendererDistDir = path.relative(
   electrobunDir,
   fs.existsSync(path.join(repoRoot, "packages/app/package.json"))
@@ -352,6 +362,9 @@ function createElectrobunWorkspaceResolvePlugin() {
           return resolved ? { path: resolved } : undefined;
         },
       );
+      build.onResolve({ filter: /^@elizaos\/core$/ }, () => ({
+        path: coreNodeEntry,
+      }));
     },
   };
 }

--- a/packages/app-core/scripts/dev-platform.mjs
+++ b/packages/app-core/scripts/dev-platform.mjs
@@ -324,7 +324,7 @@ const forceRenderer =
   process.env.ELIZA_DESKTOP_RENDERER_BUILD === "1";
 const viteWatch =
   process.env.ELIZA_DESKTOP_VITE_WATCH === "1" ||
-  process.env.ELIZA_DESKTOP_VITE_WATCH === "1";
+  process.env.MILADY_DESKTOP_VITE_WATCH === "1";
 const viteDepForceCli = process.argv.includes("--vite-force");
 const viteDepForce =
   viteDepForceCli ||
@@ -437,7 +437,7 @@ let ranInitialViteBuild = false;
 if (needRendererBuild) {
   ranInitialViteBuild = true;
   console.log("\n[eliza] Building renderer (vite build)…");
-  execFileSync(BUN_EXECUTABLE, ["run", "vite", "build"], {
+  execFileSync(BUN_EXECUTABLE, ["--bun", "run", "vite", "build"], {
     cwd: appDir,
     env: { ...process.env },
     stdio: "inherit",
@@ -942,7 +942,9 @@ async function launch() {
     pushChild(
       "vite",
       "bun",
-      viteDepForce ? ["run", "vite", "--", "--force"] : ["run", "vite"],
+      viteDepForce
+        ? ["--bun", "run", "vite", "--", "--force"]
+        : ["--bun", "run", "vite"],
       appDir,
       {
         NODE_ENV: "development",
@@ -958,9 +960,15 @@ async function launch() {
   }
 
   if (viteRollupWatch) {
-    pushChild("vite", "bun", ["run", "vite", "build", "--watch"], appDir, {
-      ELIZA_DESKTOP_VITE_FAST_DIST: "1",
-    });
+    pushChild(
+      "vite",
+      "bun",
+      ["--bun", "run", "vite", "build", "--watch"],
+      appDir,
+      {
+        ELIZA_DESKTOP_VITE_FAST_DIST: "1",
+      },
+    );
   }
 
   const electrobunChild = pushChild(

--- a/packages/app-core/scripts/dev-ui.mjs
+++ b/packages/app-core/scripts/dev-ui.mjs
@@ -1,7 +1,4 @@
 #!/usr/bin/env node
-console.log(
-  "\x1b[32m[dev-ui LOCAL PATCH START] running patched local dev-ui.mjs\x1b[0m",
-);
 
 /**
  * Development script that starts:
@@ -280,10 +277,18 @@ function isUsableNode(candidate) {
     return false;
   }
   try {
-    execFileSync(candidate, ["-e", "process.stdout.write(process.platform)"], {
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    return true;
+    const runtime = execFileSync(
+      candidate,
+      [
+        "-e",
+        "process.stdout.write(process.versions.bun ? 'bun' : `node:${process.versions.node || ''}`)",
+      ],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    ).trim();
+    return runtime.startsWith("node:");
   } catch {
     return false;
   }
@@ -304,7 +309,15 @@ function resolveApiNodeCommand(env) {
     "/usr/local/bin/node",
     "/usr/bin/node",
   ].filter(Boolean);
-  return candidates.find(isUsableNode) ?? "node";
+  const resolved = candidates.find(isUsableNode);
+  if (resolved) return resolved;
+  throw new Error(
+    [
+      "No usable Node.js binary found for the API dev server.",
+      "The API child must run on Node, not Bun, because native/CJS dependencies are loaded during runtime boot.",
+      "Install Node >=24 or set ELIZA_NODE_PATH=/absolute/path/to/node before running bun run dev.",
+    ].join(" "),
+  );
 }
 
 const visionDepsRetryCommand = [

--- a/packages/app-core/scripts/run-production-build.mjs
+++ b/packages/app-core/scripts/run-production-build.mjs
@@ -23,22 +23,66 @@ const appDir = resolveMainAppDir(rootDir, "app");
 
 /** Real Node binary — when the script is started via `bun run`, process.execPath is Bun. */
 function resolveNodeExec() {
-  if (!process.versions.bun) {
+  function isCodexBundledNode(candidate) {
+    return (
+      process.platform === "darwin" &&
+      candidate.includes(
+        `${path.sep}Applications${path.sep}Codex.app${path.sep}Contents${path.sep}Resources${path.sep}node`,
+      )
+    );
+  }
+
+  function isUsableNode(candidate) {
+    if (!candidate || isCodexBundledNode(candidate) || !fs.existsSync(candidate)) {
+      return false;
+    }
+    const probe = spawnSync(
+      candidate,
+      [
+        "-e",
+        "process.stdout.write(process.versions.bun ? 'bun' : `node:${process.versions.node || ''}`)",
+      ],
+      {
+        encoding: "utf8",
+      },
+    );
+    return probe.status === 0 && probe.stdout?.trim().startsWith("node:");
+  }
+
+  const explicitNode = process.env.ELIZA_NODE_PATH?.trim();
+  if (isUsableNode(explicitNode)) {
+    return explicitNode;
+  }
+
+  const currentIsCodexBundledNode =
+    process.platform === "darwin" &&
+    process.execPath.includes(
+      `${path.sep}Applications${path.sep}Codex.app${path.sep}Contents${path.sep}Resources${path.sep}node`,
+    );
+  if (!process.versions.bun && !currentIsCodexBundledNode) {
     return process.execPath;
   }
   const probe = spawnSync(
     "node",
-    ["-e", "process.stdout.write(process.execPath)"],
+    [
+      "-e",
+      "process.stdout.write(process.versions.bun ? '' : process.execPath)",
+    ],
     {
       encoding: "utf8",
     },
   );
   const out = probe.stdout?.trim();
-  if (probe.status === 0 && out) {
+  const probedCodexNode =
+    process.platform === "darwin" &&
+    out.includes(
+      `${path.sep}Applications${path.sep}Codex.app${path.sep}Contents${path.sep}Resources${path.sep}node`,
+    );
+  if (probe.status === 0 && out && !probedCodexNode) {
     return out;
   }
   throw new Error(
-    "Node.js is required to run this build (tsx + Vite CLI). Install Node 22+ or run: node scripts/run-production-build.mjs",
+    "A standard Node.js binary is required to run this build (tsx + native bindings). Install Node 22+ or set ELIZA_NODE_PATH=/absolute/path/to/node before running bun run build.",
   );
 }
 


### PR DESCRIPTION
Reject Bun and the Codex-bundled macOS Node when launching API/build children, since native and CJS runtime dependencies fail under those executables.

Allow ELIZA_NODE_PATH as the explicit standard-Node escape hatch, run desktop Vite through Bun's JS runtime, and resolve Electrobun core/shared sources from the nested Milady eliza workspace.