### PR TITLE
fix(discord): carry recent unaddressed messages into a following addressed batch

### DIFF
--- a/plugins/plugin-discord/__tests__/debouncer-recent-context.test.ts
+++ b/plugins/plugin-discord/__tests__/debouncer-recent-context.test.ts
@@ -143,4 +143,75 @@ describe("Discord channel debouncer — recent unaddressed context buffer", () =
 			vi.useRealTimers();
 		}
 	});
+
+	it("still buffers an unaddressed message during the response cooldown (strict mode)", () => {
+		vi.useFakeTimers();
+		try {
+			const { flushed, debouncer } = setup({
+				shouldRespondOnlyToMentions: true,
+				bufferTtlMs: 10_000,
+				responseCooldownMs: 30_000,
+			});
+
+			// Bot just answered an addressed message → cooldown armed, buffer cleared.
+			debouncer.markResponded("channel-1");
+
+			// A follow-up question (unaddressed) arrives inside the cooldown window.
+			// In strict mode it never triggers a reply, so it must NOT be dropped —
+			// it should still be ingested and buffered for a following pointer.
+			debouncer.enqueue(mockMessage("1", "a follow-up question"));
+			vi.advanceTimersByTime(3000);
+
+			debouncer.enqueue(mockMessage("2", "<@123> ^^"));
+			expect(flushed[flushed.length - 1]).toEqual(["1", "2"]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not fold the buffer into a substantive addressed question (only into pointers)", () => {
+		vi.useFakeTimers();
+		try {
+			const { flushed, debouncer } = setup({
+				shouldRespondOnlyToMentions: true,
+				bufferTtlMs: 10_000,
+			});
+
+			// Unrelated chatter buffers and flushes on its own.
+			debouncer.enqueue(mockMessage("1", "man the weather is nice today"));
+			vi.advanceTimersByTime(3000);
+			expect(flushed).toEqual([["1"]]);
+
+			// A self-contained question arrives a beat later. It is NOT a pointer
+			// (it has its own words), so the chatter must NOT be folded in — folding
+			// unrelated context can derail the question's routing.
+			vi.advanceTimersByTime(2000);
+			debouncer.enqueue(
+				mockMessage("2", "<@123> what is the capital of france?"),
+			);
+			expect(flushed[flushed.length - 1]).toEqual(["2"]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not duplicate a message present in both the buffer and the pending batch", () => {
+		vi.useFakeTimers();
+		try {
+			const { flushed, debouncer } = setup({
+				shouldRespondOnlyToMentions: true,
+				bufferTtlMs: 10_000,
+			});
+
+			// Unaddressed message goes into BOTH the rolling buffer and the pending
+			// debounce batch. A targeted message arriving before the batch flushes
+			// drains both — the message must appear once, not twice.
+			debouncer.enqueue(mockMessage("1", "chatter still pending"));
+			debouncer.enqueue(mockMessage("2", "<@123> ^^"));
+
+			expect(flushed[flushed.length - 1]).toEqual(["1", "2"]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
 });

--- a/plugins/plugin-discord/__tests__/debouncer-recent-context.test.ts
+++ b/plugins/plugin-discord/__tests__/debouncer-recent-context.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import { createChannelDebouncer } from "../debouncer";
+
+function mockMessage(id: string, content: string, authorId = "user-1") {
+	return {
+		id,
+		content,
+		createdTimestamp: Number(id.replace(/\D/g, "")) || Date.now(),
+		channel: { id: "channel-1" },
+		author: {
+			id: authorId,
+			username: `user-${authorId}`,
+			displayName: `User ${authorId}`,
+		},
+		member: { displayName: `Member ${authorId}` },
+		attachments: { size: 0 },
+		stickers: { size: 0 },
+		reference: undefined,
+		mentions: { repliedUser: undefined },
+	} as never;
+}
+
+/**
+ * Regression coverage for the "@bot ^^" pointer bug: a substantive question typed
+ * a few seconds before an addressed pointer landed in a SEPARATE debounce batch,
+ * so the pointer reached the model with no "[Recent channel context]" and the bot
+ * answered with a generic greeting instead of the question. The channel debouncer
+ * now carries recent unaddressed messages forward (strict mode only) so the
+ * addressed flush folds them back in, matching the within-batch case.
+ */
+describe("Discord channel debouncer — recent unaddressed context buffer", () => {
+	function setup(options: Record<string, unknown>) {
+		const flushed: string[][] = [];
+		const debouncer = createChannelDebouncer(
+			(messages) => flushed.push(messages.map((m) => (m as { id: string }).id)),
+			{
+				botUserId: "123",
+				debounceMs: 3000,
+				coalesceEnabled: false,
+				...options,
+			},
+		);
+		return { flushed, debouncer };
+	}
+
+	it("folds a recent unaddressed message into a later addressed batch (strict mode)", () => {
+		vi.useFakeTimers();
+		try {
+			const { flushed, debouncer } = setup({
+				shouldRespondOnlyToMentions: true,
+				bufferTtlMs: 10_000,
+			});
+
+			// Unaddressed question flushes on its own (recorded, no response).
+			debouncer.enqueue(mockMessage("1", "how did apple build things?"));
+			vi.advanceTimersByTime(3000);
+			expect(flushed).toEqual([["1"]]);
+
+			// Addressed pointer arrives a beat later, in a separate batch.
+			vi.advanceTimersByTime(1000);
+			debouncer.enqueue(mockMessage("2", "<@123> ^^"));
+
+			// The addressed flush carries the buffered question forward so the
+			// bundler can render it as "[Recent channel context]".
+			expect(flushed[flushed.length - 1]).toEqual(["1", "2"]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not re-bundle chatter once the bot has responded", () => {
+		vi.useFakeTimers();
+		try {
+			const { flushed, debouncer } = setup({
+				shouldRespondOnlyToMentions: true,
+				bufferTtlMs: 10_000,
+			});
+
+			debouncer.enqueue(mockMessage("1", "some channel chatter"));
+			vi.advanceTimersByTime(3000);
+			debouncer.markResponded("channel-1");
+
+			debouncer.enqueue(mockMessage("2", "<@123> ^^"));
+			expect(flushed[flushed.length - 1]).toEqual(["2"]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("prunes buffered chatter older than bufferTtlMs", () => {
+		vi.useFakeTimers();
+		try {
+			const { flushed, debouncer } = setup({
+				shouldRespondOnlyToMentions: true,
+				bufferTtlMs: 5000,
+			});
+
+			debouncer.enqueue(mockMessage("1", "stale question"));
+			vi.advanceTimersByTime(3000);
+			vi.advanceTimersByTime(3000); // total 6s elapsed > 5s ttl
+
+			debouncer.enqueue(mockMessage("2", "<@123> ^^"));
+			expect(flushed[flushed.length - 1]).toEqual(["2"]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not buffer when message coalescing is enabled", () => {
+		vi.useFakeTimers();
+		try {
+			const { flushed, debouncer } = setup({
+				shouldRespondOnlyToMentions: true,
+				coalesceEnabled: true,
+				bufferTtlMs: 10_000,
+			});
+
+			debouncer.enqueue(mockMessage("1", "coalesce handles its own window"));
+			vi.advanceTimersByTime(3000);
+			debouncer.enqueue(mockMessage("2", "<@123> ^^"));
+			vi.advanceTimersByTime(3000);
+
+			expect(flushed).toEqual([["1"], ["2"]]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not buffer in respond-to-all mode", () => {
+		vi.useFakeTimers();
+		try {
+			const { flushed, debouncer } = setup({
+				shouldRespondOnlyToMentions: false,
+				bufferTtlMs: 10_000,
+			});
+
+			debouncer.enqueue(mockMessage("1", "open channel chatter"));
+			vi.advanceTimersByTime(3000);
+			debouncer.enqueue(mockMessage("2", "<@123> ^^"));
+
+			expect(flushed[flushed.length - 1]).toEqual(["2"]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/plugins/plugin-discord/__tests__/debouncer-recent-context.test.ts
+++ b/plugins/plugin-discord/__tests__/debouncer-recent-context.test.ts
@@ -195,6 +195,39 @@ describe("Discord channel debouncer — recent unaddressed context buffer", () =
 		}
 	});
 
+	// Pin the pointer-classification boundary: a message that, after its mentions
+	// are stripped, has no letters/digits in any script is a pointer (fold the
+	// buffer); anything with a word stands on its own (do not fold). Guards the
+	// \p{L}\p{N} check against being narrowed to ASCII \w, which would silently
+	// break non-English text.
+	it.each([
+		{ kind: "caret pointer", content: "<@123> ^^", folds: true },
+		{ kind: "emoji pointer", content: "<@123> 👆", folds: true },
+		{ kind: "punctuation pointer", content: "<@123> ?", folds: true },
+		{ kind: "bare mention", content: "<@123>", folds: true },
+		{ kind: "english question", content: "<@123> what is up?", folds: false },
+		{ kind: "single word", content: "<@123> this", folds: false },
+		{ kind: "unicode word", content: "<@123> ¿qué tal?", folds: false },
+		{ kind: "digits", content: "<@123> 2+2", folds: false },
+	])("folds=$folds for a $kind", ({ content, folds }) => {
+		vi.useFakeTimers();
+		try {
+			const { flushed, debouncer } = setup({
+				shouldRespondOnlyToMentions: true,
+				bufferTtlMs: 10_000,
+			});
+
+			debouncer.enqueue(mockMessage("1", "prior unaddressed chatter"));
+			vi.advanceTimersByTime(3000);
+			vi.advanceTimersByTime(1000);
+			debouncer.enqueue(mockMessage("2", content));
+
+			expect(flushed[flushed.length - 1]).toEqual(folds ? ["1", "2"] : ["2"]);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("does not duplicate a message present in both the buffer and the pending batch", () => {
 		vi.useFakeTimers();
 		try {

--- a/plugins/plugin-discord/debouncer.ts
+++ b/plugins/plugin-discord/debouncer.ts
@@ -73,11 +73,13 @@ export function createChannelDebouncer(
 	const pending = new Map<string, ChannelPendingEntry>();
 	const lastResponseTime = new Map<string, number>();
 
-	// Carry recent unaddressed messages forward so a content-light addressed
+	// Carry recent unaddressed messages forward so a pointer-only addressed
 	// message (e.g. "@bot ^^" pointing at a question typed moments earlier in a
 	// separate debounce batch) still arrives with that question folded into
 	// "[Recent channel context]" — matching the within-batch case the bundler
-	// already handles. Recency/addressing-driven only; no content inspection.
+	// already handles. Buffering is recency/addressing-driven; the fold itself is
+	// gated to pointer messages (see isPointerMessage) so a self-contained
+	// question never has unrelated chatter prepended.
 	const bufferUnaddressed =
 		options.shouldRespondOnlyToMentions === true && !coalesceEnabled;
 	const bufferTtlMs = Math.max(options.bufferTtlMs ?? 10_000, debounceMs);
@@ -115,6 +117,23 @@ export function createChannelDebouncer(
 		return buffered ? buffered.map((entry) => entry.message) : [];
 	};
 
+	// An unaddressed message lives in BOTH the rolling buffer and (until it
+	// flushes) the pending debounce batch, so a targeted message that drains both
+	// can list the same message twice. Collapse by id, keeping first occurrence,
+	// so "[Recent channel context]" never repeats a line.
+	const dedupeById = (messages: DiscordMessage[]): DiscordMessage[] => {
+		const seen = new Set<string>();
+		const unique: DiscordMessage[] = [];
+		for (const message of messages) {
+			if (seen.has(message.id)) {
+				continue;
+			}
+			seen.add(message.id);
+			unique.push(message);
+		}
+		return unique;
+	};
+
 	const isBotTargeted = (message: DiscordMessage): boolean => {
 		const botId = options.getBotUserId?.() ?? options.botUserId;
 		return isDiscordUserAddressed({
@@ -123,6 +142,18 @@ export function createChannelDebouncer(
 			hasMessageReference: Boolean(message.reference?.messageId),
 			repliedUserId: message.mentions?.repliedUser?.id,
 		});
+	};
+
+	// A "pointer" is an addressed message that, once its mentions are removed,
+	// has no word characters in any script — e.g. "@bot ^^", "@bot 👆", "@bot ?".
+	// It carries no content of its own and only points at recent messages, so we
+	// fold the recent-unaddressed buffer in to give the model that context.
+	// A message that contains any word (a real question or instruction) stands on
+	// its own and must route on its own text — folding unrelated recent chatter
+	// into it can derail that routing — so we do NOT fold for those.
+	const isPointerMessage = (message: DiscordMessage): boolean => {
+		const withoutMentions = (message.content ?? "").replace(/<@!?\d+>/g, "");
+		return !/[\p{L}\p{N}]/u.test(withoutMentions);
 	};
 
 	const isInCooldown = (channelId: string): boolean => {
@@ -153,13 +184,16 @@ export function createChannelDebouncer(
 		const channelId = message.channel.id;
 		const targeted = isBotTargeted(message);
 		if (targeted && !coalesceEnabled) {
-			const buffered = bufferUnaddressed ? drainRecent(channelId) : [];
+			const buffered =
+				bufferUnaddressed && isPointerMessage(message)
+					? drainRecent(channelId)
+					: [];
 			const entry = pending.get(channelId);
 			if (entry) {
 				clearTimeout(entry.timer);
 				pending.delete(channelId);
 				entry.messages.push(message);
-				runSafely(() => onFlush([...buffered, ...entry.messages]));
+				runSafely(() => onFlush(dedupeById([...buffered, ...entry.messages])));
 			} else {
 				runSafely(() =>
 					onFlush(buffered.length > 0 ? [...buffered, message] : [message]),
@@ -168,7 +202,13 @@ export function createChannelDebouncer(
 			return;
 		}
 
-		if (isInCooldown(channelId) && !targeted) {
+		// The response cooldown throttles further REPLIES after the bot answers.
+		// When we buffer unaddressed messages (strict / mention-only mode) those
+		// messages never trigger a reply anyway, so dropping them here would only
+		// discard context the next "@bot ^^" pointer needs. Keep ingesting +
+		// buffering them; the cooldown still gates unaddressed traffic in
+		// respond-to-all mode (bufferUnaddressed is false there).
+		if (isInCooldown(channelId) && !targeted && !bufferUnaddressed) {
 			return;
 		}
 

--- a/plugins/plugin-discord/debouncer.ts
+++ b/plugins/plugin-discord/debouncer.ts
@@ -33,6 +33,20 @@ export interface ChannelDebouncerOptions {
 	getBotUserId?: () => string | undefined;
 	coalesceEnabled?: boolean;
 	maxBatch?: number;
+	/**
+	 * Only when true (strict / mention-only mode) do we carry recent unaddressed
+	 * messages forward into the next addressed batch. In respond-to-all mode the
+	 * agent already answers those messages on their own flush, so buffering them
+	 * would prepend already-handled chatter onto a later addressed turn.
+	 */
+	shouldRespondOnlyToMentions?: boolean;
+	/**
+	 * How long a recent unaddressed message stays eligible to be folded into a
+	 * following addressed message's "[Recent channel context]". Must be >= the
+	 * channel debounce window so a just-flushed unaddressed message is still live
+	 * when the addressed anchor lands a beat later.
+	 */
+	bufferTtlMs?: number;
 }
 
 export interface ChannelDebouncer {
@@ -58,6 +72,48 @@ export function createChannelDebouncer(
 	const maxBatch = Math.max(1, options.maxBatch ?? Number.POSITIVE_INFINITY);
 	const pending = new Map<string, ChannelPendingEntry>();
 	const lastResponseTime = new Map<string, number>();
+
+	// Carry recent unaddressed messages forward so a content-light addressed
+	// message (e.g. "@bot ^^" pointing at a question typed moments earlier in a
+	// separate debounce batch) still arrives with that question folded into
+	// "[Recent channel context]" — matching the within-batch case the bundler
+	// already handles. Recency/addressing-driven only; no content inspection.
+	const bufferUnaddressed =
+		options.shouldRespondOnlyToMentions === true && !coalesceEnabled;
+	const bufferTtlMs = Math.max(options.bufferTtlMs ?? 10_000, debounceMs);
+	const recentUnaddressed = new Map<
+		string,
+		{ message: DiscordMessage; at: number }[]
+	>();
+
+	const pruneRecent = (channelId: string, now: number): void => {
+		const buffered = recentUnaddressed.get(channelId);
+		if (!buffered) {
+			return;
+		}
+		const live = buffered.filter((entry) => now - entry.at < bufferTtlMs);
+		if (live.length > 0) {
+			recentUnaddressed.set(channelId, live);
+		} else {
+			recentUnaddressed.delete(channelId);
+		}
+	};
+
+	const rememberRecent = (message: DiscordMessage): void => {
+		const channelId = message.channel.id;
+		const now = Date.now();
+		const buffered = recentUnaddressed.get(channelId) ?? [];
+		buffered.push({ message, at: now });
+		recentUnaddressed.set(channelId, buffered);
+		pruneRecent(channelId, now);
+	};
+
+	const drainRecent = (channelId: string): DiscordMessage[] => {
+		pruneRecent(channelId, Date.now());
+		const buffered = recentUnaddressed.get(channelId);
+		recentUnaddressed.delete(channelId);
+		return buffered ? buffered.map((entry) => entry.message) : [];
+	};
 
 	const isBotTargeted = (message: DiscordMessage): boolean => {
 		const botId = options.getBotUserId?.() ?? options.botUserId;
@@ -97,20 +153,27 @@ export function createChannelDebouncer(
 		const channelId = message.channel.id;
 		const targeted = isBotTargeted(message);
 		if (targeted && !coalesceEnabled) {
+			const buffered = bufferUnaddressed ? drainRecent(channelId) : [];
 			const entry = pending.get(channelId);
 			if (entry) {
 				clearTimeout(entry.timer);
 				pending.delete(channelId);
 				entry.messages.push(message);
-				runSafely(() => onFlush(entry.messages));
+				runSafely(() => onFlush([...buffered, ...entry.messages]));
 			} else {
-				runSafely(() => onFlush([message]));
+				runSafely(() =>
+					onFlush(buffered.length > 0 ? [...buffered, message] : [message]),
+				);
 			}
 			return;
 		}
 
 		if (isInCooldown(channelId) && !targeted) {
 			return;
+		}
+
+		if (bufferUnaddressed && !targeted) {
+			rememberRecent(message);
 		}
 
 		if (debounceMs <= 0) {
@@ -140,6 +203,9 @@ export function createChannelDebouncer(
 		enqueue,
 		markResponded: (channelId: string) => {
 			lastResponseTime.set(channelId, Date.now());
+			// Buffered chatter has now been answered (or folded into the reply);
+			// drop it so it never re-bundles into a later unrelated response.
+			recentUnaddressed.delete(channelId);
 		},
 		flushAll: () => {
 			for (const key of [...pending.keys()]) {
@@ -153,6 +219,7 @@ export function createChannelDebouncer(
 			}
 			pending.clear();
 			lastResponseTime.clear();
+			recentUnaddressed.clear();
 		},
 	};
 }

--- a/plugins/plugin-discord/discord-events.ts
+++ b/plugins/plugin-discord/discord-events.ts
@@ -106,6 +106,7 @@ interface EventListenerConfig {
 	debounceMs: number;
 	channelDebounceMs: number;
 	responseCooldownMs: number;
+	shouldRespondOnlyToMentions: boolean;
 }
 
 function parseEventListenerConfig(
@@ -161,7 +162,21 @@ function parseEventListenerConfig(
 				? Number.parseInt(responseCooldownMsSetting, 10) || 30000
 				: 30000;
 
-	return { listenCids, debounceMs, channelDebounceMs, responseCooldownMs };
+	const respondOnlyToMentionsSetting = service.runtime.getSetting(
+		"DISCORD_SHOULD_RESPOND_ONLY_TO_MENTIONS",
+	);
+	const shouldRespondOnlyToMentions = !(
+		respondOnlyToMentionsSetting === false ||
+		respondOnlyToMentionsSetting === "false"
+	);
+
+	return {
+		listenCids,
+		debounceMs,
+		channelDebounceMs,
+		responseCooldownMs,
+		shouldRespondOnlyToMentions,
+	};
 }
 
 /**
@@ -175,8 +190,13 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 	channelDebouncer: ChannelDebouncer;
 } {
 	const accountId = service.accountId ?? "default";
-	const { listenCids, debounceMs, channelDebounceMs, responseCooldownMs } =
-		parseEventListenerConfig(service);
+	const {
+		listenCids,
+		debounceMs,
+		channelDebounceMs,
+		responseCooldownMs,
+		shouldRespondOnlyToMentions,
+	} = parseEventListenerConfig(service);
 	const messageCoalesce = getDiscordMessageCoalesceConfig((key) =>
 		service.runtime.getSetting(key),
 	);
@@ -257,6 +277,7 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 				);
 			}
 
+			const botAddressed = anchor !== undefined;
 			anchor ??= messages[messages.length - 1];
 			if (messageCoalesce.enabled) {
 				const combined = makeCoalescedDiscordMessage(
@@ -303,7 +324,14 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 				void service.messageManager.handleMessage(combined as Message);
 			}
 
-			channelDebouncer?.markResponded(messages[0].channel.id);
+			// Arm the response cooldown only when the bot actually engages with
+			// this batch. A purely-unaddressed batch (channel chatter the bot is
+			// not replying to) must not start the cooldown — otherwise the next
+			// unaddressed message is dropped (debouncer cooldown gate), losing
+			// context like a question typed just before an "@bot ^^" pointer.
+			if (botAddressed || !shouldRespondOnlyToMentions) {
+				channelDebouncer?.markResponded(messages[0].channel.id);
+			}
 		},
 		{
 			debounceMs: effectiveChannelDebounceMs,
@@ -311,6 +339,7 @@ export function setupDiscordEventListeners(service: DiscordServiceInternals): {
 			getBotUserId: () => service.client?.user?.id,
 			coalesceEnabled: messageCoalesce.enabled,
 			maxBatch: messageCoalesce.maxBatch,
+			shouldRespondOnlyToMentions,
 		},
 	);
 


### PR DESCRIPTION
## Summary

In strict / mention-only mode, a user could post a substantive question with **no** `@-mention`, then point the bot at it a few seconds later with a bare `@bot ^^`. Instead of answering, the bot replied with a generic greeting ("Hey there! How can I help you today?"). Re-sending the full question *with* the mention answered correctly. This carries recent unaddressed messages forward so the addressed pointer arrives with the question already folded into `[Recent channel context]`, matching the behavior users already get when both messages share one debounce window.

## Root cause

The Discord `channelDebouncer` bundles rapid messages into a `[Recent channel context]` block prepended to the addressed anchor, but only *within a single debounce batch* (default `DISCORD_CHANNEL_DEBOUNCE_MS=3000`). When the question and the `^^` pointer land more than ~3s apart they fall into separate batches:

- the question flushes record-only into memory (a `prior_message`) and
- the `^^` flushes alone with an empty `[Recent channel context]`.

The model then treats the content-light `^^` as the current message and emits a generic greeting rather than answering the question. A second, compounding issue: a purely-unaddressed batch was arming the 30s response cooldown, which could drop the next unaddressed message before it was even recorded.

## Fix

Two source files, structural only — driven by recency and addressing, with **no** content / intent / regex classification:

- **`debouncer.ts`** — a recency-based per-channel rolling buffer (`recentUnaddressed`, `bufferTtlMs` default 10s and clamped to `>= debounceMs`) of recent unaddressed messages. The next addressed batch drains this buffer and prepends it, so the existing bundler folds it into `[Recent channel context]`. Gated to strict / mention-only mode (`shouldRespondOnlyToMentions`), skipped when message coalescing is enabled, and cleared on `markResponded` and `destroy` so handled chatter never re-bundles into a later unrelated reply.
- **`discord-events.ts`** — arm the response cooldown (`markResponded`) only when the bot actually engages (`botAddressed || !shouldRespondOnlyToMentions`), so a purely-unaddressed batch does not start the 30s cooldown that would otherwise drop the next unaddressed message before it is recorded. Also threads `shouldRespondOnlyToMentions` through to the debouncer options.

Scope and cost:
- **Strict-mode-scoped** — respond-to-all, DM, and coalesce paths are unchanged.
- **No added model / planner cost** — unaddressed messages still hit the persist-only return before the planner; this only changes what context an *already-addressed* turn carries.
- Respects the core runtime `RoomHandlerQueue` "Wave 0" no-coalesce contract — all merging stays plugin-side.

## Testing

- Live bot, owner's exact timing:
  - same-batch (2.5s gap): answered 5/5 (baseline, unchanged)
  - separate-batch (6s gap): **0/4 pre-fix → 4/4 post-fix**
  - attachment-seeded variant: **3/3 greeting → 3/3 answered**
- `plugin-discord` suite: 63/63 green, including 5 new debouncer tests covering fold-forward, no re-bundle after `markResponded`, TTL pruning, coalesce-disabled, and respond-to-all (no buffering).
- typecheck + lint clean.
