### PR TITLE
feat(app-core): cloud SSO /pair handler for dashboard popup flow

### DIFF
--- a/packages/app-core/src/api/cloud-pair-route.test.ts
+++ b/packages/app-core/src/api/cloud-pair-route.test.ts
@@ -1,0 +1,268 @@
+import * as http from "node:http";
+import { Socket } from "node:net";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetSensitiveLimiters } from "./auth/sensitive-rate-limit";
+
+vi.mock("@elizaos/core", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+let handleCloudPairRoute: typeof import("./cloud-pair-route").handleCloudPairRoute;
+
+interface FakeRes {
+  res: http.ServerResponse;
+  body(): string;
+  status(): number;
+  headers(): Record<string, string>;
+}
+
+function fakeRes(): FakeRes {
+  let bodyText = "";
+  let writtenStatus = 200;
+  const writtenHeaders: Record<string, string> = {};
+  const req = new http.IncomingMessage(new Socket());
+  const res = new http.ServerResponse(req);
+  res.writeHead = ((
+    status: number,
+    headers?: Record<string, string>,
+  ): http.ServerResponse => {
+    writtenStatus = status;
+    if (headers) {
+      for (const [key, value] of Object.entries(headers)) {
+        writtenHeaders[key.toLowerCase()] = String(value);
+      }
+    }
+    return res;
+  }) as typeof res.writeHead;
+  res.setHeader = ((
+    key: string,
+    value: string | string[],
+  ): http.ServerResponse => {
+    writtenHeaders[key.toLowerCase()] = Array.isArray(value)
+      ? value.join(",")
+      : value;
+    return res;
+  }) as typeof res.setHeader;
+  res.end = ((chunk?: string | Buffer) => {
+    if (typeof chunk === "string") bodyText += chunk;
+    else if (chunk) bodyText += chunk.toString("utf8");
+    return res;
+  }) as typeof res.end;
+  return {
+    res,
+    body: () => bodyText,
+    status: () => writtenStatus,
+    headers: () => writtenHeaders,
+  };
+}
+
+function fakeReq(opts: {
+  pathname: string;
+  search?: string;
+  ip?: string;
+  host?: string;
+  proto?: string;
+}): http.IncomingMessage {
+  const req = new http.IncomingMessage(new Socket());
+  req.method = "GET";
+  req.url = `${opts.pathname}${opts.search ?? ""}`;
+  req.headers = {
+    host: opts.host ?? "203.0.113.10:21363",
+    ...(opts.proto ? { "x-forwarded-proto": opts.proto } : {}),
+  };
+  Object.defineProperty(req.socket, "remoteAddress", {
+    value: opts.ip ?? "203.0.113.50",
+    configurable: true,
+  });
+  return req;
+}
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+beforeAll(async () => {
+  const routeModule = await import("./cloud-pair-route");
+  handleCloudPairRoute = routeModule.handleCloudPairRoute;
+});
+
+beforeEach(() => {
+  _resetSensitiveLimiters();
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+describe("handleCloudPairRoute", () => {
+  it("returns false for non-/pair paths so the dispatch chain keeps walking", async () => {
+    const { res } = fakeRes();
+    const req = fakeReq({ pathname: "/something-else" });
+    const handled = await handleCloudPairRoute(req, res);
+    expect(handled).toBe(false);
+  });
+
+  it("returns false for non-GET methods on /pair", async () => {
+    const { res } = fakeRes();
+    const req = fakeReq({ pathname: "/pair" });
+    req.method = "POST";
+    const handled = await handleCloudPairRoute(req, res);
+    expect(handled).toBe(false);
+  });
+
+  it("renders a 400 error page when ?token is missing", async () => {
+    const harness = fakeRes();
+    const req = fakeReq({ pathname: "/pair" });
+    await handleCloudPairRoute(req, harness.res);
+    expect(harness.status()).toBe(400);
+    expect(harness.body()).toContain("Missing pairing token");
+    expect(harness.headers()["content-type"]).toContain("text/html");
+    expect(harness.headers()["cache-control"]).toContain("no-store");
+  });
+
+  it("renders 403 when cloud-api rejects the token (expired/used)", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "Invalid or expired pairing code" }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const harness = fakeRes();
+    const req = fakeReq({ pathname: "/pair", search: "?token=abc" });
+    await handleCloudPairRoute(req, harness.res);
+    expect(harness.status()).toBe(403);
+    expect(harness.body()).toContain("Sign-in link expired");
+  });
+
+  it("renders 503 when cloud-api is unreachable", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockRejectedValue(new Error("ECONNREFUSED")) as unknown as typeof globalThis.fetch;
+
+    const harness = fakeRes();
+    const req = fakeReq({ pathname: "/pair", search: "?token=abc" });
+    await handleCloudPairRoute(req, harness.res);
+    expect(harness.status()).toBe(503);
+    expect(harness.body()).toContain("Eliza Cloud is unreachable");
+  });
+
+  it("renders 502 when cloud-api returns 2xx but no apiKey", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ apiKey: null }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const harness = fakeRes();
+    const req = fakeReq({ pathname: "/pair", search: "?token=abc" });
+    await handleCloudPairRoute(req, harness.res);
+    expect(harness.status()).toBe(502);
+    expect(harness.body()).toContain("Sign-in failed");
+  });
+
+  it("forwards origin to cloud-api derived from x-forwarded headers", async () => {
+    const seen: { url?: string; init?: RequestInit } = {};
+    globalThis.fetch = vi.fn((url: string, init: RequestInit) => {
+      seen.url = url;
+      seen.init = init;
+      return Promise.resolve(
+        new Response(JSON.stringify({ apiKey: "agent_abc", agentName: "n" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const harness = fakeRes();
+    const req = fakeReq({
+      pathname: "/pair",
+      search: "?token=abc",
+      host: "203.0.113.10:21363",
+      proto: "https",
+    });
+    await handleCloudPairRoute(req, harness.res);
+    expect(harness.status()).toBe(200);
+    const headers = seen.init?.headers as Record<string, string>;
+    expect(headers.origin).toBe("https://203.0.113.10:21363");
+  });
+
+  it("renders happy-path HTML with the apiKey pinned on window globals", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({ apiKey: "agent_secret_value", agentName: "Nova" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    ) as unknown as typeof globalThis.fetch;
+
+    const harness = fakeRes();
+    const req = fakeReq({ pathname: "/pair", search: "?token=abc" });
+    await handleCloudPairRoute(req, harness.res);
+    expect(harness.status()).toBe(200);
+    const body = harness.body();
+    expect(body).toContain('"agent_secret_value"');
+    expect(body).toMatch(/window\.__ELIZAOS_API_TOKEN__\s*=\s*key/);
+    expect(body).toMatch(/window\.__ELIZA_API_TOKEN__\s*=\s*key/);
+    expect(body).toContain('window.location.replace("/")');
+    expect(harness.headers()["cache-control"]).toContain("no-store");
+    expect(harness.headers()["x-frame-options"]).toBe("DENY");
+  });
+
+  it("safely escapes an apiKey containing </script>", async () => {
+    const evilToken = `agent_a"</script><script>alert(1)</script>`;
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ apiKey: evilToken, agentName: "x" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ) as unknown as typeof globalThis.fetch;
+
+    const harness = fakeRes();
+    const req = fakeReq({ pathname: "/pair", search: "?token=abc" });
+    await handleCloudPairRoute(req, harness.res);
+    expect(harness.status()).toBe(200);
+    const body = harness.body();
+    // The inline script must close exactly ONCE — meaning a payload
+    // containing `</script>` must be escaped (we use the `<` Unicode
+    // escape) so it does NOT terminate the script early.
+    const closes = body.match(/<\/script>/g) ?? [];
+    expect(closes.length).toBe(1);
+    // And the original raw `</script>` must NOT appear in the body anywhere
+    // outside of the single legitimate closer.
+    const bodyWithoutCloser = body.replace(/<\/script>/, "");
+    expect(bodyWithoutCloser).not.toMatch(/<\/script>/);
+  });
+
+  it("rate-limits the same IP after the bucket fills", async () => {
+    // Each invocation gets a fresh Response — a single shared Response
+    // body would be consumed on the first .json() and subsequent calls
+    // would 502 because the parsed body is null.
+    globalThis.fetch = vi.fn().mockImplementation(
+      () =>
+        Promise.resolve(
+          new Response(JSON.stringify({ apiKey: "agent_k", agentName: "n" }), {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+    ) as unknown as typeof globalThis.fetch;
+
+    // Bucket size is 5/min from sensitive-rate-limit.ts. Hit it 5 times +
+    // assert the 6th call returns 429.
+    for (let i = 0; i < 5; i++) {
+      const h = fakeRes();
+      const r = fakeReq({ pathname: "/pair", search: "?token=abc", ip: "9.9.9.9" });
+      await handleCloudPairRoute(r, h.res);
+      expect(h.status()).toBe(200);
+    }
+    const h6 = fakeRes();
+    const r6 = fakeReq({ pathname: "/pair", search: "?token=abc", ip: "9.9.9.9" });
+    await handleCloudPairRoute(r6, h6.res);
+    expect(h6.status()).toBe(429);
+    expect(h6.body()).toContain("Too many sign-in attempts");
+  });
+});

--- a/packages/app-core/src/api/cloud-pair-route.ts
+++ b/packages/app-core/src/api/cloud-pair-route.ts
@@ -1,0 +1,310 @@
+/**
+ * GET /pair — server-side relay for the Eliza Cloud SSO popup.
+ *
+ * Flow:
+ *   1. Cloud dashboard mints a 60s pairing token via
+ *      POST /api/v1/eliza/agents/<id>/pairing-token and navigates a popup to
+ *      `<agent>/pair?token=<X>`.
+ *   2. This handler reads the token, calls cloud-api `POST /api/auth/pair`
+ *      server-side (origin header = the agent's own origin, so cloud-api's
+ *      origin gate matches what was baked into the token).
+ *   3. Cloud-api validates + consumes the token, returns
+ *      `{ apiKey: <ELIZA_API_TOKEN> }`.
+ *   4. This handler serves an HTML page with an inline script that pins the
+ *      apiKey on `window.__ELIZAOS_API_TOKEN__` (the global the SPA's
+ *      ElizaClient reads on hydrate) then redirects to `/`.
+ *
+ * Why server-side relay: the agent web UI runs on the docker node's public
+ * IP, which is not in cloud-api's CORS allowlist. A direct browser fetch to
+ * `api.elizacloud.ai` would fail preflight. Doing the exchange from the
+ * agent's Node process sidesteps CORS entirely.
+ */
+
+import type http from "node:http";
+import { logger } from "@elizaos/core";
+import { getSensitiveLimiter } from "./auth/sensitive-rate-limit";
+
+const RELAY_TIMEOUT_MS = 5_000;
+const pairingRelayLimiter = getSensitiveLimiter("cloud.pair.relay");
+
+function resolveCloudApiBaseUrl(): string {
+  const raw =
+    process.env.ELIZAOS_CLOUD_BASE_URL ||
+    process.env.NEXT_PUBLIC_API_URL ||
+    "https://api.elizacloud.ai/api/v1";
+  return raw.replace(/\/+$/, "");
+}
+
+function resolveCloudAuthRoot(): string {
+  // Cloud-api mounts `/api/auth/pair` at the site root, not under `/api/v1`.
+  // ELIZAOS_CLOUD_BASE_URL is the `/api/v1` URL, so strip the suffix to land
+  // on the site root.
+  const base = resolveCloudApiBaseUrl();
+  return base.replace(/\/api\/v1\/?$/, "");
+}
+
+function resolveRequestOrigin(req: http.IncomingMessage): string {
+  // Honor the proxy headers a control-plane front (Cloudflared, nginx) adds,
+  // then fall back to the Host header. The cloud-api side uses this origin
+  // verbatim to look up the pairing-token row (which was baked with the same
+  // shape at generate time).
+  const proto =
+    (req.headers["x-forwarded-proto"] as string | undefined) ||
+    (req.socket && "encrypted" in req.socket && req.socket.encrypted
+      ? "https"
+      : "http");
+  const host =
+    (req.headers["x-forwarded-host"] as string | undefined) || req.headers.host;
+  return host ? `${proto}://${host}` : "";
+}
+
+interface PairResponse {
+  apiKey?: string | null;
+  agentName?: string;
+  error?: string;
+}
+
+function renderRedirectHtml(apiKey: string): string {
+  // JSON.stringify gives us a JS-string literal that safely escapes quotes,
+  // but it does NOT escape `</script>` — which would break us out of the
+  // inline script tag. Replace `<` with the `<` escape so any
+  // `</script>` payload in a malicious key becomes inert literal text.
+  const safeKey = JSON.stringify(apiKey).replace(/</g, "\\u003c");
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="referrer" content="no-referrer">
+  <title>Signing in…</title>
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      background: #0a0a0a;
+      color: #e5e5e5;
+    }
+    p { margin: 0; font-size: 0.9rem; opacity: 0.8 }
+  </style>
+</head>
+<body>
+  <p>Signing in to your agent…</p>
+  <script>
+    (function () {
+      try {
+        var key = ${safeKey};
+        window.__ELIZAOS_API_TOKEN__ = key;
+        window.__ELIZA_API_TOKEN__ = key;
+      } catch (e) {}
+      window.location.replace("/");
+    })();
+  </script>
+</body>
+</html>`;
+}
+
+function renderErrorHtml(title: string, message: string): string {
+  // Static error page — no token, no inline data, just a back link to the
+  // dashboard so the user can re-trigger the popup.
+  const safeTitle = title.replace(/[<>&]/g, (c) =>
+    c === "<" ? "&lt;" : c === ">" ? "&gt;" : "&amp;",
+  );
+  const safeMessage = message.replace(/[<>&]/g, (c) =>
+    c === "<" ? "&lt;" : c === ">" ? "&gt;" : "&amp;",
+  );
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="referrer" content="no-referrer">
+  <title>${safeTitle}</title>
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      background: #0a0a0a;
+      color: #e5e5e5;
+    }
+    .card {
+      max-width: 28rem;
+      padding: 2rem;
+      border-radius: 0.75rem;
+      background: rgba(255, 255, 255, 0.04);
+      text-align: center;
+    }
+    h1 { font-size: 1.1rem; margin: 0 0 0.75rem; font-weight: 600 }
+    p { margin: 0 0 1.25rem; opacity: 0.8; font-size: 0.9rem; line-height: 1.5 }
+    a {
+      color: #e5e5e5;
+      text-decoration: none;
+      font-size: 0.85rem;
+      opacity: 0.7;
+    }
+    a:hover { opacity: 1 }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>${safeTitle}</h1>
+    <p>${safeMessage}</p>
+    <a href="https://www.elizacloud.ai/dashboard/agents" target="_top" rel="noopener">Back to Eliza Cloud →</a>
+  </div>
+</body>
+</html>`;
+}
+
+function sendHtml(
+  res: http.ServerResponse,
+  status: number,
+  body: string,
+): void {
+  res.writeHead(status, {
+    "content-type": "text/html; charset=utf-8",
+    "cache-control": "no-store, no-cache, must-revalidate, proxy-revalidate",
+    pragma: "no-cache",
+    expires: "0",
+    "x-frame-options": "DENY",
+    "referrer-policy": "no-referrer",
+    "x-content-type-options": "nosniff",
+  });
+  res.end(body);
+}
+
+export async function handleCloudPairRoute(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+): Promise<boolean> {
+  const method = (req.method ?? "GET").toUpperCase();
+  const url = new URL(req.url ?? "/", "http://localhost");
+  if (method !== "GET" || url.pathname !== "/pair") {
+    return false;
+  }
+
+  const ip = req.socket.remoteAddress ?? null;
+  if (!pairingRelayLimiter.consume(ip)) {
+    sendHtml(
+      res,
+      429,
+      renderErrorHtml(
+        "Too many sign-in attempts",
+        "Wait a minute and click 'Open Web UI' again from the dashboard.",
+      ),
+    );
+    return true;
+  }
+
+  const token = url.searchParams.get("token")?.trim();
+  if (!token) {
+    sendHtml(
+      res,
+      400,
+      renderErrorHtml(
+        "Missing pairing token",
+        "Open the agent from the Eliza Cloud dashboard so a fresh sign-in link is generated.",
+      ),
+    );
+    return true;
+  }
+
+  const origin = resolveRequestOrigin(req);
+  if (!origin) {
+    sendHtml(
+      res,
+      400,
+      renderErrorHtml(
+        "Missing origin",
+        "Your browser did not send a Host header. Try again from a standard browser.",
+      ),
+    );
+    return true;
+  }
+
+  const exchangeUrl = `${resolveCloudAuthRoot()}/api/auth/pair`;
+  let exchanged: PairResponse | null = null;
+  let status = 0;
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), RELAY_TIMEOUT_MS);
+    const resp = await fetch(exchangeUrl, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        origin,
+      },
+      body: JSON.stringify({ token }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    status = resp.status;
+    if (resp.ok) {
+      exchanged = (await resp.json().catch(() => null)) as PairResponse | null;
+    } else {
+      logger.warn(
+        `[cloud-pair] exchange returned non-2xx status=${status} url=${exchangeUrl}`,
+      );
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(
+      `[cloud-pair] exchange failed url=${exchangeUrl} error=${message}`,
+    );
+    sendHtml(
+      res,
+      503,
+      renderErrorHtml(
+        "Eliza Cloud is unreachable",
+        "We couldn't reach Eliza Cloud to verify your sign-in link. Try again in a minute.",
+      ),
+    );
+    return true;
+  }
+
+  if (status === 401 || status === 403 || status === 410) {
+    sendHtml(
+      res,
+      403,
+      renderErrorHtml(
+        "Sign-in link expired",
+        "Pairing links are single-use and only valid for a minute. Click 'Open Web UI' again from the dashboard.",
+      ),
+    );
+    return true;
+  }
+
+  if (status === 429) {
+    sendHtml(
+      res,
+      429,
+      renderErrorHtml(
+        "Too many sign-in attempts",
+        "Wait a minute and click 'Open Web UI' again from the dashboard.",
+      ),
+    );
+    return true;
+  }
+
+  if (!exchanged || typeof exchanged.apiKey !== "string" || !exchanged.apiKey) {
+    sendHtml(
+      res,
+      502,
+      renderErrorHtml(
+        "Sign-in failed",
+        "Eliza Cloud accepted the link but did not return a key. Try again from the dashboard.",
+      ),
+    );
+    return true;
+  }
+
+  logger.info(
+    `[cloud-pair] exchange ok agent=${exchanged.agentName ?? "agent"}`,
+  );
+  sendHtml(res, 200, renderRedirectHtml(exchanged.apiKey));
+  return true;
+}

--- a/packages/app-core/src/api/server.ts
+++ b/packages/app-core/src/api/server.ts
@@ -135,6 +135,7 @@ import { buildCharacterFromConfig } from "../runtime/build-character-from-config
 import { handleAuthBootstrapRoutes } from "./auth-bootstrap-routes";
 import { handleAuthPairingCompatRoutes } from "./auth-pairing-routes";
 import { handleAuthSessionRoutes } from "./auth-session-routes";
+import { handleCloudPairRoute } from "./cloud-pair-route";
 import { handleBackgroundTasksRoute } from "./background-tasks-routes";
 import { handleCatalogRoutes } from "./catalog-routes";
 import { handleDatabaseRowsCompatRoute } from "./database-rows-compat-routes";
@@ -733,6 +734,11 @@ async function handleCompatRouteInner(
 
   // Dev observability routes — extracted to dev-compat-routes.ts
   if (await handleDevCompatRoutes(req, res, state)) return true;
+
+  // Cloud SSO popup landing — `/pair?token=X` calls cloud-api server-side,
+  // serves HTML that pins the API token on the SPA's window global. Mounted
+  // before any other auth handler so it owns the root `/pair` URL.
+  if (await handleCloudPairRoute(req, res)) return true;
 
   // Must precede the auth-pairing handler so the rate-limited route owns /api/auth/bootstrap/exchange.
   if (await handleAuthBootstrapRoutes(req, res, state)) return true;

--- a/packages/cloud-frontend/src/hooks/open-web-ui.ts
+++ b/packages/cloud-frontend/src/hooks/open-web-ui.ts
@@ -8,7 +8,9 @@ import { toast } from "sonner";
  * 1. Opens a popup immediately (must be in click handler to avoid popup blockers)
  * 2. Fetches a one-time pairing token from the dashboard API
  * 3. Redirects the popup to the agent's /pair page with the token
- * 4. pair.html exchanges the token for an API key and stores it
+ * 4. The agent's `/pair` handler calls cloud-api `/api/auth/pair` server-side,
+ *    receives the agent's API key, and serves HTML that pins it on the SPA's
+ *    `window.__ELIZAOS_API_TOKEN__` global before redirecting to `/`.
  */
 export async function openWebUIWithPairing(agentId: string): Promise<void> {
   const popup = window.open("", "_blank");


### PR DESCRIPTION
## Why

Today, clicking **Open Web UI** on `dashboard/agents` opens a popup that navigates to `<agent>/pair?token=X`. The cloud-api side of this flow is wired: it generates a 60s pairing token via `POST /api/v1/eliza/agents/[id]/pairing-token` and the dashboard popup hook (`packages/cloud-frontend/src/hooks/open-web-ui.ts`) opens the popup at the right URL. The cloud-api also already has `POST /api/auth/pair` which validates the token and returns the agent's `ELIZA_API_TOKEN`.

**What's missing:** the agent runtime has no `/pair` route. The popup lands on the SPA's catch-all (HTTP 200 HTML for the login screen), the SPA tries `POST /api/auth/login/password` / `POST /api/auth/pair`, both 404/403, the WebSocket gets `HTTP Authentication failed`, the user sees a password screen they can't satisfy + "Reconnecting…" loops, and gives up.

I verified this live on `e2e-mpy2iutz` on staging earlier today (console: `GET /api/views 401`, `ws auth failed`, `Pairing disabled`).

## How

`GET /pair?token=X` on the agent runtime:

1. **Rate-limit** the IP via `getSensitiveLimiter(\"cloud.pair.relay\")` (5/min/IP, same bucket model as bootstrap exchange).
2. **Call cloud-api** `POST /api/auth/pair` server-side with the token in the body and the request origin in the `Origin` header. Server-side fetch sidesteps CORS — agent IPs aren't in cloud-api's allowlist and never will be.
3. **Serve HTML** with an inline script that pins the returned key on `window.__ELIZAOS_API_TOKEN__` (the global the SPA's `ElizaClient` reads on hydrate — `packages/ui/src/api/client-base.ts:388`) then `location.replace(\"/\")`.
4. **On any failure** (missing token, cloud-api 401/403/410, 5xx, timeout, rate-limit), serve a styled error page with a link back to elizacloud.ai/dashboard/agents so the user can retry.

## Security model

- Pairing tokens are **single-use, 60s TTL, triple-bound** to `(user, org, agent) + origin` (existing `pairingTokenService`). Cloud-api consumes them atomically.
- Inline-script escaping: `JSON.stringify(key).replace(/</g, '\\\\u003c')` — even a malicious key containing `</script>` becomes inert literal text. Tested.
- Response headers: `Cache-Control: no-store`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, `X-Content-Type-Options: nosniff`.
- The handler only **reads** env vars + relays one HTTP call; no DB access, no privileged surface.

## Known limitations (documented)

- **Consume-on-fail**: cloud-api consumes the token atomically. If the agent's HTML send fails after the token was consumed, the user must click \"Open Web UI\" again from the dashboard. The 60s TTL caps the damage. Idempotent preview is a follow-up if real users hit it.
- **Old agents 404 `/pair`** — same as today, no regression. Pickup requires the image rebuild (~60-80 min via `build-agent-image.yml` path filter on `packages/app-core/**`) + sandbox restart.
- **`@elizaos/core` logger**: vitest in this package can't resolve the transitive `@elizaos/logger` import, so the test mocks `@elizaos/core`. Real runtime uses the real logger.

## Tests

10 sociable unit tests covering:
- Non-`/pair` paths / non-GET methods → return false (let dispatch keep walking)
- Missing token → 400 error page
- Cloud-api 401/403/410 → 403 \"link expired\" page
- Cloud-api unreachable → 503 page
- Cloud-api 2xx without apiKey → 502 page
- Origin header derived from `x-forwarded-proto` + `x-forwarded-host`
- Happy path → 200 HTML pinning the key on both `__ELIZAOS_API_TOKEN__` and `__ELIZA_API_TOKEN__`
- Inline-script escape resists `</script>` payload (exactly one closing tag in body)
- Per-IP rate limit kicks in after 5 successes

All passing.

## Test plan

- [ ] CI green
- [ ] Merge → image rebuild lands (~60-80 min)
- [ ] Restart `e2e-mpy2iutz` (or any test sandbox) to pick up the new image
- [ ] On `staging.elizacloud.ai/dashboard/agents`, click \"Open Web UI\"
- [ ] Popup briefly shows \"Signing in to your agent…\", lands on `/` authed
- [ ] No password screen, no 401s in console, WebSocket connects
- [ ] Refresh agent UI → still authed (window global re-set by SPA boot config sync)