### PR TITLE
feat(infra): manage data-plane private network via TF on control-plane module

### DIFF
--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/main.tf
@@ -9,6 +9,30 @@ locals {
   }
 }
 
+# Private network that the runtime autoscaler attaches every data-plane worker
+# to. Lives in the SAME Hetzner project as the control-plane VM, so each env's
+# workers + their CP share one private LAN — no cross-project peering hack.
+# The autoscaler reads this network's id from CONTAINERS_HCLOUD_NETWORK_IDS in
+# /opt/eliza/cloud/.env.local on the CP (see node-autoscaler.ts).
+resource "hcloud_network" "data_plane" {
+  name     = "eliza-${var.environment}-private"
+  ip_range = var.data_plane_network_cidr
+  labels   = local.common_labels
+
+  # Same convention as the apps-shared module: ignore Hetzner-side renames so
+  # legacy names left over from out-of-band creation don't show as drift.
+  lifecycle {
+    ignore_changes = [name]
+  }
+}
+
+resource "hcloud_network_subnet" "data_plane" {
+  network_id   = hcloud_network.data_plane.id
+  type         = "cloud"
+  network_zone = "eu-central"
+  ip_range     = var.data_plane_subnet_cidr
+}
+
 resource "hcloud_ssh_key" "operators" {
   # Key the map by a short SHA-256 prefix of the public key rather than the
   # list index — keeps Terraform plans stable when operators are

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/outputs.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/outputs.tf
@@ -16,3 +16,13 @@ output "ssh_login_commands" {
     for k, v in hcloud_server.control_plane : k => "ssh root@${v.ipv4_address}"
   }
 }
+
+output "data_plane_network_id" {
+  description = "Hetzner ID of the private network the autoscaler attaches workers to. Set this as CONTAINERS_HCLOUD_NETWORK_IDS in /opt/eliza/cloud/.env.local on the CP."
+  value       = hcloud_network.data_plane.id
+}
+
+output "data_plane_subnet_cidr" {
+  description = "Subnet CIDR for the data-plane network — useful when wiring static routes or firewall rules on the CP."
+  value       = hcloud_network_subnet.data_plane.ip_range
+}

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/variables.tf
@@ -59,6 +59,19 @@ variable "cloudflare_zone_id" {
   type        = string
 }
 
+# ── Data-plane private network (autoscaled workers + CP share this LAN) ──────
+variable "data_plane_network_cidr" {
+  description = "Private network CIDR for the data plane in THIS environment's Hetzner project. Each environment owns its own Hetzner project, so identical CIDRs across envs don't conflict — keeping them aligned avoids per-env static IP surprises when the autoscaler computes worker IPs."
+  type        = string
+  default     = "10.42.0.0/16"
+}
+
+variable "data_plane_subnet_cidr" {
+  description = "Subnet within data_plane_network_cidr where workers + CP attach."
+  type        = string
+  default     = "10.42.0.0/24"
+}
+
 variable "control_plane_hostname_prefix" {
   description = "DNS subdomain prefix. Final record: <prefix>-<environment>-<n>.elizacloud.ai (e.g. eliza-production-1.elizacloud.ai)"
   type        = string


### PR DESCRIPTION
## Why

The autoscaler attaches every data-plane worker VM to a private Hetzner network. Those networks (currently `eliza-production-private` id 12305703 and `eliza-staging-private` id 12305704) were created out-of-band in the Hetzner console, before the per-env Hetzner project split.

The prod CP we just stood up in the `eliza-prod` project (Phase 4) has no network to attach workers to. Stan wants everything Terraform-managed — so this PR adds the network to the same control-plane module that owns the CP, per-env naturally via the existing backend split.

## Changes

- `hcloud_network.data_plane` — `eliza-${env}-private`, `lifecycle.ignore_changes = [name]` for parity with apps-shared
- `hcloud_network_subnet.data_plane` — eu-central
- `var.data_plane_network_cidr` default `10.42.0.0/16`
- `var.data_plane_subnet_cidr` default `10.42.0.0/24`
- `output.data_plane_network_id` — operator threads this into the CP's `.env.local` as `CONTAINERS_HCLOUD_NETWORK_IDS`
- `output.data_plane_subnet_cidr`

Same CIDR across envs is fine because each env's network lives in its own Hetzner project.

## Test plan

- [x] terraform fmt + validate
- [ ] CI validate
- [ ] After merge: dispatch `terraform-control-plane.yml` apply on production. Expect plan = `2 to add` (network + subnet), no destroys.
- [ ] Capture new network id from outputs; thread into new CP's `.env.local` as `CONTAINERS_HCLOUD_NETWORK_IDS`
- [ ] Same dispatch later on staging if/when we move staging's data-plane network out of the default project too