### PR TITLE
fix(cloud-shared): correct src import path in tenant-db isolation e2e

### DIFF
--- a/packages/cloud-shared/scripts/verify-tenant-db-isolation.ts
+++ b/packages/cloud-shared/scripts/verify-tenant-db-isolation.ts
@@ -1,10 +1,10 @@
 import { randomBytes } from "node:crypto";
 import { Client } from "pg";
-import { DirectPgExecutor } from "./src/lib/services/tenant-db/direct-pg-executor";
+import { DirectPgExecutor } from "../src/lib/services/tenant-db/direct-pg-executor";
 import {
   deriveTenantIdent,
   SqlTenantDbProvisioner,
-} from "./src/lib/services/tenant-db/tenant-db-provisioner";
+} from "../src/lib/services/tenant-db/tenant-db-provisioner";
 
 const ADMIN = "postgresql://postgres:adminpw@localhost:55432/postgres";
 const APP_A = "11111111-aaaa-4aaa-8aaa-aaaaaaaaaaaa";


### PR DESCRIPTION
## What
`scripts/verify-tenant-db-isolation.ts` imported `./src/lib/services/tenant-db/...`. Since the script lives in `scripts/`, `./src/...` resolves to the nonexistent `scripts/src/...`, so the script crashed with `Cannot find module ...direct-pg-executor` before doing anything. Its sibling e2e scripts (`_e2e-build.ts`, `_e2e-provision.ts`) correctly use `../src/...`. Fixed both imports.

## Verify
Ran the fixed script against a real local Postgres: **5 passed / 0 failed** — tenant A/B reach their own DBs, cross-tenant access rejected (REVOKE CONNECT), tenant can write its own tables, and cannot create databases (least-privilege).
