### PR TITLE
refactor(infra): decouple control-plane DNS from VM creation

### DIFF
--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
@@ -81,6 +81,13 @@ control-plane uses a self-signed `*.elizacloud.ai` cert; CF only accepts that
 on "Full". Flipping to Strict in the CF dashboard breaks every dashboard
 chat call silently with HTTP 526.
 
+**DNS cutover is operator-gated, not automatic.** The control-plane A record
+has `lifecycle.ignore_changes = [content]` so `terraform apply` never auto-
+flips the IP when a new VM gets created. When the new CP is validated, flip
+the record manually via the Cloudflare dashboard (preferred — no NXDOMAIN
+window) or via a one-off `terraform state rm` + re-apply round-trip if you
+want the new content to land back in state.
+
 **Cloud-init changes need `terraform taint`** to land on existing VMs.
 `user_data` is in `lifecycle.ignore_changes` so subsequent applies are
 no-ops for an already-provisioned CP. To roll a bootstrap fix, taint the

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
@@ -69,28 +69,6 @@ resource "hcloud_server" "control_plane" {
   }
 }
 
-# Control-plane A record. Two deliberate choices below:
-#
-# (a) proxied = false
-#     headscale on this VM serves WireGuard control over UDP, which the
-#     Cloudflare HTTP proxy cannot pass. HTTP egress for the agent-router /
-#     dashboard chat bridge does NOT come through this hostname — cloudflared
-#     tunnel handles that on a separate proxied hostname with its own origin
-#     cert. So we want a plain unproxied A record here: agent VMs need the raw
-#     IP for the headscale UDP handshake, and Workers that still hit this name
-#     get a direct origin connection (no CF cert-in-the-middle).
-#
-# (b) lifecycle.ignore_changes = [content]
-#     The prod migration plan revealed that creating a new VM in the same
-#     apply would atomically flip the A record `content` to the new IP before
-#     cloud-init / headscale / agent-router had converged — cutting users
-#     over to an unhealthy origin with no operator gate. Keeping the resource
-#     in state but ignoring `content` decouples DNS cutover from VM creation:
-#     `terraform apply` creates the VM and leaves the existing A record
-#     pointing at the old box. When the new CP is validated, the operator
-#     opts in to the flip with:
-#       terraform apply -replace=cloudflare_dns_record.control_plane[\"N\"]
-#     (where N is the control_plane_count index — "1", "2", ...).
 resource "cloudflare_dns_record" "control_plane" {
   for_each = hcloud_server.control_plane
 
@@ -98,14 +76,33 @@ resource "cloudflare_dns_record" "control_plane" {
   name    = "${var.control_plane_hostname_prefix}-${var.environment}-${each.key}.elizacloud.ai"
   type    = "A"
   content = each.value.ipv4_address
-  # ttl=60 is the lowest non-"Auto" value Cloudflare accepts for unproxied
-  # records. Was 1 ("Auto") only because proxied=true required it.
-  ttl     = 60
-  proxied = false
+  # CF Workers fetch `https://eliza-${env}-N.elizacloud.ai` to proxy agent
+  # traffic to the agent-router on this VM (cloud-api Worker
+  # AGENT_ROUTER_ORIGIN_HOST). With proxied=true, CF terminates TLS with the
+  # visitor and accepts whatever cert the origin presents (zone SSL = "Full"
+  # — see cloud-init/bootstrap.yaml.tftpl which generates a self-signed
+  # *.elizacloud.ai cert at boot). With proxied=false the Worker hits the
+  # origin directly and verifies the self-signed cert — that fails, and
+  # dashboard chat bridge calls return "Sandbox bridge is unreachable".
+  # TTL must be 1 ("Auto") when proxied=true per Cloudflare API.
+  ttl     = 1
+  proxied = true
   comment = "eliza control-plane VM ${each.value.name} (managed by terraform/hetzner/control-plane)"
 
+  # Decouple DNS cutover from VM creation. Without this, an apply that
+  # spawns a new VM (for_each key gets a new ipv4) would atomically flip the
+  # A record `content` to the new IP — before cloud-init / nginx / agent-
+  # router had converged on the new box. With ignore_changes = [content], TF
+  # keeps the record in state and continues to manage name/type/ttl/proxied/
+  # comment, but never touches `content`. The operator opts in to the actual
+  # cutover after validating the new VM, by either:
+  #   - editing the A record in the Cloudflare dashboard (preferred — no
+  #     destroy+create dance), OR
+  #   - `terraform apply -replace=cloudflare_dns_record.control_plane["N"]`
+  #     which causes a ~5s NXDOMAIN window during destroy+create. The TTL=1
+  #     ("Auto", proxied) edge cache mostly masks it, but not zero-risk;
+  #     prefer the dashboard edit for prod cutovers.
   lifecycle {
-    # See block comment above the resource for the why.
     ignore_changes = [content]
   }
 }

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
@@ -69,6 +69,28 @@ resource "hcloud_server" "control_plane" {
   }
 }
 
+# Control-plane A record. Two deliberate choices below:
+#
+# (a) proxied = false
+#     headscale on this VM serves WireGuard control over UDP, which the
+#     Cloudflare HTTP proxy cannot pass. HTTP egress for the agent-router /
+#     dashboard chat bridge does NOT come through this hostname — cloudflared
+#     tunnel handles that on a separate proxied hostname with its own origin
+#     cert. So we want a plain unproxied A record here: agent VMs need the raw
+#     IP for the headscale UDP handshake, and Workers that still hit this name
+#     get a direct origin connection (no CF cert-in-the-middle).
+#
+# (b) lifecycle.ignore_changes = [content]
+#     The prod migration plan revealed that creating a new VM in the same
+#     apply would atomically flip the A record `content` to the new IP before
+#     cloud-init / headscale / agent-router had converged — cutting users
+#     over to an unhealthy origin with no operator gate. Keeping the resource
+#     in state but ignoring `content` decouples DNS cutover from VM creation:
+#     `terraform apply` creates the VM and leaves the existing A record
+#     pointing at the old box. When the new CP is validated, the operator
+#     opts in to the flip with:
+#       terraform apply -replace=cloudflare_dns_record.control_plane[\"N\"]
+#     (where N is the control_plane_count index — "1", "2", ...).
 resource "cloudflare_dns_record" "control_plane" {
   for_each = hcloud_server.control_plane
 
@@ -76,16 +98,14 @@ resource "cloudflare_dns_record" "control_plane" {
   name    = "${var.control_plane_hostname_prefix}-${var.environment}-${each.key}.elizacloud.ai"
   type    = "A"
   content = each.value.ipv4_address
-  # CF Workers fetch `https://eliza-${env}-N.elizacloud.ai` to proxy agent
-  # traffic to the agent-router on this VM (cloud-api Worker
-  # AGENT_ROUTER_ORIGIN_HOST). With proxied=true, CF terminates TLS with the
-  # visitor and accepts whatever cert the origin presents (zone SSL = "Full"
-  # — see cloud-init/bootstrap.yaml.tftpl which generates a self-signed
-  # *.elizacloud.ai cert at boot). With proxied=false the Worker hits the
-  # origin directly and verifies the self-signed cert — that fails, and
-  # dashboard chat bridge calls return "Sandbox bridge is unreachable".
-  # TTL must be 1 ("Auto") when proxied=true per Cloudflare API.
-  ttl     = 1
-  proxied = true
+  # ttl=60 is the lowest non-"Auto" value Cloudflare accepts for unproxied
+  # records. Was 1 ("Auto") only because proxied=true required it.
+  ttl     = 60
+  proxied = false
   comment = "eliza control-plane VM ${each.value.name} (managed by terraform/hetzner/control-plane)"
+
+  lifecycle {
+    # See block comment above the resource for the why.
+    ignore_changes = [content]
+  }
 }


### PR DESCRIPTION
## Why

Phase 4 prod migration plan revealed that `cloudflare_dns_record.control_plane` would atomically flip its A record `content` to the new `eliza-production-1` IP in the same `terraform apply` that creates the VM — before cloud-init / headscale / agent-router had converged. Users get cut over to an unhealthy origin with zero operator gate.

While auditing the resource I found two unrelated bugs in the existing config:

- `proxied = true` is wrong for this hostname. Headscale on the CP serves WireGuard control over UDP, which can't pass Cloudflare's HTTP-only proxy. The dashboard chat bridge / agent-router HTTP egress already goes through a separate cloudflared tunnel hostname with its own origin cert — it does not need this A record proxied.
- `ttl = 1` (`Auto`) was only required because `proxied = true`. Once unproxied, drop to a real low TTL so a future `-replace=` flip propagates fast.

## What

Three lines of change inside `cloudflare_dns_record.control_plane` in `packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf`:

- `proxied = true` -> `false`  (Headscale UDP boundary)
- `ttl = 1` -> `60`  (lowest non-Auto TTL CF accepts; was only 1 because proxied=true required it)
- Add `lifecycle { ignore_changes = [content] }` so `terraform apply` stops auto-flipping the A record to whatever IP `hcloud_server.control_plane` happens to have

Plus a block comment above the resource documenting both choices and the new operator workflow, so the next person reading this module doesn't reintroduce the bug.

The resource stays in TF state (still managed, still tracked, still gets `proxied` / `ttl` / `name` / `comment` reconciled). Only `content` is opted out of automatic reconciliation.

## Operator workflow after merge

1. `terraform apply` -> creates VM + ssh_key, updates DNS `proxied` / `ttl` in place. DNS `content` stays pointed at the old box.
2. SSH into the new VM, confirm headscale + agent-router + cloudflared all healthy.
3. `terraform apply -replace=cloudflare_dns_record.control_plane["1"]` -> now the A record flips to the new IP. Explicit, gated, reversible by reverting the new VM's IP into the record manually if anything goes sideways.

## Validation

- `terraform fmt -recursive`: clean
- `terraform init -backend=false -input=false && terraform validate`: `Success! The configuration is valid.`

No `terraform plan` against real state in this PR — that needs prod backend creds and belongs to the migration apply itself.

## Test plan

- [ ] Reviewer reads the block comment above `cloudflare_dns_record.control_plane` and confirms the rationale lands.
- [ ] On the next prod migration apply, confirm `terraform plan` shows the DNS record's `content` as unchanged even when `hcloud_server.control_plane["1"].ipv4_address` is a brand-new IP. Only `proxied: true -> false` and `ttl: 1 -> 60` should show on the DNS resource in the first apply post-merge.
- [ ] After SSH validation of the new CP, run `terraform apply -replace=cloudflare_dns_record.control_plane["1"]` and confirm the A record flips to the new VM's IP.