### PR TITLE
feat(cloud-sdk): add ElizaCloudClient.transcribeAudio() for voice/stt

### DIFF
--- a/packages/cloud-sdk/src/client.test.ts
+++ b/packages/cloud-sdk/src/client.test.ts
@@ -338,3 +338,51 @@ describe("ElizaCloudClient web sign-in + app-credits affordances", () => {
     ).rejects.toThrow(/expired/i);
   });
 });
+
+describe("ElizaCloudClient.transcribeAudio", () => {
+  it("POSTs multipart audio to /api/v1/voice/stt with X-App-Id", async () => {
+    let captured:
+      | { url: string; method?: string; headers: Headers; body: unknown }
+      | undefined;
+    const fetchImpl = (async (input, init = {}) => {
+      captured = {
+        url: String(input),
+        method: init.method,
+        headers: new Headers(init.headers),
+        body: init.body,
+      };
+      return new Response(
+        JSON.stringify({ transcript: "hello world", duration_ms: 1234 }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const client = new ElizaCloudClient({
+      baseUrl: "https://cloud.test",
+      apiKey: "eliza_test_key",
+      fetchImpl,
+    });
+    const res = await client.transcribeAudio(
+      {
+        audio: new Blob(["fake-audio"], { type: "audio/webm" }),
+        filename: "speech.webm",
+        languageCode: "en",
+      },
+      { appId: "app-123" },
+    );
+
+    expect(res).toEqual({ transcript: "hello world", duration_ms: 1234 });
+    expect(captured?.url).toContain("/api/v1/voice/stt");
+    expect(captured?.method).toBe("POST");
+    expect(captured?.headers.get("x-app-id")).toBe("app-123");
+    expect(captured?.headers.get("authorization")).toBe(
+      "Bearer eliza_test_key",
+    );
+    // A FormData body (not a JSON string) confirms multipart — the runtime sets
+    // the multipart boundary, so the SDK never forces application/json here.
+    expect(captured?.body).toBeInstanceOf(FormData);
+    const form = captured?.body as FormData;
+    expect(form.get("languageCode")).toBe("en");
+    expect(form.get("audio")).toBeInstanceOf(Blob);
+  });
+});

--- a/packages/cloud-sdk/src/client.ts
+++ b/packages/cloud-sdk/src/client.ts
@@ -78,6 +78,8 @@ import {
   type UpsertAffiliateCodeRequest,
   type UserProfileResponse,
   type VerifyAppCreditsCheckoutResponse,
+  type VoiceSttRequest,
+  type VoiceSttResponse,
   type WithdrawAppEarningsRequest,
   type WithdrawAppEarningsResponse,
   type X402FacilitatorPaymentRequest,
@@ -363,6 +365,30 @@ export class ElizaCloudClient {
       request,
       appIdRequestOptions(options.appId),
     );
+  }
+
+  /**
+   * Transcribe audio to text via POST /api/v1/voice/stt (multipart/form-data).
+   *
+   * Mirrors {@link createEmbeddings}/{@link generateImage}: routed through the
+   * v1 client with auth headers applied automatically, and `options.appId`
+   * bills a registered app's credits via the `X-App-Id` header. The audio is
+   * sent as a FormData `audio` field; Content-Type is intentionally left unset
+   * so the runtime fetch fills in the multipart boundary.
+   */
+  transcribeAudio(
+    request: VoiceSttRequest,
+    options: InferenceCallOptions = {},
+  ): Promise<VoiceSttResponse> {
+    const form = new FormData();
+    form.append("audio", request.audio, request.filename ?? "audio");
+    if (request.languageCode !== undefined) {
+      form.append("languageCode", request.languageCode);
+    }
+    return this.v1.request<VoiceSttResponse>("POST", "/voice/stt", {
+      ...appIdRequestOptions(options.appId),
+      body: form,
+    });
   }
 
   getCreditsBalance(

--- a/packages/cloud-sdk/src/types.ts
+++ b/packages/cloud-sdk/src/types.ts
@@ -199,6 +199,28 @@ export interface GenerateImageResponse {
   numImages?: number;
 }
 
+/** Audio input for {@link ElizaCloudClient.transcribeAudio}. */
+export interface VoiceSttRequest {
+  /**
+   * Audio payload as a Blob or File. In the browser pass the File/Blob from
+   * MediaRecorder; on the server wrap a Buffer, e.g.
+   * `new Blob([buffer], { type: "audio/webm" })`. Max 25MB.
+   */
+  audio: Blob;
+  /** Filename for the multipart part (the extension aids type detection). */
+  filename?: string;
+  /** Optional language hint forwarded to the STT provider. */
+  languageCode?: string;
+}
+
+/** Result of POST /api/v1/voice/stt. */
+export interface VoiceSttResponse {
+  /** Transcribed text. */
+  transcript: string;
+  /** Audio duration in milliseconds, measured server-side. */
+  duration_ms: number;
+}
+
 export interface CreditSummaryResponse extends Record<string, unknown> {
   success: true;
   organization: {


### PR DESCRIPTION
## What
Adds `ElizaCloudClient.transcribeAudio(request, options)` — a high-level helper for `POST /api/v1/voice/stt`, mirroring `createEmbeddings` / `generateImage`. Apps currently hand-roll the multipart POST (FormData + manual `Authorization` / `X-App-Id`) because there was no typed helper.

- `src/types.ts`: `VoiceSttRequest` (`audio: Blob`, `filename?`, `languageCode?`) + `VoiceSttResponse` (`transcript`, `duration_ms`)
- `src/client.ts`: `transcribeAudio()` builds FormData and routes through `this.v1.request("POST", "/voice/stt", { ...appIdRequestOptions(options.appId), body: form })`, so auth + `X-App-Id` billing are applied automatically and the runtime sets the multipart boundary (no forced `application/json`)
- `src/client.test.ts`: unit test asserting URL, method, `X-App-Id`, bearer auth, and a `FormData` body

## Why
So apps (e.g. wiki-speech-trainer) can drop their hand-rolled STT fetch and use the SDK everywhere, like the edad reference. Additive — no existing signatures change; types auto-export via `export type * from "./types.js"`.

## Verification
`bun run --cwd packages/cloud-sdk test` → 37 pass / 0 fail · `typecheck` → clean · biome clean.
