### PR TITLE
fix(cloud-api): force pricing for OpenAI text-embedding models

### DIFF
--- a/packages/cloud-shared/src/lib/services/ai-pricing-variant-indexing.test.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing-variant-indexing.test.ts
@@ -333,6 +333,75 @@ describe("forced provider route pricing ids", () => {
       globalThis.fetch = previousFetch;
     }
   });
+
+  test("emits forced embedding:input row for bare text-embedding-3-small id", async () => {
+    // plugin-elizacloud sends the unprefixed id `text-embedding-3-small` to
+    // cloud-api's text embedding handler. BitRouter has no /v1/embeddings
+    // route (live 404 confirmed), so the request falls through to OpenAI
+    // Direct. Without a pricing row the cost computation 5xxs and
+    // plugin-sql writes zero-vectors. The forced row at priority -1 supplies
+    // the missing price without overriding a real BitRouter row if one
+    // ever materializes.
+    const previousApiKey = process.env.BITROUTER_API_KEY;
+    const previousFetch = globalThis.fetch;
+    process.env.BITROUTER_API_KEY = "test-bitrouter-key";
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ data: [] }), { status: 200 });
+
+    try {
+      const entries = await fetchBitRouterCatalogEntries();
+      const input = entries.find(
+        (entry) =>
+          entry.model === "text-embedding-3-small" &&
+          entry.chargeType === "input",
+      );
+
+      expect(input?.provider).toBe("openai");
+      expect(input?.productFamily).toBe("embedding");
+      expect(input?.unitPrice).toBe(0.00000002);
+      expect(input?.priority).toBe(-1);
+    } finally {
+      if (previousApiKey === undefined) {
+        delete process.env.BITROUTER_API_KEY;
+      } else {
+        process.env.BITROUTER_API_KEY = previousApiKey;
+      }
+      globalThis.fetch = previousFetch;
+    }
+  });
+
+  test("emits forced embedding:input row for prefixed openai/text-embedding-3-small id", async () => {
+    // plugin-openrouter sends the canonical `openai/text-embedding-3-small`
+    // form. Both prefixed and bare ids are needed because the cloud-api
+    // routes by raw model id without normalizing, and the two plugins
+    // emit different shapes.
+    const previousApiKey = process.env.BITROUTER_API_KEY;
+    const previousFetch = globalThis.fetch;
+    process.env.BITROUTER_API_KEY = "test-bitrouter-key";
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ data: [] }), { status: 200 });
+
+    try {
+      const entries = await fetchBitRouterCatalogEntries();
+      const input = entries.find(
+        (entry) =>
+          entry.model === "openai/text-embedding-3-small" &&
+          entry.chargeType === "input",
+      );
+
+      expect(input?.provider).toBe("openai");
+      expect(input?.productFamily).toBe("embedding");
+      expect(input?.unitPrice).toBe(0.00000002);
+      expect(input?.priority).toBe(-1);
+    } finally {
+      if (previousApiKey === undefined) {
+        delete process.env.BITROUTER_API_KEY;
+      } else {
+        process.env.BITROUTER_API_KEY = previousApiKey;
+      }
+      globalThis.fetch = previousFetch;
+    }
+  });
 });
 
 describe("canonicalModelId — OpenRouter routing variants on bare model ids", () => {

--- a/packages/cloud-shared/src/lib/services/ai-pricing/providers/bitrouter.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/providers/bitrouter.ts
@@ -25,6 +25,18 @@ const CEREBRAS_PRICING_SOURCE_URL = "https://www.cerebras.ai/pricing";
 const OPENROUTER_PRICING_SOURCE_URL =
   "https://openrouter.ai/openai/gpt-oss-120b";
 
+// BitRouter has no /v1/embeddings inbound route (live 404 with valid
+// PROXY_TOKEN, confirmed in source: only 4 inbound POST routes, no
+// ApiProtocol::Embeddings). The cloud-api getTextEmbeddingModel handler falls
+// through to OpenAI Direct when the model id is `openai/text-embedding-*` or
+// the bare `text-embedding-*`, and OPENAI_API_KEY is bound on the staging
+// Worker — so the only piece missing for embeddings to bill correctly was a
+// pricing row. Both bare and prefixed ids are emitted because plugin-elizacloud
+// sends the bare id and plugin-openrouter sends the `openai/` prefixed form.
+// Mirrors the gpt-oss-120b forced-pricing shape from PR #8307/#8319.
+const OPENAI_EMBEDDING_PRICING_SOURCE_URL =
+  "https://openai.com/api/pricing";
+
 const FORCED_BITROUTER_PRICING: ReadonlyArray<{
   model: string;
   provider: string;
@@ -33,6 +45,7 @@ const FORCED_BITROUTER_PRICING: ReadonlyArray<{
   inputUnitPrice: number;
   outputUnitPrice: number;
   sourceUrl: string;
+  priority?: number;
   metadata?: Record<string, unknown>;
 }> = [
   {
@@ -74,6 +87,93 @@ const FORCED_BITROUTER_PRICING: ReadonlyArray<{
     metadata: {
       sourceNote:
         "Estimate from OpenRouter public pricing (2026-06-07). Replace once BitRouter catalog returns a priced row for openai/gpt-oss-120b.",
+    },
+  },
+  // text-embedding-3-small — $0.02 / 1M input tokens
+  {
+    model: "openai/text-embedding-3-small",
+    provider: "openai",
+    productFamily: "embedding",
+    unit: "token",
+    inputUnitPrice: 0.00000002,
+    outputUnitPrice: 0,
+    sourceUrl: OPENAI_EMBEDDING_PRICING_SOURCE_URL,
+    priority: -1,
+    metadata: {
+      sourceNote:
+        "OpenAI public pricing: text-embedding-3-small at $0.02/1M tokens. Forced row because BitRouter has no /v1/embeddings route — cloud-api falls through to OpenAI Direct.",
+    },
+  },
+  {
+    model: "text-embedding-3-small",
+    provider: "openai",
+    productFamily: "embedding",
+    unit: "token",
+    inputUnitPrice: 0.00000002,
+    outputUnitPrice: 0,
+    sourceUrl: OPENAI_EMBEDDING_PRICING_SOURCE_URL,
+    priority: -1,
+    metadata: {
+      sourceNote:
+        "OpenAI public pricing: text-embedding-3-small at $0.02/1M tokens. Bare-id variant for plugin-elizacloud, which sends the unprefixed id.",
+    },
+  },
+  // text-embedding-3-large — $0.13 / 1M input tokens
+  {
+    model: "openai/text-embedding-3-large",
+    provider: "openai",
+    productFamily: "embedding",
+    unit: "token",
+    inputUnitPrice: 0.00000013,
+    outputUnitPrice: 0,
+    sourceUrl: OPENAI_EMBEDDING_PRICING_SOURCE_URL,
+    priority: -1,
+    metadata: {
+      sourceNote:
+        "OpenAI public pricing: text-embedding-3-large at $0.13/1M tokens. Forced row because BitRouter has no /v1/embeddings route — cloud-api falls through to OpenAI Direct.",
+    },
+  },
+  {
+    model: "text-embedding-3-large",
+    provider: "openai",
+    productFamily: "embedding",
+    unit: "token",
+    inputUnitPrice: 0.00000013,
+    outputUnitPrice: 0,
+    sourceUrl: OPENAI_EMBEDDING_PRICING_SOURCE_URL,
+    priority: -1,
+    metadata: {
+      sourceNote:
+        "OpenAI public pricing: text-embedding-3-large at $0.13/1M tokens. Bare-id variant for plugin-elizacloud, which sends the unprefixed id.",
+    },
+  },
+  // text-embedding-ada-002 — $0.10 / 1M input tokens
+  {
+    model: "openai/text-embedding-ada-002",
+    provider: "openai",
+    productFamily: "embedding",
+    unit: "token",
+    inputUnitPrice: 0.0000001,
+    outputUnitPrice: 0,
+    sourceUrl: OPENAI_EMBEDDING_PRICING_SOURCE_URL,
+    priority: -1,
+    metadata: {
+      sourceNote:
+        "OpenAI public pricing: text-embedding-ada-002 at $0.10/1M tokens. Forced row because BitRouter has no /v1/embeddings route — cloud-api falls through to OpenAI Direct.",
+    },
+  },
+  {
+    model: "text-embedding-ada-002",
+    provider: "openai",
+    productFamily: "embedding",
+    unit: "token",
+    inputUnitPrice: 0.0000001,
+    outputUnitPrice: 0,
+    sourceUrl: OPENAI_EMBEDDING_PRICING_SOURCE_URL,
+    priority: -1,
+    metadata: {
+      sourceNote:
+        "OpenAI public pricing: text-embedding-ada-002 at $0.10/1M tokens. Bare-id variant for plugin-elizacloud, which sends the unprefixed id.",
     },
   },
 ];
@@ -225,6 +325,7 @@ function buildForcedBitRouterPricingEntries(): PreparedPricingEntry[] {
       inputUnitPrice,
       outputUnitPrice,
       sourceUrl,
+      priority,
       metadata,
     }) => [
       {
@@ -239,6 +340,7 @@ function buildForcedBitRouterPricingEntries(): PreparedPricingEntry[] {
         sourceUrl,
         fetchedAt,
         staleAfter,
+        ...(priority !== undefined ? { priority } : {}),
         metadata,
       },
       {
@@ -253,6 +355,7 @@ function buildForcedBitRouterPricingEntries(): PreparedPricingEntry[] {
         sourceUrl,
         fetchedAt,
         staleAfter,
+        ...(priority !== undefined ? { priority } : {}),
         metadata,
       },
     ],


### PR DESCRIPTION
Embedding requests 5xx-ed because FORCED_BITROUTER_PRICING had zero embedding rows. Live-confirmed prereqs: bitrouter has no /v1/embeddings route (404 with valid token), and OPENAI_API_KEY is bound on staging Worker, so getTextEmbeddingModel falls through to OpenAI Direct once pricing resolves. Adds bare + prefixed entries for 3-small ($0.02/1M), 3-large ($0.13/1M), ada-002 ($0.10/1M). Mirrors PR #8307/#8319 (gpt-oss-120b).