### PR TITLE
fix(cloud): harden Steward login callback — consume #code= fragment + surface real errors

### DIFF
--- a/packages/cloud-frontend/src/lib/steward-session.test.ts
+++ b/packages/cloud-frontend/src/lib/steward-session.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { consumeStewardCodeFromQuery } from "./steward-session";
+
+function setUrl(url: string) {
+  window.history.replaceState(null, "", url);
+}
+
+describe("consumeStewardCodeFromQuery", () => {
+  beforeEach(() => {
+    setUrl("/login");
+  });
+
+  test("reads the code from the `?code=` query carrier and strips it", () => {
+    setUrl("/login?code=QUERY_NONCE&foo=bar");
+    expect(consumeStewardCodeFromQuery()).toBe("QUERY_NONCE");
+    // code removed, unrelated query params preserved
+    expect(window.location.search).toBe("?foo=bar");
+  });
+
+  test("reads the code from the `#code=` fragment carrier and strips it", () => {
+    setUrl("/login#code=FRAGMENT_NONCE");
+    expect(consumeStewardCodeFromQuery()).toBe("FRAGMENT_NONCE");
+    expect(window.location.hash).toBe("");
+    expect(window.location.pathname).toBe("/login");
+  });
+
+  test("reads `#code=` even when other fragment params are present, keeping them", () => {
+    setUrl("/login?keep=1#code=FRAGMENT_NONCE&state=xyz");
+    expect(consumeStewardCodeFromQuery()).toBe("FRAGMENT_NONCE");
+    // non-OAuth query + remaining fragment params survive
+    expect(window.location.search).toBe("?keep=1");
+    expect(window.location.hash).toBe("#state=xyz");
+  });
+
+  test("prefers the query carrier when both are present", () => {
+    setUrl("/login?code=QUERY_NONCE#code=FRAGMENT_NONCE");
+    expect(consumeStewardCodeFromQuery()).toBe("QUERY_NONCE");
+  });
+
+  test("returns null when no code is present (token fragment is not a code)", () => {
+    setUrl("/login#token=abc");
+    expect(consumeStewardCodeFromQuery()).toBeNull();
+    // leaves the token fragment untouched for consumeStewardTokensFromHash
+    expect(window.location.hash).toBe("#token=abc");
+  });
+
+  test("returns null on a bare URL", () => {
+    setUrl("/login");
+    expect(consumeStewardCodeFromQuery()).toBeNull();
+  });
+});

--- a/packages/cloud-frontend/src/lib/steward-session.ts
+++ b/packages/cloud-frontend/src/lib/steward-session.ts
@@ -50,26 +50,60 @@ export async function syncStewardSessionCookie(
 }
 
 /**
- * Read the one-time OAuth code from `?code=` (nonce-exchange flow). Steward
- * redirects to the callback with `?code=<NONCE>` and **no tokens** in the
- * URL. We pull the code, strip it from history immediately so it doesn't
- * appear in browser history / extension snapshots / shared URLs, and POST it
+ * Read the one-time OAuth code from the callback URL — `?code=<NONCE>` in the
+ * query OR `#code=<NONCE>` in the URL fragment (nonce-exchange flow). Steward
+ * redirects to the callback with the code and **no tokens**; which carrier it
+ * lands in depends on the tenant's OAuth response mode. The fragment is the
+ * preferred carrier because it never leaves the browser — not in access logs,
+ * Referer, or server history — the same reason tokens are fragment-delivered
+ * (see `consumeStewardTokensFromHash`). The index.html pre-init script only
+ * snapshots/strips `#token=`, so a `#code=` fragment is still on
+ * `location.hash` when React mounts.
+ *
+ * We pull the code, strip it from the URL immediately so it doesn't appear in
+ * browser history / extension snapshots / shared URLs, and POST it
  * server-side. Returns null when no code is present so the caller can fall
  * through to the hash / query token fallbacks during the rollout window.
  */
 export function consumeStewardCodeFromQuery(): string | null {
   if (typeof window === "undefined") return null;
-  const params = new URLSearchParams(window.location.search);
-  const code = params.get("code");
-  if (!code) return null;
-  params.delete("code");
-  const query = params.toString();
-  window.history.replaceState(
-    null,
-    "",
-    query ? `${window.location.pathname}?${query}` : window.location.pathname,
-  );
-  return code;
+
+  // Query carrier: `?code=<NONCE>` (response_mode=query).
+  const queryParams = new URLSearchParams(window.location.search);
+  const queryCode = queryParams.get("code");
+  if (queryCode) {
+    queryParams.delete("code");
+    const query = queryParams.toString();
+    window.history.replaceState(
+      null,
+      "",
+      query ? `${window.location.pathname}?${query}` : window.location.pathname,
+    );
+    return queryCode;
+  }
+
+  // Fragment carrier: `#code=<NONCE>` (response_mode=fragment). Steward keeps
+  // the code out of the query so it never hits the server; we read it from the
+  // fragment and strip the fragment, preserving any non-OAuth query params.
+  const hash = window.location.hash;
+  if (hash.length > 1) {
+    const hashParams = new URLSearchParams(hash.replace(/^#/, ""));
+    const hashCode = hashParams.get("code");
+    if (hashCode) {
+      hashParams.delete("code");
+      const remaining = hashParams.toString();
+      window.history.replaceState(
+        null,
+        "",
+        remaining
+          ? `${window.location.pathname}${window.location.search}#${remaining}`
+          : `${window.location.pathname}${window.location.search}`,
+      );
+      return hashCode;
+    }
+  }
+
+  return null;
 }
 
 /**

--- a/packages/cloud-frontend/src/pages/login/steward-login-section.tsx
+++ b/packages/cloud-frontend/src/pages/login/steward-login-section.tsx
@@ -143,6 +143,46 @@ function getCallbackReasonMessage(
       return t("cloud.login.callback.serverError", {
         defaultValue: "Something went wrong on our end. Try again in a moment.",
       });
+    // Steward's `GET /auth/callback/email` emits these `reason` codes; without
+    // a case each one fell through to the generic message below, masking the
+    // real failure. Keep `invalid_link` copy neutral — the link is not
+    // necessarily expired/used (it can fail when the verification store can't
+    // resolve the token), so "request a new one" alone can be a dead end.
+    case "invalid_link":
+      return t("cloud.login.callback.invalidLink", {
+        defaultValue:
+          "We couldn't verify that sign-in link. Request a new one — if it keeps happening, contact support.",
+      });
+    case "tenant_mismatch":
+      return t("cloud.login.callback.tenantMismatch", {
+        defaultValue: "That sign-in link is for a different workspace.",
+      });
+    case "rate_limited":
+      return t("cloud.login.callback.rateLimited", {
+        defaultValue: "Too many attempts. Wait a moment and try again.",
+      });
+    case "method_disabled":
+      return t("cloud.login.callback.methodDisabled", {
+        defaultValue: "That sign-in method isn't enabled for this workspace.",
+      });
+    case "sso_required":
+      return t("cloud.login.callback.ssoRequired", {
+        defaultValue: "Your organization requires SSO to sign in.",
+      });
+    case "tenant_not_found":
+    case "tenant_forbidden":
+      return t("cloud.login.callback.tenantUnavailable", {
+        defaultValue: "Workspace not found or access denied.",
+      });
+    case "missing_params":
+      return t("cloud.login.callback.missingParams", {
+        defaultValue: "That sign-in link is incomplete. Request a new one.",
+      });
+    case "mfa_required":
+      return t("cloud.login.callback.mfaRequired", {
+        defaultValue:
+          "Additional verification is required to finish signing in.",
+      });
     default:
       return t("cloud.login.callback.unknown", {
         defaultValue: "Couldn't complete sign-in. Try again.",


### PR DESCRIPTION
Two related fixes to the Steward login **return leg** (callback handling), found while debugging live prod login failures on elizacloud.ai. Both are confirmed against the real Steward source (`Steward-Fi/steward`).

## Commit 1 — consume the OAuth/email code from the URL **fragment** (`#code=`)

Steward's callback returns the one-time auth code in the URL **fragment**, not the query — for **both** OAuth (`#code=<nonce>`) and magic-link email (`#code=<nonce>&auth=email&tenantId=...`, see Steward `auth.ts` `GET /callback/email` → `setRedirectFragment`). The fragment never reaches the server (no access logs, no `Referer`) — same rationale as `#token=`. But the SPA only read `?code=` (query) and `#token=` (hash), so a `#code=` fragment was silently dropped and sign-in never completed (lands on `…/login#code=…` and sits there).

Fix: `consumeStewardCodeFromQuery()` now reads the code from `?code=` **or** `#code=`, stripping whichever it used (preserving non-OAuth params), leaving `#token=` for `consumeStewardTokensFromHash()`. Verified against real jsdom (12/12, incl. the exact prod URL) + new `steward-session.test.ts`.

## Commit 2 — surface Steward's real callback `reason` instead of a generic error

Steward's `GET /auth/callback/email` redirects failures with `?error=email_auth_failed&reason=<code>`, but the SPA's reason→message map only handled 4 codes; the rest (`invalid_link`, `tenant_mismatch`, `rate_limited`, `method_disabled`, `sso_required`, `tenant_not_found`, `tenant_forbidden`, `missing_params`, `mfa_required`) fell through to the generic "Couldn't complete sign-in. Try again." — which is exactly why a failing magic link only ever said "Try again." Added a case for each. `invalid_link` copy is intentionally neutral (the link isn't necessarily expired/used). Copy-only, no behavioral change.

## Scope / context
`packages/cloud-frontend` only. Follows #8259 (PKCE on `/authorize`) — that fixed the outbound leg; this fixes the return leg. Note: the separate live magic-link `invalid_link` itself is a **Steward-side** issue (token store not shared across Workers isolates + a redirect-origin env mismatch) tracked separately — these two commits make the eliza side correct and honest regardless.