### PR TITLE
fix(cloud-api): sign Steward proxy requests to satisfy HMAC guard

### DIFF
--- a/packages/cloud-api/__tests__/steward-embedded-signing.test.ts
+++ b/packages/cloud-api/__tests__/steward-embedded-signing.test.ts
@@ -1,0 +1,240 @@
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppEnv } from "@/types/cloud-worker-env";
+import { embeddedStewardHandler } from "../src/steward/embedded";
+
+// gitleaks:allow — synthetic test value, no entropy / real-key shape needed.
+const SECRET = "test_only_steward_secret_aaaaaaaaaaaaa";
+const UPSTREAM = "https://steward.example.test";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+function makeApp(envOverrides: Partial<AppEnv["Bindings"]> = {}) {
+  const app = new Hono<AppEnv>();
+  // The handler reads c.env via Hono — wire a stub.
+  app.use(async (c, next) => {
+    c.env = {
+      STEWARD_API_URL: UPSTREAM,
+      STEWARD_REQUEST_SIGNING_SECRET: SECRET,
+      STEWARD_TENANT_ID: "elizacloud-staging",
+      ...envOverrides,
+    } as AppEnv["Bindings"];
+    await next();
+  });
+  app.all("/steward/*", embeddedStewardHandler);
+  app.all("/steward", embeddedStewardHandler);
+  return app;
+}
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+function captureFetch(responseFactory: () => Response): {
+  calls: CapturedRequest[];
+  restore: () => void;
+} {
+  const calls: CapturedRequest[] = [];
+  globalThis.fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    const headers: Record<string, string> = {};
+    const h = new Headers(init?.headers ?? {});
+    h.forEach((value, key) => {
+      headers[key.toLowerCase()] = value;
+    });
+    let bodyText = "";
+    if (init?.body) {
+      if (init.body instanceof ArrayBuffer) {
+        bodyText = new TextDecoder().decode(init.body);
+      } else if (typeof init.body === "string") {
+        bodyText = init.body;
+      }
+    }
+    calls.push({
+      url,
+      method: (init?.method ?? "GET").toUpperCase(),
+      headers,
+      body: bodyText,
+    });
+    return responseFactory();
+  }) as typeof globalThis.fetch;
+  return {
+    calls,
+    restore: () => {
+      globalThis.fetch = ORIGINAL_FETCH;
+    },
+  };
+}
+
+async function hmacSha256Hex(secret: string, message: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(message),
+  );
+  return [...new Uint8Array(sig)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const buf = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest("SHA-256", buf);
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+let captured: ReturnType<typeof captureFetch> | null = null;
+
+beforeEach(() => {
+  captured = captureFetch(
+    () =>
+      new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+  );
+});
+
+afterEach(() => {
+  captured?.restore();
+  vi.restoreAllMocks();
+});
+
+describe("embeddedStewardHandler signing", () => {
+  it("injects X-Steward-Request-Expires-At + X-Steward-Signature on POST", async () => {
+    const FIXED_MS = Date.parse("2026-06-05T15:00:00Z");
+    vi.spyOn(Date, "now").mockReturnValue(FIXED_MS);
+    const app = makeApp();
+    const body = JSON.stringify({ email: "stan@example.com" });
+    await app.request("/steward/auth/email/send", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+
+    expect(captured!.calls).toHaveLength(1);
+    const c = captured!.calls[0];
+    expect(c.url).toBe(`${UPSTREAM}/auth/email/send`);
+    expect(c.method).toBe("POST");
+    expect(c.body).toBe(body);
+    expect(c.headers["x-steward-tenant"]).toBe("elizacloud-staging");
+    expect(c.headers["x-steward-request-expires-at"]).toBeTruthy();
+    expect(Number(c.headers["x-steward-request-expires-at"])).toBe(
+      Math.floor(Date.parse("2026-06-05T15:00:00Z") / 1000) + 60,
+    );
+    expect(c.headers["x-steward-signature"]).toMatch(/^v1=[0-9a-f]{64}$/);
+  });
+
+  it("computed signature verifies against the canonical request", async () => {
+    const FIXED_MS = Date.parse("2026-06-05T15:00:00Z");
+    vi.spyOn(Date, "now").mockReturnValue(FIXED_MS);
+    const app = makeApp();
+    const body = JSON.stringify({ email: "stan@example.com" });
+    await app.request("/steward/auth/email/send", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+    const c = captured!.calls[0]!;
+
+    const bodyHash = await sha256Hex(body);
+    const canonical = [
+      "steward-request-signature-v1",
+      "POST",
+      "/auth/email/send",
+      "elizacloud-staging",
+      await sha256Hex(""),
+      await sha256Hex(""),
+      await sha256Hex(""),
+      await sha256Hex(""),
+      await sha256Hex(""),
+      await sha256Hex(""),
+      await sha256Hex(""),
+      "",
+      c.headers["x-steward-request-expires-at"]!,
+      c.headers["idempotency-key"]!,
+      bodyHash,
+    ].join("\n");
+    const expected = await hmacSha256Hex(SECRET, canonical);
+    expect(c.headers["x-steward-signature"]).toBe(`v1=${expected}`);
+  });
+
+  it("does NOT sign GET requests (Steward skips them on the receive side)", async () => {
+    const app = makeApp();
+    await app.request("/steward/auth/providers");
+    const c = captured!.calls[0]!;
+    expect(c.method).toBe("GET");
+    expect(c.headers["x-steward-signature"]).toBeUndefined();
+    expect(c.headers["x-steward-request-expires-at"]).toBeUndefined();
+  });
+
+  it("skips signing when the secret is not configured (rollback path)", async () => {
+    const app = makeApp({ STEWARD_REQUEST_SIGNING_SECRET: undefined });
+    await app.request("/steward/auth/email/send", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    const c = captured!.calls[0]!;
+    expect(c.headers["x-steward-signature"]).toBeUndefined();
+    expect(c.headers["x-steward-request-expires-at"]).toBeUndefined();
+  });
+
+  it("stamps a fresh Idempotency-Key when the SPA didn't send one", async () => {
+    const app = makeApp();
+    await app.request("/steward/auth/email/send", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    const c = captured!.calls[0]!;
+    // RFC 4122 UUID v4: 8-4-4-4-12 hex, version=4 in slot 14, variant in slot 19.
+    expect(c.headers["idempotency-key"]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("preserves the SPA-supplied Idempotency-Key so retries dedup", async () => {
+    const app = makeApp();
+    const supplied = "11111111-2222-4333-8444-555555555555";
+    await app.request("/steward/auth/email/send", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "idempotency-key": supplied,
+      },
+      body: "{}",
+    });
+    const c = captured!.calls[0]!;
+    expect(c.headers["idempotency-key"]).toBe(supplied);
+  });
+
+  it("returns the public tenant config short-circuit without hitting upstream", async () => {
+    const app = makeApp();
+    const res = await app.request("/steward/tenants/config");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { ok: boolean; data: unknown };
+    expect(json.ok).toBe(true);
+    expect(captured!.calls).toHaveLength(0);
+  });
+});

--- a/packages/cloud-api/src/steward/embedded.ts
+++ b/packages/cloud-api/src/steward/embedded.ts
@@ -1,6 +1,93 @@
 import type { MiddlewareHandler } from "hono";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
+const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+const REQUEST_TTL_SECONDS = 60;
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i += 1) {
+    out += bytes[i].toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+async function sha256Hex(input: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", input);
+  return bytesToHex(new Uint8Array(digest));
+}
+
+async function sha256TextHex(value: string): Promise<string> {
+  return sha256Hex(new TextEncoder().encode(value).buffer);
+}
+
+async function hmacSha256Hex(secret: string, message: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(message),
+  );
+  return bytesToHex(new Uint8Array(signature));
+}
+
+/**
+ * Steward's request-signature middleware HMACs this exact ordered list with a
+ * shared secret and compares against `X-Steward-Signature: v1=<hex>`. Keep
+ * this in lockstep with `canonicalRequest` in
+ * Steward-Fi/steward:packages/api/src/middleware/authorization-signature.ts —
+ * the upstream is authoritative; if it grows a new header or reorders, this
+ * proxy starts shipping 401s and Magic Link / sensitive auth flows break.
+ */
+async function buildStewardCanonicalRequest(
+  method: string,
+  pathAndSearch: string,
+  headers: Headers,
+  body: ArrayBuffer,
+): Promise<string> {
+  const bodyHash = await sha256Hex(body);
+  const authHash = await sha256TextHex(headers.get("authorization") ?? "");
+  const apiKeyHash = await sha256TextHex(headers.get("x-steward-key") ?? "");
+  const platformKeyHash = await sha256TextHex(
+    headers.get("x-steward-platform-key") ?? "",
+  );
+  const signerIdHash = await sha256TextHex(
+    headers.get("x-steward-signer-id") ?? "",
+  );
+  const signerSecretHash = await sha256TextHex(
+    headers.get("x-steward-signer-secret") ?? "",
+  );
+  const quorumIdHash = await sha256TextHex(
+    headers.get("x-steward-key-quorum-id") ?? "",
+  );
+  const quorumCredentialsHash = await sha256TextHex(
+    headers.get("x-steward-key-quorum-credentials") ?? "",
+  );
+  return [
+    "steward-request-signature-v1",
+    method.toUpperCase(),
+    pathAndSearch,
+    headers.get("x-steward-tenant") ?? "",
+    authHash,
+    apiKeyHash,
+    platformKeyHash,
+    signerIdHash,
+    signerSecretHash,
+    quorumIdHash,
+    quorumCredentialsHash,
+    headers.get("x-steward-request-timestamp") ?? "",
+    headers.get("x-steward-request-expires-at") ?? "",
+    headers.get("idempotency-key") ?? "",
+    bodyHash,
+  ].join("\n");
+}
+
 function stripStewardPrefix(pathname: string): string {
   if (pathname === "/steward") return "/";
   if (pathname.startsWith("/steward/"))
@@ -150,9 +237,40 @@ export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
 
   const upstreamUrl = new URL(`${upstream}${stripStewardPrefix(url.pathname)}`);
   upstreamUrl.search = url.search;
-  const request = new Request(upstreamUrl.toString(), c.req.raw);
-  request.headers.set("x-forwarded-host", url.host);
-  request.headers.set("x-forwarded-proto", url.protocol.replace(":", ""));
+
+  // The Steward backend gates mutating sensitive paths (/auth, /agents,
+  // /vault, …) on BOTH a freshness header (X-Steward-Request-Expires-At) and
+  // an HMAC-SHA256 of a canonical request string keyed by a shared secret
+  // (`X-Steward-Signature: v1=<hex>`). The SDK does not send these on
+  // browser-driven flows, so the Worker proxy signs them here on behalf of
+  // the SPA. Without this, /auth/email/send (Magic Link) returns
+  // `Request expiry header required` — see Steward
+  // packages/api/src/middleware/{request-expiry,authorization-signature}.ts.
+  const method = c.req.method.toUpperCase();
+  const isMutating = MUTATING_METHODS.has(method);
+  const rawSecret = c.env.STEWARD_REQUEST_SIGNING_SECRET;
+  const signingSecret =
+    typeof rawSecret === "string" && rawSecret.length > 0 ? rawSecret : null;
+
+  let bodyBytes: ArrayBuffer | null = null;
+  if (isMutating) {
+    bodyBytes = await c.req.raw.clone().arrayBuffer();
+  }
+
+  const init: RequestInit = {
+    method,
+    headers: new Headers(c.req.raw.headers),
+    body: bodyBytes,
+    // Don't forward cf-specific properties that confuse fetch on cross-zone calls.
+    redirect: "manual",
+  };
+  const headers = init.headers as Headers;
+  headers.set("x-forwarded-host", url.host);
+  headers.set("x-forwarded-proto", url.protocol.replace(":", ""));
+  // Strip the host header that Workers carries from the inbound request — the
+  // upstream fetch sets its own.
+  headers.delete("host");
+
   // Pin the tenant per-env. Steward's email/passkey routes resolve tenant
   // from `X-Steward-Tenant || body.tenantId || STEWARD_DEFAULT_TENANT_ID`
   // (auth.ts:2171,2200,2246), so forcing the header keeps those flows scoped
@@ -164,10 +282,31 @@ export const embeddedStewardHandler: MiddlewareHandler<AppEnv> = async (c) => {
   // wrangler.toml `[env.preview.vars]`.
   const pinnedTenantId = c.env.STEWARD_TENANT_ID;
   if (typeof pinnedTenantId === "string" && pinnedTenantId.trim().length > 0) {
-    request.headers.set("x-steward-tenant", pinnedTenantId.trim());
+    headers.set("x-steward-tenant", pinnedTenantId.trim());
   }
 
-  const response = await fetch(request);
+  if (isMutating && signingSecret && bodyBytes) {
+    const expiresAt = Math.floor(Date.now() / 1000) + REQUEST_TTL_SECONDS;
+    headers.set("x-steward-request-expires-at", String(expiresAt));
+    // Steward's idempotency middleware requires Idempotency-Key on every
+    // signed mutating request. Use the SPA-supplied value when present so
+    // retries dedup, otherwise stamp a fresh UUID v4 just to satisfy the
+    // gate — without it Steward rejects with "Signed requests require an
+    // Idempotency-Key header" (packages/api/src/middleware/idempotency.ts).
+    if (!headers.get("idempotency-key")) {
+      headers.set("idempotency-key", crypto.randomUUID());
+    }
+    const canonical = await buildStewardCanonicalRequest(
+      method,
+      `${upstreamUrl.pathname}${upstreamUrl.search}`,
+      headers,
+      bodyBytes,
+    );
+    const signature = await hmacSha256Hex(signingSecret, canonical);
+    headers.set("x-steward-signature", `v1=${signature}`);
+  }
+
+  const response = await fetch(upstreamUrl.toString(), init);
   if (c.req.method === "GET" && isAuthProvidersPath(url.pathname)) {
     return patchProvidersResponse(response, c.env);
   }


### PR DESCRIPTION
## Why

Steward backend now ships two middlewares on mutating sensitive paths (\`/auth\`, \`/agents\`, \`/vault\`, \`/trade\`, etc — see [Steward sensitive-paths.ts](https://github.com/Steward-Fi/steward/blob/main/packages/api/src/middleware/sensitive-paths.ts)):

1. \`request-expiry.ts\` requires \`X-Steward-Request-Expires-At\`
2. \`authorization-signature.ts\` requires \`X-Steward-Signature: v1=<hmac-sha256-hex>\` over a canonical request string keyed by a shared secret

The cloud-api embedded Steward proxy at \`packages/cloud-api/src/steward/embedded.ts\` only stamped \`X-Steward-Tenant\` and forwarded verbatim. Any browser-driven mutating call (Magic Link \`/auth/email/send\`, passkey register, etc.) now returns \`HTTP 400 "Request expiry header required"\`.

The bug was masked when users had a live Steward session cookie — the breakage only surfaces on first sign-in or token refresh. Stan hit it today on staging.elizacloud.ai trying to fresh-login (also reproducible on prod via \`curl https://api.elizacloud.ai/steward/auth/email/send\`).

## What

When \`STEWARD_REQUEST_SIGNING_SECRET\` is configured on the Worker AND the method is mutating:

- Stamp \`X-Steward-Request-Expires-At\` (\`now + 60s\` in Unix seconds)
- Build the canonical request string (method, pathname+search, tenant + all SHA-256-hashed sensitive headers, timestamps, idempotency key, body hash) exactly matching [Steward's \`canonicalRequest\`](https://github.com/Steward-Fi/steward/blob/main/packages/api/src/middleware/authorization-signature.ts)
- HMAC-SHA256 with the secret
- Set \`X-Steward-Signature: v1=<hex>\`

Secret-absent path stays untouched → instant rollback by deleting the wrangler secret.

## Tests

5 sociable unit tests, all passing via \`bun test\`:
- Header injection on POST
- Canonical-string parity (re-implements the HMAC client-side and asserts byte-equal)
- GET-skip
- Secret-absent skip (rollback path)
- Public tenant-config short-circuit unchanged

## Deploy steps (operator)

\`\`\`bash
SECRET=\$(openssl rand -hex 32)
echo \"\$SECRET\" | bunx wrangler secret put STEWARD_REQUEST_SIGNING_SECRET --env staging --name eliza-cloud-api-staging
echo \"\$SECRET\" | bunx wrangler secret put STEWARD_REQUEST_SIGNING_SECRET --env production --name eliza-cloud-api-prod
\`\`\`

On Railway, set \`STEWARD_REQUEST_SIGNING_SECRETS=\$SECRET\` on both Steward instances (staging + prod), then restart.

## Test plan

- [ ] CI green
- [ ] Operator sets the secret on both Workers + both Steward instances
- [ ] \`curl -X POST https://staging.elizacloud.ai/steward/auth/email/send -H 'content-type: application/json' --data '{\"email\":\"test@example.com\"}'\` returns 200 (or proper Steward response, not the 400 expiry error)
- [ ] Magic Link sign-in flow works on \`staging.elizacloud.ai/login\`
- [ ] Same on prod \`www.elizacloud.ai/login\`

## Rollback

\`bunx wrangler secret delete STEWARD_REQUEST_SIGNING_SECRET --env <env>\` — the proxy falls back to the unsigned path. Steward backend would then need \`STEWARD_ALLOW_STALE_SENSITIVE_REQUESTS=true\` to accept the unsigned requests, OR a backend rollback to the version before the guard.