### PR TITLE
fix(plugin-task-coordinator): four state/parity bugs in the odysseus views

### DIFF
--- a/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-stream.test.ts
+++ b/plugins/plugin-task-coordinator/__tests__/unit/orchestrator-stream.test.ts
@@ -90,6 +90,51 @@ describe("buildConversation", () => {
     ]);
   });
 
+  it("keeps consecutive user messages as separate turns (no run-on coalescing)", () => {
+    const blocks = buildConversation(
+      [
+        baseMessage({
+          id: "u1",
+          senderKind: "user",
+          direction: "stdin",
+          content: "first question",
+          timestamp: 10,
+        }),
+        baseMessage({
+          id: "u2",
+          senderKind: "user",
+          direction: "stdin",
+          content: "second question",
+          timestamp: 11,
+        }),
+      ],
+      [] satisfies EventRecord[],
+      (message) => message.senderKind,
+      new Set(),
+    );
+
+    // Two discrete user messages must render as two distinct user turns, each
+    // with its own id/timestamp — not merged into one run-on bubble.
+    expect(blocks).toEqual([
+      {
+        kind: "user",
+        key: "msg-u1",
+        at: 10,
+        content: "first question",
+        messageIds: ["u1"],
+        sessionId: null,
+      },
+      {
+        kind: "user",
+        key: "msg-u2",
+        at: 11,
+        content: "second question",
+        messageIds: ["u2"],
+        sessionId: null,
+      },
+    ]);
+  });
+
   it("preserves message identity when adjacent chunks merge", () => {
     const blocks = buildConversation(
       [

--- a/plugins/plugin-task-coordinator/src/odysseus/GroupChatView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/GroupChatView.tsx
@@ -201,7 +201,11 @@ export function GroupChatView({
       setDetail(null);
       return;
     }
-    // Reset transient per-room UI when the selected room changes.
+    // Reset transient per-room UI when the selected room changes. Clear the
+    // previous room's detail FIRST so its now-foreign participant rows can't
+    // render or be acted on (remove/start) against the new room while the
+    // refetch is in flight.
+    setDetail(null);
     setPicking(false);
     setAddError(null);
     setStartError(null);

--- a/plugins/plugin-task-coordinator/src/odysseus/TasksView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/TasksView.tsx
@@ -290,6 +290,15 @@ export function TasksView({
     });
   }, [counts]);
 
+  // Clear a category filter whose category no longer exists (e.g. a refresh
+  // completes/removes the last thread in that category) — otherwise the list
+  // strands at "No matching tasks" with the reset chip hidden (the chip row
+  // only renders when categories.length > 1). Mirrors upstream odysseus, which
+  // clears its task filter when its count is gone before the visibility gate.
+  useEffect(() => {
+    if (filter && !counts[filter]) setFilter(null);
+  }, [counts, filter]);
+
   const visible = useMemo(() => {
     const q = search.trim().toLowerCase();
     const out = threads.filter((t) => {

--- a/plugins/plugin-task-coordinator/src/odysseus/VoiceView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/VoiceView.tsx
@@ -336,9 +336,18 @@ export function VoiceView({
 
   const stopRecording = () => {
     const handle = captureRef.current;
-    if (handle) {
-      void handle.stop().catch(() => {});
+    // The browser SpeechRecognition engine can auto-end (timeout) without
+    // propagating back to "idle", leaving the recorder wedged in a live state
+    // with a Stop button that no-ops on the already-ended handle. If the handle
+    // is gone or no longer active, force a clean reset (mirroring the open/teardown
+    // path) so the next press starts a fresh capture instead of doing nothing.
+    if (!handle?.isActive()) {
+      teardownCapture();
+      setRecState("idle");
+      setRecError(null);
+      return;
     }
+    void handle.stop().catch(() => {});
   };
 
   const toggleRecording = () => {

--- a/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
+++ b/plugins/plugin-task-coordinator/src/orchestrator-stream.tsx
@@ -405,7 +405,10 @@ type Atom =
  * are adjacent in time merge into one turn. `stderr` stays in its own lane so
  * error output never blends into normal prose. */
 function messageLane(message: CodingAgentTaskMessageRecord): string {
-  if (message.senderKind === "user") return "user";
+  // Each user message is its own turn: key on the id (not a shared "user"
+  // lane) so consecutive user messages don't coalesce into one run-on bubble
+  // under a single (wrong) shared timestamp.
+  if (message.senderKind === "user") return `user:${message.id}`;
   const stream = message.direction === "stderr" ? "err" : "out";
   // Fall back to the message id, not a shared empty string, so unrelated
   // session-less output never coalesces into one rendered turn.
@@ -539,7 +542,7 @@ export function buildConversation(
         openLane.block.messageIds.push(atom.message.id);
         continue;
       }
-      if (lane === "user") {
+      if (atom.message.senderKind === "user") {
         const block: ConversationBlock = {
           kind: "user",
           key: `msg-${atom.message.id}`,


### PR DESCRIPTION
## What

Four confirmed, **adversarially-verified** state/correctness bugs in the LIVE odysseus views, each a minimal targeted fix that matches upstream odysseus behavior. No backend/API changes.

| # | View | Bug | Fix |
|---|------|-----|-----|
| 1 | **VoiceView** | Browser SpeechRecognition auto-timeout leaves the recorder wedged in `"Recording…"` with a dead Stop button (Stop no-ops on the already-ended handle). | `stopRecording()` force-resets (teardown + `idle`) when the handle is gone/inactive, so the next press starts fresh. |
| 2 | **GroupChatView** | Switching rooms shows the *previous* room's participants and can mis-target remove/start at the new room (stale `detail` during refetch). | Clear `detail` at the top of the room-change effect so foreign rows can't render or be acted on. |
| 3 | **TasksView** | A category filter strands the list at "No matching tasks" with the reset chip hidden when that category's last thread disappears. | Clear a filter whose category no longer exists (mirrors upstream odysseus `tasks.js`). |
| 4 | **orchestrator-stream** | Consecutive user messages coalesce into one run-on bubble under a single wrong timestamp. | Give each user message its own lane; derive block `kind` from `senderKind` (not the lane string). + regression test. |

## Verification (DoD)
- `biome check` clean (0 warnings) on all changed files.
- Plugin unit tests **26/26** pass, including a new test asserting consecutive user messages render as separate turns.
- `tsgo` typecheck: **0 errors in the changed files** (the only repo-wide error is an unbuilt `@elizaos/core` in a file this PR doesn't touch — environmental).
- View bundle (`build:views`) compiles clean.

Found via an adversarial bug-hunt over the LIVE odysseus views (objective: keep the shipped odysseus UI flawless + at parity with upstream). Two further findings — a missing Cookbook per-model uninstall control and a missing drag-to-edge fullscreen snap zone — are deferred as separate follow-ups (one is a feature-add, one needs a UX intent decision).