### PR TITLE
fix(autoscaler): env-overridable minFreeSlotsBuffer + minHotAvailableSlots

### DIFF
--- a/packages/cloud-shared/src/lib/config/containers-env.ts
+++ b/packages/cloud-shared/src/lib/config/containers-env.ts
@@ -323,6 +323,33 @@ export const containersEnv = {
     return Number.isFinite(parsed) && parsed >= 1 ? Math.min(64, Math.floor(parsed)) : 8;
   },
 
+  /**
+   * Free slots that must remain across the pool before a new node is
+   * provisioned. Also acts as the drain preservation floor: a drain is
+   * refused if it would leave the pool below this number of free slots.
+   *
+   * Smaller buffer → pool can collapse to fewer nodes when demand is low
+   * (right for staging). Larger buffer → hot-start latency reserved (right
+   * for prod). Clamped to [0, 64]. Default: 4.
+   */
+  autoscaleMinFreeSlotsBuffer(): number {
+    const env = getCloudAwareEnv();
+    const raw = pick(env.CONTAINERS_AUTOSCALE_MIN_FREE_SLOTS_BUFFER);
+    const parsed = raw !== undefined ? Number(raw) : Number.NaN;
+    return Number.isFinite(parsed) && parsed >= 0 ? Math.min(64, Math.floor(parsed)) : 4;
+  },
+
+  /**
+   * Emergency floor for hot agent starts; bypasses scale-up cooldown when
+   * pool availability drops below this. Clamped to [0, 64]. Default: 1.
+   */
+  autoscaleMinHotAvailableSlots(): number {
+    const env = getCloudAwareEnv();
+    const raw = pick(env.CONTAINERS_AUTOSCALE_MIN_HOT_AVAILABLE_SLOTS);
+    const parsed = raw !== undefined ? Number(raw) : Number.NaN;
+    return Number.isFinite(parsed) && parsed >= 0 ? Math.min(64, Math.floor(parsed)) : 1;
+  },
+
   // ── Warm pool ───────────────────────────────────────────────────────────
 
   /**

--- a/packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts
+++ b/packages/cloud-shared/src/lib/services/containers/node-autoscaler.ts
@@ -63,8 +63,8 @@ export interface AutoscalePolicy {
 }
 
 export const DEFAULT_AUTOSCALE_POLICY: AutoscalePolicy = {
-  minFreeSlotsBuffer: 4,
-  minHotAvailableSlots: 1,
+  minFreeSlotsBuffer: containersEnv.autoscaleMinFreeSlotsBuffer(),
+  minHotAvailableSlots: containersEnv.autoscaleMinHotAvailableSlots(),
   maxNodes: 12,
   scaleUpCooldownMs: 5 * 60 * 1000,
   idleNodeMinAgeMs: 30 * 60 * 1000,


### PR DESCRIPTION
Hardcoded buffer=4 forces 2 nodes minimum when any agent is allocated on a 4-capacity node. Right for prod, wasteful for staging.

## Change
Adds env vars + helpers (containers-env.ts), wires into DEFAULT_AUTOSCALE_POLICY:
- `CONTAINERS_AUTOSCALE_MIN_FREE_SLOTS_BUFFER` (default 4)
- `CONTAINERS_AUTOSCALE_MIN_HOT_AVAILABLE_SLOTS` (default 1)

## Ops apply
Set `BUFFER=2` on the staging daemon (`/opt/eliza/cloud/.env.local`) → pool can collapse to 1 worker node when only ~1-2 agents allocated; scales to 2 nodes when capacity nears full.