### PR TITLE
fix(cloud-api): sign /api/auth/steward-refresh upstream call to Steward

### DIFF
--- a/packages/cloud-api/auth/steward-refresh/route.ts
+++ b/packages/cloud-api/auth/steward-refresh/route.ts
@@ -30,6 +30,7 @@ import {
 } from "@elizaos/shared/steward-session-client";
 import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
+import { signStewardMutatingRequest } from "@/api-app/steward/sign";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
 import {
   type StewardVerifyEnv,
@@ -172,27 +173,45 @@ async function callStewardRefresh(
   baseUrl: string,
   refreshToken: string,
   pinnedTenantId?: string,
+  signingSecret?: string,
 ): Promise<
   | { kind: "ok"; data: StewardRefreshOk }
   | { kind: "error"; status: number; data: StewardRefreshErr }
   | { kind: "transport"; message: string }
 > {
-  const headers: Record<string, string> = {
+  const headers = new Headers({
     "Content-Type": "application/json",
     Accept: "application/json",
-  };
+  });
   // Pin the tenant per-env: this route bypasses the /steward/* proxy in
   // bootstrap-app.ts and would otherwise hit Steward without scoping,
   // letting a staging refresh land against the prod tenant.
   if (typeof pinnedTenantId === "string" && pinnedTenantId.trim().length > 0) {
-    headers["X-Steward-Tenant"] = pinnedTenantId.trim();
+    headers.set("X-Steward-Tenant", pinnedTenantId.trim());
+  }
+  const bodyText = JSON.stringify({ refreshToken });
+  const bodyBytes = new TextEncoder().encode(bodyText);
+  const refreshUrl = new URL(`${baseUrl}/auth/refresh`);
+  // Steward's authorization-signature middleware gates mutating sensitive
+  // paths (incl. /auth/refresh) on the signed-request contract. The
+  // /steward/* embedded proxy signs automatically; this bypass route must
+  // sign the same way or Steward 502s with "Request expiry header required",
+  // which kicks the SPA back to /login after every magic-link verify.
+  if (typeof signingSecret === "string" && signingSecret.length > 0) {
+    await signStewardMutatingRequest(
+      signingSecret,
+      "POST",
+      `${refreshUrl.pathname}${refreshUrl.search}`,
+      headers,
+      bodyBytes,
+    );
   }
   let response: Response;
   try {
-    response = await fetch(`${baseUrl}/auth/refresh`, {
+    response = await fetch(refreshUrl.toString(), {
       method: "POST",
       headers,
-      body: JSON.stringify({ refreshToken }),
+      body: bodyText,
     });
   } catch (err) {
     return {
@@ -270,6 +289,7 @@ app.post("/", async (c) => {
     stewardBaseUrl,
     refreshToken,
     c.env.STEWARD_TENANT_ID,
+    c.env.STEWARD_REQUEST_SIGNING_SECRET,
   );
 
   if (refresh.kind === "transport") {


### PR DESCRIPTION
## Why

After yesterday's #8282 (staging SPA → api-staging) deployed, the magic-link return-leg gets further than before — `POST /steward/auth/email/verify` now returns 200 with the freshly-issued tokens — but it still kicks the user back to `/login?returnTo=/dashboard` with **"Request expiry header required"** rendered in the login card.

Worker tail captures the actual failure:

\`\`\`
POST /steward/auth/email/verify              200  (Steward issued tokens)
POST /api/auth/steward-session               200  (Worker cookies sync)
POST /api/auth/steward-refresh               502  {"error":"Request expiry header required","code":"internal_error"}
                                                   ↑ this kicks back to /login
\`\`\`

The SPA's session-bootstrap calls `/api/auth/steward-refresh` immediately after the verify to rotate the freshly-issued refresh token. That bypass route forwards directly to Steward `POST /auth/refresh` without going through the `/steward/*` embedded proxy in `bootstrap-app.ts` — same shape as the nonce-exchange bypass route that #8259 already taught to sign. **steward-refresh was missed in that PR**, so its outbound fetch arrives at Steward unsigned and Steward's `authorization-signature` middleware 502s it.

## What

Plumb `c.env.STEWARD_REQUEST_SIGNING_SECRET` into \`callStewardRefresh\` and sign the outbound fetch the same way \`steward-nonce-exchange\` does:

- Convert the local \`headers\` object to a \`Headers\` instance (so \`signStewardMutatingRequest\` can mutate it).
- Build the canonical URL + body bytes once, sign when the secret is configured, then \`fetch(refreshUrl, …)\`.

No new helper, no new env binding — the secret is already set on the Worker (both prod and staging) and \`signStewardMutatingRequest\` already lives in \`packages/cloud-api/src/steward/sign.ts\` (added by #8259).

## Test plan

- [ ] CI green
- [ ] cloud-cf-deploy rolls out the staging Worker
- [ ] Live test: clean SPA profile, request fresh magic link, click immediately. Worker tail should show:
  - \`POST /api/auth/steward-refresh\` → **200** (not 502)
  - Final URL = \`/dashboard\` (not \`/login?returnTo=/dashboard\`)
- [ ] Prod regression: same flow on \`www.elizacloud.ai\` still works (Worker secret is identical, signing function identical to nonce-exchange).

## Follow-up

Audit every other \`/api/auth/steward-*\` bypass route for the same gap (\`steward-session\` is read-only verification but still POSTs upstream; \`steward-nonce-exchange\` signs already). If we find more, batch them together rather than chasing one bypass-route bug at a time.