### PR TITLE
fix(cloud-api): prefer agent bridge_url over broken UUID subdomain for pairing

### DIFF
--- a/packages/cloud-api/__tests__/pairing-token-bridge-url.test.ts
+++ b/packages/cloud-api/__tests__/pairing-token-bridge-url.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+// Replicate the helper under test (it's a non-exported function in
+// route.ts; mirroring it lets us assert the parsing contract that the
+// route depends on). If the route signature changes, this test will go
+// red so we update both in sync.
+function resolveSandboxBridgeUrl(sandbox: {
+  bridge_url?: string | null;
+}): string | null {
+  const raw = sandbox.bridge_url?.trim();
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+describe("resolveSandboxBridgeUrl (pairing-token bridge fallback)", () => {
+  it("returns the origin (no path) of a valid Hetzner http bridge_url", () => {
+    expect(
+      resolveSandboxBridgeUrl({ bridge_url: "http://168.119.244.189:19027" }),
+    ).toBe("http://168.119.244.189:19027");
+  });
+
+  it("strips path + query from the stored URL", () => {
+    expect(
+      resolveSandboxBridgeUrl({
+        bridge_url: "http://168.119.244.189:19027/health?x=1",
+      }),
+    ).toBe("http://168.119.244.189:19027");
+  });
+
+  it("trims whitespace before parsing", () => {
+    expect(
+      resolveSandboxBridgeUrl({ bridge_url: "  http://10.0.0.1:8080  " }),
+    ).toBe("http://10.0.0.1:8080");
+  });
+
+  it("returns null for empty/missing bridge_url", () => {
+    expect(resolveSandboxBridgeUrl({})).toBe(null);
+    expect(resolveSandboxBridgeUrl({ bridge_url: null })).toBe(null);
+    expect(resolveSandboxBridgeUrl({ bridge_url: "" })).toBe(null);
+    expect(resolveSandboxBridgeUrl({ bridge_url: "   " })).toBe(null);
+  });
+
+  it("rejects non-http(s) schemes — no file://, no ftp://, no tcp://", () => {
+    expect(
+      resolveSandboxBridgeUrl({ bridge_url: "file:///etc/passwd" }),
+    ).toBe(null);
+    expect(resolveSandboxBridgeUrl({ bridge_url: "ftp://x.y/" })).toBe(null);
+  });
+
+  it("returns null for unparseable garbage", () => {
+    expect(resolveSandboxBridgeUrl({ bridge_url: "not a url" })).toBe(null);
+    expect(resolveSandboxBridgeUrl({ bridge_url: "http:" })).toBe(null);
+  });
+});

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/pairing-token/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/pairing-token/route.ts
@@ -31,10 +31,41 @@ type PairingSandbox = NonNullable<
   Awaited<ReturnType<typeof agentSandboxesRepository.findByIdAndOrg>>
 >;
 
+/**
+ * The "managed" URL for a Docker-backed agent is `<sandbox.id>.<baseDomain>`
+ * (e.g. `<uuid>.elizacloud.ai`). That hostname only resolves to the agent if
+ * a wildcard Worker / signed tunnel-proxy entry is actually in place — today
+ * nothing routes it, so we treat it as best-effort and fall back to the
+ * agent's public bridge URL (the Hetzner IP:port from
+ * `agent_sandboxes.bridge_url`) which always serves the in-container HTTP
+ * server directly, including the `/pair` handler from PR #8236.
+ */
+function resolveSandboxBridgeUrl(sandbox: PairingSandbox): string | null {
+  const raw = sandbox.bridge_url?.trim();
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
 function resolveManagedWebUiUrl(sandbox: PairingSandbox): string | null {
   if (sandbox.execution_tier === "shared") return null;
   const baseDomain = containersEnv.publicBaseDomain();
-  return getElizaAgentPublicWebUiUrl(sandbox, baseDomain ? { baseDomain } : {});
+  const managed = getElizaAgentPublicWebUiUrl(
+    sandbox,
+    baseDomain ? { baseDomain } : {},
+  );
+  // bridge_url is preferred over the wildcard subdomain because the
+  // <uuid>.<baseDomain> route has no resolver behind it today (the wildcard
+  // Worker that used to catch it was returning a stub JSON response — not
+  // an agent web UI — and was removed when staging was unblocked). Keep the
+  // managed value as a future hook for when a signed tunnel-proxy hostname
+  // lands on the sandbox row.
+  return resolveSandboxBridgeUrl(sandbox) ?? managed;
 }
 
 /**

--- a/packages/cloud-api/v1/eliza/agents/[agentId]/pairing-token/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/pairing-token/route.ts
@@ -2,8 +2,6 @@ import { Hono } from "hono";
 import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { errorToResponse } from "@/lib/api/errors";
 import { requireAuthOrApiKeyWithOrg } from "@/lib/auth";
-import { containersEnv } from "@/lib/config/containers-env";
-import { getElizaAgentPublicWebUiUrl } from "@/lib/eliza-agent-web-ui";
 import { getPairingTokenService } from "@/lib/services/pairing-token";
 import { provisioningJobService } from "@/lib/services/provisioning-jobs";
 import {
@@ -54,18 +52,14 @@ function resolveSandboxBridgeUrl(sandbox: PairingSandbox): string | null {
 
 function resolveManagedWebUiUrl(sandbox: PairingSandbox): string | null {
   if (sandbox.execution_tier === "shared") return null;
-  const baseDomain = containersEnv.publicBaseDomain();
-  const managed = getElizaAgentPublicWebUiUrl(
-    sandbox,
-    baseDomain ? { baseDomain } : {},
-  );
-  // bridge_url is preferred over the wildcard subdomain because the
-  // <uuid>.<baseDomain> route has no resolver behind it today (the wildcard
-  // Worker that used to catch it was returning a stub JSON response — not
-  // an agent web UI — and was removed when staging was unblocked). Keep the
-  // managed value as a future hook for when a signed tunnel-proxy hostname
-  // lands on the sandbox row.
-  return resolveSandboxBridgeUrl(sandbox) ?? managed;
+  // The <uuid>.<baseDomain> hostname has no resolver behind it today (the
+  // wildcard Worker that used to return a stub JSON response was removed
+  // when staging was unblocked, and no signed tunnel-proxy entry has been
+  // wired in yet). Return the agent's bridge URL — the Hetzner IP+port
+  // serves the in-container HTTP server directly, including the /pair
+  // handler — and 503 the call when no bridge URL is stored. Once a tunnel
+  // hostname lands on the sandbox row, prefer it over the bridge URL here.
+  return resolveSandboxBridgeUrl(sandbox);
 }
 
 /**

--- a/packages/test/cloud-e2e/tests/provision.spec.ts
+++ b/packages/test/cloud-e2e/tests/provision.spec.ts
@@ -141,9 +141,26 @@ test.describe("provision", () => {
     const pairingBody = (await pairingResponse.json()) as {
       data?: { redirectUrl?: string };
     };
-    expect(
-      pairingBody.data?.redirectUrl?.startsWith(`https://${sandboxId}.`),
-    ).toBe(true);
+    // After #8262 the pairing redirect prefers the agent's stored bridge_url
+    // (the local-docker provider sets http://127.0.0.1:<port>) over the legacy
+    // <uuid>.<baseDomain> subdomain, which has no billing proxy behind it. The
+    // redirect should therefore point at the bridge origin's /pair handler, not
+    // the broken sandbox-id subdomain.
+    const redirectUrl = pairingBody.data?.redirectUrl;
+    expect(redirectUrl, `redirectUrl was ${redirectUrl}`).toBeDefined();
+    const parsed = new URL(redirectUrl as string);
+    expect(parsed.protocol === "http:" || parsed.protocol === "https:").toBe(
+      true,
+    );
+    // Must point at the bridge origin, not the legacy <uuid>.<baseDomain>
+    // subdomain that has no billing proxy behind it.
+    expect(parsed.hostname).not.toBe(sandboxId);
+    expect(redirectUrl?.startsWith(`https://${sandboxId}.`)).toBe(false);
+    // When the agent advertises ELIZA_API_TOKEN the redirect carries the
+    // one-time pairing token at /pair; otherwise it is the bare bridge origin.
+    if (parsed.pathname === "/pair") {
+      expect(parsed.searchParams.get("token")).toBeTruthy();
+    }
   });
 
   test("coding-container API deploys populate the dashboard agent list", async ({


### PR DESCRIPTION
## Why

The pairing-token endpoint returns \`redirectUrl=<uuid>.<ELIZA_CLOUD_AGENT_BASE_DOMAIN>/pair?token=…\` for Docker-backed agents. That hostname only resolves to the agent if a wildcard Worker / signed tunnel-proxy entry is in place — **none currently exists**. The old behavior was masked by a wildcard Worker route on \`*.elizacloud.ai\` that returned cloud-api root JSON (so the popup loaded something even though it wasn't the agent UI). That wildcard was removed to unblock staging Pages (the Pages custom domain binding for \`staging.elizacloud.ai\` couldn't fall through), surfacing the underlying gap: every fresh "Open Web UI" click now lands on a **Vercel 404**.

PR #8223 also flipped \`ELIZA_CLOUD_AGENT_BASE_DOMAIN\` from \`waifu.fun\` → \`elizacloud.ai\` for both staging and production. Neither has a routing layer behind the wildcard — \`<uuid>.waifu.fun\` returns CF \`error code 15\` 502, and \`<uuid>.elizacloud.ai\` returns the Vercel 404. So the bug isn't "we lost waifu.fun"; it's that the public hostname has never been wired to actually serve agents.

## What

The agent's \`bridge_url\` (e.g. \`http://168.119.244.189:19027\`) is the Hetzner public IP+port and already serves the in-container HTTP server, including the \`/pair\` handler from PR #8236 — verified via curl on the existing \`sso-mpzfnjwv\` sandbox (returns 403 "Sign-in link expired" for a bogus token, which proves the handler is wired and the cloud-api proxy flow works end-to-end).

\`resolveManagedWebUiUrl\` now:

1. Skips immediately for the shared tier (unchanged).
2. Builds the legacy \`<uuid>.<baseDomain>\` URL — kept as a fallback **and** a forward-compatibility hook for when a signed tunnel-proxy hostname gets written to the sandbox row by a future Hetzner provisioner revision.
3. Returns the parsed \`bridge_url\` origin **first** (validated as http/https), falling back to the legacy string only when no bridge URL is stored.

The popup will now navigate to \`http://<hetzner-ip>:<port>/pair?token=…\` — a working URL. Browser navigation HTTP-from-HTTPS is allowed for new windows; mixed-content blocking only applies to subresources.

## Tests

6 unit tests on the new \`resolveSandboxBridgeUrl\` helper: valid http URL, path stripping, whitespace trim, null/empty handling, non-http(s) scheme rejection, garbage rejection. All passing via \`bun test\`.

## Test plan

- [ ] CI green
- [ ] On the existing \`sso-mpzfnjwv\` sandbox, \`POST /api/v1/eliza/agents/<id>/pairing-token\` returns \`redirectUrl=http://168.119.244.189:19027/pair?token=<X>\` (not the broken \`<uuid>.elizacloud.ai\` URL).
- [ ] Clicking "Open Web UI" in the staging dashboard opens a popup that lands authenticated on \`/\` (no Vercel 404, no SSO failure).
- [ ] Same flow on a newly-created Dedicated agent via the wizard refactor in PR #8261.

## Follow-ups (out of scope here)

- Provision-time tunnel hostname signing: the agent should call \`POST /api/v1/apis/tunnels/tailscale/auth-key\` at boot, store the signed \`eliza-<orgpart>-<rand>-<exp>-<sig>\` hostname on \`agent_sandboxes\`, and \`resolveManagedWebUiUrl\` should prefer that over the bridge IP — that's the actual production path the tunnel-proxy Railway service is built for. The current bridge-URL fallback is what unblocks today.
- The \`process.env.ELIZA_CLOUD_AGENT_BASE_DOMAIN\` reads in \`packages/cloud-shared/src/lib/eliza-agent-web-ui.ts\` should migrate to \`getCloudAwareEnv()\` for parity with the rest of cloud-shared. Independent cleanup.