### PR TITLE
fix(apps): inject tenant DSN under both DATABASE_URL and POSTGRES_URL (#8321 P0)

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/app-container-provider.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-container-provider.test.ts
@@ -58,7 +58,7 @@ describe("AppContainerProvider.provision", () => {
     expect(calls[2]).toBe("docker start 'app-nubilio'");
   });
 
-  test("provision with a DATABASE_URL stands up the DB ambassador + rewrites the DSN host", async () => {
+  test("provision with DATABASE_URL + POSTGRES_URL stands up the ambassador + rewrites BOTH", async () => {
     const { calls, ssh } = recordingSsh();
     const provider = new AppContainerProvider({ ssh, allocateHostPort: async () => 49002 });
 
@@ -69,6 +69,7 @@ describe("AppContainerProvider.provision", () => {
         ...INPUT,
         environmentVars: {
           DATABASE_URL: "postgresql://app_x:p%40ss@10.43.0.10:5432/db_app_x?sslmode=require",
+          POSTGRES_URL: "postgresql://app_x:p%40ss@10.43.0.10:5432/db_app_x?sslmode=require",
         },
       },
     });
@@ -84,6 +85,10 @@ describe("AppContainerProvider.provision", () => {
     expect(createCmd).toContain(
       "DATABASE_URL=postgresql://app_x:p%40ss@app-db-111111112222:5432/db_app_x?sslmode=require",
     );
+    expect(createCmd).toContain(
+      "POSTGRES_URL=postgresql://app_x:p%40ss@app-db-111111112222:5432/db_app_x?sslmode=require",
+    );
+    // neither var still points at the real cluster host (both rewritten to the ambassador)
     expect(createCmd).not.toContain("@10.43.0.10:5432");
   });
 

--- a/packages/cloud-shared/src/lib/services/__tests__/app-deploy-orchestrator.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-deploy-orchestrator.test.ts
@@ -47,8 +47,10 @@ describe("deployApp", () => {
     const result = await deployApp(REQ, d);
 
     expect(result).toEqual({ containerId: "container-1", jobId: "job-1" });
-    // the container row carries the app's OWN per-tenant DSN
+    // the container row carries the app's OWN per-tenant DSN under BOTH vars
+    // (DATABASE_URL standard + POSTGRES_URL for plugin-sql/eliza images)
     expect(seen.row?.environmentVars.DATABASE_URL).toBe(TENANT_DSN);
+    expect(seen.row?.environmentVars.POSTGRES_URL).toBe(TENANT_DSN);
     expect(seen.row?.image).toBe(REQ.image);
     expect(seen.row?.port).toBe(3000);
     // provision was enqueued for the created container
@@ -66,6 +68,9 @@ describe("deployApp", () => {
     await deployApp(REQ, d);
     expect(seen.row?.environmentVars.DATABASE_URL).not.toContain("agentdb");
     expect(seen.row?.environmentVars.DATABASE_URL).toContain("db_app_x");
+    // POSTGRES_URL mirrors it exactly — same isolated DB, never the agent URL
+    expect(seen.row?.environmentVars.POSTGRES_URL).not.toContain("agentdb");
+    expect(seen.row?.environmentVars.POSTGRES_URL).toContain("db_app_x");
   });
 
   test("honors a custom container port", async () => {

--- a/packages/cloud-shared/src/lib/services/app-container-provider.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-provider.ts
@@ -94,13 +94,17 @@ export class AppContainerProvider {
       for (const cmd of cmds) {
         await this.deps.ssh.exec(cmd);
       }
-      input = {
-        ...input,
-        environmentVars: {
-          ...input.environmentVars,
-          DATABASE_URL: rewriteDsnToAmbassador(dsn, ambassadorName(params.appId)),
-        },
-      };
+      // Rewrite EVERY injected DSN var (DATABASE_URL + POSTGRES_URL) to the
+      // ambassador host. They carry the same tenant DSN; an un-rewritten
+      // POSTGRES_URL would point at the real cluster host, which is unreachable
+      // from the app's --internal network.
+      const ambHost = ambassadorName(params.appId);
+      const rewritten: Record<string, string> = { ...input.environmentVars };
+      for (const key of ["DATABASE_URL", "POSTGRES_URL"]) {
+        const value = rewritten[key];
+        if (value) rewritten[key] = rewriteDsnToAmbassador(value, ambHost);
+      }
+      input = { ...input, environmentVars: rewritten };
     }
 
     const hostPort = await this.deps.allocateHostPort();

--- a/packages/cloud-shared/src/lib/services/app-deploy-orchestrator.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-orchestrator.ts
@@ -78,8 +78,12 @@ export async function deployApp(
     containerName: req.containerName,
     image: req.image,
     port: req.port ?? 3000,
-    // The app's OWN isolated DSN — never the shared agent DATABASE_URL.
-    environmentVars: { DATABASE_URL: dsn },
+    // The app's OWN isolated DSN — never the shared agent DATABASE_URL. Inject it
+    // under BOTH `DATABASE_URL` (the de-facto standard most apps read) and
+    // `POSTGRES_URL` (what plugin-sql / eliza-based images read primarily), so an
+    // arbitrary user app reaches its isolated tenant DB regardless of which var it
+    // expects — never a silent fallback to a throwaway local/PGlite store.
+    environmentVars: { DATABASE_URL: dsn, POSTGRES_URL: dsn },
   });
 
   const { id: jobId } = await deps.enqueueProvision({


### PR DESCRIPTION
Closes the **P0 isolation-contract gap** from the apps scaling audit (**#8321**, item 3).

## Why
The deploy injected the per-tenant DSN under **only `DATABASE_URL`**. Eliza-based images map
`DATABASE_URL → POSTGRES_URL`, so they're fine — but the product is **arbitrary user apps**, and
`plugin-sql` + many app images read **`POSTGRES_URL`** directly. Such an app would miss its
isolated DB and **silently fall back to a throwaway local store** → per-tenant isolation isn't
actually active for it.

## Fix
- **`app-deploy-orchestrator`**: inject the tenant DSN under **both** `DATABASE_URL` *and*
  `POSTGRES_URL` — the app hits its isolated DB whichever var it reads.
- **`app-container-provider`**: the DB ambassador now rewrites **both** vars to the ambassador host.
  (This is required: an un-rewritten `POSTGRES_URL` would point at the real cluster host, which is
  **unreachable** from the app's `--internal` network — so adding the var without this would itself
  be a bug.)

## Tests
Orchestrator asserts both vars carry the isolated DSN (never the agent URL); provider asserts both
are rewritten to the ambassador and neither still points at the cluster host. **17/17 pass**, biome
+ typecheck clean.

cc @standujar — part of the #8321 pre-launch list (the safe, additive one).