### PR TITLE
feat(cloud): migrate coding-containers to jobs-daemon + image allowlist (retire dead control-plane forward)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,22 @@
+# PLAN: Migrate coding-containers off dead control-plane forward → jobs-daemon
+
+STATUS: scaffolding (study in progress)
+
+## Problem
+POST /api/v1/coding-containers → 521. CF worker forwards to dead origin
+(container-control-plane :8791, retired, pointed at decommissioned .246).
+Node autoscaling already migrated to eliza-provisioning-worker daemon (jobs-table + Redis).
+Only coding-containers CRUD + a few crons never migrated.
+
+## Approach (copy AGENT_MESSAGE synchronous pattern from #8150)
+1. JOB_TYPES.CODING_CONTAINER_CREATE (+_DELETE/_STATUS if straightforward)
+2. Daemon execute fn: docker op on a node via daemon's EXISTING node-SSH+docker machinery
+3. Rewrite coding-containers/route.ts: enqueue + triggerImmediate + poll (synchronous)
+4. Image allowlist: CODING_CONTAINER_IMAGE_ALLOWLIST env, default ghcr.io/{dexploarer,elizaos,waifufun}/*, reject else 403
+5. Crons (deployment-monitor, process-provisioning-jobs, pool-replenish): migrate/no-op dead calls
+6. Typecheck cloud-api + cloud-shared
+
+## Daemon update procedure (do NOT deploy here; note in PR)
+scp changed .ts → eliza-1 (88.99.82.102) /opt/eliza/packages/... then restart daemon.
+
+(TBD: fill in actual job-type shapes + SSH/docker machinery reuse after study)

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,22 +1,64 @@
 # PLAN: Migrate coding-containers off dead control-plane forward → jobs-daemon
 
-STATUS: scaffolding (study in progress)
+STATUS: studied. Building.
 
-## Problem
-POST /api/v1/coding-containers → 521. CF worker forwards to dead origin
-(container-control-plane :8791, retired, pointed at decommissioned .246).
-Node autoscaling already migrated to eliza-provisioning-worker daemon (jobs-table + Redis).
-Only coding-containers CRUD + a few crons never migrated.
+## Problem (verified)
+`POST /api/v1/coding-containers` → 521. The route (`packages/cloud-api/v1/coding-containers/route.ts`)
+HTTP-forwards `${CONTAINER_CONTROL_PLANE_URL}/api/v1/containers` to a DEAD origin
+(orphan `container-control-plane` :8791, retired in the cloud migration, pointed at
+decommissioned .246; secrets unrecoverable). Node autoscaling + warm pool ALREADY
+migrated to the `eliza-provisioning-worker` daemon (jobs-table + Redis) and it's HEALTHY.
+Only coding-containers CRUD never migrated off the HTTP forward.
 
-## Approach (copy AGENT_MESSAGE synchronous pattern from #8150)
-1. JOB_TYPES.CODING_CONTAINER_CREATE (+_DELETE/_STATUS if straightforward)
-2. Daemon execute fn: docker op on a node via daemon's EXISTING node-SSH+docker machinery
-3. Rewrite coding-containers/route.ts: enqueue + triggerImmediate + poll (synchronous)
-4. Image allowlist: CODING_CONTAINER_IMAGE_ALLOWLIST env, default ghcr.io/{dexploarer,elizaos,waifufun}/*, reject else 403
-5. Crons (deployment-monitor, process-provisioning-jobs, pool-replenish): migrate/no-op dead calls
-6. Typecheck cloud-api + cloud-shared
+## KEY ARCHITECTURAL FINDING (drives the design)
+The daemon's agent-provision path (`JOB_TYPES.AGENT_PROVISION` →
+`elizaSandboxService.provision()`) **already docker-runs an arbitrary image**:
+`provision()` passes `dockerImage: rec.docker_image` into `(await getProvider()).create({...})`
+(eliza-sandbox.ts:792). The provider IS the daemon's SSH+docker machinery (node select +
+`docker run`). So a coding-container is just an `agent_sandboxes` row with a custom
+`docker_image` + coding env vars, provisioned through the SAME healthy daemon path.
 
-## Daemon update procedure (do NOT deploy here; note in PR)
-scp changed .ts → eliza-1 (88.99.82.102) /opt/eliza/packages/... then restart daemon.
+Template to copy: `packages/cloud-api/v1/eliza/agents/[agentId]/provision/route.ts`
+(create-or-reuse sandbox row → `enqueueAgentProvisionOnce` → `triggerImmediate` →
+client polls `/api/v1/jobs/{jobId}`; warm-pool fast path; worker-health gate).
 
-(TBD: fill in actual job-type shapes + SSH/docker machinery reuse after study)
+`enqueueLifecycleJob` REQUIRES a pre-existing `agent_sandboxes` row (throws
+"Agent not found"), so CREATE must first persist the row via
+`elizaSandboxService.createAgent({ ..., dockerImage })`, THEN enqueue provision.
+
+## Design
+1. **Image allowlist (security, the real gap)** — `containers-env` getter
+   `codingContainerImageAllowlist()` reading `CODING_CONTAINER_IMAGE_ALLOWLIST`
+   (comma-sep glob prefixes). Default:
+   `ghcr.io/dexploarer/*,ghcr.io/elizaos/*,ghcr.io/waifufun/*`.
+   Helper `isCodingContainerImageAllowed(image, allowlist)` in cloud-shared
+   coding-containers service. Route rejects disallowed images with **403**.
+   (Today: `image` is taken raw with ZERO validation, gated only by "any authed org".)
+
+2. **Rewrite `coding-containers/route.ts`** — replace the dead `forwardContainerCreate`
+   with: validate body → resolve image (request override → coding runner image →
+   default) → **allowlist check (403 on fail)** → `createAgent({dockerImage,env})`
+   → `enqueueAgentProvisionOnce` + `triggerImmediate` → poll job for synchronous
+   result (MAX_WAIT≈90s) → build `CloudCodingContainerSession` from the running
+   sandbox row. No new HTTP origin; everything via the healthy daemon + DB.
+
+3. **JOB_TYPE(s)** — task asked for `CODING_CONTAINER_CREATE`. Decision:
+   the *create* reuses `AGENT_PROVISION` (proven, already image-capable) to avoid
+   duplicating the entire provider machinery. We DO add a thin
+   `JOB_TYPES.CODING_CONTAINER_CREATE` alias + types for forward-compat / explicit
+   telemetry **only if** it's low-risk; if it would mean re-implementing
+   provider.create on the daemon, we skip it and document the reuse (honesty over
+   ceremony). Status job = existing `GET /api/v1/jobs/{id}` + sandbox status.
+
+4. **Dead-forwarding crons** (deployment-monitor, process-provisioning-jobs,
+   pool-replenish) — `triggerImmediate` already prefers the control-plane URL then
+   falls back to the cron-secret path; audit each cron's dead `${CONTROL_PLANE_URL}`
+   call and no-op / redirect it so it stops 521ing.
+
+## Daemon update procedure (do NOT deploy here; for PR body)
+Changed files are cloud-shared/cloud-api TS bundled by the daemon. To ship:
+`scp` changed `.ts` → `eliza-1` (88.99.82.102) `/opt/eliza/packages/...`, then
+restart `eliza-provisioning-worker.service`. Sol/Shadow deploy, not this PR.
+
+## Out of scope
+The `*.waifu.fun` public-URL 502 is SEPARATE. This PR only makes the DEPLOY CALL work.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,6 +1,42 @@
 # PLAN: Migrate coding-containers off dead control-plane forward → jobs-daemon
 
-STATUS: studied. Building.
+STATUS: DONE. cloud-api typecheck = 0 errors. cloud-shared typecheck = 0 errors.
+10/10 allowlist+payload unit tests pass.
+
+## What shipped (commits on this branch)
+1. `containers-env.ts` - `codingContainerImageAllowlist()` env getter
+   (`CODING_CONTAINER_IMAGE_ALLOWLIST`, default
+   `ghcr.io/{dexploarer,elizaos,waifufun}/*`).
+2. `coding-containers.ts` - `isCodingContainerImageAllowed()` fail-closed
+   glob/exact/wildcard matcher + 10 unit tests.
+3. `coding-containers/route.ts` - rewritten: allowlist gate (403) →
+   worker-health gate → `createAgent({dockerImage,env})` →
+   `enqueueAgentProvisionOnce` + `triggerImmediate` → poll job → session.
+   201 success / 502 fail / 202 (poll job) on timeout. No HTTP origin.
+4. All 8 dead-forwarding container crons → `cronSupersededByDaemon()` 200 ack
+   (process-provisioning-jobs, deployment-monitor, node-autoscale,
+   pool-replenish, pool-drain-idle, agent-hot-pool, pool-health-check,
+   pool-image-rollout). Removed unused `forwardCronToContainerControlPlane`.
+
+## DECISION: reuse AGENT_PROVISION instead of a new CODING_CONTAINER_CREATE job
+The task asked for a `CODING_CONTAINER_CREATE` job type. After studying the
+daemon, the create work IS `elizaSandboxService.provision()` driven by
+`JOB_TYPES.AGENT_PROVISION`, which already docker-runs an arbitrary
+`docker_image` via the provider's node-SSH + `docker run`. Adding a separate
+job type would mean either re-implementing that whole provider path on the
+daemon (high risk) or a thin alias doing the identical provision (redundant).
+Per "don't reinvent the SSH path / honesty over completeness," we REUSE
+`AGENT_PROVISION`. A coding container is modeled as an `agent_sandboxes` row
+with a custom image + coding env vars. No daemon code change is required.
+
+IMPLICATION FOR DEPLOY: because we reuse the existing job type + existing
+`provision()`, the DAEMON binary needs NO change for this PR. Only the
+cloud-api Worker (route + crons) and cloud-shared (env getter + helper)
+change, both shipping with the normal CF Worker deploy. (Future: if
+coding-specific telemetry/result shape is wanted, add
+`CODING_CONTAINER_CREATE` then - documented follow-up.)
+
+--- (original plan below) ---
 
 ## Problem (verified)
 `POST /api/v1/coding-containers` → 521. The route (`packages/cloud-api/v1/coding-containers/route.ts`)
@@ -27,7 +63,7 @@ client polls `/api/v1/jobs/{jobId}`; warm-pool fast path; worker-health gate).
 `elizaSandboxService.createAgent({ ..., dockerImage })`, THEN enqueue provision.
 
 ## Design
-1. **Image allowlist (security, the real gap)** — `containers-env` getter
+1. **Image allowlist (security, the real gap)** - `containers-env` getter
    `codingContainerImageAllowlist()` reading `CODING_CONTAINER_IMAGE_ALLOWLIST`
    (comma-sep glob prefixes). Default:
    `ghcr.io/dexploarer/*,ghcr.io/elizaos/*,ghcr.io/waifufun/*`.
@@ -35,14 +71,14 @@ client polls `/api/v1/jobs/{jobId}`; warm-pool fast path; worker-health gate).
    coding-containers service. Route rejects disallowed images with **403**.
    (Today: `image` is taken raw with ZERO validation, gated only by "any authed org".)
 
-2. **Rewrite `coding-containers/route.ts`** — replace the dead `forwardContainerCreate`
+2. **Rewrite `coding-containers/route.ts`** - replace the dead `forwardContainerCreate`
    with: validate body → resolve image (request override → coding runner image →
    default) → **allowlist check (403 on fail)** → `createAgent({dockerImage,env})`
    → `enqueueAgentProvisionOnce` + `triggerImmediate` → poll job for synchronous
    result (MAX_WAIT≈90s) → build `CloudCodingContainerSession` from the running
    sandbox row. No new HTTP origin; everything via the healthy daemon + DB.
 
-3. **JOB_TYPE(s)** — task asked for `CODING_CONTAINER_CREATE`. Decision:
+3. **JOB_TYPE(s)** - task asked for `CODING_CONTAINER_CREATE`. Decision:
    the *create* reuses `AGENT_PROVISION` (proven, already image-capable) to avoid
    duplicating the entire provider machinery. We DO add a thin
    `JOB_TYPES.CODING_CONTAINER_CREATE` alias + types for forward-compat / explicit
@@ -51,7 +87,7 @@ client polls `/api/v1/jobs/{jobId}`; warm-pool fast path; worker-health gate).
    ceremony). Status job = existing `GET /api/v1/jobs/{id}` + sandbox status.
 
 4. **Dead-forwarding crons** (deployment-monitor, process-provisioning-jobs,
-   pool-replenish) — `triggerImmediate` already prefers the control-plane URL then
+   pool-replenish) - `triggerImmediate` already prefers the control-plane URL then
    falls back to the cron-secret path; audit each cron's dead `${CONTROL_PLANE_URL}`
    call and no-op / redirect it so it stops 521ing.
 

--- a/packages/cloud-api/v1/_container-control-plane-forward.ts
+++ b/packages/cloud-api/v1/_container-control-plane-forward.ts
@@ -98,8 +98,40 @@ export async function forwardToContainerControlPlane(
   });
 }
 
-export async function forwardCronToContainerControlPlane(
+/**
+ * No-op response for CF cron routes whose work has been folded into the
+ * `eliza-provisioning-worker` daemon's own poll/maintenance cycles.
+ *
+ * These routes used to `forwardCronToContainerControlPlane`, but that origin
+ * (the standalone container-control-plane sidecar) was retired in the cloud
+ * migration and now 521s on every scheduled trigger. The actual work
+ * (job processing, node autoscale, warm-pool replenish/drain, fleet upgrade,
+ * node health) is driven by the daemon's `pollCycle` /
+ * `runInfraMaintenanceCycle` (see
+ * packages/scripts/cloud/admin/daemons/provisioning-worker.ts). The CF cron
+ * here only needs to validate auth and acknowledge — returning 200 instead of
+ * a dead-forward 5xx so the scheduled invocation stops erroring.
+ *
+ * (The former `forwardCronToContainerControlPlane` helper was removed when its
+ * last caller migrated to this no-op; `forwardToContainerControlPlane` remains
+ * for the still-live authed admin docker-node health-check forward.)
+ *
+ * Pass the daemon cycle name for observability.
+ */
+export function cronSupersededByDaemon(
   c: AppContext,
-): Promise<Response> {
-  return forwardControlPlaneRequest(c, () => {});
+  daemonCycle: string,
+): Response {
+  logger.debug("[ContainerControlPlane] cron superseded by daemon", {
+    cycle: daemonCycle,
+    path: new URL(c.req.url).pathname,
+  });
+  return c.json({
+    success: true,
+    superseded: true,
+    handledBy: "eliza-provisioning-worker",
+    cycle: daemonCycle,
+    message:
+      "This work is handled by the provisioning-worker daemon; the CF cron forward is retired.",
+  });
 }

--- a/packages/cloud-api/v1/coding-containers/route.ts
+++ b/packages/cloud-api/v1/coding-containers/route.ts
@@ -26,6 +26,19 @@
  * with ZERO validation. We now require it to match
  * `CODING_CONTAINER_IMAGE_ALLOWLIST` (default ghcr.io/{dexploarer,elizaos,
  * waifufun}/*) and reject others with 403.
+ *
+ * KNOWN GAPS vs the old control-plane path (the daemon's standard
+ * `agent_sandboxes` provision path does not yet carry these; tracked as
+ * follow-ups — see PR body). They do NOT affect a self-contained agent image
+ * like Nancy, which needs only image + env:
+ *   1. `bootstrap_source` (source.files) is NOT hydrated — a VFS-promoted
+ *      workspace would start empty. The `agent_sandboxes` schema has no
+ *      bootstrap/volume columns, so honoring this needs daemon + schema work.
+ *   2. Custom `container.cpu` / `container.memory` are NOT plumbed to
+ *      `provision()` (it uses node defaults). Same schema limitation.
+ *   3. The returned `url` is the agent bridge/health URL, NOT the browser IDE
+ *      URL the old control-plane returned. UI-facing callers must resolve the
+ *      public coding-UI URL separately until the daemon surfaces it.
  */
 
 import { Hono } from "hono";

--- a/packages/cloud-api/v1/coding-containers/route.ts
+++ b/packages/cloud-api/v1/coding-containers/route.ts
@@ -36,15 +36,22 @@
  *      bootstrap/volume columns, so honoring this needs daemon + schema work.
  *   2. Custom `container.cpu` / `container.memory` are NOT plumbed to
  *      `provision()` (it uses node defaults). Same schema limitation.
- *   3. The returned `url` is the agent bridge/health URL, NOT the browser IDE
- *      URL the old control-plane returned. UI-facing callers must resolve the
- *      public coding-UI URL separately until the daemon surfaces it.
+ *   3. The browser coding-IDE URL (if any) is a separate concern the daemon
+ *      does not yet surface; the returned `url` is the per-agent public HTTPS
+ *      URL (https://<id>.<agent-domain>).
+ *
+ * PUBLIC_BASE_URL: before provisioning we inject `https://<id>.<agent-domain>`
+ * into the container's env (unless the caller pinned one) so a self-contained
+ * agent like Nancy boots knowing its own public URL — needed for webhooks, deep
+ * links, and signing pages. The sandbox id exists pre-provision and the
+ * per-agent gateway serves that host, so there is no chicken-and-egg.
  */
 
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { containersEnv } from "@/lib/config/containers-env";
+import { getElizaAgentPublicWebUiUrl } from "@/lib/eliza-agent-web-ui";
 import {
   buildCodingContainerCreatePayload,
   buildCodingContainerSessionResponse,
@@ -78,6 +85,23 @@ function validationError(c: AppContext, message: string): Response {
 }
 
 /**
+ * Per-agent public HTTPS URL (`https://<id>.<agent-domain>`), resolving the base
+ * domain from the container control-plane config (`containersEnv`, which reads
+ * the Worker's bindings) — NOT `process.env`. This route runs in the Cloudflare
+ * Worker, where `process.env` is not populated, so calling
+ * `getElizaAgentPublicWebUiUrl` without an explicit domain would silently fall
+ * back to the default brand domain and yield an unreachable host. Returns null
+ * when no base domain is configured.
+ */
+function resolveAgentPublicUrl(sandbox: {
+  id: string;
+  headscale_ip: string | null;
+}): string | null {
+  const baseDomain = containersEnv.publicBaseDomain();
+  return getElizaAgentPublicWebUiUrl(sandbox, baseDomain ? { baseDomain } : {});
+}
+
+/**
  * Build the session response from a running sandbox row. Mirrors the upstream
  * shape the old control-plane returned, sourced from the daemon-provisioned
  * sandbox instead of the dead HTTP origin.
@@ -90,6 +114,7 @@ function buildSessionFromSandbox(
     status: string;
     bridge_url: string | null;
     health_url: string | null;
+    headscale_ip: string | null;
     created_at?: Date | string | null;
   },
 ) {
@@ -99,6 +124,10 @@ function buildSessionFromSandbox(
     upstreamData: {
       id: sandbox.id,
       status: sandbox.status,
+      // Prefer the reachable per-agent HTTPS URL (https://<id>.<domain>) so the
+      // session reports where the container is actually served; fall back to the
+      // internal bridge/health URL.
+      publicUrl: resolveAgentPublicUrl(sandbox) ?? undefined,
       url: sandbox.bridge_url ?? sandbox.health_url ?? null,
       createdAt:
         sandbox.created_at instanceof Date
@@ -153,17 +182,38 @@ async function createCodingContainer(
     dockerImage: payload.image,
   });
 
+  // ── Inject the container's own public URL as PUBLIC_BASE_URL ──────────────
+  // The sandbox id exists now (pre-provision) and the per-agent gateway serves
+  // `https://<id>.<agent-domain>`, so we can set the agent's public URL before
+  // the daemon docker-runs it — `provision()` forwards `environment_vars` into
+  // the container (eliza-sandbox.ts). A self-contained image like Nancy needs
+  // this for webhooks / deep links / signing pages. We never override a
+  // PUBLIC_BASE_URL the caller pinned explicitly.
+  let provisionRow = sandbox;
+  const publicWebUrl = resolveAgentPublicUrl(sandbox);
+  if (publicWebUrl && !payload.environment_vars["PUBLIC_BASE_URL"]) {
+    payload.environment_vars["PUBLIC_BASE_URL"] = publicWebUrl;
+    const updated = await elizaSandboxService.updateAgentEnvironment(
+      sandbox.id,
+      user.organization_id,
+      payload.environment_vars,
+    );
+    if (updated) provisionRow = updated;
+  }
+
   // ── Enqueue the (existing, image-capable) provision job + kick the daemon ──
+  // Enqueue against `provisionRow` — updateAgentEnvironment bumps `updated_at`,
+  // and enqueueAgentProvisionOnce gates on `expectedUpdatedAt`.
   let enqueue: Awaited<
     ReturnType<typeof provisioningJobService.enqueueAgentProvisionOnce>
   >;
   try {
     enqueue = await provisioningJobService.enqueueAgentProvisionOnce({
-      agentId: sandbox.id,
+      agentId: provisionRow.id,
       organizationId: user.organization_id,
       userId: user.id,
-      agentName: sandbox.agent_name ?? sandbox.id,
-      expectedUpdatedAt: sandbox.updated_at,
+      agentName: provisionRow.agent_name ?? provisionRow.id,
+      expectedUpdatedAt: provisionRow.updated_at,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -263,6 +313,8 @@ async function createCodingContainer(
         containerId: sandbox.id,
         status: "pending",
         agent: request.agent,
+        // Known pre-provision (id-derived); lets the caller wire up the URL now.
+        url: publicWebUrl ?? undefined,
       },
       jobId: job.id,
       polling: {

--- a/packages/cloud-api/v1/coding-containers/route.ts
+++ b/packages/cloud-api/v1/coding-containers/route.ts
@@ -1,147 +1,265 @@
+/**
+ * POST /api/v1/coding-containers
+ *
+ * Request a cloud coding container for an agent.
+ *
+ * HISTORY: this route used to HTTP-forward to a standalone
+ * `container-control-plane` service (`${CONTAINER_CONTROL_PLANE_URL}/api/v1/containers`).
+ * That origin was retired in the cloud migration (orphan service on :8791,
+ * pointed at the decommissioned .246 node) and now returns 521. Node
+ * autoscaling + warm pool already migrated to the `eliza-provisioning-worker`
+ * daemon (jobs table + Redis); only this route never did.
+ *
+ * NOW: a coding container is just an `agent_sandboxes` row with a custom
+ * `docker_image` + coding env vars, provisioned through the SAME healthy
+ * daemon path used for normal agents. The daemon's `AGENT_PROVISION` job
+ * (`elizaSandboxService.provision()`) already docker-runs an arbitrary image
+ * via the provider (node-SSH + `docker run`) — see eliza-sandbox.ts where
+ * `provision()` forwards `docker_image` into `provider.create()`. So we:
+ *   1. allowlist-gate the requested image (SECURITY — see below),
+ *   2. create the sandbox row (`createAgent({ dockerImage, environmentVars })`),
+ *   3. enqueue the existing provision job + trigger the daemon immediately,
+ *   4. poll the job for a synchronous result and return the session.
+ *
+ * SECURITY: coding-containers let an authenticated org run an OUTSIDE image
+ * (e.g. ghcr.io/dexploarer/bnancy:latest). The image was previously taken raw
+ * with ZERO validation. We now require it to match
+ * `CODING_CONTAINER_IMAGE_ALLOWLIST` (default ghcr.io/{dexploarer,elizaos,
+ * waifufun}/*) and reject others with 403.
+ */
+
 import { Hono } from "hono";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
+import { containersEnv } from "@/lib/config/containers-env";
 import {
   buildCodingContainerCreatePayload,
   buildCodingContainerSessionResponse,
   type CodingContainerCreatePayload,
+  isCodingContainerImageAllowed,
   type RequestCodingAgentContainerRequest,
   RequestCodingAgentContainerRequestSchema,
 } from "@/lib/services/coding-containers";
+import { elizaSandboxService } from "@/lib/services/eliza-sandbox";
+import { provisioningJobService } from "@/lib/services/provisioning-jobs";
+import {
+  checkProvisioningWorkerHealth,
+  provisioningWorkerFailureBody,
+} from "@/lib/services/provisioning-worker-health";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv, AuthedUser } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
 
-const CONTROL_PLANE_URL_KEYS = [
-  "CONTAINER_CONTROL_PLANE_URL",
-  "CONTAINER_SIDECAR_URL",
-  "HETZNER_CONTAINER_CONTROL_PLANE_URL",
-] as const;
+// How long to wait for the daemon to provision the container before returning
+// a 202 "still working" to the caller (the job keeps running; the caller can
+// poll `/api/v1/jobs/{jobId}`). Container cold-start (image pull + boot) is
+// slower than a normal agent, so we give it generous headroom.
+const MAX_WAIT_MS = 110_000;
+const POLL_INTERVAL_MS = 2_500;
 
-function readStringEnv(c: AppContext, keys: readonly string[]): string | null {
-  const env = c.env ?? {};
-  for (const key of keys) {
-    const value = env[key];
-    if (typeof value === "string" && value.trim()) return value.trim();
-  }
-  return null;
-}
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 function validationError(c: AppContext, message: string): Response {
   return c.json({ success: false, error: message }, 400);
 }
 
-async function forwardContainerCreate(
+/**
+ * Build the session response from a running sandbox row. Mirrors the upstream
+ * shape the old control-plane returned, sourced from the daemon-provisioned
+ * sandbox instead of the dead HTTP origin.
+ */
+function buildSessionFromSandbox(
+  request: RequestCodingAgentContainerRequest,
+  createPayload: CodingContainerCreatePayload,
+  sandbox: {
+    id: string;
+    status: string;
+    bridge_url: string | null;
+    health_url: string | null;
+    created_at?: Date | string | null;
+  },
+) {
+  return buildCodingContainerSessionResponse({
+    request,
+    createPayload,
+    upstreamData: {
+      id: sandbox.id,
+      status: sandbox.status,
+      url: sandbox.bridge_url ?? sandbox.health_url ?? null,
+      createdAt:
+        sandbox.created_at instanceof Date
+          ? sandbox.created_at.toISOString()
+          : (sandbox.created_at ?? undefined),
+    },
+  });
+}
+
+async function createCodingContainer(
   c: AppContext,
   user: Pick<AuthedUser, "id"> & { organization_id: string },
   request: RequestCodingAgentContainerRequest,
   payload: CodingContainerCreatePayload,
 ): Promise<Response> {
-  const baseUrl = readStringEnv(c, CONTROL_PLANE_URL_KEYS);
-  if (!baseUrl) {
+  // ── SECURITY: image allowlist gate ───────────────────────────────────
+  const allowlist = containersEnv.codingContainerImageAllowlist();
+  if (!isCodingContainerImageAllowed(payload.image, allowlist)) {
+    logger.warn("[CodingContainers API] image rejected by allowlist", {
+      orgId: user.organization_id,
+      image: payload.image,
+    });
     return c.json(
       {
         success: false,
-        code: "CONTAINER_CONTROL_PLANE_NOT_CONFIGURED",
-        error: "Container control plane URL is not configured",
+        code: "CODING_CONTAINER_IMAGE_NOT_ALLOWED",
+        error: `Image '${payload.image}' is not permitted for coding containers`,
+      },
+      403,
+    );
+  }
+
+  // ── Gate on the provisioning daemon being healthy (same as agent provision) ──
+  const workerHealth = await checkProvisioningWorkerHealth();
+  if (!workerHealth.ok) {
+    logger.warn("[CodingContainers API] provisioning worker unavailable", {
+      orgId: user.organization_id,
+      code: workerHealth.code,
+    });
+    return c.json(
+      provisioningWorkerFailureBody(workerHealth),
+      workerHealth.status,
+    );
+  }
+
+  // ── Create the sandbox row carrying the custom image + coding env vars ──
+  const sandbox = await elizaSandboxService.createAgent({
+    organizationId: user.organization_id,
+    userId: user.id,
+    agentName: payload.name || payload.project_name,
+    environmentVars: payload.environment_vars,
+    dockerImage: payload.image,
+  });
+
+  // ── Enqueue the (existing, image-capable) provision job + kick the daemon ──
+  let enqueue: Awaited<
+    ReturnType<typeof provisioningJobService.enqueueAgentProvisionOnce>
+  >;
+  try {
+    enqueue = await provisioningJobService.enqueueAgentProvisionOnce({
+      agentId: sandbox.id,
+      organizationId: user.organization_id,
+      userId: user.id,
+      agentName: sandbox.agent_name ?? sandbox.id,
+      expectedUpdatedAt: sandbox.updated_at,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.error("[CodingContainers API] failed to enqueue provision job", {
+      orgId: user.organization_id,
+      sandboxId: sandbox.id,
+      error: message,
+    });
+    return c.json(
+      {
+        success: false,
+        code: "CODING_CONTAINER_ENQUEUE_FAILED",
+        error: "Failed to start coding container provisioning",
+        retryable: true,
       },
       503,
     );
   }
 
-  const target = new URL(baseUrl);
-  target.pathname = "/api/v1/containers";
-  target.search = "";
+  const { job } = enqueue;
+  void provisioningJobService.triggerImmediate(c.env).catch(() => {
+    // Logged inside the service; the cron is the safety net.
+  });
 
-  const sourceUrl = new URL(c.req.url);
-  const headers = new Headers();
-  headers.set("content-type", "application/json");
-  headers.set("x-forwarded-host", sourceUrl.host);
-  headers.set("x-forwarded-proto", sourceUrl.protocol.replace(":", ""));
-  headers.set("x-eliza-user-id", user.id);
-  headers.set("x-eliza-organization-id", user.organization_id);
+  // ── Poll the job for a synchronous result (best-effort within timeout) ──
+  const deadline = Date.now() + MAX_WAIT_MS;
+  while (Date.now() < deadline) {
+    await sleep(POLL_INTERVAL_MS);
+    const current = await provisioningJobService.getJobForOrg(
+      job.id,
+      user.organization_id,
+    );
+    if (!current) continue;
 
-  const internalToken = readStringEnv(c, ["CONTAINER_CONTROL_PLANE_TOKEN"]);
-  if (internalToken)
-    headers.set("x-container-control-plane-token", internalToken);
-
-  const databaseUrl = readStringEnv(c, ["DATABASE_URL"]);
-  if (databaseUrl) headers.set("x-eliza-cloud-database-url", databaseUrl);
-
-  try {
-    const upstream = await fetch(target, {
-      body: JSON.stringify(payload),
-      headers,
-      method: "POST",
-      redirect: "manual",
-    });
-    const text = await upstream.text();
-    let json: unknown = null;
-    if (text.trim()) {
-      try {
-        json = JSON.parse(text);
-      } catch {
-        json = null;
-      }
-    }
-
-    if (!upstream.ok) {
-      return new Response(
-        text ||
-          JSON.stringify({
+    if (current.status === "completed") {
+      const running = await elizaSandboxService.getAgent(
+        sandbox.id,
+        user.organization_id,
+      );
+      if (!running) {
+        return c.json(
+          {
             success: false,
-            error:
-              "Container control plane rejected the coding-container request",
-          }),
-        {
-          status: upstream.status,
-          statusText: upstream.statusText,
-          headers: {
-            "content-type":
-              upstream.headers.get("content-type") ?? "application/json",
+            code: "CODING_CONTAINER_MISSING_AFTER_PROVISION",
+            error: "Coding container provisioned but sandbox row was not found",
+            jobId: job.id,
           },
+          500,
+        );
+      }
+      return c.json(
+        {
+          success: true,
+          data: buildSessionFromSandbox(request, payload, running),
+          jobId: job.id,
         },
+        201,
       );
     }
 
-    const body =
-      json && typeof json === "object" ? (json as Record<string, unknown>) : {};
-    return c.json(
-      {
-        success: true,
-        data: buildCodingContainerSessionResponse({
-          request,
-          createPayload: payload,
-          upstreamData:
-            body.data && typeof body.data === "object"
-              ? (body.data as Record<string, unknown>)
-              : body,
-        }),
-        controlPlane: {
-          status: upstream.status,
-          polling:
-            body.polling && typeof body.polling === "object"
-              ? body.polling
-              : undefined,
+    if (current.status === "failed") {
+      const result = (current.result ?? {}) as Record<string, unknown>;
+      const errMsg =
+        typeof result.error === "string"
+          ? result.error
+          : "coding container provisioning failed";
+      logger.warn("[CodingContainers API] provision job failed", {
+        sandboxId: sandbox.id,
+        jobId: job.id,
+        error: errMsg,
+      });
+      return c.json(
+        {
+          success: false,
+          code: "CODING_CONTAINER_PROVISION_FAILED",
+          error: errMsg,
+          jobId: job.id,
         },
-      },
-      201,
-    );
-  } catch (error) {
-    logger.error("[CodingContainers API] control-plane forward failed", {
-      target: target.origin,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return c.json(
-      {
-        success: false,
-        code: "CONTAINER_CONTROL_PLANE_UNREACHABLE",
-        error: "Container control plane is unreachable",
-      },
-      503,
-    );
+        502,
+      );
+    }
   }
+
+  // ── Timed out waiting. The job keeps running; return 202 so the caller can
+  // poll the job endpoint and then re-request / fetch the container by id. ──
+  logger.info("[CodingContainers API] provision still running at timeout", {
+    sandboxId: sandbox.id,
+    jobId: job.id,
+  });
+  return c.json(
+    {
+      success: true,
+      pending: true,
+      message:
+        "Coding container provisioning is in progress. Poll the job endpoint for status.",
+      data: {
+        containerId: sandbox.id,
+        status: "pending",
+        agent: request.agent,
+      },
+      jobId: job.id,
+      polling: {
+        endpoint: `/api/v1/jobs/${job.id}`,
+        intervalMs: 5000,
+        expectedDurationMs: 120000,
+      },
+    },
+    202,
+  );
 }
 
 app.post("/", async (c) => {
@@ -157,7 +275,7 @@ app.post("/", async (c) => {
     }
 
     const createPayload = buildCodingContainerCreatePayload(parsed.data);
-    return forwardContainerCreate(c, user, parsed.data, createPayload);
+    return await createCodingContainer(c, user, parsed.data, createPayload);
   } catch (error) {
     logger.error("[CodingContainers API] request error:", error);
     return failureResponse(c, error);

--- a/packages/cloud-api/v1/cron/agent-hot-pool/route.ts
+++ b/packages/cloud-api/v1/cron/agent-hot-pool/route.ts
@@ -10,12 +10,12 @@ import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
  */
 
 import { verifyCronSecret } from "@/lib/auth/cron";
-import { forwardCronToContainerControlPlane } from "../../_container-control-plane-forward";
+import { cronSupersededByDaemon } from "../../_container-control-plane-forward";
 
 async function handleAgentHotPool(c: AppContext, env?: AppEnv["Bindings"]) {
   const authError = verifyCronSecret(c.req.raw, "[Agent Hot Pool]", env);
   if (authError) return authError;
-  return forwardCronToContainerControlPlane(c);
+  return cronSupersededByDaemon(c, "runInfraMaintenanceCycle (alloc reconcile)");
 }
 
 const __hono_app = new Hono<AppEnv>();

--- a/packages/cloud-api/v1/cron/deployment-monitor/route.ts
+++ b/packages/cloud-api/v1/cron/deployment-monitor/route.ts
@@ -14,7 +14,7 @@ import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
  */
 
 import { verifyCronSecret } from "@/lib/auth/cron";
-import { forwardCronToContainerControlPlane } from "../../_container-control-plane-forward";
+import { cronSupersededByDaemon } from "../../_container-control-plane-forward";
 
 async function handleDeploymentMonitor(
   c: AppContext,
@@ -22,7 +22,7 @@ async function handleDeploymentMonitor(
 ) {
   const authError = verifyCronSecret(c.req.raw, "[Deployment Monitor]", env);
   if (authError) return authError;
-  return forwardCronToContainerControlPlane(c);
+  return cronSupersededByDaemon(c, "processFleetUpgradeCycle");
 }
 
 const __hono_app = new Hono<AppEnv>();

--- a/packages/cloud-api/v1/cron/node-autoscale/route.ts
+++ b/packages/cloud-api/v1/cron/node-autoscale/route.ts
@@ -11,12 +11,12 @@ import { Hono } from "hono";
 
 import { verifyCronSecret } from "@/lib/auth/cron";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
-import { forwardCronToContainerControlPlane } from "../../_container-control-plane-forward";
+import { cronSupersededByDaemon } from "../../_container-control-plane-forward";
 
 async function handleAutoscale(c: AppContext, env?: AppEnv["Bindings"]) {
   const authError = verifyCronSecret(c.req.raw, "[Node Autoscale]", env);
   if (authError) return authError;
-  return forwardCronToContainerControlPlane(c);
+  return cronSupersededByDaemon(c, "processNodeAutoscaleCycle");
 }
 
 const __hono_app = new Hono<AppEnv>();

--- a/packages/cloud-api/v1/cron/pool-drain-idle/route.ts
+++ b/packages/cloud-api/v1/cron/pool-drain-idle/route.ts
@@ -1,13 +1,13 @@
 import { Hono } from "hono";
 import { verifyCronSecret } from "@/lib/auth/cron";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
-import { forwardCronToContainerControlPlane } from "../../_container-control-plane-forward";
+import { cronSupersededByDaemon } from "../../_container-control-plane-forward";
 
 /** Warm pool idle-scaledown cron. Trims surplus pool entries past the idle window. */
 async function handle(c: AppContext, env?: AppEnv["Bindings"]) {
   const authError = verifyCronSecret(c.req.raw, "[Pool Drain Idle]", env);
   if (authError) return authError;
-  return forwardCronToContainerControlPlane(c);
+  return cronSupersededByDaemon(c, "processPoolDrainIdleCycle");
 }
 
 const __hono_app = new Hono<AppEnv>();

--- a/packages/cloud-api/v1/cron/pool-health-check/route.ts
+++ b/packages/cloud-api/v1/cron/pool-health-check/route.ts
@@ -1,13 +1,13 @@
 import { Hono } from "hono";
 import { verifyCronSecret } from "@/lib/auth/cron";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
-import { forwardCronToContainerControlPlane } from "../../_container-control-plane-forward";
+import { cronSupersededByDaemon } from "../../_container-control-plane-forward";
 
 /** Warm pool health-check cron. Probes each pool entry; reaps dead/stuck rows. */
 async function handle(c: AppContext, env?: AppEnv["Bindings"]) {
   const authError = verifyCronSecret(c.req.raw, "[Pool Health Check]", env);
   if (authError) return authError;
-  return forwardCronToContainerControlPlane(c);
+  return cronSupersededByDaemon(c, "processNodeHealthCheckCycle");
 }
 
 const __hono_app = new Hono<AppEnv>();

--- a/packages/cloud-api/v1/cron/pool-image-rollout/route.ts
+++ b/packages/cloud-api/v1/cron/pool-image-rollout/route.ts
@@ -1,13 +1,13 @@
 import { Hono } from "hono";
 import { verifyCronSecret } from "@/lib/auth/cron";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
-import { forwardCronToContainerControlPlane } from "../../_container-control-plane-forward";
+import { cronSupersededByDaemon } from "../../_container-control-plane-forward";
 
 /** Warm pool image-rollout cron. Drains pool entries on stale images. */
 async function handle(c: AppContext, env?: AppEnv["Bindings"]) {
   const authError = verifyCronSecret(c.req.raw, "[Pool Image Rollout]", env);
   if (authError) return authError;
-  return forwardCronToContainerControlPlane(c);
+  return cronSupersededByDaemon(c, "processPrePullImagesCycle");
 }
 
 const __hono_app = new Hono<AppEnv>();

--- a/packages/cloud-api/v1/cron/pool-replenish/route.ts
+++ b/packages/cloud-api/v1/cron/pool-replenish/route.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { verifyCronSecret } from "@/lib/auth/cron";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
-import { forwardCronToContainerControlPlane } from "../../_container-control-plane-forward";
+import { cronSupersededByDaemon } from "../../_container-control-plane-forward";
 
 /**
  * Warm pool replenisher cron. Forwards to the Node container control
@@ -10,7 +10,7 @@ import { forwardCronToContainerControlPlane } from "../../_container-control-pla
 async function handle(c: AppContext, env?: AppEnv["Bindings"]) {
   const authError = verifyCronSecret(c.req.raw, "[Pool Replenish]", env);
   if (authError) return authError;
-  return forwardCronToContainerControlPlane(c);
+  return cronSupersededByDaemon(c, "runInfraMaintenanceCycle (warm pool)");
 }
 
 const __hono_app = new Hono<AppEnv>();

--- a/packages/cloud-api/v1/cron/process-provisioning-jobs/route.ts
+++ b/packages/cloud-api/v1/cron/process-provisioning-jobs/route.ts
@@ -10,7 +10,7 @@
 import { Hono } from "hono";
 import { verifyCronSecret } from "@/lib/auth/cron";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
-import { forwardCronToContainerControlPlane } from "../../_container-control-plane-forward";
+import { cronSupersededByDaemon } from "../../_container-control-plane-forward";
 
 async function handleProcessProvisioningJobs(
   c: AppContext,
@@ -18,7 +18,7 @@ async function handleProcessProvisioningJobs(
 ) {
   const authError = verifyCronSecret(c.req.raw, "[Provisioning Jobs]", env);
   if (authError) return authError;
-  return forwardCronToContainerControlPlane(c);
+  return cronSupersededByDaemon(c, "processPendingJobs");
 }
 
 const app = new Hono<AppEnv>();

--- a/packages/cloud-shared/src/lib/config/containers-env.ts
+++ b/packages/cloud-shared/src/lib/config/containers-env.ts
@@ -102,6 +102,44 @@ export const containersEnv = {
     );
   },
 
+  /**
+   * Allowlist of image refs/prefixes permitted for coding-container deploys.
+   *
+   * SECURITY: coding-containers let an authenticated org run an OUTSIDE
+   * image (e.g. `ghcr.io/dexploarer/bnancy:latest`). Without an allowlist any
+   * authed org could run an arbitrary image on our nodes. This is the gate.
+   *
+   * Format: comma-separated glob prefixes, e.g.
+   *   `ghcr.io/dexploarer/*,ghcr.io/elizaos/*,ghcr.io/waifufun/*`
+   * A trailing `*` matches any suffix (repo path, tag, digest). An entry with
+   * no `*` must match the image exactly. Matching is case-insensitive on the
+   * registry/repo and ignores surrounding whitespace.
+   *
+   * Returns the parsed, normalized list. Empty list = allowlist disabled
+   * (handled at the call site so an unset env doesn't silently open the gate;
+   * see `isCodingContainerImageAllowed`).
+   */
+  codingContainerImageAllowlist(): string[] {
+    const env = getCloudAwareEnv();
+    const raw = pick(
+      env.CODING_CONTAINER_IMAGE_ALLOWLIST,
+      env.ELIZA_CODING_CONTAINER_IMAGE_ALLOWLIST,
+      env.CONTAINERS_CODING_IMAGE_ALLOWLIST,
+    );
+    if (raw === undefined) {
+      // Secure-by-default starter set. Operators override via env.
+      return [
+        "ghcr.io/dexploarer/*",
+        "ghcr.io/elizaos/*",
+        "ghcr.io/waifufun/*",
+      ];
+    }
+    return raw
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0);
+  },
+
   /** Explicit operator-pinned agent image, without the hardcoded fallback. */
   defaultAgentImageOverride(): string | undefined {
     const env = getCloudAwareEnv();

--- a/packages/cloud-shared/src/lib/services/coding-containers.test.ts
+++ b/packages/cloud-shared/src/lib/services/coding-containers.test.ts
@@ -3,6 +3,7 @@ import { containersEnv } from "../config/containers-env";
 import { runWithCloudBindings } from "../runtime/cloud-bindings";
 import {
   buildCodingContainerCreatePayload,
+  buildCodingContainerSessionResponse,
   isCodingContainerImageAllowed,
 } from "./coding-containers";
 
@@ -38,6 +39,43 @@ describe("coding container payloads", () => {
     );
 
     expect(payload.image).toBe("ghcr.io/example/custom-coding-image:latest");
+  });
+});
+
+describe("coding container session response url", () => {
+  it("prefers the per-agent public HTTPS url over the internal bridge url", () => {
+    const request = { agent: "claude" } as const;
+    const createPayload = buildCodingContainerCreatePayload(request);
+    const session = buildCodingContainerSessionResponse({
+      request,
+      createPayload,
+      upstreamData: {
+        id: "abc123de-0000-0000-0000-000000000000",
+        status: "running",
+        publicUrl: "https://abc123de-0000-0000-0000-000000000000.waifu.fun",
+        url: "http://10.0.0.5:3000",
+      },
+    });
+
+    expect(session.url).toBe(
+      "https://abc123de-0000-0000-0000-000000000000.waifu.fun",
+    );
+  });
+
+  it("falls back to the internal url when no public url is present", () => {
+    const request = { agent: "claude" } as const;
+    const createPayload = buildCodingContainerCreatePayload(request);
+    const session = buildCodingContainerSessionResponse({
+      request,
+      createPayload,
+      upstreamData: {
+        id: "abc123de-0000-0000-0000-000000000000",
+        status: "running",
+        url: "http://10.0.0.5:3000",
+      },
+    });
+
+    expect(session.url).toBe("http://10.0.0.5:3000");
   });
 });
 

--- a/packages/cloud-shared/src/lib/services/coding-containers.test.ts
+++ b/packages/cloud-shared/src/lib/services/coding-containers.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
+import { containersEnv } from "../config/containers-env";
 import { runWithCloudBindings } from "../runtime/cloud-bindings";
-import { buildCodingContainerCreatePayload } from "./coding-containers";
+import {
+  buildCodingContainerCreatePayload,
+  isCodingContainerImageAllowed,
+} from "./coding-containers";
 
 describe("coding container payloads", () => {
   it("uses the coding remote runner image when configured", () => {
@@ -34,5 +38,85 @@ describe("coding container payloads", () => {
     );
 
     expect(payload.image).toBe("ghcr.io/example/custom-coding-image:latest");
+  });
+});
+
+describe("coding container image allowlist", () => {
+  const DEFAULT = [
+    "ghcr.io/dexploarer/*",
+    "ghcr.io/elizaos/*",
+    "ghcr.io/waifufun/*",
+  ];
+
+  it("allows images under an allowed prefix", () => {
+    expect(
+      isCodingContainerImageAllowed("ghcr.io/dexploarer/bnancy:latest", DEFAULT),
+    ).toBe(true);
+    expect(
+      isCodingContainerImageAllowed("ghcr.io/elizaos/eliza:stable", DEFAULT),
+    ).toBe(true);
+    expect(
+      isCodingContainerImageAllowed("ghcr.io/waifufun/runner:v2", DEFAULT),
+    ).toBe(true);
+  });
+
+  it("rejects images outside the allowlist", () => {
+    expect(
+      isCodingContainerImageAllowed("docker.io/library/nginx:latest", DEFAULT),
+    ).toBe(false);
+    expect(
+      isCodingContainerImageAllowed("ghcr.io/attacker/evil:latest", DEFAULT),
+    ).toBe(false);
+    // No bare-substring bypass: prefix must match from the start.
+    expect(
+      isCodingContainerImageAllowed(
+        "evil.io/ghcr.io/elizaos/eliza:stable",
+        DEFAULT,
+      ),
+    ).toBe(false);
+  });
+
+  it("is case-insensitive and trims whitespace", () => {
+    expect(
+      isCodingContainerImageAllowed("  GHCR.IO/Elizaos/Eliza:Stable  ", DEFAULT),
+    ).toBe(true);
+  });
+
+  it("fails closed on an empty allowlist", () => {
+    expect(isCodingContainerImageAllowed("ghcr.io/elizaos/eliza", [])).toBe(
+      false,
+    );
+  });
+
+  it("supports an explicit wildcard opt-out", () => {
+    expect(isCodingContainerImageAllowed("anything/at/all", ["*"])).toBe(true);
+  });
+
+  it("supports exact-match entries", () => {
+    expect(
+      isCodingContainerImageAllowed("ghcr.io/elizaos/eliza:stable", [
+        "ghcr.io/elizaos/eliza:stable",
+      ]),
+    ).toBe(true);
+    expect(
+      isCodingContainerImageAllowed("ghcr.io/elizaos/eliza:dev", [
+        "ghcr.io/elizaos/eliza:stable",
+      ]),
+    ).toBe(false);
+  });
+
+  it("env getter returns the secure default when unset", () => {
+    const allowlist = runWithCloudBindings({}, () =>
+      containersEnv.codingContainerImageAllowlist(),
+    );
+    expect(allowlist).toEqual(DEFAULT);
+  });
+
+  it("env getter parses a comma-separated override", () => {
+    const allowlist = runWithCloudBindings(
+      { CODING_CONTAINER_IMAGE_ALLOWLIST: "ghcr.io/foo/*, ghcr.io/bar/baz:1 " },
+      () => containersEnv.codingContainerImageAllowlist(),
+    );
+    expect(allowlist).toEqual(["ghcr.io/foo/*", "ghcr.io/bar/baz:1"]);
   });
 });

--- a/packages/cloud-shared/src/lib/services/coding-containers.ts
+++ b/packages/cloud-shared/src/lib/services/coding-containers.ts
@@ -177,6 +177,47 @@ export function buildCodingContainerCreatePayload(
   };
 }
 
+/**
+ * Returns true when `image` is permitted by the coding-container allowlist.
+ *
+ * SECURITY GATE. Coding-containers run an OUTSIDE image on our docker nodes,
+ * gated only by "any authenticated org" — so without this check any authed
+ * caller could run an arbitrary image. The allowlist is the gate.
+ *
+ * Matching rules per allowlist entry (all case-insensitive, whitespace-trimmed):
+ *  - Trailing `*`  → prefix match (entry without the `*` must be a prefix of
+ *    the image). `ghcr.io/elizaos/*` allows `ghcr.io/elizaos/eliza:stable`.
+ *  - No `*`        → exact match.
+ *  - A bare `*`    → matches anything (explicit opt-out; use with care).
+ *
+ * IMPORTANT: an EMPTY allowlist denies everything (fail-closed). The caller
+ * supplies the operator-configured / default allowlist (see
+ * `containersEnv.codingContainerImageAllowlist()`), which is never empty unless
+ * an operator explicitly sets `CODING_CONTAINER_IMAGE_ALLOWLIST=` to disable
+ * all coding-container deploys.
+ */
+export function isCodingContainerImageAllowed(
+  image: string,
+  allowlist: readonly string[],
+): boolean {
+  const normalizedImage = image.trim().toLowerCase();
+  if (!normalizedImage) return false;
+  if (allowlist.length === 0) return false; // fail-closed
+
+  for (const rawEntry of allowlist) {
+    const entry = rawEntry.trim().toLowerCase();
+    if (!entry) continue;
+    if (entry === "*") return true;
+    if (entry.endsWith("*")) {
+      const prefix = entry.slice(0, -1);
+      if (normalizedImage.startsWith(prefix)) return true;
+    } else if (normalizedImage === entry) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function readString(data: Record<string, unknown>, keys: string[]): string | undefined {
   for (const key of keys) {
     const value = data[key];


### PR DESCRIPTION
## Draft — WIP, do not merge (Sol reviews)

Retires the dead `container-control-plane` HTTP forward behind `POST /api/v1/coding-containers` (returns **521**: forwards to decommissioned origin :8791 / old .246).

### Problem
The coding-containers route HTTP-forwards `${CONTAINER_CONTROL_PLANE_URL}/api/v1/containers` to a retired orphan service. Node autoscaling + warm pool already migrated to the `eliza-provisioning-worker` daemon (jobs-table + Redis), which is healthy. Only coding-containers CRUD never migrated.

### Approach
Key finding: the daemon's `AGENT_PROVISION` path (`elizaSandboxService.provision()`) **already docker-runs arbitrary images** (`provision()` passes `docker_image` into `provider.create()`). So a coding container = an `agent_sandboxes` row with a custom `docker_image` + coding env, provisioned through the SAME healthy daemon.

- Rewrite `coding-containers/route.ts`: `createAgent({dockerImage,env})` → reuse existing `enqueueAgentProvisionOnce` + `triggerImmediate` → poll job → build session response. No new HTTP origin.
- **Image allowlist (security):** `CODING_CONTAINER_IMAGE_ALLOWLIST` env (default `ghcr.io/dexploarer/*,ghcr.io/elizaos/*,ghcr.io/waifufun/*`), reject others **403**. Closes a real gap: image was previously taken raw with zero validation.
- Audit dead-forwarding crons (deployment-monitor, process-provisioning-jobs, pool-replenish) so they stop 521ing.

See `PLAN.md` on the branch for the full design + the daemon-update (scp+restart) procedure.

### Status
Building. Commits land incrementally. Out of scope: the `*.waifu.fun` public-URL 502 (separate) — this PR makes the DEPLOY CALL work.

Co-authored-by: wakesync <shadow@shad0w.xyz>