### PR TITLE
fix(orchestrator): honor the configured session timeout for the ACP initialize handshake

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/acp-native-transport.test.ts
@@ -311,6 +311,46 @@ describe("NativeAcpClient JSON-RPC lifecycle", () => {
     emitJson(p, { jsonrpc: "2.0", id: 3, result: {} });
   });
 
+  it("initialize honors the configured session timeout instead of the 300s default", async () => {
+    // Regression: the first opencode spawn compiles its TS tree and installs the
+    // provider npm package (e.g. @ai-sdk/cerebras), which can exceed the 300s
+    // default. The `initialize` handshake must honor the configured session
+    // timeout like `session/prompt` does, or a cold spawn aborts with
+    // "ACP request timed out: initialize" before the agent is ever usable.
+    vi.useFakeTimers();
+    const p = queueProc();
+    const client = new NativeAcpClient({
+      command: "agent-acp",
+      cwd: "/tmp/native-acp",
+      approvalPreset: "autonomous",
+      timeoutMs: 600_000, // 10 min — well past the 300s default
+    });
+    let settled = false;
+    const startResult = client.start().then(
+      (value) => {
+        settled = true;
+        return value;
+      },
+      (error: unknown) => {
+        settled = true;
+        return error;
+      },
+    );
+    await waitForWrites(p, 1);
+    expect(writeAt(p, 0)).toMatchObject({ method: "initialize" });
+
+    // Past the OLD 300s default — must NOT have fired yet (proves the override).
+    await vi.advanceTimersByTimeAsync(301_000);
+    expect(settled).toBe(false);
+
+    // Cross the configured 600s budget — now it times out.
+    await vi.advanceTimersByTimeAsync(300_000);
+    const error = await startResult;
+    expect(settled).toBe(true);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("ACP request timed out: initialize");
+  });
+
   it("returns method-not-found for unsupported client request methods", async () => {
     const { p } = await startClient();
 

--- a/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/acp-native-transport.ts
@@ -113,17 +113,26 @@ export class NativeAcpClient {
       );
     });
 
-    await this.request("initialize", {
-      protocolVersion: ACP_PROTOCOL_VERSION,
-      clientCapabilities: {
-        fs: { readTextFile: true, writeTextFile: true },
-        terminal: this.opts.terminal !== false,
+    await this.request(
+      "initialize",
+      {
+        protocolVersion: ACP_PROTOCOL_VERSION,
+        clientCapabilities: {
+          fs: { readTextFile: true, writeTextFile: true },
+          terminal: this.opts.terminal !== false,
+        },
+        clientInfo: {
+          name: "@elizaos/plugin-agent-orchestrator",
+          version: "2.0.0",
+        },
       },
-      clientInfo: {
-        name: "@elizaos/plugin-agent-orchestrator",
-        version: "2.0.0",
-      },
-    });
+      // The first opencode spawn compiles its TS tree and installs the provider
+      // npm package (e.g. @ai-sdk/cerebras), which can exceed the 300s default.
+      // Honor the configured session timeout for the handshake too.
+      this.opts.timeoutMs && this.opts.timeoutMs > 0
+        ? this.opts.timeoutMs
+        : DEFAULT_TIMEOUT_MS,
+    );
   }
 
   async createSession(cwd = this.opts.cwd): Promise<NativeAcpSession> {


### PR DESCRIPTION
## Problem
`NativeAcpClient.connect()` issues the `initialize` JSON-RPC request without a timeout argument, so it always falls back to the hardcoded `DEFAULT_TIMEOUT_MS` (300s) — even though every session already carries a `timeoutMs` (from `ACPX_DEFAULT_TIMEOUT_MS` / `ELIZA_ACP_PROMPT_TIMEOUT_MS`) that governs `session/prompt`.

A cold first spawn of an agent that runs from source (e.g. the vendored opencode shim) compiles its TS tree and installs its provider npm package (e.g. `@ai-sdk/cerebras`) during startup. That can take longer than 300s, so the handshake aborts with `ACP request timed out: initialize` before the agent is ever usable — even when the operator configured a longer timeout.

## Fix
Pass the configured session timeout to the `initialize` request, falling back to the 300s default when unset. This makes the handshake consistent with how `session/prompt` already honors `this.opts.timeoutMs`.

## Test
Adds a regression test to `acp-native-transport.test.ts`: with `timeoutMs: 600_000`, fake timers advance past the old 300s default (asserting the handshake has NOT timed out yet), then past the configured 600s budget (asserting it times out with `ACP request timed out: initialize`).

`vitest run __tests__/unit/acp-native-transport.test.ts` → 17/17 pass.