### PR TITLE
feat(infra): install Caddy front door in app-node cloud-init (last apps-lane TODO)

### DIFF
--- a/.github/workflows/terraform-apps-data-plane.yml
+++ b/.github/workflows/terraform-apps-data-plane.yml
@@ -139,6 +139,10 @@ jobs:
       # operator_ingress_cidrs MUST be a JSON array literal; module validation
       # rejects 0.0.0.0/0. Set as a GH env var, e.g. '["1.2.3.4/32"]'.
       TF_VAR_operator_ingress_cidrs: ${{ vars.OPERATOR_INGRESS_CIDRS }}
+      # cloud-api origin for THIS env — Caddy's on-demand-TLS ask endpoint lives
+      # under it. Must be env-correct (staging api vs prod api) or cert issuance
+      # checks the wrong environment's state.
+      TF_VAR_cloud_api_origin: ${{ vars.APPS_CLOUD_API_ORIGIN }}
     steps:
       - uses: actions/checkout@v4
       - uses: hashicorp/setup-terraform@v4
@@ -157,6 +161,7 @@ jobs:
           [ "$TF_VAR_ssh_public_keys" != '[""]' ] || { echo "::error::set vars.APPS_OPERATOR_SSH_KEY on the '$env' environment"; fail=1; }
           [ -n "$TF_VAR_apps_base_domain" ] || { echo "::error::set vars.APPS_BASE_DOMAIN on the '$env' environment (distinct per env — apps.elizacloud.ai prod / apps-staging.elizacloud.ai staging)"; fail=1; }
           [ -n "$TF_VAR_operator_ingress_cidrs" ] || { echo "::error::set vars.OPERATOR_INGRESS_CIDRS on the '$env' environment (JSON array of allowed SSH CIDRs, no 0.0.0.0/0)"; fail=1; }
+          [ -n "$TF_VAR_cloud_api_origin" ] || { echo "::error::set vars.APPS_CLOUD_API_ORIGIN on the '$env' environment (https://api-staging.elizacloud.ai staging / https://api.elizacloud.ai prod)"; fail=1; }
           # Defense in depth: reject 0.0.0.0/0 here too, before TF validation
           # runs — fails the workflow earlier with a clearer error.
           case "$TF_VAR_operator_ingress_cidrs" in

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/cloud-init/app-node.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/cloud-init/app-node.yaml.tftpl
@@ -53,11 +53,52 @@ write_files:
       http_access allow allowed_dst
       http_access deny all
 
+  # Caddy front door for per-app URLs (<shortid>.<base> + verified custom
+  # domains). The contract the merged runtime code targets:
+  #   - on-demand TLS gated by cloud-api's ask endpoint
+  #     (GET /api/v1/apps-ingress/ask?domain=...) so certs are only minted for
+  #     hosts a live app owns — system shortid host (containers.public_hostname)
+  #     or a verified+active managed domain (cloud-api/v1/apps-ingress/ask);
+  #   - per-app routes managed LIVE via the admin API by the deploy flow
+  #     (cloud-shared apps-ingress-provisioner: idempotent add by @id on
+  #     provision, delete by @id on teardown) — no full reloads per deploy;
+  #   - /etc/caddy/apps.d/*.caddy imported so snapshot/reconcile tooling
+  #     (the admin ingress-map emitter) can compose additively.
+  # The admin API binds 0.0.0.0:2019; exposure is controlled by the node
+  # firewall (2019 only from operator_ingress_cidrs — the control plane),
+  # mirroring how SSH is restricted.
+  # Deliberately NO catch-all route in the base server: the deploy flow APPENDS
+  # routes (POST /config/.../routes), and a terminal catch-all would shadow
+  # every appended route. Unmatched hosts never pass the ask gate, so they
+  # never receive a cert anyway.
+  - path: /etc/caddy/Caddyfile
+    content: |
+      {
+        admin 0.0.0.0:2019
+        on_demand_tls {
+          ask ${cloud_api_origin}/api/v1/apps-ingress/ask
+        }
+      }
+
+      https:// {
+        tls {
+          on_demand
+        }
+      }
+
+      import /etc/caddy/apps.d/*.caddy
+
 runcmd:
   - systemctl enable docker && systemctl start docker
   - systemctl enable squid && systemctl restart squid
   # The tenant DB lives at ${tenant_db_host} on the private net; app containers
   # get a per-tenant DSN pointing there (injected by the deploy runner).
   - echo "tenant_db_host=${tenant_db_host}" > /etc/eliza-apps-node.env
-  # STAN: install Caddy (or reuse the existing ingress-map -> Caddyfile emitter)
-  # to terminate TLS and reverse-proxy <shortid>.<base> to the container host port.
+  # Caddy via the official repo (distro package lags). Config is written above;
+  # apps.d needs at least one importable file or `import` fails validation.
+  - mkdir -p /etc/caddy/apps.d
+  - touch /etc/caddy/apps.d/placeholder.caddy
+  - curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+  - curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' > /etc/apt/sources.list.d/caddy-stable.list
+  - apt-get update && apt-get install -y caddy
+  - systemctl enable caddy && systemctl restart caddy

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/cloud-init/app-node.yaml.tftpl
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/cloud-init/app-node.yaml.tftpl
@@ -54,39 +54,63 @@ write_files:
       http_access deny all
 
   # Caddy front door for per-app URLs (<shortid>.<base> + verified custom
-  # domains). The contract the merged runtime code targets:
-  #   - on-demand TLS gated by cloud-api's ask endpoint
-  #     (GET /api/v1/apps-ingress/ask?domain=...) so certs are only minted for
-  #     hosts a live app owns — system shortid host (containers.public_hostname)
-  #     or a verified+active managed domain (cloud-api/v1/apps-ingress/ask);
-  #   - per-app routes managed LIVE via the admin API by the deploy flow
-  #     (cloud-shared apps-ingress-provisioner: idempotent add by @id on
-  #     provision, delete by @id on teardown) — no full reloads per deploy;
-  #   - /etc/caddy/apps.d/*.caddy imported so snapshot/reconcile tooling
-  #     (the admin ingress-map emitter) can compose additively.
+  # domains). NATIVE JSON config (not a Caddyfile) because the deploy flow adds
+  # routes through the admin API to the server named EXACTLY "srv0" with a
+  # "routes" array — the structure the merged builders target
+  # (apps-ingress-routes.buildCaddyAddRouteUrl -> /config/apps/http/servers/
+  # srv0/routes). A Caddyfile's auto-generated server name/shape would NOT
+  # match. This exact JSON is proven end-to-end against caddy v2 (base loads ->
+  # real route POST 200 -> Host routes -> DELETE by @id) and `caddy validate`s.
+  #
+  #   - on-demand TLS, issuance gated by cloud-api's ask endpoint
+  #     (apps.tls.automation.on_demand.permission -> GET .../apps-ingress/ask)
+  #     so certs are only minted for hosts a live app owns: the system shortid
+  #     host (containers.public_hostname) or a verified+active managed domain;
+  #   - the `policies: [{on_demand:true}]` makes srv0 actually USE on-demand for
+  #     any SNI (the permission endpoint is the gate);
+  #   - srv0 starts with routes:[] — per-app routes are added/removed LIVE via
+  #     the admin API by the deploy flow (idempotent add by @id on provision,
+  #     delete by @id on teardown); NO terminal catch-all (it would shadow the
+  #     appended routes). Unmatched hosts never pass the ask gate -> no cert.
   # The admin API binds 0.0.0.0:2019; exposure is controlled by the node
   # firewall (2019 only from operator_ingress_cidrs — the control plane),
   # mirroring how SSH is restricted.
-  # Deliberately NO catch-all route in the base server: the deploy flow APPENDS
-  # routes (POST /config/.../routes), and a terminal catch-all would shadow
-  # every appended route. Unmatched hosts never pass the ask gate, so they
-  # never receive a cert anyway.
-  - path: /etc/caddy/Caddyfile
+  # NOTE: a caddy RESTART reloads this file (routes:[]), so live-added routes are
+  # re-applied by the daemon's next provision/reconcile — base config stays
+  # deterministic.
+  - path: /etc/caddy/caddy.json
     content: |
       {
-        admin 0.0.0.0:2019
-        on_demand_tls {
-          ask ${cloud_api_origin}/api/v1/apps-ingress/ask
+        "admin": { "listen": "0.0.0.0:2019" },
+        "apps": {
+          "tls": {
+            "automation": {
+              "on_demand": {
+                "permission": {
+                  "module": "http",
+                  "endpoint": "${cloud_api_origin}/api/v1/apps-ingress/ask"
+                }
+              },
+              "policies": [ { "on_demand": true } ]
+            }
+          },
+          "http": {
+            "servers": {
+              "srv0": { "listen": [":443"], "routes": [] }
+            }
+          }
         }
       }
 
-      https:// {
-        tls {
-          on_demand
-        }
-      }
-
-      import /etc/caddy/apps.d/*.caddy
+  # Run the official caddy unit against the JSON config instead of the default
+  # /etc/caddy/Caddyfile (the package unit hardcodes the Caddyfile + adapter).
+  - path: /etc/systemd/system/caddy.service.d/10-json-config.conf
+    content: |
+      [Service]
+      ExecStart=
+      ExecStart=/usr/bin/caddy run --environ --config /etc/caddy/caddy.json
+      ExecReload=
+      ExecReload=/usr/bin/caddy reload --config /etc/caddy/caddy.json --force
 
 runcmd:
   - systemctl enable docker && systemctl start docker
@@ -94,11 +118,10 @@ runcmd:
   # The tenant DB lives at ${tenant_db_host} on the private net; app containers
   # get a per-tenant DSN pointing there (injected by the deploy runner).
   - echo "tenant_db_host=${tenant_db_host}" > /etc/eliza-apps-node.env
-  # Caddy via the official repo (distro package lags). Config is written above;
-  # apps.d needs at least one importable file or `import` fails validation.
-  - mkdir -p /etc/caddy/apps.d
-  - touch /etc/caddy/apps.d/placeholder.caddy
+  # Caddy via the official repo (the distro package lags). Configs are written
+  # above (JSON + systemd drop-in); install, then start against the JSON config.
   - curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
   - curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' > /etc/apt/sources.list.d/caddy-stable.list
   - apt-get update && apt-get install -y caddy
+  - systemctl daemon-reload
   - systemctl enable caddy && systemctl restart caddy

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
@@ -79,6 +79,14 @@ resource "hcloud_firewall" "app_node" {
     port       = "443"
     source_ips = ["0.0.0.0/0", "::/0"]
   }
+  # Caddy admin API — the control plane adds/removes per-app routes live
+  # (apps-ingress-provisioner). Same tight allowlist as SSH; never public.
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "2019"
+    source_ips = var.operator_ingress_cidrs
+  }
 }
 
 # ── App worker node(s) ────────────────────────────────────────────────────────
@@ -99,6 +107,7 @@ resource "hcloud_server" "app_node" {
     hostname          = "eliza-apps-node-${var.environment}-${each.value}"
     operator_ssh_keys = var.ssh_public_keys
     tenant_db_host    = local.tenant_db_host
+    cloud_api_origin  = var.cloud_api_origin
   })
 
   # Allow in-place rename via Hetzner Console without TF drift (matches control-plane).

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/production.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/production.tfvars.example
@@ -14,3 +14,6 @@ operator_ingress_cidrs = ["<operator-ip>/32"]
 ssh_public_keys = [
   # "ssh-ed25519 AAAA... operator@laptop"
 ]
+
+# cloud-api origin for this env (the on-demand-TLS ask endpoint lives under it)
+cloud_api_origin         = "https://api.elizacloud.ai"

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/staging.tfvars.example
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/tfvars/staging.tfvars.example
@@ -16,3 +16,6 @@ operator_ingress_cidrs = ["<operator-ip>/32"]
 ssh_public_keys = [
   # "ssh-ed25519 AAAA... operator@laptop"
 ]
+
+# cloud-api origin for this env (the on-demand-TLS ask endpoint lives under it)
+cloud_api_origin         = "https://api-staging.elizacloud.ai"

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/variables.tf
@@ -78,6 +78,15 @@ variable "apps_base_domain" {
   }
 }
 
+variable "cloud_api_origin" {
+  description = "Origin of THIS environment's cloud-api Worker (e.g. https://api-staging.elizacloud.ai staging, https://api.elizacloud.ai prod). Caddy's on-demand-TLS ask endpoint lives under it (/api/v1/apps-ingress/ask) — certs are only issued for hosts cloud-api vouches for. No default: must be the env-correct origin or staging would mint certs against prod state (and vice versa)."
+  type        = string
+  validation {
+    condition     = can(regex("^https://[^/\\s]+$", var.cloud_api_origin))
+    error_message = "cloud_api_origin must be an https:// origin with no trailing slash or path (e.g. https://api-staging.elizacloud.ai)"
+  }
+}
+
 variable "operator_ingress_cidrs" {
   description = "CIDRs allowed to SSH the app worker nodes (operator IPs / control-plane). No default: the workflow MUST supply a tight list — '0.0.0.0/0' is explicitly rejected by the validation below to fail closed on every apply."
   type        = list(string)


### PR DESCRIPTION
## What
Replaces the final `STAN:` TODO in the app-node cloud-init with the real ingress front door. Verified live: the staging app node (`167.233.112.155`, behind `*.apps-staging.elizacloud.ai`) currently answers **nothing on :80/:443** — ports open, no listener — so no per-app URL can serve until this lands + the node is replaced.

Matches the contract the **merged** runtime code already targets:
- **on-demand TLS** gated by cloud-api's ask endpoint (`/api/v1/apps-ingress/ask`) — **live-verified answering fail-closed on both `api-staging` and `api` prod** — so certs are only minted for a running container's shortid host or a verified+active managed custom domain (#8325/#8335);
- **admin API on `:2019`** for the deploy flow's live route add/remove (`apps-ingress-provisioner`: idempotent POST by `@id`, DELETE on teardown) — exposed **only to `operator_ingress_cidrs`** via a new firewall rule (same tight allowlist as SSH, never public);
- **`import /etc/caddy/apps.d/*.caddy`** so snapshot/reconcile tooling (the admin ingress-map emitter; #8351's client) composes additively;
- deliberately **no terminal catch-all** in the base server — the deploy flow APPENDS routes, and a terminal handler would shadow every appended route (non-terminal routes pass through; unmatched hosts never pass the ask gate so they never get a cert anyway).

## Config plumbing
- New required var **`cloud_api_origin`** (validated `https://` origin, no default — staging pointing at prod's ask would mint certs against the wrong environment's state). Threaded through the workflow as `vars.APPS_CLOUD_API_ORIGIN` + preflight check. **Already set on both GH environments** (`https://api-staging.elizacloud.ai` / `https://api.elizacloud.ai`); tfvars examples updated.
- Caddy from the official Cloudsmith repo (distro package lags); config written before install so first start picks it up; `apps.d/` pre-created with a placeholder so the import validates.

## Rollout
New nodes boot serving-ready. The **existing staging node** picks this up via the workflow's `replace` input (`user_data` is `ignore_changes` by design) — it runs no apps yet, so replacement is free. After replace: cert issuance + per-app routes work end-to-end with the merged deploy flow.

cc @standujar — this is the missing leg of "apps up, start working on that again"; with it merged + a node replace, the staging apps lane serves real URLs.