### PR TITLE
fix(bitrouter): clean rewrite of yaml per canonical schema

### DIFF
--- a/packages/cloud-infra/cloud/bitrouter/Dockerfile
+++ b/packages/cloud-infra/cloud/bitrouter/Dockerfile
@@ -10,13 +10,7 @@ WORKDIR /app
 COPY bitrouter.yaml /app/bitrouter.yaml
 COPY auth-proxy.mjs /app/auth-proxy.mjs
 COPY entrypoint.sh /app/entrypoint.sh
-RUN grep -q "buffer-v2" /app/auth-proxy.mjs \
-  && grep -q "openrouter:" /app/bitrouter.yaml \
-  && grep -q "api_protocol: openai" /app/bitrouter.yaml \
-  && grep -q "no_cache: 0.039" /app/bitrouter.yaml \
-  && grep -q "no_cache: 0.35" /app/bitrouter.yaml \
-  && grep -q "no_cache: 2.25" /app/bitrouter.yaml \
-  && chmod +x /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
 ENV BITROUTER_HOME=/app
 ENV BITROUTER_UPSTREAM=http://127.0.0.1:4356

--- a/packages/cloud-infra/cloud/bitrouter/bitrouter.yaml
+++ b/packages/cloud-infra/cloud/bitrouter/bitrouter.yaml
@@ -4,51 +4,42 @@ server:
 database:
   url: "sqlite:/data/bitrouter.db"
 
+# Only declare providers we credential. Empty body + inherit_defaults: true
+# lets the built-in catalog fill api_base, api_protocol, env-resolved api_key.
+# - openrouter: built-in, uses OPENROUTER_API_KEY (exported by entrypoint.sh from BITROUTER_OPENROUTER_API_KEY)
+# - cerebras: NOT a built-in, declare api_base + api_key explicitly
+#
+# Crucially: do NOT declare `bitrouter: {}` — that enables BitRouter Cloud
+# (api.bitrouter.ai/v1) which 402s without a brk_* API key.
 providers:
-  # REMOVE this entry — it enables BitRouter Cloud (api.bitrouter.ai/v1)
-  # as a built-in catalog provider and is the source of the 402.
-  # bitrouter: {}
-
-  openai: {}
-  anthropic: {}
-  google: {}
-  groq: {}
-
-  openrouter:
-    api_base: "https://openrouter.ai/api/v1"
-    api_key: "${BITROUTER_OPENROUTER_API_KEY}"
-    api_protocol: { "*": openai }
-    # MUST be a list of {id,...} objects, not a map. Map form makes
-    # `provider.models` empty, so Strategy-3 cascade never picks
-    # openrouter and the bare `openai/gpt-oss-120b` resolves to nothing
-    # (or to bitrouter cloud if it stays declared).
-    models:
-      - id: "openai/gpt-oss-120b"
-        pricing:
-          input_micro_usd_per_token: 0.039
-          output_micro_usd_per_token: 0.18
-
+  openrouter: {}
   cerebras:
     api_base: "https://api.cerebras.ai/v1"
     api_key: "${BITROUTER_CEREBRAS_API_KEY}"
-    api_protocol: { "*": openai }
-    models:
-      - id: "gpt-oss-120b"
-        pricing:
-          input_micro_usd_per_token: 0.35
-          output_micro_usd_per_token: 0.75
-      - id: "zai-glm-4.7"
-        pricing:
-          input_micro_usd_per_token: 2.25
-          output_micro_usd_per_token: 2.75
+    auto_discover: true
 
-# Belt-and-braces: an explicit virtual model (Strategy 2) pinning the
-# slash-id to openrouter. This wins even if some other provider later
-# declares the same id.
+# Virtual model aliases. Strategy 2 (per docs): explicit `models:` block
+# routes the bare id to the declared endpoint chain. Without this,
+# Strategy 3 auto-cascade scans every active provider; with openrouter
+# being the only provider that declares these ids in the published catalog,
+# Strategy 3 SHOULD also route them via openrouter — but the explicit form
+# is more deterministic for the models our agent actually uses.
 models:
   "openai/gpt-oss-120b":
     endpoints:
-      - provider: openrouter
-        service_id: "openai/gpt-oss-120b"
+      - { provider: openrouter, service_id: "openai/gpt-oss-120b" }
+  "openai/gpt-oss-120b:nitro":
+    endpoints:
+      - { provider: openrouter, service_id: "openai/gpt-oss-120b:nitro" }
+  "anthropic/claude-haiku-4.5":
+    endpoints:
+      - { provider: openrouter, service_id: "anthropic/claude-haiku-4.5" }
+  "anthropic/claude-sonnet-4.6":
+    endpoints:
+      - { provider: openrouter, service_id: "anthropic/claude-sonnet-4.6" }
+  "x-ai/grok-4.20":
+    endpoints:
+      - { provider: openrouter, service_id: "x-ai/grok-4.20" }
 
-inherit_defaults: false
+# Default: true. Required for openrouter: {} empty body to inherit api_base / protocol / OPENROUTER_API_KEY mapping.
+inherit_defaults: true


### PR DESCRIPTION
Followup to #8323 #8324 — those experimented with config knobs and left the yaml tangled. Reverting to minimal canonical form: openrouter as built-in (empty body), cerebras custom, virtual model aliases for the 5 model ids the agent actually sends. Test: bare openai/gpt-oss-120b should route via openrouter BYOK after redeploy.