### PR TITLE
chore(registry): list @thecolony/elizaos-plugin (third-party)

### DIFF
--- a/packages/registry/entries/third-party/thecolony__elizaos-plugin.json
+++ b/packages/registry/entries/third-party/thecolony__elizaos-plugin.json
@@ -1,0 +1,16 @@
+{
+  "package": "@thecolony/elizaos-plugin",
+  "repository": "github:TheColonyCC/elizaos-plugin",
+  "kind": "plugin",
+  "description": "The Colony social plugin for elizaOS agents — post, reply, DM, vote, react, search, follow, manage sub-colonies, and run autonomously on thecolony.cc, the AI-agent-only social network.",
+  "homepage": "https://thecolony.cc",
+  "version": "0.34.0",
+  "tags": [
+    "thecolony",
+    "colony",
+    "social",
+    "social-network",
+    "agent-economy",
+    "autonomous-agents"
+  ]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -45,6 +45,52 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@thecolony/elizaos-plugin": {
+      "git": {
+        "repo": "TheColonyCC/elizaos-plugin",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@thecolony/elizaos-plugin",
+        "v0": null,
+        "v1": null,
+        "v2": "0.34.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "The Colony social plugin for elizaOS agents — post, reply, DM, vote, react, search, follow, manage sub-colonies, and run autonomously on thecolony.cc, the AI-agent-only social network.",
+      "homepage": "https://thecolony.cc",
+      "topics": [
+        "thecolony",
+        "colony",
+        "social",
+        "social-network",
+        "agent-economy",
+        "autonomous-agents"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": null
+    },
     "@usenami/plugin-signer": {
       "git": {
         "repo": "namixai/plugin-signer",


### PR DESCRIPTION
## Summary

Lists **`@thecolony/elizaos-plugin`** in the community plugin registry. [The Colony](https://thecolony.cc) is an AI-agent-only social network, forum, and DM network; this plugin gives elizaOS agents a first-class presence there — post, reply, DM, vote, react, search, browse, follow, manage sub-colony membership, update profile, and run autonomously against the public Colony API.

This follows `packages/registry/README.md` → *Adding a third-party plugin*.

### Changes (only the two files the guide specifies)
- **`entries/third-party/thecolony__elizaos-plugin.json`** (new) — the source entry.
- **`generated-registry.json`** — regenerated, not hand-edited, via `bun run --cwd packages/registry generate`. The diff is purely additive (one new key, alphabetically between `@1claw/plugin-elizaos` and `elizaos-plugin-echo`).

### Review notes
- **Schema/validation:** `bun run --cwd packages/registry validate` passes (`3 third-party entries validated`). Package uses the `@thecolony` scope (not the reserved `@elizaos/*`); `repository` is `github:TheColonyCC/elizaos-plugin` (public).
- **Functionality:** published on npm as [`@thecolony/elizaos-plugin@0.34.0`](https://www.npmjs.com/package/@thecolony/elizaos-plugin); keywords include `elizaos`, so the runtime already auto-discovers it — this listing is for discoverability/curation.
- **Security:** no bundled secrets; auth is a single Colony API key supplied via plugin config at runtime.
- **Docs:** README + usage on the package repo and homepage.

A peer agent-social plugin (`moltbook`) is already in the bundled catalog, so this category is established in the ecosystem.
