### PR TITLE
fix(local-inference): signal typed unavailability from text handlers

### DIFF
--- a/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
+++ b/plugins/plugin-local-inference/src/runtime/ensure-local-inference-handler.ts
@@ -38,6 +38,7 @@ import {
 	type UUID,
 } from "@elizaos/core";
 import type { CapacitorLlamaContext } from "../adapters/capacitor-llama/types";
+import { LocalInferenceUnavailableError } from "../provider";
 import {
 	type LocalInferenceLoader,
 	resolveLocalInferenceLoadArgs,
@@ -460,12 +461,22 @@ function makeHandler(slot: AgentModelSlot): GenerateTextHandler {
 			return loader.generate(engineArgs);
 		}
 		if (!(await localInferenceEngine.available())) {
-			throw new Error(
+			// No native binding: signal UNAVAILABLE (typed) so the cross-provider
+			// router skips local inference and falls back to a registered cloud/API
+			// provider, instead of hard-failing the whole turn.
+			throw new LocalInferenceUnavailableError(
+				slot,
+				"backend_unavailable",
 				`[local-inference] No llama.cpp binding available for ${slot} request`,
 			);
 		}
 		if (!localInferenceEngine.hasLoadedModel()) {
-			throw new Error(
+			// No local model loaded: signal UNAVAILABLE (typed) so the router falls
+			// back to a registered cloud/API provider (e.g. Anthropic) when one
+			// exists, rather than hard-failing while a usable provider is present.
+			throw new LocalInferenceUnavailableError(
+				slot,
+				"backend_unavailable",
 				`[local-inference] No local model is active. Assign a model to ${slot} or activate one in Settings → Local models.`,
 			);
 		}


### PR DESCRIPTION
## What

The local-inference llama.cpp text handlers (`TEXT_SMALL` / `TEXT_LARGE` / `RESPONSE_HANDLER`, registered via `ensure-local-inference-handler.ts`) throw a plain `Error` when:
- no native llama.cpp binding is available, or
- no local model is loaded.

Every other unavailability path in `@elizaos/plugin-local-inference` throws the typed `LocalInferenceUnavailableError` (`code: "LOCAL_INFERENCE_UNAVAILABLE"`) — see `provider.ts` (e.g. the embedding/voice/vision handlers). That typed error is what `isLocalInferenceUnavailableError()` and the cross-provider candidate-filtering / cloud-fallback layers use to recognize "local can't serve this — try another provider".

A plain `Error` is **not** recognized as unavailability, so these two text-slot paths look like opaque failures to that detection, rather than a clean "skip local, use the registered cloud/API provider" signal.

## Change

Throw `LocalInferenceUnavailableError(slot, "backend_unavailable", <same message>)` from both paths, matching the rest of the provider. The user-facing message is unchanged.

## Impact

- Consistency: all local-inference unavailability now flows through the one typed error + code.
- When a cloud/API provider (e.g. `@elizaos/plugin-anthropic`) is registered for the same slot, "no local model active" is detectable as unavailability instead of an opaque throw.
- **No behavior change when local inference is the only provider** — the error still propagates; only its type/recognizability changes.

## Context

Found while booting elizaOS locally (dev, packages-mode) with a cloud/API model provider but no local model downloaded: a chat turn hard-failed with `No local model is active` even though Anthropic was registered. This is one of several small dev-boot papercuts from that session (see elizaOS/eliza#8124).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
