### PR TITLE
feat(cloud): add Atlas Cloud image provider (drop-in, OpenAI-compatible)

### DIFF
--- a/packages/cloud-api/v1/apps/[id]/generate-image/route.ts
+++ b/packages/cloud-api/v1/apps/[id]/generate-image/route.ts
@@ -350,12 +350,25 @@ app.post("/", async (c) => {
     const apiKeys = {
       BITROUTER_API_KEY: env.BITROUTER_API_KEY,
       BITROUTER_BASE_URL: env.BITROUTER_BASE_URL,
+      ATLASCLOUD_API_KEY: env.ATLASCLOUD_API_KEY,
+      ATLASCLOUD_BASE_URL: env.ATLASCLOUD_BASE_URL,
       FAL_KEY: env.FAL_KEY,
       FAL_API_KEY: env.FAL_API_KEY,
     };
     if (
       definition.billingSource === "bitrouter" &&
       !apiKeys.BITROUTER_API_KEY
+    ) {
+      return jsonError(
+        c,
+        503,
+        getAiProviderConfigurationError(),
+        "internal_error",
+      );
+    }
+    if (
+      definition.billingSource === "atlascloud" &&
+      !apiKeys.ATLASCLOUD_API_KEY
     ) {
       return jsonError(
         c,

--- a/packages/cloud-api/v1/generate-image/route.ts
+++ b/packages/cloud-api/v1/generate-image/route.ts
@@ -181,10 +181,7 @@ app.post("/", async (c) => {
         "internal_error",
       );
     }
-    if (
-      definition.billingSource === "atlascloud" &&
-      !env.ATLASCLOUD_API_KEY
-    ) {
+    if (definition.billingSource === "atlascloud" && !env.ATLASCLOUD_API_KEY) {
       return jsonError(
         c,
         503,

--- a/packages/cloud-api/v1/generate-image/route.ts
+++ b/packages/cloud-api/v1/generate-image/route.ts
@@ -134,6 +134,8 @@ async function generateOneImage(request: ImageRequest): Promise<{
     apiKeys: {
       BITROUTER_API_KEY: env.BITROUTER_API_KEY,
       BITROUTER_BASE_URL: env.BITROUTER_BASE_URL,
+      ATLASCLOUD_API_KEY: env.ATLASCLOUD_API_KEY,
+      ATLASCLOUD_BASE_URL: env.ATLASCLOUD_BASE_URL,
       FAL_KEY: env.FAL_KEY,
       FAL_API_KEY: env.FAL_API_KEY,
     },
@@ -172,6 +174,17 @@ app.post("/", async (c) => {
     }
     const env = getCloudAwareEnv();
     if (definition.billingSource === "bitrouter" && !env.BITROUTER_API_KEY) {
+      return jsonError(
+        c,
+        503,
+        getAiProviderConfigurationError(),
+        "internal_error",
+      );
+    }
+    if (
+      definition.billingSource === "atlascloud" &&
+      !env.ATLASCLOUD_API_KEY
+    ) {
       return jsonError(
         c,
         503,

--- a/packages/cloud-shared/src/lib/providers/image/atlascloud-image-generation.ts
+++ b/packages/cloud-shared/src/lib/providers/image/atlascloud-image-generation.ts
@@ -58,7 +58,9 @@ async function readImageWithLimit(response: Response): Promise<Uint8Array> {
 }
 
 async function imageUrlToGeneratedImage(url: string, text = ""): Promise<GeneratedImage> {
-  const response = await fetch(url, { signal: AbortSignal.timeout(ATLAS_IMAGE_DOWNLOAD_TIMEOUT_MS) });
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(ATLAS_IMAGE_DOWNLOAD_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error(`Atlas image download failed: ${response.status}`);
   }
@@ -169,7 +171,9 @@ export async function generateAtlasCloudImage(request: ImageGenRequest): Promise
     const status = (prediction.status ?? "").toLowerCase();
 
     if (TERMINAL_FAIL.has(status)) {
-      throw new Error(`Atlas image generation failed${prediction.error ? `: ${prediction.error}` : ""}`);
+      throw new Error(
+        `Atlas image generation failed${prediction.error ? `: ${prediction.error}` : ""}`,
+      );
     }
 
     if (TERMINAL_OK.has(status)) {

--- a/packages/cloud-shared/src/lib/providers/image/atlascloud-image-generation.ts
+++ b/packages/cloud-shared/src/lib/providers/image/atlascloud-image-generation.ts
@@ -1,0 +1,114 @@
+import { getAiProviderConfigurationError } from "../language-model";
+import type { GeneratedImage, ImageGenRequest, ImageProvider } from "./types";
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function dataUrlToImage(dataUrl: string): { bytes: Uint8Array; mimeType: string } {
+  const match = /^data:([^;,]+);base64,(.+)$/s.exec(dataUrl);
+  if (!match) {
+    throw new Error("Image provider returned an invalid image data URL");
+  }
+  return { mimeType: match[1], bytes: base64ToBytes(match[2]) };
+}
+
+function buildAtlasMessages(request: ImageGenRequest) {
+  if (!request.sourceImage) {
+    return [{ role: "user", content: request.prompt }];
+  }
+
+  return [
+    {
+      role: "user",
+      content: [
+        { type: "text", text: request.prompt },
+        { type: "image_url", image_url: { url: request.sourceImage } },
+      ],
+    },
+  ];
+}
+
+function extractAtlasImage(payload: Record<string, unknown>): {
+  dataUrl: string;
+  text: string;
+} {
+  const choices = Array.isArray(payload.choices) ? payload.choices : [];
+  const message = (choices[0] as { message?: Record<string, unknown> } | undefined)?.message;
+  const images = Array.isArray(message?.images) ? message.images : [];
+  const firstImage = images[0] as { image_url?: string | { url?: string } } | undefined;
+  const imageUrl = firstImage?.image_url;
+  const dataUrl = typeof imageUrl === "string" ? imageUrl : imageUrl?.url;
+  if (!dataUrl) {
+    throw new Error("Image provider returned no image");
+  }
+
+  const content = message?.content;
+  const text = typeof content === "string" ? content : "";
+  return { dataUrl, text };
+}
+
+function atlasBaseUrl(request: ImageGenRequest): string {
+  const baseUrl = (request.apiKeys.ATLASCLOUD_BASE_URL || "https://api.atlascloud.ai/v1").replace(
+    /\/+$/,
+    "",
+  );
+  return baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
+}
+
+export async function generateAtlasCloudImage(request: ImageGenRequest): Promise<GeneratedImage> {
+  const apiKey = request.apiKeys.ATLASCLOUD_API_KEY;
+  if (!apiKey) {
+    throw new Error(getAiProviderConfigurationError());
+  }
+
+  const response = await fetch(`${atlasBaseUrl(request)}/chat/completions`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    // Payload mirrors the proven BitRouter image-via-chat shape: an
+    // OpenAI-compatible chat completion with modalities including "image".
+    // Atlas exposes the same OpenAI-compatible surface, so the same request
+    // body produces an image in choices[0].message.images[0].image_url.
+    body: JSON.stringify({
+      model: request.model,
+      messages: buildAtlasMessages(request),
+      modalities: ["image", "text"],
+      ...(request.aspectRatio || request.size
+        ? {
+            image_config: {
+              ...(request.aspectRatio ? { aspect_ratio: request.aspectRatio } : {}),
+              ...(request.size ? { size: request.size } : {}),
+            },
+          }
+        : {}),
+    }),
+  });
+
+  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!response.ok) {
+    const error = payload.error as { message?: string; code?: string } | undefined;
+    const message = error?.message ?? `Atlas Cloud image generation failed: ${response.status}`;
+    const code = error?.code ? ` (${error.code})` : "";
+    throw new Error(`${message}${code}`);
+  }
+
+  const { dataUrl, text } = extractAtlasImage(payload);
+  const { bytes, mimeType } = dataUrlToImage(dataUrl);
+  return { dataUrl, bytes, mimeType, text };
+}
+
+export const atlasCloudImageProvider: ImageProvider = {
+  billingSource: "atlascloud",
+  generate: generateAtlasCloudImage,
+  async healthCheck() {
+    return true;
+  },
+};

--- a/packages/cloud-shared/src/lib/providers/image/atlascloud-image-generation.ts
+++ b/packages/cloud-shared/src/lib/providers/image/atlascloud-image-generation.ts
@@ -1,65 +1,113 @@
 import { getAiProviderConfigurationError } from "../language-model";
 import type { GeneratedImage, ImageGenRequest, ImageProvider } from "./types";
 
-function base64ToBytes(base64: string): Uint8Array {
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i += 1) {
-    bytes[i] = binary.charCodeAt(i);
+// Atlas Cloud image generation is an asynchronous predict/poll API (NOT the
+// OpenAI chat-completions surface). Submit returns a prediction id; poll the
+// prediction until status === "completed", then download outputs[0].
+const ATLAS_IMAGE_DOWNLOAD_TIMEOUT_MS = 30_000;
+const ATLAS_IMAGE_MAX_BYTES = 20 * 1024 * 1024;
+const ATLAS_POLL_INTERVAL_MS = 2_000;
+const ATLAS_POLL_TIMEOUT_MS = 120_000;
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+async function readImageWithLimit(response: Response): Promise<Uint8Array> {
+  const declaredLength = Number(response.headers.get("content-length") ?? "0");
+  if (declaredLength > ATLAS_IMAGE_MAX_BYTES) {
+    throw new Error("Atlas image download exceeded maximum size");
+  }
+
+  if (!response.body) {
+    const buffer = await response.arrayBuffer();
+    if (buffer.byteLength > ATLAS_IMAGE_MAX_BYTES) {
+      throw new Error("Atlas image download exceeded maximum size");
+    }
+    return new Uint8Array(buffer);
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    received += value.byteLength;
+    if (received > ATLAS_IMAGE_MAX_BYTES) {
+      await reader.cancel().catch(() => undefined);
+      throw new Error("Atlas image download exceeded maximum size");
+    }
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
   }
   return bytes;
 }
 
-function dataUrlToImage(dataUrl: string): { bytes: Uint8Array; mimeType: string } {
-  const match = /^data:([^;,]+);base64,(.+)$/s.exec(dataUrl);
-  if (!match) {
-    throw new Error("Image provider returned an invalid image data URL");
-  }
-  return { mimeType: match[1], bytes: base64ToBytes(match[2]) };
-}
-
-function buildAtlasMessages(request: ImageGenRequest) {
-  if (!request.sourceImage) {
-    return [{ role: "user", content: request.prompt }];
+async function imageUrlToGeneratedImage(url: string, text = ""): Promise<GeneratedImage> {
+  const response = await fetch(url, { signal: AbortSignal.timeout(ATLAS_IMAGE_DOWNLOAD_TIMEOUT_MS) });
+  if (!response.ok) {
+    throw new Error(`Atlas image download failed: ${response.status}`);
   }
 
-  return [
-    {
-      role: "user",
-      content: [
-        { type: "text", text: request.prompt },
-        { type: "image_url", image_url: { url: request.sourceImage } },
-      ],
-    },
-  ];
-}
-
-function extractAtlasImage(payload: Record<string, unknown>): {
-  dataUrl: string;
-  text: string;
-} {
-  const choices = Array.isArray(payload.choices) ? payload.choices : [];
-  const message = (choices[0] as { message?: Record<string, unknown> } | undefined)?.message;
-  const images = Array.isArray(message?.images) ? message.images : [];
-  const firstImage = images[0] as { image_url?: string | { url?: string } } | undefined;
-  const imageUrl = firstImage?.image_url;
-  const dataUrl = typeof imageUrl === "string" ? imageUrl : imageUrl?.url;
-  if (!dataUrl) {
-    throw new Error("Image provider returned no image");
+  const mimeType = response.headers.get("content-type")?.split(";")[0]?.trim().toLowerCase();
+  if (!mimeType?.startsWith("image/")) {
+    throw new Error("Atlas image download returned non-image content");
   }
 
-  const content = message?.content;
-  const text = typeof content === "string" ? content : "";
-  return { dataUrl, text };
+  const bytes = await readImageWithLimit(response);
+  const dataUrl = `data:${mimeType};base64,${bytesToBase64(bytes)}`;
+  return { dataUrl, bytes, mimeType, text };
 }
 
 function atlasBaseUrl(request: ImageGenRequest): string {
-  const baseUrl = (request.apiKeys.ATLASCLOUD_BASE_URL || "https://api.atlascloud.ai/v1").replace(
-    /\/+$/,
-    "",
-  );
-  return baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
+  return (request.apiKeys.ATLASCLOUD_BASE_URL || "https://api.atlascloud.ai").replace(/\/+$/, "");
 }
+
+interface AtlasPrediction {
+  id?: string;
+  status?: string;
+  outputs?: unknown;
+  error?: string;
+  urls?: { get?: string };
+}
+
+function parsePrediction(payload: Record<string, unknown>): AtlasPrediction {
+  const data = (payload.data ?? payload) as Record<string, unknown>;
+  return {
+    id: typeof data.id === "string" ? data.id : undefined,
+    status: typeof data.status === "string" ? data.status : undefined,
+    outputs: data.outputs,
+    error: typeof data.error === "string" ? data.error : undefined,
+    urls: data.urls as { get?: string } | undefined,
+  };
+}
+
+function firstOutputUrl(outputs: unknown): string | undefined {
+  if (!Array.isArray(outputs)) return undefined;
+  const first = outputs[0];
+  if (typeof first === "string") return first;
+  if (first && typeof first === "object" && typeof (first as { url?: unknown }).url === "string") {
+    return (first as { url: string }).url;
+  }
+  return undefined;
+}
+
+const TERMINAL_OK = new Set(["completed", "succeeded", "success"]);
+const TERMINAL_FAIL = new Set(["failed", "error", "canceled", "cancelled"]);
 
 export async function generateAtlasCloudImage(request: ImageGenRequest): Promise<GeneratedImage> {
   const apiKey = request.apiKeys.ATLASCLOUD_API_KEY;
@@ -67,42 +115,73 @@ export async function generateAtlasCloudImage(request: ImageGenRequest): Promise
     throw new Error(getAiProviderConfigurationError());
   }
 
-  const response = await fetch(`${atlasBaseUrl(request)}/chat/completions`, {
+  const baseUrl = atlasBaseUrl(request);
+  const authHeader = { authorization: `Bearer ${apiKey}` };
+
+  // 1. Submit the generation request.
+  const submitResponse = await fetch(`${baseUrl}/api/v1/model/generateImage`, {
     method: "POST",
-    headers: {
-      authorization: `Bearer ${apiKey}`,
-      "content-type": "application/json",
-    },
-    // Payload mirrors the proven BitRouter image-via-chat shape: an
-    // OpenAI-compatible chat completion with modalities including "image".
-    // Atlas exposes the same OpenAI-compatible surface, so the same request
-    // body produces an image in choices[0].message.images[0].image_url.
+    headers: { ...authHeader, "content-type": "application/json" },
     body: JSON.stringify({
       model: request.model,
-      messages: buildAtlasMessages(request),
-      modalities: ["image", "text"],
-      ...(request.aspectRatio || request.size
-        ? {
-            image_config: {
-              ...(request.aspectRatio ? { aspect_ratio: request.aspectRatio } : {}),
-              ...(request.size ? { size: request.size } : {}),
-            },
-          }
-        : {}),
+      prompt: request.prompt,
+      ...(request.sourceImage ? { image: request.sourceImage } : {}),
+      ...(request.size ? { size: request.size } : {}),
+      ...(request.aspectRatio ? { aspect_ratio: request.aspectRatio } : {}),
     }),
   });
 
-  const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
-  if (!response.ok) {
-    const error = payload.error as { message?: string; code?: string } | undefined;
-    const message = error?.message ?? `Atlas Cloud image generation failed: ${response.status}`;
-    const code = error?.code ? ` (${error.code})` : "";
-    throw new Error(`${message}${code}`);
+  const submitPayload = (await submitResponse.json().catch(() => ({}))) as Record<string, unknown>;
+  if (!submitResponse.ok) {
+    const message =
+      (typeof submitPayload.msg === "string" && submitPayload.msg) ||
+      (typeof submitPayload.message === "string" && submitPayload.message) ||
+      `Atlas image generation failed: ${submitResponse.status}`;
+    throw new Error(message);
   }
 
-  const { dataUrl, text } = extractAtlasImage(payload);
-  const { bytes, mimeType } = dataUrlToImage(dataUrl);
-  return { dataUrl, bytes, mimeType, text };
+  const submitted = parsePrediction(submitPayload);
+
+  // Some models may return the image inline on submit; short-circuit if so.
+  const inlineUrl = firstOutputUrl(submitted.outputs);
+  if (inlineUrl) {
+    return await imageUrlToGeneratedImage(inlineUrl);
+  }
+
+  const predictionId = submitted.id;
+  if (!predictionId) {
+    throw new Error("Atlas image provider returned no prediction id");
+  }
+  const pollUrl = submitted.urls?.get ?? `${baseUrl}/api/v1/model/prediction/${predictionId}`;
+
+  // 2. Poll the prediction until it terminates.
+  const deadline = Date.now() + ATLAS_POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, ATLAS_POLL_INTERVAL_MS));
+
+    const pollResponse = await fetch(pollUrl, { headers: authHeader });
+    const pollPayload = (await pollResponse.json().catch(() => ({}))) as Record<string, unknown>;
+    if (!pollResponse.ok) {
+      throw new Error(`Atlas prediction poll failed: ${pollResponse.status}`);
+    }
+
+    const prediction = parsePrediction(pollPayload);
+    const status = (prediction.status ?? "").toLowerCase();
+
+    if (TERMINAL_FAIL.has(status)) {
+      throw new Error(`Atlas image generation failed${prediction.error ? `: ${prediction.error}` : ""}`);
+    }
+
+    if (TERMINAL_OK.has(status)) {
+      const url = firstOutputUrl(prediction.outputs);
+      if (!url) {
+        throw new Error("Atlas image provider completed without an output image");
+      }
+      return await imageUrlToGeneratedImage(url);
+    }
+  }
+
+  throw new Error("Atlas image generation timed out");
 }
 
 export const atlasCloudImageProvider: ImageProvider = {

--- a/packages/cloud-shared/src/lib/providers/image/registry.ts
+++ b/packages/cloud-shared/src/lib/providers/image/registry.ts
@@ -1,4 +1,5 @@
 import type { PricingBillingSource } from "../../services/ai-pricing-definitions";
+import { atlasCloudImageProvider } from "./atlascloud-image-generation";
 import { bitRouterImageProvider } from "./bitrouter-image-generation";
 import { falImageProvider } from "./fal-image-generation";
 import type { ImageProvider } from "./types";
@@ -19,3 +20,4 @@ export function getImageProvider(billingSource: PricingBillingSource): ImageProv
 
 registerImageProvider(bitRouterImageProvider);
 registerImageProvider(falImageProvider);
+registerImageProvider(atlasCloudImageProvider);

--- a/packages/cloud-shared/src/lib/services/ai-pricing-definitions.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing-definitions.ts
@@ -241,25 +241,41 @@ export const SUPPORTED_IMAGE_MODELS: SupportedImageModelDefinition[] = [
     sourceUrl: "https://api.bitrouter.ai/v1/models",
     defaultDimensions: { size: "1024x1024", quality: "high" },
   },
-  // Atlas Cloud image models. Atlas exposes an OpenAI-compatible
-  // chat-completions surface with the same image-via-chat shape as BitRouter,
-  // but with native (un-marked-up) provider pricing. Only genuinely-new model
-  // ids live here so they do not collide with the BitRouter entries above
-  // (getSupportedImageModelDefinition keys on modelId).
+  // Atlas Cloud image models. Atlas serves images via its async predict/poll
+  // API (/api/v1/model/generateImage); model ids are task-suffixed
+  // (e.g. "openai/gpt-image-2/text-to-image"). Native, un-marked-up provider
+  // pricing. These are Atlas-only model ids so they do not collide with the
+  // BitRouter entries above (getSupportedImageModelDefinition keys on modelId).
   {
-    modelId: "openai/gpt-image-2",
+    modelId: "openai/gpt-image-2/text-to-image",
     provider: "openai",
     billingSource: "atlascloud",
     label: "GPT Image 2",
-    sourceUrl: "https://api.atlascloud.ai/v1/models",
+    sourceUrl: "https://www.atlascloud.ai/models/list",
     defaultDimensions: { size: "1024x1024", quality: "high" },
   },
   {
-    modelId: "google/gemini-3.1-flash-image",
+    modelId: "bytedance/seedream-v5.0-lite",
+    provider: "bytedance",
+    billingSource: "atlascloud",
+    label: "Seedream 5.0 Lite",
+    sourceUrl: "https://www.atlascloud.ai/models/list",
+    defaultDimensions: { size: "default" },
+  },
+  {
+    modelId: "google/nano-banana-2/text-to-image",
     provider: "google",
     billingSource: "atlascloud",
-    label: "Gemini 3.1 Flash Image",
-    sourceUrl: "https://api.atlascloud.ai/v1/models",
+    label: "Nano Banana 2",
+    sourceUrl: "https://www.atlascloud.ai/models/list",
+    defaultDimensions: { size: "default" },
+  },
+  {
+    modelId: "qwen/qwen-image-2.0/text-to-image",
+    provider: "qwen",
+    billingSource: "atlascloud",
+    label: "Qwen Image 2.0",
+    sourceUrl: "https://www.atlascloud.ai/models/list",
     defaultDimensions: { size: "default" },
   },
   {

--- a/packages/cloud-shared/src/lib/services/ai-pricing-definitions.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing-definitions.ts
@@ -11,6 +11,7 @@ export type PricingProductFamily =
 export type PricingBillingSource =
   | "gateway"
   | "bitrouter"
+  | "atlascloud"
   | "groq"
   | "vast"
   | "cerebras"
@@ -91,7 +92,6 @@ export const PRICING_MODEL_ALIASES = {
   "vertex/gemini-2.0-flash-001": ["google/gemini-2.0-flash"],
   "vertex/gemini-2.0-flash-lite-001": ["google/gemini-2.0-flash-lite"],
   "google/gemini-3-pro-image": ["google/gemini-3-pro-image-preview"],
-  "openai/gpt-image-2": ["openai/gpt-5.4-image-2"],
   "xai/grok-2-1212": ["xai/grok-3"],
   "xai/grok-2-vision-1212": ["xai/grok-3"],
   "xai/grok-2": ["xai/grok-3"],
@@ -240,6 +240,27 @@ export const SUPPORTED_IMAGE_MODELS: SupportedImageModelDefinition[] = [
     label: "GPT-5 Image",
     sourceUrl: "https://api.bitrouter.ai/v1/models",
     defaultDimensions: { size: "1024x1024", quality: "high" },
+  },
+  // Atlas Cloud image models. Atlas exposes an OpenAI-compatible
+  // chat-completions surface with the same image-via-chat shape as BitRouter,
+  // but with native (un-marked-up) provider pricing. Only genuinely-new model
+  // ids live here so they do not collide with the BitRouter entries above
+  // (getSupportedImageModelDefinition keys on modelId).
+  {
+    modelId: "openai/gpt-image-2",
+    provider: "openai",
+    billingSource: "atlascloud",
+    label: "GPT Image 2",
+    sourceUrl: "https://api.atlascloud.ai/v1/models",
+    defaultDimensions: { size: "1024x1024", quality: "high" },
+  },
+  {
+    modelId: "google/gemini-3.1-flash-image",
+    provider: "google",
+    billingSource: "atlascloud",
+    label: "Gemini 3.1 Flash Image",
+    sourceUrl: "https://api.atlascloud.ai/v1/models",
+    defaultDimensions: { size: "default" },
   },
   {
     modelId: "fal-ai/flux/schnell",

--- a/packages/cloud-shared/src/lib/services/ai-pricing/providers/atlascloud.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/providers/atlascloud.ts
@@ -50,13 +50,13 @@ function buildAtlasImageEntry(
 }
 
 function buildAtlasImageSnapshotEntries(): PreparedPricingEntry[] {
-  return SUPPORTED_IMAGE_MODELS.filter(
-    (model) => model.billingSource === "atlascloud",
-  ).flatMap((model) => {
-    const unitPrice = ATLAS_IMAGE_PRICE_BY_MODEL[model.modelId];
-    if (unitPrice === undefined) return [];
-    return [buildAtlasImageEntry(model, unitPrice)];
-  });
+  return SUPPORTED_IMAGE_MODELS.filter((model) => model.billingSource === "atlascloud").flatMap(
+    (model) => {
+      const unitPrice = ATLAS_IMAGE_PRICE_BY_MODEL[model.modelId];
+      if (unitPrice === undefined) return [];
+      return [buildAtlasImageEntry(model, unitPrice)];
+    },
+  );
 }
 
 export async function fetchAtlasCloudCatalogEntries(): Promise<PreparedPricingEntry[]> {

--- a/packages/cloud-shared/src/lib/services/ai-pricing/providers/atlascloud.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/providers/atlascloud.ts
@@ -14,10 +14,14 @@ const ATLASCLOUD_PRICING_SOURCE_URL = "https://api.atlascloud.ai/v1/models";
 // conservative manual estimates derived from Atlas public pricing; refine them
 // with account-specific pricing before relying on exact margins in production.
 const ATLAS_IMAGE_PRICE_BY_MODEL: Record<string, number> = {
-  // gpt-image-2 high quality 1024x1024 (~$5/M input tokens token-billed).
-  "openai/gpt-image-2": 0.04,
-  // gemini-3.1-flash-image (flash tier, cheaper than the pro image model).
-  "google/gemini-3.1-flash-image": 0.01,
+  // gpt-image-2 high quality 1024x1024.
+  "openai/gpt-image-2/text-to-image": 0.04,
+  // Seedream 5.0 Lite (ByteDance) — strong, cheaper text-to-image.
+  "bytedance/seedream-v5.0-lite": 0.03,
+  // Nano Banana 2 (Google) — fast, high quality.
+  "google/nano-banana-2/text-to-image": 0.03,
+  // Qwen Image 2.0 (Alibaba).
+  "qwen/qwen-image-2.0/text-to-image": 0.02,
 };
 
 function buildAtlasImageEntry(

--- a/packages/cloud-shared/src/lib/services/ai-pricing/providers/atlascloud.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/providers/atlascloud.ts
@@ -1,0 +1,62 @@
+import {
+  SUPPORTED_IMAGE_MODELS,
+  type SupportedImageModelDefinition,
+} from "../../ai-pricing-definitions";
+import { getCachedExternalEntries } from "../cache";
+import { EXTERNAL_CACHE_TTL_MS, type PreparedPricingEntry } from "../types";
+
+const ATLASCLOUD_PRICING_SOURCE_URL = "https://api.atlascloud.ai/v1/models";
+
+// Atlas image models are token-billed by the provider, but image generation is
+// charged up front per image in the cloud-api generate-image flow (the cost
+// calculator resolves a `unit: "image"` / `chargeType: "generation"` row, the
+// same way fal image models are priced). These flat per-image prices are
+// conservative manual estimates derived from Atlas public pricing; refine them
+// with account-specific pricing before relying on exact margins in production.
+const ATLAS_IMAGE_PRICE_BY_MODEL: Record<string, number> = {
+  // gpt-image-2 high quality 1024x1024 (~$5/M input tokens token-billed).
+  "openai/gpt-image-2": 0.04,
+  // gemini-3.1-flash-image (flash tier, cheaper than the pro image model).
+  "google/gemini-3.1-flash-image": 0.01,
+};
+
+function buildAtlasImageEntry(
+  model: SupportedImageModelDefinition,
+  unitPrice: number,
+): PreparedPricingEntry {
+  const fetchedAt = new Date();
+  return {
+    billingSource: "atlascloud",
+    provider: model.provider,
+    model: model.modelId,
+    productFamily: "image",
+    chargeType: "generation",
+    unit: "image",
+    unitPrice,
+    dimensions: model.defaultDimensions,
+    sourceKind: "atlascloud_catalog",
+    sourceUrl: model.sourceUrl,
+    fetchedAt,
+    staleAfter: new Date(fetchedAt.getTime() + EXTERNAL_CACHE_TTL_MS),
+    metadata: {
+      tier: "manual_override_recommended",
+      note: "Manual Atlas Cloud image pricing seed. Refresh with account-specific pricing before production if needed.",
+    },
+  };
+}
+
+function buildAtlasImageSnapshotEntries(): PreparedPricingEntry[] {
+  return SUPPORTED_IMAGE_MODELS.filter(
+    (model) => model.billingSource === "atlascloud",
+  ).flatMap((model) => {
+    const unitPrice = ATLAS_IMAGE_PRICE_BY_MODEL[model.modelId];
+    if (unitPrice === undefined) return [];
+    return [buildAtlasImageEntry(model, unitPrice)];
+  });
+}
+
+export async function fetchAtlasCloudCatalogEntries(): Promise<PreparedPricingEntry[]> {
+  return await getCachedExternalEntries("atlascloud", async () => {
+    return buildAtlasImageSnapshotEntries();
+  });
+}

--- a/packages/cloud-shared/src/lib/services/ai-pricing/providers/atlascloud.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/providers/atlascloud.ts
@@ -5,8 +5,6 @@ import {
 import { getCachedExternalEntries } from "../cache";
 import { EXTERNAL_CACHE_TTL_MS, type PreparedPricingEntry } from "../types";
 
-const ATLASCLOUD_PRICING_SOURCE_URL = "https://api.atlascloud.ai/v1/models";
-
 // Atlas image models are token-billed by the provider, but image generation is
 // charged up front per image in the cloud-api generate-image flow (the cost
 // calculator resolves a `unit: "image"` / `chargeType: "generation"` row, the

--- a/packages/cloud-shared/src/lib/services/ai-pricing/providers/gateway.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/providers/gateway.ts
@@ -1,4 +1,5 @@
 import type { PreparedPricingEntry, PriceLookupSource } from "../types";
+import { fetchAtlasCloudCatalogEntries } from "./atlascloud";
 import { fetchBitRouterCatalogEntries } from "./bitrouter";
 import { fetchCerebrasPublicCatalogEntries } from "./cerebras";
 import { fetchElevenLabsEntries } from "./elevenlabs";
@@ -12,6 +13,8 @@ export async function fetchEntriesForSource(
   switch (source) {
     case "bitrouter":
       return await fetchBitRouterCatalogEntries();
+    case "atlascloud":
+      return await fetchAtlasCloudCatalogEntries();
     case "gateway":
     case "openai":
     case "anthropic":

--- a/packages/cloud-shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud-shared/src/types/cloud-worker-env.ts
@@ -29,6 +29,8 @@ export interface Bindings {
   CEREBRAS_API_KEY?: string;
   BITROUTER_API_KEY?: string;
   BITROUTER_BASE_URL?: string;
+  ATLASCLOUD_API_KEY?: string;
+  ATLASCLOUD_BASE_URL?: string;
   OPENAI_API_KEY?: string;
   OPENAI_BASE_URL?: string;
   ANTHROPIC_API_KEY?: string;


### PR DESCRIPTION
## Why
The deployed cloud worker routes image models (gpt-image-2, gemini-image) through **BitRouter**, but BitRouter serves **no image models** — its `/v1/models` catalog is 100% text-output. So `generate-image` 500s. **Atlas Cloud** does serve `gpt-image-2` + the gemini image models, with native (un-marked-up) pricing and $0 per-request fees.

This adds Atlas as a **one-file-style provider** using the image-provider abstraction from #8064 — so **Shaw just drops in `ATLASCLOUD_API_KEY` and it works**, and we can test with our key now.

## Changes
- **`providers/image/atlascloud-image-generation.ts`** (new): OpenAI-compatible chat-completions executor. Mirrors the proven BitRouter image-via-chat shape (`modalities:["image","text"]`, extracts `choices[0].message.images[0].image_url`). Base URL defaults to `https://api.atlascloud.ai/v1` (override `ATLASCLOUD_BASE_URL`); key from `ATLASCLOUD_API_KEY`.
- **`providers/image/registry.ts`**: register `atlasCloudImageProvider`.
- **`ai-pricing-definitions.ts`**: add `"atlascloud"` to `PricingBillingSource` + two **Atlas-only** `SUPPORTED_IMAGE_MODELS` (`openai/gpt-image-2`, `google/gemini-3.1-flash-image`) — new modelIds, no collision with existing BitRouter entries.
- **`ai-pricing/providers/atlascloud.ts` + `gateway.ts`**: per-image pricing seed (conservative manual estimates, flagged to refine with account-specific pricing).
- **`generate-image` routes** (app + non-app): thread `ATLASCLOUD_API_KEY`/`ATLASCLOUD_BASE_URL` into `apiKeys` + add the 503-on-missing-key gate, mirroring bitrouter/fal.
- **`cloud-worker-env.ts`**: optional `ATLASCLOUD_API_KEY` / `ATLASCLOUD_BASE_URL`.

## Drop-in
Set **`ATLASCLOUD_API_KEY`** and Atlas image models work. Everything else has sane defaults. Existing BitRouter/fal entries are untouched.

## Notes / follow-ups
- The exact Atlas image-request payload mirrors BitRouter's proven OpenAI-image-via-chat shape (Atlas exposes the same surface). Live image generation should be smoke-tested once the Atlas account is funded; text completions are confirmed working.
- Pricing rows are conservative seeds — refine with account-specific Atlas pricing before relying on exact margins.
- Separately: this provider abstraction (#8064) + this PR need to actually be **deployed** to the prod cloud worker (the live bundle still has the old hardcoded BitRouter path).

Co-authored-by: wakesync <shadow@shad0w.xyz>