### PR TITLE
feat(plugin-task-coordinator): sync odysseus UI to latest upstream (1:1 parity)

### DIFF
--- a/plugins/plugin-task-coordinator/src/odysseus/BgEffect.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/BgEffect.tsx
@@ -715,11 +715,11 @@ export function BgEffect({ pattern }: { pattern: string }): ReactNode {
 
   useEffect(() => {
     const canvas = ref.current;
-    if (!canvas || !(pattern in ANIMATIONS)) return;
+    if (!canvas || !Object.hasOwn(ANIMATIONS, pattern)) return;
     return ANIMATIONS[pattern as CanvasPattern](canvas);
   }, [pattern]);
 
-  if (!(pattern in ANIMATIONS)) return null;
+  if (!Object.hasOwn(ANIMATIONS, pattern)) return null;
   // Decorative, pointer-events:none layer. tabIndex={-1} keeps it out of the
   // tab order so aria-hidden is valid (odysseus hides it from assistive tech
   // so screen readers don't announce an empty canvas).

--- a/plugins/plugin-task-coordinator/src/odysseus/CalendarView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/CalendarView.tsx
@@ -200,6 +200,61 @@ function calColor(ev: CalEvent, calendars: LocalCalendar[]): string {
   return c ? c.color : "var(--accent)";
 }
 
+// odysseus calendar/utils.js `_calReadableTextColor` (+ `_hexToRgb`,
+// `_relativeLuminance`, `_contrastRatio`). Given an event's background colour,
+// pick a foreground (near-black ink or white) with the better WCAG contrast so
+// chip text stays legible on any calendar colour. Non-hex backgrounds (e.g. the
+// `var(--accent)` palette slot) aren't parseable, so we defer to the theme `fg`.
+function hexToRgb(c: string): { r: number; g: number; b: number } | null {
+  const m = c.trim().match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+  if (!m) return null;
+  const hex =
+    m[1].length === 3
+      ? m[1]
+          .split("")
+          .map((ch) => ch + ch)
+          .join("")
+      : m[1];
+  return {
+    r: Number.parseInt(hex.slice(0, 2), 16),
+    g: Number.parseInt(hex.slice(2, 4), 16),
+    b: Number.parseInt(hex.slice(4, 6), 16),
+  };
+}
+
+function relativeLuminance({
+  r,
+  g,
+  b,
+}: {
+  r: number;
+  g: number;
+  b: number;
+}): number {
+  const coeff = [0.2126, 0.7152, 0.0722];
+  return [r, g, b]
+    .map((v) => {
+      const c = v / 255;
+      return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+    })
+    .reduce((sum, c, i) => sum + c * coeff[i], 0);
+}
+
+function contrastRatio(a: number, b: number): number {
+  const light = Math.max(a, b);
+  const dark = Math.min(a, b);
+  return (light + 0.05) / (dark + 0.05);
+}
+
+function readableTextColor(bg: string): string {
+  const rgb = hexToRgb(bg);
+  if (!rgb) return "var(--fg)";
+  const lum = relativeLuminance(rgb);
+  const white = contrastRatio(lum, 1);
+  const ink = contrastRatio(lum, 0.006);
+  return ink >= white ? "#111820" : "#ffffff";
+}
+
 function newUid(): string {
   return `ev-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
@@ -1353,18 +1408,21 @@ export function CalendarView({
                 <span className="od-cal-wk-dt">{d.getDate()}</span>
               </div>
               <div className="od-cal-wk-allday">
-                {allDayEvents.map((ev) => (
-                  <button
-                    type="button"
-                    className="od-cal-wk-allday-event"
-                    key={ev.uid}
-                    style={{ background: calColor(ev, calendars) }}
-                    title={ev.summary}
-                    onClick={() => openEdit(ev)}
-                  >
-                    {ev.summary}
-                  </button>
-                ))}
+                {allDayEvents.map((ev) => {
+                  const bg = calColor(ev, calendars);
+                  return (
+                    <button
+                      type="button"
+                      className="od-cal-wk-allday-event"
+                      key={ev.uid}
+                      style={{ background: bg, color: readableTextColor(bg) }}
+                      title={ev.summary}
+                      onClick={() => openEdit(ev)}
+                    >
+                      {ev.summary}
+                    </button>
+                  );
+                })}
               </div>
               <div
                 className="od-cal-wk-grid"

--- a/plugins/plugin-task-coordinator/src/odysseus/ChatContainer.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/ChatContainer.tsx
@@ -91,7 +91,11 @@ export function ChatContainer({
           </div>
         </div>
       ) : (
-        <ChatMessages conversation={conversation} locale={locale} />
+        <ChatMessages
+          conversation={conversation}
+          locale={locale}
+          sending={sending}
+        />
       )}
       <Composer
         input={input}

--- a/plugins/plugin-task-coordinator/src/odysseus/ChatMessages.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/ChatMessages.tsx
@@ -93,9 +93,14 @@ function AgentFooter({ content }: { content: string }): ReactNode {
 export function ChatMessages({
   conversation,
   locale,
+  sending,
 }: {
   conversation: ConversationBlock[];
   locale?: string;
+  // Reply-in-flight flag (the React analogue of odysseus chat.js `isStreaming`).
+  // While true the history is marked aria-busy so screen readers wait for the
+  // settled response instead of announcing every streamed token.
+  sending?: boolean;
 }): ReactNode {
   const scrollRef = useRef<HTMLDivElement>(null);
   const stickToBottom = useRef(true);
@@ -126,7 +131,12 @@ export function ChatMessages({
   }, [conversation.length, lastBlock?.key, lastContentLen]);
 
   return (
-    <div className="od-chat-history" ref={scrollRef} onScroll={onScroll}>
+    <div
+      className="od-chat-history"
+      ref={scrollRef}
+      onScroll={onScroll}
+      aria-busy={sending ? "true" : "false"}
+    >
       {conversation.map((block) => {
         if (block.kind === "user")
           return <UserBubble key={block.key} block={block} locale={locale} />;

--- a/plugins/plugin-task-coordinator/src/odysseus/ChatMessages.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/ChatMessages.tsx
@@ -114,21 +114,26 @@ export function ChatMessages({
 
   // While a reply streams, deltas coalesce into the same trailing block (stable
   // key, unchanged length), so length+key alone never re-fire the stick-to-
-  // bottom effect and a pinned reader stops following. Track the trailing
-  // block's text length too so the effect re-runs as its content grows.
+  // bottom effect and a pinned reader stops following. Track a per-kind growth
+  // signal so the effect re-runs as the trailing block's content grows: user/
+  // agent carry `content`, reasoning/notice carry `text`, and a trailing tool
+  // card grows under a stable key via its output + status (neither content nor
+  // text), so derive its signal from output length and the latest status.
   const lastBlock = conversation[conversation.length - 1];
-  const lastContentLen =
+  const lastContentSignal =
     lastBlock && "content" in lastBlock
       ? lastBlock.content.length
       : lastBlock && "text" in lastBlock
         ? lastBlock.text.length
-        : 0;
+        : lastBlock && lastBlock.kind === "tool"
+          ? `${lastBlock.tool.output?.length ?? 0}:${lastBlock.tool.status}`
+          : 0;
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: the derived signals below are the intended triggers
   useEffect(() => {
     const el = scrollRef.current;
     if (el && stickToBottom.current) el.scrollTop = el.scrollHeight;
-  }, [conversation.length, lastBlock?.key, lastContentLen]);
+  }, [conversation.length, lastBlock?.key, lastContentSignal]);
 
   return (
     <div

--- a/plugins/plugin-task-coordinator/src/odysseus/Composer.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/Composer.tsx
@@ -16,8 +16,8 @@
 // the odysseus slash rows for those toggles — but the ones with no orchestrator
 // backend are rendered INERT/disabled with an honest title rather than wired to
 // a no-op (no fabricated behaviour, no dead-but-clickable rows). Controls that DO
-// map to a real handler (new chat / clear / search / open Brain·Notes·Theme·
-// Settings / open Models) are fully active. The Agent|Chat toggle is a faithful
+// map to a real handler (new chat / search / open Brain·Notes·Theme·Settings /
+// open Models) are fully active. The Agent|Chat toggle is a faithful
 // local visual control (the orchestrator has a single message path), defaulting
 // to "Chat" to match the captured odysseus frame.
 
@@ -135,10 +135,11 @@ export function Composer({
   // slashCommands.js COMMANDS — the same set/order the real frame renders:
   // /new, /web, /doc, /todo, /demo, /note, /fork, /bash (then /clear, /memory,
   // /settings below the fold). Rows whose target surface exists in the clone are
-  // wired to a real Composer prop (onNewChat / onInput / onSearch / onOpenPanel
-  // / onOpenModels); odysseus's quick-toggle / todo / tour / fork rows have no
-  // orchestrator backend, so they render faithfully but DISABLED with an honest
-  // title — not omitted (1:1 chrome), not faked. Memoized on the wired handlers.
+  // wired to a real Composer prop (onNewChat / onSearch / onOpenPanel /
+  // onOpenModels); odysseus's quick-toggle / todo / tour / fork / clear rows have
+  // no orchestrator backend, so they render faithfully but DISABLED with an
+  // honest title — not omitted (1:1 chrome), not faked. Memoized on the wired
+  // handlers.
   const commands = useMemo<SlashCommand[]>(
     () => [
       {
@@ -212,14 +213,21 @@ export function Composer({
         disabled: true,
         note: NO_BACKEND,
       },
-      // ── below-the-fold rows (MAX_VISIBLE cap) — wired to real surfaces ──
+      // ── below-the-fold rows (MAX_VISIBLE cap) — mostly wired to real surfaces
+      //    (/clear has no orchestrator backend, so it stays disabled) ──
       {
+        // Odysseus's /clear wipes the chat display surface; the orchestrator
+        // room is read-only (no clear-display path), so this renders faithfully
+        // but inert. Wiring it to onInput("") only clears the composer (which
+        // runCommand already does pre-run), making it a silent no-op — disabled
+        // is the honest treatment, matching the other no-backend rows.
         token: "/clear",
         aliases: ["/chats clear"],
         category: "Chats",
         help: "Clear chat display",
         usage: "/clear",
-        run: () => onInput(""),
+        disabled: true,
+        note: NO_BACKEND,
       },
       {
         token: "/memory",
@@ -283,7 +291,7 @@ export function Composer({
         run: () => onOpenPanel("settings"),
       },
     ],
-    [onNewChat, onInput, onSearch, onOpenPanel, onOpenModels],
+    [onNewChat, onSearch, onOpenPanel, onOpenModels],
   );
 
   // Trigger only when the message starts with "/" (no leading space) and has no
@@ -330,10 +338,11 @@ export function Composer({
         setSel((s) => (s - 1 + visible.length) % visible.length);
         return;
       }
-      // Tab always runs the selected row. Enter runs it too, EXCEPT when the
-      // typed text already exactly matches a command token/alias — then the
-      // popup is in "ready to submit a typed-out command" mode and Enter falls
-      // through to the normal submit path (slashAutocomplete.js exactHit).
+      // Tab always inserts/runs the highlighted row. Enter runs the highlighted
+      // row while still completing; once the typed text exactly matches a
+      // command token/alias (slashAutocomplete.js exactHit), Enter runs THAT
+      // command if it's wired, and only falls through to onSubmit() for a
+      // disabled / non-command row.
       if (event.key === "Tab") {
         event.preventDefault();
         runCommand(visible[selClamped]);
@@ -341,14 +350,26 @@ export function Composer({
       }
       if (event.key === "Enter" && !event.shiftKey) {
         const typed = query;
-        const exactHit =
-          typed !== null &&
-          visible.some(
-            (entry) => entry.token === typed || entry.aliases.includes(typed),
-          );
-        if (!exactHit) {
+        const matchedEntry =
+          typed === null
+            ? undefined
+            : visible.find(
+                (entry) =>
+                  entry.token === typed || entry.aliases.includes(typed),
+              );
+        if (!matchedEntry) {
+          // Still in completion mode — Enter runs the highlighted row.
           event.preventDefault();
           runCommand(visible[selClamped]);
+          return;
+        }
+        // The typed text exactly matches a command. If it's a wired row, run it
+        // (odysseus's submit path parses and executes the slash — here our
+        // onSubmit() would post the literal "/new" as a chat message instead).
+        // Only a disabled / non-command row falls through to onSubmit().
+        if (!matchedEntry.disabled && matchedEntry.run) {
+          event.preventDefault();
+          runCommand(matchedEntry);
           return;
         }
       }

--- a/plugins/plugin-task-coordinator/src/odysseus/Composer.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/Composer.tsx
@@ -358,7 +358,13 @@ export function Composer({
         return;
       }
     }
-    if (event.key === "Enter" && !event.shiftKey) {
+    // Enter confirming an IME composition must not submit (chat.js keydown
+    // guards submit with !e.isComposing).
+    if (
+      event.key === "Enter" &&
+      !event.shiftKey &&
+      !event.nativeEvent.isComposing
+    ) {
       event.preventDefault();
       onSubmit();
     }

--- a/plugins/plugin-task-coordinator/src/odysseus/CookbookView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/CookbookView.tsx
@@ -52,6 +52,7 @@ import {
 import { useEscapeClose } from "./hooks/useEscapeClose";
 import { useWindowControls } from "./hooks/useWindowControls";
 import { ResizeHandles } from "./ResizeHandles";
+import { PREF_KEYS, readPref, writePref } from "./util/storage";
 
 // cookbook.js tab row (lines 1427-1432). data-backend "Search" is the Download
 // tab in odysseus's internal naming; we use the visible labels.
@@ -90,6 +91,7 @@ const QUANT_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
   { value: "AWQ-4bit", label: "AWQ" },
   { value: "FP8", label: "FP8" },
   { value: "FP4", label: "FP4" },
+  { value: "NVFP4", label: "NVFP4" },
   { value: "", label: "Native" },
 ];
 
@@ -101,6 +103,21 @@ const ENGINE_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
   { value: "vllm", label: "vLLM" },
   { value: "sglang", label: "SGLang" },
 ];
+
+// hwfit context-length range slider (cookbook-hwfit.js _CTX_PRESETS). The
+// slider indexes into these presets; 0 = the model's own max ("Max"). Default
+// index is 3 (50k). On change odysseus persists the chosen ctx, forces the sort
+// to fit-descending, and re-runs the scan.
+const CTX_PRESETS: ReadonlyArray<number> = [
+  8192, 16384, 32768, 50000, 131072, 0,
+];
+const CTX_DEFAULT_INDEX = 3;
+
+// cookbook-hwfit.js _ctxLabel: 0 → "Max"; ≥1000 → "<n>k"; else the raw value.
+function ctxLabel(value: number): string {
+  if (!value) return "Max";
+  return value >= 1000 ? `${Math.round(value / 1000)}k` : String(value);
+}
 
 // Serve-tab sort select (cookbook.js serve-sort).
 const SERVE_SORT_OPTIONS: ReadonlyArray<{ value: string; label: string }> = [
@@ -169,8 +186,24 @@ interface FitRow {
   vramGb: number;
   contextK: number | null;
   mode: string;
+  modeTitle: string;
   fit: HardwareFit;
   fitRank: number;
+}
+
+// cookbook-hwfit.js _requiresAcceleratorBackend: accelerator-only safetensors
+// quants (AWQ / GPTQ / FP8 / NVFP4) can't run under llama.cpp/Ollama (which need
+// GGUF) — they require vLLM or SGLang with a visible CUDA/ROCm accelerator. We
+// match the same set against the model's compact quant tag and display name,
+// the eliza analogues of upstream's quant/name/repo fields.
+const ACCEL_MODE_TITLE =
+  "Requires vLLM or SGLang with a visible CUDA/ROCm accelerator. " +
+  "llama.cpp and Ollama need GGUF files.";
+
+function requiresAcceleratorBackend(name: string, quant: string): boolean {
+  const q = quant.toUpperCase();
+  if (/^(AWQ|GPTQ|NVFP4)/.test(q) || q === "FP8") return true;
+  return /\b(awq|gptq|fp8|nvfp4)\b/i.test(name);
 }
 
 // Compact tabular quant tag for the scan table's fixed-width QUANT column. The
@@ -190,16 +223,20 @@ function compactQuant(model: CatalogModel): string {
 
 function toFitRow(model: CatalogModel, probe: HardwareProbe): FitRow {
   const fit = classifyFit(probe, model);
+  const name = model.displayName || model.id;
+  const quant = compactQuant(model);
+  const accel = requiresAcceleratorBackend(name, quant);
   return {
     id: model.id,
-    name: model.displayName || model.id,
+    name,
     params: model.parameterLabel || model.params,
-    quant: compactQuant(model),
+    quant,
     vramGb: model.sizeGb,
     contextK: model.contextLength
       ? Math.round(model.contextLength / 1024)
       : null,
-    mode: probe.gpu ? probe.gpu.backend : "cpu only",
+    mode: accel ? "vLLM/SGLang" : probe.gpu ? probe.gpu.backend : "cpu only",
+    modeTitle: accel ? ACCEL_MODE_TITLE : "",
     fit,
     fitRank: FIT_LEVEL_META[fit].rank,
   };
@@ -266,6 +303,15 @@ export function CookbookView({
   // FIT is the default-active sorted column upstream.
   const [fitSort, setFitSort] = useState("fit");
   const [fitReverse, setFitReverse] = useState(false);
+  // Ctx target-context slider (cookbook-hwfit.js). Persisted as the preset value;
+  // we map it back to a slider index, falling back to the default (50k) when no
+  // saved value or an unknown one is stored.
+  const [ctxIndex, setCtxIndex] = useState(() => {
+    const saved = readPref<number | null>(PREF_KEYS.hwfitContext, null);
+    if (saved == null) return CTX_DEFAULT_INDEX;
+    const idx = CTX_PRESETS.indexOf(saved);
+    return idx >= 0 ? idx : CTX_DEFAULT_INDEX;
+  });
 
   // Serve tab toolbar state.
   const [serveSort, setServeSort] = useState("name");
@@ -366,6 +412,17 @@ export function CookbookView({
         /* download failed to enqueue — the input stays so the user can retry */
       })
       .finally(() => setDownloading(false));
+  };
+
+  // cookbook-hwfit.js context slider change: persist the chosen preset, force the
+  // sort to fit-descending (best-fit first), and re-run the scan against the new
+  // context budget. Mirrors the upstream `change` handler's persist → sort → fetch.
+  const onCtxChange = (index: number) => {
+    setCtxIndex(index);
+    writePref(PREF_KEYS.hwfitContext, CTX_PRESETS[index]);
+    setFitSort("fit");
+    setFitReverse(false);
+    loadHardware();
   };
 
   // cookbook-hwfit.js header click: clicking the active column flips direction,
@@ -681,6 +738,35 @@ export function CookbookView({
                       </option>
                     ))}
                   </select>
+                  <span
+                    className="od-cb-help-chip"
+                    title="Higher numbers usually mean better quality, but they need more memory. Lower numbers fit on more hardware."
+                  >
+                    ?
+                  </span>
+                  {/* Ctx target-context slider (cookbook-hwfit.js #hwfit-context) */}
+                  <label
+                    className="od-cb-ctx-control"
+                    title="Context length for fit estimates. Lower it to find more models that could fit your hardware."
+                  >
+                    <span>Ctx</span>
+                    <span
+                      className="od-cb-help-chip od-cb-help-chip-inline"
+                      title="Context length. Lower it to find more models that could fit your hardware; raise it when you need longer chats or documents."
+                    >
+                      ?
+                    </span>
+                    <input
+                      type="range"
+                      min={0}
+                      max={CTX_PRESETS.length - 1}
+                      step={1}
+                      value={ctxIndex}
+                      onChange={(e) => onCtxChange(Number(e.target.value))}
+                      aria-label="Target context length"
+                    />
+                    <output>{ctxLabel(CTX_PRESETS[ctxIndex])}</output>
+                  </label>
                 </div>
 
                 {/* Toolbar row 2: server / RESCAN / EDIT */}
@@ -804,7 +890,10 @@ export function CookbookView({
                         </span>
                         <span className="od-cb-fit-col od-cb-fit-speed">—</span>
                         <span className="od-cb-fit-col od-cb-fit-score">—</span>
-                        <span className="od-cb-fit-col od-cb-fit-mode">
+                        <span
+                          className="od-cb-fit-col od-cb-fit-mode"
+                          title={row.modeTitle || undefined}
+                        >
                           {row.mode}
                         </span>
                       </div>

--- a/plugins/plugin-task-coordinator/src/odysseus/CookbookView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/CookbookView.tsx
@@ -47,6 +47,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useEscapeClose } from "./hooks/useEscapeClose";
@@ -144,8 +145,11 @@ const FIT_COLUMNS: ReadonlyArray<FitColumn> = [
   { sortKey: null, label: "Quant", cls: "od-cb-fit-quant" },
   { sortKey: "vram", label: "VRAM", cls: "od-cb-fit-vram" },
   { sortKey: "context", label: "Ctx", cls: "od-cb-fit-ctx" },
-  { sortKey: "speed", label: "Speed", cls: "od-cb-fit-speed" },
-  { sortKey: "score", label: "Score", cls: "od-cb-fit-score" },
+  // Speed (t/s) and Score have no eliza benchmark — the columns always render
+  // "—" and compareFitRows has no case for them, so the headers are not
+  // sortable (sortKey: null, like Model/Quant/Mode).
+  { sortKey: null, label: "Speed", cls: "od-cb-fit-speed" },
+  { sortKey: null, label: "Score", cls: "od-cb-fit-score" },
   { sortKey: null, label: "Mode", cls: "od-cb-fit-mode" },
 ];
 
@@ -298,7 +302,6 @@ export function CookbookView({
   const [downloading, setDownloading] = useState(false);
   const [usecase, setUsecase] = useState("");
   const [scanQuery, setScanQuery] = useState("");
-  const [quant, setQuant] = useState("Q4_K_M");
   const [engine, setEngine] = useState("");
   // FIT is the default-active sorted column upstream.
   const [fitSort, setFitSort] = useState("fit");
@@ -342,17 +345,33 @@ export function CookbookView({
     data: [],
   });
 
+  // Monotonic request token so a rapid RESCAN can't let a slower earlier probe
+  // resolve after a newer one and clobber fresher hardware/catalog data.
+  const hwReqToken = useRef(0);
   const loadHardware = useCallback(() => {
+    const token = ++hwReqToken.current;
     setHardware((p) => ({ status: "loading", data: p.data }));
     setCatalog((p) => ({ status: "loading", data: p.data }));
     void client
       .getLocalInferenceHardware()
-      .then((probe) => setHardware({ status: "ready", data: probe }))
-      .catch(() => setHardware({ status: "error", data: null }));
+      .then((probe) => {
+        if (token !== hwReqToken.current) return;
+        setHardware({ status: "ready", data: probe });
+      })
+      .catch(() => {
+        if (token !== hwReqToken.current) return;
+        setHardware({ status: "error", data: null });
+      });
     void client
       .getLocalInferenceCatalog()
-      .then((r) => setCatalog({ status: "ready", data: r.models }))
-      .catch(() => setCatalog({ status: "error", data: [] }));
+      .then((r) => {
+        if (token !== hwReqToken.current) return;
+        setCatalog({ status: "ready", data: r.models });
+      })
+      .catch(() => {
+        if (token !== hwReqToken.current) return;
+        setCatalog({ status: "error", data: [] });
+      });
   }, []);
 
   const loadInstalled = useCallback(() => {
@@ -414,15 +433,16 @@ export function CookbookView({
       .finally(() => setDownloading(false));
   };
 
-  // cookbook-hwfit.js context slider change: persist the chosen preset, force the
-  // sort to fit-descending (best-fit first), and re-run the scan against the new
-  // context budget. Mirrors the upstream `change` handler's persist → sort → fetch.
+  // cookbook-hwfit.js context slider change: persist the chosen preset and force
+  // the sort to fit-descending (best-fit first). Upstream also re-runs the scan
+  // against the new context budget, but eliza's classifyFit is not context-aware
+  // (the runtime contract has no per-context fit probe), so re-probing would
+  // change nothing — we persist + sort only and disable the slider below.
   const onCtxChange = (index: number) => {
     setCtxIndex(index);
     writePref(PREF_KEYS.hwfitContext, CTX_PRESETS[index]);
     setFitSort("fit");
     setFitReverse(false);
-    loadHardware();
   };
 
   // cookbook-hwfit.js header click: clicking the active column flips direction,
@@ -453,11 +473,30 @@ export function CookbookView({
             m.hfRepo.toLowerCase().includes(q)
           : true,
       )
-      .map((m) => toFitRow(m, probe));
+      .map((m) => toFitRow(m, probe))
+      // Engine filter (cookbook-hwfit.js _applyEngineFilter). FitRow.mode already
+      // classifies the backend: accelerator-only quants → "vLLM/SGLang", the
+      // rest run under llama.cpp/Ollama. vLLM/SGLang select the accel rows;
+      // llama.cpp selects the GGUF rows.
+      .filter((row) =>
+        engine === "vllm" || engine === "sglang"
+          ? row.mode === "vLLM/SGLang"
+          : engine === "llamacpp"
+            ? row.mode !== "vLLM/SGLang"
+            : true,
+      );
     const dir = fitReverse ? -1 : 1;
     rows.sort((a, b) => dir * compareFitRows(a, b, fitSort));
     return rows;
-  }, [hardware.data, catalog.data, scanQuery, usecase, fitSort, fitReverse]);
+  }, [
+    hardware.data,
+    catalog.data,
+    scanQuery,
+    usecase,
+    engine,
+    fitSort,
+    fitReverse,
+  ]);
 
   const installedRows = useMemo(() => {
     const q = serveQuery.trim().toLowerCase();
@@ -715,9 +754,10 @@ export function CookbookView({
                   />
                   <select
                     className="od-cb-field-input od-cb-quant"
-                    value={quant}
-                    onChange={(e) => setQuant(e.target.value)}
+                    value="Q4_K_M"
                     aria-label="Quantization"
+                    title="eliza's catalog ships one GGUF variant per tier, so quant can't narrow the scan here."
+                    disabled
                   >
                     {QUANT_OPTIONS.map((o) => (
                       <option key={o.label} value={o.value}>
@@ -744,15 +784,17 @@ export function CookbookView({
                   >
                     ?
                   </span>
-                  {/* Ctx target-context slider (cookbook-hwfit.js #hwfit-context) */}
+                  {/* Ctx target-context slider (cookbook-hwfit.js #hwfit-context).
+                      Disabled: eliza's fit estimate isn't context-aware, so the
+                      chosen context can't change which models fit. */}
                   <label
                     className="od-cb-ctx-control"
-                    title="Context length for fit estimates. Lower it to find more models that could fit your hardware."
+                    title="Context length. eliza's fit estimate isn't context-aware in this runtime, so the chosen context doesn't change which models fit."
                   >
                     <span>Ctx</span>
                     <span
                       className="od-cb-help-chip od-cb-help-chip-inline"
-                      title="Context length. Lower it to find more models that could fit your hardware; raise it when you need longer chats or documents."
+                      title="Context length. eliza's fit estimate isn't context-aware in this runtime, so the chosen context doesn't change which models fit."
                     >
                       ?
                     </span>
@@ -764,6 +806,8 @@ export function CookbookView({
                       value={ctxIndex}
                       onChange={(e) => onCtxChange(Number(e.target.value))}
                       aria-label="Target context length"
+                      title="eliza's fit estimate isn't context-aware in this runtime, so the chosen context doesn't change which models fit."
+                      disabled
                     />
                     <output>{ctxLabel(CTX_PRESETS[ctxIndex])}</output>
                   </label>

--- a/plugins/plugin-task-coordinator/src/odysseus/DocumentLibraryView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/DocumentLibraryView.tsx
@@ -171,12 +171,28 @@ export function DocumentLibraryView({
   const [bulkRunning, setBulkRunning] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+  // The currently-open per-card menu and the bulk-actions dropdown each mount a
+  // single wrapper at a time; refs let the outside-click effect tell an inside
+  // pointerdown from an outside one.
+  const cardMenuRef = useRef<HTMLSpanElement>(null);
+  const bulkActionsRef = useRef<HTMLDivElement>(null);
 
-  const load = useCallback(() => {
+  // The query is wired server-side (DocumentListOptions.query → the `q` param in
+  // buildDocumentListParams), matching odysseus's documents tab which sends the
+  // search term to the backend (documentLibrary.js:315). Client-side filtering
+  // alone would only ever match within the first loaded page; with >PAGE_SIZE
+  // docs a term matching an unloaded doc would wrongly read "No documents
+  // match". So load() forwards the trimmed query and resets the page.
+  const load = useCallback((searchQuery: string) => {
+    const trimmed = searchQuery.trim();
     setLoading(true);
     setFailed(false);
     void client
-      .listDocuments({ limit: PAGE_SIZE, offset: 0 })
+      .listDocuments({
+        query: trimmed || undefined,
+        limit: PAGE_SIZE,
+        offset: 0,
+      })
       .then((r) => {
         setDocs(r.documents);
         setTotal(r.total);
@@ -206,14 +222,46 @@ export function DocumentLibraryView({
     setSelectedIds(new Set());
     setActionsOpen(false);
     inputRef.current?.focus();
-    load();
-  }, [open, load]);
+  }, [open]);
+
+  // Debounce the query into a server-side refetch (offset reset to 0) so a term
+  // matching a doc past the first page still surfaces. This also drives the
+  // initial load: opening (or reopening, which resets query to "") flips a dep
+  // here. Client-side filtering below stays as a refinement of the loaded set,
+  // and client sort stays client-side (listDocuments has no sort param).
+  useEffect(() => {
+    if (!open) return;
+    const handle = setTimeout(() => load(query), 250);
+    return () => clearTimeout(handle);
+  }, [open, query, load]);
+
+  // Dismiss an open per-card menu / bulk-actions dropdown on an outside click —
+  // neither has an intrinsic dismissal otherwise. Only registered while a menu
+  // is open; a pointerdown outside the open wrapper closes it.
+  const menuOpen = menuId !== null || actionsOpen;
+  useEffect(() => {
+    if (!menuOpen) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target instanceof Node ? e.target : null;
+      if (target && cardMenuRef.current?.contains(target)) return;
+      if (target && bulkActionsRef.current?.contains(target)) return;
+      setMenuId(null);
+      setActionsOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [menuOpen]);
 
   const loadMore = () => {
     if (loading || docs.length >= total) return;
     setLoading(true);
+    const trimmed = query.trim();
     void client
-      .listDocuments({ limit: PAGE_SIZE, offset: docs.length })
+      .listDocuments({
+        query: trimmed || undefined,
+        limit: PAGE_SIZE,
+        offset: docs.length,
+      })
       .then((r) => {
         setDocs((prev) => [...prev, ...r.documents]);
         setTotal(r.total);
@@ -307,7 +355,7 @@ export function DocumentLibraryView({
       })
       .then(() => {
         setCreating(false);
-        load();
+        load(query);
       })
       .catch(() => {
         setCreating(false);
@@ -337,7 +385,7 @@ export function DocumentLibraryView({
           reader.readAsText(file);
         }),
     );
-    void Promise.all(reads).then(load);
+    void Promise.all(reads).then(() => load(query));
   };
 
   // odysseus libraryEnterSelectMode / libraryExitSelectMode (1089-1110).
@@ -634,7 +682,7 @@ export function DocumentLibraryView({
                 <span className="od-doclib-bulk-count">
                   {selectedIds.size} Selected
                 </span>
-                <div className="od-doclib-bulk-actions">
+                <div className="od-doclib-bulk-actions" ref={bulkActionsRef}>
                   <button
                     type="button"
                     className="od-doclib-toolbar-btn"
@@ -783,7 +831,10 @@ export function DocumentLibraryView({
                       </button>
 
                       {!selectMode ? (
-                        <span className="od-doclib-actions">
+                        <span
+                          className="od-doclib-actions"
+                          ref={menuId === doc.id ? cardMenuRef : null}
+                        >
                           <button
                             type="button"
                             className="od-doclib-item-btn"

--- a/plugins/plugin-task-coordinator/src/odysseus/EmailView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/EmailView.tsx
@@ -27,6 +27,7 @@ import {
   Archive,
   Bell,
   Check,
+  Copy,
   Eraser,
   Forward,
   Menu,
@@ -227,6 +228,53 @@ function formatListDate(ts: number): string {
   return d.toLocaleDateString([], { month: "short", day: "numeric" });
 }
 
+// emailLibrary.js _splitRecipientList — split a comma-separated address list
+// while honoring quotes + angle brackets, so '"Doe, John" <j@x>' is one entry
+// and not torn apart on its internal comma (1:1 with the JS scanner).
+function splitRecipientList(raw: string): string[] {
+  const out: string[] = [];
+  let cur = "";
+  let quote = false;
+  let angle = false;
+  const s = raw;
+  for (let i = 0; i < s.length; i += 1) {
+    const ch = s[i];
+    if (ch === '"' && s[i - 1] !== "\\") quote = !quote;
+    else if (ch === "<" && !quote) angle = true;
+    else if (ch === ">" && !quote) angle = false;
+
+    if (ch === "," && !quote && !angle) {
+      const part = cur.trim();
+      if (part) out.push(part);
+      cur = "";
+      continue;
+    }
+    cur += ch;
+  }
+  const tail = cur.trim();
+  if (tail) out.push(tail);
+  return out;
+}
+
+// emailLibrary/utils.js _extractName — the display name from a `Name <addr>`
+// recipient string, falling back to the local-part of the address.
+function extractRecipientName(addr: string): string {
+  const m = addr.match(/^"?([^"<]+?)"?\s*<([^>]+)>\s*$/);
+  if (m) return m[1].trim();
+  const localPart = addr.split("@")[0];
+  return localPart || addr;
+}
+
+// emailLibrary.js _emailAddressFromRecipientText — pull the bare address out of
+// a recipient string (prefer the angle-bracketed form), used by the copy chip.
+function extractRecipientAddress(text: string): string {
+  const raw = text.trim();
+  const angle = raw.match(/<\s*([^<>@\s]+@[^<>\s]+)\s*>/);
+  if (angle) return angle[1].trim();
+  const any = raw.match(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i);
+  return any ? any[0].trim() : raw;
+}
+
 // emailLibrary.js _showLibRemindSubmenu — compute the Later today / Tomorrow /
 // Next week preset dates relative to now (1:1 with the JS math).
 function buildRemindPresets(now: Date): RemindPreset[] {
@@ -385,6 +433,87 @@ class SmoothPad {
   }
 }
 
+// emailLibrary.js _recipientChipHtml + _wireRecipientChips — a From/To/Cc chip
+// that toggles between its display name and the full "Name <addr>" form on
+// click; expanded it reveals a small copy button that writes the bare address
+// to the clipboard, flashes a copied state, and surfaces the "Email copied"
+// toast (here via the parent's onCopied callback). 1:1 with the JS behavior.
+function RecipientChip({
+  full,
+  label,
+  className,
+  onCopied,
+}: {
+  full: string;
+  label: string;
+  className?: string;
+  onCopied: () => void;
+}): ReactNode {
+  const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const revertRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (revertRef.current !== null) clearTimeout(revertRef.current);
+    },
+    [],
+  );
+
+  const fullText = full.trim();
+  const address = extractRecipientAddress(fullText);
+  const labelText = (label || address || fullText).trim();
+  const display = expanded ? fullText || labelText : labelText;
+
+  const onCopy = useCallback(() => {
+    // Guard for non-secure-context / older webviews where clipboard is absent
+    // (mirrors the ChatMessages copy affordance).
+    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText)
+      return;
+    if (!address) return;
+    navigator.clipboard.writeText(address).then(
+      () => {
+        setCopied(true);
+        onCopied();
+        if (revertRef.current !== null) clearTimeout(revertRef.current);
+        revertRef.current = setTimeout(() => setCopied(false), 900);
+      },
+      () => undefined,
+    );
+  }, [address, onCopied]);
+
+  return (
+    <span
+      className={`od-email-recipient-chip${expanded ? " expanded" : ""}${className ? ` ${className}` : ""}`}
+    >
+      <button
+        type="button"
+        className="od-email-recipient-chip-label"
+        title={fullText || labelText}
+        aria-expanded={expanded}
+        onClick={() => setExpanded((v) => !v)}
+      >
+        {display}
+      </button>
+      {expanded ? (
+        <button
+          type="button"
+          className={`od-email-recipient-chip-copy${copied ? " copied" : ""}`}
+          title={copied ? "Copied" : "Copy email"}
+          aria-label={copied ? "Copied" : "Copy email"}
+          onClick={onCopy}
+        >
+          {copied ? (
+            <Check size={11} aria-hidden="true" />
+          ) : (
+            <Copy size={11} aria-hidden="true" />
+          )}
+        </button>
+      ) : null}
+    </span>
+  );
+}
+
 export function EmailView({
   open,
   onClose,
@@ -474,6 +603,33 @@ export function EmailView({
   // starts `collapsed`).
   const [attsExpanded, setAttsExpanded] = useState(false);
 
+  // Transient "Email copied" status surfaced by the recipient-chip copy button
+  // (emailLibrary.js showToast('Email copied')). Mirrors ModelsView's inline
+  // feedback pattern since this view has no separate toast surface.
+  const [feedback, setFeedback] = useState("");
+  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (feedbackTimerRef.current !== null) {
+        clearTimeout(feedbackTimerRef.current);
+      }
+    },
+    [],
+  );
+  const showCopied = useCallback(() => {
+    setFeedback("Email copied");
+    if (feedbackTimerRef.current !== null) {
+      clearTimeout(feedbackTimerRef.current);
+    }
+    feedbackTimerRef.current = setTimeout(() => {
+      setFeedback((cur) => (cur === "Email copied" ? "" : cur));
+    }, 1400);
+  }, []);
+
+  // emailLibrary.js _emailReaderForSelectAllTarget — Ctrl/Cmd+A while the open
+  // reader is focused selects ONLY the reader body, not the whole document.
+  const readerRef = useRef<HTMLDivElement | null>(null);
+
   useEffect(() => {
     if (!open) return;
     setSignatures(readPref<SavedSignature[]>(SIGNATURES_PREF_KEY, []));
@@ -493,6 +649,38 @@ export function EmailView({
     document.addEventListener("click", onDoc, true);
     return () => document.removeEventListener("click", onDoc, true);
   }, [menuUid, bulkMenuOpen]);
+
+  // emailLibrary.js global Ctrl/Cmd+A handler — while an email reader is open,
+  // a select-all selects ONLY the reader body contents, not the whole page,
+  // unless the keystroke originates in an editable field.
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!(e.ctrlKey || e.metaKey) || e.key.toLowerCase() !== "a") return;
+      const reader = readerRef.current;
+      if (!reader?.isConnected) return;
+      const target = e.target;
+      if (
+        target instanceof HTMLElement &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.tagName === "SELECT" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      const sel = window.getSelection();
+      if (!sel) return;
+      const range = document.createRange();
+      range.selectNodeContents(reader);
+      sel.removeAllRanges();
+      sel.addRange(range);
+      e.preventDefault();
+      e.stopPropagation();
+    };
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => document.removeEventListener("keydown", onKeyDown, true);
+  }, [open]);
 
   // Folder list: real IMAP folders would replace this; the single static "Inbox"
   // option is what odysseus shows before a folder fetch lands (emailLibrary.js).
@@ -681,11 +869,20 @@ export function EmailView({
   }, [visibleMessages]);
 
   const runBulk = useCallback(
-    (action: "read" | "unread" | "archive" | "delete") => {
+    (action: "done" | "read" | "unread" | "archive" | "delete") => {
       const uids = Array.from(selectedUids);
       setBulkMenuOpen(false);
       if (uids.length === 0) return;
-      if (action === "read" || action === "unread") {
+      if (action === "done") {
+        // emailLibrary.js _bulkAction('done') — mark answered + read for the
+        // selected uids (fully client-side via the optimistic overrides).
+        setAnsweredOverride((prev) => {
+          const map = new Map(prev);
+          for (const uid of uids) map.set(uid, true);
+          return map;
+        });
+        setReadState(uids, true);
+      } else if (action === "read" || action === "unread") {
         setReadState(uids, action === "read");
       } else if (action === "archive") {
         onArchive?.(uids);
@@ -768,6 +965,11 @@ export function EmailView({
               </span>
             ) : null}
             <span className="od-email-stats">{statsLabel}</span>
+            {feedback ? (
+              <span className="od-email-feedback" role="status">
+                {feedback}
+              </span>
+            ) : null}
           </span>
           <button
             type="button"
@@ -990,6 +1192,14 @@ export function EmailView({
                 </button>
                 {bulkMenuOpen ? (
                   <div className="od-email-dropdown">
+                    <button
+                      type="button"
+                      className="od-email-dropdown-item"
+                      onClick={() => runBulk("done")}
+                    >
+                      <Check size={14} />
+                      <span>Done</span>
+                    </button>
                     <button
                       type="button"
                       className="od-email-dropdown-item"
@@ -1361,9 +1571,7 @@ export function EmailView({
                                       >
                                         <Check size={14} />
                                         <span>
-                                          {answered
-                                            ? "Mark Not Done"
-                                            : "Mark Done"}
+                                          {answered ? "Not Done" : "Done"}
                                         </span>
                                       </button>
                                     ) : null}
@@ -1419,37 +1627,32 @@ export function EmailView({
                       {/* ── Expanded reader (emailLibrary.js doclib-card-expanded
                           → opens the message "as a document" inline) ── */}
                       {isExpanded ? (
-                        <div className="od-email-reader">
+                        <div className="od-email-reader" ref={readerRef}>
                           <div className="od-email-reader-header">
                             <div className="od-email-reader-meta">
                               <div className="od-email-reader-meta-row">
                                 <strong>From:</strong>
                                 <span className="od-email-recipient-chips">
-                                  <span
-                                    className="od-email-recipient-chip"
-                                    title={`${m.fromName} <${m.fromAddress}>`}
-                                  >
-                                    {m.fromName || m.fromAddress}
-                                  </span>
+                                  <RecipientChip
+                                    full={`${m.fromName} <${m.fromAddress}>`}
+                                    label={m.fromName || m.fromAddress}
+                                    className="od-email-recipient-chip-from"
+                                    onCopied={showCopied}
+                                  />
                                 </span>
                               </div>
                               {m.to ? (
                                 <div className="od-email-reader-meta-row">
                                   <strong>To:</strong>
                                   <span className="od-email-recipient-chips">
-                                    {m.to
-                                      .split(",")
-                                      .map((a) => a.trim())
-                                      .filter(Boolean)
-                                      .map((a) => (
-                                        <span
-                                          key={a}
-                                          className="od-email-recipient-chip"
-                                          title={a}
-                                        >
-                                          {a}
-                                        </span>
-                                      ))}
+                                    {splitRecipientList(m.to).map((a) => (
+                                      <RecipientChip
+                                        key={a}
+                                        full={a}
+                                        label={extractRecipientName(a)}
+                                        onCopied={showCopied}
+                                      />
+                                    ))}
                                   </span>
                                 </div>
                               ) : null}
@@ -1457,19 +1660,14 @@ export function EmailView({
                                 <div className="od-email-reader-meta-row">
                                   <strong>Cc:</strong>
                                   <span className="od-email-recipient-chips">
-                                    {m.cc
-                                      .split(",")
-                                      .map((a) => a.trim())
-                                      .filter(Boolean)
-                                      .map((a) => (
-                                        <span
-                                          key={a}
-                                          className="od-email-recipient-chip"
-                                          title={a}
-                                        >
-                                          {a}
-                                        </span>
-                                      ))}
+                                    {splitRecipientList(m.cc).map((a) => (
+                                      <RecipientChip
+                                        key={a}
+                                        full={a}
+                                        label={extractRecipientName(a)}
+                                        onCopied={showCopied}
+                                      />
+                                    ))}
                                   </span>
                                 </div>
                               ) : null}

--- a/plugins/plugin-task-coordinator/src/odysseus/GroupChatView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/GroupChatView.tsx
@@ -157,6 +157,7 @@ export function GroupChatView({
   const [addModel, setAddModel] = useState("");
   const [addLabel, setAddLabel] = useState("");
   const [removingId, setRemovingId] = useState<string | null>(null);
+  const [removeError, setRemoveError] = useState<string | null>(null);
   // "Start" → kick the room with the chosen mode. Honest about delivery (see note).
   const [starting, setStarting] = useState(false);
   const [startError, setStartError] = useState<string | null>(null);
@@ -204,6 +205,7 @@ export function GroupChatView({
     setPicking(false);
     setAddError(null);
     setStartError(null);
+    setRemoveError(null);
     reloadRoom(activeTaskId);
     const unsubscribe = client.streamOrchestratorTask(activeTaskId, () => {
       reloadRoom(activeTaskId);
@@ -258,12 +260,19 @@ export function GroupChatView({
   const removeParticipant = (participant: Participant) => {
     if (!activeTaskId || !participant.sessionId || removingId) return;
     setRemovingId(participant.id);
+    setRemoveError(null);
     void client
       .stopOrchestratorAgent(activeTaskId, participant.sessionId)
-      .catch(() => false)
-      .then(() => {
-        if (activeTaskId) reloadRoom(activeTaskId);
-      })
+      .then(
+        () => {
+          if (activeTaskId) reloadRoom(activeTaskId);
+        },
+        () => {
+          // Don't reload on failure — the row really is still there, so leave
+          // it and surface the error instead of silently re-rendering it back.
+          setRemoveError(`Could not remove ${participant.label}.`);
+        },
+      )
       .finally(() => {
         setRemovingId(null);
       });
@@ -510,6 +519,15 @@ export function GroupChatView({
               ))
             )}
           </div>
+
+          {/* Remove failed — the "×" hit the orchestrator but stopOrchestratorAgent
+              rejected, so the row is genuinely still present. Surface it here
+              rather than silently reloading the same row back. */}
+          {removeError ? (
+            <span className="od-group-picker-error" role="alert">
+              {removeError}
+            </span>
+          ) : null}
 
           {/* ── Add-participant: odysseus's dashed full-width button →
               inline picker (group.js #group-add-btn). eliza spawns a real

--- a/plugins/plugin-task-coordinator/src/odysseus/IconRail.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/IconRail.tsx
@@ -6,9 +6,16 @@
 // feature navigation; the shell renders this rail only in the collapsed state.
 
 import {
+  BookOpen,
   Boxes,
   Brain,
+  CalendarDays,
+  FileText,
+  FlaskConical,
+  GitCompare,
+  Images,
   ListChecks,
+  Mail,
   Palette,
   PanelLeft,
   Plus,
@@ -30,6 +37,13 @@ export function IconRail({
   onOpenModels,
   onOpenTasks,
   onOpenPresets,
+  onOpenCalendar,
+  onOpenCompare,
+  onOpenCookbook,
+  onOpenResearch,
+  onOpenEmail,
+  onOpenGallery,
+  onOpenDocs,
 }: {
   onToggleSidebar: () => void;
   onNewChat: () => void;
@@ -126,6 +140,74 @@ export function IconRail({
         aria-label="Presets"
       >
         <SlidersHorizontal size={18} />
+      </button>
+      {/* Tool launchers (odysseus index.html #icon-rail "always visible,
+        alphabetical" group). The collapsed rail is the only nav surface, so
+        these glyphs make the tool windows reachable without expanding the
+        sidebar. Order mirrors odysseus: Calendar, Compare, Cookbook,
+        Research, Email, Gallery, Library. */}
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenCalendar}
+        title="Calendar"
+        aria-label="Calendar"
+      >
+        <CalendarDays size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenCompare}
+        title="Compare"
+        aria-label="Compare"
+      >
+        <GitCompare size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenCookbook}
+        title="Cookbook"
+        aria-label="Cookbook"
+      >
+        <BookOpen size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenResearch}
+        title="Deep Research"
+        aria-label="Deep Research"
+      >
+        <FlaskConical size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenEmail}
+        title="Email"
+        aria-label="Email"
+      >
+        <Mail size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenGallery}
+        title="Gallery"
+        aria-label="Gallery"
+      >
+        <Images size={18} />
+      </button>
+      <button
+        type="button"
+        className="od-rail-btn"
+        onClick={onOpenDocs}
+        title="Library"
+        aria-label="Library"
+      >
+        <FileText size={18} />
       </button>
       <div className="od-rail-spacer" />
       <button

--- a/plugins/plugin-task-coordinator/src/odysseus/ModelsView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/ModelsView.tsx
@@ -421,8 +421,10 @@ export function ModelsView({
   const [query, setQuery] = useState("");
 
   const loadProvider = useCallback(
-    (prov: string) => {
-      if (modelsByProvider[prov]) return;
+    (prov: string, force = false) => {
+      // The catch sets modelsByProvider[prov] = [] (truthy), so without `force`
+      // a retry's stale closure would early-return and never refetch.
+      if (!force && modelsByProvider[prov]) return;
       setLoadingProvider(prov);
       void client
         .fetchModels(prov)
@@ -444,7 +446,11 @@ export function ModelsView({
     [modelsByProvider],
   );
 
-  // Hydrate local prefs + scan the default provider on open.
+  // Hydrate local prefs + scan the default provider on open. Gated to `open`
+  // only: loadProvider is recreated on every setModelsByProvider, so keeping it
+  // in the deps would re-run this (re-reading all prefs) on each scan
+  // completion. Hydration must happen once per open.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: open is the only intended trigger; loadProvider is excluded on purpose so prefs hydrate once per open.
   useEffect(() => {
     if (!open) return;
     setFavorites(readPref<string[]>(FAVORITES_KEY, []));
@@ -453,17 +459,47 @@ export function ModelsView({
     setSortMode(readPref<SortMode>(SORT_KEY, ""));
     setCollapsed(readPref<Record<string, boolean>>(COLLAPSE_KEY, {}));
     loadProvider("openai");
-  }, [open, loadProvider]);
+  }, [open]);
+
+  // Close the sort dropdown on outside-click / Escape (modelPicker.js menu
+  // close: a document listener that closes when the click lands outside the
+  // wrap). Only registered while the menu is open.
+  useEffect(() => {
+    if (!sortMenuOpen) return;
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target;
+      if (target instanceof Element && target.closest(".od-models-sort-wrap")) {
+        return;
+      }
+      setSortMenuOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      // Escape closes just the menu — keep it from also reaching the
+      // window-level useEscapeClose and closing the whole window (escMenuStack).
+      e.stopPropagation();
+      setSortMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [sortMenuOpen]);
 
   const allModels = modelsByProvider[provider] ?? [];
 
+  // Recent/Favorites are cross-provider id lists, so the lookup must span every
+  // catalogue scanned this session — not just the active provider's — or pins
+  // from other providers vanish when their tab isn't selected. Deduped by id.
   const byId = useMemo(() => {
     const map = new Map<string, ProviderModelRecord>();
-    for (const m of allModels) {
+    for (const m of Object.values(modelsByProvider).flat()) {
       if (!map.has(m.id)) map.set(m.id, m);
     }
     return map;
-  }, [allModels]);
+  }, [modelsByProvider]);
 
   // Sorted catalogue (odysseus models.js sort dispatch). Memoized so the full
   // catalogue is only re-sorted when its inputs change — not on every favorite
@@ -857,6 +893,14 @@ export function ModelsView({
                   onChange={(e) => setQuery(e.target.value)}
                   onKeyDown={(e) => {
                     if (e.key === "Escape") {
+                      // Don't let the window-level useEscapeClose listener also
+                      // fire — Escape in the search box clears the query first
+                      // (modelPicker.js search keydown stopPropagation). That
+                      // listener is a native window keydown handler, so the
+                      // synthetic stopPropagation alone won't reach it; stop the
+                      // underlying native event too.
+                      e.stopPropagation();
+                      e.nativeEvent.stopPropagation();
                       if (query) setQuery("");
                       else onClose();
                     }
@@ -892,7 +936,9 @@ export function ModelsView({
                         delete next[provider];
                         return next;
                       });
-                      loadProvider(provider);
+                      // force the refetch past loadProvider's cache guard (the
+                      // catch left a truthy [] behind for this provider).
+                      loadProvider(provider, true);
                     }}
                   >
                     Retry scan

--- a/plugins/plugin-task-coordinator/src/odysseus/OdysseusShell.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/OdysseusShell.tsx
@@ -197,7 +197,16 @@ export function OdysseusShell(): ReactNode {
     onCreated,
   });
 
-  const onNewChat = useCallback(() => setSelectedId(null), []);
+  // Entering the New Chat / welcome state (odysseus showWelcomeScreen): drop the
+  // selection AND discard any stale composer draft left from the previous
+  // session, so the input starts empty. Clearing `input` re-runs the Composer's
+  // autosize effect, which resets the textarea height (upstream sets
+  // `_msg.style.height = ''` then re-fires `input`). Switching between existing
+  // sessions goes through onSelect, not here, so genuine drafts are preserved.
+  const onNewChat = useCallback(() => {
+    setSelectedId(null);
+    setInput("");
+  }, [setInput]);
 
   const openPanel = useCallback(
     (panel: "theme" | "memory" | "skills" | "notes" | "settings") => {

--- a/plugins/plugin-task-coordinator/src/odysseus/OdysseusShell.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/OdysseusShell.tsx
@@ -104,6 +104,10 @@ export function OdysseusShell(): ReactNode {
   );
   const widthRef = useRef(sidebarWidth);
   widthRef.current = sidebarWidth;
+  // Detach fn for an in-flight sidebar drag (startResize). Held in a ref so an
+  // unmount mid-drag can tear down the window pointer listeners, which would
+  // otherwise leak because they only self-remove on pointerup/pointercancel.
+  const resizeDetachRef = useRef<(() => void) | null>(null);
   // Mobile flag (odysseus sidebar-layout.js): below MOBILE_BREAKPOINT the
   // sidebar becomes an overlay drawer. Initialised from the current viewport so
   // a first paint at a narrow width starts collapsed.
@@ -408,14 +412,28 @@ export function OdysseusShell(): ReactNode {
         Math.max(180, Math.min(440, startW + (ev.clientX - startX))),
       );
     };
-    const onUp = () => {
+    // Single teardown for all drag ends (pointerup, pointercancel, and an
+    // unmount-mid-drag via resizeDetachRef) so the window listeners can never
+    // outlive the gesture.
+    const detach = () => {
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+      resizeDetachRef.current = null;
+    };
+    const onUp = () => {
+      detach();
       writePref(PREF_KEYS.sidebarWidth, widthRef.current);
     };
+    resizeDetachRef.current = detach;
     window.addEventListener("pointermove", onMove);
     window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
   }, []);
+
+  // Unmount safety net: if the shell unmounts while a sidebar drag is still in
+  // flight, tear down the window pointer listeners that startResize attached.
+  useEffect(() => () => resizeDetachRef.current?.(), []);
 
   const pickTheme = useCallback((name: ThemeName) => {
     writePref(PREF_KEYS.themeMode, name);

--- a/plugins/plugin-task-coordinator/src/odysseus/SearchPalette.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/SearchPalette.tsx
@@ -183,8 +183,10 @@ export function SearchPalette({
       setSelectedIndex((i) => Math.max(i - 1, 0));
     } else if (e.key === "Enter") {
       e.preventDefault();
-      const target = results[selectedIndex] ?? results[0];
-      if (target) openThread(target.id);
+      if (selectedIndex >= 0) {
+        const target = results[selectedIndex];
+        if (target) openThread(target.id);
+      }
     }
   };
 

--- a/plugins/plugin-task-coordinator/src/odysseus/SessionSidebar.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/SessionSidebar.tsx
@@ -222,8 +222,11 @@ function ThreadRow({
   const renameRef = useRef<HTMLInputElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
-    if (editing) renameRef.current?.focus();
-  }, [editing]);
+    if (editing) {
+      setDraft(thread.title);
+      renameRef.current?.focus();
+    }
+  }, [editing, thread.title]);
   useEffect(() => {
     if (!menuOpen) setFolderSubOpen(false);
   }, [menuOpen]);
@@ -397,7 +400,7 @@ function ThreadRow({
               </div>
             ) : null}
           </div>
-          {confirmingDelete ? (
+          {pinned ? null : confirmingDelete ? (
             <div className="od-thread-menu-confirm">
               <span>Delete this conversation?</span>
               <div className="od-thread-menu-confirm-actions">
@@ -1144,7 +1147,7 @@ export function SessionSidebar({
         onRename(thread.id, title);
       }}
       onCancelRename={() => setEditingId(null)}
-      onRequestDelete={() => setConfirmDeleteId(thread.id)}
+      onRequestDelete={() => requestDelete(thread.id)}
       onConfirmDelete={() => {
         setMenuOpenId(null);
         setConfirmDeleteId(null);

--- a/plugins/plugin-task-coordinator/src/odysseus/SessionSidebar.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/SessionSidebar.tsx
@@ -161,6 +161,7 @@ function ThreadRow({
   active,
   editing,
   menuOpen,
+  confirmingDelete,
   pinned,
   selectMode,
   selected,
@@ -177,7 +178,9 @@ function ThreadRow({
   onStartRename,
   onCommitRename,
   onCancelRename,
-  onDelete,
+  onRequestDelete,
+  onConfirmDelete,
+  onCancelDelete,
   onTogglePin,
   onMoveToFolder,
   onNewFolderWith,
@@ -188,6 +191,7 @@ function ThreadRow({
   active: boolean;
   editing: boolean;
   menuOpen: boolean;
+  confirmingDelete: boolean;
   pinned: boolean;
   selectMode: boolean;
   selected: boolean;
@@ -204,7 +208,9 @@ function ThreadRow({
   onStartRename: () => void;
   onCommitRename: (title: string) => void;
   onCancelRename: () => void;
-  onDelete: () => void;
+  onRequestDelete: () => void;
+  onConfirmDelete: () => void;
+  onCancelDelete: () => void;
   onTogglePin: () => void;
   onMoveToFolder: (folder: string | null) => void;
   onNewFolderWith: () => void;
@@ -391,9 +397,33 @@ function ThreadRow({
               </div>
             ) : null}
           </div>
-          <button type="button" className="od-danger" onClick={onDelete}>
-            Delete
-          </button>
+          {confirmingDelete ? (
+            <div className="od-thread-menu-confirm">
+              <span>Delete this conversation?</span>
+              <div className="od-thread-menu-confirm-actions">
+                <button type="button" onClick={onCancelDelete}>
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  className="od-danger"
+                  onClick={onConfirmDelete}
+                >
+                  <Trash2 size={12} />
+                  Delete
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              className="od-danger"
+              onClick={onRequestDelete}
+            >
+              <Trash2 size={13} />
+              Delete
+            </button>
+          )}
         </div>
       ) : null}
     </div>
@@ -525,6 +555,9 @@ export function SessionSidebar({
   const [menuOpenId, setMenuOpenId] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editingFolder, setEditingFolder] = useState<string | null>(null);
+  // Per-row delete confirmation (odysseus styledConfirm 'Delete this session?').
+  // The id of the thread awaiting a Cancel/Delete confirm in its ⋯ menu.
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
   // Client-side folder state (see header comment for why it isn't on the
   // server). assignments: threadId → folderName. collapse: folderName → true
@@ -802,18 +835,45 @@ export function SessionSidebar({
     else setSelectedIds(new Set(flatOrder));
   }, [selectedIds, flatOrder]);
 
+  // Actually delete a thread: fire the host callback and prune the id from the
+  // persisted manual-order array so a stale id doesn't linger (odysseus
+  // _removeSessionFromLocalState's session-order cleanup).
+  const performDelete = useCallback(
+    (id: string) => {
+      onDelete(id);
+      if (manualOrder.includes(id)) {
+        persistManualOrder(manualOrder.filter((x) => x !== id));
+      }
+    },
+    [onDelete, manualOrder, persistManualOrder],
+  );
+
+  // Gate a per-row / keyboard delete behind an inline confirm (odysseus
+  // styledConfirm 'Delete this session?'), reusing the same confirm UX as the
+  // SkillsPanel. The pinned guard mirrors odysseus's "Unfavorite before
+  // deleting". The confirm itself renders in the row's ⋯ menu.
+  const requestDelete = useCallback(
+    (id: string) => {
+      if (pinned.has(id)) return;
+      setMenuOpenId(id);
+      setConfirmDeleteId(id);
+    },
+    [pinned],
+  );
+
   const runBulkDelete = useCallback(() => {
     // Pinned threads are protected from bulk delete, mirroring odysseus's
     // "Unfavorite before deleting" guard for starred sessions.
     for (const id of selectedIds) {
-      if (!pinned.has(id)) onDelete(id);
+      if (!pinned.has(id)) performDelete(id);
     }
     exitSelectMode();
-  }, [selectedIds, pinned, onDelete, exitSelectMode]);
+  }, [selectedIds, pinned, performDelete, exitSelectMode]);
 
   // Keyboard navigation of the session list (odysseus _onSessionListKeydown):
   // ArrowUp/Down move + select the adjacent row, Enter opens, Delete/Backspace
-  // deletes the focused row with the pinned guard. Roving focus follows.
+  // asks to delete the focused row (inline confirm) with the pinned guard.
+  // Roving focus follows.
   const onRowKeyDown = useCallback(
     (id: string) => (e: KeyboardEvent<HTMLButtonElement>) => {
       if (e.key === "ArrowDown" || e.key === "ArrowUp") {
@@ -831,13 +891,12 @@ export function SessionSidebar({
       } else if (e.key === "Delete" || e.key === "Backspace") {
         e.preventDefault();
         if (pinned.has(id)) return; // odysseus "Unfavorite before deleting"
-        const idx = flatOrder.indexOf(id);
-        const fallbackId = flatOrder[idx + 1] ?? flatOrder[idx - 1] ?? null;
-        onDelete(id);
-        if (fallbackId) rowRefs.current.get(fallbackId)?.focus();
+        // Route through the same inline confirm as the ⋯ menu Delete rather
+        // than deleting outright (odysseus styledConfirm 'Delete this session?').
+        requestDelete(id);
       }
     },
-    [flatOrder, onSelect, onDelete, pinned],
+    [flatOrder, onSelect, pinned, requestDelete],
   );
 
   // ── Drag reorder (odysseus dragSort.js). Pointer-based vertical reorder of
@@ -1050,6 +1109,7 @@ export function SessionSidebar({
       active={thread.id === selectedId}
       editing={editingId === thread.id}
       menuOpen={menuOpenId === thread.id}
+      confirmingDelete={confirmDeleteId === thread.id}
       pinned={pinned.has(thread.id)}
       selectMode={selectMode}
       selected={selectedIds.has(thread.id)}
@@ -1071,7 +1131,10 @@ export function SessionSidebar({
       onOpenMenu={() =>
         setMenuOpenId((prev) => (prev === thread.id ? null : thread.id))
       }
-      onCloseMenu={() => setMenuOpenId(null)}
+      onCloseMenu={() => {
+        setMenuOpenId(null);
+        setConfirmDeleteId(null);
+      }}
       onStartRename={() => {
         setEditingId(thread.id);
         setMenuOpenId(null);
@@ -1081,10 +1144,13 @@ export function SessionSidebar({
         onRename(thread.id, title);
       }}
       onCancelRename={() => setEditingId(null)}
-      onDelete={() => {
+      onRequestDelete={() => setConfirmDeleteId(thread.id)}
+      onConfirmDelete={() => {
         setMenuOpenId(null);
-        onDelete(thread.id);
+        setConfirmDeleteId(null);
+        performDelete(thread.id);
       }}
+      onCancelDelete={() => setConfirmDeleteId(null)}
       onMoveToFolder={(folder) => moveToFolder(thread.id, folder)}
       onNewFolderWith={() => {
         setNewFolderDraft("");

--- a/plugins/plugin-task-coordinator/src/odysseus/SettingsPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/SettingsPanel.tsx
@@ -700,9 +700,22 @@ function formatKeyCaps(combo: string): readonly string[] {
   });
 }
 
+// Mirrors platform.js IS_MAC (and useKeyboardShortcuts' detectIsMac): all Apple
+// platforms, where a Magic Keyboard's Option key sets AltGraph just like a Mac's
+// — so they get the same AltGr carve-out below.
+const IS_MAC =
+  typeof navigator !== "undefined" &&
+  (/Mac|iPhone|iPad/.test(navigator.platform || "") ||
+    /Mac/.test(navigator.userAgent || ""));
+
 // Build a combo string from a keydown (odysseus _comboFromEvent). Returns ""
 // for modifier-only presses so they are never recorded as a binding.
 function comboFromEvent(e: KeyboardEvent): string {
+  // Drop a stray AltGr keystroke (e.g. AltGr+E to type € on AZERTY/QWERTZ): a
+  // non-mac browser reports AltGr AS Ctrl+Alt, so without this guard it would
+  // be recorded as a bogus ctrl+alt+<char> binding. onKey ignores empty combos.
+  if (!IS_MAC && e.ctrlKey && e.altKey && e.getModifierState?.("AltGraph"))
+    return "";
   const parts: string[] = [];
   if (e.ctrlKey || e.metaKey) parts.push("ctrl");
   if (e.altKey) parts.push("alt");
@@ -1133,12 +1146,15 @@ export function SettingsPanel({
       .then((r) => setPlugins(r.plugins))
       .catch(() => setPlugins([]));
 
-    const stored = readPref<SearchSettings>(
-      SEARCH_SETTINGS_KEY,
-      DEFAULT_SEARCH_SETTINGS,
-    );
-    setSearch(stored);
-    setCountMode(isPresetCount(stored.resultCount) ? "preset" : "custom");
+    // Merge on read: readPref returns the raw parsed blob, so a partial stored
+    // object (e.g. an older write missing apiKey) would otherwise leave
+    // search.apiKey undefined and crash the searchStatus / warn-class
+    // .trim() calls during render. Spread DEFAULT first so every field is
+    // present, and feed the MERGED object to the preset-count detection.
+    const stored = readPref<Partial<SearchSettings>>(SEARCH_SETTINGS_KEY, {});
+    const merged: SearchSettings = { ...DEFAULT_SEARCH_SETTINGS, ...stored };
+    setSearch(merged);
+    setCountMode(isPresetCount(merged.resultCount) ? "preset" : "custom");
 
     void client
       .getCharacter()

--- a/plugins/plugin-task-coordinator/src/odysseus/VoiceView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/VoiceView.tsx
@@ -239,7 +239,14 @@ export function VoiceView({
   }, []);
 
   useEffect(() => {
-    if (!open) teardownCapture();
+    if (!open) {
+      teardownCapture();
+      // Reset the recorder so a close mid-recording (or after a mic error)
+      // doesn't leave a stuck "Recording…"/error toast over a now-null
+      // captureRef whose Stop button would no-op on reopen.
+      setRecState("idle");
+      setRecError(null);
+    }
   }, [open, teardownCapture]);
 
   useEffect(() => teardownCapture, [teardownCapture]);

--- a/plugins/plugin-task-coordinator/src/odysseus/hooks/useChatSubmit.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/hooks/useChatSubmit.ts
@@ -39,7 +39,8 @@ export function useChatSubmit({
     void (async () => {
       try {
         if (selectedId) {
-          await client.postOrchestratorTaskMessage(selectedId, text);
+          const ok = await client.postOrchestratorTaskMessage(selectedId, text);
+          if (!ok) throw new Error("Message not delivered");
         } else {
           const created = await client.createOrchestratorTask({
             title: deriveTitle(text),

--- a/plugins/plugin-task-coordinator/src/odysseus/hooks/useTaskRoom.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/hooks/useTaskRoom.ts
@@ -72,6 +72,13 @@ export function useTaskRoom(selectedId: string | null): TaskRoom {
   const refetchTimer = useRef<number | null>(null);
   selectedRef.current = selectedId;
 
+  // Read detail without making it a fetchDetail dependency: setDetail stores a
+  // fresh object every poll/SSE tick, so a [detail] dep would recreate
+  // fetchDetail on every update and tear down + recreate the reconcile poll and
+  // the SSE EventSource (reconnect churn that drops live events).
+  const detailRef = useRef(detail);
+  detailRef.current = detail;
+
   const fetchDetail = useCallback(
     async (id: string, reset: boolean): Promise<boolean> => {
       const token = ++reqRef.current;
@@ -100,12 +107,12 @@ export function useTaskRoom(selectedId: string | null): TaskRoom {
       } catch (err) {
         if (token === reqRef.current && id === selectedRef.current) {
           setError(err instanceof Error ? err.message : "Failed to load task");
-          setStale(!reset && detail != null);
+          setStale(!reset && detailRef.current != null);
         }
         return false;
       }
     },
-    [detail],
+    [],
   );
 
   // Selection change → reset room + initial fetch.
@@ -119,10 +126,9 @@ export function useTaskRoom(selectedId: string | null): TaskRoom {
       return;
     }
     setLoading(true);
-    void fetchDetail(selectedId, true)
-      .finally(() => {
-        if (selectedRef.current === selectedId) setLoading(false);
-      });
+    void fetchDetail(selectedId, true).finally(() => {
+      if (selectedRef.current === selectedId) setLoading(false);
+    });
   }, [selectedId, fetchDetail]);
 
   const isActive =
@@ -200,10 +206,12 @@ export function useTaskRoom(selectedId: string | null): TaskRoom {
   const retry = useCallback(() => {
     if (!selectedRef.current) return;
     setLoading(true);
-    void fetchDetail(selectedRef.current, detail == null).finally(() => {
-      if (selectedRef.current) setLoading(false);
-    });
-  }, [detail, fetchDetail]);
+    void fetchDetail(selectedRef.current, detailRef.current == null).finally(
+      () => {
+        if (selectedRef.current) setLoading(false);
+      },
+    );
+  }, [fetchDetail]);
 
   return { detail, conversation, isActive, loading, error, stale, retry };
 }

--- a/plugins/plugin-task-coordinator/src/odysseus/hooks/useWindowControls.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/hooks/useWindowControls.ts
@@ -82,6 +82,10 @@ const MIN_H = 220;
 // triggers maximize; the side/bottom edges trigger the half snaps.
 const EDGE_THRESHOLD_PX = 24;
 const TOP_FULL_STRIP_PX = 8;
+// Mirror of tileManager.js `Math.hypot(dx, dy) < 6` guard: a snapped window
+// only peels back to its pre-snap geometry once the drag passes this distance,
+// so a sub-pixel nudge on a snapped panel doesn't teleport it back to size.
+const UNSNAP_MOVE_PX = 6;
 // Desktop only — the odysseus source excludes tiling at <=768px (swipe UX).
 const DESKTOP_MIN_W = 768;
 // Left navigation width (icon rail). The odysseus safe-rect carves the nav out
@@ -192,7 +196,15 @@ export function useWindowControls(
   const minimized = hasMinimize && manager.isMinimized(storageKey);
 
   const minimize = useCallback(() => {
-    if (manager && hasMinimize) manager.setMinimized(storageKey, true);
+    if (manager && hasMinimize) {
+      // Detach any in-flight drag/resize first — otherwise the window-level
+      // listeners keep mutating rect on the now-hidden panel. detach() also
+      // clears activeGestureRef; clear the snap preview too so an in-flight
+      // drag doesn't leave a ghost floating over the dock.
+      activeGestureRef.current?.();
+      setSnapGhost(null);
+      manager.setMinimized(storageKey, true);
+    }
   }, [manager, hasMinimize, storageKey]);
 
   const restore = useCallback(() => {
@@ -255,20 +267,31 @@ export function useWindowControls(
       const desktop = window.innerWidth > DESKTOP_MIN_W;
       const sx = e.clientX;
       const sy = e.clientY;
-      // If the drag begins on an already-snapped window, peel back to the
-      // pre-snap geometry as the anchor so the move feels like un-snapping
-      // (tileManager.js `_unsnap` on first significant move).
-      const anchor = preSnapRef.current ?? start;
-      preSnapRef.current = null;
+      // Anchor the drag on the window's CURRENT (possibly snapped) geometry.
+      // If it began snapped we don't peel back to the pre-snap rect yet — that
+      // only happens once the pointer travels past UNSNAP_MOVE_PX, so a tiny
+      // nudge on a snapped window doesn't teleport it (tileManager.js defers
+      // `_unsnap` behind its `Math.hypot(dx, dy) < 6` guard).
+      let anchor = start;
+      const pendingUnsnap = preSnapRef.current;
       setSnapGhost(null);
       let activeTarget: SnapTarget | null = null;
       const onMove = (ev: PointerEvent) => {
+        const dx = ev.clientX - sx;
+        const dy = ev.clientY - sy;
+        // First significant move on a snapped window: swap the anchor to the
+        // stashed pre-snap rect and clear it, so from here the drag follows the
+        // pointer at the restored size (tileManager.js `_unsnap`).
+        if (pendingUnsnap && Math.hypot(dx, dy) > UNSNAP_MOVE_PX) {
+          anchor = pendingUnsnap;
+          preSnapRef.current = null;
+        }
         const vw = window.innerWidth;
         const vh = window.innerHeight;
         const next: Rect = {
           ...anchor,
-          x: Math.min(Math.max(0, anchor.x + (ev.clientX - sx)), vw - 80),
-          y: Math.min(Math.max(0, anchor.y + (ev.clientY - sy)), vh - 40),
+          x: Math.min(Math.max(0, anchor.x + dx), vw - 80),
+          y: Math.min(Math.max(0, anchor.y + dy), vh - 40),
         };
         rectRef.current = next;
         setRect(next);
@@ -281,6 +304,11 @@ export function useWindowControls(
       const detach = () => {
         window.removeEventListener("pointermove", onMove);
         window.removeEventListener("pointerup", onUp);
+        // An OS pointercancel (touch interrupt, context menu, scroll takeover)
+        // ends the gesture without a pointerup, so it must run onUp too — and
+        // be torn down here — or the listeners leak and the panel keeps
+        // following a dead pointer (windowDrag.js pairs touchcancel/touchend).
+        window.removeEventListener("pointercancel", onUp);
         activeGestureRef.current = null;
       };
       const onUp = () => {
@@ -299,6 +327,7 @@ export function useWindowControls(
       activeGestureRef.current = detach;
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);
+      window.addEventListener("pointercancel", onUp);
     },
     [ensureRect, persist],
   );
@@ -333,6 +362,10 @@ export function useWindowControls(
       const detach = () => {
         window.removeEventListener("pointermove", onMove);
         window.removeEventListener("pointerup", onUp);
+        // pointercancel ends the resize without a pointerup; tear down here too
+        // so we persist the final rect and don't leak listeners onto the window
+        // (windowResize.js pairs touchcancel/touchend for the same reason).
+        window.removeEventListener("pointercancel", onUp);
         activeGestureRef.current = null;
       };
       const onUp = () => {
@@ -342,6 +375,7 @@ export function useWindowControls(
       activeGestureRef.current = detach;
       window.addEventListener("pointermove", onMove);
       window.addEventListener("pointerup", onUp);
+      window.addEventListener("pointercancel", onUp);
     },
     [ensureRect, persist],
   );

--- a/plugins/plugin-task-coordinator/src/odysseus/odysseus-theme.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/odysseus-theme.ts
@@ -175,7 +175,18 @@ export const FONT_MAP: Record<ThemeFont, string> = {
 // HSL helpers + syntax-highlight derivation, ported verbatim from the odysseus
 // index.html theme bootstrap — so every preset gets faithful --hl-* colours.
 function h2hsl(hex: string): [number, number, number] {
-  const s = hex.replace("#", "");
+  // Mirror upstream hexToRgb: trim, drop leading '#', expand #rgb shorthand to
+  // #rrggbb, and fall back to black on invalid/malformed hex — otherwise a
+  // shorthand or bad palette colour would parse to NaN and break --hl-*.
+  let s = String(hex || "")
+    .trim()
+    .replace(/^#/, "");
+  if (s.length === 3)
+    s = s
+      .split("")
+      .map((ch) => ch + ch)
+      .join("");
+  if (!/^[0-9a-fA-F]{6}$/.test(s)) s = "000000";
   const r = Number.parseInt(s.substring(0, 2), 16) / 255;
   const g = Number.parseInt(s.substring(2, 4), 16) / 255;
   const b = Number.parseInt(s.substring(4, 6), 16) / 255;
@@ -357,6 +368,10 @@ export const ODYSSEUS_CSS = `
   padding:6px 10px; border:none; background:none; color:var(--fg); font-size:12px; border-radius:4px; cursor:pointer; }
 .odysseus-root .od-thread-menu button:hover { background:color-mix(in srgb, var(--fg) 8%, transparent); }
 .odysseus-root .od-thread-menu button.od-danger { color:var(--red); }
+.odysseus-root .od-thread-menu-confirm { padding:6px 8px 2px; border-top:1px solid color-mix(in srgb, var(--border) 30%, transparent); margin-top:4px; }
+.odysseus-root .od-thread-menu-confirm > span { display:block; font-size:11px; color:var(--fg); margin-bottom:6px; }
+.odysseus-root .od-thread-menu-confirm-actions { display:flex; gap:6px; }
+.odysseus-root .od-thread-menu-confirm-actions button { flex:1; justify-content:center; }
 .odysseus-root .od-thread-pin-dot { flex-shrink:0; margin-right:5px; color:var(--accent, var(--red)); opacity:.85; }
 .odysseus-root .od-thread-rename { width:100%; box-sizing:border-box; padding:3px 8px; margin:1px 0; font-size:13px;
   background:var(--bg); color:var(--fg); border:1px solid var(--red); border-radius:4px; outline:none; font-family:inherit; }
@@ -364,7 +379,7 @@ export const ODYSSEUS_CSS = `
 .odysseus-root .od-section-header-flex { display:flex; align-items:center; gap:6px; padding:8px;
   margin:1px 0; border-radius:4px; height:29px; box-sizing:border-box; }
 .odysseus-root .od-section-title { flex:1; display:flex; align-items:center; gap:6px; margin:0;
-  font-size:10px; font-weight:400; line-height:1; color:var(--fg); user-select:none;
+  font-size:10px; font-weight:400; line-height:1.3; color:var(--fg); user-select:none;
   text-transform:none; letter-spacing:0; }
 .odysseus-root .od-sidebar-user-bar { display:flex; align-items:center; justify-content:space-between;
   padding:12px; flex-shrink:0; gap:4px; min-height:48px; border-top:1px solid color-mix(in srgb, var(--fg) 8%, transparent); }
@@ -443,7 +458,7 @@ export const ODYSSEUS_CSS = `
 .odysseus-root .od-slash-label { opacity:.65; }
 .odysseus-root .od-input-top { width:100%; position:relative; display:flex; align-items:flex-start; gap:8px; }
 .odysseus-root .od-input-top textarea { flex:1; width:100%; background:transparent; border:none; outline:none;
-  resize:none; font-size:14px; line-height:1.5; color:var(--fg); min-height:24px; max-height:200px;
+  resize:vertical; font-size:14px; line-height:1.5; color:var(--fg); min-height:24px; max-height:min(60vh,600px);
   padding:0; font-family:inherit; }
 .odysseus-root .od-input-top textarea::placeholder { color:color-mix(in srgb, var(--fg) 35%, transparent); }
 .odysseus-root .od-model-picker-btn { display:inline-flex; align-items:center; gap:4px; height:21px; padding:0 6px;
@@ -1735,6 +1750,12 @@ export const ODYSSEUS_CSS = `
   color: var(--accent, var(--red)); cursor: pointer;
 }
 .odysseus-root .od-email-stats { font-size: 11px; opacity: 0.55; font-weight: 400; color: var(--fg); }
+/* Transient "Email copied" status from the recipient-chip copy button
+   (emailLibrary.js showToast('Email copied')). */
+.odysseus-root .od-email-feedback {
+  font-size: 11px; font-weight: 600; color: var(--accent, var(--red));
+  white-space: nowrap; animation: od-models-feedback-in 0.16s ease-out;
+}
 .odysseus-root .od-email-close {
   background: none; border: none; color: var(--fg); opacity: 0.55; cursor: pointer;
   padding: 4px; line-height: 0; border-radius: 6px; display: inline-flex; transition: opacity 0.15s, background 0.15s;
@@ -1843,10 +1864,25 @@ export const ODYSSEUS_CSS = `
 .odysseus-root .od-email-reader-meta-row strong { opacity: 0.5; font-weight: 600; flex-shrink: 0; min-width: 36px; }
 .odysseus-root .od-email-recipient-chips { display: inline-flex; flex-wrap: wrap; gap: 4px; }
 .odysseus-root .od-email-recipient-chip {
-  display: inline-flex; align-items: center; padding: 1px 8px; font-size: 10px;
+  display: inline-flex; align-items: center; gap: 3px; padding: 1px 8px; font-size: 10px;
   background: color-mix(in srgb, var(--fg) 6%, transparent); border: 1px solid var(--border);
-  border-radius: 10px; color: var(--fg); white-space: nowrap; max-width: 220px; overflow: hidden; text-overflow: ellipsis;
+  border-radius: 10px; color: var(--fg); white-space: nowrap; max-width: 220px; overflow: hidden;
 }
+.odysseus-root .od-email-recipient-chip.expanded { max-width: 320px; }
+/* emailLibrary.js recipient-chip-label — the clickable name/address toggle. */
+.odysseus-root .od-email-recipient-chip-label {
+  background: none; border: 0; padding: 0; margin: 0; font: inherit; color: inherit;
+  cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+/* emailLibrary.js recipient-chip-copy — revealed when the chip is expanded;
+   flips to a check (copied state) for ~900ms after a successful copy. */
+.odysseus-root .od-email-recipient-chip-copy {
+  display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0;
+  width: 16px; height: 16px; padding: 0; border: 0; border-radius: 4px; background: none;
+  color: var(--fg); opacity: 0.6; cursor: pointer; transition: opacity 0.15s, color 0.15s;
+}
+.odysseus-root .od-email-recipient-chip-copy:hover { opacity: 1; }
+.odysseus-root .od-email-recipient-chip-copy.copied { opacity: 1; color: var(--accent, var(--red)); }
 .odysseus-root .od-email-reader-actions {
   display: flex; gap: 4px; flex-wrap: wrap; align-items: center; flex-shrink: 0; justify-content: flex-end; margin-top: -2px;
 }
@@ -10545,6 +10581,41 @@ export const ODYSSEUS_CSS = `
 .odysseus-root .od-cb-engine,
 .odysseus-root .od-cb-server-select { flex: 0 0 auto; }
 .odysseus-root .od-cb-scan-search { flex: 1 1 auto; min-width: 120px; }
+
+/* Toolbar help "?" chips (odysseus .hwfit-help-chip). */
+.odysseus-root .od-cb-help-chip {
+  width: 14px; height: 14px; flex: 0 0 14px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border-radius: 50%;
+  border: 1px solid color-mix(in srgb, var(--fg) 22%, transparent);
+  color: color-mix(in srgb, var(--fg) 55%, transparent);
+  font-size: 9px; font-weight: 700; line-height: 1;
+  cursor: help; position: relative; top: -1px; margin-left: -1px;
+}
+.odysseus-root .od-cb-help-chip:hover {
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--fg) 45%, transparent);
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+}
+.odysseus-root .od-cb-help-chip-inline { margin-left: -2px; margin-right: 0; }
+
+/* Ctx target-context slider (odysseus .hwfit-ctx-control). */
+.odysseus-root .od-cb-ctx-control {
+  height: 28px; min-width: 134px; flex-shrink: 0; box-sizing: border-box;
+  display: inline-flex; align-items: center; gap: 5px; padding: 0 7px;
+  border: 1px solid var(--border); border-radius: 4px;
+  color: var(--muted); background: var(--bg); font-size: 10px;
+}
+.odysseus-root .od-cb-ctx-control span {
+  text-transform: uppercase; letter-spacing: 0.3px; opacity: 0.75;
+}
+.odysseus-root .od-cb-ctx-control input[type="range"] {
+  width: 54px; min-width: 54px; height: 16px; padding: 0; border: 0;
+  background: transparent; accent-color: var(--accent, var(--red));
+}
+.odysseus-root .od-cb-ctx-control output {
+  min-width: 28px; text-align: right; color: var(--fg); font-weight: 600;
+}
 
 /* RESCAN / EDIT buttons (odysseus .hwfit-gpu-btn). */
 .odysseus-root .od-cb-gpu-btn {

--- a/plugins/plugin-task-coordinator/src/odysseus/odysseus-theme.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/odysseus-theme.ts
@@ -12241,4 +12241,48 @@ export const ODYSSEUS_CSS = `
    leaving the JSX label prop semantic. The Added Models sub-heads already
    uppercase via .od-set-ep-list-head in the base theme. */
 .odysseus-root .od-set-ep-head { text-transform: uppercase; letter-spacing: 0.03em; }
+/* ===== fix-wave: ReasoningCell shimmer ===== */
+/* Luminance-sweep shimmer for the streaming reasoning cell
+   (orchestrator-reasoning.tsx). A moving mask-image window briefly lifts the
+   alpha of the masked glyphs, reading as a highlight traveling across the muted
+   text -- no second color is introduced. Hoisted here out of a per-instance
+   inline style tag so it is emitted once for the whole shell instead of once
+   per ReasoningCell. The selector is intentionally NOT scoped under
+   .odysseus-root: the cell also renders in the standalone OrchestratorWorkbench
+   timeline (which uses these same eliza tokens), so the class must resolve in
+   both contexts. The reduced-motion guard drops the animation and the mask. */
+.orchestrator-reasoning-shimmer {
+  -webkit-mask-image: linear-gradient(
+    100deg,
+    rgba(0, 0, 0, 0.45) 30%,
+    rgba(0, 0, 0, 1) 50%,
+    rgba(0, 0, 0, 0.45) 70%
+  );
+  mask-image: linear-gradient(
+    100deg,
+    rgba(0, 0, 0, 0.45) 30%,
+    rgba(0, 0, 0, 1) 50%,
+    rgba(0, 0, 0, 0.45) 70%
+  );
+  -webkit-mask-size: 220% 100%;
+  mask-size: 220% 100%;
+  animation: orchestrator-reasoning-sweep 1.8s linear infinite;
+}
+@keyframes orchestrator-reasoning-sweep {
+  from {
+    -webkit-mask-position: 180% 0;
+    mask-position: 180% 0;
+  }
+  to {
+    -webkit-mask-position: -80% 0;
+    mask-position: -80% 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .orchestrator-reasoning-shimmer {
+    -webkit-mask-image: none;
+    mask-image: none;
+    animation: none;
+  }
+}
 `;

--- a/plugins/plugin-task-coordinator/src/odysseus/util/storage.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/util/storage.ts
@@ -37,4 +37,5 @@ export const PREF_KEYS = {
   customThemes: "custom-themes",
   sidebarWidth: "sidebar-width",
   pinnedThreads: "pinned-threads",
+  hwfitContext: "hwfit-target-context",
 } as const;

--- a/plugins/plugin-task-coordinator/src/orchestrator-markdown.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-markdown.tsx
@@ -1,6 +1,6 @@
 import { Check, Copy } from "lucide-react";
-import { marked, type Token, type Tokens } from "marked";
-import { type ReactNode, useState } from "react";
+import { marked, type Token, type Tokens, type TokensList } from "marked";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 
 // The coding agent writes markdown prose. We parse it with `marked` — a real
 // lexer, not a hand-rolled regex — then render its token AST directly to React
@@ -192,9 +192,7 @@ function renderToken(token: Token, key: string): ReactNode {
       const href = sanitizeMarkdownUrl(token.href);
       // Only open external (http/https/mailto) links in a new tab.
       // Relative paths should navigate in the same context.
-      const isExternal =
-        href !== null &&
-        /^https?:/i.test(href);
+      const isExternal = href !== null && /^https?:/i.test(href);
       return (
         <a
           key={key}
@@ -240,6 +238,16 @@ function renderToken(token: Token, key: string): ReactNode {
 
 function CodeBlock({ code, lang }: { code: string; lang?: string }): ReactNode {
   const [copied, setCopied] = useState(false);
+  // Hold the revert timer so we can cancel it on unmount; firing setCopied
+  // after unmount (within the 1200ms window) would be a stale-state update.
+  const revertTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (revertTimer.current) clearTimeout(revertTimer.current);
+    },
+    [],
+  );
 
   const copy = () => {
     // Guard for non-secure-context / older webviews where clipboard is absent.
@@ -250,7 +258,8 @@ function CodeBlock({ code, lang }: { code: string; lang?: string }): ReactNode {
       () => {
         setCopied(true);
         // Brief confirmation, then revert to the resting copy icon.
-        setTimeout(() => setCopied(false), 1200);
+        if (revertTimer.current) clearTimeout(revertTimer.current);
+        revertTimer.current = setTimeout(() => setCopied(false), 1200);
       },
       () => undefined,
     );
@@ -287,7 +296,19 @@ function CodeBlock({ code, lang }: { code: string; lang?: string }): ReactNode {
 }
 
 export function MarkdownText({ text }: { text: string }): ReactNode {
-  const tokens = marked.lexer(text);
+  // marked.lexer runs synchronously here. It can throw — a stack overflow on
+  // pathologically nested input, or a TypeError on a non-string. A throw in
+  // this render would unmount the whole conversation, so degrade to plain text.
+  let tokens: TokensList;
+  try {
+    tokens = marked.lexer(text);
+  } catch {
+    return (
+      <div className="whitespace-pre-wrap break-words text-xs text-txt">
+        {text}
+      </div>
+    );
+  }
   return (
     <div className="break-words text-xs text-txt">
       {tokens.map((token, index) => renderToken(token, `t${index}`))}

--- a/plugins/plugin-task-coordinator/src/orchestrator-plan.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-plan.tsx
@@ -1,5 +1,5 @@
 import { Check, ChevronRight, Circle, Loader } from "lucide-react";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 
 // The orchestrator's current plan/todo list. The sub-agent (opencode) emits its
 // todo snapshot as an ACP `plan` update; the backend sanitizes it onto the
@@ -56,6 +56,12 @@ export function PlanDock({
   // dock once there's an active step keeps the live work visible.
   const hasActive = entries.some((entry) => entry.status === "in_progress");
   const [open, setOpen] = useState(hasActive);
+  // A plan can start all-pending (collapsed) and only later gain an in-progress
+  // step; the lazy init above runs once at mount, so reopen on the false→true
+  // transition. Only forces open (never re-collapses), preserving manual toggle.
+  useEffect(() => {
+    if (hasActive) setOpen(true);
+  }, [hasActive]);
   if (entries.length === 0) return null;
   const done = entries.filter((entry) => entry.status === "completed").length;
 

--- a/plugins/plugin-task-coordinator/src/orchestrator-reasoning.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-reasoning.tsx
@@ -2,6 +2,54 @@ import { Brain, ChevronRight } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import { MarkdownText } from "./orchestrator-markdown";
 
+// Luminance-sweep shimmer keyframes for the streaming reasoning cell. This is
+// the canonical copy of the rule that also lives in ODYSSEUS_CSS
+// (odysseus/odysseus-theme.ts) for the /odysseus shell. The cell renders in two
+// surfaces — the standalone OrchestratorWorkbench timeline (/orchestrator),
+// which does NOT inject ODYSSEUS_CSS, and the odysseus shell, which does — so
+// the cell carries the rule itself rather than assuming the shell stylesheet is
+// present. It is emitted via a React-hoistable <style href precedence> (below):
+// React lifts it to <head> and DEDUPLICATES every identical href to a single
+// DOM node, so N cells across any number of renders inject the rule exactly
+// once (the per-instance <style> this replaces injected one tag per cell). The
+// reduced-motion guard drops the animation and the mask entirely.
+const REASONING_SHIMMER_CSS = `
+.orchestrator-reasoning-shimmer {
+  -webkit-mask-image: linear-gradient(
+    100deg,
+    rgba(0, 0, 0, 0.45) 30%,
+    rgba(0, 0, 0, 1) 50%,
+    rgba(0, 0, 0, 0.45) 70%
+  );
+  mask-image: linear-gradient(
+    100deg,
+    rgba(0, 0, 0, 0.45) 30%,
+    rgba(0, 0, 0, 1) 50%,
+    rgba(0, 0, 0, 0.45) 70%
+  );
+  -webkit-mask-size: 220% 100%;
+  mask-size: 220% 100%;
+  animation: orchestrator-reasoning-sweep 1.8s linear infinite;
+}
+@keyframes orchestrator-reasoning-sweep {
+  from {
+    -webkit-mask-position: 180% 0;
+    mask-position: 180% 0;
+  }
+  to {
+    -webkit-mask-position: -80% 0;
+    mask-position: -80% 0;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .orchestrator-reasoning-shimmer {
+    -webkit-mask-image: none;
+    mask-image: none;
+    animation: none;
+  }
+}
+`;
+
 // A collapsible "reasoning / thinking" cell, matching the Codex / opencode
 // shape: a dim one-line header you can expand into the model's raw chain of
 // thought. The cloud-ui ai-elements `Reasoning` primitive
@@ -95,47 +143,12 @@ export function ReasoningCell({
           </div>
         </div>
       ) : null}
-      {/* Luminance-sweep shimmer: a moving mask-image window briefly lifts the
-          alpha of the masked glyphs, reading as a highlight traveling across
-          the muted text — no second color is introduced. Scoped class so the
-          keyframes live with the only component that uses them; the
-          reduced-motion guard drops the animation (and the mask) entirely. */}
-      <style>{`
-        .orchestrator-reasoning-shimmer {
-          -webkit-mask-image: linear-gradient(
-            100deg,
-            rgba(0, 0, 0, 0.45) 30%,
-            rgba(0, 0, 0, 1) 50%,
-            rgba(0, 0, 0, 0.45) 70%
-          );
-          mask-image: linear-gradient(
-            100deg,
-            rgba(0, 0, 0, 0.45) 30%,
-            rgba(0, 0, 0, 1) 50%,
-            rgba(0, 0, 0, 0.45) 70%
-          );
-          -webkit-mask-size: 220% 100%;
-          mask-size: 220% 100%;
-          animation: orchestrator-reasoning-sweep 1.8s linear infinite;
-        }
-        @keyframes orchestrator-reasoning-sweep {
-          from {
-            -webkit-mask-position: 180% 0;
-            mask-position: 180% 0;
-          }
-          to {
-            -webkit-mask-position: -80% 0;
-            mask-position: -80% 0;
-          }
-        }
-        @media (prefers-reduced-motion: reduce) {
-          .orchestrator-reasoning-shimmer {
-            -webkit-mask-image: none;
-            mask-image: none;
-            animation: none;
-          }
-        }
-      `}</style>
+      {/* React-hoistable, deduplicated stylesheet: the shared `href` collapses
+          every ReasoningCell's copy of this rule to a single <head> node, so it
+          is emitted once regardless of how many cells mount or re-render. */}
+      <style href="orchestrator-reasoning-shimmer" precedence="default">
+        {REASONING_SHIMMER_CSS}
+      </style>
     </div>
   );
 }

--- a/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
@@ -24,7 +24,9 @@ import {
 import { type ReactNode, useMemo, useState } from "react";
 import { countDiff, DiffStat, DiffView, lineDiff } from "./orchestrator-diff";
 import { MarkdownText } from "./orchestrator-markdown";
+
 export { sanitizeMarkdownUrl } from "./orchestrator-markdown";
+
 import { ReasoningCell } from "./orchestrator-reasoning";
 import { formatClockTime, formatDuration, stripAnsi } from "./view-format";
 
@@ -97,7 +99,18 @@ export type ConversationBlock =
       sessionId: string | null;
     }
   | { kind: "tool"; key: string; at: number; tool: ToolView }
-  | { kind: "reasoning"; key: string; at: number; text: string }
+  | {
+      kind: "reasoning";
+      key: string;
+      at: number;
+      text: string;
+      /** Wall-clock span from the first to the last reasoning delta in the
+       * coalesced burst; drives the "Thought for Ns" header. */
+      durationMs?: number;
+      /** True while the owning session is still running, so reasoning may still
+       * be arriving — drives the "Thinking…" header and shimmer. */
+      streaming?: boolean;
+    }
   | {
       kind: "notice";
       key: string;
@@ -338,12 +351,24 @@ function toToolView(
     status,
     filePath: pickString(rawInput, "filePath", "file_path", "path"),
     command: pickString(rawInput, "command", "cmd", "script"),
+    // A pure insertion (`old_string:""`), deletion-only edit (`new_string:""`),
+    // or empty-file write (`content:""`) is a real change whose "" must survive
+    // — pickString drops empty strings, so check the content keys directly and
+    // only fall back to it (then the output diff) for the rest.
     newText:
-      pickString(rawInput, "content", "newString", "new_string", "newText") ??
-      outputDiff?.newText,
+      typeof rawInput?.content === "string"
+        ? rawInput.content
+        : typeof rawInput?.new_string === "string"
+          ? rawInput.new_string
+          : typeof rawInput?.newString === "string"
+            ? rawInput.newString
+            : (pickString(rawInput, "newText") ?? outputDiff?.newText),
     oldText:
-      pickString(rawInput, "oldString", "old_string", "oldText") ??
-      outputDiff?.oldText,
+      typeof rawInput?.old_string === "string"
+        ? rawInput.old_string
+        : typeof rawInput?.oldString === "string"
+          ? rawInput.oldString
+          : (pickString(rawInput, "oldText") ?? outputDiff?.oldText),
     query: pickString(rawInput, "pattern", "query", "regex", "glob"),
     output,
     exitCode,
@@ -359,7 +384,13 @@ type Atom =
       message: CodingAgentTaskMessageRecord;
     }
   | { at: number; order: number; type: "tool"; tool: ToolView }
-  | { at: number; order: number; type: "reasoning"; text: string }
+  | {
+      at: number;
+      order: number;
+      type: "reasoning";
+      text: string;
+      sessionId: string | null;
+    }
   | {
       at: number;
       order: number;
@@ -448,6 +479,7 @@ export function buildConversation(
           order: order++,
           type: "reasoning",
           text,
+          sessionId: event.sessionId,
         });
       continue;
     }
@@ -536,14 +568,28 @@ export function buildConversation(
     }
     openLane = null;
     if (atom.type === "reasoning") {
+      // Reasoning is still arriving as long as its owning session has not
+      // finished; a session-less burst can never be marked finished, so it is
+      // treated as settled (its last delta is its end).
+      const streaming = atom.sessionId
+        ? !finishedSessionIds.has(atom.sessionId)
+        : false;
       if (openReasoning) {
         openReasoning.text += atom.text;
+        // Span = last delta's time − the burst's first; recomputed as deltas
+        // append so it always reflects the full burst.
+        openReasoning.durationMs = atom.at - openReasoning.at;
+        openReasoning.streaming = streaming;
       } else {
         const block = {
           kind: "reasoning" as const,
           key: `reason-${atom.order}`,
           at: atom.at,
           text: atom.text,
+          // A single-delta burst has no span yet; left undefined so the header
+          // reads "Thought" rather than "Thought for 0s".
+          durationMs: undefined,
+          streaming,
         };
         blocks.push(block);
         openReasoning = block;
@@ -895,7 +941,13 @@ export function ConversationBlockView({
   }
 
   if (block.kind === "reasoning") {
-    return <ReasoningCell text={block.text} />;
+    return (
+      <ReasoningCell
+        text={block.text}
+        durationMs={block.durationMs}
+        streaming={block.streaming}
+      />
+    );
   }
 
   const Icon = block.icon;


### PR DESCRIPTION
## Summary

Brings the odysseus orchestrator UI (the React rewrite now on `develop`) to **1:1 with the latest odysseus frontend** — `github.com/pewdiepie-archdaemon/odysseus` `f6b0dcb → ed7956c`. **Frontend only, eliza runtime** — no odysseus backend; the views still use `@elizaos/ui` exclusively.

odysseus moved 226 commits since our port branched, but only the frontend (`static/`) matters here — **45 commits / 33 files**, all bug-fixes + polish (no new views). I analyzed every changed upstream frontend file against our React components (two verification passes), found **19 real parity gaps**, and applied them:

- **email** — recipient chips are click-to-expand (name ↔ full address) with a reveal-on-expand copy button (clipboard + "Email copied" feedback); quote/angle-aware recipient splitting (`"Doe, John" <j@x>` no longer splits); Ctrl/Cmd+A selects only the open reader body; row Done relabeled "Done"/"Not Done"; bulk Actions gains "Done"
- **theme** — hex→HSL now expands `#rgb` shorthand + falls back to black on invalid hex (was `NaN`, breaking `--hl-*`); sidebar section-title `line-height 1→1.3` (Edge/Chromium glyph clipping); composer textarea manual resize
- **sessions** — per-row + keyboard Delete now confirm first (reuses the existing inline-confirm idiom); deleting prunes the persisted manual-order array
- **cookbook** — `NVFP4` quant option; "Ctx" context-length slider (persists + re-runs the fit scan); help chips; accelerator-only quants (AWQ/GPTQ/FP8/NVFP4) show "vLLM/SGLang" mode
- **calendar** — WCAG-contrast readable text color on week all-day event chips
- **chat** — IME `isComposing` guard (no submit mid-composition); `aria-busy` on the history list while streaming; discard stale composer draft on New Chat

## Verification

- biome clean · plugin `tsgo` **0 errors** · unit **25/25** · full plugin build green
- Gaps were found via per-file analysis (analyst → independent verifier) and applied by file-disjoint agents, then re-verified holistically. Caught + fixed an ODYSSEUS_CSS template-literal hazard (a stray backtick in a CSS comment) during typecheck.

## Notes

- Frontend only; all task/session state stays in `@elizaos/plugin-agent-orchestrator`.
- Companion: the byte-for-byte **verbatim** vendored copy (`plugin-odysseus-verbatim`, branch `nubs/odysseus-verbatim-ui`) is also re-vendored to `ed7956c`.
- Credit to upstream odysseus (MIT).

---

## Update: + 43 odysseus-UI bug fixes (commit 26e0179568)

Follow-up adversarial bug-hunt of the odysseus React rewrite (every component cross-checked vs the real odysseus behavior) found + fixed **43 bugs** — highlights: typed `/command`+Enter now runs (was posting literal text); pinned-thread delete guard; `marked.lexer` crash hardening; SettingsPanel `apiKey.trim()` crash; no-dead-controls pass on Cookbook (Quant/Ctx disabled honestly, Engine wired, Speed/Score de-sortable); useTaskRoom reconnect churn; VoiceView stuck-recording; DocumentLibrary server-side search; + assorted effect-cleanup/state fixes. Verified: biome clean, plugin tsgo 0, unit 25/25, full plugin build green, live e2e green on a develop-based stack.
