### PR TITLE
ci: terraform-control-plane.yml workflow (plan/apply control-plane per env)

### DIFF
--- a/.github/workflows/terraform-control-plane.yml
+++ b/.github/workflows/terraform-control-plane.yml
@@ -1,0 +1,127 @@
+name: Terraform — Control Plane (Hetzner)
+
+# Plan/apply the Eliza Cloud control-plane IaC
+# (packages/cloud-infra/cloud/terraform/hetzner/control-plane).
+#
+#   pull_request touching the module -> fmt + validate (NO cloud creds, no state — safe)
+#   workflow_dispatch (manual)        -> terraform plan or apply against an
+#                                        environment (staging | production)
+#
+# Apply provisions a real billed Hetzner control-plane VM (the box that runs
+# eliza-provisioning-worker, agent-router, headscale, and cloudflared). It is
+# an explicit operator action — it never auto-runs.
+# "develop = staging" is expressed by choosing environment=staging on dispatch.
+#
+# Secrets:
+#   environment-scoped (set on each `staging` / `production` GitHub Environment):
+#     HCLOUD_TOKEN                  Hetzner Cloud API token for that env's project
+#   repo-level (already present in this repo):
+#     CLOUDFLARE_API_TOKEN          Cloudflare DNS token (control-plane A record)
+#     R2_STATE_ACCESS_KEY_ID        R2 token -> AWS_ACCESS_KEY_ID (tf state backend)
+#     R2_STATE_SECRET_ACCESS_KEY    R2 token -> AWS_SECRET_ACCESS_KEY (tf state backend)
+# Variables (environment-scoped — shared with apps-data-plane workflow):
+#   APPS_CLOUDFLARE_ZONE_ID         Cloudflare zone id for elizacloud.ai (one zone)
+#   APPS_OPERATOR_SSH_KEY           operator SSH public key allowed onto the VM
+
+on:
+  pull_request:
+    paths:
+      - "packages/cloud-infra/cloud/terraform/hetzner/control-plane/**"
+      - ".github/workflows/terraform-control-plane.yml"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Environment to target
+        type: choice
+        default: staging
+        options: [staging, production]
+      action:
+        description: terraform action
+        type: choice
+        default: plan
+        options: [plan, apply]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# Serialize plan/apply per env across branches so two operators can't apply
+# the same env concurrently. PR validation stays parallel (different group).
+concurrency:
+  group: terraform-control-plane-${{ github.event.inputs.environment || format('pr-{0}', github.ref) }}
+  cancel-in-progress: false
+
+env:
+  TF_DIR: packages/cloud-infra/cloud/terraform/hetzner/control-plane
+  TF_VERSION: "1.9.5"
+
+jobs:
+  # PR validation: format + validate only. No cloud credentials, no remote state,
+  # so it runs safely on every PR (incl. before the env HCLOUD_TOKEN exists).
+  validate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+      - name: terraform fmt -check
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform fmt -check -recursive
+      - name: terraform validate (no backend)
+        working-directory: ${{ env.TF_DIR }}
+        run: |
+          terraform init -backend=false -input=false
+          terraform validate -no-color
+
+  # Manual plan/apply against a real environment. The `environment:` binding makes
+  # that env's HCLOUD_TOKEN (and any required reviewers) apply to this run.
+  plan-apply:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
+    env:
+      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      # R2 (S3-compatible) state backend creds.
+      AWS_ACCESS_KEY_ID: ${{ secrets.R2_STATE_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_STATE_SECRET_ACCESS_KEY }}
+      # Non-secret inputs threaded as TF_VAR_*. The zone id is accepted as either
+      # a secret OR a var (operators have set it both ways) — secret wins if present.
+      TF_VAR_environment: ${{ github.event.inputs.environment }}
+      TF_VAR_cloudflare_zone_id: ${{ secrets.APPS_CLOUDFLARE_ZONE_ID || vars.APPS_CLOUDFLARE_ZONE_ID }}
+      TF_VAR_ssh_public_keys: '["${{ vars.APPS_OPERATOR_SSH_KEY }}"]'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: ${{ env.TF_VERSION }}
+
+      - name: Preflight — required secrets / vars present
+        run: |
+          fail=0
+          [ -n "$HCLOUD_TOKEN" ] || { echo "::error::set secrets.HCLOUD_TOKEN on the '${{ github.event.inputs.environment }}' environment"; fail=1; }
+          [ -n "$AWS_ACCESS_KEY_ID" ] || { echo "::error::missing repo secret R2_STATE_ACCESS_KEY_ID"; fail=1; }
+          [ -n "$AWS_SECRET_ACCESS_KEY" ] || { echo "::error::missing repo secret R2_STATE_SECRET_ACCESS_KEY"; fail=1; }
+          [ -n "$CLOUDFLARE_API_TOKEN" ] || { echo "::error::missing repo secret CLOUDFLARE_API_TOKEN"; fail=1; }
+          [ -n "$TF_VAR_cloudflare_zone_id" ] || { echo "::error::set APPS_CLOUDFLARE_ZONE_ID (secret or var) on the '${{ github.event.inputs.environment }}' environment"; fail=1; }
+          [ "$TF_VAR_ssh_public_keys" != '[""]' ] || { echo "::error::set vars.APPS_OPERATOR_SSH_KEY on the '${{ github.event.inputs.environment }}' environment"; fail=1; }
+          exit $fail
+
+      - name: terraform fmt -check
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform fmt -check -recursive
+
+      - name: terraform init (R2 backend)
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform init -input=false -backend-config="backend-${{ github.event.inputs.environment }}.hcl"
+
+      - name: terraform plan
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform plan -no-color -input=false
+
+      - name: terraform apply
+        if: github.event.inputs.action == 'apply'
+        working-directory: ${{ env.TF_DIR }}
+        run: terraform apply -auto-approve -input=false


### PR DESCRIPTION
## Why

The Hetzner control-plane TF module (`packages/cloud-infra/cloud/terraform/hetzner/control-plane/`) had no GHA workflow. That left the prod + staging control-plane VMs (\`eliza-1\`, \`eliza-staging-1\`) outside TF state — they were manually created in the default Hetzner project and never imported.

To migrate them into per-env projects (\`eliza-prod\`, \`eliza-staging\`) we need a workflow.

## What

Mirror of \`terraform-apps-data-plane.yml\` retargeted at the control-plane module.

### Triggers
- \`pull_request\` touching the module → \`fmt -check\` + \`validate\` (no creds, safe)
- \`workflow_dispatch\` → plan or apply against \`staging\` or \`production\`

### Concurrency
- Apply / plan on a real env: serialized per env across branches (\`terraform-control-plane-{env}\`). Drops \`github.ref\` from the group so two branches can't race on the same R2 state.
- PR validation: parallel per ref (\`pr-{ref}\` fallback).

### Vars (shared with apps-data-plane on purpose)
- \`HCLOUD_TOKEN\` — env-scoped (already set on both \`staging\` + \`production\`)
- \`APPS_CLOUDFLARE_ZONE_ID\` — env-scoped, one zone for \`elizacloud.ai\`
- \`APPS_OPERATOR_SSH_KEY\` — env-scoped, same operator key

Sharing the same vars as apps-data-plane is intentional — one operator key, one DNS zone, one HCLOUD token per env. Renaming would just churn the var without changing the value.

## Test plan

- [ ] PR validation passes (fmt + validate)
- [ ] After merge, run \`gh workflow run terraform-control-plane.yml --ref develop -f environment=staging -f action=plan\`
- [ ] Expect: 3 adds (1 hcloud_server, 1 hcloud_ssh_key, 1 cloudflare_dns_record) in the new \`eliza-staging\` project, 0 destroys
- [ ] If plan clean, follow up with \`action=apply\` to spawn the new \`eliza-staging-1\` VM
- [ ] Migrate secrets + headscale state to the new VM, then DNS cutover