### PR TITLE
fix(infra): tenant-db cloud-init -> systemd oneshot (idempotent, survives rescale)

### DIFF
--- a/.github/workflows/terraform-apps-data-plane.yml
+++ b/.github/workflows/terraform-apps-data-plane.yml
@@ -55,6 +55,15 @@ on:
         type: choice
         default: plan
         options: [plan, apply]
+      replace:
+        description: |
+          Optional. Comma-separated TF resource addresses to force-replace on
+          this apply (e.g. "hcloud_server.tenant_db"). Threaded through as
+          `-replace=<addr>` flags. Leave empty for a normal apply. Has no
+          effect on `plan` action.
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -167,4 +176,18 @@ jobs:
       - name: terraform apply
         if: github.event.inputs.action == 'apply'
         working-directory: ${{ env.TF_DIR }}
-        run: terraform apply -auto-approve -input=false
+        # `replace` input is a comma-separated list of TF resource addresses to
+        # force-replace this run. Empty -> normal apply. The bash loop builds
+        # the -replace flags so `terraform apply` doesn't see a stray empty
+        # flag when no replace is requested.
+        run: |
+          REPLACE_ARGS=()
+          if [ -n "${{ github.event.inputs.replace }}" ]; then
+            IFS=',' read -ra ADDRS <<< "${{ github.event.inputs.replace }}"
+            for addr in "${ADDRS[@]}"; do
+              addr_trimmed="$(echo "$addr" | xargs)"
+              [ -n "$addr_trimmed" ] && REPLACE_ARGS+=("-replace=$addr_trimmed")
+            done
+            echo "::notice::forcing replacement of: ${REPLACE_ARGS[*]}"
+          fi
+          terraform apply -auto-approve -input=false "${REPLACE_ARGS[@]}"

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/cloud-init/tenant-db.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/cloud-init/tenant-db.yaml.tftpl
@@ -9,9 +9,17 @@
 #
 # Reachable ONLY on the private apps network (the firewall opens no public 5432).
 #
+# The cluster setup is wrapped in a systemd oneshot service (tenant-db-init)
+# rather than cloud-init runcmd, because runcmd is per-instance: it only fires
+# on first boot. After a Hetzner rescale (server_type change), the cloud
+# refreshes user_data + reboots but cloud-init treats it as the same instance,
+# so runcmd never runs again — and we end up with an empty volume and dead
+# Postgres. The systemd unit runs on every boot, every step is grep-/path-
+# guarded, so it's a no-op after first successful run.
+#
 # STAN: tune shared_buffers/max_connections for thousands of small DBs; wire
-# volume-snapshot backups; consider scram-sha-256 + per-shard nodes as
-# database_count grows.
+# volume-snapshot backups; generate a server TLS cert for hostssl (until then
+# the pg_hba lines below stay 'host' and the admin DSN uses sslmode=disable).
 
 hostname: ${hostname}
 manage_etc_hosts: true
@@ -33,27 +41,122 @@ packages:
   - postgresql-contrib
   - jq
 
+write_files:
+  - path: /usr/local/bin/tenant-db-init.sh
+    owner: root:root
+    permissions: '0755'
+    content: |
+      #!/usr/bin/env bash
+      # Idempotent tenant-DB cluster init. Re-running this script is a no-op
+      # once the cluster is up. Invoked by /etc/systemd/system/tenant-db-init.service
+      # on every boot — so rescales, image swaps, and operator reboots all
+      # converge back to the right state.
+      set -euo pipefail
+      log() { echo "[tenant-db-init] $*"; }
+
+      # 1. Locate the Hetzner data volume by stable scsi id.
+      VOL="$(ls /dev/disk/by-id/scsi-0HC_Volume_* 2>/dev/null | head -1 || true)"
+      if [ -z "$VOL" ]; then
+        log "no Hetzner data volume attached yet; deferring (next boot will retry)."
+        exit 0
+      fi
+      log "data volume = $VOL"
+
+      # 2. Format only if no filesystem detected. blkid is the gate — never -F.
+      if ! blkid "$VOL" >/dev/null 2>&1; then
+        log "no fs on $VOL — formatting ext4."
+        mkfs.ext4 "$VOL"
+      fi
+
+      # 3. fstab + mount, grep-guarded so we don't accumulate duplicate lines.
+      mkdir -p /mnt/tenant-pgdata
+      if ! grep -qE "^[^#]*[[:space:]]/mnt/tenant-pgdata[[:space:]]" /etc/fstab; then
+        echo "$VOL /mnt/tenant-pgdata ext4 defaults,nofail 0 2" >> /etc/fstab
+      fi
+      mountpoint -q /mnt/tenant-pgdata || mount -a
+
+      # 4. Postgres version detection. The package may not be installed on the
+      # very first boot if cloud-init hasn't reached the package stage yet —
+      # defer cleanly; the next boot will pick it up.
+      PGVER="$(ls /etc/postgresql 2>/dev/null | head -1 || true)"
+      if [ -z "$PGVER" ]; then
+        log "postgresql package not installed yet; deferring."
+        exit 0
+      fi
+      PGDATA="/mnt/tenant-pgdata/$PGVER/main"
+      CONF="/etc/postgresql/$PGVER/main/postgresql.conf"
+      HBA="/etc/postgresql/$PGVER/main/pg_hba.conf"
+      log "PGVER=$PGVER PGDATA=$PGDATA"
+
+      # 5. initdb if PGDATA doesn't exist or isn't an initialised cluster.
+      if [ ! -f "$PGDATA/PG_VERSION" ]; then
+        log "no cluster at $PGDATA — initdb."
+        systemctl stop "postgresql@$PGVER-main" 2>/dev/null || true
+        mkdir -p "$PGDATA"
+        chown -R postgres:postgres /mnt/tenant-pgdata
+        sudo -u postgres "/usr/lib/postgresql/$PGVER/bin/initdb" -D "$PGDATA" --auth-host=scram-sha-256
+      fi
+
+      # 6. postgresql.conf — sed pattern matches both commented and uncommented
+      # forms so the script is idempotent regardless of which boot ran it last.
+      sed -i -E "s|^#?[[:space:]]*data_directory[[:space:]]*=.*|data_directory = '$PGDATA'|" "$CONF"
+      sed -i -E "s|^#?[[:space:]]*listen_addresses[[:space:]]*=.*|listen_addresses = '*'|" "$CONF"
+      sed -i -E "s|^#?[[:space:]]*password_encryption[[:space:]]*=.*|password_encryption = scram-sha-256|" "$CONF"
+
+      # 7. pg_hba — grep-guard before append so reboots don't grow the file.
+      if ! grep -qE "^hostssl[[:space:]]+all[[:space:]]+all[[:space:]]+10\.30\.0\.0/16" "$HBA"; then
+        echo "hostssl all all 10.30.0.0/16 scram-sha-256" >> "$HBA"
+      fi
+      if ! grep -qE "^host[[:space:]]+all[[:space:]]+all[[:space:]]+10\.30\.0\.0/16" "$HBA"; then
+        echo "host    all all 10.30.0.0/16 scram-sha-256" >> "$HBA"
+      fi
+
+      # 8. Start / restart so the new data_directory takes effect. Restart is
+      # safe — if PGDATA changed since last run, postgres reloads cleanly; if
+      # nothing changed, restart is a no-op for clients connecting before/after.
+      systemctl enable postgresql >/dev/null
+      systemctl restart postgresql
+      # Wait for the cluster socket so the ALTER USER below doesn't race.
+      for i in 1 2 3 4 5 6 7 8 9 10; do
+        sudo -u postgres pg_isready -q && break
+        sleep 1
+      done
+
+      # 9. Admin password (postgres superuser). The value is rendered from
+      # random_password.tenant_db_admin in TF state, stable across reboots, so
+      # this ALTER is idempotent.
+      sudo -u postgres psql -tAc "ALTER USER postgres WITH PASSWORD '${admin_password}';" >/dev/null
+
+      log "done."
+
+  - path: /etc/systemd/system/tenant-db-init.service
+    owner: root:root
+    permissions: '0644'
+    content: |
+      [Unit]
+      Description=Tenant DB cluster init (idempotent, runs every boot)
+      After=network-online.target cloud-final.service
+      Wants=network-online.target
+      # Run BEFORE postgresql so the script's restart isn't fighting the
+      # default unit. The script itself enables + starts postgresql once
+      # data_directory is wired.
+      Before=postgresql.service
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStart=/usr/local/bin/tenant-db-init.sh
+      # Keep the unit's own state simple: success = postgres up; failure leaves
+      # it for the operator to inspect via `journalctl -u tenant-db-init`.
+      StandardOutput=journal
+      StandardError=journal
+
+      [Install]
+      WantedBy=multi-user.target
+
 runcmd:
-  # 1. Mount the data volume at the Postgres data dir (survives node rebuilds).
-  - export VOL=$(ls /dev/disk/by-id/scsi-0HC_Volume_* 2>/dev/null | head -1)
-  - if [ -n "$VOL" ] && ! blkid "$VOL" >/dev/null 2>&1; then mkfs.ext4 -F "$VOL"; fi
-  - systemctl stop postgresql || true
-  - mkdir -p /mnt/tenant-pgdata
-  - if [ -n "$VOL" ]; then echo "$VOL /mnt/tenant-pgdata ext4 defaults,nofail 0 2" >> /etc/fstab && mount -a; fi
-  - export PGVER=$(ls /etc/postgresql | head -1)
-  - export PGDATA="/mnt/tenant-pgdata/$PGVER/main"
-  - if [ ! -d "$PGDATA" ]; then mkdir -p "$PGDATA" && chown -R postgres:postgres /mnt/tenant-pgdata && sudo -u postgres /usr/lib/postgresql/$PGVER/bin/initdb -D "$PGDATA"; fi
-  # 2. Point the cluster config at the volume + listen on all ifaces (the
-  #    firewall + pg_hba are the access control; no public 5432 rule exists).
-  - sed -i "s|^data_directory.*|data_directory = '$PGDATA'|" /etc/postgresql/$PGVER/main/postgresql.conf
-  - sed -i "s|^#listen_addresses.*|listen_addresses = '*'|" /etc/postgresql/$PGVER/main/postgresql.conf
-  # 3. Allow the private apps subnet to connect (scram); deny everything else.
-  - echo "hostssl all all 10.30.0.0/16 scram-sha-256" >> /etc/postgresql/$PGVER/main/pg_hba.conf
-  - echo "host    all all 10.30.0.0/16 scram-sha-256" >> /etc/postgresql/$PGVER/main/pg_hba.conf
-  - sed -i "s|^#password_encryption.*|password_encryption = scram-sha-256|" /etc/postgresql/$PGVER/main/postgresql.conf
-  - systemctl enable postgresql && systemctl start postgresql
-  # 4. Set the admin (postgres) superuser password the daemon's admin DSN uses.
-  - sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD '${admin_password}';"
-  # STAN: generate a server TLS cert for hostssl (self-signed or internal CA);
-  # until then switch the pg_hba lines above to 'host' and the admin DSN to
-  # sslmode=disable on the private net.
+  # Activate the systemd unit on first boot. On subsequent boots, systemd
+  # picks it up automatically (WantedBy=multi-user.target) — runcmd is per-
+  # instance and never runs again, but the unit does.
+  - systemctl daemon-reload
+  - systemctl enable --now tenant-db-init.service


### PR DESCRIPTION
## Summary

Wraps the tenant-DB cluster setup in a systemd oneshot service installed via
`write_files`. The service runs on **every boot** (not just the first one),
every step is grep- or path-guarded so it's a no-op when there's nothing to
do.

## Why

After the cpx41/cpx42 rescale this morning (PR #8379), tenant_db came up with
postgres dead. The volume mounted fine but PGDATA never existed:

| Check | Observed |
|---|---|
| `systemctl is-active postgresql@16-main` | `inactive (dead)` |
| `pg_lsclusters` | empty |
| `df -h /mnt/tenant-pgdata` | 32K used (freshly formatted) |
| `ls /mnt/tenant-pgdata/16/main/` | no such file or directory |
| Cloud-init log on rescaled boot | finished in <1s, runcmd absent |

Root cause: cloud-init `runcmd` is per-instance (first boot only). Hetzner
rescale = stop → change type → start, same instance id, so runcmd never
fires again.

## Fixes inside the migration

A few latent bugs in the old `runcmd` script that this version closes:

- fstab append wasn't grep-guarded → duplicate lines on every re-run
- `pg_hba` `hostssl` / `host` lines weren't grep-guarded → same
- `postgresql.conf` seds only matched the commented form (`^#listen_addresses`)
  → silently failed on re-runs after the first sed had uncommented them
- PGDATA check used `! -d` → true for an empty directory left behind by a
  half-finished initdb. Now checks `! -f $PGDATA/PG_VERSION`
- `mkfs.ext4 -F` removed → the `blkid` gate is the only protection; `-F`
  would silently nuke a real fs if `blkid` ever lied
- ALTER USER postgres now waits for `pg_isready` before firing (was racing)
- Script `set -euo pipefail` so partial failures don't masquerade as success

## Workflow input

Adds an optional `replace` input to `terraform-apps-data-plane.yml` —
comma-separated TF resource addresses, threaded as `-replace=<addr>` flags.

Reason: `user_data` lives in `hcloud_server.tenant_db.lifecycle.ignore_changes`
(matches the control-plane convention, `ARCHITECTURE.md` calls this out
explicitly). So a normal apply won't replace the existing tenant_db to pick
up the fixed cloud-init. The `replace` input scratches that itch without
having to taint via local terraform CLI access.

Reusable: any future "rebuild this resource cleanly" follows the same path —
dispatch with `replace="hcloud_server.foo"`, no taint gymnastics.

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` green
- [ ] CI: PR validate job green
- [ ] After merge, dispatch with `environment=staging action=apply replace=hcloud_server.tenant_db`
- [ ] Verify the new tenant_db comes up with `systemctl is-active postgresql` = `active`, `pg_lsclusters` shows the 16/main cluster, port 5432 listening on the private net
- [ ] Then load the 2 user DBs from the OLD CP dump (separate, manual `psql -f`)