### PR TITLE
fix(cloud): mount /accept-invitation alias for Steward invite emails

### DIFF
--- a/packages/cloud-frontend/src/App.tsx
+++ b/packages/cloud-frontend/src/App.tsx
@@ -337,6 +337,10 @@ const PRELOAD_ROUTES: ReadonlyArray<RoutePreload> = [
     preload: preloadAll(InviteAcceptLayout.preload, InviteAcceptPage.preload),
   },
   {
+    path: "/accept-invitation",
+    preload: preloadAll(InviteAcceptLayout.preload, InviteAcceptPage.preload),
+  },
+  {
     path: "/payment/app-charge/:appId/:chargeId",
     preload: preloadAll(
       AppChargePaymentLayout.preload,
@@ -628,6 +632,16 @@ function App() {
 
         <Route
           path="invite/accept"
+          element={<SuspenseRoute component={InviteAcceptLayout} />}
+        >
+          <Route
+            index
+            element={<SuspenseRoute component={InviteAcceptPage} />}
+          />
+        </Route>
+
+        <Route
+          path="accept-invitation"
           element={<SuspenseRoute component={InviteAcceptLayout} />}
         >
           <Route


### PR DESCRIPTION
## Bug
Steward invite emails link to `/accept-invitation?token=...`, but the cloud SPA only registered `/invite/accept`. Every invited user landed on a 404.

## Fix
Mount the existing `InviteAcceptLayout` + `InviteAcceptPage` on `/accept-invitation` as a second path, in both the preload table and the Route tree (`packages/cloud-frontend/src/App.tsx`). No new component, no logic change — the `token` query param propagates automatically.

## Test
- `GET /accept-invitation?token=test` returns 200 SPA HTML.
- Invite-accept page renders with the token, matching `/invite/accept` behavior.
- Real Steward invite email link now resolves end-to-end in staging.