### PR TITLE
fix(install): bootstrap fixes unblocking fresh-clone dev:desktop boot

### DIFF
--- a/packages/scripts/build-private-workspace-packages.mjs
+++ b/packages/scripts/build-private-workspace-packages.mjs
@@ -44,6 +44,14 @@ const PACKAGES = [
     dir: "packages/plugin-remote-manifest",
     freshnessSentinel: "dist/index.js",
   },
+  {
+    // `@elizaos/agent/src/services/remote-plugin-bridge.ts` imports
+    // `@elizaos/plugin-worker-runtime/error`. The subpath export resolves
+    // to `./dist/error.js`, so the package must be built before any
+    // consumer (vite build, tsc, the runtime itself) can load it.
+    dir: "packages/plugin-worker-runtime",
+    freshnessSentinel: "dist/error.js",
+  },
 ];
 
 function log(msg) {

--- a/packages/shared/scripts/sync-to-public.mjs
+++ b/packages/shared/scripts/sync-to-public.mjs
@@ -27,6 +27,7 @@
 
 import {
   copyFileSync,
+  existsSync,
   mkdirSync,
   readdirSync,
   rmSync,
@@ -159,10 +160,13 @@ if (include.background) {
   synced.push(includeBackgroundVideos ? "background+videos" : "background");
 }
 if (includeClouds) {
-  copyDirClean(
-    join(ASSETS_ROOT, "clouds"),
-    join(resolvedTarget, "clouds"),
-    (entry) => {
+  // Asset trees that are not part of the git checkout (e.g. the optional
+  // `clouds/` directory on a fresh sparse checkout) must not hard-fail the
+  // consumer's prebuild. Skip with a synced-list breadcrumb instead so the
+  // caller's log makes the absence obvious.
+  const cloudsSrc = join(ASSETS_ROOT, "clouds");
+  if (existsSync(cloudsSrc)) {
+    copyDirClean(cloudsSrc, join(resolvedTarget, "clouds"), (entry) => {
       if (entry.startsWith("poster-")) {
         return /^poster-(?:640|960)\.jpg$/.test(entry);
       }
@@ -171,13 +175,15 @@ if (includeClouds) {
       return [...selectedCloudSpeeds].some((speed) =>
         entry.startsWith(`clouds_${speed}_`),
       );
-    },
-  );
-  synced.push(
-    selectedCloudSpeeds
-      ? `clouds(${[...selectedCloudSpeeds].join(",")})`
-      : "clouds",
-  );
+    });
+    synced.push(
+      selectedCloudSpeeds
+        ? `clouds(${[...selectedCloudSpeeds].join(",")})`
+        : "clouds",
+    );
+  } else {
+    synced.push("clouds(skipped:missing-source)");
+  }
 }
 
 console.log(


### PR DESCRIPTION
## Summary

Two one-file fixes that together unblock `bun run dev:desktop` from a fresh clone where the optional `packages/shared/assets/clouds/` directory is absent (e.g. sparse / partial checkouts) **and** where `@elizaos/plugin-worker-runtime` has never been built locally.

- **`fix(shared): skip --clouds sync when assets/clouds is absent`** — `dev-platform.mjs` and `build-capacitor-app.mjs` invoke `sync-to-public.mjs --clouds` unconditionally, but the source directory is not part of the tracked tree. Today the absence throws `ENOENT` and aborts the consumer's `predev`/`prebuild` chain before vite or the API can start. Now guarded by `existsSync` with a `clouds(skipped:missing-source)` breadcrumb on the synced-list log.

- **`fix(install): build @elizaos/plugin-worker-runtime in postinstall`** — `@elizaos/agent/src/services/remote-plugin-bridge.ts` imports `@elizaos/plugin-worker-runtime/error`. The subpath export resolves to `./dist/error.js`, but the package isn't in `build-private-workspace-packages.mjs` PACKAGES, so `dist/` never gets produced by postinstall. Vite, tsc, and the runtime all fail to resolve the subpath. Added with sentinel `dist/error.js`, matching the pattern already used for `packages/security` and `packages/plugin-remote-manifest`.

## How I hit these

Trying to validate end-to-end that the orchestrator / Cloud onboarding work for elizaOS/eliza#8124 works as advertised on a fresh checkout. `bun run dev:desktop` aborted on both of these before reaching the Electrobun window or the API port.

## Test plan
- [ ] `bun install` on a fresh clone — postinstall should now also build `packages/plugin-worker-runtime`.
- [ ] `bun run dev:desktop` (or `dev:web:ui`) — should not abort with `ENOENT … assets/clouds` from `sync-to-public.mjs`.
- [ ] `bun run --cwd apps/app build` — should resolve `@elizaos/plugin-worker-runtime/error` cleanly.

## Risk
Both changes are additive. No behavior change when `assets/clouds/` exists or when `plugin-worker-runtime` is already built.

Refs: elizaOS/eliza#8124