### PR TITLE
fix(ui): restore the inline chevron expand affordance on the continuous-chat overlay

### DIFF
--- a/packages/app/test/ui-smoke/plugin-views-visual.spec.ts
+++ b/packages/app/test/ui-smoke/plugin-views-visual.spec.ts
@@ -184,13 +184,11 @@ test.describe("registered plugin views visual coverage", () => {
       );
 
       if (view.shellPill === "expected") {
-        const assistantLauncher = page
-          .getByTestId("shell-home-pill")
-          .or(
-            page.getByRole("button", {
-              name: /show conversation|hide conversation/i,
-            }),
-          );
+        const assistantLauncher = page.getByTestId("shell-home-pill").or(
+          page.getByRole("button", {
+            name: /expand conversation|collapse conversation/i,
+          }),
+        );
         const assistantComposer = page
           .getByTestId("chat-composer-textarea")
           .or(page.getByLabel("message"))
@@ -203,13 +201,11 @@ test.describe("registered plugin views visual coverage", () => {
         await assistantComposer.focus();
       } else {
         await expect(
-          page
-            .getByTestId("shell-home-pill")
-            .or(
-              page.getByRole("button", {
-                name: /show conversation|hide conversation/i,
-              }),
-            ),
+          page.getByTestId("shell-home-pill").or(
+            page.getByRole("button", {
+              name: /expand conversation|collapse conversation/i,
+            }),
+          ),
         ).toHaveCount(0);
       }
 
@@ -239,8 +235,7 @@ test.describe("registered plugin views visual coverage", () => {
             element.getAttribute("role") ?? "",
             element.getAttribute("aria-label") ?? "",
             element.getAttribute("data-testid") ?? "",
-            element.textContent?.trim().replace(/\s+/g, " ").slice(0, 80) ??
-              "",
+            element.textContent?.trim().replace(/\s+/g, " ").slice(0, 80) ?? "",
           ]
             .filter(Boolean)
             .join(":");

--- a/packages/app/test/ui-smoke/tts-stt-e2e.spec.ts
+++ b/packages/app/test/ui-smoke/tts-stt-e2e.spec.ts
@@ -816,7 +816,7 @@ test("always-on chat mode starts passive browser STT and keeps capture open afte
   }
 
   const showConversation = page.getByRole("button", {
-    name: /show conversation/i,
+    name: /expand conversation|collapse conversation/i,
   });
   if ((await showConversation.count()) > 0) {
     await expect(showConversation).toBeVisible();

--- a/packages/app/test/ui-smoke/ui-smoke.spec.ts
+++ b/packages/app/test/ui-smoke/ui-smoke.spec.ts
@@ -24,7 +24,7 @@ test("chat, apps, and settings routes render through the real shell", async ({
     [
       {
         selector:
-          'button[aria-label="show conversation"], button[aria-label="hide conversation"]',
+          'button[aria-label="expand conversation"], button[aria-label="collapse conversation"]',
       },
       {
         selector:

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -81,13 +81,15 @@ describe("ContinuousChatOverlay", () => {
     expect(input.value).toBe("");
   });
 
-  it("expands the thread from the chat icon and exposes aria-expanded / a log region", () => {
+  it("expands the thread from the inline chevron and exposes aria-expanded / a log region", () => {
     render(<ContinuousChatOverlay controller={makeController()} />);
-    const toggle = screen.getByLabelText("show conversation");
+    const toggle = screen.getByLabelText("expand conversation");
     expect(toggle.getAttribute("aria-expanded")).toBe("false");
     fireEvent.click(toggle);
     expect(
-      screen.getByLabelText("hide conversation").getAttribute("aria-expanded"),
+      screen
+        .getByLabelText("collapse conversation")
+        .getAttribute("aria-expanded"),
     ).toBe("true");
     expect(document.getElementById("continuous-thread")).toBeTruthy();
   });
@@ -101,7 +103,7 @@ describe("ContinuousChatOverlay", () => {
 
   it("filters whitespace-only messages from the expanded thread", () => {
     render(<ContinuousChatOverlay controller={makeController()} />);
-    fireEvent.click(screen.getByLabelText("show conversation"));
+    fireEvent.click(screen.getByLabelText("expand conversation"));
     const log = document.getElementById("continuous-thread");
     expect(log?.textContent).toContain("hi there");
     // one real message → exactly one transcript bubble
@@ -119,7 +121,7 @@ describe("ContinuousChatOverlay", () => {
         } as unknown as Partial<ShellController>)}
       />,
     );
-    fireEvent.click(screen.getByLabelText("show conversation"));
+    fireEvent.click(screen.getByLabelText("expand conversation"));
     const log = document.getElementById("continuous-thread");
     const lines = log?.querySelectorAll('[data-testid="thread-line"]');
     expect(lines?.length).toBe(2);
@@ -131,10 +133,10 @@ describe("ContinuousChatOverlay", () => {
 
   it("collapses the expanded thread on Escape", () => {
     render(<ContinuousChatOverlay controller={makeController()} />);
-    fireEvent.click(screen.getByLabelText("show conversation"));
+    fireEvent.click(screen.getByLabelText("expand conversation"));
     const input = screen.getByLabelText("message");
     fireEvent.keyDown(input, { key: "Escape" });
-    expect(screen.getByLabelText("show conversation")).toBeTruthy();
+    expect(screen.getByLabelText("expand conversation")).toBeTruthy();
   });
 
   it("shows the attach (+) control", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -135,21 +135,22 @@ function TypingDots(): React.JSX.Element {
   );
 }
 
-/** Speech-bubble glyph for the expand/collapse affordance at the top of the stack. */
-function ChatIcon(): React.JSX.Element {
+/** Chevron for the inline expand/collapse affordance inside the composer bar. */
+function Chevron({ up }: { up: boolean }): React.JSX.Element {
   return (
     <svg
-      width="18"
-      height="18"
+      width="16"
+      height="16"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
       strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
+      style={{ transform: up ? "rotate(180deg)" : undefined }}
       aria-hidden="true"
     >
-      <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+      <path d="m18 15-6-6-6 6" />
     </svg>
   );
 }
@@ -229,7 +230,6 @@ export function ContinuousChatOverlay({
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   const threadRef = React.useRef<HTMLDivElement>(null);
   const composerRef = React.useRef<HTMLDivElement>(null);
-  const topBarRef = React.useRef<HTMLDivElement>(null);
   const focusThreadRef = React.useRef(false);
   const pushToTalkTimerRef = React.useRef<number | null>(null);
   const pushToTalkActiveRef = React.useRef(false);
@@ -413,8 +413,7 @@ export function ContinuousChatOverlay({
       if (!target) return;
       if (
         threadRef.current?.contains(target) ||
-        composerRef.current?.contains(target) ||
-        topBarRef.current?.contains(target)
+        composerRef.current?.contains(target)
       ) {
         return;
       }
@@ -437,30 +436,6 @@ export function ContinuousChatOverlay({
         aria-hidden="true"
         className="pointer-events-none absolute inset-x-0 bottom-0 h-72 bg-gradient-to-t from-black/45 via-black/15 to-transparent"
       />
-
-      {/* Chat icon — the single affordance to expand/collapse the thread. */}
-      {hasThread ? (
-        <div ref={topBarRef} className="pointer-events-auto relative mb-2">
-          <button
-            type="button"
-            aria-label={expanded ? "hide conversation" : "show conversation"}
-            aria-expanded={expanded}
-            aria-controls={
-              expanded && hasThread ? "continuous-thread" : undefined
-            }
-            onClick={toggleExpand}
-            className={cn(
-              "grid h-9 w-9 place-items-center rounded-full border transition-colors",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70",
-              expanded
-                ? "border-white/40 bg-white/85 text-black"
-                : "border-white/15 bg-black/45 text-white/80 backdrop-blur-xl hover:bg-white/15 hover:text-white",
-            )}
-          >
-            <ChatIcon />
-          </button>
-        </div>
-      ) : null}
 
       {/* Expanded — the one continuous thread, as a single flowing transcript */}
       {expanded && hasThread ? (
@@ -638,6 +613,25 @@ export function ContinuousChatOverlay({
           }}
         />
         <div className={cn(GLASS_BAR, "relative")}>
+          {/* Inline expand/collapse — a quiet chevron that dissolves into the
+              bar, not a separate floating button. */}
+          <button
+            type="button"
+            aria-label={
+              expanded ? "collapse conversation" : "expand conversation"
+            }
+            aria-expanded={expanded}
+            aria-controls={
+              expanded && hasThread ? "continuous-thread" : undefined
+            }
+            onClick={toggleExpand}
+            className={cn(
+              "grid h-8 w-7 shrink-0 place-items-center rounded-full text-white/70 transition-colors hover:text-white",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70",
+            )}
+          >
+            <Chevron up={expanded} />
+          </button>
           <SoftButton
             glyph={PLUS_GLYPH}
             label="attach image"


### PR DESCRIPTION
## What

The continuous-chat overlay's expand/collapse control had drifted into a **separate floating speech-bubble button** hovering above the composer bar. It reads as heavy chrome and breaks the overlay's minimal, single-surface feel.

This restores the original clean design: a **quiet chevron inside the composer bar** (first control, left of the attach `+`), rotating to indicate expanded/collapsed — no separate floating button.

**Before:** `[ 💬 ]` floating button above → then `[ +  say anything…  → ]`
**After:** `[ ⌃  +  say anything…  → ]` — one bar, the chevron dissolves into it.

## How
- Drop the floating `ChatIcon` button block + the `ChatIcon` glyph + the now-unused `topBarRef` (the inline chevron sits inside `composerRef`, already covered by the click-outside guard).
- Add the inline chevron as the composer bar's first child (restores `Chevron` + `aria-label` "expand/collapse conversation").
- Keeps every current behavior: image attach, push-to-talk mic, the 5-prompt suggestion strip, thread expand/collapse, Escape-to-collapse.

## Verification
- `biome check` clean on all changed files.
- Overlay unit tests **30/30** (updated the 3 assertions that matched the old aria-labels).
- Updated the ui-smoke e2e specs (`tts-stt`, `ui-smoke`, `plugin-views-visual`) that located the toggle by the old "show/hide conversation" labels.
- Verified in Storybook (screenshot): the chevron renders inline in the bar across the overlay states; no floating button.

Note: also applied biome's canonical formatting to a small pre-existing unformatted region of `plugin-views-visual.spec.ts` (file is edited here anyway).