### PR TITLE
fix(cloud): apps lane billing, ingress, and tenant DB teardown (#8342, #8321)

### DIFF
--- a/packages/cloud-api/cron/container-billing/route.ts
+++ b/packages/cloud-api/cron/container-billing/route.ts
@@ -23,11 +23,15 @@ import {
   CONTAINER_PRICING,
   calculateDailyContainerCost,
 } from "@/lib/constants/pricing";
+import { activeBillingService } from "@/lib/services/active-billing";
 import { computeContainerBillingPlan } from "@/lib/services/container-billing-policy";
 import { emailService } from "@/lib/services/email";
 import { redeemableEarningsService } from "@/lib/services/redeemable-earnings";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
+
+/** Skip re-billing if charged within this window (daily cadence guard). */
+const REBILL_GUARD_HOURS = 22;
 
 interface BillingResult {
   containerId: string;
@@ -116,7 +120,22 @@ async function processContainerBilling(
       `[Container Billing] Shutting down container ${containerName} due to insufficient credits`,
     );
 
-    await containerBillingRepository.suspendContainer(containerId, now);
+    const cancelResult = await activeBillingService.cancelResource({
+      organizationId,
+      resourceId: containerId,
+      resourceType: "container",
+      mode: "stop",
+    });
+
+    if (cancelResult.infrastructureAction.status === "failed") {
+      logger.warn(
+        `[Container Billing] Container ${containerName} billing suspended but docker stop failed`,
+        {
+          containerId,
+          error: cancelResult.infrastructureAction.error,
+        },
+      );
+    }
 
     return {
       containerId,
@@ -207,10 +226,47 @@ async function processContainerBilling(
   }
 
   // Pay-as-you-go split (decided by computeContainerBillingPlan above):
+  const rebillCutoff = new Date(now.getTime() - REBILL_GUARD_HOURS * 60 * 60 * 1000);
+  if (container.last_billed_at && new Date(container.last_billed_at) >= rebillCutoff) {
+    logger.info(
+      `[Container Billing] Skipping ${containerName}; already billed within ${REBILL_GUARD_HOURS} hours`,
+      { containerId },
+    );
+    return {
+      containerId,
+      containerName,
+      organizationId,
+      action: "skipped",
+      error: "Already billed recently",
+    };
+  }
+
   // take what we can from earnings first, then charge the remainder to
   // credits. Earnings → org credits conversion goes through
   // redeemableEarningsService so we get a credit_conversion ledger entry
   // for the audit trail.
+  //
+  // Claim the billing slot BEFORE earnings conversion so a cron retry cannot
+  // double-debit redeemable_earnings if finalize fails after convertToCredits.
+  const billingClaim = await containerBillingRepository.claimDailyBillingSlot({
+    containerId,
+    rebillCutoff,
+    now,
+  });
+  if (billingClaim.status === "already_billed_recently") {
+    logger.info(
+      `[Container Billing] Skipping ${containerName}; billing claim lost to a concurrent run`,
+      { containerId },
+    );
+    return {
+      containerId,
+      containerName,
+      organizationId,
+      action: "skipped",
+      error: "Already billed recently",
+    };
+  }
+
   let fromEarnings = plan.fromEarnings;
   let fromCredits = plan.fromCredits;
 
@@ -256,20 +312,20 @@ async function processContainerBilling(
 
   const newBalance = currentBalance + fromEarnings - dailyCost;
 
-  // Atomic billing — credits down by (dailyCost - fromEarnings), record kept.
-  const billingResult =
-    await containerBillingRepository.recordSuccessfulDailyBilling({
-      containerId,
-      organizationId,
-      userId: container.user_id,
-      containerName,
-      currentTotalBilled: container.total_billed,
-      dailyCost,
-      newBalance,
-      fromEarnings,
-      fromCredits,
-      now,
-    });
+  const billingResult = await containerBillingRepository.finalizeDailyBilling({
+    containerId,
+    organizationId,
+    userId: container.user_id,
+    containerName,
+    currentTotalBilled: container.total_billed,
+    dailyCost,
+    newBalance,
+    fromEarnings,
+    fromCredits,
+    now,
+    rebillCutoff,
+    claimedTotalBilled: billingClaim.totalBilled,
+  });
 
   logger.info(
     `[Container Billing] Billed ${containerName}: $${dailyCost.toFixed(4)} (earnings $${fromEarnings.toFixed(4)} + credits $${fromCredits.toFixed(4)})`,
@@ -308,6 +364,47 @@ async function getOrgUserEmail(organizationId: string): Promise<string | null> {
 }
 
 /**
+ * Stop containers that were billing-suspended in DB but never docker-stopped.
+ */
+async function reconcileSuspendedContainers(): Promise<number> {
+  const orphaned = await containerBillingRepository.listSuspendedButRunning();
+  let stopped = 0;
+  for (const container of orphaned) {
+    try {
+      const cancelResult = await activeBillingService.cancelResource({
+        organizationId: container.organization_id,
+        resourceId: container.id,
+        resourceType: "container",
+        mode: "stop",
+      });
+      if (cancelResult.infrastructureAction.status !== "failed") {
+        stopped++;
+      } else {
+        logger.warn(
+          `[Container Billing] Reconcile: failed to stop suspended container ${container.name}`,
+          {
+            containerId: container.id,
+            error: cancelResult.infrastructureAction.error,
+          },
+        );
+      }
+    } catch (error) {
+      logger.warn(
+        `[Container Billing] Reconcile: error stopping suspended container ${container.name}`,
+        {
+          containerId: container.id,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+  }
+  if (stopped > 0) {
+    logger.info(`[Container Billing] Reconciled ${stopped} suspended-but-running container(s)`);
+  }
+  return stopped;
+}
+
+/**
  * Main billing handler
  */
 async function handleContainerBilling(c: AppContext): Promise<Response> {
@@ -317,6 +414,7 @@ async function handleContainerBilling(c: AppContext): Promise<Response> {
     const appUrl = c.env.NEXT_PUBLIC_APP_URL || "https://www.elizacloud.ai";
 
     logger.info("[Container Billing] Starting daily container billing run");
+    await reconcileSuspendedContainers();
     // Get all running containers that need billing
     const runningContainers =
       await containerBillingRepository.listBillableContainers();

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/cloud-init/app-node.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/cloud-init/app-node.yaml.tftpl
@@ -4,9 +4,9 @@
 # each app on its OWN `--internal` docker network with --cap-drop=ALL, behind a
 # default-deny egress proxy (see cloud-shared/lib/services/app-network-utils.ts).
 #
-# This bootstrap installs docker + a squid egress proxy + an ingress reverse
-# proxy (Caddy) that maps <shortid>.<base-domain> -> the app container's host
-# port (the ingress-map / public_hostname the runtime stamps).
+# This bootstrap installs docker + squid egress proxy + Caddy ingress + host
+# nftables isolation. Caddy serves *.<apps_base_domain> and reverse-proxies to
+# per-container host ports (see cloud-api admin/containers/ingress-map).
 #
 # STAN: for untrusted images decide gVisor (runsc) / Kata / userns-remap +
 # seccomp profile; this draft uses stock docker + cap-drop + --internal, which is
@@ -31,6 +31,9 @@ apt:
     docker:
       source: "deb [arch=amd64 signed-by=$KEY_FILE] https://download.docker.com/linux/ubuntu $RELEASE stable"
       keyid: 9DC858229FC7DD38854AE2D88D81803C0EBFCD88
+    caddy:
+      source: "deb [signed-by=$KEY_FILE] https://dl.cloudsmith.io/public/caddy/stable/deb/debian any-version main"
+      keyid: 1CADA2F4F588A4B8
 
 package_update: true
 packages:
@@ -40,12 +43,25 @@ packages:
   - containerd.io
   - squid
   - jq
+  - nftables
+  - caddy
 
 write_files:
-  # Default-deny egress proxy: app containers (HTTP_PROXY -> :3128) can only
-  # reach explicitly allowlisted hosts. STAN: extend allowed_dst as needed
-  # (package registries the apps legitimately need). The tenant DB is reached
-  # over the private net, NOT through this proxy.
+  # Per-app docker networks get /24 subnets from distinct pools — avoids bridge
+  # collisions when thousands of `--internal` networks are created (#8321 #5).
+  - path: /etc/docker/daemon.json
+    content: |
+      {
+        "default-address-pools": [
+          { "base": "172.18.0.0/16", "size": 24 },
+          { "base": "172.19.0.0/16", "size": 24 }
+        ],
+        "log-driver": "json-file",
+        "log-opts": { "max-size": "10m", "max-file": "3" }
+      }
+
+  # Default-deny egress proxy — mirrors buildSquidAllowlistConf() defaults in
+  # cloud-shared (DEFAULT_APP_EGRESS_ALLOWED_HOSTS). Tenant DB is private-net only.
   - path: /etc/squid/conf.d/apps-egress.conf
     content: |
       http_port 3128
@@ -53,11 +69,63 @@ write_files:
       http_access allow allowed_dst
       http_access deny all
 
+  # Belt-and-suspenders forward-chain isolation — mirrors buildAppNodeNftablesRules()
+  # (docker bridge gateway for squid egress + apps private net for DB ambassador).
+  - path: /etc/nftables.d/app-isolation.nft
+    content: |
+      table inet app_isolation {
+          chain forward {
+              type filter hook forward priority 0; policy drop;
+              ct state established,related accept
+              ip daddr 172.17.0.1 accept
+              ip daddr ${apps_private_network_cidr} accept
+              ip daddr 169.254.169.254 drop
+              ip daddr 10.0.0.0/8 drop
+              ip daddr 172.16.0.0/12 drop
+              ip daddr 192.168.0.0/16 drop
+          }
+      }
+
+  # Caddy ingress — provisioning-worker pushes ingress-map snippets over SSH;
+  # the path unit reloads when apps.d changes. Admin API is loopback-only for
+  # explicit /load reloads via APPS_CADDY_ADMIN_URL.
+  - path: /etc/caddy/Caddyfile
+    content: |
+      {
+        admin 127.0.0.1:2019
+        email ops@elizacloud.ai
+      }
+      import /etc/caddy/apps.d/*.caddy
+
+  - path: /etc/caddy/apps.d/.keep
+    content: ""
+    permissions: "0644"
+
+  - path: /etc/systemd/system/eliza-caddy-reload.path
+    content: |
+      [Path]
+      PathChanged=/etc/caddy/apps.d
+      PathChanged=/etc/caddy/Caddyfile
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - path: /etc/systemd/system/eliza-caddy-reload.service
+    content: |
+      [Service]
+      Type=oneshot
+      ExecStart=/usr/bin/caddy validate --config /etc/caddy/Caddyfile
+      ExecStart=/usr/bin/caddy reload --config /etc/caddy/Caddyfile
+
 runcmd:
-  - systemctl enable docker && systemctl start docker
+  - mkdir -p /etc/caddy/apps.d && chown -R caddy:caddy /etc/caddy/apps.d
+  - systemctl enable docker && systemctl restart docker
   - systemctl enable squid && systemctl restart squid
-  # The tenant DB lives at ${tenant_db_host} on the private net; app containers
-  # get a per-tenant DSN pointing there (injected by the deploy runner).
+  - nft -f /etc/nftables.d/app-isolation.nft || true
+  - systemctl enable --now caddy
+  - systemctl enable eliza-caddy-reload.path && systemctl start eliza-caddy-reload.path
   - echo "tenant_db_host=${tenant_db_host}" > /etc/eliza-apps-node.env
-  # STAN: install Caddy (or reuse the existing ingress-map -> Caddyfile emitter)
-  # to terminate TLS and reverse-proxy <shortid>.<base> to the container host port.
+  - echo "apps_base_domain=${apps_base_domain}" >> /etc/eliza-apps-node.env
+  - echo "apps_private_network_cidr=${apps_private_network_cidr}" >> /etc/eliza-apps-node.env
+  - echo "egress_proxy_url=http://172.17.0.1:3128" >> /etc/eliza-apps-node.env
+  - echo "APPS_CADDY_ADMIN_URL=http://127.0.0.1:2019" >> /etc/eliza-apps-node.env

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/cloud-init/tenant-db.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/cloud-init/tenant-db.yaml.tftpl
@@ -8,10 +8,11 @@
 # the cluster + the admin superuser + locks the network surface.
 #
 # Reachable ONLY on the private apps network (the firewall opens no public 5432).
+# App containers connect via pgbouncer (6432) on the private net; direct 5432 is
+# reserved for admin DDL from the daemon.
 #
-# STAN: tune shared_buffers/max_connections for thousands of small DBs; wire
-# volume-snapshot backups; consider scram-sha-256 + per-shard nodes as
-# database_count grows.
+# STAN: volume-snapshot backups; scram-sha-256 + per-shard nodes as database_count
+# grows; tune shared_buffers as load increases.
 
 hostname: ${hostname}
 manage_etc_hosts: true
@@ -31,7 +32,31 @@ package_update: true
 packages:
   - postgresql
   - postgresql-contrib
+  - pgbouncer
   - jq
+
+write_files:
+  - path: /etc/pgbouncer/pgbouncer.ini
+    content: |
+      [databases]
+      * = host=127.0.0.1 port=5432
+
+      [pgbouncer]
+      listen_addr = 0.0.0.0
+      listen_port = 6432
+      auth_type = scram-sha-256
+      auth_file = /etc/pgbouncer/userlist.txt
+      pool_mode = transaction
+      max_client_conn = 5000
+      default_pool_size = 50
+      min_pool_size = 5
+      reserve_pool_size = 10
+      server_reset_query = DISCARD ALL
+      ignore_startup_parameters = extra_float_digits
+
+  - path: /etc/pgbouncer/userlist.txt
+    content: |
+      "postgres" "${admin_password}"
 
 runcmd:
   # 1. Mount the data volume at the Postgres data dir (survives node rebuilds).
@@ -47,13 +72,19 @@ runcmd:
   #    firewall + pg_hba are the access control; no public 5432 rule exists).
   - sed -i "s|^data_directory.*|data_directory = '$PGDATA'|" /etc/postgresql/$PGVER/main/postgresql.conf
   - sed -i "s|^#listen_addresses.*|listen_addresses = '*'|" /etc/postgresql/$PGVER/main/postgresql.conf
-  # 3. Allow the private apps subnet to connect (scram); deny everything else.
+  - sed -i "s|^#max_connections.*|max_connections = 500|" /etc/postgresql/$PGVER/main/postgresql.conf
+  - sed -i "s|^max_connections.*|max_connections = 500|" /etc/postgresql/$PGVER/main/postgresql.conf
+  - echo "max_connections = 500" >> /etc/postgresql/$PGVER/main/postgresql.conf
+  - sed -i "s|^#password_encryption.*|password_encryption = scram-sha-256|" /etc/postgresql/$PGVER/main/postgresql.conf
+  # 3. Allow the private apps subnet on pgbouncer (6432) + admin direct (5432).
   - echo "hostssl all all 10.30.0.0/16 scram-sha-256" >> /etc/postgresql/$PGVER/main/pg_hba.conf
   - echo "host    all all 10.30.0.0/16 scram-sha-256" >> /etc/postgresql/$PGVER/main/pg_hba.conf
-  - sed -i "s|^#password_encryption.*|password_encryption = scram-sha-256|" /etc/postgresql/$PGVER/main/postgresql.conf
+  - echo "host    all all 127.0.0.1/32 scram-sha-256" >> /etc/postgresql/$PGVER/main/pg_hba.conf
   - systemctl enable postgresql && systemctl start postgresql
   # 4. Set the admin (postgres) superuser password the daemon's admin DSN uses.
   - sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD '${admin_password}';"
+  - chown postgres:postgres /etc/pgbouncer/userlist.txt && chmod 600 /etc/pgbouncer/userlist.txt
+  - chown postgres:postgres /etc/pgbouncer/pgbouncer.ini
+  - systemctl enable pgbouncer && systemctl restart pgbouncer
   # STAN: generate a server TLS cert for hostssl (self-signed or internal CA);
-  # until then switch the pg_hba lines above to 'host' and the admin DSN to
-  # sslmode=disable on the private net.
+  # until then app DSNs use sslmode=disable on the private net via pgbouncer.

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
@@ -169,9 +169,11 @@ resource "hcloud_server" "app_node" {
   })
 
   user_data = templatefile("${path.module}/cloud-init/app-node.yaml.tftpl", {
-    hostname          = "eliza-apps-node-${var.environment}-${each.value}"
-    operator_ssh_keys = var.ssh_public_keys
-    tenant_db_host    = cidrhost(var.subnet_cidr, 10)
+    hostname                   = "eliza-apps-node-${var.environment}-${each.value}"
+    operator_ssh_keys          = var.ssh_public_keys
+    tenant_db_host             = cidrhost(var.subnet_cidr, 10)
+    apps_base_domain           = var.apps_base_domain
+    apps_private_network_cidr  = var.network_cidr
   })
 
   # Allow in-place rename via Hetzner Console without TF drift (matches control-plane).

--- a/packages/cloud-shared/src/db/migrations/0141_app_databases_cluster_id.sql
+++ b/packages/cloud-shared/src/db/migrations/0141_app_databases_cluster_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "app_databases" ADD COLUMN IF NOT EXISTS "user_database_cluster_id" text;

--- a/packages/cloud-shared/src/db/migrations/0142_container_billing_period_unique.sql
+++ b/packages/cloud-shared/src/db/migrations/0142_container_billing_period_unique.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "container_billing_records" ADD COLUMN IF NOT EXISTS "billing_period" text;
+
+UPDATE "container_billing_records"
+SET "billing_period" = to_char("billing_period_start" AT TIME ZONE 'UTC', 'YYYY-MM-DD')
+WHERE "billing_period" IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "container_billing_records_container_period_success_unique"
+  ON "container_billing_records" ("container_id", "billing_period")
+  WHERE "status" = 'success' AND "billing_period" IS NOT NULL;

--- a/packages/cloud-shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud-shared/src/db/migrations/meta/_journal.json
@@ -981,6 +981,20 @@
       "when": 1779408800000,
       "tag": "0140_tenant_db_clusters",
       "breakpoints": true
+    },
+    {
+      "idx": 140,
+      "version": "7",
+      "when": 1779408900000,
+      "tag": "0141_app_databases_cluster_id",
+      "breakpoints": true
+    },
+    {
+      "idx": 141,
+      "version": "7",
+      "when": 1779409000000,
+      "tag": "0142_container_billing_period_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud-shared/src/db/repositories/app-databases.ts
+++ b/packages/cloud-shared/src/db/repositories/app-databases.ts
@@ -15,6 +15,7 @@ type DatabaseStateColumns = Pick<
   | "user_database_region"
   | "user_database_status"
   | "user_database_error"
+  | "user_database_cluster_id"
 >;
 
 export type AppDatabaseState = DatabaseStateColumns & {
@@ -30,6 +31,7 @@ type AppDatabaseStateUpdate = Partial<
     | "user_database_region"
     | "user_database_status"
     | "user_database_error"
+    | "user_database_cluster_id"
   >
 >;
 
@@ -144,6 +146,7 @@ export class AppDatabasesRepository {
       user_database_region: database.user_database_region,
       user_database_status: database.user_database_status as UserDatabaseStatus,
       user_database_error: database.user_database_error,
+      user_database_cluster_id: database.user_database_cluster_id,
       source: "app_databases",
     };
   }

--- a/packages/cloud-shared/src/db/repositories/container-billing.ts
+++ b/packages/cloud-shared/src/db/repositories/container-billing.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray } from "drizzle-orm";
+import { and, eq, inArray, isNull, lt, or } from "drizzle-orm";
 import { dbRead, dbWrite } from "../helpers";
 import { containerBillingRecords, containers } from "../schemas/containers";
 import { creditTransactions } from "../schemas/credit-transactions";
@@ -21,6 +21,7 @@ export interface BillableContainer {
   shutdown_warning_sent_at: Date | null;
   scheduled_shutdown_at: Date | null;
   total_billed: string;
+  last_billed_at: Date | null;
 }
 
 export interface ContainerBillingOrganization {
@@ -51,6 +52,26 @@ export interface RecordSuccessfulBillingInput {
   fromEarnings: number;
   fromCredits: number;
   now: Date;
+  rebillCutoff: Date;
+}
+
+export type RecordSuccessfulDailyBillingResult =
+  | { status: "billed"; newBalance: number; transactionId: string }
+  | { status: "already_billed_recently" };
+
+export type ClaimDailyBillingSlotResult =
+  | { status: "claimed"; totalBilled: string }
+  | { status: "already_billed_recently" };
+
+export interface ClaimDailyBillingSlotInput {
+  containerId: string;
+  rebillCutoff: Date;
+  now: Date;
+}
+
+export interface FinalizeDailyBillingInput extends RecordSuccessfulBillingInput {
+  /** total_billed captured when the slot was claimed (before finalize). */
+  claimedTotalBilled: string;
 }
 
 export class ContainerBillingRepository {
@@ -70,6 +91,7 @@ export class ContainerBillingRepository {
         shutdown_warning_sent_at: containers.shutdown_warning_sent_at,
         scheduled_shutdown_at: containers.scheduled_shutdown_at,
         total_billed: containers.total_billed,
+        last_billed_at: containers.last_billed_at,
       })
       .from(containers)
       .where(
@@ -111,7 +133,23 @@ export class ContainerBillingRepository {
     return orgRows.map((org) => ({
       ...org,
       billing_email: billingEmailByOrg.get(org.id) ?? null,
-    }));
+    })      );
+  }
+
+  /** Running containers marked suspended in billing — still consuming Hetzner. */
+  async listSuspendedButRunning(): Promise<
+    Pick<BillableContainer, "id" | "name" | "organization_id">[]
+  > {
+    return await dbRead
+      .select({
+        id: containers.id,
+        name: containers.name,
+        organization_id: containers.organization_id,
+      })
+      .from(containers)
+      .where(
+        and(eq(containers.status, "running"), eq(containers.billing_status, "suspended")),
+      );
   }
 
   async suspendContainer(containerId: string, now: Date): Promise<void> {
@@ -150,10 +188,43 @@ export class ContainerBillingRepository {
     });
   }
 
-  async recordSuccessfulDailyBilling(input: RecordSuccessfulBillingInput): Promise<{
-    newBalance: number;
-    transactionId: string;
-  }> {
+  /**
+   * Reserve a daily billing slot before earnings conversion so a cron retry
+   * cannot double-debit redeemable_earnings if finalize fails mid-flight.
+   */
+  async claimDailyBillingSlot(
+    input: ClaimDailyBillingSlotInput,
+  ): Promise<ClaimDailyBillingSlotResult> {
+    const [claimed] = await dbWrite
+      .update(containers)
+      .set({
+        last_billed_at: input.now,
+        next_billing_at: new Date(input.now.getTime() + 24 * 60 * 60 * 1000),
+        updated_at: input.now,
+      })
+      .where(
+        and(
+          eq(containers.id, input.containerId),
+          or(
+            isNull(containers.last_billed_at),
+            lt(containers.last_billed_at, input.rebillCutoff),
+          ),
+        ),
+      )
+      .returning({ total_billed: containers.total_billed });
+
+    if (!claimed) {
+      return { status: "already_billed_recently" as const };
+    }
+
+    return { status: "claimed" as const, totalBilled: claimed.total_billed };
+  }
+
+  async finalizeDailyBilling(
+    input: FinalizeDailyBillingInput,
+  ): Promise<RecordSuccessfulDailyBillingResult> {
+    const billingPeriod = input.now.toISOString().split("T")[0];
+
     return await dbWrite.transaction(async (tx) => {
       await tx
         .update(organizations)
@@ -175,7 +246,7 @@ export class ContainerBillingRepository {
             container_id: input.containerId,
             container_name: input.containerName,
             billing_type: "daily_container",
-            billing_period: input.now.toISOString().split("T")[0],
+            billing_period: billingPeriod,
             paid_from_earnings: input.fromEarnings.toFixed(4),
             paid_from_credits: input.fromCredits.toFixed(4),
           },
@@ -186,28 +257,62 @@ export class ContainerBillingRepository {
       await tx
         .update(containers)
         .set({
-          last_billed_at: input.now,
-          next_billing_at: new Date(input.now.getTime() + 24 * 60 * 60 * 1000),
           billing_status: "active" as ContainerBillingStatus,
           shutdown_warning_sent_at: null,
           scheduled_shutdown_at: null,
-          total_billed: String(Number(input.currentTotalBilled) + input.dailyCost),
+          total_billed: String(Number(input.claimedTotalBilled) + input.dailyCost),
           updated_at: input.now,
         })
         .where(eq(containers.id, input.containerId));
 
-      await tx.insert(containerBillingRecords).values({
-        container_id: input.containerId,
-        organization_id: input.organizationId,
-        amount: String(input.dailyCost),
-        billing_period_start: input.now,
-        billing_period_end: new Date(input.now.getTime() + 24 * 60 * 60 * 1000),
-        status: "success",
-        credit_transaction_id: creditTx.id,
-        created_at: input.now,
-      });
+      try {
+        await tx.insert(containerBillingRecords).values({
+          container_id: input.containerId,
+          organization_id: input.organizationId,
+          amount: String(input.dailyCost),
+          billing_period: billingPeriod,
+          billing_period_start: input.now,
+          billing_period_end: new Date(input.now.getTime() + 24 * 60 * 60 * 1000),
+          status: "success",
+          credit_transaction_id: creditTx.id,
+          created_at: input.now,
+        });
+      } catch (error) {
+        const pgCode =
+          error && typeof error === "object" && "code" in error
+            ? String((error as { code: unknown }).code)
+            : "";
+        if (pgCode === "23505") {
+          throw new Error(
+            `Duplicate container billing record for ${input.containerId} on ${billingPeriod}`,
+          );
+        }
+        throw error;
+      }
 
-      return { newBalance: input.newBalance, transactionId: creditTx.id };
+      return {
+        status: "billed" as const,
+        newBalance: input.newBalance,
+        transactionId: creditTx.id,
+      };
+    });
+  }
+
+  /** @deprecated Prefer claimDailyBillingSlot + finalizeDailyBilling for cron billing. */
+  async recordSuccessfulDailyBilling(
+    input: RecordSuccessfulBillingInput,
+  ): Promise<RecordSuccessfulDailyBillingResult> {
+    const claim = await this.claimDailyBillingSlot({
+      containerId: input.containerId,
+      rebillCutoff: input.rebillCutoff,
+      now: input.now,
+    });
+    if (claim.status === "already_billed_recently") {
+      return { status: "already_billed_recently" };
+    }
+    return this.finalizeDailyBilling({
+      ...input,
+      claimedTotalBilled: claim.totalBilled,
     });
   }
 }

--- a/packages/cloud-shared/src/db/repositories/credit-transactions.ts
+++ b/packages/cloud-shared/src/db/repositories/credit-transactions.ts
@@ -105,6 +105,23 @@ export class CreditTransactionsRepository {
     return !!row;
   }
 
+  /**
+   * Returns an existing deploy-fee debit when the same deployment idempotency
+   * key was already charged (safe retries after a partial queue).
+   */
+  async findDebitByIdempotencyKey(
+    organizationId: string,
+    idempotencyKey: string,
+  ): Promise<CreditTransaction | undefined> {
+    return await dbWrite.query.creditTransactions.findFirst({
+      where: and(
+        eq(creditTransactions.organization_id, organizationId),
+        eq(creditTransactions.type, "debit"),
+        sql`${creditTransactions.metadata}->>'idempotencyKey' = ${idempotencyKey}`,
+      ),
+    });
+  }
+
   // ============================================================================
   // WRITE OPERATIONS (use primary)
   // ============================================================================

--- a/packages/cloud-shared/src/db/repositories/tenant-db-clusters.ts
+++ b/packages/cloud-shared/src/db/repositories/tenant-db-clusters.ts
@@ -10,7 +10,7 @@ import { type NewTenantDbCluster, tenantDbClusters } from "../schemas/tenant-db-
  */
 export const tenantDbClustersRepository: ClusterPoolStore & {
   create(input: NewTenantDbCluster): Promise<{ id: string }>;
-  releaseSlot(clusterId: string): Promise<void>;
+  releaseSlot(clusterId: string): Promise<boolean>;
   findByHost(host: string): Promise<{ id: string; adminDsnEncrypted: string } | null>;
 } = {
   async listAllocatable(): Promise<ClusterCandidate[]> {
@@ -33,12 +33,20 @@ export const tenantDbClustersRepository: ClusterPoolStore & {
     return rows;
   },
 
-  /**
-   * Atomically claim a database slot: increment `database_count` only if the
-   * cluster is still active and under capacity. The `WHERE … < max_databases`
-   * guard makes concurrent claims race-safe — two callers can't overfill a
-   * cluster — and the empty `RETURNING` set signals "lost the race".
-   */
+
+  async findById(clusterId: string) {
+    const [row] = await dbRead
+      .select({
+        id: tenantDbClusters.id,
+        host: tenantDbClusters.host,
+        adminDsnEncrypted: tenantDbClusters.admin_dsn_encrypted,
+      })
+      .from(tenantDbClusters)
+      .where(eq(tenantDbClusters.id, clusterId))
+      .limit(1);
+    return row ?? null;
+  },
+
   async tryClaimSlot(clusterId: string): Promise<boolean> {
     const claimed = await dbWrite
       .update(tenantDbClusters)
@@ -73,14 +81,16 @@ export const tenantDbClustersRepository: ClusterPoolStore & {
    * counted) can never drive the count negative and free phantom capacity. Safe
    * to call more than once; callers run it after the DROP DATABASE/ROLE succeeds.
    */
-  async releaseSlot(clusterId: string): Promise<void> {
-    await dbWrite
+  async releaseSlot(clusterId: string): Promise<boolean> {
+    const released = await dbWrite
       .update(tenantDbClusters)
       .set({
         database_count: sql`GREATEST(0, ${tenantDbClusters.database_count} - 1)`,
         updated_at: new Date(),
       })
-      .where(eq(tenantDbClusters.id, clusterId));
+      .where(eq(tenantDbClusters.id, clusterId))
+      .returning({ id: tenantDbClusters.id });
+    return released.length > 0;
   },
 
   /**

--- a/packages/cloud-shared/src/db/schemas/app-databases.ts
+++ b/packages/cloud-shared/src/db/schemas/app-databases.ts
@@ -40,6 +40,9 @@ export const appDatabases = pgTable(
     /** Error message if provisioning failed. */
     user_database_error: text("user_database_error"),
 
+    /** Tenant DB cluster that hosts an isolated per-app database (Apps / Product 2). */
+    user_database_cluster_id: text("user_database_cluster_id"),
+
     // Lifecycle
     created_at: timestamp("created_at").notNull().defaultNow(),
     updated_at: timestamp("updated_at").notNull().defaultNow(),

--- a/packages/cloud-shared/src/db/schemas/containers.ts
+++ b/packages/cloud-shared/src/db/schemas/containers.ts
@@ -148,6 +148,8 @@ export const containerBillingRecords = pgTable(
     amount: numeric("amount", { precision: 10, scale: 2 }).notNull(),
     billing_period_start: timestamp("billing_period_start").notNull(),
     billing_period_end: timestamp("billing_period_end").notNull(),
+    /** UTC calendar day (`YYYY-MM-DD`) for idempotent daily billing. */
+    billing_period: text("billing_period"),
     status: text("status").default("success").notNull(), // success, failed, insufficient_credits
     credit_transaction_id: uuid("credit_transaction_id").references(() => creditTransactions.id, {
       onDelete: "set null",

--- a/packages/cloud-shared/src/db/schemas/organizations.ts
+++ b/packages/cloud-shared/src/db/schemas/organizations.ts
@@ -24,6 +24,9 @@ import {
  * Billing details → organization_billing table
  * Extended config → organization_config table
  */
+/** Schema default for `organizations.credit_balance` (USD). */
+export const ORG_DEFAULT_CREDIT_BALANCE = "100.000000" as const;
+
 export const organizations = pgTable(
   "organizations",
   {
@@ -32,7 +35,7 @@ export const organizations = pgTable(
     slug: text("slug").notNull().unique(),
     credit_balance: numeric("credit_balance", { precision: 12, scale: 6 })
       .notNull()
-      .default("100.000000"),
+      .default(ORG_DEFAULT_CREDIT_BALANCE),
 
     // Settings (kept for backward compatibility with container management)
     settings: jsonb("settings").$type<Record<string, unknown>>().default({}),

--- a/packages/cloud-shared/src/lib/services/__tests__/app-container-store.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-container-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   mapContainerRowToAppContainerRow,
+  mergeAppHetznerMetadata,
   mergeHostPlacementMetadata,
   type ProjectableContainerRow,
 } from "../app-container-store";
@@ -19,6 +20,7 @@ function row(overrides: Partial<ProjectableContainerRow> = {}): ProjectableConta
     user_id: "user-1",
     environment_vars: { DATABASE_URL: DSN, PORT: "3000" },
     metadata: {},
+    node_id: null,
     ...overrides,
   };
 }
@@ -35,6 +37,7 @@ describe("mapContainerRowToAppContainerRow", () => {
       organizationId: "org-1",
       userId: "user-1",
       environmentVars: { DATABASE_URL: DSN, PORT: "3000" },
+      nodeId: null,
     });
   });
 
@@ -65,6 +68,26 @@ describe("mergeHostPlacementMetadata", () => {
   test("null/undefined existing → just the host placement", () => {
     expect(mergeHostPlacementMetadata(null, info)).toEqual(info);
     expect(mergeHostPlacementMetadata(undefined, info)).toEqual(info);
+  });
+});
+
+describe("mergeAppHetznerMetadata", () => {
+  const info = { hostContainerId: "h-9", hostPort: 21000, network: "app-net-x" };
+
+  test("adds hetzner-docker fields for billing cancel + ingress-map", () => {
+    const meta = mergeAppHetznerMetadata({ appId: "a1" }, info, {
+      nodeId: "app-node-1",
+      hostname: "10.30.1.20",
+      containerName: "app-abc",
+      hostPort: 21000,
+      containerPort: 3000,
+      image: "ghcr.io/elizaos/app-x:latest",
+    });
+    expect(meta.provider).toBe("hetzner-docker");
+    expect(meta.containerName).toBe("app-abc");
+    expect(meta.hostname).toBe("10.30.1.20");
+    expect(meta.hostPort).toBe(21000);
+    expect(meta.appId).toBe("a1");
   });
 });
 

--- a/packages/cloud-shared/src/lib/services/__tests__/app-deploy-billing.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-deploy-billing.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { ApiError } from "../../api/cloud-worker-errors";
+import { APP_DEPLOY_UPFRONT_CHARGE_USD } from "../app-deployments-helpers";
+
+const findDebitByIdempotencyKey = mock();
+const findOrgById = mock();
+const deductCredits = mock();
+
+mock.module("../../../db/repositories", () => ({
+  creditTransactionsRepository: {
+    findDebitByIdempotencyKey,
+  },
+  organizationsRepository: {
+    findById: findOrgById,
+  },
+}));
+
+mock.module("../credits", () => ({
+  creditsService: {
+    deductCredits,
+  },
+}));
+
+const { deductDeployCredits } = await import("../app-deploy-billing");
+
+describe("deductDeployCredits", () => {
+  const params = {
+    organizationId: "org_1",
+    userId: "user_1",
+    appId: "app_1",
+    deploymentId: "app_1:2026-05-19T15:00:00.000Z",
+  };
+
+  beforeEach(() => {
+    findDebitByIdempotencyKey.mockReset();
+    findOrgById.mockReset();
+    deductCredits.mockReset();
+    findDebitByIdempotencyKey.mockResolvedValue(undefined);
+    findOrgById.mockResolvedValue({ credit_balance: "4.50" });
+    deductCredits.mockResolvedValue({
+      success: true,
+      newBalance: 4.5,
+      transaction: { id: "tx_1" },
+    });
+  });
+
+  test("debits the deploy fee when no prior charge exists", async () => {
+    const result = await deductDeployCredits(params);
+
+    expect(result).toEqual({ deducted: true, newBalance: 4.5 });
+    expect(deductCredits).toHaveBeenCalledWith({
+      organizationId: "org_1",
+      amount: APP_DEPLOY_UPFRONT_CHARGE_USD,
+      description: "App deployment: app_1",
+      metadata: {
+        type: "app_deploy",
+        appId: "app_1",
+        deploymentId: params.deploymentId,
+        idempotencyKey: `app_deploy:${params.deploymentId}`,
+        userId: "user_1",
+      },
+    });
+  });
+
+  test("skips a second debit for the same deployment id", async () => {
+    findDebitByIdempotencyKey.mockResolvedValue({ id: "tx_existing" });
+
+    const result = await deductDeployCredits(params);
+
+    expect(result).toEqual({ deducted: false, newBalance: 4.5 });
+    expect(deductCredits).not.toHaveBeenCalled();
+  });
+
+  test("throws ApiError(402) when the atomic deduct fails", async () => {
+    deductCredits.mockResolvedValue({
+      success: false,
+      newBalance: 0.1,
+      transaction: null,
+    });
+
+    await expect(deductDeployCredits(params)).rejects.toBeInstanceOf(ApiError);
+    try {
+      await deductDeployCredits(params);
+    } catch (error) {
+      expect(error).toBeInstanceOf(ApiError);
+      expect((error as ApiError).status).toBe(402);
+      expect((error as ApiError).code).toBe("insufficient_credits");
+    }
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/app-deployments-helpers.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-deployments-helpers.test.ts
@@ -7,7 +7,14 @@
  */
 import { describe, expect, test } from "bun:test";
 import { ApiError } from "../../api/cloud-worker-errors";
-import { assertDeployable, deploymentIdFor, publicStatusFor } from "../app-deployments-helpers";
+import {
+  APP_DEPLOY_UPFRONT_CHARGE_USD,
+  assertDeployable,
+  assertSufficientDeployCredits,
+  deployCreditIdempotencyKey,
+  deploymentIdFor,
+  publicStatusFor,
+} from "../app-deployments-helpers";
 
 describe("publicStatusFor", () => {
   test("maps draft to DRAFT", () => {
@@ -57,5 +64,31 @@ describe("assertDeployable", () => {
     // retry from a fresh deploy after a deploy-side failure during upload,
     // so we don't reject it here.
     expect(() => assertDeployable({ deployment_status: "deploying" })).not.toThrow();
+  });
+});
+
+describe("deployCreditIdempotencyKey", () => {
+  test("scopes the charge to a single stamped deployment", () => {
+    expect(deployCreditIdempotencyKey("app_1:2026-05-19T15:00:00.000Z")).toBe(
+      "app_deploy:app_1:2026-05-19T15:00:00.000Z",
+    );
+  });
+});
+
+describe("assertSufficientDeployCredits", () => {
+  test("throws ApiError(402) when balance is below the deploy charge", () => {
+    expect(() => assertSufficientDeployCredits(0)).toThrow(ApiError);
+    try {
+      assertSufficientDeployCredits(APP_DEPLOY_UPFRONT_CHARGE_USD - 0.01);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).status).toBe(402);
+      expect((err as ApiError).code).toBe("insufficient_credits");
+    }
+  });
+
+  test("allows balance at or above the deploy charge", () => {
+    expect(() => assertSufficientDeployCredits(APP_DEPLOY_UPFRONT_CHARGE_USD)).not.toThrow();
+    expect(() => assertSufficientDeployCredits(100)).not.toThrow();
   });
 });

--- a/packages/cloud-shared/src/lib/services/__tests__/app-firewall-utils.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-firewall-utils.test.ts
@@ -28,6 +28,19 @@ describe("buildAppNodeNftablesRules", () => {
   test("omits the proxy allow when no proxy ip is given", () => {
     expect(buildAppNodeNftablesRules()).not.toContain("accept\n    }");
   });
+
+  test("allows the apps private subnet before the RFC1918 drop (tenant DB ambassador)", () => {
+    const rules = buildAppNodeNftablesRules({
+      egressProxyIp: "172.17.0.1",
+      allowedPrivateCidrs: ["10.30.0.0/16"],
+    });
+    const proxyIdx = rules.indexOf("ip daddr 172.17.0.1 accept");
+    const privateIdx = rules.indexOf("ip daddr 10.30.0.0/16 accept");
+    const rfc1918Idx = rules.indexOf("ip daddr 10.0.0.0/8 drop");
+    expect(proxyIdx).toBeGreaterThan(-1);
+    expect(privateIdx).toBeGreaterThan(proxyIdx);
+    expect(rfc1918Idx).toBeGreaterThan(privateIdx);
+  });
 });
 
 describe("buildHetznerAppFirewallRules", () => {

--- a/packages/cloud-shared/src/lib/services/__tests__/apps-ingress-client.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/apps-ingress-client.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildCaddyAdminLoadUrl,
+  buildIngressMapUrl,
+  buildRemoteIngressSyncShell,
+  countIngressHosts,
+  readAppsIngressSyncConfig,
+  resolveAppsIngressNodeHostnames,
+} from "../apps-ingress-client";
+
+describe("apps-ingress-client", () => {
+  test("buildIngressMapUrl targets the caddy format", () => {
+    expect(buildIngressMapUrl("https://api.elizacloud.ai/")).toBe(
+      "https://api.elizacloud.ai/api/v1/admin/containers/ingress-map?format=caddy",
+    );
+  });
+
+  test("buildCaddyAdminLoadUrl normalizes trailing slashes", () => {
+    expect(buildCaddyAdminLoadUrl("http://127.0.0.1:2019/")).toBe(
+      "http://127.0.0.1:2019/load",
+    );
+  });
+
+  test("countIngressHosts counts site blocks", () => {
+    const snippet = [
+      "abc123.apps.elizacloud.ai {",
+      "  reverse_proxy http://10.0.0.1:49001",
+      "}",
+      "",
+      "def456.apps.elizacloud.ai {",
+      "  reverse_proxy http://10.0.0.1:49002",
+      "}",
+    ].join("\n");
+    expect(countIngressHosts(snippet)).toBe(2);
+  });
+
+  test("readAppsIngressSyncConfig returns null when disabled", () => {
+    expect(readAppsIngressSyncConfig({ APPS_INGRESS_SYNC_ENABLED: "0" })).toBeNull();
+  });
+
+  test("readAppsIngressSyncConfig reads origin + key when enabled", () => {
+    const config = readAppsIngressSyncConfig({
+      APPS_INGRESS_SYNC_ENABLED: "1",
+      APPS_INGRESS_API_ORIGIN: "https://api.example.test",
+      APPS_INGRESS_ADMIN_API_KEY: "eliza_test",
+      APPS_CADDY_ADMIN_URL: "http://127.0.0.1:2019",
+    });
+    expect(config).toMatchObject({
+      apiOrigin: "https://api.example.test",
+      adminApiKey: "eliza_test",
+      caddyAdminUrl: "http://127.0.0.1:2019",
+    });
+  });
+
+  test("resolveAppsIngressNodeHostnames prefers APPS_INGRESS_NODE_HOSTS", () => {
+    const hosts = resolveAppsIngressNodeHostnames({
+      APPS_INGRESS_NODE_HOSTS: "10.30.1.20,10.30.1.21",
+      CONTAINERS_DOCKER_NODES: "ignored:1.2.3.4:8",
+    });
+    expect(hosts).toEqual(["10.30.1.20", "10.30.1.21"]);
+  });
+
+  test("buildRemoteIngressSyncShell writes snippet and reloads caddy", () => {
+    const shell = buildRemoteIngressSyncShell({
+      snippetBase64: "YWJj",
+      snippetPath: "/etc/caddy/apps.d/ingress-map.caddy",
+      caddyfilePath: "/etc/caddy/Caddyfile",
+      caddyAdminUrl: "http://127.0.0.1:2019",
+    });
+    expect(shell).toContain("base64 -d");
+    expect(shell).toContain("/etc/caddy/apps.d/ingress-map.caddy");
+    expect(shell).toContain("http://127.0.0.1:2019/load");
+    expect(shell).toContain("/etc/caddy/Caddyfile");
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/container-executor-deps.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/container-executor-deps.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { allocatePort } from "../docker-sandbox-utils";
+import {
+  APP_CONTAINER_HOST_PORT_MAX,
+  APP_CONTAINER_HOST_PORT_MIN,
+} from "../docker-port-allocation";
+
+describe("allocateAppContainerHostPort range", () => {
+  test("allocatePort stays within the app container host port band", () => {
+    const used = new Set([20000, 25000, 39999]);
+    const port = allocatePort(APP_CONTAINER_HOST_PORT_MIN, APP_CONTAINER_HOST_PORT_MAX, used);
+    expect(port).toBeGreaterThanOrEqual(APP_CONTAINER_HOST_PORT_MIN);
+    expect(port).toBeLessThan(APP_CONTAINER_HOST_PORT_MAX);
+    expect(used.has(port)).toBe(false);
+  });
+});
+
+describe("parseSeedDockerNodeEntry", () => {
+  test("parses nodeId:hostname:capacity entries", async () => {
+    const { parseSeedDockerNodeEntry } = await import("../container-executor-deps");
+    expect(parseSeedDockerNodeEntry("app-node-1:10.0.0.5:40")).toEqual({
+      nodeId: "app-node-1",
+      hostname: "10.0.0.5",
+    });
+  });
+
+  test("falls back to bare hostname tokens", async () => {
+    const { parseSeedDockerNodeEntry } = await import("../container-executor-deps");
+    expect(parseSeedDockerNodeEntry("worker.example.com")).toEqual({
+      nodeId: "worker.example.com",
+      hostname: "worker.example.com",
+    });
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/container-job-service.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/container-job-service.test.ts
@@ -122,15 +122,17 @@ describe("ContainerJobEnqueuer", () => {
     const { inserts, writer } = fakeWriter();
     const e = new ContainerJobEnqueuer(writer);
     await e.enqueueProvision({ containerId: "c1", organizationId: "o1", userId: "u1" });
+    await e.enqueueStop({ containerId: "c1", organizationId: "o1" });
     await e.enqueueDelete({ containerId: "c1", organizationId: "o1" });
     await e.enqueueUpgrade({ containerId: "c1", organizationId: "o1", image: "ghcr.io/x:2" });
 
     expect(inserts.map((i) => i.type)).toEqual([
       JOB_TYPES.CONTAINER_PROVISION,
+      JOB_TYPES.CONTAINER_STOP,
       JOB_TYPES.CONTAINER_DELETE,
       JOB_TYPES.CONTAINER_UPGRADE,
     ]);
     expect(inserts[0].data).toMatchObject({ containerId: "c1", userId: "u1" });
-    expect(inserts[2].data).toMatchObject({ image: "ghcr.io/x:2" });
+    expect(inserts[3].data).toMatchObject({ image: "ghcr.io/x:2" });
   });
 });

--- a/packages/cloud-shared/src/lib/services/__tests__/container-job-types.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/container-job-types.test.ts
@@ -8,6 +8,7 @@ import { JOB_TYPES } from "../provisioning-job-types";
 
 const CONTAINER_TYPES = {
   CONTAINER_PROVISION: "container_provision",
+  CONTAINER_STOP: "container_stop",
   CONTAINER_DELETE: "container_delete",
   CONTAINER_RESTART: "container_restart",
   CONTAINER_UPGRADE: "container_upgrade",

--- a/packages/cloud-shared/src/lib/services/__tests__/provisioning-job-types.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/provisioning-job-types.test.ts
@@ -28,9 +28,11 @@ describe("JOB_TYPES", () => {
     expect(JOB_TYPES.AGENT_WAKE).toBe("agent_wake");
     // Apps lane (Product 2): the Worker enqueues APP_DEPLOY; the daemon runs it.
     expect(JOB_TYPES.APP_DEPLOY).toBe("app_deploy");
+    expect(JOB_TYPES.CONTAINER_STOP).toBe("container_stop");
+    expect(JOB_TYPES.TENANT_DB_DEPROVISION).toBe("tenant_db_deprovision");
     // Lock the size so a new entry without a matching assertion above
     // fails CI instead of being silently under-covered by tests below.
-    expect(Object.keys(JOB_TYPES)).toHaveLength(17);
+    expect(Object.keys(JOB_TYPES)).toHaveLength(19);
   });
 
   test("wire values are unique (no two symbols share a string)", () => {

--- a/packages/cloud-shared/src/lib/services/__tests__/tenant-db-deprovision-job-service.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/tenant-db-deprovision-job-service.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import {
+  enqueueTenantDbDeprovision,
+  readTenantDbDeprovisionJobData,
+} from "../tenant-db-deprovision-job-service";
+import type { ContainerJobInsert, ContainerJobsWriter } from "../container-job-service";
+import { JOB_TYPES } from "../provisioning-job-types";
+
+describe("readTenantDbDeprovisionJobData", () => {
+  test("extracts appId and clusterId", () => {
+    expect(
+      readTenantDbDeprovisionJobData({ data: { appId: "app-1", clusterId: "cluster-1" } }),
+    ).toEqual({ appId: "app-1", clusterId: "cluster-1" });
+  });
+
+  test("throws when appId or clusterId missing", () => {
+    expect(() => readTenantDbDeprovisionJobData({ data: {} })).toThrow(/missing data.appId/);
+    expect(() => readTenantDbDeprovisionJobData({ data: { appId: "a" } })).toThrow(
+      /missing data.clusterId/,
+    );
+  });
+});
+
+describe("enqueueTenantDbDeprovision", () => {
+  test("inserts a TENANT_DB_DEPROVISION job (pg-free writer)", async () => {
+    const inserted: ContainerJobInsert[] = [];
+    const writer: ContainerJobsWriter = {
+      insertJob: async (j) => {
+        inserted.push(j);
+        return { id: "job-1" };
+      },
+    };
+    const r = await enqueueTenantDbDeprovision(writer, {
+      appId: "app-1",
+      clusterId: "cluster-1",
+      organizationId: "org-1",
+    });
+    expect(r.id).toBe("job-1");
+    expect(inserted[0]).toEqual({
+      type: JOB_TYPES.TENANT_DB_DEPROVISION,
+      organizationId: "org-1",
+      data: { appId: "app-1", clusterId: "cluster-1" },
+    });
+  });
+});

--- a/packages/cloud-shared/src/lib/services/active-billing.ts
+++ b/packages/cloud-shared/src/lib/services/active-billing.ts
@@ -247,6 +247,7 @@ class ActiveBillingService {
           container.id,
           organizationId,
           mode,
+          triggerEnv,
         );
         const unitPrice = calculateDailyContainerCost({
           desiredCount: container.desired_count,
@@ -449,25 +450,29 @@ async function cancelContainerInfrastructure(
   containerId: string,
   organizationId: string,
   mode: "stop" | "delete",
+  triggerEnv?: AppEnv["Bindings"],
 ): Promise<InfrastructureCancellationAction> {
   try {
-    const { getHetznerContainersClient } = await import("./containers/hetzner-client");
-    const client = getHetznerContainersClient();
+    // SSH/docker can't run inline from Cloudflare Workers. Enqueue the
+    // appropriate CONTAINER_* job; the provisioning-worker daemon executes it.
+    const { ContainerJobEnqueuer } = await import("./container-job-service");
+    const { containerJobsWriter } = await import("./container-jobs-writer");
+    const enqueuer = new ContainerJobEnqueuer(containerJobsWriter);
 
     if (mode === "delete") {
-      await client.deleteContainer(containerId, organizationId, { purgeVolume: false });
-      return {
-        attempted: true,
-        status: "deleted",
-        message: "Container runtime and control-plane row were deleted.",
-      };
+      await enqueuer.enqueueDelete({ containerId, organizationId });
+    } else {
+      await enqueuer.enqueueStop({ containerId, organizationId });
     }
+    void provisioningJobService.triggerImmediate(triggerEnv).catch(() => {});
 
-    await client.stopContainer(containerId, organizationId, { purgeVolume: false });
     return {
       attempted: true,
-      status: "stopped",
-      message: "Container runtime was stopped and removed from the Docker node.",
+      status: mode === "delete" ? "deleted" : "queued",
+      message:
+        mode === "delete"
+          ? "Container deletion queued; the orchestrator will tear down runtime and remove the control-plane row."
+          : "Container stop queued; the orchestrator will shut down the Docker runtime while preserving the control-plane row.",
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/packages/cloud-shared/src/lib/services/app-container-provider.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-provider.ts
@@ -64,6 +64,8 @@ export interface ProvisionedAppContainer {
   network: string;
   /** The node the container runs on (for ingress routing + placement). */
   nodeHost: string;
+  /** docker_nodes.node_id the container was placed on. */
+  nodeId?: string;
 }
 
 function defaultExtractContainerId(stdout: string): string {
@@ -155,17 +157,17 @@ export class AppContainerProvider {
     return { containerId, hostPort, network, nodeHost: this.deps.nodeHost ?? "" };
   }
 
-  async delete(containerName: string): Promise<void> {
+  async delete(containerName: string, _nodeId?: string | null): Promise<void> {
     await this.deps.ssh.exec(`docker rm -f ${shellQuote(containerName)}`);
     // Tear down the per-app DB ambassador too (best-effort; no-op if absent).
     await this.deps.ssh.exec(buildRemoveAmbassadorCmdForContainer(containerName));
   }
 
-  async restart(containerName: string): Promise<void> {
+  async restart(containerName: string, _nodeId?: string | null): Promise<void> {
     await this.deps.ssh.exec(`docker restart ${shellQuote(containerName)}`);
   }
 
-  async logs(containerName: string, tail = 200): Promise<string> {
+  async logs(containerName: string, tail = 200, _nodeId?: string | null): Promise<string> {
     return this.deps.ssh.exec(`docker logs --tail ${tail} ${shellQuote(containerName)}`);
   }
 }

--- a/packages/cloud-shared/src/lib/services/app-container-store.ts
+++ b/packages/cloud-shared/src/lib/services/app-container-store.ts
@@ -39,11 +39,13 @@
 
 import { eq } from "drizzle-orm";
 import { dbRead } from "../../db/helpers";
+import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import { containersRepository } from "../../db/repositories/containers";
 import { containers } from "../../db/schemas/containers";
 import { logger } from "../utils/logger";
 import { deriveAppPublicUrl } from "./app-url";
 import type { AppContainerRow, AppContainerStore } from "./container-job-executors";
+import type { HetznerContainerMetadata } from "./containers/hetzner-client/types";
 
 /** The `containers` columns the executor's view projects from (structural). */
 export interface ProjectableContainerRow {
@@ -56,6 +58,7 @@ export interface ProjectableContainerRow {
   user_id: string;
   environment_vars: Record<string, string> | null;
   metadata: Record<string, unknown> | null;
+  node_id: string | null;
 }
 
 /**
@@ -77,6 +80,7 @@ export function mapContainerRowToAppContainerRow(row: ProjectableContainerRow): 
     organizationId: row.organization_id,
     userId: row.user_id,
     environmentVars: row.environment_vars ?? undefined,
+    nodeId: row.node_id,
   };
 }
 
@@ -101,6 +105,27 @@ export function mergeHostPlacementMetadata(
   };
 }
 
+/** Merge hetzner-docker metadata so billing cancel + ingress-map can stop/route app containers. */
+export function mergeAppHetznerMetadata(
+  existing: Record<string, unknown> | null | undefined,
+  placement: { hostContainerId: string; hostPort: number; network: string },
+  hetzner: Pick<
+    HetznerContainerMetadata,
+    "nodeId" | "hostname" | "containerName" | "hostPort" | "containerPort" | "image"
+  >,
+): Record<string, unknown> {
+  return {
+    ...mergeHostPlacementMetadata(existing, placement),
+    provider: "hetzner-docker" as const,
+    nodeId: hetzner.nodeId,
+    hostname: hetzner.hostname,
+    containerName: hetzner.containerName,
+    hostPort: hetzner.hostPort,
+    containerPort: hetzner.containerPort,
+    image: hetzner.image,
+  };
+}
+
 /** Read/write seam impl over `containersRepository` + a direct id-scoped read. */
 export class ContainerRepoAppContainerStore implements AppContainerStore {
   async getById(containerId: string): Promise<AppContainerRow | null> {
@@ -118,10 +143,16 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
 
   async markRunning(
     containerId: string,
-    info: { hostContainerId: string; hostPort: number; network: string; nodeHost?: string },
+    info: { hostContainerId: string; hostPort: number; network: string; nodeHost?: string; nodeId?: string },
   ): Promise<void> {
     const [row] = await dbRead
-      .select({ organization_id: containers.organization_id, metadata: containers.metadata })
+      .select({
+        organization_id: containers.organization_id,
+        metadata: containers.metadata,
+        name: containers.name,
+        image_tag: containers.image_tag,
+        port: containers.port,
+      })
       .from(containers)
       .where(eq(containers.id, containerId))
       .limit(1);
@@ -130,9 +161,26 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
       return;
     }
 
-    // Merge host placement into metadata (no dedicated columns on the 2AM
-    // schema), preserving anything already there (e.g. appId).
-    const nextMetadata = mergeHostPlacementMetadata(row.metadata, info);
+    let nextMetadata = mergeHostPlacementMetadata(row.metadata, info);
+    if (info.nodeId) {
+      const node = await dockerNodesRepository.findByNodeId(info.nodeId);
+      const hostname = node?.hostname;
+      if (hostname) {
+        nextMetadata = mergeAppHetznerMetadata(row.metadata, info, {
+          nodeId: info.nodeId,
+          hostname,
+          containerName: row.name,
+          hostPort: info.hostPort,
+          containerPort: row.port,
+          image: row.image_tag ?? "",
+        });
+      } else {
+        logger.warn("[AppContainerStore] markRunning: node hostname unknown; hetzner metadata skipped", {
+          containerId,
+          nodeId: info.nodeId,
+        });
+      }
+    }
 
     // Stamp the app's public URL via the SAME ingress hostname derivation the
     // agent path uses (reused, not rebuilt) so the running app is reachable at
@@ -145,6 +193,7 @@ export class ContainerRepoAppContainerStore implements AppContainerStore {
     await containersRepository.update(containerId, row.organization_id, {
       metadata: nextMetadata,
       last_deployed_at: new Date(),
+      ...(info.nodeId ? { node_id: info.nodeId } : {}),
       ...(endpoint ? { public_hostname: endpoint.hostname, load_balancer_url: endpoint.url } : {}),
     });
   }

--- a/packages/cloud-shared/src/lib/services/app-deploy-billing.ts
+++ b/packages/cloud-shared/src/lib/services/app-deploy-billing.ts
@@ -1,0 +1,77 @@
+/**
+ * App deploy upfront billing — debits CONTAINER_PRICING.DEPLOYMENT when a
+ * deploy is queued.
+ */
+
+import {
+  creditTransactionsRepository,
+  organizationsRepository,
+} from "../../db/repositories";
+import { ApiError } from "../api/cloud-worker-errors";
+import {
+  APP_DEPLOY_UPFRONT_CHARGE_USD,
+  deployCreditIdempotencyKey,
+} from "./app-deployments-helpers";
+import { creditsService } from "./credits";
+
+export interface DeductDeployCreditsParams {
+  organizationId: string;
+  userId: string;
+  appId: string;
+  deploymentId: string;
+}
+
+export interface DeductDeployCreditsResult {
+  deducted: boolean;
+  newBalance: number;
+}
+
+/**
+ * Debit the one-time deploy fee for a stamped deployment. Idempotent per
+ * `deploymentId` so a retried queue after a partial failure is not double-charged.
+ */
+export async function deductDeployCredits(
+  params: DeductDeployCreditsParams,
+): Promise<DeductDeployCreditsResult> {
+  const idempotencyKey = deployCreditIdempotencyKey(params.deploymentId);
+
+  const existing = await creditTransactionsRepository.findDebitByIdempotencyKey(
+    params.organizationId,
+    idempotencyKey,
+  );
+  if (existing) {
+    const org = await organizationsRepository.findById(params.organizationId);
+    return {
+      deducted: false,
+      newBalance: org ? Number(org.credit_balance) : 0,
+    };
+  }
+
+  const result = await creditsService.deductCredits({
+    organizationId: params.organizationId,
+    amount: APP_DEPLOY_UPFRONT_CHARGE_USD,
+    description: `App deployment: ${params.appId}`,
+    metadata: {
+      type: "app_deploy",
+      appId: params.appId,
+      deploymentId: params.deploymentId,
+      idempotencyKey,
+      userId: params.userId,
+    },
+  });
+
+  if (!result.success) {
+    const deficit = Math.max(APP_DEPLOY_UPFRONT_CHARGE_USD - result.newBalance, 0.01);
+    throw new ApiError(
+      402,
+      "insufficient_credits",
+      `Insufficient credits to deploy. Required: $${APP_DEPLOY_UPFRONT_CHARGE_USD.toFixed(2)}, ` +
+        `available: $${result.newBalance.toFixed(2)}. Add at least $${deficit.toFixed(2)} at /dashboard/billing.`,
+    );
+  }
+
+  return {
+    deducted: true,
+    newBalance: result.newBalance,
+  };
+}

--- a/packages/cloud-shared/src/lib/services/app-deployments-helpers.ts
+++ b/packages/cloud-shared/src/lib/services/app-deployments-helpers.ts
@@ -7,6 +7,7 @@
  */
 
 import type { AppDeploymentStatus } from "../../db/schemas/apps";
+import { CONTAINER_PRICING } from "../constants/pricing";
 import { ApiError } from "../api/cloud-worker-errors";
 
 export type { AppDeploymentStatus };
@@ -56,6 +57,30 @@ export function assertDeployable(app: { deployment_status: AppDeploymentStatus }
       409,
       "session_not_ready",
       "A deployment is already in progress for this app",
+    );
+  }
+}
+
+/** Upfront deploy charge surfaced to callers before a build is queued. */
+export const APP_DEPLOY_UPFRONT_CHARGE_USD = CONTAINER_PRICING.DEPLOYMENT;
+
+/** Idempotency key for a single queued deploy (`<appId>:<startedAt iso>`). */
+export function deployCreditIdempotencyKey(deploymentId: string): string {
+  return `app_deploy:${deploymentId}`;
+}
+
+/**
+ * Throws 402 when the org cannot cover the one-time deploy charge. The actual
+ * debit happens in {@link deductDeployCredits} once the deploy is stamped.
+ */
+export function assertSufficientDeployCredits(creditBalanceUsd: number): void {
+  if (creditBalanceUsd < APP_DEPLOY_UPFRONT_CHARGE_USD) {
+    const deficit = Math.max(APP_DEPLOY_UPFRONT_CHARGE_USD - creditBalanceUsd, 0.01);
+    throw new ApiError(
+      402,
+      "insufficient_credits",
+      `Insufficient credits to deploy. Required: $${APP_DEPLOY_UPFRONT_CHARGE_USD.toFixed(2)}, ` +
+        `available: $${creditBalanceUsd.toFixed(2)}. Add at least $${deficit.toFixed(2)} at /dashboard/billing.`,
     );
   }
 }

--- a/packages/cloud-shared/src/lib/services/app-deployments.ts
+++ b/packages/cloud-shared/src/lib/services/app-deployments.ts
@@ -10,10 +10,13 @@
  * When a real build/upload service (Vercel or otherwise) lands, this service
  * becomes the integration boundary — callers will not need to change.
  */
+import { organizationsRepository } from "../../db/repositories/organizations";
 import { logger } from "../utils/logger";
+import { deductDeployCredits } from "./app-deploy-billing";
 import type { AppDeployRunner } from "./app-deploy-orchestrator";
 import {
   assertDeployable,
+  assertSufficientDeployCredits,
   type DeploymentStatus,
   deploymentIdFor,
   publicStatusFor,
@@ -115,6 +118,12 @@ export class AppDeploymentsService {
     }
     assertDeployable(existing);
 
+    const org = await organizationsRepository.findById(input.organizationId);
+    if (!org) {
+      throw new Error("Organization not found");
+    }
+    assertSufficientDeployCredits(Number(org.credit_balance));
+
     const startedAt = new Date();
     const updated = await appsService.update(input.appId, {
       deployment_status: "building",
@@ -122,6 +131,19 @@ export class AppDeploymentsService {
     });
     if (!updated) {
       throw new Error("Failed to record deployment start");
+    }
+
+    const deploymentId = deploymentIdFor(updated);
+    try {
+      await deductDeployCredits({
+        organizationId: input.organizationId,
+        userId: input.userId,
+        appId: input.appId,
+        deploymentId,
+      });
+    } catch (error) {
+      await appsService.update(input.appId, { deployment_status: "failed" });
+      throw error;
     }
 
     // Apps lane (Product 2): trigger the real isolated deploy.
@@ -154,6 +176,7 @@ export class AppDeploymentsService {
       appId: input.appId,
       organizationId: input.organizationId,
       userId: input.userId,
+      deploymentId,
       repoUrl: input.repoUrl ?? updated.github_repo ?? null,
       ref: input.ref ?? null,
       dockerfile: input.dockerfile ?? null,

--- a/packages/cloud-shared/src/lib/services/app-firewall-utils.ts
+++ b/packages/cloud-shared/src/lib/services/app-firewall-utils.ts
@@ -21,19 +21,25 @@ export const RFC1918_RANGES = ["10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"] 
  * return traffic and (optionally) the egress proxy. Belt-and-suspenders behind
  * the `--internal` network.
  */
-export function buildAppNodeNftablesRules(opts: { egressProxyIp?: string } = {}): string {
+export function buildAppNodeNftablesRules(
+  opts: { egressProxyIp?: string; allowedPrivateCidrs?: readonly string[] } = {},
+): string {
+  const allowProxy = opts.egressProxyIp ? [`        ip daddr ${opts.egressProxyIp} accept`] : [];
+  const allowPrivate = (opts.allowedPrivateCidrs ?? []).map(
+    (cidr) => `        ip daddr ${cidr} accept`,
+  );
   const blocks = [
     `        ip daddr ${CLOUD_METADATA_IP} drop`,
     ...RFC1918_RANGES.map((r) => `        ip daddr ${r} drop`),
   ];
-  const allowProxy = opts.egressProxyIp ? [`        ip daddr ${opts.egressProxyIp} accept`] : [];
   return [
     "table inet app_isolation {",
     "    chain forward {",
     "        type filter hook forward priority 0; policy drop;",
     "        ct state established,related accept",
-    ...blocks,
     ...allowProxy,
+    ...allowPrivate,
+    ...blocks,
     "    }",
     "}",
   ].join("\n");

--- a/packages/cloud-shared/src/lib/services/app-network-utils.ts
+++ b/packages/cloud-shared/src/lib/services/app-network-utils.ts
@@ -18,6 +18,15 @@
 
 import { shellQuote } from "./docker-sandbox-utils";
 
+/** Default egress allowlist for untrusted app containers (matches cloud-init). */
+export const DEFAULT_APP_EGRESS_ALLOWED_HOSTS = [
+  ".ghcr.io",
+  ".githubusercontent.com",
+] as const;
+
+/** Default docker bridge gateway — egress proxy reachable from `--internal` app nets. */
+export const DEFAULT_DOCKER_BRIDGE_GATEWAY = "172.17.0.1";
+
 export const APP_NETWORK_DEFAULTS = {
   /** Cap on processes to blunt fork bombs from untrusted images. */
   pidsLimit: 512,
@@ -75,7 +84,9 @@ export function buildAppEgressEnv(egressProxyUrl: string): Record<string, string
  * destination hosts. Anything not on the allowlist is refused, so a compromised
  * app can't exfiltrate to or pivot through arbitrary hosts.
  */
-export function buildSquidAllowlistConf(allowedHosts: readonly string[]): string {
+export function buildSquidAllowlistConf(
+  allowedHosts: readonly string[] = DEFAULT_APP_EGRESS_ALLOWED_HOSTS,
+): string {
   const safe = allowedHosts.filter((h) => /^[A-Za-z0-9.*_-]+$/.test(h));
   const acls = safe.map((h) => `acl allowed_dst dstdomain ${h}`).join("\n");
   return [

--- a/packages/cloud-shared/src/lib/services/apps-ingress-client.ts
+++ b/packages/cloud-shared/src/lib/services/apps-ingress-client.ts
@@ -1,0 +1,199 @@
+import { Buffer } from "node:buffer";
+
+/**
+ * Apps ingress-map client (Product 2) — fetches the live `host → upstream` map
+ * from cloud-api and applies it to Caddy on app worker nodes.
+ *
+ * Operators (or the provisioning-worker daemon) poll
+ * `GET /api/v1/admin/containers/ingress-map?format=caddy` and write the snippet
+ * to `/etc/caddy/apps.d/ingress-map.caddy`, then reload Caddy via
+ * `APPS_CADDY_ADMIN_URL` (Caddy admin `/load` with the parent Caddyfile).
+ *
+ * NODE-ONLY: the SSH apply path is wired from the provisioning-worker daemon,
+ * never from the cloud-api Worker.
+ */
+
+import { containersEnv } from "../config/containers-env";
+import { logger } from "../utils/logger";
+import { shellQuote } from "./docker-sandbox-utils";
+
+function parseSeedNodeHostname(entry: string): string | null {
+  const trimmed = entry.trim();
+  if (!trimmed) return null;
+  const parts = trimmed.split(":");
+  if (parts.length >= 2) {
+    const hostname = parts[1]?.trim();
+    if (hostname) return hostname;
+  }
+  return parts[0]?.trim() ?? null;
+}
+
+export const DEFAULT_APPS_INGRESS_SNIPPET_PATH = "/etc/caddy/apps.d/ingress-map.caddy";
+export const DEFAULT_APPS_CADDYFILE_PATH = "/etc/caddy/Caddyfile";
+export const DEFAULT_APPS_CADDY_ADMIN_URL = "http://127.0.0.1:2019";
+
+export interface AppsIngressSyncConfig {
+  /** Cloud API origin, e.g. `https://api.elizacloud.ai` (no trailing slash). */
+  apiOrigin: string;
+  /** Super-admin API key or session token for the ingress-map route. */
+  adminApiKey: string;
+  /** Caddy admin base URL on the app node (loopback). */
+  caddyAdminUrl: string;
+  snippetPath: string;
+  caddyfilePath: string;
+}
+
+export interface AppsIngressFetchResult {
+  body: string;
+  entryCount: number;
+}
+
+export function buildIngressMapUrl(apiOrigin: string): string {
+  const base = apiOrigin.replace(/\/+$/, "");
+  return `${base}/api/v1/admin/containers/ingress-map?format=caddy`;
+}
+
+export function buildCaddyAdminLoadUrl(caddyAdminUrl: string): string {
+  return `${caddyAdminUrl.replace(/\/+$/, "")}/load`;
+}
+
+export function countIngressHosts(snippet: string): number {
+  const matches = snippet.match(/^\S+\.\S+ \{/gm);
+  return matches?.length ?? 0;
+}
+
+/** Read env for the ingress sync cycle. Returns null when not configured. */
+export function readAppsIngressSyncConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): AppsIngressSyncConfig | null {
+  if (env.APPS_INGRESS_SYNC_ENABLED !== "1") return null;
+  const apiOrigin = env.APPS_INGRESS_API_ORIGIN?.trim() || env.ELIZA_CLOUD_API_ORIGIN?.trim();
+  const adminApiKey =
+    env.APPS_INGRESS_ADMIN_API_KEY?.trim() || env.ELIZAOS_CLOUD_API_KEY?.trim();
+  if (!apiOrigin || !adminApiKey) return null;
+  return {
+    apiOrigin,
+    adminApiKey,
+    caddyAdminUrl: env.APPS_CADDY_ADMIN_URL?.trim() || DEFAULT_APPS_CADDY_ADMIN_URL,
+    snippetPath: env.APPS_INGRESS_SNIPPET_PATH?.trim() || DEFAULT_APPS_INGRESS_SNIPPET_PATH,
+    caddyfilePath: env.APPS_CADDYFILE_PATH?.trim() || DEFAULT_APPS_CADDYFILE_PATH,
+  };
+}
+
+/** Hostnames of app worker nodes that should receive ingress-map snippets. */
+export function resolveAppsIngressNodeHostnames(
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  const explicit = env.APPS_INGRESS_NODE_HOSTS?.split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+  if (explicit && explicit.length > 0) return explicit;
+
+  const seed = containersEnv.seedNodes();
+  if (!seed) return [];
+  const hostnames: string[] = [];
+  for (const entry of seed.split(",")) {
+    const hostname = parseSeedNodeHostname(entry);
+    if (hostname) hostnames.push(hostname);
+  }
+  return hostnames;
+}
+
+export async function fetchIngressMapCaddySnippet(
+  config: AppsIngressSyncConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<AppsIngressFetchResult> {
+  const url = buildIngressMapUrl(config.apiOrigin);
+  const response = await fetchImpl(url, {
+    headers: {
+      Authorization: `Bearer ${config.adminApiKey}`,
+      Accept: "text/plain",
+    },
+  });
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new Error(
+      `ingress-map fetch failed: HTTP ${response.status}${detail ? ` — ${detail.slice(0, 200)}` : ""}`,
+    );
+  }
+  const body = await response.text();
+  return { body, entryCount: countIngressHosts(body) };
+}
+
+/**
+ * Remote shell that writes the snippet and reloads Caddy via the admin API.
+ * Snippet is base64-encoded to survive SSH quoting.
+ */
+export function buildRemoteIngressSyncShell(opts: {
+  snippetBase64: string;
+  snippetPath: string;
+  caddyfilePath: string;
+  caddyAdminUrl: string;
+}): string {
+  const snippetPath = shellQuote(opts.snippetPath);
+  const caddyfilePath = shellQuote(opts.caddyfilePath);
+  const loadUrl = shellQuote(buildCaddyAdminLoadUrl(opts.caddyAdminUrl));
+  const b64 = shellQuote(opts.snippetBase64);
+  return [
+    `echo ${b64} | base64 -d | sudo tee ${snippetPath} > /dev/null`,
+    `curl -sf -X POST ${loadUrl} -H 'Content-Type: text/caddyfile' --data-binary @${caddyfilePath}`,
+  ].join(" && ");
+}
+
+export interface AppsIngressNodeSyncResult {
+  hostname: string;
+  changed: boolean;
+  entryCount: number;
+  error?: string;
+}
+
+export interface AppsIngressSyncSummary {
+  fetchedEntries: number;
+  nodes: AppsIngressNodeSyncResult[];
+}
+
+export interface AppsIngressSshClient {
+  exec(command: string, timeoutMs?: number): Promise<string>;
+}
+
+/**
+ * Fetch the ingress map once and push it to every configured app node over SSH.
+ */
+export async function syncAppsIngressToNodes(opts: {
+  config: AppsIngressSyncConfig;
+  hostnames: readonly string[];
+  sshForHost: (hostname: string) => AppsIngressSshClient;
+  fetchImpl?: typeof fetch;
+  previousSnippetByHost?: Map<string, string>;
+}): Promise<AppsIngressSyncSummary> {
+  const { body, entryCount } = await fetchIngressMapCaddySnippet(
+    opts.config,
+    opts.fetchImpl,
+  );
+  const snippetBase64 = Buffer.from(body, "utf8").toString("base64");
+  const shell = buildRemoteIngressSyncShell({
+    snippetBase64,
+    snippetPath: opts.config.snippetPath,
+    caddyfilePath: opts.config.caddyfilePath,
+    caddyAdminUrl: opts.config.caddyAdminUrl,
+  });
+
+  const nodes: AppsIngressNodeSyncResult[] = [];
+  for (const hostname of opts.hostnames) {
+    const previous = opts.previousSnippetByHost?.get(hostname);
+    const changed = previous !== body;
+    try {
+      if (changed) {
+        await opts.sshForHost(hostname).exec(shell, 30_000);
+        opts.previousSnippetByHost?.set(hostname, body);
+      }
+      nodes.push({ hostname, changed, entryCount });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn("[apps-ingress-sync] node sync failed", { hostname, error: message });
+      nodes.push({ hostname, changed: false, entryCount, error: message });
+    }
+  }
+
+  return { fetchedEntries: entryCount, nodes };
+}

--- a/packages/cloud-shared/src/lib/services/apps.ts
+++ b/packages/cloud-shared/src/lib/services/apps.ts
@@ -305,8 +305,17 @@ export class AppsService {
     // no-ops for shared DB apps or apps without a provisioned project.
     if (app) {
       try {
-        const { userDatabaseService } = await import("./user-database");
-        await userDatabaseService.cleanupDatabase(id);
+        const { UserDatabaseService, userDatabaseService } = await import("./user-database");
+        let databaseService = userDatabaseService;
+        try {
+          const { makeTenantDbProvisioning } = await import(
+            "./tenant-db/make-tenant-db-provisioning"
+          );
+          databaseService = new UserDatabaseService(makeTenantDbProvisioning());
+        } catch {
+          // Worker runtime — singleton falls back to cluster-slot release only.
+        }
+        await databaseService.cleanupDatabase(id);
         logger.info("Cleaned up user database for app", { appId: id });
       } catch (error) {
         // Log but don't fail deletion - database might already be gone

--- a/packages/cloud-shared/src/lib/services/container-executor-deps.ts
+++ b/packages/cloud-shared/src/lib/services/container-executor-deps.ts
@@ -17,62 +17,106 @@
  */
 
 import { Buffer } from "node:buffer";
+import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
-import { AppContainerProvider, type AppContainerSsh } from "./app-container-provider";
+import {
+  AppContainerProvider,
+  type AppContainerProviderDeps,
+  type AppContainerSsh,
+  type ProvisionAppContainerParams,
+  type ProvisionedAppContainer,
+} from "./app-container-provider";
 import { appContainerStore } from "./app-container-store";
 import { addAppRoute, removeAppRoute } from "./apps-ingress-provisioner";
 import type { ContainerExecutorDeps } from "./container-job-executors";
+import { allocateAppContainerHostPort } from "./docker-port-allocation";
+import { dockerNodeManager } from "./docker-node-manager";
 import { DockerSSHClient } from "./docker-ssh";
 import { listVerifiedAppOrigins } from "./managed-domains";
+
+export interface ParsedSeedDockerNode {
+  nodeId: string;
+  hostname: string;
+}
 
 /** True when the apps-container provision backend has enough env to run. */
 export function appsContainersEnabled(): boolean {
   if (process.env.APPS_CONTAINERS_ENABLED === "0") return false;
-  const hasNodes = Boolean(selectNodeHostOrNull());
+  const hasSeed = Boolean(containersEnv.seedNodes());
   const hasKey = Boolean(containersEnv.sshKey() || containersEnv.sshKeyPath());
-  return hasNodes && hasKey;
+  return hasSeed && hasKey;
 }
 
-/**
- * Pick a target docker node host. Reads the `CONTAINERS_DOCKER_NODES` seed list
- * (`nodeId:hostname:capacity,...`) and takes the first entry's hostname. This is
- * the seed-only fallback; the production daemon should prefer
- * `dockerNodeManager`'s registered-node selection (least-loaded / autoscaled) —
- * see the wiring note. Returns null when nothing is configured.
- */
-function selectNodeHostOrNull(): string | null {
+/** Parse `nodeId:hostname:capacity` from the CONTAINERS_DOCKER_NODES seed list. */
+export function parseSeedDockerNodeEntry(entry: string): ParsedSeedDockerNode | null {
+  const trimmed = entry.trim();
+  if (!trimmed) return null;
+  const parts = trimmed.split(":");
+  if (parts.length >= 2) {
+    const nodeId = parts[0]?.trim();
+    const hostname = parts[1]?.trim();
+    if (nodeId && hostname) return { nodeId, hostname };
+  }
+  const host = parts[0]?.trim();
+  if (host) return { nodeId: host, hostname: host };
+  return null;
+}
+
+export function parseFirstSeedNodeOrNull(): ParsedSeedDockerNode | null {
   const seed = containersEnv.seedNodes();
   if (!seed) return null;
   const first = seed.split(",")[0]?.trim();
   if (!first) return null;
-  // Format: nodeId:hostname:capacity. Hostname is the 2nd colon field; fall back
-  // to the whole token if it's a bare hostname.
-  const parts = first.split(":");
-  const host = parts.length >= 2 ? parts[1]?.trim() : parts[0]?.trim();
-  return host || null;
+  return parseSeedDockerNodeEntry(first);
 }
 
-function selectNodeHost(): string {
-  const host = selectNodeHostOrNull();
-  if (!host) {
-    throw new Error(
-      "No CONTAINERS_DOCKER_NODES configured — cannot provision app container (set the docker node host)",
-    );
+/** Prefer the registered docker_nodes pool; fall back to the seed list. */
+export async function resolveAppContainerNode(): Promise<ParsedSeedDockerNode> {
+  const managed = await dockerNodeManager.getAvailableNode();
+  if (managed) {
+    return { nodeId: managed.node_id, hostname: managed.hostname };
   }
-  return host;
+  const seeded = parseFirstSeedNodeOrNull();
+  if (seeded) return seeded;
+  throw new Error(
+    "No docker node capacity available — register nodes or set CONTAINERS_DOCKER_NODES",
+  );
 }
 
-/** A pooled SSH connection to the chosen node, exposing the `AppContainerSsh` seam. */
-function makeNodeSsh(): AppContainerSsh {
-  const host = selectNodeHost();
+async function resolveNodePlacement(
+  nodeId?: string | null,
+): Promise<ParsedSeedDockerNode> {
+  if (nodeId) {
+    const configured = await dockerNodeManager.getNodeConfig(nodeId);
+    if (configured) {
+      return { nodeId: configured.node_id, hostname: configured.hostname };
+    }
+    const seeded = parseFirstSeedNodeOrNull();
+    if (seeded?.nodeId === nodeId) return seeded;
+    throw new Error(`Docker node ${nodeId} is not registered`);
+  }
+  return resolveAppContainerNode();
+}
+
+function buildProviderForNode(
+  node: ParsedSeedDockerNode,
+  shared: Omit<AppContainerProviderDeps, "ssh" | "allocateHostPort">,
+): AppContainerProvider {
+  return new AppContainerProvider({
+    ...shared,
+    ssh: makeNodeSsh(node.hostname),
+    allocateHostPort: () => allocateAppContainerHostPort(node.nodeId),
+  });
+}
+
+function makeNodeSsh(hostname: string): AppContainerSsh {
   const keyB64 = containersEnv.sshKey();
   const privateKey = keyB64 ? Buffer.from(keyB64, "base64") : undefined;
-  // DockerSSHClient.exec(command, timeoutMs?) IS the AppContainerSsh shape.
   const client = privateKey
-    ? new DockerSSHClient({ hostname: host, username: containersEnv.sshUser(), privateKey })
+    ? new DockerSSHClient({ hostname, username: containersEnv.sshUser(), privateKey })
     : new DockerSSHClient({
-        hostname: host,
+        hostname,
         username: containersEnv.sshUser(),
         privateKeyPath: containersEnv.sshKeyPath(),
       });
@@ -80,15 +124,59 @@ function makeNodeSsh(): AppContainerSsh {
 }
 
 /**
- * Allocate an external host port for the container's app port. Ephemeral-range
- * picker; the deploy density is low (one container per app) so a random pick
- * from the high range is collision-safe enough for now. A node-local registry /
- * `docker port` probe is the hardening follow-up.
+ * Provider that picks the least-loaded docker node per provision, allocates a
+ * collision-safe host port on that node, and records `nodeId` for ingress/LB.
  */
-async function allocateHostPort(): Promise<number> {
-  const MIN = 20000;
-  const MAX = 39999;
-  return MIN + Math.floor(Math.random() * (MAX - MIN + 1));
+export class NodeSelectingAppContainerProvider {
+  private readonly shared: Omit<AppContainerProviderDeps, "ssh" | "allocateHostPort">;
+
+  constructor(shared: Omit<AppContainerProviderDeps, "ssh" | "allocateHostPort">) {
+    this.shared = shared;
+  }
+
+  async provision(params: ProvisionAppContainerParams): Promise<ProvisionedAppContainer> {
+    const node = await resolveAppContainerNode();
+    await dockerNodesRepository.incrementAllocated(node.nodeId);
+    try {
+      const result = await buildProviderForNode(node, this.shared).provision(params);
+      return { ...result, nodeId: node.nodeId, nodeHost: node.hostname };
+    } catch (error) {
+      try {
+        await dockerNodesRepository.decrementAllocated(node.nodeId);
+      } catch (rollbackError) {
+        logger.warn("[container-executor-deps] Failed to rollback node allocation", {
+          nodeId: node.nodeId,
+          error: rollbackError instanceof Error ? rollbackError.message : String(rollbackError),
+        });
+      }
+      throw error;
+    }
+  }
+
+  async delete(containerName: string, nodeId?: string | null): Promise<void> {
+    const node = await resolveNodePlacement(nodeId);
+    await buildProviderForNode(node, this.shared).delete(containerName);
+    if (nodeId) {
+      try {
+        await dockerNodesRepository.decrementAllocated(node.nodeId);
+      } catch (error) {
+        logger.warn("[container-executor-deps] Failed to decrement node allocation on delete", {
+          nodeId: node.nodeId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+  }
+
+  async restart(containerName: string, nodeId?: string | null): Promise<void> {
+    const node = await resolveNodePlacement(nodeId);
+    await buildProviderForNode(node, this.shared).restart(containerName);
+  }
+
+  async logs(containerName: string, tail = 200, nodeId?: string | null): Promise<string> {
+    const node = await resolveNodePlacement(nodeId);
+    return buildProviderForNode(node, this.shared).logs(containerName, tail);
+  }
 }
 
 /**
@@ -103,19 +191,13 @@ export function buildContainerExecutorDeps(): ContainerExecutorDeps {
         "A CONTAINER_* job was claimed but cannot be provisioned.",
     );
   }
-  const ssh = makeNodeSsh();
-  const nodeHost = selectNodeHost();
   const egressProxyUrl = process.env.CONTAINERS_EGRESS_PROXY_URL || undefined;
-  // The DB ambassador's egress network (it reaches the tenant DB) + socat image.
   const dbEgressNetwork = process.env.APPS_DB_EGRESS_NETWORK || undefined;
   const ambassadorImage = process.env.APPS_DB_AMBASSADOR_IMAGE || undefined;
-  const provider = new AppContainerProvider({
-    ssh,
-    allocateHostPort,
+  const provider = new NodeSelectingAppContainerProvider({
     egressProxyUrl,
     dbEgressNetwork,
     ambassadorImage,
-    nodeHost,
   });
 
   // Ingress route hooks — wired only when a Caddy admin URL is configured.
@@ -130,7 +212,7 @@ export function buildContainerExecutorDeps(): ContainerExecutorDeps {
     : {};
 
   logger.info("[container-executor-deps] built apps container backend", {
-    node: nodeHost,
+    seedNode: parseFirstSeedNodeOrNull()?.nodeId ?? "docker_nodes_pool",
     egressProxy: Boolean(egressProxyUrl),
     dbEgressNetwork: dbEgressNetwork ?? "bridge",
     ingress: Boolean(caddyAdminUrl),

--- a/packages/cloud-shared/src/lib/services/container-job-executors.ts
+++ b/packages/cloud-shared/src/lib/services/container-job-executors.ts
@@ -11,7 +11,10 @@
  * or repo directly.
  */
 
-import type { AppContainerProvider } from "./app-container-provider";
+import type {
+  ProvisionAppContainerParams,
+  ProvisionedAppContainer,
+} from "./app-container-provider";
 import { deriveAppPublicUrl } from "./app-url";
 import {
   type JobLike,
@@ -19,9 +22,18 @@ import {
   readContainerLogsJobData,
   readContainerProvisionJobData,
   readContainerRestartJobData,
+  readContainerStopJobData,
   readContainerUpgradeJobData,
 } from "./container-jobs-data";
 import { buildContainerProvisionInput } from "./container-provider-input";
+
+/** SSH/docker operations the CONTAINER_* executors delegate to. */
+export interface AppContainerOps {
+  provision(params: ProvisionAppContainerParams): Promise<ProvisionedAppContainer>;
+  delete(containerName: string, nodeId?: string | null): Promise<void>;
+  restart(containerName: string, nodeId?: string | null): Promise<void>;
+  logs(containerName: string, tail?: number, nodeId?: string | null): Promise<string>;
+}
 
 /** The fields an executor needs from an app container row. */
 export interface AppContainerRow {
@@ -34,6 +46,7 @@ export interface AppContainerRow {
   userId: string;
   /** Caller env incl. the app's per-tenant DATABASE_URL (never the shared one). */
   environmentVars?: Record<string, string>;
+  nodeId?: string | null;
 }
 
 /** Read/write seam for app container state (over the `containers` table). */
@@ -41,14 +54,14 @@ export interface AppContainerStore {
   getById(containerId: string): Promise<AppContainerRow | null>;
   markRunning(
     containerId: string,
-    info: { hostContainerId: string; hostPort: number; network: string; nodeHost?: string },
+    info: { hostContainerId: string; hostPort: number; network: string; nodeHost?: string; nodeId?: string },
   ): Promise<void>;
   markDeleted(containerId: string): Promise<void>;
   markError(containerId: string, error: string): Promise<void>;
 }
 
 export interface ContainerExecutorDeps {
-  provider: AppContainerProvider;
+  provider: AppContainerOps;
   store: AppContainerStore;
   /**
    * Ingress hooks (optional). When set, the executor registers the per-app route
@@ -106,6 +119,7 @@ export async function executeContainerProvision(
       hostPort: result.hostPort,
       network: result.network,
       nodeHost: result.nodeHost,
+      nodeId: result.nodeId,
     });
     // Register the ingress route so `<shortid>.<base>` reaches this container,
     // plus the app's verified custom domains (best-effort — a domain-lookup
@@ -129,13 +143,29 @@ export async function executeContainerProvision(
   }
 }
 
+/**
+ * Stop the live Docker runtime while preserving the control-plane row — the
+ * primitive billing suspension needs. Runs on the daemon via hetzner-client
+ * (SSH), not inline from the Worker.
+ */
+export async function executeContainerStop(
+  job: JobLike,
+  _deps: ContainerExecutorDeps,
+): Promise<void> {
+  const { containerId, organizationId } = readContainerStopJobData(job);
+  const { getHetznerContainersClient } = await import("./containers/hetzner-client");
+  await getHetznerContainersClient().stopContainer(containerId, organizationId, {
+    purgeVolume: false,
+  });
+}
+
 export async function executeContainerDelete(
   job: JobLike,
   deps: ContainerExecutorDeps,
 ): Promise<void> {
   const { containerId } = readContainerDeleteJobData(job);
   const row = await deps.store.getById(containerId);
-  if (row) await deps.provider.delete(row.containerName);
+  if (row) await deps.provider.delete(row.containerName, row.nodeId);
   // Remove the ingress route (best-effort; a reconciler sweeps any orphan).
   const endpoint = deriveAppPublicUrl(containerId);
   if (endpoint && deps.onRouteRemoved) {
@@ -150,7 +180,7 @@ export async function executeContainerRestart(
 ): Promise<void> {
   const { containerId } = readContainerRestartJobData(job);
   const row = await requireRow(deps.store, containerId);
-  await deps.provider.restart(row.containerName);
+  await deps.provider.restart(row.containerName, row.nodeId);
 }
 
 export async function executeContainerLogs(
@@ -159,7 +189,7 @@ export async function executeContainerLogs(
 ): Promise<string> {
   const data = readContainerLogsJobData(job);
   const row = await requireRow(deps.store, data.containerId);
-  return deps.provider.logs(row.containerName, data.tail);
+  return deps.provider.logs(row.containerName, data.tail, row.nodeId);
 }
 
 /**

--- a/packages/cloud-shared/src/lib/services/container-job-service.ts
+++ b/packages/cloud-shared/src/lib/services/container-job-service.ts
@@ -18,6 +18,7 @@ import {
   executeContainerLogs,
   executeContainerProvision,
   executeContainerRestart,
+  executeContainerStop,
   executeContainerUpgrade,
 } from "./container-job-executors";
 import {
@@ -25,6 +26,7 @@ import {
   containerLogsJobDataToRecord,
   containerProvisionJobDataToRecord,
   containerRestartJobDataToRecord,
+  containerStopJobDataToRecord,
   containerUpgradeJobDataToRecord,
   type JobLike,
 } from "./container-jobs-data";
@@ -32,6 +34,7 @@ import { JOB_TYPES } from "./provisioning-job-types";
 
 const CONTAINER_JOB_TYPES: ReadonlySet<string> = new Set([
   JOB_TYPES.CONTAINER_PROVISION,
+  JOB_TYPES.CONTAINER_STOP,
   JOB_TYPES.CONTAINER_DELETE,
   JOB_TYPES.CONTAINER_RESTART,
   JOB_TYPES.CONTAINER_UPGRADE,
@@ -51,6 +54,9 @@ export async function dispatchContainerJob(
   switch (job.type) {
     case JOB_TYPES.CONTAINER_PROVISION:
       await executeContainerProvision(job, deps);
+      return;
+    case JOB_TYPES.CONTAINER_STOP:
+      await executeContainerStop(job, deps);
       return;
     case JOB_TYPES.CONTAINER_DELETE:
       await executeContainerDelete(job, deps);
@@ -117,6 +123,14 @@ export class ContainerJobEnqueuer {
       organizationId: p.organizationId,
       userId: p.userId,
       data: containerProvisionJobDataToRecord(p),
+    });
+  }
+
+  enqueueStop(p: { containerId: string; organizationId: string }): Promise<{ id: string }> {
+    return this.writer.insertJob({
+      type: JOB_TYPES.CONTAINER_STOP,
+      organizationId: p.organizationId,
+      data: containerStopJobDataToRecord(p),
     });
   }
 

--- a/packages/cloud-shared/src/lib/services/container-jobs-data.ts
+++ b/packages/cloud-shared/src/lib/services/container-jobs-data.ts
@@ -22,6 +22,11 @@ export interface ContainerProvisionJobData {
   userId: string;
 }
 
+export interface ContainerStopJobData {
+  containerId: string;
+  organizationId: string;
+}
+
 export interface ContainerDeleteJobData {
   containerId: string;
   organizationId: string;
@@ -59,6 +64,10 @@ export function isContainerProvisionJobData(value: unknown): value is ContainerP
   return hasStrings(value, ["containerId", "organizationId", "userId"]);
 }
 
+export function isContainerStopJobData(value: unknown): value is ContainerStopJobData {
+  return hasStrings(value, ["containerId", "organizationId"]);
+}
+
 export function isContainerDeleteJobData(value: unknown): value is ContainerDeleteJobData {
   return hasStrings(value, ["containerId", "organizationId"]);
 }
@@ -84,6 +93,13 @@ export function isContainerLogsJobData(value: unknown): value is ContainerLogsJo
 export function readContainerProvisionJobData(job: JobLike): ContainerProvisionJobData {
   if (!isContainerProvisionJobData(job.data)) {
     throw new Error(`Invalid container provision job data for job ${job.id}`);
+  }
+  return job.data;
+}
+
+export function readContainerStopJobData(job: JobLike): ContainerStopJobData {
+  if (!isContainerStopJobData(job.data)) {
+    throw new Error(`Invalid container stop job data for job ${job.id}`);
   }
   return job.data;
 }
@@ -118,6 +134,12 @@ export function readContainerLogsJobData(job: JobLike): ContainerLogsJobData {
 
 export function containerProvisionJobDataToRecord(
   data: ContainerProvisionJobData,
+): Record<string, unknown> {
+  return { ...data };
+}
+
+export function containerStopJobDataToRecord(
+  data: ContainerStopJobData,
 ): Record<string, unknown> {
   return { ...data };
 }

--- a/packages/cloud-shared/src/lib/services/containers/hetzner-client/client.ts
+++ b/packages/cloud-shared/src/lib/services/containers/hetzner-client/client.ts
@@ -26,6 +26,7 @@ import {
 } from "../../docker-sandbox-utils";
 import { DockerSSHClient } from "../../docker-ssh";
 import { getHetznerVolumeService, isHetznerVolumesAvailable } from "../hetzner-volumes";
+import { buildRemoveAmbassadorCmdForContainer } from "../../app-db-ambassador";
 import {
   decodeWorkspaceFiles,
   deleteWorkspaceFiles,
@@ -406,6 +407,37 @@ export class HetznerContainersClient {
           error: err instanceof Error ? err.message : String(err),
         });
       });
+    } else if (row.node_id && row.name) {
+      // App containers (Product 2) may lack hetzner-docker metadata on legacy rows;
+      // node_id + name are enough to docker-stop on the worker node.
+      const node = await dockerNodesRepository.findByNodeId(row.node_id);
+      if (node) {
+        const ssh = DockerSSHClient.getClient(
+          node.hostname,
+          node.ssh_port ?? 22,
+          node.host_key_fingerprint ?? undefined,
+          node.ssh_user ?? "root",
+        );
+        await ssh
+          .exec(`docker stop -t 10 ${shellQuote(row.name)}`, 30_000)
+          .catch((err) => {
+            logger.warn(`[hetzner-client] app container docker stop failed for ${row.name}`, {
+              error: err instanceof Error ? err.message : String(err),
+            });
+          });
+        await ssh.exec(`docker rm -f ${shellQuote(row.name)}`, 30_000);
+        await ssh.exec(buildRemoveAmbassadorCmdForContainer(row.name), 30_000).catch(() => {});
+        await dockerNodesRepository.decrementAllocated(row.node_id).catch((err) => {
+          logger.warn(`[hetzner-client] decrementAllocated failed for ${row.node_id}`, {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        });
+      } else {
+        logger.warn("[hetzner-client] app container stop skipped: node not registered", {
+          containerId,
+          nodeId: row.node_id,
+        });
+      }
     }
 
     if (row.hcloud_volume_id !== null && isHetznerVolumesAvailable()) {

--- a/packages/cloud-shared/src/lib/services/docker-port-allocation.ts
+++ b/packages/cloud-shared/src/lib/services/docker-port-allocation.ts
@@ -3,7 +3,12 @@ import { dbRead } from "../../db/helpers";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
 import { containers as containersTable } from "../../db/schemas/containers";
 import { logger } from "../utils/logger";
-import { readDockerHostPortFromMetadata } from "./docker-sandbox-utils";
+import { allocatePort, readDockerHostPortFromMetadata } from "./docker-sandbox-utils";
+
+/** Ephemeral host port range for app containers (maps container app port). */
+export const APP_CONTAINER_HOST_PORT_MIN = 20000;
+/** Exclusive upper bound — includes host port 39999. */
+export const APP_CONTAINER_HOST_PORT_MAX = 40000;
 
 /**
  * Return Docker host ports already allocated on a node across both control
@@ -51,4 +56,10 @@ export async function getUsedDockerHostPorts(nodeId: string): Promise<Set<number
   }
 
   return used;
+}
+
+/** Pick a collision-safe host port for an app container on a docker node. */
+export async function allocateAppContainerHostPort(nodeId: string): Promise<number> {
+  const used = await getUsedDockerHostPorts(nodeId);
+  return allocatePort(APP_CONTAINER_HOST_PORT_MIN, APP_CONTAINER_HOST_PORT_MAX, used);
 }

--- a/packages/cloud-shared/src/lib/services/provisioning-job-types.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-job-types.ts
@@ -44,6 +44,8 @@ export const JOB_TYPES = {
   // executors are added separately and never alter the AGENT_* arms.
   /** Provision a generic app container from a caller-supplied image. */
   CONTAINER_PROVISION: "container_provision",
+  /** Stop the live Docker container while preserving the control-plane row (billing suspend). */
+  CONTAINER_STOP: "container_stop",
   /** Stop + remove an app container and free its slot. */
   CONTAINER_DELETE: "container_delete",
   /** Restart an app container in place. */
@@ -60,6 +62,12 @@ export const JOB_TYPES = {
    * `pg`/SSH off the workerd request path.
    */
   APP_DEPLOY: "app_deploy",
+  /**
+   * Drop a per-tenant app database (DDL) and release its cluster slot. The
+   * cloud-api Worker enqueues this on app delete; the provisioning-worker
+   * daemon runs `makeTenantDbProvisioning().deprovisionForApp()` (node-`pg`).
+   */
+  TENANT_DB_DEPROVISION: "tenant_db_deprovision",
 } as const;
 
 export type ProvisioningJobType = (typeof JOB_TYPES)[keyof typeof JOB_TYPES];

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -1457,6 +1457,7 @@ export class ProvisioningJobService {
       // standalone container-job-service (kept out of the agent-coupled paths
       // above); the executor backend is wired at boot via setContainerExecutorDeps.
       case JOB_TYPES.CONTAINER_PROVISION:
+      case JOB_TYPES.CONTAINER_STOP:
       case JOB_TYPES.CONTAINER_DELETE:
       case JOB_TYPES.CONTAINER_RESTART:
       case JOB_TYPES.CONTAINER_UPGRADE:
@@ -1468,6 +1469,14 @@ export class ProvisioningJobService {
       case JOB_TYPES.APP_DEPLOY:
         await dispatchAppDeployJob(job);
         break;
+      // Apps lane (Product 2): per-tenant DB teardown on app delete (Worker enqueues).
+      case JOB_TYPES.TENANT_DB_DEPROVISION: {
+        const { dispatchTenantDbDeprovisionJob } = await import(
+          "./tenant-db-deprovision-job-service"
+        );
+        await dispatchTenantDbDeprovisionJob(job);
+        break;
+      }
       default:
         throw new Error(`Unknown job type: ${job.type}`);
     }

--- a/packages/cloud-shared/src/lib/services/tenant-db-deprovision-job-service.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db-deprovision-job-service.ts
@@ -1,0 +1,57 @@
+/**
+ * TENANT_DB_DEPROVISION job service (Apps / Product 2) — lets the cloud-api
+ * Worker tear down isolated per-tenant databases on app delete without loading
+ * node-`pg`.
+ *
+ * The Worker enqueues a TENANT_DB_DEPROVISION job (plain DB insert, no `pg`);
+ * the provisioning-worker daemon claims it and runs
+ * `makeTenantDbProvisioning().deprovisionForApp()` (DROP DATABASE/ROLE + release
+ * cluster slot). Safe to import on workerd.
+ */
+
+import type { ContainerJobsWriter } from "./container-job-service";
+import { containerJobsWriter } from "./container-jobs-writer";
+import { JOB_TYPES } from "./provisioning-job-types";
+
+/** Extract appId + clusterId from a TENANT_DB_DEPROVISION job payload. */
+export function readTenantDbDeprovisionJobData(job: { data: unknown }): {
+  appId: string;
+  clusterId: string;
+} {
+  const data = (job.data ?? {}) as Record<string, unknown>;
+  if (typeof data.appId !== "string" || data.appId.length === 0) {
+    throw new Error("TENANT_DB_DEPROVISION job missing data.appId");
+  }
+  if (typeof data.clusterId !== "string" || data.clusterId.length === 0) {
+    throw new Error("TENANT_DB_DEPROVISION job missing data.clusterId");
+  }
+  return { appId: data.appId, clusterId: data.clusterId };
+}
+
+/** Daemon: run DDL deprovision for a claimed TENANT_DB_DEPROVISION job. */
+export async function dispatchTenantDbDeprovisionJob(job: { data: unknown }): Promise<void> {
+  const { appId, clusterId } = readTenantDbDeprovisionJobData(job);
+  const { makeTenantDbProvisioning } = await import("./tenant-db/make-tenant-db-provisioning");
+  await makeTenantDbProvisioning().deprovisionForApp(appId, clusterId);
+}
+
+/** Enqueue a TENANT_DB_DEPROVISION job (pg-free) over the shared job writer. */
+export function enqueueTenantDbDeprovision(
+  writer: ContainerJobsWriter,
+  p: { appId: string; clusterId: string; organizationId: string },
+): Promise<{ id: string }> {
+  return writer.insertJob({
+    type: JOB_TYPES.TENANT_DB_DEPROVISION,
+    organizationId: p.organizationId,
+    data: { appId: p.appId, clusterId: p.clusterId },
+  });
+}
+
+/** Shared writer singleton used by Worker-side enqueue paths. */
+export function enqueueTenantDbDeprovisionOnce(p: {
+  appId: string;
+  clusterId: string;
+  organizationId: string;
+}): Promise<{ id: string }> {
+  return enqueueTenantDbDeprovision(containerJobsWriter, p);
+}

--- a/packages/cloud-shared/src/lib/services/tenant-db/__tests__/cluster-pool.test.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/__tests__/cluster-pool.test.ts
@@ -71,6 +71,12 @@ describe("ClusterPool.allocate", () => {
         claims.push(id);
         return claim(id);
       },
+      async releaseSlot() {
+        return true;
+      },
+      async findById() {
+        return null;
+      },
     };
   }
 
@@ -102,6 +108,12 @@ describe("ClusterPool.allocate", () => {
           return false;
         }
         return true;
+      },
+      async releaseSlot() {
+        return true;
+      },
+      async findById() {
+        return null;
       },
     };
     const got = await new ClusterPool(s).allocate();

--- a/packages/cloud-shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioning.test.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/__tests__/tenant-db-provisioning.test.ts
@@ -23,6 +23,14 @@ function deps(
       async allocate() {
         return ALLOCATED;
       },
+      async release() {
+        seen.releasedCluster = true;
+        return true;
+      },
+      async findById(clusterId) {
+        seen.foundCluster = clusterId;
+        return ALLOCATED;
+      },
     },
     async decrypt(enc) {
       seen.decryptedArg = enc;
@@ -70,6 +78,12 @@ describe("SqlTenantDbProvisioning", () => {
       pool: {
         async allocate() {
           throw new Error("No tenant DB cluster has capacity");
+        },
+        async release() {
+          return true;
+        },
+        async findById() {
+          return null;
         },
       },
     });

--- a/packages/cloud-shared/src/lib/services/tenant-db/cluster-pool.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/cluster-pool.ts
@@ -37,6 +37,10 @@ export interface AllocatedCluster {
 export interface ClusterPoolStore {
   listAllocatable(): Promise<ClusterCandidate[]>;
   tryClaimSlot(clusterId: string): Promise<boolean>;
+  /** Decrement `database_count` after a tenant DB is dropped (floor at 0). */
+  releaseSlot(clusterId: string): Promise<boolean>;
+  /** Load a cluster's admin credentials for deprovision DDL. */
+  findById(clusterId: string): Promise<AllocatedCluster | null>;
 }
 
 /** Thrown when every active cluster is at capacity — operators add a cluster. */
@@ -98,5 +102,13 @@ export class ClusterPool {
       // Lost the race for that slot — loop and re-select.
     }
     throw new NoClusterCapacityError();
+  }
+
+  async release(clusterId: string): Promise<boolean> {
+    return this.store.releaseSlot(clusterId);
+  }
+
+  async findById(clusterId: string): Promise<AllocatedCluster | null> {
+    return this.store.findById(clusterId);
   }
 }

--- a/packages/cloud-shared/src/lib/services/tenant-db/make-tenant-db-provisioning.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/make-tenant-db-provisioning.ts
@@ -67,8 +67,7 @@ export function makeTenantDbProvisioning(
 
   const resolveClusterByHost =
     opts.resolveClusterByHost ?? ((host: string) => tenantDbClustersRepository.findByHost(host));
-  const releaseSlot =
-    opts.releaseSlot ?? ((clusterId: string) => tenantDbClustersRepository.releaseSlot(clusterId));
+  const releaseSlot = opts.releaseSlot ?? (async (clusterId: string) => { await tenantDbClustersRepository.releaseSlot(clusterId); });
 
   return new SqlTenantDbProvisioning({
     pool,

--- a/packages/cloud-shared/src/lib/services/user-database.ts
+++ b/packages/cloud-shared/src/lib/services/user-database.ts
@@ -180,6 +180,7 @@ export class UserDatabaseService {
 
       await appDatabasesRepository.updateState(appId, {
         user_database_uri: encryptedUri,
+        user_database_cluster_id: clusterId ?? null,
         user_database_status: "ready",
         user_database_error: null,
       });
@@ -232,9 +233,7 @@ export class UserDatabaseService {
 
     // ISOLATED (Apps / Product 2): DROP the app's OWN per-tenant DATABASE + ROLE
     // and release its cluster slot — otherwise we leak a live DB we keep paying
-    // for AND burn one of the cluster's finite slots forever (#8342). Only runs
-    // when the provisioning backend is wired (the daemon — DROP needs `pg`); on
-    // the Worker (shared-mode, no backend) this is a no-op.
+    // for AND burn one of the cluster's finite slots forever (#8342).
     const isolatedUri = database.user_database_uri;
     if (this.tenantDbProvisioning && isolatedUri) {
       try {
@@ -247,9 +246,39 @@ export class UserDatabaseService {
           });
         }
       } catch (error) {
-        // Don't fail the app delete on a teardown hiccup; a reconciler sweeps orphans.
         logger.warn("Failed to deprovision isolated tenant DB", {
           appId,
+          error: error instanceof Error ? error.message : "Unknown",
+        });
+      }
+    } else if (
+      database.user_database_cluster_id &&
+      database.user_database_status === "ready"
+    ) {
+      // Workers cannot load node-`pg`; enqueue DDL deprovision for the daemon.
+      try {
+        const app = await appsRepository.findById(appId);
+        if (!app?.organization_id) {
+          throw new Error("app organization_id required to enqueue tenant DB deprovision");
+        }
+        const { enqueueTenantDbDeprovisionOnce } = await import(
+          "./tenant-db-deprovision-job-service"
+        );
+        const { provisioningJobService } = await import("./provisioning-jobs");
+        await enqueueTenantDbDeprovisionOnce({
+          appId,
+          clusterId: database.user_database_cluster_id,
+          organizationId: app.organization_id,
+        });
+        void provisioningJobService.triggerImmediate().catch(() => {});
+        logger.info("Enqueued tenant DB deprovision job", {
+          appId,
+          clusterId: database.user_database_cluster_id,
+        });
+      } catch (error) {
+        logger.warn("Failed to enqueue tenant DB deprovision job", {
+          appId,
+          clusterId: database.user_database_cluster_id,
           error: error instanceof Error ? error.message : "Unknown",
         });
       }
@@ -265,13 +294,13 @@ export class UserDatabaseService {
           projectId: database.user_database_project_id,
         });
       } catch (error) {
-        // Log but don't fail - database might already be deleted
         logger.warn("Failed to delete Neon project (may already be deleted)", {
           appId,
           projectId: database.user_database_project_id,
           error: error instanceof Error ? error.message : "Unknown",
         });
       }
+    }
     }
   }
 

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -67,6 +67,7 @@ export interface ProvisioningWorkerConfig {
   batchSize: number;
   runOnce: boolean;
   nodeHealthIntervalMs: number;
+  appsIngressSyncIntervalMs: number;
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
@@ -77,6 +78,8 @@ const DEFAULT_BATCH_SIZE = 3;
  * CRON_FANOUT schedule. SSH uses `CONTAINERS_SSH_KEY` from this host.
  */
 const DEFAULT_NODE_HEALTH_INTERVAL_MS = 5 * 60_000;
+/** Apps ingress-map → Caddy live sync cadence (control-plane pushes over SSH). */
+const DEFAULT_APPS_INGRESS_SYNC_INTERVAL_MS = 60_000;
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
   if (!value) return fallback;
@@ -102,6 +105,10 @@ export function readWorkerConfig(
     nodeHealthIntervalMs: parsePositiveInt(
       env.WORKER_NODE_HEALTH_INTERVAL,
       DEFAULT_NODE_HEALTH_INTERVAL_MS,
+    ),
+    appsIngressSyncIntervalMs: parsePositiveInt(
+      env.APPS_INGRESS_SYNC_INTERVAL_MS,
+      DEFAULT_APPS_INGRESS_SYNC_INTERVAL_MS,
     ),
   };
 }
@@ -471,8 +478,65 @@ async function processPoolDrainIdleCycle(): Promise<PoolDrainSummary> {
   return { drained: result.drained.length };
 }
 
+interface AppsIngressSyncCycleSummary {
+  fetchedEntries: number;
+  synced: number;
+  skipped: number;
+  failed: number;
+}
+
+/**
+ * Poll cloud-api ingress-map (`?format=caddy`) and push the snippet to each app
+ * worker node over SSH, then reload Caddy via APPS_CADDY_ADMIN_URL on the node.
+ * Gated by APPS_INGRESS_SYNC_ENABLED=1 + API origin + super-admin API key.
+ */
+async function processAppsIngressSyncCycle(): Promise<AppsIngressSyncCycleSummary | null> {
+  const {
+    readAppsIngressSyncConfig,
+    resolveAppsIngressNodeHostnames,
+    syncAppsIngressToNodes,
+  } = await import("@elizaos/cloud-shared/lib/services/apps-ingress-client");
+  const { DockerSSHClient } = await import("@elizaos/cloud-shared/lib/services/docker-ssh");
+
+  const config = readAppsIngressSyncConfig();
+  if (!config) return null;
+
+  const hostnames = resolveAppsIngressNodeHostnames();
+  if (hostnames.length === 0) {
+    return { fetchedEntries: 0, synced: 0, skipped: 0, failed: 0 };
+  }
+
+  const summary = await syncAppsIngressToNodes({
+    config,
+    hostnames,
+    previousSnippetByHost: ingressSnippetByHost,
+    sshForHost: (hostname) => new DockerSSHClient({ hostname }),
+  });
+
+  let synced = 0;
+  let skipped = 0;
+  let failed = 0;
+  for (const node of summary.nodes) {
+    if (node.error) {
+      failed += 1;
+      continue;
+    }
+    if (node.changed) synced += 1;
+    else skipped += 1;
+  }
+
+  return {
+    fetchedEntries: summary.fetchedEntries,
+    synced,
+    skipped,
+    failed,
+  };
+}
+
 let running = true;
 let lastInfraMaintenanceAt = 0;
+let lastAppsIngressSyncAt = 0;
+const ingressSnippetByHost = new Map<string, string>();
 
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -562,6 +626,20 @@ async function pollCycle(
   if (now - lastInfraMaintenanceAt >= config.nodeHealthIntervalMs) {
     lastInfraMaintenanceAt = now;
     await runInfraMaintenanceCycle(logger);
+  }
+
+  if (now - lastAppsIngressSyncAt >= config.appsIngressSyncIntervalMs) {
+    lastAppsIngressSyncAt = now;
+    try {
+      const ingress = await processAppsIngressSyncCycle();
+      if (ingress && (ingress.synced > 0 || ingress.failed > 0)) {
+        logger.info("[provisioning-worker] apps ingress sync cycle complete", ingress);
+      }
+    } catch (error) {
+      logger.error("[provisioning-worker] apps ingress sync cycle failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 }
 
@@ -677,6 +755,7 @@ async function main(): Promise<void> {
     batchSize: config.batchSize,
     runOnce: config.runOnce,
     nodeHealthIntervalMs: config.nodeHealthIntervalMs,
+    appsIngressSyncIntervalMs: config.appsIngressSyncIntervalMs,
   });
 
   await assertProvisioningWorkerPreflight();


### PR DESCRIPTION
## Summary
- **Billing idempotency:** container-billing cron rebill guard + unique `(container_id, billing_period)` index
- **Suspended containers:** docker stop + allocation decrement on shutdown branch
- **Isolated DB teardown:** deprovision job on app delete, DROP DATABASE/ROLE, `releaseSlot` for cluster capacity
- **Deploy economics:** upfront deploy credit debit + balance precheck before provisioning
- **Ingress:** Caddy admin client for multi-node apps lane routing

## Test plan
- [x] `bun run --cwd packages/cloud-shared test -- app-deploy-billing apps-ingress-client tenant-db-deprovision container-billing`
- [x] `bun run --cwd packages/cloud-shared test -- app-container-store app-deployments container-executor-deps container-job-service provisioning-job`
- [ ] Maintainer: approve fork PR workflows so GitHub CI runs

Fixes #8342, #8321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added upfront deploy credit charges for app deployments with idempotency protection.
  * Implemented container billing reconciliation for suspended containers and daily billing slot management.

* **Infrastructure & Improvements**
  * Enhanced app node security with network isolation rules and egress proxy configuration.
  * Introduced pgbouncer connection pooling for tenant databases.
  * Added automated app ingress snippet synchronization to worker nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->