### PR TITLE
fix(infra): make apps data-plane terraform apply cleanly on fsn1

### DIFF
--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
@@ -39,13 +39,13 @@ resource "random_password" "tenant_db_admin" {
   special = false # keep DSN URL-safe (no escaping in admin_dsn_encrypted)
 }
 
-resource "hcloud_ssh_key" "operators" {
-  for_each = { for key in var.ssh_public_keys : substr(sha256(key), 0, 12) => key }
-
-  name       = "eliza-apps-op-${var.environment}-${each.key}"
-  public_key = each.value
-  labels     = local.common_labels
-}
+# Operator/daemon SSH access is provisioned by cloud-init: each node's `deploy`
+# user gets `var.ssh_public_keys` in its authorized_keys (see cloud-init/*.tftpl),
+# and the provisioning-worker SSHes in as `deploy`. We intentionally do NOT
+# register an `hcloud_ssh_key` here: the operator key is already present in the
+# shared Hetzner project, so creating it returns 409 uniqueness_error — and an
+# hcloud-managed key only seeds `root`, which nothing connects as. var.ssh_public_keys
+# still flows to cloud-init below.
 
 # ── Private network: apps + tenant DB only; isolated from the agent plane ─────
 resource "hcloud_network" "apps" {
@@ -119,7 +119,6 @@ resource "hcloud_server" "tenant_db" {
   location     = var.hcloud_location
   server_type  = var.tenant_db_server_type
   image        = var.hcloud_image
-  ssh_keys     = [for k in hcloud_ssh_key.operators : k.id]
   firewall_ids = [hcloud_firewall.tenant_db.id]
   labels       = merge(local.common_labels, { "role" = "tenant-db" })
 
@@ -156,7 +155,6 @@ resource "hcloud_server" "app_node" {
   location     = var.hcloud_location
   server_type  = var.app_node_server_type
   image        = var.hcloud_image
-  ssh_keys     = [for k in hcloud_ssh_key.operators : k.id]
   firewall_ids = [hcloud_firewall.app_node.id]
   labels = merge(local.common_labels, {
     "role"           = "app-node"

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
@@ -21,9 +21,9 @@ variable "hcloud_image" {
 
 # ── App worker node(s): Docker hosts for UNTRUSTED user images ───────────────
 variable "app_node_server_type" {
-  description = "Hetzner server type for an app worker node (runs untrusted user containers). cpx41 = 8 vCPU / 16 GB; size to expected concurrent app density."
+  description = "Hetzner server type for an app worker node (runs untrusted user containers). ccx23 = 4 dedicated vCPU / 16 GB — dedicated vCPU suits untrusted multi-tenant workloads (no noisy-neighbor) and is orderable in fsn1 (cpx41 was retired there). Size to expected concurrent app density."
   type        = string
-  default     = "cpx41"
+  default     = "ccx23"
 }
 
 variable "app_node_count" {


### PR DESCRIPTION
## What
Two fixes so the apps data-plane terraform (`terraform-apps-data-plane.yml`, staging) actually **applies** — the plan was green but apply hit two real errors:

1. **`hcloud_ssh_key` 409 `uniqueness_error`** — the operator key already exists in the shared Hetzner project, so a *create* collides. Removed the redundant `hcloud_ssh_key` resource + the `ssh_keys` server args: operator/daemon SSH is already provisioned by cloud-init (the `deploy` user's `ssh_authorized_keys`; the provisioning-worker SSHes in as `deploy`, not root). `var.ssh_public_keys` still flows to cloud-init.
2. **`Server Type "cpx41" is unavailable in "fsn1"`** — retired type. Switched the app node default to **`ccx23`** (4 dedicated vCPU / 16 GB) — dedicated vCPU is the right call for untrusted multi-tenant containers, and it's the same orderable family as the tenant-DB's `ccx33`.

## Verified
`terraform plan` (staging, real creds) is clean: **6 to add, 0 to change, 0 to destroy** (the network/firewalls/volume were already created by the first partial apply; this completes the 2 servers + attachments + wildcard DNS). fmt + validate + init all pass in CI.

## Still blocked (NOT in this PR — owner action)
Apply currently also fails with **`resource_limit_exceeded` (server limit reached)** on the shared Hetzner project. Raising the project's server limit (or freeing a server) is a Hetzner-account action for the data-plane owner. Once raised, this module applies cleanly.
