### PR TITLE
feat(infra): cloud-init bakes nginx vhost + self-signed cert + CF proxied=true

### DIFF
--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
@@ -63,6 +63,30 @@ labels, and the Cloudflare DNS record creation; `user_data` and `image`
 diffs are suppressed by `lifecycle { ignore_changes }`. One-shot — never
 re-run.
 
+## Operational notes
+
+**SSH to the CP — always by public IP, never by hostname.** The Cloudflare DNS
+record (`eliza-${env}-N.elizacloud.ai`) is proxied (orange-cloud); CF does not
+pass TCP/22, so `ssh root@eliza-staging-1.elizacloud.ai` silently fails. Get the
+IP from terraform output:
+
+```bash
+terraform output -json control_plane_vms | jq -r '."1".ipv4'
+# Or the ready-made command:
+terraform output ssh_login_commands
+```
+
+**Cloudflare zone SSL mode MUST stay on "Full"** (not "Full (Strict)"). The
+control-plane uses a self-signed `*.elizacloud.ai` cert; CF only accepts that
+on "Full". Flipping to Strict in the CF dashboard breaks every dashboard
+chat call silently with HTTP 526.
+
+**Cloud-init changes need `terraform taint`** to land on existing VMs.
+`user_data` is in `lifecycle.ignore_changes` so subsequent applies are
+no-ops for an already-provisioned CP. To roll a bootstrap fix, taint the
+VM and re-apply — but that wipes local state (headscale DB, cloudflared
+creds, /opt/eliza checkout). Plan that out before touching prod.
+
 ## What this module does NOT manage (yet)
 
 - Headscale state (preauth keys, ACLs) — manual via `headscale` CLI.

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
@@ -13,6 +13,14 @@
 # baked in here. The operator copies `cloud/.env.local` to `/opt/eliza/cloud/.env.local`
 # in a follow-up step (one-shot, out-of-band) using `scp` or the existing
 # `packages/scripts/cloud/admin/bootstrap-provisioning-worker-host.mjs` script.
+#
+# Ingress is terminated by Cloudflare (zone elizacloud.ai, SSL mode = "Full",
+# DNS record for this VM is proxied through CF). nginx on this host accepts
+# the CF→origin connection on :80 and :443 and forwards `*.elizacloud.ai` to
+# the agent-router daemon listening on 127.0.0.1:3458. The :443 listener uses
+# a self-signed cert that's only ever seen by CF Workers — they don't verify
+# origin certs at "Full" mode (only "Full (Strict)" does). The cert subject
+# is `*.elizacloud.ai` so direct curl with `--resolve` also works for ops.
 
 hostname: ${hostname}
 manage_etc_hosts: true
@@ -63,6 +71,57 @@ write_files:
       export PATH="/home/deploy/.bun/bin:$PATH"
       export ELIZA_DEPLOY_BRANCH="${deploy_branch}"
 
+  # nginx vhost for agent-router. Replaces the default Ubuntu vhost that ships
+  # in /etc/nginx/sites-enabled/default. Matches the prod CP setup so a fresh
+  # apply on a per-env Hetzner project lands a fully-routable VM (no manual
+  # scp of nginx config post-apply).
+  - path: /etc/nginx/sites-available/eliza-agent-router
+    permissions: "0644"
+    content: |
+      server {
+        listen 80;
+        listen [::]:80;
+        server_name .elizacloud.ai;
+        client_max_body_size 50m;
+
+        location / {
+          proxy_http_version 1.1;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+          proxy_buffering off;
+          proxy_read_timeout 120s;
+          proxy_send_timeout 120s;
+          proxy_pass http://127.0.0.1:3458;
+        }
+      }
+
+      server {
+        listen 443 ssl;
+        listen [::]:443 ssl;
+        server_name .elizacloud.ai;
+        client_max_body_size 50m;
+        ssl_certificate /etc/nginx/ssl/eliza-agent-router.crt;
+        ssl_certificate_key /etc/nginx/ssl/eliza-agent-router.key;
+
+        location / {
+          proxy_http_version 1.1;
+          proxy_set_header Host $host;
+          proxy_set_header X-Real-IP $remote_addr;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          proxy_set_header X-Forwarded-Proto $scheme;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
+          proxy_buffering off;
+          proxy_read_timeout 120s;
+          proxy_send_timeout 120s;
+          proxy_pass http://127.0.0.1:3458;
+        }
+      }
+
 runcmd:
   # Docker is installed via the `apt` block above using the official
   # Docker apt repo (GPG-verified keyring), not `curl get.docker.com | sh`.
@@ -108,8 +167,23 @@ runcmd:
   - su - deploy -c 'ln -sf bun /home/deploy/.bun/bin/bunx'
 
   # Repo checkout — the GitHub deploy workflow then takes over for code updates.
+  # `--retry 3 --retry-delay 5` because the apt git install in the package phase
+  # can race with cloud-init runcmd ordering on slow Hetzner images; the bare
+  # `git clone` then bails with "fatal: repository ... does not exist" instead
+  # of a clean network retry.
   - mkdir -p /opt/eliza && chown deploy:deploy /opt/eliza
-  - su - deploy -c 'git clone --depth 200 --branch ${deploy_branch} https://github.com/elizaOS/eliza.git /opt/eliza'
+  - su - deploy -c 'for i in 1 2 3; do git clone --depth 200 --branch ${deploy_branch} https://github.com/elizaOS/eliza.git /opt/eliza && break || { echo "git clone attempt $i failed, retry in 5s..."; rm -rf /opt/eliza/*; sleep 5; }; done'
+
+  # nginx vhost for agent-router subdomain routing. Self-signed cert is fine
+  # because Cloudflare zone is in "Full" SSL mode (CF terminates with visitor,
+  # accepts any cert on the origin). The cert is regenerated on every boot —
+  # not persisted, no expiry to manage.
+  - install -d -m 0755 /etc/nginx/ssl
+  - openssl req -x509 -nodes -newkey rsa:2048 -days 3650 -keyout /etc/nginx/ssl/eliza-agent-router.key -out /etc/nginx/ssl/eliza-agent-router.crt -subj "/CN=*.elizacloud.ai" -addext "subjectAltName=DNS:*.elizacloud.ai,DNS:elizacloud.ai"
+  - chmod 600 /etc/nginx/ssl/eliza-agent-router.key
+  - rm -f /etc/nginx/sites-enabled/default
+  - ln -sf /etc/nginx/sites-available/eliza-agent-router /etc/nginx/sites-enabled/eliza-agent-router
+  - nginx -t && systemctl reload nginx
 
   # Final marker for the bootstrap-warn check that runs after this.
   - echo "eliza-control-plane bootstrap finished $(date -u +%Y-%m-%dT%H:%M:%SZ)" > /var/log/eliza-bootstrap.log

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
@@ -167,23 +167,50 @@ runcmd:
   - su - deploy -c 'ln -sf bun /home/deploy/.bun/bin/bunx'
 
   # Repo checkout — the GitHub deploy workflow then takes over for code updates.
-  # `--retry 3 --retry-delay 5` because the apt git install in the package phase
-  # can race with cloud-init runcmd ordering on slow Hetzner images; the bare
-  # `git clone` then bails with "fatal: repository ... does not exist" instead
-  # of a clean network retry.
+  # Retry loop: the apt git install in the package phase can race with
+  # cloud-init runcmd ordering on slow Hetzner images; the bare `git clone`
+  # then bails with "fatal: repository ... does not exist" instead of a
+  # clean network retry. The cleanup nukes BOTH dotfiles (.git) and
+  # non-dotfiles so the next attempt isn't blocked by a half-cloned `.git/`.
+  # `exit 1` on the 3rd failure surfaces in cloud-init logs (without it
+  # bootstrap-finished marker still gets written and the failure is silent).
   - mkdir -p /opt/eliza && chown deploy:deploy /opt/eliza
-  - su - deploy -c 'for i in 1 2 3; do git clone --depth 200 --branch ${deploy_branch} https://github.com/elizaOS/eliza.git /opt/eliza && break || { echo "git clone attempt $i failed, retry in 5s..."; rm -rf /opt/eliza/*; sleep 5; }; done'
+  - |
+    su - deploy -c '
+      set -e
+      for i in 1 2 3; do
+        if git clone --depth 200 --branch ${deploy_branch} https://github.com/elizaOS/eliza.git /opt/eliza; then
+          exit 0
+        fi
+        echo "git clone attempt $i failed"
+        rm -rf /opt/eliza
+        mkdir -p /opt/eliza
+        if [ "$i" = 3 ]; then
+          echo "git clone exhausted retries"
+          exit 1
+        fi
+        sleep 5
+      done
+    '
 
   # nginx vhost for agent-router subdomain routing. Self-signed cert is fine
   # because Cloudflare zone is in "Full" SSL mode (CF terminates with visitor,
-  # accepts any cert on the origin). The cert is regenerated on every boot —
-  # not persisted, no expiry to manage.
+  # accepts any cert on the origin — only "Full (Strict)" verifies). The
+  # cert is generated once at first-boot (cloud-init runcmd has per-instance
+  # semantics, not per-boot), valid 10 years; VM rebuild or `terraform taint`
+  # regenerates. If anyone flips the zone to Strict the chain breaks
+  # silently — track this as an operational gotcha.
   - install -d -m 0755 /etc/nginx/ssl
   - openssl req -x509 -nodes -newkey rsa:2048 -days 3650 -keyout /etc/nginx/ssl/eliza-agent-router.key -out /etc/nginx/ssl/eliza-agent-router.crt -subj "/CN=*.elizacloud.ai" -addext "subjectAltName=DNS:*.elizacloud.ai,DNS:elizacloud.ai"
   - chmod 600 /etc/nginx/ssl/eliza-agent-router.key
-  - rm -f /etc/nginx/sites-enabled/default
+  # Activate the new vhost FIRST, then remove the default. Split nginx -t
+  # from `systemctl reload` so a failing vhost surfaces in cloud-init logs
+  # (chained with && it silently no-ops the reload while leaving the new
+  # symlink active on disk — half-applied state).
   - ln -sf /etc/nginx/sites-available/eliza-agent-router /etc/nginx/sites-enabled/eliza-agent-router
-  - nginx -t && systemctl reload nginx
+  - rm -f /etc/nginx/sites-enabled/default
+  - nginx -t
+  - systemctl reload nginx
 
   # Final marker for the bootstrap-warn check that runs after this.
   - echo "eliza-control-plane bootstrap finished $(date -u +%Y-%m-%dT%H:%M:%SZ)" > /var/log/eliza-bootstrap.log

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
@@ -69,7 +69,16 @@ resource "cloudflare_dns_record" "control_plane" {
   name    = "${var.control_plane_hostname_prefix}-${var.environment}-${each.key}.elizacloud.ai"
   type    = "A"
   content = each.value.ipv4_address
-  ttl     = 60
-  proxied = false
+  # CF Workers fetch `https://eliza-${env}-N.elizacloud.ai` to proxy agent
+  # traffic to the agent-router on this VM (cloud-api Worker
+  # AGENT_ROUTER_ORIGIN_HOST). With proxied=true, CF terminates TLS with the
+  # visitor and accepts whatever cert the origin presents (zone SSL = "Full"
+  # — see cloud-init/bootstrap.yaml.tftpl which generates a self-signed
+  # *.elizacloud.ai cert at boot). With proxied=false the Worker hits the
+  # origin directly and verifies the self-signed cert — that fails, and
+  # dashboard chat bridge calls return "Sandbox bridge is unreachable".
+  # TTL must be 1 ("Auto") when proxied=true per Cloudflare API.
+  ttl     = 1
+  proxied = true
   comment = "eliza control-plane VM ${each.value.name} (managed by terraform/hetzner/control-plane)"
 }

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
@@ -51,6 +51,13 @@ resource "hcloud_server" "control_plane" {
 
   # Keep server alive across refactors: changing labels or user_data
   # shouldn't recreate the box, only update in place where possible.
+  #
+  # OPS NOTE: changes to cloud-init/bootstrap.yaml.tftpl (nginx vhost, cert
+  # generation, git clone retry, etc.) are no-ops on already-provisioned VMs
+  # because user_data is in ignore_changes. To roll a bootstrap fix onto an
+  # existing CP, run `terraform taint hcloud_server.control_plane["<idx>"]`
+  # then `apply` — recreates the VM, losing local state (headscale DB,
+  # cloudflared creds, /opt/eliza checkout). Plan that ahead of the apply.
   lifecycle {
     ignore_changes = [
       user_data,   # bootstrap runs once at first boot


### PR DESCRIPTION
## Why

Staging migration today landed a TF-spawned control-plane VM that was unroutable for agent traffic:

- nginx ran the default Ubuntu vhost on :80 (no proxy_pass to agent-router on \`127.0.0.1:3458\`)
- :443 had no listener at all
- CF DNS record \`eliza-staging-1.elizacloud.ai\` was \`proxied=false\` (grey cloud), so CF Workers fetching it went direct → got 521 on missing :443

Repaired manually on the live VM. This PR bakes the same setup into the TF module so the next apply (prod, or any re-spawn) lands a routable VM out of the box.

## What

**cloud-init/bootstrap.yaml.tftpl**:
- New \`/etc/nginx/sites-available/eliza-agent-router\` vhost (mirrors prod CP setup) — \`*.elizacloud.ai → 127.0.0.1:3458\` on :80 + :443
- Generate self-signed \`*.elizacloud.ai\` cert at boot via \`openssl req -x509\` → \`/etc/nginx/ssl/eliza-agent-router.{crt,key}\`
- Drop the default vhost + enable the new one + reload nginx
- Git clone retries 3× with 5s sleep — silent race with apt-installed \`git\` left /opt/eliza empty on a slow image

**main.tf**:
- \`cloudflare_dns_record.control_plane.proxied = true\` + \`ttl = 1\` (CF API requires Auto TTL when proxied)
- Comment explains why direct origin fetch fails on self-signed cert

## Why self-signed is fine

Zone SSL on \`elizacloud.ai\` is set to "Full" (not "Full (Strict)"). CF accepts any cert on origin when terminating TLS with the visitor. The self-signed cert is regenerated on every boot — no expiry to manage, no key rotation.

## Side effect

SSH to \`eliza-${env}-N.elizacloud.ai\` now resolves to CF IPs (proxied A record blocks the origin from DNS). Ops must SSH by **public IP** from terraform output \`control_plane_vms.<idx>.ipv4\`, not by hostname. Same pattern prod \`eliza-1\` already uses since it's also proxied in the live CF zone.

## Test plan

- [ ] CI PR validation passes (\`validate\` job runs \`terraform fmt -check\` + \`terraform validate\`)
- [ ] After merge: \`terraform apply\` on a fresh project boots a VM where:
  - \`systemctl is-active nginx\` returns active
  - \`curl -I https://<vm-ip>/\` returns 404 (= reaches agent-router which 404s on non-agent Host) — not 521 / connection refused
  - \`/etc/nginx/sites-enabled/eliza-agent-router\` exists, \`/etc/nginx/sites-enabled/default\` is gone
  - DNS record \`eliza-<env>-1.elizacloud.ai\` is proxied=true in Cloudflare