### PR TITLE
fix(feed): Steward OAuth PKCE for Feed login (#8257)

### DIFF
--- a/packages/feed/.env.example
+++ b/packages/feed/.env.example
@@ -157,6 +157,9 @@ STEWARD_MASTER_PASSWORD=dev-master-password-change-in-prod
 STEWARD_PLATFORM_KEYS=
 # Steward API URL for server-side calls (may differ from public URL in production)
 STEWARD_API_URL=http://localhost:3200
+# HMAC secret for signed Steward mutating requests (OAuth exchange in prod).
+# Must match Steward's request-signing secret when enabled upstream.
+STEWARD_REQUEST_SIGNING_SECRET=
 # App URL as seen by the Steward container (for magic-link redirects)
 # In local dev: http://localhost:3000, in prod: your production domain
 STEWARD_APP_URL=http://localhost:3000

--- a/packages/feed/apps/web/src/app/api/auth/steward/oauth/exchange/route.ts
+++ b/packages/feed/apps/web/src/app/api/auth/steward/oauth/exchange/route.ts
@@ -1,0 +1,180 @@
+/**
+ * POST /api/auth/steward/oauth/exchange
+ *
+ * Server-side half of Feed's Steward `response_type=code` OAuth flow.
+ * The browser callback page POSTs the one-time code + PKCE verifier here;
+ * we forward to Steward `POST /auth/oauth/exchange` and return tokens.
+ */
+
+import { withErrorHandling } from "@feed/api";
+import { type NextRequest, NextResponse } from "next/server";
+import { signStewardMutatingRequest } from "@/lib/auth/steward-request-sign";
+import { STEWARD_API_URL } from "@/lib/auth/steward-server";
+
+const DEFAULT_TENANT_ID =
+  process.env.STEWARD_TENANT_ID ??
+  process.env.NEXT_PUBLIC_STEWARD_TENANT_ID ??
+  "feed";
+
+type ExchangeBody = {
+  code?: string;
+  redirectUri?: string;
+  tenantId?: string;
+  codeVerifier?: string;
+};
+
+type StewardExchangeOk = {
+  ok: true;
+  token: string;
+  refreshToken?: string;
+};
+
+type StewardExchangeErr = {
+  ok: false;
+  error?: string;
+  code?: string;
+};
+
+async function callStewardExchange(body: {
+  code: string;
+  redirect_uri: string;
+  tenant_id: string;
+  code_verifier: string;
+}): Promise<
+  | { kind: "ok"; data: StewardExchangeOk }
+  | { kind: "error"; status: number; data: StewardExchangeErr }
+  | { kind: "transport"; message: string }
+> {
+  const exchangeUrl = new URL(`${STEWARD_API_URL}/auth/oauth/exchange`);
+  const headers = new Headers({
+    "Content-Type": "application/json",
+    Accept: "application/json",
+    "X-Steward-Tenant": body.tenant_id,
+  });
+  const bodyText = JSON.stringify(body);
+  const bodyBytes = new TextEncoder().encode(bodyText);
+
+  const signingSecret = process.env.STEWARD_REQUEST_SIGNING_SECRET?.trim();
+  if (signingSecret) {
+    await signStewardMutatingRequest(
+      signingSecret,
+      "POST",
+      `${exchangeUrl.pathname}${exchangeUrl.search}`,
+      headers,
+      bodyBytes,
+    );
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(exchangeUrl.toString(), {
+      method: "POST",
+      headers,
+      body: bodyText,
+    });
+  } catch (err) {
+    return {
+      kind: "transport",
+      message: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const text = await response.text();
+  let parsed: StewardExchangeOk | StewardExchangeErr | null = null;
+  try {
+    parsed = text
+      ? (JSON.parse(text) as StewardExchangeOk | StewardExchangeErr)
+      : null;
+  } catch {
+    parsed = null;
+  }
+
+  if (!response.ok || !parsed || parsed.ok !== true) {
+    return {
+      kind: "error",
+      status: response.status,
+      data: (parsed as StewardExchangeErr) ?? {
+        ok: false,
+        error: text || "Steward exchange failed",
+      },
+    };
+  }
+
+  return { kind: "ok", data: parsed };
+}
+
+export const POST = withErrorHandling(async (req: NextRequest) => {
+  let body: ExchangeBody;
+  try {
+    body = (await req.json()) as ExchangeBody;
+  } catch {
+    return NextResponse.json(
+      { ok: false, error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+
+  const code = typeof body.code === "string" ? body.code.trim() : "";
+  const redirectUri =
+    typeof body.redirectUri === "string" ? body.redirectUri.trim() : "";
+  const tenantId =
+    typeof body.tenantId === "string" && body.tenantId.trim().length > 0
+      ? body.tenantId.trim()
+      : DEFAULT_TENANT_ID;
+  const codeVerifier =
+    typeof body.codeVerifier === "string" ? body.codeVerifier.trim() : "";
+
+  if (!code) {
+    return NextResponse.json(
+      { ok: false, error: "code is required", code: "missing_code" },
+      { status: 400 },
+    );
+  }
+  if (!redirectUri) {
+    return NextResponse.json(
+      { ok: false, error: "redirectUri is required" },
+      { status: 400 },
+    );
+  }
+  if (!codeVerifier) {
+    return NextResponse.json(
+      { ok: false, error: "codeVerifier is required" },
+      { status: 400 },
+    );
+  }
+
+  const result = await callStewardExchange({
+    code,
+    redirect_uri: redirectUri,
+    tenant_id: tenantId,
+    code_verifier: codeVerifier,
+  });
+
+  if (result.kind === "transport") {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Steward upstream unavailable",
+        code: "steward_upstream_unavailable",
+      },
+      { status: 502 },
+    );
+  }
+
+  if (result.kind === "error") {
+    return NextResponse.json(
+      {
+        ok: false,
+        error: result.data.error ?? "Steward exchange failed",
+        code: result.data.code ?? "exchange_failed",
+      },
+      { status: result.status >= 400 ? result.status : 502 },
+    );
+  }
+
+  return NextResponse.json({
+    ok: true,
+    token: result.data.token,
+    refreshToken: result.data.refreshToken ?? null,
+  });
+});

--- a/packages/feed/apps/web/src/app/auth/callback/[provider]/page.tsx
+++ b/packages/feed/apps/web/src/app/auth/callback/[provider]/page.tsx
@@ -1,34 +1,51 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useEffect, useRef } from "react";
 import { useStewardAuthContext } from "@/components/providers/StewardAuthProvider";
+import {
+  buildFeedOAuthRedirectUri,
+  consumeStewardPkceVerifier,
+  type FeedStewardOAuthProvider,
+} from "@/lib/steward-oauth";
+
+const STEWARD_TENANT_ID = process.env.NEXT_PUBLIC_STEWARD_TENANT_ID ?? "feed";
+
+function isFeedOAuthProvider(value: string): value is FeedStewardOAuthProvider {
+  return value === "google" || value === "discord" || value === "twitter";
+}
 
 /**
  * OAuth callback page for Steward OAuth providers (Google, Discord, Twitter/X).
  *
- * Steward redirects here after a successful OAuth flow with:
- *   ?token=<jwt>&refresh_token=<rt>   (on success)
- *   ?error=<message>                  (on failure)
+ * PKCE code flow (current):
+ *   ?code=<nonce>  → POST /api/auth/steward/oauth/exchange → session cookies
  *
- * Security: Immediately sanitizes the URL via replaceState() to prevent
- * the JWT from appearing in browser history, referrer headers, or server logs.
+ * Legacy token-in-URL flow (backward compat during rollout):
+ *   ?token=<jwt>&refresh_token=<rt>
  */
 export default function OAuthCallbackPage() {
   const { onLoginSuccess } = useStewardAuthContext();
   const router = useRouter();
+  const params = useParams<{ provider: string }>();
   const processed = useRef(false);
 
   useEffect(() => {
     if (processed.current) return;
     processed.current = true;
 
-    const params = new URLSearchParams(window.location.search);
-    const token = params.get("token");
-    const refreshToken = params.get("refresh_token") ?? undefined;
-    const error = params.get("error");
+    const provider = params.provider;
+    if (!provider || !isFeedOAuthProvider(provider)) {
+      router.replace("/?auth_error=invalid_provider");
+      return;
+    }
 
-    // Sanitize URL immediately — remove sensitive query params from history
+    const searchParams = new URLSearchParams(window.location.search);
+    const error = searchParams.get("error");
+    const code = searchParams.get("code");
+    const token = searchParams.get("token");
+    const refreshToken = searchParams.get("refresh_token") ?? undefined;
+
     window.history.replaceState(null, "", window.location.pathname);
 
     if (error) {
@@ -36,19 +53,56 @@ export default function OAuthCallbackPage() {
       return;
     }
 
-    if (!token) {
-      router.replace("/?auth_error=missing_token");
+    if (token) {
+      onLoginSuccess(token, refreshToken)
+        .then(() => router.replace("/"))
+        .catch((err: Error) => {
+          router.replace(`/?auth_error=${encodeURIComponent(err.message)}`);
+        });
       return;
     }
 
-    onLoginSuccess(token, refreshToken)
-      .then(() => {
-        router.replace("/");
+    if (!code) {
+      router.replace("/?auth_error=missing_code");
+      return;
+    }
+
+    const codeVerifier = consumeStewardPkceVerifier();
+    if (!codeVerifier) {
+      router.replace("/?auth_error=missing_pkce_verifier");
+      return;
+    }
+
+    const redirectUri = buildFeedOAuthRedirectUri(window.location.origin, provider);
+
+    fetch("/api/auth/steward/oauth/exchange", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({
+        code,
+        redirectUri,
+        tenantId: STEWARD_TENANT_ID,
+        codeVerifier,
+      }),
+    })
+      .then(async (response) => {
+        const data = (await response.json()) as {
+          ok: boolean;
+          token?: string;
+          refreshToken?: string | null;
+          error?: string;
+        };
+        if (!response.ok || !data.ok || !data.token) {
+          throw new Error(data.error ?? "OAuth exchange failed");
+        }
+        return onLoginSuccess(data.token, data.refreshToken ?? undefined);
       })
+      .then(() => router.replace("/"))
       .catch((err: Error) => {
         router.replace(`/?auth_error=${encodeURIComponent(err.message)}`);
       });
-  }, [onLoginSuccess, router]);
+  }, [onLoginSuccess, params.provider, router]);
 
   return (
     <div className="flex min-h-dvh items-center justify-center">

--- a/packages/feed/apps/web/src/components/auth/LoginModal.tsx
+++ b/packages/feed/apps/web/src/components/auth/LoginModal.tsx
@@ -14,6 +14,13 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { useAuth } from "@/hooks/useAuth";
+import {
+  buildFeedOAuthRedirectUri,
+  buildStewardOAuthAuthorizeUrl,
+  createStewardPkcePair,
+  storeStewardPkceVerifier,
+  type FeedStewardOAuthProvider,
+} from "@/lib/steward-oauth";
 
 /**
  * Steward-backed login modal.
@@ -52,17 +59,22 @@ function requireCompletedAuth(
   return result;
 }
 
-/** Build the Steward OAuth authorize URL. Callback lands on our /auth/callback/[provider] page. */
-function oauthUrl(provider: string): string {
-  const stewardBase = getStewardApiUrl();
-  const callbackBase =
-    typeof window !== "undefined" ? window.location.origin : "";
-  const redirectUri = `${callbackBase}/auth/callback/${provider}`;
-  return (
-    `${stewardBase}/auth/oauth/${provider}/authorize` +
-    `?redirect_uri=${encodeURIComponent(redirectUri)}` +
-    `&tenant_id=${encodeURIComponent(STEWARD_TENANT_ID)}`
-  );
+async function startOAuthRedirect(
+  provider: FeedStewardOAuthProvider,
+): Promise<void> {
+  const origin = window.location.origin;
+  const redirectUri = buildFeedOAuthRedirectUri(origin, provider);
+  const pkce = await createStewardPkcePair();
+  if (!storeStewardPkceVerifier(pkce.verifier)) {
+    throw new Error(
+      "Could not start sign-in — browser storage is unavailable. Enable cookies / site data and try again.",
+    );
+  }
+  window.location.href = buildStewardOAuthAuthorizeUrl(provider, redirectUri, {
+    stewardApiUrl: getStewardApiUrl(),
+    stewardTenantId: STEWARD_TENANT_ID,
+    codeChallenge: pkce.challenge,
+  });
 }
 
 export function LoginModal({
@@ -137,8 +149,16 @@ export function LoginModal({
   }, [email, stewardAuth, onLoginSuccess]);
 
   const handleOAuth = useCallback(
-    (provider: "google" | "discord" | "twitter") => {
-      window.location.href = oauthUrl(provider);
+    (provider: FeedStewardOAuthProvider) => {
+      setStep("loading");
+      setErrorMsg("");
+      void startOAuthRedirect(provider).catch((err: unknown) => {
+        const msg =
+          err instanceof Error ? err.message : "Could not start OAuth sign-in";
+        logger.warn("OAuth redirect failed", { error: msg }, "LoginModal");
+        setErrorMsg(msg);
+        setStep("error");
+      });
     },
     [],
   );

--- a/packages/feed/apps/web/src/lib/auth/steward-request-sign.ts
+++ b/packages/feed/apps/web/src/lib/auth/steward-request-sign.ts
@@ -1,0 +1,104 @@
+/**
+ * Steward request-signing helper for Feed server routes that call Steward
+ * directly (mirrors @elizaos/cloud-shared/lib/steward/sign.ts).
+ */
+
+const REQUEST_TTL_SECONDS = 60;
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = "";
+  for (let i = 0; i < bytes.length; i += 1) {
+    out += bytes[i].toString(16).padStart(2, "0");
+  }
+  return out;
+}
+
+async function sha256Hex(input: BufferSource): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", input);
+  return bytesToHex(new Uint8Array(digest));
+}
+
+async function sha256TextHex(value: string): Promise<string> {
+  return sha256Hex(new TextEncoder().encode(value));
+}
+
+async function hmacSha256Hex(secret: string, message: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(message),
+  );
+  return bytesToHex(new Uint8Array(signature));
+}
+
+export async function buildStewardCanonicalRequest(
+  method: string,
+  pathAndSearch: string,
+  headers: Headers,
+  body: BufferSource,
+): Promise<string> {
+  const bodyHash = await sha256Hex(body);
+  const authHash = await sha256TextHex(headers.get("authorization") ?? "");
+  const apiKeyHash = await sha256TextHex(headers.get("x-steward-key") ?? "");
+  const platformKeyHash = await sha256TextHex(
+    headers.get("x-steward-platform-key") ?? "",
+  );
+  const signerIdHash = await sha256TextHex(
+    headers.get("x-steward-signer-id") ?? "",
+  );
+  const signerSecretHash = await sha256TextHex(
+    headers.get("x-steward-signer-secret") ?? "",
+  );
+  const quorumIdHash = await sha256TextHex(
+    headers.get("x-steward-key-quorum-id") ?? "",
+  );
+  const quorumCredentialsHash = await sha256TextHex(
+    headers.get("x-steward-key-quorum-credentials") ?? "",
+  );
+  return [
+    "steward-request-signature-v1",
+    method.toUpperCase(),
+    pathAndSearch,
+    headers.get("x-steward-tenant") ?? "",
+    authHash,
+    apiKeyHash,
+    platformKeyHash,
+    signerIdHash,
+    signerSecretHash,
+    quorumIdHash,
+    quorumCredentialsHash,
+    headers.get("x-steward-request-timestamp") ?? "",
+    headers.get("x-steward-request-expires-at") ?? "",
+    headers.get("idempotency-key") ?? "",
+    bodyHash,
+  ].join("\n");
+}
+
+export async function signStewardMutatingRequest(
+  secret: string,
+  method: string,
+  pathAndSearch: string,
+  headers: Headers,
+  body: BufferSource,
+): Promise<void> {
+  const expiresAt = Math.floor(Date.now() / 1000) + REQUEST_TTL_SECONDS;
+  headers.set("x-steward-request-expires-at", String(expiresAt));
+  if (!headers.get("idempotency-key")) {
+    headers.set("idempotency-key", crypto.randomUUID());
+  }
+  const canonical = await buildStewardCanonicalRequest(
+    method,
+    pathAndSearch,
+    headers,
+    body,
+  );
+  const signature = await hmacSha256Hex(secret, canonical);
+  headers.set("x-steward-signature", `v1=${signature}`);
+}

--- a/packages/feed/apps/web/src/lib/steward-oauth.test.ts
+++ b/packages/feed/apps/web/src/lib/steward-oauth.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFeedOAuthRedirectUri,
+  buildStewardOAuthAuthorizeUrl,
+  createStewardPkceChallenge,
+  createStewardPkcePair,
+} from "./steward-oauth";
+
+describe("steward-oauth", () => {
+  it("createStewardPkcePair challenge is the S256 hash of its verifier", async () => {
+    const { verifier, challenge } = await createStewardPkcePair();
+    expect(await createStewardPkceChallenge(verifier)).toBe(challenge);
+  });
+
+  it("buildFeedOAuthRedirectUri targets the provider callback page", () => {
+    expect(buildFeedOAuthRedirectUri("https://feed.example", "google")).toBe(
+      "https://feed.example/auth/callback/google",
+    );
+  });
+
+  it("buildStewardOAuthAuthorizeUrl includes PKCE params when challenge provided", () => {
+    const url = buildStewardOAuthAuthorizeUrl(
+      "discord",
+      "https://feed.example/auth/callback/discord",
+      {
+        stewardApiUrl: "https://auth.elizacloud.ai",
+        stewardTenantId: "feed",
+        codeChallenge: "challenge-abc",
+      },
+    );
+    const parsed = new URL(url);
+    expect(parsed.pathname).toBe("/auth/oauth/discord/authorize");
+    expect(parsed.searchParams.get("response_type")).toBe("code");
+    expect(parsed.searchParams.get("code_challenge")).toBe("challenge-abc");
+    expect(parsed.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(parsed.searchParams.get("redirect_uri")).toBe(
+      "https://feed.example/auth/callback/discord",
+    );
+    expect(parsed.searchParams.get("tenant_id")).toBe("feed");
+  });
+});

--- a/packages/feed/apps/web/src/lib/steward-oauth.ts
+++ b/packages/feed/apps/web/src/lib/steward-oauth.ts
@@ -1,0 +1,140 @@
+/**
+ * Steward OAuth PKCE helpers for Feed (RFC 7636).
+ *
+ * Steward's `/auth/oauth/:provider/authorize` requires a S256 `code_challenge`
+ * when `response_type=code`. Mint a verifier/challenge pair, send the challenge
+ * at /authorize, stash the verifier in browser storage, and replay it at
+ * /api/auth/steward/oauth/exchange.
+ */
+
+export type FeedStewardOAuthProvider = "google" | "discord" | "twitter";
+
+const STEWARD_PKCE_VERIFIER_STORAGE_KEY = "steward.oauth.pkce.verifier";
+const STEWARD_PKCE_VERIFIER_TTL_MS = 10 * 60 * 1000;
+const PKCE_VERIFIER_BYTES = 48;
+
+type StoredPkceVerifier = {
+  verifier: string;
+  expiresAt: number;
+};
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+export function generateStewardPkceVerifier(): string {
+  const bytes = new Uint8Array(PKCE_VERIFIER_BYTES);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}
+
+export async function createStewardPkceChallenge(
+  verifier: string,
+): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(verifier),
+  );
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+export interface StewardPkcePair {
+  verifier: string;
+  challenge: string;
+}
+
+export async function createStewardPkcePair(): Promise<StewardPkcePair> {
+  const verifier = generateStewardPkceVerifier();
+  const challenge = await createStewardPkceChallenge(verifier);
+  return { verifier, challenge };
+}
+
+export function storeStewardPkceVerifier(verifier: string): boolean {
+  if (typeof window === "undefined") return false;
+  const stored = JSON.stringify({
+    verifier,
+    expiresAt: Date.now() + STEWARD_PKCE_VERIFIER_TTL_MS,
+  } satisfies StoredPkceVerifier);
+  let storedAnywhere = false;
+  try {
+    window.sessionStorage.setItem(STEWARD_PKCE_VERIFIER_STORAGE_KEY, stored);
+    storedAnywhere = true;
+  } catch {
+    // private mode / disabled storage
+  }
+  try {
+    window.localStorage.setItem(STEWARD_PKCE_VERIFIER_STORAGE_KEY, stored);
+    storedAnywhere = true;
+  } catch {
+    // same as above
+  }
+  return storedAnywhere;
+}
+
+export function consumeStewardPkceVerifier(): string | null {
+  if (typeof window === "undefined") return null;
+  const sessionVerifier = consumeStoredPkceVerifier(window.sessionStorage);
+  const localVerifier = consumeStoredPkceVerifier(window.localStorage);
+  return sessionVerifier ?? localVerifier;
+}
+
+function consumeStoredPkceVerifier(storage: Storage): string | null {
+  try {
+    const verifier = storage.getItem(STEWARD_PKCE_VERIFIER_STORAGE_KEY);
+    storage.removeItem(STEWARD_PKCE_VERIFIER_STORAGE_KEY);
+    return parseStoredPkceVerifier(verifier);
+  } catch {
+    return null;
+  }
+}
+
+function parseStoredPkceVerifier(value: string | null): string | null {
+  if (!value) return null;
+  try {
+    const parsed = JSON.parse(value) as Partial<StoredPkceVerifier>;
+    if (
+      typeof parsed.verifier === "string" &&
+      typeof parsed.expiresAt === "number" &&
+      parsed.expiresAt >= Date.now()
+    ) {
+      return parsed.verifier;
+    }
+    return null;
+  } catch {
+    return value;
+  }
+}
+
+export function buildFeedOAuthRedirectUri(
+  origin: string,
+  provider: FeedStewardOAuthProvider,
+): string {
+  return `${origin}/auth/callback/${provider}`;
+}
+
+export function buildStewardOAuthAuthorizeUrl(
+  provider: FeedStewardOAuthProvider,
+  redirectUri: string,
+  options: {
+    stewardApiUrl: string;
+    stewardTenantId?: string;
+    codeChallenge?: string;
+  },
+): string {
+  const params = new URLSearchParams({
+    redirect_uri: redirectUri,
+    tenant_id: options.stewardTenantId ?? "feed",
+    response_type: "code",
+  });
+  if (options.codeChallenge) {
+    params.set("code_challenge", options.codeChallenge);
+    params.set("code_challenge_method", "S256");
+  }
+  const stewardApiUrl = options.stewardApiUrl.replace(/\/+$/, "");
+  return `${stewardApiUrl}/auth/oauth/${provider}/authorize?${params.toString()}`;
+}


### PR DESCRIPTION
## Summary
- Completes the **#8257 OAuth half** for the Feed app — the only remaining monorepo login surface still building plain `/authorize` URLs without PKCE.
- Feed `LoginModal` now mints PKCE verifier/challenge, sends `code_challenge` + `response_type=code` at `/authorize`, and stores the verifier for callback replay.
- New `POST /api/auth/steward/oauth/exchange` forwards the code + verifier to Steward server-side (with optional `STEWARD_REQUEST_SIGNING_SECRET` signing for prod).
- OAuth callback page handles `?code=` (PKCE flow) and keeps legacy `?token=` backward compat during rollout.

Related: #8350 covers cloud-frontend + os-homepage; this PR covers Feed.

## Test plan
- [x] `bun x vitest run apps/web/src/lib/steward-oauth.test.ts` (3 tests)
- [ ] Manual: Feed login → Google/Discord/X → callback completes sign-in
- [ ] Fork CI after maintainer workflow approval

Fixes #8257 (OAuth half — email/send 400 remains Steward service)
