### PR TITLE
fix(core): route a coding request mentioning a market term to coding, not web

### DIFF
--- a/packages/core/src/__tests__/message-routing-live-regression.test.ts
+++ b/packages/core/src/__tests__/message-routing-live-regression.test.ts
@@ -5,6 +5,7 @@ import {
 	actionResultsSuppressPostActionContinuation,
 	extractPlannerActionNames,
 	findWebLookupActionName,
+	inferDirectCurrentRequestCandidateActions,
 	inferLocalShellCommandFromMessageText,
 	inferWebSearchQueryFromMessageText,
 	looksLikeSelfPolicyExplanationRequest,
@@ -208,6 +209,26 @@ describe("live routing regressions", () => {
 				directCandidateActions: ["WEB_FETCH"],
 			}),
 		).toBe(false);
+	});
+
+	it("routes a coding request that mentions a market term to coding, not web-lookup", () => {
+		// "build an app … bitcoin price" trips looksLikeWebSearchRequest (the market
+		// term) yet is a coding task. Coding-work must be checked before web-search
+		// so it routes to coding delegation, not a web lookup.
+		const actions = [{ name: "TASKS" }, { name: "WEB_SEARCH" }];
+		expect(
+			inferDirectCurrentRequestCandidateActions(
+				actions,
+				"build an app that shows the current bitcoin price",
+			),
+		).toEqual(["TASKS"]);
+		// A pure live-info ask (no coding verb) still routes to the web lookup.
+		expect(
+			inferDirectCurrentRequestCandidateActions(
+				actions,
+				"what is the current bitcoin price",
+			),
+		).toEqual(["WEB_SEARCH"]);
 	});
 
 	it("promotes explicit reply to direct shell/search action aliases", () => {

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3837,18 +3837,22 @@ function inferAckIntentCandidateActions(
 		]);
 		if (shellAction) return [shellAction];
 	}
-	if (looksLikeWebSearchRequest(actionText)) {
-		const lookupAction = findWebLookupActionName(actions);
-		if (lookupAction) return [lookupAction];
-	}
+	// Coding-work precedes web-search: "build an app that shows the bitcoin price"
+	// trips looksLikeWebSearchRequest (market term) yet is a coding task — route it
+	// to coding delegation, not a web lookup. Mirrors the coding-first guard in
+	// shouldPreferDirectCurrentCandidateActions.
 	if (looksLikeCodingWorkRequest(actionText)) {
 		const codingAction = findCodingDelegationActionName(actions);
 		if (codingAction) return [codingAction];
 	}
+	if (looksLikeWebSearchRequest(actionText)) {
+		const lookupAction = findWebLookupActionName(actions);
+		if (lookupAction) return [lookupAction];
+	}
 	return [];
 }
 
-function inferDirectCurrentRequestCandidateActions(
+export function inferDirectCurrentRequestCandidateActions(
 	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
 	messageText: string,
 ): string[] {
@@ -3864,13 +3868,16 @@ function inferDirectCurrentRequestCandidateActions(
 		]);
 		if (shellAction) return [shellAction];
 	}
-	if (looksLikeWebSearchRequest(messageText)) {
-		const lookupAction = findWebLookupActionName(actions);
-		if (lookupAction) return [lookupAction];
-	}
+	// Coding-work precedes web-search: a coding request mentioning a live/market
+	// term ("build a crypto price tracker") must route to coding delegation, not a
+	// web lookup. Mirrors shouldPreferDirectCurrentCandidateActions' coding guard.
 	if (looksLikeCodingWorkRequest(messageText)) {
 		const codingAction = findCodingDelegationActionName(actions);
 		if (codingAction) return [codingAction];
+	}
+	if (looksLikeWebSearchRequest(messageText)) {
+		const lookupAction = findWebLookupActionName(actions);
+		if (lookupAction) return [lookupAction];
 	}
 	return [];
 }


### PR DESCRIPTION
`inferDirectCurrentRequestCandidateActions` and `inferAckIntentCandidateActions` checked `looksLikeWebSearchRequest` **before** `looksLikeCodingWorkRequest`. So a coding task that happens to mention a live/market term —

> "build an app that shows the current bitcoin price"

tripped the web-search predicate (the "bitcoin price" market term) and was routed to a **web lookup** instead of **coding delegation**.

**Fix:** check coding-work first in both functions, mirroring the coding-first guard already present in `shouldPreferDirectCurrentCandidateActions`. A pure live-info ask with no coding verb ("what is the current bitcoin price") still falls through to the web lookup.

Exported `inferDirectCurrentRequestCandidateActions` and added a regression test (coding+market → coding; pure live-info → web). Proven live on a running agent.