### PR TITLE
fix(cloud-api): set AGENT_ROUTER_ORIGIN_HOST for staging (was hitting prod CP silently)

### DIFF
--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -250,6 +250,11 @@ BITROUTER_BASE_URL = "https://bitrouter-staging.up.railway.app"
 STEWARD_TENANT_ID = "elizacloud-staging"
 NEXT_PUBLIC_STEWARD_TENANT_ID = "elizacloud-staging"
 ELIZA_CLOUD_AGENT_BASE_DOMAIN = "elizacloud.ai"
+# Routes agent-subdomain traffic to the staging control-plane VM. Without this
+# the Worker falls back to DEFAULT_AGENT_ROUTER_ORIGIN_HOST in
+# packages/cloud-api/src/index.ts (= eliza-production-1.elizacloud.ai) so
+# staging agent requests would silently hit the prod CP.
+AGENT_ROUTER_ORIGIN_HOST = "eliza-staging-1.elizacloud.ai"
 WAIFU_SERVICE_ORG_ID = "d96d3fc8-cc07-40be-b81c-ba7a7b4e8028"
 WAIFU_SERVICE_USER_ID = "90101225-836f-4fa7-a69c-f70691dcf256"
 ELIZA_APP_URL = "https://eliza.app"


### PR DESCRIPTION
## Why

After the control-plane TF apply migrated the staging CP to \`167.233.105.184\` (new eliza-staging Hetzner project), the e2e validation workflow (\`w4va6b87i\`) flagged that the staging Worker was still routing agent traffic to the prod CP — silently.

Root cause: [packages/cloud-api/src/index.ts:23](packages/cloud-api/src/index.ts#L23):
\`\`\`ts
const DEFAULT_AGENT_ROUTER_ORIGIN_HOST = "eliza-production-1.elizacloud.ai";
\`\`\`

The Worker reads \`env.AGENT_ROUTER_ORIGIN_HOST ?? DEFAULT_AGENT_ROUTER_ORIGIN_HOST\` ([index.ts:90-91](packages/cloud-api/src/index.ts#L90-L91)), and \`[env.staging.vars]\` in \`wrangler.toml\` never overrode it.

## What

1-line config: thread \`AGENT_ROUTER_ORIGIN_HOST = "eliza-staging-1.elizacloud.ai"\` in \`[env.staging.vars]\`. Comment explains the trap so a future operator doesn't strip it.

## Test plan

- [ ] Auto-deploy by \`cloud-cf-deploy.yml\` after merge
- [ ] Curl an agent-subdomain via \`https://<agent-id>.elizacloud.ai/\` from a staging context, tail \`journalctl -u eliza-agent-router -f\` on \`167.233.105.184\` — request lands on new CP
- [ ] Verify no staging traffic hits \`eliza-production-1.elizacloud.ai\` in prod CP journals

## Followup

Once the prod CP migration completes too, consider moving \`AGENT_ROUTER_ORIGIN_HOST\` to the top-level \`[vars]\` block as the new prod host name, with staging keeping the per-env override. For now leaving prod on the default since prod still runs \`eliza-production-1\` (cax21, default project, manually provisioned).