### PR TITLE
feat(ui): prompt-suggestion strip on the continuous-chat overlay

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.stories.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.stories.tsx
@@ -86,6 +86,11 @@ type Story = StoryObj<typeof meta>;
 /** Resting ambient bar over the warm "good evening" backdrop. */
 export const Ambient: Story = { args: { controller: makeController() } };
 
+/** Five tailored prompt suggestions on the empty resting overlay (keyboard-strip style). */
+export const PromptSuggestions: Story = {
+  args: { controller: makeController({ messages: [] }) },
+};
+
 /** Listening — live interim transcript + the warm breath glow. */
 export const Listening: Story = {
   args: {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -8,6 +8,7 @@ import {
   MAX_CHAT_IMAGES,
 } from "../../utils/image-attachment";
 import type { ShellMessage } from "./shell-state";
+import { usePromptSuggestions } from "./usePromptSuggestions";
 import type { ShellController } from "./useShellController";
 
 /**
@@ -245,6 +246,9 @@ export function ContinuousChatOverlay({
   const hasDraft = draft.trim().length > 0;
   const hasImages = pendingImages.length > 0;
 
+  // Five tailored prompt suggestions for the resting overlay (pure/client-side).
+  const suggestions = usePromptSuggestions(messages);
+
   // Whisper: when a genuinely NEW line arrives while collapsed, surface the
   // recent lines for 12s. Keyed on the last message id (not length, and the
   // `expanded` dep early-returns) so toggling the panel never re-triggers it.
@@ -297,6 +301,19 @@ export function ContinuousChatOverlay({
     setExpanded(true);
     inputRef.current?.focus();
   }, [draft, pendingImages, canSend, send]);
+
+  // Tapping a suggestion sends it immediately (same path as submit), so the
+  // strip is a one-tap shortcut, not just a draft pre-fill.
+  const pickSuggestion = React.useCallback(
+    (text: string) => {
+      if (!canSend) return;
+      setDraft("");
+      send(text);
+      setExpanded(true);
+      inputRef.current?.focus();
+    },
+    [canSend, send],
+  );
 
   const addImageFiles = React.useCallback((files: FileList | File[]) => {
     void filesToImageAttachments(files)
@@ -517,6 +534,41 @@ export function ContinuousChatOverlay({
         >
           {transcript}
           <span aria-hidden="true">…</span>
+        </div>
+      ) : null}
+
+      {/* Five tailored prompt suggestions — keyboard-strip style, shown only on
+          the resting overlay (collapsed, ready, nothing typed/attached, not
+          listening) so they invite a first move without ever crowding an active
+          conversation. Tapping one sends it immediately. */}
+      {!expanded &&
+      !recording &&
+      !booting &&
+      canSend &&
+      !hasDraft &&
+      !hasImages ? (
+        <div
+          className="pointer-events-auto relative mb-2 flex w-full max-w-3xl flex-wrap items-center justify-center gap-2"
+          data-testid="chat-suggestions"
+        >
+          {suggestions.map((s, i) => (
+            <button
+              key={s}
+              type="button"
+              data-testid={`chat-suggestion-${i}`}
+              aria-label={s}
+              onClick={() => pickSuggestion(s)}
+              className={cn(
+                "max-w-full truncate rounded-full border border-white/15 bg-black/40 px-3.5 py-1.5",
+                "text-[13px] text-white/80 backdrop-blur-xl transition-colors",
+                "shadow-[inset_0_1px_0_rgba(255,255,255,0.12),0_10px_30px_-12px_rgba(0,0,0,0.6)]",
+                "hover:border-white/30 hover:bg-white/15 hover:text-white",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60",
+              )}
+            >
+              {s}
+            </button>
+          ))}
         </div>
       ) : null}
 

--- a/packages/ui/src/components/shell/usePromptSuggestions.test.ts
+++ b/packages/ui/src/components/shell/usePromptSuggestions.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import type { ShellMessage } from "./shell-state";
+import { computePromptSuggestions } from "./usePromptSuggestions";
+
+const msg = (id: string, role: ShellMessage["role"], content: string) =>
+  ({ id, role, content, createdAt: 0 }) as ShellMessage;
+
+describe("computePromptSuggestions", () => {
+  it("returns exactly 5 suggestions for an empty thread", () => {
+    const out = computePromptSuggestions([]);
+    expect(out).toHaveLength(5);
+  });
+
+  it("returns unique (deduped) suggestions", () => {
+    const out = computePromptSuggestions([]);
+    expect(new Set(out).size).toBe(out.length);
+  });
+
+  it("leads with the cold-start starter when there is no thread", () => {
+    const out = computePromptSuggestions([
+      msg("a", "user", "   "), // whitespace-only does not count as a thread
+    ]);
+    expect(out).toHaveLength(5);
+    expect(out[0]).toBe("What can you do?");
+  });
+
+  it("swaps slot 0 for the continue-thread follow-up once a thread exists", () => {
+    const out = computePromptSuggestions([
+      msg("a", "user", "hi"),
+      msg("b", "assistant", "hey there"),
+    ]);
+    expect(out).toHaveLength(5);
+    expect(out[0]).toBe("Continue where we left off");
+    expect(new Set(out).size).toBe(5);
+  });
+});

--- a/packages/ui/src/components/shell/usePromptSuggestions.ts
+++ b/packages/ui/src/components/shell/usePromptSuggestions.ts
@@ -1,0 +1,51 @@
+import * as React from "react";
+
+import type { ShellMessage } from "./shell-state";
+
+/**
+ * Pure, network-free prompt suggestions for the continuous-chat overlay.
+ *
+ * Returns EXACTLY 5 short prompts to offer on the resting (collapsed, empty
+ * composer) overlay — like a phone keyboard's word strip, but for whole
+ * prompts. Phase 1 is deliberately client-only and deterministic: a fixed
+ * starter set, lightly adapted to whether a conversation is already underway
+ * (slot 0 becomes a "pick up where we left off" follow-up). A later increment
+ * can swap the body for a tailored `GET /api/suggestions` call (history +
+ * memory + active-view aware) without changing this hook's signature or the
+ * overlay that consumes it.
+ */
+
+// Cold-start starters — the first things a new user sees on the empty overlay.
+const STARTERS: readonly string[] = [
+  "What can you do?",
+  "Summarize my day",
+  "Draft a reply",
+  "What's on my plate?",
+  "Explain this for me",
+];
+
+// Shown in slot 0 once there's an active thread, so the strip nudges forward
+// instead of restarting from scratch.
+const THREAD_FOLLOW_UP = "Continue where we left off";
+
+/**
+ * Pure computation (no React) so it can be unit-tested directly. Always returns
+ * exactly 5 unique prompt strings, order-stable.
+ */
+export function computePromptSuggestions(
+  messages: readonly ShellMessage[],
+): string[] {
+  const hasThread = messages.some((m) => m.content.trim().length > 0);
+  const ordered = hasThread ? [THREAD_FOLLOW_UP, ...STARTERS] : [...STARTERS];
+  // Dedupe (order-preserving), then take exactly 5 (STARTERS guarantees >= 5).
+  return Array.from(new Set(ordered)).slice(0, 5);
+}
+
+/** Hook wrapper: memoised on whether a thread is active. */
+export function usePromptSuggestions(
+  messages: readonly ShellMessage[],
+): string[] {
+  const hasThread = messages.some((m) => m.content.trim().length > 0);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: hasThread is the only input that changes the result; recomputing on it (not the messages array identity) keeps the 5 stable across unrelated re-renders.
+  return React.useMemo(() => computePromptSuggestions(messages), [hasThread]);
+}


### PR DESCRIPTION
## What

Adds a keyboard-strip-style row of **exactly five tailored prompt suggestions** to the resting `ContinuousChatOverlay`, so the empty overlay invites a first move — mirroring odysseus's welcome-screen suggestion chips.

![suggestion strip](https://github.com/elizaOS/eliza/assets/placeholder)
*(5 glass pills above the composer: "What can you do?", "Summarize my day", "Draft a reply", "What's on my plate?", "Explain this for me")*

## How

- **New pure hook `usePromptSuggestions`** (+ `computePromptSuggestions` for direct unit-testing): returns 5 unique starters, swapping slot 0 for a "continue where we left off" follow-up once a conversation exists. Client-only and deterministic — a later increment can swap the body for a tailored `GET /api/suggestions` call (history/memory/active-view aware) **without changing the hook signature or the overlay**.
- **Overlay** renders the strip only on the resting state (collapsed · ready · nothing typed/attached · not listening), so it never crowds an active thread. Tapping a chip **sends it immediately** via the existing `controller.send` path. Reuses the overlay's dark-glass visual language.

## Scope / safety

- **Additive, presentational** — no API/backend/plugin changes; the overlay stays renderable in isolation (pure).
- `biome check` clean; the suggestion logic has a unit test (4 cases); a new `PromptSuggestions` Storybook story renders the strip over the mock backdrop.
- Verified in Storybook with Playwright: exactly 5 chips, correct labels, 0 console/page errors, and a tap fires the send handler.

First increment toward richer, context-aware prompt suggestions on the agent overlay.