### PR TITLE
fix(apps): DB ambassador so isolated app containers can reach their tenant DB

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/app-container-provider.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-container-provider.test.ts
@@ -58,6 +58,35 @@ describe("AppContainerProvider.provision", () => {
     expect(calls[2]).toBe("docker start 'app-nubilio'");
   });
 
+  test("provision with a DATABASE_URL stands up the DB ambassador + rewrites the DSN host", async () => {
+    const { calls, ssh } = recordingSsh();
+    const provider = new AppContainerProvider({ ssh, allocateHostPort: async () => 49002 });
+
+    await provider.provision({
+      appId: APP_ID,
+      containerName: "app-nubilio",
+      input: {
+        ...INPUT,
+        environmentVars: {
+          DATABASE_URL: "postgresql://app_x:p%40ss@10.43.0.10:5432/db_app_x?sslmode=require",
+        },
+      },
+    });
+
+    const joined = calls.join("\n");
+    // ambassador: rm stale, run socat to the REAL DB, attach to the app net
+    expect(joined).toContain("docker run -d --name 'app-db-111111112222'");
+    expect(joined).toContain("'TCP:10.43.0.10:5432'");
+    expect(joined).toContain("'TCP-LISTEN:5432,fork,reuseaddr'");
+    expect(joined).toMatch(/docker network connect 'app-net-\S+' 'app-db-111111112222'/);
+    // the app container's DSN host is rewritten to the ambassador (creds/db/params kept)
+    const createCmd = calls.find((c) => c.startsWith("docker create")) ?? "";
+    expect(createCmd).toContain(
+      "DATABASE_URL=postgresql://app_x:p%40ss@app-db-111111112222:5432/db_app_x?sslmode=require",
+    );
+    expect(createCmd).not.toContain("@10.43.0.10:5432");
+  });
+
   test("lifecycle verbs issue the expected docker commands", async () => {
     const { calls, ssh } = recordingSsh();
     const provider = new AppContainerProvider({ ssh, allocateHostPort: async () => 1 });
@@ -66,6 +95,7 @@ describe("AppContainerProvider.provision", () => {
     await provider.logs("app-x", 50);
     expect(calls).toEqual([
       "docker rm -f 'app-x'",
+      "docker rm -f 'app-db-x' >/dev/null 2>&1 || true",
       "docker restart 'app-x'",
       "docker logs --tail 50 'app-x'",
     ]);

--- a/packages/cloud-shared/src/lib/services/__tests__/app-db-ambassador.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-db-ambassador.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ambassadorName,
+  ambassadorNameForContainer,
+  buildEnsureAmbassadorCmds,
+  buildRemoveAmbassadorCmdForContainer,
+  parseDsnEndpoint,
+  rewriteDsnToAmbassador,
+} from "../app-db-ambassador";
+
+const APP_ID = "11111111-2222-3333-4444-555555555555";
+
+describe("ambassador naming", () => {
+  test("ambassadorName uses the same 12-char slug as the app container", () => {
+    expect(ambassadorName(APP_ID)).toBe("app-db-111111112222");
+  });
+
+  test("ambassadorNameForContainer derives from the app container name", () => {
+    expect(ambassadorNameForContainer("app-111111112222")).toBe("app-db-111111112222");
+    // round-trips with ambassadorName for the same app
+    expect(ambassadorNameForContainer("app-111111112222")).toBe(ambassadorName(APP_ID));
+  });
+});
+
+describe("parseDsnEndpoint", () => {
+  test("extracts host + port from a full DSN", () => {
+    expect(parseDsnEndpoint("postgresql://u:p@10.43.0.10:5432/db?sslmode=require")).toEqual({
+      host: "10.43.0.10",
+      port: 5432,
+    });
+  });
+
+  test("defaults the port to 5432 when absent", () => {
+    expect(parseDsnEndpoint("postgresql://u:p@db.internal/appdb")).toEqual({
+      host: "db.internal",
+      port: 5432,
+    });
+  });
+
+  test("is not fooled by an @ that isn't present (returns null)", () => {
+    expect(parseDsnEndpoint("postgresql://localhost:5432/db")).toBeNull();
+  });
+});
+
+describe("rewriteDsnToAmbassador", () => {
+  test("replaces only host:port, preserving user/pass/db/params", () => {
+    expect(
+      rewriteDsnToAmbassador(
+        "postgresql://app_x:p%40ss@10.43.0.10:5432/db_app_x?sslmode=require",
+        "app-db-111111112222",
+      ),
+    ).toBe("postgresql://app_x:p%40ss@app-db-111111112222:5432/db_app_x?sslmode=require");
+  });
+
+  test("works when the original DSN omits the port", () => {
+    expect(rewriteDsnToAmbassador("postgresql://u:p@host/db", "amb")).toBe(
+      "postgresql://u:p@amb:5432/db",
+    );
+  });
+});
+
+describe("buildEnsureAmbassadorCmds", () => {
+  test("rm stale -> run socat to the tenant DB -> attach to the app net", () => {
+    const cmds = buildEnsureAmbassadorCmds({
+      appId: APP_ID,
+      network: "app-net-111111112222333344445555",
+      db: { host: "10.43.0.10", port: 5432 },
+    });
+    expect(cmds).toHaveLength(3);
+    expect(cmds[0]).toBe("docker rm -f 'app-db-111111112222' >/dev/null 2>&1 || true");
+    // forwarder: dropped caps, started on the egress net (default bridge), socat target = the DB
+    expect(cmds[1]).toContain("docker run -d --name 'app-db-111111112222'");
+    expect(cmds[1]).toContain("--network 'bridge'");
+    expect(cmds[1]).toContain("--cap-drop=ALL");
+    expect(cmds[1]).toContain("'TCP-LISTEN:5432,fork,reuseaddr'");
+    expect(cmds[1]).toContain("'TCP:10.43.0.10:5432'");
+    expect(cmds[2]).toBe(
+      "docker network connect 'app-net-111111112222333344445555' 'app-db-111111112222'",
+    );
+  });
+
+  test("honors a custom egress network + image", () => {
+    const cmds = buildEnsureAmbassadorCmds({
+      appId: APP_ID,
+      network: "app-net-x",
+      db: { host: "db-node", port: 6543 },
+      egressNetwork: "apps-db-egress",
+      image: "alpine/socat:1.8.0.1",
+    });
+    expect(cmds[1]).toContain("--network 'apps-db-egress'");
+    expect(cmds[1]).toContain("'alpine/socat:1.8.0.1'");
+    expect(cmds[1]).toContain("'TCP:db-node:6543'");
+  });
+});
+
+describe("buildRemoveAmbassadorCmdForContainer", () => {
+  test("removes the ambassador derived from the container name (best-effort)", () => {
+    expect(buildRemoveAmbassadorCmdForContainer("app-111111112222")).toBe(
+      "docker rm -f 'app-db-111111112222' >/dev/null 2>&1 || true",
+    );
+  });
+});

--- a/packages/cloud-shared/src/lib/services/app-container-provider.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-provider.ts
@@ -11,6 +11,13 @@
  * scaffolding, no shared network, no NET_ADMIN.
  */
 
+import {
+  ambassadorName,
+  buildEnsureAmbassadorCmds,
+  buildRemoveAmbassadorCmdForContainer,
+  parseDsnEndpoint,
+  rewriteDsnToAmbassador,
+} from "./app-db-ambassador";
 import { buildAppDockerCreateCmd } from "./app-docker-cmd";
 import { appNetworkName, buildEnsureAppNetworkCmd } from "./app-network-utils";
 import type { CreateContainerInput } from "./containers/hetzner-client/types";
@@ -30,6 +37,13 @@ export interface AppContainerProviderDeps {
   pidsLimit?: number;
   /** Parse the container id from `docker create` stdout. */
   extractContainerId?: (dockerCreateStdout: string) => string;
+  /**
+   * Network the DB ambassador uses to reach the tenant DB (its only egress).
+   * Default `bridge`. The app container itself never joins this network.
+   */
+  dbEgressNetwork?: string;
+  /** socat image for the DB ambassador. Defaults to the module default. */
+  ambassadorImage?: string;
 }
 
 export interface ProvisionAppContainerParams {
@@ -61,11 +75,39 @@ export class AppContainerProvider {
     const network = appNetworkName(params.appId);
     await this.deps.ssh.exec(buildEnsureAppNetworkCmd(network));
 
+    // DB ambassador: the app is on an `--internal` net (no egress at all), so it
+    // can't reach its tenant DB directly. Stand up a per-app socat forwarder on
+    // the app net that reaches ONLY the tenant DB, and point the app's
+    // DATABASE_URL at it. The app keeps zero general egress; REVOKE-CONNECT still
+    // isolates the actual database. No DSN -> no ambassador (nothing to reach).
+    let input = params.input;
+    const dsn = input.environmentVars?.DATABASE_URL;
+    const endpoint = dsn ? parseDsnEndpoint(dsn) : null;
+    if (dsn && endpoint) {
+      const cmds = buildEnsureAmbassadorCmds({
+        appId: params.appId,
+        network,
+        db: endpoint,
+        egressNetwork: this.deps.dbEgressNetwork,
+        image: this.deps.ambassadorImage,
+      });
+      for (const cmd of cmds) {
+        await this.deps.ssh.exec(cmd);
+      }
+      input = {
+        ...input,
+        environmentVars: {
+          ...input.environmentVars,
+          DATABASE_URL: rewriteDsnToAmbassador(dsn, ambassadorName(params.appId)),
+        },
+      };
+    }
+
     const hostPort = await this.deps.allocateHostPort();
     const createCmd = buildAppDockerCreateCmd({
       appId: params.appId,
       containerName: params.containerName,
-      input: params.input,
+      input,
       hostPort,
       egressProxyUrl: this.deps.egressProxyUrl,
       pidsLimit: this.deps.pidsLimit,
@@ -80,6 +122,8 @@ export class AppContainerProvider {
 
   async delete(containerName: string): Promise<void> {
     await this.deps.ssh.exec(`docker rm -f ${shellQuote(containerName)}`);
+    // Tear down the per-app DB ambassador too (best-effort; no-op if absent).
+    await this.deps.ssh.exec(buildRemoveAmbassadorCmdForContainer(containerName));
   }
 
   async restart(containerName: string): Promise<void> {

--- a/packages/cloud-shared/src/lib/services/app-db-ambassador.ts
+++ b/packages/cloud-shared/src/lib/services/app-db-ambassador.ts
@@ -1,0 +1,146 @@
+/**
+ * DB ambassador (Apps / Product 2) — the controlled TCP path that lets an
+ * isolated `--internal` app container reach ONLY its own tenant Postgres, with
+ * no other egress.
+ *
+ * The app container sits on its per-app `--internal` network (proven: zero
+ * internet/lateral egress — it can't even reach 8.8.8.8). That same isolation
+ * also blocks its tenant DB, which lives on a different host/node. So a tiny
+ * trusted `socat` forwarder ("ambassador") is attached to the app's network and
+ * forwards `:5432` to exactly that tenant DB; the app's `DATABASE_URL` host is
+ * rewritten to the ambassador. The untrusted app keeps zero general egress; the
+ * single-purpose forwarder is the only thing that can reach the DB, and only the
+ * DB (its socat target is a fixed host:port). REVOKE-CONNECT still isolates the
+ * actual databases, so even a shared cluster stays per-tenant safe.
+ *
+ * Pure builders + a regex DSN rewrite (no URL parser — the `postgresql://`
+ * scheme is non-special and parses inconsistently), so the posture is a
+ * unit-testable contract; the real `ssh.exec` lives in the provider.
+ *
+ * ADDITIVE: nothing here touches the agent path or 2AM's container schema.
+ */
+
+import { buildAppContainerSecurityFlags } from "./app-network-utils";
+import { shellQuote } from "./docker-sandbox-utils";
+
+/** Default socat image for the forwarder. Override via deps/env in production (pin a digest). */
+export const DEFAULT_AMBASSADOR_IMAGE = "alpine/socat";
+
+/** The port the ambassador listens on (and that the rewritten DSN points at). */
+export const AMBASSADOR_LISTEN_PORT = 5432;
+
+/**
+ * Per-app ambassador container name — stable + DNS-safe. Uses the SAME 12-char
+ * slug as `containerNameForApp` (`app-<slug>`), so the ambassador is
+ * `app-db-<slug>` and teardown can derive it from the container name alone.
+ */
+export function ambassadorName(appId: string): string {
+  const short = appId
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "")
+    .slice(0, 12);
+  return `app-db-${short}`;
+}
+
+/**
+ * Derive the ambassador name from the app container name (`app-<slug>` ->
+ * `app-db-<slug>`), so `delete(containerName)` can tear the forwarder down
+ * without the appId.
+ */
+export function ambassadorNameForContainer(containerName: string): string {
+  const slug = containerName.startsWith("app-")
+    ? containerName.slice("app-".length)
+    : containerName;
+  return `app-db-${slug}`;
+}
+
+export interface DbEndpoint {
+  host: string;
+  port: number;
+}
+
+/**
+ * Extract the upstream host:port from a Postgres DSN
+ * (`postgresql://user:pass@HOST:PORT/db?params`). The credential half never
+ * contains `@` (generated passwords are base64url), so the first `@` is the
+ * userinfo separator and the host:port runs to the next `/` or `?`.
+ */
+export function parseDsnEndpoint(dsn: string): DbEndpoint | null {
+  const at = dsn.indexOf("@");
+  if (at < 0) return null;
+  const rest = dsn.slice(at + 1);
+  const end = rest.search(/[/?]/);
+  const hostport = (end >= 0 ? rest.slice(0, end) : rest).trim();
+  if (!hostport) return null;
+  const lastColon = hostport.lastIndexOf(":");
+  if (lastColon <= 0) return { host: hostport, port: 5432 };
+  const host = hostport.slice(0, lastColon);
+  const port = Number(hostport.slice(lastColon + 1));
+  if (!host || !Number.isFinite(port)) return null;
+  return { host, port };
+}
+
+/**
+ * Rewrite a Postgres DSN's host:port to the ambassador address, preserving the
+ * user, password, database, and query params verbatim.
+ */
+export function rewriteDsnToAmbassador(
+  dsn: string,
+  ambassadorHost: string,
+  ambassadorPort: number = AMBASSADOR_LISTEN_PORT,
+): string {
+  const at = dsn.indexOf("@");
+  if (at < 0) return dsn;
+  const head = dsn.slice(0, at + 1); // `postgresql://user:pass@`
+  const rest = dsn.slice(at + 1);
+  const end = rest.search(/[/?]/);
+  const tail = end >= 0 ? rest.slice(end) : ""; // `/db?params`
+  return `${head}${ambassadorHost}:${ambassadorPort}${tail}`;
+}
+
+export interface AmbassadorParams {
+  appId: string;
+  /** The app's per-app `--internal` network (the app + ambassador share it). */
+  network: string;
+  /** The tenant DB the ambassador forwards to. */
+  db: DbEndpoint;
+  /** Network that can actually reach the DB host (gives the forwarder its only egress). Default `bridge`. */
+  egressNetwork?: string;
+  /** socat image. Default {@link DEFAULT_AMBASSADOR_IMAGE}. */
+  image?: string;
+}
+
+/**
+ * Commands to (re)create the per-app DB ambassador: a socat forwarder started on
+ * an egress-capable network (so it can reach the tenant DB) and then attached to
+ * the app's `--internal` network (so the app can reach it). Capabilities are
+ * dropped — it only needs to listen + connect TCP.
+ */
+export function buildEnsureAmbassadorCmds(params: AmbassadorParams): string[] {
+  const name = ambassadorName(params.appId);
+  const image = params.image ?? DEFAULT_AMBASSADOR_IMAGE;
+  const egressNetwork = params.egressNetwork ?? "bridge";
+  const security = buildAppContainerSecurityFlags();
+  const target = `TCP:${params.db.host}:${params.db.port}`;
+  const listen = `TCP-LISTEN:${AMBASSADOR_LISTEN_PORT},fork,reuseaddr`;
+  return [
+    `docker rm -f ${shellQuote(name)} >/dev/null 2>&1 || true`,
+    [
+      "docker run -d",
+      `--name ${shellQuote(name)}`,
+      "--restart unless-stopped",
+      `--network ${shellQuote(egressNetwork)}`,
+      ...security,
+      shellQuote(image),
+      "-dd",
+      shellQuote(listen),
+      shellQuote(target),
+    ].join(" "),
+    `docker network connect ${shellQuote(params.network)} ${shellQuote(name)}`,
+  ];
+}
+
+/** Command to remove an app's ambassador, derived from the app container name. */
+export function buildRemoveAmbassadorCmdForContainer(containerName: string): string {
+  return `docker rm -f ${shellQuote(ambassadorNameForContainer(containerName))} >/dev/null 2>&1 || true`;
+}

--- a/packages/cloud-shared/src/lib/services/container-executor-deps.ts
+++ b/packages/cloud-shared/src/lib/services/container-executor-deps.ts
@@ -103,10 +103,20 @@ export function buildContainerExecutorDeps(): ContainerExecutorDeps {
   }
   const ssh = makeNodeSsh();
   const egressProxyUrl = process.env.CONTAINERS_EGRESS_PROXY_URL || undefined;
-  const provider = new AppContainerProvider({ ssh, allocateHostPort, egressProxyUrl });
+  // The DB ambassador's egress network (it reaches the tenant DB) + socat image.
+  const dbEgressNetwork = process.env.APPS_DB_EGRESS_NETWORK || undefined;
+  const ambassadorImage = process.env.APPS_DB_AMBASSADOR_IMAGE || undefined;
+  const provider = new AppContainerProvider({
+    ssh,
+    allocateHostPort,
+    egressProxyUrl,
+    dbEgressNetwork,
+    ambassadorImage,
+  });
   logger.info("[container-executor-deps] built apps container backend", {
     node: selectNodeHost(),
     egressProxy: Boolean(egressProxyUrl),
+    dbEgressNetwork: dbEgressNetwork ?? "bridge",
   });
   return { provider, store: appContainerStore };
 }


### PR DESCRIPTION
## The gap (found by testing the full deploy on staging)
App containers run on a per-app `--internal` Docker network with **zero egress**
(proven — a container on it can't even reach `8.8.8.8`). But that *also* blocks the
app's **own tenant Postgres**, which lives on a different host/node. So a deploy
would start the container, yet the app could **never connect to its database**.

The earlier 5/5 isolation proof missed this because it tested app↔DB and the
egress-block on **separate** networks — never combined. The existing `egressProxyUrl`
mechanism only covers **HTTP**; a Postgres connection is raw TCP.

## Fix — the per-app DB "ambassador" (standard ambassador/sidecar pattern)
A tiny **trusted `socat` forwarder** is attached to the app's `--internal` network and
forwards `:5432` to **only** that tenant DB. The app's `DATABASE_URL` host is rewritten
to the ambassador. So:
- the untrusted app keeps **zero general egress** (the proven `--internal` posture is unchanged);
- the single-purpose forwarder is the **only** thing that reaches the DB, and **only** the DB (fixed socat target);
- `REVOKE CONNECT` still isolates the actual databases, so a shared cluster stays per-tenant safe.

```
[app :3000]──app-net (--internal, no egress)──[socat ambassador]──bridge──▶ tenant DB :5432
     └ DATABASE_URL=…@app-db-<slug>:5432/…            (forwards ONLY to the tenant DB)
```

## Changes
- **`app-db-ambassador.ts`** (new): pure builders — `ambassadorName`, `parseDsnEndpoint`,
  `rewriteDsnToAmbassador`, `buildEnsureAmbassadorCmds`, teardown.
- **`app-container-provider.ts`**: `provision()` stands up the ambassador + rewrites the DSN
  when a `DATABASE_URL` is present; `delete()` tears it down.
- **`container-executor-deps.ts`**: `APPS_DB_EGRESS_NETWORK` / `APPS_DB_AMBASSADOR_IMAGE` env.

## Verification
- **13/13** new unit tests; biome + typecheck clean.
- **Real-infra capstone on staging — 5/5:** app network `--internal`, DSN rewritten,
  **isolated app reaches its tenant DB *through the ambassador***, internet egress **still
  blocked** (8.8.8.8), socat target pinned to the DB. (Throwaway resources, cleaned up.)

Additive; no agent-path or 2AM hot-file changes. The tenant DB should run TLS in prod
(socat is transparent TCP); the staging tenant PG has no TLS so the proof localized `sslmode`.