### PR TITLE
fix(orchestrator): forward Windows env (Path casing) to ACP sub-agents

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/should-forward-env.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  canonicalForwardedEnvKey,
+  forwardableSubAgentEnv,
   isEnvForwardableToSubAgent,
   shouldForwardEnv,
 } from "../../src/services/acp-service.js";
@@ -28,6 +30,37 @@ describe("shouldForwardEnv", () => {
 
   it("forwards ACPX_AUTH_-prefixed vars", () => {
     expect(shouldForwardEnv("ACPX_AUTH_TOKEN")).toBe(true);
+  });
+
+  // Regression: the repo runtime is Bun, and Bun on Windows reports the search
+  // path as `Path` (and other OS vars with native casing), so a case-sensitive
+  // `=== "PATH"` forwarded NONE of them — the child spawned with no PATH and the
+  // opencode shim died with "'bun' is not recognized". Match case-insensitively.
+  it("forwards PATH regardless of OS casing (Windows reports `Path`)", () => {
+    expect(shouldForwardEnv("Path")).toBe(true);
+    expect(shouldForwardEnv("path")).toBe(true);
+    expect(isEnvForwardableToSubAgent("Path")).toBe(true);
+  });
+
+  it("forwards the Windows system vars cmd.exe + Bun + the agent need", () => {
+    for (const key of [
+      "PATHEXT",
+      "SystemRoot",
+      "windir",
+      "ComSpec",
+      "TEMP",
+      "USERPROFILE",
+      "APPDATA",
+      "LOCALAPPDATA",
+    ]) {
+      expect(shouldForwardEnv(key)).toBe(true);
+    }
+  });
+
+  it("does not over-match vars that merely contain a system name", () => {
+    expect(shouldForwardEnv("MY_PATH_OVERRIDE")).toBe(false);
+    expect(shouldForwardEnv("PATHWAY")).toBe(false);
+    expect(shouldForwardEnv("TEMP_TOKEN")).toBe(false);
   });
 
   it("denies secrets that are not on the allowlist (default-deny)", () => {
@@ -65,5 +98,71 @@ describe("isEnvForwardableToSubAgent (deny-then-allow)", () => {
     expect(isEnvForwardableToSubAgent("ELIZA_HOOK_PORT")).toBe(true);
     expect(isEnvForwardableToSubAgent("ANTHROPIC_API_KEY")).toBe(true);
     expect(isEnvForwardableToSubAgent("PATH")).toBe(true);
+  });
+});
+
+// Canonicalization: OS system vars are forwarded under their uppercase form so a
+// child never inherits two casings of the same var. Non-system keys are untouched.
+describe("canonicalForwardedEnvKey", () => {
+  it("uppercases OS system vars regardless of source casing", () => {
+    expect(canonicalForwardedEnvKey("Path")).toBe("PATH");
+    expect(canonicalForwardedEnvKey("path")).toBe("PATH");
+    expect(canonicalForwardedEnvKey("Pathext")).toBe("PATHEXT");
+    expect(canonicalForwardedEnvKey("SystemRoot")).toBe("SYSTEMROOT");
+    expect(canonicalForwardedEnvKey("ProgramFiles")).toBe("PROGRAMFILES");
+  });
+
+  it("leaves non-system keys (prefix/allowlist vars) untouched", () => {
+    expect(canonicalForwardedEnvKey("ELIZA_HOOK_PORT")).toBe("ELIZA_HOOK_PORT");
+    expect(canonicalForwardedEnvKey("ANTHROPIC_API_KEY")).toBe(
+      "ANTHROPIC_API_KEY",
+    );
+    expect(canonicalForwardedEnvKey("PARALLAX_SESSION_ID")).toBe(
+      "PARALLAX_SESSION_ID",
+    );
+  });
+});
+
+// The pure host-env -> sub-agent-env projection buildEnv applies. This is the
+// regression guard for the Windows/Bun bug: Bun reports the search path as
+// `Path`, and a case-sensitive forward dropped it entirely.
+describe("forwardableSubAgentEnv", () => {
+  it("canonicalizes the Windows `Path` key to `PATH` (the bug)", () => {
+    const out = forwardableSubAgentEnv({ Path: "C:\\bun;C:\\Windows" });
+    expect(out.PATH).toBe("C:\\bun;C:\\Windows");
+    expect(out.Path).toBeUndefined();
+  });
+
+  it("never emits two casings of the same OS var", () => {
+    // A pathological env carrying both casings collapses to one canonical key.
+    const out = forwardableSubAgentEnv({ Path: "/a", PATH: "/b" });
+    expect(Object.keys(out).filter((k) => /^path$/i.test(k))).toEqual(["PATH"]);
+    expect(out.Path).toBeUndefined();
+  });
+
+  it("forwards + canonicalizes the Windows system vars", () => {
+    const out = forwardableSubAgentEnv({
+      Pathext: ".COM;.EXE;.CMD",
+      SystemRoot: "C:\\Windows",
+      ComSpec: "C:\\Windows\\System32\\cmd.exe",
+    });
+    expect(out.PATHEXT).toBe(".COM;.EXE;.CMD");
+    expect(out.SYSTEMROOT).toBe("C:\\Windows");
+    expect(out.COMSPEC).toBe("C:\\Windows\\System32\\cmd.exe");
+  });
+
+  it("keeps prefix/allowlist vars verbatim and drops denied + non-allowlisted", () => {
+    const out = forwardableSubAgentEnv({
+      ELIZA_HOOK_PORT: "2138",
+      ANTHROPIC_API_KEY: "sk-x",
+      ELIZA_VAULT_PASSPHRASE: "secret", // allowlisted by ELIZA_ but deny-listed
+      DISCORD_BOT_TOKEN: "nope", // not allowlisted
+      MISSING: undefined, // non-string skipped
+    });
+    expect(out.ELIZA_HOOK_PORT).toBe("2138");
+    expect(out.ANTHROPIC_API_KEY).toBe("sk-x");
+    expect(out.ELIZA_VAULT_PASSPHRASE).toBeUndefined();
+    expect(out.DISCORD_BOT_TOKEN).toBeUndefined();
+    expect("MISSING" in out).toBe(false);
   });
 });

--- a/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-service.ts
@@ -1963,12 +1963,11 @@ export class AcpService extends Service {
     model?: string,
     agentType?: AgentType,
   ): NodeJS.ProcessEnv {
-    const env: NodeJS.ProcessEnv = {};
-    for (const [key, value] of Object.entries(process.env)) {
-      if (typeof value !== "string") continue;
-      if (isDeniedSubAgentEnvKey(key)) continue;
-      if (shouldForwardEnv(key)) env[key] = value;
-    }
+    // Deny-list-filtered, allowlisted, casing-canonicalized host env (see
+    // forwardableSubAgentEnv / canonicalForwardedEnvKey — Bun on Windows reports
+    // OS vars like `Path` with native casing, which a child must not inherit
+    // alongside an uppercase duplicate).
+    const env: NodeJS.ProcessEnv = forwardableSubAgentEnv(process.env);
     for (const [key, value] of Object.entries(customCredentials ?? {})) {
       if (typeof value !== "string") continue;
       // customCredentials arrive with the spawn request, not from the parent's
@@ -1981,10 +1980,10 @@ export class AcpService extends Service {
         });
         continue;
       }
-      env[key] = value;
+      env[canonicalForwardedEnvKey(key)] = value;
     }
     for (const [key, value] of Object.entries(extra ?? {})) {
-      if (typeof value === "string") env[key] = value;
+      if (typeof value === "string") env[canonicalForwardedEnvKey(key)] = value;
     }
     if (model) {
       env.OPENAI_MODEL = model;
@@ -2221,16 +2220,63 @@ export function isClaudeOAuthSubscriptionToken(
   return value?.startsWith("sk-ant-oat") ?? false;
 }
 
+/**
+ * OS-level environment variables a spawned coding agent needs to function.
+ * Matched case-insensitively (see `shouldForwardEnv`): the repo runtime is Bun,
+ * and Bun on Windows reports these with native casing — `Path`, not `PATH` —
+ * so a case-sensitive check would forward NONE of them, leaving the child with
+ * no search path (the opencode shim then fails with "'bun' is not recognized").
+ * Includes the Windows essentials cmd.exe + Bun + the agent's config/cache
+ * resolution rely on, alongside the POSIX names.
+ */
+const FORWARDED_SYSTEM_ENV: ReadonlySet<string> = new Set([
+  "PATH",
+  "PATHEXT",
+  "HOME",
+  "USER",
+  "LANG",
+  "LC_ALL",
+  "LC_CTYPE",
+  "TZ",
+  "TERM",
+  // Windows essentials.
+  "SYSTEMROOT",
+  "WINDIR",
+  "COMSPEC",
+  "SYSTEMDRIVE",
+  "TEMP",
+  "TMP",
+  "USERPROFILE",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "PROGRAMDATA",
+  "PROGRAMFILES",
+  "PROGRAMFILES(X86)",
+  "COMMONPROGRAMFILES",
+  "NUMBER_OF_PROCESSORS",
+  "PROCESSOR_ARCHITECTURE",
+  "USERNAME",
+  "USERDOMAIN",
+]);
+
+/**
+ * The key a forwarded var is assigned under. OS system vars are canonicalized to
+ * their uppercase `FORWARDED_SYSTEM_ENV` form because Bun on Windows reports them
+ * with native casing (`Path`, `Pathext`, `SystemRoot`, `ProgramFiles`, …); a
+ * child must not inherit two casings of the same var (the winner is undefined on
+ * Windows), and JS consumers that read `env.PATH` case-sensitively need the
+ * canonical key. Non-system keys (ELIZA_*, API keys, model overrides) keep their
+ * original casing.
+ */
+export function canonicalForwardedEnvKey(key: string): string {
+  return FORWARDED_SYSTEM_ENV.has(key.toUpperCase()) ? key.toUpperCase() : key;
+}
+
 export function shouldForwardEnv(key: string): boolean {
   return (
-    key === "PATH" ||
-    key === "HOME" ||
-    key === "USER" ||
-    key === "LANG" ||
-    key === "LC_ALL" ||
-    key === "LC_CTYPE" ||
-    key === "TZ" ||
-    key === "TERM" ||
+    FORWARDED_SYSTEM_ENV.has(key.toUpperCase()) ||
     key.startsWith("ACPX_AUTH_") ||
     key.startsWith("ELIZA_") ||
     // Parent-context bridge session id (ELIZA_HOOK_PORT already passes via the
@@ -2263,6 +2309,25 @@ export function shouldForwardEnv(key: string): boolean {
 export function isEnvForwardableToSubAgent(key: string): boolean {
   if (isDeniedSubAgentEnvKey(key)) return false;
   return shouldForwardEnv(key);
+}
+
+/**
+ * The deny-list-filtered, allowlisted, casing-canonicalized subset of `source`
+ * to forward to a coding sub-agent. Pure (no process.env read) so it is unit
+ * testable: pass a synthetic env (e.g. `{ Path: "…" }`, the casing Bun reports
+ * on Windows) and assert the result is keyed by `PATH`. See
+ * `canonicalForwardedEnvKey` for why OS vars are canonicalized.
+ */
+export function forwardableSubAgentEnv(
+  source: Record<string, string | undefined>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(source)) {
+    if (typeof value !== "string") continue;
+    if (!isEnvForwardableToSubAgent(key)) continue;
+    out[canonicalForwardedEnvKey(key)] = value;
+  }
+  return out;
 }
 
 function extractSessionId(event: AcpJsonRpcMessage): string | undefined {


### PR DESCRIPTION
## What

`shouldForwardEnv` (the allowlist `buildEnv` uses to decide which host env vars a
spawned ACP coding sub-agent inherits) matched the OS search path as
`key === "PATH"` — case-sensitively.

The repo runtime is Bun, and **Bun on Windows reports the key as `Path`, not
`PATH`**. So `buildEnv` forwarded *none* of it, and every spawned ACP sub-agent
inherited an empty `PATH`. The vendored opencode shim then died at spawn with:

```
'bun' is not recognized as an internal or external command, operable program or batch file.
```

i.e. ACP-driven coding agents were unusable on Windows.

## Fix

- Match the OS system vars **case-insensitively** (a `Set` keyed by uppercase
  name) and broaden the set to the Windows essentials a spawned shell + Bun +
  the agent's config/cache resolution need (`PATHEXT`, `SYSTEMROOT`, `COMSPEC`,
  `SYSTEMDRIVE`, `TEMP`/`TMP`, `USERPROFILE`, `APPDATA`/`LOCALAPPDATA`,
  `PROGRAMFILES`, …) alongside the existing POSIX names.
- **Canonicalize** each forwarded system var to its uppercase form in `buildEnv`
  (all three sources: `process.env`, `customCredentials`, `extra`) so a child
  never inherits two casings of the same var (the winner is undefined on
  Windows) and JS consumers that read `env.PATH` case-sensitively resolve it.
- Extract the projection into the pure, exported `forwardableSubAgentEnv` /
  `canonicalForwardedEnvKey` so the behavior is unit-testable.

The deny-list (`isDeniedSubAgentEnvKey`) still runs **first** (deny wins over
allow), so no secret is newly forwarded — covered by the existing + new tests.

## Testing

- `__tests__/unit/should-forward-env.test.ts` — added Windows-casing,
  no-over-match, system-var, canonicalization, and dual-casing-collapse cases
  (17 pass).
- `bun run --cwd plugins/plugin-agent-orchestrator typecheck` clean.

## How it was surfaced

Running the monetized-app economics `/goal` loop end-to-end on Windows: a real
`opencode` ACP sub-agent (Cerebras `gpt-oss-120b`) would not spawn until the
PATH was forwarded.
