### PR TITLE
fix(infra): thread replace input via env var (GHA quote-escaping)

### DIFF
--- a/.github/workflows/terraform-apps-data-plane.yml
+++ b/.github/workflows/terraform-apps-data-plane.yml
@@ -186,19 +186,18 @@ jobs:
         if: github.event.inputs.action == 'apply'
         working-directory: ${{ env.TF_DIR }}
         # `replace` input is a comma-separated list of TF resource addresses to
-        # force-replace this run. Empty -> normal apply. The bash loop builds
-        # the -replace flags so `terraform apply` doesn't see a stray empty
-        # flag when no replace is requested. NOTE: tenant_db lives in
-        # apps-shared now — `-replace=hcloud_server.tenant_db` here is a no-op;
-        # use the terraform-apps-shared workflow instead.
+        # force-replace this run. Empty -> normal apply. NOTE: tenant_db lives
+        # in apps-shared now — `-replace=hcloud_server.tenant_db` here is a
+        # no-op; use the terraform-apps-shared workflow instead.
+        # See terraform-control-plane.yml for why we thread the input via $env
+        # instead of inline `${{ ... }}` (quote handling).
+        env:
+          REPLACE_INPUT: ${{ github.event.inputs.replace }}
         run: |
           REPLACE_ARGS=()
-          if [ -n "${{ github.event.inputs.replace }}" ]; then
-            IFS=',' read -ra ADDRS <<< "${{ github.event.inputs.replace }}"
+          if [ -n "$REPLACE_INPUT" ]; then
+            IFS=',' read -ra ADDRS <<< "$REPLACE_INPUT"
             for addr in "${ADDRS[@]}"; do
-              # See terraform-control-plane.yml for why this trims via bash
-              # parameter expansion instead of `xargs` — xargs strips the
-              # literal quotes inside for_each addresses like `hcloud_server.foo["1"]`.
               addr_trimmed="${addr#"${addr%%[![:space:]]*}"}"
               addr_trimmed="${addr_trimmed%"${addr_trimmed##*[![:space:]]}"}"
               [ -n "$addr_trimmed" ] && REPLACE_ARGS+=("-replace=$addr_trimmed")

--- a/.github/workflows/terraform-apps-shared.yml
+++ b/.github/workflows/terraform-apps-shared.yml
@@ -147,17 +147,16 @@ jobs:
         if: github.event.inputs.action == 'apply'
         working-directory: ${{ env.TF_DIR }}
         # `replace` input is a comma-separated list of TF resource addresses to
-        # force-replace this run. Empty -> normal apply. The bash loop builds
-        # the -replace flags so `terraform apply` doesn't see a stray empty
-        # flag when no replace is requested.
+        # force-replace this run. Empty -> normal apply.
+        # See terraform-control-plane.yml for why we thread the input via $env
+        # instead of inline `${{ ... }}` (quote handling).
+        env:
+          REPLACE_INPUT: ${{ github.event.inputs.replace }}
         run: |
           REPLACE_ARGS=()
-          if [ -n "${{ github.event.inputs.replace }}" ]; then
-            IFS=',' read -ra ADDRS <<< "${{ github.event.inputs.replace }}"
+          if [ -n "$REPLACE_INPUT" ]; then
+            IFS=',' read -ra ADDRS <<< "$REPLACE_INPUT"
             for addr in "${ADDRS[@]}"; do
-              # See terraform-control-plane.yml for why this trims via bash
-              # parameter expansion instead of `xargs` — xargs strips the
-              # literal quotes inside for_each addresses like `hcloud_server.foo["1"]`.
               addr_trimmed="${addr#"${addr%%[![:space:]]*}"}"
               addr_trimmed="${addr_trimmed%"${addr_trimmed##*[![:space:]]}"}"
               [ -n "$addr_trimmed" ] && REPLACE_ARGS+=("-replace=$addr_trimmed")

--- a/.github/workflows/terraform-control-plane.yml
+++ b/.github/workflows/terraform-control-plane.yml
@@ -148,19 +148,25 @@ jobs:
         if: github.event.inputs.action == 'apply'
         working-directory: ${{ env.TF_DIR }}
         # `replace` input is a comma-separated list of TF resource addresses
-        # to force-replace on this run. Empty -> normal apply. The bash loop
-        # builds the -replace flags so `terraform apply` doesn't see a stray
-        # empty flag when no replace is requested.
+        # to force-replace on this run. Empty -> normal apply.
+        #
+        # IMPORTANT: the input is threaded via an env var (REPLACE_INPUT), not
+        # spliced into the shell with `${{ ... }}`. GitHub Actions substitutes
+        # `${{ inputs.foo }}` at YAML-parse time as raw literal text, so any
+        # double quotes inside the input (e.g. `hcloud_server.foo["1"]`) end
+        # up being parsed by bash as quote delimiters, not as literal
+        # characters — the apply silently sees `hcloud_server.foo[1]` instead
+        # and TF treats the `[1]` as an int index against a string-keyed
+        # for_each map, so 0 changes apply with no error. Reading via $env
+        # treats the value as opaque data.
+        env:
+          REPLACE_INPUT: ${{ github.event.inputs.replace }}
         run: |
           REPLACE_ARGS=()
-          if [ -n "${{ github.event.inputs.replace }}" ]; then
-            IFS=',' read -ra ADDRS <<< "${{ github.event.inputs.replace }}"
+          if [ -n "$REPLACE_INPUT" ]; then
+            IFS=',' read -ra ADDRS <<< "$REPLACE_INPUT"
             for addr in "${ADDRS[@]}"; do
               # Trim leading/trailing whitespace via bash parameter expansion.
-              # NOT `xargs` — that strips the literal quotes inside for_each
-              # addresses like `hcloud_server.foo["1"]`, leaving the bare
-              # `hcloud_server.foo[1]` that TF then interprets as int index
-              # against a string-keyed for_each map and silently can't match.
               addr_trimmed="${addr#"${addr%%[![:space:]]*}"}"
               addr_trimmed="${addr_trimmed%"${addr_trimmed##*[![:space:]]}"}"
               [ -n "$addr_trimmed" ] && REPLACE_ARGS+=("-replace=$addr_trimmed")


### PR DESCRIPTION
Fixes the residual bug in #8389 / #8390: GitHub Actions splices `${{ inputs.replace }}` at YAML-parse time as raw literal text inside the bash double-quoted string. So an input like `hcloud_server.control_plane["1"]` gets rendered as bash source where the inner `"1"` is interpreted as shell quotes, not data — bash sees `hcloud_server.control_plane[1]` and TF can't match it against the string-keyed for_each map. Threading the input through an `env:` block on the step preserves the literal characters because bash reads env vars opaquely.

Same fix applied across the three workflows that ship the replace input:
- terraform-control-plane.yml
- terraform-apps-data-plane.yml
- terraform-apps-shared.yml

## Test plan

- [x] terraform fmt -check
- [ ] CI PR validate green
- [ ] After merge: re-dispatch `terraform-control-plane.yml` with `replace='hcloud_server.control_plane["1"]'`. Expect the apply log to show:
      `::notice::forcing replacement of: -replace=hcloud_server.control_plane["1"]`
      followed by an actual destroy+create on the server resource (1 added, 0 changed, 1 destroyed).