### PR TITLE
fix(cloud): point staging R2 BLOB binding at eliza-cloud-blob-staging

### DIFF
--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -299,7 +299,7 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 # blocks — they must be re-declared per-env. Same physical resources.
 [[env.staging.r2_buckets]]
 binding = "BLOB"
-bucket_name = "eliza-cloud-blob"
+bucket_name = "eliza-cloud-blob-staging"
 
 [env.production]
 name = "eliza-cloud-api-prod"


### PR DESCRIPTION
## Why
The `[[env.staging.r2_buckets]]` BLOB binding was pointing at the prod bucket `eliza-cloud-blob`, so staging Worker uploads/reads were hitting prod data. Staging must be isolated from prod.

## What
Switch staging BLOB binding to `eliza-cloud-blob-staging`. Prod block (`[[env.production.r2_buckets]]`) is unchanged.

## Test plan
- Deploy staging Worker, upload a blob, verify it lands in `eliza-cloud-blob-staging` (not prod).

## Operator follow-up
- Ensure `eliza-cloud-blob-staging` exists: `wrangler r2 bucket create eliza-cloud-blob-staging`
- Decide whether `R2_PUBLIC_HOST` in `[env.staging.vars]` should be overridden (currently inherits `blob.elizacloud.ai` which fronts the prod bucket).