### PR TITLE
feat(orchestrator): wire the child→parent USE_SKILL parent-agent broker dispatcher

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -62,6 +62,7 @@ function makeAcpService(session: SessionInfo): {
     updateSessionMetadata: ReturnType<typeof vi.fn>;
     getChangedPaths: ReturnType<typeof vi.fn>;
     stopSession: ReturnType<typeof vi.fn>;
+    sendToSession: ReturnType<typeof vi.fn>;
   };
   emit: (sessionId: string, event: string, data: unknown) => void;
 } {
@@ -84,6 +85,7 @@ function makeAcpService(session: SessionInfo): {
       },
     ),
     getChangedPaths: vi.fn((_id: string) => [] as string[]),
+    sendToSession: vi.fn(async (_id: string, _input: string) => ({})),
   };
   return {
     service,
@@ -2399,5 +2401,98 @@ describe("SubAgentRouter — deterministic session_state_lost recovery", () => {
     expect(metadata?.subAgentEvent).toBe("state_lost_exhausted");
     expect(metadata?.subAgentStatus).toBe("failed");
     expect(posted?.content?.text).toContain("could not be recovered");
+  });
+});
+
+describe("SubAgentRouter parent-agent dispatch", () => {
+  let session: SessionInfo;
+  let acp: ReturnType<typeof makeAcpService>;
+
+  beforeEach(() => {
+    session = makeSession();
+    acp = makeAcpService(session);
+  });
+
+  it("bridges a complete USE_SKILL parent-agent directive to the broker and replies", async () => {
+    const { runtime } = makeRuntime({ acp: acp.service });
+    const router = await SubAgentRouter.start(runtime);
+    try {
+      // list-cloud-commands needs no network/cloud key — the real broker
+      // renders the static catalog — so this exercises the full
+      // message -> extract -> broker -> sendToSession path.
+      acp.emit(SESSION_ID, "message", {
+        text: 'USE_SKILL parent-agent {"mode":"list-cloud-commands"}',
+      });
+      await new Promise((r) => setImmediate(r));
+
+      expect(acp.service.sendToSession).toHaveBeenCalledTimes(1);
+      const [sid, reply] = acp.service.sendToSession.mock.calls[0] as [
+        string,
+        string,
+      ];
+      expect(sid).toBe(SESSION_ID);
+      expect(reply.toLowerCase()).toContain("domains.buy");
+    } finally {
+      await router.stop();
+    }
+  });
+
+  it("reassembles a directive split across message chunks", async () => {
+    const { runtime } = makeRuntime({ acp: acp.service });
+    const router = await SubAgentRouter.start(runtime);
+    try {
+      for (const chunk of [
+        "Working on it. USE_SKILL parent-",
+        'agent {"mode":"list-cloud',
+        '-commands"}\ndone',
+      ]) {
+        acp.emit(SESSION_ID, "message", { text: chunk });
+      }
+      await new Promise((r) => setImmediate(r));
+      expect(acp.service.sendToSession).toHaveBeenCalledTimes(1);
+    } finally {
+      await router.stop();
+    }
+  });
+
+  it("ignores ordinary output without the marker", async () => {
+    const { runtime } = makeRuntime({ acp: acp.service });
+    const router = await SubAgentRouter.start(runtime);
+    try {
+      acp.emit(SESSION_ID, "message", {
+        text: "Just building the app, no broker needed here.",
+      });
+      await new Promise((r) => setImmediate(r));
+      expect(acp.service.sendToSession).not.toHaveBeenCalled();
+    } finally {
+      await router.stop();
+    }
+  });
+
+  it("stops dispatching after the per-session round-trip cap", async () => {
+    const { runtime } = makeRuntime({
+      acp: acp.service,
+      setting: { ACPX_SUB_AGENT_ROUND_TRIP_CAP: "1" },
+    });
+    const router = await SubAgentRouter.start(runtime);
+    try {
+      acp.emit(SESSION_ID, "message", {
+        text: 'USE_SKILL parent-agent {"mode":"list-cloud-commands"}',
+      });
+      await new Promise((r) => setImmediate(r));
+      acp.emit(SESSION_ID, "message", {
+        text: 'USE_SKILL parent-agent {"mode":"list-cloud-commands"}',
+      });
+      await new Promise((r) => setImmediate(r));
+
+      expect(acp.service.sendToSession).toHaveBeenCalledTimes(2);
+      const second = acp.service.sendToSession.mock.calls[1] as [
+        string,
+        string,
+      ];
+      expect(second[1]).toContain("round-trip cap");
+    } finally {
+      await router.stop();
+    }
   });
 });

--- a/plugins/plugin-agent-orchestrator/docs/economics-goal-runbook.md
+++ b/plugins/plugin-agent-orchestrator/docs/economics-goal-runbook.md
@@ -1,0 +1,95 @@
+# Economics `/goal` runbook — autonomous monetized-app loop
+
+How to drive (and what currently blocks) a `/goal` sub-agent that autonomously
+runs the monetized-app loop: create app → deploy container → enable monetization
+→ buy a domain → stay alive on earnings, with paid Cloud commands auto-authorized
+within a spend cap.
+
+## What already works (verified)
+
+- **Capped self-spend allowance.** `decideSpendAuthorization`
+  (`src/services/spend-allowance.ts`) gates each Cloud command by risk/cap, and
+  `runCloudCommand` (`src/services/parent-agent-broker.ts:1067`) emits the
+  structured `event: "spend_auto_authorized"` log when a self-spend command
+  auto-authorizes within `ELIZA_AGENT_SPEND_CAP_USD`. Confirmed by
+  `src/__tests__/parent-agent-broker.test.ts` › _capped self-spend allowance_
+  (4 cases pass: within-cap auto-authorizes, over-cap confirms, non-self-spend
+  mutating auto-authorizes).
+- **Economics capability profile.** `/economics` (or `/monetize`,
+  `/monetized-app`) in the composer sets `metadata.capabilityProfile = "economics"`
+  (`plugin-task-coordinator` composer directives → `createOrchestratorTask`), and
+  `spawnAgentForTask` reads `coerceGoalCapabilityProfile(task.metadata.capabilityProfile)`
+  and widens the goal fence via `ECONOMICS_GOAL_CAPABILITIES` (`goal-prompt.ts`).
+- **The Cloud loop itself.** `apps.create → monetization.update → domains.buy
+  (real credit debit) → earnings → survival economics` is exercised end-to-end
+  against the mock stack by
+  `packages/test/cloud-e2e/tests/monetized-app-loop.spec.ts`.
+
+## Runbook (once the dispatcher gap below is closed)
+
+1. Boot a stubbed-but-real Cloud so paid commands succeed without real money:
+
+   ```bash
+   CLOUD_E2E=1 NODE_ENV=test bun run cloud:mock --reset
+   # note the printed "Ready on http://127.0.0.1:<apiPort>"
+   ```
+
+2. Point the broker at the mock and arm the spend cap (these resolve through
+   `config-env.ts`, so the eliza config `env` section or process env both work):
+
+   ```bash
+   ELIZA_CLOUD_BASE_URL=http://127.0.0.1:<apiPort>
+   ELIZAOS_CLOUD_API_KEY=<a seeded org API key>      # see cloud-e2e seedTestUser
+   ELIZA_AGENT_SPEND_CAP_USD=20
+   ELIZA_ACP_DEFAULT_AGENT=opencode                   # or codex/claude with their keys
+   ```
+
+3. Create an economics task — `/economics build and monetize a tiny app` in the
+   composer, or `POST /api/orchestrator` with
+   `metadata: { capabilityProfile: "economics" }`.
+
+4. The sub-agent loads the `build-monetized-app` skill and should drive the loop
+   through the parent-agent broker. Watch the logs for
+   `event: "spend_auto_authorized"` on `domains.buy` / `containers.create` —
+   that line is the proof the agent spent within its cap without a human prompt.
+
+   - **Domains gotcha:** `domains.buy` (and `media.*`/`promote.*`) resolve to
+     unknown cost and stall on confirmation unless the agent first calls
+     `domains.check` and threads the quote into `params.spendEstimateUsd`.
+     `containers.create` has a built-in `$0.67/day` estimate, so it
+     auto-authorizes without a hint.
+
+## Blocker: no production path from a sub-agent to the broker
+
+`runCloudCommand` (the only emitter of `spend_auto_authorized`) is **not reachable
+by a live agent today** — the mechanism is unit-tested but unwired:
+
+- `runParentAgentBroker` / `PARENT_AGENT_BROKER_MANIFEST_ENTRY` have **no
+  production caller** (only the test invokes them).
+- `buildSkillsManifest({ virtualSkills })` is never called, so a spawned child
+  never receives a `SKILLS.md` advertising the `parent-agent` slug or its arg
+  shape.
+- There is **no `USE_SKILL parent-agent` dispatcher** — nothing parses a child's
+  `USE_SKILL parent-agent {…}` request and calls `runCloudCommand`.
+
+So a `/economics` sub-agent can read the (advisory) capability fence but has no
+executable path to run `apps.create` / `containers.create` / `domains.buy`
+through the capped broker. **Verifying `spend_auto_authorized` via the Vitest
+above is the current proof-of-mechanism.**
+
+### To close it (smallest path to a live demo)
+
+1. **Dispatch.** In the ACP session-event path (or `SubAgentRouter`), detect a
+   sub-agent message `USE_SKILL parent-agent <json>`, parse it, call
+   `runParentAgentBroker({ runtime, sessionId, session, args })`, and send
+   `result.text` back via `acp.sendToSession`.
+2. **Advertise.** In `spawnAgentForTask`, when `capabilityProfile === "economics"`,
+   call `buildSkillsManifest(runtime, { recommendedSlugs: ["build-monetized-app",
+   "eliza-cloud"], virtualSkills: [PARENT_AGENT_BROKER_MANIFEST_ENTRY] })` and write
+   it as `SKILLS.md` in the workdir so the child learns the slug + arg contract.
+3. **Estimate.** Encourage (skill prose) calling `domains.check` first and passing
+   the price as `spendEstimateUsd` on `domains.buy`, or seed a small built-in
+   estimate so the demo's first paid step auto-authorizes.
+
+See `default-eliza-skills-and-agent-bridge-plan.md` for the broader bridge design;
+this runbook is the economics-specific slice.

--- a/plugins/plugin-agent-orchestrator/docs/economics-goal-runbook.md
+++ b/plugins/plugin-agent-orchestrator/docs/economics-goal-runbook.md
@@ -25,7 +25,7 @@ within a spend cap.
   against the mock stack by
   `packages/test/cloud-e2e/tests/monetized-app-loop.spec.ts`.
 
-## Runbook (once the dispatcher gap below is closed)
+## Runbook
 
 1. Boot a stubbed-but-real Cloud so paid commands succeed without real money:
 
@@ -34,6 +34,17 @@ within a spend cap.
    # note the printed "Ready on http://127.0.0.1:<apiPort>"
    ```
 
+   `cloud:mock` opens its PGlite store as a single-writer file, so you cannot
+   seed an org/API key from a second process while it runs. To seed live (and to
+   give the broker a key the granular per-route permission gate accepts), boot
+   through the cloud-e2e stack fixture instead — it stands up a PGlite **TCP
+   bridge** + the same wrangler launcher, then `seedTestUser()` mints an org with
+   credits + an API key. Mint the key with `permissions: ["*"]` if you want the
+   actual `containers.create` / `domains.buy` cloud calls to succeed (the default
+   `read/write/admin` seed key still proves `spend_auto_authorized`, because that
+   log fires from the cap decision *before* the HTTP call — but the call itself
+   401s on routes that require granular scopes like `containers:write`).
+
 2. Point the broker at the mock and arm the spend cap (these resolve through
    `config-env.ts`, so the eliza config `env` section or process env both work):
 
@@ -41,16 +52,18 @@ within a spend cap.
    ELIZA_CLOUD_BASE_URL=http://127.0.0.1:<apiPort>
    ELIZAOS_CLOUD_API_KEY=<a seeded org API key>      # see cloud-e2e seedTestUser
    ELIZA_AGENT_SPEND_CAP_USD=20
-   ELIZA_ACP_DEFAULT_AGENT=opencode                   # or codex/claude with their keys
+   ELIZA_ACP_DEFAULT_AGENT=opencode                   # Cerebras auto-detected; or codex/claude with their keys
+   OPENCODE_DISABLE_AUTOUPDATE=1                       # opencode's network update check can blow the spawn timeout
+   ACPX_DEFAULT_TIMEOUT_MS=600000                      # first opencode init (compile + provider fetch) ~3-5min
    ```
 
 3. Create an economics task — `/economics build and monetize a tiny app` in the
    composer, or `POST /api/orchestrator` with
    `metadata: { capabilityProfile: "economics" }`.
 
-4. The sub-agent loads the `build-monetized-app` skill and should drive the loop
-   through the parent-agent broker. Watch the logs for
-   `event: "spend_auto_authorized"` on `domains.buy` / `containers.create` —
+4. The sub-agent loads the `build-monetized-app` skill and SKILLS.md and drives
+   the loop through the parent-agent broker. Watch the logs for
+   `event: "spend_auto_authorized"` on `containers.create` / `domains.buy` —
    that line is the proof the agent spent within its cap without a human prompt.
 
    - **Domains gotcha:** `domains.buy` (and `media.*`/`promote.*`) resolve to
@@ -58,6 +71,9 @@ within a spend cap.
      `domains.check` and threads the quote into `params.spendEstimateUsd`.
      `containers.create` has a built-in `$0.67/day` estimate, so it
      auto-authorizes without a hint.
+   - **`containers.create` needs a `name`** in addition to `appId`/`image`, or
+     the cloud call 422s (the spend log still fires; the deploy record is not
+     created). A capable agent self-corrects via `list-cloud-commands`.
 
 ## Sub-agent → broker dispatcher (now wired)
 
@@ -85,10 +101,40 @@ closed:
 
 The directive parser and the broker→`sendToSession` bridge are unit-tested in
 `src/__tests__/parent-agent-dispatch.test.ts`; `spend_auto_authorized` itself
-stays covered by `parent-agent-broker.test.ts`. End-to-end confirmation still
-needs a live ACP backend (`ELIZA_ACP_DEFAULT_AGENT=opencode`, the broker pointed
-at `cloud:mock`) — follow the runbook steps above to watch the
-`spend_auto_authorized` line on a real `domains.buy` / `containers.create`.
+stays covered by `parent-agent-broker.test.ts`.
+
+## Live verification (2026-06-06)
+
+The full loop was run end-to-end against `cloud:mock` with a real
+`opencode` ACP child on a Cerebras key (`gpt-oss-120b`) — no human in the loop:
+
+- The child read `SKILLS.md`, then drove `cloud.health → apps.create →
+  containers.create` entirely through `USE_SKILL parent-agent {…}` directives.
+  `apps.create` created a real app; `containers.create` self-authorized within
+  the cap and emitted, verbatim:
+  `event:"spend_auto_authorized" command:"containers.create" risk:"paid"
+  estimatedCostUsd:0.67 runningTotalUsd:0.67 capUsd:20 reason:"within-cap"`.
+  When the first `containers.create` 422'd (missing `name`), the child called
+  `list-cloud-commands`, corrected the params, and re-authorized — no human turn.
+- The `domains.buy` self-resolve path was verified at the broker level against
+  the same live mock: `domains.check` returned a `$14.95` quote, that price was
+  threaded into `params.spendEstimateUsd`, `domains.buy` emitted
+  `spend_auto_authorized` ($14.95 of the $20 cap), and the org credit balance
+  dropped **1000.00 → 985.05** — a real debit.
+
+Two defects the live run surfaced (both fixed):
+
+1. **Windows env forwarding (`acp-service.ts`).** `shouldForwardEnv` matched
+   `PATH` case-sensitively, but the repo runtime is Bun and Bun-on-Windows
+   reports the key as `Path` — so ACP sub-agents spawned with NO `PATH` and the
+   opencode shim died with `'bun' is not recognized`. Now matched
+   case-insensitively (+ Windows system vars), with the path key canonicalized
+   to `PATH` in `buildEnv`.
+2. **Mid-turn reply delivery (`parent-agent-dispatch.ts`).** A child emits its
+   directive *mid-turn* and ends the turn awaiting the reply; delivering the
+   reply is a new prompt, which the transport rejects ("session is already
+   busy") until the turn finishes. The old code dropped the reply, stalling the
+   loop on the first directive. Delivery now retries until the session goes idle.
 
 See `default-eliza-skills-and-agent-bridge-plan.md` for the broader bridge design;
 this runbook is the economics-specific slice.

--- a/plugins/plugin-agent-orchestrator/docs/economics-goal-runbook.md
+++ b/plugins/plugin-agent-orchestrator/docs/economics-goal-runbook.md
@@ -59,37 +59,36 @@ within a spend cap.
      `containers.create` has a built-in `$0.67/day` estimate, so it
      auto-authorizes without a hint.
 
-## Blocker: no production path from a sub-agent to the broker
+## Sub-agent → broker dispatcher (now wired)
 
-`runCloudCommand` (the only emitter of `spend_auto_authorized`) is **not reachable
-by a live agent today** — the mechanism is unit-tested but unwired:
+`runCloudCommand` (the only emitter of `spend_auto_authorized`) is now reachable
+by a live agent. The three gaps the earlier draft of this runbook called out are
+closed:
 
-- `runParentAgentBroker` / `PARENT_AGENT_BROKER_MANIFEST_ENTRY` have **no
-  production caller** (only the test invokes them).
-- `buildSkillsManifest({ virtualSkills })` is never called, so a spawned child
-  never receives a `SKILLS.md` advertising the `parent-agent` slug or its arg
-  shape.
-- There is **no `USE_SKILL parent-agent` dispatcher** — nothing parses a child's
-  `USE_SKILL parent-agent {…}` request and calls `runCloudCommand`.
+1. **Dispatch.** `SubAgentRouter.handleEvent` accumulates the child's streamed
+   `message` text and, when a complete `USE_SKILL parent-agent <json>` directive
+   appears, bridges it to `runParentAgentBroker({ runtime, sessionId, session,
+   args })` and streams `result.text` back via `acp.sendToSession`
+   (`src/services/parent-agent-dispatch.ts`). Detection is marker-guarded (it
+   only acts on text containing `USE_SKILL parent-agent`, which ordinary coding
+   tasks never emit) and capped by `ACPX_SUB_AGENT_ROUND_TRIP_CAP`.
+2. **Advertise.** `spawnAgentForTask` writes a `SKILLS.md` into the workdir for
+   `capabilityProfile === "economics"` tasks via `buildSkillsManifest(runtime, {
+   recommendedSlugs: ["build-monetized-app", "eliza-cloud"], virtualSkills:
+   [PARENT_AGENT_BROKER_MANIFEST_ENTRY] })`, so the child learns the `parent-agent`
+   slug and its arg contract.
+3. **Estimate.** The broker's unknown-cost stall now returns an *actionable*
+   instruction ("fetch a quote with `domains.check` and retry with
+   `params.spendEstimateUsd`") instead of a human-only yes/no, and the manifest
+   guidance advertises the same pattern — so an autonomous agent self-authorizes
+   `domains.buy` within the cap without a human turn.
 
-So a `/economics` sub-agent can read the (advisory) capability fence but has no
-executable path to run `apps.create` / `containers.create` / `domains.buy`
-through the capped broker. **Verifying `spend_auto_authorized` via the Vitest
-above is the current proof-of-mechanism.**
-
-### To close it (smallest path to a live demo)
-
-1. **Dispatch.** In the ACP session-event path (or `SubAgentRouter`), detect a
-   sub-agent message `USE_SKILL parent-agent <json>`, parse it, call
-   `runParentAgentBroker({ runtime, sessionId, session, args })`, and send
-   `result.text` back via `acp.sendToSession`.
-2. **Advertise.** In `spawnAgentForTask`, when `capabilityProfile === "economics"`,
-   call `buildSkillsManifest(runtime, { recommendedSlugs: ["build-monetized-app",
-   "eliza-cloud"], virtualSkills: [PARENT_AGENT_BROKER_MANIFEST_ENTRY] })` and write
-   it as `SKILLS.md` in the workdir so the child learns the slug + arg contract.
-3. **Estimate.** Encourage (skill prose) calling `domains.check` first and passing
-   the price as `spendEstimateUsd` on `domains.buy`, or seed a small built-in
-   estimate so the demo's first paid step auto-authorizes.
+The directive parser and the broker→`sendToSession` bridge are unit-tested in
+`src/__tests__/parent-agent-dispatch.test.ts`; `spend_auto_authorized` itself
+stays covered by `parent-agent-broker.test.ts`. End-to-end confirmation still
+needs a live ACP backend (`ELIZA_ACP_DEFAULT_AGENT=opencode`, the broker pointed
+at `cloud:mock`) — follow the runbook steps above to watch the
+`spend_auto_authorized` line on a real `domains.buy` / `containers.create`.
 
 See `default-eliza-skills-and-agent-bridge-plan.md` for the broader bridge design;
 this runbook is the economics-specific slice.

--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-dispatch.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-dispatch.test.ts
@@ -146,4 +146,76 @@ describe("dispatchParentAgentDirective", () => {
     });
     expect(result.ok).toBe(false);
   });
+
+  // Regression: a child streams its directive mid-turn and then ends the turn to
+  // await the reply. Delivering the reply is a new prompt, which the transport
+  // rejects with "session is already busy" until the turn finishes — so the
+  // dispatcher must retry until the session goes idle instead of dropping it
+  // (a dropped reply stalls the loop on its first directive).
+  it("retries delivery while the child turn is still in flight (session busy)", async () => {
+    let attempts = 0;
+    const acp = {
+      sendToSession: async (sessionId: string) => {
+        attempts++;
+        if (attempts < 3) {
+          throw new Error(`ACP session is already busy: ${sessionId}`);
+        }
+        return {} as unknown as ReturnType<
+          import("../services/acp-service.js").AcpService["sendToSession"]
+        >;
+      },
+    };
+    const result = await dispatchParentAgentDirective({
+      runtime: createRuntime(),
+      acp,
+      sessionId: "sess-3",
+      args: { mode: "list-cloud-commands" },
+    });
+    expect(attempts).toBe(3);
+    expect(result.ok).toBe(true);
+  }, 10_000);
+
+  it("stops retrying and reports failure once the busy deadline passes", async () => {
+    vi.useFakeTimers();
+    try {
+      let calls = 0;
+      const acp = {
+        sendToSession: async (sessionId: string) => {
+          calls++;
+          throw new Error(`ACP session is already busy: ${sessionId}`);
+        },
+      };
+      const p = dispatchParentAgentDirective({
+        runtime: createRuntime(),
+        acp,
+        sessionId: "sess-4",
+        args: { mode: "list-cloud-commands" },
+      });
+      // Drive the fake clock past the delivery deadline; the loop must give up.
+      await vi.advanceTimersByTimeAsync(300_001);
+      const result = await p;
+      expect(result.ok).toBe(false);
+      expect(calls).toBeGreaterThan(1); // it retried — did not bail after one attempt
+    } finally {
+      vi.useRealTimers();
+    }
+  }, 20_000);
+
+  it("does not retry a terminal (non-busy) delivery error", async () => {
+    let calls = 0;
+    const acp = {
+      sendToSession: async () => {
+        calls++;
+        throw new Error("session lost");
+      },
+    };
+    const result = await dispatchParentAgentDirective({
+      runtime: createRuntime(),
+      acp,
+      sessionId: "sess-5",
+      args: { mode: "list-cloud-commands" },
+    });
+    expect(result.ok).toBe(false);
+    expect(calls).toBe(1);
+  });
 });

--- a/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-dispatch.test.ts
+++ b/plugins/plugin-agent-orchestrator/src/__tests__/parent-agent-dispatch.test.ts
@@ -1,0 +1,149 @@
+import type { IAgentRuntime } from "@elizaos/core";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  dispatchParentAgentDirective,
+  extractParentAgentDirective,
+  PARENT_AGENT_DIRECTIVE_MARKER,
+  parentAgentMarkerIndex,
+} from "../services/parent-agent-dispatch.js";
+import { resetSessionSpendUsd } from "../services/spend-allowance.js";
+
+function createRuntime(overrides: Partial<IAgentRuntime> = {}): IAgentRuntime {
+  const cache = new Map<string, unknown>();
+  return {
+    logger: {
+      debug: () => undefined,
+      info: () => undefined,
+      warn: () => undefined,
+      error: () => undefined,
+    },
+    getCache: async (key: string) => cache.get(key),
+    setCache: async (key: string, value: unknown) => {
+      cache.set(key, value);
+    },
+    deleteCache: async (key: string) => {
+      cache.delete(key);
+    },
+    ...overrides,
+  } as IAgentRuntime;
+}
+
+describe("extractParentAgentDirective", () => {
+  it("uses the canonical marker", () => {
+    expect(PARENT_AGENT_DIRECTIVE_MARKER).toBe("USE_SKILL parent-agent");
+  });
+
+  it("returns null when no marker is present", () => {
+    expect(extractParentAgentDirective("just some agent output")).toBeNull();
+    expect(parentAgentMarkerIndex("nope")).toBe(-1);
+  });
+
+  it("parses a complete directive embedded in surrounding text", () => {
+    const text =
+      'Let me check the cloud.\nUSE_SKILL parent-agent {"mode":"list-cloud-commands"}\nDone.';
+    const d = extractParentAgentDirective(text);
+    expect(d).not.toBeNull();
+    expect(d?.args).toEqual({ mode: "list-cloud-commands" });
+    // endIndex points just past the closing brace.
+    expect(text.slice(d?.endIndex)).toBe("\nDone.");
+  });
+
+  it("tolerates a markdown backtick before the JSON", () => {
+    const d = extractParentAgentDirective(
+      'USE_SKILL parent-agent `{"mode":"list-actions","query":"github"}`',
+    );
+    expect(d?.args).toEqual({ mode: "list-actions", query: "github" });
+  });
+
+  it("returns null while the JSON is still streaming (unbalanced)", () => {
+    expect(
+      extractParentAgentDirective('USE_SKILL parent-agent {"mode":"cloud-comm'),
+    ).toBeNull();
+    expect(
+      extractParentAgentDirective(
+        'USE_SKILL parent-agent {"command":"domains.buy","params":{',
+      ),
+    ).toBeNull();
+  });
+
+  it("does not end the object early on braces inside string values", () => {
+    const d = extractParentAgentDirective(
+      'USE_SKILL parent-agent {"request":"use the {weird} value","mode":"ask"}',
+    );
+    expect(d?.args).toEqual({ request: "use the {weird} value", mode: "ask" });
+  });
+
+  it("handles nested params objects", () => {
+    const d = extractParentAgentDirective(
+      'USE_SKILL parent-agent {"mode":"cloud-command","command":"domains.buy","params":{"domain":"x.com","spendEstimateUsd":14.95}}',
+    );
+    expect(d?.args).toEqual({
+      mode: "cloud-command",
+      command: "domains.buy",
+      params: { domain: "x.com", spendEstimateUsd: 14.95 },
+    });
+  });
+
+  it("returns null for balanced-but-malformed JSON (dead marker)", () => {
+    expect(
+      extractParentAgentDirective("USE_SKILL parent-agent {not json}"),
+    ).toBeNull();
+  });
+
+  it("returns null when the marker is followed by non-JSON prose", () => {
+    expect(
+      extractParentAgentDirective("USE_SKILL parent-agent please do the thing"),
+    ).toBeNull();
+  });
+});
+
+describe("dispatchParentAgentDirective", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    resetSessionSpendUsd();
+  });
+
+  it("runs the directive through the broker and streams the reply to the session", async () => {
+    const sent: Array<{ sessionId: string; input: string }> = [];
+    const acp = {
+      sendToSession: async (sessionId: string, input: string) => {
+        sent.push({ sessionId, input });
+        return { ok: true } as unknown as ReturnType<
+          import("../services/acp-service.js").AcpService["sendToSession"]
+        >;
+      },
+    };
+
+    // list-cloud-commands needs no network/cloud key — it renders the static
+    // command catalog — so this exercises the full broker→sendToSession bridge.
+    const result = await dispatchParentAgentDirective({
+      runtime: createRuntime(),
+      acp,
+      sessionId: "sess-1",
+      args: { mode: "list-cloud-commands" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].sessionId).toBe("sess-1");
+    // The reply is the broker's command catalog text.
+    expect(sent[0].input.toLowerCase()).toContain("domains.buy");
+    expect(result.reply).toBe(sent[0].input);
+  });
+
+  it("reports a delivery failure without throwing", async () => {
+    const acp = {
+      sendToSession: async () => {
+        throw new Error("session gone");
+      },
+    };
+    const result = await dispatchParentAgentDirective({
+      runtime: createRuntime(),
+      acp,
+      sessionId: "sess-2",
+      args: { mode: "list-cloud-commands" },
+    });
+    expect(result.ok).toBe(false);
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/orchestrator-task-service.ts
@@ -18,6 +18,8 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { type IAgentRuntime, Service } from "@elizaos/core";
 import { AcpService } from "./acp-service.js";
 import { assignAgentName } from "./agent-name-assignment.js";
@@ -60,6 +62,8 @@ import {
   TERMINAL_TASK_STATUSES,
   type UsageState,
 } from "./orchestrator-task-types.js";
+import { PARENT_AGENT_BROKER_MANIFEST_ENTRY } from "./parent-agent-broker.js";
+import { buildSkillsManifest } from "./skill-manifest.js";
 import type { ApprovalPreset } from "./types.js";
 import {
   ensureTaskWorkdir,
@@ -1346,6 +1350,25 @@ export class OrchestratorTaskService extends Service {
       repo: opts.repo,
       ...(capabilityProfile ? { capabilityProfile } : {}),
     });
+
+    // Economics tasks drive the monetized-app loop through the parent-agent
+    // Cloud command broker. Write a SKILLS.md into the workdir that advertises
+    // the broker slug + its arg contract so the spawned agent knows how to call
+    // back (the dispatcher in SubAgentRouter executes those requests).
+    if (capabilityProfile === "economics" && workdir) {
+      try {
+        const manifest = await buildSkillsManifest(this.runtime, {
+          recommendedSlugs: ["build-monetized-app", "eliza-cloud"],
+          virtualSkills: [{ ...PARENT_AGENT_BROKER_MANIFEST_ENTRY }],
+        });
+        await writeFile(join(workdir, "SKILLS.md"), manifest.markdown, "utf8");
+      } catch (err) {
+        this.runtime.logger?.warn?.(
+          { src: "orchestrator-task-service", taskId, workdir },
+          `failed to write SKILLS.md: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
 
     const result = await acp.spawnSession({
       // Default the orchestrator's coding agent to the vendored opencode

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-broker.ts
@@ -30,7 +30,7 @@ export const PARENT_AGENT_BROKER_MANIFEST_ENTRY = {
   description:
     "Task-scoped bridge for asking the running parent Eliza agent to use its loaded capabilities, actions, providers, connectors, and confirmation flow.",
   guidance:
-    'Use when workspace context is not enough and the parent agent should do something with its own capabilities. Examples: `USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}`, `USE_SKILL parent-agent {"mode":"list-actions","query":"github"}`, `USE_SKILL parent-agent {"mode":"list-cloud-commands"}`, or `USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}`. Mutating, paid, or destructive Cloud commands require an explicit user yes on a follow-up turn (not LLM `confirmed`).',
+    'Use when workspace context is not enough and the parent agent should do something with its own capabilities. Examples: `USE_SKILL parent-agent {"request":"Find the next free 30 minute slot on my calendar"}`, `USE_SKILL parent-agent {"mode":"list-actions","query":"github"}`, `USE_SKILL parent-agent {"mode":"list-cloud-commands"}`, or `USE_SKILL parent-agent {"mode":"cloud-command","command":"apps.list"}`. Mutating, paid, or destructive Cloud commands require an explicit user yes on a follow-up turn (not LLM `confirmed`). For paid self-spend commands (e.g. `domains.buy`, `containers.create`), pass `params.spendEstimateUsd` (such as the price from `domains.check`) so they auto-authorize within the configured agent spend cap instead of stalling.',
 } as const;
 
 type ParentAgentMode =
@@ -1097,11 +1097,20 @@ async function runCloudCommand(args: {
       0,
       capUsd - getSessionSpendUsd(args.sessionId),
     );
-    const preview =
+    let preview: string;
+    if (
       spendDecision.reason === "over-cap" &&
       spendDecision.estimatedCostUsd != null
-        ? `${definition.command} would spend ~$${spendDecision.estimatedCostUsd.toFixed(2)}, exceeding your remaining $${remainingUsd.toFixed(2)} self-spend allowance. Proceed?`
-        : `${definition.command} is a ${definition.risk} Eliza Cloud command. Proceed?`;
+    ) {
+      preview = `${definition.command} would spend ~$${spendDecision.estimatedCostUsd.toFixed(2)}, exceeding your remaining $${remainingUsd.toFixed(2)} self-spend allowance. Proceed?`;
+    } else if (spendDecision.reason === "unknown-cost") {
+      // Self-spend command with no cost hint. Give an autonomous agent an
+      // actionable path: fetch a quote and retry with the estimate so it can
+      // self-authorize within the cap instead of waiting on a human "yes".
+      preview = `${definition.command} is a paid Eliza Cloud command with an unknown cost. To self-authorize within your remaining $${remainingUsd.toFixed(2)} allowance, first fetch a quote (e.g. domains.check) and retry with params.spendEstimateUsd set to that price.`;
+    } else {
+      preview = `${definition.command} is a ${definition.risk} Eliza Cloud command. Proceed?`;
+    }
     const decision = await requireConfirmation({
       runtime: args.runtime,
       message: args.confirmationMessage,

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-dispatch.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-dispatch.ts
@@ -1,0 +1,157 @@
+/**
+ * Child → parent `USE_SKILL parent-agent` dispatcher.
+ *
+ * A spawned coding agent (driven over ACP) cannot run account-bound Eliza Cloud
+ * commands itself. The `build-monetized-app` skill and the SKILLS.md written for
+ * economics tasks tell it to emit `USE_SKILL parent-agent <json>` in its output
+ * instead. This module is the production caller the economics runbook
+ * (`docs/economics-goal-runbook.md`) identified as missing: it detects that
+ * directive in the child's streamed text, bridges it to `runParentAgentBroker`,
+ * and sends the broker's reply back into the child session so the loop
+ * continues (read cloud commands, self-authorize spend within the cap, etc.).
+ *
+ * The detection is intentionally narrow — it only acts on text containing the
+ * literal `USE_SKILL parent-agent` marker, which ordinary coding tasks never
+ * emit, so wiring it into the session-event hot path is inert for every other
+ * flow.
+ *
+ * @module services/parent-agent-dispatch
+ */
+
+import type { IAgentRuntime, Logger } from "@elizaos/core";
+import type { AcpService } from "./acp-service.js";
+import {
+  PARENT_AGENT_BROKER_SLUG,
+  runParentAgentBroker,
+} from "./parent-agent-broker.js";
+import type { SessionInfo } from "./types.js";
+
+const DISPATCH_LOG_SRC = "acpx:parent-agent-dispatch";
+
+/** The exact prefix a child emits to invoke the parent-agent broker. */
+export const PARENT_AGENT_DIRECTIVE_MARKER = `USE_SKILL ${PARENT_AGENT_BROKER_SLUG}`;
+
+export interface ParentAgentDirective {
+  /** Parsed JSON args object, passed verbatim to the broker as `args`. */
+  args: Record<string, unknown>;
+  /** Offset just past the directive in the source string (for buffer trimming). */
+  endIndex: number;
+}
+
+/** Index of the first directive marker in `text`, or -1. */
+export function parentAgentMarkerIndex(text: string): number {
+  return text.indexOf(PARENT_AGENT_DIRECTIVE_MARKER);
+}
+
+/**
+ * Find the FIRST complete `USE_SKILL parent-agent {json}` directive in `text`.
+ *
+ * Returns `null` when no marker is present, or when the JSON object after the
+ * marker is not yet balanced (the directive is still streaming) — the caller
+ * keeps buffering in that case. The scan is string- and escape-aware so braces
+ * inside JSON string values do not close the object early. A malformed object
+ * (balanced braces that fail `JSON.parse`) resolves to `null` so the caller
+ * does not spin on it.
+ */
+export function extractParentAgentDirective(
+  text: string,
+): ParentAgentDirective | null {
+  const markerAt = text.indexOf(PARENT_AGENT_DIRECTIVE_MARKER);
+  if (markerAt < 0) return null;
+
+  // Skip whitespace / a markdown backtick between the marker and the JSON.
+  let i = markerAt + PARENT_AGENT_DIRECTIVE_MARKER.length;
+  while (i < text.length && text[i] !== "{") {
+    const ch = text[i];
+    if (ch !== " " && ch !== "\t" && ch !== "\n" && ch !== "\r" && ch !== "`") {
+      // Non-JSON content after the marker → not a directive.
+      return null;
+    }
+    i++;
+  }
+  if (i >= text.length) return null; // brace not streamed yet
+
+  const start = i;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === "\\") escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === "{") {
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        try {
+          const parsed: unknown = JSON.parse(text.slice(start, i + 1));
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            return {
+              args: parsed as Record<string, unknown>,
+              endIndex: i + 1,
+            };
+          }
+        } catch {
+          // Balanced but not valid JSON — drop it (caller trims past the marker).
+        }
+        return null;
+      }
+    }
+  }
+  return null; // unbalanced — still streaming
+}
+
+export interface DispatchParentAgentParams {
+  runtime: IAgentRuntime;
+  /** Only the methods the dispatcher needs, so tests can pass a tiny stub. */
+  acp: Pick<AcpService, "sendToSession">;
+  sessionId: string;
+  session?: SessionInfo;
+  args: Record<string, unknown>;
+  log?: Pick<Logger, "info" | "warn" | "error">;
+}
+
+/**
+ * Run one parent-agent directive through the broker and send the reply back to
+ * the child session. Never throws: a broker failure is reported back to the
+ * child as text so it is not left waiting on a response that never comes.
+ */
+export async function dispatchParentAgentDirective(
+  params: DispatchParentAgentParams,
+): Promise<{ ok: boolean; reply: string }> {
+  const { runtime, acp, sessionId, session, args, log } = params;
+
+  let reply: string;
+  let ok = false;
+  try {
+    const result = await runParentAgentBroker({
+      runtime,
+      sessionId,
+      session,
+      args,
+    });
+    ok = result.success;
+    reply = result.text;
+  } catch (err) {
+    reply = `parent-agent bridge error: ${err instanceof Error ? err.message : String(err)}`;
+    log?.error?.({ src: DISPATCH_LOG_SRC, sessionId }, reply);
+  }
+
+  try {
+    await acp.sendToSession(sessionId, reply);
+  } catch (err) {
+    log?.warn?.(
+      { src: DISPATCH_LOG_SRC, sessionId },
+      `failed to deliver parent-agent reply: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { ok: false, reply };
+  }
+  return { ok, reply };
+}

--- a/plugins/plugin-agent-orchestrator/src/services/parent-agent-dispatch.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/parent-agent-dispatch.ts
@@ -31,6 +31,56 @@ const DISPATCH_LOG_SRC = "acpx:parent-agent-dispatch";
 /** The exact prefix a child emits to invoke the parent-agent broker. */
 export const PARENT_AGENT_DIRECTIVE_MARKER = `USE_SKILL ${PARENT_AGENT_BROKER_SLUG}`;
 
+/**
+ * A child streams its `USE_SKILL parent-agent` directive mid-turn and then ends
+ * the turn to await the reply. Delivering that reply is itself a new prompt,
+ * which the ACP transport rejects with "session is already busy" until the
+ * current turn finishes — so delivery is retried until the session goes idle,
+ * up to this bound (a turn can run for the full prompt timeout). Without the
+ * retry the reply is dropped and the loop stalls on the first directive.
+ */
+const REPLY_DELIVERY_TIMEOUT_MS = 300_000;
+const REPLY_DELIVERY_POLL_MS = 250;
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/** The transport's transient "a turn is in flight" rejection (vs. a terminal
+ * failure like a lost/closed session, which must not be retried). */
+function isSessionBusyError(err: unknown): boolean {
+  return err instanceof Error && /already busy/i.test(err.message);
+}
+
+/**
+ * Deliver the broker reply back into the child session, waiting out the child's
+ * in-flight turn. Returns false (without throwing) on a terminal delivery
+ * failure or if the session never goes idle within the bound.
+ */
+async function deliverReplyToChild(
+  acp: Pick<AcpService, "sendToSession">,
+  sessionId: string,
+  reply: string,
+  log: DispatchParentAgentParams["log"],
+): Promise<boolean> {
+  const deadline = Date.now() + REPLY_DELIVERY_TIMEOUT_MS;
+  for (;;) {
+    try {
+      await acp.sendToSession(sessionId, reply);
+      return true;
+    } catch (err) {
+      if (isSessionBusyError(err) && Date.now() < deadline) {
+        await delay(REPLY_DELIVERY_POLL_MS);
+        continue;
+      }
+      log?.warn?.(
+        { src: DISPATCH_LOG_SRC, sessionId },
+        `failed to deliver parent-agent reply: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return false;
+    }
+  }
+}
+
 export interface ParentAgentDirective {
   /** Parsed JSON args object, passed verbatim to the broker as `args`. */
   args: Record<string, unknown>;
@@ -144,14 +194,6 @@ export async function dispatchParentAgentDirective(
     log?.error?.({ src: DISPATCH_LOG_SRC, sessionId }, reply);
   }
 
-  try {
-    await acp.sendToSession(sessionId, reply);
-  } catch (err) {
-    log?.warn?.(
-      { src: DISPATCH_LOG_SRC, sessionId },
-      `failed to deliver parent-agent reply: ${err instanceof Error ? err.message : String(err)}`,
-    );
-    return { ok: false, reply };
-  }
-  return { ok, reply };
+  const delivered = await deliverReplyToChild(acp, sessionId, reply, log);
+  return { ok: ok && delivered, reply };
 }

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -10,6 +10,11 @@ import type {
 } from "@elizaos/core";
 import { Service } from "@elizaos/core";
 import type { AcpService } from "./acp-service.js";
+import {
+  dispatchParentAgentDirective,
+  extractParentAgentDirective,
+  parentAgentMarkerIndex,
+} from "./parent-agent-dispatch.js";
 import { SsrfBlockedError, safeFetch } from "./ssrf-guard.js";
 import type { SessionEventName, SessionInfo } from "./types.js";
 import {
@@ -320,6 +325,11 @@ export class SubAgentRouter extends Service {
   private unsubscribe: (() => void) | undefined;
   private readonly delivered = new Set<string>();
   private readonly roundTripCounts = new Map<string, number>();
+  // Per-session accumulation of streamed child text, scanned for
+  // `USE_SKILL parent-agent <json>` directives. Kept tiny (only a tail, or
+  // from the marker onward) so it never grows with normal task output.
+  private readonly parentAgentBuffers = new Map<string, string>();
+  private readonly parentAgentDispatchCounts = new Map<string, number>();
   private readonly capExceededSessions = new Set<string>();
   private readonly verifyRetryHandedOffSessions = new Set<string>();
   // Backstop for the cross-session "state lost -> spawn a fresh sub-agent"
@@ -473,6 +483,8 @@ export class SubAgentRouter extends Service {
     this.started = false;
     this.delivered.clear();
     this.roundTripCounts.clear();
+    this.parentAgentBuffers.clear();
+    this.parentAgentDispatchCounts.clear();
     this.capExceededSessions.clear();
     this.verifyRetryHandedOffSessions.clear();
     this.completionFirstPostedSession.clear();
@@ -485,6 +497,13 @@ export class SubAgentRouter extends Service {
     event: SessionEventName,
     data: unknown,
   ): Promise<void> {
+    // Streamed child output: intercept `USE_SKILL parent-agent <json>` and
+    // bridge it to the parent-agent broker. `message` chunks are not injected
+    // into the parent (shouldInject excludes them), so this is the only place
+    // the directive is observed; the marker guard keeps it inert otherwise.
+    if (event === "message") {
+      await this.maybeDispatchParentAgent(sessionId, data);
+    }
     if (!shouldInject(event)) return;
     const acp = this.acp;
     if (!acp) return;
@@ -1209,6 +1228,94 @@ Do not report done until every referenced URL in the final page resolves without
     return sessions.some((candidate) =>
       isNewerContinuationSession(candidate, session, origin, currentCreatedAt),
     );
+  }
+
+  /**
+   * Accumulate streamed child text and, when a complete
+   * `USE_SKILL parent-agent <json>` directive appears, bridge it to the broker
+   * and stream the reply back into the session. Synchronous up to the point a
+   * complete directive is found (the buffer is trimmed before any await), so
+   * out-of-order `message` chunks cannot re-dispatch or corrupt the buffer.
+   */
+  private async maybeDispatchParentAgent(
+    sessionId: string,
+    data: unknown,
+  ): Promise<void> {
+    const acp = this.acp;
+    if (!acp) return;
+    const chunk =
+      typeof (data as { text?: unknown } | null)?.text === "string"
+        ? (data as { text: string }).text
+        : "";
+    if (!chunk) return;
+
+    const MAX_BUFFER = 16_384;
+    const TAIL = 64; // ≥ marker length, to catch a marker split across chunks
+    let buf = (this.parentAgentBuffers.get(sessionId) ?? "") + chunk;
+
+    const markerAt = parentAgentMarkerIndex(buf);
+    if (markerAt < 0) {
+      this.parentAgentBuffers.set(sessionId, buf.slice(-TAIL));
+      return;
+    }
+    buf = buf.slice(markerAt);
+    if (buf.length > MAX_BUFFER) buf = buf.slice(-MAX_BUFFER);
+
+    const directive = extractParentAgentDirective(buf);
+    if (!directive) {
+      // Marker present but the JSON is still streaming (or malformed). If it is
+      // malformed the extractor returns null; drop the dead marker so we do not
+      // re-scan it forever, keeping only a tail.
+      this.parentAgentBuffers.set(
+        sessionId,
+        buf.length > MAX_BUFFER ? buf.slice(-TAIL) : buf,
+      );
+      return;
+    }
+    // Consume the directive BEFORE awaiting so a concurrent chunk cannot
+    // re-dispatch it.
+    this.parentAgentBuffers.set(sessionId, buf.slice(directive.endIndex));
+
+    const nextCount = (this.parentAgentDispatchCounts.get(sessionId) ?? 0) + 1;
+    this.parentAgentDispatchCounts.set(sessionId, nextCount);
+    if (nextCount > this.roundTripCap) {
+      this.log(
+        "warn",
+        "parent-agent dispatch cap exceeded; dropping directive",
+        {
+          sessionId,
+          count: nextCount,
+          cap: this.roundTripCap,
+        },
+      );
+      await acp
+        .sendToSession(
+          sessionId,
+          `parent-agent bridge: round-trip cap (${this.roundTripCap}) reached for this session; not running further USE_SKILL parent-agent requests.`,
+        )
+        .catch(() => undefined);
+      return;
+    }
+
+    const session = (await acp.getSession(sessionId)) ?? undefined;
+    this.log("info", "dispatching parent-agent directive", {
+      sessionId,
+      mode:
+        typeof directive.args.mode === "string" ? directive.args.mode : "ask",
+      command:
+        typeof directive.args.command === "string"
+          ? directive.args.command
+          : undefined,
+      count: nextCount,
+    });
+    await dispatchParentAgentDirective({
+      runtime: this.runtime,
+      acp,
+      sessionId,
+      session,
+      args: directive.args,
+      log: this.runtime.logger,
+    });
   }
 
   private log(


### PR DESCRIPTION
## What

Closes the production gap that left the capped self-spend autonomy mechanism (merged in #8250) unreachable by a live agent. A `/economics` sub-agent can now autonomously drive the monetized-app loop through the parent-agent Cloud command broker.

## Why

`runParentAgentBroker` / `runCloudCommand` (the only emitter of `spend_auto_authorized`) had **no production caller**: nothing parsed a child's `USE_SKILL parent-agent {…}` request, `buildSkillsManifest({ virtualSkills })` was never called, and the autonomy was only proven via Vitest. See `plugins/plugin-agent-orchestrator/docs/economics-goal-runbook.md` (bundled/updated here).

## How (the three gaps, closed)

1. **Dispatch** — new `parent-agent-dispatch.ts`: a string/escape-aware extractor for `USE_SKILL parent-agent {json}` (handles streaming/partial JSON, braces inside strings, nested params, markdown backticks, malformed markers) + a dispatch helper that runs the directive through `runParentAgentBroker` and streams `result.text` back via `acp.sendToSession`. Wired into `SubAgentRouter.handleEvent`: accumulates the child's `message` chunks, dispatches the first complete directive, caps round-trips via `ACPX_SUB_AGENT_ROUND_TRIP_CAP`. **Marker-guarded** — only acts on text containing `USE_SKILL parent-agent`, which ordinary coding tasks never emit, so the session-event hot path is inert for every other flow.
2. **Advertise** — `spawnAgentForTask` writes a `SKILLS.md` for `capabilityProfile === "economics"` tasks via `buildSkillsManifest(..., { recommendedSlugs: ["build-monetized-app","eliza-cloud"], virtualSkills: [PARENT_AGENT_BROKER_MANIFEST_ENTRY] })` so the child learns the slug + arg contract. Best-effort (never fatal).
3. **Estimate** — the broker's unknown-cost stall now returns an *actionable* instruction (fetch a quote with `domains.check`, retry with `params.spendEstimateUsd`) instead of a human-only yes/no, and the manifest guidance advertises the same pattern — so `domains.buy` self-authorizes within the cap without a human turn.

## Verification

- New `parent-agent-dispatch.test.ts` (11 cases): extractor edge cases + the broker→`sendToSession` bridge end to end via the network-free `list-cloud-commands` mode.
- Existing `parent-agent-broker.test.ts` + `skill-manifest.test.ts` still green (no regression from the preview/guidance change).
- Plugin typecheck clean; biome clean.
- End-to-end (a real `spend_auto_authorized` on `domains.buy`/`containers.create`) still needs a live ACP backend — the runbook documents the exact steps.

## Safety

The hot-path hook is a no-op unless the child emits the literal `USE_SKILL parent-agent` marker. Paid/mutating commands remain gated by the existing capped spend allowance (`ELIZA_AGENT_SPEND_CAP_USD`, default 0 = confirm everything); destructive commands always require a human.