### PR TITLE
fix(cloud): accept ?token= on SSE GETs for EventSource auth

### DIFF
--- a/packages/agent/src/api/server-helpers-auth.ts
+++ b/packages/agent/src/api/server-helpers-auth.ts
@@ -232,6 +232,38 @@ export function getConfiguredApiToken(): string | undefined {
   return resolveApiToken(process.env) ?? undefined;
 }
 
+/**
+ * Extract an API token from an SSE handshake's query string.
+ *
+ * EventSource cannot set request headers, so browser SSE clients have no way
+ * to send `Authorization: Bearer …`. Cloud already opts in to `?token=` for
+ * the WebSocket path via `ELIZA_ALLOW_WS_QUERY_TOKEN=1`; this mirrors that
+ * trust model for SSE GETs while keeping the gate tightly scoped:
+ *  - same env flag (cloud-only, never silently enabled elsewhere),
+ *  - method must be GET (read-only),
+ *  - `Accept` must include `text/event-stream` so JSON endpoints with a stray
+ *    `?token=` cannot bypass the header path or leak via proxy access logs.
+ * The returned token is still validated by `tokenMatches` against
+ * `getConfiguredApiToken()` — same crypto.timingSafeEqual path as Bearer.
+ */
+function extractSseQueryToken(req: http.IncomingMessage): string | null {
+  if (process.env.ELIZA_ALLOW_WS_QUERY_TOKEN !== "1") return null;
+  if ((req.method ?? "GET").toUpperCase() !== "GET") return null;
+  const accept = firstHeaderValue(req.headers.accept) ?? "";
+  if (!accept.toLowerCase().includes("text/event-stream")) return null;
+  try {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    const raw =
+      url.searchParams.get("token") ??
+      url.searchParams.get("apiKey") ??
+      url.searchParams.get("api_key");
+    const trimmed = raw?.trim();
+    return trimmed && trimmed.length <= 1024 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
 export function extractAuthToken(req: http.IncomingMessage): string | null {
   const rawAuth =
     typeof req.headers.authorization === "string"
@@ -257,6 +289,9 @@ export function extractAuthToken(req: http.IncomingMessage): string | null {
       req.headers["x-waifu-chat-access-token"]) ||
     (typeof req.headers["x-api-key"] === "string" && req.headers["x-api-key"]);
   if (typeof header === "string" && header.trim()) return header.trim();
+
+  const sseToken = extractSseQueryToken(req);
+  if (sseToken) return sseToken;
 
   return null;
 }

--- a/packages/agent/test/api/server-helpers-auth.test.ts
+++ b/packages/agent/test/api/server-helpers-auth.test.ts
@@ -422,3 +422,107 @@ describe("isServerTokenAuthorized / X-Server-Token gateway auth", () => {
     expect(isAuthorized(req)).toBe(false);
   });
 });
+
+/**
+ * Simulate an SSE handshake from a browser EventSource: a remote (non-loopback)
+ * GET to a streaming endpoint with `Accept: text/event-stream` and the API
+ * token smuggled in the query string because EventSource cannot set headers.
+ */
+class RemoteSseRequest extends http.IncomingMessage {
+  constructor(
+    method: string,
+    url: string,
+    headers: Record<string, string> = {},
+  ) {
+    const socket = new Socket();
+    Object.defineProperty(socket, "remoteAddress", {
+      value: "203.0.113.7",
+      configurable: true,
+    });
+    super(socket);
+    this.method = method;
+    this.url = url;
+    this.headers = {};
+    this.headers.host = "203.0.113.7:19687";
+    for (const [key, value] of Object.entries(headers)) {
+      this.headers[key.toLowerCase()] = value;
+    }
+  }
+}
+
+describe("SSE query-token auth (?token= for EventSource)", () => {
+  const API_TOKEN = "agent_abc123";
+
+  beforeEach(() => {
+    delete process.env.AGENT_SERVER_SHARED_SECRET;
+    delete process.env.ELIZA_CLOUD_PROVISIONED;
+    delete process.env.ELIZA_ALLOW_WS_QUERY_TOKEN;
+    delete process.env.ELIZA_REQUIRE_LOCAL_AUTH;
+    process.env.ELIZA_API_TOKEN = API_TOKEN;
+  });
+
+  afterEach(() => {
+    delete process.env.ELIZA_API_TOKEN;
+    delete process.env.ELIZA_ALLOW_WS_QUERY_TOKEN;
+  });
+
+  it("authorizes a GET SSE handshake carrying the correct ?token= when the flag is on", () => {
+    process.env.ELIZA_ALLOW_WS_QUERY_TOKEN = "1";
+    const req = new RemoteSseRequest(
+      "GET",
+      `/api/conversations/conv-1/messages/stream?token=${API_TOKEN}`,
+      { Accept: "text/event-stream" },
+    );
+    expect(isAuthorized(req)).toBe(true);
+  });
+
+  it("rejects a GET SSE handshake with a wrong ?token=", () => {
+    process.env.ELIZA_ALLOW_WS_QUERY_TOKEN = "1";
+    const req = new RemoteSseRequest(
+      "GET",
+      "/api/conversations/conv-1/messages/stream?token=wrong",
+      { Accept: "text/event-stream" },
+    );
+    expect(isAuthorized(req)).toBe(false);
+  });
+
+  it("rejects ?token= when ELIZA_ALLOW_WS_QUERY_TOKEN is unset (non-cloud deploys stay locked)", () => {
+    // Flag NOT set -> SSE query token must be ignored entirely, even if correct.
+    const req = new RemoteSseRequest(
+      "GET",
+      `/api/conversations/conv-1/messages/stream?token=${API_TOKEN}`,
+      { Accept: "text/event-stream" },
+    );
+    expect(isAuthorized(req)).toBe(false);
+  });
+
+  it("rejects ?token= on non-SSE Accept (scope is text/event-stream only)", () => {
+    process.env.ELIZA_ALLOW_WS_QUERY_TOKEN = "1";
+    const req = new RemoteSseRequest(
+      "GET",
+      `/api/whatever?token=${API_TOKEN}`,
+      { Accept: "application/json" },
+    );
+    expect(isAuthorized(req)).toBe(false);
+  });
+
+  it("rejects ?token= on POST even with SSE Accept (read-only safety)", () => {
+    process.env.ELIZA_ALLOW_WS_QUERY_TOKEN = "1";
+    const req = new RemoteSseRequest(
+      "POST",
+      `/api/conversations/conv-1/messages/stream?token=${API_TOKEN}`,
+      { Accept: "text/event-stream" },
+    );
+    expect(isAuthorized(req)).toBe(false);
+  });
+
+  it("still prefers Bearer over ?token= when both are present", () => {
+    process.env.ELIZA_ALLOW_WS_QUERY_TOKEN = "1";
+    const req = new RemoteSseRequest(
+      "GET",
+      "/api/conversations/conv-1/messages/stream?token=wrong",
+      { Accept: "text/event-stream", Authorization: `Bearer ${API_TOKEN}` },
+    );
+    expect(isAuthorized(req)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Bug

EventSource (the browser SSE client) cannot set request headers, so it has no way to send `Authorization: Bearer <ELIZA_API_TOKEN>`. The global auth gate in `server.ts` only inspects headers via `extractAuthToken(req)`, so every SSE handshake from the cloud web UI 401s before the route handler runs. Local-inference and computer-use stream endpoints inherit the same gate. The token itself is correct (same `agent_<uuid>` value the REST chat path accepts as a Bearer) -- only the transport is wrong.

## Fix

Extend `extractAuthToken()` with a tightly-scoped SSE query-token fallback, mirroring the existing `ELIZA_ALLOW_WS_QUERY_TOKEN=1` path that already ships for WebSockets. The fallback is gated on:

- `ELIZA_ALLOW_WS_QUERY_TOKEN=1` (cloud-only opt-in, no regression elsewhere)
- `method === GET` (read-only)
- `Accept` header contains `text/event-stream` (scope strictly to SSE so a stray `?token=` on a JSON endpoint cannot bypass the header path or leak via proxy access logs)
- Token length <= 1024 (mirrors the header cap)

Validation still goes through `tokenMatches()` -> `crypto.timingSafeEqual`, identical to the Bearer path -- no new comparison semantics.

## Test plan

- [x] `bunx vitest run test/api/server-helpers-auth.test.ts` -> 21/21 pass, including 6 new SSE cases:
  - `?token=<good>` + `Accept: text/event-stream` + flag on -> authorized
  - `?token=<wrong>` + same setup -> 401
  - `?token=<good>` but flag unset -> 401 (non-cloud deploys stay locked)
  - `?token=<good>` but `Accept: application/json` -> 401 (SSE-scope only)
  - POST + SSE Accept + `?token=<good>` -> 401 (read-only safety)
  - Bearer takes precedence over `?token=` when both present
- [x] `bunx tsgo --noEmit` on packages/agent: clean for changed file
- [ ] Manual: with `ELIZA_ALLOW_WS_QUERY_TOKEN=1` + `ELIZA_API_TOKEN` set, hit `/api/conversations/:id/messages/stream?token=<api-token>` via EventSource on staging