### PR TITLE
docs(ui): add Storybook stories for nine UI primitives

### DIFF
--- a/packages/ui/src/components/ui/table.stories.tsx
+++ b/packages/ui/src/components/ui/table.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./table";
+
+const meta = {
+  title: "Primitives/Table",
+  component: Table,
+  tags: ["autodocs"],
+} satisfies Meta<typeof Table>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const agents = [
+  { name: "Eliza", model: "claude-opus-4", status: "Online", messages: 1280 },
+  { name: "Scout", model: "gpt-4o-mini", status: "Idle", messages: 342 },
+  { name: "Archivist", model: "llama-3.1-8b", status: "Offline", messages: 57 },
+];
+
+export const Default: Story = {
+  render: (args) => (
+    <Table {...args} className="w-[32rem]">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Agent</TableHead>
+          <TableHead>Model</TableHead>
+          <TableHead>Status</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {agents.map((agent) => (
+          <TableRow key={agent.name}>
+            <TableCell>{agent.name}</TableCell>
+            <TableCell>{agent.model}</TableCell>
+            <TableCell>{agent.status}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+};
+
+export const WithFooter: Story = {
+  render: (args) => (
+    <Table {...args} className="w-[32rem]">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Agent</TableHead>
+          <TableHead className="text-right">Messages</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {agents.map((agent) => (
+          <TableRow key={agent.name}>
+            <TableCell>{agent.name}</TableCell>
+            <TableCell className="text-right">{agent.messages}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          <TableCell>Total</TableCell>
+          <TableCell className="text-right">
+            {agents.reduce((sum, agent) => sum + agent.messages, 0)}
+          </TableCell>
+        </TableRow>
+      </TableFooter>
+    </Table>
+  ),
+};
+
+export const WithCaption: Story = {
+  render: (args) => (
+    <Table {...args} className="w-[32rem]">
+      <TableCaption>Active agents in this workspace.</TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Agent</TableHead>
+          <TableHead>Model</TableHead>
+          <TableHead>Status</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {agents.map((agent) => (
+          <TableRow key={agent.name}>
+            <TableCell>{agent.name}</TableCell>
+            <TableCell>{agent.model}</TableCell>
+            <TableCell>{agent.status}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+};
+
+export const SelectedRow: Story = {
+  render: (args) => (
+    <Table {...args} className="w-[32rem]">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Agent</TableHead>
+          <TableHead>Model</TableHead>
+          <TableHead>Status</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {agents.map((agent, index) => (
+          <TableRow
+            key={agent.name}
+            data-state={index === 0 ? "selected" : undefined}
+          >
+            <TableCell>{agent.name}</TableCell>
+            <TableCell>{agent.model}</TableCell>
+            <TableCell>{agent.status}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+};

--- a/packages/ui/src/components/ui/tabs.stories.tsx
+++ b/packages/ui/src/components/ui/tabs.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs";
+
+const meta = {
+  title: "Primitives/Tabs",
+  component: Tabs,
+  tags: ["autodocs"],
+  argTypes: {
+    orientation: {
+      control: "inline-radio",
+      options: ["horizontal", "vertical"],
+    },
+  },
+  args: { defaultValue: "account" },
+} satisfies Meta<typeof Tabs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Tabs {...args} className="w-[400px]">
+      <TabsList>
+        <TabsTrigger value="account">Account</TabsTrigger>
+        <TabsTrigger value="password">Password</TabsTrigger>
+      </TabsList>
+      <TabsContent value="account">
+        Manage your account details and profile information here.
+      </TabsContent>
+      <TabsContent value="password">
+        Change your password and review active sessions here.
+      </TabsContent>
+    </Tabs>
+  ),
+};
+
+export const ThreeTabs: Story = {
+  args: { defaultValue: "overview" },
+  render: (args) => (
+    <Tabs {...args} className="w-[480px]">
+      <TabsList>
+        <TabsTrigger value="overview">Overview</TabsTrigger>
+        <TabsTrigger value="analytics">Analytics</TabsTrigger>
+        <TabsTrigger value="reports">Reports</TabsTrigger>
+      </TabsList>
+      <TabsContent value="overview">
+        A high-level summary of your workspace activity.
+      </TabsContent>
+      <TabsContent value="analytics">
+        Detailed charts and engagement metrics over time.
+      </TabsContent>
+      <TabsContent value="reports">
+        Exportable reports and scheduled deliveries.
+      </TabsContent>
+    </Tabs>
+  ),
+};
+
+export const WithDisabledTab: Story = {
+  args: { defaultValue: "general" },
+  render: (args) => (
+    <Tabs {...args} className="w-[400px]">
+      <TabsList>
+        <TabsTrigger value="general">General</TabsTrigger>
+        <TabsTrigger value="billing" disabled>
+          Billing
+        </TabsTrigger>
+      </TabsList>
+      <TabsContent value="general">
+        General settings are available to everyone.
+      </TabsContent>
+      <TabsContent value="billing">
+        Billing requires an upgraded plan.
+      </TabsContent>
+    </Tabs>
+  ),
+};

--- a/packages/ui/src/components/ui/tag-editor.stories.tsx
+++ b/packages/ui/src/components/ui/tag-editor.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { TagEditor } from "./tag-editor";
+
+const meta = {
+  title: "Primitives/TagEditor",
+  component: TagEditor,
+  tags: ["autodocs"],
+  argTypes: {
+    label: { control: "text" },
+    placeholder: { control: "text" },
+    maxItems: { control: "number" },
+    addLabel: { control: "text" },
+    removeLabel: { control: "text" },
+  },
+  args: {
+    items: ["typescript", "react", "elizaos"],
+    label: "Tags",
+    placeholder: "Add a tag...",
+  },
+  render: ({ items, onChange, ...args }) => {
+    const [value, setValue] = useState(items);
+    return (
+      <TagEditor
+        {...args}
+        items={value}
+        onChange={(next) => {
+          setValue(next);
+          onChange?.(next);
+        }}
+      />
+    );
+  },
+} satisfies Meta<typeof TagEditor>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+  args: { items: [], label: "Skills" },
+};
+
+export const WithMaxItems: Story = {
+  args: { items: ["alpha", "beta"], maxItems: 3, label: "Up to 3 tags" },
+};
+
+export const WithoutLabel: Story = {
+  args: { label: undefined, placeholder: "Type and press Enter" },
+};

--- a/packages/ui/src/components/ui/textarea.stories.tsx
+++ b/packages/ui/src/components/ui/textarea.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Textarea } from "./textarea";
+
+const meta = {
+  title: "Primitives/Textarea",
+  component: Textarea,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: { control: "select", options: ["default", "form", "config"] },
+    density: {
+      control: "select",
+      options: ["default", "compact", "relaxed"],
+    },
+    hasError: { control: "boolean" },
+    disabled: { control: "boolean" },
+    placeholder: { control: "text" },
+  },
+  args: {
+    variant: "default",
+    density: "default",
+    placeholder: "Type your message...",
+  },
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Form: Story = {
+  args: { variant: "form", placeholder: "Tell us more" },
+};
+export const Config: Story = {
+  args: { variant: "config", defaultValue: '{ "key": "value" }' },
+};
+export const Compact: Story = { args: { density: "compact" } };
+export const Relaxed: Story = { args: { density: "relaxed" } };
+export const ErrorState: Story = {
+  args: { hasError: true, defaultValue: "This field has an error" },
+};
+export const Disabled: Story = {
+  args: { disabled: true, defaultValue: "Cannot edit this" },
+};

--- a/packages/ui/src/components/ui/toggle.stories.tsx
+++ b/packages/ui/src/components/ui/toggle.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Toggle } from "./toggle";
+
+const meta = {
+  title: "Primitives/Toggle",
+  component: Toggle,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: { control: "select", options: ["default", "outline"] },
+    size: { control: "select", options: ["default", "sm", "lg"] },
+    disabled: { control: "boolean" },
+    children: { control: "text" },
+  },
+  args: { children: "Bold", variant: "default", size: "default" },
+} satisfies Meta<typeof Toggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Outline: Story = { args: { variant: "outline" } };
+export const Pressed: Story = { args: { pressed: true } };
+export const Small: Story = { args: { size: "sm" } };
+export const Large: Story = { args: { size: "lg" } };
+export const Disabled: Story = { args: { disabled: true } };

--- a/packages/ui/src/components/ui/tooltip-extended.stories.tsx
+++ b/packages/ui/src/components/ui/tooltip-extended.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { IconTooltip } from "./tooltip-extended";
+
+const Trigger = ({ label }: { label: string }) => (
+  <button
+    type="button"
+    className="rounded-sm border border-border bg-bg-elevated px-3 py-1.5 text-sm text-txt-strong"
+  >
+    {label}
+  </button>
+);
+
+const meta = {
+  title: "Primitives/TooltipExtended",
+  component: IconTooltip,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Hover or focus the trigger to reveal the tooltip (CSS group-hover/group-focus-within).",
+      },
+    },
+  },
+  argTypes: {
+    label: { control: "text" },
+    shortcut: { control: "text" },
+    position: { control: "inline-radio", options: ["top", "bottom"] },
+    multiline: { control: "boolean" },
+  },
+  args: {
+    label: "Settings",
+    position: "top",
+    multiline: false,
+    children: <Trigger label="Hover me" />,
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex min-h-32 items-center justify-center p-12">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof IconTooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithShortcut: Story = {
+  args: { label: "Open command palette", shortcut: "Cmd K" },
+};
+
+export const Bottom: Story = {
+  args: { position: "bottom", label: "Appears below" },
+};
+
+export const Multiline: Story = {
+  args: {
+    label: "Send the current draft to the agent and start a new turn",
+    shortcut: "Enter",
+    multiline: true,
+  },
+};

--- a/packages/ui/src/components/ui/tooltip.stories.tsx
+++ b/packages/ui/src/components/ui/tooltip.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "./button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipHint,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./tooltip";
+
+const meta = {
+  title: "Primitives/Tooltip",
+  component: TooltipHint,
+  tags: ["autodocs"],
+  argTypes: {
+    content: { control: "text" },
+    side: {
+      control: "select",
+      options: ["top", "right", "bottom", "left"],
+    },
+    sideOffset: { control: "number" },
+    delayDuration: { control: "number" },
+  },
+  args: {
+    content: "Helpful hint",
+    side: "bottom",
+    children: <Button variant="outline">Hover me</Button>,
+  },
+} satisfies Meta<typeof TooltipHint>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Top: Story = { args: { side: "top", content: "Shown above" } };
+
+export const Right: Story = {
+  args: { side: "right", content: "Shown to the right" },
+};
+
+export const Left: Story = {
+  args: { side: "left", content: "Shown to the left" },
+};
+
+/** The composed primitives wired up manually, forced open so the content is visible. */
+export const Composed: Story = {
+  render: () => (
+    <TooltipProvider>
+      <Tooltip defaultOpen>
+        <TooltipTrigger asChild>
+          <Button variant="outline">Always visible</Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">Tooltip content</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  ),
+};

--- a/packages/ui/src/components/ui/typography.stories.tsx
+++ b/packages/ui/src/components/ui/typography.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Heading, Text } from "./typography";
+
+const meta = {
+  title: "Primitives/Typography",
+  component: Text,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "medium", "small", "muted", "lead", "large"],
+    },
+    children: { control: "text" },
+  },
+  args: {
+    children: "The quick brown fox jumps over the lazy dog.",
+    variant: "default",
+  },
+} satisfies Meta<typeof Text>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+export const Muted: Story = {
+  args: { variant: "muted", children: "Secondary, lower-emphasis copy." },
+};
+export const Lead: Story = {
+  args: { variant: "lead", children: "A leading paragraph that sets context." },
+};
+export const Large: Story = {
+  args: { variant: "large", children: "Large emphasis text" },
+};
+
+/** Every Text variant in one view. */
+export const AllTextVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <Text variant="lead">Lead</Text>
+      <Text variant="large">Large</Text>
+      <Text variant="default">Default</Text>
+      <Text variant="medium">Medium</Text>
+      <Text variant="small">Small</Text>
+      <Text variant="muted">Muted</Text>
+    </div>
+  ),
+};
+
+/** Every Heading level in one view. */
+export const Headings: Story = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <Heading level="h1">Heading h1</Heading>
+      <Heading level="h2">Heading h2</Heading>
+      <Heading level="h3">Heading h3</Heading>
+      <Heading level="h4">Heading h4</Heading>
+      <Heading level="h5">Heading h5</Heading>
+      <Heading level="h6">Heading h6</Heading>
+    </div>
+  ),
+};

--- a/packages/ui/src/components/views/ViewIcon.stories.tsx
+++ b/packages/ui/src/components/views/ViewIcon.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ViewIcon } from "./ViewIcon";
+
+const meta = {
+  title: "Views/ViewIcon",
+  component: ViewIcon,
+  tags: ["autodocs"],
+  argTypes: {
+    icon: { control: "text" },
+    label: { control: "text" },
+    className: { control: "text" },
+  },
+  args: { icon: "MessageSquare", label: "Messages", className: "h-5 w-5" },
+} satisfies Meta<typeof ViewIcon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** A known Lucide icon name resolved from the internal registry. */
+export const NamedIcon: Story = {};
+
+/** An image source (URL or data URI) renders an <img> instead of a glyph. */
+export const ImageSource: Story = {
+  args: {
+    icon: "https://avatars.githubusercontent.com/u/130973801?s=200&v=4",
+    label: "elizaOS",
+  },
+};
+
+/** Unknown / missing icon falls back to the first letter of the label. */
+export const LetterFallback: Story = {
+  args: { icon: null, label: "Wallet" },
+};
+
+/** Larger size via className override. */
+export const LargeIcon: Story = {
+  args: { icon: "Bot", label: "Agent", className: "h-10 w-10" },
+};


### PR DESCRIPTION
## What

Adds Storybook stories for nine `@elizaos/ui` components that ship today but had **no Storybook coverage**:

`Table` · `Tabs` · `TagEditor` · `Textarea` · `Tooltip` · `IconTooltip` (tooltip-extended) · `Typography` · `ViewIcon` · `Toggle`

## Why

These were the only genuinely net-new pieces on the now-superseded `nubs/continuous-chat-overlay` branch (#8178) — the continuous-chat overlay and the rest of the Storybook catalog already landed on `develop`. Rather than rebase a ~218-commit-behind branch, this PR ports just the missing stories onto current `develop`.

## Scope / safety

- **Additive only** — nine new `*.stories.tsx` files, **no source or behavior changes**.
- Each story references the components' **current** public API on develop (verified) and **renders clean in Storybook** (0 console/page errors).
- Auto-discovered by the existing `../src/**/*.stories.@(ts|tsx)` glob — **no config changes**.
- `biome check` passes on all nine files.

Closes out the Storybook portion of #8178.