### PR TITLE
fix(cloud-api): credit affiliates on embeddings + voice inference

### DIFF
--- a/packages/cloud-api/v1/embeddings/route.ts
+++ b/packages/cloud-api/v1/embeddings/route.ts
@@ -208,6 +208,9 @@ app.post("/", async (c) => {
         model,
         provider,
         billingSource,
+        // Affiliate revenue-share: when the calling app sets X-Affiliate-Code,
+        // activate the existing billUsage affiliate branch (same as /v1/messages).
+        affiliateCode: c.req.header("X-Affiliate-Code") ?? null,
       },
       { inputTokens: actualTokens, outputTokens: 0 },
       reservation,

--- a/packages/cloud-api/v1/voice/clone/route.ts
+++ b/packages/cloud-api/v1/voice/clone/route.ts
@@ -341,6 +341,8 @@ app.post("/", async (c) => {
         model: `elevenlabs/${cloneType}`,
         provider: "elevenlabs",
         billingSource: "elevenlabs",
+        // Affiliate revenue-share via X-Affiliate-Code (existing billFlatUsage branch).
+        affiliateCode: c.req.header("X-Affiliate-Code") ?? null,
         description: `Voice cloning (${cloneType}): ${voiceName}`,
       },
       cloneCost,

--- a/packages/cloud-api/v1/voice/stt/route.ts
+++ b/packages/cloud-api/v1/voice/stt/route.ts
@@ -232,6 +232,8 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         model: "elevenlabs/scribe_v1",
         provider: "elevenlabs",
         billingSource: "elevenlabs",
+        // Affiliate revenue-share via X-Affiliate-Code (existing billFlatUsage branch).
+        affiliateCode: request.headers.get("X-Affiliate-Code"),
         description: `STT transcription: ${estimatedDurationMinutes.toFixed(2)} min`,
       },
       sttCost,

--- a/packages/cloud-api/v1/voice/tts/route.ts
+++ b/packages/cloud-api/v1/voice/tts/route.ts
@@ -272,6 +272,8 @@ async function __hono_POST(request: Request, env: AppEnv["Bindings"]) {
         model: `elevenlabs/${modelId || "eleven_flash_v2_5"}`,
         provider: "elevenlabs",
         billingSource: "elevenlabs",
+        // Affiliate revenue-share via X-Affiliate-Code (existing billFlatUsage branch).
+        affiliateCode: request.headers.get("X-Affiliate-Code"),
         description: `TTS generation: ${text.length} chars${isCustomVoice ? " (custom voice)" : ""}`,
       },
       {


### PR DESCRIPTION
## What
Thread `X-Affiliate-Code` into the inference routes that already call `billUsage` / `billFlatUsage` but weren't reading the header — so affiliate revenue-share works on **embeddings** and **voice (STT / TTS / clone)**, not just `/v1/messages`, `/v1/chat`, `/v1/chat/completions`.

## Why
`billUsage` and `billFlatUsage` both already contain the affiliate-markup branch (`ai-billing.ts` — looks up `markup_percent`, credits `redeemableEarningsService.addEarnings(source:"affiliate")`). But `/v1/embeddings` and `/v1/voice/{stt,tts,clone}` built their billing context **without** `affiliateCode`, so the branch was dead and affiliates earned **$0** on those paths.

## Change
One line per route: read `X-Affiliate-Code` and pass it into the existing billing context.
- `v1/embeddings/route.ts` → `billUsage`
- `v1/voice/{stt,tts,clone}/route.ts` → `billFlatUsage`

**Safety:** header-gated and fully backward-compatible — when the header is absent the context is `null` and billing is byte-identical to today. **No new payout math** — this only activates the already-tested affiliate branch on more routes.

## Not in this PR (follow-ups)
- App-scoped (`/v1/apps/{id}/chat`, `/v1/apps/{id}/generate-image`) and top-level `generate-image/video/music` bill via `appCreditsService.deductCredits` / `creditsService.reserve` which **bypass** `billUsage`, so they need a *new* affiliate-earnings step (with a test) — deliberately left out to keep this PR's money path zero-new-logic.
- Display: `redeemable-earnings.getBalance()` breakdown + the redemptions API/UI union don't itemize `affiliate` earnings yet.
- The separate "require sign-in / remove anonymous guest sessions" cleanup is its own staged PR.
