### PR TITLE
fix(cloud-shared): allow Idempotency-Key + X-Affiliate-Code in CORS

### DIFF
--- a/packages/cloud-shared/src/lib/cors-constants.ts
+++ b/packages/cloud-shared/src/lib/cors-constants.ts
@@ -31,6 +31,11 @@ export const CORS_ALLOW_HEADER_NAMES = [
   "X-PAYMENT-RESPONSE",
   "X-PAYMENT-STATUS",
   "X-Steward-Tenant",
+  // Read by /api/v1/chat/completions for safe retries (idempotency-key) and
+  // affiliate attribution (X-Affiliate-Code); must be in the allow-list or the
+  // browser CORS preflight rejects requests that send them.
+  "Idempotency-Key",
+  "X-Affiliate-Code",
 ] as const;
 
 export const CORS_ALLOW_HEADERS = CORS_ALLOW_HEADER_NAMES.join(", ");


### PR DESCRIPTION
`/api/v1/chat/completions` reads `idempotency-key` (safe retries) and `X-Affiliate-Code` (affiliate attribution), but neither is in `CORS_ALLOW_HEADER_NAMES`. Hono's `cors()` reflects only that fixed allow-list, so a browser preflight sending either header is rejected — silently dropping idempotent retries and affiliate credit for browser apps. Adds both.