### PR TITLE
fix(wrangler): set BITROUTER_BASE_URL in [env.staging.vars]

### DIFF
--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -243,6 +243,7 @@ NODE_ENV = "production"
 NEXT_PUBLIC_APP_URL = "https://staging.elizacloud.ai"
 NEXT_PUBLIC_API_URL = "https://api-staging.elizacloud.ai"
 ELIZA_CLOUD_URL = "https://staging.elizacloud.ai"
+BITROUTER_BASE_URL = "https://bitrouter-production.up.railway.app"
 # Per-tenant `magicLinkBaseUrl` (set in Steward Neon `tenant_configs.email_config`)
 # redirects email magic-link callbacks to staging.elizacloud.ai instead of the
 # prod fallback (www.elizacloud.ai). Tenant row provisioned manually.


### PR DESCRIPTION
Background: staging Worker was missing BITROUTER_BASE_URL under [env.staging.vars] because the top-level [vars] entry does not inherit into env-specific deploys per wrangler. That made all LLM gateway calls fall back to api.bitrouter.ai/v1 (BitRouter Cloud) and 402 with no payment method, despite our Railway bitrouter instance being correctly configured. Mirroring [env.production.vars] which already had it. Stan hotfixed with wrangler secret put — this PR makes the config permanent.