### PR TITLE
fix(cloud-shared): route Cerebras default models to Cerebras before BitRouter

### DIFF
--- a/packages/cloud-shared/src/lib/providers/language-model.ts
+++ b/packages/cloud-shared/src/lib/providers/language-model.ts
@@ -266,16 +266,20 @@ export function getLanguageModel(model: string) {
     return client.languageModel(apiModelId);
   }
 
+  // Cerebras-native default IDs (gpt-oss-120b, zai-glm-4.7) are bare and are NOT
+  // in BitRouter's catalog, so they must route to Cerebras BEFORE the BitRouter
+  // catch-all — otherwise toBitRouterModelId passes them through unchanged and
+  // BitRouter rejects them. Mirrors the Groq/Vast native checks above.
+  if (isCerebrasNativeModel(model) && getProviderKey("CEREBRAS_API_KEY")) {
+    return getCerebrasClient().chat(normalizeCerebrasModelId(model));
+  }
+
   if (getBitRouterApiKey()) {
     return getBitRouterClient().languageModel(toBitRouterModelId(model));
   }
 
   if (requiresBitRouterRouting(model)) {
     throw new Error("BITROUTER_API_KEY environment variable is required for this model");
-  }
-
-  if (isCerebrasNativeModel(model) && getProviderKey("CEREBRAS_API_KEY")) {
-    return getCerebrasClient().chat(normalizeCerebrasModelId(model));
   }
 
   if (getVercelAIGatewayApiKey()) {
@@ -339,16 +343,18 @@ export function resolveAiProviderSource(
     return resolveVastEndpointConfig(model) ? "vast" : null;
   }
 
+  // Match getLanguageModel: Cerebras-native defaults are served by Cerebras
+  // before the BitRouter catch-all, so bill them to cerebras (not bitrouter).
+  if (isCerebrasNativeModel(model) && getProviderKey("CEREBRAS_API_KEY")) {
+    return "cerebras";
+  }
+
   if (getBitRouterApiKey()) {
     return "bitrouter";
   }
 
   if (requiresBitRouterRouting(model)) {
     return null;
-  }
-
-  if (isCerebrasNativeModel(model)) {
-    return getProviderKey("CEREBRAS_API_KEY") ? "cerebras" : null;
   }
 
   if (getVercelAIGatewayApiKey()) {


### PR DESCRIPTION
## Problem (potential production default-inference break)

#8233 set the default text models to **bare Cerebras IDs** (`gpt-oss-120b`, `zai-glm-4.7` — `catalog.ts:46-47`), but `getLanguageModel` routes **every** model through the BitRouter catch-all (`language-model.ts`, `if (getBitRouterApiKey())`) *before* the Cerebras branch, and `toBitRouterModelId` passes those bare IDs through unchanged.

Production carries **both** `BITROUTER_API_KEY` and `CEREBRAS_API_KEY`, so default inference is sent to BitRouter as bare `gpt-oss-120b`/`zai-glm-4.7` — IDs **not** in BitRouter's catalog (it has the prefixed `openai/gpt-oss-120b`). The Cerebras branch is therefore unreachable whenever BitRouter is configured, and default inference would fail.

## Fix

Move the `isCerebrasNativeModel(model) && getProviderKey("CEREBRAS_API_KEY")` check **above** the BitRouter catch-all in:
- `getLanguageModel` (actual routing)
- `resolveAiProviderSource` (billing attribution — now bills these to `cerebras`, matching where they run)

mirroring the existing Groq/Vast native-provider checks. `isCerebrasNativeModel` matches **only** the two bare default IDs, and `requiresBitRouterRouting` is false for them, so **every non-Cerebras model still hits BitRouter unchanged** — minimal blast radius. Non-Cerebras-key deployments still fall through to the BitRouter catch-all.

Diff is exactly this reorder (+ comments) in one file.

## Note

`hasLanguageModelProviderConfigured` has the same `Groq→BitRouter→Cerebras` ordering; left untouched here (it's a config-presence check, not routing) but flagged for a consistency follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)