### PR TITLE
feat(apps): tenant-DB teardown — deprovision + release slot on cleanup

### DIFF
--- a/packages/cloud-shared/src/db/repositories/tenant-db-clusters.ts
+++ b/packages/cloud-shared/src/db/repositories/tenant-db-clusters.ts
@@ -10,6 +10,8 @@ import { type NewTenantDbCluster, tenantDbClusters } from "../schemas/tenant-db-
  */
 export const tenantDbClustersRepository: ClusterPoolStore & {
   create(input: NewTenantDbCluster): Promise<{ id: string }>;
+  releaseSlot(clusterId: string): Promise<void>;
+  findByHost(host: string): Promise<{ id: string; adminDsnEncrypted: string } | null>;
 } = {
   async listAllocatable(): Promise<ClusterCandidate[]> {
     const rows = await dbRead
@@ -62,5 +64,39 @@ export const tenantDbClustersRepository: ClusterPoolStore & {
       .returning({ id: tenantDbClusters.id });
     if (!row) throw new Error("Failed to insert tenant_db_clusters row");
     return row;
+  },
+
+  /**
+   * Release a database slot when a tenant DB is deprovisioned — the counterpart
+   * to {@link tryClaimSlot}. Decrements `database_count`, FLOORED at 0 via
+   * `GREATEST(0, …)` so a double-release (or releasing a slot that was never
+   * counted) can never drive the count negative and free phantom capacity. Safe
+   * to call more than once; callers run it after the DROP DATABASE/ROLE succeeds.
+   */
+  async releaseSlot(clusterId: string): Promise<void> {
+    await dbWrite
+      .update(tenantDbClusters)
+      .set({
+        database_count: sql`GREATEST(0, ${tenantDbClusters.database_count} - 1)`,
+        updated_at: new Date(),
+      })
+      .where(eq(tenantDbClusters.id, clusterId));
+  },
+
+  /**
+   * Resolve the cluster that owns a tenant DB by its host (the host embedded in
+   * the app's stored DSN). Returns the id + encrypted admin DSN needed to open
+   * an admin connection for deprovisioning. `host` is unique per cluster.
+   */
+  async findByHost(host: string): Promise<{ id: string; adminDsnEncrypted: string } | null> {
+    const [row] = await dbRead
+      .select({
+        id: tenantDbClusters.id,
+        adminDsnEncrypted: tenantDbClusters.admin_dsn_encrypted,
+      })
+      .from(tenantDbClusters)
+      .where(eq(tenantDbClusters.host, host))
+      .limit(1);
+    return row ?? null;
   },
 };

--- a/packages/cloud-shared/src/lib/services/tenant-db/__tests__/tenant-db-deprovision.test.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/__tests__/tenant-db-deprovision.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test";
+import {
+  deprovisionTenantDbForApp,
+  parseDsnHost,
+  type TenantDbDeprovisionDeps,
+} from "../tenant-db-deprovision";
+
+const APP_ID = "11111111-2222-3333-4444-555555555555";
+const DSN = "postgresql://app_x:p%40ss@10.30.1.10:5432/db_app_x?sslmode=require";
+
+describe("parseDsnHost", () => {
+  test("extracts the host from a full DSN (creds + port + query stripped)", () => {
+    expect(parseDsnHost(DSN)).toBe("10.30.1.10");
+    expect(parseDsnHost("postgres://u:p@db.internal:5432/x")).toBe("db.internal");
+    expect(parseDsnHost("postgresql://u@HOST.example/db")).toBe("host.example");
+  });
+  test("returns null for an unparseable / hostless DSN", () => {
+    expect(parseDsnHost("not a dsn")).toBeNull();
+    expect(parseDsnHost("")).toBeNull();
+  });
+});
+
+function deps(over: Partial<TenantDbDeprovisionDeps> = {}) {
+  const calls: string[] = [];
+  const base: TenantDbDeprovisionDeps = {
+    async resolveClusterByHost(host) {
+      calls.push(`resolve:${host}`);
+      return { id: "cluster-1", adminDsn: "postgresql://admin@10.30.1.10/postgres" };
+    },
+    makeDeprovisioner(adminDsn, host) {
+      calls.push(`make:${host}`);
+      return {
+        async deprovision(appId) {
+          calls.push(`drop:${appId}`);
+        },
+      };
+    },
+    async releaseSlot(clusterId) {
+      calls.push(`release:${clusterId}`);
+    },
+  };
+  return { calls, deps: { ...base, ...over } };
+}
+
+describe("deprovisionTenantDbForApp", () => {
+  test("resolves the cluster, DROPs the DB, THEN releases the slot (order matters)", async () => {
+    const { calls, deps: d } = deps();
+    const result = await deprovisionTenantDbForApp(APP_ID, DSN, d);
+
+    expect(result).toEqual({ deprovisioned: true });
+    expect(calls).toEqual([
+      "resolve:10.30.1.10",
+      "make:10.30.1.10",
+      `drop:${APP_ID}`,
+      "release:cluster-1",
+    ]);
+  });
+
+  test("no-op when the DSN has no parseable host (nothing to drop)", async () => {
+    const { calls, deps: d } = deps();
+    const result = await deprovisionTenantDbForApp(APP_ID, "garbage", d);
+    expect(result).toEqual({ deprovisioned: false, reason: "no-host" });
+    expect(calls).toEqual([]); // never touches the cluster
+  });
+
+  test("no-op when no cluster owns the host (shared-mode / already-removed)", async () => {
+    let dropped = false;
+    let released = false;
+    const result = await deprovisionTenantDbForApp(APP_ID, DSN, {
+      async resolveClusterByHost() {
+        return null;
+      },
+      makeDeprovisioner() {
+        dropped = true;
+        return { async deprovision() {} };
+      },
+      async releaseSlot() {
+        released = true;
+      },
+    });
+    expect(result).toEqual({ deprovisioned: false, reason: "unknown-cluster" });
+    // resolve returned null -> nothing dropped or released
+    expect(dropped).toBe(false);
+    expect(released).toBe(false);
+  });
+
+  test("a failed DROP propagates and does NOT release the slot (DB still live)", async () => {
+    const released: string[] = [];
+    const { deps: d } = deps({
+      makeDeprovisioner() {
+        return {
+          async deprovision() {
+            throw new Error("connection refused");
+          },
+        };
+      },
+      async releaseSlot(id) {
+        released.push(id);
+      },
+    });
+    await expect(deprovisionTenantDbForApp(APP_ID, DSN, d)).rejects.toThrow("connection refused");
+    expect(released).toEqual([]); // slot stays counted — the DB wasn't dropped
+  });
+});

--- a/packages/cloud-shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioning.test.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioning.test.ts
@@ -36,6 +36,9 @@ function deps(
           seen.provisionedApp = appId;
           return { dbName: "db_app_x", roleName: "app_x", dsn: PROVISIONED_DSN };
         },
+        async deprovision(appId) {
+          seen.deprovisionedApp = appId;
+        },
       };
     },
   };
@@ -73,5 +76,31 @@ describe("SqlTenantDbProvisioning", () => {
     await expect(new SqlTenantDbProvisioning(d).provisionForApp("app-1")).rejects.toThrow(
       "capacity",
     );
+  });
+
+  test("deprovisionForApp resolves the cluster by host, DROPs the DB, releases the slot", async () => {
+    const released: string[] = [];
+    const d = deps({
+      async resolveClusterByHost(host) {
+        d.seen.resolvedHost = host;
+        return { id: "cluster-1", adminDsnEncrypted: "enc:v1:admin-dsn" };
+      },
+      async releaseSlot(clusterId) {
+        released.push(clusterId);
+      },
+    });
+    const result = await new SqlTenantDbProvisioning(d).deprovisionForApp("app-1", PROVISIONED_DSN);
+
+    expect(result).toEqual({ deprovisioned: true });
+    expect(d.seen.resolvedHost).toBe("apps-cluster-1"); // host parsed from the stored DSN
+    expect(d.seen.deprovisionedApp).toBe("app-1"); // the DROP ran on that cluster
+    expect(released).toEqual(["cluster-1"]); // the slot was released
+  });
+
+  test("deprovisionForApp throws a clear error when the teardown deps aren't wired", async () => {
+    // base deps() has no resolveClusterByHost / releaseSlot
+    await expect(
+      new SqlTenantDbProvisioning(deps()).deprovisionForApp("app-1", PROVISIONED_DSN),
+    ).rejects.toThrow("not configured");
   });
 });

--- a/packages/cloud-shared/src/lib/services/tenant-db/make-tenant-db-provisioning.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/make-tenant-db-provisioning.ts
@@ -44,6 +44,12 @@ export interface MakeTenantDbProvisioningOpts {
   decrypt?: (encrypted: string) => Promise<string>;
   /** Override the role-password generator (deterministic tests). */
   genPassword?: () => string;
+  /** Override the host->cluster resolver (teardown). Defaults to the repository. */
+  resolveClusterByHost?: (
+    host: string,
+  ) => Promise<{ id: string; adminDsnEncrypted: string } | null>;
+  /** Override the slot-release (teardown). Defaults to the repository. */
+  releaseSlot?: (clusterId: string) => Promise<void>;
 }
 
 /**
@@ -59,6 +65,11 @@ export function makeTenantDbProvisioning(
   const decrypt = opts.decrypt ?? ((encrypted: string) => fieldEncryption.decrypt(encrypted));
   const genPassword = opts.genPassword ?? genRolePassword;
 
+  const resolveClusterByHost =
+    opts.resolveClusterByHost ?? ((host: string) => tenantDbClustersRepository.findByHost(host));
+  const releaseSlot =
+    opts.releaseSlot ?? ((clusterId: string) => tenantDbClustersRepository.releaseSlot(clusterId));
+
   return new SqlTenantDbProvisioning({
     pool,
     decrypt,
@@ -68,5 +79,7 @@ export function makeTenantDbProvisioning(
         executor: new DirectPgExecutor(adminDsn),
         genPassword,
       }),
+    resolveClusterByHost,
+    releaseSlot,
   });
 }

--- a/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-deprovision.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-deprovision.ts
@@ -1,0 +1,82 @@
+/**
+ * Tenant-DB teardown (Apps / Product 2) — the deprovision counterpart to the
+ * provision path. When an isolated-DB app is deleted, its per-tenant Postgres
+ * DATABASE + ROLE must be DROPped and its cluster slot released, or we leak a
+ * live DB we keep paying for AND burn one of the cluster's finite slots forever
+ * (the billing leak tracked in #8342).
+ *
+ * Pure orchestration over injected seams (cluster resolution, the admin
+ * executor/provisioner, the slot release) so it's fully unit-testable without a
+ * live Postgres. The real DROP runs on the DAEMON (it needs `pg`), composed at
+ * the integration boundary; the app-delete route enqueues it.
+ *
+ * Idempotent + fail-safe: a missing DSN host / unknown cluster is a no-op
+ * (nothing to drop — never throws on "already gone"), and `releaseSlot` is
+ * floored at 0, so a retry or a double-delete can't corrupt the slot accounting.
+ */
+
+/** Provisioner bound to one cluster's admin connection (the deprovision half). */
+export interface TenantDbDeprovisioner {
+  deprovision(appId: string): Promise<void>;
+}
+
+export interface TenantDbDeprovisionDeps {
+  /**
+   * Resolve the cluster that owns a host (the host embedded in the app's stored
+   * DSN) to its id + DECRYPTED admin DSN. Returns null when no cluster matches
+   * (e.g. a shared-mode/Neon app, or an already-removed cluster).
+   */
+  resolveClusterByHost: (host: string) => Promise<{ id: string; adminDsn: string } | null>;
+  /** Build a provisioner bound to a cluster's admin DSN (for the DROP). */
+  makeDeprovisioner: (adminDsn: string, host: string) => TenantDbDeprovisioner;
+  /** Decrement the cluster's `database_count` (floored at 0). */
+  releaseSlot: (clusterId: string) => Promise<void>;
+}
+
+export interface TenantDbDeprovisionResult {
+  deprovisioned: boolean;
+  reason?: "no-host" | "unknown-cluster";
+}
+
+/**
+ * Parse the host from a Postgres DSN (`postgres[ql]://user:pw@HOST:port/db…`).
+ * Returns the lower-cased host without port, or null if it can't be parsed.
+ */
+export function parseDsnHost(dsn: string): string | null {
+  try {
+    // The URL parser handles credentials + ports + query strings cleanly; it
+    // requires a parseable scheme, which a Postgres DSN provides.
+    const u = new URL(dsn);
+    const host = u.hostname.trim().toLowerCase();
+    return host || null;
+  } catch {
+    // Fallback for odd DSNs: grab between the last '@' and the next ':' or '/'.
+    const at = dsn.lastIndexOf("@");
+    if (at < 0) return null;
+    const rest = dsn.slice(at + 1);
+    const host = rest.split(/[:/?]/)[0]?.trim().toLowerCase();
+    return host || null;
+  }
+}
+
+/**
+ * Drop an app's isolated tenant DB + role and release its cluster slot.
+ * Order matters: DROP first, then release the slot — so a failed DROP (which
+ * throws) leaves the slot counted (the DB still exists) rather than freeing a
+ * slot for a DB that's still live.
+ */
+export async function deprovisionTenantDbForApp(
+  appId: string,
+  dsn: string,
+  deps: TenantDbDeprovisionDeps,
+): Promise<TenantDbDeprovisionResult> {
+  const host = parseDsnHost(dsn);
+  if (!host) return { deprovisioned: false, reason: "no-host" };
+
+  const cluster = await deps.resolveClusterByHost(host);
+  if (!cluster) return { deprovisioned: false, reason: "unknown-cluster" };
+
+  await deps.makeDeprovisioner(cluster.adminDsn, host).deprovision(appId);
+  await deps.releaseSlot(cluster.id);
+  return { deprovisioned: true };
+}

--- a/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-provisioning.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/tenant-db-provisioning.ts
@@ -9,17 +9,27 @@
  */
 
 import type { AllocatedCluster } from "./cluster-pool";
+import { deprovisionTenantDbForApp, type TenantDbDeprovisionResult } from "./tenant-db-deprovision";
 import type { ProvisionedTenantDb, TenantDbCluster } from "./tenant-db-provisioner";
 
 /** What `UserDatabaseService` depends on: provision an isolated DB for an app. */
 export interface TenantDbProvisioning {
   /** Returns the app's own isolated DSN + the cluster it was placed on. */
   provisionForApp(appId: string): Promise<{ dsn: string; clusterId: string }>;
+  /**
+   * Tear down an app's isolated DB (DROP DATABASE/ROLE) and release its cluster
+   * slot, resolving the cluster from the host in the app's stored `dsn`. No-op
+   * (not deprovisioned) for a shared/unknown DSN. Requires the deprovision deps
+   * to be wired (throws a clear error otherwise).
+   */
+  deprovisionForApp(appId: string, dsn: string): Promise<TenantDbDeprovisionResult>;
 }
 
 /** A per-cluster provisioner (the U2 `SqlTenantDbProvisioner` shape). */
 export interface TenantDbProvisioner {
   provision(appId: string): Promise<ProvisionedTenantDb>;
+  /** DROP the app's DATABASE + ROLE on this cluster (teardown). */
+  deprovision(appId: string): Promise<void>;
 }
 
 export interface SqlTenantDbProvisioningDeps {
@@ -29,6 +39,15 @@ export interface SqlTenantDbProvisioningDeps {
   decrypt: (encrypted: string) => Promise<string>;
   /** Builds a provisioner bound to a cluster's admin connection. */
   makeProvisioner: (cluster: TenantDbCluster, adminDsn: string) => TenantDbProvisioner;
+  /**
+   * Resolve the cluster owning a host (from the app's stored DSN) -> id +
+   * ENCRYPTED admin DSN. Required for `deprovisionForApp`.
+   */
+  resolveClusterByHost?: (
+    host: string,
+  ) => Promise<{ id: string; adminDsnEncrypted: string } | null>;
+  /** Decrement a cluster's `database_count`. Required for `deprovisionForApp`. */
+  releaseSlot?: (clusterId: string) => Promise<void>;
 }
 
 export class SqlTenantDbProvisioning implements TenantDbProvisioning {
@@ -44,5 +63,23 @@ export class SqlTenantDbProvisioning implements TenantDbProvisioning {
     const provisioner = this.deps.makeProvisioner({ host: allocated.host }, adminDsn);
     const result = await provisioner.provision(appId);
     return { dsn: result.dsn, clusterId: allocated.id };
+  }
+
+  async deprovisionForApp(appId: string, dsn: string): Promise<TenantDbDeprovisionResult> {
+    const { resolveClusterByHost, releaseSlot } = this.deps;
+    if (!resolveClusterByHost || !releaseSlot) {
+      throw new Error(
+        "deprovisionForApp not configured: pass resolveClusterByHost + releaseSlot to SqlTenantDbProvisioning",
+      );
+    }
+    return deprovisionTenantDbForApp(appId, dsn, {
+      resolveClusterByHost: async (host) => {
+        const cluster = await resolveClusterByHost(host);
+        if (!cluster) return null;
+        return { id: cluster.id, adminDsn: await this.deps.decrypt(cluster.adminDsnEncrypted) };
+      },
+      makeDeprovisioner: (adminDsn, host) => this.deps.makeProvisioner({ host }, adminDsn),
+      releaseSlot,
+    });
   }
 }

--- a/packages/cloud-shared/src/lib/services/user-database.ts
+++ b/packages/cloud-shared/src/lib/services/user-database.ts
@@ -225,25 +225,53 @@ export class UserDatabaseService {
     logger.info("Cleaning up database for app", { appId });
 
     const database = await appDatabasesRepository.findStateByAppIdForWrite(appId);
-    if (!database?.user_database_project_id) {
+    if (!database) {
       logger.debug("No database to clean up", { appId });
       return;
     }
 
-    try {
-      const neonClient = getNeonClient();
-      await neonClient.deleteProject(database.user_database_project_id);
-      logger.info("Database cleaned up successfully", {
-        appId,
-        projectId: database.user_database_project_id,
-      });
-    } catch (error) {
-      // Log but don't fail - database might already be deleted
-      logger.warn("Failed to delete Neon project (may already be deleted)", {
-        appId,
-        projectId: database.user_database_project_id,
-        error: error instanceof Error ? error.message : "Unknown",
-      });
+    // ISOLATED (Apps / Product 2): DROP the app's OWN per-tenant DATABASE + ROLE
+    // and release its cluster slot — otherwise we leak a live DB we keep paying
+    // for AND burn one of the cluster's finite slots forever (#8342). Only runs
+    // when the provisioning backend is wired (the daemon — DROP needs `pg`); on
+    // the Worker (shared-mode, no backend) this is a no-op.
+    const isolatedUri = database.user_database_uri;
+    if (this.tenantDbProvisioning && isolatedUri) {
+      try {
+        const dsn = await fieldEncryption.decryptIfNeeded(isolatedUri);
+        if (dsn) {
+          const result = await this.tenantDbProvisioning.deprovisionForApp(appId, dsn);
+          logger.info("Isolated tenant DB deprovisioned", {
+            appId,
+            deprovisioned: result.deprovisioned,
+          });
+        }
+      } catch (error) {
+        // Don't fail the app delete on a teardown hiccup; a reconciler sweeps orphans.
+        logger.warn("Failed to deprovision isolated tenant DB", {
+          appId,
+          error: error instanceof Error ? error.message : "Unknown",
+        });
+      }
+    }
+
+    // NEON (legacy shared-host path): delete the user's Neon project.
+    if (database.user_database_project_id) {
+      try {
+        const neonClient = getNeonClient();
+        await neonClient.deleteProject(database.user_database_project_id);
+        logger.info("Database cleaned up successfully", {
+          appId,
+          projectId: database.user_database_project_id,
+        });
+      } catch (error) {
+        // Log but don't fail - database might already be deleted
+        logger.warn("Failed to delete Neon project (may already be deleted)", {
+          appId,
+          projectId: database.user_database_project_id,
+          error: error instanceof Error ? error.message : "Unknown",
+        });
+      }
     }
   }
 


### PR DESCRIPTION
Closes the **isolated-DB leak** half of #8342.

## Problem
Deleting an app with its own per-tenant Postgres **never DROPped** the DATABASE/ROLE and **never released** the cluster slot — `SqlTenantDbProvisioner.deprovision` had zero callers, there was no `releaseSlot` (only `tryClaimSlot` incremented), and `cleanupDatabase` only handled the legacy Neon path. So every deleted isolated app stranded a live DB we keep paying for **and** burned one of the cluster's 2000 finite slots permanently.

## Fix
- **`releaseSlot(clusterId)`** — the counterpart to `tryClaimSlot`; `GREATEST(0, count-1)` so a double-release can't drive the count negative. Plus **`findByHost(host)`** to resolve the owning cluster from the host in the app's stored DSN.
- **`deprovisionTenantDbForApp`** (pure, DI'd) — parse the DSN host → resolve the cluster → DROP the DB+role → **then** release the slot (order matters: a failed DROP leaves the slot counted, so we never free a slot for a still-live DB). Fail-safe no-ops for a shared/unknown DSN.
- **`SqlTenantDbProvisioning.deprovisionForApp`** wires the use-case over the repo + admin executor; `make-tenant-db-provisioning` injects the real backends.
- **`UserDatabaseService.cleanupDatabase`** now tears down the isolated path too (was Neon-only), gated on the provisioning backend being wired (the daemon — `DROP` needs `pg`); Worker-side it's a no-op.

## Tests
DSN-host parsing, drop-then-release ordering, fail-safe no-ops (no host / unknown cluster), a failed-DROP-keeps-the-slot case, the composer path, and the not-configured guard. **31 pass / 0 fail**; typecheck + biome clean.

## Scope / remaining
Additive, our tenant-DB lane only (no agent path, no 2AM billing files). The deprovision fires when `cleanupDatabase` runs on the **daemon**; wiring app-delete to trigger a daemon-side cleanup (an enqueue) is the final integration step — gated on the live daemon, like the rest of the apps lane. Pairs with #8338 (opt-in isolated DB).