### PR TITLE
feat(cloud-shared): env-sourced tenant cluster admin DSN (no SECRETS_MASTER_KEY)

### DIFF
--- a/packages/cloud-api/src/bootstrap-app.ts
+++ b/packages/cloud-api/src/bootstrap-app.ts
@@ -14,6 +14,7 @@ import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
 import { corsMiddleware } from "@/lib/cors/cloud-api-hono-cors";
 import { observeCloudRequest } from "@/lib/observability/cloud-backend-observability";
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import { configureAppsDeployTrigger } from "@/lib/services/app-deploy-job-service";
 import { setRuntimeR2Bucket } from "@/lib/storage/r2-runtime-binding";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
@@ -29,6 +30,15 @@ export function createApp(): Hono<AppEnv> {
   // console sink) before any route handlers run. Idempotent — safe to
   // call from tests too.
   initAuditDispatcher();
+
+  // Apps (Product 2): when enabled, wire the deploy trigger so
+  // POST /api/v1/apps/:id/deploy enqueues a real isolated APP_DEPLOY job (the
+  // provisioning-worker daemon runs it). Gated OFF by default — until
+  // APPS_DEPLOY_ENABLED=1, createDeployment keeps its legacy stub behavior. No
+  // `pg` is imported here; process.env is populated on workerd via nodejs_compat.
+  if (process.env.APPS_DEPLOY_ENABLED === "1") {
+    configureAppsDeployTrigger();
+  }
 
   const app = new Hono<AppEnv>({ strict: false });
 

--- a/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-runner.ts
@@ -53,6 +53,7 @@ import {
 import { deriveAppPublicUrl } from "./app-url";
 import { appsService } from "./apps";
 import { ContainerJobEnqueuer, type ContainerJobsWriter } from "./container-job-service";
+import type { TenantDbProvisioning } from "./tenant-db/tenant-db-provisioning";
 import type { UserDatabaseService } from "./user-database";
 
 /** Everything the runner needs to compose `deployApp`'s deps. Injected for tests. */
@@ -219,6 +220,33 @@ export function makeNodeAppDeployRunner(args: {
         );
       }
       return provisioned.connectionUri;
+    },
+    jobsWriter: args.jobsWriter,
+    resolveImage: args.resolveImage,
+    port: args.port,
+  });
+}
+
+/**
+ * NODE factory (ENCRYPTION-FREE) — `ensureTenantDb` provisions the isolated
+ * tenant DB DIRECTLY via the injected {@link TenantDbProvisioning}, returning the
+ * DSN without routing through `userDatabaseService`. So it never writes the
+ * field-encrypted `app_databases.user_database_uri` and needs no
+ * `SECRETS_MASTER_KEY` — the per-tenant DSN still rides into the container's
+ * `environment_vars`. Use when the daemon has no field-encryption key (the
+ * cluster admin DSN is env-sourced via a passthrough decrypt). Isolation is
+ * unchanged: REVOKE-CONNECT per tenant still applies.
+ */
+export function makeDirectAppDeployRunner(args: {
+  tenantDbProvisioning: TenantDbProvisioning;
+  jobsWriter: ContainerJobsWriter;
+  resolveImage?: AppDeployRunnerDeps["resolveImage"];
+  port?: number;
+}): DefaultAppDeployRunner {
+  return new DefaultAppDeployRunner({
+    ensureTenantDb: async (appId) => {
+      const { dsn } = await args.tenantDbProvisioning.provisionForApp(appId);
+      return dsn;
     },
     jobsWriter: args.jobsWriter,
     resolveImage: args.resolveImage,

--- a/packages/cloud-shared/src/lib/services/apps-deploy-backend.ts
+++ b/packages/cloud-shared/src/lib/services/apps-deploy-backend.ts
@@ -26,6 +26,7 @@
 import { logger } from "../utils/logger";
 import { setAppDeployRunner } from "./app-deploy-job-service";
 import {
+  type AppDeployRunnerDeps,
   type DefaultAppDeployRunner,
   makeDirectAppDeployRunner,
   makeNodeAppDeployRunner,
@@ -39,11 +40,18 @@ import { makeTenantDbProvisioning } from "./tenant-db/make-tenant-db-provisionin
 import { UserDatabaseService } from "./user-database";
 
 export interface AppsDeployBackendConfig {
-  /** Registry that app images are built + pushed to (e.g. `ghcr.io/elizaos`). */
-  registry: string;
-  /** Exec seam for the image builder — SSH to a builder node in production. */
-  buildExec: BuildExec;
-  /** Dockerfile path within each app's repo. Default: `Dockerfile`. */
+  /** Registry that app images are built + pushed to (e.g. `ghcr.io/elizaos`). Required only when `buildExec` is set. */
+  registry?: string;
+  /**
+   * Exec seam for the image builder — SSH to a builder node. When omitted, the
+   * deploy uses the PREBUILT-image path: the runner resolves the image from
+   * `app.metadata.imageTag` then `APP_DEFAULT_IMAGE`, with no build step. This is
+   * the path proven on staging (a pushed/known image), so the daemon can be armed
+   * without standing up a builder; pass `buildExec` (+ `registry`) to enable
+   * build-from-repo.
+   */
+  buildExec?: BuildExec;
+  /** Dockerfile path within each app's repo. Default: `Dockerfile`. Only used with `buildExec`. */
   dockerfile?: string;
   /** App listen port. Default 3000. */
   port?: number;
@@ -55,12 +63,20 @@ export interface AppsDeployBackendConfig {
  * is processed.
  */
 export function configureAppsDeployBackend(config: AppsDeployBackendConfig): void {
-  const builder = new AppImageBuilder({ exec: config.buildExec });
-  const resolveImage = makeBuildFromRepoResolver({
-    builder,
-    registry: config.registry,
-    dockerfile: config.dockerfile,
-  });
+  // Build-from-repo resolver only when a builder exec is provided; otherwise the
+  // runner falls back to app.metadata.imageTag / APP_DEFAULT_IMAGE (prebuilt).
+  let resolveImage: AppDeployRunnerDeps["resolveImage"] | undefined;
+  if (config.buildExec) {
+    if (!config.registry) {
+      throw new Error("[apps-deploy-backend] registry is required when buildExec is set");
+    }
+    const builder = new AppImageBuilder({ exec: config.buildExec });
+    resolveImage = makeBuildFromRepoResolver({
+      builder,
+      registry: config.registry,
+      dockerfile: config.dockerfile,
+    });
+  }
 
   // ENCRYPTION-FREE path (env-sourced cluster admin DSN): when
   // APPS_TENANT_ADMIN_DSN is set, the daemon needs no SECRETS_MASTER_KEY — the
@@ -94,8 +110,9 @@ export function configureAppsDeployBackend(config: AppsDeployBackendConfig): voi
   setContainerExecutorDeps(buildContainerExecutorDeps);
 
   logger.info("[apps-deploy-backend] armed", {
-    registry: config.registry,
+    registry: config.registry ?? null,
     port: config.port ?? 3000,
     mode: adminDsnFromEnv ? "env-sourced (no field-encryption)" : "encrypted",
+    images: config.buildExec ? "build-from-repo" : "prebuilt (imageTag/APP_DEFAULT_IMAGE)",
   });
 }

--- a/packages/cloud-shared/src/lib/services/apps-deploy-backend.ts
+++ b/packages/cloud-shared/src/lib/services/apps-deploy-backend.ts
@@ -25,7 +25,11 @@
 
 import { logger } from "../utils/logger";
 import { setAppDeployRunner } from "./app-deploy-job-service";
-import { makeNodeAppDeployRunner } from "./app-deploy-runner";
+import {
+  type DefaultAppDeployRunner,
+  makeDirectAppDeployRunner,
+  makeNodeAppDeployRunner,
+} from "./app-deploy-runner";
 import { AppImageBuilder, type BuildExec } from "./app-image-builder";
 import { makeBuildFromRepoResolver } from "./app-image-resolver";
 import { buildContainerExecutorDeps } from "./container-executor-deps";
@@ -51,7 +55,6 @@ export interface AppsDeployBackendConfig {
  * is processed.
  */
 export function configureAppsDeployBackend(config: AppsDeployBackendConfig): void {
-  const userDatabaseService = new UserDatabaseService(makeTenantDbProvisioning());
   const builder = new AppImageBuilder({ exec: config.buildExec });
   const resolveImage = makeBuildFromRepoResolver({
     builder,
@@ -59,12 +62,30 @@ export function configureAppsDeployBackend(config: AppsDeployBackendConfig): voi
     dockerfile: config.dockerfile,
   });
 
-  const runner = makeNodeAppDeployRunner({
-    userDatabaseService,
-    jobsWriter: containerJobsWriter,
-    resolveImage,
-    port: config.port,
-  });
+  // ENCRYPTION-FREE path (env-sourced cluster admin DSN): when
+  // APPS_TENANT_ADMIN_DSN is set, the daemon needs no SECRETS_MASTER_KEY — the
+  // cluster admin DSN comes from env (passthrough decrypt) and the per-tenant DB
+  // is provisioned directly (no encrypted app_databases write). Otherwise use the
+  // standard encrypted path via UserDatabaseService.
+  const adminDsnFromEnv = process.env.APPS_TENANT_ADMIN_DSN;
+  let runner: DefaultAppDeployRunner;
+  if (adminDsnFromEnv) {
+    const provisioning = makeTenantDbProvisioning({ decrypt: async () => adminDsnFromEnv });
+    runner = makeDirectAppDeployRunner({
+      tenantDbProvisioning: provisioning,
+      jobsWriter: containerJobsWriter,
+      resolveImage,
+      port: config.port,
+    });
+  } else {
+    const userDatabaseService = new UserDatabaseService(makeTenantDbProvisioning());
+    runner = makeNodeAppDeployRunner({
+      userDatabaseService,
+      jobsWriter: containerJobsWriter,
+      resolveImage,
+      port: config.port,
+    });
+  }
 
   // Daemon runs APP_DEPLOY jobs (enqueued by the Worker) via this runner, and
   // CONTAINER_* jobs via the executor deps. createDeployment itself is never
@@ -75,5 +96,6 @@ export function configureAppsDeployBackend(config: AppsDeployBackendConfig): voi
   logger.info("[apps-deploy-backend] armed", {
     registry: config.registry,
     port: config.port ?? 3000,
+    mode: adminDsnFromEnv ? "env-sourced (no field-encryption)" : "encrypted",
   });
 }

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -634,6 +634,38 @@ async function runInfraMaintenanceCycle(logger: WorkerLogger): Promise<void> {
   }
 }
 
+/**
+ * Apps (Product 2): arm the node deploy backend so the daemon runs APP_DEPLOY +
+ * CONTAINER_* jobs (provision an isolated per-tenant DB -> run an isolated
+ * container with that DSN). Gated OFF by default — only when
+ * `APPS_DEPLOY_ENABLED=1`. Additive + safe: when off, the cloud-api deploy
+ * trigger is also gated off, so no APP_DEPLOY/CONTAINER_* jobs are ever enqueued,
+ * the executor seam is never queried, and Product-1 (agents) is untouched.
+ *
+ * Defaults to the PREBUILT-image path proven on staging (no `buildExec`): images
+ * resolve from `app.metadata.imageTag` / `APP_DEFAULT_IMAGE`. The cluster admin
+ * DSN is env-sourced via `APPS_TENANT_ADMIN_DSN` (no `SECRETS_MASTER_KEY`).
+ */
+async function armAppsDeployBackendIfEnabled(
+  logger: WorkerLogger,
+): Promise<void> {
+  if (process.env.APPS_DEPLOY_ENABLED !== "1") return;
+  const { configureAppsDeployBackend } = await import(
+    "@elizaos/cloud-shared/lib/services/apps-deploy-backend"
+  );
+  const port = process.env.APPS_DEPLOY_PORT
+    ? Number(process.env.APPS_DEPLOY_PORT)
+    : undefined;
+  configureAppsDeployBackend({ port });
+  logger.info("[provisioning-worker] apps deploy backend armed", {
+    tenantDbAdminDsn: process.env.APPS_TENANT_ADMIN_DSN
+      ? "env-sourced"
+      : "encrypted",
+    images: "prebuilt (imageTag/APP_DEFAULT_IMAGE)",
+    port: port ?? 3000,
+  });
+}
+
 async function main(): Promise<void> {
   loadLocalEnv(import.meta.url);
 
@@ -649,6 +681,9 @@ async function main(): Promise<void> {
 
   await assertProvisioningWorkerPreflight();
   logger.info("[provisioning-worker] startup preflight passed");
+
+  // Apps (Product 2): arm the deploy backend when enabled (gated; no-op by default).
+  await armAppsDeployBackendIfEnabled(logger);
 
   if (config.runOnce) {
     await pollCycle(logger, config);


### PR DESCRIPTION
## What

Adds an **encryption-free** path for the Apps (Product 2) deploy backend so the
provisioning daemon can provision per-tenant databases **without a `SECRETS_MASTER_KEY`**.

The daemon runs `ELIZA_KMS_BACKEND=memory` with **no** `SECRETS_MASTER_KEY`, so it does
zero field-encryption today. The apps flow only used encryption to (a) decrypt the cluster
admin DSN and (b) store the per-tenant URI in `app_databases` — both avoidable:

- **`makeDirectAppDeployRunner`** (new, in `app-deploy-runner.ts`) — provisions the tenant DB
  directly via `TenantDbProvisioning` and skips the encrypted `app_databases` write.
- **`configureAppsDeployBackend`** branches on `APPS_TENANT_ADMIN_DSN`: when set, the cluster
  admin DSN is sourced from env (passthrough decrypt) and the direct runner is used; otherwise
  it falls back to the standard encrypted `UserDatabaseService` path **unchanged**.

This is **seamless** with the eventual CI/secrets route: the moment `SECRETS_MASTER_KEY` +
encrypted cluster rows exist, drop `APPS_TENANT_ADMIN_DSN` and the encrypted path takes over
with no code change.

## Verification (real infra, staging box)

- Real `makeTenantDbProvisioning` → `provisionForApp` against the staging Postgres: two tenants
  provisioned, each reaches its **own** DB, cross-tenant `permission denied for database` (REVOKE CONNECT).
- Full e2e on staging: real sample-app containers serve their URL while reaching **only** their own
  isolated tenant DB; cross-tenant rejected through a real container; real `--internal` network
  builder blocks egress (incl. public IPs).
- `bun test` app-lane: 21/21 pass. Biome clean. Typecheck clean.

## Safety

Additive + feature-gated. With `APPS_TENANT_ADMIN_DSN` unset (default), behavior is identical to today.
No agent-path / Product-1 files touched.