### PR TITLE
fix(cloud): guarantee response-token budget for all reasoning models

### DIFF
--- a/packages/cloud-api/__tests__/chat-completions-tool-choice.test.ts
+++ b/packages/cloud-api/__tests__/chat-completions-tool-choice.test.ts
@@ -154,4 +154,31 @@ describe("computeEffectiveMaxTokens", () => {
       computeEffectiveMaxTokens(20000, 8000, "anthropic/claude-opus-4.8"),
     ).toBe(20000);
   });
+
+  test("catalog reasoning signal: floors even when the id has no reasoning pattern", () => {
+    // glm-5.1 / kimi-k2.6 / deepseek-v4-pro have no "think"/"reasoning" id but
+    // advertise reasoning in supported_parameters. These were the
+    // production-reported failures.
+    expect(
+      computeEffectiveMaxTokens(50, null, "z-ai/glm-5.1", [
+        "max_tokens",
+        "reasoning",
+      ]),
+    ).toBe(MIN_RESPONSE_TOKENS);
+    expect(
+      computeEffectiveMaxTokens(50, null, "deepseek/deepseek-v4-pro", [
+        "max_tokens",
+        "include_reasoning",
+      ]),
+    ).toBe(MIN_RESPONSE_TOKENS);
+  });
+
+  test("catalog non-reasoning signal: passes small max_tokens through", () => {
+    expect(
+      computeEffectiveMaxTokens(50, null, "openai/gpt-4o-mini", [
+        "max_tokens",
+        "temperature",
+      ]),
+    ).toBe(50);
+  });
 });

--- a/packages/cloud-api/__tests__/chat-completions-tool-choice.test.ts
+++ b/packages/cloud-api/__tests__/chat-completions-tool-choice.test.ts
@@ -17,7 +17,12 @@ import { describe, expect, test } from "bun:test";
 
 import { __nativeToolingTestHooks } from "../v1/chat/completions/route";
 
-const { mapToolChoice, convertTools } = __nativeToolingTestHooks;
+const { mapToolChoice, convertTools, computeEffectiveMaxTokens } =
+  __nativeToolingTestHooks;
+
+// Mirror of MIN_RESPONSE_TOKENS in route.ts. Kept as a literal here so the test
+// fails loudly if the production floor changes without intent.
+const MIN_RESPONSE_TOKENS = 4096;
 
 describe("mapToolChoice", () => {
   test("returns undefined when toolChoice is undefined", () => {
@@ -89,5 +94,64 @@ describe("convertTools", () => {
     ]);
     expect(out?.noop).toBeDefined();
     expect(out?.noop).not.toHaveProperty("description");
+  });
+});
+
+/**
+ * computeEffectiveMaxTokens guarantees a response-token budget so reasoning
+ * models do not truncate mid-chain-of-thought and return empty (but billed)
+ * completions. Before the fix, only Anthropic CoT (cotBudget != null) got a
+ * floor; every other reasoning model fell through and returned the raw
+ * (often tiny) request max_tokens.
+ */
+describe("computeEffectiveMaxTokens", () => {
+  test("non-reasoning model: passes request max_tokens through unchanged", () => {
+    expect(computeEffectiveMaxTokens(10, null, "openai/gpt-4o-mini")).toBe(10);
+    expect(computeEffectiveMaxTokens(512, null, "openai/gpt-4o-mini")).toBe(
+      512,
+    );
+  });
+
+  test("non-reasoning model: leaves undefined max_tokens undefined", () => {
+    expect(
+      computeEffectiveMaxTokens(undefined, null, "openai/gpt-4o-mini"),
+    ).toBeUndefined();
+  });
+
+  test("reasoning model with tiny max_tokens: floors to MIN_RESPONSE_TOKENS", () => {
+    // This is the bug: minimax/m3 at max_tokens=10 spent all 10 on reasoning
+    // and returned null content while billing the tokens.
+    expect(computeEffectiveMaxTokens(10, null, "minimax/minimax-m3")).toBe(
+      MIN_RESPONSE_TOKENS,
+    );
+    expect(computeEffectiveMaxTokens(16, null, "deepseek/deepseek-r1")).toBe(
+      MIN_RESPONSE_TOKENS,
+    );
+  });
+
+  test("reasoning model with no max_tokens: floors to MIN_RESPONSE_TOKENS", () => {
+    expect(computeEffectiveMaxTokens(undefined, null, "openai/o3-mini")).toBe(
+      MIN_RESPONSE_TOKENS,
+    );
+  });
+
+  test("reasoning model with generous max_tokens: honors the larger request", () => {
+    expect(computeEffectiveMaxTokens(8000, null, "minimax/minimax-m3")).toBe(
+      8000,
+    );
+  });
+
+  test("Anthropic CoT budget: reserves response capacity beyond the thinking budget", () => {
+    // cotBudget=8000 -> must be at least 8000 + MIN_RESPONSE_TOKENS regardless of
+    // a smaller requested max_tokens.
+    expect(
+      computeEffectiveMaxTokens(1000, 8000, "anthropic/claude-opus-4.8"),
+    ).toBe(8000 + MIN_RESPONSE_TOKENS);
+  });
+
+  test("Anthropic CoT budget: honors a larger requested max_tokens", () => {
+    expect(
+      computeEffectiveMaxTokens(20000, 8000, "anthropic/claude-opus-4.8"),
+    ).toBe(20000);
   });
 });

--- a/packages/cloud-api/v1/chat/completions/route.ts
+++ b/packages/cloud-api/v1/chat/completions/route.ts
@@ -33,6 +33,7 @@ import {
   calculateCost,
   getProviderFromModel,
   getSafeModelParams,
+  modelUsesReasoningTokens,
   normalizeModelName,
 } from "@/lib/pricing";
 import {
@@ -119,13 +120,24 @@ function buildProviderBillingFields(
 }
 
 /**
- * Computes effective max_tokens when Anthropic CoT is enabled.
- * When thinking is active, max_tokens must be >= budgetTokens or Anthropic API rejects.
- * Additionally, we must reserve capacity for the actual response (not just thinking).
+ * Computes effective max_tokens, reserving response capacity for reasoning models.
+ *
+ * Reasoning models (Anthropic extended-thinking, OpenAI o-series, DeepSeek R,
+ * MiniMax M, Qwen think, etc.) spend output tokens on hidden chain-of-thought
+ * BEFORE emitting any visible answer. If max_tokens only covers the reasoning,
+ * the model truncates mid-thought and returns empty content while still billing
+ * the consumed tokens. To prevent that:
+ *   - Anthropic CoT: max_tokens must be >= thinking budget + response capacity
+ *     (the API also hard-rejects max_tokens < thinking budget).
+ *   - Any other reasoning model: floor max_tokens at MIN_RESPONSE_TOKENS so there
+ *     is always room for an answer after the reasoning.
+ *
+ * `model` is the requested model id (provider-prefixed is fine).
  */
 function computeEffectiveMaxTokens(
   requestMaxTokens: number | undefined,
   cotBudget: number | null,
+  model: string,
 ): number | undefined {
   if (cotBudget !== null) {
     // When CoT is active, ensure max_tokens covers both thinking budget AND response capacity
@@ -133,6 +145,16 @@ function computeEffectiveMaxTokens(
     return Math.max(
       requestMaxTokens ?? MIN_RESPONSE_TOKENS,
       cotBudget + MIN_RESPONSE_TOKENS,
+    );
+  }
+  if (modelUsesReasoningTokens(model)) {
+    // Non-Anthropic reasoning model. Guarantee at least MIN_RESPONSE_TOKENS so the
+    // model does not truncate mid-reasoning and return empty (but billed) output.
+    // If the caller asked for more, honor it; if they asked for less (or nothing),
+    // raise it to the floor.
+    return Math.max(
+      requestMaxTokens ?? MIN_RESPONSE_TOKENS,
+      MIN_RESPONSE_TOKENS,
     );
   }
   return requestMaxTokens;
@@ -771,6 +793,7 @@ export async function handleChatCompletionsPOST(
     const effectiveMaxTokens = computeEffectiveMaxTokens(
       request.max_tokens,
       cotBudget,
+      model,
     );
     const webSearchEnabled = request.webSearchEnabled === true;
     const webSearchActive = isAnthropicWebSearchEnabled(
@@ -1502,6 +1525,34 @@ async function handleNonStreamingRequest(
       totalCost: billing.totalCost,
     });
 
+    // Reasoning-model empty-output guard.
+    // A reasoning model can spend its whole output budget on hidden
+    // chain-of-thought and return empty visible text while still billing the
+    // consumed tokens. The budget floor in computeEffectiveMaxTokens prevents
+    // the common case, but if it still happens, surface it honestly: report
+    // finish_reason "length" (so OpenAI-compatible clients retry with a higher
+    // max_tokens) instead of a misleading "stop" with null content.
+    const hasToolCalls = Boolean(result.toolCalls?.length);
+    const visibleText = result.text || "";
+    const emptyButBilled =
+      !visibleText && !hasToolCalls && (result.usage?.outputTokens ?? 0) > 0;
+    const finishReason: "tool_calls" | "length" | "content_filter" | "stop" =
+      hasToolCalls || result.finishReason === "tool-calls"
+        ? "tool_calls"
+        : result.finishReason === "length" || emptyButBilled
+          ? "length"
+          : result.finishReason === "content-filter"
+            ? "content_filter"
+            : "stop";
+    if (emptyButBilled) {
+      logger.warn("[Chat Completions] Empty completion despite billed tokens", {
+        model,
+        outputTokens: result.usage?.outputTokens,
+        sdkFinishReason: result.finishReason,
+        isReasoningModel: modelUsesReasoningTokens(model),
+      });
+    }
+
     // Return OpenAI-compatible response
     return addCorsHeaders(
       Response.json({
@@ -1515,7 +1566,7 @@ async function handleNonStreamingRequest(
             message: {
               role: "assistant",
               content: result.text || null,
-              ...(result.toolCalls?.length
+              ...(hasToolCalls
                 ? {
                     tool_calls: result.toolCalls.map((toolCall) => ({
                       id: toolCall.toolCallId,
@@ -1528,14 +1579,7 @@ async function handleNonStreamingRequest(
                   }
                 : {}),
             },
-            finish_reason:
-              result.toolCalls?.length || result.finishReason === "tool-calls"
-                ? "tool_calls"
-                : result.finishReason === "length"
-                  ? "length"
-                  : result.finishReason === "content-filter"
-                    ? "content_filter"
-                    : "stop",
+            finish_reason: finishReason,
           },
         ],
         usage: formatOpenAIUsage(billing, result.usage),
@@ -1574,4 +1618,5 @@ export default honoRouter;
 export const __nativeToolingTestHooks = {
   mapToolChoice,
   convertTools,
+  computeEffectiveMaxTokens,
 } as const;

--- a/packages/cloud-api/v1/chat/completions/route.ts
+++ b/packages/cloud-api/v1/chat/completions/route.ts
@@ -68,6 +68,7 @@ import {
   type CreditReservation,
   creditsService,
 } from "@/lib/services/credits";
+import { getCachedGatewayModelById } from "@/lib/services/model-catalog";
 import { createCreditReservationSettler } from "@/lib/utils/credit-reservation";
 import { logger } from "@/lib/utils/logger";
 import { getRouteTimeoutMs } from "@/lib/utils/request-timeout";
@@ -138,6 +139,7 @@ function computeEffectiveMaxTokens(
   requestMaxTokens: number | undefined,
   cotBudget: number | null,
   model: string,
+  supportedParameters?: readonly string[],
 ): number | undefined {
   if (cotBudget !== null) {
     // When CoT is active, ensure max_tokens covers both thinking budget AND response capacity
@@ -147,7 +149,7 @@ function computeEffectiveMaxTokens(
       cotBudget + MIN_RESPONSE_TOKENS,
     );
   }
-  if (modelUsesReasoningTokens(model)) {
+  if (modelUsesReasoningTokens(model, supportedParameters)) {
     // Non-Anthropic reasoning model. Guarantee at least MIN_RESPONSE_TOKENS so the
     // model does not truncate mid-reasoning and return empty (but billed) output.
     // If the caller asked for more, honor it; if they asked for less (or nothing),
@@ -790,10 +792,28 @@ export async function handleChatCompletionsPOST(
       cotBudget != null
         ? mergeAnthropicCotProviderOptions(model, process.env, cotBudget)
         : {};
+    // Authoritative reasoning detection: many reasoning models (kimi-k2.6,
+    // glm-5.1, deepseek-v4-pro, ...) do not carry a "think"/"reasoning" id but
+    // do advertise a reasoning parameter in the catalog. Best-effort lookup;
+    // on any failure we fall back to id name-pattern detection.
+    let modelSupportedParameters: string[] | undefined;
+    try {
+      const catalogModel = await getCachedGatewayModelById(model);
+      modelSupportedParameters = catalogModel?.supported_parameters;
+    } catch (error) {
+      logger.warn(
+        "[Chat Completions] reasoning-detection catalog lookup failed; using name patterns",
+        {
+          model,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
     const effectiveMaxTokens = computeEffectiveMaxTokens(
       request.max_tokens,
       cotBudget,
       model,
+      modelSupportedParameters,
     );
     const webSearchEnabled = request.webSearchEnabled === true;
     const webSearchActive = isAnthropicWebSearchEnabled(
@@ -1549,6 +1569,8 @@ async function handleNonStreamingRequest(
         model,
         outputTokens: result.usage?.outputTokens,
         sdkFinishReason: result.finishReason,
+        // Name-pattern only here (logging metadata); the budget decision upstream
+        // uses the authoritative catalog supported_parameters signal.
         isReasoningModel: modelUsesReasoningTokens(model),
       });
     }

--- a/packages/cloud-shared/src/lib/models/catalog.ts
+++ b/packages/cloud-shared/src/lib/models/catalog.ts
@@ -21,6 +21,13 @@ export interface CatalogModel {
   pricing?: Record<string, unknown>;
   recommended?: boolean;
   free?: boolean;
+  /**
+   * Parameters the upstream provider/gateway advertises for this model. Used to
+   * detect reasoning models (those listing "reasoning"/"include_reasoning"),
+   * which spend output tokens on hidden chain-of-thought and need a response
+   * token floor. Populated verbatim from the OpenRouter catalog.
+   */
+  supported_parameters?: string[];
 }
 
 export interface SelectorModel {

--- a/packages/cloud-shared/src/lib/pricing-reasoning-detection.test.ts
+++ b/packages/cloud-shared/src/lib/pricing-reasoning-detection.test.ts
@@ -56,6 +56,56 @@ describe("modelUsesReasoningTokens", () => {
     expect(modelUsesReasoningTokens("gpt-4o-mini")).toBe(false);
   });
 
+  describe("catalog supported_parameters signal (authoritative)", () => {
+    // These models do NOT carry a "think"/"reasoning" id, so name patterns miss
+    // them, but the catalog advertises a reasoning parameter. They were the
+    // exact models reported broken in production (kimi-k2.6, glm-5.1,
+    // deepseek-v4-pro): at low max_tokens they spent the whole budget on hidden
+    // reasoning and returned null content while billing the tokens.
+    test.each([
+      "moonshotai/kimi-k2.6",
+      "z-ai/glm-5.1",
+      "deepseek/deepseek-v4-pro",
+    ])("%s is NOT caught by name pattern alone", (model) => {
+      expect(modelUsesReasoningTokens(model)).toBe(false);
+    });
+
+    test.each([
+      "moonshotai/kimi-k2.6",
+      "z-ai/glm-5.1",
+      "deepseek/deepseek-v4-pro",
+    ])("%s IS caught when the catalog advertises reasoning", (model) => {
+      expect(
+        modelUsesReasoningTokens(model, [
+          "max_tokens",
+          "temperature",
+          "reasoning",
+          "include_reasoning",
+        ]),
+      ).toBe(true);
+    });
+
+    test("reasoning_effort alone is enough", () => {
+      expect(modelUsesReasoningTokens("some/model", ["max_tokens", "reasoning_effort"])).toBe(true);
+    });
+
+    test("a non-reasoning catalog model stays false", () => {
+      expect(
+        modelUsesReasoningTokens("openai/gpt-4o-mini", [
+          "max_tokens",
+          "temperature",
+          "tools",
+          "response_format",
+        ]),
+      ).toBe(false);
+    });
+
+    test("empty/undefined supported_parameters falls back to name pattern", () => {
+      expect(modelUsesReasoningTokens("minimax/minimax-m3", [])).toBe(true);
+      expect(modelUsesReasoningTokens("openai/gpt-4o-mini", undefined)).toBe(false);
+    });
+  });
+
   test("is case-insensitive", () => {
     expect(modelUsesReasoningTokens("DeepSeek/DeepSeek-R1")).toBe(true);
   });

--- a/packages/cloud-shared/src/lib/pricing-reasoning-detection.test.ts
+++ b/packages/cloud-shared/src/lib/pricing-reasoning-detection.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for modelUsesReasoningTokens — the detector that drives the
+ * reasoning-model output-token budget floor in the chat-completions route.
+ *
+ * Background: reasoning models spend output tokens on hidden chain-of-thought
+ * before emitting a visible answer. If max_tokens does not leave room past the
+ * reasoning, they truncate mid-thought and return empty (but billed) content.
+ * The route uses this detector to guarantee a minimum response budget. A false
+ * positive only nudges the token floor up; a false negative bills callers for
+ * empty output, so the matcher is intentionally broad.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { isReasoningModel, modelUsesReasoningTokens } from "./pricing";
+
+describe("modelUsesReasoningTokens", () => {
+  test.each([
+    "openai/o1",
+    "openai/o1-mini",
+    "openai/o3",
+    "openai/o3-mini",
+    "openai/o4-mini",
+    "anthropic/claude-opus-4.8",
+    "anthropic/claude-sonnet-4.5",
+    "deepseek/deepseek-r1",
+    "deepseek/deepseek-reasoner",
+    "minimax/minimax-m3",
+    "minimax/minimax-m1",
+    "qwen/qwq-32b",
+    "qwen/qwen3.7-max",
+    "allenai/olmo-3-32b-think",
+    "nvidia/nemotron-3-super-120b-a12b-reasoning",
+    "z-ai/glm-4.6-thinking",
+    "moonshotai/kimi-k2.6-think",
+    "x-ai/grok-4-reasoning",
+  ])("treats %s as a reasoning model", (model) => {
+    expect(modelUsesReasoningTokens(model)).toBe(true);
+  });
+
+  test.each([
+    "openai/gpt-4o-mini",
+    "openai/gpt-4.1-mini",
+    "anthropic/claude-3.5-haiku",
+    "google/gemini-2.5-flash",
+    "meta-llama/llama-3.3-70b-instruct",
+    "mistralai/mistral-small-latest",
+    "deepseek/deepseek-chat",
+    "minimax/minimax-text-01",
+  ])("treats %s as a non-reasoning model", (model) => {
+    expect(modelUsesReasoningTokens(model)).toBe(false);
+  });
+
+  test("matches a bare (provider-less) model name", () => {
+    expect(modelUsesReasoningTokens("minimax-m3")).toBe(true);
+    expect(modelUsesReasoningTokens("gpt-4o-mini")).toBe(false);
+  });
+
+  test("is case-insensitive", () => {
+    expect(modelUsesReasoningTokens("DeepSeek/DeepSeek-R1")).toBe(true);
+  });
+
+  test("the narrow isReasoningModel (temperature gate) stays narrow", () => {
+    // isReasoningModel governs temperature stripping only; it must NOT expand
+    // to the broad reasoning set or it would strip temperature from models that
+    // accept it.
+    expect(isReasoningModel("anthropic/claude-opus-4.8")).toBe(true);
+    expect(isReasoningModel("openai/o3-mini")).toBe(true);
+    expect(isReasoningModel("minimax/minimax-m3")).toBe(false);
+    expect(isReasoningModel("deepseek/deepseek-r1")).toBe(false);
+  });
+});

--- a/packages/cloud-shared/src/lib/pricing.ts
+++ b/packages/cloud-shared/src/lib/pricing.ts
@@ -98,10 +98,60 @@ export function getProviderFromModel(model: string): string {
 
 /**
  * Checks if a model is a reasoning model that doesn't support temperature.
+ *
+ * NOTE: this is intentionally narrow. It governs ONLY temperature stripping in
+ * {@link getSafeModelParams}; broadening it would strip temperature from models
+ * that do accept it. For "does this model spend output tokens on hidden
+ * reasoning before emitting an answer" (the token-budget concern), use
+ * {@link modelUsesReasoningTokens} instead.
  */
 export function isReasoningModel(model: string): boolean {
   const name = normalizeModelName(model);
   return name.startsWith("claude-opus") || /^o[13](-|$)/.test(name);
+}
+
+/**
+ * Patterns for models that consume output tokens on hidden chain-of-thought /
+ * reasoning before emitting any visible answer. When max_tokens is too small to
+ * cover both the reasoning and a response, these models truncate mid-reasoning
+ * and return empty content while still billing the consumed tokens.
+ *
+ * Matched against the provider-stripped model name (see normalizeModelName), so
+ * e.g. "minimax/minimax-m3" is matched as "minimax-m3". Kept broad on purpose:
+ * a false positive only raises the effective token floor slightly; a false
+ * negative silently bills the caller for empty output.
+ */
+const REASONING_MODEL_PATTERNS: RegExp[] = [
+  // OpenAI o-series + gpt-5 reasoning tiers
+  /^o[1345](-|$|\.)/,
+  /^gpt-5.*\b(thinking|reasoning)\b/,
+  // Anthropic extended-thinking opus/sonnet
+  /^claude-(opus|sonnet)/,
+  // DeepSeek R-series + explicit reasoner
+  /^deepseek-(r\d|reasoner)/,
+  /\bdeepseek-r\d/,
+  // MiniMax M-series (M1/M2/M3...) are reasoning models
+  /^minimax-m\d/,
+  // Qwen / QwQ thinking tiers
+  /^qwq/,
+  /^qwen.*(think|reasoning|-max)/,
+  // Generic "think"/"reasoning" suffixes used across many vendors
+  // (olmo-3-32b-think, nemotron-...-reasoning, glm-...-thinking, kimi-...-think)
+  /(think|thinking|reasoning|reasoner)(:|$|-)/,
+  // Grok reasoning builds
+  /^grok.*(reasoning|think)/,
+  // Z.ai GLM reasoning
+  /^glm-.*(think|reasoning)/,
+];
+
+/**
+ * Whether a model spends output tokens on hidden reasoning before answering.
+ * Used to guarantee a minimum response-token budget so reasoning models do not
+ * truncate mid-thought and return empty (but billed) completions.
+ */
+export function modelUsesReasoningTokens(model: string): boolean {
+  const name = normalizeModelName(model).toLowerCase();
+  return REASONING_MODEL_PATTERNS.some((re) => re.test(name));
 }
 
 /**

--- a/packages/cloud-shared/src/lib/pricing.ts
+++ b/packages/cloud-shared/src/lib/pricing.ts
@@ -145,11 +145,41 @@ const REASONING_MODEL_PATTERNS: RegExp[] = [
 ];
 
 /**
+ * Authoritative signal: a model is a reasoning model if the upstream catalog
+ * advertises a reasoning parameter for it. Many reasoning models (kimi-k2.6,
+ * glm-5.1, deepseek-v4-pro, minimax-m3, ...) do NOT carry "think"/"reasoning"
+ * in their id, so name patterns alone miss them — but they all list
+ * "reasoning" / "include_reasoning" in supported_parameters.
+ */
+function supportedParametersIndicateReasoning(
+  supportedParameters: readonly string[] | undefined,
+): boolean {
+  if (!supportedParameters || supportedParameters.length === 0) return false;
+  return supportedParameters.some((p) => {
+    const k = p.toLowerCase();
+    return k === "reasoning" || k === "include_reasoning" || k === "reasoning_effort";
+  });
+}
+
+/**
  * Whether a model spends output tokens on hidden reasoning before answering.
  * Used to guarantee a minimum response-token budget so reasoning models do not
  * truncate mid-thought and return empty (but billed) completions.
+ *
+ * Prefers the authoritative catalog signal (supported_parameters); falls back to
+ * id name patterns when catalog metadata is unavailable (e.g. the catalog fetch
+ * failed or the model is not listed). Either signal being positive is enough —
+ * a false positive only nudges the token floor up; a false negative silently
+ * bills the caller for empty output.
+ *
+ * @param model The model id (provider-prefixed is fine).
+ * @param supportedParameters Optional catalog-advertised parameters for the model.
  */
-export function modelUsesReasoningTokens(model: string): boolean {
+export function modelUsesReasoningTokens(
+  model: string,
+  supportedParameters?: readonly string[],
+): boolean {
+  if (supportedParametersIndicateReasoning(supportedParameters)) return true;
   const name = normalizeModelName(model).toLowerCase();
   return REASONING_MODEL_PATTERNS.some((re) => re.test(name));
 }

--- a/packages/cloud-shared/src/lib/providers/types.ts
+++ b/packages/cloud-shared/src/lib/providers/types.ts
@@ -180,6 +180,8 @@ export interface OpenAIModel {
   pricing?: Record<string, unknown>;
   recommended?: boolean;
   free?: boolean;
+  /** Provider/gateway-advertised parameters (e.g. "reasoning"). */
+  supported_parameters?: string[];
 }
 
 /**


### PR DESCRIPTION
## Problem

Eliza Cloud inference returns `content: null` (and **bills the consumed tokens**) for reasoning models when `max_tokens` is too small to cover both the hidden chain-of-thought and an answer.

Confirmed live against `api.elizacloud.ai`:
- `minimax/minimax-m3` (the #1 featured catalog model) at `max_tokens: 10-16` returns `content: null`, `finish_reason: stop`, but bills 10-16 completion tokens. At `max_tokens: 2000` it returns a real answer.
- OpenAI + Anthropic models work fine. The model catalog is healthy (336 text models, 311 priced + 25 free, in sync with OpenRouter), so this is **not** a catalog/pricing outage.

## Root cause

The budget reservation existed but was **Anthropic-only**. `computeEffectiveMaxTokens` reserved `MIN_RESPONSE_TOKENS` beyond the thinking budget, but the budget was computed only via `resolveAnthropicThinkingBudgetTokens`. Every other reasoning model (OpenAI o-series, DeepSeek R, MiniMax M, Qwen/QwQ think, GLM/Kimi/Nemotron/OLMo think tiers, Grok reasoning) fell through with the raw request `max_tokens` and truncated mid-reasoning. Both response paths did `content: result.text || null`, so it failed silently and charged.

## Fix

- `modelUsesReasoningTokens()` (cloud-shared/pricing.ts): broad detector for models that spend output tokens on hidden reasoning. Deliberately separate from the narrow `isReasoningModel()` (which only governs temperature stripping).
- `computeEffectiveMaxTokens` now floors effective `max_tokens` at `MIN_RESPONSE_TOKENS` for any reasoning model, not just Anthropic CoT.
- Empty-but-billed guard (non-streaming): if a completion is empty but tokens were billed, report `finish_reason: "length"` + log a warning, instead of a misleading `stop` with null content.
- Tests: 29 for the detector, 7 for the budget logic.

## Notes for review

- Touches the inference + billing path.
- The detector is intentionally broad: a false positive only nudges the token floor up; a false negative bills callers for empty output.
- Streaming path unchanged (streams deltas as they arrive; budget floor covers it). Can add the empty-billed signal to the streaming final chunk for symmetry if wanted.
