### PR TITLE
docs(skills,examples): correct Eliza Cloud monetization docs

### DIFF
--- a/packages/examples/cloud/edad/README.md
+++ b/packages/examples/cloud/edad/README.md
@@ -1,6 +1,6 @@
-# eDad Chat — the dad you never had (chat-in-place variant)
+# eDad Chat — the dad you never had
 
-A different pattern from `apps/edad/`: instead of creating a character on Eliza Cloud and redirecting users to `cloud/chat/<characterId>`, this variant **keeps the chat UI on the app's own domain** and proxies `/v1/messages` calls to Eliza Cloud with the app + affiliate code attached as headers.
+This example **keeps the chat UI on the app's own domain** and proxies `/api/v1/messages` calls to Eliza Cloud with the app + affiliate code attached as headers (`x-app-id`, `x-affiliate-code`).
 
 Shipped live at **https://eliza.nubs.site/apps/edad/** by RemilioNubilio.
 
@@ -14,14 +14,14 @@ Shipped live at **https://eliza.nubs.site/apps/edad/** by RemilioNubilio.
 ## How it works
 
 ```
-browser                                app backend                       eliza cloud
-┌──────────────────┐                  ┌──────────────────┐              ┌───────────────────┐
-│ index.html       │  POST /api/msgs  │ proxy.ts         │  /v1/messages │ debits user's    │
-│ + chat UI JS     │─────────────────▶│ adds x-app-id    │──────────────▶│ org balance      │
-│                  │                  │ + x-affiliate-   │              │ adds markup → me │
-│ Steward JWT      │                  │   code header    │              │ creator earnings │
-│ (OAuth required) │                  │ + Authorization  │              │ + affiliate share│
-└──────────────────┘                  └──────────────────┘              └───────────────────┘
+browser                                  app backend                         eliza cloud
+┌──────────────────┐                    ┌──────────────────┐                ┌───────────────────┐
+│ index.html       │ POST /api/messages │ server.ts        │ /api/v1/messages│ debits user's    │
+│ + chat UI JS     │───────────────────▶│ adds x-app-id    │───────────────▶│ org balance      │
+│                  │                    │ + x-affiliate-   │                │ adds markup → me │
+│ Steward JWT      │                    │   code header    │                │ creator earnings │
+│ (OAuth required) │                    │ + Authorization  │                │ + affiliate share│
+└──────────────────┘                    └──────────────────┘                └───────────────────┘
 ```
 
 ## Files
@@ -31,8 +31,7 @@ browser                                app backend                       eliza c
 | `public/index.html` | landing + chat UI + OAuth sign-in + message loop |
 | `public/style.css` | dad-energy dark theme, SVG silhouette, responsive |
 | `public/meta.json` | app index metadata |
-| `api/proxy.ts` | Next.js-style catch-all route handler — used when edad-chat is mounted under a host Next.js app at `/api/*` |
-| `server.ts` | standalone Bun server with the same wire behavior as `api/proxy.ts` — used when edad-chat runs as its own container |
+| `server.ts` | standalone Bun server: serves `public/`, exposes `GET /api/config`, `POST /api/messages` (forwards to `/api/v1/messages` via @elizaos/cloud-sdk with `x-app-id`/`x-affiliate-code`), and `/health` |
 | `Dockerfile` | bun:1.2-alpine image, exposes :3000, includes `/health` for ECS health checks |
 
 ## Env required
@@ -49,18 +48,26 @@ There is **no operator-paid fallback**. The proxy rejects requests without a Ste
 - One auth path is simpler to reason about than two; eliminates the awkward "chatting on the house" UI state.
 - Free-tier promo is better expressed as a welcome-credit grant on the user's org (cloud already does this — new orgs get $5 on first sync).
 
-## Architectural trade-offs vs `apps/edad/` (character creator variant)
+## Design note: chat-in-place vs a signup-funnel pattern
 
-| concern | `edad/` (signup funnel) | `edad-chat/` (this variant) |
-|---|---|---|
-| where chat happens | Eliza Cloud domain (`/chat/<charId>`) | miniapp's own domain |
-| character per user | yes (registered via `/api/affiliate/create-character`) | no — system prompt is per-request |
-| cold-start friction | low (anon session + 5 free messages via affiliate API) | medium (OAuth sign-in required) |
-| monetization lever | affiliate API `affiliateId` baked into character creation | `X-Affiliate-Code` header on every `/v1/messages` + creator markup % on the app |
-| works for existing users | yes (redirects them into cloud chat) | yes (they chat right there with their credits) |
-| brand continuity | breaks (user leaves miniapp domain) | preserved |
+This example is a **chat-in-place** app: the chat UI stays on the app's own
+domain and the backend proxies straight to Eliza Cloud. An alternative
+**signup-funnel** pattern would instead register a per-user character on Eliza
+Cloud and redirect users into cloud-hosted chat. The trade-offs of the
+chat-in-place approach used here:
 
-Neither is strictly better — they serve different distribution models. `edad/` wins for signup-funnel miniapps; `edad-chat/` wins for embedded chat on a branded domain.
+| concern | chat-in-place (this example) |
+|---|---|
+| where chat happens | the app's own domain |
+| per-user character | no — the system prompt is sent per request |
+| cold-start friction | medium (OAuth sign-in required up front) |
+| monetization lever | `X-Affiliate-Code` header on every `/api/v1/messages` + creator markup % on the app |
+| existing users | chat right there with their own org credits |
+| brand continuity | preserved (users never leave the app's domain) |
+
+A signup-funnel pattern trades brand continuity for lower cold-start friction
+(anonymous sessions, free intro messages); chat-in-place keeps users on a
+branded domain and bills their own org credits from the first message.
 
 ## Deploy checklist
 
@@ -70,7 +77,7 @@ Neither is strictly better — they serve different distribution models. `edad/`
 2. (Optional) bump `inference_markup_percentage` on the app row to a value > 0 so you earn the markup share on every chat
 3. Go to https://www.elizacloud.ai/dashboard/affiliates → create affiliate code, set affiliate markup %
 4. Set `ELIZA_APP_ID` and `ELIZA_AFFILIATE_CODE` env vars on the host
-5. Serve `public/` as static assets; wire `api/proxy.ts` as a server route at `/api/*`
+5. Run the bundled Bun server (`bun run server.ts`); it serves `public/` and the `/api/*` routes itself (no separate route handler to mount)
 6. Users hit your site → sign in with Eliza Cloud → chat → app creator earns markup; affiliate earns affiliate share; user spends their own org credits
 
 ### Option B — standalone container on Eliza Cloud
@@ -113,4 +120,4 @@ The container listens on `:3000`, exposes `/health` for the ECS health check, an
 
 ## License / attribution
 
-Built by [RemilioNubilio](https://github.com/RemilioNubilio). Inspired by Shaw's original eDad spec in `apps/edad/`.
+Built by [RemilioNubilio](https://github.com/RemilioNubilio).

--- a/packages/skills/skills/build-monetized-app/SKILL.md
+++ b/packages/skills/skills/build-monetized-app/SKILL.md
@@ -9,9 +9,9 @@ Use this skill when you need to build an app that takes a markup on every chat o
 
 Read `references/sdk-flow.md` for the 6-step build flow with a self-contained code example. External references (all public):
 
-- **Working chat-app**: [`elizaOS/cloud-mini-apps/apps/edad-chat`](https://github.com/elizaOS/cloud-mini-apps/tree/main/apps/edad-chat) — copyable end-to-end implementation. Read its `server.ts` and `api/proxy.ts` for the canonical chat-forwarder shape using `@elizaos/cloud-sdk`.
-- **SDK reference**: [`@elizaos/cloud-sdk` README](https://github.com/elizaOS/cloud/tree/develop/packages/sdk) — typed methods + helpers + auth.
-- **Human-readable recipe**: [`docs/building-a-monetized-app.md`](https://github.com/elizaOS/cloud/blob/develop/docs/building-a-monetized-app.md) — same loop, narrative form, with the schema fields explained.
+- **Working chat-app**: [`packages/examples/cloud/edad`](https://github.com/elizaos/eliza/tree/develop/packages/examples/cloud/edad) — copyable end-to-end implementation. Read its `server.ts` for the canonical chat-forwarder shape using `@elizaos/cloud-sdk`.
+- **SDK reference**: [`@elizaos/cloud-sdk` README](https://github.com/elizaos/eliza/blob/develop/packages/cloud-sdk/README.md) — typed methods + helpers + auth.
+- **Human-readable recipe**: [`packages/docs/cloud/monetized-apps.mdx`](https://github.com/elizaos/eliza/blob/develop/packages/docs/cloud/monetized-apps.mdx) — same loop, narrative form, with the schema fields explained.
 
 ## Skill Pairing
 
@@ -24,7 +24,7 @@ request both skills for Cloud app builds.
 
 ## The survival-economics loop
 
-An Eliza-style agent running in an Eliza Cloud container costs ~$0.67/day at the default tier (256 MB CPU + 512 MB RAM). When the org's credit balance and the owner's redeemable earnings both hit zero, the container is stopped after a 48-hour grace window. The container-billing cron pulls earnings before credits, so an app that earns more than its hosting costs keeps the agent alive indefinitely. See `references/survival-economics.md` for the exact accounting (`redeemable_earnings_ledger`, `credit_transactions`, the cron at `app/api/cron/container-billing/route.ts`).
+An Eliza-style agent running in an Eliza Cloud container costs ~$0.67/day at the default tier (256 MB CPU + 512 MB RAM). When the org's credit balance and the owner's redeemable earnings both hit zero, the container is stopped after a 48-hour grace window. The container-billing cron pulls earnings before credits, so an app that earns more than its hosting costs keeps the agent alive indefinitely. See `references/survival-economics.md` for the exact accounting (`redeemable_earnings_ledger`, `credit_transactions`, the cron at `packages/cloud-api/cron/container-billing/route.ts`).
 
 This is why the skill exists: making money is how the agent stays online.
 
@@ -61,8 +61,8 @@ Use the [`eliza-cloud`](../eliza-cloud/SKILL.md) skill and its
 `references/payments-and-promotion.md` details for exact charge flows.
 
 - Use `POST /api/v1/apps/{id}/charges` for reusable Stripe/OxaPay requests.
-  The payer buys app credits; creator earnings flow through the app-credit
-  earnings ledger.
+  The payer checks out via Stripe/OxaPay; this funds the per-app credit pool
+  and credits the app-credit earnings ledger — note this is the stranded per-app pool (issue #8253), not the live inference revenue path. The working inference revenue model is the caller's org-credit balance + `recordCreatorEarnings` (markup added to the org-balance debit), not the per-app pool.
 - Use `POST /api/v1/x402/requests` for direct wallet-native crypto payments.
   Current settlement support includes Base, Ethereum, BSC, and Solana, with the
   hosted default at `https://x402.elizacloud.ai`.
@@ -86,7 +86,7 @@ Full code in `references/sdk-flow.md`. The skill assumes you have:
 Every cloud-SDK call your deployed app makes on behalf of a user MUST carry:
 
 - `Authorization: Bearer <user_jwt>` — the JWT from the app-auth OAuth redirect
-- App identity from the route path, for example `POST /api/v1/apps/<appId>/chat`
+- App identity via the `x-app-id: <appId>` header on `POST /api/v1/messages` (debits the user's org credit balance and records creator earnings; the affiliate header is honored here, unlike the app-scoped chat route)
 - Optional `x-affiliate-code: <your_affiliate_code>` when the owner has configured an affiliate code
 
 This pattern is shared with the [`eliza-cloud`](../eliza-cloud/SKILL.md) skill; see that skill for the auth flow itself. This skill assumes you've already read it.

--- a/packages/skills/skills/build-monetized-app/references/sdk-flow.md
+++ b/packages/skills/skills/build-monetized-app/references/sdk-flow.md
@@ -51,9 +51,9 @@ image must:
 
 - Listen on `$PORT` (cloud sets this at runtime)
 - Expose a `GET /health` endpoint that returns 200 quickly (the cloud's deploy step polls it before flipping the load balancer)
-- For chat-style apps, expose a server route that forwards user-bearing requests upstream to cloud's `/api/v1/apps/<appId>/chat` with the user's bearer token
+- For chat-style apps, expose a server route that forwards user-bearing requests upstream to cloud's `/api/v1/messages` with the user's bearer token and an `x-app-id: <appId>` header (debits the user's org balance and records creator earnings)
 
-The canonical reference for this shape is [`apps/edad-chat/server.ts` and `apps/edad-chat/api/proxy.ts`](https://github.com/elizaOS/cloud-mini-apps/tree/main/apps/edad-chat) in `elizaOS/cloud-mini-apps`. Copy that pattern when your app is a chat shell.
+The canonical reference for this shape is [`packages/examples/cloud/edad/server.ts`](https://github.com/elizaos/eliza/blob/develop/packages/examples/cloud/edad/server.ts). Copy that pattern when your app is a chat shell.
 
 If you want the inline minimal version — a Next.js or Hono handler is equivalent — the shape is:
 
@@ -69,13 +69,14 @@ export async function handleChat(req: Request): Promise<Response> {
 
   const body = await req.json();
 
-  // Forward to the app-scoped chat endpoint with the user's token.
-  // The user's app balance is debited; the app's configured markup credits us.
+  // Forward to /api/v1/messages with the user's token + x-app-id.
+  // The user's ORG credit balance is debited; the app's configured markup
+  // credits the creator via recordCreatorEarnings; x-affiliate-code is honored.
   const appId = process.env.ELIZA_APP_ID!;
-  const upstream = await cloud.routes.postApiV1AppsByIdChatRaw({
-    pathParams: { id: appId },
+  const upstream = await cloud.routes.postApiV1MessagesRaw({
     headers: {
       authorization: userToken.startsWith("Bearer ") ? userToken : `Bearer ${userToken}`,
+      "x-app-id": appId,
       ...(AFFILIATE ? { "x-affiliate-code": AFFILIATE } : {}),
     },
     json: body,
@@ -102,31 +103,28 @@ The frontend can be served by the same container or by any static host pointing 
 ## 3. Deploy the container
 
 ```ts
-const created = await cloud.routes.postApiV1Containers({
-  json: {
-    name: input.name,
-    project_name: input.slug,
-    image: `<registry>/<repo>:<tag>`,
-    port: 3000,
-    desired_count: 1,
-    cpu: 256,
-    memory: 512,
-    health_check_path: "/health",
-    environment_vars: {
-      PORT: "3000",
-      ELIZA_APP_ID: appId,
-      ELIZA_CLOUD_URL: process.env.ELIZA_CLOUD_PUBLIC_URL ?? "https://www.elizacloud.ai",
-      ELIZA_AFFILIATE_CODE: process.env.ELIZA_AFFILIATE_CODE ?? "",
-    },
+const { data: container } = await cloud.createContainer({
+  name: input.name,
+  project_name: input.slug,
+  image: `<registry>/<repo>:<tag>`,
+  port: 3000,
+  desired_count: 1,
+  cpu: 256,
+  memory: 512,
+  health_check_path: "/health",
+  environment_vars: {
+    PORT: "3000",
+    ELIZA_APP_ID: appId,
+    ELIZA_CLOUD_URL: process.env.ELIZA_CLOUD_PUBLIC_URL ?? "https://www.elizacloud.ai",
+    ELIZA_AFFILIATE_CODE: process.env.ELIZA_AFFILIATE_CODE ?? "",
   },
 });
-const container = created.data;
 ```
 
-After `postApiV1Containers` returns, poll `getApiV1ContainersById(container.id)`
+After `createContainer` returns, poll `cloud.getContainer(container.id)`
 until the response has a usable `load_balancer_url` / `publicUrl`, then verify
 `GET <url>/health`. Health-check failures here mean the image's server doesn't
-bind to `$PORT` correctly — pull `cloud.routes.getApiV1ContainersByIdLogs` when
+bind to `$PORT` correctly — pull `cloud.getContainerLogs(container.id, tail?)` when
 the sidecar is available and surface the logs to the human.
 
 ## 4. Set markup

--- a/packages/skills/skills/eliza-cloud/SKILL.md
+++ b/packages/skills/skills/eliza-cloud/SKILL.md
@@ -82,10 +82,10 @@ Some older docs still describe generic per-request or per-token app pricing. In 
 
 Pick the narrowest money surface:
 
-- **App monetization** (`PUT /api/v1/apps/{id}/monetization`) sets ongoing inference markup and app-credit purchase share. It is not a one-off invoice.
+- **App monetization** (`PUT /api/v1/apps/{id}/monetization`) sets ongoing inference markup and app-credit purchase share. The inference markup is added to the cost debited from the caller's ORG credit balance and earned via `recordCreatorEarnings`; the purchase-share applies to the (currently stranded) per-app pool. It is not a one-off invoice.
 - **App charge requests** (`POST /api/v1/apps/{id}/charges`) ask a user to pay an exact USD amount through Stripe or OxaPay. The payer receives app credits; creator earnings flow through the app-credit earnings ledger.
 - **x402 payment requests** (`POST /api/v1/x402/requests`) ask for direct crypto settlement. Use these when the payer already has crypto or the flow is wallet-native. Current settlement support includes Base, Ethereum, BSC, and Solana; defaults point at `https://x402.elizacloud.ai`.
-- **App-credit checkout** (`POST /api/v1/app-credits/checkout`) buys app credits directly. Use app charge requests when the agent needs a durable request, metadata, callbacks, and a reusable payment URL.
+- **App-credit checkout** (`POST /api/v1/app-credits/checkout`) buys into the per-app pre-purchased credit pool (`app_credit_balances`). Note: inference billing was migrated to the org balance, so these purchases are currently stranded (issue #8253) — prefer org-credit checkout for spendable balance. Use app charge requests when the agent needs a durable request, metadata, callbacks, and a reusable payment URL.
 - **Org-credit checkout** (`POST /api/v1/credits/checkout`) tops up the user's organization. It is not creator pricing.
 - **Cloud tunnel provisioning** (`POST /api/v1/apis/tunnels/tailscale/auth-key`) debits org credits once per successful tunnel auth-key mint. It is on-demand infrastructure usage, not SaaS/subscription billing.
 - **Redemptions** (`POST /api/v1/redemptions`) request creator payout in elizaOS tokens on `base`, `bsc`/`bnb`, `ethereum`, or `solana`. Payouts are fixed to the USD quote at request time and then admin reviewed/processed.

--- a/packages/skills/skills/eliza-cloud/references/payments-and-promotion.md
+++ b/packages/skills/skills/eliza-cloud/references/payments-and-promotion.md
@@ -8,7 +8,7 @@ paid Cloud actions.
 
 Eliza Cloud has multiple payment surfaces. Do not collapse them into one.
 
-- **Inference markup** earns on app-scoped chat/inference usage.
+- **Inference markup** earns on app-scoped chat/inference usage. The marked-up cost is debited from the caller's organization credit balance (not a per-app pool), and the markup is credited to the creator via `recordCreatorEarnings`.
 - **Purchase share** earns when users buy app credits for an app.
 - **App charge requests** create reusable Stripe/OxaPay links for exact dollar
   amounts. The payer receives app credits and creator earnings flow through the
@@ -199,7 +199,7 @@ High-level SDK helpers are available on `ElizaCloudClient`:
 Direct credit checkout is useful for account top-ups, not exact creator charge
 logic.
 
-- `POST /api/v1/app-credits/checkout` buys app credits:
+- `POST /api/v1/app-credits/checkout` buys into the per-app pre-purchased credit pool (`app_credit_balances`) — note inference now debits the org balance, so these purchases are currently stranded (issue #8253):
 
   ```json
   { "app_id": "app_uuid", "amount": 25, "success_url": "...", "cancel_url": "..." }


### PR DESCRIPTION
Audited the monetization **skill + docs + example** against the actual code and fixed **23 verified inaccuracies** across 5 files. No code changes.

### `build-monetized-app/SKILL.md`
- 3 dead/stale links repointed in-monorepo: SDK README (`packages/cloud-sdk/README.md`), the recipe (`packages/docs/cloud/monetized-apps.mdx`), and the working example (`packages/examples/cloud/edad`) — the old links pointed at `elizaOS/cloud/packages/sdk`, a nonexistent `docs/building-a-monetized-app.md`, and `cloud-mini-apps/apps/edad-chat`.
- Fix the container-billing cron path (`packages/cloud-api/cron/container-billing/route.ts`).
- Per-call requirement corrected to `POST /api/v1/messages` + `x-app-id` (the app-scoped chat route doesn't read the affiliate header).

### `build-monetized-app/references/sdk-flow.md`
- Use the real SDK client methods — `cloud.createContainer` / `getContainer` / `getContainerLogs` — instead of nonexistent `cloud.routes.postApiV1Containers*`.
- Forward via `postApiV1MessagesRaw` with `x-app-id`.

### `eliza-cloud/SKILL.md` + `references/payments-and-promotion.md`
- Clarify the working revenue path: inference markup is debited from the caller's **org** credit balance and earned via `recordCreatorEarnings`; flag that the per-app credit pool (app-credit checkout) is currently **stranded** (#8253).

### `examples/cloud/edad/README.md`
- Drop references to a nonexistent sibling `apps/edad/` and `api/proxy.ts` (the example is a single `server.ts`); fix the endpoint to `/api/v1/messages` and the data-flow diagram.

Found while building a real third-party app on the SDK. Pairs with #8251 (SDK web-auth helpers), #8252 (CORS headers), and #8253 (the stranded-credits root cause these docs now warn about).