### PR TITLE
fix(apps): per-app URL uses the apps domain, never the agent/milady domain

### DIFF
--- a/packages/cloud-shared/src/lib/config/containers-env.ts
+++ b/packages/cloud-shared/src/lib/config/containers-env.ts
@@ -229,6 +229,18 @@ export const containersEnv = {
   },
 
   /**
+   * Apps-only base domain for per-app public hostnames. Reads
+   * `CONTAINERS_PUBLIC_BASE_DOMAIN` (set to e.g. `apps.elizacloud.ai` on the apps
+   * data plane by the apps-data-plane terraform) with NO fallback to the agent
+   * sandbox domain (`ELIZA_CLOUD_AGENT_BASE_DOMAIN`) — unlike
+   * {@link publicBaseDomain}. So an app never silently inherits the agent/milady
+   * domain; an unset value surfaces as "no URL" instead of a wrong-domain one.
+   */
+  appsPublicBaseDomain(): string | undefined {
+    return getCloudAwareEnv().CONTAINERS_PUBLIC_BASE_DOMAIN || undefined;
+  },
+
+  /**
    * Default Hetzner Cloud location for provisioning nodes and volumes
    * (e.g. "fsn1", "nbg1", "hel1"). Hetzner volumes are location-bound, so
    * the volume and the server it attaches to must share a location.

--- a/packages/cloud-shared/src/lib/services/__tests__/app-url.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-url.test.ts
@@ -32,4 +32,21 @@ describe("deriveAppPublicUrl", () => {
     delete process.env[FALLBACK];
     expect(deriveAppPublicUrl(CID)).toBeNull();
   });
+
+  test("does NOT inherit the agent sandbox domain — null when only the agent domain is set", () => {
+    // Regression: apps must never silently land on the agent/milady domain just
+    // because they ran on a host that has ELIZA_CLOUD_AGENT_BASE_DOMAIN set.
+    delete process.env[BASE];
+    process.env[FALLBACK] = "milady.ai";
+    expect(deriveAppPublicUrl(CID)).toBeNull();
+  });
+
+  test("uses the apps base domain (apps.elizacloud.ai) when set, ignoring the agent domain", () => {
+    process.env[BASE] = "apps.elizacloud.ai";
+    process.env[FALLBACK] = "milady.ai";
+    expect(deriveAppPublicUrl(CID)).toEqual({
+      hostname: "aabbccdd.apps.elizacloud.ai",
+      url: "https://aabbccdd.apps.elizacloud.ai",
+    });
+  });
 });

--- a/packages/cloud-shared/src/lib/services/app-url.ts
+++ b/packages/cloud-shared/src/lib/services/app-url.ts
@@ -1,18 +1,21 @@
 /**
  * Per-app public URL derivation (Apps / Product 2).
  *
- * Apps are provisioned via the SSH `AppContainerProvider` path, which branches
- * around the Hetzner client — so they never pass through the client's
- * hostname/URL stamping. This reuses the SAME shared `derivePublicHostname`
- * (the ingress map's source of truth) so an app container gets a public URL
- * identical in shape to an agent container's, without rebuilding ingress and
- * without editing the hot `hetzner-client/client.ts`.
+ * An app container's public URL is `<shortid>.<apps-base-domain>` — the same
+ * shape as an agent container's, but resolved from an APPS-specific base domain
+ * (`containersEnv.appsPublicBaseDomain()` = `CONTAINERS_PUBLIC_BASE_DOMAIN`, set
+ * to e.g. `apps.elizacloud.ai` on the apps data plane by terraform). It
+ * deliberately does NOT use the shared `publicBaseDomain()`, which falls back to
+ * the agent sandbox domain (`ELIZA_CLOUD_AGENT_BASE_DOMAIN`) — apps must live on
+ * their own domain and never silently inherit the agent/milady domain.
  *
- * Returns null when `CONTAINERS_PUBLIC_BASE_DOMAIN` isn't configured (e.g. local
- * dev), so callers simply skip URL stamping rather than writing a bogus value.
+ * Returns null when the apps base domain isn't configured (e.g. local dev, or a
+ * host that only has the agent domain), so callers skip URL stamping rather than
+ * writing a wrong-domain value. The 8-hex shortid matches the agent ingress
+ * derivation, so the `*.apps.elizacloud.ai` wildcard routes identically.
  */
 
-import { derivePublicHostname } from "./containers/hetzner-client/paths";
+import { containersEnv } from "../config/containers-env";
 
 export interface AppPublicEndpoint {
   /** `<shortid>.<base-domain>` — written to containers.public_hostname. */
@@ -23,7 +26,11 @@ export interface AppPublicEndpoint {
 
 /** Derive the app's public endpoint from its container id, or null if unconfigured. */
 export function deriveAppPublicUrl(containerId: string): AppPublicEndpoint | null {
-  const hostname = derivePublicHostname(containerId);
-  if (!hostname) return null;
+  const baseDomain = containersEnv.appsPublicBaseDomain();
+  if (!baseDomain) return null;
+  // 8 hex chars from the (UUID v4) container id — matches the agent ingress
+  // shortid scheme so the wildcard DNS routes the same way.
+  const shortId = containerId.replace(/-/g, "").slice(0, 8);
+  const hostname = `${shortId}.${baseDomain}`;
   return { hostname, url: `https://${hostname}` };
 }


### PR DESCRIPTION
## Why
Found while verifying a deploy on staging: the per-app URL came out as
`<id>.milady.ai` — the **agent sandbox** domain — instead of an apps domain.

`deriveAppPublicUrl` reused the shared `containersEnv.publicBaseDomain()`, which is
`pick(CONTAINERS_PUBLIC_BASE_DOMAIN, ELIZA_CLOUD_AGENT_BASE_DOMAIN)`. So on any host
that has the agent domain set but not the apps domain, an app's public URL silently
inherited the **agent** domain. The file even documented "returns null when
`CONTAINERS_PUBLIC_BASE_DOMAIN` isn't configured" — which that agent fallback broke.

## Fix
- New `containersEnv.appsPublicBaseDomain()` — reads `CONTAINERS_PUBLIC_BASE_DOMAIN`
  (set to `apps.elizacloud.ai` on the apps data plane by the apps-data-plane terraform)
  with **no** fallback to `ELIZA_CLOUD_AGENT_BASE_DOMAIN`.
- `deriveAppPublicUrl` uses it. An app is now either on its **own** domain
  (`<shortid>.apps.elizacloud.ai`) or has **no URL** — it never lands on the
  agent/milady domain. The 8-hex shortid is unchanged, so the `*.apps.elizacloud.ai`
  wildcard routes identically.

The shared `publicBaseDomain()` (agent path) is untouched.

## Tests — 4/4
Incl. a regression: only `ELIZA_CLOUD_AGENT_BASE_DOMAIN` set → `null` (not `milady.ai`),
and `apps.elizacloud.ai` wins while the agent domain is ignored. biome + typecheck clean.