### PR TITLE
fix(plugin-task-coordinator): reset CompareView round on slot-set changes

### DIFF
--- a/plugins/plugin-task-coordinator/src/odysseus/CompareView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/CompareView.tsx
@@ -376,14 +376,26 @@ export function CompareView({
   if (win.minimized) return null;
 
   // ── Shared slot mutators (used by both selector and arena) ──
+  // A reveal/winner only applies to the exact lineup that was voted on, and the
+  // winner is tracked by INDEX (winnerIdx); any structural change to the slot
+  // set (add / remove / shuffle) would otherwise leave a stale index pointing at
+  // the wrong pane — mis-highlighting a winner/loser, or leaking blind picks
+  // while keeping a stale verdict. So every structural change clears the round.
+  const resetRound = () => {
+    setRevealed(false);
+    setWinnerIdx(null);
+  };
+
   const addSlot = () => {
     if (slots.length >= MAX_SLOTS) return;
     setSlots((cur) => [...cur, newSlot()]);
+    resetRound();
   };
 
   const removeSlot = (slotId: string) => {
     if (slots.length <= 1) return;
     setSlots((cur) => cur.filter((s) => s.slotId !== slotId));
+    resetRound();
   };
 
   const setSlotProvider = (slotId: string, provider: string) => {
@@ -433,6 +445,10 @@ export function CompareView({
       }),
     );
     setBlindMode(true);
+    // Re-shuffling replaces the lineup, so any prior vote/reveal is stale —
+    // clear it (otherwise a stale winnerIdx mis-marks a fresh pane and the old
+    // reveal leaks the newly-randomized blind names).
+    resetRound();
   };
 
   const toggleExcluded = (id: string) => {


### PR DESCRIPTION
## What
Three adversarially-verified bugs in the odysseus **Compare arena**, all one root cause: a vote is tracked by **index** (`winnerIdx`) + a `revealed` flag, but the slot-set mutators never cleared it — so a stale verdict survived changes to the lineup:

- **Remove a pane after voting** → the array shifts, `winnerIdx` now points at the wrong pane → mis-highlighted winner/loser.
- **Shuffle after a vote** → re-randomizes the lineup but keeps the stale winner **and** leaves reveal on → leaks the freshly-randomized blind names.
- **Add a pane after a vote** → the brand-new pane renders as a loser.

## How
A shared `resetRound()` (clears `revealed` + `winnerIdx`) called from `addSlot`, `removeSlot`, and `shuffleFill` — a reveal/winner only applies to the exact lineup that was voted on. **Single file, +16 lines**, no change to an in-progress (un-voted) round.

## Verification
- `biome` clean; plugin `tsgo` 0 errors in the changed file; view bundle builds.
- Verified by typecheck/build/review — the Compare arena needs live model data to screenshot (unavailable in CI); the fix is pure round-state handling.

Found via an adversarial deep-scan of the odysseus views (objective: parity + flawless). 7 more confirmed frontend bugs from the same scan are queued for follow-up PRs.