### PR TITLE
fix(ci/docker): hoist plugin-wallet transitive deps for runtime image

### DIFF
--- a/packages/app-core/scripts/collect-docker-runtime-deps.mjs
+++ b/packages/app-core/scripts/collect-docker-runtime-deps.mjs
@@ -99,6 +99,7 @@ const LINKED_WORKSPACE_PACKAGES = [
   "plugins/plugin-sql",
   "plugins/plugin-telegram",
   "plugins/plugin-video",
+  "plugins/plugin-wallet",
   "plugins/plugin-whatsapp",
   "plugins/plugin-workflow",
   "plugins/plugin-x402",

--- a/packages/app-core/scripts/link-docker-local-app-packages.mjs
+++ b/packages/app-core/scripts/link-docker-local-app-packages.mjs
@@ -64,6 +64,7 @@ const localPackages = [
   "eliza/plugins/plugin-sql",
   "eliza/plugins/plugin-telegram",
   "eliza/plugins/plugin-video",
+  "eliza/plugins/plugin-wallet",
   "eliza/plugins/plugin-whatsapp",
   "eliza/plugins/plugin-workflow",
   "eliza/plugins/plugin-x402",


### PR DESCRIPTION
Followup to #8331. The previous fix added plugin-wallet to the per-plugin bun install loop but its @lifi/sdk transitive still does not resolve in the runtime image because the dep is not hoisted at the workspace-root level. plugin-elizacloud (which works) has @ai-sdk/openai at /app/node_modules/@ai-sdk/openai/ — top-level hoisted. plugin-wallet @lifi/sdk only exists as a broken symlink in plugins/plugin-wallet/node_modules/@lifi/sdk pointing to an empty central .bun/ store. This PR fixes the hoist.