### PR TITLE
feat(cloud): enable agent web UI by default (ELIZA_UI_ENABLE=true)

### DIFF
--- a/packages/cloud-shared/src/lib/constants/agent-flavors.ts
+++ b/packages/cloud-shared/src/lib/constants/agent-flavors.ts
@@ -28,7 +28,7 @@ export const AGENT_FLAVORS: AgentFlavor[] = [
     id: "eliza",
     name: "Eliza Agent",
     description:
-      "V2 elizaOS agent — bridge API + Steward integration. Web UI disabled by default; enable with ELIZA_UI_ENABLE=true.",
+      "V2 elizaOS agent — bridge API + Steward integration. Web UI enabled by default (token-gated by the agent-router via the per-agent ELIZA_API_TOKEN); disable per-agent with ELIZA_UI_ENABLE=false.",
     dockerImage: containersEnv.defaultAgentImage(),
   },
   {

--- a/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
+++ b/packages/cloud-shared/src/lib/services/managed-eliza-config.ts
@@ -132,9 +132,11 @@ export async function prepareManagedElizaBaseEnvironment(
       ELIZA_API_TOKEN: apiToken,
       ELIZA_ALLOW_WS_QUERY_TOKEN: "1",
       ELIZA_ALLOWED_ORIGINS: mergeManagedAllowedOrigins(existingEnv.ELIZA_ALLOWED_ORIGINS),
-      // Public web UI off by default. Operators can re-enable per-agent with
-      // ELIZA_UI_ENABLE=true via existingEnv when needed for ops/debug.
-      ELIZA_UI_ENABLE: existingEnv.ELIZA_UI_ENABLE ?? "false",
+      // Public web UI on by default — users access it via the agent
+      // subdomain (https://<agent-id>.elizacloud.ai), gated by
+      // ELIZA_API_TOKEN at the agent-router. Set ELIZA_UI_ENABLE=false in
+      // existingEnv to opt out per-agent.
+      ELIZA_UI_ENABLE: existingEnv.ELIZA_UI_ENABLE ?? "true",
       ELIZAOS_CLOUD_API_KEY: agentApiKey,
       ELIZAOS_CLOUD_ENABLED: "true",
       ELIZAOS_CLOUD_BASE_URL: resolveCloudApiBaseUrl(),


### PR DESCRIPTION
## Why

The per-agent web UI is the natural way users interact with a provisioned sandbox. It was disabled by default in `managed-eliza-config` because the original concern was that a public web UI exposed without auth would leak agent state to anyone who guessed the agent subdomain.

**That gate already exists**: the agent-router (Hetzner control plane) checks the per-agent `ELIZA_API_TOKEN` on every request before proxying to the container's web port. A client without a valid token gets `401` at the agent-router and never reaches the container. The web UI itself is therefore safe to enable by default — it's not publicly reachable, only reachable through the authenticated agent-router path.

## What

- `packages/cloud-shared/src/lib/services/managed-eliza-config.ts` — default `ELIZA_UI_ENABLE` flip from `"false"` to `"true"`; comment updated to point at the agent-router gate.
- `packages/cloud-shared/src/lib/constants/agent-flavors.ts` — flavor description updated to reflect the new default.

## Opt-out path preserved

Operators who want to disable UI per-agent can still set `ELIZA_UI_ENABLE=false` in the sandbox's existingEnv at provision time.