### PR TITLE
chore(plugin-app-control): biome-format ViewManagerView.tsx

### DIFF
--- a/plugins/plugin-app-control/src/views/ViewManagerView.tsx
+++ b/plugins/plugin-app-control/src/views/ViewManagerView.tsx
@@ -326,7 +326,9 @@ function TuiStatusBadge({ view }: { view: ViewEntry }) {
 	return (
 		<span
 			style={{
-				color: view.available ? viewManagerTheme.accent : viewManagerTheme.danger,
+				color: view.available
+					? viewManagerTheme.accent
+					: viewManagerTheme.danger,
 				minWidth: 10,
 				display: "inline-block",
 			}}
@@ -398,14 +400,19 @@ function TuiViewRow({
 				gap: 12,
 				alignItems: "center",
 				padding: "8px 0",
-				borderTop: index === 0 ? "none" : `1px solid ${viewManagerTheme.borderAccent}`,
+				borderTop:
+					index === 0 ? "none" : `1px solid ${viewManagerTheme.borderAccent}`,
 			}}
 		>
 			<span style={{ color: viewManagerTheme.muted }}>
 				{String(index + 1).padStart(2, "0")}
 			</span>
-			<span style={{ color: viewManagerTheme.foreground, fontWeight: 700 }}>{view.label}</span>
-			<span style={{ color: viewManagerTheme.success }}>{view.viewType ?? "gui"}</span>
+			<span style={{ color: viewManagerTheme.foreground, fontWeight: 700 }}>
+				{view.label}
+			</span>
+			<span style={{ color: viewManagerTheme.success }}>
+				{view.viewType ?? "gui"}
+			</span>
 			<span
 				style={{
 					color: viewManagerTheme.muted,
@@ -416,7 +423,13 @@ function TuiViewRow({
 				{view.id}
 			</span>
 			<TuiStatusBadge view={view} />
-			<div style={{ gridColumn: "2 / 5", color: viewManagerTheme.muted, fontSize: 12 }}>
+			<div
+				style={{
+					gridColumn: "2 / 5",
+					color: viewManagerTheme.muted,
+					fontSize: 12,
+				}}
+			>
 				{view.description ?? view.pluginName}
 			</div>
 			<button
@@ -518,7 +531,9 @@ export function ViewManagerTuiView() {
 						marginBottom: 10,
 					}}
 				>
-					<strong style={{ color: viewManagerTheme.foreground }}>registered tui views</strong>
+					<strong style={{ color: viewManagerTheme.foreground }}>
+						registered tui views
+					</strong>
 					<TuiRefreshButton
 						loading={loading}
 						onClick={() => void fetchViews()}
@@ -527,7 +542,9 @@ export function ViewManagerTuiView() {
 
 				{error && <div style={{ color: viewManagerTheme.danger }}>{error}</div>}
 				{!error && views.length === 0 && !loading && (
-					<div style={{ color: viewManagerTheme.muted }}>no tui views registered</div>
+					<div style={{ color: viewManagerTheme.muted }}>
+						no tui views registered
+					</div>
 				)}
 				{views.map((view, index) => (
 					<TuiViewRow


### PR DESCRIPTION
`plugins/plugin-app-control/src/views/ViewManagerView.tsx` is currently not biome-formatted on `develop`, which fails the **Format Check (biome)** gate on develop and bleeds into every open PR's `pull_request` merge check.

This applies `biome check --write` to that one file — pure formatting (line wraps), no behavior change. Restores the Format Check gate to green.

```
bunx @biomejs/biome check plugins/plugin-app-control/src/views/ViewManagerView.tsx  # clean after this
```