### PR TITLE
fix(cloud): align Steward agent register/cleanup signing with shared helper

### DIFF
--- a/packages/cloud-api/__tests__/steward-sign.test.ts
+++ b/packages/cloud-api/__tests__/steward-sign.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildStewardCanonicalRequest,
   signStewardMutatingRequest,
-} from "../src/steward/sign";
+} from "@elizaos/cloud-shared/lib/steward/sign.ts";
 
 // gitleaks:allow — synthetic test value, no entropy / real-key shape needed.
 const SECRET = "test_only_steward_secret_aaaaaaaaaaaaa";

--- a/packages/cloud-api/auth/steward-nonce-exchange/route.ts
+++ b/packages/cloud-api/auth/steward-nonce-exchange/route.ts
@@ -29,7 +29,7 @@ import {
 } from "@elizaos/shared/steward-session-client";
 import { Hono } from "hono";
 import { setCookie } from "hono/cookie";
-import { signStewardMutatingRequest } from "@/api-app/steward/sign";
+import { signStewardMutatingRequest } from "@/lib/steward/sign";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
 import {
   type StewardVerifyEnv,

--- a/packages/cloud-api/auth/steward-refresh/route.ts
+++ b/packages/cloud-api/auth/steward-refresh/route.ts
@@ -30,7 +30,7 @@ import {
 } from "@elizaos/shared/steward-session-client";
 import { Hono } from "hono";
 import { deleteCookie, getCookie, setCookie } from "hono/cookie";
-import { signStewardMutatingRequest } from "@/api-app/steward/sign";
+import { signStewardMutatingRequest } from "@/lib/steward/sign";
 import { cookieDomainForHost } from "@/lib/auth/cookie-domain";
 import {
   type StewardVerifyEnv,

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -8,14 +8,17 @@
  * Reference: eliza-cloud/backend/services/container-orchestrator.ts
  */
 
-import { createHash, createHmac } from "node:crypto";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import type { DockerNode } from "../../db/schemas/docker-nodes";
-import { isAgentTokenSigningConfigured, mintAgentToken } from "../auth/agent-token";
+import {
+  isAgentTokenSigningConfigured,
+  mintAgentToken,
+} from "../auth/agent-token";
 import { containersEnv } from "../config/containers-env";
 import { getAgentBaseDomain } from "../eliza-agent-web-ui";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
+import { signStewardMutatingRequest } from "../steward/sign";
 import { resolveServerStewardApiUrlFromEnv } from "../steward-url";
 import { logger } from "../utils/logger";
 import { getNodeAutoscaler } from "./containers/node-autoscaler";
@@ -45,8 +48,15 @@ import {
 } from "./docker-sandbox-utils";
 import { DockerSSHClient } from "./docker-ssh";
 import { headscaleIntegration } from "./headscale-integration";
-import type { SandboxCreateConfig, SandboxHandle, SandboxProvider } from "./sandbox-provider-types";
-import { ensureStewardTenant, resolveStewardTenantCredentials } from "./steward-tenant-config";
+import type {
+  SandboxCreateConfig,
+  SandboxHandle,
+  SandboxProvider,
+} from "./sandbox-provider-types";
+import {
+  ensureStewardTenant,
+  resolveStewardTenantCredentials,
+} from "./steward-tenant-config";
 
 // ---------------------------------------------------------------------------
 // Exported metadata type for strongly-typed provider metadata
@@ -112,7 +122,10 @@ function resolveStewardHostUrl(): string {
 
 function resolveStewardContainerEnvUrl(): string {
   const env = getCloudAwareEnv();
-  return resolveStewardContainerUrl(resolveStewardHostUrl(), env.STEWARD_CONTAINER_URL);
+  return resolveStewardContainerUrl(
+    resolveStewardHostUrl(),
+    env.STEWARD_CONTAINER_URL,
+  );
 }
 
 const STEWARD_JWT_FILE = "/app/data/steward.jwt";
@@ -145,7 +158,10 @@ function resolveElizaCloudPublicUrl(): string {
 
 function resolveStewardRefreshUrl(): string {
   const env = getCloudAwareEnv();
-  if (typeof env.STEWARD_REFRESH_URL === "string" && env.STEWARD_REFRESH_URL.trim()) {
+  if (
+    typeof env.STEWARD_REFRESH_URL === "string" &&
+    env.STEWARD_REFRESH_URL.trim()
+  ) {
     return env.STEWARD_REFRESH_URL.trim();
   }
   return `${resolveElizaCloudPublicUrl()}/v1/agent-tokens`;
@@ -153,8 +169,12 @@ function resolveStewardRefreshUrl(): string {
 
 function resolveStewardRefreshServiceToken(): string {
   const env = getCloudAwareEnv();
-  for (const candidate of [env.ELIZA_CLOUD_SERVICE_TOKEN, env.AGENT_TOKEN_SERVICE_TOKEN]) {
-    if (typeof candidate === "string" && candidate.trim()) return candidate.trim();
+  for (const candidate of [
+    env.ELIZA_CLOUD_SERVICE_TOKEN,
+    env.AGENT_TOKEN_SERVICE_TOKEN,
+  ]) {
+    if (typeof candidate === "string" && candidate.trim())
+      return candidate.trim();
   }
   return "";
 }
@@ -171,9 +191,14 @@ function resolveStewardRefreshServiceToken(): string {
  * Persona + connector POLICY fields (dmPolicy, messagePrefix, enabled, etc.)
  * are preserved so the runtime still loads the right character + behaviour.
  */
-function redactCharacterSecrets(character: Record<string, unknown>): Record<string, unknown> {
+function redactCharacterSecrets(
+  character: Record<string, unknown>,
+): Record<string, unknown> {
   // Deep clone so we never mutate the caller's DB-derived object.
-  const clone = JSON.parse(JSON.stringify(character)) as Record<string, unknown>;
+  const clone = JSON.parse(JSON.stringify(character)) as Record<
+    string,
+    unknown
+  >;
   delete clone.secrets;
   if (clone.settings && typeof clone.settings === "object") {
     delete (clone.settings as Record<string, unknown>).secrets;
@@ -274,7 +299,8 @@ export function requiresHeadscaleRoute(
     // every key from it (Copilot review on #8152).
     const cloudEnv = getCloudAwareEnv();
     return {
-      AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK: cloudEnv.AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK,
+      AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK:
+        cloudEnv.AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK,
       CONTAINERS_PUBLIC_BASE_DOMAIN: cloudEnv.CONTAINERS_PUBLIC_BASE_DOMAIN,
       ELIZA_CLOUD_AGENT_BASE_DOMAIN: cloudEnv.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
       ENVIRONMENT: cloudEnv.ENVIRONMENT,
@@ -339,7 +365,9 @@ function buildStewardPluginInstallCommand(containerName: string): string {
  * (the proxy listens on the docker host). Returns an empty object when
  * proxy mode is disabled so callers can spread it unconditionally.
  */
-export function buildStewardProxyEnv(env: NodeJS.ProcessEnv = process.env): Record<string, string> {
+export function buildStewardProxyEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
   if (env.USE_STEWARD_PROXY !== "true") return {};
   const base = "http://host.docker.internal:8080";
   return {
@@ -370,7 +398,9 @@ const AUTOSCALED_NODE_READY_POLL_MS = 10_000;
 
 function getDockerHealthCmd(port: string, path = "/api/health"): string {
   if (!/^\d+$/.test(port)) {
-    throw new Error(`[docker-sandbox] Invalid port "${port}": must be a numeric string.`);
+    throw new Error(
+      `[docker-sandbox] Invalid port "${port}": must be a numeric string.`,
+    );
   }
   if (!/^\/[A-Za-z0-9._~/-]*$/.test(path)) {
     throw new Error(`[docker-sandbox] Invalid health check path "${path}".`);
@@ -382,7 +412,8 @@ function getDockerHealthCmd(port: string, path = "/api/health"): string {
 
 export function resolveContainerPort(config: SandboxCreateConfig): string {
   const requested =
-    typeof config.environmentVars.PORT === "string" && config.environmentVars.PORT.trim()
+    typeof config.environmentVars.PORT === "string" &&
+    config.environmentVars.PORT.trim()
       ? config.environmentVars.PORT.trim()
       : typeof config.environmentVars.HTTP_PORT === "string" &&
           config.environmentVars.HTTP_PORT.trim()
@@ -399,7 +430,9 @@ export function resolveContainerPort(config: SandboxCreateConfig): string {
 function extractStewardToken(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) {
-    throw new Error("[docker-sandbox] Steward token endpoint returned an empty response");
+    throw new Error(
+      "[docker-sandbox] Steward token endpoint returned an empty response",
+    );
   }
 
   try {
@@ -457,7 +490,9 @@ function warnMissingStewardTenantApiKey(apiKey?: string) {
   );
 }
 
-function resolveStewardRequestSigningSecret(apiKey?: string): string | undefined {
+function resolveStewardRequestSigningSecret(
+  apiKey?: string,
+): string | undefined {
   const env = getCloudAwareEnv();
   const explicit = env.STEWARD_REQUEST_SIGNING_SECRET?.trim();
   if (explicit) {
@@ -469,73 +504,79 @@ function resolveStewardRequestSigningSecret(apiKey?: string): string | undefined
   return fromList ?? apiKey?.trim() ?? undefined;
 }
 
-function resolveStewardRequestSigningKeyId(): string | undefined {
-  const keyId = getCloudAwareEnv().STEWARD_REQUEST_SIGNING_KEY_ID?.trim();
-  return keyId && keyId.length > 0 ? keyId : undefined;
+// Pre-compute the Steward-required HMAC signature headers for a POST that
+// runs on a remote worker node via the Python shim below. We sign here in
+// Node (where the signing secret lives) and pass the headers verbatim into
+// the script. Uses the shared `signStewardMutatingRequest` helper so the
+// canonical-request shape stays byte-for-byte in lockstep with the Worker's
+// `steward-refresh` and `steward-nonce-exchange` bypasses; a divergence
+// (e.g. the legacy `X-Steward-Request-Timestamp` field) makes Steward reject
+// with `Invalid request signature` and fall through to the session-owner
+// check, which then 403s with "owner or admin session required".
+// Best-effort `curl -X DELETE` against Steward's `/agents/:id` for cleanup
+// paths (failed container create, missing Headscale registration). Signs the
+// request when STEWARD_REQUEST_SIGNING_SECRET is configured so Steward's
+// authorization-signature middleware accepts it. Without signing the call
+// 401s and the agent record stays around as a ghost, blocking later retries.
+async function buildSignedDeleteAgentCurl(
+  agentId: string,
+  stewardTenant: { tenantId: string; apiKey?: string },
+): Promise<string> {
+  const path = `/agents/${encodeURIComponent(agentId)}`;
+  const url = `${resolveStewardHostUrl()}${path}`;
+  const signingSecret = resolveStewardRequestSigningSecret(
+    stewardTenant.apiKey,
+  );
+  const flags = [
+    `-H ${shellQuote(`X-Steward-Tenant: ${stewardTenant.tenantId}`)}`,
+    ...(stewardTenant.apiKey
+      ? [`-H ${shellQuote(`X-Steward-Key: ${stewardTenant.apiKey}`)}`]
+      : []),
+  ];
+  if (signingSecret !== undefined) {
+    const signed = await buildStewardSignedHeaders({
+      method: "DELETE",
+      path,
+      body: "",
+      tenantId: stewardTenant.tenantId,
+      ...(stewardTenant.apiKey === undefined
+        ? {}
+        : { apiKey: stewardTenant.apiKey }),
+      signingSecret,
+    });
+    for (const [name, value] of Object.entries(signed)) {
+      flags.push(`-H ${shellQuote(`${name}: ${value}`)}`);
+    }
+  }
+  return `curl -s -X DELETE ${flags.join(" ")} ${shellQuote(url)} || true`;
 }
 
-function sha256TextHex(value: string): string {
-  return createHash("sha256").update(value).digest("hex");
-}
-
-function buildStewardCanonicalRequest(input: {
+async function buildStewardSignedHeaders(params: {
   method: string;
-  path: string;
-  tenantId: string;
-  apiKey: string;
-  timestamp: string;
-  expiresAt: string;
-  idempotencyKey: string;
-  body: string;
-}): string {
-  return [
-    "steward-request-signature-v1",
-    input.method.toUpperCase(),
-    input.path,
-    input.tenantId,
-    sha256TextHex(""),
-    sha256TextHex(input.apiKey),
-    sha256TextHex(""),
-    sha256TextHex(""),
-    sha256TextHex(""),
-    sha256TextHex(""),
-    sha256TextHex(""),
-    input.timestamp,
-    input.expiresAt,
-    input.idempotencyKey,
-    sha256TextHex(input.body),
-  ].join("\n");
-}
-
-function buildStewardSignedHeaders(params: {
   path: string;
   body: string;
   tenantId: string;
   apiKey?: string;
   signingSecret: string;
-}): Record<string, string> {
-  const timestamp = Math.floor(Date.now() / 1000).toString();
-  const expiresAt = (Number(timestamp) + 300).toString();
-  const idempotencyKey = `eliza-cloud-${crypto.randomUUID()}`;
-  const signingKeyId = resolveStewardRequestSigningKeyId();
-  const canonical = buildStewardCanonicalRequest({
-    method: "POST",
-    path: params.path,
-    tenantId: params.tenantId,
-    apiKey: params.apiKey ?? "",
-    timestamp,
-    expiresAt,
-    idempotencyKey,
-    body: params.body,
+}): Promise<Record<string, string>> {
+  const headers = new Headers();
+  headers.set("X-Steward-Tenant", params.tenantId);
+  if (params.apiKey) headers.set("X-Steward-Key", params.apiKey);
+  await signStewardMutatingRequest(
+    params.signingSecret,
+    params.method,
+    params.path,
+    headers,
+    new TextEncoder().encode(params.body),
+  );
+  const out: Record<string, string> = {};
+  headers.forEach((value, name) => {
+    // Strip tenant/key — they're set separately by the caller (Python shim
+    // or curl flag) and we don't want to double-inject them.
+    if (name === "x-steward-tenant" || name === "x-steward-key") return;
+    out[name] = value;
   });
-  const signature = createHmac("sha256", params.signingSecret).update(canonical).digest("hex");
-  return {
-    "X-Steward-Request-Timestamp": timestamp,
-    "X-Steward-Request-Expires-At": expiresAt,
-    "Idempotency-Key": idempotencyKey,
-    "X-Steward-Signature": `v1=${signature}`,
-    ...(signingKeyId === undefined ? {} : { "X-Steward-Signing-Key-Id": signingKeyId }),
-  };
+  return out;
 }
 
 async function registerAgentWithSteward(
@@ -552,7 +593,8 @@ async function registerAgentWithSteward(
   const agentSignedHeaders =
     signingSecret === undefined
       ? {}
-      : buildStewardSignedHeaders({
+      : await buildStewardSignedHeaders({
+          method: "POST",
           path: "/agents",
           body: agentBody,
           tenantId,
@@ -562,7 +604,8 @@ async function registerAgentWithSteward(
   const tokenSignedHeaders =
     signingSecret === undefined
       ? {}
-      : buildStewardSignedHeaders({
+      : await buildStewardSignedHeaders({
+          method: "POST",
           path: `/agents/${encodeURIComponent(agentId)}/token`,
           body: tokenBody,
           tenantId,
@@ -692,7 +735,10 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     // Unreachable, but satisfies the compiler
-    throw lastError ?? new Error("[docker-sandbox] create exhausted all retry attempts");
+    throw (
+      lastError ??
+      new Error("[docker-sandbox] create exhausted all retry attempts")
+    );
   }
 
   /**
@@ -703,9 +749,17 @@ export class DockerSandboxProvider implements SandboxProvider {
    * sandboxes, so a duplicate will fail at INSERT time. The public `create()`
    * method wraps this in a retry loop to handle port collisions automatically.
    */
-  private async _createOnce(config: SandboxCreateConfig): Promise<SandboxHandle> {
-    const { agentId, agentName, environmentVars, organizationId, agentConfig, routeAgentId } =
-      config;
+  private async _createOnce(
+    config: SandboxCreateConfig,
+  ): Promise<SandboxHandle> {
+    const {
+      agentId,
+      agentName,
+      environmentVars,
+      organizationId,
+      agentConfig,
+      routeAgentId,
+    } = config;
 
     // Resolve Docker image: per-agent DB override > operator env override > hardcoded default.
     // Keep the fallback out of DOCKER_IMAGE_OVERRIDE so per-agent flavor/image
@@ -722,7 +776,8 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     const cloudEnv = getCloudAwareEnv();
     const env: HeadscaleRouteEnv = {
-      AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK: cloudEnv.AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK,
+      AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK:
+        cloudEnv.AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK,
       CONTAINERS_PUBLIC_BASE_DOMAIN: cloudEnv.CONTAINERS_PUBLIC_BASE_DOMAIN,
       ELIZA_CLOUD_AGENT_BASE_DOMAIN: cloudEnv.ELIZA_CLOUD_AGENT_BASE_DOMAIN,
       ENVIRONMENT: cloudEnv.ENVIRONMENT,
@@ -809,7 +864,11 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     // 3. Allocate ports (check DB for existing assignments to avoid collisions)
     const usedPorts = await getUsedDockerHostPorts(nodeId);
-    const bridgePort = allocatePort(BRIDGE_PORT_MIN, BRIDGE_PORT_MAX, usedPorts);
+    const bridgePort = allocatePort(
+      BRIDGE_PORT_MIN,
+      BRIDGE_PORT_MAX,
+      usedPorts,
+    );
     // No need to add bridgePort to exclusion set — web UI port range [20000,25000)
     // never overlaps bridge range [18790,19790)
     const webUiPort = allocatePort(WEBUI_PORT_MIN, WEBUI_PORT_MAX, usedPorts);
@@ -845,11 +904,13 @@ export class DockerSandboxProvider implements SandboxProvider {
       } catch (err) {
         if (headscaleRouteRequired) {
           if (dbNode) {
-            await dockerNodesRepository.decrementAllocated(nodeId).catch((rollbackErr) => {
-              logger.warn(
-                `[docker-sandbox] Failed to decrement allocated_count after Headscale preparation failure for node ${nodeId}: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
-              );
-            });
+            await dockerNodesRepository
+              .decrementAllocated(nodeId)
+              .catch((rollbackErr) => {
+                logger.warn(
+                  `[docker-sandbox] Failed to decrement allocated_count after Headscale preparation failure for node ${nodeId}: ${rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr)}`,
+                );
+              });
           }
           throw err;
         }
@@ -888,7 +949,8 @@ export class DockerSandboxProvider implements SandboxProvider {
       kmsEnv.ELIZA_KMS_BACKEND = backend;
       if (backend === "local") {
         const rootKey =
-          environmentVars.ELIZA_LOCAL_ROOT_KEY?.trim() || process.env.ELIZA_LOCAL_ROOT_KEY?.trim();
+          environmentVars.ELIZA_LOCAL_ROOT_KEY?.trim() ||
+          process.env.ELIZA_LOCAL_ROOT_KEY?.trim();
         if (rootKey) kmsEnv.ELIZA_LOCAL_ROOT_KEY = rootKey;
       }
     }
@@ -911,7 +973,9 @@ export class DockerSandboxProvider implements SandboxProvider {
       // no agent_config (the runtime keeps its default-character behaviour).
       ...(agentConfig && typeof agentConfig === "object"
         ? {
-            ELIZA_AGENT_CHARACTER_JSON: JSON.stringify(redactCharacterSecrets(agentConfig)),
+            ELIZA_AGENT_CHARACTER_JSON: JSON.stringify(
+              redactCharacterSecrets(agentConfig),
+            ),
           }
         : {}),
       STEWARD_API_URL: stewardContainerUrl,
@@ -943,7 +1007,12 @@ export class DockerSandboxProvider implements SandboxProvider {
     // 6. SSH to node, ensure volume dir, pull image, register in Steward,
     // then create/start the container. Pass hostKeyFingerprint so pooled
     // clients pin the key when available.
-    const ssh = DockerSSHClient.getClient(hostname, sshPort, hostKeyFingerprint, sshUser);
+    const ssh = DockerSSHClient.getClient(
+      hostname,
+      sshPort,
+      hostKeyFingerprint,
+      sshUser,
+    );
 
     try {
       // Ensure volume directory exists
@@ -953,10 +1022,14 @@ export class DockerSandboxProvider implements SandboxProvider {
       );
 
       // Pull image (may take a while on first run)
-      logger.info(`[docker-sandbox] Pulling image ${resolvedImage} on ${nodeId}`);
+      logger.info(
+        `[docker-sandbox] Pulling image ${resolvedImage} on ${nodeId}`,
+      );
       try {
         await ssh.exec(
-          ["docker pull", ...platformFlags, shellQuote(resolvedImage)].join(" "),
+          ["docker pull", ...platformFlags, shellQuote(resolvedImage)].join(
+            " ",
+          ),
           PULL_TIMEOUT_MS,
         );
         logger.info(`[docker-sandbox] Image pulled successfully on ${nodeId}`);
@@ -984,7 +1057,8 @@ export class DockerSandboxProvider implements SandboxProvider {
       // sandbox will skip registration silently in that case.
       const registryRedisUrl = process.env.KV_REST_API_URL?.trim() ?? "";
       const registryRedisToken = process.env.KV_REST_API_TOKEN?.trim() ?? "";
-      const canSelfRegister = registryRedisUrl !== "" && registryRedisToken !== "";
+      const canSelfRegister =
+        registryRedisUrl !== "" && registryRedisToken !== "";
       if (!canSelfRegister) {
         logger.warn(
           "[docker-sandbox] KV_REST_API_URL / KV_REST_API_TOKEN missing from orchestrator env — sandbox will not register in Redis and gateways will not route inbound platform messages to it",
@@ -1033,7 +1107,8 @@ export class DockerSandboxProvider implements SandboxProvider {
         // (no D-Bus keychain). Generate one per container — the vault state
         // lives only in the per-container PGlite, so a unique per-launch key
         // is fine.
-        ELIZA_VAULT_PASSPHRASE: environmentVars.ELIZA_VAULT_PASSPHRASE || crypto.randomUUID(),
+        ELIZA_VAULT_PASSPHRASE:
+          environmentVars.ELIZA_VAULT_PASSPHRASE || crypto.randomUUID(),
         // Gateway service discovery — see SandboxRegistry in app-core.
         // SANDBOX_PUBLIC_URL targets the public Docker host (not the headscale
         // VPN IP set later at line ~653) because the gateways on Railway can't
@@ -1046,7 +1121,9 @@ export class DockerSandboxProvider implements SandboxProvider {
               // The gateways route by the platform character_id, so the
               // container must register under (and answer as) that id, not
               // the sandbox id. Injected only when the caller provides it.
-              ...(routeAgentId?.trim() ? { SANDBOX_ROUTE_AGENT_ID: routeAgentId.trim() } : {}),
+              ...(routeAgentId?.trim()
+                ? { SANDBOX_ROUTE_AGENT_ID: routeAgentId.trim() }
+                : {}),
               SANDBOX_SERVER_NAME: `sandbox-${agentId}-${crypto.randomUUID()}`,
               SANDBOX_PUBLIC_URL: `http://${hostname}:${bridgePort}/api`,
             }
@@ -1071,7 +1148,8 @@ export class DockerSandboxProvider implements SandboxProvider {
         `--name ${shellQuote(containerName)}`,
         "--restart unless-stopped",
         `--network ${shellQuote(DOCKER_NETWORK)}`,
-        ...(requiresDockerHostGateway(stewardContainerUrl) || Object.keys(proxyEnv).length > 0
+        ...(requiresDockerHostGateway(stewardContainerUrl) ||
+        Object.keys(proxyEnv).length > 0
           ? ["--add-host host.docker.internal:host-gateway"]
           : []),
         `--health-cmd ${shellQuote(getDockerHealthCmd(allEnv.PORT || containerPort, healthCheckPath))}`,
@@ -1080,9 +1158,13 @@ export class DockerSandboxProvider implements SandboxProvider {
         "--health-start-period 15s",
         "--health-retries 6",
         ...(config.container?.memoryMb
-          ? [`--memory ${shellQuote(`${Math.ceil(config.container.memoryMb)}m`)}`]
+          ? [
+              `--memory ${shellQuote(`${Math.ceil(config.container.memoryMb)}m`)}`,
+            ]
           : []),
-        ...(headscaleEnabled ? ["--cap-add=NET_ADMIN", "--device /dev/net/tun"] : []),
+        ...(headscaleEnabled
+          ? ["--cap-add=NET_ADMIN", "--device /dev/net/tun"]
+          : []),
         `-v ${shellQuote(volumePath)}:/app/data`,
         `-v ${shellQuote(`${volumePath}/eliza`)}:/root/.eliza`,
         // The cloud image serves both API and web UI from PORT (default 3000).
@@ -1098,20 +1180,31 @@ export class DockerSandboxProvider implements SandboxProvider {
       // run the cloud-init bootstrap; the network can also be pruned away).
       // Without this, `docker create --network` below fails with an opaque
       // "network not found" and the provision retries forever.
-      await ssh.exec(buildEnsureNetworkCmd(DOCKER_NETWORK), DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        buildEnsureNetworkCmd(DOCKER_NETWORK),
+        DOCKER_CMD_TIMEOUT_MS,
+      );
 
       const containerId = extractDockerCreateContainerId(
         await ssh.exec(dockerCreateCmd, DOCKER_CMD_TIMEOUT_MS),
       );
-      await ssh.exec(`docker start ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        `docker start ${shellQuote(containerName)}`,
+        DOCKER_CMD_TIMEOUT_MS,
+      );
       logger.info(
         `[docker-sandbox] Container created on ${nodeId}: ${containerId} (${containerName})`,
       );
 
       if (shouldInstallStewardPlugin(agentId, environmentVars)) {
         try {
-          await ssh.exec(buildStewardPluginInstallCommand(containerName), PULL_TIMEOUT_MS);
-          logger.info(`[docker-sandbox] Steward Eliza plugin installed in ${containerName}`);
+          await ssh.exec(
+            buildStewardPluginInstallCommand(containerName),
+            PULL_TIMEOUT_MS,
+          );
+          logger.info(
+            `[docker-sandbox] Steward Eliza plugin installed in ${containerName}`,
+          );
         } catch (pluginErr) {
           logger.warn(
             `[docker-sandbox] Failed to install Steward Eliza plugin in ${containerName}: ${pluginErr instanceof Error ? pluginErr.message : String(pluginErr)}`,
@@ -1122,10 +1215,16 @@ export class DockerSandboxProvider implements SandboxProvider {
       if (stewardJwt && stewardRefreshServiceToken) {
         try {
           await ssh.exec(
-            buildStewardRefreshCommand(containerName, agentId, stewardRefreshServiceToken),
+            buildStewardRefreshCommand(
+              containerName,
+              agentId,
+              stewardRefreshServiceToken,
+            ),
             DOCKER_CMD_TIMEOUT_MS,
           );
-          logger.info(`[docker-sandbox] Steward JWT refresh sidecar started in ${containerName}`);
+          logger.info(
+            `[docker-sandbox] Steward JWT refresh sidecar started in ${containerName}`,
+          );
         } catch (refreshErr) {
           logger.warn(
             `[docker-sandbox] Failed to start Steward JWT refresh sidecar in ${containerName}: ${refreshErr instanceof Error ? refreshErr.message : String(refreshErr)}`,
@@ -1143,18 +1242,24 @@ export class DockerSandboxProvider implements SandboxProvider {
           cloud: {
             enabled: Boolean(allEnv.ELIZAOS_CLOUD_API_KEY),
             apiKey: allEnv.ELIZAOS_CLOUD_API_KEY || "",
-            baseUrl: allEnv.ELIZAOS_CLOUD_BASE_URL || "https://www.elizacloud.ai/api/v1",
+            baseUrl:
+              allEnv.ELIZAOS_CLOUD_BASE_URL ||
+              "https://www.elizacloud.ai/api/v1",
           },
         });
         // Base64-encode the JSON before passing it through the shell so an
         // apiKey/baseUrl containing single quotes can't break out of the
         // outer sh -c quoting or inject commands on the remote host.
-        const encodedConfig = Buffer.from(elizaConfig, "utf-8").toString("base64");
+        const encodedConfig = Buffer.from(elizaConfig, "utf-8").toString(
+          "base64",
+        );
         const writeCmd = `docker exec ${shellQuote(containerName)} sh -c ${shellQuote(
           `mkdir -p /root/.eliza && printf %s ${shellQuote(encodedConfig)} | base64 -d > /root/.eliza/eliza.json`,
         )}`;
         await ssh.exec(writeCmd, DOCKER_CMD_TIMEOUT_MS);
-        logger.info(`[docker-sandbox] Cloud config written to eliza.json in ${containerName}`);
+        logger.info(
+          `[docker-sandbox] Cloud config written to eliza.json in ${containerName}`,
+        );
       } catch (configErr) {
         logger.warn(
           `[docker-sandbox] Failed to write eliza.json: ${configErr instanceof Error ? configErr.message : String(configErr)}`,
@@ -1165,10 +1270,12 @@ export class DockerSandboxProvider implements SandboxProvider {
       // container failed to start, so we try to clean up the Steward record.
       try {
         await ssh.exec(
-          `curl -s -X DELETE -H ${shellQuote(`X-Steward-Tenant: ${stewardTenant.tenantId}`)} ${stewardTenant.apiKey ? `-H ${shellQuote(`X-Steward-Key: ${stewardTenant.apiKey}`)}` : ""} ${shellQuote(`${resolveStewardHostUrl()}/agents/${agentId}`)} || true`,
+          await buildSignedDeleteAgentCurl(agentId, stewardTenant),
           DOCKER_CMD_TIMEOUT_MS,
         );
-        logger.info(`[docker-sandbox] Cleaned up Steward agent ${agentId} after container failure`);
+        logger.info(
+          `[docker-sandbox] Cleaned up Steward agent ${agentId} after container failure`,
+        );
       } catch (cleanupErr) {
         logger.warn(
           `[docker-sandbox] Failed to cleanup Steward agent ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
@@ -1176,7 +1283,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
 
       await ssh
-        .exec(`docker rm -f ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS)
+        .exec(
+          `docker rm -f ${shellQuote(containerName)}`,
+          DOCKER_CMD_TIMEOUT_MS,
+        )
         .catch(() => {});
 
       // Rollback allocated_count on failure
@@ -1185,11 +1295,13 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
       // Clean up Headscale pre-auth key if VPN was prepared
       if (headscaleEnabled) {
-        await headscaleIntegration.cleanupContainerVPN(agentId).catch((cleanupErr) => {
-          logger.warn(
-            `[docker-sandbox] Headscale cleanup failed during rollback for ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
-          );
-        });
+        await headscaleIntegration
+          .cleanupContainerVPN(agentId)
+          .catch((cleanupErr) => {
+            logger.warn(
+              `[docker-sandbox] Headscale cleanup failed during rollback for ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
+            );
+          });
       }
       throw new Error(
         `[docker-sandbox] Failed to create container on ${nodeId}: ${err instanceof Error ? err.message : String(err)}`,
@@ -1212,7 +1324,10 @@ export class DockerSandboxProvider implements SandboxProvider {
     // 8. Wait for Headscale VPN registration if enabled
     if (headscaleEnabled) {
       try {
-        headscaleIp = await headscaleIntegration.waitForVPNRegistration(agentId, 60_000);
+        headscaleIp = await headscaleIntegration.waitForVPNRegistration(
+          agentId,
+          60_000,
+        );
         if (headscaleIp) {
           logger.info(
             `[docker-sandbox] Container ${containerName} registered on VPN: ${headscaleIp}`,
@@ -1241,7 +1356,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       });
       await ssh
         .exec(
-          `curl -s -X DELETE -H ${shellQuote(`X-Steward-Tenant: ${stewardTenant.tenantId}`)} ${stewardTenant.apiKey ? `-H ${shellQuote(`X-Steward-Key: ${stewardTenant.apiKey}`)}` : ""} ${shellQuote(`${resolveStewardHostUrl()}/agents/${agentId}`)} || true`,
+          await buildSignedDeleteAgentCurl(agentId, stewardTenant),
           DOCKER_CMD_TIMEOUT_MS,
         )
         .then(() => {
@@ -1306,18 +1421,24 @@ export class DockerSandboxProvider implements SandboxProvider {
     const hcloudToken = containersEnv.hetznerCloudToken();
     const publicKey = env.CONTAINERS_AUTOSCALE_PUBLIC_SSH_KEY?.trim();
     if (!hcloudToken || !publicKey) {
-      logger.warn("[docker-sandbox] No Docker capacity and autoscale is not configured", {
-        hasHcloudToken: Boolean(hcloudToken),
-        hasPublicKey: Boolean(publicKey),
-      });
+      logger.warn(
+        "[docker-sandbox] No Docker capacity and autoscale is not configured",
+        {
+          hasHcloudToken: Boolean(hcloudToken),
+          hasPublicKey: Boolean(publicKey),
+        },
+      );
       return null;
     }
 
     try {
-      logger.info("[docker-sandbox] No reachable Docker capacity; provisioning autoscaled node", {
-        image,
-        platform,
-      });
+      logger.info(
+        "[docker-sandbox] No reachable Docker capacity; provisioning autoscaled node",
+        {
+          image,
+          platform,
+        },
+      );
       const provisioned = await getNodeAutoscaler().provisionNode(
         {
           prePullImages: [image],
@@ -1332,7 +1453,9 @@ export class DockerSandboxProvider implements SandboxProvider {
 
       const deadline = Date.now() + AUTOSCALED_NODE_READY_TIMEOUT_MS;
       while (Date.now() < deadline) {
-        const node = await dockerNodesRepository.findByNodeId(provisioned.nodeId);
+        const node = await dockerNodesRepository.findByNodeId(
+          provisioned.nodeId,
+        );
         if (
           node &&
           (await dockerNodeManager.ensureNodeReady(node, {
@@ -1345,18 +1468,26 @@ export class DockerSandboxProvider implements SandboxProvider {
           });
           return node;
         }
-        await new Promise((resolve) => setTimeout(resolve, AUTOSCALED_NODE_READY_POLL_MS));
+        await new Promise((resolve) =>
+          setTimeout(resolve, AUTOSCALED_NODE_READY_POLL_MS),
+        );
       }
 
-      logger.warn("[docker-sandbox] Autoscaled Docker node did not become ready before timeout", {
-        nodeId: provisioned.nodeId,
-        hostname: provisioned.hostname,
-      });
+      logger.warn(
+        "[docker-sandbox] Autoscaled Docker node did not become ready before timeout",
+        {
+          nodeId: provisioned.nodeId,
+          hostname: provisioned.hostname,
+        },
+      );
       return null;
     } catch (error) {
-      logger.warn("[docker-sandbox] Autoscaled Docker node provisioning failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        "[docker-sandbox] Autoscaled Docker node provisioning failed",
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
       return null;
     }
   }
@@ -1407,7 +1538,10 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
     }
     try {
-      await ssh.exec(`docker rm -f ${shellQuote(containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        `docker rm -f ${shellQuote(containerName)}`,
+        DOCKER_CMD_TIMEOUT_MS,
+      );
     } catch (err) {
       rmErr = err;
       const msg = err instanceof Error ? err.message : String(err);
@@ -1426,7 +1560,8 @@ export class DockerSandboxProvider implements SandboxProvider {
     // Mirrors the escalation guard in stop(), but stays best-effort (no throw)
     // because traffic has already been redirected to the new container.
     if (stopErr && rmErr) {
-      const stopMsg = stopErr instanceof Error ? stopErr.message : String(stopErr);
+      const stopMsg =
+        stopErr instanceof Error ? stopErr.message : String(stopErr);
       const rmMsg = rmErr instanceof Error ? rmErr.message : String(rmErr);
       if (!isAlreadyGoneMessage(stopMsg) && !isAlreadyGoneMessage(rmMsg)) {
         logger.warn(
@@ -1436,11 +1571,13 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
     }
 
-    await dockerNodesRepository.decrementAllocated(node.node_id).catch((err) => {
-      logger.warn(
-        `[docker-sandbox] stopOnSpecificNode: decrement allocated_count failed for ${node.node_id}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    });
+    await dockerNodesRepository
+      .decrementAllocated(node.node_id)
+      .catch((err) => {
+        logger.warn(
+          `[docker-sandbox] stopOnSpecificNode: decrement allocated_count failed for ${node.node_id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
   }
 
   async stop(sandboxId: string): Promise<void> {
@@ -1468,7 +1605,10 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     try {
       // Graceful stop with 10s timeout, then force-remove
-      await ssh.exec(`docker stop -t 10 ${shellQuote(meta.containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        `docker stop -t 10 ${shellQuote(meta.containerName)}`,
+        DOCKER_CMD_TIMEOUT_MS,
+      );
       logger.info(`[docker-sandbox] Container stopped: ${meta.containerName}`);
     } catch (err) {
       stopErr = err;
@@ -1478,7 +1618,10 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     try {
-      await ssh.exec(`docker rm -f ${shellQuote(meta.containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(
+        `docker rm -f ${shellQuote(meta.containerName)}`,
+        DOCKER_CMD_TIMEOUT_MS,
+      );
       logger.info(`[docker-sandbox] Container removed: ${meta.containerName}`);
     } catch (err) {
       rmErr = err;
@@ -1488,7 +1631,8 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     if (stopErr && rmErr) {
-      const stopMsg = stopErr instanceof Error ? stopErr.message : String(stopErr);
+      const stopMsg =
+        stopErr instanceof Error ? stopErr.message : String(stopErr);
       const rmMsg = rmErr instanceof Error ? rmErr.message : String(rmErr);
       // "No such container" from either call means the container was
       // already gone — that is a success, not a failure. We only escalate
@@ -1516,11 +1660,13 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     // Clean up Headscale VPN registration if enabled
     if (process.env.HEADSCALE_API_KEY && meta.agentId) {
-      await headscaleIntegration.cleanupContainerVPN(meta.agentId).catch((err) => {
-        logger.warn(
-          `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      });
+      await headscaleIntegration
+        .cleanupContainerVPN(meta.agentId)
+        .catch((err) => {
+          logger.warn(
+            `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
     }
 
     // Remove from in-memory registry
@@ -1591,10 +1737,14 @@ export class DockerSandboxProvider implements SandboxProvider {
       // Wait before retrying (but don't overshoot the deadline)
       const remaining = deadline - Date.now();
       if (remaining > HEALTH_CHECK_POLL_INTERVAL_MS) {
-        await new Promise((resolve) => setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL_MS));
+        await new Promise((resolve) =>
+          setTimeout(resolve, HEALTH_CHECK_POLL_INTERVAL_MS),
+        );
       } else if (remaining > 0) {
         // One last attempt after a short wait
-        await new Promise((resolve) => setTimeout(resolve, Math.min(remaining, 1000)));
+        await new Promise((resolve) =>
+          setTimeout(resolve, Math.min(remaining, 1000)),
+        );
       } else {
         break;
       }
@@ -1621,11 +1771,16 @@ export class DockerSandboxProvider implements SandboxProvider {
         diagnostics: diagnostics.slice(-12_000),
       });
     } catch (diagnosticsError) {
-      logger.warn("[docker-sandbox] Failed to collect health timeout diagnostics", {
-        containerName: meta.containerName,
-        error:
-          diagnosticsError instanceof Error ? diagnosticsError.message : String(diagnosticsError),
-      });
+      logger.warn(
+        "[docker-sandbox] Failed to collect health timeout diagnostics",
+        {
+          containerName: meta.containerName,
+          error:
+            diagnosticsError instanceof Error
+              ? diagnosticsError.message
+              : String(diagnosticsError),
+        },
+      );
     }
     return false;
   }
@@ -1634,12 +1789,19 @@ export class DockerSandboxProvider implements SandboxProvider {
   // runCommand
   // ------------------------------------------------------------------
 
-  async runCommand(sandboxId: string, cmd: string, args?: string[]): Promise<string> {
+  async runCommand(
+    sandboxId: string,
+    cmd: string,
+    args?: string[],
+  ): Promise<string> {
     const meta = await this.resolveContainer(sandboxId);
 
     // Shell-escape each argument to prevent command injection
-    const escapedArgs = args && args.length > 0 ? args.map((a) => shellQuote(a)).join(" ") : "";
-    const fullCmd = escapedArgs ? `${shellQuote(cmd)} ${escapedArgs}` : shellQuote(cmd);
+    const escapedArgs =
+      args && args.length > 0 ? args.map((a) => shellQuote(a)).join(" ") : "";
+    const fullCmd = escapedArgs
+      ? `${shellQuote(cmd)} ${escapedArgs}`
+      : shellQuote(cmd);
 
     logger.info(
       `[docker-sandbox] Executing command in ${meta.containerName}: ${cmd} ${(args ?? []).join(" ").slice(0, 80)}`,
@@ -1713,7 +1875,9 @@ export class DockerSandboxProvider implements SandboxProvider {
         let sshUser = DEFAULT_SSH_USERNAME;
         let hostKeyFingerprint: string | undefined;
 
-        const dbNode = await dockerNodesRepository.findByNodeId(sandbox.node_id);
+        const dbNode = await dockerNodesRepository.findByNodeId(
+          sandbox.node_id,
+        );
         if (dbNode) {
           hostname = dbNode.hostname;
           sshPort = dbNode.ssh_port ?? DEFAULT_SSH_PORT;

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -56,6 +56,7 @@ import type {
 import {
   ensureStewardTenant,
   resolveStewardTenantCredentials,
+  type StewardTenantCredentials,
 } from "./steward-tenant-config";
 
 // ---------------------------------------------------------------------------
@@ -504,15 +505,6 @@ function resolveStewardRequestSigningSecret(
   return fromList ?? apiKey?.trim() ?? undefined;
 }
 
-// Pre-compute the Steward-required HMAC signature headers for a POST that
-// runs on a remote worker node via the Python shim below. We sign here in
-// Node (where the signing secret lives) and pass the headers verbatim into
-// the script. Uses the shared `signStewardMutatingRequest` helper so the
-// canonical-request shape stays byte-for-byte in lockstep with the Worker's
-// `steward-refresh` and `steward-nonce-exchange` bypasses; a divergence
-// (e.g. the legacy `X-Steward-Request-Timestamp` field) makes Steward reject
-// with `Invalid request signature` and fall through to the session-owner
-// check, which then 403s with "owner or admin session required".
 // Best-effort `curl -X DELETE` against Steward's `/agents/:id` for cleanup
 // paths (failed container create, missing Headscale registration). Signs the
 // request when STEWARD_REQUEST_SIGNING_SECRET is configured so Steward's
@@ -520,7 +512,7 @@ function resolveStewardRequestSigningSecret(
 // 401s and the agent record stays around as a ghost, blocking later retries.
 async function buildSignedDeleteAgentCurl(
   agentId: string,
-  stewardTenant: { tenantId: string; apiKey?: string },
+  stewardTenant: StewardTenantCredentials,
 ): Promise<string> {
   const path = `/agents/${encodeURIComponent(agentId)}`;
   const url = `${resolveStewardHostUrl()}${path}`;

--- a/packages/cloud-shared/src/lib/steward/sign.ts
+++ b/packages/cloud-shared/src/lib/steward/sign.ts
@@ -1,16 +1,17 @@
 /**
  * Steward request-signing helper for callers that bypass the `/steward/*`
- * proxy in `bootstrap-app.ts` (currently the OAuth nonce-exchange route, which
- * forwards straight to upstream Steward so it can pin the tenant per-env).
+ * proxy in cloud-api's `bootstrap-app.ts` and talk to upstream Steward
+ * directly: the OAuth nonce-exchange route, the steward-refresh bypass, and
+ * the provisioning daemon's agent registration / cleanup calls.
  *
  * Steward's `authorization-signature` middleware
  * (Steward-Fi/steward: packages/api/src/middleware/authorization-signature.ts)
- * is the AUTHORITATIVE definition of the canonical request. `embedded.ts`
- * mirrors it for the proxy path; this module mirrors it for the direct path.
- * All copies MUST stay byte-for-byte in lockstep — if upstream adds, removes,
- * or reorders a header the canonical hashes, update every copy together or
- * signed requests start returning 401. Keep this list identical to
- * `buildStewardCanonicalRequest` in `embedded.ts`.
+ * is the AUTHORITATIVE definition of the canonical request. cloud-api's
+ * `embedded.ts` mirrors it for the proxy path; this module mirrors it for
+ * every direct-path caller. All copies MUST stay byte-for-byte in lockstep —
+ * if upstream adds, removes, or reorders a header the canonical hashes,
+ * update every copy together or signed requests start returning 401. Keep
+ * this list identical to `buildStewardCanonicalRequest` in `embedded.ts`.
  */
 
 // Matches embedded.ts: a short freshness window for the X-Steward-Request-*


### PR DESCRIPTION
## Why

Today we hit `"Agent creation requires owner or admin session"` (403) when the provisioning daemon tried to register a new Dedicated agent with Steward. Same shape as the 502 we just fixed on `/api/auth/steward-refresh` — Steward's authorization-signature middleware was rejecting daemon-signed requests, so it fell through to the session-owner check and 403'd.

Root cause: the daemon had its own copy of `buildStewardCanonicalRequest` / `buildStewardSignedHeaders` in `docker-sandbox-provider.ts` that diverged from the working `cloud-api/src/steward/sign.ts` helper. The daemon copy included `X-Steward-Request-Timestamp` in the canonical hash; upstream Steward (and `cloud-api/src/steward/embedded.ts` proxy mirror) hash the slot as the empty string. Daemon HMACs verified as invalid → fell through → 403.

The two best-effort cleanup `curl -X DELETE` calls also went out unsigned, so every failed registration left a Steward ghost record. That's the trail behind the `deletion_pending` agents users sometimes saw on staging.

## What

- Move `signStewardMutatingRequest` + `buildStewardCanonicalRequest` from `packages/cloud-api/src/steward/sign.ts` to `packages/cloud-shared/src/lib/steward/sign.ts` so the daemon (which lives in cloud-shared) can use the same helper as the Worker bypass routes.
- Replace the local `buildStewardCanonicalRequest` / `buildStewardSignedHeaders` in `docker-sandbox-provider.ts` with a thin wrapper that calls the shared helper and returns a flat `Record<string, string>` (the Python shim and curl path need a plain object, not a `Headers`).
- Add `buildSignedDeleteAgentCurl` for the two cleanup paths (failed container create, missing Headscale registration). Same signing as register; passes `-H` flags built from the signed header set.
- Re-point Worker imports (`auth/steward-refresh`, `auth/steward-nonce-exchange`, `__tests__/steward-sign.test.ts`) at the new shared location.

Behavior change: signed requests now match upstream Steward's canonical-request byte-for-byte. Unsigned cleanup DELETEs are now signed when `STEWARD_REQUEST_SIGNING_SECRET` is configured. No new env vars; no schema changes.

## Test plan

- [x] Unit: `bun test packages/cloud-api/__tests__/steward-sign.test.ts` → 4 pass / 0 fail
- [x] Typecheck: `bunx tsgo --noEmit` clean on cloud-shared + cloud-api for touched files
- [ ] CI green
- [ ] Manual: after merge + daemon redeploy on staging admin (`46.224.1.246`), retry "New Agent → Dedicated → develop image" from staging.elizacloud.ai — should reach `status=running` instead of failing with 403 on Steward registration
- [ ] Manual: agent deletion goes through (no `deletion_pending` ghost)

## Follow-up (not in this PR)

- `STEWARD_REQUEST_SIGNING_KEY_ID` env var declaration in `cloud-worker-env.ts:68` and `wrangler.toml:171` is now orphan — no longer consumed. Worth a cleanup pass.