### PR TITLE
fix(plugin-lifeops): drop calls to removed registerLifeOpsApp + LifeOps view exports

### DIFF
--- a/packages/app/src/main.tsx
+++ b/packages/app/src/main.tsx
@@ -238,15 +238,12 @@ const InferenceCloudAlertButton = lazyNamedComponent<{
 const PhoneCompanionApp = lazyNamedComponent<Record<string, never>>(
   async () => (await importAppPhone()).PhoneCompanionApp,
 );
-const LifeOpsPageView = lazyNamedComponent<Record<string, never>>(
-  async () => (await importAppLifeOps()).LifeOpsPageView,
-);
-const BrowserBridgeSetupPanel = lazyNamedComponent<Record<string, never>>(
-  async () => (await importAppLifeOps()).LifeOpsBrowserSetupPanel,
-);
-const LifeOpsActivitySignalsEffect = lazyNamedComponent<Record<string, never>>(
-  async () => (await importAppLifeOps()).LifeOpsActivitySignalsEffect,
-);
+// LifeOpsPageView / LifeOpsBrowserSetupPanel / LifeOpsActivitySignalsEffect
+// were removed when @elizaos/plugin-lifeops was decomposed into plugin-todos,
+// plugin-inbox, plugin-goals, plugin-health, plugin-calendar, plugin-documents,
+// plugin-blocker, plugin-finances, plugin-relationships and renamed to
+// @elizaos/plugin-personal-assistant. The boot config slots are optional and
+// UI consumers render a fallback when absent.
 const AppBlockerSettingsCard = lazyNamedComponent<AppBlockerSettingsCardProps>(
   async () => (await importAppLifeOps()).AppBlockerSettingsCard,
 );
@@ -277,7 +274,6 @@ const FineTuningView = lazyNamedComponent<FineTuningViewProps>(
 );
 
 let loadedCompanionSceneStatusHook: (() => CompanionSceneStatus) | null = null;
-let dispatchQueuedLifeOpsGithubCallback: ((url: string) => void) | null = null;
 
 function useLoadedCompanionSceneStatus(): CompanionSceneStatus {
   return (
@@ -499,8 +495,11 @@ function buildAppBootConfig({
     stewardTransactionHistory: TransactionHistory,
     characterCatalog: APP_CHARACTER_CATALOG,
     envAliases: APP_ENV_ALIASES,
-    lifeOpsPageView: LifeOpsPageView,
-    lifeOpsBrowserSetupPanel: BrowserBridgeSetupPanel,
+    // lifeOpsPageView / lifeOpsBrowserSetupPanel intentionally omitted —
+    // both slots are optional in AppBootConfig and UI consumers render a
+    // fallback ("view unavailable") when absent. The legacy /lifeops
+    // dashboard was killed during the plugin-personal-assistant
+    // decomposition (commit eef57bf53e).
     appBlockerSettingsCard: AppBlockerSettingsCard,
     websiteBlockerSettingsCard: WebsiteBlockerSettingsCard,
     clientMiddleware: {
@@ -516,8 +515,13 @@ function initializeAppModules(): Promise<void> {
   appModulesInitialized ??= (async () => {
     await importAppCore();
 
-    const [companionModule, lifeOpsModule] = await Promise.all([
+    const [companionModule] = await Promise.all([
       importAppCompanion(),
+      // Imported for the side-effectful API client (BRIEF / PRIORITIZE /
+      // scheduled-task CRUD / approvals) and to surface AppBlocker /
+      // WebsiteBlocker settings cards. The plugin no longer exports a
+      // top-level registerLifeOpsApp() since the /lifeops view was killed
+      // during the plugin-personal-assistant decomposition.
       importAppLifeOps(),
       // Imported for its self-registration side effect (Vincent overlay app).
       importAppVincent(),
@@ -531,10 +535,7 @@ function initializeAppModules(): Promise<void> {
     ]);
 
     companionModule.registerCompanionApp();
-    lifeOpsModule.registerLifeOpsApp();
     loadedCompanionSceneStatusHook = companionModule.useCompanionSceneStatus;
-    dispatchQueuedLifeOpsGithubCallback =
-      lifeOpsModule.dispatchQueuedLifeOpsGithubCallbackFromUrl;
 
     setBootConfig(
       buildAppBootConfig({
@@ -1438,11 +1439,9 @@ function handleDeepLink(url: string): void {
       break;
     case "lifeops":
       window.location.hash = "#lifeops";
-      dispatchQueuedLifeOpsGithubCallback?.(url);
       break;
     case "settings":
       window.location.hash = "#settings";
-      dispatchQueuedLifeOpsGithubCallback?.(url);
       break;
     case "connect": {
       const gatewayUrl = parsed.searchParams.get("url");
@@ -1698,7 +1697,6 @@ function mountReactApp(): void {
               <>
                 <DesktopSurfaceNavigationRuntime />
                 <DesktopTrayRuntime />
-                <LifeOpsActivitySignalsEffect />
                 <App />
               </>
             )}

--- a/packages/app/src/plugin-loader.ts
+++ b/packages/app/src/plugin-loader.ts
@@ -31,7 +31,8 @@ import { type ComponentType, lazy } from "react";
 export const APP_PLUGIN_SPECS = {
   "@elizaos/app-core": () => import("@elizaos/app-core"),
   "@elizaos/app-companion": () => import("@elizaos/app-companion"),
-  "@elizaos/app-lifeops": () => import("@elizaos/app-lifeops"),
+  "@elizaos/plugin-personal-assistant": () =>
+    import("@elizaos/plugin-personal-assistant"),
   "@elizaos/app-phone": () => import("@elizaos/app-phone"),
   "@elizaos/app-steward": () => import("@elizaos/app-steward"),
   "@elizaos/app-task-coordinator": () =>
@@ -104,24 +105,22 @@ const InferenceCloudAlertButton = lazyNamedComponent<{
 const PhoneCompanionApp = lazyNamedComponent<Record<string, never>>(
   async () => (await loadPlugin("@elizaos/app-phone")).PhoneCompanionApp,
 );
-const LifeOpsPageView = lazyNamedComponent<Record<string, never>>(
-  async () => (await loadPlugin("@elizaos/app-lifeops")).LifeOpsPageView,
-);
-const BrowserBridgeSetupPanel = lazyNamedComponent<Record<string, never>>(
-  async () =>
-    (await loadPlugin("@elizaos/app-lifeops")).LifeOpsBrowserSetupPanel,
-);
-const LifeOpsActivitySignalsEffect = lazyNamedComponent<Record<string, never>>(
-  async () =>
-    (await loadPlugin("@elizaos/app-lifeops")).LifeOpsActivitySignalsEffect,
-);
+// LifeOpsPageView / LifeOpsBrowserSetupPanel / LifeOpsActivitySignalsEffect
+// were removed when @elizaos/plugin-lifeops was decomposed into plugin-todos,
+// plugin-inbox, plugin-goals, plugin-health, plugin-calendar, plugin-documents,
+// plugin-blocker, plugin-finances, plugin-relationships and renamed to
+// @elizaos/plugin-personal-assistant. The boot config slots are optional and
+// UI consumers render a fallback when absent.
 const AppBlockerSettingsCard = lazyNamedComponent<AppBlockerSettingsCardProps>(
-  async () => (await loadPlugin("@elizaos/app-lifeops")).AppBlockerSettingsCard,
+  async () =>
+    (await loadPlugin("@elizaos/plugin-personal-assistant"))
+      .AppBlockerSettingsCard,
 );
 const WebsiteBlockerSettingsCard =
   lazyNamedComponent<WebsiteBlockerSettingsCardProps>(
     async () =>
-      (await loadPlugin("@elizaos/app-lifeops")).WebsiteBlockerSettingsCard,
+      (await loadPlugin("@elizaos/plugin-personal-assistant"))
+        .WebsiteBlockerSettingsCard,
   );
 const StewardLogo = lazyNamedComponent<StewardLogoProps>(
   async () => (await loadPlugin("@elizaos/app-steward")).StewardLogo,
@@ -149,7 +148,7 @@ const FineTuningView = lazyNamedComponent<FineTuningViewProps>(
   async () => (await loadPlugin("@elizaos/app-training")).FineTuningView,
 );
 
-export { LifeOpsActivitySignalsEffect, PhoneCompanionApp };
+export { PhoneCompanionApp };
 
 // ---------------------------------------------------------------------------
 // Hook proxies. Companion/Vincent expose hook factories that are only known
@@ -158,7 +157,6 @@ export { LifeOpsActivitySignalsEffect, PhoneCompanionApp };
 // ---------------------------------------------------------------------------
 
 let loadedCompanionSceneStatusHook: (() => CompanionSceneStatus) | null = null;
-let dispatchQueuedLifeOpsGithubCallback: ((url: string) => void) | null = null;
 
 export function useLoadedCompanionSceneStatus(): CompanionSceneStatus {
   return (
@@ -167,10 +165,6 @@ export function useLoadedCompanionSceneStatus(): CompanionSceneStatus {
       teleportKey: "",
     }
   );
-}
-
-export function dispatchLifeOpsGithubCallbackIfReady(url: string): void {
-  dispatchQueuedLifeOpsGithubCallback?.(url);
 }
 
 // ---------------------------------------------------------------------------
@@ -200,9 +194,14 @@ export function initializeAppPlugins(
     // app-core must resolve first; it owns the shared boot config singleton.
     await loadPlugin("@elizaos/app-core");
 
-    const [companionModule, lifeOpsModule] = await Promise.all([
+    const [companionModule] = await Promise.all([
       loadPlugin("@elizaos/app-companion"),
-      loadPlugin("@elizaos/app-lifeops"),
+      // Loaded for the side-effectful API client (BRIEF / PRIORITIZE /
+      // scheduled-task CRUD / approvals) and to surface AppBlocker /
+      // WebsiteBlocker settings cards. No top-level register call since
+      // the /lifeops view was killed during the plugin-personal-assistant
+      // decomposition.
+      loadPlugin("@elizaos/plugin-personal-assistant"),
       // Loaded for its self-registration side effect (Vincent overlay app).
       loadPlugin("@elizaos/app-vincent"),
       loadPlugin("@elizaos/app-task-coordinator"),
@@ -229,8 +228,6 @@ export function initializeAppPlugins(
 
     companionModule.registerCompanionApp();
     loadedCompanionSceneStatusHook = companionModule.useCompanionSceneStatus;
-    dispatchQueuedLifeOpsGithubCallback =
-      lifeOpsModule.dispatchQueuedLifeOpsGithubCallbackFromUrl;
 
     const bootConfig: AppBootConfig = {
       branding: args.branding,
@@ -264,8 +261,9 @@ export function initializeAppPlugins(
       stewardTransactionHistory: TransactionHistory,
       characterCatalog: args.characterCatalog,
       envAliases: args.envAliases,
-      lifeOpsPageView: LifeOpsPageView,
-      lifeOpsBrowserSetupPanel: BrowserBridgeSetupPanel,
+      // lifeOpsPageView / lifeOpsBrowserSetupPanel intentionally omitted —
+      // both are optional in AppBootConfig and UI consumers render a
+      // fallback when absent.
       appBlockerSettingsCard: AppBlockerSettingsCard,
       websiteBlockerSettingsCard: WebsiteBlockerSettingsCard,
       clientMiddleware: args.clientMiddleware,

--- a/packages/app/src/types/app-plugin-module-exports.d.ts
+++ b/packages/app/src/types/app-plugin-module-exports.d.ts
@@ -23,22 +23,9 @@ declare module "@elizaos/plugin-personal-assistant" {
   export const AppBlockerSettingsCard: import("react").ComponentType<
     import("@elizaos/ui").AppBlockerSettingsCardProps
   >;
-  export const LifeOpsActivitySignalsEffect: import("react").ComponentType<
-    Record<string, never>
-  >;
-  export const LifeOpsBrowserSetupPanel: import("react").ComponentType<
-    Record<string, never>
-  >;
-  export const LifeOpsPageView: import("react").ComponentType<
-    Record<string, never>
-  >;
   export const WebsiteBlockerSettingsCard: import("react").ComponentType<
     import("@elizaos/ui").WebsiteBlockerSettingsCardProps
   >;
-  export function dispatchQueuedLifeOpsGithubCallbackFromUrl(
-    url: string,
-  ): void | Promise<void>;
-  export function registerLifeOpsApp(): void;
   export const personalAssistantPlugin: unknown;
   export default personalAssistantPlugin;
 }

--- a/packages/app/src/types/app-plugin-modules.d.ts
+++ b/packages/app/src/types/app-plugin-modules.d.ts
@@ -104,18 +104,9 @@ declare module "@elizaos/plugin-companion" {
   export * from "@elizaos/app-companion";
 }
 
-declare module "@elizaos/app-lifeops" {
-  export const LifeOpsPageView: EmptyComponent;
-  export const LifeOpsBrowserSetupPanel: EmptyComponent;
-  export const LifeOpsActivitySignalsEffect: EmptyComponent;
+declare module "@elizaos/plugin-personal-assistant" {
   export const AppBlockerSettingsCard: ComponentType<AppBlockerSettingsCardProps>;
   export const WebsiteBlockerSettingsCard: ComponentType<WebsiteBlockerSettingsCardProps>;
-  export function dispatchQueuedLifeOpsGithubCallbackFromUrl(url: string): void;
-  export function registerLifeOpsApp(): void;
-}
-
-declare module "@elizaos/plugin-personal-assistant" {
-  export * from "@elizaos/app-lifeops";
 }
 
 declare module "@elizaos/app-phone" {


### PR DESCRIPTION
## Bug
SPA boot crashed with `t.registerLifeOpsApp is not a function` — white-screen on every load.

The lifeops decomposition (`eef57bf53e`) renamed `@elizaos/plugin-lifeops` to `@elizaos/plugin-personal-assistant` and killed the `/lifeops` dashboard view, dropping `registerLifeOpsApp`, `LifeOpsPageView`, `LifeOpsBrowserSetupPanel`, `LifeOpsActivitySignalsEffect`, and `dispatchQueuedLifeOpsGithubCallbackFromUrl` from the renderer surface. `main.tsx` still called all of them. Two stale ambient module declarations (`app-plugin-modules.d.ts`, `app-plugin-module-exports.d.ts`) still advertised the missing exports, so `tsc` never caught it and the bundler emitted code that resolved to `undefined` at runtime.

## Fix
- `packages/app/src/main.tsx`
  - Drop `LifeOpsPageView` / `BrowserBridgeSetupPanel` / `LifeOpsActivitySignalsEffect` lazy handles.
  - Drop the `dispatchQueuedLifeOpsGithubCallback` local + the two URL-handler sites that called it (the queue lived inside the dead view).
  - Drop `lifeOpsModule.registerLifeOpsApp()` — function no longer exists; plugin-personal-assistant's renderer entry only re-exports the two blocker settings cards now. Keep the side-effectful import (PA api client + blocker cards still come from there).
  - Drop the `lifeOpsPageView` / `lifeOpsBrowserSetupPanel` keys from the boot config; both slots are optional in `AppBootConfig` and UI consumers already fall back to `ViewUnavailableFallback` when absent.
  - Drop the `<LifeOpsActivitySignalsEffect />` JSX render.
- `packages/app/src/plugin-loader.ts`
  - Mirror the same cleanup so the (currently unused) extracted loader stays in sync. Rename the spec key from `@elizaos/app-lifeops` (never existed as a package) to `@elizaos/plugin-personal-assistant`.
- `packages/app/src/types/app-plugin-modules.d.ts` + `packages/app/src/types/app-plugin-module-exports.d.ts`
  - Strip the stale `registerLifeOpsApp` / `LifeOpsPageView` / `LifeOpsBrowserSetupPanel` / `LifeOpsActivitySignalsEffect` / `dispatchQueuedLifeOpsGithubCallbackFromUrl` shims for `@elizaos/plugin-personal-assistant`. Keep only the exports the plugin's browser facade actually emits.

## Test plan
- [x] `packages/app` `tsc --noEmit -p tsconfig.typecheck.json`: 22 errors, all pre-existing (unrelated `@elizaos/app-core` / capacitor module resolution + `bridgeStatus` implicit-any). Zero new errors in changed files.
- [ ] SPA boots without white-screen, `/lifeops` route falls back to `ViewUnavailableFallback`.
- [ ] Personal-assistant blocker settings cards still render.