### PR TITLE
feat(orchestrator): let /goal autonomously drive the monetized-app loop (capped self-spend + economics capabilities)

### DIFF
--- a/packages/ui/src/api/client-types-cloud.ts
+++ b/packages/ui/src/api/client-types-cloud.ts
@@ -1249,6 +1249,10 @@ export interface CodingAgentCreateTaskInput {
   priority?: CodingAgentTaskThread["priority"];
   acceptanceCriteria?: string[];
   providerPolicy?: CodingAgentTaskProviderPolicy;
+  /** Free-form task metadata forwarded to the orchestrator. Recognized keys
+   * include `autoVerify` and `capabilityProfile` (e.g. `"economics"` to let the
+   * spawned sub-agent drive the monetized-app Cloud commands). */
+  metadata?: Record<string, unknown>;
 }
 
 /** Structured payload for forking a task via `POST /api/orchestrator/tasks/:id/fork`. */

--- a/plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/goal-prompt.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildGoalPrompt,
+  coerceGoalCapabilityProfile,
+  DEFAULT_GOAL_CAPABILITIES,
+  ECONOMICS_GOAL_CAPABILITIES,
+  resolveGoalCapabilities,
+} from "../services/goal-prompt.js";
+
+describe("resolveGoalCapabilities", () => {
+  it("defaults to the coding-only fence", () => {
+    expect(resolveGoalCapabilities()).toBe(DEFAULT_GOAL_CAPABILITIES);
+    expect(resolveGoalCapabilities("default")).toBe(DEFAULT_GOAL_CAPABILITIES);
+  });
+
+  it("returns the economics fence for the economics profile", () => {
+    expect(resolveGoalCapabilities("economics")).toBe(
+      ECONOMICS_GOAL_CAPABILITIES,
+    );
+  });
+});
+
+describe("coerceGoalCapabilityProfile", () => {
+  it("recognizes known profiles case-insensitively", () => {
+    expect(coerceGoalCapabilityProfile("economics")).toBe("economics");
+    expect(coerceGoalCapabilityProfile(" Economics ")).toBe("economics");
+    expect(coerceGoalCapabilityProfile("default")).toBe("default");
+  });
+
+  it("returns undefined for unknown / non-string values", () => {
+    expect(coerceGoalCapabilityProfile("nope")).toBeUndefined();
+    expect(coerceGoalCapabilityProfile(123)).toBeUndefined();
+    expect(coerceGoalCapabilityProfile(undefined)).toBeUndefined();
+  });
+});
+
+describe("buildGoalPrompt capability fence", () => {
+  const baseInput = { agentName: "Ada", goal: "ship the thing" };
+
+  it("keeps the coding-only fence by default", () => {
+    const prompt = buildGoalPrompt(baseInput);
+    expect(prompt).toContain("Use only coding-relevant capabilities");
+    expect(prompt).toContain("edit/apply patches");
+    expect(prompt).not.toContain("parent-agent Cloud command bridge");
+  });
+
+  it("renders the economics fence under the economics profile", () => {
+    const prompt = buildGoalPrompt({
+      ...baseInput,
+      capabilityProfile: "economics",
+    });
+    expect(prompt).toContain("authorized to use these capabilities");
+    expect(prompt).toContain("parent-agent Cloud command bridge");
+    expect(prompt).toContain("domains.buy");
+    expect(prompt).not.toContain("Use only coding-relevant capabilities");
+  });
+
+  it("lets an explicit allow-list override the profile", () => {
+    const prompt = buildGoalPrompt({
+      ...baseInput,
+      capabilityProfile: "economics",
+      allowedCapabilities: ["read/search files"],
+    });
+    expect(prompt).toContain("read/search files");
+    expect(prompt).not.toContain("domains.buy");
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-broker.test.ts
@@ -1,6 +1,7 @@
 import type { IAgentRuntime, Memory } from "@elizaos/core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { runParentAgentBroker } from "../services/parent-agent-broker.js";
+import { resetSessionSpendUsd } from "../services/spend-allowance.js";
 
 function createRuntime(overrides: Partial<IAgentRuntime> = {}): IAgentRuntime {
   const cache = new Map<string, unknown>();
@@ -35,6 +36,7 @@ describe("runParentAgentBroker", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
+    resetSessionSpendUsd();
   });
 
   it("lists matching parent actions", async () => {
@@ -296,5 +298,119 @@ describe("runParentAgentBroker", () => {
     const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
     expect(url.pathname).toBe("/api/v1/apps/app-1/domains/check");
     expect(init.body).toBe(JSON.stringify({ domain: "example.com" }));
+  });
+
+  describe("capped self-spend allowance", () => {
+    function stubAllowance(capUsd: string) {
+      // Point config resolution at a missing file so the cap is read from env.
+      vi.stubEnv("ELIZA_CONFIG_PATH", "/nonexistent/eliza-config.json");
+      vi.stubEnv("ELIZA_AGENT_SPEND_CAP_USD", capUsd);
+      vi.stubEnv("ELIZAOS_CLOUD_API_KEY", "test-key");
+      vi.stubEnv("ELIZA_CLOUD_BASE_URL", "https://cloud.test");
+    }
+
+    it("self-authorizes a paid self-spend command within the cap and strips the spend hint", async () => {
+      stubAllowance("50");
+      const fetchMock = vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({ success: true, status: "registered" }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          ),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await runParentAgentBroker({
+        runtime: createRuntime(),
+        sessionId: "spend-within",
+        message: brokerMessage(),
+        args: {
+          mode: "cloud-command",
+          command: "domains.buy",
+          params: { id: "app-1", domain: "myapp.com", spendEstimateUsd: 14.95 },
+        },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.text).not.toContain("Reply yes");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/api/v1/apps/app-1/domains/buy");
+      // The reserved spend hint must NOT leak into the Cloud request body.
+      expect(init.body).toBe(JSON.stringify({ domain: "myapp.com" }));
+    });
+
+    it("requires confirmation when a self-spend command exceeds the allowance", async () => {
+      stubAllowance("10");
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await runParentAgentBroker({
+        runtime: createRuntime(),
+        sessionId: "spend-over",
+        message: brokerMessage(),
+        args: {
+          mode: "cloud-command",
+          command: "domains.buy",
+          params: { id: "app-1", domain: "myapp.com", spendEstimateUsd: 14.95 },
+        },
+      });
+
+      expect(result.text).toContain("Reply yes");
+      expect(result.text).toContain("allowance");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("still requires confirmation for destructive commands even under an allowance", async () => {
+      stubAllowance("1000");
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await runParentAgentBroker({
+        runtime: createRuntime(),
+        sessionId: "spend-destructive",
+        message: brokerMessage(),
+        args: {
+          mode: "cloud-command",
+          command: "apps.delete",
+          params: { id: "app-1" },
+        },
+      });
+
+      expect(result.text).toContain("Reply yes");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("auto-authorizes non-self-spend mutating commands under an allowance", async () => {
+      stubAllowance("50");
+      const fetchMock = vi.fn(
+        async () =>
+          new Response(JSON.stringify({ success: true }), {
+            status: 201,
+            headers: { "content-type": "application/json" },
+          }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await runParentAgentBroker({
+        runtime: createRuntime(),
+        sessionId: "spend-mutating",
+        message: brokerMessage(),
+        args: {
+          mode: "cloud-command",
+          command: "apps.create",
+          params: { body: { name: "Auto App" } },
+        },
+      });
+
+      expect(result.text).not.toContain("Reply yes");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+      expect(url.pathname).toBe("/api/v1/apps");
+      expect(init.method).toBe("POST");
+    });
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/spend-allowance.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/spend-allowance.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  addSessionSpendUsd,
+  CONTAINER_DAILY_COST_USD,
+  decideSpendAuthorization,
+  estimateSelfSpendCostUsd,
+  getSessionSpendUsd,
+  readSpendCapUsd,
+  resetSessionSpendUsd,
+  SPEND_HINT_PARAM,
+  stripSpendHints,
+} from "../services/spend-allowance.js";
+
+describe("estimateSelfSpendCostUsd", () => {
+  it("defaults containers to the base daily cost when no hint is given", () => {
+    expect(estimateSelfSpendCostUsd("containers.create")).toBe(
+      CONTAINER_DAILY_COST_USD,
+    );
+    expect(estimateSelfSpendCostUsd("containers.update")).toBe(
+      CONTAINER_DAILY_COST_USD,
+    );
+  });
+
+  it("honors an explicit spend hint", () => {
+    expect(
+      estimateSelfSpendCostUsd("containers.create", {
+        [SPEND_HINT_PARAM]: 2.5,
+      }),
+    ).toBe(2.5);
+    expect(
+      estimateSelfSpendCostUsd("domains.buy", { [SPEND_HINT_PARAM]: 14.95 }),
+    ).toBe(14.95);
+    // string hints are coerced
+    expect(
+      estimateSelfSpendCostUsd("domains.buy", { [SPEND_HINT_PARAM]: "9.99" }),
+    ).toBe(9.99);
+  });
+
+  it("returns null for hint-required commands without a hint", () => {
+    expect(estimateSelfSpendCostUsd("domains.buy")).toBeNull();
+    expect(estimateSelfSpendCostUsd("media.image.generate")).toBeNull();
+  });
+
+  it("rejects negative / non-finite hints", () => {
+    expect(
+      estimateSelfSpendCostUsd("domains.buy", { [SPEND_HINT_PARAM]: -5 }),
+    ).toBeNull();
+    expect(
+      estimateSelfSpendCostUsd("domains.buy", { [SPEND_HINT_PARAM]: "abc" }),
+    ).toBeNull();
+  });
+});
+
+describe("decideSpendAuthorization", () => {
+  const base = { capUsd: 0, alreadySpentUsd: 0 } as const;
+
+  it("never gates read / dry-run commands", () => {
+    expect(
+      decideSpendAuthorization({ ...base, command: "apps.list", risk: "read" })
+        .autoAuthorize,
+    ).toBe(true);
+    expect(
+      decideSpendAuthorization({
+        ...base,
+        command: "domains.check",
+        risk: "dry-run",
+      }).autoAuthorize,
+    ).toBe(true);
+  });
+
+  it("falls back to human confirmation when the allowance is disabled (cap 0)", () => {
+    for (const risk of ["mutating", "paid", "destructive"] as const) {
+      const decision = decideSpendAuthorization({
+        ...base,
+        command: "apps.create",
+        risk,
+      });
+      expect(decision.autoAuthorize).toBe(false);
+      expect(decision.reason).toBe("allowance-disabled");
+    }
+  });
+
+  it("always requires a human for destructive commands even under a cap", () => {
+    const decision = decideSpendAuthorization({
+      command: "apps.delete",
+      risk: "destructive",
+      capUsd: 1000,
+      alreadySpentUsd: 0,
+    });
+    expect(decision.autoAuthorize).toBe(false);
+    expect(decision.reason).toBe("destructive-requires-human");
+  });
+
+  it("auto-authorizes a self-spend command within the cap and reports its cost", () => {
+    const decision = decideSpendAuthorization({
+      command: "domains.buy",
+      risk: "paid",
+      capUsd: 50,
+      alreadySpentUsd: 0,
+      params: { [SPEND_HINT_PARAM]: 14.95 },
+    });
+    expect(decision.autoAuthorize).toBe(true);
+    expect(decision.reason).toBe("within-cap");
+    expect(decision.estimatedCostUsd).toBe(14.95);
+  });
+
+  it("requires confirmation when a self-spend command exceeds the remaining budget", () => {
+    const decision = decideSpendAuthorization({
+      command: "domains.buy",
+      risk: "paid",
+      capUsd: 20,
+      alreadySpentUsd: 18,
+      params: { [SPEND_HINT_PARAM]: 14.95 },
+    });
+    expect(decision.autoAuthorize).toBe(false);
+    expect(decision.reason).toBe("over-cap");
+    // cost is surfaced so the broker can show it in the confirmation prompt
+    expect(decision.estimatedCostUsd).toBe(14.95);
+  });
+
+  it("requires confirmation for a self-spend command of unknown cost", () => {
+    const decision = decideSpendAuthorization({
+      command: "domains.buy",
+      risk: "paid",
+      capUsd: 50,
+      alreadySpentUsd: 0,
+    });
+    expect(decision.autoAuthorize).toBe(false);
+    expect(decision.reason).toBe("unknown-cost");
+  });
+
+  it("auto-authorizes containers using the base daily cost", () => {
+    const decision = decideSpendAuthorization({
+      command: "containers.create",
+      risk: "paid",
+      capUsd: 5,
+      alreadySpentUsd: 0,
+    });
+    expect(decision.autoAuthorize).toBe(true);
+    expect(decision.estimatedCostUsd).toBe(CONTAINER_DAILY_COST_USD);
+  });
+
+  it("auto-authorizes non-self-spend mutating/revenue commands under an active cap", () => {
+    // apps.create is a state change, not a debit of our balance
+    const create = decideSpendAuthorization({
+      command: "apps.create",
+      risk: "mutating",
+      capUsd: 50,
+      alreadySpentUsd: 0,
+    });
+    expect(create.autoAuthorize).toBe(true);
+    expect(create.reason).toBe("non-self-spend");
+    expect(create.estimatedCostUsd).toBeNull();
+
+    // apps.charges.create is paid-risk but the *payer* funds it (revenue)
+    const charge = decideSpendAuthorization({
+      command: "apps.charges.create",
+      risk: "paid",
+      capUsd: 50,
+      alreadySpentUsd: 0,
+    });
+    expect(charge.autoAuthorize).toBe(true);
+    expect(charge.reason).toBe("non-self-spend");
+  });
+});
+
+describe("session spend ledger", () => {
+  afterEach(() => resetSessionSpendUsd());
+
+  it("accumulates per session and isolates sessions", () => {
+    expect(getSessionSpendUsd("s1")).toBe(0);
+    expect(addSessionSpendUsd("s1", 10)).toBe(10);
+    expect(addSessionSpendUsd("s1", 5.5)).toBe(15.5);
+    expect(getSessionSpendUsd("s1")).toBe(15.5);
+    expect(getSessionSpendUsd("s2")).toBe(0);
+  });
+
+  it("ignores negative / non-finite additions", () => {
+    addSessionSpendUsd("s1", -5);
+    addSessionSpendUsd("s1", Number.NaN);
+    expect(getSessionSpendUsd("s1")).toBe(0);
+  });
+
+  it("resets a single session", () => {
+    addSessionSpendUsd("s1", 10);
+    addSessionSpendUsd("s2", 20);
+    resetSessionSpendUsd("s1");
+    expect(getSessionSpendUsd("s1")).toBe(0);
+    expect(getSessionSpendUsd("s2")).toBe(20);
+  });
+});
+
+describe("readSpendCapUsd", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("returns 0 (disabled) when unset", () => {
+    vi.stubEnv("ELIZA_CONFIG_PATH", "/nonexistent/eliza-config.json");
+    vi.stubEnv("ELIZA_AGENT_SPEND_CAP_USD", "");
+    expect(readSpendCapUsd()).toBe(0);
+  });
+
+  it("parses a positive cap from the environment", () => {
+    vi.stubEnv("ELIZA_CONFIG_PATH", "/nonexistent/eliza-config.json");
+    vi.stubEnv("ELIZA_AGENT_SPEND_CAP_USD", "25");
+    expect(readSpendCapUsd()).toBe(25);
+  });
+
+  it("treats invalid / non-positive values as disabled", () => {
+    vi.stubEnv("ELIZA_CONFIG_PATH", "/nonexistent/eliza-config.json");
+    vi.stubEnv("ELIZA_AGENT_SPEND_CAP_USD", "-1");
+    expect(readSpendCapUsd()).toBe(0);
+    vi.stubEnv("ELIZA_AGENT_SPEND_CAP_USD", "notanumber");
+    expect(readSpendCapUsd()).toBe(0);
+  });
+});
+
+describe("stripSpendHints", () => {
+  it("removes the reserved hint key and preserves the rest", () => {
+    const out = stripSpendHints({
+      id: "app-1",
+      domain: "x.com",
+      [SPEND_HINT_PARAM]: 14.95,
+    });
+    expect(out).toEqual({ id: "app-1", domain: "x.com" });
+  });
+
+  it("passes through params without a hint unchanged", () => {
+    const params = { id: "app-1" };
+    expect(stripSpendHints(params)).toBe(params);
+    expect(stripSpendHints(undefined)).toBeUndefined();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/goal-prompt.ts
@@ -24,6 +24,52 @@ export const DEFAULT_GOAL_CAPABILITIES: readonly string[] = [
   "communicate with the parent/swarm",
 ];
 
+/**
+ * Capability fence for goal tasks that build and monetize an Eliza Cloud app.
+ * Extends the coding capabilities with the parent-agent Cloud command bridge so
+ * a `/goal` sub-agent can drive the create-app → deploy → monetize → buy-domain
+ * loop. Paid Cloud commands are still gated server-side and by the broker's
+ * capped self-spend allowance (see `spend-allowance.ts`).
+ */
+export const ECONOMICS_GOAL_CAPABILITIES: readonly string[] = [
+  "read/search files",
+  "edit/apply patches",
+  "run shell/test commands",
+  "inspect git diff/status",
+  "communicate with the parent/swarm",
+  "use the parent-agent Cloud command bridge (USE_SKILL parent-agent)",
+  "create & configure Eliza Cloud apps (apps.create, apps.update, apps.monetization.update)",
+  "deploy app containers and read container quota/billing (containers.create, containers.quota)",
+  "search, buy, and attach domains (domains.search, domains.check, domains.buy, domains.attach)",
+  "create app charges & x402 payment requests (apps.charges.*, x402.requests.*)",
+  "read credits, earnings, and redemption balances (credits.*, redemptions.*)",
+];
+
+/** Named capability fences a goal task can run under. */
+export type GoalCapabilityProfile = "default" | "economics";
+
+/** Resolve a capability profile name to its allow-list. Unknown / undefined
+ * profiles fall back to the coding-only default fence. */
+export function resolveGoalCapabilities(
+  profile?: GoalCapabilityProfile,
+): readonly string[] {
+  return profile === "economics"
+    ? ECONOMICS_GOAL_CAPABILITIES
+    : DEFAULT_GOAL_CAPABILITIES;
+}
+
+/** Coerce an untyped value (e.g. a task metadata field) to a known profile, or
+ * `undefined` when it is not a recognized profile name. */
+export function coerceGoalCapabilityProfile(
+  value: unknown,
+): GoalCapabilityProfile | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "economics") return "economics";
+  if (normalized === "default") return "default";
+  return undefined;
+}
+
 export interface GoalPromptInput {
   /** The distinct person-name this sub-agent is given on spawn, so it knows its
    * own identity within the swarm (the way the main agent is named). */
@@ -39,7 +85,11 @@ export interface GoalPromptInput {
   worktreeRoomId?: string;
   workdir?: string;
   repo?: string;
-  /** Capability fence; defaults to {@link DEFAULT_GOAL_CAPABILITIES}. */
+  /** Named capability fence to apply when `allowedCapabilities` is not given.
+   * Defaults to `"default"` (the coding-only fence). */
+  capabilityProfile?: GoalCapabilityProfile;
+  /** Explicit capability fence; overrides {@link GoalPromptInput.capabilityProfile}
+   * and defaults to {@link DEFAULT_GOAL_CAPABILITIES}. */
   allowedCapabilities?: readonly string[];
 }
 
@@ -78,8 +128,9 @@ const COMPLETION_CONTRACT: readonly string[] = [
  */
 export function buildGoalPrompt(input: GoalPromptInput): string {
   const task = (input.task ?? input.goal).trim();
+  const profile = input.capabilityProfile ?? "default";
   const capabilities = [
-    ...(input.allowedCapabilities ?? DEFAULT_GOAL_CAPABILITIES),
+    ...(input.allowedCapabilities ?? resolveGoalCapabilities(profile)),
   ];
   const sections: string[] = [
     "--- Goal ---",
@@ -116,9 +167,13 @@ export function buildGoalPrompt(input: GoalPromptInput): string {
     sections.push("--- Rooms ---", roomLines.join("\n"));
   }
 
+  const capabilityLine =
+    profile === "default"
+      ? `Use only coding-relevant capabilities: ${capabilities.join(", ")}.`
+      : `You are authorized to use these capabilities for this task: ${capabilities.join(", ")}. Stay within them — do not reach for unrelated tools.`;
   sections.push(
     "--- Capabilities ---",
-    `Use only coding-relevant capabilities: ${capabilities.join(", ")}.`,
+    capabilityLine,
     "--- Working Agreement ---",
     bulletList([...COMPLETION_CONTRACT]),
     "--- Task ---",

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -24,6 +24,7 @@ import { assignAgentName } from "./agent-name-assignment.js";
 import {
   buildGoalFollowUp,
   buildGoalPrompt,
+  coerceGoalCapabilityProfile,
   type GoalFollowUpReason,
 } from "./goal-prompt.js";
 import {
@@ -1287,6 +1288,12 @@ export class OrchestratorTaskService extends Service {
       activeNames: activeSessionNames(doc.sessions),
       mainAgentName: this.runtime.character?.name,
     });
+    // Opt a task into a wider capability fence (e.g. the monetized-app
+    // economics commands) via `metadata.capabilityProfile`. Unset → the
+    // coding-only default fence.
+    const capabilityProfile = coerceGoalCapabilityProfile(
+      doc.task.metadata?.capabilityProfile,
+    );
     const goalPrompt = buildGoalPrompt({
       agentName,
       goal: doc.task.goal,
@@ -1295,6 +1302,7 @@ export class OrchestratorTaskService extends Service {
       taskRoomId: doc.task.taskRoomId ?? doc.task.roomId,
       workdir,
       repo: opts.repo,
+      ...(capabilityProfile ? { capabilityProfile } : {}),
     });
 
     const result = await acp.spawnSession({

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -6,6 +6,13 @@ import type {
 } from "@elizaos/core";
 import { requireConfirmation } from "@elizaos/core";
 import { readConfigCloudKey, readConfigEnvKey } from "./config-env.js";
+import {
+  addSessionSpendUsd,
+  decideSpendAuthorization,
+  getSessionSpendUsd,
+  readSpendCapUsd,
+  stripSpendHints,
+} from "./spend-allowance.js";
 import type { SessionInfo } from "./types.js";
 
 const LOG_PREFIX = "[ParentAgentBroker]";
@@ -1002,6 +1009,8 @@ async function runCloudCommand(args: {
   command: string | undefined;
   params?: Record<string, unknown>;
   confirmationMessage: Memory;
+  /** Child session id — keys the per-session self-spend ledger. */
+  sessionId: string;
 }): Promise<{
   success: boolean;
   text: string;
@@ -1032,12 +1041,67 @@ async function runCloudCommand(args: {
     };
   }
 
-  const needsConfirmation =
-    definition.risk === "mutating" ||
-    definition.risk === "paid" ||
-    definition.risk === "destructive";
-  if (needsConfirmation) {
-    const preview = `${definition.command} is a ${definition.risk} Eliza Cloud command. Proceed?`;
+  // Capped self-spend allowance. With no cap configured this resolves to the
+  // original "confirm every mutating/paid/destructive command" behavior; with a
+  // cap set, the agent self-authorizes within budget (see spend-allowance.ts).
+  const log = getLogger(args.runtime);
+  const params = args.params ?? {};
+  const capUsd = readSpendCapUsd();
+  const spendDecision = decideSpendAuthorization({
+    command: definition.command,
+    risk: definition.risk,
+    capUsd,
+    alreadySpentUsd: getSessionSpendUsd(args.sessionId),
+    params,
+  });
+
+  if (spendDecision.autoAuthorize) {
+    if (spendDecision.estimatedCostUsd && spendDecision.estimatedCostUsd > 0) {
+      const runningTotalUsd = addSessionSpendUsd(
+        args.sessionId,
+        spendDecision.estimatedCostUsd,
+      );
+      log?.info?.(
+        {
+          src: LOG_PREFIX,
+          event: "spend_auto_authorized",
+          sessionId: args.sessionId,
+          command: definition.command,
+          risk: definition.risk,
+          estimatedCostUsd: spendDecision.estimatedCostUsd,
+          runningTotalUsd,
+          capUsd,
+          reason: spendDecision.reason,
+        },
+        `${LOG_PREFIX} self-authorized ${definition.command} (~$${spendDecision.estimatedCostUsd.toFixed(2)}; $${runningTotalUsd.toFixed(2)} of $${capUsd.toFixed(2)} cap)`,
+      );
+    } else if (definition.risk !== "read" && definition.risk !== "dry-run") {
+      // Auto-authorized without a metered cost (a mutating state change or a
+      // revenue op the payer funds). Record it for the audit trail.
+      log?.info?.(
+        {
+          src: LOG_PREFIX,
+          event: "command_auto_authorized",
+          sessionId: args.sessionId,
+          command: definition.command,
+          risk: definition.risk,
+          reason: spendDecision.reason,
+        },
+        `${LOG_PREFIX} auto-authorized ${definition.command} (${definition.risk})`,
+      );
+    }
+  } else {
+    // Not auto-authorized → require an explicit human yes. Enrich the prompt
+    // when the spend cap is the blocker so the user sees the cost vs. budget.
+    const remainingUsd = Math.max(
+      0,
+      capUsd - getSessionSpendUsd(args.sessionId),
+    );
+    const preview =
+      spendDecision.reason === "over-cap" &&
+      spendDecision.estimatedCostUsd != null
+        ? `${definition.command} would spend ~$${spendDecision.estimatedCostUsd.toFixed(2)}, exceeding your remaining $${remainingUsd.toFixed(2)} self-spend allowance. Proceed?`
+        : `${definition.command} is a ${definition.risk} Eliza Cloud command. Proceed?`;
     const decision = await requireConfirmation({
       runtime: args.runtime,
       message: args.confirmationMessage,
@@ -1078,8 +1142,9 @@ async function runCloudCommand(args: {
     };
   }
 
-  const params = args.params ?? {};
-  const built = buildCloudUrl(args.runtime, definition, params);
+  // Drop the reserved spend-hint param so it never reaches the Cloud API.
+  const requestParams = stripSpendHints(params) ?? {};
+  const built = buildCloudUrl(args.runtime, definition, requestParams);
   if (!built.url) {
     return {
       success: false,
@@ -1092,7 +1157,7 @@ async function runCloudCommand(args: {
     };
   }
 
-  const body = cloudBody(definition, params);
+  const body = cloudBody(definition, requestParams);
   const response = await fetch(built.url, {
     method: definition.method,
     headers: {
@@ -1274,6 +1339,7 @@ export async function runParentAgentBroker(
         command: args.command,
         params: args.params,
         confirmationMessage: brokerConfirmationMemory(request),
+        sessionId: request.sessionId,
       });
     } catch (error) {
       const message =

--- a/plugins/plugin-agent-orchestrator/src/services/spend-allowance.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/spend-allowance.ts
@@ -1,0 +1,249 @@
+/**
+ * Capped self-spend allowance for the parent-agent Cloud command broker.
+ *
+ * By default every `mutating` / `paid` / `destructive` Eliza Cloud command run
+ * through the broker requires an explicit human "yes" (see `runCloudCommand` in
+ * `parent-agent-broker.ts`). That invariant is safe but it means a `/goal`
+ * sub-agent can never *autonomously* drive the monetized-app loop — every app
+ * create, container deploy, and domain buy stalls on a confirmation turn.
+ *
+ * When an operator configures a spend cap (`ELIZA_AGENT_SPEND_CAP_USD`), the
+ * agent may self-authorize commands within a bounded per-session budget:
+ *
+ *   - `read` / `dry-run`            → never need authorization (unchanged);
+ *   - `destructive`                 → ALWAYS require human confirmation;
+ *   - self-spend commands           → auto-authorize only while the running
+ *     (debit our own credits)         total + the command's estimated cost stays
+ *                                     within the cap; otherwise fall back to
+ *                                     confirmation;
+ *   - other `mutating` / `paid`     → auto-authorize while the allowance is
+ *     (state changes + revenue        active. These do not debit our balance
+ *      ops the *payer* funds, e.g.    (e.g. `apps.charges.create` creates a
+ *      `apps.charges.create`)         charge that someone else pays us).
+ *
+ * The cap is a SAFETY THROTTLE, not a durable accounting ledger: the running
+ * total is tracked in-memory per child session and resets on process restart.
+ * Real money is still ultimately gated server-side (credit balance, atomic
+ * debit/refund in the buy/charge routes). Default cap of `0` preserves the
+ * original "confirm everything" behavior exactly.
+ *
+ * @module services/spend-allowance
+ */
+
+import { readConfigEnvKey } from "./config-env.js";
+
+/** Mirror of the broker's `CloudCommandRisk` union (kept local to avoid a
+ * circular import; structurally identical so `definition.risk` is assignable). */
+export type SpendRisk =
+  | "read"
+  | "dry-run"
+  | "mutating"
+  | "paid"
+  | "destructive";
+
+/** Default daily cost of a container at the base tier ($0.67/day — see the
+ * `build-monetized-app` survival-economics docs and `cron/container-billing`).
+ * Used as the spend estimate for container deploys when no explicit hint is
+ * passed. */
+export const CONTAINER_DAILY_COST_USD = 0.67;
+
+/** Reserved param key the agent may pass to declare the expected USD cost of a
+ * self-spend command (e.g. the quoted price returned by `domains.check` before
+ * a `domains.buy`). It is read for the allowance decision and then STRIPPED by
+ * the broker before the request is built, so it never leaks into the Cloud API
+ * request body. */
+export const SPEND_HINT_PARAM = "spendEstimateUsd";
+
+/**
+ * Cloud commands that debit the caller's OWN credits / wallet (true self-spend).
+ * Only these are metered against the cap. Revenue/collection commands such as
+ * `apps.charges.*` and `x402.requests.*` are `paid`-risk but funded by the
+ * payer, so they are intentionally excluded.
+ */
+export const SELF_SPEND_COMMANDS: ReadonlySet<string> = new Set([
+  "domains.buy",
+  "containers.create",
+  "containers.update",
+  "media.image.generate",
+  "media.video.generate",
+  "media.music.generate",
+  "media.tts.generate",
+  "promote.assets.generate",
+  "promote.execute",
+  "advertising.campaigns.create",
+  "advertising.campaigns.start",
+  "advertising.creatives.create",
+]);
+
+/** Coerce an unknown value to a finite, non-negative number, or `null`. */
+function toNonNegativeNumber(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value >= 0 ? value : null;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+  }
+  return null;
+}
+
+/** Read the per-session spend cap (USD). `0` (the default) disables the
+ * allowance and preserves the original confirm-everything behavior. */
+export function readSpendCapUsd(): number {
+  const raw = readConfigEnvKey("ELIZA_AGENT_SPEND_CAP_USD");
+  const parsed = toNonNegativeNumber(raw);
+  return parsed ?? 0;
+}
+
+/**
+ * Estimate the USD a self-spend command will debit. Returns `null` when the
+ * cost cannot be determined — the caller treats `null` as "ask a human", so an
+ * unknown cost is never silently auto-spent.
+ */
+export function estimateSelfSpendCostUsd(
+  command: string,
+  params?: Record<string, unknown>,
+): number | null {
+  const hint = toNonNegativeNumber(params?.[SPEND_HINT_PARAM]);
+  if (command === "containers.create" || command === "containers.update") {
+    // Containers have a known base daily cost even without a hint.
+    return hint ?? CONTAINER_DAILY_COST_USD;
+  }
+  // domains.buy, media.*, promote.*, advertising.* — require an explicit hint
+  // (e.g. the quoted price from domains.check). Unknown → confirm.
+  return hint;
+}
+
+export interface SpendDecisionInput {
+  command: string;
+  risk: SpendRisk;
+  /** Per-session cap in USD (`0` = allowance disabled). */
+  capUsd: number;
+  /** USD already auto-authorized in this session. */
+  alreadySpentUsd: number;
+  params?: Record<string, unknown>;
+}
+
+export type SpendDecisionReason =
+  | "non-mutating"
+  | "allowance-disabled"
+  | "destructive-requires-human"
+  | "within-cap"
+  | "over-cap"
+  | "unknown-cost"
+  | "non-self-spend";
+
+export interface SpendDecision {
+  /** When true the broker may run the command without a human confirmation. */
+  autoAuthorize: boolean;
+  /** Estimated USD to add to the session ledger when auto-authorized (self-spend
+   * only); `null` for non-self-spend or unknown. */
+  estimatedCostUsd: number | null;
+  reason: SpendDecisionReason;
+}
+
+/**
+ * Decide whether a Cloud command may be auto-authorized under the capped
+ * allowance. Pure: no env reads, no ledger mutation, no clock — fully testable.
+ */
+export function decideSpendAuthorization(
+  input: SpendDecisionInput,
+): SpendDecision {
+  const { command, risk, capUsd, alreadySpentUsd, params } = input;
+
+  // Reads never mutate state or money.
+  if (risk === "read" || risk === "dry-run") {
+    return {
+      autoAuthorize: true,
+      estimatedCostUsd: null,
+      reason: "non-mutating",
+    };
+  }
+
+  // Allowance off → preserve the original confirm-everything behavior.
+  if (!(capUsd > 0)) {
+    return {
+      autoAuthorize: false,
+      estimatedCostUsd: null,
+      reason: "allowance-disabled",
+    };
+  }
+
+  // Destructive actions always need a human, regardless of cap.
+  if (risk === "destructive") {
+    return {
+      autoAuthorize: false,
+      estimatedCostUsd: null,
+      reason: "destructive-requires-human",
+    };
+  }
+
+  // Self-spend: meter the estimated cost against the remaining budget.
+  if (SELF_SPEND_COMMANDS.has(command)) {
+    const cost = estimateSelfSpendCostUsd(command, params);
+    if (cost === null) {
+      return {
+        autoAuthorize: false,
+        estimatedCostUsd: null,
+        reason: "unknown-cost",
+      };
+    }
+    const remaining = capUsd - alreadySpentUsd;
+    if (cost <= remaining) {
+      return {
+        autoAuthorize: true,
+        estimatedCostUsd: cost,
+        reason: "within-cap",
+      };
+    }
+    return { autoAuthorize: false, estimatedCostUsd: cost, reason: "over-cap" };
+  }
+
+  // Other mutating / revenue commands do not debit our balance.
+  return {
+    autoAuthorize: true,
+    estimatedCostUsd: null,
+    reason: "non-self-spend",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-session spend ledger (in-memory; resets on restart — see module note).
+// ---------------------------------------------------------------------------
+
+const sessionSpendUsd = new Map<string, number>();
+
+export function getSessionSpendUsd(sessionId: string): number {
+  return sessionSpendUsd.get(sessionId) ?? 0;
+}
+
+/** Add to a session's running total; returns the new total. Negative/NaN
+ * amounts are ignored. */
+export function addSessionSpendUsd(
+  sessionId: string,
+  amountUsd: number,
+): number {
+  const safe = Number.isFinite(amountUsd) && amountUsd > 0 ? amountUsd : 0;
+  const next = getSessionSpendUsd(sessionId) + safe;
+  sessionSpendUsd.set(sessionId, next);
+  return next;
+}
+
+/** Clear the ledger for one session, or all sessions when omitted (test/cleanup). */
+export function resetSessionSpendUsd(sessionId?: string): void {
+  if (sessionId === undefined) {
+    sessionSpendUsd.clear();
+    return;
+  }
+  sessionSpendUsd.delete(sessionId);
+}
+
+/** Return a shallow copy of `params` with the reserved spend-hint key removed,
+ * so it never reaches the Cloud API request. Returns `undefined` unchanged. */
+export function stripSpendHints(
+  params?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (!params || !(SPEND_HINT_PARAM in params)) return params;
+  const { [SPEND_HINT_PARAM]: _omit, ...rest } = params;
+  return rest;
+}

--- a/plugins/plugin-task-coordinator/src/odysseus/hooks/useChatSubmit.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/hooks/useChatSubmit.ts
@@ -5,6 +5,7 @@
 
 import { client } from "@elizaos/ui";
 import { useCallback, useState } from "react";
+import { parseComposerDirectives } from "../util/composer-directives";
 
 function deriveTitle(text: string): string {
   const words = text.trim().split(/\s+/).slice(0, 6).join(" ");
@@ -42,10 +43,15 @@ export function useChatSubmit({
           const ok = await client.postOrchestratorTaskMessage(selectedId, text);
           if (!ok) throw new Error("Message not delivered");
         } else {
+          // A leading "/economics" directive opts the new task into the
+          // monetized-app capability fence; otherwise the goal is the message.
+          const { goal, capabilityProfile } = parseComposerDirectives(text);
+          const effectiveGoal = goal || text;
           const created = await client.createOrchestratorTask({
-            title: deriveTitle(text),
-            goal: text,
+            title: deriveTitle(effectiveGoal),
+            goal: effectiveGoal,
             originalRequest: text,
+            ...(capabilityProfile ? { metadata: { capabilityProfile } } : {}),
           });
           onCreated(created.id);
         }

--- a/plugins/plugin-task-coordinator/src/odysseus/util/composer-directives.test.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/util/composer-directives.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { parseComposerDirectives } from "./composer-directives";
+
+describe("parseComposerDirectives", () => {
+  it("returns plain text unchanged with no profile", () => {
+    expect(parseComposerDirectives("build a trivia app")).toEqual({
+      goal: "build a trivia app",
+    });
+  });
+
+  it("strips the /economics directive and sets the economics profile", () => {
+    expect(
+      parseComposerDirectives("/economics build a monetized trivia app"),
+    ).toEqual({
+      goal: "build a monetized trivia app",
+      capabilityProfile: "economics",
+    });
+  });
+
+  it("is case-insensitive and trims surrounding whitespace", () => {
+    expect(parseComposerDirectives("  /Economics   ship it  ")).toEqual({
+      goal: "ship it",
+      capabilityProfile: "economics",
+    });
+  });
+
+  it("accepts the /monetize alias", () => {
+    expect(parseComposerDirectives("/monetize a notes app")).toEqual({
+      goal: "a notes app",
+      capabilityProfile: "economics",
+    });
+  });
+
+  it("does not treat a non-directive slash word as economics", () => {
+    expect(parseComposerDirectives("/economical budget app")).toEqual({
+      goal: "/economical budget app",
+    });
+  });
+
+  it("handles a bare directive with an empty goal", () => {
+    expect(parseComposerDirectives("/economics")).toEqual({
+      goal: "",
+      capabilityProfile: "economics",
+    });
+  });
+});

--- a/plugins/plugin-task-coordinator/src/odysseus/util/composer-directives.ts
+++ b/plugins/plugin-task-coordinator/src/odysseus/util/composer-directives.ts
@@ -1,0 +1,31 @@
+// Pure parsing of leading composer "/directives" so a user can opt a new
+// orchestrator task into a wider capability fence from the chat box. Kept free
+// of React / client imports so it is trivially unit-testable.
+
+export interface ComposerDirectives {
+  /** The message text with any recognized leading directive removed. */
+  goal: string;
+  /** Capability fence the spawned sub-agent should run under, when requested. */
+  capabilityProfile?: "economics";
+}
+
+/** Leading tokens that opt a task into the monetized-app economics fence. */
+const ECONOMICS_PREFIXES = ["/economics", "/monetize", "/monetized-app"];
+
+/**
+ * Parse leading directives from composer text. Currently recognizes the
+ * economics directives (e.g. `/economics build a trivia app`), which strip the
+ * token and mark the task for the economics capability profile. Unknown text is
+ * returned unchanged.
+ */
+export function parseComposerDirectives(text: string): ComposerDirectives {
+  const trimmed = text.trim();
+  const lower = trimmed.toLowerCase();
+  for (const prefix of ECONOMICS_PREFIXES) {
+    if (lower === prefix || lower.startsWith(`${prefix} `)) {
+      const goal = trimmed.slice(prefix.length).trim();
+      return { goal, capabilityProfile: "economics" };
+    }
+  }
+  return { goal: trimmed };
+}


### PR DESCRIPTION
## Why

A `/goal` sub-agent is fenced to coding-only capabilities
(`DEFAULT_GOAL_CAPABILITIES`), and every paid Cloud command through the
parent-agent broker requires an explicit human "yes". Together these mean an
agent **cannot autonomously drive the build-monetized-app loop** (create app →
deploy → monetize → buy domain → stay alive on earnings) — the loop the
`build-monetized-app` skill and the survival-economics cron were built for.

This PR adds two **opt-in** pieces so a goal task can drive that loop, with
**no change to any default behavior**.

## 1. Capped self-spend allowance (`spend-allowance.ts`)

Gate broker Cloud commands by a per-session USD budget
(`ELIZA_AGENT_SPEND_CAP_USD`, default `0` = today's confirm-everything behavior).

- `read` / `dry-run` → never gated (unchanged).
- `destructive` → ALWAYS require human confirmation, regardless of cap.
- self-spend commands (debit our own credits: `domains.buy`,
  `containers.create`, media/promote/ads) → auto-authorize only while running
  total + estimated cost ≤ cap; over cap or unknown cost → confirm.
- other mutating / revenue commands (`apps.create`, `apps.charges.create` —
  funded by the payer, not us) → auto-authorize while the allowance is active.

Cost hints come from a reserved `spendEstimateUsd` param that is stripped before
the outbound request. The ledger is in-memory per child session (a safety
throttle — real money is still gated server-side by atomic debit/refund). The
pure decision logic is fully unit-tested.

## 2. Economics capability profile (`goal-prompt.ts`)

`ECONOMICS_GOAL_CAPABILITIES` extends the coding fence with the parent-agent
Cloud bridge (apps / containers / domains / charges / credits). A task opts in
via `metadata.capabilityProfile = "economics"`; `spawnAgentForTask` applies it.
The default coding-only fence is unchanged. UI: a leading `/economics` (or
`/monetize`) directive in the Odysseus composer creates the task with that
profile.

## Safety

- **Off by default**: cap `0` + the default profile reproduce today's behavior
  exactly.
- Destructive actions and over-cap spend still require a human.
- Auto-authorizations are logged for audit.

## Tests

New unit tests: `spend-allowance.test.ts`, `goal-prompt.test.ts`, broker
allowance integration cases in `parent-agent-broker.test.ts`, and
`composer-directives.test.ts`. All green; orchestrator typecheck clean. The
end-to-end money path these capabilities drive is covered by the smoke test in
#8249.
