### PR TITLE
fix(plugin-task-coordinator): odysseus Notes focus + Search highlight bugs

### DIFF
--- a/plugins/plugin-task-coordinator/src/odysseus/NotesPanel.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/NotesPanel.tsx
@@ -19,7 +19,7 @@
 // Those controls belong in an eliza notes service + plugin-background-runner.
 
 import { Minus } from "lucide-react";
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { formatRelativeTime } from "../view-format";
 import { useWindowControls } from "./hooks/useWindowControls";
 import { ResizeHandles } from "./ResizeHandles";
@@ -791,6 +791,19 @@ function NoteForm({
   onSave: () => void;
   onCancel: () => void;
 }): ReactNode {
+  // The quick-add input swaps itself out for this form on the first keystroke
+  // (openNewForm seeds the title), which drops focus. Move focus into the title
+  // input with the caret at the end on mount, so typing continues seamlessly
+  // (mirrors notes.js, which focuses the title field when the editor opens).
+  const titleRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    const el = titleRef.current;
+    if (!el) return;
+    el.focus();
+    const end = el.value.length;
+    el.setSelectionRange(end, end);
+  }, []);
+
   return (
     <div className="od-note-form">
       <fieldset className="od-note-form-seg" aria-label="Note type">
@@ -814,6 +827,7 @@ function NoteForm({
         </button>
       </fieldset>
       <input
+        ref={titleRef}
         className="od-note-form-title"
         value={draft.title}
         onChange={(e) => setDraft((d) => ({ ...d, title: e.target.value }))}

--- a/plugins/plugin-task-coordinator/src/odysseus/SearchPalette.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/SearchPalette.tsx
@@ -24,31 +24,34 @@ import {
 
 /** Split `text` on `query` (case-insensitive) and wrap matches in a <mark>,
  * mirroring odysseus highlightMatch (search-chat.js L43-L48). React escaping
- * replaces the manual escapeHtml step. */
+ * replaces the manual escapeHtml step.
+ *
+ * Splits via a case-insensitive regex over the ORIGINAL `text` (every segment
+ * is a slice of `text` itself), rather than indexing a `toLowerCase()` copy —
+ * some characters change length when lowercased (e.g. "İ", "ẞ"), which would
+ * otherwise shift the indices and slice the highlight at the wrong offset. */
 function highlightMatch(text: string, query: string): ReactNode {
   if (!query) return text;
-  const lowerText = text.toLowerCase();
-  const lowerQuery = query.toLowerCase();
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Single capturing group keeps the matched text in the split result, so odd
+  // indices are matches and even indices are the surrounding gaps.
+  const segments = text.split(new RegExp(`(${escaped})`, "gi"));
   const parts: ReactNode[] = [];
-  let cursor = 0;
-  let matchAt = lowerText.indexOf(lowerQuery, cursor);
-  let key = 0;
-  while (matchAt !== -1) {
-    if (matchAt > cursor) {
-      parts.push(<Fragment key={key}>{text.slice(cursor, matchAt)}</Fragment>);
-      key += 1;
-    }
+  let offset = 0;
+  for (let i = 0; i < segments.length; i += 1) {
+    const seg = segments[i];
+    const start = offset; // char offset into `text` — a stable, unique key
+    offset += seg.length;
+    if (seg === "") continue;
     parts.push(
-      <mark key={key} className="od-search-highlight">
-        {text.slice(matchAt, matchAt + query.length)}
-      </mark>,
+      i % 2 === 1 ? (
+        <mark key={start} className="od-search-highlight">
+          {seg}
+        </mark>
+      ) : (
+        <Fragment key={start}>{seg}</Fragment>
+      ),
     );
-    key += 1;
-    cursor = matchAt + query.length;
-    matchAt = lowerText.indexOf(lowerQuery, cursor);
-  }
-  if (cursor < text.length) {
-    parts.push(<Fragment key={key}>{text.slice(cursor)}</Fragment>);
   }
   return parts;
 }


### PR DESCRIPTION
Two adversarially-verified, user-facing, **frontend-only** bugs found in a deep-scan of the odysseus views:

### NotesPanel — quick-add ate every keystroke after the first
Typing the first character into the quick-add bar fires `openNewForm` (seeding the title), which **swaps the quick-add input out for the full NoteForm** → focus is lost on the unmounted input, so the next keystrokes went nowhere. **You could only type one character.** Fix: NoteForm focuses its title input (caret to end) on mount, so the carried-over character continues seamlessly (mirrors `notes.js`).

### SearchPalette — highlight sliced at the wrong offset for some Unicode
`highlightMatch` indexed a `toLowerCase()` copy of the text but sliced the **original** — characters that change length when lowercased ("İ", "ẞ", …) shifted the offsets and wrapped the `<mark>` around the wrong characters. Fix: split the original text on a case-insensitive regex (each segment is a real slice); keys are the char offset (no array-index keys).

## Verification
- `biome` clean; plugin `tsgo` 0 errors in the changed files; view bundle builds.
- Verified by typecheck/build/review (these views need live data to screenshot; the fixes are focus/string-handling logic).

Part of an adversarial deep-scan of the odysseus views (parity + flawless). Sibling PR #8226 (CompareView round-state). Remaining confirmed findings (EmailView reply-all, AdminView a11y, Brain badge, Presets temp) queued separately.