### PR TITLE
fix(cloud-shared): normalize BitRouter per-million token prices to per-token

### DIFF
--- a/packages/cloud-shared/src/lib/services/ai-pricing-bitrouter-units.test.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing-bitrouter-units.test.ts
@@ -1,0 +1,84 @@
+/**
+ * BitRouter price units: the catalog stores per-token unit prices, but
+ * BitRouter exposes per-MILLION-token prices under the structured
+ * `input_tokens.no_cache` / `output_tokens.text` fields (while the legacy flat
+ * `prompt` / `completion` fields are already per-token). The ingest must divide
+ * the structured form by 1e6, otherwise every cost is inflated ~1,000,000×
+ * (the bug that made claude-sonnet reserve ~$88k for a tiny request while the
+ * far-cheaper gpt-oss models slipped under the balance check).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { buildBitRouterPreparedEntries } from "@/lib/services/ai-pricing";
+
+function priceFor(
+  entries: ReturnType<typeof buildBitRouterPreparedEntries>,
+  modelId: string,
+  chargeType: "input" | "output",
+): number | undefined {
+  return entries.find((e) => e.model === modelId && e.chargeType === chargeType)?.unitPrice;
+}
+
+describe("BitRouter pricing units", () => {
+  test("structured per-million prices are normalized to per-token", () => {
+    // claude-sonnet-4.5 live catalog: input $3 / 1M, output $15 / 1M.
+    const entries = buildBitRouterPreparedEntries({
+      id: "anthropic/claude-sonnet-4.5",
+      pricing: { input_tokens: { no_cache: 3 }, output_tokens: { text: 15 } },
+    } as never);
+
+    expect(priceFor(entries, "anthropic/claude-sonnet-4.5", "input")).toBeCloseTo(0.000003, 12);
+    expect(priceFor(entries, "anthropic/claude-sonnet-4.5", "output")).toBeCloseTo(0.000015, 12);
+  });
+
+  test("a 1k-token request costs cents, not thousands of dollars", () => {
+    const entries = buildBitRouterPreparedEntries({
+      id: "anthropic/claude-sonnet-4.5",
+      pricing: { input_tokens: { no_cache: 3 }, output_tokens: { text: 15 } },
+    } as never);
+
+    const input = priceFor(entries, "anthropic/claude-sonnet-4.5", "input") ?? 0;
+    const output = priceFor(entries, "anthropic/claude-sonnet-4.5", "output") ?? 0;
+    // 1k input + 1k output tokens
+    const cost = input * 1000 + output * 1000;
+    expect(cost).toBeCloseTo(0.018, 6); // $0.018, not $18,000
+    expect(cost).toBeLessThan(1);
+  });
+
+  test("cheap models normalize too (gpt-oss-120b)", () => {
+    const entries = buildBitRouterPreparedEntries({
+      id: "openai/gpt-oss-120b",
+      pricing: { input_tokens: { no_cache: 0.039 }, output_tokens: { text: 0.19 } },
+    } as never);
+
+    expect(priceFor(entries, "openai/gpt-oss-120b", "input")).toBeCloseTo(0.000000039, 15);
+    expect(priceFor(entries, "openai/gpt-oss-120b", "output")).toBeCloseTo(0.00000019, 15);
+  });
+
+  test("legacy flat per-token fields (OpenRouter form) are used as-is", () => {
+    const entries = buildBitRouterPreparedEntries({
+      id: "legacy/model",
+      pricing: { prompt: "0.000003", completion: "0.000015" },
+    } as never);
+
+    expect(priceFor(entries, "legacy/model", "input")).toBeCloseTo(0.000003, 12);
+    expect(priceFor(entries, "legacy/model", "output")).toBeCloseTo(0.000015, 12);
+  });
+
+  test("flat field wins over structured when both are present", () => {
+    const entries = buildBitRouterPreparedEntries({
+      id: "both/model",
+      pricing: {
+        prompt: "0.000002",
+        input_tokens: { no_cache: 3 },
+      },
+    } as never);
+
+    expect(priceFor(entries, "both/model", "input")).toBeCloseTo(0.000002, 12);
+  });
+
+  test("models without pricing produce no entries", () => {
+    const entries = buildBitRouterPreparedEntries({ id: "no/pricing", pricing: {} } as never);
+    expect(entries).toHaveLength(0);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/ai-pricing/providers/bitrouter.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/providers/bitrouter.ts
@@ -45,6 +45,36 @@ function nestedPrice(pricing: Record<string, unknown>, group: string, key: strin
   return (value as Record<string, unknown>)[key];
 }
 
+const TOKENS_PER_MILLION = 1_000_000;
+
+/**
+ * Resolves a per-token unit price from a BitRouter catalog `pricing` object.
+ *
+ * BitRouter exposes two shapes with DIFFERENT units:
+ *  - legacy flat field (`prompt` / `completion`): USD **per token** (OpenRouter
+ *    form) — used as-is;
+ *  - structured field (`input_tokens.no_cache` / `output_tokens.text`): USD
+ *    **per million tokens** — divided by 1e6 to normalize to per token.
+ *
+ * The catalog stores per-token unit prices, so the per-million form must be
+ * converted or every cost is inflated ~1,000,000× (e.g. claude-sonnet at
+ * input_tokens.no_cache=3 would bill $3/token instead of $0.000003/token).
+ */
+function resolveTokenUnitPrice(
+  pricing: Record<string, unknown>,
+  flatKey: "prompt" | "completion",
+  group: "input_tokens" | "output_tokens",
+  nestedKey: string,
+): number | null {
+  const flat = parseNumericPrice(pricing[flatKey]);
+  if (flat != null) return flat;
+
+  const perMillion = parseNumericPrice(nestedPrice(pricing, group, nestedKey));
+  if (perMillion != null) return perMillion / TOKENS_PER_MILLION;
+
+  return null;
+}
+
 export function buildBitRouterPreparedEntries(
   model: BitRouterCatalogModel,
 ): PreparedPricingEntry[] {
@@ -77,9 +107,7 @@ export function buildBitRouterPreparedEntries(
   });
 
   const entries: PreparedPricingEntry[] = [];
-  const promptPrice = parseNumericPrice(
-    pricing.prompt ?? nestedPrice(pricing, "input_tokens", "no_cache"),
-  );
+  const promptPrice = resolveTokenUnitPrice(pricing, "prompt", "input_tokens", "no_cache");
   if (promptPrice != null) {
     entries.push(buildEntry(model.id, "input", promptPrice));
     if (baseId !== null) {
@@ -87,9 +115,7 @@ export function buildBitRouterPreparedEntries(
     }
   }
 
-  const completionPrice = parseNumericPrice(
-    pricing.completion ?? nestedPrice(pricing, "output_tokens", "text"),
-  );
+  const completionPrice = resolveTokenUnitPrice(pricing, "completion", "output_tokens", "text");
   if (completionPrice != null) {
     entries.push(buildEntry(model.id, "output", completionPrice));
     if (baseId !== null) {


### PR DESCRIPTION
## Problem

BitRouter's catalog exposes token prices under the structured fields
`pricing.input_tokens.no_cache` / `pricing.output_tokens.text` in **USD per
million tokens**, whereas the legacy flat `pricing.prompt` / `pricing.completion`
fields (OpenRouter form) are **per token**.

`buildBitRouterPreparedEntries` read both with the same `parseNumericPrice(...)`
and stored the value directly as a per-token `unitPrice`, so every model priced
from the structured form was inflated **~1,000,000×**.

Verified against the live catalog — both use the structured per-million form:

| model | `input_tokens.no_cache` | `output_tokens.text` |
|---|---|---|
| `anthropic/claude-sonnet-4.5` | `3` ($3 / 1M) | `15` ($15 / 1M) |
| `openai/gpt-oss-120b` | `0.039` | `0.19` |

Effect: cheap models (gpt-oss) slipped under the balance check, but
`claude-sonnet-4.5` reserved **~$88k** for a tiny request and failed with
`insufficient_credits`.

## Fix

`resolveTokenUnitPrice()` resolves each price by source: use the flat per-token
field as-is, otherwise divide the structured per-million field by `1e6`.

## Tests

- New `ai-pricing-bitrouter-units.test.ts` (6 cases): structured→per-token for
  claude & gpt-oss, a 1k-token request costs $0.018 not $18k, legacy flat fields
  used as-is, flat-wins-over-structured precedence, and no-pricing → no entries.
- Existing `ai-pricing-variant-indexing.test.ts` still passes (22/22).
- `biome` lint and `cloud-shared` typecheck clean.