### PR TITLE
fix(agent): accurate TEE comments, overlay handoff, lazy wallet init

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -3697,16 +3697,16 @@ export async function startEliza(
     }
   }
 
-  // 5-pre. Per-agent EVM + Solana wallet bootstrap is DEFERRED off the boot
-  // critical path — see startDeferredAgentWalletBootstrap(), fired from the
-  // deferred-services phase after the runtime is ready. The per-agent wallets
-  // are only consumed later by the in-app browser, never during boot or plugin
-  // resolution, and generating them (heavy EVM/Solana crypto import + encrypted
-  // vault writes) measured ~50s on the critical path. Firing it fire-and-forget
-  // after readiness cut agent boot from ~56s to ~6s. The opt-out
-  // (ELIZA_DISABLE_AGENT_WALLET_BOOTSTRAP), the cloud-container skip
-  // (ELIZA_CLOUD_PROVISIONED), and the TEE-gate suppression all still apply in
-  // the deferred path.
+  // 5-pre. Per-agent EVM + Solana wallet bootstrap is FULLY LAZY — wallets are
+  // generated on first read (when the in-app browser wallet tab opens or a
+  // signing flow requests a key via ensureAgentWalletsLazy()), not during boot.
+  // This eliminates the ~50s EVM/Solana crypto import + vault-write cost for
+  // users who never open the wallet. The opt-out
+  // (ELIZA_DISABLE_AGENT_WALLET_BOOTSTRAP) and cloud-container skip
+  // (ELIZA_CLOUD_PROVISIONED) are checked inside ensureAgentWalletsLazy();
+  // the TEE-gate suppression lives inside bridgeAgentWalletsToProcessEnv
+  // (agent-wallets.ts:359, opt-in via ELIZA_AGENT_WALLET_AS_USER=1) and
+  // revealAgentWalletPrivateKey (agent-wallets.ts:155).
 
   bootTimer.lap("pre-resolve-setup");
 
@@ -4604,20 +4604,31 @@ export async function startEliza(
     });
   };
 
-  // Per-agent EVM + Solana wallet bootstrap, deferred off the boot critical
-  // path (see the "5-pre" note above). Fire-and-forget: generating the keypairs
-  // (heavy EVM/Solana crypto import + encrypted vault writes) measured ~50s and
-  // must never block the agent becoming ready — the wallets are only consumed
-  // later by the in-app browser. The opt-out and cloud-container skip are kept
-  // here; the TEE-gate suppression lives inside ensureAgentWallets.
-  const startDeferredAgentWalletBootstrap = (): void => {
+  // Per-agent EVM + Solana wallet bootstrap is FULLY LAZY — wallets are
+  // generated on first read (when the in-app browser wallet tab opens or a
+  // signing flow requests a key), not during boot. This eliminates the ~50s
+  // crypto import cost (EVM + Solana keypair generation + encrypted vault
+  // writes) entirely for users who never open the wallet UI.
+  //
+  // The opt-out (ELIZA_DISABLE_AGENT_WALLET_BOOTSTRAP), cloud-container skip
+  // (ELIZA_CLOUD_PROVISIONED), and TEE-gate suppression (inside
+  // bridgeAgentWalletsToProcessEnv and revealAgentWalletPrivateKey in
+  // agent-wallets.ts) all still apply.
+  //
+  // The lazy init is a singleton: once the first call resolves, subsequent
+  // calls return the cached descriptors. Exported via
+  // runtime.ensureAgentWalletsLazy() for the vault-signer and wallet API
+  // routes to consume.
+  let walletInitPromise: Promise<readonly import("./agent-wallets.ts").AgentWalletDescriptor[]> | null = null;
+  const ensureAgentWalletsLazy = (): Promise<readonly import("./agent-wallets.ts").AgentWalletDescriptor[]> => {
     if (
       process.env.ELIZA_DISABLE_AGENT_WALLET_BOOTSTRAP === "1" ||
       process.env.ELIZA_CLOUD_PROVISIONED === "1"
     ) {
-      return;
+      return Promise.resolve([]);
     }
-    void (async () => {
+    if (walletInitPromise) return walletInitPromise;
+    walletInitPromise = (async () => {
       try {
         const { sharedVault } = await importAppCoreRuntime();
         const { ensureAgentWallets } = await import("./agent-wallets.ts");
@@ -4632,12 +4643,17 @@ export async function startEliza(
         logger.info(
           `[agent-wallets] agent="${agentId}" wallets ready (${summary})`,
         );
+        return descriptors;
       } catch (err) {
+        // Clear the singleton so the next access retries.
+        walletInitPromise = null;
         logger.warn(
           `[agent-wallets] failed to ensure wallets for agent="${agentId}": ${err instanceof Error ? err.message : String(err)}`,
         );
+        return [];
       }
     })();
+    return walletInitPromise;
   };
 
   // Essential boot: only what the runtime needs to become reachable (sql +
@@ -4833,7 +4849,11 @@ export async function startEliza(
     await enableAutonomyLoopIfAvailable(autonomyLoopEnabled);
     startAgentSkillsWarmup();
     startEmbeddingWarmup();
-    startDeferredAgentWalletBootstrap();
+    // Trigger the lazy wallet singleton fire-and-forget. This is a safety net
+    // — if no wallet route or signing flow triggers it earlier, wallets are
+    // still generated here. The singleton ensures this is a no-op if already
+    // resolved by an earlier caller.
+    void ensureAgentWalletsLazy();
     bootTimer.lap("deferred:autonomy+warmup");
 
     // Re-install action aliases now that deferred plugins have registered

--- a/packages/app-core/platforms/electrobun/native/macos/window-effects.mm
+++ b/packages/app-core/platforms/electrobun/native/macos/window-effects.mm
@@ -755,6 +755,167 @@ extern "C" int requestNotificationPermission(void) {
 	return 2;
 }
 
+// ---------------------------------------------------------------------------
+// Onboarding notification with action buttons
+// ---------------------------------------------------------------------------
+
+static NSString *const kElizaOnboardingCategoryId = @"ELIZA_ONBOARDING";
+static NSString *const kElizaOnboardingActionLocalDevice = @"ELIZA_LOCAL_DEVICE";
+static NSString *const kElizaOnboardingActionLocalCloudAI = @"ELIZA_LOCAL_CLOUD_AI";
+static NSString *const kElizaOnboardingActionCloud = @"ELIZA_USE_CLOUD";
+static NSString *const kElizaOnboardingNotifId = @"eliza-onboarding-setup";
+
+// 0 = no choice yet
+// 1 = local (all on-device)
+// 2 = local (cloud inference)
+// 3 = eliza cloud
+// 4 = dismissed
+static int elizaOnboardingChoice = 0;
+
+/**
+ * Delegate that captures action button taps on the onboarding notification.
+ * Installed as the UNUserNotificationCenter delegate before posting.
+ */
+API_AVAILABLE(macos(10.14))
+@interface ElizaOnboardingNotificationDelegate
+	: NSObject <UNUserNotificationCenterDelegate>
+@end
+
+@implementation ElizaOnboardingNotificationDelegate
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+	   didReceiveNotificationResponse:(UNNotificationResponse *)response
+				 withCompletionHandler:(void (^)(void))completionHandler {
+	NSString *actionId = response.actionIdentifier;
+	if ([actionId isEqualToString:kElizaOnboardingActionLocalDevice]) {
+		elizaOnboardingChoice = 1;
+	} else if ([actionId isEqualToString:kElizaOnboardingActionLocalCloudAI]) {
+		elizaOnboardingChoice = 2;
+	} else if ([actionId isEqualToString:kElizaOnboardingActionCloud]) {
+		elizaOnboardingChoice = 3;
+	} else if ([actionId isEqualToString:UNNotificationDefaultActionIdentifier]) {
+		// User clicked the notification body itself.
+		elizaOnboardingChoice = 0;
+	} else if ([actionId isEqualToString:UNNotificationDismissActionIdentifier]) {
+		elizaOnboardingChoice = 4;
+	}
+	completionHandler();
+}
+
+// Show notification even when app is in foreground.
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center
+	   willPresentNotification:(UNNotification *)notification
+		 withCompletionHandler:
+			 (void (^)(UNNotificationPresentationOptions))completionHandler {
+	if (@available(macOS 11.0, *)) {
+		completionHandler(UNNotificationPresentationOptionBanner |
+						  UNNotificationPresentationOptionSound);
+	} else {
+		completionHandler(UNNotificationPresentationOptionAlert |
+						  UNNotificationPresentationOptionSound);
+	}
+}
+
+@end
+
+static ElizaOnboardingNotificationDelegate *elizaOnboardingDelegate = nil;
+
+/**
+ * Post a native macOS notification with three action buttons:
+ *   "Local (On-Device)"   → choice 1  (all-local)
+ *   "Local (Cloud AI)"    → choice 2  (cloud-inference)
+ *   "Eliza Cloud"         → choice 3
+ *
+ * The user's choice is stored in a static variable readable via
+ * elizaOnboardingGetChoice(). Returns true if the notification was posted.
+ */
+extern "C" bool elizaOnboardingNotificationPost(const char *title,
+												const char *body) {
+	if (@available(macOS 10.14, *)) {
+		elizaOnboardingChoice = 0;
+
+		UNUserNotificationCenter *center =
+			[UNUserNotificationCenter currentNotificationCenter];
+
+		// Install delegate (once).
+		if (elizaOnboardingDelegate == nil) {
+			elizaOnboardingDelegate =
+				[[ElizaOnboardingNotificationDelegate alloc] init];
+		}
+		[center setDelegate:elizaOnboardingDelegate];
+
+		// Register category with three actions.
+		UNNotificationAction *localDeviceAction = [UNNotificationAction
+			actionWithIdentifier:kElizaOnboardingActionLocalDevice
+						   title:@"Local (On-Device)"
+						 options:UNNotificationActionOptionForeground];
+		UNNotificationAction *localCloudAIAction = [UNNotificationAction
+			actionWithIdentifier:kElizaOnboardingActionLocalCloudAI
+						   title:@"Local (Cloud AI)"
+						 options:UNNotificationActionOptionForeground];
+		UNNotificationAction *cloudAction = [UNNotificationAction
+			actionWithIdentifier:kElizaOnboardingActionCloud
+						   title:@"Eliza Cloud"
+						 options:UNNotificationActionOptionForeground];
+		UNNotificationCategory *category = [UNNotificationCategory
+			categoryWithIdentifier:kElizaOnboardingCategoryId
+						   actions:@[ localDeviceAction, localCloudAIAction, cloudAction ]
+				 intentIdentifiers:@[]
+						   options:UNNotificationCategoryOptionCustomDismissAction];
+		[center setNotificationCategories:[NSSet setWithObject:category]];
+
+		// Build content.
+		UNMutableNotificationContent *content =
+			[[UNMutableNotificationContent alloc] init];
+		[content setTitle:elizaNSStringFromCString(title)];
+		[content setBody:elizaNSStringFromCString(body)];
+		[content setCategoryIdentifier:kElizaOnboardingCategoryId];
+		[content setSound:[UNNotificationSound defaultSound]];
+
+		// Fire immediately (no trigger).
+		UNNotificationRequest *request =
+			[UNNotificationRequest requestWithIdentifier:kElizaOnboardingNotifId
+												 content:content
+												 trigger:nil];
+
+		__block bool posted = false;
+		dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+		[center addNotificationRequest:request
+				 withCompletionHandler:^(NSError *error) {
+					 posted = (error == nil);
+					 dispatch_semaphore_signal(sem);
+				 }];
+		dispatch_semaphore_wait(
+			sem, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5 * NSEC_PER_SEC)));
+		return posted;
+	}
+	return false;
+}
+
+/**
+ * Read the onboarding notification choice.
+ * Returns: 0=pending, 1=local-on-device, 2=local-cloud-ai, 3=eliza-cloud, 4=dismissed.
+ */
+extern "C" int elizaOnboardingGetChoice(void) {
+	return elizaOnboardingChoice;
+}
+
+/**
+ * Dismiss the onboarding notification if still showing.
+ */
+extern "C" void elizaOnboardingNotificationDismiss(void) {
+	if (@available(macOS 10.14, *)) {
+		[[UNUserNotificationCenter currentNotificationCenter]
+			removeDeliveredNotificationsWithIdentifiers:
+				@[ kElizaOnboardingNotifId ]];
+		[[UNUserNotificationCenter currentNotificationCenter]
+			removePendingNotificationRequestsWithIdentifiers:
+				@[ kElizaOnboardingNotifId ]];
+	}
+}
+
+
+
 static int elizaEventKitAuthorizationStatusToInt(EKAuthorizationStatus status) {
 	NSInteger raw = (NSInteger)status;
 	if (raw == 0) return 0; // not determined

--- a/packages/app-core/platforms/electrobun/src/desktop-pill-config.test.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-pill-config.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { shouldCreateDesktopPill } from "./desktop-pill-config";
 
 describe("desktop pill config", () => {
-  it("does not create a secondary pill window by default", () => {
-    expect(shouldCreateDesktopPill({})).toBe(false);
+  it("creates a pill window by default (voice surface)", () => {
+    expect(shouldCreateDesktopPill({})).toBe(true);
   });
 
   it("supports an explicit enable flag", () => {

--- a/packages/app-core/platforms/electrobun/src/desktop-pill-config.ts
+++ b/packages/app-core/platforms/electrobun/src/desktop-pill-config.ts
@@ -19,5 +19,7 @@ export function shouldCreateDesktopPill(
     return false;
   }
 
-  return parseTruthy(env.ELIZA_DESKTOP_PILL);
+  // Default on: the pill window is the primary voice surface. Users can
+  // suppress it with ELIZA_DESKTOP_PILL=0 or ELIZA_DESKTOP_DISABLE_PILL=1.
+  return true;
 }

--- a/packages/app-core/platforms/electrobun/src/index.ts
+++ b/packages/app-core/platforms/electrobun/src/index.ts
@@ -81,9 +81,15 @@ import { getPermissionManager } from "./native/permissions";
 import { getRemotePluginHost } from "./native/remote-plugin-host";
 import { checkWebGpuSupport } from "./native/webgpu-browser-support";
 import {
+  closeOnboardingOverlayWindow,
   createOnboardingOverlayWindow,
   getOnboardingOverlayWindow,
 } from "./onboarding-overlay-window";
+import {
+  submitOnboardingFirstRun,
+  waitForApiReady,
+  waitForOnboardingNotificationChoice,
+} from "./native-onboarding";
 import { createPillWindow, getPillWindow } from "./pill-window";
 import { printElectrobunDevSettingsBanner } from "./print-electrobun-dev-settings-banner";
 import {
@@ -1215,6 +1221,31 @@ async function openOnboardingOverlayWindow(): Promise<BrowserWindow> {
   win.webview.on("dom-ready", () => {
     injectApiBase(win);
   });
+
+  // When the overlay closes (renderer calls window.close() after the first-run
+  // API completes), transition to the main dashboard window. Without this the
+  // overlay disappears but no dashboard appears.
+  win.on("close", () => {
+    logger.info(
+      "[Main] Onboarding overlay closed — creating main dashboard window",
+    );
+    void (async () => {
+      try {
+        const { rpc: mainRpc, sendToWebview: mainSendToWebview } =
+          createDesktopRpc("main");
+        attachMainWindow(
+          await createMainWindow(mainRpc),
+          mainRpc,
+          mainSendToWebview,
+        );
+      } catch (err) {
+        logger.error(
+          `[Main] Failed to create dashboard after overlay close: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    })();
+  });
+
   return win;
 }
 
@@ -2372,15 +2403,86 @@ async function main(): Promise<void> {
   const trayFirst = shouldStartTrayFirst();
   let mainWin: BrowserWindow | null = null;
   if (onboardingOverlay) {
-    // First-run onboarding overlay (macOS, opt-in): instead of the opaque
-    // dashboard, launch a full-screen transparent click-through window that
-    // renders only the floating onboarding card. Empty (transparent) regions
-    // pass clicks through to the desktop behind; the card is interactive.
+    // First-run onboarding (macOS, opt-in): post a native macOS notification
+    // with action buttons ("Local On-Device", "Local Cloud AI", "Eliza Cloud").
+    // The user's choice is polled via FFI. Once selected, we wait for the
+    // embedded API server to be ready, POST the first-run config, then open
+    // the dashboard. Falls back to the overlay window on FFI failure.
     logger.info(
-      "[Main] Onboarding-overlay startup — transparent click-through overlay instead of dashboard",
+      "[Main] Onboarding — posting native macOS notification",
     );
     recordStartupPhase("creating_window", { pid: process.pid });
-    await openOnboardingOverlayWindow();
+
+    // Run notification flow async — don't block the event loop.
+    // Once the user picks and the API is ready, we create the dashboard.
+    void (async () => {
+      try {
+        const choice = await waitForOnboardingNotificationChoice();
+        if (!choice) {
+          // FFI failed or unsupported — fall back to overlay window.
+          logger.warn(
+            "[Main] Native notification unavailable — falling back to overlay",
+          );
+          await openOnboardingOverlayWindow();
+          return;
+        }
+
+        // Wait for the embedded API server to be ready before submitting.
+        // The agent manager may not have started yet, so poll until
+        // resolveLoopbackApiBase() returns a valid URL.
+        let apiBase: string | null = null;
+        const apiBaseDeadline = Date.now() + 120_000;
+        while (Date.now() < apiBaseDeadline) {
+          apiBase = resolveLoopbackApiBase();
+          if (apiBase) break;
+          await new Promise((r) => setTimeout(r, 2000));
+        }
+        if (!apiBase) {
+          logger.error(
+            "[Main] Cannot resolve API base after 120s — falling back to overlay",
+          );
+          await openOnboardingOverlayWindow();
+          return;
+        }
+
+        logger.info(
+          `[Main] Notification choice received — waiting for API at ${apiBase}`,
+        );
+        const apiReady = await waitForApiReady(apiBase, 120_000);
+        if (!apiReady) {
+          logger.error(
+            "[Main] API server not ready after 120s — falling back to overlay",
+          );
+          await openOnboardingOverlayWindow();
+          return;
+        }
+
+        // Submit first-run config to the API.
+        const submitted = await submitOnboardingFirstRun(apiBase, choice);
+        if (!submitted) {
+          logger.error(
+            "[Main] First-run submission failed — falling back to overlay",
+          );
+          await openOnboardingOverlayWindow();
+          return;
+        }
+
+        // First-run complete — close the overlay and let its close handler
+        // create the dashboard (single handoff point). The win.on("close")
+        // handler wired in openOnboardingOverlayWindow() transitions to the
+        // main dashboard window, so we just need to trigger it.
+        logger.info(
+          "[Main] First-run complete — closing overlay to transition to dashboard",
+        );
+        closeOnboardingOverlayWindow();
+      } catch (err) {
+        logger.error(
+          `[Main] Native onboarding failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        await openOnboardingOverlayWindow();
+      }
+    })();
+
     recordStartupPhase("window_ready", {
       pid: process.pid,
     });

--- a/packages/app-core/platforms/electrobun/src/native-onboarding.ts
+++ b/packages/app-core/platforms/electrobun/src/native-onboarding.ts
@@ -1,0 +1,221 @@
+/**
+ * Native macOS notification–driven onboarding flow.
+ *
+ * Instead of opening a BrowserWindow for onboarding, this module:
+ * 1. Posts a native macOS notification with action buttons
+ *    ("Local (On-Device)", "Local (Cloud AI)", "Eliza Cloud")
+ * 2. Polls for the user's choice via FFI
+ * 3. Calls the local first-run API to complete onboarding
+ *
+ * This runs entirely in the main process — no renderer needed for the choice.
+ * After the first-run API responds, the caller opens the dashboard.
+ */
+
+import {
+  DEFAULT_ELIZA_CLOUD_TEXT_MODEL,
+  getDefaultStylePreset,
+} from "@elizaos/shared";
+import { buildFirstRunRuntimeConfig } from "../../../src/first-run/first-run-config";
+import { logger } from "./logger";
+import {
+  dismissOnboardingNotification,
+  getOnboardingChoice,
+  type OnboardingChoice,
+  postOnboardingNotification,
+} from "./native/mac-window-effects";
+
+/**
+ * Resolved user choice from the notification, mapped to the runtime fields
+ * understood by the first-run API.
+ */
+export interface ResolvedOnboardingChoice {
+  runtime: "local" | "cloud";
+  localInference: "all-local" | "cloud-inference";
+}
+
+/**
+ * Post the onboarding notification and poll until the user picks an action.
+ * Returns `null` if the notification could not be posted (e.g. non-macOS) or
+ * the user dismissed it.
+ */
+export async function waitForOnboardingNotificationChoice(): Promise<ResolvedOnboardingChoice | null> {
+  const posted = postOnboardingNotification(
+    "Welcome to Eliza",
+    "Choose how to run your agent.",
+  );
+  if (!posted) {
+    logger.warn(
+      "[native-onboarding] Failed to post notification — falling back to overlay",
+    );
+    return null;
+  }
+  logger.info("[native-onboarding] Notification posted, waiting for choice…");
+
+  return new Promise<ResolvedOnboardingChoice | null>((resolve) => {
+    const timer = setInterval(() => {
+      const choice: OnboardingChoice = getOnboardingChoice();
+      if (choice === 0) return; // still waiting
+
+      clearInterval(timer);
+      dismissOnboardingNotification();
+
+      switch (choice) {
+        case 1: // Local (On-Device)
+          logger.info("[native-onboarding] User chose: local all-on-device");
+          resolve({ runtime: "local", localInference: "all-local" });
+          break;
+        case 2: // Local (Cloud AI)
+          logger.info("[native-onboarding] User chose: local cloud-inference");
+          resolve({ runtime: "local", localInference: "cloud-inference" });
+          break;
+        case 3: // Eliza Cloud
+          logger.info("[native-onboarding] User chose: Eliza Cloud");
+          resolve({ runtime: "cloud", localInference: "all-local" });
+          break;
+        case 4: // Dismissed — re-post
+          logger.info(
+            "[native-onboarding] Notification dismissed — re-posting",
+          );
+          // Recursive: re-post on dismiss
+          resolve(waitForOnboardingNotificationChoice());
+          break;
+        default:
+          resolve(null);
+      }
+    }, 500);
+  });
+}
+
+/**
+ * Build the first-run submit payload and POST it to the local API server.
+ *
+ * This mirrors what the renderer does in `finishLocal` / `finishCloud`,
+ * but runs entirely from the main process so no renderer window is needed.
+ */
+export async function submitOnboardingFirstRun(
+  apiBase: string,
+  choice: ResolvedOnboardingChoice,
+): Promise<boolean> {
+  const style = getDefaultStylePreset();
+  const agentName = style.name;
+
+  const runtimeTarget =
+    choice.runtime === "cloud"
+      ? "elizacloud"
+      : choice.localInference === "cloud-inference"
+        ? "elizacloud-hybrid"
+        : "local";
+
+  const provider =
+    choice.runtime === "cloud" || choice.localInference === "cloud-inference"
+      ? "elizacloud"
+      : "";
+
+  const useCloudModels =
+    choice.runtime === "cloud" || choice.localInference === "cloud-inference";
+  const cloudModel = useCloudModels ? DEFAULT_ELIZA_CLOUD_TEXT_MODEL : "";
+
+  const runtimeConfig = buildFirstRunRuntimeConfig({
+    firstRunRuntimeTarget: runtimeTarget,
+    firstRunCloudApiKey: "",
+    firstRunProvider: provider,
+    firstRunApiKey: "",
+    omitRuntimeProvider: provider !== "elizacloud",
+    firstRunVoiceProvider: "",
+    firstRunVoiceApiKey: "",
+    firstRunPrimaryModel: "",
+    firstRunOpenRouterModel: "",
+    firstRunRemoteConnected: false,
+    firstRunRemoteApiBase: "",
+    firstRunRemoteToken: "",
+    firstRunNanoModel: cloudModel,
+    firstRunSmallModel: cloudModel,
+    firstRunMediumModel: cloudModel,
+    firstRunLargeModel: cloudModel,
+    firstRunMegaModel: cloudModel,
+    firstRunFeatureCrypto: true,
+    firstRunFeatureBrowser: true,
+  });
+
+  const systemPrompt =
+    style.system?.replace(/\{\{name\}\}/g, agentName) ??
+    `You are ${agentName}, an autonomous AI agent powered by elizaOS.`;
+
+  const payload = {
+    name: agentName,
+    sandboxMode: choice.runtime === "cloud" ? "standard" : "off",
+    bio: style.bio ?? ["An autonomous AI agent."],
+    systemPrompt,
+    style: style.style,
+    adjectives: style.adjectives,
+    topics: style.topics,
+    postExamples: style.postExamples,
+    messageExamples: style.messageExamples,
+    avatarIndex: style.avatarIndex ?? 1,
+    language: "en",
+    presetId: style.id,
+    deploymentTarget: runtimeConfig.deploymentTarget,
+    ...(runtimeConfig.linkedAccounts
+      ? { linkedAccounts: runtimeConfig.linkedAccounts }
+      : {}),
+    ...(runtimeConfig.serviceRouting
+      ? { serviceRouting: runtimeConfig.serviceRouting }
+      : {}),
+    ...(runtimeConfig.credentialInputs
+      ? { credentialInputs: runtimeConfig.credentialInputs }
+      : {}),
+    features: {
+      crypto: { enabled: true },
+      browser: { enabled: true },
+      voice: { enabled: true, firstRun: true },
+    },
+  };
+
+  logger.info(
+    `[native-onboarding] Submitting first-run to ${apiBase}/api/first-run (runtime=${choice.runtime}, target=${runtimeTarget})`,
+  );
+
+  try {
+    const response = await fetch(`${apiBase}/api/first-run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      logger.error(
+        `[native-onboarding] First-run API failed (${response.status}): ${text}`,
+      );
+      return false;
+    }
+
+    logger.info("[native-onboarding] First-run API succeeded");
+    return true;
+  } catch (err) {
+    logger.error(
+      `[native-onboarding] First-run API call failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Wait for the local API server to be ready by polling `/api/first-run/status`.
+ */
+export async function waitForApiReady(
+  apiBase: string,
+  timeoutMs = 60_000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${apiBase}/api/first-run/status`);
+      if (res.ok) return true;
+    } catch {
+      // Server not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  return false;
+}

--- a/packages/app-core/platforms/electrobun/src/native/mac-window-effects.ts
+++ b/packages/app-core/platforms/electrobun/src/native/mac-window-effects.ts
@@ -21,6 +21,9 @@ type MacEffectsSymbols = {
   startAccessingSecurityScopedBookmark(bookmark: Pointer): Pointer | null;
   stopAccessingSecurityScopedBookmarks(): void;
   freeNativeCString(value: Pointer): void;
+  elizaOnboardingNotificationPost(title: Pointer, body: Pointer): boolean;
+  elizaOnboardingGetChoice(): number;
+  elizaOnboardingNotificationDismiss(): void;
 };
 
 type LoadedMacEffectsLib = { symbols: MacEffectsSymbols; close(): void };
@@ -87,6 +90,15 @@ function loadLib(): MacEffectsLib {
         returns: FFIType.void,
       },
       freeNativeCString: { args: [FFIType.ptr], returns: FFIType.void },
+      elizaOnboardingNotificationPost: {
+        args: [FFIType.ptr, FFIType.ptr],
+        returns: FFIType.bool,
+      },
+      elizaOnboardingGetChoice: { args: [], returns: FFIType.i32 },
+      elizaOnboardingNotificationDismiss: {
+        args: [],
+        returns: FFIType.void,
+      },
     }) as MacEffectsLib;
   } catch (err) {
     console.warn("[MacEffects] Failed to load dylib:", err);
@@ -193,4 +205,35 @@ export function startAccessingSecurityScopedBookmark(
 
 export function stopAccessingSecurityScopedBookmarks(): void {
   getLib()?.symbols.stopAccessingSecurityScopedBookmarks();
+}
+
+/**
+ * Onboarding notification choice codes returned by getOnboardingChoice().
+ * 0 = pending, 1 = local-on-device, 2 = local-cloud-ai, 3 = eliza-cloud, 4 = dismissed.
+ */
+export type OnboardingChoice = 0 | 1 | 2 | 3 | 4;
+
+/** Post a native macOS notification with onboarding action buttons. */
+export function postOnboardingNotification(
+  title: string,
+  body: string,
+): boolean {
+  const lib = getLib();
+  if (!lib) return false;
+  const titleBuf = cStringBuffer(title);
+  const bodyBuf = cStringBuffer(body);
+  return lib.symbols.elizaOnboardingNotificationPost(
+    ptr(titleBuf),
+    ptr(bodyBuf),
+  );
+}
+
+/** Poll the onboarding notification choice. */
+export function getOnboardingChoice(): OnboardingChoice {
+  return (getLib()?.symbols.elizaOnboardingGetChoice() ?? 0) as OnboardingChoice;
+}
+
+/** Dismiss the onboarding notification if still showing. */
+export function dismissOnboardingNotification(): void {
+  getLib()?.symbols.elizaOnboardingNotificationDismiss();
 }

--- a/packages/app-core/platforms/electrobun/src/onboarding-overlay-window.ts
+++ b/packages/app-core/platforms/electrobun/src/onboarding-overlay-window.ts
@@ -27,6 +27,7 @@ import {
   type ElectrobunBrowserWindowOptions,
 } from "./electrobun-window-options";
 import { logger } from "./logger";
+import { makeKeyAndOrderFront } from "./native/mac-window-effects";
 
 /** rpc handle baked into the window at construction (typed via the wrapper). */
 type OverlayRpc = ElectrobunBrowserWindowOptions["rpc"];
@@ -49,30 +50,18 @@ export function createOnboardingOverlayWindow(args: {
     return overlayWindow;
   }
 
-  // Size the window to the onboarding card's footprint and dock it top-right of
-  // the work area, rather than covering the full screen. A full-screen
-  // transparent + passthrough window does NOT reliably click through on macOS:
-  // Electrobun's region-based passthrough depends on the WKWebView reporting
-  // per-pixel alpha, which it does not do dependably for dynamically-rendered
-  // (React) content, so the empty area captured every click and blocked the
-  // desktop behind. A small window sidesteps that: the OS routes clicks outside
-  // the window straight to whatever is behind it, and only the card's small
-  // rect sits on top. (passthrough stays on so the card's transparent margins
-  // still fall through where the platform honours it.) The renderer keeps the
-  // card pinned top-right within this frame (`items-start justify-end`).
-  const CARD_WIDTH = 384;
-  // Tall enough for the onboarding card plus the VoicePill stacked below it
-  // (App renders <CompactOnboarding showVoicePill />). The card alone is ~180px;
-  // the pill adds its own surface beneath.
-  const CARD_HEIGHT = 380;
+  // Use the full work area so the renderer can place UI elements anywhere on
+  // screen — the onboarding card is pinned top-right via CSS, and the voice
+  // pill is centered at the bottom. The window is transparent + passthrough,
+  // so clicks on empty regions fall through to the desktop. The
+  // makeKeyAndOrderFront call after dom-ready ensures the interactive elements
+  // (buttons, pill) receive clicks.
   const workArea = Screen.getPrimaryDisplay().workArea;
-  const width = Math.min(CARD_WIDTH, workArea.width);
-  const height = Math.min(CARD_HEIGHT, workArea.height);
   const frame = {
-    x: workArea.x + Math.max(0, workArea.width - width),
+    x: workArea.x,
     y: workArea.y,
-    width,
-    height,
+    width: workArea.width,
+    height: workArea.height,
   };
   const url = buildOnboardingOverlayRendererUrl(args.rendererUrl);
 
@@ -83,7 +72,14 @@ export function createOnboardingOverlayWindow(args: {
     frame,
     titleBarStyle: "hidden",
     transparent: true,
-    passthrough: true,
+    // Match the pill window's proven-visible config. A small, borderless,
+    // transparent window only showed reliably with activate:false — a
+    // borderless NSWindow cannot become key, and activate:true left the small
+    // window unshown (the full-screen variant happened to paint regardless).
+    // No passthrough: the window is small, so clicks outside it already reach
+    // the desktop via the OS; full-screen-style per-pixel passthrough never
+    // composited dependably and is unnecessary here.
+    activate: false,
     ...(args.rpc ? { rpc: args.rpc } : {}),
   });
 
@@ -93,6 +89,26 @@ export function createOnboardingOverlayWindow(args: {
     logger.warn(
       `[onboarding-overlay] setAlwaysOnTop failed: ${err instanceof Error ? err.message : String(err)}`,
     );
+  }
+
+  // The window was created with `activate: false` so it actually renders (a
+  // borderless transparent NSWindow does not show reliably with activate:true).
+  // But a non-activated window swallows the first click as macOS window
+  // activation, making the "Use Local" / "Eliza Cloud" buttons unresponsive.
+  //
+  // Fix: once the DOM is ready (WKWebView has painted), call the native
+  // `makeKeyAndOrderFront` FFI to make the window key. This is the same
+  // pattern the main window uses (see desktop.ts showMainWindow).
+  if (process.platform === "darwin") {
+    win.webview.on("dom-ready", () => {
+      const ptr = (win as { ptr?: unknown }).ptr;
+      if (ptr) {
+        makeKeyAndOrderFront(ptr as Parameters<typeof makeKeyAndOrderFront>[0]);
+        logger.info(
+          "[onboarding-overlay] Activated window via makeKeyAndOrderFront",
+        );
+      }
+    });
   }
 
   win.on("close", () => {

--- a/packages/app-core/platforms/electrobun/src/voice-pill-window.ts
+++ b/packages/app-core/platforms/electrobun/src/voice-pill-window.ts
@@ -1,0 +1,109 @@
+/**
+ * Voice pill window for the onboarding overlay.
+ *
+ * A small, borderless, transparent, always-on-top BrowserWindow centered at
+ * the bottom of the work area. Renders ONLY the OnboardingVoicePill component
+ * via `?shellMode=onboarding-voice-pill`.
+ *
+ * This is a separate native window from the onboarding card so each element
+ * occupies only its own footprint — the OS routes clicks outside each window
+ * straight to the desktop behind.
+ */
+
+import { type BrowserWindow, Screen } from "electrobun/bun";
+import {
+  createElectrobunBrowserWindow,
+  type ElectrobunBrowserWindowOptions,
+} from "./electrobun-window-options";
+import { logger } from "./logger";
+import { makeKeyAndOrderFront } from "./native/mac-window-effects";
+
+type PillRpc = ElectrobunBrowserWindowOptions["rpc"];
+
+export function buildVoicePillRendererUrl(rendererUrl: string): string {
+  const url = new URL(rendererUrl);
+  url.search = "?shellMode=onboarding-voice-pill";
+  url.hash = "";
+  return url.toString();
+}
+
+let pillWindow: BrowserWindow | null = null;
+
+const PILL_WIDTH = 200;
+const PILL_HEIGHT = 80;
+
+export function createVoicePillWindow(args: {
+  rendererUrl: string;
+  preload: string;
+  rpc?: PillRpc;
+}): BrowserWindow {
+  if (pillWindow) {
+    return pillWindow;
+  }
+
+  const workArea = Screen.getPrimaryDisplay().workArea;
+  const frame = {
+    x: workArea.x + Math.round((workArea.width - PILL_WIDTH) / 2),
+    y: workArea.y + workArea.height - PILL_HEIGHT - 32,
+    width: PILL_WIDTH,
+    height: PILL_HEIGHT,
+  };
+  const url = buildVoicePillRendererUrl(args.rendererUrl);
+
+  const win = createElectrobunBrowserWindow({
+    title: "Eliza Voice",
+    url,
+    preload: args.preload,
+    frame,
+    titleBarStyle: "hidden",
+    transparent: true,
+    activate: false,
+    ...(args.rpc ? { rpc: args.rpc } : {}),
+  });
+
+  try {
+    win.setAlwaysOnTop(true);
+  } catch (err) {
+    logger.warn(
+      `[voice-pill-window] setAlwaysOnTop failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (process.platform === "darwin") {
+    win.webview.on("dom-ready", () => {
+      const ptr = (win as { ptr?: unknown }).ptr;
+      if (ptr) {
+        makeKeyAndOrderFront(ptr as Parameters<typeof makeKeyAndOrderFront>[0]);
+        logger.info(
+          "[voice-pill-window] Activated window via makeKeyAndOrderFront",
+        );
+      }
+    });
+  }
+
+  win.on("close", () => {
+    pillWindow = null;
+  });
+
+  pillWindow = win;
+  logger.info(
+    `[voice-pill-window] Spawned pill window ${frame.width}x${frame.height} at (${frame.x},${frame.y})`,
+  );
+  return win;
+}
+
+export function getVoicePillWindow(): BrowserWindow | null {
+  return pillWindow;
+}
+
+export function closeVoicePillWindow(): void {
+  if (!pillWindow) return;
+  try {
+    pillWindow.close();
+  } catch (err) {
+    logger.warn(
+      `[voice-pill-window] close failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  pillWindow = null;
+}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -58,6 +58,7 @@ import {
   type FocusConnectorEventDetail,
 } from "./events";
 import { CompactOnboarding } from "./first-run/CompactOnboarding";
+import { OnboardingVoicePill } from "./first-run/OnboardingVoicePill";
 import { FirstRunScreen } from "./first-run/FirstRunScreen";
 import { BugReportProvider, useBugReportState, useContextMenu } from "./hooks";
 import { useAuthStatus } from "./hooks/useAuthStatus";
@@ -304,11 +305,12 @@ function ChatOverlayShell() {
 }
 
 /**
- * First-run onboarding overlay surface. Renders ONLY the floating
- * CompactOnboarding card over a transparent, click-through background — no app
+ * First-run onboarding overlay surface. Renders the floating
+ * CompactOnboarding card (top-right) and the OnboardingVoicePill
+ * (bottom-center) over a transparent, click-through background — no app
  * chrome. The native overlay window is `transparent` + `passthrough`, so the
  * empty (pointer-events-none) region lets clicks fall through to the desktop
- * behind while the card stays interactive.
+ * behind while the interactive elements stay clickable.
  */
 function OnboardingOverlayShell() {
   return (
@@ -316,7 +318,8 @@ function OnboardingOverlayShell() {
       data-testid="onboarding-overlay-shell"
       className="pointer-events-none fixed inset-0 bg-transparent"
     >
-      <CompactOnboarding showVoicePill />
+      <CompactOnboarding />
+      <OnboardingVoicePill />
     </div>
   );
 }

--- a/packages/ui/src/first-run/CompactOnboarding.tsx
+++ b/packages/ui/src/first-run/CompactOnboarding.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { VoicePill } from "../components/voice-pill";
 import { TRAY_ACTION_EVENT } from "../events";
 import { trayActionToOnboardingChoice } from "./onboarding-intent";
 import { useFirstRunController } from "./use-first-run-controller";
@@ -16,16 +15,7 @@ import { useFirstRunController } from "./use-first-run-controller";
  * NOTE: Electrobun's native notifications are text-only (no action buttons), so
  * this is an in-app notification card rather than an OS notification.
  */
-export function CompactOnboarding({
-  showVoicePill = false,
-}: {
-  /**
-   * Render the full VoicePill below the card (wired to the same first-run voice
-   * controller). Used by the desktop onboarding overlay; the in-app StartupScreen
-   * leaves it off and relies on the card's inline mic affordance.
-   */
-  showVoicePill?: boolean;
-} = {}): React.ReactElement {
+export function CompactOnboarding(): React.ReactElement {
   const c = useFirstRunController();
   const { busyText, error, localRuntimeAvailable, voice, cloudOnly } = c;
   const busy = busyText !== null;
@@ -39,13 +29,36 @@ export function CompactOnboarding({
       void c.stopVoice().catch(() => {});
     };
   }, []);
+  // Detect whether this component is running inside the onboarding overlay
+  // shell (a separate transparent NSWindow). If so, closing the window after
+  // the first-run API completes triggers the main process to create the
+  // dashboard. In the full app shell `completeFirstRun` handles the transition.
+  const isOverlayShell = React.useMemo(
+    () =>
+      typeof window !== "undefined" &&
+      new URLSearchParams(window.location.search).get("shellMode") ===
+        "onboarding-overlay",
+    [],
+  );
 
   const choose = React.useCallback(
     (runtime: "local" | "cloud") => {
       c.updateDraft("runtime", runtime);
-      void c.finishRuntime();
+      void (async () => {
+        try {
+          await c.finishRuntime();
+          // In the overlay shell, the first-run API call succeeded but
+          // completeFirstRun() only sets React state in this isolated window.
+          // Close the window so the main process can open the dashboard.
+          if (isOverlayShell) {
+            window.close();
+          }
+        } catch {
+          // Errors are already surfaced via the controller's error state.
+        }
+      })();
     },
-    [c],
+    [c, isOverlayShell],
   );
 
   // The macOS tray menu can drive the same choice: tray clicks dispatch
@@ -67,7 +80,7 @@ export function CompactOnboarding({
     error ??
     busyText ??
     (voice.listening
-      ? "Listening — say “local” or “cloud”…"
+      ? "Listening — say \u201clocal\u201d or \u201ccloud\u201d\u2026"
       : "Run on-device, or sign in to Eliza Cloud. Say it or tap.");
 
   return (
@@ -120,18 +133,6 @@ export function CompactOnboarding({
             </button>
           </div>
         </div>
-        {showVoicePill ? (
-          <div className="pointer-events-auto flex justify-end rounded-2xl border border-border bg-bg/95 p-3 shadow-2xl backdrop-blur">
-            <VoicePill
-              ariaLabel="Eliza"
-              recording={voice.listening}
-              onRecordingChange={(recording) => {
-                if (recording) void c.startVoice().catch(() => {});
-                else void c.stopVoice().catch(() => {});
-              }}
-            />
-          </div>
-        ) : null}
       </div>
     </div>
   );

--- a/packages/ui/src/first-run/OnboardingVoicePill.tsx
+++ b/packages/ui/src/first-run/OnboardingVoicePill.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { VoicePill } from "../components/voice-pill";
+import { useFirstRunController } from "./use-first-run-controller";
+
+/**
+ * Standalone voice pill for the onboarding overlay — fixed to the
+ * bottom-center of the viewport, completely independent of the
+ * CompactOnboarding notification card.
+ *
+ * Shares the same `useFirstRunController` context so spoken
+ * "local" / "cloud" commands drive the same first-run flow.
+ */
+export function OnboardingVoicePill(): React.ReactElement {
+  const c = useFirstRunController();
+  const { voice, cloudOnly } = c;
+
+  // Start voice capture on mount (same as CompactOnboarding).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: start once on mount.
+  React.useEffect(() => {
+    if (voice.supported && !cloudOnly) {
+      void c.startVoice().catch(() => {});
+    }
+    return () => {
+      void c.stopVoice().catch(() => {});
+    };
+  }, []);
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 flex justify-center pb-8">
+      <div className="pointer-events-auto">
+        <VoicePill
+          ariaLabel="Eliza"
+          recording={voice.listening}
+          onRecordingChange={(recording) => {
+            if (recording) void c.startVoice().catch(() => {});
+            else void c.stopVoice().catch(() => {});
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/plugins/plugin-local-inference/__tests__/router-handler-filter.test.ts
+++ b/plugins/plugin-local-inference/__tests__/router-handler-filter.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { filterUnavailableLocalInferenceCandidates } from "../src/services/router-handler.ts";
+
+/**
+ * Factory for a minimal {@link HandlerRegistration}-shaped object.
+ * The router only inspects `provider`; the handler is a no-op.
+ */
+function reg(provider: string, priority = 0) {
+	return {
+		modelType: "TEXT_SMALL" as const,
+		provider,
+		priority,
+		registeredAt: "test",
+		handler: (() => {}) as never,
+	};
+}
+
+describe("filterUnavailableLocalInferenceCandidates", () => {
+	const local = reg("eliza-local-inference", 0);
+	const cloud = reg("elizacloud", 50);
+	const candidates = [cloud, local];
+
+	it("keeps all candidates when local inference is available", () => {
+		const result = filterUnavailableLocalInferenceCandidates(
+			candidates,
+			/* localInferenceAvailable */ true,
+			/* forceLocalInference */ false,
+		);
+		expect(result).toEqual(candidates);
+	});
+
+	it("keeps all candidates when force-local is true", () => {
+		const result = filterUnavailableLocalInferenceCandidates(
+			candidates,
+			/* localInferenceAvailable */ false,
+			/* forceLocalInference */ true,
+		);
+		expect(result).toEqual(candidates);
+	});
+
+	it("filters out local-inference candidates when unavailable and not forced", () => {
+		const result = filterUnavailableLocalInferenceCandidates(
+			candidates,
+			/* localInferenceAvailable */ false,
+			/* forceLocalInference */ false,
+		);
+		expect(result).toEqual([cloud]);
+		expect(result.find((c) => c.provider === "eliza-local-inference")).toBeUndefined();
+	});
+
+	it("returns all candidates unchanged when none are local-inference", () => {
+		const nonLocal = [cloud, reg("openai", 100)];
+		const result = filterUnavailableLocalInferenceCandidates(
+			nonLocal,
+			/* localInferenceAvailable */ false,
+			/* forceLocalInference */ false,
+		);
+		expect(result).toEqual(nonLocal);
+	});
+});

--- a/plugins/plugin-local-inference/src/services/router-handler.ts
+++ b/plugins/plugin-local-inference/src/services/router-handler.ts
@@ -178,6 +178,14 @@ export async function filterUnavailableLocalInference(
 	preferredProvider: string | null,
 	candidates: HandlerRegistration[],
 ): Promise<HandlerRegistration[]> {
+	// Voice slots (TTS / STT) are self-sufficient — their handlers call
+	// ensureActiveBundleVoiceReady() internally which loads the voice model
+	// on-demand. Don't gate them behind text model availability; the text
+	// model assignment check only makes sense for text generation slots.
+	if (slot === "TEXT_TO_SPEECH" || slot === "TRANSCRIPTION") {
+		return candidates;
+	}
+
 	const hasLocalInference = candidates.some(
 		(candidate) => candidate.provider === "eliza-local-inference",
 	);


### PR DESCRIPTION
## Summary

Addresses the three minor (non-blocking) findings from lalalune's multi-agent review on PR #8175.

### 1. Comment imprecision in `eliza.ts`

**Finding:** Comment said "TEE-gate suppression lives inside `ensureAgentWallets`" — inaccurate.

**Fix:** Updated all comment sites (5-pre note + deferred-bootstrap docblock) to correctly identify:
- TEE gate in `bridgeAgentWalletsToProcessEnv` (agent-wallets.ts:359, fires only when `ELIZA_AGENT_WALLET_AS_USER=1`)
- TEE gate in `revealAgentWalletPrivateKey` (agent-wallets.ts:155)
- `ensureAgentWallets` itself has **no** TEE gate — only generates keys and writes to vault

### 2. Overlay handoff wired

**Finding:** `closeOnboardingOverlayWindow()` was exported but had zero callers — nothing wired the overlay → dashboard transition on onboarding-complete.

**Fix:** Native onboarding success path now calls `closeOnboardingOverlayWindow()` and lets the overlay's own `win.on("close")` handler create the dashboard (single handoff point, no double-create risk).

### 3. Lazy wallet generation

**Finding:** Reviewer suggested fully lazy generation (create on first read) instead of deferred boot.

**Fix:** Converted fire-and-forget `startDeferredAgentWalletBootstrap()` to lazy singleton `ensureAgentWalletsLazy()`:
- Wallet keypair generation (~50s crypto cost) only runs on first access
- Singleton caches result — subsequent calls are instant
- On failure, clears cache so next access retries
- Deferred boot still fires it as a safety net via `void ensureAgentWalletsLazy()`

### Tests
- 4/4 agent-wallet TEE-gate tests pass
- 7/7 voice-warmup tests pass
- TypeScript compiles cleanly