### PR TITLE
ci(cloud-cf-deploy): remove broken 'verify generated agent wildcard route' step

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -181,22 +181,6 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: bunx wrangler deploy ${{ steps.env.outputs.wrangler_args }}
 
-      # NOTE: a "Verify generated agent wildcard route" step used to live here
-      # that asserted https://00000000-0000-0000-0000-000000000000.elizacloud.ai/
-      # responded with "agent not found or not running". That contract was
-      # never actually wired — the only handler that returns that string is the
-      # Hetzner-side agent-router daemon (packages/scripts/cloud/admin/daemons/
-      # agent-router.ts), NOT the cloud-api Worker — so a `*.elizacloud.ai/*`
-      # Worker route would just return the Worker's root JSON instead. Each
-      # time the route got added to satisfy the verifier, it caught
-      # staging.elizacloud.ai/* before Pages could serve the dashboard, which
-      # broke staging end-to-end (the SPA host returned cloud-api JSON instead
-      # of HTML). Do NOT re-introduce the verifier or the wildcard until the
-      # Worker actually handles agent UUID hostnames. Until then, fall through
-      # to the default Pages routing for staging and the Hetzner nginx + Lua
-      # router for the agent subdomains (which use `agents-staging` /
-      # `agents` zones, not `elizacloud.ai`).
-
   # ---------------------------------------------------------------------------
   # Frontend (Cloudflare Pages)
   # ---------------------------------------------------------------------------

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -181,27 +181,21 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: bunx wrangler deploy ${{ steps.env.outputs.wrangler_args }}
 
-      - name: Verify generated agent wildcard route
-        if: steps.cf.outputs.configured == 'true' && steps.env.outputs.deploy_environment == 'production'
-        env:
-          AGENT_BASE_DOMAIN: elizacloud.ai
-        run: |
-          node --input-type=module <<'NODE'
-          const baseDomain = process.env.AGENT_BASE_DOMAIN;
-          if (!baseDomain) throw new Error("Agent base domain is not configured");
-          const host = `00000000-0000-0000-0000-000000000000.${baseDomain}`;
-          const response = await fetch(`https://${host}/`, {
-            redirect: "manual",
-            signal: AbortSignal.timeout(15_000),
-          });
-          const body = await response.text();
-          if (!body.includes("agent not found or not running")) {
-            throw new Error(
-              `Generated agent wildcard route is not handled by the cloud worker: status=${response.status} body=${body.slice(0, 160)}`,
-            );
-          }
-          console.log(`agent_wildcard_route=${host} status=${response.status}`);
-          NODE
+      # NOTE: a "Verify generated agent wildcard route" step used to live here
+      # that asserted https://00000000-0000-0000-0000-000000000000.elizacloud.ai/
+      # responded with "agent not found or not running". That contract was
+      # never actually wired — the only handler that returns that string is the
+      # Hetzner-side agent-router daemon (packages/scripts/cloud/admin/daemons/
+      # agent-router.ts), NOT the cloud-api Worker — so a `*.elizacloud.ai/*`
+      # Worker route would just return the Worker's root JSON instead. Each
+      # time the route got added to satisfy the verifier, it caught
+      # staging.elizacloud.ai/* before Pages could serve the dashboard, which
+      # broke staging end-to-end (the SPA host returned cloud-api JSON instead
+      # of HTML). Do NOT re-introduce the verifier or the wildcard until the
+      # Worker actually handles agent UUID hostnames. Until then, fall through
+      # to the default Pages routing for staging and the Hetzner nginx + Lua
+      # router for the agent subdomains (which use `agents-staging` /
+      # `agents` zones, not `elizacloud.ai`).
 
   # ---------------------------------------------------------------------------
   # Frontend (Cloudflare Pages)


### PR DESCRIPTION
## Why

\`cloud-cf-deploy.yml\` line 184 had:
\`\`\`yaml
- name: Verify generated agent wildcard route
  if: ... && deploy_environment == 'production'
  run: |
    node ... fetch('https://00000000-0000-0000-0000-000000000000.elizacloud.ai/')
    if (!body.includes('agent not found or not running')) throw new Error(...)
\`\`\`

The string \`agent not found or not running\` only lives in \`packages/scripts/cloud/admin/daemons/agent-router.ts\` — a **Hetzner-side daemon**, never the cloud-api Worker. So a \`*.elizacloud.ai/*\` Worker route doesn't actually return that message; it returns the Worker's root JSON (\`{name:"eliza-cloud-api", …}\`).

Each time someone added the wildcard to satisfy the verifier (most recently overnight), it caught \`staging.elizacloud.ai/*\` before Pages could serve the SPA. Result:

- Dashboard at \`staging.elizacloud.ai/dashboard/agents\` returned cloud-api JSON instead of HTML.
- The Magic Link callback (which lives at \`/login\`) was served as JSON, broke, and silently redirected to \`/login\` again.
- "+ New Agent" / "Open Web UI" were unreachable.

I deleted the wildcard yesterday and again this morning; both times it got re-added because the verifier kept telling whoever was deploying that something was missing. The fix is to drop the verifier (the contract it checks was never implemented) and leave a \`NOTE:\` explaining the trap.

## What

Replace the step with a \`# NOTE: …\` comment that documents:
- What the verifier used to check
- Why that contract was never wired
- What broke each time the wildcard was added back
- When (and how) to reintroduce a verifier alongside an actual Worker handler

No other changes — \`bunx wrangler deploy\` still runs, all the secret-publish steps still run, the staging deploy that just landed (#8282) is unaffected.

## Test plan

- [ ] CI green
- [ ] Next staging deploy produces a healthy \`staging.elizacloud.ai/dashboard/agents\` page (no JSON regression)
- [ ] Manually re-check \`https://api.cloudflare.com/.../workers/routes\` after the deploy — no \`*.elizacloud.ai/*\` route should appear, even after the verifier is gone

## Follow-up

If we want \`<uuid>.elizacloud.ai/\` to return a real "agent not found" response, the right move is:
1. Add a host-aware handler in \`packages/cloud-api/src/bootstrap-app.ts\` that detects UUID-shaped subdomains, looks the sandbox up by \`agent_sandboxes.id\` matching the leftmost label, and either proxies to \`bridge_url\` or returns the 404 message.
2. Re-introduce the Worker route \`*.elizacloud.ai/*\` AND the verifier together.
3. Make sure the route ordering still lets Pages handle \`staging.elizacloud.ai/\` for the dashboard (probably by adding a more-specific \`staging.elizacloud.ai/*\` Worker route that explicitly falls through to Pages, or by binding Pages first).

That's a separate PR; this one just stops the bleeding.