### PR TITLE
fix(bitrouter): inherit_defaults: false (BYOK only, no cloud re-injection)

### DIFF
--- a/packages/cloud-infra/cloud/bitrouter/bitrouter.yaml
+++ b/packages/cloud-infra/cloud/bitrouter/bitrouter.yaml
@@ -51,4 +51,4 @@ models:
       - provider: openrouter
         service_id: "openai/gpt-oss-120b"
 
-inherit_defaults: true
+inherit_defaults: false


### PR DESCRIPTION
Followup to #8323. Removed bitrouter cloud provider but inherit_defaults:true re-injected it via built-in catalog merge, so 402 persisted. Flipping to false. Test: bare openai/gpt-oss-120b should now route via openrouter BYOK.