### PR TITLE
fix(cloud): block the Cloudflare registrar dev stub in production

### DIFF
--- a/packages/cloud-shared/src/lib/config/deployment-environment.test.ts
+++ b/packages/cloud-shared/src/lib/config/deployment-environment.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "bun:test";
+import {
+  isProductionDeployment,
+  shouldBlockRegistrarStub,
+} from "./deployment-environment";
+
+describe("isProductionDeployment", () => {
+  it("uses ENVIRONMENT when it is set", () => {
+    expect(isProductionDeployment({ ENVIRONMENT: "production" })).toBe(true);
+    expect(
+      isProductionDeployment({ ENVIRONMENT: "staging", NODE_ENV: "production" }),
+    ).toBe(false);
+  });
+
+  it("falls back to NODE_ENV when ENVIRONMENT is unset", () => {
+    expect(isProductionDeployment({ NODE_ENV: "production" })).toBe(true);
+    expect(isProductionDeployment({ NODE_ENV: "test" })).toBe(false);
+    expect(isProductionDeployment({})).toBe(false);
+  });
+});
+
+describe("shouldBlockRegistrarStub", () => {
+  it("blocks the stub when it is enabled in a production deployment", () => {
+    expect(
+      shouldBlockRegistrarStub({
+        ELIZA_CF_REGISTRAR_DEV_STUB: "1",
+        ENVIRONMENT: "production",
+      }),
+    ).toBe(true);
+    expect(
+      shouldBlockRegistrarStub({
+        ELIZA_CF_REGISTRAR_DEV_STUB: "1",
+        NODE_ENV: "production",
+      }),
+    ).toBe(true);
+  });
+
+  it("allows the stub outside production (dev / test / staging)", () => {
+    expect(
+      shouldBlockRegistrarStub({
+        ELIZA_CF_REGISTRAR_DEV_STUB: "1",
+        NODE_ENV: "test",
+      }),
+    ).toBe(false);
+    expect(
+      shouldBlockRegistrarStub({
+        ELIZA_CF_REGISTRAR_DEV_STUB: "1",
+        ENVIRONMENT: "staging",
+      }),
+    ).toBe(false);
+    expect(shouldBlockRegistrarStub({ ELIZA_CF_REGISTRAR_DEV_STUB: "1" })).toBe(
+      false,
+    );
+  });
+
+  it("does not block when the stub flag is off", () => {
+    expect(shouldBlockRegistrarStub({ ENVIRONMENT: "production" })).toBe(false);
+    expect(
+      shouldBlockRegistrarStub({
+        ELIZA_CF_REGISTRAR_DEV_STUB: "0",
+        ENVIRONMENT: "production",
+      }),
+    ).toBe(false);
+  });
+});

--- a/packages/cloud-shared/src/lib/config/deployment-environment.ts
+++ b/packages/cloud-shared/src/lib/config/deployment-environment.ts
@@ -20,3 +20,13 @@ export function shouldBlockUnsafeWebhookSkip(env: EnvLike = process.env): boolea
 export function shouldBlockDevnetBypass(env: EnvLike = process.env): boolean {
   return env.DEVNET === "true" && isProductionDeployment(env);
 }
+
+/**
+ * Block the Cloudflare registrar/DNS dev stub from running in production. The
+ * stub (ELIZA_CF_REGISTRAR_DEV_STUB=1) returns fake registrations that still
+ * debit credits, so a stray flag in prod charges users for domains that were
+ * never registered. Dev/test/staging may keep using it.
+ */
+export function shouldBlockRegistrarStub(env: EnvLike = process.env): boolean {
+  return env.ELIZA_CF_REGISTRAR_DEV_STUB === "1" && isProductionDeployment(env);
+}

--- a/packages/cloud-shared/src/lib/services/cloudflare-dns.ts
+++ b/packages/cloud-shared/src/lib/services/cloudflare-dns.ts
@@ -7,6 +7,7 @@
  * here).
  */
 
+import { shouldBlockRegistrarStub } from "../config/deployment-environment";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { cloudflareApiRequest } from "../utils/cloudflare-api";
 import { logger } from "../utils/logger";
@@ -14,6 +15,14 @@ import { logger } from "../utils/logger";
 /** Read at call time so per-request Cloudflare Worker bindings are visible. */
 function config() {
   const env = getCloudAwareEnv();
+  // The DNS stub shares the registrar dev-stub flag; block it in production for
+  // the same reason (a stray flag must never silently fake managed-domain DNS).
+  if (shouldBlockRegistrarStub(env)) {
+    throw new Error(
+      "FATAL: ELIZA_CF_REGISTRAR_DEV_STUB=1 is set in a production deployment. " +
+        "Unset it and configure CLOUDFLARE_API_TOKEN for real DNS operations.",
+    );
+  }
   return {
     apiToken: env.CLOUDFLARE_API_TOKEN ?? "",
     devStub: env.ELIZA_CF_REGISTRAR_DEV_STUB === "1",

--- a/packages/cloud-shared/src/lib/services/cloudflare-registrar.test.ts
+++ b/packages/cloud-shared/src/lib/services/cloudflare-registrar.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { cloudflareRegistrarService } from "./cloudflare-registrar";
+
+/**
+ * Guard: the dev stub (ELIZA_CF_REGISTRAR_DEV_STUB=1) fabricates registrations
+ * but the buy route still debits credits, so it must never run in production.
+ * `config()` reads via getCloudAwareEnv(), which falls back to process.env
+ * outside a Worker context — so these tests drive it through process.env.
+ */
+describe("cloudflareRegistrarService production stub guard", () => {
+  let savedEnvironment: string | undefined;
+  let savedStub: string | undefined;
+
+  beforeEach(() => {
+    savedEnvironment = process.env.ENVIRONMENT;
+    savedStub = process.env.ELIZA_CF_REGISTRAR_DEV_STUB;
+  });
+
+  afterEach(() => {
+    if (savedEnvironment === undefined) delete process.env.ENVIRONMENT;
+    else process.env.ENVIRONMENT = savedEnvironment;
+    if (savedStub === undefined) delete process.env.ELIZA_CF_REGISTRAR_DEV_STUB;
+    else process.env.ELIZA_CF_REGISTRAR_DEV_STUB = savedStub;
+  });
+
+  it("refuses the stub in production before any registrar work happens", async () => {
+    process.env.ENVIRONMENT = "production";
+    process.env.ELIZA_CF_REGISTRAR_DEV_STUB = "1";
+
+    await expect(
+      cloudflareRegistrarService.checkAvailability("guard-example.com"),
+    ).rejects.toThrow(/production deployment/i);
+    await expect(
+      cloudflareRegistrarService.registerDomain("guard-example.com"),
+    ).rejects.toThrow(/production deployment/i);
+  });
+
+  it("still serves the stub outside production (dev/test)", async () => {
+    process.env.ENVIRONMENT = "development";
+    process.env.ELIZA_CF_REGISTRAR_DEV_STUB = "1";
+
+    const availability =
+      await cloudflareRegistrarService.checkAvailability("guard-example.com");
+    expect(availability.available).toBe(true);
+
+    const registration =
+      await cloudflareRegistrarService.registerDomain("guard-example.com");
+    expect(registration.registrationId).toContain("stub-reg-");
+  });
+});

--- a/packages/cloud-shared/src/lib/services/cloudflare-registrar.ts
+++ b/packages/cloud-shared/src/lib/services/cloudflare-registrar.ts
@@ -24,6 +24,7 @@
  * without spending money on real registrations.
  */
 
+import { shouldBlockRegistrarStub } from "../config/deployment-environment";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { CloudflareApiError, cloudflareApiRequest } from "../utils/cloudflare-api";
 import { logger } from "../utils/logger";
@@ -31,6 +32,16 @@ import { logger } from "../utils/logger";
 /** Read at call time so per-request Cloudflare Worker bindings are visible (cloud-bindings ALS). */
 function config() {
   const env = getCloudAwareEnv();
+  // Fail closed: the dev stub fabricates registrations but the buy route still
+  // debits credits, so a stray ELIZA_CF_REGISTRAR_DEV_STUB=1 in production would
+  // charge users for domains that were never registered. Refuse loudly instead.
+  if (shouldBlockRegistrarStub(env)) {
+    throw new Error(
+      "FATAL: ELIZA_CF_REGISTRAR_DEV_STUB=1 is set in a production deployment. " +
+        "Stub mode returns fake domain registrations that still debit credits. " +
+        "Unset ELIZA_CF_REGISTRAR_DEV_STUB and configure CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_API_TOKEN.",
+    );
+  }
   return {
     accountId: env.CLOUDFLARE_ACCOUNT_ID ?? "",
     apiToken: env.CLOUDFLARE_API_TOKEN ?? "",


### PR DESCRIPTION
## Problem

`domains/buy` charged a user's credits for a domain that was **never registered**. On a live run the buy returned `success: true` and debited **$14.95**, but no domain was registered: the returned zone was `stub-zone-<domain>`, the name resolves to a third-party registrar, and `domains/check` still reports it available afterward.

Root cause: `cloudflare-registrar.ts` (and `cloudflare-dns.ts`) have a dev stub gated only by `ELIZA_CF_REGISTRAR_DEV_STUB=1`, documented as "local dev + integration tests ... without spending money on real registrations." When that flag is set in **production**, the stub returns fake successes. The buy route (`v1/apps/[id]/domains/buy/route.ts`) debits credits **before** registering and only refunds when the registrar **throws** (catch -> `refundCredits` -> 502). A stub success never throws, so the refund never fires and the caller is charged for nothing. (`ensureConfigured` already fails correctly when the stub is *off* and creds are missing — the whole failure mode is the stub running in prod.)

## Fix

Make the dev stub **fail closed in production**, matching the existing footgun guards in `deployment-environment.ts` (`shouldBlockDevnetBypass`, `shouldBlockUnsafeWebhookSkip`):

- add `shouldBlockRegistrarStub(env)` = `ELIZA_CF_REGISTRAR_DEV_STUB === "1" && isProductionDeployment(env)`
- `cloudflare-registrar.ts` and `cloudflare-dns.ts` `config()` throw when it returns true

The throw happens per request inside `config()`, which the buy flow hits in `checkAvailability()` **before** any credit debit — so a misconfigured production fails loudly with **no charge** instead of silently faking registrations. Dev/test/staging (`NODE_ENV=test`, `ENVIRONMENT != production`) keep using the stub unchanged, so the cloud-e2e `monetized-app-loop` suite is unaffected.

## Tests

- `deployment-environment.test.ts` — `shouldBlockRegistrarStub` blocks only when the flag is on **and** in production (via `ENVIRONMENT` or `NODE_ENV`), allows dev/test/staging, and is off when the flag is unset.
- `cloudflare-registrar.test.ts` — the registrar **throws** when the stub flag is set with `ENVIRONMENT=production`, and still serves stub data outside production.

`bun test` (cloud-shared): 7/7 pass. Diff is additive only (no reformatting).

## Note for operators

Production should also **unset `ELIZA_CF_REGISTRAR_DEV_STUB`** and configure real `CLOUDFLARE_ACCOUNT_ID` / `CLOUDFLARE_API_TOKEN`; until real creds exist, domain buys should fail rather than fake-succeed. A latent follow-up (out of scope here): the buy route keeps the debit on an async "pending" registration that later fails — it only refunds on a synchronous throw.