### PR TITLE
test(orchestrator): cover ACP plan events and word-split text

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-service.test.ts
@@ -797,6 +797,106 @@ describe("AcpService", () => {
     expect((await service.getSession(sessionId))?.status).toBe("ready");
   });
 
+  it("native sendPrompt re-spaces word-split terminal result text blocks", async () => {
+    const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
+    await service.start();
+    const { sessionId } = await service.spawnSession({
+      name: "native-wordsplit",
+      agentType: "codex",
+      workdir: "/tmp/acp-test",
+    });
+    const client = firstNativeClient();
+    client.prompt.mockImplementationOnce(async () => {
+      client.emit({
+        jsonrpc: "2.0",
+        id: "prompt",
+        sessionId: "protocol-session",
+        result: {
+          stopReason: "end_turn",
+          content: [
+            { type: "text", text: "the change" },
+            { type: "text", text: "is" },
+            { type: "text", text: "proven and" },
+            { type: "text", text: "received" },
+            { type: "text", text: "at runtime" },
+          ],
+        },
+      } as AcpJsonRpcMessage);
+      return { stopReason: "end_turn" };
+    });
+
+    const result = await service.sendPrompt(sessionId, "answer");
+
+    expect(result.response).toBe(
+      "the change is proven and received at runtime",
+    );
+    expect(result.finalText).toBe(
+      "the change is proven and received at runtime",
+    );
+  });
+
+  it("native sendPrompt forwards sanitized ACP plan updates", async () => {
+    const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
+    const planPayloads: Array<{ entries?: unknown }> = [];
+    service.onSessionEvent((_sid, event, payload) => {
+      if (event === "plan") planPayloads.push(payload as { entries?: unknown });
+    });
+    await service.start();
+    const { sessionId } = await service.spawnSession({
+      name: "native-plan",
+      agentType: "opencode",
+      workdir: "/tmp/acp-test",
+    });
+    const client = firstNativeClient();
+    client.prompt.mockImplementationOnce(async () => {
+      client.emit({
+        jsonrpc: "2.0",
+        method: "session/update",
+        params: {
+          sessionId: "protocol-session",
+          update: {
+            sessionUpdate: "plan",
+            entries: [
+              {
+                content: "Write the file",
+                status: "in_progress",
+                priority: "medium",
+                ignored: "not forwarded",
+              },
+              {
+                content: "Read it back",
+                status: "pending",
+                priority: "low",
+              },
+              {
+                content: "Defaults apply",
+                status: "",
+                priority: 1,
+              },
+              { content: "", status: "pending", priority: "medium" },
+              "not an entry",
+            ],
+          },
+        },
+      } as AcpJsonRpcMessage);
+      client.emit({
+        jsonrpc: "2.0",
+        id: "prompt",
+        result: { stopReason: "end_turn" },
+      } as AcpJsonRpcMessage);
+      return { stopReason: "end_turn" };
+    });
+
+    await service.sendPrompt(sessionId, "go");
+
+    expect(planPayloads).toHaveLength(1);
+    expect(planPayloads[0]?.entries).toEqual([
+      { content: "Write the file", status: "in_progress", priority: "medium" },
+      { content: "Read it back", status: "pending", priority: "low" },
+      { content: "Defaults apply", status: "pending", priority: "medium" },
+    ]);
+  });
+
   it("native sendPrompt rejects overlapping prompts before swapping event handlers", async () => {
     const service = new AcpService(runtime({ ELIZA_ACP_TRANSPORT: "native" }));
     await service.start();


### PR DESCRIPTION
## Stack

This PR is stacked on #8186 (`fix(ci): align zero-key app smoke with startup shell`), which itself includes:

- #8184 `fix(app): restore dev smoke chat mount`
- #8183 `chore: sync bun lock workspace entries`

That keeps this PR's diff limited to ACP service regression tests while CI includes the base fixes required by current `develop`.

Head after stack rebase: `aae41fc7a84ed7211cf85c2a7fdcf96c6e0bcf0b`.

## Summary

Adds focused ACP service regression coverage for two behaviors that came out of the Conductor/orchestrator audit:

- native ACP `sendPrompt` terminal text blocks that arrive split word-by-word are normalized into readable `response` and `finalText` values
- native ACP plan updates are sanitized before persistence, including defaulting valid items and dropping invalid entries

## Why

These are correctness guardrails for the agent-orchestrator DTO stream. They make the existing backend behavior explicit without adding new runtime behavior.

## Validation

Focused validation before the final stack-base update:

- `git fetch origin develop`
- `git rebase origin/develop`
- `.tmp/bun-install-canary/bin/bun install --frozen-lockfile` failed because the repo lockfile would change under the local toolchain
- `.tmp/bun-install-canary/bin/bun install --no-save` passed with no tracked file changes
- `PATH="$PWD/.tmp/bun-install-canary/bin:$PATH" bun run --cwd packages/logger build`
- `PATH="$PWD/.tmp/bun-install-canary/bin:$PATH" bun run --cwd packages/core build`
- `../../.tmp/bun-install-canary/bin/bun x vitest run --config vitest.config.ts __tests__/unit/acp-service.test.ts` passed: 37 tests
- `../../.tmp/bun-install-canary/bin/bun x @biomejs/biome format .`
- `git diff --check origin/develop...HEAD`
- `git rebase origin/codex/bun-lock-workspace-sync`
- `git diff --check origin/codex/bun-lock-workspace-sync...HEAD`
- `git rebase origin/codex/app-dev-smoke-cjs-interop`
- `git diff --check origin/codex/app-dev-smoke-cjs-interop...HEAD`
- `git rebase origin/codex/ci-smoke-drift-cleanup`
- `git diff --check origin/codex/ci-smoke-drift-cleanup...HEAD`

Post-push note: this worktree's `node_modules` was removed to free disk while the shared CI-smoke worktree was validating #8186, so the focused Vitest command was not rerun after the latest #8186 base-head advance. The PR diff is unchanged and `git diff --check origin/codex/ci-smoke-drift-cleanup...HEAD` remains clean.
