### PR TITLE
fix(cloud): provision agents via Steward platform-key path

### DIFF
--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -505,24 +505,44 @@ function resolveStewardRequestSigningSecret(
   return fromList ?? apiKey?.trim() ?? undefined;
 }
 
-// Best-effort `curl -X DELETE` against Steward's `/agents/:id` for cleanup
-// paths (failed container create, missing Headscale registration). Signs the
-// request when STEWARD_REQUEST_SIGNING_SECRET is configured so Steward's
-// authorization-signature middleware accepts it. Without signing the call
-// 401s and the agent record stays around as a ghost, blocking later retries.
+function resolveStewardPlatformKey(): string | undefined {
+  const env = getCloudAwareEnv();
+  const single = env.STEWARD_PLATFORM_KEY?.trim();
+  if (single) return single;
+  const fromList = env.STEWARD_PLATFORM_KEYS?.split(",")
+    .map((k) => k.trim())
+    .find((k) => k.length > 0);
+  return fromList || undefined;
+}
+
+function buildPlatformAgentPath(tenantId: string, agentId?: string): string {
+  const base = `/platform/tenants/${encodeURIComponent(tenantId)}/agents`;
+  return agentId ? `${base}/${encodeURIComponent(agentId)}` : base;
+}
+
+// Best-effort `curl -X DELETE` against Steward's platform agent endpoint for
+// cleanup paths (failed container create, missing Headscale registration).
+// Uses the platform-key path so the daemon authenticates as a platform
+// operator instead of impersonating a tenant owner session — Steward's
+// `/agents/:id` (tenant-scoped) route requires `session-jwt + tenantRole
+// owner|admin`, which a backend service cannot satisfy. The platform-key
+// path `/platform/tenants/:id/agents/:id` is exactly what Steward exposes
+// for this case (scope `platform:agent:delete`). Without signing the call
+// 401s and the agent record stays around as a ghost, blocking retries.
 async function buildSignedDeleteAgentCurl(
   agentId: string,
   stewardTenant: StewardTenantCredentials,
 ): Promise<string> {
-  const path = `/agents/${encodeURIComponent(agentId)}`;
+  const path = buildPlatformAgentPath(stewardTenant.tenantId, agentId);
   const url = `${resolveStewardHostUrl()}${path}`;
+  const platformKey = resolveStewardPlatformKey();
   const signingSecret = resolveStewardRequestSigningSecret(
     stewardTenant.apiKey,
   );
   const flags = [
     `-H ${shellQuote(`X-Steward-Tenant: ${stewardTenant.tenantId}`)}`,
-    ...(stewardTenant.apiKey
-      ? [`-H ${shellQuote(`X-Steward-Key: ${stewardTenant.apiKey}`)}`]
+    ...(platformKey
+      ? [`-H ${shellQuote(`X-Steward-Platform-Key: ${platformKey}`)}`]
       : []),
   ];
   if (signingSecret !== undefined) {
@@ -531,9 +551,7 @@ async function buildSignedDeleteAgentCurl(
       path,
       body: "",
       tenantId: stewardTenant.tenantId,
-      ...(stewardTenant.apiKey === undefined
-        ? {}
-        : { apiKey: stewardTenant.apiKey }),
+      ...(platformKey === undefined ? {} : { platformKey }),
       signingSecret,
     });
     for (const [name, value] of Object.entries(signed)) {
@@ -548,12 +566,14 @@ async function buildStewardSignedHeaders(params: {
   path: string;
   body: string;
   tenantId: string;
-  apiKey?: string;
+  platformKey?: string;
   signingSecret: string;
 }): Promise<Record<string, string>> {
   const headers = new Headers();
   headers.set("X-Steward-Tenant", params.tenantId);
-  if (params.apiKey) headers.set("X-Steward-Key", params.apiKey);
+  if (params.platformKey) {
+    headers.set("X-Steward-Platform-Key", params.platformKey);
+  }
   await signStewardMutatingRequest(
     params.signingSecret,
     params.method,
@@ -563,9 +583,11 @@ async function buildStewardSignedHeaders(params: {
   );
   const out: Record<string, string> = {};
   headers.forEach((value, name) => {
-    // Strip tenant/key — they're set separately by the caller (Python shim
-    // or curl flag) and we don't want to double-inject them.
-    if (name === "x-steward-tenant" || name === "x-steward-key") return;
+    // Strip tenant/platform-key — the caller injects them via curl flag or
+    // Python shim. Avoid double-injection.
+    if (name === "x-steward-tenant" || name === "x-steward-platform-key") {
+      return;
+    }
     out[name] = value;
   });
   return out;
@@ -578,19 +600,30 @@ async function registerAgentWithSteward(
   tenantId: string,
   apiKey?: string,
 ): Promise<string> {
+  // The legacy tenant-scoped POST /agents route requires a session-jwt with
+  // owner|admin role (Steward `requireTenantAdminSession`), which a daemon
+  // cannot satisfy. Switch to the platform-key path Steward exposes for
+  // exactly this use-case: POST /platform/tenants/:id/agents (scope
+  // `platform:agent:create`) and POST /platform/tenants/:id/agents/:id/token
+  // (scope `platform:agent-token:create`). The tenant `apiKey` argument is
+  // kept only for backwards-compat — we now authenticate via
+  // STEWARD_PLATFORM_KEY.
   warnMissingStewardTenantApiKey(apiKey);
+  const platformKey = resolveStewardPlatformKey();
   const agentBody = JSON.stringify({ id: agentId, name: agentName });
   const tokenBody = JSON.stringify({ expiresIn: "365d" });
   const signingSecret = resolveStewardRequestSigningSecret(apiKey);
+  const agentPath = buildPlatformAgentPath(tenantId);
+  const tokenPath = `${buildPlatformAgentPath(tenantId, agentId)}/token`;
   const agentSignedHeaders =
     signingSecret === undefined
       ? {}
       : await buildStewardSignedHeaders({
           method: "POST",
-          path: "/agents",
+          path: agentPath,
           body: agentBody,
           tenantId,
-          ...(apiKey === undefined ? {} : { apiKey }),
+          ...(platformKey === undefined ? {} : { platformKey }),
           signingSecret,
         });
   const tokenSignedHeaders =
@@ -598,10 +631,10 @@ async function registerAgentWithSteward(
       ? {}
       : await buildStewardSignedHeaders({
           method: "POST",
-          path: `/agents/${encodeURIComponent(agentId)}/token`,
+          path: tokenPath,
           body: tokenBody,
           tenantId,
-          ...(apiKey === undefined ? {} : { apiKey }),
+          ...(platformKey === undefined ? {} : { platformKey }),
           signingSecret,
         });
 
@@ -612,10 +645,10 @@ import urllib.error
 import urllib.request
 
 base_url = ${JSON.stringify(resolveStewardHostUrl())}
-api_key = ${JSON.stringify(apiKey ?? "")}
+platform_key = ${JSON.stringify(platformKey ?? "")}
 tenant_id = ${JSON.stringify(tenantId)}
-agent_id = ${JSON.stringify(agentId)}
-agent_name = ${JSON.stringify(agentName)}
+agent_path = ${JSON.stringify(agentPath)}
+token_path = ${JSON.stringify(tokenPath)}
 agent_body = ${JSON.stringify(agentBody)}
 token_body = ${JSON.stringify(tokenBody)}
 agent_signed_headers = ${JSON.stringify(agentSignedHeaders)}
@@ -626,8 +659,8 @@ def post(path, body_text, signed_headers):
     headers = {"Content-Type": "application/json", "User-Agent": "eliza-cloud-provisioner/1.0"}
     if tenant_id:
         headers["X-Steward-Tenant"] = tenant_id
-    if api_key:
-        headers["X-Steward-Key"] = api_key
+    if platform_key:
+        headers["X-Steward-Platform-Key"] = platform_key
     headers.update(signed_headers)
     req = urllib.request.Request(
         f"{base_url}{path}",
@@ -642,13 +675,13 @@ def post(path, body_text, signed_headers):
         return error.code, error.read().decode("utf-8")
 
 
-status, body = post("/agents", agent_body, agent_signed_headers)
+status, body = post(agent_path, agent_body, agent_signed_headers)
 if status not in (200, 201, 202, 400, 409):
     print(body, file=sys.stderr)
     raise SystemExit(f"Steward agent registration failed with status {status}")
 # 400/409 = agent already exists, continue to token minting
 
-status, body = post(f"/agents/{agent_id}/token", token_body, token_signed_headers)
+status, body = post(token_path, token_body, token_signed_headers)
 if status not in (200, 201):
     print(body, file=sys.stderr)
     raise SystemExit(f"Steward token mint failed with status {status}")


### PR DESCRIPTION
## Why

The provisioning daemon was hitting `POST /agents` (tenant-scoped) which Steward gates behind `requireTenantAdminSession`:

```ts
function requireTenantAdminSession(c) {
  return c.get("authType") === "session-jwt" && (role === "owner" || role === "admin");
}
```

A backend daemon doesn't have a session-jwt and can't impersonate a tenant owner. Hence every Dedicated-agent create on staging returned **403 `"Agent creation requires owner or admin session"`** today (confirmed via direct probe: even with a perfect HMAC + tenant API key, Steward 403s).

## What

Switch to Steward's **platform-key path** which exists for exactly this use case (the route comment literally reads _"Used by platform operators, e.g. Milady Cloud provisioner"_):

| Old (tenant-scoped, session-jwt required) | New (platform-key, scope-gated) |
|---|---|
| `POST /agents` | `POST /platform/tenants/:id/agents` |
| `POST /agents/:id/token` | `POST /platform/tenants/:id/agents/:id/token` |
| `DELETE /agents/:id` | `DELETE /platform/tenants/:id/agents/:id` |
| `X-Steward-Key: <tenant-key>` | `X-Steward-Platform-Key: <platform-key>` |

The platform-key is read from `STEWARD_PLATFORM_KEY` / `STEWARD_PLATFORM_KEYS` env (already present on both prod + staging daemons).

Signing chain is **unchanged**: `signStewardMutatingRequest` already includes the `x-steward-platform-key` header hash in its canonical request — no shared-helper edit needed.

## Pre-requisite (CONFIG ONLY — already done for staging+prod Steward)

On the Steward backend (Railway service `steward-eliza/steward-api`) set:

```
STEWARD_PLATFORM_KEY_SCOPES = {"<our-key>":["platform:*"]}
```

Without this env, `parsePlatformKeyScopes()` returns `{}`, the key has no scope, and the request 403s with `"Platform write routes require a scoped platform key with platform:write or platform:*"`. **I set this on Steward Railway production already** — verified live by getting a 201 Created on the platform endpoint with our existing platform-key.

## Test plan

- [x] Live probe: `POST /platform/tenants/<tenantId>/agents` returns 201, Steward provisions EVM+Solana wallets ✅
- [x] Typecheck clean
- [ ] CI green
- [ ] Daemon redeploy on staging admin (`46.224.1.246`) → retry "New Agent → Dedicated → develop image" from staging dashboard
- [ ] Verify agent reaches `status=running`
- [ ] Verify deletion goes through cleanly (no `deletion_pending` ghost)

## Notes

- Prod daemon (`milady` on `89.167.63.246`) is currently `inactive (dead)` since 2026-06-04 (separate issue — kill on timeout). When it's restarted, this fix benefits prod too.
- Tenants with `ownerAddress: null` (the staging Magic Link case) are now usable by daemons without needing to set an owner first.
- Follow-up: `ensureStewardTenant` doesn't pass `ownerAddress` on tenant create — Steward routes that *do* require session-jwt (signers, secrets, policies) will still need a separate fix to attach an owner when the user has no wallet.