### PR TITLE
fix(orchestrator): preserve a sub-agent's printed-value deliverable (no truncation)

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-completion-evaluator.test.ts
@@ -68,6 +68,44 @@ describe("subAgentCompletionResponseEvaluator", () => {
     });
   });
 
+  it("surfaces a captured printed-value deliverable verbatim instead of the model's truncation", async () => {
+    // The router stripped the [tool output:] block from the completion text and
+    // carried the value as metadata.subAgentDeliverable; the parent reply was
+    // truncated to "202". The evaluator must surface the full carried value.
+    const context = makeContext({
+      text: "[sub-agent: print date (opencode) — task_complete]\nRunning the date command.",
+      metadata: { subAgentDeliverable: "2026-06-02" },
+      messageHandler: { plan: { contexts: ["general"], reply: "202" } },
+    });
+
+    expect(subAgentCompletionResponseEvaluator.shouldRun(context)).toBe(true);
+    expect(subAgentCompletionResponseEvaluator.evaluate(context)).toEqual({
+      requiresTool: false,
+      setContexts: [SIMPLE_CONTEXT_ID],
+      clearCandidateActions: true,
+      clearParentActionHints: true,
+      reply: "2026-06-02",
+      debug: [
+        "verified sub-agent completion carries a captured printed-value deliverable; surfacing it directly",
+      ],
+    });
+  });
+
+  it("keeps the current reply when it already leads with the carried deliverable", async () => {
+    // When the model's reply already contains the exact value, keep it (it adds
+    // useful one-line context) rather than discarding it for the bare value.
+    const context = makeContext({
+      text: "[sub-agent: print date (opencode) — task_complete]\nRan it.",
+      metadata: { subAgentDeliverable: "2026-06-02" },
+      messageHandler: {
+        plan: { contexts: ["general"], reply: "The date is:\n2026-06-02" },
+      },
+    });
+
+    const result = subAgentCompletionResponseEvaluator.evaluate(context);
+    expect(result.reply).toBe("The date is:\n2026-06-02");
+  });
+
   it("posts verified URL replies even when Stage 1 inferred generic TASKS", async () => {
     const context = makeContext({
       text: "[sub-agent: demo (opencode) — task_complete]\nSearch for data/apps directory.\n[tool output: data/apps]\n/workspace/apps/demo/index.html",

--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -241,6 +241,39 @@ describe("SubAgentRouter", () => {
     await router.stop();
   });
 
+  it("stamps subAgentDeliverable from a clean captured scalar (no URL / no change-set)", async () => {
+    const { runtime, handleMessage } = makeRuntime({ acp: acp.service });
+    const router = await SubAgentRouter.start(runtime);
+    acp.emit(SESSION_ID, "task_complete", {
+      response:
+        "[sub-agent: print date]\n[tool output: date]\n2026-06-02\n[/tool output]",
+      durationMs: 500,
+    });
+    await new Promise((r) => setImmediate(r));
+    const metadata = handleMessage.mock.calls[0]?.[1]?.content
+      ?.metadata as Record<string, unknown>;
+    expect(metadata?.subAgentDeliverable).toBe("2026-06-02");
+    await router.stop();
+  });
+
+  it("does NOT stamp raw JSON / multi-line tool output (live-info curl), leaving it to be summarized", async () => {
+    const { runtime, handleMessage } = makeRuntime({ acp: acp.service });
+    const router = await SubAgentRouter.start(runtime);
+    // A "fetch the bitcoin price" spawn curls an API → the captured output is raw
+    // JSON (often plus a second tool block), which the model should phrase, not
+    // dump verbatim. Only a single clean scalar line is carried.
+    acp.emit(SESSION_ID, "task_complete", {
+      response:
+        '[tool output: curl]\n{"bitcoin":{"usd":69388}}\n[/tool output]\n[tool output: py]\n/usr/bin/bash: line 1: python: not found\n[/tool output]',
+      durationMs: 500,
+    });
+    await new Promise((r) => setImmediate(r));
+    const metadata = handleMessage.mock.calls[0]?.[1]?.content
+      ?.metadata as Record<string, unknown>;
+    expect(metadata?.subAgentDeliverable).toBeUndefined();
+    await router.stop();
+  });
+
   it("carries workdir route metadata into routed terminal messages", async () => {
     session = makeSession({
       metadata: {

--- a/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
+++ b/plugins/plugin-agent-orchestrator/src/evaluators/sub-agent-completion.ts
@@ -322,6 +322,20 @@ function verifiedUrlsFromMetadata(message: Memory): string[] {
   return stringArrayOf(metadataRecord(message)?.subAgentVerifiedUrls);
 }
 
+// The printed-value deliverable the router captured verbatim from the raw
+// sub-agent stdout (set as metadata.subAgentDeliverable on the no-URL,
+// no-change-set completion path — see SubAgentRouter). Present only when there
+// is a concrete value to surface; on that path composeNarration strips the
+// captured tool-output from the completion text, so without this the value is
+// gone and the parent model re-renders (and truncates, e.g. 2026-06-02 -> 202)
+// whatever prose is left. Surfacing it here keeps the deliverable deterministic.
+function deliverableFromMetadata(message: Memory): string | undefined {
+  const value = metadataRecord(message)?.subAgentDeliverable;
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
 function isSuccessfulSubAgentCompletion(message: Memory): boolean {
   const content = contentRecord(message);
   const metadata = metadataRecord(message);
@@ -451,6 +465,8 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
     ) {
       return true;
     }
+    // A captured printed-value deliverable must be surfaced verbatim — run.
+    if (deliverableFromMetadata(message)) return true;
     if (hasVerifiedCompletionReply(currentReply, completionText, verifiedUrls))
       return true;
     if (hasCleanFinalProseAfterToolOutput(completionText)) return true;
@@ -482,6 +498,31 @@ export const subAgentCompletionResponseEvaluator: ResponseHandlerEvaluator = {
         addParentActionHints: ["TASKS"],
         debug: [
           "sub-agent completion contains failure markers without clear positive evidence; routing back through TASKS for grounded follow-up",
+        ],
+      };
+    }
+    // The router captured a printed-value deliverable verbatim (no URL, no
+    // change set). It IS the answer, and composeNarration stripped it from the
+    // completion text — so surface it directly instead of letting the parent
+    // model re-render (and truncate) it, or routing it back through TASKS as
+    // "captured tool output". Keep the current reply only if it already leads
+    // with the exact value (then it carries the value plus useful context).
+    const deliverable = deliverableFromMetadata(message);
+    if (deliverable) {
+      const cleanCurrent = cleanCompletionReply(currentReply);
+      const reply =
+        cleanCurrent?.includes(deliverable) === true
+          ? cleanCurrent
+          : deliverable;
+      return {
+        ...respondIfNeeded(messageHandler),
+        requiresTool: false,
+        setContexts: [SIMPLE_CONTEXT_ID],
+        clearCandidateActions: true,
+        clearParentActionHints: true,
+        reply,
+        debug: [
+          "verified sub-agent completion carries a captured printed-value deliverable; surfacing it directly",
         ],
       };
     }

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -764,8 +764,23 @@ export class SubAgentRouter extends Service {
         return;
       }
     }
-    if (event === "task_complete" && verifiedUrls.length > 0) {
-      text = verifiedUrlCompletionFallback(text, verifiedUrls);
+    // Structural carrier for a printed-value deliverable (mirrors the verified-
+    // URL carrier in the metadata below). On the no-change-set, no-URL completion
+    // — exactly the path where composeNarration drops the captured stdout — recover
+    // it from the RAW response (before narration strips it) so the completion
+    // evaluator can relay it verbatim instead of having the parent model
+    // re-summarize and truncate it. The change-set path and the URL path keep
+    // their deliverable through composeNarration / verifiedUrlCompletionFallback.
+    let capturedDeliverable: string | undefined;
+    if (event === "task_complete") {
+      if (verifiedUrls.length > 0) {
+        text = verifiedUrlCompletionFallback(text, verifiedUrls);
+      } else if (!changeSet) {
+        capturedDeliverable = capturedStdoutDeliverable(
+          pickPayloadString(data, "response") ??
+            pickPayloadString(data, "finalText"),
+        );
+      }
     }
     const routingKind = routingKindForEvent(event, data, capExceeded);
     const targets = swarmTargetsForRouting(origin, routingKind);
@@ -842,6 +857,9 @@ export class SubAgentRouter extends Service {
             ...(capExceeded ? { subAgentCapExceeded: true } : {}),
             ...(verifiedUrls.length > 0
               ? { subAgentVerifiedUrls: verifiedUrls }
+              : {}),
+            ...(capturedDeliverable
+              ? { subAgentDeliverable: capturedDeliverable }
               : {}),
             ...(origin.userId ? { originUserId: origin.userId } : {}),
             ...(origin.parentMessageId
@@ -1599,6 +1617,31 @@ function stripToolTranscript(text: string): string {
     .replace(/\[tool output:[^\]]*\][\s\S]*?\[\/tool output\]/g, "")
     .replace(/\n{3,}/g, "\n\n")
     .trim();
+}
+
+// Recover the captured tool-output stdout verbatim — the inner text between
+// [tool output: …] / [/tool output] markers — the inverse of stripToolTranscript.
+// On the no-change-set completion path stripToolTranscript DELETES the block
+// whole (a lone tool-output there is usually process status), but for a
+// print-a-value task (no files changed -> no diff) that block IS the deliverable
+// the user asked for. Carry it out as a structural field so the completion
+// evaluator can relay it verbatim instead of having the parent model re-render
+// (and truncate, e.g. "2026-06-02" -> "202") whatever prose survives the strip.
+function capturedStdoutDeliverable(
+  response: string | undefined,
+): string | undefined {
+  if (!response) return undefined;
+  const joined = [
+    ...response.matchAll(/\[tool output:[^\]]*\]([\s\S]*?)\[\/tool output\]/g),
+  ]
+    .map((m) => m[1]?.trim())
+    .filter((s): s is string => Boolean(s))
+    .join("\n")
+    .trim();
+  // Shape gate: a single short deliverable block. Multi-KB transcripts and long
+  // code-task narrations stay on the model-rendered path unchanged.
+  if (!joined || joined.length > 2048) return undefined;
+  return joined;
 }
 
 function composeNarration(

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -1638,9 +1638,15 @@ function capturedStdoutDeliverable(
     .filter((s): s is string => Boolean(s))
     .join("\n")
     .trim();
-  // Shape gate: a single short deliverable block. Multi-KB transcripts and long
-  // code-task narrations stay on the model-rendered path unchanged.
-  if (!joined || joined.length > 2048) return undefined;
+  // Only a SINGLE clean scalar line is surfaced verbatim — the "print/echo the
+  // answer" case this carrier exists for (a date, a number, a reversed string).
+  // Anything else stays on the model-rendered path so it gets summarized, not
+  // dumped: a multi-line capture (a tool transcript — e.g. a curl followed by a
+  // script run), a raw JSON/array payload (a curl'd API response the user wants
+  // phrased, not pasted), or a long block. Erring toward NOT firing keeps raw
+  // tool output from leaking to the user.
+  if (!joined || joined.includes("\n") || joined.length > 200) return undefined;
+  if (joined.startsWith("{") || joined.startsWith("[")) return undefined;
   return joined;
 }
 


### PR DESCRIPTION
## Problem

A "spawn a coding sub-agent, run it, and report the output" task whose result is a **printed value** (the sub-agent changed no files → no diff, and produced no URL) loses that value in the completion narration:

1. `composeNarration`'s `stripToolTranscript` deletes the captured `[tool output: …] … [/tool output]` block from the completion text (on the no-change-set path a lone tool-output block is usually process status, so it's stripped).
2. The parent model then re-renders whatever prose survives — and a weak planner **truncates** the value: `2026-06-02` → `202`, a fetched price → `705`.

So the user asks for a value, the sub-agent computes it correctly, and the bot replies with a mangled fragment.

## Fix (structural carrier, mirrors the existing verified-URL carrier)

- **Producer** (`SubAgentRouter`): on the `task_complete && !changeSet && verifiedUrls.length === 0` path, recover the captured stdout from the **raw** `response` (before narration strips it) via `capturedStdoutDeliverable` (≤2KB shape gate so multi-KB transcripts stay on the model-rendered path), and stamp it as `metadata.subAgentDeliverable` — exactly parallel to the existing `subAgentVerifiedUrls`.
- **Consumer** (`subAgentCompletionResponseEvaluator`): when `subAgentDeliverable` is present, surface it **verbatim** — keep the model's reply only if it already contains the exact value (so it gets the value *plus* a line of useful context), otherwise reply with the bare value. This is deterministic; it bypasses both the model re-render/truncation and the wrongful "route back through TASKS as captured tool output" branch.

## Why it's safe

Purely additive: the change-set path (keeps its deliverable through the diff) and the verified-URL path (keeps it through `verifiedUrlCompletionFallback`) are untouched — the carrier is gated to the *no-URL, no-change-set* case, so they never collide. `composeNarration` is unchanged.

## Verification

Proven live on a running agent: a "spawn a sub-agent that runs `date +%Y-%m-%d` and reports only the output" probe now replies with the full `2026-06-02`, where it previously truncated to `202`. +unit tests for the verbatim-surface case and the reply-already-contains case.

Addresses the deliverable-drop/truncation part of #8162.