### PR TITLE
fix(cloud): cap Steward agent-token expiresIn at 7d

### DIFF
--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -611,7 +611,11 @@ async function registerAgentWithSteward(
   warnMissingStewardTenantApiKey(apiKey);
   const platformKey = resolveStewardPlatformKey();
   const agentBody = JSON.stringify({ id: agentId, name: agentName });
-  const tokenBody = JSON.stringify({ expiresIn: "365d" });
+  // Steward caps agent-token expiry at 7d (validated in
+  // packages/api/src/routes/platform.ts — "expiresIn must be a duration up
+  // to 7d using s, m, h, or d"). The daemon refreshes agent JWTs via the
+  // STEWARD_REFRESH_URL flow before they expire, so a 7d ceiling is fine.
+  const tokenBody = JSON.stringify({ expiresIn: "7d" });
   const signingSecret = resolveStewardRequestSigningSecret(apiKey);
   const agentPath = buildPlatformAgentPath(tenantId);
   const tokenPath = `${buildPlatformAgentPath(tenantId, agentId)}/token`;


### PR DESCRIPTION
## Why

After #8301 (migration to Steward platform-key path), the daemon now hits `POST /platform/tenants/:id/agents/:id/token` which validates expiresIn against a 7d ceiling:

```
{"ok":false,"error":"expiresIn must be a duration up to 7d using s, m, h, or d"}
```

→ HTTP 400, agent provisioning fails on token mint step.

The old tenant-key path didn't enforce this ceiling, so the daemon happily sent `expiresIn: "365d"`. Platform-key path is strict.

## What

1-line change: `"365d"` → `"7d"`.

The daemon refreshes agent JWTs via `STEWARD_REFRESH_URL` on container boot, so 7d ceiling is fine (the refresh flow is independent of the original mint expiry).

## Test plan

- [x] Confirmed live: registration step now succeeds; only the token mint step was 400ing
- [ ] CI green
- [ ] Manual: after merge + daemon redeploy, retry "New Agent → Dedicated → develop image" — should reach `status=running`