### PR TITLE
feat(cloud-frontend): wizard exposes Shared vs Dedicated execution mode explicitly

### DIFF
--- a/packages/cloud-frontend/src/dashboard/agents/_components/create-eliza-agent-dialog.tsx
+++ b/packages/cloud-frontend/src/dashboard/agents/_components/create-eliza-agent-dialog.tsx
@@ -16,7 +16,16 @@ import {
   SelectValue,
   Switch,
 } from "@elizaos/ui";
-import { Check, ExternalLink, Loader2, Plus, RotateCcw, X } from "lucide-react";
+import {
+  Check,
+  Cloud,
+  ExternalLink,
+  Loader2,
+  Plus,
+  RotateCcw,
+  Server,
+  X,
+} from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -312,6 +321,14 @@ export function CreateElizaAgentDialog({
   const t = useT();
   const [open, setOpen] = useState(false);
   const [agentName, setAgentName] = useState("");
+  // Execution mode is the user-facing primitive — Shared (no container,
+  // multi-tenant cloud runtime) vs Dedicated (own Docker container).
+  // The cloud-api derives the tier from the presence of `dockerImage` in the
+  // create body: empty → shared, set → custom (Docker). So this UI state
+  // exists to translate the mode into the body field, NOT in addition to it.
+  const [executionMode, setExecutionMode] = useState<"shared" | "dedicated">(
+    "shared",
+  );
   const [flavorId, setFlavorId] = useState(getDefaultFlavor().id);
   const [customImage, setCustomImage] = useState("");
   const [autoStart, setAutoStart] = useState(true);
@@ -327,6 +344,7 @@ export function CreateElizaAgentDialog({
   const isProvisioningPhase = phase === "provisioning";
   const selectedFlavor = getFlavorById(flavorId);
   const isCustom = flavorId === "custom";
+  const isDedicated = executionMode === "dedicated";
   const resolvedDockerImage = isCustom
     ? customImage.trim()
     : selectedFlavor?.dockerImage;
@@ -366,6 +384,7 @@ export function CreateElizaAgentDialog({
 
   function resetForm() {
     setAgentName("");
+    setExecutionMode("shared");
     setFlavorId(getDefaultFlavor().id);
     setCustomImage("");
     setError(null);
@@ -399,7 +418,11 @@ export function CreateElizaAgentDialog({
         agentName: trimmedName,
         autoProvision: autoStart,
       };
-      if (resolvedDockerImage && flavorId !== getDefaultFlavor().id) {
+      // The cloud-api tiering rule (cloud-shared/agent-tier.ts) is:
+      // dockerImage absent → tier=shared (no container). Present → tier=custom
+      // (own Docker container). We send the image ONLY when the user picked
+      // "Dedicated" — that's what makes the user choice load-bearing.
+      if (isDedicated && resolvedDockerImage) {
         createBody.dockerImage = resolvedDockerImage;
       }
 
@@ -628,48 +651,139 @@ export function CreateElizaAgentDialog({
                   />
                 </div>
 
-                {/* Flavor selector */}
+                {/* Execution mode — Shared vs Dedicated. PR #8223 split the
+                    cloud into a free shared runtime + per-agent Docker
+                    containers; the user has to pick. Default is Shared (matches
+                    the agent-tier.ts default when dockerImage is absent). */}
                 <div className="space-y-1.5">
-                  <Label
-                    htmlFor="eliza-flavor"
-                    className="text-white/60 text-xs"
-                  >
-                    {t("cloud.createAgent.type", { defaultValue: "Type" })}
+                  <Label className="text-white/60 text-xs">
+                    {t("cloud.createAgent.executionMode", {
+                      defaultValue: "Execution mode",
+                    })}
                   </Label>
-                  <Select
-                    value={flavorId}
-                    onValueChange={setFlavorId}
-                    disabled={busy}
+                  <div
+                    role="radiogroup"
+                    aria-label={t("cloud.createAgent.executionMode", {
+                      defaultValue: "Execution mode",
+                    })}
+                    className="grid grid-cols-2 gap-2"
                   >
-                    <SelectTrigger
-                      id="eliza-flavor"
-                      className="bg-black/40 border-white/10 text-white"
+                    <button
+                      type="button"
+                      role="radio"
+                      aria-checked={!isDedicated}
+                      disabled={busy}
+                      onClick={() => setExecutionMode("shared")}
+                      className={`flex flex-col items-start gap-1.5 border px-3 py-2.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#FF5800]/50 disabled:opacity-50 cursor-pointer ${
+                        !isDedicated
+                          ? "border-[#FF5800]/60 bg-[#FF5800]/[0.06]"
+                          : "border-white/10 bg-black/20 hover:border-white/20"
+                      }`}
                     >
-                      <SelectValue
-                        placeholder={t("cloud.createAgent.selectFlavor", {
-                          defaultValue: "Select flavor",
+                      <div className="flex w-full items-center justify-between gap-2">
+                        <span className="inline-flex items-center gap-1.5 text-sm text-white">
+                          <Cloud className="h-3.5 w-3.5" />
+                          {t("cloud.createAgent.modeSharedTitle", {
+                            defaultValue: "Shared",
+                          })}
+                        </span>
+                        <span className="text-[10px] font-mono text-white/35">
+                          {t("cloud.createAgent.modeSharedPrice", {
+                            defaultValue: "free",
+                          })}
+                        </span>
+                      </div>
+                      <p className="text-[11px] text-white/50 leading-snug">
+                        {t("cloud.createAgent.modeSharedDescription", {
+                          defaultValue:
+                            "Multi-tenant runtime. No container. Best for chat, webhooks and cron agents.",
                         })}
-                      />
-                    </SelectTrigger>
-                    <SelectContent className="border-white/10 bg-neutral-900">
-                      {AGENT_FLAVORS.map((flavor) => (
-                        <SelectItem key={flavor.id} value={flavor.id}>
-                          <div className="flex flex-col">
-                            <span>{flavor.name}</span>
-                          </div>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  {selectedFlavor && (
-                    <p className="text-[11px] text-white/35">
-                      {selectedFlavor.description}
-                    </p>
-                  )}
+                      </p>
+                    </button>
+
+                    <button
+                      type="button"
+                      role="radio"
+                      aria-checked={isDedicated}
+                      disabled={busy}
+                      onClick={() => setExecutionMode("dedicated")}
+                      className={`flex flex-col items-start gap-1.5 border px-3 py-2.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#FF5800]/50 disabled:opacity-50 cursor-pointer ${
+                        isDedicated
+                          ? "border-[#FF5800]/60 bg-[#FF5800]/[0.06]"
+                          : "border-white/10 bg-black/20 hover:border-white/20"
+                      }`}
+                    >
+                      <div className="flex w-full items-center justify-between gap-2">
+                        <span className="inline-flex items-center gap-1.5 text-sm text-white">
+                          <Server className="h-3.5 w-3.5" />
+                          {t("cloud.createAgent.modeDedicatedTitle", {
+                            defaultValue: "Dedicated",
+                          })}
+                        </span>
+                        <span className="text-[10px] font-mono text-white/35">
+                          {formatHourlyRate(AGENT_PRICING.RUNNING_HOURLY_RATE)}
+                        </span>
+                      </div>
+                      <p className="text-[11px] text-white/50 leading-snug">
+                        {t("cloud.createAgent.modeDedicatedDescription", {
+                          defaultValue:
+                            "Own Docker container on a Hetzner node. Required for custom images, always-on plugins (Discord/Telegram), or BYO runtime.",
+                        })}
+                      </p>
+                    </button>
+                  </div>
                 </div>
 
-                {/* Custom image input */}
-                {isCustom && (
+                {/* Image selector — only meaningful when Dedicated. AGENT_FLAVORS
+                    holds the Docker image choices ("Eliza Agent" / "(Develop)"
+                    / "Custom Image"); we hide it for Shared because no image
+                    is ever sent in that mode. */}
+                {isDedicated && (
+                  <div className="space-y-1.5">
+                    <Label
+                      htmlFor="eliza-flavor"
+                      className="text-white/60 text-xs"
+                    >
+                      {t("cloud.createAgent.image", {
+                        defaultValue: "Image",
+                      })}
+                    </Label>
+                    <Select
+                      value={flavorId}
+                      onValueChange={setFlavorId}
+                      disabled={busy}
+                    >
+                      <SelectTrigger
+                        id="eliza-flavor"
+                        className="bg-black/40 border-white/10 text-white"
+                      >
+                        <SelectValue
+                          placeholder={t("cloud.createAgent.selectFlavor", {
+                            defaultValue: "Select image",
+                          })}
+                        />
+                      </SelectTrigger>
+                      <SelectContent className="border-white/10 bg-neutral-900">
+                        {AGENT_FLAVORS.map((flavor) => (
+                          <SelectItem key={flavor.id} value={flavor.id}>
+                            <div className="flex flex-col">
+                              <span>{flavor.name}</span>
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    {selectedFlavor && (
+                      <p className="text-[11px] text-white/35">
+                        {selectedFlavor.description}
+                      </p>
+                    )}
+                  </div>
+                )}
+
+                {/* Custom image URL — appears only when both Dedicated AND the
+                    Custom flavor are selected. */}
+                {isDedicated && isCustom && (
                   <div className="space-y-1.5">
                     <Label
                       htmlFor="eliza-custom-image"
@@ -696,33 +810,41 @@ export function CreateElizaAgentDialog({
                   </div>
                 )}
 
-                {/* Auto-start toggle */}
-                <div className="flex items-center justify-between gap-4 border border-white/10 bg-black/20 px-3 py-2.5">
-                  <div className="space-y-0.5">
-                    <Label
-                      htmlFor="eliza-auto-start"
-                      className="text-sm text-white/70"
-                    >
-                      {t("cloud.createAgent.startImmediately", {
-                        defaultValue: "Start immediately",
-                      })}
-                    </Label>
-                    <p className="text-[11px] text-white/35">
-                      {t("cloud.createAgent.startAfterCreation", {
-                        defaultValue: "Start right after creation",
-                      })}
-                    </p>
+                {/* Auto-start toggle — only meaningful for Dedicated agents
+                    (Shared agents are always immediately available; the
+                    cloud-api short-circuits provision to source=shared_runtime
+                    regardless). */}
+                {isDedicated && (
+                  <div className="flex items-center justify-between gap-4 border border-white/10 bg-black/20 px-3 py-2.5">
+                    <div className="space-y-0.5">
+                      <Label
+                        htmlFor="eliza-auto-start"
+                        className="text-sm text-white/70"
+                      >
+                        {t("cloud.createAgent.startImmediately", {
+                          defaultValue: "Start container immediately",
+                        })}
+                      </Label>
+                      <p className="text-[11px] text-white/35">
+                        {t("cloud.createAgent.startAfterCreation", {
+                          defaultValue:
+                            "Provision the Hetzner node and boot the container right after create.",
+                        })}
+                      </p>
+                    </div>
+                    <Switch
+                      id="eliza-auto-start"
+                      checked={autoStart}
+                      onCheckedChange={setAutoStart}
+                      disabled={busy}
+                    />
                   </div>
-                  <Switch
-                    id="eliza-auto-start"
-                    checked={autoStart}
-                    onCheckedChange={setAutoStart}
-                    disabled={busy}
-                  />
-                </div>
+                )}
 
-                {/* Cost notice */}
-                {autoStart && (
+                {/* Cost notice — Dedicated shows hourly billing + min deposit
+                    when it will actually run; Shared shows "no compute cost"
+                    so the user doesn't think Free === Free of LLM tokens. */}
+                {isDedicated && autoStart ? (
                   <div className="flex items-start gap-2.5 border border-[#FF5800]/15 bg-[#FF5800]/5 px-3 py-2.5">
                     <div className="shrink-0 mt-0.5 w-1.5 h-1.5 bg-[#FF5800] rounded-full" />
                     <div className="space-y-0.5">
@@ -746,7 +868,17 @@ export function CreateElizaAgentDialog({
                       </p>
                     </div>
                   </div>
-                )}
+                ) : !isDedicated ? (
+                  <div className="flex items-start gap-2.5 border border-white/10 bg-black/20 px-3 py-2.5">
+                    <div className="shrink-0 mt-0.5 w-1.5 h-1.5 bg-white/40 rounded-full" />
+                    <p className="text-[11px] font-mono text-white/55 leading-snug">
+                      {t("cloud.createAgent.sharedCostNote", {
+                        defaultValue:
+                          "No compute cost. You only pay for LLM tokens consumed by the agent.",
+                      })}
+                    </p>
+                  </div>
+                ) : null}
 
                 {/* Inline error */}
                 {error && (
@@ -769,7 +901,7 @@ export function CreateElizaAgentDialog({
                   disabled={
                     !agentName.trim() ||
                     busy ||
-                    (isCustom && !customImage.trim())
+                    (isDedicated && isCustom && !customImage.trim())
                   }
                 >
                   {busy && <Loader2 className="h-4 w-4 animate-spin" />}
@@ -777,12 +909,16 @@ export function CreateElizaAgentDialog({
                     ? t("cloud.createAgent.creating", {
                         defaultValue: "Creating…",
                       })
-                    : autoStart
-                      ? t("cloud.createAgent.deploy", {
-                          defaultValue: "Deploy",
-                        })
-                      : t("cloud.createAgent.create", {
-                          defaultValue: "Create",
+                    : isDedicated
+                      ? autoStart
+                        ? t("cloud.createAgent.deployDedicated", {
+                            defaultValue: "Deploy Docker container",
+                          })
+                        : t("cloud.createAgent.createDedicated", {
+                            defaultValue: "Create (don't start)",
+                          })
+                      : t("cloud.createAgent.createShared", {
+                          defaultValue: "Create shared agent",
                         })}
                 </BrandButton>
               </DialogFooter>

--- a/packages/test/cloud-e2e/tests/dashboard.spec.ts
+++ b/packages/test/cloud-e2e/tests/dashboard.spec.ts
@@ -52,7 +52,12 @@ test.describe("dashboard session", () => {
     await authenticatedPage
       .getByLabel("Agent Name")
       .fill("e2e-dashboard-agent");
-    await authenticatedPage.getByLabel("Type").click();
+    // The wizard now exposes execution mode explicitly (#8261): a custom image
+    // is only available under the Dedicated card, which reveals the image
+    // selector + Docker Image input and switches the CTA to
+    // "Deploy Docker container".
+    await authenticatedPage.getByRole("radio", { name: /Dedicated/ }).click();
+    await authenticatedPage.getByLabel("Image").click();
     await authenticatedPage
       .getByRole("option", { name: "Custom Image" })
       .click();
@@ -65,7 +70,9 @@ test.describe("dashboard session", () => {
         [201, 202].includes(response.status()),
     );
 
-    await authenticatedPage.getByRole("button", { name: "Deploy" }).click();
+    await authenticatedPage
+      .getByRole("button", { name: "Deploy Docker container" })
+      .click();
     const createResponse = await createResponsePromise;
 
     const createBody = (await createResponse.json()) as {


### PR DESCRIPTION
## Why

PR #8223 introduced agent tiering (`cloud-shared/agent-tier.ts`): an agent without a docker image runs container-free on the shared multi-tenant runtime; an agent with one gets its own Docker container on Hetzner. The wizard hid that choice behind the existing flavor dropdown — picking the default "Eliza Agent" silently created a Shared agent (no `node_id`; the Open Web UI popup ended on a Vercel 404 because the agent UUID subdomain has no infra behind it), and picking "Eliza Agent (Develop)" / "Custom Image" escalated to Docker. The user couldn't tell which one they were getting until after creation — and at that point the agent column reads "Sandbox" vs "Docker", which is too late.

Reproducer: open `staging.elizacloud.ai/dashboard/agents` → "+ New Agent" → name → Deploy with all defaults. The row shows `Sandbox`, "Shared runtime", and the Open Web UI button leads nowhere.

## What

- **Execution mode radio-card group** (Shared default, Dedicated opt-in) with Cloud/Server icons and a price chip per mode (`free` vs hourly). Each card describes what the mode is good for and why you'd pick it. Default is Shared — matches `getAgentTier` returning `"shared"` when `dockerImage` is empty.
- **Image selector + custom-image input collapse under the Dedicated card** — a Shared agent literally cannot have an image attached anymore.
- **Auto-start toggle is dedicated-only.** Shared is always immediately available; the cloud-api short-circuits `POST /provision` to `source=shared_runtime` regardless.
- **Cost notice differentiates the modes**: Dedicated shows hourly + min-deposit, Shared shows "No compute cost. You only pay for LLM tokens consumed by the agent." so `free` doesn't read as misleading.
- **`dockerImage` is sent in the create body iff the user picked Dedicated.** Matches `cloud-shared/agent-tier.ts` exactly.
- **CTA label reflects the outcome**:
  - Shared → `Create shared agent`
  - Dedicated, autostart on → `Deploy Docker container`
  - Dedicated, autostart off → `Create (don't start)`

Existing `ProvisioningProgress` flow is untouched (only fires on the dedicated path now). i18n key prefix `cloud.createAgent.*` extended with: `executionMode`, `modeSharedTitle`, `modeSharedDescription`, `modeSharedPrice`, `modeDedicatedTitle`, `modeDedicatedDescription`, `image`, `deployDedicated`, `createDedicated`, `createShared`, `sharedCostNote`.

## Test plan

- [ ] CI green (typecheck + biome — note the unrelated pre-existing `core/i18n/generated/validation-keyword-data.ts` missing-file errors).
- [ ] On the CF Pages preview URL, open `/dashboard/agents` → "+ New Agent".
- [ ] Default state: Shared selected (orange ring on left card), no image picker, no auto-start toggle, "No compute cost..." note visible, CTA reads "Create shared agent".
- [ ] Click Dedicated: image dropdown appears (defaults to "Eliza Agent"), auto-start toggle visible (on), hourly rate notice replaces the shared note, CTA reads "Deploy Docker container".
- [ ] Pick Custom Image: docker image URL input shows below the dropdown.
- [ ] Toggle auto-start off while Dedicated: CTA reads "Create (don't start)".
- [ ] Create a Shared agent: DB row has `docker_image=NULL`, `node_id=NULL`, status flips to `running` immediately; row shows "Sandbox" in the table.
- [ ] Create a Dedicated agent (Eliza Agent Develop flavor): row gets `docker_image=ghcr.io/elizaos/eliza:develop`, `node_id` set after ~90s, status `pending → provisioning → running`; row shows "Docker" / "Managed runtime".
- [ ] Aesthetic audit `bun run --cwd packages/cloud-frontend audit:cloud` must mark `/dashboard/agents` as `good`.

## Out of scope

- Fixing the broken Open Web UI subdomain routing for Shared agents (the popup at `<uuid>.elizacloud.ai/pair?token=…` 404s because the wildcard Worker route was removed and Shared agents have no `bridge_url`). Tracked separately.
- The shared-runtime chat not responding (also independent of this wizard refactor).