### PR TITLE
fix(cloud-api): make container billing idempotent per period (no double-debit on cron re-run)

### DIFF
--- a/packages/cloud-api/cron/container-billing/route.ts
+++ b/packages/cloud-api/cron/container-billing/route.ts
@@ -23,7 +23,10 @@ import {
   CONTAINER_PRICING,
   calculateDailyContainerCost,
 } from "@/lib/constants/pricing";
-import { computeContainerBillingPlan } from "@/lib/services/container-billing-policy";
+import {
+  computeContainerBillingPeriod,
+  computeContainerBillingPlan,
+} from "@/lib/services/container-billing-policy";
 import { emailService } from "@/lib/services/email";
 import { redeemableEarningsService } from "@/lib/services/redeemable-earnings";
 import { logger } from "@/lib/utils/logger";
@@ -73,6 +76,7 @@ async function processContainerBilling(
     earnings_available: number;
   },
   appUrl: string,
+  now: Date,
 ): Promise<BillingResult> {
   const containerId = container.id;
   const containerName = container.name;
@@ -94,7 +98,9 @@ async function processContainerBilling(
   });
   const earningsAvailable = plan.earningsEligible;
   const totalAvailable = plan.totalAvailable;
-  const now = new Date();
+  // Day-aligned period this charge covers. Deterministic across same-day
+  // re-runs, so the idempotency key and unique indexes below all collide.
+  const { periodStart, periodEnd } = computeContainerBillingPeriod(now);
 
   logger.info(`[Container Billing] Processing ${containerName}`, {
     containerId,
@@ -182,8 +188,8 @@ async function processContainerBilling(
         containerId,
         organizationId,
         amount: dailyCost,
-        billingPeriodStart: now,
-        billingPeriodEnd: new Date(now.getTime() + 24 * 60 * 60 * 1000),
+        billingPeriodStart: periodStart,
+        billingPeriodEnd: periodEnd,
         errorMessage: `Insufficient funds: required $${dailyCost.toFixed(2)}, available $${totalAvailable.toFixed(4)} (credits $${currentBalance.toFixed(4)} + earnings $${earningsAvailable.toFixed(4)})`,
       });
 
@@ -221,11 +227,14 @@ async function processContainerBilling(
         amount: fromEarnings,
         organizationId,
         description: `Container hosting: ${containerName}`,
+        // Stable per container+period so a same-day cron re-run does not
+        // debit the owner's earnings twice.
+        idempotencyKey: `container:${containerId}:${periodStart.toISOString()}`,
         metadata: {
           container_id: containerId,
           container_name: containerName,
           billing_type: "daily_container",
-          billing_period: now.toISOString().split("T")[0],
+          billing_period: periodStart.toISOString().split("T")[0],
         },
       });
       if (!conversion.success) {
@@ -269,7 +278,26 @@ async function processContainerBilling(
       fromEarnings,
       fromCredits,
       now,
+      billingPeriodStart: periodStart,
+      billingPeriodEnd: periodEnd,
     });
+
+  // The row-lock guard found this period already billed (e.g. an overlapping
+  // cron run committed first). Earnings were not converted here either — the
+  // idempotency key short-circuited convertToCredits — so nothing was charged.
+  if (billingResult.alreadyBilled) {
+    logger.info(
+      `[Container Billing] Skipped ${containerName}: already billed this period`,
+      { containerId },
+    );
+    return {
+      containerId,
+      containerName,
+      organizationId,
+      action: "skipped",
+      error: "Already billed this period",
+    };
+  }
 
   logger.info(
     `[Container Billing] Billed ${containerName}: $${dailyCost.toFixed(4)} (earnings $${fromEarnings.toFixed(4)} + credits $${fromCredits.toFixed(4)})`,
@@ -315,11 +343,14 @@ async function handleContainerBilling(c: AppContext): Promise<Response> {
   try {
     requireCronSecret(c);
     const appUrl = c.env.NEXT_PUBLIC_APP_URL || "https://www.elizacloud.ai";
+    // One timestamp for the whole run: the due-gate, the period, and the
+    // row-lock idempotency guard must all agree on "now".
+    const runNow = new Date();
 
     logger.info("[Container Billing] Starting daily container billing run");
-    // Get all running containers that need billing
+    // Get all running containers that need billing (and are actually due).
     const runningContainers =
-      await containerBillingRepository.listBillableContainers();
+      await containerBillingRepository.listBillableContainers(runNow);
 
     if (runningContainers.length === 0) {
       logger.info("[Container Billing] No running containers to bill");
@@ -403,7 +434,12 @@ async function handleContainerBilling(c: AppContext): Promise<Response> {
       }
 
       try {
-        const result = await processContainerBilling(container, org, appUrl);
+        const result = await processContainerBilling(
+          container,
+          org,
+          appUrl,
+          runNow,
+        );
         results.push(result);
 
         if (result.action === "billed" && result.amount) {

--- a/packages/cloud-shared/src/db/migrations/0142_container_billing_idempotency.sql
+++ b/packages/cloud-shared/src/db/migrations/0142_container_billing_idempotency.sql
@@ -1,0 +1,26 @@
+-- Container-billing idempotency hardening.
+--
+-- 1. Earnings-conversion idempotency: at most one `credit_conversion` ledger
+--    entry per idempotency key (one container charge per period). Partial so
+--    only keyed conversions are constrained; pre-existing conversions carry no
+--    key and are unaffected, so this is safe on historical data.
+CREATE UNIQUE INDEX IF NOT EXISTS redeemable_earnings_ledger_conversion_idempotency_idx
+  ON redeemable_earnings_ledger ((metadata ->> 'idempotency_key'))
+  WHERE entry_type = 'credit_conversion' AND (metadata ->> 'idempotency_key') IS NOT NULL;
+
+-- 2. Dedupe any historical duplicate successful billing rows before adding the
+--    unique index, otherwise the index creation would fail on existing data.
+--    Keep the earliest row per (container, period) by (created_at, id).
+DELETE FROM container_billing_records cbr
+USING container_billing_records dup
+WHERE cbr.status = 'success'
+  AND dup.status = 'success'
+  AND cbr.container_id = dup.container_id
+  AND cbr.billing_period_start = dup.billing_period_start
+  AND (cbr.created_at, cbr.id) > (dup.created_at, dup.id);
+
+-- 3. Enforce at most one successful charge per container per billing period.
+--    Partial so retries of a failed/insufficient-credits period stay allowed.
+CREATE UNIQUE INDEX IF NOT EXISTS container_billing_records_period_unique
+  ON container_billing_records (container_id, billing_period_start)
+  WHERE status = 'success';

--- a/packages/cloud-shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud-shared/src/db/migrations/meta/_journal.json
@@ -981,6 +981,13 @@
       "when": 1779408800000,
       "tag": "0140_tenant_db_clusters",
       "breakpoints": true
+    },
+    {
+      "idx": 140,
+      "version": "7",
+      "when": 1779409000000,
+      "tag": "0142_container_billing_idempotency",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud-shared/src/db/repositories/container-billing.ts
+++ b/packages/cloud-shared/src/db/repositories/container-billing.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, isNull, lte, or } from "drizzle-orm";
 import { dbRead, dbWrite } from "../helpers";
 import { containerBillingRecords, containers } from "../schemas/containers";
 import { creditTransactions } from "../schemas/credit-transactions";
@@ -50,11 +50,22 @@ export interface RecordSuccessfulBillingInput {
   newBalance: number;
   fromEarnings: number;
   fromCredits: number;
+  /** Wall-clock time of this billing run (used for the row-lock period guard). */
   now: Date;
+  /** UTC-day-aligned start of the period this charge covers. */
+  billingPeriodStart: Date;
+  /** End of the period; also written to `next_billing_at`. */
+  billingPeriodEnd: Date;
 }
 
 export class ContainerBillingRepository {
-  async listBillableContainers(): Promise<BillableContainer[]> {
+  /**
+   * Containers due for billing as of `now`. Gating on `next_billing_at` (set
+   * to the end of the last billed period) makes the cron idempotent for the
+   * common case: a same-day re-run skips containers whose period is already
+   * paid. `null` means never billed → due immediately.
+   */
+  async listBillableContainers(now: Date): Promise<BillableContainer[]> {
     return await dbRead
       .select({
         id: containers.id,
@@ -76,6 +87,7 @@ export class ContainerBillingRepository {
         and(
           eq(containers.status, "running"),
           inArray(containers.billing_status, ["active", "warning", "shutdown_pending"]),
+          or(isNull(containers.next_billing_at), lte(containers.next_billing_at, now)),
         ),
       );
   }
@@ -152,9 +164,34 @@ export class ContainerBillingRepository {
 
   async recordSuccessfulDailyBilling(input: RecordSuccessfulBillingInput): Promise<{
     newBalance: number;
-    transactionId: string;
+    transactionId: string | null;
+    alreadyBilled: boolean;
   }> {
     return await dbWrite.transaction(async (tx) => {
+      // Idempotency guard: lock the container row and re-check whether it has
+      // already been billed for this period. `next_billing_at` is the end of
+      // the period last charged; if it is still in the future, the period is
+      // paid — skip without touching any balance. This closes the read→write
+      // race between listBillableContainers and this write (e.g. two concurrent
+      // cron invocations both selecting the container before either commits).
+      const [locked] = await tx
+        .select({ next_billing_at: containers.next_billing_at })
+        .from(containers)
+        .where(eq(containers.id, input.containerId))
+        .for("update");
+
+      if (locked?.next_billing_at && locked.next_billing_at > input.now) {
+        const [org] = await tx
+          .select({ credit_balance: organizations.credit_balance })
+          .from(organizations)
+          .where(eq(organizations.id, input.organizationId));
+        return {
+          newBalance: org ? Number(org.credit_balance) : input.newBalance,
+          transactionId: null,
+          alreadyBilled: true,
+        };
+      }
+
       await tx
         .update(organizations)
         .set({
@@ -163,19 +200,24 @@ export class ContainerBillingRepository {
         })
         .where(eq(organizations.id, input.organizationId));
 
+      // Record only the credit-balance movement (fromCredits). The earnings
+      // portion is debited from the redeemable-earnings ledger via
+      // convertToCredits, so charging the full dailyCost here would
+      // double-count it and break credit_balance == sum(credit_transactions).
       const [creditTx] = await tx
         .insert(creditTransactions)
         .values({
           organization_id: input.organizationId,
           user_id: input.userId,
-          amount: String(-input.dailyCost),
+          amount: String(-input.fromCredits),
           type: "debit",
           description: `Daily container billing: ${input.containerName}`,
           metadata: {
             container_id: input.containerId,
             container_name: input.containerName,
             billing_type: "daily_container",
-            billing_period: input.now.toISOString().split("T")[0],
+            billing_period: input.billingPeriodStart.toISOString().split("T")[0],
+            daily_cost: input.dailyCost.toFixed(4),
             paid_from_earnings: input.fromEarnings.toFixed(4),
             paid_from_credits: input.fromCredits.toFixed(4),
           },
@@ -187,7 +229,7 @@ export class ContainerBillingRepository {
         .update(containers)
         .set({
           last_billed_at: input.now,
-          next_billing_at: new Date(input.now.getTime() + 24 * 60 * 60 * 1000),
+          next_billing_at: input.billingPeriodEnd,
           billing_status: "active" as ContainerBillingStatus,
           shutdown_warning_sent_at: null,
           scheduled_shutdown_at: null,
@@ -200,14 +242,14 @@ export class ContainerBillingRepository {
         container_id: input.containerId,
         organization_id: input.organizationId,
         amount: String(input.dailyCost),
-        billing_period_start: input.now,
-        billing_period_end: new Date(input.now.getTime() + 24 * 60 * 60 * 1000),
+        billing_period_start: input.billingPeriodStart,
+        billing_period_end: input.billingPeriodEnd,
         status: "success",
         credit_transaction_id: creditTx.id,
         created_at: input.now,
       });
 
-      return { newBalance: input.newBalance, transactionId: creditTx.id };
+      return { newBalance: input.newBalance, transactionId: creditTx.id, alreadyBilled: false };
     });
   }
 }

--- a/packages/cloud-shared/src/db/schemas/containers.ts
+++ b/packages/cloud-shared/src/db/schemas/containers.ts
@@ -160,6 +160,11 @@ export const containerBillingRecords = pgTable(
     org_idx: index("container_billing_records_org_idx").on(table.organization_id),
     created_idx: index("container_billing_records_created_idx").on(table.created_at),
     status_idx: index("container_billing_records_status_idx").on(table.status),
+    // At most one successful charge per container per (day-aligned) period.
+    // Partial so retries of a failed/insufficient period are still allowed.
+    period_unique: uniqueIndex("container_billing_records_period_unique")
+      .on(table.container_id, table.billing_period_start)
+      .where(sql`${table.status} = 'success'`),
   }),
 );
 

--- a/packages/cloud-shared/src/db/schemas/redeemable-earnings.ts
+++ b/packages/cloud-shared/src/db/schemas/redeemable-earnings.ts
@@ -258,6 +258,13 @@ export const redeemableEarningsLedger = pgTable(
       table.earnings_source,
       table.source_id,
     ),
+    // Idempotency backstop for convertToCredits: at most one credit_conversion
+    // entry per idempotency key. Partial so it only constrains keyed rows.
+    conversion_idempotency_idx: uniqueIndex("redeemable_earnings_ledger_conversion_idempotency_idx")
+      .on(sql`(${table.metadata} ->> 'idempotency_key')`)
+      .where(
+        sql`${table.entry_type} = 'credit_conversion' and (${table.metadata} ->> 'idempotency_key') is not null`,
+      ),
   }),
 );
 

--- a/packages/cloud-shared/src/lib/services/__tests__/container-billing-idempotency.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/container-billing-idempotency.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Container-billing idempotency hardening (deeper-4b).
+ *
+ * Pins the defense-in-depth that keeps a cron re-run from double-debiting:
+ *  1. `computeContainerBillingPeriod` is deterministic per UTC day (pure).
+ *  2. `convertToCredits` is idempotent per `idempotencyKey` — a re-run returns
+ *     the original ledger entry and does NOT debit earnings again.
+ *  3. `listBillableContainers` gates on `next_billing_at` (already-paid periods
+ *     are skipped) and `recordSuccessfulDailyBilling`:
+ *       - row-locks the container and no-ops if the period is already billed,
+ *       - records the credit_transaction as `-fromCredits` (not `-dailyCost`)
+ *         so credit_balance reconciles with sum(credit_transactions).
+ *
+ * The DB-backed cases run against in-process PGlite so the real SQL (FOR UPDATE,
+ * the JSONB-keyed lookup, and the partial unique indexes from migration 0139)
+ * executes. They self-skip if PGlite is unavailable.
+ */
+
+import { beforeAll, describe, expect, test } from "bun:test";
+
+process.env.DATABASE_URL ||= "pglite://memory";
+process.env.NODE_ENV ||= "test";
+
+import { computeContainerBillingPeriod } from "../container-billing-policy";
+
+const PGLITE_TIMEOUT = 60000;
+
+const ORG_ID = "00000000-0000-0000-0000-0000000000a1";
+const USER_ID = "00000000-0000-0000-0000-0000000000b2";
+const CONTAINER_ID = "00000000-0000-0000-0000-0000000000c3";
+
+let dbWrite: typeof import("../../../db/client").dbWrite;
+let redeemableEarningsService: typeof import("../redeemable-earnings").redeemableEarningsService;
+let containerBillingRepository: typeof import("../../../db/repositories/container-billing").containerBillingRepository;
+let pgliteReady = true;
+
+beforeAll(async () => {
+  try {
+    ({ dbWrite } = await import("../../../db/client"));
+    ({ redeemableEarningsService } = await import("../redeemable-earnings"));
+    ({ containerBillingRepository } = await import("../../../db/repositories/container-billing"));
+
+    // Minimal schema: the columns these code paths touch + the unique indexes
+    // from migration 0139. FKs are omitted (single-table seams under test).
+    // drizzle's execute() uses the extended protocol — one statement per call.
+    const ddl = [
+      `CREATE TABLE IF NOT EXISTS redeemable_earnings (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id uuid NOT NULL,
+        total_earned numeric(18,4) NOT NULL DEFAULT '0',
+        total_redeemed numeric(18,4) NOT NULL DEFAULT '0',
+        total_pending numeric(18,4) NOT NULL DEFAULT '0',
+        available_balance numeric(18,4) NOT NULL DEFAULT '0',
+        earned_from_miniapps numeric(18,4) NOT NULL DEFAULT '0',
+        earned_from_agents numeric(18,4) NOT NULL DEFAULT '0',
+        earned_from_mcps numeric(18,4) NOT NULL DEFAULT '0',
+        earned_from_affiliates numeric(18,4) NOT NULL DEFAULT '0',
+        earned_from_app_owner_shares numeric(18,4) NOT NULL DEFAULT '0',
+        earned_from_creator_shares numeric(18,4) NOT NULL DEFAULT '0',
+        total_converted_to_credits numeric(18,4) NOT NULL DEFAULT '0',
+        last_earning_at timestamp,
+        last_redemption_at timestamp,
+        version numeric(10,0) NOT NULL DEFAULT '0',
+        created_at timestamp NOT NULL DEFAULT now(),
+        updated_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `CREATE TABLE IF NOT EXISTS redeemable_earnings_ledger (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id uuid NOT NULL,
+        entry_type text NOT NULL,
+        amount numeric(18,4) NOT NULL,
+        balance_after numeric(18,4) NOT NULL,
+        earnings_source text,
+        source_id uuid,
+        redemption_id uuid,
+        description text NOT NULL,
+        metadata jsonb NOT NULL DEFAULT '{}',
+        created_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `CREATE UNIQUE INDEX IF NOT EXISTS redeemable_earnings_ledger_conversion_idempotency_idx
+        ON redeemable_earnings_ledger ((metadata ->> 'idempotency_key'))
+        WHERE entry_type = 'credit_conversion' AND (metadata ->> 'idempotency_key') IS NOT NULL`,
+      `CREATE TABLE IF NOT EXISTS organizations (
+        id uuid PRIMARY KEY,
+        credit_balance numeric(20,6) NOT NULL DEFAULT '0',
+        updated_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `CREATE TABLE IF NOT EXISTS credit_transactions (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        organization_id uuid NOT NULL,
+        user_id uuid,
+        amount numeric(12,6) NOT NULL,
+        type text NOT NULL,
+        description text,
+        metadata jsonb NOT NULL DEFAULT '{}',
+        stripe_payment_intent_id text,
+        created_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `CREATE TABLE IF NOT EXISTS containers (
+        id uuid PRIMARY KEY,
+        name text NOT NULL,
+        project_name text NOT NULL,
+        organization_id uuid NOT NULL,
+        user_id uuid NOT NULL,
+        status text NOT NULL,
+        billing_status text NOT NULL,
+        desired_count integer NOT NULL DEFAULT 1,
+        cpu integer NOT NULL DEFAULT 1,
+        memory integer NOT NULL DEFAULT 1024,
+        shutdown_warning_sent_at timestamp,
+        scheduled_shutdown_at timestamp,
+        total_billed numeric(12,2) NOT NULL DEFAULT '0',
+        last_billed_at timestamp,
+        next_billing_at timestamp,
+        updated_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `CREATE TABLE IF NOT EXISTS container_billing_records (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        container_id uuid NOT NULL,
+        organization_id uuid NOT NULL,
+        amount numeric(10,2) NOT NULL,
+        billing_period_start timestamp NOT NULL,
+        billing_period_end timestamp NOT NULL,
+        status text NOT NULL DEFAULT 'success',
+        credit_transaction_id uuid,
+        error_message text,
+        created_at timestamp NOT NULL DEFAULT now()
+      )`,
+      `CREATE UNIQUE INDEX IF NOT EXISTS container_billing_records_period_unique
+        ON container_billing_records (container_id, billing_period_start)
+        WHERE status = 'success'`,
+    ];
+    for (const stmt of ddl) {
+      await dbWrite.execute(stmt);
+    }
+  } catch (error) {
+    pgliteReady = false;
+    console.warn("[container-billing-idempotency] PGlite unavailable, skipping DB cases:", error);
+  }
+}, PGLITE_TIMEOUT);
+
+describe("computeContainerBillingPeriod", () => {
+  test("normalizes to the UTC day regardless of time of day", () => {
+    const { periodStart, periodEnd } = computeContainerBillingPeriod(
+      new Date("2026-06-05T14:30:45.123Z"),
+    );
+    expect(periodStart.toISOString()).toBe("2026-06-05T00:00:00.000Z");
+    expect(periodEnd.toISOString()).toBe("2026-06-06T00:00:00.000Z");
+  });
+
+  test("is stable across two timestamps on the same UTC day", () => {
+    const a = computeContainerBillingPeriod(new Date("2026-06-05T00:00:01.000Z"));
+    const b = computeContainerBillingPeriod(new Date("2026-06-05T23:59:59.000Z"));
+    expect(a.periodStart.getTime()).toBe(b.periodStart.getTime());
+  });
+
+  test("rolls to a new period across the UTC midnight boundary", () => {
+    const a = computeContainerBillingPeriod(new Date("2026-06-05T23:59:59.000Z"));
+    const b = computeContainerBillingPeriod(new Date("2026-06-06T00:00:01.000Z"));
+    expect(a.periodStart.getTime()).not.toBe(b.periodStart.getTime());
+  });
+});
+
+describe("convertToCredits idempotency", () => {
+  test(
+    "same idempotencyKey debits earnings exactly once",
+    async () => {
+      if (!pgliteReady) return;
+      await dbWrite.execute(`DELETE FROM redeemable_earnings_ledger;`);
+      await dbWrite.execute(`DELETE FROM redeemable_earnings;`);
+      await dbWrite.execute(
+        `INSERT INTO redeemable_earnings (user_id, total_earned, available_balance)
+         VALUES ('${USER_ID}', '100', '100');`,
+      );
+
+      const key = "container:c3:2026-06-05T00:00:00.000Z";
+      const first = await redeemableEarningsService.convertToCredits({
+        userId: USER_ID,
+        amount: 0.67,
+        organizationId: ORG_ID,
+        description: "Container hosting: test",
+        idempotencyKey: key,
+      });
+      const second = await redeemableEarningsService.convertToCredits({
+        userId: USER_ID,
+        amount: 0.67,
+        organizationId: ORG_ID,
+        description: "Container hosting: test",
+        idempotencyKey: key,
+      });
+
+      expect(first.success).toBe(true);
+      expect(second.success).toBe(true);
+      // Idempotent: same ledger entry, balance debited only once.
+      expect(second.ledgerEntryId).toBe(first.ledgerEntryId);
+      expect(Number(first.newBalance)).toBeCloseTo(99.33, 4);
+      expect(Number(second.newBalance)).toBeCloseTo(99.33, 4);
+
+      const ledger = await dbWrite.execute(
+        `SELECT count(*)::int AS n FROM redeemable_earnings_ledger WHERE entry_type = 'credit_conversion';`,
+      );
+      const earnings = await dbWrite.execute(
+        `SELECT available_balance FROM redeemable_earnings WHERE user_id = '${USER_ID}';`,
+      );
+      expect((ledger.rows[0] as { n: number }).n).toBe(1);
+      expect(
+        Number((earnings.rows[0] as { available_balance: string }).available_balance),
+      ).toBeCloseTo(99.33, 4);
+    },
+    PGLITE_TIMEOUT,
+  );
+
+  test(
+    "a different key (next period) debits again",
+    async () => {
+      if (!pgliteReady) return;
+      const next = await redeemableEarningsService.convertToCredits({
+        userId: USER_ID,
+        amount: 0.67,
+        organizationId: ORG_ID,
+        description: "Container hosting: test",
+        idempotencyKey: "container:c3:2026-06-06T00:00:00.000Z",
+      });
+      expect(next.success).toBe(true);
+      expect(Number(next.newBalance)).toBeCloseTo(98.66, 4);
+
+      const ledger = await dbWrite.execute(
+        `SELECT count(*)::int AS n FROM redeemable_earnings_ledger WHERE entry_type = 'credit_conversion';`,
+      );
+      expect((ledger.rows[0] as { n: number }).n).toBe(2);
+    },
+    PGLITE_TIMEOUT,
+  );
+});
+
+describe("container billing gate + row-lock guard", () => {
+  test(
+    "gates by next_billing_at, records -fromCredits, and is idempotent on re-run",
+    async () => {
+      if (!pgliteReady) return;
+      await dbWrite.execute(`DELETE FROM container_billing_records;`);
+      await dbWrite.execute(`DELETE FROM credit_transactions;`);
+      await dbWrite.execute(`DELETE FROM containers;`);
+      await dbWrite.execute(`DELETE FROM organizations;`);
+      await dbWrite.execute(
+        `INSERT INTO organizations (id, credit_balance) VALUES ('${ORG_ID}', '50');`,
+      );
+      await dbWrite.execute(
+        `INSERT INTO containers (id, name, project_name, organization_id, user_id, status, billing_status, total_billed)
+         VALUES ('${CONTAINER_ID}', 'web', 'proj', '${ORG_ID}', '${USER_ID}', 'running', 'active', '0');`,
+      );
+
+      const now = new Date("2026-06-05T14:30:00.000Z");
+      const { periodStart, periodEnd } = computeContainerBillingPeriod(now);
+
+      // Never billed (next_billing_at null) → due.
+      const dueBefore = await containerBillingRepository.listBillableContainers(now);
+      expect(dueBefore.map((c) => c.id)).toContain(CONTAINER_ID);
+
+      const billInput = {
+        containerId: CONTAINER_ID,
+        organizationId: ORG_ID,
+        userId: USER_ID,
+        containerName: "web",
+        currentTotalBilled: "0",
+        dailyCost: 0.67,
+        newBalance: 49.33,
+        fromEarnings: 0,
+        fromCredits: 0.67,
+        now,
+        billingPeriodStart: periodStart,
+        billingPeriodEnd: periodEnd,
+      };
+
+      const firstBill = await containerBillingRepository.recordSuccessfulDailyBilling(billInput);
+      expect(firstBill.alreadyBilled).toBe(false);
+
+      // credit_transaction is the credit-balance movement only (-fromCredits).
+      const tx = await dbWrite.execute(
+        `SELECT amount FROM credit_transactions WHERE organization_id = '${ORG_ID}';`,
+      );
+      expect(tx.rows.length).toBe(1);
+      expect(Number((tx.rows[0] as { amount: string }).amount)).toBeCloseTo(-0.67, 6);
+
+      // Now gated out — next_billing_at advanced to the period end.
+      const dueAfter = await containerBillingRepository.listBillableContainers(now);
+      expect(dueAfter.map((c) => c.id)).not.toContain(CONTAINER_ID);
+
+      // Re-run for the same period: row-lock guard no-ops, no second debit.
+      const secondBill = await containerBillingRepository.recordSuccessfulDailyBilling(billInput);
+      expect(secondBill.alreadyBilled).toBe(true);
+      expect(secondBill.transactionId).toBeNull();
+
+      const txAfter = await dbWrite.execute(
+        `SELECT count(*)::int AS n FROM credit_transactions WHERE organization_id = '${ORG_ID}';`,
+      );
+      const recAfter = await dbWrite.execute(
+        `SELECT count(*)::int AS n FROM container_billing_records WHERE container_id = '${CONTAINER_ID}' AND status = 'success';`,
+      );
+      expect((txAfter.rows[0] as { n: number }).n).toBe(1);
+      expect((recAfter.rows[0] as { n: number }).n).toBe(1);
+    },
+    PGLITE_TIMEOUT,
+  );
+});

--- a/packages/cloud-shared/src/lib/services/container-billing-policy.ts
+++ b/packages/cloud-shared/src/lib/services/container-billing-policy.ts
@@ -80,3 +80,27 @@ export function computeContainerBillingPlan(
     earningsEligible,
   };
 }
+
+/** The billing window a single charge covers. */
+export interface ContainerBillingPeriod {
+  /** Inclusive start of the period (UTC midnight of the run day). */
+  periodStart: Date;
+  /** Exclusive end of the period (the next UTC midnight). */
+  periodEnd: Date;
+}
+
+/**
+ * Normalize a billing run timestamp to a deterministic, calendar-day-aligned
+ * period. Container billing is a daily model, so the period a charge covers is
+ * the UTC day it runs in — independent of the exact minute the cron fired.
+ *
+ * This determinism is load-bearing for idempotency: re-running the cron on the
+ * same UTC day yields the same `periodStart`, so the earnings-conversion
+ * idempotency key and the `container_billing_records(container_id,
+ * billing_period_start)` unique index both collide and prevent a double-debit.
+ */
+export function computeContainerBillingPeriod(now: Date): ContainerBillingPeriod {
+  const periodStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const periodEnd = new Date(periodStart.getTime() + 24 * 60 * 60 * 1000);
+  return { periodStart, periodEnd };
+}

--- a/packages/cloud-shared/src/lib/services/redeemable-earnings.ts
+++ b/packages/cloud-shared/src/lib/services/redeemable-earnings.ts
@@ -741,8 +741,16 @@ class RedeemableEarningsService {
     organizationId: string;
     description: string;
     metadata?: Record<string, unknown>;
+    /**
+     * Stable per-charge key (e.g. `container:<id>:<utc-day>`). When supplied,
+     * the conversion is idempotent: a re-run with the same key returns the
+     * original ledger entry instead of debiting earnings again. Enforced both
+     * here (lookup under the per-user advisory lock) and by a partial unique
+     * index on `redeemable_earnings_ledger((metadata->>'idempotency_key'))`.
+     */
+    idempotencyKey?: string;
   }): Promise<{ success: boolean; newBalance: number; ledgerEntryId: string; error?: string }> {
-    const { userId, amount, organizationId, description, metadata = {} } = params;
+    const { userId, amount, organizationId, description, metadata = {}, idempotencyKey } = params;
 
     if (amount <= 0) {
       return { success: false, newBalance: 0, ledgerEntryId: "", error: "Amount must be positive" };
@@ -752,6 +760,7 @@ class RedeemableEarningsService {
     const ledgerMetadata = normalizeLedgerMetadata({
       ...metadata,
       transaction_type: "credit_conversion",
+      ...(idempotencyKey ? { idempotency_key: idempotencyKey } : {}),
     });
 
     const result = await dbWrite.transaction(async (tx) => {
@@ -767,6 +776,27 @@ class RedeemableEarningsService {
 
       if (!earnings) {
         throw new Error("No earnings record found");
+      }
+
+      // Idempotency: if this exact charge was already converted, return the
+      // prior ledger entry without re-debiting. The advisory lock above
+      // serializes concurrent conversions for this user, so the prior entry is
+      // always visible here once committed.
+      if (idempotencyKey) {
+        const [existing] = await tx
+          .select({ id: redeemableEarningsLedger.id })
+          .from(redeemableEarningsLedger)
+          .where(
+            and(
+              eq(redeemableEarningsLedger.entry_type, "credit_conversion"),
+              sql`${redeemableEarningsLedger.metadata} ->> 'idempotency_key' = ${idempotencyKey}`,
+            ),
+          )
+          .limit(1);
+
+        if (existing) {
+          return { earnings, ledgerEntryId: existing.id, idempotent: true };
+        }
       }
 
       const available = new Decimal(earnings.available_balance);
@@ -809,15 +839,21 @@ class RedeemableEarningsService {
         })
         .returning();
 
-      return { earnings: updated, ledgerEntryId: ledgerEntry.id };
+      return { earnings: updated, ledgerEntryId: ledgerEntry.id, idempotent: false };
     });
 
-    logger.info("[RedeemableEarnings] Converted to org credits", {
-      userId: `${userId.slice(0, 8)}...`,
-      organizationId: `${organizationId.slice(0, 8)}...`,
-      amount,
-      newBalance: Number(result.earnings.available_balance),
-    });
+    logger.info(
+      result.idempotent
+        ? "[RedeemableEarnings] Skipped duplicate conversion (idempotent)"
+        : "[RedeemableEarnings] Converted to org credits",
+      {
+        userId: `${userId.slice(0, 8)}...`,
+        organizationId: `${organizationId.slice(0, 8)}...`,
+        amount,
+        idempotencyKey,
+        newBalance: Number(result.earnings.available_balance),
+      },
+    );
 
     return {
       success: true,


### PR DESCRIPTION
## What

Hardens the daily container-billing cron so a re-run (manual trigger, overlapping CF cron, retry) can never double-debit. Defense in depth across three layers, plus a billing reconciliation fix.

**Stacks on #8269** (the free-hosting fix). Until that merges, the diff here includes its single commit; afterward this shrinks to just the four new commits.

## Why

The cron had no idempotency: `convertToCredits` re-debited earnings on every call, `listBillableContainers` ignored the (written-but-never-read) `next_billing_at`, there was no app-level lock (CF cron provides none), and `credit_transactions` recorded `-dailyCost` while `credit_balance` only moved by `-fromCredits` — so the ledger overstated the credit debit by the earnings portion (which is already on the earnings ledger), breaking `credit_balance == sum(credit_transactions)`.

## How

- **Deterministic period.** `computeContainerBillingPeriod(now)` normalizes the run to its UTC day, so the period (and the key derived from it) is stable across same-day re-runs.
- **Earnings idempotency.** `convertToCredits` takes an optional `idempotencyKey` (`container:<id>:<utc-day>`); under the per-user advisory lock it returns the prior `credit_conversion` ledger entry instead of debiting again. Backed by a partial unique index on `redeemable_earnings_ledger((metadata->>'idempotency_key'))`.
- **Query gate.** `listBillableContainers(now)` skips containers whose `next_billing_at` is still in the future (already paid this period).
- **Row-lock guard.** `recordSuccessfulDailyBilling` locks the container row and no-ops if the period is already billed — closing the read→write race between listing and charging. Backed by a partial unique index on `container_billing_records(container_id, billing_period_start) WHERE status='success'`.
- **Reconciliation.** The `credit_transaction` now records `-fromCredits` (the actual credit-balance movement); `dailyCost` and the earnings/credits split stay in metadata.

## Migration (0139)

Adds both partial unique indexes and **dedupes any pre-existing duplicate `success` rows first** (keep earliest by `created_at,id`) so the index can be created on existing prod data — confirmed duplicates can exist today since nothing guarded against them. The ledger index is partial on a non-null key, so existing conversions (which carry no key) are unaffected.

## Verification

- `db:migrate` applies all 140 migrations from scratch incl. 0139 against the real cumulative schema — clean.
- New PGlite-backed suite (`container-billing-idempotency.test.ts`) exercises the real SQL (`FOR UPDATE`, the JSONB-keyed lookup, both partial unique indexes): earnings debit once per key, gate by `next_billing_at`, `-fromCredits` recorded, row-lock no-op on re-run.
- `cloud-shared` + `cloud-api` typecheck clean; biome clean; `db:check-migrations` passes.