### PR TITLE
fix(test): resolve @elizaos/logger to source in vitest config (fixes #8164)

### DIFF
--- a/packages/test/vitest/default.config.ts
+++ b/packages/test/vitest/default.config.ts
@@ -317,6 +317,19 @@ const vitestResolveAlias: ModuleAlias[] = [
   },
   ...workspacePluginSourceAliases,
   ...getOptionalPluginSdkAliases(repoRoot),
+  {
+    // @elizaos/core imports @elizaos/logger; the package's default export points
+    // at an unbuilt ./dist, so — like every other @elizaos workspace package in
+    // this config — resolve it to its source so vitest doesn't need a build.
+    find: /^@elizaos\/logger$/,
+    replacement: path.join(
+      elizaWorkspaceRoot,
+      "packages",
+      "logger",
+      "src",
+      "index.ts",
+    ),
+  },
   ...(elizaCoreEntry
     ? [
         {


### PR DESCRIPTION
## Problem

CI is currently red repo-wide (**Server Tests**, **Plugin Tests**, **Zero-Key Deterministic E2E**, **Build production Docker image**) because vitest can't resolve the new `@elizaos/logger` package:

```
Error: Failed to resolve entry for package "@elizaos/logger".
The package may have incorrect main/module/exports specified in its package.json.
  File: packages/core/src/logger.ts:32
```

Every open PR against `develop` inherits these failures.

## Root cause

`@elizaos/core` now imports `@elizaos/logger`, whose `package.json` `.` export resolves to `./dist/index.js` by default — and `packages/logger/dist` is not built before these vitest suites run. The shared vitest config (`packages/test/vitest/default.config.ts`) already aliases every other `@elizaos/*` workspace package (`core`, `agent`, `app-core`, `shared`, …) to its **source** so tests don't need a build — `@elizaos/logger` was simply never added to that list when it was introduced.

## Fix

Add the one missing alias, mirroring the existing `@elizaos/core` entry, pointing `@elizaos/logger` at `packages/logger/src/index.ts`. Minimal and consistent with how the file already handles every other workspace package — no build-graph or condition changes.

## Verification

The three previously-failing agent view suites now pass:

```
bunx vitest run src/__tests__/views-system-smoke.test.ts \
  src/__tests__/views-registry-integration.test.ts \
  src/__tests__/plugin-tui-view-coverage.test.ts
→ Test Files 3 passed (3) | Tests 61 passed (61)
```

Fixes #8164.