### PR TITLE
feat(infra): multi-project Hetzner pattern (per-env project token + docs)

### DIFF
--- a/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
@@ -101,6 +101,64 @@ hcloud server delete milady-core-2
 DELETE FROM docker_nodes WHERE node_id LIKE 'milady-core-%';
 ```
 
+## Multi-project layout
+
+Each environment lives in its **own Hetzner Cloud Project** — not just its own
+state file. Projects are administrative containers in the Hetzner Cloud
+console: separate API tokens, separate per-project resource quotas (5 servers
+by default, 10 with KYC), separate SSH keys, separate private networks. There
+is no `hcloud_project` Terraform resource — projects are management-plane only.
+
+```
+Hetzner Cloud account (one human)
+├── Project "eliza-prod"      (HCLOUD_TOKEN_PROD,    5/5 servers max)
+│   ├── eliza-1               (control-plane, cax21)
+│   └── eliza-core-<hex>      (worker, ccx33, autoscaled)
+└── Project "eliza-staging"   (HCLOUD_TOKEN_STAGING, 5/5 servers max)
+    ├── eliza-staging-1               (control-plane, cpx32)
+    ├── eliza-core-<hex>              (worker, autoscaled)
+    └── eliza-apps-node-staging-1     (apps Product-2)
+```
+
+### Why split
+
+- **Quota isolation** — prod can't starve staging, staging can't starve prod
+- **Blast radius** — a leaked staging token can't delete prod resources
+- **Cost visibility** — Hetzner billing already splits per project in the invoice
+- **No upgrade ticket** — 2 projects × 5 default quota = 10 effective servers,
+  vs. waiting for a manual `Limit increase` on a single shared project
+
+### Token plumbing
+
+| Where                                          | Sets                          | Used for                |
+|------------------------------------------------|-------------------------------|-------------------------|
+| GitHub Environment `staging`   → `HCLOUD_TOKEN`| staging project token         | terraform plan/apply on staging |
+| GitHub Environment `production`→ `HCLOUD_TOKEN`| prod project token            | terraform plan/apply on prod    |
+| Staging control-plane `/opt/eliza/cloud/.env.local` → `HETZNER_CLOUD_API_KEY` | staging project token | provisioning-worker autoscaler   |
+| Prod control-plane `/opt/eliza/cloud/.env.local`    → `HETZNER_CLOUD_API_KEY` | prod project token    | provisioning-worker autoscaler   |
+
+Terraform's `provider "hcloud" { token = var.hcloud_token }` block accepts the
+token from either `var.hcloud_token` (tfvars / `-var`) or the `HCLOUD_TOKEN`
+env var. GHA wires the env var via the environment-scoped secret.
+
+### Migrating an existing project to a per-env split
+
+Hetzner has **no move-resource-between-projects** API. The move is destructive:
+
+1. **Create the new project** in console.hetzner.cloud (free, instant)
+2. **Generate a token** scoped to the new project; store as the matching
+   GitHub Environment secret + the matching control-plane env var
+3. **Provision the new env's resources** fresh in the new project via
+   terraform apply
+4. **Migrate state** by recreating agents (the daemon does this on a
+   `recreate` job — picks up env vars then targets the new project)
+5. **Delete the old resources** from the old project; the old project becomes
+   the home of the OTHER env (e.g. keep "default" as prod, new "staging"
+   gets the new project)
+
+Downtime is per-agent during recreate; control-plane is unaffected because
+the daemon stays running on its own VM.
+
 ## Followups (not in this initial PR)
 
 - [ ] Terraform module for headscale state (preauth keys, ACLs)
@@ -111,8 +169,8 @@ DELETE FROM docker_nodes WHERE node_id LIKE 'milady-core-%';
       (`pool-replenish`, `pool-health-check`, `pool-image-rollout`,
       `deployment-monitor`). Once done, retire the
       `packages/cloud-services/container-control-plane/` package entirely.
-- [ ] Raise Hetzner Cloud server limit (open ticket) to enable autoscale
-      past the default cap of ~10 servers per account.
+- [ ] Raise Hetzner Cloud server limit (open ticket) — only if the
+      per-project default 5 isn't enough after the multi-project split.
 
 ## Operator runbook
 

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/providers.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/providers.tf
@@ -1,9 +1,13 @@
 provider "hcloud" {
-  # Token comes from HCLOUD_TOKEN env var by default — never commit it.
-  # token = var.hcloud_token
+  # Token resolution order:
+  #   1. var.hcloud_token (passed via tfvars or -var)
+  #   2. HCLOUD_TOKEN env var (the GHA pattern — set per GitHub Environment)
+  # Each environment uses a token scoped to its OWN Hetzner Cloud Project.
+  # See ../ARCHITECTURE.md § "Multi-project layout".
+  token = var.hcloud_token
 }
 
 provider "cloudflare" {
-  # Token comes from CLOUDFLARE_API_TOKEN env var by default.
-  # api_token = var.cloudflare_api_token
+  # Token comes from CLOUDFLARE_API_TOKEN env var (no per-env variable needed
+  # — the Cloudflare project is one shared account, not split by environment).
 }

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
@@ -7,6 +7,19 @@ variable "environment" {
   }
 }
 
+# ── Multi-project credentials ────────────────────────────────────────────────
+# Each environment has its own Hetzner Cloud Project (= its own 5-server quota,
+# its own SSH keys, its own private network). The provider picks up the token
+# from this variable OR the HCLOUD_TOKEN env var. GitHub Actions wires the
+# right project's token via the environment-scoped secret HCLOUD_TOKEN.
+# See ARCHITECTURE.md § "Multi-project layout" for the pattern.
+variable "hcloud_token" {
+  description = "Hetzner Cloud API token for the project that owns THIS environment's resources. Leave null to pick up from HCLOUD_TOKEN env var (the GHA pattern)."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
 variable "hcloud_location" {
   description = "Hetzner Cloud datacenter location. MUST match the control-plane + agent data plane (fsn1) so the private network and DB latency stay sane."
   type        = string

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/providers.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/providers.tf
@@ -1,9 +1,13 @@
 provider "hcloud" {
-  # Token comes from HCLOUD_TOKEN env var by default — never commit it.
-  # token = var.hcloud_token
+  # Token resolution order:
+  #   1. var.hcloud_token (passed via tfvars or -var)
+  #   2. HCLOUD_TOKEN env var (the GHA pattern — set per GitHub Environment)
+  # Each environment uses a token scoped to its OWN Hetzner Cloud Project.
+  # See ../ARCHITECTURE.md § "Multi-project layout".
+  token = var.hcloud_token
 }
 
 provider "cloudflare" {
-  # Token comes from CLOUDFLARE_API_TOKEN env var by default.
-  # api_token = var.cloudflare_api_token
+  # Token comes from CLOUDFLARE_API_TOKEN env var (no per-env variable needed
+  # — the Cloudflare project is one shared account, not split by environment).
 }

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf
@@ -7,6 +7,19 @@ variable "environment" {
   }
 }
 
+# ── Multi-project credentials ────────────────────────────────────────────────
+# Each environment has its own Hetzner Cloud Project (= its own 5-server quota,
+# its own SSH keys, its own private network). The provider picks up the token
+# from this variable OR the HCLOUD_TOKEN env var. GitHub Actions wires the
+# right project's token via the environment-scoped secret HCLOUD_TOKEN.
+# See ../ARCHITECTURE.md § "Multi-project layout" for the pattern.
+variable "hcloud_token" {
+  description = "Hetzner Cloud API token for the project that owns THIS environment's resources. Leave null to pick up from HCLOUD_TOKEN env var (the GHA pattern)."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
 variable "hcloud_location" {
   description = "Hetzner Cloud datacenter location (must match data-plane). Existing fleet runs in fsn1."
   type        = string


### PR DESCRIPTION
## Why
Currently both staging and prod live in the SAME Hetzner Cloud Project, sharing a 5-server quota. Hitting the cap blocks any new apply (e.g. apps-data-plane staging needs server #6 → 422 limit_exceeded).

## What
- Add explicit `hcloud_token` variable to both modules (sensitive, defaults to env var fallback)
- Wire `provider "hcloud" { token = var.hcloud_token }` so tfvars + env both work
- ARCHITECTURE.md gets a new "Multi-project layout" section: layout, token plumbing table, migration steps

## Ops apply
1. `console.hetzner.cloud` → create projects `eliza-prod` + `eliza-staging`
2. Generate 2 API tokens, store as `HCLOUD_TOKEN` in the matching GitHub Environment secret
3. Future terraform apply auto-targets the right project — no code change needed
4. Daemon /opt/eliza/cloud/.env.local `HETZNER_CLOUD_API_KEY` aligned with the env