### PR TITLE
fix(cloud-e2e): boot cloud-api via the wrangler dev launcher

### DIFF
--- a/packages/test/cloud-e2e/.gitignore
+++ b/packages/test/cloud-e2e/.gitignore
@@ -1,0 +1,5 @@
+# Per-run process logs streamed by the stack fixture
+.logs/
+# Playwright output
+test-results/
+playwright-report/

--- a/packages/test/cloud-e2e/src/fixtures/stack.ts
+++ b/packages/test/cloud-e2e/src/fixtures/stack.ts
@@ -60,6 +60,7 @@ export interface StackHandle {
   stop: () => Promise<void>;
   urls: {
     api: string;
+    /** Empty string when the stack was started with `frontend: false`. */
     frontend: string;
     hetzner: string;
     controlPlane: string;
@@ -229,6 +230,12 @@ export interface StartCloudStackOptions {
   apiPort?: number;
   /** Override frontend port. Default: free port. */
   frontendPort?: number;
+  /**
+   * Boot the cloud-frontend Vite dev server. Defaults to true. Set to false for
+   * API-only stacks (e.g. the monetized-app loop) that never drive a browser —
+   * skips the Vite spawn + health wait, and leaves `urls.frontend` empty.
+   */
+  frontend?: boolean;
 }
 
 /**
@@ -327,11 +334,19 @@ export async function startCloudStack(
     );
   }
 
+  // Boot cloud-api through its wrangler dev launcher — the same entrypoint the
+  // cloud:mock stack uses (`bun run --cwd packages/cloud-api dev`). The earlier
+  // no-wrangler "e2e-server" adapter imported cloud-api straight from TypeScript
+  // source, which neither node (it can't load the extensionless `.ts` relative
+  // imports) nor bun (cloud-api's `@/…` path aliases need a tsconfig `baseUrl`
+  // that tsgo forbids) can resolve — only wrangler/esbuild bundling does. The
+  // `stripBunAncestryEnv` in env.ts exists precisely so wrangler starts from a
+  // bun-spawned context. wrangler pre-bundles, so requests are fast.
   procs.push(
     spawnLogged(
       "cloud-api",
-      "node",
-      ["packages/scripts/cloud/admin/dev/cloud-api-e2e-server.mjs"],
+      BUN,
+      ["run", "--cwd", "packages/cloud-api", "dev"],
       {
         env: stackEnv,
         cwd: REPO_ROOT,
@@ -346,32 +361,35 @@ export async function startCloudStack(
     label: "cloud-api",
   });
 
-  // 3. cloud-frontend Vite dev
-  const frontendEnv = {
-    ...stackEnv,
-    PORT: String(frontendPort),
-    VITE_API_BASE_URL: apiUrl,
-    VITE_API_PROXY_TARGET: apiUrl,
-    NEXT_PUBLIC_API_BASE_URL: apiUrl,
-  };
-  procs.push(
-    spawnLogged(
-      "cloud-frontend",
-      BUN,
-      ["run", "dev", "--", "--host", "127.0.0.1"],
-      {
-        env: frontendEnv,
-        cwd: join(REPO_ROOT, "packages", "cloud-frontend"),
-        logFile: join(LOG_DIR, "cloud-frontend.log"),
-      },
-    ),
-  );
+  // 3. cloud-frontend Vite dev (skipped for API-only stacks)
+  let frontendUrl = "";
+  if (opts.frontend !== false) {
+    const frontendEnv = {
+      ...stackEnv,
+      PORT: String(frontendPort),
+      VITE_API_BASE_URL: apiUrl,
+      VITE_API_PROXY_TARGET: apiUrl,
+      NEXT_PUBLIC_API_BASE_URL: apiUrl,
+    };
+    procs.push(
+      spawnLogged(
+        "cloud-frontend",
+        BUN,
+        ["run", "dev", "--", "--host", "127.0.0.1"],
+        {
+          env: frontendEnv,
+          cwd: join(REPO_ROOT, "packages", "cloud-frontend"),
+          logFile: join(LOG_DIR, "cloud-frontend.log"),
+        },
+      ),
+    );
 
-  const frontendUrl = `http://127.0.0.1:${frontendPort}`;
-  await waitForHttpOk(frontendUrl, {
-    timeoutMs: 120_000,
-    label: "cloud-frontend",
-  });
+    frontendUrl = `http://127.0.0.1:${frontendPort}`;
+    await waitForHttpOk(frontendUrl, {
+      timeoutMs: 120_000,
+      label: "cloud-frontend",
+    });
+  }
 
   let stopped = false;
   const stop = async () => {


### PR DESCRIPTION
## Problem

The cloud-e2e stack fixture cannot boot cloud-api. Since #8112 it launches `cloud-api-e2e-server.mjs`, which `import()`s the cloud-api worker straight from TypeScript source (`packages/cloud-api/src/index.ts`). Neither runtime can load it from source:

- **node** throws `ERR_MODULE_NOT_FOUND` on the first extensionless `.ts` relative import (`./worker-polyfills`);
- **bun** can't resolve cloud-api's `@/…` path aliases without a tsconfig `baseUrl`, which **tsgo** (the repo typechecker) rejects.

Only wrangler/esbuild bundling resolves the aliases. So `startCloudStack` times out at the cloud-api health wait, and every cloud-e2e spec — including the merged `monetized-app-loop.spec.ts` — can't run.

## Fix

Boot cloud-api through the same wrangler dev launcher `cloud:mock` already uses: `bun run --cwd packages/cloud-api dev`. The `stripBunAncestryEnv` in `env.ts` exists precisely so wrangler starts from a bun-spawned context. wrangler pre-bundles, so requests are fast (no per-request cold start).

Also add an opt-in `frontend?: false` option to `startCloudStack` for API-only stacks, and gitignore the fixture's runtime `.logs/`.

## Verification

Booted the API-only stack via this launcher and ran the full monetized-app loop (create → monetization → domains.buy with a real $14.95 credit debit → earnings → survival-economics) end to end against the mock: **ALL PASS**. This is the harness change that makes the already-merged `monetized-app-loop.spec.ts` (and the rest of the cloud-e2e suite) actually boot cloud-api.