### PR TITLE
chore(cloud): autoscale minFreeSlotsBuffer default 4 -> 2 (iso prod/staging)

### DIFF
--- a/packages/cloud-shared/src/lib/config/containers-env.ts
+++ b/packages/cloud-shared/src/lib/config/containers-env.ts
@@ -328,15 +328,15 @@ export const containersEnv = {
    * provisioned. Also acts as the drain preservation floor: a drain is
    * refused if it would leave the pool below this number of free slots.
    *
-   * Smaller buffer → pool can collapse to fewer nodes when demand is low
-   * (right for staging). Larger buffer → hot-start latency reserved (right
-   * for prod). Clamped to [0, 64]. Default: 4.
+   * Default: 2 — half a 4-slot node kept hot across the pool. Bump via env
+   * for fleets where the cold-start tail matters more than node cost.
+   * Clamped to [0, 64].
    */
   autoscaleMinFreeSlotsBuffer(): number {
     const env = getCloudAwareEnv();
     const raw = pick(env.CONTAINERS_AUTOSCALE_MIN_FREE_SLOTS_BUFFER);
     const parsed = raw !== undefined ? Number(raw) : Number.NaN;
-    return Number.isFinite(parsed) && parsed >= 0 ? Math.min(64, Math.floor(parsed)) : 4;
+    return Number.isFinite(parsed) && parsed >= 0 ? Math.min(64, Math.floor(parsed)) : 2;
   },
 
   /**


### PR DESCRIPTION
## Why

After #8353 made `CONTAINERS_AUTOSCALE_MIN_FREE_SLOTS_BUFFER` env-configurable, staging was overridden to `2` to collapse to 1 node when idle, but prod kept the code default `4`. Same daemon code, different scaling shape — silent env divergence.

`staging doit être iso prod` is the explicit requirement here: the autoscaler must behave identically across envs unless explicitly tuned.

## What

`autoscaleMinFreeSlotsBuffer()` default 4 → 2 in `containers-env.ts`.

Behavior:

```
1 agent  -> 1 node (4 slots, 1 used, 3 free >= buffer 2 -> drain refused at 0 nodes)
4 agents -> 1 node (full, 0 free < buffer 2 -> scale up triggered)
5 agents -> 2 nodes
```

Same as staging today; prod converges down from "always 2 hot nodes" to "collapse when idle".

## After merge

Drop the `CONTAINERS_AUTOSCALE_MIN_FREE_SLOTS_BUFFER=2` line from the staging daemon `/opt/eliza/cloud/.env.local` — the override is now redundant. Restart `eliza-cloud-provisioning-worker` once dropped. (Daemon still picks up the new default from the next image / next daemon restart anyway, but the override leaves drift behind.)

## Not changed

- `autoscaleMinHotAvailableSlots()` default stays at `1` — different knob, different concern (emergency floor for hot starts bypassing cooldown), no symmetry issue.
- Test fixture in `node-autoscaler.test.ts` still uses `minFreeSlotsBuffer: 4` — the policy is constructed explicitly for the test, not asserting the default, so the test stays valid.