### PR TITLE
fix(cloud-sdk): repair route-coverage audit tool (wrong path + stale regex)

### DIFF
--- a/packages/cloud-sdk/scripts/audit-api-routes.mjs
+++ b/packages/cloud-sdk/scripts/audit-api-routes.mjs
@@ -86,13 +86,21 @@ async function readGeneratedRouteMethods(cloudRoot) {
   const sourcePath = path.join(
     cloudRoot,
     "packages",
-    "sdk",
+    "cloud-sdk",
     "src",
     "public-routes.ts",
   );
   const source = await readFile(sourcePath, "utf8");
+  // Tolerant of the generator's multi-line descriptor format, e.g.
+  //   "GET /api/v1/models": {
+  //     method: "GET",
+  //     path: "/api/v1/models",
+  //     methodName: "getApiV1Models",
+  // `\s*` spans the newlines+indentation between the key and each field; the
+  // quoted-key-then-`{` anchor keeps matches scoped to one entry (inner fields
+  // use bare keys like `method:`, so they never re-trigger the key capture).
   const endpointRe =
-    /^\s+"([^"]+)": \{ method: "([^"]+)", path: "([^"]+)", methodName: "([^"]+)"/gm;
+    /"([^"]+)":\s*\{\s*method:\s*"([^"]+)",\s*path:\s*"([^"]+)",\s*methodName:\s*"([^"]+)"/g;
   const routes = new Map();
 
   for (const match of source.matchAll(endpointRe)) {


### PR DESCRIPTION
## What

`packages/cloud-sdk/scripts/audit-api-routes.mjs` — the tool that verifies every public Cloud API route has a generated SDK wrapper — was **double-broken and silently non-functional**:

1. **Wrong package path.** It read the generated route map from `packages/sdk/src/public-routes.ts`, but the package dir is `packages/cloud-sdk` → the script crashed with `ENOENT` before reporting anything.
2. **Stale descriptor regex.** The regex expected the old single-line emit (`"KEY": { method: "..", path: "..", methodName: ".." }`). The generator now emits each field on its own line, so even with the path fixed the regex matched **0 of 444** descriptors and falsely reported every public route — including `chat/completions` and `voice/stt` — as missing a wrapper.

## Fix

- Correct the path segment `sdk` → `cloud-sdk`.
- Make the descriptor regex tolerant of the multi-line generated format (`\s*` spans the newlines/indentation; the quoted-key-then-`{` anchor keeps each match scoped to one entry).

## Verification

```
$ node packages/cloud-sdk/scripts/audit-api-routes.mjs
- Generated public route method pairs: 453
- Route method pairs with generated SDK wrappers: 444
- Public route method pairs missing generated SDK wrappers: 9
- Generated SDK route wrappers with no matching route file: 0
```

The tool now parses 444 descriptors and reports **444/453** covered. `POST /api/v1/chat/completions` and `POST /api/v1/voice/stt` (the routes the Cloud apps / SDK consumers use) are confirmed in the Covered list. The 9 genuinely-missing wrappers are unrelated admin/infra/container/security routes (pre-existing; out of scope here).

- `bun run --cwd packages/cloud-sdk test` → 37 pass / 18 skip / 0 fail
- `bun run --cwd packages/cloud-sdk lint` → 0 errors (1 pre-existing non-fatal warning in `live.e2e.test.ts`, untouched)

## Scope / risk

Standalone dev tool — **not wired into CI or any build/turbo step** — so no gate/build impact. Additive, single-file, parsing-only change.