### PR TITLE
fix(autoscaler): emit environment + tier labels on provision

### DIFF
--- a/packages/cloud-shared/src/lib/config/containers-env.ts
+++ b/packages/cloud-shared/src/lib/config/containers-env.ts
@@ -217,6 +217,23 @@ export const containersEnv = {
   },
 
   /**
+   * Cloud deployment environment (`staging`, `production`, `local`, …).
+   *
+   * Stamped onto provisioned Hetzner servers via the `environment` label so
+   * the orchestrator/scheduler can scope per-env operations from the API
+   * (`?label_selector=environment=staging`) and never act on a node from a
+   * different environment.
+   *
+   * Defaults to `"local"` to match the other env-prefixed callers
+   * (cache client, a2a task store, credit-events) — same fallback, same
+   * source of truth (the `ENVIRONMENT` env var).
+   */
+  environment(): string {
+    const env = getCloudAwareEnv();
+    return pick(env.ENVIRONMENT) ?? "local";
+  },
+
+  /**
    * Base domain for per-container public hostnames (e.g.
    * `containers.elizacloud.ai`). When set, every new container gets
    * `<short-id>.<base-domain>` written to `public_hostname` and is

--- a/packages/cloud-shared/src/lib/services/containers/node-autoscaler.test.ts
+++ b/packages/cloud-shared/src/lib/services/containers/node-autoscaler.test.ts
@@ -184,6 +184,8 @@ describe("NodeAutoscaler Hetzner provisioning", () => {
       labels: {
         "managed-by": "eliza-cloud",
         "node-id": "node-test",
+        environment: "local",
+        tier: "data-plane",
         purpose: "onboarding-e2e",
       },
     });

--- a/packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts
+++ b/packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts
@@ -244,9 +244,18 @@ export class NodeAutoscaler {
     });
 
     const client = getHetznerCloudClient();
+    // `environment` + `tier` let the orchestrator scope server lookups via
+    // Hetzner's label_selector (e.g. `environment=staging,tier=data-plane`) so
+    // staging never touches a production node, and a runaway daemon can't
+    // accidentally claim/drain a server from a sibling environment. Without
+    // these labels every API-discovered node looks identical, which is how we
+    // shipped a staging node tagged `environment=production` in the first
+    // place. Caller overrides via `request.labels` win (test seams).
     const labels = {
       "managed-by": "eliza-cloud",
       "node-id": nodeId,
+      environment: containersEnv.environment(),
+      tier: "data-plane",
       ...request.labels,
     };
 
@@ -357,7 +366,10 @@ export class NodeAutoscaler {
       await client.deleteServer(hcloudServerId);
     } catch (err) {
       if (err instanceof HetznerCloudError && err.code === "not_found") {
-        logger.info("[autoscaler] Hetzner server already gone", { nodeId, hcloudServerId });
+        logger.info("[autoscaler] Hetzner server already gone", {
+          nodeId,
+          hcloudServerId,
+        });
       } else {
         throw err;
       }


### PR DESCRIPTION
## Summary

Hetzner servers provisioned by the node autoscaler only carried `managed-by` + `node-id`, so every API-discovered node looked identical across environments. A staging node ended up tagged `environment=production` from a hand-fix and stayed that way because the autoscaler had no opinion to overwrite it on the next replenish.

This stamps `environment` (from `ENVIRONMENT` env var, defaults to `local`) + `tier=data-plane` at create time so the orchestrator can scope server lookups via `label_selector=environment=<env>,tier=data-plane` and a daemon can never accidentally claim or drain a sibling-env node.

- Adds `containersEnv.environment()` (single source of truth, falls back to `local` like the other env-prefixed callers).
- Emits `environment` + `tier` from `NodeAutoscaler.provisionNode`, before the caller-supplied `request.labels` spread so test/explicit overrides still win.
- Updates the autoscaler unit test to assert the new label shape.

Fleet was just relabeled out-of-band (staging nodes 136422174 + 137939722 -> `environment=staging,tier=data-plane,managed-by=eliza-cloud`); this PR makes that the steady-state behaviour so the next provision keeps the contract.

## Test plan

- [x] `bun test packages/cloud-shared/src/lib/services/containers/node-autoscaler.test.ts` (6 pass)
- [x] `bun run typecheck` in `packages/cloud-shared`
- [x] `biome check --write` clean on changed files
- [ ] Confirm next autoscale-up event in staging tags the new server with `environment=staging,tier=data-plane` (visible in `hcloud server describe`)