### PR TITLE
Add @1claw/plugin-elizaos to the plugin registry

### DIFF
--- a/packages/registry/entries/third-party/1claw-plugin-elizaos.json
+++ b/packages/registry/entries/third-party/1claw-plugin-elizaos.json
@@ -1,0 +1,15 @@
+{
+  "package": "@1claw/plugin-elizaos",
+  "repository": "github:1clawAI/1claw-elizaos-plugin",
+  "kind": "plugin",
+  "description": "HSM-backed secrets + multi-chain signing for elizaOS agents via 1Claw \u2014 vault access and EVM/Solana/BTC/XRP/Cardano/Tron signing without the agent ever holding private keys; optional Shroud TEE LLM proxy.",
+  "homepage": "https://github.com/1clawAI/1claw-elizaos-plugin",
+  "version": "0.1.0",
+  "tags": [
+    "security",
+    "secrets",
+    "vault",
+    "signing",
+    "multi-chain"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -42,6 +42,50 @@
       "kind": "plugin",
       "registryKind": "plugin",
       "directory": "packages/examples/plugin-echo"
+    },
+    "@1claw/plugin-elizaos": {
+      "git": {
+        "repo": "1clawAI/1claw-elizaos-plugin",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@1claw/plugin-elizaos",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "HSM-backed secrets + multi-chain signing for elizaOS agents via 1Claw \u2014 vault access and EVM/Solana/BTC/XRP/Cardano/Tron signing without the agent ever holding private keys; optional Shroud TEE LLM proxy.",
+      "homepage": "https://github.com/1clawAI/1claw-elizaos-plugin",
+      "topics": [
+        "security",
+        "secrets",
+        "vault",
+        "signing",
+        "multi-chain"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin"
     }
   }
 }


### PR DESCRIPTION
Adds **[@1claw/plugin-elizaos](https://www.npmjs.com/package/@1claw/plugin-elizaos)** to the curated third-party registry.

**What it is:** brings [1Claw](https://1claw.xyz) to elizaOS agents — HSM-backed secret access and multi-chain signing (EVM, Solana, BTC, XRP, Cardano, Tron) so an agent can use secrets and sign transactions **without ever holding private keys or seeing credentials in context**; optional Shroud TEE LLM proxy.

- npm: `@1claw/plugin-elizaos` (published, has the `elizaos` keyword)
- repo: https://github.com/1clawAI/1claw-elizaos-plugin

**Changes** (per the registry guide):
- `packages/registry/entries/third-party/1claw-plugin-elizaos.json` — source entry (mirrors the `plugin-echo` example)
- `packages/registry/generated-registry.json` — regenerated to include the entry

Hand-prepared the entry/generated files following the `plugin-echo` example since the package was just published; happy to rename the file or align exactly with `elizaos plugins submit` / `bun run generate` output if you'd prefer.