### PR TITLE
fix(orchestrator): guard stream identity and task deletion

### DIFF
--- a/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-stream.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-stream.test.ts
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import {
   buildConversation,
+  type ConversationBlock,
   MarkdownText,
   sanitizeMarkdownUrl,
 } from "../../src/orchestrator-stream";
@@ -209,7 +210,7 @@ describe("buildConversation", () => {
     expect(blocks).toEqual([
       expect.objectContaining({
         kind: "tool",
-        key: "tool-call-1",
+        key: "tool-session-codex:call-1",
         tool: expect.objectContaining({
           eventIds: ["tool-start", "tool-end"],
           sessionId: "session-codex",
@@ -222,6 +223,71 @@ describe("buildConversation", () => {
         eventType: "blocked",
         sessionId: "session-codex",
       }),
+    ]);
+  });
+
+  it("keeps duplicate tool call ids separate across sessions", () => {
+    const blocks = buildConversation(
+      [] satisfies MessageRecord[],
+      [
+        baseEvent({
+          id: "session-a-tool",
+          sessionId: "session-a",
+          eventType: "tool_running",
+          timestamp: 10,
+          summary: "session a",
+          data: {
+            toolCall: {
+              id: "call-1",
+              title: "bash",
+              kind: "execute",
+              status: "completed",
+              rawInput: { command: "bun test:a" },
+            },
+          },
+        }),
+        baseEvent({
+          id: "session-b-tool",
+          sessionId: "session-b",
+          eventType: "tool_running",
+          timestamp: 11,
+          summary: "session b",
+          data: {
+            toolCall: {
+              id: "call-1",
+              title: "bash",
+              kind: "execute",
+              status: "completed",
+              rawInput: { command: "bun test:b" },
+            },
+          },
+        }),
+      ],
+      (message) => message.senderKind,
+      new Set(),
+    );
+
+    const toolBlocks = blocks.filter(
+      (block): block is Extract<ConversationBlock, { kind: "tool" }> =>
+        block.kind === "tool",
+    );
+
+    expect(toolBlocks).toHaveLength(2);
+    expect(toolBlocks.map((block) => block.key)).toEqual([
+      "tool-session-a:call-1",
+      "tool-session-b:call-1",
+    ]);
+    expect(toolBlocks.map((block) => block.tool.id)).toEqual([
+      "call-1",
+      "call-1",
+    ]);
+    expect(toolBlocks.map((block) => block.tool.eventIds)).toEqual([
+      ["session-a-tool"],
+      ["session-b-tool"],
+    ]);
+    expect(toolBlocks.map((block) => block.tool.command)).toEqual([
+      "bun test:a",
+      "bun test:b",
     ]);
   });
 });

--- a/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-stream.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-stream.test.ts
@@ -1,12 +1,16 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import { buildConversation } from "../../src/orchestrator-stream";
+import {
+  buildConversation,
+  MarkdownText,
+  sanitizeMarkdownUrl,
+} from "../../src/orchestrator-stream";
 
 type MessageRecord = Parameters<typeof buildConversation>[0][number];
 type EventRecord = Parameters<typeof buildConversation>[1][number];
 
-const baseMessage = (
-  overrides: Partial<MessageRecord>,
-): MessageRecord => ({
+const baseMessage = (overrides: Partial<MessageRecord>): MessageRecord => ({
   id: "message-1",
   threadId: "task-1",
   sessionId: null,
@@ -15,6 +19,18 @@ const baseMessage = (
   content: "hello",
   timestamp: 1,
   metadata: {},
+  createdAt: "2026-05-30T18:00:00.000Z",
+  ...overrides,
+});
+
+const baseEvent = (overrides: Partial<EventRecord>): EventRecord => ({
+  id: "event-1",
+  threadId: "task-1",
+  sessionId: null,
+  eventType: "notice",
+  timestamp: 1,
+  summary: "notice",
+  data: {},
   createdAt: "2026-05-30T18:00:00.000Z",
   ...overrides,
 });
@@ -58,12 +74,183 @@ describe("buildConversation", () => {
         key: "msg-user-stdin",
         at: 10,
         content: "Please run browser smoke and report visible notes.",
+        messageIds: ["user-stdin"],
+        sessionId: null,
       },
       expect.objectContaining({
         kind: "agent",
         key: "msg-agent-stdout",
         content: "Visible sub-agent response.",
+        messageIds: ["agent-stdout"],
+        sessionId: "session-codex",
       }),
     ]);
+  });
+
+  it("preserves message identity when adjacent chunks merge", () => {
+    const blocks = buildConversation(
+      [
+        baseMessage({
+          id: "chunk-1",
+          sessionId: "session-codex",
+          content: "First",
+          timestamp: 10,
+        }),
+        baseMessage({
+          id: "chunk-2",
+          sessionId: "session-codex",
+          content: "second.",
+          timestamp: 11,
+        }),
+      ],
+      [] satisfies EventRecord[],
+      (message) => message.senderKind,
+      new Set(),
+    );
+
+    expect(blocks).toEqual([
+      expect.objectContaining({
+        kind: "agent",
+        key: "msg-chunk-1",
+        content: "Firstsecond.",
+        messageIds: ["chunk-1", "chunk-2"],
+        sessionId: "session-codex",
+      }),
+    ]);
+  });
+
+  it("does not merge unrelated session-less agent output", () => {
+    const blocks = buildConversation(
+      [
+        baseMessage({
+          id: "orchestrator-a",
+          sessionId: null,
+          content: "Task A",
+          timestamp: 10,
+        }),
+        baseMessage({
+          id: "orchestrator-b",
+          sessionId: null,
+          content: "Task B",
+          timestamp: 11,
+        }),
+      ],
+      [] satisfies EventRecord[],
+      (message) => message.senderKind,
+      new Set(),
+    );
+
+    expect(blocks).toEqual([
+      expect.objectContaining({
+        kind: "agent",
+        key: "msg-orchestrator-a",
+        content: "Task A",
+        messageIds: ["orchestrator-a"],
+        sessionId: null,
+      }),
+      expect.objectContaining({
+        kind: "agent",
+        key: "msg-orchestrator-b",
+        content: "Task B",
+        messageIds: ["orchestrator-b"],
+        sessionId: null,
+      }),
+    ]);
+  });
+
+  it("preserves event identity for merged tool calls and notices", () => {
+    const blocks = buildConversation(
+      [] satisfies MessageRecord[],
+      [
+        baseEvent({
+          id: "tool-start",
+          sessionId: "session-codex",
+          eventType: "tool_running",
+          timestamp: 10,
+          summary: "running",
+          data: {
+            toolCall: {
+              id: "call-1",
+              title: "bash",
+              kind: "execute",
+              status: "in_progress",
+              rawInput: { command: "bun test" },
+            },
+          },
+        }),
+        baseEvent({
+          id: "tool-end",
+          sessionId: "session-codex",
+          eventType: "tool_running",
+          timestamp: 11,
+          summary: "done",
+          data: {
+            toolCall: {
+              id: "call-1",
+              title: "bash",
+              kind: "execute",
+              status: "completed",
+              output: "passed",
+            },
+          },
+        }),
+        baseEvent({
+          id: "blocked-event",
+          sessionId: "session-codex",
+          eventType: "blocked",
+          timestamp: 12,
+          summary: "Needs input",
+        }),
+      ],
+      (message) => message.senderKind,
+      new Set(),
+    );
+
+    expect(blocks).toEqual([
+      expect.objectContaining({
+        kind: "tool",
+        key: "tool-call-1",
+        tool: expect.objectContaining({
+          eventIds: ["tool-start", "tool-end"],
+          sessionId: "session-codex",
+        }),
+      }),
+      expect.objectContaining({
+        kind: "notice",
+        key: "evt-blocked-event",
+        eventId: "blocked-event",
+        eventType: "blocked",
+        sessionId: "session-codex",
+      }),
+    ]);
+  });
+});
+
+describe("MarkdownText", () => {
+  it("allows only safe markdown link protocols", () => {
+    expect(sanitizeMarkdownUrl("https://example.com")).toBe(
+      "https://example.com",
+    );
+    expect(sanitizeMarkdownUrl("mailto:ops@example.com")).toBe(
+      "mailto:ops@example.com",
+    );
+    expect(sanitizeMarkdownUrl("/relative/path")).toBe("/relative/path");
+    expect(sanitizeMarkdownUrl("javascript:alert(1)")).toBeNull();
+    expect(sanitizeMarkdownUrl("data:text/html,<svg>")).toBeNull();
+  });
+
+  it("renders unsafe markdown links without href attributes", () => {
+    const html = renderToStaticMarkup(
+      createElement(MarkdownText, {
+        text:
+          "[safe](https://example.com) [bad](javascript:alert) " +
+          "[relative](/task/1)",
+      }),
+    );
+
+    expect(html).toContain('href="https://example.com"');
+    expect(html).toContain('href="/task/1"');
+    expect(html).not.toContain("javascript:");
+    expect(html).toContain("bad");
   });
 });

--- a/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
+++ b/plugins/plugin-task-coordinator/src/OrchestratorWorkbench.tsx
@@ -1183,6 +1183,7 @@ function AcceptanceSection({
       <ul className="space-y-1">
         {criteria.map((criterion, index) => (
           <li
+            // biome-ignore lint/suspicious/noArrayIndexKey: criteria strings may repeat, so index disambiguates the composite key
             key={`${criterion}-${index}`}
             className="flex items-start gap-1.5 text-xs-tight text-txt"
           >
@@ -3043,12 +3044,21 @@ export function OrchestratorWorkbench() {
             onReopen={() =>
               runMutation(() => client.reopenCodingAgentTaskThread(detail.id))
             }
-            onDelete={() =>
+            onDelete={() => {
+              const confirmed =
+                typeof window === "undefined" ||
+                window.confirm(
+                  t("orchestrator.confirmDelete", {
+                    defaultValue:
+                      "Delete this task and its transcript? This can't be undone.",
+                  }),
+                );
+              if (!confirmed) return;
               runMutation(async () => {
                 await client.deleteOrchestratorTask(detail.id);
                 setSelectedId(null);
-              })
-            }
+              });
+            }}
             onFork={() =>
               runMutation(async () => {
                 const forked = await client.forkOrchestratorTask(detail.id);

--- a/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
@@ -37,12 +37,15 @@ import { formatClockTime, stripAnsi } from "./view-format";
 //     token-ish), so consecutive same-sender chunks are concatenated into one
 //     turn instead of rendered as dozens of fragment bubbles.
 //   • A single tool invocation emits several `tool_running` events (in_progress
-//     → completed), so they are merged by `toolCall.id` into one card carrying
-//     the final status.
+//     → completed), so they are merged by session-scoped `toolCall.id` into one
+//     card carrying the final status.
 
 type ToolStatus = "running" | "done" | "failed";
 
 export interface ToolView {
+  /** Session-scoped render key; raw tool ids are not globally unique. */
+  groupKey: string;
+  /** The tool call's raw id from the adapter, preserved for inspection. */
   id: string;
   /** Task event ids merged into this rendered tool call. */
   eventIds: string[];
@@ -215,6 +218,7 @@ function rawToolCall(
  * non-empty output. */
 function toToolView(
   id: string,
+  groupKey: string,
   events: CodingAgentTaskEventRecord[],
 ): ToolView {
   let title = "tool";
@@ -235,6 +239,7 @@ function toToolView(
     if (nextOutput) output = nextOutput;
   }
   return {
+    groupKey,
     id,
     eventIds: events.map((event) => event.id),
     sessionId: events[0]?.sessionId ?? null,
@@ -285,6 +290,13 @@ function messageLane(message: CodingAgentTaskMessageRecord): string {
   return `${message.senderKind}:${message.sessionId ?? message.id}:${stream}`;
 }
 
+function toolGroupKey(
+  event: CodingAgentTaskEventRecord,
+  toolCallId: string,
+): string {
+  return `${event.sessionId ?? event.threadId ?? "sessionless"}:${toolCallId}`;
+}
+
 /** Turn the polled message + event records into the ordered conversation the
  * room renders. */
 export function buildConversation(
@@ -293,7 +305,10 @@ export function buildConversation(
   resolveSenderName: (message: CodingAgentTaskMessageRecord) => string,
   finishedSessionIds: ReadonlySet<string>,
 ): ConversationBlock[] {
-  const toolEvents = new Map<string, CodingAgentTaskEventRecord[]>();
+  const toolEvents = new Map<
+    string,
+    { id: string; events: CodingAgentTaskEventRecord[] }
+  >();
   const toolFirstSeen = new Map<string, number>();
   const atoms: Atom[] = [];
   let order = 0;
@@ -319,11 +334,12 @@ export function buildConversation(
     if (call) {
       const id =
         pickString(call, "id", "toolCallId", "callId") ?? `tool-${event.id}`;
-      const list = toolEvents.get(id);
-      if (list) list.push(event);
+      const groupKey = toolGroupKey(event, id);
+      const group = toolEvents.get(groupKey);
+      if (group) group.events.push(event);
       else {
-        toolEvents.set(id, [event]);
-        toolFirstSeen.set(id, event.timestamp);
+        toolEvents.set(groupKey, { id, events: [event] });
+        toolFirstSeen.set(groupKey, event.timestamp);
       }
       continue;
     }
@@ -339,8 +355,9 @@ export function buildConversation(
     });
   }
 
-  for (const [id, list] of toolEvents) {
-    const tool = toToolView(id, list);
+  for (const [groupKey, group] of toolEvents) {
+    const list = group.events;
+    const tool = toToolView(group.id, groupKey, list);
     // opencode never persists a tool's terminal status — its events top out at
     // `in_progress`. Once the owning session has finished, a still-"running"
     // tool has in fact completed, so reflect that instead of a perpetual spinner.
@@ -353,7 +370,7 @@ export function buildConversation(
       tool.status = "done";
     }
     atoms.push({
-      at: toolFirstSeen.get(id) ?? list[0].timestamp,
+      at: toolFirstSeen.get(groupKey) ?? list[0].timestamp,
       order: order++,
       type: "tool",
       tool,
@@ -408,7 +425,7 @@ export function buildConversation(
     if (atom.type === "tool") {
       blocks.push({
         kind: "tool",
-        key: `tool-${atom.tool.id}`,
+        key: `tool-${atom.tool.groupKey}`,
         at: atom.at,
         tool: atom.tool,
       });

--- a/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
@@ -44,6 +44,9 @@ type ToolStatus = "running" | "done" | "failed";
 
 export interface ToolView {
   id: string;
+  /** Task event ids merged into this rendered tool call. */
+  eventIds: string[];
+  sessionId: string | null;
   /** The tool's own name, e.g. `write`, `bash`, `read`. */
   title: string;
   /** ACP tool kind, e.g. `edit`, `execute`, `read`, `search`. */
@@ -64,7 +67,14 @@ export interface ToolView {
 }
 
 export type ConversationBlock =
-  | { kind: "user"; key: string; at: number; content: string }
+  | {
+      kind: "user";
+      key: string;
+      at: number;
+      content: string;
+      messageIds: string[];
+      sessionId: string | null;
+    }
   | {
       kind: "agent";
       key: string;
@@ -72,12 +82,17 @@ export type ConversationBlock =
       senderName: string;
       content: string;
       tone: "normal" | "error";
+      messageIds: string[];
+      sessionId: string | null;
     }
   | { kind: "tool"; key: string; at: number; tool: ToolView }
   | {
       kind: "notice";
       key: string;
       at: number;
+      eventId: string;
+      eventType: string;
+      sessionId: string | null;
       icon: LucideIcon;
       tone: string;
       text: string;
@@ -221,6 +236,8 @@ function toToolView(
   }
   return {
     id,
+    eventIds: events.map((event) => event.id),
+    sessionId: events[0]?.sessionId ?? null,
     title,
     kind,
     status,
@@ -251,6 +268,8 @@ type Atom =
       at: number;
       order: number;
       type: "notice";
+      eventId: string;
+      sessionId: string | null;
       eventType: string;
       summary: string;
     };
@@ -261,7 +280,9 @@ type Atom =
 function messageLane(message: CodingAgentTaskMessageRecord): string {
   if (message.senderKind === "user") return "user";
   const stream = message.direction === "stderr" ? "err" : "out";
-  return `${message.senderKind}:${message.sessionId ?? ""}:${stream}`;
+  // Fall back to the message id, not a shared empty string, so unrelated
+  // session-less output never coalesces into one rendered turn.
+  return `${message.senderKind}:${message.sessionId ?? message.id}:${stream}`;
 }
 
 /** Turn the polled message + event records into the ordered conversation the
@@ -311,6 +332,8 @@ export function buildConversation(
       at: event.timestamp,
       order: order++,
       type: "notice",
+      eventId: event.id,
+      sessionId: event.sessionId,
       eventType: event.eventType,
       summary: event.summary,
     });
@@ -351,6 +374,7 @@ export function buildConversation(
       const text = stripAnsi(atom.message.content);
       if (openLane && openLane.lane === lane) {
         openLane.block.content += text;
+        openLane.block.messageIds.push(atom.message.id);
         continue;
       }
       if (lane === "user") {
@@ -359,6 +383,8 @@ export function buildConversation(
           key: `msg-${atom.message.id}`,
           at: atom.at,
           content: text,
+          messageIds: [atom.message.id],
+          sessionId: atom.message.sessionId,
         };
         blocks.push(block);
         openLane = { lane, block };
@@ -370,6 +396,8 @@ export function buildConversation(
           senderName: resolveSenderName(atom.message),
           content: text,
           tone: atom.message.direction === "stderr" ? "error" : "normal",
+          messageIds: [atom.message.id],
+          sessionId: atom.message.sessionId,
         };
         blocks.push(block);
         openLane = { lane, block };
@@ -388,8 +416,11 @@ export function buildConversation(
       const meta = noticeMeta(atom.eventType);
       blocks.push({
         kind: "notice",
-        key: `evt-${atom.order}`,
+        key: `evt-${atom.eventId}`,
         at: atom.at,
+        eventId: atom.eventId,
+        eventType: atom.eventType,
+        sessionId: atom.sessionId,
         icon: meta.icon,
         tone: meta.tone,
         text: atom.summary.trim() || meta.label,
@@ -407,11 +438,30 @@ export function buildConversation(
 // in-repo precedent (config-field's preview renderer).
 
 const FENCE = /```([\w-]*)\n?([\s\S]*?)```/g;
+const SAFE_MARKDOWN_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+
+function hasUnsafeControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code <= 31 || code === 127) return true;
+  }
+  return false;
+}
+
+export function sanitizeMarkdownUrl(href: string): string | null {
+  const value = href.trim();
+  if (!value || hasUnsafeControlCharacter(value)) return null;
+
+  const protocolMatch = /^[a-z][a-z0-9+.-]*:/i.exec(value);
+  if (!protocolMatch) return value;
+
+  const protocol = protocolMatch[0].toLowerCase();
+  return SAFE_MARKDOWN_LINK_PROTOCOLS.has(protocol) ? value : null;
+}
 
 function renderInline(text: string, keyBase: string): ReactNode[] {
   const nodes: ReactNode[] = [];
-  const pattern =
-    /\*\*([^*]+)\*\*|`([^`]+)`|\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
+  const pattern = /\*\*([^*]+)\*\*|`([^`]+)`|\[([^\]]+)\]\(([^\s)]+)\)/g;
   let last = 0;
   let index = 0;
   let match = pattern.exec(text);
@@ -433,10 +483,18 @@ function renderInline(text: string, keyBase: string): ReactNode[] {
         </code>,
       );
     } else if (match[3] !== undefined) {
+      const href = sanitizeMarkdownUrl(match[4]);
+      if (!href) {
+        nodes.push(<span key={`${keyBase}-l${index}`}>{match[3]}</span>);
+        last = match.index + match[0].length;
+        index += 1;
+        match = pattern.exec(text);
+        continue;
+      }
       nodes.push(
         <a
           key={`${keyBase}-l${index}`}
-          href={match[4]}
+          href={href}
           target="_blank"
           rel="noreferrer"
           className="text-accent underline underline-offset-2"


### PR DESCRIPTION
## Stack

This PR is stacked on #8186 (`fix(ci): align zero-key app smoke with startup shell`), which itself includes:

- #8184 `fix(app): restore dev smoke chat mount`
- #8183 `chore: sync bun lock workspace entries`

That keeps this PR's diff limited to task-coordinator stream/deletion safety while CI includes the base fixes required by current `develop`.

Head after stack rebase: `b9f06d692f9aecf6fac8578ed86a8b9e9168ef1a`.

## Summary

Hardens the task-coordinator orchestrator UI in the narrow safety/correctness slice from the Conductor audit:

- preserves message and event identity metadata in conversation blocks
- prevents unrelated session-less agent output from coalescing into one rendered turn
- scopes tool-event grouping by session so duplicate adapter tool ids do not merge across sub-agent sessions
- sanitizes markdown links before rendering agent output
- asks for browser confirmation before deleting an orchestrator task

## Why

The operator view needs trustworthy recovery and inspection surfaces. This PR keeps rendered stream blocks traceable to backend records and removes two sharp UI edges without changing orchestrator execution behavior.

## Validation

Focused validation before the final stack-base update:

- `git fetch origin develop`
- `git rebase origin/develop`
- `PATH=/home/nubs/Git/iqlabs/eliza-labs/eliza-conductor-inspector/node_modules/.bin:$PATH biome check plugins/plugin-task-coordinator/src/orchestrator-stream.tsx plugins/plugin-task-coordinator/__tests__/unit/orchestrator-stream.test.ts`
- `PATH=/home/nubs/Git/iqlabs/eliza-labs/eliza-conductor-inspector/node_modules/.bin:$PATH vitest run --config vitest.config.ts __tests__/unit/orchestrator-stream.test.ts` from `plugins/plugin-task-coordinator`: 7 tests passed
- `git diff --check origin/develop...HEAD`
- `git rebase origin/codex/bun-lock-workspace-sync`
- `git diff --check origin/codex/bun-lock-workspace-sync...HEAD`
- `git rebase origin/codex/app-dev-smoke-cjs-interop`
- `git diff --check origin/codex/app-dev-smoke-cjs-interop...HEAD`
- `git rebase origin/codex/ci-smoke-drift-cleanup`
- `git diff --check origin/codex/ci-smoke-drift-cleanup...HEAD`

Note: this split worktree could not use `bun install --frozen-lockfile` with local Bun 1.3.13 because it rejects the current `bun.lock` version. The focused test was run against the dependency-bearing Conductor checkout without tracked file changes. Post-push, `git diff --check origin/codex/ci-smoke-drift-cleanup...HEAD` remains clean against the advanced #8186 base.
