### PR TITLE
fix(cloud): restore 5xx billing refund (only charge when charged upstream)

### DIFF
--- a/packages/cloud-shared/src/lib/services/proxy/engine.test.ts
+++ b/packages/cloud-shared/src/lib/services/proxy/engine.test.ts
@@ -1,11 +1,13 @@
 /**
  * Tests for resolveBillableCost — the proxy engine's billing decision.
  *
- * Regression: a no-upstream fast-fail 5xx response (for example a circuit-open
- * 503) used to reconcile the full reserved `cost`, over-billing the org for a
- * request that returned no service. Provider-attempted 5xx responses may still
- * represent real upstream spend, so handlers must report actualCost: 0 when no
- * upstream work happened.
+ * Regression: a synthesized 5xx response (upstream-down after retries, a
+ * circuit-open 503, etc.) used to reconcile the full reserved `cost`,
+ * over-billing the org for a request that returned no service. We only charge
+ * the caller when we actually got charged upstream, so a 5xx refunds the
+ * reservation unless the handler reports an explicit partial `actualCost` (the
+ * real upstream charge). Abuse is contained by rate limiting + the circuit
+ * breaker, not by over-billing failed requests.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -31,12 +33,12 @@ describe("resolveBillableCost", () => {
     expect(resolveBillableCost({ response: res(302) }, RESERVED)).toBe(RESERVED);
   });
 
-  test("5xx without actualCost preserves reserved cost for provider-attempted failures", () => {
-    expect(resolveBillableCost({ response: res(502) }, RESERVED)).toBe(RESERVED);
+  test("502 upstream-down without actualCost refunds to 0 (the regression)", () => {
+    expect(resolveBillableCost({ response: res(502) }, RESERVED)).toBe(0);
   });
 
-  test("503 circuit-open with explicit zero actualCost refunds to 0", () => {
-    expect(resolveBillableCost({ response: res(503), actualCost: 0 }, RESERVED)).toBe(0);
+  test("503 circuit-open refunds to 0", () => {
+    expect(resolveBillableCost({ response: res(503) }, RESERVED)).toBe(0);
   });
 
   test("500 with an explicit partial actualCost bills only that partial cost", () => {

--- a/packages/cloud-shared/src/lib/services/proxy/engine.ts
+++ b/packages/cloud-shared/src/lib/services/proxy/engine.ts
@@ -119,10 +119,13 @@ function wrapResponseWithHeaders(response: Response, headers: Headers): Response
  *
  * - 2xx success (`response.ok`): bill the handler's reported `actualCost`, or
  *   the full reserved `cost` when the handler didn't report one.
- * - 5xx: bill the handler's reported `actualCost`, or the full reserved
- *   `cost` when omitted. Provider-attempted failures can still cost upstream
- *   credits. No-upstream fast-fail paths (for example circuit-open) must set
- *   `actualCost: 0` explicitly to refund the reservation.
+ * - 5xx: the caller received no service (upstream-down after retries, circuit
+ *   open, etc.), so refund the reservation — bill only an explicit partial
+ *   `actualCost` if the handler set one (the real upstream charge), otherwise
+ *   0. This mirrors the thrown-error path, which reconciles to 0. We only
+ *   charge the caller when we actually got charged upstream; abuse is contained
+ *   by rate limiting + the circuit breaker, never by over-billing failed
+ *   requests.
  * - everything else (3xx redirects, 4xx client errors): billed at the reserved
  *   `cost` unless the handler reported a different `actualCost`, preserving
  *   prior behavior.
@@ -135,7 +138,7 @@ export function resolveBillableCost(
     return result.actualCost ?? reservedCost;
   }
   if (result.response.status >= 500) {
-    return result.actualCost ?? reservedCost;
+    return result.actualCost ?? 0;
   }
   return result.actualCost ?? reservedCost;
 }
@@ -270,10 +273,10 @@ export function createHandler(
         throw error;
       }
 
-      // Only bill for actual work performed. Returned 5xx responses default to
-      // the reserved cost because upstream attempts can be provider-billed even
-      // when they fail; no-upstream fast-fails report actualCost: 0 explicitly.
-      // See resolveBillableCost.
+      // Only bill for actual work performed. A synthesized server-side error
+      // (5xx — upstream-down after retries, circuit open, etc.) means the
+      // caller got no service, so it refunds the reservation just like the
+      // thrown-error path above. See resolveBillableCost.
       const actualCost = resolveBillableCost(result, cost);
       await reservation.reconcile(actualCost);
 


### PR DESCRIPTION
## What

Restores the 5xx billing-refund fix from closed PR #8133, which a janitorial WIP commit (\`2d5582ffd7\`) had clobbered on develop.

\`resolveBillableCost\` had been flattened into a no-op — all three branches returned \`actualCost ?? reservedCost\` — so a 502/503 that returned **no service** (upstream-down after retries, circuit-open) was billed the **full reserved cost**.

## Fix

A synthesized 5xx now refunds the reservation unless the handler reports an explicit partial \`actualCost\` (the real upstream charge), mirroring the thrown-error path:

\`\`\`ts
if (result.response.status >= 500) {
  return result.actualCost ?? 0;   // was: ?? reservedCost
}
\`\`\`

**Principle:** only charge the caller when we actually got charged upstream. Abuse ("getting nuked") is contained by the existing per-API-key rate limiting (\`withRateLimit\`, 100 req/60s) + the per-network circuit breaker (fast-fails 503 with \`actualCost: 0\`) — never by over-billing legitimate callers for failed requests.

## Tests

Updated \`engine.test.ts\`: 502/503 without \`actualCost\` now assert refund-to-0; explicit partial \`actualCost\` still bills the partial. Logic verified (pure function).

## Context

Found while reviewing the batch of closed nubs/* + codex/* PRs (#8137, #8135, #8134, #8133, #8132, #8131, #8130, #8129, #8128, #8123, #8112). All others were already landed on develop via curated direct commits; #8133's security route-removal also landed, but only its billing half had been reverted. This PR re-lands just that billing half.

### Follow-up (not in this PR)
A residual free-retry abuse vector exists: rate limiting is per-API-key request-count, not per-org cost-budget, so an attacker can spin up keys and consume upstream spend on always-5xx requests. Consider cost-based rate limiting + per-org aggregate limits as a separate hardening task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)