### PR TITLE
fix(infra): retire cpx41 in apps data-plane tfvars examples

### DIFF
--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/production.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/production.tfvars.example
@@ -6,7 +6,7 @@ cloudflare_zone_id = "<zone-id-for-elizacloud.ai>"
 apps_base_domain   = "apps.elizacloud.ai"
 
 app_node_count           = 2 # behind a load balancer (see main.tf STAN note)
-app_node_server_type     = "cpx41"
+app_node_server_type     = "ccx23"
 tenant_db_server_type    = "ccx33"
 tenant_db_volume_size_gb = 500
 

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/staging.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/staging.tfvars.example
@@ -7,7 +7,7 @@ apps_base_domain   = "apps-staging.elizacloud.ai"
 
 # Sizing — start small for the allowlist beta.
 app_node_count           = 1
-app_node_server_type     = "cpx41"
+app_node_server_type     = "ccx23"
 tenant_db_server_type    = "ccx33"
 tenant_db_volume_size_gb = 200
 


### PR DESCRIPTION
The `app_node_server_type` default was already fixed cpx41→ccx23 (839bb81799 — cpx41 is retired/unorderable in fsn1), but the staging + production `tfvars.example` files still showed `cpx41`. Copying them would reproduce the "Server Type cpx41 is unavailable in fsn1" apply error. This aligns the examples with the orderable default. Examples-only; no functional change (the workflow uses the variable default).