### PR TITLE
style(plugin-twitch): biome-format integration.test.ts (unblocks Format Check CI)

### DIFF
--- a/plugins/plugin-twitch/__tests__/integration.test.ts
+++ b/plugins/plugin-twitch/__tests__/integration.test.ts
@@ -177,7 +177,6 @@ describe("Plugin metadata", () => {
     expect(twitchPlugin.services).toContain(TwitchService);
     expect(twitchPlugin.services).toContain(TwitchWorkflowCredentialProvider);
   });
-
 });
 
 // ===========================================================================


### PR DESCRIPTION
The **Format Check (biome)** CI job is currently failing repo-wide on a single unformatted file — `plugins/plugin-twitch/__tests__/integration.test.ts` — which blocks the `format:check` gate on every open PR against `develop`.

```
× Formatter would have printed the following content:  __tests__/integration.test.ts
```

This applies `biome format` to that file (a 1-line whitespace change, no logic change), so `bun run --cwd plugins/plugin-twitch format:check` passes again.