### PR TITLE
fix(infra): control-plane default server type cpx21 -> cpx32 (cpx21 retired in fsn1)

### DIFF
--- a/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
@@ -9,7 +9,8 @@ split so we stop treating manually-created VMs as "infrastructure-by-prayer".
 ┌──────────────────────────────────────────────────────────────┐
 │  Tier 1 — Control plane (static, 1-2 VMs, Terraform)        │
 │                                                              │
-│   eliza-1   (Hetzner cpx21, fsn1)             │
+│   eliza-1   (Hetzner cax21 ARM, fsn1, manual)               │
+│   eliza-staging-1   (Hetzner cpx32 x86, fsn1)               │
 │     ├── eliza-provisioning-worker  (systemd, queue consumer)│
 │     ├── eliza-agent-router         (systemd, HTTP routing)  │
 │     ├── headscale                  (VPN mesh)               │
@@ -18,7 +19,8 @@ split so we stop treating manually-created VMs as "infrastructure-by-prayer".
 │     └── (optional: grafana/prometheus)                      │
 │                                                              │
 │   Lifecycle: long-lived. Replaced on demand, not autoscaled.│
-│   Cost: ~€5/mo per VM (cpx21).                              │
+│   Cost: prod ~€7/mo (cax21), staging ~€11/mo (cpx32).       │
+│   See variables.tf for cpx21→cpx32 retirement + ARM notes.  │
 └──────────────────────────────────────────────────────────────┘
                               │ enqueue / SSH
                               ▼

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
@@ -79,10 +79,14 @@ These are tracked as follow-ups in
 
 | Component                    | Resource    | Monthly (€) |
 |------------------------------|-------------|-------------|
-| 1× cpx21 (3 vCPU / 4 GB)     | control VM  | ~5          |
+| 1× cpx32 (4 vCPU / 8 GB) x86 | control VM  | ~11         |
 | 1× IPv4 + IPv6               | floating IP | included    |
 | Cloudflare R2 state          | < 100 KB    | 0           |
-| **Total per environment**    |             | **~5**      |
+| **Total per environment**    |             | **~11**     |
+
+The default is `cpx32` since Hetzner retired `cpx21` in `fsn1`. Production VM
+`eliza-1` actually runs `cax21` (ARM, ~€7/mo, manually provisioned) — flipping
+prod via TF needs the cloud-init arm64 templating fix tracked as a followup.
 
 A 2nd control-plane VM (HA, currently unused) doubles the line. The
 **data-plane autoscale** cost is separate and elastic.

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
@@ -78,12 +78,11 @@ runcmd:
   - curl -fsSL https://deb.nodesource.com/setup_24.x | bash -
   - apt-get install -y nodejs
 
-  # Swap: the staging cpx32 / cpx22 / cax11 shapes are too small to run
-  # `turbo run build --filter=@elizaos/...` (19+ packages in parallel)
-  # without OOM-killing one of the workspace builds. 8 GB swap is enough
-  # headroom that the build completes even under memory pressure; on
-  # bigger control-plane shapes (cax21 8 GB) this is unused. Persists
-  # across reboots via /etc/fstab.
+  # Swap as defensive headroom: cpx32 (8 GB) and cax21 (8 GB) both fit the
+  # workspace build, but a parallel `turbo run build` can spike past RSS
+  # and OOM-kill one of the packages. 8 GB swap absorbs the peak. On
+  # smaller shapes (cpx11 2 GB, cax11 4 GB) this is the only way the
+  # build completes at all. Persists across reboots via /etc/fstab.
   - test -f /swapfile || fallocate -l 8G /swapfile
   - chmod 600 /swapfile
   - mkswap /swapfile || true

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
@@ -53,10 +53,11 @@ resource "hcloud_server" "control_plane" {
   # shouldn't recreate the box, only update in place where possible.
   lifecycle {
     ignore_changes = [
-      user_data, # bootstrap runs once at first boot
-      image,     # updating image rebuilds — explicit `terraform taint` to opt in
-      name,      # legacy VMs may not follow the env-prefixed naming convention; renaming is out of band
-      ssh_keys,  # operator key rotations don't recreate the box (keys are baked into authorized_keys at boot)
+      user_data,   # bootstrap runs once at first boot
+      image,       # updating image rebuilds — explicit `terraform taint` to opt in
+      name,        # legacy VMs may not follow the env-prefixed naming convention; renaming is out of band
+      ssh_keys,    # operator key rotations don't recreate the box (keys are baked into authorized_keys at boot)
+      server_type, # cross-arch flips (cax21 ARM ↔ cpx32 x86) are ForceNew, not in-place; would wipe headscale + cloudflared state on adopt-existing-vm import. Resize must go through `terraform taint` or out-of-band `hcloud server change-type` before plan/apply.
     ]
   }
 }

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/tfvars/production.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/tfvars/production.tfvars.example
@@ -1,6 +1,8 @@
 environment           = "production"
 hcloud_location       = "fsn1"
-hcloud_server_type    = "cpx21"
+# Production VM eliza-1 runs cax21 (ARM) today. Keep tfvars on x86 cpx32 for now
+# — flipping prod to cax21 via TF needs the cloud-init arm64 fix (followup).
+hcloud_server_type    = "cpx32"
 control_plane_count   = 1
 cloudflare_zone_id    = "<zone-id-for-elizacloud.ai>"
 

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/tfvars/staging.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/tfvars/staging.tfvars.example
@@ -2,7 +2,7 @@
 
 environment           = "staging"
 hcloud_location       = "fsn1"
-hcloud_server_type    = "cpx21"
+hcloud_server_type    = "cpx32"
 control_plane_count   = 1
 cloudflare_zone_id    = "<zone-id-for-elizacloud.ai>"
 

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf
@@ -27,9 +27,9 @@ variable "hcloud_location" {
 }
 
 variable "hcloud_server_type" {
-  description = "Hetzner server type for the control-plane VM. cpx21 = 3 vCPU / 4 GB / 80 GB SSD ≈ €5/mo, enough for daemon + agent-router + headscale + monitoring."
+  description = "Hetzner server type for the control-plane VM. cpx32 = 4 vCPU / 8 GB / 160 GB SSD ≈ €11/mo, matches the existing staging eliza-staging-1 manually-provisioned VM. Previously cpx21 (3 vCPU / 4 GB) but Hetzner retired cpx21 in fsn1. Production runs cax21 (ARM) — switching staging to ARM would save ~€4/mo and unblock future cpx retirement, but needs a few cloud-init template tweaks (docker apt arch + bun-linux-aarch64 archive). Staging stays on x86 cpx32 here for parity with the proven-working setup; ARM migration is followup."
   type        = string
-  default     = "cpx21"
+  default     = "cpx32"
 }
 
 variable "hcloud_image" {


### PR DESCRIPTION
## Why

Yesterday's apply of \`terraform-control-plane.yml\` on the new \`eliza-staging\` Hetzner project failed:

\`\`\`
Error: Server Type "cpx21" is unavailable in "fsn1" and can no longer be ordered
  with hcloud_server.control_plane["1"],
  on main.tf line 23
\`\`\`

Hetzner retired \`cpx21\` in \`fsn1\`. The variable default was \`cpx21\`, no override in the workflow, no override on the GH env var, so the apply hit the closed path.

## What

- \`variables.tf\`: \`hcloud_server_type\` default → \`cpx32\`
- \`tfvars/staging.tfvars.example\` + \`tfvars/production.tfvars.example\`: same flip

Picked \`cpx32\` because it matches the existing manually-provisioned \`eliza-staging-1\` (x86 4 vCPU / 8 GB, ~€11/mo). Cutover stays on the shape that's been proven to run agent-router + headscale + cloudflared + provisioning-worker without surprises.

Production VM \`eliza-1\` actually runs \`cax21\` (ARM, ~€7/mo). Flipping the TF default to ARM would save money + sidestep future cpx retirement, but needs cloud-init templating (\`docker apt arch=arm64\`, \`bun-linux-aarch64\`). That's a separate PR — for the unblock we stay on the x86 path.

## Test plan

- [ ] After merge, re-dispatch \`terraform-control-plane.yml\` (environment=staging, action=apply) — should now create \`eliza-staging-1\` cpx32 in the new \`eliza-staging\` project and update the DNS record.
- [ ] Followup: ARM migration PR (\`startswith(var.hcloud_server_type, "cax") ? "arm64" : "amd64"\` template var in cloud-init).