### PR TITLE
Add EvoLink support to plugin-openai

### DIFF
--- a/plugins/plugin-openai/README.md
+++ b/plugins/plugin-openai/README.md
@@ -13,7 +13,7 @@ OpenAI model-provider plugin for [elizaOS](https://github.com/elizaos/eliza). Ad
 - **Deep research** — `ModelType.RESEARCH` via the OpenAI Responses API (`o3-deep-research` by default); returns annotated, multi-source research reports.
 - **Tokenizer** — encode/decode using js-tiktoken (browser-safe, no network calls).
 
-Works with any OpenAI-compatible endpoint: OpenAI, Cerebras, OpenRouter, local servers, etc.
+Works with any OpenAI-compatible endpoint: OpenAI, Cerebras, EvoLink, OpenRouter, local servers, etc.
 
 ## Enabling the plugin
 
@@ -25,7 +25,7 @@ Add `@elizaos/plugin-openai` to your character's plugin list:
 }
 ```
 
-The plugin auto-enables when `OPENAI_API_KEY` or `CEREBRAS_API_KEY` is present in the environment.
+The plugin auto-enables when `OPENAI_API_KEY`, `CEREBRAS_API_KEY`, or `EVOLINK_API_KEY` is present in the environment.
 
 ## Required configuration
 
@@ -44,7 +44,10 @@ Set these as environment variables or in your character's `settings` object.
 | Variable | Default | Description |
 |---|---|---|
 | `OPENAI_BASE_URL` | `https://api.openai.com/v1` | Override for compatible endpoints |
-| `ELIZA_PROVIDER` | — | Set to `cerebras` to force Cerebras mode |
+| `ELIZA_PROVIDER` | — | Set to `cerebras` or `evolink` to force a compatible-provider mode |
+| `EVOLINK_API_KEY` | — | Auth for EvoLink's OpenAI-compatible endpoint |
+| `EVOLINK_BASE_URL` | `https://direct.evolink.ai/v1` | EvoLink endpoint used when `EVOLINK_API_KEY` enables the plugin |
+| `EVOLINK_MODEL` | `gpt-5.2` | Text model used by EvoLink mode |
 
 ### Text generation models
 
@@ -199,6 +202,10 @@ Then set `OPENAI_BROWSER_BASE_URL=http://localhost:3000/openai`.
 ## Cerebras compatibility
 
 Point `OPENAI_BASE_URL` at a Cerebras endpoint or set `ELIZA_PROVIDER=cerebras` and the plugin automatically adapts: structured output uses `json_object` mode, `reasoning_effort` defaults to `"low"` for reasoning-capable models (to prevent empty responses), and `CEREBRAS_API_KEY` is accepted as an alias for `OPENAI_API_KEY`. Embeddings fall back to a deterministic local hash when no explicit embedding URL is set, since Cerebras does not provide an embeddings endpoint.
+
+## EvoLink compatibility
+
+Set `EVOLINK_API_KEY` to use EvoLink through its OpenAI-compatible endpoint. The plugin defaults to `https://direct.evolink.ai/v1` and `gpt-5.2`; set `EVOLINK_BASE_URL` or `EVOLINK_MODEL` to override either value.
 
 ## Prompt caching
 

--- a/plugins/plugin-openai/__tests__/auto-enable.test.ts
+++ b/plugins/plugin-openai/__tests__/auto-enable.test.ts
@@ -1,0 +1,18 @@
+import type { PluginAutoEnableContext } from "@elizaos/core";
+import { describe, expect, it } from "vitest";
+
+import { shouldEnable } from "../auto-enable";
+
+function ctx(env: Record<string, string | undefined>): PluginAutoEnableContext {
+  return { env } as PluginAutoEnableContext;
+}
+
+describe("plugin-openai auto-enable", () => {
+  it("enables when EVOLINK_API_KEY is present", () => {
+    expect(shouldEnable(ctx({ EVOLINK_API_KEY: "evl-test" }))).toBe(true);
+  });
+
+  it("ignores blank EvoLink API keys", () => {
+    expect(shouldEnable(ctx({ EVOLINK_API_KEY: " " }))).toBe(false);
+  });
+});

--- a/plugins/plugin-openai/__tests__/cerebras-config.shape.test.ts
+++ b/plugins/plugin-openai/__tests__/cerebras-config.shape.test.ts
@@ -25,6 +25,9 @@ const ENV_KEYS = [
   "CEREBRAS_API_KEY",
   "CEREBRAS_BASE_URL",
   "CEREBRAS_MODEL",
+  "EVOLINK_API_KEY",
+  "EVOLINK_BASE_URL",
+  "EVOLINK_MODEL",
   "OPENAI_API_KEY",
   "OPENAI_SMALL_MODEL",
   "OPENAI_LARGE_MODEL",
@@ -187,6 +190,46 @@ describe("plugin-openai Cerebras config (pure)", () => {
     });
     expect(getBaseURL(runtime)).toBe("https://api.openrouter.ai/api/v1");
     expect(getApiKey(runtime)).toBe("sk-openrouter-fake");
+  });
+
+  it("auto-detects EvoLink mode when only EVOLINK_API_KEY is present", () => {
+    const runtime = buildRuntime({
+      EVOLINK_API_KEY: "evl-fake",
+      OPENAI_API_KEY: undefined,
+      OPENAI_BASE_URL: undefined,
+    });
+    expect(getBaseURL(runtime)).toBe("https://direct.evolink.ai/v1");
+    expect(getApiKey(runtime)).toBe("evl-fake");
+    expect(getSmallModel(runtime)).toBe("gpt-5.2");
+    expect(getLargeModel(runtime)).toBe("gpt-5.2");
+    expect(getResponseHandlerModel(runtime)).toBe("gpt-5.2");
+    expect(getActionPlannerModel(runtime)).toBe("gpt-5.2");
+  });
+
+  it("supports explicit EvoLink base URL and model overrides", () => {
+    const runtime = buildRuntime({
+      ELIZA_PROVIDER: "evolink",
+      EVOLINK_API_KEY: "evl-fake",
+      EVOLINK_BASE_URL: "https://direct.evolink.ai/v1",
+      EVOLINK_MODEL: "gpt-5.1",
+      SMALL_MODEL: "stale-small",
+      LARGE_MODEL: "stale-large",
+    });
+    expect(getBaseURL(runtime)).toBe("https://direct.evolink.ai/v1");
+    expect(getApiKey(runtime)).toBe("evl-fake");
+    expect(getSmallModel(runtime)).toBe("gpt-5.1");
+    expect(getLargeModel(runtime)).toBe("gpt-5.1");
+  });
+
+  it("respects explicit OPENAI settings over EvoLink aliases", () => {
+    const runtime = buildRuntime({
+      EVOLINK_API_KEY: "evl-fake",
+      OPENAI_API_KEY: "sk-openai-fake",
+      OPENAI_BASE_URL: "https://api.openai.com/v1",
+    });
+    expect(getBaseURL(runtime)).toBe("https://api.openai.com/v1");
+    expect(getApiKey(runtime)).toBe("sk-openai-fake");
+    expect(getSmallModel(runtime)).toBe("gpt-5.4-mini");
   });
 
   it("uses a deterministic local embedding fallback in Cerebras mode without an embedding endpoint", async () => {

--- a/plugins/plugin-openai/auto-enable.ts
+++ b/plugins/plugin-openai/auto-enable.ts
@@ -6,7 +6,7 @@
 // auto-enable engine loads dozens of these per boot.
 import type { PluginAutoEnableContext } from "@elizaos/core";
 
-const ENV_KEYS = ["OPENAI_API_KEY", "CEREBRAS_API_KEY"] as const;
+const ENV_KEYS = ["OPENAI_API_KEY", "CEREBRAS_API_KEY", "EVOLINK_API_KEY"] as const;
 
 /** Enable when an OpenAI-compatible API key is present in the environment. */
 export function shouldEnable(ctx: PluginAutoEnableContext): boolean {

--- a/plugins/plugin-openai/index.ts
+++ b/plugins/plugin-openai/index.ts
@@ -53,12 +53,15 @@ export const openaiPlugin: Plugin = {
   name: "openai",
   description: "OpenAI API integration for text, image, audio, and embedding models",
   autoEnable: {
-    envKeys: ["OPENAI_API_KEY"],
+    envKeys: ["OPENAI_API_KEY", "CEREBRAS_API_KEY", "EVOLINK_API_KEY"],
   },
 
   config: {
     OPENAI_API_KEY: env.OPENAI_API_KEY ?? null,
     OPENAI_BASE_URL: env.OPENAI_BASE_URL ?? null,
+    EVOLINK_API_KEY: env.EVOLINK_API_KEY ?? null,
+    EVOLINK_BASE_URL: env.EVOLINK_BASE_URL ?? null,
+    EVOLINK_MODEL: env.EVOLINK_MODEL ?? null,
     OPENAI_NANO_MODEL: env.OPENAI_NANO_MODEL ?? null,
     OPENAI_MEDIUM_MODEL: env.OPENAI_MEDIUM_MODEL ?? null,
     OPENAI_SMALL_MODEL: env.OPENAI_SMALL_MODEL ?? null,

--- a/plugins/plugin-openai/package.json
+++ b/plugins/plugin-openai/package.json
@@ -103,6 +103,26 @@
         "default": "https://api.openai.com/v1",
         "sensitive": false
       },
+      "EVOLINK_API_KEY": {
+        "type": "string",
+        "description": "API key used to authenticate requests to EvoLink's OpenAI-compatible API.",
+        "required": false,
+        "sensitive": true
+      },
+      "EVOLINK_BASE_URL": {
+        "type": "string",
+        "description": "Base URL for EvoLink's OpenAI-compatible API.",
+        "required": false,
+        "default": "https://direct.evolink.ai/v1",
+        "sensitive": false
+      },
+      "EVOLINK_MODEL": {
+        "type": "string",
+        "description": "Identifier of the EvoLink chat model to use when EVOLINK_API_KEY enables this plugin.",
+        "required": false,
+        "default": "gpt-5.2",
+        "sensitive": false
+      },
       "OPENAI_SMALL_MODEL": {
         "type": "string",
         "description": "Identifier of the small language model to be used (overrides SMALL_MODEL).",

--- a/plugins/plugin-openai/utils/config.ts
+++ b/plugins/plugin-openai/utils/config.ts
@@ -97,6 +97,31 @@ export function isCerebrasMode(runtime: IAgentRuntime): boolean {
   return false;
 }
 
+/**
+ * True when the resolved base URL or `ELIZA_PROVIDER` setting marks the
+ * runtime as using EvoLink's OpenAI-compatible endpoint. Used to scope the
+ * `EVOLINK_API_KEY` alias so OpenAI users are not affected.
+ */
+export function isEvoLinkMode(runtime: IAgentRuntime): boolean {
+  const explicitProvider = getSetting(runtime, "ELIZA_PROVIDER");
+  if (explicitProvider && explicitProvider.toLowerCase() === "evolink") {
+    return true;
+  }
+  const baseURL = getSetting(runtime, "OPENAI_BASE_URL");
+  if (baseURL && /(^|\.)evolink\.ai(\/|$)/i.test(baseURL)) {
+    return true;
+  }
+  const evolinkKey = getSetting(runtime, "EVOLINK_API_KEY");
+  if (
+    evolinkKey &&
+    !getSetting(runtime, "OPENAI_API_KEY") &&
+    !getSetting(runtime, "OPENAI_BASE_URL")
+  ) {
+    return true;
+  }
+  return false;
+}
+
 export function getApiKey(runtime: IAgentRuntime): string | undefined {
   // Cerebras serves an OpenAI-compatible API. When the runtime is pointed at
   // Cerebras (either via `ELIZA_PROVIDER=cerebras` or an `OPENAI_BASE_URL`
@@ -107,6 +132,12 @@ export function getApiKey(runtime: IAgentRuntime): string | undefined {
     const cerebrasKey = getSetting(runtime, "CEREBRAS_API_KEY");
     if (cerebrasKey) {
       return cerebrasKey;
+    }
+  }
+  if (isEvoLinkMode(runtime)) {
+    const evolinkKey = getSetting(runtime, "EVOLINK_API_KEY");
+    if (evolinkKey) {
+      return evolinkKey;
     }
   }
   return getSetting(runtime, "OPENAI_API_KEY");
@@ -149,10 +180,17 @@ export function getBaseURL(runtime: IAgentRuntime): string {
     isCerebrasMode(runtime) && !getSetting(runtime, "OPENAI_BASE_URL")
       ? (getSetting(runtime, "CEREBRAS_BASE_URL") ?? "https://api.cerebras.ai/v1")
       : undefined;
+  const evolinkBaseURL =
+    isEvoLinkMode(runtime) && !getSetting(runtime, "OPENAI_BASE_URL")
+      ? (getSetting(runtime, "EVOLINK_BASE_URL") ?? "https://direct.evolink.ai/v1")
+      : undefined;
   const baseURL =
     isBrowser() && browserURL
       ? browserURL
-      : (getSetting(runtime, "OPENAI_BASE_URL") ?? cerebrasBaseURL ?? "https://api.openai.com/v1");
+      : (getSetting(runtime, "OPENAI_BASE_URL") ??
+        cerebrasBaseURL ??
+        evolinkBaseURL ??
+        "https://api.openai.com/v1");
   logger.debug(`[OpenAI] Base URL: ${baseURL}`);
   return baseURL;
 }
@@ -201,10 +239,15 @@ function getCerebrasModel(runtime: IAgentRuntime): string | undefined {
   return isCerebrasMode(runtime) ? getSetting(runtime, "CEREBRAS_MODEL") : undefined;
 }
 
+function getEvoLinkModel(runtime: IAgentRuntime): string | undefined {
+  return isEvoLinkMode(runtime) ? (getSetting(runtime, "EVOLINK_MODEL") ?? "gpt-5.2") : undefined;
+}
+
 export function getSmallModel(runtime: IAgentRuntime): string {
   return (
     getSetting(runtime, "OPENAI_SMALL_MODEL") ??
     getCerebrasModel(runtime) ??
+    getEvoLinkModel(runtime) ??
     getSetting(runtime, "SMALL_MODEL") ??
     "gpt-5.4-mini"
   );
@@ -214,6 +257,7 @@ export function getNanoModel(runtime: IAgentRuntime): string {
   return (
     getSetting(runtime, "OPENAI_NANO_MODEL") ??
     getCerebrasModel(runtime) ??
+    getEvoLinkModel(runtime) ??
     getSetting(runtime, "NANO_MODEL") ??
     getSmallModel(runtime)
   );
@@ -223,6 +267,7 @@ export function getMediumModel(runtime: IAgentRuntime): string {
   return (
     getSetting(runtime, "OPENAI_MEDIUM_MODEL") ??
     getCerebrasModel(runtime) ??
+    getEvoLinkModel(runtime) ??
     getSetting(runtime, "MEDIUM_MODEL") ??
     getSmallModel(runtime)
   );
@@ -232,6 +277,7 @@ export function getLargeModel(runtime: IAgentRuntime): string {
   return (
     getSetting(runtime, "OPENAI_LARGE_MODEL") ??
     getCerebrasModel(runtime) ??
+    getEvoLinkModel(runtime) ??
     getSetting(runtime, "LARGE_MODEL") ??
     "gpt-5"
   );
@@ -250,6 +296,7 @@ export function getResponseHandlerModel(runtime: IAgentRuntime): string {
     getSetting(runtime, "OPENAI_RESPONSE_HANDLER_MODEL") ??
     getSetting(runtime, "OPENAI_SHOULD_RESPOND_MODEL") ??
     getCerebrasModel(runtime) ??
+    getEvoLinkModel(runtime) ??
     getSetting(runtime, "RESPONSE_HANDLER_MODEL") ??
     getSetting(runtime, "SHOULD_RESPOND_MODEL") ??
     getSmallModel(runtime)
@@ -261,6 +308,7 @@ export function getActionPlannerModel(runtime: IAgentRuntime): string {
     getSetting(runtime, "OPENAI_ACTION_PLANNER_MODEL") ??
     getSetting(runtime, "OPENAI_PLANNER_MODEL") ??
     getCerebrasModel(runtime) ??
+    getEvoLinkModel(runtime) ??
     getSetting(runtime, "ACTION_PLANNER_MODEL") ??
     getSetting(runtime, "PLANNER_MODEL") ??
     getMediumModel(runtime)


### PR DESCRIPTION
## Summary
- allow @elizaos/plugin-openai to auto-enable with EVOLINK_API_KEY
- resolve EvoLink's OpenAI-compatible base URL and default text model when only EvoLink settings are present
- document EvoLink env vars and expose them in pluginParameters

## Validation
- bun install --no-save
- bun run --cwd packages/core build
- bunx vitest run --config vitest.config.ts __tests__/cerebras-config.shape.test.ts __tests__/auto-enable.test.ts (from plugins/plugin-openai) => 2 files / 17 tests passed
- bun run --cwd plugins/plugin-openai typecheck
- bunx @biomejs/biome check plugins/plugin-openai/README.md plugins/plugin-openai/auto-enable.ts plugins/plugin-openai/index.ts plugins/plugin-openai/utils/config.ts plugins/plugin-openai/__tests__/cerebras-config.shape.test.ts plugins/plugin-openai/__tests__/auto-enable.test.ts
- bun run --cwd plugins/plugin-openai build
- git diff --check
- rg "evolink/auto|api\.evolink\.ai/v1|api\.evolink\.ai" plugins/plugin-openai (no matches)