### PR TITLE
feat (registry): register elizaos-plugin-neynar-search as third-party plugin

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-neynar-search.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-neynar-search.json
@@ -1,0 +1,8 @@
+{
+  "package": "elizaos-plugin-neynar-search",
+  "repository": "github:xavier-arosemena/elizaos-plugin-neynar-search",
+  "kind": "plugin",
+  "description": "Farcaster engagement discovery, like, reply, and follow/unfollow actions via Neynar REST API for ElizaOS agents",
+  "version": "0.1.0",
+  "tags": ["farcaster", "neynar", "social", "discovery"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -87,6 +87,50 @@
       "kind": "plugin",
       "registryKind": "plugin",
       "directory": "packages/examples/plugin-echo"
+    },
+    "elizaos-plugin-neynar-search": {
+      "git": {
+        "repo": "xavier-arosemena/elizaos-plugin-neynar-search",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "elizaos-plugin-neynar-search",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "Farcaster engagement discovery, like, reply, and follow/unfollow actions via Neynar REST API for ElizaOS agents",
+      "homepage": null,
+      "topics": [
+        "farcaster",
+        "neynar",
+        "social",
+        "discovery"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
     }
   }
 }


### PR DESCRIPTION
Registers elizaos-plugin-neynar-search in the third-party plugins registry.

- Package: elizaos-plugin-neynar-search
- Repository: github:xavier-arosemena/elizaos-plugin-neynar-search
- Kind: plugin
- Version: 0.1.0
