### PR TITLE
fix(cloud-frontend): unblock magic-link sign-in when no app-auth context

### DIFF
--- a/packages/cloud-frontend/src/pages/auth/callback/email/page.tsx
+++ b/packages/cloud-frontend/src/pages/auth/callback/email/page.tsx
@@ -39,23 +39,19 @@ export default function StewardEmailCallbackPage() {
       return;
     }
 
-    if (!returnTo) {
-      setStatus("error");
-      setError(
-        t("cloud.emailCallback.noRequest", {
-          defaultValue:
-            "Could not find the app authorization request. Start sign-in again from the app.",
-        }),
-      );
-      return;
-    }
+    // `returnTo` is set when the email flow was kicked off from the
+    // /app-auth/authorize page (third-party app integration). For a regular
+    // dashboard sign-in (e.g. magic link triggered from /login with a tenant
+    // whose `magicLinkBaseUrl` points back to this SPA), localStorage is
+    // empty and we fall back to /dashboard.
+    const destination = returnTo ?? "/dashboard";
 
     let redirectTimer: ReturnType<typeof setTimeout> | null = null;
     const finishSuccess = () => {
       clearStoredAppAuthorizeReturnTo();
       setStatus("success");
       redirectTimer = setTimeout(() => {
-        window.location.replace(returnTo);
+        window.location.replace(destination);
       }, 1500);
     };
 


### PR DESCRIPTION
## Why

After #8176 + #8179 landed, magic-link redirects on staging correctly point to \`staging.elizacloud.ai/auth/callback/email?token=…&email=…\`. But clicking the link shows:

> **Sign-in failed** — Could not find the app authorization request. Start sign-in again from the app.

Root cause at \`packages/cloud-frontend/src/pages/auth/callback/email/page.tsx:42-50\`:

\`\`\`ts
const returnTo = useMemo(readStoredAppAuthorizeReturnTo, []);
...
if (!returnTo) {
  setStatus("error");
  setError("Could not find the app authorization request...");
  return;
}
\`\`\`

The page was hard-gated on \`localStorage[eliza_app_auth_return_to]\` being populated — assuming the user always came from the \`/app-auth/authorize\` flow (third-party app integration, e.g. an external app embedding Eliza Cloud login).

In prod, the magic-link flow doesn't hit this page: Steward's server-side \`GET /auth/callback/email\` handler validates the token and 302s the user to \`\${EMAIL_AUTH_REDIRECT_BASE_URL}/login?token=<JWT>&refreshToken=<…>\` — the SPA \`/login\` page handles the JWT directly.

In staging (post #8176), Steward's \`tenant_configs.email_config.magicLinkBaseUrl\` points back at us, so the email link skips Steward's server-side handler and lands directly here. With no \`/app-auth/authorize\` visit beforehand, localStorage is empty → error before token verification ever runs.

## How

Treat \`returnTo\` as optional. If absent, fall back to \`/dashboard\`. Token verification runs the same way; cookie sync unchanged. App-auth context still wins when present, so the existing third-party-app flow is preserved.

\`\`\`diff
- if (!returnTo) {
-   setError("Could not find the app authorization request…");
-   return;
- }
+ const destination = returnTo ?? \"/dashboard\";
\`\`\`

## Test plan

- [ ] CI green
- [ ] Merge → Pages auto-deploys
- [ ] On \`staging.elizacloud.ai/login\`, click \"Magic Link\", enter an email, click link from inbox → must reach \`/dashboard\` (or whatever returnTo was when triggered from \`/app-auth/authorize\`)
- [ ] Prod magic link still works (uses Steward's server-side callback, doesn't hit this page)
- [ ] Existing app-auth third-party integration still redirects to the original \`returnTo\`