### PR TITLE
fix(infra): control-plane cloud-init bun integrity check + workflow replace input

### DIFF
--- a/.github/workflows/terraform-control-plane.yml
+++ b/.github/workflows/terraform-control-plane.yml
@@ -44,6 +44,15 @@ on:
         type: choice
         default: plan
         options: [plan, apply]
+      replace:
+        description: |
+          Optional. Comma-separated TF resource addresses to force-replace on
+          this apply (e.g. `hcloud_server.control_plane["1"]`). Threaded as
+          `-replace=<addr>` flags. Leave empty for a normal apply. No effect
+          on `plan`.
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -138,4 +147,18 @@ jobs:
       - name: terraform apply
         if: github.event.inputs.action == 'apply'
         working-directory: ${{ env.TF_DIR }}
-        run: terraform apply -auto-approve -input=false
+        # `replace` input is a comma-separated list of TF resource addresses
+        # to force-replace on this run. Empty -> normal apply. The bash loop
+        # builds the -replace flags so `terraform apply` doesn't see a stray
+        # empty flag when no replace is requested.
+        run: |
+          REPLACE_ARGS=()
+          if [ -n "${{ github.event.inputs.replace }}" ]; then
+            IFS=',' read -ra ADDRS <<< "${{ github.event.inputs.replace }}"
+            for addr in "${ADDRS[@]}"; do
+              addr_trimmed="$(echo "$addr" | xargs)"
+              [ -n "$addr_trimmed" ] && REPLACE_ARGS+=("-replace=$addr_trimmed")
+            done
+            echo "::notice::forcing replacement of: ${REPLACE_ARGS[*]}"
+          fi
+          terraform apply -auto-approve -input=false "${REPLACE_ARGS[@]}"

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
@@ -155,10 +155,15 @@ runcmd:
   # PR review — we still trust GitHub's HTTPS, but the manifest commits
   # the publisher to a specific hash that an attacker can't forge mid-flight.
   - install -d -o deploy -g deploy /home/deploy/.bun /home/deploy/.bun/bin
-  - su - deploy -c 'curl -fsSL -o /tmp/bun.zip https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-linux-x64.zip'
+  # Download under the same filename that appears in SHASUMS256.txt so that
+  # `sha256sum -c` can find the file on disk. The previous version wrote to
+  # /tmp/bun.zip and silently failed integrity check ("bun-linux-x64.zip: No
+  # such file or directory") — sha256sum reads the path from the SHASUMS
+  # line, not from our local filename choice.
+  - su - deploy -c 'curl -fsSL -o /tmp/bun-linux-x64.zip https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-linux-x64.zip'
   - su - deploy -c 'curl -fsSL -o /tmp/bun-SHASUMS256.txt https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/SHASUMS256.txt'
   - su - deploy -c 'cd /tmp && grep "bun-linux-x64.zip" bun-SHASUMS256.txt | sha256sum -c -'
-  - su - deploy -c 'cd /tmp && unzip -q bun.zip && install -m 0755 bun-linux-x64/bun /home/deploy/.bun/bin/bun && rm -rf /tmp/bun.zip /tmp/bun-linux-x64 /tmp/bun-SHASUMS256.txt'
+  - su - deploy -c 'cd /tmp && unzip -q bun-linux-x64.zip && install -m 0755 bun-linux-x64/bun /home/deploy/.bun/bin/bun && rm -rf /tmp/bun-linux-x64.zip /tmp/bun-linux-x64 /tmp/bun-SHASUMS256.txt'
 
   # The `bunx` invocation used by some workspace build scripts is a separate
   # binary (or symlink) alongside `bun`. Older release tarballs ship it; the


### PR DESCRIPTION
## Why

Phase 4 prod CP migration uncovered two latent bugs in the control-plane module the moment we provisioned a fresh box on the eliza-prod project.

### Bug 1: bun install silently fails sha256 integrity check
\`bootstrap.yaml.tftpl\` downloaded bun to \`/tmp/bun.zip\` but the integrity check is \`grep "bun-linux-x64.zip" bun-SHASUMS256.txt | sha256sum -c -\`, which reads the local filename from the SHASUMS line — it looks for \`/tmp/bun-linux-x64.zip\`, not \`/tmp/bun.zip\`. Cloud-init output on the new prod VM:
\`\`\`
sha256sum: bun-linux-x64.zip: No such file or directory
bun-linux-x64.zip: FAILED open or read
\`\`\`
The check exit code was discarded so cloud-init kept going, but bun never landed. Fix: rename the download target to match what SHASUMS says.

### Bug 2: no \`replace\` input on the workflow
The two apps workflows (\`terraform-apps-shared.yml\`, \`terraform-apps-data-plane.yml\`) both got an optional \`replace\` input in earlier PRs so operators can force a TF replacement of a specific resource without taint gymnastics. The control-plane workflow didn't have the same input. Mirror the same shape here.

## What this unblocks

After merge, force a fresh cloud-init on the existing \`eliza-production-1\` (Hetzner id 139673804) so it picks up the bun fix + the now-existent \`main\` branch on the repo:
\`\`\`
gh workflow run terraform-control-plane.yml --ref develop \\
  -f environment=production -f action=apply \\
  -f replace='hcloud_server.control_plane["1"]'
\`\`\`
The DNS record still has \`lifecycle.ignore_changes = [content]\` (from #8388) so the A-record content stays pointed at old \`eliza-1\` through the replacement — no user cutover.

## Test plan

- [x] terraform fmt -check + validate green locally
- [ ] CI PR validate green
- [ ] After merge: dispatch the apply with \`replace='hcloud_server.control_plane["1"]'\`, expect 1 destroy + 1 create on the server (TF state-only, no DNS or ssh_key churn)
- [ ] SSH \`deploy@<new-ip>\`, confirm \`bun --version\` returns 1.3.13, \`/opt/eliza\` has the monorepo on main, systemd units installed