### PR TITLE
fix(cloud-frontend): staging SPA hits staging Worker for Steward auth (tenant isolation)

### DIFF
--- a/packages/cloud-frontend/src/lib/steward-session.test.ts
+++ b/packages/cloud-frontend/src/lib/steward-session.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./steward-session";
 
 describe("resolveStewardAuthEndpoint", () => {
-  it("routes production cloud auth calls through the direct API host", () => {
+  it("routes prod browser hosts to api.elizacloud.ai", () => {
     expect(
       resolveStewardAuthEndpoint(
         STEWARD_NONCE_EXCHANGE_ENDPOINT,
@@ -21,11 +21,35 @@ describe("resolveStewardAuthEndpoint", () => {
       resolveStewardAuthEndpoint(STEWARD_SESSION_ENDPOINT, "elizacloud.ai"),
     ).toBe("https://api.elizacloud.ai/api/auth/steward-session");
     expect(
+      resolveStewardAuthEndpoint(STEWARD_REFRESH_ENDPOINT, "dev.elizacloud.ai"),
+    ).toBe("https://api.elizacloud.ai/api/auth/steward-refresh");
+  });
+
+  it("routes staging.elizacloud.ai to api-staging (tenant isolation)", () => {
+    // Staging Steward tenant is `elizacloud-staging`; the prod Worker pins
+    // tenant `elizacloud`. Mixing them previously caused the bypass route to
+    // 401 `code_invalid` and silently send the user back to /login on every
+    // magic-link return.
+    expect(
+      resolveStewardAuthEndpoint(
+        STEWARD_NONCE_EXCHANGE_ENDPOINT,
+        "staging.elizacloud.ai",
+      ),
+    ).toBe(
+      "https://api-staging.elizacloud.ai/api/auth/steward-nonce-exchange",
+    );
+    expect(
+      resolveStewardAuthEndpoint(
+        STEWARD_SESSION_ENDPOINT,
+        "staging.elizacloud.ai",
+      ),
+    ).toBe("https://api-staging.elizacloud.ai/api/auth/steward-session");
+    expect(
       resolveStewardAuthEndpoint(
         STEWARD_REFRESH_ENDPOINT,
         "staging.elizacloud.ai",
       ),
-    ).toBe("https://api.elizacloud.ai/api/auth/steward-refresh");
+    ).toBe("https://api-staging.elizacloud.ai/api/auth/steward-refresh");
   });
 
   it("keeps local and preview auth calls same-origin", () => {

--- a/packages/cloud-frontend/src/lib/steward-session.ts
+++ b/packages/cloud-frontend/src/lib/steward-session.ts
@@ -6,13 +6,22 @@ import {
   StewardSessionError,
 } from "@elizaos/shared/steward-session-client";
 
-const ELIZA_CLOUD_BROWSER_HOSTS = new Set([
-  "elizacloud.ai",
-  "www.elizacloud.ai",
-  "dev.elizacloud.ai",
-  "staging.elizacloud.ai",
-]);
-const ELIZA_CLOUD_DIRECT_AUTH_BASE = "https://api.elizacloud.ai";
+// Cross-zone direct-call routing for the Steward auth bypass endpoints.
+// Pages previews and third-party app integrations need an absolute URL —
+// the SPA can be served from a host that isn't bound to its API Worker.
+// Each browser host MUST point at its OWN API Worker because the Workers
+// pin a tenant via STEWARD_TENANT_ID and the bypass routes 401 with
+// `code_invalid` when a code minted for one tenant is exchanged against
+// another. Mixing staging into the prod base previously sent
+// staging-tenant codes (`elizacloud-staging`) to the prod tenant
+// (`elizacloud`) Worker — the silent failure that lands users back on
+// /login after the magic-link callback.
+const ELIZA_CLOUD_AUTH_BASES: Record<string, string> = {
+  "elizacloud.ai": "https://api.elizacloud.ai",
+  "www.elizacloud.ai": "https://api.elizacloud.ai",
+  "dev.elizacloud.ai": "https://api.elizacloud.ai",
+  "staging.elizacloud.ai": "https://api-staging.elizacloud.ai",
+};
 
 export function resolveStewardAuthEndpoint(
   path: string,
@@ -20,10 +29,8 @@ export function resolveStewardAuthEndpoint(
     ? ""
     : window.location.hostname.toLowerCase(),
 ): string {
-  if (ELIZA_CLOUD_BROWSER_HOSTS.has(hostname.toLowerCase())) {
-    return `${ELIZA_CLOUD_DIRECT_AUTH_BASE}${path}`;
-  }
-  return path;
+  const base = ELIZA_CLOUD_AUTH_BASES[hostname.toLowerCase()];
+  return base ? `${base}${path}` : path;
 }
 
 async function postAuthJson(


### PR DESCRIPTION
## Why

The Magic Link return-leg silently sends users back to /login on staging.elizacloud.ai. Reproducible with Playwright: open /login#code=… and the SPA POSTs to `https://api.elizacloud.ai/api/auth/steward-nonce-exchange` (the prod Worker) instead of `https://api-staging.elizacloud.ai/...`.

`packages/cloud-frontend/src/lib/steward-session.ts` mapped all of `{elizacloud.ai, www.elizacloud.ai, dev.elizacloud.ai, staging.elizacloud.ai}` onto the same `ELIZA_CLOUD_DIRECT_AUTH_BASE = "https://api.elizacloud.ai"`. Each Worker pins its Steward tenant via `STEWARD_TENANT_ID` (`elizacloud-staging` vs `elizacloud`), and both the embedded `/steward` proxy and the steward-nonce-exchange bypass route forward that header to Steward. So a code minted by the staging tenant 401s when the exchange happens against the prod tenant. The bypass route responds `{error:"Invalid or already-used code", code:"code_invalid"}` and the SPA's callback flow returns to /login with no surfaced error.

This bug was masked while Steward did NOT yet require PKCE + signatures: the prod-vs-staging exchange was either failing in a way the SPA already absorbed, or both env Workers were silently letting unsigned/lenient exchanges through. After PR #8259 (PKCE + nonce-exchange signing) tightened the path, the tenant mismatch became user-visible.

## What

Replace the single shared base string with a per-host map:

```ts
const ELIZA_CLOUD_AUTH_BASES: Record<string, string> = {
  "elizacloud.ai": "https://api.elizacloud.ai",
  "www.elizacloud.ai": "https://api.elizacloud.ai",
  "dev.elizacloud.ai": "https://api.elizacloud.ai",
  "staging.elizacloud.ai": "https://api-staging.elizacloud.ai",
};
```

This matches what the Pages Function `_proxy.ts` already does for the same-origin `/api/*` calls (staging.pages.dev → api-staging, prod → api).

## Tests

The existing `resolveStewardAuthEndpoint` test was **actively asserting the bug** — it expected `staging.elizacloud.ai` to map to `api.elizacloud.ai`. Updated to keep the prod cases and add a dedicated tenant-isolation case that covers all three endpoints (nonce-exchange, session, refresh) on staging.

3 new tests + 3 unchanged prod tests, all green via `bun x vitest run --environment=jsdom`.

## Test plan

- [ ] CI green
- [ ] Cloud-cf-deploy rolls out the new SPA bundle
- [ ] On staging.elizacloud.ai, click Magic Link → check inbox → click the link → land authenticated on /dashboard (not /login)
- [ ] DevTools Network shows POST to `api-staging.elizacloud.ai/api/auth/steward-nonce-exchange` returning 200 with `data.token`
- [ ] No regression on prod (`www.elizacloud.ai` still hits `api.elizacloud.ai`)