### PR TITLE
feat(cloud): isolate Steward tenant for staging magic-link redirect

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -160,7 +160,9 @@ jobs:
           VITE_API_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai' }}
           NEXT_PUBLIC_API_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://api.elizacloud.ai' || 'https://api-staging.elizacloud.ai' }}
           NEXT_PUBLIC_APP_URL: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'https://elizacloud.ai' || 'https://staging.elizacloud.ai' }}
-          NEXT_PUBLIC_STEWARD_TENANT_ID: elizacloud
+          # Staging uses a separate Steward tenant (`elizacloud-staging`) so its
+          # `magicLinkBaseUrl` redirects email callbacks back to staging.elizacloud.ai.
+          NEXT_PUBLIC_STEWARD_TENANT_ID: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'elizacloud' || 'elizacloud-staging' }}
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
 
       - name: Resolve Pages branch

--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -237,6 +237,11 @@ NODE_ENV = "production"
 NEXT_PUBLIC_APP_URL = "https://staging.elizacloud.ai"
 NEXT_PUBLIC_API_URL = "https://api-staging.elizacloud.ai"
 ELIZA_CLOUD_URL = "https://staging.elizacloud.ai"
+# Per-tenant `magicLinkBaseUrl` (set in Steward Neon `tenant_configs.email_config`)
+# redirects email magic-link callbacks to staging.elizacloud.ai instead of the
+# prod fallback (www.elizacloud.ai). Tenant row provisioned manually.
+STEWARD_TENANT_ID = "elizacloud-staging"
+NEXT_PUBLIC_STEWARD_TENANT_ID = "elizacloud-staging"
 ELIZA_CLOUD_AGENT_BASE_DOMAIN = "waifu.fun"
 WAIFU_SERVICE_ORG_ID = "d96d3fc8-cc07-40be-b81c-ba7a7b4e8028"
 WAIFU_SERVICE_USER_ID = "90101225-836f-4fa7-a69c-f70691dcf256"


### PR DESCRIPTION
## Why

Staging email magic-link logins still redirect to **www.elizacloud.ai** (prod) instead of **staging.elizacloud.ai**. Root cause traced to [Steward-Fi/steward](https://github.com/Steward-Fi/steward) `packages/api/src/routes/auth.ts:1212`:

```ts
function getEmailAuthRedirectBaseUrl(): string {
  return (process.env.EMAIL_AUTH_REDIRECT_BASE_URL || "https://www.elizacloud.ai").replace(...);
}
```

After magic-link click, Steward backend redirects to that single base URL — no SDK or frontend override per-origin.

OAuth/passkey already work (allowlists patched on Railway), magic-link uses a different code path.

## How

Steward exposes a per-tenant override: `tenant_configs.email_config.magicLinkBaseUrl`. When set, magic links are built against that URL instead of Steward's APP_URL — the third-party app then owns the callback page and calls `POST /auth/email/verify` to mint the JWT.

This PR splits staging onto its own Steward tenant (`elizacloud-staging`) whose `magicLinkBaseUrl=https://staging.elizacloud.ai`. Magic links from staging now land on the staging SPA's existing `/auth/callback/email` route.

**Changes:**
- `packages/cloud-api/wrangler.toml` — staging Worker `STEWARD_TENANT_ID = "elizacloud-staging"`
- `.github/workflows/cloud-cf-deploy.yml` — Pages build env `NEXT_PUBLIC_STEWARD_TENANT_ID` conditional

Prod path unchanged — `STEWARD_TENANT_ID` isn't set in `[env.production.vars]` so SDK defaults to `elizacloud`.

## Pre-merge step (must run BEFORE merge)

Run this SQL on the Steward Neon DB (Railway `steward-api` service, env `DATABASE_URL`):

```sql
BEGIN;
INSERT INTO tenants (id, name, api_key_hash, owner_address, created_at, updated_at)
SELECT 'elizacloud-staging', 'Eliza Cloud (Staging)', api_key_hash, owner_address, NOW(), NOW()
FROM tenants WHERE id = 'elizacloud'
ON CONFLICT (id) DO NOTHING;

INSERT INTO tenant_configs (tenant_id, display_name, email_config, policy_exposure, policy_templates, secret_route_presets, created_at, updated_at)
SELECT 'elizacloud-staging', 'Eliza Cloud (Staging)',
  COALESCE(email_config, '{}'::jsonb) || jsonb_build_object('magicLinkBaseUrl', 'https://staging.elizacloud.ai', 'magicLinkCallbackPath', '/auth/callback/email'),
  policy_exposure, policy_templates, secret_route_presets, NOW(), NOW()
FROM tenant_configs WHERE tenant_id = 'elizacloud'
ON CONFLICT (tenant_id) DO UPDATE SET
  email_config = COALESCE(tenant_configs.email_config, '{}'::jsonb) || jsonb_build_object('magicLinkBaseUrl', 'https://staging.elizacloud.ai', 'magicLinkCallbackPath', '/auth/callback/email'),
  updated_at = NOW();
COMMIT;
```

Full SQL with sanity selects + rollback at `/tmp/staging-steward-tenant.sql`.

If the PR merges before the SQL lands, staging auth breaks (404 unknown tenant on every request).

## Trade-offs

- **Users siloed** between prod and staging tenants (a prod user must re-sign-up on staging). Intended for a testing env.
- **OAuth/passkey allowlists** are global on Railway and already include staging — those flows survive the split.
- **Same `api_key_hash`** reused so existing `STEWARD_TENANT_API_KEY` continues to work for staging admin ops.

## Test plan

- [ ] Stan runs the SQL on Steward Neon → both rows visible via sanity SELECTs
- [ ] PR marked ready → CI green
- [ ] Merge → Pages + Worker auto-deploy on develop push
- [ ] Open `https://staging.elizacloud.ai/login`, click "Magic Link" with Stan's email
- [ ] Email link must redirect to `staging.elizacloud.ai/auth/callback/email?token=…` (NOT www)
- [ ] Session establishes → reach `staging.elizacloud.ai/dashboard/agents`
- [ ] Verify prod magic link still works (`elizacloud.ai/login` → www.elizacloud.ai)