### PR TITLE
fix(infra): replace-input trim must not use xargs (strips for_each quotes)

### DIFF
--- a/.github/workflows/terraform-apps-data-plane.yml
+++ b/.github/workflows/terraform-apps-data-plane.yml
@@ -196,7 +196,11 @@ jobs:
           if [ -n "${{ github.event.inputs.replace }}" ]; then
             IFS=',' read -ra ADDRS <<< "${{ github.event.inputs.replace }}"
             for addr in "${ADDRS[@]}"; do
-              addr_trimmed="$(echo "$addr" | xargs)"
+              # See terraform-control-plane.yml for why this trims via bash
+              # parameter expansion instead of `xargs` — xargs strips the
+              # literal quotes inside for_each addresses like `hcloud_server.foo["1"]`.
+              addr_trimmed="${addr#"${addr%%[![:space:]]*}"}"
+              addr_trimmed="${addr_trimmed%"${addr_trimmed##*[![:space:]]}"}"
               [ -n "$addr_trimmed" ] && REPLACE_ARGS+=("-replace=$addr_trimmed")
             done
             echo "::notice::forcing replacement of: ${REPLACE_ARGS[*]}"

--- a/.github/workflows/terraform-apps-shared.yml
+++ b/.github/workflows/terraform-apps-shared.yml
@@ -155,7 +155,11 @@ jobs:
           if [ -n "${{ github.event.inputs.replace }}" ]; then
             IFS=',' read -ra ADDRS <<< "${{ github.event.inputs.replace }}"
             for addr in "${ADDRS[@]}"; do
-              addr_trimmed="$(echo "$addr" | xargs)"
+              # See terraform-control-plane.yml for why this trims via bash
+              # parameter expansion instead of `xargs` — xargs strips the
+              # literal quotes inside for_each addresses like `hcloud_server.foo["1"]`.
+              addr_trimmed="${addr#"${addr%%[![:space:]]*}"}"
+              addr_trimmed="${addr_trimmed%"${addr_trimmed##*[![:space:]]}"}"
               [ -n "$addr_trimmed" ] && REPLACE_ARGS+=("-replace=$addr_trimmed")
             done
             echo "::notice::forcing replacement of: ${REPLACE_ARGS[*]}"

--- a/.github/workflows/terraform-control-plane.yml
+++ b/.github/workflows/terraform-control-plane.yml
@@ -156,7 +156,13 @@ jobs:
           if [ -n "${{ github.event.inputs.replace }}" ]; then
             IFS=',' read -ra ADDRS <<< "${{ github.event.inputs.replace }}"
             for addr in "${ADDRS[@]}"; do
-              addr_trimmed="$(echo "$addr" | xargs)"
+              # Trim leading/trailing whitespace via bash parameter expansion.
+              # NOT `xargs` — that strips the literal quotes inside for_each
+              # addresses like `hcloud_server.foo["1"]`, leaving the bare
+              # `hcloud_server.foo[1]` that TF then interprets as int index
+              # against a string-keyed for_each map and silently can't match.
+              addr_trimmed="${addr#"${addr%%[![:space:]]*}"}"
+              addr_trimmed="${addr_trimmed%"${addr_trimmed##*[![:space:]]}"}"
               [ -n "$addr_trimmed" ] && REPLACE_ARGS+=("-replace=$addr_trimmed")
             done
             echo "::notice::forcing replacement of: ${REPLACE_ARGS[*]}"


### PR DESCRIPTION
## Why

The \`replace\` input bash loop added in #8385 / #8389 used \`xargs\` to trim whitespace. \`xargs\` also strips literal quotes, so an input like \`hcloud_server.control_plane[\"1\"]\` reached terraform apply as \`-replace=hcloud_server.control_plane[1]\` — TF interpreted \`[1]\` as an integer index, found no match against the string-keyed for_each map, and silently applied 0 changes.

Hit live on PR #8389 first replace-apply (run 27360421726):
\`\`\`
::notice::forcing replacement of: -replace=hcloud_server.control_plane[1]
No changes. Your infrastructure matches the configuration.
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
\`\`\`

## Fix

Use bash parameter expansion to trim — preserves quotes. Applied in all three workflows that ship the \`replace\` input:
- terraform-control-plane.yml
- terraform-apps-data-plane.yml
- terraform-apps-shared.yml

## Test plan

- [x] terraform fmt -check on both modules
- [ ] CI validate green
- [ ] After merge: re-dispatch \`terraform-control-plane.yml\` with \`replace='hcloud_server.control_plane["1"]'\` — expect the existing eliza-production-1 (id 139673804) to be replaced this time, picking up the bun race fix + the now-existent main branch.