### PR TITLE
fix(core): suppress a leaked TASKS spawn-arg JSON envelope from the user reply

### DIFF
--- a/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
+++ b/packages/core/src/runtime/__tests__/planner-loop-user-facing-text.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+	looksLikeSpawnEnvelopeJson,
 	runPlannerLoop,
 	singleVerifiedUserFacingToolResultText,
 } from "../planner-loop";
@@ -263,5 +264,49 @@ describe("singleVerifiedUserFacingToolResultText — failed-step filter", () => 
 	it("returns undefined when there are no successful tools", () => {
 		const trajectory = trajectoryWith([failedStep]);
 		expect(singleVerifiedUserFacingToolResultText(trajectory)).toBeUndefined();
+	});
+});
+
+// A weak planner (gpt-oss-class) sometimes hallucinates its own TASKS spawn-arg
+// object into messageToUser, leaking {"task":…,"agentType":"opencode",…} to the
+// user instead of spawning + narrating the sub-agent's real result (battery #3).
+// userSafeFinalMessage suppresses it via this structural shape detector.
+describe("looksLikeSpawnEnvelopeJson — spawn-arg leak detector", () => {
+	it("flags a leaked TASKS spawn-arg JSON object", () => {
+		expect(
+			looksLikeSpawnEnvelopeJson(
+				'{"task":"Fetch the current Bitcoin price","agentType":"opencode","approvalPreset":"standard","brief":"webfetch coingecko"}',
+			),
+		).toBe(true);
+	});
+
+	it("flags the same envelope wrapped in a ```json fence", () => {
+		expect(
+			looksLikeSpawnEnvelopeJson(
+				'```json\n{"task":"x","agentType":"codex","brief":"y"}\n```',
+			),
+		).toBe(true);
+	});
+
+	it("does NOT flag a real prose answer", () => {
+		expect(
+			looksLikeSpawnEnvelopeJson("The current price of bitcoin is $68,000."),
+		).toBe(false);
+	});
+
+	it("does NOT flag a genuine JSON answer with non-spawn keys", () => {
+		expect(
+			looksLikeSpawnEnvelopeJson('{"favoriteColor":"teal","mood":"calm"}'),
+		).toBe(false);
+	});
+
+	it("does NOT flag an object with only one spawn discriminator", () => {
+		expect(looksLikeSpawnEnvelopeJson('{"task":"do a thing"}')).toBe(false);
+	});
+
+	it("does NOT flag non-object / unparseable text", () => {
+		expect(looksLikeSpawnEnvelopeJson("[1,2,3]")).toBe(false);
+		expect(looksLikeSpawnEnvelopeJson('{"task": broken')).toBe(false);
+		expect(looksLikeSpawnEnvelopeJson("")).toBe(false);
 	});
 });

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -417,7 +417,7 @@ export async function runPlannerLoop(
 					status: "finished",
 					trajectory,
 					evaluator: terminalEvaluator,
-					finalMessage,
+					finalMessage: userSafeFinalMessage(finalMessage, trajectory),
 				};
 			}
 
@@ -511,7 +511,9 @@ export async function runPlannerLoop(
 			return {
 				status: "finished",
 				trajectory,
-				finalMessage: suppressReply ? "" : latestResult.text,
+				finalMessage: suppressReply
+					? ""
+					: userSafeFinalMessage(latestResult.text, trajectory),
 			};
 		}
 
@@ -2519,10 +2521,62 @@ function userSafeFinalMessage(
 	return candidate ? "I handled the available step." : undefined;
 }
 
+// Canonical TASKS/spawn-arg vocabulary. A planner that hallucinates its own
+// tool-call arguments into messageToUser leaks a JSON object like
+// {"task":"…","agentType":"opencode","approvalPreset":"standard","brief":"…"}.
+// Detect it by SHAPE — the reply itself must JSON.parse to an object whose keys
+// are a subset of this vocabulary with at least two discriminators — never by
+// matching the user's words. Real prose cannot JSON.parse to this object, and a
+// genuine user-requested JSON answer carries foreign keys, so this never fires
+// on a real reply.
+const SPAWN_ARG_KEYS = new Set([
+	"task",
+	"agentType",
+	"approvalPreset",
+	"brief",
+	"workdir",
+	"model",
+	"memoryContent",
+	"agents",
+	"repo",
+	"keepAliveAfterComplete",
+	"op",
+	"action",
+]);
+const SPAWN_ARG_DISCRIMINATORS = [
+	"task",
+	"agentType",
+	"approvalPreset",
+	"brief",
+];
+
+export function looksLikeSpawnEnvelopeJson(text: string): boolean {
+	let body = text.trim();
+	const fence = body.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+	if (fence?.[1]) body = fence[1].trim();
+	if (!body.startsWith("{") || !body.endsWith("}")) return false;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(body);
+	} catch {
+		return false;
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return false;
+	}
+	const keys = Object.keys(parsed as Record<string, unknown>);
+	if (keys.length === 0) return false;
+	if (!keys.every((k) => SPAWN_ARG_KEYS.has(k))) return false;
+	return (
+		SPAWN_ARG_DISCRIMINATORS.filter((k) => k in (parsed as object)).length >= 2
+	);
+}
+
 function isUnsafeUserVisibleText(value: string | undefined): boolean {
 	if (!value) return false;
 	const text = value.trim();
 	if (!text) return false;
+	if (looksLikeSpawnEnvelopeJson(text)) return true;
 	return [
 		/\bto=functions\.[A-Z0-9_]+\b/i,
 		/\bfunctions\.[A-Z0-9_]+\b/i,


### PR DESCRIPTION
A weak planner (gpt-oss-class) sometimes hallucinates its own `TASKS`/spawn-action argument object into `messageToUser`, so the user receives the raw envelope:

```json
{"task":"Fetch the current Bitcoin price","agentType":"opencode","approvalPreset":"standard","brief":"…"}
```

verbatim, instead of the spawned sub-agent's eventual result (the routing itself was correct — it *did* spawn — but the action-args leaked to the channel and the real result was never narrated).

**Fix (structural, not a regex on user intent):**
- Teach `isUnsafeUserVisibleText` a `looksLikeSpawnEnvelopeJson` detector: the reply must `JSON.parse` to an *object* whose keys are a **subset of the spawn-arg vocabulary** (`task`/`agentType`/`approvalPreset`/`brief`/…) with **≥2 discriminating keys**. Real prose can't parse to this object, and a genuine user-requested JSON answer carries foreign keys — so it never fires on a real reply (handles a ```` ```json ```` fence too).
- Route the two remaining planner-loop finish branches (the `continueChain===false` early return and the terminal-tool-call branch) through `userSafeFinalMessage`, so **all** finish branches go through the one guard.

Unit-tested (`looksLikeSpawnEnvelopeJson` positive/fenced/negative cases). Proven live on a running agent — the leak is gone, the sub-agent's result is narrated instead.