### PR TITLE
fix(cloud-api): clarify insufficient-credits wording on inference

### DIFF
--- a/packages/cloud-api/v1/apps/[id]/chat/route.ts
+++ b/packages/cloud-api/v1/apps/[id]/chat/route.ts
@@ -308,7 +308,7 @@ async function handlePOST(
     });
 
     if (!deductionResult.success) {
-      logger.warn("[App Chat] Insufficient app credits", {
+      logger.warn("[App Chat] Insufficient cloud credits", {
         appId,
         userId: user.id,
         required: deductionResult.totalCost,
@@ -321,7 +321,7 @@ async function handlePOST(
             error: {
               message:
                 deductionResult.message ||
-                `Insufficient app credits. Required: $${deductionResult.totalCost.toFixed(4)}`,
+                `Insufficient credits. Required: $${deductionResult.totalCost.toFixed(4)}`,
               type: "insufficient_quota",
               code: "insufficient_app_credits",
               required: deductionResult.totalCost,

--- a/packages/cloud-api/v1/apps/[id]/generate-image/route.ts
+++ b/packages/cloud-api/v1/apps/[id]/generate-image/route.ts
@@ -427,7 +427,7 @@ app.post("/", async (c) => {
       return c.json(
         {
           success: false,
-          error: "Insufficient app credits",
+          error: "Insufficient credits",
           code: "insufficient_app_credits",
           required: deduction.totalCost,
           balance: deduction.newBalance,

--- a/packages/cloud-api/v1/chat/completions/route.ts
+++ b/packages/cloud-api/v1/chat/completions/route.ts
@@ -902,12 +902,15 @@ export async function handleChatCompletionsPOST(
         user.id,
         costWithMarkup.totalCost,
       );
+      // checkBalance() reads the user's org (cloud) credit balance — the same
+      // source deductCredits()/reconcileCredits() debit — not a per-app pool.
+      // Keep the wording consistent with the org-credits branch (re #8253).
       if (!balanceCheck.sufficient) {
         return addCorsHeaders(
           Response.json(
             {
               error: {
-                message: `Insufficient app credits. Required: $${costWithMarkup.totalCost.toFixed(4)}`,
+                message: `Insufficient credits. Required: $${costWithMarkup.totalCost.toFixed(4)}`,
                 type: "insufficient_quota",
                 code: "insufficient_credits",
               },

--- a/packages/cloud-api/v1/messages/route.ts
+++ b/packages/cloud-api/v1/messages/route.ts
@@ -595,10 +595,12 @@ app.post("/", async (c) => {
       costWithMarkup.totalCost,
     );
 
+    // checkBalance() reads the org (cloud) credit balance — same source as the
+    // org-credits branch and deductCredits(); keep the wording identical (#8253).
     if (!balanceCheck.sufficient) {
       return anthropicError(
         "rate_limit_error",
-        `Insufficient app credits. Required: $${costWithMarkup.totalCost.toFixed(4)}`,
+        `Insufficient credits. Required: $${costWithMarkup.totalCost.toFixed(4)}`,
         429,
       );
     }


### PR DESCRIPTION
## What
Several monetized-inference error surfaces say **"Insufficient app credits"** — implying a per-app credit pool — even though billing already runs against the user's **org (cloud) credit balance**.

`appCreditsService.deductCredits()` / `reconcileCredits()` were switched off the (now-stranded) `app_credit_balances` pool to the org balance, and `checkBalance()` reads the org balance too. The wording just never caught up.

Changes (message/comment only):
- `/v1/chat/completions`, `/v1/messages`, `/v1/apps/[id]/chat`, `/v1/apps/[id]/generate-image`: `Insufficient app credits` → `Insufficient credits`
- `/v1/apps/[id]/chat` log line → `Insufficient cloud credits`
- short comment at each pre-check noting `checkBalance()` reads the org balance

## Why
The "app credits" wording makes integrators think they must pre-fund a per-app pool (the stranded one) when users actually spend their org credits.

## Notes
Error `code`s left **unchanged** to avoid a contract break — text only. biome clean on the changed files; full suite via CI. Refs #8253.
