### PR TITLE
fix(elizaos): gate npm publish on global-install smoke (#8000)

### DIFF
--- a/.github/workflows/quality-fork.yml
+++ b/.github/workflows/quality-fork.yml
@@ -123,3 +123,32 @@ jobs:
         run: bun run test:e2e
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  elizaos-cli-global-smoke:
+    name: elizaos CLI global-install smoke (#8000)
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install dependencies
+        run: bun install --ignore-scripts --no-frozen-lockfile
+
+      - name: Lint bin exports (#8000 static guard)
+        run: bun run --cwd packages/elizaos lint:bin-exports
+
+      - name: Packaged smoke (global + local install, node + bun)
+        run: bun run --cwd packages/elizaos test:packaged

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -566,6 +566,14 @@ jobs:
           done
           echo "✅ All publish-critical packages built successfully"
 
+      # elizaOS/eliza#8000: block publishing another CLI that crashes on global
+      # install (ERR_PACKAGE_PATH_NOT_EXPORTED). npm pack -> global install under
+      # npm and bun, then run the bin under node and bun.
+      - name: elizaos global-install smoke (#8000)
+        run: |
+          bun run --cwd packages/elizaos lint:bin-exports
+          bun run --cwd packages/elizaos test:packaged
+
       # Replace workspace:* references with actual versions before publishing
       # This is required because Bun workspaces use workspace:* protocol
       # which npm doesn't understand when the packages are published
@@ -752,7 +760,7 @@ jobs:
 
             Install the CLI globally to get started:
             ```bash
-            bun i -g @elizaos/cli@${{ steps.release_type.outputs.dist_tag }}
+            bun i -g elizaos@${{ steps.release_type.outputs.dist_tag }}
             ```
 
             Or add packages to your project:
@@ -786,7 +794,7 @@ jobs:
           echo "## Quick Start" >> $GITHUB_STEP_SUMMARY
           echo "Install the CLI globally:" >> $GITHUB_STEP_SUMMARY
           echo '```bash' >> $GITHUB_STEP_SUMMARY
-          echo "bun i -g @elizaos/cli@${{ steps.release_type.outputs.dist_tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "bun i -g elizaos@${{ steps.release_type.outputs.dist_tag }}" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Or add to your project:" >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ A _plugin_ sits between the two: framework-shaped (registers actions/providers/s
 **Prerequisites:** [Node.js v24+](https://nodejs.org/), [bun](https://bun.sh/docs/installation). On Windows, use [WSL 2](https://learn.microsoft.com/en-us/windows/wsl/install-manual).
 
 ```bash
-bun add -g elizaos
+bun add -g elizaos@beta
 elizaos create my-first-agent --template project
 cd my-first-agent
 # add OPENAI_API_KEY=... to .env (or your provider's key)

--- a/packages/docs/cli/overview.mdx
+++ b/packages/docs/cli/overview.mdx
@@ -8,13 +8,13 @@ The CLI is intentionally small. It does not manage running agents — your proje
 ## Install
 
 ```bash
-npx elizaos --help
+npx elizaos@beta --help
 ```
 
 Or globally:
 
 ```bash
-bun add -g elizaos
+bun add -g elizaos@beta
 elizaos --help
 ```
 

--- a/packages/docs/cli/overview.mdx
+++ b/packages/docs/cli/overview.mdx
@@ -14,7 +14,7 @@ npx elizaos --help
 Or globally:
 
 ```bash
-bun add -g @elizaos/cli
+bun add -g elizaos
 elizaos --help
 ```
 

--- a/packages/docs/cloud/agents.mdx
+++ b/packages/docs/cloud/agents.mdx
@@ -90,7 +90,7 @@ Response:
 
 ```bash
 # Install the scaffolding CLI
-bun add -g elizaos
+bun add -g elizaos@beta
 
 # Create a local project
 elizaos create research-assistant --template project

--- a/packages/docs/cloud/installation.mdx
+++ b/packages/docs/cloud/installation.mdx
@@ -25,7 +25,7 @@ bun add @elizaos/core @elizaos/plugin-elizacloud
 Install the elizaOS CLI for project and plugin scaffolding:
 
 ```bash
-bun add -g elizaos
+bun add -g elizaos@beta
 ```
 
 Verify the installation:

--- a/packages/docs/cloud/quickstart.mdx
+++ b/packages/docs/cloud/quickstart.mdx
@@ -231,7 +231,7 @@ sections.
 <Step title="Install the CLI">
 
 ```bash
-bun add -g elizaos
+bun add -g elizaos@beta
 ```
 
 </Step>

--- a/packages/docs/installation.mdx
+++ b/packages/docs/installation.mdx
@@ -22,13 +22,13 @@ The public `elizaos` package installs the `elizaos` binary. The CLI is small on 
 You can run the CLI without a global install:
 
 ```bash
-npx elizaos
+npx elizaos@beta
 ```
 
 Or install it globally:
 
 ```bash
-bun add -g elizaos
+bun add -g elizaos@beta
 ```
 
 Verify the installed binary:
@@ -117,7 +117,19 @@ The upgrade command reads `.elizaos/template.json`, renders the latest version o
     export PATH="$HOME/.bun/bin:$PATH"
     ```
 
-    You can always use `npx elizaos` without a global install.
+    You can always use `npx elizaos@beta` without a global install.
+  </Accordion>
+
+  <Accordion icon="triangle-exclamation" title="ERR_PACKAGE_PATH_NOT_EXPORTED on elizaos --version">
+    npm `latest` still points at `elizaos@1.7.2`, whose bin shim imports a
+    forbidden `@elizaos/cli` subpath. Pin the beta channel until `latest` is
+    republished:
+
+    ```bash
+    bun add -g elizaos@beta
+    # or
+    npx elizaos@beta --version
+    ```
   </Accordion>
 
   <Accordion icon="node-js" title="Node version mismatch">

--- a/packages/docs/plugins/create-a-plugin.md
+++ b/packages/docs/plugins/create-a-plugin.md
@@ -476,8 +476,8 @@ Override in `eliza.json`:
 If you have the upstream `elizaos` CLI installed globally, you can scaffold a plugin project:
 
 ```bash
-# Requires the elizaos CLI (npm i -g elizaos)
-npx elizaos create my-plugin --template plugin --language typescript
+# Requires the elizaos CLI (npm i -g elizaos@beta)
+npx elizaos@beta create my-plugin --template plugin --language typescript
 ```
 
 Alternatively, copy the manual scaffold from [Step 1](#step-1-scaffold-the-project) above — it produces the same structure.

--- a/packages/elizaos/build.ts
+++ b/packages/elizaos/build.ts
@@ -6,7 +6,22 @@ import * as path from "node:path";
 import { copyDir } from "./safe-copy-dir.ts";
 
 const PACKAGE_DIR = import.meta.dir;
+const REPO_ROOT = path.resolve(PACKAGE_DIR, "..", "..");
 const DIST_DIR = path.join(PACKAGE_DIR, "dist");
+
+function resolveBin(name: string): string {
+  const local = path.join(REPO_ROOT, "node_modules", ".bin", name);
+  if (process.platform === "win32") {
+    const winLocal = `${local}.cmd`;
+    if (fs.existsSync(winLocal)) return winLocal;
+    if (fs.existsSync(local)) return local;
+    const winRepo = path.join(REPO_ROOT, "node_modules", ".bin", `${name}.cmd`);
+    if (fs.existsSync(winRepo)) return winRepo;
+  } else if (fs.existsSync(local)) {
+    return local;
+  }
+  return name;
+}
 const LEGACY_TEMPLATE_SOURCE_DIR = path.resolve(PACKAGE_DIR, "..", "templates");
 const TEMPLATE_DIR = path.join(PACKAGE_DIR, "templates");
 const MANIFEST_PATH = path.join(PACKAGE_DIR, "templates-manifest.json");
@@ -78,7 +93,7 @@ function prepareTemplates(): void {
         : new Date().toISOString(),
   };
   fs.writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
-  execSync(`bunx --bun @biomejs/biome format --write ${MANIFEST_PATH}`, {
+  execSync(`${resolveBin("biome")} format --write ${MANIFEST_PATH}`, {
     cwd: PACKAGE_DIR,
     stdio: "inherit",
   });
@@ -88,7 +103,7 @@ function buildTypescript(): void {
   if (!fs.existsSync(DIST_DIR)) {
     fs.mkdirSync(DIST_DIR, { recursive: true });
   }
-  execSync("bunx --bun tsc -p tsconfig.json", {
+  execSync(`${resolveBin("tsc")} -p tsconfig.json`, {
     cwd: PACKAGE_DIR,
     stdio: "inherit",
   });

--- a/packages/elizaos/package.json
+++ b/packages/elizaos/package.json
@@ -31,7 +31,7 @@
     "test": "vitest run --passWithNoTests",
     "test:packaged": "node ./scripts/packaged-smoke.mjs",
     "lint:bin-exports": "node ./scripts/lint-bin-exports.mjs",
-    "prepublishOnly": "bun run build"
+    "prepublishOnly": "bun run build && bun run lint:bin-exports"
   },
   "dependencies": {
     "@clack/prompts": "^1.0.0",

--- a/packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx
+++ b/packages/ui/src/cloud-ui/components/dashboard/cloud-dashboard-components.tsx
@@ -241,7 +241,7 @@ export function ContainersSkeleton() {
 
 export function ContainersEmptyState() {
   const [copiedIndex, setCopiedIndex] = useState<number | null>(null);
-  const commands = ["bun i -g @elizaos/cli", "elizaos deploy"];
+  const commands = ["bun i -g elizaos", "elizaos deploy"];
 
   const handleCopy = async (text: string, index: number) => {
     await navigator.clipboard.writeText(text);

--- a/packages/ui/src/cloud-ui/components/docs/mdx-components.stories.tsx
+++ b/packages/ui/src/cloud-ui/components/docs/mdx-components.stories.tsx
@@ -74,7 +74,7 @@ export const StepsList: Story = {
     <Steps>
       <h3>Install the CLI</h3>
       <p>
-        Run <code>bun add -g @elizaos/cli</code> to install the elizaos CLI
+        Run <code>bun add -g elizaos</code> to install the elizaos CLI
         globally.
       </p>
       <h3>Scaffold a project</h3>


### PR DESCRIPTION
## Summary
- **#8000 root cause was already fixed on develop** (removed `@elizaos/cli` alias shim; `elizaos` bin points at `./dist/cli.js`).
- **#8001 is also fixed on develop** — the 2.x CLI has no `engine.io` / Socket.IO on the boot path; `packaged-smoke.mjs` exercises global install under **npm + bun** and runs `--version` / `--help` under **node + bun** before publish.
- **This PR closes the regression loop** so another broken `latest` cannot ship:
  - `prepublishOnly` runs `lint:bin-exports` after build
  - `release.yaml` runs full `test:packaged` (global install under npm + bun, node + bun) **before** lerna publish
  - `Quality (Fork)` adds the same elizaos smoke job for fork PRs
- Corrects stale `@elizaos/cli` install instructions → `elizaos`

## Test plan
- [x] `bun run --cwd packages/elizaos lint:bin-exports`
- [ ] GitHub: `Test Packaging` / `Quality (Fork)` elizaos global-install smoke (after workflow approval)
- [ ] Next beta release blocked if global install regresses

Fixes #8000
Fixes #8001

**Note:** npm `latest` is still `1.7.2` until maintainers cut a release — users should `npm i -g elizaos@beta` or use repo `bun run --cwd packages/elizaos` until then.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI installation guidance across documentation and in-app components to use `elizaos` for global installation.

* **Chores**
  * Enhanced CI/CD workflows with additional CLI quality checks and smoke tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
