### PR TITLE
feat(registry): add @madeonsol/plugin-madeonsol third-party entry

### DIFF
--- a/packages/registry/entries/third-party/madeonsol__plugin-madeonsol.json
+++ b/packages/registry/entries/third-party/madeonsol__plugin-madeonsol.json
@@ -1,0 +1,18 @@
+{
+  "package": "@madeonsol/plugin-madeonsol",
+  "repository": "github:LamboPoewert/plugin-madeonsol",
+  "kind": "plugin",
+  "description": "Real-time Solana memecoin intelligence for elizaOS agents — KOL trade feeds from 1,000+ tracked wallets, multi-KOL coordination signals, pump.fun deployer reputation, and wallet PnL. Auth via MadeOnSol API key or x402 USDC micropayments.",
+  "homepage": "https://github.com/LamboPoewert/plugin-madeonsol",
+  "version": "1.9.0",
+  "tags": [
+    "solana",
+    "kol",
+    "memecoin",
+    "smart-money",
+    "trading",
+    "x402",
+    "deployer-hunter",
+    "copy-trading"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -45,6 +45,54 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@madeonsol/plugin-madeonsol": {
+      "git": {
+        "repo": "LamboPoewert/plugin-madeonsol",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@madeonsol/plugin-madeonsol",
+        "v0": null,
+        "v1": null,
+        "v2": "1.9.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Real-time Solana memecoin intelligence for elizaOS agents — KOL trade feeds from 1,000+ tracked wallets, multi-KOL coordination signals, pump.fun deployer reputation, and wallet PnL. Auth via MadeOnSol API key or x402 USDC micropayments.",
+      "homepage": "https://github.com/LamboPoewert/plugin-madeonsol",
+      "topics": [
+        "solana",
+        "kol",
+        "memecoin",
+        "smart-money",
+        "trading",
+        "x402",
+        "deployer-hunter",
+        "copy-trading"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "elizaos-plugin-echo": {
       "git": {
         "repo": "elizaOS/eliza",


### PR DESCRIPTION
## What

Adds a third-party registry entry for [`@madeonsol/plugin-madeonsol`](https://www.npmjs.com/package/@madeonsol/plugin-madeonsol) per the process in `packages/registry/README.md`:

- `entries/third-party/madeonsol__plugin-madeonsol.json` (new entry)
- `generated-registry.json` regenerated via `src/generate.ts`

No other files touched. `validate-cli` passes (3 entries validated).

## About the plugin

Real-time Solana memecoin intelligence for elizaOS agents, backed by the [MadeOnSol](https://madeonsol.com) API:

- KOL trade feed from 1,000+ tracked Solana wallets (sub-3s from on-chain confirmation)
- Multi-KOL coordination/convergence signals
- Pump.fun deployer reputation tiers + new-launch alerts
- Wallet win rate / FIFO cost-basis PnL

Auth is either a MadeOnSol API key (free tier available) or **x402 USDC micropayments** — agents with a Solana wallet can pay per call with no signup.

- npm: `@madeonsol/plugin-madeonsol` @ 1.9.0 (keywords include `elizaos` for runtime auto-discovery)
- Repo: https://github.com/LamboPoewert/plugin-madeonsol (MIT, logo + banner assets included)
- `package.json` carries `agentConfig` with typed plugin parameters

I own the package and repository.