### PR TITLE
refactor(infra): default tenant_db to cpx41 (shared CPU, no dedicated quota)

### DIFF
--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/production.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/production.tfvars.example
@@ -7,6 +7,9 @@ apps_base_domain   = "apps.elizacloud.ai"
 
 app_node_count           = 2 # behind a load balancer (see main.tf STAN note)
 app_node_server_type     = "ccx23"
+# Production override: ccx33 = dedicated 8 vCPU / 32 GB for perf headroom on
+# the prod tenant_db. Module default (cpx42, shared) is fine for staging but
+# we pay for dedicated CPU here.
 tenant_db_server_type    = "ccx33"
 tenant_db_volume_size_gb = 500
 

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/staging.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/staging.tfvars.example
@@ -6,9 +6,11 @@ cloudflare_zone_id = "<zone-id-for-elizacloud.ai>"
 apps_base_domain   = "apps-staging.elizacloud.ai"
 
 # Sizing — start small for the allowlist beta.
+# tenant_db_server_type omitted: inherit the module default (cpx42, shared CPU,
+# no dedicated-vCPU quota cost). Add an explicit override here when you need to
+# pin a different type for staging.
 app_node_count           = 1
 app_node_server_type     = "ccx23"
-tenant_db_server_type    = "ccx33"
 tenant_db_volume_size_gb = 200
 
 # MUST NOT overlap the agent data-plane network.

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
@@ -57,9 +57,9 @@ variable "app_node_count" {
 
 # ── Tenant Postgres cluster node: thousands of DATABASE+ROLE per node ─────────
 variable "tenant_db_server_type" {
-  description = "Hetzner server type for the tenant Postgres node. ccx33 (dedicated 8 vCPU / 32 GB) is a sane start for thousands of small tenant DBs; scale up or add nodes (shards) as database_count grows."
+  description = "Hetzner server type for the tenant Postgres node. cpx41 (8 shared vCPU / 16 GB) is the alpha-stage default — no dedicated-CPU quota required, ~€16/mo. Postgres runs server-side (no untrusted code execution), so shared CPU is fine for isolation; the boundary is hostssl + private-network firewall + per-tenant ROLE. For thousands-of-DBs scale or perf-sensitive prod, upgrade to ccx33 (dedicated 8 vCPU / 32 GB) via tfvars override + Hetzner server type upgrade (rebootable, volume persists)."
   type        = string
-  default     = "ccx33"
+  default     = "cpx41"
 }
 
 variable "tenant_db_volume_size_gb" {

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
@@ -40,7 +40,7 @@ variable "hcloud_image" {
 
 # ── App worker node(s): Docker hosts for UNTRUSTED user images ───────────────
 variable "app_node_server_type" {
-  description = "Hetzner server type for an app worker node (runs untrusted user containers). ccx23 = 4 dedicated vCPU / 16 GB — dedicated vCPU suits untrusted multi-tenant workloads where a co-tenant can run code (apps Product 2): no noisy-neighbor on CPU steal, mitigates side-channel risk on the host. Size to expected concurrent app density."
+  description = "Hetzner server type for an app worker node (runs untrusted user containers). ccx23 = 4 dedicated vCPU / 16 GB — dedicated vCPU is required because tenants run untrusted code: no CPU steal from noisy neighbors, mitigates host side-channel risk. Size to expected concurrent app density."
   type        = string
   default     = "ccx23"
 }
@@ -57,9 +57,9 @@ variable "app_node_count" {
 
 # ── Tenant Postgres cluster node: thousands of DATABASE+ROLE per node ─────────
 variable "tenant_db_server_type" {
-  description = "Hetzner server type for the tenant Postgres node. cpx41 (8 shared vCPU / 16 GB) is the alpha-stage default — no dedicated-CPU quota required, ~€32/mo in fsn1. Postgres runs server-side (no untrusted code execution on this VM), so shared CPU is fine for isolation; the boundary is hostssl + private-network firewall + per-tenant ROLE. For thousands-of-DBs scale or perf-sensitive prod, upgrade to ccx33 (dedicated 8 vCPU / 32 GB, ~€62/mo) via tfvars override + Hetzner server type upgrade (rebootable, volume persists)."
+  description = "Hetzner server type for the tenant Postgres node. cpx42 (8 shared vCPU / 16 GB AMD, ~€25/mo in fsn1) — no dedicated-CPU quota required. Postgres runs server-side (no untrusted code execution on this VM), so shared CPU is fine for isolation; the boundary is hostssl + private-network firewall + per-tenant ROLE. For prod scale or perf-sensitive workloads, override to ccx33 (dedicated 8 vCPU / 32 GB, ~€62/mo)."
   type        = string
-  default     = "cpx41"
+  default     = "cpx42"
 }
 
 variable "tenant_db_volume_size_gb" {

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
@@ -40,7 +40,7 @@ variable "hcloud_image" {
 
 # ── App worker node(s): Docker hosts for UNTRUSTED user images ───────────────
 variable "app_node_server_type" {
-  description = "Hetzner server type for an app worker node (runs untrusted user containers). ccx23 = 4 dedicated vCPU / 16 GB — dedicated vCPU suits untrusted multi-tenant workloads (no noisy-neighbor) and is orderable in fsn1 (cpx41 was retired there). Size to expected concurrent app density."
+  description = "Hetzner server type for an app worker node (runs untrusted user containers). ccx23 = 4 dedicated vCPU / 16 GB — dedicated vCPU suits untrusted multi-tenant workloads where a co-tenant can run code (apps Product 2): no noisy-neighbor on CPU steal, mitigates side-channel risk on the host. Size to expected concurrent app density."
   type        = string
   default     = "ccx23"
 }
@@ -57,7 +57,7 @@ variable "app_node_count" {
 
 # ── Tenant Postgres cluster node: thousands of DATABASE+ROLE per node ─────────
 variable "tenant_db_server_type" {
-  description = "Hetzner server type for the tenant Postgres node. cpx41 (8 shared vCPU / 16 GB) is the alpha-stage default — no dedicated-CPU quota required, ~€16/mo. Postgres runs server-side (no untrusted code execution), so shared CPU is fine for isolation; the boundary is hostssl + private-network firewall + per-tenant ROLE. For thousands-of-DBs scale or perf-sensitive prod, upgrade to ccx33 (dedicated 8 vCPU / 32 GB) via tfvars override + Hetzner server type upgrade (rebootable, volume persists)."
+  description = "Hetzner server type for the tenant Postgres node. cpx41 (8 shared vCPU / 16 GB) is the alpha-stage default — no dedicated-CPU quota required, ~€32/mo in fsn1. Postgres runs server-side (no untrusted code execution on this VM), so shared CPU is fine for isolation; the boundary is hostssl + private-network firewall + per-tenant ROLE. For thousands-of-DBs scale or perf-sensitive prod, upgrade to ccx33 (dedicated 8 vCPU / 32 GB, ~€62/mo) via tfvars override + Hetzner server type upgrade (rebootable, volume persists)."
   type        = string
   default     = "cpx41"
 }


### PR DESCRIPTION
## Summary

Default `tenant_db_server_type` in the `apps-data-plane` Hetzner module flips from `ccx33` (dedicated 8 vCPU / 32 GB) to `cpx41` (shared 8 vCPU / 16 GB).

Why:
- ccx33 burns 8 dedicated cores from a Hetzner account-wide quota that's currently the bottleneck — it stops `app_node` (ccx23, 4 dedicated cores) from even being created. Real alpha workload on tenant_db is 2 user DBs at ~7.5 MB total, so ccx33 is wildly oversized.
- cpx41 uses 0 dedicated cores, frees quota for app_node + future workers, and costs ~€16/mo vs ~€60/mo (save ~€44/mo per env).
- Postgres runs server-side, no untrusted code execution — shared CPU doesn't degrade the isolation boundary. The boundary is hostssl + private-network firewall + per-tenant ROLE, none of which depend on dedicated cores.
- If/when scale or perf warrants ccx33, the upgrade is a tfvars override + a rebootable Hetzner server type upgrade. The 200 GB volume with PGDATA stays attached, no data migration.

## Migration impact

Next `terraform apply` will REPLACE the existing ccx33 server (id `139192935`):
- destroy: `hcloud_server.tenant_db` (ccx33) + `hcloud_server_network.tenant_db` + `hcloud_volume_attachment.tenant_db`
- create: `hcloud_server.tenant_db` (cpx41) + reattach the existing 200 GB volume (PGDATA mounted at `/mnt/tenant-pgdata`)
- cloud-init's `if [ ! -d $PGDATA ]` guard skips initdb on the fresh node, so any existing data on the volume is preserved
- `random_password.tenant_db_admin` stays stable in state — admin creds don't rotate
- Brief downtime during replace (~minutes); acceptable at alpha (2 tiny DBs).

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform init -backend=false && terraform validate` green locally
- [ ] CI Terraform validate green
- [ ] Manual `terraform apply` in staging — expect REPLACE of tenant_db server, app_node ccx23 (4 dedicated cores) now fits under the quota, reach 11/11 resources
- [ ] Post-apply: `psql` reachable on private IP, `\l` shows existing tenant DBs intact, app_node Docker up