### PR TITLE
feat(infra): make the dedicated tenant-DB node optional (default off)

### DIFF
--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
@@ -114,7 +114,11 @@ resource "hcloud_firewall" "tenant_db" {
 }
 
 # ── Tenant Postgres node ──────────────────────────────────────────────────────
+# Gated on var.provision_tenant_db (default false): beta runs app-node-only and
+# co-locates the first tenant DBs on the app node, so a dedicated ccx33 isn't a
+# fixed loss at low density (#8342). Flip the var to true to add it at scale.
 resource "hcloud_server" "tenant_db" {
+  count        = var.provision_tenant_db ? 1 : 0
   name         = "eliza-apps-tenantdb-${var.environment}"
   location     = var.hcloud_location
   server_type  = var.tenant_db_server_type
@@ -134,7 +138,8 @@ resource "hcloud_server" "tenant_db" {
 }
 
 resource "hcloud_server_network" "tenant_db" {
-  server_id  = hcloud_server.tenant_db.id
+  count      = var.provision_tenant_db ? 1 : 0
+  server_id  = hcloud_server.tenant_db[0].id
   network_id = hcloud_network.apps.id
   # First usable host in the subnet — stable private IP the app nodes + the
   # control-plane provisioner connect to (admin DSN host).
@@ -142,8 +147,9 @@ resource "hcloud_server_network" "tenant_db" {
 }
 
 resource "hcloud_volume_attachment" "tenant_db_data" {
+  count     = var.provision_tenant_db ? 1 : 0
   volume_id = hcloud_volume.tenant_db_data.id
-  server_id = hcloud_server.tenant_db.id
+  server_id = hcloud_server.tenant_db[0].id
   automount = false
 }
 

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/outputs.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/outputs.tf
@@ -4,8 +4,8 @@ output "tenant_db_private_host" {
 }
 
 output "tenant_db_public_ip" {
-  description = "Public IP of the tenant DB node (SSH/admin only — Postgres is NOT exposed publicly)."
-  value       = hcloud_server.tenant_db.ipv4_address
+  description = "Public IP of the tenant DB node (SSH/admin only — Postgres is NOT exposed publicly). null when provision_tenant_db = false (app-node-only beta)."
+  value       = one(hcloud_server.tenant_db[*].ipv4_address)
 }
 
 output "tenant_db_admin_dsn" {

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/production.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/production.tfvars.example
@@ -19,3 +19,7 @@ operator_ingress_cidrs = ["<operator-ip>/32"]
 ssh_public_keys = [
   # "ssh-ed25519 AAAA... operator@laptop"
 ]
+
+# Beta: app-node-only (no dedicated DB node — co-locate the first tenant DBs on
+# the app node). Flip to true once you have real DB-app density (#8342).
+provision_tenant_db      = false

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/staging.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/staging.tfvars.example
@@ -22,3 +22,7 @@ operator_ingress_cidrs = ["0.0.0.0/0", "::/0"]
 ssh_public_keys = [
   # "ssh-ed25519 AAAA... operator@laptop"
 ]
+
+# Beta: app-node-only (no dedicated DB node — co-locate the first tenant DBs on
+# the app node). Flip to true once you have real DB-app density (#8342).
+provision_tenant_db      = false

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
@@ -49,6 +49,12 @@ variable "tenant_db_volume_size_gb" {
   default     = 200
 }
 
+variable "provision_tenant_db" {
+  description = "Provision the dedicated tenant Postgres node (the ccx33). DEFAULT false: a dedicated DB node is pure unrecovered cost at low density (#8342), so for beta we run app-node-only and co-locate the first few tenant DBs on the app node. Flip to true once you have real DB-app density to justify a dedicated cluster node. The app node is independent of it (it only bakes in the static private DB host)."
+  type        = bool
+  default     = false
+}
+
 variable "ssh_public_keys" {
   description = "Operator SSH public keys allowed to log in as root. Provide via tfvars; never commit private keys."
   type        = list(string)


### PR DESCRIPTION
## Why
A dedicated ccx33 tenant-DB node (~$53/mo) is **pure unrecovered fixed cost at low density** — the apps lane runs *negative* below ~3 paying containers (#8342). For beta we want **app-node-only** and co-locate the first few tenant DBs on the app node, then add the dedicated node once DB-app density justifies it.

## What
- New var **`provision_tenant_db`** (bool, **default `false`**).
- `count`-gate the tenant-DB **server** + its `hcloud_server_network` + `hcloud_volume_attachment` on it (the app node is independent — it only bakes in the static private DB host via `cidrhost`, so an app-node-only apply is a clean **+1 server, not +2**).
- Guard the `tenant_db_public_ip` output with `one()` → `null` when the node isn't provisioned.
- The volume + firewall + admin password are **left intact** (cheap/free, **no destroys**) and ready for when the node is added.
- `provision_tenant_db = false` added to the tfvars examples.

## Net
The beta apply brings up **just the app node (~$24/mo)** instead of both (~$77/mo) — **saving ~$53/mo** while DB density is low — and you flip one var to add the dedicated cluster node at scale. Pairs with the lean container tier ($0.67/day) for a cost-optimal, profitable beta.

## Verification
Standard HCL (count-gating + `one()` guard); the `terraform plan` CI on this PR validates it. terraform isn't installed in this sandbox.