### PR TITLE
feat(cloud-sdk): "Sign in with Eliza Cloud" app-auth SDK

### DIFF
--- a/packages/cloud-sdk/AGENTS.md
+++ b/packages/cloud-sdk/AGENTS.md
@@ -92,6 +92,29 @@ import { MockCloudSetupSessionService, DEFAULT_SETUP_POLICY, isActionAllowed }
   from "@elizaos/cloud-sdk/cloud-setup-session";
 ```
 
+### Sub-export (`@elizaos/cloud-sdk/app-auth`)
+
+"Sign in with Eliza Cloud" client helpers for **third-party apps** — a small,
+dependency-free wrapper over the live app-auth flow (consent page →
+one-time `eac_` code → `GET /api/v1/app-auth/session` exchange → user). No PKCE
+(the consent step is gated by the user's existing Eliza Cloud session; the
+`redirect_uri` is validated against the app's registered allowed origins).
+
+```ts
+import { ElizaCloudAppAuth } from "@elizaos/cloud-sdk/app-auth";
+
+const auth = new ElizaCloudAppAuth({ appId, redirectUri });
+// 1. send the user here:
+location.href = auth.authorizeUrl(state);
+// 2. on your callback route (server-side recommended):
+const { user, app } = await auth.completeSignIn(req.url);
+```
+
+Standalone functions are also exported: `buildAppAuthorizeUrl`,
+`parseAppAuthorizeCallback`, `exchangeAppAuthorizeCode`, `looksLikeAppAuthCode`,
+plus `ElizaCloudAuthError` and the `APP_AUTH_*` path/prefix constants. All take
+an optional `fetchImpl` / `baseUrl` / `apiBaseUrl` for tests and custom origins.
+
 ## Commands
 
 ```bash

--- a/packages/cloud-sdk/CLAUDE.md
+++ b/packages/cloud-sdk/CLAUDE.md
@@ -92,6 +92,29 @@ import { MockCloudSetupSessionService, DEFAULT_SETUP_POLICY, isActionAllowed }
   from "@elizaos/cloud-sdk/cloud-setup-session";
 ```
 
+### Sub-export (`@elizaos/cloud-sdk/app-auth`)
+
+"Sign in with Eliza Cloud" client helpers for **third-party apps** — a small,
+dependency-free wrapper over the live app-auth flow (consent page →
+one-time `eac_` code → `GET /api/v1/app-auth/session` exchange → user). No PKCE
+(the consent step is gated by the user's existing Eliza Cloud session; the
+`redirect_uri` is validated against the app's registered allowed origins).
+
+```ts
+import { ElizaCloudAppAuth } from "@elizaos/cloud-sdk/app-auth";
+
+const auth = new ElizaCloudAppAuth({ appId, redirectUri });
+// 1. send the user here:
+location.href = auth.authorizeUrl(state);
+// 2. on your callback route (server-side recommended):
+const { user, app } = await auth.completeSignIn(req.url);
+```
+
+Standalone functions are also exported: `buildAppAuthorizeUrl`,
+`parseAppAuthorizeCallback`, `exchangeAppAuthorizeCode`, `looksLikeAppAuthCode`,
+plus `ElizaCloudAuthError` and the `APP_AUTH_*` path/prefix constants. All take
+an optional `fetchImpl` / `baseUrl` / `apiBaseUrl` for tests and custom origins.
+
 ## Commands
 
 ```bash

--- a/packages/cloud-sdk/package.json
+++ b/packages/cloud-sdk/package.json
@@ -36,6 +36,16 @@
       "import": "./dist/cloud-setup-session/*.js",
       "default": "./dist/cloud-setup-session/*.js"
     },
+    "./app-auth": {
+      "types": "./dist/app-auth/index.d.ts",
+      "eliza-source": {
+        "types": "./src/app-auth/index.ts",
+        "import": "./src/app-auth/index.ts",
+        "default": "./src/app-auth/index.ts"
+      },
+      "import": "./dist/app-auth/index.js",
+      "default": "./dist/app-auth/index.js"
+    },
     "./package.json": "./package.json"
   }
 }

--- a/packages/cloud-sdk/src/app-auth/app-auth.test.ts
+++ b/packages/cloud-sdk/src/app-auth/app-auth.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  APP_AUTH_CODE_PREFIX,
+  buildAppAuthorizeUrl,
+  ElizaCloudAppAuth,
+  ElizaCloudAuthError,
+  exchangeAppAuthorizeCode,
+  looksLikeAppAuthCode,
+  parseAppAuthorizeCallback,
+} from "./index.js";
+
+const APP_ID = "11111111-2222-3333-4444-555555555555";
+const REDIRECT = "https://nubilio.app/auth/callback";
+const CODE = `${APP_AUTH_CODE_PREFIX}abcdef123456`;
+
+type FetchFn = (
+  input: string | URL | Request,
+  init?: RequestInit,
+) => Promise<Response>;
+
+/** Cast a narrow fetch mock to the full `typeof fetch` the SDK expects. */
+const asFetch = (fn: FetchFn): typeof fetch => fn as unknown as typeof fetch;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** A fetch mock that always returns `body` with `status`. */
+function fetchReturning(body: unknown, status = 200) {
+  return vi.fn<FetchFn>(async () => jsonResponse(body, status));
+}
+
+/** Read the headers object the mock was first called with. */
+function headersOf(
+  mock: ReturnType<typeof fetchReturning>,
+): Record<string, string> {
+  const init: RequestInit = mock.mock.calls[0][1] ?? {};
+  return (init.headers ?? {}) as Record<string, string>;
+}
+
+describe("buildAppAuthorizeUrl", () => {
+  it("builds the consent URL with app_id, redirect_uri, state", () => {
+    const url = new URL(
+      buildAppAuthorizeUrl({
+        appId: APP_ID,
+        redirectUri: REDIRECT,
+        state: "xyz",
+      }),
+    );
+    expect(url.origin + url.pathname).toBe(
+      "https://www.elizacloud.ai/app-auth/authorize",
+    );
+    expect(url.searchParams.get("app_id")).toBe(APP_ID);
+    expect(url.searchParams.get("redirect_uri")).toBe(REDIRECT);
+    expect(url.searchParams.get("state")).toBe("xyz");
+  });
+
+  it("omits state when not provided and honors a custom baseUrl", () => {
+    const url = new URL(
+      buildAppAuthorizeUrl({
+        appId: APP_ID,
+        redirectUri: REDIRECT,
+        baseUrl: "https://staging.elizacloud.ai/",
+      }),
+    );
+    expect(url.host).toBe("staging.elizacloud.ai");
+    expect(url.searchParams.has("state")).toBe(false);
+  });
+
+  it("throws when appId or redirectUri is missing", () => {
+    expect(() =>
+      buildAppAuthorizeUrl({ appId: "", redirectUri: REDIRECT }),
+    ).toThrow();
+    expect(() =>
+      buildAppAuthorizeUrl({ appId: APP_ID, redirectUri: "" }),
+    ).toThrow();
+  });
+});
+
+describe("looksLikeAppAuthCode", () => {
+  it("accepts eac_ codes and rejects everything else", () => {
+    expect(looksLikeAppAuthCode(CODE)).toBe(true);
+    expect(looksLikeAppAuthCode("nope")).toBe(false);
+    expect(looksLikeAppAuthCode(null)).toBe(false);
+    expect(looksLikeAppAuthCode(undefined)).toBe(false);
+  });
+});
+
+describe("parseAppAuthorizeCallback", () => {
+  it("parses a success callback from a full URL string", () => {
+    const cb = parseAppAuthorizeCallback(`${REDIRECT}?code=${CODE}&state=xyz`);
+    expect(cb).toEqual({
+      code: CODE,
+      state: "xyz",
+      error: null,
+      errorDescription: null,
+    });
+  });
+
+  it("parses a denial callback", () => {
+    const cb = parseAppAuthorizeCallback(
+      `${REDIRECT}?error=access_denied&error_description=User%20denied%20authorization&state=xyz`,
+    );
+    expect(cb.error).toBe("access_denied");
+    expect(cb.errorDescription).toBe("User denied authorization");
+    expect(cb.code).toBeNull();
+  });
+
+  it("accepts URLSearchParams, a bare query string, and a Location-like object", () => {
+    expect(
+      parseAppAuthorizeCallback(new URLSearchParams(`code=${CODE}`)).code,
+    ).toBe(CODE);
+    expect(parseAppAuthorizeCallback(`?code=${CODE}`).code).toBe(CODE);
+    expect(parseAppAuthorizeCallback(`code=${CODE}`).code).toBe(CODE);
+    expect(parseAppAuthorizeCallback({ search: `?code=${CODE}` }).code).toBe(
+      CODE,
+    );
+  });
+
+  it("returns all-null for an empty callback", () => {
+    expect(parseAppAuthorizeCallback(REDIRECT)).toEqual({
+      code: null,
+      state: null,
+      error: null,
+      errorDescription: null,
+    });
+  });
+});
+
+describe("exchangeAppAuthorizeCode", () => {
+  it("GETs the session endpoint with a Bearer code and returns the user", async () => {
+    const user = {
+      id: "user-1",
+      email: "nubs@example.com",
+      name: "Nubs",
+      avatar: null,
+      createdAt: "2026-06-06T00:00:00Z",
+    };
+    const fetchImpl = fetchReturning({
+      success: true,
+      user,
+      app: { id: APP_ID, name: "Nubilio" },
+    });
+
+    const session = await exchangeAppAuthorizeCode(CODE, {
+      appId: APP_ID,
+      fetchImpl: asFetch(fetchImpl),
+    });
+
+    expect(session.user).toEqual(user);
+    expect(session.app).toEqual({ id: APP_ID, name: "Nubilio" });
+
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      "https://api.elizacloud.ai/api/v1/app-auth/session",
+    );
+    expect(fetchImpl.mock.calls[0][1]?.method).toBe("GET");
+    const headers = headersOf(fetchImpl);
+    expect(headers.authorization).toBe(`Bearer ${CODE}`);
+    expect(headers["x-app-id"]).toBe(APP_ID);
+  });
+
+  it("honors a custom apiBaseUrl", async () => {
+    const fetchImpl = fetchReturning({
+      success: true,
+      user: { id: "u", email: null, name: null, avatar: null, createdAt: null },
+    });
+    await exchangeAppAuthorizeCode(CODE, {
+      apiBaseUrl: "https://api.staging.elizacloud.ai/api/v1/",
+      fetchImpl: asFetch(fetchImpl),
+    });
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      "https://api.staging.elizacloud.ai/api/v1/app-auth/session",
+    );
+  });
+
+  it("rejects a non-eac_ code before making any request", async () => {
+    const fetchImpl = vi.fn<FetchFn>();
+    await expect(
+      exchangeAppAuthorizeCode("not-a-code", { fetchImpl: asFetch(fetchImpl) }),
+    ).rejects.toBeInstanceOf(ElizaCloudAuthError);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("throws ElizaCloudAuthError with the server code on a 401", async () => {
+    const fetchImpl = fetchReturning(
+      {
+        error: {
+          code: "code_invalid",
+          message: "Invalid or expired authorization code",
+        },
+      },
+      401,
+    );
+    const promise = exchangeAppAuthorizeCode(CODE, {
+      fetchImpl: asFetch(fetchImpl),
+    });
+    await expect(promise).rejects.toBeInstanceOf(ElizaCloudAuthError);
+    await expect(promise).rejects.toMatchObject({
+      statusCode: 401,
+      code: "code_invalid",
+    });
+    await expect(promise).rejects.toThrow("Invalid or expired");
+  });
+});
+
+describe("ElizaCloudAppAuth", () => {
+  it("binds appId + redirectUri and delegates", async () => {
+    const fetchImpl = fetchReturning({
+      success: true,
+      user: { id: "u", email: null, name: null, avatar: null, createdAt: null },
+    });
+    const auth = new ElizaCloudAppAuth({
+      appId: APP_ID,
+      redirectUri: REDIRECT,
+      fetchImpl: asFetch(fetchImpl),
+    });
+
+    expect(new URL(auth.authorizeUrl("s")).searchParams.get("app_id")).toBe(
+      APP_ID,
+    );
+
+    await auth.completeSignIn(`${REDIRECT}?code=${CODE}&state=s`);
+    expect(headersOf(fetchImpl)["x-app-id"]).toBe(APP_ID);
+  });
+
+  it("completeSignIn throws on a denial callback without fetching", async () => {
+    const fetchImpl = vi.fn<FetchFn>();
+    const auth = new ElizaCloudAppAuth({
+      appId: APP_ID,
+      redirectUri: REDIRECT,
+      fetchImpl: asFetch(fetchImpl),
+    });
+    await expect(
+      auth.completeSignIn(
+        `${REDIRECT}?error=access_denied&error_description=nope`,
+      ),
+    ).rejects.toMatchObject({ code: "access_denied" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("completeSignIn throws when no code is present", async () => {
+    const auth = new ElizaCloudAppAuth({
+      appId: APP_ID,
+      redirectUri: REDIRECT,
+    });
+    await expect(auth.completeSignIn(REDIRECT)).rejects.toMatchObject({
+      code: "missing_code",
+    });
+  });
+});

--- a/packages/cloud-sdk/src/app-auth/index.ts
+++ b/packages/cloud-sdk/src/app-auth/index.ts
@@ -1,0 +1,358 @@
+/**
+ * "Sign in with Eliza Cloud" — client helpers for third-party apps.
+ *
+ * Lets any app authenticate its users through Eliza Cloud with a small,
+ * dependency-free authorization-code flow:
+ *
+ *   1. Redirect the user to the consent page:
+ *        buildAppAuthorizeUrl({ appId, redirectUri, state })
+ *      → https://www.elizacloud.ai/app-auth/authorize?app_id=…&redirect_uri=…&state=…
+ *
+ *   2. Eliza Cloud redirects back to `redirectUri` with a one-time code:
+ *        success: <redirectUri>?code=eac_…&state=…
+ *        denied:  <redirectUri>?error=access_denied&error_description=…&state=…
+ *      Read it with parseAppAuthorizeCallback(window.location).
+ *
+ *   3. Exchange the code (server-side recommended) for the user:
+ *        exchangeAppAuthorizeCode(code)
+ *      → GET /api/v1/app-auth/session  (Authorization: Bearer eac_…)
+ *      → { user: { id, email, name, avatar, createdAt }, app }
+ *
+ * The code is opaque (`eac_` prefix), single-use, and expires in 5 minutes.
+ * There is no PKCE on this flow — the consent step is gated by the user's
+ * existing Eliza Cloud session, and `redirect_uri` is validated against the
+ * app's registered allowed origins.
+ */
+
+import {
+  DEFAULT_ELIZA_CLOUD_API_BASE_URL,
+  DEFAULT_ELIZA_CLOUD_BASE_URL,
+} from "../types.js";
+
+/** Path of the hosted consent page (relative to the site base URL). */
+export const APP_AUTH_AUTHORIZE_PATH = "/app-auth/authorize";
+/** Path of the code-exchange endpoint (relative to the API base URL). */
+export const APP_AUTH_SESSION_PATH = "/app-auth/session";
+/** Prefix every Eliza Cloud app-auth code carries. */
+export const APP_AUTH_CODE_PREFIX = "eac_";
+
+/** True when `value` looks like an Eliza Cloud app-auth code (`eac_…`). */
+export function looksLikeAppAuthCode(
+  value: string | null | undefined,
+): value is string {
+  return typeof value === "string" && value.startsWith(APP_AUTH_CODE_PREFIX);
+}
+
+export interface BuildAppAuthorizeUrlOptions {
+  /** The app's UUID, as registered with Eliza Cloud. */
+  appId: string;
+  /** Where Eliza Cloud sends the user back. Must be a registered origin. */
+  redirectUri: string;
+  /** Opaque value echoed back on the callback for CSRF protection. */
+  state?: string;
+  /** Site origin hosting the consent page. Defaults to www.elizacloud.ai. */
+  baseUrl?: string;
+}
+
+/**
+ * Build the URL to redirect a user to so they can authorize your app.
+ * Mirrors the params the hosted consent page reads (`app_id`, `redirect_uri`,
+ * `state`).
+ */
+export function buildAppAuthorizeUrl(
+  options: BuildAppAuthorizeUrlOptions,
+): string {
+  const { appId, redirectUri, state, baseUrl } = options;
+  if (!appId) throw new TypeError("buildAppAuthorizeUrl: appId is required");
+  if (!redirectUri) {
+    throw new TypeError("buildAppAuthorizeUrl: redirectUri is required");
+  }
+  const base = trimTrailingSlash(baseUrl ?? DEFAULT_ELIZA_CLOUD_BASE_URL);
+  const url = new URL(`${base}${APP_AUTH_AUTHORIZE_PATH}`);
+  url.searchParams.set("app_id", appId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  if (state != null) url.searchParams.set("state", state);
+  return url.toString();
+}
+
+export interface AppAuthorizeCallback {
+  /** The one-time `eac_` code on success, else null. */
+  code: string | null;
+  /** The `state` value echoed back, if any. */
+  state: string | null;
+  /** The error code on denial/failure (e.g. `access_denied`), else null. */
+  error: string | null;
+  /** Human-readable error detail, if any. */
+  errorDescription: string | null;
+}
+
+/**
+ * Parse the callback Eliza Cloud redirected to. Accepts a full URL string, a
+ * `URL`, a `URLSearchParams`, or a raw query string (with or without `?`).
+ * In a browser you can pass `window.location`.
+ */
+export function parseAppAuthorizeCallback(
+  input: string | URL | URLSearchParams | { search: string } | Location,
+): AppAuthorizeCallback {
+  const params = toSearchParams(input);
+  return {
+    code: params.get("code"),
+    state: params.get("state"),
+    error: params.get("error"),
+    errorDescription: params.get("error_description"),
+  };
+}
+
+/** A user as returned by the Eliza Cloud app-auth session endpoint. */
+export interface ElizaCloudUser {
+  id: string;
+  email: string | null;
+  name: string | null;
+  avatar: string | null;
+  createdAt: string | null;
+}
+
+/** The app the code was issued for, when resolvable. */
+export interface ElizaCloudAppInfo {
+  id: string;
+  name: string;
+}
+
+export interface AppAuthSession {
+  user: ElizaCloudUser;
+  app: ElizaCloudAppInfo | null;
+}
+
+/** Thrown when the code exchange is rejected by Eliza Cloud. */
+export class ElizaCloudAuthError extends Error {
+  readonly statusCode: number;
+  readonly code: string | null;
+  constructor(message: string, statusCode: number, code: string | null = null) {
+    super(message);
+    this.name = "ElizaCloudAuthError";
+    this.statusCode = statusCode;
+    this.code = code;
+  }
+}
+
+export interface ExchangeAppAuthorizeCodeOptions {
+  /** API base URL. Defaults to https://api.elizacloud.ai/api/v1. */
+  apiBaseUrl?: string;
+  /** Bind the exchange to a specific app id (sent as `X-App-Id`). */
+  appId?: string;
+  /** Inject a custom fetch (e.g. for tests or non-global runtimes). */
+  fetchImpl?: typeof fetch;
+  /** Abort signal forwarded to fetch. */
+  signal?: AbortSignal;
+}
+
+/**
+ * Exchange a one-time `eac_` code for the signed-in Eliza Cloud user. The code
+ * is consumed on first use. Run this server-side so the code never sits in a
+ * browser. Throws `ElizaCloudAuthError` on a non-2xx response.
+ */
+export async function exchangeAppAuthorizeCode(
+  code: string,
+  options: ExchangeAppAuthorizeCodeOptions = {},
+): Promise<AppAuthSession> {
+  if (!looksLikeAppAuthCode(code)) {
+    throw new ElizaCloudAuthError(
+      "Not a valid Eliza Cloud app-auth code (expected an `eac_` code).",
+      400,
+      "invalid_code",
+    );
+  }
+  const apiBase = trimTrailingSlash(
+    options.apiBaseUrl ?? DEFAULT_ELIZA_CLOUD_API_BASE_URL,
+  );
+  const fetchImpl = options.fetchImpl ?? fetch;
+
+  const headers: Record<string, string> = {
+    authorization: `Bearer ${code}`,
+    accept: "application/json",
+  };
+  if (options.appId) headers["x-app-id"] = options.appId;
+
+  const response = await fetchImpl(`${apiBase}${APP_AUTH_SESSION_PATH}`, {
+    method: "GET",
+    headers,
+    signal: options.signal,
+  });
+
+  const body = (await response.json().catch(() => null)) as
+    | AppAuthSessionResponse
+    | CloudErrorShape
+    | null;
+
+  if (
+    !response.ok ||
+    !body ||
+    (body as AppAuthSessionResponse).success !== true
+  ) {
+    const { message, code: errCode } = readError(body, response.status);
+    throw new ElizaCloudAuthError(message, response.status, errCode);
+  }
+
+  const ok = body as AppAuthSessionResponse;
+  return { user: ok.user, app: ok.app ?? null };
+}
+
+export interface ElizaCloudAppAuthOptions {
+  /** The app's UUID, as registered with Eliza Cloud. */
+  appId: string;
+  /** Where Eliza Cloud sends the user back. Must be a registered origin. */
+  redirectUri: string;
+  /** Site origin hosting the consent page. Defaults to www.elizacloud.ai. */
+  baseUrl?: string;
+  /** API base URL. Defaults to https://api.elizacloud.ai/api/v1. */
+  apiBaseUrl?: string;
+  /** Inject a custom fetch (e.g. for tests or non-global runtimes). */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Small stateful wrapper that binds `appId` + `redirectUri` once so you don't
+ * repeat them. All methods delegate to the standalone functions above.
+ */
+export class ElizaCloudAppAuth {
+  private readonly appId: string;
+  private readonly redirectUri: string;
+  private readonly baseUrl: string;
+  private readonly apiBaseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: ElizaCloudAppAuthOptions) {
+    if (!options.appId)
+      throw new TypeError("ElizaCloudAppAuth: appId is required");
+    if (!options.redirectUri) {
+      throw new TypeError("ElizaCloudAppAuth: redirectUri is required");
+    }
+    this.appId = options.appId;
+    this.redirectUri = options.redirectUri;
+    this.baseUrl = options.baseUrl ?? DEFAULT_ELIZA_CLOUD_BASE_URL;
+    this.apiBaseUrl = options.apiBaseUrl ?? DEFAULT_ELIZA_CLOUD_API_BASE_URL;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  /** Build the consent-page URL to redirect the user to. */
+  authorizeUrl(state?: string): string {
+    return buildAppAuthorizeUrl({
+      appId: this.appId,
+      redirectUri: this.redirectUri,
+      state,
+      baseUrl: this.baseUrl,
+    });
+  }
+
+  /** Parse the callback Eliza Cloud redirected back to. */
+  parseCallback(
+    input: string | URL | URLSearchParams | { search: string } | Location,
+  ): AppAuthorizeCallback {
+    return parseAppAuthorizeCallback(input);
+  }
+
+  /** Exchange a raw `eac_` code for the user. */
+  exchangeCode(
+    code: string,
+    opts: { signal?: AbortSignal } = {},
+  ): Promise<AppAuthSession> {
+    return exchangeAppAuthorizeCode(code, {
+      apiBaseUrl: this.apiBaseUrl,
+      appId: this.appId,
+      fetchImpl: this.fetchImpl,
+      signal: opts.signal,
+    });
+  }
+
+  /**
+   * Parse a callback and exchange its code in one step. Throws
+   * `ElizaCloudAuthError` if the callback carries an error or no code.
+   */
+  async completeSignIn(
+    input: string | URL | URLSearchParams | { search: string } | Location,
+    opts: { signal?: AbortSignal } = {},
+  ): Promise<AppAuthSession> {
+    const cb = this.parseCallback(input);
+    if (cb.error) {
+      throw new ElizaCloudAuthError(
+        cb.errorDescription ?? `Authorization failed: ${cb.error}`,
+        400,
+        cb.error,
+      );
+    }
+    if (!cb.code) {
+      throw new ElizaCloudAuthError(
+        "No authorization code present on the callback URL.",
+        400,
+        "missing_code",
+      );
+    }
+    return this.exchangeCode(cb.code, opts);
+  }
+}
+
+// ── internals ───────────────────────────────────────────────────────────────
+
+interface AppAuthSessionResponse {
+  success: true;
+  user: ElizaCloudUser;
+  app?: ElizaCloudAppInfo | null;
+}
+
+interface CloudErrorShape {
+  success?: false;
+  error?: unknown;
+  message?: unknown;
+  code?: unknown;
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value;
+}
+
+function toSearchParams(
+  input: string | URL | URLSearchParams | { search: string } | Location,
+): URLSearchParams {
+  if (input instanceof URLSearchParams) return input;
+  if (input instanceof URL) return input.searchParams;
+  if (typeof input === "string") {
+    // Accept a full URL, a "?a=b" query, or a bare "a=b" query.
+    if (input.includes("://")) return new URL(input).searchParams;
+    return new URLSearchParams(input.startsWith("?") ? input.slice(1) : input);
+  }
+  // A Location-like object with a `.search` string.
+  return new URLSearchParams(
+    input.search.startsWith("?") ? input.search.slice(1) : input.search,
+  );
+}
+
+function readError(
+  body: AppAuthSessionResponse | CloudErrorShape | null,
+  status: number,
+): { message: string; code: string | null } {
+  const fallback = `Eliza Cloud sign-in failed (HTTP ${status}).`;
+  if (!body || typeof body !== "object")
+    return { message: fallback, code: null };
+  const err = (body as CloudErrorShape).error;
+  const errObj = isRecord(err) ? err : null;
+  const message =
+    (typeof err === "string" ? err : undefined) ??
+    (errObj && typeof errObj.message === "string"
+      ? errObj.message
+      : undefined) ??
+    (typeof (body as CloudErrorShape).message === "string"
+      ? ((body as CloudErrorShape).message as string)
+      : undefined) ??
+    fallback;
+  const code =
+    (errObj && typeof errObj.code === "string" ? errObj.code : undefined) ??
+    (typeof (body as CloudErrorShape).code === "string"
+      ? ((body as CloudErrorShape).code as string)
+      : undefined) ??
+    null;
+  return { message, code };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}


### PR DESCRIPTION
> **Draft / proposal.** Slice 1 of an "Eliza Cloud Apps" direction (turnkey building blocks for third-party/hosted apps). Self-contained, new sub-export only — **touches no server, data-plane, or agent code.**

## What

New `@elizaos/cloud-sdk/app-auth` sub-export: a small, **dependency-free** client that lets any third-party app authenticate its users through Eliza Cloud — "Sign in with Eliza Cloud." It wraps the **already-live** app-auth flow; no backend changes.

## The flow it wraps (built against the real contract)

No PKCE — the consent step is gated by the user's existing Eliza Cloud session, and `redirect_uri` is validated against the app's registered allowed origins (`/api/v1/apps/:id/public`).

1. **Authorize** — `buildAppAuthorizeUrl({ appId, redirectUri, state })` → `https://www.elizacloud.ai/app-auth/authorize?app_id=…&redirect_uri=…&state=…` (matches what the hosted `<AuthorizeContent>` consent page reads).
2. **Callback** — Eliza redirects back: `<redirectUri>?code=eac_…&state=…` on success, or `?error=access_denied&error_description=…&state=…` on denial (matches `buildAppAuthorizeCompletionRedirect`).
3. **Exchange** — `exchangeAppAuthorizeCode(code)` → `GET /api/v1/app-auth/session` with `Authorization: Bearer eac_…` → `{ user: { id, email, name, avatar, createdAt }, app }`. The `eac_` code is opaque, single-use, 5-min TTL (matches `app-auth-codes.ts` + the `session` route).

## API

```ts
import { ElizaCloudAppAuth } from "@elizaos/cloud-sdk/app-auth";
const auth = new ElizaCloudAppAuth({ appId, redirectUri });
location.href = auth.authorizeUrl(state);                  // 1
const { user, app } = await auth.completeSignIn(req.url);  // 2 + 3 (server-side)
```

Also exports the standalone `buildAppAuthorizeUrl`, `parseAppAuthorizeCallback`, `exchangeAppAuthorizeCode`, `looksLikeAppAuthCode`, `ElizaCloudAuthError`, and the `APP_AUTH_*` constants. All accept optional `fetchImpl` / `baseUrl` / `apiBaseUrl` for tests + custom origins. Defaults reuse the package's `DEFAULT_ELIZA_CLOUD_BASE_URL` / `DEFAULT_ELIZA_CLOUD_API_BASE_URL`.

## Tests

15 unit tests (mocked fetch): URL build (+ custom base, optional state, validation), callback parsing across input shapes (URL string / `URLSearchParams` / bare query / `Location`), code exchange with Bearer + `X-App-Id` assertions, custom `apiBaseUrl`, and error paths (non-`eac_` short-circuit, `401` → `ElizaCloudAuthError` with server code). biome + tsgo clean. Pure TS, zero new deps.

## Why draft

It's a proposal for the Apps direction — happy to adjust the surface, the home (sub-export vs root barrel), or naming. Follows the existing `./cloud-setup-session` sub-export pattern. Documented in the package CLAUDE.md/AGENTS.md.