### PR TITLE
feat(cloud-sdk): web sign-in helper + X-App-Id affordance for inference

### DIFF
--- a/packages/cloud-sdk/README.md
+++ b/packages/cloud-sdk/README.md
@@ -22,6 +22,50 @@ const stream = await cloud.routes.postApiV1ChatCompletionsRaw({
 });
 ```
 
+## Sign in with Eliza Cloud (web app) + app-credits
+
+A third-party web app can let users sign in with their Eliza Cloud account — no
+API key pasting — and bill inference to a registered app's credits (the app
+owner earns the configured markup). The client exposes the whole flow:
+
+```ts
+const cloud = new ElizaCloudClient(); // no key needed to start the login
+
+// 1. Start a login session and open the hosted login (a tab works well).
+const { sessionId, browserUrl } = await cloud.startCliLogin();
+window.open(browserUrl, "_blank");
+
+// 2. Poll until the user authorizes (handles the deadline/interval/terminal
+//    states for you; throws on expiry/error/timeout).
+const { apiKey, userId } = await cloud.waitForCliLogin(sessionId);
+cloud.setApiKey(apiKey!);
+
+// 3. Show/buy app-credits for your registered app.
+const balance = await cloud.getAppCreditsBalance("app_123");
+const checkout = await cloud.createAppCreditsCheckout({
+  app_id: "app_123",
+  amount: 5,
+  success_url: location.origin,
+  cancel_url: location.origin,
+});
+
+// 4. Run inference billed to the app's credits via the `appId` option
+//    (sends the `X-App-Id` header). Omit `appId` to bill the caller's own credits.
+const reply = await cloud.createChatCompletion(
+  { model: "anthropic/claude-sonnet-4.5", messages: [{ role: "user", content: "hi" }] },
+  { appId: "app_123" },
+);
+```
+
+`waitForCliLogin(sessionId, { timeoutMs?, intervalMs?, signal? })` and the
+`{ appId }` option on `createChatCompletion` / `createResponse` /
+`createEmbeddings` / `generateImage` exist so browser apps don't have to
+hand-roll the polling loop or a raw `fetch` to send `X-App-Id`.
+
+> Browser note: `startCliLogin` / `pollCliLogin` are CORS-friendly (token auth,
+> no cookies). `pairWithToken` is server/agent-only — it sets an `Origin` header
+> that browsers forbid `fetch` from overriding.
+
 `cloud.routes` is generated from the public Cloud API route tree under
 `apps/api`, including both Next-style exported HTTP handlers and Hono
 `app.get` / `app.post` / `app.all` route modules. It intentionally excludes

--- a/packages/cloud-sdk/src/client.test.ts
+++ b/packages/cloud-sdk/src/client.test.ts
@@ -262,3 +262,79 @@ describe("ElizaCloudClient CLI login", () => {
     );
   });
 });
+
+describe("ElizaCloudClient web sign-in + app-credits affordances", () => {
+  it("sends X-App-Id when an appId is passed to createChatCompletion", async () => {
+    const { client, requests } = createClientRecorder({
+      choices: [{ message: { role: "assistant", content: "hi" } }],
+    });
+
+    await client.createChatCompletion(
+      {
+        model: "anthropic/claude-sonnet-4.5",
+        messages: [{ role: "user", content: "hi" }],
+      },
+      { appId: "app-123" },
+    );
+
+    expect(requests[0].url).toContain("/api/v1/chat/completions");
+    expect(requests[0].headers["x-app-id"]).toBe("app-123");
+  });
+
+  it("omits X-App-Id when no appId is given", async () => {
+    const { client, requests } = createClientRecorder({ choices: [] });
+    await client.createChatCompletion({
+      model: "anthropic/claude-sonnet-4.5",
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(requests[0].headers["x-app-id"]).toBeUndefined();
+  });
+
+  it("waitForCliLogin polls until authenticated and returns the key", async () => {
+    const statuses = ["pending", "pending", "authenticated"];
+    let call = 0;
+    const fetchImpl = (async (_input, _init = {}) => {
+      const status = statuses[Math.min(call++, statuses.length - 1)];
+      const body =
+        status === "authenticated"
+          ? { status, apiKey: "eliza_new_key", userId: "user-9" }
+          : { status };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+
+    const client = new ElizaCloudClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl,
+    });
+    const result = await client.waitForCliLogin("sess-1", {
+      intervalMs: 1,
+      timeoutMs: 5_000,
+    });
+
+    expect(result.status).toBe("authenticated");
+    expect(result.apiKey).toBe("eliza_new_key");
+    expect(result.userId).toBe("user-9");
+    expect(call).toBeGreaterThanOrEqual(3);
+  });
+
+  it("waitForCliLogin throws on an expired session", async () => {
+    const fetchImpl = (async (_input, _init = {}) =>
+      new Response(
+        JSON.stringify({ status: "expired", error: "session expired" }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      )) as typeof fetch;
+    const client = new ElizaCloudClient({
+      baseUrl: "https://cloud.test",
+      fetchImpl,
+    });
+    await expect(
+      client.waitForCliLogin("sess-2", { intervalMs: 1 }),
+    ).rejects.toThrow(/expired/i);
+  });
+});

--- a/packages/cloud-sdk/src/client.ts
+++ b/packages/cloud-sdk/src/client.ts
@@ -115,6 +115,23 @@ function encodePathParam(value: string | number): string {
   return encodeURIComponent(String(value));
 }
 
+/** Per-call options for the inference methods (chat/responses/embeddings/image). */
+export interface InferenceCallOptions {
+  /**
+   * Bill this request to a registered Eliza Cloud app's credits by sending the
+   * `X-App-Id` header. The app owner earns the configured markup. Omit to bill
+   * the caller's own org/personal credits.
+   */
+  appId?: string;
+}
+
+/** Build the request options that carry the `X-App-Id` header, if an app id is set. */
+function appIdRequestOptions(appId?: string): {
+  headers?: Record<string, string>;
+} {
+  return appId ? { headers: { "X-App-Id": appId } } : {};
+}
+
 function withPathParams(
   path: string,
   params?: Record<string, string | number>,
@@ -249,6 +266,49 @@ export class ElizaCloudClient {
     );
   }
 
+  /**
+   * Poll a CLI/web login session until it resolves. Returns the authenticated
+   * response (with `apiKey`/`userId`) as soon as the user authorizes, or throws
+   * on expiry/error/timeout. Saves every web integration from re-implementing
+   * the deadline + interval + terminal-status loop around {@link pollCliLogin}.
+   *
+   * Typical web flow:
+   * ```ts
+   * const { sessionId, browserUrl } = await cloud.startCliLogin();
+   * window.open(browserUrl, "_blank");
+   * const { apiKey } = await cloud.waitForCliLogin(sessionId);
+   * cloud.setApiKey(apiKey!);
+   * ```
+   */
+  async waitForCliLogin(
+    sessionId: string,
+    options: {
+      timeoutMs?: number;
+      intervalMs?: number;
+      signal?: AbortSignal;
+    } = {},
+  ): Promise<CliLoginPollResponse> {
+    const timeoutMs = options.timeoutMs ?? 300_000;
+    const intervalMs = options.intervalMs ?? 2_000;
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      if (options.signal?.aborted) {
+        throw new Error("Eliza Cloud sign-in was cancelled");
+      }
+      const result = await this.pollCliLogin(sessionId);
+      if (result.status === "authenticated") {
+        return result;
+      }
+      if (result.status === "expired" || result.status === "error") {
+        throw new Error(result.error ?? `Eliza Cloud sign-in ${result.status}`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+
+    throw new Error("Timed out waiting for Eliza Cloud sign-in");
+  }
+
   pairWithToken(token: string, origin: string): Promise<AuthPairResponse> {
     return this.request<AuthPairResponse>("POST", "/api/auth/pair", {
       json: { token },
@@ -263,22 +323,46 @@ export class ElizaCloudClient {
 
   createResponse(
     request: ResponsesCreateRequest,
+    options: InferenceCallOptions = {},
   ): Promise<ResponsesCreateResponse> {
-    return this.v1.post<ResponsesCreateResponse>("/responses", request);
+    return this.v1.post<ResponsesCreateResponse>(
+      "/responses",
+      request,
+      appIdRequestOptions(options.appId),
+    );
   }
 
   createChatCompletion(
     request: ChatCompletionRequest,
+    options: InferenceCallOptions = {},
   ): Promise<ChatCompletionResponse> {
-    return this.v1.post<ChatCompletionResponse>("/chat/completions", request);
+    return this.v1.post<ChatCompletionResponse>(
+      "/chat/completions",
+      request,
+      appIdRequestOptions(options.appId),
+    );
   }
 
-  createEmbeddings(request: EmbeddingsRequest): Promise<EmbeddingsResponse> {
-    return this.v1.post<EmbeddingsResponse>("/embeddings", request);
+  createEmbeddings(
+    request: EmbeddingsRequest,
+    options: InferenceCallOptions = {},
+  ): Promise<EmbeddingsResponse> {
+    return this.v1.post<EmbeddingsResponse>(
+      "/embeddings",
+      request,
+      appIdRequestOptions(options.appId),
+    );
   }
 
-  generateImage(request: GenerateImageRequest): Promise<GenerateImageResponse> {
-    return this.v1.post<GenerateImageResponse>("/generate-image", request);
+  generateImage(
+    request: GenerateImageRequest,
+    options: InferenceCallOptions = {},
+  ): Promise<GenerateImageResponse> {
+    return this.v1.post<GenerateImageResponse>(
+      "/generate-image",
+      request,
+      appIdRequestOptions(options.appId),
+    );
   }
 
   getCreditsBalance(


### PR DESCRIPTION
## Why
Third-party web apps signing in with Eliza Cloud + monetizing via app-credits currently have to **hand-roll** two things the SDK should provide: the cli-login polling loop, and a raw `fetch` to send the `X-App-Id` header (the typed inference methods take no options). (Surfaced building a real app on the SDK.)

## What
- **`waitForCliLogin(sessionId, { timeoutMs, intervalMs, signal })`** — polls `pollCliLogin` to a terminal state; resolves with `apiKey`/`userId` on `authenticated`, throws on `expired`/`error`/timeout. Mirrors the existing `pollJob` helper.
- **`{ appId }` option** on `createChatCompletion` / `createResponse` / `createEmbeddings` / `generateImage` — forwards the `X-App-Id` header (via the existing `v1.post` options) so inference bills the app's credits and the owner earns the markup. Omit it to bill the caller's own credits — fully backward compatible.
- **README**: a "Sign in with Eliza Cloud (web app) + app-credits" section documenting the end-to-end flow, plus a note that `pairWithToken` is server/agent-only (browsers forbid overriding `Origin`).

## Tests
Unit tests (mock fetch) cover the `X-App-Id` header present/absent and `waitForCliLogin` polling to `authenticated` / throwing on `expired`. `bun run --cwd packages/cloud-sdk typecheck` + `lint` + `test` all green.

No breaking changes — all new params are optional.