### PR TITLE
fix(infra): install headscale in control-plane cloud-init

### DIFF
--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
@@ -94,6 +94,30 @@ no-ops for an already-provisioned CP. To roll a bootstrap fix, taint the
 VM and re-apply — but that wipes local state (headscale DB, cloudflared
 creds, /opt/eliza checkout). Plan that out before touching prod.
 
+**Headscale handoff on a fresh CP.** Cloud-init installs the `headscale`
+package (binary, systemd unit, `/var/lib/headscale` state dir owned by the
+package user) but stops the auto-started service so it doesn't bind with a
+fresh empty DB. On first deploy the operator overlays the prior CP's
+config + state:
+```bash
+# From the prior CP
+ssh root@PRIOR_CP 'sudo tar czf /tmp/hs.tgz -C /var/lib/headscale db.sqlite noise_private.key'
+scp root@PRIOR_CP:/tmp/hs.tgz /tmp/hs.tgz
+ssh root@PRIOR_CP 'sudo cat /etc/headscale/config.yaml' > /tmp/headscale-config.yaml
+
+# Adjust server_url for the new CP's hostname
+sed -i -E 's|^server_url:.*|server_url: https://eliza-${env}-1.elizacloud.ai|' /tmp/headscale-config.yaml
+
+# Push to NEW CP
+scp /tmp/headscale-config.yaml /tmp/hs.tgz deploy@NEW_CP:/tmp/
+ssh deploy@NEW_CP '
+  sudo mv /tmp/headscale-config.yaml /etc/headscale/config.yaml
+  sudo tar xzf /tmp/hs.tgz -C /var/lib/headscale
+  sudo chown -R headscale:headscale /var/lib/headscale
+  sudo systemctl enable --now headscale
+'
+```
+
 ## What this module does NOT manage (yet)
 
 - Headscale state (preauth keys, ACLs) — manual via `headscale` CLI.

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/cloud-init/bootstrap.yaml.tftpl
@@ -64,6 +64,17 @@ packages:
   # this package list — we need Node 24, and Ubuntu 24.04's default nodejs is
   # older. See the NodeSource setup_24.x call in runcmd.
 
+  # headscale: VPN coordination server for the agent containers. We install
+  # the package here so a fresh VM has the binary + systemd unit + a deploy-
+  # ready /var/lib/headscale state dir (owned by the package's `headscale`
+  # user). Env-specific bits (server_url in config.yaml, the SQLite db, and
+  # noise_private.key) are an operator handoff on first deploy — same shape
+  # as cloud/.env.local. The package's default config.yaml ships fine for
+  # a fresh tailnet; the operator overlays it from the prior CP for env
+  # continuity. Stopped + masked at first boot so the package's auto-start
+  # doesn't bind to localhost before the operator copies the real config.
+  - headscale
+
 write_files:
   - path: /etc/profile.d/eliza-paths.sh
     permissions: "0644"
@@ -216,6 +227,14 @@ runcmd:
   - rm -f /etc/nginx/sites-enabled/default
   - nginx -t
   - systemctl reload nginx
+
+  # Headscale: stop the package's auto-started service so it doesn't bind
+  # to localhost with a fresh empty DB before the operator overlays the
+  # real config.yaml + state from the prior CP. Keep the unit enabled so a
+  # `systemctl start headscale` after the operator handoff brings it up
+  # cleanly. (We don't mask — masking would surprise an operator who runs
+  # `systemctl start headscale` and gets a silent "masked" no-op.)
+  - systemctl stop headscale 2>/dev/null || true
 
   # Final marker for the bootstrap-warn check that runs after this.
   - echo "eliza-control-plane bootstrap finished $(date -u +%Y-%m-%dT%H:%M:%SZ)" > /var/log/eliza-bootstrap.log


### PR DESCRIPTION
Last cloud-init gap from tonight's prod CP migration. We had to install headscale by hand on the new CP (curl deb + dpkg -i + chown state dir). Now the package install + systemd unit + state dir come from cloud-init's `packages:` list. The runcmd stops the package's auto-started service so it doesn't bind with a fresh empty DB before the operator overlays the prior CP's config + state.

Env-specific bits (`server_url`, SQLite db, noise_private.key) stay an operator handoff — same shape as `cloud/.env.local`. The exact migration runbook is documented in the module's README so the next CP rebuild follows it instead of rediscovering it from scratch.

## What's still NOT in cloud-init (intentionally)

- `config.yaml` overlay — env-specific (`server_url` per CP hostname). Operator copies + sed adjusts on first deploy.
- `/var/lib/headscale/db.sqlite` + `noise_private.key` — operator copies from prior CP to preserve users / API keys / pre-auth keys.

## What was NOT a gap

Checked the deploy workflow (`deploy-eliza-provisioning-worker.yml`): it already runs `bun install --no-save --ignore-scripts`, manually creates the `@elizaos/cloud-shared` symlink, runs `bun run build:core`, and the plugin-sql `@elizaos/core` symlink. The manual deploy we did tonight was only because `ELIZA_PROVISIONING_SSH_KEY` secret pointed at the OLD CP's key — once we set it correctly the workflow ran green end-to-end.

## Test plan

- [x] terraform fmt -check + validate green locally
- [ ] CI validate green
- [ ] On next CP rebuild (some future Phase 6 / staging-CP re-image), confirm `apt list --installed | grep headscale` returns 0.28.0+ from default Ubuntu repo, `/var/lib/headscale` exists owned by headscale user, `systemctl is-active headscale` returns `inactive` (waiting for operator to copy config + state)