### PR TITLE
fix(cloud): raise pair relay timeout to 15s

### DIFF
--- a/packages/app-core/src/api/cloud-pair-route.ts
+++ b/packages/app-core/src/api/cloud-pair-route.ts
@@ -26,7 +26,7 @@ import type http from "node:http";
 import { logger } from "@elizaos/core";
 import { getSensitiveLimiter } from "./auth/sensitive-rate-limit";
 
-const RELAY_TIMEOUT_MS = 5_000;
+const RELAY_TIMEOUT_MS = 15_000;
 const pairingRelayLimiter = getSensitiveLimiter("cloud.pair.relay");
 
 function resolveCloudApiBaseUrl(): string {


### PR DESCRIPTION
## Bug

On staging, the Web UI sign-in link occasionally surfaces "Sign-in link expired" even though the token is fresh. Root cause: Worker latency on `POST /api/auth/pair` sometimes exceeds the 5s `AbortController` deadline in the relay. The relay aborts, but the cloud-api request actually completes and burns the (single-use) pairing token. The user's automatic retry then hits an already-consumed token and gets a 401.

## Fix

Raise `RELAY_TIMEOUT_MS` in `packages/app-core/src/api/cloud-pair-route.ts` from `5_000` to `15_000`. Pair is a low-rate interactive flow, so a higher ceiling is fine in exchange for not torching tokens on transient slow responses.

## Test

- Typecheck clean for the changed file (pre-existing repo errors unrelated).
- Manual: opened Web UI from staging dashboard, observed the relay completing successfully even when cloud-api response is in the 5–15s range.