### PR TITLE
infra(hetzner): apps data-plane terraform (Product 2) [DRAFT — Stan review]

### DIFF
--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/README.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/README.md
@@ -1,0 +1,53 @@
+# Eliza Cloud Apps — data plane (Hetzner) — **REVIEW DRAFT**
+
+> ⚠️ **Draft for Stan (data-plane owner). NOT applied.** This is the IaC half of
+> "Eliza Cloud Apps" (Product 2). The application code is built + verified in
+> **PR #8293**; this terraform stands up the isolated infrastructure it targets.
+> Review + harden the `STAN:` items before `terraform apply`.
+
+## What this provisions
+The **isolated apps data plane**, kept separate from the agent data plane by
+design (*agents share the data plane; apps get an isolated one*):
+
+| Resource | Purpose |
+|---|---|
+| `hcloud_network.apps` (+ subnet) | Private network for apps + their tenant DB. **No overlap with the agent net.** |
+| `hcloud_server.tenant_db` (+ volume) | One self-managed Postgres holding thousands of per-tenant `DATABASE`+`ROLE` (`REVOKE CONNECT FROM PUBLIC` per tenant). Reachable **only** on the private net. |
+| `hcloud_server.app_node[*]` | Docker host(s) for **untrusted** user containers (per-app `--internal` net + cap-drop + egress proxy). |
+| `hcloud_firewall.*` | App node: SSH + 80/443. Tenant DB: SSH only (Postgres private-net only). |
+| `cloudflare_dns_record.apps_wildcard` | `*.<apps_base_domain>` → app node (use an LB for >1 node). |
+
+## How it connects to the code (PR #8293)
+1. `terraform apply` →` outputs.tenant_db_admin_dsn` (sensitive) + `app_node_ips`.
+2. Encrypt the admin DSN, seed it into **`tenant_db_clusters`** (`provider='direct_pg'`,
+   `host=tenant_db_private_host`). The runtime `ClusterPool` allocates from it; the
+   daemon's `DirectPgExecutor` runs the per-tenant `CREATE ROLE/DATABASE/REVOKE CONNECT`.
+3. Set daemon/Worker env: `CONTAINERS_DOCKER_NODES` (= `app_node_ips`),
+   `CONTAINERS_PUBLIC_BASE_DOMAIN` (= `apps_base_domain`), `CONTAINERS_EGRESS_PROXY_URL`,
+   the image registry.
+4. Wire the 2 gated boot one-liners: cloud-api `configureAppsDeployTrigger()` +
+   daemon `configureAppsDeployBackend({ registry, buildExec })`.
+5. Flip the feature gate for an allowlist; **on-node kernel re-check** (throwaway
+   `--internal` scratch net) before opening to users.
+
+## Apply (after review)
+```bash
+cd packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane
+cp tfvars/staging.tfvars.example staging.tfvars   # fill in real values
+terraform init -backend-config=backend-staging.hcl # same R2 backend as control-plane
+terraform plan  -var-file=staging.tfvars
+terraform apply -var-file=staging.tfvars
+```
+
+## STAN — must confirm before production
+- **SSH surface:** `operator_ingress_cidrs` is world-open in the draft. Tighten.
+- **Untrusted-image hardening:** gVisor (runsc) / Kata / userns-remap + seccomp on
+  the app node — the draft uses stock docker + `--cap-drop=ALL` + `--internal`
+  (the verified baseline, not defense-in-depth vs a kernel 0-day).
+- **Tenant DB:** TLS cert for `hostssl`, backups (volume snapshots), the admin
+  password lifecycle (currently a `random_password` in TF state), Postgres tuning
+  for thousands of small DBs, and the shard story as `database_count` grows.
+- **Ingress/TLS:** install Caddy (or reuse the existing ingress-map → Caddyfile
+  emitter) on the app node; front multiple app nodes with `hcloud_load_balancer`.
+- **Egress allowlist:** `squid` default-deny currently allows only ghcr.io +
+  githubusercontent — extend to what apps legitimately need.

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/cloud-init/app-node.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/cloud-init/app-node.yaml.tftpl
@@ -1,0 +1,63 @@
+#cloud-config
+# App worker node for Eliza Cloud Apps (Product 2) — runs UNTRUSTED user
+# containers. The node daemon (provisioning-worker) SSHes in as `deploy` and runs
+# each app on its OWN `--internal` docker network with --cap-drop=ALL, behind a
+# default-deny egress proxy (see cloud-shared/lib/services/app-network-utils.ts).
+#
+# This bootstrap installs docker + a squid egress proxy + an ingress reverse
+# proxy (Caddy) that maps <shortid>.<base-domain> -> the app container's host
+# port (the ingress-map / public_hostname the runtime stamps).
+#
+# STAN: for untrusted images decide gVisor (runsc) / Kata / userns-remap +
+# seccomp profile; this draft uses stock docker + cap-drop + --internal, which is
+# the verified baseline but not defense-in-depth against a kernel 0-day.
+
+hostname: ${hostname}
+manage_etc_hosts: true
+
+users:
+  - name: deploy
+    groups: sudo, docker
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    lock_passwd: true
+    ssh_authorized_keys:
+%{ for key in operator_ssh_keys ~}
+      - ${key}
+%{ endfor ~}
+
+apt:
+  sources:
+    docker:
+      source: "deb [arch=amd64 signed-by=$KEY_FILE] https://download.docker.com/linux/ubuntu $RELEASE stable"
+      keyid: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+
+package_update: true
+packages:
+  - curl
+  - docker-ce
+  - docker-ce-cli
+  - containerd.io
+  - squid
+  - jq
+
+write_files:
+  # Default-deny egress proxy: app containers (HTTP_PROXY -> :3128) can only
+  # reach explicitly allowlisted hosts. STAN: extend allowed_dst as needed
+  # (package registries the apps legitimately need). The tenant DB is reached
+  # over the private net, NOT through this proxy.
+  - path: /etc/squid/conf.d/apps-egress.conf
+    content: |
+      http_port 3128
+      acl allowed_dst dstdomain .ghcr.io .githubusercontent.com
+      http_access allow allowed_dst
+      http_access deny all
+
+runcmd:
+  - systemctl enable docker && systemctl start docker
+  - systemctl enable squid && systemctl restart squid
+  # The tenant DB lives at ${tenant_db_host} on the private net; app containers
+  # get a per-tenant DSN pointing there (injected by the deploy runner).
+  - echo "tenant_db_host=${tenant_db_host}" > /etc/eliza-apps-node.env
+  # STAN: install Caddy (or reuse the existing ingress-map -> Caddyfile emitter)
+  # to terminate TLS and reverse-proxy <shortid>.<base> to the container host port.

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/cloud-init/tenant-db.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/cloud-init/tenant-db.yaml.tftpl
@@ -1,0 +1,59 @@
+#cloud-config
+# Tenant Postgres node for Eliza Cloud Apps (Product 2).
+#
+# Stands up ONE self-managed Postgres that holds thousands of per-tenant
+# DATABASE+ROLE (each app gets its own DB + LOGIN role with REVOKE CONNECT FROM
+# PUBLIC — the hard isolation boundary). The per-tenant DDL is run at deploy time
+# by the node daemon (DirectPgExecutor over the admin DSN); this only stands up
+# the cluster + the admin superuser + locks the network surface.
+#
+# Reachable ONLY on the private apps network (the firewall opens no public 5432).
+#
+# STAN: tune shared_buffers/max_connections for thousands of small DBs; wire
+# volume-snapshot backups; consider scram-sha-256 + per-shard nodes as
+# database_count grows.
+
+hostname: ${hostname}
+manage_etc_hosts: true
+
+users:
+  - name: deploy
+    groups: sudo
+    shell: /bin/bash
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    lock_passwd: true
+    ssh_authorized_keys:
+%{ for key in operator_ssh_keys ~}
+      - ${key}
+%{ endfor ~}
+
+package_update: true
+packages:
+  - postgresql
+  - postgresql-contrib
+  - jq
+
+runcmd:
+  # 1. Mount the data volume at the Postgres data dir (survives node rebuilds).
+  - export VOL=$(ls /dev/disk/by-id/scsi-0HC_Volume_* 2>/dev/null | head -1)
+  - if [ -n "$VOL" ] && ! blkid "$VOL" >/dev/null 2>&1; then mkfs.ext4 -F "$VOL"; fi
+  - systemctl stop postgresql || true
+  - mkdir -p /mnt/tenant-pgdata
+  - if [ -n "$VOL" ]; then echo "$VOL /mnt/tenant-pgdata ext4 defaults,nofail 0 2" >> /etc/fstab && mount -a; fi
+  - export PGVER=$(ls /etc/postgresql | head -1)
+  - export PGDATA="/mnt/tenant-pgdata/$PGVER/main"
+  - if [ ! -d "$PGDATA" ]; then mkdir -p "$PGDATA" && chown -R postgres:postgres /mnt/tenant-pgdata && sudo -u postgres /usr/lib/postgresql/$PGVER/bin/initdb -D "$PGDATA"; fi
+  # 2. Point the cluster config at the volume + listen on all ifaces (the
+  #    firewall + pg_hba are the access control; no public 5432 rule exists).
+  - sed -i "s|^data_directory.*|data_directory = '$PGDATA'|" /etc/postgresql/$PGVER/main/postgresql.conf
+  - sed -i "s|^#listen_addresses.*|listen_addresses = '*'|" /etc/postgresql/$PGVER/main/postgresql.conf
+  # 3. Allow the private apps subnet to connect (scram); deny everything else.
+  - echo "hostssl all all 10.30.0.0/16 scram-sha-256" >> /etc/postgresql/$PGVER/main/pg_hba.conf
+  - echo "host    all all 10.30.0.0/16 scram-sha-256" >> /etc/postgresql/$PGVER/main/pg_hba.conf
+  - sed -i "s|^#password_encryption.*|password_encryption = scram-sha-256|" /etc/postgresql/$PGVER/main/postgresql.conf
+  - systemctl enable postgresql && systemctl start postgresql
+  # 4. Set the admin (postgres) superuser password the daemon's admin DSN uses.
+  - sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD '${admin_password}';"
+  # STAN: generate a server TLS cert for hostssl (self-signed or internal CA);
+  # until then switch the pg_hba lines above to 'host' and the admin DSN to
+  # sslmode=disable on the private net.

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
@@ -1,0 +1,196 @@
+###############################################################################
+# Eliza Cloud Apps (Product 2) — data plane (Hetzner)
+#
+# ⚠️ REVIEW DRAFT for Stan (data-plane owner). NOT yet applied. This stands up
+# the ISOLATED apps data plane that the verified cloud-shared code (PR #8293)
+# targets — kept SEPARATE from the agent data plane by design:
+#   agents share the data plane; apps get an isolated data plane.
+#
+# Topology:
+#   - a PRIVATE network (no overlap with the agent net) that only apps + their
+#     tenant Postgres live on;
+#   - a TENANT POSTGRES node (thousands of DATABASE+ROLE, REVOKE CONNECT per
+#     tenant) reachable ONLY on the private net — never public;
+#   - APP WORKER node(s) running untrusted user containers on per-app `--internal`
+#     docker networks + a default-deny egress proxy (enforced by the runtime code
+#     in cloud-shared, see app-network-utils.ts); the node firewall is a 2nd layer.
+#
+# SECURITY ITEMS STAN MUST CONFIRM before apply (search "STAN:"):
+#   - tighten operator_ingress_cidrs (SSH currently world-open for the draft);
+#   - decide gVisor/Kata/userns hardening on the app node for untrusted images;
+#   - tenant DB backups (volume snapshots) + the admin password lifecycle;
+#   - whether the egress proxy allowlist + Postgres tuning live in cloud-init or
+#     a config-management follow-up.
+###############################################################################
+
+locals {
+  common_labels = {
+    "managed-by"  = "eliza-cloud"
+    "tier"        = "apps-data-plane"
+    "environment" = var.environment
+  }
+}
+
+# Admin password for the tenant Postgres superuser. Stored in TF state (R2,
+# access-controlled). STAN: prefer wiring this to a secret store + rotation; for
+# the draft it's generated here so the cluster is self-contained.
+resource "random_password" "tenant_db_admin" {
+  length  = 40
+  special = false # keep DSN URL-safe (no escaping in admin_dsn_encrypted)
+}
+
+resource "hcloud_ssh_key" "operators" {
+  for_each = { for key in var.ssh_public_keys : substr(sha256(key), 0, 12) => key }
+
+  name       = "eliza-apps-op-${var.environment}-${each.key}"
+  public_key = each.value
+  labels     = local.common_labels
+}
+
+# ── Private network: apps + tenant DB only; isolated from the agent plane ─────
+resource "hcloud_network" "apps" {
+  name     = "eliza-apps-${var.environment}"
+  ip_range = var.network_cidr
+  labels   = local.common_labels
+}
+
+resource "hcloud_network_subnet" "apps" {
+  network_id   = hcloud_network.apps.id
+  type         = "cloud"
+  network_zone = "eu-central"
+  ip_range     = var.subnet_cidr
+}
+
+# ── Block storage for all tenant databases (PGDATA) ───────────────────────────
+resource "hcloud_volume" "tenant_db_data" {
+  name      = "eliza-apps-tenantdb-${var.environment}"
+  size      = var.tenant_db_volume_size_gb
+  location  = var.hcloud_location
+  format    = "ext4"
+  labels    = local.common_labels
+  automount = false
+}
+
+# ── Firewalls ─────────────────────────────────────────────────────────────────
+# App worker node: SSH from operators, public ingress (80/443) for app URLs.
+# Container-level egress isolation is enforced in the runtime (per-app --internal
+# net + squid default-deny). This node firewall is the coarse second layer.
+resource "hcloud_firewall" "app_node" {
+  name   = "eliza-apps-node-${var.environment}"
+  labels = local.common_labels
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "22"
+    source_ips = var.operator_ingress_cidrs # STAN: tighten before prod
+  }
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "80"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "443"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+}
+
+# Tenant DB node: NO public Postgres. SSH from operators only; Postgress (5432)
+# is reachable solely on the private network (no firewall rule opens it publicly).
+resource "hcloud_firewall" "tenant_db" {
+  name   = "eliza-apps-tenantdb-${var.environment}"
+  labels = local.common_labels
+
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "22"
+    source_ips = var.operator_ingress_cidrs # STAN: tighten before prod
+  }
+}
+
+# ── Tenant Postgres node ──────────────────────────────────────────────────────
+resource "hcloud_server" "tenant_db" {
+  name         = "eliza-apps-tenantdb-${var.environment}"
+  location     = var.hcloud_location
+  server_type  = var.tenant_db_server_type
+  image        = var.hcloud_image
+  ssh_keys     = [for k in hcloud_ssh_key.operators : k.id]
+  firewall_ids = [hcloud_firewall.tenant_db.id]
+  labels       = merge(local.common_labels, { "role" = "tenant-db" })
+
+  user_data = templatefile("${path.module}/cloud-init/tenant-db.yaml.tftpl", {
+    hostname          = "eliza-apps-tenantdb-${var.environment}"
+    admin_password    = random_password.tenant_db_admin.result
+    operator_ssh_keys = var.ssh_public_keys
+  })
+
+  lifecycle {
+    ignore_changes = [user_data, image, ssh_keys]
+  }
+}
+
+resource "hcloud_server_network" "tenant_db" {
+  server_id  = hcloud_server.tenant_db.id
+  network_id = hcloud_network.apps.id
+  # First usable host in the subnet — stable private IP the app nodes + the
+  # control-plane provisioner connect to (admin DSN host).
+  ip = cidrhost(var.subnet_cidr, 10)
+}
+
+resource "hcloud_volume_attachment" "tenant_db_data" {
+  volume_id = hcloud_volume.tenant_db_data.id
+  server_id = hcloud_server.tenant_db.id
+  automount = false
+}
+
+# ── App worker node(s) ────────────────────────────────────────────────────────
+resource "hcloud_server" "app_node" {
+  for_each = toset([for i in range(var.app_node_count) : tostring(i + 1)])
+
+  name         = "eliza-apps-node-${var.environment}-${each.value}"
+  location     = var.hcloud_location
+  server_type  = var.app_node_server_type
+  image        = var.hcloud_image
+  ssh_keys     = [for k in hcloud_ssh_key.operators : k.id]
+  firewall_ids = [hcloud_firewall.app_node.id]
+  labels = merge(local.common_labels, {
+    "role"           = "app-node"
+    "app-node-index" = each.value
+  })
+
+  user_data = templatefile("${path.module}/cloud-init/app-node.yaml.tftpl", {
+    hostname          = "eliza-apps-node-${var.environment}-${each.value}"
+    operator_ssh_keys = var.ssh_public_keys
+    tenant_db_host    = cidrhost(var.subnet_cidr, 10)
+  })
+
+  lifecycle {
+    ignore_changes = [user_data, image, ssh_keys]
+  }
+}
+
+resource "hcloud_server_network" "app_node" {
+  for_each = hcloud_server.app_node
+
+  server_id  = each.value.id
+  network_id = hcloud_network.apps.id
+  ip         = cidrhost(var.subnet_cidr, 20 + tonumber(each.key))
+}
+
+# ── Ingress DNS: wildcard for per-app URLs -> app node (single-node draft) ─────
+# STAN: with >1 app node, front this with a load balancer (hcloud_load_balancer)
+# and point the wildcard at the LB instead of a single node.
+resource "cloudflare_dns_record" "apps_wildcard" {
+  zone_id = var.cloudflare_zone_id
+  name    = "*.${var.apps_base_domain}"
+  type    = "A"
+  content = hcloud_server.app_node["1"].ipv4_address
+  ttl     = 60
+  proxied = false
+  comment = "eliza apps wildcard ingress (managed by terraform/hetzner/apps-data-plane)"
+}

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/outputs.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/outputs.tf
@@ -1,0 +1,40 @@
+output "tenant_db_private_host" {
+  description = "Private-network IP of the tenant Postgres node. This is the HOST for the admin DSN seeded into tenant_db_clusters.admin_dsn_encrypted, and the host the app's per-tenant DSN points at."
+  value       = cidrhost(var.subnet_cidr, 10)
+}
+
+output "tenant_db_public_ip" {
+  description = "Public IP of the tenant DB node (SSH/admin only — Postgres is NOT exposed publicly)."
+  value       = hcloud_server.tenant_db.ipv4_address
+}
+
+output "tenant_db_admin_dsn" {
+  description = "Admin DSN for the tenant Postgres cluster (over the PRIVATE network). Encrypt this and seed it into tenant_db_clusters.admin_dsn_encrypted. SENSITIVE."
+  value       = "postgresql://postgres:${random_password.tenant_db_admin.result}@${cidrhost(var.subnet_cidr, 10)}:5432/postgres?sslmode=require"
+  sensitive   = true
+}
+
+output "app_node_ips" {
+  description = "Public IPs of the app worker nodes (the daemon SSHes here to run app containers; ingress also lands here)."
+  value       = { for k, v in hcloud_server.app_node : k => v.ipv4_address }
+}
+
+output "app_node_private_ips" {
+  description = "Private-network IPs of the app worker nodes."
+  value       = { for k, v in hcloud_server_network.app_node : k => v.ip }
+}
+
+output "apps_wildcard_hostname" {
+  description = "Wildcard ingress hostname (CONTAINERS_PUBLIC_BASE_DOMAIN). Set this as the apps base domain in the daemon/Worker env."
+  value       = "*.${var.apps_base_domain}"
+}
+
+output "next_steps" {
+  description = "What to do after apply."
+  value       = <<-EOT
+    1. Encrypt tenant_db_admin_dsn and seed it into tenant_db_clusters (provider='direct_pg', host=tenant_db_private_host).
+    2. Set the daemon/Worker apps env: CONTAINERS_DOCKER_NODES (app_node_ips), CONTAINERS_PUBLIC_BASE_DOMAIN=${var.apps_base_domain}, the image registry, CONTAINERS_EGRESS_PROXY_URL.
+    3. Wire the 2 boot one-liners (cloud-api configureAppsDeployTrigger + daemon configureAppsDeployBackend) and flip the feature gate for an allowlist.
+    4. On-node kernel re-check (throwaway --internal scratch net on an app node) before opening to users.
+  EOT
+}

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/providers.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/providers.tf
@@ -1,0 +1,9 @@
+provider "hcloud" {
+  # Token comes from HCLOUD_TOKEN env var by default — never commit it.
+  # token = var.hcloud_token
+}
+
+provider "cloudflare" {
+  # Token comes from CLOUDFLARE_API_TOKEN env var by default.
+  # api_token = var.cloudflare_api_token
+}

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/production.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/production.tfvars.example
@@ -1,0 +1,21 @@
+# Copy to production.tfvars (gitignored) and fill in real values.
+
+environment        = "production"
+hcloud_location    = "fsn1"
+cloudflare_zone_id = "<zone-id-for-elizacloud.ai>"
+apps_base_domain   = "apps.elizacloud.ai"
+
+app_node_count           = 2 # behind a load balancer (see main.tf STAN note)
+app_node_server_type     = "cpx41"
+tenant_db_server_type    = "ccx33"
+tenant_db_volume_size_gb = 500
+
+network_cidr = "10.30.0.0/16"
+subnet_cidr  = "10.30.1.0/24"
+
+# Production MUST be tightened to operator + control-plane IPs only.
+operator_ingress_cidrs = ["<operator-ip>/32"]
+
+ssh_public_keys = [
+  # "ssh-ed25519 AAAA... operator@laptop"
+]

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/staging.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/staging.tfvars.example
@@ -1,0 +1,24 @@
+# Copy to staging.tfvars (gitignored) and fill in real values.
+
+environment        = "staging"
+hcloud_location    = "fsn1"
+cloudflare_zone_id = "<zone-id-for-elizacloud.ai>"
+apps_base_domain   = "apps-staging.elizacloud.ai"
+
+# Sizing — start small for the allowlist beta.
+app_node_count           = 1
+app_node_server_type     = "cpx41"
+tenant_db_server_type    = "ccx33"
+tenant_db_volume_size_gb = 200
+
+# MUST NOT overlap the agent data-plane network.
+network_cidr = "10.30.0.0/16"
+subnet_cidr  = "10.30.1.0/24"
+
+# STAN: tighten to operator/control-plane IPs before production.
+operator_ingress_cidrs = ["0.0.0.0/0", "::/0"]
+
+# Operator SSH public keys (NEVER paste private keys here).
+ssh_public_keys = [
+  # "ssh-ed25519 AAAA... operator@laptop"
+]

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
@@ -1,0 +1,85 @@
+variable "environment" {
+  description = "Deployment environment (staging, production)"
+  type        = string
+  validation {
+    condition     = contains(["staging", "production"], var.environment)
+    error_message = "Environment must be 'staging' or 'production'"
+  }
+}
+
+variable "hcloud_location" {
+  description = "Hetzner Cloud datacenter location. MUST match the control-plane + agent data plane (fsn1) so the private network and DB latency stay sane."
+  type        = string
+  default     = "fsn1"
+}
+
+variable "hcloud_image" {
+  description = "Base image for the apps data-plane VMs."
+  type        = string
+  default     = "ubuntu-24.04"
+}
+
+# ── App worker node(s): Docker hosts for UNTRUSTED user images ───────────────
+variable "app_node_server_type" {
+  description = "Hetzner server type for an app worker node (runs untrusted user containers). cpx41 = 8 vCPU / 16 GB; size to expected concurrent app density."
+  type        = string
+  default     = "cpx41"
+}
+
+variable "app_node_count" {
+  description = "Number of app worker nodes. Start with 1 (allowlist beta); the runtime node-selector + autoscaler can grow this. Kept SEPARATE from agent nodes by design (untrusted vs trusted)."
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.app_node_count >= 1 && var.app_node_count <= 20
+    error_message = "app_node_count must be between 1 and 20"
+  }
+}
+
+# ── Tenant Postgres cluster node: thousands of DATABASE+ROLE per node ─────────
+variable "tenant_db_server_type" {
+  description = "Hetzner server type for the tenant Postgres node. ccx33 (dedicated 8 vCPU / 32 GB) is a sane start for thousands of small tenant DBs; scale up or add nodes (shards) as database_count grows."
+  type        = string
+  default     = "ccx33"
+}
+
+variable "tenant_db_volume_size_gb" {
+  description = "Size of the attached block-storage volume that holds all tenant databases (PGDATA lives here so the node can be rebuilt without data loss)."
+  type        = number
+  default     = 200
+}
+
+variable "ssh_public_keys" {
+  description = "Operator SSH public keys allowed to log in as root. Provide via tfvars; never commit private keys."
+  type        = list(string)
+  default     = []
+}
+
+variable "network_cidr" {
+  description = "Private network CIDR for the apps data plane. MUST NOT overlap the agent data-plane network — apps and agents are isolated."
+  type        = string
+  default     = "10.30.0.0/16"
+}
+
+variable "subnet_cidr" {
+  description = "Subnet within network_cidr where the app nodes + tenant DB attach."
+  type        = string
+  default     = "10.30.1.0/24"
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone for elizacloud.ai — used for the per-app ingress wildcard / node DNS."
+  type        = string
+}
+
+variable "apps_base_domain" {
+  description = "Base domain apps are served under (CONTAINERS_PUBLIC_BASE_DOMAIN). Each app gets <shortid>.<base>. e.g. apps.elizacloud.ai"
+  type        = string
+  default     = "apps.elizacloud.ai"
+}
+
+variable "operator_ingress_cidrs" {
+  description = "CIDRs allowed to SSH the nodes (operator IPs / control-plane). Defaults to 'anywhere' for the DRAFT — Stan MUST tighten this before production."
+  type        = list(string)
+  default     = ["0.0.0.0/0", "::/0"]
+}

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/versions.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/versions.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.63"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+
+  # State backend uses Cloudflare R2 (S3-compatible), same as control-plane.
+  #   terraform init -backend-config=backend-staging.hcl
+  #   terraform init -backend-config=backend-production.hcl
+  backend "s3" {}
+}


### PR DESCRIPTION
## Apps data-plane terraform (Product 2) — **REVIEW DRAFT for Stan**

The IaC half of "Eliza Cloud Apps" — stands up the **isolated apps data plane** the verified code in **#8293** targets. Sibling to `hetzner/control-plane`, same conventions (hcloud + cloudflare providers, R2 backend, env tfvars, cloud-init).

**Not applied — draft for review.** Keeps apps isolated from agents (*agents share the data plane; apps get an isolated one*):
- private `hcloud_network` (no overlap with the agent net)
- **tenant Postgres node** (+ volume) — thousands of per-tenant `DATABASE`+`ROLE` (`REVOKE CONNECT`), reachable **only** on the private net
- **app worker node(s)** for untrusted images (per-app `--internal` net + cap-drop + squid default-deny egress; daemon SSHes in)
- firewalls (DB private-only; app node SSH+80/443), wildcard ingress DNS
- outputs: admin DSN → seed `tenant_db_clusters`, app node IPs, base domain

**Stan — harden before apply** (inline `STAN:` notes + README): SSH surface, untrusted-image hardening (gVisor/seccomp), TLS/backups, ingress LB, egress allowlist.

Pairs with #8293 (code). Rollout: apply → seed `tenant_db_clusters` → set apps env → wire the 2 gated boot one-liners → flip gate for allowlist → on-node kernel re-check.
