### PR TITLE
registry: add @usenami/plugin-signer (third-party)

### DIFF
--- a/packages/registry/entries/third-party/usenami__plugin-signer.json
+++ b/packages/registry/entries/third-party/usenami__plugin-signer.json
@@ -1,0 +1,9 @@
+{
+  "package": "@usenami/plugin-signer",
+  "repository": "github:namixai/plugin-signer",
+  "kind": "plugin",
+  "description": "Keyless CEX/DEX perp order signing for elizaOS agents — HMAC/EIP-712 signatures are computed inside an AWS Nitro Enclave, so the venue API key never enters the agent process. Covers 6 venues: Binance, OKX, Asterdex, KuCoin, Bybit, Hyperliquid.",
+  "homepage": "https://usenami.io/signer",
+  "version": "0.2.0",
+  "tags": ["trading", "perpetuals", "cex", "dex", "signing", "security", "nitro-enclave"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -45,6 +45,53 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@usenami/plugin-signer": {
+      "git": {
+        "repo": "namixai/plugin-signer",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@usenami/plugin-signer",
+        "v0": null,
+        "v1": null,
+        "v2": "0.2.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Keyless CEX/DEX perp order signing for elizaOS agents — HMAC/EIP-712 signatures are computed inside an AWS Nitro Enclave, so the venue API key never enters the agent process. Covers 6 venues: Binance, OKX, Asterdex, KuCoin, Bybit, Hyperliquid.",
+      "homepage": "https://usenami.io/signer",
+      "topics": [
+        "trading",
+        "perpetuals",
+        "cex",
+        "dex",
+        "signing",
+        "security",
+        "nitro-enclave"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "elizaos-plugin-echo": {
       "git": {
         "repo": "elizaOS/eliza",


### PR DESCRIPTION
Adds a third-party community registry entry for **`@usenami/plugin-signer`** — an ElizaOS plugin that signs CEX/DEX perpetual orders through an **AWS Nitro Enclave**, so the venue API key never enters the agent process (HMAC/EIP-712 signing happens inside attested code; enclave-side per-asset policy caps). Covers 6 venues: Binance, OKX, Asterdex, KuCoin, Bybit, Hyperliquid.

- **npm:** [`@usenami/plugin-signer@0.2.0`](https://www.npmjs.com/package/@usenami/plugin-signer) (community scope; `@elizaos/*` left reserved)
- **repo:** [github.com/namixai/plugin-signer](https://github.com/namixai/plugin-signer) (public, MIT, CI green)
- **landing:** [usenami.io/signer](https://usenami.io/signer)

Checklist (per `packages/registry` README / publish docs):
- [x] Published to npm under our own scope
- [x] `elizaos` keyword in package.json (auto-discovery)
- [x] Public GitHub repository
- [x] README with setup + required env vars (`SIGNER_GATEWAY_URL`, `SIGNER_API_TOKEN`)
- [x] `entries/third-party/usenami__plugin-signer.json` added; `bun run --cwd packages/registry validate && generate` run (3 entries OK), regenerated `generated-registry.json` included

**Security note:** keys are generated and used only inside the Nitro Enclave; the running code is provable via PCR0 (AWS-signed measurement) + an on-chain registration, and the KMS-encrypted key material is bound to that exact PCR0 — only the attested enclave can decrypt. Maintainer: namixai (contact: alex@usenami.io).