### PR TITLE
fix(app): resolve es-toolkit/compat/* to ESM (fixes recharts blank screen)

### DIFF
--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -1512,6 +1512,63 @@ export default defineConfig({
     ),
   },
   plugins: [
+    // es-toolkit@1.47's `./compat/*` export map exposes only a CJS condition
+    // (no ESM `import`), so `import get from "es-toolkit/compat/get"` (recharts
+    // default-imports 11 such subpaths) resolves to a CJS shim Vite can't
+    // surface a `default` for when served raw -> blank app. Rewrite each to the
+    // real ESM `dist/compat/**/<name>.mjs` (resolved relative to the importer)
+    // and re-export the named binding as default. Mirrors the optimizer-path
+    // plugin in optimizeDeps.rolldownOptions so both serve paths are covered.
+    {
+      name: "es-toolkit-compat-esm-raw",
+      enforce: "pre",
+      resolveId(source, importer) {
+        const m = /^es-toolkit\/compat\/([A-Za-z0-9_]+)$/.exec(source);
+        if (!m) return null;
+        let dir = null;
+        try {
+          const req = createRequire(
+            importer || path.join(elizaRoot, "node_modules", "x.js"),
+          );
+          dir = path.dirname(req.resolve("es-toolkit/package.json"));
+        } catch {
+          return null;
+        }
+        const stack = [path.join(dir, "dist", "compat")];
+        let mjs = null;
+        while (stack.length) {
+          const d = stack.pop();
+          let entries;
+          try {
+            entries = fs.readdirSync(d, { withFileTypes: true });
+          } catch {
+            continue;
+          }
+          for (const ent of entries) {
+            const full = path.join(d, ent.name);
+            if (ent.isDirectory()) stack.push(full);
+            else if (ent.name === `${m[1]}.mjs`) {
+              mjs = full;
+              break;
+            }
+          }
+          if (mjs) break;
+        }
+        if (!mjs) return null;
+        return `\0estk-raw:${m[1]}\0${mjs}`;
+      },
+      load(id) {
+        if (!id.startsWith("\0estk-raw:")) return null;
+        const rest = id.slice("\0estk-raw:".length);
+        const sep = rest.indexOf("\0");
+        const name = rest.slice(0, sep);
+        const spec = JSON.stringify(rest.slice(sep + 1));
+        return (
+          `export { ${name} as default } from ${spec};\n` +
+          `export * from ${spec};\n`
+        );
+      },
+    },
     {
       // lucide-react ships ~1500 icons but the app uses ~130. The barrel is not
       // tree-shaken (the directory alias hides the package's sideEffects:false,
@@ -2202,6 +2259,63 @@ export const INVALID_TRACER_PROVIDER = {};
             return generateNodeBuiltinStub(
               id.slice("\0node-stub:".length),
               _require,
+            );
+          },
+        },
+        {
+          // es-toolkit@1.47 `./compat/*` is CJS-only and its CJS impl names a
+          // local `require_isUnsafeProperty` that collides with the dep
+          // optimizer's CJS-interop helper -> self-shadowing
+          // `var require_isUnsafeProperty = require_isUnsafeProperty()` (TDZ ->
+          // "is not a function") -> blank app. Resolve each
+          // `es-toolkit/compat/<name>` to its ESM `dist/compat/**/<name>.mjs`
+          // and re-export the named binding as default so the optimizer never
+          // touches the broken CJS path. (Raw-serve counterpart is in `plugins`.)
+          name: "es-toolkit-compat-esm-optimize",
+          resolveId(source, importer) {
+            const m = /^es-toolkit\/compat\/([A-Za-z0-9_]+)$/.exec(source);
+            if (!m) return null;
+            let dir = null;
+            try {
+              const req = createRequire(
+                importer || path.join(elizaRoot, "node_modules", "x.js"),
+              );
+              dir = path.dirname(req.resolve("es-toolkit/package.json"));
+            } catch {
+              return null;
+            }
+            const stack = [path.join(dir, "dist", "compat")];
+            let mjs = null;
+            while (stack.length) {
+              const d = stack.pop();
+              let entries;
+              try {
+                entries = fs.readdirSync(d, { withFileTypes: true });
+              } catch {
+                continue;
+              }
+              for (const ent of entries) {
+                const full = path.join(d, ent.name);
+                if (ent.isDirectory()) stack.push(full);
+                else if (ent.name === `${m[1]}.mjs`) {
+                  mjs = full;
+                  break;
+                }
+              }
+              if (mjs) break;
+            }
+            if (!mjs) return null;
+            return `\0estk-compat:${m[1]}\0${mjs}`;
+          },
+          load(id) {
+            if (!id.startsWith("\0estk-compat:")) return null;
+            const rest = id.slice("\0estk-compat:".length);
+            const sep = rest.indexOf("\0");
+            const name = rest.slice(0, sep);
+            const spec = JSON.stringify(rest.slice(sep + 1));
+            return (
+              `export { ${name} as default } from ${spec};\n` +
+              `export * from ${spec};\n`
             );
           },
         },


### PR DESCRIPTION
## Symptom

The dashboard app (`packages/app`) renders a **blank screen** when a route pulls in `recharts` (e.g. via the `@elizaos/ui` chart wrapper). The console shows one of two errors depending on whether Vite pre-bundles recharts on that boot:

- pre-bundled: `Uncaught (in promise) TypeError: require_isUnsafeProperty is not a function` at `recharts.js`
- served raw: `SyntaxError: The requested module '.../es-toolkit/compat/get.js' does not provide an export named 'default'`

## Root cause

`recharts@3.8.1` default-imports 11 `es-toolkit/compat/<name>` subpaths (`get`, `omit`, `sortBy`, `throttle`, `last`, `maxBy`, `minBy`, `range`, `sumBy`, `uniqBy`, `isPlainObject`).

`es-toolkit@1.47`'s `package.json` `exports` map gives `./compat/*` **only a CJS condition** (no `import`/ESM):

```jsonc
"./compat/*": { "default": { "types": "./compat/*.d.ts", "default": "./compat/*.js" } }
```

So Vite resolves those imports to es-toolkit's CJS `compat/<name>.js`. Two failure modes:

1. **Pre-bundled** — the dep optimizer bundles the transitive CJS `dist/compat/**/<name>.js`, whose source declares a local `const require_isUnsafeProperty = require(...)`. That name collides with the optimizer's own CJS-interop init helper, emitting a self-shadowing `var require_isUnsafeProperty = require_isUnsafeProperty()` → TDZ → "is not a function".
2. **Served raw** — the CJS shim has no ESM `default` export Vite can surface → "does not provide an export named 'default'".

The real root cause is the es-toolkit packaging (`./compat/*` should also offer an `import` condition pointing at the `.mjs` output). This PR is a consumer-side workaround until that lands.

## Fix

Add a small resolver on **both** serve paths Vite may use:

- the top-level `plugins` array (raw-serve path), and
- `optimizeDeps.rolldownOptions.plugins` (optimizer path),

that rewrites each `es-toolkit/compat/<name>` to its real ESM `dist/compat/**/<name>.mjs` (located relative to the **importer**, so the es-toolkit version recharts actually depends on is used) and emits a tiny virtual module re-exporting the named binding as `default` (+ `export *`), matching how recharts consumes it. Covering both paths keeps it correct whether or not Vite pre-bundles recharts on a given boot.

## Verification

Booted the app dev server (WSL, packages-mode, Vite v8/Rolldown); the recharts-bearing routes that previously blanked now render, and the `es-toolkit/compat/get` request resolves to the rewritten ESM virtual module (HTTP 200, valid JS) instead of the CJS shim.

Context: hit while booting elizaOS locally to spawn a Claude Code sub-agent (see elizaOS/eliza#8124).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
