### PR TITLE
fix(cloud): stabilize Steward OAuth redirect URI

### DIFF
--- a/packages/cloud-frontend/src/pages/login/login-return-to.test.ts
+++ b/packages/cloud-frontend/src/pages/login/login-return-to.test.ts
@@ -1,11 +1,20 @@
-import { describe, expect, test } from "vitest";
-import { resolveLoginReturnTo } from "./login-return-to";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  consumePendingOAuthReturnTo,
+  resolveLoginReturnTo,
+  storePendingOAuthReturnTo,
+} from "./login-return-to";
 
 function params(query: string) {
   return new URLSearchParams(query);
 }
 
 describe("resolveLoginReturnTo", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    vi.restoreAllMocks();
+  });
+
   test("prefers an internal returnTo query over a pending OAuth return target", () => {
     expect(
       resolveLoginReturnTo(
@@ -34,5 +43,35 @@ describe("resolveLoginReturnTo", () => {
     expect(resolveLoginReturnTo(params(""), "//evil.test/callback")).toBe(
       "/dashboard/agents",
     );
+  });
+
+  test("stores and consumes a sanitized OAuth return target outside redirect_uri", () => {
+    storePendingOAuthReturnTo(
+      params("returnTo=/auth/cli-login%3Fsession%3Dabc"),
+    );
+
+    expect(consumePendingOAuthReturnTo()).toBe("/auth/cli-login?session=abc");
+    expect(consumePendingOAuthReturnTo()).toBeNull();
+  });
+
+  test.each([
+    "https://evil.test/dashboard",
+    "//evil.test/dashboard",
+    "",
+  ])("does not persist hostile OAuth return target %j", (returnTo) => {
+    storePendingOAuthReturnTo(
+      params(`returnTo=${encodeURIComponent(returnTo)}`),
+    );
+
+    expect(consumePendingOAuthReturnTo()).toBeNull();
+  });
+
+  test("keeps pending OAuth return target across retry without returnTo in the URL", () => {
+    storePendingOAuthReturnTo(
+      params("returnTo=/payment/success%3Fsession%3D123"),
+    );
+    storePendingOAuthReturnTo(params(""));
+
+    expect(consumePendingOAuthReturnTo()).toBe("/payment/success?session=123");
   });
 });

--- a/packages/cloud-frontend/src/pages/login/login-return-to.ts
+++ b/packages/cloud-frontend/src/pages/login/login-return-to.ts
@@ -1,4 +1,5 @@
 const DEFAULT_LOGIN_RETURN_TO = "/dashboard/agents";
+const PENDING_OAUTH_RETURN_TO_KEY = "eliza.login.oauth.returnTo";
 
 function sanitizeLoginReturnTo(
   value: string | null | undefined,
@@ -15,4 +16,30 @@ export function resolveLoginReturnTo(
     sanitizeLoginReturnTo(pendingOAuthReturnTo) ??
     DEFAULT_LOGIN_RETURN_TO
   );
+}
+
+export function storePendingOAuthReturnTo(searchParams: {
+  get(name: string): string | null;
+}): void {
+  if (typeof window === "undefined") return;
+  const returnTo = sanitizeLoginReturnTo(searchParams.get("returnTo"));
+  try {
+    if (returnTo) {
+      window.sessionStorage.setItem(PENDING_OAUTH_RETURN_TO_KEY, returnTo);
+    }
+  } catch {
+    // Storage can be disabled in private browsing modes. Losing returnTo is
+    // better than putting it back into OAuth redirect_uri and failing login.
+  }
+}
+
+export function consumePendingOAuthReturnTo(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const returnTo = window.sessionStorage.getItem(PENDING_OAUTH_RETURN_TO_KEY);
+    window.sessionStorage.removeItem(PENDING_OAUTH_RETURN_TO_KEY);
+    return sanitizeLoginReturnTo(returnTo);
+  } catch {
+    return null;
+  }
 }

--- a/packages/cloud-frontend/src/pages/login/steward-login-section.tsx
+++ b/packages/cloud-frontend/src/pages/login/steward-login-section.tsx
@@ -28,7 +28,11 @@ import {
   exchangeStewardCodeViaApi,
   syncStewardSessionCookie,
 } from "../../lib/steward-session";
-import { resolveLoginReturnTo } from "./login-return-to";
+import {
+  consumePendingOAuthReturnTo,
+  resolveLoginReturnTo,
+  storePendingOAuthReturnTo,
+} from "./login-return-to";
 import {
   buildStewardOAuthAuthorizeUrl,
   buildStewardOAuthRedirectUri,
@@ -228,10 +232,7 @@ export default function StewardLoginSection() {
       // exchange then omits it and Steward surfaces the mismatch.
       const codeVerifier = consumeStewardPkceVerifier() ?? undefined;
       exchangeStewardCodeViaApi(code, {
-        redirectUri: buildStewardOAuthRedirectUri(
-          window.location.origin,
-          window.location.search,
-        ),
+        redirectUri: buildStewardOAuthRedirectUri(window.location.origin),
         tenantId: STEWARD_TENANT_ID,
         codeVerifier,
       })
@@ -246,7 +247,9 @@ export default function StewardLoginSection() {
             writeStoredStewardToken(res.token);
             window.dispatchEvent(new CustomEvent("steward-token-sync"));
           }
-          setRedirectTo(resolveLoginReturnTo(searchParams));
+          setRedirectTo(
+            resolveLoginReturnTo(searchParams, consumePendingOAuthReturnTo()),
+          );
         })
         .catch((sessionError) => {
           setCallbackError(
@@ -277,7 +280,9 @@ export default function StewardLoginSection() {
 
     syncStewardSessionCookie(token, refreshToken)
       .then(() => {
-        setRedirectTo(resolveLoginReturnTo(searchParams));
+        setRedirectTo(
+          resolveLoginReturnTo(searchParams, consumePendingOAuthReturnTo()),
+        );
       })
       .catch((sessionError) => {
         setCallbackError(
@@ -393,12 +398,12 @@ export default function StewardLoginSection() {
   async function handleOAuth(provider: StewardOAuthProvider) {
     setLoading(provider);
     setError(null);
-    // Server-side redirect flow. Preserve the current query string on
-    // redirect_uri so returnTo (used by /auth/cli-login, app-authorize, etc.)
-    // survives the OAuth round-trip. Without this, users signing in from a
-    // deep-linked page land on /dashboard instead of the page that redirected
-    // them to /login. The authorize endpoint reads `tenant_id` (snake_case);
-    // camelCase `tenantId` falls back to the user's personal tenant.
+    // Server-side redirect flow. Keep redirect_uri stable at /login so it
+    // matches Steward's exact tenant OAuth allowlist. Do not include returnTo
+    // or other volatile login query params in redirect_uri; those can make
+    // production logins fail allowlist checks before reaching the provider.
+    // The authorize endpoint reads `tenant_id` (snake_case); camelCase
+    // `tenantId` falls back to the user's personal tenant.
     // Cloudflare Pages preview deploys live on `*.pages.dev`, whose hashed
     // subdomain is never on the Steward tenant's redirect_uri allowlist.
     // Route OAuth through staging.elizacloud.ai (which is whitelisted, matching
@@ -433,11 +438,11 @@ export default function StewardLoginSection() {
       setLoading(null);
       return;
     }
+    storePendingOAuthReturnTo(searchParams);
     window.location.href = buildStewardOAuthAuthorizeUrl(
       provider,
       oauthOrigin,
       {
-        redirectSearch: window.location.search,
         stewardApiUrl,
         stewardTenantId: STEWARD_TENANT_ID,
         codeChallenge,

--- a/packages/cloud-frontend/src/pages/login/steward-oauth-url.test.ts
+++ b/packages/cloud-frontend/src/pages/login/steward-oauth-url.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   buildStewardOAuthAuthorizeUrl,
+  buildStewardOAuthRedirectUri,
   consumeStewardPkceVerifier,
   createStewardPkceChallenge,
   createStewardPkcePair,
@@ -42,12 +43,21 @@ describe("Steward OAuth PKCE", () => {
     expect(consumeStewardPkceVerifier()).toBeNull();
   });
 
+  it("buildStewardOAuthRedirectUri stays stable regardless of login query params", () => {
+    expect(buildStewardOAuthRedirectUri("https://www.elizacloud.ai")).toBe(
+      "https://www.elizacloud.ai/login",
+    );
+  });
+
   it("buildStewardOAuthAuthorizeUrl includes the PKCE challenge only when provided", () => {
     const withPkce = new URL(
       buildStewardOAuthAuthorizeUrl("google", "https://www.elizacloud.ai", {
         stewardApiUrl: "https://api.example/steward",
         codeChallenge: "CHALLENGE",
       }),
+    );
+    expect(withPkce.searchParams.get("redirect_uri")).toBe(
+      "https://www.elizacloud.ai/login",
     );
     expect(withPkce.searchParams.get("response_type")).toBe("code");
     expect(withPkce.searchParams.get("code_challenge")).toBe("CHALLENGE");

--- a/packages/cloud-frontend/src/pages/login/steward-oauth-url.ts
+++ b/packages/cloud-frontend/src/pages/login/steward-oauth-url.ts
@@ -10,22 +10,18 @@ export type StewardOAuthProvider = "google" | "discord" | "github";
  * value we send at /authorize time exactly matches the value we send at
  * /exchange time — Steward rejects the exchange if they differ.
  */
-export function buildStewardOAuthRedirectUri(
-  origin: string,
-  redirectSearch?: string,
-): string {
-  let normalizedSearch = redirectSearch ?? "";
-  if (normalizedSearch && !normalizedSearch.startsWith("?")) {
-    normalizedSearch = `?${normalizedSearch}`;
-  }
-  return `${origin}/login${normalizedSearch}`;
+export function buildStewardOAuthRedirectUri(origin: string): string {
+  // Keep the OAuth redirect URI stable. Steward allowlists exact redirect URLs
+  // for tenant OAuth; putting volatile login query params (returnTo, app auth,
+  // CLI state, etc.) in redirect_uri makes legitimate production logins miss
+  // the allowlist. Preserve post-login destinations outside redirect_uri.
+  return `${origin}/login`;
 }
 
 export function buildStewardOAuthAuthorizeUrl(
   provider: StewardOAuthProvider,
   origin: string,
   options?: {
-    redirectSearch?: string;
     stewardApiUrl?: string;
     stewardTenantId?: string;
     /**
@@ -37,10 +33,7 @@ export function buildStewardOAuthAuthorizeUrl(
     codeChallenge?: string;
   },
 ): string {
-  const redirectUri = buildStewardOAuthRedirectUri(
-    origin,
-    options?.redirectSearch,
-  );
+  const redirectUri = buildStewardOAuthRedirectUri(origin);
   const params = new URLSearchParams({
     redirect_uri: redirectUri,
     tenant_id: options?.stewardTenantId ?? DEFAULT_STEWARD_TENANT_ID,


### PR DESCRIPTION
## Summary
- keep Steward OAuth redirect_uri pinned to the allowlisted /login URL
- preserve deep-link returnTo targets in sanitized sessionStorage instead of embedding them in redirect_uri
- reuse the same stable redirect_uri during nonce exchange

## Verification
- bun run --cwd packages/cloud-frontend test -- src/pages/login/steward-oauth-url.test.ts src/pages/login/login-return-to.test.ts
- bun run --cwd packages/cloud-frontend typecheck
- bun run --cwd packages/cloud-frontend build:client
- codex review --uncommitted