### PR TITLE
feat(plugin-task-coordinator): odysseus-style orchestrator UI

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5008,6 +5008,7 @@
         "@xterm/addon-fit": "^0.10.0",
         "@xterm/xterm": "^5.5.0",
         "lucide-react": "^1.0.0",
+        "marked": "^18.0.4",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
       },

--- a/packages/app/test/ui-smoke/apps-session-route-cases.ts
+++ b/packages/app/test/ui-smoke/apps-session-route-cases.ts
@@ -207,6 +207,12 @@ export const DIRECT_ROUTE_CASES: readonly DirectRouteCase[] = [
     timeoutMs: 90_000,
   },
   {
+    name: "odysseus app shell page",
+    path: "/odysseus",
+    selector: '[data-testid="odysseus-shell"]',
+    timeoutMs: 90_000,
+  },
+  {
     name: "orchestrator tui app shell page",
     path: "/orchestrator/tui",
     readyChecks: [

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -458,6 +458,22 @@ function visibleDynamicPage(
   return Boolean(page && (developerModeEnabled || !page.developerOnly));
 }
 
+/**
+ * Whether the active app-shell page wants to render edge-to-edge with no host
+ * top-bar/chrome. Looks the active tab up in the runtime page registry and
+ * reads its `fullBleed` flag — backward-compatible: pages that don't set it
+ * keep the normal chrome.
+ */
+function useTabIsFullBleed(tab: string): boolean {
+  return useMemo(
+    () =>
+      listAppShellPages().some(
+        (entry) => entry.id === tab && entry.fullBleed === true,
+      ),
+    [tab],
+  );
+}
+
 function trimmedNavigationPath(navigationPath: string): string {
   return navigationPath.length > 1 && navigationPath.endsWith("/")
     ? navigationPath.slice(0, -1)
@@ -810,6 +826,7 @@ type ShellContentProps = {
   isChat: boolean;
   isCompanionTab: boolean;
   isDesktopWorkspacePage: boolean;
+  isFullBleed: boolean;
   isHeartbeats: boolean;
   isSettingsPage: boolean;
   isWallets: boolean;
@@ -935,9 +952,7 @@ function RoutedShellContent(props: ShellContentProps): ReactNode {
     : null;
   return (
     <div key={`tab-shell-${props.tab}`} className={APP_SHELL_CLASS}>
-      {props.tab !== "orchestrator" ? (
-        <Header pageRightExtras={headerActions} />
-      ) : null}
+      <Header pageRightExtras={headerActions} />
       {props.desktopTabBar}
       <main className={routedShellMainClass(props.tab)}>
         <ViewRouter
@@ -1003,7 +1018,20 @@ function DesktopWorkspaceShellContent(props: ShellContentProps): ReactNode {
   );
 }
 
+function FullBleedShellContent(props: ShellContentProps): ReactNode {
+  // Edge-to-edge: no Header, no desktop tab bar, no surrounding padding — the
+  // page owns its full window (e.g. the odysseus orchestrator).
+  return (
+    <div key={`fullbleed-shell-${props.tab}`} className={APP_SHELL_CLASS}>
+      <main className="flex flex-1 min-h-0 min-w-0 overflow-hidden">
+        <ViewRouter />
+      </main>
+    </div>
+  );
+}
+
 function ShellContent(props: ShellContentProps): ReactNode {
+  if (props.isFullBleed) return <FullBleedShellContent {...props} />;
   if (props.isChat) return <ChatRouteShellContent {...props} />;
   const companionContent = CompanionShellContent(props);
   if (companionContent) return companionContent;
@@ -1233,6 +1261,7 @@ export function App() {
   const isSettingsPage = tab === "settings" || tab === "voice";
   const isAppsToolPage = isAppsToolTab(tab);
   const isDesktopWorkspacePage = tab === "desktop";
+  const isFullBleed = useTabIsFullBleed(tab);
 
   // Keep hook order stable across first-run/auth state transitions.
   // Otherwise React can throw when first-run setup completes and the main shell mounts.
@@ -1415,6 +1444,7 @@ export function App() {
         isChat={isChat}
         isCompanionTab={isCompanionTab}
         isDesktopWorkspacePage={isDesktopWorkspacePage}
+        isFullBleed={isFullBleed}
         isHeartbeats={isHeartbeats}
         isSettingsPage={isSettingsPage}
         isWallets={isWallets}
@@ -1440,6 +1470,7 @@ export function App() {
       isWallets,
       isAppsToolPage,
       isDesktopWorkspacePage,
+      isFullBleed,
       characterHeaderActions,
       handleDeferredTaskOpen,
       customActionsPanelOpen,

--- a/packages/ui/src/app-shell-registry.ts
+++ b/packages/ui/src/app-shell-registry.ts
@@ -22,6 +22,12 @@ export interface AppShellPageRegistration {
   developerOnly?: boolean;
   /** Optional named group the tab belongs to. */
   group?: string;
+  /**
+   * When true, the shell mounts this page edge-to-edge with no host
+   * top-bar/chrome — for views that own their full window, e.g. the odysseus
+   * orchestrator.
+   */
+  fullBleed?: boolean;
   /** The React component the shell mounts when this page is active. */
   Component: ComponentType<unknown>;
 }

--- a/plugins/plugin-task-coordinator/AGENTS.md
+++ b/plugins/plugin-task-coordinator/AGENTS.md
@@ -38,14 +38,20 @@ Calls `registerTaskCoordinatorSlots` from `@elizaos/ui` with:
 
 ### App shell pages (`src/register.ts`)
 
-Registers `/orchestrator` (order 70) and `/orchestrator/tui` (order 71) in the `developer` group via `registerAppShellPage` from `@elizaos/ui/app-shell-registry`.
+Registers three pages in the `developer` group via `registerAppShellPage` from `@elizaos/ui/app-shell-registry`:
+
+- `/odysseus` (order 69, `fullBleed: true`) — the `OdysseusShell` chat UI (see `src/odysseus/`).
+- `/orchestrator` (order 70, `fullBleed: true`) — the `OrchestratorWorkbench`.
+- `/orchestrator/tui` (order 71) — the TUI variant.
+
+`fullBleed: true` opts the page into edge-to-edge mounting (no host header / tab-bar / padding) — these views own their full window. The flag is defined on `AppShellPageRegistration` in `@elizaos/ui`.
 
 ## Layout
 
 ```
 src/
   index.ts                         Plugin definition — views + capabilities declared here
-  register.ts                      App-shell page registration (orchestrator routes)
+  register.ts                      App-shell page registration (/odysseus, /orchestrator, /orchestrator/tui)
   register-slots.ts                Slot registry fills for ui null-placeholders
   CodingAgentTasksPanel.tsx        Task thread list + PTY session panel; re-exports OrchestratorWorkbench
   OrchestratorWorkbench.tsx        Multi-agent orchestration workbench (main UI)
@@ -63,9 +69,24 @@ src/
   PtyTerminalPane.tsx              Full terminal pane variant
   orchestrator-stream.tsx          Conversation-view builder for orchestrator event/message records
   orchestrator-diff.tsx            Diff view component for file-change tool cards
+  orchestrator-markdown.tsx        Markdown renderer (marked) for chat prose; shared MarkdownText
+  orchestrator-plan.tsx            Plan/checklist block renderer
+  orchestrator-reasoning.tsx       Collapsible reasoning block renderer
   view-format.ts                   Pure display formatters (time, tokens, USD, ANSI-strip)
   session-hydration.ts             Re-exports mapServerTasksToSessions + TERMINAL_STATUSES from @elizaos/ui
   pty-status-dots.ts               Re-exports PULSE_STATUSES + STATUS_DOT from @elizaos/ui
+  odysseus/                        Odysseus-style orchestrator chat UI (full-bleed /odysseus page)
+    OdysseusShell.tsx              Root shell: sidebar/rail, composer, tool-window host
+    SessionSidebar.tsx IconRail.tsx  Labeled nav sidebar + its collapsed 48px icon rail
+    Composer.tsx ChatContainer.tsx ChatMessages.tsx MessageBubble.tsx ChatTopBar.tsx  Chat column
+    MemoryPanel.tsx SkillsPanel.tsx NotesPanel.tsx SettingsPanel.tsx PresetsPanel.tsx ThemeMenu.tsx  Panels
+    TasksView/ModelsView/EmailView/CalendarView/GroupChatView/AdminView/GalleryView/
+      GalleryEditorView/CompareView/ResearchView/VoiceView/CookbookView/DocumentLibraryView.tsx  Tool views
+    WindowManager.tsx MinimizedDock.tsx ResizeHandles.tsx  Cross-view window registry + minimize dock + resize
+    SearchPalette.tsx EmojiPicker.tsx Spinner.tsx BgEffect.tsx  Misc UI
+    odysseus-theme.ts              ODYSSEUS_CSS — the theme stylesheet (CSS-in-template-literal)
+    hooks/                         useWindowControls, useKeyboardShortcuts, useTaskRoom, useChatSubmit, useEscapeClose
+    util/storage.ts                Namespaced localStorage helpers
   api/
     coding-agents-auth-sanitize.ts       Sanitizes triggerAuth() responses (whitelist + URL scheme check)
     coding-agents-preflight-normalize.ts Normalizes preflight auth field to typed NormalizedPreflightAuth

--- a/plugins/plugin-task-coordinator/CLAUDE.md
+++ b/plugins/plugin-task-coordinator/CLAUDE.md
@@ -38,14 +38,20 @@ Calls `registerTaskCoordinatorSlots` from `@elizaos/ui` with:
 
 ### App shell pages (`src/register.ts`)
 
-Registers `/orchestrator` (order 70) and `/orchestrator/tui` (order 71) in the `developer` group via `registerAppShellPage` from `@elizaos/ui/app-shell-registry`.
+Registers three pages in the `developer` group via `registerAppShellPage` from `@elizaos/ui/app-shell-registry`:
+
+- `/odysseus` (order 69, `fullBleed: true`) — the `OdysseusShell` chat UI (see `src/odysseus/`).
+- `/orchestrator` (order 70, `fullBleed: true`) — the `OrchestratorWorkbench`.
+- `/orchestrator/tui` (order 71) — the TUI variant.
+
+`fullBleed: true` opts the page into edge-to-edge mounting (no host header / tab-bar / padding) — these views own their full window. The flag is defined on `AppShellPageRegistration` in `@elizaos/ui`.
 
 ## Layout
 
 ```
 src/
   index.ts                         Plugin definition — views + capabilities declared here
-  register.ts                      App-shell page registration (orchestrator routes)
+  register.ts                      App-shell page registration (/odysseus, /orchestrator, /orchestrator/tui)
   register-slots.ts                Slot registry fills for ui null-placeholders
   CodingAgentTasksPanel.tsx        Task thread list + PTY session panel; re-exports OrchestratorWorkbench
   OrchestratorWorkbench.tsx        Multi-agent orchestration workbench (main UI)
@@ -63,9 +69,24 @@ src/
   PtyTerminalPane.tsx              Full terminal pane variant
   orchestrator-stream.tsx          Conversation-view builder for orchestrator event/message records
   orchestrator-diff.tsx            Diff view component for file-change tool cards
+  orchestrator-markdown.tsx        Markdown renderer (marked) for chat prose; shared MarkdownText
+  orchestrator-plan.tsx            Plan/checklist block renderer
+  orchestrator-reasoning.tsx       Collapsible reasoning block renderer
   view-format.ts                   Pure display formatters (time, tokens, USD, ANSI-strip)
   session-hydration.ts             Re-exports mapServerTasksToSessions + TERMINAL_STATUSES from @elizaos/ui
   pty-status-dots.ts               Re-exports PULSE_STATUSES + STATUS_DOT from @elizaos/ui
+  odysseus/                        Odysseus-style orchestrator chat UI (full-bleed /odysseus page)
+    OdysseusShell.tsx              Root shell: sidebar/rail, composer, tool-window host
+    SessionSidebar.tsx IconRail.tsx  Labeled nav sidebar + its collapsed 48px icon rail
+    Composer.tsx ChatContainer.tsx ChatMessages.tsx MessageBubble.tsx ChatTopBar.tsx  Chat column
+    MemoryPanel.tsx SkillsPanel.tsx NotesPanel.tsx SettingsPanel.tsx PresetsPanel.tsx ThemeMenu.tsx  Panels
+    TasksView/ModelsView/EmailView/CalendarView/GroupChatView/AdminView/GalleryView/
+      GalleryEditorView/CompareView/ResearchView/VoiceView/CookbookView/DocumentLibraryView.tsx  Tool views
+    WindowManager.tsx MinimizedDock.tsx ResizeHandles.tsx  Cross-view window registry + minimize dock + resize
+    SearchPalette.tsx EmojiPicker.tsx Spinner.tsx BgEffect.tsx  Misc UI
+    odysseus-theme.ts              ODYSSEUS_CSS — the theme stylesheet (CSS-in-template-literal)
+    hooks/                         useWindowControls, useKeyboardShortcuts, useTaskRoom, useChatSubmit, useEscapeClose
+    util/storage.ts                Namespaced localStorage helpers
   api/
     coding-agents-auth-sanitize.ts       Sanitizes triggerAuth() responses (whitelist + URL scheme check)
     coding-agents-preflight-normalize.ts Normalizes preflight auth field to typed NormalizedPreflightAuth

--- a/plugins/plugin-task-coordinator/package.json
+++ b/plugins/plugin-task-coordinator/package.json
@@ -33,6 +33,7 @@
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "lucide-react": "^1.0.0",
+    "marked": "^18.0.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/plugins/plugin-task-coordinator/src/odysseus/AdminView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/AdminView.tsx
@@ -1,0 +1,935 @@
+// odysseus Admin panel (static/js/admin.js + the admin sub-tabs of the settings
+// modal in static/index.html). The admin-only surface: a left rail of admin
+// sections (Users / System / Agent Tools), the Users tab (Registration
+// "Open signup" toggle, the user list with a per-user privilege panel — feature
+// toggles, a daily-message limit, and an allowed-models checkbox list — plus an
+// Add User form), the System tab (Data Backup export/import + a per-category
+// Danger Zone wipe list), and the Agent Tools tab (the single "Built-in Tools"
+// card whose body is a categorized, collapsible tool catalogue — admin.js
+// loadBuiltinTools() rendering #adm-builtin-tools-list, index.html ~line 2121).
+// 1:1 chrome: .admin-card / .admin-switch / .admin-user-row / .admin-badge /
+// .admin-btn-* / .admin-tool-* mirror odysseus's DOM and CSS classes.
+//
+// elizaMapping: odysseus's admin panel is backed by a multi-user auth server
+// (GET/POST /api/auth/users, /api/auth/status, /api/auth/signup-toggle,
+// /api/auth/features, /api/auth/users/{u}/privileges, /api/admin/wipe/{kind},
+// /api/export, /api/import). The eliza orchestrator client exposes NONE of these
+// (grepped the @elizaos/ui `client` singleton — there is no listUsers /
+// signupEnabled / authFeatures / adminWipe method; tsgo would fail on any
+// invented call). eliza runs a single agent, not a multi-tenant auth surface,
+// so this is the faithful no-eliza-equivalent path: the FULL admin chrome is
+// built pixel-exact so it lights up the moment such a backend exists, but every
+// surface renders its honest EMPTY/DISABLED state — the user list shows
+// odysseus's "No users found", toggles are disabled, and a panel-wide notice
+// reads "Admin features require server configuration." NO fabricated users,
+// roles, or feature flags are ever shown. The one real mapping is the allowed-
+// models checkbox list, populated from client.fetchModels(provider) — the same
+// /api/models fetch CompareView + GalleryView use — so it lights up with the
+// agent's real providers even though no users exist to assign them to.
+
+import type { ProviderModelRecord } from "@elizaos/ui";
+import { client } from "@elizaos/ui";
+import {
+  ChevronDown,
+  Database,
+  Download,
+  Minus,
+  Settings as SettingsIcon,
+  ShieldAlert,
+  Upload,
+  UserPlus,
+  Users,
+  Wrench,
+  X,
+} from "lucide-react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+
+// Providers whose model lists feed the per-user "Allowed models" checkbox list —
+// the same real /api/models fetch keys CompareView + GalleryView use.
+const PROVIDERS = [
+  "openai",
+  "anthropic",
+  "google",
+  "openrouter",
+  "groq",
+  "xai",
+  "ollama",
+] as const;
+
+type AdminTab = "users" | "system" | "tools";
+
+// odysseus admin.js PRIV_LABELS — the per-user boolean feature grants. Kept 1:1
+// so the privilege panel reads exactly like odysseus's once a user backend
+// exists to bind them to.
+const PRIV_LABELS: ReadonlyArray<readonly [string, string]> = [
+  ["can_use_agent", "Agent mode"],
+  ["can_use_browser", "Browser automation"],
+  ["can_use_bash", "Shell / Python / Files"],
+  ["can_use_documents", "Document editor"],
+  ["can_use_research", "Deep research"],
+  ["can_generate_images", "Image generation"],
+  ["can_manage_memory", "Memory & skills"],
+];
+
+// odysseus admin.js TOOL_META — the built-in tool catalogue rendered into the
+// Agent Tools tab's single "Built-in Tools" card (loadBuiltinTools(), grouped
+// by `cat` in CATEGORY_ORDER). Each row is name + description + an approximate
+// context-token badge. This is static catalogue metadata describing odysseus's
+// tool surface — NOT fabricated runtime state — so the card reads exactly like
+// odysseus's while every toggle stays disabled until a /api/tools backend
+// exists to report and persist enabled/disabled state. (admin.js's dead
+// featureLabels/loadFeatures targeted #adm-featureToggles, which exists nowhere
+// in index.html, so it is intentionally omitted.)
+interface ToolMeta {
+  id: string;
+  name: string;
+  desc: string;
+  cat: string;
+  ctx: string;
+}
+
+const TOOL_META: readonly ToolMeta[] = [
+  {
+    id: "bash",
+    name: "Shell",
+    desc: "Execute bash commands",
+    cat: "Code",
+    ctx: "~200",
+  },
+  {
+    id: "python",
+    name: "Python",
+    desc: "Run Python scripts",
+    cat: "Code",
+    ctx: "~200",
+  },
+  {
+    id: "read_file",
+    name: "Read File",
+    desc: "Read files from disk",
+    cat: "Code",
+    ctx: "~150",
+  },
+  {
+    id: "write_file",
+    name: "Write File",
+    desc: "Write/create files",
+    cat: "Code",
+    ctx: "~150",
+  },
+  {
+    id: "web_search",
+    name: "Web Search",
+    desc: "Search the web via SearXNG",
+    cat: "Search",
+    ctx: "~300",
+  },
+  {
+    id: "search_chats",
+    name: "Search Chats",
+    desc: "Search conversation history",
+    cat: "Search",
+    ctx: "~150",
+  },
+  {
+    id: "create_document",
+    name: "Create Document",
+    desc: "Create new documents",
+    cat: "Documents",
+    ctx: "~200",
+  },
+  {
+    id: "update_document",
+    name: "Update Document",
+    desc: "Modify existing documents",
+    cat: "Documents",
+    ctx: "~200",
+  },
+  {
+    id: "edit_document",
+    name: "Edit Document",
+    desc: "Find & replace in documents",
+    cat: "Documents",
+    ctx: "~200",
+  },
+  {
+    id: "suggest_document",
+    name: "Suggest Changes",
+    desc: "Propose document edits",
+    cat: "Documents",
+    ctx: "~200",
+  },
+  {
+    id: "manage_documents",
+    name: "Manage Documents",
+    desc: "List, delete, organize docs",
+    cat: "Documents",
+    ctx: "~150",
+  },
+  {
+    id: "generate_image",
+    name: "Generate Image",
+    desc: "Create images via AI",
+    cat: "Media",
+    ctx: "~150",
+  },
+  {
+    id: "manage_memory",
+    name: "Memory",
+    desc: "Save and recall memories",
+    cat: "Knowledge",
+    ctx: "~200",
+  },
+  {
+    id: "manage_skills",
+    name: "Skills",
+    desc: "Learn and use procedures",
+    cat: "Knowledge",
+    ctx: "~200",
+  },
+  {
+    id: "manage_rag",
+    name: "RAG / Docs",
+    desc: "Query indexed documents",
+    cat: "Knowledge",
+    ctx: "~150",
+  },
+  {
+    id: "chat_with_model",
+    name: "Chat with Model",
+    desc: "Talk to another AI model",
+    cat: "Multi-Agent",
+    ctx: "~200",
+  },
+  {
+    id: "second_opinion",
+    name: "Second Opinion",
+    desc: "Get another model's take",
+    cat: "Multi-Agent",
+    ctx: "~150",
+  },
+  {
+    id: "pipeline",
+    name: "Pipeline",
+    desc: "Multi-step AI workflows",
+    cat: "Multi-Agent",
+    ctx: "~200",
+  },
+  {
+    id: "ask_teacher",
+    name: "Ask Teacher",
+    desc: "Query a more capable model",
+    cat: "Multi-Agent",
+    ctx: "~150",
+  },
+  {
+    id: "send_to_session",
+    name: "Send to Session",
+    desc: "Send message to another chat",
+    cat: "Sessions",
+    ctx: "~100",
+  },
+  {
+    id: "create_session",
+    name: "Create Session",
+    desc: "Start a new chat session",
+    cat: "Sessions",
+    ctx: "~100",
+  },
+  {
+    id: "list_sessions",
+    name: "List Sessions",
+    desc: "Browse existing sessions",
+    cat: "Sessions",
+    ctx: "~100",
+  },
+  {
+    id: "manage_session",
+    name: "Manage Session",
+    desc: "Rename, archive, configure",
+    cat: "Sessions",
+    ctx: "~100",
+  },
+  {
+    id: "list_models",
+    name: "List Models",
+    desc: "Show available models",
+    cat: "System",
+    ctx: "~100",
+  },
+  {
+    id: "ui_control",
+    name: "UI Control",
+    desc: "Change theme, layout, settings",
+    cat: "System",
+    ctx: "~150",
+  },
+  {
+    id: "manage_tasks",
+    name: "Tasks",
+    desc: "Schedule automated tasks",
+    cat: "System",
+    ctx: "~150",
+  },
+  {
+    id: "api_call",
+    name: "API Call",
+    desc: "Make HTTP requests",
+    cat: "System",
+    ctx: "~200",
+  },
+  {
+    id: "manage_endpoints",
+    name: "Endpoints",
+    desc: "Add/remove model endpoints",
+    cat: "System",
+    ctx: "~100",
+  },
+  {
+    id: "manage_mcp",
+    name: "MCP Servers",
+    desc: "Manage MCP connections",
+    cat: "System",
+    ctx: "~100",
+  },
+  {
+    id: "manage_webhooks",
+    name: "Webhooks",
+    desc: "Configure webhook events",
+    cat: "System",
+    ctx: "~100",
+  },
+  {
+    id: "manage_tokens",
+    name: "API Tokens",
+    desc: "Manage API access tokens",
+    cat: "System",
+    ctx: "~100",
+  },
+  {
+    id: "manage_settings",
+    name: "Settings",
+    desc: "Change app settings",
+    cat: "System",
+    ctx: "~100",
+  },
+];
+
+// admin.js loadBuiltinTools() catOrder — the category render order. "Other" is
+// odysseus's catch-all for tools without TOOL_META; no catalogue rows fall into
+// it here, so it renders only if the list ever gains an unknown tool.
+const CATEGORY_ORDER = [
+  "Code",
+  "Search",
+  "Documents",
+  "Media",
+  "Knowledge",
+  "Multi-Agent",
+  "Sessions",
+  "System",
+  "Other",
+] as const;
+
+// odysseus index.html Danger Zone rows (data-wipe-kind + label + sub). 1:1.
+interface WipeRow {
+  kind: string;
+  label: string;
+  sub: string;
+}
+
+const WIPE_ROWS: WipeRow[] = [
+  {
+    kind: "chats",
+    label: "Wipe all chats",
+    sub: "Every session, message, and chat history. Documents/notes/etc. stay.",
+  },
+  {
+    kind: "memory",
+    label: "Wipe all memory",
+    sub: "Clears the Memory table and the vector store. Skills not affected.",
+  },
+  {
+    kind: "skills",
+    label: "Wipe all skills",
+    sub: "Drops every SKILL.md file. Memory not affected.",
+  },
+  {
+    kind: "notes",
+    label: "Wipe all notes",
+    sub: "Every note, todo, and checklist.",
+  },
+  {
+    kind: "tasks",
+    label: "Wipe all tasks",
+    sub: "Every scheduled task and its run history.",
+  },
+  {
+    kind: "documents",
+    label: "Wipe all documents",
+    sub: "Every document and version. Drafts, exports, library — all gone.",
+  },
+  {
+    kind: "gallery",
+    label: "Wipe all gallery",
+    sub: "Every image record and the upload directory on disk.",
+  },
+  {
+    kind: "calendar",
+    label: "Wipe all calendar",
+    sub: "Every event and every calendar (incl. CalDAV-synced ones).",
+  },
+];
+
+// A user record, shaped to odysseus admin.js's /api/auth/users rows so the list
+// + privilege panel light up 1:1 the moment an auth backend populates it. The
+// default set is always empty (honest empty state) — never seeded with demo
+// rows.
+interface AdminUser {
+  username: string;
+  is_admin: boolean;
+}
+
+export function AdminView({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}): ReactNode {
+  useEscapeClose(open, onClose);
+  const win = useWindowControls(
+    "win-admin",
+    { w: 900, h: 760 },
+    { label: "Admin", icon: "ShieldAlert", onClose },
+  );
+  const [tab, setTab] = useState<AdminTab>("users");
+  const [expandedUser, setExpandedUser] = useState<string | null>(null);
+  const [models, setModels] = useState<ProviderModelRecord[]>([]);
+
+  // No eliza client method backs a multi-user auth surface (see file header) —
+  // the user set is intentionally empty until such a backend exists. Never
+  // seeded with demo data.
+  const users = useMemo<AdminUser[]>(() => [], []);
+
+  // Populate the "Allowed models" checkbox list from the REAL provider model
+  // lists — the same /api/models endpoint the settings + compare surfaces use.
+  // Failures are non-fatal: the list simply shows fewer models.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void Promise.all(
+      PROVIDERS.map((provider) =>
+        client
+          .fetchModels(provider)
+          .then((r): ProviderModelRecord[] => r.models)
+          .catch((): ProviderModelRecord[] => []),
+      ),
+    ).then((lists) => {
+      if (cancelled) return;
+      const seen = new Set<string>();
+      const flat: ProviderModelRecord[] = [];
+      for (const m of lists.flat()) {
+        if (seen.has(m.id)) continue;
+        seen.add(m.id);
+        flat.push(m);
+      }
+      flat.sort((a, b) => a.name.localeCompare(b.name));
+      setModels(flat);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  return (
+    <div
+      className={`od-search-overlay od-admin-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Admin"
+    >
+      <button
+        type="button"
+        aria-label="Close admin"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel od-admin-panel" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        {/* ── Modal header (settings-modal header) ── */}
+        <div
+          className="od-admin-header od-window-header"
+          onPointerDown={win.onDragStart}
+        >
+          <span className="od-admin-header-title">
+            <ShieldAlert size={14} aria-hidden="true" />
+            Admin
+          </span>
+          <span className="od-admin-header-spacer" />
+          <button
+            type="button"
+            className="od-window-min-btn"
+            onClick={win.minimize}
+            title="Minimize"
+            aria-label="Minimize"
+          >
+            <Minus size={14} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="od-admin-close"
+            aria-label="Close admin"
+            title="Close"
+            onClick={onClose}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        {/* ── Honest empty-state notice: eliza has no admin/auth backend ── */}
+        <div className="od-admin-notice">
+          Admin features require server configuration. This orchestrator runs a
+          single agent — multi-user management, signup control, and feature
+          flags light up once an auth backend is connected.
+        </div>
+
+        <div className="od-admin-body">
+          {/* ── Left rail of admin sections (settings-sidebar admin-only) ── */}
+          <div
+            className="od-admin-rail"
+            role="tablist"
+            aria-label="Admin sections"
+          >
+            <div className="od-admin-rail-label">Admin</div>
+            {/* Rail item order matches the real odysseus settings ADMIN group:
+                Agent Tools, then Users, then System (verified vs 16-admin.png). */}
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === "tools"}
+              className={`od-admin-rail-item${tab === "tools" ? " active" : ""}`}
+              onClick={() => setTab("tools")}
+            >
+              <Wrench size={15} aria-hidden="true" />
+              <span>Agent Tools</span>
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === "users"}
+              className={`od-admin-rail-item${tab === "users" ? " active" : ""}`}
+              onClick={() => setTab("users")}
+            >
+              <Users size={15} aria-hidden="true" />
+              <span>Users</span>
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === "system"}
+              className={`od-admin-rail-item${tab === "system" ? " active" : ""}`}
+              onClick={() => setTab("system")}
+            >
+              <SettingsIcon size={15} aria-hidden="true" />
+              <span>System</span>
+            </button>
+          </div>
+
+          {/* ── Panels ── */}
+          <div className="od-admin-panels">
+            {tab === "users" ? (
+              <UsersTab
+                users={users}
+                models={models}
+                expandedUser={expandedUser}
+                onToggleUser={(u) =>
+                  setExpandedUser((cur) => (cur === u ? null : u))
+                }
+              />
+            ) : null}
+            {tab === "tools" ? <ToolsTab /> : null}
+            {tab === "system" ? <SystemTab /> : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function UsersTab({
+  users,
+  models,
+  expandedUser,
+  onToggleUser,
+}: {
+  users: AdminUser[];
+  models: ProviderModelRecord[];
+  expandedUser: string | null;
+  onToggleUser: (username: string) => void;
+}): ReactNode {
+  return (
+    <>
+      {/* ── Registration card (index.html ADMIN: USERS — Registration) ── */}
+      <div className="od-admin-card">
+        <h2 className="od-admin-card-title">
+          <UserPlus size={14} aria-hidden="true" />
+          Registration
+        </h2>
+        <div className="od-admin-toggle-row">
+          <div>
+            <div className="od-admin-toggle-label">Open signup</div>
+            <div className="od-admin-toggle-sub">
+              Allow anyone to create an account from the login page
+            </div>
+          </div>
+          <label className="od-admin-switch" title="Requires an auth backend">
+            <input type="checkbox" disabled />
+            <span className="od-admin-slider" />
+          </label>
+        </div>
+      </div>
+
+      {/* ── Users list card (index.html ADMIN: USERS — Users) ── */}
+      <div className="od-admin-card">
+        <h2 className="od-admin-card-title">
+          <Users size={14} aria-hidden="true" />
+          Users
+        </h2>
+        {users.length === 0 ? (
+          <div className="od-admin-empty">No users found</div>
+        ) : (
+          users.map((u) => (
+            <UserRow
+              key={u.username}
+              user={u}
+              models={models}
+              expanded={expandedUser === u.username}
+              onToggle={() => onToggleUser(u.username)}
+            />
+          ))
+        )}
+      </div>
+
+      {/* ── Add User form (index.html ADMIN: USERS — Add User) ── */}
+      <div className="od-admin-card">
+        <h2 className="od-admin-card-title">
+          <UserPlus size={14} aria-hidden="true" />
+          Add User
+        </h2>
+        <div className="od-admin-add-form">
+          <input type="text" placeholder="Username (email)" disabled />
+          <input type="password" placeholder="Password (min 8)" disabled />
+          <div
+            className="od-admin-switch-inline"
+            title="Grant full admin access"
+          >
+            <label className="od-admin-switch">
+              <input type="checkbox" disabled />
+              <span className="od-admin-slider" />
+            </label>{" "}
+            Admin
+          </div>
+        </div>
+        <div className="od-admin-add-row">
+          <button type="button" className="od-admin-btn-add" disabled>
+            Add User
+          </button>
+          <span className="od-admin-add-msg">Auth backend not connected</span>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function UserRow({
+  user,
+  models,
+  expanded,
+  onToggle,
+}: {
+  user: AdminUser;
+  models: ProviderModelRecord[];
+  expanded: boolean;
+  onToggle: () => void;
+}): ReactNode {
+  const initial = user.username.charAt(0).toUpperCase();
+  return (
+    <div className="od-admin-user-row">
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: mirrors odysseus's click-to-expand user header; the Rename/Remove buttons within it are real buttons. */}
+      {/* biome-ignore lint/a11y/noStaticElementInteractions: same — odysseus header row is click-to-expand. */}
+      <div
+        className="od-admin-user-header"
+        onClick={() => {
+          if (!user.is_admin) onToggle();
+        }}
+      >
+        <div className="od-admin-user-info">
+          <span className="od-admin-user-avatar">{initial}</span>
+          <div>
+            <span className="od-admin-user-name">{user.username}</span>
+            {user.is_admin ? (
+              <span className="od-admin-badge">ADMIN</span>
+            ) : (
+              <span className="od-admin-user-hint">
+                Click to manage privileges
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="od-admin-user-actions">
+          <button type="button" className="od-admin-btn-sm" disabled>
+            Rename
+          </button>
+          {user.is_admin ? null : (
+            <button type="button" className="od-admin-btn-delete" disabled>
+              Remove
+            </button>
+          )}
+          {/* odysseus shows a rotating expand chevron on non-admin rows
+              (admin.js line 59: .admin-user-chevron), rotating 180deg when the
+              privilege panel opens. Admin rows have no privilege panel, so no
+              chevron — matching odysseus. */}
+          {user.is_admin ? null : (
+            <ChevronDown
+              size={12}
+              aria-hidden="true"
+              className={`od-admin-user-chevron${expanded ? " open" : ""}`}
+            />
+          )}
+        </div>
+      </div>
+
+      {user.is_admin ? null : (
+        <div className={`od-admin-priv-panel${expanded ? "" : " hidden"}`}>
+          <div className="od-admin-priv-section">Features</div>
+          {PRIV_LABELS.map(([key, label]) => (
+            <div className="od-admin-priv-row" key={key}>
+              <span className="od-admin-priv-label">{label}</span>
+              <label className="od-admin-switch od-admin-switch-sm">
+                <input type="checkbox" disabled />
+                <span className="od-admin-slider" />
+              </label>
+            </div>
+          ))}
+
+          <div className="od-admin-priv-section">Limits</div>
+          <div className="od-admin-priv-row">
+            <div>
+              <span className="od-admin-priv-label">Daily message limit</span>
+              <div className="od-admin-priv-hint">0 = no limit</div>
+            </div>
+            <input
+              type="number"
+              min={0}
+              defaultValue={0}
+              disabled
+              className="od-admin-priv-num"
+            />
+          </div>
+
+          <div className="od-admin-priv-models-head">
+            <span className="od-admin-priv-label">Allowed models</span>
+            <span className="od-admin-priv-models-actions">
+              <span>All</span>
+              <span>None</span>
+            </span>
+          </div>
+          <div className="od-admin-priv-hint">
+            All models allowed (no restrictions)
+          </div>
+          <div className="od-admin-priv-models-list">
+            {models.length === 0 ? (
+              <span className="od-admin-priv-models-empty">
+                No models available
+              </span>
+            ) : (
+              models.map((m) => (
+                <label className="od-admin-priv-model-row" key={m.id}>
+                  <input type="checkbox" disabled defaultChecked />
+                  <span>{m.name}</span>
+                </label>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// odysseus Agent Tools tab — the single "Built-in Tools" card whose body is the
+// categorized, collapsible catalogue (admin.js loadBuiltinTools, index.html
+// #adm-builtin-tools-list). No eliza client method backs /api/tools (no
+// listTools/builtinTools on the @elizaos/ui client — see file header), so the
+// catalogue renders the real odysseus tool surface with every toggle disabled:
+// the chrome (category groups, count badges, collapsible bodies, per-tool rows
+// with a context-token badge) is pixel-exact and lights up the moment such a
+// backend exists, but no enabled/disabled runtime state is fabricated.
+function ToolsTab(): ReactNode {
+  const [collapsed, setCollapsed] = useState<Set<string>>(
+    // odysseus renders every category body with the `hidden` class — collapsed
+    // by default. Start every catalogue category collapsed to match.
+    () => new Set(CATEGORY_ORDER),
+  );
+
+  const categories = useMemo(
+    () =>
+      CATEGORY_ORDER.map((cat) => ({
+        cat,
+        tools: TOOL_META.filter((t) => t.cat === cat),
+      })).filter((g) => g.tools.length > 0),
+    [],
+  );
+
+  const toggleCategory = (cat: string): void => {
+    setCollapsed((cur) => {
+      const next = new Set(cur);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      return next;
+    });
+  };
+
+  return (
+    <div className="od-admin-card">
+      <h2 className="od-admin-card-title">
+        <Wrench size={14} aria-hidden="true" />
+        Built-in Tools
+      </h2>
+      <div className="od-admin-toggle-sub">
+        Enable or disable tools available to the AI agent.
+      </div>
+      <div className="od-admin-tool-list">
+        {categories.length === 0 ? (
+          <div className="od-admin-empty">No tools found</div>
+        ) : (
+          categories.map(({ cat, tools }) => {
+            const isOpen = !collapsed.has(cat);
+            return (
+              <div className="od-admin-tool-category" key={cat}>
+                <button
+                  type="button"
+                  className="od-admin-tool-cat-header"
+                  aria-expanded={isOpen}
+                  onClick={() => toggleCategory(cat)}
+                >
+                  <span>{cat}</span>
+                  <span className="od-admin-tool-cat-right">
+                    {/* odysseus shows enabledCount/totalCount (admin.js
+                        loadBuiltinTools). No /api/tools backend reports an
+                        enabled set, so every toggle renders unchecked — the
+                        honest count is therefore 0/total, matching the off
+                        switches (NOT total/total, which would imply all on). */}
+                    <span className="od-admin-tool-cat-count">
+                      0/{tools.length}
+                    </span>
+                    <span
+                      className="od-admin-switch"
+                      title="Requires a tools backend"
+                    >
+                      <input type="checkbox" disabled />
+                      <span className="od-admin-slider" />
+                    </span>
+                    <ChevronDown
+                      size={12}
+                      aria-hidden="true"
+                      className={`od-admin-tool-cat-chevron${isOpen ? " open" : ""}`}
+                    />
+                  </span>
+                </button>
+                {isOpen ? (
+                  <div className="od-admin-tool-cat-body">
+                    {tools.map((t) => (
+                      <div className="od-admin-tool-row" key={t.id}>
+                        <div className="od-admin-tool-info">
+                          <span className="od-admin-tool-name">{t.name}</span>
+                          <span className="od-admin-tool-desc">{t.desc}</span>
+                        </div>
+                        <span
+                          className="od-admin-tool-ctx"
+                          title="Approximate context tokens used"
+                        >
+                          {t.ctx}
+                        </span>
+                        <label className="od-admin-switch">
+                          <input type="checkbox" disabled />
+                          <span className="od-admin-slider" />
+                        </label>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SystemTab(): ReactNode {
+  return (
+    <>
+      {/* ── Data Backup card (index.html SYSTEM — Data Backup) ── */}
+      <div className="od-admin-card">
+        <h2 className="od-admin-card-title">
+          <Database size={14} aria-hidden="true" />
+          Data Backup
+        </h2>
+        <div className="od-admin-toggle-sub">
+          Export or import your user data (memories, presets, settings, skills,
+          preferences) as a JSON file.
+        </div>
+        <div className="od-admin-backup-row">
+          <button type="button" className="od-admin-btn-add" disabled>
+            <Download size={12} aria-hidden="true" />
+            Export Data
+          </button>
+          <button type="button" className="od-admin-btn-add" disabled>
+            <Upload size={12} aria-hidden="true" />
+            Import Data
+          </button>
+        </div>
+        <div className="od-admin-add-msg">Backup endpoints not connected</div>
+      </div>
+
+      {/* ── Danger Zone card (index.html SYSTEM — Danger Zone) ── */}
+      <div className="od-admin-card od-admin-danger-card">
+        {/* odysseus's Danger Zone heading is a plain colored <h2> with no
+            icon (index.html line 2143: <h2 style="color:#e55">Danger Zone). */}
+        <h2 className="od-admin-card-title od-admin-danger-title">
+          Danger Zone
+        </h2>
+        <div className="od-admin-toggle-sub">
+          Irreversible. Each wipe targets one category — pick exactly what you
+          want gone.
+        </div>
+        {WIPE_ROWS.map((row) => (
+          <div className="od-admin-wipe-row" key={row.kind}>
+            <div>
+              <div className="od-admin-toggle-label">{row.label}</div>
+              <div className="od-admin-toggle-sub">{row.sub}</div>
+            </div>
+            <button type="button" className="od-admin-btn-delete" disabled>
+              Wipe
+            </button>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/BgEffect.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/BgEffect.tsx
@@ -1,0 +1,734 @@
+// odysseus canvas background effects (static/js/theme.js _CANVAS_PATTERNS).
+// A <canvas> behind the shell content (z-index:-1) running the active pattern's
+// animation. Ported faithfully so far: "sparkles" (twinkling 4-point stars);
+// the others (synapse/rain/constellations/perlin/petals/embers) follow the same
+// init+RAF shape and slot into ANIMATIONS as they're ported.
+
+import { type ReactNode, useEffect, useRef } from "react";
+
+type CanvasPattern =
+  | "sparkles"
+  | "petals"
+  | "rain"
+  | "constellations"
+  | "embers"
+  | "synapse"
+  | "perlin";
+const ANIMATIONS: Record<
+  CanvasPattern,
+  (canvas: HTMLCanvasElement) => () => void
+> = {
+  sparkles: runSparkles,
+  petals: runPetals,
+  rain: runRain,
+  constellations: runConstellations,
+  embers: runEmbers,
+  synapse: runSynapse,
+  perlin: runPerlin,
+};
+
+function hexRgba(hex: string, a: number): string {
+  const h = hex.replace("#", "");
+  if (h.length < 6) return `rgba(156,222,242,${a})`;
+  const n = Number.parseInt(h.slice(0, 6), 16);
+  return `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},${a})`;
+}
+
+// Value-noise helpers ported from odysseus theme.js (_bgNoise2d / _bgSmoothNoise).
+function bgNoise2d(x: number, y: number): number {
+  const n = Math.sin(x * 12.9898 + y * 78.233) * 43758.5453;
+  return n - Math.floor(n);
+}
+function bgSmoothNoise(x: number, y: number): number {
+  const ix = Math.floor(x);
+  const iy = Math.floor(y);
+  const fx = x - ix;
+  const fy = y - iy;
+  const a = bgNoise2d(ix, iy);
+  const b = bgNoise2d(ix + 1, iy);
+  const cc = bgNoise2d(ix, iy + 1);
+  const d = bgNoise2d(ix + 1, iy + 1);
+  const ux = fx * fx * (3 - 2 * fx);
+  const uy = fy * fy * (3 - 2 * fy);
+  return a + (b - a) * ux + (cc - a) * uy + (a - b - cc + d) * ux * uy;
+}
+
+function effectColor(canvas: HTMLCanvasElement): string {
+  const s = getComputedStyle(canvas);
+  return (
+    s.getPropertyValue("--bg-effect-color").trim() ||
+    s.getPropertyValue("--fg").trim() ||
+    "#9cdef2"
+  );
+}
+
+// getComputedStyle forces a style recalc, so reading the theme color on every
+// requestAnimationFrame frame (~60x/sec) is wasteful for a decorative layer.
+// odysseus only changes --bg-effect-color when the theme/color-picker changes,
+// not per frame. We therefore re-resolve on a throttled cadence (and a manual
+// refresh fires on resize, which already runs on layout changes) so a live
+// color-picker drag still updates within a few frames without the recalc cost.
+const COLOR_REFRESH_FRAMES = 30;
+function makeColorReader(canvas: HTMLCanvasElement): {
+  read: () => string;
+  refresh: () => void;
+} {
+  let cached = effectColor(canvas);
+  let frames = 0;
+  return {
+    read() {
+      if (++frames >= COLOR_REFRESH_FRAMES) {
+        frames = 0;
+        cached = effectColor(canvas);
+      }
+      return cached;
+    },
+    refresh() {
+      frames = 0;
+      cached = effectColor(canvas);
+    },
+  };
+}
+
+// Verbatim port of odysseus theme.js _initSparkles.
+function runSparkles(canvas: HTMLCanvasElement): () => void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return () => {};
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  let w = 0;
+  let h = 0;
+  const sparkles: {
+    x: number;
+    y: number;
+    size: number;
+    phase: number;
+    speed: number;
+    life: number;
+  }[] = [];
+  const makeSpark = () => ({
+    x: Math.random() * w,
+    y: Math.random() * h,
+    size: 2 + Math.random() * 5,
+    phase: Math.random() * Math.PI * 2,
+    speed: 0.015 + Math.random() * 0.03,
+    life: 0.5 + Math.random() * 0.5,
+  });
+  const color = makeColorReader(canvas);
+  const resize = () => {
+    w = canvas.clientWidth || window.innerWidth;
+    h = canvas.clientHeight || window.innerHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    color.refresh();
+    if (sparkles.length === 0)
+      for (let i = 0; i < 35; i++) sparkles.push(makeSpark());
+  };
+  resize();
+  window.addEventListener("resize", resize);
+  const drawStar = (
+    x: number,
+    y: number,
+    r: number,
+    c: string,
+    alpha: number,
+  ) => {
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.fillStyle = c;
+    ctx.globalAlpha = alpha;
+    ctx.beginPath();
+    ctx.moveTo(0, -r);
+    ctx.quadraticCurveTo(r * 0.15, -r * 0.15, r, 0);
+    ctx.quadraticCurveTo(r * 0.15, r * 0.15, 0, r);
+    ctx.quadraticCurveTo(-r * 0.15, r * 0.15, -r, 0);
+    ctx.quadraticCurveTo(-r * 0.15, -r * 0.15, 0, -r);
+    ctx.fill();
+    ctx.restore();
+  };
+  let raf = 0;
+  const draw = () => {
+    raf = requestAnimationFrame(draw);
+    ctx.clearRect(0, 0, w, h);
+    const c = color.read();
+    for (const s of sparkles) {
+      s.phase += s.speed;
+      const twinkle = Math.sin(s.phase);
+      const alpha = Math.max(0, twinkle) * 0.25 * s.life;
+      const scale = 0.5 + Math.max(0, twinkle) * 0.5;
+      if (alpha > 0.01) drawStar(s.x, s.y, s.size * scale, c, alpha);
+      if (s.phase > Math.PI * 6) Object.assign(s, makeSpark());
+    }
+  };
+  draw();
+  return () => {
+    cancelAnimationFrame(raf);
+    window.removeEventListener("resize", resize);
+  };
+}
+
+// Verbatim port of odysseus theme.js _initPetals — gentle falling petals.
+function runPetals(canvas: HTMLCanvasElement): () => void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return () => {};
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  let w = 0;
+  let h = 0;
+  const petals: {
+    x: number;
+    y: number;
+    size: number;
+    rot: number;
+    vr: number;
+    vy: number;
+    drift: number;
+    driftSpeed: number;
+    wobble: number;
+  }[] = [];
+  const make = () => ({
+    x: Math.random() * w,
+    y: -10 - Math.random() * 40,
+    size: 3 + Math.random() * 5,
+    rot: Math.random() * Math.PI * 2,
+    vr: (Math.random() - 0.5) * 0.03,
+    vy: 0.3 + Math.random() * 0.6,
+    drift: Math.random() * Math.PI * 2,
+    driftSpeed: 0.008 + Math.random() * 0.012,
+    wobble: 0.3 + Math.random() * 0.8,
+  });
+  const color = makeColorReader(canvas);
+  const resize = () => {
+    w = canvas.clientWidth || window.innerWidth;
+    h = canvas.clientHeight || window.innerHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    color.refresh();
+    if (petals.length === 0)
+      for (let i = 0; i < 30; i++) {
+        const p = make();
+        p.y = Math.random() * h;
+        petals.push(p);
+      }
+  };
+  resize();
+  window.addEventListener("resize", resize);
+  let raf = 0;
+  const draw = () => {
+    raf = requestAnimationFrame(draw);
+    ctx.clearRect(0, 0, w, h);
+    const c = color.read();
+    for (const p of petals) {
+      p.y += p.vy;
+      p.rot += p.vr;
+      p.drift += p.driftSpeed;
+      p.x += Math.sin(p.drift) * p.wobble;
+      if (p.y > h + 15) Object.assign(p, make());
+      ctx.save();
+      ctx.translate(p.x, p.y);
+      ctx.rotate(p.rot);
+      ctx.fillStyle = c;
+      ctx.globalAlpha = 0.2;
+      ctx.beginPath();
+      ctx.ellipse(
+        -p.size * 0.2,
+        0,
+        p.size * 0.6,
+        p.size * 0.3,
+        0.3,
+        0,
+        Math.PI * 2,
+      );
+      ctx.fill();
+      ctx.globalAlpha = 0.15;
+      ctx.beginPath();
+      ctx.ellipse(
+        p.size * 0.2,
+        0,
+        p.size * 0.6,
+        p.size * 0.3,
+        -0.3,
+        0,
+        Math.PI * 2,
+      );
+      ctx.fill();
+      ctx.restore();
+    }
+    ctx.globalAlpha = 1;
+  };
+  draw();
+  return () => {
+    cancelAnimationFrame(raf);
+    window.removeEventListener("resize", resize);
+  };
+}
+
+// Verbatim port of odysseus theme.js _initRain — falling gradient streaks.
+function runRain(canvas: HTMLCanvasElement): () => void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return () => {};
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  let w = 0;
+  let h = 0;
+  const drops: {
+    x: number;
+    y: number;
+    len: number;
+    speed: number;
+    alpha: number;
+  }[] = [];
+  const MAX_DROPS = 130;
+  const color = makeColorReader(canvas);
+  const resize = () => {
+    w = canvas.clientWidth || window.innerWidth;
+    h = canvas.clientHeight || window.innerHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    color.refresh();
+  };
+  resize();
+  window.addEventListener("resize", resize);
+  const spawn = () => {
+    const len = 20 + Math.random() * 40;
+    drops.push({
+      x: Math.random() * w,
+      y: -len,
+      len,
+      speed: 4 + Math.random() * 8,
+      alpha: 0.32 + Math.random() * 0.28,
+    });
+  };
+  let raf = 0;
+  const draw = () => {
+    raf = requestAnimationFrame(draw);
+    ctx.clearRect(0, 0, w, h);
+    const c = color.read();
+    if (drops.length < MAX_DROPS && Math.random() < 0.6) spawn();
+    for (let i = drops.length - 1; i >= 0; i--) {
+      const d = drops[i];
+      d.y += d.speed;
+      if (d.y > h + d.len) {
+        drops.splice(i, 1);
+        continue;
+      }
+      const grad = ctx.createLinearGradient(d.x, d.y - d.len, d.x, d.y);
+      grad.addColorStop(0, "transparent");
+      grad.addColorStop(1, c);
+      ctx.strokeStyle = grad;
+      ctx.globalAlpha = d.alpha;
+      ctx.lineWidth = 1.3;
+      ctx.beginPath();
+      ctx.moveTo(d.x, d.y - d.len);
+      ctx.lineTo(d.x, d.y);
+      ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+  };
+  draw();
+  return () => {
+    cancelAnimationFrame(raf);
+    window.removeEventListener("resize", resize);
+  };
+}
+
+// Verbatim port of odysseus theme.js _initConstellations — drifting stars
+// with proximity-connecting lines + twinkle.
+function runConstellations(canvas: HTMLCanvasElement): () => void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return () => {};
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  let w = 0;
+  let h = 0;
+  const STAR_COUNT = 50;
+  const CONNECT_DIST = 120;
+  let stars: {
+    x: number;
+    y: number;
+    vx: number;
+    vy: number;
+    r: number;
+    phase: number;
+  }[] = [];
+  const initStars = () => {
+    stars = [];
+    for (let i = 0; i < STAR_COUNT; i++)
+      stars.push({
+        x: Math.random() * w,
+        y: Math.random() * h,
+        vx: (Math.random() - 0.5) * 0.15,
+        vy: (Math.random() - 0.5) * 0.15,
+        r: 0.8 + Math.random() * 0.8,
+        phase: Math.random() * Math.PI * 2,
+      });
+  };
+  const color = makeColorReader(canvas);
+  const resize = () => {
+    w = canvas.clientWidth || window.innerWidth;
+    h = canvas.clientHeight || window.innerHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    color.refresh();
+    if (stars.length === 0) initStars();
+  };
+  resize();
+  const onResize = () => {
+    resize();
+    initStars();
+  };
+  window.addEventListener("resize", onResize);
+  let t = 0;
+  let raf = 0;
+  const draw = () => {
+    raf = requestAnimationFrame(draw);
+    t += 0.01;
+    ctx.clearRect(0, 0, w, h);
+    const c = color.read();
+    for (const s of stars) {
+      s.x += s.vx;
+      s.y += s.vy;
+      if (s.x < 0) s.x = w;
+      if (s.x > w) s.x = 0;
+      if (s.y < 0) s.y = h;
+      if (s.y > h) s.y = 0;
+    }
+    ctx.strokeStyle = c;
+    ctx.lineWidth = 0.5;
+    for (let i = 0; i < stars.length; i++)
+      for (let j = i + 1; j < stars.length; j++) {
+        const dx = stars[i].x - stars[j].x;
+        const dy = stars[i].y - stars[j].y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist < CONNECT_DIST) {
+          ctx.globalAlpha = (1 - dist / CONNECT_DIST) * 0.15;
+          ctx.beginPath();
+          ctx.moveTo(stars[i].x, stars[i].y);
+          ctx.lineTo(stars[j].x, stars[j].y);
+          ctx.stroke();
+        }
+      }
+    ctx.fillStyle = c;
+    for (const s of stars) {
+      const twinkle = 0.5 + 0.5 * Math.sin(t * 2 + s.phase);
+      ctx.globalAlpha = 0.15 + twinkle * 0.25;
+      ctx.beginPath();
+      ctx.arc(s.x, s.y, s.r, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+  };
+  draw();
+  return () => {
+    cancelAnimationFrame(raf);
+    window.removeEventListener("resize", onResize);
+  };
+}
+
+// Verbatim port of odysseus theme.js _initEmbers — rising glowing embers with
+// sparks + occasional ground bursts (destination-out fade + lighter compositing).
+function runEmbers(canvas: HTMLCanvasElement): () => void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return () => {};
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  let w = 0;
+  let h = 0;
+  const embers: {
+    x: number;
+    y: number;
+    vx: number;
+    vy: number;
+    r: number;
+    life: number;
+    maxLife: number;
+    wobble: number;
+    spark: boolean;
+  }[] = [];
+  const make = () => ({
+    x: Math.random() * w,
+    y: h + Math.random() * 40,
+    vx: (Math.random() - 0.5) * 0.3,
+    vy: -0.3 - Math.random() * 0.8,
+    r: 0.3 + Math.random() * 0.6,
+    life: 0,
+    maxLife: 220 + Math.random() * 220,
+    wobble: Math.random() * Math.PI * 2,
+    spark: false,
+  });
+  const colorReader = makeColorReader(canvas);
+  const resize = () => {
+    w = canvas.clientWidth || window.innerWidth;
+    h = canvas.clientHeight || window.innerHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    colorReader.refresh();
+    if (embers.length === 0)
+      for (let i = 0; i < 60; i++) {
+        const e = make();
+        e.y = Math.random() * h;
+        e.life = Math.random() * e.maxLife;
+        embers.push(e);
+      }
+  };
+  resize();
+  window.addEventListener("resize", resize);
+  let raf = 0;
+  const draw = () => {
+    raf = requestAnimationFrame(draw);
+    ctx.globalCompositeOperation = "destination-out";
+    ctx.fillStyle = "rgba(0,0,0,0.18)";
+    ctx.fillRect(0, 0, w, h);
+    ctx.globalCompositeOperation = "lighter";
+    const color = colorReader.read();
+    for (let i = embers.length - 1; i >= 0; i--) {
+      const e = embers[i];
+      e.wobble += 0.03;
+      e.x += e.vx + Math.sin(e.wobble) * 0.5;
+      e.y += e.vy;
+      e.life++;
+      if (e.life > e.maxLife || e.y < -20) {
+        embers.splice(i, 1);
+        if (embers.length < 70) embers.push(make());
+        continue;
+      }
+      if (!e.spark && Math.random() < 0.003) e.spark = true;
+      const lr = e.life / e.maxLife;
+      const fade = Math.min(1, Math.min(lr * 4, (1 - lr) * 3));
+      const r = e.r * (e.spark ? 2.4 : 1);
+      const a = (e.spark ? 0.9 : 0.55) * fade;
+      const g = ctx.createRadialGradient(e.x, e.y, 0, e.x, e.y, r * 4);
+      g.addColorStop(0, hexRgba(color, a));
+      g.addColorStop(0.4, hexRgba(color, a * 0.3));
+      g.addColorStop(1, hexRgba(color, 0));
+      ctx.fillStyle = g;
+      ctx.fillRect(e.x - r * 4, e.y - r * 4, r * 8, r * 8);
+      ctx.fillStyle = hexRgba("#ffffff", a * 0.6);
+      ctx.beginPath();
+      ctx.arc(e.x, e.y, r * 0.5, 0, Math.PI * 2);
+      ctx.fill();
+      e.spark = false;
+    }
+    if (Math.random() < 0.015) {
+      const bx = Math.random() * w;
+      for (let i = 0; i < 5; i++) {
+        const e = make();
+        e.x = bx + (Math.random() - 0.5) * 40;
+        e.y = h - 10;
+        e.vy *= 1.5;
+        embers.push(e);
+      }
+    }
+    ctx.globalCompositeOperation = "source-over";
+  };
+  draw();
+  return () => {
+    cancelAnimationFrame(raf);
+    window.removeEventListener("resize", resize);
+  };
+}
+
+// Verbatim port of odysseus theme.js _initSynapse — grid pulses with trails.
+function runSynapse(canvas: HTMLCanvasElement): () => void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return () => {};
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const GRID = 24;
+  const MAX_PULSES = 20;
+  const SPEED_MIN = 2;
+  const SPEED_MAX = 22;
+  const TRAIL_LEN = 12;
+  let w = 0;
+  let h = 0;
+  let cols = 0;
+  let rows = 0;
+  const pulses: { x: number; y: number; dx: number; dy: number }[] = [];
+  const color = makeColorReader(canvas);
+  const resize = () => {
+    w = canvas.clientWidth || window.innerWidth;
+    h = canvas.clientHeight || window.innerHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    color.refresh();
+    cols = Math.ceil(w / GRID);
+    rows = Math.ceil(h / GRID);
+  };
+  resize();
+  window.addEventListener("resize", resize);
+  const spawn = () => {
+    const speed = SPEED_MIN + Math.random() * (SPEED_MAX - SPEED_MIN);
+    if (Math.random() > 0.5)
+      pulses.push({
+        x: -TRAIL_LEN,
+        y: Math.floor(Math.random() * (rows + 1)) * GRID,
+        dx: speed,
+        dy: 0,
+      });
+    else
+      pulses.push({
+        x: Math.floor(Math.random() * (cols + 1)) * GRID,
+        y: -TRAIL_LEN,
+        dx: 0,
+        dy: speed,
+      });
+  };
+  let raf = 0;
+  const draw = () => {
+    raf = requestAnimationFrame(draw);
+    ctx.clearRect(0, 0, w, h);
+    const c = color.read();
+    if (pulses.length < MAX_PULSES && Math.random() < 0.12) spawn();
+    for (let i = pulses.length - 1; i >= 0; i--) {
+      const p = pulses[i];
+      p.x += p.dx;
+      p.y += p.dy;
+      if (p.x > w + TRAIL_LEN || p.y > h + TRAIL_LEN) {
+        pulses.splice(i, 1);
+        continue;
+      }
+      const tx = p.x - (p.dx > 0 ? TRAIL_LEN : 0);
+      const ty = p.y - (p.dy > 0 ? TRAIL_LEN : 0);
+      const grad = ctx.createLinearGradient(tx, ty, p.x, p.y);
+      grad.addColorStop(0, "transparent");
+      grad.addColorStop(1, c);
+      ctx.strokeStyle = grad;
+      ctx.globalAlpha = 0.35;
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(tx, ty);
+      ctx.lineTo(p.x, p.y);
+      ctx.stroke();
+      ctx.globalAlpha = 0.55;
+      ctx.fillStyle = c;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, 1.2, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+  };
+  draw();
+  return () => {
+    cancelAnimationFrame(raf);
+    window.removeEventListener("resize", resize);
+  };
+}
+
+// Verbatim port of odysseus theme.js _initPerlinFlow — noise-driven particle streams.
+function runPerlin(canvas: HTMLCanvasElement): () => void {
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return () => {};
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  let w = 0;
+  let h = 0;
+  let t = 0;
+  const particles: { x: number; y: number; life: number }[] = [];
+  const color = makeColorReader(canvas);
+  // Cache the parsed --bg fade rgba and only re-parse when the bg string
+  // actually changes — odysseus's _initPerlinFlow does exactly this
+  // (_cachedBg / _fadeStyle) so the per-frame path never touches the parser.
+  let cachedBg = "";
+  let fadeStyle = "rgba(40,44,52,0.02)";
+  let bgFrames = 0;
+  const fade = () => {
+    if (++bgFrames < COLOR_REFRESH_FRAMES && cachedBg) return fadeStyle;
+    bgFrames = 0;
+    const bg =
+      getComputedStyle(canvas).getPropertyValue("--bg").trim() || "#282c34";
+    if (bg === cachedBg) return fadeStyle;
+    cachedBg = bg;
+    const hh = bg.replace("#", "");
+    if (hh.length < 6) {
+      fadeStyle = "rgba(40,44,52,0.02)";
+    } else {
+      const n = Number.parseInt(hh.slice(0, 6), 16);
+      fadeStyle = `rgba(${(n >> 16) & 255},${(n >> 8) & 255},${n & 255},0.02)`;
+    }
+    return fadeStyle;
+  };
+  const resize = () => {
+    w = canvas.clientWidth || window.innerWidth;
+    h = canvas.clientHeight || window.innerHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    color.refresh();
+    bgFrames = COLOR_REFRESH_FRAMES;
+    if (particles.length === 0)
+      for (let i = 0; i < 200; i++)
+        particles.push({
+          x: Math.random() * w,
+          y: Math.random() * h,
+          life: Math.random(),
+        });
+  };
+  resize();
+  window.addEventListener("resize", resize);
+  let raf = 0;
+  const draw = () => {
+    raf = requestAnimationFrame(draw);
+    ctx.fillStyle = fade();
+    ctx.fillRect(0, 0, w, h);
+    const c = color.read();
+    for (const p of particles) {
+      const angle =
+        bgSmoothNoise(p.x * 0.004 + t * 0.0008, p.y * 0.004 + 100) *
+        Math.PI *
+        6;
+      const speed = 1 + bgSmoothNoise(p.x * 0.003, p.y * 0.003 + 50) * 1.5;
+      p.x += Math.cos(angle) * speed;
+      p.y += Math.sin(angle) * speed;
+      p.life -= 0.001;
+      if (p.life <= 0 || p.x < 0 || p.x > w || p.y < 0 || p.y > h) {
+        p.x = Math.random() * w;
+        p.y = Math.random() * h;
+        p.life = 1;
+      }
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, 1, 0, Math.PI * 2);
+      ctx.fillStyle = c;
+      ctx.globalAlpha = p.life * 0.15;
+      ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+    t++;
+  };
+  draw();
+  return () => {
+    cancelAnimationFrame(raf);
+    window.removeEventListener("resize", resize);
+  };
+}
+
+export const CANVAS_BG_PATTERNS: CanvasPattern[] = [
+  "sparkles",
+  "petals",
+  "rain",
+  "constellations",
+  "embers",
+  "synapse",
+  "perlin",
+];
+
+export function BgEffect({ pattern }: { pattern: string }): ReactNode {
+  const ref = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas || !(pattern in ANIMATIONS)) return;
+    return ANIMATIONS[pattern as CanvasPattern](canvas);
+  }, [pattern]);
+
+  if (!(pattern in ANIMATIONS)) return null;
+  // Decorative, pointer-events:none layer. tabIndex={-1} keeps it out of the
+  // tab order so aria-hidden is valid (odysseus hides it from assistive tech
+  // so screen readers don't announce an empty canvas).
+  return (
+    <canvas
+      ref={ref}
+      className="od-bg-canvas"
+      tabIndex={-1}
+      aria-hidden="true"
+    />
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/CalendarView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/CalendarView.tsx
@@ -1,0 +1,1757 @@
+// odysseus calendar (static/js/calendar.js + calendar/utils.js). A local-first
+// month/week/year/agenda calendar: a prev/today/next toolbar with a
+// week/month/year/agenda view toggle, a settings cog + refresh, a +New event
+// button, a per-calendar filter chip row, the four view bodies, a day-detail
+// panel, an event create/edit form, a per-event more-menu, and a calendar
+// settings panel (per-calendar colour/name/delete, New calendar, .ics
+// import/export).
+//
+// elizaMapping: odysseus's calendar is CalDAV-backed (an HTTP API for events +
+// a /api/calendar/quick-parse NLP endpoint + /api/notes for reminders). eliza
+// exposes the LifeOps calendar *types* (LifeOpsCalendarEvent /
+// LifeOpsCalendarFeed in @elizaos/ui's client-types-config) but NO
+// frontend-callable client method to fetch/create events, parse natural
+// language, or create reminder notes. So this is the faithful no-eliza-backend
+// path: the calendar is fully **local-first** — calendars and events are owned
+// by, created in, and persisted to localStorage (matching odysseus's local
+// zero-state before any CalDAV sync). Nothing is fabricated as if it came from
+// the agent. Two odysseus surfaces require a backend eliza lacks and are
+// therefore intentionally NOT shipped (rather than shipped as dead controls):
+//   - the natural-language quick-add row (needs /api/calendar/quick-parse),
+//   - "Remind me" / CalDAV "Sync now" (need /api/notes + a CalDAV server).
+// An eliza-backed calendar client method is the follow-up that unlocks both.
+
+import {
+  ArrowLeft,
+  ArrowRight,
+  Settings as Cog,
+  Download,
+  Minus,
+  Plus,
+  RefreshCw,
+  Search,
+  Trash2,
+  Upload,
+  X,
+} from "lucide-react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+import { readPref, writePref } from "./util/storage";
+
+// Local-prefs keys for the persisted calendar list + event store. Not in the
+// shared PREF_KEYS enum (that file is owned by the shell) — namespaced the same
+// way via readPref/writePref.
+const CAL_PREF_KEY = "calendars";
+const EVENTS_PREF_KEY = "calendar-events";
+
+// How long the Refresh button keeps its spin animation after a (synchronous,
+// local) re-read from storage — a brief visual ack mirroring odysseus's CalDAV
+// "Sync now" feedback. Purely cosmetic.
+const SYNC_SPIN_MS = 450;
+
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+const MONTHS = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+] as const;
+const MON_SHORT = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+] as const;
+
+// odysseus calendar/utils.js CAL_PALETTE — first slot is the theme accent so a
+// single local calendar inherits the active odysseus theme.
+const CAL_PALETTE = [
+  "var(--accent)",
+  "#5b8abf",
+  "#bf6b5b",
+  "#5bbf7a",
+  "#bf9a5b",
+  "#9a5bbf",
+  "#5bbfb8",
+  "#bf8a5b",
+  "#7070c0",
+  "#bf5b8a",
+] as const;
+
+// odysseus _showCalSettings COLORS — the swatch row for new/edited calendars.
+const CAL_SETTINGS_COLORS = [
+  "#5b8abf",
+  "#4caf50",
+  "#ff9800",
+  "#e91e63",
+  "#9c27b0",
+  "#00bcd4",
+  "#795548",
+  "#607d8b",
+  "#f44336",
+  "#7c4dff",
+] as const;
+
+// Recurrence options mirror odysseus's _showEventForm <select id="cal-f-rrule">.
+const RRULE_OPTIONS = [
+  { value: "", label: "Does not repeat" },
+  { value: "FREQ=DAILY", label: "Daily" },
+  { value: "FREQ=WEEKLY", label: "Weekly" },
+  { value: "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR", label: "Weekdays" },
+  { value: "FREQ=MONTHLY", label: "Monthly" },
+  { value: "FREQ=YEARLY", label: "Yearly" },
+] as const;
+
+type CalendarViewMode = "week" | "month" | "year" | "agenda";
+
+interface LocalCalendar {
+  href: string;
+  name: string;
+  color: string;
+}
+
+interface CalEvent {
+  uid: string;
+  summary: string;
+  calendarHref: string;
+  // `YYYY-MM-DD` local date the event starts on.
+  date: string;
+  // `YYYY-MM-DD` local date the event ends on (== date for single-day events).
+  endDate: string;
+  // `HH:MM` 24h start time, empty for all-day events.
+  startTime: string;
+  // `HH:MM` 24h end time, empty for all-day events.
+  endTime: string;
+  allDay: boolean;
+  location: string;
+  description: string;
+  rrule: string;
+}
+
+// Representative local calendar — the zero-state odysseus ships before any
+// CalDAV sync or .ics import. A SINGLE calendar by default so the filter chip
+// row + "± tags" toggle stay hidden (odysseus only renders them when
+// `_calendars.length > 1`, calendar.js:819), matching the captured frame.
+// Coloured from CAL_PALETTE, not real agent data; the user can add more from
+// Calendar Settings, at which point the filter row appears.
+const DEFAULT_CALENDARS: LocalCalendar[] = [
+  { href: "local/personal", name: "Personal", color: CAL_PALETTE[0] },
+];
+
+function ymd(d: Date): string {
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${m}-${day}`;
+}
+
+function isoWeekNumber(d: Date): number {
+  const tgt = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  tgt.setDate(tgt.getDate() + 3 - ((tgt.getDay() + 6) % 7));
+  const yearStart = new Date(tgt.getFullYear(), 0, 1);
+  return Math.ceil(((tgt.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}
+
+// "9:30 AM"-style clock label from an "HH:MM" 24h string.
+function fmtClock(hhmm: string): string {
+  if (!hhmm) return "";
+  const [hStr, mStr] = hhmm.split(":");
+  const h = Number(hStr);
+  const m = Number(mStr);
+  if (Number.isNaN(h) || Number.isNaN(m)) return "";
+  const ampm = h >= 12 ? "PM" : "AM";
+  const h12 = h % 12 === 0 ? 12 : h % 12;
+  return `${h12}:${String(m).padStart(2, "0")} ${ampm}`;
+}
+
+function fmtLongDate(dateStr: string): string {
+  return new Date(`${dateStr}T00:00:00`).toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function calColor(ev: CalEvent, calendars: LocalCalendar[]): string {
+  const c = calendars.find((cal) => cal.href === ev.calendarHref);
+  return c ? c.color : "var(--accent)";
+}
+
+function newUid(): string {
+  return `ev-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+// ── .ics (RFC 5545) serialise / parse — pure client-side, mirrors odysseus's
+//    per-calendar Export and the .ics Import file picker. ──────────────────
+
+function toIcsDate(dateStr: string, time: string, allDay: boolean): string {
+  const compact = dateStr.replace(/-/g, "");
+  if (allDay || !time) return `;VALUE=DATE:${compact}`;
+  const t = time.replace(":", "");
+  return `:${compact}T${t}00`;
+}
+
+function buildIcs(cal: LocalCalendar, events: CalEvent[]): string {
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//elizaOS//odysseus-calendar//EN",
+    `X-WR-CALNAME:${cal.name}`,
+  ];
+  for (const ev of events) {
+    lines.push("BEGIN:VEVENT");
+    lines.push(`UID:${ev.uid}`);
+    lines.push(`SUMMARY:${ev.summary.replace(/\n/g, "\\n")}`);
+    lines.push(`DTSTART${toIcsDate(ev.date, ev.startTime, ev.allDay)}`);
+    lines.push(`DTEND${toIcsDate(ev.endDate, ev.endTime, ev.allDay)}`);
+    if (ev.location) lines.push(`LOCATION:${ev.location}`);
+    if (ev.description)
+      lines.push(`DESCRIPTION:${ev.description.replace(/\n/g, "\\n")}`);
+    if (ev.rrule) lines.push(`RRULE:${ev.rrule}`);
+    lines.push("END:VEVENT");
+  }
+  lines.push("END:VCALENDAR");
+  return lines.join("\r\n");
+}
+
+function parseIcsDate(raw: string): {
+  date: string;
+  time: string;
+  allDay: boolean;
+} {
+  // Strip any TZID/VALUE params, keep the value after the last ':'.
+  const value = raw.includes(":") ? raw.slice(raw.lastIndexOf(":") + 1) : raw;
+  const isDateOnly = !value.includes("T");
+  const y = value.slice(0, 4);
+  const mo = value.slice(4, 6);
+  const d = value.slice(6, 8);
+  const date = `${y}-${mo}-${d}`;
+  if (isDateOnly) return { date, time: "", allDay: true };
+  const hh = value.slice(9, 11);
+  const mm = value.slice(11, 13);
+  return { date, time: `${hh}:${mm}`, allDay: false };
+}
+
+function parseIcs(text: string, calendarHref: string): CalEvent[] {
+  const out: CalEvent[] = [];
+  const blocks = text.split(/BEGIN:VEVENT/i).slice(1);
+  for (const block of blocks) {
+    const body = block.split(/END:VEVENT/i)[0];
+    const lines = body.split(/\r?\n/);
+    let summary = "";
+    let location = "";
+    let description = "";
+    let rrule = "";
+    let start: { date: string; time: string; allDay: boolean } | null = null;
+    let end: { date: string; time: string; allDay: boolean } | null = null;
+    for (const line of lines) {
+      const head = line.split(":")[0]?.split(";")[0]?.toUpperCase() ?? "";
+      if (head === "SUMMARY")
+        summary = line.slice(line.indexOf(":") + 1).replace(/\\n/g, "\n");
+      else if (head === "LOCATION")
+        location = line.slice(line.indexOf(":") + 1);
+      else if (head === "DESCRIPTION")
+        description = line.slice(line.indexOf(":") + 1).replace(/\\n/g, "\n");
+      else if (head === "RRULE") rrule = line.slice(line.indexOf(":") + 1);
+      else if (head === "DTSTART") start = parseIcsDate(line);
+      else if (head === "DTEND") end = parseIcsDate(line);
+    }
+    if (!start) continue;
+    out.push({
+      uid: newUid(),
+      summary: summary || "(no title)",
+      calendarHref,
+      date: start.date,
+      endDate: end ? end.date : start.date,
+      startTime: start.time,
+      endTime: end ? end.time : start.time,
+      allDay: start.allDay,
+      location,
+      description,
+      rrule,
+    });
+  }
+  return out;
+}
+
+// ── Event form (modeled on odysseus _showEventForm) ──────────────────────
+
+interface EventFormProps {
+  existing: CalEvent | null;
+  defaultDate: string;
+  calendars: LocalCalendar[];
+  onSave: (ev: CalEvent) => void;
+  onDelete: (uid: string) => void;
+  onCancel: () => void;
+}
+
+function EventForm({
+  existing,
+  defaultDate,
+  calendars,
+  onSave,
+  onDelete,
+  onCancel,
+}: EventFormProps): ReactNode {
+  const [summary, setSummary] = useState(existing?.summary ?? "");
+  const [date, setDate] = useState(existing?.date ?? defaultDate);
+  const [endDate, setEndDate] = useState(
+    existing?.endDate ?? existing?.date ?? defaultDate,
+  );
+  const [allDay, setAllDay] = useState(existing?.allDay ?? false);
+  const [startTime, setStartTime] = useState(existing?.startTime || "09:00");
+  const [endTime, setEndTime] = useState(existing?.endTime || "10:00");
+  const [location, setLocation] = useState(existing?.location ?? "");
+  const [description, setDescription] = useState(existing?.description ?? "");
+  const [rrule, setRrule] = useState(existing?.rrule ?? "");
+  const [calendarHref, setCalendarHref] = useState(
+    existing?.calendarHref ?? calendars[0]?.href ?? "",
+  );
+  const titleRef = useRef<HTMLInputElement | null>(null);
+
+  // Focus the title input on open — matches odysseus's bespoke-form behaviour
+  // without tripping the a11y/noAutofocus lint on the attribute form.
+  useEffect(() => {
+    titleRef.current?.focus();
+  }, []);
+
+  const isEdit = !!existing;
+  const mapsHref = location
+    ? `https://maps.apple.com/?q=${encodeURIComponent(location)}`
+    : "";
+
+  const submit = () => {
+    const cleanEnd = endDate < date ? date : endDate;
+    onSave({
+      uid: existing?.uid ?? newUid(),
+      summary: summary.trim() || "(no title)",
+      calendarHref,
+      date,
+      endDate: cleanEnd,
+      startTime: allDay ? "" : startTime,
+      endTime: allDay ? "" : endTime,
+      allDay,
+      location: location.trim(),
+      description: description.trim(),
+      rrule,
+    });
+  };
+
+  return (
+    <div className="od-cal-form">
+      <div className="od-cal-hero">
+        <span className="od-cal-hero-time">
+          {allDay ? "All day" : fmtClock(startTime)}
+        </span>
+        <span className="od-cal-hero-date">{fmtLongDate(date)}</span>
+      </div>
+
+      <div className="od-cal-title-wrap">
+        <input
+          ref={titleRef}
+          type="text"
+          className="od-cal-input od-cal-hero-title"
+          placeholder={isEdit ? "Event title" : "What's happening?"}
+          value={summary}
+          onChange={(e) => setSummary(e.target.value)}
+          autoComplete="off"
+        />
+      </div>
+
+      <div className="od-cal-form-details">
+        <div className="od-cal-form-row">
+          <input
+            type="date"
+            className="od-cal-input"
+            value={date}
+            onChange={(e) => {
+              setDate(e.target.value);
+              if (endDate < e.target.value) setEndDate(e.target.value);
+            }}
+            aria-label="Start date"
+          />
+          <span className="od-cal-form-to">to</span>
+          <input
+            type="date"
+            className="od-cal-input"
+            value={endDate}
+            min={date}
+            onChange={(e) => setEndDate(e.target.value)}
+            aria-label="End date"
+          />
+          <label className="od-cal-allday-ctrl">
+            <span>All day</span>
+            <input
+              type="checkbox"
+              checked={allDay}
+              onChange={(e) => setAllDay(e.target.checked)}
+            />
+          </label>
+        </div>
+
+        {allDay ? null : (
+          <div className="od-cal-form-row">
+            <input
+              type="time"
+              className="od-cal-input"
+              value={startTime}
+              onChange={(e) => setStartTime(e.target.value)}
+              aria-label="Start time"
+            />
+            <span className="od-cal-form-to">–</span>
+            <input
+              type="time"
+              className="od-cal-input"
+              value={endTime}
+              onChange={(e) => setEndTime(e.target.value)}
+              aria-label="End time"
+            />
+          </div>
+        )}
+
+        <div className="od-cal-form-row">
+          <input
+            type="text"
+            className="od-cal-input"
+            placeholder="Location"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+          />
+          {mapsHref ? (
+            <a
+              className="od-cal-loc-map"
+              href={mapsHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Open in Maps"
+            >
+              Map
+            </a>
+          ) : null}
+        </div>
+
+        <select
+          className="od-cal-input"
+          value={rrule}
+          onChange={(e) => setRrule(e.target.value)}
+          aria-label="Recurrence"
+        >
+          {RRULE_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+
+        <textarea
+          className="od-cal-input"
+          placeholder="Description"
+          rows={2}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+
+        {calendars.length > 1 ? (
+          <select
+            className="od-cal-input"
+            value={calendarHref}
+            onChange={(e) => setCalendarHref(e.target.value)}
+            aria-label="Calendar"
+          >
+            {calendars.map((c) => (
+              <option key={c.href} value={c.href}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        ) : null}
+      </div>
+
+      <div className="od-cal-form-actions">
+        {isEdit ? (
+          <button
+            type="button"
+            className="od-cal-btn od-cal-btn-danger"
+            onClick={() => existing && onDelete(existing.uid)}
+          >
+            Delete
+          </button>
+        ) : null}
+        <button type="button" className="od-cal-btn" onClick={onCancel}>
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="od-cal-btn od-cal-btn-primary"
+          onClick={submit}
+        >
+          {isEdit ? "Save" : "Create"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Calendar settings panel (modeled on odysseus _showCalSettings) ────────
+
+interface CalSettingsProps {
+  calendars: LocalCalendar[];
+  onChange: (cals: LocalCalendar[]) => void;
+  onImport: (events: CalEvent[]) => void;
+  eventsFor: (href: string) => CalEvent[];
+  onClose: () => void;
+}
+
+function CalSettings({
+  calendars,
+  onChange,
+  onImport,
+  eventsFor,
+  onClose,
+}: CalSettingsProps): ReactNode {
+  const fileRef = useRef<HTMLInputElement | null>(null);
+  const [importTarget, setImportTarget] = useState<string>(
+    calendars[0]?.href ?? "",
+  );
+  const [importStatus, setImportStatus] = useState<string>("");
+
+  const updateCal = (href: string, patch: Partial<LocalCalendar>) => {
+    onChange(calendars.map((c) => (c.href === href ? { ...c, ...patch } : c)));
+  };
+
+  const deleteCal = (href: string) => {
+    onChange(calendars.filter((c) => c.href !== href));
+  };
+
+  const addCal = () => {
+    const color =
+      CAL_SETTINGS_COLORS[calendars.length % CAL_SETTINGS_COLORS.length];
+    onChange([
+      ...calendars,
+      { href: `local/${newUid()}`, name: "New calendar", color },
+    ]);
+  };
+
+  const exportCal = (cal: LocalCalendar) => {
+    const ics = buildIcs(cal, eventsFor(cal.href));
+    const blob = new Blob([ics], { type: "text/calendar" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${cal.name.replace(/[^\w-]+/g, "_") || "calendar"}.ics`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImportFile = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = typeof reader.result === "string" ? reader.result : "";
+      const target = importTarget || calendars[0]?.href || "";
+      if (!target) {
+        setImportStatus("Add a calendar first");
+        return;
+      }
+      const parsed = parseIcs(text, target);
+      if (!parsed.length) {
+        setImportStatus("No events found in file");
+        return;
+      }
+      onImport(parsed);
+      setImportStatus(
+        `Imported ${parsed.length} event${parsed.length === 1 ? "" : "s"}`,
+      );
+    };
+    reader.onerror = () => setImportStatus("Could not read file");
+    reader.readAsText(file);
+  };
+
+  return (
+    <div className="od-cal-settings-overlay">
+      <button
+        type="button"
+        className="od-cal-settings-backdrop"
+        aria-label="Close settings"
+        onClick={onClose}
+      />
+      <div
+        className="od-cal-settings-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Calendar settings"
+      >
+        <div className="od-cal-settings-head">
+          <span>Calendar Settings</span>
+          <button
+            type="button"
+            className="od-cal-settings-close"
+            onClick={onClose}
+            aria-label="Close settings"
+          >
+            <X size={14} />
+          </button>
+        </div>
+        <div className="od-cal-settings-body">
+          <div className="od-cal-settings-section">
+            <div className="od-cal-settings-label">Your calendars</div>
+            <div className="od-cal-settings-list">
+              {calendars.map((c) => (
+                <div className="od-cal-settings-row" key={c.href}>
+                  <input
+                    type="color"
+                    className="od-cal-s-color"
+                    value={
+                      c.color.startsWith("#") ? c.color : CAL_SETTINGS_COLORS[0]
+                    }
+                    onChange={(e) =>
+                      updateCal(c.href, { color: e.target.value })
+                    }
+                    aria-label={`${c.name} colour`}
+                  />
+                  <input
+                    type="text"
+                    className="od-cal-s-name-input"
+                    value={c.name}
+                    onChange={(e) =>
+                      updateCal(c.href, { name: e.target.value })
+                    }
+                    aria-label="Calendar name"
+                  />
+                  <button
+                    type="button"
+                    className="od-cal-s-del"
+                    title="Delete calendar"
+                    aria-label={`Delete ${c.name}`}
+                    onClick={() => deleteCal(c.href)}
+                  >
+                    <Trash2 size={13} />
+                  </button>
+                </div>
+              ))}
+            </div>
+            <button
+              type="button"
+              className="od-cal-settings-btn"
+              onClick={addCal}
+            >
+              <Plus size={11} /> New calendar
+            </button>
+          </div>
+
+          <div className="od-cal-settings-section od-cal-settings-divided">
+            <div className="od-cal-settings-label">Import calendar</div>
+            <div className="od-cal-settings-import-row">
+              {calendars.length > 1 ? (
+                <select
+                  className="od-cal-input od-cal-import-target"
+                  value={importTarget}
+                  onChange={(e) => setImportTarget(e.target.value)}
+                  aria-label="Import into calendar"
+                >
+                  {calendars.map((c) => (
+                    <option key={c.href} value={c.href}>
+                      {c.name}
+                    </option>
+                  ))}
+                </select>
+              ) : null}
+              <button
+                type="button"
+                className="od-cal-settings-btn"
+                onClick={() => fileRef.current?.click()}
+              >
+                <Upload size={11} /> Import .ics
+              </button>
+              <input
+                ref={fileRef}
+                type="file"
+                accept=".ics,.ical"
+                className="od-cal-hidden-file"
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) handleImportFile(file);
+                  e.target.value = "";
+                }}
+              />
+              {importStatus ? (
+                <span className="od-cal-settings-status">{importStatus}</span>
+              ) : null}
+            </div>
+            <div className="od-cal-settings-hint">
+              Upload a .ics file to import events. Google Calendar, Apple
+              Calendar, and Outlook all export .ics files.
+            </div>
+          </div>
+
+          <div className="od-cal-settings-section od-cal-settings-divided">
+            <div className="od-cal-settings-label">Export calendar</div>
+            <div className="od-cal-settings-export-row">
+              {calendars.map((c) => (
+                <button
+                  type="button"
+                  className="od-cal-settings-btn"
+                  key={c.href}
+                  title={`Download ${c.name}.ics`}
+                  onClick={() => exportCal(c)}
+                >
+                  <Download size={11} /> {c.name}
+                </button>
+              ))}
+            </div>
+            <div className="od-cal-settings-hint">
+              Download a calendar as .ics for backup or to import into another
+              app.
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Empty state (modeled on odysseus _renderEmpty) ────────────────────────
+
+function CalEmptyState({
+  onNewCalendar,
+  onImport,
+}: {
+  onNewCalendar: () => void;
+  onImport: () => void;
+}): ReactNode {
+  return (
+    <div className="od-cal-empty-state">
+      <svg
+        width="48"
+        height="48"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="od-cal-empty-ico"
+        aria-hidden="true"
+      >
+        <rect x="3" y="4" width="18" height="18" rx="2" />
+        <line x1="16" y1="2" x2="16" y2="6" />
+        <line x1="8" y1="2" x2="8" y2="6" />
+        <line x1="3" y1="10" x2="21" y2="10" />
+      </svg>
+      <div className="od-cal-empty-title">No calendars yet</div>
+      <div className="od-cal-empty-msg">
+        Create a local calendar or import an .ics file to get started.
+      </div>
+      <div className="od-cal-empty-actions">
+        <button
+          type="button"
+          className="od-cal-btn od-cal-btn-primary"
+          onClick={onNewCalendar}
+        >
+          New calendar
+        </button>
+        <button type="button" className="od-cal-btn" onClick={onImport}>
+          Import .ics
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── Event more-menu (modeled on odysseus _showEventMoreMenu) ──────────────
+
+function EventMoreMenu({
+  x,
+  y,
+  onEdit,
+  onDelete,
+  onClose,
+}: {
+  x: number;
+  y: number;
+  onEdit: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}): ReactNode {
+  useEffect(() => {
+    const onDoc = () => onClose();
+    // Defer so the opening click doesn't immediately dismiss.
+    const id = window.setTimeout(
+      () => window.addEventListener("click", onDoc, { once: true }),
+      0,
+    );
+    return () => {
+      window.clearTimeout(id);
+      window.removeEventListener("click", onDoc);
+    };
+  }, [onClose]);
+
+  return (
+    <div
+      className="od-cal-event-dropdown"
+      style={{ top: y, left: x }}
+      role="menu"
+    >
+      <button
+        type="button"
+        className="od-cal-dropdown-item"
+        role="menuitem"
+        onClick={onEdit}
+      >
+        Edit
+      </button>
+      <button
+        type="button"
+        className="od-cal-dropdown-item od-cal-dropdown-danger"
+        role="menuitem"
+        onClick={onDelete}
+      >
+        Delete
+      </button>
+    </div>
+  );
+}
+
+export function CalendarView({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}): ReactNode {
+  const [view, setView] = useState<CalendarViewMode>("month");
+  const [current, setCurrent] = useState<Date>(() => new Date());
+  const [selectedDay, setSelectedDay] = useState<string>(() => ymd(new Date()));
+  const [hiddenCals, setHiddenCals] = useState<ReadonlySet<string>>(
+    () => new Set<string>(),
+  );
+  // Day-detail global search (calendar.js `_searchQuery`). When non-empty, the
+  // day-detail body lists every matching event (summary/description/location)
+  // instead of just the selected day's events.
+  const [searchQuery, setSearchQuery] = useState("");
+  // "± tags" filter-row collapse (calendar.js `_filtersCollapsed`). Only
+  // surfaces once there is >1 calendar; default expanded like odysseus.
+  const [filtersCollapsed, setFiltersCollapsed] = useState(false);
+  // Local-first persisted state — calendars + events both live in localStorage
+  // (see file header). `version` bumps when the user hits Refresh, forcing a
+  // re-read from storage so an external edit/import in another tab is picked up.
+  const [calendars, setCalendars] = useState<LocalCalendar[]>(() =>
+    readPref<LocalCalendar[]>(CAL_PREF_KEY, DEFAULT_CALENDARS),
+  );
+  const [events, setEvents] = useState<CalEvent[]>(() =>
+    readPref<CalEvent[]>(EVENTS_PREF_KEY, []),
+  );
+  const [formState, setFormState] = useState<{
+    existing: CalEvent | null;
+    date: string;
+  } | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [moreMenu, setMoreMenu] = useState<{
+    ev: CalEvent;
+    x: number;
+    y: number;
+  } | null>(null);
+  const [syncing, setSyncing] = useState(false);
+  // The pending sync-spin timer, cleared on unmount so the cosmetic
+  // setSyncing(false) never fires after the view is gone.
+  const syncTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(
+    null,
+  );
+
+  const win = useWindowControls(
+    "win-calendar",
+    { w: 720, h: 620 },
+    { label: "Calendar", icon: "CalendarDays", onClose },
+  );
+
+  const persistCalendars = useCallback((next: LocalCalendar[]) => {
+    setCalendars(next);
+    writePref(CAL_PREF_KEY, next);
+  }, []);
+
+  const persistEvents = useCallback((next: CalEvent[]) => {
+    setEvents(next);
+    writePref(EVENTS_PREF_KEY, next);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (settingsOpen) {
+        setSettingsOpen(false);
+        return;
+      }
+      if (formState) {
+        setFormState(null);
+        return;
+      }
+      if (searchQuery) {
+        setSearchQuery("");
+        return;
+      }
+      onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose, settingsOpen, formState, searchQuery]);
+
+  // Clear the pending sync-spin timer on unmount.
+  useEffect(
+    () => () => {
+      if (syncTimerRef.current !== null) {
+        window.clearTimeout(syncTimerRef.current);
+      }
+    },
+    [],
+  );
+
+  const today = ymd(new Date());
+  const year = current.getFullYear();
+  const month = current.getMonth();
+
+  const eventVisible = useCallback(
+    (e: CalEvent): boolean => !hiddenCals.has(e.calendarHref),
+    [hiddenCals],
+  );
+  const visibleEvents = useMemo(
+    () => events.filter(eventVisible),
+    [events, eventVisible],
+  );
+
+  const eventsForDay = useCallback(
+    (date: string): CalEvent[] =>
+      visibleEvents
+        .filter((e) => date >= e.date && date <= e.endDate)
+        .sort((a, b) => {
+          if (a.allDay !== b.allDay) return a.allDay ? -1 : 1;
+          return (a.startTime || "").localeCompare(b.startTime || "");
+        }),
+    [visibleEvents],
+  );
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  const toggleCal = (href: string) => {
+    setHiddenCals((prev) => {
+      const next = new Set(prev);
+      if (next.has(href)) next.delete(href);
+      else next.add(href);
+      return next;
+    });
+  };
+
+  const shiftPeriod = (delta: number) => {
+    if (view === "year") setCurrent(new Date(year + delta, month, 1));
+    else if (view === "week")
+      setCurrent(new Date(year, month, current.getDate() + delta * 7));
+    else setCurrent(new Date(year, month + delta, 1));
+  };
+
+  const goToday = () => {
+    const now = new Date();
+    setCurrent(now);
+    setSelectedDay(ymd(now));
+  };
+
+  const doRefresh = () => {
+    setSyncing(true);
+    setCalendars(readPref<LocalCalendar[]>(CAL_PREF_KEY, DEFAULT_CALENDARS));
+    setEvents(readPref<CalEvent[]>(EVENTS_PREF_KEY, []));
+    if (syncTimerRef.current !== null) {
+      window.clearTimeout(syncTimerRef.current);
+    }
+    syncTimerRef.current = window.setTimeout(() => {
+      setSyncing(false);
+      syncTimerRef.current = null;
+    }, SYNC_SPIN_MS);
+  };
+
+  const saveEvent = (ev: CalEvent) => {
+    const idx = events.findIndex((e) => e.uid === ev.uid);
+    const next =
+      idx >= 0
+        ? events.map((e) => (e.uid === ev.uid ? ev : e))
+        : [...events, ev];
+    persistEvents(next);
+    setFormState(null);
+    setSelectedDay(ev.date);
+  };
+
+  const deleteEvent = (uid: string) => {
+    persistEvents(events.filter((e) => e.uid !== uid));
+    setFormState(null);
+    setMoreMenu(null);
+  };
+
+  const openNew = (date?: string) =>
+    setFormState({ existing: null, date: date ?? selectedDay ?? today });
+  const openEdit = (ev: CalEvent) =>
+    setFormState({ existing: ev, date: ev.date });
+
+  const showFilters = calendars.length > 1;
+
+  // ── Toolbar (shared across views) ───────────────────────────────────────
+  const titleText =
+    view === "agenda"
+      ? "Upcoming"
+      : view === "year"
+        ? String(year)
+        : `${MONTHS[month]} ${year}`;
+  const weekSuffix = view === "week" ? ` · W${isoWeekNumber(current)}` : "";
+
+  const toolbar = (
+    <div className="od-cal-toolbar">
+      <div className="od-cal-toolbar-nav">
+        <button
+          type="button"
+          className="od-cal-nav"
+          onClick={() => shiftPeriod(-1)}
+          aria-label="Previous"
+        >
+          <ArrowLeft size={13} />
+        </button>
+        <button
+          type="button"
+          className="od-cal-nav od-cal-today-btn"
+          onClick={goToday}
+        >
+          Today
+        </button>
+        <span className="od-cal-period-title">
+          {titleText}
+          {weekSuffix}
+        </span>
+        <button
+          type="button"
+          className="od-cal-nav"
+          onClick={() => shiftPeriod(1)}
+          aria-label="Next"
+        >
+          <ArrowRight size={13} />
+        </button>
+      </div>
+      <div className="od-cal-toolbar-right">
+        <div className="od-cal-view-toggle">
+          {(["week", "month", "year", "agenda"] as const).map((v) => (
+            <button
+              type="button"
+              key={v}
+              className={`od-cal-view-btn${view === v ? " active" : ""}`}
+              onClick={() => setView(v)}
+            >
+              {v[0].toUpperCase() + v.slice(1)}
+            </button>
+          ))}
+        </div>
+        <button
+          type="button"
+          className="od-cal-nav"
+          title="Calendar settings"
+          aria-label="Calendar settings"
+          onClick={() => setSettingsOpen(true)}
+        >
+          <Cog size={13} />
+        </button>
+        <button
+          type="button"
+          className={`od-cal-nav${syncing ? " od-cal-syncing" : ""}`}
+          title="Refresh from storage"
+          aria-label="Refresh"
+          onClick={doRefresh}
+        >
+          <RefreshCw size={13} />
+        </button>
+        {showFilters ? (
+          <button
+            type="button"
+            className="od-cal-filter-toggle"
+            title={filtersCollapsed ? "Show filters" : "Hide filters"}
+            onClick={() => setFiltersCollapsed((c) => !c)}
+          >
+            {filtersCollapsed ? "+ tags" : "− tags"}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          className="od-cal-add-btn od-cal-add-btn-text"
+          title="New event"
+          aria-label="New event"
+          onClick={() => openNew()}
+        >
+          <span className="od-cal-add-plus">
+            <Plus size={13} />
+          </span>
+          <span className="od-cal-add-label">New</span>
+        </button>
+      </div>
+    </div>
+  );
+
+  // ── Window titlebar (calendar.js .modal-header, line 573) ────────────────
+  // The draggable window chrome: calendar glyph + accent "Calendar" wordmark on
+  // the left, minimize ("—") + close on the right. Minimize hides the panel and
+  // surfaces a dock chip via the shell WindowManager (see useWindowControls).
+  const windowHeader = (
+    <div className="od-cal-window-header" onPointerDown={win.onDragStart}>
+      <h4 className="od-cal-title">
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <rect x="3" y="4" width="18" height="18" rx="2" />
+          <line x1="16" y1="2" x2="16" y2="6" />
+          <line x1="8" y1="2" x2="8" y2="6" />
+          <line x1="3" y1="10" x2="21" y2="10" />
+        </svg>
+        <span>Calendar</span>
+      </h4>
+      <button
+        type="button"
+        className="od-window-min-btn"
+        onClick={win.minimize}
+        title="Minimize"
+        aria-label="Minimize"
+      >
+        <Minus size={14} aria-hidden="true" />
+      </button>
+      <button
+        type="button"
+        className="od-cal-window-close"
+        aria-label="Close calendar"
+        onClick={onClose}
+      >
+        <X size={16} />
+      </button>
+    </div>
+  );
+
+  // ── Quick-add row (calendar.js line 803) ─────────────────────────────────
+  // odysseus parses natural language here via /api/calendar/quick-parse, which
+  // eliza has no client method for (see file header). We render the row for 1:1
+  // chrome with its accent "Quick add" hint overlay, but as an honest inert
+  // input — disabled with a title explaining the parser is unavailable locally,
+  // so it never pretends to accept input it cannot understand.
+  const quickAddRow = (
+    <div className="od-cal-quickadd-row">
+      <input
+        type="text"
+        className="od-cal-quickadd-input"
+        placeholder=" "
+        autoComplete="off"
+        disabled
+        title="Natural-language quick add needs a calendar parser backend (unavailable locally)"
+        aria-label="Quick add event (unavailable)"
+      />
+      <span className="od-cal-quickadd-hint" aria-hidden="true">
+        <span className="od-cal-qa-accent">Quick add</span> — return home to
+        Ithaca 1pm tmrw{" "}
+        <svg
+          className="od-cal-qa-enter"
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="9 10 4 15 9 20" />
+          <path d="M20 4v7a4 4 0 0 1-4 4H4" />
+        </svg>
+      </span>
+    </div>
+  );
+
+  const filterRow =
+    showFilters && !filtersCollapsed ? (
+      <div className="od-cal-filters">
+        {calendars.map((c) => {
+          const off = hiddenCals.has(c.href);
+          return (
+            <button
+              type="button"
+              key={c.href}
+              className={`od-cal-filter-item${off ? " od-cal-filter-off" : ""}`}
+              onClick={() => toggleCal(c.href)}
+            >
+              <span
+                className="od-cal-filter-dot"
+                style={{ background: c.color }}
+              />
+              {c.name}
+            </button>
+          );
+        })}
+      </div>
+    ) : null;
+
+  // ── Month grid ──────────────────────────────────────────────────────────
+  const first = new Date(year, month, 1);
+  const dow = (first.getDay() + 6) % 7;
+  const gridStart = new Date(year, month, 1 - dow);
+  const weekRows: { date: string; cellDate: Date; isOther: boolean }[][] = [];
+  for (let row = 0; row < 6; row++) {
+    const cols: { date: string; cellDate: Date; isOther: boolean }[] = [];
+    for (let col = 0; col < 7; col++) {
+      const i = row * 7 + col;
+      const cd = new Date(gridStart);
+      cd.setDate(gridStart.getDate() + i);
+      cols.push({
+        date: ymd(cd),
+        cellDate: cd,
+        isOther: cd.getMonth() !== month,
+      });
+    }
+    weekRows.push(cols);
+  }
+
+  const monthBody = (
+    <div className="od-cal-grid">
+      <div className="od-cal-week-headers">
+        {WEEKDAYS.map((wd) => (
+          <div className="od-cal-weekday" key={wd}>
+            {wd}
+          </div>
+        ))}
+      </div>
+      {weekRows.map((cols) => (
+        <div className="od-cal-week-row" key={cols[0].date}>
+          {cols.map((cell) => {
+            const singles = eventsForDay(cell.date);
+            const maxInline = 3;
+            const showInline = singles.slice(0, maxInline);
+            const cls = [
+              "od-cal-day",
+              cell.isOther ? "od-cal-other" : "",
+              cell.date === today ? "od-cal-today" : "",
+              cell.date === selectedDay ? "od-cal-selected" : "",
+            ]
+              .filter(Boolean)
+              .join(" ");
+            return (
+              <button
+                type="button"
+                className={cls}
+                key={cell.date}
+                onClick={() => setSelectedDay(cell.date)}
+                onDoubleClick={() => openNew(cell.date)}
+              >
+                <span className="od-cal-day-num">
+                  {cell.cellDate.getDate()}
+                </span>
+                {showInline.map((ev) => (
+                  <span className="od-cal-event-row" key={ev.uid}>
+                    <span
+                      className="od-cal-event-row-dot"
+                      style={{ background: calColor(ev, calendars) }}
+                    />
+                    {ev.startTime ? (
+                      <span className="od-cal-event-row-time">
+                        {fmtClock(ev.startTime)}
+                      </span>
+                    ) : null}
+                    <span className="od-cal-event-row-name">{ev.summary}</span>
+                  </span>
+                ))}
+                {singles.length > maxInline ? (
+                  <span className="od-cal-event-more-count">
+                    +{singles.length - maxInline} more
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+
+  // ── Week view (hour rail + day columns) ─────────────────────────────────
+  const weekStartDow = (current.getDay() + 6) % 7;
+  const weekStart = new Date(year, month, current.getDate() - weekStartDow);
+  const weekDays: { ds: string; d: Date; idx: number }[] = [];
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(weekStart);
+    d.setDate(weekStart.getDate() + i);
+    weekDays.push({ ds: ymd(d), d, idx: i });
+  }
+  const HOUR_START = 7;
+  const HOUR_END = 22;
+  const HOUR_PX = 40;
+  const hours: number[] = [];
+  for (let h = HOUR_START; h < HOUR_END; h++) hours.push(h);
+  const hourLabel = (h: number): string => {
+    const ampm = h >= 12 ? "PM" : "AM";
+    const h12 = h % 12 === 0 ? 12 : h % 12;
+    return `${h12} ${ampm}`;
+  };
+  const minsFromStart = (hhmm: string): number => {
+    const [h, m] = hhmm.split(":").map(Number);
+    return (h - HOUR_START) * 60 + m;
+  };
+
+  const weekBody = (
+    <div className="od-cal-wk-wrap">
+      <div className="od-cal-wk-rail">
+        <div className="od-cal-wk-rail-spacer" />
+        {hours.map((h) => (
+          <div
+            className="od-cal-wk-rail-cell"
+            style={{ height: HOUR_PX }}
+            key={h}
+          >
+            <span>{hourLabel(h)}</span>
+          </div>
+        ))}
+      </div>
+      <div className="od-cal-wk-cols">
+        {weekDays.map(({ ds, d, idx }) => {
+          const dayEvents = eventsForDay(ds);
+          const allDayEvents = dayEvents.filter((e) => e.allDay);
+          const timedEvents = dayEvents.filter((e) => !e.allDay);
+          const isToday = ds === today;
+          return (
+            <div
+              className={`od-cal-wk-col${isToday ? " od-cal-wk-today" : ""}`}
+              key={ds}
+            >
+              <div className="od-cal-wk-col-head">
+                <span className="od-cal-wk-dn">{WEEKDAYS[idx]}</span>
+                <span className="od-cal-wk-dt">{d.getDate()}</span>
+              </div>
+              <div className="od-cal-wk-allday">
+                {allDayEvents.map((ev) => (
+                  <button
+                    type="button"
+                    className="od-cal-wk-allday-event"
+                    key={ev.uid}
+                    style={{ background: calColor(ev, calendars) }}
+                    title={ev.summary}
+                    onClick={() => openEdit(ev)}
+                  >
+                    {ev.summary}
+                  </button>
+                ))}
+              </div>
+              <div
+                className="od-cal-wk-grid"
+                style={{ height: hours.length * HOUR_PX }}
+              >
+                {hours.map((h) => (
+                  <div
+                    className="od-cal-wk-cell"
+                    style={{ height: HOUR_PX }}
+                    key={h}
+                  />
+                ))}
+                {timedEvents.map((ev) => {
+                  const top = (minsFromStart(ev.startTime) / 60) * HOUR_PX;
+                  const endM = ev.endTime
+                    ? minsFromStart(ev.endTime)
+                    : minsFromStart(ev.startTime) + 60;
+                  const height = Math.max(
+                    16,
+                    ((endM - minsFromStart(ev.startTime)) / 60) * HOUR_PX,
+                  );
+                  return (
+                    <button
+                      type="button"
+                      className="od-cal-wk-event"
+                      key={ev.uid}
+                      style={{
+                        top,
+                        height,
+                        background: `color-mix(in srgb, ${calColor(ev, calendars)} 22%, var(--bg))`,
+                        borderLeftColor: calColor(ev, calendars),
+                      }}
+                      onClick={() => openEdit(ev)}
+                    >
+                      <span className="od-cal-wk-event-time">
+                        {fmtClock(ev.startTime)}
+                      </span>
+                      <span className="od-cal-wk-event-name">{ev.summary}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+
+  // ── Year view (12 mini month grids) ─────────────────────────────────────
+  const yearBody = (
+    <div className="od-cal-year">
+      {Array.from({ length: 12 }, (_, m) => {
+        const mFirst = new Date(year, m, 1);
+        const mDow = (mFirst.getDay() + 6) % 7;
+        const daysInMonth = new Date(year, m + 1, 0).getDate();
+        const cells: (number | null)[] = [];
+        for (let p = 0; p < mDow; p++) cells.push(null);
+        for (let d = 1; d <= daysInMonth; d++) cells.push(d);
+        return (
+          <button
+            type="button"
+            className="od-cal-year-month"
+            key={MON_SHORT[m]}
+            onClick={() => {
+              setCurrent(new Date(year, m, 1));
+              setView("month");
+            }}
+          >
+            <div className="od-cal-year-month-title">{MON_SHORT[m]}</div>
+            <div className="od-cal-year-grid">
+              {["M", "T", "W", "T", "F", "S", "S"].map((wd, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: fixed 7-element weekday header
+                <div className="od-cal-year-wd" key={`wd-${i}`}>
+                  {wd}
+                </div>
+              ))}
+              {cells.map((d, i) => {
+                if (d == null)
+                  // biome-ignore lint/suspicious/noArrayIndexKey: fixed-position leading blank cell
+                  return <div className="od-cal-year-cell" key={`pad-${i}`} />;
+                const ds = `${year}-${String(m + 1).padStart(2, "0")}-${String(d).padStart(2, "0")}`;
+                const has = eventsForDay(ds).length > 0;
+                const cls = [
+                  "od-cal-year-cell",
+                  "od-cal-year-day",
+                  ds === today ? "od-cal-year-today" : "",
+                  has ? "od-cal-year-has" : "",
+                ]
+                  .filter(Boolean)
+                  .join(" ");
+                return (
+                  <div className={cls} key={ds}>
+                    {d}
+                  </div>
+                );
+              })}
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+
+  // ── Agenda view (chronological, grouped by day) ─────────────────────────
+  const agendaStart = ymd(current);
+  const agendaEndDate = new Date(current);
+  agendaEndDate.setMonth(agendaEndDate.getMonth() + 3);
+  const agendaEnd = ymd(agendaEndDate);
+  const agendaEvents = visibleEvents
+    .filter((e) => e.date >= agendaStart && e.date <= agendaEnd)
+    .sort((a, b) => {
+      if (a.date !== b.date) return a.date.localeCompare(b.date);
+      return (a.startTime || "").localeCompare(b.startTime || "");
+    });
+  const agendaByDate = new Map<string, CalEvent[]>();
+  for (const ev of agendaEvents) {
+    const list = agendaByDate.get(ev.date) ?? [];
+    list.push(ev);
+    agendaByDate.set(ev.date, list);
+  }
+  if (today >= agendaStart && today <= agendaEnd && !agendaByDate.has(today))
+    agendaByDate.set(today, []);
+  const agendaDates = [...agendaByDate.keys()].sort();
+
+  const agendaBody = (
+    <div className="od-cal-agenda">
+      {agendaDates.length === 0 ? (
+        <div className="od-cal-empty">No upcoming events</div>
+      ) : (
+        agendaDates.map((date) => {
+          const evs = agendaByDate.get(date) ?? [];
+          return (
+            <div
+              className={`od-cal-agenda-day${date === today ? " is-today" : ""}`}
+              key={date}
+            >
+              <div className="od-cal-agenda-date">
+                {fmtLongDate(date)}
+                {date === today ? (
+                  <span className="od-cal-agenda-today-badge">Today</span>
+                ) : null}
+              </div>
+              {evs.length === 0 ? (
+                <div className="od-cal-agenda-empty">No events</div>
+              ) : (
+                evs.map((ev) => (
+                  <button
+                    type="button"
+                    className="od-cal-agenda-event"
+                    key={ev.uid}
+                    onClick={() => openEdit(ev)}
+                  >
+                    <span
+                      className="od-cal-event-dot"
+                      style={{ background: calColor(ev, calendars) }}
+                    />
+                    <div className="od-cal-event-info">
+                      <div className="od-cal-event-name">{ev.summary}</div>
+                      <div className="od-cal-event-time">
+                        {ev.allDay
+                          ? "All day"
+                          : `${fmtClock(ev.startTime)} – ${fmtClock(ev.endTime)}`}
+                        {ev.location ? ` · ${ev.location}` : ""}
+                      </div>
+                    </div>
+                  </button>
+                ))
+              )}
+            </div>
+          );
+        })
+      )}
+    </div>
+  );
+
+  // ── Day detail (month/week footer panel) ────────────────────────────────
+  const detailEvents = eventsForDay(selectedDay);
+  // Global search across all visible events (calendar.js:1722-1751). When the
+  // in-panel search has text, the day body lists every matching event instead
+  // of the selected day's events.
+  const trimmedQuery = searchQuery.trim().toLowerCase();
+  const searchResults = trimmedQuery
+    ? visibleEvents
+        .filter(
+          (e) =>
+            e.summary.toLowerCase().includes(trimmedQuery) ||
+            e.description.toLowerCase().includes(trimmedQuery) ||
+            e.location.toLowerCase().includes(trimmedQuery),
+        )
+        .sort((a, b) => {
+          if (a.date !== b.date) return a.date.localeCompare(b.date);
+          return (a.startTime || "").localeCompare(b.startTime || "");
+        })
+    : [];
+
+  const renderEventRow = (ev: CalEvent, withDate: boolean): ReactNode => (
+    <div className="od-cal-event-item" key={ev.uid}>
+      <span
+        className="od-cal-event-dot"
+        style={{ background: calColor(ev, calendars) }}
+      />
+      <button
+        type="button"
+        className="od-cal-event-info od-cal-event-info-btn"
+        onClick={() => openEdit(ev)}
+      >
+        <div className="od-cal-event-name">{ev.summary}</div>
+        <div className="od-cal-event-time">
+          {withDate ? `${fmtLongDate(ev.date)} · ` : ""}
+          {ev.allDay
+            ? "All day"
+            : `${fmtClock(ev.startTime)} – ${fmtClock(ev.endTime)}`}
+          {ev.location ? ` · ${ev.location}` : ""}
+        </div>
+      </button>
+      <button
+        type="button"
+        className="od-cal-event-more-btn"
+        title="More"
+        aria-label="Event actions"
+        onClick={(e) => {
+          const r = e.currentTarget.getBoundingClientRect();
+          setMoreMenu({ ev, x: r.left, y: r.bottom + 4 });
+        }}
+      >
+        ⋯
+      </button>
+    </div>
+  );
+
+  const dayDetail =
+    view === "month" || view === "week" ? (
+      <>
+        {/* Decorative grip divider (calendar.js .cal-splitter). Drag-to-resize
+            needs the host window manager; here it is a faithful static divider
+            between the grid and the day-detail, so it carries no interactive
+            role. */}
+        <div className="od-cal-splitter" aria-hidden="true">
+          <div className="od-cal-splitter-grip" />
+        </div>
+        <div className="od-cal-day-detail">
+          <div className="od-cal-search-wrap">
+            <Search
+              size={13}
+              className="od-cal-search-icon"
+              aria-hidden="true"
+            />
+            <input
+              type="search"
+              className="od-cal-search-input"
+              placeholder="Search all events…"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              aria-label="Search all events"
+            />
+          </div>
+          <div className="od-cal-detail-header">
+            <span>
+              {fmtLongDate(selectedDay)}
+              {selectedDay === today ? (
+                <span className="od-cal-detail-today"> (Today)</span>
+              ) : null}
+            </span>
+            <button
+              type="button"
+              className="od-cal-add-btn od-cal-add-btn-text od-cal-add-btn-sm"
+              title="New event"
+              aria-label="New event on this day"
+              onClick={() => openNew(selectedDay)}
+            >
+              <span className="od-cal-add-plus">
+                <Plus size={11} />
+              </span>
+              <span className="od-cal-add-label">New</span>
+            </button>
+          </div>
+          {trimmedQuery ? (
+            <>
+              <div className="od-cal-day-search-meta">
+                {searchResults.length} result
+                {searchResults.length === 1 ? "" : "s"}
+              </div>
+              {searchResults.length === 0 ? (
+                <div className="od-cal-empty">No events match</div>
+              ) : (
+                searchResults.map((ev) => renderEventRow(ev, true))
+              )}
+            </>
+          ) : detailEvents.length === 0 ? (
+            <div className="od-cal-empty">No events</div>
+          ) : (
+            detailEvents.map((ev) => renderEventRow(ev, false))
+          )}
+        </div>
+      </>
+    ) : null;
+
+  const hasCalendars = calendars.length > 0;
+
+  return (
+    <div
+      className={`od-search-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Calendar"
+    >
+      <button
+        type="button"
+        aria-label="Close calendar"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel od-cal-panel" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        {windowHeader}
+        <div className="od-cal-body">
+          {!hasCalendars ? (
+            <CalEmptyState
+              onNewCalendar={() => {
+                persistCalendars([
+                  {
+                    href: `local/${newUid()}`,
+                    name: "New calendar",
+                    color: CAL_SETTINGS_COLORS[0],
+                  },
+                ]);
+                setSettingsOpen(true);
+              }}
+              onImport={() => setSettingsOpen(true)}
+            />
+          ) : formState ? (
+            <>
+              {toolbar}
+              <EventForm
+                existing={formState.existing}
+                defaultDate={formState.date}
+                calendars={calendars}
+                onSave={saveEvent}
+                onDelete={deleteEvent}
+                onCancel={() => setFormState(null)}
+              />
+            </>
+          ) : (
+            <>
+              {toolbar}
+              {quickAddRow}
+              {filterRow}
+              {view === "month" ? monthBody : null}
+              {view === "week" ? weekBody : null}
+              {view === "year" ? yearBody : null}
+              {view === "agenda" ? agendaBody : null}
+              {dayDetail}
+            </>
+          )}
+        </div>
+      </div>
+
+      {settingsOpen ? (
+        <CalSettings
+          calendars={calendars}
+          onChange={persistCalendars}
+          onImport={(imported) => persistEvents([...events, ...imported])}
+          eventsFor={(href) => events.filter((e) => e.calendarHref === href)}
+          onClose={() => setSettingsOpen(false)}
+        />
+      ) : null}
+
+      {moreMenu ? (
+        <EventMoreMenu
+          x={moreMenu.x}
+          y={moreMenu.y}
+          onEdit={() => {
+            openEdit(moreMenu.ev);
+            setMoreMenu(null);
+          }}
+          onDelete={() => deleteEvent(moreMenu.ev.uid)}
+          onClose={() => setMoreMenu(null)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/ChatContainer.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/ChatContainer.tsx
@@ -1,0 +1,93 @@
+// odysseus main column (static/index.html main.chat-container): top bar, the
+// message log (or the welcome screen when empty), and the composer.
+
+import { Eye } from "lucide-react";
+import type { ReactNode } from "react";
+import type { ConversationBlock } from "../orchestrator-stream";
+import { ChatMessages } from "./ChatMessages";
+import { ChatTopBar } from "./ChatTopBar";
+import { Composer } from "./Composer";
+
+export function ChatContainer({
+  title,
+  conversation,
+  locale,
+  input,
+  onInput,
+  onSubmit,
+  onStop,
+  sending,
+  isActive,
+  modelLabel,
+  onNewChat,
+  onSearch,
+  onOpenPanel,
+  onOpenModels,
+}: {
+  title: string;
+  conversation: ConversationBlock[];
+  locale?: string;
+  input: string;
+  onInput: (value: string) => void;
+  onSubmit: () => void;
+  onStop: () => void;
+  sending: boolean;
+  isActive: boolean;
+  modelLabel: string;
+  onNewChat: () => void;
+  onSearch: () => void;
+  onOpenPanel: (
+    panel: "theme" | "memory" | "skills" | "notes" | "settings",
+  ) => void;
+  onOpenModels?: () => void;
+}): ReactNode {
+  return (
+    <main className="od-chat-container" aria-label="Chat area">
+      <ChatTopBar title={title} />
+      {conversation.length === 0 ? (
+        <div className="od-welcome">
+          <div className="od-welcome-title">
+            <svg viewBox="0 0 32 32" width="28" height="28" aria-hidden="true">
+              <path d="M16 4L16 22L6 22Z" fill="currentColor" />
+              <path d="M16 8L16 22L24 22Z" fill="currentColor" opacity="0.6" />
+              <path
+                d="M4 24Q10 20 16 24Q22 28 28 24"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                fill="none"
+                strokeLinecap="round"
+              />
+            </svg>
+            Orchestrator
+          </div>
+          <div className="od-welcome-sub">
+            Message the orchestrator to start a task.
+          </div>
+          <p className="od-welcome-hint">
+            Describe the work and the orchestrator will plan it, spin up coding
+            agents, and report back here.
+          </p>
+          <div className="od-welcome-presence">
+            <Eye size={12} aria-hidden="true" />
+            <span>Nobody</span>
+          </div>
+        </div>
+      ) : (
+        <ChatMessages conversation={conversation} locale={locale} />
+      )}
+      <Composer
+        input={input}
+        onInput={onInput}
+        onSubmit={onSubmit}
+        onStop={onStop}
+        sending={sending}
+        isActive={isActive}
+        modelLabel={modelLabel}
+        onNewChat={onNewChat}
+        onSearch={onSearch}
+        onOpenPanel={onOpenPanel}
+        onOpenModels={onOpenModels}
+      />
+    </main>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/ChatMessages.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/ChatMessages.tsx
@@ -107,11 +107,23 @@ export function ChatMessages({
     stickToBottom.current = distance < 80;
   }, []);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: conversation is the trigger
+  // While a reply streams, deltas coalesce into the same trailing block (stable
+  // key, unchanged length), so length+key alone never re-fire the stick-to-
+  // bottom effect and a pinned reader stops following. Track the trailing
+  // block's text length too so the effect re-runs as its content grows.
+  const lastBlock = conversation[conversation.length - 1];
+  const lastContentLen =
+    lastBlock && "content" in lastBlock
+      ? lastBlock.content.length
+      : lastBlock && "text" in lastBlock
+        ? lastBlock.text.length
+        : 0;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: the derived signals below are the intended triggers
   useEffect(() => {
     const el = scrollRef.current;
     if (el && stickToBottom.current) el.scrollTop = el.scrollHeight;
-  }, [conversation.length, conversation[conversation.length - 1]?.key]);
+  }, [conversation.length, lastBlock?.key, lastContentLen]);
 
   return (
     <div className="od-chat-history" ref={scrollRef} onScroll={onScroll}>

--- a/plugins/plugin-task-coordinator/src/odysseus/ChatMessages.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/ChatMessages.tsx
@@ -1,0 +1,138 @@
+// The message log. Reuses buildConversation's block list: user/agent turns are
+// rendered as odysseus bubbles; tool/reasoning/notice blocks reuse the shared
+// ConversationBlockView (which inherits the odysseus palette via the remapped
+// theme vars). Sticks to the newest entry unless the user has scrolled up.
+//
+// Assistant turns carry a hover-revealed action footer (odysseus chatRenderer.js
+// createMsgFooter). Of odysseus's seven footer actions only Copy has a real
+// backing surface in eliza's orchestrator — edit / regenerate-from-here /
+// rewrite-shorter / explain-simpler / fork / delete all require message-mutation
+// endpoints the orchestrator does not expose, and the "memory used" pill needs a
+// recall source the stream never emits. Rather than render dead controls that
+// route nowhere, the footer ships the honest, wired subset: a single Copy button
+// (the same affordance as the upstream footer-copy-btn) over the turn's prose.
+// The remaining actions + metrics belong with the streaming/message-mutation
+// layer (useChatSubmit.ts, orchestrator-stream.tsx) and are tracked there.
+
+import { Check, Copy } from "lucide-react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import type { ConversationBlock } from "../orchestrator-stream";
+import { ConversationBlockView } from "../orchestrator-stream";
+import { AgentBubble, UserBubble } from "./MessageBubble";
+
+type AgentBlock = Extract<ConversationBlock, { kind: "agent" }>;
+
+// How long the Copy button shows its success glyph before reverting (odysseus
+// chatRenderer.js footer-copy-btn reverts after 1500ms).
+const COPY_FEEDBACK_MS = 1500;
+
+/** Hover-revealed action footer for one assistant turn (odysseus
+ * createMsgFooter). Copy is the only action with a real wired surface in the
+ * orchestrator, so it is the only control shown — no dead edit/fork/delete
+ * buttons, no memory pill without a recall source. Copy writes the turn's prose
+ * to the clipboard and flips to a brief success glyph, matching the upstream
+ * footer-copy-btn and the CodeBlock copy affordance. */
+function AgentFooter({ content }: { content: string }): ReactNode {
+  const [copied, setCopied] = useState(false);
+  // Revert timer for the success glyph; cleared on unmount and before re-arming
+  // so a copy on a message that scrolls/unmounts within the window never sets
+  // state on an unmounted component.
+  const revertRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (revertRef.current !== null) clearTimeout(revertRef.current);
+    },
+    [],
+  );
+
+  const onCopy = useCallback(() => {
+    // Guard for non-secure-context / older webviews where clipboard is absent.
+    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText)
+      return;
+    navigator.clipboard.writeText(content).then(
+      () => {
+        setCopied(true);
+        if (revertRef.current !== null) clearTimeout(revertRef.current);
+        revertRef.current = setTimeout(
+          () => setCopied(false),
+          COPY_FEEDBACK_MS,
+        );
+      },
+      () => undefined,
+    );
+  }, [content]);
+
+  return (
+    <div className="od-msg-footer">
+      <span className="od-msg-actions">
+        <button
+          type="button"
+          className="od-footer-copy-btn"
+          title={copied ? "Copied" : "Copy message"}
+          aria-label={copied ? "Copied" : "Copy message"}
+          data-copied={copied ? "true" : undefined}
+          onClick={onCopy}
+        >
+          {copied ? (
+            <Check width="14" height="14" aria-hidden="true" />
+          ) : (
+            <Copy width="14" height="14" aria-hidden="true" />
+          )}
+        </button>
+      </span>
+    </div>
+  );
+}
+
+export function ChatMessages({
+  conversation,
+  locale,
+}: {
+  conversation: ConversationBlock[];
+  locale?: string;
+}): ReactNode {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const stickToBottom = useRef(true);
+
+  const onScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+    stickToBottom.current = distance < 80;
+  }, []);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: conversation is the trigger
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el && stickToBottom.current) el.scrollTop = el.scrollHeight;
+  }, [conversation.length, conversation[conversation.length - 1]?.key]);
+
+  return (
+    <div className="od-chat-history" ref={scrollRef} onScroll={onScroll}>
+      {conversation.map((block) => {
+        if (block.kind === "user")
+          return <UserBubble key={block.key} block={block} locale={locale} />;
+        if (block.kind === "agent") {
+          const agent: AgentBlock = block;
+          return (
+            <div className="od-msg-group" key={agent.key}>
+              <AgentBubble block={agent} locale={locale} />
+              <AgentFooter content={agent.content} />
+            </div>
+          );
+        }
+        return (
+          <div className="od-msg-cells" key={block.key}>
+            <ConversationBlockView block={block} locale={locale} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/ChatTopBar.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/ChatTopBar.tsx
@@ -1,0 +1,23 @@
+// odysseus chat top bar (.chat-top-bar / .chat-meta-overlay): a centered, dim
+// session title with a small dropdown caret affordance. Cost/token meta and the
+// export menu land in later phases; the caret is a visual affordance only (no
+// session menu is wired yet), so it renders as a non-interactive glyph rather
+// than a dead clickable control.
+
+import { ChevronDown } from "lucide-react";
+import type { ReactNode } from "react";
+
+export function ChatTopBar({ title }: { title: string }): ReactNode {
+  return (
+    <div className="od-chat-top-bar">
+      <span className="od-chat-meta">
+        {title}
+        <ChevronDown
+          size={11}
+          className="od-chat-meta-caret"
+          aria-hidden="true"
+        />
+      </span>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/CompareView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/CompareView.tsx
@@ -1,0 +1,1738 @@
+// odysseus Model A/B Compare arena (static/js/compare/*). The flow is two
+// stages, 1:1 with odysseus:
+//   1. A pre-flight SELECTOR modal (compare/selector.js showModelSelector) —
+//      pick the models per slot, choose blind / parallel-vs-sequential / shuffle,
+//      set a per-run timeout, then Start.
+//   2. The ARENA (compare/index.js _buildCompareUI) — a header bar (mode label +
+//      Score / Export / Blind / Shuffle / + Model), a grid of model panes (each
+//      a swap-title, action cluster, chat-history, and a per-pane Vote footer), a
+//      shared vote bar (Score / Tie / Reveal / Reset), and an Eval-prompts picker.
+//
+// elizaMapping: the model lists come from the REAL model catalog via
+// client.fetchModels(provider) (the same /api/models endpoint the settings
+// surface uses; returns ProviderModelRecord[]). The vote scoreboard persists
+// locally exactly like odysseus's localStorage votes, and the shuffle-pool
+// exclusion list mirrors odysseus's 'shuffle-pool-excluded'. The Export actions
+// (copy markdown / download .md / print) are pure client-side and fully real.
+//
+// What is NOT wired (and is therefore an HONEST empty state, never faked): eliza
+// streams a single agent, not N independent model sessions at once, so there is
+// no dual-model streaming RACE backend — the panes render odysseus's faithful
+// ready state ("Send a prompt to all models…") and never show fabricated
+// responses. The Agent / Search / Research compare TYPES, the model pre-flight
+// probe, and the per-pane Re-roll/Copy/Expand actions all operate on that absent
+// stream, so they are deferred (Chat only) or shown disabled with an explicit
+// reason rather than as dead controls.
+
+import type { ProviderModelRecord } from "@elizaos/ui";
+import { client } from "@elizaos/ui";
+import {
+  Check,
+  ChevronDown,
+  Copy,
+  Dices,
+  Download,
+  Eye,
+  EyeOff,
+  FileText,
+  List,
+  ListFilter,
+  Maximize2,
+  Menu,
+  MessageSquare,
+  Minus,
+  Play,
+  Plus,
+  RefreshCw,
+  RotateCcw,
+  Save,
+  Search,
+  SearchCheck,
+  Terminal,
+  X,
+} from "lucide-react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { formatRelativeTime } from "../view-format";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+import { readPref, writePref } from "./util/storage";
+
+// localStorage key for the persisted vote scoreboard, matching odysseus's
+// VOTES_STORAGE_KEY ('odysseus-compare-votes').
+const COMPARE_VOTES_KEY = "compare-votes";
+// Excluded-from-shuffle model ids — matches odysseus's 'shuffle-pool-excluded'.
+const SHUFFLE_EXCLUDED_KEY = "compare-shuffle-excluded";
+const VOTES_MAX = 200;
+
+// ── Provider list for the model dropdowns (real /api/models fetch keys) ──
+const PROVIDERS = [
+  "openai",
+  "anthropic",
+  "google",
+  "openrouter",
+  "groq",
+  "xai",
+  "ollama",
+] as const;
+
+// ── Eval-prompt templates, 1:1 from compare/icons.js EVAL_PROMPTS.chat ──
+interface EvalPrompt {
+  sub: string;
+  label: string;
+  prompt: string;
+  answer?: string;
+}
+
+const EVAL_PROMPTS: EvalPrompt[] = [
+  {
+    sub: "★ Featured",
+    label: "Sum digits 2^100",
+    answer: "115",
+    prompt:
+      "Compute the sum of the decimal digits of 2^100. Do NOT use code execution — work it out by reasoning about the number. Show every step, then end with the final number on its own line.",
+  },
+  {
+    sub: "★ Featured",
+    label: "Three jugs",
+    answer: "4 pours: 7→5, 5→3, 3→7, 5→3",
+    prompt:
+      "You have three jugs of capacities 7, 5, and 3 liters. The 7-liter jug starts full; the others empty. Using only pouring (no markings), produce the shortest sequence of pours that leaves exactly 2 liters in the 3-liter jug. Output each step as `pour A → B` on its own line. Then state the total number of pours on a final line.",
+  },
+  {
+    sub: "Visual",
+    label: "Draw SVG",
+    prompt:
+      "Output a complete self-contained HTML file (```html block, no explanation, no other text) that centers a single SVG illustration on a simple background. The SVG must use only inline shapes — no <img>, no external assets, no JavaScript. Make it expressive and detailed. The SVG should depict: a friendly robot",
+  },
+  {
+    sub: "Visual explain",
+    label: "Black hole HTML",
+    prompt:
+      "Output a complete HTML file (```html block, no explanation outside the code) that visually explains how a black hole forms.",
+  },
+  {
+    sub: "Visual explain",
+    label: "Butterfly ASCII",
+    prompt:
+      "Explain the butterfly lifecycle using ASCII art. Produce four separate frames in fenced code blocks, in order: egg, caterpillar, chrysalis, adult butterfly.",
+  },
+];
+
+// ── Compare TYPE tabs, 1:1 with selector.js `_modes` (Chat / Agent / Search /
+// Research). Only Chat is faithfully representable on this runtime — Agent /
+// Search / Research need a dual-model run plus a search-provider backend the
+// single-agent runtime does not expose, so they render present-but-disabled
+// (never omitted) to preserve odysseus's full four-tab row. ──
+type CompareType = "chat" | "agent" | "search" | "research";
+
+interface CompareTypeTab {
+  id: CompareType;
+  label: string;
+  // The single-agent runtime backs only `chat`; the rest are inert/honest.
+  enabled: boolean;
+  disabledReason: string;
+}
+
+const CMP_TYPES: CompareTypeTab[] = [
+  { id: "chat", label: "Chat", enabled: true, disabledReason: "" },
+  {
+    id: "agent",
+    label: "Agent",
+    enabled: false,
+    disabledReason:
+      "Agent compare needs a dual-model tool-running backend the single-agent runtime does not expose.",
+  },
+  {
+    id: "search",
+    label: "Search",
+    enabled: false,
+    disabledReason:
+      "Search compare needs a search-provider backend the single-agent runtime does not expose.",
+  },
+  {
+    id: "research",
+    label: "Research",
+    enabled: false,
+    disabledReason:
+      "Research compare needs a deep-research backend the single-agent runtime does not expose.",
+  },
+];
+
+// ── Per-slot model selection (one row in the selector → one pane in the arena) ──
+interface Slot {
+  slotId: string;
+  provider: string;
+  modelId: string;
+  modelName: string;
+}
+
+// ── Persisted vote record (mirrors compare/vote.js _saveVote shape) ──
+interface VoteRecord {
+  models: string[];
+  winner: string;
+  prompt: string;
+  blind: boolean;
+  mode: string;
+  timestamp: number;
+}
+
+const TIMEOUT_MIN = 5;
+const TIMEOUT_MAX = 300;
+const TIMEOUT_DEFAULT = 300;
+const MAX_SLOTS = 8;
+
+// `winnerIdx` holds the winning pane index; this sentinel records a Tie vote
+// (a non-pane outcome). Negative values never style a pane (compare/vote.js).
+const TIE_WINNER = -1;
+// Sequential-mode pane cascade (compare/index.js _sequentialOffset): each pane
+// is nudged right by `seqStep` px, with the per-pane step shrinking as panes
+// grow so the total cascade stays within SEQ_CASCADE_MAX px.
+const SEQ_STEP_MAX_PX = 20;
+const SEQ_CASCADE_MAX_PX = 80;
+
+function newSlot(provider = "openai"): Slot {
+  return {
+    slotId: `slot-${crypto.randomUUID()}`,
+    provider,
+    modelId: "",
+    modelName: "",
+  };
+}
+
+/** Slot label: letters in parallel (A, B), numbers in sequential (1, 2). */
+function slotChar(i: number, parallel: boolean): string {
+  return parallel ? String.fromCharCode(65 + i) : String(i + 1);
+}
+
+// Confetti particle burst from a point (compare/vote.js spawnConfetti). The
+// celebratory hues are fixed semantic accents, kept literal as in odysseus.
+const CONFETTI_COLORS = [
+  "#ffd700",
+  "#ff6b6b",
+  "#5b8def",
+  "#51cf66",
+  "#ff922b",
+  "#cc5de8",
+  "#22b8cf",
+  "#ffffff",
+];
+
+function spawnConfetti(cx: number, cy: number, count: number): void {
+  for (let i = 0; i < count; i++) {
+    const el = document.createElement("div");
+    el.className = "od-confetti-piece";
+    const color =
+      CONFETTI_COLORS[Math.floor(Math.random() * CONFETTI_COLORS.length)];
+    const size = 5 + Math.random() * 8;
+    const isCircle = Math.random() > 0.5;
+    el.style.width = `${size}px`;
+    el.style.height = `${isCircle ? size : size * 0.6}px`;
+    el.style.background = color;
+    el.style.borderRadius = isCircle ? "50%" : "2px";
+    el.style.left = `${cx}px`;
+    el.style.top = `${cy}px`;
+    const angle = Math.random() * Math.PI * 2;
+    const speed = 60 + Math.random() * 160;
+    const dx = Math.cos(angle) * speed;
+    const dy = Math.sin(angle) * speed - 100;
+    const duration = 1.0 + Math.random() * 1.0;
+    el.animate(
+      [
+        { transform: "translate(0, 0) rotate(0deg) scale(1)", opacity: 1 },
+        {
+          transform: `translate(${dx}px, ${dy + 200}px) rotate(${400 + Math.random() * 400}deg) scale(0)`,
+          opacity: 0,
+        },
+      ],
+      {
+        duration: duration * 1000,
+        easing: "cubic-bezier(0.15, 0.6, 0.35, 1)",
+        fill: "forwards",
+      },
+    );
+    document.body.appendChild(el);
+    window.setTimeout(() => el.remove(), duration * 1000 + 50);
+  }
+}
+
+export function CompareView({
+  open,
+  onClose,
+  locale,
+}: {
+  open: boolean;
+  onClose: () => void;
+  locale?: string;
+}): ReactNode {
+  useEscapeClose(open, onClose);
+  const win = useWindowControls(
+    "win-compare",
+    { w: 1180, h: 880 },
+    { label: "Compare", icon: "Columns2", onClose },
+  );
+
+  // ── Stage: the selector runs first; the arena mounts only after Start. ──
+  const [started, setStarted] = useState(false);
+
+  // ── Run configuration (set in the selector, read by the arena) ──
+  const [blindMode, setBlindMode] = useState(true);
+  const [parallel, setParallel] = useState(true);
+  // odysseus's Save toggle keeps compare sessions after closing. The single-agent
+  // runtime has no dual-model compare-session store, so this is rendered inert
+  // (disabled) with an honest reason rather than faking persistence.
+  const saveOnClose = false;
+  // Per-run timeout in seconds. Named *Sec to avoid shadowing global setTimeout.
+  const [timeoutSec, setTimeoutSec] = useState(TIMEOUT_DEFAULT);
+  const [slots, setSlots] = useState<Slot[]>([newSlot(), newSlot()]);
+
+  // ── Shared model catalog (fetched lazily per provider) ──
+  const [modelsByProvider, setModelsByProvider] = useState<
+    Record<string, ProviderModelRecord[]>
+  >({});
+  const [excludedModels, setExcludedModels] = useState<string[]>([]);
+
+  // ── Arena state ──
+  const [swapOpenFor, setSwapOpenFor] = useState<string | null>(null);
+  const [evalMenuOpen, setEvalMenuOpen] = useState(false);
+  const [exportMenuOpen, setExportMenuOpen] = useState(false);
+  const [expectedAnswer, setExpectedAnswer] = useState("");
+  const [draft, setDraft] = useState("");
+  const [votes, setVotes] = useState<VoteRecord[]>([]);
+  const [scoreboardOpen, setScoreboardOpen] = useState(false);
+  const [poolEditorOpen, setPoolEditorOpen] = useState(false);
+  const [revealed, setRevealed] = useState(false);
+  // Vote outcome for winner/loser styling: index of winner, -1 tie, null none.
+  const [winnerIdx, setWinnerIdx] = useState<number | null>(null);
+
+  const loadProvider = useCallback((provider: string) => {
+    setModelsByProvider((prev) => {
+      if (prev[provider]) return prev;
+      void client
+        .fetchModels(provider)
+        .then((r) => {
+          setModelsByProvider((cur) => ({ ...cur, [provider]: r.models }));
+        })
+        .catch(() => {
+          setModelsByProvider((cur) => ({ ...cur, [provider]: [] }));
+        });
+      return prev;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    setVotes(readPref<VoteRecord[]>(COMPARE_VOTES_KEY, []));
+    setExcludedModels(readPref<string[]>(SHUFFLE_EXCLUDED_KEY, []));
+    loadProvider("openai");
+  }, [open, loadProvider]);
+
+  // Group eval prompts by sub-category in original order (compare/index.js
+  // _renderItems). useMemo keeps the grouping stable across renders.
+  const evalGroups = useMemo(() => {
+    const order: string[] = [];
+    const groups: Record<string, EvalPrompt[]> = {};
+    for (const p of EVAL_PROMPTS) {
+      const list = groups[p.sub];
+      if (list) {
+        list.push(p);
+      } else {
+        groups[p.sub] = [p];
+        order.push(p.sub);
+      }
+    }
+    return order.map((sub) => ({ sub, items: groups[sub] }));
+  }, []);
+
+  // Confetti burst at the winning pane on a decisive vote (compare/vote.js
+  // spawnConfetti — 3 staggered bursts). Pure client-side; no backend needed.
+  useEffect(() => {
+    if (winnerIdx === null || winnerIdx < 0) return;
+    const titleEl = document.querySelector(
+      `.od-compare-pane[data-pane="${winnerIdx}"] .od-pane-title-name`,
+    );
+    if (!titleEl) return;
+    const rect = titleEl.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const timers = [
+      window.setTimeout(() => spawnConfetti(cx, cy, 50), 0),
+      window.setTimeout(() => spawnConfetti(cx - 30, cy, 25), 150),
+      window.setTimeout(() => spawnConfetti(cx + 30, cy, 25), 300),
+    ];
+    return () => {
+      for (const t of timers) window.clearTimeout(t);
+    };
+  }, [winnerIdx]);
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  // ── Shared slot mutators (used by both selector and arena) ──
+  const addSlot = () => {
+    if (slots.length >= MAX_SLOTS) return;
+    setSlots((cur) => [...cur, newSlot()]);
+  };
+
+  const removeSlot = (slotId: string) => {
+    if (slots.length <= 1) return;
+    setSlots((cur) => cur.filter((s) => s.slotId !== slotId));
+  };
+
+  const setSlotProvider = (slotId: string, provider: string) => {
+    loadProvider(provider);
+    setSlots((cur) =>
+      cur.map((s) =>
+        s.slotId === slotId
+          ? { ...s, provider, modelId: "", modelName: "" }
+          : s,
+      ),
+    );
+  };
+
+  const setSlotModel = (slotId: string, m: ProviderModelRecord) => {
+    setSlots((cur) =>
+      cur.map((s) =>
+        s.slotId === slotId ? { ...s, modelId: m.id, modelName: m.name } : s,
+      ),
+    );
+    setSwapOpenFor(null);
+  };
+
+  // Dice shuffle — randomly fill every slot from the loaded model pool, honoring
+  // the shuffle-pool exclusions, then auto-enable blind so the picks stay hidden
+  // (compare/selector.js diceBtn). Operates only on already-loaded providers.
+  const shuffleFill = () => {
+    const pool: Array<{ provider: string; m: ProviderModelRecord }> = [];
+    for (const [provider, list] of Object.entries(modelsByProvider)) {
+      for (const m of list) {
+        if (!excludedModels.includes(m.id)) pool.push({ provider, m });
+      }
+    }
+    if (pool.length === 0) return;
+    for (let i = pool.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [pool[i], pool[j]] = [pool[j], pool[i]];
+    }
+    setSlots((cur) =>
+      cur.map((s, i) => {
+        const pick = pool[i % pool.length];
+        return {
+          ...s,
+          provider: pick.provider,
+          modelId: pick.m.id,
+          modelName: pick.m.name,
+        };
+      }),
+    );
+    setBlindMode(true);
+  };
+
+  const toggleExcluded = (id: string) => {
+    setExcludedModels((cur) => {
+      const next = cur.includes(id)
+        ? cur.filter((x) => x !== id)
+        : [...cur, id];
+      writePref(SHUFFLE_EXCLUDED_KEY, next);
+      return next;
+    });
+  };
+
+  const resetConfig = () => {
+    setBlindMode(true);
+    setParallel(true);
+    setTimeoutSec(TIMEOUT_DEFAULT);
+    setSlots([newSlot(), newSlot()]);
+  };
+
+  // ── Vote persistence + handlers ──
+  const persistVote = (next: VoteRecord[]) => {
+    const capped = next.slice(-VOTES_MAX);
+    setVotes(capped);
+    writePref(COMPARE_VOTES_KEY, capped);
+  };
+
+  // Record a vote for pane `idx`, or a tie when `idx === TIE_WINNER`.
+  const handleVote = (idx: number) => {
+    const names = slots.map(
+      (s, i) => s.modelName || `Model ${slotChar(i, parallel)}`,
+    );
+    const winner = idx === TIE_WINNER ? "tie" : names[idx];
+    persistVote([
+      ...votes,
+      {
+        models: names,
+        winner,
+        prompt: draft,
+        blind: blindMode,
+        mode: "chat",
+        timestamp: Date.now(),
+      },
+    ]);
+    setRevealed(true);
+    setWinnerIdx(idx);
+  };
+
+  // Blind Reveal — unmask the model names without recording an outcome.
+  const handleReveal = () => setRevealed(true);
+
+  const pickEval = (p: EvalPrompt) => {
+    setDraft(p.prompt);
+    setExpectedAnswer(p.answer ?? "");
+    setEvalMenuOpen(false);
+  };
+
+  // ── Export: build a real markdown comparison and copy / download / print it
+  // (compare/index.js _buildComparisonMarkdown + export fns). Pure client-side. ──
+  const buildMarkdown = (): string => {
+    const date = new Date().toISOString().slice(0, 19).replace("T", " ");
+    const promptText =
+      draft.trim() || "(no prompt yet — enter one and run a comparison first)";
+    let md = "# Compare\n\n";
+    md += `**When:** ${date}\n`;
+    md += `**Type:** chat${blindMode ? " (blind)" : ""}\n`;
+    md += `**Prompt:**\n\n\`\`\`\n${promptText}\n\`\`\`\n\n`;
+    if (expectedAnswer) md += `**Expected answer:** \`${expectedAnswer}\`\n\n`;
+    slots.forEach((s, i) => {
+      const name = s.modelName || `Model ${slotChar(i, parallel)}`;
+      md += `## ${name}\n\n`;
+      md +=
+        "_(no response — single-agent runtime has no dual-model streaming backend yet)_\n\n";
+      md += "---\n\n";
+    });
+    return md;
+  };
+
+  const exportCopy = () => {
+    setExportMenuOpen(false);
+    const md = buildMarkdown();
+    void navigator.clipboard?.writeText(md).catch(() => {
+      // clipboard denied/unavailable — best-effort, never fatal.
+    });
+  };
+
+  const exportDownload = () => {
+    setExportMenuOpen(false);
+    const md = buildMarkdown();
+    const ts = new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-");
+    const blob = new Blob([md], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `compare-${ts}.md`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    window.setTimeout(() => URL.revokeObjectURL(url), 1000);
+  };
+
+  const exportPrint = () => {
+    setExportMenuOpen(false);
+    const md = buildMarkdown();
+    const w = window.open("", "_blank");
+    if (!w) return;
+    const esc = (s: string): string =>
+      s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    w.document.write(
+      `<!doctype html><meta charset="utf-8"><title>Compare export</title><style>body{font-family:system-ui,sans-serif;max-width:780px;margin:32px auto;padding:0 24px;line-height:1.55;color:#222}pre{white-space:pre-wrap}</style><body><pre>${esc(md)}</pre><script>window.onload=function(){setTimeout(function(){window.print()},100)}</script>`,
+    );
+    w.document.close();
+  };
+
+  // ── Render: selector first, arena after Start ──
+  const overlayClass = `od-search-overlay od-compare-overlay${win.windowed ? " od-windowed" : ""}`;
+
+  if (!started) {
+    return (
+      <div
+        className={overlayClass}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Compare models — configure"
+      >
+        <button
+          type="button"
+          aria-label="Close compare"
+          onClick={onClose}
+          className="od-search-backdrop"
+        />
+        <CompareSelector
+          slots={slots}
+          modelsByProvider={modelsByProvider}
+          blindMode={blindMode}
+          parallel={parallel}
+          saveOnClose={saveOnClose}
+          timeout={timeoutSec}
+          onSetBlind={setBlindMode}
+          onSetParallel={setParallel}
+          onSetTimeout={setTimeoutSec}
+          onAddSlot={addSlot}
+          onRemoveSlot={removeSlot}
+          onSetSlotProvider={setSlotProvider}
+          onSetSlotModel={setSlotModel}
+          onShuffleFill={shuffleFill}
+          onReset={resetConfig}
+          onOpenScoreboard={() => setScoreboardOpen(true)}
+          onStart={() => setStarted(true)}
+          onClose={onClose}
+        />
+        {scoreboardOpen ? (
+          <Scoreboard
+            votes={votes}
+            locale={locale}
+            onClear={() => persistVote([])}
+            onClose={() => setScoreboardOpen(false)}
+          />
+        ) : null}
+      </div>
+    );
+  }
+
+  const cols = Math.min(slots.length, 4);
+  const seqStep = parallel
+    ? 0
+    : Math.min(
+        SEQ_STEP_MAX_PX,
+        Math.floor(SEQ_CASCADE_MAX_PX / Math.max(slots.length, 1)),
+      );
+
+  const paneLabel = (i: number): string =>
+    blindMode && !revealed
+      ? `Model ${slotChar(i, parallel)}`
+      : slots[i].modelName || `Model ${slotChar(i, parallel)}`;
+
+  const modeLabel = `Comparing ${slots.length} models${blindMode ? " (blind)" : ""} · ${parallel ? "parallel" : "sequential"} · ${timeoutSec}s timeout`;
+
+  return (
+    <div
+      className={overlayClass}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Compare models"
+    >
+      <button
+        type="button"
+        aria-label="Close compare"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel od-compare-panel" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        {/* ── Header bar (compare/index.js _buildCompareUI step 8) ── */}
+        <div
+          className="od-compare-header-bar od-window-header"
+          onPointerDown={win.onDragStart}
+        >
+          <div className="od-compare-header-left">
+            <span className="od-compare-header-icon" aria-hidden="true">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                role="img"
+                aria-label="Compare"
+              >
+                <rect x="2" y="3" width="8" height="18" rx="1" />
+                <rect x="14" y="3" width="8" height="18" rx="1" />
+              </svg>
+            </span>
+            <span className="od-compare-header-label">{modeLabel}</span>
+          </div>
+          <div className="od-compare-header-actions">
+            <div className="od-compare-export-wrap">
+              <button
+                type="button"
+                className="od-compare-hbtn"
+                title="Export options"
+                aria-haspopup="menu"
+                aria-expanded={exportMenuOpen}
+                onClick={() => setExportMenuOpen((v) => !v)}
+              >
+                <Download size={14} />
+                <span>Export</span>
+              </button>
+              {exportMenuOpen ? (
+                <div className="od-compare-export-menu" role="menu">
+                  <button
+                    type="button"
+                    className="od-compare-export-item"
+                    role="menuitem"
+                    onClick={exportCopy}
+                  >
+                    Copy as Markdown
+                  </button>
+                  <button
+                    type="button"
+                    className="od-compare-export-item"
+                    role="menuitem"
+                    onClick={exportDownload}
+                  >
+                    Download .md
+                  </button>
+                  <button
+                    type="button"
+                    className="od-compare-export-item"
+                    role="menuitem"
+                    onClick={exportPrint}
+                  >
+                    Print / Save PDF
+                  </button>
+                </div>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              className={`od-compare-hbtn od-compare-blind${blindMode ? " on" : ""}`}
+              title="Blind mode — hide model names until you vote"
+              aria-pressed={blindMode}
+              onClick={() => {
+                setBlindMode((v) => !v);
+                setRevealed(false);
+              }}
+            >
+              {blindMode ? <EyeOff size={14} /> : <Eye size={14} />}
+              <span>Blind</span>
+            </button>
+            <button
+              type="button"
+              className="od-compare-hbtn"
+              title="Shuffle — randomly re-pick the models for each slot"
+              onClick={shuffleFill}
+            >
+              <Dices size={14} />
+              <span>Shuffle</span>
+            </button>
+            <button
+              type="button"
+              className="od-compare-hbtn"
+              title="Shuffle pool — choose which models the shuffle can pick"
+              aria-haspopup="dialog"
+              onClick={() => setPoolEditorOpen(true)}
+            >
+              <ListFilter size={14} />
+              <span>Pool</span>
+            </button>
+            <button
+              type="button"
+              className="od-compare-hbtn"
+              title="Add model pane"
+              disabled={slots.length >= MAX_SLOTS}
+              onClick={addSlot}
+            >
+              <Plus size={14} />
+              <span>Add</span>
+            </button>
+            <button
+              type="button"
+              className="od-window-min-btn"
+              onClick={win.minimize}
+              title="Minimize"
+              aria-label="Minimize"
+            >
+              <Minus size={14} aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              className="od-compare-hbtn od-compare-close-btn"
+              title="Close compare mode"
+              aria-label="Close compare mode"
+              onClick={onClose}
+            >
+              <X size={14} />
+            </button>
+          </div>
+        </div>
+
+        {/* ── Grid of panes (compare/index.js step 9) ── */}
+        <div className="od-compare-grid" data-cols={String(cols)}>
+          {slots.map((slot, i) => {
+            const providerModels = modelsByProvider[slot.provider] ?? [];
+            const isWinner = revealed && winnerIdx === i;
+            const isLoser =
+              revealed &&
+              winnerIdx !== null &&
+              winnerIdx >= 0 &&
+              winnerIdx !== i;
+            const paneClass = `od-compare-pane${isWinner ? " winner" : ""}${isLoser ? " loser" : ""}`;
+            return (
+              <div
+                className={paneClass}
+                data-pane={String(i)}
+                key={slot.slotId}
+                style={seqStep ? { marginLeft: `${i * seqStep}px` } : undefined}
+              >
+                <div className="od-pane-header">
+                  <button
+                    type="button"
+                    className="od-pane-title-btn"
+                    onClick={() =>
+                      setSwapOpenFor((cur) =>
+                        cur === slot.slotId ? null : slot.slotId,
+                      )
+                    }
+                  >
+                    {isWinner ? (
+                      <span className="od-pane-winner-star" aria-hidden="true">
+                        ★
+                      </span>
+                    ) : null}
+                    {isLoser ? (
+                      <span className="od-pane-loser-mark" aria-hidden="true">
+                        =
+                      </span>
+                    ) : null}
+                    <span className="od-pane-title-name">{paneLabel(i)}</span>
+                    {isWinner ? (
+                      <span className="od-pane-winner-tag">Winner!</span>
+                    ) : null}
+                    <ChevronDown
+                      className="od-pane-title-caret"
+                      size={11}
+                      aria-hidden="true"
+                    />
+                  </button>
+                  <div className="od-pane-actions">
+                    <button
+                      type="button"
+                      className="od-pane-action-btn"
+                      title="Re-roll — available once a dual-model streaming run exists"
+                      aria-label="Re-roll"
+                      disabled
+                    >
+                      <RefreshCw size={12} />
+                    </button>
+                    <button
+                      type="button"
+                      className="od-pane-action-btn"
+                      title="Copy — available once a response has streamed"
+                      aria-label="Copy"
+                      disabled
+                    >
+                      <Copy size={12} />
+                    </button>
+                    <button
+                      type="button"
+                      className="od-pane-action-btn"
+                      title="Expand — available once a response has streamed"
+                      aria-label="Expand"
+                      disabled
+                    >
+                      <Maximize2 size={12} />
+                    </button>
+                    <button
+                      type="button"
+                      className="od-pane-action-btn od-pane-close-btn"
+                      title="Remove pane"
+                      aria-label="Remove pane"
+                      disabled={slots.length <= 1}
+                      onClick={() => removeSlot(slot.slotId)}
+                    >
+                      <X size={12} />
+                    </button>
+                  </div>
+                </div>
+
+                {swapOpenFor === slot.slotId ? (
+                  <ModelSwapDropdown
+                    slot={slot}
+                    providerModels={providerModels}
+                    onSetProvider={(prov) => setSlotProvider(slot.slotId, prov)}
+                    onSetModel={(m) => setSlotModel(slot.slotId, m)}
+                  />
+                ) : null}
+
+                <div className="od-pane-history" id={`cmp-history-${i}`}>
+                  <div className="od-pane-ready">
+                    Send a prompt to all models to start the comparison.
+                  </div>
+                </div>
+
+                <div className="od-pane-vote-footer">
+                  <button
+                    type="button"
+                    className="od-pane-vote-btn"
+                    disabled={!draft.trim() || revealed}
+                    onClick={() => handleVote(i)}
+                  >
+                    <Check size={13} />
+                    <span className="od-pane-vote-label">
+                      Vote {paneLabel(i)}
+                    </span>
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* ── Vote bar (compare/vote.js buildVoteBar) ── */}
+        <div className="od-compare-vote-bar">
+          <button
+            type="button"
+            className="od-compare-vote-btn od-compare-score-btn"
+            title="Scoreboard"
+            onClick={() => setScoreboardOpen(true)}
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              role="img"
+              aria-label="Scoreboard"
+            >
+              <rect x="3" y="3" width="7" height="7" />
+              <rect x="14" y="3" width="7" height="7" />
+              <rect x="3" y="14" width="7" height="7" />
+              <rect x="14" y="14" width="7" height="7" />
+            </svg>
+            Score
+          </button>
+          <button
+            type="button"
+            className="od-compare-vote-btn od-compare-vote-tie"
+            disabled={!draft.trim() || revealed}
+            onClick={() => handleVote(TIE_WINNER)}
+          >
+            Tie
+          </button>
+          {blindMode ? (
+            <button
+              type="button"
+              className="od-compare-vote-btn"
+              disabled={!draft.trim()}
+              onClick={handleReveal}
+            >
+              <Eye size={14} /> Reveal
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="od-compare-vote-btn od-compare-rematch-btn"
+            onClick={() => {
+              setRevealed(false);
+              setWinnerIdx(null);
+              setDraft("");
+              setExpectedAnswer("");
+              setStarted(false);
+            }}
+          >
+            <RotateCcw size={14} /> Reset
+          </button>
+        </div>
+
+        {/* ── Composer (mirrors .chat-input-bar + eval-prompts picker) ── */}
+        <div className="od-compare-input-bar">
+          {expectedAnswer ? (
+            <div className="od-cmp-eval-expected">
+              <span className="od-cmp-eval-expected-label">Expected:</span>{" "}
+              <strong className="od-cmp-eval-expected-value">
+                {expectedAnswer}
+              </strong>
+              <button
+                type="button"
+                className="od-cmp-eval-expected-close"
+                title="Dismiss"
+                aria-label="Dismiss expected answer"
+                onClick={() => setExpectedAnswer("")}
+              >
+                ×
+              </button>
+            </div>
+          ) : null}
+          <div className="od-cmp-input-top">
+            {!draft.trim() ? (
+              <div className="od-cmp-eval-wrap">
+                <button
+                  type="button"
+                  className="od-cmp-eval-btn"
+                  title="Insert an evaluation prompt"
+                  onClick={() => setEvalMenuOpen((v) => !v)}
+                >
+                  <FileText size={13} />
+                  <span className="od-cmp-eval-label">Eval prompts</span>
+                  <ChevronDown
+                    className="od-cmp-eval-caret"
+                    size={12}
+                    aria-hidden="true"
+                  />
+                </button>
+                {evalMenuOpen ? (
+                  <div className="od-cmp-eval-menu">
+                    {evalGroups.map((g) => (
+                      <div key={g.sub}>
+                        <div className="od-cmp-eval-group-label">{g.sub}</div>
+                        {g.items.map((p) => (
+                          <button
+                            type="button"
+                            key={p.label}
+                            className="od-cmp-eval-item"
+                            onClick={() => pickEval(p)}
+                          >
+                            {p.label}
+                            {p.answer ? (
+                              <span
+                                className="od-cmp-eval-item-tick"
+                                title="Has expected answer"
+                              >
+                                ✓
+                              </span>
+                            ) : null}
+                          </button>
+                        ))}
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+          <textarea
+            className="od-compare-input"
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") onClose();
+            }}
+            placeholder="Enter prompt for all models…"
+            aria-label="Compare prompt"
+          />
+        </div>
+      </div>
+
+      {/* ── Scoreboard overlay (compare/scoreboard.js showScoreboard) ── */}
+      {scoreboardOpen ? (
+        <Scoreboard
+          votes={votes}
+          locale={locale}
+          onClear={() => persistVote([])}
+          onClose={() => setScoreboardOpen(false)}
+        />
+      ) : null}
+
+      {/* ── Shuffle-pool editor (compare/index.js showShufflePoolEditor) ──
+          Opened from the arena header's Pool control, matching odysseus where
+          the exclusion editor lives on the running arena, not the selector. */}
+      {poolEditorOpen ? (
+        <ShufflePoolEditor
+          modelsByProvider={modelsByProvider}
+          excludedModels={excludedModels}
+          onToggle={toggleExcluded}
+          onClose={() => setPoolEditorOpen(false)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+// ── Pre-flight model selector modal (compare/selector.js showModelSelector) ──
+function CompareSelector({
+  slots,
+  modelsByProvider,
+  blindMode,
+  parallel,
+  saveOnClose,
+  timeout,
+  onSetBlind,
+  onSetParallel,
+  onSetTimeout,
+  onAddSlot,
+  onRemoveSlot,
+  onSetSlotProvider,
+  onSetSlotModel,
+  onShuffleFill,
+  onReset,
+  onOpenScoreboard,
+  onStart,
+  onClose,
+}: {
+  slots: Slot[];
+  modelsByProvider: Record<string, ProviderModelRecord[]>;
+  blindMode: boolean;
+  parallel: boolean;
+  saveOnClose: boolean;
+  timeout: number;
+  onSetBlind: (v: boolean) => void;
+  onSetParallel: (v: boolean) => void;
+  onSetTimeout: (v: number) => void;
+  onAddSlot: () => void;
+  onRemoveSlot: (slotId: string) => void;
+  onSetSlotProvider: (slotId: string, provider: string) => void;
+  onSetSlotModel: (slotId: string, m: ProviderModelRecord) => void;
+  onShuffleFill: () => void;
+  onReset: () => void;
+  onOpenScoreboard: () => void;
+  onStart: () => void;
+  onClose: () => void;
+}): ReactNode {
+  const win = useWindowControls(
+    "win-compare-selector",
+    { w: 520, h: 560 },
+    { label: "Model Comparison", icon: "Columns2", onClose },
+  );
+  // At least one slot must carry a chosen model before Start is meaningful.
+  const canStart = slots.some((s) => s.modelId);
+  // Mirror selector.js's whole-section empty state: when every provider in use
+  // has finished loading and returned zero models, collapse the rows + Add Model
+  // to a single centered "No models available" notice. We keep the per-row
+  // "No models — pick a provider" hint whenever at least one provider has models.
+  const noModelsAvailable =
+    slots.length > 0 &&
+    slots.every((s) => {
+      const loaded = modelsByProvider[s.provider];
+      return loaded !== undefined && loaded.length === 0;
+    });
+
+  // Minimized to the dock — the MinimizedDock chip restores it (modalManager.js).
+  if (win.minimized) return null;
+
+  return (
+    <div className="od-search-panel od-cmp-selector" style={win.panelStyle}>
+      <ResizeHandles controls={win} />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div
+        className="od-cmp-sel-header od-window-header"
+        onPointerDown={win.onDragStart}
+      >
+        <h4 className="od-cmp-sel-title">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            role="img"
+            aria-label="Compare"
+          >
+            <circle cx="18" cy="18" r="3" />
+            <circle cx="6" cy="6" r="3" />
+            <path d="M13 6h3a2 2 0 0 1 2 2v7" />
+            <path d="M11 18H8a2 2 0 0 1-2-2V9" />
+          </svg>
+          Model Comparison
+        </h4>
+        <div className="od-cmp-sel-header-actions">
+          <button
+            type="button"
+            className="od-window-min-btn"
+            onClick={win.minimize}
+            title="Minimize"
+            aria-label="Minimize"
+          >
+            <Minus size={14} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="od-cmp-sel-close"
+            title="Close"
+            aria-label="Close"
+            onClick={onClose}
+          >
+            <X size={14} />
+          </button>
+        </div>
+      </div>
+
+      <div className="od-cmp-sel-body">
+        <p className="od-cmp-sel-desc">
+          Select models to compare side-by-side. Send the same prompt to all.
+        </p>
+
+        {/* Mode toggles — Blind / Parallel / Shuffle / Save / Reset, each a tall
+            icon-over-label box (selector.js compare-*-toggle, 56px flex:1 1 0). */}
+        <div className="od-cmp-sel-section">
+          <div className="od-cmp-sel-label">Mode:</div>
+          <div className="od-cmp-sel-toggles">
+            <button
+              type="button"
+              className={`od-cmp-toggle od-cmp-toggle-blind${blindMode ? " active" : ""}`}
+              title="Blind Mode — hide model names until you vote"
+              aria-pressed={blindMode}
+              onClick={() => onSetBlind(!blindMode)}
+            >
+              {blindMode ? <EyeOff size={18} /> : <Eye size={18} />}
+              <span className="od-cmp-toggle-label">Blind</span>
+            </button>
+            <button
+              type="button"
+              className={`od-cmp-toggle od-cmp-toggle-parallel${parallel ? " active" : ""}`}
+              title="Parallel — run all models at once vs one at a time"
+              aria-pressed={parallel}
+              onClick={() => onSetParallel(!parallel)}
+            >
+              {parallel ? <Menu size={18} /> : <List size={18} />}
+              <span className="od-cmp-toggle-label">
+                {parallel ? "Parallel" : "Sequential"}
+              </span>
+            </button>
+            <button
+              type="button"
+              className="od-cmp-toggle"
+              title="Shuffle — randomly pick models for each slot"
+              onClick={onShuffleFill}
+            >
+              <Dices size={18} />
+              <span className="od-cmp-toggle-label">Shuffle</span>
+            </button>
+            <button
+              type="button"
+              className="od-cmp-toggle od-cmp-toggle-save"
+              title="Save — keep sessions after closing compare (unavailable: the single-agent runtime has no dual-model compare-session store)"
+              aria-pressed={saveOnClose}
+              disabled
+            >
+              <Save size={18} />
+              <span className="od-cmp-toggle-label">Save</span>
+            </button>
+            <button
+              type="button"
+              className="od-cmp-toggle"
+              title="Reset — restore all defaults"
+              onClick={onReset}
+            >
+              <RotateCcw size={18} />
+              <span className="od-cmp-toggle-label">Reset</span>
+            </button>
+          </div>
+        </div>
+
+        {/* Type tabs — Chat / Agent / Search / Research, each the SAME tall
+            icon-over-label box as the Mode toggles (selector.js compare-mode-tab).
+            Only Chat is wired on the single-agent runtime; Agent / Search /
+            Research render present-but-disabled (never omitted) with an honest
+            reason rather than as dead tabs. */}
+        <div className="od-cmp-sel-section">
+          <div className="od-cmp-sel-label">Type:</div>
+          <div className="od-cmp-sel-tabs">
+            {CMP_TYPES.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                className={`od-cmp-sel-tab${t.id === "chat" ? " active" : ""}`}
+                title={t.enabled ? t.label : t.disabledReason}
+                aria-pressed={t.id === "chat"}
+                disabled={!t.enabled}
+              >
+                {t.id === "chat" ? <MessageSquare size={18} /> : null}
+                {t.id === "agent" ? <Terminal size={18} /> : null}
+                {t.id === "search" ? <Search size={18} /> : null}
+                {t.id === "research" ? <SearchCheck size={18} /> : null}
+                <span className="od-cmp-toggle-label">{t.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Model rows. odysseus has no MODELS section label; the rows live
+            directly under the Type tabs. When every chosen provider has loaded
+            and returned zero models, the whole list collapses to a single
+            centered "No models available" notice (selector.js line 1305). */}
+        <div className="od-cmp-sel-section">
+          {noModelsAvailable ? (
+            <div className="od-cmp-sel-empty">No models available</div>
+          ) : (
+            <>
+              <div className="od-cmp-sel-rows">
+                {slots.map((slot, i) => {
+                  const providerModels = modelsByProvider[slot.provider] ?? [];
+                  return (
+                    <div className="od-cmp-sel-row" key={slot.slotId}>
+                      <span className="od-cmp-sel-rowlabel">
+                        {blindMode ? (
+                          <EyeOff size={13} aria-label="Blind" />
+                        ) : (
+                          slotChar(i, parallel)
+                        )}
+                      </span>
+                      <select
+                        className="od-cmp-form-control od-cmp-prov-select"
+                        value={slot.provider}
+                        aria-label="Provider"
+                        onChange={(e) =>
+                          onSetSlotProvider(slot.slotId, e.target.value)
+                        }
+                      >
+                        {PROVIDERS.map((prov) => (
+                          <option key={prov} value={prov}>
+                            {prov}
+                          </option>
+                        ))}
+                      </select>
+                      <SelectorModelPicker
+                        slot={slot}
+                        providerModels={providerModels}
+                        onSelect={(m) => onSetSlotModel(slot.slotId, m)}
+                      />
+                      {slots.length > 1 ? (
+                        <button
+                          type="button"
+                          className="od-cmp-rm-btn"
+                          title="Remove slot"
+                          aria-label="Remove slot"
+                          onClick={() => onRemoveSlot(slot.slotId)}
+                        >
+                          ×
+                        </button>
+                      ) : null}
+                    </div>
+                  );
+                })}
+              </div>
+              {slots.length < MAX_SLOTS ? (
+                <button
+                  type="button"
+                  className="od-cmp-add-btn"
+                  onClick={onAddSlot}
+                >
+                  + Add Model
+                </button>
+              ) : null}
+            </>
+          )}
+        </div>
+
+        {/* Timeout + scoreboard */}
+        <div className="od-cmp-sel-footer-row">
+          <span className="od-cmp-sel-timeout-label">Timeout:</span>
+          <input
+            type="number"
+            className="od-cmp-sel-timeout-input"
+            min={TIMEOUT_MIN}
+            max={TIMEOUT_MAX}
+            value={timeout}
+            aria-label="Timeout in seconds"
+            onChange={(e) => {
+              const n = Number.parseInt(e.target.value, 10);
+              if (Number.isNaN(n)) {
+                onSetTimeout(TIMEOUT_MIN);
+                return;
+              }
+              onSetTimeout(Math.min(TIMEOUT_MAX, Math.max(TIMEOUT_MIN, n)));
+            }}
+          />
+          <span className="od-cmp-sel-timeout-suffix">seconds</span>
+          <button
+            type="button"
+            className="od-cmp-sel-score-btn"
+            onClick={onOpenScoreboard}
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              role="img"
+              aria-label="Scoreboard"
+            >
+              <rect x="3" y="3" width="7" height="7" />
+              <rect x="14" y="3" width="7" height="7" />
+              <rect x="3" y="14" width="7" height="7" />
+              <rect x="14" y="14" width="7" height="7" />
+            </svg>
+            Scoreboard
+          </button>
+        </div>
+      </div>
+
+      <div className="od-cmp-sel-footer">
+        <button
+          type="button"
+          className="od-cmp-sel-start"
+          disabled={!canStart}
+          onClick={onStart}
+        >
+          <Play size={14} /> Start
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Searchable model picker for one selector row — odysseus _buildSearchablePicker
+// upgrades the plain <select> to a typeahead once a provider has >5 models.
+function SelectorModelPicker({
+  slot,
+  providerModels,
+  onSelect,
+}: {
+  slot: Slot;
+  providerModels: ProviderModelRecord[];
+  onSelect: (m: ProviderModelRecord) => void;
+}): ReactNode {
+  const [query, setQuery] = useState("");
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("click", onDoc, true);
+    return () => document.removeEventListener("click", onDoc, true);
+  }, [open]);
+
+  if (providerModels.length === 0) {
+    return (
+      <span className="od-cmp-sel-noslot">No models — pick a provider</span>
+    );
+  }
+
+  // Small lists keep the native select; large lists get the searchable picker.
+  if (providerModels.length <= 5) {
+    return (
+      <select
+        className="od-cmp-form-control od-cmp-model-select"
+        value={slot.modelId}
+        aria-label="Model"
+        onChange={(e) => {
+          const m = providerModels.find((x) => x.id === e.target.value);
+          if (m) onSelect(m);
+        }}
+      >
+        <option value="" disabled>
+          Choose model…
+        </option>
+        {providerModels.map((m) => (
+          <option key={m.id} value={m.id}>
+            {m.name}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  const q = query.trim().toLowerCase();
+  const matches = q
+    ? providerModels.filter((m) => m.name.toLowerCase().includes(q))
+    : providerModels;
+
+  return (
+    <div className="od-cmp-picker" ref={wrapRef}>
+      <input
+        type="text"
+        className="od-cmp-form-control"
+        placeholder="Search models…"
+        aria-label="Search models"
+        value={open ? query : slot.modelName}
+        onFocus={() => {
+          setQuery("");
+          setOpen(true);
+        }}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
+      />
+      {open ? (
+        <div className="od-cmp-picker-dropdown" role="listbox">
+          {matches.length === 0 ? (
+            <div className="od-cmp-picker-empty">No matches</div>
+          ) : (
+            matches.map((m) => (
+              <button
+                type="button"
+                key={m.id}
+                className={`od-cmp-picker-item${m.id === slot.modelId ? " current" : ""}`}
+                onClick={() => {
+                  onSelect(m);
+                  setOpen(false);
+                }}
+              >
+                {m.name}
+              </button>
+            ))
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+// Arena model-swap dropdown — odysseus _showModelSwapDropdown adds a search box
+// once a provider has >5 models.
+function ModelSwapDropdown({
+  slot,
+  providerModels,
+  onSetProvider,
+  onSetModel,
+}: {
+  slot: Slot;
+  providerModels: ProviderModelRecord[];
+  onSetProvider: (provider: string) => void;
+  onSetModel: (m: ProviderModelRecord) => void;
+}): ReactNode {
+  const [query, setQuery] = useState("");
+  const q = query.trim().toLowerCase();
+  const matches = q
+    ? providerModels.filter((m) => m.name.toLowerCase().includes(q))
+    : providerModels;
+
+  return (
+    <div className="od-pane-model-dropdown" role="listbox">
+      <select
+        className="od-pane-prov-select"
+        value={slot.provider}
+        onChange={(e) => onSetProvider(e.target.value)}
+        aria-label="Provider"
+      >
+        {PROVIDERS.map((prov) => (
+          <option key={prov} value={prov}>
+            {prov}
+          </option>
+        ))}
+      </select>
+      {providerModels.length > 5 ? (
+        <input
+          type="text"
+          className="od-pane-model-search"
+          placeholder="Search models…"
+          aria-label="Search models"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+      ) : null}
+      {matches.length === 0 ? (
+        <div className="od-pane-model-empty">No models found.</div>
+      ) : (
+        matches.map((m) => (
+          <button
+            type="button"
+            key={m.id}
+            className={`od-pane-model-item${m.id === slot.modelId ? " current" : ""}`}
+            onClick={() => onSetModel(m)}
+          >
+            {m.name}
+          </button>
+        ))
+      )}
+    </div>
+  );
+}
+
+// Shuffle-pool editor — exclude models from the dice (compare/index.js
+// showShufflePoolEditor). Excludes persist to localStorage; only providers
+// already loaded into the catalog appear here.
+function ShufflePoolEditor({
+  modelsByProvider,
+  excludedModels,
+  onToggle,
+  onClose,
+}: {
+  modelsByProvider: Record<string, ProviderModelRecord[]>;
+  excludedModels: string[];
+  onToggle: (id: string) => void;
+  onClose: () => void;
+}): ReactNode {
+  const groups = useMemo(
+    () =>
+      Object.entries(modelsByProvider)
+        .filter(([, list]) => list.length > 0)
+        .map(([provider, list]) => ({ provider, list })),
+    [modelsByProvider],
+  );
+
+  return (
+    <div
+      className="od-compare-scoreboard-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Shuffle pool"
+    >
+      <button
+        type="button"
+        className="od-search-backdrop"
+        aria-label="Close shuffle pool"
+        onClick={onClose}
+      />
+      <div className="od-compare-scoreboard od-cmp-pool">
+        <div className="od-mem-head">
+          <span className="od-mem-title">Shuffle Pool</span>
+          <button
+            type="button"
+            className="od-cmp-sel-close"
+            title="Close"
+            aria-label="Close"
+            onClick={onClose}
+          >
+            <X size={14} />
+          </button>
+        </div>
+        <p className="od-cmp-sel-desc">
+          Uncheck models to exclude them from random shuffle. They can still be
+          picked manually.
+        </p>
+        {groups.length === 0 ? (
+          <div className="od-search-empty">
+            No models loaded yet — open a provider's model list first.
+          </div>
+        ) : (
+          <div className="od-cmp-pool-list">
+            {groups.map((g) => (
+              <div key={g.provider}>
+                <div className="od-cmp-pool-heading">{g.provider}</div>
+                {g.list.map((m) => (
+                  <label className="od-cmp-pool-row" key={m.id}>
+                    <input
+                      type="checkbox"
+                      checked={!excludedModels.includes(m.id)}
+                      onChange={() => onToggle(m.id)}
+                    />
+                    <span>{m.name}</span>
+                  </label>
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface ScoreRow {
+  name: string;
+  wins: number;
+  losses: number;
+  ties: number;
+  games: number;
+}
+
+function Scoreboard({
+  votes,
+  locale,
+  onClear,
+  onClose,
+}: {
+  votes: VoteRecord[];
+  locale?: string;
+  onClear: () => void;
+  onClose: () => void;
+}): ReactNode {
+  const rows = useMemo<ScoreRow[]>(() => {
+    const stats: Record<string, ScoreRow> = {};
+    for (const v of votes) {
+      for (const m of v.models) {
+        if (!stats[m]) {
+          stats[m] = { name: m, wins: 0, losses: 0, ties: 0, games: 0 };
+        }
+        stats[m].games += 1;
+        if (v.winner === "tie") stats[m].ties += 1;
+        else if (v.winner === m) stats[m].wins += 1;
+        else stats[m].losses += 1;
+      }
+    }
+    return Object.values(stats).sort((a, b) => {
+      const rateA = a.games ? a.wins / a.games : 0;
+      const rateB = b.games ? b.wins / b.games : 0;
+      return rateB - rateA;
+    });
+  }, [votes]);
+
+  const lastVote = votes.length > 0 ? votes[votes.length - 1] : null;
+
+  return (
+    <div
+      className="od-compare-scoreboard-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Scoreboard"
+    >
+      <button
+        type="button"
+        className="od-search-backdrop"
+        aria-label="Close scoreboard"
+        onClick={onClose}
+      />
+      <div className="od-compare-scoreboard">
+        <div className="od-mem-head">
+          <span className="od-mem-title">Scoreboard</span>
+          <span className="od-mem-stats">
+            {votes.length} vote{votes.length === 1 ? "" : "s"} recorded
+            {lastVote
+              ? ` · ${formatRelativeTime(lastVote.timestamp, locale)}`
+              : ""}
+          </span>
+        </div>
+        {rows.length === 0 ? (
+          <div className="od-search-empty">
+            No votes yet. Run a comparison and vote!
+          </div>
+        ) : (
+          <table className="od-scoreboard-table">
+            <thead>
+              <tr>
+                <th>Model</th>
+                <th>Win%</th>
+                <th>W</th>
+                <th>L</th>
+                <th>T</th>
+                <th>Games</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((r) => {
+                const pct = r.games ? Math.round((r.wins / r.games) * 100) : 0;
+                return (
+                  <tr key={r.name}>
+                    <td className="od-scoreboard-model">{r.name}</td>
+                    <td className="od-scoreboard-pct">{pct}%</td>
+                    <td>{r.wins}</td>
+                    <td>{r.losses}</td>
+                    <td>{r.ties}</td>
+                    <td>{r.games}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+        <button
+          type="button"
+          className="od-scoreboard-clear-btn"
+          onClick={onClear}
+        >
+          Clear History
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/Composer.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/Composer.tsx
@@ -1,0 +1,532 @@
+// odysseus composer (static/index.html .chat-input-bar + .chat-input-bottom): a
+// borderless textarea with a model-picker chip pinned top-right, a bottom row
+// (.chat-input-bottom) with the odysseus left icon group (overflow chevron /
+// web-search magnifier / shell terminal) and, on the right, the Agent|Chat
+// segmented mode toggle followed by the send/stop action. A slash-command menu
+// (type "/" → filtered commands) sits above the bar. The send button swaps to a
+// stop control while the agent is working — matching odysseus and the eliza
+// ChatComposer.
+//
+// Faithfulness note — what the orchestrator backend actually supports:
+// `postOrchestratorTaskMessage(taskId, content)` and `createOrchestratorTask`
+// take a plain message; there is no web/shell/document toggle, per-message mode,
+// or quick-toggle slash path on the orchestrator client. Odysseus surfaces those
+// because its backend has them. For pixel-1:1 chrome the controls below are
+// rendered faithfully — the left web/shell icons and the Agent|Chat toggle, and
+// the odysseus slash rows for those toggles — but the ones with no orchestrator
+// backend are rendered INERT/disabled with an honest title rather than wired to
+// a no-op (no fabricated behaviour, no dead-but-clickable rows). Controls that DO
+// map to a real handler (new chat / clear / search / open Brain·Notes·Theme·
+// Settings / open Models) are fully active. The Agent|Chat toggle is a faithful
+// local visual control (the orchestrator has a single message path), defaulting
+// to "Chat" to match the captured odysseus frame.
+
+import { ArrowUp, ChevronUp, Search, Square, Terminal } from "lucide-react";
+import {
+  Fragment,
+  type KeyboardEvent,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+// A leaf entry in the slash-command autocomplete (odysseus
+// static/js/slashAutocomplete.js _flatten()). `token` is what gets inserted /
+// shown ("/new"), `aliases` are alternative spellings the scorer also matches,
+// `category` drives the grouped section headers, `help` is the description,
+// `usage` is the right-aligned hint (only rendered when it differs from token).
+// `run` is the wired handler when the command maps to a real Composer prop;
+// `disabled` rows are rendered faithfully (1:1 chrome + copy) but inert with an
+// `note` explaining the orchestrator has no backend for them — never a silent
+// no-op, never fabricated behaviour.
+interface SlashCommand {
+  token: string;
+  aliases: string[];
+  category: string;
+  help: string;
+  usage: string;
+  run?: () => void;
+  disabled?: boolean;
+  note?: string;
+}
+
+const MAX_VISIBLE = 12;
+
+// Honest reason shown on slash rows that odysseus exposes but the orchestrator
+// backend has no path for (web/document/bash quick-toggles, todos, tours, fork).
+// They render for 1:1 chrome but stay inert rather than no-op or fabricate.
+const NO_BACKEND = "Not available in the Orchestrator";
+
+// Prefix wins over substring; an alias match scores below a token match; a
+// help-text hit is the weakest signal. Mirrors slashAutocomplete.js
+// _scoreMatch(). `query` already starts with "/".
+function scoreMatch(entry: SlashCommand, query: string): number {
+  const q = query.toLowerCase();
+  const t = entry.token.toLowerCase();
+  if (t === q) return 1000;
+  if (t.startsWith(q)) return 500 + (50 - Math.min(50, t.length - q.length));
+  for (const a of entry.aliases) {
+    const al = a.toLowerCase();
+    if (al === q) return 900;
+    if (al.startsWith(q)) return 400;
+  }
+  if (t.includes(q)) return 100;
+  if (entry.help.toLowerCase().includes(q.slice(1))) return 25;
+  return 0;
+}
+
+export function Composer({
+  input,
+  onInput,
+  onSubmit,
+  onStop,
+  sending,
+  isActive,
+  modelLabel,
+  onNewChat,
+  onSearch,
+  onOpenPanel,
+  onOpenModels,
+}: {
+  input: string;
+  onInput: (value: string) => void;
+  onSubmit: () => void;
+  onStop: () => void;
+  sending: boolean;
+  isActive: boolean;
+  modelLabel: string;
+  onNewChat: () => void;
+  onSearch: () => void;
+  onOpenPanel: (
+    panel: "theme" | "memory" | "skills" | "notes" | "settings",
+  ) => void;
+  // Opens the models surface (the clone's ModelsView). Mirrors odysseus's
+  // model-picker entry point — the orchestrator has no per-message model-switch
+  // endpoint, so the chip opens the management surface rather than a fabricated
+  // inline switcher. Optional so the contract stays backward-compatible; the
+  // chip only becomes a button when it's wired.
+  onOpenModels?: () => void;
+}): ReactNode {
+  const taRef = useRef<HTMLTextAreaElement>(null);
+  const [sel, setSel] = useState(0);
+  const [dismissed, setDismissed] = useState(false);
+  // Agent|Chat mode toggle. The orchestrator has a single message path, so this
+  // is a faithful local visual control (not wired to a backend mode field).
+  // Defaults to "chat" to match the captured odysseus slash-menu frame, where
+  // the Chat segment is the active one.
+  const [mode, setMode] = useState<"agent" | "chat">("chat");
+
+  // Auto-grow textarea (24px → 200px), matching odysseus. `input` is a
+  // trigger-only dep: the effect re-measures the textarea whenever the value
+  // changes, even though it reads scrollHeight rather than `input` directly.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: trigger-only dep
+  useEffect(() => {
+    const el = taRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+  }, [input]);
+
+  // The command registry, ported to mirror the deployed odysseus slash menu
+  // (static/js/slashAutocomplete.js _flatten + PROMOTED_ALIASES short forms).
+  // The rows, their category headers, help, and usage strings are verbatim from
+  // slashCommands.js COMMANDS — the same set/order the real frame renders:
+  // /new, /web, /doc, /todo, /demo, /note, /fork, /bash (then /clear, /memory,
+  // /settings below the fold). Rows whose target surface exists in the clone are
+  // wired to a real Composer prop (onNewChat / onInput / onSearch / onOpenPanel
+  // / onOpenModels); odysseus's quick-toggle / todo / tour / fork rows have no
+  // orchestrator backend, so they render faithfully but DISABLED with an honest
+  // title — not omitted (1:1 chrome), not faked. Memoized on the wired handlers.
+  const commands = useMemo<SlashCommand[]>(
+    () => [
+      {
+        token: "/new",
+        aliases: ["/create", "/chats new"],
+        category: "Chats",
+        help: "Create new chat",
+        usage: "/new",
+        run: onNewChat,
+      },
+      {
+        token: "/web",
+        aliases: ["/search web", "/toggle web"],
+        category: "Quick toggles",
+        help: "Toggle web search",
+        usage: "/web",
+        disabled: true,
+        note: NO_BACKEND,
+      },
+      {
+        token: "/doc",
+        aliases: ["/toggle doc"],
+        category: "Quick toggles",
+        help: "Toggle document editor",
+        usage: "/doc",
+        disabled: true,
+        note: NO_BACKEND,
+      },
+      {
+        token: "/todo",
+        aliases: ["/td"],
+        category: "Productivity",
+        help: "Add or list todos",
+        usage: "/todo Your task  ·  /todo list",
+        disabled: true,
+        note: NO_BACKEND,
+      },
+      {
+        token: "/demo",
+        aliases: ["/tour"],
+        category: "Tours",
+        help: "Full guided product tour",
+        usage: "/demo",
+        disabled: true,
+        note: NO_BACKEND,
+      },
+      {
+        token: "/note",
+        aliases: ["/n"],
+        category: "Memory",
+        help: "Quick-save a note",
+        usage: "/note text",
+        disabled: true,
+        note: NO_BACKEND,
+      },
+      {
+        token: "/fork",
+        aliases: ["/cp", "/chats fork"],
+        category: "Chats",
+        help: "Fork chat (keep first N msgs)",
+        usage: "/fork",
+        disabled: true,
+        note: NO_BACKEND,
+      },
+      {
+        token: "/bash",
+        aliases: ["/shell", "/toggle bash"],
+        category: "Quick toggles",
+        help: "Toggle bash/shell",
+        usage: "/bash",
+        disabled: true,
+        note: NO_BACKEND,
+      },
+      // ── below-the-fold rows (MAX_VISIBLE cap) — wired to real surfaces ──
+      {
+        token: "/clear",
+        aliases: ["/chats clear"],
+        category: "Chats",
+        help: "Clear chat display",
+        usage: "/clear",
+        run: () => onInput(""),
+      },
+      {
+        token: "/memory",
+        aliases: ["/brain", "/memories"],
+        category: "Memory",
+        help: "Open Brain",
+        usage: "/memory",
+        run: () => onOpenPanel("memory"),
+      },
+      {
+        token: "/skills",
+        aliases: [],
+        category: "Tools",
+        help: "Open Skills",
+        usage: "/skills",
+        run: () => onOpenPanel("skills"),
+      },
+      {
+        token: "/notes",
+        aliases: [],
+        category: "Tools",
+        help: "Open Notes",
+        usage: "/notes",
+        run: () => onOpenPanel("notes"),
+      },
+      {
+        token: "/find",
+        aliases: ["/search"],
+        category: "Utility",
+        help: "Search all conversations",
+        usage: "/find query",
+        run: onSearch,
+      },
+      // /models is only offered when the models surface is wired (onOpenModels).
+      ...(onOpenModels
+        ? [
+            {
+              token: "/models",
+              aliases: ["/model"],
+              category: "Settings",
+              help: "List available models",
+              usage: "/models",
+              run: onOpenModels,
+            },
+          ]
+        : []),
+      {
+        token: "/theme",
+        aliases: [],
+        category: "Settings",
+        help: "Change color theme",
+        usage: "/theme name",
+        run: () => onOpenPanel("theme"),
+      },
+      {
+        token: "/settings",
+        aliases: ["/config", "/preferences"],
+        category: "Settings",
+        help: "Open the Settings panel",
+        usage: "/settings",
+        run: () => onOpenPanel("settings"),
+      },
+    ],
+    [onNewChat, onInput, onSearch, onOpenPanel, onOpenModels],
+  );
+
+  // Trigger only when the message starts with "/" (no leading space) and has no
+  // newline — we don't autocomplete mid-prose. A trailing space after the
+  // command is allowed so a typed-out command still resolves to its row.
+  const query =
+    input.startsWith("/") && !input.includes("\n") ? input.trim() : null;
+  // A bare "/" is the "show everything" case: render the registry in its
+  // definition order (which preserves odysseus's repeated/non-contiguous
+  // category headers — Quick toggles appears for /web,/doc and again for /bash),
+  // capped at MAX_VISIBLE exactly like slashAutocomplete.js's all.slice(0,12).
+  // Scoring a bare "/" would reorder rows by token length, so we skip it.
+  const visible: SlashCommand[] =
+    query === null
+      ? []
+      : query === "/"
+        ? commands.slice(0, MAX_VISIBLE)
+        : commands
+            .map((entry) => ({ entry, score: scoreMatch(entry, query) }))
+            .filter((scored) => scored.score > 0)
+            .sort((a, b) => b.score - a.score)
+            .slice(0, MAX_VISIBLE)
+            .map((scored) => scored.entry);
+  const slashOpen = visible.length > 0 && !dismissed;
+  const selClamped = Math.min(sel, Math.max(0, visible.length - 1));
+
+  const runCommand = (command: SlashCommand) => {
+    if (command.disabled || !command.run) return;
+    onInput("");
+    setDismissed(false);
+    setSel(0);
+    command.run();
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (slashOpen) {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setSel((s) => (s + 1) % visible.length);
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setSel((s) => (s - 1 + visible.length) % visible.length);
+        return;
+      }
+      // Tab always runs the selected row. Enter runs it too, EXCEPT when the
+      // typed text already exactly matches a command token/alias — then the
+      // popup is in "ready to submit a typed-out command" mode and Enter falls
+      // through to the normal submit path (slashAutocomplete.js exactHit).
+      if (event.key === "Tab") {
+        event.preventDefault();
+        runCommand(visible[selClamped]);
+        return;
+      }
+      if (event.key === "Enter" && !event.shiftKey) {
+        const typed = query;
+        const exactHit =
+          typed !== null &&
+          visible.some(
+            (entry) => entry.token === typed || entry.aliases.includes(typed),
+          );
+        if (!exactHit) {
+          event.preventDefault();
+          runCommand(visible[selClamped]);
+          return;
+        }
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setDismissed(true);
+        return;
+      }
+    }
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      onSubmit();
+    }
+  };
+
+  const onChange = (value: string) => {
+    onInput(value);
+    setDismissed(false);
+    setSel(0);
+  };
+
+  const hasDraft = input.trim().length > 0;
+
+  return (
+    <div className="od-input-bar">
+      {slashOpen ? (
+        <div className="od-slash-ac" role="listbox" aria-label="Slash commands">
+          {visible.map((command, i) => {
+            const prev = i > 0 ? visible[i - 1] : null;
+            const showCat = prev === null || prev.category !== command.category;
+            const showUsage = command.usage !== command.token;
+            return (
+              <Fragment key={command.token}>
+                {showCat ? (
+                  <div className="od-slash-ac-cat">{command.category}</div>
+                ) : null}
+                <button
+                  type="button"
+                  role="option"
+                  aria-selected={i === selClamped}
+                  aria-disabled={command.disabled ? true : undefined}
+                  title={command.disabled ? command.note : undefined}
+                  className={`od-slash-ac-row${i === selClamped ? " active" : ""}${
+                    command.disabled ? " od-slash-ac-disabled" : ""
+                  }`}
+                  onMouseEnter={() => setSel(i)}
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    runCommand(command);
+                  }}
+                >
+                  <span className="od-slash-ac-token">{command.token}</span>
+                  <span className="od-slash-ac-help">{command.help}</span>
+                  {showUsage ? (
+                    <span className="od-slash-ac-usage">{command.usage}</span>
+                  ) : null}
+                </button>
+              </Fragment>
+            );
+          })}
+        </div>
+      ) : null}
+      <div className="od-input-top">
+        <textarea
+          ref={taRef}
+          value={input}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder="Message the orchestrator..."
+          rows={1}
+          aria-label="Message input"
+        />
+        {onOpenModels ? (
+          <button
+            type="button"
+            className="od-model-picker-btn"
+            title="Switch model"
+            onClick={onOpenModels}
+          >
+            <span>{modelLabel}</span>
+            <ChevronUp size={10} />
+          </button>
+        ) : (
+          <span className="od-model-picker-btn od-model-picker-static">
+            {modelLabel}
+            <ChevronUp size={10} />
+          </span>
+        )}
+      </div>
+      <div className="od-input-bottom">
+        <div className="od-input-left">
+          {/* Overflow / expand chevron (odysseus .overflow-plus-btn). The
+              orchestrator has no attach/RAG/doc tools menu, so it renders inert
+              for 1:1 chrome rather than opening a fabricated menu. */}
+          <button
+            type="button"
+            className="od-icon-btn"
+            title="More tools (not available in the Orchestrator)"
+            aria-label="More tools"
+            aria-disabled="true"
+            disabled
+          >
+            <ChevronUp size={16} />
+          </button>
+          {/* Web search (odysseus #web-toggle-btn). No orchestrator web-search
+              toggle — inert for chrome parity. */}
+          <button
+            type="button"
+            className="od-icon-btn"
+            title="Web search (not available in the Orchestrator)"
+            aria-label="Web search"
+            aria-disabled="true"
+            disabled
+          >
+            <Search size={16} />
+          </button>
+          {/* Shell access (odysseus #bash-toggle-btn). No orchestrator shell
+              toggle — inert for chrome parity. */}
+          <button
+            type="button"
+            className="od-icon-btn"
+            title="Shell access (not available in the Orchestrator)"
+            aria-label="Shell access"
+            aria-disabled="true"
+            disabled
+          >
+            <Terminal size={16} />
+          </button>
+        </div>
+        <div className="od-input-right">
+          {/* Agent | Chat segmented toggle (odysseus .mode-toggle). Faithful
+              local visual control — the orchestrator has one message path, so
+              this does not switch a backend mode; it defaults to Chat to match
+              the captured frame. */}
+          <div
+            className={`od-mode-toggle${mode === "chat" ? " od-mode-chat" : ""}`}
+          >
+            <button
+              type="button"
+              className={`od-mode-btn${mode === "agent" ? " active" : ""}`}
+              aria-pressed={mode === "agent"}
+              onClick={() => setMode("agent")}
+            >
+              Agent
+            </button>
+            <button
+              type="button"
+              className={`od-mode-btn${mode === "chat" ? " active" : ""}`}
+              aria-pressed={mode === "chat"}
+              onClick={() => setMode("chat")}
+            >
+              Chat
+            </button>
+          </div>
+          {isActive ? (
+            <button
+              type="button"
+              className="od-send-btn od-stop"
+              onClick={onStop}
+              title="Stop"
+              aria-label="Stop"
+            >
+              <Square size={14} fill="currentColor" />
+            </button>
+          ) : (
+            <button
+              type="button"
+              className="od-send-btn"
+              onClick={onSubmit}
+              disabled={!hasDraft || sending}
+              title="Send"
+              aria-label="Send"
+            >
+              <ArrowUp size={16} />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/CookbookView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/CookbookView.tsx
@@ -1,0 +1,1077 @@
+// odysseus Cookbook (static/js/cookbook.js + cookbookServe.js +
+// cookbookDownload.js + cookbook-hwfit.js + cookbook-diagnosis.js, plus the
+// .cookbook-* / .hwfit-* / .admin-card rules in static/style.css). odysseus's
+// Cookbook is a local-model serve workbench with FOUR tabs — Download / Serve /
+// Dependencies / Settings (cookbook.js _renderRecipes, lines 1427-1432). It is
+// NOT a recipe/skill grid: the previous port invented a "Recipes / What Fits?"
+// surface that does not exist upstream. This rebuild restores the real four-tab
+// chrome 1:1.
+//
+// elizaMapping: eliza DOES have a local-inference backend that maps onto this
+// workbench almost field-for-field:
+//   • Download tab → client.getLocalInferenceHardware() (the detected-hardware
+//     pill row), client.getLocalInferenceCatalog() (the FIT/MODEL/PARAM/QUANT/
+//     VRAM/CTX/SCORE scan table — fit is classified client-side from the REAL
+//     probe vs the REAL catalog sizeGb/minRamGb, the eliza analogue of
+//     odysseus's client-side _detectBackend ranker; no benchmarked t/s exists in
+//     eliza's contract so the Speed column honestly shows "—"),
+//     client.searchHuggingFaceGguf() (the "Trending models that fit" list +
+//     paste-a-HF-link search), and client.startLocalInferenceDownload() (the
+//     real Download button).
+//   • Serve tab → client.getLocalInferenceInstalled() (cached/installed GGUFs on
+//     disk), with the real per-model uninstall available through
+//     client.uninstallLocalInferenceModel(). Empty = honest "no cached models".
+//   • Dependencies tab → eliza has no /api/cookbook/packages optional-deps
+//     surface, so the deps grid renders odysseus's chrome (server select +
+//     description) in an honest empty state — never fabricated package rows.
+//   • Settings tab → the HF-token block (eliza has no HF-token endpoint, so the
+//     input is rendered but disabled with an honest reason) and the Servers
+//     block, wired to client.getLocalInferenceProviders() (the real local-
+//     inference provider registry). No invented SSH servers.
+// Every control either calls a real @elizaos/ui client method or renders a
+// faithful inert/disabled state with an honest reason — no fabricated hardware,
+// models, packages, or servers.
+
+import type { CatalogModel, HardwareProbe, InstalledModel } from "@elizaos/ui";
+import { client } from "@elizaos/ui";
+import {
+  Box,
+  Download,
+  Minus,
+  RefreshCw,
+  Server,
+  Settings as SettingsIcon,
+} from "lucide-react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+
+// cookbook.js tab row (lines 1427-1432). data-backend "Search" is the Download
+// tab in odysseus's internal naming; we use the visible labels.
+type CookbookTab = "download" | "serve" | "dependencies" | "settings";
+
+const COOKBOOK_TABS: ReadonlyArray<{
+  id: CookbookTab;
+  label: string;
+  icon: ReactNode;
+}> = [
+  { id: "download", label: "Download", icon: <Download size={12} /> },
+  { id: "serve", label: "Serve", icon: <Server size={12} /> },
+  { id: "dependencies", label: "Dependencies", icon: <Box size={12} /> },
+  { id: "settings", label: "Settings", icon: <SettingsIcon size={12} /> },
+];
+
+// hwfit toolbar 1: the "Type" use-case select (cookbook.js hwfit-usecase). The
+// "Image" option was removed upstream; "Vision" (multimodal) stays.
+const USECASE_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: "", label: "Type" },
+  { value: "general", label: "General" },
+  { value: "coding", label: "Coding" },
+  { value: "reasoning", label: "Reasoning" },
+  { value: "chat", label: "Chat" },
+  { value: "multimodal", label: "Vision" },
+];
+
+// hwfit-quant select (cookbook.js). Verbatim value/label pairs.
+const QUANT_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: "Q4_K_M", label: "Q4" },
+  { value: "Q8_0", label: "Q8" },
+  { value: "Q6_K", label: "Q6" },
+  { value: "Q5_K_M", label: "Q5" },
+  { value: "Q3_K_M", label: "Q3" },
+  { value: "Q2_K", label: "Q2" },
+  { value: "AWQ-4bit", label: "AWQ" },
+  { value: "FP8", label: "FP8" },
+  { value: "FP4", label: "FP4" },
+  { value: "", label: "Native" },
+];
+
+// hwfit-engine select (cookbook.js). llama.cpp/GGUF runs everywhere; vLLM/SGLang
+// are CUDA/datacenter-ROCm.
+const ENGINE_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: "", label: "Engine" },
+  { value: "llamacpp", label: "llama.cpp" },
+  { value: "vllm", label: "vLLM" },
+  { value: "sglang", label: "SGLang" },
+];
+
+// Serve-tab sort select (cookbook.js serve-sort).
+const SERVE_SORT_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: "name", label: "Name" },
+  { value: "size-desc", label: "Size ↓" },
+  { value: "size-asc", label: "Size ↑" },
+  { value: "recent", label: "Recent" },
+];
+
+// cookbook-hwfit.js _hwfitColumns — the scan table header. `sortKey` mirrors the
+// column's data-sort (null = not sortable). Fit is sortable and ranks the
+// categorical fit level; it is the default-active column upstream (the FIT
+// header carries the descending triangle in the captured frame).
+interface FitColumn {
+  sortKey: string | null;
+  label: string;
+  cls: string;
+}
+
+const FIT_COLUMNS: ReadonlyArray<FitColumn> = [
+  { sortKey: "fit", label: "Fit", cls: "od-cb-fit-fit" },
+  { sortKey: null, label: "Model", cls: "od-cb-fit-name" },
+  { sortKey: "params", label: "Param", cls: "od-cb-fit-params" },
+  { sortKey: null, label: "Quant", cls: "od-cb-fit-quant" },
+  { sortKey: "vram", label: "VRAM", cls: "od-cb-fit-vram" },
+  { sortKey: "context", label: "Ctx", cls: "od-cb-fit-ctx" },
+  { sortKey: "speed", label: "Speed", cls: "od-cb-fit-speed" },
+  { sortKey: "score", label: "Score", cls: "od-cb-fit-score" },
+  { sortKey: null, label: "Mode", cls: "od-cb-fit-mode" },
+];
+
+// cookbook-hwfit.js _fitColors — fit-level → colour. Mapped onto eliza theme
+// vars (green/yellow/orange/red) keeping the perfect→too_tight ramp.
+const FIT_LEVEL_META: Record<
+  HardwareFit,
+  { label: string; cls: string; rank: number }
+> = {
+  fits: { label: "fits", cls: "od-cb-fit-fits", rank: 3 },
+  tight: { label: "tight", cls: "od-cb-fit-tight", rank: 1 },
+  wontfit: { label: "wont fit", cls: "od-cb-fit-wontfit", rank: 0 },
+};
+
+type HardwareFit = "fits" | "tight" | "wontfit";
+
+// Client-side fit classification — the eliza analogue of odysseus's client-side
+// ranker. Uses ONLY real probe + real catalog numbers (no fabrication): a model
+// "fits" when its download size sits comfortably under available memory, "tight"
+// when it crowds it, "wontfit" when RAM is below the catalog's own minimum or
+// the file dwarfs memory. Mirrors @elizaos/ui's assessCatalogModelFit thresholds.
+function classifyFit(probe: HardwareProbe, model: CatalogModel): HardwareFit {
+  const budgetGb = probe.gpu ? probe.gpu.totalVramGb : probe.totalRamGb;
+  if (probe.totalRamGb < model.minRamGb) return "wontfit";
+  if (model.sizeGb > budgetGb * 0.8) return "wontfit";
+  if (model.sizeGb > budgetGb * 0.65) return "tight";
+  return "fits";
+}
+
+// A scan-table row built from a real catalog model + the real probe. Every field
+// is sourced from the backend; `speed`/`score` are null where eliza has no
+// measured benchmark, rendered as "—" rather than a fabricated number.
+interface FitRow {
+  id: string;
+  name: string;
+  params: string;
+  quant: string;
+  vramGb: number;
+  contextK: number | null;
+  mode: string;
+  fit: HardwareFit;
+  fitRank: number;
+}
+
+// Compact tabular quant tag for the scan table's fixed-width QUANT column. The
+// catalog's `quant` field is a marketing string for the Eliza-1 tiers ("Eliza-1
+// optimized local runtime"), which overflows the column; the real per-model
+// GGUF quant lives on the quantization matrix's defaultVariantId (e.g.
+// "q4_k_m"), the same compact tag odysseus shows (Q4_K_M). Prefer that; fall
+// back to `quant` only when it is already a short tabular tag (a single token,
+// no spaces, e.g. a raw HF GGUF quant); otherwise show an honest "—".
+function compactQuant(model: CatalogModel): string {
+  const variant = model.quantization?.defaultVariantId;
+  if (variant) return variant.toUpperCase();
+  const raw = model.quant.trim();
+  if (raw && !raw.includes(" ")) return raw.toUpperCase();
+  return "—";
+}
+
+function toFitRow(model: CatalogModel, probe: HardwareProbe): FitRow {
+  const fit = classifyFit(probe, model);
+  return {
+    id: model.id,
+    name: model.displayName || model.id,
+    params: model.parameterLabel || model.params,
+    quant: compactQuant(model),
+    vramGb: model.sizeGb,
+    contextK: model.contextLength
+      ? Math.round(model.contextLength / 1024)
+      : null,
+    mode: probe.gpu ? probe.gpu.backend : "cpu only",
+    fit,
+    fitRank: FIT_LEVEL_META[fit].rank,
+  };
+}
+
+// Detected-hardware pills (cookbook.js #hwfit-hw-row + cookbook-hwfit
+// _hwfitRenderHw). Built from the REAL probe; renders honest "No GPU" plus the
+// real RAM / cores / arch facts. Never invents a GPU.
+interface HwPill {
+  key: string;
+  label: string;
+}
+
+function hwPills(probe: HardwareProbe): HwPill[] {
+  const pills: HwPill[] = [];
+  if (probe.gpu) {
+    pills.push({
+      key: "gpu",
+      label: `${probe.gpu.backend} · ${probe.gpu.totalVramGb.toFixed(1)} GB VRAM`,
+    });
+  } else {
+    pills.push({ key: "gpu", label: "No GPU" });
+  }
+  pills.push({
+    key: "ram",
+    label: `${probe.freeRamGb.toFixed(1)} / ${probe.totalRamGb.toFixed(1)} GB RAM`,
+  });
+  pills.push({ key: "cores", label: `${probe.cpuCores} cores` });
+  pills.push({ key: "arch", label: `${probe.platform}_${probe.arch}` });
+  return pills;
+}
+
+type Loadable<T> = {
+  status: "idle" | "loading" | "ready" | "error";
+  data: T;
+};
+
+export function CookbookView({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}): ReactNode {
+  useEscapeClose(open, onClose);
+  // Wide workbench panel — the scan table needs FIT/MODEL/PARAM/QUANT/VRAM/CTX/
+  // SPEED/SCORE/MODE across its width (odysseus opens at min(780px, 92vw)).
+  const win = useWindowControls(
+    "win-cookbook",
+    { w: 780, h: 820 },
+    { label: "Cookbook", icon: "BookOpen", onClose },
+  );
+  const [tab, setTab] = useState<CookbookTab>("download");
+
+  // Download tab: collapsible Download card + scan toolbar state.
+  const [downloadCardOpen, setDownloadCardOpen] = useState(false);
+  const [trendingOpen, setTrendingOpen] = useState(false);
+  const [repoInput, setRepoInput] = useState("");
+  const [downloading, setDownloading] = useState(false);
+  const [usecase, setUsecase] = useState("");
+  const [scanQuery, setScanQuery] = useState("");
+  const [quant, setQuant] = useState("Q4_K_M");
+  const [engine, setEngine] = useState("");
+  // FIT is the default-active sorted column upstream.
+  const [fitSort, setFitSort] = useState("fit");
+  const [fitReverse, setFitReverse] = useState(false);
+
+  // Serve tab toolbar state.
+  const [serveSort, setServeSort] = useState("name");
+  const [serveQuery, setServeQuery] = useState("");
+
+  // Real backend surfaces.
+  const [hardware, setHardware] = useState<Loadable<HardwareProbe | null>>({
+    status: "idle",
+    data: null,
+  });
+  const [catalog, setCatalog] = useState<Loadable<CatalogModel[]>>({
+    status: "idle",
+    data: [],
+  });
+  const [installed, setInstalled] = useState<Loadable<InstalledModel[]>>({
+    status: "idle",
+    data: [],
+  });
+  const [trending, setTrending] = useState<Loadable<CatalogModel[]>>({
+    status: "idle",
+    data: [],
+  });
+  type ProviderRow = Awaited<
+    ReturnType<typeof client.getLocalInferenceProviders>
+  >["providers"][number];
+  const [providers, setProviders] = useState<Loadable<ProviderRow[]>>({
+    status: "idle",
+    data: [],
+  });
+
+  const loadHardware = useCallback(() => {
+    setHardware((p) => ({ status: "loading", data: p.data }));
+    setCatalog((p) => ({ status: "loading", data: p.data }));
+    void client
+      .getLocalInferenceHardware()
+      .then((probe) => setHardware({ status: "ready", data: probe }))
+      .catch(() => setHardware({ status: "error", data: null }));
+    void client
+      .getLocalInferenceCatalog()
+      .then((r) => setCatalog({ status: "ready", data: r.models }))
+      .catch(() => setCatalog({ status: "error", data: [] }));
+  }, []);
+
+  const loadInstalled = useCallback(() => {
+    setInstalled((p) => ({ status: "loading", data: p.data }));
+    void client
+      .getLocalInferenceInstalled()
+      .then((r) => setInstalled({ status: "ready", data: r.models }))
+      .catch(() => setInstalled({ status: "error", data: [] }));
+  }, []);
+
+  const loadProviders = useCallback(() => {
+    setProviders((p) => ({ status: "loading", data: p.data }));
+    void client
+      .getLocalInferenceProviders()
+      .then((r) => setProviders({ status: "ready", data: r.providers }))
+      .catch(() => setProviders({ status: "error", data: [] }));
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    loadHardware();
+    loadInstalled();
+    loadProviders();
+  }, [open, loadHardware, loadInstalled, loadProviders]);
+
+  // "Trending models that fit your hardware" — real HF GGUF search. Lazy-loaded
+  // when the collapsible list first opens.
+  const loadTrending = useCallback(() => {
+    setTrending((p) => ({ status: "loading", data: p.data }));
+    void client
+      .searchHuggingFaceGguf("gguf", 20)
+      .then((r) => setTrending({ status: "ready", data: r.models }))
+      .catch(() => setTrending({ status: "error", data: [] }));
+  }, []);
+
+  const toggleTrending = () => {
+    setTrendingOpen((openNow) => {
+      const next = !openNow;
+      if (next && trending.status === "idle") loadTrending();
+      return next;
+    });
+  };
+
+  // Real Download — paste a HF repo/URL, hit Download.
+  // client.startLocalInferenceDownload kicks off the real download job.
+  const startDownload = () => {
+    const spec = repoInput.trim();
+    if (!spec || downloading) return;
+    setDownloading(true);
+    void client
+      .startLocalInferenceDownload(spec)
+      .then(() => {
+        setRepoInput("");
+        loadInstalled();
+      })
+      .catch(() => {
+        /* download failed to enqueue — the input stays so the user can retry */
+      })
+      .finally(() => setDownloading(false));
+  };
+
+  // cookbook-hwfit.js header click: clicking the active column flips direction,
+  // clicking a new column resets to highest-first.
+  const onSortColumn = (key: string | null) => {
+    if (!key) return;
+    if (fitSort === key) {
+      setFitReverse((v) => !v);
+    } else {
+      setFitSort(key);
+      setFitReverse(false);
+    }
+  };
+
+  // Scan table rows, filtered + sorted client-side (faithful to odysseus's
+  // client-side hwfit filtering). Only renders when a real probe + catalog are
+  // present — never fabricates rows.
+  const fitRows = useMemo(() => {
+    const probe = hardware.data;
+    if (!probe) return [];
+    const q = scanQuery.trim().toLowerCase();
+    const rows = catalog.data
+      .filter((m) => !m.hiddenFromCatalog)
+      .filter((m) => (usecase ? matchesUsecase(m, usecase) : true))
+      .filter((m) =>
+        q
+          ? (m.displayName || m.id).toLowerCase().includes(q) ||
+            m.hfRepo.toLowerCase().includes(q)
+          : true,
+      )
+      .map((m) => toFitRow(m, probe));
+    const dir = fitReverse ? -1 : 1;
+    rows.sort((a, b) => dir * compareFitRows(a, b, fitSort));
+    return rows;
+  }, [hardware.data, catalog.data, scanQuery, usecase, fitSort, fitReverse]);
+
+  const installedRows = useMemo(() => {
+    const q = serveQuery.trim().toLowerCase();
+    const rows = installed.data.filter((m) =>
+      q ? (m.displayName || m.id).toLowerCase().includes(q) : true,
+    );
+    rows.sort((a, b) => compareInstalled(a, b, serveSort));
+    return rows;
+  }, [installed.data, serveQuery, serveSort]);
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  const probe = hardware.data;
+  const pills = probe ? hwPills(probe) : [];
+
+  return (
+    <div
+      className={`od-search-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Cookbook"
+    >
+      <button
+        type="button"
+        aria-label="Close cookbook"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel od-cb-panel" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+
+        {/* ── Header (cookbook-modal .modal-header: book glyph + title + close).
+            No recipe count, no header refresh — refresh is the Scan toolbar's
+            RESCAN button (cookbook.js index.html L1293-1294). ── */}
+        <div
+          className="od-cb-head od-window-header"
+          onPointerDown={win.onDragStart}
+        >
+          <span className="od-cb-title">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              role="img"
+              aria-label="Cookbook"
+              className="od-cb-title-icon"
+            >
+              <path d="M12 7v14" />
+              <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z" />
+            </svg>
+            Cookbook
+          </span>
+          <span className="od-cb-head-spacer" />
+          <button
+            type="button"
+            className="od-window-min-btn"
+            onClick={win.minimize}
+            title="Minimize"
+            aria-label="Minimize"
+          >
+            <Minus size={14} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="od-cb-close"
+            aria-label="Close cookbook"
+            title="Close"
+            onClick={onClose}
+          >
+            ✖
+          </button>
+        </div>
+
+        {/* ── Tab row (cookbook.js .cookbook-tab set) ── */}
+        <div className="od-cb-tabs" role="tablist" aria-label="Cookbook tabs">
+          {COOKBOOK_TABS.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              role="tab"
+              aria-selected={tab === t.id}
+              className={`od-cb-tab${tab === t.id ? " od-cb-tab-active" : ""}`}
+              onClick={() => setTab(t.id)}
+            >
+              <span className="od-cb-tab-icon" aria-hidden="true">
+                {t.icon}
+              </span>
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="od-cb-body">
+          {/* ════ Download tab (cookbook.js data-backend-group="Search") ════ */}
+          {tab === "download" ? (
+            <>
+              {/* Collapsible Download admin-card (cookbook.js 1435-1499) */}
+              <div className="od-cb-card-section">
+                <button
+                  type="button"
+                  className="od-cb-section-toggle"
+                  aria-expanded={downloadCardOpen}
+                  onClick={() => setDownloadCardOpen((v) => !v)}
+                >
+                  <span className="od-cb-section-h2">Download</span>
+                  <span
+                    className={`od-cb-section-arrow${downloadCardOpen ? " od-cb-section-arrow-open" : ""}`}
+                    aria-hidden="true"
+                  >
+                    ▸
+                  </span>
+                </button>
+                {downloadCardOpen ? (
+                  <div className="od-cb-section-body">
+                    <p className="od-cb-desc">
+                      Download directly from Scan, or paste a HuggingFace model
+                      link.
+                    </p>
+                    <div className="od-cb-dl-serverrow">
+                      <select
+                        className="od-cb-select"
+                        aria-label="Download server"
+                        value="local"
+                        disabled
+                      >
+                        <option value="local">Local</option>
+                      </select>
+                      <button
+                        type="button"
+                        className="od-cb-toolbar-btn"
+                        title="Add server in Settings"
+                        onClick={() => setTab("settings")}
+                      >
+                        add server
+                      </button>
+                    </div>
+                    <div className="od-cb-dl-input">
+                      <input
+                        type="text"
+                        className="od-cb-field-input"
+                        value={repoInput}
+                        onChange={(e) => setRepoInput(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") startDownload();
+                        }}
+                        placeholder="org/model-name, HF URL, or org/model:QUANT_TAG"
+                        aria-label="Model repo or HuggingFace URL"
+                      />
+                      <button
+                        type="button"
+                        className="od-cb-dl-btn"
+                        onClick={startDownload}
+                        disabled={!repoInput.trim() || downloading}
+                      >
+                        {downloading ? "Downloading…" : "Download"}
+                      </button>
+                    </div>
+                    {/* Trending models that fit — real HF GGUF search */}
+                    <div className="od-cb-trending">
+                      <button
+                        type="button"
+                        className="od-cb-toolbar-btn od-cb-trending-toggle"
+                        aria-expanded={trendingOpen}
+                        onClick={toggleTrending}
+                      >
+                        <span
+                          className={`od-cb-section-arrow${trendingOpen ? " od-cb-section-arrow-open" : ""}`}
+                          aria-hidden="true"
+                        >
+                          ▸
+                        </span>
+                        Trending models that fit your hardware
+                      </button>
+                      {trendingOpen ? (
+                        <div className="od-cb-trending-list">
+                          {trending.status === "loading" ? (
+                            <div className="od-cb-loading">
+                              Scanning models…
+                            </div>
+                          ) : trending.status === "error" ? (
+                            <div className="od-cb-loading">
+                              Couldn't reach HuggingFace search.
+                            </div>
+                          ) : trending.data.length === 0 ? (
+                            <div className="od-cb-loading">
+                              No trending models found.
+                            </div>
+                          ) : (
+                            trending.data.map((m) => (
+                              <button
+                                type="button"
+                                key={m.id}
+                                className="od-cb-trending-row"
+                                title={m.hfRepo}
+                                onClick={() => setRepoInput(m.hfRepo)}
+                              >
+                                <span className="od-cb-trending-name">
+                                  {m.displayName || m.id}
+                                </span>
+                                <span className="od-cb-trending-meta">
+                                  {m.quant} · {m.sizeGb.toFixed(1)}G
+                                </span>
+                              </button>
+                            ))
+                          )}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+
+              {/* Scan / Download admin-card (cookbook.js Search section) */}
+              <div className="od-cb-card-section od-cb-scan-section">
+                <span className="od-cb-section-h2">Scan / Download</span>
+                <p className="od-cb-desc">
+                  Scans your hardware for what models you can run. Hardware is
+                  cached; hit the scan button to re-probe after changing GPUs.
+                </p>
+
+                {/* Toolbar row 1: Type / Search / Quant / Engine */}
+                <div className="od-cb-toolbar">
+                  <select
+                    className="od-cb-field-input od-cb-usecase"
+                    value={usecase}
+                    onChange={(e) => setUsecase(e.target.value)}
+                    aria-label="Use case"
+                  >
+                    {USECASE_OPTIONS.map((o) => (
+                      <option key={o.label} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                  <input
+                    type="text"
+                    className="od-cb-field-input od-cb-scan-search"
+                    value={scanQuery}
+                    onChange={(e) => setScanQuery(e.target.value)}
+                    placeholder="Search models..."
+                    aria-label="Search models"
+                  />
+                  <select
+                    className="od-cb-field-input od-cb-quant"
+                    value={quant}
+                    onChange={(e) => setQuant(e.target.value)}
+                    aria-label="Quantization"
+                  >
+                    {QUANT_OPTIONS.map((o) => (
+                      <option key={o.label} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                  <select
+                    className="od-cb-field-input od-cb-engine"
+                    value={engine}
+                    onChange={(e) => setEngine(e.target.value)}
+                    aria-label="Serving engine"
+                    title="Filter by serving engine"
+                  >
+                    {ENGINE_OPTIONS.map((o) => (
+                      <option key={o.label} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* Toolbar row 2: server / RESCAN / EDIT */}
+                <div className="od-cb-toolbar">
+                  <select
+                    className="od-cb-field-input od-cb-server-select"
+                    aria-label="Scan server"
+                    value="local"
+                    disabled
+                  >
+                    <option value="local">Local</option>
+                  </select>
+                  <span className="od-cb-toolbar-spacer" />
+                  <button
+                    type="button"
+                    className="od-cb-gpu-btn od-cb-rescan"
+                    title="Re-scan hardware"
+                    onClick={loadHardware}
+                    disabled={hardware.status === "loading"}
+                  >
+                    <RefreshCw
+                      size={12}
+                      className={
+                        hardware.status === "loading" ? "od-cb-spin" : ""
+                      }
+                    />
+                    RESCAN
+                  </button>
+                  <button
+                    type="button"
+                    className="od-cb-gpu-btn od-cb-edit"
+                    title="Set hardware manually — eliza probes hardware directly, so manual override isn't wired here."
+                    disabled
+                  >
+                    EDIT
+                  </button>
+                </div>
+
+                {/* Detected-hardware pill row (cookbook.js #hwfit-hw-row) */}
+                {pills.length > 0 ? (
+                  <div className="od-cb-hw-row">
+                    <span className="od-cb-hw-label">Detected hardware</span>
+                    <div className="od-cb-hw-pills">
+                      {pills.map((p) => (
+                        <span className="od-cb-hw-pill" key={p.key}>
+                          {p.label}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+
+                {/* Scan table (cookbook-hwfit.js _hwfitRenderList) */}
+                <div className="od-cb-fit-table">
+                  <div className="od-cb-fit-row od-cb-fit-header">
+                    {FIT_COLUMNS.map((col) => {
+                      const sortable = col.sortKey ? " od-cb-fit-sortable" : "";
+                      const active =
+                        col.sortKey && col.sortKey === fitSort
+                          ? " od-cb-fit-sort-active"
+                          : "";
+                      const arrow =
+                        col.sortKey === fitSort
+                          ? fitReverse
+                            ? " ▲"
+                            : " ▼"
+                          : "";
+                      return (
+                        <button
+                          key={col.label}
+                          type="button"
+                          className={`od-cb-fit-col ${col.cls}${sortable}${active}`}
+                          onClick={() => onSortColumn(col.sortKey)}
+                          disabled={!col.sortKey}
+                        >
+                          {col.label}
+                          {arrow}
+                        </button>
+                      );
+                    })}
+                  </div>
+                  {hardware.status === "loading" ||
+                  catalog.status === "loading" ? (
+                    <div className="od-cb-loading">Scanning hardware…</div>
+                  ) : hardware.status === "error" ? (
+                    <div className="od-cb-loading">
+                      No hardware probe available — eliza couldn't reach the
+                      local-inference runtime to scan this machine.
+                    </div>
+                  ) : fitRows.length === 0 ? (
+                    <div className="od-cb-loading">
+                      {scanQuery.trim() || usecase
+                        ? "No models match these filters — try clearing the search or use-case."
+                        : "No models fit your hardware."}
+                    </div>
+                  ) : (
+                    fitRows.map((row) => (
+                      <div className="od-cb-fit-row" key={row.id}>
+                        <span
+                          className={`od-cb-fit-col od-cb-fit-fit ${FIT_LEVEL_META[row.fit].cls}`}
+                        >
+                          {FIT_LEVEL_META[row.fit].label}
+                        </span>
+                        <span
+                          className="od-cb-fit-col od-cb-fit-name"
+                          title={row.name}
+                        >
+                          {row.name}
+                        </span>
+                        <span className="od-cb-fit-col od-cb-fit-params">
+                          {row.params}
+                        </span>
+                        <span className="od-cb-fit-col od-cb-fit-quant">
+                          {row.quant}
+                        </span>
+                        <span className="od-cb-fit-col od-cb-fit-vram">
+                          {row.vramGb.toFixed(1)}G
+                        </span>
+                        <span className="od-cb-fit-col od-cb-fit-ctx">
+                          {row.contextK ? `${row.contextK}k` : "?"}
+                        </span>
+                        <span className="od-cb-fit-col od-cb-fit-speed">—</span>
+                        <span className="od-cb-fit-col od-cb-fit-score">—</span>
+                        <span className="od-cb-fit-col od-cb-fit-mode">
+                          {row.mode}
+                        </span>
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
+            </>
+          ) : null}
+
+          {/* ════ Serve tab (cookbook.js data-backend-group="Serve") ════ */}
+          {tab === "serve" ? (
+            <div className="od-cb-card-section">
+              <span className="od-cb-section-h2">
+                Serve
+                {installed.status === "ready" ? (
+                  <span className="od-cb-section-count">
+                    {installed.data.length}
+                  </span>
+                ) : null}
+              </span>
+              <div className="od-cb-toolbar">
+                <input
+                  type="text"
+                  className="od-cb-field-input od-cb-scan-search"
+                  value={serveQuery}
+                  onChange={(e) => setServeQuery(e.target.value)}
+                  placeholder="Search cached models…"
+                  aria-label="Search cached models"
+                />
+                <select
+                  className="od-cb-field-input od-cb-quant"
+                  value={serveSort}
+                  onChange={(e) => setServeSort(e.target.value)}
+                  aria-label="Sort cached models"
+                >
+                  {SERVE_SORT_OPTIONS.map((o) => (
+                    <option key={o.value} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  className="od-cb-toolbar-btn"
+                  title="Refresh cached models"
+                  onClick={loadInstalled}
+                  disabled={installed.status === "loading"}
+                >
+                  <RefreshCw
+                    size={12}
+                    className={
+                      installed.status === "loading" ? "od-cb-spin" : ""
+                    }
+                  />
+                </button>
+              </div>
+              <div className="od-cb-serve-list">
+                {installed.status === "loading" ? (
+                  <div className="od-cb-loading">Loading cached models…</div>
+                ) : installed.status === "error" ? (
+                  <div className="od-cb-loading">
+                    No serve runtime — eliza couldn't reach the local-inference
+                    backend, so there are no cached models to serve.
+                  </div>
+                ) : installedRows.length === 0 ? (
+                  <div className="od-cb-loading">
+                    No cached models yet. Download one from the Download tab to
+                    serve it locally.
+                  </div>
+                ) : (
+                  installedRows.map((m) => (
+                    <div className="od-cb-card" key={m.id}>
+                      <div className="od-cb-serve-card-main">
+                        <span className="od-cb-serve-card-name" title={m.path}>
+                          {m.displayName || m.id}
+                        </span>
+                        <span className="od-cb-serve-card-size">
+                          {(m.sizeBytes / 1e9).toFixed(1)} GB
+                        </span>
+                      </div>
+                      {m.hfRepo ? (
+                        <span className="od-cb-serve-card-repo">
+                          {m.hfRepo}
+                        </span>
+                      ) : null}
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          ) : null}
+
+          {/* ════ Dependencies tab (cookbook.js data-backend-group="Dependencies") ════ */}
+          {tab === "dependencies" ? (
+            <div className="od-cb-card-section">
+              <div className="od-cb-deps-head">
+                <span className="od-cb-section-h2">Dependencies</span>
+                <span className="od-cb-deps-server-label">Server</span>
+                <select
+                  className="od-cb-field-input od-cb-deps-server"
+                  aria-label="Dependencies server"
+                  value="local"
+                  disabled
+                >
+                  <option value="local">Local</option>
+                </select>
+              </div>
+              <p className="od-cb-desc">
+                Optional packages that extend Orchestrator capabilities.
+              </p>
+              <div className="od-cb-deps-grid">
+                <div className="od-cb-loading">
+                  No optional-package manager — eliza has no
+                  install-from-Cookbook backend, so there are no dependency
+                  packages to list or install here.
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {/* ════ Settings tab (cookbook.js data-backend-group="Settings") ════ */}
+          {tab === "settings" ? (
+            <div className="od-cb-settings-stack">
+              {/* HuggingFace Token block */}
+              <div className="od-cb-card-section">
+                <span className="od-cb-section-h2">HuggingFace Token</span>
+                <p className="od-cb-desc">
+                  Personal access token for downloading gated and private
+                  models.
+                </p>
+                <input
+                  type="password"
+                  className="od-cb-field-input"
+                  placeholder="hf_… — token storage isn't wired in this orchestrator"
+                  aria-label="HuggingFace token"
+                  disabled
+                />
+              </div>
+
+              {/* Servers block — real local-inference provider registry */}
+              <div className="od-cb-card-section">
+                <div className="od-cb-deps-head">
+                  <span className="od-cb-section-h2">Servers</span>
+                  <button
+                    type="button"
+                    className="od-cb-toolbar-btn od-cb-server-refresh"
+                    title="Refresh providers"
+                    onClick={loadProviders}
+                    disabled={providers.status === "loading"}
+                  >
+                    <RefreshCw
+                      size={12}
+                      className={
+                        providers.status === "loading" ? "od-cb-spin" : ""
+                      }
+                    />
+                  </button>
+                </div>
+                <p className="od-cb-desc">
+                  Local inference providers and where each model is served.
+                  Local is this machine.
+                </p>
+                <div className="od-cb-servers-list">
+                  {providers.status === "loading" ? (
+                    <div className="od-cb-loading">Loading providers…</div>
+                  ) : providers.status === "error" ? (
+                    <div className="od-cb-loading">
+                      No provider registry — eliza couldn't reach the
+                      local-inference backend.
+                    </div>
+                  ) : providers.data.length === 0 ? (
+                    <div className="od-cb-loading">
+                      No inference providers configured.
+                    </div>
+                  ) : (
+                    providers.data.map((p) => (
+                      <div className="od-cb-server-row" key={p.id}>
+                        <div className="od-cb-server-main">
+                          <span className="od-cb-server-name">{p.label}</span>
+                          <span
+                            className={`od-cb-server-state${p.enableState.enabled ? " od-cb-server-on" : " od-cb-server-off"}`}
+                            title={p.enableState.reason}
+                          >
+                            {p.enableState.enabled ? "ready" : "off"}
+                          </span>
+                        </div>
+                        {p.description ? (
+                          <span className="od-cb-server-desc">
+                            {p.description}
+                          </span>
+                        ) : null}
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// cookbook-hwfit use-case filter — maps odysseus's use-case axis onto eliza's
+// real CatalogModel.category. "general"/"chat" accept the chat tier; "coding"
+// the code tier; "reasoning" the reasoning tier; "multimodal" (Vision) has no
+// eliza catalog analogue, so it intentionally matches nothing rather than
+// inventing a vision tier.
+function matchesUsecase(model: CatalogModel, usecase: string): boolean {
+  switch (usecase) {
+    case "coding":
+      return model.category === "code";
+    case "reasoning":
+      return model.category === "reasoning";
+    case "chat":
+    case "general":
+      return model.category === "chat" || model.category === "tiny";
+    case "multimodal":
+      return false;
+    default:
+      return true;
+  }
+}
+
+// Column comparator for the scan table (highest-first before the reverse flag).
+function compareFitRows(a: FitRow, b: FitRow, key: string): number {
+  switch (key) {
+    case "fit":
+      return b.fitRank - a.fitRank;
+    case "params":
+      return paramSize(b.params) - paramSize(a.params);
+    case "vram":
+      return b.vramGb - a.vramGb;
+    case "context":
+      return (b.contextK ?? 0) - (a.contextK ?? 0);
+    default:
+      return (a.name || "").localeCompare(b.name || "");
+  }
+}
+
+// Parse a "7B" / "0.5B" / "360M" param label into a comparable GB-scale number.
+function paramSize(label: string): number {
+  const m = label.match(/([\d.]+)\s*([BM])/i);
+  if (!m) return 0;
+  const n = Number.parseFloat(m[1]);
+  if (Number.isNaN(n)) return 0;
+  return m[2].toUpperCase() === "M" ? n / 1000 : n;
+}
+
+function compareInstalled(
+  a: InstalledModel,
+  b: InstalledModel,
+  key: string,
+): number {
+  switch (key) {
+    case "size-desc":
+      return b.sizeBytes - a.sizeBytes;
+    case "size-asc":
+      return a.sizeBytes - b.sizeBytes;
+    case "recent": {
+      const at = a.lastUsedAt ? Date.parse(a.lastUsedAt) : 0;
+      const bt = b.lastUsedAt ? Date.parse(b.lastUsedAt) : 0;
+      return bt - at;
+    }
+    default:
+      return (a.displayName || a.id).localeCompare(b.displayName || b.id);
+  }
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/DocumentLibraryView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/DocumentLibraryView.tsx
@@ -1,0 +1,883 @@
+// odysseus Document Library (static/js/documentLibrary.js — the #doclib-modal
+// "Library" with its Chats / Documents / Research / Archive lib-tabs) plus
+// rag.js + fileHandler.js. The Documents tab is a list of documents with a
+// per-card expandable reader/preview pane and a RAG-inclusion indicator.
+//
+// REUSED-EXISTING-ELIZA-PLUGIN path: eliza already owns a full document/RAG
+// backend (plugin-knowledge surfaced through the @elizaos/ui client —
+// client.listDocuments / getDocument / deleteDocument / getDocumentStats /
+// uploadDocument). In eliza, the document corpus *is* the RAG corpus: every
+// listed document is retrievable, and `fragmentCount` is how many embedded
+// chunks it contributes to retrieval. So odysseus's separate "/api/personal"
+// RAG list (rag.js) and the document library (documentLibrary.js) collapse onto
+// one eliza source of truth — we render the document list and expose each doc's
+// fragment count as its live "in RAG" indicator, plus delete (= remove from
+// RAG), Create (a blank doc), and import (fileHandler.js openPicker →
+// uploadDocument), with a multi-select bulk bar and extension filter chips.
+//
+// Honest scope of the lib-tabs: only the Documents corpus is backed by an
+// eliza client method. odysseus's Chats / Research / Archive tabs are separate
+// surfaces (sessions live in the sidebar; deep-research + a document archive
+// have no eliza endpoint), so those tabs render a truthful empty panel that
+// names where the data lives rather than a fabricated list. odysseus's per-card
+// Open / Clone / Archive actions are session-backed; eliza exposes no document
+// session-open / clone / archive endpoint, so we ship only the real, eliza-
+// backed Export + Delete (no dead controls).
+//
+// Faithful to the odysseus DOM: .lib-tabs > .lib-tab, .doclib-grid >
+// .doclib-card.memory-item with a title row (doc icon + title + RAG badge +
+// chevron), a meta line (source · ext · size · time), a ⋮ actions menu, an
+// expand-to-preview pane with an expanded-action footer, a memory-toolbar with
+// sort + Select + extension chips, and a memory-bulk-bar. Pixel-exact via od-
+// classes mapped 1:1 onto odysseus's doclib + memory-item + lib-tab rules.
+
+import type {
+  DocumentDetail,
+  DocumentRecord,
+  DocumentStats,
+} from "@elizaos/ui";
+import { client } from "@elizaos/ui";
+import {
+  Archive,
+  BookOpen,
+  ChevronDown,
+  Download,
+  FilePlus,
+  FileText,
+  type LucideIcon,
+  MessageSquare,
+  Minus,
+  MoreVertical,
+  Search,
+  Trash2,
+  Upload,
+  X,
+} from "lucide-react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { formatRelativeTime } from "../view-format";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+
+const PAGE_SIZE = 40;
+
+type SortField = "recent" | "oldest" | "name" | "size";
+type LibTab = "chats" | "documents" | "research" | "archive";
+
+interface CardState {
+  detail: DocumentDetail | null;
+  loading: boolean;
+  failed: boolean;
+}
+
+function humanSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// odysseus derives an extension from a doc's language; eliza documents carry a
+// filename + contentType, so we read the extension straight off the filename.
+function fileExtension(filename: string): string {
+  const dot = filename.lastIndexOf(".");
+  if (dot <= 0 || dot === filename.length - 1) return "";
+  return filename.slice(dot + 1).toLowerCase();
+}
+
+function sortDocs(docs: DocumentRecord[], field: SortField): DocumentRecord[] {
+  const next = [...docs];
+  if (field === "name") {
+    next.sort((a, b) => a.filename.localeCompare(b.filename));
+  } else if (field === "size") {
+    next.sort((a, b) => b.fileSize - a.fileSize);
+  } else if (field === "oldest") {
+    next.sort((a, b) => a.createdAt - b.createdAt);
+  } else {
+    next.sort((a, b) => b.createdAt - a.createdAt);
+  }
+  return next;
+}
+
+// odysseus libraryRenderLangChips (documentLibrary.js:354) — an "all (N)" chip
+// + a per-language chip for each distinct value, sorted by count desc. eliza
+// documents have no language, so the file extension is the faithful analog.
+function extensionCounts(docs: DocumentRecord[]): [string, number][] {
+  const counts = new Map<string, number>();
+  for (const d of docs) {
+    const ext = fileExtension(d.filename) || "—";
+    counts.set(ext, (counts.get(ext) ?? 0) + 1);
+  }
+  return [...counts.entries()].sort((a, b) => b[1] - a[1]);
+}
+
+// odysseus renders a 12px leading SVG on every lib-tab (documentLibrary.js:1578)
+// — Chats=speech-bubble, Documents=file, Research=magnifier, Archive=box.
+const LIB_TABS: { id: LibTab; label: string; icon: LucideIcon }[] = [
+  { id: "chats", label: "Chats", icon: MessageSquare },
+  { id: "documents", label: "Documents", icon: FileText },
+  { id: "research", label: "Research", icon: Search },
+  { id: "archive", label: "Archive", icon: Archive },
+];
+
+// odysseus's Chats / Research / Archive tabs read separate backends. eliza
+// exposes none of them through this surface, so each renders an honest panel
+// naming where that data actually lives — never a fabricated list.
+const TAB_EMPTY: Record<Exclude<LibTab, "documents">, string> = {
+  chats:
+    "Chat sessions live in the conversation sidebar, not the document corpus.",
+  research:
+    "Deep-research reports are not part of this agent's document corpus.",
+  archive:
+    "This agent's document corpus has no archive — documents are either indexed for retrieval or deleted.",
+};
+
+export function DocumentLibraryView({
+  open,
+  onClose,
+  locale,
+}: {
+  open: boolean;
+  onClose: () => void;
+  locale?: string;
+}): ReactNode {
+  useEscapeClose(open, onClose);
+  const win = useWindowControls(
+    "win-documents",
+    { w: 640, h: 760 },
+    { label: "Documents", icon: "FileText", onClose },
+  );
+  const [tab, setTab] = useState<LibTab>("documents");
+  const [docs, setDocs] = useState<DocumentRecord[]>([]);
+  const [total, setTotal] = useState(0);
+  const [stats, setStats] = useState<DocumentStats | null>(null);
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<SortField>("recent");
+  const [activeExt, setActiveExt] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [menuId, setMenuId] = useState<string | null>(null);
+  const [cards, setCards] = useState<Record<string, CardState>>({});
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [actionsOpen, setActionsOpen] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [bulkRunning, setBulkRunning] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setFailed(false);
+    void client
+      .listDocuments({ limit: PAGE_SIZE, offset: 0 })
+      .then((r) => {
+        setDocs(r.documents);
+        setTotal(r.total);
+        setLoading(false);
+      })
+      .catch(() => {
+        setDocs([]);
+        setTotal(0);
+        setLoading(false);
+        setFailed(true);
+      });
+    void client
+      .getDocumentStats()
+      .then(setStats)
+      .catch(() => setStats(null));
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    setTab("documents");
+    setQuery("");
+    setActiveExt(null);
+    setExpandedId(null);
+    setMenuId(null);
+    setCards({});
+    setSelectMode(false);
+    setSelectedIds(new Set());
+    setActionsOpen(false);
+    inputRef.current?.focus();
+    load();
+  }, [open, load]);
+
+  const loadMore = () => {
+    if (loading || docs.length >= total) return;
+    setLoading(true);
+    void client
+      .listDocuments({ limit: PAGE_SIZE, offset: docs.length })
+      .then((r) => {
+        setDocs((prev) => [...prev, ...r.documents]);
+        setTotal(r.total);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  };
+
+  const toggleExpand = (doc: DocumentRecord) => {
+    setMenuId(null);
+    if (expandedId === doc.id) {
+      setExpandedId(null);
+      return;
+    }
+    setExpandedId(doc.id);
+    if (cards[doc.id]?.detail || cards[doc.id]?.loading) return;
+    setCards((prev) => ({
+      ...prev,
+      [doc.id]: { detail: null, loading: true, failed: false },
+    }));
+    void client
+      .getDocument(doc.id)
+      .then((r) => {
+        setCards((prev) => ({
+          ...prev,
+          [doc.id]: { detail: r.document, loading: false, failed: false },
+        }));
+      })
+      .catch(() => {
+        setCards((prev) => ({
+          ...prev,
+          [doc.id]: { detail: null, loading: false, failed: true },
+        }));
+      });
+  };
+
+  const removeDoc = (doc: DocumentRecord) => {
+    setMenuId(null);
+    void client
+      .deleteDocument(doc.id)
+      .then(() => {
+        setDocs((prev) => prev.filter((d) => d.id !== doc.id));
+        setTotal((prev) => Math.max(0, prev - 1));
+        setSelectedIds((prev) => {
+          if (!prev.has(doc.id)) return prev;
+          const next = new Set(prev);
+          next.delete(doc.id);
+          return next;
+        });
+        if (expandedId === doc.id) setExpandedId(null);
+        void client
+          .getDocumentStats()
+          .then(setStats)
+          .catch(() => setStats(null));
+      })
+      .catch(() => setFailed(true));
+  };
+
+  // odysseus Export: fetch full content + download as a file. eliza's
+  // getDocument returns content.text, so we build the blob from that.
+  const exportDoc = (doc: DocumentRecord) => {
+    setMenuId(null);
+    void client
+      .getDocument(doc.id)
+      .then((r) => {
+        const text = r.document.content?.text ?? "";
+        const blob = new Blob([text], { type: "text/plain" });
+        const href = URL.createObjectURL(blob);
+        const anchor = document.createElement("a");
+        anchor.href = href;
+        anchor.download = doc.filename;
+        anchor.click();
+        URL.revokeObjectURL(href);
+      })
+      .catch(() => setFailed(true));
+  };
+
+  // odysseus doclib-create-btn (~1670): create a new blank document. odysseus
+  // spins up a session + opens the editor; eliza has no document editor, so the
+  // faithful, honest equivalent is to add a blank document to the corpus via
+  // the real uploadDocument method, then refresh so it appears in the list.
+  const createBlankDoc = () => {
+    if (creating) return;
+    setCreating(true);
+    setMenuId(null);
+    void client
+      .uploadDocument({
+        content: "",
+        filename: "Untitled.md",
+        contentType: "text/markdown",
+      })
+      .then(() => {
+        setCreating(false);
+        load();
+      })
+      .catch(() => {
+        setCreating(false);
+        setFailed(true);
+      });
+  };
+
+  const onPickFiles = (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const reads = Array.from(files).map(
+      (file) =>
+        new Promise<void>((resolve) => {
+          const reader = new FileReader();
+          reader.onload = () => {
+            const content =
+              typeof reader.result === "string" ? reader.result : "";
+            void client
+              .uploadDocument({
+                content,
+                filename: file.name,
+                contentType: file.type || "text/plain",
+              })
+              .then(() => resolve())
+              .catch(() => resolve());
+          };
+          reader.onerror = () => resolve();
+          reader.readAsText(file);
+        }),
+    );
+    void Promise.all(reads).then(load);
+  };
+
+  // odysseus libraryEnterSelectMode / libraryExitSelectMode (1089-1110).
+  const enterSelectMode = () => {
+    setSelectMode(true);
+    setSelectedIds(new Set());
+    setMenuId(null);
+    setExpandedId(null);
+    setActionsOpen(false);
+  };
+  const exitSelectMode = () => {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+    setActionsOpen(false);
+  };
+  const toggleSelectItem = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  const q = query.trim().toLowerCase();
+  const byQuery = q
+    ? docs.filter((d) => d.filename.toLowerCase().includes(q))
+    : docs;
+  const byExt = activeExt
+    ? byQuery.filter((d) => (fileExtension(d.filename) || "—") === activeExt)
+    : byQuery;
+  const visible = sortDocs(byExt, sort);
+  const extChips = extensionCounts(docs);
+  const allSelected =
+    visible.length > 0 && visible.every((d) => selectedIds.has(d.id));
+
+  const toggleSelectAll = () => {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(visible.map((d) => d.id)));
+    }
+  };
+
+  const bulkDelete = () => {
+    if (selectedIds.size === 0 || bulkRunning) return;
+    setActionsOpen(false);
+    setBulkRunning(true);
+    const ids = [...selectedIds];
+    void Promise.all(
+      ids.map((id) =>
+        client
+          .deleteDocument(id)
+          .then(() => id)
+          .catch(() => null),
+      ),
+    ).then((results) => {
+      const deleted = new Set(results.filter((r): r is string => r !== null));
+      setDocs((prev) => prev.filter((d) => !deleted.has(d.id)));
+      setTotal((prev) => Math.max(0, prev - deleted.size));
+      setBulkRunning(false);
+      exitSelectMode();
+      void client
+        .getDocumentStats()
+        .then(setStats)
+        .catch(() => setStats(null));
+    });
+  };
+
+  const bulkExport = () => {
+    if (selectedIds.size === 0) return;
+    setActionsOpen(false);
+    for (const doc of visible) {
+      if (selectedIds.has(doc.id)) exportDoc(doc);
+    }
+  };
+
+  // odysseus libraryRenderStats (documentLibrary.js:344): "N document[s]",
+  // always carrying the noun. We extend it with the indexed-fragment count
+  // (eliza's live "in RAG" signal) when stats have loaded.
+  const headerCount = stats
+    ? `${stats.documentCount} document${stats.documentCount === 1 ? "" : "s"} · ${stats.fragmentCount} indexed`
+    : `${total} document${total === 1 ? "" : "s"}`;
+
+  return (
+    <div
+      className={`od-search-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Library"
+    >
+      <button
+        type="button"
+        aria-label="Close library"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel od-doclib-panel" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        <div
+          className="od-doclib-header od-window-header"
+          onPointerDown={win.onDragStart}
+        >
+          <span className="od-doclib-title">
+            <BookOpen size={14} aria-hidden="true" />
+            Library
+          </span>
+          <button
+            type="button"
+            className="od-window-min-btn"
+            onClick={win.minimize}
+            title="Minimize"
+            aria-label="Minimize"
+          >
+            <Minus size={14} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="od-doclib-close"
+            onClick={onClose}
+            aria-label="Close"
+            title="Close"
+          >
+            <X size={12} aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="od-lib-tabs" role="tablist" aria-label="Library tabs">
+          {LIB_TABS.map((t) => {
+            const TabIcon = t.icon;
+            return (
+              <button
+                key={t.id}
+                type="button"
+                role="tab"
+                aria-selected={tab === t.id}
+                className={`od-lib-tab${tab === t.id ? " od-lib-tab-active" : ""}`}
+                onClick={() => setTab(t.id)}
+              >
+                <TabIcon size={12} aria-hidden="true" />
+                {t.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {tab !== "documents" ? (
+          <div className="od-doclib-tab-empty">{TAB_EMPTY[tab]}</div>
+        ) : (
+          <>
+            <div className="od-doclib-subhead">
+              <h2 className="od-doclib-heading">
+                Documents <span className="od-doclib-count">{headerCount}</span>
+              </h2>
+              <button
+                type="button"
+                className="od-doclib-toolbar-btn od-doclib-import"
+                onClick={() => fileRef.current?.click()}
+                title="Import files from disk"
+              >
+                <Upload size={11} aria-hidden="true" /> Import
+              </button>
+              <button
+                type="button"
+                className="od-doclib-toolbar-btn"
+                onClick={createBlankDoc}
+                disabled={creating}
+                title="Create a new blank document"
+              >
+                <FilePlus size={11} aria-hidden="true" />{" "}
+                {creating ? "Creating…" : "Create"}
+              </button>
+              <input
+                ref={fileRef}
+                type="file"
+                multiple
+                className="od-doclib-file-input"
+                onChange={(e) => {
+                  onPickFiles(e.target.files);
+                  e.target.value = "";
+                }}
+              />
+            </div>
+
+            <p className="od-doclib-desc">
+              Every document here is part of the agent's retrieval corpus.
+              Import or create files to add them to RAG, or remove a document to
+              take it out.
+            </p>
+
+            <div className="od-doclib-toolbar">
+              <div className="od-doclib-filters">
+                <select
+                  className="od-doclib-sort"
+                  value={sort}
+                  onChange={(e) => {
+                    const next = e.target.value;
+                    if (
+                      next === "name" ||
+                      next === "size" ||
+                      next === "oldest"
+                    ) {
+                      setSort(next);
+                    } else {
+                      setSort("recent");
+                    }
+                  }}
+                  aria-label="Sort documents"
+                >
+                  <option value="recent">Recent</option>
+                  <option value="oldest">Oldest</option>
+                  <option value="name">A–Z</option>
+                  <option value="size">Size</option>
+                </select>
+                <button
+                  type="button"
+                  className={`od-doclib-toolbar-btn${selectMode ? " od-doclib-toolbar-btn-active" : ""}`}
+                  onClick={selectMode ? exitSelectMode : enterSelectMode}
+                  title="Select documents"
+                >
+                  {selectMode ? "Cancel" : "Select"}
+                </button>
+                {/* odysseus doclib-tidy-btn (documentLibrary.js:1682) — an AI
+                    pass that removes empty/junk/duplicate documents. eliza
+                    exposes no tidy/dedupe endpoint, so the control renders for
+                    chrome parity but stays inert/disabled with an honest reason
+                    (no fabricated action — see the file header's no-dead-controls
+                    note). */}
+                <button
+                  type="button"
+                  className="od-doclib-toolbar-btn"
+                  disabled
+                  title="Tidy (remove empty / junk / duplicate documents) is not available — this agent's corpus has no tidy endpoint"
+                >
+                  Tidy
+                </button>
+              </div>
+              <input
+                ref={inputRef}
+                className="od-doclib-search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") onClose();
+                }}
+                placeholder="Search documents…"
+                aria-label="Search documents"
+              />
+              {extChips.length > 0 ? (
+                <div className="od-doclib-chips">
+                  <button
+                    type="button"
+                    className={`od-doclib-chip${activeExt === null ? " od-doclib-chip-active" : ""}`}
+                    onClick={() => setActiveExt(null)}
+                  >
+                    all ({docs.length})
+                  </button>
+                  {extChips.map(([ext, count]) => (
+                    <button
+                      key={ext}
+                      type="button"
+                      className={`od-doclib-chip${activeExt === ext ? " od-doclib-chip-active" : ""}`}
+                      onClick={() =>
+                        setActiveExt((prev) => (prev === ext ? null : ext))
+                      }
+                    >
+                      {ext} ({count})
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+
+            {selectMode ? (
+              <div className="od-doclib-bulk-bar">
+                <label className="od-doclib-bulk-all">
+                  <input
+                    type="checkbox"
+                    checked={allSelected}
+                    onChange={toggleSelectAll}
+                  />{" "}
+                  All
+                </label>
+                <span className="od-doclib-bulk-count">
+                  {selectedIds.size} Selected
+                </span>
+                <div className="od-doclib-bulk-actions">
+                  <button
+                    type="button"
+                    className="od-doclib-toolbar-btn"
+                    disabled={selectedIds.size === 0 || bulkRunning}
+                    onClick={() => setActionsOpen((p) => !p)}
+                  >
+                    Actions <ChevronDown size={11} aria-hidden="true" />
+                  </button>
+                  {actionsOpen ? (
+                    <div className="od-doclib-dropdown">
+                      <button
+                        type="button"
+                        className="od-doclib-dropdown-item"
+                        onClick={bulkExport}
+                      >
+                        <Download size={14} aria-hidden="true" />
+                        <span>Export</span>
+                      </button>
+                      <button
+                        type="button"
+                        className="od-doclib-dropdown-item od-doclib-dropdown-danger"
+                        onClick={bulkDelete}
+                      >
+                        <Trash2 size={14} aria-hidden="true" />
+                        <span>Delete</span>
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+                <button
+                  type="button"
+                  className="od-doclib-bulk-cancel"
+                  onClick={exitSelectMode}
+                  title="Cancel (Esc)"
+                  aria-label="Cancel select"
+                >
+                  <X size={12} aria-hidden="true" />
+                </button>
+              </div>
+            ) : null}
+
+            <div className="od-doclib-grid">
+              {visible.length === 0 ? (
+                loading ? (
+                  <div className="od-doclib-empty">Loading…</div>
+                ) : failed ? (
+                  <div className="od-doclib-empty">
+                    Failed to load documents.
+                  </div>
+                ) : q || activeExt ? (
+                  <div className="od-doclib-empty">
+                    No documents match your search.
+                  </div>
+                ) : (
+                  // odysseus libraryRenderGrid empty branch (documentLibrary.js:410):
+                  // "No documents yet" + a dim span with an underlined accent
+                  // "Import" link + " · or create one in a session".
+                  <div className="od-doclib-empty od-doclib-empty-inline">
+                    <span>No documents yet</span>
+                    <span className="od-doclib-empty-hint">
+                      <button
+                        type="button"
+                        className="od-doclib-empty-import"
+                        onClick={() => fileRef.current?.click()}
+                      >
+                        Import
+                        <Upload size={13} aria-hidden="true" />
+                      </button>
+                      {" · or create one in a session"}
+                    </span>
+                  </div>
+                )
+              ) : (
+                visible.map((doc) => {
+                  const expanded = expandedId === doc.id;
+                  const card = cards[doc.id];
+                  const ext = fileExtension(doc.filename);
+                  const selected = selectedIds.has(doc.id);
+                  return (
+                    <div
+                      className={`od-doclib-card od-memory-item${expanded ? " od-doclib-card-expanded" : ""}${selected ? " od-doclib-card-selected" : ""}`}
+                      key={doc.id}
+                    >
+                      {selectMode ? (
+                        <label className="od-doclib-card-check">
+                          <input
+                            type="checkbox"
+                            checked={selected}
+                            onChange={() => toggleSelectItem(doc.id)}
+                            aria-label={`Select ${doc.filename}`}
+                          />
+                        </label>
+                      ) : null}
+                      <button
+                        type="button"
+                        className="od-doclib-card-main"
+                        onClick={() =>
+                          selectMode
+                            ? toggleSelectItem(doc.id)
+                            : toggleExpand(doc)
+                        }
+                        aria-expanded={selectMode ? undefined : expanded}
+                      >
+                        <div className="od-doclib-content">
+                          <div className="od-doclib-titlerow">
+                            <span className="od-doclib-item-title">
+                              <FileText
+                                size={12}
+                                className="od-doclib-doc-icon"
+                                aria-hidden="true"
+                              />
+                              {doc.filename}
+                            </span>
+                            <span
+                              className={`od-doclib-ver${doc.fragmentCount > 0 ? "" : " od-doclib-ver-muted"}`}
+                              title={`${doc.fragmentCount} retrieval fragment${doc.fragmentCount === 1 ? "" : "s"}`}
+                            >
+                              {doc.fragmentCount > 0
+                                ? `${doc.fragmentCount} rag`
+                                : "no rag"}
+                            </span>
+                            {!selectMode ? (
+                              <ChevronDown
+                                size={12}
+                                className="od-doclib-chevron"
+                                aria-hidden="true"
+                              />
+                            ) : null}
+                          </div>
+                          <div className="od-doclib-meta">
+                            <span>{doc.provenance.label}</span>
+                            <span className="od-doclib-meta-sep">·</span>
+                            {ext ? (
+                              <>
+                                <span>{ext}</span>
+                                <span className="od-doclib-meta-sep">·</span>
+                              </>
+                            ) : null}
+                            <span>{humanSize(doc.fileSize)}</span>
+                            <span className="od-doclib-meta-sep">·</span>
+                            <span>
+                              {formatRelativeTime(doc.createdAt, locale)}
+                            </span>
+                          </div>
+                        </div>
+                      </button>
+
+                      {!selectMode ? (
+                        <span className="od-doclib-actions">
+                          <button
+                            type="button"
+                            className="od-doclib-item-btn"
+                            title="Actions"
+                            aria-label="Document actions"
+                            onClick={() =>
+                              setMenuId((prev) =>
+                                prev === doc.id ? null : doc.id,
+                              )
+                            }
+                          >
+                            <MoreVertical size={14} aria-hidden="true" />
+                          </button>
+                          {menuId === doc.id ? (
+                            <div className="od-doclib-dropdown">
+                              <button
+                                type="button"
+                                className="od-doclib-dropdown-item"
+                                onClick={() => exportDoc(doc)}
+                              >
+                                <Download size={14} aria-hidden="true" />
+                                <span>Export</span>
+                              </button>
+                              <button
+                                type="button"
+                                className="od-doclib-dropdown-item od-doclib-dropdown-danger"
+                                disabled={!doc.canDelete}
+                                title={
+                                  doc.canDelete
+                                    ? "Remove from RAG"
+                                    : (doc.deleteabilityReason ??
+                                      "Cannot delete")
+                                }
+                                onClick={() => removeDoc(doc)}
+                              >
+                                <Trash2 size={14} aria-hidden="true" />
+                                <span>Delete</span>
+                              </button>
+                            </div>
+                          ) : null}
+                        </span>
+                      ) : null}
+
+                      {expanded && !selectMode ? (
+                        <div className="od-doclib-preview">
+                          <pre>
+                            <code>
+                              {card?.loading
+                                ? "Loading…"
+                                : card?.failed
+                                  ? "Failed to load document."
+                                  : (card?.detail?.content?.text ??
+                                    "(empty document)")}
+                            </code>
+                          </pre>
+                          <div className="od-doclib-expanded-actions">
+                            <button
+                              type="button"
+                              className="od-doclib-text-btn od-doclib-text-btn-danger"
+                              disabled={!doc.canDelete}
+                              onClick={() => removeDoc(doc)}
+                            >
+                              <Trash2 size={11} aria-hidden="true" /> Delete
+                            </button>
+                            <div className="od-doclib-action-group">
+                              <button
+                                type="button"
+                                className="od-doclib-text-btn"
+                                onClick={() => exportDoc(doc)}
+                              >
+                                <Download size={11} aria-hidden="true" /> Export
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      ) : null}
+                    </div>
+                  );
+                })
+              )}
+            </div>
+
+            {docs.length < total ? (
+              <button
+                type="button"
+                className="od-doclib-load-more"
+                onClick={loadMore}
+              >
+                Load more
+              </button>
+            ) : null}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/EmailView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/EmailView.tsx
@@ -1,0 +1,1890 @@
+// odysseus Email client (static/js/emailLibrary.js + emailInbox.js + signature.js
+// + the `email-*` rules in style.css). The full mail surface: an accounts strip
+// ("All (default)" + per-account chips), a folder + filter toolbar (with the
+// Pending/Stale buckets + a Tags optgroup), a search row with undone / attachment
+// quick-toggles, a multi-select bulk bar, a message list whose rows carry a
+// per-sender pastel avatar, sender/date, urgency dot (red ≥3 / orange =2),
+// attachment + tag pills, a per-row done check + a ⋮ actions menu, a reading
+// split-pane (From/To/Cc chips + Reply / Reply-all / Forward actions + collapsible
+// attachments + body), a compose draft surface, and a saved-signatures picker with
+// a draw-new capture pad (signature.js `pick`/`capture`).
+//
+// elizaMapping: odysseus's email is IMAP/SMTP-backed via its own Python routes
+// (/api/email/list, /read, /accounts, /folders, mark-answered, archive, delete…).
+// eliza has NO email backend — none of the @elizaos/ui `client` methods map to a
+// mail store (the cross-channel `client.getInbox*` methods are connector chats:
+// imessage / telegram / discord, a different surface, NOT email). So this is the
+// faithful no-eliza-equivalent path: every surface is built pixel-exact so it
+// lights up the moment a mail backend exists. Controls that only mutate local view
+// state (done check, read/unread, select, compose) work today; controls that need
+// a server round-trip (Archive, Delete, Remind, Clear reminders, AI reply, Summary,
+// Send, attachment download) are wired to optional callback props and only render
+// when the host supplies a handler — never as dead buttons that route nowhere. The
+// default is odysseus's own honest empty state ("No account connected" / "No
+// emails"), never seeded with fabricated messages presented as agent-fetched.
+
+import {
+  Archive,
+  Bell,
+  Check,
+  Eraser,
+  Forward,
+  Menu,
+  Minus,
+  MoreVertical,
+  Paperclip,
+  PenLine,
+  RefreshCw,
+  Reply,
+  ReplyAll,
+  RotateCcw,
+  Search,
+  Smile,
+  Sparkles,
+  Star,
+  Trash2,
+  X,
+} from "lucide-react";
+import {
+  type ReactNode,
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+import { Spinner } from "./Spinner";
+import { readPref, writePref } from "./util/storage";
+
+// Local-prefs key for the saved-signature list (signature.js persists these
+// server-side via /api/signatures; with no eliza backend they live locally).
+// Not in the shared PREF_KEYS table — this view owns its own non-shared pref.
+const SIGNATURES_PREF_KEY = "email-signatures";
+// signature.js _loadSmoothness/_saveSmoothness — the draw-pad smoothing level.
+const SIGNATURE_SMOOTH_PREF_KEY = "email-signature-smoothness";
+
+// ── Folder + filter model (emailLibrary.js folder select + filter select) ──
+// `tag:*` values mirror the Tags optgroup in emailLibrary.js (lines 631-639).
+type FilterValue =
+  | "all"
+  | "unread"
+  | "favorites"
+  | "undone"
+  | "reminders"
+  | "unanswered"
+  | "pending_30d"
+  | "stale_30d"
+  | "tag:urgent"
+  | "tag:reply-soon"
+  | "tag:spam"
+  | "tag:newsletter"
+  | "tag:marketing";
+
+// Flat filters (emailLibrary.js email-lib-filter options, lines 623-630).
+const FILTERS: { value: FilterValue; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "unread", label: "Unread" },
+  { value: "favorites", label: "Favorites" },
+  { value: "undone", label: "Undone" },
+  { value: "reminders", label: "Reminders" },
+  { value: "unanswered", label: "Unanswered" },
+  { value: "pending_30d", label: "Pending · 30d" },
+  { value: "stale_30d", label: "Stale · >30d" },
+];
+
+// Tags optgroup (emailLibrary.js lines 631-639). `tag` is the bare label the
+// urgency-scanner / sorter stamps on a message; the option value is `tag:<tag>`.
+const TAG_FILTERS: { value: FilterValue; tag: string; label: string }[] = [
+  { value: "tag:urgent", tag: "urgent", label: "Urgent" },
+  { value: "tag:reply-soon", tag: "reply-soon", label: "Reply soon" },
+  { value: "tag:spam", tag: "spam", label: "Spam" },
+  { value: "tag:newsletter", tag: "newsletter", label: "Newsletter" },
+  { value: "tag:marketing", tag: "marketing", label: "Marketing" },
+];
+
+const ALL_FILTERS: { value: FilterValue; label: string }[] = [
+  ...FILTERS,
+  ...TAG_FILTERS.map((t) => ({ value: t.value, label: t.label })),
+];
+
+// Window for the Pending · 30d / Stale · >30d buckets (30 days in ms).
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+// emailLibrary.js folder select initial markup (lines 622-624): before any IMAP
+// folder list arrives, the dropdown carries a single static option —
+// `<option value="INBOX">Inbox</option>` (title-case "Inbox"). The full
+// role-ordered set (Sent/Drafts/Archive/…) is only surfaced once a real folder
+// fetch lands (emailInbox.js sortedFolders), which never happens without a mail
+// backend, so we render only the initial Inbox option here. A `folders` prop
+// can override this once folder data exists.
+const INITIAL_FOLDERS: { value: string; label: string }[] = [
+  { value: "INBOX", label: "Inbox" },
+];
+
+// ── Domain shapes, mirroring the /api/email/list + /read response fields the
+// odysseus renderers read (from_name, from_address, subject, date, is_read,
+// is_answered, is_flagged, has_attachments, attachments, tags, urgency score).
+// Typed up front so the list + reader light up unchanged once a mail client
+// exists. ──
+interface EmailAccount {
+  id: string;
+  name: string;
+  address: string;
+  isDefault: boolean;
+}
+
+interface EmailTag {
+  label: string;
+}
+
+// emailLibrary.js attachment record (uid + index identify it for download).
+interface EmailAttachment {
+  index: number;
+  filename: string;
+  // Byte size — rendered as KB in the chip (emailLibrary.js `att-size`).
+  size: number;
+}
+
+interface EmailMessage {
+  uid: string;
+  fromName: string;
+  fromAddress: string;
+  to: string;
+  cc: string;
+  subject: string;
+  date: number;
+  isRead: boolean;
+  isAnswered: boolean;
+  isFlagged: boolean;
+  hasAttachments: boolean;
+  attachments: EmailAttachment[];
+  tags: EmailTag[];
+  // Urgency-scanner tier: 3 = urgent now (red), 2 = reply soon (orange), else 0.
+  urgency: number;
+  body: string;
+}
+
+interface SavedSignature {
+  id: string;
+  name: string;
+  dataUrl: string;
+}
+
+// emailLibrary.js _showLibRemindSubmenu presets (Later today / Tomorrow / Next
+// week / custom). Resolved against `now` each time the submenu opens.
+interface RemindPreset {
+  key: string;
+  label: string;
+  sub: string;
+  date: Date;
+}
+
+// odysseus emailInbox.js _senderColor — deterministic per-sender pastel hue so
+// the same correspondent always gets the same avatar/dot colour. 1:1 hash.
+function senderColor(name: string): string {
+  if (!name) return "hsl(220, 55%, 65%)";
+  const key = name.toLowerCase();
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = ((hash << 5) - hash + key.charCodeAt(i)) | 0;
+  }
+  const hue = ((hash % 360) + 360) % 360;
+  return `hsl(${hue}, 55%, 65%)`;
+}
+
+// emailInbox.js _urgencyColor — turns the scanner score into a dot tint.
+function urgencyColor(score: number): string {
+  if (score >= 3) return "var(--red)";
+  if (score === 2) return "#f0ad4e";
+  return "";
+}
+
+// Narrow a raw <select> value back to FilterValue without an `as` cast — look
+// it up against the known filter set, falling back to "all" if unrecognized.
+function toFilterValue(raw: string): FilterValue {
+  const match = ALL_FILTERS.find((f) => f.value === raw);
+  return match ? match.value : "all";
+}
+
+function initial(name: string): string {
+  const n = name.trim();
+  return (n.length > 0 ? n[0] : "?").toUpperCase();
+}
+
+// emailInbox.js _createEmailItem date formatting — time if today, else MMM D.
+function formatListDate(ts: number): string {
+  if (!ts) return "";
+  const d = new Date(ts);
+  const now = new Date();
+  const isToday = d.toDateString() === now.toDateString();
+  if (isToday) {
+    return d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  }
+  return d.toLocaleDateString([], { month: "short", day: "numeric" });
+}
+
+// emailLibrary.js _showLibRemindSubmenu — compute the Later today / Tomorrow /
+// Next week preset dates relative to now (1:1 with the JS math).
+function buildRemindPresets(now: Date): RemindPreset[] {
+  const laterToday = new Date(now);
+  const sixPm = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    18,
+    0,
+  );
+  if (sixPm.getTime() - now.getTime() < 60 * 60 * 1000) {
+    laterToday.setTime(now.getTime() + 3 * 60 * 60 * 1000);
+  } else {
+    laterToday.setTime(sixPm.getTime());
+  }
+  const tomorrow = new Date(now);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(8, 0, 0, 0);
+  const daysUntilMon = (8 - now.getDay()) % 7 || 7;
+  const nextWeek = new Date(now);
+  nextWeek.setDate(now.getDate() + daysUntilMon);
+  nextWeek.setHours(8, 0, 0, 0);
+  const timeFmt: Intl.DateTimeFormatOptions = {
+    hour: "numeric",
+    minute: "2-digit",
+  };
+  return [
+    {
+      key: "later",
+      label: "Later today",
+      sub: laterToday.toLocaleTimeString([], timeFmt),
+      date: laterToday,
+    },
+    {
+      key: "tomorrow",
+      label: "Tomorrow",
+      sub: tomorrow.toLocaleTimeString([], timeFmt),
+      date: tomorrow,
+    },
+    {
+      key: "nextweek",
+      label: "Next week",
+      sub: `${nextWeek.toLocaleDateString([], { weekday: "short" })} ${nextWeek.toLocaleTimeString([], timeFmt)}`,
+      date: nextWeek,
+    },
+  ];
+}
+
+// signature.js _smoothnessToParams / SmoothPad — a minimal moving-average draw
+// pad. `smooth` 0..10 maps to how many trailing points get averaged into the
+// rendered point, matching the JS pad's perceived smoothing.
+class SmoothPad {
+  private readonly ctx: CanvasRenderingContext2D;
+  private readonly strokes: { x: number; y: number }[][] = [];
+  private current: { x: number; y: number }[] | null = null;
+  private window: number;
+
+  constructor(
+    private readonly canvas: HTMLCanvasElement,
+    smooth: number,
+  ) {
+    const ctx = canvas.getContext("2d");
+    if (!ctx) throw new Error("[EmailView] 2D canvas context unavailable");
+    this.ctx = ctx;
+    this.window = SmoothPad.windowFor(smooth);
+    this.ctx.lineWidth = 2.4;
+    this.ctx.lineCap = "round";
+    this.ctx.lineJoin = "round";
+  }
+
+  private static windowFor(smooth: number): number {
+    return 1 + Math.round(Math.max(0, Math.min(10, smooth)) * 0.6);
+  }
+
+  setSmoothness(smooth: number): void {
+    this.window = SmoothPad.windowFor(smooth);
+  }
+
+  private point(ev: PointerEvent): { x: number; y: number } {
+    const rect = this.canvas.getBoundingClientRect();
+    return {
+      x: ((ev.clientX - rect.left) / rect.width) * this.canvas.width,
+      y: ((ev.clientY - rect.top) / rect.height) * this.canvas.height,
+    };
+  }
+
+  begin(ev: PointerEvent): void {
+    this.current = [this.point(ev)];
+    this.strokes.push(this.current);
+  }
+
+  extend(ev: PointerEvent): void {
+    if (!this.current) return;
+    this.current.push(this.point(ev));
+    this.redraw();
+  }
+
+  end(): void {
+    this.current = null;
+  }
+
+  undo(): void {
+    this.strokes.pop();
+    this.redraw();
+  }
+
+  clear(): void {
+    this.strokes.length = 0;
+    this.current = null;
+    this.redraw();
+  }
+
+  isEmpty(): boolean {
+    return this.strokes.every((s) => s.length < 2);
+  }
+
+  private smoothed(stroke: { x: number; y: number }[]): {
+    x: number;
+    y: number;
+  }[] {
+    if (this.window <= 1) return stroke;
+    const out: { x: number; y: number }[] = [];
+    for (let i = 0; i < stroke.length; i++) {
+      let sx = 0;
+      let sy = 0;
+      let n = 0;
+      for (let j = Math.max(0, i - this.window + 1); j <= i; j++) {
+        sx += stroke[j].x;
+        sy += stroke[j].y;
+        n++;
+      }
+      out.push({ x: sx / n, y: sy / n });
+    }
+    return out;
+  }
+
+  private redraw(): void {
+    const styles = getComputedStyle(this.canvas);
+    this.ctx.strokeStyle = styles.color || "#000";
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    for (const stroke of this.strokes) {
+      const pts = this.smoothed(stroke);
+      if (pts.length < 2) continue;
+      this.ctx.beginPath();
+      this.ctx.moveTo(pts[0].x, pts[0].y);
+      for (let i = 1; i < pts.length; i++) {
+        this.ctx.lineTo(pts[i].x, pts[i].y);
+      }
+      this.ctx.stroke();
+    }
+  }
+
+  toDataUrl(): string {
+    return this.canvas.toDataURL("image/png");
+  }
+}
+
+export function EmailView({
+  open,
+  onClose,
+  loading = false,
+  remindersEnabled = false,
+  accounts = [],
+  messages = [],
+  onRefresh,
+  onArchive,
+  onDelete,
+  onRemind,
+  onClearReminders,
+  onAiReply,
+  onSummarize,
+  onSend,
+  onDownloadAttachment,
+}: {
+  open: boolean;
+  onClose: () => void;
+  // While a mail fetch is in flight the grid shows odysseus's whirlpool +
+  // "Loading emails" affordance (emailLibrary.js _renderEmailLoading). With no
+  // eliza mail backend this stays false, so the honest empty state is default.
+  loading?: boolean;
+  // emailLibrary.js gates the bell/reminder quick-toggle behind whether the
+  // reminder feature is enabled (#email-reminder-btn starts `hidden`). Defaults
+  // off so the toggle stays hidden until a backend turns reminders on.
+  remindersEnabled?: boolean;
+  accounts?: EmailAccount[];
+  messages?: EmailMessage[];
+  // Server-backed actions — each renders only when its handler is supplied, so
+  // the surface is faithful when a mail backend wires it and honest (no dead
+  // control) when none exists. eliza has none today, so all default undefined.
+  onRefresh?: () => void;
+  onArchive?: (uids: string[]) => void;
+  onDelete?: (uids: string[]) => void;
+  onRemind?: (uid: string, at: Date) => void;
+  onClearReminders?: () => void;
+  onAiReply?: (uid: string) => void;
+  onSummarize?: (uid: string) => void;
+  onSend?: (draft: { to: string; subject: string; body: string }) => void;
+  onDownloadAttachment?: (uid: string, index: number, filename: string) => void;
+}): ReactNode {
+  useEscapeClose(open, onClose);
+  const win = useWindowControls(
+    "win-email",
+    { w: 720, h: 800 },
+    { label: "Email", icon: "Mail", onClose },
+  );
+
+  const [accountId, setAccountId] = useState<string | null>(null);
+  const [folder, setFolder] = useState<string>("INBOX");
+  const [filter, setFilter] = useState<FilterValue>("all");
+  const [search, setSearch] = useState("");
+  const [undoneOnly, setUndoneOnly] = useState(false);
+  const [attachmentsOnly, setAttachmentsOnly] = useState(false);
+  const [selectedUid, setSelectedUid] = useState<string | null>(null);
+  const [composing, setComposing] = useState(false);
+  const [draftTo, setDraftTo] = useState("");
+  const [draftSubject, setDraftSubject] = useState("");
+  const [draftBody, setDraftBody] = useState("");
+  const [sigPickerOpen, setSigPickerOpen] = useState(false);
+  const [sigCaptureOpen, setSigCaptureOpen] = useState(false);
+  const [signatures, setSignatures] = useState<SavedSignature[]>([]);
+
+  // Per-row ⋮ menu: the uid whose dropdown is open (emailLibrary.js
+  // _showCardMenu — one open at a time), plus its remind submenu flag.
+  const [menuUid, setMenuUid] = useState<string | null>(null);
+  const [remindSubmenuOpen, setRemindSubmenuOpen] = useState(false);
+
+  // Multi-select / bulk bar (emailLibrary.js state._selectMode/_selectedUids).
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedUids, setSelectedUids] = useState<Set<string>>(new Set());
+  const [bulkMenuOpen, setBulkMenuOpen] = useState(false);
+
+  // Local optimistic overrides for done/read so the per-row check + bulk
+  // read/unread give real feedback even before a backend round-trips (matching
+  // emailLibrary.js, which flips the visible class as the source of truth). A
+  // real onArchive/onSetAnswered backend can layer on top later.
+  const [answeredOverride, setAnsweredOverride] = useState<
+    Map<string, boolean>
+  >(new Map());
+  const [readOverride, setReadOverride] = useState<Map<string, boolean>>(
+    new Map(),
+  );
+
+  // Reader attachments fold state (emailLibrary.js .email-reader-atts-wrap
+  // starts `collapsed`).
+  const [attsExpanded, setAttsExpanded] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setSignatures(readPref<SavedSignature[]>(SIGNATURES_PREF_KEY, []));
+  }, [open]);
+
+  // Close any open per-row / bulk menu on outside click (emailLibrary.js
+  // document-level `close` handler).
+  useEffect(() => {
+    if (menuUid === null && !bulkMenuOpen) return;
+    const onDoc = (e: MouseEvent) => {
+      const t = e.target;
+      if (t instanceof Element && t.closest(".od-email-menu-anchor")) return;
+      setMenuUid(null);
+      setRemindSubmenuOpen(false);
+      setBulkMenuOpen(false);
+    };
+    document.addEventListener("click", onDoc, true);
+    return () => document.removeEventListener("click", onDoc, true);
+  }, [menuUid, bulkMenuOpen]);
+
+  // Folder list: real IMAP folders would replace this; the single static "Inbox"
+  // option is what odysseus shows before a folder fetch lands (emailLibrary.js).
+  const folders = useMemo<{ value: string; label: string }[]>(
+    () => [...INITIAL_FOLDERS],
+    [],
+  );
+
+  // Resolve a message's effective done/read state through the local overrides.
+  const isAnswered = useCallback(
+    (m: EmailMessage): boolean => answeredOverride.get(m.uid) ?? m.isAnswered,
+    [answeredOverride],
+  );
+  const isRead = useCallback(
+    (m: EmailMessage): boolean => readOverride.get(m.uid) ?? m.isRead,
+    [readOverride],
+  );
+
+  // No eliza client method backs a mail store (see file header) — the message
+  // set is intentionally empty unless data is passed in, so the honest empty
+  // state is the default. The filter pipeline below is wired against the typed
+  // set so the list lights up unchanged once a backend exists.
+  const visibleMessages = useMemo<EmailMessage[]>(() => {
+    const q = search.trim().toLowerCase();
+    const now = Date.now();
+    const tagFilter = TAG_FILTERS.find((t) => t.value === filter);
+    return messages.filter((m) => {
+      const answered = answeredOverride.get(m.uid) ?? m.isAnswered;
+      const read = readOverride.get(m.uid) ?? m.isRead;
+      if (filter === "unread" && read) return false;
+      if (filter === "favorites" && !m.isFlagged) return false;
+      if (filter === "undone" && answered) return false;
+      if (filter === "unanswered" && answered) return false;
+      if (filter === "pending_30d" && now - m.date > THIRTY_DAYS_MS) {
+        return false;
+      }
+      if (filter === "stale_30d" && now - m.date <= THIRTY_DAYS_MS) {
+        return false;
+      }
+      if (tagFilter && !m.tags.some((t) => t.label === tagFilter.tag)) {
+        return false;
+      }
+      if (undoneOnly && answered) return false;
+      if (attachmentsOnly && !m.hasAttachments) return false;
+      if (q.length > 0) {
+        const hay =
+          `${m.subject} ${m.fromName} ${m.fromAddress} ${m.body}`.toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+  }, [
+    messages,
+    filter,
+    search,
+    undoneOnly,
+    attachmentsOnly,
+    answeredOverride,
+    readOverride,
+  ]);
+
+  const remindPresets = useMemo<RemindPreset[]>(
+    () => (remindSubmenuOpen ? buildRemindPresets(new Date()) : []),
+    [remindSubmenuOpen],
+  );
+
+  const isSentFolder = /sent/i.test(folder);
+  const isRemindersFilter = filter === "reminders";
+
+  const unreadCount = messages.filter((m) => !isRead(m)).length;
+
+  const startCompose = useCallback(() => {
+    setComposing(true);
+    setSelectedUid(null);
+    setDraftTo("");
+    setDraftSubject("");
+    setDraftBody("");
+  }, []);
+
+  const closeCompose = useCallback(() => {
+    setComposing(false);
+    setDraftTo("");
+    setDraftSubject("");
+    setDraftBody("");
+  }, []);
+
+  const startReply = useCallback(
+    (m: EmailMessage, mode: "reply" | "reply-all" | "forward") => {
+      setSelectedUid(null);
+      setComposing(true);
+      if (mode === "forward") {
+        setDraftTo("");
+        setDraftSubject(
+          /^fwd?\s*:/i.test(m.subject) ? m.subject : `Fwd: ${m.subject}`,
+        );
+      } else {
+        setDraftTo(m.fromAddress);
+        setDraftSubject(
+          /^re\s*:/i.test(m.subject) ? m.subject : `Re: ${m.subject}`,
+        );
+      }
+      setDraftBody("");
+    },
+    [],
+  );
+
+  const insertSignature = useCallback((sig: SavedSignature) => {
+    setDraftBody((b) => `${b}\n\n— ${sig.name}`);
+    setSigPickerOpen(false);
+  }, []);
+
+  const persistSignatures = useCallback((next: SavedSignature[]) => {
+    setSignatures(next);
+    writePref(SIGNATURES_PREF_KEY, next);
+  }, []);
+
+  const deleteSignature = useCallback(
+    (id: string) => {
+      persistSignatures(signatures.filter((s) => s.id !== id));
+    },
+    [signatures, persistSignatures],
+  );
+
+  // emailLibrary.js doneCheck toggle — flip the visible state, optimistically,
+  // and mark-read on done (mirrors mark-answered + mark-read).
+  const toggleDone = useCallback(
+    (m: EmailMessage) => {
+      const next = !isAnswered(m);
+      setAnsweredOverride((prev) => {
+        const map = new Map(prev);
+        map.set(m.uid, next);
+        return map;
+      });
+      if (next) {
+        setReadOverride((prev) => {
+          const map = new Map(prev);
+          map.set(m.uid, true);
+          return map;
+        });
+      }
+    },
+    [isAnswered],
+  );
+
+  const setReadState = useCallback((uids: string[], read: boolean) => {
+    setReadOverride((prev) => {
+      const map = new Map(prev);
+      for (const uid of uids) map.set(uid, read);
+      return map;
+    });
+  }, []);
+
+  const toggleSelect = useCallback((uid: string) => {
+    setSelectedUids((prev) => {
+      const next = new Set(prev);
+      if (next.has(uid)) next.delete(uid);
+      else next.add(uid);
+      return next;
+    });
+  }, []);
+
+  const enterSelect = useCallback((uid?: string) => {
+    setSelectMode(true);
+    if (uid) setSelectedUids((prev) => new Set(prev).add(uid));
+    setMenuUid(null);
+  }, []);
+
+  const exitSelect = useCallback(() => {
+    setSelectMode(false);
+    setSelectedUids(new Set());
+    setBulkMenuOpen(false);
+  }, []);
+
+  const allSelected =
+    visibleMessages.length > 0 &&
+    visibleMessages.every((m) => selectedUids.has(m.uid));
+
+  const toggleSelectAll = useCallback(() => {
+    setSelectedUids((prev) => {
+      const everySelected =
+        visibleMessages.length > 0 &&
+        visibleMessages.every((m) => prev.has(m.uid));
+      if (everySelected) return new Set();
+      return new Set(visibleMessages.map((m) => m.uid));
+    });
+  }, [visibleMessages]);
+
+  const runBulk = useCallback(
+    (action: "read" | "unread" | "archive" | "delete") => {
+      const uids = Array.from(selectedUids);
+      setBulkMenuOpen(false);
+      if (uids.length === 0) return;
+      if (action === "read" || action === "unread") {
+        setReadState(uids, action === "read");
+      } else if (action === "archive") {
+        onArchive?.(uids);
+      } else if (action === "delete") {
+        onDelete?.(uids);
+      }
+      exitSelect();
+    },
+    [selectedUids, setReadState, onArchive, onDelete, exitSelect],
+  );
+
+  const closeRowMenu = useCallback(() => {
+    setMenuUid(null);
+    setRemindSubmenuOpen(false);
+  }, []);
+
+  const sendDraft = useCallback(() => {
+    if (!onSend) return;
+    onSend({ to: draftTo, subject: draftSubject, body: draftBody });
+    closeCompose();
+  }, [onSend, draftTo, draftSubject, draftBody, closeCompose]);
+
+  // Stats label — short queries collapse back to the list like
+  // emailLibrary.js _doSearch.
+  const statsLabel =
+    visibleMessages.length === 1
+      ? "1 email"
+      : `${visibleMessages.length} emails`;
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  return (
+    <div
+      className={`od-search-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Email"
+    >
+      <button
+        type="button"
+        aria-label="Close email"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel od-email-panel" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        {/* ── Header (emailLibrary.js modal-header) ── */}
+        <div
+          className="od-email-head od-window-header"
+          onPointerDown={win.onDragStart}
+        >
+          <span className="od-email-head-title">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              role="img"
+              aria-label="Email"
+            >
+              <rect x="2" y="4" width="20" height="16" rx="2" />
+              <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+            </svg>
+            Email
+            {unreadCount > 0 ? (
+              <span className="od-email-unread-badge">
+                {unreadCount > 999 ? "999+ unread" : `${unreadCount} unread`}
+              </span>
+            ) : null}
+            <span className="od-email-stats">{statsLabel}</span>
+          </span>
+          <button
+            type="button"
+            className="od-window-min-btn"
+            onClick={win.minimize}
+            title="Minimize"
+            aria-label="Minimize"
+          >
+            <Minus size={14} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="od-email-close"
+            onClick={onClose}
+            aria-label="Close email"
+            title="Close"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        <p className="od-email-desc">
+          All emails. Click to open as a document.
+        </p>
+
+        {/* ── Accounts strip (emailLibrary.js _renderAccountsStrip) ── */}
+        <div className="od-email-accounts-row">
+          <div className="od-email-accounts">
+            <button
+              type="button"
+              className={`od-email-chip${accountId === null ? " active" : ""}`}
+              onClick={() => setAccountId(null)}
+            >
+              All (default)
+            </button>
+            {accounts.map((a) => (
+              <button
+                type="button"
+                key={a.id}
+                className={`od-email-chip${accountId === a.id ? " active" : ""}`}
+                title={`${a.address}${a.isDefault ? " (default)" : ""}`}
+                onClick={() => setAccountId(a.id)}
+              >
+                {a.name || a.address}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            className="od-email-compose-btn"
+            onClick={startCompose}
+            title="New email"
+          >
+            <svg
+              width="11"
+              height="11"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              role="img"
+              aria-label="New email"
+            >
+              <rect x="2" y="4" width="20" height="16" rx="2" />
+              <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+            </svg>
+            <span>New</span>
+          </button>
+        </div>
+
+        {/* ── Toolbar: folder + filter selects, search row, quick toggles ── */}
+        <div className="od-email-toolbar">
+          <div className="od-email-toolbar-row">
+            <select
+              className="od-email-select"
+              value={folder}
+              onChange={(e) => setFolder(e.target.value)}
+              aria-label="Folder"
+            >
+              {folders.map((f) => (
+                <option key={f.value} value={f.value}>
+                  {f.label}
+                </option>
+              ))}
+            </select>
+            <select
+              className="od-email-select"
+              value={filter}
+              onChange={(e) => setFilter(toFilterValue(e.target.value))}
+              aria-label="Filter"
+            >
+              {FILTERS.map((f) => (
+                <option key={f.value} value={f.value}>
+                  {f.label}
+                </option>
+              ))}
+              <optgroup label="Tags">
+                {TAG_FILTERS.map((t) => (
+                  <option key={t.value} value={t.value}>
+                    {t.label}
+                  </option>
+                ))}
+              </optgroup>
+            </select>
+            <button
+              type="button"
+              className={`od-email-tbtn${selectMode ? " active" : ""}`}
+              onClick={() => (selectMode ? exitSelect() : enterSelect())}
+            >
+              {selectMode ? "Cancel" : "Select"}
+            </button>
+            {onRefresh ? (
+              <button
+                type="button"
+                className="od-email-tbtn"
+                title="Refresh"
+                aria-label="Refresh"
+                onClick={onRefresh}
+              >
+                <RefreshCw size={12} />
+              </button>
+            ) : null}
+            {isRemindersFilter && onClearReminders ? (
+              <button
+                type="button"
+                className="od-email-tbtn"
+                title="Permanently delete reminder emails"
+                aria-label="Clear reminders"
+                onClick={onClearReminders}
+              >
+                <Eraser size={12} />
+                <span className="od-email-tbtn-label">Clear</span>
+              </button>
+            ) : null}
+          </div>
+          <div className="od-email-search-row">
+            <span className="od-email-search-wrap">
+              <Search size={12} className="od-email-search-icon" />
+              <input
+                type="text"
+                className="od-email-search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") onClose();
+                }}
+                placeholder="Search emails…"
+                aria-label="Search emails"
+              />
+              {/* Inline quick-toggles, absolutely positioned inside the field
+                  (emailLibrary.js lines 654-662: #email-reminder-btn /
+                  #email-undone-btn / #email-attach-btn). The bell is hidden
+                  until reminders are enabled (starts `hidden`). */}
+              <span className="od-email-search-toggles">
+                {remindersEnabled ? (
+                  <button
+                    type="button"
+                    className={`od-email-inline-toggle${isRemindersFilter ? " active" : ""}`}
+                    title="Show reminder emails"
+                    aria-label="Show reminder emails"
+                    aria-pressed={isRemindersFilter}
+                    onClick={() =>
+                      setFilter((f) =>
+                        f === "reminders" ? "all" : "reminders",
+                      )
+                    }
+                  >
+                    <Bell size={12} />
+                  </button>
+                ) : null}
+                <button
+                  type="button"
+                  className={`od-email-inline-toggle${undoneOnly ? " active" : ""}`}
+                  title="Show only emails not marked as done (undone)"
+                  aria-label="Show only emails not marked as done"
+                  aria-pressed={undoneOnly}
+                  onClick={() => setUndoneOnly((v) => !v)}
+                >
+                  <Check size={12} />
+                </button>
+                <button
+                  type="button"
+                  className={`od-email-inline-toggle${attachmentsOnly ? " active" : ""}`}
+                  title="Show only emails with attachments"
+                  aria-label="Show only emails with attachments"
+                  aria-pressed={attachmentsOnly}
+                  onClick={() => setAttachmentsOnly((v) => !v)}
+                >
+                  <Paperclip size={12} />
+                </button>
+              </span>
+            </span>
+          </div>
+          {/* ── Bulk bar (emailLibrary.js email-lib-bulk) ── */}
+          {selectMode ? (
+            <div className="od-email-bulk">
+              <label className="od-email-bulk-all">
+                <input
+                  type="checkbox"
+                  checked={allSelected}
+                  onChange={toggleSelectAll}
+                />
+                All
+              </label>
+              <span className="od-email-bulk-count">
+                {selectedUids.size} Selected
+              </span>
+              <span className="od-email-menu-anchor od-email-bulk-actions-wrap">
+                <button
+                  type="button"
+                  className="od-email-tbtn od-email-bulk-actions-btn"
+                  disabled={selectedUids.size === 0}
+                  onClick={() => setBulkMenuOpen((v) => !v)}
+                >
+                  <Menu size={11} />
+                  <span>Actions</span>
+                  <span className="od-email-bulk-caret" aria-hidden="true">
+                    ▼
+                  </span>
+                </button>
+                {bulkMenuOpen ? (
+                  <div className="od-email-dropdown">
+                    <button
+                      type="button"
+                      className="od-email-dropdown-item"
+                      onClick={() => runBulk("read")}
+                    >
+                      <Check size={14} />
+                      <span>Mark Read</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="od-email-dropdown-item"
+                      onClick={() => runBulk("unread")}
+                    >
+                      <Bell size={14} />
+                      <span>Mark Unread</span>
+                    </button>
+                    {onArchive ? (
+                      <button
+                        type="button"
+                        className="od-email-dropdown-item"
+                        onClick={() => runBulk("archive")}
+                      >
+                        <Archive size={14} />
+                        <span>Archive</span>
+                      </button>
+                    ) : null}
+                  </div>
+                ) : null}
+              </span>
+              {onDelete ? (
+                <button
+                  type="button"
+                  className="od-email-tbtn od-email-bulk-delete"
+                  disabled={selectedUids.size === 0}
+                  onClick={() => runBulk("delete")}
+                >
+                  <Trash2 size={12} />
+                  <span className="od-email-tbtn-label">Delete</span>
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="od-email-tbtn od-email-bulk-cancel"
+                title="Cancel (Esc)"
+                aria-label="Cancel selection"
+                onClick={exitSelect}
+              >
+                <X size={12} />
+              </button>
+            </div>
+          ) : null}
+        </div>
+
+        {/* ── Single-column card grid (emailLibrary.js #email-lib-grid
+            .doclib-grid). odysseus has no inline reading pane: a card opens
+            "as a document" by expanding in place to surface the reader
+            (From/To/Cc + actions + body); compose opens the same way as an
+            expanded compose card at the top of the grid. ── */}
+        <div className="od-email-grid">
+          {loading ? (
+            <div className="od-email-loading">
+              <Spinner label="Loading emails" />
+            </div>
+          ) : (
+            <>
+              {composing ? (
+                <div className="od-email-card od-email-card-compose expanded">
+                  <div className="od-email-compose">
+                    <div className="od-email-compose-head">
+                      <span className="od-email-compose-title">
+                        New message
+                      </span>
+                      <button
+                        type="button"
+                        className="od-email-tbtn"
+                        onClick={closeCompose}
+                        aria-label="Discard draft"
+                        title="Discard"
+                      >
+                        <X size={13} />
+                      </button>
+                    </div>
+                    <label className="od-email-field">
+                      <span className="od-email-field-label">To</span>
+                      <input
+                        type="text"
+                        className="od-email-field-input"
+                        value={draftTo}
+                        onChange={(e) => setDraftTo(e.target.value)}
+                        placeholder="recipient@example.com"
+                      />
+                    </label>
+                    <label className="od-email-field">
+                      <span className="od-email-field-label">Subject</span>
+                      <input
+                        type="text"
+                        className="od-email-field-input"
+                        value={draftSubject}
+                        onChange={(e) => setDraftSubject(e.target.value)}
+                        placeholder="Subject"
+                      />
+                    </label>
+                    <textarea
+                      className="od-email-compose-body"
+                      value={draftBody}
+                      onChange={(e) => setDraftBody(e.target.value)}
+                      placeholder="Write your message…"
+                      aria-label="Message body"
+                    />
+                    <div className="od-email-compose-footer">
+                      <button
+                        type="button"
+                        className="od-email-sig-btn"
+                        onClick={() => setSigPickerOpen(true)}
+                      >
+                        <PenLine size={12} />
+                        Signature
+                      </button>
+                      <span className="od-email-compose-spacer" />
+                      <button
+                        type="button"
+                        className="od-email-send-btn"
+                        disabled={!draftTo.trim() || !onSend}
+                        title={
+                          onSend
+                            ? "Send"
+                            : "Email send has no eliza backend yet"
+                        }
+                        onClick={sendDraft}
+                      >
+                        Send
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+
+              {accounts.length === 0 && messages.length === 0 ? (
+                <div className="od-email-empty">
+                  <span className="od-email-empty-title">
+                    No emails
+                    <Smile size={14} className="od-email-empty-smiley" />
+                  </span>
+                  <span className="od-email-empty-sub">
+                    Set up at:{" "}
+                    <span className="od-email-empty-link">
+                      Settings › Integrations
+                    </span>
+                  </span>
+                </div>
+              ) : visibleMessages.length === 0 ? (
+                <div className="od-email-empty od-email-empty-filtered">
+                  <span className="od-email-empty-title">
+                    No emails
+                    <Smile size={14} className="od-email-empty-smiley" />
+                  </span>
+                </div>
+              ) : (
+                visibleMessages.map((m) => {
+                  const senderName = isSentFolder
+                    ? m.to || "(no recipient)"
+                    : m.fromName || m.fromAddress;
+                  const color = senderColor(senderName);
+                  const dotColor = urgencyColor(m.urgency) || color;
+                  const answered = isAnswered(m);
+                  const read = isRead(m);
+                  const isExpanded = !composing && m.uid === selectedUid;
+                  const cls = [
+                    "od-email-card",
+                    answered ? "od-email-answered" : "",
+                    !read ? "od-email-unread" : "",
+                    isExpanded ? "expanded" : "",
+                    selectedUids.has(m.uid) ? "od-email-row-selected" : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ");
+                  return (
+                    <div key={m.uid} className={cls}>
+                      <div className="od-email-card-row">
+                        {selectMode ? (
+                          <input
+                            type="checkbox"
+                            className="od-email-row-check"
+                            checked={selectedUids.has(m.uid)}
+                            onChange={() => toggleSelect(m.uid)}
+                            aria-label={`Select ${senderName}`}
+                          />
+                        ) : null}
+                        <button
+                          type="button"
+                          className="od-email-item-open"
+                          onClick={() => {
+                            if (selectMode) {
+                              toggleSelect(m.uid);
+                              return;
+                            }
+                            setComposing(false);
+                            setSelectedUid((prev) =>
+                              prev === m.uid ? null : m.uid,
+                            );
+                          }}
+                        >
+                          {!selectMode ? (
+                            <span
+                              className="od-email-avatar"
+                              style={{ background: color }}
+                            >
+                              {initial(senderName)}
+                            </span>
+                          ) : null}
+                          <span className="od-email-item-content">
+                            <span className="od-email-subject">
+                              {m.subject || "(no subject)"}
+                              {!read && !answered ? (
+                                <span
+                                  className="od-email-unread-dot"
+                                  style={{ color: dotColor }}
+                                  title={
+                                    m.urgency >= 3
+                                      ? "Urgent — needs reply now"
+                                      : m.urgency === 2
+                                        ? "Reply soon"
+                                        : "Unread"
+                                  }
+                                >
+                                  <svg
+                                    width="8"
+                                    height="8"
+                                    viewBox="0 0 24 24"
+                                    fill="currentColor"
+                                    role="img"
+                                    aria-label="Unread"
+                                  >
+                                    <circle cx="12" cy="12" r="6" />
+                                  </svg>
+                                </span>
+                              ) : null}
+                              {m.hasAttachments ? (
+                                <span
+                                  className="od-email-attach-ico"
+                                  title="Has attachments"
+                                >
+                                  <Paperclip size={10} />
+                                </span>
+                              ) : null}
+                              {m.tags.length > 0 ? (
+                                <span className="od-email-tags">
+                                  {m.tags.map((t) => (
+                                    <span
+                                      key={t.label}
+                                      className={`od-email-tag od-email-tag-${t.label}`}
+                                    >
+                                      {t.label}
+                                    </span>
+                                  ))}
+                                </span>
+                              ) : null}
+                            </span>
+                            <span className="od-email-card-meta">
+                              <span
+                                className="od-email-sender"
+                                style={{ color }}
+                              >
+                                {isSentFolder ? `to ${senderName}` : senderName}
+                              </span>
+                              <span className="od-email-meta-sep"> · </span>
+                              <span className="od-email-date">
+                                {formatListDate(m.date)}
+                              </span>
+                            </span>
+                          </span>
+                        </button>
+                        {!isSentFolder ? (
+                          <button
+                            type="button"
+                            className={`od-email-done${answered ? " active" : ""}`}
+                            title={answered ? "Mark not done" : "Mark done"}
+                            aria-label={
+                              answered ? "Mark not done" : "Mark done"
+                            }
+                            aria-pressed={answered}
+                            onClick={() => toggleDone(m)}
+                          >
+                            <Check size={13} />
+                          </button>
+                        ) : null}
+                        {!selectMode ? (
+                          <span className="od-email-item-menu od-email-menu-anchor">
+                            <button
+                              type="button"
+                              className="od-email-item-menu-btn"
+                              title="Actions"
+                              aria-label="Email actions"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setRemindSubmenuOpen(false);
+                                setMenuUid((prev) =>
+                                  prev === m.uid ? null : m.uid,
+                                );
+                              }}
+                            >
+                              <MoreVertical size={14} />
+                            </button>
+                            {menuUid === m.uid ? (
+                              <div className="od-email-dropdown">
+                                {remindSubmenuOpen && onRemind ? (
+                                  <>
+                                    <div className="od-email-dropdown-header">
+                                      Remind me
+                                    </div>
+                                    {remindPresets.map((p) => (
+                                      <button
+                                        type="button"
+                                        key={p.key}
+                                        className="od-email-dropdown-item"
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          onRemind(m.uid, p.date);
+                                          closeRowMenu();
+                                        }}
+                                      >
+                                        <span>{p.label}</span>
+                                        <span className="od-email-dropdown-sub">
+                                          {p.sub}
+                                        </span>
+                                      </button>
+                                    ))}
+                                  </>
+                                ) : (
+                                  <>
+                                    <button
+                                      type="button"
+                                      className="od-email-dropdown-item"
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        setComposing(false);
+                                        setSelectedUid(m.uid);
+                                        closeRowMenu();
+                                      }}
+                                    >
+                                      <Reply size={14} />
+                                      <span>Open</span>
+                                    </button>
+                                    {onRemind ? (
+                                      <button
+                                        type="button"
+                                        className="od-email-dropdown-item"
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          setRemindSubmenuOpen(true);
+                                        }}
+                                      >
+                                        <Bell size={14} />
+                                        <span>Remind to reply</span>
+                                        <span className="od-email-dropdown-arrow">
+                                          ›
+                                        </span>
+                                      </button>
+                                    ) : null}
+                                    {!isSentFolder ? (
+                                      <button
+                                        type="button"
+                                        className="od-email-dropdown-item"
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          toggleDone(m);
+                                          closeRowMenu();
+                                        }}
+                                      >
+                                        <Check size={14} />
+                                        <span>
+                                          {answered
+                                            ? "Mark Not Done"
+                                            : "Mark Done"}
+                                        </span>
+                                      </button>
+                                    ) : null}
+                                    {onArchive ? (
+                                      <button
+                                        type="button"
+                                        className="od-email-dropdown-item"
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          onArchive([m.uid]);
+                                          closeRowMenu();
+                                        }}
+                                      >
+                                        <Archive size={14} />
+                                        <span>Archive</span>
+                                      </button>
+                                    ) : null}
+                                    <button
+                                      type="button"
+                                      className="od-email-dropdown-item"
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        enterSelect(m.uid);
+                                      }}
+                                    >
+                                      <span className="od-email-dropdown-bullet">
+                                        ●
+                                      </span>
+                                      <span>Select</span>
+                                    </button>
+                                    {onDelete ? (
+                                      <button
+                                        type="button"
+                                        className="od-email-dropdown-item od-email-dropdown-danger"
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          onDelete([m.uid]);
+                                          closeRowMenu();
+                                        }}
+                                      >
+                                        <Trash2 size={14} />
+                                        <span>Delete</span>
+                                      </button>
+                                    ) : null}
+                                  </>
+                                )}
+                              </div>
+                            ) : null}
+                          </span>
+                        ) : null}
+                      </div>
+
+                      {/* ── Expanded reader (emailLibrary.js doclib-card-expanded
+                          → opens the message "as a document" inline) ── */}
+                      {isExpanded ? (
+                        <div className="od-email-reader">
+                          <div className="od-email-reader-header">
+                            <div className="od-email-reader-meta">
+                              <div className="od-email-reader-meta-row">
+                                <strong>From:</strong>
+                                <span className="od-email-recipient-chips">
+                                  <span
+                                    className="od-email-recipient-chip"
+                                    title={`${m.fromName} <${m.fromAddress}>`}
+                                  >
+                                    {m.fromName || m.fromAddress}
+                                  </span>
+                                </span>
+                              </div>
+                              {m.to ? (
+                                <div className="od-email-reader-meta-row">
+                                  <strong>To:</strong>
+                                  <span className="od-email-recipient-chips">
+                                    {m.to
+                                      .split(",")
+                                      .map((a) => a.trim())
+                                      .filter(Boolean)
+                                      .map((a) => (
+                                        <span
+                                          key={a}
+                                          className="od-email-recipient-chip"
+                                          title={a}
+                                        >
+                                          {a}
+                                        </span>
+                                      ))}
+                                  </span>
+                                </div>
+                              ) : null}
+                              {m.cc ? (
+                                <div className="od-email-reader-meta-row">
+                                  <strong>Cc:</strong>
+                                  <span className="od-email-recipient-chips">
+                                    {m.cc
+                                      .split(",")
+                                      .map((a) => a.trim())
+                                      .filter(Boolean)
+                                      .map((a) => (
+                                        <span
+                                          key={a}
+                                          className="od-email-recipient-chip"
+                                          title={a}
+                                        >
+                                          {a}
+                                        </span>
+                                      ))}
+                                  </span>
+                                </div>
+                              ) : null}
+                            </div>
+                            <div className="od-email-reader-actions">
+                              <button
+                                type="button"
+                                className="od-email-reader-btn"
+                                title="Reply"
+                                onClick={() => startReply(m, "reply")}
+                              >
+                                <Reply size={14} />
+                                <span className="od-email-reader-btn-label">
+                                  Reply
+                                </span>
+                              </button>
+                              <button
+                                type="button"
+                                className="od-email-reader-btn"
+                                title="Reply all"
+                                onClick={() => startReply(m, "reply-all")}
+                              >
+                                <ReplyAll size={14} />
+                                <span className="od-email-reader-btn-label">
+                                  Reply all
+                                </span>
+                              </button>
+                              <button
+                                type="button"
+                                className="od-email-reader-btn"
+                                title="Forward"
+                                onClick={() => startReply(m, "forward")}
+                              >
+                                <Forward size={14} />
+                                <span className="od-email-reader-btn-label">
+                                  Forward
+                                </span>
+                              </button>
+                              {onAiReply ? (
+                                <button
+                                  type="button"
+                                  className="od-email-reader-btn"
+                                  title="AI reply"
+                                  onClick={() => onAiReply(m.uid)}
+                                >
+                                  <Sparkles size={14} />
+                                  <span className="od-email-reader-btn-label">
+                                    AI reply
+                                  </span>
+                                </button>
+                              ) : null}
+                              {onSummarize ? (
+                                <button
+                                  type="button"
+                                  className="od-email-reader-btn"
+                                  title="Summarize"
+                                  onClick={() => onSummarize(m.uid)}
+                                >
+                                  <Search size={14} />
+                                  <span className="od-email-reader-btn-label">
+                                    Summary
+                                  </span>
+                                </button>
+                              ) : null}
+                            </div>
+                          </div>
+                          {m.isFlagged ? (
+                            <div className="od-email-reader-subject">
+                              <Star
+                                size={13}
+                                className="od-email-reader-star"
+                              />
+                            </div>
+                          ) : null}
+                          {m.attachments.length > 0 ? (
+                            <div
+                              className={`od-email-atts-wrap${attsExpanded ? "" : " collapsed"}`}
+                            >
+                              <button
+                                type="button"
+                                className="od-email-atts-header"
+                                aria-expanded={attsExpanded}
+                                onClick={() => setAttsExpanded((v) => !v)}
+                              >
+                                <Paperclip size={11} />
+                                <span>
+                                  Attachments ({m.attachments.length})
+                                </span>
+                                <svg
+                                  className="od-email-atts-chevron"
+                                  width="10"
+                                  height="10"
+                                  viewBox="0 0 24 24"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  strokeWidth="2.5"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                  aria-hidden="true"
+                                >
+                                  <polyline points="6 9 12 15 18 9" />
+                                </svg>
+                              </button>
+                              <div className="od-email-atts">
+                                {m.attachments.map((att) => (
+                                  <button
+                                    type="button"
+                                    key={att.index}
+                                    className="od-email-att-chip"
+                                    disabled={!onDownloadAttachment}
+                                    title={
+                                      onDownloadAttachment
+                                        ? `Download ${att.filename}`
+                                        : "Attachment download has no eliza backend yet"
+                                    }
+                                    onClick={() =>
+                                      onDownloadAttachment?.(
+                                        m.uid,
+                                        att.index,
+                                        att.filename,
+                                      )
+                                    }
+                                  >
+                                    <Paperclip size={12} />
+                                    <span className="od-email-att-name">
+                                      {att.filename}
+                                    </span>
+                                    <span className="od-email-att-size">
+                                      {Math.round((att.size || 0) / 1024)} KB
+                                    </span>
+                                  </button>
+                                ))}
+                              </div>
+                            </div>
+                          ) : null}
+                          <div className="od-email-reader-body">{m.body}</div>
+                        </div>
+                      ) : null}
+                    </div>
+                  );
+                })
+              )}
+            </>
+          )}
+
+          {/* Floating compose button (emailLibrary.js #email-lib-fab). */}
+          <button
+            type="button"
+            className="od-email-fab"
+            onClick={startCompose}
+            aria-label="New email"
+            title="New email"
+          >
+            <svg
+              width="22"
+              height="22"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <rect x="2.5" y="4.5" width="19" height="15" rx="2.5" />
+              <path d="M3 6.5l9 6 9-6" />
+            </svg>
+            <span className="od-email-fab-label">New</span>
+          </button>
+        </div>
+      </div>
+
+      {/* ── Signature picker (signature.js pick) ── */}
+      {sigPickerOpen ? (
+        <div
+          className="od-email-sig-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Choose a signature"
+        >
+          <button
+            type="button"
+            className="od-search-backdrop"
+            aria-label="Close signature picker"
+            onClick={() => setSigPickerOpen(false)}
+          />
+          <div className="od-email-sig-panel">
+            <div className="od-mem-head">
+              <span className="od-mem-title">Choose a signature</span>
+              <button
+                type="button"
+                className="od-email-tbtn"
+                onClick={() => setSigPickerOpen(false)}
+                aria-label="Close"
+                title="Close"
+              >
+                <X size={14} />
+              </button>
+            </div>
+            <button
+              type="button"
+              className="od-email-sig-new"
+              onClick={() => {
+                setSigPickerOpen(false);
+                setSigCaptureOpen(true);
+              }}
+            >
+              <PenLine size={13} />
+              <span>Draw new signature</span>
+            </button>
+            {signatures.length === 0 ? (
+              <div className="od-email-sig-empty">
+                No saved signatures yet — draw one above.
+              </div>
+            ) : (
+              <div className="od-email-sig-grid">
+                {signatures.map((s) => (
+                  <span key={s.id} className="od-email-sig-tile-wrap">
+                    <button
+                      type="button"
+                      className="od-email-sig-tile"
+                      onClick={() => insertSignature(s)}
+                    >
+                      <img src={s.dataUrl} alt={s.name} />
+                      <span className="od-email-sig-name">{s.name}</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="od-email-sig-del"
+                      title="Delete signature"
+                      aria-label={`Delete ${s.name}`}
+                      onClick={() => deleteSignature(s.id)}
+                    >
+                      <X size={11} />
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      ) : null}
+
+      {/* ── Signature capture pad (signature.js capture) ── */}
+      {sigCaptureOpen ? (
+        <SignatureCapture
+          onClose={() => setSigCaptureOpen(false)}
+          onSave={(sig) => {
+            persistSignatures([...signatures, sig]);
+            setSigCaptureOpen(false);
+            insertSignature(sig);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+// signature.js capture() — a smoothing draw pad with a smoothness slider,
+// undo/clear, and save. Saves persist via the parent's persistSignatures
+// (localStorage, since eliza has no /api/signatures backend).
+function SignatureCapture({
+  onClose,
+  onSave,
+}: {
+  onClose: () => void;
+  onSave: (sig: SavedSignature) => void;
+}): ReactNode {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const padRef = useRef<SmoothPad | null>(null);
+  const [smooth, setSmooth] = useState<number>(() =>
+    readPref<number>(SIGNATURE_SMOOTH_PREF_KEY, 3),
+  );
+  const [name, setName] = useState("");
+  const [empty, setEmpty] = useState(true);
+
+  // Build the pad once from the canvas at mount. It starts at the persisted
+  // smoothness (re-read here so this effect owns no reactive dependency); live
+  // slider changes flow through the setSmoothness effect below.
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    padRef.current = new SmoothPad(
+      canvas,
+      readPref<number>(SIGNATURE_SMOOTH_PREF_KEY, 3),
+    );
+    return () => {
+      padRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    padRef.current?.setSmoothness(smooth);
+  }, [smooth]);
+
+  const onPointerDown = (e: ReactPointerEvent<HTMLCanvasElement>) => {
+    e.currentTarget.setPointerCapture(e.pointerId);
+    padRef.current?.begin(e.nativeEvent);
+  };
+  const onPointerMove = (e: ReactPointerEvent<HTMLCanvasElement>) => {
+    if (e.buttons === 0) return;
+    padRef.current?.extend(e.nativeEvent);
+  };
+  const onPointerUp = () => {
+    padRef.current?.end();
+    setEmpty(padRef.current?.isEmpty() ?? true);
+  };
+
+  const onSmoothChange = (v: number) => {
+    setSmooth(v);
+    writePref(SIGNATURE_SMOOTH_PREF_KEY, v);
+  };
+
+  const clear = () => {
+    padRef.current?.clear();
+    setEmpty(true);
+  };
+  const undo = () => {
+    padRef.current?.undo();
+    setEmpty(padRef.current?.isEmpty() ?? true);
+  };
+
+  const save = () => {
+    const pad = padRef.current;
+    if (!pad || pad.isEmpty()) return;
+    onSave({
+      id:
+        typeof crypto !== "undefined" && "randomUUID" in crypto
+          ? crypto.randomUUID()
+          : `sig-${Date.now()}`,
+      name: name.trim() || "Signature",
+      dataUrl: pad.toDataUrl(),
+    });
+  };
+
+  return (
+    <div
+      className="od-email-sig-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Draw your signature"
+    >
+      <button
+        type="button"
+        className="od-search-backdrop"
+        aria-label="Cancel signature"
+        onClick={onClose}
+      />
+      <div className="od-email-sig-panel od-email-sig-capture">
+        <div className="od-mem-head">
+          <span className="od-mem-title">Draw your signature</span>
+          <button
+            type="button"
+            className="od-email-tbtn"
+            onClick={onClose}
+            aria-label="Close"
+            title="Close"
+          >
+            <X size={14} />
+          </button>
+        </div>
+        <canvas
+          ref={canvasRef}
+          className="od-email-sig-canvas"
+          width={900}
+          height={280}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerLeave={onPointerUp}
+          onPointerCancel={onPointerUp}
+        />
+        <div className="od-email-sig-smooth">
+          <span className="od-email-sig-smooth-label">Smoothness</span>
+          <input
+            type="range"
+            min={0}
+            max={10}
+            step={1}
+            value={smooth}
+            onChange={(e) => onSmoothChange(Number(e.target.value))}
+            aria-label="Smoothness"
+          />
+          <span className="od-email-sig-smooth-val">{smooth}</span>
+        </div>
+        <input
+          type="text"
+          className="od-email-sig-name-input"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Name (optional, e.g. 'Full' or 'Initials')"
+          aria-label="Signature name"
+        />
+        <div className="od-email-sig-footer">
+          <button type="button" className="od-email-sig-btn" onClick={clear}>
+            Clear
+          </button>
+          <button type="button" className="od-email-sig-btn" onClick={undo}>
+            <RotateCcw size={12} />
+            Undo
+          </button>
+          <span className="od-email-compose-spacer" />
+          <button type="button" className="od-email-sig-btn" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="od-email-send-btn"
+            disabled={empty}
+            onClick={save}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/EmojiPicker.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/EmojiPicker.tsx
@@ -1,0 +1,653 @@
+// odysseus emoji picker (static/js/emojiPicker.js + .emoji-picker* rules in
+// static/style.css). Despite the "emoji" name, this is a MONOCHROME ICON picker
+// by design: a curated set of characters that have a genuine text (monochrome)
+// presentation, each rendered as an inline Lucide-style SVG. Pure colour emoji
+// (grin/cry/thumbs) are intentionally excluded because they have no flat text
+// form and so cannot be sent non-coloured. On insert we append U+FE0E
+// (VARIATION SELECTOR-15) for any codepoint >= 0x80 so the glyph renders flat
+// for the recipient too, not just in this (already-SVG) picker UI.
+//
+// A popover: a bare search box on top and a single scrollable list of named
+// groups, each an 8-column grid of icon buttons (no category-tab strip and no
+// "Recent" section — odysseus has neither; the upstream picker stacks every
+// group and filters them live by the search box). Clicking an icon inserts its
+// character and closes the popover (odysseus emojiPicker.js render(): the cell
+// click runs _insertEmoji(char) immediately followed by _closePicker()).
+// elizaMapping: this surface is 100% client-side in odysseus too — the icon
+// dataset is a static constant — so there is no eliza backend to wire and
+// nothing is fabricated.
+//
+// Host surface: in odysseus the emoji-picker button lives ONLY in the
+// document/email markdown formatting toolbar, never in the chat composer (the
+// chat composer's bottom-left row is overflow / web-search / shell). The clone's
+// chat composer therefore does not mount this picker; it stays exported for the
+// document/email editor surface to host. Mounted there, this matches odysseus
+// 1:1.
+
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+
+// Text variation selector (U+FE0E) — appended on insert to characters that
+// might render as a colour emoji, asking the browser/recipient to use text
+// (monochrome) presentation. Matches emojiPicker.js VS15. Built from the
+// codepoint rather than an invisible literal so it survives editing/copy.
+const VS15 = String.fromCodePoint(0xfe0e);
+
+interface IconItem {
+  // The character actually inserted into the draft (with VS-15 appended for
+  // codepoints >= 0x80, mirroring emojiPicker.js _insertEmoji).
+  char: string;
+  // Searchable label (matches emojiPicker.js item[1]).
+  label: string;
+  // Inline SVG path content for the cell glyph (the body of the I() helper in
+  // emojiPicker.js). Rendered inside a fixed 24x24 stroke SVG.
+  path: ReactNode;
+}
+
+interface IconGroup {
+  name: string;
+  items: IconItem[];
+}
+
+// ── Icon dataset, 1:1 with emojiPicker.js EMOJI_GROUPS. Each item is a
+// monochrome symbol with a real text presentation, drawn as a Lucide-style SVG
+// (24x24 viewBox, 2px stroke) so the picker shows flat icons rather than
+// system colour emoji. ──
+const ICON_GROUPS: IconGroup[] = [
+  {
+    name: "Faces & Hearts",
+    items: [
+      {
+        char: "☻",
+        label: "grin",
+        path: (
+          <>
+            <circle cx="12" cy="12" r="10" />
+            <path d="M7 14 C 7 18, 17 18, 17 14 Z" />
+            <line x1="9" y1="9" x2="9.01" y2="9" />
+            <line x1="15" y1="9" x2="15.01" y2="9" />
+          </>
+        ),
+      },
+      {
+        char: "♡",
+        label: "heart-outline",
+        path: (
+          <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z" />
+        ),
+      },
+      {
+        char: "★",
+        label: "star",
+        path: (
+          <polygon
+            points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"
+            fill="currentColor"
+            stroke="none"
+          />
+        ),
+      },
+      {
+        char: "☆",
+        label: "star-outline",
+        path: (
+          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+        ),
+      },
+      {
+        char: "✦",
+        label: "sparkle",
+        path: (
+          <polygon
+            points="12 2 14 10 22 12 14 14 12 22 10 14 2 12 10 10"
+            fill="currentColor"
+            stroke="none"
+          />
+        ),
+      },
+      {
+        char: "☽",
+        label: "moon",
+        path: <path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8z" />,
+      },
+    ],
+  },
+  {
+    name: "Checks & Marks",
+    items: [
+      {
+        char: "✓",
+        label: "check",
+        path: <polyline points="20 6 9 17 4 12" />,
+      },
+      {
+        char: "✗",
+        label: "cross",
+        path: (
+          <>
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </>
+        ),
+      },
+      {
+        char: "✘",
+        label: "cross-heavy",
+        path: (
+          <>
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </>
+        ),
+      },
+      {
+        char: "★",
+        label: "star-filled",
+        path: (
+          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+        ),
+      },
+      {
+        char: "☆",
+        label: "star-empty",
+        path: (
+          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+        ),
+      },
+      {
+        char: "●",
+        label: "dot",
+        path: (
+          <circle cx="12" cy="12" r="6" fill="currentColor" stroke="none" />
+        ),
+      },
+      {
+        char: "○",
+        label: "circle",
+        path: <circle cx="12" cy="12" r="8" />,
+      },
+      {
+        char: "■",
+        label: "square-filled",
+        path: (
+          <rect
+            x="6"
+            y="6"
+            width="12"
+            height="12"
+            fill="currentColor"
+            stroke="none"
+          />
+        ),
+      },
+      {
+        char: "□",
+        label: "square-empty",
+        path: <rect x="5" y="5" width="14" height="14" />,
+      },
+      {
+        char: "◆",
+        label: "diamond",
+        path: <polygon points="12 3 21 12 12 21 3 12" />,
+      },
+      {
+        char: "◇",
+        label: "diamond-empty",
+        path: <polygon points="12 3 21 12 12 21 3 12" />,
+      },
+      {
+        char: "†",
+        label: "dagger",
+        path: (
+          <>
+            <line x1="12" y1="4" x2="12" y2="20" />
+            <line x1="8" y1="8" x2="16" y2="8" />
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    name: "Arrows",
+    items: [
+      {
+        char: "→",
+        label: "arrow-right",
+        path: (
+          <>
+            <line x1="5" y1="12" x2="19" y2="12" />
+            <polyline points="12 5 19 12 12 19" />
+          </>
+        ),
+      },
+      {
+        char: "←",
+        label: "arrow-left",
+        path: (
+          <>
+            <line x1="19" y1="12" x2="5" y2="12" />
+            <polyline points="12 19 5 12 12 5" />
+          </>
+        ),
+      },
+      {
+        char: "↑",
+        label: "arrow-up",
+        path: (
+          <>
+            <line x1="12" y1="19" x2="12" y2="5" />
+            <polyline points="5 12 12 5 19 12" />
+          </>
+        ),
+      },
+      {
+        char: "↓",
+        label: "arrow-down",
+        path: (
+          <>
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <polyline points="19 12 12 19 5 12" />
+          </>
+        ),
+      },
+      {
+        char: "⇒",
+        label: "arrow-r-dbl",
+        path: (
+          <>
+            <polyline points="10 5 17 12 10 19" />
+            <polyline points="6 5 13 12 6 19" />
+          </>
+        ),
+      },
+      {
+        char: "⇐",
+        label: "arrow-l-dbl",
+        path: (
+          <>
+            <polyline points="14 5 7 12 14 19" />
+            <polyline points="18 5 11 12 18 19" />
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    name: "Math & Punctuation",
+    items: [
+      {
+        char: "±",
+        label: "plus-minus",
+        path: (
+          <>
+            <line x1="4" y1="10" x2="20" y2="10" />
+            <line x1="12" y1="2" x2="12" y2="18" />
+            <line x1="4" y1="20" x2="20" y2="20" />
+          </>
+        ),
+      },
+      {
+        char: "×",
+        label: "multiply",
+        path: (
+          <>
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </>
+        ),
+      },
+      {
+        char: "÷",
+        label: "divide",
+        path: (
+          <>
+            <circle cx="12" cy="6" r="1.5" fill="currentColor" stroke="none" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+            <circle cx="12" cy="18" r="1.5" fill="currentColor" stroke="none" />
+          </>
+        ),
+      },
+      {
+        char: "≈",
+        label: "approx",
+        path: (
+          <>
+            <path d="M4 9 C 6 6, 8 12, 10 9 S 14 6, 16 9 S 20 12, 22 9" />
+            <path d="M4 15 C 6 12, 8 18, 10 15 S 14 12, 16 15 S 20 18, 22 15" />
+          </>
+        ),
+      },
+      {
+        char: "≠",
+        label: "not-equal",
+        path: (
+          <>
+            <line x1="5" y1="9" x2="19" y2="9" />
+            <line x1="5" y1="15" x2="19" y2="15" />
+            <line x1="16" y1="5" x2="8" y2="19" />
+          </>
+        ),
+      },
+      {
+        char: "≤",
+        label: "lte",
+        path: (
+          <>
+            <polyline points="17 5 7 11 17 17" />
+            <line x1="7" y1="20" x2="17" y2="20" />
+          </>
+        ),
+      },
+      {
+        char: "≥",
+        label: "gte",
+        path: (
+          <>
+            <polyline points="7 5 17 11 7 17" />
+            <line x1="7" y1="20" x2="17" y2="20" />
+          </>
+        ),
+      },
+      {
+        char: "∞",
+        label: "infinity",
+        path: (
+          <path d="M18.178 8c5.096 0 5.096 8 0 8-5.095 0-7.133-8-12.739-8-4.585 0-4.585 8 0 8 5.606 0 7.644-8 12.739-8z" />
+        ),
+      },
+      {
+        char: "π",
+        label: "pi",
+        path: (
+          <>
+            <line x1="4" y1="8" x2="20" y2="8" />
+            <line x1="9" y1="8" x2="9" y2="20" />
+            <line x1="15" y1="8" x2="15" y2="20" />
+          </>
+        ),
+      },
+      {
+        char: "Σ",
+        label: "sum",
+        path: <polyline points="6 4 18 4 10 12 18 20 6 20" />,
+      },
+      {
+        char: "∆",
+        label: "delta",
+        path: <polygon points="12 4 20 20 4 20" />,
+      },
+      {
+        char: "√",
+        label: "root",
+        path: <polyline points="4 14 8 20 14 4 22 4" />,
+      },
+      {
+        char: "°",
+        label: "degree",
+        path: <circle cx="12" cy="8" r="3" />,
+      },
+      {
+        char: "§",
+        label: "section",
+        path: <path d="M14 6 a4 3 0 1 0 -4 4 q-3 0 -3 3 t3 3 q3 0 3 -3" />,
+      },
+      {
+        char: "¶",
+        label: "pilcrow",
+        path: (
+          <>
+            <path d="M16 4 H 9 a4 4 0 0 0 0 8 H 12 V 20" />
+            <line x1="16" y1="4" x2="16" y2="20" />
+          </>
+        ),
+      },
+      {
+        char: "•",
+        label: "bullet",
+        path: (
+          <circle cx="12" cy="12" r="3" fill="currentColor" stroke="none" />
+        ),
+      },
+      {
+        char: "…",
+        label: "ellipsis",
+        path: (
+          <>
+            <circle cx="6" cy="12" r="1.5" fill="currentColor" stroke="none" />
+            <circle cx="12" cy="12" r="1.5" fill="currentColor" stroke="none" />
+            <circle cx="18" cy="12" r="1.5" fill="currentColor" stroke="none" />
+          </>
+        ),
+      },
+      {
+        char: "—",
+        label: "em-dash",
+        path: <line x1="4" y1="12" x2="20" y2="12" />,
+      },
+      {
+        char: "«",
+        label: "quote-l",
+        path: (
+          <>
+            <polyline points="12 5 6 12 12 19" />
+            <polyline points="18 5 12 12 18 19" />
+          </>
+        ),
+      },
+      {
+        char: "»",
+        label: "quote-r",
+        path: (
+          <>
+            <polyline points="6 5 12 12 6 19" />
+            <polyline points="12 5 18 12 12 19" />
+          </>
+        ),
+      },
+      {
+        char: '"',
+        label: "quote-dbl",
+        path: (
+          <>
+            <line x1="8" y1="5" x2="8" y2="11" />
+            <line x1="11" y1="5" x2="11" y2="11" />
+            <line x1="13" y1="5" x2="13" y2="11" />
+            <line x1="16" y1="5" x2="16" y2="11" />
+          </>
+        ),
+      },
+    ],
+  },
+  {
+    name: "Currency & Misc",
+    // Currency/typographic glyphs drawn as their own character inside the SVG
+    // (matching emojiPicker.js, which uses <text> nodes for these so they keep
+    // the picker's monochrome look without bespoke vector art per symbol).
+    items: [
+      { char: "€", label: "euro", path: <CurrencyGlyph glyph="€" /> },
+      { char: "£", label: "pound", path: <CurrencyGlyph glyph="£" /> },
+      { char: "¥", label: "yen", path: <CurrencyGlyph glyph="¥" /> },
+      { char: "$", label: "dollar", path: <CurrencyGlyph glyph="$" /> },
+      { char: "¢", label: "cent", path: <CurrencyGlyph glyph="¢" /> },
+      { char: "%", label: "percent", path: <CurrencyGlyph glyph="%" /> },
+      {
+        char: "‰",
+        label: "per-mille",
+        path: <CurrencyGlyph glyph="‰" size={13} />,
+      },
+      {
+        char: "№",
+        label: "number",
+        path: <CurrencyGlyph glyph="№" size={12} />,
+      },
+    ],
+  },
+];
+
+// SVG <text> glyph for currency/typographic symbols (emojiPicker.js renders
+// these as a <text> node inside the icon SVG rather than as vector strokes).
+function CurrencyGlyph({
+  glyph,
+  size = 16,
+}: {
+  glyph: string;
+  size?: number;
+}): ReactNode {
+  return (
+    <text
+      x="12"
+      y="16"
+      fontSize={size}
+      textAnchor="middle"
+      fill="currentColor"
+      stroke="none"
+    >
+      {glyph}
+    </text>
+  );
+}
+
+// The picker glyph: a Lucide-style 24x24 stroke SVG wrapping the item's path.
+function IconGlyph({ path }: { path: ReactNode }): ReactNode {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {path}
+    </svg>
+  );
+}
+
+export function EmojiPicker({
+  open,
+  onPick,
+  onClose,
+  anchorClassName,
+}: {
+  open: boolean;
+  onPick: (emoji: string) => void;
+  onClose: () => void;
+  anchorClassName?: string;
+}): ReactNode {
+  const [query, setQuery] = useState("");
+  const rootRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reset the search + focus the search box each time the popover opens.
+  useEffect(() => {
+    if (!open) return;
+    setQuery("");
+    inputRef.current?.focus();
+  }, [open]);
+
+  // Escape closes; click outside the popover closes (composer popover pattern,
+  // not the modal-overlay backdrop). Listens only while open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    const onDocPointer = (e: PointerEvent) => {
+      const root = rootRef.current;
+      if (root && e.target instanceof Node && !root.contains(e.target)) {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    document.addEventListener("pointerdown", onDocPointer);
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.removeEventListener("pointerdown", onDocPointer);
+    };
+  }, [open, onClose]);
+
+  // Live filter across every group: match the item label (case-insensitive) or
+  // the raw character, dropping groups with no remaining items. Empty query
+  // shows all groups. Matches emojiPicker.js render(filter).
+  const groups = useMemo<IconGroup[]>(() => {
+    const raw = query.trim();
+    if (!raw) return ICON_GROUPS;
+    const f = raw.toLowerCase();
+    const filtered: IconGroup[] = [];
+    for (const group of ICON_GROUPS) {
+      const items = group.items.filter(
+        (item) =>
+          item.label.toLowerCase().includes(f) || item.char.includes(raw),
+      );
+      if (items.length > 0) filtered.push({ name: group.name, items });
+    }
+    return filtered;
+  }, [query]);
+
+  // Insert the character then close. Append VS-15 for codepoints >= 0x80 so the
+  // recipient sees a flat/monochrome glyph, not a system colour emoji
+  // (emojiPicker.js _insertEmoji). The cell click closes the popover
+  // immediately, matching odysseus (render() runs _insertEmoji then
+  // _closePicker on each cell click).
+  const pick = (char: string) => {
+    const cp = char.codePointAt(0);
+    const out = cp !== undefined && cp >= 0x80 ? char + VS15 : char;
+    onPick(out);
+    onClose();
+  };
+
+  if (!open) return null;
+
+  const rootClass = anchorClassName
+    ? `od-emoji-popover ${anchorClassName}`
+    : "od-emoji-popover";
+
+  return (
+    <div
+      ref={rootRef}
+      className={rootClass}
+      role="dialog"
+      aria-label="Icon picker"
+    >
+      {/* Bare search input (odysseus .emoji-picker-search is a full-width
+          <input> with no leading icon, placeholder "Search…"). */}
+      <input
+        ref={inputRef}
+        className="od-emoji-search-input"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") onClose();
+        }}
+        placeholder="Search…"
+        aria-label="Search icons"
+      />
+
+      {/* Single scrollable stack of groups. Empty groups are dropped and an
+          all-empty filter simply renders nothing — odysseus shows no
+          "no match" message (render() just skips empty groups). */}
+      <div className="od-emoji-body">
+        {groups.map((group) => (
+          <div className="od-emoji-section" key={group.name}>
+            <div className="od-emoji-section-label">{group.name}</div>
+            <div className="od-emoji-grid">
+              {group.items.map((item) => (
+                <button
+                  type="button"
+                  key={`${group.name}:${item.label}`}
+                  className="od-emoji-cell"
+                  title={item.label}
+                  onClick={() => pick(item.char)}
+                >
+                  <IconGlyph path={item.path} />
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/GalleryEditorView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/GalleryEditorView.tsx
@@ -1,0 +1,1721 @@
+// odysseus Gallery Editor (static/js/galleryEditor.js + the whole editor/
+// subdir). A canvas image editor: a top toolbar (undo/redo/history, zoom group,
+// Image + Filter menus, Shortcuts, Import, Save), a left tool palette (Move /
+// Crop / Transform / Brush / Eraser / Clone / Lasso / Wand / Inpaint / Bg
+// Remove / Sharpen), a central canvas stage with a checkerboard transparency
+// backdrop, a right panel of per-tool option sliders + a LAYERS list, a
+// floating HISTORY popover, and a keyboard-shortcuts cheatsheet. The full
+// editor CHROME is cloned pixel-exact from odysseus's build/toolbar.js,
+// build/topbar.js, build/controls.js, build/right-panel.js, build/popups.js,
+// layer-panel.js, and history-panel.js.
+//
+// elizaMapping: odysseus's editor is server-backed — the canvas drawing engine,
+// undo stack, layer compositor, and the AI tools (inpaint / outpaint / remove /
+// bg-remove / sharpen / harmonize / style) all live behind a Python image
+// backend (POST a flattened PNG → get a result layer). eliza exposes NO
+// frontend-callable image / canvas / diffusion backend (grepped the @elizaos/ui
+// `client` singleton — only model *config* fetch exists). So this is the honest
+// no-eliza-equivalent path: every control is present and pixel-exact so the
+// editor lights up 1:1 the moment a canvas backend exists, but the central
+// stage renders odysseus's faithful empty "load or generate an image to edit"
+// affordance instead of a fabricated canvas, the layer list is empty (no demo
+// layers), the history popover shows only the genuine "Current" marker, and the
+// AI / inpaint model dropdowns are populated from the REAL provider model lists
+// via client.fetchModels(provider) — the same /api/models endpoint the gallery
+// + compare + settings surfaces use. No fabricated canvas pixels, layers, undo
+// states, or AI results are ever shown.
+
+import { client } from "@elizaos/ui";
+import {
+  Eraser,
+  Image as ImageIcon,
+  Minus,
+  Paintbrush,
+  Redo2,
+  RotateCcw,
+  Sparkles,
+  Undo2,
+  Upload,
+  Wand2,
+  X,
+} from "lucide-react";
+import { type ReactNode, useEffect, useState } from "react";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+
+// Providers whose model lists feed the AI / inpaint model dropdowns — the same
+// real /api/models fetch keys CompareView + GalleryView use.
+const PROVIDERS = [
+  "openai",
+  "anthropic",
+  "google",
+  "openrouter",
+  "groq",
+  "xai",
+  "ollama",
+] as const;
+
+// Honest disabled-control tooltip. eliza exposes no frontend image / canvas /
+// diffusion backend, so every control that would mutate pixels (menu actions,
+// AI buttons, selection-edit buttons) is disabled with this shared title
+// instead of rendering an enabled control that routes nowhere.
+const NO_BACKEND = "No image backend is connected yet";
+
+// odysseus editor/build/toolbar.js `tools` — the left tool palette, including
+// the AI-tools (✦) flag and the keyboard hint. `sep` rows render a labeled
+// separator (the label is blank in odysseus but the separator rule stays).
+type ToolId =
+  | "move"
+  | "crop"
+  | "transform"
+  | "brush"
+  | "eraser"
+  | "clone"
+  | "lasso"
+  | "wand"
+  | "inpaint"
+  | "rembg"
+  | "sharpen";
+
+interface ToolDef {
+  id: ToolId;
+  label: string;
+  key?: string;
+  ai?: boolean;
+}
+
+interface SepDef {
+  sep: true;
+}
+
+const TOOLS: ReadonlyArray<ToolDef | SepDef> = [
+  { id: "move", label: "Move", key: "V" },
+  { id: "crop", label: "Crop", key: "C" },
+  { id: "transform", label: "Transform", key: "T" },
+  { sep: true },
+  { id: "brush", label: "Brush", key: "B" },
+  { id: "eraser", label: "Eraser", key: "E" },
+  { sep: true },
+  { id: "clone", label: "Clone", key: "K" },
+  { id: "lasso", label: "Lasso", key: "L" },
+  { id: "wand", label: "Wand", key: "W" },
+  { sep: true },
+  { id: "inpaint", label: "Inpaint", key: "M", ai: true },
+  { id: "rembg", label: "Bg Remove", ai: true },
+  { id: "sharpen", label: "Sharpen", key: "S", ai: true },
+];
+
+function isSep(t: ToolDef | SepDef): t is SepDef {
+  return "sep" in t;
+}
+
+// odysseus toolbar.js per-tool icon SVGs — Move/Crop/Transform/Lasso are
+// unicode glyphs; the rest are lucide-react icons matching odysseus's inline
+// SVG paths (Brush ↔ Paintbrush, Eraser, Clone ↔ stamp, Wand, Inpaint ↔
+// Paintbrush, Bg Remove ↔ scissors glyph, Sharpen ↔ ◈ glyph).
+function ToolIcon({ id }: { id: ToolId }): ReactNode {
+  if (id === "move") return <span className="ge-tool-glyph">✥</span>;
+  if (id === "crop") return <span className="ge-tool-glyph">✂</span>;
+  if (id === "transform") return <span className="ge-tool-glyph">⤢</span>;
+  if (id === "lasso") return <span className="ge-tool-glyph">⟡</span>;
+  if (id === "rembg") return <span className="ge-tool-glyph">✄</span>;
+  if (id === "sharpen") return <span className="ge-tool-glyph">◈</span>;
+  if (id === "brush" || id === "inpaint") return <Paintbrush size={18} />;
+  if (id === "eraser") return <Eraser size={18} />;
+  if (id === "wand") return <Wand2 size={18} />;
+  // clone
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label="Clone"
+    >
+      <circle cx="12" cy="9" r="3" />
+      <path d="M9 12l-3 4h12l-3-4" />
+      <path d="M4 20h16" />
+    </svg>
+  );
+}
+
+// Log-scale brush slider position (controls.js: log(size)/log(800)*1000).
+function brushSliderValue(size: number): number {
+  return Math.round((Math.log(Math.max(1, size)) / Math.log(800)) * 1000);
+}
+
+// Selection-action button icons — match odysseus controls.js inline SVGs for
+// the Lasso / Wand action rows (invert ↔ swap arrows, delete ↔ X, erase ↔
+// trash, copy ↔ overlapping rects, mask ↔ wand). 12×12 to sit in .ge-btn-sm.
+type SelectionIconKind = "invert" | "delete" | "erase" | "copy" | "mask";
+
+function SelectionIcon({ kind }: { kind: SelectionIconKind }): ReactNode {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      role="img"
+      aria-label={kind}
+    >
+      {kind === "invert" ? (
+        <>
+          <polyline points="17 1 21 5 17 9" />
+          <path d="M3 11V9a4 4 0 0 1 4-4h14" />
+          <polyline points="7 23 3 19 7 15" />
+          <path d="M21 13v2a4 4 0 0 1-4 4H3" />
+        </>
+      ) : null}
+      {kind === "delete" ? (
+        <>
+          <line x1="6" y1="6" x2="18" y2="18" />
+          <line x1="18" y1="6" x2="6" y2="18" />
+        </>
+      ) : null}
+      {kind === "erase" ? (
+        <path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6" />
+      ) : null}
+      {kind === "copy" ? (
+        <>
+          <rect x="9" y="9" width="13" height="13" rx="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </>
+      ) : null}
+      {kind === "mask" ? (
+        <>
+          <path d="M9.06 11.9l8.07-8.06a2.85 2.85 0 1 1 4.03 4.03l-8.06 8.08" />
+          <path d="M7.07 14.94c-1.66 0-3 1.35-3 3.02 0 1.33-2.5 1.52-2 2.02 1.08 1.1 2.49 2.02 4 2.02 2.2 0 4-1.8 4-4.04a3.01 3.01 0 0 0-3-3.02z" />
+        </>
+      ) : null}
+    </svg>
+  );
+}
+
+// A stroke-modifier slider row (Opacity / Flow / Softness) — shared by the
+// Brush / Eraser / Clone sections (controls.js .ge-eraser-row). Read-only here
+// (no canvas engine to drive), matching odysseus's default values.
+function StrokeRow({
+  previewId,
+  label,
+  value,
+  min,
+  max,
+}: {
+  previewId: string;
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+}): ReactNode {
+  const sliderId = `${previewId}-slider`;
+  return (
+    <div className="ge-control-row ge-eraser-row">
+      <span className="ge-eraser-preview" id={previewId} aria-hidden="true" />
+      <label htmlFor={sliderId}>{label}</label>
+      <input
+        id={sliderId}
+        type="range"
+        min={min}
+        max={max}
+        value={value}
+        readOnly
+      />
+      <span className="ge-slider-value">{value}%</span>
+    </div>
+  );
+}
+
+export function GalleryEditorView({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}): ReactNode {
+  useEscapeClose(open, onClose);
+  const win = useWindowControls(
+    "win-editor",
+    { w: 1280, h: 900 },
+    { label: "Image Editor", icon: "Pencil", onClose },
+  );
+  const [tool, setTool] = useState<ToolId>("move");
+  const [models, setModels] = useState<string[]>([]);
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  const [imageMenuOpen, setImageMenuOpen] = useState(false);
+  const [filterMenuOpen, setFilterMenuOpen] = useState(false);
+  const [saveMenuOpen, setSaveMenuOpen] = useState(false);
+  const [inpaintMode, setInpaintMode] = useState<"paint" | "erase">("paint");
+  const [wandMode, setWandMode] = useState<"replace" | "add" | "subtract">(
+    "replace",
+  );
+
+  // Populate the AI / inpaint model dropdowns from the REAL provider model
+  // lists (same /api/models endpoint the other surfaces use). Failures are
+  // non-fatal — the dropdown simply shows fewer models.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void Promise.all(
+      PROVIDERS.map((provider) =>
+        client
+          .fetchModels(provider)
+          .then((r): string[] => r.models.map((m) => m.name))
+          .catch((): string[] => []),
+      ),
+    ).then((lists) => {
+      if (cancelled) return;
+      setModels(Array.from(new Set(lists.flat())).sort());
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  // Which per-tool section the right panel shows (galleryEditor.js tool-switch).
+  const showBrushControls =
+    tool === "brush" || tool === "eraser" || tool === "clone";
+  const showColorRow = tool === "brush";
+
+  return (
+    <div
+      className={`od-search-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Gallery editor"
+    >
+      <button
+        type="button"
+        aria-label="Close editor"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel od-ge-panel" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        <div className="gallery-editor">
+          {/* ── Top bar (editor/build/topbar.js buildTopbar) ── */}
+          <div
+            className="ge-topbar od-window-header"
+            onPointerDown={win.onDragStart}
+          >
+            <div className="ge-topbar-left">
+              <span
+                className="ge-alpha-badge"
+                title="This editor is in active development — expect rough edges"
+              >
+                ALPHA
+              </span>
+              <button
+                type="button"
+                className="ge-btn ge-btn-sm ge-stacked-btn"
+                title="Undo"
+                disabled
+              >
+                <span className="ge-stacked-glyph">
+                  <Undo2 size={14} />
+                </span>
+                <span className="ge-stacked-label">UNDO</span>
+              </button>
+              <button
+                type="button"
+                className="ge-btn ge-btn-sm ge-stacked-btn"
+                title="Redo"
+                disabled
+              >
+                <span className="ge-stacked-glyph">
+                  <Redo2 size={14} />
+                </span>
+                <span className="ge-stacked-label">REDO</span>
+              </button>
+              <button
+                type="button"
+                className="ge-btn ge-btn-sm ge-stacked-btn"
+                title="History — click an entry to jump to that state"
+                aria-label="History"
+                onClick={() => setHistoryOpen((v) => !v)}
+              >
+                <span className="ge-stacked-glyph">
+                  <RotateCcw size={14} />
+                </span>
+                <span className="ge-stacked-label">HISTORY</span>
+              </button>
+              <span className="ge-topbar-sep" />
+              <button
+                type="button"
+                className="ge-btn ge-btn-sm"
+                title={NO_BACKEND}
+                aria-label="Zoom out"
+                disabled
+              >
+                −
+              </button>
+              <span className="ge-zoom-stack">
+                <span className="ge-zoom-glyph">
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    role="img"
+                    aria-label="Zoom"
+                  >
+                    <circle cx="11" cy="11" r="7" />
+                    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+                  </svg>
+                </span>
+                <span className="ge-zoom-label">100%</span>
+              </span>
+              <button
+                type="button"
+                className="ge-btn ge-btn-sm"
+                title={NO_BACKEND}
+                aria-label="Zoom in"
+                disabled
+              >
+                +
+              </button>
+              <span className="ge-topbar-sep" />
+              <button
+                type="button"
+                className="ge-btn ge-btn-sm ge-stacked-btn"
+                title={NO_BACKEND}
+                aria-label="Fit to view"
+                disabled
+              >
+                <span className="ge-stacked-glyph">
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    role="img"
+                    aria-label="Fit"
+                  >
+                    <polyline points="4 14 4 20 10 20" />
+                    <polyline points="20 10 20 4 14 4" />
+                    <line x1="14" y1="10" x2="21" y2="3" />
+                    <line x1="3" y1="21" x2="10" y2="14" />
+                  </svg>
+                </span>
+                <span className="ge-stacked-label">FIT</span>
+              </button>
+              <button
+                type="button"
+                className="ge-btn ge-btn-sm ge-stacked-btn"
+                title={NO_BACKEND}
+                aria-label="Actual size"
+                disabled
+              >
+                <span className="ge-stacked-glyph">1:1</span>
+                <span className="ge-stacked-label">SCALE</span>
+              </button>
+              <span className="ge-topbar-sep" />
+            </div>
+            <div className="ge-topbar-right">
+              <div className="ge-image-wrap">
+                <button
+                  type="button"
+                  className="ge-btn ge-btn-sm"
+                  title="Image actions"
+                  aria-haspopup="true"
+                  onClick={() => {
+                    setImageMenuOpen((v) => !v);
+                    setFilterMenuOpen(false);
+                    setSaveMenuOpen(false);
+                  }}
+                >
+                  Image ▾
+                </button>
+                {imageMenuOpen ? (
+                  <div className="ge-image-menu dropdown" role="menu">
+                    <button
+                      type="button"
+                      className="dropdown-item-compact"
+                      disabled
+                      title={NO_BACKEND}
+                    >
+                      <span className="dropdown-icon">⤢</span>
+                      <span>Canvas…</span>
+                    </button>
+                    <div className="ge-filter-submenu-label">Transform</div>
+                    <button
+                      type="button"
+                      className="dropdown-item-compact"
+                      disabled
+                      title={NO_BACKEND}
+                    >
+                      <span className="dropdown-icon">↻</span>
+                      <span>Rotate 90° CW</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="dropdown-item-compact"
+                      disabled
+                      title={NO_BACKEND}
+                    >
+                      <span className="dropdown-icon">↺</span>
+                      <span>Rotate 180°</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="dropdown-item-compact"
+                      disabled
+                      title={NO_BACKEND}
+                    >
+                      <span className="dropdown-icon">⇆</span>
+                      <span>Flip horizontal</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="dropdown-item-compact"
+                      disabled
+                      title={NO_BACKEND}
+                    >
+                      <span className="dropdown-icon">⇅</span>
+                      <span>Flip vertical</span>
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+              <div className="ge-filter-wrap">
+                <button
+                  type="button"
+                  className="ge-btn ge-btn-sm"
+                  title="Filters"
+                  aria-haspopup="true"
+                  onClick={() => {
+                    setFilterMenuOpen((v) => !v);
+                    setImageMenuOpen(false);
+                    setSaveMenuOpen(false);
+                  }}
+                >
+                  Filter ▾
+                </button>
+                {filterMenuOpen ? (
+                  <div className="ge-filter-menu dropdown" role="menu">
+                    <div className="ge-filter-submenu-label">Blur</div>
+                    <button
+                      type="button"
+                      className="dropdown-item-compact"
+                      disabled
+                      title={NO_BACKEND}
+                    >
+                      <span className="dropdown-icon">◍</span>
+                      <span>Gaussian Blur…</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="dropdown-item-compact"
+                      disabled
+                      title={NO_BACKEND}
+                    >
+                      <span className="dropdown-icon">◎</span>
+                      <span>Zoom Blur…</span>
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+              <span className="ge-topbar-sep" />
+              <button
+                type="button"
+                className="ge-btn ge-btn-sm"
+                title="Keyboard shortcuts (?)"
+                aria-label="Shortcuts"
+                onClick={() => setShortcutsOpen((v) => !v)}
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  role="img"
+                  aria-label="Shortcuts"
+                >
+                  <rect x="2" y="6" width="20" height="12" rx="2" />
+                  <path d="M6 10h.01M10 10h.01M14 10h.01M18 10h.01M7 14h10" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                className="ge-btn ge-btn-sm"
+                title={NO_BACKEND}
+                aria-label="Import image as layer"
+                disabled
+              >
+                + Import
+              </button>
+              <div className="ge-save-wrap">
+                <button
+                  type="button"
+                  className="ge-btn ge-btn-primary ge-save-menu-btn"
+                  title="Save options"
+                  onClick={() => {
+                    setSaveMenuOpen((v) => !v);
+                    setImageMenuOpen(false);
+                    setFilterMenuOpen(false);
+                  }}
+                >
+                  Save
+                  <svg
+                    width="9"
+                    height="9"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    role="img"
+                    aria-label="Save options"
+                  >
+                    <polyline points="6 9 12 15 18 9" />
+                  </svg>
+                </button>
+                {saveMenuOpen ? (
+                  <div className="ge-save-menu dropdown" role="menu">
+                    <div className="dropdown-section-label">Image</div>
+                    <button
+                      type="button"
+                      className="dropdown-item-compact"
+                      disabled
+                      title={NO_BACKEND}
+                    >
+                      <span>Save over original</span>
+                      <span className="dropdown-shortcut">Ctrl+S</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="dropdown-item-compact"
+                      disabled
+                      title={NO_BACKEND}
+                    >
+                      <span>Save as copy</span>
+                      <span className="dropdown-shortcut">Ctrl+Shift+S</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="dropdown-item-compact"
+                      disabled
+                      title={NO_BACKEND}
+                    >
+                      <span>Download PNG</span>
+                    </button>
+                    <div className="dropdown-section-divider" />
+                    <div className="dropdown-section-label">Project</div>
+                    <button
+                      type="button"
+                      className="dropdown-item-compact"
+                      disabled
+                      title={NO_BACKEND}
+                    >
+                      <span>Save project (.json)</span>
+                    </button>
+                    <button
+                      type="button"
+                      className="dropdown-item-compact"
+                      disabled
+                      title={NO_BACKEND}
+                    >
+                      <span>Load project…</span>
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                className="od-window-min-btn"
+                onClick={win.minimize}
+                title="Minimize"
+                aria-label="Minimize"
+              >
+                <Minus size={14} aria-hidden="true" />
+              </button>
+              <button
+                type="button"
+                className="ge-ge-close"
+                aria-label="Close editor"
+                title="Close editor"
+                onClick={onClose}
+              >
+                <X size={16} />
+              </button>
+            </div>
+          </div>
+
+          {/* ── Editor body (toolbar + canvas + right panel) ── */}
+          <div className="ge-editor-body">
+            {/* Left tool palette (editor/build/toolbar.js) */}
+            <div className="ge-toolbar">
+              {TOOLS.map((t, i) =>
+                isSep(t) ? (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: separators carry no id and never reorder.
+                  <div className="ge-tool-sep" key={`sep-${i}`} />
+                ) : (
+                  <button
+                    type="button"
+                    key={t.id}
+                    className={`ge-tool-btn${t.id === tool ? " active" : ""}${t.ai ? " is-ai" : ""}`}
+                    title={t.label + (t.key ? ` (${t.key})` : "")}
+                    onClick={() => setTool(t.id)}
+                  >
+                    {t.ai ? (
+                      <span className="ge-tool-ai" title="AI">
+                        ✦
+                      </span>
+                    ) : null}
+                    <span className="ge-tool-icon">
+                      <ToolIcon id={t.id} />
+                    </span>
+                    <span className="ge-tool-label">{t.label}</span>
+                  </button>
+                ),
+              )}
+            </div>
+
+            {/* Canvas area (center) — honest empty stage. No canvas backend in
+                eliza, so render the checkerboard stage with odysseus's
+                "load / generate an image to edit" landing instead of a
+                fabricated canvas. */}
+            <div className="ge-canvas-area">
+              <div className="gallery-editor-landing">
+                <ImageIcon size={40} strokeWidth={1.25} aria-hidden="true" />
+                <h3>
+                  Image editor <span className="ge-alpha-tag">Alpha</span>
+                </h3>
+                <p>
+                  Load an image from the gallery or generate one to start
+                  editing. The canvas, layers, and AI tools light up once an
+                  image backend is connected.
+                </p>
+                <div className="gallery-editor-landing-actions">
+                  <button
+                    type="button"
+                    className="ge-btn ge-ge-landing-btn"
+                    disabled
+                    title={NO_BACKEND}
+                  >
+                    <Upload size={14} />
+                    Import image
+                  </button>
+                  <button
+                    type="button"
+                    className="ge-btn ge-ge-landing-btn"
+                    disabled
+                    title={NO_BACKEND}
+                  >
+                    <Sparkles size={14} />
+                    Generate image
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {/* Right panel (controls + layers) — editor/build/right-panel.js */}
+            <div className="ge-right-panel">
+              <div className="ge-controls">
+                {/* Brush controls — Color + Size (controls.js #ge-brush-controls) */}
+                {showBrushControls ? (
+                  <div className="ge-brush-controls">
+                    {showColorRow ? (
+                      <div className="ge-control-row ge-color-row">
+                        <label htmlFor="ge-color-picker">Color</label>
+                        <input
+                          id="ge-color-picker"
+                          type="color"
+                          className="ge-color-picker"
+                          value="#ff3b3b"
+                          readOnly
+                        />
+                      </div>
+                    ) : null}
+                    <div className="ge-control-row">
+                      <label htmlFor="ge-size-slider">
+                        {tool === "eraser" ? "Brush Size " : "Size "}
+                        <span className="ge-size-label">12px</span>
+                      </label>
+                      <input
+                        id="ge-size-slider"
+                        type="range"
+                        className="ge-size-slider"
+                        min={0}
+                        max={1000}
+                        value={brushSliderValue(12)}
+                        readOnly
+                      />
+                    </div>
+                  </div>
+                ) : null}
+
+                {/* Brush section (Opacity / Flow / Softness) */}
+                {tool === "brush" ? (
+                  <div className="ge-eraser-section">
+                    <div className="ge-section-title">Brush</div>
+                    <StrokeRow
+                      previewId="ge-brush-preview-opacity"
+                      label="Opacity"
+                      value={100}
+                      min={10}
+                      max={100}
+                    />
+                    <StrokeRow
+                      previewId="ge-brush-preview-flow"
+                      label="Flow"
+                      value={100}
+                      min={5}
+                      max={100}
+                    />
+                    <StrokeRow
+                      previewId="ge-brush-preview-softness"
+                      label="Softness"
+                      value={100}
+                      min={0}
+                      max={300}
+                    />
+                  </div>
+                ) : null}
+
+                {/* Eraser section */}
+                {tool === "eraser" ? (
+                  <div className="ge-eraser-section">
+                    <div className="ge-section-title">Eraser</div>
+                    <StrokeRow
+                      previewId="ge-eraser-preview-opacity"
+                      label="Opacity"
+                      value={100}
+                      min={10}
+                      max={100}
+                    />
+                    <StrokeRow
+                      previewId="ge-eraser-preview-flow"
+                      label="Flow"
+                      value={100}
+                      min={5}
+                      max={100}
+                    />
+                    <StrokeRow
+                      previewId="ge-eraser-preview-softness"
+                      label="Softness"
+                      value={100}
+                      min={0}
+                      max={300}
+                    />
+                  </div>
+                ) : null}
+
+                {/* Clone section */}
+                {tool === "clone" ? (
+                  <div className="ge-eraser-section">
+                    <div className="ge-section-title ge-section-title-with-help">
+                      <span>Clone</span>
+                      <span
+                        className="ge-section-help"
+                        role="img"
+                        aria-label="How clone works"
+                        title="Alt-click somewhere on the canvas to set the sample source, then drag elsewhere to clone those pixels onto the active layer."
+                      >
+                        ?
+                      </span>
+                    </div>
+                    <p className="ge-section-hint">
+                      <strong>Alt-click</strong> to set source · drag to paint
+                    </p>
+                    <StrokeRow
+                      previewId="ge-clone-preview-opacity"
+                      label="Opacity"
+                      value={100}
+                      min={10}
+                      max={100}
+                    />
+                    <StrokeRow
+                      previewId="ge-clone-preview-flow"
+                      label="Flow"
+                      value={100}
+                      min={5}
+                      max={100}
+                    />
+                    <StrokeRow
+                      previewId="ge-clone-preview-softness"
+                      label="Softness"
+                      value={100}
+                      min={0}
+                      max={300}
+                    />
+                  </div>
+                ) : null}
+
+                {/* Lasso section (controls.js #ge-lasso-section). The
+                    selection-edit actions operate on a live mask, so without a
+                    canvas backend they are honestly disabled. */}
+                {tool === "lasso" ? (
+                  <div className="ge-lasso-section">
+                    <div className="ge-control-row ge-actions ge-ge-actions-wrap">
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-sm ge-btn-iconlabel"
+                        title={NO_BACKEND}
+                        disabled
+                      >
+                        <SelectionIcon kind="invert" />
+                        Invert
+                      </button>
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-sm ge-btn-iconlabel"
+                        title={NO_BACKEND}
+                        disabled
+                      >
+                        <SelectionIcon kind="delete" />
+                        Delete
+                      </button>
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-sm ge-btn-iconlabel"
+                        title={NO_BACKEND}
+                        disabled
+                      >
+                        <SelectionIcon kind="copy" />
+                        Copy Layer
+                      </button>
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-sm ge-btn-iconlabel"
+                        title={NO_BACKEND}
+                        disabled
+                      >
+                        <SelectionIcon kind="mask" />
+                        To Mask
+                      </button>
+                    </div>
+                    <p className="ge-ge-tiny-hint">
+                      Draw a freehand selection. Esc to cancel.
+                    </p>
+                  </div>
+                ) : null}
+
+                {/* Wand section */}
+                {tool === "wand" ? (
+                  <div className="ge-wand-section">
+                    <div className="ge-control-row ge-ge-mode-row">
+                      <button
+                        type="button"
+                        className={`ge-btn ge-btn-sm ge-wand-mode-btn${wandMode === "replace" ? " active" : ""}`}
+                        title="Replace selection on each click"
+                        onClick={() => setWandMode("replace")}
+                      >
+                        New
+                      </button>
+                      <button
+                        type="button"
+                        className={`ge-btn ge-btn-sm ge-wand-mode-btn${wandMode === "add" ? " active" : ""}`}
+                        title="Add to selection (Shift)"
+                        onClick={() => setWandMode("add")}
+                      >
+                        + Add
+                      </button>
+                      <button
+                        type="button"
+                        className={`ge-btn ge-btn-sm ge-wand-mode-btn${wandMode === "subtract" ? " active" : ""}`}
+                        title="Subtract from selection (Alt)"
+                        onClick={() => setWandMode("subtract")}
+                      >
+                        − Subtract
+                      </button>
+                    </div>
+                    <div className="ge-control-row ge-eraser-row">
+                      <span
+                        className="ge-eraser-preview"
+                        id="ge-wand-tol-preview"
+                        aria-hidden="true"
+                      />
+                      <label htmlFor="ge-wand-tolerance">
+                        Tolerance <span className="ge-slider-value">32</span>
+                      </label>
+                      {/* Live retune toggle — re-runs the flood fill while the
+                          tolerance slider drags. Needs an active selection, so
+                          honestly disabled without a canvas backend. */}
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-sm ge-wand-live-btn"
+                        title={NO_BACKEND}
+                        aria-pressed="false"
+                        disabled
+                      >
+                        Live
+                      </button>
+                      <input
+                        id="ge-wand-tolerance"
+                        type="range"
+                        min={0}
+                        max={100}
+                        value={32}
+                        readOnly
+                      />
+                    </div>
+                    {/* Selection-edge refine rows (controls.js #ge-wand-refine-*).
+                        They retune an existing selection's mask alpha, so without
+                        a canvas backend they sit in their honest disabled state. */}
+                    <div className="ge-control-row ge-eraser-row ge-sel-refine">
+                      <span
+                        className="ge-eraser-preview"
+                        id="ge-wand-feather-preview"
+                        aria-hidden="true"
+                      />
+                      <label htmlFor="ge-wand-feather">
+                        Feather <span className="ge-slider-value">0px</span>
+                      </label>
+                      <input
+                        id="ge-wand-feather"
+                        type="range"
+                        min={0}
+                        max={200}
+                        value={0}
+                        title={NO_BACKEND}
+                        disabled
+                      />
+                    </div>
+                    <div className="ge-control-row ge-eraser-row ge-sel-refine">
+                      <span
+                        className="ge-eraser-preview"
+                        id="ge-wand-grow-preview"
+                        aria-hidden="true"
+                      />
+                      <label htmlFor="ge-wand-grow">
+                        Edge stroke <span className="ge-slider-value">0px</span>
+                      </label>
+                      <input
+                        id="ge-wand-grow"
+                        type="range"
+                        min={-40}
+                        max={40}
+                        value={0}
+                        title={NO_BACKEND}
+                        disabled
+                      />
+                    </div>
+                    {/* Visibility toggle + selection-edit action row
+                        (controls.js #ge-wand-vis / clear / invert / delete /
+                        copy / mask). All operate on a live selection. */}
+                    <div className="ge-control-row ge-actions ge-ge-actions-wrap">
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-sm ge-mask-vis-btn visible"
+                        title={NO_BACKEND}
+                        aria-label="Toggle selection overlay"
+                        disabled
+                      >
+                        <svg
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          role="img"
+                          aria-label="Selection overlay"
+                        >
+                          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                          <circle cx="12" cy="12" r="3" />
+                        </svg>
+                      </button>
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-sm ge-btn-iconlabel"
+                        title={NO_BACKEND}
+                        disabled
+                      >
+                        <SelectionIcon kind="delete" />
+                        Clear
+                      </button>
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-sm ge-btn-iconlabel"
+                        title={NO_BACKEND}
+                        disabled
+                      >
+                        <SelectionIcon kind="invert" />
+                        Invert
+                      </button>
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-sm ge-btn-iconlabel"
+                        title={NO_BACKEND}
+                        disabled
+                      >
+                        <SelectionIcon kind="erase" />
+                        Erase
+                      </button>
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-sm ge-btn-iconlabel"
+                        title={NO_BACKEND}
+                        disabled
+                      >
+                        <SelectionIcon kind="copy" />
+                        Copy Layer
+                      </button>
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-sm ge-btn-iconlabel"
+                        title={NO_BACKEND}
+                        disabled
+                      >
+                        <SelectionIcon kind="mask" />
+                        To Mask
+                      </button>
+                    </div>
+                    <p className="ge-ge-tiny-hint">
+                      Click a region to select similar pixels. Shift+click to
+                      add, Alt+click to subtract. Esc to clear.
+                    </p>
+                  </div>
+                ) : null}
+
+                {/* Inpaint section (controls.js .ge-inpaint-section) */}
+                {tool === "inpaint" ? (
+                  <div className="ge-inpaint-section">
+                    {/* Popover drag-head (controls.js .ge-inpaint-popover-head).
+                        In odysseus this header only shows once the section is
+                        torn off into a floating popover over the canvas; inline
+                        in the right panel it stays hidden (matched in CSS). The
+                        close control returns to the Move tool. */}
+                    <div className="ge-inpaint-popover-head">
+                      <div className="ge-section-title ge-section-title-with-help ge-inpaint-popover-title">
+                        <span>INPAINT</span>
+                      </div>
+                      <button
+                        type="button"
+                        className="ge-inpaint-popover-close"
+                        title="Close inpaint panel"
+                        aria-label="Close inpaint panel"
+                        onClick={() => setTool("move")}
+                      >
+                        <X size={14} />
+                      </button>
+                    </div>
+                    <div className="ge-section-title ge-section-title-with-help">
+                      <span>INPAINT</span>
+                      <span
+                        className="ge-section-help"
+                        role="img"
+                        aria-label="How inpaint works"
+                        title="Brush the area you want the AI to redraw — the red preview marks the mask region. Generate fills with what your prompt describes; Remove fills with the surrounding background."
+                      >
+                        ?
+                      </span>
+                    </div>
+                    <p className="ge-section-hint">
+                      Generates or removes from the mask you have selected. Set{" "}
+                      <strong>Strength</strong> before and adjust{" "}
+                      <strong>Edge feather / stroke</strong> after.
+                    </p>
+                    <div className="ge-section-title ge-ge-mask-brush-title">
+                      <span>Mask Brush</span>
+                      <input
+                        type="color"
+                        className="ge-color-picker ge-inpaint-mask-color"
+                        value="#ff6e6e"
+                        readOnly
+                        title="Mask overlay color"
+                      />
+                    </div>
+                    <div className="ge-control-row ge-ge-mode-row">
+                      <button
+                        type="button"
+                        className={`ge-btn ge-btn-sm ge-inpaint-mode-btn ge-ge-mode-half${inpaintMode === "paint" ? " active" : ""}`}
+                        onClick={() => setInpaintMode("paint")}
+                      >
+                        Paint
+                      </button>
+                      <button
+                        type="button"
+                        className={`ge-btn ge-btn-sm ge-inpaint-mode-btn ge-ge-mode-half${inpaintMode === "erase" ? " active" : ""}`}
+                        onClick={() => setInpaintMode("erase")}
+                      >
+                        Erase
+                      </button>
+                    </div>
+                    <div className="ge-control-row ge-eraser-row">
+                      <span
+                        className="ge-eraser-preview"
+                        id="ge-inpaint-brush-preview"
+                        aria-hidden="true"
+                      />
+                      <label htmlFor="ge-inpaint-brush-slider">
+                        Mask Brush Size
+                      </label>
+                      <input
+                        type="range"
+                        id="ge-inpaint-brush-slider"
+                        min={0}
+                        max={1000}
+                        value={brushSliderValue(100)}
+                        readOnly
+                      />
+                      <span className="ge-slider-value">100px</span>
+                    </div>
+                    <div className="ge-control-row ge-actions ge-inpaint-mask-row">
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-sm ge-mask-vis-btn visible"
+                        title={NO_BACKEND}
+                        aria-label="Toggle mask"
+                        disabled
+                      >
+                        <svg
+                          width="12"
+                          height="12"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          role="img"
+                          aria-label="Toggle mask"
+                        >
+                          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                          <circle cx="12" cy="12" r="3" />
+                        </svg>
+                        <span>Hide</span>
+                      </button>
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-sm ge-btn-iconlabel"
+                        title={NO_BACKEND}
+                        disabled
+                      >
+                        Invert
+                      </button>
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-sm ge-btn-iconlabel"
+                        title={NO_BACKEND}
+                        disabled
+                      >
+                        Clear
+                      </button>
+                    </div>
+                    <hr className="ge-section-divider" />
+                    <div className="ge-section-title">
+                      <span>PROMPT</span>
+                    </div>
+                    <input
+                      type="text"
+                      className="ge-inpaint-prompt"
+                      placeholder="What to fill the masked area with..."
+                      aria-label="Inpaint prompt"
+                    />
+                    <div className="ge-control-row ge-inpaint-model-row ge-ge-model-row">
+                      <label htmlFor="ge-ai-inpaint">Model</label>
+                      <select
+                        id="ge-ai-inpaint"
+                        className="ge-ai-model"
+                        title="Model for inpainting"
+                      >
+                        <option value="">Auto</option>
+                        {models.map((m) => (
+                          <option key={m} value={m}>
+                            {m}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                    <div className="ge-control-row ge-eraser-row ge-ge-strength-row">
+                      <span
+                        className="ge-eraser-preview"
+                        id="ge-strength-preview"
+                        aria-hidden="true"
+                      />
+                      <label htmlFor="ge-strength-slider">Strength</label>
+                      <input
+                        id="ge-strength-slider"
+                        type="range"
+                        min={10}
+                        max={100}
+                        value={75}
+                        readOnly
+                      />
+                      <span className="ge-slider-value">0.75</span>
+                    </div>
+                    <div className="ge-control-row ge-actions ge-ge-ai-actions">
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-primary ge-btn-ai ge-ge-ai-btn"
+                        disabled
+                        title={NO_BACKEND}
+                      >
+                        <span className="ge-btn-ai-mark" aria-hidden="true">
+                          ✦
+                        </span>
+                        Generate
+                      </button>
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-ai ge-ge-ai-btn"
+                        disabled
+                        title={NO_BACKEND}
+                      >
+                        <span className="ge-btn-ai-mark" aria-hidden="true">
+                          ✦
+                        </span>
+                        Remove
+                      </button>
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-ai ge-ge-ai-btn"
+                        disabled
+                        title={NO_BACKEND}
+                      >
+                        <span className="ge-btn-ai-mark" aria-hidden="true">
+                          ✦
+                        </span>
+                        Outpaint
+                      </button>
+                    </div>
+                    {/* POSTPROCESS group (controls.js #ge-inpaint-postedge-*).
+                        Live edge-trimming of the last inpaint-result layer. The
+                        sliders only exist once a Generate has produced a result
+                        layer — so honestly they sit in the "Available after
+                        Generate" state, with the edit sliders disabled. */}
+                    <hr className="ge-section-divider" />
+                    <div className="ge-section-title ge-section-title-with-help">
+                      <span>POSTPROCESS</span>
+                      <span
+                        className="ge-section-help"
+                        role="img"
+                        aria-label="What this does"
+                        title="Live edge trimming for the last Inpaint Result layer. Edge feather softens the alpha boundary; Edge stroke expands (+) or contracts (−) the visible edge into the AI buffer generated around your brush."
+                      >
+                        ?
+                      </span>
+                    </div>
+                    <p className="ge-section-hint ge-ge-postedge-hint">
+                      Available after Generate.
+                    </p>
+                    <div className="ge-control-row ge-eraser-row">
+                      <span
+                        className="ge-eraser-preview"
+                        id="ge-feather-preview"
+                        aria-hidden="true"
+                      />
+                      <label htmlFor="ge-feather-slider">
+                        Edge feather{" "}
+                        <span className="ge-slider-value">0px</span>
+                      </label>
+                      <input
+                        id="ge-feather-slider"
+                        type="range"
+                        min={0}
+                        max={200}
+                        value={0}
+                        title={NO_BACKEND}
+                        disabled
+                      />
+                    </div>
+                    <div className="ge-control-row ge-eraser-row">
+                      <span
+                        className="ge-eraser-preview"
+                        id="ge-edgestroke-preview"
+                        aria-hidden="true"
+                      />
+                      <label htmlFor="ge-edgestroke-slider">
+                        Edge stroke <span className="ge-slider-value">0px</span>
+                      </label>
+                      <input
+                        id="ge-edgestroke-slider"
+                        type="range"
+                        min={-80}
+                        max={80}
+                        value={0}
+                        title={NO_BACKEND}
+                        disabled
+                      />
+                    </div>
+                  </div>
+                ) : null}
+
+                {/* Bg Remove section (controls.js .ge-rembg-section) */}
+                {tool === "rembg" ? (
+                  <div className="ge-rembg-section">
+                    <div className="ge-section-title ge-section-title-with-help">
+                      <span>Background Remove</span>
+                      <span
+                        className="ge-section-help"
+                        role="img"
+                        aria-label="What this does"
+                        title="Runs an ML model that keeps the foreground (usually a person, product, or animal) and forces the rest transparent."
+                      >
+                        ?
+                      </span>
+                    </div>
+                    <div className="ge-control-row ge-actions">
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-primary ge-btn-ai ge-ge-ai-btn"
+                        disabled
+                        title={NO_BACKEND}
+                      >
+                        <span className="ge-btn-ai-mark" aria-hidden="true">
+                          ✦
+                        </span>
+                        Bg Remove
+                      </button>
+                    </div>
+                    <hr className="ge-section-divider" />
+                    <div className="ge-section-title">
+                      <span>Edge cleanup</span>
+                    </div>
+                    <div className="ge-control-row ge-eraser-row">
+                      <span
+                        className="ge-eraser-preview"
+                        id="ge-rembg-feather-preview"
+                        aria-hidden="true"
+                      />
+                      <label htmlFor="ge-rembg-feather">Feather</label>
+                      <input
+                        id="ge-rembg-feather"
+                        type="range"
+                        min={0}
+                        max={20}
+                        value={0}
+                        readOnly
+                      />
+                      <span className="ge-slider-value">0px</span>
+                    </div>
+                    <div className="ge-control-row ge-eraser-row">
+                      <span
+                        className="ge-eraser-preview"
+                        id="ge-rembg-grow-preview"
+                        aria-hidden="true"
+                      />
+                      <label htmlFor="ge-rembg-grow">Edge</label>
+                      <input
+                        id="ge-rembg-grow"
+                        type="range"
+                        min={-10}
+                        max={10}
+                        value={0}
+                        readOnly
+                      />
+                      <span className="ge-slider-value">0px</span>
+                    </div>
+                  </div>
+                ) : null}
+
+                {/* Sharpen section (controls.js .ge-sharpen-section) */}
+                {tool === "sharpen" ? (
+                  <div className="ge-sharpen-section">
+                    <div className="ge-control-row ge-eraser-row">
+                      <span
+                        className="ge-eraser-preview"
+                        id="ge-sharpen-preview"
+                        aria-hidden="true"
+                      />
+                      <label htmlFor="ge-sharpen-amount">Amount</label>
+                      <input
+                        id="ge-sharpen-amount"
+                        type="range"
+                        min={10}
+                        max={100}
+                        value={50}
+                        readOnly
+                      />
+                      <span className="ge-slider-value">50%</span>
+                    </div>
+                    <div className="ge-control-row ge-actions">
+                      <button
+                        type="button"
+                        className="ge-btn ge-btn-primary ge-ge-ai-btn"
+                        disabled
+                        title={NO_BACKEND}
+                      >
+                        Sharpen
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+
+              {/* Layers panel (controls.js layerPanelHTML + layer-panel.js) */}
+              <div className="ge-layers">
+                <div className="ge-layers-header">
+                  <span className="ge-layers-grab" />
+                  <span className="ge-layers-title">Layers</span>
+                  <button
+                    type="button"
+                    className="ge-btn ge-btn-sm ge-icon-btn"
+                    title="Merge down"
+                    aria-label="Merge down"
+                    disabled
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      role="img"
+                      aria-label="Merge down"
+                    >
+                      <line x1="12" y1="5" x2="12" y2="19" />
+                      <polyline points="6 13 12 19 18 13" />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    className="ge-btn ge-btn-sm ge-icon-btn"
+                    title="Merge all"
+                    aria-label="Merge all"
+                    disabled
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      role="img"
+                      aria-label="Merge all"
+                    >
+                      <path d="M12 3v6M9 6l3-3 3 3M3 14h18M12 14v7M9 18l3 3 3-3" />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    className="ge-btn ge-btn-sm ge-icon-btn"
+                    title="Flatten copy (keeps originals)"
+                    aria-label="Flatten copy"
+                    disabled
+                  >
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      role="img"
+                      aria-label="Flatten copy"
+                    >
+                      <path d="M12 2 L4 6 L4 18 L12 22 L20 18 L20 6 Z" />
+                      <path d="M12 2 L12 22" />
+                      <path d="M4 6 L20 6" />
+                      <path d="M4 18 L20 18" />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    className="ge-btn ge-btn-sm ge-ge-add-layer"
+                    title="Add empty layer"
+                    disabled
+                  >
+                    + Add
+                  </button>
+                </div>
+                <div className="ge-layers-list">
+                  {/* Honest empty state — no canvas backend, so no layers. */}
+                  <div className="ge-ge-layers-empty">
+                    No layers yet. Open an image to start a layered edit.
+                  </div>
+                </div>
+              </div>
+
+              <div className="ge-panel-resize" title="Drag to resize panel" />
+            </div>
+          </div>
+        </div>
+
+        {/* ── History popover (editor/history-panel.js) — honest: only the
+            genuine "Current" marker, no fabricated undo entries. ── */}
+        {historyOpen ? (
+          <div className="ge-history-panel ge-frosted" role="dialog">
+            <div className="ge-history-head">
+              <span className="ge-adj-icon">
+                <RotateCcw size={14} />
+              </span>
+              <span className="ge-history-title">History</span>
+              <span className="ge-head-btns">
+                <button
+                  type="button"
+                  className="ge-history-close"
+                  title="Close"
+                  aria-label="Close history"
+                  onClick={() => setHistoryOpen(false)}
+                >
+                  ×
+                </button>
+              </span>
+            </div>
+            <div className="ge-history-list">
+              <button type="button" className="ge-history-row current">
+                <span className="ge-history-row-dot" />
+                <span className="ge-history-row-label">Current</span>
+                <span className="ge-history-row-time">now</span>
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {/* ── Shortcuts cheatsheet (editor/build/popups.js shortcutsPopupHTML) ── */}
+        {shortcutsOpen ? (
+          <div
+            className="ge-shortcuts-overlay"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Editor shortcuts"
+          >
+            <button
+              type="button"
+              className="od-search-backdrop"
+              aria-label="Close shortcuts"
+              onClick={() => setShortcutsOpen(false)}
+            />
+            <div className="ge-shortcuts-card">
+              <div className="ge-shortcuts-head">
+                <span>Editor Shortcuts</span>
+                <button
+                  type="button"
+                  className="ge-history-close"
+                  aria-label="Close shortcuts"
+                  onClick={() => setShortcutsOpen(false)}
+                >
+                  ✖
+                </button>
+              </div>
+              <div className="ge-shortcuts-grid">
+                <div className="ge-shortcuts-col">
+                  <h5>Tools</h5>
+                  <div>
+                    <kbd>V</kbd> Move
+                  </div>
+                  <div>
+                    <kbd>T</kbd> Transform
+                  </div>
+                  <div>
+                    <kbd>B</kbd> Brush
+                  </div>
+                  <div>
+                    <kbd>E</kbd> Eraser
+                  </div>
+                  <div>
+                    <kbd>K</kbd> Clone Stamp
+                  </div>
+                  <div>
+                    <kbd>L</kbd> Lasso
+                  </div>
+                  <div>
+                    <kbd>W</kbd> Wand
+                  </div>
+                  <div>
+                    <kbd>M</kbd> Inpaint
+                  </div>
+                  <div>
+                    <kbd>C</kbd> Crop
+                  </div>
+                  <div>
+                    <kbd>S</kbd> Sharpen
+                  </div>
+                </div>
+                <div className="ge-shortcuts-col">
+                  <h5>Edit</h5>
+                  <div>
+                    <kbd>Ctrl</kbd>+<kbd>Z</kbd> Undo
+                  </div>
+                  <div>
+                    <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Z</kbd> Redo
+                  </div>
+                  <div>
+                    <kbd>Ctrl</kbd>+<kbd>S</kbd> Save
+                  </div>
+                  <div>
+                    <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> Save to
+                    Gallery
+                  </div>
+                  <div>
+                    <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>J</kbd> New Layer
+                  </div>
+                  <div>
+                    <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>T</kbd> Free Transform
+                  </div>
+                </div>
+                <div className="ge-shortcuts-col">
+                  <h5>Selection</h5>
+                  <div>
+                    <kbd>Ctrl</kbd>+<kbd>A</kbd> Select All
+                  </div>
+                  <div>
+                    <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>D</kbd> Deselect
+                  </div>
+                  <div>
+                    <kbd>Ctrl</kbd>+<kbd>C</kbd> Copy to layer
+                  </div>
+                  <div>
+                    <kbd>Ctrl</kbd>+<kbd>D</kbd> Delete pixels
+                  </div>
+                  <div>
+                    <kbd>Esc</kbd> Cancel selection / crop
+                  </div>
+                </div>
+                <div className="ge-shortcuts-col">
+                  <h5>Brush / Mask</h5>
+                  <div>
+                    <kbd>[</kbd> Brush size −
+                  </div>
+                  <div>
+                    <kbd>]</kbd> Brush size +
+                  </div>
+                </div>
+              </div>
+              <div className="ge-shortcuts-foot">
+                Press <kbd>?</kbd> or click the keyboard icon to toggle.
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/GalleryView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/GalleryView.tsx
@@ -1,0 +1,461 @@
+// odysseus image gallery (static/js/gallery.js — the Photos tab: an upload +
+// library tool). Odysseus's gallery is a photo BACKUP + LIBRARY surface whose
+// every affordance — upload, albums, source filter, sort, AI-tagging, the
+// detail lightbox, favorite/download/delete — is server-backed via
+// /api/gallery/* (library, upload, albums, PATCH/DELETE per image,
+// audit/tagging). The grid also stores images generated elsewhere (chat),
+// refreshed via a 'gallery-refresh' window event.
+//
+// elizaMapping: eliza exposes NO frontend-callable gallery client method —
+// grepped the @elizaos/ui `client` singleton: there is no fetchGallery /
+// uploadGallery / generateImage / album / favorite method. The only adjacent
+// surface, MediaGalleryView, just SQL-scans the agent's message memory for
+// media URLs (read-only detection) — it has no upload, albums, sources,
+// favorites, sort, or AI-tagging. So none of odysseus's gallery controls can be
+// wired to real behaviour, and this is the faithful no-eliza-equivalent path:
+// the full Photos chrome (search + 'to tag' hint, source filter, sort, Select,
+// the All / Favorites filter chips, the Upload tile) plus the Albums, Edit, and
+// Settings tabs all render for exact 1:1 layout, but every control is
+// INERT/disabled with an honest title explaining there is no image-library (or
+// canvas) backend — no control routes nowhere, and no data is faked. The grid
+// shows odysseus's exact empty state ("No photos yet. Click Upload or
+// drag-and-drop to get started!") as the cell beside the Upload tile, and the
+// Settings tab keeps odysseus's AI-Tagging explainer. No fabricated images,
+// sources, prompts, albums, counts, or progress are ever shown.
+
+import {
+  CornerDownLeft,
+  Image as ImageIcon,
+  Minus,
+  Upload,
+  X,
+} from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+
+type GalleryTab = "images" | "albums" | "editor" | "settings";
+
+// odysseus gallery.js _renderEditorLanding() template presets (lines 1070-1078)
+// — the native <select> size list. Picking one would open the full editor at
+// that canvas size; eliza has no frontend canvas/diffusion backend, so the
+// select is rendered faithfully but inert (honest: no canvas backend).
+const EDITOR_TEMPLATES: ReadonlyArray<{ w: number; h: number; label: string }> =
+  [
+    { w: 1024, h: 1024, label: "Square HD — 1024 × 1024" },
+    { w: 1920, h: 1080, label: "Widescreen — 1920 × 1080" },
+    { w: 1080, h: 1920, label: "Portrait — 1080 × 1920" },
+    { w: 1080, h: 1080, label: "Instagram — 1080 × 1080" },
+    { w: 1500, h: 1050, label: "Postcard — 1500 × 1050" },
+    { w: 2480, h: 3508, label: "A4 (300dpi) — 2480 × 3508" },
+    { w: 2550, h: 3300, label: "Letter (300dpi) — 2550 × 3300" },
+    { w: 3840, h: 2160, label: "4K — 3840 × 2160" },
+  ];
+
+// Honest disabled reason for the Photos-tab controls (search, source filter,
+// sort, Select, Upload, filter chips). eliza exposes no image-library backend,
+// so none of these can do real work — they render 1:1 but stay inert.
+const NO_BACKEND = "No image-library backend is connected yet";
+
+// Honest disabled reason for the canvas-opening affordances (New canvas /
+// template select). eliza exposes no frontend canvas/diffusion backend, so a
+// blank canvas can't be created here; "Browse photos" stays real (it just
+// switches to the Photos tab, same as odysseus).
+const NO_CANVAS_BACKEND = "No image/canvas backend is connected yet";
+
+export function GalleryView({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+  locale?: string;
+}): ReactNode {
+  useEscapeClose(open, onClose);
+  const win = useWindowControls(
+    "win-gallery",
+    { w: 960, h: 820 },
+    { label: "Gallery", icon: "Images", onClose },
+  );
+  const [tab, setTab] = useState<GalleryTab>("images");
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  return (
+    <div
+      className={`od-search-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Gallery"
+    >
+      <button
+        type="button"
+        aria-label="Close gallery"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel od-gallery-panel" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        {/* ── Modal header (gallery.js modal-header) ── */}
+        <div
+          className="od-gallery-header od-window-header"
+          onPointerDown={win.onDragStart}
+        >
+          <h4 className="od-gallery-title">
+            <ImageIcon size={14} aria-hidden="true" />
+            <span>Gallery</span>
+            {/* gallery.js #gallery-stats — dim 'N photos' count. No image
+                library backend, so an honest 0. */}
+            <span className="od-gallery-stats">0 photos</span>
+          </h4>
+          <button
+            type="button"
+            className="od-window-min-btn"
+            onClick={win.minimize}
+            title="Minimize"
+            aria-label="Minimize"
+          >
+            <Minus size={14} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="od-gallery-close"
+            aria-label="Close gallery"
+            onClick={onClose}
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* ── Tabs (gallery.js .gallery-tabs): Photos · Albums · Edit · Settings ── */}
+        <div className="od-gallery-tabs">
+          <button
+            type="button"
+            className={`od-gallery-tab${tab === "images" ? " active" : ""}`}
+            onClick={() => setTab("images")}
+          >
+            <span className="od-gallery-tab-icon">
+              <ImageIcon size={14} />
+            </span>
+            <span className="od-gallery-tab-label">Photos</span>
+          </button>
+          <button
+            type="button"
+            className={`od-gallery-tab${tab === "albums" ? " active" : ""}`}
+            onClick={() => setTab("albums")}
+          >
+            <span className="od-gallery-tab-icon">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                role="img"
+                aria-label="Albums"
+              >
+                <rect x="3" y="3" width="7" height="7" rx="1" />
+                <rect x="14" y="3" width="7" height="7" rx="1" />
+                <rect x="3" y="14" width="7" height="7" rx="1" />
+                <rect x="14" y="14" width="7" height="7" rx="1" />
+              </svg>
+            </span>
+            <span className="od-gallery-tab-label">Albums</span>
+          </button>
+          {/* Edit tab (gallery.js lines 1925-1929) — between Albums and
+              Settings, pencil icon + 'Edit'. (The hidden close × that
+              odysseus shows once a project is loaded needs an editor-drafts
+              backend eliza lacks, so it is omitted in this empty state.) */}
+          <button
+            type="button"
+            className={`od-gallery-tab${tab === "editor" ? " active" : ""}`}
+            onClick={() => setTab("editor")}
+          >
+            <span className="od-gallery-tab-icon">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                role="img"
+                aria-label="Edit"
+              >
+                <path d="M17 3a2.83 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+              </svg>
+            </span>
+            <span className="od-gallery-tab-label">Edit</span>
+          </button>
+          <button
+            type="button"
+            className={`od-gallery-tab${tab === "settings" ? " active" : ""}`}
+            onClick={() => setTab("settings")}
+          >
+            <span className="od-gallery-tab-icon">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                role="img"
+                aria-label="Settings"
+              >
+                <circle cx="12" cy="12" r="3" />
+                <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.6 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.6a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+              </svg>
+            </span>
+            <span className="od-gallery-tab-label">Settings</span>
+          </button>
+        </div>
+
+        {/* ── Body ── */}
+        <div className="od-gallery-body">
+          {tab === "images" ? (
+            <div className="od-gallery-images-container">
+              {/* Toolbar (gallery.js .gallery-toolbar, lines 1945-1960):
+                  search w/ 'to tag' enter-hint, source filter, sort, Select.
+                  No gallery backend → every control inert/disabled with an
+                  honest title, but the full row renders for 1:1 layout. */}
+              <div className="od-gallery-toolbar">
+                <div className="od-gallery-search-wrap">
+                  <input
+                    type="text"
+                    className="od-gallery-search"
+                    placeholder="Search photos, tags..."
+                    disabled
+                    title={NO_BACKEND}
+                    aria-label="Search photos, tags"
+                  />
+                  {/* odysseus's '↵ to tag' hint — hidden until text is typed
+                      (CSS :not(:placeholder-shown)); our input is disabled and
+                      empty, so it stays hidden, matching the real frame. */}
+                  <span
+                    className="od-gallery-search-enter-hint"
+                    aria-hidden="true"
+                  >
+                    <CornerDownLeft
+                      size={13}
+                      className="od-gallery-enter-key"
+                    />
+                    to tag
+                  </span>
+                </div>
+                <span className="od-gallery-toolbar-break" aria-hidden="true" />
+                <select
+                  className="od-gallery-model-filter"
+                  disabled
+                  title={NO_BACKEND}
+                  aria-label="Filter by source"
+                  defaultValue=""
+                >
+                  <option value="">All sources</option>
+                </select>
+                <select
+                  className="od-gallery-sort"
+                  disabled
+                  title={NO_BACKEND}
+                  aria-label="Sort order"
+                  defaultValue="shuffle"
+                >
+                  <option value="shuffle">Random</option>
+                  <option value="recent">Recent</option>
+                  <option value="oldest">Oldest</option>
+                </select>
+                <button
+                  type="button"
+                  className="od-gallery-select-btn od-gallery-toolbar-action"
+                  disabled
+                  title={`Select for bulk actions — ${NO_BACKEND}`}
+                >
+                  <span>Select</span>
+                </button>
+              </div>
+
+              {/* Filter chips (gallery.js #gallery-filter-chips, _renderAlbums
+                  lines 380-383): All (active) + heart Favorites. Inert — there
+                  is nothing to filter, but the row renders for 1:1 chrome. */}
+              <div className="od-gallery-filter-chips od-gallery-album-chips">
+                <button
+                  type="button"
+                  className="od-gallery-chip active"
+                  disabled
+                  title={NO_BACKEND}
+                >
+                  All
+                </button>
+                <button
+                  type="button"
+                  className="od-gallery-chip od-gallery-chip-fav"
+                  disabled
+                  title={`Favorites — ${NO_BACKEND}`}
+                  aria-label="Favorites"
+                >
+                  &#9829;
+                </button>
+              </div>
+
+              {/* Grid: Upload tile + odysseus's exact empty caption as the cell
+                  beside it (gallery.js _renderGrid empty branch: uploadTile +
+                  the empty caption in the same grid). No upload endpoint exists,
+                  so the tile is a disabled affordance rather than a control that
+                  routes nowhere. */}
+              <div className="od-gallery-grid od-gallery-grid-empty">
+                <div
+                  className="od-gallery-card od-gallery-card-upload od-gallery-card-disabled"
+                  title={`Upload photos or videos — ${NO_BACKEND}`}
+                  aria-disabled="true"
+                >
+                  <div className="od-gallery-card-upload-inner">
+                    <Upload size={32} strokeWidth={1.5} />
+                    <div className="od-gallery-card-upload-label">Upload</div>
+                  </div>
+                </div>
+                <div className="od-gallery-empty">
+                  No photos yet. Click Upload or drag-and-drop to get started!
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {tab === "albums" ? (
+            <div className="od-gallery-secondary">
+              <div className="od-gallery-empty">No albums yet.</div>
+            </div>
+          ) : null}
+
+          {/* ── Edit tab landing (gallery.js _renderEditorLanding, lines
+              1083-1112). Pen-tool glyph + 'Image Editor' Alpha heading,
+              'New canvas...'/'Browse photos' actions, template select, and the
+              Saved-projects row. eliza has no canvas/editor-drafts backend, so
+              canvas-creating controls are honestly inert and the saved-projects
+              grid shows its empty state — but every control is present 1:1. ── */}
+          {tab === "editor" ? (
+            <div className="od-gallery-secondary">
+              <div className="gallery-editor-landing">
+                <svg
+                  width="48"
+                  height="48"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  style={{ opacity: 0.6 }}
+                  role="img"
+                  aria-label="Image editor"
+                >
+                  <path d="M12 19l7-7 3 3-7 7-3-3z" />
+                  <path d="M18 13l-1.5-7.5L2 2l3.5 14.5L13 18l5-5z" />
+                  <path d="M2 2l7.586 7.586" />
+                  <circle cx="11" cy="11" r="2" />
+                </svg>
+                <h3>
+                  Image Editor <span className="ge-alpha-tag">Alpha</span>
+                </h3>
+                <p>
+                  Start a blank canvas, or open a photo from your gallery to
+                  edit it.
+                </p>
+                <div className="gallery-editor-landing-actions">
+                  <button
+                    type="button"
+                    className="od-gallery-select-btn gallery-editor-landing-btn"
+                    title={NO_CANVAS_BACKEND}
+                    disabled
+                  >
+                    New canvas...
+                  </button>
+                  <button
+                    type="button"
+                    className="od-gallery-select-btn gallery-editor-landing-btn"
+                    onClick={() => setTab("images")}
+                  >
+                    Browse photos
+                  </button>
+                </div>
+                <label className="gallery-editor-template-label">
+                  Or pick a template
+                  <select
+                    className="gallery-editor-template-select"
+                    defaultValue=""
+                    title={NO_CANVAS_BACKEND}
+                    disabled
+                    aria-label="Pick a canvas template size"
+                  >
+                    <option value="">Select a size…</option>
+                    {EDITOR_TEMPLATES.map((p, i) => (
+                      <option key={p.label} value={i}>
+                        {p.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <div className="gallery-editor-drafts">
+                  <div className="gallery-editor-drafts-header">
+                    <h4 className="gallery-editor-drafts-title">
+                      Saved projects
+                    </h4>
+                    <input
+                      type="search"
+                      className="gallery-editor-drafts-search"
+                      placeholder="Search projects…"
+                      autoComplete="off"
+                      title="Saved projects need an editor-drafts backend, which isn’t connected yet"
+                      disabled
+                      aria-label="Search saved projects"
+                    />
+                    <button
+                      type="button"
+                      className="od-gallery-select-btn"
+                      title="Saved projects need an editor-drafts backend, which isn’t connected yet"
+                      disabled
+                    >
+                      Select
+                    </button>
+                  </div>
+                  <div className="gallery-editor-drafts-grid">
+                    <div className="od-gallery-empty">
+                      No saved projects yet.
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          {tab === "settings" ? (
+            <div className="od-gallery-secondary">
+              <div className="od-gallery-settings-card">
+                <h2 className="od-gallery-settings-title">AI Tagging</h2>
+                <p className="od-gallery-settings-desc">
+                  Auto-tag photos by content with your vision model. Your own
+                  tags are kept. Available once an image library is connected.
+                </p>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/GroupChatView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/GroupChatView.tsx
@@ -1,0 +1,640 @@
+// odysseus Group — the multi-model "group chat" composer (static/js/group.js +
+// the #custom-preset-modal[data-chartab-panel="group"] markup in
+// static/index.html L1179-1188, styled by the .compare-parallel-toggle /
+// .preset-* rules in static/style.css).
+//
+// IMPORTANT — surface shape: odysseus's "Group" is NOT a standalone window. It
+// is a TAB inside the Prompt/Persona modal. Its tab body is, top-to-bottom:
+//   1. a single full-width Sequential/Parallel mode toggle (.compare-parallel-toggle,
+//      default 'round-robin' → label "Sequential"; group.js L18),
+//   2. a stacked #group-participants list — minimal rows (12px name + a dim
+//      10px model sublabel + a plain "×" remove), NO status dots, NO idle
+//      dimming (group.js _render L63-79),
+//   3. a full-width DASHED "+ Add participant" button that expands to a two-
+//      <select> persona+model picker, auto-adding on model change, max 8
+//      (group.js L83-116),
+// and the modal's shared footer carries Cancel + a "Start" button (index.html
+// L1191-1195) that fans the chosen participants out into a fresh group.
+//
+// elizaMapping: eliza has no "N independent model sessions" fan-out backend, but
+// the orchestrator DOES own real multi-participant task rooms, which is the
+// faithful mapping. A task thread IS a group: its `sessions` are the sub-agent
+// participants and the orchestrator coordinates them. odysseus's add-participant
+// (persona + model) maps to client.addOrchestratorAgent (spawn a real sub-agent
+// into the room) and per-row "×" maps to client.stopOrchestratorAgent — the
+// same endpoints the workbench roster uses. eliza agents pick framework + model
+// (not a character persona), so the picker exposes the real fields the
+// orchestrator accepts (framework / model / label) instead of fabricating a
+// persona step — a documented, intentional substitution (see deferred note).
+//
+// Two odysseus affordances are intentionally NOT cloned, to avoid slop:
+//   • odysseus's group is created fresh from the participant list with no notion
+//     of an existing "room"; eliza MUST attach sub-agents to a concrete task
+//     room, so a single room-target <select> is kept and documented as an
+//     intentional eliza-only deviation (NOT presented as 1:1).
+//   • saved GROUP PRESETS (#group-presets-list, /api/presets/groups) — eliza has
+//     no preset/group client method, so no chip row is rendered (no dead control).
+//
+// The bespoke floating-window chrome of the prior port (titled "Group Chat"
+// header + participant-count badge, room-picker ROW, roster-beside-stream two
+// column body, in-panel composer + "Posting to …" note + per-bubble stream) had
+// no counterpart in the real frame and has been removed: odysseus's group tab
+// has no composer (messages go through the main chat bar after Start) and no
+// stream of its own.
+
+import {
+  type CodingAgentAddAgentInput,
+  type CodingAgentTaskSessionRecord,
+  type CodingAgentTaskThread,
+  type CodingAgentTaskThreadDetail,
+  client,
+} from "@elizaos/ui";
+import { Minus } from "lucide-react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+import { LoadingRow } from "./Spinner";
+import { readPref, writePref } from "./util/storage";
+
+// odysseus persists its group config under GROUP_STATE_KEY
+// ('odysseus-group-state'); the only client-relevant field is `_mode`, so we
+// own a single (non-shared) pref rather than bloating the shared PREF_KEYS
+// table. Mirrors NotesPanel/CompareView's per-view-pref pattern.
+const GROUP_MODE_KEY = "group-mode";
+
+// odysseus's two fan-out modes (group.js `_mode`). The default is 'round-robin'
+// (group.js L18) → the toggle shows "Sequential" at rest and gets the .active
+// accent only when flipped to 'parallel'. Local-only here — see header.
+type GroupMode = "parallel" | "round-robin";
+
+function toMode(value: string): GroupMode {
+  // odysseus defaults to round-robin; only an explicit 'parallel' flips it.
+  return value === "parallel" ? "parallel" : "round-robin";
+}
+
+/** A sub-agent session's display name — label first, else the framework,
+ * mirroring group.js's `p.character ? name : model.display`. */
+function sessionLabel(session: CodingAgentTaskSessionRecord): string {
+  const label = session.label.trim();
+  if (label) return label;
+  return session.framework || "agent";
+}
+
+/** A sub-agent's sublabel — the model id, cleaned to the short tail the way
+ * group.js does (`display.split('/').pop()`). */
+function sessionSublabel(session: CodingAgentTaskSessionRecord): string {
+  const model = session.model?.trim();
+  if (!model) return session.framework || "";
+  const tail = model.split("/").pop();
+  return tail || model;
+}
+
+// A row in the group participant list. odysseus rows are character/model entries
+// the user has staged; here each row is a real sub-agent session already in the
+// room (the orchestrator is always present implicitly as the coordinator, so it
+// is not listed as a removable participant — only spawned sub-agents are).
+interface Participant {
+  id: string;
+  label: string;
+  sublabel: string;
+  /** The session id the orchestrator stops by, for the row "×" remove. */
+  sessionId: string | null;
+}
+
+/** Build the staged-participant list from the room's sub-agent sessions.
+ * odysseus lists models the user has added; the orchestrator room's analogue is
+ * its live sub-agent sessions (the user + orchestrator coordinator are
+ * structural and implied, not rows in this list — matching odysseus, where the
+ * list holds only the added models, not "you"). */
+function buildParticipants(detail: CodingAgentTaskThreadDetail): Participant[] {
+  return detail.sessions.map((session) => ({
+    id: session.id,
+    label: sessionLabel(session),
+    sublabel: sessionSublabel(session),
+    sessionId: session.sessionId,
+  }));
+}
+
+// odysseus caps a group at 8 models (group.js L104). Mirror the cap on the real
+// roster so "Add participant" disables at the same ceiling.
+const MAX_PARTICIPANTS = 8;
+
+export function GroupChatView({
+  open,
+  onClose,
+  initialTaskId,
+}: {
+  open: boolean;
+  onClose: () => void;
+  locale?: string;
+  initialTaskId?: string;
+}): ReactNode {
+  useEscapeClose(open, onClose);
+  // odysseus's group tab lives inside the compact #custom-preset-modal
+  // (min(460px,90vw)); size the window to match rather than the prior large
+  // 860×760 floating window.
+  const win = useWindowControls(
+    "win-group",
+    { w: 460, h: 540 },
+    { label: "Group Chat", icon: "MessagesSquare", onClose },
+  );
+  const [threads, setThreads] = useState<CodingAgentTaskThread[]>([]);
+  const [threadsFetched, setThreadsFetched] = useState(false);
+  const [activeTaskId, setActiveTaskId] = useState<string | null>(
+    initialTaskId ?? null,
+  );
+  const [detail, setDetail] = useState<CodingAgentTaskThreadDetail | null>(
+    null,
+  );
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [mode, setMode] = useState<GroupMode>("round-robin");
+  // Participant management (odysseus add-participant / per-row remove).
+  const [picking, setPicking] = useState(false);
+  const [addBusy, setAddBusy] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+  const [addFramework, setAddFramework] = useState("");
+  const [addModel, setAddModel] = useState("");
+  const [addLabel, setAddLabel] = useState("");
+  const [removingId, setRemovingId] = useState<string | null>(null);
+  // "Start" → kick the room with the chosen mode. Honest about delivery (see note).
+  const [starting, setStarting] = useState(false);
+  const [startError, setStartError] = useState<string | null>(null);
+
+  // Load the room list + restore the persisted mode when the view opens.
+  useEffect(() => {
+    if (!open) return;
+    setMode(toMode(readPref<string>(GROUP_MODE_KEY, "round-robin")));
+    void client
+      .listCodingAgentTaskThreads({ limit: 100 })
+      .catch((): CodingAgentTaskThread[] => [])
+      .then((list) => {
+        setThreads(list);
+        setThreadsFetched(true);
+        setActiveTaskId((cur) => {
+          if (cur && list.some((t) => t.id === cur)) return cur;
+          if (initialTaskId && list.some((t) => t.id === initialTaskId)) {
+            return initialTaskId;
+          }
+          return list.length > 0 ? list[0].id : null;
+        });
+      });
+  }, [open, initialTaskId]);
+
+  // Refetch the room detail (the staged participant list) for the active task.
+  // The orchestrator exposes a live SSE change stream per task, so we subscribe
+  // and refetch on every room mutation — the same pattern the workbench uses.
+  const reloadRoom = useCallback((taskId: string) => {
+    setDetailLoading(true);
+    void client
+      .getCodingAgentTaskThread(taskId)
+      .catch((): CodingAgentTaskThreadDetail | null => null)
+      .then((d) => {
+        setDetail(d);
+        setDetailLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!open || !activeTaskId) {
+      setDetail(null);
+      return;
+    }
+    // Reset transient per-room UI when the selected room changes.
+    setPicking(false);
+    setAddError(null);
+    setStartError(null);
+    reloadRoom(activeTaskId);
+    const unsubscribe = client.streamOrchestratorTask(activeTaskId, () => {
+      reloadRoom(activeTaskId);
+    });
+    return unsubscribe;
+  }, [open, activeTaskId, reloadRoom]);
+
+  const setModePersist = (next: GroupMode) => {
+    setMode(next);
+    writePref(GROUP_MODE_KEY, next);
+  };
+
+  // odysseus add-participant: spawn a real sub-agent into the room via the
+  // orchestrator (client.addOrchestratorAgent — the same endpoint the workbench
+  // roster uses). The orchestrator chooses sensible defaults when a field is
+  // blank, so only the model/framework/label the user typed are sent.
+  const addParticipant = () => {
+    if (!activeTaskId || addBusy) return;
+    const input: CodingAgentAddAgentInput = {
+      framework: addFramework.trim() || undefined,
+      model: addModel.trim() || undefined,
+      label: addLabel.trim() || undefined,
+    };
+    setAddBusy(true);
+    setAddError(null);
+    void client
+      .addOrchestratorAgent(activeTaskId, input)
+      .then(
+        (updated) => {
+          if (updated) {
+            setDetail(updated);
+            setPicking(false);
+            setAddFramework("");
+            setAddModel("");
+            setAddLabel("");
+            reloadRoom(activeTaskId);
+          } else {
+            setAddError("This room no longer exists.");
+          }
+        },
+        () => {
+          setAddError("Failed to add participant.");
+        },
+      )
+      .finally(() => {
+        setAddBusy(false);
+      });
+  };
+
+  // odysseus per-row remove: stop the sub-agent participant (client
+  // .stopOrchestratorAgent).
+  const removeParticipant = (participant: Participant) => {
+    if (!activeTaskId || !participant.sessionId || removingId) return;
+    setRemovingId(participant.id);
+    void client
+      .stopOrchestratorAgent(activeTaskId, participant.sessionId)
+      .catch(() => false)
+      .then(() => {
+        if (activeTaskId) reloadRoom(activeTaskId);
+      })
+      .finally(() => {
+        setRemovingId(null);
+      });
+  };
+
+  // odysseus's footer "Start" fans the staged participants out into a fresh
+  // group and closes the modal (group.js L130-159; needs ≥2 participants). The
+  // faithful eliza analogue is a real room kickoff: post the chosen mode as a
+  // room message so the orchestrator and its sub-agents see the same prompt,
+  // then close — the same postOrchestratorTaskMessage endpoint the workbench
+  // composer uses. (The Parallel/Sequential mode itself is a local preference;
+  // it does not drive backend scheduling — see the foot note.)
+  const start = (participantCount: number) => {
+    if (!activeTaskId || starting) return;
+    if (participantCount < 2) {
+      setStartError("Need at least 2 participants — add models.");
+      return;
+    }
+    setStarting(true);
+    setStartError(null);
+    void client
+      .postOrchestratorTaskMessage(
+        activeTaskId,
+        mode === "parallel"
+          ? "Group started — all participants respond."
+          : "Group started — participants respond in turn.",
+      )
+      .then(
+        (ok) => {
+          if (ok) {
+            onClose();
+          } else {
+            setStartError("Could not start the group in this room.");
+          }
+        },
+        () => {
+          setStartError("Failed to start. Check your connection.");
+        },
+      )
+      .finally(() => {
+        setStarting(false);
+      });
+  };
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  // The group is "empty" — odysseus's honest no-conversation state — when there
+  // is no selectable task room at all.
+  const noRoom = threadsFetched && threads.length === 0;
+  const participants = detail ? buildParticipants(detail) : [];
+  const canStart = participants.length >= 2 && !!activeTaskId && !noRoom;
+  const atCap = participants.length >= MAX_PARTICIPANTS;
+
+  return (
+    <div
+      className={`od-search-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Group"
+    >
+      <button
+        type="button"
+        aria-label="Close group"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel od-group-panel" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        {/* ── Modal header (index.html #custom-preset-modal .modal-header;
+            the active tab here is "Group" + the modal's own close-btn) ── */}
+        <div
+          className="od-group-header od-window-header"
+          onPointerDown={win.onDragStart}
+        >
+          <span className="od-group-header-title">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+              <circle cx="9" cy="7" r="4" />
+              <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
+              <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+            </svg>
+            <span>Group</span>
+          </span>
+          <button
+            type="button"
+            className="od-window-min-btn"
+            onClick={win.minimize}
+            title="Minimize"
+            aria-label="Minimize"
+          >
+            <Minus size={14} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="od-group-close"
+            aria-label="Close group"
+            title="Close"
+            onClick={onClose}
+          >
+            ✖
+          </button>
+        </div>
+
+        <div className="od-group-tab">
+          {/* ── Room target — eliza-only deviation (a group must attach to a
+              concrete orchestrator task room). Documented; not 1:1 odysseus. ── */}
+          {threads.length > 0 ? (
+            <div className="od-group-roomrow">
+              <label className="od-group-roomlabel" htmlFor="od-group-room">
+                Room
+              </label>
+              <select
+                id="od-group-room"
+                className="od-group-roomselect"
+                value={activeTaskId ?? ""}
+                onChange={(e) => setActiveTaskId(e.target.value || null)}
+                aria-label="Select task room"
+              >
+                {threads.map((thread) => (
+                  <option key={thread.id} value={thread.id}>
+                    {thread.title}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+
+          {/* ── Mode toggle (group.js #group-mode-btn, .compare-parallel-toggle
+              styling; default Sequential, custom line/dot SVGs) ── */}
+          <div className="od-group-moderow">
+            <button
+              type="button"
+              className={`od-group-mode-btn${mode === "parallel" ? " active" : ""}`}
+              title={
+                mode === "parallel"
+                  ? "All participants respond"
+                  : "Round-robin — participants take turns"
+              }
+              aria-pressed={mode === "parallel"}
+              onClick={() =>
+                setModePersist(mode === "parallel" ? "round-robin" : "parallel")
+              }
+            >
+              {mode === "parallel" ? (
+                // ICON_PAR — three flush lines (group.js L120).
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  aria-hidden="true"
+                >
+                  <line x1="4" y1="6" x2="20" y2="6" />
+                  <line x1="4" y1="12" x2="20" y2="12" />
+                  <line x1="4" y1="18" x2="20" y2="18" />
+                </svg>
+              ) : (
+                // ICON_SEQ — three lines with leading dots (group.js L121).
+                <svg
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  aria-hidden="true"
+                >
+                  <line x1="8" y1="6" x2="20" y2="6" />
+                  <line x1="8" y1="12" x2="20" y2="12" />
+                  <line x1="8" y1="18" x2="20" y2="18" />
+                  <circle cx="4" cy="6" r="1.5" fill="currentColor" />
+                  <circle cx="4" cy="12" r="1.5" fill="currentColor" />
+                  <circle cx="4" cy="18" r="1.5" fill="currentColor" />
+                </svg>
+              )}
+              <span className="od-group-mode-label">
+                {mode === "parallel" ? "Parallel" : "Sequential"}
+              </span>
+            </button>
+          </div>
+
+          {/* ── Participant list (group.js #group-participants _render rows) ── */}
+          <div className="od-group-participants">
+            {noRoom || !activeTaskId ? (
+              <div className="od-group-participants-empty">
+                No group conversation. The orchestrator opens a task room with
+                its sub-agents when you start a coding job — that room becomes
+                the group.
+              </div>
+            ) : detailLoading && participants.length === 0 ? (
+              <div className="od-group-participants-empty">
+                <LoadingRow label="Loading…" />
+              </div>
+            ) : participants.length === 0 ? (
+              <div className="od-group-participants-empty">
+                No participants yet — add a model.
+              </div>
+            ) : (
+              participants.map((p) => (
+                <div className="od-group-participant" key={p.id}>
+                  <span className="od-group-participant-text">
+                    <span className="od-group-participant-name">{p.label}</span>
+                    {p.sublabel && p.sublabel !== p.label ? (
+                      <span className="od-group-participant-sub">
+                        {p.sublabel}
+                      </span>
+                    ) : null}
+                  </span>
+                  {p.sessionId ? (
+                    <button
+                      type="button"
+                      className="od-group-participant-remove"
+                      title="Remove"
+                      aria-label={`Remove ${p.label}`}
+                      disabled={removingId !== null}
+                      onClick={() => removeParticipant(p)}
+                    >
+                      ×
+                    </button>
+                  ) : null}
+                </div>
+              ))
+            )}
+          </div>
+
+          {/* ── Add-participant: odysseus's dashed full-width button →
+              inline picker (group.js #group-add-btn). eliza spawns a real
+              sub-agent so the picker fields are framework / model / label
+              (documented deviation from odysseus's persona+model selects). ── */}
+          {picking && activeTaskId && !noRoom ? (
+            <div className="od-group-picker">
+              <input
+                className="od-group-picker-input"
+                value={addFramework}
+                onChange={(e) => setAddFramework(e.target.value)}
+                placeholder="Framework (optional)"
+                aria-label="Participant framework"
+              />
+              <input
+                className="od-group-picker-input"
+                value={addModel}
+                onChange={(e) => setAddModel(e.target.value)}
+                placeholder="Model (optional)"
+                aria-label="Participant model"
+              />
+              <input
+                className="od-group-picker-input"
+                value={addLabel}
+                onChange={(e) => setAddLabel(e.target.value)}
+                placeholder="Label (optional)"
+                aria-label="Participant label"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") addParticipant();
+                }}
+              />
+              {addError ? (
+                <span className="od-group-picker-error">{addError}</span>
+              ) : null}
+              <div className="od-group-picker-foot">
+                <button
+                  type="button"
+                  className="od-group-picker-cancel"
+                  onClick={() => {
+                    setPicking(false);
+                    setAddError(null);
+                  }}
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="od-group-picker-submit"
+                  disabled={addBusy}
+                  onClick={addParticipant}
+                >
+                  {addBusy ? "Adding…" : "Add"}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              className="od-group-add-btn"
+              disabled={!activeTaskId || noRoom || atCap}
+              title={
+                atCap
+                  ? "Maximum 8 participants"
+                  : "Add a participant to the group"
+              }
+              onClick={() => {
+                setPicking(true);
+                setAddError(null);
+              }}
+            >
+              + Add participant
+            </button>
+          )}
+        </div>
+
+        {/* ── Footer (index.html .modal-footer: Cancel + Start) ── */}
+        <div className="od-group-footer">
+          {startError ? (
+            <span className="od-group-footer-error" role="alert">
+              {startError}
+            </span>
+          ) : null}
+          <span className="od-group-footer-spacer" />
+          <button type="button" className="od-group-cancel" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="od-group-start"
+            disabled={!canStart || starting}
+            title={
+              canStart
+                ? "Start the group"
+                : "Add at least 2 participants to start"
+            }
+            onClick={() => start(participants.length)}
+          >
+            {starting ? null : (
+              // Leading play triangle — the real Prompt modal's shared footer
+              // button (index.html #save-custom-preset / PresetsPanel
+              // .od-preset-start-btn) carries a "▶" glyph before its label.
+              <svg
+                className="od-group-start-glyph"
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <polygon points="5 3 19 12 5 21 5 3" />
+              </svg>
+            )}
+            {starting ? "Starting…" : "Start Prompt"}
+          </button>
+        </div>
+
+        {/* odysseus's mode toggle drives real fan-out scheduling; eliza's
+            orchestrator schedules its own sub-agents, so the toggle above is a
+            local preference and does not change room delivery. */}
+        <div className="od-group-note">
+          The orchestrator delivers room messages to its sub-agents; the
+          Parallel / Sequential toggle is a local preference and doesn’t change
+          delivery.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/IconRail.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/IconRail.tsx
@@ -1,0 +1,272 @@
+// 48px icon rail. Holds the sidebar toggle (hamburger), the New-chat action
+// (odysseus rail-new-session), the theme picker, settings, and the feature
+// glyphs (memory, calendar, gallery, …). Mutually exclusive with the wide
+// sidebar (odysseus sidebar-layout.js: the rail shows ONLY when the sidebar is
+// collapsed). When the sidebar is expanded its labeled rows carry the same
+// feature navigation; the shell renders this rail only in the collapsed state.
+
+import {
+  BookOpen,
+  Boxes,
+  Brain,
+  CalendarDays,
+  Columns2,
+  FileText,
+  FlaskConical,
+  Images,
+  ListChecks,
+  Mail,
+  MessagesSquare,
+  Mic,
+  Palette,
+  PanelLeft,
+  Pencil,
+  Plus,
+  Settings,
+  ShieldAlert,
+  SlidersHorizontal,
+  StickyNote,
+  Zap,
+} from "lucide-react";
+import type { ReactNode } from "react";
+
+export function IconRail({
+  onToggleSidebar,
+  onNewChat,
+  onOpenTheme,
+  onOpenMemory,
+  onOpenSkills,
+  onOpenNotes,
+  onOpenSettings,
+  onOpenCompare,
+  onOpenResearch,
+  onOpenDocs,
+  onOpenCalendar,
+  onOpenEmail,
+  onOpenGallery,
+  onOpenCookbook,
+  onOpenModels,
+  onOpenTasks,
+  onOpenEditor,
+  onOpenGroup,
+  onOpenAdmin,
+  onOpenVoice,
+  onOpenPresets,
+}: {
+  onToggleSidebar: () => void;
+  onNewChat: () => void;
+  onOpenTheme: () => void;
+  onOpenMemory: () => void;
+  onOpenSkills: () => void;
+  onOpenNotes: () => void;
+  onOpenSettings: () => void;
+  onOpenCompare: () => void;
+  onOpenResearch: () => void;
+  onOpenDocs: () => void;
+  onOpenCalendar: () => void;
+  onOpenEmail: () => void;
+  onOpenGallery: () => void;
+  onOpenCookbook: () => void;
+  onOpenModels: () => void;
+  onOpenTasks: () => void;
+  onOpenEditor: () => void;
+  onOpenGroup: () => void;
+  onOpenAdmin: () => void;
+  onOpenVoice: () => void;
+  onOpenPresets: () => void;
+}): ReactNode {
+  return (
+    <div className="od-icon-rail">
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onToggleSidebar}
+        title="Toggle sidebar"
+        aria-label="Toggle sidebar"
+      >
+        <PanelLeft size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn od-rail-new-chat"
+        onClick={onNewChat}
+        title="New chat"
+        aria-label="New chat"
+      >
+        <Plus size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenMemory}
+        title="Memory"
+        aria-label="Memory"
+      >
+        <Brain size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenSkills}
+        title="Skills"
+        aria-label="Skills"
+      >
+        <Zap size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenNotes}
+        title="Notes"
+        aria-label="Notes"
+      >
+        <StickyNote size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenDocs}
+        title="Documents"
+        aria-label="Documents"
+      >
+        <FileText size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenCompare}
+        title="Compare"
+        aria-label="Compare"
+      >
+        <Columns2 size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenResearch}
+        title="Deep Research"
+        aria-label="Deep Research"
+      >
+        <FlaskConical size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenCalendar}
+        title="Calendar"
+        aria-label="Calendar"
+      >
+        <CalendarDays size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenTasks}
+        title="Tasks"
+        aria-label="Tasks"
+      >
+        <ListChecks size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenModels}
+        title="Models"
+        aria-label="Models"
+      >
+        <Boxes size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenEmail}
+        title="Email"
+        aria-label="Email"
+      >
+        <Mail size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenGallery}
+        title="Gallery"
+        aria-label="Gallery"
+      >
+        <Images size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenCookbook}
+        title="Cookbook"
+        aria-label="Cookbook"
+      >
+        <BookOpen size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenGroup}
+        title="Group Chat"
+        aria-label="Group Chat"
+      >
+        <MessagesSquare size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenEditor}
+        title="Image Editor"
+        aria-label="Image Editor"
+      >
+        <Pencil size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenAdmin}
+        title="Admin"
+        aria-label="Admin"
+      >
+        <ShieldAlert size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenVoice}
+        title="Voice"
+        aria-label="Voice"
+      >
+        <Mic size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenPresets}
+        title="Presets"
+        aria-label="Presets"
+      >
+        <SlidersHorizontal size={18} />
+      </button>
+      <div className="od-rail-spacer" />
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenTheme}
+        title="Theme"
+        aria-label="Theme"
+      >
+        <Palette size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenSettings}
+        title="Settings"
+        aria-label="Settings"
+      >
+        <Settings size={18} />
+      </button>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/MemoryPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/MemoryPanel.tsx
@@ -1,0 +1,642 @@
+// odysseus Brain modal (static/js/memory.js + index.html #memory-modal). One
+// "Brain" window with four tabs — Memories / Skills / Add / Settings — over
+// eliza's memory + skills backends (client.getMemoryFeed / searchMemory /
+// getMemoryStats / rememberMemory and the skills client surface, the
+// REUSED-EXISTING-ELIZA-PLUGIN path: plugin-sql memory tables +
+// plugin-agent-skills).
+//
+// Fidelity vs odysseus: we reproduce the full four-tab chrome 1:1. The Skills
+// tab renders the shared <SkillsContent /> (the same body the standalone
+// SkillsPanel uses). odysseus also carries controls eliza has no backend for —
+// the "include memories in chat context" toggle, multi-select / AI "Tidy"
+// dedup, file Import/Export, the "Most used" memory sort (no per-memory usage
+// counter), and the auto-extract / inject / auto-approve Settings switches.
+// Those are rendered faithfully but inert/disabled with an honest reason rather
+// than omitted (1:1 chrome) or faked (no fabricated data/behaviour). Browse,
+// Add memory, Add skill and the Skills tab are fully real.
+
+import type { MemoryFeedResponse, MemoryStatsResponse } from "@elizaos/ui";
+import { client } from "@elizaos/ui";
+import {
+  Brain,
+  CirclePlus,
+  Download,
+  Minus,
+  Search,
+  Settings,
+  Sparkles,
+  Upload,
+  X,
+  Zap,
+} from "lucide-react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { formatRelativeTime } from "../view-format";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+import { SkillsContent } from "./SkillsPanel";
+import { readPref, writePref } from "./util/storage";
+
+type MemoryTab = "browse" | "skills" | "add" | "settings";
+type MemorySort = "newest" | "oldest" | "alpha";
+
+const SORT_KEY = "memory-sort";
+const ALL = "all";
+
+// Controls odysseus draws that eliza exposes no backend for. Rendered faithfully
+// but disabled, with this honest reason on the title attribute.
+const NO_BACKEND = "Not available on this agent's memory backend yet";
+
+interface MemoryRow {
+  id: string;
+  type: string;
+  text: string;
+  source: string | null;
+  createdAt: number;
+}
+
+const SORT_LABELS: Record<MemorySort, string> = {
+  newest: "Newest",
+  oldest: "Oldest",
+  alpha: "A-Z",
+};
+
+function isMemorySort(value: string): value is MemorySort {
+  return value === "newest" || value === "oldest" || value === "alpha";
+}
+
+function toRow(m: MemoryFeedResponse["memories"][number]): MemoryRow {
+  return {
+    id: m.id,
+    type: m.type,
+    text: m.text,
+    source: m.source,
+    createdAt: m.createdAt,
+  };
+}
+
+function sortRows(rows: MemoryRow[], sort: MemorySort): MemoryRow[] {
+  const next = [...rows];
+  if (sort === "newest") next.sort((a, b) => b.createdAt - a.createdAt);
+  else if (sort === "oldest") next.sort((a, b) => a.createdAt - b.createdAt);
+  else next.sort((a, b) => a.text.localeCompare(b.text));
+  return next;
+}
+
+export function MemoryPanel({
+  open,
+  onClose,
+  locale,
+}: {
+  open: boolean;
+  onClose: () => void;
+  locale?: string;
+}): ReactNode {
+  const [tab, setTab] = useState<MemoryTab>("browse");
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<MemorySort>(() =>
+    readPref<MemorySort>(SORT_KEY, "newest"),
+  );
+  const [activeCategory, setActiveCategory] = useState<string>(ALL);
+  const [rows, setRows] = useState<MemoryRow[]>([]);
+  const [stats, setStats] = useState<MemoryStatsResponse | null>(null);
+  const [skillsCount, setSkillsCount] = useState(0);
+  const [draft, setDraft] = useState("");
+  const [adding, setAdding] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const win = useWindowControls(
+    "win-memory",
+    { w: 560, h: 640 },
+    { label: "Brain", icon: "Brain", onClose },
+  );
+
+  const refreshStats = useCallback(() => {
+    void client
+      .getMemoryStats()
+      .then(setStats)
+      .catch(() => setStats(null));
+  }, []);
+
+  const onSkillsCount = useCallback((_enabled: number, total: number) => {
+    setSkillsCount(total);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    setTab("browse");
+    setQuery("");
+    setActiveCategory(ALL);
+    setDraft("");
+    setAddError(null);
+    inputRef.current?.focus();
+    refreshStats();
+  }, [open, refreshStats]);
+
+  useEffect(() => {
+    if (!open || tab !== "browse") return;
+    let cancelled = false;
+    const q = query.trim();
+    const timer = window.setTimeout(() => {
+      const load = q
+        ? client.searchMemory(q, { limit: 50 }).then((r) =>
+            r.results.map((m) => ({
+              id: m.id,
+              type: "match",
+              text: m.text,
+              source: null,
+              createdAt: m.createdAt,
+            })),
+          )
+        : client
+            .getMemoryFeed({ limit: 50 })
+            .then((r) => r.memories.map(toRow));
+      void load
+        .then((next) => {
+          if (!cancelled) setRows(next);
+        })
+        .catch(() => {
+          if (!cancelled) setRows([]);
+        });
+    }, 140);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [open, tab, query]);
+
+  // Reload feed after a successful add or when switching back to Browse.
+  const reloadFeed = useCallback(() => {
+    if (query.trim()) return;
+    void client
+      .getMemoryFeed({ limit: 50 })
+      .then((r) => setRows(r.memories.map(toRow)))
+      .catch(() => setRows([]));
+  }, [query]);
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  const onSortChange = (value: string) => {
+    if (!isMemorySort(value)) return;
+    setSort(value);
+    writePref(SORT_KEY, value);
+  };
+
+  // Category chips are derived from the distinct memory `type` values actually
+  // present (odysseus buildCategoryChips derives from data, never hardcodes the
+  // full set) plus a leading "all". Search results aren't typed, so the chip
+  // row only applies to the unfiltered feed.
+  const searchActive = query.trim().length > 0;
+  const categories = searchActive
+    ? []
+    : [ALL, ...Array.from(new Set(rows.map((m) => m.type))).sort()];
+
+  const filtered = sortRows(
+    activeCategory === ALL || searchActive
+      ? rows
+      : rows.filter((m) => m.type === activeCategory),
+    sort,
+  );
+
+  const total = stats?.total ?? rows.length;
+  const visibleLabel =
+    filtered.length === total ? `${total}` : `${filtered.length}/${total}`;
+
+  const submitAdd = () => {
+    const text = draft.trim();
+    if (!text || adding) return;
+    setAdding(true);
+    setAddError(null);
+    void client
+      .rememberMemory(text)
+      .then(() => {
+        setDraft("");
+        refreshStats();
+        reloadFeed();
+        setTab("browse");
+      })
+      .catch(() => setAddError("Couldn't save that memory. Try again."))
+      .finally(() => setAdding(false));
+  };
+
+  return (
+    <div
+      className={`od-search-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Brain"
+    >
+      <button
+        type="button"
+        aria-label="Close brain"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel od-mem-panel" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        <div
+          className="od-mem-head od-window-header"
+          onPointerDown={win.onDragStart}
+        >
+          <span className="od-mem-title">
+            <Brain size={14} className="od-mem-title-icon" aria-hidden="true" />
+            Brain
+          </span>
+          <span className="od-mem-head-spacer" />
+          <button
+            type="button"
+            className="od-window-min-btn"
+            onClick={win.minimize}
+            title="Minimize"
+            aria-label="Minimize"
+          >
+            <Minus size={14} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="od-win-close"
+            title="Close"
+            aria-label="Close brain"
+            onClick={onClose}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="od-mem-tabs" role="tablist" aria-label="Brain tabs">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "browse"}
+            className={`od-mem-tab${tab === "browse" ? " active" : ""}`}
+            onClick={() => setTab("browse")}
+          >
+            <Brain size={12} aria-hidden="true" />
+            Memories <span className="od-mem-tab-count">{total}</span>
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "skills"}
+            className={`od-mem-tab${tab === "skills" ? " active" : ""}`}
+            onClick={() => setTab("skills")}
+          >
+            <Zap size={12} aria-hidden="true" />
+            Skills <span className="od-mem-tab-count">{skillsCount}</span>
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "add"}
+            className={`od-mem-tab${tab === "add" ? " active" : ""}`}
+            onClick={() => {
+              setTab("add");
+              setAddError(null);
+            }}
+          >
+            <CirclePlus size={12} aria-hidden="true" />
+            Add
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "settings"}
+            className={`od-mem-tab${tab === "settings" ? " active" : ""}`}
+            onClick={() => setTab("settings")}
+          >
+            <Settings size={12} aria-hidden="true" />
+            Settings
+          </button>
+        </div>
+
+        {tab === "browse" ? (
+          <div className="od-mem-card">
+            <div className="od-mem-card-head">
+              <h2 className="od-mem-card-title">
+                Memories{" "}
+                <span className="od-mem-card-count">{visibleLabel}</span>
+              </h2>
+              <span className="od-mem-card-spacer" />
+              <label
+                className="od-mem-switch"
+                title={`Include memories in chat context — ${NO_BACKEND}`}
+              >
+                <input type="checkbox" defaultChecked disabled />
+                <span className="od-mem-switch-track" aria-hidden="true" />
+              </label>
+            </div>
+            <p className="od-mem-desc">
+              Long-term facts the agent remembers across chats — recall, edit,
+              or curate.
+            </p>
+            <div className="od-mem-toolbar">
+              <div className="od-mem-toolbar-row">
+                <select
+                  className="od-mem-sort"
+                  value={sort}
+                  onChange={(e) => onSortChange(e.target.value)}
+                  aria-label="Sort memories"
+                >
+                  {(Object.keys(SORT_LABELS) as MemorySort[]).map((s) => (
+                    <option key={s} value={s}>
+                      {SORT_LABELS[s]}
+                    </option>
+                  ))}
+                  <option value="uses" disabled>
+                    Most used
+                  </option>
+                </select>
+                <button
+                  type="button"
+                  className="od-mem-toolbar-btn"
+                  title={`Select multiple memories — ${NO_BACKEND}`}
+                  disabled
+                >
+                  Select
+                </button>
+                <button
+                  type="button"
+                  className="od-mem-toolbar-btn"
+                  title={`AI tidy: deduplicate and clean up memories — ${NO_BACKEND}`}
+                  disabled
+                >
+                  <Sparkles size={11} aria-hidden="true" /> Tidy
+                </button>
+              </div>
+              <div className="od-mem-search-wrap">
+                <Search size={13} className="od-mem-search-icon" />
+                <input
+                  ref={inputRef}
+                  className="od-mem-search"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Escape") onClose();
+                  }}
+                  placeholder="Search memories…"
+                  aria-label="Search memories"
+                />
+              </div>
+              {categories.length > 1 ? (
+                <div className="od-mem-cats">
+                  {categories.map((cat) => (
+                    <button
+                      type="button"
+                      key={cat}
+                      className={`od-mem-cat${cat === activeCategory ? " active" : ""}`}
+                      onClick={() => setActiveCategory(cat)}
+                    >
+                      {cat}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+            <div className="od-search-list od-mem-list">
+              {filtered.length === 0 ? (
+                searchActive || activeCategory !== ALL ? (
+                  <div className="od-search-empty">No matches.</div>
+                ) : (
+                  <div className="od-search-empty od-mem-empty">
+                    <div>No memories yet 🙂</div>
+                    <button
+                      type="button"
+                      className="od-mem-empty-link"
+                      onClick={() => setTab("add")}
+                    >
+                      Import in Add tab
+                    </button>
+                  </div>
+                )
+              ) : (
+                filtered.map((m) => (
+                  <div className="od-mem-item" key={m.id}>
+                    <div className="od-mem-item-body">
+                      <span className="od-mem-text">{m.text}</span>
+                      <div className="od-mem-meta">
+                        <span className={`od-mem-badge od-mem-badge-${m.type}`}>
+                          {m.type}
+                        </span>
+                        {m.source ? (
+                          <span className="od-mem-source">
+                            {m.source === "auto" ? "auto" : "manual"}
+                          </span>
+                        ) : null}
+                        {m.createdAt ? (
+                          <span
+                            className="od-mem-time"
+                            title={new Date(m.createdAt).toLocaleString(locale)}
+                          >
+                            {formatRelativeTime(m.createdAt, locale)}
+                          </span>
+                        ) : null}
+                      </div>
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        ) : null}
+
+        {tab === "skills" ? (
+          <div className="od-mem-card od-mem-card-skills">
+            <SkillsContent
+              active={tab === "skills"}
+              onClose={onClose}
+              onCountChange={onSkillsCount}
+            />
+          </div>
+        ) : null}
+
+        {tab === "add" ? (
+          <div className="od-mem-add">
+            <div className="od-mem-card od-mem-add-card">
+              <div className="od-mem-card-head">
+                <h2 className="od-mem-card-title">
+                  <Brain
+                    size={14}
+                    className="od-mem-title-icon"
+                    aria-hidden="true"
+                  />
+                  Add Memory
+                </h2>
+                <span className="od-mem-card-spacer" />
+                <button
+                  type="button"
+                  className="od-mem-io-btn"
+                  title={`Import memories from a file — ${NO_BACKEND}`}
+                  disabled
+                >
+                  <Upload size={13} aria-hidden="true" /> Import
+                </button>
+                <button
+                  type="button"
+                  className="od-mem-io-btn"
+                  title={`Export all memories as JSON — ${NO_BACKEND}`}
+                  disabled
+                >
+                  <Download size={13} aria-hidden="true" /> Export
+                </button>
+              </div>
+              <p className="od-mem-desc od-mem-add-desc">
+                Add a long-term fact the agent should remember across chats —
+                e.g. "I prefer concise replies".
+              </p>
+              <input
+                className="od-mem-add-input"
+                value={draft}
+                onChange={(e) => {
+                  setDraft(e.target.value);
+                  if (addError) setAddError(null);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") submitAdd();
+                  else if (e.key === "Escape") onClose();
+                }}
+                placeholder="Add a memory — e.g. 'I prefer concise replies'"
+                aria-label="New memory"
+                // biome-ignore lint/a11y/noAutofocus: Add tab is opened intentionally to type.
+                autoFocus
+              />
+              <div className="od-mem-add-foot">
+                {addError ? (
+                  <span className="od-mem-add-error">{addError}</span>
+                ) : (
+                  <span />
+                )}
+                <button
+                  type="button"
+                  className="od-mem-add-btn"
+                  onClick={submitAdd}
+                  disabled={!draft.trim() || adding}
+                >
+                  {adding ? "Saving…" : "Add memory"}
+                </button>
+              </div>
+            </div>
+
+            <div className="od-mem-card od-mem-add-card">
+              <div className="od-mem-card-head">
+                <h2 className="od-mem-card-title">
+                  <Zap
+                    size={14}
+                    className="od-mem-title-icon"
+                    aria-hidden="true"
+                  />
+                  Add Skill
+                </h2>
+              </div>
+              <p className="od-mem-desc">
+                Create a skill by hand — title, what it solves, and an approach.
+                Use the Skills tab to add and edit skills.
+              </p>
+              <button
+                type="button"
+                className="od-mem-add-btn od-mem-add-btn-secondary"
+                onClick={() => setTab("skills")}
+              >
+                <Zap size={12} aria-hidden="true" /> Open Skills tab
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {tab === "settings" ? (
+          <div className="od-mem-settings">
+            <div className="od-mem-card od-mem-set-card">
+              <div className="od-mem-set-row">
+                <h2 className="od-mem-card-title">Auto-extract memories</h2>
+                <label
+                  className="od-mem-switch"
+                  title={`Automatically extract memories from conversations — ${NO_BACKEND}`}
+                >
+                  <input type="checkbox" defaultChecked disabled />
+                  <span className="od-mem-switch-track" aria-hidden="true" />
+                </label>
+              </div>
+              <span className="od-mem-set-sub">
+                Automatically extract memories from conversations.
+              </span>
+            </div>
+            <div className="od-mem-card od-mem-set-card">
+              <div className="od-mem-set-row">
+                <h2 className="od-mem-card-title">Auto-extract skills</h2>
+                <label
+                  className="od-mem-switch"
+                  title={`Automatically draft reusable skills from your workflows — ${NO_BACKEND}`}
+                >
+                  <input type="checkbox" disabled />
+                  <span className="od-mem-switch-track" aria-hidden="true" />
+                </label>
+              </div>
+              <span className="od-mem-set-sub">
+                Automatically draft reusable skills from your workflows.
+              </span>
+            </div>
+            <div className="od-mem-card od-mem-set-card">
+              <div className="od-mem-set-row">
+                <h2 className="od-mem-card-title">Inject Skills</h2>
+              </div>
+              <span className="od-mem-set-sub">
+                Controls how many relevant skills are added to each agent
+                request.
+              </span>
+              <div className="od-mem-set-control">
+                <span className="od-mem-set-sub">Max skills per request</span>
+                <input
+                  type="number"
+                  className="od-mem-set-number"
+                  min={0}
+                  max={12}
+                  step={1}
+                  defaultValue={3}
+                  disabled
+                  title={NO_BACKEND}
+                  aria-label="Max skills per request"
+                />
+              </div>
+              <span className="od-mem-set-sub od-mem-set-hint">
+                Set to 0 to disable skill injection.
+              </span>
+            </div>
+            <div className="od-mem-card od-mem-set-card">
+              <div className="od-mem-set-row">
+                <h2 className="od-mem-card-title">Auto-approve skills</h2>
+                <label
+                  className="od-mem-switch"
+                  title={`Publish passing skills at or above the confidence threshold — ${NO_BACKEND}`}
+                >
+                  <input type="checkbox" defaultChecked disabled />
+                  <span className="od-mem-switch-track" aria-hidden="true" />
+                </label>
+              </div>
+              <span className="od-mem-set-sub">
+                Off = keep audit results as drafts unless manually approved.
+              </span>
+            </div>
+            <p className="od-mem-set-note">
+              These extraction and injection controls reflect odysseus's Brain
+              settings. This agent's memory and skills backend manages them
+              automatically, so they are shown for reference but not editable
+              here.
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/MessageBubble.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/MessageBubble.tsx
@@ -1,0 +1,320 @@
+// odysseus message bubbles (static/index.html .msg-user / .msg-ai). User turns
+// are right-aligned rounded bubbles; agent turns are left bubbles with a model
+// role header (dot + name) above flat markdown. Prose + code render through the
+// shared MarkdownText so we don't re-solve markdown here.
+//
+// Each bubble carries:
+//   • a per-turn action footer — odysseus chatRenderer.js createUserMsgFooter /
+//     createMsgFooter. Odysseus's user footer offers edit / delete / copy /
+//     resend with an overflow menu, but edit / delete / resend all require
+//     per-message mutation endpoints the orchestrator does not expose (the
+//     client only has postOrchestratorTaskMessage + a whole-task delete — there
+//     is no per-message PUT/DELETE). So, exactly as ChatMessages' AgentFooter
+//     does for the assistant turn, we ship only the honest wired subset: a Copy
+//     button. No dead edit/delete/resend controls that route nowhere.
+//   • a sensitive-info censor — odysseus static/js/censor.js. Pure client-side:
+//     it blurs emails / API keys / tokens / JWTs / private keys / internal IPs
+//     in the rendered body and reveals an item on click. Off by default, gated
+//     on the same opt-in pref odysseus uses (`odysseus-sensitive-blur`), so it
+//     never alters output unless the user turned it on.
+
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { MarkdownText } from "../orchestrator-markdown";
+import type { ConversationBlock } from "../orchestrator-stream";
+import { formatClockTime } from "../view-format";
+
+type UserBlock = Extract<ConversationBlock, { kind: "user" }>;
+type AgentBlock = Extract<ConversationBlock, { kind: "agent" }>;
+
+// ── Sensitive-info censor (odysseus static/js/censor.js) ───────────────────
+// Patterns that mark a substring as sensitive. Ported 1:1 from censor.js
+// PATTERNS — emails, API-key prefixes, bearer tokens, key=value credentials,
+// PEM private keys, long hashes, JWTs, internal-network IPs.
+const CENSOR_PATTERNS: { re: RegExp; label: string }[] = [
+  { re: /\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b/g, label: "email" },
+  {
+    re: /\b(sk-[a-zA-Z0-9]{20,}|pk-[a-zA-Z0-9]{20,}|ghp_[a-zA-Z0-9]{36,}|gho_[a-zA-Z0-9]{36,}|glpat-[a-zA-Z0-9\-_]{20,}|xox[bpras]-[a-zA-Z0-9-]{10,}|npm_[a-zA-Z0-9]{36,}|AKIA[A-Z0-9]{12,})\b/g,
+    label: "api-key",
+  },
+  { re: /Bearer\s+[A-Za-z0-9._-]{20,}/g, label: "token" },
+  {
+    re: /(?:password|passwd|secret|api[_-]?key|access[_-]?token|auth[_-]?token|private[_-]?key|client[_-]?secret)[\s]*[:=]\s*["']?[^\s"'<]{4,}["']?/gi,
+    label: "credential",
+  },
+  {
+    re: /-----BEGIN\s[\w\s]*PRIVATE KEY-----[\s\S]*?-----END\s[\w\s]*PRIVATE KEY-----/g,
+    label: "private-key",
+  },
+  { re: /\b[0-9a-f]{32,}\b/gi, label: "hash" },
+  {
+    re: /\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+    label: "jwt",
+  },
+  {
+    re: /\b(?:10\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])|192\.168)\.\d{1,3}\.\d{1,3}(?::\d+)?\b/g,
+    label: "internal-ip",
+  },
+];
+
+const CENSOR_PREF_KEY = "odysseus-sensitive-blur";
+
+// How long the Copy button shows its success glyph before reverting (odysseus
+// chatRenderer.js footer-copy-btn reverts after 1500ms).
+const COPY_FEEDBACK_MS = 1500;
+
+/** Mirrors censor.js `_prefEnabled` — opt-in, off unless explicitly turned on. */
+function censorEnabled(): boolean {
+  if (typeof localStorage === "undefined") return false;
+  try {
+    return localStorage.getItem(CENSOR_PREF_KEY) === "on";
+  } catch {
+    return false;
+  }
+}
+
+interface CensorMatch {
+  start: number;
+  end: number;
+  text: string;
+  label: string;
+}
+
+/** Wrap sensitive substrings inside a single text node with `.od-censored`
+ * spans. Faithful to censor.js `_processElement` Pass 1: collect every pattern
+ * match, merge overlaps, then splice the node into text / censored fragments. */
+function censorTextNode(node: Text): void {
+  const text = node.textContent;
+  if (!text || text.trim().length < 4) return;
+
+  const matches: CensorMatch[] = [];
+  for (const pattern of CENSOR_PATTERNS) {
+    pattern.re.lastIndex = 0;
+    let m = pattern.re.exec(text);
+    while (m !== null) {
+      matches.push({
+        start: m.index,
+        end: m.index + m[0].length,
+        text: m[0],
+        label: pattern.label,
+      });
+      m = pattern.re.exec(text);
+    }
+  }
+  if (matches.length === 0) return;
+
+  matches.sort((a, b) => a.start - b.start);
+  const deduped: CensorMatch[] = [matches[0]];
+  for (let i = 1; i < matches.length; i++) {
+    const prev = deduped[deduped.length - 1];
+    if (matches[i].start < prev.end) {
+      if (matches[i].end > prev.end) prev.end = matches[i].end;
+    } else {
+      deduped.push(matches[i]);
+    }
+  }
+
+  const frag = document.createDocumentFragment();
+  let lastIdx = 0;
+  for (const match of deduped) {
+    if (match.start > lastIdx) {
+      frag.appendChild(
+        document.createTextNode(text.slice(lastIdx, match.start)),
+      );
+    }
+    const span = document.createElement("span");
+    span.className = "od-censored";
+    span.dataset.type = match.label;
+    span.title = `Click to reveal ${match.label}`;
+    span.textContent = match.text;
+    frag.appendChild(span);
+    lastIdx = match.end;
+  }
+  if (lastIdx < text.length) {
+    frag.appendChild(document.createTextNode(text.slice(lastIdx)));
+  }
+  node.parentNode?.replaceChild(frag, node);
+}
+
+/** Walk every (uncensored, non-`<pre>`) text node under `root` and censor it. */
+function censorElement(root: HTMLElement): void {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  const targets: Text[] = [];
+  let node = walker.nextNode();
+  while (node !== null) {
+    // SHOW_TEXT yields only Text nodes; the instanceof keeps the type honest
+    // (no cast) and satisfies the parentElement access below.
+    if (node instanceof Text) {
+      const parent = node.parentElement;
+      // Don't censor code blocks or anything already censored.
+      if (parent && !parent.closest("pre, .od-censored")) targets.push(node);
+    }
+    node = walker.nextNode();
+  }
+  for (const target of targets) censorTextNode(target);
+}
+
+/** Hook: run the censor over a body ref after each render of `content`, and
+ * wire click-to-reveal on the censored spans. No-op unless the pref is on. */
+function useCensoredBody(content: string) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-censor whenever the rendered body content changes
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !censorEnabled()) return;
+    censorElement(el);
+    const onClick = (e: MouseEvent) => {
+      const target = e.target;
+      if (!(target instanceof HTMLElement)) return;
+      const item = target.closest(".od-censored");
+      if (!item) return;
+      e.preventDefault();
+      e.stopPropagation();
+      item.classList.toggle("revealed");
+    };
+    el.addEventListener("click", onClick);
+    return () => el.removeEventListener("click", onClick);
+  }, [content]);
+
+  return ref;
+}
+
+/** Hover-revealed Copy action for one turn — odysseus footer-copy-btn. Copy is
+ * the only footer action with a real wired surface (it is pure client-side);
+ * edit / delete / resend need per-message mutation endpoints the orchestrator
+ * does not expose, so they are intentionally absent rather than dead controls.
+ * Mirrors ChatMessages' AgentFooter so user and assistant footers behave alike. */
+function CopyFooter({ content }: { content: string }): ReactNode {
+  const [copied, setCopied] = useState(false);
+  // Revert timer for the success glyph; cleared on unmount and before re-arming
+  // so copying a message that unmounts within the window never sets state on an
+  // unmounted component.
+  const revertRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (revertRef.current !== null) clearTimeout(revertRef.current);
+    },
+    [],
+  );
+
+  const onCopy = useCallback(() => {
+    // Guard for non-secure-context / older webviews where clipboard is absent.
+    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText)
+      return;
+    navigator.clipboard.writeText(content).then(
+      () => {
+        setCopied(true);
+        if (revertRef.current !== null) clearTimeout(revertRef.current);
+        revertRef.current = setTimeout(
+          () => setCopied(false),
+          COPY_FEEDBACK_MS,
+        );
+      },
+      () => undefined,
+    );
+  }, [content]);
+
+  return (
+    <div className="od-msg-footer">
+      <span className="od-msg-actions">
+        <button
+          type="button"
+          className="od-footer-copy-btn"
+          title={copied ? "Copied" : "Copy message"}
+          aria-label={copied ? "Copied" : "Copy message"}
+          data-copied={copied ? "true" : undefined}
+          onClick={onCopy}
+        >
+          {copied ? <CheckGlyph /> : <CopyGlyph />}
+        </button>
+      </span>
+    </div>
+  );
+}
+
+// odysseus chatRenderer.js COPY_ICON / CHECK_ICON, as inline SVG so the footer
+// matches the upstream copy affordance exactly (lucide is used elsewhere; these
+// two-stroke glyphs are the odysseus originals).
+function CopyGlyph(): ReactNode {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+function CheckGlyph(): ReactNode {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+export function UserBubble({
+  block,
+  locale,
+}: {
+  block: UserBlock;
+  locale?: string;
+}): ReactNode {
+  const bodyRef = useCensoredBody(block.content);
+  return (
+    <div className="od-msg od-msg-user">
+      <div className="od-body" ref={bodyRef}>
+        <MarkdownText text={block.content} />
+      </div>
+      <div className="od-msg-time">{formatClockTime(block.at, locale)}</div>
+      <CopyFooter content={block.content} />
+    </div>
+  );
+}
+
+export function AgentBubble({
+  block,
+  locale,
+}: {
+  block: AgentBlock;
+  locale?: string;
+}): ReactNode {
+  const bodyRef = useCensoredBody(block.content);
+  return (
+    <div className="od-msg od-msg-ai">
+      <div className="od-role">{block.senderName}</div>
+      <div
+        className={`od-body${block.tone === "error" ? " od-body-error" : ""}`}
+        ref={bodyRef}
+      >
+        <MarkdownText text={block.content} />
+      </div>
+      <div className="od-msg-time">{formatClockTime(block.at, locale)}</div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/MessageBubble.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/MessageBubble.tsx
@@ -20,6 +20,7 @@
 
 import {
   type ReactNode,
+  type RefObject,
   useCallback,
   useEffect,
   useRef,
@@ -160,8 +161,19 @@ function censorElement(root: HTMLElement): void {
 }
 
 /** Hook: run the censor over a body ref after each render of `content`, and
- * wire click-to-reveal on the censored spans. No-op unless the pref is on. */
-function useCensoredBody(content: string) {
+ * wire click-to-reveal on the censored spans. No-op unless the pref is on.
+ *
+ * Returns `{ ref, markdownKey }`. When censoring is enabled the censor mutates
+ * MarkdownText's rendered DOM (swapping text nodes for `.od-censored` spans);
+ * `markdownKey` (= content) must be applied to the MarkdownText element so React
+ * REMOUNTS that subtree on every content change instead of reconciling in place
+ * over the out-of-tree mutations — which would throw a NotFoundError once the
+ * trailing block streams under a stable key. When disabled, `markdownKey` is
+ * undefined so streaming stays a cheap in-place reconcile. */
+function useCensoredBody(content: string): {
+  ref: RefObject<HTMLDivElement | null>;
+  markdownKey: string | undefined;
+} {
   const ref = useRef<HTMLDivElement>(null);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: re-censor whenever the rendered body content changes
@@ -182,7 +194,7 @@ function useCensoredBody(content: string) {
     return () => el.removeEventListener("click", onClick);
   }, [content]);
 
-  return ref;
+  return { ref, markdownKey: censorEnabled() ? content : undefined };
 }
 
 /** Hover-revealed Copy action for one turn — odysseus footer-copy-btn. Copy is
@@ -285,11 +297,11 @@ export function UserBubble({
   block: UserBlock;
   locale?: string;
 }): ReactNode {
-  const bodyRef = useCensoredBody(block.content);
+  const { ref: bodyRef, markdownKey } = useCensoredBody(block.content);
   return (
     <div className="od-msg od-msg-user">
       <div className="od-body" ref={bodyRef}>
-        <MarkdownText text={block.content} />
+        <MarkdownText key={markdownKey} text={block.content} />
       </div>
       <div className="od-msg-time">{formatClockTime(block.at, locale)}</div>
       <CopyFooter content={block.content} />
@@ -304,7 +316,7 @@ export function AgentBubble({
   block: AgentBlock;
   locale?: string;
 }): ReactNode {
-  const bodyRef = useCensoredBody(block.content);
+  const { ref: bodyRef, markdownKey } = useCensoredBody(block.content);
   return (
     <div className="od-msg od-msg-ai">
       <div className="od-role">{block.senderName}</div>
@@ -312,7 +324,7 @@ export function AgentBubble({
         className={`od-body${block.tone === "error" ? " od-body-error" : ""}`}
         ref={bodyRef}
       >
-        <MarkdownText text={block.content} />
+        <MarkdownText key={markdownKey} text={block.content} />
       </div>
       <div className="od-msg-time">{formatClockTime(block.at, locale)}</div>
     </div>

--- a/plugins/plugin-task-coordinator/src/odysseus/MinimizedDock.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/MinimizedDock.tsx
@@ -1,0 +1,124 @@
+// MinimizedDock — odysseus's bottom dock of chips, one per minimized tool
+// window (static/js/modalManager.js `_renderDock` + the `#minimized-dock` /
+// `.minimized-dock-chip` rules in static/style.css). Pure presentational: it
+// reads the minimized-window list from the WindowManager and renders a chip
+// (icon + label + ×) for each. Clicking a chip restores the window
+// (setMinimized(id, false)); the × closes it (meta.onClose + un-minimize).
+// Theme-var styled,
+// no .css import — the dock CSS is appended to ODYSSEUS_CSS (see odysseus-theme).
+//
+// The drag/reorder/chain physics from the odysseus source are intentionally
+// out of scope for this core: the chip is a plain restore/close control. Layout
+// stays faithful (bottom-anchored pill row), but the elaborate touch gestures
+// are a later enhancement, not part of the minimize-to-dock core.
+
+import {
+  BookOpen,
+  Boxes,
+  Brain,
+  CalendarDays,
+  Columns2,
+  FileText,
+  FlaskConical,
+  Images,
+  LayoutGrid,
+  ListChecks,
+  type LucideIcon,
+  Mail,
+  MessagesSquare,
+  Mic,
+  Palette,
+  Pencil,
+  Settings,
+  ShieldAlert,
+  SlidersHorizontal,
+  StickyNote,
+  X,
+  Zap,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { useWindowManager } from "./WindowManager";
+
+// Explicit name→component map. lucide-react@1 ships no clean dynamic `icons`
+// record we can type against without an `any`, so the dock keeps a small,
+// strictly-typed registry of the icons the odysseus tool windows actually use.
+// A view passes the matching name string as its `meta.icon`; an unrecognised
+// name falls back to a neutral window glyph rather than crashing.
+const ICONS: Readonly<Record<string, LucideIcon>> = {
+  BookOpen,
+  Boxes,
+  Brain,
+  CalendarDays,
+  Columns2,
+  FileText,
+  FlaskConical,
+  Images,
+  ListChecks,
+  Mail,
+  MessagesSquare,
+  Mic,
+  Palette,
+  Pencil,
+  Settings,
+  ShieldAlert,
+  SlidersHorizontal,
+  StickyNote,
+  Zap,
+};
+
+function iconFor(name: string): LucideIcon {
+  return ICONS[name] ?? LayoutGrid;
+}
+
+export function MinimizedDock(): ReactNode {
+  const manager = useWindowManager();
+  // No provider, or nothing minimized → render nothing (the dock element only
+  // exists while it has chips, matching modalManager.js's empty-dock hide).
+  if (!manager || manager.minimizedWindows.length === 0) return null;
+
+  return (
+    <div
+      className="od-minimized-dock"
+      role="toolbar"
+      aria-label="Minimized windows"
+    >
+      {manager.minimizedWindows.map((win) => {
+        const Icon = iconFor(win.icon);
+        return (
+          <div key={win.id} className="od-dock-chip">
+            <button
+              type="button"
+              className="od-dock-chip-restore"
+              onClick={() => manager.setMinimized(win.id, false)}
+              title={`Restore ${win.label}`}
+              aria-label={`Restore ${win.label}`}
+            >
+              <Icon
+                className="od-dock-chip-icon"
+                size={14}
+                aria-hidden="true"
+              />
+              <span className="od-dock-chip-label">{win.label}</span>
+            </button>
+            <button
+              type="button"
+              className="od-dock-chip-close"
+              onClick={() => {
+                // Close the underlying view, then clear its minimized flag so
+                // the chip disappears. (We don't unregister: the view stays
+                // mounted in the shell, so its hook keeps owning the entry —
+                // unregistering here would orphan it until a remount.)
+                win.onClose?.();
+                manager.setMinimized(win.id, false);
+              }}
+              title={`Close ${win.label}`}
+              aria-label={`Close ${win.label}`}
+            >
+              <X size={13} aria-hidden="true" />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/ModelsView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/ModelsView.tsx
@@ -1,0 +1,955 @@
+// odysseus model catalog + picker + provider management (static/js/models.js +
+// modelPicker.js + modelSort.js + providers.js). A model-browser panel: a
+// provider rail (left) that lets you pick which provider to scan, a sort menu
+// (Default / A→Z / Last used / Most used), and a catalogue body that mirrors
+// the reworked modelPicker.js browse model:
+//   • a search box (shown once a catalogue is large) that filters the whole
+//     scanned catalogue FLAT — id / display / provider name — across groups;
+//   • in browse mode, a Recent section (auto-tracked, last 5 picks) and a
+//     Favorites section pinned on top (manual);
+//   • below them, small catalogues list everything under one "All models"
+//     header, while large catalogues (> BROWSE_ALL_LIMIT) group the remaining
+//     models under collapsible PROVIDER headers (provider = the model-id slug,
+//     e.g. `anthropic/…`, mapped to a display name), each with a chevron +
+//     count and a domino expand on open;
+//   • every row carries a per-model favorite dot (provider-logo when matched)
+//     that toggles favorite with a transient pulse, plus the "+ Chat" /
+//     "+ Image" action and a drag-handle affordance.
+// Favorites / recent / usage / sort / collapse state persist locally exactly
+// like odysseus (FAVORITES_KEY / RECENT_KEY / USAGE_KEY / SORT_KEY /
+// COLLAPSE_KEY via readPref/writePref).
+//
+// elizaMapping: the model lists are wired to the REAL model catalogue via
+// client.fetchModels(provider) — the same /api/models endpoint CompareView's
+// dropdowns use, returning ProviderModelRecord[]. odysseus's catalogue is a
+// server scan that returns endpoint-grouped items with category (local vs api)
+// and per-endpoint online/offline state; eliza's fetchModels returns a FLAT
+// ProviderModelRecord[] ({ id, name, category }) per provider, with NO endpoint
+// identity and NO online/offline signal — its `category` is the model modality
+// (chat / image / embedding / …), not odysseus's local-vs-API axis. So the rail
+// picks a PROVIDER (not an endpoint), and the in-body grouping is by the model
+// id's slug (modelPicker.js _providerSlug / _providerDisplayName), faithful to
+// upstream's provider-grouped browse. odysseus's Local/API category headers and
+// per-endpoint collapsible sub-groups (models.js categoryOrder / multiEndpoints /
+// endpoint-offline-badge) are deliberately NOT reproduced: the underlying
+// endpoint/category(local-vs-api)/offline data does not exist in eliza's
+// contract, and synthesising it would be fabricated UI. The COLLAPSE_KEY group
+// keys are `ep:<provider>:<slug>` (real, used by the provider groups). Favorites
+// + recent + usage tracking are per-browser localStorage, never agent state.
+// odysseus's true model-switch (createDirectChat) starts a new session against a
+// specific endpoint URL; eliza has no per-model session-spawn client method (the
+// agent runs one configured model), so the "+ Chat" action records local usage +
+// recent + emits a DOM event a host can wire later, and never fabricates a
+// started session. Providers eliza has no key configured for return the faithful
+// empty state ("No models available") rather than seeded/representative rows.
+
+import type { ProviderModelRecord } from "@elizaos/ui";
+import { client } from "@elizaos/ui";
+import { ChevronDown, GripVertical, Minus, Search, X } from "lucide-react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+import { LoadingRow } from "./Spinner";
+import { readPref, writePref } from "./util/storage";
+
+// ── Local-pref keys (odysseus models.js / modelPicker.js constants, namespaced
+// via readPref) ──
+const FAVORITES_KEY = "model-favorites";
+const RECENT_KEY = "model-recent";
+const USAGE_KEY = "model-usage";
+const SORT_KEY = "model-sort";
+const COLLAPSE_KEY = "models-collapsed";
+
+// ── Provider scan keys (real /api/models fetch keys, mirrors CompareView) ──
+const PROVIDERS = [
+  "openai",
+  "anthropic",
+  "google",
+  "openrouter",
+  "groq",
+  "xai",
+  "ollama",
+] as const;
+
+type Provider = (typeof PROVIDERS)[number];
+
+// ── Sort modes (odysseus models.js _getSortMode values) ──
+type SortMode = "" | "alpha" | "last-used" | "most-used";
+
+const SORT_OPTIONS: { value: SortMode; label: string }[] = [
+  { value: "", label: "Default" },
+  { value: "alpha", label: "A → Z" },
+  { value: "last-used", label: "Last used" },
+  { value: "most-used", label: "Most used" },
+];
+
+// Up to MAX_VISIBLE models render eagerly per provider group; the rest sit
+// behind "Show N more" (odysseus models.js MAX_VISIBLE = 5).
+const MAX_VISIBLE = 5;
+// Search box only appears once a scan exposes this many models
+// (odysseus models.js totalModelCount >= 10 gate).
+const SEARCH_THRESHOLD = 10;
+// Recent tracks the last RECENT_MAX picks, most-recent-first
+// (modelPicker.js RECENT_MAX = 5).
+const RECENT_MAX = 5;
+// Catalogues at or below this size list everything under one "All models"
+// header; larger ones fall back to collapsible provider groups
+// (modelPicker.js BROWSE_ALL_LIMIT = 12).
+const BROWSE_ALL_LIMIT = 12;
+
+interface UsageEntry {
+  count: number;
+  last: number;
+}
+type UsageMap = Record<string, UsageEntry>;
+
+// ── Provider display names + slug grouping (modelPicker.js _PROVIDER_NAMES /
+// _PROVIDER_ALIAS / _providerSlug / _providerDisplayName). The provider is the
+// model-id slug before the first "/", aliased + prettified. Models with no
+// slash fall under "other". ──
+const PROVIDER_NAMES: Record<string, string> = {
+  "01-ai": "Yi",
+  abacusai: "Abacus AI",
+  adept: "Adept",
+  ai21: "AI21 Labs",
+  ai21labs: "AI21 Labs",
+  "aion-labs": "Aion Labs",
+  aisingapore: "AI Singapore",
+  allenai: "Allen AI",
+  amazon: "Amazon",
+  "anthracite-org": "Anthracite",
+  anthropic: "Anthropic",
+  "arcee-ai": "Arcee AI",
+  baai: "BAAI",
+  baidu: "Baidu",
+  bigcode: "BigCode",
+  "black-forest-labs": "Black Forest Labs",
+  bytedance: "ByteDance",
+  "bytedance-seed": "ByteDance",
+  cognitivecomputations: "Cognitive Computations",
+  cohere: "Cohere",
+  databricks: "Databricks",
+  deepcogito: "DeepCogito",
+  deepseek: "DeepSeek",
+  "deepseek-ai": "DeepSeek",
+  essentialai: "Essential AI",
+  google: "Google",
+  gryphe: "Gryphe",
+  ibm: "IBM",
+  "ibm-granite": "IBM Granite",
+  inception: "Inception",
+  inclusionai: "Inclusion AI",
+  inflection: "Inflection",
+  kwaipilot: "KwaiPilot",
+  liquid: "Liquid AI",
+  mancer: "Mancer",
+  meta: "Llama",
+  "meta-llama": "Llama",
+  microsoft: "Microsoft",
+  minimax: "MiniMax",
+  minimaxai: "MiniMax",
+  mistralai: "Mistral",
+  moonshotai: "Moonshot",
+  morph: "Morph",
+  "nex-agi": "Nex AGI",
+  nousresearch: "Nous Research",
+  "nv-mistralai": "NVIDIA x Mistral",
+  nvidia: "NVIDIA",
+  openai: "OpenAI",
+  openrouter: "OpenRouter",
+  perceptron: "Perceptron",
+  perplexity: "Perplexity",
+  poolside: "Poolside",
+  "prime-intellect": "Prime Intellect",
+  qwen: "Qwen",
+  rekaai: "Reka",
+  relace: "Relace",
+  sao10k: "Sao10k",
+  sarvamai: "Sarvam AI",
+  snowflake: "Snowflake",
+  stepfun: "StepFun",
+  "stepfun-ai": "StepFun",
+  stockmark: "Stockmark",
+  switchpoint: "SwitchPoint",
+  tencent: "Tencent",
+  thedrummer: "TheDrummer",
+  undi95: "Undi95",
+  upstage: "Upstage",
+  writer: "Writer",
+  "x-ai": "xAI",
+  xiaomi: "Xiaomi",
+  "z-ai": "Zhipu",
+  zyphra: "Zyphra",
+  "~anthropic": "Anthropic",
+  "~google": "Google",
+  "~moonshotai": "Moonshot",
+  "~openai": "OpenAI",
+};
+
+const PROVIDER_ALIAS: Record<string, string> = {
+  "meta-llama": "meta",
+  deepseek: "deepseek-ai",
+  minimaxai: "minimax",
+  "stepfun-ai": "stepfun",
+  ai21labs: "ai21",
+  "ibm-granite": "ibm",
+  "bytedance-seed": "bytedance",
+  "~anthropic": "anthropic",
+  "~google": "google",
+  "~moonshotai": "moonshotai",
+  "~openai": "openai",
+};
+
+/** modelPicker.js `_providerDisplayName`: prettify a slug to a label. */
+function providerDisplayName(slug: string): string {
+  const known = PROVIDER_NAMES[slug];
+  if (known) return known;
+  return slug.charAt(0).toUpperCase() + slug.slice(1).replace(/-/g, " ");
+}
+
+/** modelPicker.js `_providerSlug`: the id prefix before "/", aliased. */
+function providerSlug(modelId: string): string {
+  const slash = modelId.indexOf("/");
+  const raw = slash > 0 ? modelId.substring(0, slash) : "other";
+  return PROVIDER_ALIAS[raw] ?? raw;
+}
+
+// ── Provider-scan-key → brand label (providers.js display names). The rail keys
+// are the /api/models fetch keys ("openai", "xai", …); some differ from the
+// PROVIDER_NAMES slugs ("xai" vs "x-ai"). Map each to the canonical brand label
+// (OpenAI, xAI, OpenRouter, Ollama, …) so casing comes from data, not CSS. ──
+const RAIL_SLUG_ALIAS: Record<Provider, string> = {
+  openai: "openai",
+  anthropic: "anthropic",
+  google: "google",
+  openrouter: "openrouter",
+  groq: "groq",
+  xai: "x-ai",
+  ollama: "ollama",
+};
+
+/** Brand-correct label for a provider-scan key (rail + header). */
+function providerRailLabel(p: Provider): string {
+  return providerDisplayName(RAIL_SLUG_ALIAS[p]);
+}
+
+// ── Provider-logo regex table (odysseus static/js/providers.js _PROVIDERS),
+// returning an SVG path-set keyed by a regex over the model id. Kept inline so
+// the model dot mirrors odysseus exactly without depending on @elizaos/ui's
+// provider registry (which has a different contract). ──
+interface LogoDef {
+  re: RegExp;
+  paths: ReactNode;
+  fill: boolean;
+}
+
+const PROVIDER_LOGOS: LogoDef[] = [
+  {
+    re: /openai|gpt-|^o[13]-|chatgpt|dall-e/i,
+    fill: true,
+    paths: (
+      <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 10.696.453a6.023 6.023 0 0 0-5.75 4.172 6.061 6.061 0 0 0-3.946 2.945 6.024 6.024 0 0 0 .742 7.099 5.98 5.98 0 0 0 .516 4.911 6.046 6.046 0 0 0 6.51 2.9A5.996 5.996 0 0 0 13.26 23.547a6.023 6.023 0 0 0 5.75-4.172 6.061 6.061 0 0 0 3.946-2.945 6.024 6.024 0 0 0-.674-6.609zM13.26 21.047a4.508 4.508 0 0 1-2.886-1.041l.143-.082 4.793-2.769a.777.777 0 0 0 .391-.676V10.34l2.026 1.17a.072.072 0 0 1 .039.061v5.596a4.532 4.532 0 0 1-4.506 4.48zM3.968 17.64a4.473 4.473 0 0 1-.537-3.018l.143.086 4.793 2.769a.79.79 0 0 0 .782 0l5.852-3.379v2.34a.072.072 0 0 1-.029.062l-4.845 2.796a4.532 4.532 0 0 1-6.159-1.656zM2.804 7.922a4.49 4.49 0 0 1 2.348-1.973V11.6a.778.778 0 0 0 .391.676l5.852 3.378-2.026 1.17a.072.072 0 0 1-.068 0L4.456 14.03a4.532 4.532 0 0 1-1.652-6.108zm16.423 3.823L13.375 8.367l2.026-1.17a.072.072 0 0 1 .068 0l4.845 2.796a4.525 4.525 0 0 1-.7 8.08V12.42a.778.778 0 0 0-.387-.676zm2.015-3.025l-.143-.086-4.793-2.769a.79.79 0 0 0-.782 0L9.672 9.243V6.903a.072.072 0 0 1 .029-.062l4.845-2.796a4.525 4.525 0 0 1 6.696 4.675zM8.598 12.66L6.57 11.49a.072.072 0 0 1-.039-.061V5.833a4.525 4.525 0 0 1 7.413-3.48l-.143.082-4.793 2.769a.777.777 0 0 0-.391.676l-.019 6.78zm1.1-2.379l2.607-1.505 2.607 1.505v3.01l-2.607 1.505-2.607-1.505z" />
+    ),
+  },
+  {
+    re: /openrouter|open router/i,
+    fill: false,
+    paths: (
+      <>
+        <circle cx="5" cy="12" r="2.5" />
+        <circle cx="19" cy="6" r="2.5" />
+        <circle cx="19" cy="18" r="2.5" />
+        <path d="M7.5 12h4.5c2 0 2.5-6 4.5-6" />
+        <path d="M12 12c2 0 2.5 6 4.5 6" />
+      </>
+    ),
+  },
+  {
+    re: /anthropic|claude/i,
+    fill: true,
+    paths: (
+      <path d="M17.3041 3.541h-3.6718l6.696 16.918H24Zm-10.6082 0L0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5528h3.7442L10.5363 3.5409Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z" />
+    ),
+  },
+  {
+    re: /google|gemini|gemma/i,
+    fill: true,
+    paths: (
+      <path d="M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81" />
+    ),
+  },
+  {
+    re: /meta|llama(?![.\-_ ]?cpp)/i,
+    fill: true,
+    paths: (
+      <path d="M6.915 4.03c-1.968 0-3.683 1.28-4.871 3.113C.704 9.208 0 11.883 0 14.449c0 .706.07 1.369.21 1.973a6.624 6.624 0 0 0 .265.86 5.297 5.297 0 0 0 .371.761c.696 1.159 1.818 1.927 3.593 1.927 1.497 0 2.633-.671 3.965-2.444.76-1.012 1.144-1.626 2.663-4.32l.756-1.339.186-.325c.061.1.121.196.183.3l2.152 3.595c.724 1.21 1.665 2.556 2.47 3.314 1.046.987 1.992 1.22 3.06 1.22 1.075 0 1.876-.355 2.455-.843a3.743 3.743 0 0 0 .81-.973c.542-.939.861-2.127.861-3.745 0-2.72-.681-5.357-2.084-7.45-1.282-1.912-2.957-2.93-4.716-2.93-1.047 0-2.088.467-3.053 1.308-.652.57-1.257 1.29-1.82 2.05-.69-.875-1.335-1.547-1.958-2.056-1.182-.966-2.315-1.303-3.454-1.303zm10.16 2.053c1.147 0 2.188.758 2.992 1.999 1.132 1.748 1.647 4.195 1.647 6.4 0 1.548-.368 2.9-1.839 2.9-.58 0-1.027-.23-1.664-1.004-.496-.601-1.343-1.878-2.832-4.358l-.617-1.028a44.908 44.908 0 0 0-1.255-1.98c.07-.109.141-.224.211-.327 1.12-1.667 2.118-2.602 3.358-2.602zm-10.201.553c1.265 0 2.058.791 2.675 1.446.307.327.737.871 1.234 1.579l-1.02 1.566c-.757 1.163-1.882 3.017-2.837 4.338-1.191 1.649-1.81 1.817-2.486 1.817-.524 0-1.038-.237-1.383-.794-.263-.426-.464-1.13-.464-2.046 0-2.221.63-4.535 1.66-6.088.454-.687.964-1.226 1.533-1.533a2.264 2.264 0 0 1 1.088-.285z" />
+    ),
+  },
+  {
+    re: /mistral/i,
+    fill: true,
+    paths: (
+      <path d="M17.143 3.429v3.428h-3.429v3.429h-3.428V6.857H6.857V3.43H3.43v13.714H0v3.428h10.286v-3.428H6.857v-3.429h3.429v3.429h3.429v-3.429h3.428v3.429h-3.428v3.428H24v-3.428h-3.43V3.429z" />
+    ),
+  },
+  {
+    re: /deepseek/i,
+    fill: true,
+    paths: (
+      <path d="M23.748 4.482c-.254-.124-.364.113-.512.234-.051.039-.094.09-.137.136-.372.397-.806.657-1.373.626-.829-.046-1.537.214-2.163.848-.133-.782-.575-1.248-1.247-1.548-.352-.156-.708-.311-.955-.65-.172-.241-.219-.51-.305-.774-.055-.16-.11-.323-.293-.35-.2-.031-.278.136-.356.276-.313.572-.434 1.202-.422 1.84.027 1.436.633 2.58 1.838 3.393.137.093.172.187.129.323-.082.28-.18.552-.266.833-.055.179-.137.217-.329.14a5.526 5.526 0 01-1.736-1.18c-.857-.828-1.631-1.742-2.597-2.458a11.365 11.365 0 00-.689-.471c-.985-.957.13-1.743.388-1.836.27-.098.093-.432-.779-.428-.872.004-1.67.295-2.687.684a3.055 3.055 0 01-.465.137 9.597 9.597 0 00-2.883-.102c-1.885.21-3.39 1.102-4.497 2.623C.082 8.606-.231 10.684.152 12.85c.403 2.284 1.569 4.175 3.36 5.653 1.858 1.533 3.997 2.284 6.438 2.14 1.482-.085 3.133-.284 4.994-1.86.47.234.962.327 1.78.397.63.059 1.236-.03 1.705-.128.735-.156.684-.837.419-.961-2.155-1.004-1.682-.595-2.113-.926 1.096-1.296 2.746-2.642 3.392-7.003.05-.347.007-.565 0-.845-.004-.17.035-.237.23-.256a4.173 4.173 0 001.545-.475c1.396-.763 1.96-2.015 2.093-3.517.02-.23-.004-.467-.247-.588zM11.581 18c-2.089-1.642-3.102-2.183-3.52-2.16-.392.024-.321.471-.235.763.09.288.207.486.371.739.114.167.192.416-.113.603-.673.416-1.842-.14-1.897-.167-1.361-.802-2.5-1.86-3.301-3.307-.774-1.393-1.224-2.887-1.298-4.482-.02-.386.093-.522.477-.592a4.696 4.696 0 011.529-.039c2.132.312 3.946 1.265 5.468 2.774.868.86 1.525 1.887 2.202 2.891.72 1.066 1.494 2.082 2.48 2.914.348.292.625.514.891.677-.802.09-2.14.11-3.054-.614zm1-6.44a.306.306 0 01.415-.287.302.302 0 01.2.288.306.306 0 01-.31.307.303.303 0 01-.304-.308zm3.11 1.596c-.2.081-.399.151-.59.16a1.245 1.245 0 01-.798-.254c-.274-.23-.47-.358-.552-.758a1.73 1.73 0 01.016-.588c.07-.327-.008-.537-.239-.727-.187-.156-.426-.199-.688-.199a.559.559 0 01-.254-.078c-.11-.054-.2-.19-.114-.358.028-.054.16-.186.192-.21.356-.202.767-.136 1.146.016.352.144.618.408 1.001.782.391.451.462.576.685.914.176.265.336.537.445.848.067.195-.019.354-.25.452z" />
+    ),
+  },
+  {
+    re: /x-ai|xai|grok/i,
+    fill: true,
+    paths: (
+      <path d="M14.234 10.162 22.977 0h-2.072l-7.591 8.824L7.251 0H.258l9.168 13.343L.258 24H2.33l8.016-9.318L16.749 24h6.993zm-2.837 3.299-.929-1.329L3.076 1.56h3.182l5.965 8.532.929 1.329 7.754 11.09h-3.182z" />
+    ),
+  },
+  {
+    re: /ollama|:11434/i,
+    fill: true,
+    paths: (
+      <path d="M12 2.5c-3.1 0-5.65 2.43-5.86 5.48A6.62 6.62 0 0 0 3 13.62C3 18 6.8 21.5 12 21.5s9-3.5 9-7.88a6.62 6.62 0 0 0-3.14-5.64C17.65 4.93 15.1 2.5 12 2.5Zm-2.7 8.25a1.15 1.15 0 1 1 0 2.3 1.15 1.15 0 0 1 0-2.3Zm5.4 0a1.15 1.15 0 1 1 0 2.3 1.15 1.15 0 0 1 0-2.3Zm-5.15 5.15c.75.7 1.55 1.04 2.45 1.04s1.7-.34 2.45-1.04c.26-.24.66-.23.9.03.24.26.23.66-.03.9-.98.91-2.08 1.37-3.32 1.37s-2.34-.46-3.32-1.37a.64.64 0 0 1-.03-.9.64.64 0 0 1 .9-.03Z" />
+    ),
+  },
+  {
+    re: /groq/i,
+    fill: true,
+    paths: (
+      <path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm0 3.2a4.8 4.8 0 0 1 0 9.6h-1.5v2.6a.8.8 0 0 1-1.6 0V9.9a4.8 4.8 0 0 1 3.1-4.7zm0 1.6a3.2 3.2 0 0 0-1.5 6V6.9c.5-.07 1-.07 1.5-.1z" />
+    ),
+  },
+];
+
+/** Returns the matching provider logo SVG, or null (odysseus providerLogo). */
+function providerLogo(modelId: string): ReactNode {
+  if (!modelId) return null;
+  for (const def of PROVIDER_LOGOS) {
+    if (def.re.test(modelId)) {
+      return (
+        <svg
+          viewBox="0 0 24 24"
+          fill={def.fill ? "currentColor" : "none"}
+          stroke={def.fill ? undefined : "currentColor"}
+          strokeWidth={def.fill ? undefined : 2}
+          strokeLinecap={def.fill ? undefined : "round"}
+          strokeLinejoin={def.fill ? undefined : "round"}
+          role="img"
+          aria-label="Provider"
+        >
+          {def.paths}
+        </svg>
+      );
+    }
+  }
+  return null;
+}
+
+/** odysseus modelSort.js `_sortText`: trailing path segment, trimmed. */
+function sortText(value: string): string {
+  return value.split("/").pop()?.trim() || value;
+}
+
+/** Last-used epoch for a model id (0 when never used). odysseus usage[mid].last. */
+function lastUsed(usage: UsageMap, id: string): number {
+  const entry = usage[id];
+  return entry ? entry.last : 0;
+}
+
+/** Use-count for a model id (0 when never used). odysseus usage[mid].count. */
+function countFor(usage: UsageMap, id: string): number {
+  const entry = usage[id];
+  return entry ? entry.count : 0;
+}
+
+/** odysseus modelSort.js `_compareText`: numeric, case-insensitive. */
+function compareModels(a: ProviderModelRecord, b: ProviderModelRecord): number {
+  const opts: Intl.CollatorOptions = { numeric: true, sensitivity: "base" };
+  return (
+    sortText(a.name).localeCompare(sortText(b.name), undefined, opts) ||
+    a.name.localeCompare(b.name, undefined, opts)
+  );
+}
+
+/** Short display name: trailing path segment (odysseus displayName.split('/').pop()). */
+function shortName(name: string): string {
+  return name.split("/").pop() || name;
+}
+
+export function ModelsView({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}): ReactNode {
+  useEscapeClose(open, onClose);
+  const win = useWindowControls(
+    "win-models",
+    { w: 820, h: 720 },
+    { label: "Models", icon: "Boxes", onClose },
+  );
+
+  const [provider, setProvider] = useState<Provider>("openai");
+  const [modelsByProvider, setModelsByProvider] = useState<
+    Record<string, ProviderModelRecord[]>
+  >({});
+  const [errored, setErrored] = useState<ReadonlySet<string>>(
+    () => new Set<string>(),
+  );
+  const [loadingProvider, setLoadingProvider] = useState<string | null>(null);
+  const [favorites, setFavorites] = useState<string[]>([]);
+  const [recent, setRecent] = useState<string[]>([]);
+  const [usage, setUsage] = useState<UsageMap>({});
+  const [sortMode, setSortMode] = useState<SortMode>("");
+  const [sortMenuOpen, setSortMenuOpen] = useState(false);
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+  const [shownAll, setShownAll] = useState<ReadonlySet<string>>(
+    () => new Set<string>(),
+  );
+  const [justExpanded, setJustExpanded] = useState<string | null>(null);
+  const [pulsing, setPulsing] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState("");
+  const [query, setQuery] = useState("");
+
+  const loadProvider = useCallback(
+    (prov: string) => {
+      if (modelsByProvider[prov]) return;
+      setLoadingProvider(prov);
+      void client
+        .fetchModels(prov)
+        .then((r) => {
+          setModelsByProvider((prev) => ({ ...prev, [prov]: r.models }));
+        })
+        .catch(() => {
+          setModelsByProvider((prev) => ({ ...prev, [prov]: [] }));
+          setErrored((prev) => {
+            const next = new Set(prev);
+            next.add(prov);
+            return next;
+          });
+        })
+        .finally(() => {
+          setLoadingProvider((cur) => (cur === prov ? null : cur));
+        });
+    },
+    [modelsByProvider],
+  );
+
+  // Hydrate local prefs + scan the default provider on open.
+  useEffect(() => {
+    if (!open) return;
+    setFavorites(readPref<string[]>(FAVORITES_KEY, []));
+    setRecent(readPref<string[]>(RECENT_KEY, []));
+    setUsage(readPref<UsageMap>(USAGE_KEY, {}));
+    setSortMode(readPref<SortMode>(SORT_KEY, ""));
+    setCollapsed(readPref<Record<string, boolean>>(COLLAPSE_KEY, {}));
+    loadProvider("openai");
+  }, [open, loadProvider]);
+
+  const allModels = modelsByProvider[provider] ?? [];
+
+  const byId = useMemo(() => {
+    const map = new Map<string, ProviderModelRecord>();
+    for (const m of allModels) {
+      if (!map.has(m.id)) map.set(m.id, m);
+    }
+    return map;
+  }, [allModels]);
+
+  // Sorted catalogue (odysseus models.js sort dispatch). Memoized so the full
+  // catalogue is only re-sorted when its inputs change — not on every favorite
+  // pulse / toast / menu toggle re-render (large providers list hundreds).
+  const sorted = useMemo(() => {
+    const copy = allModels.slice();
+    if (sortMode === "alpha") {
+      copy.sort(compareModels);
+    } else if (sortMode === "last-used") {
+      copy.sort((a, b) => lastUsed(usage, b.id) - lastUsed(usage, a.id));
+    } else if (sortMode === "most-used") {
+      copy.sort((a, b) => countFor(usage, b.id) - countFor(usage, a.id));
+    }
+    return copy;
+  }, [allModels, sortMode, usage]);
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  const persistFavorites = (next: string[]) => {
+    setFavorites(next);
+    writePref(FAVORITES_KEY, next);
+  };
+
+  // modelPicker.js `_toggleFavorite` + the favorite-dot polish: toggle the
+  // favorite, flash the dot (transient pulse), and surface a transient toast
+  // ("Favorited" / "Unfavorited"), mirroring uiModule.showToast upstream.
+  const toggleFavorite = (mid: string) => {
+    const idx = favorites.indexOf(mid);
+    const nowFav = idx < 0;
+    persistFavorites(
+      nowFav ? [...favorites, mid] : favorites.filter((x) => x !== mid),
+    );
+    setPulsing(mid);
+    window.setTimeout(() => {
+      setPulsing((cur) => (cur === mid ? null : cur));
+    }, 340);
+    setFeedback(nowFav ? "Favorited" : "Unfavorited");
+    window.setTimeout(() => {
+      setFeedback((cur) =>
+        cur === (nowFav ? "Favorited" : "Unfavorited") ? "" : cur,
+      );
+    }, 1400);
+  };
+
+  // odysseus models.js `_trackUsage` + modelPicker.js `_pushRecent` — bump
+  // count, stamp last-used, and unshift onto Recent (deduped, capped). The
+  // actual model-switch (createDirectChat) has no eliza client equivalent, so
+  // this only records local state + broadcasts a DOM event a host can wire.
+  const trackUsage = (mid: string) => {
+    const nextUsage: UsageMap = { ...usage };
+    const entry = nextUsage[mid] ?? { count: 0, last: 0 };
+    nextUsage[mid] = { count: entry.count + 1, last: Date.now() };
+    setUsage(nextUsage);
+    writePref(USAGE_KEY, nextUsage);
+
+    const nextRecent = [mid, ...recent.filter((x) => x !== mid)].slice(
+      0,
+      RECENT_MAX,
+    );
+    setRecent(nextRecent);
+    writePref(RECENT_KEY, nextRecent);
+
+    if (typeof document !== "undefined") {
+      document.dispatchEvent(
+        new CustomEvent("odysseus:model-picked", {
+          detail: { provider, modelId: mid },
+        }),
+      );
+    }
+  };
+
+  const pickSort = (mode: SortMode) => {
+    setSortMode(mode);
+    writePref(SORT_KEY, mode);
+    setSortMenuOpen(false);
+  };
+
+  const isCollapsed = (key: string): boolean => collapsed[key] === true;
+
+  const toggleCollapse = (key: string) => {
+    const next = { ...collapsed, [key]: !isCollapsed(key) };
+    setCollapsed(next);
+    writePref(COLLAPSE_KEY, next);
+    // Domino-expand the group when it opens (modelPicker.js _justExpanded).
+    setJustExpanded(next[key] ? null : key);
+  };
+
+  const isLoading = loadingProvider === provider && !modelsByProvider[provider];
+  const isErrored = errored.has(provider);
+  const hasModels = allModels.length > 0;
+
+  // Flat search. Mirrors modelPicker.js search mode: match id / display /
+  // provider name, case-insensitive, across all groups.
+  const q = query.toLowerCase().trim();
+  const searchMatches = q
+    ? sorted.filter((m) =>
+        [m.id, m.name, providerDisplayName(providerSlug(m.id))]
+          .join(" ")
+          .toLowerCase()
+          .includes(q),
+      )
+    : [];
+
+  // Browse mode (modelPicker.js _populate): Recent (auto) + Favorites (manual)
+  // pinned on top, then either a flat "All models" list (small catalogues) or
+  // collapsible provider groups (large catalogues). Pinned ids are deduped out
+  // of the lower lists.
+  const recentModels = recent
+    .map((id) => byId.get(id))
+    .filter((m): m is ProviderModelRecord => m !== undefined)
+    .slice(0, RECENT_MAX);
+  const favModels = favorites
+    .map((id) => byId.get(id))
+    .filter((m): m is ProviderModelRecord => m !== undefined);
+
+  const pinnedIds = new Set<string>([
+    ...recentModels.map((m) => m.id),
+    ...favModels.map((m) => m.id),
+  ]);
+  const rest = sorted.filter((m) => !pinnedIds.has(m.id));
+
+  // Large catalogue → provider-slug groups, ordered by display name.
+  const providerGroups: { slug: string; models: ProviderModelRecord[] }[] =
+    (() => {
+      const groups = new Map<string, ProviderModelRecord[]>();
+      for (const m of rest) {
+        const slug = providerSlug(m.id);
+        const bucket = groups.get(slug);
+        if (bucket) bucket.push(m);
+        else groups.set(slug, [m]);
+      }
+      return [...groups.keys()]
+        .sort((a, b) =>
+          providerDisplayName(a).localeCompare(providerDisplayName(b)),
+        )
+        .map((slug) => {
+          const models = groups.get(slug);
+          return { slug, models: models ?? [] };
+        });
+    })();
+
+  const isLargeCatalogue = allModels.length > BROWSE_ALL_LIMIT;
+  const showSearch = allModels.length >= SEARCH_THRESHOLD;
+  const hasPinned = recentModels.length > 0 || favModels.length > 0;
+
+  const sortLabel =
+    SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? "Default";
+
+  const renderRow = (m: ProviderModelRecord): ReactNode => {
+    const logo = providerLogo(m.id);
+    const isFav = favorites.includes(m.id);
+    const isImage = m.category === "image";
+    return (
+      <div className="od-models-row" data-model-id={m.id} key={m.id}>
+        <span
+          className="od-models-drag"
+          title="Drag to reorder"
+          aria-hidden="true"
+        >
+          <GripVertical size={11} />
+        </span>
+        <button
+          type="button"
+          className={`od-model-fav-btn${logo ? " od-provider-logo" : ""}${isFav ? " active" : ""}${pulsing === m.id ? " od-fav-pulse" : ""}`}
+          title={isFav ? "Remove from favorites" : "Add to favorites"}
+          aria-label={isFav ? "Remove from favorites" : "Add to favorites"}
+          aria-pressed={isFav}
+          onClick={() => toggleFavorite(m.id)}
+        >
+          {logo}
+        </button>
+        <span className="od-models-grow">
+          {shortName(m.name)}
+          {isImage ? (
+            <span
+              className="od-model-type-badge"
+              title="Image generation model"
+            >
+              IMG
+            </span>
+          ) : null}
+        </span>
+        <button
+          type="button"
+          className="od-model-chat-btn"
+          onClick={() => trackUsage(m.id)}
+        >
+          {isImage ? "+ Image" : "+ Chat"}
+        </button>
+      </div>
+    );
+  };
+
+  // Pinned Recent / Favorites sections (modelPicker.js _addSection) — a flat
+  // labelled list, no collapse.
+  const renderPinned = (
+    label: string,
+    list: ProviderModelRecord[],
+  ): ReactNode =>
+    list.length > 0 ? (
+      <>
+        <div className="od-models-section-label">{label}</div>
+        <div className="od-models-group-content">{list.map(renderRow)}</div>
+      </>
+    ) : null;
+
+  // A collapsible provider group (modelPicker.js mp-provider-header +
+  // mp-provider-group). Capped at MAX_VISIBLE behind a "Show N more".
+  const renderProviderGroup = (
+    slug: string,
+    models: ProviderModelRecord[],
+  ): ReactNode => {
+    const key = `ep:${provider}:${slug}`;
+    const groupCollapsed = isCollapsed(key);
+    const seeAll = shownAll.has(key);
+    const visible = seeAll ? models : models.slice(0, MAX_VISIBLE);
+    const overflow = models.length - visible.length;
+    return (
+      <div key={slug}>
+        <button
+          type="button"
+          className="od-models-provider-header"
+          onClick={() => toggleCollapse(key)}
+        >
+          <span
+            className={`od-models-provider-chevron${groupCollapsed ? " collapsed" : ""}`}
+            aria-hidden="true"
+          >
+            <ChevronDown size={11} />
+          </span>
+          <span className="od-models-provider-group-name">
+            {providerDisplayName(slug)}
+          </span>
+          <span className="od-models-provider-group-count">
+            {models.length}
+          </span>
+        </button>
+        {groupCollapsed ? null : (
+          <div
+            className={`od-models-group-content indented${justExpanded === key ? " od-just-expanded" : ""}`}
+          >
+            {visible.map(renderRow)}
+            {overflow > 0 ? (
+              <button
+                type="button"
+                className="od-models-show-all-btn"
+                onClick={() =>
+                  setShownAll((prev) => {
+                    const next = new Set(prev);
+                    next.add(key);
+                    return next;
+                  })
+                }
+              >
+                Show {overflow} more model{overflow === 1 ? "" : "s"}
+              </button>
+            ) : null}
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className={`od-search-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Models"
+    >
+      <button
+        type="button"
+        aria-label="Close models"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel od-models-panel" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        <div
+          className="od-mem-head od-window-header"
+          onPointerDown={win.onDragStart}
+        >
+          <span className="od-mem-title">Models</span>
+          {feedback ? (
+            <span className="od-models-feedback" role="status">
+              {feedback}
+            </span>
+          ) : null}
+          <span className="od-mem-stats">
+            {hasModels
+              ? `${allModels.length} model${allModels.length === 1 ? "" : "s"} · ${providerRailLabel(provider)}`
+              : providerRailLabel(provider)}
+          </span>
+          <span className="od-window-controls">
+            <button
+              type="button"
+              className="od-window-min-btn"
+              onClick={win.minimize}
+              title="Minimize"
+              aria-label="Minimize"
+            >
+              <Minus size={14} aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              className="od-window-close-btn"
+              onClick={onClose}
+              title="Close"
+              aria-label="Close"
+            >
+              <X size={14} aria-hidden="true" />
+            </button>
+          </span>
+        </div>
+
+        <div className="od-models-body">
+          {/* ── Provider rail (providers.js — pick which provider to scan) ── */}
+          <div className="od-models-providers">
+            <div className="od-models-providers-head">Providers</div>
+            {PROVIDERS.map((p) => {
+              const list = modelsByProvider[p];
+              const count = list ? list.length : null;
+              return (
+                <button
+                  type="button"
+                  key={p}
+                  className={`od-models-provider-row${p === provider ? " active" : ""}`}
+                  onClick={() => {
+                    setProvider(p);
+                    setQuery("");
+                    setShownAll(new Set<string>());
+                    setJustExpanded(null);
+                    loadProvider(p);
+                  }}
+                >
+                  <span className="od-models-provider-name">
+                    {providerRailLabel(p)}
+                  </span>
+                  {count !== null ? (
+                    <span className="od-models-provider-count">{count}</span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* ── Catalogue (#models box) ── */}
+          <div className="od-models-list">
+            <div className="od-models-toolbar">
+              <div className="od-models-sort-wrap">
+                <button
+                  type="button"
+                  className="od-models-sort-btn"
+                  title="Sort models"
+                  onClick={() => setSortMenuOpen((v) => !v)}
+                >
+                  <span>{sortLabel}</span>
+                  <ChevronDown size={12} />
+                </button>
+                {sortMenuOpen ? (
+                  <div className="od-models-sort-menu" role="menu">
+                    {SORT_OPTIONS.map((o) => (
+                      <button
+                        type="button"
+                        key={o.value || "default"}
+                        className={`od-models-sort-item${o.value === sortMode ? " current" : ""}`}
+                        onClick={() => pickSort(o.value)}
+                      >
+                        {o.label}
+                      </button>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            </div>
+
+            {showSearch ? (
+              <div className="od-models-search-row">
+                <Search size={13} className="od-models-search-icon" />
+                <input
+                  className="od-model-search-input"
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Escape") {
+                      if (query) setQuery("");
+                      else onClose();
+                    }
+                  }}
+                  placeholder="Search models…"
+                  aria-label="Search models"
+                />
+              </div>
+            ) : null}
+
+            <div className="od-models-scroll">
+              {isLoading ? (
+                <LoadingRow
+                  label={`Scanning ${providerRailLabel(provider)}…`}
+                />
+              ) : isErrored ? (
+                <div className="od-models-empty-state">
+                  <span className="od-models-muted">
+                    Couldn't reach {providerRailLabel(provider)}
+                  </span>
+                  <br />
+                  <button
+                    type="button"
+                    className="od-models-retry-link"
+                    onClick={() => {
+                      setErrored((prev) => {
+                        const next = new Set(prev);
+                        next.delete(provider);
+                        return next;
+                      });
+                      setModelsByProvider((prev) => {
+                        const next = { ...prev };
+                        delete next[provider];
+                        return next;
+                      });
+                      loadProvider(provider);
+                    }}
+                  >
+                    Retry scan
+                  </button>
+                </div>
+              ) : !hasModels ? (
+                <div className="od-models-empty-state">
+                  <span className="od-models-muted">No models available</span>
+                  <br />
+                  <span className="od-models-muted-sm">
+                    Configure a {providerRailLabel(provider)} API key in
+                    Settings to scan models.
+                  </span>
+                </div>
+              ) : q ? (
+                /* ── Search mode: flat, filtered results across the catalogue ── */
+                searchMatches.length === 0 ? (
+                  <div className="od-models-empty-state">
+                    <span className="od-models-muted">
+                      No models match "{query.trim()}"
+                    </span>
+                  </div>
+                ) : (
+                  <div className="od-models-group-content">
+                    {searchMatches.map(renderRow)}
+                  </div>
+                )
+              ) : (
+                /* ── Browse mode: Recent + Favorites, then All / provider groups ── */
+                <>
+                  {renderPinned("Recent", recentModels)}
+                  {renderPinned("Favorites", favModels)}
+
+                  {rest.length > 0 ? (
+                    isLargeCatalogue ? (
+                      providerGroups.map((g) =>
+                        renderProviderGroup(g.slug, g.models),
+                      )
+                    ) : (
+                      <>
+                        {hasPinned ? (
+                          <div className="od-models-section-label">
+                            All models
+                          </div>
+                        ) : null}
+                        <div className="od-models-group-content">
+                          {rest.map(renderRow)}
+                        </div>
+                      </>
+                    )
+                  ) : null}
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/NotesPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/NotesPanel.tsx
@@ -1,0 +1,1124 @@
+// odysseus notes (static/js/notes.js) — Google-Keep-style notes + todos.
+//
+// SCOPE (frontend v1, local-storage backed): odysseus's notes are server-backed.
+// This port faithfully reproduces every *client-side* surface of notes.js —
+// the header action row (archive + list/grid toggle), search, the quick-add
+// bar with Note/Todo type pills expanding to a full edit form, note cards with
+// title/body/checklist/color/#tag chips, pin-to-top, the label filter-chip bar,
+// select-mode + bulk archive/delete, and the archive view (tinted pane,
+// unarchive, delete-forever) with undo — all persisted in localStorage.
+//
+// DELIBERATELY OUT OF SCOPE (each needs a backend eliza does not yet have, so
+// rendering it would be a dead control):
+//   - Reminders / recurrence / fire-loop / browser Notification — needs a
+//     server scheduler (plugin-background-runner). A local timer that only
+//     fires while this tab+panel are open is not a real reminder, so the bell
+//     is omitted rather than faked.
+//   - Goal note type — odysseus goals are AI-decomposed server-side.
+//   - Draw/canvas note + custom background-image color — both need the
+//     /api/upload image backend.
+// These land when an eliza notes service + plugin-background-runner exists.
+
+import { Minus } from "lucide-react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { formatRelativeTime } from "../view-format";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+import { PREF_KEYS, readPref, writePref } from "./util/storage";
+
+type NoteType = "note" | "todo";
+
+// Preset colors mirror notes.js COLORS (custom-image sentinel dropped — no
+// upload backend). "" is the default/no-color state.
+type NoteColor = "" | "red" | "orange" | "yellow" | "green" | "blue" | "purple";
+
+const COLORS: { name: string; value: NoteColor }[] = [
+  { name: "default", value: "" },
+  { name: "red", value: "red" },
+  { name: "orange", value: "orange" },
+  { name: "yellow", value: "yellow" },
+  { name: "green", value: "green" },
+  { name: "blue", value: "blue" },
+  { name: "purple", value: "purple" },
+];
+
+interface ChecklistItem {
+  id: string;
+  text: string;
+  done: boolean;
+}
+
+interface Note {
+  id: string;
+  type: NoteType;
+  title: string;
+  // Free text body for "note", empty for "todo" (which uses `items`).
+  content: string;
+  items: ChecklistItem[];
+  color: NoteColor;
+  // Space-separated #tags, normalized to a bare-word array.
+  labels: string[];
+  pinned: boolean;
+  archived: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+// label-filter chip state: a specific #tag, the "default" (untagged) bucket, or
+// null (= All).
+type ActiveFilter = string | "default" | null;
+
+// notes.js _noteTags: split label string on whitespace, strip leading #, dedupe.
+function parseLabels(raw: string): string[] {
+  const seen = new Set<string>();
+  for (const part of raw.trim().split(/\s+/)) {
+    const t = part.replace(/^#+/, "").trim();
+    if (t) seen.add(t);
+  }
+  return [...seen];
+}
+
+function hasItems(n: Note): boolean {
+  return n.type === "todo" && n.items.length > 0;
+}
+
+// notes.js goal/checklist progress "N/M".
+function progress(n: Note): string {
+  if (!hasItems(n)) return "";
+  const done = n.items.filter((it) => it.done).length;
+  return `${done}/${n.items.length}`;
+}
+
+// notes.js persists the view toggle under 'odysseus-notes-view'; the typed
+// shim namespaces keys, so we keep a local key constant rather than touch the
+// shared PREF_KEYS table.
+const NOTES_VIEW_KEY = "notes-view";
+
+const EMPTY_DRAFT = {
+  type: "todo" as NoteType,
+  title: "",
+  content: "",
+  items: [] as ChecklistItem[],
+  itemDraft: "",
+  color: "" as NoteColor,
+  labels: "",
+};
+
+// ── inline icons (mirror notes.js / ui.js inline SVGs verbatim) ──
+const SVG_PROPS = {
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round",
+  strokeLinejoin: "round",
+} as const;
+
+// notes.js line 1119 — note/document icon before the "Notes" title.
+function NoteDocIcon(): ReactNode {
+  return (
+    <svg
+      width="14"
+      height="14"
+      {...SVG_PROPS}
+      className="od-notes-title-icon"
+      aria-hidden="true"
+    >
+      <path d="M5 3h10l4 4v14H5z" />
+      <path d="M15 3v5h5" />
+      <path d="M8 17.5 15.5 10l2.5 2.5L10.5 20H8z" />
+    </svg>
+  );
+}
+
+// notes.js line 1122 / 1204 ARCHIVE_ICON — archive-box.
+function ArchiveIcon(): ReactNode {
+  return (
+    <svg width="14" height="14" {...SVG_PROPS} aria-hidden="true">
+      <rect x="2" y="3" width="20" height="5" rx="1" />
+      <path d="M4 8v11a2 2 0 002 2h12a2 2 0 002-2V8" />
+      <path d="M10 12h4" />
+    </svg>
+  );
+}
+
+// notes.js line 1205 CLOSE_ICON — X swapped in while viewing the archive.
+function CloseIcon(): ReactNode {
+  return (
+    <svg
+      width="14"
+      height="14"
+      {...SVG_PROPS}
+      strokeWidth={2.4}
+      aria-hidden="true"
+    >
+      <line x1="6" y1="6" x2="18" y2="18" />
+      <line x1="18" y1="6" x2="6" y2="18" />
+    </svg>
+  );
+}
+
+// notes.js line 1126 — 2x2 grid (view toggle).
+function GridIcon(): ReactNode {
+  return (
+    <svg width="14" height="14" {...SVG_PROPS} aria-hidden="true">
+      <rect x="3" y="3" width="7" height="7" />
+      <rect x="14" y="3" width="7" height="7" />
+      <rect x="3" y="14" width="7" height="7" />
+      <rect x="14" y="14" width="7" height="7" />
+    </svg>
+  );
+}
+
+// notes.js line 2019 / 2791 — hamburger lines (the "note" type pill).
+function NoteLinesIcon(): ReactNode {
+  return (
+    <svg width="13" height="13" {...SVG_PROPS} aria-hidden="true">
+      <line x1="4" y1="6" x2="20" y2="6" />
+      <line x1="4" y1="12" x2="20" y2="12" />
+      <line x1="4" y1="18" x2="14" y2="18" />
+    </svg>
+  );
+}
+
+// notes.js line 2022 / 2795 — checkbox + check (the "to-do" type pill).
+function TodoCheckIcon(): ReactNode {
+  return (
+    <svg width="13" height="13" {...SVG_PROPS} aria-hidden="true">
+      <polyline points="9 11 12 14 22 4" />
+      <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
+    </svg>
+  );
+}
+
+// notes.js line 2027 — photo/camera (quick-add attach). No upload backend, so
+// the control is rendered for chrome parity but kept inert (see file header).
+function PhotoIcon(): ReactNode {
+  return (
+    <svg width="14" height="14" {...SVG_PROPS} aria-hidden="true">
+      <rect x="3" y="3" width="18" height="18" rx="2" />
+      <circle cx="8.5" cy="8.5" r="1.5" />
+      <polyline points="21 15 16 10 5 21" />
+    </svg>
+  );
+}
+
+// ui.js emptyStateIcon('smiley') — paired with the empty-list message.
+function SmileyIcon(): ReactNode {
+  return (
+    <svg
+      width="14"
+      height="14"
+      {...SVG_PROPS}
+      className="od-notes-empty-icon"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <path d="M8 14s1.5 2 4 2 4-2 4-2" />
+      <line x1="9" y1="9" x2="9.01" y2="9" />
+      <line x1="15" y1="9" x2="15.01" y2="9" />
+    </svg>
+  );
+}
+
+export function NotesPanel({
+  open,
+  onClose,
+  locale,
+}: {
+  open: boolean;
+  onClose: () => void;
+  locale?: string;
+}): ReactNode {
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [search, setSearch] = useState("");
+  const [activeFilter, setActiveFilter] = useState<ActiveFilter>(null);
+  const [viewMode, setViewMode] = useState<"list" | "grid">(() =>
+    readPref<"list" | "grid">(NOTES_VIEW_KEY, "list"),
+  );
+  const [showingArchived, setShowingArchived] = useState(false);
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  // Quick-add type pill steers the form the bar expands into.
+  const [quickType, setQuickType] = useState<NoteType>("todo");
+  // The id being edited in-place, "__new__" for the add form, or null.
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState({ ...EMPTY_DRAFT });
+  // Undo target for the last archive action (notes.js _undoStack, capped to one
+  // surfaced banner — most recent action wins).
+  const [undoArchiveId, setUndoArchiveId] = useState<string | null>(null);
+
+  const win = useWindowControls(
+    "win-notes",
+    { w: 560, h: 640 },
+    { label: "Notes", icon: "StickyNote", onClose },
+  );
+
+  useEffect(() => {
+    if (open) setNotes(readPref<Note[]>(PREF_KEYS.notes, []));
+  }, [open]);
+
+  // Reset transient view state whenever the panel is opened fresh.
+  useEffect(() => {
+    if (!open) return;
+    setSearch("");
+    setActiveFilter(null);
+    setShowingArchived(false);
+    setSelectMode(false);
+    setSelectedIds(new Set());
+    setEditingId(null);
+    setUndoArchiveId(null);
+  }, [open]);
+
+  const persist = (next: Note[]) => {
+    setNotes(next);
+    writePref(PREF_KEYS.notes, next);
+  };
+
+  const updateNote = (id: string, patch: Partial<Note>) => {
+    persist(
+      notes.map((n) =>
+        n.id === id ? { ...n, ...patch, updatedAt: Date.now() } : n,
+      ),
+    );
+  };
+
+  const closeForm = () => {
+    setEditingId(null);
+    setDraft({ ...EMPTY_DRAFT });
+  };
+
+  const openNewForm = (type: NoteType, seedTitle: string) => {
+    setEditingId("__new__");
+    setDraft({ ...EMPTY_DRAFT, type, title: seedTitle });
+  };
+
+  const openEditForm = (n: Note) => {
+    setEditingId(n.id);
+    setDraft({
+      type: n.type,
+      title: n.title,
+      content: n.content,
+      items: n.items.map((it) => ({ ...it })),
+      itemDraft: "",
+      color: n.color,
+      labels: n.labels.map((l) => `#${l}`).join(" "),
+    });
+  };
+
+  const saveDraft = () => {
+    const title = draft.title.trim();
+    const content = draft.content.trim();
+    const items = draft.items;
+    // Don't persist an empty shell.
+    if (!title && !content && items.length === 0) {
+      closeForm();
+      return;
+    }
+    const labels = parseLabels(draft.labels);
+    if (editingId === "__new__") {
+      const now = Date.now();
+      persist([
+        {
+          id: crypto.randomUUID(),
+          type: draft.type,
+          title,
+          content: draft.type === "todo" ? "" : content,
+          items: draft.type === "todo" ? items : [],
+          color: draft.color,
+          labels,
+          pinned: false,
+          archived: false,
+          createdAt: now,
+          updatedAt: now,
+        },
+        ...notes,
+      ]);
+    } else if (editingId) {
+      updateNote(editingId, {
+        type: draft.type,
+        title,
+        content: draft.type === "todo" ? "" : content,
+        items: draft.type === "todo" ? items : [],
+        color: draft.color,
+        labels,
+      });
+    }
+    closeForm();
+  };
+
+  const addDraftItem = () => {
+    const text = draft.itemDraft.trim();
+    if (!text) return;
+    setDraft((d) => ({
+      ...d,
+      items: [...d.items, { id: crypto.randomUUID(), text, done: false }],
+      itemDraft: "",
+    }));
+  };
+
+  // ── card-level actions ──
+  const togglePin = (n: Note) => updateNote(n.id, { pinned: !n.pinned });
+
+  const archiveNote = (n: Note) => {
+    setUndoArchiveId(n.id);
+    updateNote(n.id, { archived: true });
+  };
+
+  const runUndoArchive = () => {
+    if (!undoArchiveId) return;
+    updateNote(undoArchiveId, { archived: false });
+    setUndoArchiveId(null);
+  };
+
+  const unarchiveNote = (n: Note) => updateNote(n.id, { archived: false });
+
+  const deleteNote = (id: string) => persist(notes.filter((x) => x.id !== id));
+
+  const toggleItem = (note: Note, itemId: string) => {
+    updateNote(note.id, {
+      items: note.items.map((it) =>
+        it.id === itemId ? { ...it, done: !it.done } : it,
+      ),
+    });
+  };
+
+  const removeItem = (note: Note, itemId: string) => {
+    updateNote(note.id, {
+      items: note.items.filter((it) => it.id !== itemId),
+    });
+  };
+
+  const addItemToCard = (note: Note, text: string) => {
+    const t = text.trim();
+    if (!t) return;
+    updateNote(note.id, {
+      items: [...note.items, { id: crypto.randomUUID(), text: t, done: false }],
+    });
+  };
+
+  // ── select mode ──
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const exitSelectMode = () => {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+  };
+
+  // ── derived: labels + filtered/sorted list ──
+  const allLabels = useMemo(() => {
+    const set = new Set<string>();
+    for (const n of notes) {
+      if (n.archived) continue;
+      for (const l of n.labels) set.add(l);
+    }
+    return [...set].sort();
+  }, [notes]);
+
+  const defaultCount = useMemo(
+    () => notes.filter((n) => !n.archived && n.labels.length === 0).length,
+    [notes],
+  );
+
+  const visible = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    let list = notes.filter((n) => n.archived === showingArchived);
+    if (!showingArchived) {
+      if (activeFilter === "default") {
+        list = list.filter((n) => n.labels.length === 0);
+      } else if (activeFilter) {
+        list = list.filter((n) => n.labels.includes(activeFilter));
+      }
+    }
+    if (q) {
+      list = list.filter((n) => {
+        if (n.title.toLowerCase().includes(q)) return true;
+        if (n.content.toLowerCase().includes(q)) return true;
+        if (n.labels.some((l) => l.toLowerCase().includes(q))) return true;
+        if (n.items.some((it) => it.text.toLowerCase().includes(q)))
+          return true;
+        return false;
+      });
+    }
+    return [...list].sort((a, b) => {
+      // Archive view: newest archived first.
+      if (showingArchived) return b.updatedAt - a.updatedAt;
+      // notes.js: pinned floats to the top, then by recency.
+      if (a.pinned && !b.pinned) return -1;
+      if (!a.pinned && b.pinned) return 1;
+      return b.updatedAt - a.updatedAt;
+    });
+  }, [notes, search, activeFilter, showingArchived]);
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  return (
+    <div
+      className={`od-search-overlay od-notes-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Notes"
+    >
+      <button
+        type="button"
+        aria-label="Close notes"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div
+        className={`od-search-panel od-mem-panel od-notes-panel${showingArchived ? " od-notes-archived" : ""}`}
+        style={win.panelStyle}
+      >
+        <ResizeHandles controls={win} />
+        <div
+          className="od-mem-head od-window-header od-notes-head"
+          onPointerDown={win.onDragStart}
+        >
+          <span className="od-mem-title od-notes-title">
+            <NoteDocIcon />
+            Notes
+          </span>
+          <span className="od-notes-head-spacer" />
+          <button
+            type="button"
+            className={`od-notes-head-btn od-notes-head-icon-btn${showingArchived ? " active" : ""}`}
+            onClick={() => {
+              setShowingArchived((v) => !v);
+              exitSelectMode();
+            }}
+            title={showingArchived ? "Exit archive" : "View archive"}
+            aria-pressed={showingArchived}
+          >
+            {showingArchived ? <CloseIcon /> : <ArchiveIcon />}
+            <span className="od-notes-head-btn-label">Archive</span>
+          </button>
+          <button
+            type="button"
+            className="od-notes-head-btn od-notes-head-icon-btn"
+            onClick={() => {
+              const next = viewMode === "grid" ? "list" : "grid";
+              setViewMode(next);
+              writePref(NOTES_VIEW_KEY, next);
+            }}
+            title="Toggle view"
+          >
+            <GridIcon />
+            <span className="od-notes-head-btn-label">
+              {viewMode === "grid" ? "List" : "Grid"}
+            </span>
+          </button>
+          <button
+            type="button"
+            className="od-window-min-btn"
+            onClick={win.minimize}
+            title="Minimize"
+            aria-label="Minimize"
+          >
+            <Minus size={14} aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="od-notes-searchbar">
+          <input
+            className="od-search-input od-notes-search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Escape") {
+                if (search) setSearch("");
+                else onClose();
+              }
+            }}
+            placeholder="Search notes…"
+            aria-label="Search notes"
+          />
+          {!showingArchived ? (
+            <button
+              type="button"
+              className={`od-notes-select-trigger${selectMode ? " active" : ""}`}
+              onClick={() => {
+                if (selectMode) exitSelectMode();
+                else setSelectMode(true);
+              }}
+            >
+              {selectMode ? "Cancel" : "Select"}
+            </button>
+          ) : null}
+        </div>
+
+        {selectMode ? (
+          <div className="od-notes-bulk-bar">
+            <label className="od-notes-bulk-all">
+              <input
+                type="checkbox"
+                checked={
+                  visible.length > 0 &&
+                  visible.every((n) => selectedIds.has(n.id))
+                }
+                onChange={(e) =>
+                  setSelectedIds(
+                    e.target.checked
+                      ? new Set(visible.map((n) => n.id))
+                      : new Set(),
+                  )
+                }
+              />{" "}
+              All
+            </label>
+            <span className="od-notes-bulk-count">
+              {selectedIds.size} selected
+            </span>
+            <span className="od-notes-head-spacer" />
+            <button
+              type="button"
+              className="od-notes-bulk-btn"
+              disabled={selectedIds.size === 0}
+              onClick={() => {
+                const ids = selectedIds;
+                persist(
+                  notes.map((n) =>
+                    ids.has(n.id)
+                      ? { ...n, archived: true, updatedAt: Date.now() }
+                      : n,
+                  ),
+                );
+                exitSelectMode();
+              }}
+            >
+              Archive
+            </button>
+            <button
+              type="button"
+              className="od-notes-bulk-btn danger"
+              disabled={selectedIds.size === 0}
+              onClick={() => {
+                const ids = selectedIds;
+                persist(notes.filter((n) => !ids.has(n.id)));
+                exitSelectMode();
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        ) : null}
+
+        {undoArchiveId ? (
+          <div className="od-notes-undo">
+            <span>Note archived.</span>
+            <button
+              type="button"
+              className="od-notes-undo-btn"
+              onClick={runUndoArchive}
+            >
+              Undo
+            </button>
+            <button
+              type="button"
+              className="od-notes-undo-dismiss"
+              onClick={() => setUndoArchiveId(null)}
+              aria-label="Dismiss"
+            >
+              ✕
+            </button>
+          </div>
+        ) : null}
+
+        {/* Label filter-chip bar — only over the active list. */}
+        {!showingArchived && (allLabels.length > 0 || defaultCount > 0) ? (
+          <div className="od-notes-labels">
+            <button
+              type="button"
+              className={`od-notes-chip${activeFilter === null ? " active" : ""}`}
+              onClick={() => setActiveFilter(null)}
+            >
+              All
+            </button>
+            <button
+              type="button"
+              className={`od-notes-chip${activeFilter === "default" ? " active" : ""}`}
+              onClick={() =>
+                setActiveFilter((f) => (f === "default" ? null : "default"))
+              }
+              title="Notes without tags"
+            >
+              Default{" "}
+              <span className="od-notes-chip-count">{defaultCount}</span>
+            </button>
+            {allLabels.map((lbl) => (
+              <button
+                type="button"
+                key={lbl}
+                className={`od-notes-chip${activeFilter === lbl ? " active" : ""}`}
+                onClick={() => setActiveFilter((f) => (f === lbl ? null : lbl))}
+              >
+                #{lbl}
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        <div className={`od-search-list od-notes-list od-notes-${viewMode}`}>
+          {/* Quick-add bar / expanded form — active list only. */}
+          {!showingArchived && editingId === "__new__" ? (
+            <NoteForm
+              draft={draft}
+              setDraft={setDraft}
+              addItem={addDraftItem}
+              onSave={saveDraft}
+              onCancel={closeForm}
+            />
+          ) : !showingArchived ? (
+            <div className="od-notes-quickadd">
+              <fieldset
+                className="od-notes-quick-seg"
+                aria-label="New item type"
+              >
+                <button
+                  type="button"
+                  className={`od-notes-quick-pill${quickType === "note" ? " active" : ""}`}
+                  aria-label="Note"
+                  aria-pressed={quickType === "note"}
+                  onClick={() => setQuickType("note")}
+                  title="Note"
+                >
+                  <NoteLinesIcon />
+                </button>
+                <button
+                  type="button"
+                  className={`od-notes-quick-pill${quickType === "todo" ? " active" : ""}`}
+                  aria-label="To-do"
+                  aria-pressed={quickType === "todo"}
+                  onClick={() => setQuickType("todo")}
+                  title="To-do"
+                >
+                  <TodoCheckIcon />
+                </button>
+              </fieldset>
+              <input
+                className="od-notes-quick-input"
+                placeholder={
+                  quickType === "note" ? "Add a note…" : "Add a to-do…"
+                }
+                onChange={(e) => openNewForm(quickType, e.target.value)}
+                aria-label="Add note"
+              />
+              {/* notes.js attach-photo control. The plugin has no /api/upload
+                  image backend (see file header), so it is rendered for 1:1
+                  chrome parity but kept inert/disabled rather than faked. */}
+              <button
+                type="button"
+                className="od-notes-quick-icon"
+                disabled
+                title="Attach photo (needs an image-upload backend)"
+                aria-label="Attach photo (unavailable)"
+              >
+                <PhotoIcon />
+              </button>
+            </div>
+          ) : null}
+
+          {visible.length === 0 ? (
+            <div className="od-notes-empty-msg">
+              {showingArchived ? "No archived notes" : "No notes yet"}
+              <SmileyIcon />
+            </div>
+          ) : (
+            visible.map((n) =>
+              editingId === n.id ? (
+                <NoteForm
+                  key={n.id}
+                  draft={draft}
+                  setDraft={setDraft}
+                  addItem={addDraftItem}
+                  onSave={saveDraft}
+                  onCancel={closeForm}
+                />
+              ) : (
+                <NoteCard
+                  key={n.id}
+                  note={n}
+                  locale={locale}
+                  showingArchived={showingArchived}
+                  selectMode={selectMode}
+                  selected={selectedIds.has(n.id)}
+                  onToggleSelect={() => toggleSelect(n.id)}
+                  onEdit={() => openEditForm(n)}
+                  onTogglePin={() => togglePin(n)}
+                  onArchive={() => archiveNote(n)}
+                  onUnarchive={() => unarchiveNote(n)}
+                  onDelete={() => deleteNote(n.id)}
+                  onToggleItem={(itemId) => toggleItem(n, itemId)}
+                  onRemoveItem={(itemId) => removeItem(n, itemId)}
+                  onAddItem={(text) => addItemToCard(n, text)}
+                  onSetColor={(color) => updateNote(n.id, { color })}
+                  onFilterLabel={(lbl) => setActiveFilter(lbl)}
+                />
+              ),
+            )
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type Draft = typeof EMPTY_DRAFT;
+
+function NoteForm({
+  draft,
+  setDraft,
+  addItem,
+  onSave,
+  onCancel,
+}: {
+  draft: Draft;
+  setDraft: (fn: (d: Draft) => Draft) => void;
+  addItem: () => void;
+  onSave: () => void;
+  onCancel: () => void;
+}): ReactNode {
+  return (
+    <div className="od-note-form">
+      <fieldset className="od-note-form-seg" aria-label="Note type">
+        <button
+          type="button"
+          className={`od-notes-quick-pill od-note-form-pill${draft.type === "note" ? " active" : ""}`}
+          aria-pressed={draft.type === "note"}
+          onClick={() => setDraft((d) => ({ ...d, type: "note" }))}
+        >
+          <NoteLinesIcon />
+          <span>Note</span>
+        </button>
+        <button
+          type="button"
+          className={`od-notes-quick-pill od-note-form-pill${draft.type === "todo" ? " active" : ""}`}
+          aria-pressed={draft.type === "todo"}
+          onClick={() => setDraft((d) => ({ ...d, type: "todo" }))}
+        >
+          <TodoCheckIcon />
+          <span>To-do</span>
+        </button>
+      </fieldset>
+      <input
+        className="od-note-form-title"
+        value={draft.title}
+        onChange={(e) => setDraft((d) => ({ ...d, title: e.target.value }))}
+        placeholder="Title"
+        aria-label="Note title"
+      />
+      {draft.type === "note" ? (
+        <textarea
+          className="od-note-form-body"
+          value={draft.content}
+          onChange={(e) => setDraft((d) => ({ ...d, content: e.target.value }))}
+          placeholder="Take a note…"
+          aria-label="Note body"
+          rows={3}
+        />
+      ) : (
+        <div className="od-note-form-items">
+          {draft.items.map((it) => (
+            <div
+              className={`od-note-cl-item${it.done ? " done" : ""}`}
+              key={it.id}
+            >
+              <button
+                type="button"
+                className="od-note-check"
+                aria-label={it.done ? "Mark not done" : "Mark done"}
+                aria-pressed={it.done}
+                onClick={() =>
+                  setDraft((d) => ({
+                    ...d,
+                    items: d.items.map((x) =>
+                      x.id === it.id ? { ...x, done: !x.done } : x,
+                    ),
+                  }))
+                }
+              />
+              <span className="od-note-check-text">{it.text}</span>
+              <button
+                type="button"
+                className="od-note-cl-rm"
+                aria-label="Delete item"
+                onClick={() =>
+                  setDraft((d) => ({
+                    ...d,
+                    items: d.items.filter((x) => x.id !== it.id),
+                  }))
+                }
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+          <input
+            className="od-note-cl-add"
+            value={draft.itemDraft}
+            onChange={(e) =>
+              setDraft((d) => ({ ...d, itemDraft: e.target.value }))
+            }
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                addItem();
+              }
+            }}
+            placeholder="+ Add item"
+            aria-label="Add checklist item"
+          />
+        </div>
+      )}
+      <div className="od-note-form-colors">
+        {COLORS.map((c) => (
+          <button
+            type="button"
+            key={c.value || "none"}
+            className={`od-note-color-dot${draft.color === c.value ? " active" : ""}${c.value ? ` od-note-color-${c.value}` : ""}`}
+            title={c.name}
+            aria-label={`Color ${c.name}`}
+            onClick={() => setDraft((d) => ({ ...d, color: c.value }))}
+          />
+        ))}
+      </div>
+      <input
+        className="od-note-form-labels"
+        value={draft.labels}
+        onChange={(e) => setDraft((d) => ({ ...d, labels: e.target.value }))}
+        placeholder="#tags (space separated)"
+        aria-label="Tags"
+      />
+      <div className="od-note-form-actions">
+        <button type="button" className="od-notes-head-btn" onClick={onCancel}>
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="od-notes-head-btn primary"
+          onClick={onSave}
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function NoteCard({
+  note,
+  locale,
+  showingArchived,
+  selectMode,
+  selected,
+  onToggleSelect,
+  onEdit,
+  onTogglePin,
+  onArchive,
+  onUnarchive,
+  onDelete,
+  onToggleItem,
+  onRemoveItem,
+  onAddItem,
+  onSetColor,
+  onFilterLabel,
+}: {
+  note: Note;
+  locale?: string;
+  showingArchived: boolean;
+  selectMode: boolean;
+  selected: boolean;
+  onToggleSelect: () => void;
+  onEdit: () => void;
+  onTogglePin: () => void;
+  onArchive: () => void;
+  onUnarchive: () => void;
+  onDelete: () => void;
+  onToggleItem: (itemId: string) => void;
+  onRemoveItem: (itemId: string) => void;
+  onAddItem: (text: string) => void;
+  onSetColor: (color: NoteColor) => void;
+  onFilterLabel: (lbl: string) => void;
+}): ReactNode {
+  const [itemDraft, setItemDraft] = useState("");
+  const colorClass = note.color ? ` od-note-color-${note.color}` : "";
+
+  return (
+    <div
+      className={`od-note-card${note.pinned ? " pinned" : ""}${selected ? " selected" : ""}${colorClass}`}
+    >
+      {selectMode ? (
+        <input
+          type="checkbox"
+          className="od-note-card-cb"
+          checked={selected}
+          onChange={onToggleSelect}
+          aria-label="Select note"
+        />
+      ) : null}
+
+      {!showingArchived ? (
+        <button
+          type="button"
+          className={`od-note-pin${note.pinned ? " active" : ""}`}
+          onClick={onTogglePin}
+          title={note.pinned ? "Unpin" : "Pin"}
+          aria-label={note.pinned ? "Unpin note" : "Pin note"}
+        >
+          {note.pinned ? "📌" : "📍"}
+        </button>
+      ) : null}
+
+      <div className="od-note-card-head">
+        <button
+          type="button"
+          className={`od-note-card-title${note.title ? "" : " empty"}`}
+          onClick={onEdit}
+        >
+          {note.title || (note.type === "todo" ? "(to-do)" : "(untitled)")}
+        </button>
+      </div>
+
+      {hasItems(note) ? (
+        <div className="od-note-checklist">
+          {note.items.map((it) => (
+            <div
+              className={`od-note-cl-item${it.done ? " done" : ""}`}
+              key={it.id}
+            >
+              <button
+                type="button"
+                className="od-note-check"
+                aria-label={it.done ? "Mark not done" : "Mark done"}
+                aria-pressed={it.done}
+                onClick={() => onToggleItem(it.id)}
+              />
+              <span className="od-note-check-text">{it.text}</span>
+              <button
+                type="button"
+                className="od-note-cl-rm"
+                aria-label="Delete item"
+                onClick={() => onRemoveItem(it.id)}
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+          <input
+            className="od-note-cl-add"
+            value={itemDraft}
+            onChange={(e) => setItemDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                onAddItem(itemDraft);
+                setItemDraft("");
+              }
+            }}
+            placeholder="+ Add item"
+            aria-label="Add item"
+          />
+        </div>
+      ) : note.content ? (
+        <button type="button" className="od-note-card-body" onClick={onEdit}>
+          {note.content}
+        </button>
+      ) : null}
+
+      {note.labels.length ? (
+        <div className="od-note-card-labels">
+          {note.labels.map((lbl) => (
+            <button
+              type="button"
+              key={lbl}
+              className="od-note-card-chip"
+              onClick={() => onFilterLabel(lbl)}
+              title={`Filter #${lbl}`}
+            >
+              #{lbl}
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="od-note-card-actions">
+        <div className="od-note-card-colors">
+          {COLORS.map((c) => (
+            <button
+              type="button"
+              key={c.value || "none"}
+              className={`od-note-color-dot${note.color === c.value ? " active" : ""}${c.value ? ` od-note-color-${c.value}` : ""}`}
+              title={c.name}
+              aria-label={`Color ${c.name}`}
+              onClick={() => onSetColor(c.value)}
+            />
+          ))}
+        </div>
+        <span className="od-note-card-spacer" />
+        {hasItems(note) ? (
+          <span className="od-note-card-progress">{progress(note)}</span>
+        ) : null}
+        <span className="od-note-time">
+          {formatRelativeTime(note.updatedAt, locale)}
+        </span>
+        {showingArchived ? (
+          <>
+            <button
+              type="button"
+              className="od-note-card-act"
+              onClick={onUnarchive}
+              title="Unarchive"
+              aria-label="Unarchive note"
+            >
+              ⤺
+            </button>
+            <button
+              type="button"
+              className="od-note-card-act danger"
+              onClick={onDelete}
+              title="Delete forever"
+              aria-label="Delete forever"
+            >
+              ✕
+            </button>
+          </>
+        ) : (
+          <>
+            <button
+              type="button"
+              className="od-note-card-act"
+              onClick={onArchive}
+              title="Archive"
+              aria-label="Archive note"
+            >
+              ⤓
+            </button>
+            <button
+              type="button"
+              className="od-note-card-act danger"
+              onClick={onDelete}
+              title="Delete"
+              aria-label="Delete note"
+            >
+              ✕
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/OdysseusShell.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/OdysseusShell.tsx
@@ -1,0 +1,658 @@
+// OdysseusShell — root of the odysseus port (Phase 1: shell + chat/streaming).
+// Pixel-faithful odysseus chrome (icon rail + 240px sidebar + chat container)
+// wired to the existing ACP task-room contracts. Registered at /odysseus so the
+// live /orchestrator workbench keeps working while this is iterated; it becomes
+// /orchestrator once approved.
+//
+// Theming: themeVars(name) is applied inline on the root (the active odysseus
+// preset's palette + remapped eliza semantic tokens, so reused components
+// inherit the look); ODYSSEUS_CSS structural rules are injected via a <style>
+// tag. No .css import, keeping the plugin's Node-side view manifest import safe.
+
+import type { CodingAgentTaskThread } from "@elizaos/ui";
+import { client } from "@elizaos/ui";
+import {
+  type PointerEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { AdminView } from "./AdminView";
+import { BgEffect } from "./BgEffect";
+import { CalendarView } from "./CalendarView";
+import { ChatContainer } from "./ChatContainer";
+import { CompareView } from "./CompareView";
+import { CookbookView } from "./CookbookView";
+import { DocumentLibraryView } from "./DocumentLibraryView";
+import { EmailView } from "./EmailView";
+import { GalleryEditorView } from "./GalleryEditorView";
+import { GalleryView } from "./GalleryView";
+import { GroupChatView } from "./GroupChatView";
+import { useChatSubmit } from "./hooks/useChatSubmit";
+import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
+import { useTaskRoom } from "./hooks/useTaskRoom";
+import { IconRail } from "./IconRail";
+import { MemoryPanel } from "./MemoryPanel";
+import { MinimizedDock } from "./MinimizedDock";
+import { ModelsView } from "./ModelsView";
+import { NotesPanel } from "./NotesPanel";
+import {
+  buildThemeVars,
+  FONT_MAP,
+  ODYSSEUS_CSS,
+  ODYSSEUS_THEMES,
+  type ThemeDensity,
+  type ThemeFont,
+  type ThemeName,
+  type ThemePalette,
+  themeVars,
+} from "./odysseus-theme";
+import { PresetsPanel } from "./PresetsPanel";
+import { ResearchView } from "./ResearchView";
+import { SearchPalette } from "./SearchPalette";
+import { SessionSidebar } from "./SessionSidebar";
+import { SettingsPanel } from "./SettingsPanel";
+import { SkillsPanel } from "./SkillsPanel";
+import { TasksView } from "./TasksView";
+import { ThemeMenu } from "./ThemeMenu";
+import { PREF_KEYS, readPref, writePref } from "./util/storage";
+import { VoiceView } from "./VoiceView";
+import { WindowManagerProvider } from "./WindowManager";
+
+const THREAD_POLL_MS = 5_000;
+
+// odysseus sidebar-layout.js AUTO_COLLAPSE_WIDTH: below this viewport width the
+// sidebar stops being an in-flow, drag-resizable panel and becomes an overlay
+// drawer that slides in over the chat with a tap-to-close backdrop.
+const MOBILE_BREAKPOINT = 700;
+
+// Feature-launch ids shared between the icon rail (collapsed state) and the
+// expanded sidebar's labeled rows. Each maps 1:1 to an existing view setter in
+// the shell (see openTool); the sidebar imports this type to type its handler.
+export type ToolId =
+  | "theme"
+  | "memory"
+  | "skills"
+  | "notes"
+  | "settings"
+  | "compare"
+  | "research"
+  | "docs"
+  | "calendar"
+  | "email"
+  | "gallery"
+  | "cookbook"
+  | "models"
+  | "tasks"
+  | "editor"
+  | "group"
+  | "admin"
+  | "voice"
+  | "presets";
+
+export function OdysseusShell(): ReactNode {
+  const [threads, setThreads] = useState<CodingAgentTaskThread[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() =>
+    readPref<boolean>(PREF_KEYS.sidebarCollapsed, false),
+  );
+  const [sidebarWidth, setSidebarWidth] = useState<number>(() =>
+    readPref<number>(PREF_KEYS.sidebarWidth, 240),
+  );
+  const widthRef = useRef(sidebarWidth);
+  widthRef.current = sidebarWidth;
+  // Mobile flag (odysseus sidebar-layout.js): below MOBILE_BREAKPOINT the
+  // sidebar becomes an overlay drawer. Initialised from the current viewport so
+  // a first paint at a narrow width starts collapsed.
+  const [isMobile, setIsMobile] = useState(
+    () =>
+      typeof window !== "undefined" && window.innerWidth < MOBILE_BREAKPOINT,
+  );
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [themeName, setThemeName] = useState<ThemeName>(() =>
+    readPref<ThemeName>(PREF_KEYS.themeMode, "dark"),
+  );
+  const [themeMenuOpen, setThemeMenuOpen] = useState(false);
+  const [memoryOpen, setMemoryOpen] = useState(false);
+  const [skillsOpen, setSkillsOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [notesOpen, setNotesOpen] = useState(false);
+  const [compareOpen, setCompareOpen] = useState(false);
+  const [researchOpen, setResearchOpen] = useState(false);
+  const [docsOpen, setDocsOpen] = useState(false);
+  const [calendarOpen, setCalendarOpen] = useState(false);
+  const [emailOpen, setEmailOpen] = useState(false);
+  const [galleryOpen, setGalleryOpen] = useState(false);
+  const [cookbookOpen, setCookbookOpen] = useState(false);
+  const [modelsOpen, setModelsOpen] = useState(false);
+  const [tasksOpen, setTasksOpen] = useState(false);
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [groupOpen, setGroupOpen] = useState(false);
+  const [adminOpen, setAdminOpen] = useState(false);
+  const [voiceOpen, setVoiceOpen] = useState(false);
+  const [presetsOpen, setPresetsOpen] = useState(false);
+  const [font, setFont] = useState<ThemeFont>(() =>
+    readPref<ThemeFont>(PREF_KEYS.font, "mono"),
+  );
+  const [density, setDensity] = useState<ThemeDensity>(() =>
+    readPref<ThemeDensity>(PREF_KEYS.density, "comfortable"),
+  );
+  const [customColors, setCustomColors] = useState<ThemePalette>(() =>
+    readPref<ThemePalette>(PREF_KEYS.customTheme, ODYSSEUS_THEMES.dark),
+  );
+  const [bgPattern, setBgPattern] = useState<string>(() =>
+    readPref<string>(PREF_KEYS.bgPattern, "none"),
+  );
+  const [customThemes, setCustomThemes] = useState<
+    Record<string, ThemePalette>
+  >(() => readPref<Record<string, ThemePalette>>(PREF_KEYS.customThemes, {}));
+  const [pinnedIds, setPinnedIds] = useState<string[]>(() =>
+    readPref<string[]>(PREF_KEYS.pinnedThreads, []),
+  );
+
+  const refreshThreads = useCallback(async () => {
+    const next = await client
+      .listCodingAgentTaskThreads({ limit: 100 })
+      .catch(() => null);
+    if (next) setThreads(next);
+  }, []);
+
+  useEffect(() => {
+    void refreshThreads();
+    const timer = window.setInterval(
+      () => void refreshThreads(),
+      THREAD_POLL_MS,
+    );
+    return () => window.clearInterval(timer);
+  }, [refreshThreads]);
+
+  const { detail, conversation, isActive } = useTaskRoom(selectedId);
+
+  const activeSessionId = useMemo(() => {
+    const session = (detail?.sessions ?? []).find((s) => s.stoppedAt == null);
+    return session?.sessionId ?? null;
+  }, [detail?.sessions]);
+
+  const onCreated = useCallback(
+    (id: string) => {
+      setSelectedId(id);
+      void refreshThreads();
+    },
+    [refreshThreads],
+  );
+
+  const { input, setInput, sending, submit, stop } = useChatSubmit({
+    selectedId,
+    activeSessionId,
+    onCreated,
+  });
+
+  const onNewChat = useCallback(() => setSelectedId(null), []);
+
+  const openPanel = useCallback(
+    (panel: "theme" | "memory" | "skills" | "notes" | "settings") => {
+      if (panel === "theme") setThemeMenuOpen(true);
+      else if (panel === "memory") setMemoryOpen(true);
+      else if (panel === "skills") setSkillsOpen(true);
+      else if (panel === "notes") setNotesOpen(true);
+      else setSettingsOpen(true);
+    },
+    [],
+  );
+
+  // Single feature-launch dispatcher shared by the icon rail and the expanded
+  // sidebar's labeled rows, so both surfaces open the SAME existing panels
+  // (odysseus: the rail glyphs and the sidebar tool rows target one tool each).
+  // Every id maps to a real existing view setter — no fabricated panels.
+  const openTool = useCallback((tool: ToolId) => {
+    switch (tool) {
+      case "theme":
+        setThemeMenuOpen(true);
+        break;
+      case "memory":
+        setMemoryOpen(true);
+        break;
+      case "skills":
+        setSkillsOpen(true);
+        break;
+      case "notes":
+        setNotesOpen(true);
+        break;
+      case "settings":
+        setSettingsOpen(true);
+        break;
+      case "compare":
+        setCompareOpen(true);
+        break;
+      case "research":
+        setResearchOpen(true);
+        break;
+      case "docs":
+        setDocsOpen(true);
+        break;
+      case "calendar":
+        setCalendarOpen(true);
+        break;
+      case "email":
+        setEmailOpen(true);
+        break;
+      case "gallery":
+        setGalleryOpen(true);
+        break;
+      case "cookbook":
+        setCookbookOpen(true);
+        break;
+      case "models":
+        setModelsOpen(true);
+        break;
+      case "tasks":
+        setTasksOpen(true);
+        break;
+      case "editor":
+        setEditorOpen(true);
+        break;
+      case "group":
+        setGroupOpen(true);
+        break;
+      case "admin":
+        setAdminOpen(true);
+        break;
+      case "voice":
+        setVoiceOpen(true);
+        break;
+      default:
+        setPresetsOpen(true);
+    }
+  }, []);
+
+  const onRenameThread = useCallback(
+    (id: string, title: string) => {
+      void client
+        .updateOrchestratorTask(id, { title })
+        .then(() => refreshThreads())
+        .catch(() => {});
+    },
+    [refreshThreads],
+  );
+
+  const onDeleteThread = useCallback(
+    (id: string) => {
+      void client
+        .deleteOrchestratorTask(id)
+        .then(() => {
+          setSelectedId((cur) => (cur === id ? null : cur));
+          return refreshThreads();
+        })
+        .catch(() => {});
+    },
+    [refreshThreads],
+  );
+
+  // Pin/unpin a thread (odysseus star): pinned threads sort to the top of the
+  // Chats list and persist across reloads (client-only, localStorage-backed).
+  const onTogglePin = useCallback((id: string) => {
+    setPinnedIds((prev) => {
+      const next = prev.includes(id)
+        ? prev.filter((p) => p !== id)
+        : [...prev, id];
+      writePref(PREF_KEYS.pinnedThreads, next);
+      return next;
+    });
+  }, []);
+
+  // odysseus _wasAutoCollapsed: remembers that the sidebar was collapsed *by*
+  // the responsive auto-collapse (not the user), so it is only auto-restored
+  // when the viewport grows back to desktop. A user toggle clears it.
+  const wasAutoCollapsedRef = useRef(false);
+
+  const toggleSidebar = useCallback(() => {
+    // A deliberate toggle is always the user's intent — drop the auto-collapse
+    // flag so a later desktop resize doesn't pop the drawer back open.
+    wasAutoCollapsedRef.current = false;
+    setSidebarCollapsed((prev) => {
+      // The collapsed pref is desktop-only: on mobile the drawer is transient
+      // overlay state and must not overwrite the user's desktop preference.
+      if (!isMobile) writePref(PREF_KEYS.sidebarCollapsed, !prev);
+      return !prev;
+    });
+  }, [isMobile]);
+
+  // Responsive auto-collapse (odysseus sidebar-layout.js checkSidebarAutoCollapse
+  // + the resize listener it cleans up). Crossing below MOBILE_BREAKPOINT
+  // collapses the sidebar into the overlay drawer; growing back to desktop
+  // restores it only if the auto-collapse is what hid it. The drawer also
+  // starts closed every time we enter mobile so the chat is unobstructed.
+  useEffect(() => {
+    const onResize = () => {
+      const mobile = window.innerWidth < MOBILE_BREAKPOINT;
+      setIsMobile(mobile);
+      setSidebarCollapsed((prev) => {
+        if (mobile) {
+          if (!prev) {
+            wasAutoCollapsedRef.current = true;
+            return true;
+          }
+          return prev;
+        }
+        if (prev && wasAutoCollapsedRef.current) {
+          wasAutoCollapsedRef.current = false;
+          return false;
+        }
+        return prev;
+      });
+    };
+    onResize();
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  // On mobile the drawer is "open" when not collapsed; selecting a thread or
+  // starting a new chat should dismiss it so the chat is visible (odysseus
+  // closes the sidebar on navigation on phones).
+  const closeMobileDrawer = useCallback(() => {
+    if (isMobile) setSidebarCollapsed(true);
+  }, [isMobile]);
+
+  // Keyboard shortcuts (odysseus keyboard-shortcuts.js): toggle sidebar, new
+  // chat, focus composer, and open the tool surfaces. Only actions wired here
+  // are bound; AltGr-safe + suppressed while typing (except focusInput).
+  useKeyboardShortcuts({
+    toggleSidebar,
+    newSession: onNewChat,
+    focusInput: () => {
+      const ta = document.querySelector<HTMLTextAreaElement>(
+        '.odysseus-root textarea[aria-label="Message input"]',
+      );
+      ta?.focus();
+    },
+    openSettings: () => setSettingsOpen(true),
+    openCalendar: () => setCalendarOpen(true),
+    openCompare: () => setCompareOpen(true),
+    openCookbook: () => setCookbookOpen(true),
+    openResearch: () => setResearchOpen(true),
+    openGallery: () => setGalleryOpen(true),
+    openMemory: () => setMemoryOpen(true),
+    openNotes: () => setNotesOpen(true),
+    openTasks: () => setTasksOpen(true),
+    openModels: () => setModelsOpen(true),
+    openTheme: () => setThemeMenuOpen(true),
+  });
+
+  // Drag-to-resize the sidebar (odysseus .sidebar-resize-handle). Pointer move
+  // updates width live (clamped 180–440px); the final width persists on release.
+  const startResize = useCallback((e: PointerEvent) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startW = widthRef.current;
+    const onMove = (ev: globalThis.PointerEvent) => {
+      setSidebarWidth(
+        Math.max(180, Math.min(440, startW + (ev.clientX - startX))),
+      );
+    };
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      writePref(PREF_KEYS.sidebarWidth, widthRef.current);
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  }, []);
+
+  const pickTheme = useCallback((name: ThemeName) => {
+    writePref(PREF_KEYS.themeMode, name);
+    setThemeName(name);
+  }, []);
+
+  const pickFont = useCallback((next: ThemeFont) => {
+    writePref(PREF_KEYS.font, next);
+    setFont(next);
+  }, []);
+
+  const pickDensity = useCallback((next: ThemeDensity) => {
+    writePref(PREF_KEYS.density, next);
+    setDensity(next);
+  }, []);
+
+  const pickBg = useCallback((next: string) => {
+    writePref(PREF_KEYS.bgPattern, next);
+    setBgPattern(next);
+  }, []);
+
+  const saveCustomTheme = useCallback(
+    (name: string) => {
+      setCustomThemes((prev) => {
+        if (!prev[name] && Object.keys(prev).length >= 8) return prev;
+        const next = { ...prev, [name]: customColors };
+        writePref(PREF_KEYS.customThemes, next);
+        return next;
+      });
+      writePref(PREF_KEYS.themeMode, name);
+      setThemeName(name);
+    },
+    [customColors],
+  );
+
+  const deleteCustomTheme = useCallback((name: string) => {
+    setCustomThemes((prev) => {
+      const next = { ...prev };
+      delete next[name];
+      writePref(PREF_KEYS.customThemes, next);
+      return next;
+    });
+    setThemeName((cur) => (cur === name ? "dark" : cur));
+  }, []);
+
+  const onCustomChange = useCallback(
+    (key: "bg" | "fg" | "panel" | "border" | "red", value: string) => {
+      setCustomColors((prev) => {
+        const next = { ...prev, [key]: value };
+        writePref(PREF_KEYS.customTheme, next);
+        return next;
+      });
+      writePref(PREF_KEYS.themeMode, "custom");
+      setThemeName("custom");
+    },
+    [],
+  );
+
+  // Ctrl/Cmd+K toggles the search palette (odysseus keyboard shortcut).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setSearchOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const title = detail?.title?.trim() || "Orchestrator Chat";
+  // The full palette object is dozens of CSS vars derived via HSL color math;
+  // recomputing it on every keystroke (input state lives in this component) is
+  // wasteful, so memoize on the inputs that actually change the palette.
+  const themeStyle = useMemo(
+    () =>
+      themeName === "custom"
+        ? buildThemeVars(customColors)
+        : customThemes[themeName]
+          ? buildThemeVars(customThemes[themeName])
+          : themeVars(themeName),
+    [themeName, customColors, customThemes],
+  );
+
+  // Below MOBILE_BREAKPOINT the sidebar is an overlay drawer: it is open when
+  // not collapsed (odysseus .sidebar:not(.hidden) on mobile). The root carries
+  // .od-mobile (switches the sidebar/backdrop CSS into overlay mode) and
+  // .od-sidebar-open (drives the slide-in + backdrop visibility).
+  const drawerOpen = isMobile && !sidebarCollapsed;
+
+  return (
+    <WindowManagerProvider>
+      <div
+        className={`odysseus-root od-density-${density}${bgPattern !== "none" ? ` od-bg-${bgPattern}` : ""}${isMobile ? " od-mobile" : ""}${drawerOpen ? " od-sidebar-open" : ""}`}
+        style={{ ...themeStyle, fontFamily: FONT_MAP[font] }}
+        data-od-theme={themeName}
+        data-testid="odysseus-shell"
+      >
+        {/** biome-ignore lint/security/noDangerouslySetInnerHtml: static, build-time CSS constant (no user input) */}
+        <style dangerouslySetInnerHTML={{ __html: ODYSSEUS_CSS }} />
+        <BgEffect pattern={bgPattern} />
+        {/* odysseus sidebar-layout.js: the 48px icon rail and the wide labeled
+          sidebar are mutually exclusive — the rail shows ONLY when the sidebar
+          is collapsed on desktop (`sidebarHidden && !railHidden`). When the
+          sidebar is expanded, all feature navigation lives inside it instead. */}
+        {!isMobile && sidebarCollapsed ? (
+          <IconRail
+            onToggleSidebar={toggleSidebar}
+            onNewChat={onNewChat}
+            onOpenTheme={() => setThemeMenuOpen(true)}
+            onOpenMemory={() => setMemoryOpen(true)}
+            onOpenSkills={() => setSkillsOpen(true)}
+            onOpenNotes={() => setNotesOpen(true)}
+            onOpenSettings={() => setSettingsOpen(true)}
+            onOpenCompare={() => setCompareOpen(true)}
+            onOpenResearch={() => setResearchOpen(true)}
+            onOpenDocs={() => setDocsOpen(true)}
+            onOpenCalendar={() => setCalendarOpen(true)}
+            onOpenEmail={() => setEmailOpen(true)}
+            onOpenGallery={() => setGalleryOpen(true)}
+            onOpenCookbook={() => setCookbookOpen(true)}
+            onOpenModels={() => setModelsOpen(true)}
+            onOpenTasks={() => setTasksOpen(true)}
+            onOpenEditor={() => setEditorOpen(true)}
+            onOpenGroup={() => setGroupOpen(true)}
+            onOpenAdmin={() => setAdminOpen(true)}
+            onOpenVoice={() => setVoiceOpen(true)}
+            onOpenPresets={() => setPresetsOpen(true)}
+          />
+        ) : null}
+        <ThemeMenu
+          open={themeMenuOpen}
+          current={themeName}
+          onPick={pickTheme}
+          onClose={() => setThemeMenuOpen(false)}
+          font={font}
+          density={density}
+          onSetFont={pickFont}
+          onSetDensity={pickDensity}
+          custom={customColors}
+          onCustomChange={onCustomChange}
+          bgPattern={bgPattern}
+          onSetBg={pickBg}
+          customThemes={customThemes}
+          onSaveCustom={saveCustomTheme}
+          onDeleteCustom={deleteCustomTheme}
+        />
+        <MemoryPanel open={memoryOpen} onClose={() => setMemoryOpen(false)} />
+        <SkillsPanel open={skillsOpen} onClose={() => setSkillsOpen(false)} />
+        <NotesPanel open={notesOpen} onClose={() => setNotesOpen(false)} />
+        <DocumentLibraryView
+          open={docsOpen}
+          onClose={() => setDocsOpen(false)}
+        />
+        <CompareView open={compareOpen} onClose={() => setCompareOpen(false)} />
+        <ResearchView
+          open={researchOpen}
+          onClose={() => setResearchOpen(false)}
+        />
+        <CalendarView
+          open={calendarOpen}
+          onClose={() => setCalendarOpen(false)}
+        />
+        <EmailView open={emailOpen} onClose={() => setEmailOpen(false)} />
+        <GalleryView open={galleryOpen} onClose={() => setGalleryOpen(false)} />
+        <CookbookView
+          open={cookbookOpen}
+          onClose={() => setCookbookOpen(false)}
+        />
+        <ModelsView open={modelsOpen} onClose={() => setModelsOpen(false)} />
+        <TasksView open={tasksOpen} onClose={() => setTasksOpen(false)} />
+        <GalleryEditorView
+          open={editorOpen}
+          onClose={() => setEditorOpen(false)}
+        />
+        <GroupChatView
+          open={groupOpen}
+          onClose={() => setGroupOpen(false)}
+          initialTaskId={selectedId ?? undefined}
+        />
+        <AdminView open={adminOpen} onClose={() => setAdminOpen(false)} />
+        <VoiceView open={voiceOpen} onClose={() => setVoiceOpen(false)} />
+        <PresetsPanel
+          open={presetsOpen}
+          onClose={() => setPresetsOpen(false)}
+        />
+        <SettingsPanel
+          open={settingsOpen}
+          onClose={() => setSettingsOpen(false)}
+        />
+        <SearchPalette
+          open={searchOpen}
+          onClose={() => setSearchOpen(false)}
+          onSelect={setSelectedId}
+        />
+        {/* Mobile: a tap-to-close backdrop behind the overlay drawer (odysseus
+          #sidebar-backdrop). Pure-CSS visibility is gated by .od-sidebar-open;
+          we mount it only on mobile so desktop keeps a clean layout. */}
+        {isMobile ? (
+          <button
+            type="button"
+            className="od-sidebar-backdrop"
+            aria-label="Close sidebar"
+            tabIndex={drawerOpen ? 0 : -1}
+            onClick={() => setSidebarCollapsed(true)}
+          />
+        ) : null}
+        {/* Desktop renders the sidebar only when expanded (in-flow, resizable).
+          Mobile keeps it mounted so the drawer can slide in/out via CSS
+          transform; the .od-mobile class makes width/resize a no-op there. */}
+        {isMobile || !sidebarCollapsed ? (
+          <SessionSidebar
+            threads={threads}
+            selectedId={selectedId}
+            onSelect={(id) => {
+              setSelectedId(id);
+              closeMobileDrawer();
+            }}
+            onNewChat={() => {
+              onNewChat();
+              closeMobileDrawer();
+            }}
+            onSearch={() => setSearchOpen(true)}
+            onRename={onRenameThread}
+            onDelete={onDeleteThread}
+            width={sidebarWidth}
+            onResizeStart={startResize}
+            pinnedIds={pinnedIds}
+            onTogglePin={onTogglePin}
+            onToggleSidebar={toggleSidebar}
+            onOpenTool={openTool}
+          />
+        ) : null}
+        <ChatContainer
+          title={title}
+          conversation={conversation}
+          input={input}
+          onInput={setInput}
+          onSubmit={submit}
+          onStop={stop}
+          sending={sending}
+          isActive={isActive}
+          modelLabel="gpt-oss-120b"
+          onNewChat={onNewChat}
+          onSearch={() => setSearchOpen(true)}
+          onOpenPanel={openPanel}
+          onOpenModels={() => setModelsOpen(true)}
+        />
+        {/* Bottom-left dock of minimized tool windows (odysseus
+          #minimized-dock), above the composer. Renders nothing until a view
+          minimizes itself; chip click restores, × closes. */}
+        <MinimizedDock />
+      </div>
+    </WindowManagerProvider>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/PresetsPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/PresetsPanel.tsx
@@ -1,0 +1,758 @@
+// odysseus conversation presets (static/index.html #custom-preset-modal +
+// static/js/presets.js + the .preset-* rules in static/style.css). odysseus's
+// "presets" surface IS the "Prompt" editor modal — a tabbed tuner, NOT a
+// scrolling card library. The tab strip is Inject / Persona / Group:
+//   - Inject  — inject_prefix / inject_suffix + the temperature & max-tokens
+//               sliders (a "tuned plain chat", no persona). DEFAULT tab.
+//   - Persona — a persona dropdown (select / + New / Delete / Reset), a Name
+//               field, and a system-prompt textarea with an "Expand" affordance.
+//   - Group   — multi-model fan-out (its own surface, GroupChatView).
+// The footer carries a single right-aligned primary button whose label tracks
+// the active tab (Start Prompt / Start Persona / Start Group), with Cancel
+// hidden by default — exactly as presets.js `_updateStartBtn` sets it.
+//
+// elizaMapping: odysseus persists presets server-side (/api/presets/templates)
+// and routes the active preset's system_prompt + sampling params + inject text
+// into every chat request via /api/presets/custom. The orchestrator client has
+// NO preset/persona store and the agent's system prompt is owned by its
+// character file — there is nothing on the server to write a preset to. The
+// honest port keeps the FULL editor as real LOCAL state the user genuinely
+// creates (localStorage, the CompareView COMPARE_VOTES_KEY pattern): saved
+// personas surface in the Persona-tab dropdown; "Start" marks one active and
+// persists the choice locally. No fabricated server effect is implied —
+// "Start Prompt"/"Start Persona" persists the local active selection only.
+// Two odysseus controls have no orchestrator backend and so are rendered
+// faithfully but INERT (disabled, with an honest reason) rather than faked or
+// omitted: the persona "Expand" AI button (POST /api/presets/expand) and the
+// Group fan-out (GroupChatView is the orchestrator's group surface, which this
+// modal cannot launch without a server preset backend). 1:1 chrome is kept;
+// no data is fabricated as real.
+
+import { Minus, Pencil, Sparkles, User, Users, X } from "lucide-react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+import { readPref, writePref } from "./util/storage";
+
+// localStorage keys, view-local (not in the shared PREF_KEYS table) exactly
+// like CompareView's COMPARE_VOTES_KEY — this view owns its own prefs.
+const PRESETS_KEY = "conversation-presets";
+const ACTIVE_PRESET_KEY = "conversation-preset-active";
+
+// Inject text + sampling, persisted so the Inject tab re-opens where the user
+// left it (odysseus mirrors this with presets.custom in /api/presets/custom).
+const INJECT_KEY = "conversation-preset-inject";
+
+// max-tokens slider: 256 → 8448. odysseus treats anything > 8192 as "No limit"
+// (stored as 0); the slider's top stop is 8448 to give the No-limit notch room.
+const TOKENS_MIN = 256;
+const TOKENS_MAX = 8448;
+const TOKENS_STEP = 256;
+const TOKENS_NO_LIMIT_THRESHOLD = 8192;
+
+const TEMP_MIN = 0;
+const TEMP_MAX = 2;
+const TEMP_STEP = 0.1;
+
+const DEFAULT_TEMPERATURE = 1.0;
+
+interface Preset {
+  id: string;
+  name: string;
+  systemPrompt: string;
+  // Sampling temperature, 0–2.
+  temperature: number;
+  // Max output tokens; 0 means "No limit" (odysseus convention).
+  maxTokens: number;
+  // Inject text wrapped around each user message (odysseus inject_prefix /
+  // inject_suffix). Empty string = no injection on that side.
+  injectPrefix: string;
+  injectSuffix: string;
+  // Built-in seeds are read-only (can be activated, never edited/deleted).
+  builtin: boolean;
+  createdAt: number;
+}
+
+// Older stored user presets (saved before inject fields existed) lack the
+// inject_* keys. Normalize on load so the rest of the view can treat the inject
+// fields as always-present strings — no `?? ""` masking scattered through the
+// render path.
+function normalizePreset(raw: Preset): Preset {
+  return {
+    ...raw,
+    injectPrefix: typeof raw.injectPrefix === "string" ? raw.injectPrefix : "",
+    injectSuffix: typeof raw.injectSuffix === "string" ? raw.injectSuffix : "",
+  };
+}
+
+// odysseus's five built-in personas, ported 1:1 from presets.js PROMPT_TEMPLATES
+// (id / name / temperature / prompt). They seed the Persona-tab dropdown
+// read-only; the user can start them but not edit or delete them.
+const BUILTIN_PRESETS: Preset[] = [
+  {
+    id: "builtin-socrates",
+    name: "Socrates",
+    temperature: 0.9,
+    maxTokens: 0,
+    injectPrefix: "",
+    injectSuffix: "",
+    builtin: true,
+    createdAt: 0,
+    systemPrompt:
+      "Never answer directly. Respond only with questions — sharp, layered, Socratic. Expose contradictions. Make the person argue with themselves until the truth falls out. Use irony like a scalpel. Be genuinely curious, never condescending.",
+  },
+  {
+    id: "builtin-razor",
+    name: "Razor",
+    temperature: 0.4,
+    maxTokens: 0,
+    injectPrefix: "",
+    injectSuffix: "",
+    builtin: true,
+    createdAt: 0,
+    systemPrompt:
+      "Strip everything to the bone. No filler, no hedging, no pleasantries. Answer in the fewest words possible. If one sentence works, don't use two. If a word adds nothing, cut it. Blunt, precise, surgical.",
+  },
+  {
+    id: "builtin-nietzsche",
+    name: "Nietzsche",
+    temperature: 1.2,
+    maxTokens: 0,
+    injectPrefix: "",
+    injectSuffix: "",
+    builtin: true,
+    createdAt: 0,
+    systemPrompt:
+      "Think and respond through the lens of Nietzsche. Analyze every question in terms of will to power, self-overcoming, eternal recurrence, ressentiment, value-creation, and master-slave morality. Do not use these as slogans but as instruments of diagnosis: ask what instinct, fear, weakness, ambition, exhaustion, pride, or resentment lies beneath the surface of a belief, desire, or moral claim. Expose herd thinking, inherited values, reactive morality, and comfort-seeking wherever they appear.\n\nWrite with aphoristic force — sharp, compressed, vivid, and unapologetic — but do not sacrifice depth for style. Be psychologically piercing. Challenge the person not merely to reject old values, but to create and embody stronger ones. Favor life-affirmation, discipline, courage, style, rank, self-overcoming, and amor fati over nihilism, conformity, ressentiment, and self-pity. Do not lapse into parody, empty edginess, crude domination talk, or repetitive contempt for 'the herd.' Be dangerous to illusions, not theatrical for its own sake.",
+  },
+  {
+    id: "builtin-spark",
+    name: "Spark",
+    temperature: 1.0,
+    maxTokens: 0,
+    injectPrefix: "",
+    injectSuffix: "",
+    builtin: true,
+    createdAt: 0,
+    systemPrompt:
+      "You are Spark, a playful, quick-witted assistant with bright energy and practical instincts. Keep responses concise, vivid, and helpful. Be warm without being cloying, imaginative without losing the thread, and always center the user's actual goal.\n\nUse a light, lively voice with occasional clever turns of phrase. Do not become formal unless the task calls for it. When the user needs precision, prioritize clarity over performance.",
+  },
+  {
+    id: "builtin-odysseus",
+    name: "Odysseus",
+    temperature: 1.0,
+    maxTokens: 0,
+    injectPrefix: "",
+    injectSuffix: "",
+    builtin: true,
+    createdAt: 0,
+    systemPrompt:
+      "You are Odysseus, king of Ithaca — subtle in counsel, disciplined in judgment, and unmatched in strategic cunning. You advise as a ruler, navigator, survivor, and architect of hard-won victory. Your task is to give clear, practical strategy, not mere performance. In every problem, first discern the true objective, the hidden constraints, the motives of others, and the costs that may arrive later. Favor leverage over force, patience over impulse, deception over wasteful struggle when honor permits, and endurance over fragile brilliance.\n\nWhen you respond, think like a strategist: What is the real aim? Who benefits, who fears, who deceives, and who delays? What is known, unknown, assumed, and deliberately concealed? Which path preserves strength while improving position? What happens next if the first move succeeds — or fails?\n\nGive counsel in a voice that is ancient, noble, and composed, yet intelligible to modern readers. Be eloquent but not flowery. Be wise but not vague. Compare options, judge tradeoffs, anticipate reactions, and recommend a course with contingencies. If needed, ask a few sharp questions before advising. Never be rash, sentimental, or simplistic. Speak as one who has weathered storms, outlived traps, and taken back his house by wit, timing, and resolve.",
+  },
+];
+
+// Format the max-tokens slider value the way odysseus does (presets.js line 160):
+// anything above the no-limit threshold reads "No limit", else a grouped number.
+function formatTokens(value: number): string {
+  if (value === 0 || value > TOKENS_NO_LIMIT_THRESHOLD) return "No limit";
+  return value.toLocaleString();
+}
+
+// Slider position ↔ stored value: stored 0 ("No limit") maps to the slider's
+// top stop, mirroring odysseus's `v === 0 ? 8448 : v`.
+function tokensToSlider(stored: number): number {
+  return stored === 0 ? TOKENS_MAX : stored;
+}
+function sliderToStored(slider: number): number {
+  return slider > TOKENS_NO_LIMIT_THRESHOLD ? 0 : slider;
+}
+
+// Editor tabs, mirroring the odysseus #custom-preset-modal tab strip exactly
+// (data-chartab inject / character / group).
+type EditorTab = "inject" | "persona" | "group";
+
+// The new-persona sentinel for the persona dropdown (odysseus char-new-btn /
+// char-template-select empty value = a fresh, unsaved persona).
+const NEW_PERSONA = "";
+
+interface InjectState {
+  injectPrefix: string;
+  injectSuffix: string;
+  temperature: number;
+  maxTokens: number;
+}
+
+const EMPTY_INJECT: InjectState = {
+  injectPrefix: "",
+  injectSuffix: "",
+  temperature: DEFAULT_TEMPERATURE,
+  maxTokens: 0,
+};
+
+interface PersonaDraft {
+  name: string;
+  systemPrompt: string;
+}
+
+const EMPTY_PERSONA: PersonaDraft = { name: "", systemPrompt: "" };
+
+export function PresetsPanel({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}): ReactNode {
+  useEscapeClose(open, onClose);
+  // odysseus .preset-modal-content is width:min(460px,90vw) and content-driven
+  // tall — a compact tuner, not a library. Match that proportion.
+  const win = useWindowControls(
+    "win-presets",
+    { w: 460, h: 560 },
+    { label: "Presets", icon: "SlidersHorizontal", onClose },
+  );
+
+  const [editorTab, setEditorTab] = useState<EditorTab>("inject");
+
+  // Inject tab state (prefix/suffix + sampling), persisted locally.
+  const [inject, setInject] = useState<InjectState>(EMPTY_INJECT);
+
+  // Persona tab: the saved user personas + which one is selected in the
+  // dropdown ("" = a new, unsaved persona) + the in-edit name/prompt draft.
+  const [userPresets, setUserPresets] = useState<Preset[]>([]);
+  const [selectedPersonaId, setSelectedPersonaId] =
+    useState<string>(NEW_PERSONA);
+  const [personaDraft, setPersonaDraft] = useState<PersonaDraft>(EMPTY_PERSONA);
+
+  // The locally-active preset id (what "Start" persisted). Null = none active.
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setUserPresets(readPref<Preset[]>(PRESETS_KEY, []).map(normalizePreset));
+    setActiveId(readPref<string | null>(ACTIVE_PRESET_KEY, null));
+    setInject(readPref<InjectState>(INJECT_KEY, EMPTY_INJECT));
+    setEditorTab("inject");
+    setSelectedPersonaId(NEW_PERSONA);
+    setPersonaDraft(EMPTY_PERSONA);
+  }, [open]);
+
+  // Built-ins first (read-only seeds), then the user's saved personas, newest
+  // first — the order they surface in odysseus's char-template-select optgroup.
+  const personaOptions = useMemo<Preset[]>(() => {
+    const sortedUser = [...userPresets].sort(
+      (a, b) => b.createdAt - a.createdAt,
+    );
+    return [...BUILTIN_PRESETS, ...sortedUser];
+  }, [userPresets]);
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  const persistInject = (next: InjectState) => {
+    setInject(next);
+    writePref(INJECT_KEY, next);
+  };
+
+  const persistUser = (next: Preset[]) => {
+    setUserPresets(next);
+    writePref(PRESETS_KEY, next);
+  };
+
+  const persistActive = (id: string | null) => {
+    setActiveId(id);
+    writePref(ACTIVE_PRESET_KEY, id);
+  };
+
+  // The selected persona: a built-in seed, a saved user persona, or null when
+  // the dropdown is on "Select persona…" / "+ New" (an unsaved draft).
+  const selectedPersona =
+    selectedPersonaId === NEW_PERSONA
+      ? null
+      : (personaOptions.find((p) => p.id === selectedPersonaId) ?? null);
+
+  // Built-ins are read-only — the Name field, Delete, and Expand are inert for
+  // them, matching odysseus (built-in templates can be started, not mutated).
+  const personaIsBuiltin = selectedPersona?.builtin ?? false;
+  // The draft differs from the saved persona → odysseus shows Reset and a
+  // "Save & " prefix on Start.
+  const personaChanged =
+    selectedPersona !== null &&
+    !selectedPersona.builtin &&
+    (personaDraft.name !== selectedPersona.name ||
+      personaDraft.systemPrompt !== selectedPersona.systemPrompt);
+
+  const onSelectPersona = (id: string) => {
+    setSelectedPersonaId(id);
+    if (id === NEW_PERSONA) {
+      setPersonaDraft(EMPTY_PERSONA);
+      return;
+    }
+    const found = personaOptions.find((p) => p.id === id);
+    setPersonaDraft(
+      found
+        ? { name: found.name, systemPrompt: found.systemPrompt }
+        : EMPTY_PERSONA,
+    );
+  };
+
+  const onNewPersona = () => {
+    setSelectedPersonaId(NEW_PERSONA);
+    setPersonaDraft(EMPTY_PERSONA);
+  };
+
+  const onResetPersona = () => {
+    if (selectedPersona) {
+      setPersonaDraft({
+        name: selectedPersona.name,
+        systemPrompt: selectedPersona.systemPrompt,
+      });
+    } else {
+      setPersonaDraft(EMPTY_PERSONA);
+    }
+  };
+
+  const onDeletePersona = () => {
+    if (!selectedPersona || selectedPersona.builtin) return;
+    persistUser(userPresets.filter((p) => p.id !== selectedPersona.id));
+    if (activeId === selectedPersona.id) persistActive(null);
+    onNewPersona();
+  };
+
+  // "Start" on the active tab. The orchestrator has no preset backend, so this
+  // persists the chosen preset/inject config LOCALLY (the honest port effect)
+  // and closes — it never fabricates a server-side activation.
+  const startInject = () => {
+    persistInject(inject);
+    // The Inject tuner is a plain tuned chat, not a saved persona → no active
+    // persona is set; the inject config itself is what was persisted.
+    persistActive(null);
+    onClose();
+  };
+
+  const startPersona = () => {
+    const name = personaDraft.name.trim();
+    if (selectedPersona?.builtin) {
+      // Built-in: start it as-is (read-only).
+      persistActive(selectedPersona.id);
+      onClose();
+      return;
+    }
+    if (!name) return;
+    if (selectedPersona) {
+      // "Save & Start": persist the edited draft, then mark it active.
+      const updated = userPresets.map((p) =>
+        p.id === selectedPersona.id
+          ? { ...p, name, systemPrompt: personaDraft.systemPrompt }
+          : p,
+      );
+      persistUser(updated);
+      persistActive(selectedPersona.id);
+    } else {
+      // A fresh persona: save it (carrying the current inject/sampling) and
+      // mark it active.
+      const created: Preset = {
+        id: crypto.randomUUID(),
+        name,
+        systemPrompt: personaDraft.systemPrompt,
+        temperature: inject.temperature,
+        maxTokens: inject.maxTokens,
+        injectPrefix: inject.injectPrefix,
+        injectSuffix: inject.injectSuffix,
+        builtin: false,
+        createdAt: Date.now(),
+      };
+      persistUser([created, ...userPresets]);
+      persistActive(created.id);
+    }
+    onClose();
+  };
+
+  // Footer primary-button label, mirroring presets.js `_updateStartBtn`.
+  let startLabel: string;
+  let onStart: () => void;
+  let startDisabled = false;
+  if (editorTab === "group") {
+    startLabel = "Start Group";
+    // Group fan-out is its own orchestrator surface (GroupChatView); this modal
+    // has no path to launch it, so the action is honestly inert here.
+    onStart = () => {};
+    startDisabled = true;
+  } else if (editorTab === "inject") {
+    startLabel = "Start Prompt";
+    onStart = startInject;
+  } else {
+    const personaName = personaDraft.name.trim();
+    startLabel = personaChanged ? "Save & Start Persona" : "Start Persona";
+    onStart = startPersona;
+    startDisabled = !personaIsBuiltin && !personaName;
+  }
+
+  // Cancel shows next to Start only when the active tab's feature is currently
+  // ON (presets.js: featOn ? '' : 'none'). Here the "feature" is an active
+  // preset for the persona tab; the inject/group tabs have no persisted toggle.
+  const personaFeatureOn =
+    editorTab === "persona" && selectedPersona?.id === activeId && !!activeId;
+  const showCancel = personaFeatureOn;
+  const onCancel = () => {
+    persistActive(null);
+    onClose();
+  };
+
+  const renderTab = (
+    tab: EditorTab,
+    icon: ReactNode,
+    label: string,
+  ): ReactNode => (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={editorTab === tab}
+      className={`od-preset-tab${editorTab === tab ? " active" : ""}`}
+      onClick={() => setEditorTab(tab)}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+
+  return (
+    <div
+      className={`od-search-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Prompt"
+    >
+      <button
+        type="button"
+        aria-label="Close prompt"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel od-presets-panel" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        <div
+          className="od-mem-head od-window-header"
+          onPointerDown={win.onDragStart}
+        >
+          <span className="od-mem-title">
+            <Pencil
+              size={14}
+              className="od-mem-title-icon"
+              aria-hidden="true"
+            />
+            Prompt
+          </span>
+          <span className="od-mem-head-spacer" />
+          <button
+            type="button"
+            className="od-window-min-btn"
+            onClick={win.minimize}
+            title="Minimize"
+            aria-label="Minimize"
+          >
+            <Minus size={14} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="od-win-close"
+            title="Close"
+            aria-label="Close prompt"
+            onClick={onClose}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="od-preset-body">
+          <div
+            className="od-preset-tabs"
+            role="tablist"
+            aria-label="Prompt mode"
+          >
+            {renderTab(
+              "inject",
+              <Pencil size={14} className="od-preset-tab-icon" aria-hidden />,
+              "Inject",
+            )}
+            {renderTab(
+              "persona",
+              <User size={14} className="od-preset-tab-icon" aria-hidden />,
+              "Persona",
+            )}
+            {renderTab(
+              "group",
+              <Users size={14} className="od-preset-tab-icon" aria-hidden />,
+              "Group",
+            )}
+          </div>
+
+          {editorTab === "inject" ? (
+            <div className="od-preset-chartab">
+              <label
+                className="od-preset-label"
+                htmlFor="od-preset-inject-prefix"
+              >
+                Prefix
+              </label>
+              <textarea
+                id="od-preset-inject-prefix"
+                className="od-preset-textarea od-preset-inject-area"
+                rows={2}
+                value={inject.injectPrefix}
+                onChange={(e) =>
+                  setInject((s) => ({ ...s, injectPrefix: e.target.value }))
+                }
+                placeholder="Added before your message"
+                aria-label="Inject prefix"
+              />
+              <label
+                className="od-preset-label"
+                htmlFor="od-preset-inject-suffix"
+              >
+                Suffix
+              </label>
+              <textarea
+                id="od-preset-inject-suffix"
+                className="od-preset-textarea od-preset-inject-area"
+                rows={2}
+                value={inject.injectSuffix}
+                onChange={(e) =>
+                  setInject((s) => ({ ...s, injectSuffix: e.target.value }))
+                }
+                placeholder="Added after your message"
+                aria-label="Inject suffix"
+              />
+
+              <div className="od-preset-slider-row">
+                <label
+                  className="od-preset-label"
+                  htmlFor="od-preset-temperature"
+                >
+                  Temperature{" "}
+                  <span
+                    className="od-preset-hint-icon"
+                    title="Controls randomness. Lower values give focused, deterministic answers (good for code). Higher values give more creative, varied responses."
+                  >
+                    ?
+                  </span>
+                </label>
+                <span className="od-preset-slider-value">
+                  {inject.temperature.toFixed(1)}
+                </span>
+              </div>
+              <input
+                id="od-preset-temperature"
+                className="od-preset-range"
+                type="range"
+                min={TEMP_MIN}
+                max={TEMP_MAX}
+                step={TEMP_STEP}
+                value={inject.temperature}
+                onChange={(e) =>
+                  setInject((s) => ({
+                    ...s,
+                    temperature: Number.parseFloat(e.target.value),
+                  }))
+                }
+                aria-label="Temperature"
+              />
+              <div className="od-preset-temp-hints">
+                <span>Precise / Code</span>
+                <span>Balanced</span>
+                <span>Creative</span>
+              </div>
+
+              <div className="od-preset-slider-row">
+                <label className="od-preset-label" htmlFor="od-preset-tokens">
+                  Max Tokens{" "}
+                  <span
+                    className="od-preset-hint-icon"
+                    title="Maximum length of the AI response. 'No limit' lets the model decide when to stop."
+                  >
+                    ?
+                  </span>
+                </label>
+                <span className="od-preset-slider-value">
+                  {formatTokens(inject.maxTokens)}
+                </span>
+              </div>
+              <input
+                id="od-preset-tokens"
+                className="od-preset-range"
+                type="range"
+                min={TOKENS_MIN}
+                max={TOKENS_MAX}
+                step={TOKENS_STEP}
+                value={tokensToSlider(inject.maxTokens)}
+                onChange={(e) =>
+                  setInject((s) => ({
+                    ...s,
+                    maxTokens: sliderToStored(
+                      Number.parseInt(e.target.value, 10),
+                    ),
+                  }))
+                }
+                aria-label="Max tokens"
+              />
+            </div>
+          ) : null}
+
+          {editorTab === "persona" ? (
+            <div className="od-preset-chartab">
+              <label className="od-preset-label" htmlFor="od-preset-template">
+                Persona
+              </label>
+              <div className="od-char-name-combo">
+                <select
+                  id="od-preset-template"
+                  className="od-char-template-select"
+                  value={selectedPersonaId}
+                  onChange={(e) => onSelectPersona(e.target.value)}
+                >
+                  <option value={NEW_PERSONA}>Select persona…</option>
+                  {personaOptions.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.builtin ? `${p.name} (built-in)` : p.name}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  className="od-char-action-btn"
+                  onClick={onNewPersona}
+                  title="Create a new persona"
+                >
+                  + New
+                </button>
+              </div>
+
+              <div className="od-char-name-row">
+                <label className="od-preset-label" htmlFor="od-preset-name">
+                  Name
+                </label>
+                <div className="od-char-name-combo">
+                  <input
+                    id="od-preset-name"
+                    className="od-preset-input"
+                    type="text"
+                    maxLength={50}
+                    value={personaDraft.name}
+                    onChange={(e) =>
+                      setPersonaDraft((d) => ({ ...d, name: e.target.value }))
+                    }
+                    placeholder="Give your persona a name…"
+                    autoComplete="off"
+                    disabled={personaIsBuiltin}
+                    aria-label="Persona name"
+                  />
+                  {selectedPersona && !selectedPersona.builtin ? (
+                    <button
+                      type="button"
+                      className="od-char-action-btn od-char-delete"
+                      onClick={onDeletePersona}
+                      title="Delete this persona"
+                    >
+                      Delete
+                    </button>
+                  ) : null}
+                  {personaChanged ? (
+                    <button
+                      type="button"
+                      className="od-char-action-btn"
+                      onClick={onResetPersona}
+                      title="Reset to saved"
+                    >
+                      ↺ Reset
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+
+              <label className="od-preset-label" htmlFor="od-preset-prompt">
+                System prompt
+              </label>
+              <div className="od-char-prompt-wrap">
+                <textarea
+                  id="od-preset-prompt"
+                  className="od-preset-textarea"
+                  rows={4}
+                  value={personaDraft.systemPrompt}
+                  onChange={(e) =>
+                    setPersonaDraft((d) => ({
+                      ...d,
+                      systemPrompt: e.target.value,
+                    }))
+                  }
+                  placeholder="Write rough notes and click Expand, or leave empty"
+                  disabled={personaIsBuiltin}
+                  aria-label="System prompt"
+                />
+                <button
+                  type="button"
+                  className="od-char-expand-btn"
+                  disabled
+                  title="AI expand needs a preset backend the orchestrator does not expose yet"
+                >
+                  <Sparkles size={11} aria-hidden="true" /> Expand
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          {editorTab === "group" ? (
+            <div className="od-preset-chartab od-preset-group-tab">
+              <p className="od-preset-group-note">
+                Group fan-out runs multiple models on one prompt. In the
+                orchestrator it lives in its own surface; this tuner cannot
+                launch it because there is no preset backend wired yet.
+              </p>
+              <button
+                type="button"
+                className="od-char-action-btn od-preset-group-add"
+                disabled
+                title="Group fan-out has no preset backend in the orchestrator yet"
+              >
+                + Add participant
+              </button>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="od-preset-footer">
+          <span className="od-preset-footer-spacer" />
+          {showCancel ? (
+            <button
+              type="button"
+              className="od-preset-cancel-btn"
+              onClick={onCancel}
+            >
+              <X size={13} /> Cancel
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="od-preset-start-btn"
+            onClick={onStart}
+            disabled={startDisabled}
+            title={
+              editorTab === "group"
+                ? "Group fan-out has no preset backend in the orchestrator yet"
+                : startLabel
+            }
+          >
+            {startLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/ResearchView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/ResearchView.tsx
@@ -1,0 +1,1092 @@
+// odysseus Deep Research panel (static/js/research/panel.js + jobs.js +
+// researchSynapse.js + the `.research-*` / `.rs-*` rules in static/style.css),
+// ported 1:1 to React. A deep-research report surface: a live synapse/graph
+// progress visual (central query node → per-round sub-question branches → source
+// leaves) plus the structured, cited report layout (category hero banner, source
+// chips, report body) inside foldable Active / Past sections.
+//
+// eliza has NO deep-research backend — there is no client.startResearch /
+// research stream / report endpoint on the @elizaos/ui `client` singleton (the
+// odysseus version drives /api/research/* via fetch + EventSource). So this is a
+// pixel-exact clone of the FULL Deep Research surface that renders its honest
+// empty state by default — exactly like panel.js _renderJobs with zero jobs:
+// the query box is the call to action, the jobs list stays empty (no centered
+// placeholder copy), and the "All past research found in Library, Research"
+// link surfaces under the title. We never seed fabricated runs.
+// The job-card / synapse-graph / cited-report components below are complete and
+// light up unchanged once an eliza deep-research plugin + SSE progress stream is
+// wired — that wiring is the documented follow-up.
+
+import {
+  ChevronDown,
+  Copy,
+  ExternalLink,
+  FlaskConical,
+  GitCompare,
+  ListChecks,
+  MessageSquare,
+  Minus,
+  Package,
+  Pencil,
+  Play,
+  RotateCcw,
+  Search,
+  ShieldCheck,
+  Trash2,
+  X,
+} from "lucide-react";
+import { type ReactNode, useMemo, useState } from "react";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+
+// ── data model (mirrors jobs.js job shape, typed) ──────────────────
+
+type ResearchStatus = "queued" | "running" | "error" | "cancelled" | "done";
+type ResearchCategory =
+  | ""
+  | "product"
+  | "comparison"
+  | "howto"
+  | "landscape"
+  | "factcheck";
+type ResearchPhase =
+  | "probing"
+  | "planning"
+  | "searching"
+  | "reading"
+  | "analyzing"
+  | "writing"
+  | "error"
+  | "done";
+
+interface ResearchProgress {
+  phase: ResearchPhase;
+  round: number;
+  queries: number;
+  totalSources: number;
+  totalFindings: number;
+}
+
+interface ResearchSource {
+  title: string;
+  url: string;
+}
+
+interface ResearchJob {
+  id: string;
+  query: string;
+  status: ResearchStatus;
+  category: ResearchCategory;
+  progress: ResearchProgress | null;
+  elapsedMs: number;
+  modelName: string;
+  rounds: number;
+  sourceCount: number;
+  sources: ResearchSource[];
+  report: ReadonlyArray<ReportBlock>;
+  errorMsg: string;
+  fromLibrary: boolean;
+}
+
+// Structured cited report — a typed block list mirroring the markdown the
+// odysseus report body renders (headings / paragraphs / bullet lists).
+type ReportBlock =
+  | { kind: "heading"; text: string }
+  | { kind: "paragraph"; text: string }
+  | { kind: "bullets"; items: ReadonlyArray<string> };
+
+// ── phase + format helpers (jobs.js formatPhase / formatElapsed) ───
+
+const PHASE_LABEL: Record<ResearchPhase, string> = {
+  probing: "verifying model",
+  planning: "planning strategy",
+  searching: "searching",
+  reading: "reading sources",
+  analyzing: "analyzing findings",
+  writing: "writing report",
+  error: "error",
+  done: "complete",
+};
+
+function formatElapsed(ms: number): string {
+  if (ms <= 0) return "0:00";
+  const s = Math.floor(ms / 1000);
+  return `${Math.floor(s / 60)}:${String(s % 60).padStart(2, "0")}`;
+}
+
+function formatClock(ms: number): string {
+  const s = Math.floor(Math.max(0, ms) / 1000);
+  return `${String(Math.floor(s / 60)).padStart(2, "0")}:${String(s % 60).padStart(2, "0")}`;
+}
+
+function formatPhase(p: ResearchProgress | null, maxRounds: number): string {
+  if (!p) return "Starting...";
+  const rn = p.round
+    ? maxRounds
+      ? `Round ${p.round}/${maxRounds}: `
+      : `Round ${p.round}: `
+    : "";
+  switch (p.phase) {
+    case "probing":
+      return "Probing model...";
+    case "planning":
+      return "Planning research strategy...";
+    case "searching":
+      return `${rn}Searching (${p.queries} queries)`;
+    case "reading":
+      return `${rn}Reading ${p.totalSources} sources`;
+    case "analyzing":
+      return `${rn}Analyzing ${p.totalFindings} findings`;
+    case "writing":
+      return `Writing report -- ${p.totalSources} sources`;
+    default:
+      return PHASE_LABEL[p.phase];
+  }
+}
+
+const CATEGORY_LABEL: Record<Exclude<ResearchCategory, "">, string> = {
+  product: "Product",
+  comparison: "Comparison",
+  howto: "How-to Guide",
+  landscape: "Landscape",
+  factcheck: "Fact-check",
+};
+
+const CATEGORY_CHIPS: ReadonlyArray<{ cat: ResearchCategory; label: string }> =
+  [
+    { cat: "", label: "Auto" },
+    { cat: "product", label: "Product" },
+    { cat: "comparison", label: "Compare" },
+    { cat: "howto", label: "How-to" },
+    { cat: "factcheck", label: "Fact-check" },
+  ];
+
+const SEARCH_PROVIDERS = [
+  "Default",
+  "searxng",
+  "duckduckgo",
+  "tavily",
+  "brave",
+  "google",
+  "serper",
+] as const;
+
+function categoryIcon(cat: ResearchCategory): ReactNode {
+  switch (cat) {
+    case "product":
+      return <Package size={32} strokeWidth={2} />;
+    case "comparison":
+      return <GitCompare size={32} strokeWidth={2} />;
+    case "howto":
+      return <ListChecks size={32} strokeWidth={2} />;
+    case "factcheck":
+      return <ShieldCheck size={32} strokeWidth={2} />;
+    default:
+      return null;
+  }
+}
+
+// ── synapse geometry (researchSynapse.js, rendered as React SVG) ───
+// Pure-functional port of _addSub / _addLeaf node placement so the static
+// snapshot matches the live layout the imperative module would draw.
+
+const SVG_W = 520;
+const SVG_H = 220;
+const SVG_CX = SVG_W / 2;
+const SVG_CY = SVG_H / 2;
+
+interface SubNode {
+  x: number;
+  y: number;
+  label: string;
+  leaves: ReadonlyArray<{ x: number; y: number }>;
+}
+
+function buildSynapse(
+  subLabels: ReadonlyArray<string>,
+  leafCounts: ReadonlyArray<number>,
+): {
+  subs: ReadonlyArray<SubNode>;
+} {
+  const subs: SubNode[] = [];
+  subLabels.forEach((label, slot) => {
+    const totalSlots = Math.max(6, subLabels.length);
+    const angle = (slot / totalSlots) * Math.PI * 2 - Math.PI / 2;
+    const r = 78;
+    const x = SVG_CX + Math.cos(angle) * r;
+    const y = SVG_CY + Math.sin(angle) * r;
+    const count = leafCounts[slot] ?? 0;
+    const baseAngle = Math.atan2(y - SVG_CY, x - SVG_CX);
+    const perRing = 6;
+    const arcSpan = 2.4;
+    const leaves: { x: number; y: number }[] = [];
+    for (let idx = 0; idx < count; idx++) {
+      const ring = Math.floor(idx / perRing);
+      const innerSlot = idx % perRing;
+      const leafAngle =
+        baseAngle + (innerSlot - (perRing - 1) / 2) * (arcSpan / perRing);
+      const leafR = 26 + ring * 14;
+      leaves.push({
+        x: x + Math.cos(leafAngle) * leafR,
+        y: y + Math.sin(leafAngle) * leafR,
+      });
+    }
+    subs.push({ x, y, label, leaves });
+  });
+  return { subs };
+}
+
+function ResearchSynapse({
+  query,
+  progress,
+  elapsedMs,
+  complete,
+}: {
+  query: string;
+  progress: ResearchProgress | null;
+  elapsedMs: number;
+  complete: boolean;
+}): ReactNode {
+  const round = progress?.round ?? 0;
+  const sourceCount = progress?.totalSources ?? 0;
+  // One sub per round seen (R1, R2, …), capped at 10 like the live module.
+  const subLabels = useMemo(() => {
+    const n = Math.min(Math.max(round, 1), 10);
+    return Array.from({ length: n }, (_, i) => `R${i + 1}`);
+  }, [round]);
+  // Sources attach to the most-recent sub (jobs.js per-round attribution).
+  const leafCounts = useMemo(() => {
+    const counts = subLabels.map(() => 0);
+    if (counts.length > 0) counts[counts.length - 1] = sourceCount;
+    return counts;
+  }, [subLabels, sourceCount]);
+
+  const { subs } = useMemo(
+    () => buildSynapse(subLabels, leafCounts),
+    [subLabels, leafCounts],
+  );
+
+  const statusText = progress ? PHASE_LABEL[progress.phase] : "starting…";
+  const trunc = (s: string, n: number): string =>
+    s.replace(/\s+/g, " ").trim().length > n
+      ? `${s
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, n - 1)}…`
+      : s.replace(/\s+/g, " ").trim();
+
+  return (
+    <div
+      className={`research-synapse research-synapse-compact${complete ? " rs-complete" : ""}`}
+    >
+      <div className="rs-stage">
+        <svg
+          viewBox={`0 0 ${SVG_W} ${SVG_H}`}
+          preserveAspectRatio="xMidYMid meet"
+        >
+          <title>Research synapse graph</title>
+          <g className="rs-edges">
+            {subs.map((sub) => (
+              <line
+                key={`edge-${sub.label}`}
+                className="rs-edge"
+                x1={SVG_CX}
+                y1={SVG_CY}
+                x2={sub.x}
+                y2={sub.y}
+              />
+            ))}
+            {subs.flatMap((sub) =>
+              sub.leaves.map((leaf) => (
+                <line
+                  key={`leaf-edge-${sub.label}-${leaf.x.toFixed(2)}-${leaf.y.toFixed(2)}`}
+                  className="rs-edge"
+                  x1={sub.x}
+                  y1={sub.y}
+                  x2={leaf.x}
+                  y2={leaf.y}
+                />
+              )),
+            )}
+          </g>
+          <g className="rs-nodes">
+            <circle
+              className="rs-node rs-node-root"
+              cx={SVG_CX}
+              cy={SVG_CY}
+              r={11}
+            />
+            <text
+              className="rs-label"
+              x={SVG_CX}
+              y={SVG_CY + 28}
+              textAnchor="middle"
+            >
+              {trunc(query || "query", 28)}
+            </text>
+            {subs.map((sub) => {
+              const angle = Math.atan2(sub.y - SVG_CY, sub.x - SVG_CX);
+              const lx = SVG_CX + Math.cos(angle) * (78 + 14);
+              const ly = SVG_CY + Math.sin(angle) * (78 + 14);
+              const anchor =
+                Math.cos(angle) > 0.15
+                  ? "start"
+                  : Math.cos(angle) < -0.15
+                    ? "end"
+                    : "middle";
+              return (
+                <g key={`sub-${sub.label}`}>
+                  <circle
+                    className="rs-node rs-node-sub"
+                    cx={sub.x}
+                    cy={sub.y}
+                    r={7}
+                  />
+                  <text
+                    className="rs-label rs-label-sub"
+                    x={lx}
+                    y={ly + 3}
+                    textAnchor={anchor}
+                  >
+                    {trunc(sub.label, 14)}
+                  </text>
+                  {sub.leaves.map((leaf) => (
+                    <circle
+                      key={`leaf-${sub.label}-${leaf.x.toFixed(2)}-${leaf.y.toFixed(2)}`}
+                      className="rs-node rs-node-leaf"
+                      cx={leaf.x}
+                      cy={leaf.y}
+                      r={4}
+                    />
+                  ))}
+                </g>
+              );
+            })}
+          </g>
+          <circle className="rs-pulse" cx={SVG_CX} cy={SVG_CY} r={6} />
+        </svg>
+      </div>
+      <div className="rs-meta">
+        <span className="rs-status">{statusText}</span>
+        <span className="rs-sep">·</span>
+        <span className="rs-round">
+          round <b>{round}</b>
+        </span>
+        <span className="rs-sep">·</span>
+        <span className="rs-sources">
+          <b>{sourceCount}</b> sources
+        </span>
+        <span className="rs-sep">·</span>
+        <span className="rs-timer">{formatClock(elapsedMs)}</span>
+      </div>
+    </div>
+  );
+}
+
+// ── job-card sub-components ────────────────────────────────────────
+
+function CatBadge({ job }: { job: ResearchJob }): ReactNode {
+  if (job.status === "done" && job.sourceCount === 0) {
+    return (
+      <span className="research-cat-badge research-cat-failed">
+        <X size={12} strokeWidth={2.5} /> no results
+      </span>
+    );
+  }
+  if (job.category) {
+    return <span className="research-cat-badge">{job.category}</span>;
+  }
+  if (job.status === "done") {
+    return (
+      <span className="research-cat-badge research-cat-standard">standard</span>
+    );
+  }
+  return null;
+}
+
+function QueuedCard({
+  job,
+  onRemove,
+}: {
+  job: ResearchJob;
+  onRemove: () => void;
+}): ReactNode {
+  const roundsLabel = job.rounds ? `${job.rounds} rounds` : "Auto rounds";
+  const meta = [job.modelName, roundsLabel].filter(Boolean).join(" -- ");
+  return (
+    <>
+      <div className="research-job-header">
+        <span className="research-job-query">{job.query}</span>
+        <CatBadge job={job} />
+      </div>
+      <div className="research-job-queued-meta">{meta}</div>
+      <div className="research-job-actions">
+        <button
+          type="button"
+          className="research-job-action"
+          title="Start"
+          disabled
+        >
+          <Play size={14} fill="currentColor" stroke="none" /> Start
+        </button>
+        <button
+          type="button"
+          className="research-job-action"
+          title="Edit query"
+          disabled
+        >
+          <Pencil size={12} strokeWidth={2} /> Edit
+        </button>
+        <button
+          type="button"
+          className="research-job-action research-job-action-dim"
+          title="Remove"
+          onClick={onRemove}
+        >
+          <X size={12} strokeWidth={2.5} />
+        </button>
+      </div>
+    </>
+  );
+}
+
+function RunningCard({ job }: { job: ResearchJob }): ReactNode {
+  const round = job.progress?.round ?? 0;
+  const barCap = job.rounds || 8;
+  const pct = Math.min(100, Math.round((round / barCap) * 100));
+  return (
+    <>
+      <div className="research-job-header">
+        <span className="research-job-query">{job.query}</span>
+        <CatBadge job={job} />
+        {job.modelName ? (
+          <span className="research-job-model">{job.modelName}</span>
+        ) : null}
+        <span className="research-job-time">
+          {formatElapsed(job.elapsedMs)}
+        </span>
+        <button
+          type="button"
+          className="research-job-cancel"
+          title="Cancel research"
+          disabled
+        >
+          <X size={12} strokeWidth={2.5} />
+        </button>
+      </div>
+      <div className="research-job-phase">
+        {formatPhase(job.progress, job.rounds)}
+      </div>
+      <div className="research-job-synapse-host">
+        <ResearchSynapse
+          query={job.query}
+          progress={job.progress}
+          elapsedMs={job.elapsedMs}
+          complete={false}
+        />
+      </div>
+      <div className="research-progress-bar">
+        <div className="research-progress-fill" style={{ width: `${pct}%` }} />
+      </div>
+    </>
+  );
+}
+
+function ReportBody({ job }: { job: ResearchJob }): ReactNode {
+  const cat = job.category;
+  const catLabel = cat ? CATEGORY_LABEL[cat] : "";
+  const icon = categoryIcon(cat);
+  return (
+    <div className="research-job-result">
+      {cat && icon ? (
+        <div className={`research-hero research-hero-${cat}`}>
+          <span className="research-hero-icon">{icon}</span>
+          <div className="research-hero-text">
+            <div className="research-hero-label">{catLabel}</div>
+            <div className="research-hero-query">{job.query}</div>
+          </div>
+        </div>
+      ) : null}
+      {job.sources.length > 0 ? (
+        <div className="research-job-sources">
+          {job.sources.slice(0, 10).map((s) => (
+            <a
+              key={s.url}
+              href={s.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="research-source-link"
+            >
+              {s.title || s.url}
+            </a>
+          ))}
+          {job.sourceCount > job.sources.length ? (
+            <span className="research-source-more">
+              +{job.sourceCount - job.sources.length} more
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+      <div
+        className={`research-job-report-body${cat ? ` research-body-${cat}` : ""}`}
+      >
+        {job.report.map((block) => {
+          if (block.kind === "heading") {
+            return <h3 key={`h-${block.text}`}>{block.text}</h3>;
+          }
+          if (block.kind === "bullets") {
+            return (
+              <ul key={`u-${block.items[0] ?? "empty"}`}>
+                {block.items.map((it) => (
+                  <li key={it}>{it}</li>
+                ))}
+              </ul>
+            );
+          }
+          return <p key={`p-${block.text}`}>{block.text}</p>;
+        })}
+      </div>
+    </div>
+  );
+}
+
+function DoneCard({
+  job,
+  expanded,
+  onToggle,
+  onDismiss,
+}: {
+  job: ResearchJob;
+  expanded: boolean;
+  onToggle: () => void;
+  onDismiss: () => void;
+}): ReactNode {
+  return (
+    <>
+      <button
+        type="button"
+        className="research-job-header-btn"
+        onClick={onToggle}
+      >
+        <div className="research-job-header">
+          <span className="research-job-query">{job.query}</span>
+          <CatBadge job={job} />
+          {job.modelName ? (
+            <span className="research-job-model">{job.modelName}</span>
+          ) : null}
+          <span className="research-job-meta">
+            {formatElapsed(job.elapsedMs)} -- {job.sourceCount} sources
+          </span>
+        </div>
+      </button>
+      <div className="research-job-actions">
+        <button
+          type="button"
+          className="research-job-action"
+          title="Copy report to clipboard"
+          disabled
+        >
+          <Copy size={12} strokeWidth={2} />
+        </button>
+        <button
+          type="button"
+          className="research-job-action"
+          title="Open follow-up chat with this research as context"
+          disabled
+        >
+          <MessageSquare size={12} strokeWidth={2} /> Discuss
+        </button>
+        <button
+          type="button"
+          className="research-job-action research-job-action-report"
+          title="Visual report"
+          onClick={onToggle}
+        >
+          <ExternalLink size={11} strokeWidth={2} /> Visual Report
+        </button>
+        <button
+          type="button"
+          className="research-job-action research-job-action-dim"
+          title="Clear from list"
+          onClick={onDismiss}
+        >
+          <X size={12} strokeWidth={2.5} />
+        </button>
+        <button
+          type="button"
+          className="research-job-action research-job-action-dim"
+          title="Delete from disk"
+          disabled
+        >
+          <Trash2 size={12} strokeWidth={2} /> Delete
+        </button>
+      </div>
+      {expanded ? <ReportBody job={job} /> : null}
+    </>
+  );
+}
+
+function ErrorCard({
+  job,
+  onDismiss,
+}: {
+  job: ResearchJob;
+  onDismiss: () => void;
+}): ReactNode {
+  return (
+    <>
+      <div className="research-job-header">
+        <span className="research-job-query">{job.query}</span>
+        {job.category ? (
+          <span className="research-cat-badge">{job.category}</span>
+        ) : null}
+        <span className="research-job-status">{job.status}</span>
+      </div>
+      {job.errorMsg ? (
+        <div className="research-job-error">{job.errorMsg}</div>
+      ) : null}
+      <div className="research-job-actions">
+        <button
+          type="button"
+          className="research-job-action"
+          title="Retry"
+          disabled
+        >
+          <RotateCcw size={12} strokeWidth={2} /> Retry
+        </button>
+        <button
+          type="button"
+          className="research-job-action"
+          title="Edit and retry"
+          disabled
+        >
+          <Pencil size={12} strokeWidth={2} /> Edit
+        </button>
+        <button
+          type="button"
+          className="research-job-action research-job-action-dim"
+          title="Dismiss"
+          onClick={onDismiss}
+        >
+          <X size={12} strokeWidth={2.5} />
+        </button>
+      </div>
+    </>
+  );
+}
+
+function JobCard({
+  job,
+  expanded,
+  onToggleExpand,
+  onRemove,
+}: {
+  job: ResearchJob;
+  expanded: boolean;
+  onToggleExpand: () => void;
+  onRemove: () => void;
+}): ReactNode {
+  const failed = job.status === "done" && job.sourceCount === 0;
+  const classes = [
+    "research-job-card",
+    job.status,
+    job.fromLibrary ? "from-library" : "",
+    failed ? "research-job-failed" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <div className={classes} data-category={job.category || undefined}>
+      {job.status === "queued" ? (
+        <QueuedCard job={job} onRemove={onRemove} />
+      ) : null}
+      {job.status === "running" ? <RunningCard job={job} /> : null}
+      {job.status === "done" ? (
+        <DoneCard
+          job={job}
+          expanded={expanded}
+          onToggle={onToggleExpand}
+          onDismiss={onRemove}
+        />
+      ) : null}
+      {job.status === "error" || job.status === "cancelled" ? (
+        <ErrorCard job={job} onDismiss={onRemove} />
+      ) : null}
+    </div>
+  );
+}
+
+function JobSection({
+  sectionKey,
+  title,
+  jobs,
+  collapsed,
+  onToggleCollapsed,
+  onClearAll,
+  expandedId,
+  onToggleExpand,
+  onRemove,
+  onOpenLibrary,
+}: {
+  sectionKey: "active" | "past";
+  title: string;
+  jobs: ReadonlyArray<ResearchJob>;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+  onClearAll: () => void;
+  expandedId: string | null;
+  onToggleExpand: (id: string) => void;
+  onRemove: (id: string) => void;
+  onOpenLibrary: () => void;
+}): ReactNode {
+  if (jobs.length === 0) return null;
+  const failed =
+    sectionKey === "active" &&
+    jobs.some((j) => j.status === "error" || j.status === "cancelled");
+  const dotStyle =
+    sectionKey === "active"
+      ? failed
+        ? { background: "var(--red)" }
+        : { background: "var(--accent, var(--red))" }
+      : { background: "var(--ok)" };
+  const dotPulse = sectionKey === "active" && !failed;
+  return (
+    <div className={`research-section${collapsed ? " collapsed" : ""}`}>
+      <div className="research-section-header">
+        <button
+          type="button"
+          className="research-section-toggle"
+          onClick={onToggleCollapsed}
+          aria-expanded={!collapsed}
+        >
+          <span className="research-section-title">{title}</span>
+          <span className="research-section-count memory-count">
+            {jobs.length} research
+          </span>
+        </button>
+        <span className="research-section-right">
+          <button
+            type="button"
+            className="research-section-clear"
+            title="Clear all research"
+            onClick={onClearAll}
+          >
+            <X size={12} strokeWidth={2.5} /> Clear all
+          </button>
+          <span
+            className={`research-section-dot${dotPulse ? " pulsing" : ""}`}
+            style={dotStyle}
+          />
+          <ChevronDown
+            size={12}
+            strokeWidth={2.5}
+            className="research-section-chevron"
+          />
+        </span>
+      </div>
+      {sectionKey === "past" ? (
+        <div className="memory-desc research-library-hint">
+          All past research found in{" "}
+          <button
+            type="button"
+            className="research-library-link"
+            onClick={onOpenLibrary}
+          >
+            Library, Research
+          </button>
+        </div>
+      ) : null}
+      <div className="research-section-body">
+        {jobs.map((j) => (
+          <JobCard
+            key={j.id}
+            job={j}
+            expanded={expandedId === j.id}
+            onToggleExpand={() => onToggleExpand(j.id)}
+            onRemove={() => onRemove(j.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── main panel ─────────────────────────────────────────────────────
+
+export function ResearchView({
+  open,
+  onClose,
+  onOpenLibrary,
+}: {
+  open: boolean;
+  onClose: () => void;
+  // Opens the Library on its Research tab — mirrors odysseus's
+  // documentModule.openLibrary({ tab: 'research' }) that the "Library,
+  // Research" hint link triggers. Optional: the shell wires it; without it the
+  // link still does the faithful first half (closes the Research panel).
+  onOpenLibrary?: () => void;
+}): ReactNode {
+  useEscapeClose(open, onClose);
+  // odysseus opens the pane at width:min(640px,92vw); max-height:85vh, centered
+  // in the overlay. The default windowed height stays compact to match the
+  // un-populated modal proportions (the query card + collapsed jobs list); the
+  // user can drag-resize taller. Width 640 matches odysseus's min(640px,92vw).
+  const win = useWindowControls(
+    "win-research",
+    { w: 640, h: 620 },
+    { label: "Deep Research", icon: "FlaskConical", onClose },
+  );
+  const [jobs, setJobs] = useState<ReadonlyArray<ResearchJob>>([]);
+  const [draft, setDraft] = useState("");
+  const [activeCat, setActiveCat] = useState<ResearchCategory>("");
+  // odysseus panel.js initializes `_settingsCollapsed` from
+  // localStorage.getItem(_COLLAPSE_KEY) === '1', which is false on first open —
+  // so the Settings row (Rounds / Search engine / Endpoint / Model) renders
+  // EXPANDED by default and the toggle chevron points down. Mirror that here.
+  const [settingsOpen, setSettingsOpen] = useState(true);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState<{
+    active: boolean;
+    past: boolean;
+  }>({
+    active: false,
+    past: false,
+  });
+
+  // Deep Research has no elizaOS backend yet, so `jobs` stays empty and the
+  // panel renders its honest empty state. The full job / synapse-graph / report
+  // UI below is a pixel-exact clone that lights up once a research backend is
+  // wired — we never seed fabricated runs.
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  const active = jobs.filter(
+    (j) =>
+      j.status === "queued" ||
+      j.status === "running" ||
+      j.status === "error" ||
+      j.status === "cancelled",
+  );
+  const past = jobs.filter((j) => j.status === "done");
+  const total = past.length;
+
+  const removeJob = (id: string) => {
+    setJobs((prev) => prev.filter((j) => j.id !== id));
+    if (expandedId === id) setExpandedId(null);
+  };
+  const toggleExpand = (id: string) =>
+    setExpandedId((prev) => (prev === id ? null : id));
+
+  // panel.js _renderJobs: the "Library, Research" link closes the Research
+  // panel first (so the Library opens above it), then opens the Library on its
+  // Research tab. onOpenLibrary is the shell-supplied navigation; without it
+  // the link still performs the faithful close.
+  const openLibrary = () => {
+    onClose();
+    onOpenLibrary?.();
+  };
+
+  // panel.js: the Past section only renders when there are done jobs; when it
+  // doesn't, the "All past research found in Library, Research" line surfaces
+  // under the main title instead so the link is always discoverable.
+  const showNoPastHint = past.length === 0;
+
+  return (
+    <div
+      className={`od-search-overlay od-research-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Deep Research"
+    >
+      <button
+        type="button"
+        aria-label="Close research"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel research-pane" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        <div
+          className="research-pane-header od-window-header"
+          onPointerDown={win.onDragStart}
+        >
+          <h4>
+            <Search size={14} strokeWidth={2} />
+            <span>Deep Research</span>
+          </h4>
+          <div className="research-pane-header-actions">
+            <button
+              type="button"
+              className="od-window-min-btn"
+              onClick={win.minimize}
+              title="Minimize"
+              aria-label="Minimize"
+            >
+              <Minus size={14} aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              className="research-pane-close close-btn"
+              title="Close"
+              aria-label="Close research"
+              onClick={onClose}
+            >
+              <X size={14} strokeWidth={2.5} />
+            </button>
+          </div>
+        </div>
+        <div className="research-pane-body">
+          <div className="research-new-job">
+            <div className="research-new-job-title">
+              <h2>
+                Research{" "}
+                <span className="memory-count research-stats">
+                  {total} research
+                </span>
+              </h2>
+            </div>
+            <p className="memory-desc research-desc">
+              <FlaskConical size={14} strokeWidth={2} />
+              <span>Multi-step web research with an LLM-in-the-loop agent</span>
+            </p>
+            {showNoPastHint ? (
+              <div className="memory-desc research-no-past-hint">
+                All past research found in{" "}
+                <button
+                  type="button"
+                  className="research-library-link"
+                  onClick={openLibrary}
+                >
+                  Library, Research
+                </button>
+              </div>
+            ) : null}
+            <textarea
+              className="research-query"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Escape") onClose();
+              }}
+              placeholder="e.g. Trace Odysseus's ten-year journey home from Troy — every island, monster, and detour, and why each one cost him"
+              rows={4}
+              aria-label="Research query"
+            />
+            <div className="research-category-row">
+              {CATEGORY_CHIPS.map((c) => (
+                <button
+                  key={c.label}
+                  type="button"
+                  className={`research-cat${activeCat === c.cat ? " active" : ""}`}
+                  onClick={() => setActiveCat(c.cat)}
+                >
+                  {c.label}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              className={`research-settings-toggle${settingsOpen ? "" : " collapsed"}`}
+              onClick={() => setSettingsOpen((v) => !v)}
+              aria-expanded={settingsOpen}
+            >
+              Settings
+              <ChevronDown
+                size={10}
+                strokeWidth={2.5}
+                className="research-settings-chevron"
+              />
+            </button>
+            {settingsOpen ? (
+              <div className="research-settings-row">
+                <label className="research-setting">
+                  <span className="research-setting-label">Rounds</span>
+                  <select defaultValue="0" aria-label="Rounds">
+                    <option value="0">Auto</option>
+                    {Array.from({ length: 20 }, (_, i) => i + 1).map((n) => (
+                      <option key={n} value={n}>
+                        {n}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="research-setting">
+                  <span className="research-setting-label">Search engine</span>
+                  <select defaultValue="Default" aria-label="Search engine">
+                    {SEARCH_PROVIDERS.map((p) => (
+                      <option key={p} value={p}>
+                        {p}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="research-setting">
+                  <span className="research-setting-label">Endpoint</span>
+                  <select defaultValue="" aria-label="Endpoint">
+                    <option value="">Default</option>
+                  </select>
+                </label>
+                <label className="research-setting">
+                  <span className="research-setting-label">Model</span>
+                  <select defaultValue="" aria-label="Model">
+                    <option value="">Default</option>
+                  </select>
+                </label>
+              </div>
+            ) : null}
+            <div className="research-controls-row">
+              <button type="button" className="research-add-btn" disabled>
+                <span className="research-add-plus">+</span> Queue
+              </button>
+              <button type="button" className="research-start-btn" disabled>
+                <Play size={14} fill="currentColor" stroke="none" /> Start
+              </button>
+            </div>
+          </div>
+          {/* panel.js _renderJobs: with zero jobs the list body is simply
+              empty (the query box is the call to action; discoverability of
+              past research is the under-title hint). Each JobSection renders
+              null when its array is empty, so no centered empty-state text. */}
+          <div className="research-jobs-list">
+            <JobSection
+              sectionKey="active"
+              title="Active"
+              jobs={active}
+              collapsed={collapsed.active}
+              onToggleCollapsed={() =>
+                setCollapsed((c) => ({ ...c, active: !c.active }))
+              }
+              onClearAll={() => setJobs([])}
+              expandedId={expandedId}
+              onToggleExpand={toggleExpand}
+              onRemove={removeJob}
+              onOpenLibrary={openLibrary}
+            />
+            <JobSection
+              sectionKey="past"
+              title="Past research"
+              jobs={past}
+              collapsed={collapsed.past}
+              onToggleCollapsed={() =>
+                setCollapsed((c) => ({ ...c, past: !c.past }))
+              }
+              onClearAll={() => setJobs([])}
+              expandedId={expandedId}
+              onToggleExpand={toggleExpand}
+              onRemove={removeJob}
+              onOpenLibrary={openLibrary}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/ResizeHandles.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/ResizeHandles.tsx
@@ -1,0 +1,29 @@
+// The 8 edge/corner resize grips for a windowed odysseus tool view
+// (static/js/windowResize.js). Render inside the panel; each grip wires the
+// matching direction into the window controls. No-ops visually until the panel
+// is windowed, but harmless to always render.
+
+import type { ReactNode } from "react";
+import type { ResizeDir, WindowControls } from "./hooks/useWindowControls";
+
+const DIRS: ResizeDir[] = ["n", "s", "e", "w", "ne", "nw", "se", "sw"];
+
+export function ResizeHandles({
+  controls,
+}: {
+  controls: WindowControls;
+}): ReactNode {
+  if (!controls.windowed) return null;
+  return (
+    <>
+      {DIRS.map((dir) => (
+        <div
+          key={dir}
+          className={`od-rz-handle od-rz-${dir}`}
+          onPointerDown={controls.onResizeStart(dir)}
+          aria-hidden="true"
+        />
+      ))}
+    </>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/SearchPalette.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/SearchPalette.tsx
@@ -1,0 +1,269 @@
+// odysseus Ctrl+K search palette (static/js/search-chat.js). A centered command
+// palette that searches conversations by title/request via the existing
+// listCodingAgentTaskThreads({ search }) endpoint.
+//
+// Fidelity note vs. odysseus: search-chat.js queries /api/search?q= for
+// full-text MESSAGE hits and groups them by session, rendering one row per
+// matched message (role + snippet + time). The eliza client exposes no
+// message-search endpoint — only thread search (title + originalRequest). So
+// each result here is a whole conversation, not a per-message hit: we port the
+// row chrome (query highlight, snippet, relative timestamp) and the keyboard
+// navigation (ArrowUp/Down, Enter, selected scroll-into-view) faithfully, but
+// do not fabricate per-message grouping the backend cannot supply.
+
+import type { CodingAgentTaskThread } from "@elizaos/ui";
+import { client } from "@elizaos/ui";
+import {
+  Fragment,
+  type KeyboardEvent,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+
+/** Split `text` on `query` (case-insensitive) and wrap matches in a <mark>,
+ * mirroring odysseus highlightMatch (search-chat.js L43-L48). React escaping
+ * replaces the manual escapeHtml step. */
+function highlightMatch(text: string, query: string): ReactNode {
+  if (!query) return text;
+  const lowerText = text.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+  let matchAt = lowerText.indexOf(lowerQuery, cursor);
+  let key = 0;
+  while (matchAt !== -1) {
+    if (matchAt > cursor) {
+      parts.push(<Fragment key={key}>{text.slice(cursor, matchAt)}</Fragment>);
+      key += 1;
+    }
+    parts.push(
+      <mark key={key} className="od-search-highlight">
+        {text.slice(matchAt, matchAt + query.length)}
+      </mark>,
+    );
+    key += 1;
+    cursor = matchAt + query.length;
+    matchAt = lowerText.indexOf(lowerQuery, cursor);
+  }
+  if (cursor < text.length) {
+    parts.push(<Fragment key={key}>{text.slice(cursor)}</Fragment>);
+  }
+  return parts;
+}
+
+/** Relative timestamp: today → clock time, this week → weekday + time, else
+ * absolute date — odysseus formatTimestamp (search-chat.js L50-L62). */
+function formatTimestamp(
+  value: string | number | null,
+  locale?: string,
+): string {
+  if (value === null) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  const diff = Date.now() - date.getTime();
+  if (diff < 86_400_000) {
+    return date.toLocaleTimeString(locale, {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+  if (diff < 604_800_000) {
+    return date.toLocaleDateString(locale, {
+      weekday: "short",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }
+  return date.toLocaleDateString(locale, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+/** Single-line snippet for a conversation result: the original request if it
+ * adds detail beyond the title, else the summary. */
+function resultSnippet(thread: CodingAgentTaskThread): string {
+  const request = thread.originalRequest.trim();
+  if (request && request !== thread.title.trim()) return request;
+  return thread.summary?.trim() ?? "";
+}
+
+export function SearchPalette({
+  open,
+  onClose,
+  onSelect,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onSelect: (id: string) => void;
+}): ReactNode {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<CodingAgentTaskThread[]>([]);
+  const [error, setError] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setQuery("");
+      setSelectedIndex(-1);
+      setError(false);
+      inputRef.current?.focus();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const timer = window.setTimeout(() => {
+      void client
+        .listCodingAgentTaskThreads({
+          search: query.trim() || undefined,
+          includeArchived: true,
+          limit: 20,
+        })
+        .then((threads) => {
+          if (!cancelled) {
+            setResults(threads);
+            setSelectedIndex(-1);
+            setError(false);
+          }
+        })
+        .catch(() => {
+          // Surface a state rather than silently showing "no results" — a
+          // failed lookup is not the same as an empty one (the user can't
+          // otherwise tell whether the backend is unreachable).
+          if (!cancelled) {
+            setResults([]);
+            setError(true);
+          }
+        });
+    }, 120);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [open, query]);
+
+  // Keep the selected row scrolled into view as the selection moves —
+  // odysseus updateSelection (search-chat.js L118-L129).
+  useEffect(() => {
+    if (selectedIndex < 0) return;
+    const list = listRef.current;
+    if (!list) return;
+    const row =
+      list.querySelectorAll<HTMLElement>(".od-search-item")[selectedIndex];
+    row?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  if (!open) return null;
+
+  const openThread = (id: string): void => {
+    onSelect(id);
+    onClose();
+  };
+
+  // Arrow/Enter navigation over the result list — odysseus handleKeydown
+  // (search-chat.js L131-L153).
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === "Escape") {
+      onClose();
+      return;
+    }
+    if (results.length === 0) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.min(i + 1, results.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const target = results[selectedIndex] ?? results[0];
+      if (target) openThread(target.id);
+    }
+  };
+
+  const trimmedQuery = query.trim();
+
+  return (
+    <div
+      className="od-search-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Search conversations"
+    >
+      <button
+        type="button"
+        className="od-search-backdrop"
+        aria-label="Close search"
+        onClick={onClose}
+      />
+      <div className="od-search-panel">
+        <input
+          ref={inputRef}
+          className="od-search-input"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder="Search conversations…"
+          aria-label="Search conversations"
+        />
+        <div className="od-search-list" ref={listRef}>
+          {results.length === 0 ? (
+            <div
+              className={
+                error ? "od-search-empty od-search-error" : "od-search-empty"
+              }
+              role={error ? "alert" : undefined}
+            >
+              {error
+                ? "Search failed. Check your connection and try again."
+                : trimmedQuery
+                  ? "No results found"
+                  : "No conversations found."}
+            </div>
+          ) : (
+            results.map((thread, index) => {
+              const snippet = resultSnippet(thread);
+              const time = formatTimestamp(
+                thread.latestActivityAt ?? thread.updatedAt,
+              );
+              return (
+                <button
+                  type="button"
+                  key={thread.id}
+                  className={
+                    index === selectedIndex
+                      ? "od-search-item od-selected"
+                      : "od-search-item"
+                  }
+                  onClick={() => openThread(thread.id)}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                >
+                  <span className="od-search-item-body">
+                    <span className="od-search-item-title">
+                      {highlightMatch(thread.title, trimmedQuery)}
+                    </span>
+                    {snippet ? (
+                      <span className="od-search-item-snippet">
+                        {highlightMatch(snippet, trimmedQuery)}
+                      </span>
+                    ) : null}
+                  </span>
+                  {time ? (
+                    <span className="od-search-item-time">{time}</span>
+                  ) : null}
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/SessionSidebar.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/SessionSidebar.tsx
@@ -1,0 +1,1519 @@
+// odysseus left sidebar (static/index.html nav.sidebar). brand header (= new
+// chat), New Chat + Search actions, the Chats list mapped onto orchestrator
+// task threads with a hover ⋯ menu (Pin / Rename / Move to folder / Delete), a
+// bulk select-mode (checkbox + shift-range + bulk delete), collapsible FOLDERS,
+// a collapsible section + sort picker, keyboard navigation, and drag-reorder.
+//
+// elizaMapping: thread data is the REAL orchestrator task list (props.threads).
+// Pin / rename / delete are the existing host callbacks (onTogglePin / onRename
+// / onDelete) — unchanged contract. Eliza task threads have no server-side
+// folder field (unlike odysseus sessions, which PATCH /api/session with a
+// `folder`), so folder ASSIGNMENTS, per-folder COLLAPSE state, the manual sort
+// ORDER, the active SORT MODE, and the Chats-section COLLAPSE are persisted
+// client-side via util/storage — mirroring odysseus's loadFolderState /
+// section-collapsed / odysseus-session-sort / session-order while keeping the
+// real thread rows untouched. No fabricated thread data.
+//
+// Faithful-to-odysseus mappings of session affordances onto thread fields:
+//   • type icon  ← thread.kind (chat / agent / research / group / fork)
+//   • activity dot ← thread.status + thread.paused (processing / done / failed)
+//   • sort modes  ← sessions.js _sortMode (active / newest / group / manual)
+//   • drag handle ← dragSort.js (pointer reorder, persisted manual order)
+// The odysseus "Tidy" AI auto-sort is intentionally NOT ported: it needs a
+// server LLM endpoint the orchestrator does not expose (see deferred notes).
+
+import type { CodingAgentTaskThread } from "@elizaos/ui";
+import {
+  ArrowUpDown,
+  BookOpen,
+  Bot,
+  Boxes,
+  Brain,
+  CalendarDays,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Columns2,
+  FileText,
+  FlaskConical,
+  Folder,
+  FolderPlus,
+  GitFork,
+  GripVertical,
+  Images,
+  ListChecks,
+  Mail,
+  MessageSquare,
+  MessagesSquare,
+  Mic,
+  MoreHorizontal,
+  Palette,
+  PanelLeft,
+  Pencil,
+  Pin,
+  Plus,
+  Search,
+  SearchCode,
+  Settings,
+  ShieldAlert,
+  SlidersHorizontal,
+  Star,
+  StickyNote,
+  Trash2,
+  Users,
+  Wrench,
+  X,
+  Zap,
+} from "lucide-react";
+import {
+  type KeyboardEvent,
+  type MouseEvent,
+  type PointerEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { ToolId } from "./OdysseusShell";
+import { readPref, writePref } from "./util/storage";
+
+// localStorage keys (added to PREF_KEYS — see integrationNotes). thread→folder
+// assignment map, the collapse state per folder, the folder roster (so an empty
+// folder survives until explicitly deleted, matching odysseus where a folder
+// vanishes only when its last session leaves AND it is removed), the manual
+// drag order, the active sort mode, and the Chats-section collapse.
+const FOLDERS_KEY = "session-folders";
+const FOLDER_STATE_KEY = "session-folder-state";
+const FOLDER_ROSTER_KEY = "session-folder-roster";
+const SORT_MODE_KEY = "session-sort";
+const MANUAL_ORDER_KEY = "session-order";
+const SECTION_COLLAPSED_KEY = "session-section-collapsed";
+// Collapse state for the feature-navigation "Tools" section (odysseus
+// #tools-section is collapsible like #sessions-section).
+const TOOLS_COLLAPSED_KEY = "tools-section-collapsed";
+
+// Feature-navigation rows that live in the expanded sidebar (odysseus
+// #tools-section + #email-section + #models-section). icon/label/tool map onto
+// the host's openTool dispatcher; every tool id is a real existing view.
+// Brain→memory and Library→documents mirror odysseus's tool ids.
+const TOOL_ROWS: { tool: ToolId; label: string; Icon: typeof Brain }[] = [
+  { tool: "memory", label: "Brain", Icon: Brain },
+  { tool: "calendar", label: "Calendar", Icon: CalendarDays },
+  { tool: "compare", label: "Compare", Icon: Columns2 },
+  { tool: "cookbook", label: "Cookbook", Icon: BookOpen },
+  { tool: "research", label: "Deep Research", Icon: FlaskConical },
+  { tool: "gallery", label: "Gallery", Icon: Images },
+  { tool: "docs", label: "Library", Icon: FileText },
+  { tool: "notes", label: "Notes", Icon: StickyNote },
+  { tool: "tasks", label: "Tasks", Icon: ListChecks },
+  { tool: "theme", label: "Theme", Icon: Palette },
+];
+
+// Additional launchers present in this build but not in odysseus's stock Tools
+// list. Grouped into a "More" cluster so every rail launcher stays reachable
+// from the expanded sidebar.
+const MORE_ROWS: { tool: ToolId; label: string; Icon: typeof Brain }[] = [
+  { tool: "group", label: "Group Chat", Icon: MessagesSquare },
+  { tool: "editor", label: "Image Editor", Icon: Pencil },
+  { tool: "voice", label: "Voice", Icon: Mic },
+  { tool: "skills", label: "Skills", Icon: Zap },
+  { tool: "presets", label: "Presets", Icon: SlidersHorizontal },
+  { tool: "admin", label: "Admin", Icon: ShieldAlert },
+  { tool: "settings", label: "Settings", Icon: Settings },
+];
+
+// Sentinel folder name for the catch-all group rendered when real folders exist
+// (odysseus's "Unsorted" wrapper, keyed __unsorted__ in folder state).
+const UNFILED = "__unfiled__";
+
+// odysseus sessions.js _sortMode vocabulary. `null` (manual) is the default and
+// honours the user's drag order; the three explicit modes mirror the
+// #session-sort-dropdown options (index.html L715-L735).
+type SortMode = "active" | "newest" | "group" | null;
+const SORT_OPTIONS: { value: Exclude<SortMode, null>; label: string }[] = [
+  { value: "active", label: "Last Active" },
+  { value: "newest", label: "Newest First" },
+  { value: "group", label: "By Folder" },
+];
+
+type FolderAssignments = Record<string, string>;
+type FolderCollapse = Record<string, boolean>;
+
+// Activity-dot state derived from a thread's own status vocabulary, faithful to
+// odysseus's processing (.processing pulse) / done (.notify badge) semantics
+// (sessions.js L681-L696). Eliza thread statuses differ from session statuses,
+// so we map the orchestrator vocabulary directly rather than reuse STATUS_DOT.
+type ActivityState = "processing" | "done" | "failed" | null;
+function activityState(thread: CodingAgentTaskThread): ActivityState {
+  if (thread.paused) return null;
+  switch (thread.status) {
+    case "active":
+    case "validating":
+      return "processing";
+    case "done":
+      return "done";
+    case "failed":
+      return "failed";
+    default:
+      return null;
+  }
+}
+
+// Leading per-row type icon, varying by thread kind — mirrors odysseus's
+// session-icon block (sessions.js L268-L303). thread.kind is free-form on the
+// orchestrator, so we match the known kinds and fall back to the chat bubble.
+function TypeIcon({ kind }: { kind: string }): ReactNode {
+  const k = kind.toLowerCase();
+  if (k.includes("group"))
+    return <Users size={12} className="od-thread-type" />;
+  if (k.includes("fork"))
+    return <GitFork size={12} className="od-thread-type" />;
+  if (k.includes("research"))
+    return <SearchCode size={12} className="od-thread-type" />;
+  if (k.includes("agent")) return <Bot size={12} className="od-thread-type" />;
+  return <MessageSquare size={12} className="od-thread-type" />;
+}
+
+function ThreadRow({
+  thread,
+  active,
+  editing,
+  menuOpen,
+  pinned,
+  selectMode,
+  selected,
+  draggable,
+  dragging,
+  dropBefore,
+  folderNames,
+  currentFolder,
+  rowRef,
+  onSelect,
+  onToggleSelect,
+  onOpenMenu,
+  onCloseMenu,
+  onStartRename,
+  onCommitRename,
+  onCancelRename,
+  onDelete,
+  onTogglePin,
+  onMoveToFolder,
+  onNewFolderWith,
+  onRowKeyDown,
+  onDragHandleDown,
+}: {
+  thread: CodingAgentTaskThread;
+  active: boolean;
+  editing: boolean;
+  menuOpen: boolean;
+  pinned: boolean;
+  selectMode: boolean;
+  selected: boolean;
+  draggable: boolean;
+  dragging: boolean;
+  dropBefore: boolean;
+  folderNames: string[];
+  currentFolder: string | null;
+  rowRef: (el: HTMLButtonElement | null) => void;
+  onSelect: (e: MouseEvent) => void;
+  onToggleSelect: (e: MouseEvent) => void;
+  onOpenMenu: () => void;
+  onCloseMenu: () => void;
+  onStartRename: () => void;
+  onCommitRename: (title: string) => void;
+  onCancelRename: () => void;
+  onDelete: () => void;
+  onTogglePin: () => void;
+  onMoveToFolder: (folder: string | null) => void;
+  onNewFolderWith: () => void;
+  onRowKeyDown: (e: KeyboardEvent<HTMLButtonElement>) => void;
+  onDragHandleDown: (e: PointerEvent) => void;
+}): ReactNode {
+  const [draft, setDraft] = useState(thread.title);
+  const [folderSubOpen, setFolderSubOpen] = useState(false);
+  const renameRef = useRef<HTMLInputElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (editing) renameRef.current?.focus();
+  }, [editing]);
+  useEffect(() => {
+    if (!menuOpen) setFolderSubOpen(false);
+  }, [menuOpen]);
+
+  // Dismiss the ⋯ menu on an outside click or Escape (odysseus escMenuStack:
+  // outside-click + Escape both tear a transient menu down). The listeners are
+  // attached only while this row's menu is open and on the next tick so the
+  // opening click doesn't immediately close it.
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onDocPointer = (e: globalThis.PointerEvent) => {
+      const target = e.target;
+      if (target instanceof Node && menuRef.current?.contains(target)) return;
+      onCloseMenu();
+    };
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onCloseMenu();
+      }
+    };
+    const id = window.setTimeout(() => {
+      document.addEventListener("pointerdown", onDocPointer, true);
+    }, 0);
+    document.addEventListener("keydown", onKey, true);
+    return () => {
+      window.clearTimeout(id);
+      document.removeEventListener("pointerdown", onDocPointer, true);
+      document.removeEventListener("keydown", onKey, true);
+    };
+  }, [menuOpen, onCloseMenu]);
+
+  if (editing) {
+    const commit = () => {
+      const next = draft.trim();
+      if (next && next !== thread.title) onCommitRename(next);
+      else onCancelRename();
+    };
+    const onKey = (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") commit();
+      else if (e.key === "Escape") onCancelRename();
+    };
+    return (
+      <input
+        ref={renameRef}
+        className="od-thread-rename"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={onKey}
+        onBlur={commit}
+        aria-label="Rename conversation"
+      />
+    );
+  }
+
+  const activity = activityState(thread);
+
+  return (
+    <div
+      className={`od-thread-row${selected ? " od-row-selected" : ""}${dragging ? " od-dragging" : ""}${dropBefore ? " od-drop-before" : ""}`}
+    >
+      {selectMode ? (
+        <button
+          type="button"
+          className={`od-session-select-cb${selected ? " checked" : ""}`}
+          onClick={onToggleSelect}
+          aria-pressed={selected}
+          aria-label={
+            selected ? "Deselect conversation" : "Select conversation"
+          }
+          title="Select"
+        >
+          {selected ? "●" : "○"}
+        </button>
+      ) : draggable ? (
+        <span
+          className="od-thread-drag"
+          title="Drag to reorder"
+          aria-hidden="true"
+          onPointerDown={onDragHandleDown}
+        >
+          <GripVertical size={11} />
+        </span>
+      ) : null}
+      <button
+        type="button"
+        ref={rowRef}
+        className={`od-list-item od-thread-main${active ? " active" : ""}`}
+        onClick={selectMode ? onToggleSelect : onSelect}
+        onKeyDown={onRowKeyDown}
+        title={thread.title}
+        data-thread-id={thread.id}
+      >
+        <span className="od-thread-icon-wrap">
+          <TypeIcon kind={thread.kind} />
+          {activity ? (
+            <span
+              className={`od-thread-dot od-dot-${activity}`}
+              title={
+                activity === "processing"
+                  ? "Working"
+                  : activity === "done"
+                    ? "Completed"
+                    : "Failed"
+              }
+              aria-hidden="true"
+            />
+          ) : null}
+        </span>
+        {pinned ? (
+          <Star size={11} className="od-thread-pin-dot" fill="currentColor" />
+        ) : null}
+        <span className="od-grow">{thread.title}</span>
+      </button>
+      {selectMode ? null : (
+        <button
+          type="button"
+          className="od-thread-menu-btn"
+          onClick={onOpenMenu}
+          title="Conversation actions"
+          aria-label="Conversation actions"
+        >
+          <MoreHorizontal size={14} />
+        </button>
+      )}
+      {menuOpen && !selectMode ? (
+        <div className="od-thread-menu" ref={menuRef}>
+          <button type="button" onClick={onTogglePin}>
+            <Pin size={13} />
+            {pinned ? "Unpin" : "Pin"}
+          </button>
+          <button type="button" onClick={onStartRename}>
+            Rename
+          </button>
+          <div className="od-folder-submenu-wrap">
+            <button
+              type="button"
+              onClick={() => setFolderSubOpen((v) => !v)}
+              aria-expanded={folderSubOpen}
+            >
+              <Folder size={13} />
+              Move to folder
+            </button>
+            {folderSubOpen ? (
+              <div className="od-thread-submenu">
+                <button
+                  type="button"
+                  className={currentFolder === null ? " od-cur" : ""}
+                  onClick={() => onMoveToFolder(null)}
+                >
+                  (No folder)
+                </button>
+                {folderNames.map((name) => (
+                  <button
+                    type="button"
+                    key={name}
+                    className={name === currentFolder ? " od-cur" : ""}
+                    onClick={() => onMoveToFolder(name)}
+                  >
+                    {name}
+                  </button>
+                ))}
+                <button
+                  type="button"
+                  className="od-folder-new"
+                  onClick={onNewFolderWith}
+                >
+                  <Plus size={12} />
+                  New Folder
+                </button>
+              </div>
+            ) : null}
+          </div>
+          <button type="button" className="od-danger" onClick={onDelete}>
+            Delete
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function FolderHeader({
+  name,
+  label,
+  count,
+  collapsed,
+  deletable,
+  editing,
+  onToggle,
+  onStartRename,
+  onCommitRename,
+  onCancelRename,
+  onDelete,
+}: {
+  name: string;
+  label: string;
+  count: number;
+  collapsed: boolean;
+  deletable: boolean;
+  editing: boolean;
+  onToggle: () => void;
+  onStartRename: () => void;
+  onCommitRename: (next: string) => void;
+  onCancelRename: () => void;
+  onDelete: () => void;
+}): ReactNode {
+  const [draft, setDraft] = useState(label);
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (editing) {
+      setDraft(label);
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [editing, label]);
+
+  if (editing) {
+    const commit = () => {
+      const next = draft.trim();
+      if (next && next !== label) onCommitRename(next);
+      else onCancelRename();
+    };
+    return (
+      <input
+        ref={inputRef}
+        className="od-thread-rename od-folder-rename"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          else if (e.key === "Escape") onCancelRename();
+        }}
+        onBlur={commit}
+        aria-label="Rename folder"
+      />
+    );
+  }
+
+  return (
+    <div className="od-session-folder-header">
+      <button
+        type="button"
+        className="od-folder-toggle-main"
+        onClick={onToggle}
+        onDoubleClick={deletable ? onStartRename : undefined}
+        aria-expanded={!collapsed}
+      >
+        {collapsed ? (
+          <ChevronRight size={12} className="od-folder-toggle" />
+        ) : (
+          <ChevronDown size={12} className="od-folder-toggle" />
+        )}
+        <span className="od-folder-name">
+          {name === UNFILED ? "Unsorted" : name}
+        </span>
+        <span className="od-folder-count">({count})</span>
+      </button>
+      {deletable ? (
+        <button
+          type="button"
+          className="od-folder-delete-btn"
+          onClick={onDelete}
+          title="Delete folder (threads move to Unsorted)"
+          aria-label="Delete folder"
+        >
+          <X size={12} />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+export function SessionSidebar({
+  threads,
+  selectedId,
+  onSelect,
+  onNewChat,
+  onSearch,
+  onRename,
+  onDelete,
+  width,
+  onResizeStart,
+  pinnedIds,
+  onTogglePin,
+  onToggleSidebar,
+  onOpenTool,
+}: {
+  threads: CodingAgentTaskThread[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+  onNewChat: () => void;
+  onSearch: () => void;
+  onRename: (id: string, title: string) => void;
+  onDelete: (id: string) => void;
+  width: number;
+  onResizeStart: (e: PointerEvent) => void;
+  pinnedIds: string[];
+  onTogglePin: (id: string) => void;
+  // Collapse the sidebar back to the icon rail (odysseus #sidebar-toggle-btn).
+  onToggleSidebar: () => void;
+  // Open a feature view — the same panels the icon rail opens.
+  onOpenTool: (tool: ToolId) => void;
+}): ReactNode {
+  const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingFolder, setEditingFolder] = useState<string | null>(null);
+
+  // Client-side folder state (see header comment for why it isn't on the
+  // server). assignments: threadId → folderName. collapse: folderName → true
+  // when collapsed. roster: the ordered set of folder names that exist even
+  // when empty.
+  const [assignments, setAssignments] = useState<FolderAssignments>(() =>
+    readPref<FolderAssignments>(FOLDERS_KEY, {}),
+  );
+  const [collapse, setCollapse] = useState<FolderCollapse>(() =>
+    readPref<FolderCollapse>(FOLDER_STATE_KEY, {}),
+  );
+  const [roster, setRoster] = useState<string[]>(() =>
+    readPref<string[]>(FOLDER_ROSTER_KEY, []),
+  );
+
+  // Active sort mode (odysseus _sortMode / odysseus-session-sort). null = the
+  // user's manual drag order. Section collapse (odysseus section-collapsed) and
+  // the persisted manual drag order (odysseus session-order).
+  const [sortMode, setSortMode] = useState<SortMode>(() =>
+    readPref<SortMode>(SORT_MODE_KEY, null),
+  );
+  const [sortOpen, setSortOpen] = useState(false);
+  const [sectionCollapsed, setSectionCollapsed] = useState<boolean>(() =>
+    readPref<boolean>(SECTION_COLLAPSED_KEY, false),
+  );
+  // Tools-section collapse (odysseus #tools-section). Persisted client-side
+  // like the Chats-section collapse.
+  const [toolsCollapsed, setToolsCollapsed] = useState<boolean>(() =>
+    readPref<boolean>(TOOLS_COLLAPSED_KEY, false),
+  );
+  const [manualOrder, setManualOrder] = useState<string[]>(() =>
+    readPref<string[]>(MANUAL_ORDER_KEY, []),
+  );
+
+  // Bulk select mode (odysseus _selectMode). selectedIds + an anchor for
+  // shift-range selection. lastIndex tracks the click anchor in the flat
+  // visible order.
+  const [selectMode, setSelectMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [anchorIndex, setAnchorIndex] = useState<number | null>(null);
+  const [confirmingBulkDelete, setConfirmingBulkDelete] = useState(false);
+
+  // New-folder inline composer (replaces odysseus's styledPrompt). When set,
+  // the thread id to drop into the freshly-created folder, or "" for an empty
+  // top-level folder.
+  const [newFolderFor, setNewFolderFor] = useState<string | null>(null);
+  const [newFolderDraft, setNewFolderDraft] = useState("");
+  const newFolderRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (newFolderFor !== null) newFolderRef.current?.focus();
+  }, [newFolderFor]);
+
+  const persistAssignments = useCallback((next: FolderAssignments) => {
+    setAssignments(next);
+    writePref(FOLDERS_KEY, next);
+  }, []);
+  const persistCollapse = useCallback((next: FolderCollapse) => {
+    setCollapse(next);
+    writePref(FOLDER_STATE_KEY, next);
+  }, []);
+  const persistRoster = useCallback((next: string[]) => {
+    setRoster(next);
+    writePref(FOLDER_ROSTER_KEY, next);
+  }, []);
+  const persistSortMode = useCallback((next: SortMode) => {
+    setSortMode(next);
+    writePref(SORT_MODE_KEY, next);
+  }, []);
+  const persistManualOrder = useCallback((next: string[]) => {
+    setManualOrder(next);
+    writePref(MANUAL_ORDER_KEY, next);
+  }, []);
+  const toggleSection = useCallback(() => {
+    setSectionCollapsed((prev) => {
+      const next = !prev;
+      writePref(SECTION_COLLAPSED_KEY, next);
+      return next;
+    });
+  }, []);
+  const toggleTools = useCallback(() => {
+    setToolsCollapsed((prev) => {
+      const next = !prev;
+      writePref(TOOLS_COLLAPSED_KEY, next);
+      return next;
+    });
+  }, []);
+
+  // Valid thread ids — prune any stale assignment whose thread is gone so
+  // localStorage doesn't grow unbounded across the agent's lifetime.
+  const threadIds = useMemo(() => new Set(threads.map((t) => t.id)), [threads]);
+  useEffect(() => {
+    let changed = false;
+    const next: FolderAssignments = {};
+    for (const [id, folder] of Object.entries(assignments)) {
+      if (threadIds.has(id)) next[id] = folder;
+      else changed = true;
+    }
+    if (changed) persistAssignments(next);
+  }, [threadIds, assignments, persistAssignments]);
+
+  const pinned = useMemo(() => new Set(pinnedIds), [pinnedIds]);
+
+  // Base order: when in manual sort, honour the persisted drag order (unknown
+  // ids — freshly-created threads — append in server order); otherwise the
+  // server recency order. Pinned threads always float to the top (odysseus
+  // starred-first), preserving relative order. A stable partition keeps the
+  // list from reshuffling on every poll.
+  const ordered = useMemo(() => {
+    let base: CodingAgentTaskThread[];
+    if (sortMode === null && manualOrder.length > 0) {
+      const rank = new Map(manualOrder.map((id, i) => [id, i]));
+      base = [...threads].sort((a, b) => {
+        const ra = rank.get(a.id);
+        const rb = rank.get(b.id);
+        if (ra === undefined && rb === undefined) return 0;
+        if (ra === undefined) return 1;
+        if (rb === undefined) return -1;
+        return ra - rb;
+      });
+    } else if (sortMode === "newest") {
+      base = [...threads].sort((a, b) =>
+        b.createdAt.localeCompare(a.createdAt),
+      );
+    } else if (sortMode === "active") {
+      // "Last Active" — by latest activity, falling back to updatedAt for rows
+      // with no recorded activity yet (odysseus last_message_at → updated_at).
+      base = [...threads].sort((a, b) => {
+        const av = a.latestActivityAt ?? Date.parse(a.updatedAt);
+        const bv = b.latestActivityAt ?? Date.parse(b.updatedAt);
+        return bv - av;
+      });
+    } else {
+      base = threads;
+    }
+    return [
+      ...base.filter((t) => pinned.has(t.id)),
+      ...base.filter((t) => !pinned.has(t.id)),
+    ];
+  }, [threads, pinned, sortMode, manualOrder]);
+
+  // Folders render only in manual mode and the explicit "By Folder" mode
+  // (odysseus: folders shown for _sortMode null or 'group', flat otherwise).
+  const showFolders = sortMode === null || sortMode === "group";
+
+  // Folder names that should render: roster entries that still exist, plus any
+  // folder referenced by a live assignment but missing from the roster (e.g.
+  // hand-edited storage). Stable order = roster order, then discovered tail.
+  const folderNames = useMemo(() => {
+    const assigned = new Set(
+      Object.entries(assignments)
+        .filter(([id]) => threadIds.has(id))
+        .map(([, folder]) => folder),
+    );
+    const names: string[] = [];
+    for (const name of roster) if (!names.includes(name)) names.push(name);
+    for (const name of assigned) if (!names.includes(name)) names.push(name);
+    return names;
+  }, [roster, assignments, threadIds]);
+
+  // Group ordered threads by folder; everything else is unfiled.
+  const grouped = useMemo(() => {
+    const byFolder = new Map<string, CodingAgentTaskThread[]>();
+    for (const name of folderNames) byFolder.set(name, []);
+    const unfiled: CodingAgentTaskThread[] = [];
+    for (const t of ordered) {
+      const folder = assignments[t.id];
+      if (showFolders && folder && byFolder.has(folder)) {
+        const arr = byFolder.get(folder);
+        if (arr) arr.push(t);
+      } else {
+        unfiled.push(t);
+      }
+    }
+    return { byFolder, unfiled };
+  }, [ordered, folderNames, assignments, showFolders]);
+
+  // Flat visible order (for shift-range selection + keyboard nav + drag): when
+  // folders render, folders first (in roster order, only when expanded), then
+  // unfiled; otherwise the plain ordered list.
+  const flatOrder = useMemo(() => {
+    if (!showFolders) return ordered.map((t) => t.id);
+    const flat: string[] = [];
+    for (const name of folderNames) {
+      if (collapse[name]) continue;
+      for (const t of grouped.byFolder.get(name) ?? []) flat.push(t.id);
+    }
+    for (const t of grouped.unfiled) flat.push(t.id);
+    return flat;
+  }, [showFolders, ordered, folderNames, collapse, grouped]);
+
+  // Roving-focus refs for the session rows (odysseus _onSessionListKeydown
+  // moves focus + selects the next row). Keyed by thread id; the live set is
+  // rebuilt every render so stale rows drop out.
+  const rowRefs = useRef(new Map<string, HTMLButtonElement>());
+  const setRowRef = useCallback(
+    (id: string) => (el: HTMLButtonElement | null) => {
+      if (el) rowRefs.current.set(id, el);
+      else rowRefs.current.delete(id);
+    },
+    [],
+  );
+
+  const exitSelectMode = useCallback(() => {
+    setSelectMode(false);
+    setSelectedIds(new Set());
+    setAnchorIndex(null);
+    setConfirmingBulkDelete(false);
+  }, []);
+
+  // Escape exits select mode (odysseus parity). The sort dropdown handles its
+  // own Escape via the outside-click effect below.
+  useEffect(() => {
+    if (!selectMode) return;
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") exitSelectMode();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [selectMode, exitSelectMode]);
+
+  // Sort dropdown dismissal (outside-click + Escape), mirroring odysseus's
+  // escMenuStack-managed dropdowns.
+  const sortWrapRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!sortOpen) return;
+    const onDocPointer = (e: globalThis.PointerEvent) => {
+      const target = e.target;
+      if (target instanceof Node && sortWrapRef.current?.contains(target))
+        return;
+      setSortOpen(false);
+    };
+    const onKey = (e: globalThis.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setSortOpen(false);
+      }
+    };
+    const id = window.setTimeout(() => {
+      document.addEventListener("pointerdown", onDocPointer, true);
+    }, 0);
+    document.addEventListener("keydown", onKey, true);
+    return () => {
+      window.clearTimeout(id);
+      document.removeEventListener("pointerdown", onDocPointer, true);
+      document.removeEventListener("keydown", onKey, true);
+    };
+  }, [sortOpen]);
+
+  const toggleSelect = useCallback(
+    (id: string, shiftKey: boolean) => {
+      const idx = flatOrder.indexOf(id);
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (shiftKey && anchorIndex !== null && idx >= 0) {
+          const lo = Math.min(anchorIndex, idx);
+          const hi = Math.max(anchorIndex, idx);
+          for (let i = lo; i <= hi; i++) {
+            const tid = flatOrder[i];
+            if (tid) next.add(tid);
+          }
+        } else if (next.has(id)) {
+          next.delete(id);
+        } else {
+          next.add(id);
+        }
+        return next;
+      });
+      if (!shiftKey) setAnchorIndex(idx >= 0 ? idx : null);
+    },
+    [flatOrder, anchorIndex],
+  );
+
+  const selectAll = useCallback(() => {
+    if (selectedIds.size === flatOrder.length) setSelectedIds(new Set());
+    else setSelectedIds(new Set(flatOrder));
+  }, [selectedIds, flatOrder]);
+
+  const runBulkDelete = useCallback(() => {
+    // Pinned threads are protected from bulk delete, mirroring odysseus's
+    // "Unfavorite before deleting" guard for starred sessions.
+    for (const id of selectedIds) {
+      if (!pinned.has(id)) onDelete(id);
+    }
+    exitSelectMode();
+  }, [selectedIds, pinned, onDelete, exitSelectMode]);
+
+  // Keyboard navigation of the session list (odysseus _onSessionListKeydown):
+  // ArrowUp/Down move + select the adjacent row, Enter opens, Delete/Backspace
+  // deletes the focused row with the pinned guard. Roving focus follows.
+  const onRowKeyDown = useCallback(
+    (id: string) => (e: KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.preventDefault();
+        const idx = flatOrder.indexOf(id);
+        if (idx < 0) return;
+        const nextId =
+          e.key === "ArrowDown" ? flatOrder[idx + 1] : flatOrder[idx - 1];
+        if (!nextId) return;
+        rowRefs.current.get(nextId)?.focus();
+        onSelect(nextId);
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        onSelect(id);
+      } else if (e.key === "Delete" || e.key === "Backspace") {
+        e.preventDefault();
+        if (pinned.has(id)) return; // odysseus "Unfavorite before deleting"
+        const idx = flatOrder.indexOf(id);
+        const fallbackId = flatOrder[idx + 1] ?? flatOrder[idx - 1] ?? null;
+        onDelete(id);
+        if (fallbackId) rowRefs.current.get(fallbackId)?.focus();
+      }
+    },
+    [flatOrder, onSelect, onDelete, pinned],
+  );
+
+  // ── Drag reorder (odysseus dragSort.js). Pointer-based vertical reorder of
+  // the unfiled rows, persisted to the manual order; dragging snaps the list to
+  // manual sort (clears any active sort mode, like odysseus's Rearrange). Only
+  // unfiled rows reorder — in-folder ordering follows the folder's own list,
+  // and reordering inside a folder is not part of the eliza folder model. ──
+  const [dragId, setDragId] = useState<string | null>(null);
+  const [dropBeforeId, setDropBeforeId] = useState<string | null>(null);
+  const dragState = useRef<{
+    id: string;
+    pointerId: number;
+    order: string[];
+    rows: { id: string; mid: number }[];
+  } | null>(null);
+  // Detach for the in-flight drag's window listeners, so a drag interrupted by
+  // unmount (e.g. the dragged thread disappears on a poll) doesn't leak them.
+  const dragDetach = useRef<(() => void) | null>(null);
+  useEffect(() => {
+    return () => {
+      dragDetach.current?.();
+    };
+  }, []);
+
+  const beginDrag = useCallback(
+    (id: string) => (e: PointerEvent) => {
+      if (selectMode) return;
+      e.preventDefault();
+      e.stopPropagation();
+      // Drag operates on the unfiled list — the reorderable surface. Snapshot
+      // the current visible unfiled order so the drag is deterministic.
+      const order = grouped.unfiled.map((t) => t.id);
+      if (!order.includes(id)) return;
+      const rows: { id: string; mid: number }[] = [];
+      for (const tid of order) {
+        const el = rowRefs.current.get(tid);
+        if (el) {
+          const r = el.getBoundingClientRect();
+          rows.push({ id: tid, mid: r.top + r.height / 2 });
+        }
+      }
+      dragState.current = { id, pointerId: e.pointerId, order, rows };
+      setDragId(id);
+      const move = (ev: globalThis.PointerEvent) => {
+        const st = dragState.current;
+        if (!st || ev.pointerId !== st.pointerId) return;
+        let before: string | null = null;
+        for (const row of st.rows) {
+          if (row.id === st.id) continue;
+          if (ev.clientY < row.mid) {
+            before = row.id;
+            break;
+          }
+        }
+        setDropBeforeId(before === st.id ? null : before);
+      };
+      const detach = () => {
+        document.removeEventListener("pointermove", move);
+        document.removeEventListener("pointerup", up);
+        document.removeEventListener("pointercancel", up);
+        dragDetach.current = null;
+      };
+      const up = (ev: globalThis.PointerEvent) => {
+        const st = dragState.current;
+        detach();
+        dragState.current = null;
+        setDragId(null);
+        setDropBeforeId(null);
+        if (!st || ev.pointerId !== st.pointerId) return;
+        // Resolve the drop target from the last hovered row.
+        let before: string | null = null;
+        for (const row of st.rows) {
+          if (row.id === st.id) continue;
+          if (ev.clientY < row.mid) {
+            before = row.id;
+            break;
+          }
+        }
+        const next = st.order.filter((x) => x !== st.id);
+        const at = before ? next.indexOf(before) : next.length;
+        next.splice(at < 0 ? next.length : at, 0, st.id);
+        if (next.join(" ") === st.order.join(" ")) return;
+        // Persist the full manual order: dragged unfiled list + any other
+        // threads (folder-assigned / not currently visible) appended in their
+        // existing relative order, so the saved order stays total.
+        const seen = new Set(next);
+        const tail = ordered.map((t) => t.id).filter((x) => !seen.has(x));
+        persistManualOrder([...next, ...tail]);
+        if (sortMode !== null) persistSortMode(null);
+      };
+      document.addEventListener("pointermove", move);
+      document.addEventListener("pointerup", up);
+      document.addEventListener("pointercancel", up);
+      dragDetach.current = detach;
+    },
+    [
+      selectMode,
+      grouped,
+      ordered,
+      sortMode,
+      persistManualOrder,
+      persistSortMode,
+    ],
+  );
+
+  const moveToFolder = useCallback(
+    (threadId: string, folder: string | null) => {
+      const next = { ...assignments };
+      if (folder === null) delete next[threadId];
+      else next[threadId] = folder;
+      persistAssignments(next);
+      if (folder !== null && !roster.includes(folder)) {
+        persistRoster([...roster, folder]);
+      }
+      setMenuOpenId(null);
+    },
+    [assignments, persistAssignments, roster, persistRoster],
+  );
+
+  const toggleFolder = useCallback(
+    (name: string) => {
+      persistCollapse({ ...collapse, [name]: !collapse[name] });
+    },
+    [collapse, persistCollapse],
+  );
+
+  const renameFolder = useCallback(
+    (oldName: string, nextName: string) => {
+      const nextAssign: FolderAssignments = {};
+      for (const [id, folder] of Object.entries(assignments)) {
+        nextAssign[id] = folder === oldName ? nextName : folder;
+      }
+      persistAssignments(nextAssign);
+      persistRoster(roster.map((n) => (n === oldName ? nextName : n)));
+      if (collapse[oldName] !== undefined) {
+        const nextCollapse = { ...collapse };
+        nextCollapse[nextName] = nextCollapse[oldName];
+        delete nextCollapse[oldName];
+        persistCollapse(nextCollapse);
+      }
+      setEditingFolder(null);
+    },
+    [
+      assignments,
+      persistAssignments,
+      roster,
+      persistRoster,
+      collapse,
+      persistCollapse,
+    ],
+  );
+
+  // Delete a folder: threads inside fall back to Unsorted (we only drop the
+  // grouping; real thread data is never touched here).
+  const deleteFolder = useCallback(
+    (name: string) => {
+      const nextAssign: FolderAssignments = {};
+      for (const [id, folder] of Object.entries(assignments)) {
+        if (folder !== name) nextAssign[id] = folder;
+      }
+      persistAssignments(nextAssign);
+      persistRoster(roster.filter((n) => n !== name));
+      if (collapse[name] !== undefined) {
+        const nextCollapse = { ...collapse };
+        delete nextCollapse[name];
+        persistCollapse(nextCollapse);
+      }
+    },
+    [
+      assignments,
+      persistAssignments,
+      roster,
+      persistRoster,
+      collapse,
+      persistCollapse,
+    ],
+  );
+
+  const commitNewFolder = useCallback(() => {
+    const name = newFolderDraft.trim();
+    const target = newFolderFor;
+    setNewFolderFor(null);
+    setNewFolderDraft("");
+    if (!name) return;
+    if (!roster.includes(name)) persistRoster([...roster, name]);
+    if (target) {
+      persistAssignments({ ...assignments, [target]: name });
+      setMenuOpenId(null);
+    }
+    // Expand the new folder so the user sees the thread land there.
+    if (collapse[name]) persistCollapse({ ...collapse, [name]: false });
+  }, [
+    newFolderDraft,
+    newFolderFor,
+    roster,
+    persistRoster,
+    assignments,
+    persistAssignments,
+    collapse,
+    persistCollapse,
+  ]);
+
+  const renderThreadRow = (
+    thread: CodingAgentTaskThread,
+    canDrag: boolean,
+  ): ReactNode => (
+    <ThreadRow
+      key={thread.id}
+      thread={thread}
+      active={thread.id === selectedId}
+      editing={editingId === thread.id}
+      menuOpen={menuOpenId === thread.id}
+      pinned={pinned.has(thread.id)}
+      selectMode={selectMode}
+      selected={selectedIds.has(thread.id)}
+      draggable={canDrag && !pinned.has(thread.id)}
+      dragging={dragId === thread.id}
+      dropBefore={dropBeforeId === thread.id}
+      folderNames={folderNames}
+      currentFolder={assignments[thread.id] ?? null}
+      rowRef={setRowRef(thread.id)}
+      onTogglePin={() => {
+        setMenuOpenId(null);
+        onTogglePin(thread.id);
+      }}
+      onSelect={() => {
+        setMenuOpenId(null);
+        onSelect(thread.id);
+      }}
+      onToggleSelect={(e) => toggleSelect(thread.id, e.shiftKey)}
+      onOpenMenu={() =>
+        setMenuOpenId((prev) => (prev === thread.id ? null : thread.id))
+      }
+      onCloseMenu={() => setMenuOpenId(null)}
+      onStartRename={() => {
+        setEditingId(thread.id);
+        setMenuOpenId(null);
+      }}
+      onCommitRename={(title) => {
+        setEditingId(null);
+        onRename(thread.id, title);
+      }}
+      onCancelRename={() => setEditingId(null)}
+      onDelete={() => {
+        setMenuOpenId(null);
+        onDelete(thread.id);
+      }}
+      onMoveToFolder={(folder) => moveToFolder(thread.id, folder)}
+      onNewFolderWith={() => {
+        setNewFolderDraft("");
+        setNewFolderFor(thread.id);
+        setMenuOpenId(null);
+      }}
+      onRowKeyDown={onRowKeyDown(thread.id)}
+      onDragHandleDown={beginDrag(thread.id)}
+    />
+  );
+
+  const hasFolders = showFolders && folderNames.length > 0;
+  const selectableCount = flatOrder.length;
+  const protectedSelected = [...selectedIds].some((id) => pinned.has(id));
+  // Unfiled rows reorder by drag only in manual mode (sortMode null), matching
+  // odysseus, where Rearrange is only meaningful against the manual order.
+  const canDragUnfiled = sortMode === null && !selectMode;
+  const activeSortLabel =
+    SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? "Manual";
+
+  return (
+    <nav className="od-sidebar" aria-label="Sidebar" style={{ width }}>
+      <div className="od-sidebar-header">
+        <button
+          type="button"
+          className="od-sidebar-hamburger"
+          onClick={onToggleSidebar}
+          title="Toggle sidebar"
+          aria-label="Toggle sidebar"
+        >
+          <PanelLeft size={18} />
+        </button>
+        <button
+          type="button"
+          className="od-sidebar-brand-title"
+          onClick={onNewChat}
+          title="New chat"
+        >
+          Orchestrator
+        </button>
+      </div>
+      <div className="od-sidebar-inner">
+        <button type="button" className="od-list-item" onClick={onNewChat}>
+          <Plus size={15} />
+          <span className="od-grow">New Chat</span>
+        </button>
+        <button type="button" className="od-list-item" onClick={onSearch}>
+          <Search size={13} />
+          <span className="od-grow">Search</span>
+        </button>
+
+        {/* Email section (odysseus #email-section): a labeled header that opens
+            the inbox plus a compose (+) button that also opens Email. */}
+        <div className="od-section">
+          <div className="od-section-header-flex">
+            <button
+              type="button"
+              className="od-section-title od-section-title-btn"
+              onClick={() => onOpenTool("email")}
+              title="Open email inbox"
+            >
+              <Mail size={13} />
+              <span className="od-grow">Email</span>
+            </button>
+            <button
+              type="button"
+              className="od-list-item-plus-btn"
+              onClick={() => onOpenTool("email")}
+              title="Compose email"
+              aria-label="Compose email"
+            >
+              <Plus size={12} />
+              <span className="od-list-item-plus-label">new</span>
+            </button>
+          </div>
+        </div>
+
+        {/* Models section (odysseus #models-section): a labeled header row that
+            opens the model picker view. */}
+        <div className="od-section">
+          <div className="od-section-header-flex">
+            <button
+              type="button"
+              className="od-section-title od-section-title-btn"
+              onClick={() => onOpenTool("models")}
+              title="Models"
+            >
+              <Boxes size={13} />
+              <span className="od-grow">Models</span>
+            </button>
+          </div>
+        </div>
+
+        {/* Tools section (odysseus #tools-section): a collapsible wrench-headed
+            section whose rows each open one existing feature view. */}
+        <div className={`od-section${toolsCollapsed ? " od-collapsed" : ""}`}>
+          <div className="od-section-header-flex">
+            <button
+              type="button"
+              className="od-section-title od-section-toggle"
+              onClick={toggleTools}
+              aria-expanded={!toolsCollapsed}
+              title={toolsCollapsed ? "Expand Tools" : "Collapse Tools"}
+            >
+              {toolsCollapsed ? (
+                <ChevronRight size={12} className="od-section-chevron" />
+              ) : (
+                <ChevronDown size={12} className="od-section-chevron" />
+              )}
+              <Wrench size={12} />
+              Tools
+            </button>
+          </div>
+          <div className="od-section-body">
+            {TOOL_ROWS.map(({ tool, label, Icon }) => (
+              <button
+                type="button"
+                key={tool}
+                className="od-list-item"
+                onClick={() => onOpenTool(tool)}
+                title={label}
+              >
+                <Icon size={14} className="od-tool-icon" />
+                <span className="od-grow">{label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* More cluster: launchers present in this build beyond odysseus's stock
+            Tools list, so every icon-rail action is reachable when expanded. */}
+        <div className="od-section">
+          <div className="od-section-header-flex">
+            <span className="od-section-title">More</span>
+          </div>
+          <div className="od-section-body">
+            {MORE_ROWS.map(({ tool, label, Icon }) => (
+              <button
+                type="button"
+                key={tool}
+                className="od-list-item"
+                onClick={() => onOpenTool(tool)}
+                title={label}
+              >
+                <Icon size={14} className="od-tool-icon" />
+                <span className="od-grow">{label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className={`od-section${sectionCollapsed ? " od-collapsed" : ""}`}>
+          <div className="od-section-header-flex">
+            <button
+              type="button"
+              className="od-section-title od-section-toggle"
+              onClick={toggleSection}
+              aria-expanded={!sectionCollapsed}
+              title={sectionCollapsed ? "Expand Chats" : "Collapse Chats"}
+            >
+              {sectionCollapsed ? (
+                <ChevronRight size={12} className="od-section-chevron" />
+              ) : (
+                <ChevronDown size={12} className="od-section-chevron" />
+              )}
+              <MessageSquare size={13} />
+              Chats
+            </button>
+            <div className="od-sort-wrap" ref={sortWrapRef}>
+              <button
+                type="button"
+                className={`od-section-icon-btn${sortMode !== null ? " active" : ""}`}
+                title={`Sort: ${activeSortLabel}`}
+                aria-label="Sort conversations"
+                aria-expanded={sortOpen}
+                onClick={() => setSortOpen((v) => !v)}
+              >
+                <ArrowUpDown size={13} />
+              </button>
+              {sortOpen ? (
+                <div className="od-sort-dropdown" role="menu">
+                  {SORT_OPTIONS.map((opt) => (
+                    <button
+                      type="button"
+                      key={opt.value}
+                      role="menuitemradio"
+                      aria-checked={sortMode === opt.value}
+                      className={`od-sort-option${sortMode === opt.value ? " od-cur" : ""}`}
+                      onClick={() => {
+                        // Toggle off → revert to manual (odysseus parity).
+                        persistSortMode(
+                          sortMode === opt.value ? null : opt.value,
+                        );
+                        setSortOpen(false);
+                      }}
+                    >
+                      {sortMode === opt.value ? (
+                        <Check size={12} />
+                      ) : (
+                        <span className="od-sort-check-spacer" />
+                      )}
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              className="od-section-icon-btn"
+              title="New folder"
+              aria-label="New folder"
+              onClick={() => {
+                setNewFolderDraft("");
+                setNewFolderFor("");
+              }}
+            >
+              <FolderPlus size={13} />
+            </button>
+            <button
+              type="button"
+              className={`od-section-icon-btn${selectMode ? " active" : ""}`}
+              title={selectMode ? "Exit select mode" : "Select multiple"}
+              aria-label={selectMode ? "Exit select mode" : "Select multiple"}
+              aria-pressed={selectMode}
+              onClick={() => {
+                if (selectMode) exitSelectMode();
+                else {
+                  setSelectMode(true);
+                  setMenuOpenId(null);
+                }
+              }}
+            >
+              <Check size={13} />
+            </button>
+          </div>
+
+          <div className="od-section-body">
+            {selectMode ? (
+              <div className="od-session-bulk-bar">
+                <button
+                  type="button"
+                  className="od-session-bulk-cb"
+                  onClick={selectAll}
+                  aria-label="Select all"
+                  title="Select all"
+                >
+                  {selectedIds.size > 0 && selectedIds.size === selectableCount
+                    ? "●"
+                    : "○"}
+                </button>
+                <span className="od-session-bulk-count">
+                  {selectedIds.size} selected
+                </span>
+                {confirmingBulkDelete ? (
+                  <>
+                    <button
+                      type="button"
+                      className="od-session-bulk-btn od-danger"
+                      onClick={runBulkDelete}
+                    >
+                      Confirm
+                    </button>
+                    <button
+                      type="button"
+                      className="od-session-bulk-btn"
+                      onClick={() => setConfirmingBulkDelete(false)}
+                    >
+                      Cancel
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    className="od-session-bulk-btn od-danger"
+                    disabled={selectedIds.size === 0}
+                    onClick={() => setConfirmingBulkDelete(true)}
+                    title={
+                      protectedSelected
+                        ? "Pinned conversations are skipped"
+                        : "Delete selected"
+                    }
+                  >
+                    <Trash2 size={13} />
+                    Delete
+                  </button>
+                )}
+                <button
+                  type="button"
+                  className="od-session-bulk-btn"
+                  onClick={exitSelectMode}
+                  aria-label="Close select mode"
+                  title="Done"
+                >
+                  <X size={13} />
+                </button>
+              </div>
+            ) : null}
+
+            {/* New-folder inline composer (odysseus styledPrompt replacement) */}
+            {newFolderFor !== null ? (
+              <input
+                ref={newFolderRef}
+                className="od-thread-rename od-folder-rename"
+                value={newFolderDraft}
+                placeholder="Folder name…"
+                onChange={(e) => setNewFolderDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") commitNewFolder();
+                  else if (e.key === "Escape") {
+                    setNewFolderFor(null);
+                    setNewFolderDraft("");
+                  }
+                }}
+                onBlur={commitNewFolder}
+                aria-label="New folder name"
+              />
+            ) : null}
+
+            {/* Folders first, then unfiled (odysseus group/manual mode). */}
+            {hasFolders
+              ? folderNames.map((name) => {
+                  const items = grouped.byFolder.get(name) ?? [];
+                  const collapsed = Boolean(collapse[name]);
+                  return (
+                    <div className="od-session-folder" key={name}>
+                      <FolderHeader
+                        name={name}
+                        label={name}
+                        count={items.length}
+                        collapsed={collapsed}
+                        deletable={true}
+                        editing={editingFolder === name}
+                        onToggle={() => toggleFolder(name)}
+                        onStartRename={() => setEditingFolder(name)}
+                        onCommitRename={(next) => renameFolder(name, next)}
+                        onCancelRename={() => setEditingFolder(null)}
+                        onDelete={() => deleteFolder(name)}
+                      />
+                      {collapsed ? null : (
+                        <div className="od-session-folder-content">
+                          {items.length === 0 ? (
+                            <div className="od-folder-empty">Empty</div>
+                          ) : (
+                            items.map((t) => renderThreadRow(t, false))
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })
+              : null}
+
+            {hasFolders && grouped.unfiled.length > 0 ? (
+              <div className="od-session-folder">
+                <FolderHeader
+                  name={UNFILED}
+                  label="Unsorted"
+                  count={grouped.unfiled.length}
+                  collapsed={Boolean(collapse[UNFILED])}
+                  deletable={false}
+                  editing={false}
+                  onToggle={() => toggleFolder(UNFILED)}
+                  onStartRename={() => undefined}
+                  onCommitRename={() => undefined}
+                  onCancelRename={() => undefined}
+                  onDelete={() => undefined}
+                />
+                {collapse[UNFILED] ? null : (
+                  <div className="od-session-folder-content">
+                    {grouped.unfiled.map((t) =>
+                      renderThreadRow(t, canDragUnfiled),
+                    )}
+                  </div>
+                )}
+              </div>
+            ) : (
+              grouped.unfiled.map((t) => renderThreadRow(t, canDragUnfiled))
+            )}
+
+            {threads.length === 0 ? (
+              <div className="od-folder-empty od-chats-empty">
+                No conversations yet
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+      <div className="od-sidebar-user-bar">
+        <div className="od-user-left">
+          <div className="od-user-avatar">U</div>
+          <span className="od-user-name">User</span>
+        </div>
+        <button
+          type="button"
+          className="od-user-btn"
+          title="Settings"
+          aria-label="Settings"
+          onClick={() => onOpenTool("settings")}
+        >
+          <Settings size={16} />
+        </button>
+      </div>
+      <button
+        type="button"
+        className="od-sidebar-resize-handle"
+        onPointerDown={onResizeStart}
+        aria-label={`Resize sidebar (${width}px)`}
+      />
+    </nav>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/SettingsPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/SettingsPanel.tsx
@@ -1,0 +1,2559 @@
+// odysseus Settings panel (static/js/settings.js + admin.js + search.js, the
+// #settings-modal markup in static/index.html lines ~1300-2220, and the
+// settings-* / admin-* rules in style.css). A tabbed modal surface whose left
+// nav-rail is grouped into four sections separated by dividers, plus an
+// admin-only "Admin" section:
+//   • AI plumbing — Add Models (services) / AI Defaults (ai) / Search (search)
+//   • Comms       — Integrations / Email / Reminders
+//   • UX          — Appearance / Shortcuts
+//   • Account     — Account
+//   • ADMIN       — Agent Tools (tools) / Users / System
+// (Issue #208: a centered window whose content height differs per tab jumps up
+// and down between tab switches, so the panel is fixed-height and the overlay
+// anchors to flex-start so the rail and window never shift between tabs.)
+//
+// odysseus has NO separate Admin window — Admin lives inside this Settings
+// modal as the admin-only trio, so the clone's standalone AdminView content is
+// folded in here (Users / Agent Tools / System).
+//
+// elizaMapping — real eliza wiring where the @elizaos/ui `client` exposes it,
+// honest disabled/empty chrome where it does NOT (grepped the singleton; the
+// only relevant methods are getMcpStatus / getPlugins / getCharacter /
+// updateCharacter / fetchModels — there is no endpoints / users / auth /
+// backup / search-config / reminders / integrations API, so tsgo would fail on
+// any invented call):
+//   • Add Models (services) — the endpoint add/list machinery is odysseus's
+//     /api/admin/endpoints surface, absent from eliza's client. The full
+//     collapsible Local/API add forms + Added Models lists are rendered
+//     pixel-faithful but inert/disabled with an honest note; the Added Models
+//     lists surface the REAL installed model-provider plugins
+//     (client.getPlugins, category "ai-provider") as the closest live mapping,
+//     and fall back to odysseus's "None" empty state.
+//   • AI Defaults (ai) — odysseus's per-endpoint model map (default / utility /
+//     vision / research / agent) is owned by the eliza runtime, which exposes
+//     no per-endpoint editor. The cards render faithful but disabled, with the
+//     real provider plugins shown read-only and an honest note.
+//   • Search (search) — odysseus's search-provider / result-count / key fields
+//     are its /api/auth/settings surface (not exposed). They persist locally
+//     via readPref/writePref under SEARCH_SETTINGS_KEY with an honest note,
+//     matching the CompareView COMPARE_VOTES_KEY precedent.
+//   • Integrations / Email / Reminders / Account — odysseus's unified-accounts,
+//     email-account, reminder-channel, and auth/account surfaces have no eliza
+//     client method. Full chrome, honest disabled/empty states; Account shows
+//     the real agent name from client.getCharacter().
+//   • Appearance — odysseus's appearance panel is a pure-frontend UI VISIBILITY
+//     editor (per-element show/hide switches grouped Sidebar / Chat Area, plus
+//     Reset All), persisted in localStorage under UI_VIS_KEY and broadcast via
+//     OdysseusUiVisEvent so the shell can hide/show the matching elements. The
+//     live theme/font/density prefs stay owned by the shell's Theme rail (a
+//     read-only summary here).
+//   • Shortcuts — odysseus's keyboard-shortcuts panel is client-side; we port
+//     the rebindable list, persisted locally under KEYBINDS_KEY and broadcast
+//     via OdysseusKeybindEvent for the shell's global key handler.
+//   • Admin (tools / users / system) — odysseus's admin sub-tabs are backed by
+//     a multi-user auth server (/api/auth/users, /api/admin/wipe, /api/export,
+//     …) that eliza does not run. Full chrome, every control disabled with an
+//     honest reason; the Users "Allowed models" list is populated from the REAL
+//     client.fetchModels(provider) — the same /api/models fetch CompareView +
+//     GalleryView use — so it lights up with the agent's real providers.
+
+import type {
+  McpServerStatus,
+  PluginInfo,
+  ProviderModelRecord,
+} from "@elizaos/ui";
+import { client } from "@elizaos/ui";
+import { Minus } from "lucide-react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+import { PREF_KEYS, readPref, writePref } from "./util/storage";
+
+// localStorage key for the locally-persisted web-search preference. The web
+// search provider / result-count / key fields are odysseus's /api/auth/settings
+// surface, which eliza's client does NOT expose — so this view owns its own
+// (non-shared) pref rather than adding to the shared PREF_KEYS table, matching
+// the CompareView precedent (COMPARE_VOTES_KEY). If a future eliza search-config
+// endpoint lands, promote this to PREF_KEYS.searchSettings (see integrationNotes).
+const SEARCH_SETTINGS_KEY = "search-settings";
+
+// odysseus settings-sidebar tabs (index.html data-settings-tab values), 1:1.
+type SettingsTab =
+  | "services"
+  | "ai"
+  | "search"
+  | "integrations"
+  | "email"
+  | "reminders"
+  | "appearance"
+  | "shortcuts"
+  | "account"
+  | "tools"
+  | "users"
+  | "system";
+
+// A leading 15x15 icon path-set per rail item (lucide-style, path data copied
+// from index.html lines 1316-1371). Rendered inline so the rail matches
+// odysseus's icon+label nav items exactly.
+interface RailItem {
+  id: SettingsTab;
+  label: string;
+  icon: ReactNode;
+  admin?: boolean;
+}
+
+// Dividers + the admin section header are positioned by the section the item
+// closes (odysseus groups: …Search ⸺ …Reminders ⸺ Shortcuts ⸺ Account ⸺ ADMIN).
+const DIVIDER_AFTER: ReadonlySet<SettingsTab> = new Set([
+  "search",
+  "reminders",
+  "shortcuts",
+  "account",
+]);
+
+function railSvg(children: ReactNode): ReactNode {
+  return (
+    <svg
+      width="15"
+      height="15"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  );
+}
+
+const RAIL: readonly RailItem[] = [
+  {
+    id: "services",
+    label: "Add Models",
+    icon: railSvg(
+      <>
+        <rect x="2" y="2" width="20" height="8" rx="2" />
+        <rect x="2" y="14" width="20" height="8" rx="2" />
+        <circle cx="6" cy="6" r="1" />
+        <circle cx="6" cy="18" r="1" />
+      </>,
+    ),
+  },
+  {
+    id: "ai",
+    label: "AI Defaults",
+    icon: railSvg(
+      <path d="M12 2a4 4 0 0 0-4 4v2H6a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V10a2 2 0 0 0-2-2h-2V6a4 4 0 0 0-4-4z" />,
+    ),
+  },
+  {
+    id: "search",
+    label: "Search",
+    icon: railSvg(
+      <>
+        <circle cx="11" cy="11" r="8" />
+        <line x1="21" y1="21" x2="16.65" y2="16.65" />
+      </>,
+    ),
+  },
+  {
+    id: "integrations",
+    label: "Integrations",
+    icon: railSvg(
+      <>
+        <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+        <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+      </>,
+    ),
+  },
+  {
+    id: "email",
+    label: "Email",
+    icon: railSvg(
+      <>
+        <rect x="2" y="4" width="20" height="16" rx="2" />
+        <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+      </>,
+    ),
+  },
+  {
+    id: "reminders",
+    label: "Reminders",
+    icon: railSvg(
+      <>
+        <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+        <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+      </>,
+    ),
+  },
+  {
+    id: "appearance",
+    label: "Appearance",
+    icon: railSvg(
+      <>
+        <circle cx="12" cy="12" r="10" />
+        <path d="M12 2a7 7 0 0 0 0 20 4 4 0 0 1 0-8 4 4 0 0 0 0-8" />
+      </>,
+    ),
+  },
+  {
+    id: "shortcuts",
+    label: "Shortcuts",
+    icon: railSvg(
+      <>
+        <rect x="2" y="4" width="20" height="16" rx="2" />
+        <path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M8 12h.01M12 12h.01M16 12h.01M7 16h10" />
+      </>,
+    ),
+  },
+  {
+    id: "account",
+    label: "Account",
+    icon: railSvg(
+      <>
+        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+        <circle cx="12" cy="7" r="4" />
+      </>,
+    ),
+  },
+  {
+    id: "tools",
+    label: "Agent Tools",
+    admin: true,
+    icon: railSvg(
+      <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />,
+    ),
+  },
+  {
+    id: "users",
+    label: "Users",
+    admin: true,
+    icon: railSvg(
+      <>
+        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+        <circle cx="9" cy="7" r="4" />
+        <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+        <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+      </>,
+    ),
+  },
+  {
+    id: "system",
+    label: "System",
+    admin: true,
+    icon: railSvg(
+      <>
+        <circle cx="12" cy="12" r="3" />
+        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+      </>,
+    ),
+  },
+];
+
+// ── 14x14 card-title icons (admin-card h2 leading svg, opacity 0.6). ──
+function cardSvg(children: ReactNode): ReactNode {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  );
+}
+
+const ICON_SERVER = cardSvg(
+  <>
+    <rect x="2" y="2" width="20" height="8" rx="2" />
+    <rect x="2" y="14" width="20" height="8" rx="2" />
+    <circle cx="6" cy="6" r="1" />
+    <circle cx="6" cy="18" r="1" />
+  </>,
+);
+const ICON_DEVICE = cardSvg(
+  <>
+    <rect x="2" y="3" width="20" height="14" rx="2" />
+    <line x1="8" y1="21" x2="16" y2="21" />
+    <line x1="12" y1="17" x2="12" y2="21" />
+  </>,
+);
+const ICON_GLOBE = cardSvg(
+  <>
+    <circle cx="12" cy="12" r="10" />
+    <line x1="2" y1="12" x2="22" y2="12" />
+    <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+  </>,
+);
+const ICON_CHAT = cardSvg(
+  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />,
+);
+const ICON_WRENCH = cardSvg(
+  <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />,
+);
+const ICON_EYE = cardSvg(
+  <>
+    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+    <circle cx="12" cy="12" r="3" />
+  </>,
+);
+const ICON_RESEARCH = cardSvg(
+  <>
+    <circle cx="11" cy="11" r="8" />
+    <path d="M21 21l-4.35-4.35" />
+    <line x1="11" y1="8" x2="11" y2="14" />
+    <line x1="8" y1="11" x2="14" y2="11" />
+  </>,
+);
+const ICON_SEARCH = cardSvg(
+  <>
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </>,
+);
+const ICON_LINK = cardSvg(
+  <>
+    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+  </>,
+);
+const ICON_ENVELOPE = cardSvg(
+  <>
+    <rect x="2" y="4" width="20" height="16" rx="2" />
+    <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+  </>,
+);
+const ICON_PEN = cardSvg(
+  <>
+    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+  </>,
+);
+const ICON_BELL = cardSvg(
+  <>
+    <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+    <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+  </>,
+);
+const ICON_CHECK = cardSvg(
+  <>
+    <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+    <polyline points="22 4 12 14.01 9 11.01" />
+  </>,
+);
+const ICON_USER = cardSvg(
+  <>
+    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+    <circle cx="12" cy="7" r="4" />
+  </>,
+);
+const ICON_USERPLUS = cardSvg(
+  <>
+    <path d="M16 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+    <circle cx="8.5" cy="7" r="4" />
+    <line x1="20" y1="8" x2="20" y2="14" />
+    <line x1="23" y1="11" x2="17" y2="11" />
+  </>,
+);
+const ICON_USERS = cardSvg(
+  <>
+    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+    <circle cx="9" cy="7" r="4" />
+    <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+    <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+  </>,
+);
+const ICON_LOCK = cardSvg(
+  <>
+    <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+  </>,
+);
+const ICON_LOCK2FA = cardSvg(
+  <>
+    <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    <circle cx="12" cy="16" r="1" />
+  </>,
+);
+const ICON_DATABASE = cardSvg(
+  <>
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+    <polyline points="17 8 12 3 7 8" />
+    <line x1="12" y1="3" x2="12" y2="15" />
+  </>,
+);
+const ICON_CAL = cardSvg(
+  <>
+    <rect x="3" y="4" width="18" height="18" rx="2" />
+    <line x1="16" y1="2" x2="16" y2="6" />
+    <line x1="8" y1="2" x2="8" y2="6" />
+    <line x1="3" y1="10" x2="21" y2="10" />
+    <path d="M9 16l2 2 4-4" />
+  </>,
+);
+
+// ── Web-search providers (search.js _labels + settings.js _searchProviderHints
+// / _searchNeedsKey / _searchKeyFields), 1:1 from upstream. ──
+type SearchProvider =
+  | "searxng"
+  | "duckduckgo"
+  | "brave"
+  | "google_pse"
+  | "tavily"
+  | "serper"
+  | "disabled";
+
+interface SearchProviderMeta {
+  id: SearchProvider;
+  label: string;
+  hint: string;
+  needsKey: boolean;
+}
+
+const SEARCH_PROVIDERS: readonly SearchProviderMeta[] = [
+  {
+    id: "searxng",
+    label: "SearXNG",
+    hint: "Self-hosted SearXNG instance. Leave URL empty to use the SEARXNG_INSTANCE env var.",
+    needsKey: false,
+  },
+  {
+    id: "duckduckgo",
+    label: "DuckDuckGo",
+    hint: "Free search — no API key required. Works out of the box.",
+    needsKey: false,
+  },
+  {
+    id: "brave",
+    label: "Brave Search",
+    hint: "Get your API key from brave.com/search/api",
+    needsKey: true,
+  },
+  {
+    id: "google_pse",
+    label: "Google PSE",
+    hint: "Requires a Google API key and a Programmable Search Engine ID (CX). Create one at programmablesearchengine.google.com",
+    needsKey: true,
+  },
+  {
+    id: "tavily",
+    label: "Tavily",
+    hint: "AI-optimized search. 1,000 free credits/month at tavily.com",
+    needsKey: true,
+  },
+  {
+    id: "serper",
+    label: "Serper",
+    hint: "Google results via API. 2,500 free queries at serper.dev",
+    needsKey: true,
+  },
+  {
+    id: "disabled",
+    label: "Disabled",
+    hint: "Web search and deep research tools will be unavailable.",
+    needsKey: false,
+  },
+];
+
+// Result-count presets (settings.js updateCountDisplay), plus "custom".
+const RESULT_COUNT_PRESETS: readonly number[] = [3, 5, 10, 20];
+
+function isPresetCount(n: number): boolean {
+  return RESULT_COUNT_PRESETS.includes(n);
+}
+
+// Locally-persisted web-search preference (odysseus search_* settings shape,
+// trimmed to what this surface edits). Persisted via SEARCH_SETTINGS_KEY until
+// eliza exposes a search-config client method.
+interface SearchSettings {
+  provider: SearchProvider;
+  resultCount: number;
+  searxngUrl: string;
+  apiKey: string;
+  googlePseCx: string;
+}
+
+const DEFAULT_SEARCH_SETTINGS: SearchSettings = {
+  provider: "searxng",
+  resultCount: 5,
+  searxngUrl: "",
+  apiKey: "",
+  googlePseCx: "",
+};
+
+function providerMeta(id: SearchProvider): SearchProviderMeta {
+  const found = SEARCH_PROVIDERS.find((p) => p.id === id);
+  return found ?? SEARCH_PROVIDERS[0];
+}
+
+// Narrow the <select>'s string value to a known SearchProvider without a cast:
+// look it up in the provider table (the only source of <option> values), so an
+// unknown value falls back to the first provider instead of asserting a type.
+function toSearchProvider(value: string): SearchProvider {
+  const found = SEARCH_PROVIDERS.find((p) => p.id === value);
+  return found ? found.id : SEARCH_PROVIDERS[0].id;
+}
+
+// ── Appearance: UI-visibility editor (odysseus initAppearance / applyUIVis) ──
+// odysseus keys hide DOM elements by data-ui-key; we scope the set to the
+// elements THIS clone's shell renders (IconRail tools + sidebar pieces) so each
+// toggle maps to a real surface the integrator can hide. Default is visible.
+const UI_VIS_KEY = "ui-visibility";
+
+// Broadcast on every visibility change so OdysseusShell can hide/show the
+// matching elements without this panel importing the shell (one-way contract,
+// mirrors odysseus's window.applyUIVis). The shell reads UI_VIS_KEY on mount
+// and listens for this event.
+const UI_VIS_EVENT = "odysseus:ui-visibility-change";
+
+interface VisToggle {
+  key: string;
+  label: string;
+  hint?: string;
+}
+
+interface VisGroup {
+  title: string;
+  icon: ReactNode;
+  rows: readonly VisToggle[];
+}
+
+// Grouped exactly as odysseus (Sidebar / Chat Area), trimmed to the surfaces
+// the clone shell owns. Keys match the shell's data-ui-key contract.
+const VIS_GROUPS: readonly VisGroup[] = [
+  {
+    title: "Sidebar",
+    icon: cardSvg(
+      <>
+        <rect x="3" y="3" width="18" height="18" rx="2" />
+        <line x1="9" y1="3" x2="9" y2="21" />
+      </>,
+    ),
+    rows: [
+      { key: "sidebar-brand", label: "Brand", hint: "App name" },
+      { key: "sidebar-search", label: "Search" },
+      { key: "sidebar-new-chat", label: "New Chat" },
+      {
+        key: "sessions-section",
+        label: "Chats",
+        hint: "Session history list",
+      },
+    ],
+  },
+  {
+    title: "Tools",
+    icon: ICON_WRENCH,
+    rows: [
+      { key: "tool-memory", label: "Memory" },
+      { key: "tool-skills", label: "Skills" },
+      { key: "tool-notes", label: "Notes" },
+      { key: "tool-library", label: "Documents" },
+      { key: "tool-compare", label: "Compare" },
+      { key: "tool-research", label: "Deep Research" },
+      { key: "tool-calendar", label: "Calendar" },
+      { key: "tool-tasks", label: "Tasks" },
+      { key: "tool-models", label: "Models" },
+      { key: "tool-email", label: "Email" },
+      { key: "tool-gallery", label: "Gallery" },
+      { key: "tool-cookbook", label: "Cookbook" },
+      { key: "tool-group", label: "Group Chat" },
+      { key: "tool-editor", label: "Image Editor" },
+      { key: "tool-admin", label: "Admin" },
+      { key: "tool-voice", label: "Voice" },
+      { key: "tool-presets", label: "Presets" },
+      { key: "tool-theme", label: "Theme" },
+    ],
+  },
+  {
+    title: "Chat Area",
+    icon: cardSvg(
+      <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />,
+    ),
+    rows: [
+      {
+        key: "chat-meta",
+        label: "Session Header",
+        hint: "Model name & controls above chat",
+      },
+      {
+        key: "show-thinking",
+        label: "Thinking Process",
+        hint: "Show reasoning collapsibles",
+      },
+    ],
+  },
+];
+
+// A row is visible unless explicitly set false (odysseus default-on semantics).
+function isVisOn(state: Record<string, boolean>, key: string): boolean {
+  return state[key] !== false;
+}
+
+// ── Shortcuts: rebindable keybinds (odysseus keyboard-shortcuts.js) ──
+// odysseus persists via /api/auth/settings (absent in eliza); we persist
+// locally and broadcast so the shell's global key handler can pick up changes.
+const KEYBINDS_KEY = "keybinds";
+const KEYBIND_EVENT = "odysseus:keybinds-change";
+
+// odysseus _defaultKeybinds (keyboard-shortcuts.js). Open-tool combos are
+// unbound by default except Calendar; the panel lets the user assign them.
+const SHORTCUT_DEFAULTS: Readonly<Record<string, string>> = {
+  search: "ctrl+k",
+  toggle_sidebar: "ctrl+alt+b",
+  new_session: "ctrl+alt+n",
+  fav_session: "ctrl+alt+f",
+  delete_session: "ctrl+alt+d",
+  cancel: "escape",
+  settings: "ctrl+,",
+  focus_input: "ctrl+/",
+  open_calendar: "ctrl+alt+c",
+  open_compare: "",
+  open_cookbook: "",
+  open_research: "",
+  open_gallery: "",
+  open_library: "",
+  open_memory: "",
+  open_notes: "",
+  open_tasks: "",
+  open_theme: "",
+};
+
+const SHORTCUT_LABELS: Readonly<Record<string, string>> = {
+  search: "Search conversations",
+  toggle_sidebar: "Toggle sidebar",
+  new_session: "New session",
+  fav_session: "Favorite session",
+  delete_session: "Delete session",
+  cancel: "Cancel / close",
+  settings: "Toggle Settings",
+  focus_input: "Focus chat input",
+  open_calendar: "Open Calendar",
+  open_compare: "Open Compare",
+  open_cookbook: "Open Cookbook",
+  open_research: "Open Deep Research",
+  open_gallery: "Open Gallery",
+  open_library: "Open Library",
+  open_memory: "Open Memory",
+  open_notes: "Open Notes",
+  open_tasks: "Open Tasks",
+  open_theme: "Open Theme",
+};
+
+// odysseus SHORTCUT_CATEGORIES (settings.js), trimmed to bound actions.
+const SHORTCUT_CATEGORIES: ReadonlyArray<{
+  name: string;
+  keys: readonly string[];
+}> = [
+  {
+    name: "Navigation",
+    keys: ["search", "toggle_sidebar", "focus_input", "settings"],
+  },
+  { name: "Sessions", keys: ["new_session", "fav_session", "delete_session"] },
+  { name: "General", keys: ["cancel"] },
+  {
+    name: "Open Tools",
+    keys: [
+      "open_calendar",
+      "open_compare",
+      "open_cookbook",
+      "open_research",
+      "open_gallery",
+      "open_library",
+      "open_memory",
+      "open_notes",
+      "open_tasks",
+      "open_theme",
+    ],
+  },
+];
+
+// Render a combo as keycap chips (odysseus _formatKeyCaps).
+function formatKeyCaps(combo: string): readonly string[] {
+  return combo.split("+").map((p) => {
+    if (p === "ctrl") return "Ctrl";
+    if (p === "alt") return "Alt";
+    if (p === "shift") return "Shift";
+    if (p === "meta") return "Cmd";
+    if (p === "escape") return "Esc";
+    if (p === "space") return "Space";
+    return p.length === 1
+      ? p.toUpperCase()
+      : p.charAt(0).toUpperCase() + p.slice(1);
+  });
+}
+
+// Build a combo string from a keydown (odysseus _comboFromEvent). Returns ""
+// for modifier-only presses so they are never recorded as a binding.
+function comboFromEvent(e: KeyboardEvent): string {
+  const parts: string[] = [];
+  if (e.ctrlKey || e.metaKey) parts.push("ctrl");
+  if (e.altKey) parts.push("alt");
+  if (e.shiftKey) parts.push("shift");
+  const key = e.key.toLowerCase();
+  if (!["control", "alt", "shift", "meta"].includes(key)) {
+    parts.push(key === " " ? "space" : key);
+  }
+  const combo = parts.join("+");
+  // Reject modifier-only combos (odysseus guard).
+  if (
+    combo === "" ||
+    combo === "ctrl" ||
+    combo === "alt" ||
+    combo === "shift" ||
+    combo === "ctrl+alt" ||
+    combo === "ctrl+shift" ||
+    combo === "alt+shift" ||
+    combo === "ctrl+alt+shift"
+  ) {
+    return "";
+  }
+  return combo;
+}
+
+// ── Admin: built-in tool catalogue (admin.js TOOL_META, index.html
+// #adm-builtin-tools-list). Static catalogue metadata — NOT runtime state — so
+// the Agent Tools card reads 1:1 while every toggle stays disabled until a
+// /api/tools backend exists. ──
+interface ToolMeta {
+  id: string;
+  name: string;
+  desc: string;
+  cat: string;
+  ctx: string;
+}
+
+const TOOL_META: readonly ToolMeta[] = [
+  {
+    id: "bash",
+    name: "Shell",
+    desc: "Execute bash commands",
+    cat: "Code",
+    ctx: "~200",
+  },
+  {
+    id: "python",
+    name: "Python",
+    desc: "Run Python scripts",
+    cat: "Code",
+    ctx: "~200",
+  },
+  {
+    id: "read_file",
+    name: "Read File",
+    desc: "Read files from disk",
+    cat: "Code",
+    ctx: "~150",
+  },
+  {
+    id: "write_file",
+    name: "Write File",
+    desc: "Write/create files",
+    cat: "Code",
+    ctx: "~150",
+  },
+  {
+    id: "web_search",
+    name: "Web Search",
+    desc: "Search the web via SearXNG",
+    cat: "Search",
+    ctx: "~300",
+  },
+  {
+    id: "search_chats",
+    name: "Search Chats",
+    desc: "Search conversation history",
+    cat: "Search",
+    ctx: "~150",
+  },
+  {
+    id: "create_document",
+    name: "Create Document",
+    desc: "Create new documents",
+    cat: "Documents",
+    ctx: "~200",
+  },
+  {
+    id: "update_document",
+    name: "Update Document",
+    desc: "Modify existing documents",
+    cat: "Documents",
+    ctx: "~200",
+  },
+  {
+    id: "edit_document",
+    name: "Edit Document",
+    desc: "Find & replace in documents",
+    cat: "Documents",
+    ctx: "~200",
+  },
+  {
+    id: "suggest_document",
+    name: "Suggest Changes",
+    desc: "Propose document edits",
+    cat: "Documents",
+    ctx: "~200",
+  },
+  {
+    id: "manage_documents",
+    name: "Manage Documents",
+    desc: "List, delete, organize docs",
+    cat: "Documents",
+    ctx: "~150",
+  },
+  {
+    id: "generate_image",
+    name: "Generate Image",
+    desc: "Create images via AI",
+    cat: "Media",
+    ctx: "~150",
+  },
+  {
+    id: "manage_memory",
+    name: "Memory",
+    desc: "Save and recall memories",
+    cat: "Knowledge",
+    ctx: "~200",
+  },
+  {
+    id: "manage_skills",
+    name: "Skills",
+    desc: "Learn and use procedures",
+    cat: "Knowledge",
+    ctx: "~200",
+  },
+  {
+    id: "manage_rag",
+    name: "RAG / Docs",
+    desc: "Query indexed documents",
+    cat: "Knowledge",
+    ctx: "~150",
+  },
+  {
+    id: "chat_with_model",
+    name: "Chat with Model",
+    desc: "Talk to another AI model",
+    cat: "Multi-Agent",
+    ctx: "~200",
+  },
+  {
+    id: "second_opinion",
+    name: "Second Opinion",
+    desc: "Get another model's take",
+    cat: "Multi-Agent",
+    ctx: "~150",
+  },
+  {
+    id: "pipeline",
+    name: "Pipeline",
+    desc: "Multi-step AI workflows",
+    cat: "Multi-Agent",
+    ctx: "~200",
+  },
+  {
+    id: "ask_teacher",
+    name: "Ask Teacher",
+    desc: "Query a more capable model",
+    cat: "Multi-Agent",
+    ctx: "~150",
+  },
+  {
+    id: "send_to_session",
+    name: "Send to Session",
+    desc: "Send message to another chat",
+    cat: "Sessions",
+    ctx: "~100",
+  },
+  {
+    id: "create_session",
+    name: "Create Session",
+    desc: "Start a new chat session",
+    cat: "Sessions",
+    ctx: "~100",
+  },
+  {
+    id: "list_sessions",
+    name: "List Sessions",
+    desc: "Browse existing sessions",
+    cat: "Sessions",
+    ctx: "~100",
+  },
+  {
+    id: "manage_session",
+    name: "Manage Session",
+    desc: "Rename, archive, configure",
+    cat: "Sessions",
+    ctx: "~100",
+  },
+  {
+    id: "list_models",
+    name: "List Models",
+    desc: "Show available models",
+    cat: "System",
+    ctx: "~100",
+  },
+  {
+    id: "ui_control",
+    name: "UI Control",
+    desc: "Change theme, layout, settings",
+    cat: "System",
+    ctx: "~150",
+  },
+  {
+    id: "manage_tasks",
+    name: "Tasks",
+    desc: "Schedule automated tasks",
+    cat: "System",
+    ctx: "~150",
+  },
+  {
+    id: "api_call",
+    name: "API Call",
+    desc: "Make HTTP requests",
+    cat: "System",
+    ctx: "~200",
+  },
+  {
+    id: "manage_endpoints",
+    name: "Endpoints",
+    desc: "Add/remove model endpoints",
+    cat: "System",
+    ctx: "~100",
+  },
+  {
+    id: "manage_mcp",
+    name: "MCP Servers",
+    desc: "Manage MCP connections",
+    cat: "System",
+    ctx: "~100",
+  },
+  {
+    id: "manage_webhooks",
+    name: "Webhooks",
+    desc: "Configure webhook events",
+    cat: "System",
+    ctx: "~100",
+  },
+  {
+    id: "manage_tokens",
+    name: "API Tokens",
+    desc: "Manage API access tokens",
+    cat: "System",
+    ctx: "~100",
+  },
+  {
+    id: "manage_settings",
+    name: "Settings",
+    desc: "Change app settings",
+    cat: "System",
+    ctx: "~100",
+  },
+];
+
+const CATEGORY_ORDER = [
+  "Code",
+  "Search",
+  "Documents",
+  "Media",
+  "Knowledge",
+  "Multi-Agent",
+  "Sessions",
+  "System",
+  "Other",
+] as const;
+
+// odysseus admin.js PRIV_LABELS — per-user boolean feature grants.
+const PRIV_LABELS: ReadonlyArray<readonly [string, string]> = [
+  ["can_use_agent", "Agent mode"],
+  ["can_use_browser", "Browser automation"],
+  ["can_use_bash", "Shell / Python / Files"],
+  ["can_use_documents", "Document editor"],
+  ["can_use_research", "Deep research"],
+  ["can_generate_images", "Image generation"],
+  ["can_manage_memory", "Memory & skills"],
+];
+
+// odysseus index.html Danger Zone rows (data-wipe-kind + label + sub). 1:1.
+interface WipeRow {
+  kind: string;
+  label: string;
+  sub: string;
+}
+
+const WIPE_ROWS: readonly WipeRow[] = [
+  {
+    kind: "chats",
+    label: "Wipe all chats",
+    sub: "Every session, message, and chat history. Documents/notes/etc. stay.",
+  },
+  {
+    kind: "memory",
+    label: "Wipe all memory",
+    sub: "Clears `memory.json`, the Memory table, and the vector store. Skills not affected.",
+  },
+  {
+    kind: "skills",
+    label: "Wipe all skills",
+    sub: "Drops `data/skills/` (all SKILL.md files). Memory not affected.",
+  },
+  {
+    kind: "notes",
+    label: "Wipe all notes",
+    sub: "Every note, todo, and checklist.",
+  },
+  {
+    kind: "tasks",
+    label: "Wipe all tasks",
+    sub: "Every scheduled task and its run history (Tasks tool).",
+  },
+  {
+    kind: "documents",
+    label: "Wipe all documents",
+    sub: "Every document and version. Drafts, exports, library — all gone.",
+  },
+  {
+    kind: "gallery",
+    label: "Wipe all gallery",
+    sub: "Every image record and the upload directory on disk.",
+  },
+  {
+    kind: "calendar",
+    label: "Wipe all calendar",
+    sub: "Every event and every calendar (incl. CalDAV-synced ones; resync to restore).",
+  },
+];
+
+// Real provider model lists feed the per-user "Allowed models" list — the same
+// /api/models fetch keys CompareView + GalleryView use.
+const MODEL_PROVIDERS = [
+  "openai",
+  "anthropic",
+  "google",
+  "openrouter",
+  "groq",
+  "xai",
+  "ollama",
+] as const;
+
+// ── Small reusable card chrome (admin-card h2 + admin-toggle-sub). ──
+function CardTitle({
+  icon,
+  children,
+  faded,
+}: {
+  icon: ReactNode;
+  children: ReactNode;
+  faded?: string;
+}): ReactNode {
+  return (
+    <h2 className="od-set-card-title">
+      <span className="od-set-card-title-icon">{icon}</span>
+      <span>{children}</span>
+      {faded ? <span className="od-set-card-faded">{faded}</span> : null}
+    </h2>
+  );
+}
+
+function Sub({ children }: { children: ReactNode }): ReactNode {
+  return <div className="od-set-sub">{children}</div>;
+}
+
+export function SettingsPanel({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}): ReactNode {
+  useEscapeClose(open, onClose);
+  const win = useWindowControls(
+    "win-settings",
+    { w: 820, h: 700 },
+    { label: "Settings", icon: "Settings", onClose },
+  );
+  const [tab, setTab] = useState<SettingsTab>("services");
+
+  // General/admin — MCP servers (real status) + installed plugins (real list).
+  const [servers, setServers] = useState<McpServerStatus[]>([]);
+  const [plugins, setPlugins] = useState<PluginInfo[]>([]);
+
+  // Web search — local preference (no eliza backend).
+  const [search, setSearch] = useState<SearchSettings>(DEFAULT_SEARCH_SETTINGS);
+  const [countMode, setCountMode] = useState<"preset" | "custom">("preset");
+
+  // Account — real character / agent name (read-only here).
+  const [agentName, setAgentName] = useState("");
+
+  // Appearance — read-only mirror of the live shell theme prefs (Theme rail is
+  // the writer), plus the editable UI-visibility toggle set.
+  const [themeMode, setThemeMode] = useState("dark");
+  const [font, setFont] = useState("mono");
+  const [density, setDensity] = useState("comfortable");
+  const [vis, setVis] = useState<Record<string, boolean>>({});
+
+  // Shortcuts — editable keybinds + the action currently being rebound.
+  const [keybinds, setKeybinds] =
+    useState<Record<string, string>>(SHORTCUT_DEFAULTS);
+  const [rebinding, setRebinding] = useState<string | null>(null);
+  const keybindsRef = useRef(keybinds);
+  keybindsRef.current = keybinds;
+
+  // Admin — real provider models for the per-user "Allowed models" list.
+  const [models, setModels] = useState<ProviderModelRecord[]>([]);
+
+  // Services — collapsed/expanded state of the Local/API add sections.
+  const [openLocal, setOpenLocal] = useState(false);
+  const [openApi, setOpenApi] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    void client
+      .getMcpStatus()
+      .then((r) => setServers(r.servers))
+      .catch(() => setServers([]));
+    void client
+      .getPlugins()
+      .then((r) => setPlugins(r.plugins))
+      .catch(() => setPlugins([]));
+
+    const stored = readPref<SearchSettings>(
+      SEARCH_SETTINGS_KEY,
+      DEFAULT_SEARCH_SETTINGS,
+    );
+    setSearch(stored);
+    setCountMode(isPresetCount(stored.resultCount) ? "preset" : "custom");
+
+    void client
+      .getCharacter()
+      .then((r) => setAgentName(r.agentName))
+      .catch(() => setAgentName(""));
+
+    setThemeMode(readPref<string>(PREF_KEYS.themeMode, "dark"));
+    setFont(readPref<string>(PREF_KEYS.font, "mono"));
+    setDensity(readPref<string>(PREF_KEYS.density, "comfortable"));
+
+    setVis(readPref<Record<string, boolean>>(UI_VIS_KEY, {}));
+    setKeybinds({
+      ...SHORTCUT_DEFAULTS,
+      ...readPref<Record<string, string>>(KEYBINDS_KEY, {}),
+    });
+    setRebinding(null);
+  }, [open]);
+
+  // Populate the admin "Allowed models" list from the REAL provider model lists
+  // — the same /api/models endpoint the settings + compare surfaces use.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void Promise.all(
+      MODEL_PROVIDERS.map((provider) =>
+        client
+          .fetchModels(provider)
+          .then((r): ProviderModelRecord[] => r.models)
+          .catch((): ProviderModelRecord[] => []),
+      ),
+    ).then((lists) => {
+      if (cancelled) return;
+      const seen = new Set<string>();
+      const flat: ProviderModelRecord[] = [];
+      for (const m of lists.flat()) {
+        if (seen.has(m.id)) continue;
+        seen.add(m.id);
+        flat.push(m);
+      }
+      flat.sort((a, b) => a.name.localeCompare(b.name));
+      setModels(flat);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  // Persist + broadcast outside any setState updater (updaters must stay pure;
+  // React StrictMode runs them twice, which would double-write the pref and fire
+  // the events twice).
+  const persistKeybinds = useCallback((next: Record<string, string>) => {
+    setKeybinds(next);
+    writePref(KEYBINDS_KEY, next);
+    window.dispatchEvent(new CustomEvent(KEYBIND_EVENT, { detail: next }));
+  }, []);
+
+  useEffect(() => {
+    if (!rebinding) return;
+    const action = rebinding;
+    const onKey = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.key === "Escape") {
+        setRebinding(null);
+        return;
+      }
+      const combo = comboFromEvent(e);
+      if (!combo) return;
+      persistKeybinds({ ...keybindsRef.current, [action]: combo });
+      setRebinding(null);
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [rebinding, persistKeybinds]);
+
+  const persistVis = useCallback((next: Record<string, boolean>) => {
+    setVis(next);
+    writePref(UI_VIS_KEY, next);
+    window.dispatchEvent(new CustomEvent(UI_VIS_EVENT, { detail: next }));
+  }, []);
+
+  const toggleVis = useCallback(
+    (key: string) => {
+      persistVis({ ...vis, [key]: !isVisOn(vis, key) });
+    },
+    [vis, persistVis],
+  );
+
+  const resetVis = useCallback(() => {
+    persistVis({});
+  }, [persistVis]);
+
+  const resetKeybind = useCallback(
+    (action: string) => {
+      persistKeybinds({
+        ...keybinds,
+        [action]: SHORTCUT_DEFAULTS[action] ?? "",
+      });
+    },
+    [keybinds, persistKeybinds],
+  );
+
+  const resetAllKeybinds = useCallback(() => {
+    setRebinding(null);
+    persistKeybinds({ ...SHORTCUT_DEFAULTS });
+  }, [persistKeybinds]);
+
+  // Real installed model-provider plugins — surfaced as the closest live
+  // mapping for the "Added Models" endpoint lists.
+  const modelPlugins = useMemo(
+    () => plugins.filter((p) => p.category === "ai-provider"),
+    [plugins],
+  );
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  const persistSearch = (next: SearchSettings) => {
+    setSearch(next);
+    writePref(SEARCH_SETTINGS_KEY, next);
+  };
+
+  const activeProvider = providerMeta(search.provider);
+  const searchStatus =
+    search.provider === "disabled"
+      ? "Search disabled"
+      : `${activeProvider.label} · ${search.resultCount} results${
+          activeProvider.needsKey
+            ? search.apiKey.trim()
+              ? " · key set"
+              : " · no key"
+            : ""
+        }`;
+
+  return (
+    <div
+      className={`od-search-overlay od-settings-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Settings"
+    >
+      <button
+        type="button"
+        aria-label="Close settings"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel od-settings-panel" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        {/* ── Header (settings-modal header) ── */}
+        <div
+          className="od-settings-header od-window-header"
+          onPointerDown={win.onDragStart}
+        >
+          <span className="od-settings-header-icon" aria-hidden="true">
+            ⚙
+          </span>
+          <span className="od-settings-header-title">Settings</span>
+          <span className="od-settings-header-spacer" />
+          {/* odysseus's Settings modal header carries only minimize + close —
+              no Peek (theme-opacity) control on this surface. */}
+          <button
+            type="button"
+            className="od-window-min-btn"
+            onClick={win.minimize}
+            title="Minimize"
+            aria-label="Minimize"
+          >
+            <Minus size={14} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="od-settings-close"
+            aria-label="Close settings"
+            title="Close settings"
+            onClick={onClose}
+          >
+            ✖
+          </button>
+        </div>
+
+        {/* Subtitle row (index.html admin-toggle-sub under the header). */}
+        <div className="od-settings-subtitle">
+          Toggle on/off visibility of tools and modules across the interface.
+        </div>
+
+        {/* ── Body: left tab rail + anchored panels ── */}
+        <div className="od-settings-body">
+          <div
+            className="od-settings-rail"
+            role="tablist"
+            aria-label="Settings sections"
+          >
+            {RAIL.map((item) => (
+              <RailButton
+                key={item.id}
+                item={item}
+                active={tab === item.id}
+                onSelect={() => setTab(item.id)}
+              />
+            ))}
+          </div>
+
+          <div className="od-settings-panels">
+            {tab === "services" ? (
+              <div className="od-settings-section" role="tabpanel">
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_SERVER} faded="(Endpoints)">
+                    Add Models
+                  </CardTitle>
+                  <Sub>Connect local models first, or add a cloud API.</Sub>
+
+                  {/* Local subsection (collapsible) */}
+                  <CollapsibleEndpoint
+                    open={openLocal}
+                    onToggle={() => setOpenLocal((v) => !v)}
+                    icon={ICON_DEVICE}
+                    label="Local"
+                  >
+                    <div className="od-set-ep-form">
+                      <div className="od-set-ep-row">
+                        <input
+                          className="od-settings-input"
+                          type="text"
+                          placeholder="Paste endpoint URL, e.g. http://localhost:11434/v1"
+                          disabled
+                        />
+                        <select
+                          className="od-settings-select od-set-ep-type"
+                          disabled
+                        >
+                          <option>LLM</option>
+                          <option>Image</option>
+                        </select>
+                      </div>
+                      <div className="od-set-ep-row od-set-ep-actions">
+                        <span className="od-set-ep-spacer" />
+                        <button
+                          type="button"
+                          className="od-settings-btn-sm"
+                          disabled
+                        >
+                          Test
+                        </button>
+                        <button
+                          type="button"
+                          className="od-settings-btn-add"
+                          disabled
+                        >
+                          Add
+                        </button>
+                      </div>
+                      <div className="od-set-quickstart">
+                        <span className="od-set-quickstart-label">
+                          Quickstart
+                        </span>
+                        <button
+                          type="button"
+                          className="od-settings-btn-sm"
+                          disabled
+                        >
+                          <span className="od-set-btn-ico">{ICON_SEARCH}</span>
+                          Scan for Servers
+                        </button>
+                        <button
+                          type="button"
+                          className="od-settings-btn-sm"
+                          disabled
+                        >
+                          Ollama
+                        </button>
+                      </div>
+                    </div>
+                  </CollapsibleEndpoint>
+
+                  {/* API subsection (collapsible) */}
+                  <CollapsibleEndpoint
+                    open={openApi}
+                    onToggle={() => setOpenApi((v) => !v)}
+                    icon={ICON_GLOBE}
+                    label="API"
+                  >
+                    <div className="od-set-ep-form">
+                      <div className="od-set-ep-row">
+                        <input
+                          className="od-settings-input"
+                          type="text"
+                          placeholder="Base URL or pick provider"
+                          disabled
+                        />
+                      </div>
+                      <div className="od-set-ep-row">
+                        <input
+                          className="od-settings-input"
+                          type="password"
+                          placeholder="API key"
+                          disabled
+                        />
+                        <select
+                          className="od-settings-select od-set-ep-type"
+                          disabled
+                        >
+                          <option>LLM</option>
+                          <option>Image</option>
+                        </select>
+                        <button
+                          type="button"
+                          className="od-settings-btn-sm"
+                          disabled
+                        >
+                          Test
+                        </button>
+                        <button
+                          type="button"
+                          className="od-settings-btn-add"
+                          disabled
+                        >
+                          Add
+                        </button>
+                      </div>
+                    </div>
+                  </CollapsibleEndpoint>
+                </div>
+
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_DEVICE} faded="(Endpoints)">
+                    Added Models
+                  </CardTitle>
+                  <Sub>Manage the endpoints you've added.</Sub>
+                  <div className="od-set-ep-list">
+                    <div className="od-set-ep-list-head">
+                      <span className="od-set-ep-list-ico">{ICON_DEVICE}</span>
+                      <span>Local</span>
+                    </div>
+                    <div className="od-set-ep-none">None</div>
+                  </div>
+                  <div className="od-set-ep-list">
+                    <div className="od-set-ep-list-head">
+                      <span className="od-set-ep-list-ico">{ICON_GLOBE}</span>
+                      <span>API</span>
+                    </div>
+                    {modelPlugins.length === 0 ? (
+                      <div className="od-set-ep-none">None</div>
+                    ) : (
+                      modelPlugins.map((p) => (
+                        <div className="od-skill-item" key={p.id}>
+                          <div className="od-skill-info">
+                            <div className="od-skill-name">{p.name}</div>
+                            <div className="od-skill-desc">
+                              {p.configured ? "configured" : "not configured"}
+                            </div>
+                          </div>
+                          <span
+                            className={`od-skill-toggle${p.enabled ? " on" : ""}`}
+                          >
+                            {p.enabled ? "On" : "Off"}
+                          </span>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                </div>
+                <div className="od-settings-note">
+                  Endpoints are added through the eliza runtime, not this client
+                  — the add forms are shown faithfully but disabled. The API
+                  list surfaces the agent's real installed model-provider
+                  plugins.
+                </div>
+              </div>
+            ) : null}
+
+            {tab === "ai" ? (
+              <div className="od-settings-section" role="tabpanel">
+                <AiCard
+                  icon={ICON_CHAT}
+                  title="Default Chat Model"
+                  sub="The model used when creating a new chat session."
+                />
+                <AiCard
+                  icon={ICON_WRENCH}
+                  title="Utility Model"
+                  faded="(Recommended: Local Endpoint)"
+                  sub="Runs background tasks (compaction, cleanup, auto-naming, retrieving memories from files) on a small/local model instead of your chat model. Leave blank to use the chat model."
+                />
+                <AiCard
+                  icon={ICON_EYE}
+                  title="Vision"
+                  sub="Analyze images with a vision-capable model."
+                />
+                <AiCard
+                  icon={ICON_RESEARCH}
+                  title="Research Model"
+                  sub="Model used for Deep Research. Falls back to the default chat model if not set."
+                />
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_WRENCH}>Agent</CardTitle>
+                  <Sub>Controls for the agent tool loop.</Sub>
+                  <div className="od-settings-row">
+                    <span className="od-settings-label">Active agent</span>
+                    <span className="od-settings-value">
+                      {agentName || "—"}
+                    </span>
+                  </div>
+                  <div className="od-settings-row">
+                    <span className="od-settings-label">Plugins loaded</span>
+                    <span className="od-settings-value">{plugins.length}</span>
+                  </div>
+                  <div className="od-settings-row">
+                    <span className="od-settings-label">Model providers</span>
+                    <span className="od-settings-value">
+                      {modelPlugins.length}
+                    </span>
+                  </div>
+                </div>
+                <div className="od-settings-note">
+                  This agent's model map (default / utility / vision / research
+                  endpoints and fallback chains) is owned by the eliza runtime,
+                  which does not expose a per-endpoint editor to this client —
+                  so the selectors are shown disabled rather than offering an
+                  editor that cannot persist.
+                </div>
+              </div>
+            ) : null}
+
+            {tab === "search" ? (
+              <div className="od-settings-section" role="tabpanel">
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_SEARCH}>Web Search</CardTitle>
+                  <Sub>Search API used for web search and deep research.</Sub>
+                  <div className="od-settings-field">
+                    <label
+                      className="od-settings-flabel"
+                      htmlFor="od-set-search-provider"
+                    >
+                      Provider
+                    </label>
+                    <select
+                      id="od-set-search-provider"
+                      className="od-settings-select"
+                      value={search.provider}
+                      onChange={(e) =>
+                        persistSearch({
+                          ...search,
+                          provider: toSearchProvider(e.target.value),
+                        })
+                      }
+                    >
+                      {SEARCH_PROVIDERS.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.label}
+                        </option>
+                      ))}
+                    </select>
+                    <div className="od-settings-hint">
+                      {activeProvider.hint}
+                    </div>
+                  </div>
+
+                  {search.provider !== "disabled" ? (
+                    <div className="od-settings-field">
+                      <label
+                        className="od-settings-flabel"
+                        htmlFor="od-set-search-count"
+                      >
+                        Results
+                      </label>
+                      <select
+                        id="od-set-search-count"
+                        className="od-settings-select"
+                        value={
+                          countMode === "custom"
+                            ? "custom"
+                            : String(search.resultCount)
+                        }
+                        onChange={(e) => {
+                          if (e.target.value === "custom") {
+                            setCountMode("custom");
+                            return;
+                          }
+                          setCountMode("preset");
+                          persistSearch({
+                            ...search,
+                            resultCount: Number.parseInt(e.target.value, 10),
+                          });
+                        }}
+                      >
+                        {RESULT_COUNT_PRESETS.map((n) => (
+                          <option key={n} value={String(n)}>
+                            {n}
+                          </option>
+                        ))}
+                        <option value="custom">Custom</option>
+                      </select>
+                      {countMode === "custom" ? (
+                        <input
+                          className="od-settings-input"
+                          type="number"
+                          min={1}
+                          max={100}
+                          value={search.resultCount}
+                          aria-label="Custom result count"
+                          onChange={(e) => {
+                            const raw = Number.parseInt(e.target.value, 10);
+                            const clamped = Number.isFinite(raw)
+                              ? Math.max(1, Math.min(100, raw))
+                              : search.resultCount;
+                            persistSearch({ ...search, resultCount: clamped });
+                          }}
+                        />
+                      ) : null}
+                    </div>
+                  ) : null}
+
+                  {search.provider === "searxng" ? (
+                    <div className="od-settings-field">
+                      <label
+                        className="od-settings-flabel"
+                        htmlFor="od-set-search-url"
+                      >
+                        URL
+                      </label>
+                      <input
+                        id="od-set-search-url"
+                        className="od-settings-input"
+                        type="text"
+                        placeholder="http://localhost:8080"
+                        value={search.searxngUrl}
+                        onChange={(e) =>
+                          persistSearch({
+                            ...search,
+                            searxngUrl: e.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                  ) : null}
+
+                  {activeProvider.needsKey ? (
+                    <div className="od-settings-field">
+                      <label
+                        className="od-settings-flabel"
+                        htmlFor="od-set-search-key"
+                      >
+                        API Key
+                      </label>
+                      <input
+                        id="od-set-search-key"
+                        className="od-settings-input"
+                        type="password"
+                        placeholder="API key"
+                        value={search.apiKey}
+                        onChange={(e) =>
+                          persistSearch({ ...search, apiKey: e.target.value })
+                        }
+                      />
+                    </div>
+                  ) : null}
+
+                  {search.provider === "google_pse" ? (
+                    <div className="od-settings-field">
+                      <label
+                        className="od-settings-flabel"
+                        htmlFor="od-set-search-cx"
+                      >
+                        CX ID
+                      </label>
+                      <input
+                        id="od-set-search-cx"
+                        className="od-settings-input"
+                        type="text"
+                        placeholder="Google PSE engine ID"
+                        value={search.googlePseCx}
+                        onChange={(e) =>
+                          persistSearch({
+                            ...search,
+                            googlePseCx: e.target.value,
+                          })
+                        }
+                      />
+                    </div>
+                  ) : null}
+
+                  <div
+                    className={`od-settings-status${
+                      search.provider === "disabled" ||
+                      (activeProvider.needsKey && !search.apiKey.trim())
+                        ? " warn"
+                        : ""
+                    }`}
+                  >
+                    {searchStatus}
+                  </div>
+                  <div className="od-settings-note">
+                    Stored as a local browser preference — eliza does not yet
+                    expose a search-config endpoint to persist this server-side.
+                  </div>
+                </div>
+              </div>
+            ) : null}
+
+            {tab === "integrations" ? (
+              <div className="od-settings-section" role="tabpanel">
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_LINK}>Connections</CardTitle>
+                  <Sub>All external service connections in one place.</Sub>
+                  <div className="od-settings-empty">
+                    No integrations connected.
+                  </div>
+                  <div className="od-set-center-actions">
+                    <button
+                      type="button"
+                      className="od-settings-btn-sm"
+                      disabled
+                    >
+                      + Add Integration
+                    </button>
+                  </div>
+                </div>
+                <div className="od-settings-note">
+                  Unified integrations (API keys, calendars, contacts, email
+                  accounts, MCP, vault) are managed by the eliza runtime — this
+                  client has no integrations API, so the surface is shown
+                  faithfully but inert.
+                </div>
+              </div>
+            ) : null}
+
+            {tab === "email" ? (
+              <div className="od-settings-section" role="tabpanel">
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_ENVELOPE}>Email Accounts</CardTitle>
+                  <div className="od-set-row-action">
+                    <Sub>
+                      Add, edit, delete, and test accounts in Integrations.
+                    </Sub>
+                    <button
+                      type="button"
+                      className="od-settings-btn-add"
+                      disabled
+                    >
+                      Manage in Integrations
+                    </button>
+                  </div>
+                </div>
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_CAL}>Email Tasks</CardTitle>
+                  <div className="od-set-row-action">
+                    <Sub>Manage email background tasks in Tasks.</Sub>
+                    <button
+                      type="button"
+                      className="od-settings-btn-add"
+                      disabled
+                    >
+                      Open Tasks
+                    </button>
+                  </div>
+                </div>
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_PEN}>Writing Style</CardTitle>
+                  <Sub>
+                    AI-extracted from your sent emails. Used when AI drafts
+                    replies.
+                  </Sub>
+                  <textarea
+                    className="od-settings-textarea"
+                    rows={4}
+                    placeholder="e.g. I write emails in this style. I don't use exclamation marks. I sign emails with: ..."
+                    disabled
+                  />
+                  <div className="od-settings-actions od-set-actions-end">
+                    <button
+                      type="button"
+                      className="od-settings-btn-add"
+                      disabled
+                    >
+                      Extract from Sent (15 emails)
+                    </button>
+                    <button
+                      type="button"
+                      className="od-settings-btn-add"
+                      disabled
+                    >
+                      Save
+                    </button>
+                  </div>
+                </div>
+                <div className="od-settings-note">
+                  Email accounts and writing-style extraction are owned by the
+                  eliza runtime — no email-config API is exposed to this client,
+                  so these controls are shown faithfully but inert.
+                </div>
+              </div>
+            ) : null}
+
+            {tab === "reminders" ? (
+              <div className="od-settings-section" role="tabpanel">
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_BELL}>How you're reminded</CardTitle>
+                  <Sub>Controls how fired note reminders are delivered.</Sub>
+                  <div className="od-settings-field">
+                    <label
+                      className="od-settings-flabel"
+                      htmlFor="od-set-rem-ch"
+                    >
+                      Channel
+                    </label>
+                    <select
+                      id="od-set-rem-ch"
+                      className="od-settings-select"
+                      disabled
+                    >
+                      <option>Browser notification (default)</option>
+                      <option>Email</option>
+                      <option>ntfy</option>
+                    </select>
+                  </div>
+                </div>
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_CHECK}>AI Synthesis</CardTitle>
+                  <Sub>
+                    When on, the utility model writes a short, warm one-line
+                    reminder for browser, email, AND ntfy reminders instead of
+                    just the raw note content.
+                  </Sub>
+                </div>
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_LINK}>Public App URL</CardTitle>
+                  <Sub>
+                    Used to build clickable links back to Orchestrator inside
+                    outgoing reminder / urgent-email emails. Leave blank to omit
+                    links.
+                  </Sub>
+                  <div className="od-settings-field">
+                    <label
+                      className="od-settings-flabel"
+                      htmlFor="od-set-rem-url"
+                    >
+                      URL
+                    </label>
+                    <input
+                      id="od-set-rem-url"
+                      className="od-settings-input"
+                      type="url"
+                      placeholder="https://chat.example.com"
+                      disabled
+                    />
+                  </div>
+                </div>
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_CHECK}>Test</CardTitle>
+                  <Sub>
+                    Fire a test reminder using your current settings to verify
+                    everything works.
+                  </Sub>
+                  <div className="od-settings-actions od-set-actions-end">
+                    <button
+                      type="button"
+                      className="od-settings-btn-add"
+                      disabled
+                    >
+                      Send Test Reminder
+                    </button>
+                  </div>
+                </div>
+                <div className="od-settings-note">
+                  Reminder delivery (channels, ntfy, email-from) is owned by the
+                  eliza runtime — no reminder-config API is exposed to this
+                  client, so these controls are shown faithfully but inert.
+                </div>
+              </div>
+            ) : null}
+
+            {tab === "appearance" ? (
+              <div className="od-settings-section" role="tabpanel">
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_EYE}>Theme</CardTitle>
+                  <div className="od-settings-row">
+                    <span className="od-settings-label">Theme</span>
+                    <span className="od-settings-value">{themeMode}</span>
+                  </div>
+                  <div className="od-settings-row">
+                    <span className="od-settings-label">Font</span>
+                    <span className="od-settings-value">{font}</span>
+                  </div>
+                  <div className="od-settings-row">
+                    <span className="od-settings-label">Density</span>
+                    <span className="od-settings-value">{density}</span>
+                  </div>
+                  <div className="od-settings-note">
+                    Theme, font, and density are set live from the shell's theme
+                    rail so changes preview instantly; this tab mirrors the
+                    active values.
+                  </div>
+                </div>
+
+                {VIS_GROUPS.map((group) => (
+                  <div className="od-settings-card" key={group.title}>
+                    <CardTitle icon={group.icon}>{group.title}</CardTitle>
+                    <div className="od-vis-toggles">
+                      {group.rows.map((row) => {
+                        const on = isVisOn(vis, row.key);
+                        return (
+                          <button
+                            type="button"
+                            key={row.key}
+                            className="od-vis-row"
+                            aria-pressed={on}
+                            onClick={() => toggleVis(row.key)}
+                          >
+                            <span className="od-vis-label">
+                              {row.label}
+                              {row.hint ? (
+                                <span className="od-vis-hint">{row.hint}</span>
+                              ) : null}
+                            </span>
+                            <span
+                              className={`od-vis-switch${on ? " on" : ""}`}
+                            />
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
+
+                <div className="od-settings-actions od-vis-reset-row">
+                  <button
+                    type="button"
+                    className="od-settings-reset"
+                    onClick={resetVis}
+                  >
+                    Reset All
+                  </button>
+                </div>
+                <div className="od-settings-note">
+                  Show or hide shell elements. Stored as a local browser
+                  preference and applied live to the sidebar and tool rail.
+                </div>
+              </div>
+            ) : null}
+
+            {tab === "shortcuts" ? (
+              <div className="od-settings-section" role="tabpanel">
+                <div className="od-settings-card od-shortcut-head-card">
+                  <div>
+                    <CardTitle
+                      icon={cardSvg(
+                        <>
+                          <rect x="2" y="4" width="20" height="16" rx="2" />
+                          <path d="M6 8h.01M10 8h.01M14 8h.01M18 8h.01M8 12h.01M12 12h.01M16 12h.01M7 16h10" />
+                        </>,
+                      )}
+                    >
+                      Keyboard Shortcuts
+                    </CardTitle>
+                    <div className="od-settings-hint">
+                      Click a shortcut to rebind. Press Escape to cancel.
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    className="od-settings-reset"
+                    onClick={resetAllKeybinds}
+                  >
+                    Reset
+                  </button>
+                </div>
+                <div className="od-settings-card">
+                  {(() => {
+                    // Highlight any combo bound to more than one action
+                    // (odysseus _findConflicts).
+                    const seen = new Set<string>();
+                    const conflicts = new Set<string>();
+                    for (const combo of Object.values(keybinds)) {
+                      if (!combo) continue;
+                      if (seen.has(combo)) conflicts.add(combo);
+                      else seen.add(combo);
+                    }
+                    return SHORTCUT_CATEGORIES.map((cat) => (
+                      <div key={cat.name}>
+                        <div className="od-shortcut-category">{cat.name}</div>
+                        {cat.keys.map((action) => {
+                          const combo = keybinds[action] ?? "";
+                          const isCustom =
+                            combo !== (SHORTCUT_DEFAULTS[action] ?? "");
+                          const isListening = rebinding === action;
+                          const conflict =
+                            combo.length > 0 && conflicts.has(combo);
+                          return (
+                            <div
+                              key={action}
+                              className={`od-shortcut-row${conflict ? " conflict" : ""}`}
+                            >
+                              <span className="od-shortcut-label">
+                                {SHORTCUT_LABELS[action] ?? action}
+                                {conflict ? (
+                                  <span
+                                    className="od-shortcut-warn"
+                                    title="Duplicate shortcut"
+                                  >
+                                    !
+                                  </span>
+                                ) : null}
+                              </span>
+                              <div className="od-shortcut-controls">
+                                <button
+                                  type="button"
+                                  className={`od-shortcut-key${combo ? "" : " unset"}${isListening ? " listening" : ""}`}
+                                  title="Click to rebind"
+                                  onClick={() =>
+                                    setRebinding(isListening ? null : action)
+                                  }
+                                >
+                                  {isListening ? (
+                                    <span className="od-shortcut-listening">
+                                      Press keys…
+                                    </span>
+                                  ) : combo ? (
+                                    formatKeyCaps(combo).map((cap, i) => (
+                                      // biome-ignore lint/suspicious/noArrayIndexKey: keycaps are positional within a fixed combo
+                                      <kbd key={`${action}-${i}`}>{cap}</kbd>
+                                    ))
+                                  ) : (
+                                    <span className="od-shortcut-unset">
+                                      Set
+                                    </span>
+                                  )}
+                                </button>
+                                {isCustom ? (
+                                  <button
+                                    type="button"
+                                    className="od-shortcut-resetbtn"
+                                    title="Reset to default"
+                                    aria-label={`Reset ${SHORTCUT_LABELS[action] ?? action}`}
+                                    onClick={() => resetKeybind(action)}
+                                  >
+                                    ↩
+                                  </button>
+                                ) : null}
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                    ));
+                  })()}
+                </div>
+                <div className="od-settings-note">
+                  Stored as a local browser preference. The shell applies these
+                  bindings to its global key handler.
+                </div>
+              </div>
+            ) : null}
+
+            {tab === "account" ? (
+              <div className="od-settings-section" role="tabpanel">
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_USER}>Account</CardTitle>
+                  <div className="od-set-account-row">
+                    <span className="od-set-account-avatar">
+                      {(agentName.charAt(0) || "A").toUpperCase()}
+                    </span>
+                    <div className="od-set-account-meta">
+                      <div className="od-set-account-name">
+                        {agentName || "—"}
+                      </div>
+                      <div className="od-set-account-role">Agent</div>
+                    </div>
+                    <button
+                      type="button"
+                      className="od-settings-btn-logout"
+                      disabled
+                    >
+                      <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        aria-hidden="true"
+                      >
+                        <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                        <polyline points="16 17 21 12 16 7" />
+                        <line x1="21" y1="12" x2="9" y2="12" />
+                      </svg>
+                      Logout
+                    </button>
+                  </div>
+                </div>
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_LOCK}>Change Password</CardTitle>
+                  <div className="od-settings-field">
+                    <input
+                      className="od-settings-input"
+                      type="password"
+                      placeholder="Current password"
+                      disabled
+                    />
+                    <input
+                      className="od-settings-input"
+                      type="password"
+                      placeholder="New password (min 8)"
+                      disabled
+                    />
+                    <input
+                      className="od-settings-input"
+                      type="password"
+                      placeholder="Confirm new password"
+                      disabled
+                    />
+                    <div className="od-settings-actions od-set-actions-end">
+                      <button
+                        type="button"
+                        className="od-settings-btn-add"
+                        disabled
+                      >
+                        Update Password
+                      </button>
+                    </div>
+                  </div>
+                </div>
+                <div className="od-settings-card">
+                  <CardTitle icon={ICON_LOCK2FA}>
+                    Two-Factor Authentication
+                  </CardTitle>
+                  <div className="od-settings-empty">
+                    Two-factor authentication requires an auth backend.
+                  </div>
+                </div>
+                <div className="od-settings-note">
+                  This orchestrator runs a single agent — account credentials,
+                  password change, and 2FA light up once an auth backend is
+                  connected. The name shown is the live agent identity.
+                </div>
+              </div>
+            ) : null}
+
+            {tab === "tools" ? (
+              <div className="od-settings-section" role="tabpanel">
+                <ToolsTab />
+              </div>
+            ) : null}
+
+            {tab === "users" ? (
+              <div className="od-settings-section" role="tabpanel">
+                <UsersTab models={models} />
+              </div>
+            ) : null}
+
+            {tab === "system" ? (
+              <div className="od-settings-section" role="tabpanel">
+                <SystemTab servers={servers} />
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Rail button: icon + label, with the divider + admin-section header it
+// closes rendered after it (odysseus settings-sidebar grouping). ──
+function RailButton({
+  item,
+  active,
+  onSelect,
+}: {
+  item: RailItem;
+  active: boolean;
+  onSelect: () => void;
+}): ReactNode {
+  return (
+    <>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={active}
+        className={`od-settings-rail-item${active ? " active" : ""}`}
+        onClick={onSelect}
+      >
+        <span className="od-settings-rail-ico">{item.icon}</span>
+        <span>{item.label}</span>
+      </button>
+      {DIVIDER_AFTER.has(item.id) ? (
+        <div className="od-settings-rail-divider" aria-hidden="true" />
+      ) : null}
+      {item.id === "account" ? (
+        <div className="od-settings-rail-label">Admin</div>
+      ) : null}
+    </>
+  );
+}
+
+// ── Collapsible Local/API endpoint add section (services tab). ──
+function CollapsibleEndpoint({
+  open,
+  onToggle,
+  icon,
+  label,
+  children,
+}: {
+  open: boolean;
+  onToggle: () => void;
+  icon: ReactNode;
+  label: string;
+  children: ReactNode;
+}): ReactNode {
+  return (
+    <div className={`od-set-ep-section${open ? " open" : ""}`}>
+      <button
+        type="button"
+        className="od-set-ep-head"
+        aria-expanded={open}
+        onClick={onToggle}
+      >
+        <span className="od-set-ep-head-ico">{icon}</span>
+        <span>{label}</span>
+        <svg
+          className="od-set-ep-caret"
+          width="11"
+          height="11"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          {/* Right-pointing chevron when collapsed; CSS rotates it to point
+              down (90deg) when the section is .open — matching odysseus's
+              collapsible Local/API rows. */}
+          <polyline points="9 18 15 12 9 6" />
+        </svg>
+      </button>
+      {open ? children : null}
+    </div>
+  );
+}
+
+// ── AI Defaults card: faithful Endpoint/Model selectors, disabled (the eliza
+// runtime owns the model map; no per-endpoint editor is exposed). ──
+function AiCard({
+  icon,
+  title,
+  faded,
+  sub,
+}: {
+  icon: ReactNode;
+  title: string;
+  faded?: string;
+  sub: string;
+}): ReactNode {
+  return (
+    <div className="od-settings-card">
+      <CardTitle icon={icon} faded={faded}>
+        {title}
+      </CardTitle>
+      <Sub>{sub}</Sub>
+      <div className="od-settings-row">
+        <span className="od-settings-label">Endpoint</span>
+        <select className="od-settings-select od-set-inline-select" disabled>
+          <option>—</option>
+        </select>
+      </div>
+      <div className="od-settings-row">
+        <span className="od-settings-label">Model</span>
+        <select className="od-settings-select od-set-inline-select" disabled>
+          <option>—</option>
+        </select>
+      </div>
+    </div>
+  );
+}
+
+// ── Admin: Agent Tools tab (odysseus loadBuiltinTools). Catalogue chrome only;
+// every toggle disabled until a /api/tools backend exists. ──
+function ToolsTab(): ReactNode {
+  const [collapsed, setCollapsed] = useState<Set<string>>(
+    () => new Set(CATEGORY_ORDER),
+  );
+
+  const categories = useMemo(
+    () =>
+      CATEGORY_ORDER.map((cat) => ({
+        cat,
+        tools: TOOL_META.filter((t) => t.cat === cat),
+      })).filter((g) => g.tools.length > 0),
+    [],
+  );
+
+  const toggleCategory = (cat: string): void => {
+    setCollapsed((cur) => {
+      const next = new Set(cur);
+      if (next.has(cat)) next.delete(cat);
+      else next.add(cat);
+      return next;
+    });
+  };
+
+  return (
+    <>
+      <div className="od-settings-card">
+        <CardTitle icon={ICON_WRENCH}>Built-in Tools</CardTitle>
+        <Sub>Enable or disable tools available to the AI agent.</Sub>
+        <div className="od-set-tool-list">
+          {categories.map(({ cat, tools }) => {
+            const isOpen = !collapsed.has(cat);
+            return (
+              <div className="od-set-tool-cat" key={cat}>
+                <button
+                  type="button"
+                  className="od-set-tool-cat-head"
+                  aria-expanded={isOpen}
+                  onClick={() => toggleCategory(cat)}
+                >
+                  <span>{cat}</span>
+                  <span className="od-set-tool-cat-right">
+                    <span className="od-set-tool-cat-count">
+                      0/{tools.length}
+                    </span>
+                    <span className="od-set-tool-cat-chev" data-open={isOpen}>
+                      ▾
+                    </span>
+                  </span>
+                </button>
+                {isOpen ? (
+                  <div className="od-set-tool-cat-body">
+                    {tools.map((t) => (
+                      <div className="od-set-tool-row" key={t.id}>
+                        <div className="od-set-tool-info">
+                          <span className="od-set-tool-name">{t.name}</span>
+                          <span className="od-set-tool-desc">{t.desc}</span>
+                        </div>
+                        <span
+                          className="od-set-tool-ctx"
+                          title="Approximate context tokens used"
+                        >
+                          {t.ctx}
+                        </span>
+                        <label className="od-set-switch">
+                          <input type="checkbox" disabled />
+                          <span className="od-set-slider" />
+                        </label>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <div className="od-settings-note">
+        The tool catalogue is the agent's real built-in tool surface, shown
+        read-only — the eliza runtime exposes no tools-config API to this
+        client, so each toggle is disabled until such a backend exists.
+      </div>
+    </>
+  );
+}
+
+// ── Admin: Users tab (odysseus /api/auth/users). No multi-user auth backend in
+// eliza — full chrome, honest empty/disabled state; the "Allowed models" list
+// is the only real mapping (client.fetchModels). ──
+function UsersTab({ models }: { models: ProviderModelRecord[] }): ReactNode {
+  return (
+    <>
+      <div className="od-settings-card">
+        <CardTitle icon={ICON_USERPLUS}>Registration</CardTitle>
+        <div className="od-settings-row">
+          <div>
+            <div className="od-settings-value">Open signup</div>
+            <Sub>Allow anyone to create an account from the login page</Sub>
+          </div>
+          <label className="od-set-switch" title="Requires an auth backend">
+            <input type="checkbox" disabled />
+            <span className="od-set-slider" />
+          </label>
+        </div>
+      </div>
+      <div className="od-settings-card">
+        <CardTitle icon={ICON_USERS}>Users</CardTitle>
+        <div className="od-settings-empty">No users found</div>
+      </div>
+      <div className="od-settings-card">
+        <CardTitle icon={ICON_USERPLUS}>Add User</CardTitle>
+        <div className="od-set-add-form">
+          <input type="text" placeholder="Username (email)" disabled />
+          <input type="password" placeholder="Password (min 8)" disabled />
+          <label
+            className="od-set-switch-inline"
+            title="Grant full admin access"
+          >
+            <span className="od-set-switch">
+              <input type="checkbox" disabled />
+              <span className="od-set-slider" />
+            </span>
+            Admin
+          </label>
+        </div>
+        <div className="od-settings-actions">
+          <button type="button" className="od-settings-btn-add" disabled>
+            Add User
+          </button>
+          <span className="od-settings-status warn">
+            Auth backend not connected
+          </span>
+        </div>
+      </div>
+      <div className="od-settings-card">
+        <CardTitle icon={ICON_SERVER}>Allowed Models</CardTitle>
+        <Sub>
+          Per-user model allow-lists bind here once an auth backend exists.
+          These are the agent's real available models.
+        </Sub>
+        <div className="od-set-priv-models">
+          {models.length === 0 ? (
+            <span className="od-settings-empty">No models available</span>
+          ) : (
+            models.map((m) => (
+              <label className="od-set-priv-model" key={m.id}>
+                <input type="checkbox" disabled defaultChecked />
+                <span>{m.name}</span>
+              </label>
+            ))
+          )}
+        </div>
+      </div>
+      <div className="od-settings-note">
+        This orchestrator runs a single agent — multi-user management, signup
+        control, and per-user privileges ({PRIV_LABELS.length} feature grants)
+        light up once an auth backend is connected. No users are fabricated.
+      </div>
+    </>
+  );
+}
+
+// ── Admin: System tab (odysseus Data Backup + Danger Zone). No backup/wipe API
+// in eliza — full chrome, every control disabled with an honest reason. ──
+function SystemTab({ servers }: { servers: McpServerStatus[] }): ReactNode {
+  return (
+    <>
+      <div className="od-settings-card">
+        <CardTitle icon={ICON_SERVER}>MCP Servers</CardTitle>
+        {servers.length === 0 ? (
+          <div className="od-settings-empty">No MCP servers configured.</div>
+        ) : (
+          servers.map((s) => (
+            <div className="od-skill-item" key={s.name}>
+              <div className="od-skill-info">
+                <div className="od-skill-name">{s.name}</div>
+                {s.error ? (
+                  <div className="od-skill-desc">{s.error}</div>
+                ) : null}
+              </div>
+              <span className={`od-skill-toggle${s.connected ? " on" : ""}`}>
+                {s.connected ? "Up" : "Down"}
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+      <div className="od-settings-card">
+        <CardTitle icon={ICON_DATABASE}>Data Backup</CardTitle>
+        <Sub>
+          Export or import your user data (memories, presets, settings, skills,
+          preferences) as a JSON file.
+        </Sub>
+        <div className="od-settings-actions">
+          <button type="button" className="od-settings-btn-add" disabled>
+            Export Data
+          </button>
+          <button type="button" className="od-settings-btn-add" disabled>
+            Import Data
+          </button>
+        </div>
+        <span className="od-settings-status warn">
+          Backup endpoints not connected
+        </span>
+      </div>
+      <div className="od-settings-card od-set-danger-card">
+        <h2 className="od-set-card-title od-set-danger-title">Danger Zone</h2>
+        <Sub>
+          Irreversible. Each wipe targets one category — pick exactly what you
+          want gone.
+        </Sub>
+        {WIPE_ROWS.map((row) => (
+          <div className="od-set-wipe-row" key={row.kind}>
+            <div>
+              <div className="od-settings-value">{row.label}</div>
+              <Sub>{row.sub}</Sub>
+            </div>
+            <button type="button" className="od-settings-btn-delete" disabled>
+              Wipe
+            </button>
+          </div>
+        ))}
+      </div>
+      <div className="od-settings-note">
+        Data backup and category wipes are owned by the eliza runtime — no
+        backup/wipe API is exposed to this client, so these controls are shown
+        faithfully but inert. MCP server status above is read live.
+      </div>
+    </>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/SkillsPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/SkillsPanel.tsx
@@ -172,7 +172,12 @@ export function SkillsContent({
       return;
     }
     setExpandedId(s.id);
-    if (sources[s.id]?.content !== undefined || sources[s.id]?.loading) return;
+    // Refetch when never loaded OR a prior load failed; only skip when a load
+    // is in flight or already succeeded (a failed source caches content:"" with
+    // failed:true, so don't treat that empty string as "already loaded").
+    const cached = sources[s.id];
+    if (cached?.loading || (cached?.content !== undefined && !cached.failed))
+      return;
     setSources((prev) => ({
       ...prev,
       [s.id]: { content: "", loading: true, failed: false },
@@ -201,7 +206,14 @@ export function SkillsContent({
     };
     if (expandedId !== s.id) setExpandedId(s.id);
     const existing = sources[s.id];
-    if (existing?.content !== undefined && !existing.loading) {
+    // Only open the editor from cache for a genuinely-loaded source. A failed
+    // load caches content:"" (failed:true); opening that and saving would
+    // overwrite the real SKILL.md with an empty string — so refetch instead.
+    if (
+      existing?.content !== undefined &&
+      !existing.loading &&
+      !existing.failed
+    ) {
       begin(existing.content);
       return;
     }
@@ -499,6 +511,7 @@ export function SkillsContent({
                         type="button"
                         className="od-skills-dropdown-item"
                         onClick={() => startEdit(s)}
+                        disabled={src?.loading || src?.failed}
                       >
                         <SquarePen size={14} />
                         <span>Edit</span>

--- a/plugins/plugin-task-coordinator/src/odysseus/SkillsPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/SkillsPanel.tsx
@@ -1,0 +1,716 @@
+// odysseus skills manager (static/js/skills.js + index.html Skills tab). Lists
+// the agent's skills with a sort/filter toolbar, expandable cards that load +
+// edit the SKILL.md source, and per-card actions (Enable/Disable, Edit, Delete),
+// reusing eliza's skills backend (@elizaos/plugin-agent-skills via the
+// @elizaos/ui client — the REUSED-EXISTING-PLUGIN path).
+//
+// Fidelity note vs odysseus: odysseus models skills as draft/published and
+// surfaces confidence %, uses, audit verdicts, duplicate detection, a sandbox
+// "Test" run and a bulk "Audit all" loop. eliza's skills backend has none of
+// those — its real lifecycle field is `enabled` (a skill is injected into
+// context when enabled), plus an optional security `scanStatus`. So we keep the
+// odysseus card/toolbar/expand/edit/delete surface 1:1 but drive the lifecycle
+// control off the real `enabled` field rather than fabricating a publish state,
+// confidence, uses, test or audit affordances that route nowhere.
+//
+// odysseus unifies Skills into the one "Brain" modal as a tab. To support that
+// without duplicating the whole card surface, the toolbar/search/add/grid body
+// is exported as <SkillsContent /> and reused by MemoryPanel's Skills tab; the
+// standalone SkillsPanel (still opened from the icon rail) wraps that body in
+// the same draggable window chrome the other tool views use.
+
+import type { SkillInfo } from "@elizaos/ui";
+import { client } from "@elizaos/ui";
+import {
+  ChevronDown,
+  Minus,
+  MoreVertical,
+  Plus,
+  Power,
+  PowerOff,
+  Save,
+  SquarePen,
+  Trash2,
+  X,
+} from "lucide-react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+
+type SkillSort = "name" | "status";
+type SkillFilter = "all" | "enabled" | "disabled";
+
+interface SourceState {
+  content: string;
+  loading: boolean;
+  failed: boolean;
+}
+
+function sortSkills(list: SkillInfo[], sort: SkillSort): SkillInfo[] {
+  const next = [...list];
+  if (sort === "status") {
+    // Enabled first, then alpha — surfaces the live (injected) skills on top.
+    next.sort(
+      (a, b) =>
+        Number(b.enabled) - Number(a.enabled) || a.name.localeCompare(b.name),
+    );
+  } else {
+    next.sort((a, b) => a.name.localeCompare(b.name));
+  }
+  return next;
+}
+
+/**
+ * Skills tab body — toolbar + search + add + card grid, with no window chrome
+ * of its own. Rendered both standalone (inside SkillsPanel's window) and inline
+ * as the Brain modal's Skills tab. `onCountChange` lets the host surface the
+ * enabled/total count in the tab label, matching odysseus's #skills-count.
+ */
+export function SkillsContent({
+  active,
+  onClose,
+  onCountChange,
+}: {
+  active: boolean;
+  onClose: () => void;
+  onCountChange?: (enabled: number, total: number) => void;
+}): ReactNode {
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState<SkillSort>("status");
+  const [filter, setFilter] = useState<SkillFilter>("all");
+  const [skills, setSkills] = useState<SkillInfo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [failed, setFailed] = useState(false);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [menuId, setMenuId] = useState<string | null>(null);
+  const [sources, setSources] = useState<Record<string, SourceState>>({});
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [addName, setAddName] = useState("");
+  const [addDesc, setAddDesc] = useState("");
+  const [creating, setCreating] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setFailed(false);
+    void client
+      .getSkills()
+      .then((r) => {
+        setSkills(r.skills);
+        setLoading(false);
+      })
+      .catch(() => {
+        setSkills([]);
+        setLoading(false);
+        setFailed(true);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!active) return;
+    setQuery("");
+    setExpandedId(null);
+    setMenuId(null);
+    setEditingId(null);
+    setConfirmDeleteId(null);
+    setAdding(false);
+    setSources({});
+    inputRef.current?.focus();
+    load();
+  }, [active, load]);
+
+  const enabledCount = skills.filter((s) => s.enabled).length;
+  useEffect(() => {
+    onCountChange?.(enabledCount, skills.length);
+  }, [enabledCount, skills.length, onCountChange]);
+
+  if (!active) return null;
+
+  const q = query.trim().toLowerCase();
+  const matched = q
+    ? skills.filter(
+        (s) =>
+          s.name.toLowerCase().includes(q) ||
+          s.description.toLowerCase().includes(q),
+      )
+    : skills;
+  const byFilter = matched.filter((s) =>
+    filter === "enabled"
+      ? s.enabled
+      : filter === "disabled"
+        ? !s.enabled
+        : true,
+  );
+  const visible = sortSkills(byFilter, sort);
+
+  const toggleEnabled = (s: SkillInfo) => {
+    setMenuId(null);
+    const op = s.enabled ? client.disableSkill(s.id) : client.enableSkill(s.id);
+    void op
+      .then((r) => {
+        setSkills((prev) => prev.map((x) => (x.id === s.id ? r.skill : x)));
+      })
+      .catch(() => {});
+  };
+
+  const toggleExpand = (s: SkillInfo) => {
+    setMenuId(null);
+    setEditingId(null);
+    if (expandedId === s.id) {
+      setExpandedId(null);
+      return;
+    }
+    setExpandedId(s.id);
+    if (sources[s.id]?.content !== undefined || sources[s.id]?.loading) return;
+    setSources((prev) => ({
+      ...prev,
+      [s.id]: { content: "", loading: true, failed: false },
+    }));
+    void client
+      .getSkillSource(s.id)
+      .then((r) => {
+        setSources((prev) => ({
+          ...prev,
+          [s.id]: { content: r.content, loading: false, failed: false },
+        }));
+      })
+      .catch(() => {
+        setSources((prev) => ({
+          ...prev,
+          [s.id]: { content: "", loading: false, failed: true },
+        }));
+      });
+  };
+
+  const startEdit = (s: SkillInfo) => {
+    setMenuId(null);
+    const begin = (content: string) => {
+      setEditDraft(content);
+      setEditingId(s.id);
+    };
+    if (expandedId !== s.id) setExpandedId(s.id);
+    const existing = sources[s.id];
+    if (existing?.content !== undefined && !existing.loading) {
+      begin(existing.content);
+      return;
+    }
+    setSources((prev) => ({
+      ...prev,
+      [s.id]: { content: "", loading: true, failed: false },
+    }));
+    void client
+      .getSkillSource(s.id)
+      .then((r) => {
+        setSources((prev) => ({
+          ...prev,
+          [s.id]: { content: r.content, loading: false, failed: false },
+        }));
+        begin(r.content);
+      })
+      .catch(() => {
+        setSources((prev) => ({
+          ...prev,
+          [s.id]: { content: "", loading: false, failed: true },
+        }));
+      });
+  };
+
+  const saveEdit = (s: SkillInfo) => {
+    setSaving(true);
+    void client
+      .saveSkillSource(s.id, editDraft)
+      .then((r) => {
+        setSources((prev) => ({
+          ...prev,
+          [s.id]: { content: editDraft, loading: false, failed: false },
+        }));
+        setSkills((prev) => prev.map((x) => (x.id === s.id ? r.skill : x)));
+        setEditingId(null);
+        setSaving(false);
+      })
+      .catch(() => setSaving(false));
+  };
+
+  // odysseus's master toggle. eliza has no single "all skills" flag, so this is
+  // wired honestly to the real per-skill backend: ON = every skill enabled;
+  // flipping it bulk-enables (when not all are on) or bulk-disables every skill.
+  const allEnabled = skills.length > 0 && enabledCount === skills.length;
+  const toggleAll = () => {
+    setMenuId(null);
+    const turnOn = !allEnabled;
+    for (const s of skills) {
+      if (s.enabled === turnOn) continue;
+      const op = turnOn ? client.enableSkill(s.id) : client.disableSkill(s.id);
+      void op
+        .then((r) => {
+          setSkills((prev) => prev.map((x) => (x.id === s.id ? r.skill : x)));
+        })
+        .catch(() => {});
+    }
+  };
+
+  const removeSkill = (s: SkillInfo) => {
+    setMenuId(null);
+    void client
+      .deleteSkill(s.id)
+      .then(() => {
+        setSkills((prev) => prev.filter((x) => x.id !== s.id));
+        if (expandedId === s.id) setExpandedId(null);
+        setConfirmDeleteId(null);
+      })
+      .catch(() => setConfirmDeleteId(null));
+  };
+
+  const createSkill = () => {
+    const name = addName.trim();
+    const description = addDesc.trim();
+    if (!name) return;
+    setCreating(true);
+    void client
+      .createSkill(name, description)
+      .then((r) => {
+        setSkills((prev) => [r.skill, ...prev]);
+        setAddName("");
+        setAddDesc("");
+        setAdding(false);
+        setCreating(false);
+      })
+      .catch(() => setCreating(false));
+  };
+
+  return (
+    <>
+      <div className="od-skills-section-head">
+        <span className="od-skills-section-title">Skills</span>
+        <span className="od-skills-section-count">
+          {skills.length} {skills.length === 1 ? "skill" : "skills"}
+        </span>
+        <label className="od-admin-switch od-skills-section-switch">
+          <input
+            type="checkbox"
+            checked={allEnabled}
+            disabled={skills.length === 0}
+            onChange={toggleAll}
+            aria-label={allEnabled ? "Disable all skills" : "Enable all skills"}
+          />
+          <span className="od-admin-slider" />
+        </label>
+      </div>
+
+      <p className="od-skills-desc">
+        Reusable procedures the agent can call via /skill. Enabled skills are
+        injected into chat context when relevant.
+      </p>
+
+      <div className="od-skills-toolbar">
+        <select
+          className="od-skills-select"
+          value={sort}
+          onChange={(e) => {
+            const next = e.target.value;
+            setSort(next === "name" ? "name" : "status");
+          }}
+          aria-label="Sort skills"
+        >
+          <option value="status">Enabled first</option>
+          <option value="name">A-Z</option>
+        </select>
+        <select
+          className="od-skills-select"
+          value={filter}
+          onChange={(e) => {
+            const next = e.target.value;
+            setFilter(
+              next === "enabled"
+                ? "enabled"
+                : next === "disabled"
+                  ? "disabled"
+                  : "all",
+            );
+          }}
+          aria-label="Filter skills"
+        >
+          <option value="all">All skills</option>
+          <option value="enabled">Enabled only</option>
+          <option value="disabled">Disabled only</option>
+        </select>
+        <button
+          type="button"
+          className="od-skills-toolbar-btn"
+          onClick={() => {
+            setAdding((prev) => !prev);
+            setAddName("");
+            setAddDesc("");
+          }}
+          title="Add a new skill"
+        >
+          <Plus size={11} /> New
+        </button>
+      </div>
+
+      <input
+        ref={inputRef}
+        className="od-skills-search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") onClose();
+        }}
+        placeholder="Search skills…"
+        aria-label="Search skills"
+      />
+
+      {adding ? (
+        <div className="od-skills-add">
+          <input
+            className="od-skills-add-input"
+            value={addName}
+            onChange={(e) => setAddName(e.target.value)}
+            placeholder="Skill name (e.g. deploy-to-staging)"
+            aria-label="New skill name"
+          />
+          <textarea
+            className="od-skills-add-textarea"
+            value={addDesc}
+            onChange={(e) => setAddDesc(e.target.value)}
+            placeholder="When should the agent use this skill?"
+            aria-label="New skill description"
+            rows={2}
+          />
+          <div className="od-skills-add-actions">
+            <button
+              type="button"
+              className="od-skills-text-btn"
+              onClick={() => setAdding(false)}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="od-skills-text-btn od-skills-text-btn-primary"
+              onClick={createSkill}
+              disabled={!addName.trim() || creating}
+            >
+              <Plus size={11} /> {creating ? "Creating…" : "Create skill"}
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="od-skills-grid">
+        {visible.length === 0 ? (
+          <div className="od-skills-empty">
+            {loading
+              ? "Loading…"
+              : failed
+                ? "Failed to load skills."
+                : q
+                  ? "No skills match your search."
+                  : "No skills yet. Use the agent and it will auto-extract them, or add one above."}
+          </div>
+        ) : (
+          visible.map((s) => {
+            const expanded = expandedId === s.id;
+            const editing = editingId === s.id;
+            const src = sources[s.id];
+            const confirming = confirmDeleteId === s.id;
+            return (
+              <div
+                className={`od-skills-card${expanded ? " od-skills-card-expanded" : ""}`}
+                key={s.id}
+              >
+                <button
+                  type="button"
+                  className="od-skills-card-main"
+                  onClick={() => toggleExpand(s)}
+                  aria-expanded={expanded}
+                >
+                  <div className="od-skills-content">
+                    <div className="od-skills-titlerow">
+                      <code className="od-skills-name">{s.name}</code>
+                      <span
+                        className={`od-skills-status${s.enabled ? " on" : ""}`}
+                      >
+                        {s.enabled ? "enabled" : "disabled"}
+                      </span>
+                      {s.scanStatus && s.scanStatus !== "clean" ? (
+                        <span
+                          className={`od-skills-scan od-skills-scan-${s.scanStatus}`}
+                          title={`Security scan: ${s.scanStatus}`}
+                        >
+                          {s.scanStatus}
+                        </span>
+                      ) : null}
+                      <ChevronDown
+                        size={12}
+                        className="od-skills-chevron"
+                        aria-hidden="true"
+                      />
+                    </div>
+                    {s.description ? (
+                      <div className="od-skills-desc-line">{s.description}</div>
+                    ) : null}
+                  </div>
+                </button>
+
+                <span className="od-skills-actions">
+                  <button
+                    type="button"
+                    className="od-skills-item-btn"
+                    title="Actions"
+                    aria-label="Skill actions"
+                    onClick={() =>
+                      setMenuId((prev) => (prev === s.id ? null : s.id))
+                    }
+                  >
+                    <MoreVertical size={14} />
+                  </button>
+                  {menuId === s.id ? (
+                    <div className="od-skills-dropdown">
+                      <button
+                        type="button"
+                        className="od-skills-dropdown-item"
+                        onClick={() => toggleEnabled(s)}
+                      >
+                        {s.enabled ? (
+                          <>
+                            <PowerOff size={14} />
+                            <span>Disable</span>
+                          </>
+                        ) : (
+                          <>
+                            <Power size={14} />
+                            <span>Enable</span>
+                          </>
+                        )}
+                      </button>
+                      <button
+                        type="button"
+                        className="od-skills-dropdown-item"
+                        onClick={() => startEdit(s)}
+                      >
+                        <SquarePen size={14} />
+                        <span>Edit</span>
+                      </button>
+                      <button
+                        type="button"
+                        className="od-skills-dropdown-item od-skills-dropdown-danger"
+                        onClick={() => {
+                          setMenuId(null);
+                          setConfirmDeleteId(s.id);
+                          if (expandedId !== s.id) setExpandedId(s.id);
+                        }}
+                      >
+                        <Trash2 size={14} />
+                        <span>Delete</span>
+                      </button>
+                    </div>
+                  ) : null}
+                </span>
+
+                {expanded ? (
+                  <div className="od-skills-preview">
+                    {editing ? (
+                      <textarea
+                        className="od-skills-editor"
+                        spellCheck={false}
+                        value={editDraft}
+                        onChange={(e) => setEditDraft(e.target.value)}
+                        aria-label={`Edit ${s.name} source`}
+                      />
+                    ) : (
+                      <pre>
+                        <code>
+                          {src?.loading
+                            ? "Loading…"
+                            : src?.failed
+                              ? "Failed to load SKILL.md."
+                              : src?.content
+                                ? src.content
+                                : "(empty skill)"}
+                        </code>
+                      </pre>
+                    )}
+
+                    {confirming ? (
+                      <div className="od-skills-confirm">
+                        <span>Delete “{s.name}”? This removes SKILL.md.</span>
+                        <button
+                          type="button"
+                          className="od-skills-text-btn"
+                          onClick={() => setConfirmDeleteId(null)}
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          type="button"
+                          className="od-skills-text-btn od-skills-text-btn-danger"
+                          onClick={() => removeSkill(s)}
+                        >
+                          <Trash2 size={11} /> Delete
+                        </button>
+                      </div>
+                    ) : (
+                      <div className="od-skills-expanded-actions">
+                        <button
+                          type="button"
+                          className="od-skills-text-btn od-skills-text-btn-danger"
+                          onClick={() => setConfirmDeleteId(s.id)}
+                        >
+                          <Trash2 size={11} /> Delete
+                        </button>
+                        <div className="od-skills-action-group">
+                          <button
+                            type="button"
+                            className="od-skills-text-btn"
+                            onClick={() => toggleEnabled(s)}
+                          >
+                            {s.enabled ? (
+                              <>
+                                <PowerOff size={11} /> Disable
+                              </>
+                            ) : (
+                              <>
+                                <Power size={11} /> Enable
+                              </>
+                            )}
+                          </button>
+                          {editing ? (
+                            <button
+                              type="button"
+                              className="od-skills-text-btn od-skills-text-btn-primary"
+                              onClick={() => saveEdit(s)}
+                              disabled={saving}
+                            >
+                              <Save size={11} /> {saving ? "Saving…" : "Save"}
+                            </button>
+                          ) : (
+                            <button
+                              type="button"
+                              className="od-skills-text-btn"
+                              onClick={() => startEdit(s)}
+                              disabled={src?.loading || src?.failed}
+                            >
+                              <SquarePen size={11} /> Edit
+                            </button>
+                          )}
+                        </div>
+                      </div>
+                    )}
+
+                    {editing ? (
+                      <button
+                        type="button"
+                        className="od-skills-edit-cancel"
+                        onClick={() => setEditingId(null)}
+                        title="Discard changes"
+                        aria-label="Discard changes"
+                      >
+                        <X size={11} /> Discard
+                      </button>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </>
+  );
+}
+
+export function SkillsPanel({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}): ReactNode {
+  useEscapeClose(open, onClose);
+  const win = useWindowControls(
+    "win-skills",
+    { w: 560, h: 640 },
+    { label: "Skills", icon: "Zap", onClose },
+  );
+  const [counts, setCounts] = useState<{ enabled: number; total: number }>({
+    enabled: 0,
+    total: 0,
+  });
+  const onCountChange = useCallback((enabled: number, total: number) => {
+    setCounts({ enabled, total });
+  }, []);
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  return (
+    <div
+      className={`od-search-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Skills"
+    >
+      <button
+        type="button"
+        aria-label="Close skills"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel od-skills-panel" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        <div
+          className="od-mem-head od-window-header"
+          onPointerDown={win.onDragStart}
+        >
+          <span className="od-mem-title">Skills</span>
+          <span className="od-mem-stats">
+            {counts.enabled} / {counts.total} enabled
+          </span>
+          <span className="od-mem-head-spacer" />
+          <button
+            type="button"
+            className="od-window-min-btn"
+            onClick={win.minimize}
+            title="Minimize"
+            aria-label="Minimize"
+          >
+            <Minus size={14} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="od-win-close"
+            title="Close"
+            aria-label="Close skills"
+            onClick={onClose}
+          >
+            <X size={14} />
+          </button>
+        </div>
+        <SkillsContent
+          active={open}
+          onClose={onClose}
+          onCountChange={onCountChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/Spinner.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/Spinner.tsx
@@ -1,0 +1,148 @@
+// odysseus spinner.js — the AI "thinking/processing" indicator, ported to a
+// lightweight, pure-presentational React component.
+//
+// Upstream (static/js/spinner.js) is a class that paints one of several
+// animations into a DOM node it owns and tears down via start()/stop()/destroy().
+// The three that actually ship in odysseus' loading UI are:
+//   • `spinner` — ASCII frames ['|','/','-','\\'] cycled at 150 ms ("AI is
+//     processing |"). The export's default `style` is "right" (label then frame).
+//   • `wave`    — block-bar frames ['▁▂▃','▂▃▄', …] cycled the same way.
+//   • `whirlpool` — a canvas spiral ring used by `createWhirlpool()` /
+//     `createLoadingRow()` for list/empty-state loading (`.lib-loading-row`):
+//     a label beside a spinning ring that self-stops once removed from the DOM.
+//
+// Here those map to <Spinner variant>:
+//   • variant omitted / "whirlpool" → the spinning ring (the default odysseus
+//     loading indicator; faithful to createWhirlpool/createLoadingRow). A CSS
+//     conic/border ring is the equivalent of the canvas spiral and stops
+//     painting the instant React unmounts it — same leak-safety guarantee the
+//     upstream `isConnected` check provides.
+//   • "dots" → the ASCII |/-\ frames, cycled at the upstream 150 ms cadence.
+//   • "wave" → the upstream block-bar frames, same cadence.
+//
+// `LoadingRow` is the direct port of `createLoadingRow` / `.lib-loading-row`:
+// a label plus the ring, for swapping in place of a bare "Loading…" string.
+//
+// Pure presentational: no data, no side-effects beyond a frame timer that is
+// cleaned up on unmount. Theme-var coloured; styles live in ODYSSEUS_CSS
+// (returned as cssAdditions), scoped under .odysseus-root.
+
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+
+/** Which animation to render. Omit for the whirlpool ring (odysseus default). */
+export type SpinnerVariant = "dots" | "wave" | "whirlpool";
+
+/** odysseus `animations.spinner` — the ASCII frames, cycled at 150 ms. */
+const DOTS_FRAMES: readonly string[] = ["|", "/", "-", "\\"];
+
+/** odysseus `animations.wave` — block-bar frames (literal glyphs, never escapes). */
+const WAVE_FRAMES: readonly string[] = [
+  "▁▂▃",
+  "▂▃▄",
+  "▃▄▅",
+  "▄▅▆",
+  "▅▆▅",
+  "▆▅▄",
+  "▅▄▃",
+  "▄▃▂",
+  "▃▂▁",
+];
+
+/** Upstream `start(speed = 150)`: frame advance interval, in ms. */
+const FRAME_MS = 150;
+
+/**
+ * Cycle through `frames` at the upstream cadence, returning the current glyph.
+ * The interval is torn down on unmount — the React equivalent of `stop()`.
+ */
+function useFrameCycle(frames: readonly string[]): string {
+  const [index, setIndex] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((current) => (current + 1) % frames.length);
+    }, FRAME_MS);
+    return () => {
+      clearInterval(id);
+    };
+  }, [frames.length]);
+  return frames[index] ?? frames[0] ?? "";
+}
+
+/** The ASCII / block-bar text spinner (`variant: "dots" | "wave"`). */
+function GlyphSpinner({
+  frames,
+  label,
+}: {
+  frames: readonly string[];
+  label?: string;
+}): ReactNode {
+  const frame = useFrameCycle(frames);
+  // odysseus default `style` is "right": message then frame, single space.
+  return (
+    <span
+      className="od-spinner od-spinner-glyph"
+      role="status"
+      aria-live="polite"
+    >
+      {label ? <span className="od-spinner-label">{label}</span> : null}
+      <span className="od-spinner-frame" aria-hidden="true">
+        {frame}
+      </span>
+      {label ? null : <span className="od-sr-only">Loading</span>}
+    </span>
+  );
+}
+
+/** The whirlpool ring (odysseus default loading indicator). Pure CSS. */
+function RingSpinner({ label }: { label?: string }): ReactNode {
+  return (
+    <span
+      className="od-spinner od-spinner-ring"
+      role="status"
+      aria-live="polite"
+    >
+      <span className="od-whirlpool" aria-hidden="true" />
+      {label ? (
+        <span className="od-spinner-label">{label}</span>
+      ) : (
+        <span className="od-sr-only">Loading</span>
+      )}
+    </span>
+  );
+}
+
+/**
+ * The odysseus processing indicator. Omit `variant` (or pass "whirlpool") for
+ * the spinning ring used across odysseus' loading UI; pass "dots" / "wave" for
+ * the ASCII / block-bar text spinners. `label` is shown beside the animation.
+ */
+export function Spinner({
+  variant,
+  label,
+}: {
+  variant?: SpinnerVariant;
+  label?: string;
+}): ReactNode {
+  if (variant === "dots") {
+    return <GlyphSpinner frames={DOTS_FRAMES} label={label} />;
+  }
+  if (variant === "wave") {
+    return <GlyphSpinner frames={WAVE_FRAMES} label={label} />;
+  }
+  return <RingSpinner label={label} />;
+}
+
+/**
+ * odysseus spinner.js `createLoadingRow` / `.lib-loading-row`: a consistent
+ * inline loading row (label + whirlpool ring) for list/empty-state loading.
+ * Drop-in replacement for a bare "Loading…" string in a view body.
+ */
+export function LoadingRow({ label }: { label: string }): ReactNode {
+  return (
+    <div className="od-loading-row">
+      <span>{label}</span>
+      <span className="od-whirlpool" aria-hidden="true" />
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/TasksView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/TasksView.tsx
@@ -1,0 +1,1049 @@
+// odysseus Tasks modal (static/js/tasks.js — "Ongoing Tasks"). Scheduled /
+// background tasks list with status chips + per-task actions: a header
+// (Ongoing Tasks + count + Pause-all toggle), a description line, a toolbar
+// (sort select + Select toggle + search box), category filter chips, a flat
+// list of task cards (icon + title + status badge + Run-now + ⋮ kebab, with an
+// expandable detail revealing meta + last-run result + the prompt/goal), the
+// bulk-select bar, a run-history sub-view, and the live clock footer.
+//
+// elizaMapping: eliza's orchestrator owns real task threads, so this is the
+// REAL-wired path (no fabricated rows). The list is
+// client.listCodingAgentTaskThreads({ limit }); odysseus's status model
+// (active / paused / completed / error) maps onto the orchestrator's richer
+// status union (open / active / waiting_on_user / blocked / validating / done /
+// failed / archived / interrupted) plus the `paused` flag. The status-pill
+// pause/resume + "Pause all" wire to client.pauseOrchestratorTask /
+// resumeOrchestratorTask / pauseAllOrchestratorTasks / resumeAllOrchestratorTasks;
+// delete wires to deleteOrchestratorTask; run-history opens
+// getCodingAgentTaskThread and renders the thread's decision log as runs.
+// odysseus's create-task form, ssh/script action types, cron pickers, and the
+// CalDAV-style onboarding have no eliza backend, so the "Add" tab renders an
+// honest empty placeholder rather than a fake builder. When the orchestrator
+// has zero threads we show odysseus's faithful "No tasks yet" empty state.
+
+import {
+  type CodingAgentOrchestratorStatus,
+  type CodingAgentTaskDecisionRecord,
+  type CodingAgentTaskThread,
+  type CodingAgentTaskThreadDetail,
+  client,
+} from "@elizaos/ui";
+import {
+  Activity,
+  CheckSquare,
+  ListChecks,
+  Minus,
+  MoreVertical,
+  Pause,
+  Play,
+  Plus,
+  Trash2,
+  X,
+  Zap,
+} from "lucide-react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { formatIsoRelative, formatRelativeTime } from "../view-format";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+import { LoadingRow } from "./Spinner";
+
+// odysseus tracks four display states (active / paused / completed / error).
+// Collapse the orchestrator's richer status union + `paused` flag onto them so
+// the chips, sort ranks, and status dots read exactly like odysseus's.
+type DisplayStatus = "active" | "paused" | "completed" | "error";
+
+type SortMode = "recent" | "name" | "status";
+
+type TabId = "tasks" | "activity" | "new";
+
+// odysseus _statusDot colours (tasks.js) — kept as theme vars so the dot
+// inherits the active palette instead of odysseus's literal hex.
+const STATUS_DOT_COLOR: Record<DisplayStatus, string> = {
+  active: "var(--ok)",
+  paused: "var(--orange, #ff9800)",
+  completed: "var(--muted)",
+  error: "var(--red)",
+};
+
+// odysseus _statusRank (tasks.js _renderList) for the "Status" sort.
+const STATUS_RANK: Record<DisplayStatus, number> = {
+  active: 0,
+  paused: 1,
+  completed: 2,
+  error: 3,
+};
+
+// odysseus _CATEGORY_ORDER (tasks.js). We derive a task's category from its
+// orchestrator `kind` instead of odysseus's built-in action names, but keep the
+// same ordering + lowercase chip styling.
+const CATEGORY_ORDER = [
+  "Other",
+  "Coding",
+  "Research",
+  "Review",
+  "Docs",
+  "Ops",
+] as const;
+
+// Map the orchestrator's free-form thread `kind` onto the chip taxonomy. The
+// orchestrator's real kinds are coding-domain ("task" / "coding" / "code" /
+// "research" / "review" / "docs" / "ops"), NOT odysseus's built-in email /
+// calendar / memory action domains — those have no eliza task data, so we do
+// not fabricate them. When threads genuinely span >1 category the chip row
+// appears (CATEGORY_ORDER guard, identical to odysseus tasks.js:593); when a
+// user's threads all share one kind it collapses to a single "Other" group and
+// the row hides, exactly as odysseus does for a homogeneous task list.
+const KIND_CATEGORY: Record<string, (typeof CATEGORY_ORDER)[number]> = {
+  task: "Other",
+  coding: "Coding",
+  code: "Coding",
+  build: "Coding",
+  feature: "Coding",
+  bug: "Coding",
+  bugfix: "Coding",
+  fix: "Coding",
+  research: "Research",
+  investigate: "Research",
+  explore: "Research",
+  review: "Review",
+  audit: "Review",
+  docs: "Docs",
+  doc: "Docs",
+  documentation: "Docs",
+  ops: "Ops",
+  devops: "Ops",
+  infra: "Ops",
+  deploy: "Ops",
+};
+
+function categoryFor(thread: CodingAgentTaskThread): string {
+  const key = thread.kind.toLowerCase();
+  return KIND_CATEGORY[key] ?? "Other";
+}
+
+// odysseus's 4-point sparkle (tasks.js:370). Rendered as the exact inline SVG
+// path rather than a lucide glyph so the AI mark matches odysseus pixel-for-pixel.
+function AiMark(): ReactNode {
+  return (
+    <svg
+      className="od-tasks-ai-mark"
+      width="10"
+      height="10"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-label="Uses model"
+      role="img"
+    >
+      <title>Uses model</title>
+      <path d="M12 0L14.59 8.41L23 12L14.59 15.59L12 24L9.41 15.59L1 12L9.41 8.41Z" />
+    </svg>
+  );
+}
+
+// odysseus _taskAiMark (tasks.js:365) — a 4-point sparkle after the name for
+// model-backed tasks. The orchestrator runs every task through a model, but we
+// only show the mark for threads that have actually consumed model tokens, so
+// it reflects real usage rather than a fabricated "uses model" flag.
+function usesModel(thread: CodingAgentTaskThread): boolean {
+  return thread.usage.totalTokens > 0;
+}
+
+function displayStatus(thread: CodingAgentTaskThread): DisplayStatus {
+  if (thread.paused) return "paused";
+  if (thread.status === "failed" || thread.status === "interrupted") {
+    return "error";
+  }
+  // Only genuinely finished states collapse onto "completed". A "blocked"
+  // task is active-but-stuck — it keeps its active badge + pause/history
+  // controls rather than being mislabelled as done.
+  if (thread.status === "done" || thread.status === "archived") {
+    return "completed";
+  }
+  return "active";
+}
+
+// odysseus _scheduleLabel analogue — there are no cron schedules in eliza, so
+// the slim meta line describes the thread instead: kind · priority · repo.
+function metaLine(thread: CodingAgentTaskThread, locale?: string): string {
+  const parts: string[] = [categoryFor(thread)];
+  if (thread.priority !== "normal") parts.push(thread.priority);
+  if (thread.latestRepo) parts.push(thread.latestRepo);
+  if (thread.sessionCount > 0) {
+    parts.push(
+      `${thread.sessionCount} agent${thread.sessionCount === 1 ? "" : "s"}`,
+    );
+  }
+  if (thread.latestActivityAt) {
+    parts.push(`active ${formatRelativeTime(thread.latestActivityAt, locale)}`);
+  } else {
+    parts.push(formatIsoRelative(thread.createdAt, locale, "—"));
+  }
+  return parts.join(" · ");
+}
+
+export function TasksView({
+  open,
+  onClose,
+  locale,
+}: {
+  open: boolean;
+  onClose: () => void;
+  locale?: string;
+}): ReactNode {
+  useEscapeClose(open, onClose);
+  const win = useWindowControls(
+    "win-tasks",
+    { w: 600, h: 760 },
+    { label: "Tasks", icon: "ListChecks", onClose },
+  );
+  const [tab, setTab] = useState<TabId>("tasks");
+  const [threads, setThreads] = useState<CodingAgentTaskThread[]>([]);
+  const [status, setStatus] = useState<CodingAgentOrchestratorStatus | null>(
+    null,
+  );
+  const [fetched, setFetched] = useState(false);
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<SortMode>("recent");
+  const [filter, setFilter] = useState<string | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [selectMode, setSelectMode] = useState(false);
+  const [selected, setSelected] = useState<ReadonlySet<string>>(
+    () => new Set<string>(),
+  );
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [historyFor, setHistoryFor] = useState<CodingAgentTaskThread | null>(
+    null,
+  );
+  const [historyDetail, setHistoryDetail] =
+    useState<CodingAgentTaskThreadDetail | null>(null);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  // Monotonic token so only the most recent history fetch may settle the
+  // loading flag — a fast back-then-reopen (or switch-and-return) can't leave
+  // an intermediate request's resolution stuck on the wrong thread.
+  const historyTokenRef = useRef(0);
+  const [clock, setClock] = useState("");
+
+  const refresh = useCallback(async () => {
+    const [list, st] = await Promise.all([
+      client.listCodingAgentTaskThreads({ limit: 100 }).catch(() => []),
+      client.getOrchestratorStatus().catch(() => null),
+    ]);
+    setThreads(list);
+    setStatus(st);
+    setFetched(true);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    setTab("tasks");
+    setHistoryFor(null);
+    setError(null);
+    void refresh();
+  }, [open, refresh]);
+
+  // odysseus tasks.js _tickClock — a live "Weekday, Mon D, YYYY · HH:MM:SS".
+  useEffect(() => {
+    if (!open) return;
+    const tick = () => {
+      const now = new Date();
+      const day = now.toLocaleDateString(locale, { weekday: "long" });
+      const date = now.toLocaleDateString(locale, {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      });
+      const time = now.toLocaleTimeString(locale, {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+      });
+      setClock(`${day}, ${date} · ${time}`);
+    };
+    tick();
+    const timer = window.setInterval(tick, 1000);
+    return () => window.clearInterval(timer);
+  }, [open, locale]);
+
+  const counts = useMemo(() => {
+    const c: Record<string, number> = {};
+    for (const t of threads) {
+      const cat = categoryFor(t);
+      c[cat] = (c[cat] ?? 0) + 1;
+    }
+    return c;
+  }, [threads]);
+
+  const categories = useMemo(() => {
+    return Object.keys(counts).sort((a, b) => {
+      const ia = CATEGORY_ORDER.indexOf(a as (typeof CATEGORY_ORDER)[number]);
+      const ib = CATEGORY_ORDER.indexOf(b as (typeof CATEGORY_ORDER)[number]);
+      return (ia < 0 ? 99 : ia) - (ib < 0 ? 99 : ib);
+    });
+  }, [counts]);
+
+  const visible = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    const out = threads.filter((t) => {
+      if (filter && categoryFor(t) !== filter) return false;
+      if (q) {
+        const hay =
+          `${t.title} ${t.originalRequest} ${t.summary ?? ""} ${t.kind}`.toLowerCase();
+        if (!hay.includes(q)) return false;
+      }
+      return true;
+    });
+    out.sort((a, b) => {
+      if (sort === "name") return a.title.localeCompare(b.title);
+      if (sort === "status") {
+        const sa = STATUS_RANK[displayStatus(a)];
+        const sb = STATUS_RANK[displayStatus(b)];
+        if (sa !== sb) return sa - sb;
+        return a.title.localeCompare(b.title);
+      }
+      const ia = CATEGORY_ORDER.indexOf(
+        categoryFor(a) as (typeof CATEGORY_ORDER)[number],
+      );
+      const ib = CATEGORY_ORDER.indexOf(
+        categoryFor(b) as (typeof CATEGORY_ORDER)[number],
+      );
+      if (ia !== ib) return (ia < 0 ? 99 : ia) - (ib < 0 ? 99 : ib);
+      return a.title.localeCompare(b.title);
+    });
+    return out;
+  }, [threads, search, filter, sort]);
+
+  const hasActive = threads.some((t) => displayStatus(t) === "active");
+  const hasPaused = threads.some((t) => displayStatus(t) === "paused");
+
+  const runMutation = useCallback(
+    (fn: () => Promise<unknown>, failureMessage: string) => {
+      if (busy) return;
+      setBusy(true);
+      setError(null);
+      void (async () => {
+        let failed = false;
+        try {
+          await fn();
+        } catch {
+          failed = true;
+        }
+        // Always reflect server truth before releasing the busy guard, so the
+        // refetch lands while the controls are still disabled. Don't let a
+        // refresh failure mask a successful mutation.
+        await refresh().catch(() => undefined);
+        if (failed) setError(failureMessage);
+        setBusy(false);
+      })();
+    },
+    [busy, refresh],
+  );
+
+  const toggleAll = () => {
+    if (hasActive) {
+      runMutation(
+        () => client.pauseAllOrchestratorTasks(),
+        "Couldn't pause all tasks.",
+      );
+    } else if (hasPaused) {
+      runMutation(
+        () => client.resumeAllOrchestratorTasks(),
+        "Couldn't resume all tasks.",
+      );
+    }
+  };
+
+  const toggleSelect = (id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const enterSelect = () => {
+    setSelectMode(true);
+    setSelected(new Set<string>());
+  };
+  const exitSelect = () => {
+    setSelectMode(false);
+    setSelected(new Set<string>());
+  };
+
+  const bulkDelete = () => {
+    const ids = [...selected];
+    if (ids.length === 0) return;
+    runMutation(
+      async () => {
+        const results = await Promise.allSettled(
+          ids.map((id) => client.deleteOrchestratorTask(id)),
+        );
+        if (results.some((r) => r.status === "rejected")) {
+          throw new Error("bulk-delete-partial-failure");
+        }
+      },
+      `Couldn't delete ${ids.length === 1 ? "the task" : "some tasks"}.`,
+    );
+    exitSelect();
+  };
+
+  const openHistory = (thread: CodingAgentTaskThread) => {
+    const token = ++historyTokenRef.current;
+    setHistoryFor(thread);
+    setHistoryDetail(null);
+    setHistoryLoading(true);
+    void client
+      .getCodingAgentTaskThread(thread.id)
+      .catch(() => null)
+      .then((detail) => {
+        if (historyTokenRef.current !== token) return;
+        setHistoryDetail(detail);
+        setHistoryLoading(false);
+      });
+  };
+
+  const closeHistory = () => {
+    // Invalidate any in-flight fetch so its resolution can't reopen/spin the
+    // history pane after the user has navigated away.
+    historyTokenRef.current++;
+    setHistoryFor(null);
+    setHistoryDetail(null);
+    setHistoryLoading(false);
+  };
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  return (
+    <div
+      className={`od-search-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Tasks"
+    >
+      <button
+        type="button"
+        aria-label="Close tasks"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div className="od-search-panel od-tasks-panel" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        {/* ── Modal header (tasks.js openTasks .modal-header) ── */}
+        <div
+          className="od-tasks-header od-window-header"
+          onPointerDown={win.onDragStart}
+        >
+          <span className="od-tasks-header-title">
+            <ListChecks size={14} aria-hidden="true" />
+            Tasks
+          </span>
+          <span className="od-tasks-header-spacer" />
+          <button
+            type="button"
+            className="od-window-min-btn"
+            onClick={win.minimize}
+            title="Minimize"
+            aria-label="Minimize"
+          >
+            <Minus size={14} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="od-tasks-close"
+            aria-label="Close tasks"
+            title="Close"
+            onClick={onClose}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        {/* ── Tab bar (.memory-tabs .tasks-tabs) ── */}
+        <div className="od-tasks-tabs" role="tablist">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "tasks"}
+            className={`od-tasks-tab${tab === "tasks" ? " active" : ""}`}
+            onClick={() => setTab("tasks")}
+          >
+            <CheckSquare size={12} aria-hidden="true" />
+            Tasks <span className="od-tasks-tab-count">{threads.length}</span>
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "activity"}
+            className={`od-tasks-tab${tab === "activity" ? " active" : ""}`}
+            onClick={() => setTab("activity")}
+          >
+            <Activity size={12} aria-hidden="true" />
+            Activity
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "new"}
+            className={`od-tasks-tab${tab === "new" ? " active" : ""}`}
+            onClick={() => setTab("new")}
+          >
+            <Plus size={12} aria-hidden="true" />
+            Add
+          </button>
+        </div>
+
+        <div className="od-tasks-body">
+          {historyFor ? (
+            <RunHistory
+              thread={historyFor}
+              detail={historyDetail}
+              loading={historyLoading}
+              locale={locale}
+              onBack={closeHistory}
+            />
+          ) : tab === "tasks" ? (
+            <div className="od-tasks-card">
+              <div className="od-tasks-headrow">
+                <h2 className="od-tasks-h2">
+                  Ongoing Tasks{" "}
+                  <span className="od-tasks-head-count">
+                    {threads.length
+                      ? `${threads.length} task${threads.length === 1 ? "" : "s"}`
+                      : ""}
+                  </span>
+                </h2>
+                <button
+                  type="button"
+                  className="od-tasks-toolbar-btn"
+                  title={
+                    hasActive
+                      ? "Pause every active task"
+                      : "Resume every paused task"
+                  }
+                  disabled={busy || (!hasActive && !hasPaused)}
+                  onClick={toggleAll}
+                >
+                  {hasActive ? (
+                    <Pause size={11} aria-hidden="true" />
+                  ) : (
+                    <Play size={11} aria-hidden="true" />
+                  )}
+                  {hasActive ? "Pause all" : "Resume all"}
+                </button>
+              </div>
+              <p className="od-tasks-desc">
+                Scheduled prompts and actions that run automatically. Results
+                appear in a dedicated session.
+              </p>
+
+              <div className="od-tasks-toolbar">
+                <div className="od-tasks-toolbar-left">
+                  <select
+                    className="od-tasks-sort"
+                    value={sort}
+                    onChange={(e) => setSort(e.target.value as SortMode)}
+                    aria-label="Sort tasks"
+                  >
+                    <option value="recent">Recent</option>
+                    <option value="name">A–Z</option>
+                    <option value="status">Status</option>
+                  </select>
+                  <button
+                    type="button"
+                    className={`od-tasks-toolbar-btn${selectMode ? " active" : ""}`}
+                    title="Select tasks"
+                    onClick={() => (selectMode ? exitSelect() : enterSelect())}
+                  >
+                    {selectMode ? "Cancel" : "Select"}
+                  </button>
+                </div>
+                <input
+                  type="text"
+                  className="od-tasks-search"
+                  placeholder="Search tasks…"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Escape") onClose();
+                  }}
+                  aria-label="Search tasks"
+                />
+              </div>
+
+              {error ? (
+                <div className="od-tasks-error" role="alert">
+                  <span className="od-tasks-error-text">{error}</span>
+                  <button
+                    type="button"
+                    className="od-tasks-error-dismiss"
+                    aria-label="Dismiss error"
+                    title="Dismiss"
+                    onClick={() => setError(null)}
+                  >
+                    <X size={11} />
+                  </button>
+                </div>
+              ) : null}
+
+              {selectMode ? (
+                <div className="od-tasks-bulk-bar">
+                  <label className="od-tasks-bulk-all">
+                    <input
+                      type="checkbox"
+                      checked={
+                        threads.length > 0 &&
+                        threads.every((t) => selected.has(t.id))
+                      }
+                      onChange={(e) => {
+                        if (e.target.checked) {
+                          setSelected(new Set(threads.map((t) => t.id)));
+                        } else {
+                          setSelected(new Set<string>());
+                        }
+                      }}
+                    />{" "}
+                    All
+                  </label>
+                  <span className="od-tasks-bulk-count">
+                    {selected.size} Selected
+                  </span>
+                  <button
+                    type="button"
+                    className="od-tasks-toolbar-btn danger od-tasks-bulk-delete"
+                    disabled={selected.size === 0 || busy}
+                    onClick={bulkDelete}
+                  >
+                    <Trash2 size={11} aria-hidden="true" />
+                    Delete
+                  </button>
+                  <button
+                    type="button"
+                    className="od-tasks-toolbar-btn od-tasks-bulk-cancel"
+                    title="Cancel (Esc)"
+                    onClick={exitSelect}
+                  >
+                    <X size={11} aria-hidden="true" />
+                  </button>
+                </div>
+              ) : null}
+
+              {categories.length > 1 ? (
+                <div className="od-tasks-chips">
+                  <button
+                    type="button"
+                    className={`od-tasks-chip${filter === null ? " active" : ""}`}
+                    onClick={() => setFilter(null)}
+                  >
+                    all ({threads.length})
+                  </button>
+                  {categories.map((cat) => (
+                    <button
+                      type="button"
+                      key={cat}
+                      className={`od-tasks-chip${filter === cat ? " active" : ""}`}
+                      onClick={() => setFilter(filter === cat ? null : cat)}
+                    >
+                      {cat} ({counts[cat]})
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+
+              <div className="od-tasks-list">
+                {!fetched ? (
+                  <div className="od-tasks-empty">
+                    <LoadingRow label="Loading…" />
+                  </div>
+                ) : threads.length === 0 ? (
+                  <div className="od-tasks-empty">
+                    No tasks yet. The orchestrator creates a task thread when
+                    you start a coding job.
+                  </div>
+                ) : visible.length === 0 ? (
+                  <div className="od-tasks-empty">No matching tasks.</div>
+                ) : (
+                  visible.map((thread) => (
+                    <TaskCard
+                      key={thread.id}
+                      thread={thread}
+                      locale={locale}
+                      busy={busy}
+                      expanded={expandedId === thread.id}
+                      selectMode={selectMode}
+                      selected={selected.has(thread.id)}
+                      onToggleExpand={() =>
+                        setExpandedId((cur) =>
+                          cur === thread.id ? null : thread.id,
+                        )
+                      }
+                      onToggleSelect={() => toggleSelect(thread.id)}
+                      onPause={() =>
+                        runMutation(
+                          () => client.pauseOrchestratorTask(thread.id),
+                          "Couldn't pause the task.",
+                        )
+                      }
+                      onResume={() =>
+                        runMutation(
+                          () => client.resumeOrchestratorTask(thread.id),
+                          "Couldn't resume the task.",
+                        )
+                      }
+                      onDelete={() =>
+                        runMutation(
+                          () => client.deleteOrchestratorTask(thread.id),
+                          "Couldn't delete the task.",
+                        )
+                      }
+                      onHistory={() => openHistory(thread)}
+                    />
+                  ))
+                )}
+              </div>
+            </div>
+          ) : tab === "activity" ? (
+            <div className="od-tasks-card">
+              <h2 className="od-tasks-h2">Activity</h2>
+              <p className="od-tasks-desc">
+                A running log of finished task runs. Open a task and view its
+                history to see its decision-by-decision activity.
+              </p>
+              <div className="od-tasks-list">
+                {status && status.sessionCount > 0 ? (
+                  <div className="od-tasks-empty">
+                    {status.activeSessionCount} active · {status.sessionCount}{" "}
+                    total agent sessions across {status.taskCount} task
+                    {status.taskCount === 1 ? "" : "s"}.
+                  </div>
+                ) : (
+                  <div className="od-tasks-empty">No activity yet.</div>
+                )}
+              </div>
+            </div>
+          ) : (
+            <div className="od-tasks-card">
+              <h2 className="od-tasks-h2">Add a task</h2>
+              <p className="od-tasks-desc">
+                Tasks are created by the orchestrator when you send it a coding
+                job from the chat. There is no scheduled-task builder yet.
+              </p>
+              <div className="od-tasks-add-empty">
+                <Zap size={18} aria-hidden="true" />
+                <span>Start a task by messaging the orchestrator.</span>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="od-tasks-clock">{clock}</div>
+      </div>
+    </div>
+  );
+}
+
+function TaskCard({
+  thread,
+  locale,
+  busy,
+  expanded,
+  selectMode,
+  selected,
+  onToggleExpand,
+  onToggleSelect,
+  onPause,
+  onResume,
+  onDelete,
+  onHistory,
+}: {
+  thread: CodingAgentTaskThread;
+  locale?: string;
+  busy: boolean;
+  expanded: boolean;
+  selectMode: boolean;
+  selected: boolean;
+  onToggleExpand: () => void;
+  onToggleSelect: () => void;
+  onPause: () => void;
+  onResume: () => void;
+  onDelete: () => void;
+  onHistory: () => void;
+}): ReactNode {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const ds = displayStatus(thread);
+  const runnable = ds !== "completed";
+
+  const detailMeta: string[] = [];
+  if (thread.latestWorkdir) detailMeta.push(`→ ${thread.latestWorkdir}`);
+  if (thread.decisionCount > 0) {
+    detailMeta.push(
+      `${thread.decisionCount} decision${thread.decisionCount === 1 ? "" : "s"}`,
+    );
+  }
+  if (thread.usage.totalTokens > 0) {
+    detailMeta.push(`${thread.usage.totalTokens} tok`);
+  }
+
+  return (
+    <div
+      className={`od-tasks-item${ds === "paused" ? " task-paused" : ""}${
+        selected ? " selected" : ""
+      }${expanded ? " expanded" : ""}`}
+      data-id={thread.id}
+    >
+      <div className="od-tasks-item-content">
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: the title row mirrors odysseus's expand-on-click card; the kebab + status pill within it are real buttons. */}
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: same — odysseus card row is click-to-expand. */}
+        <div
+          className="od-tasks-item-title-row"
+          onClick={() => {
+            if (selectMode) onToggleSelect();
+            else onToggleExpand();
+          }}
+        >
+          {selectMode ? (
+            <input
+              type="checkbox"
+              className="od-tasks-select-cb"
+              checked={selected}
+              onChange={onToggleSelect}
+              onClick={(e) => e.stopPropagation()}
+              aria-label={`Select ${thread.title}`}
+            />
+          ) : null}
+          <span className="od-tasks-item-icon" aria-hidden="true">
+            <ListChecks size={13} />
+          </span>
+          <span className="od-tasks-item-title">{thread.title}</span>
+          {usesModel(thread) ? <AiMark /> : null}
+          <span className="od-tasks-item-flex" />
+          {ds === "paused" ? (
+            <button
+              type="button"
+              className="od-tasks-status-badge od-tasks-paused-badge"
+              title="Paused — click to resume"
+              disabled={busy}
+              onClick={(e) => {
+                e.stopPropagation();
+                onResume();
+              }}
+            >
+              <Play size={10} aria-hidden="true" />
+              <span className="od-tasks-state-label">paused</span>
+            </button>
+          ) : ds === "active" ? (
+            <button
+              type="button"
+              className="od-tasks-status-badge od-tasks-active-badge"
+              title="Active — click to pause"
+              disabled={busy}
+              onClick={(e) => {
+                e.stopPropagation();
+                onPause();
+              }}
+            >
+              <Pause size={10} aria-hidden="true" />
+              <span className="od-tasks-state-label">active</span>
+            </button>
+          ) : ds === "error" ? (
+            <span className="od-tasks-status-badge od-tasks-error-badge">
+              error
+            </span>
+          ) : (
+            <span className="od-tasks-status-badge od-tasks-done-badge">
+              done
+            </span>
+          )}
+          {/* Row chrome: in real odysseus the History badge + ⋮ kebab sit
+              right of the status pill and are always-on (not hover-only), so
+              .od-tasks-item-actions is visible at rest — see cssAdditions. */}
+          <div className="od-tasks-item-actions">
+            {runnable ? (
+              <button
+                type="button"
+                className="od-tasks-status-badge od-tasks-run-badge"
+                title="Run history"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onHistory();
+                }}
+              >
+                <Activity size={10} />
+                <span>History</span>
+              </button>
+            ) : null}
+            <div className="od-tasks-menu-wrap">
+              <button
+                type="button"
+                className="od-tasks-menu-btn"
+                title="Actions"
+                aria-label="Task actions"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setMenuOpen((v) => !v);
+                }}
+              >
+                <MoreVertical size={14} />
+              </button>
+              {menuOpen ? (
+                <div className="od-tasks-menu" role="menu">
+                  {ds === "active" ? (
+                    <button
+                      type="button"
+                      className="od-tasks-menu-item"
+                      onClick={() => {
+                        setMenuOpen(false);
+                        onPause();
+                      }}
+                    >
+                      <Pause size={12} /> Pause
+                    </button>
+                  ) : ds === "paused" ? (
+                    <button
+                      type="button"
+                      className="od-tasks-menu-item"
+                      onClick={() => {
+                        setMenuOpen(false);
+                        onResume();
+                      }}
+                    >
+                      <Play size={12} /> Resume
+                    </button>
+                  ) : null}
+                  <button
+                    type="button"
+                    className="od-tasks-menu-item"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      onHistory();
+                    }}
+                  >
+                    <Activity size={12} /> History
+                  </button>
+                  <button
+                    type="button"
+                    className="od-tasks-menu-item danger"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      onDelete();
+                    }}
+                  >
+                    <Trash2 size={12} /> Delete
+                  </button>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        <div className="od-tasks-item-meta">{metaLine(thread, locale)}</div>
+
+        {expanded ? (
+          <div className="od-tasks-item-detail">
+            {detailMeta.length ? (
+              <div className="od-tasks-item-detail-meta">
+                {detailMeta.join(" · ")}
+              </div>
+            ) : null}
+            {thread.summary ? (
+              <div
+                className={`od-tasks-item-result${
+                  ds === "error" ? " error" : ""
+                }`}
+              >
+                <span className="od-tasks-item-result-mark">
+                  {ds === "error" ? "✗" : "✓"}
+                </span>{" "}
+                <span className="od-tasks-item-result-text">
+                  {thread.summary}
+                </span>
+              </div>
+            ) : null}
+            <div className="od-tasks-item-desc">{thread.originalRequest}</div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function RunHistory({
+  thread,
+  detail,
+  loading,
+  locale,
+  onBack,
+}: {
+  thread: CodingAgentTaskThread;
+  detail: CodingAgentTaskThreadDetail | null;
+  loading: boolean;
+  locale?: string;
+  onBack: () => void;
+}): ReactNode {
+  const runs: CodingAgentTaskDecisionRecord[] = detail?.decisions ?? [];
+  return (
+    <div className="od-tasks-card">
+      <div className="od-tasks-history-header">
+        <button type="button" className="od-tasks-btn" onClick={onBack}>
+          ← Back
+        </button>
+        <span className="od-tasks-history-title">
+          {thread.title} — Run history
+        </span>
+      </div>
+      {loading ? (
+        <div className="od-tasks-empty">
+          <LoadingRow label="Loading…" />
+        </div>
+      ) : runs.length === 0 ? (
+        <div className="od-tasks-empty">No runs yet.</div>
+      ) : (
+        <div className="od-tasks-runs-list">
+          {runs.map((run) => {
+            const isErr = run.decision === "error" || run.decision === "failed";
+            return (
+              <div
+                key={run.id}
+                className={`od-tasks-run-item${isErr ? " error" : ""}`}
+              >
+                <div className="od-tasks-run-header">
+                  <span
+                    className="od-tasks-run-dot"
+                    style={{
+                      background: isErr
+                        ? STATUS_DOT_COLOR.error
+                        : STATUS_DOT_COLOR.active,
+                    }}
+                  />
+                  <span>{run.decision || run.event}</span>
+                  <span className="od-tasks-run-time">
+                    {formatRelativeTime(run.timestamp, locale)}
+                  </span>
+                </div>
+                <div className="od-tasks-run-result">
+                  {run.reasoning || run.promptText || "—"}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/ThemeMenu.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/ThemeMenu.tsx
@@ -1,0 +1,1523 @@
+// odysseus theme picker (static/js/theme.js theme grid + static/js/colorPicker.js
+// + the harmony/import-export rows from initThemeUI). An anchored popover of the
+// 16 built-in presets; each swatch previews its bg/panel + accent. Picking one
+// applies it (buildThemeVars) and persists. Below the grid: font, density,
+// background-pattern pills, the five custom-colour rows (each opening odysseus's
+// IN-HOUSE HSV picker — hue strip + sat/val square + hex input + recent colours
+// + harmony suggestions, ported 1:1 from colorPicker.js, NO native
+// <input type=color>), the collapsible "More Colors" advanced editor (the 13
+// ADV_KEYS grouped Chat Bubbles / Sidebar / Input / Code / Controls, each row a
+// swatch + per-key reset that tracks the computed default, plus a "Clear
+// Advanced Overrides" button), a colour-harmony generator (generateHarmonyColors:
+// complementary / analogous / triadic / monochromatic from an accent + light/
+// dark mode), and JSON theme import/export.
+//
+// Base-colour writeback flows through onCustomChange(key, hex); advanced-colour
+// writeback flows through onAdvancedChange(key, hex) / onClearAdvanced(), so the
+// parent's single custom-palette pipeline (OdysseusShell setCustomColors →
+// writePref(customTheme) → setThemeName("custom")) stays the only source of
+// truth. Per-key reset compares the live value to the *reference* theme (the
+// active preset/custom theme) for base keys and to computeAdvancedDefaults() for
+// advanced keys, matching theme.js syncResetButtons. Recent colours are the
+// picker's own local pref (storage.ts NS), the only persistence this component
+// owns. Pure client-side, visual-only.
+
+import {
+  ChevronRight,
+  Download,
+  Minus,
+  Pipette,
+  RotateCcw,
+  Upload,
+  Wand2,
+  X,
+} from "lucide-react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import {
+  ODYSSEUS_THEMES,
+  type ThemeDensity,
+  type ThemeFont,
+  type ThemeName,
+  type ThemePalette,
+} from "./odysseus-theme";
+import { ResizeHandles } from "./ResizeHandles";
+import { readPref, writePref } from "./util/storage";
+
+// theme.js renderThemeGrid label mapping — preset keys render lowercase, with
+// two special cases: the internal "dark" theme shows as "original" and "gpt"
+// shows as "GPT". Custom themes keep their slug verbatim.
+function themeLabel(name: string): string {
+  if (name === "dark") return "original";
+  if (name === "gpt") return "GPT";
+  return name;
+}
+
+// theme.js initThemeUI tab strip — Browse themes vs Customize.
+type ThemeTab = "themes" | "customize";
+
+const FONTS: ThemeFont[] = ["mono", "sans", "serif"];
+const DENSITIES: ThemeDensity[] = ["compact", "comfortable", "spacious"];
+// theme.js MAX_CUSTOM_THEMES — must mirror the OdysseusShell saveCustomTheme cap.
+const MAX_CUSTOM_THEMES = 8;
+type CustomKey = "bg" | "fg" | "panel" | "border" | "red";
+const CUSTOM_KEYS: CustomKey[] = ["bg", "fg", "panel", "border", "red"];
+const BG_PATTERNS = [
+  "none",
+  "dots",
+  "sparkles",
+  "petals",
+  "rain",
+  "constellations",
+  "embers",
+  "synapse",
+  "perlin",
+] as const;
+
+// Recent-colours pref (colorPicker.js LS_RECENT 'odysseus-recent-colors'); owned
+// by this view, not part of the shared PREF_KEYS table.
+const RECENT_COLORS_KEY = "recent-colors";
+const MAX_RECENT = 12;
+
+// Preview swatch order matches theme.js harmony-preview: bg, panel, fg, border, red.
+const PREVIEW_KEYS: CustomKey[] = ["bg", "panel", "fg", "border", "red"];
+
+// Advanced "More Colors" editor (theme.js ADV_KEYS), grouped exactly as the
+// odysseus index.html #themeAdvanced section. Each key maps to a CSS var the
+// expanded buildThemeVars emits (see odysseus-theme.ts). Ported 1:1.
+type AdvKey =
+  | "userBubbleBg"
+  | "aiBubbleBg"
+  | "bubbleBorder"
+  | "sidebarBg"
+  | "brandColor"
+  | "hamburgerColor"
+  | "inputBg"
+  | "inputBorder"
+  | "sendBtnBg"
+  | "sendBtnHover"
+  | "codeBg"
+  | "codeFg"
+  | "toggleActive";
+
+interface AdvKeyDef {
+  key: AdvKey;
+  label: string;
+  group: string;
+}
+
+const ADV_KEYS: AdvKeyDef[] = [
+  { key: "userBubbleBg", label: "User Chat Bubble", group: "Chat Bubbles" },
+  { key: "aiBubbleBg", label: "AI Chat Bubble", group: "Chat Bubbles" },
+  { key: "bubbleBorder", label: "Border Chat Bubble", group: "Chat Bubbles" },
+  { key: "sidebarBg", label: "Sidebar Bg", group: "Sidebar" },
+  { key: "brandColor", label: "Odysseus Logo", group: "Sidebar" },
+  { key: "hamburgerColor", label: "Hamburger Menu", group: "Sidebar" },
+  { key: "inputBg", label: "Input Bg", group: "Chat Input / Prompt Area" },
+  {
+    key: "inputBorder",
+    label: "Input Border",
+    group: "Chat Input / Prompt Area",
+  },
+  { key: "sendBtnBg", label: "Send Btn", group: "Chat Input / Prompt Area" },
+  {
+    key: "sendBtnHover",
+    label: "Send Hover",
+    group: "Chat Input / Prompt Area",
+  },
+  { key: "codeBg", label: "Code Bg", group: "Code Blocks" },
+  { key: "codeFg", label: "Code Text", group: "Code Blocks" },
+  { key: "toggleActive", label: "Toggle On", group: "Controls" },
+];
+
+// Stable group order (Map preserves insertion; ADV_KEYS is already grouped).
+const ADV_GROUP_ORDER = [
+  "Chat Bubbles",
+  "Sidebar",
+  "Chat Input / Prompt Area",
+  "Code Blocks",
+  "Controls",
+];
+
+type AdvancedPalette = Partial<Record<AdvKey, string>>;
+
+// Customize-tab "Colors" card order + labels (index.html L466-473). The
+// odysseus base grid also carries a "Sidebar" row that writes to the advanced
+// `sidebarBg` key (there is no base CUSTOM_KEY for it), so it is rendered as an
+// advanced-backed row inline with the base colour rows.
+interface ColorRowDef {
+  kind: "base" | "adv";
+  baseKey?: CustomKey;
+  advKey?: AdvKey;
+  label: string;
+}
+const COLORS_CARD_ROWS: ColorRowDef[] = [
+  { kind: "base", baseKey: "bg", label: "Background" },
+  { kind: "base", baseKey: "fg", label: "Text" },
+  { kind: "base", baseKey: "panel", label: "Panel" },
+  { kind: "adv", advKey: "sidebarBg", label: "Sidebar" },
+  { kind: "base", baseKey: "border", label: "Border" },
+  { kind: "base", baseKey: "red", label: "Accent" },
+];
+
+const HARMONY_TYPES = [
+  "complementary",
+  "analogous",
+  "triadic",
+  "monochromatic",
+] as const;
+type HarmonyType = (typeof HARMONY_TYPES)[number];
+type HarmonyMode = "dark" | "light";
+
+function toHarmonyType(value: string): HarmonyType {
+  const match = HARMONY_TYPES.find((t) => t === value);
+  return match ?? "complementary";
+}
+
+function toHarmonyMode(value: string): HarmonyMode {
+  return value === "light" ? "light" : "dark";
+}
+
+const HEX6 = /^#[0-9a-f]{6}$/i;
+
+// ── Colour maths (colorPicker.js + theme.js, ported 1:1) ──────────────────
+function clamp(v: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, v));
+}
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+interface Hsv {
+  h: number;
+  s: number;
+  v: number;
+}
+
+function hexToRgb(hex: string): Rgb {
+  let h = hex.replace("#", "");
+  if (h.length === 3) {
+    h = h
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
+  if (!/^[0-9a-f]{6}$/i.test(h)) return { r: 0, g: 0, b: 0 };
+  const n = Number.parseInt(h, 16);
+  return { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
+}
+
+function rgbToHex(r: number, g: number, b: number): string {
+  return `#${[r, g, b]
+    .map((v) =>
+      Math.round(clamp(v, 0, 255))
+        .toString(16)
+        .padStart(2, "0"),
+    )
+    .join("")}`;
+}
+
+function rgbToHsv(r0: number, g0: number, b0: number): Hsv {
+  const r = r0 / 255;
+  const g = g0 / 255;
+  const b = b0 / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const d = max - min;
+  const s = max === 0 ? 0 : d / max;
+  const v = max;
+  let h: number;
+  if (d === 0) h = 0;
+  else if (max === r) h = (g - b) / d + (g < b ? 6 : 0);
+  else if (max === g) h = (b - r) / d + 2;
+  else h = (r - g) / d + 4;
+  return { h: h * 60, s: s * 100, v: v * 100 };
+}
+
+function hsvToRgb(h0: number, s0: number, v0: number): Rgb {
+  const h = (((h0 % 360) + 360) % 360) / 60;
+  const s = s0 / 100;
+  const v = v0 / 100;
+  const i = Math.floor(h);
+  const f = h - i;
+  const p = v * (1 - s);
+  const q = v * (1 - f * s);
+  const t = v * (1 - (1 - f) * s);
+  let r: number;
+  let g: number;
+  let b: number;
+  switch (i % 6) {
+    case 0:
+      r = v;
+      g = t;
+      b = p;
+      break;
+    case 1:
+      r = q;
+      g = v;
+      b = p;
+      break;
+    case 2:
+      r = p;
+      g = v;
+      b = t;
+      break;
+    case 3:
+      r = p;
+      g = q;
+      b = v;
+      break;
+    case 4:
+      r = t;
+      g = p;
+      b = v;
+      break;
+    default:
+      r = v;
+      g = p;
+      b = q;
+      break;
+  }
+  return {
+    r: Math.round(r * 255),
+    g: Math.round(g * 255),
+    b: Math.round(b * 255),
+  };
+}
+
+function hsvToHex(h: number, s: number, v: number): string {
+  const { r, g, b } = hsvToRgb(h, s, v);
+  return rgbToHex(r, g, b);
+}
+
+function hexToHsv(hex: string): Hsv {
+  const { r, g, b } = hexToRgb(hex);
+  return rgbToHsv(r, g, b);
+}
+
+// theme.js hexToHSL → [h(0..360), s(0..100), l(0..100)]
+function hexToHsl(hex: string): [number, number, number] {
+  const { r: r0, g: g0, b: b0 } = hexToRgb(hex);
+  const r = r0 / 255;
+  const g = g0 / 255;
+  const b = b0 / 255;
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const l = (max + min) / 2;
+  let h = 0;
+  let s = 0;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    if (max === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+    else if (max === g) h = ((b - r) / d + 2) / 6;
+    else h = ((r - g) / d + 4) / 6;
+  }
+  return [h * 360, s * 100, l * 100];
+}
+
+// theme.js hslToHex
+function hslToHex(h0: number, s0: number, l0: number): string {
+  const h = ((h0 % 360) + 360) % 360;
+  const s = clamp(s0, 0, 100) / 100;
+  const l = clamp(l0, 0, 100) / 100;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number): number => {
+    const k = (n + h / 30) % 12;
+    return l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1));
+  };
+  const toHex = (v: number): string =>
+    Math.round(v * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${toHex(f(0))}${toHex(f(8))}${toHex(f(4))}`;
+}
+
+// theme.js generateHarmonyColors → the five base colours (no advanced).
+function generateHarmonyColors(
+  accentHex: string,
+  harmonyType: HarmonyType,
+  mode: HarmonyMode,
+): ThemePalette {
+  const [h, s] = hexToHsl(accentHex);
+  const isDark = mode === "dark";
+
+  let bgH: number;
+  let bgS: number;
+  let bgL: number;
+  let fgS: number;
+  let fgL: number;
+  let panelL: number;
+  let borderH: number;
+  let borderS: number;
+  let borderL: number;
+
+  if (harmonyType === "complementary") {
+    bgH = h;
+    bgS = Math.max(s * 0.15, 3);
+    bgL = isDark ? 13 : 95;
+    fgL = isDark ? 85 : 15;
+    fgS = Math.max(s * 0.2, 5);
+    panelL = isDark ? 8 : 98;
+    borderH = h;
+    borderS = Math.max(s * 0.25, 8);
+    borderL = isDark ? 28 : 75;
+  } else if (harmonyType === "analogous") {
+    bgH = (h - 30 + 360) % 360;
+    bgS = Math.max(s * 0.12, 3);
+    bgL = isDark ? 14 : 95;
+    fgL = isDark ? 84 : 18;
+    fgS = Math.max(s * 0.15, 5);
+    panelL = isDark ? 9 : 97;
+    borderH = (h + 30) % 360;
+    borderS = Math.max(s * 0.3, 10);
+    borderL = isDark ? 30 : 72;
+  } else if (harmonyType === "triadic") {
+    bgH = (h + 240) % 360;
+    bgS = Math.max(s * 0.1, 2);
+    bgL = isDark ? 13 : 96;
+    fgL = isDark ? 86 : 14;
+    fgS = Math.max(s * 0.18, 5);
+    panelL = isDark ? 8 : 99;
+    borderH = (h + 120) % 360;
+    borderS = Math.max(s * 0.2, 8);
+    borderL = isDark ? 28 : 74;
+  } else {
+    bgH = h;
+    bgS = Math.max(s * 0.08, 2);
+    bgL = isDark ? 12 : 96;
+    fgL = isDark ? 87 : 13;
+    fgS = Math.max(s * 0.15, 5);
+    panelL = isDark ? 7 : 99;
+    borderH = h;
+    borderS = Math.max(s * 0.2, 6);
+    borderL = isDark ? 26 : 76;
+  }
+
+  return {
+    bg: hslToHex(bgH, bgS, bgL),
+    fg: hslToHex(h, fgS, fgL),
+    panel: hslToHex(bgH, bgS * 0.6, panelL),
+    border: hslToHex(borderH, borderS, borderL),
+    red: accentHex,
+  };
+}
+
+// theme.js computeAdvancedDefaults — the value each advanced key falls back to
+// when there is no override. Derives codeBg/codeFg the same way applyColors'
+// deriveSyntaxColors does (bg luminance ±4), so the advanced editor's swatches
+// track the base palette exactly. Ported 1:1.
+function computeAdvancedDefaults(c: ThemePalette): Record<AdvKey, string> {
+  const [bgH, bgS, bgL] = hexToHsl(c.bg);
+  const isDark = bgL < 50;
+  const codeBgL = isDark ? Math.max(bgL - 4, 0) : Math.min(bgL + 4, 100);
+  const red = HEX6.test(c.red) ? c.red : "#e06c75";
+  return {
+    userBubbleBg: c.bg,
+    aiBubbleBg: c.panel,
+    bubbleBorder: c.border,
+    sidebarBg: c.panel,
+    brandColor: red,
+    hamburgerColor: c.fg,
+    inputBg: c.panel,
+    inputBorder: c.border,
+    sendBtnBg: red,
+    sendBtnHover: red,
+    codeBg: hslToHex(bgH, bgS, codeBgL),
+    codeFg: c.fg,
+    toggleActive: red,
+  };
+}
+
+// colorPicker.js computeSuggestions — five harmony swatches off the live HSV.
+interface Suggestion {
+  hex: string;
+  label: string;
+}
+function computeSuggestions(h: number, s: number, v: number): Suggestion[] {
+  return [
+    { hex: hsvToHex(h + 180, s, v), label: "Complement" },
+    { hex: hsvToHex(h + 30, s, v), label: "Analogous +30°" },
+    { hex: hsvToHex(h - 30, s, v), label: "Analogous -30°" },
+    { hex: hsvToHex(h + 150, s, v), label: "Split-complement" },
+    {
+      hex: hsvToHex(h, s, clamp(v > 50 ? v - 30 : v + 30, 10, 95)),
+      label: "Tone shift",
+    },
+  ];
+}
+
+function normalizeHex(input: string): string | null {
+  let v = input.trim();
+  if (!v.startsWith("#")) v = `#${v}`;
+  return HEX6.test(v) ? v.toLowerCase() : null;
+}
+
+// ── In-house HSV picker popover (colorPicker.js buildPopover/syncUI/handleDrag) ──
+function ColorPickerPopover({
+  value,
+  recents,
+  onPreview,
+  onCommit,
+  onClose,
+}: {
+  value: string;
+  recents: string[];
+  onPreview: (hex: string) => void;
+  onCommit: (hex: string) => void;
+  onClose: () => void;
+}): ReactNode {
+  const init = hexToHsv(value);
+  const [hsv, setHsv] = useState<Hsv>(init);
+  const [hexText, setHexText] = useState(value);
+  const slRef = useRef<HTMLButtonElement>(null);
+  const hueRef = useRef<HTMLButtonElement>(null);
+  const dragRef = useRef<"sl" | "hue" | null>(null);
+
+  const current = hsvToHex(hsv.h, hsv.s, hsv.v);
+  const pureHue = hsvToHex(hsv.h, 100, 100);
+  const suggestions = computeSuggestions(hsv.h, hsv.s, hsv.v);
+
+  const pushPreview = useCallback(
+    (next: Hsv) => {
+      setHsv(next);
+      const hex = hsvToHex(next.h, next.s, next.v);
+      setHexText(hex);
+      onPreview(hex);
+    },
+    [onPreview],
+  );
+
+  const handleDrag = useCallback(
+    (e: PointerEvent | React.PointerEvent) => {
+      const mode = dragRef.current;
+      if (mode === "sl" && slRef.current) {
+        const r = slRef.current.getBoundingClientRect();
+        const x = clamp((e.clientX - r.left) / r.width, 0, 1);
+        const y = clamp((e.clientY - r.top) / r.height, 0, 1);
+        pushPreview({ h: hsv.h, s: x * 100, v: (1 - y) * 100 });
+      } else if (mode === "hue" && hueRef.current) {
+        const r = hueRef.current.getBoundingClientRect();
+        const x = clamp((e.clientX - r.left) / r.width, 0, 1);
+        pushPreview({ h: x * 360, s: hsv.s, v: hsv.v });
+      }
+    },
+    [hsv.h, hsv.s, hsv.v, pushPreview],
+  );
+
+  // Window-level pointer listeners while dragging (colorPicker.js
+  // _installWindowPointer): a drag started on the square/hue keeps tracking
+  // even when the pointer leaves the element, and commits on release.
+  useEffect(() => {
+    const onMove = (e: PointerEvent): void => {
+      if (dragRef.current) handleDrag(e);
+    };
+    const onUp = (): void => {
+      if (dragRef.current) {
+        dragRef.current = null;
+        onCommit(hsvToHex(hsv.h, hsv.s, hsv.v));
+      }
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+  }, [handleDrag, hsv.h, hsv.s, hsv.v, onCommit]);
+
+  const startDrag = (mode: "sl" | "hue") => (e: React.PointerEvent) => {
+    dragRef.current = mode;
+    handleDrag(e);
+    e.preventDefault();
+  };
+
+  const applyHex = (raw: string): void => {
+    setHexText(raw);
+    const hex = normalizeHex(raw);
+    if (hex) {
+      const v = hexToHsv(hex);
+      setHsv(v);
+      onPreview(hex);
+    }
+  };
+
+  const pickSwatch = (hex: string): void => {
+    const v = hexToHsv(hex);
+    setHsv(v);
+    setHexText(hex);
+    onPreview(hex);
+    onCommit(hex);
+  };
+
+  const eyedrop = useCallback((): void => {
+    const Picker = (
+      window as unknown as {
+        EyeDropper?: new () => { open: () => Promise<{ sRGBHex: string }> };
+      }
+    ).EyeDropper;
+    if (!Picker) return;
+    void new Picker()
+      .open()
+      .then((r) => {
+        const hex = normalizeHex(r.sRGBHex);
+        if (!hex) return;
+        setHsv(hexToHsv(hex));
+        setHexText(hex);
+        onPreview(hex);
+        onCommit(hex);
+      })
+      .catch(() => {
+        // user cancelled the OS eyedropper — no-op
+      });
+  }, [onPreview, onCommit]);
+
+  const eyedropperSupported =
+    typeof window !== "undefined" && "EyeDropper" in window;
+
+  return (
+    <fieldset className="od-cp-popover" aria-label="Colour picker">
+      <button
+        type="button"
+        ref={slRef}
+        className="od-cp-sl"
+        style={{ background: pureHue }}
+        onPointerDown={startDrag("sl")}
+        aria-label="Saturation and value"
+      >
+        <span className="od-cp-sl-white" />
+        <span className="od-cp-sl-black" />
+        <span
+          className="od-cp-sl-handle"
+          style={{ left: `${hsv.s}%`, top: `${100 - hsv.v}%` }}
+        />
+      </button>
+      <button
+        type="button"
+        ref={hueRef}
+        className="od-cp-hue"
+        onPointerDown={startDrag("hue")}
+        aria-label="Hue"
+      >
+        <span
+          className="od-cp-hue-handle"
+          style={{ left: `${(hsv.h / 360) * 100}%` }}
+        />
+      </button>
+      <div className="od-cp-row">
+        <span className="od-cp-preview" style={{ background: current }} />
+        <input
+          className="od-cp-hex"
+          type="text"
+          maxLength={7}
+          spellCheck={false}
+          autoComplete="off"
+          value={hexText}
+          onChange={(e) => applyHex(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              const hex = normalizeHex(hexText);
+              if (hex) onCommit(hex);
+              onClose();
+            }
+            if (e.key === "Escape") onClose();
+          }}
+          aria-label="Hex colour"
+        />
+        <button
+          type="button"
+          className="od-cp-eyedropper"
+          title={
+            eyedropperSupported
+              ? "Eyedropper"
+              : "Eyedropper not supported in this browser"
+          }
+          aria-label="Eyedropper"
+          disabled={!eyedropperSupported}
+          onClick={eyedrop}
+        >
+          <Pipette size={13} />
+        </button>
+      </div>
+      <div className="od-cp-section-label">Suggestions</div>
+      <div className="od-cp-swatches">
+        {suggestions.map((sug) => (
+          <button
+            type="button"
+            key={sug.label}
+            className="od-cp-swatch"
+            title={`${sug.label}: ${sug.hex}`}
+            style={{ background: sug.hex }}
+            onClick={() => pickSwatch(sug.hex)}
+            aria-label={sug.label}
+          />
+        ))}
+      </div>
+      <div className="od-cp-section-label">Recent</div>
+      <div className="od-cp-swatches">
+        {recents.length > 0 ? (
+          recents.map((hex) => (
+            <button
+              type="button"
+              key={hex}
+              className="od-cp-swatch"
+              title={hex}
+              style={{ background: hex }}
+              onClick={() => pickSwatch(hex)}
+              aria-label={`Recent ${hex}`}
+            />
+          ))
+        ) : (
+          <span className="od-cp-recent-empty">(none yet)</span>
+        )}
+      </div>
+    </fieldset>
+  );
+}
+
+export function ThemeMenu({
+  open,
+  current,
+  onPick,
+  onClose,
+  font,
+  density,
+  onSetFont,
+  onSetDensity,
+  custom,
+  onCustomChange,
+  customAdvanced,
+  onAdvancedChange,
+  onClearAdvanced,
+  bgPattern,
+  onSetBg,
+  customThemes,
+  onSaveCustom,
+  onDeleteCustom,
+}: {
+  open: boolean;
+  current: ThemeName;
+  onPick: (name: ThemeName) => void;
+  onClose: () => void;
+  font: ThemeFont;
+  density: ThemeDensity;
+  onSetFont: (font: ThemeFont) => void;
+  onSetDensity: (density: ThemeDensity) => void;
+  custom: ThemePalette;
+  onCustomChange: (key: CustomKey, value: string) => void;
+  /** Current advanced overrides; absent keys fall back to computed defaults. */
+  customAdvanced?: AdvancedPalette;
+  /** Set one advanced override (theme.js adv-<key> input handler). */
+  onAdvancedChange?: (key: AdvKey, value: string) => void;
+  /** Strip all advanced overrides (theme.js #theme-adv-clear). */
+  onClearAdvanced?: () => void;
+  bgPattern: string;
+  onSetBg: (pattern: string) => void;
+  customThemes: Record<string, ThemePalette>;
+  onSaveCustom: (name: string) => void;
+  onDeleteCustom: (name: string) => void;
+}): ReactNode {
+  const [activeTab, setActiveTab] = useState<ThemeTab>("themes");
+  // theme.js theme-opacity-toggle ("Peek") — fades the modal so the page
+  // behind it shows through; only meaningful on the Customize tab.
+  const [peek, setPeek] = useState(false);
+  const [saveName, setSaveName] = useState("");
+  const [saveError, setSaveError] = useState("");
+  const [pickerKey, setPickerKey] = useState<CustomKey | null>(null);
+  const [advPickerKey, setAdvPickerKey] = useState<AdvKey | null>(null);
+  const [advOpen, setAdvOpen] = useState(false);
+  const [recents, setRecents] = useState<string[]>([]);
+  const [harmonyAccent, setHarmonyAccent] = useState(custom.red);
+  const [harmonyType, setHarmonyType] = useState<HarmonyType>("complementary");
+  const [harmonyMode, setHarmonyMode] = useState<HarmonyMode>("dark");
+  const [accentPickerOpen, setAccentPickerOpen] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
+  const [importText, setImportText] = useState("");
+  const [importError, setImportError] = useState("");
+  const [exported, setExported] = useState(false);
+
+  // Centered, draggable + edge-resizable modal window (windowDrag.js /
+  // windowResize.js port), matching the other odysseus tool modals. The theme
+  // popup is the small compact dialog from index.html #theme-popup.
+  useEscapeClose(open, onClose);
+  const win = useWindowControls("win-theme", { w: 520, h: 600 });
+
+  useEffect(() => {
+    if (open) setRecents(readPref<string[]>(RECENT_COLORS_KEY, []));
+  }, [open]);
+
+  // Keep the harmony accent in sync if the base "red" colour changes underneath
+  // us (e.g. the user edits the Accent custom colour while the menu stays
+  // mounted) — otherwise the harmony swatch + Generate preview go stale.
+  useEffect(() => {
+    setHarmonyAccent(custom.red);
+  }, [custom.red]);
+
+  // colorPicker.js addRecent — newest first, deduped, capped at MAX_RECENT.
+  const commitRecent = useCallback((hex: string) => {
+    const norm = normalizeHex(hex);
+    if (!norm) return;
+    setRecents((prev) => {
+      const next = [norm, ...prev.filter((c) => c !== norm)].slice(
+        0,
+        MAX_RECENT,
+      );
+      writePref(RECENT_COLORS_KEY, next);
+      return next;
+    });
+  }, []);
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  const applyPalette = (palette: ThemePalette): void => {
+    for (const key of CUSTOM_KEYS) {
+      onCustomChange(key, palette[key]);
+    }
+  };
+
+  const harmonyPreview = generateHarmonyColors(
+    HEX6.test(harmonyAccent) ? harmonyAccent : "#e06c75",
+    harmonyType,
+    harmonyMode,
+  );
+
+  // ── Advanced editor support ──────────────────────────────────────────────
+  const adv: AdvancedPalette = customAdvanced ?? {};
+  const advDefaults = computeAdvancedDefaults(custom);
+  // The effective swatch value: an override if set, else the computed default.
+  const advValue = (key: AdvKey): string => adv[key] ?? advDefaults[key];
+
+  // Reference palette for per-key reset — the active preset/custom theme you
+  // started from (theme.js refColors). Base resets snap to it; advanced resets
+  // snap to that reference's computed defaults.
+  const refColors: ThemePalette =
+    ODYSSEUS_THEMES[current] ?? customThemes[current] ?? custom;
+  const refAdvDefaults = computeAdvancedDefaults(refColors);
+
+  // theme.js syncResetButtons — a base key is "changed" when it differs from
+  // the reference theme's value; an advanced key when it differs from the
+  // reference theme's computed default.
+  const baseChanged = (key: CustomKey): boolean => {
+    const ref = refColors[key];
+    return (
+      HEX6.test(ref) &&
+      HEX6.test(custom[key]) &&
+      custom[key].toLowerCase() !== ref.toLowerCase()
+    );
+  };
+  const advChanged = (key: AdvKey): boolean => {
+    const ref = refAdvDefaults[key];
+    const cur = advValue(key);
+    return cur.toLowerCase() !== ref.toLowerCase();
+  };
+
+  const resetBase = (key: CustomKey): void => {
+    const ref = refColors[key];
+    if (HEX6.test(ref)) onCustomChange(key, ref);
+  };
+  const resetAdv = (key: AdvKey): void => {
+    onAdvancedChange?.(key, refAdvDefaults[key]);
+  };
+
+  // A single Customize > Colors card row. Base keys (bg/fg/panel/border/red)
+  // write through onCustomChange; the lone advanced-backed row ("Sidebar")
+  // writes through onAdvancedChange so it tracks the same single-pipeline as
+  // the rest of the advanced editor (theme.js wires #adv-sidebarBg the same way).
+  const renderColorRow = (row: ColorRowDef): ReactNode => {
+    if (row.kind === "adv" && row.advKey) {
+      const aKey = row.advKey;
+      const hex = advValue(aKey);
+      const open = advPickerKey === aKey;
+      return (
+        <div key={`adv-${aKey}`} className="od-theme-color-row">
+          <button
+            type="button"
+            className="od-cp-swatch-trigger"
+            style={{ background: hex }}
+            onClick={() =>
+              setAdvPickerKey((cur) => (cur === aKey ? null : aKey))
+            }
+            aria-label={`Edit ${row.label}`}
+            aria-expanded={open}
+          />
+          <span className="od-theme-color-key">{row.label}</span>
+          <span className="od-theme-color-hex">{hex}</span>
+          <button
+            type="button"
+            className={`od-theme-reset-btn${advChanged(aKey) ? " changed" : ""}`}
+            onClick={() => resetAdv(aKey)}
+            disabled={!advChanged(aKey)}
+            title={`Reset ${row.label}`}
+            aria-label={`Reset ${row.label}`}
+          >
+            <RotateCcw size={11} />
+          </button>
+          {open ? (
+            <ColorPickerPopover
+              value={HEX6.test(hex) ? hex : "#000000"}
+              recents={recents}
+              onPreview={(next) => onAdvancedChange?.(aKey, next)}
+              onCommit={(next) => {
+                onAdvancedChange?.(aKey, next);
+                commitRecent(next);
+              }}
+              onClose={() => setAdvPickerKey(null)}
+            />
+          ) : null}
+        </div>
+      );
+    }
+    if (!row.baseKey) return null;
+    const bKey = row.baseKey;
+    const open = pickerKey === bKey;
+    return (
+      <div key={`base-${bKey}`} className="od-theme-color-row">
+        <button
+          type="button"
+          className="od-cp-swatch-trigger"
+          style={{ background: custom[bKey] }}
+          onClick={() => setPickerKey((cur) => (cur === bKey ? null : bKey))}
+          aria-label={`Edit ${row.label}`}
+          aria-expanded={open}
+        />
+        <span className="od-theme-color-key">{row.label}</span>
+        <span className="od-theme-color-hex">{custom[bKey]}</span>
+        <button
+          type="button"
+          className={`od-theme-reset-btn${baseChanged(bKey) ? " changed" : ""}`}
+          onClick={() => resetBase(bKey)}
+          disabled={!baseChanged(bKey)}
+          title={`Reset ${row.label} to ${current}`}
+          aria-label={`Reset ${row.label}`}
+        >
+          <RotateCcw size={11} />
+        </button>
+        {open ? (
+          <ColorPickerPopover
+            value={HEX6.test(custom[bKey]) ? custom[bKey] : "#000000"}
+            recents={recents}
+            onPreview={(hex) => onCustomChange(bKey, hex)}
+            onCommit={(hex) => {
+              onCustomChange(bKey, hex);
+              commitRecent(hex);
+            }}
+            onClose={() => setPickerKey(null)}
+          />
+        ) : null}
+      </div>
+    );
+  };
+
+  // theme.js doSave — name/slug/builtin/limit validation, surfaced inline.
+  const handleSave = (): void => {
+    setSaveError("");
+    const name = saveName.trim();
+    if (!name) {
+      setSaveError("Enter a name.");
+      return;
+    }
+    const slug = name
+      .toLowerCase()
+      .replace(/\s+/g, "-")
+      .replace(/[^a-z0-9-]/g, "");
+    if (!slug) {
+      setSaveError("Invalid name.");
+      return;
+    }
+    if (ODYSSEUS_THEMES[slug]) {
+      setSaveError("Cannot overwrite a built-in theme.");
+      return;
+    }
+    const isNew = !(slug in customThemes);
+    if (isNew && Object.keys(customThemes).length >= MAX_CUSTOM_THEMES) {
+      setSaveError(`Max ${MAX_CUSTOM_THEMES} custom themes. Delete one first.`);
+      return;
+    }
+    onSaveCustom(slug);
+    setSaveName("");
+  };
+
+  const handleExport = (): void => {
+    const name = current || "custom";
+    const obj = { name, colors: custom, font, density, bgPattern };
+    const json = JSON.stringify(obj, null, 2);
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `odysseus_${name}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    setExported(true);
+    window.setTimeout(() => setExported(false), 1500);
+  };
+
+  const handleImport = (): void => {
+    setImportError("");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(importText.trim());
+    } catch {
+      setImportError("Invalid JSON.");
+      return;
+    }
+    if (typeof parsed !== "object" || parsed === null) {
+      setImportError("Invalid theme object.");
+      return;
+    }
+    const root = parsed as Record<string, unknown>;
+    const colorsSource =
+      typeof root.colors === "object" && root.colors !== null
+        ? (root.colors as Record<string, unknown>)
+        : root;
+    const missing = CUSTOM_KEYS.filter(
+      (k) => typeof colorsSource[k] !== "string",
+    );
+    if (missing.length > 0) {
+      setImportError(`Missing: ${missing.join(", ")}`);
+      return;
+    }
+    const palette: ThemePalette = {
+      bg: "",
+      fg: "",
+      panel: "",
+      border: "",
+      red: "",
+    };
+    for (const k of CUSTOM_KEYS) {
+      const raw = colorsSource[k];
+      if (typeof raw !== "string" || !HEX6.test(raw)) {
+        setImportError(`Bad hex for ${k}`);
+        return;
+      }
+      palette[k] = raw;
+    }
+    applyPalette(palette);
+    const rawName = typeof root.name === "string" ? root.name : "imported";
+    const slug =
+      rawName
+        .toLowerCase()
+        .replace(/\s+/g, "-")
+        .replace(/[^a-z0-9-]/g, "") || "imported";
+    if (typeof root.bgPattern === "string") onSetBg(root.bgPattern);
+    onSaveCustom(slug);
+    setImportOpen(false);
+    setImportText("");
+  };
+
+  const customEntries = Object.entries(customThemes);
+
+  // A theme swatch — the coin-stack of four overlapping colour circles
+  // (bg, panel, fg, red) above a centred name (theme.js renderThemeGrid +
+  // style.css .theme-swatch). Used for both preset and custom grids.
+  const renderSwatch = (
+    name: string,
+    palette: ThemePalette,
+    isCustom: boolean,
+  ): ReactNode => (
+    <button
+      type="button"
+      key={name}
+      className={`od-theme-swatch${name === current ? " active" : ""}`}
+      onClick={() => {
+        onPick(name);
+        onClose();
+      }}
+    >
+      <span className="od-theme-swatch-colors">
+        <span style={{ background: palette.bg }} />
+        <span style={{ background: palette.panel }} />
+        <span style={{ background: palette.fg }} />
+        <span style={{ background: palette.red }} />
+      </span>
+      <span className="od-theme-swatch-name">
+        {isCustom ? name : themeLabel(name)}
+      </span>
+      {isCustom ? (
+        <button
+          type="button"
+          className="od-theme-delete-btn"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDeleteCustom(name);
+          }}
+          aria-label={`Delete ${name}`}
+          title="Delete theme"
+        >
+          <X size={11} />
+        </button>
+      ) : null}
+    </button>
+  );
+
+  return (
+    <div
+      className={`od-search-overlay od-theme-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Theme"
+    >
+      <button
+        type="button"
+        className="od-search-backdrop"
+        aria-label="Close theme menu"
+        onClick={onClose}
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+      <div
+        className={`od-search-panel od-theme-panel${peek ? " od-theme-peek" : ""}`}
+        style={win.panelStyle}
+      >
+        <ResizeHandles controls={win} />
+        {/* ── Header (index.html .theme-popup-header) ── */}
+        <div
+          className="od-theme-header od-window-header"
+          onPointerDown={win.onDragStart}
+        >
+          <span className="od-theme-title">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              role="img"
+              aria-label="Theme"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <path d="M12 2a7 7 0 0 0 0 20 4 4 0 0 1 0-8 4 4 0 0 0 0-8" />
+              <circle cx="8" cy="9" r="1.5" fill="currentColor" />
+              <circle cx="15" cy="14" r="1.5" fill="currentColor" />
+              <circle cx="9" cy="15" r="1.5" fill="currentColor" />
+            </svg>
+            Theme
+          </span>
+          {activeTab === "customize" ? (
+            <button
+              type="button"
+              className={`od-theme-peek-btn${peek ? " active" : ""}`}
+              onClick={() => setPeek((v) => !v)}
+              aria-pressed={peek}
+              title="Fade this window to preview the page behind it"
+            >
+              <svg
+                width="11"
+                height="11"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
+              <span className="od-theme-peek-label">Peek</span>
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="od-window-min-btn"
+            onClick={win.minimize}
+            title="Minimize"
+            aria-label="Minimize"
+          >
+            <Minus size={14} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="od-theme-close"
+            onClick={onClose}
+            aria-label="Close theme"
+            title="Close"
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        {/* ── Tab strip (index.html #theme-tabs) ── */}
+        <div className="od-theme-tabs">
+          <button
+            type="button"
+            className={`od-theme-tab${activeTab === "themes" ? " active" : ""}`}
+            onClick={() => setActiveTab("themes")}
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <path d="M12 2a7 7 0 0 0 0 20 4 4 0 0 1 0-8 4 4 0 0 0 0-8" />
+              <circle cx="8" cy="9" r="1.4" fill="currentColor" />
+              <circle cx="15" cy="14" r="1.4" fill="currentColor" />
+              <circle cx="9" cy="15" r="1.4" fill="currentColor" />
+            </svg>
+            Themes
+          </button>
+          <button
+            type="button"
+            className={`od-theme-tab${activeTab === "customize" ? " active" : ""}`}
+            onClick={() => setActiveTab("customize")}
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M9.06 11.9l-3.5 3.5a2.85 2.85 0 1 0 4.03 4.03l8.49-8.49a4.5 4.5 0 1 0-6.36-6.36L3.18 12.62" />
+              <path d="M14 7l3 3" />
+            </svg>
+            Customize
+          </button>
+        </div>
+
+        {/* ── Tab: Browse themes (index.html #theme-tab-browse) ── */}
+        {activeTab === "themes" ? (
+          <div className="od-theme-tab-panel">
+            <div className="od-theme-card">
+              <h2>Default Themes</h2>
+              <div className="od-theme-grid">
+                {Object.entries(ODYSSEUS_THEMES).map(([name, palette]) =>
+                  renderSwatch(name, palette, false),
+                )}
+              </div>
+            </div>
+            {customEntries.length > 0 ? (
+              <div className="od-theme-card">
+                <h2>Your Themes</h2>
+                <div className="od-theme-grid">
+                  {customEntries.map(([name, palette]) =>
+                    renderSwatch(name, palette, true),
+                  )}
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+
+        {/* ── Tab: Customize (index.html #theme-tab-customize) ── */}
+        {activeTab === "customize" ? (
+          <div className="od-theme-tab-panel">
+            <div className="od-theme-card">
+              <h2>Colors</h2>
+              <div className="od-theme-custom-grid">
+                {COLORS_CARD_ROWS.map((row) => renderColorRow(row))}
+              </div>
+            </div>
+            {onAdvancedChange ? (
+              <>
+                <button
+                  type="button"
+                  className={`od-theme-adv-toggle${advOpen ? " open" : ""}`}
+                  onClick={() => setAdvOpen((v) => !v)}
+                  aria-expanded={advOpen}
+                >
+                  <ChevronRight size={13} className="od-theme-adv-arrow" />
+                  More Colors
+                </button>
+                {advOpen ? (
+                  <div className="od-theme-adv-section">
+                    {ADV_GROUP_ORDER.map((group) => (
+                      <div key={group} className="od-theme-adv-group">
+                        <div className="od-theme-adv-group-label">{group}</div>
+                        <div className="od-theme-custom-rows">
+                          {ADV_KEYS.filter((d) => d.group === group).map(
+                            (def) => (
+                              <div key={def.key} className="od-theme-color-row">
+                                <button
+                                  type="button"
+                                  className="od-cp-swatch-trigger"
+                                  style={{ background: advValue(def.key) }}
+                                  onClick={() =>
+                                    setAdvPickerKey((cur) =>
+                                      cur === def.key ? null : def.key,
+                                    )
+                                  }
+                                  aria-label={`Edit ${def.label}`}
+                                  aria-expanded={advPickerKey === def.key}
+                                />
+                                <span className="od-theme-color-key">
+                                  {def.label}
+                                </span>
+                                <span className="od-theme-color-hex">
+                                  {advValue(def.key)}
+                                </span>
+                                <button
+                                  type="button"
+                                  className={`od-theme-reset-btn${advChanged(def.key) ? " changed" : ""}`}
+                                  onClick={() => resetAdv(def.key)}
+                                  disabled={!advChanged(def.key)}
+                                  title={`Reset ${def.label}`}
+                                  aria-label={`Reset ${def.label}`}
+                                >
+                                  <RotateCcw size={11} />
+                                </button>
+                                {advPickerKey === def.key ? (
+                                  <ColorPickerPopover
+                                    value={
+                                      HEX6.test(advValue(def.key))
+                                        ? advValue(def.key)
+                                        : "#000000"
+                                    }
+                                    recents={recents}
+                                    onPreview={(hex) =>
+                                      onAdvancedChange(def.key, hex)
+                                    }
+                                    onCommit={(hex) => {
+                                      onAdvancedChange(def.key, hex);
+                                      commitRecent(hex);
+                                    }}
+                                    onClose={() => setAdvPickerKey(null)}
+                                  />
+                                ) : null}
+                              </div>
+                            ),
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                    <button
+                      type="button"
+                      className="od-theme-adv-clear"
+                      onClick={() => onClearAdvanced?.()}
+                      disabled={Object.keys(adv).length === 0}
+                    >
+                      Clear Advanced Overrides
+                    </button>
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+            <div className="od-theme-card">
+              <h2>Color Harmony</h2>
+              <div className="od-theme-harmony">
+                <div className="od-theme-harmony-row">
+                  <button
+                    type="button"
+                    className="od-cp-swatch-trigger"
+                    style={{
+                      background: HEX6.test(harmonyAccent)
+                        ? harmonyAccent
+                        : "#e06c75",
+                    }}
+                    onClick={() => setAccentPickerOpen((v) => !v)}
+                    aria-label="Harmony accent colour"
+                    aria-expanded={accentPickerOpen}
+                  />
+                  <select
+                    className="od-theme-select"
+                    value={harmonyType}
+                    onChange={(e) =>
+                      setHarmonyType(toHarmonyType(e.target.value))
+                    }
+                    aria-label="Harmony type"
+                  >
+                    {HARMONY_TYPES.map((t) => (
+                      <option key={t} value={t}>
+                        {t}
+                      </option>
+                    ))}
+                  </select>
+                  <select
+                    className="od-theme-select"
+                    value={harmonyMode}
+                    onChange={(e) =>
+                      setHarmonyMode(toHarmonyMode(e.target.value))
+                    }
+                    aria-label="Harmony mode"
+                  >
+                    <option value="dark">dark</option>
+                    <option value="light">light</option>
+                  </select>
+                </div>
+                {accentPickerOpen ? (
+                  <ColorPickerPopover
+                    value={HEX6.test(harmonyAccent) ? harmonyAccent : "#e06c75"}
+                    recents={recents}
+                    onPreview={setHarmonyAccent}
+                    onCommit={(hex) => {
+                      setHarmonyAccent(hex);
+                      commitRecent(hex);
+                    }}
+                    onClose={() => setAccentPickerOpen(false)}
+                  />
+                ) : null}
+                <div className="od-theme-harmony-preview">
+                  {PREVIEW_KEYS.map((k) => (
+                    <span key={k} style={{ background: harmonyPreview[k] }} />
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  className="od-theme-harmony-gen"
+                  onClick={() => applyPalette(harmonyPreview)}
+                >
+                  <Wand2 size={13} /> Generate
+                </button>
+              </div>
+            </div>
+            <div className="od-theme-card">
+              <h2>Font &amp; Layout</h2>
+              <div className="od-theme-section">Font</div>
+              <div className="od-theme-row">
+                {FONTS.map((f) => (
+                  <button
+                    type="button"
+                    key={f}
+                    className={`od-theme-pill${font === f ? " active" : ""}`}
+                    onClick={() => onSetFont(f)}
+                  >
+                    {f}
+                  </button>
+                ))}
+              </div>
+              <div className="od-theme-section">Density</div>
+              <div className="od-theme-row">
+                {DENSITIES.map((d) => (
+                  <button
+                    type="button"
+                    key={d}
+                    className={`od-theme-pill${density === d ? " active" : ""}`}
+                    onClick={() => onSetDensity(d)}
+                  >
+                    {d}
+                  </button>
+                ))}
+              </div>
+              <div className="od-theme-section">Background / Effect</div>
+              <div className="od-theme-row od-theme-row-wrap">
+                {BG_PATTERNS.map((b) => (
+                  <button
+                    type="button"
+                    key={b}
+                    className={`od-theme-pill${bgPattern === b ? " active" : ""}`}
+                    onClick={() => onSetBg(b)}
+                  >
+                    {b}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="od-theme-card">
+              <h2>Save / Share</h2>
+              <div className="od-theme-save">
+                <input
+                  className="od-theme-save-input"
+                  value={saveName}
+                  onChange={(e) => {
+                    setSaveName(e.target.value);
+                    if (saveError) setSaveError("");
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleSave();
+                  }}
+                  placeholder="Theme name…"
+                  maxLength={32}
+                  aria-label="Custom theme name"
+                />
+                <button
+                  type="button"
+                  className="od-theme-pill"
+                  onClick={handleSave}
+                >
+                  Save
+                </button>
+              </div>
+              {saveError ? (
+                <div className="od-theme-save-error">{saveError}</div>
+              ) : null}
+              <div className="od-theme-io">
+                <button
+                  type="button"
+                  className="od-theme-io-btn"
+                  onClick={() => {
+                    setImportOpen((v) => !v);
+                    setImportText("");
+                    setImportError("");
+                  }}
+                >
+                  <Upload size={13} /> Import
+                </button>
+                <button
+                  type="button"
+                  className="od-theme-io-btn"
+                  onClick={handleExport}
+                >
+                  <Download size={13} /> {exported ? "Downloaded!" : "Export"}
+                </button>
+              </div>
+              {importOpen ? (
+                <div className="od-theme-import">
+                  <textarea
+                    className="od-theme-import-area"
+                    value={importText}
+                    onChange={(e) => setImportText(e.target.value)}
+                    placeholder='{"name":"…","colors":{"bg":"#…","fg":"#…","panel":"#…","border":"#…","red":"#…"}}'
+                    aria-label="Theme JSON"
+                  />
+                  {importError ? (
+                    <div className="od-theme-import-error">{importError}</div>
+                  ) : null}
+                  <div className="od-theme-import-actions">
+                    <button
+                      type="button"
+                      className="od-theme-pill"
+                      onClick={handleImport}
+                    >
+                      Apply
+                    </button>
+                    <button
+                      type="button"
+                      className="od-theme-pill"
+                      onClick={() => {
+                        setImportOpen(false);
+                        setImportText("");
+                        setImportError("");
+                      }}
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/VoiceView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/VoiceView.tsx
@@ -1,0 +1,552 @@
+// odysseus voice surface (static/js/voiceRecorder.js + the #recording-indicator
+// / #mic-btn rules in style.css, plus the hidden TTS admin-card in
+// static/index.html). 1:1 with what odysseus actually renders on the chat
+// surface — NOT a centered "Voice & Speech" modal (odysseus has no /voice route,
+// no voice-view, no voice-panel, and the 17-voice.png frame is just the empty
+// default chat). The real odysseus voice chrome is:
+//
+//   • Recorder — a small inline mic toggle (#mic-btn) and, only while recording,
+//     a position:fixed top toast (#recording-indicator): a pulsing record icon,
+//     "Recording…" text, and a red "Stop" button, with an .error red-banner
+//     state for mic/permission failures. There is NO in-panel waveform, NO
+//     MM:SS timer, NO transcript block: odysseus's insertTranscription() writes
+//     the transcript straight into the chat composer (#message). Backed by the
+//     REAL createVoiceCapture() factory (local-inference ASR with a browser
+//     SpeechRecognition fallback) — never fabricated audio.
+//
+//   • TTS — odysseus's "Text to Speech" admin-card lives INSIDE Settings and is
+//     shipped hidden (`<div class="admin-card" hidden style="display:none">`):
+//     a speaker-polygon SVG + "Text to Speech" title + an admin-switch toggle,
+//     the subtitle "Configure TTS provider for assistant message read-aloud.",
+//     Provider / Model / Voice / Speed <select>s, and a single "Preview" button.
+//     We render that card faithfully but, like odysseus, keep it hidden by
+//     default (a disclosure reveals it). It is wired to the REAL
+//     client.getStreamVoice() / streamVoiceSpeak() surface; when no voice
+//     backend is attached the controls stay inert/disabled with an honest
+//     reason rather than faking audio. (No free-text "read aloud" textarea and
+//     no Speak/Stop pair — read-aloud is per assistant message in odysseus.)
+//
+// elizaMapping: createVoiceCapture() is the same ASR factory the shell + voice
+// pill use; transcript segments are routed into the chat composer exactly as
+// voiceRecorder.js's insertTranscription() did. getStreamVoice() reports whether
+// a voice backend is attached on THIS surface; the orchestrator agent is a
+// coding-agent surface that usually has no voice service wired, so the TTS
+// Preview stays disabled with an honest reason when the service is absent.
+
+import {
+  client,
+  createVoiceCapture,
+  EDGE_BACKUP_VOICES,
+  PREMADE_VOICES,
+  VOICE_PROVIDERS,
+  type VoiceCaptureHandle,
+  type VoiceCaptureState,
+  type VoicePreset,
+} from "@elizaos/ui";
+import { Mic, Minus } from "lucide-react";
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { useEscapeClose } from "./hooks/useEscapeClose";
+import { useWindowControls } from "./hooks/useWindowControls";
+import { ResizeHandles } from "./ResizeHandles";
+import { readPref, writePref } from "./util/storage";
+
+// odysseus TTS provider <select> options (set-ttsProviderSelect).
+const TTS_PROVIDERS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: "disabled", label: "Disabled" },
+  { value: "browser", label: "Browser (built-in)" },
+  { value: "local", label: "Local (Kokoro-82M)" },
+];
+
+// odysseus TTS model <select> options (set-ttsModelSelect).
+const TTS_MODELS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: "tts-1", label: "tts-1 (fast)" },
+  { value: "tts-1-hd", label: "tts-1-hd (quality)" },
+  { value: "gpt-4o-mini-tts", label: "gpt-4o-mini-tts (steerable)" },
+];
+
+// odysseus TTS voice <select> options (set-ttsVoiceSelect).
+const TTS_VOICES: ReadonlyArray<{ value: string; label: string }> = [
+  { value: "alloy", label: "Alloy" },
+  { value: "ash", label: "Ash" },
+  { value: "coral", label: "Coral" },
+  { value: "echo", label: "Echo" },
+  { value: "fable", label: "Fable" },
+  { value: "nova", label: "Nova" },
+  { value: "onyx", label: "Onyx" },
+  { value: "sage", label: "Sage" },
+  { value: "shimmer", label: "Shimmer" },
+];
+
+// odysseus TTS speed <select> options (set-ttsSpeedSelect); "1" is the default.
+const TTS_SPEEDS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: "0.5", label: "0.5x" },
+  { value: "0.75", label: "0.75x" },
+  { value: "1", label: "1x (normal)" },
+  { value: "1.25", label: "1.25x" },
+  { value: "1.5", label: "1.5x" },
+  { value: "2", label: "2x" },
+];
+
+// Persisted TTS selections — odysseus stored these server-side; the orchestrator
+// has no TTS-settings backend, so the picks are local prefs owned by this view.
+const TTS_PROVIDER_KEY = "voice-tts-provider";
+const TTS_MODEL_KEY = "voice-tts-model";
+const TTS_VOICE_KEY = "voice-tts-voice";
+const TTS_SPEED_KEY = "voice-tts-speed";
+
+// Live TTS-service status as reported by client.getStreamVoice(). `loading`
+// while the probe is in flight; `attached`+`enabled` only when the service says
+// a backend is actually wired — otherwise Preview stays disabled honestly.
+interface VoiceStatus {
+  loading: boolean;
+  enabled: boolean;
+  provider: string | null;
+  configuredProvider: string | null;
+  attached: boolean;
+}
+
+const INITIAL_STATUS: VoiceStatus = {
+  loading: true,
+  enabled: false,
+  provider: null,
+  configuredProvider: null,
+  attached: false,
+};
+
+// Resolve a human provider label for the honest Preview-disabled reason.
+function providerLabelFor(status: VoiceStatus): string {
+  const id = status.provider ?? status.configuredProvider;
+  if (!id) return "None";
+  const match = VOICE_PROVIDERS.find((p) => p.id === id);
+  return match ? match.label : id;
+}
+
+// Preset catalogue keyed off the configured stream-voice provider, matching the
+// voice.ts EDGE_BACKUP_VOICES intent (ElevenLabs → full PREMADE catalogue; the
+// Edge / local fallback gets the trimmed pair). Surfaced only as the inert
+// hint when no backend is attached, never as fabricated audio.
+function presetsForProvider(provider: string | null): VoicePreset[] {
+  if (provider === "elevenlabs") return PREMADE_VOICES;
+  return EDGE_BACKUP_VOICES;
+}
+
+// odysseus's insertTranscription(): append a transcript segment to the chat
+// composer textarea (#message) and refire its input event so the composer
+// auto-resizes. The orchestrator composer is the same shared chat input.
+function insertTranscription(text: string): boolean {
+  if (!text) return false;
+  if (typeof document === "undefined") return false;
+  const input = document.getElementById("message");
+  if (
+    !(input instanceof HTMLTextAreaElement || input instanceof HTMLInputElement)
+  ) {
+    return false;
+  }
+  const existing = input.value.trim();
+  input.value = existing ? `${existing} ${text}` : text;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+  input.focus();
+  return true;
+}
+
+export function VoiceView({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}): ReactNode {
+  useEscapeClose(open, onClose);
+  // The windowed surface is the odysseus TTS admin-card (the only persistent
+  // voice chrome). The recording-indicator is a position:fixed toast that
+  // floats above it, exactly as in odysseus.
+  const win = useWindowControls(
+    "win-voice",
+    { w: 440, h: 360 },
+    { label: "Voice", icon: "Mic", onClose },
+  );
+
+  // ── TTS state (mirrors the hidden Settings admin-card) ──
+  const [status, setStatus] = useState<VoiceStatus>(INITIAL_STATUS);
+  const [ttsCardOpen, setTtsCardOpen] = useState(false);
+  const [ttsProvider, setTtsProvider] = useState<string>(() =>
+    readPref<string>(TTS_PROVIDER_KEY, "disabled"),
+  );
+  const [ttsModel, setTtsModel] = useState<string>(() =>
+    readPref<string>(TTS_MODEL_KEY, "tts-1"),
+  );
+  const [ttsVoice, setTtsVoice] = useState<string>(() =>
+    readPref<string>(TTS_VOICE_KEY, "alloy"),
+  );
+  const [ttsSpeed, setTtsSpeed] = useState<string>(() =>
+    readPref<string>(TTS_SPEED_KEY, "1"),
+  );
+  const [previewMsg, setPreviewMsg] = useState<string>("");
+
+  // ── Recorder state ──
+  const [recState, setRecState] = useState<VoiceCaptureState>("idle");
+  const [recError, setRecError] = useState<string | null>(null);
+
+  const captureRef = useRef<VoiceCaptureHandle | null>(null);
+
+  // Probe the real voice service when the surface opens (getStreamVoice()).
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setStatus(INITIAL_STATUS);
+    void client
+      .getStreamVoice()
+      .then((res) => {
+        if (cancelled) return;
+        setStatus({
+          loading: false,
+          enabled: res.enabled,
+          provider: res.provider,
+          configuredProvider: res.configuredProvider,
+          attached: res.isAttached,
+        });
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setStatus({
+          loading: false,
+          enabled: false,
+          provider: null,
+          configuredProvider: null,
+          attached: false,
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  // Release the live capture when the surface closes or the component unmounts
+  // mid-recording (the view is normally kept mounted and toggled via `open`,
+  // but a true unmount while recording must still free the mic).
+  const teardownCapture = useCallback(() => {
+    const handle = captureRef.current;
+    if (handle) {
+      handle.dispose();
+      captureRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) teardownCapture();
+  }, [open, teardownCapture]);
+
+  useEffect(() => teardownCapture, [teardownCapture]);
+
+  if (!open) return null;
+  if (win.minimized) return null;
+
+  const recording = recState === "listening" || recState === "starting";
+  const recErrored = recState === "error" && recError !== null;
+  const ttsAttached = !status.loading && status.enabled && status.attached;
+  const providerLabel = providerLabelFor(status);
+  const presetHints = presetsForProvider(
+    status.provider ?? status.configuredProvider,
+  );
+
+  const persistProvider = (value: string) => {
+    setTtsProvider(value);
+    writePref(TTS_PROVIDER_KEY, value);
+  };
+  const persistModel = (value: string) => {
+    setTtsModel(value);
+    writePref(TTS_MODEL_KEY, value);
+  };
+  const persistVoice = (value: string) => {
+    setTtsVoice(value);
+    writePref(TTS_VOICE_KEY, value);
+  };
+  const persistSpeed = (value: string) => {
+    setTtsSpeed(value);
+    writePref(TTS_SPEED_KEY, value);
+  };
+
+  // odysseus's set-ttsPreviewBtn: speak a short sample through the attached
+  // voice service. Inert unless a backend is actually attached.
+  const previewTts = () => {
+    if (!ttsAttached) return;
+    setPreviewMsg("Previewing…");
+    void client
+      .streamVoiceSpeak("This is a preview of the assistant voice.")
+      .then((res) => {
+        setPreviewMsg(res.speaking ? "Speaking…" : "");
+      })
+      .catch((err: unknown) => {
+        setPreviewMsg(err instanceof Error ? err.message : "Preview failed");
+      });
+  };
+
+  const startRecording = () => {
+    if (recording) return;
+    setRecError(null);
+
+    if (typeof window !== "undefined" && !window.isSecureContext) {
+      setRecError(
+        "Microphone requires HTTPS. Use a reverse proxy with SSL or access via localhost.",
+      );
+      setRecState("error");
+      return;
+    }
+    if (
+      typeof navigator === "undefined" ||
+      !navigator.mediaDevices ||
+      !navigator.mediaDevices.getUserMedia
+    ) {
+      setRecError("Microphone not supported in this browser.");
+      setRecState("error");
+      return;
+    }
+
+    const handle = createVoiceCapture({
+      onTranscript: (segment) => {
+        // Final segments go straight to the chat composer (odysseus
+        // insertTranscription). Interim segments are not surfaced — odysseus
+        // had no interim UI on this build.
+        if (segment.final) insertTranscription(segment.text);
+      },
+      onStateChange: (state, error) => {
+        setRecState(state);
+        if (state === "error" && error) setRecError(error.message);
+      },
+    });
+    captureRef.current = handle;
+
+    void handle.start().catch(() => {
+      // start() already surfaced the error via onStateChange("error", …).
+    });
+  };
+
+  const stopRecording = () => {
+    const handle = captureRef.current;
+    if (handle) {
+      void handle.stop().catch(() => {});
+    }
+  };
+
+  const toggleRecording = () => {
+    if (recording) {
+      stopRecording();
+    } else {
+      startRecording();
+    }
+  };
+
+  return (
+    <div
+      className={`od-search-overlay${win.windowed ? " od-windowed" : ""}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Voice and speech"
+    >
+      <button
+        type="button"
+        aria-label="Close voice panel"
+        onClick={onClose}
+        className="od-search-backdrop"
+      />
+      {win.snapGhost ? (
+        <div
+          className="od-snap-ghost"
+          style={win.snapGhost}
+          aria-hidden="true"
+        />
+      ) : null}
+
+      {/* odysseus #recording-indicator: a position:fixed top toast, shown only
+          while recording (or on a mic/permission error). Pulsing record icon +
+          "Recording…" text + red Stop button; .error → red banner. */}
+      {recording || recErrored ? (
+        <div
+          className={`od-recording-indicator${recErrored ? " error" : ""}`}
+          role="status"
+        >
+          <div className="od-recording-content">
+            <Mic className="od-recording-icon" size={20} aria-hidden="true" />
+            <span className="od-recording-text">
+              {recErrored ? "Microphone error" : "Recording…"}
+            </span>
+          </div>
+          {recErrored ? (
+            <div className="od-recording-error">{recError}</div>
+          ) : (
+            <button
+              type="button"
+              className="od-stop-recording-btn"
+              onClick={stopRecording}
+            >
+              Stop
+            </button>
+          )}
+        </div>
+      ) : null}
+
+      {/* The persistent voice chrome: a single inline mic toggle plus the
+          odysseus "Text to Speech" admin-card (hidden by default, like
+          odysseus's `<div class="admin-card" hidden>`). */}
+      <div className="od-voice-card" style={win.panelStyle}>
+        <ResizeHandles controls={win} />
+        <div className="od-voice-card-bar" onPointerDown={win.onDragStart}>
+          <button
+            type="button"
+            className="od-window-min-btn"
+            onClick={win.minimize}
+            title="Minimize"
+            aria-label="Minimize"
+          >
+            <Minus size={14} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className={`od-mic-btn${recording ? " recording" : ""}`}
+            onClick={toggleRecording}
+            title={recording ? "Stop recording" : "Start recording"}
+            aria-label={recording ? "Stop recording" : "Start recording"}
+            aria-pressed={recording}
+          >
+            <Mic size={16} aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="od-voice-disclosure"
+            onClick={() => setTtsCardOpen((v) => !v)}
+            aria-expanded={ttsCardOpen}
+          >
+            {ttsCardOpen ? "Hide" : "Text to Speech"}
+          </button>
+        </div>
+
+        {ttsCardOpen ? (
+          <div className="od-admin-card">
+            <h2 className="od-admin-card-title">
+              {/* odysseus speaker-polygon SVG (set-ttsEnabledToggle header). */}
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="od-admin-card-icon"
+                aria-hidden="true"
+              >
+                <title>Text to Speech</title>
+                <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5" />
+                <path d="M19.07 4.93a10 10 0 0 1 0 14.14" />
+                <path d="M15.54 8.46a5 5 0 0 1 0 7.07" />
+              </svg>
+              <span>Text to Speech</span>
+              <span className="od-admin-card-spacer" />
+              <label className="od-admin-switch">
+                <input
+                  type="checkbox"
+                  checked={ttsAttached}
+                  disabled
+                  aria-label="Text to Speech enabled"
+                />
+                <span className="od-admin-slider" />
+              </label>
+            </h2>
+            <div className="od-admin-toggle-sub">
+              Configure TTS provider for assistant message read-aloud.
+            </div>
+            <div className="od-tts-fields">
+              <div className="od-tts-row">
+                <span className="od-settings-label">Provider</span>
+                <select
+                  className="od-settings-select"
+                  value={ttsProvider}
+                  onChange={(e) => persistProvider(e.target.value)}
+                  aria-label="TTS provider"
+                >
+                  {TTS_PROVIDERS.map((p) => (
+                    <option key={p.value} value={p.value}>
+                      {p.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="od-tts-row">
+                <span className="od-settings-label">Model</span>
+                <select
+                  className="od-settings-select"
+                  value={ttsModel}
+                  onChange={(e) => persistModel(e.target.value)}
+                  aria-label="TTS model"
+                >
+                  {TTS_MODELS.map((m) => (
+                    <option key={m.value} value={m.value}>
+                      {m.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="od-tts-row">
+                <span className="od-settings-label">Voice</span>
+                <select
+                  className="od-settings-select"
+                  value={ttsVoice}
+                  onChange={(e) => persistVoice(e.target.value)}
+                  aria-label="TTS voice"
+                >
+                  {TTS_VOICES.map((v) => (
+                    <option key={v.value} value={v.value}>
+                      {v.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="od-tts-row">
+                <span className="od-settings-label">Speed</span>
+                <select
+                  className="od-settings-select"
+                  value={ttsSpeed}
+                  onChange={(e) => persistSpeed(e.target.value)}
+                  aria-label="TTS speed"
+                >
+                  {TTS_SPEEDS.map((s) => (
+                    <option key={s.value} value={s.value}>
+                      {s.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <button
+                type="button"
+                className="od-admin-btn-sm"
+                onClick={previewTts}
+                disabled={!ttsAttached}
+                title={
+                  ttsAttached
+                    ? "Preview the assistant voice"
+                    : `No voice service attached (provider: ${providerLabel}). Preview is unavailable.`
+                }
+              >
+                Preview
+              </button>
+              <div className="od-tts-msg">
+                {status.loading
+                  ? "Checking voice service…"
+                  : ttsAttached
+                    ? previewMsg
+                    : `No voice service is attached to the orchestrator (${presetHints.length} fallback voices available). Read-aloud stays off until a provider is configured.`}
+              </div>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/WindowManager.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/WindowManager.tsx
@@ -1,0 +1,158 @@
+// WindowManager — the core of odysseus's minimize-to-dock window system
+// (static/js/modalManager.js `_state` map + `_renderDock`). A single React
+// context owns the registry of every tool window that opted into minimize:
+// id → { id, label, icon, minimized }. Tool views register on mount (and
+// unregister on unmount) via useWindowControls; the MinimizedDock subscribes
+// to the derived list of currently-minimized windows and renders a chip each.
+//
+// Why a context instead of the module-global Map the odysseus source uses: in
+// React the dock and the windows are sibling components, so the minimized set
+// has to be reactive state that re-renders the dock when a window minimizes.
+// The provider holds that state; the registry entries themselves are plain
+// data (no DOM handles — restore/close run through the React tree, not by
+// toggling `.hidden` on a detached element).
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+
+// The icon is a lucide icon NAME (e.g. "StickyNote"), resolved to a component
+// by the dock's explicit name→component map. We keep it a plain string here so
+// the registry stays serializable-shaped data and the manager never imports
+// lucide — only the presentational dock does.
+export interface WindowMeta {
+  /** Human-readable window title shown on the dock chip. */
+  label: string;
+  /** A lucide-react icon name (e.g. "Calendar"); resolved by the dock. */
+  icon: string;
+  /** Close the underlying view (the dock chip's × calls this so closing a
+   *  minimized window truly closes it instead of resurrecting its panel).
+   *  useWindowControls passes a stable wrapper, so its identity never churns. */
+  onClose?: () => void;
+}
+
+export interface WindowEntry extends WindowMeta {
+  /** Stable window id — the same storageKey the view passes to useWindowControls. */
+  id: string;
+  /** Whether the window is currently minimized to the dock. */
+  minimized: boolean;
+}
+
+export interface WindowManagerApi {
+  /** Register (or refresh the meta of) a window. Idempotent on re-register;
+   *  preserves the existing `minimized` flag so a meta refresh never restores. */
+  register(id: string, meta: WindowMeta): void;
+  /** Remove a window from the registry entirely (its dock chip disappears). */
+  unregister(id: string): void;
+  /** Flip a window's minimized flag. No-op for an unregistered id. */
+  setMinimized(id: string, minimized: boolean): void;
+  /** Read a single window's minimized flag (false when unregistered). */
+  isMinimized(id: string): boolean;
+  /** The windows currently minimized, in stable insertion order. */
+  minimizedWindows: WindowEntry[];
+}
+
+const WindowManagerContext = createContext<WindowManagerApi | null>(null);
+
+export function WindowManagerProvider({
+  children,
+}: {
+  children: ReactNode;
+}): ReactNode {
+  // Insertion-ordered registry. A Map preserves the order windows registered
+  // in, so the dock chips stay in a stable order across minimize/restore
+  // cycles (parity with modalManager.js `_dockOrder`, which only drops an id
+  // on full close — here, on unregister).
+  const [registry, setRegistry] = useState<Map<string, WindowEntry>>(
+    () => new Map(),
+  );
+
+  const register = useCallback((id: string, meta: WindowMeta) => {
+    setRegistry((prev) => {
+      const existing = prev.get(id);
+      // Re-register only rewrites meta; a window that was minimized stays
+      // minimized (a remount/meta-refresh must not silently restore it).
+      const next: WindowEntry = {
+        id,
+        label: meta.label,
+        icon: meta.icon,
+        onClose: meta.onClose,
+        minimized: existing?.minimized ?? false,
+      };
+      // Skip the state churn when nothing actually changed (avoids a needless
+      // re-render when a view re-registers with identical meta on every render).
+      if (
+        existing &&
+        existing.label === next.label &&
+        existing.icon === next.icon &&
+        existing.minimized === next.minimized
+      ) {
+        return prev;
+      }
+      const copy = new Map(prev);
+      copy.set(id, next);
+      return copy;
+    });
+  }, []);
+
+  const unregister = useCallback((id: string) => {
+    setRegistry((prev) => {
+      if (!prev.has(id)) return prev;
+      const copy = new Map(prev);
+      copy.delete(id);
+      return copy;
+    });
+  }, []);
+
+  const setMinimized = useCallback((id: string, minimized: boolean) => {
+    setRegistry((prev) => {
+      const existing = prev.get(id);
+      if (!existing || existing.minimized === minimized) return prev;
+      const copy = new Map(prev);
+      copy.set(id, { ...existing, minimized });
+      return copy;
+    });
+  }, []);
+
+  const isMinimized = useCallback(
+    (id: string): boolean => registry.get(id)?.minimized === true,
+    [registry],
+  );
+
+  const minimizedWindows = useMemo(
+    () => [...registry.values()].filter((w) => w.minimized),
+    [registry],
+  );
+
+  const api = useMemo<WindowManagerApi>(
+    () => ({
+      register,
+      unregister,
+      setMinimized,
+      isMinimized,
+      minimizedWindows,
+    }),
+    [register, unregister, setMinimized, isMinimized, minimizedWindows],
+  );
+
+  return (
+    <WindowManagerContext.Provider value={api}>
+      {children}
+    </WindowManagerContext.Provider>
+  );
+}
+
+/**
+ * Access the window manager. Returns `null` when called outside a
+ * WindowManagerProvider — callers (useWindowControls) must degrade gracefully
+ * rather than throw, so a view rendered standalone (tests, storybook, a host
+ * that hasn't wrapped the shell) never breaks.
+ */
+export function useWindowManager(): WindowManagerApi | null {
+  return useContext(WindowManagerContext);
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/hooks/useChatSubmit.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/hooks/useChatSubmit.ts
@@ -1,0 +1,68 @@
+// Composer submit/stop wiring. Sending to a selected thread posts a user
+// message (the SSE change-ping then refetches it into the room within ~150ms);
+// sending with no thread selected creates one (title = first words, goal =
+// message) and selects it. Stop aborts the active sub-agent session.
+
+import { client } from "@elizaos/ui";
+import { useCallback, useState } from "react";
+
+function deriveTitle(text: string): string {
+  const words = text.trim().split(/\s+/).slice(0, 6).join(" ");
+  return words.slice(0, 80) || "New chat";
+}
+
+export interface ChatSubmit {
+  input: string;
+  setInput: (value: string) => void;
+  sending: boolean;
+  submit: () => void;
+  stop: () => void;
+}
+
+export function useChatSubmit({
+  selectedId,
+  activeSessionId,
+  onCreated,
+}: {
+  selectedId: string | null;
+  activeSessionId: string | null;
+  onCreated: (id: string) => void;
+}): ChatSubmit {
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+
+  const submit = useCallback(() => {
+    const text = input.trim();
+    if (!text || sending) return;
+    setSending(true);
+    setInput("");
+    void (async () => {
+      try {
+        if (selectedId) {
+          await client.postOrchestratorTaskMessage(selectedId, text);
+        } else {
+          const created = await client.createOrchestratorTask({
+            title: deriveTitle(text),
+            goal: text,
+            originalRequest: text,
+          });
+          onCreated(created.id);
+        }
+      } catch {
+        // Restore the draft so the user can retry; the room surfaces errors.
+        setInput((prev) => (prev ? prev : text));
+      } finally {
+        setSending(false);
+      }
+    })();
+  }, [input, sending, selectedId, onCreated]);
+
+  const stop = useCallback(() => {
+    if (!selectedId || !activeSessionId) return;
+    void client
+      .stopOrchestratorAgent(selectedId, activeSessionId)
+      .catch(() => {});
+  }, [selectedId, activeSessionId]);
+
+  return { input, setInput, sending, submit, stop };
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/hooks/useEscapeClose.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/hooks/useEscapeClose.ts
@@ -1,0 +1,17 @@
+// Shared modal affordance for the odysseus port: while `open`, a global Escape
+// keypress invokes `onClose`. Every view-modal (panels + full-bleed tool views)
+// uses this so close-on-Escape is consistent with odysseus's modal behaviour
+// regardless of where focus sits.
+
+import { useEffect } from "react";
+
+export function useEscapeClose(open: boolean, onClose: () => void): void {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/hooks/useKeyboardShortcuts.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,169 @@
+// Global keyboard shortcuts for the odysseus port — a faithful TS port of
+// static/js/keyboard-shortcuts.js + platform.js combo matching, adapted from
+// odysseus's DOM-button-click model to the clone's React state-callback model.
+//
+// odysseus initKeyboardShortcuts() fires actions by clicking the matching
+// sidebar/tool button; the clone instead drives its own setX state setters, so
+// this hook takes a typed handler map and only binds the actions whose handler
+// the caller actually provides. Behaviour preserved: a single window keydown
+// listener (cleaned up on unmount), AltGr-safe combo matching (drop keystrokes
+// that assert the AltGraph modifier state on non-mac, per platform.js, so
+// typing @ # { } on a non-US layout can't fire a Ctrl+Alt shortcut),
+// preventDefault on a match, and shortcuts that never fire while focus sits in
+// an input/textarea/contenteditable — with focusInput the one exception, so a
+// user can re-grab the composer from anywhere.
+
+import { useEffect, useRef } from "react";
+
+// ── Bindable actions, mapped to the surfaces the clone HAS. Each is the combo
+//    string odysseus uses (focus_input/settings/toggle_sidebar/new_session/
+//    open_calendar) or the open_<tool> naming for the per-tool set. Matching is
+//    case-insensitive on the final key, exactly like _matchesCombo.
+export interface KeyboardShortcutHandlers {
+  toggleSidebar?: () => void;
+  newSession?: () => void;
+  focusInput?: () => void;
+  openSettings?: () => void;
+  openCalendar?: () => void;
+  openCompare?: () => void;
+  openCookbook?: () => void;
+  openResearch?: () => void;
+  openGallery?: () => void;
+  openMemory?: () => void;
+  openNotes?: () => void;
+  openTasks?: () => void;
+  openModels?: () => void;
+  openTheme?: () => void;
+}
+
+type ShortcutAction = keyof KeyboardShortcutHandlers;
+
+// Default keybinds, mirroring static/js/keyboard-shortcuts.js `_defaultKeybinds`.
+// odysseus leaves most open_* combos empty (bound only via settings); the clone
+// has no per-action settings surface yet, so each tool gets a stable Ctrl+Alt
+// default in the spirit of the bound calendar shortcut. focusInput stays Ctrl+/
+// and settings Ctrl+, exactly as odysseus ships them.
+const KEYBINDS: Record<ShortcutAction, string> = {
+  toggleSidebar: "ctrl+alt+b",
+  newSession: "ctrl+alt+n",
+  focusInput: "ctrl+/",
+  openSettings: "ctrl+,",
+  openCalendar: "ctrl+alt+c",
+  openCompare: "ctrl+alt+p",
+  openCookbook: "ctrl+alt+k",
+  openResearch: "ctrl+alt+r",
+  openGallery: "ctrl+alt+g",
+  openMemory: "ctrl+alt+m",
+  openNotes: "ctrl+alt+o",
+  openTasks: "ctrl+alt+t",
+  openModels: "ctrl+alt+l",
+  openTheme: "ctrl+alt+h",
+} as const;
+
+// Mirrors platform.js IS_MAC: all Apple platforms (Magic Keyboard Option also
+// sets AltGraph), matching the existing isMac checks in calendar.js/sessions.js.
+function detectIsMac(): boolean {
+  if (typeof navigator === "undefined") return false;
+  const platform = navigator.platform || "";
+  const ua = navigator.userAgent || "";
+  return /Mac|iPhone|iPad/.test(platform) || /Mac/.test(ua);
+}
+
+// platform.js isAltGrEvent: true only when a non-mac event presents AS Ctrl+Alt
+// AND asserts the AltGraph modifier state — i.e. the AltGr collision we drop.
+// An event that asserts AltGraph without Ctrl+Alt (ISO_Level3_Shift, a stray
+// modifier) is deliberately left alone. Always false on mac, where Option
+// legitimately sets AltGraph.
+function isAltGrEvent(e: KeyboardEvent, isMac: boolean): boolean {
+  return (
+    !isMac &&
+    e.ctrlKey &&
+    e.altKey &&
+    typeof e.getModifierState === "function" &&
+    e.getModifierState("AltGraph")
+  );
+}
+
+// Port of _matchesCombo: split on '+', require exact ctrl/alt/shift state
+// (ctrl satisfied by either Ctrl or Meta, as odysseus treats Cmd as Ctrl), and
+// compare the remaining key case-insensitively. AltGr keystrokes never match.
+function matchesCombo(
+  e: KeyboardEvent,
+  combo: string,
+  isMac: boolean,
+): boolean {
+  if (!combo) return false;
+  if (isAltGrEvent(e, isMac)) return false;
+  const parts = combo.split("+");
+  const needCtrl = parts.includes("ctrl");
+  const needAlt = parts.includes("alt");
+  const needShift = parts.includes("shift");
+  const key =
+    parts.find((p) => p !== "ctrl" && p !== "alt" && p !== "shift") ?? "";
+  if (needCtrl !== (e.ctrlKey || e.metaKey)) return false;
+  if (needAlt !== e.altKey) return false;
+  if (needShift !== e.shiftKey) return false;
+  return e.key.toLowerCase() === key;
+}
+
+// True when focus sits in a text-entry surface — input, textarea, or any
+// contenteditable element. Shortcuts (except focusInput) stay inert here so a
+// Ctrl+, typed into the composer never steals the keystroke.
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA") return true;
+  return target.isContentEditable;
+}
+
+// The order odysseus checks bindings in: structural surfaces first, then the
+// per-tool open set, with focusInput last (matching the source's final clause).
+const ACTION_ORDER: readonly ShortcutAction[] = [
+  "toggleSidebar",
+  "newSession",
+  "openSettings",
+  "openCalendar",
+  "openCompare",
+  "openCookbook",
+  "openResearch",
+  "openGallery",
+  "openMemory",
+  "openNotes",
+  "openTasks",
+  "openModels",
+  "openTheme",
+  "focusInput",
+] as const;
+
+/**
+ * Bind a single global keydown listener for the odysseus shortcut set. Only
+ * actions whose handler is supplied are matched; everything else is ignored.
+ * The listener is bound once and reads the latest `handlers` via a ref, so
+ * changing the handler closures never re-adds it; it is removed on unmount.
+ */
+export function useKeyboardShortcuts(handlers: KeyboardShortcutHandlers): void {
+  // Keep the latest handlers in a ref so the effect can bind once and never
+  // tear down/re-add the listener as the caller's closures change each render.
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  useEffect(() => {
+    const isMac = detectIsMac();
+    const onKeyDown = (e: KeyboardEvent): void => {
+      const current = handlersRef.current;
+      const editable = isEditableTarget(e.target);
+      for (const action of ACTION_ORDER) {
+        const handler = current[action];
+        if (!handler) continue;
+        if (!matchesCombo(e, KEYBINDS[action], isMac)) continue;
+        // While focus is in a text field, only focusInput is allowed to fire.
+        if (editable && action !== "focusInput") continue;
+        e.preventDefault();
+        handler();
+        return;
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/hooks/useTaskRoom.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/hooks/useTaskRoom.ts
@@ -1,0 +1,177 @@
+// Loads + live-updates one task room, mirroring the proven OrchestratorWorkbench
+// pattern (three tiers: initial fetch on selection, reconcile poll, SSE
+// change-ping → debounced tail refetch). Returns the odysseus conversation
+// (block list) plus activity state. The SessionEvent contract is unchanged —
+// this is the "reuse existing ACP" path from the port roadmap (Phase 1).
+
+import type {
+  CodingAgentTaskEventRecord,
+  CodingAgentTaskMessageRecord,
+  CodingAgentTaskThreadDetail,
+} from "@elizaos/ui";
+import { client } from "@elizaos/ui";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  buildConversation,
+  type ConversationBlock,
+} from "../../orchestrator-stream";
+
+const POLL_INTERVAL_MS = 5_000;
+const ACTIVE_POLL_INTERVAL_MS = 1_500;
+const TIMELINE_PAGE_LIMIT = 50;
+const REFETCH_DEBOUNCE_MS = 150;
+
+function mergeById<T extends { id: string; timestamp: number }>(
+  previous: T[],
+  incoming: T[],
+): T[] {
+  const byId = new Map<string, T>();
+  for (const item of previous) byId.set(item.id, item);
+  for (const item of incoming) byId.set(item.id, item);
+  return [...byId.values()].sort((a, b) => a.timestamp - b.timestamp);
+}
+
+function resolveSenderName(
+  message: CodingAgentTaskMessageRecord,
+  sessionLabelById: Map<string, string>,
+  mainAgentName: string,
+): string {
+  if (message.senderKind === "sub_agent") {
+    const label = message.sessionId
+      ? sessionLabelById.get(message.sessionId)?.trim()
+      : undefined;
+    return label || "Sub-agent";
+  }
+  if (message.senderKind === "orchestrator") return mainAgentName;
+  if (message.senderKind === "user") return "You";
+  return "System";
+}
+
+export interface TaskRoom {
+  detail: CodingAgentTaskThreadDetail | null;
+  conversation: ConversationBlock[];
+  isActive: boolean;
+  loading: boolean;
+}
+
+export function useTaskRoom(selectedId: string | null): TaskRoom {
+  const [detail, setDetail] = useState<CodingAgentTaskThreadDetail | null>(
+    null,
+  );
+  const [messages, setMessages] = useState<CodingAgentTaskMessageRecord[]>([]);
+  const [events, setEvents] = useState<CodingAgentTaskEventRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const reqRef = useRef(0);
+  const selectedRef = useRef<string | null>(selectedId);
+  const refetchTimer = useRef<number | null>(null);
+  selectedRef.current = selectedId;
+
+  const fetchDetail = useCallback(async (id: string, reset: boolean) => {
+    const token = ++reqRef.current;
+    const [nextDetail, messagePage, eventPage] = await Promise.all([
+      client.getCodingAgentTaskThread(id),
+      client.listOrchestratorTaskMessages(id, { limit: TIMELINE_PAGE_LIMIT }),
+      client.listOrchestratorTaskEvents(id, { limit: TIMELINE_PAGE_LIMIT }),
+    ]);
+    if (token !== reqRef.current || id !== selectedRef.current) return;
+    setDetail(nextDetail);
+    if (reset) {
+      setMessages(mergeById([], messagePage.items));
+      setEvents(mergeById([], eventPage.items));
+    } else {
+      setMessages((prev) => mergeById(prev, messagePage.items));
+      setEvents((prev) => mergeById(prev, eventPage.items));
+    }
+  }, []);
+
+  // Selection change → reset room + initial fetch.
+  useEffect(() => {
+    if (!selectedId) {
+      setDetail(null);
+      setMessages([]);
+      setEvents([]);
+      return;
+    }
+    setLoading(true);
+    void fetchDetail(selectedId, true)
+      .catch(() => {})
+      .finally(() => {
+        if (selectedRef.current === selectedId) setLoading(false);
+      });
+  }, [selectedId, fetchDetail]);
+
+  const isActive =
+    detail != null &&
+    (detail.activeSessionCount > 0 ||
+      detail.status === "active" ||
+      detail.status === "validating");
+
+  // Reconcile poll (safety net for dropped SSE).
+  useEffect(() => {
+    if (!selectedId) return;
+    const ms = isActive ? ACTIVE_POLL_INTERVAL_MS : POLL_INTERVAL_MS;
+    const timer = window.setInterval(
+      () => void fetchDetail(selectedId, false).catch(() => {}),
+      ms,
+    );
+    return () => window.clearInterval(timer);
+  }, [selectedId, isActive, fetchDetail]);
+
+  // Live SSE change-ping → debounced tail refetch.
+  useEffect(() => {
+    if (!selectedId) return;
+    const scheduleRefetch = () => {
+      if (refetchTimer.current != null)
+        window.clearTimeout(refetchTimer.current);
+      refetchTimer.current = window.setTimeout(() => {
+        void fetchDetail(selectedId, false).catch(() => {});
+      }, REFETCH_DEBOUNCE_MS);
+    };
+    const unsubscribe = client.streamOrchestratorTask(
+      selectedId,
+      scheduleRefetch,
+    );
+    return () => {
+      unsubscribe();
+      if (refetchTimer.current != null) {
+        window.clearTimeout(refetchTimer.current);
+        refetchTimer.current = null;
+      }
+    };
+  }, [selectedId, fetchDetail]);
+
+  const sessionLabelById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const s of detail?.sessions ?? []) {
+      const label = s.label?.trim();
+      if (s.sessionId && label) map.set(s.sessionId, label);
+    }
+    return map;
+  }, [detail?.sessions]);
+
+  const finishedSessionIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const s of detail?.sessions ?? []) {
+      if (s.sessionId && (s.stoppedAt != null || s.status === "completed")) {
+        ids.add(s.sessionId);
+      }
+    }
+    return ids;
+  }, [detail?.sessions]);
+
+  const mainAgentName = detail?.sessions?.[0]?.label?.trim() || "Orchestrator";
+
+  const conversation = useMemo(
+    () =>
+      buildConversation(
+        messages,
+        events,
+        (m) => resolveSenderName(m, sessionLabelById, mainAgentName),
+        finishedSessionIds,
+      ),
+    [messages, events, sessionLabelById, mainAgentName, finishedSessionIds],
+  );
+
+  return { detail, conversation, isActive, loading };
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/hooks/useWindowControls.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/hooks/useWindowControls.ts
@@ -1,0 +1,372 @@
+// Window-manager controls for the odysseus tool views (static/js/windowDrag.js
+// + windowResize.js + tileManager.js + modalSnap.js + modalManager.js).
+// Turns a centered overlay panel into a draggable + edge/corner-resizable
+// floating window whose position/size persist per view, with desktop
+// edge-tiling (snap) on title-bar drag.
+//
+// Usage: const win = useWindowControls("win-compare", { w: 1180, h: 880 });
+//   - overlay:  className={`od-search-overlay${win.windowed ? " od-windowed" : ""}`}
+//   - panel:    style={win.panelStyle}
+//   - header:   onPointerDown={win.onDragStart}   (drags ignore buttons/inputs)
+//   - inside panel: <ResizeHandles controls={win} />
+//   - snap preview (rendered by the view, fixed-position so it floats above):
+//       {win.snapGhost ? <div className="od-snap-ghost" style={win.snapGhost} /> : null}
+// Until the user first drags/resizes, `windowed` is false and the panel keeps
+// its default centered CSS — so nothing changes visually until interacted with.
+//
+// MINIMIZE (modalManager.js port): pass a 3rd `meta` arg ({ label, icon }) and
+// the hook registers the window into the WindowManager registry on mount
+// (unregister on unmount). It then reads `minimized` from the manager and
+// exposes `minimize()` / `restore()` that flip that flag; the MinimizedDock
+// renders a chip per minimized window. The view gates its own render on
+// `win.minimized` (returns null while minimized) and the dock click restores
+// it. Used OUTSIDE a WindowManagerProvider the minimize surface degrades to a
+// no-op (minimized stays false, minimize/restore do nothing) so a standalone
+// view never breaks. The `meta` arg is OPTIONAL and additive — the existing
+// two-arg call sites keep their exact behaviour with minimize simply unwired.
+//
+// TILING (tileManager.js port): while dragging the title bar, when the pointer
+// nears a screen edge we compute a snap target and expose `snapGhost` (a fixed
+// CSS rect) so a translucent preview can render. On pointer-up over a zone the
+// panel rect snaps to that target; the pre-snap rect is stashed so the next
+// drag-away restores it. Zones are faithful to tileManager.js `_zoneForPointer`,
+// which keeps ONLY top strip → maximize, right edge → right-half, bottom edge →
+// bottom-half. The left-half and corner snaps are deliberately disabled in the
+// source (the nav rail/sidebar lives on the left, so docking over it is awkward),
+// so they are omitted here too.
+
+import {
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { readPref, writePref } from "../util/storage";
+import { useWindowManager, type WindowMeta } from "../WindowManager";
+
+export type ResizeDir = "n" | "s" | "e" | "w" | "ne" | "nw" | "se" | "sw";
+
+type SnapZone = "maximize" | "right-half" | "bottom-half";
+
+interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface WindowControls {
+  windowed: boolean;
+  panelStyle: CSSProperties;
+  onDragStart: (e: ReactPointerEvent) => void;
+  onResizeStart: (dir: ResizeDir) => (e: ReactPointerEvent) => void;
+  /** Fixed-position CSS rect for the translucent snap preview, or null when
+   *  the drag is not over a snap zone. The owning view renders it. */
+  snapGhost: CSSProperties | null;
+  /** True while the window is minimized to the dock. Always false when no
+   *  `meta` was passed or when used outside a WindowManagerProvider — so a
+   *  view that never gates on it is unaffected. */
+  minimized: boolean;
+  /** Minimize the window to the dock chip. No-op without a manager/meta. */
+  minimize: () => void;
+  /** Restore the window from the dock. No-op without a manager/meta. */
+  restore: () => void;
+}
+
+const MIN_W = 360;
+const MIN_H = 220;
+
+// Mirror of tileManager.js EDGE_THRESHOLD_PX / TOP_FULL_STRIP_PX. The top strip
+// triggers maximize; the side/bottom edges trigger the half snaps.
+const EDGE_THRESHOLD_PX = 24;
+const TOP_FULL_STRIP_PX = 8;
+// Desktop only — the odysseus source excludes tiling at <=768px (swipe UX).
+const DESKTOP_MIN_W = 768;
+// Left navigation width (icon rail). The odysseus safe-rect carves the nav out
+// of the left edge so windows never dock over it; we approximate with the rail
+// width as the always-present floor (parity with tileManager.js, which never
+// snaps to the left edge — only maximize / right-half / bottom-half).
+const RAIL_W = 48;
+const SAFE_PAD = 4;
+
+interface SnapTarget {
+  zone: SnapZone;
+  rect: Rect;
+}
+
+// The safe area windows tile into: the viewport minus the left nav rail and a
+// small inset (parity with tileManager.js `_viewportSafeRect`). We can't read
+// live DOM widths from a pure hook, so we treat the rail as the always-on left
+// floor; snaps only ever fill from this left edge rightward (maximize /
+// right-half / bottom-half), so they never land over the nav.
+function safeRect(): {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+} {
+  return {
+    left: RAIL_W + SAFE_PAD,
+    top: SAFE_PAD,
+    right: window.innerWidth - SAFE_PAD,
+    bottom: window.innerHeight - SAFE_PAD,
+  };
+}
+
+// Compute the snap target under the pointer, or null when none. Faithful to
+// tileManager.js `_zoneForPointer`: top strip → maximize, right edge →
+// right-half, bottom edge → bottom-half. The left edge / corners are
+// deliberately not snap zones (the source disabled them — the nav lives there).
+function zoneForPointer(x: number, y: number): SnapTarget | null {
+  const safe = safeRect();
+  const w = safe.right - safe.left;
+  const h = safe.bottom - safe.top;
+  if (y <= safe.top + TOP_FULL_STRIP_PX) {
+    return { zone: "maximize", rect: { x: safe.left, y: safe.top, w, h } };
+  }
+  if (x >= safe.right - EDGE_THRESHOLD_PX) {
+    return {
+      zone: "right-half",
+      rect: { x: safe.left + w / 2, y: safe.top, w: w / 2, h },
+    };
+  }
+  if (y >= safe.bottom - EDGE_THRESHOLD_PX) {
+    return {
+      zone: "bottom-half",
+      rect: { x: safe.left, y: safe.top + h / 2, w, h: h / 2 },
+    };
+  }
+  return null;
+}
+
+function ghostStyle(rect: Rect): CSSProperties {
+  return {
+    position: "fixed",
+    left: rect.x,
+    top: rect.y,
+    width: rect.w,
+    height: rect.h,
+  };
+}
+
+export function useWindowControls(
+  storageKey: string,
+  defaults: { w: number; h: number },
+  meta?: WindowMeta,
+): WindowControls {
+  const [rect, setRect] = useState<Rect | null>(() =>
+    readPref<Rect | null>(storageKey, null),
+  );
+
+  // Minimize-to-dock wiring (modalManager.js). The manager is null when this
+  // hook runs outside a WindowManagerProvider; in that case minimize/restore
+  // become no-ops and `minimized` is permanently false, so a standalone view
+  // (or a two-arg call site that passes no meta) is entirely unaffected.
+  const manager = useWindowManager();
+  // Register on mount / unregister on unmount — only when a view opts in by
+  // passing meta. Keying the effect on the meta fields (not the object
+  // identity) lets a view pass an inline `{ label, icon }` without thrashing
+  // register on every render. The manager API methods are stable callbacks.
+  const label = meta?.label;
+  const icon = meta?.icon;
+  const register = manager?.register;
+  const unregister = manager?.unregister;
+  // Keep the latest onClose in a ref and register a STABLE wrapper, so the
+  // dock chip's × can close the view (not just un-minimize it) without the
+  // changing onClose identity re-running the register effect every render.
+  const onCloseRef = useRef(meta?.onClose);
+  onCloseRef.current = meta?.onClose;
+  const stableOnClose = useCallback(() => onCloseRef.current?.(), []);
+  useEffect(() => {
+    if (!register || !unregister || label === undefined || icon === undefined) {
+      return;
+    }
+    register(storageKey, { label, icon, onClose: stableOnClose });
+    return () => unregister(storageKey);
+  }, [register, unregister, storageKey, label, icon, stableOnClose]);
+
+  const hasMinimize =
+    manager !== null && label !== undefined && icon !== undefined;
+  const minimized = hasMinimize && manager.isMinimized(storageKey);
+
+  const minimize = useCallback(() => {
+    if (manager && hasMinimize) manager.setMinimized(storageKey, true);
+  }, [manager, hasMinimize, storageKey]);
+
+  const restore = useCallback(() => {
+    if (manager && hasMinimize) manager.setMinimized(storageKey, false);
+  }, [manager, hasMinimize, storageKey]);
+  const rectRef = useRef<Rect | null>(rect);
+  rectRef.current = rect;
+
+  const [snapGhost, setSnapGhost] = useState<CSSProperties | null>(null);
+
+  // The rect the window had before it snapped to a zone — restored on the next
+  // drag-away (tileManager.js `_tilePreSnap`). Null when not currently snapped.
+  const preSnapRef = useRef<Rect | null>(null);
+
+  // Teardown for the in-flight drag/resize gesture. A gesture registers its
+  // window listeners while active and stashes the remover here so an unmount
+  // mid-drag detaches them — otherwise the listeners leak and keep calling the
+  // state setters after the host view is gone.
+  const activeGestureRef = useRef<(() => void) | null>(null);
+  useEffect(
+    () => () => {
+      activeGestureRef.current?.();
+      activeGestureRef.current = null;
+    },
+    [],
+  );
+
+  // Lazily seed a centered rect from the viewport on first interaction.
+  const ensureRect = useCallback((): Rect => {
+    if (rectRef.current) return rectRef.current;
+    const vw = window.innerWidth;
+    const vh = window.innerHeight;
+    const w = Math.min(defaults.w, vw - 40);
+    const h = Math.min(defaults.h, vh - 40);
+    const seeded: Rect = {
+      x: Math.max(20, Math.round((vw - w) / 2)),
+      y: Math.max(20, Math.round((vh - h) / 2)),
+      w,
+      h,
+    };
+    rectRef.current = seeded;
+    setRect(seeded);
+    return seeded;
+  }, [defaults.w, defaults.h]);
+
+  const persist = useCallback(() => {
+    if (rectRef.current) writePref(storageKey, rectRef.current);
+  }, [storageKey]);
+
+  const onDragStart = useCallback(
+    (e: ReactPointerEvent) => {
+      // Don't start a drag from an interactive control inside the header.
+      if (
+        e.target instanceof Element &&
+        e.target.closest("button, input, select, textarea, a")
+      )
+        return;
+      e.preventDefault();
+      const start = ensureRect();
+      const desktop = window.innerWidth > DESKTOP_MIN_W;
+      const sx = e.clientX;
+      const sy = e.clientY;
+      // If the drag begins on an already-snapped window, peel back to the
+      // pre-snap geometry as the anchor so the move feels like un-snapping
+      // (tileManager.js `_unsnap` on first significant move).
+      const anchor = preSnapRef.current ?? start;
+      preSnapRef.current = null;
+      setSnapGhost(null);
+      let activeTarget: SnapTarget | null = null;
+      const onMove = (ev: PointerEvent) => {
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+        const next: Rect = {
+          ...anchor,
+          x: Math.min(Math.max(0, anchor.x + (ev.clientX - sx)), vw - 80),
+          y: Math.min(Math.max(0, anchor.y + (ev.clientY - sy)), vh - 40),
+        };
+        rectRef.current = next;
+        setRect(next);
+        if (desktop) {
+          const target = zoneForPointer(ev.clientX, ev.clientY);
+          activeTarget = target;
+          setSnapGhost(target ? ghostStyle(target.rect) : null);
+        }
+      };
+      const detach = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        activeGestureRef.current = null;
+      };
+      const onUp = () => {
+        detach();
+        setSnapGhost(null);
+        if (activeTarget) {
+          // Stash the pre-snap rect so the next drag-away restores it, then
+          // snap the panel to fill the zone (tileManager.js `_applySnap`).
+          preSnapRef.current = rectRef.current ?? anchor;
+          const snapped = activeTarget.rect;
+          rectRef.current = snapped;
+          setRect(snapped);
+        }
+        persist();
+      };
+      activeGestureRef.current = detach;
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+    },
+    [ensureRect, persist],
+  );
+
+  const onResizeStart = useCallback(
+    (dir: ResizeDir) => (e: ReactPointerEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const start = ensureRect();
+      // A manual resize breaks any snap, so forget the pre-snap rect.
+      preSnapRef.current = null;
+      const sx = e.clientX;
+      const sy = e.clientY;
+      const onMove = (ev: PointerEvent) => {
+        const dx = ev.clientX - sx;
+        const dy = ev.clientY - sy;
+        let { x, y, w, h } = start;
+        if (dir.includes("e")) w = Math.max(MIN_W, start.w + dx);
+        if (dir.includes("s")) h = Math.max(MIN_H, start.h + dy);
+        if (dir.includes("w")) {
+          w = Math.max(MIN_W, start.w - dx);
+          x = start.x + (start.w - w);
+        }
+        if (dir.includes("n")) {
+          h = Math.max(MIN_H, start.h - dy);
+          y = start.y + (start.h - h);
+        }
+        const next: Rect = { x, y, w, h };
+        rectRef.current = next;
+        setRect(next);
+      };
+      const detach = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+        activeGestureRef.current = null;
+      };
+      const onUp = () => {
+        detach();
+        persist();
+      };
+      activeGestureRef.current = detach;
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+    },
+    [ensureRect, persist],
+  );
+
+  const panelStyle: CSSProperties = rect
+    ? {
+        position: "absolute",
+        left: rect.x,
+        top: rect.y,
+        width: rect.w,
+        height: rect.h,
+        margin: 0,
+        maxWidth: "none",
+        maxHeight: "none",
+      }
+    : {};
+
+  return {
+    windowed: rect !== null,
+    panelStyle,
+    onDragStart,
+    onResizeStart,
+    snapGhost,
+    minimized,
+    minimize,
+    restore,
+  };
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/odysseus-theme.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/odysseus-theme.ts
@@ -1,0 +1,12165 @@
+// odysseus design system, ported 1:1 from github.com/pewdiepie-archdaemon/odysseus
+// (static/js/theme.js THEMES + the inline theme bootstrap in static/index.html +
+// static/style.css). MIT, ported with permission; credited in ACKNOWLEDGMENTS.
+//
+// Three exports, mirroring the existing ORCHESTRATOR_THEME pattern so the agent
+// (Node) can import this plugin's view manifest without ever evaluating a .css
+// file (see @elizaos/ui CLAUDE.md — index.ts is CSS-free on purpose):
+//   • ODYSSEUS_THEMES — the 16 built-in 5-colour palettes (verbatim from
+//     theme.js), + buildThemeVars(palette) which derives the full root CSS-var
+//     set: odysseus's own syntax-highlight HSL derivation PLUS the eliza
+//     semantic-token remaps (--card/--txt/--muted/--accent/--ok/…) so reused
+//     eliza components (ConversationBlockView, ReasoningCell, DiffView,
+//     MarkdownText) inherit the active odysseus theme for free.
+//   • themeVars(name) — convenience: buildThemeVars for a named preset.
+//   • ODYSSEUS_CSS — structural rules that can't be inline (pseudo-elements,
+//     :hover, @keyframes, ::-webkit-scrollbar). Rendered once via a <style> tag
+//     inside OdysseusShell, scoped under .odysseus-root so nothing leaks.
+
+import type { CSSProperties } from "react";
+
+export type CssVarStyle = CSSProperties & Record<`--${string}`, string>;
+
+export interface ThemePalette {
+  bg: string;
+  fg: string;
+  panel: string;
+  border: string;
+  red: string;
+  advanced?: {
+    sendBtnBg?: string;
+    sendBtnHover?: string;
+    userBubbleBg?: string;
+    aiBubbleBg?: string;
+    inputBg?: string;
+  };
+}
+
+export type ThemeName = string;
+
+/** odysseus's built-in theme palettes (static/js/theme.js `THEMES`), 1:1. */
+export const ODYSSEUS_THEMES: Record<string, ThemePalette> = {
+  dark: {
+    bg: "#282c34",
+    fg: "#9cdef2",
+    panel: "#111111",
+    border: "#355a66",
+    red: "#e06c75",
+  },
+  light: {
+    bg: "#f0ebe3",
+    fg: "#5a5248",
+    panel: "#faf6f0",
+    border: "#d4cdc2",
+    red: "#c47d5a",
+  },
+  midnight: {
+    bg: "#0d1117",
+    fg: "#c9d1d9",
+    panel: "#161b22",
+    border: "#30363d",
+    red: "#f85149",
+  },
+  paper: {
+    bg: "#faf8f5",
+    fg: "#3b3836",
+    panel: "#ffffff",
+    border: "#d5d0c8",
+    red: "#c5ac4a",
+  },
+  cyberpunk: {
+    bg: "#0a0a0f",
+    fg: "#0ff0fc",
+    panel: "#12101a",
+    border: "#9b30ff",
+    red: "#e040fb",
+  },
+  retrowave: {
+    bg: "#1a1a2e",
+    fg: "#e94560",
+    panel: "#16213e",
+    border: "#533483",
+    red: "#e94560",
+  },
+  forest: {
+    bg: "#1b2a1b",
+    fg: "#a8d5a2",
+    panel: "#142414",
+    border: "#3d6b3d",
+    red: "#7cb871",
+  },
+  ocean: {
+    bg: "#0b1a2c",
+    fg: "#64d2ff",
+    panel: "#091422",
+    border: "#1e5074",
+    red: "#4facfe",
+  },
+  ume: {
+    bg: "#2b1b2e",
+    fg: "#f5c2e7",
+    panel: "#1e1420",
+    border: "#6c4675",
+    red: "#f5a0c0",
+  },
+  copper: {
+    bg: "#1c1410",
+    fg: "#e8c39e",
+    panel: "#140f0a",
+    border: "#7a5533",
+    red: "#d4764e",
+  },
+  terminal: {
+    bg: "#000000",
+    fg: "#00ff41",
+    panel: "#0a0a0a",
+    border: "#003b00",
+    red: "#00ff41",
+  },
+  organs: {
+    bg: "#0a0406",
+    fg: "#efe1c8",
+    panel: "#15080a",
+    border: "#3a1519",
+    red: "#c83240",
+  },
+  lavender: {
+    bg: "#f3eef8",
+    fg: "#3d3551",
+    panel: "#faf7ff",
+    border: "#cec3de",
+    red: "#9b6dcc",
+  },
+  gpt: {
+    bg: "#212121",
+    fg: "#ececec",
+    panel: "#171717",
+    border: "#424242",
+    red: "#949494",
+    advanced: {
+      sendBtnBg: "#949494",
+      sendBtnHover: "#7f7f7f",
+      userBubbleBg: "#2f2f2f",
+      aiBubbleBg: "#171717",
+      inputBg: "#2f2f2f",
+    },
+  },
+  claude: {
+    bg: "#262624",
+    fg: "#f5f4f0",
+    panel: "#30302e",
+    border: "#4a4a47",
+    red: "#c6613f",
+  },
+  cute: {
+    bg: "#fff0f5",
+    fg: "#d4608a",
+    panel: "#fff8fa",
+    border: "#f0c0d0",
+    red: "#ff6b9d",
+  },
+};
+
+export const DEFAULT_THEME = "dark";
+
+export type ThemeFont = "mono" | "sans" | "serif";
+export type ThemeDensity = "compact" | "comfortable" | "spacious";
+
+/** odysseus font choices (static/js/theme.js FONT_MAP), 1:1. */
+export const FONT_MAP: Record<ThemeFont, string> = {
+  mono: "'Fira Code', ui-monospace, monospace",
+  sans: "system-ui, -apple-system, 'Segoe UI', sans-serif",
+  serif: "Georgia, 'Times New Roman', serif",
+};
+
+// HSL helpers + syntax-highlight derivation, ported verbatim from the odysseus
+// index.html theme bootstrap — so every preset gets faithful --hl-* colours.
+function h2hsl(hex: string): [number, number, number] {
+  const s = hex.replace("#", "");
+  const r = Number.parseInt(s.substring(0, 2), 16) / 255;
+  const g = Number.parseInt(s.substring(2, 4), 16) / 255;
+  const b = Number.parseInt(s.substring(4, 6), 16) / 255;
+  const mx = Math.max(r, g, b);
+  const mn = Math.min(r, g, b);
+  const l = (mx + mn) / 2;
+  let h = 0;
+  let sv = 0;
+  if (mx !== mn) {
+    const d = mx - mn;
+    sv = l > 0.5 ? d / (2 - mx - mn) : d / (mx + mn);
+    if (mx === r) h = ((g - b) / d + (g < b ? 6 : 0)) / 6;
+    else if (mx === g) h = ((b - r) / d + 2) / 6;
+    else h = ((r - g) / d + 4) / 6;
+  }
+  return [h * 360, sv * 100, l * 100];
+}
+
+function hsl2h(h: number, sv: number, l: number): string {
+  const hh = ((h % 360) + 360) % 360;
+  const s = Math.max(0, Math.min(100, sv)) / 100;
+  const ll = Math.max(0, Math.min(100, l)) / 100;
+  const a = s * Math.min(ll, 1 - ll);
+  const f = (n: number) => {
+    const k = (n + hh / 30) % 12;
+    return ll - a * Math.max(-1, Math.min(k - 3, 9 - k, 1));
+  };
+  const th = (v: number) =>
+    Math.round(v * 255)
+      .toString(16)
+      .padStart(2, "0");
+  return `#${th(f(0))}${th(f(8))}${th(f(4))}`;
+}
+
+/** Derive the full root CSS-var set from a 5-colour odysseus palette. */
+export function buildThemeVars(c: ThemePalette): CssVarStyle {
+  const bH = h2hsl(c.bg);
+  const fH = h2hsl(c.fg);
+  const rH = h2hsl(c.red);
+  const dark = bH[2] < 50;
+  const mix = (base: string, pct: number) =>
+    `color-mix(in srgb, ${base} ${pct}%, transparent)`;
+  const vars: CssVarStyle = {
+    "--bg": c.bg,
+    "--fg": c.fg,
+    "--panel": c.panel,
+    "--border": c.border,
+    "--red": c.red,
+    "--green": "#50fa7b",
+    "--warn": "#f0ad4e",
+    "--brand-color": c.red,
+    "--model-dot": mix(c.fg, 30),
+    "--hl-bg": hsl2h(
+      bH[0],
+      bH[1],
+      dark ? Math.max(bH[2] - 4, 0) : Math.min(bH[2] + 4, 100),
+    ),
+    "--hl-fg": c.fg,
+    "--hl-keyword": hsl2h(
+      (rH[0] + 280) % 360,
+      Math.min(rH[1] + 10, 80),
+      dark ? 70 : 45,
+    ),
+    "--hl-string": hsl2h(40, Math.min(fH[1] + 20, 70), dark ? 72 : 42),
+    "--hl-comment": hsl2h(
+      fH[0],
+      Math.max(fH[1] - 20, 5),
+      fH[2] * 0.5 + bH[2] * 0.5,
+    ),
+    "--hl-function": hsl2h(210, Math.min(fH[1] + 20, 75), dark ? 70 : 45),
+    "--hl-number": hsl2h(20, Math.min(fH[1] + 15, 65), dark ? 68 : 48),
+    "--hl-builtin": hsl2h(180, Math.min(fH[1] + 15, 60), dark ? 65 : 40),
+    "--hl-variable": hsl2h((fH[0] + 30) % 360, Math.min(fH[1] + 5, 60), fH[2]),
+    "--hl-params": hsl2h(
+      fH[0],
+      Math.max(fH[1] - 5, 10),
+      dark ? Math.min(fH[2] + 8, 85) : Math.max(fH[2] - 8, 25),
+    ),
+    "--bg-elevated": `color-mix(in srgb, ${c.fg} 6%, ${c.bg})`,
+    "--card": c.panel,
+    "--card-foreground": c.fg,
+    "--surface": c.panel,
+    "--text": c.fg,
+    "--txt": c.fg,
+    "--text-strong": dark ? "#ffffff" : "#000000",
+    "--chat-text": c.fg,
+    "--muted": mix(c.fg, 56),
+    "--muted-strong": mix(c.fg, 74),
+    "--border-strong": mix(c.fg, 22),
+    "--border-hover": mix(c.fg, 22),
+    "--bg-accent": mix(c.red, 8),
+    "--bg-hover": mix(c.fg, 8),
+    "--bg-muted": mix(c.fg, 12),
+    "--accent": c.red,
+    "--accent-subtle": mix(c.red, 14),
+    "--ok": "#50fa7b",
+    "--destructive": c.red,
+    "--info": mix(c.fg, 74),
+    "--ring": c.red,
+    "--input": c.advanced?.inputBg ?? c.panel,
+    "--focus": mix(c.fg, 14),
+    "--status-info-bg": mix(c.fg, 6),
+    "--link-color": c.fg,
+    "--link-hover-color": c.red,
+    "--scrollbar-track": c.panel,
+    "--scrollbar-thumb-start": c.red,
+    "--scrollbar-thumb-mid": c.red,
+    "--scrollbar-thumb-end": c.red,
+  };
+  if (c.advanced?.userBubbleBg)
+    vars["--user-bubble-bg"] = c.advanced.userBubbleBg;
+  if (c.advanced?.aiBubbleBg) vars["--ai-bubble-bg"] = c.advanced.aiBubbleBg;
+  if (c.advanced?.inputBg) vars["--input-bg"] = c.advanced.inputBg;
+  if (c.advanced?.sendBtnBg) vars["--send-btn-bg"] = c.advanced.sendBtnBg;
+  return vars;
+}
+
+export function themeVars(name: ThemeName): CssVarStyle {
+  return buildThemeVars(
+    ODYSSEUS_THEMES[name] ?? ODYSSEUS_THEMES[DEFAULT_THEME],
+  );
+}
+
+// Structural CSS — verbatim odysseus rules, re-prefixed `od-` and scoped under
+// .odysseus-root so they never collide with or leak into the rest of eliza.
+export const ODYSSEUS_CSS = `
+.odysseus-root { display:flex; height:100%; min-height:0; width:100%; overflow:hidden; position:relative; isolation:isolate;
+  background:var(--bg); color:var(--fg);
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif; }
+
+/* ── icon rail ── */
+.odysseus-root .od-icon-rail { width:48px; flex-shrink:0; display:flex; flex-direction:column;
+  align-items:center; gap:4px; padding:14px 0; background:var(--panel);
+  border-right:1px solid var(--border); }
+.odysseus-root .od-rail-btn { width:32px; height:32px; display:flex; align-items:center; justify-content:center;
+  border:none; background:none; color:var(--fg); opacity:.45; border-radius:8px; cursor:pointer;
+  transition:opacity .12s, background .12s; }
+.odysseus-root .od-rail-btn:hover { opacity:1; background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-rail-btn.active { opacity:1; color:var(--red); background:color-mix(in srgb, var(--red) 12%, transparent); }
+.odysseus-root .od-rail-spacer { flex:1; }
+
+/* ── sidebar ── */
+.odysseus-root .od-sidebar { width:240px; flex-shrink:0; display:flex; flex-direction:column;
+  overflow:hidden; min-height:0; background:var(--sidebar-bg, var(--panel)); position:relative;
+  border-right:1px solid var(--border); box-shadow:0 4px 12px rgba(0,0,0,.1); backdrop-filter:blur(10px); }
+.odysseus-root .od-sidebar-resize-handle { position:absolute; top:0; right:0; width:5px; height:100%;
+  cursor:col-resize; z-index:5; touch-action:none; border:none; padding:0; margin:0;
+  background:transparent; appearance:none; }
+.odysseus-root .od-sidebar-resize-handle:hover,
+.odysseus-root .od-sidebar-resize-handle:focus-visible { background:color-mix(in srgb, var(--red) 30%, transparent); outline:none; }
+.odysseus-root .od-sidebar.od-collapsed { width:0; border-right:none; }
+.odysseus-root .od-sidebar-header { display:flex; align-items:center; gap:8px;
+  padding:15px 12px 6px; flex-shrink:0; min-height:40px; }
+.odysseus-root .od-sidebar-brand-title { font-size:1rem; font-weight:600; line-height:1.35;
+  color:var(--brand-color, var(--red)); white-space:nowrap; user-select:none; cursor:pointer;
+  background:none; border:none; padding:0; font-family:inherit; text-align:left; }
+.odysseus-root .od-sidebar-inner { flex:1; overflow-y:auto; overflow-x:hidden; overscroll-behavior-y:none;
+  scrollbar-width:none; display:flex; flex-direction:column; gap:0; padding:10px 8px 8px; min-height:0; }
+.odysseus-root .od-sidebar-inner::-webkit-scrollbar { display:none; }
+.odysseus-root .od-list-item { display:flex; gap:6px; align-items:center; padding:3px 8px; margin:0;
+  border-radius:4px; border:1px solid transparent; line-height:1.3; font-size:13px; color:var(--fg);
+  background:transparent; transition:background .08s; cursor:pointer; }
+.odysseus-root .od-list-item:hover { background:color-mix(in srgb, var(--red) 8%, transparent); }
+.odysseus-root .od-list-item.active { background:color-mix(in srgb, var(--red) 10%, transparent);
+  border-color:var(--red); }
+.odysseus-root .od-list-item .od-grow { flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.odysseus-root .od-list-item .od-sub { font-size:10px; opacity:.5; white-space:nowrap; }
+.odysseus-root .od-thread-row { position:relative; display:flex; align-items:center; }
+.odysseus-root .od-thread-row .od-thread-main { flex:1; min-width:0; }
+.odysseus-root .od-thread-menu-btn { position:absolute; right:4px; top:50%; transform:translateY(-50%);
+  width:22px; height:22px; display:flex; align-items:center; justify-content:center; border:none;
+  background:var(--panel); color:var(--fg); opacity:0; border-radius:4px; cursor:pointer; transition:opacity .12s; }
+.odysseus-root .od-thread-row:hover .od-thread-menu-btn { opacity:.55; }
+.odysseus-root .od-thread-menu-btn:hover { opacity:1; background:color-mix(in srgb, var(--fg) 10%, transparent); }
+.odysseus-root .od-thread-menu { position:absolute; right:4px; top:calc(50% + 14px); z-index:30;
+  background:var(--panel); border:1px solid var(--border); border-radius:8px; box-shadow:0 6px 20px rgba(0,0,0,.4);
+  min-width:120px; overflow:hidden; padding:4px; }
+.odysseus-root .od-thread-menu button { display:flex; align-items:center; gap:7px; width:100%; text-align:left;
+  padding:6px 10px; border:none; background:none; color:var(--fg); font-size:12px; border-radius:4px; cursor:pointer; }
+.odysseus-root .od-thread-menu button:hover { background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-thread-menu button.od-danger { color:var(--red); }
+.odysseus-root .od-thread-pin-dot { flex-shrink:0; margin-right:5px; color:var(--accent, var(--red)); opacity:.85; }
+.odysseus-root .od-thread-rename { width:100%; box-sizing:border-box; padding:3px 8px; margin:1px 0; font-size:13px;
+  background:var(--bg); color:var(--fg); border:1px solid var(--red); border-radius:4px; outline:none; font-family:inherit; }
+.odysseus-root .od-section { padding:0; margin:0; }
+.odysseus-root .od-section-header-flex { display:flex; align-items:center; gap:6px; padding:8px;
+  margin:1px 0; border-radius:4px; height:29px; box-sizing:border-box; }
+.odysseus-root .od-section-title { flex:1; display:flex; align-items:center; gap:6px; margin:0;
+  font-size:10px; font-weight:400; line-height:1; color:var(--fg); user-select:none;
+  text-transform:none; letter-spacing:0; }
+.odysseus-root .od-sidebar-user-bar { display:flex; align-items:center; justify-content:space-between;
+  padding:12px; flex-shrink:0; gap:4px; min-height:48px; border-top:1px solid color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-user-left { display:flex; align-items:center; gap:10px; flex:1; min-width:0;
+  cursor:pointer; padding:6px 8px; border-radius:8px; transition:background .15s; }
+.odysseus-root .od-user-left:hover { background:color-mix(in srgb, var(--fg) 6%, transparent); }
+.odysseus-root .od-user-avatar { width:24px; height:24px; border-radius:50%; display:flex; align-items:center;
+  justify-content:center; font-size:10px; font-weight:600; color:var(--fg); opacity:.7; flex-shrink:0;
+  text-transform:uppercase; background:color-mix(in srgb, var(--fg) 12%, transparent); }
+.odysseus-root .od-user-name { font-size:9.75px; font-weight:500; color:var(--fg); opacity:.8;
+  overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.odysseus-root .od-user-btn { background:none; border:none; color:var(--fg); opacity:.35; cursor:pointer;
+  padding:6px; border-radius:6px; display:flex; align-items:center; transition:opacity .12s, background .12s; }
+.odysseus-root .od-user-btn:hover { opacity:1; background:color-mix(in srgb, var(--fg) 8%, transparent); }
+
+/* ── chat container ── */
+.odysseus-root .od-chat-container { flex:1; display:flex; flex-direction:column; padding:0 16px;
+  overflow:hidden; position:relative; min-height:0; min-width:0; margin-top:8px; }
+.odysseus-root .od-chat-top-bar { display:flex; align-items:center; justify-content:center; flex-shrink:0;
+  position:relative; z-index:2; padding:5px 0 0; min-height:25px; }
+.odysseus-root .od-chat-meta { font-size:.75em; line-height:1; color:color-mix(in srgb, var(--fg) 40%, transparent);
+  white-space:nowrap; display:flex; align-items:center; gap:6px; }
+
+/* ── message log ── */
+.odysseus-root .od-chat-history { flex:1; overflow-y:auto; overflow-x:hidden; overscroll-behavior-y:none;
+  margin-bottom:8px; min-height:0; --chat-max:800px; display:flex; flex-direction:column;
+  padding-left:max(0px, calc((100% - var(--chat-max)) / 2));
+  padding-right:max(12px, calc((100% - var(--chat-max)) / 2 + 12px)); }
+.odysseus-root .od-chat-history::-webkit-scrollbar { width:8px; }
+.odysseus-root .od-chat-history::-webkit-scrollbar-track { background:var(--panel); }
+.odysseus-root .od-chat-history::-webkit-scrollbar-thumb { background-color:var(--red); border-radius:4px;
+  border:2px solid var(--panel); }
+.odysseus-root .od-chat-history::-webkit-scrollbar-thumb:hover { background-color:color-mix(in srgb, var(--red) 80%, white); }
+.odysseus-root .od-msg { margin:8px 0; position:relative; display:flex; flex-direction:column;
+  line-height:1.4; word-wrap:break-word; overflow-wrap:break-word; animation:od-msg-enter .3s ease-out both; }
+.odysseus-root .od-msg-user { align-items:flex-end; align-self:flex-end; margin-left:auto; margin-right:8px;
+  background:var(--user-bubble-bg, color-mix(in srgb, var(--fg) 8%, var(--bg))); border:1px solid var(--border);
+  border-radius:18px 18px 0 18px; width:fit-content; max-width:85%; min-width:80px; padding:10px 12px; }
+.odysseus-root .od-msg-ai { align-items:flex-start; align-self:flex-start; margin-right:auto; margin-left:8px;
+  background:var(--ai-bubble-bg, var(--panel)); border:1px solid var(--border);
+  border-radius:18px 18px 18px 0; width:85%; max-width:85%; min-width:80px; padding:10px 12px; }
+.odysseus-root .od-role { font-weight:600; margin-bottom:6px; display:flex; align-items:center; gap:6px;
+  overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-size:.85em; color:var(--fg); }
+.odysseus-root .od-role::before { content:''; width:8px; height:8px; border-radius:50%;
+  background:var(--model-dot); flex-shrink:0; }
+.odysseus-root .od-msg-user .od-role { color:color-mix(in srgb, var(--fg) 60%, transparent); }
+.odysseus-root .od-msg-user .od-role::before { background:color-mix(in srgb, var(--fg) 40%, transparent); }
+.odysseus-root .od-body { width:100%; white-space:normal; word-break:break-word; overflow-wrap:anywhere;
+  line-height:1.5; font-size:.95em; color:var(--fg); }
+.odysseus-root .od-body > * { margin-top:8px; margin-bottom:8px; }
+.odysseus-root .od-body > *:first-child { margin-top:0; }
+.odysseus-root .od-body > *:last-child { margin-bottom:0; }
+.odysseus-root .od-msg-time { font-size:.7rem; color:color-mix(in srgb, var(--fg) 45%, transparent); margin-top:6px; }
+.odysseus-root .od-msg-cells { width:100%; max-width:var(--chat-max); margin:0 auto; }
+
+/* ── composer ── */
+.odysseus-root .od-input-bar { position:relative; background:var(--input-bg, var(--panel)); border:1px solid var(--input-border, var(--border));
+  border-radius:16px; padding:10px 12px; display:flex; flex-direction:column; gap:8px;
+  max-width:800px; margin:0 auto 12px; width:100%; }
+.odysseus-root .od-slash-menu { position:absolute; bottom:calc(100% + 6px); left:0; right:0; z-index:10;
+  background:var(--panel); border:1px solid var(--border); border-radius:12px; box-shadow:0 8px 24px rgba(0,0,0,.4);
+  overflow:hidden; padding:4px; }
+.odysseus-root .od-slash-item { display:flex; align-items:center; gap:10px; width:100%; padding:7px 10px;
+  border:none; background:none; color:var(--fg); font-size:13px; text-align:left; border-radius:6px; cursor:pointer; }
+.odysseus-root .od-slash-item.active { background:color-mix(in srgb, var(--red) 12%, transparent); }
+.odysseus-root .od-slash-name { font-family:'Fira Code', ui-monospace, monospace; color:var(--red);
+  font-weight:600; min-width:64px; }
+.odysseus-root .od-slash-label { opacity:.65; }
+.odysseus-root .od-input-top { width:100%; position:relative; display:flex; align-items:flex-start; gap:8px; }
+.odysseus-root .od-input-top textarea { flex:1; width:100%; background:transparent; border:none; outline:none;
+  resize:none; font-size:14px; line-height:1.5; color:var(--fg); min-height:24px; max-height:200px;
+  padding:0; font-family:inherit; }
+.odysseus-root .od-input-top textarea::placeholder { color:color-mix(in srgb, var(--fg) 35%, transparent); }
+.odysseus-root .od-model-picker-btn { display:inline-flex; align-items:center; gap:4px; height:21px; padding:0 6px;
+  font-size:11px; font-weight:500; font-family:inherit; background:none; border:1px solid transparent;
+  border-radius:4px; color:color-mix(in srgb, var(--fg) 40%, transparent); cursor:pointer; white-space:nowrap;
+  flex-shrink:0; transition:background .15s, color .15s, border-color .15s; }
+.odysseus-root .od-model-picker-btn:hover { border-color:var(--border);
+  background:color-mix(in srgb, var(--fg) 8%, transparent); color:var(--fg); }
+.odysseus-root .od-input-bottom { display:flex; justify-content:space-between; align-items:center; margin-top:4px; }
+.odysseus-root .od-input-left { display:flex; gap:4px; align-items:center; min-width:0; flex:1; }
+.odysseus-root .od-input-right { display:flex; gap:8px; align-items:center; flex-shrink:0; }
+.odysseus-root .od-icon-btn { width:30px; height:30px; display:flex; align-items:center; justify-content:center;
+  background:none; border:none; border-radius:6px; color:color-mix(in srgb, var(--fg) 45%, transparent);
+  cursor:pointer; transition:background .12s, color .12s; flex-shrink:0; }
+.odysseus-root .od-icon-btn:hover { color:var(--fg); background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-icon-btn.active { color:var(--red); background:color-mix(in srgb, var(--red) 12%, transparent); }
+.odysseus-root .od-mode-toggle { display:flex; flex-shrink:0; height:28px; border:1px solid var(--border);
+  border-radius:10px; overflow:hidden; position:relative; }
+.odysseus-root .od-mode-toggle::before { content:''; position:absolute; top:0; left:0; width:50%; height:100%;
+  background:color-mix(in srgb, var(--fg) 10%, transparent); border-radius:9px;
+  transition:transform .3s cubic-bezier(.34,1.56,.64,1); z-index:0; }
+.odysseus-root .od-mode-toggle.od-mode-chat::before { transform:translateX(100%); }
+.odysseus-root .od-mode-btn { background:none; border:none; color:color-mix(in srgb, var(--fg) 40%, transparent);
+  cursor:pointer; padding:0 10px; font-size:11px; font-weight:500; font-family:inherit; transition:color .2s;
+  white-space:nowrap; height:100%; position:relative; z-index:1; }
+.odysseus-root .od-mode-btn.active { color:var(--fg); cursor:default; }
+.odysseus-root .od-send-btn { background:var(--send-btn-bg, var(--red)); color:#fff; border:none; border-radius:8px;
+  min-width:32px; width:32px; height:32px; padding:0; cursor:pointer; display:flex; align-items:center;
+  justify-content:center; flex-shrink:0; overflow:hidden;
+  transition:background .25s, color .25s, opacity .1s; }
+.odysseus-root .od-send-btn:hover { background:color-mix(in srgb, var(--red) 80%, white); }
+.odysseus-root .od-send-btn:disabled { opacity:.4; cursor:default; }
+.odysseus-root .od-send-btn.od-stop { background:color-mix(in srgb, var(--red) 18%, transparent);
+  color:var(--red); }
+.odysseus-root .od-send-btn.od-stop:hover { background:color-mix(in srgb, var(--red) 28%, transparent); }
+
+/* ── theme menu ── */
+.odysseus-root .od-theme-menu { position:absolute; left:52px; bottom:12px; z-index:60; width:260px;
+  background:var(--panel); border:1px solid var(--border); border-radius:12px; box-shadow:0 12px 40px rgba(0,0,0,.45);
+  padding:10px; }
+.odysseus-root .od-theme-grid { display:grid; grid-template-columns:repeat(2, 1fr); gap:6px; }
+.odysseus-root .od-theme-swatch { display:flex; align-items:center; gap:8px; padding:6px 8px; border:1px solid var(--border);
+  border-radius:8px; background:none; color:var(--fg); cursor:pointer; font-size:12px; text-align:left;
+  transition:border-color .12s; }
+.odysseus-root .od-theme-swatch:hover { border-color:var(--red); }
+.odysseus-root .od-theme-swatch.active { border-color:var(--red); box-shadow:0 0 0 1px var(--red) inset; }
+.odysseus-root .od-theme-chip { width:20px; height:20px; border-radius:6px; flex-shrink:0;
+  border:1px solid rgba(255,255,255,.15); }
+.odysseus-root .od-theme-name { text-transform:capitalize; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.odysseus-root .od-theme-section { font-size:10px; text-transform:uppercase; letter-spacing:.04em; opacity:.5; margin:10px 2px 4px; }
+.odysseus-root .od-theme-row { display:flex; gap:6px; }
+.odysseus-root .od-theme-pill { flex:1; padding:5px 8px; border:1px solid var(--border); border-radius:8px;
+  background:none; color:var(--fg); font-size:11px; cursor:pointer; text-transform:capitalize; transition:border-color .12s; }
+.odysseus-root .od-theme-pill:hover { border-color:var(--red); }
+.odysseus-root .od-theme-pill.active { border-color:var(--red); color:var(--red); }
+.odysseus-root .od-theme-custom { display:flex; gap:6px; justify-content:space-between; }
+.odysseus-root .od-theme-color { display:flex; flex-direction:column; align-items:center; gap:3px; font-size:9px;
+  color:color-mix(in srgb, var(--fg) 55%, transparent); text-transform:capitalize; cursor:pointer; }
+.odysseus-root .od-theme-color input[type=color] { width:34px; height:24px; border:1px solid var(--border);
+  border-radius:6px; background:none; padding:0; cursor:pointer; }
+.odysseus-root .od-theme-save { display:flex; gap:6px; margin-top:8px; }
+.odysseus-root .od-theme-save-input { flex:1; min-width:0; padding:5px 8px; border:1px solid var(--border);
+  border-radius:8px; background:var(--bg); color:var(--fg); font-size:11px; outline:none; }
+.odysseus-root .od-theme-saved { display:flex; flex-wrap:wrap; gap:6px; margin-top:8px; }
+.odysseus-root .od-theme-saved-item { display:inline-flex; align-items:center; border:1px solid var(--border);
+  border-radius:8px; overflow:hidden; }
+.odysseus-root .od-theme-saved-name { background:none; border:none; color:var(--fg); font-size:11px;
+  padding:4px 8px; cursor:pointer; text-transform:capitalize; }
+.odysseus-root .od-theme-saved-del { background:none; border:none; border-left:1px solid var(--border);
+  color:color-mix(in srgb, var(--fg) 45%, transparent); font-size:10px; padding:4px 7px; cursor:pointer; }
+.odysseus-root .od-theme-saved-del:hover { color:var(--red); }
+
+/* ── welcome ── */
+.odysseus-root .od-welcome { flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center;
+  gap:8px; color:var(--fg); }
+.odysseus-root .od-welcome-title { display:flex; align-items:center; gap:10px; font-size:1.6rem; font-weight:600;
+  color:var(--brand-color, var(--red)); }
+.odysseus-root .od-welcome-sub { font-size:.9rem; opacity:.55; }
+
+@keyframes od-msg-enter { from { opacity:0; transform:translateY(10px); } to { opacity:1; transform:translateY(0); } }
+
+/* density */
+.odysseus-root.od-density-compact { font-size:13px; }
+.odysseus-root.od-density-compact .od-msg { padding:6px 10px; }
+.odysseus-root.od-density-spacious { font-size:16px; }
+.odysseus-root.od-density-spacious .od-msg { padding:14px 18px; }
+
+/* bg patterns (odysseus static/style.css .bg-pattern-dots; canvas patterns
+   perlin/petals/sparkles/synapse are a later effects port) */
+.odysseus-root.od-bg-dots { background-image: radial-gradient(color-mix(in srgb, var(--fg) 5%, transparent) 1px, transparent 1px);
+  background-size:20px 20px; }
+.odysseus-root .od-bg-canvas { position:absolute; inset:0; width:100%; height:100%; pointer-events:none; z-index:-1; }
+
+/* ── search palette (Ctrl+K) ── */
+.odysseus-root .od-search-overlay { position:absolute; inset:0; z-index:50; display:flex;
+  align-items:flex-start; justify-content:center; padding:12vh 0 5vh; overflow-y:auto;
+  background:rgba(0,0,0,.45); }
+/* A centered (non-windowed) panel is capped to the viewport so its header +
+   footer chrome stay on-screen and inner scroll regions own the overflow; if a
+   panel is still taller, the overlay itself scrolls so nothing is unreachable.
+   A windowed panel sets its own height inline (win.panelStyle), which wins. */
+.odysseus-root .od-search-overlay:not(.od-windowed) > .od-search-panel { max-height:83vh; }
+.odysseus-root .od-search-backdrop { position:absolute; inset:0; z-index:0; background:none; border:none;
+  padding:0; margin:0; cursor:default; }
+.odysseus-root .od-search-panel { position:relative; z-index:1; width:560px; max-width:90%; background:var(--panel);
+  border:1px solid var(--border); border-radius:12px; box-shadow:0 12px 40px rgba(0,0,0,.4); overflow:hidden; }
+.odysseus-root .od-search-input { width:100%; padding:14px 16px; background:transparent; border:none;
+  border-bottom:1px solid var(--border); color:var(--fg); font-size:15px; outline:none; box-sizing:border-box; }
+.odysseus-root .od-search-input::placeholder { color:color-mix(in srgb, var(--fg) 35%, transparent); }
+.odysseus-root .od-search-list { max-height:50vh; overflow-y:auto; }
+.odysseus-root .od-search-item { display:flex; align-items:center; gap:8px; padding:10px 16px; width:100%;
+  background:none; border:none; cursor:pointer; color:var(--fg); font-size:13px; text-align:left; }
+.odysseus-root .od-search-item:hover { background:color-mix(in srgb, var(--red) 10%, transparent); }
+.odysseus-root .od-search-empty { padding:16px; color:color-mix(in srgb, var(--fg) 45%, transparent);
+  font-size:13px; text-align:center; }
+
+/* ── memory panel ── */
+.odysseus-root .od-mem-head { display:flex; align-items:baseline; justify-content:space-between; gap:8px;
+  padding:13px 16px 6px; }
+.odysseus-root .od-mem-title { font-size:14px; font-weight:600; color:var(--fg); }
+.odysseus-root .od-mem-stats { font-size:11px; color:color-mix(in srgb, var(--fg) 55%, transparent); }
+.odysseus-root .od-mem-item { display:flex; align-items:baseline; gap:10px; padding:8px 16px;
+  border-top:1px solid color-mix(in srgb, var(--fg) 6%, transparent); }
+.odysseus-root .od-mem-type { font-size:9px; text-transform:uppercase; letter-spacing:.04em; color:var(--red);
+  flex-shrink:0; min-width:54px; }
+.odysseus-root .od-mem-text { flex:1; font-size:13px; color:var(--fg); overflow:hidden; text-overflow:ellipsis;
+  display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; }
+.odysseus-root .od-mem-time { font-size:10px; color:color-mix(in srgb, var(--fg) 45%, transparent); flex-shrink:0; }
+
+/* ── skills panel ── */
+.odysseus-root .od-skill-item { display:flex; align-items:center; gap:10px; padding:9px 16px;
+  border-top:1px solid color-mix(in srgb, var(--fg) 6%, transparent); }
+.odysseus-root .od-skill-info { flex:1; min-width:0; }
+.odysseus-root .od-skill-name { font-size:13px; font-weight:500; color:var(--fg); display:flex; align-items:center; gap:6px; }
+.odysseus-root .od-skill-desc { font-size:11px; color:color-mix(in srgb, var(--fg) 55%, transparent);
+  overflow:hidden; text-overflow:ellipsis; display:-webkit-box; -webkit-line-clamp:1; -webkit-box-orient:vertical; }
+.odysseus-root .od-skill-scan { font-size:8px; text-transform:uppercase; padding:1px 5px; border-radius:4px;
+  background:color-mix(in srgb, var(--warn) 20%, transparent); color:var(--warn); flex-shrink:0; }
+.odysseus-root .od-skill-toggle { flex-shrink:0; padding:4px 10px; border:1px solid var(--border); border-radius:12px;
+  background:none; color:color-mix(in srgb, var(--fg) 50%, transparent); font-size:10px; cursor:pointer; min-width:38px; }
+.odysseus-root .od-skill-toggle.on { border-color:var(--ok); color:var(--ok); background:color-mix(in srgb, var(--ok) 12%, transparent); }
+.odysseus-root .od-set-section { font-size:10px; text-transform:uppercase; letter-spacing:.04em; opacity:.5;
+  padding:11px 16px 4px; position:sticky; top:0; background:var(--panel); z-index:1; }
+
+/* ── notes panel ── */
+.odysseus-root .od-note-add { padding:4px 16px 8px; }
+.odysseus-root .od-note-add .od-search-input { border:1px solid var(--border); border-radius:8px; }
+.odysseus-root .od-note-item { display:flex; align-items:flex-start; gap:10px; padding:9px 16px;
+  border-top:1px solid color-mix(in srgb, var(--fg) 6%, transparent); }
+.odysseus-root .od-note-body { flex:1; min-width:0; }
+.odysseus-root .od-note-text { font-size:13px; color:var(--fg); white-space:pre-wrap; word-break:break-word; }
+.odysseus-root .od-note-time { font-size:10px; color:color-mix(in srgb, var(--fg) 45%, transparent); margin-top:3px; }
+.odysseus-root .od-note-del { flex-shrink:0; background:none; border:none; cursor:pointer; font-size:12px;
+  padding:2px 6px; border-radius:4px; color:color-mix(in srgb, var(--fg) 40%, transparent); }
+.odysseus-root .od-note-del:hover { color:var(--red); background:color-mix(in srgb, var(--red) 10%, transparent); }
+
+
+/* ===== CompareView ===== */
+
+/* ── Compare arena (odysseus static/js/compare/* + style.css compare rules) ── */
+/* Full-bleed arena reusing the .od-search-overlay backdrop pattern. The panel
+   is a large column: header bar, pane grid, vote bar, composer. */
+.odysseus-root .od-compare-panel {
+  width: min(1180px, 96vw);
+  height: min(86vh, 880px);
+  max-width: none;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+  animation: od-compare-enter 0.3s ease-out;
+}
+@keyframes od-compare-enter {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Header bar — compare/index.js step 8 (.compare-header-bar) */
+.odysseus-root .od-compare-header-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border);
+}
+.odysseus-root .od-compare-header-left {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+.odysseus-root .od-compare-header-icon {
+  display: inline-flex;
+  flex-shrink: 0;
+  margin-right: 6px;
+  opacity: 0.85;
+  color: var(--fg);
+}
+.odysseus-root .od-compare-header-label {
+  font-size: 10px;
+  font-weight: 400;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+.odysseus-root .od-compare-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.odysseus-root .od-compare-hbtn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--fg);
+  cursor: pointer;
+  padding: 3px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  opacity: 0.7;
+  transition: all 0.15s;
+  line-height: 1;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-family: inherit;
+}
+.odysseus-root .od-compare-hbtn:hover { opacity: 1; border-color: var(--fg); }
+.odysseus-root .od-compare-hbtn.on {
+  opacity: 1;
+  border-color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+}
+.odysseus-root .od-compare-close-btn { padding: 3px 8px; }
+
+/* Export dropdown — compare/index.js _toggleExportMenu (.compare-export-menu) */
+.odysseus-root .od-compare-export-wrap {
+  position: relative;
+  display: inline-flex;
+}
+.odysseus-root .od-compare-export-menu {
+  position: absolute;
+  z-index: 10001;
+  top: calc(100% + 4px);
+  left: 0;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  padding: 4px;
+  font-size: 12px;
+  display: flex;
+  flex-direction: column;
+  min-width: 170px;
+}
+.odysseus-root .od-compare-export-item {
+  background: none;
+  border: none;
+  color: var(--fg);
+  text-align: left;
+  padding: 8px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+}
+.odysseus-root .od-compare-export-item:hover {
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+}
+
+/* Grid of panes — style.css .compare-grid */
+.odysseus-root .od-compare-grid {
+  display: grid;
+  gap: 4px;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: hidden;
+  grid-auto-rows: 1fr;
+  padding: 4px;
+}
+.odysseus-root .od-compare-grid[data-cols="1"] { grid-template-columns: 1fr; }
+.odysseus-root .od-compare-grid[data-cols="2"] { grid-template-columns: 1fr 1fr; }
+.odysseus-root .od-compare-grid[data-cols="3"] { grid-template-columns: 1fr 1fr 1fr; }
+.odysseus-root .od-compare-grid[data-cols="4"] { grid-template-columns: repeat(4, 1fr); }
+
+/* Pane — style.css .compare-pane */
+.odysseus-root .od-compare-pane {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  min-height: 0;
+  min-width: 0;
+}
+.odysseus-root .od-pane-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+  border-bottom: 1px solid var(--border);
+  font-size: 0.82em;
+  font-weight: 600;
+  color: var(--fg);
+  transition: background 0.4s;
+  flex-shrink: 0;
+  overflow: hidden;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+/* pane title as clickable model-swap button — style.css .pane-title-btn */
+.odysseus-root .od-pane-title-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 400;
+  font-family: inherit;
+  color: var(--fg);
+  padding: 0;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: opacity 0.15s;
+  min-width: 0;
+  flex: 1 1 0;
+}
+.odysseus-root .od-pane-title-btn:hover { opacity: 0.7; }
+.odysseus-root .od-pane-title-caret {
+  font-size: 0.6em;
+  opacity: 0.35;
+  flex-shrink: 0;
+  position: relative;
+  top: 2px;
+}
+.odysseus-root .od-pane-title-btn:hover .od-pane-title-caret { opacity: 0.7; }
+.odysseus-root .od-pane-timer {
+  font-size: 10px;
+  font-weight: 400;
+  opacity: 0.45;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  padding-right: 4px;
+}
+.odysseus-root .od-pane-finish-badge {
+  font-weight: 600;
+  color: var(--red);
+}
+.odysseus-root .od-pane-actions {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+.odysseus-root .od-pane-action-btn {
+  background: none;
+  border: none;
+  color: var(--fg);
+  cursor: pointer;
+  opacity: 0.3;
+  padding: 2px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  transition: all 0.15s;
+}
+.odysseus-root .od-pane-action-btn:hover {
+  opacity: 0.8;
+  background: color-mix(in srgb, var(--fg) 6%, transparent);
+}
+.odysseus-root .od-pane-close-btn { opacity: 0.3; }
+.odysseus-root .od-pane-close-btn:hover { opacity: 1; color: var(--red); }
+
+/* Model swap dropdown — style.css .pane-model-dropdown / .pane-model-item */
+.odysseus-root .od-pane-model-dropdown {
+  position: absolute;
+  z-index: 1000;
+  top: 30px;
+  left: 6px;
+  min-width: 220px;
+  max-width: calc(100% - 12px);
+  max-height: 300px;
+  overflow-y: auto;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  padding: 4px;
+}
+.odysseus-root .od-pane-prov-select {
+  width: 100%;
+  padding: 6px 8px;
+  margin-bottom: 4px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.78em;
+  font-family: inherit;
+}
+.odysseus-root .od-pane-model-item {
+  display: block;
+  width: 100%;
+  padding: 6px 10px;
+  font-size: 0.7em;
+  text-align: left;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: var(--fg);
+  cursor: pointer;
+  transition: background 0.1s;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.odysseus-root .od-pane-model-item:hover {
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+}
+.odysseus-root .od-pane-model-item.current { color: var(--red); font-weight: 600; }
+.odysseus-root .od-pane-model-empty {
+  padding: 10px;
+  text-align: center;
+  font-size: 11px;
+  opacity: 0.5;
+}
+
+/* Pane chat-history scroller — style.css .compare-pane .chat-history */
+.odysseus-root .od-pane-history {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+}
+.odysseus-root .od-pane-ready {
+  margin: auto;
+  padding: 16px;
+  text-align: center;
+  font-size: 0.82em;
+  font-style: italic;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+
+/* Per-pane vote footer — style.css .pane-vote-footer / .pane-vote-btn */
+.odysseus-root .od-pane-vote-footer {
+  padding: 6px 8px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+  flex-shrink: 0;
+}
+.odysseus-root .od-pane-vote-btn {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, opacity 0.15s;
+}
+.odysseus-root .od-pane-vote-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent, var(--fg)) 12%, var(--bg));
+  border-color: var(--accent, var(--fg));
+}
+.odysseus-root .od-pane-vote-btn:disabled { cursor: not-allowed; opacity: 0.4; }
+.odysseus-root .od-pane-vote-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+/* Vote bar — style.css .compare-vote-bar / .compare-vote-btn */
+.odysseus-root .od-compare-vote-bar {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+}
+.odysseus-root .od-compare-vote-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 13px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--fg);
+  cursor: pointer;
+  font-size: 0.8em;
+  font-family: inherit;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+.odysseus-root .od-compare-vote-btn:hover:not(:disabled) {
+  border-color: var(--red);
+  background: color-mix(in srgb, var(--red) 11%, transparent);
+}
+.odysseus-root .od-compare-vote-btn:disabled { cursor: not-allowed; opacity: 0.25; }
+.odysseus-root .od-compare-vote-tie { opacity: 0.7; }
+.odysseus-root .od-compare-rematch-btn {
+  margin-left: 8px;
+  border-color: color-mix(in srgb, var(--fg) 20%, transparent);
+  opacity: 0.6;
+}
+.odysseus-root .od-compare-rematch-btn:hover { opacity: 1; }
+
+/* Composer + eval picker — style.css .chat-input-bar / .cmp-eval-* */
+.odysseus-root .od-compare-input-bar {
+  position: relative;
+  padding: 8px 10px 10px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.odysseus-root .od-cmp-input-top {
+  position: relative;
+  height: 0;
+}
+.odysseus-root .od-cmp-eval-wrap {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2;
+}
+.odysseus-root .od-cmp-eval-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  font-size: 11px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  opacity: 0.75;
+  transition: opacity 0.15s, border-color 0.15s;
+}
+.odysseus-root .od-cmp-eval-btn:hover { opacity: 1; border-color: var(--fg); }
+.odysseus-root .od-cmp-eval-caret { opacity: 0.7; transform: rotate(180deg); }
+.odysseus-root .od-cmp-eval-menu {
+  position: absolute;
+  bottom: calc(100% + 4px);
+  right: 0;
+  min-width: 220px;
+  max-width: 280px;
+  max-height: 360px;
+  overflow-y: auto;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.3);
+  padding: 4px;
+  z-index: 1000;
+}
+.odysseus-root .od-cmp-eval-group-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.45;
+  font-weight: 600;
+  padding: 6px 8px 2px;
+}
+.odysseus-root .od-cmp-eval-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 5px 8px;
+  background: none;
+  border: none;
+  color: var(--fg);
+  font-size: 11px;
+  font-family: inherit;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.odysseus-root .od-cmp-eval-item:hover {
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+}
+.odysseus-root .od-cmp-eval-item-tick {
+  float: right;
+  margin-left: 6px;
+  font-size: 10px;
+  color: var(--ok);
+  opacity: 0.8;
+}
+/* Expected-answer chip — style.css .cmp-eval-expected */
+.odysseus-root .od-cmp-eval-expected {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  right: 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  font-size: 11px;
+  background: var(--panel);
+  border: 1px solid color-mix(in srgb, var(--ok) 50%, transparent);
+  border-radius: 8px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4), 0 1px 2px rgba(0, 0, 0, 0.2);
+  color: var(--fg);
+  width: fit-content;
+  z-index: 5;
+}
+.odysseus-root .od-cmp-eval-expected-label {
+  opacity: 0.6;
+  text-transform: uppercase;
+  font-size: 9px;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+}
+.odysseus-root .od-cmp-eval-expected-value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 11px;
+}
+.odysseus-root .od-cmp-eval-expected-close {
+  background: none;
+  border: none;
+  color: var(--fg);
+  font-size: 14px;
+  line-height: 1;
+  padding: 0 0 0 4px;
+  opacity: 0.5;
+  cursor: pointer;
+  font-family: inherit;
+}
+.odysseus-root .od-cmp-eval-expected-close:hover { opacity: 1; }
+.odysseus-root .od-compare-input {
+  width: 100%;
+  min-height: 52px;
+  resize: none;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 0.9em;
+  line-height: 1.4;
+}
+.odysseus-root .od-compare-input:focus {
+  outline: none;
+  border-color: var(--accent, var(--fg));
+}
+
+/* Scoreboard overlay — scoreboard.js + style.css .scoreboard-table */
+.odysseus-root .od-compare-scoreboard-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 10001;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.odysseus-root .od-compare-scoreboard {
+  position: relative;
+  z-index: 1;
+  width: min(520px, 92vw);
+  max-height: 80vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 14px 16px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.45);
+}
+.odysseus-root .od-scoreboard-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88em;
+}
+.odysseus-root .od-scoreboard-table th {
+  text-align: center;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+  font-size: 0.85em;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.odysseus-root .od-scoreboard-table th:first-child { text-align: left; }
+.odysseus-root .od-scoreboard-table td {
+  padding: 5px 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 40%, transparent);
+  text-align: center;
+}
+.odysseus-root .od-scoreboard-table td.od-scoreboard-model {
+  text-align: left;
+  font-weight: 500;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.odysseus-root .od-scoreboard-table td.od-scoreboard-pct {
+  font-weight: 600;
+  color: var(--red);
+}
+.odysseus-root .od-scoreboard-table tbody tr:hover {
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
+}
+.odysseus-root .od-scoreboard-clear-btn {
+  align-self: flex-end;
+  padding: 4px 12px;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--fg);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+  opacity: 0.6;
+  transition: opacity 0.15s;
+}
+.odysseus-root .od-scoreboard-clear-btn:hover { opacity: 1; }
+
+/* ===== ResearchView ===== */
+
+/* ── Deep Research panel (odysseus static/js/research/* + .research-*/.rs-* in style.css), 1:1.
+   Colors mapped onto the eliza theme vars: --accent-primary→--accent, --fg-dim/--fg-muted→--muted,
+   --color-success→--ok. The odysseus source already used var(--accent, var(--red)) fallbacks. */
+
+/* Pane: override the shared .od-search-panel sizing to odysseus's centered ~640px / 85vh modal. */
+.odysseus-root .od-search-panel.research-pane {
+  width: min(640px, 92vw); max-width: 92vw; max-height: 85vh;
+  display: flex; flex-direction: column;
+  padding: 10px; box-sizing: border-box;
+  font-size: 12px; letter-spacing: -0.015em;
+  position: relative; isolation: isolate; overflow: hidden;
+  background: var(--bg);
+}
+.odysseus-root .research-pane-header {
+  display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: 6px; user-select: none;
+}
+.odysseus-root .research-pane-header h4 {
+  margin: 0; display: flex; align-items: center; gap: 6px;
+  font-size: 1rem; font-weight: 600; letter-spacing: -0.03em; color: var(--red);
+}
+.odysseus-root .research-pane-header-actions { display: flex; align-items: center; gap: 2px; margin-left: auto; }
+.odysseus-root .research-pane-close {
+  background: transparent; border: none; color: var(--fg); opacity: 0.55;
+  cursor: pointer; padding: 2px; display: flex; transition: opacity 0.15s;
+}
+.odysseus-root .research-pane-close:hover { opacity: 1; }
+.odysseus-root .research-pane-body {
+  flex: 1; min-height: 0; overflow: hidden; display: flex; flex-direction: column;
+  padding: 0; margin: 0; background: transparent; border: 0; border-radius: 0;
+  font-size: 12px; color: var(--fg);
+}
+
+/* New-job compose card (.research-new-job → admin-card surface). */
+.odysseus-root .research-new-job {
+  padding: 12px; margin-bottom: 10px; background: var(--panel);
+  border: 1px solid var(--border); border-radius: 8px; flex-shrink: 0;
+}
+.odysseus-root .research-new-job-title { display: flex; align-items: baseline; gap: 8px; margin-bottom: 2px; }
+.odysseus-root .research-new-job h2 { margin: 0; padding: 0; line-height: 1; font-size: 14px; font-weight: 600; letter-spacing: -0.03em; }
+.odysseus-root .research-stats { font-size: 0.6em; opacity: 0.6; font-weight: normal; }
+.odysseus-root .memory-count { font-variant-numeric: tabular-nums; }
+.odysseus-root .memory-desc { font-size: 12px; opacity: 0.7; }
+.odysseus-root .research-desc { margin-top: 6px; display: flex; align-items: center; gap: 6px; }
+.odysseus-root .research-desc svg { flex-shrink: 0; opacity: 0.8; }
+.odysseus-root .research-query {
+  width: 100%; resize: vertical; min-height: 80px; max-height: 240px;
+  background: var(--bg); color: var(--fg); border: 1px solid var(--border); border-radius: 6px;
+  padding: 8px 10px; font-size: 12px; font-family: inherit; box-sizing: border-box; margin-top: 6px;
+}
+.odysseus-root .research-query:focus { outline: none; border-color: var(--accent, var(--red)); }
+
+/* Category chips (.research-cat → doclib-chip). */
+.odysseus-root .research-category-row { display: flex; gap: 4px; margin-top: 8px; flex-wrap: wrap; }
+.odysseus-root .research-cat {
+  padding: 2px 10px; border-radius: 12px; font-size: 10px;
+  border: 1px solid var(--border); background: transparent; color: var(--muted);
+  cursor: pointer; user-select: none;
+  transition: background 0.15s, border-color 0.15s, color 0.15s; position: relative; top: -4px;
+}
+.odysseus-root .research-cat:hover { border-color: var(--red); }
+.odysseus-root .research-cat.active {
+  background: color-mix(in srgb, var(--red) 15%, transparent);
+  border-color: color-mix(in srgb, var(--red) 40%, transparent); color: var(--red);
+}
+
+/* Settings toggle + body. */
+.odysseus-root .research-settings-toggle {
+  display: flex; align-items: center; gap: 6px; width: 100%; text-align: left;
+  height: 26px; padding: 0 8px; margin-top: 23px;
+  background: none; border: 1px solid var(--border); border-radius: 4px;
+  color: color-mix(in srgb, var(--fg) 60%, transparent);
+  font-size: 11px; font-family: inherit; cursor: pointer; transition: all 0.15s;
+}
+.odysseus-root .research-settings-toggle:hover { color: var(--fg); border-color: var(--fg); }
+.odysseus-root .research-settings-chevron { display: inline-flex; transition: transform 0.2s; margin-left: auto; }
+.odysseus-root .research-settings-toggle.collapsed .research-settings-chevron { transform: rotate(-90deg); }
+.odysseus-root .research-settings-row {
+  display: flex; gap: 6px; margin-top: 8px; flex-wrap: wrap; padding: 8px 10px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+  border: 1px solid var(--border); border-radius: 6px;
+}
+.odysseus-root .research-setting { display: flex; flex-direction: column; flex: 1; min-width: 90px; }
+.odysseus-root .research-setting-label { font-size: 9px; text-transform: uppercase; letter-spacing: 0.5px; opacity: 0.5; margin-bottom: 2px; }
+.odysseus-root .research-setting select {
+  font-size: 11px; padding: 4px 6px; background: var(--bg); color: var(--fg);
+  border: 1px solid var(--border); border-radius: 4px;
+}
+
+/* Controls row (Queue / Start). */
+.odysseus-root .research-controls-row { display: flex; align-items: center; gap: 10px; margin-top: 10px; }
+.odysseus-root .research-add-btn {
+  padding: 6px 14px; border: 1px solid var(--border); border-radius: 6px;
+  background: transparent; color: var(--fg); font-size: 12px; cursor: pointer; transition: background 0.15s;
+}
+.odysseus-root .research-add-btn:hover:not(:disabled) { background: color-mix(in srgb, var(--border) 30%, transparent); }
+.odysseus-root .research-start-btn {
+  margin-left: auto; display: flex; align-items: center; gap: 5px;
+  padding: 6px 16px; border: none; border-radius: 6px;
+  background: var(--accent, var(--red)); color: #fff; font-size: 12px; font-weight: 600;
+  cursor: pointer; transition: opacity 0.15s;
+}
+.odysseus-root .research-start-btn:hover:not(:disabled) { opacity: 0.85; }
+.odysseus-root .research-add-btn:disabled, .odysseus-root .research-start-btn:disabled { opacity: 0.6; cursor: not-allowed; }
+
+/* Jobs list. */
+.odysseus-root .research-jobs-list {
+  flex: 1; min-height: 0; overflow-y: auto; padding: 6px 0;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.odysseus-root .research-empty { text-align: center; padding: 30px 14px; font-size: 12px; opacity: 0.4; }
+
+/* Foldable sections (Active / Past research). */
+.odysseus-root .research-section {
+  margin-top: 6px; background: var(--panel); border: 1px solid var(--border);
+  border-radius: 8px; overflow: hidden;
+}
+.odysseus-root .research-section-header {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  padding: 10px 12px; user-select: none; transition: background 0.15s;
+}
+.odysseus-root .research-section:not(.collapsed) > .research-section-header { border-bottom: 1px solid var(--border); }
+.odysseus-root .research-section-header:hover { background: color-mix(in srgb, var(--fg) 4%, transparent); }
+.odysseus-root .research-section-toggle {
+  display: flex; align-items: center; gap: 8px; flex: 1; min-width: 0;
+  background: none; border: none; color: inherit; cursor: pointer; text-align: left; padding: 0; font: inherit;
+}
+.odysseus-root .research-section-title { font-size: 14px; font-weight: 600; letter-spacing: -0.03em; }
+.odysseus-root .research-section-count { font-size: 10px; opacity: 0.6; font-weight: normal; font-variant-numeric: tabular-nums; }
+.odysseus-root .research-section-right { display: flex; align-items: center; gap: 8px; margin-left: auto; }
+.odysseus-root .research-section-clear {
+  display: inline-flex; align-items: center; gap: 4px;
+  background: none; border: 1px solid transparent; color: var(--muted);
+  font-size: 10px; font-family: inherit; cursor: pointer; padding: 2px 6px; border-radius: 4px;
+  opacity: 0.6; transition: all 0.15s;
+}
+.odysseus-root .research-section-clear:hover { opacity: 1; color: var(--fg); border-color: var(--border); }
+.odysseus-root .research-section-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; opacity: 0.9; }
+.odysseus-root .research-section-dot.pulsing { animation: research-dot-pulse 1.5s ease-in-out infinite; }
+@keyframes research-dot-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent, var(--red)) 55%, transparent); }
+  70%      { box-shadow: 0 0 0 6px color-mix(in srgb, var(--accent, var(--red)) 0%, transparent); }
+}
+.odysseus-root .research-section-chevron { flex-shrink: 0; opacity: 0.55; transition: transform 0.2s ease; }
+.odysseus-root .research-section.collapsed .research-section-chevron { transform: rotate(-90deg); }
+.odysseus-root .research-section-body { display: flex; flex-direction: column; gap: 8px; padding: 12px; }
+.odysseus-root .research-section.collapsed .research-section-body { display: none; }
+.odysseus-root .research-library-hint { padding: 0 12px 4px; font-size: 11px; opacity: 0.7; }
+
+/* Job cards (.research-job-card → doclib-card). */
+.odysseus-root .research-job-card {
+  margin: 0; padding: 8px 10px; background: color-mix(in srgb, var(--fg) 3%, transparent);
+  border: 1px solid var(--border); border-radius: 8px; transition: background 0.15s, border-color 0.15s;
+}
+.odysseus-root .research-job-card:hover {
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
+  border-color: color-mix(in srgb, var(--fg) 16%, transparent);
+}
+.odysseus-root .research-job-card.running { border-left: 3px solid var(--accent, var(--red)); }
+.odysseus-root .research-job-card.queued { border-left: 3px solid var(--muted); }
+.odysseus-root .research-job-card.done { border-left: 1px solid var(--border); }
+.odysseus-root .research-job-card.done.from-library { opacity: 1; }
+.odysseus-root .research-job-card.error, .odysseus-root .research-job-card.cancelled { border-left: 3px solid var(--red); }
+.odysseus-root .research-job-card[data-category] { --cat-color: var(--accent, var(--red)); }
+.odysseus-root .research-job-card[data-category="product"]    { --cat-color: #5b8abf; }
+.odysseus-root .research-job-card[data-category="comparison"] { --cat-color: #e5a33a; }
+.odysseus-root .research-job-card[data-category="howto"]      { --cat-color: #82c882; }
+.odysseus-root .research-job-card[data-category="landscape"]  { --cat-color: #a07ae0; }
+.odysseus-root .research-job-card[data-category="factcheck"]  { --cat-color: var(--red); }
+.odysseus-root .research-job-card.done[data-category] { background: color-mix(in srgb, var(--cat-color) 4%, transparent); }
+.odysseus-root .research-job-card.done[data-category]:hover { background: color-mix(in srgb, var(--cat-color) 7%, transparent); }
+
+/* Job header + meta. */
+.odysseus-root .research-job-header { display: flex; align-items: center; gap: 8px; }
+.odysseus-root .research-job-header-btn {
+  display: block; width: 100%; background: none; border: none; padding: 0;
+  font: inherit; color: inherit; cursor: pointer; text-align: left;
+}
+.odysseus-root .research-job-card.running .research-job-query,
+.odysseus-root .research-job-card.running .research-cat-badge,
+.odysseus-root .research-job-card.running .research-job-model,
+.odysseus-root .research-job-card.running .research-job-time { position: relative; top: -4px; }
+.odysseus-root .research-job-query {
+  flex: 1; font-size: 11px; font-weight: 600; letter-spacing: -0.01em;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--fg);
+}
+.odysseus-root .research-job-time, .odysseus-root .research-job-meta { font-size: 10px; opacity: 0.5; white-space: nowrap; font-family: monospace; }
+.odysseus-root .research-job-status { font-size: 10px; text-transform: uppercase; opacity: 0.6; }
+.odysseus-root .research-job-model { font-size: 9px; opacity: 0.4; white-space: nowrap; max-width: 120px; overflow: hidden; text-overflow: ellipsis; }
+.odysseus-root .research-job-cancel { background: transparent; border: none; color: var(--fg); opacity: 0.4; cursor: pointer; padding: 2px; display: flex; transition: opacity 0.15s; }
+.odysseus-root .research-job-cancel:hover { opacity: 1; }
+.odysseus-root .research-job-phase { font-size: 11px; opacity: 0.6; margin-top: 4px; }
+.odysseus-root .research-job-queued-meta { font-size: 10px; opacity: 0.4; margin-top: 2px; }
+.odysseus-root .research-job-error { font-size: 11px; color: var(--red); margin-top: 4px; line-height: 1.4; word-break: break-word; }
+
+/* Category badge. */
+.odysseus-root .research-cat-badge {
+  font-size: 10px; font-weight: 500; text-transform: lowercase; letter-spacing: 0;
+  padding: 0; background: transparent; border: 0; border-radius: 0;
+  color: var(--cat-color, var(--accent)); opacity: 0.55; flex-shrink: 0; margin-left: 2px;
+  position: relative; top: -1px; display: inline-flex; align-items: center; gap: 3px;
+}
+.odysseus-root .research-cat-badge.research-cat-standard { color: var(--ok); opacity: 0.75; }
+.odysseus-root .research-cat-badge.research-cat-failed { color: var(--red); opacity: 0.8; }
+
+/* Action buttons (.research-job-action → doclib-toolbar-btn). */
+.odysseus-root .research-job-actions { display: flex; gap: 4px; margin-top: 6px; }
+.odysseus-root .research-job-actions .research-job-action:not(.research-job-action-dim) + .research-job-action-dim { margin-left: auto; }
+.odysseus-root .research-job-actions > .research-job-action-dim:first-child { margin-left: auto; }
+.odysseus-root .research-job-action {
+  display: inline-flex; align-items: center; gap: 4px; padding: 5px 10px;
+  background: none; border: 1px solid var(--border); border-radius: 6px;
+  color: var(--muted); font-size: 11px; font-family: inherit; white-space: nowrap;
+  cursor: pointer; transition: all 0.15s;
+}
+.odysseus-root .research-job-action:hover:not(:disabled) { color: var(--fg); border-color: var(--fg); }
+.odysseus-root .research-job-action:disabled { opacity: 0.45; cursor: not-allowed; }
+.odysseus-root .research-job-action-dim { opacity: 0.5; border-color: transparent; }
+.odysseus-root .research-job-action-dim:hover:not(:disabled) { opacity: 1; }
+
+/* Progress bar. */
+.odysseus-root .research-progress-bar { height: 3px; background: var(--border); border-radius: 2px; margin-top: 6px; overflow: hidden; }
+.odysseus-root .research-progress-fill { height: 100%; background: var(--accent, var(--red)); border-radius: 2px; transition: width 0.4s ease; }
+
+/* Result / report. */
+.odysseus-root .research-job-result { margin-top: 10px; border-top: 1px solid var(--border); padding-top: 10px; }
+.odysseus-root .research-job-sources { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 8px; }
+.odysseus-root .research-source-link {
+  font-size: 10px; padding: 2px 6px; background: color-mix(in srgb, var(--accent, var(--red)) 10%, transparent);
+  border-radius: 3px; color: var(--accent, var(--red)); text-decoration: none; white-space: nowrap;
+  max-width: 200px; overflow: hidden; text-overflow: ellipsis;
+}
+.odysseus-root .research-source-link:hover { text-decoration: underline; }
+.odysseus-root .research-source-more { font-size: 10px; opacity: 0.5; padding: 2px 4px; }
+.odysseus-root .research-job-report-body { font-size: 12px; line-height: 1.55; max-height: 400px; overflow-y: auto; }
+.odysseus-root .research-job-report-body h1,
+.odysseus-root .research-job-report-body h2,
+.odysseus-root .research-job-report-body h3 { font-size: 13px; margin: 12px 0 4px; color: var(--cat-color, var(--accent, var(--fg))); }
+.odysseus-root .research-job-report-body p { margin: 4px 0; }
+.odysseus-root .research-job-report-body ul { margin: 4px 0; }
+
+/* Category hero banner. */
+.odysseus-root .research-hero {
+  display: flex; align-items: center; gap: 14px; padding: 16px 18px; margin: 8px 0 14px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, color-mix(in srgb, var(--cat-color, var(--accent)) 18%, transparent) 0%, color-mix(in srgb, var(--cat-color, var(--accent)) 5%, transparent) 100%);
+  border-left: 4px solid var(--cat-color, var(--accent)); position: relative; overflow: hidden;
+}
+.odysseus-root .research-hero::after {
+  content: ''; position: absolute; right: -40px; top: -40px; width: 160px; height: 160px; border-radius: 50%;
+  background: radial-gradient(circle, color-mix(in srgb, var(--cat-color, var(--accent)) 15%, transparent) 0%, transparent 60%); pointer-events: none;
+}
+.odysseus-root .research-hero-icon {
+  flex-shrink: 0; width: 32px; height: 32px; color: var(--cat-color, var(--accent));
+  display: flex; align-items: center; justify-content: center;
+  filter: drop-shadow(0 2px 4px color-mix(in srgb, var(--cat-color, var(--accent)) 40%, transparent));
+}
+.odysseus-root .research-hero-text { flex: 1; min-width: 0; }
+.odysseus-root .research-hero-label { font-size: 10px; text-transform: uppercase; letter-spacing: 1.2px; font-weight: 700; opacity: 0.7; margin-bottom: 3px; color: var(--cat-color, var(--accent)); }
+.odysseus-root .research-hero-query { font-size: 15px; font-weight: 600; line-height: 1.3; color: var(--fg); }
+
+/* Per-category report body theming. */
+.odysseus-root .research-body-product ul { list-style: none; padding-left: 0; }
+.odysseus-root .research-body-product ul li {
+  padding: 6px 10px 6px 28px; margin: 4px 0;
+  border-left: 2px solid color-mix(in srgb, #5b8abf 40%, transparent);
+  background: color-mix(in srgb, #5b8abf 4%, transparent); border-radius: 0 4px 4px 0; position: relative;
+}
+.odysseus-root .research-body-product ul li::before { content: '▸'; position: absolute; left: 10px; color: #5b8abf; font-weight: bold; }
+.odysseus-root .research-body-howto ol { counter-reset: howto-step; list-style: none; padding-left: 0; }
+.odysseus-root .research-body-howto ol > li {
+  counter-increment: howto-step; position: relative; padding: 10px 12px 10px 52px; margin: 8px 0;
+  background: color-mix(in srgb, #82c882 5%, transparent); border-radius: 8px; border-left: 2px solid #82c882;
+}
+.odysseus-root .research-body-howto ol > li::before {
+  content: counter(howto-step); position: absolute; left: 10px; top: 14px;
+  width: 30px; height: 30px; border-radius: 50%; background: #82c882; color: #fff;
+  font-weight: 700; font-size: 13px; display: flex; align-items: center; justify-content: center;
+  box-shadow: 0 2px 6px color-mix(in srgb, #82c882 40%, transparent);
+}
+.odysseus-root .research-body-factcheck strong {
+  color: var(--red); padding: 1px 6px; border-radius: 4px; background: color-mix(in srgb, var(--red) 12%, transparent);
+}
+
+/* ── Synapse graph (researchSynapse.js + .research-synapse / .rs-* in style.css). ── */
+.odysseus-root .research-synapse {
+  margin: 6px 0 4px; border: 1px solid var(--border); border-radius: 10px;
+  background:
+    radial-gradient(ellipse at center, color-mix(in srgb, var(--accent, var(--red)) 10%, transparent) 0%, transparent 70%),
+    color-mix(in srgb, var(--panel) 50%, var(--bg));
+  overflow: hidden;
+}
+.odysseus-root .research-synapse .rs-stage { height: 200px; position: relative; }
+.odysseus-root .research-synapse-compact .rs-stage { height: 130px; }
+.odysseus-root .research-synapse-compact .rs-meta { padding: 4px 8px 5px; font-size: 10px; }
+.odysseus-root .research-synapse-compact .rs-label-sub { font-size: 8px; }
+.odysseus-root .research-synapse svg { display: block; width: 100%; height: 100%; }
+.odysseus-root .research-synapse .rs-edge { stroke: var(--border); stroke-width: 1.2; fill: none; opacity: 0.55; }
+.odysseus-root .research-synapse .rs-node {
+  fill: var(--bg); stroke: var(--accent, var(--red)); stroke-width: 1.5;
+  transition: all 0.3s ease; transform-box: fill-box; transform-origin: center;
+}
+.odysseus-root .research-synapse .rs-node-root { fill: var(--accent, var(--red)); stroke: var(--accent, var(--red)); }
+.odysseus-root .research-synapse .rs-node-sub { stroke: color-mix(in srgb, var(--accent, var(--red)) 70%, var(--fg)); }
+.odysseus-root .research-synapse .rs-node-leaf {
+  stroke: color-mix(in srgb, var(--accent, var(--red)) 55%, transparent);
+  fill: color-mix(in srgb, var(--accent, var(--red)) 22%, var(--bg));
+}
+.odysseus-root .research-synapse .rs-pulse {
+  fill: var(--accent, var(--red)); opacity: 0;
+  animation: rs-pulse 2.6s ease-out infinite; transform-box: fill-box; transform-origin: center;
+}
+@keyframes rs-pulse {
+  0%   { transform: scale(1); opacity: 0.65; }
+  100% { transform: scale(5); opacity: 0; }
+}
+.odysseus-root .research-synapse .rs-label { fill: var(--fg); font-size: 10px; font-family: ui-monospace, "JetBrains Mono", monospace; pointer-events: none; opacity: 0.85; }
+.odysseus-root .research-synapse .rs-label-sub { font-size: 9px; opacity: 0.7; }
+.odysseus-root .research-synapse .rs-meta {
+  display: flex; align-items: center; gap: 6px; flex-wrap: wrap; padding: 6px 10px 8px;
+  font-family: ui-monospace, "JetBrains Mono", monospace; font-size: 11px; color: var(--muted); opacity: 0.85;
+  border-top: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
+}
+.odysseus-root .research-synapse .rs-meta .rs-status { color: var(--accent, var(--red)); font-weight: 600; }
+.odysseus-root .research-synapse .rs-meta b { color: var(--fg); font-weight: 600; }
+.odysseus-root .research-synapse .rs-meta .rs-sep { opacity: 0.4; }
+.odysseus-root .research-synapse.rs-complete .rs-pulse { animation: none; opacity: 0; }
+.odysseus-root .research-synapse.rs-complete .rs-node-root { fill: var(--ok); stroke: var(--ok); }
+.odysseus-root .research-synapse.rs-complete .rs-meta .rs-status { color: var(--ok); }
+.odysseus-root .research-job-synapse-host.synapse-collapsed { display: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .odysseus-root .research-synapse .rs-pulse { animation: none; }
+  .odysseus-root .research-section-dot.pulsing { animation: none; }
+}
+
+/* ===== DocumentLibraryView ===== */
+
+/* ── document library (documentLibrary.js #doclib-modal Documents tab + rag.js) ── */
+.odysseus-root .od-doclib-panel { width:640px; max-width:92%; display:flex; flex-direction:column; max-height:85vh; }
+.odysseus-root .od-doclib-header { display:flex; align-items:center; gap:8px; padding:13px 16px 6px; }
+.odysseus-root .od-doclib-title { font-size:14px; font-weight:600; letter-spacing:-0.03em; color:var(--fg); }
+.odysseus-root .od-doclib-count { font-size:11px; color:color-mix(in srgb, var(--fg) 55%, transparent); }
+.odysseus-root .od-doclib-toolbar-btn { background:none; border:1px solid var(--border);
+  color:color-mix(in srgb, var(--fg) 60%, transparent); font-size:11px; height:24px; padding:0 8px; border-radius:6px;
+  cursor:pointer; font-family:inherit; white-space:nowrap; display:inline-flex; align-items:center; gap:3px;
+  transition:all .15s; }
+.odysseus-root .od-doclib-toolbar-btn:hover { border-color:var(--fg); color:var(--fg); }
+.odysseus-root .od-doclib-import { margin-left:auto; }
+.odysseus-root .od-doclib-close { background:var(--bg); color:var(--fg); border:1px solid var(--fg); font-size:12px;
+  width:24px; height:24px; padding:0; display:inline-flex; align-items:center; justify-content:center; line-height:1;
+  cursor:pointer; border-radius:4px; flex-shrink:0; }
+.odysseus-root .od-doclib-close:hover { background:var(--fg); color:var(--bg); }
+.odysseus-root .od-doclib-file-input { display:none; }
+.odysseus-root .od-doclib-desc { margin:0; padding:0 16px; font-size:11px; line-height:1.5;
+  color:color-mix(in srgb, var(--fg) 50%, transparent); }
+.odysseus-root .od-doclib-toolbar { display:flex; align-items:center; gap:8px; padding:8px 16px; }
+.odysseus-root .od-doclib-filters { display:flex; gap:4px; flex-wrap:wrap; }
+.odysseus-root .od-doclib-sort { background:var(--bg); color:var(--fg); border:1px solid var(--border);
+  border-radius:6px; font-family:inherit; font-size:11px; height:24px; padding:0 6px; cursor:pointer; }
+.odysseus-root .od-doclib-sort:focus { outline:none; border-color:var(--red); }
+.odysseus-root .od-doclib-search { height:24px; padding:0 8px; border-radius:6px; border:1px solid var(--border);
+  background:var(--bg); color:var(--fg); font-family:inherit; font-size:11px; flex:1; box-sizing:border-box; }
+.odysseus-root .od-doclib-search:focus { outline:none; border-color:var(--red); }
+.odysseus-root .od-doclib-search::placeholder { color:color-mix(in srgb, var(--fg) 40%, transparent); }
+.odysseus-root .od-doclib-grid { display:flex; flex-direction:column; gap:4px; overflow-y:auto; padding:2px 16px;
+  min-height:0; flex:1; }
+.odysseus-root .od-doclib-empty { text-align:center; color:color-mix(in srgb, var(--fg) 35%, transparent);
+  padding:32px 16px; font-size:12px; font-style:italic; }
+.odysseus-root .od-doclib-card { display:flex; align-items:flex-start; gap:8px; flex-direction:row; flex-wrap:wrap;
+  border:1px solid var(--border); border-radius:8px; background:color-mix(in srgb, var(--fg) 3%, transparent);
+  cursor:pointer; position:relative; transition:all .15s; flex-shrink:0; }
+.odysseus-root .od-doclib-card:hover { background:color-mix(in srgb, var(--fg) 5%, transparent);
+  border-color:color-mix(in srgb, var(--fg) 16%, transparent); }
+.odysseus-root .od-doclib-card-main { flex:1; min-width:0; display:flex; background:none; border:none; padding:8px 10px;
+  cursor:pointer; text-align:left; color:inherit; font-family:inherit; }
+.odysseus-root .od-doclib-content { flex:1; min-width:0; padding-top:4px; }
+.odysseus-root .od-doclib-titlerow { display:flex; align-items:center; gap:6px; width:100%; }
+.odysseus-root .od-doclib-item-title { font-size:12px; font-weight:500; overflow:hidden; text-overflow:ellipsis;
+  white-space:nowrap; flex:0 1 auto; min-width:0; display:inline-flex; align-items:center; gap:4px; color:var(--fg); }
+.odysseus-root .od-doclib-doc-icon { opacity:.55; flex-shrink:0; }
+.odysseus-root .od-doclib-ver { font-size:9px; padding:1px 6px; border-radius:8px; flex-shrink:0; font-weight:600;
+  letter-spacing:.3px; text-transform:lowercase;
+  background:color-mix(in srgb, var(--red) 15%, transparent);
+  border:1px solid color-mix(in srgb, var(--red) 40%, transparent); color:var(--red); }
+.odysseus-root .od-doclib-ver-muted { background:color-mix(in srgb, var(--fg) 6%, transparent);
+  border-color:color-mix(in srgb, var(--fg) 12%, transparent); color:color-mix(in srgb, var(--fg) 35%, transparent); }
+.odysseus-root .od-doclib-chevron { margin-left:auto; align-self:center; opacity:.6; flex-shrink:0;
+  transition:transform .15s ease; }
+.odysseus-root .od-doclib-card-expanded .od-doclib-chevron { transform:rotate(180deg); }
+.odysseus-root .od-doclib-meta { font-size:10px; opacity:.55; margin-top:2px; display:flex; align-items:center;
+  gap:6px; flex-wrap:wrap; color:var(--fg); }
+.odysseus-root .od-doclib-meta-sep { opacity:.5; }
+.odysseus-root .od-doclib-actions { display:flex; gap:4px; flex-shrink:0; position:relative; padding:8px 8px 0 0; }
+.odysseus-root .od-doclib-item-btn { background:none; border:1px solid transparent;
+  color:color-mix(in srgb, var(--fg) 50%, transparent); height:22px; padding:0 6px; border-radius:6px; cursor:pointer;
+  display:flex; align-items:center; opacity:0; transition:all .15s; }
+.odysseus-root .od-doclib-card:hover .od-doclib-item-btn { opacity:1; }
+.odysseus-root .od-doclib-item-btn:hover { color:var(--fg); border-color:var(--border);
+  background:color-mix(in srgb, var(--fg) 6%, transparent); }
+.odysseus-root .od-doclib-dropdown { position:absolute; top:100%; right:0; z-index:1000; width:max-content; padding:4px;
+  background:var(--panel); border:1px solid var(--border); border-radius:8px; box-shadow:0 8px 24px rgba(0,0,0,.3);
+  font-size:12px; }
+.odysseus-root .od-doclib-dropdown-item { display:flex; align-items:center; gap:7px; width:100%; text-align:left;
+  padding:6px 10px; border:none; background:none; color:var(--fg); font-size:12px; border-radius:4px; cursor:pointer;
+  font-family:inherit; }
+.odysseus-root .od-doclib-dropdown-item:hover { background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-doclib-dropdown-item:disabled { opacity:.35; cursor:default; }
+.odysseus-root .od-doclib-dropdown-danger { color:var(--red); }
+.odysseus-root .od-doclib-card-expanded { flex-direction:column; cursor:default; }
+.odysseus-root .od-doclib-preview { flex-basis:100%; width:100%; padding:8px 12px;
+  font-family:'Fira Code', ui-monospace, monospace; font-size:9.5px; line-height:1.5;
+  color:var(--hl-fg, var(--fg)); border-top:1px solid color-mix(in srgb, var(--border) 30%, transparent); margin:0; }
+.odysseus-root .od-doclib-preview pre { margin:0; max-height:40vh; overflow-y:auto; white-space:pre-wrap;
+  word-break:break-word; }
+.odysseus-root .od-doclib-preview code { background:none; padding:0; font-family:inherit; }
+.odysseus-root .od-doclib-expanded-actions { display:flex; align-items:flex-start; gap:6px; padding:8px 0 2px;
+  border-top:1px solid color-mix(in srgb, var(--border) 30%, transparent); margin-top:4px; }
+.odysseus-root .od-doclib-action-group { display:flex; flex-direction:column; gap:3px; margin-left:auto; }
+.odysseus-root .od-doclib-text-btn { display:inline-flex; align-items:center; justify-content:center; gap:4px;
+  box-sizing:border-box; font-size:10px; padding:3px 8px; border-radius:4px; background:none; border:1px solid var(--border);
+  color:color-mix(in srgb, var(--fg) 60%, transparent); cursor:pointer; font-family:inherit;
+  transition:border-color .15s, color .15s; }
+.odysseus-root .od-doclib-text-btn:hover { border-color:var(--red); color:var(--red); }
+.odysseus-root .od-doclib-text-btn:disabled { opacity:.35; cursor:not-allowed; }
+.odysseus-root .od-doclib-text-btn-danger { color:var(--red); border-color:color-mix(in srgb, var(--red) 60%, transparent); }
+.odysseus-root .od-doclib-text-btn-danger:hover { border-color:var(--red); color:var(--red); }
+.odysseus-root .od-doclib-load-more { display:block; margin:8px auto 12px; padding:6px 16px; background:transparent;
+  border:1px solid var(--border); border-radius:6px; color:color-mix(in srgb, var(--fg) 60%, transparent); font-size:11px;
+  cursor:pointer; flex-shrink:0; font-family:inherit; transition:border-color .15s, color .15s; }
+.odysseus-root .od-doclib-load-more:hover { border-color:var(--red); color:var(--red); }
+
+/* ===== CalendarView ===== */
+
+/* ── calendar view (od-cal-*) — ported 1:1 from odysseus calendar.js + the
+   .cal-* rules in static/style.css, re-prefixed od- and scoped under
+   .odysseus-root; colours mapped onto the theme CSS-vars so the theme engine
+   recolours the clone. ── */
+.odysseus-root .od-cal-panel { width:min(720px, 94vw); max-width:94vw; display:flex; flex-direction:row; gap:0; }
+.odysseus-root .od-cal-body { flex:1; min-width:0; display:flex; flex-direction:column; gap:8px; padding:14px 16px; min-height:0; overflow:hidden; }
+
+/* toolbar */
+.odysseus-root .od-cal-toolbar { display:flex; align-items:center; gap:6px; flex-wrap:wrap; line-height:1; max-width:100%; row-gap:6px; }
+.odysseus-root .od-cal-toolbar-nav { display:inline-flex; align-items:center; gap:4px; flex-wrap:wrap; }
+.odysseus-root .od-cal-toolbar-right { display:inline-flex; align-items:center; gap:6px; margin-left:auto; flex-wrap:wrap; }
+.odysseus-root .od-cal-title { font-size:13px; font-weight:600; white-space:nowrap; height:24px; line-height:24px; padding:0 6px; display:inline-flex; align-items:center; box-sizing:border-box; color:var(--fg); }
+.odysseus-root button.od-cal-nav { display:inline-flex; align-items:center; justify-content:center; background:color-mix(in srgb, var(--fg) 6%, transparent); border:1px solid var(--border); color:var(--fg); border-radius:5px; padding:0 8px; height:24px; cursor:pointer; font-size:11px; font-family:inherit; box-sizing:border-box; }
+.odysseus-root button.od-cal-nav:hover { background:color-mix(in srgb, var(--fg) 12%, transparent); }
+.odysseus-root button.od-cal-today-btn { font-size:10px; opacity:0.5; }
+.odysseus-root button.od-cal-today-btn:hover { opacity:1; }
+
+/* +New pill */
+.odysseus-root button.od-cal-add-btn.od-cal-add-btn-text { width:auto; background:color-mix(in srgb, var(--fg) 8%, transparent); color:var(--fg); border:1px solid var(--border); border-radius:12px; padding:0 10px 0 6px; display:inline-flex; align-items:center; gap:4px; height:24px; line-height:1; cursor:pointer; font-family:inherit; transition:background 0.15s, border-color 0.15s; }
+.odysseus-root button.od-cal-add-btn.od-cal-add-btn-text:hover { background:color-mix(in srgb, var(--fg) 14%, transparent); border-color:var(--accent); opacity:1; }
+.odysseus-root .od-cal-add-plus { display:inline-flex; align-items:center; color:var(--accent, var(--red)); transition:transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1); }
+.odysseus-root button.od-cal-add-btn.od-cal-add-btn-text:hover .od-cal-add-plus { transform:rotate(180deg); }
+.odysseus-root .od-cal-add-label { font-size:11px; font-weight:600; line-height:1; opacity:0.85; }
+
+/* view toggle */
+.odysseus-root .od-cal-view-toggle { display:inline-flex; align-items:stretch; border:1px solid var(--border); border-radius:5px; overflow:hidden; box-sizing:border-box; padding:0; margin:0; line-height:1; }
+.odysseus-root button.od-cal-view-btn { display:inline-flex; align-items:center; justify-content:center; background:transparent; border:none; color:var(--fg); font-size:11px; font-family:inherit; font-weight:500; padding:2px 12px; margin:0; cursor:pointer; opacity:0.45; line-height:1; height:24px; box-sizing:border-box; }
+.odysseus-root .od-cal-view-btn + .od-cal-view-btn { border-left:1px solid var(--border); }
+.odysseus-root .od-cal-view-btn:hover { opacity:0.75; }
+.odysseus-root .od-cal-view-btn.active { background:color-mix(in srgb, var(--fg) 12%, transparent); opacity:1; font-weight:600; }
+
+/* filter chips */
+.odysseus-root .od-cal-filters { display:flex; gap:6px; flex-wrap:wrap; }
+.odysseus-root .od-cal-filter-item { display:inline-flex; align-items:center; gap:4px; cursor:pointer; font-size:10px; padding:1px 8px; line-height:1.4; border-radius:10px; background:color-mix(in srgb, var(--fg) 5%, transparent); border:1px solid var(--border); color:var(--fg); font-family:inherit; transition:opacity 0.15s; }
+.odysseus-root .od-cal-filter-item:hover { background:color-mix(in srgb, var(--fg) 10%, transparent); }
+.odysseus-root .od-cal-filter-item.od-cal-filter-off { opacity:0.25; text-decoration:line-through; }
+.odysseus-root .od-cal-filter-dot { width:7px; height:7px; border-radius:50%; flex-shrink:0; }
+
+/* month grid */
+.odysseus-root .od-cal-grid { flex:1 1 auto; min-height:120px; overflow-y:auto; overflow-x:hidden; display:flex; flex-direction:column; gap:1px; background:color-mix(in srgb, var(--fg) 8%, transparent); border-radius:6px; }
+.odysseus-root .od-cal-week-headers { display:grid; grid-template-columns:repeat(7,1fr); gap:1px; }
+.odysseus-root .od-cal-week-row { position:relative; display:grid; grid-template-columns:repeat(7,1fr); gap:1px; }
+.odysseus-root .od-cal-weekday { background:color-mix(in srgb, var(--fg) 5%, var(--bg)); text-align:center; font-size:10px; font-weight:600; opacity:0.4; padding:5px 0; color:var(--fg); }
+.odysseus-root .od-cal-day { display:block; width:100%; text-align:left; background:var(--bg); min-height:78px; padding:3px; cursor:pointer; position:relative; transition:background 0.12s; overflow:hidden; border:none; font-family:inherit; color:var(--fg); }
+.odysseus-root .od-cal-day:hover { background:color-mix(in srgb, var(--fg) 5%, var(--bg)); }
+.odysseus-root .od-cal-day.od-cal-today { box-shadow:inset 0 0 0 2px var(--accent, var(--red)); background:color-mix(in srgb, var(--accent, var(--red)) 15%, var(--bg)); border-radius:8px; }
+.odysseus-root .od-cal-day.od-cal-today .od-cal-day-num { color:var(--bg); font-weight:800; background:var(--accent, var(--red)); border-radius:10px; padding:1px 6px; display:inline-block; opacity:1; line-height:1.3; }
+.odysseus-root .od-cal-day.od-cal-selected:not(.od-cal-today) { box-shadow:inset 0 0 0 2px color-mix(in srgb, var(--accent, var(--fg)) 65%, transparent); background:color-mix(in srgb, var(--accent, var(--fg)) 12%, var(--bg)); border-radius:8px; }
+.odysseus-root .od-cal-day.od-cal-selected:not(.od-cal-today) .od-cal-day-num { color:var(--accent, var(--fg)); opacity:1; font-weight:700; }
+.odysseus-root .od-cal-day.od-cal-other { opacity:0.25; }
+.odysseus-root .od-cal-day-num { font-size:10px; font-weight:600; display:block; margin-bottom:1px; opacity:0.7; line-height:1.2; }
+.odysseus-root .od-cal-event-row { display:flex; align-items:center; gap:3px; padding:1px 2px; border-radius:2px; line-height:1.15; margin-bottom:1px; }
+.odysseus-root .od-cal-event-row:hover { background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-cal-event-row-dot { width:4px; height:4px; border-radius:50%; flex-shrink:0; }
+.odysseus-root .od-cal-event-row-time { font-size:9px; opacity:0.5; font-variant-numeric:tabular-nums; flex-shrink:0; }
+.odysseus-root .od-cal-event-row-name { font-size:9px; opacity:0.8; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; flex:1; min-width:0; }
+.odysseus-root .od-cal-event-more { font-size:8px; opacity:0.4; padding-left:6px; display:block; }
+
+/* day-detail panel */
+.odysseus-root .od-cal-day-detail { margin-top:4px; border-top:1px solid var(--border); padding-top:8px; max-height:200px; overflow-y:auto; overscroll-behavior:contain; flex-shrink:0; }
+.odysseus-root .od-cal-detail-header { display:flex; justify-content:space-between; align-items:center; font-size:12px; font-weight:600; margin-bottom:6px; padding-right:8px; color:var(--fg); }
+.odysseus-root .od-cal-empty { font-size:11px; opacity:0.3; padding:4px 0; color:var(--fg); }
+.odysseus-root .od-cal-event-item { display:flex; gap:8px; padding:6px 8px; border-radius:5px; align-items:flex-start; }
+.odysseus-root .od-cal-event-item:hover { background:color-mix(in srgb, var(--fg) 6%, transparent); }
+.odysseus-root .od-cal-event-dot { width:7px; height:7px; border-radius:50%; flex-shrink:0; margin-top:4px; }
+.odysseus-root .od-cal-event-info { flex:1; min-width:0; }
+.odysseus-root .od-cal-event-name { font-size:12px; font-weight:500; color:var(--fg); }
+.odysseus-root .od-cal-event-time { font-size:10px; opacity:0.4; color:var(--fg); }
+
+/* calendars sidebar (right rail of the modal) */
+.odysseus-root .od-cal-sidebar { width:160px; flex-shrink:0; border-left:1px solid var(--border); padding:14px 10px; display:flex; flex-direction:column; gap:2px; overflow-y:auto; }
+.odysseus-root .od-cal-sidebar-head { font-size:10px; text-transform:uppercase; letter-spacing:.04em; opacity:0.5; padding:0 6px 6px; color:var(--fg); }
+.odysseus-root .od-cal-s-row { display:flex; align-items:center; gap:8px; width:100%; text-align:left; padding:5px 6px; border:none; background:none; border-radius:5px; cursor:pointer; color:var(--fg); font-family:inherit; font-size:12px; transition:background 0.12s; }
+.odysseus-root .od-cal-s-row:hover { background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-cal-s-row.od-cal-s-off { opacity:0.4; }
+.odysseus-root .od-cal-s-dot { width:9px; height:9px; border-radius:50%; flex-shrink:0; }
+.odysseus-root .od-cal-s-name { flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+
+@media (max-width: 768px) {
+  .odysseus-root .od-cal-panel { flex-direction:column; }
+  .odysseus-root .od-cal-sidebar { width:100%; border-left:none; border-top:1px solid var(--border); flex-direction:row; flex-wrap:wrap; }
+  .odysseus-root .od-cal-day { min-height:44px; padding:2px; }
+}
+
+
+
+/* ===== EmailView ===== */
+/* ── EmailView (odysseus emailLibrary.js + emailInbox.js + signature.js + the
+   email-* rules in static/style.css). All scoped under .odysseus-root; colors
+   via theme vars only. Append verbatim to ODYSSEUS_CSS in odysseus-theme.ts. ── */
+
+.odysseus-root .od-email-panel {
+  width: min(720px, 92vw); max-width: 92vw; height: 85vh; max-height: 85vh;
+  display: flex; flex-direction: column; padding: 0; overflow: hidden; background: var(--bg);
+}
+.odysseus-root .od-email-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 8px;
+  padding: 12px 14px 10px; border-bottom: 1px solid var(--border); flex-shrink: 0;
+}
+.odysseus-root .od-email-head-title {
+  display: inline-flex; align-items: center; gap: 6px; font-size: 15px; font-weight: 600; color: var(--fg);
+}
+.odysseus-root .od-email-head-title svg { vertical-align: -2px; }
+.odysseus-root .od-email-unread-badge {
+  font-size: 10px; font-weight: 600; padding: 1px 7px; border-radius: 10px;
+  background: color-mix(in srgb, var(--accent, var(--red)) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent, var(--red)) 40%, transparent);
+  color: var(--accent, var(--red)); cursor: pointer;
+}
+.odysseus-root .od-email-stats { font-size: 11px; opacity: 0.55; font-weight: 400; color: var(--fg); }
+.odysseus-root .od-email-close {
+  background: none; border: none; color: var(--fg); opacity: 0.55; cursor: pointer;
+  padding: 4px; line-height: 0; border-radius: 6px; display: inline-flex; transition: opacity 0.15s, background 0.15s;
+}
+.odysseus-root .od-email-close:hover { opacity: 1; background: color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-email-desc { margin: 8px 14px 4px; font-size: 11px; opacity: 0.6; color: var(--fg); }
+.odysseus-root .od-email-accounts-row { display: flex; align-items: center; gap: 6px; padding: 4px 14px 0; flex-shrink: 0; }
+.odysseus-root .od-email-accounts { display: flex; gap: 4px; flex-wrap: wrap; flex: 1; min-width: 0; }
+.odysseus-root .od-email-chip {
+  height: 26px; box-sizing: border-box; padding: 0 11px; display: inline-flex; align-items: center;
+  gap: 4px; border-radius: 13px; font-size: 11px; line-height: 1; border: 1px solid var(--border);
+  background: none; color: var(--fg); cursor: pointer; transition: border-color 0.15s, background 0.15s;
+}
+.odysseus-root .od-email-chip:hover { border-color: var(--red); }
+.odysseus-root .od-email-chip.active {
+  background: color-mix(in srgb, var(--red) 15%, transparent);
+  border-color: color-mix(in srgb, var(--red) 40%, transparent); color: var(--red);
+}
+.odysseus-root .od-email-compose-btn {
+  flex-shrink: 0; margin-left: auto; display: inline-flex; align-items: center; gap: 3px;
+  height: 26px; padding: 0 10px; border-radius: 6px; font-size: 11px; border: 1px solid var(--border);
+  background: var(--panel); color: var(--fg); cursor: pointer; transition: border-color 0.15s, background 0.15s;
+}
+.odysseus-root .od-email-compose-btn:hover { border-color: var(--accent, var(--red)); }
+.odysseus-root .od-email-toolbar { display: flex; flex-direction: column; gap: 6px; padding: 8px 14px; flex-shrink: 0; }
+.odysseus-root .od-email-toolbar-row { display: flex; gap: 6px; align-items: center; }
+.odysseus-root .od-email-search-row { display: flex; gap: 6px; align-items: center; }
+.odysseus-root .od-email-select {
+  flex: 1; min-width: 0; height: 28px; padding: 0 8px; border-radius: 6px; font-size: 11px;
+  text-overflow: ellipsis; background: var(--bg); color: var(--fg); border: 1px solid var(--border); cursor: pointer;
+}
+.odysseus-root .od-email-tbtn {
+  flex-shrink: 0; height: 28px; min-width: 28px; padding: 0 7px; border-radius: 6px;
+  display: inline-flex; align-items: center; justify-content: center; background: var(--panel);
+  color: var(--fg); border: 1px solid var(--border); cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+.odysseus-root .od-email-tbtn:hover { border-color: var(--accent, var(--red)); }
+.odysseus-root .od-email-tbtn.active {
+  background: color-mix(in srgb, var(--accent, var(--red)) 15%, transparent);
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 40%, transparent); color: var(--accent, var(--red));
+}
+.odysseus-root .od-email-search-wrap { position: relative; flex: 1; min-width: 120px; }
+.odysseus-root .od-email-search-icon {
+  position: absolute; left: 8px; top: 50%; transform: translateY(-50%); opacity: 0.45; pointer-events: none; color: var(--fg);
+}
+.odysseus-root .od-email-search {
+  width: 100%; height: 28px; padding: 0 8px 0 26px; border-radius: 6px; font-size: 11px;
+  background: var(--bg); color: var(--fg); border: 1px solid var(--border);
+}
+.odysseus-root .od-email-search::placeholder { color: color-mix(in srgb, var(--fg) 35%, transparent); }
+.odysseus-root .od-email-body { display: flex; flex: 1; min-height: 0; border-top: 1px solid var(--border); }
+.odysseus-root .od-email-list { width: 300px; flex-shrink: 0; overflow-y: auto; border-right: 1px solid var(--border); }
+.odysseus-root .od-email-item {
+  display: flex; align-items: flex-start; gap: 8px; width: 100%; text-align: left; padding: 8px 12px;
+  cursor: pointer; border: none; background: none; border-bottom: 1px solid var(--border);
+  position: relative; color: var(--fg); transition: background 0.1s;
+}
+.odysseus-root .od-email-item:hover { background: color-mix(in srgb, var(--fg) 3%, transparent); }
+.odysseus-root .od-email-item:hover .od-email-item-menu { opacity: 0.5; }
+.odysseus-root .od-email-item.od-email-selected { background: color-mix(in srgb, var(--accent, var(--red)) 8%, transparent); }
+.odysseus-root .od-email-item.od-email-answered { opacity: 0.7; }
+.odysseus-root .od-email-avatar {
+  width: 28px; height: 28px; border-radius: 50%; color: #fff; flex-shrink: 0; display: flex;
+  align-items: center; justify-content: center; font-size: 12px; font-weight: 600; margin-top: 1px;
+}
+.odysseus-root .od-email-item-content { flex: 1; min-width: 0; overflow: hidden; display: flex; flex-direction: column; }
+.odysseus-root .od-email-item-top { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+.odysseus-root .od-email-sender { font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.odysseus-root .od-email-date { font-size: 10px; opacity: 0.5; white-space: nowrap; flex-shrink: 0; }
+.odysseus-root .od-email-subject {
+  font-size: 11px; opacity: 0.6; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  margin-top: 1px; display: flex; align-items: center; gap: 4px;
+}
+.odysseus-root .od-email-unread-dot { display: inline-flex; align-items: center; flex-shrink: 0; }
+.odysseus-root .od-email-attach-ico { opacity: 0.6; display: inline-flex; flex-shrink: 0; }
+.odysseus-root .od-email-tags { display: inline-flex; gap: 3px; margin-left: 2px; }
+.odysseus-root .od-email-tag {
+  font-size: 9px; line-height: 1; padding: 2px 5px; border-radius: 8px; font-weight: 500;
+  text-transform: uppercase; letter-spacing: 0.3px; background: color-mix(in srgb, var(--fg) 14%, transparent); color: var(--fg);
+}
+.odysseus-root .od-email-tag-urgent { background: color-mix(in srgb, var(--red) 25%, transparent); color: var(--red); font-weight: 600; }
+.odysseus-root .od-email-tag-newsletter,
+.odysseus-root .od-email-tag-marketing { background: color-mix(in srgb, var(--fg) 18%, transparent); }
+.odysseus-root .od-email-item-menu { flex-shrink: 0; opacity: 0; color: var(--fg); padding: 4px 0; transition: opacity 0.15s; }
+.odysseus-root .od-email-empty {
+  display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 4px; padding: 28px 16px; text-align: center;
+}
+.odysseus-root .od-email-empty-title { font-size: 13px; opacity: 0.6; color: var(--fg); }
+.odysseus-root .od-email-empty-sub { font-size: 11px; opacity: 0.45; color: var(--fg); }
+.odysseus-root .od-email-pane { flex: 1; min-width: 0; display: flex; flex-direction: column; }
+.odysseus-root .od-email-pane-placeholder {
+  flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 10px; opacity: 0.4; font-size: 12px; color: var(--fg);
+}
+.odysseus-root .od-email-reader { display: flex; flex-direction: column; flex: 1; min-height: 0; font-size: 12px; }
+.odysseus-root .od-email-reader-header {
+  display: flex; flex-direction: row; align-items: flex-start; gap: 12px; padding: 10px 14px;
+  border-bottom: 1px solid var(--border); background: var(--bg); flex-shrink: 0;
+}
+.odysseus-root .od-email-reader-meta {
+  flex: 1; min-width: 0; opacity: 0.85; line-height: 1.7; font-size: 11px; display: flex; flex-direction: column; gap: 4px;
+}
+.odysseus-root .od-email-reader-meta-row { display: flex; align-items: center; gap: 6px; min-width: 0; }
+.odysseus-root .od-email-reader-meta-row strong { opacity: 0.5; font-weight: 600; flex-shrink: 0; min-width: 36px; }
+.odysseus-root .od-email-recipient-chips { display: inline-flex; flex-wrap: wrap; gap: 4px; }
+.odysseus-root .od-email-recipient-chip {
+  display: inline-flex; align-items: center; padding: 1px 8px; font-size: 10px;
+  background: color-mix(in srgb, var(--fg) 6%, transparent); border: 1px solid var(--border);
+  border-radius: 10px; color: var(--fg); white-space: nowrap; max-width: 220px; overflow: hidden; text-overflow: ellipsis;
+}
+.odysseus-root .od-email-reader-actions {
+  display: flex; gap: 4px; flex-wrap: wrap; align-items: center; flex-shrink: 0; justify-content: flex-end; margin-top: -2px;
+}
+.odysseus-root .od-email-reader-btn {
+  display: inline-flex; align-items: center; gap: 4px; height: 26px; padding: 0 8px; border-radius: 6px;
+  font-size: 11px; background: var(--panel); color: var(--fg); border: 1px solid var(--border);
+  cursor: pointer; transition: border-color 0.15s, background 0.15s;
+}
+.odysseus-root .od-email-reader-btn:hover { border-color: var(--accent, var(--red)); }
+.odysseus-root .od-email-reader-subject {
+  display: flex; align-items: center; gap: 6px; padding: 10px 14px 4px; font-size: 14px;
+  font-weight: 600; color: var(--fg); flex-shrink: 0;
+}
+.odysseus-root .od-email-reader-star { color: var(--accent, var(--red)); opacity: 0.85; flex-shrink: 0; }
+.odysseus-root .od-email-reader-body {
+  font-size: 12px; line-height: 1.55; white-space: pre-wrap; word-wrap: break-word; overflow-wrap: anywhere;
+  flex: 1; overflow-y: auto; padding: 8px 14px 14px; min-height: 0; color: var(--fg);
+}
+.odysseus-root .od-email-compose { display: flex; flex-direction: column; flex: 1; min-height: 0; }
+.odysseus-root .od-email-compose-head {
+  display: flex; align-items: center; justify-content: space-between; padding: 10px 14px;
+  border-bottom: 1px solid var(--border); flex-shrink: 0;
+}
+.odysseus-root .od-email-compose-title { font-size: 13px; font-weight: 600; color: var(--fg); }
+.odysseus-root .od-email-field {
+  display: flex; align-items: center; gap: 8px; padding: 6px 14px; border-bottom: 1px solid var(--border); flex-shrink: 0;
+}
+.odysseus-root .od-email-field-label { font-size: 11px; opacity: 0.5; min-width: 50px; color: var(--fg); }
+.odysseus-root .od-email-field-input {
+  flex: 1; min-width: 0; height: 24px; font-size: 12px; background: transparent; border: none; color: var(--fg); outline: none;
+}
+.odysseus-root .od-email-compose-body {
+  flex: 1; min-height: 0; resize: none; padding: 12px 14px; font-size: 12px; line-height: 1.55;
+  background: transparent; border: none; color: var(--fg); outline: none; font-family: inherit;
+}
+.odysseus-root .od-email-compose-footer {
+  display: flex; align-items: center; gap: 8px; padding: 8px 14px; border-top: 1px solid var(--border); flex-shrink: 0;
+}
+.odysseus-root .od-email-compose-spacer { flex: 1; }
+.odysseus-root .od-email-sig-btn {
+  display: inline-flex; align-items: center; gap: 4px; height: 28px; padding: 0 10px; border-radius: 6px;
+  font-size: 11px; background: var(--panel); color: var(--fg); border: 1px solid var(--border);
+  cursor: pointer; transition: border-color 0.15s;
+}
+.odysseus-root .od-email-sig-btn:hover { border-color: var(--accent, var(--red)); }
+.odysseus-root .od-email-send-btn {
+  height: 28px; padding: 0 16px; border-radius: 6px; font-size: 11px; font-weight: 600;
+  background: var(--accent, var(--red)); color: #fff; border: none; cursor: pointer; transition: opacity 0.15s;
+}
+.odysseus-root .od-email-send-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.odysseus-root .od-email-sig-overlay { position: absolute; inset: 0; z-index: 60; display: flex; align-items: center; justify-content: center; }
+.odysseus-root .od-email-sig-panel {
+  position: relative; z-index: 1; width: 420px; max-width: 90%; background: var(--panel);
+  border: 1px solid var(--border); border-radius: 12px; padding: 16px; box-shadow: 0 12px 40px rgba(0,0,0,0.4);
+}
+.odysseus-root .od-email-sig-empty { padding: 16px; text-align: center; font-size: 12px; opacity: 0.55; color: var(--fg); }
+.odysseus-root .od-email-sig-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; margin-top: 10px; }
+.odysseus-root .od-email-sig-tile {
+  display: flex; flex-direction: column; align-items: center; gap: 4px; padding: 8px;
+  border: 1px solid var(--border); border-radius: 8px; background: var(--bg); cursor: pointer; transition: border-color 0.15s;
+}
+.odysseus-root .od-email-sig-tile:hover { border-color: var(--accent, var(--red)); }
+.odysseus-root .od-email-sig-tile img { max-width: 100%; height: 44px; object-fit: contain; }
+.odysseus-root .od-email-sig-name { font-size: 11px; opacity: 0.85; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+/* ===== GalleryView ===== */
+/* ════════════════════════════════════════════════════════════════════
+   Gallery — odysseus static/js/gallery.js (Photos tab) + style.css gallery
+   rules, ported 1:1. Grid + detail lightbox + generate bar. All colors via
+   theme vars, all selectors scoped under .odysseus-root.
+   ════════════════════════════════════════════════════════════════════ */
+
+.odysseus-root .od-gallery-panel {
+  width: min(960px, 94vw);
+  max-width: 94vw;
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Header (gallery.js .modal-header) ── */
+.odysseus-root .od-gallery-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 14px 8px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.odysseus-root .od-gallery-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--fg);
+}
+.odysseus-root .od-gallery-stats {
+  font-size: 10px;
+  font-weight: normal;
+  color: color-mix(in srgb, var(--fg) 50%, transparent);
+  margin-left: 4px;
+}
+.odysseus-root .od-gallery-close {
+  background: none;
+  border: none;
+  color: var(--fg);
+  opacity: 0.6;
+  cursor: pointer;
+  padding: 2px;
+  display: inline-flex;
+  border-radius: 4px;
+  transition: opacity 0.15s, background 0.15s;
+}
+.odysseus-root .od-gallery-close:hover {
+  opacity: 1;
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+}
+
+/* ── Tabs (style.css .gallery-tabs / .gallery-tab) ── */
+.odysseus-root .od-gallery-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  padding: 0 16px;
+  background: var(--panel);
+  flex-shrink: 0;
+}
+.odysseus-root .od-gallery-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 18px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--fg);
+  opacity: 0.6;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  transition: opacity 0.15s, border-color 0.15s;
+}
+.odysseus-root .od-gallery-tab:hover {
+  opacity: 0.85;
+}
+.odysseus-root .od-gallery-tab.active {
+  opacity: 1;
+  border-bottom-color: var(--red);
+}
+.odysseus-root .od-gallery-tab-icon {
+  display: inline-flex;
+  align-items: center;
+  opacity: 0.85;
+}
+.odysseus-root .od-gallery-tab.active .od-gallery-tab-icon {
+  opacity: 1;
+}
+
+/* ── Body ── */
+.odysseus-root .od-gallery-body {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  padding: 8px 14px 12px;
+}
+.odysseus-root .od-gallery-images-container {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+}
+.odysseus-root .od-gallery-secondary {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+/* ── Toolbar (style.css .gallery-toolbar) ── */
+.odysseus-root .od-gallery-toolbar {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 6px;
+  align-items: center;
+  flex-shrink: 0;
+}
+.odysseus-root .od-gallery-search-wrap {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+}
+.odysseus-root .od-gallery-search-icon {
+  position: absolute;
+  left: 9px;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+  pointer-events: none;
+}
+.odysseus-root .od-gallery-search {
+  flex: 1;
+  width: 100%;
+  padding: 5px 8px 5px 28px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font: inherit;
+  font-size: 12px;
+  outline: none;
+  box-sizing: border-box;
+}
+.odysseus-root .od-gallery-search:focus {
+  border-color: var(--red);
+}
+.odysseus-root .od-gallery-search::placeholder {
+  color: color-mix(in srgb, var(--fg) 35%, transparent);
+}
+.odysseus-root .od-gallery-model-filter,
+.odysseus-root .od-gallery-sort {
+  padding: 5px 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+.odysseus-root .od-gallery-select-btn {
+  padding: 6px 11px;
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+  opacity: 0.6;
+  transition: all 0.15s;
+}
+.odysseus-root .od-gallery-select-btn:hover {
+  opacity: 1;
+}
+.odysseus-root .od-gallery-select-btn.active {
+  background: color-mix(in srgb, var(--red) 28%, transparent);
+  color: var(--red);
+  border-color: var(--red);
+  font-weight: 600;
+  opacity: 1;
+}
+
+/* ── Grid (style.css .gallery-grid / .gallery-card) ── */
+.odysseus-root .od-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 8px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 2px;
+}
+.odysseus-root .od-gallery-card {
+  position: relative;
+  aspect-ratio: 1;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s, transform 0.15s;
+}
+.odysseus-root .od-gallery-card:hover {
+  border-color: var(--red);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--red) 15%, transparent);
+  transform: translateY(-1px);
+}
+.odysseus-root .od-gallery-card-upload {
+  border-style: dashed;
+  background: color-mix(in srgb, var(--fg) 3%, var(--bg));
+  opacity: 0.75;
+  transition: opacity 0.12s, border-color 0.15s, transform 0.15s;
+}
+.odysseus-root .od-gallery-card-upload:hover {
+  opacity: 1;
+  border-color: var(--red);
+  transform: translateY(-1px);
+}
+.odysseus-root .od-gallery-card-upload-inner {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  color: var(--fg);
+}
+.odysseus-root .od-gallery-card-upload-label {
+  font-size: 12px;
+  font-weight: 500;
+  opacity: 0.8;
+}
+.odysseus-root .od-gallery-card-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.odysseus-root .od-gallery-fav-btn {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 2;
+  background: rgba(0, 0, 0, 0.4);
+  border: none;
+  border-radius: 50%;
+  width: 26px;
+  height: 26px;
+  color: rgba(255, 255, 255, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.15s;
+  padding: 0;
+}
+.odysseus-root .od-gallery-card:hover .od-gallery-fav-btn {
+  opacity: 1;
+}
+.odysseus-root .od-gallery-fav-btn.od-gallery-fav-active {
+  opacity: 1;
+  color: var(--red);
+}
+.odysseus-root .od-gallery-dl-btn {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  z-index: 2;
+  background: rgba(0, 0, 0, 0.4);
+  border: none;
+  border-radius: 50%;
+  width: 26px;
+  height: 26px;
+  color: rgba(255, 255, 255, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s;
+  padding: 0;
+}
+.odysseus-root .od-gallery-card:hover .od-gallery-dl-btn {
+  opacity: 1;
+}
+.odysseus-root .od-gallery-dl-btn:hover {
+  background: rgba(0, 0, 0, 0.7);
+  color: #fff;
+}
+.odysseus-root .od-gallery-select-dot {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  z-index: 2;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--fg) 30%, transparent);
+  border: 1px solid color-mix(in srgb, var(--fg) 50%, transparent);
+}
+.odysseus-root .od-gallery-card-info {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 6px 8px;
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.75));
+  color: #fff;
+  text-align: left;
+}
+.odysseus-root .od-gallery-card-prompt {
+  font-size: 10px;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.odysseus-root .od-gallery-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+  font-size: 9px;
+  opacity: 0.8;
+}
+.odysseus-root .od-gallery-card-model {
+  padding: 1px 5px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.15);
+}
+
+/* Empty state (style.css .gallery-empty) — honest "No images yet". */
+.odysseus-root .od-gallery-empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  color: color-mix(in srgb, var(--fg) 35%, transparent);
+  padding: 32px 16px;
+  font-size: 12px;
+  font-style: italic;
+}
+
+/* ── Generate prompt bar (no eliza image backend → disabled CTA + note) ── */
+.odysseus-root .od-gallery-generate-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 8px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+.odysseus-root .od-gallery-generate-icon {
+  color: var(--accent, var(--red));
+  opacity: 0.85;
+  flex-shrink: 0;
+}
+.odysseus-root .od-gallery-generate-input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  color: var(--fg);
+  font: inherit;
+  font-size: 13px;
+  outline: none;
+}
+.odysseus-root .od-gallery-generate-input::placeholder {
+  color: color-mix(in srgb, var(--fg) 35%, transparent);
+}
+.odysseus-root .od-gallery-generate-btn {
+  padding: 6px 14px;
+  background: var(--accent, var(--red));
+  color: #fff;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: opacity 0.15s;
+}
+.odysseus-root .od-gallery-generate-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.odysseus-root .od-gallery-generate-note {
+  margin-top: 5px;
+  font-size: 10.5px;
+  font-style: italic;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+  flex-shrink: 0;
+}
+
+/* ── Settings tab card (style.css .admin-card) ── */
+.odysseus-root .od-gallery-settings-card {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+  background: color-mix(in srgb, var(--fg) 2%, var(--panel));
+}
+.odysseus-root .od-gallery-settings-title {
+  margin: 0 0 6px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.odysseus-root .od-gallery-settings-desc {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--fg) 60%, transparent);
+}
+
+/* ── Detail lightbox (style.css .gallery-detail*) ── */
+.odysseus-root .od-gallery-detail {
+  position: absolute;
+  inset: 0;
+  background: var(--panel);
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+.odysseus-root .od-gallery-detail-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  position: sticky;
+  top: 0;
+  background: var(--panel);
+  z-index: 5;
+}
+.odysseus-root .od-gallery-detail-spacer {
+  flex: 1;
+}
+.odysseus-root .od-gallery-detail-back {
+  background: none;
+  border: none;
+  color: var(--fg);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+.odysseus-root .od-gallery-detail-back:hover {
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+}
+.odysseus-root .od-gallery-detail-fav {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--fg);
+  opacity: 0.7;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.15s, color 0.15s, border-color 0.15s;
+}
+.odysseus-root .od-gallery-detail-fav:hover {
+  opacity: 1;
+}
+.odysseus-root .od-gallery-detail-fav.active {
+  opacity: 1;
+  color: var(--red);
+  border-color: var(--red);
+}
+.odysseus-root .od-gallery-detail-menu-wrap {
+  position: relative;
+}
+.odysseus-root .od-gallery-detail-menu-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--fg);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 26px;
+  padding: 0;
+  border-radius: 4px;
+  transition: border-color 0.15s;
+}
+.odysseus-root .od-gallery-detail-menu-btn:hover {
+  border-color: var(--fg);
+}
+.odysseus-root .od-gallery-detail-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 150px;
+  padding: 3px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 14px color-mix(in srgb, var(--fg) 18%, transparent);
+  z-index: 12;
+  display: flex;
+  flex-direction: column;
+}
+.odysseus-root .od-gallery-detail-menu-item {
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
+  font: inherit;
+  color: var(--fg);
+  padding: 5px 8px;
+  font-size: 11px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.odysseus-root .od-gallery-detail-menu-item:hover {
+  background: color-mix(in srgb, var(--red) 10%, transparent);
+}
+.odysseus-root .od-gallery-detail-menu-danger {
+  color: var(--red);
+}
+.odysseus-root .od-gallery-detail-body {
+  display: flex;
+  gap: 16px;
+  padding: 12px;
+  flex: 1;
+  min-height: 0;
+}
+.odysseus-root .od-gallery-detail-image {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+}
+.odysseus-root .od-gallery-detail-img-frame {
+  position: relative;
+  display: inline-flex;
+  max-width: 100%;
+  max-height: 70vh;
+}
+.odysseus-root .od-gallery-detail-img {
+  max-width: 100%;
+  max-height: 70vh;
+  border-radius: 6px;
+  object-fit: contain;
+  display: block;
+}
+.odysseus-root .od-gallery-detail-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(0, 0, 0, 0.45);
+  color: rgba(255, 255, 255, 0.85);
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s;
+  z-index: 3;
+  padding: 0;
+}
+.odysseus-root .od-gallery-detail-image:hover .od-gallery-detail-nav {
+  opacity: 0.85;
+}
+.odysseus-root .od-gallery-detail-nav:hover {
+  opacity: 1 !important;
+  background: rgba(0, 0, 0, 0.7);
+}
+.odysseus-root .od-gallery-detail-nav-prev {
+  left: 8px;
+}
+.odysseus-root .od-gallery-detail-nav-next {
+  right: 8px;
+}
+.odysseus-root .od-gallery-detail-nav-disabled {
+  opacity: 0 !important;
+  pointer-events: none;
+}
+.odysseus-root .od-gallery-detail-rotate {
+  position: absolute;
+  top: 8px;
+  background: rgba(0, 0, 0, 0.45);
+  color: rgba(255, 255, 255, 0.85);
+  border: none;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s, background 0.15s;
+  z-index: 3;
+  padding: 0;
+}
+.odysseus-root .od-gallery-detail-image:hover .od-gallery-detail-rotate {
+  opacity: 0.85;
+}
+.odysseus-root .od-gallery-detail-rotate:hover {
+  opacity: 1 !important;
+  background: rgba(0, 0, 0, 0.7);
+}
+.odysseus-root .od-gallery-detail-rotate-ccw {
+  left: 8px;
+}
+.odysseus-root .od-gallery-detail-rotate-cw {
+  right: 8px;
+}
+.odysseus-root .od-gallery-detail-sidebar {
+  width: 240px;
+  flex-shrink: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  min-width: 0;
+}
+.odysseus-root .od-gallery-detail-section {
+  margin-bottom: 12px;
+}
+.odysseus-root .od-gallery-detail-label,
+.odysseus-root .od-gallery-detail-section > label {
+  display: block;
+  font-size: 10px;
+  font-weight: 600;
+  opacity: 0.6;
+  margin-bottom: 3px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--fg);
+}
+.odysseus-root .od-gallery-detail-section > div {
+  font-size: 12px;
+  word-break: break-word;
+  color: var(--fg);
+}
+.odysseus-root .od-gallery-detail-prompt {
+  white-space: pre-wrap;
+  line-height: 1.4;
+}
+.odysseus-root .od-gallery-tag-input,
+.odysseus-root .od-gallery-detail-name-input {
+  width: 100%;
+  padding: 5px 8px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font: inherit;
+  font-size: 11px;
+  box-sizing: border-box;
+}
+.odysseus-root .od-gallery-detail-name-input {
+  font-size: 13px;
+  font-weight: 500;
+}
+.odysseus-root .od-gallery-tag-input:focus,
+.odysseus-root .od-gallery-detail-name-input:focus {
+  border-color: var(--red);
+  outline: none;
+}
+
+/* Narrow: stack detail body, full-width sidebar (style.css gallery @media). */
+@media (max-width: 768px) {
+  .odysseus-root .od-gallery-detail-body {
+    flex-direction: column;
+  }
+  .odysseus-root .od-gallery-detail-sidebar {
+    width: 100%;
+  }
+}
+/* ===== CookbookView ===== */
+/* ── Cookbook (CookbookView.tsx). odysseus cookbook.js modal + .doclib-card
+   .skill-card recipe grid + codeRunner.js run-output panel + cookbook-* button
+   rules, scoped under .odysseus-root. Base .od-search-overlay / .od-search-backdrop
+   / .od-search-panel / .od-mem-head / .od-mem-title / .od-mem-stats /
+   .od-search-empty already live in ODYSSEUS_CSS — only cookbook-specific
+   .od-cb-* classes are added here. All colors via theme vars. ── */
+
+/* Panel: a tall centered modal like the cookbook modal (#cookbook-modal). */
+.odysseus-root .od-cb-panel {
+  width: 640px;
+  max-width: 92%;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  padding: 14px 16px 16px;
+  gap: 10px;
+}
+
+/* Head row: title · stats · refresh (cookbook.js modal header). The shared
+   .od-mem-head supplies the baseline flex; refresh pins to the right. */
+.odysseus-root .od-cb-head { align-items: center; }
+.odysseus-root .od-cb-refresh {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  opacity: 0.7;
+  cursor: pointer;
+  transition: opacity 0.15s, border-color 0.15s, color 0.15s;
+}
+.odysseus-root .od-cb-refresh:hover {
+  opacity: 1;
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.odysseus-root .od-cb-refresh:disabled { opacity: 0.4; cursor: default; }
+@keyframes od-cb-spin { to { transform: rotate(360deg); } }
+.odysseus-root .od-cb-spin { animation: od-cb-spin 0.8s linear infinite; }
+
+/* Search row (cookbook hwfit-search styling — icon + flat input). */
+.odysseus-root .od-cb-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+}
+.odysseus-root .od-cb-search-icon {
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+  flex-shrink: 0;
+}
+.odysseus-root .od-cb-search-input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--fg);
+  font-size: 13px;
+  font-family: inherit;
+}
+.odysseus-root .od-cb-search-input::placeholder {
+  color: color-mix(in srgb, var(--fg) 35%, transparent);
+}
+
+/* Recipe grid — .doclib-grid: a vertical list of cards, scrollable. */
+.odysseus-root .od-cb-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+.odysseus-root .od-cb-grid::-webkit-scrollbar { width: 4px; }
+.odysseus-root .od-cb-grid::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--fg) 15%, transparent);
+  border-radius: 4px;
+}
+
+.odysseus-root .od-cb-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 28px 16px;
+  font-size: 12px;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+
+/* Recipe card — .doclib-card.skill-card: bordered, hoverable, expands. */
+.odysseus-root .od-cb-card {
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  transition: background 0.15s, border-color 0.15s;
+  position: relative;
+}
+.odysseus-root .od-cb-card:hover {
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
+  border-color: color-mix(in srgb, var(--fg) 16%, transparent);
+}
+.odysseus-root .od-cb-card-expanded {
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
+/* Collapsed header row — icon · name+desc column · right badges/chevron.
+   Matches .skill-card-header (min-height 46px tap target). */
+.odysseus-root .od-cb-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-height: 46px;
+  box-sizing: border-box;
+  padding: 7px 10px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  color: var(--fg);
+  font-family: inherit;
+}
+.odysseus-root .od-cb-card-icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  color: var(--accent);
+  opacity: 0.85;
+}
+.odysseus-root .od-cb-lang-svg { display: block; }
+.odysseus-root .od-cb-card-textcol {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.odysseus-root .od-cb-card-name {
+  font-weight: 600;
+  font-size: 12.5px;
+  line-height: 1.3;
+  word-break: break-word;
+}
+.odysseus-root .od-cb-card-desc {
+  font-size: 10px;
+  opacity: 0.55;
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.odysseus-root .od-cb-card-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+/* Status / state badges — .memory-cat-badge clone. */
+.odysseus-root .od-cb-badge {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  text-transform: lowercase;
+  white-space: nowrap;
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+}
+.odysseus-root .od-cb-badge-on {
+  background: color-mix(in srgb, var(--ok, var(--accent)) 22%, transparent);
+  color: var(--ok, var(--accent));
+}
+.odysseus-root .od-cb-badge-off {
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+.odysseus-root .od-cb-badge-warning {
+  background: color-mix(in srgb, var(--red) 20%, transparent);
+  color: var(--red);
+}
+.odysseus-root .od-cb-badge-critical,
+.odysseus-root .od-cb-badge-blocked {
+  background: color-mix(in srgb, var(--red) 28%, transparent);
+  color: var(--red);
+  border: 1px solid color-mix(in srgb, var(--red) 40%, transparent);
+}
+.odysseus-root .od-cb-chevron {
+  display: inline-flex;
+  align-items: center;
+  opacity: 0.5;
+  flex-shrink: 0;
+}
+
+/* Expanded preview — .doclib-card-preview: top-bordered detail body. */
+.odysseus-root .od-cb-card-preview {
+  border-top: 1px solid color-mix(in srgb, var(--border) 40%, transparent);
+  padding: 8px 12px 10px;
+}
+.odysseus-root .od-cb-md-pre {
+  margin: 0;
+  font-family: "Berkeley Mono", "SF Mono", "Fira Code", monospace;
+  font-size: 11.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--txt, var(--fg));
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+/* Run-output panel (codeRunner.js .code-runner-output) — honest unavailable
+   state, never fabricated program output. */
+.odysseus-root .od-cb-run-output {
+  margin: 8px 0 0;
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-family: "Fira Code", monospace;
+  font-size: 11px;
+  line-height: 1.45;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  font-style: italic;
+}
+
+/* Action footer — .doclib-card-expanded-actions: Run left, Copy/Download
+   right-grouped (.doclib-action-group margin-left:auto). */
+.odysseus-root .od-cb-card-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-top: 8px;
+  margin-top: 8px;
+  border-top: 1px solid color-mix(in srgb, var(--border) 40%, transparent);
+}
+.odysseus-root .od-cb-action-group {
+  display: flex;
+  gap: 6px;
+  margin-left: auto;
+}
+.odysseus-root .od-cb-action-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  box-sizing: border-box;
+  font-size: 10px;
+  padding: 3px 8px;
+  border-radius: 4px;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--muted, color-mix(in srgb, var(--fg) 60%, transparent));
+  cursor: pointer;
+  font-family: inherit;
+  transition: border-color 0.15s, color 0.15s, opacity 0.15s;
+}
+.odysseus-root .od-cb-action-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.odysseus-root .od-cb-action-btn:disabled { opacity: 0.4; cursor: default; }
+/* Run button — accent fill (.cookbook-run-btn). Disabled until an execution
+   backend exists, matching the honest run-output state. */
+.odysseus-root .od-cb-run-btn:not(:disabled) {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--panel);
+  font-weight: 600;
+}
+/* ===== ModelsView ===== */
+/* ===== ModelsView ===== */
+/* Port of odysseus model catalog (static/js/models.js + modelPicker.js +
+   providers.js + style.css model rules). Panel is a 2-column body: a provider
+   rail (which provider to scan) + the catalogue list (sort menu, search box,
+   Favorites + provider endpoint groups, model rows). All colors via theme vars;
+   spacing/sizes copied 1:1 from style.css. Append inside ODYSSEUS_CSS in
+   odysseus-theme.ts (everything scoped under .odysseus-root). */
+
+/* Panel: reuse the shared .od-search-panel chrome but widen + give it height
+   for the catalogue (mirrors odysseus's models surface, larger than the 560px
+   search palette). */
+.odysseus-root .od-models-panel {
+  width: min(820px, 94vw);
+  height: min(80vh, 720px);
+  max-width: none;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+}
+.odysseus-root .od-models-body {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+  border-top: 1px solid color-mix(in srgb, var(--fg) 6%, transparent);
+}
+
+/* ── Provider rail (providers.js — pick which provider to scan) ── */
+.odysseus-root .od-models-providers {
+  width: 168px;
+  flex-shrink: 0;
+  border-right: 1px solid color-mix(in srgb, var(--fg) 6%, transparent);
+  padding: 8px 8px 12px;
+  overflow-y: auto;
+}
+.odysseus-root .od-models-providers-head {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  opacity: 0.5;
+  padding: 5px 8px 6px;
+}
+.odysseus-root .od-models-provider-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 4px;
+  background: none;
+  color: color-mix(in srgb, var(--fg) 70%, transparent);
+  font-size: 12px;
+  text-transform: capitalize;
+  cursor: pointer;
+  transition: background 0.08s, color 0.08s;
+}
+.odysseus-root .od-models-provider-row:hover {
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
+  color: var(--fg);
+}
+.odysseus-root .od-models-provider-row.active {
+  background: color-mix(in srgb, var(--red) 10%, transparent);
+  color: var(--fg);
+}
+.odysseus-root .od-models-provider-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.odysseus-root .od-models-provider-count {
+  flex-shrink: 0;
+  font-size: 10px;
+  opacity: 0.5;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Catalogue column ── */
+.odysseus-root .od-models-list {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  padding: 8px 12px 12px;
+}
+.odysseus-root .od-models-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 6px;
+}
+.odysseus-root .od-models-sort-wrap { position: relative; }
+.odysseus-root .od-models-sort-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 24px;
+  padding: 0 8px;
+  font-size: 11px;
+  font-family: inherit;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: color-mix(in srgb, var(--fg) 60%, transparent);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+.odysseus-root .od-models-sort-btn:hover {
+  border-color: var(--red);
+  color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
+}
+.odysseus-root .od-models-sort-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 5;
+  min-width: 140px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+  padding: 4px;
+}
+.odysseus-root .od-models-sort-item {
+  display: block;
+  width: 100%;
+  padding: 6px 8px;
+  text-align: left;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: var(--fg);
+  font-size: 12px;
+  cursor: pointer;
+}
+.odysseus-root .od-models-sort-item:hover {
+  background: color-mix(in srgb, var(--red) 8%, transparent);
+}
+.odysseus-root .od-models-sort-item.current {
+  color: var(--red);
+  font-weight: 600;
+}
+
+/* In-list search (style.css .model-search-input, line 3661). */
+.odysseus-root .od-models-search-row {
+  position: relative;
+  margin-bottom: 6px;
+}
+.odysseus-root .od-models-search-icon {
+  position: absolute;
+  left: 9px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: color-mix(in srgb, var(--fg) 35%, transparent);
+  pointer-events: none;
+}
+.odysseus-root .od-model-search-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 10px 6px 28px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 0.8rem;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.odysseus-root .od-model-search-input:focus { border-color: var(--red); }
+.odysseus-root .od-model-search-input::placeholder {
+  color: color-mix(in srgb, var(--fg) 30%, transparent);
+}
+
+.odysseus-root .od-models-scroll {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+}
+
+/* Category / endpoint group headers (style.css lines 1468-1493). */
+.odysseus-root .od-models-category-header,
+.odysseus-root .od-models-endpoint-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 4px 8px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.85em;
+  font-weight: 600;
+  text-align: left;
+  text-transform: capitalize;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  border-radius: 4px;
+  user-select: none;
+  transition: background 0.08s, color 0.08s;
+}
+.odysseus-root .od-models-category-header { margin-top: 4px; }
+.odysseus-root .od-models-category-header:hover,
+.odysseus-root .od-models-endpoint-label:hover {
+  color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+}
+.odysseus-root .od-folder-toggle {
+  font-size: 0.7em;
+  width: 10px;
+  text-align: center;
+  flex-shrink: 0;
+}
+.odysseus-root .od-folder-count {
+  font-weight: 400;
+  opacity: 0.5;
+  font-size: 0.9em;
+}
+.odysseus-root .od-models-group-content.indented { padding-left: 4px; }
+
+/* Model row (style.css lines 3624-3633 + 1304 hover). */
+.odysseus-root .od-models-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--border);
+  padding: 4px;
+  margin: 4px 0;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.08s, border-color 0.08s;
+}
+.odysseus-root .od-models-row:hover {
+  background: color-mix(in srgb, var(--red) 8%, transparent);
+  border-color: var(--red);
+}
+.odysseus-root .od-models-drag {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: color-mix(in srgb, var(--fg) 30%, transparent);
+  cursor: grab;
+}
+.odysseus-root .od-models-grow {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  color: var(--fg);
+}
+
+/* Favorite dot / provider-logo holder (style.css lines 3634-3660 + 7179). */
+.odysseus-root .od-model-fav-btn {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: 1.5px solid color-mix(in srgb, var(--fg) 22%, transparent);
+  flex-shrink: 0;
+  cursor: pointer;
+  background: none;
+  padding: 0;
+  margin-left: 4px;
+  position: relative;
+  transition: all 0.15s;
+}
+.odysseus-root .od-model-fav-btn:hover {
+  border-color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 27%, transparent);
+  transform: scale(1.3);
+}
+.odysseus-root .od-model-fav-btn.active {
+  background: var(--fg);
+  border-color: var(--fg);
+}
+.odysseus-root .od-model-fav-btn.active:hover { opacity: 0.6; }
+/* When a provider logo matches, the dot becomes a 14px logo holder. */
+.odysseus-root .od-model-fav-btn.od-provider-logo {
+  width: 14px;
+  height: 14px;
+  border: none;
+  border-radius: 0;
+  background: none;
+  opacity: 0.4;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg);
+}
+.odysseus-root .od-model-fav-btn.od-provider-logo.active { opacity: 1; }
+.odysseus-root .od-model-fav-btn.od-provider-logo:hover {
+  opacity: 1;
+  transform: scale(1.2);
+  background: none;
+}
+.odysseus-root .od-model-fav-btn.od-provider-logo svg {
+  width: 14px;
+  height: 14px;
+  display: block;
+}
+
+/* IMG badge (style.css models.js inline badge). */
+.odysseus-root .od-model-type-badge {
+  font-size: 0.65em;
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: var(--accent);
+  color: var(--bg);
+  flex-shrink: 0;
+}
+
+/* "+ Chat" / "+ Image" action (style.css .model-chat-btn + .models-row button). */
+.odysseus-root .od-model-chat-btn {
+  margin-left: auto;
+  flex-shrink: 0;
+  height: 24px;
+  padding: 0 8px;
+  font-size: 9px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.08s, border-color 0.08s;
+}
+.odysseus-root .od-model-chat-btn:hover { border-color: var(--red); }
+
+/* "Show N more" overflow (style.css .models-show-all-btn inline). */
+.odysseus-root .od-models-show-all-btn {
+  display: block;
+  width: 100%;
+  text-align: center;
+  padding: 6px;
+  background: none;
+  border: none;
+  opacity: 0.5;
+  cursor: pointer;
+  font-size: 0.82em;
+  color: var(--fg);
+  transition: opacity 0.15s;
+}
+.odysseus-root .od-models-show-all-btn:hover { opacity: 0.8; }
+
+/* Empty / loading / error states (style.css .models-empty-state line 7176 +
+   .muted-sm / .accent-link). */
+.odysseus-root .od-models-empty-state {
+  text-align: center;
+  padding: 16px 8px;
+  line-height: 1.6;
+}
+.odysseus-root .od-models-muted {
+  color: color-mix(in srgb, var(--fg) 50%, transparent);
+  font-size: 13px;
+}
+.odysseus-root .od-models-muted-sm {
+  opacity: 0.45;
+  font-size: 0.8em;
+  color: var(--fg);
+}
+.odysseus-root .od-models-retry-link {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 0.85em;
+  padding: 4px 0 0;
+}
+.odysseus-root .od-models-retry-link:hover { text-decoration: underline; }
+/* ===== TasksView ===== */
+/* ── Tasks modal (odysseus static/js/tasks.js + style.css .task-* / .memory-* rules).
+   Real-wired orchestrator task list. All scoped under .odysseus-root, colours via theme vars. ── */
+
+/* Panel — override the shared .od-search-panel sizing to odysseus's centered
+   ~600px modal (.tasks-modal-content { max-width:600px; width:min(600px,92vw) }). */
+.odysseus-root .od-search-panel.od-tasks-panel {
+  width: min(600px, 92vw);
+  max-width: 600px;
+  max-height: 85vh;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  overflow: hidden;
+  font-size: 12px;
+}
+
+/* Modal header (.modal-header) */
+.odysseus-root .od-tasks-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-bottom: 8px;
+}
+.odysseus-root .od-tasks-header-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.odysseus-root .od-tasks-header-spacer { flex: 1; }
+.odysseus-root .od-tasks-close {
+  background: none;
+  border: none;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  cursor: pointer;
+  display: inline-flex;
+  padding: 2px;
+  border-radius: 6px;
+  transition: color 0.15s, background 0.15s;
+}
+.odysseus-root .od-tasks-close:hover {
+  color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+}
+
+/* Tab bar (.memory-tabs .tasks-tabs) — full-bleed underline re-inset 10px. */
+.odysseus-root .od-tasks-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  margin: -2px -10px 8px;
+  padding: 0 10px;
+  flex-shrink: 0;
+}
+.odysseus-root .od-tasks-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: none;
+  border: none;
+  color: var(--fg);
+  opacity: 0.5;
+  font-size: 12px;
+  font-family: inherit;
+  padding: 8px 14px;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: opacity 0.15s, border-color 0.15s, color 0.15s, background 0.15s;
+}
+.odysseus-root .od-tasks-tab:hover {
+  opacity: 0.8;
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
+}
+.odysseus-root .od-tasks-tab.active {
+  opacity: 1;
+  color: var(--red);
+  border-bottom-color: var(--red);
+}
+.odysseus-root .od-tasks-tab-count {
+  font-size: 0.8em;
+  opacity: 0.6;
+  font-weight: normal;
+  margin-left: 4px;
+}
+
+/* Body + card (.modal-body + .admin-card) */
+.odysseus-root .od-tasks-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.odysseus-root .od-tasks-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+}
+.odysseus-root .od-tasks-headrow {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 2px;
+}
+.odysseus-root .od-tasks-h2 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  color: var(--fg);
+}
+.odysseus-root .od-tasks-head-count {
+  font-size: 0.6em;
+  opacity: 0.6;
+  font-weight: normal;
+}
+.odysseus-root .od-tasks-desc {
+  margin: 4px 0 0;
+  font-size: 11px;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--fg) 50%, transparent);
+}
+
+/* Toolbar (.memory-toolbar + .memory-toolbar-btn + sort + search) */
+.odysseus-root .od-tasks-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 4px 0 8px;
+}
+.odysseus-root .od-tasks-toolbar-left {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.odysseus-root .od-tasks-toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  background: none;
+  border: 1px solid var(--border);
+  color: color-mix(in srgb, var(--fg) 60%, transparent);
+  font-size: 11px;
+  height: 24px;
+  padding: 0 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+.odysseus-root .od-tasks-toolbar-btn:hover:not(:disabled) {
+  border-color: var(--fg);
+  color: var(--fg);
+}
+.odysseus-root .od-tasks-toolbar-btn.active {
+  background: color-mix(in srgb, var(--red) 15%, transparent);
+  border-color: color-mix(in srgb, var(--red) 40%, transparent);
+  color: var(--red);
+}
+.odysseus-root .od-tasks-toolbar-btn.danger {
+  color: var(--red);
+  border-color: color-mix(in srgb, var(--red) 40%, transparent);
+}
+.odysseus-root .od-tasks-toolbar-btn.danger:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--red) 10%, transparent);
+}
+.odysseus-root .od-tasks-toolbar-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.odysseus-root .od-tasks-headrow .od-tasks-toolbar-btn { margin-left: auto; }
+
+.odysseus-root .od-tasks-sort {
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 11px;
+  height: 24px;
+  padding: 0 6px;
+  cursor: pointer;
+  width: 86px;
+}
+.odysseus-root .od-tasks-sort:focus { outline: none; border-color: var(--red); }
+
+.odysseus-root .od-tasks-search {
+  height: 24px;
+  padding: 0 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 11px;
+  width: 100%;
+  box-sizing: border-box;
+}
+.odysseus-root .od-tasks-search:focus { outline: none; border-color: var(--red); }
+.odysseus-root .od-tasks-search::placeholder {
+  color: color-mix(in srgb, var(--fg) 40%, transparent);
+}
+
+/* Bulk-select bar (.memory-bulk-bar) */
+.odysseus-root .od-tasks-bulk-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 18px 6px 2px;
+  margin-bottom: 8px;
+  border: 1px solid color-mix(in srgb, var(--red) 30%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--red) 5%, transparent);
+  font-size: 11px;
+}
+.odysseus-root .od-tasks-bulk-all {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.odysseus-root .od-tasks-bulk-count { color: color-mix(in srgb, var(--fg) 70%, transparent); }
+.odysseus-root .od-tasks-bulk-delete { margin-left: auto; }
+.odysseus-root .od-tasks-bulk-cancel { padding: 3px 6px; }
+
+/* Category filter chips (.memory-cat-chip) */
+.odysseus-root .od-tasks-chips {
+  display: flex;
+  gap: 5px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+.odysseus-root .od-tasks-chip {
+  background: none;
+  border: 1px solid var(--border);
+  color: color-mix(in srgb, var(--fg) 60%, transparent);
+  font-size: 10px;
+  height: 22px;
+  padding: 0 8px;
+  display: inline-flex;
+  align-items: center;
+  border-radius: 10px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all 0.15s;
+  text-transform: lowercase;
+}
+.odysseus-root .od-tasks-chip:hover { border-color: var(--red); color: var(--red); }
+.odysseus-root .od-tasks-chip.active {
+  background: color-mix(in srgb, var(--red) 15%, transparent);
+  border-color: color-mix(in srgb, var(--red) 40%, transparent);
+  color: var(--red);
+}
+
+/* List (.memory-list) */
+.odysseus-root .od-tasks-list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  overscroll-behavior: contain;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.odysseus-root .od-tasks-empty {
+  opacity: 0.4;
+  font-size: 12px;
+  text-align: center;
+  padding: 24px 12px;
+  line-height: 1.5;
+}
+
+/* Task card (.memory-item.task-card) */
+.odysseus-root .od-tasks-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+  max-height: 200px;
+  flex-shrink: 0;
+  transition: all 0.15s;
+}
+.odysseus-root .od-tasks-item:hover {
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
+  border-color: color-mix(in srgb, var(--fg) 16%, transparent);
+}
+.odysseus-root .od-tasks-item.selected {
+  border-color: color-mix(in srgb, var(--red) 45%, transparent);
+  background: color-mix(in srgb, var(--red) 6%, transparent);
+}
+/* paused: dim + saturate-down + diagonal hatch (.memory-item.task-paused) */
+.odysseus-root .od-tasks-item.task-paused {
+  opacity: 0.45;
+  filter: saturate(0.55);
+  background: repeating-linear-gradient(
+    45deg,
+    color-mix(in srgb, var(--fg) 2%, transparent),
+    color-mix(in srgb, var(--fg) 2%, transparent) 8px,
+    color-mix(in srgb, var(--fg) 5%, transparent) 8px,
+    color-mix(in srgb, var(--fg) 5%, transparent) 16px
+  );
+}
+.odysseus-root .od-tasks-item.task-paused:hover { opacity: 0.85; filter: saturate(0.9); }
+
+.odysseus-root .od-tasks-item-content {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.odysseus-root .od-tasks-item-title-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+.odysseus-root .od-tasks-item-icon {
+  display: inline-flex;
+  opacity: 0.4;
+  flex-shrink: 0;
+}
+.odysseus-root .od-tasks-item-title {
+  font-size: 12px;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.odysseus-root .od-tasks-item-flex { flex: 1; }
+
+/* Status badges (.task-status-badge + variants) */
+.odysseus-root .od-tasks-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 9px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  flex-shrink: 0;
+  cursor: pointer;
+  border: 1px solid transparent;
+  line-height: 16px;
+  font-family: inherit;
+  transition: transform 0.12s ease, border-color 0.12s ease, background 0.12s ease, filter 0.12s ease;
+  user-select: none;
+}
+.odysseus-root button.od-tasks-status-badge { appearance: none; }
+.odysseus-root .od-tasks-status-badge:hover { filter: brightness(1.08) saturate(1.15); }
+.odysseus-root .od-tasks-paused-badge {
+  color: var(--orange, #ffb86c);
+  background: color-mix(in srgb, var(--orange, #ffb86c) 22%, transparent);
+  border-color: color-mix(in srgb, var(--orange, #ffb86c) 35%, transparent);
+}
+.odysseus-root .od-tasks-paused-badge:hover {
+  background: color-mix(in srgb, var(--orange, #ffb86c) 30%, transparent);
+  border-color: color-mix(in srgb, var(--orange, #ffb86c) 55%, transparent);
+}
+.odysseus-root .od-tasks-active-badge {
+  color: var(--ok, #50fa7b);
+  background: color-mix(in srgb, var(--ok, #50fa7b) 20%, transparent);
+  border-color: color-mix(in srgb, var(--ok, #50fa7b) 35%, transparent);
+}
+.odysseus-root .od-tasks-active-badge:hover {
+  background: color-mix(in srgb, var(--ok, #50fa7b) 28%, transparent);
+  border-color: color-mix(in srgb, var(--ok, #50fa7b) 55%, transparent);
+}
+.odysseus-root .od-tasks-error-badge {
+  color: var(--red);
+  background: color-mix(in srgb, var(--red) 16%, transparent);
+  border-color: color-mix(in srgb, var(--red) 34%, transparent);
+  cursor: default;
+}
+.odysseus-root .od-tasks-done-badge {
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  border-color: color-mix(in srgb, var(--fg) 18%, transparent);
+  cursor: default;
+}
+.odysseus-root .od-tasks-run-badge {
+  color: var(--accent, var(--red));
+  background: color-mix(in srgb, var(--accent, var(--red)) 16%, transparent);
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 34%, transparent);
+}
+.odysseus-root .od-tasks-run-badge:hover {
+  background: color-mix(in srgb, var(--accent, var(--red)) 24%, transparent);
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 52%, transparent);
+}
+
+/* Card actions (.memory-item-actions) — reveal on hover */
+.odysseus-root .od-tasks-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.15s;
+}
+.odysseus-root .od-tasks-item:hover .od-tasks-item-actions,
+.odysseus-root .od-tasks-item.expanded .od-tasks-item-actions { opacity: 1; }
+.odysseus-root .od-tasks-menu-wrap { position: relative; }
+.odysseus-root .od-tasks-menu-btn {
+  background: none;
+  border: 1px solid transparent;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  height: 22px;
+  padding: 0 4px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  transition: all 0.15s;
+}
+.odysseus-root .od-tasks-menu-btn:hover {
+  color: var(--fg);
+  border-color: var(--border);
+  background: color-mix(in srgb, var(--fg) 6%, transparent);
+}
+.odysseus-root .od-tasks-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 5;
+  margin-top: 4px;
+  min-width: 130px;
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 6px 18px color-mix(in srgb, #000 35%, transparent);
+}
+.odysseus-root .od-tasks-menu-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: none;
+  border: none;
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 11px;
+  text-align: left;
+  padding: 5px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.odysseus-root .od-tasks-menu-item:hover { background: color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-tasks-menu-item.danger { color: var(--red); }
+.odysseus-root .od-tasks-menu-item.danger:hover { background: color-mix(in srgb, var(--red) 12%, transparent); }
+
+/* Select checkbox (.memory-select-cb) — 6px round dot */
+.odysseus-root .od-tasks-select-cb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 6px; height: 6px;
+  min-width: 6px; min-height: 6px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: transparent;
+  cursor: pointer;
+  flex-shrink: 0;
+  margin: 0;
+  box-sizing: content-box;
+  transition: all 0.15s;
+}
+.odysseus-root .od-tasks-select-cb:hover { border-color: var(--red); }
+.odysseus-root .od-tasks-select-cb:checked { background: var(--red); border-color: var(--red); }
+
+/* Slim meta line + expandable detail */
+.odysseus-root .od-tasks-item-meta {
+  font-size: 10px;
+  opacity: 0.4;
+  margin-top: -1px;
+}
+.odysseus-root .od-tasks-item-detail {
+  margin-top: 7px;
+  padding: 8px 0 2px;
+  border-top: 1px solid var(--border);
+}
+.odysseus-root .od-tasks-item-detail-meta {
+  font-size: 10px;
+  opacity: 0.4;
+  margin-bottom: 6px;
+}
+.odysseus-root .od-tasks-item-result {
+  font-size: 11px;
+  margin-bottom: 6px;
+  padding: 4px 8px;
+  border-left: 2px solid var(--ok, #50fa7b);
+  background: color-mix(in srgb, var(--ok, #50fa7b) 8%, transparent);
+  border-radius: 2px;
+  line-height: 1.4;
+}
+.odysseus-root .od-tasks-item-result.error {
+  border-left-color: var(--red);
+  background: color-mix(in srgb, var(--red) 8%, transparent);
+}
+.odysseus-root .od-tasks-item-result-mark { font-weight: 600; color: var(--ok, #50fa7b); }
+.odysseus-root .od-tasks-item-result.error .od-tasks-item-result-mark { color: var(--red); }
+.odysseus-root .od-tasks-item-result-text { opacity: 0.9; }
+.odysseus-root .od-tasks-item-desc {
+  font-size: 11px;
+  opacity: 0.6;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+}
+
+/* "Add" tab placeholder */
+.odysseus-root .od-tasks-add-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 32px 16px;
+  opacity: 0.4;
+  font-size: 12px;
+  text-align: center;
+}
+
+/* Run-history sub-view (.task-history-header / .task-runs-list / .task-run-item) */
+.odysseus-root .od-tasks-history-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.odysseus-root .od-tasks-history-title { font-size: 13px; opacity: 0.7; }
+.odysseus-root .od-tasks-btn {
+  font-family: inherit;
+  font-size: 11px;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: none;
+  color: var(--fg);
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity 0.15s, background 0.15s;
+}
+.odysseus-root .od-tasks-btn:hover { opacity: 1; }
+.odysseus-root .od-tasks-runs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
+}
+.odysseus-root .od-tasks-run-item {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+}
+.odysseus-root .od-tasks-run-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+}
+.odysseus-root .od-tasks-run-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.odysseus-root .od-tasks-run-time { margin-left: auto; font-size: 10px; opacity: 0.45; }
+.odysseus-root .od-tasks-run-result {
+  font-size: 11px;
+  opacity: 0.6;
+  margin-top: 4px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* Live clock footer (.tasks-clock) */
+.odysseus-root .od-tasks-clock {
+  font-size: 10px;
+  opacity: 0.35;
+  text-align: center;
+  padding: 6px 0 2px;
+  flex-shrink: 0;
+}
+
+
+/* ===== GalleryEditorView ===== */
+/* ════════════════════════════════════════════════════════════════════
+   Gallery Editor (odysseus galleryEditor.js + editor/* + editor rules in
+   style.css). Scoped under .odysseus-root, colors via theme vars. Ported
+   1:1 from odysseus's .gallery-editor / .ge-* rules. Reuses the shared
+   .od-search-overlay / .od-search-backdrop backdrop pattern (CompareView)
+   with a large full-bleed .od-ge-panel.
+   ════════════════════════════════════════════════════════════════════ */
+
+/* Full-bleed editor panel — large column reusing the overlay backdrop,
+   same convention as .od-compare-panel. */
+.odysseus-root .od-ge-panel {
+  width: min(1280px, 97vw);
+  height: min(90vh, 920px);
+  max-width: none;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+  animation: od-ge-enter 0.3s ease-out;
+}
+@keyframes od-ge-enter {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.odysseus-root .gallery-editor {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+/* ── Top bar ── */
+.odysseus-root .ge-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  gap: 8px;
+  position: relative;
+  z-index: 5;
+}
+.odysseus-root .ge-topbar-left,
+.odysseus-root .ge-topbar-right {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.odysseus-root .ge-alpha-badge {
+  flex-shrink: 0;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  line-height: 1;
+  padding: 3px 6px;
+  margin-right: 4px;
+  border-radius: 4px;
+  color: var(--accent, var(--red));
+  background: color-mix(in srgb, var(--accent, var(--red)) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--accent, var(--red)) 40%, transparent);
+  text-transform: uppercase;
+  user-select: none;
+  cursor: default;
+}
+.odysseus-root .ge-topbar-sep {
+  width: 1px;
+  height: 16px;
+  background: var(--border);
+  margin: 0 4px;
+}
+.odysseus-root .ge-ge-close {
+  background: none;
+  border: none;
+  color: var(--muted, var(--fg));
+  cursor: pointer;
+  padding: 4px;
+  margin-left: 2px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.7;
+  transition: opacity 0.15s, background 0.15s, color 0.15s;
+}
+.odysseus-root .ge-ge-close:hover {
+  opacity: 1;
+  color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+}
+
+/* Topbar buttons sit visually 2px low against label baselines. */
+.odysseus-root .ge-topbar .ge-btn,
+.odysseus-root .ge-topbar .ge-btn-sm,
+.odysseus-root .ge-topbar select { position: relative; top: -2px; }
+
+/* Stacked button — glyph over a small uppercase label (Undo/Redo/Hist). */
+.odysseus-root .ge-stacked-btn {
+  display: inline-flex !important;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  padding: 2px 8px !important;
+  line-height: 1;
+}
+.odysseus-root .ge-stacked-btn .ge-stacked-glyph {
+  font-size: 14px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 14px;
+}
+.odysseus-root .ge-stacked-btn .ge-stacked-glyph svg { display: block; }
+.odysseus-root .ge-stacked-btn .ge-stacked-label {
+  font-size: 8px;
+  letter-spacing: 0.06em;
+  opacity: 0.65;
+  font-weight: 600;
+  position: relative;
+  top: 2px;
+}
+.odysseus-root .ge-zoom-stack {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
+  line-height: 1;
+  padding: 0 4px;
+}
+.odysseus-root .ge-zoom-stack .ge-zoom-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.7;
+  position: relative;
+  left: -1px;
+}
+.odysseus-root .ge-zoom-stack .ge-zoom-glyph svg { width: 16px; height: 16px; }
+.odysseus-root .ge-zoom-stack .ge-zoom-label {
+  font-size: 8px;
+  letter-spacing: 0.06em;
+  opacity: 0.65;
+  font-weight: 600;
+  position: relative;
+  top: 4px;
+  left: 1px;
+}
+
+/* Topbar dropdown menus (Image / Filter / Save). */
+.odysseus-root .ge-image-wrap,
+.odysseus-root .ge-filter-wrap,
+.odysseus-root .ge-save-wrap { position: relative; display: inline-block; }
+.odysseus-root .ge-image-menu,
+.odysseus-root .ge-filter-menu,
+.odysseus-root .ge-save-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 160px;
+  padding: 4px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 14px color-mix(in srgb, var(--fg) 18%, transparent);
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.odysseus-root .ge-save-menu-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.odysseus-root .ge-image-menu .dropdown-item-compact,
+.odysseus-root .ge-filter-menu .dropdown-item-compact,
+.odysseus-root .ge-save-menu .dropdown-item-compact {
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
+  font: inherit;
+  font-size: 11px;
+  color: var(--fg);
+  border-radius: 5px;
+  padding: 5px 8px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.odysseus-root .ge-image-menu .dropdown-item-compact:hover,
+.odysseus-root .ge-filter-menu .dropdown-item-compact:hover,
+.odysseus-root .ge-save-menu .dropdown-item-compact:hover {
+  background: color-mix(in srgb, var(--fg) 12%, transparent);
+}
+.odysseus-root .ge-image-menu .dropdown-icon,
+.odysseus-root .ge-filter-menu .dropdown-icon,
+.odysseus-root .ge-save-menu .dropdown-icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--muted, var(--fg));
+  flex-shrink: 0;
+  width: 14px;
+  justify-content: center;
+}
+.odysseus-root .dropdown-shortcut {
+  margin-left: auto;
+  font-size: 9px;
+  opacity: 0.5;
+  font-variant-numeric: tabular-nums;
+}
+.odysseus-root .ge-filter-submenu-label,
+.odysseus-root .dropdown-section-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.5;
+  font-weight: 600;
+  padding: 6px 8px 2px;
+}
+.odysseus-root .dropdown-section-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+  opacity: 0.6;
+}
+
+/* ── Editor body (toolbar + canvas + panel) ── */
+.odysseus-root .ge-editor-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+/* ── Left tool palette ── */
+.odysseus-root .ge-toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 8px 8px 0;
+  background: var(--panel);
+  border-right: 1px solid var(--border);
+  width: 56px;
+  flex-shrink: 0;
+  overflow-y: auto;
+}
+.odysseus-root .ge-tool-sep {
+  border-top: 1px solid var(--border);
+  margin: 4px 0;
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+.odysseus-root .ge-tool-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  padding: 0 2px;
+  height: 42px;
+  flex-shrink: 0;
+  border: none;
+  background: none;
+  color: var(--fg);
+  opacity: 0.6;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background 0.15s, opacity 0.15s;
+  position: relative;
+}
+.odysseus-root .ge-tool-btn:hover { opacity: 0.85; }
+.odysseus-root .ge-tool-btn:hover::after {
+  content: '';
+  position: absolute;
+  inset: 0 2px 0 -2px;
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  border-radius: 6px;
+  z-index: -1;
+  pointer-events: none;
+}
+.odysseus-root .ge-tool-btn.active {
+  opacity: 1;
+  color: var(--red);
+  background: none;
+}
+.odysseus-root .ge-tool-btn.active::before {
+  content: '';
+  position: absolute;
+  inset: 0 2px 0 -2px;
+  background: color-mix(in srgb, var(--red) 18%, transparent);
+  border-radius: 6px;
+  z-index: 0;
+  pointer-events: none;
+}
+.odysseus-root .ge-tool-btn > * { position: relative; z-index: 1; left: -2px; }
+.odysseus-root .ge-tool-icon {
+  font-size: 18px;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.odysseus-root .ge-tool-glyph { font-size: 18px; line-height: 1; }
+.odysseus-root .ge-tool-label {
+  font-size: 9px;
+  line-height: 1.25;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.odysseus-root .ge-tool-ai {
+  position: absolute !important;
+  top: 1px;
+  left: 3px !important;
+  z-index: 2;
+  color: inherit;
+  opacity: 0.7;
+  pointer-events: none;
+  font-size: 11px;
+  line-height: 1;
+  font-weight: 700;
+}
+.odysseus-root .ge-tool-btn.is-ai:hover .ge-tool-ai { opacity: 0.95; }
+.odysseus-root .ge-tool-btn.is-ai.active .ge-tool-ai { opacity: 1; }
+
+/* ── Canvas area (center) + checkerboard + honest landing ── */
+.odysseus-root .ge-canvas-area {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+  background: var(--bg);
+  position: relative;
+  min-width: 0;
+}
+.odysseus-root .gallery-editor-landing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 64px 16px;
+  flex: 1;
+  text-align: center;
+  color: var(--fg);
+  /* Checkerboard transparency backdrop framed like odysseus's canvas. */
+  width: min(520px, 72%);
+  aspect-ratio: 4 / 3;
+  max-height: 80%;
+  border-radius: 8px;
+  background:
+    repeating-conic-gradient(
+      color-mix(in srgb, var(--fg) 8%, transparent) 0% 25%,
+      color-mix(in srgb, var(--fg) 3%, transparent) 0% 50%
+    ) 50% / 22px 22px;
+  border: 1px dashed color-mix(in srgb, var(--fg) 20%, transparent);
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.18);
+}
+.odysseus-root .gallery-editor-landing h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+.odysseus-root .gallery-editor-landing p {
+  margin: 0;
+  opacity: 0.6;
+  font-size: 13px;
+  max-width: 320px;
+  line-height: 1.5;
+}
+.odysseus-root .ge-alpha-tag {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  vertical-align: middle;
+  padding: 1px 5px;
+  border-radius: 4px;
+  color: var(--accent, var(--red));
+  background: color-mix(in srgb, var(--accent, var(--red)) 15%, transparent);
+  position: relative;
+  top: -1px;
+}
+.odysseus-root .gallery-editor-landing-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 8px;
+}
+.odysseus-root .ge-ge-landing-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 16px;
+  font-size: 12px;
+}
+.odysseus-root .ge-ge-landing-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Right panel (controls + layers) ── */
+.odysseus-root .ge-right-panel {
+  width: 220px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--border);
+  background: var(--panel);
+  overflow-y: auto;
+  overflow-x: hidden;
+  position: relative;
+}
+.odysseus-root .ge-controls {
+  flex: 0 0 auto;
+  padding: 10px 10px 6px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.odysseus-root .ge-brush-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.odysseus-root .ge-controls input[type="range"] {
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  display: block;
+}
+.odysseus-root .ge-control-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--fg);
+}
+.odysseus-root .ge-control-row label {
+  flex-shrink: 0;
+  opacity: 0.7;
+  min-width: 36px;
+}
+.odysseus-root .ge-color-picker {
+  width: 24px;
+  height: 24px;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  padding: 0;
+  cursor: pointer;
+  background: none;
+  overflow: hidden;
+  flex: 0 0 24px;
+}
+.odysseus-root .ge-color-picker::-webkit-color-swatch-wrapper { padding: 0; }
+.odysseus-root .ge-color-picker::-webkit-color-swatch { border: none; border-radius: 50%; }
+.odysseus-root .ge-color-picker::-moz-color-swatch { border: none; border-radius: 50%; }
+
+/* Section titles / hints / dividers / help chip. */
+.odysseus-root .ge-section-title {
+  margin: 10px 0 4px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.5;
+  font-weight: 600;
+}
+.odysseus-root .ge-section-title-with-help {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+}
+.odysseus-root .ge-ge-mask-brush-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+}
+.odysseus-root .ge-section-hint {
+  font-size: 10.5px;
+  line-height: 1.45;
+  opacity: 0.55;
+  margin: 0 0 8px;
+}
+.odysseus-root .ge-ge-tiny-hint {
+  font-size: 9px;
+  opacity: 0.4;
+  margin: 4px 0 0;
+}
+.odysseus-root .ge-section-divider {
+  border: 0;
+  border-top: 1px solid var(--border);
+  margin: 10px -2px;
+  opacity: 0.6;
+}
+.odysseus-root .ge-section-help {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  margin-left: 4px;
+  font-size: 9px;
+  font-weight: 600;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  color: var(--muted, var(--fg));
+  background: none;
+  cursor: help;
+  position: relative;
+  top: -1px;
+  opacity: 0.7;
+  transition: opacity 0.15s, color 0.15s, border-color 0.15s;
+}
+.odysseus-root .ge-section-title-with-help .ge-section-help { margin-left: 0; }
+.odysseus-root .ge-section-help:hover {
+  opacity: 1;
+  color: var(--fg);
+  border-color: var(--muted, var(--fg));
+}
+
+/* Slider rows (Opacity / Flow / Softness / Tolerance / Strength / …). */
+.odysseus-root .ge-eraser-row {
+  display: flex !important;
+  align-items: center !important;
+  gap: 8px;
+  padding: 2px 0;
+  position: relative;
+}
+.odysseus-root .ge-eraser-row label {
+  font-size: 10px;
+  opacity: 0.55;
+  flex: 0 0 78px;
+  white-space: nowrap;
+}
+.odysseus-root .ge-eraser-row input[type="range"] {
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 8px;
+  accent-color: var(--red);
+  -webkit-appearance: none;
+  appearance: none;
+  background: color-mix(in srgb, var(--fg) 25%, transparent);
+  border-radius: 999px;
+  margin: 0;
+  position: relative;
+  z-index: 2;
+}
+.odysseus-root .ge-eraser-row input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--red);
+  border: none;
+  cursor: pointer;
+}
+.odysseus-root .ge-eraser-row input[type="range"]::-moz-range-thumb {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--red);
+  border: none;
+  cursor: pointer;
+}
+.odysseus-root .ge-slider-value {
+  flex: 0 0 auto;
+  margin: 0 0 0 6px;
+  padding: 0 4px;
+  font-size: 10px;
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+  min-width: 34px;
+  text-align: right;
+  white-space: nowrap;
+}
+.odysseus-root .ge-eraser-preview {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--fg);
+  flex-shrink: 0;
+  display: inline-block;
+  opacity: 0.5;
+}
+
+/* Size slider in the brush-controls block (no preview disk). */
+.odysseus-root .ge-size-slider {
+  flex: 1 1 auto;
+  height: 8px;
+  accent-color: var(--red);
+  -webkit-appearance: none;
+  appearance: none;
+  background: color-mix(in srgb, var(--fg) 25%, transparent);
+  border-radius: 999px;
+}
+.odysseus-root .ge-size-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--red);
+  border: none;
+  cursor: pointer;
+}
+.odysseus-root .ge-size-slider::-moz-range-thumb {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--red);
+  border: none;
+  cursor: pointer;
+}
+.odysseus-root .ge-size-label {
+  margin-left: 4px;
+  padding: 0 4px;
+  font-size: 10px;
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Action button clusters. */
+.odysseus-root .ge-actions {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.odysseus-root .ge-ge-actions-wrap { margin-top: 4px; }
+.odysseus-root .ge-ge-mode-row { display: flex; gap: 4px; margin-bottom: 4px; }
+.odysseus-root .ge-ge-model-row { margin-top: 6px; }
+.odysseus-root .ge-ge-strength-row { margin-top: 6px; }
+.odysseus-root .ge-ge-ai-actions {
+  margin-top: 6px;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  min-width: 0;
+}
+.odysseus-root .ge-ge-ai-btn { flex: 1 1 0; }
+.odysseus-root .ge-ge-ai-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.odysseus-root .ge-ge-mode-half {
+  flex: 1 1 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+
+/* Base buttons. */
+.odysseus-root .ge-btn {
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--fg);
+  font-size: 11px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.odysseus-root .ge-btn:hover { background: color-mix(in srgb, var(--fg) 10%, var(--bg)); }
+.odysseus-root .ge-btn.active {
+  background: color-mix(in srgb, var(--accent, var(--red)) 16%, var(--bg));
+  border-color: var(--accent, var(--red));
+  color: var(--accent, var(--red));
+}
+.odysseus-root .ge-btn-sm { padding: 3px 6px; font-size: 10px; }
+.odysseus-root .ge-btn-iconlabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.odysseus-root .ge-btn-primary {
+  background: var(--red);
+  color: #fff;
+  border-color: var(--red);
+  font-weight: 600;
+}
+.odysseus-root .ge-btn-primary:hover { background: color-mix(in srgb, var(--red) 85%, #000); }
+.odysseus-root .ge-btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+.odysseus-root .ge-btn-ai-mark {
+  display: inline-block;
+  font-size: 11px;
+  line-height: 1;
+  font-weight: 700;
+  opacity: 0.75;
+  margin-right: 1px;
+}
+.odysseus-root .ge-mask-vis-btn {
+  background: none !important;
+  border: none !important;
+  padding: 2px 4px !important;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  opacity: 0.5;
+  transition: opacity 0.12s;
+}
+.odysseus-root .ge-mask-vis-btn.visible { opacity: 0.9; }
+.odysseus-root .ge-mask-vis-btn:hover { opacity: 1; background: none !important; }
+.odysseus-root .ge-inpaint-mode-btn,
+.odysseus-root .ge-wand-mode-btn {
+  font-size: 11px;
+  padding: 4px 8px;
+  opacity: 0.6;
+  border: 1px solid var(--border);
+}
+.odysseus-root .ge-wand-mode-btn { flex: 1 1 0; padding: 4px 6px; }
+.odysseus-root .ge-inpaint-mode-btn.active,
+.odysseus-root .ge-wand-mode-btn.active {
+  opacity: 1;
+  background: color-mix(in srgb, var(--accent, var(--red)) 18%, transparent);
+  border-color: var(--accent, var(--red));
+  color: var(--accent, var(--red));
+  font-weight: 600;
+}
+
+/* Inpaint section bits. */
+.odysseus-root .ge-inpaint-section {
+  padding: 8px 0;
+  border-top: 1px solid var(--border);
+  margin-top: 4px;
+}
+.odysseus-root .ge-inpaint-mask-row {
+  display: flex !important;
+  gap: 4px;
+  align-items: center;
+  margin-top: 4px;
+}
+.odysseus-root .ge-inpaint-prompt {
+  width: 100%;
+  padding: 6px 8px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 12px;
+  font-family: inherit;
+  margin-top: 4px;
+  box-sizing: border-box;
+}
+.odysseus-root .ge-inpaint-prompt:focus { border-color: var(--red); outline: none; }
+.odysseus-root .ge-inpaint-model-row { display: flex; align-items: center; gap: 8px; }
+.odysseus-root .ge-inpaint-model-row label { flex: 0 0 auto; font-size: 10px; opacity: 0.65; }
+.odysseus-root .ge-ai-model {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 10px;
+  padding: 4px 6px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+/* ── Layers panel ── */
+.odysseus-root .ge-layers {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+.odysseus-root .ge-layers-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--fg);
+  opacity: 0.8;
+  border-bottom: 1px solid var(--border);
+}
+.odysseus-root .ge-layers-title { flex: 1; }
+.odysseus-root .ge-layers-grab { display: none; }
+.odysseus-root .ge-icon-btn {
+  padding: 4px 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.odysseus-root .ge-layers-header .ge-btn:disabled,
+.odysseus-root .ge-ge-add-layer:disabled { opacity: 0.4; cursor: not-allowed; }
+.odysseus-root .ge-layers-list {
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 0;
+}
+.odysseus-root .ge-ge-layers-empty {
+  padding: 18px 12px;
+  font-size: 11px;
+  text-align: center;
+  opacity: 0.5;
+  line-height: 1.5;
+}
+
+/* Panel resize grab handle. */
+.odysseus-root .ge-panel-resize {
+  position: absolute;
+  left: -3px;
+  top: 0;
+  bottom: 0;
+  width: 6px;
+  cursor: ew-resize;
+  background: transparent;
+  z-index: 5;
+  transition: background 0.12s;
+}
+.odysseus-root .ge-panel-resize:hover {
+  background: color-mix(in srgb, var(--red) 30%, transparent);
+}
+.odysseus-root .ge-panel-resize::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 2px;
+  height: 24px;
+  background: color-mix(in srgb, var(--fg) 35%, transparent);
+  border-radius: 2px;
+}
+
+/* ── History popover (frosted) ── */
+.odysseus-root .ge-frosted {
+  background: color-mix(in srgb, var(--panel) 70%, transparent);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border: 1px solid color-mix(in srgb, var(--fg) 12%, transparent);
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.55);
+}
+.odysseus-root .ge-history-panel {
+  position: absolute;
+  top: 52px;
+  left: 92px;
+  z-index: 60;
+  width: 240px;
+  max-height: 360px;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  color: var(--fg);
+}
+.odysseus-root .ge-history-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid color-mix(in srgb, var(--fg) 10%, transparent);
+}
+.odysseus-root .ge-adj-icon {
+  display: inline-flex;
+  align-items: center;
+  color: var(--muted, var(--fg));
+  flex-shrink: 0;
+}
+.odysseus-root .ge-history-title { font-weight: 600; font-size: 12px; flex: 1 1 auto; }
+.odysseus-root .ge-head-btns { display: inline-flex; margin-left: auto; }
+.odysseus-root .ge-history-close {
+  background: none;
+  border: none;
+  color: var(--muted, var(--fg));
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+  flex-shrink: 0;
+}
+.odysseus-root .ge-history-close:hover { color: var(--fg); }
+.odysseus-root .ge-history-list { overflow-y: auto; padding: 4px 0; }
+.odysseus-root .ge-history-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 5px 10px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  color: var(--fg);
+  font-size: 11px;
+}
+.odysseus-root .ge-history-row:hover { background: color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .ge-history-row.current {
+  background: color-mix(in srgb, var(--accent, var(--red)) 18%, transparent);
+}
+.odysseus-root .ge-history-row.current .ge-history-row-dot { background: var(--accent, var(--red)); }
+.odysseus-root .ge-history-row-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--muted, var(--fg));
+  flex-shrink: 0;
+}
+.odysseus-root .ge-history-row-label {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.odysseus-root .ge-history-row-time { font-size: 9px; opacity: 0.55; flex-shrink: 0; }
+
+/* ── Shortcuts cheatsheet overlay ── */
+.odysseus-root .ge-shortcuts-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 70;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.odysseus-root .ge-shortcuts-card {
+  position: relative;
+  z-index: 1;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 18px 12px;
+  box-shadow: 0 8px 30px color-mix(in srgb, var(--fg) 25%, transparent);
+  width: min(720px, 92%);
+  max-height: 86%;
+  overflow-y: auto;
+  color: var(--fg);
+}
+.odysseus-root .ge-shortcuts-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+  font-weight: 600;
+  font-size: 13px;
+}
+.odysseus-root .ge-shortcuts-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px 24px;
+}
+@media (min-width: 720px) {
+  .odysseus-root .ge-shortcuts-grid { grid-template-columns: repeat(4, 1fr); }
+}
+.odysseus-root .ge-shortcuts-col h5 {
+  margin: 0 0 6px;
+  font-size: 11px;
+  opacity: 0.6;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+.odysseus-root .ge-shortcuts-col > div {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 4px 0;
+  opacity: 0.85;
+  line-height: 1.5;
+}
+.odysseus-root .ge-shortcuts-col > div kbd:last-of-type { margin-right: 6px; }
+.odysseus-root .ge-shortcuts-card kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border: 1px solid color-mix(in srgb, var(--accent, var(--red)) 55%, transparent);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--accent, var(--red)) 14%, transparent);
+  color: var(--accent, var(--red));
+  min-width: 18px;
+  line-height: 1.4;
+}
+.odysseus-root .ge-shortcuts-foot {
+  margin-top: 12px;
+  font-size: 11px;
+  opacity: 0.55;
+  text-align: center;
+}
+/* ===== GroupChatView ===== */
+/* ── Group Chat (odysseus group.js + .msg-group rules) ──────────────────────
+   A wide panel: header with a participant count + parallel/sequential mode
+   toggle + close, a room picker, then a two-column body (participant roster +
+   shared message stream) above a composer. Reuses the shared .od-msg /
+   .od-role / .od-body / .od-msg-time bubble styles already in ODYSSEUS_CSS; the
+   classes below are the group-specific chrome. All colours via theme vars. */
+.odysseus-root .od-search-panel.od-group-panel {
+  width: 860px;
+  max-width: 94%;
+  height: 80vh;
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+.odysseus-root .od-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.odysseus-root .od-group-header-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.odysseus-root .od-group-header-count {
+  font-size: 11px;
+  font-weight: 400;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+.odysseus-root .od-group-header-spacer { flex: 1; }
+/* odysseus #group-mode-btn — icon + label, comfortable touch target. */
+.odysseus-root .od-group-mode-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  font-size: 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+  color: var(--fg);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.odysseus-root .od-group-mode-btn:hover {
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+}
+/* odysseus #group-toggle-btn.active — red wash when parallel ("all respond"). */
+.odysseus-root .od-group-mode-btn.active {
+  color: var(--red);
+  background: color-mix(in srgb, var(--red) 12%, transparent);
+  border-color: color-mix(in srgb, var(--red) 40%, transparent);
+}
+.odysseus-root .od-group-mode-label { font-size: 12px; font-weight: 500; }
+.odysseus-root .od-group-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  border: none;
+  background: none;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.odysseus-root .od-group-close:hover {
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  color: var(--fg);
+}
+.odysseus-root .od-group-roompicker {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.odysseus-root .od-group-roompicker-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--fg) 50%, transparent);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.odysseus-root .od-group-room-select {
+  flex: 1;
+  min-width: 0;
+  height: 28px;
+  padding: 0 8px;
+  font-size: 12px;
+  font-family: inherit;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  outline: none;
+  cursor: pointer;
+}
+.odysseus-root .od-group-room-select:focus { border-color: var(--accent, var(--red)); }
+.odysseus-root .od-group-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+/* ── Participant roster (odysseus group-participants list) ── */
+.odysseus-root .od-group-roster {
+  width: 210px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+.odysseus-root .od-group-roster-head {
+  padding: 10px 12px 6px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+.odysseus-root .od-group-roster-empty {
+  padding: 12px;
+  font-size: 12px;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+.odysseus-root .od-group-roster-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 0 6px 8px;
+}
+/* odysseus participant row: flex, color-mix bg, 6px radius. */
+.odysseus-root .od-group-participant {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+}
+.odysseus-root .od-group-participant.idle { opacity: 0.55; }
+.odysseus-root .od-group-participant-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.odysseus-root .od-group-participant-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1;
+}
+.odysseus-root .od-group-participant-name {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--fg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.odysseus-root .od-group-participant-sub {
+  font-size: 10px;
+  color: color-mix(in srgb, var(--fg) 38%, transparent);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* ── Shared message stream ── */
+.odysseus-root .od-group-stream-wrap {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+.odysseus-root .od-group-stream {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  padding: 12px 14px;
+}
+.odysseus-root .od-group-empty {
+  margin: auto;
+  max-width: 360px;
+  text-align: center;
+  font-size: 13px;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+/* odysseus .msg-group .role is bold; the per-sender dot/name/time mirror the
+   group bubble header (role + role-timestamp). */
+.odysseus-root .od-msg-group .od-role { font-weight: 600; }
+.odysseus-root .od-group-role-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.odysseus-root .od-group-role-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.odysseus-root .od-group-role-time {
+  font-size: 0.7rem;
+  font-weight: 400;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+  margin-left: 2px;
+}
+/* ── Composer (odysseus .chat-input-bar) ── */
+.odysseus-root .od-group-composer {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 10px 14px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.odysseus-root .od-group-input {
+  flex: 1;
+  min-height: 38px;
+  max-height: 120px;
+  resize: none;
+  padding: 9px 11px;
+  font-size: 13px;
+  font-family: inherit;
+  line-height: 1.4;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  background: var(--input-bg, var(--bg));
+  color: var(--fg);
+  outline: none;
+}
+.odysseus-root .od-group-input:focus { border-color: var(--accent, var(--red)); }
+.odysseus-root .od-group-input:disabled { opacity: 0.5; cursor: not-allowed; }
+.odysseus-root .od-group-send {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  flex-shrink: 0;
+  border-radius: 8px;
+  border: none;
+  background: var(--accent, var(--red));
+  color: #fff;
+  cursor: pointer;
+  transition: filter 0.12s, opacity 0.12s;
+}
+.odysseus-root .od-group-send:hover:not(:disabled) { filter: brightness(1.1); }
+.odysseus-root .od-group-send:disabled { opacity: 0.4; cursor: not-allowed; }
+.odysseus-root .od-group-note {
+  padding: 0 14px 10px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: color-mix(in srgb, var(--fg) 42%, transparent);
+  flex-shrink: 0;
+}
+.odysseus-root .od-group-note strong { color: color-mix(in srgb, var(--fg) 70%, transparent); }
+/* ===== AdminView ===== */
+/* ════════════════════════════════════════════════════════════════════
+   AdminView — odysseus admin panel (admin.js + index.html admin sub-tabs).
+   All rules scoped under .odysseus-root; colors via theme vars only.
+   Mirrors odysseus's .admin-card / .admin-switch / .admin-user-row /
+   .admin-badge / .admin-btn-* / .admin-toggle-* / .admin-priv-* rules.
+   ════════════════════════════════════════════════════════════════════ */
+
+/* Full-bleed panel (sized like CompareView's .od-compare-panel) */
+.odysseus-root .od-admin-panel {
+  display: flex;
+  flex-direction: column;
+  width: min(900px, 94vw);
+  height: min(86vh, 760px);
+  max-height: 86vh;
+  padding: 0;
+  overflow: hidden;
+}
+
+/* ── Header (settings-modal header) ── */
+.odysseus-root .od-admin-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.odysseus-root .od-admin-header-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--fg);
+}
+.odysseus-root .od-admin-header-spacer { flex: 1; }
+.odysseus-root .od-admin-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--fg);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.odysseus-root .od-admin-close:hover { background: var(--border); border-color: var(--red); }
+
+/* ── Honest empty-state notice ── */
+.odysseus-root .od-admin-notice {
+  margin: 10px 14px 0;
+  padding: 9px 12px;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--fg) 4%, var(--panel));
+  color: color-mix(in srgb, var(--fg) 70%, transparent);
+  font-size: 11.5px;
+  line-height: 1.5;
+  flex-shrink: 0;
+}
+
+/* ── Body: left rail + panels ── */
+.odysseus-root .od-admin-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  gap: 0;
+}
+.odysseus-root .od-admin-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 178px;
+  flex-shrink: 0;
+  padding: 12px 10px;
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+}
+.odysseus-root .od-admin-rail-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  opacity: 0.35;
+  padding: 4px 8px 6px;
+}
+.odysseus-root .od-admin-rail-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 10px;
+  border: none;
+  border-radius: 7px;
+  background: none;
+  color: color-mix(in srgb, var(--fg) 75%, transparent);
+  font-size: 13px;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.odysseus-root .od-admin-rail-item:hover {
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  color: var(--fg);
+}
+.odysseus-root .od-admin-rail-item.active {
+  background: color-mix(in srgb, var(--accent, var(--red)) 14%, transparent);
+  color: var(--fg);
+}
+.odysseus-root .od-admin-panels {
+  flex: 1;
+  min-width: 0;
+  padding: 14px;
+  overflow-y: auto;
+}
+
+/* ── Cards (admin-card) ── */
+.odysseus-root .od-admin-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 10px;
+}
+.odysseus-root .od-admin-card-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  margin: 0 0 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 40%, transparent);
+  color: var(--fg);
+}
+.odysseus-root .od-admin-card-title svg { opacity: 0.6; flex-shrink: 0; }
+.odysseus-root .od-admin-danger-card {
+  border-color: color-mix(in srgb, var(--red) 27%, transparent);
+}
+.odysseus-root .od-admin-danger-title { color: var(--red); }
+.odysseus-root .od-admin-danger-title svg { opacity: 1; }
+
+/* ── Toggle rows (admin-toggle-*) ── */
+.odysseus-root .od-admin-toggle-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.odysseus-root .od-admin-toggle-label { font-size: 13px; font-weight: 500; color: var(--fg); }
+.odysseus-root .od-admin-toggle-sub {
+  color: color-mix(in srgb, var(--fg) 50%, transparent);
+  font-size: 11px;
+  margin-top: 2px;
+  line-height: 1.45;
+}
+
+/* ── Switch (admin-switch / admin-slider) ── */
+.odysseus-root .od-admin-switch {
+  position: relative;
+  width: 30px;
+  height: 16px;
+  flex-shrink: 0;
+  display: inline-block;
+}
+.odysseus-root .od-admin-switch-sm { transform: scale(0.85); }
+.odysseus-root .od-admin-switch input { opacity: 0; width: 0; height: 0; }
+.odysseus-root .od-admin-slider {
+  position: absolute;
+  inset: 0;
+  background: color-mix(in srgb, var(--fg) 50%, transparent);
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.08s;
+}
+.odysseus-root .od-admin-slider::before {
+  content: '';
+  position: absolute;
+  left: 2px;
+  top: 2px;
+  width: 12px;
+  height: 12px;
+  background: var(--panel);
+  border-radius: 50%;
+  transition: transform 0.08s;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+.odysseus-root .od-admin-switch input:checked + .od-admin-slider { background: var(--red); }
+.odysseus-root .od-admin-switch input:checked + .od-admin-slider::before { transform: translateX(14px); }
+.odysseus-root .od-admin-switch input:disabled + .od-admin-slider { cursor: not-allowed; opacity: 0.6; }
+.odysseus-root .od-admin-switch-inline {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: color-mix(in srgb, var(--fg) 60%, transparent);
+}
+
+/* ── User rows (admin-user-row) ── */
+.odysseus-root .od-admin-empty {
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+  font-size: 12px;
+  padding: 10px 4px;
+  text-align: center;
+}
+.odysseus-root .od-admin-user-row {
+  display: flex;
+  flex-direction: column;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  margin-bottom: 6px;
+  transition: border-color 0.15s;
+}
+.odysseus-root .od-admin-user-row:hover {
+  border-color: color-mix(in srgb, var(--fg) 20%, var(--border));
+}
+.odysseus-root .od-admin-user-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  padding: 4px 0;
+}
+.odysseus-root .od-admin-user-info { display: flex; align-items: center; gap: 8px; }
+.odysseus-root .od-admin-user-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--accent, var(--red)) 20%, var(--panel));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 600;
+  flex-shrink: 0;
+  color: var(--accent, var(--red));
+}
+.odysseus-root .od-admin-user-name { font-size: 13px; font-weight: 500; color: var(--fg); }
+.odysseus-root .od-admin-user-hint { font-size: 10px; opacity: 0.4; display: block; }
+.odysseus-root .od-admin-user-actions { display: flex; gap: 8px; align-items: center; }
+.odysseus-root .od-admin-badge {
+  font-size: 10px;
+  padding: 2px 6px;
+  margin-left: 6px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--red) 20%, transparent);
+  color: var(--red);
+  font-weight: 600;
+}
+
+/* ── Privilege panel (admin-priv-*) ── */
+.odysseus-root .od-admin-priv-panel {
+  max-height: 1200px;
+  transition: max-height 0.3s ease, opacity 0.2s ease, padding 0.2s ease;
+  overflow: hidden;
+  padding: 8px 0 4px;
+  border-top: 1px solid var(--border);
+  margin-top: 8px;
+}
+.odysseus-root .od-admin-priv-panel.hidden {
+  max-height: 0;
+  opacity: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  margin-top: 0;
+  border-top: none;
+}
+.odysseus-root .od-admin-priv-section {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.35;
+  font-weight: 600;
+  margin: 10px 0 4px;
+}
+.odysseus-root .od-admin-priv-section:first-child { margin-top: 0; }
+.odysseus-root .od-admin-priv-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 0;
+}
+.odysseus-root .od-admin-priv-label { font-size: 12px; color: var(--fg); }
+.odysseus-root .od-admin-priv-hint {
+  font-size: 10px;
+  opacity: 0.4;
+  margin-bottom: 4px;
+}
+.odysseus-root .od-admin-priv-num {
+  width: 70px;
+  padding: 4px 6px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--fg);
+  font-size: 12px;
+  text-align: center;
+}
+.odysseus-root .od-admin-priv-models-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 4px;
+}
+.odysseus-root .od-admin-priv-models-actions { display: flex; gap: 8px; font-size: 10px; opacity: 0.5; }
+.odysseus-root .od-admin-priv-models-list {
+  max-height: 150px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 6px;
+  background: var(--bg);
+}
+.odysseus-root .od-admin-priv-models-empty { opacity: 0.4; font-size: 11px; }
+.odysseus-root .od-admin-priv-model-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 2px;
+  font-size: 12px;
+  color: var(--fg);
+}
+.odysseus-root .od-admin-priv-model-row input { accent-color: var(--accent, var(--red)); }
+
+/* ── Buttons (admin-btn-*) ── */
+.odysseus-root .od-admin-btn-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border: none;
+  border-radius: 6px;
+  background: var(--red);
+  color: #fff;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 11px;
+  font-family: inherit;
+  transition: all 0.15s;
+}
+.odysseus-root .od-admin-btn-add:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--red) 80%, white);
+}
+.odysseus-root .od-admin-btn-add:disabled { opacity: 0.5; cursor: not-allowed; }
+.odysseus-root .od-admin-btn-delete {
+  background: none;
+  border: 1px solid color-mix(in srgb, var(--red) 27%, transparent);
+  color: var(--red);
+  padding: 4px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+  white-space: nowrap;
+  transition: all 0.15s;
+}
+.odysseus-root .od-admin-btn-delete:hover:not(:disabled) {
+  background: var(--red);
+  border-color: var(--red);
+  color: #fff;
+}
+.odysseus-root .od-admin-btn-delete:disabled { opacity: 0.5; cursor: not-allowed; }
+.odysseus-root .od-admin-btn-sm {
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--fg);
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+}
+.odysseus-root .od-admin-btn-sm:hover:not(:disabled) { background: var(--border); border-color: var(--red); }
+.odysseus-root .od-admin-btn-sm:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* ── Add-user form (admin-add-form) ── */
+.odysseus-root .od-admin-add-form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+.odysseus-root .od-admin-add-form input[type="text"],
+.odysseus-root .od-admin-add-form input[type="password"] {
+  flex: 1;
+  min-width: 120px;
+  padding: 5px 8px;
+  height: 32px;
+  box-sizing: border-box;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 12px;
+}
+.odysseus-root .od-admin-add-form input:focus { outline: none; border-color: var(--red); }
+.odysseus-root .od-admin-add-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+}
+.odysseus-root .od-admin-add-msg {
+  font-size: 11px;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+
+/* ── Feature list (Agent Tools) ── */
+.odysseus-root .od-admin-feature-list { margin-top: 6px; }
+.odysseus-root .od-admin-feature-row {
+  padding: 0.4rem 0;
+  border-bottom: 1px solid var(--border);
+}
+.odysseus-root .od-admin-feature-row:last-child { border-bottom: none; }
+
+/* ── System tab (Backup + Danger Zone) ── */
+.odysseus-root .od-admin-backup-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+}
+.odysseus-root .od-admin-wipe-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 8px;
+  gap: 12px;
+}
+.odysseus-root .od-admin-wipe-row:first-of-type { margin-top: 4px; }
+
+
+/* ===== sync: ModelsView ===== */
+/* ── ModelsView upstream reconcile: provider-grouped browse + search/recent/
+   favorites + favorite-dot feedback (modelPicker.js mp-* rules). Scoped under
+   .odysseus-root; theme vars only. Base od- classes (od-models-group-content,
+   od-models-show-all-btn, od-model-fav-btn, od-folder-*) already live in
+   odysseus-theme.ts — these are NEW rules for the new markup only. ── */
+
+/* Transient "Favorited" / "Unfavorited" toast in the panel head
+   (modelPicker.js uiModule.showToast). */
+.odysseus-root .od-models-feedback {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--accent, var(--red));
+  margin-left: auto;
+  margin-right: 8px;
+  white-space: nowrap;
+  animation: od-models-feedback-in 0.16s ease-out;
+}
+@keyframes od-models-feedback-in {
+  from { opacity: 0; transform: translateY(-2px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* Section labels for the pinned Recent / Favorites / All models lists
+   (modelPicker.js .mp-section-label). */
+.odysseus-root .od-models-section-label {
+  font-size: 0.72em;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  opacity: 0.4;
+  padding: 6px 8px 2px;
+  color: var(--fg);
+}
+
+/* Collapsible PROVIDER group headers in large catalogues
+   (modelPicker.js .mp-provider-header). */
+.odysseus-root .od-models-provider-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 5px 8px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-size: 0.78em;
+  font-weight: 500;
+  color: var(--fg);
+  border-radius: 4px;
+  user-select: none;
+  transition: background 0.08s;
+}
+.odysseus-root .od-models-provider-header:hover {
+  background: color-mix(in srgb, var(--fg) 6%, transparent);
+}
+.odysseus-root .od-models-provider-chevron {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  opacity: 0.4;
+  transition: transform 0.2s, opacity 0.15s;
+}
+.odysseus-root .od-models-provider-header:hover .od-models-provider-chevron {
+  opacity: 0.7;
+}
+.odysseus-root .od-models-provider-chevron.collapsed {
+  transform: rotate(-90deg);
+}
+.odysseus-root .od-models-provider-group-name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.odysseus-root .od-models-provider-group-count {
+  font-size: 0.85em;
+  opacity: 0.4;
+  flex-shrink: 0;
+}
+
+/* Transient pulse on the favorite dot when toggled
+   (modelPicker.js .mp-fav-dot.pulse / @keyframes mpFavPulse). */
+.odysseus-root .od-model-fav-btn.od-fav-pulse {
+  animation: od-fav-pulse 0.34s ease-out;
+}
+@keyframes od-fav-pulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent, var(--red)) 0%, transparent);
+  }
+  45% {
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent, var(--red)) 45%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent, var(--red)) 0%, transparent);
+  }
+}
+
+/* Domino expand when a provider group opens
+   (modelPicker.js .mp-provider-group.mp-just-expanded / @keyframes mp-domino-in). */
+.odysseus-root .od-models-group-content.od-just-expanded .od-models-row {
+  animation: od-models-domino-in 0.31s cubic-bezier(0.22, 1.61, 0.36, 1) backwards;
+}
+.odysseus-root .od-models-group-content.od-just-expanded .od-models-row:nth-child(1) { animation-delay: 0.035s; }
+.odysseus-root .od-models-group-content.od-just-expanded .od-models-row:nth-child(2) { animation-delay: 0.07s; }
+.odysseus-root .od-models-group-content.od-just-expanded .od-models-row:nth-child(3) { animation-delay: 0.105s; }
+.odysseus-root .od-models-group-content.od-just-expanded .od-models-row:nth-child(4) { animation-delay: 0.14s; }
+.odysseus-root .od-models-group-content.od-just-expanded .od-models-row:nth-child(5) { animation-delay: 0.175s; }
+@keyframes od-models-domino-in {
+  0% { opacity: 0; transform: translateY(6px) scale(0.94); }
+  60% { opacity: 1; }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+/* ===== sync: CookbookView ===== */
+/* ── Cookbook v2: tab row (cookbook.js .cookbook-tab set) ── */
+.odysseus-root .od-cb-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 8px;
+}
+.odysseus-root .od-cb-tab {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  padding: 6px 14px;
+  font-size: 12px;
+  font-family: inherit;
+  color: var(--muted);
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  transition: color 0.1s, border-color 0.1s;
+  white-space: nowrap;
+}
+.odysseus-root .od-cb-tab:hover { color: var(--fg); }
+.odysseus-root .od-cb-tab-active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+/* ── Serve / What-Fits shared control row (engine filter, GPU chip, saved-config) ── */
+.odysseus-root .od-cb-serve,
+.odysseus-root .od-cb-fit {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow-y: auto;
+}
+.odysseus-root .od-cb-serve-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 2px 0;
+}
+.odysseus-root .od-cb-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: var(--muted);
+}
+.odysseus-root .od-cb-field-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  color: var(--muted);
+}
+.odysseus-root .od-cb-select {
+  height: 24px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  color: var(--fg);
+  border-radius: 4px;
+  font: inherit;
+  font-size: 11px;
+  padding: 0 6px;
+  box-sizing: border-box;
+  cursor: pointer;
+}
+.odysseus-root .od-cb-select:hover { border-color: var(--fg); }
+
+/* GPU chip (cookbook-hwfit.js _hwfitRenderHw .hwfit-hw-chip) — honest "off"
+   state with no detected GPU; the full reason lives in the title tooltip. */
+.odysseus-root .od-cb-gpu-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  height: 17px;
+  padding: 0 8px;
+  border-radius: 6px;
+  font-size: 10px;
+  white-space: nowrap;
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  color: var(--fg);
+  opacity: 0.7;
+  cursor: help;
+}
+.odysseus-root .od-cb-gpu-chip-off {
+  background: transparent;
+  opacity: 0.4;
+}
+
+/* Saved-config split badge (cookbookServe.js .cookbook-saved-split): a filled
+   accent "Save" joined to an outlined count-arrow trigger. Disabled here since
+   eliza has no serve backend to save a launch config against. */
+.odysseus-root .od-cb-saved-split {
+  display: inline-flex;
+  gap: 0;
+}
+.odysseus-root .od-cb-saved-save,
+.odysseus-root .od-cb-saved-arrow {
+  height: 24px;
+  font: inherit;
+  font-size: 11px;
+  border: 1px solid var(--accent);
+  cursor: pointer;
+  box-sizing: border-box;
+}
+.odysseus-root .od-cb-saved-save {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 10px;
+  background: var(--red);
+  color: #fff;
+  border-color: var(--red);
+  font-weight: 600;
+  border-radius: 6px 0 0 6px;
+}
+.odysseus-root .od-cb-saved-arrow {
+  padding: 0 6px;
+  background: var(--panel);
+  color: var(--fg);
+  border-left: none;
+  border-radius: 0 6px 6px 0;
+}
+.odysseus-root .od-cb-saved-save:disabled,
+.odysseus-root .od-cb-saved-arrow:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.odysseus-root .od-cb-serve-empty { margin: 4px 0; }
+
+/* ── Serve diagnostics / recommendations panel (cookbook-diagnosis.js
+   .cookbook-diagnosis _showDiagnosis): idle/empty state — no serve error to
+   diagnose because eliza can't launch a serve task. ── */
+.odysseus-root .od-cb-diagnosis {
+  margin-top: 2px;
+  padding: 10px 12px;
+  background: color-mix(in srgb, var(--red) 8%, transparent);
+  border: 1px solid color-mix(in srgb, var(--red) 30%, transparent);
+  border-radius: 6px;
+}
+.odysseus-root .od-cb-diag-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 6px;
+}
+.odysseus-root .od-cb-diag-title {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--red);
+}
+.odysseus-root .od-cb-diag-message {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--red);
+  margin-bottom: 4px;
+}
+.odysseus-root .od-cb-diag-suggestion {
+  font-size: 11px;
+  line-height: 1.35;
+  color: var(--muted);
+}
+
+/* ── What-Fits fit table (cookbook-hwfit.js .hwfit-row / .hwfit-header /
+   _hwfitColumns). Sortable header incl. the Fit column; body is the honest
+   no-hardware empty state. ── */
+.odysseus-root .od-cb-fit-table {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.odysseus-root .od-cb-fit-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  font-size: 11px;
+}
+.odysseus-root .od-cb-fit-header {
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+}
+.odysseus-root .od-cb-fit-col {
+  appearance: none;
+  -webkit-appearance: none;
+  flex-shrink: 0;
+  text-align: left;
+  white-space: nowrap;
+  background: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  color: var(--muted);
+}
+.odysseus-root .od-cb-fit-sortable { cursor: pointer; user-select: none; }
+.odysseus-root .od-cb-fit-sortable:hover { color: var(--fg); }
+.odysseus-root .od-cb-fit-sort-active { color: var(--red); }
+.odysseus-root .od-cb-fit-col:disabled { cursor: default; }
+.odysseus-root .od-cb-fit-fit { width: 52px; font-weight: 700; }
+.odysseus-root .od-cb-fit-name { flex: 1; min-width: 0; }
+.odysseus-root .od-cb-fit-params { width: 42px; }
+.odysseus-root .od-cb-fit-quant { width: 52px; }
+.odysseus-root .od-cb-fit-vram { width: 42px; }
+.odysseus-root .od-cb-fit-ctx { width: 32px; }
+.odysseus-root .od-cb-fit-speed { width: 44px; }
+.odysseus-root .od-cb-fit-score { width: 40px; font-weight: 700; }
+.odysseus-root .od-cb-fit-mode { width: 48px; }
+/* ===== sync: Composer ===== */
+/* Slash command autocomplete popup, ported 1:1 from odysseus
+   static/style.css (.slash-autocomplete-popup + .slash-ac-* rules added by
+   "Add slash command autocomplete popup"). Renamed to the od-slash-ac-*
+   namespace so it composes alongside — not collides with — the existing
+   .od-slash-menu rules in odysseus-theme.ts. Anchored above the composer (the
+   composer already position:relative), and colour-mapped onto the eliza theme
+   vars: upstream --panel/--bg→--panel/--bg, --fg→--fg, --fg-muted→--muted,
+   --accent fallback --red kept verbatim. */
+.odysseus-root .od-slash-ac { position:absolute; bottom:calc(100% + 6px); left:0; z-index:9000;
+  width:100%; max-width:520px; min-width:280px; max-height:min(50vh, 360px); overflow-y:auto;
+  background:var(--panel, var(--bg)); border:1px solid var(--border); border-radius:8px;
+  box-shadow:0 8px 24px rgba(0,0,0,.35); font-size:13px; color:var(--fg); padding:4px 0; }
+.odysseus-root .od-slash-ac-cat { font-size:10px; letter-spacing:.08em; text-transform:uppercase;
+  color:var(--muted); padding:6px 10px 2px; opacity:.7; }
+.odysseus-root .od-slash-ac-row { display:flex; align-items:baseline; gap:8px; width:100%;
+  padding:5px 10px; border:none; background:none; text-align:left; cursor:pointer; line-height:1.3;
+  white-space:nowrap; overflow:hidden; font-size:13px; color:var(--fg); font-family:inherit; }
+.odysseus-root .od-slash-ac-row:hover { background-color:color-mix(in srgb, var(--accent, var(--red)) 10%, transparent); }
+.odysseus-root .od-slash-ac-row.active { background-color:color-mix(in srgb, var(--accent, var(--red)) 14%, transparent); }
+.odysseus-root .od-slash-ac-token { font-family:'Fira Code', ui-monospace, monospace;
+  color:var(--accent, var(--red)); font-weight:600; flex-shrink:0; }
+.odysseus-root .od-slash-ac-help { color:var(--fg); opacity:.85; flex:1; min-width:0;
+  overflow:hidden; text-overflow:ellipsis; }
+.odysseus-root .od-slash-ac-usage { color:var(--muted); font-family:'Fira Code', ui-monospace, monospace;
+  font-size:11px; opacity:.55; flex-shrink:0; }
+
+
+/* ===== wave4: ThemeMenu ===== */
+/* Append to ODYSSEUS_CSS in odysseus-theme.ts, in the "theme menu" section.
+   Ported from static/style.css .cp-* (34408+), .theme-io-* / .theme-import-*
+   (6167+), .theme-harmony-* (6224+); scoped under .odysseus-root, theme-var
+   driven, matching the existing .od-theme-* rules. */
+
+/* taller scrollable menu now that it carries pickers + harmony + import/export */
+.odysseus-root .od-theme-menu { max-height:min(80vh, 640px); overflow-y:auto; }
+.odysseus-root .od-theme-row-wrap { flex-wrap:wrap; }
+
+/* custom colour rows (swatch trigger + key + hex), each anchoring a popover */
+.odysseus-root .od-theme-custom-rows { display:flex; flex-direction:column; gap:6px; }
+.odysseus-root .od-theme-color-row { position:relative; display:flex; align-items:center; gap:8px; }
+.odysseus-root .od-cp-swatch-trigger { width:24px; height:24px; flex-shrink:0; border-radius:6px;
+  border:1px solid var(--border); padding:0; cursor:pointer; }
+.odysseus-root .od-cp-swatch-trigger:hover { border-color:var(--red); }
+.odysseus-root .od-theme-color-key { font-size:11px; text-transform:capitalize;
+  color:color-mix(in srgb, var(--fg) 70%, transparent); }
+.odysseus-root .od-theme-color-hex { margin-left:auto; font-size:10px;
+  font-family:ui-monospace,'Fira Code',monospace; text-transform:lowercase;
+  color:color-mix(in srgb, var(--fg) 45%, transparent); }
+
+/* in-house HSV picker popover (.cp-popover et al.) */
+.odysseus-root .od-cp-popover { position:absolute; left:0; top:30px; z-index:70; width:228px;
+  margin:0; padding:10px; border:1px solid var(--border); border-radius:8px;
+  background:var(--panel); color:var(--fg); font-size:12px;
+  box-shadow:0 8px 24px rgba(0,0,0,.45); user-select:none; }
+.odysseus-root .od-cp-sl { position:relative; display:block; width:100%; height:150px; padding:0;
+  border:none; border-radius:6px; cursor:crosshair; overflow:hidden; touch-action:none; }
+.odysseus-root .od-cp-sl-white { position:absolute; inset:0; pointer-events:none;
+  background:linear-gradient(to right, #fff, rgba(255,255,255,0)); }
+.odysseus-root .od-cp-sl-black { position:absolute; inset:0; pointer-events:none;
+  background:linear-gradient(to top, #000, rgba(0,0,0,0)); }
+.odysseus-root .od-cp-sl-handle { position:absolute; width:12px; height:12px; margin:-6px 0 0 -6px;
+  border:2px solid #fff; border-radius:50%; pointer-events:none;
+  box-shadow:0 0 0 1px rgba(0,0,0,.6), 0 1px 3px rgba(0,0,0,.5); }
+.odysseus-root .od-cp-hue { position:relative; display:block; width:100%; height:14px; margin-top:10px;
+  padding:0; border:none; border-radius:7px; cursor:pointer; touch-action:none;
+  background:linear-gradient(to right,#f00,#ff0,#0f0,#0ff,#00f,#f0f,#f00); }
+.odysseus-root .od-cp-hue-handle { position:absolute; top:50%; width:10px; height:18px; margin:-9px 0 0 -5px;
+  border:2px solid #fff; border-radius:3px; pointer-events:none;
+  box-shadow:0 0 0 1px rgba(0,0,0,.6), 0 1px 3px rgba(0,0,0,.5); }
+.odysseus-root .od-cp-row { display:flex; align-items:center; gap:6px; margin-top:10px; }
+.odysseus-root .od-cp-preview { width:24px; height:24px; flex-shrink:0; border-radius:50%;
+  border:1px solid var(--border); }
+.odysseus-root .od-cp-hex { flex:1; min-width:0; padding:4px 6px; border:1px solid var(--border);
+  border-radius:4px; background:var(--bg); color:var(--fg); font-size:12px;
+  font-family:ui-monospace,'Fira Code',monospace; text-transform:lowercase; outline:none; }
+.odysseus-root .od-cp-hex:focus { border-color:var(--red); }
+.odysseus-root .od-cp-eyedropper { width:26px; height:26px; flex-shrink:0; padding:0;
+  display:flex; align-items:center; justify-content:center; border:1px solid var(--border);
+  border-radius:4px; background:transparent; color:var(--fg); cursor:pointer; transition:background .1s; }
+.odysseus-root .od-cp-eyedropper:hover:not(:disabled) { background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-cp-eyedropper:disabled { opacity:.3; cursor:default; }
+.odysseus-root .od-cp-section-label { margin:10px 0 4px; font-size:10px; text-transform:uppercase;
+  letter-spacing:.06em; opacity:.5; }
+.odysseus-root .od-cp-swatches { display:flex; flex-wrap:wrap; gap:4px; }
+.odysseus-root .od-cp-swatch { width:20px; height:20px; padding:0; border-radius:50%;
+  border:1px solid var(--border); cursor:pointer; transition:transform .08s; }
+.odysseus-root .od-cp-swatch:hover { transform:scale(1.15); }
+.odysseus-root .od-cp-recent-empty { padding:2px 0; font-size:11px; opacity:.4; }
+
+/* harmony generator (.theme-harmony-row / .harmony-generate-btn / .harmony-preview) */
+.odysseus-root .od-theme-harmony { position:relative; display:flex; flex-direction:column; gap:8px; }
+.odysseus-root .od-theme-harmony-row { display:flex; align-items:center; gap:6px; }
+.odysseus-root .od-theme-select { flex:1; min-width:0; padding:5px 8px; border:1px solid var(--border);
+  border-radius:6px; background:var(--bg); color:var(--fg); font-size:11px;
+  font-family:inherit; text-transform:capitalize; cursor:pointer; outline:none; }
+.odysseus-root .od-theme-select:focus { border-color:var(--red); }
+.odysseus-root .od-theme-harmony-preview { display:flex; height:20px; overflow:hidden;
+  border:1px solid var(--border); border-radius:6px; }
+.odysseus-root .od-theme-harmony-preview span { flex:1; }
+.odysseus-root .od-theme-harmony-gen { display:flex; align-items:center; justify-content:center; gap:6px;
+  width:100%; padding:5px 14px; border:1px solid var(--red); border-radius:6px;
+  background:transparent; color:var(--red); font-size:12px; font-family:inherit;
+  cursor:pointer; transition:background .15s; }
+.odysseus-root .od-theme-harmony-gen:hover { background:color-mix(in srgb, var(--red) 11%, transparent); }
+
+/* import / export (.theme-io-* / .theme-import-*) */
+.odysseus-root .od-theme-io { display:flex; gap:6px; margin-top:6px; }
+.odysseus-root .od-theme-io-btn { flex:1; display:flex; align-items:center; justify-content:center; gap:6px;
+  padding:5px 10px; border:1px solid var(--border); border-radius:6px; background:transparent;
+  color:var(--fg); font-size:12px; font-family:inherit; opacity:.7; cursor:pointer; transition:all .15s; }
+.odysseus-root .od-theme-io-btn:hover { opacity:1; border-color:var(--fg);
+  background:color-mix(in srgb, var(--fg) 5%, transparent); }
+.odysseus-root .od-theme-import { display:flex; flex-direction:column; gap:4px; margin-top:6px; }
+.odysseus-root .od-theme-import-area { width:100%; min-height:56px; padding:6px 8px; resize:vertical;
+  border:1px solid var(--border); border-radius:6px; background:var(--bg); color:var(--fg);
+  font-size:.7rem; font-family:ui-monospace,'Fira Code',monospace; outline:none; }
+.odysseus-root .od-theme-import-area:focus { border-color:var(--red); }
+.odysseus-root .od-theme-import-error { font-size:11px; color:var(--red); }
+.odysseus-root .od-theme-import-actions { display:flex; gap:6px; }
+/* ===== wave4: SessionSidebar ===== */
+/* ── SessionSidebar deepening: folders + multi-select + folder submenu ──
+   Append to ODYSSEUS_CSS in odysseus-theme.ts. All scoped under .odysseus-root.
+   Ported from odysseus static/style.css (.session-folder*, .session-bulk*,
+   .session-select-cb, .session-folder-submenu) onto the theme var system. */
+
+/* section header action buttons (New folder / Select-mode toggle) */
+.odysseus-root .od-section-header-flex { justify-content:space-between; }
+.odysseus-root .od-section-icon-btn { flex-shrink:0; width:22px; height:22px; display:flex;
+  align-items:center; justify-content:center; border:none; background:none; color:var(--fg);
+  opacity:.4; border-radius:4px; cursor:pointer; transition:opacity .1s, background .1s; }
+.odysseus-root .od-section-icon-btn:hover { opacity:.85; background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-section-icon-btn.active { opacity:1; color:var(--accent, var(--red));
+  background:color-mix(in srgb, var(--red) 12%, transparent); }
+
+/* bulk select bar (odysseus .session-bulk-bar) */
+.odysseus-root .od-session-bulk-bar { display:flex; align-items:center; gap:6px; padding:4px 8px;
+  margin:1px 0 3px; border-radius:4px; font-size:11px;
+  background:color-mix(in srgb, var(--fg) 5%, transparent);
+  border:1px solid color-mix(in srgb, var(--border) 60%, transparent); }
+.odysseus-root .od-session-bulk-cb { background:none; border:none; cursor:pointer; font-size:15px;
+  line-height:1; color:var(--accent, var(--red)); padding:0 2px; flex-shrink:0; }
+.odysseus-root .od-session-bulk-count { flex:1; color:var(--fg); opacity:.7; white-space:nowrap;
+  overflow:hidden; text-overflow:ellipsis; }
+.odysseus-root .od-session-bulk-btn { display:inline-flex; align-items:center; gap:4px; background:none;
+  border:none; border-radius:4px; color:var(--fg); padding:3px 6px; font-family:inherit;
+  font-size:11px; cursor:pointer; opacity:.6; transition:opacity .1s; }
+.odysseus-root .od-session-bulk-btn:hover { opacity:1; }
+.odysseus-root .od-session-bulk-btn:disabled { opacity:.25; cursor:default; }
+.odysseus-root .od-session-bulk-btn.od-danger { color:var(--red); }
+
+/* per-row select checkbox (odysseus .session-select-cb dot) */
+.odysseus-root .od-session-select-cb { flex-shrink:0; width:20px; align-self:stretch; display:flex;
+  align-items:center; justify-content:center; background:none; border:none; cursor:pointer;
+  font-size:15px; line-height:1; color:var(--fg); opacity:.4; user-select:none;
+  transition:opacity .1s, color .1s; padding:0; }
+.odysseus-root .od-session-select-cb.checked { opacity:1; color:var(--accent, var(--red)); }
+.odysseus-root .od-thread-row.od-row-selected .od-thread-main {
+  background:color-mix(in srgb, var(--red) 7%, transparent); }
+
+/* folders (odysseus .session-folder / .session-folder-header) */
+.odysseus-root .od-session-folder { margin:2px 0; }
+.odysseus-root .od-session-folder-header { display:flex; align-items:center; gap:2px;
+  border-radius:4px; transition:background .08s; }
+.odysseus-root .od-session-folder-header:hover { background:color-mix(in srgb, var(--fg) 4%, transparent); }
+.odysseus-root .od-folder-toggle-main { flex:1; min-width:0; display:flex; align-items:center; gap:6px;
+  padding:4px 8px; background:none; border:none; cursor:pointer; user-select:none;
+  font-family:inherit; font-size:.88em; font-weight:600; text-align:left;
+  color:color-mix(in srgb, var(--fg) 55%, transparent); transition:color .08s; }
+.odysseus-root .od-session-folder-header:hover .od-folder-toggle-main { color:var(--fg); }
+.odysseus-root .od-folder-toggle { flex-shrink:0; opacity:.7; }
+.odysseus-root .od-folder-name { flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.odysseus-root .od-folder-count { font-weight:400; opacity:.5; font-size:.85em; flex-shrink:0; }
+.odysseus-root .od-folder-delete-btn { flex-shrink:0; width:22px; height:22px; display:flex;
+  align-items:center; justify-content:center; background:none; border:none; color:var(--fg);
+  opacity:0; cursor:pointer; border-radius:4px; transition:opacity .08s, color .08s; }
+.odysseus-root .od-session-folder-header:hover .od-folder-delete-btn { opacity:.5; }
+.odysseus-root .od-folder-delete-btn:hover { opacity:1; color:var(--red); }
+.odysseus-root .od-session-folder-content { padding-left:4px; }
+.odysseus-root .od-session-folder-content .od-thread-row,
+.odysseus-root .od-session-folder-content .od-thread-rename {
+  border-bottom:1px solid color-mix(in srgb, var(--fg) 7%, transparent); }
+.odysseus-root .od-session-folder-content .od-thread-row:last-child { border-bottom:none; }
+.odysseus-root .od-folder-rename { font-weight:600; }
+.odysseus-root .od-folder-empty { padding:4px 12px; font-size:11px; opacity:.4; color:var(--fg); user-select:none; }
+.odysseus-root .od-chats-empty { padding:8px; text-align:center; }
+
+/* "Move to folder" submenu inside the ⋯ thread menu (odysseus .session-folder-submenu) */
+.odysseus-root .od-folder-submenu-wrap { position:relative; }
+.odysseus-root .od-folder-submenu-wrap > button { display:flex; align-items:center; gap:7px;
+  width:100%; text-align:left; padding:6px 10px; border:none; background:none; color:var(--fg);
+  font-size:12px; border-radius:4px; cursor:pointer; }
+.odysseus-root .od-folder-submenu-wrap > button:hover { background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-thread-submenu { margin:2px 0 2px 8px; padding:3px;
+  border-left:1px solid color-mix(in srgb, var(--border) 60%, transparent);
+  max-height:180px; overflow-y:auto; }
+.odysseus-root .od-thread-submenu button { display:flex; align-items:center; gap:6px; width:100%;
+  text-align:left; padding:5px 8px; border:none; background:none; color:var(--fg); font-size:12px;
+  border-radius:4px; cursor:pointer; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.odysseus-root .od-thread-submenu button:hover { background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-thread-submenu button.od-cur { opacity:.45; }
+.odysseus-root .od-thread-submenu button.od-folder-new { color:var(--accent, var(--red)); }
+/* ===== wave4: SettingsPanel ===== */
+/* ── odysseus Settings panel — tabbed, top-anchored (settings.js + Issue #208).
+   Scoped under .odysseus-root, theme vars only. Modeled on the shipped
+   .od-admin-* rail/panel rules so the two surfaces look identical. The panel is
+   FIXED-HEIGHT and the overlay anchors to flex-start (top) so switching tabs
+   never shifts the rail/window. Append to ODYSSEUS_CSS in odysseus-theme.ts. ── */
+
+/* Overlay: pin the panel to the top of the chat area (Issue #208) instead of
+   the shared .od-search-overlay's 12vh centered offset. */
+.odysseus-root .od-settings-overlay { align-items: flex-start; padding-top: 7vh; }
+
+/* Panel: fixed size — never grows/shrinks per tab. */
+.odysseus-root .od-settings-panel {
+  display: flex;
+  flex-direction: column;
+  width: min(820px, 94vw);
+  height: min(82vh, 700px);
+  max-height: 82vh;
+  padding: 0;
+  overflow: hidden;
+}
+
+/* Header */
+.odysseus-root .od-settings-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.odysseus-root .od-settings-header-title {
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--fg);
+}
+.odysseus-root .od-settings-header-spacer { flex: 1; }
+.odysseus-root .od-settings-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--fg);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.odysseus-root .od-settings-close:hover { background: var(--border); border-color: var(--red); }
+
+/* Body: left tab rail + panels */
+.odysseus-root .od-settings-body { display: flex; flex: 1; min-height: 0; }
+.odysseus-root .od-settings-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 168px;
+  flex-shrink: 0;
+  padding: 12px 10px;
+  border-right: 1px solid var(--border);
+  overflow-y: auto;
+}
+.odysseus-root .od-settings-rail-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 600;
+  opacity: 0.35;
+  padding: 4px 8px 6px;
+}
+.odysseus-root .od-settings-rail-item {
+  padding: 7px 10px;
+  border: none;
+  border-radius: 7px;
+  background: none;
+  color: color-mix(in srgb, var(--fg) 75%, transparent);
+  font-size: 13px;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.odysseus-root .od-settings-rail-item:hover {
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  color: var(--fg);
+}
+.odysseus-root .od-settings-rail-item.active {
+  background: color-mix(in srgb, var(--accent, var(--red)) 14%, transparent);
+  color: var(--fg);
+}
+
+/* Panels: the only scrolling region — rail + window stay fixed. */
+.odysseus-root .od-settings-panels { flex: 1; min-width: 0; padding: 14px; overflow-y: auto; }
+.odysseus-root .od-settings-section { display: flex; flex-direction: column; gap: 10px; }
+
+/* Cards (admin-card) */
+.odysseus-root .od-settings-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+}
+.odysseus-root .od-settings-card-title {
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  margin: 0 0 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 40%, transparent);
+  color: var(--fg);
+}
+
+/* Key/value rows (General + Appearance) */
+.odysseus-root .od-settings-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 0;
+}
+.odysseus-root .od-settings-label { font-size: 12px; color: color-mix(in srgb, var(--fg) 60%, transparent); }
+.odysseus-root .od-settings-value { font-size: 13px; color: var(--fg); }
+
+/* Form fields (Web Search + Persona) */
+.odysseus-root .od-settings-field { display: flex; flex-direction: column; gap: 5px; margin-bottom: 12px; }
+.odysseus-root .od-settings-field:last-child { margin-bottom: 0; }
+.odysseus-root .od-settings-flabel {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+}
+.odysseus-root .od-settings-select,
+.odysseus-root .od-settings-input,
+.odysseus-root .od-settings-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--fg) 4%, var(--panel));
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: var(--fg);
+  font-size: 13px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color 0.12s;
+}
+.odysseus-root .od-settings-textarea { resize: vertical; line-height: 1.5; }
+.odysseus-root .od-settings-select:focus,
+.odysseus-root .od-settings-input:focus,
+.odysseus-root .od-settings-textarea:focus {
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 55%, var(--border));
+}
+.odysseus-root .od-settings-input::placeholder,
+.odysseus-root .od-settings-textarea::placeholder {
+  color: color-mix(in srgb, var(--fg) 32%, transparent);
+}
+
+/* Hints / status / notes */
+.odysseus-root .od-settings-hint { font-size: 11px; line-height: 1.5; color: color-mix(in srgb, var(--fg) 50%, transparent); }
+.odysseus-root .od-settings-status { margin-top: 4px; font-size: 12px; color: var(--ok, var(--fg)); }
+.odysseus-root .od-settings-status.warn { color: var(--red); }
+.odysseus-root .od-settings-note {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--fg) 4%, var(--panel));
+  font-size: 11px;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--fg) 62%, transparent);
+}
+
+/* Empty states (reuse the muted look of .od-search-empty) */
+.odysseus-root .od-settings-empty { padding: 10px 2px; font-size: 12px; color: color-mix(in srgb, var(--fg) 45%, transparent); }
+
+/* Persona save action */
+.odysseus-root .od-settings-actions { display: flex; align-items: center; gap: 10px; margin-top: 4px; }
+.odysseus-root .od-settings-save {
+  padding: 7px 14px;
+  border: 1px solid color-mix(in srgb, var(--accent, var(--red)) 45%, var(--border));
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--accent, var(--red)) 14%, transparent);
+  color: var(--fg);
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s;
+}
+.odysseus-root .od-settings-save:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent, var(--red)) 22%, transparent);
+}
+.odysseus-root .od-settings-save:disabled { opacity: 0.55; cursor: default; }
+
+/* The existing .od-skill-item / .od-skill-toggle rules (already in ODYSSEUS_CSS)
+   are reused as-is for the MCP-server + plugin rows — no new CSS needed there. */
+/* ===== wave4: ChatMessages ===== */
+/* ── odysseus SOURCES box (style.css .sources-section + .source-link, 1:1) ──
+   Add to ODYSSEUS_CSS in odysseus-theme.ts. All rescoped under
+   .odysseus-root .od-* and use the existing CSS-var system (--red/--fg). */
+
+.odysseus-root .od-msg-group { display:flex; flex-direction:column; }
+/* Pull the sources footer flush under the agent bubble (bubble owns its own
+   bottom margin via .od-msg-ai), constrained to bubble width like odysseus. */
+.odysseus-root .od-msg-sources { margin:-4px 0 12px; max-width:760px; }
+
+.odysseus-root .od-sources-section {
+  margin:8px 0 12px;
+  border:1px solid color-mix(in srgb, var(--red) 30%, transparent);
+  border-radius:8px; overflow:hidden; transition:all .3s ease; }
+.odysseus-root .od-sources-header {
+  display:flex; align-items:center; justify-content:space-between;
+  width:100%; padding:8px 12px; cursor:pointer; border:none; text-align:left;
+  background:color-mix(in srgb, var(--red) 8%, transparent);
+  border-bottom:1px solid color-mix(in srgb, var(--red) 20%, transparent);
+  transition:background .2s ease; user-select:none; font-family:inherit; }
+.odysseus-root .od-sources-header:hover {
+  background:color-mix(in srgb, var(--red) 12%, transparent); }
+.odysseus-root .od-sources-header-left {
+  display:flex; align-items:center; gap:8px;
+  font-size:.85em; font-weight:500; color:var(--red); }
+.odysseus-root .od-sources-header-left svg {
+  width:14px; height:14px; flex-shrink:0; opacity:.7; }
+.odysseus-root .od-sources-toggle {
+  font-size:.8em; color:var(--red); opacity:.7; }
+.odysseus-root .od-sources-toggle::after { content:'\\25B6'; }
+.odysseus-root .od-sources-toggle[data-arrow="down"]::after { content:'\\25BC'; }
+/* Content is conditionally mounted in React, so it's shown as soon as present
+   (the upstream max-height transition was driven by the toggle class). */
+.odysseus-root .od-sources-content { padding:8px 10px; }
+.odysseus-root .od-sources-content-inner {
+  display:flex; flex-direction:column; gap:4px; }
+.odysseus-root .od-source-link {
+  display:flex; align-items:center; gap:8px; padding:5px 8px; border-radius:6px;
+  background:color-mix(in srgb, var(--fg) 4%, transparent);
+  text-decoration:none; color:var(--fg); transition:background .15s ease; }
+.odysseus-root .od-source-link:hover {
+  background:color-mix(in srgb, var(--fg) 10%, transparent); }
+.odysseus-root .od-source-num {
+  display:inline-flex; align-items:center; justify-content:center;
+  min-width:20px; height:20px; border-radius:50%;
+  background:color-mix(in srgb, var(--fg) 15%, transparent);
+  color:var(--fg); font-size:.7em; font-weight:600; flex-shrink:0; }
+.odysseus-root .od-source-title {
+  flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap;
+  font-size:.82em; }
+.odysseus-root .od-source-domain {
+  font-size:.72em; opacity:.45; flex-shrink:0; }
+
+/* ── RAG sources box (style.css .rag-sources, 1:1) ── */
+.odysseus-root .od-rag-sources {
+  margin-top:12px; border:1px solid var(--border); border-radius:6px;
+  padding:8px; font-size:12px; }
+.odysseus-root .od-rag-sources summary {
+  cursor:pointer; color:var(--red); font-weight:bold; font-size:11px; }
+.odysseus-root .od-rag-source-item {
+  margin-top:8px; padding:6px; border-radius:4px;
+  background:color-mix(in srgb, var(--fg) 4%, transparent);
+  border-left:2px solid var(--red); }
+.odysseus-root .od-rag-similarity {
+  color:color-mix(in srgb, var(--fg) 50%, transparent);
+  font-size:10px; margin-left:6px; }
+.odysseus-root .od-rag-snippet {
+  color:color-mix(in srgb, var(--fg) 65%, transparent);
+  font-size:11px; margin-top:4px; white-space:pre-wrap;
+  max-height:60px; overflow:hidden; }
+
+
+/* ===== wave5: VoiceView ===== */
+/* ── Voice & speech panel (odysseus tts-ai.js + voiceRecorder.js + the
+   #recording-indicator / #mic-btn rules in style.css). Appended to ODYSSEUS_CSS
+   in odysseus-theme.ts. Reuses .od-search-overlay/.od-search-backdrop/
+   .od-search-panel/.od-mem-head/.od-mem-title/.od-mem-stats already in
+   ODYSSEUS_CSS — only voice-specific rules below, all scoped .odysseus-root. ── */
+.odysseus-root .od-search-panel.od-voice-panel { width:460px; }
+.odysseus-root .od-voice-section { padding:14px 16px;
+  border-top:1px solid color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-voice-section:first-of-type { border-top:none; }
+.odysseus-root .od-voice-section-head { display:flex; align-items:center; gap:7px;
+  font-size:12px; font-weight:600; color:var(--fg); margin-bottom:10px; }
+.odysseus-root .od-voice-section-head svg { color:color-mix(in srgb, var(--fg) 60%, transparent); }
+
+/* TTS provider/voice field */
+.odysseus-root .od-voice-field { display:flex; align-items:center; gap:10px; margin-bottom:10px; }
+.odysseus-root .od-voice-label { font-size:11px; color:color-mix(in srgb, var(--fg) 55%, transparent);
+  min-width:40px; }
+.odysseus-root .od-voice-select { flex:1; padding:7px 9px; background:var(--bg); color:var(--fg);
+  border:1px solid var(--border); border-radius:6px; font-size:12px; outline:none;
+  font-family:inherit; cursor:pointer; }
+.odysseus-root .od-voice-select:focus { border-color:color-mix(in srgb, var(--fg) 45%, transparent); }
+
+.odysseus-root .od-voice-tts-input { width:100%; box-sizing:border-box; min-height:60px; resize:vertical;
+  padding:9px 11px; background:var(--bg); color:var(--fg); border:1px solid var(--border);
+  border-radius:8px; font-size:13px; font-family:inherit; line-height:1.45; outline:none; }
+.odysseus-root .od-voice-tts-input::placeholder { color:color-mix(in srgb, var(--fg) 35%, transparent); }
+.odysseus-root .od-voice-tts-input:focus { border-color:color-mix(in srgb, var(--fg) 45%, transparent); }
+
+.odysseus-root .od-voice-tts-controls { display:flex; gap:8px; margin-top:10px; }
+.odysseus-root .od-voice-btn { display:inline-flex; align-items:center; gap:6px; padding:7px 13px;
+  border-radius:7px; font-size:12px; font-weight:500; cursor:pointer; border:1px solid var(--border);
+  background:var(--bg); color:var(--fg); transition:background .15s ease, border-color .15s ease, opacity .15s ease; }
+.odysseus-root .od-voice-btn:hover { background:color-mix(in srgb, var(--fg) 7%, transparent);
+  border-color:color-mix(in srgb, var(--fg) 40%, transparent); }
+.odysseus-root .od-voice-btn:disabled { opacity:.4; cursor:not-allowed; }
+.odysseus-root .od-voice-btn-speak { border-color:color-mix(in srgb, var(--accent, var(--fg)) 55%, transparent);
+  color:var(--accent, var(--fg)); }
+.odysseus-root .od-voice-btn-stop { border-color:var(--color-recording, var(--red));
+  color:var(--color-recording, var(--red)); }
+
+/* honest disabled state (no voice backend attached) */
+.odysseus-root .od-voice-disabled { display:flex; flex-direction:column; align-items:center; gap:6px;
+  text-align:center; padding:18px 12px; color:color-mix(in srgb, var(--fg) 50%, transparent); }
+.odysseus-root .od-voice-disabled svg { color:color-mix(in srgb, var(--fg) 35%, transparent); margin-bottom:2px; }
+.odysseus-root .od-voice-disabled-title { font-size:13px; font-weight:600;
+  color:color-mix(in srgb, var(--fg) 70%, transparent); }
+.odysseus-root .od-voice-disabled-sub { font-size:11.5px; line-height:1.5; max-width:300px; }
+
+.odysseus-root .od-voice-status-row { display:flex; align-items:center; gap:8px; padding:8px 0;
+  font-size:12px; color:color-mix(in srgb, var(--fg) 55%, transparent); }
+.odysseus-root .od-voice-spin { animation:od-voice-spin .8s linear infinite; }
+@keyframes od-voice-spin { to { transform:rotate(360deg); } }
+
+/* recorder row: mic button + waveform meter + MM:SS timer */
+.odysseus-root .od-voice-recorder { display:flex; align-items:center; gap:12px; }
+.odysseus-root .od-voice-mic { flex-shrink:0; width:44px; height:44px; border-radius:50%;
+  display:inline-flex; align-items:center; justify-content:center; cursor:pointer;
+  background:var(--bg); color:var(--fg); border:1px solid var(--border);
+  transition:background .2s ease, border-color .2s ease, color .2s ease; }
+.odysseus-root .od-voice-mic:hover { background:color-mix(in srgb, var(--fg) 6%, transparent);
+  border-color:var(--fg); }
+.odysseus-root .od-voice-mic.recording { background:var(--color-recording, var(--red)); color:#fff;
+  border-color:var(--color-recording, var(--red)); animation:od-voice-pulse 1.5s infinite; }
+@keyframes od-voice-pulse { 0% { opacity:1; } 50% { opacity:.7; } 100% { opacity:1; } }
+
+.odysseus-root .od-voice-wave { flex:1; display:flex; align-items:center; gap:2px; height:40px;
+  padding:0 4px; overflow:hidden; }
+.odysseus-root .od-voice-wave-bar { flex:1; min-width:2px; border-radius:2px;
+  background:color-mix(in srgb, var(--fg) 35%, transparent); transition:height .08s linear; }
+.odysseus-root .od-voice-mic.recording ~ .od-voice-wave .od-voice-wave-bar {
+  background:color-mix(in srgb, var(--color-recording, var(--red)) 75%, transparent); }
+.odysseus-root .od-voice-timer { flex-shrink:0; font-variant-numeric:tabular-nums; font-size:13px;
+  color:color-mix(in srgb, var(--fg) 60%, transparent); min-width:42px; text-align:right; }
+
+.odysseus-root .od-voice-rec-indicator { display:flex; align-items:center; gap:8px; margin-top:10px;
+  font-size:12px; font-weight:500; color:var(--color-recording, var(--red)); }
+.odysseus-root .od-voice-rec-dot { width:9px; height:9px; border-radius:50%;
+  background:var(--color-recording, var(--red)); animation:od-voice-pulse 1.5s infinite; }
+
+.odysseus-root .od-voice-transcript { margin-top:10px; padding:10px 12px; border-radius:8px;
+  background:color-mix(in srgb, var(--fg) 4%, transparent); border:1px solid var(--border);
+  font-size:13px; line-height:1.5; color:var(--fg); white-space:pre-wrap; }
+.odysseus-root .od-voice-interim { color:color-mix(in srgb, var(--fg) 45%, transparent); font-style:italic; }
+.odysseus-root .od-voice-hint { margin-top:10px; font-size:11.5px; line-height:1.5;
+  color:color-mix(in srgb, var(--fg) 45%, transparent); }
+
+.odysseus-root .od-voice-err { display:flex; align-items:center; gap:6px; margin-top:10px;
+  font-size:12px; color:var(--red); }
+.odysseus-root .od-voice-err svg { flex-shrink:0; }
+/* ===== wave5: PresetsPanel ===== */
+/* ===== PresetsPanel (odysseus static/js/presets.js + .preset-* in style.css) ===== */
+/* Reuses the shared .od-search-overlay / .od-search-backdrop / .od-search-panel
+   chrome and the .od-mem-head / .od-mem-title / .od-mem-stats header (same as
+   NotesPanel/MemoryPanel). Only preset-specific rules below, scoped to
+   .odysseus-root. Sliders/temp-hints/section labels are ported 1:1 from
+   odysseus's .preset-range / .preset-temp-hints / .preset-section-header. */
+
+/* Panel: a touch wider + capped height so the list + footer fit a tall library. */
+.odysseus-root .od-search-panel.od-presets-panel {
+  width: 600px;
+  max-width: 92%;
+  display: flex;
+  flex-direction: column;
+  max-height: 78vh;
+}
+
+/* Toolbar: active-preset tag (left) + New-preset button (right). */
+.odysseus-root .od-preset-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 2px 16px 10px;
+}
+.odysseus-root .od-preset-active-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--ok, var(--accent));
+}
+.odysseus-root .od-preset-active-tag.od-preset-active-none {
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+  font-weight: 500;
+}
+.odysseus-root .od-preset-new-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 11px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: none;
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.odysseus-root .od-preset-new-btn:hover {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
+  color: var(--accent);
+}
+
+/* Preset list rows. */
+.odysseus-root .od-preset-list {
+  flex: 1;
+  min-height: 80px;
+}
+.odysseus-root .od-preset-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 11px 16px;
+  border-top: 1px solid color-mix(in srgb, var(--fg) 6%, transparent);
+}
+.odysseus-root .od-preset-item.active {
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
+}
+.odysseus-root .od-preset-info {
+  flex: 1;
+  min-width: 0;
+}
+.odysseus-root .od-preset-name {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fg);
+  margin-bottom: 3px;
+}
+.odysseus-root .od-preset-badge {
+  font-size: 8px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 1px 5px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+  color: color-mix(in srgb, var(--fg) 60%, transparent);
+  font-weight: 600;
+}
+.odysseus-root .od-preset-prompt {
+  font-size: 11px;
+  line-height: 1.4;
+  color: color-mix(in srgb, var(--fg) 58%, transparent);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+.odysseus-root .od-preset-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 5px;
+  font-size: 10px;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+.odysseus-root .od-preset-actions {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+}
+.odysseus-root .od-preset-activate {
+  padding: 4px 11px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: none;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+.odysseus-root .od-preset-activate:hover {
+  color: var(--fg);
+  border-color: var(--fg);
+}
+.odysseus-root .od-preset-activate.on {
+  border-color: var(--ok, var(--accent));
+  color: var(--ok, var(--accent));
+  background: color-mix(in srgb, var(--ok, var(--accent)) 12%, transparent);
+}
+.odysseus-root .od-preset-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border: none;
+  border-radius: 6px;
+  background: none;
+  color: color-mix(in srgb, var(--fg) 50%, transparent);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.odysseus-root .od-preset-icon-btn:hover {
+  color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+}
+.odysseus-root .od-preset-icon-btn.od-preset-del:hover {
+  color: var(--red);
+  background: color-mix(in srgb, var(--red) 10%, transparent);
+}
+
+/* Footer honesty note. */
+.odysseus-root .od-preset-foot {
+  flex-shrink: 0;
+  padding: 10px 16px 13px;
+  border-top: 1px solid color-mix(in srgb, var(--fg) 6%, transparent);
+  font-size: 11px;
+  line-height: 1.45;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+
+/* ── Editor (create / edit) — ports .preset-slider-row / .preset-range /
+   .preset-temp-hints / .preset-save-template-btn ── */
+.odysseus-root .od-preset-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 4px 16px 16px;
+  overflow-y: auto;
+}
+.odysseus-root .od-preset-field {
+  display: flex;
+  flex-direction: column;
+}
+.odysseus-root .od-preset-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--fg);
+  margin: 0 0 5px;
+}
+.odysseus-root .od-preset-input {
+  width: 100%;
+  padding: 9px 11px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 13px;
+  outline: none;
+  box-sizing: border-box;
+}
+.odysseus-root .od-preset-input:focus {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
+}
+.odysseus-root .od-preset-textarea {
+  width: 100%;
+  min-height: 130px;
+  resize: vertical;
+  padding: 10px 11px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.5;
+  outline: none;
+  box-sizing: border-box;
+}
+.odysseus-root .od-preset-textarea:focus {
+  border-color: color-mix(in srgb, var(--accent) 50%, var(--border));
+}
+.odysseus-root .od-preset-slider-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+.odysseus-root .od-preset-slider-value {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg);
+  min-width: 56px;
+  text-align: right;
+}
+.odysseus-root .od-preset-range {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 6px;
+  background: var(--border);
+  border-radius: 4px;
+  outline: none;
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
+  display: block;
+  cursor: pointer;
+}
+.odysseus-root .od-preset-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--red, var(--fg));
+  cursor: pointer;
+  border: 2px solid var(--panel);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+.odysseus-root .od-preset-range::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--red, var(--fg));
+  cursor: pointer;
+  border: 2px solid var(--panel);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+.odysseus-root .od-preset-range::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: 4px;
+}
+.odysseus-root .od-preset-range::-moz-range-track {
+  height: 6px;
+  background: var(--border);
+  border-radius: 4px;
+}
+.odysseus-root .od-preset-temp-hints {
+  display: flex;
+  font-size: 10px;
+  color: color-mix(in srgb, var(--fg) 50%, transparent);
+  margin-top: 5px;
+  padding: 0 2px;
+  opacity: 0.8;
+}
+.odysseus-root .od-preset-temp-hints span {
+  flex: 1;
+}
+.odysseus-root .od-preset-temp-hints span:nth-child(2) {
+  text-align: center;
+}
+.odysseus-root .od-preset-temp-hints span:last-child {
+  text-align: right;
+}
+.odysseus-root .od-preset-editor-foot {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 2px;
+}
+.odysseus-root .od-preset-cancel-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 7px 14px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: none;
+  color: color-mix(in srgb, var(--fg) 70%, transparent);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.odysseus-root .od-preset-cancel-btn:hover {
+  color: var(--fg);
+  border-color: var(--fg);
+}
+.odysseus-root .od-preset-save-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 7px 14px;
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--accent);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.odysseus-root .od-preset-save-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+.odysseus-root .od-preset-save-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+/* ===== wave5: EmojiPicker ===== */
+/* ===== EmojiPicker — composer popover (odysseus static/js/emojiPicker.js +
+   .emoji-* rules in static/style.css). Anchored ABOVE the composer like the
+   slash-autocomplete popup (.od-slash-ac uses the same bottom:calc(100%+6px)
+   trick), scoped under .odysseus-root, theme-var driven. Append to ODYSSEUS_CSS
+   in odysseus-theme.ts, in the "sync: Composer" section next to .od-slash-ac. */
+
+/* The popover shell. The composer (.od-input-bar) is already position:relative,
+   so this docks above-left of the emoji icon button. anchorClassName can pin it
+   elsewhere if a caller wants. */
+.odysseus-root .od-emoji-popover { position:absolute; bottom:calc(100% + 6px); left:0; z-index:9000;
+  width:332px; max-width:calc(100vw - 24px); background:var(--panel, var(--bg));
+  border:1px solid var(--border); border-radius:10px; box-shadow:0 8px 24px rgba(0,0,0,.4);
+  display:flex; flex-direction:column; overflow:hidden; color:var(--fg); }
+
+/* Search row */
+.odysseus-root .od-emoji-search { display:flex; align-items:center; gap:6px; padding:8px 10px;
+  border-bottom:1px solid var(--border); }
+.odysseus-root .od-emoji-search-icon { color:var(--muted); flex-shrink:0; }
+.odysseus-root .od-emoji-search-input { flex:1; min-width:0; background:transparent; border:none;
+  outline:none; font-size:13px; font-family:inherit; color:var(--fg); padding:2px 0; }
+.odysseus-root .od-emoji-search-input::placeholder { color:color-mix(in srgb, var(--fg) 35%, transparent); }
+
+/* Category tab strip */
+.odysseus-root .od-emoji-tabs { display:flex; align-items:center; gap:2px; padding:4px 6px;
+  border-bottom:1px solid var(--border); overflow-x:auto; }
+.odysseus-root .od-emoji-tab { flex:0 0 auto; width:30px; height:30px; display:flex; align-items:center;
+  justify-content:center; background:none; border:none; border-radius:6px; cursor:pointer;
+  font-size:17px; line-height:1; color:color-mix(in srgb, var(--fg) 55%, transparent);
+  transition:background .12s, color .12s; }
+.odysseus-root .od-emoji-tab:hover { background:color-mix(in srgb, var(--fg) 8%, transparent); color:var(--fg); }
+.odysseus-root .od-emoji-tab.active { background:color-mix(in srgb, var(--accent, var(--red)) 14%, transparent);
+  color:var(--accent, var(--red)); }
+
+/* Scrollable body + grid */
+.odysseus-root .od-emoji-body { max-height:260px; overflow-y:auto; padding:6px 8px 8px; }
+.odysseus-root .od-emoji-section-label { font-size:10px; letter-spacing:.08em; text-transform:uppercase;
+  color:var(--muted); padding:6px 2px 4px; opacity:.7; }
+.odysseus-root .od-emoji-grid { display:grid; grid-template-columns:repeat(8, 1fr); gap:1px; }
+.odysseus-root .od-emoji-cell { width:100%; aspect-ratio:1; display:flex; align-items:center;
+  justify-content:center; background:none; border:none; border-radius:6px; cursor:pointer;
+  font-size:20px; line-height:1; padding:0; transition:background .1s; }
+.odysseus-root .od-emoji-cell:hover { background:color-mix(in srgb, var(--accent, var(--red)) 16%, transparent); }
+
+/* Honest empty state (no keyword match) */
+.odysseus-root .od-emoji-empty { display:flex; flex-direction:column; align-items:center; gap:8px;
+  padding:28px 12px; color:var(--muted); font-size:12px; text-align:center; }
+
+/* Scrollbar to match the rest of the odysseus surfaces */
+.odysseus-root .od-emoji-body::-webkit-scrollbar,
+.odysseus-root .od-emoji-tabs::-webkit-scrollbar { width:8px; height:8px; }
+.odysseus-root .od-emoji-body::-webkit-scrollbar-thumb,
+.odysseus-root .od-emoji-tabs::-webkit-scrollbar-thumb {
+  background:color-mix(in srgb, var(--fg) 18%, transparent); border-radius:4px; }
+
+/* ── window-manager: draggable + edge/corner-resizable tool windows
+   (windowDrag.js + windowResize.js). Grips render only when a panel is
+   windowed (position:absolute via inline style), anchored to it. ── */
+.odysseus-root .od-window-header { cursor:grab; }
+.odysseus-root .od-window-header:active { cursor:grabbing; }
+.odysseus-root .od-rz-handle { position:absolute; z-index:30; touch-action:none; }
+.odysseus-root .od-rz-n { top:-3px; left:10px; right:10px; height:7px; cursor:ns-resize; }
+.odysseus-root .od-rz-s { bottom:-3px; left:10px; right:10px; height:7px; cursor:ns-resize; }
+.odysseus-root .od-rz-e { right:-3px; top:10px; bottom:10px; width:7px; cursor:ew-resize; }
+.odysseus-root .od-rz-w { left:-3px; top:10px; bottom:10px; width:7px; cursor:ew-resize; }
+.odysseus-root .od-rz-ne { top:-5px; right:-5px; width:14px; height:14px; cursor:nesw-resize; }
+.odysseus-root .od-rz-nw { top:-5px; left:-5px; width:14px; height:14px; cursor:nwse-resize; }
+.odysseus-root .od-rz-se { bottom:-5px; right:-5px; width:14px; height:14px; cursor:nwse-resize; }
+.odysseus-root .od-rz-sw { bottom:-5px; left:-5px; width:14px; height:14px; cursor:nesw-resize; }
+
+
+/* ===== fix-wave-A: MemoryPanel ===== */
+
+/* ── MemoryPanel: bounded panel + tabs/toolbar/chips/meta/add (memory.js + index.html memory modal) ── */
+/* Bounded, scroll-inside-panel fix: the non-windowed panel is a flex column
+   capped to the viewport; the list owns the overflow so the panel's rounded
+   bottom border always stays on-screen (no mid-row clip past the fold). The
+   windowed (dragged/resized) panel sets its own inline height, which wins. */
+.odysseus-root .od-search-overlay:not(.od-windowed) > .od-search-panel.od-mem-panel {
+  max-height: 84vh; display: flex; flex-direction: column; }
+.odysseus-root .od-search-panel.od-mem-panel.od-windowed,
+.odysseus-root .od-windowed > .od-search-panel.od-mem-panel { display: flex; flex-direction: column; }
+.odysseus-root .od-mem-panel { display: flex; flex-direction: column; min-height: 0; }
+.odysseus-root .od-mem-list { flex: 1 1 auto; max-height: none; min-height: 0; }
+
+/* Tabs */
+.odysseus-root .od-mem-tabs { display: flex; gap: 4px; padding: 8px 12px 0; border-bottom: 1px solid var(--border); }
+.odysseus-root .od-mem-tab { display: inline-flex; align-items: center; gap: 5px; padding: 7px 12px 8px;
+  background: none; border: none; border-bottom: 2px solid transparent; margin-bottom: -1px;
+  color: color-mix(in srgb, var(--fg) 55%, transparent); font-size: 12px; font-weight: 500; cursor: pointer; }
+.odysseus-root .od-mem-tab:hover { color: var(--fg); }
+.odysseus-root .od-mem-tab.active { color: var(--fg); border-bottom-color: var(--accent, var(--red)); }
+
+/* Description line under tabs */
+.odysseus-root .od-mem-desc { margin: 10px 16px 0; font-size: 11px; line-height: 1.45;
+  color: color-mix(in srgb, var(--fg) 55%, transparent); }
+
+/* Browse toolbar: sort select + search field */
+.odysseus-root .od-mem-toolbar { display: flex; align-items: center; gap: 8px; padding: 10px 16px 8px; }
+.odysseus-root .od-mem-sort { flex-shrink: 0; padding: 5px 8px; border: 1px solid var(--border); border-radius: 7px;
+  background: var(--input-bg, var(--panel)); color: var(--fg); font-size: 12px; cursor: pointer; outline: none; }
+.odysseus-root .od-mem-sort:focus-visible { border-color: var(--accent, var(--red)); }
+.odysseus-root .od-mem-search-wrap { position: relative; flex: 1; min-width: 0; display: flex; align-items: center; }
+.odysseus-root .od-mem-search-icon { position: absolute; left: 9px; color: color-mix(in srgb, var(--fg) 40%, transparent);
+  pointer-events: none; }
+.odysseus-root .od-mem-search { width: 100%; box-sizing: border-box; padding: 6px 10px 6px 28px; border: 1px solid var(--border);
+  border-radius: 7px; background: var(--input-bg, var(--panel)); color: var(--fg); font-size: 13px; outline: none; }
+.odysseus-root .od-mem-search::placeholder { color: color-mix(in srgb, var(--fg) 35%, transparent); }
+.odysseus-root .od-mem-search:focus-visible { border-color: var(--accent, var(--red)); }
+
+/* Category chips */
+.odysseus-root .od-mem-cats { display: flex; flex-wrap: wrap; gap: 6px; padding: 0 16px 10px; }
+.odysseus-root .od-mem-cat { padding: 3px 10px; border: 1px solid var(--border); border-radius: 12px; background: none;
+  color: color-mix(in srgb, var(--fg) 60%, transparent); font-size: 11px; cursor: pointer; text-transform: lowercase; }
+.odysseus-root .od-mem-cat:hover { color: var(--fg); border-color: color-mix(in srgb, var(--fg) 30%, transparent); }
+.odysseus-root .od-mem-cat.active { color: var(--accent, var(--red)); border-color: var(--accent, var(--red));
+  background: color-mix(in srgb, var(--accent, var(--red)) 12%, transparent); }
+
+/* List item: text + metadata row (overrides the old single-line .od-mem-item flex layout) */
+.odysseus-root .od-mem-item { display: block; align-items: initial; gap: 0; padding: 9px 16px;
+  border-top: 1px solid color-mix(in srgb, var(--fg) 6%, transparent); }
+.odysseus-root .od-mem-item-body { display: flex; flex-direction: column; gap: 5px; min-width: 0; }
+.odysseus-root .od-mem-item .od-mem-text { display: block; flex: initial; font-size: 13px; line-height: 1.4;
+  color: var(--fg); white-space: normal; overflow: visible; -webkit-line-clamp: initial; word-break: break-word; }
+.odysseus-root .od-mem-meta { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
+.odysseus-root .od-mem-badge { font-size: 9px; text-transform: uppercase; letter-spacing: .04em; padding: 1px 6px;
+  border-radius: 4px; background: color-mix(in srgb, var(--accent, var(--red)) 14%, transparent);
+  color: var(--accent, var(--red)); flex-shrink: 0; }
+.odysseus-root .od-mem-source { font-size: 10px; color: color-mix(in srgb, var(--fg) 50%, transparent);
+  border: 1px solid var(--border); border-radius: 4px; padding: 0 5px; }
+.odysseus-root .od-mem-item .od-mem-time { font-size: 10px; color: color-mix(in srgb, var(--fg) 45%, transparent);
+  flex-shrink: 0; }
+
+/* Empty-state link (switches to Add tab) */
+.odysseus-root .od-mem-empty-link { background: none; border: none; padding: 0; font: inherit; cursor: pointer;
+  color: var(--accent, var(--red)); text-decoration: underline; }
+
+/* Add tab */
+.odysseus-root .od-mem-add { display: flex; flex-direction: column; gap: 10px; padding: 4px 16px 16px; }
+.odysseus-root .od-mem-add-desc { margin: 8px 0 0; }
+.odysseus-root .od-mem-add-input { width: 100%; box-sizing: border-box; padding: 9px 12px; border: 1px solid var(--border);
+  border-radius: 8px; background: var(--input-bg, var(--panel)); color: var(--fg); font-size: 13px; outline: none; }
+.odysseus-root .od-mem-add-input::placeholder { color: color-mix(in srgb, var(--fg) 35%, transparent); }
+.odysseus-root .od-mem-add-input:focus-visible { border-color: var(--accent, var(--red)); }
+.odysseus-root .od-mem-add-foot { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+.odysseus-root .od-mem-add-error { font-size: 11px; color: var(--red); }
+.odysseus-root .od-mem-add-btn { padding: 6px 14px; border: 1px solid var(--accent, var(--red)); border-radius: 8px;
+  background: color-mix(in srgb, var(--accent, var(--red)) 14%, transparent); color: var(--accent, var(--red));
+  font-size: 12px; font-weight: 500; cursor: pointer; }
+.odysseus-root .od-mem-add-btn:hover:not(:disabled) { background: color-mix(in srgb, var(--accent, var(--red)) 22%, transparent); }
+.odysseus-root .od-mem-add-btn:disabled { opacity: .5; cursor: default; }
+
+/* ===== fix-wave-A: GalleryView ===== */
+/* ── GalleryView: honest empty-state layout (no image-library backend) ──
+   The default .od-gallery-grid uses flex:1 so a populated grid scrolls and
+   fills the panel. With no backend the grid is always empty; flex:1 would
+   stretch it and float the "No photos yet" caption into a centered void
+   (odysseus appends the caption right after the Upload tile, never centered).
+   This modifier stops the grid from stretching so the caption reads as a
+   caption directly under the Upload tile, matching odysseus's markup order. */
+.odysseus-root .od-gallery-grid.od-gallery-grid-empty {
+  flex: 0 0 auto;
+  overflow: visible;
+  align-content: start;
+  max-height: none;
+}
+/* Upload tile rendered as a disabled affordance (no upload endpoint exists),
+   consistent with the honest no-backend posture: dimmed, not-allowed, and no
+   hover-lift implying it is actionable. */
+.odysseus-root .od-gallery-card.od-gallery-card-disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+.odysseus-root .od-gallery-card.od-gallery-card-disabled:hover {
+  border-color: var(--border);
+  box-shadow: none;
+  transform: none;
+  opacity: 0.5;
+}
+/* Honest explainer under the empty grid — same muted register as
+   .od-gallery-settings-desc, scoped to the images container. */
+.odysseus-root .od-gallery-backend-note {
+  margin-top: 10px;
+  padding: 0 2px;
+  font-size: 11px;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+/* ===== fix-wave-A: SkillsPanel ===== */
+
+/* ── skills panel (rewritten; mirrors the proven .od-doclib-* card/toolbar/
+   expand/edit/delete rules 1:1, scoped + theme-var driven). Replaces the old
+   singular .od-skill-* block. ── */
+.odysseus-root .od-skills-panel { width:560px; max-width:92%; display:flex; flex-direction:column; max-height:85vh; }
+.odysseus-root .od-skills-desc { margin:0; padding:2px 16px 0; font-size:11px; line-height:1.5;
+  color:color-mix(in srgb, var(--fg) 50%, transparent); }
+.odysseus-root .od-skills-toolbar { display:flex; align-items:center; gap:8px; padding:8px 16px 4px; flex-wrap:wrap; }
+.odysseus-root .od-skills-select { background:var(--bg); color:var(--fg); border:1px solid var(--border);
+  border-radius:6px; font-family:inherit; font-size:11px; height:24px; padding:0 6px; cursor:pointer; }
+.odysseus-root .od-skills-select:focus { outline:none; border-color:var(--red); }
+.odysseus-root .od-skills-toolbar-btn { margin-left:auto; background:none; border:1px solid var(--border);
+  color:color-mix(in srgb, var(--fg) 60%, transparent); font-size:11px; height:24px; padding:0 8px; border-radius:6px;
+  cursor:pointer; font-family:inherit; white-space:nowrap; display:inline-flex; align-items:center; gap:3px;
+  transition:all .15s; }
+.odysseus-root .od-skills-toolbar-btn:hover { border-color:var(--fg); color:var(--fg); }
+.odysseus-root .od-skills-search { height:26px; margin:4px 16px 6px; padding:0 8px; border-radius:6px;
+  border:1px solid var(--border); background:var(--bg); color:var(--fg); font-family:inherit; font-size:12px;
+  box-sizing:border-box; }
+.odysseus-root .od-skills-search:focus { outline:none; border-color:var(--red); }
+.odysseus-root .od-skills-search::placeholder { color:color-mix(in srgb, var(--fg) 40%, transparent); }
+.odysseus-root .od-skills-add { display:flex; flex-direction:column; gap:6px; margin:0 16px 8px; padding:10px;
+  border:1px solid var(--border); border-radius:8px; background:color-mix(in srgb, var(--fg) 3%, transparent); }
+.odysseus-root .od-skills-add-input, .odysseus-root .od-skills-add-textarea { width:100%; box-sizing:border-box;
+  background:var(--bg); color:var(--fg); border:1px solid var(--border); border-radius:6px; font-family:inherit;
+  font-size:12px; padding:5px 8px; resize:vertical; }
+.odysseus-root .od-skills-add-input:focus, .odysseus-root .od-skills-add-textarea:focus { outline:none; border-color:var(--red); }
+.odysseus-root .od-skills-add-input::placeholder, .odysseus-root .od-skills-add-textarea::placeholder { color:color-mix(in srgb, var(--fg) 40%, transparent); }
+.odysseus-root .od-skills-add-actions { display:flex; justify-content:flex-end; gap:6px; }
+.odysseus-root .od-skills-grid { display:flex; flex-direction:column; gap:4px; overflow-y:auto; padding:2px 16px 12px;
+  min-height:0; flex:1; }
+.odysseus-root .od-skills-empty { text-align:center; color:color-mix(in srgb, var(--fg) 35%, transparent);
+  padding:32px 16px; font-size:12px; font-style:italic; }
+.odysseus-root .od-skills-card { display:flex; align-items:flex-start; gap:8px; flex-direction:row; flex-wrap:wrap;
+  border:1px solid var(--border); border-radius:8px; background:color-mix(in srgb, var(--fg) 3%, transparent);
+  position:relative; transition:all .15s; flex-shrink:0; }
+.odysseus-root .od-skills-card:hover { background:color-mix(in srgb, var(--fg) 5%, transparent);
+  border-color:color-mix(in srgb, var(--fg) 16%, transparent); }
+.odysseus-root .od-skills-card-main { flex:1; min-width:0; display:flex; background:none; border:none; padding:9px 10px;
+  cursor:pointer; text-align:left; color:inherit; font-family:inherit; }
+.odysseus-root .od-skills-content { flex:1; min-width:0; }
+.odysseus-root .od-skills-titlerow { display:flex; align-items:center; gap:6px; width:100%; }
+.odysseus-root .od-skills-name { font-size:12.5px; font-weight:600; color:var(--fg); overflow:hidden;
+  text-overflow:ellipsis; white-space:nowrap; flex:0 1 auto; min-width:0; font-family:'Fira Code', ui-monospace, monospace; }
+.odysseus-root .od-skills-status { font-size:8px; text-transform:uppercase; letter-spacing:.04em; padding:1px 6px;
+  border-radius:8px; flex-shrink:0; font-weight:600;
+  background:color-mix(in srgb, var(--fg) 8%, transparent);
+  border:1px solid color-mix(in srgb, var(--fg) 14%, transparent);
+  color:color-mix(in srgb, var(--fg) 45%, transparent); }
+.odysseus-root .od-skills-status.on { background:color-mix(in srgb, var(--ok) 14%, transparent);
+  border-color:color-mix(in srgb, var(--ok) 45%, transparent); color:var(--ok); }
+.odysseus-root .od-skills-scan { font-size:8px; text-transform:uppercase; letter-spacing:.04em; padding:1px 5px;
+  border-radius:4px; flex-shrink:0; font-weight:600;
+  background:color-mix(in srgb, var(--warn) 20%, transparent); color:var(--warn); }
+.odysseus-root .od-skills-scan-critical, .odysseus-root .od-skills-scan-blocked {
+  background:color-mix(in srgb, var(--red) 20%, transparent); color:var(--red); }
+.odysseus-root .od-skills-chevron { margin-left:auto; align-self:center; opacity:.6; flex-shrink:0;
+  transition:transform .15s ease; }
+.odysseus-root .od-skills-card-expanded .od-skills-chevron { transform:rotate(180deg); }
+.odysseus-root .od-skills-desc-line { font-size:11px; margin-top:3px; line-height:1.4;
+  color:color-mix(in srgb, var(--fg) 55%, transparent); overflow:hidden; text-overflow:ellipsis;
+  display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; }
+.odysseus-root .od-skills-card-expanded .od-skills-desc-line { -webkit-line-clamp:none; }
+.odysseus-root .od-skills-actions { display:flex; gap:4px; flex-shrink:0; position:relative; padding:9px 8px 0 0; }
+.odysseus-root .od-skills-item-btn { background:none; border:1px solid transparent;
+  color:color-mix(in srgb, var(--fg) 50%, transparent); height:22px; padding:0 6px; border-radius:6px; cursor:pointer;
+  display:flex; align-items:center; opacity:0; transition:all .15s; }
+.odysseus-root .od-skills-card:hover .od-skills-item-btn, .odysseus-root .od-skills-card-expanded .od-skills-item-btn { opacity:1; }
+.odysseus-root .od-skills-item-btn:hover { color:var(--fg); border-color:var(--border);
+  background:color-mix(in srgb, var(--fg) 6%, transparent); }
+.odysseus-root .od-skills-dropdown { position:absolute; top:100%; right:0; z-index:1000; width:max-content; padding:4px;
+  background:var(--panel); border:1px solid var(--border); border-radius:8px; box-shadow:0 8px 24px rgba(0,0,0,.3);
+  font-size:12px; }
+.odysseus-root .od-skills-dropdown-item { display:flex; align-items:center; gap:7px; width:100%; text-align:left;
+  padding:6px 10px; border:none; background:none; color:var(--fg); font-size:12px; border-radius:4px; cursor:pointer;
+  font-family:inherit; }
+.odysseus-root .od-skills-dropdown-item:hover { background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-skills-dropdown-danger { color:var(--red); }
+.odysseus-root .od-skills-card-expanded { flex-direction:column; }
+.odysseus-root .od-skills-preview { flex-basis:100%; width:100%; padding:8px 12px;
+  border-top:1px solid color-mix(in srgb, var(--border) 30%, transparent); margin:0; box-sizing:border-box; }
+.odysseus-root .od-skills-preview pre { margin:0; max-height:40vh; overflow-y:auto; white-space:pre-wrap;
+  word-break:break-word; font-family:'Fira Code', ui-monospace, monospace; font-size:10.5px; line-height:1.5;
+  color:var(--hl-fg, var(--fg)); }
+.odysseus-root .od-skills-preview code { background:none; padding:0; font-family:inherit; }
+.odysseus-root .od-skills-editor { width:100%; box-sizing:border-box; min-height:200px; max-height:40vh; resize:vertical;
+  background:var(--bg); color:var(--fg); border:1px solid var(--border); border-radius:6px;
+  font-family:'Fira Code', ui-monospace, monospace; font-size:10.5px; line-height:1.5; padding:8px; }
+.odysseus-root .od-skills-editor:focus { outline:none; border-color:var(--red); }
+.odysseus-root .od-skills-expanded-actions { display:flex; align-items:flex-start; gap:6px; padding:8px 0 2px;
+  border-top:1px solid color-mix(in srgb, var(--border) 30%, transparent); margin-top:8px; }
+.odysseus-root .od-skills-action-group { display:flex; gap:6px; margin-left:auto; }
+.odysseus-root .od-skills-confirm { display:flex; align-items:center; gap:8px; padding:8px 0 2px;
+  border-top:1px solid color-mix(in srgb, var(--border) 30%, transparent); margin-top:8px; font-size:11px;
+  color:color-mix(in srgb, var(--fg) 70%, transparent); }
+.odysseus-root .od-skills-confirm > span:first-child { margin-right:auto; }
+.odysseus-root .od-skills-edit-cancel { display:inline-flex; align-items:center; gap:4px; margin-top:6px;
+  background:none; border:none; color:color-mix(in srgb, var(--fg) 45%, transparent); font-size:10px; cursor:pointer;
+  font-family:inherit; padding:2px 0; }
+.odysseus-root .od-skills-edit-cancel:hover { color:var(--fg); }
+.odysseus-root .od-skills-text-btn { display:inline-flex; align-items:center; justify-content:center; gap:4px;
+  box-sizing:border-box; font-size:10px; padding:3px 8px; border-radius:4px; background:none; border:1px solid var(--border);
+  color:color-mix(in srgb, var(--fg) 60%, transparent); cursor:pointer; font-family:inherit;
+  transition:border-color .15s, color .15s; }
+.odysseus-root .od-skills-text-btn:hover { border-color:var(--fg); color:var(--fg); }
+.odysseus-root .od-skills-text-btn:disabled { opacity:.35; cursor:not-allowed; }
+.odysseus-root .od-skills-text-btn-primary { border-color:color-mix(in srgb, var(--ok) 55%, transparent); color:var(--ok); }
+.odysseus-root .od-skills-text-btn-primary:hover { border-color:var(--ok); color:var(--ok); }
+.odysseus-root .od-skills-text-btn-danger { color:var(--red); border-color:color-mix(in srgb, var(--red) 60%, transparent); }
+.odysseus-root .od-skills-text-btn-danger:hover { border-color:var(--red); color:var(--red); }
+
+/* ===== fix-wave-A: NotesPanel ===== */
+
+/* ── notes panel (rebuilt to odysseus notes.js surface) ── */
+.odysseus-root .od-notes-panel { display:flex; flex-direction:column; }
+.odysseus-root .od-notes-panel.od-notes-archived { background:color-mix(in srgb, var(--accent, var(--red)) 5%, var(--panel)); }
+
+.odysseus-root .od-notes-head { display:flex; align-items:center; gap:8px; }
+.odysseus-root .od-notes-head-spacer { flex:1 1 auto; }
+.odysseus-root .od-notes-head-btn { background:none; border:1px solid transparent; cursor:pointer;
+  font-size:11px; font-weight:600; color:color-mix(in srgb, var(--fg) 70%, transparent);
+  padding:3px 9px; border-radius:6px; line-height:1.4; }
+.odysseus-root .od-notes-head-btn:hover { background:color-mix(in srgb, var(--fg) 7%, transparent); color:var(--fg); }
+.odysseus-root .od-notes-head-btn.active { color:var(--fg); border-color:var(--border); background:color-mix(in srgb, var(--fg) 6%, transparent); }
+.odysseus-root .od-notes-head-btn.primary { background:var(--accent, var(--red)); color:#fff; border-color:transparent; }
+.odysseus-root .od-notes-head-btn.primary:hover { filter:brightness(0.94); background:var(--accent, var(--red)); color:#fff; }
+
+.odysseus-root .od-notes-searchbar { display:flex; align-items:center; gap:8px; padding:4px 16px 8px; }
+.odysseus-root .od-notes-search { flex:1 1 auto; border:1px solid var(--border); border-radius:8px; }
+.odysseus-root .od-notes-select-trigger { flex-shrink:0; background:none; border:1px solid var(--border);
+  border-radius:8px; cursor:pointer; font-size:11px; font-weight:600; padding:6px 11px;
+  color:color-mix(in srgb, var(--fg) 70%, transparent); }
+.odysseus-root .od-notes-select-trigger:hover { color:var(--fg); background:color-mix(in srgb, var(--fg) 6%, transparent); }
+.odysseus-root .od-notes-select-trigger.active { color:var(--fg); background:color-mix(in srgb, var(--fg) 8%, transparent); }
+
+.odysseus-root .od-notes-bulk-bar { display:flex; align-items:center; gap:10px; padding:6px 16px;
+  margin:0 16px 6px; border:1px solid var(--border); border-radius:8px;
+  background:color-mix(in srgb, var(--fg) 4%, transparent); font-size:11px; }
+.odysseus-root .od-notes-bulk-all { display:flex; align-items:center; gap:5px; cursor:pointer; color:var(--fg); }
+.odysseus-root .od-notes-bulk-count { color:color-mix(in srgb, var(--fg) 60%, transparent); font-weight:600; }
+.odysseus-root .od-notes-bulk-btn { background:none; border:1px solid var(--border); border-radius:6px;
+  cursor:pointer; font-size:11px; font-weight:600; padding:4px 10px; color:var(--fg); }
+.odysseus-root .od-notes-bulk-btn:hover:not(:disabled) { background:color-mix(in srgb, var(--fg) 7%, transparent); }
+.odysseus-root .od-notes-bulk-btn.danger:hover:not(:disabled) { color:var(--red); border-color:color-mix(in srgb, var(--red) 50%, var(--border)); background:color-mix(in srgb, var(--red) 8%, transparent); }
+.odysseus-root .od-notes-bulk-btn:disabled { opacity:0.4; cursor:default; }
+
+.odysseus-root .od-notes-undo { display:flex; align-items:center; gap:10px; margin:0 16px 6px;
+  padding:6px 12px; border-radius:8px; font-size:12px; color:var(--fg);
+  background:color-mix(in srgb, var(--fg) 8%, transparent); border:1px solid var(--border); }
+.odysseus-root .od-notes-undo-btn { background:none; border:none; cursor:pointer; font-weight:700;
+  color:var(--accent, var(--red)); font-size:12px; padding:0; }
+.odysseus-root .od-notes-undo-btn:hover { text-decoration:underline; }
+.odysseus-root .od-notes-undo-dismiss { margin-left:auto; background:none; border:none; cursor:pointer;
+  font-size:11px; color:color-mix(in srgb, var(--fg) 45%, transparent); padding:2px 4px; }
+.odysseus-root .od-notes-undo-dismiss:hover { color:var(--fg); }
+
+.odysseus-root .od-notes-labels { display:flex; flex-wrap:wrap; gap:6px; padding:0 16px 8px; }
+.odysseus-root .od-notes-chip { background:none; border:1px solid var(--border); border-radius:999px;
+  cursor:pointer; font-size:11px; font-weight:600; padding:3px 10px;
+  color:color-mix(in srgb, var(--fg) 65%, transparent); display:inline-flex; align-items:center; gap:5px; }
+.odysseus-root .od-notes-chip:hover { color:var(--fg); background:color-mix(in srgb, var(--fg) 6%, transparent); }
+.odysseus-root .od-notes-chip.active { color:var(--fg); border-color:color-mix(in srgb, var(--fg) 40%, var(--border));
+  background:color-mix(in srgb, var(--fg) 9%, transparent); }
+.odysseus-root .od-notes-chip-count { font-size:10px; opacity:0.7; }
+
+.odysseus-root .od-notes-list { padding:0 16px 16px; }
+.odysseus-root .od-notes-list.od-notes-grid { column-count:2; column-gap:12px; }
+.odysseus-root .od-notes-list.od-notes-grid > * { break-inside:avoid; margin-bottom:12px; }
+.odysseus-root .od-notes-list.od-notes-list { display:flex; flex-direction:column; gap:10px; }
+
+/* quick-add bar + type pills */
+.odysseus-root .od-notes-quickadd { display:flex; align-items:center; gap:8px; margin-bottom:12px;
+  border:1px solid var(--border); border-radius:10px; padding:6px 8px;
+  background:color-mix(in srgb, var(--fg) 3%, transparent); }
+.odysseus-root .od-notes-quick-seg, .odysseus-root .od-note-form-seg { display:inline-flex; flex-shrink:0;
+  border:1px solid var(--border); border-radius:8px; overflow:hidden; padding:0; margin:0;
+  min-inline-size:auto; }
+.odysseus-root .od-notes-quick-pill { background:none; border:none; cursor:pointer; font-size:11px;
+  font-weight:600; padding:4px 10px; color:color-mix(in srgb, var(--fg) 55%, transparent); }
+.odysseus-root .od-notes-quick-pill + .od-notes-quick-pill { border-left:1px solid var(--border); }
+.odysseus-root .od-notes-quick-pill:hover { color:var(--fg); }
+.odysseus-root .od-notes-quick-pill.active { color:var(--fg); background:color-mix(in srgb, var(--fg) 10%, transparent); }
+.odysseus-root .od-notes-quick-input { flex:1 1 auto; background:none; border:none; outline:none;
+  font-size:13px; color:var(--fg); padding:4px 2px; font-family:inherit; }
+.odysseus-root .od-notes-quick-input::placeholder { color:color-mix(in srgb, var(--fg) 40%, transparent); }
+
+/* full edit form */
+.odysseus-root .od-note-form { display:flex; flex-direction:column; gap:8px; margin-bottom:12px;
+  border:1px solid color-mix(in srgb, var(--fg) 25%, var(--border)); border-radius:10px; padding:10px;
+  background:var(--card, var(--panel)); }
+.odysseus-root .od-note-form-seg { align-self:flex-start; }
+.odysseus-root .od-note-form-title, .odysseus-root .od-note-form-labels { background:none; border:none;
+  outline:none; font-size:14px; font-weight:600; color:var(--fg); padding:2px 0; font-family:inherit; }
+.odysseus-root .od-note-form-labels { font-size:12px; font-weight:500; color:color-mix(in srgb, var(--fg) 75%, transparent); }
+.odysseus-root .od-note-form-title::placeholder, .odysseus-root .od-note-form-labels::placeholder,
+.odysseus-root .od-note-form-body::placeholder { color:color-mix(in srgb, var(--fg) 38%, transparent); }
+.odysseus-root .od-note-form-body { background:none; border:none; outline:none; resize:vertical;
+  font-size:13px; color:var(--fg); font-family:inherit; line-height:1.5; min-height:60px; }
+.odysseus-root .od-note-form-items { display:flex; flex-direction:column; gap:4px; }
+.odysseus-root .od-note-form-actions { display:flex; justify-content:flex-end; gap:8px; margin-top:4px; }
+
+/* note card */
+.odysseus-root .od-note-card { position:relative; border:1px solid var(--border); border-radius:10px;
+  padding:10px 12px; background:var(--card, var(--panel)); display:flex; flex-direction:column; gap:7px; }
+.odysseus-root .od-note-card.pinned { border-color:color-mix(in srgb, var(--accent, var(--red)) 45%, var(--border)); }
+.odysseus-root .od-note-card.selected { border-color:var(--accent, var(--red));
+  box-shadow:0 0 0 1px var(--accent, var(--red)) inset; }
+.odysseus-root .od-note-card-cb { position:absolute; top:9px; left:9px; }
+.odysseus-root .od-note-pin { position:absolute; top:6px; right:8px; background:none; border:none;
+  cursor:pointer; font-size:13px; line-height:1; opacity:0.45; padding:2px; filter:grayscale(1); }
+.odysseus-root .od-note-pin:hover { opacity:0.9; }
+.odysseus-root .od-note-pin.active { opacity:1; filter:none; }
+.odysseus-root .od-note-card-head { display:flex; align-items:flex-start; gap:8px; padding-right:22px; }
+.odysseus-root .od-note-card-title { background:none; border:none; cursor:pointer; text-align:left;
+  font-size:14px; font-weight:600; color:var(--fg); padding:0; flex:1; font-family:inherit;
+  word-break:break-word; }
+.odysseus-root .od-note-card-title.empty { color:color-mix(in srgb, var(--fg) 40%, transparent); font-weight:500; font-style:italic; }
+.odysseus-root .od-note-card-body { background:none; border:none; cursor:pointer; text-align:left;
+  font-size:13px; color:var(--fg); white-space:pre-wrap; word-break:break-word; padding:0;
+  font-family:inherit; line-height:1.5; }
+
+/* checklist */
+.odysseus-root .od-note-checklist, .odysseus-root .od-note-form-items { display:flex; flex-direction:column; gap:3px; }
+.odysseus-root .od-note-cl-item { display:flex; align-items:center; gap:8px; }
+.odysseus-root .od-note-check { flex-shrink:0; width:16px; height:16px; border-radius:5px;
+  border:1.5px solid color-mix(in srgb, var(--fg) 35%, var(--border)); background:none; cursor:pointer;
+  padding:0; position:relative; }
+.odysseus-root .od-note-check:hover { border-color:var(--fg); }
+.odysseus-root .od-note-cl-item.done .od-note-check { background:var(--ok, #4caf50); border-color:var(--ok, #4caf50); }
+.odysseus-root .od-note-cl-item.done .od-note-check::after { content:""; position:absolute; left:4.5px; top:1px;
+  width:4px; height:8px; border:solid #fff; border-width:0 2px 2px 0; transform:rotate(45deg); }
+.odysseus-root .od-note-check-text { flex:1; font-size:13px; color:var(--fg); word-break:break-word; }
+.odysseus-root .od-note-cl-item.done .od-note-check-text { text-decoration:line-through;
+  color:color-mix(in srgb, var(--fg) 45%, transparent); }
+.odysseus-root .od-note-cl-rm { flex-shrink:0; background:none; border:none; cursor:pointer; font-size:10px;
+  color:color-mix(in srgb, var(--fg) 35%, transparent); padding:2px 4px; opacity:0; }
+.odysseus-root .od-note-cl-item:hover .od-note-cl-rm { opacity:1; }
+.odysseus-root .od-note-cl-rm:hover { color:var(--red); }
+.odysseus-root .od-note-cl-add { background:none; border:none; outline:none; font-size:12px; color:var(--fg);
+  padding:2px 0 2px 24px; font-family:inherit; }
+.odysseus-root .od-note-cl-add::placeholder { color:color-mix(in srgb, var(--fg) 38%, transparent); }
+
+/* card labels (clickable #tag chips) */
+.odysseus-root .od-note-card-labels { display:flex; flex-wrap:wrap; gap:5px; }
+.odysseus-root .od-note-card-chip { background:color-mix(in srgb, var(--fg) 7%, transparent); border:none;
+  border-radius:999px; cursor:pointer; font-size:10.5px; font-weight:600; padding:2px 8px;
+  color:color-mix(in srgb, var(--fg) 70%, transparent); }
+.odysseus-root .od-note-card-chip:hover { color:var(--fg); background:color-mix(in srgb, var(--fg) 12%, transparent); }
+
+/* card footer: color dots + progress + time + actions */
+.odysseus-root .od-note-card-actions { display:flex; align-items:center; gap:8px; margin-top:1px; }
+.odysseus-root .od-note-card-colors, .odysseus-root .od-note-form-colors { display:flex; align-items:center; gap:5px; }
+.odysseus-root .od-note-card-spacer { flex:1 1 auto; }
+.odysseus-root .od-note-card-progress { font-size:11px; font-weight:700;
+  color:color-mix(in srgb, var(--fg) 55%, transparent); }
+.odysseus-root .od-note-card-act { background:none; border:none; cursor:pointer; font-size:13px; line-height:1;
+  padding:2px 5px; border-radius:5px; color:color-mix(in srgb, var(--fg) 45%, transparent); }
+.odysseus-root .od-note-card-act:hover { color:var(--fg); background:color-mix(in srgb, var(--fg) 7%, transparent); }
+.odysseus-root .od-note-card-act.danger:hover { color:var(--red); background:color-mix(in srgb, var(--red) 10%, transparent); }
+
+/* color dots — pale palette mirrors notes.js COLOR_HEX (fixed semantic note tints) */
+.odysseus-root .od-note-color-dot { width:15px; height:15px; border-radius:50%; cursor:pointer;
+  border:1px solid color-mix(in srgb, var(--fg) 20%, transparent); padding:0; box-sizing:border-box;
+  background:var(--border); }
+.odysseus-root .od-note-color-dot.active { box-shadow:0 0 0 2px var(--panel), 0 0 0 3.5px var(--fg); }
+.odysseus-root .od-note-color-dot.od-note-color-red { background:#f0b5ba; }
+.odysseus-root .od-note-color-dot.od-note-color-orange { background:#e8ccb2; }
+.odysseus-root .od-note-color-dot.od-note-color-yellow { background:#f2dfbd; }
+.odysseus-root .od-note-color-dot.od-note-color-green { background:#cce0bc; }
+.odysseus-root .od-note-color-dot.od-note-color-blue { background:#b0d7f7; }
+.odysseus-root .od-note-color-dot.od-note-color-purple { background:#e2bcee; }
+
+/* whole-card tint when a color is set */
+.odysseus-root .od-note-card.od-note-color-red { background:color-mix(in srgb, #f0b5ba 18%, var(--card, var(--panel))); border-color:color-mix(in srgb, #f0b5ba 45%, var(--border)); }
+.odysseus-root .od-note-card.od-note-color-orange { background:color-mix(in srgb, #e8ccb2 18%, var(--card, var(--panel))); border-color:color-mix(in srgb, #e8ccb2 45%, var(--border)); }
+.odysseus-root .od-note-card.od-note-color-yellow { background:color-mix(in srgb, #f2dfbd 18%, var(--card, var(--panel))); border-color:color-mix(in srgb, #f2dfbd 45%, var(--border)); }
+.odysseus-root .od-note-card.od-note-color-green { background:color-mix(in srgb, #cce0bc 18%, var(--card, var(--panel))); border-color:color-mix(in srgb, #cce0bc 45%, var(--border)); }
+.odysseus-root .od-note-card.od-note-color-blue { background:color-mix(in srgb, #b0d7f7 18%, var(--card, var(--panel))); border-color:color-mix(in srgb, #b0d7f7 45%, var(--border)); }
+.odysseus-root .od-note-card.od-note-color-purple { background:color-mix(in srgb, #e2bcee 18%, var(--card, var(--panel))); border-color:color-mix(in srgb, #e2bcee 45%, var(--border)); }
+
+/* ===== fix-wave-A: Composer ===== */
+/* ── Composer: non-interactive model label ──────────────────────────────
+   When the model chip is not wired to a models surface (onOpenModels absent),
+   the composer renders it as a plain label, not a button. Strip the button
+   hover/cursor affordances so it doesn't masquerade as a clickable control.
+   Appends to ODYSSEUS_CSS in odysseus-theme.ts next to .od-model-picker-btn. */
+.odysseus-root .od-model-picker-btn.od-model-picker-static { cursor:default; }
+.odysseus-root .od-model-picker-btn.od-model-picker-static:hover {
+  border-color:transparent; background:none;
+  color:color-mix(in srgb, var(--fg) 40%, transparent); }
+
+/* ===== fix-wave-A: CompareView ===== */
+/* ===== CompareView fix wave (selector pre-flight, overflow, winner/confetti) ===== */
+
+/* HIGH — composer textarea clipped below viewport. The arena overlay is
+   inset:0 inside .odysseus-root (which sits below the top app bar), so the
+   shared .od-search-overlay's 12vh top padding + the panel's 86vh height
+   overflowed the overlay and pushed the composer past the viewport bottom.
+   Scope a tighter padding to the compare overlay and re-cap the panel
+   container-relative so it can never exceed the overlay it lives in.
+   These rules come AFTER the originals in the stylesheet, so at equal
+   specificity they win. */
+.odysseus-root .od-search-overlay.od-compare-overlay { padding: 2vh 0; }
+.odysseus-root .od-search-overlay.od-compare-overlay:not(.od-windowed) > .od-search-panel {
+  max-height: calc(100% - 28px);
+}
+.odysseus-root .od-compare-panel {
+  height: min(86vh, calc(100% - 28px));
+  max-height: calc(100% - 28px);
+}
+
+/* The pane title caret is now a lucide <svg> rather than a glyph span. */
+.odysseus-root svg.od-pane-title-caret {
+  flex-shrink: 0;
+  opacity: 0.35;
+  position: relative;
+  top: 1px;
+}
+.odysseus-root .od-pane-title-btn:hover svg.od-pane-title-caret { opacity: 0.7; }
+.odysseus-root .od-pane-title-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+.odysseus-root .od-pane-action-btn:disabled { opacity: 0.18; cursor: not-allowed; }
+.odysseus-root .od-pane-action-btn:disabled:hover { background: none; opacity: 0.18; }
+
+/* Winner / loser decoration — style.css .compare-pane.winner/.loser */
+.odysseus-root .od-compare-pane.winner .od-pane-header {
+  background: color-mix(in srgb, var(--red) 12%, transparent);
+  border-bottom-color: color-mix(in srgb, var(--red) 30%, var(--border));
+}
+.odysseus-root .od-compare-pane.winner .od-pane-title-name { color: var(--red); }
+.odysseus-root .od-compare-pane.loser .od-pane-header { opacity: 0.5; }
+.odysseus-root .od-pane-winner-star { color: var(--red); flex-shrink: 0; }
+.odysseus-root .od-pane-loser-mark { opacity: 0.5; flex-shrink: 0; }
+.odysseus-root .od-pane-winner-tag {
+  color: var(--red);
+  font-size: 0.82em;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  position: relative;
+  top: -1px;
+  flex-shrink: 0;
+}
+
+/* Confetti — style.css .confetti-piece (fixed-position particle, no color rule;
+   colors are set inline from the celebratory palette). */
+.odysseus-root ~ .od-confetti-piece,
+.od-confetti-piece {
+  position: fixed;
+  pointer-events: none;
+  z-index: 1000000;
+}
+
+/* Model-swap dropdown search input (odysseus _showModelSwapDropdown, >5 models) */
+.odysseus-root .od-pane-model-search {
+  width: 100%;
+  padding: 6px 8px;
+  margin-bottom: 4px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.78em;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+.odysseus-root .od-pane-model-search::placeholder { color: color-mix(in srgb, var(--fg) 40%, transparent); }
+.odysseus-root .od-pane-model-search:focus { outline: none; border-color: var(--accent, var(--fg)); }
+
+/* ── Pre-flight selector modal (compare/selector.js showModelSelector) ── */
+.odysseus-root .od-cmp-selector {
+  width: min(520px, 92vw);
+  max-width: 92vw;
+  max-height: 83vh;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+.odysseus-root .od-cmp-sel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.odysseus-root .od-cmp-sel-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.odysseus-root .od-cmp-sel-close {
+  background: none;
+  border: none;
+  color: var(--fg);
+  opacity: 0.6;
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+.odysseus-root .od-cmp-sel-close:hover { opacity: 1; background: color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-cmp-sel-body {
+  padding: 12px 16px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.odysseus-root .od-cmp-sel-desc {
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  font-size: 0.85em;
+  margin: 0 0 12px;
+}
+.odysseus-root .od-cmp-sel-section { margin-bottom: 14px; }
+.odysseus-root .od-cmp-sel-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.5;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+.odysseus-root .od-cmp-sel-toggles { display: flex; gap: 4px; flex-wrap: wrap; }
+.odysseus-root .od-cmp-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  font-size: 11px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: all 0.15s;
+}
+.odysseus-root .od-cmp-toggle:hover { opacity: 1; border-color: var(--fg); }
+.odysseus-root .od-cmp-toggle.active {
+  opacity: 1;
+  border-color: var(--accent, var(--fg));
+  background: color-mix(in srgb, var(--accent, var(--fg)) 12%, transparent);
+}
+.odysseus-root .od-cmp-sel-tabs { display: flex; gap: 4px; }
+.odysseus-root .od-cmp-sel-tab {
+  padding: 5px 14px;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: default;
+}
+.odysseus-root .od-cmp-sel-tab.active {
+  border-color: var(--accent, var(--fg));
+  background: color-mix(in srgb, var(--accent, var(--fg)) 12%, transparent);
+}
+.odysseus-root .od-cmp-sel-rows { display: flex; flex-direction: column; gap: 6px; }
+.odysseus-root .od-cmp-sel-row { display: flex; align-items: center; gap: 6px; }
+.odysseus-root .od-cmp-sel-rowlabel {
+  flex-shrink: 0;
+  width: 18px;
+  text-align: center;
+  font-size: 0.82em;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--fg) 70%, transparent);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.odysseus-root .od-cmp-form-control {
+  padding: 5px 8px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.82em;
+  font-family: inherit;
+  box-sizing: border-box;
+}
+.odysseus-root .od-cmp-form-control:focus { outline: none; border-color: var(--accent, var(--fg)); }
+.odysseus-root .od-cmp-prov-select { flex-shrink: 0; width: 92px; }
+.odysseus-root .od-cmp-model-select { flex: 1 1 auto; min-width: 0; }
+.odysseus-root .od-cmp-sel-noslot {
+  flex: 1 1 auto;
+  font-size: 0.8em;
+  font-style: italic;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+.odysseus-root .od-cmp-picker { flex: 1 1 auto; position: relative; min-width: 0; }
+.odysseus-root .od-cmp-picker .od-cmp-form-control { width: 100%; }
+.odysseus-root .od-cmp-picker-dropdown {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  max-height: 200px;
+  overflow-y: auto;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  z-index: 100;
+  padding: 4px;
+}
+.odysseus-root .od-cmp-picker-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 6px 10px;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: var(--fg);
+  font-size: 0.82em;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.odysseus-root .od-cmp-picker-item:hover { background: color-mix(in srgb, var(--fg) 10%, transparent); }
+.odysseus-root .od-cmp-picker-item.current { color: var(--red); font-weight: 600; }
+.odysseus-root .od-cmp-picker-empty {
+  padding: 8px 12px;
+  font-size: 0.8em;
+  font-style: italic;
+  color: color-mix(in srgb, var(--fg) 40%, transparent);
+}
+.odysseus-root .od-cmp-rm-btn {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--fg);
+  opacity: 0.3;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 6px;
+  font-family: inherit;
+}
+.odysseus-root .od-cmp-rm-btn:hover { opacity: 1; color: var(--red); }
+.odysseus-root .od-cmp-add-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  margin-top: 8px;
+  padding: 6px 12px;
+  background: none;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  font-size: 0.82em;
+  font-family: inherit;
+  cursor: pointer;
+  opacity: 0.6;
+  transition: opacity 0.15s;
+}
+.odysseus-root .od-cmp-add-btn:hover { opacity: 1; }
+.odysseus-root .od-cmp-sel-footer-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+.odysseus-root .od-cmp-sel-timeout-label,
+.odysseus-root .od-cmp-sel-timeout-suffix {
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  font-size: 0.82em;
+}
+.odysseus-root .od-cmp-sel-timeout-input {
+  width: 60px;
+  padding: 4px 8px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 0.82em;
+  font-family: inherit;
+  text-align: center;
+}
+.odysseus-root .od-cmp-sel-timeout-input:focus { outline: none; border-color: var(--accent, var(--fg)); }
+.odysseus-root .od-cmp-sel-score-btn {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.82em;
+  font-family: inherit;
+  opacity: 0.7;
+  transition: opacity 0.15s;
+}
+.odysseus-root .od-cmp-sel-score-btn:hover { opacity: 1; }
+.odysseus-root .od-cmp-sel-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.odysseus-root .od-cmp-sel-start {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 16px;
+  box-sizing: border-box;
+  background: var(--accent, var(--red));
+  color: var(--bg);
+  border: 1px solid var(--accent, var(--red));
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.odysseus-root .od-cmp-sel-start:hover:not(:disabled) { opacity: 0.85; }
+.odysseus-root .od-cmp-sel-start:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* Shuffle-pool editor (compare/index.js showShufflePoolEditor) */
+.odysseus-root .od-cmp-pool { width: min(420px, 92vw); }
+.odysseus-root .od-cmp-pool-list { max-height: 400px; overflow-y: auto; }
+.odysseus-root .od-cmp-pool-heading {
+  font-size: 0.78em;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--fg) 50%, transparent);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 8px 4px 4px;
+}
+.odysseus-root .od-cmp-pool-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 4px;
+  cursor: pointer;
+  font-size: 0.85em;
+  color: var(--fg);
+  border-radius: 4px;
+}
+.odysseus-root .od-cmp-pool-row:hover { background: color-mix(in srgb, var(--fg) 4%, transparent); }
+/* ===== fix-wave-A: CalendarView ===== */
+/* ── Calendar: new surfaces (event form, settings modal, empty state, more-menu, week/year/agenda views). Scoped, theme vars only. ── */
+
+/* +New small variant used in the day-detail header */
+.odysseus-root button.od-cal-add-btn.od-cal-add-btn-text.od-cal-add-btn-sm { height:20px; padding:0 8px 0 5px; border-radius:10px; }
+.odysseus-root .od-cal-add-btn-sm .od-cal-add-label { font-size:10px; }
+
+/* refresh spin */
+@keyframes od-cal-spin { to { transform:rotate(360deg); } }
+.odysseus-root button.od-cal-nav.od-cal-syncing svg { animation:od-cal-spin 0.8s linear infinite; }
+
+/* +N more (renamed from od-cal-event-more to avoid colliding with the more-button) */
+.odysseus-root .od-cal-event-more-count { font-size:8px; opacity:0.4; padding-left:6px; display:block; }
+
+/* day-detail event row: clickable info + more button */
+.odysseus-root .od-cal-event-info-btn { background:none; border:none; text-align:left; cursor:pointer; font-family:inherit; padding:0; color:var(--fg); }
+.odysseus-root .od-cal-event-more-btn { background:none; border:none; color:var(--fg); opacity:0.4; cursor:pointer; font-size:15px; line-height:1; padding:0 4px; align-self:flex-start; border-radius:4px; }
+.odysseus-root .od-cal-event-more-btn:hover { opacity:0.9; background:color-mix(in srgb, var(--fg) 8%, transparent); }
+
+/* event more-menu dropdown */
+.odysseus-root .od-cal-event-dropdown { position:fixed; z-index:60; min-width:150px; background:var(--panel, var(--bg)); border:1px solid var(--border); border-radius:8px; box-shadow:0 8px 24px rgba(0,0,0,0.3); padding:4px; display:flex; flex-direction:column; }
+.odysseus-root .od-cal-dropdown-item { display:flex; align-items:center; gap:6px; width:100%; text-align:left; background:none; border:none; color:var(--fg); font-family:inherit; font-size:12px; padding:7px 10px; border-radius:5px; cursor:pointer; }
+.odysseus-root .od-cal-dropdown-item:hover { background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-cal-dropdown-item.od-cal-dropdown-danger { color:var(--red); }
+
+/* event form (bespoke) */
+.odysseus-root .od-cal-form { flex:1; min-height:0; overflow-y:auto; display:flex; flex-direction:column; gap:10px; padding:4px 2px; }
+.odysseus-root .od-cal-hero { display:flex; flex-direction:column; align-items:center; gap:2px; padding:8px 0 2px; }
+.odysseus-root .od-cal-hero-time { font-size:22px; font-weight:700; color:var(--accent, var(--fg)); font-variant-numeric:tabular-nums; }
+.odysseus-root .od-cal-hero-date { font-size:12px; opacity:0.6; color:var(--fg); }
+.odysseus-root .od-cal-title-wrap { display:flex; justify-content:center; }
+.odysseus-root .od-cal-hero-title { font-size:16px; font-weight:600; text-align:center; }
+.odysseus-root .od-cal-input { background:color-mix(in srgb, var(--fg) 5%, transparent); border:1px solid var(--border); border-radius:6px; padding:6px 8px; color:var(--fg); font-family:inherit; font-size:12px; box-sizing:border-box; }
+.odysseus-root .od-cal-input:focus { outline:none; border-color:var(--accent, var(--border)); }
+.odysseus-root textarea.od-cal-input { resize:vertical; min-height:42px; }
+.odysseus-root .od-cal-hero-title { background:none; border:none; border-bottom:1px solid var(--border); border-radius:0; }
+.odysseus-root .od-cal-form-details { display:flex; flex-direction:column; gap:8px; }
+.odysseus-root .od-cal-form-row { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+.odysseus-root .od-cal-form-row .od-cal-input[type="date"], .odysseus-root .od-cal-form-row .od-cal-input[type="time"] { flex:1; min-width:90px; }
+.odysseus-root .od-cal-form-to { opacity:0.35; font-size:12px; }
+.odysseus-root .od-cal-allday-ctrl { display:inline-flex; align-items:center; gap:6px; font-size:11px; opacity:0.7; margin-left:auto; cursor:pointer; color:var(--fg); }
+.odysseus-root .od-cal-loc-map { font-size:11px; color:var(--accent, var(--red)); text-decoration:none; font-weight:600; flex-shrink:0; }
+.odysseus-root .od-cal-form-actions { display:flex; gap:8px; justify-content:flex-end; align-items:center; margin-top:auto; padding-top:6px; }
+.odysseus-root .od-cal-btn { background:color-mix(in srgb, var(--fg) 8%, transparent); border:1px solid var(--border); color:var(--fg); border-radius:6px; padding:6px 14px; font-family:inherit; font-size:12px; cursor:pointer; }
+.odysseus-root .od-cal-btn:hover { background:color-mix(in srgb, var(--fg) 14%, transparent); }
+.odysseus-root .od-cal-btn.od-cal-btn-primary { background:var(--accent, var(--red)); border-color:var(--accent, var(--red)); color:var(--bg); font-weight:600; }
+.odysseus-root .od-cal-btn.od-cal-btn-primary:hover { filter:brightness(1.08); }
+.odysseus-root .od-cal-btn.od-cal-btn-danger { color:var(--red); margin-right:auto; }
+
+/* settings modal */
+.odysseus-root .od-cal-settings-overlay { position:fixed; inset:0; z-index:70; display:flex; align-items:center; justify-content:center; }
+.odysseus-root .od-cal-settings-backdrop { position:absolute; inset:0; background:rgba(0,0,0,0.45); border:none; cursor:default; }
+.odysseus-root .od-cal-settings-modal { position:relative; z-index:1; width:420px; max-width:92vw; max-height:88vh; overflow-y:auto; background:var(--panel); border:1px solid var(--border); border-radius:12px; box-shadow:0 12px 40px rgba(0,0,0,0.4); }
+.odysseus-root .od-cal-settings-head { display:flex; align-items:center; justify-content:space-between; padding:12px 16px; border-bottom:1px solid var(--border); font-size:13px; font-weight:600; color:var(--fg); }
+.odysseus-root .od-cal-settings-close { background:none; border:none; color:var(--fg); opacity:0.6; cursor:pointer; display:inline-flex; padding:2px; border-radius:4px; }
+.odysseus-root .od-cal-settings-close:hover { opacity:1; background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-cal-settings-body { padding:16px; display:flex; flex-direction:column; gap:16px; }
+.odysseus-root .od-cal-settings-divided { border-top:1px solid var(--border); padding-top:12px; }
+.odysseus-root .od-cal-settings-label { font-size:11px; opacity:0.5; margin-bottom:6px; color:var(--fg); }
+.odysseus-root .od-cal-settings-list { display:flex; flex-direction:column; gap:4px; }
+.odysseus-root .od-cal-settings-row { display:flex; align-items:center; gap:8px; padding:6px 8px; border-radius:6px; background:color-mix(in srgb, var(--fg) 4%, transparent); }
+.odysseus-root .od-cal-s-color { width:24px; height:24px; border:none; background:none; cursor:pointer; padding:0; border-radius:50%; overflow:hidden; flex-shrink:0; }
+.odysseus-root .od-cal-s-name-input { flex:1; min-width:0; background:none; border:1px solid var(--border); border-radius:4px; padding:3px 6px; color:var(--fg); font-size:12px; font-family:inherit; }
+.odysseus-root .od-cal-s-del { background:none; border:none; color:var(--red); opacity:0.75; cursor:pointer; padding:2px; display:inline-flex; flex-shrink:0; }
+.odysseus-root .od-cal-s-del:hover { opacity:1; }
+.odysseus-root .od-cal-settings-btn { display:inline-flex; align-items:center; gap:4px; background:color-mix(in srgb, var(--fg) 8%, transparent); border:1px solid var(--border); color:var(--fg); border-radius:6px; padding:5px 10px; font-size:11px; font-family:inherit; cursor:pointer; }
+.odysseus-root .od-cal-settings-btn:hover { background:color-mix(in srgb, var(--fg) 14%, transparent); }
+.odysseus-root .od-cal-settings-import-row, .odysseus-root .od-cal-settings-export-row { display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
+.odysseus-root .od-cal-import-target { font-size:11px; padding:4px 6px; }
+.odysseus-root .od-cal-settings-status { font-size:11px; opacity:0.6; color:var(--fg); }
+.odysseus-root .od-cal-settings-hint { font-size:10px; opacity:0.4; margin-top:4px; color:var(--fg); }
+.odysseus-root .od-cal-hidden-file { display:none; }
+
+/* empty state */
+.odysseus-root .od-cal-empty-state { flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:8px; text-align:center; padding:24px; color:var(--fg); }
+.odysseus-root .od-cal-empty-ico { opacity:0.3; }
+.odysseus-root .od-cal-empty-title { font-size:14px; font-weight:600; }
+.odysseus-root .od-cal-empty-msg { font-size:12px; opacity:0.55; max-width:280px; }
+.odysseus-root .od-cal-empty-actions { display:flex; gap:8px; justify-content:center; flex-wrap:wrap; margin-top:4px; }
+
+/* week view */
+.odysseus-root .od-cal-wk-wrap { flex:1 1 auto; min-height:0; overflow-y:auto; display:flex; background:color-mix(in srgb, var(--fg) 8%, transparent); border-radius:6px; }
+.odysseus-root .od-cal-wk-rail { flex-shrink:0; width:46px; display:flex; flex-direction:column; }
+.odysseus-root .od-cal-wk-rail-spacer { height:38px; flex-shrink:0; }
+.odysseus-root .od-cal-wk-rail-cell { display:flex; justify-content:flex-end; padding-right:5px; box-sizing:border-box; }
+.odysseus-root .od-cal-wk-rail-cell span { font-size:9px; opacity:0.4; position:relative; top:-5px; color:var(--fg); }
+.odysseus-root .od-cal-wk-cols { flex:1; display:grid; grid-template-columns:repeat(7,1fr); gap:1px; min-width:0; }
+.odysseus-root .od-cal-wk-col { background:var(--bg); min-width:0; display:flex; flex-direction:column; }
+.odysseus-root .od-cal-wk-col.od-cal-wk-today { background:color-mix(in srgb, var(--accent, var(--red)) 7%, var(--bg)); }
+.odysseus-root .od-cal-wk-col-head { height:38px; display:flex; flex-direction:column; align-items:center; justify-content:center; border-bottom:1px solid var(--border); flex-shrink:0; }
+.odysseus-root .od-cal-wk-dn { font-size:9px; font-weight:600; opacity:0.45; color:var(--fg); }
+.odysseus-root .od-cal-wk-dt { font-size:13px; font-weight:600; color:var(--fg); }
+.odysseus-root .od-cal-wk-today .od-cal-wk-dt { color:var(--accent, var(--red)); }
+.odysseus-root .od-cal-wk-allday { display:flex; flex-direction:column; gap:1px; padding:1px; min-height:2px; }
+.odysseus-root .od-cal-wk-allday-event { font-size:9px; color:var(--bg); border:none; border-radius:3px; padding:1px 3px; text-align:left; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; cursor:pointer; font-family:inherit; }
+.odysseus-root .od-cal-wk-grid { position:relative; flex:1; }
+.odysseus-root .od-cal-wk-cell { border-bottom:1px solid color-mix(in srgb, var(--fg) 6%, transparent); box-sizing:border-box; }
+.odysseus-root .od-cal-wk-event { position:absolute; left:1px; right:1px; border:none; border-left:3px solid; border-radius:3px; padding:1px 4px; text-align:left; overflow:hidden; cursor:pointer; font-family:inherit; display:flex; flex-direction:column; color:var(--fg); }
+.odysseus-root .od-cal-wk-event-time { font-size:8px; opacity:0.6; font-variant-numeric:tabular-nums; }
+.odysseus-root .od-cal-wk-event-name { font-size:9px; font-weight:500; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+
+/* year view */
+.odysseus-root .od-cal-year { flex:1 1 auto; min-height:0; overflow-y:auto; display:grid; grid-template-columns:repeat(auto-fill, minmax(150px, 1fr)); gap:10px; padding:2px; }
+.odysseus-root .od-cal-year-month { background:color-mix(in srgb, var(--fg) 4%, transparent); border:1px solid var(--border); border-radius:8px; padding:8px; cursor:pointer; font-family:inherit; text-align:left; color:var(--fg); }
+.odysseus-root .od-cal-year-month:hover { background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-cal-year-month-title { font-size:11px; font-weight:600; margin-bottom:5px; color:var(--accent, var(--fg)); }
+.odysseus-root .od-cal-year-grid { display:grid; grid-template-columns:repeat(7,1fr); gap:1px; }
+.odysseus-root .od-cal-year-wd { font-size:7px; opacity:0.35; text-align:center; color:var(--fg); }
+.odysseus-root .od-cal-year-cell { font-size:8px; text-align:center; aspect-ratio:1; display:flex; align-items:center; justify-content:center; border-radius:50%; color:var(--fg); }
+.odysseus-root .od-cal-year-day { opacity:0.65; }
+.odysseus-root .od-cal-year-has { font-weight:700; opacity:1; background:color-mix(in srgb, var(--accent, var(--fg)) 22%, transparent); }
+.odysseus-root .od-cal-year-today { background:var(--accent, var(--red)); color:var(--bg); font-weight:800; opacity:1; }
+
+/* agenda view */
+.odysseus-root .od-cal-agenda { flex:1 1 auto; min-height:0; overflow-y:auto; display:flex; flex-direction:column; gap:4px; padding:2px; }
+.odysseus-root .od-cal-agenda-day { padding:4px 0; }
+.odysseus-root .od-cal-agenda-date { font-size:11px; font-weight:600; opacity:0.7; padding:4px 2px; display:flex; align-items:center; gap:8px; color:var(--fg); border-bottom:1px solid var(--border); margin-bottom:2px; }
+.odysseus-root .od-cal-agenda-day.is-today .od-cal-agenda-date { opacity:1; color:var(--accent, var(--fg)); }
+.odysseus-root .od-cal-agenda-today-badge { font-size:9px; font-weight:700; background:var(--accent, var(--red)); color:var(--bg); border-radius:8px; padding:1px 6px; }
+.odysseus-root .od-cal-agenda-empty { font-size:11px; opacity:0.3; padding:2px; color:var(--fg); }
+.odysseus-root .od-cal-agenda-event { display:flex; gap:8px; align-items:flex-start; padding:6px 8px; border-radius:5px; background:none; border:none; width:100%; text-align:left; cursor:pointer; font-family:inherit; color:var(--fg); }
+.odysseus-root .od-cal-agenda-event:hover { background:color-mix(in srgb, var(--fg) 6%, transparent); }
+/* ===== fix-wave-A: ChatMessages ===== */
+/* ===== wave4: ChatMessages (footer) =====
+   Replaces the old citation-box CSS that backed the now-deleted AgentSources
+   surface (see shellWiring — the integrator should remove the dead
+   .od-sources-section / .od-source-link / .od-rag-sources block, which also
+   used forbidden raw-unicode 'content:'\\NNNN'' escapes). Faithful to odysseus
+   style.css .msg-footer / .msg-actions / .footer-copy-btn, rescoped under
+   .odysseus-root with theme vars. The copy/check glyphs are lucide icons, so no
+   CSS 'content' escapes are used. */
+.odysseus-root .od-msg-group { display: flex; flex-direction: column; }
+
+/* Footer sits flush under the assistant bubble, indented to the bubble's left
+   edge (.od-msg-ai has margin-left:8px). Hidden at rest, revealed on group
+   hover / keyboard focus, and kept visible briefly after a copy. */
+.odysseus-root .od-msg-footer {
+  display: flex; align-items: center; gap: 6px;
+  margin: -2px 0 10px 8px;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+  font-size: 0.75rem;
+  opacity: 0; transition: opacity 0.15s ease;
+}
+.odysseus-root .od-msg-group:hover .od-msg-footer,
+.odysseus-root .od-msg-footer:focus-within { opacity: 1; }
+.odysseus-root .od-msg-actions { display: inline-flex; align-items: center; gap: 4px; }
+.odysseus-root .od-footer-copy-btn {
+  background: none; border: none; cursor: pointer;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+  padding: 2px 6px; border-radius: 4px; line-height: 1;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: color 0.15s ease;
+}
+.odysseus-root .od-footer-copy-btn:hover { color: var(--accent, var(--red)); }
+.odysseus-root .od-footer-copy-btn:focus-visible {
+  outline: none; color: var(--accent, var(--red));
+}
+/* Copied success state mirrors --ok and keeps the footer pinned visible. */
+.odysseus-root .od-footer-copy-btn[data-copied="true"] { color: var(--ok, var(--accent, var(--red))); }
+
+/* ===== fix-wave-A: GroupChatView ===== */
+/* ── GroupChatView fixwave: per-participant dots, run-stacking, participant mgmt ── */
+/* Finding #1: the .msg-group role already gets a generic ::before dot in
+   var(--model-dot); our explicit .od-group-role-dot span carries the real
+   per-participant colour, so suppress the generic pseudo-dot to avoid a double
+   dot and let the hashed colour be the single source of truth. */
+.odysseus-root .od-msg-group .od-role::before { display: none; }
+/* Finding #2: stacked .od-body blocks inside one coalesced group bubble flow as
+   one turn — separate the runs' paragraphs with a small gap, not a new bubble. */
+.odysseus-root .od-msg-group .od-body + .od-body { margin-top: 8px; }
+
+/* Finding #3: roster header becomes a flex row to seat the add (+) button. */
+.odysseus-root .od-group-roster-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.odysseus-root .od-group-roster-add {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 5px;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+  color: color-mix(in srgb, var(--fg) 60%, transparent);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.odysseus-root .od-group-roster-add:hover {
+  background: color-mix(in srgb, var(--accent, var(--red)) 14%, transparent);
+  color: var(--fg);
+}
+/* odysseus's faint per-row remove X (opacity 0.5, brightens on hover). */
+.odysseus-root .od-group-participant-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0;
+  width: 18px;
+  height: 18px;
+  border: none;
+  border-radius: 4px;
+  background: none;
+  color: var(--fg);
+  opacity: 0.4;
+  cursor: pointer;
+  transition: opacity 0.12s, background 0.12s;
+}
+.odysseus-root .od-group-participant-remove:hover:not(:disabled) {
+  opacity: 1;
+  background: color-mix(in srgb, var(--red) 16%, transparent);
+}
+.odysseus-root .od-group-participant-remove:disabled {
+  opacity: 0.25;
+  cursor: not-allowed;
+}
+/* Add-participant row — mirrors odysseus's inline picker (color-mix bg, 6px radius). */
+.odysseus-root .od-group-add {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0 6px 8px;
+  padding: 8px;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+  border: 1px solid var(--border);
+}
+.odysseus-root .od-group-add-input {
+  height: 26px;
+  padding: 0 8px;
+  font-size: 11px;
+  font-family: inherit;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  background: var(--input-bg, var(--bg));
+  color: var(--fg);
+  outline: none;
+}
+.odysseus-root .od-group-add-input:focus {
+  border-color: var(--accent, var(--red));
+}
+.odysseus-root .od-group-add-error {
+  font-size: 11px;
+  line-height: 1.35;
+  color: var(--red);
+}
+.odysseus-root .od-group-add-foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+.odysseus-root .od-group-add-cancel,
+.odysseus-root .od-group-add-submit {
+  height: 24px;
+  padding: 0 10px;
+  font-size: 11px;
+  font-weight: 500;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: filter 0.12s, background 0.12s, opacity 0.12s;
+}
+.odysseus-root .od-group-add-cancel {
+  border: 1px solid var(--border);
+  background: none;
+  color: color-mix(in srgb, var(--fg) 65%, transparent);
+}
+.odysseus-root .od-group-add-cancel:hover {
+  background: color-mix(in srgb, var(--fg) 6%, transparent);
+  color: var(--fg);
+}
+.odysseus-root .od-group-add-submit {
+  border: none;
+  background: var(--accent, var(--red));
+  color: #fff;
+}
+.odysseus-root .od-group-add-submit:hover:not(:disabled) { filter: brightness(1.1); }
+.odysseus-root .od-group-add-submit:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Finding #4: inline send-failure notice under the composer. */
+.odysseus-root .od-group-send-error {
+  padding: 0 14px 8px;
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--red);
+  flex-shrink: 0;
+}
+/* ===== fix-wave-A: EmailView ===== */
+/* ── EmailView fix wave: empty-state symmetry, per-row done + ⋮ menu, bulk bar,
+   reader attachments, signature draw-new + capture pad. Overrides of existing
+   .od-email-list / .od-email-empty rely on later-in-cascade equal-specificity
+   winning (this block is appended after the base email rules). ── */
+
+/* med #1: list becomes a flex column so the empty state can center in the full
+   column height (was top-aligned with a void below). */
+.odysseus-root .od-email-list { display: flex; flex-direction: column; }
+.odysseus-root .od-email-empty {
+  flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center;
+  gap: 4px; padding: 28px 16px; text-align: center;
+}
+
+/* Row hosts the clickable open-button + done check + ⋮ menu as flex siblings. */
+.odysseus-root .od-email-item-open {
+  flex: 1; min-width: 0; display: flex; align-items: flex-start; gap: 8px; text-align: left;
+  background: none; border: none; padding: 0; margin: 0; cursor: pointer; color: inherit; font: inherit;
+}
+.odysseus-root .od-email-row-check {
+  flex-shrink: 0; margin-top: 4px; accent-color: var(--accent, var(--red)); cursor: pointer;
+}
+.odysseus-root .od-email-item.od-email-row-selected {
+  background: color-mix(in srgb, var(--accent, var(--red)) 8%, transparent);
+}
+
+/* high: per-row Mark-done check toggle. Dim by default, brightens on hover, accent when active. */
+.odysseus-root .od-email-done {
+  flex-shrink: 0; display: inline-flex; align-items: center; justify-content: center;
+  width: 18px; height: 18px; margin-top: 1px; padding: 0; border-radius: 5px;
+  background: none; border: 1px solid transparent; cursor: pointer;
+  color: color-mix(in srgb, var(--fg) 35%, transparent); opacity: 0; transition: opacity 0.15s, color 0.15s, border-color 0.15s;
+}
+.odysseus-root .od-email-item:hover .od-email-done { opacity: 1; }
+.odysseus-root .od-email-done:hover { color: var(--fg); border-color: var(--border); }
+.odysseus-root .od-email-done.active {
+  opacity: 1; color: var(--ok, var(--accent, var(--red))); border-color: transparent;
+}
+
+/* ⋮ menu anchor (existing .od-email-item-menu keeps its hover-reveal; add the popover anchor). */
+.odysseus-root .od-email-item-menu { position: relative; }
+.odysseus-root .od-email-item-menu-btn {
+  display: inline-flex; align-items: center; justify-content: center; padding: 2px; border-radius: 5px;
+  background: none; border: 1px solid transparent; color: var(--fg); cursor: pointer; transition: border-color 0.15s;
+}
+.odysseus-root .od-email-item-menu-btn:hover { border-color: var(--border); }
+/* Keep the menu column visible while its dropdown is open even when not hovered. */
+.odysseus-root .od-email-menu-anchor { position: relative; }
+
+/* high: per-email ⋮ dropdown (mirrors emailLibrary.js _showCardMenu / .email-card-dropdown). */
+.odysseus-root .od-email-dropdown {
+  position: absolute; top: 100%; right: 0; z-index: 1000; width: max-content; min-width: 150px; padding: 4px;
+  background: var(--panel); border: 1px solid var(--border); border-radius: 8px; box-shadow: 0 8px 24px rgba(0,0,0,0.3);
+  font-size: 12px; display: flex; flex-direction: column;
+}
+.odysseus-root .od-email-dropdown-item {
+  display: flex; align-items: center; gap: 7px; width: 100%; text-align: left; padding: 6px 10px;
+  border: none; background: none; color: var(--fg); font-size: 12px; border-radius: 4px; cursor: pointer; font-family: inherit;
+}
+.odysseus-root .od-email-dropdown-item:hover { background: color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-email-dropdown-danger { color: var(--red); }
+.odysseus-root .od-email-dropdown-header {
+  padding: 6px 10px 4px; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px;
+  opacity: 0.5; color: var(--fg); pointer-events: none;
+}
+.odysseus-root .od-email-dropdown-sub { margin-left: auto; font-size: 10px; opacity: 0.5; }
+.odysseus-root .od-email-dropdown-arrow { margin-left: auto; opacity: 0.5; }
+.odysseus-root .od-email-dropdown-bullet {
+  display: inline-flex; width: 14px; justify-content: center; font-size: 15px; line-height: 1; color: var(--fg);
+}
+
+/* Text label sitting beside an icon inside a toolbar button (Clear / Delete). */
+.odysseus-root .od-email-tbtn-label { margin-left: 4px; font-size: 11px; }
+
+/* med: bulk-select bar (mirrors .memory-bulk-bar / email-lib-bulk). */
+.odysseus-root .od-email-bulk {
+  display: flex; align-items: center; gap: 8px; padding: 6px 8px; border-radius: 8px; font-size: 11px;
+  border: 1px solid color-mix(in srgb, var(--red) 30%, transparent);
+  background: color-mix(in srgb, var(--red) 5%, transparent);
+}
+.odysseus-root .od-email-bulk-all { display: inline-flex; align-items: center; gap: 6px; color: var(--fg); cursor: pointer; }
+.odysseus-root .od-email-bulk-all input { accent-color: var(--accent, var(--red)); cursor: pointer; }
+.odysseus-root .od-email-bulk-count { color: color-mix(in srgb, var(--fg) 70%, transparent); }
+.odysseus-root .od-email-bulk-actions-wrap { position: relative; }
+.odysseus-root .od-email-bulk-actions-wrap .od-email-dropdown { left: 0; right: auto; }
+.odysseus-root .od-email-bulk-delete { margin-left: auto; }
+.odysseus-root .od-email-bulk-delete:not(:disabled):hover { border-color: var(--red); color: var(--red); }
+.odysseus-root .od-email-tbtn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* med: reader collapsible attachments (mirrors .email-reader-atts-wrap). */
+.odysseus-root .od-email-atts-wrap {
+  border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent); flex-shrink: 0;
+}
+.odysseus-root .od-email-atts-header {
+  display: flex; align-items: center; gap: 6px; width: 100%; padding: 8px 14px; font-size: 11px;
+  background: none; border: none; color: color-mix(in srgb, var(--fg) 75%, transparent); cursor: pointer; font-family: inherit;
+}
+.odysseus-root .od-email-atts-chevron { margin-left: auto; transition: transform 0.15s ease; }
+.odysseus-root .od-email-atts-wrap.collapsed .od-email-atts-chevron { transform: rotate(-90deg); }
+.odysseus-root .od-email-atts-wrap.collapsed .od-email-atts { display: none; }
+.odysseus-root .od-email-atts { display: flex; flex-wrap: wrap; gap: 6px; padding: 0 14px 10px; }
+.odysseus-root .od-email-att-chip {
+  display: inline-flex; align-items: center; gap: 6px; max-width: 100%; padding: 4px 9px; border-radius: 14px;
+  font-size: 11px; background: color-mix(in srgb, var(--fg) 6%, transparent); border: 1px solid var(--border);
+  color: var(--fg); cursor: pointer; transition: border-color 0.15s;
+}
+.odysseus-root .od-email-att-chip:not(:disabled):hover { border-color: var(--accent, var(--red)); }
+.odysseus-root .od-email-att-chip:disabled { cursor: default; opacity: 0.7; }
+.odysseus-root .od-email-att-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 160px; }
+.odysseus-root .od-email-att-size { opacity: 0.5; font-size: 10px; }
+
+/* med: signature picker "Draw new" tile + per-tile delete (signature.js pick). */
+.odysseus-root .od-email-sig-new {
+  display: flex; align-items: center; justify-content: center; gap: 6px; width: 100%; margin: 10px 0 12px;
+  padding: 8px; border-radius: 6px; font-size: 12px; font-weight: 600;
+  background: var(--accent, var(--red)); color: #fff; border: none; cursor: pointer; transition: opacity 0.15s;
+}
+.odysseus-root .od-email-sig-new:hover { opacity: 0.9; }
+.odysseus-root .od-email-sig-tile-wrap { position: relative; display: flex; }
+.odysseus-root .od-email-sig-tile-wrap .od-email-sig-tile { flex: 1; }
+.odysseus-root .od-email-sig-del {
+  position: absolute; top: 2px; right: 2px; width: 18px; height: 18px; display: inline-flex; align-items: center;
+  justify-content: center; padding: 0; border-radius: 50%; background: var(--panel); border: 1px solid var(--border);
+  color: color-mix(in srgb, var(--fg) 60%, transparent); cursor: pointer; transition: color 0.15s, border-color 0.15s;
+}
+.odysseus-root .od-email-sig-del:hover { color: var(--red); border-color: var(--red); }
+
+/* med: signature capture pad (signature.js capture). */
+.odysseus-root .od-email-sig-capture { width: min(560px, 92%); }
+.odysseus-root .od-email-sig-canvas {
+  width: 100%; height: auto; aspect-ratio: 900 / 280; margin-top: 12px; border-radius: 8px;
+  background: var(--card, var(--bg)); border: 1px solid var(--border); color: var(--fg); touch-action: none; cursor: crosshair;
+}
+.odysseus-root .od-email-sig-smooth { display: flex; align-items: center; gap: 10px; margin-top: 10px; font-size: 11px; }
+.odysseus-root .od-email-sig-smooth-label { white-space: nowrap; opacity: 0.8; color: var(--fg); }
+.odysseus-root .od-email-sig-smooth input { flex: 1; accent-color: var(--accent, var(--red)); }
+.odysseus-root .od-email-sig-smooth-val {
+  width: 18px; text-align: right; font-variant-numeric: tabular-nums; opacity: 0.7; color: var(--fg);
+}
+.odysseus-root .od-email-sig-name-input {
+  width: 100%; height: 30px; margin-top: 10px; padding: 0 10px; border-radius: 6px; font-size: 12px;
+  background: var(--bg); color: var(--fg); border: 1px solid var(--border);
+}
+.odysseus-root .od-email-sig-name-input::placeholder { color: color-mix(in srgb, var(--fg) 35%, transparent); }
+.odysseus-root .od-email-sig-footer {
+  display: flex; align-items: center; gap: 8px; margin-top: 12px; padding-top: 8px; border-top: 1px solid var(--border);
+}
+/* ===== fix-wave-A: DocumentLibraryView ===== */
+/* ===== DocumentLibraryView — lib-tabs, subhead, chips, bulk bar (fix wave) ===== */
+/* In this view the header is just Title + Close; push Close to the right. */
+.odysseus-root .od-doclib-header .od-doclib-close { margin-left:auto; }
+
+/* odysseus .lib-tabs / .lib-tab (style.css L22130) — underline tab bar. */
+.odysseus-root .od-lib-tabs { display:flex; gap:0; padding:0 12px; margin:2px 0 4px;
+  border-bottom:1px solid var(--border); }
+.odysseus-root .od-lib-tab { background:none; border:none; border-bottom:2px solid transparent;
+  color:color-mix(in srgb, var(--fg) 55%, transparent); font-size:12px; font-family:inherit;
+  padding:6px 14px; cursor:pointer; transition:color .12s, border-color .12s; }
+.odysseus-root .od-lib-tab:hover { color:var(--fg); }
+.odysseus-root .od-lib-tab-active { color:var(--accent, var(--red));
+  border-bottom-color:var(--accent, var(--red)); }
+
+/* Honest empty panel for the non-Documents tabs (no eliza backend). */
+.odysseus-root .od-doclib-tab-empty { flex:1; display:flex; align-items:center; justify-content:center;
+  text-align:center; padding:40px 24px; font-size:12px; font-style:italic; line-height:1.6;
+  color:color-mix(in srgb, var(--fg) 38%, transparent); }
+
+/* Documents subhead: count on the left, Import + Create grouped on the right
+   (Import keeps its existing margin-left:auto). */
+.odysseus-root .od-doclib-subhead { display:flex; align-items:center; gap:8px; padding:6px 16px 0; }
+.odysseus-root .od-doclib-toolbar-btn:disabled { opacity:.45; cursor:default; }
+.odysseus-root .od-doclib-toolbar-btn-active { border-color:var(--red); color:var(--red); }
+
+/* Extension filter chips (odysseus .memory-cat-chip, style.css L10649). */
+.odysseus-root .od-doclib-chips { display:flex; gap:4px; flex-wrap:wrap; flex-basis:100%; }
+.odysseus-root .od-doclib-chip { background:none; border:1px solid var(--border);
+  color:color-mix(in srgb, var(--fg) 60%, transparent); font-size:10px; height:22px; padding:0 8px;
+  display:inline-flex; align-items:center; border-radius:10px; cursor:pointer; font-family:inherit;
+  transition:all .15s; }
+.odysseus-root .od-doclib-chip:hover { border-color:var(--red); color:var(--red); }
+.odysseus-root .od-doclib-chip-active { background:color-mix(in srgb, var(--red) 15%, transparent);
+  border-color:color-mix(in srgb, var(--red) 40%, transparent); color:var(--red); }
+
+/* Bulk-select bar (odysseus .memory-bulk-bar, style.css L10022). */
+.odysseus-root .od-doclib-bulk-bar { display:flex; align-items:center; gap:8px; margin:2px 16px 4px;
+  padding:6px 8px; font-size:11px; border-radius:8px;
+  border:1px solid color-mix(in srgb, var(--red) 30%, transparent);
+  background:color-mix(in srgb, var(--red) 5%, transparent); }
+.odysseus-root .od-doclib-bulk-all { display:inline-flex; align-items:center; gap:4px;
+  color:var(--fg); cursor:pointer; }
+.odysseus-root .od-doclib-bulk-count { color:color-mix(in srgb, var(--fg) 70%, transparent); }
+.odysseus-root .od-doclib-bulk-actions { position:relative; margin-left:auto; }
+.odysseus-root .od-doclib-bulk-actions .od-doclib-dropdown { right:0; }
+.odysseus-root .od-doclib-bulk-cancel { background:none; border:1px solid transparent;
+  color:color-mix(in srgb, var(--fg) 60%, transparent); width:24px; height:24px; padding:0; border-radius:6px;
+  display:inline-flex; align-items:center; justify-content:center; cursor:pointer; transition:all .15s; }
+.odysseus-root .od-doclib-bulk-cancel:hover { color:var(--fg); border-color:var(--border); }
+
+/* Per-card selection affordance. */
+.odysseus-root .od-doclib-card-check { display:flex; align-items:center; padding:10px 0 0 10px; flex-shrink:0; }
+.odysseus-root .od-doclib-card-selected { border-color:color-mix(in srgb, var(--red) 50%, transparent);
+  background:color-mix(in srgb, var(--red) 7%, transparent); }
+/* ===== fix-wave-A: SettingsPanel ===== */
+/* ── Settings · Appearance UI-visibility editor (odysseus .vis-*) ── */
+.odysseus-root .od-vis-toggles { display: flex; flex-direction: column; gap: 2px; }
+.odysseus-root .od-vis-row {
+  display: flex; align-items: center; gap: 8px;
+  width: 100%; box-sizing: border-box;
+  padding: 6px 8px; border: none; border-radius: 6px;
+  background: transparent; color: var(--fg);
+  font: inherit; text-align: left; cursor: pointer;
+  transition: background 0.12s;
+}
+.odysseus-root .od-vis-row:hover { background: color-mix(in srgb, var(--fg) 6%, transparent); }
+.odysseus-root .od-vis-label { flex: 1; min-width: 0; font-size: 12px; color: var(--fg); user-select: none; }
+.odysseus-root .od-vis-hint { margin-left: 6px; font-size: 10px; color: color-mix(in srgb, var(--fg) 35%, transparent); }
+.odysseus-root .od-vis-switch {
+  position: relative; flex-shrink: 0;
+  width: 30px; height: 16px; border-radius: 8px;
+  background: color-mix(in srgb, var(--fg) 18%, transparent);
+  transition: background 0.18s;
+}
+.odysseus-root .od-vis-switch::after {
+  content: ""; position: absolute; top: 2px; left: 2px;
+  width: 12px; height: 12px; border-radius: 50%;
+  background: var(--panel); box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  transition: transform 0.18s;
+}
+.odysseus-root .od-vis-switch.on { background: var(--accent, var(--red)); }
+.odysseus-root .od-vis-switch.on::after { transform: translateX(14px); }
+.odysseus-root .od-vis-reset-row { justify-content: flex-end; }
+
+/* Shared reset button (Reset All / Reset) */
+.odysseus-root .od-settings-reset {
+  padding: 6px 12px; border-radius: 7px;
+  border: 1px solid var(--border); background: transparent;
+  color: color-mix(in srgb, var(--fg) 70%, transparent);
+  font-size: 12px; font-family: inherit; cursor: pointer;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
+}
+.odysseus-root .od-settings-reset:hover {
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 50%, var(--border));
+  background: color-mix(in srgb, var(--accent, var(--red)) 8%, transparent);
+  color: var(--fg);
+}
+
+/* ── Settings · Keyboard Shortcuts (odysseus .shortcut-*) ── */
+.odysseus-root .od-shortcut-head-card {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+}
+.odysseus-root .od-shortcut-head-card .od-settings-card-title {
+  margin: 0; padding: 0; border-bottom: none;
+}
+.odysseus-root .od-shortcut-category {
+  font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em;
+  color: color-mix(in srgb, var(--fg) 40%, transparent);
+  padding: 8px 0 4px; margin-top: 4px;
+}
+.odysseus-root .od-shortcut-category:first-child { margin-top: 0; padding-top: 0; }
+.odysseus-root .od-shortcut-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  padding: 5px 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 30%, transparent);
+}
+.odysseus-root .od-shortcut-row:last-child { border-bottom: none; }
+.odysseus-root .od-shortcut-row.conflict {
+  background: color-mix(in srgb, var(--red) 7%, transparent);
+  border-radius: 5px; padding: 5px 6px; border-bottom: none;
+}
+.odysseus-root .od-shortcut-label {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 12px; color: var(--fg);
+}
+.odysseus-root .od-shortcut-warn {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 14px; height: 14px; border-radius: 50%;
+  background: var(--red); color: var(--bg);
+  font-size: 9px; font-weight: 700;
+}
+.odysseus-root .od-shortcut-controls { display: flex; align-items: center; gap: 4px; }
+.odysseus-root .od-shortcut-key {
+  display: flex; align-items: center; gap: 3px;
+  padding: 2px 4px; border: none; border-radius: 5px;
+  background: transparent; color: var(--fg);
+  font-family: inherit; cursor: pointer; transition: background 0.15s;
+}
+.odysseus-root .od-shortcut-key:hover {
+  background: color-mix(in srgb, var(--accent, var(--red)) 10%, transparent);
+}
+.odysseus-root .od-shortcut-key.listening {
+  background: color-mix(in srgb, var(--accent, var(--red)) 12%, transparent);
+}
+.odysseus-root .od-shortcut-key kbd {
+  display: inline-block; min-width: 20px; padding: 2px 6px; text-align: center;
+  font-family: inherit; font-size: 10px; font-weight: 600; line-height: 1.4;
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--accent, var(--red)) 14%, var(--bg));
+  border: 1px solid color-mix(in srgb, var(--accent, var(--red)) 40%, var(--border));
+  color: var(--accent, var(--red));
+}
+.odysseus-root .od-shortcut-listening {
+  font-size: 10px; color: var(--accent, var(--red));
+}
+.odysseus-root .od-shortcut-unset {
+  padding: 2px 8px; font-size: 10px; border-radius: 5px;
+  border: 1px dashed var(--border);
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+.odysseus-root .od-shortcut-key.unset:hover .od-shortcut-unset {
+  border-color: var(--accent, var(--red)); color: var(--fg);
+}
+.odysseus-root .od-shortcut-resetbtn {
+  display: flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px; border-radius: 5px;
+  border: 1px solid var(--border); background: transparent;
+  color: color-mix(in srgb, var(--fg) 60%, transparent);
+  font-size: 12px; cursor: pointer; transition: border-color 0.15s, color 0.15s;
+}
+.odysseus-root .od-shortcut-resetbtn:hover {
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 50%, var(--border));
+  color: var(--fg);
+}
+/* ===== fix-wave-A: EmojiPicker ===== */
+/* ===== EmojiPicker (monochrome icon picker) — overrides for the SVG rewrite.
+   The picker no longer renders a category-tab strip, a "Recent" section, or
+   colored glyph cells; cells now host inline 24x24 stroke SVGs (matching
+   odysseus .emoji-picker-item svg { width:16px; height:16px }). Appended after
+   the original wave5 .od-emoji-* block so these win on equal specificity. The
+   old .od-emoji-tab* rules in that block are now dead (no .od-emoji-tab element
+   is rendered) and harmless; they can be deleted by the integrator. ===== */
+.odysseus-root .od-emoji-cell {
+  color: color-mix(in srgb, var(--fg) 78%, transparent);
+  font-size: 0; /* no glyph text — the cell hosts an SVG only */
+}
+.odysseus-root .od-emoji-cell:hover {
+  color: var(--fg);
+}
+.odysseus-root .od-emoji-cell svg {
+  width: 18px;
+  height: 18px;
+  display: block;
+}
+/* The body holds the whole stacked group list (no tab strip above it). Give the
+   first group label a little less top padding so it sits tight under search. */
+.odysseus-root .od-emoji-body > .od-emoji-section:first-child .od-emoji-section-label {
+  padding-top: 2px;
+}
+/* ===== fix-wave-A: ThemeMenu ===== */
+
+/* ===== wave: ThemeMenu — per-picker reset + advanced ("More Colours") editor =====
+   Ported from odysseus static/style.css (.color-reset-btn, .theme-adv-toggle,
+   .theme-adv-section/group, .theme-adv-clear-btn, .theme-save-error) onto the
+   theme-var system. All scoped under .odysseus-root. */
+
+/* per-row reset affordance — hidden until the value differs from the reference,
+   then a faint icon that brightens to accent on hover (theme.js .changed). The
+   button stays in layout when inert so row width never jumps. */
+.odysseus-root .od-theme-reset-btn { width:20px; height:20px; flex-shrink:0; padding:0;
+  display:flex; align-items:center; justify-content:center; border:none; background:none;
+  color:var(--fg); opacity:0; cursor:default; transition:opacity .15s, color .15s; }
+.odysseus-root .od-theme-reset-btn.changed { opacity:.4; cursor:pointer; }
+.odysseus-root .od-theme-reset-btn.changed:hover { opacity:1; color:var(--red); }
+
+/* advanced section disclosure toggle */
+.odysseus-root .od-theme-adv-toggle { display:flex; align-items:center; gap:4px;
+  margin:10px 0; padding:6px 8px; width:100%; text-align:left; cursor:pointer;
+  font-size:11px; font-family:inherit; color:var(--red); opacity:.8;
+  border:1px solid var(--border); border-radius:6px; background:transparent;
+  transition:opacity .15s, background .15s; user-select:none; }
+.odysseus-root .od-theme-adv-toggle:hover { opacity:1;
+  background:color-mix(in srgb, var(--fg) 4%, transparent); }
+.odysseus-root .od-theme-adv-arrow { flex-shrink:0; transition:transform .2s; }
+.odysseus-root .od-theme-adv-toggle.open .od-theme-adv-arrow { transform:rotate(90deg); }
+
+/* advanced groups */
+.odysseus-root .od-theme-adv-section { margin:8px 0 10px; display:flex;
+  flex-direction:column; gap:8px; }
+.odysseus-root .od-theme-adv-group { display:flex; flex-direction:column; gap:4px; }
+.odysseus-root .od-theme-adv-group-label { font-size:10px; opacity:.5;
+  text-transform:uppercase; letter-spacing:.04em;
+  color:color-mix(in srgb, var(--fg) 70%, transparent); }
+.odysseus-root .od-theme-adv-clear { margin-top:2px; width:100%; padding:5px;
+  border:1px solid var(--border); border-radius:6px; background:transparent;
+  color:var(--fg); opacity:.5; cursor:pointer; font-size:12px; font-family:inherit;
+  transition:opacity .15s; }
+.odysseus-root .od-theme-adv-clear:hover:not(:disabled) { opacity:1; }
+.odysseus-root .od-theme-adv-clear:disabled { opacity:.25; cursor:default; }
+
+/* inline save error (theme.js #theme-save-error) */
+.odysseus-root .od-theme-save-error { margin-top:4px; font-size:11px; color:var(--red); }
+
+/* ===== fix-wave-A: AdminView ===== */
+/* ── AdminView fixes (fixwave) ─────────────────────────────────────────────
+   1. Built-in Tools catalogue chrome (Agent Tools tab) — translates odysseus's
+      .admin-tool-* rules (style.css ~21857) to scoped .od-admin-tool-* classes.
+   2. Modal centering — odysseus's settings modal is centered (.modal
+      align-items/justify-content:center) at .modal-content max-height:85vh; the
+      shared .od-search-overlay is top-anchored at 12vh, so scope the admin
+      overlay back to centered and size the panel to content up to 85vh so the
+      composer no longer protrudes below and a sparse tab doesn't leave a void. */
+
+/* Center the admin overlay (override the shared 12vh top-anchored search overlay). */
+.odysseus-root .od-admin-overlay {
+  align-items: center;
+  justify-content: center;
+  padding: 5vh 0;
+}
+/* Size the panel to its content up to odysseus's 85vh cap (was a fixed
+   min(86vh,760px) that ran the bottom to ~98vh / left a void on short tabs).
+   A windowed panel still sets its own height inline (win.panelStyle), which wins. */
+.odysseus-root .od-admin-overlay:not(.od-windowed) > .od-admin-panel {
+  height: auto;
+  max-height: 85vh;
+}
+
+/* ── Built-in Tools catalogue (admin.js loadBuiltinTools / #adm-builtin-tools-list) ── */
+.odysseus-root .od-admin-tool-list { margin-top: 6px; }
+
+.odysseus-root .od-admin-tool-category {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin-bottom: 6px;
+  overflow: hidden;
+  transition: border-color 0.15s;
+}
+.odysseus-root .od-admin-tool-category:hover {
+  border-color: color-mix(in srgb, var(--fg) 20%, var(--border));
+}
+
+/* Header is a real <button> (click-to-collapse) — reset native button chrome. */
+.odysseus-root .od-admin-tool-cat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 8px 10px;
+  border: none;
+  background: transparent;
+  color: var(--fg);
+  font-size: 12px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.odysseus-root .od-admin-tool-cat-header:hover {
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+}
+.odysseus-root .od-admin-tool-cat-right {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.odysseus-root .od-admin-tool-cat-count {
+  font-size: 10px;
+  opacity: 0.5;
+}
+.odysseus-root .od-admin-tool-cat-chevron {
+  opacity: 0.3;
+  transition: transform 0.2s, opacity 0.2s;
+}
+.odysseus-root .od-admin-tool-cat-chevron.open {
+  transform: rotate(180deg);
+  opacity: 0.7;
+}
+
+.odysseus-root .od-admin-tool-cat-body {
+  border-top: 1px solid var(--border);
+  padding: 4px 0;
+}
+.odysseus-root .od-admin-tool-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  /* align toggles with the header toggle (chevron 12px + gap 6px + padding) */
+  padding: 5px 10px 5px 10px;
+  padding-right: 28px;
+  transition: background 0.08s;
+}
+.odysseus-root .od-admin-tool-row:hover {
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+}
+.odysseus-root .od-admin-tool-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.odysseus-root .od-admin-tool-name {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--fg);
+}
+.odysseus-root .od-admin-tool-desc {
+  font-size: 10px;
+  opacity: 0.4;
+  color: var(--fg);
+}
+.odysseus-root .od-admin-tool-ctx {
+  font-size: 9px;
+  opacity: 0.3;
+  flex-shrink: 0;
+  min-width: 35px;
+  text-align: right;
+  color: var(--fg);
+  font-family: 'Berkeley Mono', 'SF Mono', 'Fira Code', monospace;
+}
+/* ===== fix-wave-A: MessageBubble ===== */
+/* ── Message footer (odysseus chatRenderer.js .msg-footer / .msg-actions /
+   .footer-copy-btn). Used by UserBubble.CopyFooter here AND already referenced
+   by ChatMessages.AgentFooter — these classes were used but never styled, so
+   adding them styles both the user and assistant copy footers. Faithful to
+   odysseus: a muted footer row with a copy button that tints to --accent on
+   hover; the user footer right-aligns because .od-msg-user is align-items:flex-end. */
+.odysseus-root .od-msg-footer {
+  display:flex; align-items:center; gap:6px; flex-wrap:wrap; margin-top:6px;
+  color:color-mix(in srgb, var(--fg) 45%, transparent); font-size:.75rem; position:relative;
+}
+.odysseus-root .od-msg-actions { display:inline-flex; align-items:center; gap:4px; }
+.odysseus-root .od-footer-copy-btn {
+  background:none; border:none; color:color-mix(in srgb, var(--fg) 45%, transparent);
+  cursor:pointer; padding:2px 6px; border-radius:4px; line-height:1;
+  display:inline-flex; align-items:center; justify-content:center; transition:color .15s;
+}
+.odysseus-root .od-footer-copy-btn:hover,
+.odysseus-root .od-footer-copy-btn[data-copied="true"] { color:var(--accent, var(--red)); }
+
+/* ── Sensitive-info censor (odysseus style.css .censored-item). Fixed semantic
+   tints: red while blurred (sensitive), green once revealed (acknowledged). */
+.odysseus-root .od-censored {
+  filter:blur(5px); cursor:pointer; transition:filter .2s; border-radius:2px;
+  padding:0 2px; background:color-mix(in srgb, var(--red) 8%, transparent); user-select:none;
+}
+.odysseus-root .od-censored:hover {
+  filter:blur(3px); background:color-mix(in srgb, var(--red) 15%, transparent);
+}
+.odysseus-root .od-censored.revealed {
+  filter:none; background:color-mix(in srgb, var(--ok) 8%, transparent);
+  user-select:auto; cursor:text;
+}
+/* ===== fix-wave-A: GalleryEditorView ===== */
+
+/* ── Gallery editor: wand Live-retune pill (controls.js .ge-wand-live-btn). ── */
+.odysseus-root .ge-wand-live-btn {
+  flex: 0 0 auto;
+  min-width: 46px;
+  height: 22px;
+  padding: 0 10px;
+  border-radius: 999px;
+  font-size: 10px;
+  line-height: 1;
+  opacity: 0.6;
+  background: color-mix(in srgb, var(--fg) 5%, transparent);
+  transition: opacity 0.15s, color 0.15s, border-color 0.15s, background 0.15s;
+}
+.odysseus-root .ge-wand-live-btn:hover:not(:disabled) { opacity: 0.85; }
+.odysseus-root .ge-wand-live-btn.active {
+  opacity: 1;
+  background: color-mix(in srgb, var(--accent, var(--red)) 18%, transparent);
+  border-color: var(--accent, var(--red));
+  color: var(--accent, var(--red));
+  font-weight: 600;
+}
+
+/* Inpaint tear-off popover head — hidden when the section renders inline in the
+   right panel (odysseus only reveals it once the section is torn off into a
+   floating popover over the canvas). Kept faithful so it lights up 1:1. */
+.odysseus-root .ge-inpaint-popover-head { display: none; }
+.odysseus-root .ge-inpaint-popover-head .ge-inpaint-popover-title { margin: 0; flex: 1 1 auto; }
+.odysseus-root .ge-inpaint-popover-close {
+  flex: 0 0 auto;
+  border: none;
+  background: none;
+  color: var(--muted, var(--fg));
+  line-height: 1;
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  transition: color 0.14s ease, background-color 0.14s ease;
+}
+.odysseus-root .ge-inpaint-popover-close:hover {
+  color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+}
+
+/* POSTPROCESS "Available after Generate." hint — dimmed, matches odysseus. */
+.odysseus-root .ge-ge-postedge-hint { opacity: 0.45; margin: 0 0 8px; }
+
+/* Honest disabled states for the editor's selection / edge controls. A control
+   with no eliza backend is disabled, not removed, so the surface stays 1:1. */
+.odysseus-root .ge-controls .ge-btn-iconlabel:disabled,
+.odysseus-root .ge-controls .ge-mask-vis-btn:disabled,
+.odysseus-root .ge-wand-live-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.odysseus-root .ge-controls input[type="range"]:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.odysseus-root .ge-sel-refine input[type="range"]:disabled { cursor: not-allowed; }
+
+/* ===== fix-wave-A: TasksView ===== */
+/* Tasks: mutation-failure inline bar (.od-tasks-error). Shown above the bulk bar when a pause/resume/delete server call fails, replacing the old silent-swallow behaviour. Mirrors the .od-tasks-bulk-bar red-tint treatment. */
+.odysseus-root .od-tasks-error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px 6px 10px;
+  margin-bottom: 8px;
+  border: 1px solid color-mix(in srgb, var(--red) 45%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--red) 10%, transparent);
+  font-size: 11px;
+}
+.odysseus-root .od-tasks-error-text {
+  flex: 1;
+  color: var(--red);
+}
+.odysseus-root .od-tasks-error-dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border: none;
+  background: transparent;
+  color: color-mix(in srgb, var(--red) 80%, var(--fg));
+  border-radius: 5px;
+  cursor: pointer;
+}
+.odysseus-root .od-tasks-error-dismiss:hover {
+  background: color-mix(in srgb, var(--red) 18%, transparent);
+}
+/* ===== fix-wave-A: SessionSidebar ===== */
+/* ===== SessionSidebar fixwave: type icon + activity dot, drag handle,
+   sort dropdown, section collapse. Scoped .odysseus-root, theme vars only. ===== */
+
+/* Chats section title is now a collapse toggle button (was a span). Reset the
+   button chrome and keep the odysseus section-title look; the chevron rotates
+   via swapped icons. */
+.odysseus-root .od-section-toggle { background:none; border:none; padding:0; cursor:pointer;
+  font-family:inherit; text-align:left; }
+.odysseus-root .od-section-chevron { flex-shrink:0; opacity:.55; transition:opacity .1s; }
+.odysseus-root .od-section-toggle:hover .od-section-chevron { opacity:.9; }
+/* Collapsed: hide the section body (the rows / folders / bulk bar). */
+.odysseus-root .od-section.od-collapsed .od-section-body { display:none; }
+
+/* Leading type icon + activity dot wrapper (odysseus .session-icon +
+   .session-star activity state). The dot sits at the icon's lower-right. */
+.odysseus-root .od-thread-icon-wrap { position:relative; flex-shrink:0; display:flex;
+  align-items:center; justify-content:center; width:16px; height:16px; }
+.odysseus-root .od-thread-type { opacity:.55; }
+.odysseus-root .od-list-item.active .od-thread-type { opacity:.85; }
+.odysseus-root .od-thread-dot { position:absolute; right:-2px; bottom:-2px; width:7px; height:7px;
+  border-radius:50%; box-sizing:border-box;
+  border:1.5px solid var(--panel, var(--bg)); }
+/* processing → accent pulse (odysseus .session-star.processing) */
+.odysseus-root .od-dot-processing { background:var(--accent, var(--red));
+  animation:od-thread-dot-pulse 1.1s ease-in-out infinite; }
+/* done → ok notify badge (odysseus .session-star.notify) */
+.odysseus-root .od-dot-done { background:var(--ok, var(--accent, var(--red))); }
+/* failed → red */
+.odysseus-root .od-dot-failed { background:var(--red); }
+@keyframes od-thread-dot-pulse {
+  0%, 100% { opacity:1; transform:scale(1); }
+  50% { opacity:.45; transform:scale(.72); }
+}
+
+/* Per-row drag handle (odysseus .item-drag-handle ⋮⋮). Occupies the same left
+   gutter as the select checkbox; only visible/active when reorder is allowed. */
+.odysseus-root .od-thread-drag { flex-shrink:0; width:16px; align-self:stretch; display:flex;
+  align-items:center; justify-content:center; color:var(--fg); opacity:0;
+  cursor:grab; touch-action:none; user-select:none; transition:opacity .1s; }
+.odysseus-root .od-thread-row:hover .od-thread-drag { opacity:.4; }
+.odysseus-root .od-thread-drag:hover { opacity:.8; }
+.odysseus-root .od-thread-drag:active { cursor:grabbing; }
+/* dragging row + magnetic drop indicator (odysseus .dragging / drag-placeholder) */
+.odysseus-root .od-thread-row.od-dragging { opacity:.5; }
+.odysseus-root .od-thread-row.od-drop-before { box-shadow:inset 0 2px 0 var(--accent, var(--red)); }
+
+/* Sort dropdown (odysseus #session-sort-dropdown). Anchored under the funnel
+   icon button in the section header. */
+.odysseus-root .od-sort-wrap { position:relative; flex-shrink:0; }
+.odysseus-root .od-sort-dropdown { position:absolute; top:calc(100% + 4px); right:0; z-index:40;
+  min-width:148px; padding:3px; border-radius:6px;
+  background:var(--card, var(--panel, var(--bg)));
+  border:1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  box-shadow:0 6px 22px rgba(0,0,0,.32); }
+.odysseus-root .od-sort-option { display:flex; align-items:center; gap:6px; width:100%; text-align:left;
+  padding:6px 9px; border:none; background:none; color:var(--fg); font-family:inherit;
+  font-size:12px; border-radius:4px; cursor:pointer; }
+.odysseus-root .od-sort-option:hover { background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-sort-option.od-cur { color:var(--accent, var(--red)); }
+.odysseus-root .od-sort-check-spacer { display:inline-block; width:12px; height:12px; flex-shrink:0; }
+/* ===== fix-wave-A: SearchPalette ===== */
+/* ── search palette result rows (Ctrl+K) ── odysseus search-result-item /
+   search-result-snippet / search-result-time / mark.search-highlight (style.css
+   L5988-L6030). The shared .od-search-item already supplies flex/gap/padding;
+   these add the stacked title+snippet body, the muted time column, the selected
+   state, and the matched-query highlight. */
+.odysseus-root .od-search-item { min-width:0; }
+.odysseus-root .od-search-item.od-selected { background:color-mix(in srgb, var(--red) 10%, transparent); }
+.odysseus-root .od-search-item-body { flex:1; min-width:0; display:flex; flex-direction:column; gap:2px; }
+.odysseus-root .od-search-item-title { font-size:13px; color:var(--fg);
+  overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.odysseus-root .od-search-item-snippet { font-size:11px; color:color-mix(in srgb, var(--fg) 55%, transparent);
+  overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.odysseus-root .od-search-item-time { flex-shrink:0; align-self:center; font-size:10px;
+  color:color-mix(in srgb, var(--fg) 35%, transparent); white-space:nowrap; }
+.odysseus-root mark.od-search-highlight { background:var(--accent); color:var(--bg);
+  border-radius:2px; padding:0 2px; font-weight:600; }
+/* ===== fix-wave-A: ModelsView ===== */
+/* ── ModelsView fixes (audit wave) ───────────────────────────────────────── */
+
+/* Finding 1: provider-rail brand casing now comes from data (providerRailLabel),
+   not from text-transform. Override the earlier .od-models-provider-row rule so
+   labels render verbatim (OpenAI / xAI / OpenRouter / Ollama), not capitalized
+   ("Openai" / "Xai"). Equal specificity, declared later → wins by source order. */
+.odysseus-root .od-models-provider-row { text-transform: none; }
+
+/* Finding 2: odysseus spinner.js createLoadingRow / .lib-loading-row — an inline
+   loading row (label + whirlpool spinner) for list/empty-state loading. Upstream
+   paints a canvas whirlpool that self-stops once removed from the DOM; this CSS
+   ring is the faithful equivalent (it stops painting when React unmounts it). */
+.odysseus-root .od-loading-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 28px 16px;
+  font-size: 12px;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+.odysseus-root .od-whirlpool {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 2px solid transparent;
+  border-top-color: color-mix(in srgb, var(--red) 90%, transparent);
+  border-right-color: color-mix(in srgb, var(--red) 55%, transparent);
+  border-bottom-color: color-mix(in srgb, var(--red) 25%, transparent);
+  animation: od-whirlpool-spin 0.85s linear infinite;
+}
+@keyframes od-whirlpool-spin {
+  to { transform: rotate(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .odysseus-root .od-whirlpool { animation-duration: 2.4s; }
+}
+/* ===== fix-wave-A: CookbookView ===== */
+/* ── Cookbook panel overflow fix (audit: panel bottom clipped off-screen) ──
+   The shared .od-search-overlay reserves padding:12vh top + 5vh bottom (17vh).
+   The prior .od-cb-panel max-height:85vh pushed the total to ~102vh, so the
+   panel's bottom border + last card were clipped below the viewport. Cap the
+   panel so it fits within the reserved offset with a ~1vh safety margin; the
+   inner .od-cb-grid / .od-cb-running own the overflow and scroll internally. */
+.odysseus-root .od-cb-panel { max-height: calc(100vh - 18vh); }
+
+/* ── Cookbook tab count badge (cookbookRunning.js .cookbook-tab-count) ──
+   The Running tab carries the active-run count inline, so the tab itself must
+   be an inline-flex row (matching odysseus's .cookbook-tab display). */
+.odysseus-root .od-cb-tab { display: inline-flex; align-items: center; gap: 4px; }
+.odysseus-root .od-cb-tab-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--accent) 20%, transparent);
+  color: var(--accent);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+/* ── Running tab list (cookbookRunning.js _renderRunningTab) ──
+   Scrollable column of run cards, like the recipe grid. */
+.odysseus-root .od-cb-running {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  padding-right: 2px;
+}
+.odysseus-root .od-cb-running::-webkit-scrollbar { width: 4px; }
+.odysseus-root .od-cb-running::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--fg) 15%, transparent);
+  border-radius: 4px;
+}
+
+/* Run card (.cookbook-task): bordered, left accent stripe coloured by status. */
+.odysseus-root .od-cb-run {
+  border: 1px solid var(--border);
+  border-left: 3px solid color-mix(in srgb, var(--fg) 30%, transparent);
+  border-radius: 8px;
+  overflow: hidden;
+  background: color-mix(in srgb, var(--fg) 3%, var(--bg));
+  transition: border-color 0.15s, background 0.15s;
+}
+.odysseus-root .od-cb-run:hover {
+  border-color: color-mix(in srgb, var(--fg) 25%, var(--border));
+  background: color-mix(in srgb, var(--fg) 5%, var(--bg));
+}
+/* Status-driven left stripe (cookbookRunning.js :has() stripe colors). */
+.odysseus-root .od-cb-run[data-status="running"],
+.odysseus-root .od-cb-run[data-status="done"] {
+  border-left-color: var(--green);
+}
+.odysseus-root .od-cb-run[data-status="stopping"] { border-left-color: var(--orange); }
+.odysseus-root .od-cb-run[data-status="queued"],
+.odysseus-root .od-cb-run[data-status="stopped"] { border-left-color: var(--warn); }
+.odysseus-root .od-cb-run[data-status="error"] {
+  border-color: var(--red);
+  border-left-color: var(--red);
+  background: color-mix(in srgb, var(--red) 8%, var(--bg));
+}
+
+/* Header row: type chip · name · status pill · Stop (.cookbook-task-header). */
+.odysseus-root .od-cb-run-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  background: color-mix(in srgb, var(--fg) 7%, transparent);
+  font-size: 12px;
+  border-bottom: 1px solid color-mix(in srgb, var(--fg) 6%, transparent);
+}
+.odysseus-root .od-cb-run-type {
+  text-transform: uppercase;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  flex-shrink: 0;
+  background: color-mix(in srgb, var(--green) 16%, transparent);
+  color: var(--green);
+  white-space: nowrap;
+}
+.odysseus-root .od-cb-run-name {
+  flex: 1;
+  min-width: 0;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--fg);
+}
+.odysseus-root .od-cb-run-status {
+  font-size: 9px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-weight: 600;
+  line-height: 16px;
+  flex-shrink: 0;
+  text-transform: lowercase;
+}
+.odysseus-root .od-cb-run-status-running {
+  background: color-mix(in srgb, var(--green) 20%, transparent);
+  color: var(--green);
+}
+.odysseus-root .od-cb-run-status-done {
+  background: color-mix(in srgb, var(--green) 15%, transparent);
+  color: var(--green);
+}
+.odysseus-root .od-cb-run-status-stopping {
+  background: color-mix(in srgb, var(--orange) 22%, transparent);
+  color: var(--orange);
+}
+.odysseus-root .od-cb-run-status-queued,
+.odysseus-root .od-cb-run-status-stopped {
+  background: color-mix(in srgb, var(--warn) 18%, transparent);
+  color: var(--warn);
+}
+.odysseus-root .od-cb-run-status-error {
+  background: color-mix(in srgb, var(--red) 16%, transparent);
+  color: var(--red);
+}
+/* Stop control (cookbookRunning.js Stop menu action — danger styled). */
+.odysseus-root .od-cb-run-stop {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  font-size: 9px;
+  font-weight: 600;
+  font-family: inherit;
+  padding: 2px 7px;
+  border-radius: 4px;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+  background: color-mix(in srgb, var(--red) 14%, transparent);
+  color: var(--red);
+  border: 1px solid color-mix(in srgb, var(--red) 30%, transparent);
+  transition: background 0.15s, opacity 0.15s;
+}
+.odysseus-root .od-cb-run-stop:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--red) 24%, transparent);
+}
+.odysseus-root .od-cb-run-stop:disabled { opacity: 0.45; cursor: default; }
+
+/* Sub row: plugin name + uptime (.cookbook-task-sub, monospace muted). */
+.odysseus-root .od-cb-run-sub {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 10px 2px;
+  line-height: 1;
+}
+.odysseus-root .od-cb-run-plugin {
+  font-size: 9px;
+  font-family: "Fira Code", ui-monospace, monospace;
+  color: var(--muted);
+  opacity: 0.6;
+  letter-spacing: 0.3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.odysseus-root .od-cb-run-uptime {
+  font-size: 9px;
+  font-family: "Fira Code", ui-monospace, monospace;
+  color: var(--muted);
+  opacity: 0.5;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+/* Summary / session-status line + non-healthy health line. */
+.odysseus-root .od-cb-run-summary {
+  padding: 0 10px 8px;
+  font-size: 11px;
+  color: color-mix(in srgb, var(--fg) 70%, transparent);
+  line-height: 1.4;
+}
+.odysseus-root .od-cb-run-health {
+  padding: 6px 10px;
+  margin: 0 8px 8px;
+  border-radius: 6px;
+  font-size: 10px;
+  line-height: 1.4;
+}
+.odysseus-root .od-cb-run-health-degraded {
+  background: color-mix(in srgb, var(--warn) 12%, transparent);
+  color: var(--warn);
+}
+.odysseus-root .od-cb-run-health-offline {
+  background: color-mix(in srgb, var(--red) 12%, transparent);
+  color: var(--red);
+}
+/* ===== fix-wave-A: ResearchView ===== */
+/* Research: empty-state under-title hint + the Library link (odysseus
+   static/style.css L34897-34906 + the #research-no-past-hint inline styles in
+   panel.js L356). The under-title hint is distinct from the existing
+   .research-library-hint (Past-section footer) — it sits under the title with
+   a small negative top margin so it tucks against the description line.
+   .research-library-link is missing from the theme entirely; added here. */
+.odysseus-root .research-no-past-hint {
+  margin-top: -2px; font-size: 11px; opacity: 0.7; line-height: 1.3;
+}
+.odysseus-root .research-library-link {
+  background: none; border: none; padding: 0; cursor: pointer;
+  font: inherit; color: var(--accent, var(--red)); text-decoration: underline;
+}
+.odysseus-root .research-library-link:hover { opacity: 0.8; }
+/* ===== fix-wave-A: PresetsPanel ===== */
+/* ===== PresetsPanel: editor tab strip + inject fields (wave: PresetsPanel) =====
+   Append to ODYSSEUS_CSS in odysseus-theme.ts, directly after the existing
+   '.odysseus-root .od-preset-save-btn:disabled { ... }' rule (end of the
+   Presets block, before the EmojiPicker section). Mirrors odysseus
+   .preset-tabs / .preset-tab (static/style.css L9215-9258): full-width tabs,
+   muted resting color, accent underline when active. All theme-var driven. */
+.odysseus-root .od-preset-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  margin: 0 0 2px;
+}
+.odysseus-root .od-preset-tab {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 10px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s, border-color 0.15s;
+}
+.odysseus-root .od-preset-tab:hover {
+  color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+}
+.odysseus-root .od-preset-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+/* Inject prefix/suffix textareas are short by default (odysseus uses rows=2),
+   overriding the tall min-height of the shared .od-preset-textarea. */
+.odysseus-root .od-preset-inject-area {
+  min-height: 56px;
+}
+/* "inject" tag in the list-item meta row — keeps the meta line's small size,
+   tinted toward the accent so a preset carrying inject text reads as such. */
+.odysseus-root .od-preset-meta-inject {
+  color: color-mix(in srgb, var(--accent) 80%, var(--fg));
+  font-weight: 600;
+}
+/* ===== fix-wave-A: IconRail ===== */
+/* icon rail: New-chat action reads as available (primary affordance), not dimmed like the contextual launchers — mirrors odysseus rail-new-session prominence */
+.odysseus-root .od-rail-btn.od-rail-new-chat { opacity:.75; }
+.odysseus-root .od-rail-btn.od-rail-new-chat:hover { opacity:1; }
+
+
+/* ===== Extend useWindowControls.ts to add edge tiling/snap on title-bar drag and an ephemeral minimized state, porting odysseus tileManager.js + modalSnap.js + modalManager.js minimize — fully backward compatible. ===== */
+/* Translucent edge-tiling snap preview (tileManager.js #tile-ghost). Rendered
+   by the dragging view from win.snapGhost (position:fixed + left/top/width/height
+   inline). Scoped under .odysseus-root, theme vars only, springy fade-in. */
+.odysseus-root .od-snap-ghost {
+  position: fixed;
+  z-index: 9998;
+  pointer-events: none;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  border: 2px dashed color-mix(in srgb, var(--accent) 55%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent) inset;
+  animation: od-snap-ghost-in 0.12s ease-out;
+}
+@keyframes od-snap-ghost-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+/* ===== Port odysseus spinner.js to a React component at plugins/plugin-task-coordinator/src/odysseus/Spinner.tsx — a presentational Spinner({ variant?, label? }) (variant: 'dots' | 'wave' | default whirlpool ring) plus a LoadingRow({ label }) for list/empty states. Theme-var colored, strict TS, biome-clean, no .css import (CSS returned as cssAdditions). ===== */
+/* ── odysseus spinner.js — Spinner / LoadingRow (NEW classes only) ──
+   The whirlpool ring (.od-whirlpool) and the loading row (.od-loading-row),
+   plus @keyframes od-whirlpool-spin, ALREADY EXIST in ODYSSEUS_CSS
+   (odysseus-theme.ts ~lines 8684-8709). Spinner.tsx reuses them verbatim, so
+   DO NOT re-add them. Only the text-spinner + a11y helper classes below are new. */
+
+/* shared spinner wrapper: ring/glyph variants share inline-flex layout */
+.odysseus-root .od-spinner {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  white-space: pre;
+  line-height: 1;
+  color: color-mix(in srgb, var(--fg) 70%, transparent);
+}
+.odysseus-root .od-spinner-label {
+  font-family: inherit;
+  font-size: 12px;
+  color: color-mix(in srgb, var(--fg) 65%, transparent);
+}
+
+/* dots / wave text spinner: the cycling ASCII or block-bar glyph.
+   Frame text is swapped in JS at the upstream 150ms cadence; this only styles
+   it. The accent/red theme var matches odysseus' rgba(156,222,242,…) wave hue
+   when the active palette is the default. */
+.odysseus-root .od-spinner-frame {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.5px;
+  color: color-mix(in srgb, var(--accent) 85%, var(--fg));
+  /* a soft breathing pulse so the glyph cycle reads as "alive" even mid-frame */
+  animation: od-spinner-pulse 1.5s ease-in-out infinite;
+}
+@keyframes od-spinner-pulse {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .odysseus-root .od-spinner-frame { animation: none; opacity: 0.9; }
+}
+
+/* visually-hidden live-region text for the icon-only (no-label) case */
+.odysseus-root .od-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+
+/* ===== Add mobile-responsive overlay-drawer behavior to the odysseus clone shell (port of sidebar-layout.js), gated below a 700px viewport. ===== */
+/* ── mobile sidebar overlay drawer (odysseus sidebar-layout.js + the
+   max-width:768px .sidebar / #sidebar-backdrop rules in static/style.css) ──
+   Below MOBILE_BREAKPOINT (700px) the shell sets .od-mobile on the root and adds
+   .od-sidebar-open while the drawer is open. The drawer then slides in OVER the
+   chat (it does not push it) backed by a tap-to-close scrim. All gating is
+   class-based so the desktop in-flow, drag-resizable sidebar is untouched.
+   position:absolute (not fixed) because everything is scoped inside the
+   position:relative .odysseus-root host. */
+.odysseus-root .od-sidebar-backdrop { display:none; }
+.odysseus-root.od-mobile .od-sidebar-backdrop { display:block; position:absolute; inset:0;
+  z-index:199; border:none; padding:0; margin:0; appearance:none; cursor:pointer;
+  background:color-mix(in srgb, var(--bg) 45%, rgba(0,0,0,.55)); opacity:0; pointer-events:none;
+  transition:opacity .25s ease; }
+.odysseus-root.od-mobile.od-sidebar-open .od-sidebar-backdrop { opacity:1; pointer-events:auto; }
+.odysseus-root.od-mobile .od-sidebar { position:absolute; top:0; bottom:0; left:0; z-index:200;
+  width:min(82vw, 320px) !important; max-width:320px; flex-shrink:0;
+  box-shadow:4px 0 24px rgba(0,0,0,.5); transform:translateX(-100%);
+  transition:transform .25s ease; }
+.odysseus-root.od-mobile.od-sidebar-open .od-sidebar { transform:translateX(0); }
+/* The drag-resize handle is meaningless for a full-width overlay drawer — hide
+   it on mobile so an edge touch can't start a phantom resize. */
+.odysseus-root.od-mobile .od-sidebar-resize-handle { display:none; }
+@media (prefers-reduced-motion: reduce) {
+  .odysseus-root.od-mobile .od-sidebar,
+  .odysseus-root.od-mobile .od-sidebar-backdrop { transition:none; }
+}
+
+
+/* sweep:shell-chat */
+/* MessageBubble: error-tone agent body. Replaces an inline style={{color:'var(--red)'}}
+   so the error color lives in CSS like every other bubble rule. */
+.odysseus-root .od-msg-ai .od-body.od-body-error { color: var(--red); }
+/* sweep:sidebar-theme */
+/* ── ThemeMenu close backdrop (replaces the removed inline style on the
+   dialog's dismiss button). Sits under the anchored .od-theme-menu popover and
+   catches outside clicks. Scoped under .odysseus-root. ── */
+.odysseus-root .od-theme-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 55;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: default;
+}
+
+/* ── SearchPalette failed-lookup state. Reuses the .od-search-empty centred
+   layout but tints the message with the theme accent so a backend/network
+   failure is visually distinct from a genuinely empty result. ── */
+.odysseus-root .od-search-empty.od-search-error {
+  color: var(--red);
+}
+/* sweep:tools-b */
+/* GroupChatView: stderr message bubbles render in the error color. Moved off an
+   inline style={{ color: "var(--red)" }} into a class so styling lives in CSS.
+   (The per-participant role-dot colors stay inline — they are hashed hsl()
+   values computed per participant and cannot be static classes.) */
+.odysseus-root .od-group-body-stderr {
+  color: var(--red);
+}
+
+/* ===== GalleryView: Edit-tab landing (gallery.js _renderEditorLanding) =====
+   The Gallery modal's Edit tab (the real 13-image-editor frame). The shared
+   .gallery-editor-landing rule is the GalleryEditorView CANVAS stage (a
+   checkerboard, aspect-ratio box). Inside the gallery Edit tab the landing is
+   instead a plain, flat, top-aligned hero (odysseus style.css line 22615), so
+   these rules are scoped under .od-gallery-secondary to override the canvas
+   styling without touching GalleryEditorView. Colors via theme vars. */
+.odysseus-root .od-gallery-secondary .gallery-editor-landing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 14px;
+  padding: 48px 16px 24px;
+  flex: 0 0 auto;
+  width: auto;
+  aspect-ratio: auto;
+  max-height: none;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  background: none;
+  text-align: center;
+  color: var(--fg);
+}
+.odysseus-root .od-gallery-secondary .gallery-editor-landing h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+.odysseus-root .od-gallery-secondary .gallery-editor-landing p {
+  margin: 0;
+  opacity: 0.6;
+  font-size: 13px;
+  max-width: 320px;
+  line-height: 1.5;
+}
+.odysseus-root .gallery-editor-landing-btn {
+  padding: 7px 22px;
+  font-size: 13px;
+  opacity: 0.85;
+}
+.odysseus-root .gallery-editor-landing-btn:hover:not(:disabled) {
+  opacity: 1;
+}
+.odysseus-root .gallery-editor-landing-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+/* Template picker — native <select>, centered under the actions. */
+.odysseus-root .gallery-editor-template-label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  margin-top: 18px;
+  font-size: 11px;
+  opacity: 0.55;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.odysseus-root .gallery-editor-template-select {
+  min-width: 240px;
+  padding: 8px 12px;
+  background: var(--panel);
+  color: var(--fg);
+  border: 1px solid var(--red);
+  border-radius: 6px;
+  font: inherit;
+  font-size: 13px;
+  text-transform: none;
+  letter-spacing: normal;
+  cursor: pointer;
+}
+.odysseus-root .gallery-editor-template-select:hover:not(:disabled),
+.odysseus-root .gallery-editor-template-select:focus {
+  outline: none;
+  border-color: var(--red);
+}
+.odysseus-root .gallery-editor-template-select:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+/* Saved-projects row: divider + centered header (title / search / Select). */
+.odysseus-root .gallery-editor-drafts {
+  width: min(720px, 92%);
+  margin: 28px auto 0;
+  padding-top: 18px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.odysseus-root .gallery-editor-drafts-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.odysseus-root .gallery-editor-drafts-title {
+  margin: 0;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.55;
+  font-weight: 600;
+  text-align: left;
+  flex-shrink: 0;
+}
+.odysseus-root .gallery-editor-drafts-search {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 280px;
+  height: 26px;
+  box-sizing: border-box;
+  padding: 0 8px;
+  font-size: 12px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+.odysseus-root .gallery-editor-drafts-search:focus {
+  outline: none;
+  border-color: var(--red);
+}
+.odysseus-root .gallery-editor-drafts-search:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+.odysseus-root .gallery-editor-drafts-search::placeholder {
+  color: color-mix(in srgb, var(--fg) 35%, transparent);
+}
+/* The Select button trails the header, lined up with the search bar height. */
+.odysseus-root .gallery-editor-drafts-header .od-gallery-select-btn {
+  margin-left: auto;
+  height: 26px;
+  box-sizing: border-box;
+  padding: 0 10px;
+  font-size: 12px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.odysseus-root .gallery-editor-drafts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 10px;
+}
+/* Honest empty saved-projects state — no editor-drafts backend. */
+.odysseus-root .gallery-editor-drafts-grid .od-gallery-empty {
+  grid-column: 1 / -1;
+}
+
+/* ===== SettingsPanel: full 12-tab odysseus settings modal =====
+   odysseus #settings-modal (index.html ~1300-2220) + settings.js / admin.js
+   chrome. Builds on the existing .od-settings-* / .od-vis-* / .od-shortcut-* /
+   .od-skill-* base rules above; only the new structure (rail icons + grouped
+   dividers + ADMIN header, header peek toggle, subtitle row, card icon/faded/
+   sub, services collapsible endpoint sections + lists, inline AI selectors,
+   account block, switches, add-form, allowed-models, tool catalogue, danger
+   zone) is defined here. Theme vars only, scoped .odysseus-root. */
+
+/* Header: leading gear icon + Peek (theme-opacity) toggle (inert; shell owns
+   the fade). */
+.odysseus-root .od-settings-header-icon { font-size: 15px; line-height: 1; color: var(--red); }
+.odysseus-root .od-settings-peek {
+  display: inline-flex; align-items: center; gap: 5px; height: 26px; padding: 0 9px;
+  border: 1px solid var(--border); border-radius: 6px; background: var(--panel);
+  color: color-mix(in srgb, var(--fg) 60%, transparent); font-size: 11px; font-family: inherit;
+  cursor: pointer; transition: background 0.15s, border-color 0.15s;
+}
+.odysseus-root .od-settings-peek:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Subtitle row under the header (admin-toggle-sub). */
+.odysseus-root .od-settings-subtitle {
+  padding: 6px 14px 8px; font-size: 11px;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+  flex-shrink: 0;
+}
+
+/* Rail: icon + label items, grouped by dividers + admin section header. */
+.odysseus-root .od-settings-rail-item {
+  display: flex; align-items: center; gap: 9px;
+}
+.odysseus-root .od-settings-rail-ico {
+  display: inline-flex; flex-shrink: 0;
+  color: color-mix(in srgb, var(--fg) 60%, transparent);
+}
+.odysseus-root .od-settings-rail-item.active .od-settings-rail-ico { color: var(--accent, var(--red)); }
+.odysseus-root .od-settings-rail-item.active { color: var(--fg); font-weight: 500; }
+.odysseus-root .od-settings-rail-divider {
+  height: 1px; margin: 7px 4px; flex-shrink: 0;
+  background: color-mix(in srgb, var(--border) 70%, transparent);
+}
+
+/* Card title: leading icon + faded parenthetical suffix + sub line. */
+.odysseus-root .od-set-card-title {
+  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+  margin: 0 0 4px; padding-bottom: 6px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 40%, transparent);
+  font-size: 14px; font-weight: 600; letter-spacing: -0.03em; color: var(--fg);
+}
+.odysseus-root .od-set-card-title-icon { display: inline-flex; opacity: 0.6; flex-shrink: 0; }
+.odysseus-root .od-set-card-faded { font-size: 0.82em; font-weight: normal; opacity: 0.45; }
+.odysseus-root .od-set-sub {
+  margin-bottom: 8px; font-size: 11px; line-height: 1.5;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+}
+
+/* Inline (right-aligned) selects in AI Defaults rows. */
+.odysseus-root .od-set-inline-select { width: auto; min-width: 150px; padding: 6px 9px; }
+
+/* Buttons (admin-btn-sm / admin-btn-add / admin-btn-delete, 1:1). */
+.odysseus-root .od-settings-btn-sm,
+.odysseus-root .od-settings-btn-add,
+.odysseus-root .od-settings-btn-delete {
+  display: inline-flex; align-items: center; gap: 5px; padding: 6px 13px;
+  border-radius: 6px; font-size: 12px; font-family: inherit; cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, opacity 0.15s;
+}
+.odysseus-root .od-settings-btn-sm {
+  border: 1px solid var(--border); background: var(--panel); color: var(--fg);
+}
+.odysseus-root .od-settings-btn-sm:hover:not(:disabled) { background: var(--border); border-color: var(--red); }
+.odysseus-root .od-settings-btn-add {
+  border: 1px solid color-mix(in srgb, var(--accent, var(--red)) 45%, var(--border));
+  background: color-mix(in srgb, var(--accent, var(--red)) 14%, transparent); color: var(--fg);
+}
+.odysseus-root .od-settings-btn-add:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent, var(--red)) 22%, transparent);
+}
+.odysseus-root .od-settings-btn-delete {
+  border: 1px solid color-mix(in srgb, var(--red) 50%, var(--border));
+  background: color-mix(in srgb, var(--red) 10%, transparent); color: var(--red);
+  white-space: nowrap;
+}
+.odysseus-root .od-settings-btn-delete:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--red) 18%, transparent);
+}
+.odysseus-root .od-settings-btn-sm:disabled,
+.odysseus-root .od-settings-btn-add:disabled,
+.odysseus-root .od-settings-btn-delete:disabled { opacity: 0.5; cursor: not-allowed; }
+.odysseus-root .od-set-btn-ico { display: inline-flex; }
+.odysseus-root .od-set-actions-end { justify-content: flex-end; }
+.odysseus-root .od-set-center-actions { text-align: center; padding: 8px 0 2px; }
+.odysseus-root .od-set-row-action { display: flex; align-items: center; gap: 10px; }
+.odysseus-root .od-set-row-action .od-set-sub { flex: 1; margin: 0; }
+
+/* Services: collapsible Local/API endpoint add sections. */
+.odysseus-root .od-set-ep-section {
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  border-radius: 7px; margin-top: 12px; overflow: hidden;
+}
+.odysseus-root .od-set-ep-section:first-of-type { margin-top: 4px; }
+.odysseus-root .od-set-ep-head {
+  display: flex; align-items: center; gap: 4px; width: 100%;
+  padding: 9px 11px; border: none; background: color-mix(in srgb, var(--fg) 4%, transparent);
+  color: var(--fg); font-size: 12px; font-weight: 500; font-family: inherit;
+  text-align: left; cursor: pointer; transition: background 0.12s;
+}
+.odysseus-root .od-set-ep-head:hover { background: color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-set-ep-head-ico { display: inline-flex; opacity: 0.7; }
+.odysseus-root .od-set-ep-caret { margin-left: auto; transition: transform 0.15s; opacity: 0.6; }
+.odysseus-root .od-set-ep-section.open .od-set-ep-caret { transform: rotate(180deg); }
+.odysseus-root .od-set-ep-form { display: flex; flex-direction: column; gap: 8px; padding: 11px; }
+.odysseus-root .od-set-ep-row { display: flex; gap: 8px; align-items: center; }
+.odysseus-root .od-set-ep-actions { justify-content: flex-end; }
+.odysseus-root .od-set-ep-spacer { flex: 1; }
+.odysseus-root .od-set-ep-type { width: 80px; flex-shrink: 0; }
+.odysseus-root .od-set-quickstart {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  padding-top: 6px; border-top: 1px solid color-mix(in srgb, var(--border) 40%, transparent);
+}
+.odysseus-root .od-set-quickstart-label {
+  font-size: 11px; color: color-mix(in srgb, var(--fg) 50%, transparent);
+}
+
+/* Added Models endpoint lists (Local / API → None). */
+.odysseus-root .od-set-ep-list { margin-top: 14px; }
+.odysseus-root .od-set-ep-list:first-of-type { margin-top: 4px; }
+.odysseus-root .od-set-ep-list-head {
+  display: flex; align-items: center; gap: 5px; margin-bottom: 4px;
+  font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+  color: color-mix(in srgb, var(--fg) 60%, transparent);
+}
+.odysseus-root .od-set-ep-list-ico { display: inline-flex; opacity: 0.7; }
+.odysseus-root .od-set-ep-none { padding: 4px 2px; font-size: 12px; color: var(--accent, var(--red)); }
+
+/* Account block. */
+.odysseus-root .od-set-account-row { display: flex; align-items: center; gap: 10px; margin: 4px 0; }
+.odysseus-root .od-set-account-avatar {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 32px; height: 32px; border-radius: 50%; flex-shrink: 0;
+  background: color-mix(in srgb, var(--accent, var(--red)) 18%, transparent);
+  color: var(--fg); font-size: 14px; font-weight: 600;
+}
+.odysseus-root .od-set-account-meta { flex: 1; min-width: 0; }
+.odysseus-root .od-set-account-name { font-size: 13px; font-weight: 600; color: var(--fg); }
+.odysseus-root .od-set-account-role { font-size: 11px; opacity: 0.5; }
+.odysseus-root .od-settings-btn-logout {
+  display: inline-flex; align-items: center; gap: 6px; padding: 6px 12px;
+  border: 1px solid var(--red); border-radius: 6px;
+  background: color-mix(in srgb, var(--red) 10%, transparent);
+  color: var(--red); font-size: 12px; font-family: inherit; cursor: pointer;
+}
+.odysseus-root .od-settings-btn-logout:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Switches (admin-switch / admin-slider, reused for tools + users). */
+.odysseus-root .od-set-switch { position: relative; display: inline-block; width: 36px; height: 20px; flex-shrink: 0; }
+.odysseus-root .od-set-switch input { opacity: 0; width: 0; height: 0; }
+.odysseus-root .od-set-slider {
+  position: absolute; inset: 0; cursor: pointer; border-radius: 20px;
+  background: color-mix(in srgb, var(--fg) 22%, transparent); transition: background 0.15s;
+}
+.odysseus-root .od-set-slider::before {
+  content: ""; position: absolute; left: 3px; top: 3px; width: 14px; height: 14px;
+  border-radius: 50%; background: var(--bg); transition: transform 0.15s;
+}
+.odysseus-root .od-set-switch input:checked + .od-set-slider { background: var(--accent, var(--red)); }
+.odysseus-root .od-set-switch input:checked + .od-set-slider::before { transform: translateX(16px); }
+.odysseus-root .od-set-switch input:disabled + .od-set-slider { cursor: not-allowed; opacity: 0.6; }
+.odysseus-root .od-set-switch-inline {
+  display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--fg);
+}
+
+/* Add User form. */
+.odysseus-root .od-set-add-form { display: flex; flex-direction: column; gap: 8px; margin-bottom: 8px; }
+.odysseus-root .od-set-add-form input {
+  padding: 7px 9px; background: color-mix(in srgb, var(--fg) 4%, var(--panel));
+  border: 1px solid var(--border); border-radius: 6px; color: var(--fg);
+  font-size: 12px; font-family: inherit; outline: none;
+}
+
+/* Allowed-models checkbox grid (real provider models). */
+.odysseus-root .od-set-priv-models {
+  display: flex; flex-direction: column; gap: 4px; max-height: 200px; overflow-y: auto;
+  padding: 2px; border: 1px solid color-mix(in srgb, var(--border) 50%, transparent); border-radius: 6px;
+}
+.odysseus-root .od-set-priv-model {
+  display: flex; align-items: center; gap: 7px; padding: 4px 6px;
+  font-size: 12px; color: var(--fg);
+}
+.odysseus-root .od-set-priv-model input { accent-color: var(--accent, var(--red)); }
+
+/* Agent Tools catalogue (collapsible categories). */
+.odysseus-root .od-set-tool-list { display: flex; flex-direction: column; gap: 6px; }
+.odysseus-root .od-set-tool-cat {
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent); border-radius: 7px; overflow: hidden;
+}
+.odysseus-root .od-set-tool-cat-head {
+  display: flex; align-items: center; justify-content: space-between; width: 100%;
+  padding: 8px 11px; border: none; background: color-mix(in srgb, var(--fg) 4%, transparent);
+  color: var(--fg); font-size: 12px; font-weight: 600; font-family: inherit;
+  cursor: pointer; transition: background 0.12s;
+}
+.odysseus-root .od-set-tool-cat-head:hover { background: color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-set-tool-cat-right { display: flex; align-items: center; gap: 8px; }
+.odysseus-root .od-set-tool-cat-count {
+  font-size: 11px; opacity: 0.5;
+}
+.odysseus-root .od-set-tool-cat-chev { font-size: 10px; opacity: 0.5; transition: transform 0.15s; }
+.odysseus-root .od-set-tool-cat-chev[data-open="true"] { transform: rotate(180deg); }
+.odysseus-root .od-set-tool-cat-body { padding: 4px 2px; }
+.odysseus-root .od-set-tool-row {
+  display: flex; align-items: center; gap: 10px; padding: 7px 9px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 30%, transparent);
+}
+.odysseus-root .od-set-tool-row:last-child { border-bottom: none; }
+.odysseus-root .od-set-tool-info { flex: 1; min-width: 0; }
+.odysseus-root .od-set-tool-name { font-size: 12px; font-weight: 500; color: var(--fg); display: block; }
+.odysseus-root .od-set-tool-desc { font-size: 11px; color: color-mix(in srgb, var(--fg) 50%, transparent); }
+.odysseus-root .od-set-tool-ctx {
+  font-size: 10px; opacity: 0.45; padding: 1px 6px; flex-shrink: 0;
+  border: 1px solid color-mix(in srgb, var(--border) 60%, transparent); border-radius: 10px;
+}
+
+/* System: Danger Zone. */
+.odysseus-root .od-set-danger-card { border-color: color-mix(in srgb, var(--red) 40%, var(--border)); }
+.odysseus-root .od-set-danger-title { color: var(--red); border-bottom-color: color-mix(in srgb, var(--red) 25%, transparent); }
+.odysseus-root .od-set-wipe-row {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  padding: 8px 0; border-bottom: 1px solid color-mix(in srgb, var(--border) 30%, transparent);
+}
+.odysseus-root .od-set-wipe-row:last-of-type { border-bottom: none; }
+
+
+/* ===== 1to1: brain ===== */
+/* ===== brain-1to1: MemoryPanel as the unified Brain modal ===== */
+
+/* Window header: title (icon + text) on the left, close button on the right.
+   .od-mem-head already supplies the baseline flex; add a spacer + close. */
+.odysseus-root .od-mem-title { display: inline-flex; align-items: center; gap: 6px; }
+.odysseus-root .od-mem-title-icon { color: var(--accent, var(--red)); flex-shrink: 0; }
+.odysseus-root .od-mem-head-spacer { flex: 1 1 auto; }
+.odysseus-root .od-win-close { display: inline-flex; align-items: center; justify-content: center;
+  width: 26px; height: 26px; padding: 0; border: 1px solid transparent; border-radius: 6px;
+  background: none; color: color-mix(in srgb, var(--fg) 55%, transparent); cursor: pointer; flex-shrink: 0; }
+.odysseus-root .od-win-close:hover { color: var(--fg); border-color: var(--border);
+  background: color-mix(in srgb, var(--fg) 8%, transparent); }
+
+/* Four-tab row count badges (#memory-count / #skills-count). */
+.odysseus-root .od-mem-tab-count { font-size: 0.8em; opacity: 0.6; font-weight: 400; margin-left: 2px; }
+
+/* Inner admin-card wrapping each tab body. Browse + Skills cards are flex
+   columns that own their own scroll so the panel's rounded bottom stays put. */
+.odysseus-root .od-mem-card { display: flex; flex-direction: column; min-height: 0; flex: 1 1 auto;
+  margin: 10px 12px 12px; padding: 12px 14px; border: 1px solid var(--border); border-radius: 10px;
+  background: var(--card, color-mix(in srgb, var(--fg) 3%, transparent)); overflow: hidden; }
+.odysseus-root .od-mem-card-skills { padding: 8px 8px 4px; }
+
+/* Card header row: H2 title (+ count) — spacer — toggle / io-buttons. */
+.odysseus-root .od-mem-card-head { display: flex; align-items: center; gap: 8px; margin-bottom: 2px; }
+.odysseus-root .od-mem-card-title { display: inline-flex; align-items: center; gap: 6px; margin: 0; padding: 0;
+  line-height: 1; font-size: 15px; font-weight: 600; color: var(--fg); }
+.odysseus-root .od-mem-card-count { font-size: 0.6em; opacity: 0.6; font-weight: 400; }
+.odysseus-root .od-mem-card-spacer { flex: 1 1 auto; }
+
+/* Context-include / settings toggle — odysseus .admin-switch, rendered inert.
+   Faithful pill+knob look; dimmed + not-allowed to read as a disabled chrome. */
+.odysseus-root .od-mem-switch { position: relative; display: inline-flex; flex-shrink: 0; cursor: not-allowed; }
+.odysseus-root .od-mem-switch input { position: absolute; opacity: 0; width: 0; height: 0; margin: 0; }
+.odysseus-root .od-mem-switch-track { position: relative; width: 34px; height: 18px; border-radius: 999px;
+  background: color-mix(in srgb, var(--fg) 18%, transparent); transition: background .15s; }
+.odysseus-root .od-mem-switch-track::after { content: ""; position: absolute; top: 2px; left: 2px;
+  width: 14px; height: 14px; border-radius: 50%; background: var(--bg); transition: transform .15s; }
+.odysseus-root .od-mem-switch input:checked + .od-mem-switch-track {
+  background: color-mix(in srgb, var(--accent, var(--red)) 55%, transparent); }
+.odysseus-root .od-mem-switch input:checked + .od-mem-switch-track::after { transform: translateX(16px); }
+.odysseus-root .od-mem-switch input:disabled + .od-mem-switch-track { opacity: 0.55; }
+
+/* Browse description sits inside the card now (reset the old absolute margin). */
+.odysseus-root .od-mem-card .od-mem-desc { margin: 6px 0 0; }
+
+/* Toolbar restructured to a column: row 1 (sort + Select + Tidy), full-width
+   search, then chips. Overrides the old single-row flex layout. */
+.odysseus-root .od-mem-card .od-mem-toolbar { display: flex; flex-direction: column; align-items: stretch;
+  gap: 8px; padding: 10px 0 8px; }
+.odysseus-root .od-mem-toolbar-row { display: flex; align-items: center; gap: 8px; }
+.odysseus-root .od-mem-card .od-mem-sort { flex: 0 0 auto; }
+.odysseus-root .od-mem-toolbar-btn { display: inline-flex; align-items: center; gap: 3px; flex-shrink: 0;
+  padding: 5px 10px; border: 1px solid var(--border); border-radius: 7px; background: none;
+  color: color-mix(in srgb, var(--fg) 65%, transparent); font-size: 12px; font-family: inherit; cursor: pointer; }
+.odysseus-root .od-mem-toolbar-btn:hover:not(:disabled) { color: var(--fg); border-color: var(--fg); }
+.odysseus-root .od-mem-toolbar-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+.odysseus-root .od-mem-card .od-mem-search-wrap { width: 100%; }
+.odysseus-root .od-mem-card .od-mem-cats { padding: 0; }
+
+/* Stacked honest empty state: caption line + Import-in-Add link below. */
+.odysseus-root .od-mem-empty { display: flex; flex-direction: column; align-items: center; gap: 6px; }
+.odysseus-root .od-mem-empty .od-mem-empty-link { font-size: 12px; font-style: italic; }
+
+/* Add tab: stack of cards. */
+.odysseus-root .od-mem-add { display: flex; flex-direction: column; gap: 10px; padding: 10px 12px 14px;
+  overflow-y: auto; min-height: 0; flex: 1 1 auto; }
+.odysseus-root .od-mem-add-card { flex: 0 0 auto; margin: 0; }
+.odysseus-root .od-mem-add-card .od-mem-add-desc { margin: 6px 0 8px; }
+.odysseus-root .od-mem-io-btn { display: inline-flex; align-items: center; gap: 4px; flex-shrink: 0;
+  height: 26px; padding: 0 9px; border: 1px solid var(--border); border-radius: 7px; background: none;
+  color: color-mix(in srgb, var(--fg) 65%, transparent); font-size: 12px; font-family: inherit; cursor: pointer; }
+.odysseus-root .od-mem-io-btn:hover:not(:disabled) { color: var(--fg); border-color: var(--fg); }
+.odysseus-root .od-mem-io-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+.odysseus-root .od-mem-add-btn { display: inline-flex; align-items: center; gap: 5px; }
+.odysseus-root .od-mem-add-btn-secondary { align-self: flex-start; margin-top: 8px;
+  border-color: var(--border); background: none; color: color-mix(in srgb, var(--fg) 70%, transparent); }
+.odysseus-root .od-mem-add-btn-secondary:hover:not(:disabled) { color: var(--fg); border-color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 6%, transparent); }
+
+/* Settings tab: odysseus admin-card stack. */
+.odysseus-root .od-mem-settings { display: flex; flex-direction: column; gap: 10px; padding: 10px 12px 14px;
+  overflow-y: auto; min-height: 0; flex: 1 1 auto; }
+.odysseus-root .od-mem-set-card { flex: 0 0 auto; margin: 0; }
+.odysseus-root .od-mem-set-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.odysseus-root .od-mem-set-sub { display: block; margin-top: 6px; font-size: 11px; line-height: 1.45;
+  color: color-mix(in srgb, var(--fg) 55%, transparent); }
+.odysseus-root .od-mem-set-hint { opacity: 0.8; }
+.odysseus-root .od-mem-set-control { display: flex; align-items: center; justify-content: space-between;
+  gap: 12px; margin-top: 8px; }
+.odysseus-root .od-mem-set-number { flex-shrink: 0; width: 72px; padding: 4px 6px; border: 1px solid var(--border);
+  border-radius: 6px; background: var(--input-bg, var(--panel)); color: var(--fg); font-size: 12px;
+  text-align: right; font-variant-numeric: tabular-nums; }
+.odysseus-root .od-mem-set-number:disabled { opacity: 0.5; cursor: not-allowed; }
+.odysseus-root .od-mem-set-note { margin: 2px 0 0; padding: 0 2px; font-size: 11px; line-height: 1.5;
+  color: color-mix(in srgb, var(--fg) 45%, transparent); }
+
+/* The Skills tab body reuses .od-skills-* rules; align its desc/toolbar/search/
+   grid/add to the inner card padding rather than the old fixed 16px page inset. */
+.odysseus-root .od-mem-card-skills .od-skills-desc,
+.odysseus-root .od-mem-card-skills .od-skills-toolbar { padding-left: 6px; padding-right: 6px; }
+.odysseus-root .od-mem-card-skills .od-skills-search { margin-left: 6px; margin-right: 6px; }
+.odysseus-root .od-mem-card-skills .od-skills-grid { padding-left: 6px; padding-right: 6px; }
+.odysseus-root .od-mem-card-skills .od-skills-add { margin-left: 6px; margin-right: 6px; }
+/* ===== 1to1: notes ===== */
+/* ===== fix-wave-B: NotesPanel (1:1 with odysseus notes.js) =====
+   Appended AFTER the existing fix-wave-A NotesPanel block so equal-specificity
+   rules win. Right-docks the pane, restyles the accent title, header icon
+   buttons, icon-only quick-add pills, the inert photo control, and the
+   smiley empty state. All scoped .odysseus-root, theme-var driven. */
+
+/* Right-dock: override the centered .od-search-overlay default. The pane pins
+   to the right edge, full viewport height (notes.js _restoreNotesSidebarDock →
+   modal-right-docked). Dragging/resizing hands off to win.panelStyle, so this
+   only governs the un-interacted default. */
+.odysseus-root .od-search-overlay.od-notes-overlay {
+  align-items: stretch; justify-content: flex-end; padding: 0; overflow: hidden; }
+.odysseus-root .od-notes-overlay:not(.od-windowed) > .od-search-panel.od-mem-panel.od-notes-panel {
+  width: 560px; max-width: 88%; height: 100%; max-height: none;
+  border-radius: 12px 0 0 12px; box-shadow: -12px 0 40px rgba(0,0,0,.4); }
+
+/* Accent title + leading document icon (notes.js .notes-pane-title). */
+.odysseus-root .od-notes-title { display: inline-flex; align-items: center; gap: 6px;
+  color: var(--accent, var(--red)); }
+.odysseus-root .od-notes-title-icon { flex-shrink: 0; }
+
+/* Header buttons carry an icon + label (notes.js .notes-header-text-btn). */
+.odysseus-root .od-notes-head-icon-btn { display: inline-flex; align-items: center; gap: 5px; }
+.odysseus-root .od-notes-head-icon-btn svg { flex-shrink: 0; opacity: 0.85; }
+.odysseus-root .od-notes-head-icon-btn:hover svg { opacity: 1; }
+.odysseus-root .od-notes-head-btn-label { line-height: 1; }
+
+/* Quick-add type pills are icon-only squares (notes.js .notes-quick-type-pill). */
+.odysseus-root .od-notes-quick-seg .od-notes-quick-pill { display: inline-flex; align-items: center;
+  justify-content: center; padding: 5px 8px; }
+.odysseus-root .od-notes-quick-seg .od-notes-quick-pill svg { display: block; }
+/* Trailing attach-photo control — inert (no upload backend) but present for
+   chrome parity (notes.js .notes-quick-icon). */
+.odysseus-root .od-notes-quick-icon { flex-shrink: 0; background: none; border: none; cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center; padding: 4px 6px; border-radius: 6px;
+  color: color-mix(in srgb, var(--fg) 45%, transparent); }
+.odysseus-root .od-notes-quick-icon:hover:not(:disabled) { color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 7%, transparent); }
+.odysseus-root .od-notes-quick-icon:disabled { opacity: 0.4; cursor: default; }
+
+/* Form type-seg pills keep icon + text label (notes.js .note-form-type-pill). */
+.odysseus-root .od-note-form-pill { display: inline-flex; align-items: center; gap: 5px; }
+.odysseus-root .od-note-form-pill svg { flex-shrink: 0; }
+
+/* Empty-list message + smiley (notes.js .notes-empty-msg / ui.js emptyStateIcon). */
+.odysseus-root .od-notes-empty-msg { padding: 28px 16px; text-align: center; font-size: 13px;
+  color: color-mix(in srgb, var(--fg) 50%, transparent);
+  display: flex; align-items: center; justify-content: center; gap: 4px; }
+.odysseus-root .od-notes-empty-icon { vertical-align: -3px; flex-shrink: 0; }
+/* ===== 1to1: documents ===== */
+/* ===== documents view 1:1 fixes (scoped .odysseus-root; theme vars only) ===== */
+
+/* Title: leading BookOpen icon + accent tint, matching odysseus
+   .modal-header h4 { color:var(--red) } with the open-book SVG. */
+.odysseus-root .od-doclib-title {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 14px; font-weight: 600; letter-spacing: -0.03em;
+  color: var(--accent, var(--red));
+}
+.odysseus-root .od-doclib-title svg { flex-shrink: 0; }
+
+/* Lib-tabs: 12px leading icon sits 3px left of the label (documentLibrary.js:1578). */
+.odysseus-root .od-lib-tab {
+  display: inline-flex; align-items: center; gap: 3px;
+}
+.odysseus-root .od-lib-tab svg { flex-shrink: 0; vertical-align: -1px; }
+
+/* Documents <h2> heading + small dim inline count (odysseus inline
+   <h2 margin:0;padding:0;line-height:1> + .memory-count 0.6em/0.6 opacity). */
+.odysseus-root .od-doclib-heading {
+  margin: 0; padding: 0; line-height: 1;
+  font-size: 14px; font-weight: 600; letter-spacing: -0.03em; color: var(--fg);
+  display: inline-flex; align-items: baseline; gap: 6px;
+}
+.odysseus-root .od-doclib-count {
+  font-size: 0.6em; opacity: 0.6; font-weight: normal;
+  color: color-mix(in srgb, var(--fg) 70%, transparent);
+}
+
+/* Stacked toolbar: filters row, then full-width search on its own row, then
+   chips row — odysseus .memory-toolbar { flex-direction:column } (style.css:9936). */
+.odysseus-root .od-doclib-toolbar {
+  display: flex; flex-direction: column; align-items: stretch; gap: 6px;
+  padding: 4px 16px 8px;
+}
+.odysseus-root .od-doclib-search { flex: none; width: 100%; }
+
+/* Inline empty state: "No documents yet" + dim hint with an underlined accent
+   Import link + " · or create one in a session" (documentLibrary.js:410-417). */
+.odysseus-root .od-doclib-empty-inline {
+  display: flex; align-items: center; justify-content: center;
+  gap: 8px; flex-wrap: wrap; font-style: normal;
+}
+.odysseus-root .od-doclib-empty-hint {
+  opacity: 0.7; font-size: 11px;
+  display: inline-flex; align-items: center;
+}
+.odysseus-root .od-doclib-empty-import {
+  background: none; border: none; padding: 0; cursor: pointer;
+  font-family: inherit; font-size: 11px;
+  color: var(--accent, var(--red)); text-decoration: underline;
+  display: inline-flex; align-items: center; gap: 0;
+}
+.odysseus-root .od-doclib-empty-import svg { margin: 0 4px; vertical-align: -2px; }
+.odysseus-root .od-doclib-empty-import:hover { opacity: 0.85; }
+/* ===== 1to1: compare ===== */
+/* ── Compare selector: 1:1 with odysseus selector.js / style.css (compare-*-toggle
+   + compare-mode-tab). These rules are appended after the base ODYSSEUS_CSS block
+   so they override the earlier pill-shaped .od-cmp-toggle / .od-cmp-sel-tab rules
+   with odysseus's tall icon-over-label box metrics. Theme-var coloured; the
+   semantic per-toggle hues (orange/blue/amber) are kept literal exactly as odysseus
+   hard-codes them, with Save mapped to --ok. */
+
+/* Section label — 9px uppercase w/ trailing colon (style.css .compare-section-label) */
+.odysseus-root .od-cmp-sel-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  opacity: 0.5;
+  font-weight: 600;
+  margin-bottom: 5px;
+}
+
+/* Mode-toggle + Type-tab rows: both stretch full width (children flex:1 1 0) */
+.odysseus-root .od-cmp-sel-toggles { display: flex; gap: 4px; flex-wrap: wrap; align-items: flex-start; min-width: 0; }
+.odysseus-root .od-cmp-sel-tabs { display: flex; gap: 4px; flex-wrap: wrap; min-width: 0; }
+
+/* Stacked icon-over-label box (style.css .compare-blind/parallel/dice/save/reset-toggle
+   and .compare-mode-tab — identical metrics) */
+.odysseus-root .od-cmp-toggle,
+.odysseus-root .od-cmp-sel-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: auto;
+  flex: 1 1 0;
+  flex-shrink: 0;
+  gap: 0;
+  padding: 5px 4px 4px;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  opacity: 0.35;
+  cursor: pointer;
+  user-select: none;
+  font-family: inherit;
+  font-weight: 500;
+  font-size: 11px;
+  transition: all 0.15s;
+}
+.odysseus-root .od-cmp-toggle-label {
+  display: block;
+  font-size: 9px;
+  line-height: 1;
+  margin-top: 2px;
+  font-weight: 500;
+}
+.odysseus-root .od-cmp-toggle:hover,
+.odysseus-root .od-cmp-sel-tab:hover {
+  opacity: 0.7;
+  background: color-mix(in srgb, var(--fg) 6%, transparent);
+  border-color: var(--border);
+}
+.odysseus-root .od-cmp-toggle:disabled,
+.odysseus-root .od-cmp-sel-tab:disabled {
+  cursor: not-allowed;
+}
+.odysseus-root .od-cmp-toggle:disabled:hover,
+.odysseus-root .od-cmp-sel-tab:disabled:hover {
+  opacity: 0.35;
+  background: none;
+}
+
+/* Generic active box (Shuffle/Reset have no special hue; matches .compare-mode-tab.active) */
+.odysseus-root .od-cmp-toggle.active,
+.odysseus-root .od-cmp-sel-tab.active {
+  opacity: 1;
+  border-color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+}
+
+/* Per-toggle semantic accents (style.css .compare-blind/parallel/save-toggle) */
+.odysseus-root .od-cmp-toggle-blind.active {
+  opacity: 1;
+  color: #ff9800;
+  border-color: #ff9800;
+  background: rgba(255, 152, 0, 0.1);
+}
+/* Parallel resting (toggle ON->sequential shows amber); active==parallel shows blue */
+.odysseus-root .od-cmp-toggle-parallel {
+  opacity: 1;
+  color: #e0a050;
+  border-color: #e0a050;
+  background: rgba(224, 160, 80, 0.1);
+}
+.odysseus-root .od-cmp-toggle-parallel.active {
+  color: #5b8def;
+  border-color: #5b8def;
+  background: rgba(91, 141, 239, 0.1);
+}
+.odysseus-root .od-cmp-toggle-save.active {
+  opacity: 1;
+  color: var(--ok);
+  border-color: var(--ok);
+  background: color-mix(in srgb, var(--ok) 12%, transparent);
+}
+
+/* Whole-section empty state (selector.js line 1305 "No models available") */
+.odysseus-root .od-cmp-sel-empty {
+  color: var(--red);
+  font-size: 0.85em;
+  padding: 12px 0;
+  text-align: center;
+}
+/* ===== 1to1: research ===== */
+/* ===== fix-wave: ResearchView 1:1 ===== */
+/* Center the Deep Research pane vertically in its overlay to match odysseus's
+   centered '.modal' (the real frame shows the pane mid-screen, not tucked at
+   the shared overlay's 12vh top anchor). Scoped to the research overlay only so
+   the other tool panels keep their top-anchored placement. The windowed state
+   (after drag) still wins via inline win.panelStyle. */
+.odysseus-root .od-search-overlay.od-research-overlay {
+  align-items: center;
+  padding: 2vh 0;
+}
+
+/* Framed close button — match odysseus '.close-btn' (a 24x24 bordered box with
+   var(--bg) fill + 1px solid var(--fg) border, hover inverts), so the header
+   control reads as a framed box like the real frame rather than a borderless
+   glyph. Higher specificity than the base '.research-pane-close' rule, so the
+   framed look wins; the inner lucide X is centered. */
+.odysseus-root .research-pane-close.close-btn {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  opacity: 1;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--fg);
+  border-radius: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+  flex-shrink: 0;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.odysseus-root .research-pane-close.close-btn:hover {
+  background: var(--fg);
+  color: var(--bg);
+  opacity: 1;
+}
+/* ===== 1to1: calendar ===== */
+/* ===== CalendarView 1:1 additions (scoped .odysseus-root, theme vars only) =====
+   Appended after the base calendar block in odysseus-theme.ts; later rules win
+   on equal specificity, so the .od-cal-title redefinition (now the window
+   titlebar wordmark) and the .od-cal-panel column override take effect. */
+
+/* Panel now stacks the window titlebar above the body (was flex-direction:row
+   for a never-rendered right sidebar). */
+.odysseus-root .od-cal-panel { flex-direction:column; }
+
+/* Window titlebar (calendar.js .modal-header). Mirrors the gallery/email header
+   chrome: icon + accent wordmark on the left, close on the right, draggable. */
+.odysseus-root .od-cal-window-header { display:flex; align-items:center; justify-content:space-between; padding:10px 14px 8px; border-bottom:1px solid var(--border); flex-shrink:0; }
+.odysseus-root .od-cal-title { display:flex; align-items:center; gap:6px; margin:0; font-size:1rem; font-weight:600; color:var(--accent, var(--red)); }
+.odysseus-root .od-cal-title svg { color:var(--accent, var(--red)); flex-shrink:0; }
+.odysseus-root .od-cal-window-close { background:none; border:none; color:var(--fg); opacity:0.6; cursor:pointer; padding:2px; display:inline-flex; border-radius:4px; transition:opacity 0.15s, background 0.15s; }
+.odysseus-root .od-cal-window-close:hover { opacity:1; background:color-mix(in srgb, var(--fg) 10%, transparent); }
+
+/* The body no longer owns the top chrome — tighten its top padding so the
+   toolbar sits just under the titlebar. */
+.odysseus-root .od-cal-body { padding-top:10px; }
+
+/* Period label (was .od-cal-title before the titlebar repurposed that name). */
+.odysseus-root .od-cal-period-title { font-size:13px; font-weight:600; white-space:nowrap; height:24px; line-height:24px; padding:0 6px; display:inline-flex; align-items:center; box-sizing:border-box; color:var(--fg); }
+
+/* "± tags" filter toggle (calendar.js .cal-filter-toggle). */
+.odysseus-root button.od-cal-filter-toggle { display:inline-flex; align-items:center; justify-content:center; background:color-mix(in srgb, var(--fg) 6%, transparent); border:1px solid var(--border); color:var(--fg); border-radius:5px; padding:0 8px; height:24px; cursor:pointer; font-size:10px; font-family:inherit; opacity:0.7; box-sizing:border-box; transition:opacity 0.15s, background 0.15s; }
+.odysseus-root button.od-cal-filter-toggle:hover { opacity:1; background:color-mix(in srgb, var(--fg) 12%, transparent); }
+
+/* Quick-add row (calendar.js .cal-quickadd-row) — inert/disabled here. */
+.odysseus-root .od-cal-quickadd-row { position:relative; display:flex; align-items:center; gap:8px; margin:0 0 8px; padding:1px 10px; border:1px solid var(--border); border-radius:8px; background:color-mix(in srgb, var(--fg) 3%, var(--bg)); transition:border-color 0.15s, background 0.15s; }
+.odysseus-root .od-cal-quickadd-input { flex:1; min-width:0; background:transparent; border:none; outline:none; color:var(--fg); font-family:inherit; font-size:12px; height:22px; padding:0; cursor:not-allowed; }
+.odysseus-root .od-cal-quickadd-input::placeholder { color:transparent; }
+.odysseus-root .od-cal-quickadd-hint { position:absolute; left:10px; top:50%; transform:translateY(-50%); font-size:12px; color:var(--fg); opacity:0.5; pointer-events:none; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:calc(100% - 20px); }
+.odysseus-root .od-cal-quickadd-hint .od-cal-qa-accent { color:var(--accent, var(--red)); }
+.odysseus-root .od-cal-quickadd-hint .od-cal-qa-enter { vertical-align:-2px; color:var(--accent, var(--red)); opacity:0.8; }
+
+/* Day-detail splitter grip (calendar.js .cal-splitter) — decorative divider. */
+.odysseus-root .od-cal-splitter { height:8px; margin:6px -10px 0; display:flex; align-items:center; justify-content:center; flex-shrink:0; user-select:none; }
+.odysseus-root .od-cal-splitter-grip { width:42px; height:3px; border-radius:2px; background:color-mix(in srgb, var(--fg) 25%, transparent); transition:background 0.12s; }
+.odysseus-root .od-cal-splitter:hover .od-cal-splitter-grip { background:var(--accent, var(--red)); }
+
+/* In-panel global search (calendar.js .cal-search-wrap / .cal-day-search). */
+.odysseus-root .od-cal-search-wrap { position:relative; display:block; margin-bottom:6px; }
+.odysseus-root .od-cal-search-icon { position:absolute; left:8px; top:50%; transform:translateY(-50%); pointer-events:none; opacity:0.45; color:var(--fg); }
+.odysseus-root .od-cal-search-input { width:100%; box-sizing:border-box; background:color-mix(in srgb, var(--fg) 5%, var(--bg)); border:1px solid var(--border); border-radius:5px; padding:0 8px 0 28px; height:24px; color:var(--fg); font-size:11px; font-family:inherit; }
+.odysseus-root .od-cal-search-input:focus { outline:none; border-color:var(--accent); }
+.odysseus-root .od-cal-search-input::placeholder { color:color-mix(in srgb, var(--fg) 35%, transparent); }
+.odysseus-root .od-cal-day-search-meta { font-size:10px; opacity:0.5; margin:0 2px 6px; color:var(--fg); }
+
+/* "(Today)" suffix in the day-detail header (calendar.js:1719). */
+.odysseus-root .od-cal-detail-today { color:var(--accent, var(--red)); font-weight:600; }
+
+/* Day-detail "+ New" collapses to an icon-only round button at panel width
+   (real frame shows the circular plus, label hidden). Toolbar New keeps label. */
+.odysseus-root button.od-cal-add-btn.od-cal-add-btn-text.od-cal-add-btn-sm { width:24px; height:24px; padding:0; border-radius:50%; justify-content:center; }
+.odysseus-root .od-cal-add-btn-sm .od-cal-add-label { display:none; }
+.odysseus-root .od-cal-add-btn-sm .od-cal-add-plus { margin:0; }
+/* ===== 1to1: tasks ===== */
+/* ── Tasks: AI sparkle mark + status-badge label/icon parity (tasks.js _taskAiMark / _renderList) ── */
+
+/* odysseus .task-ai-mark (style.css:21411) — accent 4-point star riding just
+   after the task title. Scoped + theme-var coloured. */
+.odysseus-root .od-tasks-ai-mark {
+  flex: 0 0 auto;
+  color: var(--accent, var(--red));
+  opacity: 0.78;
+  margin-left: 2px;
+  position: relative;
+  top: -1px;
+}
+
+/* Status-badge glyphs (active pause-bars / paused play) ride up 1px like
+   odysseus .task-state-badge svg (style.css:10267). */
+.odysseus-root .od-tasks-status-badge svg {
+  position: relative;
+  top: -1px;
+}
+
+/* The text inside the active/paused state badge (mirrors .task-state-label).
+   Kept inline so the icon + word read as one pill; hidden room reserved for the
+   icon by the badge's own gap. */
+.odysseus-root .od-tasks-state-label {
+  display: inline;
+  line-height: 1;
+}
+/* ===== 1to1: email ===== */
+/* ── EmailView 1:1 restructure (emailLibrary.js): single-column card grid that
+   expands a card "as a document" in place — no two-pane split, no reading-pane
+   placeholder. These rules supersede the earlier two-column .od-email-body /
+   .od-email-list / .od-email-pane layout. ── */
+
+/* Toolbar buttons: compact .memory-toolbar-btn parity — same height as the
+   folder/filter selects, normal weight, tight padding (gap: Select looked tall
+   and heavy). */
+.odysseus-root .od-email-tbtn {
+  height: 28px; padding: 0 8px; font-size: 11px; font-weight: 400; gap: 4px;
+}
+.odysseus-root .od-email-tbtn .od-email-tbtn-label { font-size: 11px; }
+
+/* Inline search quick-toggles (#email-reminder/undone/attach), absolutely
+   positioned inside the search field — the input reserves room on the right. */
+.odysseus-root .od-email-search { padding-right: 92px; }
+.odysseus-root .od-email-search-toggles {
+  position: absolute; right: 4px; top: 50%; transform: translateY(-50%);
+  display: inline-flex; align-items: center; gap: 2px;
+}
+.odysseus-root .od-email-inline-toggle {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 22px; padding: 0; border-radius: 5px;
+  background: none; border: 1px solid transparent; color: var(--fg);
+  opacity: 0.55; cursor: pointer; transition: opacity 0.15s, border-color 0.15s, background 0.15s, color 0.15s;
+}
+.odysseus-root .od-email-inline-toggle:hover { opacity: 1; border-color: var(--border); }
+.odysseus-root .od-email-inline-toggle.active {
+  opacity: 1; color: var(--accent, var(--red));
+  background: color-mix(in srgb, var(--accent, var(--red)) 15%, transparent);
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 40%, transparent);
+}
+
+/* Bulk bar Actions button (hamburger + caret) and the trailing Cancel button. */
+.odysseus-root .od-email-bulk-actions-btn { gap: 4px; }
+.odysseus-root .od-email-bulk-caret { font-size: 9px; opacity: 0.55; }
+.odysseus-root .od-email-bulk-cancel { margin-left: 4px; min-width: 28px; }
+.odysseus-root .od-email-bulk-cancel:hover { border-color: var(--red); color: var(--red); }
+
+/* The grid: single column, scrolls internally, anchors the (mobile) FAB. */
+.odysseus-root .od-email-grid {
+  flex: 1; min-height: 0; overflow-y: auto; position: relative;
+  display: flex; flex-direction: column; gap: 4px;
+  padding: 8px 14px 14px; border-top: 1px solid var(--border);
+}
+
+/* Loading affordance (whirlpool + "Loading emails"), .email-loading-with-label. */
+.odysseus-root .od-email-loading {
+  min-height: 180px; display: flex; flex-direction: column;
+  align-items: center; justify-content: center; gap: 8px; text-align: center;
+}
+
+/* A card (emailLibrary.js .doclib-card.memory-item): bordered rounded box. */
+.odysseus-root .od-email-card {
+  display: flex; flex-direction: column; gap: 6px; flex-shrink: 0;
+  border: 1px solid var(--border); border-radius: 8px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+  transition: border-color 0.15s, background 0.15s;
+}
+.odysseus-root .od-email-card:hover { border-color: color-mix(in srgb, var(--fg) 16%, transparent); }
+.odysseus-root .od-email-card.od-email-answered { opacity: 0.7; }
+.odysseus-root .od-email-card.od-email-row-selected {
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 45%, transparent);
+  background: color-mix(in srgb, var(--accent, var(--red)) 8%, transparent);
+}
+.odysseus-root .od-email-card.expanded {
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 35%, transparent);
+}
+
+/* The collapsed card header row (avatar + subject/meta + done + menu). */
+.odysseus-root .od-email-card-row {
+  display: flex; align-items: flex-start; gap: 8px; padding: 8px 10px; position: relative;
+}
+.odysseus-root .od-email-card-row:hover .od-email-done { opacity: 1; }
+.odysseus-root .od-email-card-row:hover .od-email-item-menu { opacity: 0.5; }
+.odysseus-root .od-email-card.expanded .od-email-item-menu { opacity: 0.5; }
+
+/* The open-as-document trigger fills the row's clickable area. */
+.odysseus-root .od-email-item-open {
+  display: flex; align-items: flex-start; gap: 8px; flex: 1; min-width: 0;
+  text-align: left; border: none; background: none; padding: 0; cursor: pointer; color: var(--fg);
+}
+
+/* Card meta line (sender · date) — emailLibrary.js .memory-item-meta. */
+.odysseus-root .od-email-card-meta {
+  display: flex; align-items: baseline; gap: 0; margin-top: 2px;
+  font-size: 10px; opacity: 0.7; min-width: 0;
+}
+.odysseus-root .od-email-card-meta .od-email-sender { font-weight: 600; }
+.odysseus-root .od-email-meta-sep { opacity: 0.55; flex-shrink: 0; }
+.odysseus-root .od-email-card-meta .od-email-date { opacity: 1; }
+
+/* Subject is the card title now (.memory-item-title weight). */
+.odysseus-root .od-email-card .od-email-subject {
+  font-size: 12px; font-weight: 500; opacity: 1; color: var(--fg);
+}
+
+/* Done check resting state mirrors emailLibrary.js .email-card-done (faintly
+   visible, not fully hidden) so the card reads like the real list. */
+.odysseus-root .od-email-card .od-email-done { opacity: 0.18; }
+.odysseus-root .od-email-card .od-email-done.active { opacity: 1; }
+
+/* Expanded reader now lives INSIDE the card (no longer a flex:1 pane). */
+.odysseus-root .od-email-card.expanded .od-email-reader {
+  flex: none; min-height: 0; border-top: 1px solid var(--border);
+}
+.odysseus-root .od-email-card.expanded .od-email-reader-body {
+  flex: none; overflow: visible; max-height: 320px; overflow-y: auto;
+}
+.odysseus-root .od-email-card.expanded .od-email-reader-header { background: transparent; }
+
+/* Compose card (the "New message" document) inside the grid. */
+.odysseus-root .od-email-card-compose { background: var(--bg); }
+.odysseus-root .od-email-card-compose .od-email-compose { flex: none; min-height: 0; }
+.odysseus-root .od-email-card-compose .od-email-compose-body {
+  flex: none; min-height: 180px; height: 220px;
+}
+
+/* Empty state: "No emails" + smiley + Settings link accent. */
+.odysseus-root .od-email-empty { padding: 32px 16px; }
+.odysseus-root .od-email-empty-title {
+  display: inline-flex; align-items: center; gap: 6px; font-size: 13px; opacity: 0.6;
+}
+.odysseus-root .od-email-empty-smiley { opacity: 0.7; }
+.odysseus-root .od-email-empty-link {
+  color: var(--accent, var(--red)); text-decoration: underline;
+}
+
+/* FAB (#email-lib-fab): mobile-only — hidden on desktop exactly like odysseus,
+   where the top "New" button is the desktop entry point. On <=768px the FAB
+   shows and the top compose button hides. */
+.odysseus-root .od-email-fab { display: none; }
+@media (max-width: 768px) {
+  .odysseus-root .od-email-compose-btn { display: none; }
+  .odysseus-root .od-email-fab {
+    display: inline-flex; align-items: center; gap: 9px;
+    position: absolute; right: 16px; bottom: 18px;
+    height: 56px; min-width: 56px; padding: 0 20px 0 18px;
+    border: none; border-radius: 999px;
+    background: var(--accent, var(--red)); color: #fff;
+    font-size: 15px; font-weight: 600; line-height: 1; cursor: pointer;
+    box-shadow: 0 6px 18px rgba(0,0,0,0.38), 0 2px 6px rgba(0,0,0,0.28);
+    z-index: 30;
+  }
+  .odysseus-root .od-email-fab-label { white-space: nowrap; }
+}
+/* ===== 1to1: gallery ===== */
+/* ===== GalleryView 1:1 fixes: Photos toolbar hint, filter chips, empty cell =====
+   Scoped under .odysseus-root, theme-var driven. Mirrors odysseus static/style.css
+   (.gallery-search-enter-hint, .gallery-toolbar-break, .gallery-chip*, _renderGrid
+   empty branch). The toolbar/search/model-filter/sort/select-btn base rules already
+   exist in odysseus-theme.ts; these only add what was missing + override the search
+   padding now that there is no left magnifier icon (the real frame has none). */
+
+/* The real Photos search has NO left magnifier icon (placeholder starts at the
+   left edge); reset the left padding the icon variant added, and reserve right
+   room for the '↵ to tag' hint, matching odysseus .gallery-search. */
+.odysseus-root .od-gallery-toolbar .od-gallery-search {
+  padding: 5px 78px 5px 8px;
+}
+
+/* '↵ to tag' enter-hint inside the search wrap — hidden until text is typed
+   (odysseus .gallery-search:not(:placeholder-shown) ~ hint). Our input is
+   disabled + empty, so it stays hidden, matching the real frame. */
+.odysseus-root .od-gallery-search-enter-hint {
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--accent, var(--red));
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.12s;
+  white-space: nowrap;
+}
+.odysseus-root .od-gallery-search:not(:placeholder-shown) ~ .od-gallery-search-enter-hint {
+  opacity: 0.95;
+}
+.odysseus-root .od-gallery-enter-key {
+  flex-shrink: 0;
+}
+
+/* Toolbar break spacer — present in markup, collapsed on desktop (odysseus
+   .gallery-toolbar-break { display:none }). */
+.odysseus-root .od-gallery-toolbar-break {
+  display: none;
+}
+
+/* Filter-chip row under the search (odysseus #gallery-filter-chips /
+   .gallery-album-chips): All + Favorites heart. */
+.odysseus-root .od-gallery-filter-chips {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+  padding: 0 0 3px;
+  margin-bottom: 6px;
+  flex-shrink: 0;
+}
+
+/* Chips (odysseus .gallery-chip). Inert here, so disabled is muted but the
+   active 'All' pill keeps its red treatment for 1:1 chrome. */
+.odysseus-root .od-gallery-chip {
+  height: 28px;
+  box-sizing: border-box;
+  padding: 0 13px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  border-radius: 14px;
+  font-size: 12px;
+  line-height: 1;
+  border: 1px solid var(--border);
+  background: none;
+  color: var(--fg);
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+.odysseus-root .od-gallery-chip:hover:not(:disabled) {
+  border-color: var(--red);
+}
+.odysseus-root .od-gallery-chip.active {
+  background: color-mix(in srgb, var(--red) 15%, transparent);
+  border-color: color-mix(in srgb, var(--red) 40%, transparent);
+  color: var(--red);
+}
+.odysseus-root .od-gallery-chip:disabled {
+  cursor: not-allowed;
+}
+.odysseus-root .od-gallery-chip:disabled:not(.active) {
+  opacity: 0.55;
+}
+.odysseus-root .od-gallery-chip-fav {
+  color: var(--red);
+  padding: 0 11px;
+}
+.odysseus-root .od-gallery-chip-fav.active {
+  background: color-mix(in srgb, var(--red) 15%, transparent);
+  border-color: var(--red);
+}
+
+/* Empty caption sits as the grid CELL beside the Upload tile (odysseus
+   _renderGrid empty branch appends the caption right after the tile, in the
+   same grid), instead of spanning full width below it. Scoped to the empty
+   grid so albums/editor full-width empty states are unaffected. */
+.odysseus-root .od-gallery-grid-empty .od-gallery-empty {
+  grid-column: auto;
+  align-self: start;
+  padding: 28px 12px 0;
+  text-align: center;
+}
+/* ===== 1to1: image-editor ===== */
+/* ===== GalleryView: Edit-tab landing (gallery.js _renderEditorLanding) =====
+   The Gallery modal's Edit tab (the real 13-image-editor frame). The shared
+   .gallery-editor-landing rule is the GalleryEditorView CANVAS stage (a
+   checkerboard, aspect-ratio box). Inside the gallery Edit tab the landing is
+   instead a plain, flat, top-aligned hero (odysseus style.css line 22615), so
+   these rules are scoped under .od-gallery-secondary to override the canvas
+   styling without touching GalleryEditorView. Colors via theme vars. */
+.odysseus-root .od-gallery-secondary .gallery-editor-landing {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 14px;
+  padding: 48px 16px 24px;
+  flex: 0 0 auto;
+  width: auto;
+  aspect-ratio: auto;
+  max-height: none;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  background: none;
+  text-align: center;
+  color: var(--fg);
+}
+.odysseus-root .od-gallery-secondary .gallery-editor-landing h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+.odysseus-root .od-gallery-secondary .gallery-editor-landing p {
+  margin: 0;
+  opacity: 0.6;
+  font-size: 13px;
+  max-width: 320px;
+  line-height: 1.5;
+}
+.odysseus-root .gallery-editor-landing-btn {
+  padding: 7px 22px;
+  font-size: 13px;
+  opacity: 0.85;
+}
+.odysseus-root .gallery-editor-landing-btn:hover:not(:disabled) {
+  opacity: 1;
+}
+.odysseus-root .gallery-editor-landing-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+/* Template picker — native <select>, centered under the actions. */
+.odysseus-root .gallery-editor-template-label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  margin-top: 18px;
+  font-size: 11px;
+  opacity: 0.55;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.odysseus-root .gallery-editor-template-select {
+  min-width: 240px;
+  padding: 8px 12px;
+  background: var(--panel);
+  color: var(--fg);
+  border: 1px solid var(--red);
+  border-radius: 6px;
+  font: inherit;
+  font-size: 13px;
+  text-transform: none;
+  letter-spacing: normal;
+  cursor: pointer;
+}
+.odysseus-root .gallery-editor-template-select:hover:not(:disabled),
+.odysseus-root .gallery-editor-template-select:focus {
+  outline: none;
+  border-color: var(--red);
+}
+.odysseus-root .gallery-editor-template-select:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+/* Saved-projects row: divider + centered header (title / search / Select). */
+.odysseus-root .gallery-editor-drafts {
+  width: min(720px, 92%);
+  margin: 28px auto 0;
+  padding-top: 18px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.odysseus-root .gallery-editor-drafts-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.odysseus-root .gallery-editor-drafts-title {
+  margin: 0;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.55;
+  font-weight: 600;
+  text-align: left;
+  flex-shrink: 0;
+}
+.odysseus-root .gallery-editor-drafts-search {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 280px;
+  height: 26px;
+  box-sizing: border-box;
+  padding: 0 8px;
+  font-size: 12px;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+.odysseus-root .gallery-editor-drafts-search:focus {
+  outline: none;
+  border-color: var(--red);
+}
+.odysseus-root .gallery-editor-drafts-search:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+.odysseus-root .gallery-editor-drafts-search::placeholder {
+  color: color-mix(in srgb, var(--fg) 35%, transparent);
+}
+/* The Select button trails the header, lined up with the search bar height. */
+.odysseus-root .gallery-editor-drafts-header .od-gallery-select-btn {
+  margin-left: auto;
+  height: 26px;
+  box-sizing: border-box;
+  padding: 0 10px;
+  font-size: 12px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.odysseus-root .gallery-editor-drafts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 10px;
+}
+/* Honest empty saved-projects state — no editor-drafts backend. */
+.odysseus-root .gallery-editor-drafts-grid .od-gallery-empty {
+  grid-column: 1 / -1;
+}
+/* ===== 1to1: cookbook ===== */
+/* ===== sync: CookbookView (real Download/Serve/Dependencies/Settings workbench) =====
+   Appended after the existing .od-cb-* rules in odysseus-theme.ts. The previous
+   port's .od-cb-* rules (panel/tabs/select/field/fit-table/fit-col/loading/card/
+   badge/spin) are reused as-is; these add the four-tab workbench chrome that the
+   rebuild introduces (admin-card sectioning, hardware-pill row, scan/download
+   toolbars, deps grid, settings blocks, the book-glyph header + close button).
+   Scoped to .odysseus-root, theme-var driven, no raw unicode escapes. ── */
+
+/* Wide workbench panel — the scan table needs FIT/MODEL/PARAM/QUANT/VRAM/CTX/
+   SPEED/SCORE/MODE across its width (odysseus opens at min(780px, 92vw)). */
+.odysseus-root .od-cb-panel { width: 780px; max-height: 90vh; }
+
+/* Header: book glyph + title (accent), spacer, close (✖). Replaces the old
+   od-mem-head reuse so the header is self-contained. */
+.odysseus-root .od-cb-head {
+  display: flex; align-items: center; gap: 8px; flex: 0 0 auto;
+}
+.odysseus-root .od-cb-title {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 1rem; font-weight: 600; color: var(--accent, var(--red));
+}
+.odysseus-root .od-cb-title-icon { display: block; flex-shrink: 0; }
+.odysseus-root .od-cb-head-spacer { flex: 1 1 auto; }
+.odysseus-root .od-cb-close {
+  appearance: none; -webkit-appearance: none;
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 26px; height: 26px; padding: 0; line-height: 1; font-size: 13px;
+  background: none; border: 1px solid var(--border); border-radius: 6px;
+  color: var(--fg); opacity: 0.7; cursor: pointer;
+  transition: opacity 0.15s, border-color 0.15s, color 0.15s;
+}
+.odysseus-root .od-cb-close:hover { opacity: 1; border-color: var(--red); color: var(--red); }
+
+/* Tab icons sit just left of the label (cookbook.js tab inline SVGs). */
+.odysseus-root .od-cb-tab {
+  display: inline-flex; align-items: center; gap: 5px;
+}
+.odysseus-root .od-cb-tab-icon { display: inline-flex; }
+
+/* Scrollable body holding the per-tab admin-card stack. */
+.odysseus-root .od-cb-body {
+  flex: 1 1 auto; min-height: 0; overflow-y: auto;
+  display: flex; flex-direction: column; gap: 10px; padding-right: 2px;
+}
+.odysseus-root .od-cb-body::-webkit-scrollbar { width: 4px; }
+.odysseus-root .od-cb-body::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--fg) 20%, transparent); border-radius: 2px;
+}
+
+/* admin-card sectioning — bordered near-panel blocks (odysseus .admin-card). */
+.odysseus-root .od-cb-card-section {
+  display: flex; flex-direction: column; gap: 0;
+  border: 1px solid var(--border); border-radius: 8px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+  padding: 12px 14px;
+}
+.odysseus-root .od-cb-scan-section { flex: 1 1 auto; min-height: 0; }
+.odysseus-root .od-cb-settings-stack {
+  display: flex; flex-direction: column; gap: 10px;
+}
+
+/* Section heading — cyan/info accent (odysseus admin-card h2 is cyan); falls
+   back to a blue-mix so it never collides with the red active-tab/title. */
+.odysseus-root .od-cb-section-h2 {
+  display: inline-flex; align-items: baseline; gap: 8px;
+  margin: 0; padding: 0; line-height: 1;
+  font-size: 1rem; font-weight: 600;
+  color: var(--info, var(--ok, #5b8def));
+}
+.odysseus-root .od-cb-section-count {
+  font-size: 0.6em; opacity: 0.6; font-weight: normal; color: var(--muted);
+}
+.odysseus-root .od-cb-section-toggle {
+  appearance: none; -webkit-appearance: none;
+  display: flex; align-items: baseline; gap: 8px; width: 100%;
+  background: transparent; border: 0; padding: 0; color: inherit;
+  text-align: left; cursor: pointer; font: inherit;
+}
+.odysseus-root .od-cb-section-arrow {
+  margin-left: auto; display: inline-block; font-size: 13px; line-height: 1;
+  transition: transform 0.15s; color: var(--muted);
+}
+.odysseus-root .od-cb-section-toggle .od-cb-section-arrow { margin-left: auto; }
+.odysseus-root .od-cb-trending-toggle .od-cb-section-arrow { margin-left: 0; }
+.odysseus-root .od-cb-section-arrow-open { transform: rotate(90deg); }
+.odysseus-root .od-cb-section-body {
+  display: flex; flex-direction: column; gap: 6px; margin-top: 6px;
+}
+.odysseus-root .od-cb-desc {
+  margin: 6px 0 0; font-size: 11px; line-height: 1.4; color: var(--muted);
+}
+
+/* Generic flat field input (odysseus .cookbook-field-input / .memory-search-input). */
+.odysseus-root .od-cb-field-input {
+  height: 28px; box-sizing: border-box;
+  border: 1px solid var(--border); border-radius: 4px;
+  background: var(--bg); color: var(--fg);
+  font: inherit; font-size: 11px; padding: 0 8px;
+}
+.odysseus-root .od-cb-field-input::placeholder { color: var(--muted); opacity: 0.7; }
+.odysseus-root .od-cb-field-input:disabled { opacity: 0.5; cursor: not-allowed; }
+.odysseus-root select.od-cb-field-input { cursor: pointer; }
+.odysseus-root input[type="password"].od-cb-field-input { width: 100%; }
+
+/* Small toolbar button (odysseus .memory-toolbar-btn). */
+.odysseus-root .od-cb-toolbar-btn {
+  appearance: none; -webkit-appearance: none;
+  display: inline-flex; align-items: center; justify-content: center; gap: 5px;
+  height: 28px; padding: 0 10px; box-sizing: border-box;
+  border: 1px solid var(--border); border-radius: 4px;
+  background: var(--bg); color: var(--fg);
+  font: inherit; font-size: 11px; cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.odysseus-root .od-cb-toolbar-btn:hover:not(:disabled) { border-color: var(--fg); }
+.odysseus-root .od-cb-toolbar-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Download card: server row + repo input + Download button. */
+.odysseus-root .od-cb-dl-serverrow {
+  display: flex; gap: 4px; align-items: center;
+}
+.odysseus-root .od-cb-dl-serverrow .od-cb-select,
+.odysseus-root .od-cb-dl-serverrow select { height: 28px; }
+.odysseus-root .od-cb-dl-input { display: flex; gap: 4px; align-items: stretch; }
+.odysseus-root .od-cb-dl-input .od-cb-field-input { flex: 1 1 auto; }
+.odysseus-root .od-cb-dl-btn {
+  appearance: none; -webkit-appearance: none;
+  height: 28px; padding: 0 14px; box-sizing: border-box;
+  border: 1px solid var(--accent, var(--red)); border-radius: 4px;
+  background: color-mix(in srgb, var(--accent, var(--red)) 14%, transparent);
+  color: var(--accent, var(--red)); font: inherit; font-size: 11px;
+  font-weight: 600; cursor: pointer; white-space: nowrap;
+}
+.odysseus-root .od-cb-dl-btn:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent, var(--red)) 22%, transparent);
+}
+.odysseus-root .od-cb-dl-btn:disabled { opacity: 0.45; cursor: not-allowed; }
+
+/* Trending list (collapsible HF search results). */
+.odysseus-root .od-cb-trending { display: flex; flex-direction: column; gap: 4px; }
+.odysseus-root .od-cb-trending-toggle { width: 100%; justify-content: flex-start; gap: 6px; }
+.odysseus-root .od-cb-trending-list {
+  display: flex; flex-direction: column; gap: 4px;
+  max-height: 240px; overflow-y: auto; margin-top: 2px;
+}
+.odysseus-root .od-cb-trending-row {
+  appearance: none; -webkit-appearance: none;
+  display: flex; align-items: center; gap: 8px; width: 100%;
+  padding: 6px 8px; border: 1px solid var(--border); border-radius: 6px;
+  background: var(--bg); color: var(--fg); font: inherit; font-size: 11px;
+  text-align: left; cursor: pointer; transition: border-color 0.15s;
+}
+.odysseus-root .od-cb-trending-row:hover { border-color: var(--fg); }
+.odysseus-root .od-cb-trending-name { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.odysseus-root .od-cb-trending-meta { flex-shrink: 0; color: var(--muted); font-size: 10px; }
+
+/* Scan toolbars (two stacked rows: filters + server/rescan/edit). */
+.odysseus-root .od-cb-toolbar {
+  display: flex; align-items: center; gap: 6px; margin-top: 8px; flex-wrap: wrap;
+}
+.odysseus-root .od-cb-toolbar-spacer { flex: 1 1 auto; }
+.odysseus-root .od-cb-usecase,
+.odysseus-root .od-cb-quant,
+.odysseus-root .od-cb-engine,
+.odysseus-root .od-cb-server-select { flex: 0 0 auto; }
+.odysseus-root .od-cb-scan-search { flex: 1 1 auto; min-width: 120px; }
+
+/* RESCAN / EDIT buttons (odysseus .hwfit-gpu-btn). */
+.odysseus-root .od-cb-gpu-btn {
+  appearance: none; -webkit-appearance: none;
+  display: inline-flex; align-items: center; gap: 5px;
+  height: 28px; padding: 0 10px; box-sizing: border-box;
+  border: 1px solid var(--border); border-radius: 4px;
+  background: var(--bg); color: var(--fg);
+  font: inherit; font-size: 10px; letter-spacing: 0.3px; cursor: pointer;
+  white-space: nowrap; transition: border-color 0.15s, color 0.15s;
+}
+.odysseus-root .od-cb-gpu-btn:hover:not(:disabled) { border-color: var(--fg); }
+.odysseus-root .od-cb-gpu-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Detected-hardware pill row (cookbook.js #hwfit-hw-row). */
+.odysseus-root .od-cb-hw-row {
+  display: flex; align-items: center; gap: 6px; margin-top: 8px; flex-wrap: wrap;
+}
+.odysseus-root .od-cb-hw-label {
+  font-size: 10px; padding: 2px 8px; border-radius: 10px; flex-shrink: 0;
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  color: var(--fg); opacity: 0.7; white-space: nowrap;
+}
+.odysseus-root .od-cb-hw-pills { display: flex; gap: 4px; flex-wrap: wrap; flex: 1 1 auto; }
+.odysseus-root .od-cb-hw-pill {
+  font-size: 10px; padding: 2px 8px; border-radius: 10px; white-space: nowrap;
+  border: 1px solid var(--border);
+  background: color-mix(in srgb, var(--fg) 5%, transparent); color: var(--fg);
+}
+
+/* Scan table: make the existing fit-table scroll + add fit-level colours. */
+.odysseus-root .od-cb-fit-table { margin-top: 8px; max-height: 360px; overflow-y: auto; }
+.odysseus-root .od-cb-fit-table .od-cb-fit-row:not(.od-cb-fit-header) { cursor: default; }
+.odysseus-root .od-cb-fit-fits { color: var(--ok, var(--green, #50fa7b)); }
+.odysseus-root .od-cb-fit-tight { color: var(--orange, #ffb86c); }
+.odysseus-root .od-cb-fit-wontfit { color: var(--red, #ff5555); }
+.odysseus-root .od-cb-fit-col.od-cb-fit-fit { width: 60px; }
+
+/* Serve tab list (cached/installed models). */
+.odysseus-root .od-cb-serve-list {
+  display: flex; flex-direction: column; gap: 6px; margin-top: 8px;
+  max-height: 420px; overflow-y: auto;
+}
+.odysseus-root .od-cb-serve-card-main {
+  display: flex; align-items: baseline; gap: 8px;
+}
+.odysseus-root .od-cb-serve-card-name {
+  flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis;
+  white-space: nowrap; font-size: 12px; color: var(--fg); font-weight: 600;
+}
+.odysseus-root .od-cb-serve-card-size { flex-shrink: 0; font-size: 10px; color: var(--muted); }
+.odysseus-root .od-cb-serve-card-repo {
+  font-size: 10px; color: var(--muted); opacity: 0.8; margin-top: 2px;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+/* Dependencies head + grid. */
+.odysseus-root .od-cb-deps-head { display: flex; align-items: center; gap: 8px; }
+.odysseus-root .od-cb-deps-server-label { font-size: 10px; opacity: 0.5; margin-left: auto; }
+.odysseus-root .od-cb-deps-server { height: 28px; min-width: 70px; }
+.odysseus-root .od-cb-deps-grid { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
+
+/* Settings: servers list. */
+.odysseus-root .od-cb-server-refresh { margin-left: auto; padding: 0 8px; }
+.odysseus-root .od-cb-servers-list { display: flex; flex-direction: column; gap: 6px; margin-top: 8px; }
+.odysseus-root .od-cb-server-row {
+  display: flex; flex-direction: column; gap: 2px;
+  border: 1px solid var(--border); border-radius: 6px; padding: 8px 10px;
+  background: var(--bg);
+}
+.odysseus-root .od-cb-server-main { display: flex; align-items: baseline; gap: 8px; }
+.odysseus-root .od-cb-server-name { flex: 1 1 auto; font-size: 12px; color: var(--fg); font-weight: 600; }
+.odysseus-root .od-cb-server-state {
+  flex-shrink: 0; font-size: 9px; text-transform: uppercase; letter-spacing: 0.3px;
+  padding: 1px 6px; border-radius: 4px;
+}
+.odysseus-root .od-cb-server-on {
+  color: var(--ok, var(--green, #50fa7b));
+  background: color-mix(in srgb, var(--ok, #50fa7b) 14%, transparent);
+}
+.odysseus-root .od-cb-server-off { color: var(--muted); background: color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-cb-server-desc { font-size: 10px; color: var(--muted); line-height: 1.35; }
+/* ===== 1to1: group ===== */
+/* ===== GroupChatView (1:1 rewrite) — odysseus Group TAB surface =====
+   The real odysseus 'Group' is the #custom-preset-modal[data-chartab-panel=group]
+   tab body (group.js + index.html L1179-1188): a compact modal whose content is a
+   full-width Sequential/Parallel mode toggle, a stacked minimal participant list,
+   a dashed '+ Add participant' button, and a Cancel/Start footer. These rules
+   re-declare every class the rewritten view uses (and override the prior wide
+   two-column od-group-* block, which is applied earlier in the theme). All colours
+   are eliza theme vars; structure/proportion/spacing follow odysseus. */
+
+/* Compact modal panel (odysseus .preset-modal-content min(460px,90vw)). */
+.odysseus-root .od-search-panel.od-group-panel {
+  width: 460px;
+  max-width: 90vw;
+  height: auto;
+  max-height: 86vh;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
+/* Modal header (.modal-header): icon + 'Group' on the left, ✖ on the right. */
+.odysseus-root .od-group-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.odysseus-root .od-group-header-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--fg);
+}
+.odysseus-root .od-group-header-title svg { flex-shrink: 0; }
+.odysseus-root .od-group-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: none;
+  color: color-mix(in srgb, var(--fg) 60%, transparent);
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.odysseus-root .od-group-close:hover {
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  color: var(--fg);
+}
+
+/* Tab body (.preset-modal-body): single scrollable column. */
+.odysseus-root .od-group-tab {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 16px 4px;
+  overflow-y: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Room target — eliza-only deviation (a group attaches to a real task room). */
+.odysseus-root .od-group-roomrow {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.odysseus-root .od-group-roomlabel {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+.odysseus-root .od-group-roomselect {
+  width: 100%;
+  height: 30px;
+  padding: 0 8px;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--fg);
+  background: var(--card, var(--panel));
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+}
+.odysseus-root .od-group-roomselect:focus {
+  outline: none;
+  border-color: var(--accent, var(--red));
+}
+
+/* Mode toggle row — odysseus #group-mode-btn is a single full-width
+   .compare-parallel-toggle (icon-over-label box). Resting = Sequential
+   (neutral); .active = Parallel (accent wash). */
+.odysseus-root .od-group-moderow {
+  display: flex;
+  gap: 4px;
+}
+.odysseus-root .od-group-mode-btn {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  width: auto;
+  height: auto;
+  padding: 6px 4px 5px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: none;
+  color: var(--fg);
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.15s, color 0.15s, border-color 0.15s, opacity 0.15s;
+}
+.odysseus-root .od-group-mode-btn:hover {
+  background: color-mix(in srgb, var(--fg) 6%, transparent);
+}
+.odysseus-root .od-group-mode-btn.active {
+  color: var(--accent, var(--red));
+  border-color: color-mix(in srgb, var(--accent, var(--red)) 50%, transparent);
+  background: color-mix(in srgb, var(--accent, var(--red)) 10%, transparent);
+}
+.odysseus-root .od-group-mode-btn svg { flex-shrink: 0; }
+.odysseus-root .od-group-mode-label {
+  display: block;
+  font-size: 9px;
+  line-height: 1;
+  margin-top: 2px;
+  font-weight: 500;
+}
+
+/* Participant list (#group-participants) — stacked minimal rows. */
+.odysseus-root .od-group-participants {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 220px;
+  overflow-y: auto;
+}
+.odysseus-root .od-group-participants-empty {
+  font-size: 12px;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  padding: 8px 2px;
+}
+/* odysseus row: subtle fg-3% pill, name + dim sublabel + plain × (no dots). */
+.odysseus-root .od-group-participant {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+  border-radius: 6px;
+}
+.odysseus-root .od-group-participant-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+}
+.odysseus-root .od-group-participant-name {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--fg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.odysseus-root .od-group-participant-sub {
+  font-size: 10px;
+  opacity: 0.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.odysseus-root .od-group-participant-remove {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--fg);
+  opacity: 0.5;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 4px;
+  transition: opacity 0.12s;
+}
+.odysseus-root .od-group-participant-remove:hover:not(:disabled) { opacity: 1; }
+.odysseus-root .od-group-participant-remove:disabled {
+  opacity: 0.25;
+  cursor: not-allowed;
+}
+
+/* Dashed full-width '+ Add participant' (#group-add-btn .preset-save-btn). */
+.odysseus-root .od-group-add-btn {
+  width: 100%;
+  padding: 5px;
+  background: none;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  opacity: 0.6;
+  font-family: inherit;
+  font-size: 11px;
+  cursor: pointer;
+  transition: opacity 0.12s, border-color 0.12s;
+}
+.odysseus-root .od-group-add-btn:hover:not(:disabled) {
+  opacity: 1;
+  border-color: color-mix(in srgb, var(--fg) 35%, transparent);
+}
+.odysseus-root .od-group-add-btn:disabled { opacity: 0.3; cursor: not-allowed; }
+
+/* Inline picker (odysseus appends two <select>s; eliza uses 3 real fields). */
+.odysseus-root .od-group-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+}
+.odysseus-root .od-group-picker-input {
+  width: 100%;
+  height: 28px;
+  padding: 0 8px;
+  font-family: inherit;
+  font-size: 11px;
+  color: var(--fg);
+  background: var(--card, var(--panel));
+  border: 1px solid var(--border);
+  border-radius: 5px;
+}
+.odysseus-root .od-group-picker-input:focus {
+  outline: none;
+  border-color: var(--accent, var(--red));
+}
+.odysseus-root .od-group-picker-error {
+  font-size: 11px;
+  color: var(--red);
+}
+.odysseus-root .od-group-picker-foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+}
+.odysseus-root .od-group-picker-cancel,
+.odysseus-root .od-group-picker-submit {
+  padding: 4px 12px;
+  font-family: inherit;
+  font-size: 11px;
+  border-radius: 5px;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  transition: background 0.12s, filter 0.12s, opacity 0.12s;
+}
+.odysseus-root .od-group-picker-cancel {
+  background: none;
+  color: color-mix(in srgb, var(--fg) 70%, transparent);
+}
+.odysseus-root .od-group-picker-cancel:hover {
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+}
+.odysseus-root .od-group-picker-submit {
+  background: var(--accent, var(--red));
+  border-color: var(--accent, var(--red));
+  color: #fff;
+}
+.odysseus-root .od-group-picker-submit:hover:not(:disabled) { filter: brightness(1.1); }
+.odysseus-root .od-group-picker-submit:disabled { opacity: 0.5; cursor: not-allowed; }
+
+/* Footer (.modal-footer): Cancel + Start, right-aligned. */
+.odysseus-root .od-group-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.odysseus-root .od-group-footer-spacer { flex: 1; }
+.odysseus-root .od-group-footer-error {
+  font-size: 11px;
+  color: var(--red);
+}
+.odysseus-root .od-group-cancel {
+  padding: 6px 14px;
+  font-family: inherit;
+  font-size: 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: none;
+  color: color-mix(in srgb, var(--fg) 75%, transparent);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.odysseus-root .od-group-cancel:hover {
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  color: var(--fg);
+}
+.odysseus-root .od-group-start {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 16px;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  border-radius: 6px;
+  border: 1px solid var(--accent, var(--red));
+  background: var(--accent, var(--red));
+  color: #fff;
+  cursor: pointer;
+  transition: filter 0.12s, opacity 0.12s;
+}
+.odysseus-root .od-group-start:hover:not(:disabled) { filter: brightness(1.1); }
+.odysseus-root .od-group-start:disabled { opacity: 0.45; cursor: not-allowed; }
+
+/* Honest delivery note (eliza: mode is a local pref, not backend scheduling). */
+.odysseus-root .od-group-note {
+  padding: 8px 16px 12px;
+  font-size: 11px;
+  line-height: 1.5;
+  color: color-mix(in srgb, var(--fg) 50%, transparent);
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+/* Mobile: keep the mode toggle a comfortable single full-width touch target
+   (odysseus #group-mode-btn @max-width:520px → row layout, larger label). */
+@media (max-width: 520px) {
+  .odysseus-root .od-group-mode-btn {
+    flex-direction: row;
+    min-height: 44px;
+    padding: 8px 14px;
+    gap: 8px;
+  }
+  .odysseus-root .od-group-mode-label { font-size: 13px; margin-top: 0; }
+}
+/* ===== 1to1: admin ===== */
+/* ── AdminView: non-admin user-row expand chevron (admin.js .admin-user-chevron, index.html-rendered user rows). Rotates 180deg when the privilege panel is open, mirroring odysseus's chevron behavior. NEW class — not present in odysseus-theme.ts. ── */
+.odysseus-root .od-admin-user-chevron {
+  flex-shrink: 0;
+  opacity: 0.3;
+  color: var(--fg);
+  transition: transform 0.2s, opacity 0.2s;
+}
+.odysseus-root .od-admin-user-chevron.open {
+  transform: rotate(180deg);
+  opacity: 0.7;
+}
+/* ===== 1to1: voice ===== */
+/* ── Voice surface (odysseus #recording-indicator + #mic-btn + hidden TTS
+   admin-card). No centered voice modal — odysseus has none. Colors map the
+   odysseus --color-recording red onto the eliza --red theme var. ── */
+
+/* odysseus #recording-indicator: position:fixed top toast, shown only while
+   recording (or on a mic/permission error). */
+.odysseus-root .od-recording-indicator {
+  position: fixed;
+  top: 10px;
+  left: 0;
+  right: 0;
+  margin: 10px;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px;
+  background: color-mix(in srgb, var(--bg) 82%, transparent);
+  backdrop-filter: blur(10px);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+.odysseus-root .od-recording-indicator.error {
+  background: color-mix(in srgb, var(--red) 88%, black);
+  border-color: var(--red);
+}
+.odysseus-root .od-recording-content {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--fg);
+}
+.odysseus-root .od-recording-icon {
+  color: var(--red);
+  animation: od-voice-pulse 1.5s infinite;
+}
+.odysseus-root .od-recording-text {
+  font-size: 16px;
+  font-weight: 500;
+}
+.odysseus-root .od-recording-error {
+  color: #fff;
+  font-size: 14px;
+}
+.odysseus-root .od-stop-recording-btn {
+  background: var(--red);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+.odysseus-root .od-stop-recording-btn:hover {
+  background: color-mix(in srgb, var(--red) 80%, black);
+}
+
+@keyframes od-voice-pulse {
+  0% { opacity: 1; }
+  50% { opacity: 0.7; }
+  100% { opacity: 1; }
+}
+
+/* Persistent voice chrome: inline mic toggle + disclosure for the hidden TTS
+   card. Reuses the shared od-search-panel positioning (style=win.panelStyle). */
+.odysseus-root .od-voice-card {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 440px;
+  max-width: calc(100vw - 32px);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.45);
+}
+.odysseus-root .od-voice-card-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: default;
+}
+
+/* odysseus #mic-btn: small inline 4px-radius toggle; .recording = red + pulse. */
+.odysseus-root .od-mic-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  color: var(--fg);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+.odysseus-root .od-mic-btn:hover {
+  background: color-mix(in srgb, var(--fg) 6%, transparent);
+  border-color: var(--fg);
+}
+.odysseus-root .od-mic-btn.recording {
+  background: var(--red);
+  border-color: var(--red);
+  color: #fff;
+  animation: od-voice-pulse 1.5s infinite;
+}
+.odysseus-root .od-voice-disclosure {
+  flex: 1;
+  text-align: left;
+  background: transparent;
+  border: none;
+  color: color-mix(in srgb, var(--fg) 70%, transparent);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  padding: 4px 0;
+}
+.odysseus-root .od-voice-disclosure:hover {
+  color: var(--fg);
+}
+
+/* odysseus .admin-card (the hidden TTS card). */
+.odysseus-root .od-admin-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+}
+.odysseus-root .od-admin-card-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  margin: 0 0 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 40%, transparent);
+}
+.odysseus-root .od-admin-card-icon {
+  opacity: 0.6;
+}
+.odysseus-root .od-admin-card-spacer {
+  flex: 1;
+}
+.odysseus-root .od-admin-toggle-sub {
+  color: color-mix(in srgb, var(--fg) 65%, transparent);
+  font-size: 11px;
+  margin-bottom: 8px;
+}
+
+/* odysseus .admin-switch / .admin-slider (the toggle, here read-only). */
+.odysseus-root .od-admin-switch {
+  position: relative;
+  width: 30px;
+  height: 16px;
+  flex-shrink: 0;
+  display: inline-block;
+}
+.odysseus-root .od-admin-switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.odysseus-root .od-admin-slider {
+  position: absolute;
+  inset: 0;
+  background: color-mix(in srgb, var(--fg) 50%, transparent);
+  border-radius: 8px;
+  cursor: not-allowed;
+  transition: background 0.08s;
+}
+.odysseus-root .od-admin-slider::before {
+  content: "";
+  position: absolute;
+  left: 2px;
+  top: 2px;
+  width: 12px;
+  height: 12px;
+  background: var(--panel);
+  border-radius: 50%;
+  transition: transform 0.08s;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+.odysseus-root .od-admin-switch input:checked + .od-admin-slider {
+  background: var(--red);
+}
+.odysseus-root .od-admin-switch input:checked + .od-admin-slider::before {
+  transform: translateX(14px);
+}
+
+/* TTS field rows (Provider/Model/Voice/Speed) + Preview + status message. */
+.odysseus-root .od-tts-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.odysseus-root .od-tts-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.odysseus-root .od-settings-label {
+  font-size: 12px;
+  min-width: 70px;
+}
+.odysseus-root .od-settings-select {
+  flex: 1;
+  min-width: 0;
+  max-width: 100%;
+  padding: 5px 8px;
+  font-family: inherit;
+  font-size: 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  transition: border-color 0.15s;
+  outline: none;
+}
+.odysseus-root .od-settings-select:focus {
+  border-color: var(--red);
+}
+.odysseus-root .od-admin-btn-sm {
+  align-self: flex-start;
+  margin-top: 4px;
+  padding: 5px 16px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--panel);
+  color: var(--fg);
+  cursor: pointer;
+  font-size: 12px;
+}
+.odysseus-root .od-admin-btn-sm:hover:not(:disabled) {
+  background: var(--border);
+  border-color: var(--red);
+}
+.odysseus-root .od-admin-btn-sm:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.odysseus-root .od-tts-msg {
+  font-size: 11px;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+/* ===== 1to1: presets ===== */
+/* ── Presets / "Prompt" editor modal (odysseus #custom-preset-modal) ──
+   Scoped to .odysseus-root. The shared chrome classes (od-search-overlay,
+   od-search-panel, od-mem-head, od-window-header, od-mem-title,
+   od-mem-title-icon, od-mem-head-spacer, od-win-close, od-snap-ghost) are
+   defined elsewhere; below are only the preset-modal content rules, ported
+   from style.css .preset-* / .char-* but driven by eliza theme vars. */
+
+/* Compact tuner proportions: odysseus .preset-modal-content is
+   width:min(460px,90vw), radius 12px, content-driven height (not a tall
+   library). Only applied before the user drags/resizes (when not .od-windowed). */
+.odysseus-root .od-search-overlay:not(.od-windowed) .od-presets-panel {
+  width: min(460px, 90vw);
+  height: auto;
+  max-height: 88vh;
+  border-radius: 12px;
+}
+.odysseus-root .od-presets-panel {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.odysseus-root .od-preset-body {
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 0 16px;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Tab strip — full-bleed underline border (style.css .preset-tabs). */
+.odysseus-root .od-preset-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  margin: 0 -16px 12px;
+  padding: 0 16px;
+}
+.odysseus-root .od-preset-tab {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 10px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.odysseus-root .od-preset-tab-icon {
+  flex-shrink: 0;
+}
+.odysseus-root .od-preset-tab:hover {
+  color: var(--fg);
+  background: color-mix(in srgb, var(--fg) 4%, transparent);
+}
+.odysseus-root .od-preset-tab.active {
+  color: var(--red);
+  border-bottom-color: var(--red);
+}
+
+.odysseus-root .od-preset-chartab {
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 4px;
+}
+
+/* Labels + fields (style.css #custom-preset-modal .modal-body label/input). */
+.odysseus-root .od-preset-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--fg);
+  margin: 8px 0 4px;
+  display: block;
+}
+.odysseus-root .od-preset-textarea,
+.odysseus-root .od-preset-input {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  padding: 8px 10px;
+  font-size: 13px;
+  font-family: inherit;
+  transition: border-color 0.15s;
+}
+.odysseus-root .od-preset-textarea {
+  resize: vertical;
+}
+.odysseus-root .od-preset-inject-area {
+  margin-bottom: 8px;
+}
+.odysseus-root .od-preset-textarea:focus,
+.odysseus-root .od-preset-input:focus {
+  outline: none;
+  border-color: var(--red);
+}
+.odysseus-root .od-preset-input:disabled,
+.odysseus-root .od-preset-textarea:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* Slider rows (style.css .preset-slider-row / -value / .preset-range). */
+.odysseus-root .od-preset-slider-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 12px;
+  margin-bottom: 6px;
+}
+.odysseus-root .od-preset-slider-row .od-preset-label {
+  margin: 0;
+}
+.odysseus-root .od-preset-slider-value {
+  font-size: 12px;
+  color: var(--fg);
+  font-weight: 600;
+  min-width: 40px;
+  text-align: right;
+}
+.odysseus-root .od-preset-range {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 6px;
+  background: var(--border);
+  border-radius: 4px;
+  outline: none;
+  margin: 0 0 4px;
+  box-sizing: border-box;
+  display: block;
+  padding: 0;
+}
+.odysseus-root .od-preset-range::-webkit-slider-runnable-track {
+  height: 6px;
+  border-radius: 4px;
+}
+.odysseus-root .od-preset-range::-moz-range-track {
+  height: 6px;
+  background: var(--border);
+  border-radius: 4px;
+}
+.odysseus-root .od-preset-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--red);
+  cursor: pointer;
+  border: 2px solid var(--panel);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+.odysseus-root .od-preset-range::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--red);
+  cursor: pointer;
+  border: 2px solid var(--panel);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+/* Temp hints under the temperature slider (style.css .preset-temp-hints). */
+.odysseus-root .od-preset-temp-hints {
+  display: flex;
+  font-size: 10px;
+  color: var(--muted);
+  margin-top: -4px;
+  margin-bottom: 10px;
+  padding: 0 2px;
+  opacity: 0.7;
+}
+.odysseus-root .od-preset-temp-hints span {
+  flex: 1;
+}
+.odysseus-root .od-preset-temp-hints span:nth-child(2) {
+  text-align: center;
+}
+.odysseus-root .od-preset-temp-hints span:last-child {
+  text-align: right;
+}
+
+/* "?" hint badge next to slider labels (style.css .preset-hint-icon). */
+.odysseus-root .od-preset-hint-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  border: 1px solid var(--border);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--muted);
+  cursor: help;
+  vertical-align: middle;
+  margin-left: 4px;
+  transition: all 0.15s;
+}
+.odysseus-root .od-preset-hint-icon:hover {
+  color: var(--fg);
+  border-color: var(--fg);
+}
+
+/* Persona tab: dropdown + action buttons (style.css .char-name-combo /
+   .char-template-select / .char-action-btn / .char-prompt-wrap / .char-expand-btn). */
+.odysseus-root .od-char-name-combo {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.odysseus-root .od-char-name-combo input,
+.odysseus-root .od-char-name-combo select {
+  flex: 1;
+}
+.odysseus-root .od-char-template-select {
+  flex: 1;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  padding: 6px 8px;
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+}
+.odysseus-root .od-char-template-select:focus {
+  outline: none;
+  border-color: var(--red);
+}
+.odysseus-root .od-char-name-row {
+  margin-top: 4px;
+}
+.odysseus-root .od-char-action-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--muted);
+  font-size: 11px;
+  padding: 4px 8px;
+  cursor: pointer;
+  transition: all 0.15s;
+  flex-shrink: 0;
+  white-space: nowrap;
+  min-width: 64px;
+  text-align: center;
+}
+.odysseus-root .od-char-action-btn:hover:not(:disabled) {
+  color: var(--fg);
+  border-color: var(--fg);
+}
+.odysseus-root .od-char-action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.odysseus-root .od-char-delete:hover:not(:disabled) {
+  color: var(--red);
+  border-color: var(--red);
+}
+
+.odysseus-root .od-char-prompt-wrap {
+  position: relative;
+}
+.odysseus-root .od-char-prompt-wrap .od-preset-textarea {
+  padding-bottom: 32px;
+}
+.odysseus-root .od-char-expand-btn {
+  position: absolute;
+  bottom: 8px;
+  right: 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--muted);
+  font-size: 11px;
+  padding: 2px 8px;
+  cursor: pointer;
+  transition: all 0.15s;
+  z-index: 1;
+}
+.odysseus-root .od-char-expand-btn:hover:not(:disabled) {
+  color: var(--red);
+  border-color: var(--red);
+}
+.odysseus-root .od-char-expand-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* Group tab — faithful but inert (no preset backend in the orchestrator). */
+.odysseus-root .od-preset-group-tab {
+  gap: 8px;
+}
+.odysseus-root .od-preset-group-note {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--muted);
+  margin: 12px 0 8px;
+}
+.odysseus-root .od-preset-group-add {
+  width: 100%;
+  background: none;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  opacity: 0.6;
+  font-size: 11px;
+  padding: 6px;
+  cursor: not-allowed;
+}
+
+/* Footer — single right-aligned primary Start button + hidden Cancel
+   (style.css #custom-preset-modal .modal-footer, presets.js label logic). */
+.odysseus-root .od-preset-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  margin: 0 16px;
+  padding: 10px 0 14px;
+  border-top: 1px solid var(--border);
+}
+.odysseus-root .od-preset-footer-spacer {
+  flex: 1;
+}
+.odysseus-root .od-preset-cancel-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  border: 1px solid var(--border);
+  background: none;
+  color: var(--fg);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.odysseus-root .od-preset-cancel-btn:hover {
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+}
+.odysseus-root .od-preset-start-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 7px 14px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  background: var(--accent, var(--red));
+  color: var(--bg);
+  border: 1px solid var(--accent, var(--red));
+  cursor: pointer;
+  transition: all 0.15s;
+}
+/* Leading play-triangle icon on Start, masked SVG so the label text can change
+   freely (parity with style.css #save-custom-preset::before). No raw unicode. */
+.odysseus-root .od-preset-start-btn::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpolygon points='5 3 19 12 5 21 5 3'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpolygon points='5 3 19 12 5 21 5 3'/%3E%3C/svg%3E") center / contain no-repeat;
+}
+.odysseus-root .od-preset-start-btn:hover:not(:disabled) {
+  opacity: 0.85;
+}
+.odysseus-root .od-preset-start-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+/* ===== 1to1: theme ===== */
+/* ── ThemeMenu: centered modal window (index.html #theme-modal > #theme-popup),
+   superseding the old sidebar-anchored .od-theme-menu popover. Reuses the
+   shared .od-search-overlay / .od-search-backdrop / .od-search-panel modal
+   pattern so it drags + edge-resizes like every other odysseus tool window.
+   Scoped under .odysseus-root. ── */
+.odysseus-root .od-theme-overlay { padding: 8vh 0 5vh; }
+.odysseus-root .od-search-overlay.od-theme-overlay:not(.od-windowed) > .od-search-panel.od-theme-panel {
+  max-height: min(85vh, 600px); }
+.odysseus-root .od-theme-panel { width: min(520px, 92vw); display: flex; flex-direction: column;
+  min-height: 0; background: var(--bg); padding: 10px; box-sizing: border-box; overflow: hidden;
+  transition: opacity .15s; }
+.odysseus-root .od-theme-panel.od-windowed,
+.odysseus-root .od-windowed > .od-search-panel.od-theme-panel { display: flex; flex-direction: column; }
+/* Peek — fade the modal so the page behind shows through (theme.js opacity toggle) */
+.odysseus-root .od-theme-panel.od-theme-peek { opacity: .35; }
+
+/* Header (.modal-header.theme-popup-header) */
+.odysseus-root .od-theme-header { display: flex; align-items: center; gap: 8px; margin-bottom: 6px;
+  flex-shrink: 0; user-select: none; }
+.odysseus-root .od-theme-title { display: inline-flex; align-items: center; gap: 6px;
+  margin-right: auto; font-size: 1rem; font-weight: 600; letter-spacing: -0.03em; color: var(--red); }
+/* Peek toggle — small bordered pill with eye icon (.theme-opacity-wrap) */
+.odysseus-root .od-theme-peek-btn { display: inline-flex; align-items: center; gap: 5px;
+  padding: 3px 8px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg);
+  color: var(--fg); font-size: 11px; cursor: pointer; opacity: .7; transition: opacity .12s, border-color .12s; }
+.odysseus-root .od-theme-peek-btn:hover { opacity: 1; }
+.odysseus-root .od-theme-peek-btn.active { opacity: 1; border-color: var(--red); color: var(--red); }
+.odysseus-root .od-theme-peek-btn > svg { flex-shrink: 0; }
+/* Close — bordered square button (.close-btn) */
+.odysseus-root .od-theme-close { display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; padding: 0; flex-shrink: 0; border: 1px solid var(--fg); border-radius: 4px;
+  background: var(--bg); color: var(--fg); cursor: pointer; line-height: 1; transition: background .12s, color .12s; }
+.odysseus-root .od-theme-close:hover { background: var(--fg); color: var(--bg); }
+
+/* Tab strip (.admin-tabs / .admin-tab) */
+.odysseus-root .od-theme-tabs { display: flex; gap: 0; margin: 0 -10px 8px; padding: 0 10px;
+  border-bottom: 1px solid var(--border); flex-shrink: 0; }
+.odysseus-root .od-theme-tab { display: inline-flex; align-items: center; gap: 5px; padding: 6px 14px;
+  background: none; border: none; border-bottom: 2px solid transparent; color: var(--muted);
+  font-size: 12px; font-family: inherit; cursor: pointer; transition: color .12s, border-color .12s; }
+.odysseus-root .od-theme-tab:hover { color: var(--fg); }
+.odysseus-root .od-theme-tab.active { color: var(--red); border-bottom-color: var(--red); }
+.odysseus-root .od-theme-tab > svg { flex-shrink: 0; }
+
+/* Scrollable tab body (.theme-tab-panel) */
+.odysseus-root .od-theme-tab-panel { overflow-y: auto; min-height: 0; flex: 1; padding-bottom: 10px; }
+
+/* Card (.admin-card + .admin-card h2) */
+.odysseus-root .od-theme-card { background: var(--panel); border: 1px solid var(--border);
+  border-radius: 8px; padding: 12px; margin-bottom: 10px; }
+.odysseus-root .od-theme-card h2 { display: flex; align-items: center; font-size: 14px; font-weight: 600;
+  letter-spacing: -0.03em; margin: 0 0 8px; padding-bottom: 6px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 40%, transparent); color: var(--fg); }
+
+/* Swatch grid (.theme-grid) — ~6 columns of coin-stacked swatches */
+.odysseus-root .od-theme-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(66px, 1fr));
+  gap: 6px; margin-bottom: 0; }
+/* Swatch (.theme-swatch) — coin-stack of circles above a centred name */
+.odysseus-root .od-theme-swatch { position: relative; display: block; padding: 5px; text-align: center;
+  border: 2px solid var(--border); border-radius: 8px; background: none; color: var(--fg);
+  font-size: 0.65rem; cursor: pointer; transition: border-color .15s, transform .15s; }
+.odysseus-root .od-theme-swatch:hover { border-color: var(--red); transform: scale(1.06); }
+.odysseus-root .od-theme-swatch.active { border-color: var(--red);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--red) 33%, transparent); }
+.odysseus-root .od-theme-swatch-colors { display: flex; justify-content: center; margin-bottom: 3px; }
+.odysseus-root .od-theme-swatch-colors span { width: 15px; height: 15px; border-radius: 50%;
+  margin-left: -5px; border: 1.5px solid color-mix(in srgb, var(--fg) 12%, transparent); }
+.odysseus-root .od-theme-swatch-colors span:first-child { margin-left: 0; }
+.odysseus-root .od-theme-swatch-name { display: block; text-transform: none; overflow: hidden;
+  text-overflow: ellipsis; white-space: nowrap; }
+/* Custom-swatch delete — accent circular X tucked into the top-right corner */
+.odysseus-root .od-theme-delete-btn { position: absolute; top: -6px; right: -6px; display: inline-flex;
+  align-items: center; justify-content: center; width: 18px; height: 18px; padding: 0; border-radius: 50%;
+  border: none; background: var(--red); color: var(--bg); cursor: pointer; line-height: 1; }
+.odysseus-root .od-theme-delete-btn:hover { filter: brightness(1.1); }
+
+/* Colors card 2-col grid (.theme-custom) */
+.odysseus-root .od-theme-custom-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 4px 12px; }
+/* ===== 1to1: settings ===== */
+/* ===== SettingsPanel: full 12-tab odysseus settings modal =====
+   Appended to ODYSSEUS_CSS in odysseus-theme.ts (before the closing backtick).
+   Builds on the existing .od-settings-* / .od-vis-* / .od-shortcut-* / .od-skill-*
+   base rules; only the NEW structure is defined here. Theme vars only, scoped
+   .odysseus-root, no raw unicode escapes. New classes:
+   od-settings-header-icon, od-settings-peek, od-settings-subtitle,
+   od-settings-rail-ico, od-settings-rail-divider (active-rail icon accent),
+   od-set-card-title / -icon / od-set-card-faded / od-set-sub,
+   od-set-inline-select, od-settings-btn-sm / -add / -delete / -logout,
+   od-set-btn-ico / -actions-end / -center-actions / -row-action,
+   od-set-ep-section/.open / -head / -head-ico / -caret / -form / -row /
+   -actions / -spacer / -type / od-set-quickstart(-label),
+   od-set-ep-list / -list-head / -list-ico / -none,
+   od-set-account-row / -avatar / -meta / -name / -role,
+   od-set-switch / -slider / -switch-inline, od-set-add-form,
+   od-set-priv-models / -priv-model,
+   od-set-tool-list / -cat / -cat-head / -cat-right / -cat-count / -cat-chev /
+   -cat-body / -tool-row / -tool-info / -tool-name / -tool-desc / -tool-ctx,
+   od-set-danger-card / -danger-title / -wipe-row.
+   (Full rule bodies were written into odysseus-theme.ts; see that file.) */
+/* ===== 1to1: composer ===== */
+/* ===== composer 1:1 (Composer.tsx): inert bottom-row tool icons + faithful
+   disabled slash rows. Appended to ODYSSEUS_CSS in odysseus-theme.ts after the
+   existing .od-input-* / .od-slash-ac-* blocks so these win on equal
+   specificity. Scoped .odysseus-root, theme-var only, no raw unicode escapes. */
+
+/* The odysseus .chat-input-bottom left group (overflow chevron / web-search /
+   shell terminal) is rendered for pixel-1:1 chrome, but the orchestrator backend
+   has no overflow-menu / web-search / shell toggle, so the buttons are honestly
+   inert. Keep the resting muted look of .od-icon-btn (matching odysseus
+   .input-icon-btn at rest) and just suppress the hover affordance so they read
+   present-but-inert rather than dimmed-out. */
+.odysseus-root .od-icon-btn:disabled { cursor:default; }
+.odysseus-root .od-icon-btn:disabled:hover {
+  color:color-mix(in srgb, var(--fg) 45%, transparent); background:none; }
+
+/* Slash rows odysseus exposes that the orchestrator has no backend for
+   (/web, /doc, /todo, /demo, /note, /fork, /bash) render faithfully but inert:
+   the row keeps its accent token + copy (1:1), while it is dimmed and
+   non-interactive with an honest title. No hover/active highlight. */
+.odysseus-root .od-slash-ac-row.od-slash-ac-disabled { cursor:default; opacity:.5; }
+.odysseus-root .od-slash-ac-row.od-slash-ac-disabled:hover,
+.odysseus-root .od-slash-ac-row.od-slash-ac-disabled.active { background-color:transparent; }
+
+/* ===== emoji picker 1:1 refinements (EmojiPicker.tsx → odysseus .emoji-picker*).
+   Appended after the wave5 + fix-wave-A .od-emoji-* blocks so these override on
+   equal specificity. Matches static/style.css .emoji-picker / .emoji-picker-search
+   / .emoji-picker-group-name / .emoji-picker-item metrics. ===== */
+
+/* Popover shell: narrower + tighter radius/shadow + vh-relative height cap to
+   match odysseus .emoji-picker { width:min(300px,92vw); border-radius:8px;
+   box-shadow:0 8px 24px rgba(0,0,0,.3); max-height:min(300px,55vh) }. */
+.odysseus-root .od-emoji-popover {
+  width:min(300px, 92vw); border-radius:8px;
+  box-shadow:0 8px 24px rgba(0,0,0,.3); max-height:min(300px, 55vh); }
+
+/* Bare search input (no wrapper, no leading icon): full-width with a bottom
+   border + padding + 12px font, matching odysseus .emoji-picker-search. */
+.odysseus-root .od-emoji-search-input {
+  width:100%; box-sizing:border-box; padding:8px 12px; font-size:12px;
+  border-bottom:1px solid var(--border); }
+
+/* Body flexes within the capped popover instead of a fixed 260px cap. */
+.odysseus-root .od-emoji-body { max-height:none; flex:1 1 auto; padding:0 6px 4px; }
+
+/* Group label: quieter + tighter tracking (odysseus .emoji-picker-group-name
+   { font-size:10px; font-weight:600; opacity:.5; letter-spacing:0.5px;
+   padding:4px 4px 2px }). */
+.odysseus-root .od-emoji-section-label {
+  font-weight:600; opacity:.5; letter-spacing:0.5px;
+  padding:4px 4px 2px; text-transform:none; }
+
+/* Cells: 4px radius + 16x16 svg (odysseus .emoji-picker-item { padding:4px;
+   border-radius:4px } / .emoji-picker-item svg { width:16px; height:16px }).
+   The 16x16 svg rule overrides the earlier fix-wave-A 18x18 rule. */
+.odysseus-root .od-emoji-cell { border-radius:4px; padding:4px; }
+.odysseus-root .od-emoji-cell svg { width:16px; height:16px; }
+.odysseus-root .od-emoji-group, .odysseus-root .od-emoji-section { padding:0 6px 4px; }
+
+/* ===== Expanded-sidebar feature navigation (Tools/Email/Models/More) ===== */
+.odysseus-root .od-sidebar-hamburger { flex-shrink:0; width:30px; height:30px; display:flex;
+  align-items:center; justify-content:center; border:none; background:none; color:var(--fg);
+  opacity:.55; border-radius:6px; cursor:pointer; padding:0; margin-left:-4px;
+  transition:opacity .12s, background .12s; }
+.odysseus-root .od-sidebar-hamburger:hover { opacity:1;
+  background:color-mix(in srgb, var(--fg) 8%, transparent); }
+.odysseus-root .od-section-title-btn { background:none; border:none; padding:0; cursor:pointer;
+  font-family:inherit; text-align:left; }
+.odysseus-root .od-section-title-btn:hover { color:var(--accent, var(--red)); }
+.odysseus-root .od-list-item-plus-btn { flex-shrink:0; display:inline-flex; align-items:center;
+  gap:2px; border:none; background:none; color:var(--accent, var(--red)); opacity:.7;
+  border-radius:4px; padding:2px 4px; cursor:pointer; font-family:inherit; font-size:10px;
+  transition:opacity .1s, background .1s; }
+.odysseus-root .od-list-item-plus-btn:hover { opacity:1;
+  background:color-mix(in srgb, var(--accent, var(--red)) 12%, transparent); }
+.odysseus-root .od-list-item-plus-label { font-size:10px; line-height:1; }
+.odysseus-root .od-tool-icon { flex-shrink:0; opacity:.5; transition:opacity .1s; }
+.odysseus-root .od-list-item:hover .od-tool-icon { opacity:.85; }
+
+/* ===== Minimize-to-dock window system (port of odysseus modalManager.js
+   #minimized-dock + .minimized-dock-chip from static/style.css). The dock is a
+   bottom-left pill row of chips, one per minimized tool window, rendered above
+   the composer. Each chip = a restore button (icon + label) plus a close (×)
+   button. Theme-var driven, scoped under .odysseus-root. ===== */
+.odysseus-root .od-minimized-dock {
+  position: absolute; left: 12px; bottom: 12px; z-index: 60;
+  display: flex; flex-wrap: wrap; gap: 6px;
+  max-width: calc(100% - 24px);
+  padding: 0; margin: 0;
+  pointer-events: none;
+}
+.odysseus-root .od-dock-chip {
+  pointer-events: auto;
+  display: inline-flex; align-items: center;
+  background: var(--panel, var(--card, var(--bg)));
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--fg, var(--txt));
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
+  animation: od-dock-chip-in 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+}
+.odysseus-root .od-dock-chip-restore {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 6px 6px 10px;
+  background: none; border: none;
+  color: inherit; font: inherit; font-size: 12px; line-height: 1;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.odysseus-root .od-dock-chip-restore:hover {
+  background: color-mix(in srgb, var(--accent, var(--red)) 14%, transparent);
+}
+.odysseus-root .od-dock-chip-icon { flex-shrink: 0; opacity: 0.75; }
+.odysseus-root .od-dock-chip-label { white-space: nowrap; }
+.odysseus-root .od-dock-chip-close {
+  display: inline-flex; align-items: center; justify-content: center;
+  flex-shrink: 0;
+  width: 24px; height: 100%; min-height: 28px; padding: 0;
+  background: none; border: none;
+  border-left: 1px solid var(--border);
+  color: var(--muted, var(--fg)); cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+.odysseus-root .od-dock-chip-close:hover {
+  background: color-mix(in srgb, var(--red) 18%, transparent);
+  color: var(--red);
+}
+@keyframes od-dock-chip-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.94); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+@media (max-width: 700px) {
+  .odysseus-root .od-dock-chip-label { display: none; }
+  .odysseus-root .od-dock-chip-restore { padding: 8px; }
+}
+
+
+/* ===== Minimized-window dock (modalManager.js minimized-dock) ===== */
+.odysseus-root .od-minimized-dock {
+  position: absolute; left: 12px; bottom: 12px; z-index: 60;
+  display: flex; flex-wrap: wrap; gap: 6px;
+  max-width: calc(100% - 24px); padding: 0; margin: 0; pointer-events: none; }
+.odysseus-root .od-dock-chip {
+  pointer-events: auto; display: inline-flex; align-items: center;
+  background: var(--panel, var(--card, var(--bg))); border: 1px solid var(--border);
+  border-radius: 999px; color: var(--fg, var(--txt));
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.35); overflow: hidden;
+  animation: od-dock-chip-in 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) both; }
+.odysseus-root .od-dock-chip-restore {
+  display: inline-flex; align-items: center; gap: 6px; padding: 6px 6px 6px 10px;
+  background: none; border: none; color: inherit; font: inherit; font-size: 12px;
+  line-height: 1; cursor: pointer; transition: background 0.12s, color 0.12s; }
+.odysseus-root .od-dock-chip-restore:hover { background: color-mix(in srgb, var(--accent, var(--red)) 14%, transparent); }
+.odysseus-root .od-dock-chip-icon { flex-shrink: 0; opacity: 0.75; }
+.odysseus-root .od-dock-chip-label { white-space: nowrap; }
+.odysseus-root .od-dock-chip-close {
+  display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0;
+  width: 24px; height: 100%; min-height: 28px; padding: 0; background: none; border: none;
+  border-left: 1px solid var(--border); color: var(--muted, var(--fg)); cursor: pointer;
+  transition: background 0.12s, color 0.12s; }
+.odysseus-root .od-dock-chip-close:hover { background: color-mix(in srgb, var(--red) 18%, transparent); color: var(--red); }
+@keyframes od-dock-chip-in {
+  from { opacity: 0; transform: translateY(8px) scale(0.94); }
+  to   { opacity: 1; transform: translateY(0) scale(1); } }
+/* Boxed window-control button (real odysseus renders the minimize/close pair as
+   small bordered squares, not borderless glyphs). */
+.odysseus-root .od-window-min-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; padding: 0; flex-shrink: 0;
+  background: none; border: 1px solid var(--border); border-radius: 6px;
+  color: color-mix(in srgb, var(--fg) 55%, transparent); cursor: pointer;
+  transition: opacity 0.15s, background 0.15s, color 0.15s, border-color 0.15s; }
+.odysseus-root .od-window-min-btn:hover {
+  color: var(--fg); border-color: color-mix(in srgb, var(--fg) 35%, transparent);
+  background: color-mix(in srgb, var(--fg) 10%, transparent); }
+@media (max-width: 700px) {
+  .odysseus-root .od-dock-chip-label { display: none; }
+  .odysseus-root .od-dock-chip-restore { padding: 8px; } }
+
+
+/* === residual:ChatTopBar+ChatContainer === */
+/* ── chat top-bar session caret (1:1 residual) ── */
+.odysseus-root .od-chat-meta-caret {
+  opacity: .4;
+  flex-shrink: 0;
+  transition: opacity .12s, transform .12s;
+}
+.odysseus-root .od-chat-meta:hover .od-chat-meta-caret {
+  opacity: .7;
+  transform: translateY(-1px);
+}
+
+/* ── welcome empty-state stacked rows (1:1 residual) ── */
+.odysseus-root .od-welcome-hint {
+  margin: 6px 0 0;
+  max-width: 320px;
+  text-align: center;
+  font-size: .8rem;
+  line-height: 1.45;
+  opacity: .35;
+  color: var(--muted, var(--fg));
+}
+.odysseus-root .od-welcome-presence {
+  margin-top: 14px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--panel) 60%, transparent);
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+  font-size: .75rem;
+  line-height: 1;
+}
+.odysseus-root .od-welcome-presence svg {
+  opacity: .8;
+}
+/* === residual:SkillsPanel === */
+/* ===== SkillsPanel 1:1 residual: inner section header band ===== */
+/* REAL odysseus shows a titled section band inside the Skills card (bold
+   "Skills" + muted count + right-pinned master toggle) sitting above the
+   description. Scoped .odysseus-root, theme-var driven; reuses the existing
+   .od-admin-switch / .od-admin-slider rules for the toggle. */
+.odysseus-root .od-skills-section-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px 0;
+}
+.odysseus-root .od-skills-section-title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--fg);
+  letter-spacing: -0.01em;
+}
+.odysseus-root .od-skills-section-count {
+  font-size: 11px;
+  color: color-mix(in srgb, var(--fg) 45%, transparent);
+}
+.odysseus-root .od-skills-section-switch {
+  margin-left: auto;
+}
+/* Brain-modal Skills tab uses the tighter inner-card inset, mirroring the
+   existing .od-mem-card-skills overrides for desc/toolbar/search/grid/add. */
+.odysseus-root .od-mem-card-skills .od-skills-section-head {
+  padding-left: 6px;
+  padding-right: 6px;
+}
+/* === residual:CompareView === */
+.odysseus-root .od-cmp-sel-header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+/* === residual:CalendarView === */
+/* ── CalendarView 1:1 residual fixes ─────────────────────────────────────── */
+
+/* Header layout: let the "Calendar" wordmark fill the row so the minimize +
+   close buttons group together at the far-right edge (real odysseus), instead
+   of the minimize button landing mid-width under space-between distribution. */
+.odysseus-root .od-cal-window-header {
+  gap: 6px;
+}
+.odysseus-root .od-cal-window-header .od-cal-title {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+/* Close button: matching boxed rounded-rect chrome paired with the (already
+   boxed) minimize button — a ~24px bordered square, not a bare glyph. */
+.odysseus-root .od-cal-window-close {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  opacity: 1;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  transition:
+    background 0.15s,
+    color 0.15s,
+    border-color 0.15s;
+}
+.odysseus-root .od-cal-window-close:hover {
+  opacity: 1;
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--fg) 35%, transparent);
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+}
+
+/* Month-grid cells: top-anchor the day number + event rows at the top-left of
+   each cell (real odysseus) instead of vertically centering the button body. */
+.odysseus-root .od-cal-day {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+/* === residual:TasksView === */
+/* ── Tasks: per-card action chrome is always-on (real odysseus tasks.js shows
+   the RUN/History badge + ⋮ kebab at rest, right of the status pill) ──
+   Overrides the earlier ODYSSEUS_CSS rule that hid .od-tasks-item-actions
+   with opacity:0 until :hover. Same-or-higher specificity + later source
+   order, so it wins the cascade; theme-var driven, scoped .odysseus-root. */
+.odysseus-root .od-tasks-item .od-tasks-item-actions {
+  opacity: 1;
+}
+/* Keep the kebab legible at rest (its base color was tuned for the hover-
+   reveal state); slightly lift toward --fg so it reads on every card. */
+.odysseus-root .od-tasks-item .od-tasks-menu-btn {
+  color: color-mix(in srgb, var(--fg) 62%, transparent);
+}
+/* === residual:ModelsView === */
+/* ── Window-control cluster: group the boxed minimize/close pair so they sit
+   adjacent at the right of the space-between window header (the header uses
+   align-items:baseline, so the cluster re-centers the boxed buttons). Matches
+   real odysseus window chrome (— then ✕). ── */
+.odysseus-root .od-window-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+/* Boxed close button — same bordered-square shape as the shared
+   .od-window-min-btn, but with a destructive red hover (close = destructive,
+   consistent with the dock-chip close affordance). Colors via theme vars. */
+.odysseus-root .od-window-close-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  flex-shrink: 0;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  cursor: pointer;
+  transition: opacity 0.15s, background 0.15s, color 0.15s, border-color 0.15s;
+}
+.odysseus-root .od-window-close-btn:hover {
+  color: var(--red);
+  border-color: color-mix(in srgb, var(--red) 45%, transparent);
+  background: color-mix(in srgb, var(--red) 16%, transparent);
+}
+/* === residual:EmailView === */
+/* EmailView 1:1 residual — header window controls.
+   Real odysseus renders the minimize + close pair as two grouped, bordered
+   rounded squares at the far right of the title bar. The shared
+   .od-window-min-btn is already boxed globally; this brings the view-owned
+   close button to match it and regroups the header so the pair sits adjacent
+   at the far right (no large space-between gap scattering them). */
+.odysseus-root .od-email-head {
+  justify-content: flex-start;
+}
+.odysseus-root .od-email-head-title {
+  margin-right: auto;
+}
+/* Tight gap so the minimize + close controls cluster as a pair. */
+.odysseus-root .od-email-head .od-window-min-btn {
+  margin-right: -2px;
+}
+/* Box the close control to mirror the global boxed minimize button. */
+.odysseus-root .od-email-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  flex-shrink: 0;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  opacity: 1;
+  line-height: 0;
+  cursor: pointer;
+  transition: opacity 0.15s, background 0.15s, color 0.15s, border-color 0.15s;
+}
+.odysseus-root .od-email-close:hover {
+  opacity: 1;
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--fg) 35%, transparent);
+  background: color-mix(in srgb, var(--fg) 10%, transparent);
+}
+/* === residual:CookbookView === */
+/* CookbookView scan-table column hardening — clamp every fixed-width fit
+   column so a long value (e.g. a verbose catalog quant string) can never bleed
+   across the QUANT/VRAM/CTX/SPEED cells the way it did in the residual frame.
+   The display layer already feeds a compact quant tag; this is the belt-and-
+   braces guard. Scoped to .odysseus-root and uses theme vars only. */
+.odysseus-root .od-cb-fit-col {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+/* === residual:GroupChatView === */
+/* GroupChatView footer Start glyph — size/shrink parity with the real Prompt
+   modal footer button (.od-preset-start-btn::before). Color inherits the
+   button's currentColor (theme --accent/--red text), so disabled opacity on
+   .od-group-start carries the glyph too. No hex, no raw unicode escapes. */
+.odysseus-root .od-group-start .od-group-start-glyph {
+  flex-shrink: 0;
+  display: block;
+}
+/* === residual:SettingsPanel === */
+/* SettingsPanel 1:1 residual overrides — scoped .odysseus-root, theme vars,
+   equal specificity to the base theme rules so source order (cssAdditions
+   loaded after odysseus-theme) wins. These cannot live in odysseus-theme.ts
+   (not an editable file for this task), so they override here. */
+
+/* Collapsible Local/API rows: the caret is now a RIGHT-pointing chevron when
+   collapsed (matching real odysseus); when the section is .open it rotates a
+   quarter-turn to point DOWN. Overrides the base rule's rotate(180deg). */
+.odysseus-root .od-set-ep-section.open .od-set-ep-caret { transform: rotate(90deg); }
+
+/* Uppercase the collapsible Local/API row labels (real frame shows LOCAL/API),
+   leaving the JSX label prop semantic. The Added Models sub-heads already
+   uppercase via .od-set-ep-list-head in the base theme. */
+.odysseus-root .od-set-ep-head { text-transform: uppercase; letter-spacing: 0.03em; }
+`;

--- a/plugins/plugin-task-coordinator/src/odysseus/util/storage.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/util/storage.ts
@@ -1,0 +1,40 @@
+// Typed localStorage shim (ported from odysseus static/js/storage.js intent):
+// a single namespaced accessor so UI prefs (sidebar width, density, collapsed
+// rail, think-block expansion) survive reloads without scattering raw
+// localStorage calls. SSR/Node-safe — guards on `window`.
+
+const NS = "odysseus:";
+
+export function readPref<T>(key: string, fallback: T): T {
+  if (typeof window === "undefined") return fallback;
+  try {
+    const raw = window.localStorage.getItem(NS + key);
+    if (raw == null) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function writePref(key: string, value: unknown): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(NS + key, JSON.stringify(value));
+  } catch {
+    // quota / disabled storage — prefs are best-effort, never fatal.
+  }
+}
+
+export const PREF_KEYS = {
+  sidebarCollapsed: "sidebar-collapsed",
+  density: "density",
+  activeThread: "active-thread",
+  themeMode: "theme-mode",
+  font: "font",
+  customTheme: "custom-theme",
+  notes: "notes",
+  bgPattern: "bg-pattern",
+  customThemes: "custom-themes",
+  sidebarWidth: "sidebar-width",
+  pinnedThreads: "pinned-threads",
+} as const;

--- a/plugins/plugin-task-coordinator/src/orchestrator-diff.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-diff.tsx
@@ -90,29 +90,135 @@ export function lineDiff(oldText: string, newText: string): DiffRow[] {
   return rows;
 }
 
+/** Count added vs removed lines in an already-aligned diff, so a tool header
+ * can show the edit magnitude without re-running the alignment. */
+export function countDiff(rows: DiffRow[]): { added: number; removed: number } {
+  let added = 0;
+  let removed = 0;
+  for (const row of rows) {
+    if (row.type === "add") added++;
+    else if (row.type === "remove") removed++;
+  }
+  return { added, removed };
+}
+
+/**
+ * Compact '+N −M' magnitude badge for a tool-call header. Green addition count
+ * + red removal count (meaning-correct; see ROW_TONE), neutral otherwise.
+ */
+export function DiffStat({
+  added,
+  removed,
+}: {
+  added: number;
+  removed: number;
+}): ReactNode {
+  return (
+    <span className="inline-flex items-center gap-1 font-mono text-2xs tabular-nums">
+      <span className="text-ok">+{added}</span>
+      <span className="text-red-500">&minus;{removed}</span>
+    </span>
+  );
+}
+
+// Meaning-only color: green for additions (--ok), red for deletions, muted for
+// everything unchanged. No fills heavier than /10 so the palette stays calm.
 const ROW_TONE: Record<DiffRow["type"], string> = {
-  context: "text-txt/80",
+  context: "text-muted",
   add: "bg-ok/10 text-ok",
-  remove: "bg-danger/10 text-danger",
+  remove: "bg-red-500/10 text-red-500",
 };
 
 const ROW_SIGN: Record<DiffRow["type"], string> = {
-  context: " ",
+  context: "",
   add: "+",
   remove: "-",
 };
 
+/** A run of unchanged lines longer than this is folded to a divider. Three
+ * lines of context are kept on each inner edge of the fold (git/Codex style),
+ * so a fold only appears when there is something to actually hide. */
+const CONTEXT_FOLD_THRESHOLD = 6;
+const CONTEXT_EDGE = 3;
+
+/** A folded gap stands in for `hidden` consecutive context rows. It is purely
+ * derived from the row sequence — no state, no expansion — matching Codex's
+ * non-interactive "⋯ N unchanged" divider. */
+interface FoldRow {
+  type: "fold";
+  hidden: number;
+  /** Stable key from the surrounding line numbers. */
+  key: string;
+}
+
+type ViewRow = DiffRow | FoldRow;
+
+/** Collapse long runs of context into fold dividers. Leading/trailing context
+ * keeps only its inner-facing edge (no point showing context before the first
+ * change or after the last one beyond what frames it). Pure + stateless. */
+function foldContext(rows: DiffRow[]): ViewRow[] {
+  const out: ViewRow[] = [];
+  let i = 0;
+  while (i < rows.length) {
+    if (rows[i].type !== "context") {
+      out.push(rows[i]);
+      i++;
+      continue;
+    }
+    // Gather the maximal run of context rows starting at i.
+    let j = i;
+    while (j < rows.length && rows[j].type === "context") j++;
+    const run = rows.slice(i, j);
+    const atStart = i === 0;
+    const atEnd = j === rows.length;
+    const head = atStart ? 0 : CONTEXT_EDGE;
+    const tail = atEnd ? 0 : CONTEXT_EDGE;
+    const hidden = run.length - head - tail;
+
+    // Fold only a genuinely long run, and only when the kept edges still leave
+    // something worth tucking behind the divider.
+    if (run.length > CONTEXT_FOLD_THRESHOLD && hidden > 0) {
+      for (let k = 0; k < head; k++) out.push(run[k]);
+      const before = head > 0 ? run[head - 1] : undefined;
+      const after = run[run.length - tail] ?? run[run.length - 1];
+      out.push({
+        type: "fold",
+        hidden,
+        key: `fold:${before?.oldLine ?? "_"}:${after?.newLine ?? "_"}`,
+      });
+      for (let k = run.length - tail; k < run.length; k++) out.push(run[k]);
+    } else {
+      for (const row of run) out.push(row);
+    }
+    i = j;
+  }
+  return out;
+}
+
 function Gutter({ value }: { value: number | null }): ReactNode {
   return (
-    <span className="w-8 shrink-0 select-none px-1 text-right text-muted/50 tabular-nums">
-      {value === null ? "" : value}
+    <span className="w-8 shrink-0 select-none px-1 text-right text-muted/40 tabular-nums">
+      {value ?? ""}
     </span>
+  );
+}
+
+/** The "⋯ N unchanged" divider for a folded run of context. */
+function FoldDivider({ hidden }: { hidden: number }): ReactNode {
+  return (
+    <div className="flex items-center gap-2 border-border/30 border-y bg-bg-accent/40 px-2 py-0.5 text-muted/50 text-2xs">
+      <span className="select-none">&ctdot;</span>
+      <span className="select-none tabular-nums">
+        {hidden} unchanged {hidden === 1 ? "line" : "lines"}
+      </span>
+    </div>
   );
 }
 
 /**
  * Render an edit as an interleaved diff. When `oldText` is omitted (a file
- * write rather than an edit) every line is shown as an addition.
+ * write rather than an edit) every line is shown as an addition. Long runs of
+ * unchanged context are folded to a quiet "⋯ N unchanged" divider.
  */
 export function DiffView({
   oldText,
@@ -131,28 +237,34 @@ export function DiffView({
         }))
       : lineDiff(oldText, newText);
 
+  const view = foldContext(rows);
+
   return (
     <div
-      className="overflow-auto rounded-md border border-border/40 bg-bg/60 font-mono text-2xs leading-relaxed"
+      className="overflow-x-hidden overflow-y-auto rounded-sm border border-border/40 bg-bg-accent font-mono text-2xs leading-snug"
       style={{ maxHeight: "18rem" }}
       data-testid="orchestrator-diff"
     >
-      {rows.map((row) => (
-        // (oldLine, newLine) pairs are unique within a diff, so no index key.
-        <div
-          key={`${row.oldLine ?? "_"}:${row.newLine ?? "_"}:${row.type}`}
-          className={`flex ${ROW_TONE[row.type]}`}
-        >
-          <Gutter value={row.oldLine} />
-          <Gutter value={row.newLine} />
-          <span className="w-3 shrink-0 select-none text-center opacity-70">
-            {ROW_SIGN[row.type]}
-          </span>
-          <span className="min-w-0 flex-1 whitespace-pre-wrap break-all pr-2">
-            {row.text}
-          </span>
-        </div>
-      ))}
+      {view.map((row) =>
+        row.type === "fold" ? (
+          <FoldDivider key={row.key} hidden={row.hidden} />
+        ) : (
+          // (oldLine, newLine) pairs are unique within a diff, so no index key.
+          <div
+            key={`${row.oldLine ?? "_"}:${row.newLine ?? "_"}:${row.type}`}
+            className={`flex ${ROW_TONE[row.type]}`}
+          >
+            <Gutter value={row.oldLine} />
+            <Gutter value={row.newLine} />
+            <span className="w-3 shrink-0 select-none text-center opacity-70">
+              {ROW_SIGN[row.type]}
+            </span>
+            <span className="min-w-0 flex-1 whitespace-pre-wrap break-all pr-2">
+              {row.text}
+            </span>
+          </div>
+        ),
+      )}
     </div>
   );
 }

--- a/plugins/plugin-task-coordinator/src/orchestrator-markdown.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-markdown.tsx
@@ -1,0 +1,256 @@
+import { Check, Copy } from "lucide-react";
+import { marked, type Token, type Tokens } from "marked";
+import { type ReactNode, useState } from "react";
+
+// The coding agent writes markdown prose. We parse it with `marked` — a real
+// lexer, not a hand-rolled regex — then render its token AST directly to React
+// elements. Rendering the AST (rather than marked's HTML string) means nothing
+// is ever injected via dangerouslySetInnerHTML: raw HTML that appears in the
+// stream is shown as escaped text, never executed, so there's no XSS surface
+// and no sanitizer dependency. marked is pure ESM with zero dependencies, so it
+// also sidesteps the rolldown dev-optimizer's CommonJS-interop hang that
+// react-markdown's `style-to-js` dep triggers in this app.
+
+function alignStyle(align: Tokens.TableCell["align"]) {
+  return align ? { textAlign: align } : undefined;
+}
+
+function renderChildren(tokens: Token[] | undefined, key: string): ReactNode {
+  if (!tokens || tokens.length === 0) return null;
+  return tokens.map((token, index) => renderToken(token, `${key}.${index}`));
+}
+
+function renderToken(token: Token, key: string): ReactNode {
+  switch (token.type) {
+    case "space":
+    case "def":
+      return null;
+    case "paragraph":
+      return (
+        <p key={key} className="my-1 leading-relaxed first:mt-0 last:mb-0">
+          {renderChildren(token.tokens, key)}
+        </p>
+      );
+    case "heading": {
+      const depth = Math.min(Math.max(token.depth, 1), 4);
+      const Tag = `h${depth}` as "h1" | "h2" | "h3" | "h4";
+      return (
+        <Tag key={key} className="mt-2 mb-1 font-semibold text-txt first:mt-0">
+          {renderChildren(token.tokens, key)}
+        </Tag>
+      );
+    }
+    case "code":
+      return <CodeBlock key={key} code={token.text} lang={token.lang} />;
+    case "blockquote":
+      return (
+        <blockquote
+          key={key}
+          className="my-1 border-l-2 border-border pl-3 text-muted-strong"
+        >
+          {renderChildren(token.tokens, key)}
+        </blockquote>
+      );
+    case "list": {
+      const items = token.items.map((item, index) => {
+        // Composite path key (parent path + position): stable across this
+        // immutable, fully-recomputed AST render, and unique among siblings.
+        const itemKey = `${key}.${index}`;
+        return (
+          <li key={itemKey} className="my-0.5 marker:text-muted">
+            {item.task ? (
+              <input
+                type="checkbox"
+                checked={Boolean(item.checked)}
+                readOnly
+                aria-hidden
+                className="mr-1.5 align-middle accent-accent"
+              />
+            ) : null}
+            {renderChildren(item.tokens, itemKey)}
+          </li>
+        );
+      });
+      return token.ordered ? (
+        <ol
+          key={key}
+          start={typeof token.start === "number" ? token.start : undefined}
+          className="my-1 list-decimal space-y-0.5 pl-5"
+        >
+          {items}
+        </ol>
+      ) : (
+        <ul key={key} className="my-1 list-disc space-y-0.5 pl-5">
+          {items}
+        </ul>
+      );
+    }
+    case "table":
+      return (
+        <div key={key} className="my-1.5 overflow-x-auto">
+          <table className="w-full border-collapse text-2xs">
+            <thead>
+              <tr>
+                {token.header.map((cell, index) => {
+                  const cellKey = `${key}.h${index}`;
+                  return (
+                    <th
+                      key={cellKey}
+                      style={alignStyle(cell.align)}
+                      className="border border-border/60 bg-bg/40 px-2 py-1 text-left font-semibold text-txt"
+                    >
+                      {renderChildren(cell.tokens, cellKey)}
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody>
+              {token.rows.map((row, rowIndex) => {
+                const rowKey = `${key}.r${rowIndex}`;
+                return (
+                  <tr key={rowKey}>
+                    {row.map((cell, cellIndex) => {
+                      const cellKey = `${rowKey}c${cellIndex}`;
+                      return (
+                        <td
+                          key={cellKey}
+                          style={alignStyle(cell.align)}
+                          className="border border-border/50 px-2 py-1 align-top"
+                        >
+                          {renderChildren(cell.tokens, cellKey)}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      );
+    case "hr":
+      return <hr key={key} className="my-2 border-border/50" />;
+    case "strong":
+      return (
+        <strong key={key} className="font-semibold text-txt">
+          {renderChildren(token.tokens, key)}
+        </strong>
+      );
+    case "em":
+      return (
+        <em key={key} className="italic">
+          {renderChildren(token.tokens, key)}
+        </em>
+      );
+    case "del":
+      return (
+        <del key={key} className="line-through opacity-80">
+          {renderChildren(token.tokens, key)}
+        </del>
+      );
+    case "codespan":
+      return (
+        <code
+          key={key}
+          className="break-words rounded-sm bg-bg/70 px-1 py-px font-mono text-[0.95em] text-txt-strong"
+        >
+          {token.text}
+        </code>
+      );
+    case "link":
+      return (
+        <a
+          key={key}
+          href={token.href}
+          title={token.title ?? undefined}
+          target="_blank"
+          rel="noreferrer"
+          className="text-txt-strong underline underline-offset-2 transition-colors hover:text-accent"
+        >
+          {renderChildren(token.tokens, key)}
+        </a>
+      );
+    case "image":
+      return (
+        <img
+          key={key}
+          src={token.href}
+          alt={token.text}
+          title={token.title ?? undefined}
+          className="my-1 max-w-full rounded-sm border border-border/50"
+        />
+      );
+    case "br":
+      return <br key={key} />;
+    case "escape":
+      return token.text;
+    case "text":
+      // A block-level text token (e.g. loose-list content) carries inline
+      // tokens; an inline text leaf is just its string.
+      return token.tokens && token.tokens.length > 0
+        ? renderChildren(token.tokens, key)
+        : token.text;
+    default:
+      // `html` and any other raw tokens are rendered as escaped text — never
+      // injected as markup — so stray tags in the stream can't execute.
+      return "raw" in token ? token.raw : null;
+  }
+}
+
+function CodeBlock({ code, lang }: { code: string; lang?: string }): ReactNode {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    // Guard for non-secure-context / older webviews where clipboard is absent.
+    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
+      return;
+    }
+    navigator.clipboard.writeText(code).then(
+      () => {
+        setCopied(true);
+        // Brief confirmation, then revert to the resting copy icon.
+        setTimeout(() => setCopied(false), 1200);
+      },
+      () => undefined,
+    );
+  };
+
+  return (
+    <div className="group/code relative my-1 overflow-hidden rounded-sm border border-border/50 bg-bg/80">
+      {lang ? (
+        <div className="border-b border-border/40 px-2.5 py-0.5 font-mono text-3xs uppercase tracking-wide text-muted">
+          {lang}
+        </div>
+      ) : null}
+      <button
+        type="button"
+        onClick={copy}
+        aria-label={copied ? "Copied" : "Copy code"}
+        // Unobtrusive: faded until the block is hovered/focused, fully shown
+        // once copied. Green only as the success affordance.
+        className={`absolute right-1 top-1 z-10 rounded p-1 text-muted opacity-0 transition-[color,opacity] hover:bg-bg-hover/60 hover:text-txt focus-visible:opacity-100 group-hover/code:opacity-100 ${
+          copied ? "text-ok opacity-100" : ""
+        }`}
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5" aria-hidden />
+        ) : (
+          <Copy className="h-3.5 w-3.5" aria-hidden />
+        )}
+      </button>
+      <pre className="max-h-72 overflow-auto px-2.5 py-1.5 font-mono text-2xs leading-relaxed text-txt">
+        <code className="whitespace-pre-wrap break-words">{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+export function MarkdownText({ text }: { text: string }): ReactNode {
+  const tokens = marked.lexer(text);
+  return (
+    <div className="break-words text-xs text-txt">
+      {tokens.map((token, index) => renderToken(token, `t${index}`))}
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/orchestrator-plan.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-plan.tsx
@@ -1,0 +1,111 @@
+import { Check, ChevronRight, Circle, Loader } from "lucide-react";
+import { type ReactNode, useState } from "react";
+
+// The orchestrator's current plan/todo list. The sub-agent (opencode) emits its
+// todo snapshot as an ACP `plan` update; the backend sanitizes it onto the
+// task's `currentPlan`, and this dock renders it the way Codex/Claude/opencode
+// surface a live checklist: a pinned, collapsible panel with per-item status
+// (pending / in-progress / done) and a progress count. Color is meaning-only —
+// green = done, neutral spinner = in-progress, muted = pending; no accent fill.
+
+interface PlanEntry {
+  content: string;
+  status: "pending" | "in_progress" | "completed";
+}
+
+/** Narrow the loosely-typed `currentPlan` DTO (Record<string, unknown>) into the
+ * typed entries this view renders, dropping anything malformed. */
+function readEntries(plan: Record<string, unknown>): PlanEntry[] {
+  const raw = plan.entries;
+  if (!Array.isArray(raw)) return [];
+  const entries: PlanEntry[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const record = item as Record<string, unknown>;
+    const content = typeof record.content === "string" ? record.content : "";
+    if (content === "") continue;
+    const status =
+      record.status === "in_progress" || record.status === "completed"
+        ? record.status
+        : "pending";
+    entries.push({ content, status });
+  }
+  return entries;
+}
+
+function StatusIcon({ status }: { status: PlanEntry["status"] }): ReactNode {
+  if (status === "completed")
+    return <Check className="h-3 w-3 shrink-0 text-ok" aria-hidden />;
+  if (status === "in_progress")
+    return (
+      <Loader
+        className="h-3 w-3 shrink-0 animate-spin text-muted-strong"
+        aria-hidden
+      />
+    );
+  return <Circle className="h-3 w-3 shrink-0 text-muted/60" aria-hidden />;
+}
+
+export function PlanDock({
+  plan,
+}: {
+  plan: Record<string, unknown>;
+}): ReactNode {
+  const entries = readEntries(plan);
+  // The agent has just begun in-progress items first by default, so opening the
+  // dock once there's an active step keeps the live work visible.
+  const hasActive = entries.some((entry) => entry.status === "in_progress");
+  const [open, setOpen] = useState(hasActive);
+  if (entries.length === 0) return null;
+  const done = entries.filter((entry) => entry.status === "completed").length;
+
+  return (
+    <div
+      className="rounded-md border border-border/50 bg-card/40"
+      data-testid="orchestrator-plan"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left"
+      >
+        <ChevronRight
+          className={`h-3 w-3 shrink-0 text-muted transition-transform ${open ? "rotate-90" : ""}`}
+        />
+        <span className="text-xs font-semibold text-txt">Plan</span>
+        <span className="flex-1" />
+        <span className="font-mono text-2xs tabular-nums text-muted">
+          {done}/{entries.length}
+        </span>
+      </button>
+      {open ? (
+        <ul className="space-y-0.5 px-2.5 pb-2">
+          {entries.map((entry, index) => (
+            <li
+              // Plan entries have no stable id and may repeat content across a
+              // single immutable snapshot; position is the only discriminator.
+              // biome-ignore lint/suspicious/noArrayIndexKey: positional plan snapshot
+              key={`${entry.content}-${index}`}
+              className="flex items-start gap-2 text-xs-tight"
+            >
+              <span className="mt-0.5">
+                <StatusIcon status={entry.status} />
+              </span>
+              <span
+                className={
+                  entry.status === "completed"
+                    ? "text-muted line-through"
+                    : entry.status === "in_progress"
+                      ? "text-txt"
+                      : "text-muted-strong"
+                }
+              >
+                {entry.content}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/orchestrator-reasoning.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-reasoning.tsx
@@ -1,0 +1,141 @@
+import { Brain, ChevronRight } from "lucide-react";
+import { type ReactNode, useState } from "react";
+import { MarkdownText } from "./orchestrator-markdown";
+
+// A collapsible "reasoning / thinking" cell, matching the Codex / opencode
+// shape: a dim one-line header you can expand into the model's raw chain of
+// thought. The cloud-ui ai-elements `Reasoning` primitive
+// (packages/ui/.../ai-elements/reasoning.tsx) carries a Radix
+// `useControllableState` + auto-open/auto-close timer machine and its own
+// `text-muted-foreground`/`text-sm` skin keyed to seconds. Our contract is a
+// flat presentational `{ text, durationMs, streaming }` with a humanized
+// duration, a `MarkdownText` body, and an in-token shimmer — none of which that
+// primitive exposes — so we build a self-contained collapsible on the same
+// useState open/setOpen pattern the sibling tool-call cell uses, re-skinned to
+// eliza tokens (text-2xs, text-muted, rounded-md, border-border/50).
+
+/** Humanize a stopwatch duration the way Codex's header reads: sub-minute as
+ * whole seconds, then minutes (+ trailing seconds). Display-only rounding. */
+function humanizeDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000));
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
+}
+
+/**
+ * A collapsed-by-default reasoning cell. While the model is still thinking the
+ * header reads "Thinking…" and the body text gets a luminance-sweep shimmer;
+ * once finished it reads "Thought for {duration}". The shimmer is a CSS
+ * mask-image sweep over the SAME `text-muted` glyphs — it introduces no new
+ * color, and it is disabled under `prefers-reduced-motion`.
+ *
+ * Pure presentational: it renders only from its props and owns no data.
+ *
+ * @param props.text - The reasoning / chain-of-thought markdown to render.
+ * @param props.durationMs - Total thinking time in ms; humanized in the header.
+ * @param props.streaming - Whether reasoning is still arriving (drives the
+ *   "Thinking…" label and the shimmer).
+ */
+export function ReasoningCell({
+  text,
+  durationMs,
+  streaming,
+}: {
+  text: string;
+  durationMs?: number;
+  streaming?: boolean;
+}): ReactNode {
+  const [open, setOpen] = useState(false);
+
+  const header = streaming
+    ? "Thinking…"
+    : durationMs !== undefined
+      ? `Thought for ${humanizeDuration(durationMs)}`
+      : "Thought";
+
+  return (
+    <div
+      className="rounded-md border border-border/50 bg-card/50"
+      data-testid="orchestrator-reasoning"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((value) => !value)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 px-2.5 py-1.5 text-left"
+      >
+        <ChevronRight
+          className={`h-3 w-3 shrink-0 text-muted transition-transform ${
+            open ? "rotate-90" : ""
+          }`}
+        />
+        <Brain className="h-3.5 w-3.5 shrink-0 text-muted-strong" />
+        <span
+          className={`min-w-0 flex-1 truncate text-2xs italic text-muted ${
+            // The header itself gets the shimmer while streaming so the cell
+            // reads as "alive" even when collapsed.
+            streaming ? "orchestrator-reasoning-shimmer" : ""
+          }`}
+        >
+          {header}
+        </span>
+      </button>
+      {open ? (
+        <div className="px-2.5 pb-2">
+          <div
+            className={`text-2xs italic text-muted ${
+              streaming ? "orchestrator-reasoning-shimmer" : ""
+            }`}
+          >
+            <MarkdownText text={text} />
+          </div>
+        </div>
+      ) : null}
+      {/* Luminance-sweep shimmer: a moving mask-image window briefly lifts the
+          alpha of the masked glyphs, reading as a highlight traveling across
+          the muted text — no second color is introduced. Scoped class so the
+          keyframes live with the only component that uses them; the
+          reduced-motion guard drops the animation (and the mask) entirely. */}
+      <style>{`
+        .orchestrator-reasoning-shimmer {
+          -webkit-mask-image: linear-gradient(
+            100deg,
+            rgba(0, 0, 0, 0.45) 30%,
+            rgba(0, 0, 0, 1) 50%,
+            rgba(0, 0, 0, 0.45) 70%
+          );
+          mask-image: linear-gradient(
+            100deg,
+            rgba(0, 0, 0, 0.45) 30%,
+            rgba(0, 0, 0, 1) 50%,
+            rgba(0, 0, 0, 0.45) 70%
+          );
+          -webkit-mask-size: 220% 100%;
+          mask-size: 220% 100%;
+          animation: orchestrator-reasoning-sweep 1.8s linear infinite;
+        }
+        @keyframes orchestrator-reasoning-sweep {
+          from {
+            -webkit-mask-position: 180% 0;
+            mask-position: 180% 0;
+          }
+          to {
+            -webkit-mask-position: -80% 0;
+            mask-position: -80% 0;
+          }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .orchestrator-reasoning-shimmer {
+            -webkit-mask-image: none;
+            mask-image: none;
+            animation: none;
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
@@ -21,9 +21,11 @@ import {
   Terminal,
   Wrench,
 } from "lucide-react";
-import { type ReactNode, useState } from "react";
-import { DiffView } from "./orchestrator-diff";
-import { formatClockTime, stripAnsi } from "./view-format";
+import { type ReactNode, useMemo, useState } from "react";
+import { countDiff, DiffStat, DiffView, lineDiff } from "./orchestrator-diff";
+import { MarkdownText } from "./orchestrator-markdown";
+import { ReasoningCell } from "./orchestrator-reasoning";
+import { formatClockTime, formatDuration, stripAnsi } from "./view-format";
 
 // The orchestrator room renders a coding-agent session the way Claude Code /
 // Codex do: a single flowing conversation of (1) the user's prompts, (2) the
@@ -61,6 +63,11 @@ export interface ToolView {
   query?: string;
   /** Tool result/output, ANSI-stripped. */
   output?: string;
+  /** Process exit code for `execute` tools (0 = success); null/undefined when
+   * not an exec tool or not yet finished. */
+  exitCode?: number | null;
+  /** Wall-clock duration in ms from the tool's first to last event. */
+  durationMs?: number;
 }
 
 export type ConversationBlock =
@@ -74,6 +81,7 @@ export type ConversationBlock =
       tone: "normal" | "error";
     }
   | { kind: "tool"; key: string; at: number; tool: ToolView }
+  | { kind: "reasoning"; key: string; at: number; text: string }
   | {
       kind: "notice";
       key: string;
@@ -103,14 +111,14 @@ const NOTICE_META: Record<string, NoticeMeta> = {
   task_registered: { icon: Circle, tone: "text-muted", label: "Task started" },
   task_complete: { icon: CircleCheck, tone: "text-ok", label: "Completed" },
   stopped: { icon: CircleStop, tone: "text-muted", label: "Stopped" },
-  blocked: { icon: OctagonX, tone: "text-warn", label: "Blocked" },
+  blocked: { icon: OctagonX, tone: "text-muted-strong", label: "Blocked" },
   blocked_auto_resolved: {
     icon: Check,
     tone: "text-muted",
     label: "Auto-resolved",
   },
-  escalation: { icon: CircleAlert, tone: "text-warn", label: "Escalation" },
-  error: { icon: CircleX, tone: "text-danger", label: "Error" },
+  escalation: { icon: CircleAlert, tone: "text-muted", label: "Escalation" },
+  error: { icon: CircleX, tone: "text-red-500", label: "Error" },
 };
 
 function noticeMeta(eventType: string): NoticeMeta {
@@ -157,6 +165,19 @@ function pickString(
   return undefined;
 }
 
+/** First finite number among `keys` on `obj`. */
+function pickNumber(
+  obj: Record<string, unknown> | undefined,
+  ...keys: string[]
+): number | undefined {
+  if (!obj) return undefined;
+  for (const key of keys) {
+    const value = obj[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return undefined;
+}
+
 /** Tool output arrives as a possibly JSON-encoded string (e.g. `"\"\""` for an
  * empty result); decode one layer, strip ANSI, and drop if empty. */
 function normalizeOutput(value: unknown): string | undefined {
@@ -185,6 +206,54 @@ function normalizeOutput(value: unknown): string | undefined {
   return clean === "" ? undefined : clean;
 }
 
+interface ToolOutput {
+  text?: string;
+  diff?: { path?: string; oldText?: string; newText?: string };
+}
+
+/** ACP tool results arrive as a JSON-encoded array of content blocks, e.g.
+ * `[{type:"content",content:{type:"text",text}}, {type:"diff",path,oldText,newText}]`.
+ * Pull out the human-readable text and any file diff so the card renders real
+ * prose + a diff instead of dumping the raw JSON the agent returned. Plain
+ * (non-block) strings fall back to {@link normalizeOutput}. */
+function parseToolOutput(raw: unknown): ToolOutput {
+  let value = raw;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed.startsWith("[") && !trimmed.startsWith("{")) {
+      return { text: normalizeOutput(raw) };
+    }
+    try {
+      value = JSON.parse(trimmed);
+    } catch {
+      return { text: normalizeOutput(raw) };
+    }
+  }
+  const blocks = Array.isArray(value) ? value : [value];
+  const texts: string[] = [];
+  let diff: ToolOutput["diff"];
+  for (const block of blocks) {
+    const record = asRecord(block);
+    if (!record) continue;
+    if (record.type === "diff") {
+      diff = {
+        path: pickString(record, "path"),
+        oldText:
+          typeof record.oldText === "string" ? record.oldText : undefined,
+        newText:
+          typeof record.newText === "string" ? record.newText : undefined,
+      };
+      continue;
+    }
+    const inner = asRecord(record.content) ?? record;
+    const text =
+      pickString(inner, "text", "content") ?? pickString(record, "text");
+    if (text) texts.push(text);
+  }
+  const joined = stripAnsi(texts.join("\n")).trim();
+  return { text: joined === "" ? undefined : joined, diff };
+}
+
 /** The raw `data.toolCall` object the ACP service forwards (see its field
  * mapping). Kept as an open record because adapters vary in which fields they
  * populate (`title`/`name`, `rawInput`/`input`, `output`/`rawOutput`, …); every
@@ -207,6 +276,8 @@ function toToolView(
   let status: ToolStatus = "running";
   let rawInput: Record<string, unknown> | undefined;
   let output: string | undefined;
+  let outputDiff: ToolOutput["diff"];
+  let exitCode: number | undefined;
   for (const event of events) {
     const call = rawToolCall(event);
     if (!call) continue;
@@ -216,9 +287,27 @@ function toToolView(
     if (rawStatus) status = TOOL_STATUS_FROM_RAW[rawStatus] ?? status;
     const nextInput = asRecord(call.rawInput) ?? asRecord(call.input);
     if (nextInput) rawInput = { ...rawInput, ...nextInput };
-    const nextOutput = normalizeOutput(call.output ?? call.rawOutput);
-    if (nextOutput) output = nextOutput;
+    const parsed = parseToolOutput(call.output ?? call.rawOutput);
+    if (parsed.text) output = parsed.text;
+    if (
+      parsed.diff?.oldText !== undefined ||
+      parsed.diff?.newText !== undefined
+    )
+      outputDiff = parsed.diff;
+    const nextExit =
+      pickNumber(asRecord(call.exitStatus), "exitCode") ??
+      pickNumber(call, "exitCode");
+    if (nextExit !== undefined) exitCode = nextExit;
   }
+  // A finished exec tool's exit code is the authoritative status — opencode tops
+  // its tool events out at in_progress, so the code is what distinguishes a
+  // success from a failure.
+  if (typeof exitCode === "number") status = exitCode === 0 ? "done" : "failed";
+  // Wall-clock span from the tool's first to last event.
+  const durationMs =
+    events.length > 1
+      ? events[events.length - 1].timestamp - events[0].timestamp
+      : undefined;
   return {
     id,
     title,
@@ -226,16 +315,16 @@ function toToolView(
     status,
     filePath: pickString(rawInput, "filePath", "file_path", "path"),
     command: pickString(rawInput, "command", "cmd", "script"),
-    newText: pickString(
-      rawInput,
-      "content",
-      "newString",
-      "new_string",
-      "newText",
-    ),
-    oldText: pickString(rawInput, "oldString", "old_string", "oldText"),
+    newText:
+      pickString(rawInput, "content", "newString", "new_string", "newText") ??
+      outputDiff?.newText,
+    oldText:
+      pickString(rawInput, "oldString", "old_string", "oldText") ??
+      outputDiff?.oldText,
     query: pickString(rawInput, "pattern", "query", "regex", "glob"),
     output,
+    exitCode,
+    durationMs: durationMs && durationMs > 0 ? durationMs : undefined,
   };
 }
 
@@ -247,6 +336,7 @@ type Atom =
       message: CodingAgentTaskMessageRecord;
     }
   | { at: number; order: number; type: "tool"; tool: ToolView }
+  | { at: number; order: number; type: "reasoning"; text: string }
   | {
       at: number;
       order: number;
@@ -261,7 +351,9 @@ type Atom =
 function messageLane(message: CodingAgentTaskMessageRecord): string {
   if (message.senderKind === "user") return "user";
   const stream = message.direction === "stderr" ? "err" : "out";
-  return `${message.senderKind}:${message.sessionId ?? ""}:${stream}`;
+  // Fall back to the message id (not a shared "") when there's no session, so
+  // unrelated session-less outputs never coalesce into one merged turn.
+  return `${message.senderKind}:${message.sessionId ?? message.id}:${stream}`;
 }
 
 /** Turn the polled message + event records into the ordered conversation the
@@ -278,12 +370,14 @@ export function buildConversation(
   let order = 0;
 
   for (const message of messages) {
+    // Skip raw stdin/keystroke echoes from sub-agents, but ALWAYS render the
+    // user's own typed messages — those are recorded with senderKind "user"
+    // AND direction "stdin", and skipping them hid the user's input entirely.
     if (
-      (message.direction === "stdin" || message.direction === "keys") &&
-      message.senderKind !== "user"
-    ) {
+      message.senderKind !== "user" &&
+      (message.direction === "stdin" || message.direction === "keys")
+    )
       continue;
-    }
     if (stripAnsi(message.content).trim() === "") continue;
     atoms.push({
       at: message.timestamp,
@@ -304,6 +398,21 @@ export function buildConversation(
         toolEvents.set(id, [event]);
         toolFirstSeen.set(id, event.timestamp);
       }
+      continue;
+    }
+    // Reasoning streams as many small `agent_thought_chunk` deltas; capture the
+    // full text from event.data (not the 160-char summary) and let the block
+    // pass coalesce consecutive deltas into one collapsible cell — rendering
+    // each delta as its own notice would flood the room.
+    if (event.eventType === "reasoning") {
+      const text = typeof event.data?.text === "string" ? event.data.text : "";
+      if (text)
+        atoms.push({
+          at: event.timestamp,
+          order: order++,
+          type: "reasoning",
+          text,
+        });
       continue;
     }
     if (NOISE_EVENT_TYPES.has(event.eventType)) continue;
@@ -344,9 +453,14 @@ export function buildConversation(
     lane: string;
     block: Extract<ConversationBlock, { kind: "user" | "agent" }>;
   } | null = null;
+  // Consecutive reasoning deltas coalesce into one collapsible cell, the way a
+  // message lane coalesces; any non-reasoning atom closes the burst.
+  let openReasoning: Extract<ConversationBlock, { kind: "reasoning" }> | null =
+    null;
 
   for (const atom of atoms) {
     if (atom.type === "message") {
+      openReasoning = null;
       const lane = messageLane(atom.message);
       const text = stripAnsi(atom.message.content);
       if (openLane && openLane.lane === lane) {
@@ -377,6 +491,22 @@ export function buildConversation(
       continue;
     }
     openLane = null;
+    if (atom.type === "reasoning") {
+      if (openReasoning) {
+        openReasoning.text += atom.text;
+      } else {
+        const block = {
+          kind: "reasoning" as const,
+          key: `reason-${atom.order}`,
+          at: atom.at,
+          text: atom.text,
+        };
+        blocks.push(block);
+        openReasoning = block;
+      }
+      continue;
+    }
+    openReasoning = null;
     if (atom.type === "tool") {
       blocks.push({
         kind: "tool",
@@ -398,156 +528,6 @@ export function buildConversation(
   }
 
   return blocks;
-}
-
-// --- Lightweight markdown ---------------------------------------------------
-// The agent writes markdown prose; rendering it (code fences, inline code,
-// bold, lists, headings) is what makes the room read like a chat rather than a
-// log. This is deliberately small — no external markdown engine — matching the
-// in-repo precedent (config-field's preview renderer).
-
-const FENCE = /```([\w-]*)\n?([\s\S]*?)```/g;
-
-function renderInline(text: string, keyBase: string): ReactNode[] {
-  const nodes: ReactNode[] = [];
-  const pattern =
-    /\*\*([^*]+)\*\*|`([^`]+)`|\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
-  let last = 0;
-  let index = 0;
-  let match = pattern.exec(text);
-  while (match !== null) {
-    if (match.index > last) nodes.push(text.slice(last, match.index));
-    if (match[1] !== undefined) {
-      nodes.push(
-        <strong key={`${keyBase}-b${index}`} className="font-semibold text-txt">
-          {match[1]}
-        </strong>,
-      );
-    } else if (match[2] !== undefined) {
-      nodes.push(
-        <code
-          key={`${keyBase}-c${index}`}
-          className="rounded bg-bg/70 px-1 py-px font-mono text-[0.95em] text-accent"
-        >
-          {match[2]}
-        </code>,
-      );
-    } else if (match[3] !== undefined) {
-      nodes.push(
-        <a
-          key={`${keyBase}-l${index}`}
-          href={match[4]}
-          target="_blank"
-          rel="noreferrer"
-          className="text-accent underline underline-offset-2"
-        >
-          {match[3]}
-        </a>,
-      );
-    }
-    last = match.index + match[0].length;
-    index += 1;
-    match = pattern.exec(text);
-  }
-  if (last < text.length) nodes.push(text.slice(last));
-  return nodes;
-}
-
-function renderProse(text: string, keyBase: string): ReactNode {
-  const lines = text.split("\n");
-  return lines.map((line, lineIndex) => {
-    const key = `${keyBase}-${lineIndex}`;
-    if (line.trim() === "") return <div key={key} className="h-2" />;
-    const heading = /^(#{1,6})\s+(.*)$/.exec(line);
-    if (heading) {
-      return (
-        <div key={key} className="mt-1 font-semibold text-txt">
-          {renderInline(heading[2], key)}
-        </div>
-      );
-    }
-    const bullet = /^\s*[-*•]\s+(.*)$/.exec(line);
-    if (bullet) {
-      return (
-        <div key={key} className="flex gap-1.5">
-          <span className="select-none text-muted">•</span>
-          <span className="min-w-0 flex-1">{renderInline(bullet[1], key)}</span>
-        </div>
-      );
-    }
-    const numbered = /^\s*(\d+)\.\s+(.*)$/.exec(line);
-    if (numbered) {
-      return (
-        <div key={key} className="flex gap-1.5">
-          <span className="select-none tabular-nums text-muted">
-            {numbered[1]}.
-          </span>
-          <span className="min-w-0 flex-1">
-            {renderInline(numbered[2], key)}
-          </span>
-        </div>
-      );
-    }
-    return (
-      <div key={key} className="break-words leading-relaxed">
-        {renderInline(line, key)}
-      </div>
-    );
-  });
-}
-
-export function MarkdownText({ text }: { text: string }): ReactNode {
-  const segments: ReactNode[] = [];
-  let last = 0;
-  let index = 0;
-  FENCE.lastIndex = 0;
-  let match = FENCE.exec(text);
-  while (match !== null) {
-    if (match.index > last) {
-      segments.push(
-        <div key={`p${index}`}>
-          {renderProse(text.slice(last, match.index), `p${index}`)}
-        </div>,
-      );
-    }
-    segments.push(
-      <CodeBlock
-        key={`f${index}`}
-        language={match[1]}
-        code={match[2].replace(/\n$/, "")}
-      />,
-    );
-    last = match.index + match[0].length;
-    index += 1;
-    match = FENCE.exec(text);
-  }
-  if (last < text.length) {
-    segments.push(
-      <div key={`p${index}`}>{renderProse(text.slice(last), `p${index}`)}</div>,
-    );
-  }
-  return <div className="space-y-0.5">{segments}</div>;
-}
-
-function CodeBlock({
-  language,
-  code,
-}: {
-  language?: string;
-  code: string;
-}): ReactNode {
-  return (
-    <div className="my-1 overflow-hidden rounded-md border border-border/50 bg-bg/80">
-      {language ? (
-        <div className="border-b border-border/40 px-2 py-0.5 font-mono text-2xs text-muted">
-          {language}
-        </div>
-      ) : null}
-      <pre className="max-h-72 overflow-auto px-2.5 py-1.5 font-mono text-2xs leading-relaxed text-txt">
-        {code}
-      </pre>
-    </div>
-  );
 }
 
 // --- Conversation block views ----------------------------------------------
@@ -584,6 +564,44 @@ function toolIcon(tool: ToolView): LucideIcon {
   );
 }
 
+// Codex labels a tool by the ACTION it took, not the raw tool name: "Ran",
+// "Read", "Edited", "Searched", not "bash"/"grep". Present tense while the call
+// is in flight, past tense once it has settled (the red badge carries failure,
+// so a failed run is still "Ran"). Tuple is [running, settled].
+const VERB_BY_KIND: Record<string, readonly [string, string]> = {
+  execute: ["Running", "Ran"],
+  read: ["Reading", "Read"],
+  edit: ["Editing", "Edited"],
+  search: ["Searching", "Searched"],
+  fetch: ["Fetching", "Searched web"],
+  move: ["Moving", "Moved"],
+  delete: ["Deleting", "Deleted"],
+  think: ["Thinking", "Thought"],
+};
+
+const VERB_BY_TITLE: Record<string, readonly [string, string]> = {
+  write: ["Writing", "Wrote"],
+  edit: ["Editing", "Edited"],
+  read: ["Reading", "Read"],
+  bash: ["Running", "Ran"],
+  shell: ["Running", "Ran"],
+  grep: ["Searching", "Searched"],
+  glob: ["Searching", "Searched"],
+  list: ["Listing", "Listed"],
+  webfetch: ["Fetching", "Searched web"],
+  fetch: ["Fetching", "Searched web"],
+};
+
+/** The action verb for a tool's header, status-aware. Falls back to the raw
+ * tool name for kinds we don't have a verb for, so nothing renders blank. */
+function toolVerb(tool: ToolView): string {
+  const pair =
+    VERB_BY_TITLE[tool.title.toLowerCase()] ??
+    VERB_BY_KIND[tool.kind.toLowerCase()];
+  if (!pair) return tool.title;
+  return tool.status === "running" ? pair[0] : pair[1];
+}
+
 /** The shortest meaningful one-liner about what a tool touched, shown in the
  * collapsed header (file name, command, or query). */
 function toolTarget(tool: ToolView): string | undefined {
@@ -600,9 +618,14 @@ const STATUS_BADGE: Record<
   ToolStatus,
   { icon: LucideIcon; tone: string; label: string; spin?: boolean }
 > = {
-  running: { icon: Loader, tone: "text-accent", label: "Running", spin: true },
+  running: {
+    icon: Loader,
+    tone: "text-muted-strong",
+    label: "Running",
+    spin: true,
+  },
   done: { icon: Check, tone: "text-ok", label: "Done" },
-  failed: { icon: CircleX, tone: "text-danger", label: "Failed" },
+  failed: { icon: CircleX, tone: "text-red-500", label: "Failed" },
 };
 
 const MAX_BODY_CHARS = 4000;
@@ -616,6 +639,19 @@ function TruncatedNote(): ReactNode {
   return (
     <div className="px-1 text-2xs text-muted/70">… (truncated for display)</div>
   );
+}
+
+/** Command output's meaningful result — the error, the exit summary, the last
+ * failing line — usually lives at the END, so when it's too long keep BOTH
+ * ends and elide the middle rather than dropping the tail (a head-only clamp
+ * hides exactly the part you opened the card to read). Diffs keep the head-only
+ * clamp above; a mid-string marker there would corrupt line alignment. */
+function clampOutput(text: string): string {
+  if (text.length <= MAX_BODY_CHARS) return text;
+  const head = Math.ceil(MAX_BODY_CHARS * 0.6);
+  const tail = MAX_BODY_CHARS - head;
+  const elided = text.length - head - tail;
+  return `${text.slice(0, head).trimEnd()}\n\n… ${elided.toLocaleString()} characters elided …\n\n${text.slice(-tail).trimStart()}`;
 }
 
 /** The expandable body of a tool card: an interleaved diff for edits, the new
@@ -638,28 +674,16 @@ function ToolBody({ tool }: { tool: ToolView }): ReactNode {
     if (truncated) blocks.push(<TruncatedNote key="content-trunc" />);
   }
 
-  if (tool.command) {
-    blocks.push(
-      <div
-        key="cmd"
-        className="rounded-md border border-border/40 bg-black/40 px-2.5 py-1 font-mono text-2xs text-txt"
-      >
-        <span className="select-none text-ok">$ </span>
-        <span className="whitespace-pre-wrap break-words">{tool.command}</span>
-      </div>,
-    );
-  }
-
+  // The command itself is already shown (untruncated on hover) in the card
+  // header, so the body carries only its output — no redundant `$` echo.
   if (tool.output) {
-    const { body, truncated } = clamp(tool.output);
     blocks.push(
       <pre
         key="out"
         className="overflow-auto rounded-md border border-border/40 bg-bg/60 px-2.5 py-1.5 font-mono text-2xs leading-relaxed text-muted"
         style={{ maxHeight: "14rem" }}
       >
-        {body}
-        {truncated ? "\n… (truncated)" : ""}
+        {clampOutput(tool.output)}
       </pre>,
     );
   }
@@ -668,22 +692,35 @@ function ToolBody({ tool }: { tool: ToolView }): ReactNode {
   return <div className="mt-1.5 space-y-1.5">{blocks}</div>;
 }
 
-function ToolCallCard({
-  tool,
-  at,
-  locale,
-}: {
-  tool: ToolView;
-  at: number;
-  locale?: string;
-}): ReactNode {
+function ToolCallCard({ tool }: { tool: ToolView }): ReactNode {
   const Icon = toolIcon(tool);
   const badge = STATUS_BADGE[tool.status];
   const BadgeIcon = badge.icon;
   const target = toolTarget(tool);
-  const hasBody = Boolean(
-    tool.newText !== undefined || tool.command || tool.output,
+  // The command lives in the header; only a diff/new content or captured
+  // output makes the card expandable. A command that printed nothing is a
+  // single tidy line — no chevron, no empty body.
+  const hasBody = Boolean(tool.newText !== undefined || tool.output);
+  // Edit/write magnitude shown on the collapsed header so the reader sees the
+  // size of a change without expanding it.
+  const diffStat = useMemo(
+    () =>
+      tool.newText === undefined
+        ? null
+        : countDiff(lineDiff(tool.oldText ?? "", tool.newText)),
+    [tool.oldText, tool.newText],
   );
+  // Codex-style result suffix: a non-zero exit code (red badge already conveys
+  // failure) and the wall-clock duration, both dim/mono.
+  const meta: string[] = [];
+  if (typeof tool.exitCode === "number" && tool.exitCode !== 0)
+    meta.push(`exit ${tool.exitCode}`);
+  // Only surface a duration once it's meaningful. A non-streaming command
+  // (e.g. `pip install --quiet`) emits its start and end events within the
+  // same tick, so a sub-second event-span is a logging artifact, not a real
+  // runtime — showing "1ms" for a multi-second install would be misleading.
+  if (tool.durationMs !== undefined && tool.durationMs >= 1000)
+    meta.push(formatDuration(tool.durationMs));
   // Open by default while the agent is mid-edit so the change is visible as it
   // streams; collapse finished read/search calls to keep the room scannable.
   const [open, setOpen] = useState(
@@ -691,7 +728,7 @@ function ToolCallCard({
   );
   return (
     <div
-      className="rounded-md border border-border/50 bg-bg-accent/20"
+      className="rounded-md border border-border/50 bg-card/50"
       data-testid="orchestrator-tool-call"
     >
       <button
@@ -707,17 +744,23 @@ function ToolCallCard({
         ) : (
           <span className="w-3 shrink-0" />
         )}
-        <Icon className="h-3.5 w-3.5 shrink-0 text-accent" />
-        <span className="shrink-0 font-mono text-xs font-semibold text-txt">
-          {tool.title}
+        <Icon className="h-3.5 w-3.5 shrink-0 text-muted-strong" />
+        <span className="shrink-0 text-xs font-semibold text-txt">
+          {toolVerb(tool)}
         </span>
-        {target ? (
-          <span className="min-w-0 flex-1 truncate font-mono text-2xs text-muted">
+        {target && target !== tool.title ? (
+          <span
+            title={target}
+            className="min-w-0 flex-1 truncate font-mono text-2xs text-muted"
+          >
             {target}
           </span>
         ) : (
           <span className="flex-1" />
         )}
+        {diffStat && (diffStat.added > 0 || diffStat.removed > 0) ? (
+          <DiffStat added={diffStat.added} removed={diffStat.removed} />
+        ) : null}
         <span
           className={`flex shrink-0 items-center gap-1 text-2xs ${badge.tone}`}
         >
@@ -726,9 +769,11 @@ function ToolCallCard({
           />
           {badge.label}
         </span>
-        <span className="shrink-0 tabular-nums text-2xs text-muted/70">
-          {formatClockTime(at, locale)}
-        </span>
+        {meta.length > 0 ? (
+          <span className="shrink-0 font-mono text-2xs tabular-nums text-muted/70">
+            {meta.join(" · ")}
+          </span>
+        ) : null}
       </button>
       {open ? (
         <div className="px-2.5 pb-2">{<ToolBody tool={tool} />}</div>
@@ -751,40 +796,47 @@ export function ConversationBlockView({
         data-testid="orchestrator-user-message"
       >
         <div
-          className="rounded-lg bg-accent/20 px-2.5 py-1.5 text-xs text-txt"
-          style={{ maxWidth: "88%" }}
+          className="rounded-lg border border-border/50 bg-surface px-3 py-2 text-xs text-txt"
+          style={{ maxWidth: "80%" }}
         >
-          <div className="mb-0.5 text-2xs tabular-nums text-muted">
+          <div className="whitespace-pre-wrap break-words leading-relaxed">
+            {block.content}
+          </div>
+          <div className="mt-1 text-3xs tabular-nums text-muted/70">
             {formatClockTime(block.at, locale)}
           </div>
-          <div className="whitespace-pre-wrap break-words">{block.content}</div>
         </div>
       </div>
     );
   }
 
   if (block.kind === "agent") {
+    // Codex Desktop renders the assistant turn FLAT (full-width markdown, no
+    // bubble) with a small identity marker — only the user's turn is bubbled.
     return (
       <div
-        className="flex flex-col items-start"
+        className="flex w-full flex-col items-start"
         data-testid="orchestrator-agent-message"
       >
+        <div className="mb-1 flex items-center gap-2 text-3xs text-muted">
+          <span
+            className="inline-block h-1.5 w-1.5 rounded-full bg-muted-strong"
+            aria-hidden
+          />
+          <span className="font-semibold tracking-tight text-txt/90">
+            {block.senderName}
+          </span>
+          <span className="tabular-nums">
+            {formatClockTime(block.at, locale)}
+          </span>
+        </div>
         <div
-          className={`rounded-lg px-2.5 py-1.5 text-xs ${
+          className={
             block.tone === "error"
-              ? "bg-danger/10 text-danger"
-              : "bg-bg-hover/60 text-txt"
-          }`}
-          style={{ maxWidth: "92%" }}
+              ? "w-full border-l-2 border-red-500/40 pl-2.5 text-red-500"
+              : "w-full text-txt"
+          }
         >
-          <div className="mb-0.5 flex items-center gap-2 text-2xs text-muted">
-            <span className="font-semibold tracking-tight text-txt/90">
-              {block.senderName}
-            </span>
-            <span className="tabular-nums">
-              {formatClockTime(block.at, locale)}
-            </span>
-          </div>
           <MarkdownText text={block.content} />
         </div>
       </div>
@@ -792,7 +844,11 @@ export function ConversationBlockView({
   }
 
   if (block.kind === "tool") {
-    return <ToolCallCard tool={block.tool} at={block.at} locale={locale} />;
+    return <ToolCallCard tool={block.tool} />;
+  }
+
+  if (block.kind === "reasoning") {
+    return <ReasoningCell text={block.text} />;
   }
 
   const Icon = block.icon;
@@ -805,9 +861,6 @@ export function ConversationBlockView({
       <Icon className={`h-3 w-3 shrink-0 ${block.tone}`} />
       <span className={`min-w-0 shrink truncate font-medium ${block.tone}`}>
         {block.text}
-      </span>
-      <span className="shrink-0 tabular-nums">
-        {formatClockTime(block.at, locale)}
       </span>
       <span className="h-px flex-1 bg-border/40" />
     </div>

--- a/plugins/plugin-task-coordinator/src/register.ts
+++ b/plugins/plugin-task-coordinator/src/register.ts
@@ -1,6 +1,7 @@
 import { registerAppShellPage } from "@elizaos/ui/app-shell-registry";
 import { OrchestratorTuiView } from "./CodingAgentTasksPanel";
 import { OrchestratorWorkbench } from "./OrchestratorWorkbench";
+import { OdysseusShell } from "./odysseus/OdysseusShell";
 
 registerAppShellPage({
   id: "orchestrator",
@@ -10,7 +11,22 @@ registerAppShellPage({
   path: "/orchestrator",
   order: 70,
   group: "developer",
+  fullBleed: true,
   Component: OrchestratorWorkbench,
+});
+
+// odysseus 1:1 port — rendered at /odysseus while iterated; folds into
+// /orchestrator once approved.
+registerAppShellPage({
+  id: "odysseus",
+  pluginId: "@elizaos/plugin-task-coordinator",
+  label: "Odysseus",
+  icon: "MessageSquare",
+  path: "/odysseus",
+  order: 69,
+  group: "developer",
+  fullBleed: true,
+  Component: OdysseusShell,
 });
 
 registerAppShellPage({

--- a/plugins/plugin-task-coordinator/src/view-format.ts
+++ b/plugins/plugin-task-coordinator/src/view-format.ts
@@ -71,3 +71,13 @@ export function formatUsd(value: number, locale?: string): string {
     maximumFractionDigits: value !== 0 && value < 1 ? 4 : 2,
   }).format(value);
 }
+
+/** Humanize a millisecond duration for tool timings: "420ms", "4.1s", "2m 30s". */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  const seconds = ms / 1000;
+  if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rest = Math.round(seconds % 60);
+  return rest ? `${minutes}m ${rest}s` : `${minutes}m`;
+}

--- a/plugins/plugin-task-coordinator/test/odysseus-shell.live.e2e.test.ts
+++ b/plugins/plugin-task-coordinator/test/odysseus-shell.live.e2e.test.ts
@@ -1,0 +1,423 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type BrowserContext, chromium, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// Live UI e2e for the odysseus port at /odysseus. Drives the real running dev
+// stack (`bun run dev:web:ui`) headless and asserts the surfaces this port
+// ships: shell chrome, composer, theme engine (preset recolor + canvas effects),
+// and the reuse-backed Memory/Skills panels (against real agent data). Gated on
+// the stack being reachable — a no-op (skipped) without a running stack; run via
+// `bun run --cwd plugins/plugin-task-coordinator test:e2e:manual`.
+
+const BASE = process.env.ORCH_BASE_URL ?? "http://127.0.0.1:2138";
+
+function httpCode(url: string): string {
+  const result = spawnSync(
+    "curl",
+    ["-s", "-o", "/dev/null", "-w", "%{http_code}", "--max-time", "4", url],
+    { encoding: "utf8" },
+  );
+  return (result.stdout ?? "").trim();
+}
+
+const STACK_UP =
+  httpCode(`${BASE}/odysseus`) === "200" &&
+  httpCode(`${BASE}/api/orchestrator/tasks`) === "200";
+
+function chromePath(): string | undefined {
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  for (const candidate of [
+    "/usr/bin/google-chrome",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+  ]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+const IGNORED_CONSOLE =
+  /Failed to load resource|willReadFrequently|WebGL|GPU stall|\[vite\]|API server unavailable|WebSocket connection to|ERR_CONNECTION_REFUSED/;
+
+describe.skipIf(!STACK_UP)("odysseus shell (live e2e)", () => {
+  let context: BrowserContext;
+  let page: Page;
+  const pageErrors: string[] = [];
+
+  async function ensureShell(): Promise<void> {
+    // ~90s budget — covers a cold dev-server compile of the view bundle.
+    for (let i = 0; i < 90; i++) {
+      if (await page.locator('[data-testid="odysseus-shell"]').count()) return;
+      const connect = page.getByRole("button", { name: /^connect$/i }).first();
+      if (await connect.isVisible().catch(() => false)) {
+        await page
+          .getByText("Local", { exact: false })
+          .first()
+          .click()
+          .catch(() => {});
+        await connect.click().catch(() => {});
+      }
+      await page.waitForTimeout(1000);
+    }
+    throw new Error("odysseus shell never loaded");
+  }
+
+  const bgVar = () =>
+    page.evaluate(() =>
+      getComputedStyle(
+        document.querySelector('[data-testid="odysseus-shell"]') as Element,
+      )
+        .getPropertyValue("--bg")
+        .trim(),
+    );
+
+  // The theme menu is now a tabbed modal (Themes / Customize). Open it only if
+  // it isn't already showing (the rail button toggles), then optionally switch
+  // to a tab. Swatches live under "Themes" (default); font/density/background
+  // pills live under "Customize".
+  async function openTheme(tab?: "Themes" | "Customize") {
+    await ensureRail();
+    // Picking a swatch closes the menu (onPick→onClose), so let any close
+    // animation settle before deciding whether to re-open — a racy count check
+    // would skip the re-open mid-animation and the grid would never appear.
+    await page.waitForTimeout(350);
+    const visible = await page
+      .locator(".od-theme-panel")
+      .isVisible()
+      .catch(() => false);
+    if (!visible) {
+      await page.locator('.od-rail-btn[aria-label="Theme"]').click();
+      await page
+        .locator(".od-theme-panel")
+        .waitFor({ state: "visible", timeout: 8000 });
+      await page.waitForTimeout(250);
+    }
+    if (tab) {
+      await page
+        .locator(".od-theme-tab", { hasText: tab })
+        .click()
+        .catch(() => {});
+      await page.waitForTimeout(250);
+    }
+  }
+  // The theme menu stays open while tweaking pills (font/density/bg) — odysseus
+  // behaviour; close it before touching the rail again. The full-screen backdrop
+  // button sits BEHIND the centered panel, so a click on it lands on the panel;
+  // ThemeMenu honours Escape (useEscapeClose), so press that, then fall back to
+  // the in-panel close button, and verify the panel is gone.
+  async function closeTheme() {
+    await page.keyboard.press("Escape").catch(() => {});
+    await page.waitForTimeout(250);
+    if ((await page.locator(".od-theme-panel").count()) > 0) {
+      await page
+        .locator('[aria-label="Close theme"]')
+        .click({ timeout: 1500 })
+        .catch(() => {});
+      await page.waitForTimeout(250);
+    }
+    await page
+      .locator(".od-theme-panel")
+      .waitFor({ state: "hidden", timeout: 4000 })
+      .catch(() => {});
+  }
+  // Memory/Skills overlays center the panel over the full-size backdrop, so a
+  // backdrop-center click lands on the panel; Escape (handled by the auto-
+  // focused search input) closes reliably.
+  async function closeOverlay() {
+    await page.keyboard.press("Escape").catch(() => {});
+    await page.waitForTimeout(250);
+  }
+  // odysseus shows the 48px icon-rail and the wide sidebar mutually exclusively:
+  // the rail appears only when the sidebar is collapsed. Tools/theme/memory/
+  // skills open from the rail, so ensure it's visible (collapse the sidebar via
+  // its header hamburger) before clicking a rail button.
+  async function ensureRail() {
+    if (
+      await page
+        .locator(".od-icon-rail")
+        .isVisible()
+        .catch(() => false)
+    )
+      return;
+    await page
+      .locator(".od-sidebar-hamburger")
+      .click()
+      .catch(() => {});
+    await page
+      .locator(".od-icon-rail")
+      .waitFor({ state: "visible", timeout: 5000 })
+      .catch(() => {});
+    await page.waitForTimeout(200);
+  }
+  // The thread list + resize handle live in the expanded sidebar; ensure it
+  // shows (expand via the rail's toggle button) before touching them.
+  async function ensureSidebar() {
+    if (
+      await page
+        .locator(".od-sidebar")
+        .isVisible()
+        .catch(() => false)
+    )
+      return;
+    await page
+      .locator('.od-rail-btn[aria-label="Toggle sidebar"]')
+      .click()
+      .catch(() => {});
+    await page
+      .locator(".od-sidebar")
+      .waitFor({ state: "visible", timeout: 5000 })
+      .catch(() => {});
+    await page.waitForTimeout(200);
+  }
+
+  beforeAll(async () => {
+    context = await chromium.launchPersistentContext(
+      // Distinct default profile dir per live-e2e suite: vitest runs test files
+      // in parallel, and two suites sharing one chromium user-data-dir collide
+      // on the ProcessSingleton lock. ORCH_PROFILE still overrides for manual runs.
+      process.env.ORCH_PROFILE ??
+        path.join(os.tmpdir(), "eliza-orch-e2e-profile-odysseus"),
+      {
+        headless: true,
+        viewport: { width: 1600, height: 1000 },
+        executablePath: chromePath(),
+        args: ["--no-sandbox", "--disable-gpu"],
+      },
+    );
+    page = context.pages()[0] ?? (await context.newPage());
+    page.on("pageerror", (error) =>
+      pageErrors.push(String(error).slice(0, 240)),
+    );
+    page.on("console", (m) => {
+      if (m.type() === "error" && !IGNORED_CONSOLE.test(m.text()))
+        pageErrors.push(m.text().slice(0, 200));
+    });
+    // `commit` (fires on navigation start) instead of `domcontentloaded`: the
+    // dev server lazily compiles the (large) view bundle on the first cold
+    // request, which can exceed the default 30s DOMContentLoaded wait. The shell
+    // selector poll in ensureShell() is the real readiness gate.
+    await page.goto(`${BASE}/odysseus`, {
+      waitUntil: "commit",
+      timeout: 120_000,
+    });
+    await ensureShell();
+    await page.waitForTimeout(800);
+  }, 120_000);
+
+  afterAll(async () => {
+    await context?.close();
+  });
+
+  it("renders the shell chrome with no page errors", async () => {
+    expect(await page.locator('[data-testid="odysseus-shell"]').count()).toBe(
+      1,
+    );
+    // Default desktop state is the expanded sidebar; the rail is its collapsed
+    // alternative and is mutually exclusive (matching odysseus), so exactly one
+    // of the two is mounted at a time — here the sidebar.
+    expect(await page.locator(".od-sidebar").count()).toBe(1);
+    expect(await page.locator(".od-icon-rail").count()).toBe(0);
+    expect(await page.locator(".od-input-bar").count()).toBe(1);
+    expect(pageErrors, pageErrors.join("\n")).toEqual([]);
+  });
+
+  it("theme presets recolor the shell (cyberpunk → restore dark)", async () => {
+    await openTheme("Themes");
+    const cyber = page.locator(".od-theme-swatch", { hasText: "cyberpunk" });
+    await cyber.scrollIntoViewIfNeeded();
+    await cyber.click();
+    await page.waitForTimeout(300);
+    expect(await bgVar()).toBe("#0a0a0f");
+    await openTheme("Themes");
+    // The default One-Dark theme's swatch is labelled "original" (themeLabel),
+    // matching odysseus — not "dark".
+    const dark = page
+      .locator(".od-theme-swatch", { hasText: "original" })
+      .first();
+    await dark.scrollIntoViewIfNeeded();
+    await dark.click();
+    await page.waitForTimeout(300);
+    expect(await bgVar()).toBe("#282c34");
+  });
+
+  it("canvas bg-effects mount when selected", async () => {
+    // Background pills live under the Customize tab in the tabbed theme modal.
+    await openTheme("Customize");
+    const sparkles = page.locator(".od-theme-pill", { hasText: "sparkles" });
+    await sparkles.scrollIntoViewIfNeeded();
+    await sparkles.click();
+    await page.waitForTimeout(400);
+    expect(await page.locator(".od-bg-canvas").count()).toBe(1);
+    // pills keep the menu open; reuse it, then close before leaving.
+    const none = page.locator(".od-theme-pill", { hasText: "none" });
+    await none.scrollIntoViewIfNeeded();
+    await none.click();
+    await page.waitForTimeout(200);
+    expect(await page.locator(".od-bg-canvas").count()).toBe(0);
+    await closeTheme();
+  });
+
+  it("memory panel lists real memories (reused plugin-sql backend)", async () => {
+    await closeTheme();
+    await ensureRail();
+    await page.locator('.od-rail-btn[aria-label="Memory"]').click();
+    // The panel loads stats + the memory feed on open; wait for the first row
+    // (browse tab is the default) rather than a fixed delay.
+    await page
+      .locator(".od-mem-item")
+      .first()
+      .waitFor({ timeout: 8000 })
+      .catch(() => {});
+    expect(await page.locator(".od-mem-item").count()).toBeGreaterThan(0);
+    await closeOverlay();
+  });
+
+  it("skills panel lists skills (reused plugin-agent-skills backend)", async () => {
+    await closeOverlay();
+    await ensureRail();
+    await page.locator('.od-rail-btn[aria-label="Skills"]').click();
+    // Skills render as expandable cards (.od-skills-card) post-redesign.
+    await page
+      .locator(".od-skills-card")
+      .first()
+      .waitFor({ timeout: 8000 })
+      .catch(() => {});
+    expect(await page.locator(".od-skills-card").count()).toBeGreaterThan(0);
+    await closeOverlay();
+  });
+
+  // The ported tool views (wave 1 + 2): each rail launcher opens an overlay
+  // panel and Escape closes it, with no page errors. Asserts the surface mounts
+  // — fidelity/data is verified per-view elsewhere (screenshots).
+  const TOOL_VIEWS = [
+    "Documents",
+    "Compare",
+    "Deep Research",
+    "Calendar",
+    "Tasks",
+    "Models",
+    "Email",
+    "Gallery",
+    "Cookbook",
+    "Image Editor",
+    "Group Chat",
+    "Admin",
+  ];
+  for (const label of TOOL_VIEWS) {
+    it(`opens + closes the ${label} view`, async () => {
+      await closeOverlay();
+      await ensureRail();
+      await page.locator(`.od-rail-btn[aria-label="${label}"]`).click();
+      await page.waitForTimeout(700);
+      expect(await page.locator(".od-search-overlay").count()).toBeGreaterThan(
+        0,
+      );
+      await page.keyboard.press("Escape");
+      await page.waitForTimeout(300);
+      expect(await page.locator(".od-search-overlay").count()).toBe(0);
+    });
+  }
+
+  // Pin/star a thread (odysseus): pinning floats it to the top of the Chats
+  // list with a star, and persists; unpinning clears it. Needs ≥2 threads on
+  // the live stack — soft-skips otherwise.
+  it("pinning a thread floats it to the top with a star", async () => {
+    await closeOverlay();
+    await page.evaluate(() =>
+      window.localStorage.removeItem("odysseus:pinned-threads"),
+    );
+    await page.reload({ waitUntil: "commit", timeout: 120_000 });
+    await ensureShell();
+    await ensureSidebar();
+    await page.waitForTimeout(600);
+
+    const rows = page.locator(".od-thread-row");
+    const count = await rows.count();
+    if (count < 2) return; // not enough threads to prove reordering
+
+    const lastTitle = (
+      await rows
+        .nth(count - 1)
+        .locator(".od-grow")
+        .innerText()
+    ).trim();
+    await rows.nth(count - 1).hover();
+    await rows
+      .nth(count - 1)
+      .locator(".od-thread-menu-btn")
+      .click();
+    await page.waitForTimeout(150);
+    await page.getByRole("button", { name: /^Pin$/ }).click();
+    await page.waitForTimeout(300);
+
+    const firstTitle = (
+      await rows.nth(0).locator(".od-grow").innerText()
+    ).trim();
+    expect(firstTitle).toBe(lastTitle);
+    expect(await rows.nth(0).locator(".od-thread-pin-dot").count()).toBe(1);
+    expect(
+      await page.evaluate(() =>
+        window.localStorage.getItem("odysseus:pinned-threads"),
+      ),
+    ).toContain('"');
+
+    // Unpin (cleanup) → pref empties.
+    await rows.nth(0).hover();
+    await rows.nth(0).locator(".od-thread-menu-btn").click();
+    await page.waitForTimeout(150);
+    await page.getByRole("button", { name: /^Unpin$/ }).click();
+    await page.waitForTimeout(250);
+    expect(
+      await page.evaluate(() =>
+        window.localStorage.getItem("odysseus:pinned-threads"),
+      ),
+    ).toBe("[]");
+  });
+
+  // Drag-resize the sidebar (odysseus .sidebar-resize-handle): widen on drag,
+  // clamp at the 180px floor, and persist the final width across reload. Runs
+  // last because it reloads the page.
+  it("sidebar resize handle widens, clamps, and persists", async () => {
+    await closeOverlay();
+    await ensureSidebar();
+    const sidebar = page.locator(".od-sidebar").first();
+    const handle = page.locator(".od-sidebar-resize-handle").first();
+    expect(await handle.count()).toBe(1);
+
+    const widthOf = async () => (await sidebar.boundingBox())?.width ?? 0;
+    const dragBy = async (dx: number) => {
+      const hb = await handle.boundingBox();
+      if (!hb) throw new Error("resize handle has no box");
+      const cx = hb.x + hb.width / 2;
+      const cy = hb.y + hb.height / 2;
+      await page.mouse.move(cx, cy);
+      await page.mouse.down();
+      await page.mouse.move(cx + dx / 2, cy, { steps: 5 });
+      await page.mouse.move(cx + dx, cy, { steps: 5 });
+      await page.mouse.up();
+      await page.waitForTimeout(200);
+    };
+
+    const w0 = await widthOf();
+    await dragBy(70);
+    expect(await widthOf()).toBeGreaterThan(w0 + 40);
+
+    // Drag far left → clamps at the 180px floor.
+    await dragBy(-400);
+    expect(Math.abs((await widthOf()) - 180)).toBeLessThan(3);
+    expect(
+      await page.evaluate(() =>
+        window.localStorage.getItem("odysseus:sidebar-width"),
+      ),
+    ).toBe("180");
+
+    // Persisted width survives a reload.
+    await page.reload({ waitUntil: "commit", timeout: 120_000 });
+    await ensureShell();
+    await page.waitForTimeout(400);
+    expect(Math.abs((await widthOf()) - 180)).toBeLessThan(3);
+  });
+});

--- a/plugins/plugin-task-coordinator/test/orchestrator-workbench.live.e2e.test.ts
+++ b/plugins/plugin-task-coordinator/test/orchestrator-workbench.live.e2e.test.ts
@@ -1,0 +1,207 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { type BrowserContext, chromium, type Page } from "playwright";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+// Live UI e2e for the /orchestrator workbench. It drives the real running dev
+// stack (`bun run dev:web:ui`) with a headless browser and asserts the things
+// that actually broke in practice: raw ACP JSON leaking into the transcript,
+// horizontal overflow, the user's own message not appearing after sending, and
+// any console/page errors. It is gated on the stack being reachable, so it is a
+// no-op (skipped) in environments without a running stack — run it explicitly
+// with `bun run --cwd plugins/plugin-task-coordinator test:e2e:manual`.
+
+const BASE = process.env.ORCH_BASE_URL ?? "http://127.0.0.1:2138";
+
+function httpCode(url: string): string {
+  const result = spawnSync(
+    "curl",
+    ["-s", "-o", "/dev/null", "-w", "%{http_code}", "--max-time", "4", url],
+    { encoding: "utf8" },
+  );
+  return (result.stdout ?? "").trim();
+}
+
+// Both the UI and the API proxy must answer 200 — the API check ensures the
+// agent is actually up, not just vite serving the shell.
+const STACK_UP =
+  httpCode(`${BASE}/orchestrator`) === "200" &&
+  httpCode(`${BASE}/api/orchestrator/tasks`) === "200";
+
+function chromePath(): string | undefined {
+  if (process.env.CHROME_PATH) return process.env.CHROME_PATH;
+  for (const candidate of [
+    "/usr/bin/google-chrome",
+    "/usr/bin/chromium",
+    "/usr/bin/chromium-browser",
+  ]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined; // fall back to Playwright's bundled Chromium
+}
+
+// Console noise that is environmental (GPU/canvas perf hints, dev resource
+// 404s) rather than an application error. "API server unavailable" startup
+// warnings and WebSocket connection failures are dev-stack connection-timing:
+// the dev supervisor respawns the agent on exit, so a page load can briefly
+// race a respawning API/WS — the UI handles this gracefully (logs + reconnects)
+// and a genuine API outage is still caught by the functional tests above.
+const IGNORED_CONSOLE =
+  /Failed to load resource|willReadFrequently|WebGL|GPU stall|\[vite\]|API server unavailable|WebSocket connection to|ERR_CONNECTION_REFUSED/;
+
+// The raw ACP content-block JSON that must never reach the rendered transcript.
+const RAW_ACP_JSON = /\[\s*\{\s*"type"\s*:\s*"(?:diff|content|text)"/;
+
+describe.skipIf(!STACK_UP)("orchestrator workbench (live e2e)", () => {
+  let context: BrowserContext;
+  let page: Page;
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+
+  async function present(testid: string): Promise<boolean> {
+    return (await page.locator(`[data-testid="${testid}"]`).count()) > 0;
+  }
+
+  async function ensureWorkbench(): Promise<void> {
+    // Brand-new browser profiles hit the "Where should Eliza run?" onboarding;
+    // pick Local and connect so the workbench loads. A returning profile skips
+    // straight through.
+    for (let i = 0; i < 40; i++) {
+      if (await present("orchestrator-workbench")) return;
+      const connect = page.getByRole("button", { name: /^connect$/i }).first();
+      if (await connect.isVisible().catch(() => false)) {
+        await page
+          .getByText("Local", { exact: false })
+          .first()
+          .click()
+          .catch(() => {});
+        await connect.click().catch(() => {});
+      }
+      await page.waitForTimeout(1000);
+    }
+    throw new Error("orchestrator workbench never loaded");
+  }
+
+  async function openTask(index: number): Promise<void> {
+    await page
+      .locator('[data-testid="orchestrator-task-item"]')
+      .nth(index)
+      .click();
+    await page.waitForTimeout(1200);
+  }
+
+  beforeAll(async () => {
+    context = await chromium.launchPersistentContext(
+      // Distinct default profile dir per live-e2e suite: vitest runs test files
+      // in parallel, and two suites sharing one chromium user-data-dir collide
+      // on the ProcessSingleton lock. ORCH_PROFILE still overrides for manual runs.
+      process.env.ORCH_PROFILE ??
+        path.join(os.tmpdir(), "eliza-orch-e2e-profile-workbench"),
+      {
+        headless: true,
+        viewport: { width: 1600, height: 1000 },
+        executablePath: chromePath(),
+        args: ["--no-sandbox", "--disable-gpu"],
+      },
+    );
+    page = context.pages()[0] ?? (await context.newPage());
+    page.on("console", (message) => {
+      const type = message.type();
+      if (type !== "error" && type !== "warning") return;
+      const text = message.text();
+      if (!IGNORED_CONSOLE.test(text)) consoleErrors.push(text.slice(0, 200));
+    });
+    page.on("pageerror", (error) =>
+      pageErrors.push(String(error).slice(0, 240)),
+    );
+    await page.goto(`${BASE}/orchestrator`, { waitUntil: "domcontentloaded" });
+    await ensureWorkbench();
+    await page.waitForTimeout(1200);
+  }, 120_000);
+
+  afterAll(async () => {
+    await context?.close();
+  });
+
+  it("loads the workbench with no page errors", async () => {
+    expect(await present("orchestrator-workbench")).toBe(true);
+    expect(pageErrors, pageErrors.join("\n")).toEqual([]);
+  });
+
+  it("renders every task without raw ACP JSON in the transcript", async () => {
+    const count = await page
+      .locator('[data-testid="orchestrator-task-item"]')
+      .count();
+    for (let i = 0; i < count; i++) {
+      await openTask(i);
+      const text = await page
+        .locator('[data-testid="orchestrator-message-list"]')
+        .innerText()
+        .catch(() => "");
+      expect(RAW_ACP_JSON.test(text), `task ${i} leaked raw ACP JSON`).toBe(
+        false,
+      );
+      expect(text).not.toContain("[object Object]");
+      expect(text).not.toContain("undefined\n");
+    }
+  }, 120_000);
+
+  it("does not overflow the transcript horizontally", async () => {
+    const count = await page
+      .locator('[data-testid="orchestrator-task-item"]')
+      .count();
+    for (let i = 0; i < count; i++) {
+      await openTask(i);
+      const overflow = await page.evaluate(() => {
+        const el = document.querySelector(
+          '[data-testid="orchestrator-message-list"]',
+        );
+        return el ? el.scrollWidth - el.clientWidth : 0;
+      });
+      expect(
+        overflow,
+        `task ${i} overflows by ${overflow}px`,
+      ).toBeLessThanOrEqual(4);
+    }
+  }, 120_000);
+
+  it("shows the user's message in the transcript after sending", async () => {
+    const items = page.locator('[data-testid="orchestrator-task-item"]');
+    if ((await items.count()) === 0) return;
+    await openTask(0);
+    const composer = page
+      .locator(
+        '[data-testid="orchestrator-composer"] textarea, [data-testid="orchestrator-composer"] input, textarea',
+      )
+      .first();
+    expect(await composer.count()).toBeGreaterThan(0);
+    const probe = `e2e-probe-${process.pid}-${Math.floor(performance.now())}`;
+    await composer.fill(probe);
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(2500);
+    const transcript = await page
+      .locator('[data-testid="orchestrator-message-list"]')
+      .innerText()
+      .catch(() => "");
+    expect(
+      transcript.includes(probe),
+      "the sent message never appeared in the transcript",
+    ).toBe(true);
+  }, 60_000);
+
+  it("opens and closes the create-task dialog", async () => {
+    if (!(await present("orchestrator-new-task"))) return;
+    await page.locator('[data-testid="orchestrator-new-task"]').first().click();
+    await page.waitForTimeout(600);
+    expect(await present("orchestrator-create-dialog")).toBe(true);
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(400);
+    expect(await present("orchestrator-create-dialog")).toBe(false);
+  }, 60_000);
+
+  it("had no application console errors across the session", () => {
+    expect(consoleErrors, consoleErrors.join("\n")).toEqual([]);
+  });
+});

--- a/plugins/plugin-task-coordinator/vitest.e2e.config.ts
+++ b/plugins/plugin-task-coordinator/vitest.e2e.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from "vitest/config";
+
+// Live e2e config. The default `vitest.config.ts` (and the repo root config)
+// exclude `*.live.e2e.test.ts` because they drive the real running dev stack
+// (`bun run dev:web:ui`) with a headless browser. They're opt-in: run with
+// `bun run --cwd plugins/plugin-task-coordinator test:e2e:manual`. Each suite
+// gates itself on the stack being reachable, so it skips cleanly when it isn't.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.live.e2e.test.ts"],
+    exclude: ["dist/**", "**/node_modules/**"],
+    testTimeout: 600_000,
+    hookTimeout: 120_000,
+  },
+});


### PR DESCRIPTION
## Summary

Adds a full **chat-shell UI for the multi-agent orchestrator**, modeled on the
[odysseus](https://github.com/pewdiepie-archdaemon/odysseus) frontend (MIT) and
rebuilt from scratch in **React on `@elizaos/ui`**, wired to the **existing
elizaOS runtime**. This is **frontend only** — there is no new backend; all
task/session state continues to live in `@elizaos/plugin-agent-orchestrator`.

The new surface renders at **`/odysseus`** (and the existing **`/orchestrator`**
route) as a full-window app: a labeled session sidebar, a rich composer, a theme
engine, the memory/skills/notes/settings panels, and the full set of tool views.

> Credit: the original UI/UX design is from **odysseus** (MIT). This is an
> independent React reimplementation on elizaOS's own stack — none of the
> odysseus Python backend is used.

## What's included

**New `plugins/plugin-task-coordinator/src/odysseus/` shell (~40 files):**
- `OdysseusShell` root + `SessionSidebar` (folders, multi-select, pin, drag,
  resize) + collapsible 48px `IconRail` (mutually exclusive with the sidebar)
- `Composer` with slash-command + emoji autocomplete and a bottom action row
- Theme engine (`ThemeMenu` / `PresetsPanel`): preset recolor + customize
  (font / density / background), mapped onto elizaOS semantic CSS vars
- `MemoryPanel` (memories/skills/add/settings), `SkillsPanel`, `NotesPanel`,
  `SettingsPanel`
- Tool views: tasks, models, email, calendar, gallery (+ editor), compare,
  research, voice, group chat, cookbook, document library, admin
- A cross-view **window manager** (`WindowManager` + `useWindowControls`):
  drag / resize / edge-snap / minimize-to-dock (`MinimizedDock`)
- `useKeyboardShortcuts`, `useEscapeClose`, `useTaskRoom`, `useChatSubmit`

**Orchestrator render helpers:**
- `orchestrator-markdown` (via `marked`), `orchestrator-plan`,
  `orchestrator-reasoning`
- `orchestrator-stream` now always renders the user's own `stdin` messages
  (preserves the existing `senderKind === "user"` fix)

**App-shell `fullBleed` capability (`packages/ui`):**
- Opt-in `fullBleed?: boolean` on `AppShellPageRegistration`
  (backward-compatible). When set, the host shell mounts the page edge-to-edge
  via `ViewRouter` — **no header, no tab bar, no routed padding** — so a view
  that owns its whole window has no surrounding dashboard chrome.
- This **replaces the prior hardcoded `tab !== "orchestrator"` header
  special-case** in `RoutedShellContent` with a general, declarative flag.
- `/orchestrator` and the new `/odysseus` route are registered `fullBleed: true`.

**Other:**
- adds the `marked` dependency to the plugin
- isolates each `*.live.e2e.test.ts` suite's default chromium profile dir so
  parallel vitest file execution can't collide on the ProcessSingleton lock

## Verification

Built on a fresh branch off current `develop` and verified there:

- biome check — clean across all 53 changed source files
- `tsgo --noEmit` (plugin) — **0 errors** against current `develop` APIs
- `tsgo --noEmit` (`@elizaos/ui`) — 0 errors in `App.tsx` / `app-shell-registry.ts`
- plugin unit tests — **19/19** pass
- plugin build — `tsup` + views bundle + type declarations all succeed
- live e2e (`*.live.e2e.test.ts`) — **26/26** pass against a running dev stack,
  and Playwright render checks confirm the host header is absent on `/odysseus`
  (full-bleed) and the global chat overlay behaves correctly

## Scope / notes

- **Frontend only.** No actions/providers/services added; state stays in
  `@elizaos/plugin-agent-orchestrator`.
- The `fullBleed` flag is opt-in and changes no existing page's behavior.
- Some per-view actions render honest empty/disabled states where elizaOS has no
  corresponding client method yet (e.g. email IMAP/SMTP, calendar CalDAV,
  gallery image backend, voice TTS/STT) — these light up unchanged once the
  matching runtime routes exist. Happy to file follow-up issues for these.

Screenshots / a short screen recording can be added on request.

## Related

- Closes #8188 (proposal/motivation).
- Unblocked by #8187 — a develop-side `biome` format fix for `plugin-app-control/src/views/ViewManagerView.tsx` that currently red-fails the repo-wide **Format Check** gate (and every open PR). This PR's Format Check goes green once #8187 lands.

## CI status (for reviewers)

This PR's own gates are green: Format Check (this PR's files), Server Tests, unit-tests, lint-and-types, integration-tests, coverage on changed files, gitleaks, check-pr-title, route-coverage, iOS Simulator Build, Homepage Build, Electrobun Desktop Contract, Cloud Live E2E.

The currently-red lanes are **pre-existing on `develop`**, not introduced here — proven by #8187 (a 1-file format-only change) failing the *identical* set:

- Plugin Tests — `@elizaos/plugin-rlm` (`server.test.ts` spawns `/nonexistent/python`)
- Client Tests — `FineTuningTuiView.test.tsx` (plugin-training)
- Zero-Key Deterministic E2E, `bun run dev onboarding chat`, `env:audit:check`
- Android Debug Build — `shortcuts.xml` deep-link audit (`run-mobile-build.mjs`)
- Format Check (biome) — develop's `ViewManagerView.tsx` (→ #8187)

A short screen recording / screenshots of the live `/odysseus` surfaces can be added on request.
