### PR TITLE
feat(infra): apps-data-plane uses HCLOUD_APPS_TOKEN (shared Hetzner project)

### DIFF
--- a/.github/workflows/terraform-apps-data-plane.yml
+++ b/.github/workflows/terraform-apps-data-plane.yml
@@ -11,10 +11,21 @@ name: Terraform — Apps Data Plane (Hetzner)
 # Postgres node), so it is an explicit operator action — it never auto-runs.
 # "develop = staging" is expressed by choosing environment=staging on dispatch.
 #
+# Topology:
+#   Apps Product 2 (untrusted user containers + per-user tenant DB) lives in
+#   a DEDICATED Hetzner project (`apps`) — separate from the agent control-
+#   plane projects (`eliza-staging`, `eliza-prod`). One Hetzner project
+#   holds both staging and production Apps resources; the per-env scoping
+#   stays in the Terraform state file key + resource names (eliza-apps-node-
+#   ${env}-N, eliza-apps-tenantdb-${env}). This is intentional: Apps Product
+#   2 is alpha — operator overhead of two more projects (apps-staging +
+#   apps-prod) isn't worth it until there's real prod traffic to isolate.
+#
 # Secrets:
-#   environment-scoped (set on each `staging` / `production` GitHub Environment):
-#     HCLOUD_TOKEN                  Hetzner Cloud API token for that env's project
-#   repo-level (already present in this repo):
+#   repo-level (NOT env-scoped — apps project is shared across envs):
+#     HCLOUD_APPS_TOKEN             Hetzner Cloud API token for the `apps`
+#                                   project. Both staging + production
+#                                   applies authenticate with the same value.
 #     CLOUDFLARE_API_TOKEN          Cloudflare DNS token (wildcard apps record)
 #     R2_STATE_ACCESS_KEY_ID        R2 token -> AWS_ACCESS_KEY_ID (tf state backend)
 #     R2_STATE_SECRET_ACCESS_KEY    R2 token -> AWS_SECRET_ACCESS_KEY (tf state backend)
@@ -83,14 +94,17 @@ jobs:
           terraform init -backend=false -input=false
           terraform validate -no-color
 
-  # Manual plan/apply against a real environment. The `environment:` binding makes
-  # that env's HCLOUD_TOKEN (and any required reviewers) apply to this run.
+  # Manual plan/apply against a real environment. The `environment:` binding
+  # gates the run on the GH environment's required-reviewer rule (if set), but
+  # the Hetzner credential is the repo-level HCLOUD_APPS_TOKEN — Apps Product
+  # 2 lives in a dedicated shared Hetzner project, not the per-env eliza-prod
+  # / eliza-staging projects (see header comment).
   plan-apply:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: ${{ github.event.inputs.environment }}
     env:
-      HCLOUD_TOKEN: ${{ secrets.HCLOUD_TOKEN }}
+      HCLOUD_TOKEN: ${{ secrets.HCLOUD_APPS_TOKEN }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       # R2 (S3-compatible) state backend creds.
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_STATE_ACCESS_KEY_ID }}
@@ -117,7 +131,7 @@ jobs:
         run: |
           env="${{ github.event.inputs.environment }}"
           fail=0
-          [ -n "$HCLOUD_TOKEN" ] || { echo "::error::set secrets.HCLOUD_TOKEN on the '$env' environment"; fail=1; }
+          [ -n "$HCLOUD_TOKEN" ] || { echo "::error::set repo secret HCLOUD_APPS_TOKEN (apps Hetzner project token, shared across envs)"; fail=1; }
           [ -n "$AWS_ACCESS_KEY_ID" ] || { echo "::error::missing repo secret R2_STATE_ACCESS_KEY_ID"; fail=1; }
           [ -n "$AWS_SECRET_ACCESS_KEY" ] || { echo "::error::missing repo secret R2_STATE_SECRET_ACCESS_KEY"; fail=1; }
           [ -n "$CLOUDFLARE_API_TOKEN" ] || { echo "::error::missing repo secret CLOUDFLARE_API_TOKEN"; fail=1; }

--- a/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md
@@ -113,29 +113,38 @@ is no `hcloud_project` Terraform resource — projects are management-plane only
 
 ```
 Hetzner Cloud account (one human)
-├── Project "eliza-prod"      (HCLOUD_TOKEN_PROD,    5/5 servers max)
+├── Project "eliza-prod"      (env-scoped HCLOUD_TOKEN, 5/5 servers max)
 │   ├── eliza-1               (control-plane, cax21)
-│   └── eliza-core-<hex>      (worker, ccx33, autoscaled)
-└── Project "eliza-staging"   (HCLOUD_TOKEN_STAGING, 5/5 servers max)
-    ├── eliza-staging-1               (control-plane, cpx32)
-    ├── eliza-core-<hex>              (worker, autoscaled)
-    └── eliza-apps-node-staging-1     (apps Product-2)
+│   └── eliza-core-<hex>      (worker, ccx33, autoscaled by node-autoscaler.ts)
+├── Project "eliza-staging"   (env-scoped HCLOUD_TOKEN, 5/5 servers max)
+│   ├── eliza-staging-1               (control-plane, cpx32)
+│   └── eliza-core-<hex>              (worker, cpx32, autoscaled)
+└── Project "apps"            (repo-level HCLOUD_APPS_TOKEN, shared)
+    ├── eliza-apps-node-staging-1     (apps Product-2, staging)
+    ├── eliza-apps-tenantdb-staging   (tenant Postgres, staging)
+    ├── eliza-apps-node-production-1  (apps Product-2, production)
+    └── eliza-apps-tenantdb-production (tenant Postgres, production)
 ```
 
 ### Why split
 
-- **Quota isolation** — prod can't starve staging, staging can't starve prod
-- **Blast radius** — a leaked staging token can't delete prod resources
+- **Quota isolation** — prod can't starve staging, staging can't starve prod;
+  apps untrusted-container quota is independent of agent capacity
+- **Blast radius** — a leaked staging token can't delete prod resources; an
+  apps-tenant-DB compromise can't reach the agent plane (separate network)
 - **Cost visibility** — Hetzner billing already splits per project in the invoice
-- **No upgrade ticket** — 2 projects × 5 default quota = 10 effective servers,
-  vs. waiting for a manual `Limit increase` on a single shared project
+- **Apps stays simple** — Product 2 is alpha; one shared `apps` project keeps
+  operator overhead low until there's real prod-Apps traffic to isolate.
+  Future split into `apps-staging` + `apps-prod` is a token-and-state-file
+  swap, no resource recreation.
 
 ### Token plumbing
 
 | Where                                          | Sets                          | Used for                |
 |------------------------------------------------|-------------------------------|-------------------------|
-| GitHub Environment `staging`   → `HCLOUD_TOKEN`| staging project token         | terraform plan/apply on staging |
-| GitHub Environment `production`→ `HCLOUD_TOKEN`| prod project token            | terraform plan/apply on prod    |
+| GitHub Environment `staging`   → `HCLOUD_TOKEN`| staging project token         | terraform plan/apply on control-plane staging |
+| GitHub Environment `production`→ `HCLOUD_TOKEN`| prod project token            | terraform plan/apply on control-plane prod    |
+| Repo-level → `HCLOUD_APPS_TOKEN`               | apps project token (shared)   | terraform plan/apply on apps-data-plane (both envs) |
 | Staging control-plane `/opt/eliza/cloud/.env.local` → `HCLOUD_TOKEN` | staging project token | provisioning-worker autoscaler   |
 | Prod control-plane `/opt/eliza/cloud/.env.local`    → `HCLOUD_TOKEN` | prod project token    | provisioning-worker autoscaler   |
 

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/README.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/README.md
@@ -31,10 +31,38 @@ design (*agents share the data plane; apps get an isolated one*):
    `--internal` scratch net) before opening to users.
 
 ## Apply (after review)
+
+**One-shot setup on a fresh `apps` Hetzner project**, then every subsequent
+apply just works:
+
+1. **Generate a Hetzner API token** scoped to the `apps` project (Console →
+   Security → API Tokens). Store it as the repo-level GitHub secret
+   `HCLOUD_APPS_TOKEN` (shared across staging + production — the apps data
+   plane is one project, see `../ARCHITECTURE.md`).
+2. **Register the operator SSH public key** in the `apps` project (Console →
+   Security → SSH Keys → Add). Without this, the `eliza-op-${env}` key
+   isn't usable by the autoscaler's later `--ssh-key` references and recovery
+   paths break. cloud-init still seeds `authorized_keys` from
+   `var.ssh_public_keys` for the `deploy` user — but the hcloud-managed key
+   is the canonical fallback for root-level `hcloud server reset` flows.
+
+Then plan/apply from CI:
+
+```bash
+gh workflow run terraform-apps-data-plane.yml --ref develop \
+  -f environment=staging -f action=plan
+# Review the plan in the run logs, then:
+gh workflow run terraform-apps-data-plane.yml --ref develop \
+  -f environment=staging -f action=apply
+```
+
+Or locally for debugging:
+
 ```bash
 cd packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane
 cp tfvars/staging.tfvars.example staging.tfvars   # fill in real values
-terraform init -backend-config=backend-staging.hcl # same R2 backend as control-plane
+export HCLOUD_TOKEN=...      # the HCLOUD_APPS_TOKEN value
+terraform init -backend-config=backend-staging.hcl
 terraform plan  -var-file=staging.tfvars
 terraform apply -var-file=staging.tfvars
 ```

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
@@ -42,10 +42,13 @@ resource "random_password" "tenant_db_admin" {
 # Operator/daemon SSH access is provisioned by cloud-init: each node's `deploy`
 # user gets `var.ssh_public_keys` in its authorized_keys (see cloud-init/*.tftpl),
 # and the provisioning-worker SSHes in as `deploy`. We intentionally do NOT
-# register an `hcloud_ssh_key` here: the operator key is already present in the
-# shared Hetzner project, so creating it returns 409 uniqueness_error — and an
-# hcloud-managed key only seeds `root`, which nothing connects as. var.ssh_public_keys
-# still flows to cloud-init below.
+# register an `hcloud_ssh_key` here: the apps Hetzner project is shared across
+# staging + production (Apps Product 2 is alpha — one project for both envs is
+# enough). Both env applies would race on the same `eliza-op-...` key and 409
+# the second one. The operator pubkey is added to the apps project ONCE via
+# Hetzner Console (out-of-band, one-shot); after that all cloud-init writes
+# work — they only need the pubkey string in var.ssh_public_keys, not a
+# Hetzner-registered key reference.
 
 # ── Private network: apps + tenant DB only; isolated from the agent plane ─────
 resource "hcloud_network" "apps" {

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/providers.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/providers.tf
@@ -1,9 +1,11 @@
 provider "hcloud" {
   # Token resolution order:
   #   1. var.hcloud_token (passed via tfvars or -var)
-  #   2. HCLOUD_TOKEN env var (the GHA pattern — set per GitHub Environment)
-  # Each environment uses a token scoped to its OWN Hetzner Cloud Project.
-  # See ../ARCHITECTURE.md § "Multi-project layout".
+  #   2. HCLOUD_TOKEN env var (the GHA pattern — sourced from the REPO-level
+  #      secret HCLOUD_APPS_TOKEN; both staging + production applies share it
+  #      because the apps data-plane lives in a single shared Hetzner Cloud
+  #      Project, NOT split per environment like the control-plane is).
+  # See ../ARCHITECTURE.md § "Multi-project layout" for the topology.
   token = var.hcloud_token
 }
 

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
@@ -7,14 +7,20 @@ variable "environment" {
   }
 }
 
-# ── Multi-project credentials ────────────────────────────────────────────────
-# Each environment has its own Hetzner Cloud Project (= its own 5-server quota,
-# its own SSH keys, its own private network). The provider picks up the token
-# from this variable OR the HCLOUD_TOKEN env var. GitHub Actions wires the
-# right project's token via the environment-scoped secret HCLOUD_TOKEN.
-# See ARCHITECTURE.md § "Multi-project layout" for the pattern.
+# ── Shared apps-project credentials ──────────────────────────────────────────
+# The apps data-plane lives in a SINGLE SHARED Hetzner Cloud Project (one
+# quota, one set of SSH keys, one private network) — NOT split per environment
+# like the control-plane is. The per-env scoping stays in the Terraform state
+# file key + resource names (eliza-apps-node-${env}-N, eliza-apps-tenantdb-
+# ${env}); both staging and production apply rounds land in the same Hetzner
+# project.
+#
+# The provider picks up the token from this variable OR the HCLOUD_TOKEN env
+# var. GitHub Actions wires the REPO-LEVEL secret HCLOUD_APPS_TOKEN as
+# HCLOUD_TOKEN for both staging and production runs.
+# See ARCHITECTURE.md § "Multi-project layout" for the topology.
 variable "hcloud_token" {
-  description = "Hetzner Cloud API token for the project that owns THIS environment's resources. Leave null to pick up from HCLOUD_TOKEN env var (the GHA pattern)."
+  description = "Hetzner Cloud API token for the shared apps Hetzner project. Leave null to pick up from HCLOUD_TOKEN env var (the GHA pattern, sourced from repo-level secret HCLOUD_APPS_TOKEN)."
   type        = string
   default     = null
   sensitive   = true


### PR DESCRIPTION
## Why

Apps Product 2 now lives in a **dedicated Hetzner project** \`apps\`, separate from the per-env agent control-plane projects (\`eliza-staging\`, \`eliza-prod\`). One shared project hosts both staging + production Apps resources — Apps is still alpha, operator overhead of two more projects (apps-staging + apps-prod) isn't worth it until there's real prod traffic to isolate.

## What

| File | Change |
|------|--------|
| \`.github/workflows/terraform-apps-data-plane.yml\` | \`HCLOUD_TOKEN\` now sourced from \`secrets.HCLOUD_APPS_TOKEN\` (repo-level) instead of env-scoped \`HCLOUD_TOKEN\`. Header + preflight error msg updated. |
| \`packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf\` | Comment on the absent \`hcloud_ssh_key\` resource now explains the shared-project rationale (race + 409 between env applies). |
| \`packages/cloud-infra/cloud/terraform/hetzner/ARCHITECTURE.md\` | Multi-project diagram shows 3 projects (\`eliza-prod\`, \`eliza-staging\`, \`apps\`). Token-plumbing table adds \`HCLOUD_APPS_TOKEN\` row. |

## Topology after merge

\`\`\`
eliza-prod      env-scoped HCLOUD_TOKEN  control-plane + agents prod
eliza-staging   env-scoped HCLOUD_TOKEN  control-plane + agents staging
apps            repo-level HCLOUD_APPS_TOKEN  Apps Product 2 staging + prod (shared)
default         <legacy, to drain + delete in phase 5>
\`\`\`

## Pre-merge state

- \`HCLOUD_APPS_TOKEN\` repo secret is set (verified \`gh secret list\`)
- Operator pubkey already registered in the \`apps\` Hetzner project via Console
- \`apps\` project is empty (0 servers) — first apply will create everything

## Test plan

- [ ] CI \`validate\` job passes (terraform fmt + validate)
- [ ] After merge: \`gh workflow run terraform-apps-data-plane.yml --ref develop -f environment=staging -f action=plan\`
- [ ] Plan should show ~9 adds in \`apps\` project (network, subnet, 2 firewalls, server, server_network, volume, DNS, + tenant_db resources if provision_tenant_db=true)
- [ ] If clean: \`-f action=apply\`
- [ ] Followup (not in this PR): \`pg_dumpall\` the staging tenant DB on OLD CP → restore onto the new \`eliza-apps-tenantdb-staging\` node → update DSN refs for the 2 live user apps

## Followup (separate)

When Apps Product 2 ships to prod with real traffic, split into \`apps-staging\` + \`apps-prod\` projects (= rename existing + create second + state file split). Resource recreation not needed; it's a token-and-state-key swap.