### PR TITLE
fix(cloud): hydrate Steward cookie refresh sessions

### DIFF
--- a/packages/cloud-api/auth/steward-refresh/route.ts
+++ b/packages/cloud-api/auth/steward-refresh/route.ts
@@ -13,7 +13,9 @@
  *     `/api/auth/steward-session`).
  *  4. Sets new HttpOnly cookies (`steward-token`, `steward-refresh-token`)
  *     and the non-HttpOnly `steward-authed=1` marker.
- *  5. Returns `{ ok, expiresAt }` — **no tokens in the response body**.
+ *  5. Returns `{ ok, expiresAt }`. Trusted first-party browser origins also
+ *     receive the short-lived access token so the SPA can hydrate its
+ *     localStorage mirror while route auth remains synchronous.
  *
  * Origin/Referer CSRF check mirrors `/api/auth/steward-session`.
  *
@@ -100,6 +102,21 @@ function checkOrigin(
     ok: false,
     reason: `origin=${origin ?? "null"} referer=${referer ?? "null"}`,
   };
+}
+
+function shouldReturnClientToken(
+  c: { req: { header: (name: string) => string | undefined } },
+  isProduction: boolean,
+): boolean {
+  const origin =
+    originHost(c.req.header("origin")) ?? originHost(c.req.header("referer"));
+  const host = (c.req.header("host") ?? "").split(":")[0]?.toLowerCase() ?? "";
+  if (!origin) return false;
+  // The SPA still uses a localStorage access-token mirror for synchronous
+  // route auth. Cookie refresh must hydrate that mirror for every origin the
+  // CSRF check already accepts, otherwise valid HttpOnly-cookie sessions can
+  // bounce back to /login on previews/custom same-origin hosts.
+  return isPermittedOrigin(origin, host, isProduction);
 }
 
 function stewardSecretConfigured(env: StewardVerifyEnv): boolean {
@@ -333,6 +350,7 @@ app.post("/", async (c) => {
     ok: true,
     expiresAt: refresh.data.expiresAt,
     expiresIn: refresh.data.expiresIn,
+    ...(shouldReturnClientToken(c, isProduction) ? { token } : {}),
   });
 });
 

--- a/packages/cloud-frontend/src/lib/steward-session.ts
+++ b/packages/cloud-frontend/src/lib/steward-session.ts
@@ -118,8 +118,9 @@ export function consumeStewardTokensFromHash(): {
  * `syncStewardSessionCookie`'s plumbing — same base URL, same credentials,
  * same skipAuth treatment). Posts the one-time OAuth code to the cloud-api
  * nonce-exchange route, which calls Steward `/auth/oauth/exchange`
- * server-side and sets HttpOnly steward-token cookies. Access and refresh
- * tokens never enter this process.
+ * server-side and sets HttpOnly steward-token cookies. Trusted Cloud origins
+ * also receive the short-lived access token so the SPA can hydrate its
+ * localStorage mirror until route auth no longer requires synchronous reads.
  *
  * Throws `StewardSessionError` on non-2xx so callers can surface the
  * specific code (`code_invalid`, `code_expired`, `code_redirect_mismatch`,
@@ -159,20 +160,30 @@ export async function exchangeStewardCodeViaApi(
 }
 
 /**
- * Cookie-only session refresh. Sends an empty POST to the cloud-api
+ * Cookie-backed session refresh. Sends an empty POST to the cloud-api
  * `steward-refresh` route with `credentials: "include"`; the HttpOnly
- * `steward-refresh-token` cookie travels automatically. The server
- * exchanges it with Steward, sets fresh HttpOnly cookies, and returns
- * `{ ok, expiresAt }`. No tokens enter JS.
+ * `steward-refresh-token` cookie travels automatically. The server exchanges
+ * it with Steward and sets fresh HttpOnly cookies. Trusted Cloud origins also
+ * receive a short-lived access token so the SPA can hydrate its localStorage
+ * mirror and avoid login loops while route auth still reads synchronously.
  *
- * Returns `true` on success, `false` when the server rejected the refresh
- * (cookie missing / revoked / Steward 401 — the server has already cleared
- * the stale cookies in that case).
+ * Throws `ApiError` when the cookie is missing/revoked or the server rejects
+ * the refresh.
  */
-export async function refreshStewardSessionViaCookie(): Promise<boolean> {
+export async function refreshStewardSessionViaCookie(): Promise<{
+  ok: true;
+  expiresAt?: number;
+  expiresIn?: number;
+  token?: string;
+}> {
   const response = await apiFetch(STEWARD_REFRESH_ENDPOINT, {
     method: "POST",
     skipAuth: true,
   });
-  return response.ok;
+  return (await response.json()) as {
+    ok: true;
+    expiresAt?: number;
+    expiresIn?: number;
+    token?: string;
+  };
 }

--- a/packages/cloud-frontend/src/pages/login/steward-login-section.test.tsx
+++ b/packages/cloud-frontend/src/pages/login/steward-login-section.test.tsx
@@ -27,6 +27,7 @@ function deferred<T>() {
 
 const mocks = vi.hoisted(() => ({
   getProviders: vi.fn(),
+  refreshStewardSessionViaCookie: vi.fn(),
   signInWithEmail: vi.fn(),
   signInWithPasskey: vi.fn(),
   walletButtonProps: [] as unknown[],
@@ -68,6 +69,7 @@ vi.mock("../../lib/steward-session", () => ({
   consumeStewardCodeFromQuery: vi.fn(() => null),
   consumeStewardTokensFromHash: vi.fn(() => null),
   exchangeStewardCodeViaApi: vi.fn(),
+  refreshStewardSessionViaCookie: mocks.refreshStewardSessionViaCookie,
 }));
 
 vi.mock("./steward-wallet-providers", () => ({
@@ -91,12 +93,16 @@ vi.mock("./wallet-buttons", () => ({
 import { I18nProvider } from "@/providers/I18nProvider";
 import StewardLoginSection from "./steward-login-section";
 
-function renderLogin() {
+function renderLogin(initialEntry = "/login") {
   return render(
     <I18nProvider initialLang="en">
-      <MemoryRouter initialEntries={["/login"]}>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <Routes>
           <Route path="/login" element={<StewardLoginSection />} />
+          <Route
+            path="/dashboard/agents"
+            element={<div>Dashboard agents</div>}
+          />
         </Routes>
       </MemoryRouter>
     </I18nProvider>,
@@ -104,7 +110,11 @@ function renderLogin() {
 }
 
 beforeEach(() => {
+  // biome-ignore lint/suspicious/noDocumentCookie: jsdom auth-cookie setup.
+  document.cookie = "steward-authed=; Max-Age=0; Path=/";
+  window.localStorage.clear();
   mocks.getProviders.mockReset();
+  mocks.refreshStewardSessionViaCookie.mockReset();
   mocks.signInWithEmail.mockReset();
   mocks.signInWithPasskey.mockReset();
   mocks.walletButtonProps.length = 0;
@@ -167,6 +177,27 @@ describe("StewardLoginSection", () => {
     expect(screen.getByTestId("wallet-buttons")).toBeVisible();
     expect(mocks.walletButtonProps).toContainEqual(
       expect.objectContaining({ autoStart: "ethereum" }),
+    );
+  });
+
+  test("hydrates a cookie-only Steward session before redirecting", async () => {
+    // biome-ignore lint/suspicious/noDocumentCookie: jsdom auth-cookie setup.
+    document.cookie = "steward-authed=1; Path=/";
+    mocks.getProviders.mockResolvedValue({
+      passkey: true,
+      email: true,
+      oauth: [],
+    });
+    mocks.refreshStewardSessionViaCookie.mockResolvedValue({
+      ok: true,
+      token: "header.payload.signature",
+    });
+
+    renderLogin("/login?returnTo=%2Fdashboard%2Fagents");
+
+    expect(await screen.findByText("Dashboard agents")).toBeVisible();
+    expect(window.localStorage.getItem("steward_session_token")).toBe(
+      "header.payload.signature",
     );
   });
 });

--- a/packages/cloud-frontend/src/pages/login/steward-login-section.tsx
+++ b/packages/cloud-frontend/src/pages/login/steward-login-section.tsx
@@ -26,6 +26,7 @@ import {
   consumeStewardCodeFromQuery,
   consumeStewardTokensFromHash,
   exchangeStewardCodeViaApi,
+  refreshStewardSessionViaCookie,
   syncStewardSessionCookie,
 } from "../../lib/steward-session";
 import {
@@ -236,17 +237,27 @@ export default function StewardLoginSection() {
         tenantId: STEWARD_TENANT_ID,
         codeVerifier,
       })
-        .then((res) => {
+        .then(async (res) => {
           // Mirror the JWT into localStorage so `@stwd/react`'s `useAuth()`
           // and `readStewardSessionFromStorage()` see the session on the
           // very next route mount. Without this, OAuth users land back on
           // `/login` after a successful exchange (HttpOnly cookies alone
           // aren't enough — the SPA auth check requires the localStorage
-          // copy until that's relaxed).
-          if (res?.token) {
-            writeStoredStewardToken(res.token);
-            window.dispatchEvent(new CustomEvent("steward-token-sync"));
+          // copy until that's relaxed). If an older Worker returns only
+          // cookies, hydrate through the cookie refresh endpoint before
+          // redirecting instead of bouncing into a login loop.
+          let token = res?.token;
+          if (!token && hasStewardAuthedCookie()) {
+            const refreshed = await refreshStewardSessionViaCookie();
+            token = refreshed?.token;
           }
+          if (!token) {
+            throw new Error(
+              "Sign-in completed, but the browser session could not be hydrated. Refresh and try again.",
+            );
+          }
+          writeStoredStewardToken(token);
+          window.dispatchEvent(new CustomEvent("steward-token-sync"));
           setRedirectTo(
             resolveLoginReturnTo(searchParams, consumePendingOAuthReturnTo()),
           );
@@ -308,7 +319,19 @@ export default function StewardLoginSection() {
           return;
         }
 
-        if (!readStoredStewardToken() && !hasStewardAuthedCookie()) return;
+        const storedToken = readStoredStewardToken();
+        if (!storedToken && hasStewardAuthedCookie()) {
+          const refreshed = await refreshStewardSessionViaCookie();
+          if (cancelled) return;
+          if (refreshed?.token) {
+            writeStoredStewardToken(refreshed.token);
+            window.dispatchEvent(new CustomEvent("steward-token-sync"));
+            setRedirectTo(resolveLoginReturnTo(searchParams));
+          }
+          return;
+        }
+
+        if (!storedToken) return;
 
         const refreshed = await auth.refreshSession();
         if (cancelled) return;

--- a/packages/cloud-frontend/src/providers/StewardProviderRuntime.tsx
+++ b/packages/cloud-frontend/src/providers/StewardProviderRuntime.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { writeStoredStewardToken } from "@elizaos/shared/steward-session-client";
 import type { StewardClient as StewardReactClient } from "@stwd/react";
 import { StewardProvider, useAuth as useStewardAuth } from "@stwd/react";
 import { StewardClient } from "@stwd/sdk";
@@ -104,6 +105,14 @@ function AuthTokenSync({ children }: { children: React.ReactNode }) {
           credentials: "include",
         });
         if (res.ok) {
+          const body = (await res.json().catch(() => null)) as {
+            token?: string;
+          } | null;
+          if (body?.token) {
+            writeStoredStewardToken(body.token);
+            lastSyncedToken.current = body.token;
+            wasAuthenticated.current = true;
+          }
           try {
             window.dispatchEvent(new CustomEvent("steward-token-sync"));
           } catch {

--- a/packages/shared/src/steward-session-client/index.ts
+++ b/packages/shared/src/steward-session-client/index.ts
@@ -53,8 +53,9 @@ export const STEWARD_NONCE_EXCHANGE_ENDPOINT =
 /**
  * Same-origin endpoint that rotates the Steward access + refresh tokens
  * using the HttpOnly `steward-refresh-token` cookie. The browser POSTs
- * with `credentials: "include"`; the cookie travels automatically and no
- * token ever enters JS.
+ * with `credentials: "include"`; the cookie travels automatically. Trusted
+ * Cloud browser origins receive the short-lived access token so the SPA can
+ * refresh its localStorage mirror while route auth remains synchronous.
  */
 export const STEWARD_REFRESH_ENDPOINT = "/api/auth/steward-refresh";
 


### PR DESCRIPTION
## Summary
- return the refreshed Steward access token from `/api/auth/steward-refresh` for trusted Cloud origins
- hydrate the SPA localStorage token mirror from cookie refresh so valid HttpOnly-cookie sessions do not bounce back to `/login`
- make the OAuth callback fail visibly instead of redirect-looping if exchange succeeds without a JS-readable token
- add login coverage for cookie-only Steward session recovery

## Verification
- bun run --cwd packages/cloud-frontend test -- src/pages/login/steward-login-section.test.tsx
- bun run --cwd packages/cloud-frontend typecheck
- bun run --cwd packages/cloud-api typecheck
- bun run --cwd packages/cloud-frontend build:client
- codex review --uncommitted