### PR TITLE
feat (registry): register elizaos-plugin-reddit-search as third-party plugin

### DIFF
--- a/packages/registry/entries/third-party/elizaos-plugin-reddit-search.json
+++ b/packages/registry/entries/third-party/elizaos-plugin-reddit-search.json
@@ -1,0 +1,8 @@
+{
+  "package": "elizaos-plugin-reddit-search",
+  "repository": "github:xavier-arosemena/elizaos-plugin-reddit-search",
+  "kind": "plugin",
+  "description": "ElizaOS plugin for Reddit integration — search, engage, and manage Reddit interactions autonomously",
+  "version": "0.1.0",
+  "tags": ["reddit", "social", "discovery"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -178,6 +178,49 @@
       "kind": "plugin",
       "registryKind": "plugin",
       "directory": null
+    },
+    "elizaos-plugin-reddit-search": {
+      "git": {
+        "repo": "xavier-arosemena/elizaos-plugin-reddit-search",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "elizaos-plugin-reddit-search",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "ElizaOS plugin for Reddit integration — search, engage, and manage Reddit interactions autonomously",
+      "homepage": null,
+      "topics": [
+        "reddit",
+        "social",
+        "discovery"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
     }
   }
 }


### PR DESCRIPTION
Registers elizaos-plugin-reddit-search in the third-party plugins registry.

- Package: elizaos-plugin-reddit-search
- Repository: github:xavier-arosemena/elizaos-plugin-reddit-search
- Kind: plugin
- Version: 0.1.0
