### PR TITLE
fix(bitrouter): wire OpenRouter as a real BYOK upstream (stop using BitRouter Cloud)

### DIFF
--- a/packages/cloud-infra/cloud/bitrouter/bitrouter.yaml
+++ b/packages/cloud-infra/cloud/bitrouter/bitrouter.yaml
@@ -11,6 +11,9 @@ providers:
   google: {}
   groq: {}
   openrouter:
+    api_base: "https://openrouter.ai/api/v1"
+    api_key: "${BITROUTER_OPENROUTER_API_KEY}"
+    api_protocol: openai
     models:
       "openai/gpt-oss-120b":
         pricing:


### PR DESCRIPTION
## The bug (shaw)
> "we have a bitrouter bug — it's trying to use their cloud not our local keys" (≈1000x cost)

## Root cause
Our self-hosted BitRouter (`bitrouter-production.up.railway.app`) routes OSS models
(`gpt-oss-120b`) to its **`openrouter`** provider — but in `bitrouter.yaml` that provider
block carried **only pricing**, with **no `api_base` / `api_key` / `api_protocol`**:

```yaml
  openrouter:
    models:
      "openai/gpt-oss-120b": { pricing: ... }   # ← no credentials, can't BYOK-route
```

So BitRouter couldn't reach OpenRouter with our key, and those requests fell through to the
**`bitrouter: {}`** provider = **BitRouter Cloud** (the `brk_` key) — *their cloud, not our
local keys*, at ~1000x the OpenRouter passthrough price. The ~1000x is the **symptom**; the
bug is the missing upstream credential.

Three signals confirm this is the spot:
1. shaw: *"bitrouter takes openrouter as a provider — that's how it's supposed to be set up."*
2. `entrypoint.sh` **already exports** `BITROUTER_OPENROUTER_API_KEY` (← `BITROUTER_OPENROUTER_API_KEY` or `OPENROUTER_API_KEY`) — the key is plumbed and unused.
3. The working **`cerebras`** provider shows the exact required shape; the `Dockerfile` even build-guards for `api_protocol: openai`.

## Fix
Complete the `openrouter` provider block, mirroring `cerebras` (3 lines):

```yaml
  openrouter:
    api_base: "https://openrouter.ai/api/v1"
    api_key: "${BITROUTER_OPENROUTER_API_KEY}"
    api_protocol: openai
    models: ...
```

**No cloud-shared code change** — BitRouter stays the router (shaw's design); this just gives
its `openrouter` provider the credentials it was missing. (Deliberately did *not* add a parallel
OpenRouter-direct provider in cloud-shared — that would duplicate what BitRouter already does.)

## Deploy step (required)
Set `BITROUTER_OPENROUTER_API_KEY` (our OpenRouter key) on the Railway **bitrouter** service,
then redeploy:
```bash
railway variables --service bitrouter --set "BITROUTER_OPENROUTER_API_KEY=<sk-or-...>" --skip-deploys
railway up --service bitrouter packages/cloud-infra/cloud/bitrouter --path-as-root
```

## Verification
- `bitrouter.yaml` parses; `openrouter` now has `api_base`+`api_key`+`api_protocol`+`models`.
- Dockerfile build guards (`openrouter:`, `api_protocol: openai`, pricing values) all pass.