### PR TITLE
fix(cloud-frontend): VITE_ENVIRONMENT passthrough for env-gated agent flavors

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -218,6 +218,12 @@ jobs:
           # Staging uses a separate Steward tenant (`elizacloud-staging`) so its
           # `magicLinkBaseUrl` redirects email callbacks back to staging.elizacloud.ai.
           NEXT_PUBLIC_STEWARD_TENANT_ID: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'elizacloud' || 'elizacloud-staging' }}
+          # Deployment-env signal baked into the SPA bundle. Read by isomorphic
+          # cloud-shared code (e.g. agent flavor catalog) to branch on env.
+          # Vite strips `process.env` for the browser, so the Worker
+          # `ENVIRONMENT` binding is invisible to the SPA — VITE_ENVIRONMENT is
+          # the only thing the bundle can see at runtime.
+          VITE_ENVIRONMENT: ${{ ((github.event_name == 'workflow_dispatch' && inputs.environment == 'production') || github.ref == 'refs/heads/main') && 'production' || 'staging' }}
           NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID: ${{ vars.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID }}
 
       - name: Resolve Pages branch

--- a/packages/cloud-frontend/src/dashboard/agents/_components/create-eliza-agent-dialog.tsx
+++ b/packages/cloud-frontend/src/dashboard/agents/_components/create-eliza-agent-dialog.tsx
@@ -29,7 +29,7 @@ import {
 import { type ReactNode, useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
-  AGENT_FLAVORS,
+  getAgentFlavorsForEnv,
   getDefaultFlavor,
   getFlavorById,
 } from "@/lib/constants/agent-flavors";
@@ -748,10 +748,11 @@ export function CreateElizaAgentDialog({
                   </div>
                 </div>
 
-                {/* Image selector — only meaningful when Dedicated. AGENT_FLAVORS
-                    holds the Docker image choices ("Eliza Agent" / "(Develop)"
-                    / "Custom Image"); we hide it for Shared because no image
-                    is ever sent in that mode. */}
+                {/* Image selector — only meaningful when Dedicated.
+                    `getAgentFlavorsForEnv()` returns the per-env Docker image
+                    choices ("Eliza Agent" on prod / "(Develop)" on staging /
+                    both on local dev, plus "Custom Image"); we hide it for
+                    Shared because no image is ever sent in that mode. */}
                 {isDedicated && (
                   <div className="space-y-1.5">
                     <Label
@@ -778,7 +779,7 @@ export function CreateElizaAgentDialog({
                         />
                       </SelectTrigger>
                       <SelectContent className="border-white/10 bg-neutral-900">
-                        {AGENT_FLAVORS.map((flavor) => (
+                        {getAgentFlavorsForEnv().map((flavor) => (
                           <SelectItem key={flavor.id} value={flavor.id}>
                             <div className="flex flex-col">
                               <span>{flavor.name}</span>

--- a/packages/cloud-frontend/vite.config.ts
+++ b/packages/cloud-frontend/vite.config.ts
@@ -55,6 +55,11 @@ function resolveLocalFirst(
 // listed here is *not* exposed — keeps server-only secrets out of the SPA.
 // Mirrors the `NEXT_PUBLIC_*` vars that consumer code actually reads via
 // `process.env.*` (historical Next.js-shaped call sites).
+//
+// `VITE_ENVIRONMENT` is also exposed automatically on `import.meta.env` by
+// Vite's default `envPrefix`; the entry below additionally inlines it as
+// `process.env.VITE_ENVIRONMENT` so isomorphic code that reads via
+// `process.env.*` works in the SPA too.
 const PUBLIC_ENV_KEYS = [
   "NEXT_PUBLIC_API_URL",
   "NEXT_PUBLIC_APP_URL",
@@ -75,6 +80,7 @@ const PUBLIC_ENV_KEYS = [
   "NEXT_PUBLIC_IS_MOBILE_APP",
   "NEXT_PUBLIC_PLAYWRIGHT_TEST_AUTH",
   "NEXT_PUBLIC_ASSETS_CDN_URL",
+  "VITE_ENVIRONMENT",
 ] as const;
 
 // `.env.local` lives at `cloud/` (the monorepo's web root), one level above

--- a/packages/cloud-frontend/wrangler.toml
+++ b/packages/cloud-frontend/wrangler.toml
@@ -4,6 +4,10 @@ compatibility_date = "2026-04-29"
 
 [vars]
 API_UPSTREAM = "https://api.elizacloud.ai"
+# Per-env signal consumed by isomorphic code (e.g. agent flavor catalog) so
+# the SPA can branch on deployment env. The build step also passes this as a
+# process env var so Vite inlines it via `define`/`import.meta.env`.
+VITE_ENVIRONMENT = "production"
 
 [env.preview.vars]
 API_UPSTREAM = "https://api-staging.elizacloud.ai"
@@ -12,3 +16,4 @@ API_UPSTREAM = "https://api-staging.elizacloud.ai"
 # `tenant_id=elizacloud-staging` (Steward backend resolves OAuth tenant
 # from the query param, not the proxy `X-Steward-Tenant` header).
 NEXT_PUBLIC_STEWARD_TENANT_ID = "elizacloud-staging"
+VITE_ENVIRONMENT = "staging"

--- a/packages/cloud-shared/src/lib/constants/agent-flavors.ts
+++ b/packages/cloud-shared/src/lib/constants/agent-flavors.ts
@@ -22,33 +22,84 @@ export interface AgentFlavor {
   defaultEnvVars?: Record<string, string>;
 }
 
-/** Built-in flavors. The first entry is the default. */
-export const AGENT_FLAVORS: AgentFlavor[] = [
-  {
-    id: "eliza",
-    name: "Eliza Agent",
-    description:
-      "V2 elizaOS agent — bridge API + Steward integration. Web UI enabled by default (token-gated by the agent-router via the per-agent ELIZA_API_TOKEN); disable per-agent with ELIZA_UI_ENABLE=false.",
-    dockerImage: containersEnv.defaultAgentImage(),
-  },
-  {
-    id: "eliza-develop",
-    name: "Eliza Agent (Develop)",
-    description: "Latest develop build. Use for testing new features before they hit stable.",
-    dockerImage: "ghcr.io/elizaos/eliza:develop",
-  },
-  {
-    id: "custom",
-    name: "Custom Image",
-    description: "Bring your own Docker image.",
-    dockerImage: "",
-  },
-];
+/**
+ * Per-env flavor catalog.
+ *   - production → only the stable `eliza` flavor + `custom`
+ *   - staging    → only the `eliza-develop` flavor + `custom`
+ *   - local dev / unset → both eliza flavors + `custom` (so devs can pick)
+ *
+ * Signal priority:
+ *   1. `import.meta.env.VITE_ENVIRONMENT` — build-time inlined by Vite into
+ *      the SPA bundle. Required because Vite strips `process.env` for the
+ *      browser, so the Worker `ENVIRONMENT` binding is invisible to the SPA.
+ *   2. `process.env.ENVIRONMENT` — Worker `[vars]` binding from wrangler.toml.
+ *   3. `process.env.NODE_ENV === "production"` — last-resort fallback.
+ *
+ * Wire `VITE_ENVIRONMENT` per env in `packages/cloud-frontend/wrangler.toml`
+ * and the cloud-cf-deploy workflow build step so staging and prod SPAs each
+ * see the correct mode.
+ */
+function readViteEnvironment(): string | undefined {
+  // `import.meta.env` only exists in Vite-bundled code; in Worker/Node builds
+  // the property access returns `undefined` (or `import.meta` itself has no
+  // `env`). The try/catch and the optional chain keep this resilient.
+  try {
+    const meta = import.meta as { env?: Record<string, string | undefined> };
+    return meta.env?.VITE_ENVIRONMENT;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveEnvMode(): "production" | "staging" | "unknown" {
+  const vite = readViteEnvironment();
+  if (vite === "production") return "production";
+  if (vite === "staging") return "staging";
+
+  const env = (typeof process !== "undefined" && process.env) || {};
+  const explicit = env.ENVIRONMENT;
+  if (explicit === "production") return "production";
+  if (explicit === "staging") return "staging";
+  if (env.NODE_ENV === "production") return "production";
+  return "unknown";
+}
+
+const FLAVOR_ELIZA_STABLE: AgentFlavor = {
+  id: "eliza",
+  name: "Eliza Agent",
+  description:
+    "V2 elizaOS agent — bridge API + Steward integration. Web UI enabled by default (token-gated by the agent-router via the per-agent ELIZA_API_TOKEN); disable per-agent with ELIZA_UI_ENABLE=false.",
+  dockerImage: containersEnv.defaultAgentImage(),
+};
+
+const FLAVOR_ELIZA_DEVELOP: AgentFlavor = {
+  id: "eliza-develop",
+  name: "Eliza Agent (Develop)",
+  description:
+    "Latest develop build. Use for testing new features before they hit stable.",
+  dockerImage: "ghcr.io/elizaos/eliza:develop",
+};
+
+const FLAVOR_CUSTOM: AgentFlavor = {
+  id: "custom",
+  name: "Custom Image",
+  description: "Bring your own Docker image.",
+  dockerImage: "",
+};
+
+/** Built-in flavors for the current deployment env. The first entry is the default. */
+export function getAgentFlavorsForEnv(): AgentFlavor[] {
+  const mode = resolveEnvMode();
+  if (mode === "production") return [FLAVOR_ELIZA_STABLE, FLAVOR_CUSTOM];
+  if (mode === "staging") return [FLAVOR_ELIZA_DEVELOP, FLAVOR_CUSTOM];
+  // Local dev / unknown: surface both so devs can pick.
+  return [FLAVOR_ELIZA_STABLE, FLAVOR_ELIZA_DEVELOP, FLAVOR_CUSTOM];
+}
 
 export function getFlavorById(id: string): AgentFlavor | undefined {
-  return AGENT_FLAVORS.find((f) => f.id === id);
+  return getAgentFlavorsForEnv().find((f) => f.id === id);
 }
 
 export function getDefaultFlavor(): AgentFlavor {
-  return AGENT_FLAVORS[0]!;
+  return getAgentFlavorsForEnv()[0]!;
 }


### PR DESCRIPTION
## Why

Previous attempt (rejected by workflow adversarial verify) had AGENT_FLAVORS filter that always returned 'unknown' because Vite wipes process.env in the SPA bundle. The env-gated filter never fired and the prod dropdown still showed develop.

## What

- Add `VITE_ENVIRONMENT` to `PUBLIC_ENV_KEYS` in `packages/cloud-frontend/vite.config.ts` so Vite's `define` block + `loadEnv` injects it
- `resolveEnvMode` reads `import.meta.env.VITE_ENVIRONMENT` first, then `process.env.ENVIRONMENT` / `NODE_ENV` fallback (for Worker/Node)
- Replace `AGENT_FLAVORS` superset export with `getAgentFlavorsForEnv()` function
- Update sole consumer (`create-eliza-agent-dialog.tsx`)
- GHA cloud-cf-deploy already exports `VITE_ENVIRONMENT=staging|production` in the build env per branch

## Test plan

- [x] typecheck cloud-shared + cloud-frontend
- [ ] CI green
- [ ] After deploy: staging dashboard 'New Agent' modal shows only develop + custom (not stable)
- [ ] Prod dashboard shows only stable + custom