### PR TITLE
fix(bitrouter): switch to api-key mode (BYOK)

### DIFF
--- a/packages/cloud-infra/cloud/bitrouter/bitrouter.yaml
+++ b/packages/cloud-infra/cloud/bitrouter/bitrouter.yaml
@@ -5,47 +5,50 @@ database:
   url: "sqlite:/data/bitrouter.db"
 
 providers:
-  bitrouter: {}
+  # REMOVE this entry — it enables BitRouter Cloud (api.bitrouter.ai/v1)
+  # as a built-in catalog provider and is the source of the 402.
+  # bitrouter: {}
+
   openai: {}
   anthropic: {}
   google: {}
   groq: {}
+
   openrouter:
     api_base: "https://openrouter.ai/api/v1"
     api_key: "${BITROUTER_OPENROUTER_API_KEY}"
-    api_protocol: openai
+    api_protocol: { "*": openai }
+    # MUST be a list of {id,...} objects, not a map. Map form makes
+    # `provider.models` empty, so Strategy-3 cascade never picks
+    # openrouter and the bare `openai/gpt-oss-120b` resolves to nothing
+    # (or to bitrouter cloud if it stays declared).
     models:
-      "openai/gpt-oss-120b":
+      - id: "openai/gpt-oss-120b"
         pricing:
-          input_tokens:
-            no_cache: 0.039
-            cache_read: 0
-            cache_write: 0
-          output_tokens:
-            text: 0.18
-            reasoning: 0
+          input_micro_usd_per_token: 0.039
+          output_micro_usd_per_token: 0.18
+
   cerebras:
     api_base: "https://api.cerebras.ai/v1"
     api_key: "${BITROUTER_CEREBRAS_API_KEY}"
-    api_protocol: openai
+    api_protocol: { "*": openai }
     models:
-      gpt-oss-120b:
+      - id: "gpt-oss-120b"
         pricing:
-          input_tokens:
-            no_cache: 0.35
-            cache_read: 0
-            cache_write: 0
-          output_tokens:
-            text: 0.75
-            reasoning: 0
-      zai-glm-4.7:
+          input_micro_usd_per_token: 0.35
+          output_micro_usd_per_token: 0.75
+      - id: "zai-glm-4.7"
         pricing:
-          input_tokens:
-            no_cache: 2.25
-            cache_read: 0
-            cache_write: 0
-          output_tokens:
-            text: 2.75
-            reasoning: 0
+          input_micro_usd_per_token: 2.25
+          output_micro_usd_per_token: 2.75
+
+# Belt-and-braces: an explicit virtual model (Strategy 2) pinning the
+# slash-id to openrouter. This wins even if some other provider later
+# declares the same id.
+models:
+  "openai/gpt-oss-120b":
+    endpoints:
+      - provider: openrouter
+        service_id: "openai/gpt-oss-120b"
 
 inherit_defaults: true


### PR DESCRIPTION
## Summary

BitRouter Cloud (`api.bitrouter.ai/v1`) was rejecting all chat completion calls with HTTP 402 (no payment method on the cloud account). Switch the bitrouter config to api-key-only mode so requests for `openai/gpt-oss-120b` pass through to OpenRouter via `BITROUTER_OPENROUTER_API_KEY`.

## Changes

- Removed `providers: { bitrouter: {} }` — this was enabling the BitRouter Cloud built-in catalog provider as a fallback.
- Converted `openrouter.models` and `cerebras.models` from map syntax (`"id": {pricing: ...}`) to the required list-of-objects syntax (`- id: "..."`). The map form makes `provider.models` empty, so the Strategy-3 routing cascade never picks them.
- Switched `api_protocol: openai` to `api_protocol: { "*": openai }` (the schema-correct form).
- Updated pricing keys to the canonical `input_micro_usd_per_token` / `output_micro_usd_per_token` shape.
- Added an explicit top-level `models:` virtual (Strategy 2) pinning `openai/gpt-oss-120b` to the `openrouter` provider as belt-and-braces.

## Test plan

- [ ] Deploy and confirm `openai/gpt-oss-120b` requests resolve via OpenRouter (no more 402 from `api.bitrouter.ai`)
- [ ] Verify cerebras-routed models still work