### PR TITLE
feat(cloud): Eliza Cloud Apps (Product 2) — per-tenant-isolated container hosting

### DIFF
--- a/packages/cloud-shared/scripts/_e2e-build.ts
+++ b/packages/cloud-shared/scripts/_e2e-build.ts
@@ -1,0 +1,39 @@
+/**
+ * E2E build helper — drives the REAL AppImageBuilder against local Docker so the
+ * build pipeline's impure executor is verified end-to-end (not mocked). The
+ * `exec` seam runs `sudo sh -c <docker build ...>` locally; in production the
+ * same builder runs over SSH to a builder node.
+ *
+ * Env: REGISTRY, APP_ID, CONTEXT (build dir), DOCKERFILE (optional).
+ */
+
+import { spawn } from "node:child_process";
+import { AppImageBuilder, type BuildExec } from "../src/lib/services/app-image-builder";
+
+const localExec: BuildExec = {
+  exec: (command) =>
+    new Promise<string>((resolve, reject) => {
+      const p = spawn("sudo", ["sh", "-c", command], { stdio: ["ignore", "pipe", "pipe"] });
+      let out = "";
+      p.stdout.on("data", (d) => {
+        out += d;
+      });
+      p.stderr.on("data", (d) => {
+        out += d;
+      });
+      p.on("close", (code) =>
+        code === 0 ? resolve(out) : reject(new Error(`build exit ${code}:\n${out.slice(-800)}`)),
+      );
+    }),
+};
+
+const res = await new AppImageBuilder({ exec: localExec }).build({
+  registry: process.env.REGISTRY!,
+  appId: process.env.APP_ID!,
+  context: process.env.CONTEXT!,
+  dockerfile: process.env.DOCKERFILE || undefined,
+});
+
+process.stderr.write(`${res.buildOutput.slice(-300)}\n`);
+process.stdout.write(res.imageRef);
+process.exit(0);

--- a/packages/cloud-shared/scripts/_e2e-provision.ts
+++ b/packages/cloud-shared/scripts/_e2e-provision.ts
@@ -1,0 +1,75 @@
+/**
+ * E2E provisioning helper (Apps / Product 2) — host-side half of the real
+ * container↔isolated-DB verification (see verify-e2e-container-db.sh).
+ *
+ * Drives the REAL composed stack (makeTenantDbProvisioning -> ClusterPool ->
+ * tenantDbClustersRepository -> SqlTenantDbProvisioner -> DirectPgExecutor)
+ * against a throwaway tenant Postgres, then prints the two tenants' DSNs as JSON
+ * so the bash orchestrator can run real app containers that connect with them.
+ *
+ * Env:
+ *   ADMIN_DSN     superuser admin DSN the host-side provisioner connects with
+ *                 (host-published, e.g. postgresql://postgres:pw@localhost:55444/postgres?sslmode=disable)
+ *   CLUSTER_HOST  the in-docker-network address the APP CONTAINER uses to reach
+ *                 the same PG (e.g. apps-tenant-pg:5432) — becomes the DSN host
+ *   DATABASE_URL  must equal ADMIN_DSN so the repository's dbWrite hits this PG
+ */
+
+import { randomBytes } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { Client } from "pg";
+import { tenantDbClustersRepository } from "../src/db/repositories/tenant-db-clusters";
+import { makeTenantDbProvisioning } from "../src/lib/services/tenant-db/make-tenant-db-provisioning";
+import { deriveTenantIdent } from "../src/lib/services/tenant-db/tenant-db-provisioner";
+
+const ADMIN_DSN = process.env.ADMIN_DSN!;
+const CLUSTER_HOST = process.env.CLUSTER_HOST!;
+const APP_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const APP_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+async function adminExec(sql: string): Promise<void> {
+  const c = new Client({ connectionString: ADMIN_DSN });
+  await c.connect();
+  try {
+    await c.query(sql);
+  } finally {
+    await c.end();
+  }
+}
+
+// 1. Apply migration 0140 to the throwaway tenant PG (idempotent).
+const migration = readFileSync("./src/db/migrations/0140_tenant_db_clusters.sql", "utf8");
+for (const stmt of migration.split("--> statement-breakpoint")) {
+  if (stmt.trim()) await adminExec(stmt.trim());
+}
+await adminExec("DELETE FROM tenant_db_clusters");
+
+// 2. Seed a cluster whose host is the CONTAINER-reachable address; the admin DSN
+//    (host-published) is what DirectPgExecutor connects with to run the DDL.
+await tenantDbClustersRepository.create({
+  provider: "direct_pg",
+  host: CLUSTER_HOST,
+  admin_dsn_encrypted: ADMIN_DSN, // passthrough decrypt below
+  max_databases: 100,
+  database_count: 0,
+  is_active: true,
+});
+
+// 3. Provision two tenants through the real composer.
+const provisioning = makeTenantDbProvisioning({
+  decrypt: async (x) => x,
+  genPassword: () => randomBytes(18).toString("base64url"),
+});
+const a = await provisioning.provisionForApp(APP_A);
+const b = await provisioning.provisionForApp(APP_B);
+
+const identA = deriveTenantIdent(APP_A);
+const identB = deriveTenantIdent(APP_B);
+
+process.stdout.write(
+  `${JSON.stringify({
+    a: { dsn: a.dsn, role: identA.roleName, db: identA.dbName },
+    b: { dsn: b.dsn, role: identB.roleName, db: identB.dbName },
+  })}\n`,
+);
+process.exit(0);

--- a/packages/cloud-shared/scripts/e2e-sample-app/Dockerfile
+++ b/packages/cloud-shared/scripts/e2e-sample-app/Dockerfile
@@ -1,0 +1,10 @@
+# Sample user app for the Apps/Product 2 end-to-end proof. FROM postgres:16-alpine
+# so it ships psql (to reach its tenant DB) + busybox nc (to serve its URL) with
+# zero extra image pulls. A real user app would be any web server + DB client.
+FROM postgres:16-alpine
+COPY server.sh /usr/local/bin/server.sh
+RUN chmod +x /usr/local/bin/server.sh
+ENV PORT=3000
+# Drop the postgres image's entrypoint so our server runs directly.
+ENTRYPOINT []
+CMD ["/usr/local/bin/server.sh"]

--- a/packages/cloud-shared/scripts/e2e-sample-app/server.sh
+++ b/packages/cloud-shared/scripts/e2e-sample-app/server.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Minimal "user app" for the Apps/Product 2 end-to-end proof: connect to the
+# per-tenant DATABASE_URL the platform injected, then serve that DB identity over
+# HTTP (the app's URL). Stands in for any user web app that has its own database.
+set -u
+PORT="${PORT:-3000}"
+
+# Reach OUR OWN isolated tenant DB (proves app -> isolated DB connectivity).
+DBINFO="$(psql "$DATABASE_URL" -tAc "select 'db='||current_database()||' user='||current_user" 2>&1 | head -1)"
+echo "[sample-app] DATABASE_URL connect -> $DBINFO"
+
+BODY="hello from app | $DBINFO"
+LEN=$(printf '%s' "$BODY" | wc -c)
+
+# Serve the identity over HTTP on $PORT; one busybox-nc accept per request.
+echo "[sample-app] serving on :$PORT"
+while true; do
+  printf 'HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: %s\r\nConnection: close\r\n\r\n%s' \
+    "$LEN" "$BODY" | nc -l -p "$PORT"
+done

--- a/packages/cloud-shared/scripts/verify-deploy-db-writes.sh
+++ b/packages/cloud-shared/scripts/verify-deploy-db-writes.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Verify the apps deploy DB-orchestration adapters against the REAL drizzle schema
+# on a throwaway, fully-migrated PGlite store (the team's local Postgres). Proves
+# the container/job inserts + the per-tenant-DSN invariant for real, not mocked.
+#
+# Requires: bun. Run from packages/cloud-shared/.
+set -uo pipefail
+
+STORE="/tmp/apps-deploy-db-$$"
+cleanup() { rm -rf "$STORE"; }
+trap cleanup EXIT
+
+echo "=== migrate the REAL schema into a throwaway PGlite store ==="
+rm -rf "$STORE"; mkdir -p "$STORE"
+DATABASE_URL="pglite://$STORE" bun run db:migrate 2>&1 | tail -2
+
+echo
+echo "=== run the adapter write-verification against the real schema ==="
+DATABASE_URL="pglite://$STORE" \
+  CONTAINERS_PUBLIC_BASE_DOMAIN="containers.elizacloud.ai" \
+  bun run scripts/verify-deploy-db-writes.ts

--- a/packages/cloud-shared/scripts/verify-deploy-db-writes.ts
+++ b/packages/cloud-shared/scripts/verify-deploy-db-writes.ts
@@ -1,0 +1,129 @@
+/**
+ * Real-schema verification of the apps deploy DB-orchestration (Apps / Product 2).
+ *
+ * Runs the adapters' ACTUAL writes — toNewContainer -> containersRepository.create,
+ * appContainerStore.getById/markRunning/markError, containerJobsWriter.insertJob —
+ * against the REAL drizzle schema on a migrated PGlite store (the team's local
+ * Postgres, vector-enabled). Proves the load-bearing invariant for real:
+ *   containers.environment_vars.DATABASE_URL == the app's OWN per-tenant DSN,
+ * and that the container/job rows insert cleanly against the real NOT NULL /
+ * jsonb / enum constraints (what typecheck alone can't prove).
+ *
+ * Tenant-DB DDL + image build are stubbed here (each is verified for real
+ * elsewhere: verify-tenant-db-isolation.ts / verify-e2e-deploy.sh). This isolates
+ * the DB-write glue. Run via verify-deploy-db-writes.sh (migrates a throwaway
+ * store first). Requires DATABASE_URL=pglite://<migrated dir>.
+ */
+
+import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
+import { dbWrite } from "../src/db/client";
+import { containersRepository } from "../src/db/repositories/containers";
+import { appContainerStore } from "../src/lib/services/app-container-store";
+import { toNewContainer } from "../src/lib/services/app-deploy-runner";
+import { containerJobsWriter } from "../src/lib/services/container-jobs-writer";
+import { JOB_TYPES } from "../src/lib/services/provisioning-job-types";
+
+let pass = 0;
+let fail = 0;
+function check(name: string, ok: boolean, detail = ""): void {
+  console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? `  — ${detail}` : ""}`);
+  ok ? pass++ : fail++;
+}
+
+const rand = randomUUID().slice(0, 8);
+const orgId = randomUUID();
+const userId = randomUUID();
+const appId = randomUUID();
+const DSN = "postgresql://app_x:s3cret@cluster-1:5432/db_app_x?sslmode=require";
+
+// --- seed the FK parents (minimal required columns) ---
+await dbWrite.execute(
+  sql`INSERT INTO organizations (id, name, slug) VALUES (${orgId}, ${"Test Org"}, ${`test-org-${rand}`})`,
+);
+await dbWrite.execute(
+  sql`INSERT INTO users (id, steward_user_id) VALUES (${userId}, ${`steward-${rand}`})`,
+);
+
+// --- 1) toNewContainer -> containersRepository.create against the real table ---
+const created = await containersRepository.create(
+  toNewContainer({
+    appId,
+    organizationId: orgId,
+    userId,
+    containerName: `app-${rand}`,
+    image: "ghcr.io/elizaos/app-x:latest",
+    port: 3000,
+    environmentVars: { DATABASE_URL: DSN, PORT: "3000" },
+  }),
+);
+check("container row inserts cleanly against the real schema", Boolean(created?.id));
+check(
+  "the app's OWN per-tenant DSN landed in environment_vars.DATABASE_URL",
+  created.environment_vars?.DATABASE_URL === DSN,
+  created.environment_vars?.DATABASE_URL,
+);
+check(
+  "project_name keys off appId; status pending",
+  created.project_name === appId && created.status === "pending",
+);
+
+// --- 2) appContainerStore.getById projects the real row ---
+const view = await appContainerStore.getById(created.id);
+check(
+  "getById maps the real row (appId from metadata, DSN in env)",
+  view?.appId === appId &&
+    view?.environmentVars?.DATABASE_URL === DSN &&
+    view?.image === "ghcr.io/elizaos/app-x:latest",
+);
+
+// --- 3) markRunning writes status + host placement metadata (+ URL if configured) ---
+await appContainerStore.markRunning(created.id, {
+  hostContainerId: "host-ctr-1",
+  hostPort: 21345,
+  network: `app-net-${rand}`,
+});
+const afterRun = await containersRepository.findById(created.id, orgId);
+const meta = (afterRun?.metadata ?? {}) as Record<string, unknown>;
+check("markRunning -> status running", afterRun?.status === "running");
+check(
+  "markRunning merged host placement into metadata (appId preserved)",
+  meta.hostContainerId === "host-ctr-1" && meta.hostPort === 21345 && meta.appId === appId,
+);
+if (process.env.CONTAINERS_PUBLIC_BASE_DOMAIN) {
+  check(
+    "markRunning stamped a public URL (base domain configured)",
+    typeof afterRun?.public_hostname === "string" &&
+      (afterRun?.load_balancer_url ?? "").startsWith("https://"),
+    afterRun?.load_balancer_url ?? "",
+  );
+}
+
+// --- 4) containerJobsWriter.insertJob -> real jobs row, agent_id null ---
+const job = await containerJobsWriter.insertJob({
+  type: JOB_TYPES.CONTAINER_PROVISION,
+  organizationId: orgId,
+  userId,
+  data: { containerId: created.id },
+});
+const jobRow = await dbWrite.execute(sql`SELECT type, agent_id FROM jobs WHERE id = ${job.id}`);
+const jr = (jobRow.rows?.[0] ?? {}) as { type?: string; agent_id?: string | null };
+check(
+  "CONTAINER_PROVISION job inserted with agent_id NULL",
+  jr.type === JOB_TYPES.CONTAINER_PROVISION && (jr.agent_id ?? null) === null,
+);
+
+// --- 5) markError / markDeleted real status transitions ---
+await appContainerStore.markError(created.id, "boom");
+check(
+  "markError -> status failed + error stored",
+  (await containersRepository.findById(created.id, orgId))?.status === "failed",
+);
+await appContainerStore.markDeleted(created.id);
+check(
+  "markDeleted -> status stopped (row reusable)",
+  (await containersRepository.findById(created.id, orgId))?.status === "stopped",
+);
+
+console.log(`\n=== ${pass} passed, ${fail} failed ===`);
+process.exit(fail ? 1 : 0);

--- a/packages/cloud-shared/scripts/verify-e2e-container-db.sh
+++ b/packages/cloud-shared/scripts/verify-e2e-container-db.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# E2E real-Docker verification (Apps / Product 2): a REAL container process
+# reaches its OWN isolated Postgres DB, is REJECTED from another tenant's DB
+# (REVOKE CONNECT, over real docker networking), and our REAL --internal network
+# builder blocks egress. No mocks, no VPS, no prod — throwaway resources only.
+#
+# Requires: sudo docker, bun. Run from packages/cloud-shared/.
+#   bash scripts/verify-e2e-container-db.sh
+set -uo pipefail
+
+NET_DB="apps-dbnet"
+PG="apps-tenant-pg"
+PGPORT=55444
+PGPASS=adminpw
+IMG=postgres:16-alpine
+PASS=0; FAIL=0
+check() { if [ "$1" = "ok" ]; then echo "PASS  $2"; PASS=$((PASS+1)); else echo "FAIL  $2 ${3:-}"; FAIL=$((FAIL+1)); fi; }
+
+cleanup() {
+  sudo docker rm -f "$PG" >/dev/null 2>&1 || true
+  # remove the per-app --internal net if it was created
+  [ -n "${APPNET:-}" ] && sudo docker network rm "$APPNET" >/dev/null 2>&1 || true
+  sudo docker network rm "$NET_DB" >/dev/null 2>&1 || true
+  rm -f /tmp/e2e-dsns.json
+}
+trap cleanup EXIT
+
+echo "=== setup: throwaway tenant-PG on a real docker network ==="
+sudo docker rm -f "$PG" >/dev/null 2>&1 || true
+sudo docker network rm "$NET_DB" >/dev/null 2>&1 || true
+sudo docker network create --driver bridge "$NET_DB" >/dev/null
+sudo docker run -d --name "$PG" --network "$NET_DB" -p "$PGPORT:5432" \
+  -e POSTGRES_PASSWORD="$PGPASS" "$IMG" >/dev/null
+# wait for readiness
+for i in $(seq 1 30); do
+  if sudo docker exec "$PG" pg_isready -U postgres >/dev/null 2>&1; then break; fi
+  sleep 1
+done
+
+echo "=== provision two tenants through the REAL composer (host side) ==="
+export ADMIN_DSN="postgresql://postgres:${PGPASS}@localhost:${PGPORT}/postgres?sslmode=disable"
+export CLUSTER_HOST="${PG}:5432"
+export DATABASE_URL="$ADMIN_DSN"
+bun run scripts/_e2e-provision.ts > /tmp/e2e-dsns.json || { echo "provisioning FAILED"; cat /tmp/e2e-dsns.json; exit 1; }
+cat /tmp/e2e-dsns.json
+
+DSN_A=$(node -e "process.stdout.write(require('/tmp/e2e-dsns.json').a.dsn)")
+DSN_B=$(node -e "process.stdout.write(require('/tmp/e2e-dsns.json').b.dsn)")
+DB_A=$(node -e "process.stdout.write(require('/tmp/e2e-dsns.json').a.db)")
+DB_B=$(node -e "process.stdout.write(require('/tmp/e2e-dsns.json').b.db)")
+# sslmode=require -> disable for the no-TLS throwaway PG
+DSN_A_L=${DSN_A/sslmode=require/sslmode=disable}
+DSN_B_L=${DSN_B/sslmode=require/sslmode=disable}
+# tenant B's creds aimed at tenant A's database (the cross-tenant attempt)
+CROSS=${DSN_B_L/\/$DB_B\?/\/$DB_A\?}
+
+echo
+echo "=== DATA PLANE: real app containers over real docker networking ==="
+# 1) App A container reaches its OWN database.
+OUT=$(sudo docker run --rm --network "$NET_DB" "$IMG" psql "$DSN_A_L" -tAc "select current_database()" 2>&1)
+[ "$OUT" = "$DB_A" ] && check ok "app-A container connects to its OWN isolated DB ($DB_A)" || check fail "app-A own DB" "got: $OUT"
+
+# 2) App B container reaches its OWN database (sanity).
+OUT=$(sudo docker run --rm --network "$NET_DB" "$IMG" psql "$DSN_B_L" -tAc "select current_database()" 2>&1)
+[ "$OUT" = "$DB_B" ] && check ok "app-B container connects to its OWN isolated DB ($DB_B)" || check fail "app-B own DB" "got: $OUT"
+
+# 3) THE BOUNDARY: app B's role, from a container, CANNOT open app A's DB.
+OUT=$(sudo docker run --rm --network "$NET_DB" "$IMG" psql "$CROSS" -tAc "select 1" 2>&1)
+echo "$OUT" | grep -qiE "permission denied for database" \
+  && check ok "cross-tenant REJECTED through a real container (REVOKE CONNECT)" \
+  || check fail "cross-tenant rejection" "got: $(echo "$OUT" | head -1)"
+
+echo
+echo "=== NETWORK PLANE: our REAL buildEnsureAppNetworkCmd (--internal) blocks egress ==="
+# Drive the actual builder: it prints the network name + the exact create command.
+APPNET=$(bun -e "import {appNetworkName} from './src/lib/services/app-network-utils'; process.stdout.write(appNetworkName('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'))")
+BUILDER_CMD=$(bun -e "import {buildEnsureAppNetworkCmd,appNetworkName} from './src/lib/services/app-network-utils'; process.stdout.write(buildEnsureAppNetworkCmd(appNetworkName('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa')))")
+echo "builder: $BUILDER_CMD"
+sudo sh -c "$BUILDER_CMD"   # execute our real builder output as root
+sudo docker network inspect "$APPNET" --format '{{.Internal}}' | grep -q true \
+  && check ok "buildEnsureAppNetworkCmd created an --internal network" \
+  || check fail "internal network flag"
+
+# A container on the --internal net has NO egress (cannot reach the DB host nor internet).
+OUT=$(sudo docker run --rm --network "$APPNET" "$IMG" sh -c "timeout 5 psql 'postgresql://x:y@${PG}:5432/z?sslmode=disable' -tAc 'select 1' 2>&1; echo EXIT=\$?" 2>&1)
+echo "$OUT" | grep -qiE "could not translate host name|could not connect|no route|timeout|timed out|Name does not resolve|EXIT=[^0]" \
+  && check ok "container on --internal net is EGRESS-BLOCKED (no route off-network)" \
+  || check fail "internal egress block" "got: $(echo "$OUT" | head -1)"
+
+echo
+echo "=== $PASS passed, $FAIL failed ==="
+exit $((FAIL>0 ? 1 : 0))

--- a/packages/cloud-shared/scripts/verify-e2e-deploy.sh
+++ b/packages/cloud-shared/scripts/verify-e2e-deploy.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# FULL end-to-end deploy proof (Apps / Product 2) on REAL local infra — the whole
+# flow the goal describes, no mocks, no VPS, no prod:
+#   build user image (real AppImageBuilder + docker build)
+#     -> provision per-tenant DB (real composed stack)
+#     -> run the image as an --internal isolated container with its per-tenant DSN
+#     -> it reaches ITS OWN DB and serves its URL
+#     -> it CANNOT reach another tenant's DB (REVOKE CONNECT)
+#     -> it has NO internet egress (--internal)
+#
+# Requires: sudo docker (passwordless), bun. Run from packages/cloud-shared/.
+set -uo pipefail
+
+PG=apps-tenant-pg
+PGPORT=55445
+PGPASS=adminpw
+IMG=postgres:16-alpine
+SEEDNET=apps-seednet
+APP_ID="aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+APP_RUN=app-run
+INGRESS=app-ingress
+PASS=0; FAIL=0
+check(){ if [ "$1" = ok ]; then echo "PASS  $2"; PASS=$((PASS+1)); else echo "FAIL  $2 ${3:-}"; FAIL=$((FAIL+1)); fi; }
+
+cleanup(){
+  sudo docker rm -f "$APP_RUN" "$INGRESS" "$PG" >/dev/null 2>&1 || true
+  [ -n "${APPNET:-}" ] && sudo docker network rm "$APPNET" >/dev/null 2>&1 || true
+  sudo docker network rm "$SEEDNET" >/dev/null 2>&1 || true
+  sudo docker rmi -f "${IMAGE_REF:-}" >/dev/null 2>&1 || true
+  rm -f /tmp/e2e-dsns.json
+}
+trap cleanup EXIT
+
+echo "=== 1) BUILD the user app image via the REAL AppImageBuilder (local docker build) ==="
+IMAGE_REF=$(REGISTRY=apps-local APP_ID="$APP_ID" CONTEXT=scripts/e2e-sample-app \
+  bun run scripts/_e2e-build.ts) || { echo "build FAILED"; exit 1; }
+echo "built: $IMAGE_REF"
+sudo docker image inspect "$IMAGE_REF" >/dev/null 2>&1 \
+  && check ok "build pipeline produced a real local image ($IMAGE_REF)" \
+  || { check fail "image build"; exit 1; }
+
+echo
+echo "=== 2) PROVISION per-tenant DBs through the real composed stack ==="
+sudo docker rm -f "$PG" >/dev/null 2>&1 || true
+sudo docker network rm "$SEEDNET" >/dev/null 2>&1 || true
+sudo docker network create --driver bridge "$SEEDNET" >/dev/null
+sudo docker run -d --name "$PG" --network "$SEEDNET" -p "$PGPORT:5432" \
+  -e POSTGRES_PASSWORD="$PGPASS" "$IMG" >/dev/null
+for i in $(seq 1 30); do sudo docker exec "$PG" pg_isready -U postgres >/dev/null 2>&1 && break; sleep 1; done
+
+export ADMIN_DSN="postgresql://postgres:${PGPASS}@localhost:${PGPORT}/postgres?sslmode=disable"
+export CLUSTER_HOST="${PG}:5432"
+export DATABASE_URL="$ADMIN_DSN"
+bun run scripts/_e2e-provision.ts > /tmp/e2e-dsns.json || { echo "provision FAILED"; cat /tmp/e2e-dsns.json; exit 1; }
+DSN_A=$(node -e "process.stdout.write(require('/tmp/e2e-dsns.json').a.dsn)")
+DSN_B=$(node -e "process.stdout.write(require('/tmp/e2e-dsns.json').b.dsn)")
+DB_A=$(node -e "process.stdout.write(require('/tmp/e2e-dsns.json').a.db)")
+DB_B=$(node -e "process.stdout.write(require('/tmp/e2e-dsns.json').b.db)")
+DSN_A_L=${DSN_A/sslmode=require/sslmode=disable}
+DSN_B_L=${DSN_B/sslmode=require/sslmode=disable}
+CROSS=${DSN_B_L/\/$DB_B\?/\/$DB_A\?}   # tenant B creds aimed at tenant A's DB
+echo "tenant A db=$DB_A"
+
+echo
+echo "=== 3) RUN the image as an --internal isolated container with its per-tenant DSN ==="
+# Build the per-app --internal network via the REAL builder, then attach the DB
+# to it (the tenant DB sits on an allowed path; the internet does not).
+APPNET=$(bun -e "import {appNetworkName} from './src/lib/services/app-network-utils'; process.stdout.write(appNetworkName('$APP_ID'))")
+BUILDER_CMD=$(bun -e "import {buildEnsureAppNetworkCmd,appNetworkName} from './src/lib/services/app-network-utils'; process.stdout.write(buildEnsureAppNetworkCmd(appNetworkName('$APP_ID')))")
+sudo sh -c "$BUILDER_CMD"
+sudo docker network connect "$APPNET" "$PG"   # tenant DB reachable on the isolated net
+SECFLAGS=$(bun -e "import {buildAppContainerSecurityFlags} from './src/lib/services/app-network-utils'; process.stdout.write(buildAppContainerSecurityFlags().join(' '))")
+echo "security flags: $SECFLAGS"
+sudo docker run -d --name "$APP_RUN" --network "$APPNET" $SECFLAGS \
+  -e DATABASE_URL="$DSN_A_L" -e PORT=3000 "$IMAGE_REF" >/dev/null
+sleep 4
+
+echo
+echo "=== 4) app reaches ITS OWN DB + serves its URL ==="
+LOGS=$(sudo docker logs "$APP_RUN" 2>&1)
+echo "$LOGS" | grep -q "db=$DB_A" \
+  && check ok "deployed app connected to its OWN isolated DB ($DB_A)" \
+  || check fail "app->own DB" "logs: $(echo "$LOGS" | head -2 | tr '\n' ' ')"
+
+# The "URL": an ingress sibling on the app network fetches the app (prod ingress
+# reaches the container over the docker network, exactly like this).
+URLBODY=$(sudo docker run --rm --network "$APPNET" "$IMG" \
+  sh -c "for i in 1 2 3 4 5; do wget -qO- http://$APP_RUN:3000/ 2>/dev/null && break; sleep 1; done")
+echo "URL body: $URLBODY"
+echo "$URLBODY" | grep -q "db=$DB_A" \
+  && check ok "app serves its URL (HTTP) returning its own DB identity" \
+  || check fail "app URL serve" "got: $URLBODY"
+
+echo
+echo "=== 5) app CANNOT reach another tenant's DB (REVOKE CONNECT) ==="
+XOUT=$(sudo docker run --rm --network "$APPNET" "$IMG" psql "$CROSS" -tAc "select 1" 2>&1)
+echo "$XOUT" | grep -qiE "permission denied for database" \
+  && check ok "cross-tenant DB access REJECTED from the isolated container" \
+  || check fail "cross-tenant rejection" "got: $(echo "$XOUT" | head -1)"
+
+echo
+echo "=== 6) app has NO internet egress (--internal) ==="
+EOUT=$(sudo docker run --rm --network "$APPNET" "$IMG" \
+  sh -c "timeout 5 wget -qO- http://1.1.1.1/ 2>&1; echo EXIT=\$?")
+echo "$EOUT" | grep -qiE "bad address|download timed out|timed out|EXIT=[^0]" \
+  && check ok "isolated container has NO internet egress" \
+  || check fail "egress block" "got: $(echo "$EOUT" | head -1)"
+
+echo
+echo "=== $PASS passed, $FAIL failed ==="
+exit $((FAIL>0 ? 1 : 0))

--- a/packages/cloud-shared/scripts/verify-tenant-db-isolation.ts
+++ b/packages/cloud-shared/scripts/verify-tenant-db-isolation.ts
@@ -1,0 +1,89 @@
+import { randomBytes } from "node:crypto";
+import { Client } from "pg";
+import { DirectPgExecutor } from "./src/lib/services/tenant-db/direct-pg-executor";
+import {
+  deriveTenantIdent,
+  SqlTenantDbProvisioner,
+} from "./src/lib/services/tenant-db/tenant-db-provisioner";
+
+const ADMIN = "postgresql://postgres:adminpw@localhost:55432/postgres";
+const APP_A = "11111111-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const APP_B = "22222222-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+let pass = 0;
+let fail = 0;
+function check(name: string, ok: boolean, detail = "") {
+  console.log(`${ok ? "PASS" : "FAIL"}  ${name}${detail ? "  — " + detail : ""}`);
+  ok ? pass++ : fail++;
+}
+
+// The throwaway local Postgres has no TLS; the real cluster does. Strip the
+// (correct-for-prod) sslmode=require for these local connection checks so a
+// rejection is genuinely REVOKE CONNECT, not a TLS handshake failure.
+const local = (dsn: string) => dsn.replace("sslmode=require", "sslmode=disable");
+
+async function canConnect(dsn: string): Promise<{ ok: boolean; err?: string }> {
+  const c = new Client({ connectionString: local(dsn) });
+  try {
+    await c.connect();
+    await c.query("select 1");
+    await c.end();
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, err: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+const provisioner = new SqlTenantDbProvisioner({
+  cluster: { host: "localhost:55432" },
+  executor: new DirectPgExecutor(ADMIN),
+  genPassword: () => randomBytes(16).toString("hex"),
+});
+
+const a = await provisioner.provision(APP_A);
+const b = await provisioner.provision(APP_B);
+const identA = deriveTenantIdent(APP_A);
+const identB = deriveTenantIdent(APP_B);
+console.log(`provisioned A=${identA.dbName} (role ${identA.roleName}), B=${identB.dbName}`);
+
+// 1. Each tenant can reach its OWN database.
+check("tenant A connects to its own DB", (await canConnect(a.dsn)).ok);
+check("tenant B connects to its own DB", (await canConnect(b.dsn)).ok);
+
+// 2. THE BOUNDARY: tenant A's credentials must NOT connect to tenant B's DB.
+const aCredsToBDb = a.dsn.replace(`/${identA.dbName}?`, `/${identB.dbName}?`);
+const cross = await canConnect(aCredsToBDb);
+check(
+  "tenant A is REJECTED from tenant B's DB (REVOKE CONNECT)",
+  !cross.ok,
+  cross.ok ? "BREACH: connected!" : `rejected: ${(cross.err ?? "").slice(0, 70)}`,
+);
+
+// 3. Tenant A can actually use its own DB (schema privileges granted).
+const ca = new Client({ connectionString: local(a.dsn) });
+await ca.connect();
+try {
+  await ca.query("create table t_demo (id int)");
+  await ca.query("insert into t_demo values (1)");
+  const r = await ca.query("select count(*)::int as n from t_demo");
+  check("tenant A can create + write tables in its own DB", r.rows[0].n === 1);
+} catch (e) {
+  check("tenant A can create + write tables in its own DB", false, String(e).slice(0, 70));
+} finally {
+  await ca.end();
+}
+
+// 4. The tenant role is least-privilege (cannot create databases).
+const ca2 = new Client({ connectionString: local(a.dsn) });
+await ca2.connect();
+try {
+  await ca2.query('create database "sneaky_db"');
+  check("tenant A CANNOT create databases (least-privilege)", false, "BREACH: created a DB!");
+} catch {
+  check("tenant A CANNOT create databases (least-privilege)", true);
+} finally {
+  await ca2.end();
+}
+
+console.log(`\n=== ${pass} passed, ${fail} failed ===`);
+process.exit(fail ? 1 : 0);

--- a/packages/cloud-shared/src/db/migrations/0140_tenant_db_clusters.sql
+++ b/packages/cloud-shared/src/db/migrations/0140_tenant_db_clusters.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS "tenant_db_clusters" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"provider" text DEFAULT 'direct_pg' NOT NULL,
+	"host" text NOT NULL,
+	"admin_dsn_encrypted" text NOT NULL,
+	"max_databases" integer DEFAULT 2000 NOT NULL,
+	"database_count" integer DEFAULT 0 NOT NULL,
+	"is_active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "tenant_db_clusters_active_idx" ON "tenant_db_clusters" USING btree ("is_active");

--- a/packages/cloud-shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud-shared/src/db/migrations/meta/_journal.json
@@ -974,6 +974,13 @@
       "when": 1779408700000,
       "tag": "0137_agent_execution_tier",
       "breakpoints": true
+    },
+    {
+      "idx": 139,
+      "version": "7",
+      "when": 1779408800000,
+      "tag": "0140_tenant_db_clusters",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud-shared/src/db/repositories/tenant-db-clusters.ts
+++ b/packages/cloud-shared/src/db/repositories/tenant-db-clusters.ts
@@ -1,0 +1,66 @@
+import { and, eq, sql } from "drizzle-orm";
+import type { ClusterCandidate, ClusterPoolStore } from "../../lib/services/tenant-db/cluster-pool";
+import { dbRead, dbWrite } from "../helpers";
+import { type NewTenantDbCluster, tenantDbClusters } from "../schemas/tenant-db-clusters";
+
+/**
+ * Repository for the apps tenant-DB cluster pool. Implements
+ * {@link ClusterPoolStore} over the `tenant_db_clusters` table — the persistent
+ * backend the {@link ClusterPool} allocates from.
+ */
+export const tenantDbClustersRepository: ClusterPoolStore & {
+  create(input: NewTenantDbCluster): Promise<{ id: string }>;
+} = {
+  async listAllocatable(): Promise<ClusterCandidate[]> {
+    const rows = await dbRead
+      .select({
+        id: tenantDbClusters.id,
+        host: tenantDbClusters.host,
+        adminDsnEncrypted: tenantDbClusters.admin_dsn_encrypted,
+        databaseCount: tenantDbClusters.database_count,
+        maxDatabases: tenantDbClusters.max_databases,
+        isActive: tenantDbClusters.is_active,
+      })
+      .from(tenantDbClusters)
+      .where(
+        and(
+          eq(tenantDbClusters.is_active, true),
+          sql`${tenantDbClusters.database_count} < ${tenantDbClusters.max_databases}`,
+        ),
+      );
+    return rows;
+  },
+
+  /**
+   * Atomically claim a database slot: increment `database_count` only if the
+   * cluster is still active and under capacity. The `WHERE … < max_databases`
+   * guard makes concurrent claims race-safe — two callers can't overfill a
+   * cluster — and the empty `RETURNING` set signals "lost the race".
+   */
+  async tryClaimSlot(clusterId: string): Promise<boolean> {
+    const claimed = await dbWrite
+      .update(tenantDbClusters)
+      .set({
+        database_count: sql`${tenantDbClusters.database_count} + 1`,
+        updated_at: new Date(),
+      })
+      .where(
+        and(
+          eq(tenantDbClusters.id, clusterId),
+          eq(tenantDbClusters.is_active, true),
+          sql`${tenantDbClusters.database_count} < ${tenantDbClusters.max_databases}`,
+        ),
+      )
+      .returning({ id: tenantDbClusters.id });
+    return claimed.length > 0;
+  },
+
+  async create(input: NewTenantDbCluster): Promise<{ id: string }> {
+    const [row] = await dbWrite
+      .insert(tenantDbClusters)
+      .values(input)
+      .returning({ id: tenantDbClusters.id });
+    if (!row) throw new Error("Failed to insert tenant_db_clusters row");
+    return row;
+  },
+};

--- a/packages/cloud-shared/src/db/schemas/index.ts
+++ b/packages/cloud-shared/src/db/schemas/index.ts
@@ -75,6 +75,7 @@ export * from "./secrets";
 export * from "./seo";
 export * from "./service-pricing";
 export * from "./telegram-chats";
+export * from "./tenant-db-clusters";
 export * from "./token-redemptions";
 export * from "./tts-first-line-cache";
 export * from "./twilio-inbound-calls";

--- a/packages/cloud-shared/src/db/schemas/tenant-db-clusters.ts
+++ b/packages/cloud-shared/src/db/schemas/tenant-db-clusters.ts
@@ -1,0 +1,52 @@
+import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { boolean, index, integer, pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+
+/**
+ * Tenant DB cluster pool (Apps / Product 2).
+ *
+ * Each row is one app-owned Postgres cluster that holds many per-tenant
+ * databases (DATABASE-per-tenant + ROLE-per-tenant). The pool picks the
+ * least-loaded active cluster with remaining capacity; when every cluster is
+ * full, an operator adds another cluster row (+ box) and new tenants land
+ * there — this "roll to a new cluster" is how we scale past any single
+ * server's / managed-provider's database cap.
+ *
+ * This is the APPS data plane only — it has nothing to do with the shared
+ * agent DATABASE_URL or `agent_sandboxes`.
+ */
+export const tenantDbClusters = pgTable(
+  "tenant_db_clusters",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+
+    /** Backend kind: `direct_pg` (self-managed) or `neon`. */
+    provider: text("provider").notNull().default("direct_pg"),
+
+    /** Host[:port] used to build tenant DSNs (the data-plane endpoint). */
+    host: text("host").notNull(),
+
+    /**
+     * Encrypted admin DSN used to run CREATE DATABASE / CREATE ROLE on this
+     * cluster. SENSITIVE — never expose to client code or logs.
+     */
+    admin_dsn_encrypted: text("admin_dsn_encrypted").notNull(),
+
+    /** Max tenant databases this cluster holds before it stops accepting new ones. */
+    max_databases: integer("max_databases").notNull().default(2000),
+
+    /** Current number of tenant databases provisioned on this cluster. */
+    database_count: integer("database_count").notNull().default(0),
+
+    /** Whether new tenants may be allocated here. */
+    is_active: boolean("is_active").notNull().default(true),
+
+    created_at: timestamp("created_at").notNull().defaultNow(),
+    updated_at: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => ({
+    active_idx: index("tenant_db_clusters_active_idx").on(table.is_active),
+  }),
+);
+
+export type TenantDbCluster = InferSelectModel<typeof tenantDbClusters>;
+export type NewTenantDbCluster = InferInsertModel<typeof tenantDbClusters>;

--- a/packages/cloud-shared/src/lib/services/__tests__/app-build-cmd.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-build-cmd.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { buildAppImageBuildCmd, buildAppImagePushCmd } from "../app-build-cmd";
+
+const REF = "ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:a1b2c3d";
+
+describe("buildAppImageBuildCmd", () => {
+  test("plain docker build from a local context, no push", () => {
+    expect(buildAppImageBuildCmd({ context: "/work/src", imageRef: REF })).toBe(
+      `docker build --tag '${REF}' '/work/src'`,
+    );
+  });
+
+  test("git URL context builds natively (no clone step)", () => {
+    const cmd = buildAppImageBuildCmd({
+      context: "https://github.com/u/repo.git#main",
+      imageRef: REF,
+    });
+    expect(cmd).toContain("'https://github.com/u/repo.git#main'");
+  });
+
+  test("push implies buildx + --push (no --load)", () => {
+    const cmd = buildAppImageBuildCmd({ context: "/c", imageRef: REF, push: true });
+    expect(cmd.startsWith("docker buildx build")).toBe(true);
+    expect(cmd).toContain("--push");
+    expect(cmd).not.toContain("--load");
+  });
+
+  test("buildx without push gets --load so the image lands locally", () => {
+    const cmd = buildAppImageBuildCmd({ context: "/c", imageRef: REF, buildx: true });
+    expect(cmd).toContain("docker buildx build");
+    expect(cmd).toContain("--load");
+    expect(cmd).not.toContain("--push");
+  });
+
+  test("dockerfile + build args are quoted", () => {
+    const cmd = buildAppImageBuildCmd({
+      context: "/c",
+      imageRef: REF,
+      dockerfile: "docker/Dockerfile.prod",
+      buildArgs: { NODE_ENV: "production" },
+    });
+    expect(cmd).toContain("--file 'docker/Dockerfile.prod'");
+    expect(cmd).toContain("--build-arg 'NODE_ENV=production'");
+  });
+
+  test("shell-quotes a context with metacharacters (injection-safe)", () => {
+    const cmd = buildAppImageBuildCmd({ context: "/c; rm -rf /", imageRef: REF });
+    expect(cmd).toContain("'/c; rm -rf /'");
+    expect(cmd).not.toMatch(/ rm -rf \/$/); // never bare
+  });
+});
+
+describe("buildAppImagePushCmd", () => {
+  test("quotes the ref", () => {
+    expect(buildAppImagePushCmd(REF)).toBe(`docker push '${REF}'`);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/app-container-provider.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-container-provider.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { AppContainerProvider, type AppContainerSsh } from "../app-container-provider";
+import type { CreateContainerInput } from "../containers/hetzner-client/types";
+
+const APP_ID = "11111111-2222-3333-4444-555555555555";
+
+const INPUT: CreateContainerInput = {
+  name: "nubilio-web",
+  projectName: "nubilio",
+  organizationId: "org-1",
+  userId: "user-1",
+  image: "ghcr.io/nubs/nubilio:latest",
+  port: 3000,
+  desiredCount: 1,
+  cpu: 1,
+  memoryMb: 512,
+  healthCheckPath: "/health",
+};
+
+function recordingSsh(create = "containerid-abc123") {
+  const calls: string[] = [];
+  const ssh: AppContainerSsh = {
+    async exec(command) {
+      calls.push(command);
+      if (command.startsWith("docker create")) return create;
+      return "";
+    },
+  };
+  return { calls, ssh };
+}
+
+describe("AppContainerProvider.provision", () => {
+  test("ensures the --internal network, creates, starts, and returns the id", async () => {
+    const { calls, ssh } = recordingSsh();
+    const provider = new AppContainerProvider({
+      ssh,
+      allocateHostPort: async () => 49001,
+      egressProxyUrl: "http://egress-gw:3128",
+    });
+
+    const result = await provider.provision({
+      appId: APP_ID,
+      containerName: "app-nubilio",
+      input: INPUT,
+    });
+
+    expect(result.containerId).toBe("containerid-abc123");
+    expect(result.hostPort).toBe(49001);
+    expect(result.network).toMatch(/^app-net-/);
+
+    // network ensure first, then create, then start
+    expect(calls[0]).toContain("docker network create --driver bridge --internal");
+    expect(calls[1]).toContain("docker create");
+    expect(calls[1]).toContain("--cap-drop=ALL");
+    expect(calls[1]).toContain("-p 49001:3000");
+    expect(calls[1]).toContain("HTTP_PROXY=http://egress-gw:3128");
+    expect(calls[1]).not.toContain("NET_ADMIN");
+    expect(calls[2]).toBe("docker start 'app-nubilio'");
+  });
+
+  test("lifecycle verbs issue the expected docker commands", async () => {
+    const { calls, ssh } = recordingSsh();
+    const provider = new AppContainerProvider({ ssh, allocateHostPort: async () => 1 });
+    await provider.delete("app-x");
+    await provider.restart("app-x");
+    await provider.logs("app-x", 50);
+    expect(calls).toEqual([
+      "docker rm -f 'app-x'",
+      "docker restart 'app-x'",
+      "docker logs --tail 50 'app-x'",
+    ]);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/app-container-store.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-container-store.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import {
+  mapContainerRowToAppContainerRow,
+  mergeHostPlacementMetadata,
+  type ProjectableContainerRow,
+} from "../app-container-store";
+import { toNewContainer } from "../app-deploy-runner";
+
+const DSN = "postgresql://app_x:pw@cluster:5432/db_app_x?sslmode=require";
+
+function row(overrides: Partial<ProjectableContainerRow> = {}): ProjectableContainerRow {
+  return {
+    id: "c-1",
+    name: "app-abc",
+    project_name: "app-id-123",
+    image_tag: "ghcr.io/elizaos/app-x:latest",
+    port: 3000,
+    organization_id: "org-1",
+    user_id: "user-1",
+    environment_vars: { DATABASE_URL: DSN, PORT: "3000" },
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe("mapContainerRowToAppContainerRow", () => {
+  test("projects columns and carries the per-tenant DSN through env vars", () => {
+    const r = mapContainerRowToAppContainerRow(row());
+    expect(r).toEqual({
+      id: "c-1",
+      appId: "app-id-123", // from project_name (no metadata.appId)
+      containerName: "app-abc",
+      image: "ghcr.io/elizaos/app-x:latest",
+      port: 3000,
+      organizationId: "org-1",
+      userId: "user-1",
+      environmentVars: { DATABASE_URL: DSN, PORT: "3000" },
+    });
+  });
+
+  test("prefers metadata.appId over project_name when present", () => {
+    expect(mapContainerRowToAppContainerRow(row({ metadata: { appId: "meta-app" } })).appId).toBe(
+      "meta-app",
+    );
+  });
+
+  test("null image_tag becomes empty string", () => {
+    expect(mapContainerRowToAppContainerRow(row({ image_tag: null })).image).toBe("");
+  });
+});
+
+describe("mergeHostPlacementMetadata", () => {
+  const info = { hostContainerId: "h-9", hostPort: 21000, network: "app-net-x" };
+
+  test("preserves existing metadata (e.g. appId) and adds host placement", () => {
+    expect(mergeHostPlacementMetadata({ appId: "a1", foo: 1 }, info)).toEqual({
+      appId: "a1",
+      foo: 1,
+      hostContainerId: "h-9",
+      hostPort: 21000,
+      network: "app-net-x",
+    });
+  });
+
+  test("null/undefined existing → just the host placement", () => {
+    expect(mergeHostPlacementMetadata(null, info)).toEqual(info);
+    expect(mergeHostPlacementMetadata(undefined, info)).toEqual(info);
+  });
+});
+
+describe("toNewContainer", () => {
+  test("the app's OWN DSN rides in environment_vars; project_name + metadata key off appId", () => {
+    const nc = toNewContainer({
+      appId: "app-id-123",
+      organizationId: "org-1",
+      userId: "user-1",
+      containerName: "app-abc",
+      image: "ghcr.io/elizaos/app-x:latest",
+      port: 3000,
+      environmentVars: { DATABASE_URL: DSN },
+    });
+    expect(nc.environment_vars).toEqual({ DATABASE_URL: DSN });
+    expect(nc.project_name).toBe("app-id-123");
+    expect(nc.metadata).toEqual({ appId: "app-id-123" });
+    expect(nc.status).toBe("pending");
+    expect(nc.image_tag).toBe("ghcr.io/elizaos/app-x:latest");
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/app-deploy-job-service.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-deploy-job-service.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import {
+  dispatchAppDeployJob,
+  enqueueAppDeploy,
+  getAppDeployRunner,
+  readAppDeployJobData,
+  setAppDeployRunner,
+} from "../app-deploy-job-service";
+import type { ContainerJobInsert, ContainerJobsWriter } from "../container-job-service";
+
+describe("readAppDeployJobData", () => {
+  test("extracts appId", () => {
+    expect(readAppDeployJobData({ data: { appId: "app-1" } })).toEqual({ appId: "app-1" });
+  });
+  test("throws when appId missing/blank", () => {
+    expect(() => readAppDeployJobData({ data: {} })).toThrow(/missing data.appId/);
+    expect(() => readAppDeployJobData({ data: { appId: "" } })).toThrow(/missing data.appId/);
+  });
+});
+
+describe("app deploy runner injection", () => {
+  test("getAppDeployRunner throws before it is wired", () => {
+    expect(() => getAppDeployRunner()).toThrow(/not configured/);
+  });
+
+  test("dispatchAppDeployJob runs the injected runner with the appId", async () => {
+    const calls: string[] = [];
+    setAppDeployRunner({ run: async (id) => void calls.push(id) });
+    await dispatchAppDeployJob({ data: { appId: "app-42" } });
+    expect(calls).toEqual(["app-42"]);
+  });
+});
+
+describe("enqueueAppDeploy", () => {
+  test("inserts an APP_DEPLOY job carrying the appId (pg-free writer)", async () => {
+    const inserted: ContainerJobInsert[] = [];
+    const writer: ContainerJobsWriter = {
+      insertJob: async (j) => {
+        inserted.push(j);
+        return { id: "job-1" };
+      },
+    };
+    const r = await enqueueAppDeploy(writer, {
+      appId: "app-1",
+      organizationId: "org-1",
+      userId: "u-1",
+    });
+    expect(r.id).toBe("job-1");
+    expect(inserted[0]).toEqual({
+      type: "app_deploy",
+      organizationId: "org-1",
+      userId: "u-1",
+      data: { appId: "app-1" },
+    });
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/app-deploy-orchestrator.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-deploy-orchestrator.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
   type AppDeployDeps,
-  deployApp,
   type DeployAppRequest,
+  deployApp,
   type NewAppContainerRow,
 } from "../app-deploy-orchestrator";
 

--- a/packages/cloud-shared/src/lib/services/__tests__/app-deploy-orchestrator.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-deploy-orchestrator.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type AppDeployDeps,
+  deployApp,
+  type DeployAppRequest,
+  type NewAppContainerRow,
+} from "../app-deploy-orchestrator";
+
+const REQ: DeployAppRequest = {
+  appId: "11111111-2222-3333-4444-555555555555",
+  organizationId: "org-1",
+  userId: "user-1",
+  containerName: "app-nubilio",
+  image: "ghcr.io/nubs/nubilio:latest",
+};
+
+const TENANT_DSN = "postgresql://app_x:pw@apps-cluster-1/db_app_x?sslmode=require";
+
+function deps(over: Partial<AppDeployDeps> = {}) {
+  const seen: {
+    row?: NewAppContainerRow;
+    enqueued?: { containerId: string };
+    linked?: { appId: string; containerId: string };
+  } = {};
+  const base: AppDeployDeps = {
+    async ensureTenantDb() {
+      return TENANT_DSN;
+    },
+    async createContainerRow(row) {
+      seen.row = row;
+      return { containerId: "container-1" };
+    },
+    async enqueueProvision(p) {
+      seen.enqueued = { containerId: p.containerId };
+      return { id: "job-1" };
+    },
+    async linkContainerToApp(appId, containerId) {
+      seen.linked = { appId, containerId };
+    },
+  };
+  return { seen, deps: { ...base, ...over } };
+}
+
+describe("deployApp", () => {
+  test("provisions an isolated DB, creates the row with that DSN, enqueues, links", async () => {
+    const { seen, deps: d } = deps();
+    const result = await deployApp(REQ, d);
+
+    expect(result).toEqual({ containerId: "container-1", jobId: "job-1" });
+    // the container row carries the app's OWN per-tenant DSN
+    expect(seen.row?.environmentVars.DATABASE_URL).toBe(TENANT_DSN);
+    expect(seen.row?.image).toBe(REQ.image);
+    expect(seen.row?.port).toBe(3000);
+    // provision was enqueued for the created container
+    expect(seen.enqueued?.containerId).toBe("container-1");
+    // container linked back to the app
+    expect(seen.linked).toEqual({ appId: REQ.appId, containerId: "container-1" });
+  });
+
+  test("the injected DSN is the per-tenant one, never a shared agent URL", async () => {
+    const { seen, deps: d } = deps({
+      async ensureTenantDb() {
+        return TENANT_DSN;
+      },
+    });
+    await deployApp(REQ, d);
+    expect(seen.row?.environmentVars.DATABASE_URL).not.toContain("agentdb");
+    expect(seen.row?.environmentVars.DATABASE_URL).toContain("db_app_x");
+  });
+
+  test("honors a custom container port", async () => {
+    const { seen, deps: d } = deps();
+    await deployApp({ ...REQ, port: 8080 }, d);
+    expect(seen.row?.port).toBe(8080);
+  });
+
+  test("surfaces a DB-provisioning failure before creating any container", async () => {
+    let created = false;
+    const { deps: d } = deps({
+      async ensureTenantDb() {
+        throw new Error("No tenant DB cluster has capacity");
+      },
+      async createContainerRow(row) {
+        created = true;
+        return { containerId: "x" };
+      },
+    });
+    await expect(deployApp(REQ, d)).rejects.toThrow("capacity");
+    expect(created).toBe(false);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/app-docker-cmd.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-docker-cmd.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { buildAppDockerCreateCmd } from "../app-docker-cmd";
+import type { CreateContainerInput } from "../containers/hetzner-client/types";
+
+const APP_ID = "11111111-2222-3333-4444-555555555555";
+
+function input(over: Partial<CreateContainerInput> = {}): CreateContainerInput {
+  return {
+    name: "nubilio-web",
+    projectName: "nubilio",
+    organizationId: "org-1",
+    userId: "user-1",
+    image: "ghcr.io/nubs/nubilio:latest",
+    port: 3000,
+    desiredCount: 1,
+    cpu: 1,
+    memoryMb: 512,
+    healthCheckPath: "/health",
+    ...over,
+  };
+}
+
+function build(over: Partial<CreateContainerInput> = {}, egress?: string) {
+  return buildAppDockerCreateCmd({
+    appId: APP_ID,
+    containerName: "app-nubilio",
+    input: input(over),
+    hostPort: 49001,
+    egressProxyUrl: egress,
+  });
+}
+
+describe("buildAppDockerCreateCmd", () => {
+  test("puts the container on its own --internal app network", () => {
+    const cmd = build();
+    expect(cmd).toMatch(/--network 'app-net-[a-z0-9]+'/);
+    expect(cmd).not.toContain("containers-isolated");
+  });
+
+  test("hardens the container and NEVER uses the agent escapes", () => {
+    const cmd = build();
+    expect(cmd).toContain("--cap-drop=ALL");
+    expect(cmd).toContain("no-new-privileges");
+    expect(cmd).toContain("--pids-limit=512");
+    expect(cmd).not.toContain("NET_ADMIN");
+    expect(cmd).not.toContain("/dev/net/tun");
+    expect(cmd).not.toContain("--privileged");
+    expect(cmd).not.toContain("host.docker.internal");
+    // no eliza scaffolding mounts
+    expect(cmd).not.toContain("/root/.eliza");
+  });
+
+  test("maps the host port, sets memory, and runs the requested image", () => {
+    const cmd = build();
+    expect(cmd).toContain("-p 49001:3000");
+    expect(cmd).toContain("--memory '512m'");
+    expect(cmd).toContain("'ghcr.io/nubs/nubilio:latest'");
+  });
+
+  test("never auto-injects DATABASE_URL, but forwards a caller-supplied one", () => {
+    expect(build()).not.toContain("DATABASE_URL");
+    const dsn = "postgresql://app_x:pw@apps-cluster-1/db_app_x?sslmode=require";
+    const withDb = build({ environmentVars: { DATABASE_URL: dsn } });
+    expect(withDb).toContain(`-e ${"'"}DATABASE_URL=${dsn}${"'"}`);
+  });
+
+  test("routes egress through the proxy when one is given", () => {
+    const cmd = build({}, "http://egress-gw:3128");
+    expect(cmd).toContain("HTTP_PROXY=http://egress-gw:3128");
+    expect(cmd).toContain("HTTPS_PROXY=http://egress-gw:3128");
+  });
+
+  test("honors a custom container port and health path", () => {
+    const cmd = build({ port: 8080, healthCheckPath: "/healthz" });
+    expect(cmd).toContain("-p 49001:8080");
+    expect(cmd).toContain("localhost:8080/healthz");
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/app-firewall-utils.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-firewall-utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildAppNodeNftablesRules,
+  buildHetznerAppFirewallRules,
+  CLOUD_METADATA_IP,
+  RFC1918_RANGES,
+} from "../app-firewall-utils";
+
+describe("buildAppNodeNftablesRules", () => {
+  const rules = buildAppNodeNftablesRules({ egressProxyIp: "10.200.0.5" });
+
+  test("default-drops the forward chain", () => {
+    expect(rules).toContain("policy drop;");
+  });
+
+  test("blocks the cloud metadata endpoint and every RFC1918 range", () => {
+    expect(rules).toContain(`ip daddr ${CLOUD_METADATA_IP} drop`);
+    for (const range of RFC1918_RANGES) {
+      expect(rules).toContain(`ip daddr ${range} drop`);
+    }
+  });
+
+  test("allows established return traffic and the egress proxy", () => {
+    expect(rules).toContain("ct state established,related accept");
+    expect(rules).toContain("ip daddr 10.200.0.5 accept");
+  });
+
+  test("omits the proxy allow when no proxy ip is given", () => {
+    expect(buildAppNodeNftablesRules()).not.toContain("accept\n    }");
+  });
+});
+
+describe("buildHetznerAppFirewallRules", () => {
+  test("allows inbound to the host-port range only from control-plane CIDRs", () => {
+    const rules = buildHetznerAppFirewallRules({
+      controlPlaneCidrs: ["10.0.0.1/32"],
+      hostPortRange: "49000-49999",
+    });
+    expect(rules).toHaveLength(1);
+    expect(rules[0]).toMatchObject({
+      direction: "in",
+      protocol: "tcp",
+      port: "49000-49999",
+      source_ips: ["10.0.0.1/32"],
+    });
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/app-image-builder.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-image-builder.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { AppImageBuilder, type BuildExec } from "../app-image-builder";
+
+const APP = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+function fakeExec(): BuildExec & { calls: Array<{ cmd: string; timeoutMs?: number }> } {
+  const calls: Array<{ cmd: string; timeoutMs?: number }> = [];
+  return {
+    calls,
+    async exec(cmd: string, timeoutMs?: number) {
+      calls.push({ cmd, timeoutMs });
+      return "Successfully built abc123";
+    },
+  };
+}
+
+describe("AppImageBuilder", () => {
+  test("resolves the ref and execs the composed build command", async () => {
+    const exec = fakeExec();
+    const builder = new AppImageBuilder({ exec });
+    const res = await builder.build({
+      registry: "ghcr.io/elizaos",
+      appId: APP,
+      sourceRef: "a1b2c3d",
+      context: "/work/repo",
+      dockerfile: "Dockerfile",
+    });
+
+    expect(res.imageRef).toBe("ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:a1b2c3d");
+    expect(res.buildOutput).toContain("Successfully built");
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0].cmd).toBe(
+      "docker build --tag 'ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:a1b2c3d' --file 'Dockerfile' '/work/repo'",
+    );
+  });
+
+  test("push routes through buildx --push", async () => {
+    const exec = fakeExec();
+    await new AppImageBuilder({ exec }).build({
+      registry: "ghcr.io/elizaos",
+      appId: APP,
+      context: "https://github.com/u/repo.git#main",
+      push: true,
+    });
+    expect(exec.calls[0].cmd.startsWith("docker buildx build")).toBe(true);
+    expect(exec.calls[0].cmd).toContain("--push");
+  });
+
+  test("propagates a build failure", async () => {
+    const exec: BuildExec = {
+      async exec() {
+        throw new Error("exit 1: dockerfile parse error");
+      },
+    };
+    await expect(
+      new AppImageBuilder({ exec }).build({ registry: "r", appId: APP, context: "/c" }),
+    ).rejects.toThrow(/parse error/);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/app-image-ref.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-image-ref.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { appImageSlug, buildAppImageRef, deriveImageTag } from "../app-image-ref";
+
+const APP = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+describe("appImageSlug", () => {
+  test("strips to [a-z0-9], lowercases, caps at 24", () => {
+    expect(appImageSlug(APP)).toBe("aaaaaaaaaaaa4aaa8aaaaaaa");
+    expect(appImageSlug("ABC-123-def-456-ghi")).toBe("abc123def456ghi");
+  });
+
+  test("throws on a too-short slug", () => {
+    expect(() => appImageSlug("a-b-c")).toThrow(/too short/);
+  });
+});
+
+describe("deriveImageTag", () => {
+  test("absent/empty ref → latest", () => {
+    expect(deriveImageTag()).toBe("latest");
+    expect(deriveImageTag("")).toBe("latest");
+  });
+
+  test("passes through a clean git sha", () => {
+    expect(deriveImageTag("a1b2c3d")).toBe("a1b2c3d");
+  });
+
+  test("collapses unsafe chars and strips a leading dot/dash", () => {
+    expect(deriveImageTag("feature/cool branch")).toBe("feature-cool-branch");
+    expect(deriveImageTag("-.weird")).toBe("weird");
+  });
+
+  test("caps at 128 chars", () => {
+    expect(deriveImageTag("x".repeat(200)).length).toBe(128);
+  });
+});
+
+describe("buildAppImageRef", () => {
+  test("composes <registry>/app-<slug>:<tag>", () => {
+    expect(
+      buildAppImageRef({ registry: "ghcr.io/elizaos", appId: APP, sourceRef: "a1b2c3d" }),
+    ).toBe("ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:a1b2c3d");
+  });
+
+  test("defaults tag to latest and trims trailing slashes on the registry", () => {
+    expect(buildAppImageRef({ registry: "registry.local:5000/apps/", appId: APP })).toBe(
+      "registry.local:5000/apps/app-aaaaaaaaaaaa4aaa8aaaaaaa:latest",
+    );
+  });
+
+  test("rejects an invalid registry", () => {
+    expect(() => buildAppImageRef({ registry: "bad registry!", appId: APP })).toThrow(
+      /invalid registry/,
+    );
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/app-image-resolver.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-image-resolver.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { AppImageBuilder, type BuildExec } from "../app-image-builder";
+import { makeBuildFromRepoResolver } from "../app-image-resolver";
+
+const APP = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+function recordingBuilder(): { builder: AppImageBuilder; cmds: string[] } {
+  const cmds: string[] = [];
+  const exec: BuildExec = {
+    async exec(cmd) {
+      cmds.push(cmd);
+      return "built";
+    },
+  };
+  return { builder: new AppImageBuilder({ exec }), cmds };
+}
+
+describe("makeBuildFromRepoResolver", () => {
+  test("builds + pushes from app.github_repo and returns the ref", async () => {
+    const { builder, cmds } = recordingBuilder();
+    const resolve = makeBuildFromRepoResolver({ builder, registry: "ghcr.io/elizaos" });
+    const ref = await resolve({
+      id: APP,
+      name: "demo",
+      metadata: { ref: "a1b2c3d" },
+      repoUrl: "https://github.com/u/repo.git",
+    });
+
+    expect(ref).toBe("ghcr.io/elizaos/app-aaaaaaaaaaaa4aaa8aaaaaaa:a1b2c3d");
+    expect(cmds[0]).toContain("docker buildx build");
+    expect(cmds[0]).toContain("--push");
+    expect(cmds[0]).toContain("'https://github.com/u/repo.git'");
+  });
+
+  test("falls back to metadata.repoUrl when github_repo is absent", async () => {
+    const { builder, cmds } = recordingBuilder();
+    const resolve = makeBuildFromRepoResolver({ builder, registry: "r" });
+    const ref = await resolve({ id: APP, name: "demo", metadata: { repoUrl: "/local/ctx" } });
+    expect(ref).toBe("r/app-aaaaaaaaaaaa4aaa8aaaaaaa:latest");
+    expect(cmds[0]).toContain("'/local/ctx'");
+  });
+
+  test("returns undefined (no error) when the app has no repo", async () => {
+    const { builder, cmds } = recordingBuilder();
+    const resolve = makeBuildFromRepoResolver({ builder, registry: "r" });
+    expect(await resolve({ id: APP, name: "demo", metadata: {} })).toBeUndefined();
+    expect(cmds).toHaveLength(0);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/app-network-utils.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-network-utils.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import {
+  appNetworkName,
+  buildAppContainerSecurityFlags,
+  buildAppEgressEnv,
+  buildEnsureAppNetworkCmd,
+  buildSquidAllowlistConf,
+} from "../app-network-utils";
+
+const APP_ID = "11111111-2222-3333-4444-555555555555";
+
+describe("appNetworkName", () => {
+  test("derives a stable per-app network name", () => {
+    const n = appNetworkName(APP_ID);
+    expect(n).toBe(appNetworkName(APP_ID));
+    expect(n).toMatch(/^app-net-[a-z0-9]+$/);
+    // never the shared agent network
+    expect(n).not.toBe("containers-isolated");
+  });
+});
+
+describe("buildEnsureAppNetworkCmd — isolation is real (--internal)", () => {
+  const cmd = buildEnsureAppNetworkCmd("app-net-x");
+
+  test("creates an --internal bridge (the load-bearing flag)", () => {
+    expect(cmd).toContain("--driver bridge --internal");
+    expect(cmd).toContain("app-net-x");
+  });
+
+  test("never references the shared agent network name", () => {
+    expect(cmd).not.toContain("containers-isolated");
+  });
+});
+
+describe("buildAppContainerSecurityFlags — untrusted-image hardening", () => {
+  const flags = buildAppContainerSecurityFlags();
+  const joined = flags.join(" ");
+
+  test("drops all caps, forbids privilege escalation, bounds pids", () => {
+    expect(joined).toContain("--cap-drop=ALL");
+    expect(joined).toContain("no-new-privileges");
+    expect(joined).toContain("--pids-limit=512");
+  });
+
+  test("NEVER grants the agent-only network escapes", () => {
+    expect(joined).not.toContain("NET_ADMIN");
+    expect(joined).not.toContain("/dev/net/tun");
+    expect(joined).not.toContain("--privileged");
+    expect(joined).not.toContain("host.docker.internal");
+    expect(joined).not.toContain("cap-add");
+  });
+
+  test("honors a custom pids limit", () => {
+    expect(buildAppContainerSecurityFlags({ pidsLimit: 128 }).join(" ")).toContain(
+      "--pids-limit=128",
+    );
+  });
+});
+
+describe("buildAppEgressEnv", () => {
+  test("routes all HTTP(S) egress through the proxy, bypassing localhost", () => {
+    const env = buildAppEgressEnv("http://egress-gw:3128");
+    expect(env.HTTP_PROXY).toBe("http://egress-gw:3128");
+    expect(env.HTTPS_PROXY).toBe("http://egress-gw:3128");
+    expect(env.http_proxy).toBe("http://egress-gw:3128");
+    expect(env.NO_PROXY).toContain("127.0.0.1");
+  });
+});
+
+describe("buildSquidAllowlistConf — default deny", () => {
+  test("allows only listed hosts and denies everything else", () => {
+    const conf = buildSquidAllowlistConf(["api.stripe.com", "*.elizacloud.ai"]);
+    expect(conf).toContain("acl allowed_dst dstdomain api.stripe.com");
+    expect(conf).toContain("acl allowed_dst dstdomain *.elizacloud.ai");
+    expect(conf).toContain("http_access allow allowed_dst");
+    expect(conf).toContain("http_access deny all");
+  });
+
+  test("an empty allowlist denies everything (no allow line)", () => {
+    const conf = buildSquidAllowlistConf([]);
+    expect(conf).toContain("http_access deny all");
+    expect(conf).not.toContain("http_access allow");
+  });
+
+  test("ignores malformed/injection-y host entries", () => {
+    const conf = buildSquidAllowlistConf(["evil.com\nhttp_access allow all"]);
+    expect(conf).not.toContain("http_access allow all");
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/app-url.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-url.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { deriveAppPublicUrl } from "../app-url";
+
+const BASE = "CONTAINERS_PUBLIC_BASE_DOMAIN";
+const FALLBACK = "ELIZA_CLOUD_AGENT_BASE_DOMAIN";
+const prevBase = process.env[BASE];
+const prevFallback = process.env[FALLBACK];
+
+function restore(key: string, prev: string | undefined) {
+  if (prev === undefined) delete process.env[key];
+  else process.env[key] = prev;
+}
+
+afterEach(() => {
+  restore(BASE, prevBase);
+  restore(FALLBACK, prevFallback);
+});
+
+const CID = "aabbccdd-1111-4222-8333-444455556666";
+
+describe("deriveAppPublicUrl", () => {
+  test("derives <shortid>.<base> hostname + https url when a base domain is set", () => {
+    process.env[BASE] = "containers.elizacloud.ai";
+    expect(deriveAppPublicUrl(CID)).toEqual({
+      hostname: "aabbccdd.containers.elizacloud.ai",
+      url: "https://aabbccdd.containers.elizacloud.ai",
+    });
+  });
+
+  test("returns null when no public base domain is configured (e.g. local dev)", () => {
+    delete process.env[BASE];
+    delete process.env[FALLBACK];
+    expect(deriveAppPublicUrl(CID)).toBeNull();
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/container-job-executors.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/container-job-executors.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import type { AppContainerProvider, ProvisionedAppContainer } from "../app-container-provider";
+import {
+  type AppContainerRow,
+  type AppContainerStore,
+  executeContainerDelete,
+  executeContainerLogs,
+  executeContainerProvision,
+  executeContainerRestart,
+} from "../container-job-executors";
+
+const ROW: AppContainerRow = {
+  id: "container-1",
+  appId: "11111111-2222-3333-4444-555555555555",
+  containerName: "app-nubilio",
+  image: "ghcr.io/nubs/nubilio:latest",
+  port: 3000,
+  organizationId: "org-1",
+  userId: "user-1",
+  environmentVars: { DATABASE_URL: "postgresql://app_x:pw@cluster1/db_app_x" },
+};
+
+function fakeStore(row: AppContainerRow | null = ROW) {
+  const events: Array<{ op: string; id: string; info?: unknown }> = [];
+  const store: AppContainerStore = {
+    async getById() {
+      return row;
+    },
+    async markRunning(id, info) {
+      events.push({ op: "running", id, info });
+    },
+    async markDeleted(id) {
+      events.push({ op: "deleted", id });
+    },
+    async markError(id, error) {
+      events.push({ op: "error", id, info: error });
+    },
+  };
+  return { events, store };
+}
+
+function fakeProvider(over: Partial<Record<keyof AppContainerProvider, unknown>> = {}) {
+  const calls: Array<{ op: string; arg: unknown }> = [];
+  const provider = {
+    async provision(params: unknown): Promise<ProvisionedAppContainer> {
+      calls.push({ op: "provision", arg: params });
+      return { containerId: "docker-abc", hostPort: 49001, network: "app-net-x" };
+    },
+    async delete(name: string) {
+      calls.push({ op: "delete", arg: name });
+    },
+    async restart(name: string) {
+      calls.push({ op: "restart", arg: name });
+    },
+    async logs(name: string, tail?: number) {
+      calls.push({ op: "logs", arg: { name, tail } });
+      return "log output";
+    },
+    ...over,
+  } as unknown as AppContainerProvider;
+  return { calls, provider };
+}
+
+const job = (data: unknown) => ({ id: "job-1", data });
+
+describe("executeContainerProvision", () => {
+  test("builds input from the row, provisions, and marks running", async () => {
+    const { events, store } = fakeStore();
+    const { calls, provider } = fakeProvider();
+    await executeContainerProvision(
+      job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+      {
+        provider,
+        store,
+      },
+    );
+
+    const provisionCall = calls.find((c) => c.op === "provision");
+    expect(provisionCall).toBeDefined();
+    // input carries the row's image + the per-tenant DSN, NOT a shared one
+    const arg = provisionCall?.arg as {
+      input: { image: string; environmentVars?: Record<string, string> };
+    };
+    expect(arg.input.image).toBe(ROW.image);
+    expect(arg.input.environmentVars?.DATABASE_URL).toContain("db_app_x");
+
+    expect(events).toEqual([
+      {
+        op: "running",
+        id: "container-1",
+        info: { hostContainerId: "docker-abc", hostPort: 49001, network: "app-net-x" },
+      },
+    ]);
+  });
+
+  test("marks error and rethrows when provisioning fails", async () => {
+    const { events, store } = fakeStore();
+    const { provider } = fakeProvider({
+      async provision() {
+        throw new Error("docker create failed");
+      },
+    } as never);
+    await expect(
+      executeContainerProvision(
+        job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+        {
+          provider,
+          store,
+        },
+      ),
+    ).rejects.toThrow("docker create failed");
+    expect(events[0]).toMatchObject({ op: "error", id: "container-1" });
+  });
+
+  test("throws when the container row is missing", async () => {
+    const { store } = fakeStore(null);
+    const { provider } = fakeProvider();
+    await expect(
+      executeContainerProvision(job({ containerId: "gone", organizationId: "o", userId: "u" }), {
+        provider,
+        store,
+      }),
+    ).rejects.toThrow("not found");
+  });
+});
+
+describe("executeContainerDelete / restart / logs", () => {
+  test("delete removes the container then marks it deleted", async () => {
+    const { events, store } = fakeStore();
+    const { calls, provider } = fakeProvider();
+    await executeContainerDelete(job({ containerId: "container-1", organizationId: "org-1" }), {
+      provider,
+      store,
+    });
+    expect(calls.find((c) => c.op === "delete")?.arg).toBe("app-nubilio");
+    expect(events).toEqual([{ op: "deleted", id: "container-1" }]);
+  });
+
+  test("restart restarts by container name", async () => {
+    const { store } = fakeStore();
+    const { calls, provider } = fakeProvider();
+    await executeContainerRestart(job({ containerId: "container-1", organizationId: "org-1" }), {
+      provider,
+      store,
+    });
+    expect(calls.find((c) => c.op === "restart")?.arg).toBe("app-nubilio");
+  });
+
+  test("logs returns the provider output for the requested tail", async () => {
+    const { store } = fakeStore();
+    const { calls, provider } = fakeProvider();
+    const out = await executeContainerLogs(
+      job({ containerId: "container-1", organizationId: "org-1", tail: 50 }),
+      { provider, store },
+    );
+    expect(out).toBe("log output");
+    expect(calls.find((c) => c.op === "logs")?.arg).toEqual({ name: "app-nubilio", tail: 50 });
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/container-job-service.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/container-job-service.test.ts
@@ -6,8 +6,8 @@ import type {
   ContainerExecutorDeps,
 } from "../container-job-executors";
 import {
-  type ContainerJobInsert,
   ContainerJobEnqueuer,
+  type ContainerJobInsert,
   type ContainerJobsWriter,
   dispatchContainerJob,
   getContainerExecutorDeps,

--- a/packages/cloud-shared/src/lib/services/__tests__/container-job-service.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/container-job-service.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import type { AppContainerProvider } from "../app-container-provider";
+import type {
+  AppContainerRow,
+  AppContainerStore,
+  ContainerExecutorDeps,
+} from "../container-job-executors";
+import {
+  type ContainerJobInsert,
+  ContainerJobEnqueuer,
+  type ContainerJobsWriter,
+  dispatchContainerJob,
+  getContainerExecutorDeps,
+  isContainerJobType,
+  setContainerExecutorDeps,
+} from "../container-job-service";
+import { JOB_TYPES } from "../provisioning-job-types";
+
+const ROW: AppContainerRow = {
+  id: "container-1",
+  appId: "11111111-2222-3333-4444-555555555555",
+  containerName: "app-nubilio",
+  image: "ghcr.io/nubs/nubilio:latest",
+  port: 3000,
+  organizationId: "org-1",
+  userId: "user-1",
+};
+
+function fakeDeps() {
+  const calls: string[] = [];
+  const store: AppContainerStore = {
+    async getById() {
+      return ROW;
+    },
+    async markRunning() {},
+    async markDeleted() {
+      calls.push("markDeleted");
+    },
+    async markError() {},
+  };
+  const provider = {
+    async provision() {
+      calls.push("provision");
+      return { containerId: "c", hostPort: 1, network: "n" };
+    },
+    async delete() {
+      calls.push("delete");
+    },
+    async restart() {
+      calls.push("restart");
+    },
+    async logs() {
+      calls.push("logs");
+      return "out";
+    },
+  } as unknown as AppContainerProvider;
+  return { calls, deps: { provider, store } satisfies ContainerExecutorDeps };
+}
+
+describe("isContainerJobType", () => {
+  test("recognizes only the CONTAINER_* types", () => {
+    expect(isContainerJobType(JOB_TYPES.CONTAINER_PROVISION)).toBe(true);
+    expect(isContainerJobType(JOB_TYPES.CONTAINER_LOGS)).toBe(true);
+    expect(isContainerJobType(JOB_TYPES.AGENT_PROVISION)).toBe(false);
+    expect(isContainerJobType("nonsense")).toBe(false);
+  });
+});
+
+describe("dispatchContainerJob", () => {
+  const cases: Array<[string, string]> = [
+    [JOB_TYPES.CONTAINER_PROVISION, "provision"],
+    [JOB_TYPES.CONTAINER_DELETE, "delete"],
+    [JOB_TYPES.CONTAINER_RESTART, "restart"],
+    [JOB_TYPES.CONTAINER_UPGRADE, "provision"],
+    [JOB_TYPES.CONTAINER_LOGS, "logs"],
+  ];
+  for (const [type, expected] of cases) {
+    test(`routes ${type} to ${expected}`, async () => {
+      const { calls, deps } = fakeDeps();
+      await dispatchContainerJob(
+        {
+          id: "j",
+          type,
+          data: { containerId: "container-1", organizationId: "org-1", userId: "user-1" },
+        },
+        deps,
+      );
+      expect(calls).toContain(expected);
+    });
+  }
+
+  test("throws on a non-container job type", async () => {
+    const { deps } = fakeDeps();
+    await expect(
+      dispatchContainerJob({ id: "j", type: JOB_TYPES.AGENT_PROVISION, data: {} }, deps),
+    ).rejects.toThrow("Not a container job type");
+  });
+});
+
+describe("getContainerExecutorDeps / setContainerExecutorDeps", () => {
+  test("throws until the backend is wired, then returns it", () => {
+    expect(() => getContainerExecutorDeps()).toThrow("not configured");
+    const { deps } = fakeDeps();
+    setContainerExecutorDeps(() => deps);
+    expect(getContainerExecutorDeps()).toBe(deps);
+  });
+});
+
+describe("ContainerJobEnqueuer", () => {
+  function fakeWriter() {
+    const inserts: ContainerJobInsert[] = [];
+    const writer: ContainerJobsWriter = {
+      async insertJob(job) {
+        inserts.push(job);
+        return { id: `job-${inserts.length}` };
+      },
+    };
+    return { inserts, writer };
+  }
+
+  test("enqueues each lifecycle verb with the right type + data", async () => {
+    const { inserts, writer } = fakeWriter();
+    const e = new ContainerJobEnqueuer(writer);
+    await e.enqueueProvision({ containerId: "c1", organizationId: "o1", userId: "u1" });
+    await e.enqueueDelete({ containerId: "c1", organizationId: "o1" });
+    await e.enqueueUpgrade({ containerId: "c1", organizationId: "o1", image: "ghcr.io/x:2" });
+
+    expect(inserts.map((i) => i.type)).toEqual([
+      JOB_TYPES.CONTAINER_PROVISION,
+      JOB_TYPES.CONTAINER_DELETE,
+      JOB_TYPES.CONTAINER_UPGRADE,
+    ]);
+    expect(inserts[0].data).toMatchObject({ containerId: "c1", userId: "u1" });
+    expect(inserts[2].data).toMatchObject({ image: "ghcr.io/x:2" });
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/container-job-types.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/container-job-types.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Wire-value coverage for the CONTAINER_* (Apps / Product 2) job lane. Same
+ * rationale as the AGENT_* smoke tests in provisioning-job-types.test.ts: the
+ * DB stores the string, not the symbol, so a typo silently mis-routes a job.
+ */
+import { describe, expect, test } from "bun:test";
+import { JOB_TYPES } from "../provisioning-job-types";
+
+const CONTAINER_TYPES = {
+  CONTAINER_PROVISION: "container_provision",
+  CONTAINER_DELETE: "container_delete",
+  CONTAINER_RESTART: "container_restart",
+  CONTAINER_UPGRADE: "container_upgrade",
+  CONTAINER_LOGS: "container_logs",
+} as const;
+
+describe("JOB_TYPES — CONTAINER_* lane", () => {
+  test("registers every container job type with its wire value", () => {
+    for (const [key, wire] of Object.entries(CONTAINER_TYPES)) {
+      expect(JOB_TYPES[key as keyof typeof JOB_TYPES]).toBe(wire);
+    }
+  });
+
+  test("container wire values are unique and don't collide with agent values", () => {
+    const all = Object.values(JOB_TYPES);
+    expect(new Set(all).size).toBe(all.length);
+    for (const wire of Object.values(CONTAINER_TYPES)) {
+      expect(all.filter((v) => v === wire)).toHaveLength(1);
+    }
+  });
+
+  test("container wire values are snake_case and container-namespaced", () => {
+    for (const wire of Object.values(CONTAINER_TYPES)) {
+      expect(wire).toMatch(/^container_[a-z]+$/);
+    }
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/container-jobs-data.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/container-jobs-data.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import {
+  containerLogsJobDataToRecord,
+  containerProvisionJobDataToRecord,
+  containerUpgradeJobDataToRecord,
+  isContainerLogsJobData,
+  isContainerProvisionJobData,
+  isContainerUpgradeJobData,
+  type JobLike,
+  readContainerDeleteJobData,
+  readContainerLogsJobData,
+  readContainerProvisionJobData,
+  readContainerRestartJobData,
+  readContainerUpgradeJobData,
+} from "../container-jobs-data";
+
+const job = (data: unknown): JobLike => ({ id: "job-1", data });
+
+describe("container-jobs-data codecs", () => {
+  test("provision round-trips through toRecord -> read", () => {
+    const data = { containerId: "c1", organizationId: "o1", userId: "u1" };
+    const record = containerProvisionJobDataToRecord(data);
+    expect(readContainerProvisionJobData(job(record))).toEqual(data);
+  });
+
+  test("delete + restart accept the minimal {containerId, organizationId}", () => {
+    const data = { containerId: "c1", organizationId: "o1" };
+    expect(readContainerDeleteJobData(job(data))).toEqual(data);
+    expect(readContainerRestartJobData(job(data))).toEqual(data);
+  });
+
+  test("upgrade keeps an optional image, logs keeps an optional tail", () => {
+    const up = { containerId: "c1", organizationId: "o1", image: "ghcr.io/x:2" };
+    expect(readContainerUpgradeJobData(job(containerUpgradeJobDataToRecord(up)))).toEqual(up);
+    const noImg = { containerId: "c1", organizationId: "o1" };
+    expect(readContainerUpgradeJobData(job(noImg))).toEqual(noImg);
+
+    const logs = { containerId: "c1", organizationId: "o1", tail: 200 };
+    expect(readContainerLogsJobData(job(containerLogsJobDataToRecord(logs)))).toEqual(logs);
+  });
+
+  test("guards reject malformed data", () => {
+    expect(isContainerProvisionJobData({ containerId: "c1", organizationId: "o1" })).toBe(false); // missing userId
+    expect(isContainerProvisionJobData(null)).toBe(false);
+    expect(isContainerUpgradeJobData({ containerId: "c1", organizationId: "o1", image: 5 })).toBe(
+      false,
+    );
+    expect(isContainerLogsJobData({ containerId: "c1", organizationId: "o1", tail: "200" })).toBe(
+      false,
+    );
+  });
+
+  test("read* throws (with the job id) on invalid data", () => {
+    expect(() => readContainerProvisionJobData(job({ containerId: "c1" }))).toThrow("job-1");
+    expect(() => readContainerLogsJobData(job("nope"))).toThrow();
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/container-provider-input.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/container-provider-input.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  APP_CONTAINER_DEFAULTS,
+  buildContainerProvisionInput,
+  type ContainerProvisionParams,
+} from "../container-provider-input";
+
+const base: ContainerProvisionParams = {
+  name: "nubilio-web",
+  projectName: "nubilio",
+  organizationId: "org-1",
+  userId: "user-1",
+  image: "ghcr.io/nubs/nubilio:latest",
+};
+
+describe("buildContainerProvisionInput", () => {
+  test("applies defaults for unset fields", () => {
+    const input = buildContainerProvisionInput(base);
+    expect(input.port).toBe(APP_CONTAINER_DEFAULTS.port);
+    expect(input.desiredCount).toBe(APP_CONTAINER_DEFAULTS.desiredCount);
+    expect(input.cpu).toBe(APP_CONTAINER_DEFAULTS.cpu);
+    expect(input.memoryMb).toBe(APP_CONTAINER_DEFAULTS.memoryMb);
+    expect(input.healthCheckPath).toBe(APP_CONTAINER_DEFAULTS.healthCheckPath);
+    expect(input.apiKeyId).toBeNull();
+  });
+
+  test("overrides win over defaults and carry the core fields through", () => {
+    const input = buildContainerProvisionInput({
+      ...base,
+      port: 8080,
+      cpu: 2,
+      memoryMb: 1024,
+      healthCheckPath: "/healthz",
+      description: "nubilio app",
+    });
+    expect(input.port).toBe(8080);
+    expect(input.cpu).toBe(2);
+    expect(input.memoryMb).toBe(1024);
+    expect(input.healthCheckPath).toBe("/healthz");
+    expect(input.image).toBe(base.image);
+    expect(input.name).toBe(base.name);
+    expect(input.organizationId).toBe(base.organizationId);
+    expect(input.description).toBe("nubilio app");
+  });
+
+  // The load-bearing invariant: the apps builder NEVER injects DATABASE_URL
+  // (the inverse of the agent path's shared-DB force-overwrite).
+  test("never auto-injects DATABASE_URL", () => {
+    const input = buildContainerProvisionInput({
+      ...base,
+      environmentVars: { NODE_ENV: "production", PORT: "3000" },
+    });
+    expect(input.environmentVars?.DATABASE_URL).toBeUndefined();
+    expect(input.environmentVars).toEqual({ NODE_ENV: "production", PORT: "3000" });
+  });
+
+  test("with no env at all, no DATABASE_URL appears", () => {
+    const input = buildContainerProvisionInput(base);
+    expect(input.environmentVars?.DATABASE_URL).toBeUndefined();
+  });
+
+  test("forwards a caller-supplied (per-tenant) DATABASE_URL verbatim", () => {
+    // The isolated per-tenant DSN is the caller's responsibility (a later unit);
+    // the builder passes it through untouched, never sourcing it from the env.
+    const dsn = "postgresql://app_x:pw@cluster1/db_app_x?sslmode=require";
+    const input = buildContainerProvisionInput({
+      ...base,
+      environmentVars: { DATABASE_URL: dsn },
+    });
+    expect(input.environmentVars?.DATABASE_URL).toBe(dsn);
+  });
+
+  test("does not let callers mutate the output env by reference", () => {
+    const env = { FOO: "bar" };
+    const input = buildContainerProvisionInput({ ...base, environmentVars: env });
+    env.FOO = "mutated";
+    expect(input.environmentVars?.FOO).toBe("bar");
+  });
+
+  test("throws on missing required fields", () => {
+    expect(() => buildContainerProvisionInput({ ...base, name: "" })).toThrow();
+    expect(() => buildContainerProvisionInput({ ...base, image: "" })).toThrow();
+    expect(() => buildContainerProvisionInput({ ...base, organizationId: "" })).toThrow();
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/provisioning-job-types.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/provisioning-job-types.test.ts
@@ -26,9 +26,11 @@ describe("JOB_TYPES", () => {
     expect(JOB_TYPES.AGENT_UPGRADE).toBe("agent_upgrade");
     expect(JOB_TYPES.AGENT_SLEEP).toBe("agent_sleep");
     expect(JOB_TYPES.AGENT_WAKE).toBe("agent_wake");
+    // Apps lane (Product 2): the Worker enqueues APP_DEPLOY; the daemon runs it.
+    expect(JOB_TYPES.APP_DEPLOY).toBe("app_deploy");
     // Lock the size so a new entry without a matching assertion above
     // fails CI instead of being silently under-covered by tests below.
-    expect(Object.keys(JOB_TYPES)).toHaveLength(16);
+    expect(Object.keys(JOB_TYPES)).toHaveLength(17);
   });
 
   test("wire values are unique (no two symbols share a string)", () => {

--- a/packages/cloud-shared/src/lib/services/__tests__/provisioning-job-types.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/provisioning-job-types.test.ts
@@ -28,7 +28,7 @@ describe("JOB_TYPES", () => {
     expect(JOB_TYPES.AGENT_WAKE).toBe("agent_wake");
     // Lock the size so a new entry without a matching assertion above
     // fails CI instead of being silently under-covered by tests below.
-    expect(Object.keys(JOB_TYPES)).toHaveLength(11);
+    expect(Object.keys(JOB_TYPES)).toHaveLength(16);
   });
 
   test("wire values are unique (no two symbols share a string)", () => {

--- a/packages/cloud-shared/src/lib/services/app-build-cmd.ts
+++ b/packages/cloud-shared/src/lib/services/app-build-cmd.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure `docker build` command assembly for the Apps / Product 2 build pipeline.
+ *
+ * Turns a build request (source context, optional Dockerfile, image ref, build
+ * args) into the exact `docker build` / `docker buildx build` command the
+ * (impure) build executor runs over SSH on a builder node — or locally in
+ * verification. Pure string assembly, so the build invocation is a unit-testable
+ * contract, mirroring app-docker-cmd.ts.
+ *
+ * The source context is either a local dir path OR a git URL — docker builds git
+ * contexts natively (`docker build https://host/repo.git#ref:subdir`), so the
+ * common "build from the user's repo" path needs no separate clone step.
+ *
+ * SECURITY: only NON-secret values belong in `buildArgs` (they're baked into the
+ * image history). Secrets must be injected at RUN time via the per-tenant
+ * `environmentVars` (see app-docker-cmd.ts), never here.
+ */
+
+import { shellQuote } from "./docker-sandbox-utils";
+
+export interface AppBuildCmdParams {
+  /** Build context: a local dir path or a git URL (optionally `#ref:subdir`). */
+  context: string;
+  /** Dockerfile path relative to the context. Default: docker's `Dockerfile`. */
+  dockerfile?: string;
+  /** Full image reference to tag the build with (see buildAppImageRef). */
+  imageRef: string;
+  /** Push to the registry after build (requires buildx) vs load locally. */
+  push?: boolean;
+  /** Non-secret build args. */
+  buildArgs?: Record<string, string>;
+  /**
+   * Force `docker buildx build`. Implied by `push`. When false (and not
+   * pushing), uses plain `docker build` (the image lands in the local daemon).
+   */
+  buildx?: boolean;
+}
+
+/** Assemble the docker build command for a user app image. */
+export function buildAppImageBuildCmd(params: AppBuildCmdParams): string {
+  const useBuildx = params.buildx ?? Boolean(params.push);
+  const parts: string[] = [useBuildx ? "docker buildx build" : "docker build"];
+
+  parts.push(`--tag ${shellQuote(params.imageRef)}`);
+  if (params.dockerfile) {
+    parts.push(`--file ${shellQuote(params.dockerfile)}`);
+  }
+  for (const [key, value] of Object.entries(params.buildArgs ?? {})) {
+    parts.push(`--build-arg ${shellQuote(`${key}=${value}`)}`);
+  }
+
+  if (params.push) {
+    parts.push("--push");
+  } else if (useBuildx) {
+    // buildx doesn't load into the local daemon by default; --load does.
+    parts.push("--load");
+  }
+
+  parts.push(shellQuote(params.context));
+  return parts.join(" ");
+}
+
+/** The `docker push <ref>` command, when build + push are separate steps. */
+export function buildAppImagePushCmd(imageRef: string): string {
+  return `docker push ${shellQuote(imageRef)}`;
+}

--- a/packages/cloud-shared/src/lib/services/app-container-provider.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-provider.ts
@@ -1,0 +1,92 @@
+/**
+ * App container provider (Apps / Product 2) — the thin, app-only orchestrator
+ * that runs an isolated user container on a node. It composes the pure builders
+ * (network ensure + docker-create + isolation flags) and drives them over an
+ * injected SSH seam, so the orchestration is unit-testable with a fake SSH and
+ * the real `ssh.exec` is the only IO.
+ *
+ * Deliberately NOT a subclass of DockerSandboxProvider and NOT coupled to the
+ * `containers` table here — recording the row is the job executor's concern
+ * (kept out so this stays decoupled from 2AM's container schema/repo). No eliza
+ * scaffolding, no shared network, no NET_ADMIN.
+ */
+
+import { buildAppDockerCreateCmd } from "./app-docker-cmd";
+import { appNetworkName, buildEnsureAppNetworkCmd } from "./app-network-utils";
+import type { CreateContainerInput } from "./containers/hetzner-client/types";
+import { shellQuote } from "./docker-sandbox-utils";
+
+/** Minimal SSH seam — runs a command on the target node and returns stdout. */
+export interface AppContainerSsh {
+  exec(command: string, timeoutMs?: number): Promise<string>;
+}
+
+export interface AppContainerProviderDeps {
+  ssh: AppContainerSsh;
+  /** Allocate an external host port to map to the container's app port. */
+  allocateHostPort: () => Promise<number>;
+  /** Optional egress proxy URL routed into the container. */
+  egressProxyUrl?: string;
+  pidsLimit?: number;
+  /** Parse the container id from `docker create` stdout. */
+  extractContainerId?: (dockerCreateStdout: string) => string;
+}
+
+export interface ProvisionAppContainerParams {
+  appId: string;
+  containerName: string;
+  input: CreateContainerInput;
+}
+
+export interface ProvisionedAppContainer {
+  containerId: string;
+  hostPort: number;
+  network: string;
+}
+
+function defaultExtractContainerId(stdout: string): string {
+  const last = stdout.trim().split("\n").pop()?.trim() ?? "";
+  return last;
+}
+
+export class AppContainerProvider {
+  private readonly deps: AppContainerProviderDeps;
+
+  constructor(deps: AppContainerProviderDeps) {
+    this.deps = deps;
+  }
+
+  /** Ensure the per-app `--internal` network, create the container, start it. */
+  async provision(params: ProvisionAppContainerParams): Promise<ProvisionedAppContainer> {
+    const network = appNetworkName(params.appId);
+    await this.deps.ssh.exec(buildEnsureAppNetworkCmd(network));
+
+    const hostPort = await this.deps.allocateHostPort();
+    const createCmd = buildAppDockerCreateCmd({
+      appId: params.appId,
+      containerName: params.containerName,
+      input: params.input,
+      hostPort,
+      egressProxyUrl: this.deps.egressProxyUrl,
+      pidsLimit: this.deps.pidsLimit,
+    });
+
+    const stdout = await this.deps.ssh.exec(createCmd);
+    const containerId = (this.deps.extractContainerId ?? defaultExtractContainerId)(stdout);
+    await this.deps.ssh.exec(`docker start ${shellQuote(params.containerName)}`);
+
+    return { containerId, hostPort, network };
+  }
+
+  async delete(containerName: string): Promise<void> {
+    await this.deps.ssh.exec(`docker rm -f ${shellQuote(containerName)}`);
+  }
+
+  async restart(containerName: string): Promise<void> {
+    await this.deps.ssh.exec(`docker restart ${shellQuote(containerName)}`);
+  }
+
+  async logs(containerName: string, tail = 200): Promise<string> {
+    return this.deps.ssh.exec(`docker logs --tail ${tail} ${shellQuote(containerName)}`);
+  }
+}

--- a/packages/cloud-shared/src/lib/services/app-container-store.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-store.ts
@@ -44,6 +44,58 @@ import { containers } from "../../db/schemas/containers";
 import { logger } from "../utils/logger";
 import type { AppContainerRow, AppContainerStore } from "./container-job-executors";
 
+/** The `containers` columns the executor's view projects from (structural). */
+export interface ProjectableContainerRow {
+  id: string;
+  name: string;
+  project_name: string;
+  image_tag: string | null;
+  port: number;
+  organization_id: string;
+  user_id: string;
+  environment_vars: Record<string, string> | null;
+  metadata: Record<string, unknown> | null;
+}
+
+/**
+ * Project a `containers` row onto the executor's {@link AppContainerRow}. Pure,
+ * so the impedance map (image_tag→image, the appId fallback chain, the env-vars
+ * carrying the per-tenant DSN) is unit-tested without a DB.
+ */
+export function mapContainerRowToAppContainerRow(row: ProjectableContainerRow): AppContainerRow {
+  const metaAppId =
+    typeof row.metadata?.appId === "string" ? (row.metadata.appId as string) : undefined;
+  return {
+    id: row.id,
+    // project_name is set to the appId by the deploy orchestrator's
+    // createContainerRow; metadata.appId is a belt-and-suspenders fallback.
+    appId: metaAppId ?? row.project_name,
+    containerName: row.name,
+    image: row.image_tag ?? "",
+    port: row.port,
+    organizationId: row.organization_id,
+    userId: row.user_id,
+    environmentVars: row.environment_vars ?? undefined,
+  };
+}
+
+/**
+ * Merge host-placement fields into a container's metadata jsonb, preserving
+ * everything already there (e.g. `appId`). Pure — the 2AM `containers` schema
+ * has no dedicated host columns, so metadata is the canonical placement sink.
+ */
+export function mergeHostPlacementMetadata(
+  existing: Record<string, unknown> | null | undefined,
+  info: { hostContainerId: string; hostPort: number; network: string },
+): Record<string, unknown> {
+  return {
+    ...(existing ?? {}),
+    hostContainerId: info.hostContainerId,
+    hostPort: info.hostPort,
+    network: info.network,
+  };
+}
+
 /** Read/write seam impl over `containersRepository` + a direct id-scoped read. */
 export class ContainerRepoAppContainerStore implements AppContainerStore {
   async getById(containerId: string): Promise<AppContainerRow | null> {
@@ -56,22 +108,7 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
       .where(eq(containers.id, containerId))
       .limit(1);
     if (!row) return null;
-
-    return {
-      id: row.id,
-      // project_name is set to the appId by the deploy orchestrator's
-      // createContainerRow; metadata.appId is a belt-and-suspenders fallback.
-      appId:
-        (typeof (row.metadata as Record<string, unknown>)?.appId === "string"
-          ? ((row.metadata as Record<string, unknown>).appId as string)
-          : undefined) ?? row.project_name,
-      containerName: row.name,
-      image: row.image_tag ?? "",
-      port: row.port,
-      organizationId: row.organization_id,
-      userId: row.user_id,
-      environmentVars: (row.environment_vars as Record<string, string>) ?? undefined,
-    };
+    return mapContainerRowToAppContainerRow(row);
   }
 
   async markRunning(
@@ -90,12 +127,7 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
 
     // Merge host placement into metadata (no dedicated columns on the 2AM
     // schema), preserving anything already there (e.g. appId).
-    const nextMetadata: Record<string, unknown> = {
-      ...((row.metadata as Record<string, unknown>) ?? {}),
-      hostContainerId: info.hostContainerId,
-      hostPort: info.hostPort,
-      network: info.network,
-    };
+    const nextMetadata = mergeHostPlacementMetadata(row.metadata, info);
 
     // Two writes: status (id-scoped) + metadata/last_deployed_at (org-scoped
     // update, which is the only metadata-writing surface the repo exposes).

--- a/packages/cloud-shared/src/lib/services/app-container-store.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-store.ts
@@ -1,0 +1,121 @@
+/**
+ * AppContainerStore (Apps / Product 2) — the integration backing for the
+ * {@link AppContainerStore} read/write seam declared in
+ * `container-job-executors.ts`. It adapts the apps-lane executor's container
+ * view onto 2AM's `containers` table via `containersRepository`, so the executor
+ * itself never imports that schema/repo (decoupled per the seam's intent).
+ *
+ * IMPEDANCE MAP — the executor's AppContainerRow vs the `containers` columns:
+ *   AppContainerRow.id              -> containers.id
+ *   AppContainerRow.appId           -> containers.project_name  (the deploy
+ *                                       orchestrator sets project_name = appId)
+ *   AppContainerRow.containerName   -> containers.name
+ *   AppContainerRow.image           -> containers.image_tag
+ *   AppContainerRow.port            -> containers.port
+ *   AppContainerRow.organizationId  -> containers.organization_id
+ *   AppContainerRow.userId          -> containers.user_id
+ *   AppContainerRow.environmentVars -> containers.environment_vars (jsonb;
+ *                                       carries the per-tenant DATABASE_URL)
+ *
+ * markRunning persists {hostContainerId, hostPort, network}. The `containers`
+ * table has NO dedicated columns for these (2AM's 2026-05-17 schema), so they
+ * are merged into `containers.metadata` (the only free-form jsonb sink). When
+ * 2AM's #8273 lands and ALTERs the schema, prefer real columns if it adds them;
+ * until then `metadata` is canonical for host placement. We also stamp
+ * `last_deployed_at` on success for the deploy-status poll.
+ *
+ * STATUS VOCAB (containers.ContainerStatus): pending | building | deploying |
+ *   running | stopped | failed | deleting | deleted. We use:
+ *     markRunning -> "running", markError -> "failed", markDeleted -> "stopped".
+ *   ("stopped" keeps the partial unique index active_project_volume_unique happy:
+ *   its predicate excludes status IN ('failed','stopped').)
+ *
+ * SERVER + NODE: this is a plain DB adapter (no `pg`), but it is wired into the
+ * node daemon's container-executor deps (the daemon runs the provision against a
+ * real worker node). `getById` uses a non-org-scoped read (the executor only has
+ * the container id from the job payload; the repo's findById/update are
+ * org-scoped, so we read the org from the row first, then call org-scoped update).
+ */
+
+import { eq } from "drizzle-orm";
+import { dbRead } from "../../db/helpers";
+import { containersRepository } from "../../db/repositories/containers";
+import { containers } from "../../db/schemas/containers";
+import { logger } from "../utils/logger";
+import type { AppContainerRow, AppContainerStore } from "./container-job-executors";
+
+/** Read/write seam impl over `containersRepository` + a direct id-scoped read. */
+export class ContainerRepoAppContainerStore implements AppContainerStore {
+  async getById(containerId: string): Promise<AppContainerRow | null> {
+    // The executor only has the container id (from the job payload), but the
+    // repo's findById is org-scoped. Read by primary key directly to recover the
+    // full row (incl. organization_id), then project onto AppContainerRow.
+    const [row] = await dbRead
+      .select()
+      .from(containers)
+      .where(eq(containers.id, containerId))
+      .limit(1);
+    if (!row) return null;
+
+    return {
+      id: row.id,
+      // project_name is set to the appId by the deploy orchestrator's
+      // createContainerRow; metadata.appId is a belt-and-suspenders fallback.
+      appId:
+        (typeof (row.metadata as Record<string, unknown>)?.appId === "string"
+          ? ((row.metadata as Record<string, unknown>).appId as string)
+          : undefined) ?? row.project_name,
+      containerName: row.name,
+      image: row.image_tag ?? "",
+      port: row.port,
+      organizationId: row.organization_id,
+      userId: row.user_id,
+      environmentVars: (row.environment_vars as Record<string, string>) ?? undefined,
+    };
+  }
+
+  async markRunning(
+    containerId: string,
+    info: { hostContainerId: string; hostPort: number; network: string },
+  ): Promise<void> {
+    const [row] = await dbRead
+      .select({ organization_id: containers.organization_id, metadata: containers.metadata })
+      .from(containers)
+      .where(eq(containers.id, containerId))
+      .limit(1);
+    if (!row) {
+      logger.warn("[AppContainerStore] markRunning: container not found", { containerId });
+      return;
+    }
+
+    // Merge host placement into metadata (no dedicated columns on the 2AM
+    // schema), preserving anything already there (e.g. appId).
+    const nextMetadata: Record<string, unknown> = {
+      ...((row.metadata as Record<string, unknown>) ?? {}),
+      hostContainerId: info.hostContainerId,
+      hostPort: info.hostPort,
+      network: info.network,
+    };
+
+    // Two writes: status (id-scoped) + metadata/last_deployed_at (org-scoped
+    // update, which is the only metadata-writing surface the repo exposes).
+    await containersRepository.updateStatus(containerId, "running");
+    await containersRepository.update(containerId, row.organization_id, {
+      metadata: nextMetadata,
+      last_deployed_at: new Date(),
+    });
+  }
+
+  async markDeleted(containerId: string): Promise<void> {
+    // "stopped" rather than the terminal "deleted" so a redeploy can reuse the
+    // row; both satisfy the active_project_volume_unique predicate exclusion.
+    await containersRepository.updateStatus(containerId, "stopped");
+  }
+
+  async markError(containerId: string, error: string): Promise<void> {
+    await containersRepository.updateStatus(containerId, "failed", error);
+  }
+}
+
+/** Singleton — wired into the daemon's container-executor deps. */
+export const appContainerStore: AppContainerStore = new ContainerRepoAppContainerStore();

--- a/packages/cloud-shared/src/lib/services/app-container-store.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-store.ts
@@ -42,6 +42,7 @@ import { dbRead } from "../../db/helpers";
 import { containersRepository } from "../../db/repositories/containers";
 import { containers } from "../../db/schemas/containers";
 import { logger } from "../utils/logger";
+import { deriveAppPublicUrl } from "./app-url";
 import type { AppContainerRow, AppContainerStore } from "./container-job-executors";
 
 /** The `containers` columns the executor's view projects from (structural). */
@@ -129,12 +130,18 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
     // schema), preserving anything already there (e.g. appId).
     const nextMetadata = mergeHostPlacementMetadata(row.metadata, info);
 
-    // Two writes: status (id-scoped) + metadata/last_deployed_at (org-scoped
+    // Stamp the app's public URL via the SAME ingress hostname derivation the
+    // agent path uses (reused, not rebuilt) so the running app is reachable at
+    // a real URL. Skipped when no public base domain is configured (local dev).
+    const endpoint = deriveAppPublicUrl(containerId);
+
+    // Two writes: status (id-scoped) + metadata/url/last_deployed_at (org-scoped
     // update, which is the only metadata-writing surface the repo exposes).
     await containersRepository.updateStatus(containerId, "running");
     await containersRepository.update(containerId, row.organization_id, {
       metadata: nextMetadata,
       last_deployed_at: new Date(),
+      ...(endpoint ? { public_hostname: endpoint.hostname, load_balancer_url: endpoint.url } : {}),
     });
   }
 

--- a/packages/cloud-shared/src/lib/services/app-deploy-job-service.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-job-service.ts
@@ -1,0 +1,76 @@
+/**
+ * APP_DEPLOY job service (Apps / Product 2) — the runtime split that lets the
+ * cloud-api Worker trigger a real isolated deploy without ever touching `pg`.
+ *
+ * The Worker deploy route ENQUEUES an APP_DEPLOY job (a plain DB insert, no `pg`)
+ * via {@link enqueueAppDeploy}; the provisioning-worker daemon claims it and runs
+ * the node {@link AppDeployRunner} via {@link dispatchAppDeployJob} (ensure
+ * tenant DB -> create container row with the per-tenant DSN -> enqueue
+ * CONTAINER_PROVISION -> link). This keeps all DDL/SSH on the node side
+ * (workerd can't load `pg`) while the deploy request stays Worker-native.
+ *
+ * The executor backend is injected at daemon boot via {@link setAppDeployRunner}
+ * (see apps-deploy-backend.ts), mirroring setContainerExecutorDeps — so this
+ * module imports no `pg`/SSH and stays safe to load anywhere.
+ */
+
+import type { AppDeployRunner } from "./app-deploy-orchestrator";
+import { appDeploymentsService } from "./app-deployments";
+import type { ContainerJobsWriter } from "./container-job-service";
+import { containerJobsWriter } from "./container-jobs-writer";
+import { JOB_TYPES } from "./provisioning-job-types";
+
+// ── runtime-injected executor (daemon side) ─────────────────────────────────
+let appDeployRunner: AppDeployRunner | null = null;
+
+/** Wire the node deploy runner the daemon runs for APP_DEPLOY jobs. */
+export function setAppDeployRunner(runner: AppDeployRunner): void {
+  appDeployRunner = runner;
+}
+
+/** Resolve the deploy runner, or throw if the backend isn't wired yet. */
+export function getAppDeployRunner(): AppDeployRunner {
+  if (!appDeployRunner) {
+    throw new Error("App deploy runner not configured — call setAppDeployRunner()");
+  }
+  return appDeployRunner;
+}
+
+/** Extract the appId from an APP_DEPLOY job payload (throws if absent). */
+export function readAppDeployJobData(job: { data: unknown }): { appId: string } {
+  const data = (job.data ?? {}) as Record<string, unknown>;
+  if (typeof data.appId !== "string" || data.appId.length === 0) {
+    throw new Error("APP_DEPLOY job missing data.appId");
+  }
+  return { appId: data.appId };
+}
+
+/** Daemon: run the full deploy for a claimed APP_DEPLOY job via the injected runner. */
+export async function dispatchAppDeployJob(job: { data: unknown }): Promise<void> {
+  const { appId } = readAppDeployJobData(job);
+  await getAppDeployRunner().run(appId);
+}
+
+// ── enqueue (Worker / request side) ─────────────────────────────────────────
+/** Enqueue an APP_DEPLOY job (pg-free) over the shared job writer. */
+export function enqueueAppDeploy(
+  writer: ContainerJobsWriter,
+  p: { appId: string; organizationId: string; userId?: string },
+): Promise<{ id: string }> {
+  return writer.insertJob({
+    type: JOB_TYPES.APP_DEPLOY,
+    organizationId: p.organizationId,
+    userId: p.userId,
+    data: { appId: p.appId },
+  });
+}
+
+/**
+ * Worker boot (Apps / Product 2): wire `appDeploymentsService.createDeployment`
+ * to enqueue APP_DEPLOY over the shared (pg-free) job writer. Call once in
+ * cloud-api boot — after this, hitting the deploy route enqueues the real
+ * isolated deploy that the daemon runs. Safe to import on workerd (no `pg`).
+ */
+export function configureAppsDeployTrigger(): void {
+  appDeploymentsService.setDeployEnqueuer((p) => enqueueAppDeploy(containerJobsWriter, p));
+}

--- a/packages/cloud-shared/src/lib/services/app-deploy-orchestrator.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-orchestrator.ts
@@ -51,6 +51,16 @@ export interface DeployAppResult {
 }
 
 /**
+ * Seam the deploy route/service calls to kick off the real provision for a
+ * queued app deploy. The concrete runner (wired with the apps repo, image
+ * resolution, and {@link deployApp}'s deps) lives at the integration boundary;
+ * `AppDeploymentsService` invokes it after marking the app `building`.
+ */
+export interface AppDeployRunner {
+  run(appId: string): Promise<void>;
+}
+
+/**
  * Deploy an app container. Order matters: the DB DSN must exist before the
  * container row is created (the row carries it), and the row must exist before
  * the provision job can reference it.

--- a/packages/cloud-shared/src/lib/services/app-deploy-orchestrator.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-orchestrator.ts
@@ -1,0 +1,84 @@
+/**
+ * App deploy orchestration (Apps / Product 2) — turns a deploy request into a
+ * real provision: ensure the app's ISOLATED per-tenant DB, create a container
+ * row carrying that DSN, enqueue a CONTAINER_PROVISION job, and link the
+ * container to the app. This is what replaces the `/v1/apps/:id/deploy` stub
+ * (which only flipped status='building').
+ *
+ * Every side is an injected seam, so the flow is unit-testable with fakes and
+ * stays decoupled from 2AM's `containers` schema/repo (createContainerRow is
+ * injected). The load-bearing property — the app container gets its OWN DSN, not
+ * the shared agent DATABASE_URL — is asserted as a unit test.
+ */
+
+export interface DeployAppRequest {
+  appId: string;
+  organizationId: string;
+  userId: string;
+  containerName: string;
+  image: string;
+  port?: number;
+}
+
+export interface NewAppContainerRow {
+  appId: string;
+  organizationId: string;
+  userId: string;
+  containerName: string;
+  image: string;
+  port: number;
+  environmentVars: Record<string, string>;
+}
+
+export interface AppDeployDeps {
+  /** Ensure the app's isolated per-tenant DB exists; returns its DSN. */
+  ensureTenantDb: (appId: string) => Promise<string>;
+  /** Create the container row (in the `containers` table); returns its id. */
+  createContainerRow: (row: NewAppContainerRow) => Promise<{ containerId: string }>;
+  /** Enqueue the provision job for a container. */
+  enqueueProvision: (p: {
+    containerId: string;
+    organizationId: string;
+    userId: string;
+  }) => Promise<{ id: string }>;
+  /** Record the container id on the app (e.g. apps.metadata.containerId). */
+  linkContainerToApp: (appId: string, containerId: string) => Promise<void>;
+}
+
+export interface DeployAppResult {
+  containerId: string;
+  jobId: string;
+}
+
+/**
+ * Deploy an app container. Order matters: the DB DSN must exist before the
+ * container row is created (the row carries it), and the row must exist before
+ * the provision job can reference it.
+ */
+export async function deployApp(
+  req: DeployAppRequest,
+  deps: AppDeployDeps,
+): Promise<DeployAppResult> {
+  const dsn = await deps.ensureTenantDb(req.appId);
+
+  const { containerId } = await deps.createContainerRow({
+    appId: req.appId,
+    organizationId: req.organizationId,
+    userId: req.userId,
+    containerName: req.containerName,
+    image: req.image,
+    port: req.port ?? 3000,
+    // The app's OWN isolated DSN — never the shared agent DATABASE_URL.
+    environmentVars: { DATABASE_URL: dsn },
+  });
+
+  const { id: jobId } = await deps.enqueueProvision({
+    containerId,
+    organizationId: req.organizationId,
+    userId: req.userId,
+  });
+
+  await deps.linkContainerToApp(req.appId, containerId);
+
+  return { containerId, jobId };
+}

--- a/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
@@ -78,6 +78,8 @@ export interface AppDeployRunnerDeps {
     id: string;
     name: string;
     metadata: Record<string, unknown>;
+    /** The app's git repo (apps.github_repo) — the build pipeline's context. */
+    repoUrl?: string;
   }) => Promise<string | undefined> | string | undefined;
   /** App listen port. Default 3000. */
   port?: number;
@@ -104,7 +106,7 @@ export function toNewContainer(row: NewAppContainerRow): NewContainer {
 
 async function resolveImageRef(
   deps: AppDeployRunnerDeps,
-  app: { id: string; name: string; metadata: Record<string, unknown> },
+  app: { id: string; name: string; metadata: Record<string, unknown>; repoUrl?: string },
 ): Promise<string> {
   const fromResolver = deps.resolveImage ? await deps.resolveImage(app) : undefined;
   const fromMetadata =
@@ -142,6 +144,7 @@ export class DefaultAppDeployRunner implements AppDeployRunner {
       id: app.id,
       name: app.name,
       metadata: (app.metadata as Record<string, unknown>) ?? {},
+      repoUrl: app.github_repo ?? undefined,
     });
     const containerName = containerNameForApp(appId);
 

--- a/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
@@ -50,6 +50,7 @@ import {
   deployApp,
   type NewAppContainerRow,
 } from "./app-deploy-orchestrator";
+import { deriveAppPublicUrl } from "./app-url";
 import { appsService } from "./apps";
 import { ContainerJobEnqueuer, type ContainerJobsWriter } from "./container-job-service";
 import type { UserDatabaseService } from "./user-database";
@@ -164,8 +165,13 @@ export class DefaultAppDeployRunner implements AppDeployRunner {
         // Re-read for the freshest metadata before merging containerId in.
         const current = await appsService.getById(id);
         const existingMeta = (current?.metadata as Record<string, unknown>) ?? {};
+        // The public URL is deterministic from the container id (same ingress
+        // derivation as the agent path), so the deploy-status poll can surface
+        // it immediately. Skipped when no public base domain is configured.
+        const endpoint = deriveAppPublicUrl(containerId);
         await appsService.update(id, {
           metadata: { ...existingMeta, containerId },
+          ...(endpoint ? { production_url: endpoint.url } : {}),
         });
       },
     };

--- a/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
@@ -1,0 +1,251 @@
+/**
+ * Concrete AppDeployRunner (Apps / Product 2) — the integration boundary that
+ * implements the {@link AppDeployRunner} seam `AppDeploymentsService` calls after
+ * marking an app `building`. It loads the app, resolves the image + container
+ * name, composes `deployApp`'s injected deps over the real services/repos, and
+ * runs the orchestration: ensure isolated tenant DB -> create container row
+ * carrying that DSN -> enqueue CONTAINER_PROVISION -> link container to app.
+ *
+ * ── THE RUNTIME SPLIT (load-bearing) ─────────────────────────────────────────
+ * `deployApp.ensureTenantDb` must run `CREATE DATABASE`/`CREATE ROLE` DDL, which
+ * goes through `DirectPgExecutor` (node-`pg`). The cloud-api deploy route runs on
+ * Cloudflare Workers (workerd) where `pg` does NOT load. So there are two ways to
+ * wire `ensureTenantDb`, and the factory picks the right one by runtime:
+ *
+ *   (A) NODE runtime (the provisioning-worker daemon, or any node host of the
+ *       deploy path): `ensureTenantDb` runs the real isolated provision inline
+ *       via `userDatabaseService.provisionDatabase` backed by the injected
+ *       `SqlTenantDbProvisioning` (DirectPgExecutor). Returns the per-tenant DSN.
+ *
+ *   (B) WORKER runtime (cloud-api): `ensureTenantDb` must NOT touch `pg`. The
+ *       Worker-safe factory provisions in SHARED-DB fallback mode at request time
+ *       (no DDL — just returns the shared DATABASE_URL the legacy path used), OR,
+ *       once the daemon owns tenant-DB DDL, returns a placeholder the daemon
+ *       overwrites before the container boots. Today's foundation keeps the
+ *       isolated DDL on the node side, so the Worker factory uses the shared-DB
+ *       provision (still isolated by app/agent UUID via plugin-sql) and leaves
+ *       a TODO to move DDL into the CONTAINER_PROVISION executor when the daemon
+ *       gains an ensure-tenant-db step. Either way the deploy route never calls
+ *       `pg`, satisfying the workerd constraint.
+ *
+ * The image is resolved from the build-pipeline output. There is no build service
+ * yet (app-deployments.ts notes this), so `resolveImage` reads, in order:
+ *   1. an explicit override passed into the runner (CI / tests),
+ *   2. `app.metadata.imageTag` (where a future build step writes the built ref),
+ *   3. `APP_DEFAULT_IMAGE` env (a placeholder runtime image for smoke tests).
+ * It throws if none resolve, surfacing a clear "no image to deploy" rather than
+ * provisioning an empty container.
+ *
+ * Every dependency is injected, so the runner is unit-testable with fakes and the
+ * load-bearing property — `containers.environment_vars.DATABASE_URL` is the
+ * per-tenant DSN, never the shared agent URL — is asserted directly.
+ */
+
+import { containersRepository } from "../../db/repositories/containers";
+import type { NewContainer } from "../../db/schemas/containers";
+import { logger } from "../utils/logger";
+import {
+  type AppDeployDeps,
+  type AppDeployRunner,
+  deployApp,
+  type NewAppContainerRow,
+} from "./app-deploy-orchestrator";
+import { appsService } from "./apps";
+import { ContainerJobEnqueuer, type ContainerJobsWriter } from "./container-job-service";
+import type { UserDatabaseService } from "./user-database";
+
+/** Everything the runner needs to compose `deployApp`'s deps. Injected for tests. */
+export interface AppDeployRunnerDeps {
+  /**
+   * Ensures the app's isolated per-tenant DB exists and returns its DSN.
+   *
+   * NODE: `(appId, appName) => userDatabaseService.provisionDatabase(...)` over a
+   * `SqlTenantDbProvisioning` (DirectPgExecutor) — the real isolated DDL path.
+   * WORKER: a `pg`-free provision (shared-DB fallback) — see the file header.
+   *
+   * Receives `appName` for provisioning/logging parity with provisionDatabase.
+   */
+  ensureTenantDb: (appId: string, appName: string) => Promise<string>;
+  /** Persists a container row; returns its id. Defaults to `containersRepository.create`. */
+  createContainerRow?: (row: NewAppContainerRow) => Promise<{ containerId: string }>;
+  /** Enqueues the provision job. Defaults to a `ContainerJobEnqueuer` over the writer. */
+  jobsWriter: ContainerJobsWriter;
+  /**
+   * Resolve the full image reference (`ghcr.io/owner/app:tag`) to deploy. When
+   * omitted, falls back to `app.metadata.imageTag` then `APP_DEFAULT_IMAGE`.
+   */
+  resolveImage?: (app: {
+    id: string;
+    name: string;
+    metadata: Record<string, unknown>;
+  }) => Promise<string | undefined> | string | undefined;
+  /** App listen port. Default 3000. */
+  port?: number;
+}
+
+/** Map the orchestrator's NewAppContainerRow onto a `containers` insert. */
+export function toNewContainer(row: NewAppContainerRow): NewContainer {
+  return {
+    name: row.containerName,
+    // project_name = appId so the executor's AppContainerStore can recover the
+    // appId from the row, and so the partial unique index keys per-app.
+    project_name: row.appId,
+    organization_id: row.organizationId,
+    user_id: row.userId,
+    image_tag: row.image,
+    port: row.port,
+    // The app's OWN isolated DSN rides here — never the shared agent DATABASE_URL.
+    environment_vars: row.environmentVars,
+    // Stash appId in metadata too (belt-and-suspenders for the store's getById).
+    metadata: { appId: row.appId },
+    status: "pending",
+  };
+}
+
+async function resolveImageRef(
+  deps: AppDeployRunnerDeps,
+  app: { id: string; name: string; metadata: Record<string, unknown> },
+): Promise<string> {
+  const fromResolver = deps.resolveImage ? await deps.resolveImage(app) : undefined;
+  const fromMetadata =
+    typeof app.metadata?.imageTag === "string" ? (app.metadata.imageTag as string) : undefined;
+  const fromEnv = process.env.APP_DEFAULT_IMAGE;
+  const image = fromResolver ?? fromMetadata ?? fromEnv;
+  if (!image) {
+    throw new Error(
+      `No image to deploy for app ${app.id}: pass resolveImage, set app.metadata.imageTag, or APP_DEFAULT_IMAGE`,
+    );
+  }
+  return image;
+}
+
+/** A stable, DNS/Docker-safe container name for an app: `app-<first 12 of id>`. */
+export function containerNameForApp(appId: string): string {
+  const slug = appId.toLowerCase().replace(/[^a-z0-9]/g, "");
+  return `app-${slug.slice(0, 12)}`;
+}
+
+export class DefaultAppDeployRunner implements AppDeployRunner {
+  private readonly deps: AppDeployRunnerDeps;
+
+  constructor(deps: AppDeployRunnerDeps) {
+    this.deps = deps;
+  }
+
+  async run(appId: string): Promise<void> {
+    const app = await appsService.getById(appId);
+    if (!app) {
+      throw new Error(`App ${appId} not found`);
+    }
+
+    const image = await resolveImageRef(this.deps, {
+      id: app.id,
+      name: app.name,
+      metadata: (app.metadata as Record<string, unknown>) ?? {},
+    });
+    const containerName = containerNameForApp(appId);
+
+    const enqueuer = new ContainerJobEnqueuer(this.deps.jobsWriter);
+    const createContainerRow =
+      this.deps.createContainerRow ??
+      (async (row: NewAppContainerRow) => {
+        const created = await containersRepository.create(toNewContainer(row));
+        return { containerId: created.id };
+      });
+
+    const orchestratorDeps: AppDeployDeps = {
+      ensureTenantDb: (id) => this.deps.ensureTenantDb(id, app.name),
+      createContainerRow,
+      enqueueProvision: (p) => enqueuer.enqueueProvision(p),
+      linkContainerToApp: async (id, containerId) => {
+        // Re-read for the freshest metadata before merging containerId in.
+        const current = await appsService.getById(id);
+        const existingMeta = (current?.metadata as Record<string, unknown>) ?? {};
+        await appsService.update(id, {
+          metadata: { ...existingMeta, containerId },
+        });
+      },
+    };
+
+    const result = await deployApp(
+      {
+        appId,
+        organizationId: app.organization_id,
+        userId: app.created_by_user_id,
+        containerName,
+        image,
+        port: this.deps.port ?? 3000,
+      },
+      orchestratorDeps,
+    );
+
+    logger.info("[AppDeployRunner] deploy provisioned", {
+      appId,
+      containerId: result.containerId,
+      jobId: result.jobId,
+      image,
+    });
+  }
+}
+
+/**
+ * NODE factory — the real isolated provision path. `ensureTenantDb` runs the
+ * tenant-DB DDL inline via the injected `userDatabaseService` (which must have
+ * been constructed with a `SqlTenantDbProvisioning`/DirectPgExecutor; otherwise
+ * it transparently falls back to shared-DB mode). Use this where the deploy path
+ * runs on node (the daemon, or a node sidecar hosting the deploy route).
+ */
+export function makeNodeAppDeployRunner(args: {
+  userDatabaseService: UserDatabaseService;
+  jobsWriter: ContainerJobsWriter;
+  resolveImage?: AppDeployRunnerDeps["resolveImage"];
+  port?: number;
+}): DefaultAppDeployRunner {
+  return new DefaultAppDeployRunner({
+    ensureTenantDb: async (appId, appName) => {
+      const provisioned = await args.userDatabaseService.provisionDatabase(appId, appName);
+      if (!provisioned.success || !provisioned.connectionUri) {
+        throw new Error(
+          `ensureTenantDb failed for app ${appId}: ${provisioned.error ?? "no connection URI"}`,
+        );
+      }
+      return provisioned.connectionUri;
+    },
+    jobsWriter: args.jobsWriter,
+    resolveImage: args.resolveImage,
+    port: args.port,
+  });
+}
+
+/**
+ * WORKER factory — `pg`-free. `ensureTenantDb` runs `provisionDatabase` over a
+ * `userDatabaseService` constructed WITHOUT a tenant-DB provisioning backend, so
+ * it takes the shared-DB fallback (returns process.env.DATABASE_URL; no DDL, no
+ * `pg`). Isolation in this mode is by app/agent UUID scoping in plugin-sql, not
+ * by REVOKE-CONNECT. Use this in cloud-api (workerd) until tenant-DB DDL is moved
+ * into the CONTAINER_PROVISION executor (then this factory enqueues instead).
+ *
+ * The injected `userDatabaseService` here is the bare singleton (no provisioning
+ * backend) — passing it explicitly keeps the dependency visible and testable.
+ */
+export function makeWorkerAppDeployRunner(args: {
+  userDatabaseService: UserDatabaseService;
+  jobsWriter: ContainerJobsWriter;
+  resolveImage?: AppDeployRunnerDeps["resolveImage"];
+  port?: number;
+}): DefaultAppDeployRunner {
+  return new DefaultAppDeployRunner({
+    ensureTenantDb: async (appId, appName) => {
+      const provisioned = await args.userDatabaseService.provisionDatabase(appId, appName);
+      if (!provisioned.success || !provisioned.connectionUri) {
+        throw new Error(
+          `ensureTenantDb (shared) failed for app ${appId}: ${provisioned.error ?? "no connection URI"}`,
+        );
+      }
+      return provisioned.connectionUri;
+    },
+    jobsWriter: args.jobsWriter,
+    resolveImage: args.resolveImage,
+    port: args.port,
+  });
+}

--- a/packages/cloud-shared/src/lib/services/app-deployments.ts
+++ b/packages/cloud-shared/src/lib/services/app-deployments.ts
@@ -11,13 +11,13 @@
  * becomes the integration boundary — callers will not need to change.
  */
 import { logger } from "../utils/logger";
+import type { AppDeployRunner } from "./app-deploy-orchestrator";
 import {
   assertDeployable,
   type DeploymentStatus,
   deploymentIdFor,
   publicStatusFor,
 } from "./app-deployments-helpers";
-import type { AppDeployRunner } from "./app-deploy-orchestrator";
 import { appsService } from "./apps";
 
 export type { DeploymentStatus } from "./app-deployments-helpers";
@@ -53,7 +53,7 @@ export interface DeploymentRecord {
 }
 
 export class AppDeploymentsService {
-  private readonly deployRunner?: AppDeployRunner;
+  private deployRunner?: AppDeployRunner;
 
   /**
    * @param deployRunner When wired (Apps / Product 2), a deploy provisions a
@@ -62,6 +62,16 @@ export class AppDeploymentsService {
    */
   constructor(deployRunner?: AppDeployRunner) {
     this.deployRunner = deployRunner;
+  }
+
+  /**
+   * Runtime-inject the deploy backend (Apps / Product 2). Used by the node boot
+   * composer (`configureAppsDeployBackend`) so the singleton this Worker/daemon
+   * shares can be armed without a module-load-time `pg`/SSH dependency. Calling
+   * with the same runner is idempotent; legacy behavior holds until it's set.
+   */
+  setDeployRunner(runner: AppDeployRunner): void {
+    this.deployRunner = runner;
   }
 
   /**

--- a/packages/cloud-shared/src/lib/services/app-deployments.ts
+++ b/packages/cloud-shared/src/lib/services/app-deployments.ts
@@ -52,8 +52,20 @@ export interface DeploymentRecord {
   startedAt: string;
 }
 
+/**
+ * Enqueue an APP_DEPLOY job (pg-free) so the daemon runs the real isolated
+ * deploy. The Worker deploy route wires this so `createDeployment` never touches
+ * `pg`/SSH on the workerd request path.
+ */
+export type AppDeployEnqueuer = (p: {
+  appId: string;
+  organizationId: string;
+  userId: string;
+}) => Promise<unknown>;
+
 export class AppDeploymentsService {
   private deployRunner?: AppDeployRunner;
+  private deployEnqueuer?: AppDeployEnqueuer;
 
   /**
    * @param deployRunner When wired (Apps / Product 2), a deploy provisions a
@@ -65,13 +77,21 @@ export class AppDeploymentsService {
   }
 
   /**
-   * Runtime-inject the deploy backend (Apps / Product 2). Used by the node boot
-   * composer (`configureAppsDeployBackend`) so the singleton this Worker/daemon
-   * shares can be armed without a module-load-time `pg`/SSH dependency. Calling
-   * with the same runner is idempotent; legacy behavior holds until it's set.
+   * Runtime-inject the DIRECT deploy backend (node/test path): `createDeployment`
+   * runs the runner inline. Production prefers {@link setDeployEnqueuer} so the
+   * Worker stays pg-free. Idempotent; legacy behavior holds until set.
    */
   setDeployRunner(runner: AppDeployRunner): void {
     this.deployRunner = runner;
+  }
+
+  /**
+   * Runtime-inject the WORKER deploy trigger: `createDeployment` enqueues an
+   * APP_DEPLOY job (pg-free) the daemon runs. Takes precedence over a direct
+   * runner. Wired in cloud-api boot.
+   */
+  setDeployEnqueuer(enqueuer: AppDeployEnqueuer): void {
+    this.deployEnqueuer = enqueuer;
   }
 
   /**
@@ -104,15 +124,24 @@ export class AppDeploymentsService {
       throw new Error("Failed to record deployment start");
     }
 
-    // Apps lane (Product 2): if the real deploy backend is wired, kick off the
-    // isolated container provision. Best-effort — on failure mark the app
-    // errored so the caller's status poll reflects it. No-op (legacy stub
-    // behavior) when no runner is injected.
-    if (this.deployRunner) {
+    // Apps lane (Product 2): trigger the real isolated deploy.
+    //   WORKER  — enqueue an APP_DEPLOY job (pg-free); the daemon runs it.
+    //   NODE/test — run the injected runner inline.
+    //   neither wired — legacy stub (status flip only).
+    // On failure, mark the app errored so the caller's status poll reflects it.
+    if (this.deployEnqueuer || this.deployRunner) {
       try {
-        await this.deployRunner.run(input.appId);
+        if (this.deployEnqueuer) {
+          await this.deployEnqueuer({
+            appId: input.appId,
+            organizationId: input.organizationId,
+            userId: input.userId,
+          });
+        } else if (this.deployRunner) {
+          await this.deployRunner.run(input.appId);
+        }
       } catch (error) {
-        logger.error("[AppDeployments] deploy run failed", {
+        logger.error("[AppDeployments] deploy trigger failed", {
           appId: input.appId,
           error: error instanceof Error ? error.message : String(error),
         });

--- a/packages/cloud-shared/src/lib/services/app-deployments.ts
+++ b/packages/cloud-shared/src/lib/services/app-deployments.ts
@@ -17,6 +17,7 @@ import {
   deploymentIdFor,
   publicStatusFor,
 } from "./app-deployments-helpers";
+import type { AppDeployRunner } from "./app-deploy-orchestrator";
 import { appsService } from "./apps";
 
 export type { DeploymentStatus } from "./app-deployments-helpers";
@@ -52,6 +53,17 @@ export interface DeploymentRecord {
 }
 
 export class AppDeploymentsService {
+  private readonly deployRunner?: AppDeployRunner;
+
+  /**
+   * @param deployRunner When wired (Apps / Product 2), a deploy provisions a
+   *   real isolated container after the app is marked `building`. When omitted,
+   *   `createDeployment` keeps its legacy behavior (status flip only).
+   */
+  constructor(deployRunner?: AppDeployRunner) {
+    this.deployRunner = deployRunner;
+  }
+
   /**
    * Mark the app as building and stamp `last_deployed_at`.
    *
@@ -80,6 +92,23 @@ export class AppDeploymentsService {
     });
     if (!updated) {
       throw new Error("Failed to record deployment start");
+    }
+
+    // Apps lane (Product 2): if the real deploy backend is wired, kick off the
+    // isolated container provision. Best-effort — on failure mark the app
+    // errored so the caller's status poll reflects it. No-op (legacy stub
+    // behavior) when no runner is injected.
+    if (this.deployRunner) {
+      try {
+        await this.deployRunner.run(input.appId);
+      } catch (error) {
+        logger.error("[AppDeployments] deploy run failed", {
+          appId: input.appId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        await appsService.update(input.appId, { deployment_status: "failed" });
+        throw error;
+      }
     }
 
     logger.info("[AppDeployments] deployment queued", {

--- a/packages/cloud-shared/src/lib/services/app-docker-cmd.ts
+++ b/packages/cloud-shared/src/lib/services/app-docker-cmd.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure `docker create` command assembly for a user app container (Apps /
+ * Product 2). Mirrors the agent provider's flag-array style but composes the
+ * apps-lane isolation posture: the per-app `--internal` network (U4), dropped
+ * capabilities (U4), and an optional egress proxy — and deliberately OMITS the
+ * agent-only bits (eliza volume mounts, `--add-host host.docker.internal`,
+ * NET_ADMIN/tun). Reads no ambient env: any `DATABASE_URL` is the caller's
+ * per-tenant DSN passed via `environmentVars`, never sourced here.
+ *
+ * Pure string assembly so the exact run posture is a unit-testable contract;
+ * the real `ssh.exec` of this command lives in the (impure) provider.
+ */
+
+import {
+  appNetworkName,
+  buildAppContainerSecurityFlags,
+  buildAppEgressEnv,
+} from "./app-network-utils";
+import type { CreateContainerInput } from "./containers/hetzner-client/types";
+import { shellQuote } from "./docker-sandbox-utils";
+
+export interface BuildAppDockerCmdParams {
+  appId: string;
+  containerName: string;
+  /** The provider input (image, port, memoryMb, env, healthCheckPath). */
+  input: CreateContainerInput;
+  /** Externally allocated host port mapped to the container's app port. */
+  hostPort: number;
+  /** When set, route container HTTP(S) egress through this proxy. */
+  egressProxyUrl?: string;
+  pidsLimit?: number;
+}
+
+function appHealthCmd(port: number, path: string): string {
+  return `curl -fsS http://localhost:${port}${path} || exit 1`;
+}
+
+/** Build the `docker create` command for an isolated app container. */
+export function buildAppDockerCreateCmd(params: BuildAppDockerCmdParams): string {
+  const { input } = params;
+  const network = appNetworkName(params.appId);
+  const security = buildAppContainerSecurityFlags({ pidsLimit: params.pidsLimit });
+  const egress = params.egressProxyUrl ? buildAppEgressEnv(params.egressProxyUrl) : {};
+
+  // Default PORT, then caller env (may override PORT), then infra egress (wins).
+  const allEnv: Record<string, string> = {
+    PORT: String(input.port),
+    ...input.environmentVars,
+    ...egress,
+  };
+  const envFlags = Object.entries(allEnv)
+    .map(([key, value]) => `-e ${shellQuote(`${key}=${value}`)}`)
+    .join(" ");
+
+  return [
+    "docker create",
+    `--name ${shellQuote(params.containerName)}`,
+    "--restart unless-stopped",
+    `--network ${shellQuote(network)}`,
+    ...security,
+    `--health-cmd ${shellQuote(appHealthCmd(input.port, input.healthCheckPath ?? "/health"))}`,
+    "--health-interval 10s",
+    "--health-timeout 5s",
+    "--health-start-period 15s",
+    "--health-retries 6",
+    ...(input.memoryMb ? [`--memory ${shellQuote(`${Math.ceil(input.memoryMb)}m`)}`] : []),
+    `-p ${params.hostPort}:${input.port}`,
+    envFlags,
+    shellQuote(input.image),
+  ]
+    .filter((part) => part.length > 0)
+    .join(" ");
+}

--- a/packages/cloud-shared/src/lib/services/app-firewall-utils.ts
+++ b/packages/cloud-shared/src/lib/services/app-firewall-utils.ts
@@ -1,0 +1,71 @@
+/**
+ * App-node firewall builders (Apps / Product 2) — defense-in-depth on top of
+ * the per-app `--internal` network + egress proxy (U4). Pure config/rule
+ * builders so the posture is a unit-testable contract; applying them on a node
+ * is an operator/terraform step, VPS-validated, never done from here.
+ *
+ * Two layers: a host nftables ruleset that DROPs container traffic to the cloud
+ * metadata endpoint + RFC1918 ranges (so a container can't reach the
+ * instance-metadata service or pivot across the private network), and
+ * server-level Hetzner Cloud firewall rules.
+ */
+
+/** Cloud instance-metadata endpoint — must never be reachable from a tenant app. */
+export const CLOUD_METADATA_IP = "169.254.169.254";
+/** RFC1918 private ranges blocked from tenant containers. */
+export const RFC1918_RANGES = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"] as const;
+
+/**
+ * nftables ruleset for the forward chain on an app node: default-drop, block
+ * the metadata IP + private ranges from container egress, allow established
+ * return traffic and (optionally) the egress proxy. Belt-and-suspenders behind
+ * the `--internal` network.
+ */
+export function buildAppNodeNftablesRules(opts: { egressProxyIp?: string } = {}): string {
+  const blocks = [
+    `        ip daddr ${CLOUD_METADATA_IP} drop`,
+    ...RFC1918_RANGES.map((r) => `        ip daddr ${r} drop`),
+  ];
+  const allowProxy = opts.egressProxyIp ? [`        ip daddr ${opts.egressProxyIp} accept`] : [];
+  return [
+    "table inet app_isolation {",
+    "    chain forward {",
+    "        type filter hook forward priority 0; policy drop;",
+    "        ct state established,related accept",
+    ...blocks,
+    ...allowProxy,
+    "    }",
+    "}",
+  ].join("\n");
+}
+
+/** A Hetzner Cloud firewall rule (subset we use). */
+export interface HetznerFirewallRule {
+  direction: "in" | "out";
+  protocol: "tcp" | "udp" | "icmp";
+  port?: string;
+  source_ips?: string[];
+  destination_ips?: string[];
+  description?: string;
+}
+
+/**
+ * Server-level Hetzner firewall for an app node: allow inbound only from the
+ * control-plane/LB CIDRs on the host-port range that maps to app containers;
+ * everything else inbound is denied by Hetzner's default-deny. (Egress is
+ * governed by nftables + the proxy above.)
+ */
+export function buildHetznerAppFirewallRules(opts: {
+  controlPlaneCidrs: readonly string[];
+  hostPortRange: string;
+}): HetznerFirewallRule[] {
+  return [
+    {
+      direction: "in",
+      protocol: "tcp",
+      port: opts.hostPortRange,
+      source_ips: [...opts.controlPlaneCidrs],
+      description: "app container host ports — control plane / LB only",
+    },
+  ];
+}

--- a/packages/cloud-shared/src/lib/services/app-image-builder.ts
+++ b/packages/cloud-shared/src/lib/services/app-image-builder.ts
@@ -1,0 +1,70 @@
+/**
+ * AppImageBuilder (Apps / Product 2) — the impure build executor for the
+ * repo→image pipeline. Composes the pure ref/command builders
+ * ({@link buildAppImageRef}, {@link buildAppImageBuildCmd}) and runs them over
+ * an injected `exec` seam: SSH to a builder node in production, a local shell in
+ * verification. The ONLY IO is `exec`, so the orchestration is unit-testable
+ * with a fake and the same code path is exercised locally against real Docker.
+ *
+ * Decoupled from the deploy/run path: the builder yields a resolvable image ref;
+ * `app-deploy-runner.ts` resolves that ref and the container provider runs it.
+ */
+
+import { type AppBuildCmdParams, buildAppImageBuildCmd } from "./app-build-cmd";
+import { buildAppImageRef } from "./app-image-ref";
+
+/** Command-exec seam — structurally the same as `AppContainerSsh` (reusable). */
+export interface BuildExec {
+  exec(command: string, timeoutMs?: number): Promise<string>;
+}
+
+export interface AppImageBuildRequest {
+  /** Registry + namespace the image is tagged/pushed under. */
+  registry: string;
+  appId: string;
+  /** Git sha/branch built from (→ image tag); omitted → `latest`. */
+  sourceRef?: string;
+  /** Build context: local dir path or git URL. */
+  context: string;
+  /** Dockerfile path relative to the context. */
+  dockerfile?: string;
+  /** Push to the registry after build; else the image stays on the build host. */
+  push?: boolean;
+  /** Non-secret build args (baked into image history — never secrets). */
+  buildArgs?: Record<string, string>;
+}
+
+export interface AppImageBuildResult {
+  /** The resolvable `<registry>/app-<slug>:<tag>` the deploy step runs. */
+  imageRef: string;
+  /** Raw build output (stdout+stderr), for logs/diagnostics. */
+  buildOutput: string;
+}
+
+export class AppImageBuilder {
+  private readonly exec: BuildExec;
+  private readonly timeoutMs: number;
+
+  constructor(deps: { exec: BuildExec; timeoutMs?: number }) {
+    this.exec = deps.exec;
+    this.timeoutMs = deps.timeoutMs ?? 10 * 60_000;
+  }
+
+  /** Build (and optionally push) the app image; returns the resolvable ref. */
+  async build(req: AppImageBuildRequest): Promise<AppImageBuildResult> {
+    const imageRef = buildAppImageRef({
+      registry: req.registry,
+      appId: req.appId,
+      sourceRef: req.sourceRef,
+    });
+    const params: AppBuildCmdParams = {
+      context: req.context,
+      dockerfile: req.dockerfile,
+      imageRef,
+      push: req.push,
+      buildArgs: req.buildArgs,
+    };
+    const buildOutput = await this.exec.exec(buildAppImageBuildCmd(params), this.timeoutMs);
+    return { imageRef, buildOutput };
+  }
+}

--- a/packages/cloud-shared/src/lib/services/app-image-ref.ts
+++ b/packages/cloud-shared/src/lib/services/app-image-ref.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure image-reference derivation for the Apps / Product 2 build pipeline.
+ *
+ * A user app is built into an OCI image tagged per app + source ref, pushed to a
+ * registry, and resolved at deploy to run as an isolated container. These pure
+ * helpers turn (registry, appId, sourceRef) into a stable, registry-safe
+ * `<registry>/app-<slug>:<tag>` — no IO, so the naming contract is unit-tested.
+ *
+ * The app slug mirrors `deriveTenantIdent`'s slugging so an app's image, tenant
+ * DB, role, and container name all key off the same stable short id.
+ */
+
+/** Chars not allowed in a docker tag are collapsed to `-`. */
+const TAG_UNSAFE = /[^a-zA-Z0-9_.-]/g;
+
+/** Short, registry-safe slug of an app id (mirrors deriveTenantIdent's slug). */
+export function appImageSlug(appId: string): string {
+  const slug = appId
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "")
+    .slice(0, 24);
+  if (slug.length < 8) {
+    throw new Error(`appImageSlug: appId ${appId} yields too short a slug (${slug.length})`);
+  }
+  return slug;
+}
+
+/**
+ * Normalize a source ref (git sha or branch) into a valid docker tag. Docker
+ * tags can't start with `.`/`-` and are ≤128 chars; anything unsafe collapses
+ * to `-`. An empty/absent ref yields `latest`.
+ */
+export function deriveImageTag(sourceRef?: string): string {
+  if (!sourceRef) return "latest";
+  const tag = sourceRef
+    .replace(TAG_UNSAFE, "-")
+    .replace(/^[.-]+/, "")
+    .slice(0, 128);
+  return tag.length > 0 ? tag : "latest";
+}
+
+export interface AppImageRefParams {
+  /** Registry + namespace, e.g. `ghcr.io/elizaos` or `registry.local:5000/apps`. */
+  registry: string;
+  appId: string;
+  /** Git sha/branch the image was built from; omitted → `latest`. */
+  sourceRef?: string;
+}
+
+/** Build the full image reference `<registry>/app-<slug>:<tag>`. */
+export function buildAppImageRef(params: AppImageRefParams): string {
+  const registry = params.registry.replace(/\/+$/, "");
+  // Registry may carry a host, optional :port, and a namespace path.
+  if (!/^[a-zA-Z0-9._:/-]+$/.test(registry) || registry.length === 0) {
+    throw new Error(`buildAppImageRef: invalid registry "${params.registry}"`);
+  }
+  return `${registry}/app-${appImageSlug(params.appId)}:${deriveImageTag(params.sourceRef)}`;
+}

--- a/packages/cloud-shared/src/lib/services/app-image-resolver.ts
+++ b/packages/cloud-shared/src/lib/services/app-image-resolver.ts
@@ -1,0 +1,54 @@
+/**
+ * Build-from-repo image resolver (Apps / Product 2) — connects the build
+ * pipeline to the deploy runner. Returns a `resolveImage` (the shape
+ * `AppDeployRunner` calls) that BUILDS the app's image from its git repo via
+ * {@link AppImageBuilder} and returns the pushed, resolvable ref.
+ *
+ * Returns `undefined` when the app has no repo, so the deploy runner falls
+ * through to `app.metadata.imageTag` / `APP_DEFAULT_IMAGE` (e.g. a prebuilt or
+ * smoke-test image) — never an error for the no-repo case.
+ *
+ * Docker builds git URLs natively (`docker build <git-url>#ref:subdir`), so the
+ * repo URL is passed straight through as the build context — no clone step.
+ */
+
+import type { AppImageBuilder } from "./app-image-builder";
+
+export interface BuildFromRepoResolverDeps {
+  builder: AppImageBuilder;
+  /** Registry the image is tagged + pushed to. */
+  registry: string;
+  /** Dockerfile path within the repo. Default: docker's `Dockerfile`. */
+  dockerfile?: string;
+}
+
+interface ResolverApp {
+  id: string;
+  name: string;
+  metadata: Record<string, unknown>;
+  /** apps.github_repo — the primary build context source. */
+  repoUrl?: string;
+}
+
+/** A `resolveImage` that builds + pushes the app image from its repo. */
+export function makeBuildFromRepoResolver(
+  deps: BuildFromRepoResolverDeps,
+): (app: ResolverApp) => Promise<string | undefined> {
+  return async (app) => {
+    const metaRepo = typeof app.metadata?.repoUrl === "string" ? app.metadata.repoUrl : undefined;
+    const repo = app.repoUrl ?? metaRepo;
+    if (!repo) return undefined;
+
+    const sourceRef = typeof app.metadata?.ref === "string" ? app.metadata.ref : undefined;
+    const { imageRef } = await deps.builder.build({
+      registry: deps.registry,
+      appId: app.id,
+      context: repo,
+      dockerfile: deps.dockerfile,
+      sourceRef,
+      // Push so the deploy/worker node can pull the freshly built image.
+      push: true,
+    });
+    return imageRef;
+  };
+}

--- a/packages/cloud-shared/src/lib/services/app-network-utils.ts
+++ b/packages/cloud-shared/src/lib/services/app-network-utils.ts
@@ -1,0 +1,90 @@
+/**
+ * Per-tenant network isolation builders (Apps / Product 2).
+ *
+ * Untrusted user app containers must NOT share the agent network or reach the
+ * host/control plane. These pure builders produce the docker args that put each
+ * app on its OWN `--internal` network (no direct egress, no inter-tenant
+ * routing) behind a default-deny egress proxy, with capabilities dropped — the
+ * opposite of the agent path, which uses a plain shared bridge and (under
+ * headscale) NET_ADMIN + /dev/net/tun.
+ *
+ * Pure string/arg construction, so the isolation posture is a unit-testable
+ * contract; kernel enforcement (does --internal actually block egress?) is
+ * validated on a throwaway scratch network on the VPS, never here.
+ *
+ * ADDITIVE: nothing here touches the agent network config (`docker-sandbox-*`,
+ * `containers-isolated`, DOCKER_NETWORK) — that path stays exactly as-is.
+ */
+
+import { shellQuote } from "./docker-sandbox-utils";
+
+export const APP_NETWORK_DEFAULTS = {
+  /** Cap on processes to blunt fork bombs from untrusted images. */
+  pidsLimit: 512,
+} as const;
+
+/** Per-app docker network name (each tenant gets its own isolated network). */
+export function appNetworkName(appId: string): string {
+  const short = appId
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "")
+    .slice(0, 24);
+  return `app-net-${short}`;
+}
+
+/**
+ * Idempotently ensure a per-app `--internal` bridge exists. `--internal` is the
+ * load-bearing flag: containers on it have NO route off the network except via
+ * an explicitly-attached egress proxy. Mirrors the agent
+ * `buildEnsureNetworkCmd` shape but adds `--internal`.
+ */
+export function buildEnsureAppNetworkCmd(network: string): string {
+  const net = shellQuote(network);
+  return `docker network inspect ${net} >/dev/null 2>&1 || docker network create --driver bridge --internal ${net} >/dev/null 2>&1 || docker network inspect ${net} >/dev/null`;
+}
+
+/**
+ * Hardening flags for an untrusted app container. Drops ALL capabilities,
+ * forbids privilege escalation, and bounds processes. Deliberately NEVER emits
+ * NET_ADMIN, `--device /dev/net/tun`, `--privileged`, or
+ * `--add-host host.docker.internal:host-gateway` (the agent-only escapes).
+ */
+export function buildAppContainerSecurityFlags(opts: { pidsLimit?: number } = {}): string[] {
+  const pids = opts.pidsLimit ?? APP_NETWORK_DEFAULTS.pidsLimit;
+  return ["--cap-drop=ALL", "--security-opt", "no-new-privileges", `--pids-limit=${pids}`];
+}
+
+/**
+ * Env that routes all HTTP(S) egress through the per-node egress proxy so the
+ * default-deny allowlist (see {@link buildSquidAllowlistConf}) applies. Set on
+ * the app container; combined with `--internal` there is no other way out.
+ */
+export function buildAppEgressEnv(egressProxyUrl: string): Record<string, string> {
+  return {
+    HTTP_PROXY: egressProxyUrl,
+    HTTPS_PROXY: egressProxyUrl,
+    http_proxy: egressProxyUrl,
+    https_proxy: egressProxyUrl,
+    NO_PROXY: "localhost,127.0.0.1",
+    no_proxy: "localhost,127.0.0.1",
+  };
+}
+
+/**
+ * Build a default-deny Squid config that permits egress ONLY to the listed
+ * destination hosts. Anything not on the allowlist is refused, so a compromised
+ * app can't exfiltrate to or pivot through arbitrary hosts.
+ */
+export function buildSquidAllowlistConf(allowedHosts: readonly string[]): string {
+  const safe = allowedHosts.filter((h) => /^[A-Za-z0-9.*_-]+$/.test(h));
+  const acls = safe.map((h) => `acl allowed_dst dstdomain ${h}`).join("\n");
+  return [
+    "# Apps egress allowlist — default deny. Generated; do not hand-edit.",
+    "http_port 3128",
+    acls,
+    safe.length > 0 ? "http_access allow allowed_dst" : "",
+    "http_access deny all",
+  ]
+    .filter((line) => line.length > 0)
+    .join("\n");
+}

--- a/packages/cloud-shared/src/lib/services/app-url.ts
+++ b/packages/cloud-shared/src/lib/services/app-url.ts
@@ -1,0 +1,29 @@
+/**
+ * Per-app public URL derivation (Apps / Product 2).
+ *
+ * Apps are provisioned via the SSH `AppContainerProvider` path, which branches
+ * around the Hetzner client — so they never pass through the client's
+ * hostname/URL stamping. This reuses the SAME shared `derivePublicHostname`
+ * (the ingress map's source of truth) so an app container gets a public URL
+ * identical in shape to an agent container's, without rebuilding ingress and
+ * without editing the hot `hetzner-client/client.ts`.
+ *
+ * Returns null when `CONTAINERS_PUBLIC_BASE_DOMAIN` isn't configured (e.g. local
+ * dev), so callers simply skip URL stamping rather than writing a bogus value.
+ */
+
+import { derivePublicHostname } from "./containers/hetzner-client/paths";
+
+export interface AppPublicEndpoint {
+  /** `<shortid>.<base-domain>` — written to containers.public_hostname. */
+  hostname: string;
+  /** `https://<hostname>` — written to containers.load_balancer_url + apps.production_url. */
+  url: string;
+}
+
+/** Derive the app's public endpoint from its container id, or null if unconfigured. */
+export function deriveAppPublicUrl(containerId: string): AppPublicEndpoint | null {
+  const hostname = derivePublicHostname(containerId);
+  if (!hostname) return null;
+  return { hostname, url: `https://${hostname}` };
+}

--- a/packages/cloud-shared/src/lib/services/apps-deploy-backend.ts
+++ b/packages/cloud-shared/src/lib/services/apps-deploy-backend.ts
@@ -24,8 +24,8 @@
  */
 
 import { logger } from "../utils/logger";
+import { setAppDeployRunner } from "./app-deploy-job-service";
 import { makeNodeAppDeployRunner } from "./app-deploy-runner";
-import { appDeploymentsService } from "./app-deployments";
 import { AppImageBuilder, type BuildExec } from "./app-image-builder";
 import { makeBuildFromRepoResolver } from "./app-image-resolver";
 import { buildContainerExecutorDeps } from "./container-executor-deps";
@@ -66,7 +66,10 @@ export function configureAppsDeployBackend(config: AppsDeployBackendConfig): voi
     port: config.port,
   });
 
-  appDeploymentsService.setDeployRunner(runner);
+  // Daemon runs APP_DEPLOY jobs (enqueued by the Worker) via this runner, and
+  // CONTAINER_* jobs via the executor deps. createDeployment itself is never
+  // called here (it runs on the Worker, which enqueues APP_DEPLOY).
+  setAppDeployRunner(runner);
   setContainerExecutorDeps(buildContainerExecutorDeps);
 
   logger.info("[apps-deploy-backend] armed", {

--- a/packages/cloud-shared/src/lib/services/apps-deploy-backend.ts
+++ b/packages/cloud-shared/src/lib/services/apps-deploy-backend.ts
@@ -1,0 +1,76 @@
+/**
+ * NODE-ONLY boot composer for the Apps / Product 2 deploy backend — the single
+ * entrypoint that arms everything the foundation built, so wiring it in is one
+ * call. Composes:
+ *   - real per-tenant DB provisioning (makeTenantDbProvisioning -> ClusterPool ->
+ *     DirectPgExecutor) into a UserDatabaseService,
+ *   - the build-from-repo image resolver (AppImageBuilder over an SSH builder),
+ *   - the concrete node AppDeployRunner (ensure tenant DB -> create container row
+ *     carrying the per-tenant DSN -> enqueue CONTAINER_PROVISION -> link), injected
+ *     into the shared appDeploymentsService,
+ *   - the container executor backend (setContainerExecutorDeps), so the daemon's
+ *     CONTAINER_* dispatch resolves a real provider + store.
+ *
+ * NODE-ONLY: pulls in `pg` (DirectPgExecutor) + SSH; call it from the
+ * provisioning-worker daemon (or a node host of the deploy path), never from the
+ * cloud-api Worker (workerd can't load `pg`). Until this is called, the deploy
+ * path keeps its legacy stub behavior (status flip only) — so importing it is
+ * always safe; nothing connects until a deploy/CONTAINER_* job actually runs.
+ *
+ * The cloud-api deploy route still runs on the Worker; how it triggers this node
+ * flow (enqueue an APP_DEPLOY job the daemon claims, vs. a node deploy host) is
+ * the deploy-route-split decision — this composer is runtime-agnostic and works
+ * under either, so it doesn't pre-commit that choice.
+ */
+
+import { logger } from "../utils/logger";
+import { makeNodeAppDeployRunner } from "./app-deploy-runner";
+import { appDeploymentsService } from "./app-deployments";
+import { AppImageBuilder, type BuildExec } from "./app-image-builder";
+import { makeBuildFromRepoResolver } from "./app-image-resolver";
+import { buildContainerExecutorDeps } from "./container-executor-deps";
+import { setContainerExecutorDeps } from "./container-job-service";
+import { containerJobsWriter } from "./container-jobs-writer";
+import { makeTenantDbProvisioning } from "./tenant-db/make-tenant-db-provisioning";
+import { UserDatabaseService } from "./user-database";
+
+export interface AppsDeployBackendConfig {
+  /** Registry that app images are built + pushed to (e.g. `ghcr.io/elizaos`). */
+  registry: string;
+  /** Exec seam for the image builder — SSH to a builder node in production. */
+  buildExec: BuildExec;
+  /** Dockerfile path within each app's repo. Default: `Dockerfile`. */
+  dockerfile?: string;
+  /** App listen port. Default 3000. */
+  port?: number;
+}
+
+/**
+ * Arm the node-side Apps deploy backend. Call once at daemon boot. Safe to wire
+ * unconditionally — provisioning only runs when a real deploy / CONTAINER_* job
+ * is processed.
+ */
+export function configureAppsDeployBackend(config: AppsDeployBackendConfig): void {
+  const userDatabaseService = new UserDatabaseService(makeTenantDbProvisioning());
+  const builder = new AppImageBuilder({ exec: config.buildExec });
+  const resolveImage = makeBuildFromRepoResolver({
+    builder,
+    registry: config.registry,
+    dockerfile: config.dockerfile,
+  });
+
+  const runner = makeNodeAppDeployRunner({
+    userDatabaseService,
+    jobsWriter: containerJobsWriter,
+    resolveImage,
+    port: config.port,
+  });
+
+  appDeploymentsService.setDeployRunner(runner);
+  setContainerExecutorDeps(buildContainerExecutorDeps);
+
+  logger.info("[apps-deploy-backend] armed", {
+    registry: config.registry,
+    port: config.port ?? 3000,
+  });
+}

--- a/packages/cloud-shared/src/lib/services/container-executor-deps.ts
+++ b/packages/cloud-shared/src/lib/services/container-executor-deps.ts
@@ -1,0 +1,112 @@
+/**
+ * Container-executor deps composition (Apps / Product 2) — builds the
+ * `{ provider, store }` backend that `setContainerExecutorDeps` injects, so the
+ * daemon's `getContainerExecutorDeps()` resolves a REAL provider (SSH -> docker
+ * on a worker node) + the REAL container store (over `containers`).
+ *
+ * Kept in cloud-shared (not the daemon file) so the daemon edit stays a one-line
+ * `setContainerExecutorDeps(buildContainerExecutorDeps)` and the composition is
+ * unit-testable / reusable. NODE-ONLY: it uses `DockerSSHClient` (ssh2) and is
+ * wired only into the node daemon — never the Worker.
+ *
+ * FEATURE GATE: returns deps that throw a clear error if the apps-container
+ * backend isn't configured (no docker nodes / no SSH key), so wiring it in is
+ * safe even before infra env is present — provision only runs when a
+ * CONTAINER_* job is claimed AND the env is set. Set `APPS_CONTAINERS_ENABLED=1`
+ * (or rely on `CONTAINERS_DOCKER_NODES` being present) to arm it.
+ */
+
+import { Buffer } from "node:buffer";
+import { containersEnv } from "../config/containers-env";
+import { logger } from "../utils/logger";
+import { AppContainerProvider, type AppContainerSsh } from "./app-container-provider";
+import { appContainerStore } from "./app-container-store";
+import type { ContainerExecutorDeps } from "./container-job-executors";
+import { DockerSSHClient } from "./docker-ssh";
+
+/** True when the apps-container provision backend has enough env to run. */
+export function appsContainersEnabled(): boolean {
+  if (process.env.APPS_CONTAINERS_ENABLED === "0") return false;
+  const hasNodes = Boolean(selectNodeHostOrNull());
+  const hasKey = Boolean(containersEnv.sshKey() || containersEnv.sshKeyPath());
+  return hasNodes && hasKey;
+}
+
+/**
+ * Pick a target docker node host. Reads the `CONTAINERS_DOCKER_NODES` seed list
+ * (`nodeId:hostname:capacity,...`) and takes the first entry's hostname. This is
+ * the seed-only fallback; the production daemon should prefer
+ * `dockerNodeManager`'s registered-node selection (least-loaded / autoscaled) —
+ * see the wiring note. Returns null when nothing is configured.
+ */
+function selectNodeHostOrNull(): string | null {
+  const seed = containersEnv.seedNodes();
+  if (!seed) return null;
+  const first = seed.split(",")[0]?.trim();
+  if (!first) return null;
+  // Format: nodeId:hostname:capacity. Hostname is the 2nd colon field; fall back
+  // to the whole token if it's a bare hostname.
+  const parts = first.split(":");
+  const host = parts.length >= 2 ? parts[1]?.trim() : parts[0]?.trim();
+  return host || null;
+}
+
+function selectNodeHost(): string {
+  const host = selectNodeHostOrNull();
+  if (!host) {
+    throw new Error(
+      "No CONTAINERS_DOCKER_NODES configured — cannot provision app container (set the docker node host)",
+    );
+  }
+  return host;
+}
+
+/** A pooled SSH connection to the chosen node, exposing the `AppContainerSsh` seam. */
+function makeNodeSsh(): AppContainerSsh {
+  const host = selectNodeHost();
+  const keyB64 = containersEnv.sshKey();
+  const privateKey = keyB64 ? Buffer.from(keyB64, "base64") : undefined;
+  // DockerSSHClient.exec(command, timeoutMs?) IS the AppContainerSsh shape.
+  const client = privateKey
+    ? new DockerSSHClient({ hostname: host, username: containersEnv.sshUser(), privateKey })
+    : new DockerSSHClient({
+        hostname: host,
+        username: containersEnv.sshUser(),
+        privateKeyPath: containersEnv.sshKeyPath(),
+      });
+  return { exec: (command, timeoutMs) => client.exec(command, timeoutMs) };
+}
+
+/**
+ * Allocate an external host port for the container's app port. Ephemeral-range
+ * picker; the deploy density is low (one container per app) so a random pick
+ * from the high range is collision-safe enough for now. A node-local registry /
+ * `docker port` probe is the hardening follow-up.
+ */
+async function allocateHostPort(): Promise<number> {
+  const MIN = 20000;
+  const MAX = 39999;
+  return MIN + Math.floor(Math.random() * (MAX - MIN + 1));
+}
+
+/**
+ * Build the executor backend. Pass to `setContainerExecutorDeps(() => ...)`.
+ * Throws (lazily, when a job actually runs) if the backend isn't configured —
+ * so wiring it is always safe; nothing connects until a CONTAINER_* job lands.
+ */
+export function buildContainerExecutorDeps(): ContainerExecutorDeps {
+  if (!appsContainersEnabled()) {
+    throw new Error(
+      "Apps container backend not configured (need CONTAINERS_DOCKER_NODES + CONTAINERS_SSH_KEY/_PATH). " +
+        "A CONTAINER_* job was claimed but cannot be provisioned.",
+    );
+  }
+  const ssh = makeNodeSsh();
+  const egressProxyUrl = process.env.CONTAINERS_EGRESS_PROXY_URL || undefined;
+  const provider = new AppContainerProvider({ ssh, allocateHostPort, egressProxyUrl });
+  logger.info("[container-executor-deps] built apps container backend", {
+    node: selectNodeHost(),
+    egressProxy: Boolean(egressProxyUrl),
+  });
+  return { provider, store: appContainerStore };
+}

--- a/packages/cloud-shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud-shared/src/lib/services/container-job-executors.ts
@@ -19,6 +19,7 @@ import {
   readContainerLogsJobData,
   readContainerProvisionJobData,
   readContainerRestartJobData,
+  readContainerUpgradeJobData,
 } from "./container-jobs-data";
 
 /** The fields an executor needs from an app container row. */
@@ -114,4 +115,47 @@ export async function executeContainerLogs(
   const data = readContainerLogsJobData(job);
   const row = await requireRow(deps.store, data.containerId);
   return deps.provider.logs(row.containerName, data.tail);
+}
+
+/**
+ * Re-deploy a container onto a (possibly new) image: best-effort remove the old
+ * container, then provision afresh and mark running. Brief downtime; blue/green
+ * is a later refinement.
+ */
+export async function executeContainerUpgrade(
+  job: JobLike,
+  deps: ContainerExecutorDeps,
+): Promise<void> {
+  const data = readContainerUpgradeJobData(job);
+  const row = await requireRow(deps.store, data.containerId);
+  await deps.provider.delete(row.containerName).catch(() => {
+    // old container may already be gone; provisioning replaces it regardless
+  });
+  const input = buildContainerProvisionInput({
+    name: row.containerName,
+    projectName: row.appId,
+    organizationId: row.organizationId,
+    userId: row.userId,
+    image: data.image ?? row.image,
+    port: row.port,
+    environmentVars: row.environmentVars,
+  });
+  try {
+    const result = await deps.provider.provision({
+      appId: row.appId,
+      containerName: row.containerName,
+      input,
+    });
+    await deps.store.markRunning(data.containerId, {
+      hostContainerId: result.containerId,
+      hostPort: result.hostPort,
+      network: result.network,
+    });
+  } catch (error) {
+    await deps.store.markError(
+      data.containerId,
+      error instanceof Error ? error.message : String(error),
+    );
+    throw error;
+  }
 }

--- a/packages/cloud-shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud-shared/src/lib/services/container-job-executors.ts
@@ -12,7 +12,6 @@
  */
 
 import type { AppContainerProvider } from "./app-container-provider";
-import { buildContainerProvisionInput } from "./container-provider-input";
 import {
   type JobLike,
   readContainerDeleteJobData,
@@ -21,6 +20,7 @@ import {
   readContainerRestartJobData,
   readContainerUpgradeJobData,
 } from "./container-jobs-data";
+import { buildContainerProvisionInput } from "./container-provider-input";
 
 /** The fields an executor needs from an app container row. */
 export interface AppContainerRow {

--- a/packages/cloud-shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud-shared/src/lib/services/container-job-executors.ts
@@ -1,0 +1,117 @@
+/**
+ * CONTAINER_* job executors (Apps / Product 2) — the per-type handlers the
+ * provisioning daemon runs for app containers. Kept as a standalone, fully
+ * dependency-injected module so the dispatch + state transitions are
+ * unit-testable with fakes; the integration into `provisioning-jobs.ts` is a
+ * thin set of `case JOB_TYPES.CONTAINER_*` arms that delegate here (appended,
+ * never replacing the AGENT_* arms).
+ *
+ * Decoupled from 2AM's `containers` table: it reads/writes app container rows
+ * through an injected {@link AppContainerStore}, so it never imports that schema
+ * or repo directly.
+ */
+
+import type { AppContainerProvider } from "./app-container-provider";
+import { buildContainerProvisionInput } from "./container-provider-input";
+import {
+  type JobLike,
+  readContainerDeleteJobData,
+  readContainerLogsJobData,
+  readContainerProvisionJobData,
+  readContainerRestartJobData,
+} from "./container-jobs-data";
+
+/** The fields an executor needs from an app container row. */
+export interface AppContainerRow {
+  id: string;
+  appId: string;
+  containerName: string;
+  image: string;
+  port: number;
+  organizationId: string;
+  userId: string;
+  /** Caller env incl. the app's per-tenant DATABASE_URL (never the shared one). */
+  environmentVars?: Record<string, string>;
+}
+
+/** Read/write seam for app container state (over the `containers` table). */
+export interface AppContainerStore {
+  getById(containerId: string): Promise<AppContainerRow | null>;
+  markRunning(
+    containerId: string,
+    info: { hostContainerId: string; hostPort: number; network: string },
+  ): Promise<void>;
+  markDeleted(containerId: string): Promise<void>;
+  markError(containerId: string, error: string): Promise<void>;
+}
+
+export interface ContainerExecutorDeps {
+  provider: AppContainerProvider;
+  store: AppContainerStore;
+}
+
+async function requireRow(store: AppContainerStore, containerId: string): Promise<AppContainerRow> {
+  const row = await store.getById(containerId);
+  if (!row) throw new Error(`App container ${containerId} not found`);
+  return row;
+}
+
+export async function executeContainerProvision(
+  job: JobLike,
+  deps: ContainerExecutorDeps,
+): Promise<void> {
+  const { containerId } = readContainerProvisionJobData(job);
+  const row = await requireRow(deps.store, containerId);
+  const input = buildContainerProvisionInput({
+    name: row.containerName,
+    projectName: row.appId,
+    organizationId: row.organizationId,
+    userId: row.userId,
+    image: row.image,
+    port: row.port,
+    environmentVars: row.environmentVars,
+  });
+  try {
+    const result = await deps.provider.provision({
+      appId: row.appId,
+      containerName: row.containerName,
+      input,
+    });
+    await deps.store.markRunning(containerId, {
+      hostContainerId: result.containerId,
+      hostPort: result.hostPort,
+      network: result.network,
+    });
+  } catch (error) {
+    await deps.store.markError(containerId, error instanceof Error ? error.message : String(error));
+    throw error;
+  }
+}
+
+export async function executeContainerDelete(
+  job: JobLike,
+  deps: ContainerExecutorDeps,
+): Promise<void> {
+  const { containerId } = readContainerDeleteJobData(job);
+  const row = await deps.store.getById(containerId);
+  if (row) await deps.provider.delete(row.containerName);
+  await deps.store.markDeleted(containerId);
+}
+
+export async function executeContainerRestart(
+  job: JobLike,
+  deps: ContainerExecutorDeps,
+): Promise<void> {
+  const { containerId } = readContainerRestartJobData(job);
+  const row = await requireRow(deps.store, containerId);
+  await deps.provider.restart(row.containerName);
+}
+
+export async function executeContainerLogs(
+  job: JobLike,
+  deps: ContainerExecutorDeps,
+): Promise<string> {
+  const data = readContainerLogsJobData(job);
+  const row = await requireRow(deps.store, data.containerId);
+  return deps.provider.logs(row.containerName, data.tail);
+}

--- a/packages/cloud-shared/src/lib/services/container-job-service.ts
+++ b/packages/cloud-shared/src/lib/services/container-job-service.ts
@@ -1,0 +1,162 @@
+/**
+ * CONTAINER_* job service (Apps / Product 2) — the glue between the daemon's
+ * job switch and the executor logic, plus enqueue helpers. Kept OUT of the
+ * agent-coupled `provisioning-jobs.ts` (whose enqueue path advisory-locks
+ * `agent_sandboxes`): containers have no agent row, so they get their own
+ * enqueue path here over an injected jobs writer. The only edit to
+ * `provisioning-jobs.ts` is appending CONTAINER_* switch cases that call
+ * {@link dispatchContainerJob} — additive, never touching the AGENT_* arms.
+ *
+ * The executor backend (real provider + container store) is provided at runtime
+ * via {@link setContainerExecutorDeps} (wired in U3c / on the stack), so this
+ * module imports no DB/SSH and stays unit-testable.
+ */
+
+import {
+  type ContainerExecutorDeps,
+  executeContainerDelete,
+  executeContainerLogs,
+  executeContainerProvision,
+  executeContainerRestart,
+  executeContainerUpgrade,
+} from "./container-job-executors";
+import {
+  containerDeleteJobDataToRecord,
+  containerLogsJobDataToRecord,
+  containerProvisionJobDataToRecord,
+  containerRestartJobDataToRecord,
+  containerUpgradeJobDataToRecord,
+  type JobLike,
+} from "./container-jobs-data";
+import { JOB_TYPES } from "./provisioning-job-types";
+
+const CONTAINER_JOB_TYPES: ReadonlySet<string> = new Set([
+  JOB_TYPES.CONTAINER_PROVISION,
+  JOB_TYPES.CONTAINER_DELETE,
+  JOB_TYPES.CONTAINER_RESTART,
+  JOB_TYPES.CONTAINER_UPGRADE,
+  JOB_TYPES.CONTAINER_LOGS,
+]);
+
+/** True for the CONTAINER_* job types this service owns. */
+export function isContainerJobType(type: string): boolean {
+  return CONTAINER_JOB_TYPES.has(type);
+}
+
+/** Route a CONTAINER_* job to its executor. */
+export async function dispatchContainerJob(
+  job: JobLike & { type: string },
+  deps: ContainerExecutorDeps,
+): Promise<void> {
+  switch (job.type) {
+    case JOB_TYPES.CONTAINER_PROVISION:
+      await executeContainerProvision(job, deps);
+      return;
+    case JOB_TYPES.CONTAINER_DELETE:
+      await executeContainerDelete(job, deps);
+      return;
+    case JOB_TYPES.CONTAINER_RESTART:
+      await executeContainerRestart(job, deps);
+      return;
+    case JOB_TYPES.CONTAINER_UPGRADE:
+      await executeContainerUpgrade(job, deps);
+      return;
+    case JOB_TYPES.CONTAINER_LOGS:
+      await executeContainerLogs(job, deps);
+      return;
+    default:
+      throw new Error(`Not a container job type: ${job.type}`);
+  }
+}
+
+// ── runtime-injected executor backend ────────────────────────────────────────
+
+let depsFactory: (() => ContainerExecutorDeps) | null = null;
+
+/** Wire the real executor backend (provider + store). Called in U3c / on boot. */
+export function setContainerExecutorDeps(factory: () => ContainerExecutorDeps): void {
+  depsFactory = factory;
+}
+
+/** Resolve the executor backend, or throw if it hasn't been wired yet. */
+export function getContainerExecutorDeps(): ContainerExecutorDeps {
+  if (!depsFactory) {
+    throw new Error("Container executor backend not configured — call setContainerExecutorDeps()");
+  }
+  return depsFactory();
+}
+
+// ── enqueue ──────────────────────────────────────────────────────────────────
+
+export interface ContainerJobInsert {
+  type: string;
+  organizationId: string;
+  userId?: string;
+  data: Record<string, unknown>;
+}
+
+/** Insert seam — the real writer wraps jobsRepository/dbWrite (integration). */
+export interface ContainerJobsWriter {
+  insertJob(job: ContainerJobInsert): Promise<{ id: string }>;
+}
+
+export class ContainerJobEnqueuer {
+  private readonly writer: ContainerJobsWriter;
+
+  constructor(writer: ContainerJobsWriter) {
+    this.writer = writer;
+  }
+
+  enqueueProvision(p: {
+    containerId: string;
+    organizationId: string;
+    userId: string;
+  }): Promise<{ id: string }> {
+    return this.writer.insertJob({
+      type: JOB_TYPES.CONTAINER_PROVISION,
+      organizationId: p.organizationId,
+      userId: p.userId,
+      data: containerProvisionJobDataToRecord(p),
+    });
+  }
+
+  enqueueDelete(p: { containerId: string; organizationId: string }): Promise<{ id: string }> {
+    return this.writer.insertJob({
+      type: JOB_TYPES.CONTAINER_DELETE,
+      organizationId: p.organizationId,
+      data: containerDeleteJobDataToRecord(p),
+    });
+  }
+
+  enqueueRestart(p: { containerId: string; organizationId: string }): Promise<{ id: string }> {
+    return this.writer.insertJob({
+      type: JOB_TYPES.CONTAINER_RESTART,
+      organizationId: p.organizationId,
+      data: containerRestartJobDataToRecord(p),
+    });
+  }
+
+  enqueueUpgrade(p: {
+    containerId: string;
+    organizationId: string;
+    image?: string;
+  }): Promise<{ id: string }> {
+    return this.writer.insertJob({
+      type: JOB_TYPES.CONTAINER_UPGRADE,
+      organizationId: p.organizationId,
+      data: containerUpgradeJobDataToRecord(p),
+    });
+  }
+
+  enqueueLogs(p: {
+    containerId: string;
+    organizationId: string;
+    tail?: number;
+  }): Promise<{ id: string }> {
+    return this.writer.insertJob({
+      type: JOB_TYPES.CONTAINER_LOGS,
+      organizationId: p.organizationId,
+      data: containerLogsJobDataToRecord(p),
+    });
+  }
+}

--- a/packages/cloud-shared/src/lib/services/container-jobs-data.ts
+++ b/packages/cloud-shared/src/lib/services/container-jobs-data.ts
@@ -1,0 +1,145 @@
+/**
+ * Wire shapes + codecs for the CONTAINER_* (Apps / Product 2) job lane.
+ *
+ * Mirrors the AGENT_* job-data codecs in `provisioning-jobs.ts` (an interface
+ * per job type + an `is*` runtime guard + a `read*` that validates a job row's
+ * `data` + a `*ToRecord` for persistence), but for the generic app-container
+ * lifecycle. Kept in its own module so the apps lane never touches the agent
+ * codecs, and intentionally dependency-free: it reads from a structural
+ * `JobLike` rather than importing the `Job`/queue types, so the whole contract
+ * is unit-testable with no DB/queue/docker imports.
+ */
+
+/** Minimal structural view of a queue job row — the real `Job` is assignable. */
+export interface JobLike {
+  id: string;
+  data: unknown;
+}
+
+export interface ContainerProvisionJobData {
+  containerId: string;
+  organizationId: string;
+  userId: string;
+}
+
+export interface ContainerDeleteJobData {
+  containerId: string;
+  organizationId: string;
+}
+
+export interface ContainerRestartJobData {
+  containerId: string;
+  organizationId: string;
+}
+
+export interface ContainerUpgradeJobData {
+  containerId: string;
+  organizationId: string;
+  /** Optional new image reference; omit to re-pull the current tag. */
+  image?: string;
+}
+
+export interface ContainerLogsJobData {
+  containerId: string;
+  organizationId: string;
+  /** Number of trailing log lines to fetch. */
+  tail?: number;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function hasStrings(value: unknown, keys: readonly string[]): boolean {
+  if (!isRecord(value)) return false;
+  return keys.every((k) => typeof value[k] === "string");
+}
+
+export function isContainerProvisionJobData(value: unknown): value is ContainerProvisionJobData {
+  return hasStrings(value, ["containerId", "organizationId", "userId"]);
+}
+
+export function isContainerDeleteJobData(value: unknown): value is ContainerDeleteJobData {
+  return hasStrings(value, ["containerId", "organizationId"]);
+}
+
+export function isContainerRestartJobData(value: unknown): value is ContainerRestartJobData {
+  return hasStrings(value, ["containerId", "organizationId"]);
+}
+
+export function isContainerUpgradeJobData(value: unknown): value is ContainerUpgradeJobData {
+  return (
+    hasStrings(value, ["containerId", "organizationId"]) &&
+    (!isRecord(value) || value.image === undefined || typeof value.image === "string")
+  );
+}
+
+export function isContainerLogsJobData(value: unknown): value is ContainerLogsJobData {
+  return (
+    hasStrings(value, ["containerId", "organizationId"]) &&
+    (!isRecord(value) || value.tail === undefined || typeof value.tail === "number")
+  );
+}
+
+export function readContainerProvisionJobData(job: JobLike): ContainerProvisionJobData {
+  if (!isContainerProvisionJobData(job.data)) {
+    throw new Error(`Invalid container provision job data for job ${job.id}`);
+  }
+  return job.data;
+}
+
+export function readContainerDeleteJobData(job: JobLike): ContainerDeleteJobData {
+  if (!isContainerDeleteJobData(job.data)) {
+    throw new Error(`Invalid container delete job data for job ${job.id}`);
+  }
+  return job.data;
+}
+
+export function readContainerRestartJobData(job: JobLike): ContainerRestartJobData {
+  if (!isContainerRestartJobData(job.data)) {
+    throw new Error(`Invalid container restart job data for job ${job.id}`);
+  }
+  return job.data;
+}
+
+export function readContainerUpgradeJobData(job: JobLike): ContainerUpgradeJobData {
+  if (!isContainerUpgradeJobData(job.data)) {
+    throw new Error(`Invalid container upgrade job data for job ${job.id}`);
+  }
+  return job.data;
+}
+
+export function readContainerLogsJobData(job: JobLike): ContainerLogsJobData {
+  if (!isContainerLogsJobData(job.data)) {
+    throw new Error(`Invalid container logs job data for job ${job.id}`);
+  }
+  return job.data;
+}
+
+export function containerProvisionJobDataToRecord(
+  data: ContainerProvisionJobData,
+): Record<string, unknown> {
+  return { ...data };
+}
+
+export function containerDeleteJobDataToRecord(
+  data: ContainerDeleteJobData,
+): Record<string, unknown> {
+  return { ...data };
+}
+
+export function containerRestartJobDataToRecord(
+  data: ContainerRestartJobData,
+): Record<string, unknown> {
+  return { ...data };
+}
+
+export function containerUpgradeJobDataToRecord(
+  data: ContainerUpgradeJobData,
+): Record<string, unknown> {
+  return { ...data };
+}
+
+export function containerLogsJobDataToRecord(data: ContainerLogsJobData): Record<string, unknown> {
+  return { ...data };
+}

--- a/packages/cloud-shared/src/lib/services/container-jobs-writer.ts
+++ b/packages/cloud-shared/src/lib/services/container-jobs-writer.ts
@@ -1,0 +1,47 @@
+/**
+ * ContainerJobsWriter (Apps / Product 2) — the integration backing for the
+ * {@link ContainerJobsWriter} insert seam declared in `container-job-service.ts`.
+ *
+ * `ContainerJobEnqueuer` (in container-job-service.ts) builds the typed
+ * CONTAINER_* job payloads and delegates persistence to this writer, which wraps
+ * the existing `jobsRepository.create` (no second queue, no advisory-lock dance —
+ * the agent enqueue path advisory-locks `agent_sandboxes`, but containers have no
+ * agent row, so they take this plain insert path).
+ *
+ * Maps `ContainerJobInsert` -> `NewJob`:
+ *   - type            -> jobs.type            (e.g. "container_provision")
+ *   - organizationId  -> jobs.organization_id (NOT NULL FK; required)
+ *   - userId          -> jobs.user_id         (nullable FK; null when absent)
+ *   - data            -> jobs.data            (jsonb; the typed container payload)
+ *
+ * `agent_id` / `character_id` stay NULL: the indexed-field extractor in
+ * `jobs.ts` reads them from `data.agentId` / `data.characterId`, and container
+ * job data carries neither (see `container-jobs-data.ts`), so both index columns
+ * are correctly null. The daemon claims these rows by `type` alongside the
+ * agent jobs (`claimPendingJobs` has no org/agent filter in cron mode), and the
+ * `executeJob` switch routes CONTAINER_* to `dispatchContainerJob`.
+ *
+ * Server-only (node + Worker both fine — this is a plain DB insert, no `pg`).
+ */
+
+import { jobsRepository } from "../../db/repositories/jobs";
+import type { ContainerJobInsert, ContainerJobsWriter } from "./container-job-service";
+
+/** Real writer over `jobsRepository`. Construct once; inject into ContainerJobEnqueuer. */
+export class JobsRepositoryContainerJobsWriter implements ContainerJobsWriter {
+  async insertJob(job: ContainerJobInsert): Promise<{ id: string }> {
+    const created = await jobsRepository.create({
+      type: job.type,
+      organization_id: job.organizationId,
+      // user_id is a nullable FK; container jobs may be enqueued without a user
+      // (e.g. system-driven delete/restart). Pass null rather than undefined so
+      // the column is explicitly cleared rather than relying on insert defaults.
+      user_id: job.userId ?? null,
+      data: job.data,
+    });
+    return { id: created.id };
+  }
+}
+
+/** Singleton — the cloud-api route side and the daemon both reuse this instance. */
+export const containerJobsWriter: ContainerJobsWriter = new JobsRepositoryContainerJobsWriter();

--- a/packages/cloud-shared/src/lib/services/container-provider-input.ts
+++ b/packages/cloud-shared/src/lib/services/container-provider-input.ts
@@ -1,0 +1,106 @@
+/**
+ * Build a `CreateContainerInput` for a user-deployed app container (Apps /
+ * Product 2), from app-level parameters + sensible defaults.
+ *
+ * This is the apps-lane counterpart to the agent provisioning path, and it
+ * exists to enforce ONE load-bearing invariant as a pure, unit-testable
+ * contract: **it never auto-injects `DATABASE_URL`.** The agent path
+ * deliberately force-overwrites `DATABASE_URL` with the shared cluster URL
+ * *after* spreading caller env (so an agent can't bring its own DB); the apps
+ * path must do the opposite — it reads no `process.env`, and forwards only the
+ * caller-supplied `environmentVars` verbatim. The per-tenant isolated DSN (a
+ * later unit) is passed IN by the caller via `environmentVars`; it is never
+ * sourced from the shared environment here.
+ */
+
+import type { CreateContainerInput } from "./containers/hetzner-client/types";
+
+/** Defaults for a small stateless web app. All overridable per-call. */
+export const APP_CONTAINER_DEFAULTS = {
+  port: 3000,
+  desiredCount: 1,
+  cpu: 1,
+  memoryMb: 512,
+  healthCheckPath: "/health",
+} as const;
+
+export interface ContainerProvisionParams {
+  /** Container name (unique within the org/project). */
+  name: string;
+  /** Project the container belongs to (keys the persistent volume). */
+  projectName: string;
+  organizationId: string;
+  userId: string;
+  apiKeyId?: string | null;
+  description?: string;
+  /** Full image reference, e.g. `ghcr.io/owner/app:tag`. */
+  image: string;
+  /** App listen port. Default 3000. */
+  port?: number;
+  /** Replicas (must be 1 on the shared pool). Default 1. */
+  desiredCount?: number;
+  /** CPU units (billing/compat). Default 1. */
+  cpu?: number;
+  /** Memory MB (`docker run --memory`). Default 512. */
+  memoryMb?: number;
+  /** Health-check path probed by the cron monitor. Default `/health`. */
+  healthCheckPath?: string;
+  /**
+   * Environment forwarded into the container verbatim. The caller owns this —
+   * including any per-tenant `DATABASE_URL`. This builder never adds, removes,
+   * or overwrites entries here.
+   */
+  environmentVars?: Record<string, string>;
+  /** Mount a project-scoped persistent volume. Default false. */
+  persistVolume?: boolean;
+}
+
+/**
+ * Pure builder: app params -> `CreateContainerInput`. Applies
+ * {@link APP_CONTAINER_DEFAULTS} for any unset field and forwards
+ * `environmentVars` unchanged. Reads no ambient environment.
+ */
+export function buildContainerProvisionInput(
+  params: ContainerProvisionParams,
+): CreateContainerInput {
+  if (!params.name) {
+    throw new TypeError("buildContainerProvisionInput: name is required");
+  }
+  if (!params.projectName) {
+    throw new TypeError("buildContainerProvisionInput: projectName is required");
+  }
+  if (!params.image) {
+    throw new TypeError("buildContainerProvisionInput: image is required");
+  }
+  if (!params.organizationId || !params.userId) {
+    throw new TypeError("buildContainerProvisionInput: organizationId and userId are required");
+  }
+
+  const input: CreateContainerInput = {
+    name: params.name,
+    projectName: params.projectName,
+    organizationId: params.organizationId,
+    userId: params.userId,
+    apiKeyId: params.apiKeyId ?? null,
+    image: params.image,
+    port: params.port ?? APP_CONTAINER_DEFAULTS.port,
+    desiredCount: params.desiredCount ?? APP_CONTAINER_DEFAULTS.desiredCount,
+    cpu: params.cpu ?? APP_CONTAINER_DEFAULTS.cpu,
+    memoryMb: params.memoryMb ?? APP_CONTAINER_DEFAULTS.memoryMb,
+    healthCheckPath: params.healthCheckPath ?? APP_CONTAINER_DEFAULTS.healthCheckPath,
+  };
+
+  if (params.description !== undefined) {
+    input.description = params.description;
+  }
+  if (params.persistVolume !== undefined) {
+    input.persistVolume = params.persistVolume;
+  }
+  // Forward caller env verbatim — never source DATABASE_URL (or anything) from
+  // the ambient/shared environment. Copy so callers can't mutate our output.
+  if (params.environmentVars) {
+    input.environmentVars = { ...params.environmentVars };
+  }
+
+  return input;
+}

--- a/packages/cloud-shared/src/lib/services/provisioning-job-types.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-job-types.ts
@@ -52,6 +52,14 @@ export const JOB_TYPES = {
   CONTAINER_UPGRADE: "container_upgrade",
   /** Fetch recent logs from an app container. */
   CONTAINER_LOGS: "container_logs",
+  /**
+   * Run the full app deploy on a node host (Apps / Product 2): the cloud-api
+   * Worker enqueues this (pg-free) and the provisioning-worker daemon claims it,
+   * runs the node AppDeployRunner (ensure tenant DB -> create container row with
+   * the per-tenant DSN -> enqueue CONTAINER_PROVISION -> link), keeping all
+   * `pg`/SSH off the workerd request path.
+   */
+  APP_DEPLOY: "app_deploy",
 } as const;
 
 export type ProvisioningJobType = (typeof JOB_TYPES)[keyof typeof JOB_TYPES];

--- a/packages/cloud-shared/src/lib/services/provisioning-job-types.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-job-types.ts
@@ -34,6 +34,24 @@ export const JOB_TYPES = {
    * inverse of `agent_sleep`.
    */
   AGENT_WAKE: "agent_wake",
+
+  // ── Apps lane (Product 2) ──────────────────────────────────────────────
+  // Generic, image-agnostic container lifecycle for user-deployed apps —
+  // distinct from the AGENT_* lane above. These rows target the `containers`
+  // table (not `agent_sandboxes`), carry NO eliza scaffolding, and NEVER
+  // receive the shared agent DATABASE_URL. The daemon picks them up via the
+  // same `Object.values(JOB_TYPES)` scan, so registering them here is enough;
+  // executors are added separately and never alter the AGENT_* arms.
+  /** Provision a generic app container from a caller-supplied image. */
+  CONTAINER_PROVISION: "container_provision",
+  /** Stop + remove an app container and free its slot. */
+  CONTAINER_DELETE: "container_delete",
+  /** Restart an app container in place. */
+  CONTAINER_RESTART: "container_restart",
+  /** Re-deploy an app container onto a new image. */
+  CONTAINER_UPGRADE: "container_upgrade",
+  /** Fetch recent logs from an app container. */
+  CONTAINER_LOGS: "container_logs",
 } as const;
 
 export type ProvisioningJobType = (typeof JOB_TYPES)[keyof typeof JOB_TYPES];

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -29,6 +29,7 @@ import { assertSafeOutboundUrl } from "../security/outbound-url";
 import { logger } from "../utils/logger";
 import { elizaProvisionAdvisoryLockSql } from "./eliza-provision-lock";
 import { elizaSandboxService } from "./eliza-sandbox";
+import { dispatchContainerJob, getContainerExecutorDeps } from "./container-job-service";
 import { JOB_TYPES, type ProvisioningJobType } from "./provisioning-job-types";
 import {
   isWaifuWebhookTargetUrl,
@@ -1450,6 +1451,16 @@ export class ProvisioningJobService {
         break;
       case JOB_TYPES.AGENT_SNAPSHOT:
         await this.executeAgentSnapshot(job);
+        break;
+      // Apps lane (Product 2): generic app-container lifecycle. Routed to the
+      // standalone container-job-service (kept out of the agent-coupled paths
+      // above); the executor backend is wired at boot via setContainerExecutorDeps.
+      case JOB_TYPES.CONTAINER_PROVISION:
+      case JOB_TYPES.CONTAINER_DELETE:
+      case JOB_TYPES.CONTAINER_RESTART:
+      case JOB_TYPES.CONTAINER_UPGRADE:
+      case JOB_TYPES.CONTAINER_LOGS:
+        await dispatchContainerJob(job, getContainerExecutorDeps());
         break;
       default:
         throw new Error(`Unknown job type: ${job.type}`);

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -27,9 +27,10 @@ import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { jobs } from "../../db/schemas/jobs";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
 import { logger } from "../utils/logger";
+import { dispatchAppDeployJob } from "./app-deploy-job-service";
+import { dispatchContainerJob, getContainerExecutorDeps } from "./container-job-service";
 import { elizaProvisionAdvisoryLockSql } from "./eliza-provision-lock";
 import { elizaSandboxService } from "./eliza-sandbox";
-import { dispatchContainerJob, getContainerExecutorDeps } from "./container-job-service";
 import { JOB_TYPES, type ProvisioningJobType } from "./provisioning-job-types";
 import {
   isWaifuWebhookTargetUrl,
@@ -1461,6 +1462,11 @@ export class ProvisioningJobService {
       case JOB_TYPES.CONTAINER_UPGRADE:
       case JOB_TYPES.CONTAINER_LOGS:
         await dispatchContainerJob(job, getContainerExecutorDeps());
+        break;
+      // Apps lane (Product 2): the node deploy. The Worker enqueues this; the
+      // daemon runs the real isolated provision via the injected AppDeployRunner.
+      case JOB_TYPES.APP_DEPLOY:
+        await dispatchAppDeployJob(job);
         break;
       default:
         throw new Error(`Unknown job type: ${job.type}`);

--- a/packages/cloud-shared/src/lib/services/tenant-db/__tests__/cluster-pool.test.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/__tests__/cluster-pool.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type ClusterCandidate,
+  ClusterPool,
+  type ClusterPoolStore,
+  NoClusterCapacityError,
+  selectLeastLoadedCluster,
+} from "../cluster-pool";
+
+function cluster(p: Partial<ClusterCandidate> & { id: string }): ClusterCandidate {
+  return {
+    host: `host-${p.id}`,
+    adminDsnEncrypted: `enc-${p.id}`,
+    databaseCount: 0,
+    maxDatabases: 10,
+    isActive: true,
+    ...p,
+  };
+}
+
+describe("selectLeastLoadedCluster", () => {
+  test("picks the active cluster with the lowest database_count", () => {
+    const chosen = selectLeastLoadedCluster([
+      cluster({ id: "a", databaseCount: 5 }),
+      cluster({ id: "b", databaseCount: 2 }),
+      cluster({ id: "c", databaseCount: 8 }),
+    ]);
+    expect(chosen?.id).toBe("b");
+  });
+
+  test("ties break deterministically by id", () => {
+    const chosen = selectLeastLoadedCluster([
+      cluster({ id: "z", databaseCount: 3 }),
+      cluster({ id: "a", databaseCount: 3 }),
+    ]);
+    expect(chosen?.id).toBe("a");
+  });
+
+  test("skips full and inactive clusters", () => {
+    expect(
+      selectLeastLoadedCluster([
+        cluster({ id: "full", databaseCount: 10, maxDatabases: 10 }),
+        cluster({ id: "off", databaseCount: 0, isActive: false }),
+      ]),
+    ).toBeNull();
+    expect(
+      selectLeastLoadedCluster([
+        cluster({ id: "full", databaseCount: 10, maxDatabases: 10 }),
+        cluster({ id: "ok", databaseCount: 9, maxDatabases: 10 }),
+      ])?.id,
+    ).toBe("ok");
+  });
+
+  test("returns null for an empty pool", () => {
+    expect(selectLeastLoadedCluster([])).toBeNull();
+  });
+});
+
+describe("ClusterPool.allocate", () => {
+  function store(
+    candidates: ClusterCandidate[],
+    claim: (id: string) => boolean,
+  ): ClusterPoolStore & { claims: string[] } {
+    const claims: string[] = [];
+    return {
+      claims,
+      async listAllocatable() {
+        return candidates;
+      },
+      async tryClaimSlot(id) {
+        claims.push(id);
+        return claim(id);
+      },
+    };
+  }
+
+  test("allocates the least-loaded cluster and returns its admin handle", async () => {
+    const s = store(
+      [cluster({ id: "a", databaseCount: 4 }), cluster({ id: "b", databaseCount: 1 })],
+      () => true,
+    );
+    const got = await new ClusterPool(s).allocate();
+    expect(got).toEqual({ id: "b", host: "host-b", adminDsnEncrypted: "enc-b" });
+    expect(s.claims).toEqual(["b"]);
+  });
+
+  test("retries on a lost claim race, then succeeds on the next candidate", async () => {
+    // 'b' is least-loaded but its claim races to full; the next read reflects
+    // that (b is gone), so 'a' wins on the retry.
+    const claims: string[] = [];
+    let bAvailable = true;
+    const s: ClusterPoolStore = {
+      async listAllocatable() {
+        return bAvailable
+          ? [cluster({ id: "a", databaseCount: 4 }), cluster({ id: "b", databaseCount: 1 })]
+          : [cluster({ id: "a", databaseCount: 4 })];
+      },
+      async tryClaimSlot(id) {
+        claims.push(id);
+        if (id === "b") {
+          bAvailable = false; // raced to full
+          return false;
+        }
+        return true;
+      },
+    };
+    const got = await new ClusterPool(s).allocate();
+    expect(got.id).toBe("a");
+    expect(claims).toEqual(["b", "a"]);
+  });
+
+  test("throws NoClusterCapacityError when nothing is claimable", async () => {
+    const s = store([cluster({ id: "full", databaseCount: 10, maxDatabases: 10 })], () => true);
+    await expect(new ClusterPool(s).allocate()).rejects.toBeInstanceOf(NoClusterCapacityError);
+  });
+
+  test("throws after exhausting attempts when every claim keeps racing", async () => {
+    const s = store([cluster({ id: "a", databaseCount: 1 })], () => false);
+    await expect(new ClusterPool(s, { maxAttempts: 3 }).allocate()).rejects.toBeInstanceOf(
+      NoClusterCapacityError,
+    );
+    expect(s.claims).toEqual(["a", "a", "a"]);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioner.test.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioner.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildAdminDdl,
+  buildDeprovisionDdl,
+  buildDsn,
+  buildTenantDdl,
+  deriveTenantIdent,
+  quoteIdent,
+  SqlTenantDbProvisioner,
+  type TenantDbSqlExecutor,
+} from "../tenant-db-provisioner";
+
+const APP_ID = "11111111-2222-3333-4444-555555555555";
+
+describe("deriveTenantIdent", () => {
+  test("derives valid, stable db + role identifiers from an app id", () => {
+    const a = deriveTenantIdent(APP_ID);
+    expect(a).toEqual(deriveTenantIdent(APP_ID)); // stable
+    expect(a.dbName).toMatch(/^db_app_[a-z0-9]+$/);
+    expect(a.roleName).toMatch(/^app_[a-z0-9]+$/);
+    expect(a.dbName.length).toBeLessThanOrEqual(63);
+    expect(a.roleName.length).toBeLessThanOrEqual(63);
+  });
+
+  test("rejects an app id with too little entropy", () => {
+    expect(() => deriveTenantIdent("a-b-c")).toThrow();
+  });
+});
+
+describe("quoteIdent", () => {
+  test("double-quotes and escapes embedded quotes", () => {
+    expect(quoteIdent("db_app_x")).toBe('"db_app_x"');
+    expect(quoteIdent('a"b')).toBe('"a""b"');
+  });
+});
+
+describe("buildAdminDdl — the hard cross-tenant boundary as a contract", () => {
+  const ident = deriveTenantIdent(APP_ID);
+  const ddl = buildAdminDdl(ident, "s3cr3t");
+
+  test("creates the role BEFORE the database owns it (order is load-bearing)", () => {
+    const roleIdx = ddl.findIndex((s) => s.startsWith("CREATE ROLE"));
+    const dbIdx = ddl.findIndex((s) => s.startsWith("CREATE DATABASE"));
+    expect(roleIdx).toBeGreaterThanOrEqual(0);
+    expect(dbIdx).toBeGreaterThan(roleIdx);
+  });
+
+  test("REVOKEs CONNECT from PUBLIC and GRANTs it only to the tenant role", () => {
+    const joined = ddl.join("\n");
+    expect(joined).toContain(`REVOKE CONNECT ON DATABASE ${quoteIdent(ident.dbName)} FROM PUBLIC`);
+    expect(joined).toContain(
+      `GRANT CONNECT ON DATABASE ${quoteIdent(ident.dbName)} TO ${quoteIdent(ident.roleName)}`,
+    );
+  });
+
+  test("the role is least-privilege (no superuser/createdb/createrole)", () => {
+    const createRole = ddl.find((s) => s.startsWith("CREATE ROLE"))!;
+    expect(createRole).toContain("NOSUPERUSER");
+    expect(createRole).toContain("NOCREATEDB");
+    expect(createRole).toContain("NOCREATEROLE");
+  });
+
+  test("escapes a password containing a single quote", () => {
+    const evil = buildAdminDdl(ident, "pw'; DROP DATABASE postgres;--");
+    const createRole = evil.find((s) => s.startsWith("CREATE ROLE"))!;
+    expect(createRole).toContain("''"); // escaped quote, not a break-out
+  });
+});
+
+describe("buildTenantDdl", () => {
+  test("locks the public schema to the tenant role only", () => {
+    const ident = deriveTenantIdent(APP_ID);
+    const ddl = buildTenantDdl(ident);
+    expect(ddl).toContain("REVOKE ALL ON SCHEMA public FROM PUBLIC");
+    expect(ddl).toContain(`GRANT ALL ON SCHEMA public TO ${quoteIdent(ident.roleName)}`);
+  });
+});
+
+describe("buildDeprovisionDdl", () => {
+  test("drops the database WITH FORCE, then the role", () => {
+    const ident = deriveTenantIdent(APP_ID);
+    const ddl = buildDeprovisionDdl(ident);
+    expect(ddl[0]).toContain("DROP DATABASE IF EXISTS");
+    expect(ddl[0]).toContain("WITH (FORCE)");
+    expect(ddl[1]).toContain("DROP ROLE IF EXISTS");
+  });
+});
+
+describe("buildDsn", () => {
+  test("builds an sslmode=require DSN with URL-encoded credentials", () => {
+    const dsn = buildDsn({
+      host: "apps-cluster-1:5432",
+      roleName: "app_x",
+      password: "p@ss/w:rd",
+      dbName: "db_app_x",
+    });
+    expect(dsn).toBe(
+      "postgresql://app_x:p%40ss%2Fw%3Ard@apps-cluster-1:5432/db_app_x?sslmode=require",
+    );
+  });
+});
+
+describe("SqlTenantDbProvisioner", () => {
+  function recordingExecutor() {
+    const calls: Array<{ kind: "admin" | "db"; dbName?: string; statements: string[] }> = [];
+    const executor: TenantDbSqlExecutor = {
+      async execAdmin(statements) {
+        calls.push({ kind: "admin", statements: [...statements] });
+      },
+      async execInDatabase(dbName, statements) {
+        calls.push({ kind: "db", dbName, statements: [...statements] });
+      },
+    };
+    return { calls, executor };
+  }
+
+  test("provisions: admin DDL first, then in-database DDL, returns the scoped DSN", async () => {
+    const { calls, executor } = recordingExecutor();
+    const provisioner = new SqlTenantDbProvisioner({
+      cluster: { host: "apps-cluster-1" },
+      executor,
+      genPassword: () => "fixed-password",
+    });
+
+    const result = await provisioner.provision(APP_ID);
+    const ident = deriveTenantIdent(APP_ID);
+
+    expect(result.dbName).toBe(ident.dbName);
+    expect(result.roleName).toBe(ident.roleName);
+    expect(result.dsn).toBe(
+      `postgresql://${ident.roleName}:fixed-password@apps-cluster-1/${ident.dbName}?sslmode=require`,
+    );
+
+    // ordering: admin (role+db+connect) before in-database (schema) lockdown
+    expect(calls[0].kind).toBe("admin");
+    expect(calls[1].kind).toBe("db");
+    expect(calls[1].dbName).toBe(ident.dbName);
+    // the boundary statement actually got issued
+    expect(calls[0].statements.join("\n")).toContain("REVOKE CONNECT ON DATABASE");
+  });
+
+  test("deprovisions via admin DROP DATABASE/ROLE", async () => {
+    const { calls, executor } = recordingExecutor();
+    const provisioner = new SqlTenantDbProvisioner({
+      cluster: { host: "h" },
+      executor,
+      genPassword: () => "x",
+    });
+    await provisioner.deprovision(APP_ID);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].kind).toBe("admin");
+    expect(calls[0].statements[0]).toContain("DROP DATABASE IF EXISTS");
+  });
+});

--- a/packages/cloud-shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioning.test.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioning.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import type { AllocatedCluster } from "../cluster-pool";
+import {
+  SqlTenantDbProvisioning,
+  type SqlTenantDbProvisioningDeps,
+  type TenantDbProvisioner,
+} from "../tenant-db-provisioning";
+
+const ALLOCATED: AllocatedCluster = {
+  id: "cluster-1",
+  host: "apps-cluster-1:5432",
+  adminDsnEncrypted: "enc:v1:admin-dsn",
+};
+
+const PROVISIONED_DSN = "postgresql://app_x:pw@apps-cluster-1:5432/db_app_x?sslmode=require";
+
+function deps(
+  over: Partial<SqlTenantDbProvisioningDeps> = {},
+): SqlTenantDbProvisioningDeps & { seen: Record<string, unknown> } {
+  const seen: Record<string, unknown> = {};
+  const base: SqlTenantDbProvisioningDeps = {
+    pool: {
+      async allocate() {
+        return ALLOCATED;
+      },
+    },
+    async decrypt(enc) {
+      seen.decryptedArg = enc;
+      return "postgresql://admin:pw@apps-cluster-1:5432/postgres";
+    },
+    makeProvisioner(cluster, adminDsn): TenantDbProvisioner {
+      seen.providerCluster = cluster;
+      seen.providerAdminDsn = adminDsn;
+      return {
+        async provision(appId) {
+          seen.provisionedApp = appId;
+          return { dbName: "db_app_x", roleName: "app_x", dsn: PROVISIONED_DSN };
+        },
+      };
+    },
+  };
+  return { ...base, ...over, seen };
+}
+
+describe("SqlTenantDbProvisioning", () => {
+  test("provisions on the allocated cluster and returns the real isolated DSN", async () => {
+    const d = deps();
+    const result = await new SqlTenantDbProvisioning(d).provisionForApp("app-1");
+
+    expect(result).toEqual({ dsn: PROVISIONED_DSN, clusterId: "cluster-1" });
+    // it decrypted THIS cluster's admin dsn and handed it to the provisioner
+    expect(d.seen.decryptedArg).toBe("enc:v1:admin-dsn");
+    expect(d.seen.providerAdminDsn).toBe("postgresql://admin:pw@apps-cluster-1:5432/postgres");
+    expect(d.seen.providerCluster).toEqual({ host: "apps-cluster-1:5432" });
+    expect(d.seen.provisionedApp).toBe("app-1");
+  });
+
+  test("the returned DSN is the per-tenant one, never the shared env DATABASE_URL", async () => {
+    process.env.DATABASE_URL = "postgresql://SHARED@shared/agentdb";
+    const result = await new SqlTenantDbProvisioning(deps()).provisionForApp("app-1");
+    expect(result.dsn).toBe(PROVISIONED_DSN);
+    expect(result.dsn).not.toContain("SHARED");
+  });
+
+  test("propagates a NoClusterCapacity failure from the pool", async () => {
+    const d = deps({
+      pool: {
+        async allocate() {
+          throw new Error("No tenant DB cluster has capacity");
+        },
+      },
+    });
+    await expect(new SqlTenantDbProvisioning(d).provisionForApp("app-1")).rejects.toThrow(
+      "capacity",
+    );
+  });
+});

--- a/packages/cloud-shared/src/lib/services/tenant-db/cluster-pool.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/cluster-pool.ts
@@ -1,0 +1,102 @@
+/**
+ * Tenant DB cluster pool (Apps / Product 2) — least-loaded selection + race-safe
+ * slot claiming. Picks where a new per-tenant database should be created so the
+ * apps data plane scales past any single cluster's cap by spreading tenants
+ * across N clusters and rolling onto a fresh one when the current set fills.
+ *
+ * Pure selection logic + a thin coordinator over an injected store, so the
+ * whole policy is unit-testable with no DB. Backend-agnostic (self-managed PG
+ * or Neon-as-cluster) — a cluster is just {host, adminDsn, capacity, load}.
+ */
+
+/** A cluster the pool may allocate a tenant database onto. */
+export interface ClusterCandidate {
+  id: string;
+  host: string;
+  /** Encrypted admin DSN for running provisioning DDL on this cluster. */
+  adminDsnEncrypted: string;
+  databaseCount: number;
+  maxDatabases: number;
+  isActive: boolean;
+}
+
+/** The cluster chosen for a tenant + its (claimed) slot. */
+export interface AllocatedCluster {
+  id: string;
+  host: string;
+  adminDsnEncrypted: string;
+}
+
+/**
+ * Storage seam. `listAllocatable` returns candidate clusters (ideally
+ * pre-filtered to active + has-capacity, but the pool defends regardless).
+ * `tryClaimSlot` atomically increments `database_count` only if still under
+ * `max_databases`, returning false if it raced to full — the DB-level guard
+ * that keeps two concurrent allocations from overfilling a cluster.
+ */
+export interface ClusterPoolStore {
+  listAllocatable(): Promise<ClusterCandidate[]>;
+  tryClaimSlot(clusterId: string): Promise<boolean>;
+}
+
+/** Thrown when every active cluster is at capacity — operators add a cluster. */
+export class NoClusterCapacityError extends Error {
+  constructor(message = "No tenant DB cluster has capacity; add a cluster") {
+    super(message);
+    this.name = "NoClusterCapacityError";
+  }
+}
+
+/**
+ * Pure: pick the least-loaded active cluster that still has capacity. Ties
+ * break by id for deterministic selection. Returns null when none qualify.
+ */
+export function selectLeastLoadedCluster(
+  clusters: readonly ClusterCandidate[],
+): ClusterCandidate | null {
+  let best: ClusterCandidate | null = null;
+  for (const c of clusters) {
+    if (!c.isActive || c.databaseCount >= c.maxDatabases) continue;
+    if (
+      best === null ||
+      c.databaseCount < best.databaseCount ||
+      (c.databaseCount === best.databaseCount && c.id < best.id)
+    ) {
+      best = c;
+    }
+  }
+  return best;
+}
+
+export class ClusterPool {
+  private readonly store: ClusterPoolStore;
+  private readonly maxAttempts: number;
+
+  constructor(store: ClusterPoolStore, opts: { maxAttempts?: number } = {}) {
+    this.store = store;
+    this.maxAttempts = opts.maxAttempts ?? 5;
+  }
+
+  /**
+   * Allocate a slot on the least-loaded cluster, claiming it atomically. Re-reads
+   * and retries when a claim loses a race (the cluster filled under us), and
+   * throws {@link NoClusterCapacityError} once nothing claimable remains.
+   */
+  async allocate(): Promise<AllocatedCluster> {
+    for (let attempt = 0; attempt < this.maxAttempts; attempt++) {
+      const candidates = await this.store.listAllocatable();
+      const chosen = selectLeastLoadedCluster(candidates);
+      if (!chosen) break;
+      const claimed = await this.store.tryClaimSlot(chosen.id);
+      if (claimed) {
+        return {
+          id: chosen.id,
+          host: chosen.host,
+          adminDsnEncrypted: chosen.adminDsnEncrypted,
+        };
+      }
+      // Lost the race for that slot — loop and re-select.
+    }
+    throw new NoClusterCapacityError();
+  }
+}

--- a/packages/cloud-shared/src/lib/services/tenant-db/direct-pg-executor.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/direct-pg-executor.ts
@@ -1,0 +1,44 @@
+/**
+ * DirectPgExecutor (Apps / Product 2) — the real {@link TenantDbSqlExecutor}
+ * backend for a self-managed Postgres cluster. Connects with the cluster's
+ * admin DSN (node-postgres) and runs provisioning DDL one statement at a time
+ * in autocommit (CREATE DATABASE cannot run inside a transaction).
+ *
+ * This is the IO adapter behind the pure provisioner (U2): the DDL/DSN strings
+ * are built + unit-tested there; this just executes them. Its behavior is
+ * validated against a real Postgres (integration), not mocked.
+ */
+
+import { Client } from "pg";
+import type { TenantDbSqlExecutor } from "./tenant-db-provisioner";
+
+export class DirectPgExecutor implements TenantDbSqlExecutor {
+  private readonly adminDsn: string;
+
+  /** @param adminDsn admin connection to the cluster's maintenance database. */
+  constructor(adminDsn: string) {
+    this.adminDsn = adminDsn;
+  }
+
+  private async run(connectionString: string, statements: readonly string[]): Promise<void> {
+    const client = new Client({ connectionString });
+    await client.connect();
+    try {
+      for (const sql of statements) {
+        await client.query(sql);
+      }
+    } finally {
+      await client.end();
+    }
+  }
+
+  async execAdmin(statements: readonly string[]): Promise<void> {
+    await this.run(this.adminDsn, statements);
+  }
+
+  async execInDatabase(dbName: string, statements: readonly string[]): Promise<void> {
+    const url = new URL(this.adminDsn);
+    url.pathname = `/${encodeURIComponent(dbName)}`;
+    await this.run(url.toString(), statements);
+  }
+}

--- a/packages/cloud-shared/src/lib/services/tenant-db/make-tenant-db-provisioning.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/make-tenant-db-provisioning.ts
@@ -1,0 +1,72 @@
+/**
+ * NODE-ONLY composer for the apps tenant-DB provisioning seam (Apps / Product 2).
+ *
+ * Wires the persistent cluster pool (`tenantDbClustersRepository`, over the
+ * `tenant_db_clusters` table) + the real Postgres DDL executor (`DirectPgExecutor`,
+ * node-`pg`) into a single {@link SqlTenantDbProvisioning} that
+ * `UserDatabaseService` consumes. This is the REAL isolated path:
+ * `provisionForApp` allocates the least-loaded cluster with capacity, decrypts
+ * its admin DSN, and runs CREATE ROLE / CREATE DATABASE / REVOKE CONNECT FROM
+ * PUBLIC against that cluster — handing the app its OWN least-privilege DSN and
+ * never the shared agent `DATABASE_URL`.
+ *
+ * NODE-ONLY: `DirectPgExecutor` imports `pg`, which does not load on Cloudflare
+ * Workers (workerd). Construct this only on the provisioning-worker daemon (or a
+ * node host of the deploy path), never in cloud-api. The Worker deploy path uses
+ * the shared-DB fallback (a `UserDatabaseService` with no provisioning backend).
+ *
+ * The cluster admin DSN is decrypted with the one-arg `fieldEncryption.decrypt`
+ * (the ciphertext self-describes its `orgKeyId`, so the platform org it was
+ * sealed under is resolved from the blob — no org id needed at this layer).
+ */
+
+import { randomBytes } from "node:crypto";
+import { tenantDbClustersRepository } from "../../../db/repositories/tenant-db-clusters";
+import { fieldEncryption } from "../field-encryption";
+import { ClusterPool, type ClusterPoolStore } from "./cluster-pool";
+import { DirectPgExecutor } from "./direct-pg-executor";
+import { SqlTenantDbProvisioner } from "./tenant-db-provisioner";
+import { SqlTenantDbProvisioning } from "./tenant-db-provisioning";
+
+/**
+ * Strong random role password, URL-safe so it never breaks the generated DSN
+ * (`base64url` has no `+` `/` `=` — the chars that would need DSN-escaping).
+ * 36 bytes → 48 chars → ~288 bits.
+ */
+function genRolePassword(): string {
+  return randomBytes(36).toString("base64url");
+}
+
+export interface MakeTenantDbProvisioningOpts {
+  /** Override the cluster store (tests). Defaults to the real repository. */
+  store?: ClusterPoolStore;
+  /** Override the admin-DSN decryptor (tests). Defaults to `fieldEncryption.decrypt`. */
+  decrypt?: (encrypted: string) => Promise<string>;
+  /** Override the role-password generator (deterministic tests). */
+  genPassword?: () => string;
+}
+
+/**
+ * Build the real node-side tenant-DB provisioning backend over the persistent
+ * cluster pool + node-`pg`. Inject into `new UserDatabaseService(provisioning)`
+ * (or the node deploy runner) so apps get isolated databases.
+ */
+export function makeTenantDbProvisioning(
+  opts: MakeTenantDbProvisioningOpts = {},
+): SqlTenantDbProvisioning {
+  const store = opts.store ?? tenantDbClustersRepository;
+  const pool = new ClusterPool(store);
+  const decrypt = opts.decrypt ?? ((encrypted: string) => fieldEncryption.decrypt(encrypted));
+  const genPassword = opts.genPassword ?? genRolePassword;
+
+  return new SqlTenantDbProvisioning({
+    pool,
+    decrypt,
+    makeProvisioner: (cluster, adminDsn) =>
+      new SqlTenantDbProvisioner({
+        cluster,
+        executor: new DirectPgExecutor(adminDsn),
+        genPassword,
+      }),
+  });
+}

--- a/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-provisioner.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-provisioner.ts
@@ -1,0 +1,170 @@
+/**
+ * Per-tenant database isolation (Apps / Product 2) — the pure provisioning core.
+ *
+ * Strategy: DATABASE-per-tenant + ROLE-per-tenant on a shared, app-owned
+ * Postgres cluster. Each app gets its own database owned by its own login role,
+ * and `REVOKE CONNECT ON DATABASE ... FROM PUBLIC` + `GRANT CONNECT ... TO
+ * <role>` means a tenant credential is rejected at the connection/auth layer
+ * before any query runs — a HARD cross-tenant boundary, not encryption-at-rest.
+ * CREATE DATABASE / CREATE ROLE is O(1) cheap DDL with effectively unbounded
+ * count per cluster, sharded across N clusters by the pool (a later unit), so
+ * it structurally defeats any single-provider project/branch cap.
+ *
+ * This module is the PURE core: identifier derivation, the DDL/DSN string
+ * builders (the boundary expressed as a contract), and an orchestrator driven
+ * by injected executors — zero `pg`/Neon/network imports, so the entire
+ * behaviour (including the REVOKE-CONNECT boundary) is unit-testable with mocks.
+ * The concrete backend (self-managed Postgres now; Neon-as-cluster later) plugs
+ * in behind {@link TenantDbSqlExecutor} with no change here.
+ *
+ * NOTE: never touches the agent path — agents keep `process.env.DATABASE_URL`.
+ */
+
+/** Postgres identifiers (database + login role) for one tenant app. */
+export interface TenantDbIdent {
+  dbName: string;
+  roleName: string;
+}
+
+/** A provisioned tenant DB: the identifiers + the role's scoped DSN. */
+export interface ProvisionedTenantDb extends TenantDbIdent {
+  /** `postgresql://<role>:<pw>@<host>/<db>?sslmode=require` — the ONLY creds the app gets. */
+  dsn: string;
+}
+
+/** Where a tenant DB is created (one shard of the apps cluster pool). */
+export interface TenantDbCluster {
+  /** Host[:port] of the cluster, used to build the tenant DSN. */
+  host: string;
+}
+
+/**
+ * Executes DDL against the cluster. Two surfaces because tenant schema grants
+ * must run INSIDE the freshly-created database, on a separate connection from
+ * the admin connection that created it. Statements run one-at-a-time and
+ * OUTSIDE a transaction — `CREATE DATABASE` cannot run in a transaction block.
+ */
+export interface TenantDbSqlExecutor {
+  /** Run admin DDL on the cluster's maintenance database (e.g. `postgres`). */
+  execAdmin(statements: readonly string[]): Promise<void>;
+  /** Run DDL connected to a specific tenant database. */
+  execInDatabase(dbName: string, statements: readonly string[]): Promise<void>;
+}
+
+export interface SqlTenantDbProvisionerDeps {
+  cluster: TenantDbCluster;
+  executor: TenantDbSqlExecutor;
+  /** Generates a strong random role password. Injected for deterministic tests. */
+  genPassword: () => string;
+}
+
+/** Double-quote a Postgres identifier, escaping embedded quotes. */
+export function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+/** Single-quote a Postgres string literal, escaping embedded quotes. */
+function quoteLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Derive stable, collision-free Postgres identifiers from an app id. The id is
+ * lowercased and stripped to `[a-z0-9]`, so identifiers are always valid and
+ * never need quoting for correctness (we still quote in DDL defensively).
+ */
+export function deriveTenantIdent(appId: string): TenantDbIdent {
+  const slug = appId.toLowerCase().replace(/[^a-z0-9]/g, "");
+  if (slug.length < 8) {
+    throw new Error(`deriveTenantIdent: appId ${appId} yields too short a slug (${slug.length})`);
+  }
+  const short = slug.slice(0, 24);
+  return { dbName: `db_app_${short}`, roleName: `app_${short}` };
+}
+
+/**
+ * Admin-connection DDL: create the role, create its database, and lock down
+ * connect privileges so ONLY this role can open the database. Statement order
+ * is load-bearing — the role must exist before the database can be owned by it.
+ */
+export function buildAdminDdl(ident: TenantDbIdent, password: string): string[] {
+  const role = quoteIdent(ident.roleName);
+  const db = quoteIdent(ident.dbName);
+  return [
+    `CREATE ROLE ${role} LOGIN PASSWORD ${quoteLiteral(password)} NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT`,
+    `CREATE DATABASE ${db} OWNER ${role}`,
+    `REVOKE CONNECT ON DATABASE ${db} FROM PUBLIC`,
+    `GRANT CONNECT ON DATABASE ${db} TO ${role}`,
+  ];
+}
+
+/**
+ * In-database DDL (run connected to the new database): take the public schema
+ * away from PUBLIC and grant it to the tenant role only. Closes the
+ * "PUBLIC can create in public schema" default so a tenant role is the sole
+ * principal inside its own database.
+ */
+export function buildTenantDdl(ident: TenantDbIdent): string[] {
+  const role = quoteIdent(ident.roleName);
+  return ["REVOKE ALL ON SCHEMA public FROM PUBLIC", `GRANT ALL ON SCHEMA public TO ${role}`];
+}
+
+/** Teardown DDL: drop the database (forcing connections closed) then the role. */
+export function buildDeprovisionDdl(ident: TenantDbIdent): string[] {
+  return [
+    `DROP DATABASE IF EXISTS ${quoteIdent(ident.dbName)} WITH (FORCE)`,
+    `DROP ROLE IF EXISTS ${quoteIdent(ident.roleName)}`,
+  ];
+}
+
+/** Build the role-scoped connection string. Credentials are URL-encoded. */
+export function buildDsn(params: {
+  host: string;
+  roleName: string;
+  password: string;
+  dbName: string;
+}): string {
+  const user = encodeURIComponent(params.roleName);
+  const pw = encodeURIComponent(params.password);
+  const db = encodeURIComponent(params.dbName);
+  return `postgresql://${user}:${pw}@${params.host}/${db}?sslmode=require`;
+}
+
+/**
+ * Orchestrates provisioning over an injected executor: derive identifiers,
+ * mint a password, run admin DDL (role+db+connect lockdown), then in-database
+ * DDL (schema lockdown), and return the role-scoped DSN. Pure of any real DB
+ * driver — the executor is the only IO seam.
+ */
+export class SqlTenantDbProvisioner {
+  private readonly cluster: TenantDbCluster;
+  private readonly executor: TenantDbSqlExecutor;
+  private readonly genPassword: () => string;
+
+  constructor(deps: SqlTenantDbProvisionerDeps) {
+    this.cluster = deps.cluster;
+    this.executor = deps.executor;
+    this.genPassword = deps.genPassword;
+  }
+
+  async provision(appId: string): Promise<ProvisionedTenantDb> {
+    const ident = deriveTenantIdent(appId);
+    const password = this.genPassword();
+    await this.executor.execAdmin(buildAdminDdl(ident, password));
+    await this.executor.execInDatabase(ident.dbName, buildTenantDdl(ident));
+    return {
+      ...ident,
+      dsn: buildDsn({
+        host: this.cluster.host,
+        roleName: ident.roleName,
+        password,
+        dbName: ident.dbName,
+      }),
+    };
+  }
+
+  async deprovision(appId: string): Promise<void> {
+    const ident = deriveTenantIdent(appId);
+    await this.executor.execAdmin(buildDeprovisionDdl(ident));
+  }
+}

--- a/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-provisioning.integration.test.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-provisioning.integration.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tenant-DB provisioning — REAL Postgres integration (Apps / Product 2).
+ *
+ * Drives the FULL composed stack end-to-end against a live Postgres:
+ *   makeTenantDbProvisioning -> ClusterPool -> tenantDbClustersRepository (real
+ *   dbRead/dbWrite) -> SqlTenantDbProvisioner -> DirectPgExecutor (node-`pg`).
+ *
+ * It proves the two load-bearing properties that mocks cannot:
+ *   1. RACE SAFETY — two concurrent slot claims on a one-slot cluster: exactly
+ *      one wins (the atomic `UPDATE ... WHERE database_count < max RETURNING`).
+ *   2. TENANT ISOLATION — a provisioned app reaches its OWN database but another
+ *      app's role is rejected by `REVOKE CONNECT ON DATABASE ... FROM PUBLIC`
+ *      ("permission denied for database") — the hard auth-layer boundary.
+ *
+ * GATED: runs only when `APPS_TENANT_DB_TEST_DSN` is set to a superuser admin
+ * DSN (e.g. `postgresql://postgres:pw@localhost:55432/postgres?sslmode=disable`).
+ * `DATABASE_URL` MUST point at the SAME database so the repository's dbRead/
+ * dbWrite hit it. With no DSN the whole describe is skipped, so CI stays green
+ * without infra. Local run:
+ *
+ *   DATABASE_URL='postgresql://postgres:adminpw@localhost:55432/postgres?sslmode=disable' \
+ *   APPS_TENANT_DB_TEST_DSN="$DATABASE_URL" \
+ *   bun test src/lib/services/tenant-db/tenant-db-provisioning.integration.test.ts
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Client } from "pg";
+import { tenantDbClustersRepository } from "../../../db/repositories/tenant-db-clusters";
+import { ClusterPool, NoClusterCapacityError } from "./cluster-pool";
+import { makeTenantDbProvisioning } from "./make-tenant-db-provisioning";
+
+const ADMIN_DSN = process.env.APPS_TENANT_DB_TEST_DSN;
+const HOST = process.env.APPS_TENANT_DB_TEST_HOST ?? "localhost:55432";
+const RUN = Boolean(ADMIN_DSN);
+
+/** Identities created during the run, dropped in afterAll. */
+const created: Array<{ role: string; db: string }> = [];
+
+async function adminExec(sql: string): Promise<void> {
+  const client = new Client({ connectionString: ADMIN_DSN });
+  await client.connect();
+  try {
+    await client.query(sql);
+  } finally {
+    await client.end();
+  }
+}
+
+/** Connect with a tenant DSN and ping; resolves to 1 on success, rejects otherwise. */
+async function connectAndPing(dsn: string): Promise<number> {
+  const client = new Client({ connectionString: dsn });
+  await client.connect();
+  try {
+    const res = await client.query<{ one: number }>("SELECT 1 AS one");
+    return res.rows[0]?.one ?? -1;
+  } finally {
+    await client.end();
+  }
+}
+
+/** Tenant DSNs carry `sslmode=require`; the local test PG has no TLS. */
+function localize(dsn: string): string {
+  return dsn.replace("sslmode=require", "sslmode=disable");
+}
+
+function parseDsn(dsn: string): { role: string; pw: string; db: string } {
+  const u = new URL(dsn);
+  return { role: u.username, pw: u.password, db: u.pathname.replace(/^\//, "") };
+}
+
+async function resetClusters(): Promise<void> {
+  await adminExec("DELETE FROM tenant_db_clusters");
+}
+
+const d = RUN ? describe : describe.skip;
+
+d("tenant-db provisioning over real Postgres", () => {
+  beforeAll(async () => {
+    // Apply migration 0140 idempotently (CREATE TABLE/INDEX IF NOT EXISTS).
+    const sql = readFileSync(
+      join(import.meta.dir, "../../../db/migrations/0140_tenant_db_clusters.sql"),
+      "utf8",
+    );
+    for (const stmt of sql.split("--> statement-breakpoint")) {
+      const trimmed = stmt.trim();
+      if (trimmed) await adminExec(trimmed);
+    }
+  });
+
+  beforeEach(async () => {
+    await resetClusters();
+  });
+
+  afterAll(async () => {
+    for (const { role, db } of created) {
+      await adminExec(`DROP DATABASE IF EXISTS "${db}" WITH (FORCE)`).catch(() => {});
+      await adminExec(`DROP ROLE IF EXISTS "${role}"`).catch(() => {});
+    }
+    await resetClusters().catch(() => {});
+  });
+
+  test("two concurrent claims on a one-slot cluster: exactly one wins", async () => {
+    const { id } = await tenantDbClustersRepository.create({
+      provider: "direct_pg",
+      host: HOST,
+      admin_dsn_encrypted: ADMIN_DSN!,
+      max_databases: 5,
+      database_count: 4, // exactly one slot left
+      is_active: true,
+    });
+
+    const [a, b] = await Promise.all([
+      tenantDbClustersRepository.tryClaimSlot(id),
+      tenantDbClustersRepository.tryClaimSlot(id),
+    ]);
+
+    expect([a, b].filter(Boolean)).toHaveLength(1); // never overfills
+    expect(await tenantDbClustersRepository.tryClaimSlot(id)).toBe(false); // now full
+
+    // Pool sees no allocatable capacity once the only cluster is full.
+    await expect(new ClusterPool(tenantDbClustersRepository).allocate()).rejects.toBeInstanceOf(
+      NoClusterCapacityError,
+    );
+  });
+
+  test("provisionForApp gives an isolated DB reachable only by its own role", async () => {
+    await tenantDbClustersRepository.create({
+      provider: "direct_pg",
+      host: HOST,
+      admin_dsn_encrypted: ADMIN_DSN!, // passthrough decrypt below
+      max_databases: 100,
+      database_count: 0,
+      is_active: true,
+    });
+
+    // decrypt passthrough: the column holds the plaintext admin DSN for the test.
+    const provisioning = makeTenantDbProvisioning({ decrypt: async (x) => x });
+
+    const app1 = randomUUID();
+    const app2 = randomUUID();
+    const r1 = await provisioning.provisionForApp(app1);
+    const r2 = await provisioning.provisionForApp(app2);
+
+    const t1 = parseDsn(r1.dsn);
+    const t2 = parseDsn(r2.dsn);
+    created.push({ role: t1.role, db: t1.db }, { role: t2.role, db: t2.db });
+
+    // 1) Each app reaches its OWN database.
+    expect(await connectAndPing(localize(r1.dsn))).toBe(1);
+    expect(await connectAndPing(localize(r2.dsn))).toBe(1);
+
+    // 2) Cross-tenant is rejected at the database CONNECT boundary: app2's role
+    //    cannot open app1's database (REVOKE CONNECT ... FROM PUBLIC).
+    const crossDsn = `postgresql://${encodeURIComponent(t2.role)}:${encodeURIComponent(
+      t2.pw,
+    )}@${HOST}/${t1.db}?sslmode=disable`;
+    await expect(connectAndPing(crossDsn)).rejects.toThrow(/permission denied for database/i);
+
+    // The allocator recorded both placements on the cluster.
+    expect(r1.clusterId).toBe(r2.clusterId);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-provisioning.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-provisioning.ts
@@ -1,0 +1,48 @@
+/**
+ * High-level per-tenant DB provisioning seam (Apps / Product 2).
+ *
+ * Composes the cluster pool (where) + the per-tenant provisioner (what) into a
+ * single `provisionForApp(appId)` that `UserDatabaseService` calls instead of
+ * handing apps the shared agent DATABASE_URL. Every dependency is injected, so
+ * the orchestration is unit-testable with no DB; the concrete cluster store +
+ * the real Postgres executor (the IO backends) plug in behind these seams.
+ */
+
+import type { AllocatedCluster } from "./cluster-pool";
+import type { ProvisionedTenantDb, TenantDbCluster } from "./tenant-db-provisioner";
+
+/** What `UserDatabaseService` depends on: provision an isolated DB for an app. */
+export interface TenantDbProvisioning {
+  /** Returns the app's own isolated DSN + the cluster it was placed on. */
+  provisionForApp(appId: string): Promise<{ dsn: string; clusterId: string }>;
+}
+
+/** A per-cluster provisioner (the U2 `SqlTenantDbProvisioner` shape). */
+export interface TenantDbProvisioner {
+  provision(appId: string): Promise<ProvisionedTenantDb>;
+}
+
+export interface SqlTenantDbProvisioningDeps {
+  /** Allocates the least-loaded cluster with capacity. */
+  pool: { allocate(): Promise<AllocatedCluster> };
+  /** Decrypts a cluster's stored admin DSN. */
+  decrypt: (encrypted: string) => Promise<string>;
+  /** Builds a provisioner bound to a cluster's admin connection. */
+  makeProvisioner: (cluster: TenantDbCluster, adminDsn: string) => TenantDbProvisioner;
+}
+
+export class SqlTenantDbProvisioning implements TenantDbProvisioning {
+  private readonly deps: SqlTenantDbProvisioningDeps;
+
+  constructor(deps: SqlTenantDbProvisioningDeps) {
+    this.deps = deps;
+  }
+
+  async provisionForApp(appId: string): Promise<{ dsn: string; clusterId: string }> {
+    const allocated = await this.deps.pool.allocate();
+    const adminDsn = await this.deps.decrypt(allocated.adminDsnEncrypted);
+    const provisioner = this.deps.makeProvisioner({ host: allocated.host }, adminDsn);
+    const result = await provisioner.provision(appId);
+    return { dsn: result.dsn, clusterId: allocated.id };
+  }
+}

--- a/packages/cloud-shared/src/lib/services/user-database.ts
+++ b/packages/cloud-shared/src/lib/services/user-database.ts
@@ -11,6 +11,7 @@ import type { App, UserDatabaseStatus } from "../../db/schemas/apps";
 import { logger } from "../utils/logger";
 import { fieldEncryption } from "./field-encryption";
 import { getNeonClient } from "./neon-client";
+import type { TenantDbProvisioning } from "./tenant-db/tenant-db-provisioning";
 
 /**
  * Result from provisioning a user database.
@@ -59,6 +60,19 @@ export interface DatabaseStatus {
 }
 
 export class UserDatabaseService {
+  private readonly tenantDbProvisioning?: TenantDbProvisioning;
+
+  /**
+   * @param tenantDbProvisioning When provided, apps get a fully ISOLATED
+   *   per-tenant database (own DB + role + REVOKE-CONNECT boundary). When
+   *   omitted, falls back to the legacy shared cloud DATABASE_URL. The real
+   *   isolated backend is injected once its cluster store + Postgres executor
+   *   are wired (Apps / Product 2).
+   */
+  constructor(tenantDbProvisioning?: TenantDbProvisioning) {
+    this.tenantDbProvisioning = tenantDbProvisioning;
+  }
+
   /**
    * Provision a database for an app.
    *
@@ -142,16 +156,27 @@ export class UserDatabaseService {
     }
 
     try {
-      // Use shared cloud DATABASE_URL instead of per-app Neon projects.
-      // ElizaOS plugin-sql tables scope data by agent/app UUID, so multiple
-      // apps safely coexist. This avoids BRANCHES_LIMIT_EXCEEDED errors.
-      const sharedDbUrl = process.env.DATABASE_URL;
-      if (!sharedDbUrl) {
-        throw new Error("DATABASE_URL not configured in cloud environment");
+      // Per-tenant ISOLATED database (Apps / Product 2) when the provisioning
+      // backend is wired; otherwise fall back to the legacy shared cloud
+      // DATABASE_URL (plugin-sql tables scope by agent/app UUID, so the shared
+      // mode still coexists safely). The isolated path provisions the app its
+      // own DB + role and stores that real DSN — never the shared agent URL.
+      let connectionUri: string;
+      let clusterId: string | undefined;
+      if (this.tenantDbProvisioning) {
+        const provisioned = await this.tenantDbProvisioning.provisionForApp(appId);
+        connectionUri = provisioned.dsn;
+        clusterId = provisioned.clusterId;
+      } else {
+        const sharedDbUrl = process.env.DATABASE_URL;
+        if (!sharedDbUrl) {
+          throw new Error("DATABASE_URL not configured in cloud environment");
+        }
+        connectionUri = sharedDbUrl;
       }
 
-      // Encrypt the connection URI before storing
-      const encryptedUri = await fieldEncryption.encrypt(app.organization_id, sharedDbUrl);
+      // Encrypt the connection URI before storing.
+      const encryptedUri = await fieldEncryption.encrypt(app.organization_id, connectionUri);
 
       await appDatabasesRepository.updateState(appId, {
         user_database_uri: encryptedUri,
@@ -159,11 +184,15 @@ export class UserDatabaseService {
         user_database_error: null,
       });
 
-      logger.info("Database provisioned successfully (shared DB)", { appId });
+      logger.info("Database provisioned successfully", {
+        appId,
+        mode: this.tenantDbProvisioning ? "isolated" : "shared",
+        clusterId,
+      });
 
       return {
         success: true,
-        connectionUri: sharedDbUrl,
+        connectionUri,
         region,
       };
     } catch (error) {


### PR DESCRIPTION
## Eliza Cloud Apps (Product 2) — per-tenant-isolated container hosting

Lets users deploy arbitrary container apps with a **per-tenant database, sign-in, a per-app URL, and metered hosting billing**, isolated from the shared Eliza **agent** system. Layered onto 2AM's `/api/v1/containers` surface — never rebuilt.

**Draft for review (nubs + Shaw). Not requesting merge yet.** All changes are additive and the agent plane is byte-for-byte untouched; the apps path is feature-gated off until its env/infra is configured.

### What's here (all in `packages/cloud-shared`, additive)
- **Per-tenant DB isolation** — `tenant_db_clusters` pool (race-safe `tryClaimSlot`), `SqlTenantDbProvisioner` + `DirectPgExecutor`, composer `makeTenantDbProvisioning`. Strategy: DATABASE+ROLE-per-tenant with `REVOKE CONNECT … FROM PUBLIC` (a hard auth-layer boundary), pluggable provider. Migration `0140` (journal-registered).
- **Per-tenant network isolation** — `--internal` network + `--cap-drop=ALL`/`no-new-privileges`/`pids-limit`, default-deny egress proxy. Never `NET_ADMIN`/tun (those stay agent-only).
- **Repo→image build pipeline** — pure ref/build-cmd builders + `AppImageBuilder` (over an injected SSH/exec seam).
- **Deploy orchestration + adapters** — `AppDeployRunner` (ensure tenant DB → create container row carrying the per-tenant DSN → enqueue `CONTAINER_PROVISION` → link via `apps.metadata.containerId`), `AppContainerStore` (maps host placement into `containers.metadata`), `ContainerJobsWriter`.
- **Per-app URL** — reuses the shared `derivePublicHostname` (ingress source of truth) to stamp `public_hostname`/`load_balancer_url` + `apps.production_url`.
- **`APP_DEPLOY` trigger** — the Worker enqueues `APP_DEPLOY` (pg-free); the daemon claims it and runs the node runner, so `pg`/SSH never touch the workerd request path.

### Verified for real (not mocks)
- **Real Postgres 16:** cross-tenant connection rejected — `permission denied for database` (`REVOKE CONNECT`).
- **Real Docker:** `scripts/verify-e2e-deploy.sh` 5/5 — build user image → provision per-tenant DB → run `--internal` isolated container with its DSN → reaches its own DB + serves its URL → rejected from other tenants' DBs → no egress.
- **Real drizzle schema (PGlite):** `scripts/verify-deploy-db-writes.sh` 10/10 — adapter inserts, the per-tenant-DSN-in-`environment_vars` invariant, URL stamping.
- **236 unit tests green, typecheck + biome clean.** Migration `0140` applies in the full real chain.

### Remaining rollout (NOT in this PR — needs infra + review)
1. Two boot one-liners during apps-infra rollout: cloud-api `configureAppsDeployTrigger()` + daemon `configureAppsDeployBackend({ registry, buildExec })`.
2. Apps **data-plane infra** via terraform+CI: app docker node(s), the tenant Postgres cluster, image registry, egress proxy.
3. VPS scratch kernel-validation (read-only / non-destructive).

### Non-collision
Rebased-clean on `develop` (new files + appended enum keys / switch cases). Does not touch the agent path or 2AM's hot files (`v1/containers/route.ts`, `[id]/route.ts`, `cron/container-billing/route.ts`, `db/schemas/containers.ts`, `hetzner-client/client.ts`). Billing-field init (`next_billing_at`) is a coordination item with 2AM's #8273.
