### PR TITLE
refactor(infra): drop provision_tenant_db toggle, always provision the node

### DIFF
--- a/.github/workflows/terraform-apps-data-plane.yml
+++ b/.github/workflows/terraform-apps-data-plane.yml
@@ -37,11 +37,6 @@ name: Terraform — Apps Data Plane (Hetzner)
 #   OPERATOR_INGRESS_CIDRS          JSON array of allowed SSH CIDRs, e.g.
 #                                        ["1.2.3.4/32"] — `0.0.0.0/0` rejected
 #                                        by the module's `validation` block.
-#   PROVISION_TENANT_DB (optional)  "true" to provision the dedicated tenant
-#                                        Postgres node (ccx33 + 200 GB volume).
-#                                        Default "false" — only the volume gets
-#                                        created, no server. Flip to "true"
-#                                        when ready to host real tenant DBs.
 
 on:
   pull_request:
@@ -126,11 +121,6 @@ jobs:
       # operator_ingress_cidrs MUST be a JSON array literal; module validation
       # rejects 0.0.0.0/0. Set as a GH env var, e.g. '["1.2.3.4/32"]'.
       TF_VAR_operator_ingress_cidrs: ${{ vars.OPERATOR_INGRESS_CIDRS }}
-      # provision_tenant_db: "true"/"false" toggle for spawning the dedicated
-      # tenant Postgres ccx33 node. Default false — the volume gets created
-      # either way, but the server only when this var is "true". Flip once
-      # there's real tenant DB traffic to host.
-      TF_VAR_provision_tenant_db: ${{ vars.PROVISION_TENANT_DB || 'false' }}
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v3

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
@@ -117,11 +117,7 @@ resource "hcloud_firewall" "tenant_db" {
 }
 
 # ── Tenant Postgres node ──────────────────────────────────────────────────────
-# Gated on var.provision_tenant_db (default false): beta runs app-node-only and
-# co-locates the first tenant DBs on the app node, so a dedicated ccx33 isn't a
-# fixed loss at low density (#8342). Flip the var to true to add it at scale.
 resource "hcloud_server" "tenant_db" {
-  count        = var.provision_tenant_db ? 1 : 0
   name         = "eliza-apps-tenantdb-${var.environment}"
   location     = var.hcloud_location
   server_type  = var.tenant_db_server_type
@@ -142,8 +138,7 @@ resource "hcloud_server" "tenant_db" {
 }
 
 resource "hcloud_server_network" "tenant_db" {
-  count      = var.provision_tenant_db ? 1 : 0
-  server_id  = hcloud_server.tenant_db[0].id
+  server_id  = hcloud_server.tenant_db.id
   network_id = hcloud_network.apps.id
   # First usable host in the subnet — stable private IP the app nodes + the
   # control-plane provisioner connect to (admin DSN host).
@@ -151,9 +146,8 @@ resource "hcloud_server_network" "tenant_db" {
 }
 
 resource "hcloud_volume_attachment" "tenant_db_data" {
-  count     = var.provision_tenant_db ? 1 : 0
   volume_id = hcloud_volume.tenant_db_data.id
-  server_id = hcloud_server.tenant_db[0].id
+  server_id = hcloud_server.tenant_db.id
   automount = false
 }
 

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/outputs.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/outputs.tf
@@ -4,8 +4,8 @@ output "tenant_db_private_host" {
 }
 
 output "tenant_db_public_ip" {
-  description = "Public IP of the tenant DB node (SSH/admin only — Postgres is NOT exposed publicly). null when provision_tenant_db = false (app-node-only beta)."
-  value       = one(hcloud_server.tenant_db[*].ipv4_address)
+  description = "Public IP of the tenant DB node (SSH/admin only — Postgres is NOT exposed publicly)."
+  value       = hcloud_server.tenant_db.ipv4_address
 }
 
 output "tenant_db_admin_dsn" {

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/production.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/production.tfvars.example
@@ -19,7 +19,3 @@ operator_ingress_cidrs = ["<operator-ip>/32"]
 ssh_public_keys = [
   # "ssh-ed25519 AAAA... operator@laptop"
 ]
-
-# Beta: app-node-only (no dedicated DB node — co-locate the first tenant DBs on
-# the app node). Flip to true once you have real DB-app density (#8342).
-provision_tenant_db      = false

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/staging.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/staging.tfvars.example
@@ -22,7 +22,3 @@ operator_ingress_cidrs = ["<operator-ip>/32"]
 ssh_public_keys = [
   # "ssh-ed25519 AAAA... operator@laptop"
 ]
-
-# Beta: app-node-only (no dedicated DB node — co-locate the first tenant DBs on
-# the app node). Flip to true once you have real DB-app density (#8342).
-provision_tenant_db      = false

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
@@ -68,12 +68,6 @@ variable "tenant_db_volume_size_gb" {
   default     = 200
 }
 
-variable "provision_tenant_db" {
-  description = "Provision the dedicated tenant Postgres node (the ccx33). DEFAULT false: a dedicated DB node is pure unrecovered cost at low density (#8342), so for beta we run app-node-only and co-locate the first few tenant DBs on the app node. Flip to true once you have real DB-app density to justify a dedicated cluster node. The app node is independent of it (it only bakes in the static private DB host)."
-  type        = bool
-  default     = false
-}
-
 variable "ssh_public_keys" {
   description = "Operator SSH public keys allowed to log in as root. Provide via tfvars; never commit private keys."
   type        = list(string)


### PR DESCRIPTION
## Summary

Reverts the bool toggle from #8377. Apps data-plane always provisions the
tenant_db ccx33 — no flag, no off mode.

- Dropped `var.provision_tenant_db` + the 3 `count = … ? 1 : 0` gates on
  `hcloud_server.tenant_db` / `hcloud_server_network.tenant_db` /
  `hcloud_volume_attachment.tenant_db_data`
- Cleaned `outputs.tf` (no more "null when off" language on `tenant_db_public_ip`)
- Dropped the `TF_VAR_provision_tenant_db` env block + header doc in the workflow
- Dropped the `provision_tenant_db = false` line in both tfvars examples

Stan's call: "pas de true/false" — iterating means replacing, not accumulating a
flag we will never flip.

## Behavior after merge

Next `terraform apply` on staging (or prod) creates the tenant_db node + private
network attachment + volume attachment in the `apps` Hetzner project. ~€60/mo.

The GH env var `PROVISION_TENANT_DB` set on staging (~5 min ago) becomes dead
state — leave it, it's read by nothing now.

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform init -backend=false && terraform validate` → Success
- [x] `grep -rn provision_tenant_db packages/cloud-infra .github/workflows` → 0 matches
- [ ] PR CI: `validate` job green
- [ ] Manual: dispatch `terraform-apps-data-plane.yml` plan on staging — expect a
      ~3-resource ADD (server + network + volume_attachment), no other changes