### PR TITLE
fix(plugin-task-coordinator): reset CompareView round on provider/model swap

### DIFF
--- a/plugins/plugin-task-coordinator/src/odysseus/CompareView.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/CompareView.tsx
@@ -377,10 +377,12 @@ export function CompareView({
 
   // ── Shared slot mutators (used by both selector and arena) ──
   // A reveal/winner only applies to the exact lineup that was voted on, and the
-  // winner is tracked by INDEX (winnerIdx); any structural change to the slot
-  // set (add / remove / shuffle) would otherwise leave a stale index pointing at
-  // the wrong pane — mis-highlighting a winner/loser, or leaking blind picks
-  // while keeping a stale verdict. So every structural change clears the round.
+  // winner is tracked by INDEX (winnerIdx). Any change to the lineup invalidates
+  // that verdict: add / remove / shuffle shift or replace the indices, and
+  // swapping a slot's provider/model changes what an unchanged index refers to —
+  // the crown is model-bound, not pane-bound. Either way a stale winner/reveal
+  // mis-highlights a pane (or leaks blind picks), so every lineup change clears
+  // the round.
   const resetRound = () => {
     setRevealed(false);
     setWinnerIdx(null);
@@ -407,6 +409,7 @@ export function CompareView({
           : s,
       ),
     );
+    resetRound();
   };
 
   const setSlotModel = (slotId: string, m: ProviderModelRecord) => {
@@ -416,6 +419,7 @@ export function CompareView({
       ),
     );
     setSwapOpenFor(null);
+    resetRound();
   };
 
   // Dice shuffle — randomly fill every slot from the loaded model pool, honoring

--- a/plugins/plugin-task-coordinator/src/odysseus/SearchPalette.tsx
+++ b/plugins/plugin-task-coordinator/src/odysseus/SearchPalette.tsx
@@ -28,8 +28,9 @@ import {
  *
  * Splits via a case-insensitive regex over the ORIGINAL `text` (every segment
  * is a slice of `text` itself), rather than indexing a `toLowerCase()` copy —
- * some characters change length when lowercased (e.g. "İ", "ẞ"), which would
- * otherwise shift the indices and slice the highlight at the wrong offset. */
+ * some characters change length when lowercased (e.g. "İ" → "i" + U+0307, two
+ * code units), which would otherwise shift the indices in the lowercased copy
+ * and slice the highlight at the wrong offset. */
 function highlightMatch(text: string, query: string): ReactNode {
   if (!query) return text;
   const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");


### PR DESCRIPTION
## What

PR #8226 added `resetRound()` (clears `revealed` + `winnerIdx`) on **add / remove / shuffle** of compare slots, but not when a slot's **provider or model is swapped** mid-round. Because the winner is tracked by array **index** and the crown is **model-bound**, swapping the model behind a pane leaves a stale winner/loser badge — and a stale reveal — attached to a model that was never voted on.

This calls `resetRound()` from `setSlotProvider` and `setSlotModel` so *every* lineup change invalidates the verdict, closing the same bug class #8226 targeted. Also corrects the `SearchPalette.highlightMatch` comment: only `"İ"` expands when lowercased in V8/Bun (→ `"i" + U+0307`), not `"ẞ"`.

## Why

Surfaced during a multi-agent review pass over the open `plugin-task-coordinator` PRs. The reviewers' deeper finding — that `winnerIdx`-by-index is the root fragility and tracking the winner by stable `slotId` would eliminate the class entirely — is noted as a larger follow-up; this is the minimal, consistent fix matching the merged #8226 approach.

## Test

- `bunx @biomejs/biome check` — clean on both files.
- Scoped `tsc --noEmit` over the plugin — no errors in the changed files.
- No dedicated unit suite exists for these odysseus components (only live-e2e suites needing real CLIs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)