### PR TITLE
feat(orchestrator): add LLM goal verifier for /goal-style auto-validation

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/goal-llm-verifier.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/goal-llm-verifier.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Unit tests for the LLM goal verifier — covers the pure parts (prompt
+ * builder, response parser) and the orchestrator paths that bypass the
+ * model entirely (empty criteria, empty evidence, model failure).
+ *
+ * The model call itself is mocked via a minimal runtime stub so the suite
+ * never reaches a real provider.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildVerificationPrompt,
+  LLM_GOAL_VERIFIER_NAME,
+  parseJudgeResponse,
+  verifyGoalCompletion,
+} from "../../src/services/goal-llm-verifier.js";
+
+interface MockRuntimeOptions {
+  response?: string;
+  shouldThrow?: Error;
+  recordCall?: (args: { modelType: unknown; params: unknown }) => void;
+}
+
+function makeMockRuntime(opts: MockRuntimeOptions = {}) {
+  return {
+    useModel: async (modelType: unknown, params: unknown) => {
+      opts.recordCall?.({ modelType, params });
+      if (opts.shouldThrow) throw opts.shouldThrow;
+      return opts.response ?? "";
+    },
+  } as unknown as Parameters<typeof verifyGoalCompletion>[0];
+}
+
+describe("LLM_GOAL_VERIFIER_NAME", () => {
+  it("is the stable string callers stamp onto validateTask payloads", () => {
+    expect(LLM_GOAL_VERIFIER_NAME).toBe("llm-goal-verifier");
+  });
+});
+
+describe("buildVerificationPrompt", () => {
+  it("enumerates acceptance criteria as a numbered list", () => {
+    const prompt = buildVerificationPrompt({
+      goal: "Ship X",
+      acceptanceCriteria: ["foo passes", "bar passes"],
+      completionEvidence: "all done",
+    });
+    expect(prompt).toContain("1. foo passes");
+    expect(prompt).toContain("2. bar passes");
+  });
+
+  it("instructs the model to fail when evidence is silent on a criterion", () => {
+    const prompt = buildVerificationPrompt({
+      goal: "Ship X",
+      acceptanceCriteria: ["foo"],
+      completionEvidence: "nothing to see",
+    });
+    expect(prompt).toMatch(/silent on a criterion/);
+  });
+
+  it("includes the goal text", () => {
+    const prompt = buildVerificationPrompt({
+      goal: "Implement caching for /search endpoint",
+      acceptanceCriteria: ["c1"],
+      completionEvidence: "e",
+    });
+    expect(prompt).toContain("Implement caching for /search endpoint");
+  });
+
+  it("places a no-fence JSON instruction near the schema", () => {
+    const prompt = buildVerificationPrompt({
+      goal: "X",
+      acceptanceCriteria: ["c"],
+      completionEvidence: "e",
+    });
+    expect(prompt).toMatch(/Do not wrap it in ```/);
+    expect(prompt).toMatch(/"passed": <true\|false>/);
+  });
+
+  it("truncates very long completion evidence to keep the prompt bounded", () => {
+    const longEvidence = "X".repeat(20_000);
+    const prompt = buildVerificationPrompt({
+      goal: "X",
+      acceptanceCriteria: ["c"],
+      completionEvidence: longEvidence,
+    });
+    expect(prompt).toMatch(/\[…evidence truncated…\]/);
+    expect(prompt.length).toBeLessThan(20_000);
+  });
+});
+
+describe("parseJudgeResponse", () => {
+  it("accepts a clean JSON object and reports passed=true with empty missing", () => {
+    const parsed = parseJudgeResponse(
+      '{"passed": true, "summary": "all green", "missing": []}',
+      ["c1"],
+    );
+    expect(parsed.passed).toBe(true);
+    expect(parsed.summary).toBe("all green");
+    expect(parsed.missing).toEqual([]);
+  });
+
+  it("treats passed=true + non-empty missing as a failed verdict (schema invariant)", () => {
+    const parsed = parseJudgeResponse(
+      '{"passed": true, "summary": "x", "missing": ["c1"]}',
+      ["c1"],
+    );
+    expect(parsed.passed).toBe(false);
+    expect(parsed.missing).toEqual(["c1"]);
+  });
+
+  it("extracts the JSON object from prose preamble", () => {
+    const parsed = parseJudgeResponse(
+      'Here is my analysis. {"passed": false, "summary": "c2 not met", "missing": ["c2"]} Thanks.',
+      ["c1", "c2"],
+    );
+    expect(parsed.passed).toBe(false);
+    expect(parsed.summary).toBe("c2 not met");
+    expect(parsed.missing).toEqual(["c2"]);
+  });
+
+  it("handles nested braces in JSON values", () => {
+    const parsed = parseJudgeResponse(
+      '{"passed": false, "summary": "outer", "missing": ["{still text}"]}',
+      ["c"],
+    );
+    expect(parsed.missing).toEqual(["{still text}"]);
+  });
+
+  it("falls back to fail with full criteria list when no JSON object is present", () => {
+    const parsed = parseJudgeResponse("totally not json", ["c1", "c2"]);
+    expect(parsed.passed).toBe(false);
+    expect(parsed.summary).toMatch(/could not be parsed/);
+    expect(parsed.missing).toEqual(["c1", "c2"]);
+  });
+
+  it("falls back to fail when the JSON has invalid syntax", () => {
+    const parsed = parseJudgeResponse('{"passed": true, this is broken}', [
+      "c1",
+    ]);
+    expect(parsed.passed).toBe(false);
+    expect(parsed.missing).toEqual(["c1"]);
+  });
+
+  it("falls back to fail when parsed JSON is not an object", () => {
+    const parsed = parseJudgeResponse("[1,2,3]", ["c1"]);
+    expect(parsed.passed).toBe(false);
+    expect(parsed.missing).toEqual(["c1"]);
+  });
+
+  it("trims whitespace from missing entries and drops empties", () => {
+    const parsed = parseJudgeResponse(
+      '{"passed": false, "summary": "s", "missing": ["  c1  ", "", "c2"]}',
+      ["c1", "c2"],
+    );
+    expect(parsed.missing).toEqual(["c1", "c2"]);
+  });
+
+  it("clamps the summary to 280 chars", () => {
+    const long = "a".repeat(500);
+    const parsed = parseJudgeResponse(
+      `{"passed": true, "summary": "${long}", "missing": []}`,
+      ["c"],
+    );
+    expect(parsed.summary.length).toBe(280);
+  });
+});
+
+describe("verifyGoalCompletion (orchestration paths)", () => {
+  it("short-circuits to pass when acceptanceCriteria is empty", async () => {
+    const runtime = makeMockRuntime({
+      recordCall: () => {
+        throw new Error("model should not be called");
+      },
+    });
+    const result = await verifyGoalCompletion(runtime, {
+      goal: "anything",
+      acceptanceCriteria: [],
+      completionEvidence: "done",
+    });
+    expect(result.passed).toBe(true);
+    expect(result.summary).toMatch(/no acceptance criteria/i);
+    expect(result.missing).toEqual([]);
+    expect(result.rawResponse).toBe("");
+  });
+
+  it("short-circuits to fail when completionEvidence is empty", async () => {
+    const runtime = makeMockRuntime({
+      recordCall: () => {
+        throw new Error("model should not be called");
+      },
+    });
+    const result = await verifyGoalCompletion(runtime, {
+      goal: "x",
+      acceptanceCriteria: ["c1"],
+      completionEvidence: "",
+    });
+    expect(result.passed).toBe(false);
+    expect(result.summary).toMatch(/no completion evidence/i);
+    expect(result.missing).toEqual(["c1"]);
+  });
+
+  it("short-circuits to fail when completionEvidence is only whitespace", async () => {
+    const runtime = makeMockRuntime();
+    const result = await verifyGoalCompletion(runtime, {
+      goal: "x",
+      acceptanceCriteria: ["c1"],
+      completionEvidence: "   \n  \t  ",
+    });
+    expect(result.passed).toBe(false);
+    expect(result.missing).toEqual(["c1"]);
+  });
+
+  it("calls the model with TEXT_SMALL and forwards the prompt", async () => {
+    const calls: Array<{ modelType: unknown; params: unknown }> = [];
+    const runtime = makeMockRuntime({
+      recordCall: (args) => calls.push(args),
+      response: '{"passed": true, "summary": "ok", "missing": []}',
+    });
+    await verifyGoalCompletion(runtime, {
+      goal: "x",
+      acceptanceCriteria: ["c1"],
+      completionEvidence: "evidence",
+    });
+    expect(calls).toHaveLength(1);
+    const [{ modelType, params }] = calls;
+    expect(modelType).toBe("TEXT_SMALL");
+    expect(params).toMatchObject({ stopSequences: [] });
+    expect((params as { prompt: string }).prompt).toMatch(/Acceptance criteria/);
+  });
+
+  it("returns a structured fail when the model throws", async () => {
+    const runtime = makeMockRuntime({
+      shouldThrow: new Error("provider down"),
+    });
+    const result = await verifyGoalCompletion(runtime, {
+      goal: "x",
+      acceptanceCriteria: ["c1"],
+      completionEvidence: "evidence",
+    });
+    expect(result.passed).toBe(false);
+    expect(result.summary).toMatch(/provider down/);
+    expect(result.missing).toEqual(["c1"]);
+    expect(result.rawResponse).toBe("");
+  });
+
+  it("returns a passed verdict on a clean model response", async () => {
+    const runtime = makeMockRuntime({
+      response: '{"passed": true, "summary": "all good", "missing": []}',
+    });
+    const result = await verifyGoalCompletion(runtime, {
+      goal: "x",
+      acceptanceCriteria: ["c1", "c2"],
+      completionEvidence: "ran tests, all passed",
+    });
+    expect(result.passed).toBe(true);
+    expect(result.summary).toBe("all good");
+    expect(result.missing).toEqual([]);
+    expect(result.rawResponse).toContain('"passed": true');
+  });
+
+  it("returns a failed verdict when the model identifies missing criteria", async () => {
+    const runtime = makeMockRuntime({
+      response:
+        '{"passed": false, "summary": "tests not run", "missing": ["test suite green"]}',
+    });
+    const result = await verifyGoalCompletion(runtime, {
+      goal: "x",
+      acceptanceCriteria: ["test suite green"],
+      completionEvidence: "edited files but did not run tests",
+    });
+    expect(result.passed).toBe(false);
+    expect(result.summary).toBe("tests not run");
+    expect(result.missing).toEqual(["test suite green"]);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
+++ b/plugins/plugin-agent-orchestrator/src/api/orchestrator-routes.ts
@@ -11,6 +11,10 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  LLM_GOAL_VERIFIER_NAME,
+  verifyGoalCompletion,
+} from "../services/goal-llm-verifier.js";
 import type { TaskThreadDetailDto } from "../services/orchestrator-task-mapper.js";
 import { OrchestratorTaskService } from "../services/orchestrator-task-service.js";
 import type {
@@ -410,6 +414,65 @@ async function dispatchOrchestratorRoutes(
         return true;
       }
       sendJson(res, forked, 201);
+      return true;
+    }
+
+    // POST /tasks/:taskId/auto-validate  { completionEvidence: string }
+    //
+    // LLM-based goal verifier: reads the task's `acceptanceCriteria` and the
+    // caller-supplied completion evidence, asks a small model to judge whether
+    // every criterion is met, and forwards the verdict to `validateTask` under
+    // `verifier: "llm-goal-verifier"`. Opt-in per call so an LLM-billed
+    // judgment never fires without an explicit caller. See
+    // {@link verifyGoalCompletion} for the judge prompt and parser.
+    //
+    // Refs: elizaOS/eliza#8124
+    if (method === "POST" && sub === "auto-validate" && segments.length === 2) {
+      const body = await parseBody(req).catch(() => null);
+      if (!body) {
+        sendError(res, "Invalid JSON body", 400);
+        return true;
+      }
+      const completionEvidence = asString(body.completionEvidence) ?? "";
+      const doc = await service.getTask(taskId);
+      if (!doc) {
+        sendError(res, "Task not found", 404);
+        return true;
+      }
+      if (doc.task.status !== "validating") {
+        sendError(
+          res,
+          `Task must be validating before auto-validation can run (current: ${doc.task.status})`,
+          409,
+        );
+        return true;
+      }
+      const verdict = await verifyGoalCompletion(ctx.runtime, {
+        goal: doc.task.goal,
+        acceptanceCriteria: doc.task.acceptanceCriteria,
+        completionEvidence,
+      });
+      const task = await service
+        .validateTask(taskId, {
+          passed: verdict.passed,
+          summary: verdict.summary,
+          evidence: verdict.rawResponse || completionEvidence,
+          verifier: LLM_GOAL_VERIFIER_NAME,
+        })
+        .catch((error: unknown) => {
+          sendError(
+            res,
+            error instanceof Error ? error.message : "Validation failed",
+            409,
+          );
+          return undefined;
+        });
+      if (task === undefined) return true;
+      if (!task) {
+        sendError(res, "Task not found", 404);
+        return true;
+      }
+      sendJson(res, { task, verdict });
       return true;
     }
 

--- a/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-llm-verifier.ts
@@ -1,0 +1,237 @@
+/**
+ * LLM-based goal verifier.
+ *
+ * On `task_complete` an orchestrator task advances to status `validating`
+ * (see {@link OrchestratorTaskService.recordSessionEvent}) and waits for a
+ * caller to invoke {@link OrchestratorTaskService.validateTask} with a
+ * pass/fail judgment. Historically the only validators were a human
+ * pressing a button in the orchestrator UI and the pattern-based
+ * sub-agent-completion response evaluator (which only routes back through
+ * TASKS when the completion text contains explicit failure markers, not
+ * when the work simply doesn't meet the goal).
+ *
+ * This service is the third validator: a small-model judge that reads the
+ * task's `acceptanceCriteria` and the sub-agent's completion evidence and
+ * returns a structured `{ passed, summary, missing }` verdict. Callers
+ * (HTTP route, orchestrator UI button, future automatic hook) forward the
+ * verdict to {@link OrchestratorTaskService.validateTask} using
+ * `verifier: "llm-goal-verifier"`.
+ *
+ * Design constraints:
+ *
+ * - **No automatic firing.** The verifier is opt-in per task so an LLM
+ *   call cannot be triggered without an explicit caller — protects users
+ *   from surprise model spend.
+ * - **Small model only.** `ModelType.TEXT_SMALL` is sufficient for a
+ *   yes/no judgment against a short criteria list and keeps the per-task
+ *   cost bounded.
+ * - **Defensive parse.** A malformed model response always resolves to
+ *   `passed: false` with an explanatory summary, never crashes the route.
+ *
+ * Refs: elizaOS/eliza#8124
+ *
+ * @module services/goal-llm-verifier
+ */
+
+import { type IAgentRuntime, ModelType } from "@elizaos/core";
+
+/** Stable identifier the verifier stamps onto the `validateTask` payload so
+ *  callers can distinguish LLM judgments from human approvals or pattern
+ *  evaluators in the orchestrator audit log. */
+export const LLM_GOAL_VERIFIER_NAME = "llm-goal-verifier";
+
+export interface GoalVerificationInput {
+  /** The durable task goal — the "what" the worker owns. */
+  goal: string;
+  /** Explicit acceptance criteria from the task record. May be empty when
+   *  the task was opened without any. */
+  acceptanceCriteria: readonly string[];
+  /** Concatenated completion evidence: sub-agent final reply, test output,
+   *  files touched, etc. The caller decides what to include. */
+  completionEvidence: string;
+}
+
+export interface GoalVerificationResult {
+  /** True when every acceptance criterion appears to be met AND no stated
+   *  constraint was violated. */
+  passed: boolean;
+  /** One-sentence human-readable summary suitable for the
+   *  `OrchestratorTaskEvent.summary` field. */
+  summary: string;
+  /** Each criterion the verifier could not confirm from the evidence. Empty
+   *  when `passed` is true. Used by the orchestrator to compose a
+   *  corrective follow-up prompt. */
+  missing: string[];
+  /** Raw model response text, kept for the audit log and for tests. */
+  rawResponse: string;
+}
+
+const EMPTY_CRITERIA_SUMMARY =
+  "No acceptance criteria were specified on the task; defaulting to pass.";
+const EMPTY_EVIDENCE_SUMMARY =
+  "No completion evidence was provided; cannot confirm criteria.";
+const MALFORMED_RESPONSE_SUMMARY =
+  "Verifier returned a response that could not be parsed; defaulting to fail.";
+
+const MAX_EVIDENCE_CHARS = 12_000;
+
+function trimEvidence(evidence: string): string {
+  if (evidence.length <= MAX_EVIDENCE_CHARS) return evidence;
+  const headSlice = Math.floor(MAX_EVIDENCE_CHARS * 0.6);
+  const tailSlice = MAX_EVIDENCE_CHARS - headSlice - 32;
+  return `${evidence.slice(0, headSlice)}\n\n[…evidence truncated…]\n\n${evidence.slice(-tailSlice)}`;
+}
+
+function bulletList(items: readonly string[]): string {
+  return items.map((item, index) => `${index + 1}. ${item}`).join("\n");
+}
+
+/** The judge prompt. Kept deliberately small and structured so a small
+ *  model can produce parseable JSON reliably. */
+export function buildVerificationPrompt(input: GoalVerificationInput): string {
+  const criteria = bulletList(input.acceptanceCriteria);
+  const evidence = trimEvidence(input.completionEvidence.trim());
+  return [
+    "You are verifying whether a coding sub-agent satisfied every acceptance criterion of an orchestrator task before the parent agent marks the task done.",
+    "",
+    `Task goal:`,
+    input.goal.trim() || "(no goal text was provided)",
+    "",
+    "Acceptance criteria (each must hold for the task to pass):",
+    criteria,
+    "",
+    "Completion evidence reported by the sub-agent:",
+    "---",
+    evidence || "(no evidence)",
+    "---",
+    "",
+    "For EACH numbered criterion above, decide whether the evidence directly demonstrates the criterion holds.",
+    "Be strict: if the evidence is silent on a criterion, that criterion fails.",
+    "",
+    "Respond with a SINGLE JSON object and nothing else. Do not wrap it in ```. Schema:",
+    '{ "passed": <true|false>, "summary": "<one sentence under 200 chars>", "missing": ["<criterion text that was NOT confirmed>", ...] }',
+    "",
+    '`passed` MUST be false whenever `missing` is non-empty.',
+    "If every criterion is confirmed, `missing` must be an empty array and `passed` true.",
+  ].join("\n");
+}
+
+interface ParsedJudgeResponse {
+  passed: boolean;
+  summary: string;
+  missing: string[];
+}
+
+function findFirstJsonObject(raw: string): string | null {
+  const start = raw.indexOf("{");
+  if (start < 0) return null;
+  let depth = 0;
+  for (let i = start; i < raw.length; i += 1) {
+    const ch = raw[i];
+    if (ch === "{") depth += 1;
+    else if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) return raw.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+export function parseJudgeResponse(
+  raw: string,
+  acceptanceCriteria: readonly string[],
+): ParsedJudgeResponse {
+  const text = raw.trim();
+  const jsonSlice = findFirstJsonObject(text);
+  if (!jsonSlice) {
+    return {
+      passed: false,
+      summary: MALFORMED_RESPONSE_SUMMARY,
+      missing: [...acceptanceCriteria],
+    };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonSlice);
+  } catch {
+    return {
+      passed: false,
+      summary: MALFORMED_RESPONSE_SUMMARY,
+      missing: [...acceptanceCriteria],
+    };
+  }
+  if (parsed === null || typeof parsed !== "object") {
+    return {
+      passed: false,
+      summary: MALFORMED_RESPONSE_SUMMARY,
+      missing: [...acceptanceCriteria],
+    };
+  }
+  const record = parsed as Record<string, unknown>;
+  const passedRaw = record.passed;
+  const summaryRaw = record.summary;
+  const missingRaw = record.missing;
+  const missing = Array.isArray(missingRaw)
+    ? missingRaw
+        .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+        .filter((entry) => entry.length > 0)
+    : [];
+  // Enforce the schema invariant: missing non-empty ⇒ passed false.
+  const passed = passedRaw === true && missing.length === 0;
+  const summary =
+    typeof summaryRaw === "string" && summaryRaw.trim().length > 0
+      ? summaryRaw.trim().slice(0, 280)
+      : passed
+        ? "All acceptance criteria confirmed by verifier."
+        : "Verifier did not confirm every acceptance criterion.";
+  return { passed, summary, missing };
+}
+
+/**
+ * Ask a small model to judge whether the sub-agent's completion evidence
+ * satisfies every acceptance criterion. Returns a structured verdict the
+ * caller can forward to {@link OrchestratorTaskService.validateTask}.
+ *
+ * Pure with respect to filesystem and network state — the only side effect
+ * is one `runtime.useModel` call.
+ */
+export async function verifyGoalCompletion(
+  runtime: IAgentRuntime,
+  input: GoalVerificationInput,
+): Promise<GoalVerificationResult> {
+  if (input.acceptanceCriteria.length === 0) {
+    return {
+      passed: true,
+      summary: EMPTY_CRITERIA_SUMMARY,
+      missing: [],
+      rawResponse: "",
+    };
+  }
+  if (input.completionEvidence.trim().length === 0) {
+    return {
+      passed: false,
+      summary: EMPTY_EVIDENCE_SUMMARY,
+      missing: [...input.acceptanceCriteria],
+      rawResponse: "",
+    };
+  }
+  const prompt = buildVerificationPrompt(input);
+  let raw: string;
+  try {
+    const result = await runtime.useModel(ModelType.TEXT_SMALL, {
+      prompt,
+      stopSequences: [],
+    });
+    raw = typeof result === "string" ? result : String(result);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return {
+      passed: false,
+      summary: `Verifier model call failed: ${detail.slice(0, 200)}`,
+      missing: [...input.acceptanceCriteria],
+      rawResponse: "",
+    };
+  }
+  const parsed = parseJudgeResponse(raw, input.acceptanceCriteria);
+  return { ...parsed, rawResponse: raw };
+}


### PR DESCRIPTION
## Summary

elizaOS/eliza#8124 says the orchestrator should \"ALWAYS act like \`/goal\` — confirming that sub agents complete all criteria and didn't break any constraints\". Today a sub-agent's \`task_complete\` event advances the task to \`validating\` and waits for a caller to invoke \`OrchestratorTaskService.validateTask\`. The only existing validators are a human pressing a button in the orchestrator UI and the pattern-based \`sub-agent-completion\` response evaluator (which routes back through TASKS only when completion text contains explicit failure markers — it does not judge whether the work satisfies the goal).

This PR adds a third validator: a small-model judge that reads the task's \`acceptanceCriteria\` and the caller-supplied completion evidence and returns a structured \`{ passed, summary, missing }\` verdict. The verdict is forwarded to the existing \`validateTask\` under \`verifier: \"llm-goal-verifier\"\` so audit-log consumers can distinguish LLM judgments from human approvals.

## Commits

1. **\`feat: add LLM goal verifier service\`** — pure judge function + 23 unit tests covering the prompt builder, response parser (clean JSON, prose preamble, nested braces, malformed JSON, non-object root, schema-invariant enforcement, summary clamp, whitespace trim), and orchestration paths that bypass the model (empty criteria, empty evidence, model throw, pass, fail). Model call is mocked via a minimal runtime stub.

2. **\`feat: expose POST /tasks/:id/auto-validate\`** — wires the service into the orchestrator HTTP surface. Validates the task is \`validating\`, calls \`verifyGoalCompletion\` once, forwards verdict to \`validateTask\`, returns \`{ task, verdict }\`.

## Design constraints

- **No automatic firing.** The verifier runs only when an explicit caller invokes \`POST /tasks/:id/auto-validate\` — orchestrator UI button, TASKS sub-action, or future event-driven hook. An LLM-billed judgment never fires without consent.
- **\`ModelType.TEXT_SMALL\`** is sufficient for yes/no judgment against a short criteria list and keeps per-task cost bounded.
- **Defensive parse.** Malformed model responses always resolve to \`passed: false\` with an explanatory summary, never crash the route.
- **Empty criteria** short-circuits to pass; **empty evidence** short-circuits to fail. Both paths skip the model call entirely.

## Test plan

- [ ] \`bun run --cwd plugins/plugin-agent-orchestrator test:unit\` passes (23 new tests).
- [ ] On a working dev:desktop boot: spawn a task with acceptance criteria, wait for sub-agent completion, \`POST /api/orchestrator/tasks/:id/auto-validate { completionEvidence: \"…\" }\`, confirm the task transitions to \`done\` or back to \`active\` based on the verdict.

## Out of scope (follow-up PRs)

- Automatic firing on \`validating\` transition. Requires a settings flag (\`ELIZAOS_ORCHESTRATOR_AUTO_VALIDATE\`) and an event-driven listener. Held back until the judge is proven on real workloads.
- Auto-extraction of \`completionEvidence\` from the most recent \`task_complete\` event + last sub_agent messages. Currently the caller supplies it.
- gpt-oss-120b orchestrator policy. The verifier already routes through \`runtime.useModel\` so whatever the runtime's small-model provider is configured to use will be used.

Refs: elizaOS/eliza#8124