### PR TITLE
fix(cloud-api): allow staging.elizacloud.ai in CORS

### DIFF
--- a/packages/cloud-shared/src/lib/cors/cloud-api-hono-cors.ts
+++ b/packages/cloud-shared/src/lib/cors/cloud-api-hono-cors.ts
@@ -27,6 +27,8 @@ import { CORS_ALLOW_HEADER_NAMES, CORS_ALLOW_METHOD_NAMES } from "../cors-consta
 const STATIC_ALLOWED_ORIGINS = new Set<string>([
   "https://elizacloud.ai",
   "https://www.elizacloud.ai",
+  "https://staging.elizacloud.ai",
+  "https://dev.elizacloud.ai",
   "https://elizaos.ai",
   "https://www.elizaos.ai",
   "https://os.elizacloud.ai",


### PR DESCRIPTION
## Why

The staging SPA at \`staging.elizacloud.ai\` calls \`/steward/auth/email/verify\` to complete magic-link sign-in. The Worker's CORS allowlist (\`packages/cloud-shared/src/lib/cors/cloud-api-hono-cors.ts:27-35\`) only contains:

\`\`\`ts
\"https://elizacloud.ai\",
\"https://www.elizacloud.ai\",
\"https://elizaos.ai\",
...
\`\`\`

When the staging origin sends a preflight, \`isAllowedOrigin\` returns false → Worker omits \`Access-Control-Allow-Origin\` → browser blocks the cross-origin POST with \"Failed to fetch\". The SPA shows **Sign-in failed — Failed to fetch**.

Empirically reproduced:
\`\`\`
$ curl -isX OPTIONS 'https://staging.elizacloud.ai/steward/auth/email/verify' \\
    -H 'Origin: https://staging.elizacloud.ai' ...
HTTP/2 204
# (no access-control-allow-origin header)
\`\`\`

vs prod:
\`\`\`
$ curl -isX OPTIONS 'https://www.elizacloud.ai/steward/...' ...
access-control-allow-origin: https://www.elizacloud.ai
\`\`\`

## How

Add \`staging.elizacloud.ai\` and \`dev.elizacloud.ai\` to the static allowlist.

\`dev.elizacloud.ai\` is already in \`packages/cloud-shared/src/lib/steward-url.ts:32\` \`ELIZA_CLOUD_PROXIED_HOSTS\` (so the SDK bypasses the Pages proxy and hits the Worker direct there) but was never in the CORS allowlist — same bug would surface if it were ever used.

## Closes the staging rollout

This is the final gap after #8176 (tenant + env vars), #8179 (proxy header + bypass routes), #8194 (email callback fallback). After this lands, magic-link sign-in completes end-to-end on staging.

## Test plan

- [ ] CI green
- [ ] Merge → Worker auto-deploys
- [ ] \`curl -i OPTIONS https://api-staging.elizacloud.ai/steward/auth/email/verify -H 'Origin: https://staging.elizacloud.ai'\` → must include \`access-control-allow-origin: https://staging.elizacloud.ai\`
- [ ] Full magic-link login on staging.elizacloud.ai → reach /dashboard/agents
- [ ] Prod unaffected (still allowlisted)