### PR TITLE
fix(cloud-api): bill containers when earnings conversion fails

### DIFF
--- a/packages/cloud-api/cron/container-billing/route.ts
+++ b/packages/cloud-api/cron/container-billing/route.ts
@@ -211,27 +211,46 @@ async function processContainerBilling(
   // credits. Earnings → org credits conversion goes through
   // redeemableEarningsService so we get a credit_conversion ledger entry
   // for the audit trail.
-  const { fromEarnings, fromCredits } = plan;
+  let fromEarnings = plan.fromEarnings;
+  let fromCredits = plan.fromCredits;
 
   if (fromEarnings > 0 && org.earnings_source_user_id) {
-    const conversion = await redeemableEarningsService.convertToCredits({
-      userId: org.earnings_source_user_id,
-      amount: fromEarnings,
-      organizationId,
-      description: `Container hosting: ${containerName}`,
-      metadata: {
-        container_id: containerId,
-        container_name: containerName,
-        billing_type: "daily_container",
-        billing_period: now.toISOString().split("T")[0],
-      },
-    });
-    if (!conversion.success) {
+    try {
+      const conversion = await redeemableEarningsService.convertToCredits({
+        userId: org.earnings_source_user_id,
+        amount: fromEarnings,
+        organizationId,
+        description: `Container hosting: ${containerName}`,
+        metadata: {
+          container_id: containerId,
+          container_name: containerName,
+          billing_type: "daily_container",
+          billing_period: now.toISOString().split("T")[0],
+        },
+      });
+      if (!conversion.success) {
+        throw new Error("earnings conversion returned success=false");
+      }
+    } catch (conversionError) {
+      // convertToCredits debits the earnings ledger and THROWS on
+      // insufficient/contended earnings (it never returns success=false). The
+      // earnings were not debited, so do NOT spare credits by fromEarnings —
+      // charge the full day to credits. Previously this threw out of the whole
+      // handler, leaving the container unbilled (free hosting) for the day, and
+      // the unconditional `+ fromEarnings` below would have inflated the balance
+      // by undebited earnings.
       logger.error(
-        `[Container Billing] Earnings convert failed for ${containerName}`,
-        conversion,
+        `[Container Billing] Earnings convert failed for ${containerName}; charging full cost to credits`,
+        {
+          containerId,
+          error:
+            conversionError instanceof Error
+              ? conversionError.message
+              : String(conversionError),
+        },
       );
-      // Fall through: try to charge full cost to credits below.
+      fromEarnings = 0;
+      fromCredits = dailyCost;
     }
   }
 


### PR DESCRIPTION
## Problem

In the container-billing cron, `redeemableEarningsService.convertToCredits` **throws** on insufficient/contended earnings for a positive amount — it never returns `{ success: false }` (see `redeemable-earnings.ts` lines 769/774/796). So the guard

```ts
if (!conversion.success) { /* Fall through: try to charge full cost to credits below. */ }
```

is **dead code**, and the throw propagates out of `processContainerBilling` — the container is recorded as `error` and **never billed for the day (free hosting)**. The unconditional `newBalance = currentBalance + fromEarnings - dailyCost` would also have inflated the balance by earnings that were never debited.

## Fix

Wrap `convertToCredits` in try/catch. On failure, charge the full day to credits (`fromEarnings = 0`, `fromCredits = dailyCost`) — matching the documented intent — instead of aborting billing. This also closes the latent balance-inflation path.

The deeper hardening (per-(container, billing_period) idempotency on `convertToCredits`, gating `listBillableContainers` on `next_billing_at`, and recording the `credit_transactions` amount as `-fromCredits` for ledger reconciliation) is intentionally left as a follow-up since it needs a migration + a reconciliation-semantics decision.