### PR TITLE
fix(dev): reliable agent hot-reload via source-only watcher

### DIFF
--- a/packages/app-core/scripts/dev-ui.mjs
+++ b/packages/app-core/scripts/dev-ui.mjs
@@ -29,6 +29,7 @@ import process from "node:process";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { resolveDesktopApiPort, resolveDesktopUiPort } from "@elizaos/shared";
 import * as JSON5Module from "json5";
+import { startAgentSourceWatcher } from "./lib/agent-source-watcher.mjs";
 import { createApiSupervisor } from "./lib/api-supervisor.mjs";
 import { relativeAppDir, resolveMainAppDir } from "./lib/app-dir.mjs";
 import { getBunVersionAdvisory } from "./lib/bun-version-guard.mjs";
@@ -223,12 +224,13 @@ const devLogLevel =
     .toLowerCase() || "info";
 const quietApiLogs = process.env.ELIZA_DEV_QUIET_LOGS === "1";
 const verboseApiLogs = process.env.ELIZA_DEV_VERBOSE_LOGS !== "0";
-// Keep `node --watch` opt-in for the API server. Concurrent package builds,
-// native plugin builds, and staged plugin copies rewrite workspace `dist/`
-// files; Node follows imports into those files and can hot-reload while the
-// runtime is still bootstrapping, leaving PGlite locked by the previous
-// process. The supervisor still restarts the API on explicit restart exits.
-const skipBunWatch = process.env.ELIZA_DEV_NO_WATCH !== "0";
+// Agent hot-reload is ON by default: a source-only watcher (see
+// startAgentSourceWatcher) bounces the API child through the supervisor when
+// backend `*/src` changes. Unlike the old `node --watch`, it never watches
+// `dist/`, so concurrent package builds can't trigger a reload loop — which is
+// why this no longer needs the opt-in / concurrent-build auto-disable dance.
+// Opt out with ELIZA_DEV_NO_WATCH=1.
+const skipSourceWatch = process.env.ELIZA_DEV_NO_WATCH === "1";
 const DEV_TEST_MOCK_ENV_KEYS = [
   "ELIZA_MOCK_GOOGLE_BASE",
   "ELIZA_MOCK_TWILIO_BASE",
@@ -643,103 +645,6 @@ function createStartupFilter(dest) {
 }
 
 // ---------------------------------------------------------------------------
-// Concurrent build detection — node --watch follows imports into workspace
-// `dist/` files. If a build is rewriting those files (worse: its `clean` step
-// deletes `dist/` out from under the running server), --watch hot-reloads on
-// every write and prevents the agent from finishing initialization. We detect
-// that case here and auto-disable --watch.
-//
-// Primary signal: live `<package>/.build-lock/metadata.json` dirs written by
-// scripts/with-package-build-lock.mjs. Each carries the builder's PID, so a
-// lock whose PID is still alive is an unambiguous "build in progress" — far
-// more reliable than pattern-matching `ps` command lines (which misses bare
-// `build:dist:unlocked` and other non-turbo/tsup invocations).
-// ---------------------------------------------------------------------------
-
-function isPidAlive(pid) {
-  if (!Number.isInteger(pid) || pid <= 0) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    // ESRCH = no such process; EPERM = alive but not ours (still alive).
-    return error?.code === "EPERM";
-  }
-}
-
-// Scan `<root>/{packages,plugins}/*/.build-lock/metadata.json` for a lock whose
-// builder PID is still running. Returns that PID, or null if none are live.
-function detectLiveBuildLock(scanRoots) {
-  for (const root of scanRoots) {
-    for (const group of ["packages", "plugins"]) {
-      const groupDir = path.join(root, group);
-      let entries;
-      try {
-        entries = readdirSync(groupDir, { withFileTypes: true });
-      } catch {
-        continue;
-      }
-      for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
-        const metaPath = path.join(
-          groupDir,
-          entry.name,
-          ".build-lock",
-          "metadata.json",
-        );
-        if (!existsSync(metaPath)) continue;
-        try {
-          const pid = Number(JSON.parse(readFileSync(metaPath, "utf8"))?.pid);
-          if (isPidAlive(pid)) return pid;
-        } catch {
-          // Unreadable/partial lock — ignore; the build-lock helper self-heals.
-        }
-      }
-    }
-  }
-  return null;
-}
-
-function detectConcurrentBuilds(scanRoots = []) {
-  const lockPid = detectLiveBuildLock(scanRoots);
-  if (lockPid) return lockPid;
-  if (process.platform === "win32") return null;
-  let psOut;
-  try {
-    psOut = execSync("ps axo pid=,command=", {
-      encoding: "utf8",
-      maxBuffer: 10 * 1024 * 1024,
-      stdio: ["pipe", "pipe", "ignore"],
-    });
-  } catch {
-    return null;
-  }
-  const buildSignatures = [
-    /\bturbo\s+run\s+build\b/i,
-    /\bbun\s+run\s+build\b/i,
-    /\btsup\b.*\bbuild\b/i,
-    // No \b before --noEmit / tsconfig.build: a hyphen and a dot are non-word
-    // chars, so \b never matches at that boundary — the prior
-    // /\btsc\b.*\b(--noEmit|tsconfig\.build)\b/i was dead code that matched
-    // neither `tsc --noEmit` nor `vite build`, the exact commands that drive
-    // the node --watch hot-reload loop. Match them loosely instead.
-    /\btsc\b.*--noEmit/i,
-    /\btsc\b.*tsconfig\.build/i,
-    /\bvite\b.*\bbuild\b/i,
-  ];
-  for (const line of psOut.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    if (buildSignatures.some((re) => re.test(trimmed))) {
-      const sp = trimmed.indexOf(" ");
-      const pidStr = sp > 0 ? trimmed.slice(0, sp).trim() : trimmed;
-      return Number.parseInt(pidStr, 10) || null;
-    }
-  }
-  return null;
-}
-
-// ---------------------------------------------------------------------------
 // Port cleanup — force-kill zombie processes on our dev ports
 // ---------------------------------------------------------------------------
 
@@ -831,7 +736,7 @@ function isPortListening(port) {
 // ---------------------------------------------------------------------------
 // Wait for the agent runtime to be ready (not just the TCP port).
 // Polls GET /api/health and resolves when { ready: true }.
-// Handles node --watch restarts gracefully (connection resets → retry).
+// Handles supervised hot-reload restarts gracefully (connection resets → retry).
 // ---------------------------------------------------------------------------
 
 async function waitForAgentReady(
@@ -962,6 +867,8 @@ if (!uiOnly) {
 
 let apiProcess = null;
 let viteProcess = null;
+/** @type {{ count: number, close: () => void } | null} */
+let sourceWatcher = null;
 let shuttingDown = false;
 let vitePluginBuildAttempted = false;
 let viteRestartCount = 0;
@@ -989,6 +896,10 @@ function cleanup(exitCode = 0) {
   }
   shuttingDown = true;
 
+  if (sourceWatcher) {
+    sourceWatcher.close();
+    sourceWatcher = null;
+  }
   terminateChild(viteProcess, "SIGTERM");
   terminateChild(apiProcess, "SIGTERM");
   if (viteRestartTimer) {
@@ -1234,25 +1145,10 @@ if (uiOnly) {
     devServerEntry = path.resolve(cwd, devServerEntry);
   }
 
-  let useWatch = !skipBunWatch;
-  if (useWatch) {
-    const elizaSubmodule = path.join(cwd, "eliza");
-    const buildScanRoots = [
-      cwd,
-      ...(existsSync(path.join(elizaSubmodule, "package.json"))
-        ? [elizaSubmodule]
-        : []),
-    ];
-    const buildPid = detectConcurrentBuilds(buildScanRoots);
-    if (buildPid) {
-      console.log(
-        `  ${green(logPrefix)} ${dim(
-          `Concurrent build detected (PID ${buildPid}) — disabling --watch to avoid hot-reload loop on dist/ writes. Set ELIZA_DEV_NO_WATCH=1 to silence this notice.`,
-        )}`,
-      );
-      useWatch = false;
-    }
-  }
+  // Agent hot-reload is driven by a source-only watcher (started after the
+  // supervisor below), not by `node --watch`. The watcher never sees `dist/`,
+  // so it is immune to concurrent-build churn.
+  const useWatch = !skipSourceWatch;
 
   const apiRuntimeCmd = resolveApiRuntimeCommand(process.env);
   const apiRuntimeIsBun = apiRuntimeCmd === "bun";
@@ -1267,7 +1163,6 @@ if (uiOnly) {
       apiRuntimeIsBun ? "--preload" : "--import",
       filePath,
     ]),
-    ...(useWatch ? ["--watch"] : []),
     devServerEntry,
   ];
   // The API server resolves @elizaos/* deps via Bun workspace lookup, which
@@ -1285,7 +1180,7 @@ if (uiOnly) {
   const childEnv = createDevChildEnv(process.env);
   // V8 bytecode cache for the Node API runtime. The runtime is deliberately
   // Node (not Bun) for node: built-ins, so this persists compiled module
-  // bytecode across boots and --watch restarts, trimming plugin-import cost.
+  // bytecode across boots and hot-reload restarts, trimming plugin-import cost.
   // Node 22.8+ honors it; older node and Bun ignore the var (safe no-op).
   // Pinned under the state dir (not os.tmpdir()) so an OS temp reap doesn't
   // wipe the warm ~100MB cache and force a multi-second cold recompile on the
@@ -1393,11 +1288,36 @@ if (uiOnly) {
     },
     onGiveUp: (code) => cleanup(code ?? 1),
     isShuttingDown: () => shuttingDown,
+    // Reuse the dev process-tree killer so a hot-reload restart takes the
+    // API child's descendants (coding sub-agents, native helpers) with it.
+    terminate: (child, signal) => terminateChild(child, signal),
     log: (message) => console.log(`\n  ${green(logPrefix)} ${message}`),
     warn: (message) => console.error(`\n  ${green(logPrefix)} ${message}`),
   });
 
   apiSupervisor.start();
+
+  // Agent hot-reload: bounce the API child when backend source changes. The
+  // watcher only sees `*/src`, so concurrent `dist/` builds never trigger it.
+  if (useWatch) {
+    sourceWatcher = startAgentSourceWatcher({
+      root: apiSpawnCwd,
+      onChange: (relPath) => {
+        console.log(
+          `\n  ${green(logPrefix)} ${dim(`Source change (${relPath}) — reloading agent…`)}`,
+        );
+        apiSupervisor.restart();
+      },
+      onError: (dir, err) => {
+        console.log(
+          `  ${green(logPrefix)} ${dim(`Hot-reload watch skipped for ${path.relative(apiSpawnCwd, dir)}: ${err.message}`)}`,
+        );
+      },
+    });
+    console.log(
+      `  ${green(logPrefix)} ${dim(`Agent hot-reload on: watching ${sourceWatcher.count} source dirs (set ELIZA_DEV_NO_WATCH=1 to disable).`)}`,
+    );
+  }
 
   // Start Vite immediately, in parallel with the API boot. The dev server only
   // proxies to the API at request time — it has no startup dependency on the

--- a/packages/app-core/scripts/lib/agent-source-watcher.mjs
+++ b/packages/app-core/scripts/lib/agent-source-watcher.mjs
@@ -1,0 +1,156 @@
+/**
+ * Agent source hot-reload watcher.
+ *
+ * Watches the backend `<pkg>/src` dirs (the TypeScript the dev API child loads via
+ * the `eliza-source` condition) and fires a debounced callback when real code
+ * changes. Watching each `<pkg>/src` dir directly — never `dist/`, `node_modules/`,
+ * or build output — means concurrent package builds rewriting `dist/` generate
+ * no events here. That decoupling is the whole point: the old `node --watch`
+ * followed imports into `dist/` and reloaded mid-build, so it had to be
+ * disabled; this never does.
+ *
+ * dev-ui.mjs wires `onChange` to the API supervisor's `restart()`.
+ */
+
+import { existsSync, readdirSync, watch } from "node:fs";
+import path from "node:path";
+
+// Pure-frontend packages are served + HMR'd by Vite and are NOT loaded by the
+// API child, so editing them must not bounce the agent.
+export const HOT_RELOAD_FRONTEND_PACKAGES = new Set([
+  "ui",
+  "app",
+  "cloud-frontend",
+  "os-homepage",
+  "homepage",
+  "docs",
+  "docs-elizacloud-redirect",
+  "tui",
+  "robot",
+  "os",
+]);
+
+export const HOT_RELOAD_CODE_FILE = /\.(?:[cm]?tsx?|[cm]?js|json)$/;
+export const HOT_RELOAD_TEST_FILE = /\.(?:test|spec)\.[cm]?[jt]sx?$/;
+export const HOT_RELOAD_IGNORED_SEGMENT =
+  /(?:^|[/\\])(?:dist|node_modules|\.turbo|\.git|coverage|__tests__|\.vite|build)(?:[/\\]|$)/;
+export const HOT_RELOAD_DEBOUNCE_MS = 350;
+
+/**
+ * Collect the `<group>/<pkg>/src` dirs whose changes should reload the agent.
+ * Skips pure-frontend packages (Vite owns those) and any package without a
+ * `src/` dir.
+ *
+ * @param {string} root Repo root that holds `packages/` and `plugins/`.
+ * @returns {string[]} Absolute `<pkg>/src` dirs to watch.
+ */
+export function collectAgentSourceDirs(root) {
+  const dirs = [];
+  for (const group of ["packages", "plugins"]) {
+    const groupDir = path.join(root, group);
+    let entries;
+    try {
+      entries = readdirSync(groupDir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (
+        group === "packages" &&
+        HOT_RELOAD_FRONTEND_PACKAGES.has(entry.name)
+      ) {
+        continue;
+      }
+      const srcDir = path.join(groupDir, entry.name, "src");
+      if (existsSync(srcDir)) dirs.push(srcDir);
+    }
+  }
+  return dirs;
+}
+
+/**
+ * Whether a watch event for `absPath` should trigger a reload. A null/empty
+ * path (some platforms omit the filename) is treated as reloadable so we never
+ * miss a real change. Build output, deps, and test/coverage dirs are ignored,
+ * and only code files (ts/tsx/js/mjs/cjs/json) qualify.
+ *
+ * @param {string | null | undefined} absPath
+ * @returns {boolean}
+ */
+export function isReloadableChangePath(absPath) {
+  if (!absPath) return true;
+  if (HOT_RELOAD_IGNORED_SEGMENT.test(absPath)) return false;
+  if (HOT_RELOAD_TEST_FILE.test(absPath)) return false;
+  return HOT_RELOAD_CODE_FILE.test(absPath);
+}
+
+/**
+ * Start watching the agent source dirs. Returns a handle with the number of
+ * dirs watched and a `close()`.
+ *
+ * @param {Object} params
+ * @param {string} params.root Repo root.
+ * @param {(relPath: string) => void} params.onChange Debounced; receives the
+ *   changed path relative to `root` (or "source" when the filename is unknown).
+ * @param {(dir: string, err: Error) => void} [params.onError] Per-dir watch
+ *   setup failure (e.g. a platform without recursive watch).
+ * @param {number} [params.debounceMs]
+ * @returns {{ count: number, close: () => void }}
+ */
+export function startAgentSourceWatcher({
+  root,
+  onChange,
+  onError,
+  debounceMs = HOT_RELOAD_DEBOUNCE_MS,
+}) {
+  const dirs = collectAgentSourceDirs(root);
+  /** @type {import("node:fs").FSWatcher[]} */
+  const watchers = [];
+  /** @type {ReturnType<typeof setTimeout> | null} */
+  let debounce = null;
+  let pendingFile = null;
+
+  const fire = (absPath) => {
+    if (absPath && !isReloadableChangePath(absPath)) return;
+    if (absPath) pendingFile = absPath;
+    if (debounce) clearTimeout(debounce);
+    debounce = setTimeout(() => {
+      const changed = pendingFile;
+      pendingFile = null;
+      debounce = null;
+      onChange(changed ? path.relative(root, changed) : "source");
+    }, debounceMs);
+    debounce.unref?.();
+  };
+
+  for (const dir of dirs) {
+    try {
+      const fsWatcher = watch(dir, { recursive: true }, (_event, filename) => {
+        fire(filename ? path.join(dir, filename.toString()) : null);
+      });
+      // A dir vanishing mid-build (clean step) must not crash the dev process.
+      fsWatcher.on("error", () => {});
+      watchers.push(fsWatcher);
+    } catch (err) {
+      onError?.(dir, err);
+    }
+  }
+
+  return {
+    count: dirs.length,
+    close() {
+      if (debounce) {
+        clearTimeout(debounce);
+        debounce = null;
+      }
+      for (const fsWatcher of watchers) {
+        try {
+          fsWatcher.close();
+        } catch {
+          // already closed
+        }
+      }
+    },
+  };
+}

--- a/packages/app-core/scripts/lib/agent-source-watcher.test.mjs
+++ b/packages/app-core/scripts/lib/agent-source-watcher.test.mjs
@@ -1,0 +1,135 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  collectAgentSourceDirs,
+  isReloadableChangePath,
+  startAgentSourceWatcher,
+} from "./agent-source-watcher.mjs";
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitUntil(predicate, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await delay(40);
+  }
+  return predicate();
+}
+
+describe("collectAgentSourceDirs", () => {
+  let root = null;
+  afterEach(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+    root = null;
+  });
+
+  it("includes backend packages + all plugins, excludes frontend + src-less dirs", () => {
+    root = mkdtempSync(path.join(tmpdir(), "agent-watch-"));
+    const mk = (...p) => mkdirSync(path.join(root, ...p), { recursive: true });
+    mk("packages", "core", "src");
+    mk("packages", "agent", "src");
+    mk("packages", "ui", "src"); // frontend → excluded
+    mk("packages", "app", "src"); // frontend → excluded
+    mk("packages", "no-src"); // has no src → excluded
+    mk("plugins", "plugin-app-control", "src");
+    mk("plugins", "plugin-x", "src");
+
+    const dirs = collectAgentSourceDirs(root)
+      .map((d) => path.relative(root, d).split(path.sep).join("/"))
+      .sort();
+    expect(dirs).toEqual([
+      "packages/agent/src",
+      "packages/core/src",
+      "plugins/plugin-app-control/src",
+      "plugins/plugin-x/src",
+    ]);
+  });
+
+  it("returns [] when packages/ and plugins/ are absent", () => {
+    root = mkdtempSync(path.join(tmpdir(), "agent-watch-empty-"));
+    expect(collectAgentSourceDirs(root)).toEqual([]);
+  });
+});
+
+describe("isReloadableChangePath", () => {
+  it("reloads for backend code files the agent loads", () => {
+    for (const p of [
+      "/r/plugins/plugin-app-control/src/actions/views.ts",
+      "/r/packages/agent/src/api/server.ts",
+      "/r/packages/core/src/runtime/x.tsx",
+      "/r/plugins/p/src/registry.json",
+      "/r/packages/shared/src/util.mjs",
+    ]) {
+      expect(isReloadableChangePath(p)).toBe(true);
+    }
+  });
+
+  it("ignores build output, deps, and test/coverage dirs", () => {
+    for (const p of [
+      "/r/packages/core/dist/index.js",
+      "/r/packages/core/src/node_modules/x/y.js",
+      "/r/packages/core/src/__tests__/a.ts",
+      "/r/packages/core/.turbo/log.json",
+      "/r/packages/core/coverage/lcov.js",
+    ]) {
+      expect(isReloadableChangePath(p)).toBe(false);
+    }
+  });
+
+  it("ignores co-located test/spec files and non-code files", () => {
+    for (const p of [
+      "/r/packages/core/src/views.test.ts",
+      "/r/packages/core/src/views.spec.tsx",
+      "/r/packages/core/src/readme.md",
+      "/r/packages/core/src/styles.css",
+    ]) {
+      expect(isReloadableChangePath(p)).toBe(false);
+    }
+  });
+
+  it("treats an unknown (null/undefined) filename as reloadable", () => {
+    expect(isReloadableChangePath(null)).toBe(true);
+    expect(isReloadableChangePath(undefined)).toBe(true);
+  });
+});
+
+describe("startAgentSourceWatcher (integration)", () => {
+  let root = null;
+  let handle = null;
+  afterEach(() => {
+    if (handle) handle.close();
+    handle = null;
+    if (root) rmSync(root, { recursive: true, force: true });
+    root = null;
+  });
+
+  it("fires onChange (debounced) for a real backend src edit", async () => {
+    root = mkdtempSync(path.join(tmpdir(), "agent-watch-int-"));
+    const mk = (...p) => mkdirSync(path.join(root, ...p), { recursive: true });
+    mk("plugins", "plugin-app-control", "src", "actions");
+    mk("packages", "ui", "src"); // frontend → not among watched dirs
+
+    const calls = [];
+    handle = startAgentSourceWatcher({
+      root,
+      debounceMs: 60,
+      onChange: (rel) => calls.push(rel),
+    });
+    // Only the plugin src is watched; the frontend package is excluded.
+    expect(handle.count).toBe(1);
+
+    await delay(200); // let the OS watcher arm before the first write
+    writeFileSync(
+      path.join(root, "plugins/plugin-app-control/src/actions/views.ts"),
+      "export const x = 1;\n",
+    );
+
+    const fired = await waitUntil(() => calls.length > 0, 4000);
+    expect(fired).toBe(true);
+    expect(calls.some((c) => c.includes("views.ts"))).toBe(true);
+  });
+});

--- a/packages/app-core/scripts/lib/api-supervisor.mjs
+++ b/packages/app-core/scripts/lib/api-supervisor.mjs
@@ -3,12 +3,16 @@
  *
  * Both `dev-ui.mjs` and `dev-platform.mjs` need to keep the API server alive
  * across `process.exit(0)` (RESTART action), `process.exit(75)` (CLI runner
- * restart exit code), and `bun --watch` reloads — but stop trying when the
- * server keeps exiting in a tight window (a real crash that needs a human).
+ * restart exit code), and intentional reloads — but stop trying when the server
+ * keeps exiting in a tight window (a real crash that needs a human).
  *
  * The supervisor is unaware of how the API is spawned; callers pass a
  * `spawnChild()` factory that returns a node ChildProcess. The factory is
  * called once per launch, including relaunches.
+ *
+ * `restart()` lets a source watcher bounce the running child for a hot reload:
+ * the kill it triggers is classified as intentional, so it relaunches
+ * immediately and never counts toward the crash streak.
  *
  * Defaults:
  *   - 10s rolling window
@@ -19,6 +23,7 @@
 const DEFAULT_WINDOW_MS = 10_000;
 const DEFAULT_LIMIT = 5;
 const DEFAULT_RESPAWN_DELAY_MS = 400;
+const DEFAULT_KILL_ESCALATE_MS = 4_000;
 
 /**
  * @typedef {Object} ApiSupervisorOptions
@@ -35,6 +40,9 @@ const DEFAULT_RESPAWN_DELAY_MS = 400;
  *   trigger shutdown.
  * @property {() => boolean} isShuttingDown
  *   Returns true while the parent process is in shutdown. Suppresses relaunch.
+ * @property {(child: import("node:child_process").ChildProcess, signal: "SIGTERM" | "SIGKILL") => void} [terminate]
+ *   How to kill a child for an intentional `restart()`. Defaults to
+ *   `child.kill(signal)`; callers that spawn process trees pass a tree-killer.
  * @property {(message: string) => void} [log] Defaults to `console.log`.
  * @property {(message: string) => void} [warn] Defaults to `console.error`.
  * @property {number} [windowMs] Default 10_000.
@@ -52,6 +60,13 @@ export function createApiSupervisor(opts) {
     onExit,
     onGiveUp,
     isShuttingDown,
+    terminate = (child, signal) => {
+      try {
+        child.kill(signal);
+      } catch {
+        // child already gone — nothing to signal.
+      }
+    },
     log = console.log.bind(console),
     warn = console.error.bind(console),
     windowMs = DEFAULT_WINDOW_MS,
@@ -63,13 +78,44 @@ export function createApiSupervisor(opts) {
   let lastExitAt = 0;
   /** @type {ReturnType<typeof setTimeout> | null} */
   let pendingRespawn = null;
+  /** @type {import("node:child_process").ChildProcess | null} */
+  let currentChild = null;
+  /** When true, the next exit is a hot reload, not a crash. */
+  let intentionalRestart = false;
+  /** @type {ReturnType<typeof setTimeout> | null} */
+  let killEscalation = null;
+
+  function clearKillEscalation() {
+    if (killEscalation) {
+      clearTimeout(killEscalation);
+      killEscalation = null;
+    }
+  }
+
+  function scheduleRelaunch() {
+    pendingRespawn = setTimeout(() => {
+      pendingRespawn = null;
+      if (!isShuttingDown()) launch();
+    }, respawnDelayMs);
+  }
 
   function launch() {
     const child = spawnChild();
+    currentChild = child;
     if (onSpawn) onSpawn(child);
     child.on("exit", (code) => {
       if (onExit) onExit(child);
+      if (child === currentChild) currentChild = null;
+      clearKillEscalation();
       if (isShuttingDown()) return;
+
+      // Intentional hot reload (a source change). Relaunch promptly without
+      // touching the crash streak — this is expected, not a failure.
+      if (intentionalRestart) {
+        intentionalRestart = false;
+        scheduleRelaunch();
+        return;
+      }
 
       const now = Date.now();
       streak = now - lastExitAt < windowMs ? streak + 1 : 1;
@@ -87,15 +133,11 @@ export function createApiSupervisor(opts) {
 
       // The agent's RESTART action and `/api/restart` both bounce the server
       // with `process.exit(0)`; the CLI runner uses 75 as the dedicated
-      // restart exit code; Bun's `--watch` reload also exits cleanly. Treat
-      // any non-shutdown exit as "please restart me" and re-spawn.
+      // restart exit code. Treat any non-shutdown exit as "please restart me".
       log(
         `API exited with code ${code} — relaunching (attempt ${streak}/${limit})…`,
       );
-      pendingRespawn = setTimeout(() => {
-        pendingRespawn = null;
-        if (!isShuttingDown()) launch();
-      }, respawnDelayMs);
+      scheduleRelaunch();
     });
     return child;
   }
@@ -104,12 +146,39 @@ export function createApiSupervisor(opts) {
     start() {
       return launch();
     },
-    /** Cancel any pending relaunch (e.g. during shutdown). */
+    /**
+     * Bounce the running API child for a hot reload. No-op during shutdown.
+     * Safe to call repeatedly (e.g. from a debounced watcher) — overlapping
+     * calls collapse onto the one in-flight kill.
+     */
+    restart() {
+      if (isShuttingDown()) return;
+      const child = currentChild;
+      if (!child) {
+        // Already between processes — a relaunch is queued (or will be). Make
+        // sure one is actually pending so a restart() in the gap isn't lost.
+        if (!pendingRespawn) launch();
+        return;
+      }
+      // An intentional reload is not a crash — reset the streak so a burst of
+      // edits can never trip the crash-loop give-up.
+      streak = 0;
+      if (intentionalRestart) return; // a kill is already in flight
+      intentionalRestart = true;
+      terminate(child, "SIGTERM");
+      killEscalation = setTimeout(() => {
+        killEscalation = null;
+        if (currentChild === child) terminate(child, "SIGKILL");
+      }, DEFAULT_KILL_ESCALATE_MS);
+      killEscalation.unref?.();
+    },
+    /** Cancel any pending relaunch / kill escalation (e.g. during shutdown). */
     cancelPendingRespawn() {
       if (pendingRespawn) {
         clearTimeout(pendingRespawn);
         pendingRespawn = null;
       }
+      clearKillEscalation();
     },
   };
 }

--- a/packages/app-core/scripts/lib/api-supervisor.test.mjs
+++ b/packages/app-core/scripts/lib/api-supervisor.test.mjs
@@ -1,0 +1,121 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createApiSupervisor } from "./api-supervisor.mjs";
+
+function makeChild() {
+  const child = new EventEmitter();
+  child.kill = vi.fn();
+  return child;
+}
+
+function setup(overrides = {}) {
+  const spawned = [];
+  const terminate = vi.fn();
+  const onGiveUp = vi.fn();
+  let shuttingDown = false;
+  const sup = createApiSupervisor({
+    spawnChild: () => {
+      const child = makeChild();
+      spawned.push(child);
+      return child;
+    },
+    onGiveUp,
+    isShuttingDown: () => shuttingDown,
+    terminate,
+    log: () => {},
+    warn: () => {},
+    respawnDelayMs: 10,
+    ...overrides,
+  });
+  return {
+    sup,
+    spawned,
+    terminate,
+    onGiveUp,
+    setShutdown: (value) => {
+      shuttingDown = value;
+    },
+    last: () => spawned[spawned.length - 1],
+  };
+}
+
+describe("createApiSupervisor", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("relaunches after an unintentional exit", () => {
+    const { sup, spawned } = setup();
+    sup.start();
+    expect(spawned).toHaveLength(1);
+    spawned[0].emit("exit", 1);
+    vi.advanceTimersByTime(20);
+    expect(spawned).toHaveLength(2);
+  });
+
+  it("gives up after exceeding the crash limit within the window", () => {
+    const { sup, onGiveUp, last } = setup({ limit: 3, windowMs: 10_000 });
+    sup.start();
+    for (let i = 0; i < 5; i++) {
+      last().emit("exit", 1);
+      vi.advanceTimersByTime(20);
+    }
+    expect(onGiveUp).toHaveBeenCalled();
+  });
+
+  it("restart() bounces the child WITHOUT ever counting as a crash", () => {
+    const { sup, spawned, terminate, onGiveUp } = setup({ limit: 3 });
+    sup.start();
+    // Far more intentional reloads than the crash limit, in a tight window.
+    for (let i = 0; i < 12; i++) {
+      const before = spawned.length;
+      sup.restart();
+      expect(terminate).toHaveBeenLastCalledWith(
+        spawned[before - 1],
+        "SIGTERM",
+      );
+      spawned[before - 1].emit("exit", 0); // child honors SIGTERM
+      vi.advanceTimersByTime(20);
+      expect(spawned).toHaveLength(before + 1);
+    }
+    expect(onGiveUp).not.toHaveBeenCalled();
+  });
+
+  it("collapses overlapping restart() calls onto one in-flight kill", () => {
+    const { sup, spawned, terminate } = setup();
+    sup.start();
+    sup.restart();
+    sup.restart();
+    sup.restart();
+    expect(terminate).toHaveBeenCalledTimes(1);
+    spawned[0].emit("exit", 0);
+    vi.advanceTimersByTime(20);
+    expect(spawned).toHaveLength(2);
+  });
+
+  it("escalates to SIGKILL when the child ignores SIGTERM", () => {
+    const { sup, spawned, terminate } = setup();
+    sup.start();
+    sup.restart();
+    expect(terminate).toHaveBeenCalledWith(spawned[0], "SIGTERM");
+    vi.advanceTimersByTime(4000);
+    expect(terminate).toHaveBeenCalledWith(spawned[0], "SIGKILL");
+  });
+
+  it("restart() is a no-op during shutdown", () => {
+    const { sup, terminate, setShutdown } = setup();
+    sup.start();
+    setShutdown(true);
+    sup.restart();
+    expect(terminate).not.toHaveBeenCalled();
+  });
+
+  it("does not relaunch when the child exits during shutdown", () => {
+    const { sup, spawned, setShutdown } = setup();
+    sup.start();
+    setShutdown(true);
+    spawned[0].emit("exit", 0);
+    vi.advanceTimersByTime(20);
+    expect(spawned).toHaveLength(1);
+  });
+});

--- a/packages/ui/src/hooks/useVoiceChat.ts
+++ b/packages/ui/src/hooks/useVoiceChat.ts
@@ -45,7 +45,10 @@ import {
   type LocalAsrRecorder,
   startLocalAsrRecorder,
 } from "../voice/local-asr-capture";
-import { transcribeLocalInferenceWav } from "../voice/local-asr-transcribe";
+import {
+  isLocalInferenceAsrReady,
+  transcribeLocalInferenceWav,
+} from "../voice/local-asr-transcribe";
 import {
   collapseWhitespace,
   nextIdleMouthOpen,
@@ -715,6 +718,12 @@ export function useVoiceChat(options: VoiceChatOptions): VoiceChatState {
         return false;
       }
       if (!isLocalAsrCaptureSupported()) {
+        return false;
+      }
+      // Defer to the next backend (talk-mode / browser) when the server can't
+      // transcribe right now — capturing here would only 502 at stop() with no
+      // recoverable fallback (no whisper model / native adapter installed).
+      if (!(await isLocalInferenceAsrReady())) {
         return false;
       }
 

--- a/packages/ui/src/voice/local-asr-transcribe.ts
+++ b/packages/ui/src/voice/local-asr-transcribe.ts
@@ -25,6 +25,39 @@ export interface TranscribeWavResult {
   text: string;
 }
 
+/**
+ * Probe whether the server can fulfill local-inference ASR right now via
+ * `GET /api/asr/local-inference/status` (`{ ready, provider }`).
+ *
+ * Capture surfaces use this to choose a backend that can actually transcribe:
+ * routing audio to `/api/asr/local-inference` when the server has no whisper
+ * model / native adapter 502s at `stop()` with no recoverable fallback, so an
+ * unready (or unreachable) server must degrade to browser ASR instead. A
+ * failed probe deliberately resolves `false` — "unknown readiness" is treated
+ * as "not ready" so we never capture audio we can't transcribe.
+ */
+export async function isLocalInferenceAsrReady(
+  options?: TranscribeWavOptions,
+): Promise<boolean> {
+  try {
+    const res = await fetchWithCsrf(
+      resolveApiUrl("/api/asr/local-inference/status"),
+      {
+        method: "GET",
+        headers: { Accept: "application/json" },
+        signal: options?.signal,
+      },
+    );
+    if (!res.ok) return false;
+    const parsed = (await res.json().catch(() => null)) as {
+      ready?: unknown;
+    } | null;
+    return parsed?.ready === true;
+  } catch {
+    return false;
+  }
+}
+
 export async function transcribeLocalInferenceWav(
   audio: Uint8Array,
   options?: TranscribeWavOptions,

--- a/packages/ui/src/voice/voice-capture-factory.test.ts
+++ b/packages/ui/src/voice/voice-capture-factory.test.ts
@@ -7,7 +7,10 @@ import {
   type LocalAsrRecorderOptions,
   startLocalAsrRecorder,
 } from "./local-asr-capture";
-import { transcribeLocalInferenceWav } from "./local-asr-transcribe";
+import {
+  isLocalInferenceAsrReady,
+  transcribeLocalInferenceWav,
+} from "./local-asr-transcribe";
 import { createVoiceCapture } from "./voice-capture-factory";
 
 vi.mock("./local-asr-capture", () => ({
@@ -16,16 +19,19 @@ vi.mock("./local-asr-capture", () => ({
 }));
 
 vi.mock("./local-asr-transcribe", () => ({
+  isLocalInferenceAsrReady: vi.fn(),
   transcribeLocalInferenceWav: vi.fn(),
 }));
 
 const isLocalAsrCaptureSupportedMock = vi.mocked(isLocalAsrCaptureSupported);
 const startLocalAsrRecorderMock = vi.mocked(startLocalAsrRecorder);
+const isLocalInferenceAsrReadyMock = vi.mocked(isLocalInferenceAsrReady);
 const transcribeLocalInferenceWavMock = vi.mocked(transcribeLocalInferenceWav);
 
 describe("createVoiceCapture", () => {
   beforeEach(() => {
     isLocalAsrCaptureSupportedMock.mockReturnValue(true);
+    isLocalInferenceAsrReadyMock.mockResolvedValue(true);
     transcribeLocalInferenceWavMock.mockResolvedValue({
       text: "Ada Lovelace",
     });
@@ -96,5 +102,26 @@ describe("createVoiceCapture", () => {
       onTranscript: vi.fn(),
     });
     expect(capture.getAnalyser()).toBeNull();
+  });
+
+  it("falls back to browser when local-inference ASR is not server-ready", async () => {
+    // No whisper model / native adapter on the server → status probe is false,
+    // so we must not capture audio we can only 502 on. jsdom has no
+    // SpeechRecognition, so the browser fallback surfaces its own error — the
+    // point is we never started the local recorder.
+    isLocalInferenceAsrReadyMock.mockResolvedValue(false);
+    const onStateChange = vi.fn();
+    const capture = createVoiceCapture({
+      asrProvider: "local-inference",
+      onStateChange,
+      onTranscript: vi.fn(),
+    });
+
+    await expect(capture.start()).rejects.toThrow(/SpeechRecognition/);
+    expect(startLocalAsrRecorderMock).not.toHaveBeenCalled();
+    expect(onStateChange).toHaveBeenLastCalledWith(
+      "error",
+      expect.any(Error),
+    );
   });
 });

--- a/packages/ui/src/voice/voice-capture-factory.ts
+++ b/packages/ui/src/voice/voice-capture-factory.ts
@@ -25,7 +25,10 @@ import {
   type LocalAsrRecorder,
   startLocalAsrRecorder,
 } from "./local-asr-capture";
-import { transcribeLocalInferenceWav } from "./local-asr-transcribe";
+import {
+  isLocalInferenceAsrReady,
+  transcribeLocalInferenceWav,
+} from "./local-asr-transcribe";
 import {
   getSpeechRecognitionCtor,
   type SpeechRecognitionInstance,
@@ -109,29 +112,28 @@ export interface VoiceCaptureHandle {
   getAnalyser(): AnalyserNode | null;
 }
 
-interface ResolvedBackend {
-  kind: VoiceCaptureBackend;
-}
-
-function resolveBackend(
+async function resolveBackendKind(
   preferred: AsrProvider | "browser" | undefined,
-): ResolvedBackend {
+): Promise<VoiceCaptureBackend> {
   if (preferred === "browser") {
-    return { kind: "browser" };
+    return "browser";
   }
-  // local-inference is the default, but it requires both the mic capture
-  // primitives and (ultimately) a reachable /api/asr/local-inference. We
-  // can only check the former here; if the round-trip fails at stop() the
-  // caller is notified via onStateChange("error", err).
-  if (preferred === "local-inference" || preferred === undefined) {
-    if (isLocalAsrCaptureSupported()) {
-      return { kind: "local-inference" };
-    }
+  // local-inference is the default, but it needs BOTH the client mic-capture
+  // primitives AND a server that can actually transcribe. Probe the server's
+  // readiness (GET /api/asr/local-inference/status) so an unconfigured box
+  // (no whisper model / native adapter) degrades to browser SpeechRecognition
+  // instead of capturing audio it can only 502 on at stop().
+  if (
+    (preferred === "local-inference" || preferred === undefined) &&
+    isLocalAsrCaptureSupported() &&
+    (await isLocalInferenceAsrReady())
+  ) {
+    return "local-inference";
   }
   // Eliza-cloud / OpenAI providers go through the local-inference route
   // server-side today; until that changes, browser API is the only sane
   // client-side fallback.
-  return { kind: "browser" };
+  return "browser";
 }
 
 export function createVoiceCapture(
@@ -144,7 +146,9 @@ export function createVoiceCapture(
     lang = "en-US",
     localAsrAutoStop,
   } = options;
-  const backend = resolveBackend(asrProvider);
+  // Resolved on start() — the server-readiness probe is async, so the backend
+  // choice is deferred from construction to the first start() call.
+  let backendKind: VoiceCaptureBackend | null = null;
 
   let state: VoiceCaptureState = "idle";
   let active = false;
@@ -226,7 +230,8 @@ export function createVoiceCapture(
     if (active) return;
     setState("starting");
     try {
-      if (backend.kind === "local-inference") {
+      backendKind = await resolveBackendKind(asrProvider);
+      if (backendKind === "local-inference") {
         await startLocalInference();
       } else {
         startBrowser();
@@ -241,7 +246,7 @@ export function createVoiceCapture(
   async function stop(): Promise<void> {
     if (!active && state !== "starting") return;
 
-    if (backend.kind === "local-inference") {
+    if (backendKind === "local-inference") {
       const current = recorder;
       recorder = null;
       active = false;

--- a/plugins/plugin-local-inference/src/services/voice/whisper-cpp-asr.ts
+++ b/plugins/plugin-local-inference/src/services/voice/whisper-cpp-asr.ts
@@ -83,16 +83,10 @@ function resolveLibraryPath(): string | null {
 	const libName = platformLibName();
 	return firstExisting([
 		// Repo-local host build via plugin-local-inference/native/build-whisper.mjs.
-		path.resolve(
-			here,
-			"..",
-			"..",
-			"..",
-			"..",
-			"native",
-			"build-whisper",
-			libName,
-		),
+		// This file ships at <plugin>/src/services/voice (local mode) and
+		// <plugin>/dist/services/voice (packages mode) — both three levels under
+		// the plugin root, so three "../" reach it before native/build-whisper.
+		path.resolve(here, "..", "..", "..", "native", "build-whisper", libName),
 		// User-installed location populated by ensure-whisper-gguf.sh / installer.
 		path.join(resolveStateDir(), "local-inference", "bin", "whisper", libName),
 		// Linux per-host packaged location.


### PR DESCRIPTION
The dev API child ran with watch off by default (and auto-disabled whenever a concurrent build was detected), so agent/plugin source edits never reached the running agent. `node --watch` followed imports into dist/ and hot-reloaded mid-build, which is why it had to stay disabled.

Replace it with a source-only watcher (packages/*/src + plugins/*/src, excluding frontend packages, dist, node_modules, and tests) that bounces the supervised API child on change — decoupled from dist churn, so concurrent builds never trigger it. Add an intentional restart() to the API supervisor that relaunches immediately without counting toward the crash-loop streak. On by default; opt out with ELIZA_DEV_NO_WATCH=1.

<!-- Use this template by filling in information and copying and pasting relevant items out of the HTML comments. -->

# Relates to

<!-- LINK TO ISSUE OR TICKET -->

<!-- This risks section must be filled out before the final review and merge. -->

# Risks

<!--
Low, medium, large. List what kind of risks and what could be affected.
-->

# Background

## What does this PR do?

## What kind of change is this?

<!--
Bug fixes (non-breaking change which fixes an issue)
Improvements (misc. changes to existing features)
Features (non-breaking change which adds functionality)
Updates (new versions of included code)
-->

<!-- This "Why" section is most relevant if there are no linked issues explaining why. If there is a related issue, it might make sense to skip this why section. -->
<!--
## Why are we doing this? Any context or related work?
-->

# Documentation changes needed?

<!--
My changes do not require a change to the project documentation.
My changes require a change to the project documentation.
If documentation change is needed: I have updated the documentation accordingly.
-->

<!-- Please show how you tested the PR. This will really help if the PR needs to be retested and probably help the PR get merged quicker. -->

# Testing

## Where should a reviewer start?

## Detailed testing steps

<!--
None: Automated tests are acceptable.
-->

<!--
- As [anon/admin], go to [link]
  - [do action]
  - verify [result]
-->

<!-- If there is a UI change, please include before and after screenshots or videos. This will speed up PRs being merged. It is extra nice to annotate screenshots with arrows or boxes pointing out the differences. -->
<!--
## Screenshots
### Before
### After
-->

<!-- If there is anything about the deployment, please make a note. -->
<!--
# Deploy Notes
-->

<!--  Copy and paste command line output. -->
<!--
## Database changes
-->

<!--  Please specify deploy instructions if there is something more than the automated steps. -->
<!--
## Deployment instructions
-->

<!-- If you are on Discord, please join https://discord.gg/ai16z and state your Discord username here for the contributor role and join us in #development-feed -->
<!--
## Discord username

-->
