### PR TITLE
fix(cloud): send PKCE on Steward OAuth + sign the nonce-exchange call

### DIFF
--- a/packages/cloud-api/__tests__/steward-sign.test.ts
+++ b/packages/cloud-api/__tests__/steward-sign.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildStewardCanonicalRequest,
+  signStewardMutatingRequest,
+} from "../src/steward/sign";
+
+// gitleaks:allow — synthetic test value, no entropy / real-key shape needed.
+const SECRET = "test_only_steward_secret_aaaaaaaaaaaaa";
+
+// Independent re-implementation of the HMAC the way Steward verifies it, so the
+// test proves the signature actually validates rather than just matching shape.
+async function hmacSha256Hex(secret: string, message: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(message),
+  );
+  return [...new Uint8Array(sig)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("steward sign.ts", () => {
+  it("buildStewardCanonicalRequest emits the 15-field v1 canonical in order", async () => {
+    const headers = new Headers({
+      "x-steward-tenant": "elizacloud",
+      "idempotency-key": "idem-1",
+      "x-steward-request-expires-at": "1780000000",
+    });
+    const body = new TextEncoder().encode(JSON.stringify({ code: "n" }));
+    const canonical = await buildStewardCanonicalRequest(
+      "post",
+      "/auth/oauth/exchange",
+      headers,
+      body,
+    );
+    const lines = canonical.split("\n");
+    expect(lines).toHaveLength(15);
+    expect(lines[0]).toBe("steward-request-signature-v1");
+    expect(lines[1]).toBe("POST"); // method upcased
+    expect(lines[2]).toBe("/auth/oauth/exchange");
+    expect(lines[3]).toBe("elizacloud"); // x-steward-tenant verbatim
+    expect(lines[12]).toBe("1780000000"); // expires-at verbatim
+    expect(lines[13]).toBe("idem-1"); // idempotency-key verbatim
+    expect(lines[14]).toMatch(/^[0-9a-f]{64}$/); // body sha256
+  });
+
+  it("signStewardMutatingRequest stamps freshness + idempotency + a verifiable v1 signature", async () => {
+    const fixedMs = Date.parse("2026-06-05T15:00:00Z");
+    vi.spyOn(Date, "now").mockReturnValue(fixedMs);
+    const headers = new Headers({
+      "content-type": "application/json",
+      "x-steward-tenant": "elizacloud",
+    });
+    const body = new TextEncoder().encode(
+      JSON.stringify({ code: "nonce", code_verifier: "v" }),
+    );
+    await signStewardMutatingRequest(
+      SECRET,
+      "POST",
+      "/auth/oauth/exchange",
+      headers,
+      body,
+    );
+
+    // 60s freshness window, inside Steward's ±5min tolerance.
+    expect(headers.get("x-steward-request-expires-at")).toBe(
+      String(Math.floor(fixedMs / 1000) + 60),
+    );
+    expect(headers.get("idempotency-key")).toMatch(/^[0-9a-f-]{36}$/);
+    const sig = headers.get("x-steward-signature");
+    expect(sig).toMatch(/^v1=[0-9a-f]{64}$/);
+
+    // Recompute over the exact signed headers/body — Steward's check must pass.
+    const canonical = await buildStewardCanonicalRequest(
+      "POST",
+      "/auth/oauth/exchange",
+      headers,
+      body,
+    );
+    expect(sig).toBe(`v1=${await hmacSha256Hex(SECRET, canonical)}`);
+  });
+
+  it("preserves a caller-supplied Idempotency-Key instead of overwriting it", async () => {
+    const headers = new Headers({ "idempotency-key": "caller-key-123" });
+    const body = new TextEncoder().encode("{}");
+    await signStewardMutatingRequest(SECRET, "POST", "/auth/x", headers, body);
+    expect(headers.get("idempotency-key")).toBe("caller-key-123");
+  });
+
+  it("binds the signature to the body — a tampered body no longer verifies", async () => {
+    const headers = new Headers({ "x-steward-tenant": "elizacloud" });
+    const body = new TextEncoder().encode(JSON.stringify({ code: "real" }));
+    await signStewardMutatingRequest(SECRET, "POST", "/auth/x", headers, body);
+    const tampered = new TextEncoder().encode(JSON.stringify({ code: "evil" }));
+    const canonicalForTampered = await buildStewardCanonicalRequest(
+      "POST",
+      "/auth/x",
+      headers,
+      tampered,
+    );
+    expect(headers.get("x-steward-signature")).not.toBe(
+      `v1=${await hmacSha256Hex(SECRET, canonicalForTampered)}`,
+    );
+  });
+});

--- a/packages/cloud-api/auth/steward-nonce-exchange/route.ts
+++ b/packages/cloud-api/auth/steward-nonce-exchange/route.ts
@@ -29,6 +29,7 @@ import {
 } from "@elizaos/shared/steward-session-client";
 import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
+import { signStewardMutatingRequest } from "@/api-app/steward/sign";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
 import {
   type StewardVerifyEnv,
@@ -183,31 +184,58 @@ interface StewardExchangeErr {
  */
 async function callStewardExchange(
   baseUrl: string,
-  body: { code: string; redirect_uri: string; tenant_id: string | null },
+  body: {
+    code: string;
+    redirect_uri: string;
+    tenant_id: string | null;
+    code_verifier?: string;
+  },
   pinnedTenantId?: string,
+  signingSecret?: string | null,
 ): Promise<
   | { kind: "ok"; data: StewardExchangeOk }
   | { kind: "error"; status: number; data: StewardExchangeErr }
   | { kind: "transport"; message: string }
 > {
-  const headers: Record<string, string> = {
+  const exchangeUrl = new URL(`${baseUrl}/auth/oauth/exchange`);
+  const headers = new Headers({
     "Content-Type": "application/json",
     Accept: "application/json",
-  };
+  });
   // Pin the tenant per-env: this route bypasses the /steward/* proxy in
   // bootstrap-app.ts. Steward's `/auth/oauth/exchange` reads tenant from
   // the body (auth.ts:2557-2563), but if a caller sends `tenant_id=null`
   // Steward falls back to STEWARD_DEFAULT_TENANT_ID. The header is a
   // belt-and-suspenders pin in case future Steward versions consult it.
   if (typeof pinnedTenantId === "string" && pinnedTenantId.trim().length > 0) {
-    headers["X-Steward-Tenant"] = pinnedTenantId.trim();
+    headers.set("X-Steward-Tenant", pinnedTenantId.trim());
+  }
+  // Steward gates mutating `/auth/*` on a freshness header AND an HMAC
+  // signature (`X-Steward-Signature: v1=<hex>`). The `/steward/*` proxy signs
+  // for browser-driven flows, but this route forwards to Steward directly (to
+  // pin the tenant), so it must sign here too — otherwise the exchange 401s
+  // with "X-Steward-Signature header required". Sign over the EXACT bytes we
+  // send. Without a configured secret we send unsigned (same as the proxy) and
+  // let Steward decide. See packages/cloud-api/src/steward/{embedded,sign}.ts.
+  // (The signer mints a fresh Idempotency-Key per attempt — fine here because
+  // the OAuth code is single-use; Steward 401s a replayed code anyway.)
+  const bodyText = JSON.stringify(body);
+  const bodyBytes = new TextEncoder().encode(bodyText);
+  if (typeof signingSecret === "string" && signingSecret.length > 0) {
+    await signStewardMutatingRequest(
+      signingSecret,
+      "POST",
+      `${exchangeUrl.pathname}${exchangeUrl.search}`,
+      headers,
+      bodyBytes,
+    );
   }
   let response: Response;
   try {
-    response = await fetch(`${baseUrl}/auth/oauth/exchange`, {
+    response = await fetch(exchangeUrl.toString(), {
       method: "POST",
       headers,
-      body: JSON.stringify(body),
+      body: bodyText,
     });
   } catch (err) {
     return {
@@ -260,6 +288,8 @@ app.post("/", async (c) => {
     redirect_uri?: unknown;
     tenantId?: unknown;
     tenant_id?: unknown;
+    codeVerifier?: unknown;
+    code_verifier?: unknown;
   };
 
   const code = typeof body.code === "string" ? body.code.trim() : "";
@@ -282,6 +312,16 @@ app.post("/", async (c) => {
   const envTenant = c.env.STEWARD_TENANT_ID?.trim() ?? "";
   const tenantId =
     rawTenant.length > 0 ? rawTenant : envTenant.length > 0 ? envTenant : null;
+  // PKCE verifier for `response_type=code`. The SPA stashes it before the
+  // /authorize redirect and replays it here; we forward it to Steward, which
+  // checks it against the challenge bound at /authorize. Absent for the legacy
+  // (pre-PKCE) and wallet flows — forward only when present.
+  const codeVerifier =
+    typeof body.codeVerifier === "string"
+      ? body.codeVerifier.trim()
+      : typeof body.code_verifier === "string"
+        ? body.code_verifier.trim()
+        : "";
 
   if (!code) {
     logExchange("missing-code");
@@ -320,8 +360,10 @@ app.post("/", async (c) => {
       code,
       redirect_uri: redirectUri,
       tenant_id: tenantId,
+      ...(codeVerifier ? { code_verifier: codeVerifier } : {}),
     },
     c.env.STEWARD_TENANT_ID,
+    c.env.STEWARD_REQUEST_SIGNING_SECRET,
   );
 
   if (exchange.kind === "transport") {

--- a/packages/cloud-api/src/steward/sign.ts
+++ b/packages/cloud-api/src/steward/sign.ts
@@ -1,0 +1,132 @@
+/**
+ * Steward request-signing helper for callers that bypass the `/steward/*`
+ * proxy in `bootstrap-app.ts` (currently the OAuth nonce-exchange route, which
+ * forwards straight to upstream Steward so it can pin the tenant per-env).
+ *
+ * Steward's `authorization-signature` middleware
+ * (Steward-Fi/steward: packages/api/src/middleware/authorization-signature.ts)
+ * is the AUTHORITATIVE definition of the canonical request. `embedded.ts`
+ * mirrors it for the proxy path; this module mirrors it for the direct path.
+ * All copies MUST stay byte-for-byte in lockstep — if upstream adds, removes,
+ * or reorders a header the canonical hashes, update every copy together or
+ * signed requests start returning 401. Keep this list identical to
+ * `buildStewardCanonicalRequest` in `embedded.ts`.
+ */
+
+// Matches embedded.ts: a short freshness window for the X-Steward-Request-*
+// header, well inside Steward's ±5min skew/TTL tolerance.
+const REQUEST_TTL_SECONDS = 60;
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i += 1) {
+    out += bytes[i].toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+async function sha256Hex(input: BufferSource): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", input);
+  return bytesToHex(new Uint8Array(digest));
+}
+
+async function sha256TextHex(value: string): Promise<string> {
+  return sha256Hex(new TextEncoder().encode(value));
+}
+
+async function hmacSha256Hex(secret: string, message: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(message),
+  );
+  return bytesToHex(new Uint8Array(signature));
+}
+
+/**
+ * Build the exact ordered canonical string Steward HMACs. Keep in lockstep
+ * with `buildStewardCanonicalRequest` in `embedded.ts` and `canonicalRequest`
+ * in Steward's authorization-signature middleware.
+ */
+export async function buildStewardCanonicalRequest(
+  method: string,
+  pathAndSearch: string,
+  headers: Headers,
+  body: BufferSource,
+): Promise<string> {
+  const bodyHash = await sha256Hex(body);
+  const authHash = await sha256TextHex(headers.get("authorization") ?? "");
+  const apiKeyHash = await sha256TextHex(headers.get("x-steward-key") ?? "");
+  const platformKeyHash = await sha256TextHex(
+    headers.get("x-steward-platform-key") ?? "",
+  );
+  const signerIdHash = await sha256TextHex(
+    headers.get("x-steward-signer-id") ?? "",
+  );
+  const signerSecretHash = await sha256TextHex(
+    headers.get("x-steward-signer-secret") ?? "",
+  );
+  const quorumIdHash = await sha256TextHex(
+    headers.get("x-steward-key-quorum-id") ?? "",
+  );
+  const quorumCredentialsHash = await sha256TextHex(
+    headers.get("x-steward-key-quorum-credentials") ?? "",
+  );
+  return [
+    "steward-request-signature-v1",
+    method.toUpperCase(),
+    pathAndSearch,
+    headers.get("x-steward-tenant") ?? "",
+    authHash,
+    apiKeyHash,
+    platformKeyHash,
+    signerIdHash,
+    signerSecretHash,
+    quorumIdHash,
+    quorumCredentialsHash,
+    headers.get("x-steward-request-timestamp") ?? "",
+    headers.get("x-steward-request-expires-at") ?? "",
+    headers.get("idempotency-key") ?? "",
+    bodyHash,
+  ].join("\n");
+}
+
+/**
+ * Apply Steward's freshness + HMAC signature headers to `headers` in place for
+ * a mutating upstream request. Sets `X-Steward-Request-Expires-At`, an
+ * `Idempotency-Key` (preserving any caller-supplied one — Steward's idempotency
+ * middleware requires it on every signed mutating request), and
+ * `X-Steward-Signature: v1=<hex>`.
+ *
+ * `pathAndSearch` and `headers` MUST match what is actually sent upstream, and
+ * `body` MUST be the exact bytes of the request body, or the signature won't
+ * verify.
+ */
+export async function signStewardMutatingRequest(
+  secret: string,
+  method: string,
+  pathAndSearch: string,
+  headers: Headers,
+  body: BufferSource,
+): Promise<void> {
+  const expiresAt = Math.floor(Date.now() / 1000) + REQUEST_TTL_SECONDS;
+  headers.set("x-steward-request-expires-at", String(expiresAt));
+  if (!headers.get("idempotency-key")) {
+    headers.set("idempotency-key", crypto.randomUUID());
+  }
+  const canonical = await buildStewardCanonicalRequest(
+    method,
+    pathAndSearch,
+    headers,
+    body,
+  );
+  const signature = await hmacSha256Hex(secret, canonical);
+  headers.set("x-steward-signature", `v1=${signature}`);
+}

--- a/packages/cloud-frontend/src/lib/steward-session.ts
+++ b/packages/cloud-frontend/src/lib/steward-session.ts
@@ -127,7 +127,7 @@ export function consumeStewardTokensFromHash(): {
  */
 export async function exchangeStewardCodeViaApi(
   code: string,
-  opts: { redirectUri?: string; tenantId?: string } = {},
+  opts: { redirectUri?: string; tenantId?: string; codeVerifier?: string } = {},
 ): Promise<StewardNonceExchangeResponse> {
   const response = await apiFetch(STEWARD_NONCE_EXCHANGE_ENDPOINT, {
     method: "POST",
@@ -136,6 +136,10 @@ export async function exchangeStewardCodeViaApi(
       code,
       ...(opts.redirectUri ? { redirectUri: opts.redirectUri } : {}),
       ...(opts.tenantId ? { tenantId: opts.tenantId } : {}),
+      // PKCE verifier replayed for `response_type=code`. The cloud-api
+      // nonce-exchange route forwards it to Steward `/auth/oauth/exchange`,
+      // which checks it against the challenge bound at /authorize.
+      ...(opts.codeVerifier ? { codeVerifier: opts.codeVerifier } : {}),
     },
   });
 

--- a/packages/cloud-frontend/src/pages/login/steward-login-section.tsx
+++ b/packages/cloud-frontend/src/pages/login/steward-login-section.tsx
@@ -28,7 +28,10 @@ import { resolveLoginReturnTo } from "./login-return-to";
 import {
   buildStewardOAuthAuthorizeUrl,
   buildStewardOAuthRedirectUri,
+  consumeStewardPkceVerifier,
+  createStewardPkcePair,
   type StewardOAuthProvider,
+  storeStewardPkceVerifier,
 } from "./steward-oauth-url";
 import { StewardWalletProviders } from "./steward-wallet-providers";
 import { WalletButtons } from "./wallet-buttons";
@@ -201,12 +204,18 @@ export default function StewardLoginSection() {
     // and sets HttpOnly cookies. Access + refresh tokens never enter JS.
     const code = consumeStewardCodeFromQuery();
     if (code) {
+      // Replay the PKCE verifier stashed before the /authorize redirect so
+      // Steward can match it against the bound challenge. Null when the flow
+      // predates PKCE (rollout window) or sessionStorage was cleared — the
+      // exchange then omits it and Steward surfaces the mismatch.
+      const codeVerifier = consumeStewardPkceVerifier() ?? undefined;
       exchangeStewardCodeViaApi(code, {
         redirectUri: buildStewardOAuthRedirectUri(
           window.location.origin,
           window.location.search,
         ),
         tenantId: STEWARD_TENANT_ID,
+        codeVerifier,
       })
         .then((res) => {
           // Mirror the JWT into localStorage so `@stwd/react`'s `useAuth()`
@@ -380,6 +389,30 @@ export default function StewardLoginSection() {
     const oauthOrigin = host.endsWith(".pages.dev")
       ? "https://staging.elizacloud.ai"
       : window.location.origin;
+    // Steward requires a PKCE challenge on `response_type=code`. Mint the
+    // verifier/challenge pair, stash the verifier for the post-redirect
+    // /exchange step, and send only the challenge to /authorize. If crypto is
+    // unavailable, surface the error instead of redirecting into a guaranteed
+    // 400 ("code_challenge is required for response_type=code").
+    let codeChallenge: string;
+    try {
+      const pkce = await createStewardPkcePair();
+      // Fail fast if the verifier can't be persisted: redirecting with a
+      // challenge we can't later answer would just 401 after a full OAuth
+      // round-trip. Better to tell the user upfront.
+      if (!storeStewardPkceVerifier(pkce.verifier)) {
+        setError(
+          "Could not start sign-in — browser storage is unavailable. Enable cookies / site data and try again.",
+        );
+        setLoading(null);
+        return;
+      }
+      codeChallenge = pkce.challenge;
+    } catch (e: unknown) {
+      setError(getErrorMessage(e, "Could not start sign-in"));
+      setLoading(null);
+      return;
+    }
     window.location.href = buildStewardOAuthAuthorizeUrl(
       provider,
       oauthOrigin,
@@ -387,6 +420,7 @@ export default function StewardLoginSection() {
         redirectSearch: window.location.search,
         stewardApiUrl,
         stewardTenantId: STEWARD_TENANT_ID,
+        codeChallenge,
       },
     );
   }

--- a/packages/cloud-frontend/src/pages/login/steward-oauth-url.test.ts
+++ b/packages/cloud-frontend/src/pages/login/steward-oauth-url.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  buildStewardOAuthAuthorizeUrl,
+  consumeStewardPkceVerifier,
+  createStewardPkceChallenge,
+  createStewardPkcePair,
+  generateStewardPkceVerifier,
+  storeStewardPkceVerifier,
+} from "./steward-oauth-url";
+
+describe("Steward OAuth PKCE", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("createStewardPkceChallenge matches the RFC 7636 Appendix B vector", async () => {
+    // The canonical RFC 7636 example — also what Steward's pkceChallengeForVerifier
+    // computes (base64url(sha256(verifier))). Locks our S256 to the spec.
+    const challenge = await createStewardPkceChallenge(
+      "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+    );
+    expect(challenge).toBe("E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+  });
+
+  it("generateStewardPkceVerifier is URL-safe and within RFC 7636 length bounds", () => {
+    const verifier = generateStewardPkceVerifier();
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(verifier.length).toBeGreaterThanOrEqual(43);
+    expect(verifier.length).toBeLessThanOrEqual(128);
+    expect(generateStewardPkceVerifier()).not.toBe(verifier); // high-entropy
+  });
+
+  it("createStewardPkcePair's challenge is the S256 hash of its verifier", async () => {
+    const { verifier, challenge } = await createStewardPkcePair();
+    expect(challenge).toBe(await createStewardPkceChallenge(verifier));
+  });
+
+  it("store/consume round-trips the verifier exactly once (single-use)", () => {
+    expect(storeStewardPkceVerifier("verifier-xyz")).toBe(true);
+    expect(consumeStewardPkceVerifier()).toBe("verifier-xyz");
+    // Consumed — a replayed/duplicate callback can't reuse a stale verifier.
+    expect(consumeStewardPkceVerifier()).toBeNull();
+  });
+
+  it("buildStewardOAuthAuthorizeUrl includes the PKCE challenge only when provided", () => {
+    const withPkce = new URL(
+      buildStewardOAuthAuthorizeUrl("google", "https://www.elizacloud.ai", {
+        stewardApiUrl: "https://api.example/steward",
+        codeChallenge: "CHALLENGE",
+      }),
+    );
+    expect(withPkce.searchParams.get("response_type")).toBe("code");
+    expect(withPkce.searchParams.get("code_challenge")).toBe("CHALLENGE");
+    expect(withPkce.searchParams.get("code_challenge_method")).toBe("S256");
+
+    const withoutPkce = new URL(
+      buildStewardOAuthAuthorizeUrl("google", "https://www.elizacloud.ai", {
+        stewardApiUrl: "https://api.example/steward",
+      }),
+    );
+    expect(withoutPkce.searchParams.has("code_challenge")).toBe(false);
+    expect(withoutPkce.searchParams.has("code_challenge_method")).toBe(false);
+  });
+});

--- a/packages/cloud-frontend/src/pages/login/steward-oauth-url.ts
+++ b/packages/cloud-frontend/src/pages/login/steward-oauth-url.ts
@@ -28,6 +28,13 @@ export function buildStewardOAuthAuthorizeUrl(
     redirectSearch?: string;
     stewardApiUrl?: string;
     stewardTenantId?: string;
+    /**
+     * PKCE S256 challenge. Steward's `/auth/oauth/:provider/authorize` rejects
+     * `response_type=code` without it (`code_challenge is required for
+     * response_type=code`). Pair it with the verifier replayed at /exchange via
+     * {@link createStewardPkcePair} + {@link storeStewardPkceVerifier}.
+     */
+    codeChallenge?: string;
   },
 ): string {
   const redirectUri = buildStewardOAuthRedirectUri(
@@ -42,9 +49,91 @@ export function buildStewardOAuthAuthorizeUrl(
     // tokens server-side via /api/auth/steward-nonce-exchange.
     response_type: "code",
   });
+  if (options?.codeChallenge) {
+    params.set("code_challenge", options.codeChallenge);
+    params.set("code_challenge_method", "S256");
+  }
 
   const stewardApiUrl =
     options?.stewardApiUrl ?? resolveBrowserStewardApiUrl(origin);
 
   return `${stewardApiUrl}/auth/oauth/${provider}/authorize?${params.toString()}`;
+}
+
+// ─── PKCE (RFC 7636) ────────────────────────────────────────────────────────
+// Steward hardened `/auth/oauth/:provider/authorize` to require a PKCE
+// `code_challenge` (S256) for `response_type=code`. We mint a high-entropy
+// verifier, send `base64url(sha256(verifier))` as the challenge at /authorize,
+// stash the verifier in sessionStorage, and replay it at /exchange. Steward
+// recomputes the challenge and rejects the exchange unless it matches what was
+// bound at /authorize — binding the redirect to the browser that began it
+// (RFC 7636 auth-code interception defense). Mirrors Steward's
+// `pkceChallengeForVerifier` (packages/api/src/routes/auth.ts).
+
+const STEWARD_PKCE_VERIFIER_STORAGE_KEY = "steward.oauth.pkce.verifier";
+// 48 random bytes → 64 base64url chars, comfortably inside RFC 7636's 43–128.
+const PKCE_VERIFIER_BYTES = 48;
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export function generateStewardPkceVerifier(): string {
+  const bytes = new Uint8Array(PKCE_VERIFIER_BYTES);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}
+
+export async function createStewardPkceChallenge(
+  verifier: string,
+): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(verifier),
+  );
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+export interface StewardPkcePair {
+  verifier: string;
+  challenge: string;
+}
+
+export async function createStewardPkcePair(): Promise<StewardPkcePair> {
+  const verifier = generateStewardPkceVerifier();
+  const challenge = await createStewardPkceChallenge(verifier);
+  return { verifier, challenge };
+}
+
+export function storeStewardPkceVerifier(verifier: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    window.sessionStorage.setItem(STEWARD_PKCE_VERIFIER_STORAGE_KEY, verifier);
+    return true;
+  } catch {
+    // sessionStorage can throw (private mode / storage disabled). Signal failure
+    // so the caller fails fast upfront instead of redirecting into a guaranteed
+    // post-OAuth verifier mismatch (Steward bound a challenge we can't answer).
+    return false;
+  }
+}
+
+export function consumeStewardPkceVerifier(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const verifier = window.sessionStorage.getItem(
+      STEWARD_PKCE_VERIFIER_STORAGE_KEY,
+    );
+    if (verifier) {
+      window.sessionStorage.removeItem(STEWARD_PKCE_VERIFIER_STORAGE_KEY);
+    }
+    return verifier;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## What

Make the Eliza Cloud login send **PKCE** on the Steward OAuth flow, and have the
nonce-exchange route **sign** its direct upstream call — the two client-side
gaps that broke "Sign in with Eliza Cloud" after Steward's auth hardening.

Refs #8257.

## Why (root cause — verified against prod `api.elizacloud.ai`)

Steward was hardened on 2026-05-28 (`3faf518`) to require, on `/auth/*`:
1. a PKCE `code_challenge` (S256) on `GET /auth/oauth/:provider/authorize` for
   `response_type=code`, and
2. an HMAC request signature (`X-Steward-Signature: v1=<hex>`) + freshness
   header on mutating routes.

The Eliza Cloud client never sent either, so live reproduction shows:

```
GET  /steward/auth/oauth/google/authorize?...&response_type=code
  → 400 {"error":"code_challenge is required for response_type=code"}
POST /steward/auth/oauth/exchange   (and /auth/email/send)
  → 401 {"error":"X-Steward-Signature header required"}
```

The **signing** half of the proxy path was already fixed in #8256
(`embeddedStewardHandler`). This PR closes the remaining client gaps:

- **PKCE** is not sent anywhere by the SPA.
- The **nonce-exchange route bypasses the `/steward/*` signing proxy** (it calls
  upstream Steward directly to pin the tenant), so its `/auth/oauth/exchange`
  POST is unsigned and 401s even after #8256 ships.

## Changes

**Frontend PKCE (`packages/cloud-frontend`)**
- `pages/login/steward-oauth-url.ts`: add `createStewardPkcePair` /
  `createStewardPkceChallenge` / `generateStewardPkceVerifier` (S256, RFC 7636)
  and `store`/`consumeStewardPkceVerifier` (sessionStorage, single-use); add a
  `codeChallenge` option on `buildStewardOAuthAuthorizeUrl`.
- `pages/login/steward-login-section.tsx`: mint + stash the verifier before the
  `/authorize` redirect; replay it on the callback into the exchange.
- `lib/steward-session.ts`: forward `codeVerifier` to the nonce-exchange route.

**Exchange signing (`packages/cloud-api`)**
- `src/steward/sign.ts` (new): `buildStewardCanonicalRequest` +
  `signStewardMutatingRequest` — a faithful, **lockstep** copy of the proxy
  signer in `src/steward/embedded.ts` (and Steward's
  `authorization-signature.ts`). Same 15-field canonical, same `v1=` HMAC.
- `auth/steward-nonce-exchange/route.ts`: forward `code_verifier` to Steward and
  sign the upstream `/auth/oauth/exchange` POST when
  `STEWARD_REQUEST_SIGNING_SECRET` is set (unsigned otherwise — same posture as
  the proxy).

## Backward compatibility

- Wallet (SIWE/SIWS), email/magic-link, and passkey flows are untouched.
- The exchange still works with **no** verifier and/or **no** signing secret
  (both forwarded only when present); legacy pre-PKCE callbacks degrade to
  Steward's own error rather than crashing.
- Accepts both `codeVerifier` and `code_verifier` body shapes.

## Testing

- `packages/cloud-frontend/.../steward-oauth-url.test.ts` — PKCE S256 locked to
  the RFC 7636 Appendix B vector (`dBjf… → E9Me…`, identical to Steward's
  `pkceChallengeForVerifier`), verifier charset/length, single-use store/consume,
  and conditional `code_challenge` query params.
- `packages/cloud-api/__tests__/steward-sign.test.ts` — canonical field order,
  freshness + idempotency stamping, an **independently-recomputed signature that
  verifies**, idempotency-key preservation, and body-tamper rejection.

> Note: the full monorepo install/test run was done in CI (local install was not
> possible in my environment). The PKCE crypto and the signer were additionally
> proven against standalone references before commit.

## NOT in this PR — required deploy/ops follow-ups for prod to go green

This PR is the client code. Prod login also needs (cannot be done in-repo):
1. **Redeploy `cloud-api`** with #8256 **and set `STEWARD_REQUEST_SIGNING_SECRET`**
   (matching the upstream Steward `STEWARD_REQUEST_SIGNING_SECRETS`) — unblocks
   email/passkey/wallet immediately.
2. **Configure the `elizacloud` tenant's OAuth redirect allowlist**
   (`STEWARD_OAUTH_ALLOWED_REDIRECTS` or tenant `allowedRedirectUrls`,
   e.g. `https://www.elizacloud.ai/login`, `https://staging.elizacloud.ai/login`)
   — currently returns `"OAuth redirect_uri allowlist is not configured for this
   tenant"`, the last gate for Google after PKCE.
