### PR TITLE
fix(core): bound the advanced-memory rolling-summary prompt and first-store offset

### DIFF
--- a/packages/core/src/features/advanced-memory/evaluators/memory-items.test.ts
+++ b/packages/core/src/features/advanced-memory/evaluators/memory-items.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import type {
+  EvaluatorRunOptions,
+  IAgentRuntime,
+  Memory,
+  State,
+} from "../../../types";
+import { type SummaryPrepared, summaryEvaluator } from "./memory-items";
+
+const runtime = {
+  agentId: "agent-1",
+  character: { name: "Agent" },
+  getService: () => null,
+} as unknown as IAgentRuntime;
+
+function msg(id: string, text: string): Memory {
+  return {
+    id,
+    entityId: "user-1",
+    content: { text, senderName: "User" },
+    createdAt: 1,
+  } as unknown as Memory;
+}
+
+function preparedWith(over: Partial<SummaryPrepared>): SummaryPrepared {
+  return {
+    memoryService: {} as SummaryPrepared["memoryService"],
+    summarizationMessages: [],
+    existingSummary: null,
+    lastOffset: 0,
+    totalDialogueCount: 0,
+    canSummarize: false,
+    ...over,
+  };
+}
+
+function promptFor(prepared: SummaryPrepared): string {
+  return summaryEvaluator.prompt({
+    runtime,
+    message: msg("trigger", "trigger"),
+    state: {} as State,
+    options: {} as EvaluatorRunOptions,
+    prepared,
+  });
+}
+
+describe("summaryEvaluator.prompt — bounded message window (regression)", () => {
+  // Regression for the unbounded first-summary prompt: the no-existing-summary
+  // branch used to render the full allDialogueMessages (up to 1000 fetched), which
+  // over-sent — context_length_exceeded in busy rooms, so the summary never stored
+  // and the same oversized request retried forever — and double-counted messages on
+  // the next run (the stored lastMessageOffset only advances by summarizationMessages).
+  // The prompt must always reflect the bounded summarizationMessages slice.
+
+  it("renders only the bounded summarizationMessages when there is no existing summary", () => {
+    const text = promptFor(
+      preparedWith({
+        existingSummary: null,
+        summarizationMessages: [msg("1", "alpha"), msg("2", "bravo")],
+      }),
+    );
+    expect(text).toContain("alpha");
+    expect(text).toContain("bravo");
+    expect(text).toContain("Existing summary:\nNone");
+    // exactly one rendered line per bounded message — never the full history
+    expect((text.match(/^User: /gm) || []).length).toBe(2);
+  });
+
+  it("merges the bounded slice into an existing summary", () => {
+    const text = promptFor(
+      preparedWith({
+        existingSummary: {
+          summary: "prior context",
+          topics: ["t1"],
+        } as SummaryPrepared["existingSummary"],
+        summarizationMessages: [msg("3", "charlie")],
+      }),
+    );
+    expect(text).toContain("charlie");
+    expect(text).toContain("prior context");
+    expect((text.match(/^User: /gm) || []).length).toBe(1);
+  });
+});
+
+describe("summaryEvaluator storeSummary processor — first-store offset (regression)", () => {
+  // Regression: the first store (no existing summary) set
+  // lastMessageOffset = totalDialogueCount (the full backlog) while only the
+  // bounded slice was actually summarized, silently skipping every message past
+  // the slice on subsequent runs. It must advance by the summarized slice, the
+  // same way the existing-summary branch does.
+  it("advances lastMessageOffset by the bounded slice, not the full backlog", async () => {
+    const stored: Array<Record<string, unknown>> = [];
+    const memoryService = {
+      storeSessionSummary: async (rec: Record<string, unknown>) => {
+        stored.push(rec);
+      },
+      updateSessionSummary: async () => {},
+    } as unknown as SummaryPrepared["memoryService"];
+
+    const prepared = preparedWith({
+      memoryService,
+      existingSummary: null,
+      summarizationMessages: [msg("1", "alpha"), msg("2", "bravo")],
+      lastOffset: 0,
+      totalDialogueCount: 1000,
+      canSummarize: true,
+    });
+
+    const processor = summaryEvaluator.processors?.[0];
+    expect(processor).toBeDefined();
+    await processor?.process({
+      runtime,
+      message: msg("trigger", "trigger"),
+      state: {} as State,
+      options: {} as EvaluatorRunOptions,
+      prepared,
+      output: { text: "rolling summary", topics: [], keyPoints: [] },
+      evaluatorName: "summary",
+    });
+
+    expect(stored).toHaveLength(1);
+    expect(stored[0].lastMessageOffset).toBe(2); // slice length, NOT 1000
+    expect(stored[0].messageCount).toBe(2);
+  });
+});

--- a/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
+++ b/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
@@ -60,7 +60,6 @@ export interface LongTermMemoryOutput {
 
 export interface SummaryPrepared {
   memoryService: MemoryService;
-  allDialogueMessages: Memory[];
   summarizationMessages: Memory[];
   existingSummary: Awaited<
     ReturnType<MemoryService["getCurrentSessionSummary"]>
@@ -226,7 +225,6 @@ async function prepareSummary(
       : [];
   return {
     memoryService,
-    allDialogueMessages,
     summarizationMessages,
     existingSummary,
     lastOffset,
@@ -291,9 +289,13 @@ export const summaryEvaluator: Evaluator<SummaryOutput, SummaryPrepared> = {
     return prepareSummary(runtime, message);
   },
   prompt({ runtime, prepared }) {
-    const recentMessages = prepared.existingSummary
-      ? prepared.summarizationMessages
-      : prepared.allDialogueMessages;
+    // Always prompt with the bounded summarizationMessages slice. The stored
+    // lastMessageOffset only advances by this slice, so prompting with the full
+    // allDialogueMessages (up to 1000 fetched) on the first summary both
+    // over-sends — context_length_exceeded in busy rooms, the summary never
+    // stores, so the same oversized request retries forever — and double-counts
+    // messages on the next run. The rolling summary builds up across runs.
+    const recentMessages = prepared.summarizationMessages;
     return `Update rolling summary. Merge recent messages into existing summary/topics. Keep key info, decisions, open questions, main topics. If nothing useful: text="", topics=[], keyPoints=[].
 
 Existing summary:
@@ -360,8 +362,13 @@ ${formatMessages(runtime, recentMessages)}`;
                 ? message.entityId
                 : undefined,
             summary: summaryText,
-            messageCount: prepared.totalDialogueCount,
-            lastMessageOffset: prepared.totalDialogueCount,
+            // Advance by the bounded slice we actually summarized, not the full
+            // backlog — otherwise the first summary covers only the first
+            // summaryMaxNewMessages messages but jumps the offset past the rest,
+            // silently dropping them. Mirrors the existing-summary branch
+            // (newOffset) so the rolling summary catches up over runs.
+            messageCount: prepared.summarizationMessages.length,
+            lastMessageOffset: newOffset,
             startTime,
             endTime,
             topics: output.topics,

--- a/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
+++ b/packages/core/src/features/advanced-memory/evaluators/memory-items.ts
@@ -1,12 +1,12 @@
 import { logger } from "../../../logger.ts";
 import { EvaluatorPriority } from "../../../services/evaluator-priorities.ts";
 import type {
-	Evaluator,
-	IAgentRuntime,
-	JSONSchema,
-	Memory,
-	RegisteredEvaluator,
-	UUID,
+  Evaluator,
+  IAgentRuntime,
+  JSONSchema,
+  Memory,
+  RegisteredEvaluator,
+  UUID,
 } from "../../../types/index.ts";
 import { isSyntheticConversationArtifactMemory } from "../../../utils/synthetic-conversation-artifact.ts";
 import { isObjectRecord as isRecord } from "../../../utils/type-guards.ts";
@@ -17,284 +17,284 @@ import { LongTermMemoryCategory, type MemoryExtraction } from "../types.ts";
 const MEMORY_CATEGORIES = Object.values(LongTermMemoryCategory);
 
 const summarySchema: JSONSchema = {
-	type: "object",
-	properties: {
-		text: { type: "string" },
-		topics: { type: "array", items: { type: "string" } },
-		keyPoints: { type: "array", items: { type: "string" } },
-	},
-	required: ["text", "topics", "keyPoints"],
-	additionalProperties: false,
+  type: "object",
+  properties: {
+    text: { type: "string" },
+    topics: { type: "array", items: { type: "string" } },
+    keyPoints: { type: "array", items: { type: "string" } },
+  },
+  required: ["text", "topics", "keyPoints"],
+  additionalProperties: false,
 };
 
 const longTermMemorySchema: JSONSchema = {
-	type: "object",
-	properties: {
-		memories: {
-			type: "array",
-			items: {
-				type: "object",
-				properties: {
-					category: { type: "string", enum: MEMORY_CATEGORIES },
-					content: { type: "string" },
-					confidence: { type: "number" },
-				},
-				required: ["category", "content", "confidence"],
-				additionalProperties: false,
-			},
-		},
-	},
-	required: ["memories"],
-	additionalProperties: false,
+  type: "object",
+  properties: {
+    memories: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          category: { type: "string", enum: MEMORY_CATEGORIES },
+          content: { type: "string" },
+          confidence: { type: "number" },
+        },
+        required: ["category", "content", "confidence"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["memories"],
+  additionalProperties: false,
 };
 
 export interface SummaryOutput {
-	text: string;
-	topics: string[];
-	keyPoints: string[];
+  text: string;
+  topics: string[];
+  keyPoints: string[];
 }
 
 export interface LongTermMemoryOutput {
-	memories: MemoryExtraction[];
+  memories: MemoryExtraction[];
 }
 
 export interface SummaryPrepared {
-	memoryService: MemoryService;
-	allDialogueMessages: Memory[];
-	summarizationMessages: Memory[];
-	existingSummary: Awaited<
-		ReturnType<MemoryService["getCurrentSessionSummary"]>
-	>;
-	lastOffset: number;
-	totalDialogueCount: number;
-	canSummarize: boolean;
+  memoryService: MemoryService;
+  allDialogueMessages: Memory[];
+  summarizationMessages: Memory[];
+  existingSummary: Awaited<
+    ReturnType<MemoryService["getCurrentSessionSummary"]>
+  >;
+  lastOffset: number;
+  totalDialogueCount: number;
+  canSummarize: boolean;
 }
 
 export interface LongTermMemoryPrepared {
-	memoryService: MemoryService;
-	recentMessages: Memory[];
-	existingMemories: string;
-	currentMessageCount: number;
+  memoryService: MemoryService;
+  recentMessages: Memory[];
+  existingMemories: string;
+  currentMessageCount: number;
 }
 
 const SUMMARY_PLACEHOLDER = "Summary not available";
 
 function toStringArray(value: unknown): string[] {
-	if (!Array.isArray(value)) return [];
-	return value
-		.map((entry) => (typeof entry === "string" ? entry.trim() : ""))
-		.filter(Boolean);
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
+    .filter(Boolean);
 }
 
 function isDialogueMessage(msg: Memory): boolean {
-	return (
-		!isSyntheticConversationArtifactMemory(msg) &&
-		!(
-			msg.content.type === "action_result" &&
-			(msg.metadata?.type as string) === "action_result"
-		) &&
-		((msg.metadata?.type as string) === "agent_response_message" ||
-			(msg.metadata?.type as string) === "user_message")
-	);
+  return (
+    !isSyntheticConversationArtifactMemory(msg) &&
+    !(
+      msg.content.type === "action_result" &&
+      (msg.metadata?.type as string) === "action_result"
+    ) &&
+    ((msg.metadata?.type as string) === "agent_response_message" ||
+      (msg.metadata?.type as string) === "user_message")
+  );
 }
 
 async function getDialogueMessageCount(
-	runtime: IAgentRuntime,
-	roomId: UUID,
+  runtime: IAgentRuntime,
+  roomId: UUID,
 ): Promise<number> {
-	const messages = await runtime.getMemories({
-		tableName: "messages",
-		roomId,
-		limit: 100,
-		unique: false,
-	});
-	return messages.filter(isDialogueMessage).length;
+  const messages = await runtime.getMemories({
+    tableName: "messages",
+    roomId,
+    limit: 100,
+    unique: false,
+  });
+  return messages.filter(isDialogueMessage).length;
 }
 
 async function shouldSummarize(
-	runtime: IAgentRuntime,
-	message: Memory,
-	memoryService: MemoryService,
+  runtime: IAgentRuntime,
+  message: Memory,
+  memoryService: MemoryService,
 ): Promise<boolean> {
-	const config = memoryService.getConfig();
-	const currentDialogueCount = await getDialogueMessageCount(
-		runtime,
-		message.roomId,
-	);
-	const existingSummary = await memoryService.getCurrentSessionSummary(
-		message.roomId,
-	);
-	if (!existingSummary) {
-		return currentDialogueCount >= config.shortTermSummarizationThreshold;
-	}
-	const newDialogueCount =
-		currentDialogueCount - existingSummary.lastMessageOffset;
-	return newDialogueCount >= config.shortTermSummarizationInterval;
+  const config = memoryService.getConfig();
+  const currentDialogueCount = await getDialogueMessageCount(
+    runtime,
+    message.roomId,
+  );
+  const existingSummary = await memoryService.getCurrentSessionSummary(
+    message.roomId,
+  );
+  if (!existingSummary) {
+    return currentDialogueCount >= config.shortTermSummarizationThreshold;
+  }
+  const newDialogueCount =
+    currentDialogueCount - existingSummary.lastMessageOffset;
+  return newDialogueCount >= config.shortTermSummarizationInterval;
 }
 
 async function shouldExtractLongTerm(
-	runtime: IAgentRuntime,
-	message: Memory,
-	memoryService: MemoryService,
+  runtime: IAgentRuntime,
+  message: Memory,
+  memoryService: MemoryService,
 ): Promise<boolean> {
-	if (!message.entityId || message.entityId === runtime.agentId) return false;
-	const config = memoryService.getConfig();
-	if (!config.longTermExtractionEnabled) return false;
-	const currentMessageCount = await runtime.countMemories({
-		roomIds: [message.roomId],
-		unique: false,
-		tableName: "messages",
-	});
-	return memoryService.shouldRunExtraction(
-		message.entityId,
-		message.roomId,
-		currentMessageCount,
-	);
+  if (!message.entityId || message.entityId === runtime.agentId) return false;
+  const config = memoryService.getConfig();
+  if (!config.longTermExtractionEnabled) return false;
+  const currentMessageCount = await runtime.countMemories({
+    roomIds: [message.roomId],
+    unique: false,
+    tableName: "messages",
+  });
+  return memoryService.shouldRunExtraction(
+    message.entityId,
+    message.roomId,
+    currentMessageCount,
+  );
 }
 
 function formatMessages(runtime: IAgentRuntime, msgs: Memory[]): string {
-	return msgs
-		.map((msg) => {
-			const sender =
-				msg.entityId === runtime.agentId
-					? (runtime.character.name ?? "Agent")
-					: msg.content.senderName || msg.entityId || "User";
-			return `${sender}: ${msg.content.text || "[non-text message]"}`;
-		})
-		.join("\n");
+  return msgs
+    .map((msg) => {
+      const sender =
+        msg.entityId === runtime.agentId
+          ? (runtime.character.name ?? "Agent")
+          : msg.content.senderName || msg.entityId || "User";
+      return `${sender}: ${msg.content.text || "[non-text message]"}`;
+    })
+    .join("\n");
 }
 
 function parseSummaryOutput(output: unknown): SummaryOutput | null {
-	if (!isRecord(output)) return null;
-	const text = typeof output.text === "string" ? output.text.trim() : "";
-	return {
-		text: text || SUMMARY_PLACEHOLDER,
-		topics: toStringArray(output.topics),
-		keyPoints: toStringArray(output.keyPoints),
-	};
+  if (!isRecord(output)) return null;
+  const text = typeof output.text === "string" ? output.text.trim() : "";
+  return {
+    text: text || SUMMARY_PLACEHOLDER,
+    topics: toStringArray(output.topics),
+    keyPoints: toStringArray(output.keyPoints),
+  };
 }
 
 function parseLongTermOutput(output: unknown): LongTermMemoryOutput | null {
-	if (!isRecord(output) || !Array.isArray(output.memories)) return null;
-	const memories: MemoryExtraction[] = [];
-	for (const entry of output.memories) {
-		if (!isRecord(entry)) continue;
-		const category =
-			typeof entry.category === "string"
-				? (entry.category.trim().toLowerCase() as LongTermMemoryCategory)
-				: null;
-		if (!category || !MEMORY_CATEGORIES.some((item) => item === category)) {
-			continue;
-		}
-		const content =
-			typeof entry.content === "string" ? entry.content.trim() : "";
-		const confidence =
-			typeof entry.confidence === "number" ? entry.confidence : Number.NaN;
-		if (!content || Number.isNaN(confidence)) continue;
-		memories.push({ category, content, confidence });
-	}
-	return { memories };
+  if (!isRecord(output) || !Array.isArray(output.memories)) return null;
+  const memories: MemoryExtraction[] = [];
+  for (const entry of output.memories) {
+    if (!isRecord(entry)) continue;
+    const category =
+      typeof entry.category === "string"
+        ? (entry.category.trim().toLowerCase() as LongTermMemoryCategory)
+        : null;
+    if (!category || !MEMORY_CATEGORIES.some((item) => item === category)) {
+      continue;
+    }
+    const content =
+      typeof entry.content === "string" ? entry.content.trim() : "";
+    const confidence =
+      typeof entry.confidence === "number" ? entry.confidence : Number.NaN;
+    if (!content || Number.isNaN(confidence)) continue;
+    memories.push({ category, content, confidence });
+  }
+  return { memories };
 }
 
 async function prepareSummary(
-	runtime: IAgentRuntime,
-	message: Memory,
+  runtime: IAgentRuntime,
+  message: Memory,
 ): Promise<SummaryPrepared> {
-	const memoryService = runtime.getService("memory") as MemoryService | null;
-	if (!memoryService) throw new Error("MemoryService not found");
-	const config = memoryService.getConfig();
-	const allMessages = await runtime.getMemories({
-		tableName: "messages",
-		roomId: message.roomId,
-		limit: 1000,
-		unique: false,
-	});
-	const allDialogueMessages = allMessages
-		.filter(isDialogueMessage)
-		.sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
-	const existingSummary = await memoryService.getCurrentSessionSummary(
-		message.roomId,
-	);
-	const lastOffset = existingSummary?.lastMessageOffset || 0;
-	const totalDialogueCount = allDialogueMessages.length;
-	const newDialogueCount = totalDialogueCount - lastOffset;
-	const maxNewMessages = config.summaryMaxNewMessages || 50;
-	const messagesToProcess = Math.min(newDialogueCount, maxNewMessages);
-	const summarizationMessages =
-		newDialogueCount > 0
-			? allDialogueMessages.slice(lastOffset, lastOffset + messagesToProcess)
-			: [];
-	return {
-		memoryService,
-		allDialogueMessages,
-		summarizationMessages,
-		existingSummary,
-		lastOffset,
-		totalDialogueCount,
-		canSummarize: summarizationMessages.length > 0,
-	};
+  const memoryService = runtime.getService("memory") as MemoryService | null;
+  if (!memoryService) throw new Error("MemoryService not found");
+  const config = memoryService.getConfig();
+  const allMessages = await runtime.getMemories({
+    tableName: "messages",
+    roomId: message.roomId,
+    limit: 1000,
+    unique: false,
+  });
+  const allDialogueMessages = allMessages
+    .filter(isDialogueMessage)
+    .sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
+  const existingSummary = await memoryService.getCurrentSessionSummary(
+    message.roomId,
+  );
+  const lastOffset = existingSummary?.lastMessageOffset || 0;
+  const totalDialogueCount = allDialogueMessages.length;
+  const newDialogueCount = totalDialogueCount - lastOffset;
+  const maxNewMessages = config.summaryMaxNewMessages || 50;
+  const messagesToProcess = Math.min(newDialogueCount, maxNewMessages);
+  const summarizationMessages =
+    newDialogueCount > 0
+      ? allDialogueMessages.slice(lastOffset, lastOffset + messagesToProcess)
+      : [];
+  return {
+    memoryService,
+    allDialogueMessages,
+    summarizationMessages,
+    existingSummary,
+    lastOffset,
+    totalDialogueCount,
+    canSummarize: summarizationMessages.length > 0,
+  };
 }
 
 async function prepareLongTermMemory(
-	runtime: IAgentRuntime,
-	message: Memory,
+  runtime: IAgentRuntime,
+  message: Memory,
 ): Promise<LongTermMemoryPrepared> {
-	const memoryService = runtime.getService("memory") as MemoryService | null;
-	if (!memoryService) throw new Error("MemoryService not found");
-	const [recentRaw, existingLongTerm, currentMessageCount] = await Promise.all([
-		runtime.getMemories({
-			tableName: "messages",
-			roomId: message.roomId,
-			limit: 20,
-			unique: false,
-		}),
-		message.entityId
-			? memoryService.getLongTermMemories(message.entityId, undefined, 30)
-			: Promise.resolve([]),
-		runtime.countMemories({
-			roomIds: [message.roomId],
-			unique: false,
-			tableName: "messages",
-		}),
-	]);
-	const existingMemories =
-		existingLongTerm.length > 0
-			? existingLongTerm
-					.map(
-						(memory) =>
-							`[${memory.category}] ${memory.content} (confidence: ${memory.confidence})`,
-					)
-					.join("\n")
-			: "None yet";
-	return {
-		memoryService,
-		recentMessages: recentRaw
-			.filter((memory) => !isSyntheticConversationArtifactMemory(memory))
-			.sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0)),
-		existingMemories,
-		currentMessageCount,
-	};
+  const memoryService = runtime.getService("memory") as MemoryService | null;
+  if (!memoryService) throw new Error("MemoryService not found");
+  const [recentRaw, existingLongTerm, currentMessageCount] = await Promise.all([
+    runtime.getMemories({
+      tableName: "messages",
+      roomId: message.roomId,
+      limit: 20,
+      unique: false,
+    }),
+    message.entityId
+      ? memoryService.getLongTermMemories(message.entityId, undefined, 30)
+      : Promise.resolve([]),
+    runtime.countMemories({
+      roomIds: [message.roomId],
+      unique: false,
+      tableName: "messages",
+    }),
+  ]);
+  const existingMemories =
+    existingLongTerm.length > 0
+      ? existingLongTerm
+          .map(
+            (memory) =>
+              `[${memory.category}] ${memory.content} (confidence: ${memory.confidence})`,
+          )
+          .join("\n")
+      : "None yet";
+  return {
+    memoryService,
+    recentMessages: recentRaw
+      .filter((memory) => !isSyntheticConversationArtifactMemory(memory))
+      .sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0)),
+    existingMemories,
+    currentMessageCount,
+  };
 }
 
 export const summaryEvaluator: Evaluator<SummaryOutput, SummaryPrepared> = {
-	name: "summary",
-	description: "Rolls forward the room's compact conversation summary.",
-	priority: EvaluatorPriority.MEMORY_SUMMARY,
-	schema: summarySchema,
-	async shouldRun({ runtime, message }) {
-		if (!message.content.text || !message.roomId) return false;
-		const memoryService = runtime.getService("memory") as MemoryService | null;
-		if (!memoryService) return false;
-		return shouldSummarize(runtime, message, memoryService);
-	},
-	async prepare({ runtime, message }) {
-		return prepareSummary(runtime, message);
-	},
-	prompt({ runtime, prepared }) {
-		const recentMessages = prepared.existingSummary
-			? prepared.summarizationMessages
-			: prepared.allDialogueMessages;
-		return `Update rolling summary. Merge recent messages into existing summary/topics. Keep key info, decisions, open questions, main topics. If nothing useful: text="", topics=[], keyPoints=[].
+  name: "summary",
+  description: "Rolls forward the room's compact conversation summary.",
+  priority: EvaluatorPriority.MEMORY_SUMMARY,
+  schema: summarySchema,
+  async shouldRun({ runtime, message }) {
+    if (!message.content.text || !message.roomId) return false;
+    const memoryService = runtime.getService("memory") as MemoryService | null;
+    if (!memoryService) return false;
+    return shouldSummarize(runtime, message, memoryService);
+  },
+  async prepare({ runtime, message }) {
+    return prepareSummary(runtime, message);
+  },
+  prompt({ runtime, prepared }) {
+    const recentMessages = prepared.existingSummary
+      ? prepared.summarizationMessages
+      : prepared.allDialogueMessages;
+    return `Update rolling summary. Merge recent messages into existing summary/topics. Keep key info, decisions, open questions, main topics. If nothing useful: text="", topics=[], keyPoints=[].
 
 Existing summary:
 ${prepared.existingSummary?.summary ?? "None"}
@@ -304,188 +304,188 @@ ${prepared.existingSummary?.topics?.join(", ") || "None"}
 
 Recent messages to merge:
 ${formatMessages(runtime, recentMessages)}`;
-	},
-	parse: parseSummaryOutput,
-	processors: [
-		{
-			name: "storeSummary",
-			async process({ runtime, message, prepared, output }) {
-				if (!prepared.canSummarize) return undefined;
-				const summaryText = output.text;
-				if (
-					!summaryText ||
-					summaryText === SUMMARY_PLACEHOLDER ||
-					summaryText.trim().length === 0
-				) {
-					return undefined;
-				}
-				const firstMessage = prepared.summarizationMessages[0];
-				const lastMessage =
-					prepared.summarizationMessages[
-						prepared.summarizationMessages.length - 1
-					];
-				const startTime = prepared.existingSummary
-					? prepared.existingSummary.startTime
-					: firstMessage?.createdAt && firstMessage.createdAt > 0
-						? new Date(firstMessage.createdAt)
-						: new Date();
-				const endTime =
-					lastMessage?.createdAt && lastMessage.createdAt > 0
-						? new Date(lastMessage.createdAt)
-						: new Date();
-				const newOffset =
-					prepared.lastOffset + prepared.summarizationMessages.length;
+  },
+  parse: parseSummaryOutput,
+  processors: [
+    {
+      name: "storeSummary",
+      async process({ runtime, message, prepared, output }) {
+        if (!prepared.canSummarize) return undefined;
+        const summaryText = output.text;
+        if (
+          !summaryText ||
+          summaryText === SUMMARY_PLACEHOLDER ||
+          summaryText.trim().length === 0
+        ) {
+          return undefined;
+        }
+        const firstMessage = prepared.summarizationMessages[0];
+        const lastMessage =
+          prepared.summarizationMessages[
+            prepared.summarizationMessages.length - 1
+          ];
+        const startTime = prepared.existingSummary
+          ? prepared.existingSummary.startTime
+          : firstMessage?.createdAt && firstMessage.createdAt > 0
+            ? new Date(firstMessage.createdAt)
+            : new Date();
+        const endTime =
+          lastMessage?.createdAt && lastMessage.createdAt > 0
+            ? new Date(lastMessage.createdAt)
+            : new Date();
+        const newOffset =
+          prepared.lastOffset + prepared.summarizationMessages.length;
 
-				if (prepared.existingSummary) {
-					await prepared.memoryService.updateSessionSummary(
-						prepared.existingSummary.id,
-						message.roomId,
-						{
-							summary: summaryText,
-							messageCount:
-								prepared.existingSummary.messageCount +
-								prepared.summarizationMessages.length,
-							lastMessageOffset: newOffset,
-							endTime,
-							topics: output.topics,
-							metadata: { keyPoints: output.keyPoints },
-						},
-					);
-				} else {
-					await prepared.memoryService.storeSessionSummary({
-						agentId: runtime.agentId,
-						roomId: message.roomId,
-						entityId:
-							message.entityId !== runtime.agentId
-								? message.entityId
-								: undefined,
-						summary: summaryText,
-						messageCount: prepared.totalDialogueCount,
-						lastMessageOffset: prepared.totalDialogueCount,
-						startTime,
-						endTime,
-						topics: output.topics,
-						metadata: { keyPoints: output.keyPoints },
-					});
-				}
+        if (prepared.existingSummary) {
+          await prepared.memoryService.updateSessionSummary(
+            prepared.existingSummary.id,
+            message.roomId,
+            {
+              summary: summaryText,
+              messageCount:
+                prepared.existingSummary.messageCount +
+                prepared.summarizationMessages.length,
+              lastMessageOffset: newOffset,
+              endTime,
+              topics: output.topics,
+              metadata: { keyPoints: output.keyPoints },
+            },
+          );
+        } else {
+          await prepared.memoryService.storeSessionSummary({
+            agentId: runtime.agentId,
+            roomId: message.roomId,
+            entityId:
+              message.entityId !== runtime.agentId
+                ? message.entityId
+                : undefined,
+            summary: summaryText,
+            messageCount: prepared.totalDialogueCount,
+            lastMessageOffset: prepared.totalDialogueCount,
+            startTime,
+            endTime,
+            topics: output.topics,
+            metadata: { keyPoints: output.keyPoints },
+          });
+        }
 
-				logAdvancedMemoryTrajectory({
-					runtime,
-					message,
-					providerName: "MEMORY_SUMMARIZATION",
-					purpose: "evaluate",
-					data: {
-						hasExistingSummary: !!prepared.existingSummary,
-						processedDialogueMessages: prepared.summarizationMessages.length,
-						totalDialogueMessages: prepared.totalDialogueCount,
-						topicCount: output.topics.length,
-						keyPointCount: output.keyPoints.length,
-					},
-					query: { roomId: message.roomId },
-				});
+        logAdvancedMemoryTrajectory({
+          runtime,
+          message,
+          providerName: "MEMORY_SUMMARIZATION",
+          purpose: "evaluate",
+          data: {
+            hasExistingSummary: !!prepared.existingSummary,
+            processedDialogueMessages: prepared.summarizationMessages.length,
+            totalDialogueMessages: prepared.totalDialogueCount,
+            topicCount: output.topics.length,
+            keyPointCount: output.keyPoints.length,
+          },
+          query: { roomId: message.roomId },
+        });
 
-				return {
-					success: true,
-					values: {
-						summarized: true,
-						summaryMessagesProcessed: prepared.summarizationMessages.length,
-					},
-				};
-			},
-		},
-	],
+        return {
+          success: true,
+          values: {
+            summarized: true,
+            summaryMessagesProcessed: prepared.summarizationMessages.length,
+          },
+        };
+      },
+    },
+  ],
 };
 
 export const longTermMemoryEvaluator: Evaluator<
-	LongTermMemoryOutput,
-	LongTermMemoryPrepared
+  LongTermMemoryOutput,
+  LongTermMemoryPrepared
 > = {
-	name: "longTermMemory",
-	description:
-		"Extracts high-confidence persistent memories about the user from conversation context.",
-	priority: EvaluatorPriority.MEMORY_LONG_TERM,
-	schema: longTermMemorySchema,
-	async shouldRun({ runtime, message }) {
-		if (!message.content.text || !message.roomId || !message.entityId) {
-			return false;
-		}
-		const memoryService = runtime.getService("memory") as MemoryService | null;
-		if (!memoryService) return false;
-		return shouldExtractLongTerm(runtime, message, memoryService);
-	},
-	async prepare({ runtime, message }) {
-		return prepareLongTermMemory(runtime, message);
-	},
-	prompt({ runtime, prepared }) {
-		return `Extract up to 3 high-confidence persistent user memories. Categories: episodic, semantic, procedural. Keep only specific, concrete, user-unique info likely useful in 3+ months, confidence >=0.85, not already present. Skip one-time tasks, current bugs, exploratory questions, temporary context, pleasantries, generic patterns, rolling summaries, compacted ledgers, synthetic compaction artifacts.
+  name: "longTermMemory",
+  description:
+    "Extracts high-confidence persistent memories about the user from conversation context.",
+  priority: EvaluatorPriority.MEMORY_LONG_TERM,
+  schema: longTermMemorySchema,
+  async shouldRun({ runtime, message }) {
+    if (!message.content.text || !message.roomId || !message.entityId) {
+      return false;
+    }
+    const memoryService = runtime.getService("memory") as MemoryService | null;
+    if (!memoryService) return false;
+    return shouldExtractLongTerm(runtime, message, memoryService);
+  },
+  async prepare({ runtime, message }) {
+    return prepareLongTermMemory(runtime, message);
+  },
+  prompt({ runtime, prepared }) {
+    return `Extract up to 3 high-confidence persistent user memories. Categories: episodic, semantic, procedural. Keep only specific, concrete, user-unique info likely useful in 3+ months, confidence >=0.85, not already present. Skip one-time tasks, current bugs, exploratory questions, temporary context, pleasantries, generic patterns, rolling summaries, compacted ledgers, synthetic compaction artifacts.
 
 Existing long-term memories:
 ${prepared.existingMemories}
 
 Recent messages:
 ${formatMessages(runtime, prepared.recentMessages)}`;
-	},
-	parse: parseLongTermOutput,
-	processors: [
-		{
-			name: "storeLongTermMemory",
-			async process({ runtime, message, prepared, output }) {
-				const config = prepared.memoryService.getConfig();
-				const minConfidence = Math.max(
-					config.longTermConfidenceThreshold,
-					0.85,
-				);
-				const extractedAt = new Date().toISOString();
-				let longTermStored = 0;
-				for (const extraction of output.memories) {
-					if (extraction.confidence < minConfidence) continue;
-					await prepared.memoryService.storeLongTermMemory({
-						agentId: runtime.agentId,
-						entityId: message.entityId,
-						category: extraction.category,
-						content: extraction.content,
-						confidence: extraction.confidence,
-						source: "conversation",
-						metadata: {
-							roomId: message.roomId,
-							extractedAt,
-						},
-					});
-					longTermStored += 1;
-				}
-				await prepared.memoryService.setLastExtractionCheckpoint(
-					message.entityId,
-					message.roomId,
-					prepared.currentMessageCount,
-				);
-				logAdvancedMemoryTrajectory({
-					runtime,
-					message,
-					providerName: "LONG_TERM_MEMORY_EXTRACTION",
-					purpose: "evaluate",
-					data: {
-						extractedMemoryCount: output.memories.length,
-						storedMemoryCount: longTermStored,
-					},
-					query: {
-						entityId: message.entityId,
-						roomId: message.roomId,
-					},
-				});
-				logger.debug(
-					{ src: "evaluator:memory", longTermStored },
-					"Stored long-term memories from evaluator service",
-				);
-				return {
-					success: true,
-					values: { longTermStored },
-				};
-			},
-		},
-	],
+  },
+  parse: parseLongTermOutput,
+  processors: [
+    {
+      name: "storeLongTermMemory",
+      async process({ runtime, message, prepared, output }) {
+        const config = prepared.memoryService.getConfig();
+        const minConfidence = Math.max(
+          config.longTermConfidenceThreshold,
+          0.85,
+        );
+        const extractedAt = new Date().toISOString();
+        let longTermStored = 0;
+        for (const extraction of output.memories) {
+          if (extraction.confidence < minConfidence) continue;
+          await prepared.memoryService.storeLongTermMemory({
+            agentId: runtime.agentId,
+            entityId: message.entityId,
+            category: extraction.category,
+            content: extraction.content,
+            confidence: extraction.confidence,
+            source: "conversation",
+            metadata: {
+              roomId: message.roomId,
+              extractedAt,
+            },
+          });
+          longTermStored += 1;
+        }
+        await prepared.memoryService.setLastExtractionCheckpoint(
+          message.entityId,
+          message.roomId,
+          prepared.currentMessageCount,
+        );
+        logAdvancedMemoryTrajectory({
+          runtime,
+          message,
+          providerName: "LONG_TERM_MEMORY_EXTRACTION",
+          purpose: "evaluate",
+          data: {
+            extractedMemoryCount: output.memories.length,
+            storedMemoryCount: longTermStored,
+          },
+          query: {
+            entityId: message.entityId,
+            roomId: message.roomId,
+          },
+        });
+        logger.debug(
+          { src: "evaluator:memory", longTermStored },
+          "Stored long-term memories from evaluator service",
+        );
+        return {
+          success: true,
+          values: { longTermStored },
+        };
+      },
+    },
+  ],
 };
 
 export const memoryItems: RegisteredEvaluator[] = [
-	summaryEvaluator,
-	longTermMemoryEvaluator,
+  summaryEvaluator,
+  longTermMemoryEvaluator,
 ];


### PR DESCRIPTION
## Summary

The advanced-memory `summaryEvaluator` (`packages/core/src/features/advanced-memory/evaluators/memory-items.ts`) has two coupled bugs that surface in busy rooms — the second was found while reviewing the fix for the first.

### Bug 1 — unbounded first-summary prompt → permanent `context_length_exceeded` loop
`prepareSummary()` caps the work window at `summaryMaxNewMessages` (default 50 / `MemoryService` config 20) and advances `lastMessageOffset` by that bounded `summarizationMessages` slice. But `prompt()` rendered the full `allDialogueMessages` (fetched with `limit: 1000`, unbounded by tokens) on the **no-existing-summary** branch:

```ts
const recentMessages = prepared.existingSummary
  ? prepared.summarizationMessages   // bounded (≤ maxNewMessages)
  : prepared.allDialogueMessages;    // up to 1000 messages, unbounded by tokens
```

In a high-traffic room the first summary therefore sends a request far over the model's context window (observed live: a ~3.1M-token request to a 131k-limit endpoint → `400 context_length_exceeded`). Because the request fails, the summary never stores, so `existingSummary` stays null and the **same oversized request retries forever**. It also double-counts messages on the next run (the offset only advanced by the bounded slice).

### Bug 2 — first store jumps the offset past unsummarized messages (silent data loss)
On the first store (no existing summary), the offset was set to the whole backlog while only the bounded slice was summarized:

```ts
messageCount: prepared.totalDialogueCount,      // e.g. 1000
lastMessageOffset: prepared.totalDialogueCount, // e.g. 1000
```

So after summarizing the first ≤20 messages, the offset jumps to 1000 and messages 20→1000 are **never summarized** on subsequent runs. (The existing-summary branch already does the right thing via `newOffset = lastOffset + summarizationMessages.length`.)

## Fix
- `prompt()` always uses the bounded `summarizationMessages` slice.
- The first-store branch advances `lastMessageOffset`/`messageCount` by the summarized slice (`newOffset`), mirroring the existing-summary branch, so the rolling summary builds up **incrementally and bounded** instead of crashing or skipping.
- Drop the now-unused `allDialogueMessages` field from `SummaryPrepared` (the local var stays — it still feeds `totalDialogueCount` and the slice). No external consumer reads the field.
- Add regression tests: the prompt is bounded to `summarizationMessages` regardless of `existingSummary`, and the first store advances the offset by the slice (not the backlog).

## Notes
- Commit 1 is a **pure tabs→spaces biome reformat** of the file (no logic change — `git diff -w` is empty) so the logic change in commit 2 is a minimal, reviewable ~14-line diff. The file was tab-indented; `biome.json` enforces 2-space.
- A pre-existing follow-up (left out of scope): the cap is by message **count**, not tokens, so pathologically large individual messages could still exceed context within the bounded slice — a token-budget cap would be a separate enhancement.

## Test
```
bun run --cwd packages/core test -- --run memory-items   # 3 passed
bun run --cwd packages/core typecheck                     # clean
```
