### PR TITLE
fix(daemon): use systemKey() helper for KMS preflight key id

### DIFF
--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.test.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.test.ts
@@ -15,7 +15,7 @@ describe("assertProvisioningWorkerPreflight", () => {
       env: { ELIZA_KMS_BACKEND: "local" },
     });
     expect(getOrCreateKey).toHaveBeenCalledWith(
-      "system:provisioning-worker-preflight",
+      "system:provisioning-worker-preflight/v1",
     );
   });
 

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -188,7 +188,12 @@ export async function assertProvisioningWorkerPreflight(
 
   try {
     const kms = createKmsClient({ env });
-    await kms.getOrCreateKey("system:provisioning-worker-preflight");
+    // Use the systemKey() helper so the key id matches the KEY_RE regex in
+    // packages/security/src/kms/key-namespace.ts (`/v<digit>` suffix required).
+    // Bare strings like "system:..." now throw `malformed key id` since the
+    // strict namespace regex landed in 0330ba3d64.
+    const { systemKey } = await import("@elizaos/security/kms");
+    await kms.getOrCreateKey(systemKey("provisioning-worker-preflight"));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(


### PR DESCRIPTION
## Why

Staging daemon hit a restart loop today (NRestarts=2881 before I caught it). Root cause is a self-conflict between two of recent commits:

- `0330ba3d64` (2026-05-28) introduces the strict KEY_RE regex in `packages/security/src/kms/key-namespace.ts` requiring every key id to end in `/v<digit>`.
- `56e266be82` (2026-05-30) adds the daemon preflight that calls `kms.getOrCreateKey("system:provisioning-worker-preflight")` — bare string, no `/v1` suffix.

When the strict regex sees the bare string it throws `KmsError: malformed key id: system:provisioning-worker-preflight`. The preflight catches that and bails the worker startup; systemd restarts it on a 7s cycle.

## Fix

`packages/scripts/cloud/admin/daemons/provisioning-worker.ts` — import the `systemKey()` helper from `@elizaos/security/kms` and use it to construct the canonical `system:provisioning-worker-preflight/v1` id. Same runtime behaviour for KMS storage; passes the regex.

`packages/scripts/cloud/admin/daemons/provisioning-worker.test.ts` — assertion updated to match the new key id string.

## Validation

- Staging daemon (eliza-staging-1) is currently in restart loop — this PR will land on develop, auto-deploy via the env-matrix workflow, daemon restarts on the new code, preflight passes.
- Prod is unaffected: it runs main, which doesn't include 56e266be82 yet (main is at the develop→main merge from yesterday 22:47, BEFORE 56e266be82 was written). Once we promote the next develop → main, prod gets this fix at the same time as the offending daemon code.

## Blocks

The next develop → main promote should wait until this PR is merged so prod doesn't inherit the restart loop.