### PR TITLE
fix(cloud): pass WS auth token via query param for staging handshake

### DIFF
--- a/packages/agent/src/api/server-auth.ts
+++ b/packages/agent/src/api/server-auth.ts
@@ -568,12 +568,13 @@ export function resolveWebSocketUpgradeRejection(
       : null;
   }
 
-  if (
-    process.env.ELIZA_ALLOW_WS_QUERY_TOKEN !== "1" &&
-    hasWsQueryToken(wsUrl)
-  ) {
-    return { status: 401, reason: "Unauthorized" };
-  }
+  // Note: we used to reject upgrades when a query token was present but
+  // ELIZA_ALLOW_WS_QUERY_TOKEN was not "1". That veto was actively harmful —
+  // browsers cannot set Authorization on `new WebSocket(url)`, so SPAs have no
+  // option but to pass the token in the URL. extractWsQueryToken() already
+  // returns null when the flag is off, so handshakeToken simply falls through
+  // to header-or-null and the post-open `{type:"auth"}` fallback covers
+  // self-hosted setups behind header-aware upstream proxies.
 
   const handshakeToken = extractWebSocketHandshakeToken(req, wsUrl);
   if (handshakeToken && !tokenMatches(expected, handshakeToken)) {

--- a/packages/agent/src/api/server-helpers-auth.ts
+++ b/packages/agent/src/api/server-helpers-auth.ts
@@ -1019,12 +1019,13 @@ export function resolveWebSocketUpgradeRejection(
       : null;
   }
 
-  if (
-    process.env.ELIZA_ALLOW_WS_QUERY_TOKEN !== "1" &&
-    hasWsQueryToken(wsUrl)
-  ) {
-    return { status: 401, reason: "Unauthorized" };
-  }
+  // Note: we used to reject upgrades when a query token was present but
+  // ELIZA_ALLOW_WS_QUERY_TOKEN was not "1". That veto was actively harmful —
+  // browsers cannot set Authorization on `new WebSocket(url)`, so SPAs have no
+  // option but to pass the token in the URL. extractWsQueryToken() already
+  // returns null when the flag is off, so handshakeToken simply falls through
+  // to header-or-null and the post-open `{type:"auth"}` fallback covers
+  // self-hosted setups behind header-aware upstream proxies.
 
   const handshakeToken = extractWebSocketHandshakeToken(req, wsUrl);
   if (handshakeToken && !tokenMatches(expected, handshakeToken)) {

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -781,6 +781,13 @@ export class ElizaClient {
 
     let url = `${wsProtocol}//${host}/ws`;
     const params = new URLSearchParams({ clientId: this.clientId });
+    // Browsers cannot set Authorization on `new WebSocket(url)`. Pass the same
+    // token HTTP uses as a query param; cloud servers (ELIZA_ALLOW_WS_QUERY_TOKEN=1)
+    // honor it during the upgrade handshake. Self-hosted servers without that
+    // flag will ignore the query token and fall back to the post-open
+    // `{type:"auth"}` message below.
+    const token = this.apiToken;
+    if (token) params.set("token", token);
     url += `?${params.toString()}`;
 
     this.ws = new WebSocket(url);


### PR DESCRIPTION
## Bug

The SPA in `packages/ui/src/api/client-base.ts` opens `new WebSocket(ws://<host>/ws?clientId=...)` with no auth in the URL. Browsers can't set the `Authorization` header on `new WebSocket(url)`, so the only handshake-time channel is the query string.

Cloud-provisioned containers set `ELIZA_ALLOW_WS_QUERY_TOKEN=1` (see `packages/cloud-shared/src/lib/services/managed-eliza-config.ts`) and require a handshake token because no trusted upstream proxy authenticates the upgrade. Result on staging: every WS upgrade hits `resolveWebSocketUpgradeRejection()` with no handshake token and is rejected 401, blocking the realtime channel for every managed agent.

A second, latent issue made the obvious client-side fix risky: `server-auth.ts` and `server-helpers-auth.ts` (two near-duplicate copies kept in sync) actively rejected upgrades whose URL carried a token when `ELIZA_ALLOW_WS_QUERY_TOKEN` was unset — so adding the token blindly would 401 every self-hosted user who had `ELIZA_API_TOKEN` set but not the WS flag.

## Fix

- `packages/ui/src/api/client-base.ts` (`connectWs`): append `?token=<apiToken>` (URLSearchParams handles encoding) when an `apiToken` is available. The post-open `{type:"auth"}` send stays as the fallback for non-cloud servers where the query token is ignored.
- `packages/agent/src/api/server-auth.ts` and `packages/agent/src/api/server-helpers-auth.ts`: drop the `if (flag !== "1" && hasWsQueryToken) return 401` veto. `extractWsQueryToken()` already returns `null` when the flag is off, so `handshakeToken` cleanly falls back to header-or-null. The veto only existed to surface mis-config and now actively breaks any client that cannot set `Authorization` on a WebSocket — i.e. every browser.

After both changes: cloud staging unblocks (query token consumed during handshake), prod stays green (same code path), self-hosted users see no behavior change (their token is ignored at handshake, post-open auth still works).

## Test Plan

- Staging: open a cloud-provisioned agent in the SPA; confirm WS connects (no 401 in network log on `/ws`), realtime events flow, no reconnect storm.
- Self-hosted with `ELIZA_API_TOKEN` set and `ELIZA_ALLOW_WS_QUERY_TOKEN` unset: confirm WS still connects via the post-open `{type:"auth"}` path (server ignores the URL token, handshake passes with no token because no `isCloudProvisionedContainer`, post-open auth message authorizes the session).
- Self-hosted with no `ELIZA_API_TOKEN`: confirm WS connects as before (no token sent, `expected=null` path).
- `bunx tsgo --noEmit` on `packages/ui` and `packages/agent`: no new errors on the changed files.