### PR TITLE
fix(cloud): drop hardcoded prod fallback in eliza.json provisioning

### DIFF
--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -1266,14 +1266,21 @@ export class DockerSandboxProvider implements SandboxProvider {
       // does not abort provisioning — the env vars on the container still
       // carry the same values.
       try {
+        if (!allEnv.ELIZAOS_CLOUD_BASE_URL) {
+          throw new Error(
+            "[docker-sandbox] ELIZAOS_CLOUD_BASE_URL is not set in container env. " +
+              "Refusing to fall back to the hardcoded prod URL (https://www.elizacloud.ai/api/v1) — " +
+              "this caused staging containers to silently call prod. " +
+              "Configure ELIZAOS_CLOUD_BASE_URL in the daemon/Worker env (e.g. " +
+              "https://api-staging.elizacloud.ai/api/v1 for staging, https://api.elizacloud.ai/api/v1 for prod).",
+          );
+        }
         const elizaConfig = JSON.stringify({
           logging: { level: "info" },
           cloud: {
             enabled: Boolean(allEnv.ELIZAOS_CLOUD_API_KEY),
             apiKey: allEnv.ELIZAOS_CLOUD_API_KEY || "",
-            baseUrl:
-              allEnv.ELIZAOS_CLOUD_BASE_URL ||
-              "https://www.elizacloud.ai/api/v1",
+            baseUrl: allEnv.ELIZAOS_CLOUD_BASE_URL,
           },
         });
         // Base64-encode the JSON before passing it through the shell so an


### PR DESCRIPTION
## Why
`docker-sandbox-provider` wrote `eliza.json` with a hardcoded `https://www.elizacloud.ai/api/v1` baseUrl when `ELIZAOS_CLOUD_BASE_URL` was unset, silently routing staging containers to the prod cloud API.

## What
Replace the `||` fallback with an explicit throw when `ELIZAOS_CLOUD_BASE_URL` is missing. The outer try/catch (best-effort eliza.json write) catches it, logs a clear warning, and provisioning continues — container env vars still carry the correct value, so this is the safe failure mode while surfacing the misconfig.

## Test plan
- Boot staging daemon without `ELIZAOS_CLOUD_BASE_URL`: warning logged, no prod baseUrl leaks into eliza.json; with it set, baseUrl matches env.