### PR TITLE
feat(ui): time-of-day + history-aware prompt suggestions on the continuous-chat overlay

### DIFF
--- a/packages/ui/src/components/shell/usePromptSuggestions.test.ts
+++ b/packages/ui/src/components/shell/usePromptSuggestions.test.ts
@@ -17,7 +17,7 @@ describe("computePromptSuggestions", () => {
     expect(new Set(out).size).toBe(out.length);
   });
 
-  it("leads with the cold-start starter when there is no thread", () => {
+  it("leads with the neutral starter when there is no thread and no clock", () => {
     const out = computePromptSuggestions([
       msg("a", "user", "   "), // whitespace-only does not count as a thread
     ]);
@@ -25,13 +25,26 @@ describe("computePromptSuggestions", () => {
     expect(out[0]).toBe("What can you do?");
   });
 
-  it("swaps slot 0 for the continue-thread follow-up once a thread exists", () => {
-    const out = computePromptSuggestions([
-      msg("a", "user", "hi"),
-      msg("b", "assistant", "hey there"),
-    ]);
-    expect(out).toHaveLength(5);
-    expect(out[0]).toBe("Continue where we left off");
-    expect(new Set(out).size).toBe(5);
+  it("tailors the cold-start lead to the time of day", () => {
+    expect(computePromptSuggestions([], 8)[0]).toBe("Plan my day"); // morning
+    expect(computePromptSuggestions([], 14)[0]).toBe("What's left today?"); // afternoon
+    expect(computePromptSuggestions([], 21)[0]).toBe("Recap my day"); // evening
+    expect(computePromptSuggestions([], 3)[0]).toBe("Recap my day"); // late night
+    // still exactly 5 unique regardless of the hour
+    for (const h of [8, 14, 21, 3]) {
+      const out = computePromptSuggestions([], h);
+      expect(out).toHaveLength(5);
+      expect(new Set(out).size).toBe(5);
+    }
+  });
+
+  it("history beats time of day: an active thread always leads with the follow-up", () => {
+    const thread = [msg("a", "user", "hi"), msg("b", "assistant", "hey there")];
+    for (const h of [8, 14, 21, undefined]) {
+      const out = computePromptSuggestions(thread, h);
+      expect(out).toHaveLength(5);
+      expect(out[0]).toBe("Continue where we left off");
+      expect(new Set(out).size).toBe(5);
+    }
   });
 });

--- a/packages/ui/src/components/shell/usePromptSuggestions.ts
+++ b/packages/ui/src/components/shell/usePromptSuggestions.ts
@@ -7,15 +7,19 @@ import type { ShellMessage } from "./shell-state";
  *
  * Returns EXACTLY 5 short prompts to offer on the resting (collapsed, empty
  * composer) overlay — like a phone keyboard's word strip, but for whole
- * prompts. Phase 1 is deliberately client-only and deterministic: a fixed
- * starter set, lightly adapted to whether a conversation is already underway
- * (slot 0 becomes a "pick up where we left off" follow-up). A later increment
- * can swap the body for a tailored `GET /api/suggestions` call (history +
- * memory + active-view aware) without changing this hook's signature or the
- * overlay that consumes it.
+ * prompts. Client-only and deterministic, lightly tailored to context:
+ *  - HISTORY: once a conversation is underway, slot 0 becomes a "pick up where
+ *    we left off" follow-up so the strip nudges forward, not from scratch.
+ *  - TIME OF DAY: with no thread yet, slot 0 matches the overlay's own
+ *    morning/afternoon/evening greeting ("Plan my day" / "What's left today?" /
+ *    "Recap my day"), so the first move feels of-the-moment.
+ *
+ * A later increment can back this with a tailored `GET /api/suggestions` call
+ * (memory + active-view aware) without changing this hook's signature or the
+ * overlay that consumes it — the static set here stays as the offline fallback.
  */
 
-// Cold-start starters — the first things a new user sees on the empty overlay.
+// Cold-start starters — the stable pool the strip always draws from.
 const STARTERS: readonly string[] = [
   "What can you do?",
   "Summarize my day",
@@ -25,27 +29,48 @@ const STARTERS: readonly string[] = [
 ];
 
 // Shown in slot 0 once there's an active thread, so the strip nudges forward
-// instead of restarting from scratch.
+// instead of restarting from scratch (history-aware).
 const THREAD_FOLLOW_UP = "Continue where we left off";
 
 /**
+ * The time-of-day lead prompt for an empty overlay, matching the greeting the
+ * overlay shows. `hour` is a local 0–23 hour; when omitted, falls back to the
+ * neutral first starter (e.g. server render / unknown clock).
+ */
+function timeOfDayLead(hour: number | undefined): string {
+  if (hour === undefined) return STARTERS[0];
+  if (hour >= 5 && hour < 12) return "Plan my day";
+  if (hour >= 12 && hour < 18) return "What's left today?";
+  return "Recap my day";
+}
+
+/**
  * Pure computation (no React) so it can be unit-tested directly. Always returns
- * exactly 5 unique prompt strings, order-stable.
+ * exactly 5 unique prompt strings, order-stable. `hour` (local 0–23) tailors the
+ * cold-start lead; an active thread takes precedence with a continue follow-up.
  */
 export function computePromptSuggestions(
   messages: readonly ShellMessage[],
+  hour?: number,
 ): string[] {
   const hasThread = messages.some((m) => m.content.trim().length > 0);
-  const ordered = hasThread ? [THREAD_FOLLOW_UP, ...STARTERS] : [...STARTERS];
-  // Dedupe (order-preserving), then take exactly 5 (STARTERS guarantees >= 5).
-  return Array.from(new Set(ordered)).slice(0, 5);
+  const lead = hasThread ? THREAD_FOLLOW_UP : timeOfDayLead(hour);
+  // Lead first, then the stable pool; dedupe (order-preserving) and take 5.
+  // STARTERS alone is >= 5, so a deduped lead never drops the count below 5.
+  return Array.from(new Set([lead, ...STARTERS])).slice(0, 5);
 }
 
-/** Hook wrapper: memoised on whether a thread is active. */
+/** Hook wrapper: memoised on the inputs that change the result. */
 export function usePromptSuggestions(
   messages: readonly ShellMessage[],
 ): string[] {
   const hasThread = messages.some((m) => m.content.trim().length > 0);
-  // biome-ignore lint/correctness/useExhaustiveDependencies: hasThread is the only input that changes the result; recomputing on it (not the messages array identity) keeps the 5 stable across unrelated re-renders.
-  return React.useMemo(() => computePromptSuggestions(messages), [hasThread]);
+  // Bucket the clock to the hour so the strip is stable within an hour and only
+  // recomputes when the time-of-day lead would actually change.
+  const hour = new Date().getHours();
+  // biome-ignore lint/correctness/useExhaustiveDependencies: hasThread + hour are the only inputs that change the result; depending on the messages array identity would needlessly churn the 5 on every unrelated re-render.
+  return React.useMemo(
+    () => computePromptSuggestions(messages, hour),
+    [hasThread, hour],
+  );
 }


### PR DESCRIPTION
## What
Makes the resting-overlay's 5-prompt suggestion strip lightly **tailored** (client-side, no backend): the lead chip now matches the overlay's own greeting — **"Plan my day"** (morning) · **"What's left today?"** (afternoon) · **"Recap my day"** (evening). An active thread still takes precedence with the **"Continue where we left off"** follow-up.

Builds on the always-5 strip (#8201). Next step toward "context/history-aware" suggestions without touching any backend.

## How
- `computePromptSuggestions(messages, hour?)` stays a **pure, deterministic** function (the hour is injected for testing; the hook reads the local clock and memoises per hour-bucket). Keeps the **exactly-5-unique** invariant. History (active thread) beats time-of-day for slot 0.
- The static starter set remains the offline fallback for a future `GET /api/suggestions` backend (tracked in a separate issue for coordination — not built here).

## Verification
- `biome check` clean.
- Unit tests **5/5** (time-of-day leads, history-precedence, 5-unique invariant across hours).
- `tsgo` 0 errors in the changed file.
- Visual: the strip's render is structurally unchanged from the screenshot-verified #8201 (only the text of the lead chip varies); pure-logic change.

Frontend-only, 2 files. Opening for review.