### PR TITLE
fix(cloud): force-price openai/gpt-oss-120b in BitRouter catalog

### DIFF
--- a/packages/cloud-shared/src/lib/services/ai-pricing-variant-indexing.test.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing-variant-indexing.test.ts
@@ -19,14 +19,18 @@ import { fetchBitRouterCatalogEntries } from "@/lib/services/ai-pricing/provider
 
 describe("stripVersionedSnapshotSuffix — dated and labelled suffixes", () => {
   test("strips compact 8-digit date suffix", () => {
-    expect(stripVersionedSnapshotSuffix("anthropic/claude-3-5-haiku-20241022")).toBe(
-      "anthropic/claude-3-5-haiku",
-    );
+    expect(
+      stripVersionedSnapshotSuffix("anthropic/claude-3-5-haiku-20241022"),
+    ).toBe("anthropic/claude-3-5-haiku");
   });
 
   test("strips ISO date suffix", () => {
-    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-2024-11-20")).toBe("openai/gpt-4o");
-    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-2024-08-06")).toBe("openai/gpt-4o");
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-2024-11-20")).toBe(
+      "openai/gpt-4o",
+    );
+    expect(stripVersionedSnapshotSuffix("openai/gpt-4o-2024-08-06")).toBe(
+      "openai/gpt-4o",
+    );
   });
 
   test("strips -latest label", () => {
@@ -46,7 +50,9 @@ describe("stripVersionedSnapshotSuffix — dated and labelled suffixes", () => {
   });
 
   test("dated suffix bypasses the 2-segment safety check for short bases", () => {
-    expect(stripVersionedSnapshotSuffix("openai/o1-2024-12-17")).toBe("openai/o1");
+    expect(stripVersionedSnapshotSuffix("openai/o1-2024-12-17")).toBe(
+      "openai/o1",
+    );
   });
 });
 
@@ -55,14 +61,18 @@ describe("stripVersionedSnapshotSuffix — numeric snapshot suffixes", () => {
     expect(stripVersionedSnapshotSuffix("google/gemini-2.0-flash-001")).toBe(
       "google/gemini-2.0-flash",
     );
-    expect(stripVersionedSnapshotSuffix("google/gemini-2.0-flash-lite-001")).toBe(
-      "google/gemini-2.0-flash-lite",
-    );
+    expect(
+      stripVersionedSnapshotSuffix("google/gemini-2.0-flash-lite-001"),
+    ).toBe("google/gemini-2.0-flash-lite");
   });
 
   test("strips multi-digit numeric snapshot when two+ segments remain", () => {
-    expect(stripVersionedSnapshotSuffix("vendor/family-name-1234")).toBe("vendor/family-name");
-    expect(stripVersionedSnapshotSuffix("vendor/family-name-99")).toBe("vendor/family-name");
+    expect(stripVersionedSnapshotSuffix("vendor/family-name-1234")).toBe(
+      "vendor/family-name",
+    );
+    expect(stripVersionedSnapshotSuffix("vendor/family-name-99")).toBe(
+      "vendor/family-name",
+    );
   });
 
   test("does NOT strip when result would collapse to one segment after slash", () => {
@@ -74,7 +84,9 @@ describe("stripVersionedSnapshotSuffix — numeric snapshot suffixes", () => {
 describe("stripVersionedSnapshotSuffix — must-not-strip cases", () => {
   test("returns null when no suffix pattern matches", () => {
     expect(stripVersionedSnapshotSuffix("openai/gpt-4o-mini")).toBeNull();
-    expect(stripVersionedSnapshotSuffix("anthropic/claude-3-5-haiku")).toBeNull();
+    expect(
+      stripVersionedSnapshotSuffix("anthropic/claude-3-5-haiku"),
+    ).toBeNull();
     expect(stripVersionedSnapshotSuffix("google/gemini-2.5-flash")).toBeNull();
     expect(stripVersionedSnapshotSuffix("openai/gpt-4o")).toBeNull();
   });
@@ -98,7 +110,9 @@ describe("stripVersionedSnapshotSuffix — must-not-strip cases", () => {
     // A vendor suffix like -99000001 must not be silently stripped as a
     // compact date. Year-anchoring the compact-date pattern is what blocks
     // this: only -19YYMMDD / -20YYMMDD shapes are accepted as dates.
-    expect(stripVersionedSnapshotSuffix("vendor/family-name-99000001")).toBeNull();
+    expect(
+      stripVersionedSnapshotSuffix("vendor/family-name-99000001"),
+    ).toBeNull();
   });
 
   test("accepts realistic compact-date suffixes for both 19xx and 20xx years", () => {
@@ -129,14 +143,22 @@ describe("buildBitRouterPreparedEntries — exact + stripped variants", () => {
     expect(inputEntries).toHaveLength(2);
     expect(outputEntries).toHaveLength(2);
 
-    const exactInput = inputEntries.find((e) => e.model === "google/gemini-2.0-flash-001");
-    const strippedInput = inputEntries.find((e) => e.model === "google/gemini-2.0-flash");
+    const exactInput = inputEntries.find(
+      (e) => e.model === "google/gemini-2.0-flash-001",
+    );
+    const strippedInput = inputEntries.find(
+      (e) => e.model === "google/gemini-2.0-flash",
+    );
     expect(exactInput?.priority).toBeUndefined();
     expect(strippedInput?.priority).toBe(-1);
     expect(exactInput?.unitPrice).toBe(strippedInput?.unitPrice);
 
-    const exactOutput = outputEntries.find((e) => e.model === "google/gemini-2.0-flash-001");
-    const strippedOutput = outputEntries.find((e) => e.model === "google/gemini-2.0-flash");
+    const exactOutput = outputEntries.find(
+      (e) => e.model === "google/gemini-2.0-flash-001",
+    );
+    const strippedOutput = outputEntries.find(
+      (e) => e.model === "google/gemini-2.0-flash",
+    );
     expect(exactOutput?.priority).toBeUndefined();
     expect(strippedOutput?.priority).toBe(-1);
     expect(exactOutput?.unitPrice).toBe(strippedOutput?.unitPrice);
@@ -161,7 +183,9 @@ describe("buildBitRouterPreparedEntries — exact + stripped variants", () => {
       pricing: { prompt: "0.0000008" },
     });
 
-    const stripped = entries.find((e) => e.model === "anthropic/claude-3-5-haiku");
+    const stripped = entries.find(
+      (e) => e.model === "anthropic/claude-3-5-haiku",
+    );
     expect(stripped?.model).toBe("anthropic/claude-3-5-haiku");
     expect(stripped?.priority).toBe(-1);
     expect(stripped?.provider).toBe("anthropic");
@@ -189,27 +213,35 @@ describe("buildBitRouterPreparedEntries — exact + stripped variants", () => {
 
     expect(entries).toHaveLength(2);
     expect(entries.every((e) => e.chargeType === "input")).toBe(true);
-    expect(entries.find((e) => e.model === "google/gemini-2.0-flash")?.priority).toBe(-1);
+    expect(
+      entries.find((e) => e.model === "google/gemini-2.0-flash")?.priority,
+    ).toBe(-1);
   });
 });
 
 describe("forced provider route pricing ids", () => {
   test("keeps forced route ids canonical before slash-prefixed aliases", () => {
-    expect(canonicalModelId("openrouter:openai/gpt-oss-120b", "openrouter")).toBe(
-      "openrouter:openai/gpt-oss-120b",
+    expect(
+      canonicalModelId("openrouter:openai/gpt-oss-120b", "openrouter"),
+    ).toBe("openrouter:openai/gpt-oss-120b");
+    expect(canonicalModelId("cerebras:gpt-oss-120b", "cerebras")).toBe(
+      "cerebras:gpt-oss-120b",
     );
-    expect(canonicalModelId("cerebras:gpt-oss-120b", "cerebras")).toBe("cerebras:gpt-oss-120b");
   });
 
   test("infers provider from forced route prefixes", () => {
-    expect(inferProviderFromCanonicalModel("openrouter:openai/gpt-oss-120b")).toBe("openrouter");
-    expect(inferProviderFromCanonicalModel("cerebras:zai-glm-4.7")).toBe("cerebras");
+    expect(
+      inferProviderFromCanonicalModel("openrouter:openai/gpt-oss-120b"),
+    ).toBe("openrouter");
+    expect(inferProviderFromCanonicalModel("cerebras:zai-glm-4.7")).toBe(
+      "cerebras",
+    );
   });
 
   test("uses underlying catalog id as an alias for OpenRouter forced routes", () => {
-    expect(expandPricingCatalogModelCandidates("openrouter:openai/gpt-oss-120b")).toContain(
-      "openai/gpt-oss-120b",
-    );
+    expect(
+      expandPricingCatalogModelCandidates("openrouter:openai/gpt-oss-120b"),
+    ).toContain("openai/gpt-oss-120b");
   });
 
   test("adds synthetic Cerebras pricing rows to the BitRouter catalog", async () => {
@@ -227,16 +259,24 @@ describe("forced provider route pricing ids", () => {
     try {
       const entries = await fetchBitRouterCatalogEntries();
       const gptInput = entries.find(
-        (entry) => entry.model === "cerebras:gpt-oss-120b" && entry.chargeType === "input",
+        (entry) =>
+          entry.model === "cerebras:gpt-oss-120b" &&
+          entry.chargeType === "input",
       );
       const gptOutput = entries.find(
-        (entry) => entry.model === "cerebras:gpt-oss-120b" && entry.chargeType === "output",
+        (entry) =>
+          entry.model === "cerebras:gpt-oss-120b" &&
+          entry.chargeType === "output",
       );
       const glmInput = entries.find(
-        (entry) => entry.model === "cerebras:zai-glm-4.7" && entry.chargeType === "input",
+        (entry) =>
+          entry.model === "cerebras:zai-glm-4.7" &&
+          entry.chargeType === "input",
       );
       const glmOutput = entries.find(
-        (entry) => entry.model === "cerebras:zai-glm-4.7" && entry.chargeType === "output",
+        (entry) =>
+          entry.model === "cerebras:zai-glm-4.7" &&
+          entry.chargeType === "output",
       );
 
       expect(gptInput?.provider).toBe("cerebras");
@@ -244,6 +284,46 @@ describe("forced provider route pricing ids", () => {
       expect(gptOutput?.unitPrice).toBe(0.00000075);
       expect(glmInput?.unitPrice).toBe(0.00000225);
       expect(glmOutput?.unitPrice).toBe(0.00000275);
+    } finally {
+      if (previousApiKey === undefined) {
+        delete process.env.BITROUTER_API_KEY;
+      } else {
+        process.env.BITROUTER_API_KEY = previousApiKey;
+      }
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  test("adds a synthetic openai/gpt-oss-120b row so :nitro / :free variants resolve", async () => {
+    // Default cloud TEXT_SMALL model is `openai/gpt-oss-120b:nitro`
+    // (packages/core/src/contracts/service-routing.ts). BitRouter's catalog
+    // doesn't currently return a priced row for the base id, so without this
+    // forced entry every credit-debiting chat request 500s with
+    // "Pricing unavailable for language:input openai/gpt-oss-120b". The
+    // variant stripper in candidate-selection collapses :nitro / :free onto
+    // the base, so one base entry covers every variant.
+    const previousApiKey = process.env.BITROUTER_API_KEY;
+    const previousFetch = globalThis.fetch;
+    process.env.BITROUTER_API_KEY = "test-bitrouter-key";
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ data: [] }), { status: 200 });
+
+    try {
+      const entries = await fetchBitRouterCatalogEntries();
+      const input = entries.find(
+        (entry) =>
+          entry.model === "openai/gpt-oss-120b" && entry.chargeType === "input",
+      );
+      const output = entries.find(
+        (entry) =>
+          entry.model === "openai/gpt-oss-120b" &&
+          entry.chargeType === "output",
+      );
+
+      expect(input?.provider).toBe("openai");
+      expect(input?.productFamily).toBe("language");
+      expect(input?.unitPrice).toBe(0.0000001);
+      expect(output?.unitPrice).toBe(0.0000005);
     } finally {
       if (previousApiKey === undefined) {
         delete process.env.BITROUTER_API_KEY;
@@ -306,7 +386,11 @@ describe("chooseBestCandidatePricingEntry — tie-break when stripped variants c
     const a = buildCandidate("google/gemini-2.0-flash-001", 0.0000001);
     const b = buildCandidate("google/gemini-2.0-flash-002", 0.0000001);
 
-    const winner = chooseBestCandidatePricingEntry([a, b], {}, "google/gemini-2.0-flash");
+    const winner = chooseBestCandidatePricingEntry(
+      [a, b],
+      {},
+      "google/gemini-2.0-flash",
+    );
     expect(winner?.entry.model).toBe("google/gemini-2.0-flash");
     expect(winner?.entry.unitPrice).toBe(0.0000001);
   });

--- a/packages/cloud-shared/src/lib/services/ai-pricing/providers/bitrouter.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/providers/bitrouter.ts
@@ -1,8 +1,14 @@
 import { getProviderKey } from "../../../providers/provider-env";
 import { logger } from "../../../utils/logger";
-import { type PricingChargeUnit, type PricingProductFamily } from "../../ai-pricing-definitions";
+import {
+  type PricingChargeUnit,
+  type PricingProductFamily,
+} from "../../ai-pricing-definitions";
 import { getCachedExternalEntries } from "../cache";
-import { inferProviderFromCanonicalModel, parseNumericPrice } from "../dimensions";
+import {
+  inferProviderFromCanonicalModel,
+  parseNumericPrice,
+} from "../dimensions";
 import { stripVersionedSnapshotSuffix } from "../suffix-stripping";
 import {
   type BitRouterCatalogModel,
@@ -11,6 +17,13 @@ import {
 } from "../types";
 
 const CEREBRAS_PRICING_SOURCE_URL = "https://www.cerebras.ai/pricing";
+// OpenRouter doesn't return a priced row from BitRouter for `openai/gpt-oss-120b`,
+// but it's the canonical fallback for the cloud's default TEXT_SMALL model
+// (`openai/gpt-oss-120b:nitro`, see packages/core/src/contracts/service-routing.ts).
+// Variant stripping in candidate-selection.ts collapses :nitro / :free to the
+// base id, so one base entry covers every variant.
+const OPENROUTER_PRICING_SOURCE_URL =
+  "https://openrouter.ai/openai/gpt-oss-120b";
 
 const FORCED_BITROUTER_PRICING: ReadonlyArray<{
   model: string;
@@ -31,7 +44,8 @@ const FORCED_BITROUTER_PRICING: ReadonlyArray<{
     outputUnitPrice: 0.00000075,
     sourceUrl: CEREBRAS_PRICING_SOURCE_URL,
     metadata: {
-      sourceNote: "Cerebras Developer tier price converted from $0.35/$0.75 per 1M tokens.",
+      sourceNote:
+        "Cerebras Developer tier price converted from $0.35/$0.75 per 1M tokens.",
     },
   },
   {
@@ -43,27 +57,47 @@ const FORCED_BITROUTER_PRICING: ReadonlyArray<{
     outputUnitPrice: 0.00000275,
     sourceUrl: CEREBRAS_PRICING_SOURCE_URL,
     metadata: {
-      sourceNote: "Cerebras Developer tier price converted from $2.25/$2.75 per 1M tokens.",
+      sourceNote:
+        "Cerebras Developer tier price converted from $2.25/$2.75 per 1M tokens.",
+    },
+  },
+  {
+    model: "openai/gpt-oss-120b",
+    provider: "openai",
+    productFamily: "language",
+    unit: "token",
+    // $0.10 / 1M input tokens
+    inputUnitPrice: 0.0000001,
+    // $0.50 / 1M output tokens
+    outputUnitPrice: 0.0000005,
+    sourceUrl: OPENROUTER_PRICING_SOURCE_URL,
+    metadata: {
+      sourceNote:
+        "Estimate from OpenRouter public pricing (2026-06-07). Replace once BitRouter catalog returns a priced row for openai/gpt-oss-120b.",
     },
   },
 ];
 
 function bitRouterModelsUrl(): string {
-  const baseUrl = (getProviderKey("BITROUTER_BASE_URL") ?? "https://api.bitrouter.ai/v1").replace(
-    /\/+$/,
-    "",
-  );
+  const baseUrl = (
+    getProviderKey("BITROUTER_BASE_URL") ?? "https://api.bitrouter.ai/v1"
+  ).replace(/\/+$/, "");
   const apiBaseUrl = baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
   return `${apiBaseUrl}/models?output_modalities=all`;
 }
 
-function inferBitRouterProductFamily(model: BitRouterCatalogModel): PricingProductFamily {
+function inferBitRouterProductFamily(
+  model: BitRouterCatalogModel,
+): PricingProductFamily {
   if (model.id.includes("embedding")) {
     return "embedding";
   }
   const outputModalities = model.architecture?.output_modalities;
   if (Array.isArray(outputModalities) && outputModalities.length > 0) {
-    if (outputModalities.includes("image") && !outputModalities.includes("text")) {
+    if (
+      outputModalities.includes("image") &&
+      !outputModalities.includes("text")
+    ) {
       return "image";
     }
     return "language";
@@ -77,7 +111,11 @@ function inferBitRouterProductFamily(model: BitRouterCatalogModel): PricingProdu
   return "language";
 }
 
-function nestedPrice(pricing: Record<string, unknown>, group: string, key: string): unknown {
+function nestedPrice(
+  pricing: Record<string, unknown>,
+  group: string,
+  key: string,
+): unknown {
   const value = pricing[group];
   if (!value || typeof value !== "object") return undefined;
   return (value as Record<string, unknown>)[key];
@@ -145,7 +183,12 @@ export function buildBitRouterPreparedEntries(
   });
 
   const entries: PreparedPricingEntry[] = [];
-  const promptPrice = resolveTokenUnitPrice(pricing, "prompt", "input_tokens", "no_cache");
+  const promptPrice = resolveTokenUnitPrice(
+    pricing,
+    "prompt",
+    "input_tokens",
+    "no_cache",
+  );
   if (promptPrice != null) {
     entries.push(buildEntry(model.id, "input", promptPrice));
     if (baseId !== null) {
@@ -153,7 +196,12 @@ export function buildBitRouterPreparedEntries(
     }
   }
 
-  const completionPrice = resolveTokenUnitPrice(pricing, "completion", "output_tokens", "text");
+  const completionPrice = resolveTokenUnitPrice(
+    pricing,
+    "completion",
+    "output_tokens",
+    "text",
+  );
   if (completionPrice != null) {
     entries.push(buildEntry(model.id, "output", completionPrice));
     if (baseId !== null) {
@@ -233,10 +281,14 @@ async function fetchBitRouterJson<T>(url: string): Promise<T> {
   return (await response.json()) as T;
 }
 
-export async function fetchBitRouterCatalogEntries(): Promise<PreparedPricingEntry[]> {
+export async function fetchBitRouterCatalogEntries(): Promise<
+  PreparedPricingEntry[]
+> {
   return await getCachedExternalEntries("bitrouter", async () => {
     const url = bitRouterModelsUrl();
-    const payload = await fetchBitRouterJson<{ data?: BitRouterCatalogModel[] }>(url);
+    const payload = await fetchBitRouterJson<{
+      data?: BitRouterCatalogModel[];
+    }>(url);
     const models = Array.isArray(payload.data) ? payload.data : [];
     const entries = [
       ...models.flatMap((model) => buildBitRouterPreparedEntries(model)),


### PR DESCRIPTION
## Bug

The cloud's default TEXT_SMALL model is hard-coded to `openai/gpt-oss-120b:nitro` (see `packages/core/src/contracts/service-routing.ts`, `packages/cloud-shared/src/lib/models/catalog.ts`), but BitRouter's catalog API is not returning a priced row for `openai/gpt-oss-120b`.

The LLM gateway resolves pricing via `resolvePreparedPricingEntry` (`packages/cloud-shared/src/lib/services/ai-pricing/lookup.ts`), which throws `Pricing unavailable for language:input openai/gpt-oss-120b` before debiting credits. Every credit-debiting code path 500s on staging:

- chat title generation
- `/v1/chat/completions`
- `/v1/messages`
- `/v1/apps/[id]/chat`

Same image ships to prod, so prod is one cache-miss away from the same failure.

## Fix

Mirror the forced-pricing pattern already used for the Cerebras routes: add an `openai/gpt-oss-120b` entry to `FORCED_BITROUTER_PRICING` with a conservative estimate from OpenRouter public pricing ($0.10 / $0.50 per 1M tokens).

The variant stripper in `candidate-selection.ts` collapses `:nitro` and `:free` onto the base id, so one base entry covers every variant. Real BitRouter rows will win once BitRouter starts publishing pricing — the forced entries inherit the same `EXTERNAL_CACHE_TTL_MS` refresh cycle.

Files touched:
- `packages/cloud-shared/src/lib/services/ai-pricing/providers/bitrouter.ts` — forced-pricing entry
- `packages/cloud-shared/src/lib/services/ai-pricing-variant-indexing.test.ts` — synthetic-row assertion

## Test plan

- [x] `bun test packages/cloud-shared/src/lib/services/ai-pricing-variant-indexing.test.ts` (covers the new synthetic-row assertion)
- [ ] Deploy to staging, trigger chat title generation on a new conversation — request should debit credits instead of 500ing with `Pricing unavailable`
- [ ] Hit `/v1/chat/completions` with `openai/gpt-oss-120b:nitro` (or rely on default routing) and confirm the billing record persists