### PR TITLE
fix(plugin-google): unblock cloud-cf-deploy via Options-shape casts

### DIFF
--- a/plugins/plugin-google/src/client-factory.ts
+++ b/plugins/plugin-google/src/client-factory.ts
@@ -54,9 +54,7 @@ export class GoogleApiClientFactory {
     reason: string
   ): Promise<calendar_v3.Calendar> {
     const auth = await this.resolveAuthClient(account, capabilities, reason);
-    return google.calendar(
-      this.apiOptions("v3", auth) as unknown as calendar_v3.Options,
-    );
+    return google.calendar(this.apiOptions("v3", auth) as unknown as calendar_v3.Options);
   }
 
   async drive(

--- a/plugins/plugin-google/src/client-factory.ts
+++ b/plugins/plugin-google/src/client-factory.ts
@@ -45,7 +45,7 @@ export class GoogleApiClientFactory {
     reason: string
   ): Promise<gmail_v1.Gmail> {
     const auth = await this.resolveAuthClient(account, capabilities, reason);
-    return google.gmail(this.apiOptions("v1", auth));
+    return google.gmail(this.apiOptions("v1", auth) as unknown as gmail_v1.Options);
   }
 
   async calendar(
@@ -54,7 +54,9 @@ export class GoogleApiClientFactory {
     reason: string
   ): Promise<calendar_v3.Calendar> {
     const auth = await this.resolveAuthClient(account, capabilities, reason);
-    return google.calendar(this.apiOptions("v3", auth));
+    return google.calendar(
+      this.apiOptions("v3", auth) as unknown as calendar_v3.Options,
+    );
   }
 
   async drive(
@@ -63,7 +65,7 @@ export class GoogleApiClientFactory {
     reason: string
   ): Promise<drive_v3.Drive> {
     const auth = await this.resolveAuthClient(account, capabilities, reason);
-    return google.drive(this.apiOptions("v3", auth));
+    return google.drive(this.apiOptions("v3", auth) as unknown as drive_v3.Options);
   }
 
   async docs(
@@ -72,7 +74,7 @@ export class GoogleApiClientFactory {
     reason: string
   ): Promise<docs_v1.Docs> {
     const auth = await this.resolveAuthClient(account, capabilities, reason);
-    return google.docs(this.apiOptions("v1", auth));
+    return google.docs(this.apiOptions("v1", auth) as unknown as docs_v1.Options);
   }
 
   async sheets(
@@ -81,7 +83,7 @@ export class GoogleApiClientFactory {
     reason: string
   ): Promise<sheets_v4.Sheets> {
     const auth = await this.resolveAuthClient(account, capabilities, reason);
-    return google.sheets(this.apiOptions("v4", auth));
+    return google.sheets(this.apiOptions("v4", auth) as unknown as sheets_v4.Options);
   }
 
   async meet(
@@ -90,9 +92,16 @@ export class GoogleApiClientFactory {
     reason: string
   ): Promise<meet_v2.Meet> {
     const auth = await this.resolveAuthClient(account, capabilities, reason);
-    return google.meet(this.apiOptions("v2", auth));
+    return google.meet(this.apiOptions("v2", auth) as unknown as meet_v2.Options);
   }
 
+  // The `as <ns>.Options` casts at each call site bridge a TypeScript
+  // identity mismatch: bun's isolated linker installs two copies of
+  // google-auth-library (one direct, one nested under googleapis-common),
+  // so `Auth.OAuth2Client` from 'googleapis' and the `OAuth2Client` baked
+  // into each `<ns>.Options['auth']` resolve to different physical classes.
+  // Runtime is fine — the cast pins TS to the correct Options shape per
+  // method without an override or a global `any`.
   private apiOptions<TVersion extends string>(
     version: TVersion,
     auth: GoogleAuthClient


### PR DESCRIPTION
## Why

The cloud-cf-deploy `build:core` step builds plugin-google transitively (app-core → plugin-health → plugin-calendar → plugin-google) and has been failing on develop with:

```
client-factory.ts(48,25): error TS2769: No overload matches this call.
  Type 'OAuth2Client' (10.7.0) is not assignable to
  Type 'OAuth2Client' (10.5.0)
    Types have separate declarations of a private property 'redirectUri'.
```

bun's isolated linker installs **two copies** of `google-auth-library`:
- `googleapis@169.0.0` declares `google-auth-library: ^10.2.0` → resolves to **10.7.0**
- `googleapis-common@8.0.2` declares `google-auth-library: 10.5.0` exact → installs **10.5.0** nested

Shaw's earlier `#7d1ee6e34c` routed the type via `googleapis.Auth`, but that's the 10.7.0 side, while `gmail_v1.Options.auth` (and the calendar/drive/docs/sheets/meet equivalents) is typed against the 10.5.0 side baked into googleapis itself. Same physical class, different TypeScript nominal identity.

Tried `overrides` and `resolutions` in root package.json — bun still nests the second copy under `googleapis-common`. The next available lever is at the call site.

## What

Per-method `as unknown as <ns>.Options` cast on each of the six service constructors (`gmail`, `calendar`, `drive`, `docs`, `sheets`, `meet`). Runtime auth object is structurally identical — only the TS nominal check is wrong. Short comment near `apiOptions` documents the trap so the next person looking at this code doesn't spend an afternoon retracing it.

## Impact

Unblocks `cloud-cf-deploy` which has been failing all afternoon. Three already-merged cloud-api fixes are sitting undeployed behind this:
- #8282 staging tenant routing
- #8283 wildcard verify-step removal
- #8287 steward-refresh signing (the Magic Link callback fix)

## Test plan

- [ ] CI green
- [ ] `cloud-cf-deploy` on develop completes both Worker + Pages
- [ ] Worker staging picks up the steward-refresh signing (Magic Link callback lands on /dashboard, not /login?returnTo=)
- [ ] No regression on prod Worker

## Follow-up

A proper fix would pin both googleapis dependencies to the same auth-library minor (or wait for googleapis-common to bump). That's an upstream concern; this cast keeps us shipping while it gets sorted.