### PR TITLE
fix: resolve bun.exe on Windows so cloud:mock and cloud-e2e boot

### DIFF
--- a/packages/scripts/cloud/admin/dev/cloud-api-dev.mjs
+++ b/packages/scripts/cloud/admin/dev/cloud-api-dev.mjs
@@ -26,15 +26,24 @@ const pollIntervalMs = 500;
 
 function bunExecutable() {
   if (process.env.BUN && existsSync(process.env.BUN)) return process.env.BUN;
-  const homeBun = path.resolve(process.env.HOME || "", ".bun/bin/bun");
-  if (existsSync(homeBun)) return homeBun;
-  const pathBun = process.env.PATH?.split(path.delimiter)
-    .map((entry) => path.resolve(entry, "bun"))
-    .find((candidate) => existsSync(candidate));
-  if (pathBun) return pathBun;
+  // On Windows, Node can spawn `bun.exe` directly but NOT the extensionless npm
+  // shim (`spawn ENOENT`) nor a `.cmd` without `shell: true`. Probe the native
+  // `.exe` first so the npm shim never wins. On POSIX the binary is just `bun`.
+  const names = process.platform === "win32" ? ["bun.exe", "bun"] : ["bun"];
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  const dirs = [
+    path.resolve(home, ".bun/bin"),
+    ...(process.env.PATH?.split(path.delimiter) ?? []),
+  ];
+  for (const dir of dirs) {
+    for (const name of names) {
+      const candidate = path.resolve(dir, name);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
   if (process.env.npm_execpath?.includes("bun"))
     return process.env.npm_execpath;
-  return "bun";
+  return process.platform === "win32" ? "bun.exe" : "bun";
 }
 
 function isRealNodeExecutable(candidate) {

--- a/packages/test/cloud-e2e/src/fixtures/stack.ts
+++ b/packages/test/cloud-e2e/src/fixtures/stack.ts
@@ -12,11 +12,11 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
-import { createWriteStream, type WriteStream } from "node:fs";
+import { createWriteStream, existsSync, type WriteStream } from "node:fs";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { type AddressInfo, createConnection, createServer } from "node:net";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { delimiter, join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import {
   type RunningControlPlaneMock,
@@ -28,6 +28,30 @@ import {
 } from "@elizaos/cloud-test-mocks/hetzner";
 
 import { buildSharedEnv } from "./env";
+
+/**
+ * Resolve the bun executable for `child_process.spawn`. On Windows, Node cannot
+ * spawn the extensionless npm `bun` shim (spawn ENOENT) nor a `.cmd` without
+ * `shell: true`, so probe the native `bun.exe` first. POSIX uses plain `bun`.
+ */
+function resolveBun(): string {
+  if (process.env.BUN && existsSync(process.env.BUN)) return process.env.BUN;
+  const names = process.platform === "win32" ? ["bun.exe", "bun"] : ["bun"];
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  const dirs = [
+    resolve(home, ".bun/bin"),
+    ...(process.env.PATH?.split(delimiter) ?? []),
+  ];
+  for (const dir of dirs) {
+    for (const name of names) {
+      const candidate = resolve(dir, name);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  return process.platform === "win32" ? "bun.exe" : "bun";
+}
+
+const BUN = resolveBun();
 
 const REPO_ROOT = resolve(import.meta.dirname, "../../../../..");
 const LOG_DIR = resolve(import.meta.dirname, "../../.logs");
@@ -265,7 +289,7 @@ export async function startCloudStack(
   procs.push(
     spawnLogged(
       "pglite",
-      "bun",
+      BUN,
       ["run", "packages/scripts/cloud/admin/dev/pglite-server.ts"],
       {
         env: pgliteEnv,
@@ -293,7 +317,7 @@ export async function startCloudStack(
   if (!opts.skipMigrate) {
     await runLoggedStep(
       "cloud-migrate",
-      "bun",
+      BUN,
       ["run", "--cwd", "packages/cloud-shared", "db:migrate"],
       {
         env: stackEnv,
@@ -333,7 +357,7 @@ export async function startCloudStack(
   procs.push(
     spawnLogged(
       "cloud-frontend",
-      "bun",
+      BUN,
       ["run", "dev", "--", "--host", "127.0.0.1"],
       {
         env: frontendEnv,


### PR DESCRIPTION
## Problem

On Windows, `bun run cloud:mock` and the `cloud-e2e` stack cannot boot the
cloud-api. The dev launchers `spawn("bun", …)` to start `pglite-server.ts`
(and wrangler / migrate), but Node cannot exec the extensionless npm `bun`
shim → `spawn ENOENT (…\npm\bun)`. The Hetzner and control-plane mocks start
fine; only cloud-api dies, so the entire local/e2e cloud stack is unusable on
Windows.

## Fix

Resolve the bun executable Windows-safely in both launchers — probe the native
`bun.exe` first (Node can spawn an `.exe` directly; it cannot spawn the
extensionless shim, nor a `.cmd` without `shell:true`). POSIX behavior is
unchanged (plain `bun`).

- `packages/scripts/cloud/admin/dev/cloud-api-dev.mjs` — `bunExecutable()`
- `packages/test/cloud-e2e/src/fixtures/stack.ts` — new `resolveBun()` for the
  pglite / migrate / frontend spawns

## Verification

With the `cloud-api-dev` fix, `CLOUD_E2E=1 NODE_ENV=test bun run cloud:mock
--no-frontend` boots cloud-api end to end on Windows — migrations run, wrangler
prints `Ready on http://127.0.0.1:<port>`, and `/api/health` returns
`{"status":"ok"}`. Previously it died at the pglite spawn. The `cloud-e2e`
`stack.ts` change mirrors the identical, verified resolver.

No behavior change on macOS / Linux.
