### PR TITLE
feat(infra): wire TF_VAR_provision_tenant_db in apps-data-plane workflow

### DIFF
--- a/.github/workflows/terraform-apps-data-plane.yml
+++ b/.github/workflows/terraform-apps-data-plane.yml
@@ -37,6 +37,11 @@ name: Terraform — Apps Data Plane (Hetzner)
 #   OPERATOR_INGRESS_CIDRS          JSON array of allowed SSH CIDRs, e.g.
 #                                        ["1.2.3.4/32"] — `0.0.0.0/0` rejected
 #                                        by the module's `validation` block.
+#   PROVISION_TENANT_DB (optional)  "true" to provision the dedicated tenant
+#                                        Postgres node (ccx33 + 200 GB volume).
+#                                        Default "false" — only the volume gets
+#                                        created, no server. Flip to "true"
+#                                        when ready to host real tenant DBs.
 
 on:
   pull_request:
@@ -121,6 +126,11 @@ jobs:
       # operator_ingress_cidrs MUST be a JSON array literal; module validation
       # rejects 0.0.0.0/0. Set as a GH env var, e.g. '["1.2.3.4/32"]'.
       TF_VAR_operator_ingress_cidrs: ${{ vars.OPERATOR_INGRESS_CIDRS }}
+      # provision_tenant_db: "true"/"false" toggle for spawning the dedicated
+      # tenant Postgres ccx33 node. Default false — the volume gets created
+      # either way, but the server only when this var is "true". Flip once
+      # there's real tenant DB traffic to host.
+      TF_VAR_provision_tenant_db: ${{ vars.PROVISION_TENANT_DB || 'false' }}
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
## Why

apps-data-plane TF has a \`provision_tenant_db\` bool variable that gates the dedicated ccx33 tenant Postgres node. Default \`false\` (Apps Product 2 is alpha — unrecovered cost at low density). The workflow never threaded the variable, so flipping it required editing \`variables.tf\` and shipping a PR.

This PR wires it through a GH env var so operators can flip it per env without code changes.

## What

\`.github/workflows/terraform-apps-data-plane.yml\`:

\`\`\`yaml
TF_VAR_provision_tenant_db: \${{ vars.PROVISION_TENANT_DB || 'false' }}
\`\`\`

Plus a header comment documenting the new var.

## Post-merge ops

\`\`\`bash
gh variable set PROVISION_TENANT_DB --repo elizaOS/eliza --env staging --body 'true'
gh workflow run terraform-apps-data-plane.yml --ref develop \\
  -f environment=staging -f action=apply
\`\`\`

This unblocks the live staging tenant DB migration:
1. Apply spawns \`eliza-apps-tenantdb-staging\` (ccx33 + 200 GB volume attached)
2. \`pg_dumpall\` from OLD CP container (eliza-apps-tenantdb on 46.224.1.246)
3. Restore into the new node
4. Update DSN refs for the 2 user app DBs (\`app-container-provider.ts\` config)

## Env-scoped vs repo-level

\`PROVISION_TENANT_DB\` is env-scoped — staging and production won't flip at the same time. Staging first (live migration today). Production gets flipped when Apps Product 2 ships real traffic.

## Test plan

- [ ] CI \`validate\` job passes (terraform fmt + validate)
- [ ] After merge + setting the var: \`gh workflow run terraform-apps-data-plane.yml -f environment=staging -f action=plan\` shows 4 more adds beyond the 8 already-planned (tenant_db server + server_network + volume attachment + random_password — though the volume was already in the 8)