### PR TITLE
Add blackwall-eliza-guardrail to the plugin registry

### DIFF
--- a/packages/registry/entries/third-party/blackwall-eliza-guardrail.json
+++ b/packages/registry/entries/third-party/blackwall-eliza-guardrail.json
@@ -4,7 +4,7 @@
   "kind": "plugin",
   "description": "BLACK_WALL pre-action risk guardrail for elizaOS agents - wraps every action handler with a forecast() check so STOP-rated actions abort before they run; gateCall() adds per-call gating for multi-step handlers. Observe mode by default (zero behavior change).",
   "homepage": "https://github.com/bluetieroperations-create/blackwall-eliza-guardrail",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "tags": [
     "security",
     "guardrails",

--- a/packages/registry/entries/third-party/blackwall-eliza-guardrail.json
+++ b/packages/registry/entries/third-party/blackwall-eliza-guardrail.json
@@ -1,0 +1,15 @@
+{
+  "package": "blackwall-eliza-guardrail",
+  "repository": "github:bluetieroperations-create/blackwall-eliza-guardrail",
+  "kind": "plugin",
+  "description": "BLACK_WALL pre-action risk guardrail for elizaOS agents - wraps every action handler with a forecast() check so STOP-rated actions abort before they run; gateCall() adds per-call gating for multi-step handlers. Observe mode by default (zero behavior change).",
+  "homepage": "https://github.com/bluetieroperations-create/blackwall-eliza-guardrail",
+  "version": "0.2.0",
+  "tags": [
+    "security",
+    "guardrails",
+    "ai-safety",
+    "risk-gate",
+    "onchain-safety"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -92,6 +92,102 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "blackwall-eliza-guardrail": {
+      "git": {
+        "repo": "bluetieroperations-create/blackwall-eliza-guardrail",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "blackwall-eliza-guardrail",
+        "v0": null,
+        "v1": null,
+        "v2": "0.2.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "BLACK_WALL pre-action risk guardrail for elizaOS agents - wraps every action handler with a forecast() check so STOP-rated actions abort before they run; gateCall() adds per-call gating for multi-step handlers. Observe mode by default (zero behavior change).",
+      "homepage": "https://github.com/bluetieroperations-create/blackwall-eliza-guardrail",
+      "topics": [
+        "security",
+        "guardrails",
+        "ai-safety",
+        "risk-gate",
+        "onchain-safety"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
+    "elizaos-plugin-coinrailz": {
+      "git": {
+        "repo": "tdnupe3/elizaos-plugin-coinrailz",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "elizaos-plugin-coinrailz",
+        "v0": null,
+        "v1": null,
+        "v2": "2.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Agent Treasury + Payments: non-custodial USDC yield on Solana (Kamino, ~3.4% APY) and Base (ERC-4626 routing via Aave/Compound/Morpho), plus 65 live x402 pay-per-call services for inference, IoT data, satellite imagery, and execution.",
+      "homepage": "https://coinrailz.com",
+      "topics": [
+        "payments",
+        "x402",
+        "usdc",
+        "yield",
+        "treasury",
+        "solana",
+        "base",
+        "defi",
+        "micropayments",
+        "iot",
+        "satellite"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "elizaos-plugin-echo": {
       "git": {
         "repo": "elizaOS/eliza",

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -109,7 +109,7 @@
         "repo": "blackwall-eliza-guardrail",
         "v0": null,
         "v1": null,
-        "v2": "0.2.0"
+        "v2": "0.2.1"
       },
       "supports": {
         "v0": false,


### PR DESCRIPTION
## What

Adds a third-party registry entry for [`blackwall-eliza-guardrail`](https://www.npmjs.com/package/blackwall-eliza-guardrail) (published, v0.2.1) — a **pre-action risk guardrail** for elizaOS agents.

It wraps every registered action handler at `init()` with a `forecast()` risk check (BLACK_WALL) so STOP-rated actions abort *before* they run, plus an opt-in `gateCall()` for per-call gating inside multi-step handlers. **Defaults to `observe` mode** (logs verdicts, never aborts — zero behavior change), so it's safe to drop in; flip to `enforce` once trusted.

- npm: `blackwall-eliza-guardrail@0.2.1` · MIT · ESM
- repo: https://github.com/bluetieroperations-create/blackwall-eliza-guardrail
- `keywords` include `elizaos`

## Changes

- `entries/third-party/blackwall-eliza-guardrail.json` — source entry.
- `generated-registry.json` — regenerated via the package's transform; only the new entry inserted, existing entries unchanged.

Validates against `schema/registry-entry.schema.json` (unscoped name, not `@elizaos/*`; required `package`/`repository`/`kind` present).
