### PR TITLE
feat(apps): serve verified custom domains through the apps ingress

### DIFF
--- a/packages/cloud-api/v1/apps-ingress/ask/route.ts
+++ b/packages/cloud-api/v1/apps-ingress/ask/route.ts
@@ -2,6 +2,8 @@ import { and, eq, sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { dbRead } from "@/db/helpers";
 import { containers as containersTable } from "@/db/schemas/containers";
+import { appsService } from "@/lib/services/apps";
+import { managedDomainsService } from "@/lib/services/managed-domains";
 import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
@@ -9,16 +11,20 @@ import type { AppEnv } from "@/types/cloud-worker-env";
  * GET /api/v1/apps-ingress/ask?domain=<host>
  *
  * Caddy on-demand-TLS `ask` endpoint for the apps front door. Before issuing a
- * Let's Encrypt cert for `<shortid>.apps.elizacloud.ai`, the app node's Caddy
- * calls this with the requested SNI in `?domain=`. We return **200** iff a
- * RUNNING / deploying app container owns that exact public hostname — so Caddy
- * only ever requests certs for real, live apps, and an attacker can't make it
- * spam Let's Encrypt for non-existent subdomains.
+ * Let's Encrypt cert for a host, the app node's Caddy calls this with the
+ * requested SNI in `?domain=`. We return **200** iff that host is one of:
+ *   1. the system `<shortid>.apps.elizacloud.ai` host of a RUNNING / deploying
+ *      app container (exact `containers.public_hostname` match), or
+ *   2. a user's own **verified, active custom domain** bound to an active,
+ *      approved app (e.g. `elocute.fun`) — mirroring the reviewed predicate in
+ *      `/api/v1/domains/resolve`. DNS-TXT verification is the ownership proof, so
+ *      an attacker can't authorize a cert for a domain they don't control.
+ * Anything else 404s, so Caddy never spams Let's Encrypt for hosts we don't own.
  *
- * PUBLIC + side-effect-free: it only reveals whether a given app subdomain is
- * live, which the wildcard DNS already implies. (Hardening — a per-node token /
- * IP allowlist — is tracked in #8321.) Fails CLOSED: on a lookup error we deny
- * the cert rather than authorize one we can't verify.
+ * PUBLIC + side-effect-free: it only reveals whether a given host maps to a live
+ * app, which the DNS already implies. (Hardening — a per-node token / IP
+ * allowlist — is tracked in #8321.) Fails CLOSED: on a lookup error we deny the
+ * cert rather than authorize one we can't verify.
  */
 const app = new Hono<AppEnv>();
 
@@ -38,7 +44,20 @@ app.get("/", async (c) => {
         ),
       )
       .limit(1);
-    return row ? c.text("ok", 200) : c.text("unknown app", 404);
+    if (row) return c.text("ok", 200);
+
+    // Not a system <shortid>.<base> host — authorize a cert only for a verified,
+    // active custom domain bound to an active+approved app (the /domains/resolve
+    // predicate). The container's liveness is enforced separately by the route
+    // existing: no route -> 502 (a transient error, never a cert-abuse vector).
+    const managed = await managedDomainsService.getDomainByName(domain);
+    if (managed?.appId && managed.verified && managed.status === "active") {
+      const appRow = await appsService.getById(managed.appId);
+      if (appRow?.is_active && appRow.is_approved) {
+        return c.text("ok", 200);
+      }
+    }
+    return c.text("unknown app", 404);
   } catch (error) {
     logger.error("[apps-ingress/ask] lookup failed", {
       error: error instanceof Error ? error.message : String(error),

--- a/packages/cloud-shared/src/lib/services/__tests__/apps-ingress-routes.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/apps-ingress-routes.test.ts
@@ -26,6 +26,26 @@ describe("buildCaddyRoute", () => {
       handle: [{ handler: "reverse_proxy", upstreams: [{ dial: "10.30.1.5:28123" }] }],
     });
   });
+
+  test("folds verified custom domains into the same route's host-match (deduped + lowercased)", () => {
+    const route = buildCaddyRoute({
+      hostname: HOST,
+      extraHostnames: ["Elocute.fun", "www.elocute.fun", "elocute.fun", "   "],
+      nodeHost: "10.30.1.5",
+      hostPort: 28123,
+    });
+    // @id stays keyed off the wildcard host, so one DELETE tears down all hosts
+    expect(route["@id"]).toBe("app-abc12345");
+    expect(route.match).toEqual([
+      { host: ["abc12345.apps.elizacloud.ai", "elocute.fun", "www.elocute.fun"] },
+    ]);
+  });
+
+  test("empty/omitted extraHostnames keeps the plain single-host route", () => {
+    expect(
+      buildCaddyRoute({ hostname: HOST, extraHostnames: [], nodeHost: "n", hostPort: 1 }).match,
+    ).toEqual([{ host: ["abc12345.apps.elizacloud.ai"] }]);
+  });
 });
 
 describe("admin-API urls", () => {

--- a/packages/cloud-shared/src/lib/services/__tests__/container-job-executors.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/container-job-executors.test.ts
@@ -202,6 +202,71 @@ describe("ingress route hooks", () => {
     });
   });
 
+  test("provision folds the app's verified custom domains into the route", async () => {
+    await withBase("apps.elizacloud.ai", async () => {
+      const { store } = fakeStore();
+      const { provider } = fakeProvider({
+        async provision() {
+          return {
+            containerId: "docker-abc",
+            hostPort: 49001,
+            network: "app-net-x",
+            nodeHost: "10.30.1.5",
+          };
+        },
+      } as never);
+      let captured: { hostname: string; extraHostnames?: string[] } | undefined;
+      await executeContainerProvision(
+        job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+        {
+          provider,
+          store,
+          listVerifiedAppHostnames: async (appId) => {
+            expect(appId).toBe(ROW.appId); // looked up by the app, not the container
+            return ["elocute.fun", "www.elocute.fun"];
+          },
+          onRouteAdded: async (r) => {
+            captured = r;
+          },
+        },
+      );
+      expect(captured?.hostname).toMatch(/\.apps\.elizacloud\.ai$/);
+      expect(captured?.extraHostnames).toEqual(["elocute.fun", "www.elocute.fun"]);
+    });
+  });
+
+  test("a custom-domain lookup failure never fails the deploy (route still added, no extras)", async () => {
+    await withBase("apps.elizacloud.ai", async () => {
+      const { events, store } = fakeStore();
+      const { provider } = fakeProvider({
+        async provision() {
+          return {
+            containerId: "docker-abc",
+            hostPort: 49001,
+            network: "app-net-x",
+            nodeHost: "10.30.1.5",
+          };
+        },
+      } as never);
+      let captured: { extraHostnames?: string[] } | undefined;
+      await executeContainerProvision(
+        job({ containerId: "container-1", organizationId: "org-1", userId: "user-1" }),
+        {
+          provider,
+          store,
+          listVerifiedAppHostnames: async () => {
+            throw new Error("domains db unavailable");
+          },
+          onRouteAdded: async (r) => {
+            captured = r;
+          },
+        },
+      );
+      expect(captured?.extraHostnames).toEqual([]); // degraded gracefully
+      expect(events.find((e) => e.op === "running")).toBeDefined(); // deploy still succeeded
+    });
+  });
+
   test("delete removes the route (best-effort)", async () => {
     await withBase("apps.elizacloud.ai", async () => {
       const { store } = fakeStore();

--- a/packages/cloud-shared/src/lib/services/apps-ingress-routes.ts
+++ b/packages/cloud-shared/src/lib/services/apps-ingress-routes.ts
@@ -16,10 +16,30 @@
 export interface AppRouteInput {
   /** The app's public host, e.g. `abc12345.apps.elizacloud.ai`. */
   hostname: string;
+  /**
+   * Additional hostnames to host-match on the SAME route — the app's verified
+   * custom domains (e.g. `elocute.fun`). One route, many hosts, one `@id`, so a
+   * single DELETE tears them all down. Deduped against `hostname`; empty/omitted
+   * keeps the route a plain single-host wildcard route.
+   */
+  extraHostnames?: string[];
   /** The app node the container runs on (private IP or hostname reachable by Caddy). */
   nodeHost: string;
   /** The published host port of the container on that node. */
   hostPort: number;
+}
+
+/** Lower-case, trim, drop empties, and de-dupe a host list (order-preserving). */
+function normalizeHosts(hosts: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const host of hosts) {
+    const norm = host.trim().toLowerCase();
+    if (!norm || seen.has(norm)) continue;
+    seen.add(norm);
+    out.push(norm);
+  }
+  return out;
 }
 
 /** A Caddy admin-API route object (the subset we emit). */
@@ -44,7 +64,7 @@ export function buildCaddyRouteId(hostname: string): string {
 export function buildCaddyRoute(input: AppRouteInput): CaddyRoute {
   return {
     "@id": buildCaddyRouteId(input.hostname),
-    match: [{ host: [input.hostname] }],
+    match: [{ host: normalizeHosts([input.hostname, ...(input.extraHostnames ?? [])]) }],
     handle: [
       {
         handler: "reverse_proxy",

--- a/packages/cloud-shared/src/lib/services/container-executor-deps.ts
+++ b/packages/cloud-shared/src/lib/services/container-executor-deps.ts
@@ -24,6 +24,7 @@ import { appContainerStore } from "./app-container-store";
 import { addAppRoute, removeAppRoute } from "./apps-ingress-provisioner";
 import type { ContainerExecutorDeps } from "./container-job-executors";
 import { DockerSSHClient } from "./docker-ssh";
+import { listVerifiedAppOrigins } from "./managed-domains";
 
 /** True when the apps-container provision backend has enough env to run. */
 export function appsContainersEnabled(): boolean {
@@ -134,5 +135,16 @@ export function buildContainerExecutorDeps(): ContainerExecutorDeps {
     dbEgressNetwork: dbEgressNetwork ?? "bridge",
     ingress: Boolean(caddyAdminUrl),
   });
-  return { provider, store: appContainerStore, ...ingress };
+  return {
+    provider,
+    store: appContainerStore,
+    // Verified custom domains for the app -> bare hostnames, folded into the
+    // ingress route's host-match. Reuses the existing CORS verified-origin query
+    // (status='active' AND verified=true); only invoked when ingress is wired.
+    listVerifiedAppHostnames: (appId) =>
+      listVerifiedAppOrigins(appId).then((origins) =>
+        origins.map((origin) => origin.replace(/^https?:\/\//, "").replace(/\/+$/, "")),
+      ),
+    ...ingress,
+  };
 }

--- a/packages/cloud-shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud-shared/src/lib/services/container-job-executors.ts
@@ -55,10 +55,23 @@ export interface ContainerExecutorDeps {
    * `<shortid>.<base>` -> `nodeHost:hostPort` right after the container is marked
    * running, and removes it on delete. add failures fail the deploy (so the user
    * retries rather than a silent 502); remove failures are swallowed (a reconciler
-   * sweeps orphans). No-ops when unset (ingress not configured).
+   * sweeps orphans). No-ops when unset (ingress not configured). `extraHostnames`
+   * carries the app's verified custom domains, host-matched on the same route.
    */
-  onRouteAdded?: (route: { hostname: string; nodeHost: string; hostPort: number }) => Promise<void>;
+  onRouteAdded?: (route: {
+    hostname: string;
+    extraHostnames?: string[];
+    nodeHost: string;
+    hostPort: number;
+  }) => Promise<void>;
   onRouteRemoved?: (route: { hostname: string }) => Promise<void>;
+  /**
+   * Verified custom hostnames attached to an app (e.g. `elocute.fun`), folded
+   * into the ingress route's host-match so the app also serves on its own
+   * domain(s). Optional + best-effort: a lookup failure (or unset hook) just
+   * means the app keeps only its `<shortid>.<base>` host — never fails a deploy.
+   */
+  listVerifiedAppHostnames?: (appId: string) => Promise<string[]>;
 }
 
 async function requireRow(store: AppContainerStore, containerId: string): Promise<AppContainerRow> {
@@ -94,12 +107,18 @@ export async function executeContainerProvision(
       network: result.network,
       nodeHost: result.nodeHost,
     });
-    // Register the ingress route so `<shortid>.<base>` reaches this container.
+    // Register the ingress route so `<shortid>.<base>` reaches this container,
+    // plus the app's verified custom domains (best-effort — a domain-lookup
+    // failure must NOT fail the deploy; the app just keeps its wildcard host).
     // Inside the try: an add failure marks the container errored (no silent 502).
     const endpoint = deriveAppPublicUrl(containerId);
     if (endpoint && deps.onRouteAdded) {
+      const extraHostnames = deps.listVerifiedAppHostnames
+        ? await deps.listVerifiedAppHostnames(row.appId).catch(() => [] as string[])
+        : [];
       await deps.onRouteAdded({
         hostname: endpoint.hostname,
+        extraHostnames,
         nodeHost: result.nodeHost,
         hostPort: result.hostPort,
       });


### PR DESCRIPTION
## What

Bridges the **already-existing** custom-domain stack into the Product-2 Caddy apps ingress (#8325), so a user's own verified domain (e.g. `elocute.fun`) actually **serves their app** — not just CORS + a DNS target.

### Why this is additive, not a rewrite
A deep codebase scan confirmed custom-domain support already exists and is **reusable** — `managed_domains` (canonical table), the `AppDomains` dashboard (add / copy TXT+CNAME / verify-poll / SSL badges / remove), the buy + DNS-TXT-verify flow, and the `/domains/resolve` resolver. But all of it was **disjoint from the Caddy ingress**: the on-demand-TLS `ask` gate authorized certs only by `containers.public_hostname`, and the per-app route host-matched only that single `<shortid>.apps.elizacloud.ai` host. So a verified custom domain got CORS + a DNS target but **was never served**. This PR is the missing last mile, reusing the existing data + query (no new table, no new query, no UI change).

## Changes (additive, our ingress lane only)

- **`ask` cert-gate** (`v1/apps-ingress/ask/route.ts`): after the `public_hostname` miss, also return `200` when `?domain` is a **verified + active** `managed_domains` row bound to an **active, approved** app — mirroring the reviewed `/api/v1/domains/resolve` predicate. DNS-TXT verification is the ownership proof, so this can't authorize certs for domains the caller doesn't control. The common wildcard path is unchanged and still returns early.
- **route host-match** (`apps-ingress-routes.ts`): `buildCaddyRoute` folds `extraHostnames` (the app's verified custom domains) into the **same** route's host array — deduped + lowercased, same `@id`, so one DELETE tears them all down.
- **provision wiring** (`container-job-executors.ts` + `container-executor-deps.ts`): `executeContainerProvision` gathers the app's verified custom hostnames via a new **injected, best-effort** `listVerifiedAppHostnames` seam (a lookup failure never fails the deploy), wired to the existing `listVerifiedAppOrigins` query. The executor stays schema-decoupled; the whole path is still gated on `APPS_CADDY_ADMIN_URL` (no-op when ingress isn't configured).

## Tests / verification
- `bun test` (cloud-shared ingress suites): **24/24 pass** — route builder multi-host dedup/lowercase; provision folds verified domains; provision degrades gracefully on a domain-lookup failure; existing single-host + no-ingress paths unchanged. `apps-ingress-routes.ts` at 100% coverage.
- `biome check` clean on all changed files; `typecheck` clean for all changed files (the only diagnostics are pre-existing missing generated i18n files in core/shared).

## Scope / constraints
- Touches only our ingress files + a **READ** of `managed_domains`/`apps`. No agent-path files, no 2AM hot files (`v1/containers/*`, `cron/container-billing`, `containers.ts` schema, hetzner client), no schema migration.
- **Readiness note:** like the rest of #8325, this is *built + unit-tested but awaiting the apps node + Stan's Caddy install* (cloud-init Caddy is still a TODO) before it can be proven end-to-end.

## Follow-up (out of scope, noted)
The super-admin `admin/containers/ingress-map` snapshot still lists only `public_hostname`; an operator driving Caddy purely from that map (rather than the live admin API) would need it extended for custom domains too.