### PR TITLE
fix(cloud-apps): tear down isolated tenant DB on app delete (#8342)

### DIFF
--- a/packages/cloud-api/src/bootstrap-app.ts
+++ b/packages/cloud-api/src/bootstrap-app.ts
@@ -14,6 +14,7 @@ import { ApiError, failureResponse } from "@/lib/api/cloud-worker-errors";
 import { corsMiddleware } from "@/lib/cors/cloud-api-hono-cors";
 import { observeCloudRequest } from "@/lib/observability/cloud-backend-observability";
 import { runWithCloudBindingsAsync } from "@/lib/runtime/cloud-bindings";
+import { configureAppsDeprovisionTrigger } from "@/lib/services/app-db-deprovision-job-service";
 import { configureAppsDeployTrigger } from "@/lib/services/app-deploy-job-service";
 import { setRuntimeR2Bucket } from "@/lib/storage/r2-runtime-binding";
 import { logger } from "@/lib/utils/logger";
@@ -148,6 +149,10 @@ export function createApp(): Hono<AppEnv> {
   // `pg` is imported here; process.env is populated on workerd via nodejs_compat.
   if (process.env.APPS_DEPLOY_ENABLED === "1") {
     configureAppsDeployTrigger();
+    // Same lane: when an app with an isolated tenant DB is deleted, enqueue an
+    // APP_DB_DEPROVISION job so the daemon DROPs the DB + frees the cluster slot
+    // (the Worker can't — no `pg`). Without it the DB + slot leak (#8342).
+    configureAppsDeprovisionTrigger();
   }
 
   const app = new Hono<AppEnv>({ strict: false });

--- a/packages/cloud-shared/src/lib/services/__tests__/app-db-deprovision-job-service.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/app-db-deprovision-job-service.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type AppDbDeprovisioner,
+  dispatchAppDbDeprovisionJob,
+  enqueueAppDbDeprovision,
+  getAppDbDeprovisioner,
+  readAppDbDeprovisionJobData,
+  setAppDbDeprovisioner,
+} from "../app-db-deprovision-job-service";
+import type { ContainerJobInsert, ContainerJobsWriter } from "../container-job-service";
+
+describe("readAppDbDeprovisionJobData", () => {
+  test("extracts appId + dbUri", () => {
+    expect(readAppDbDeprovisionJobData({ data: { appId: "app-1", dbUri: "enc:v1:x" } })).toEqual({
+      appId: "app-1",
+      dbUri: "enc:v1:x",
+    });
+  });
+  test("throws when appId missing/blank", () => {
+    expect(() => readAppDbDeprovisionJobData({ data: { dbUri: "x" } })).toThrow(
+      /missing data.appId/,
+    );
+    expect(() => readAppDbDeprovisionJobData({ data: { appId: "", dbUri: "x" } })).toThrow(
+      /missing data.appId/,
+    );
+  });
+  test("throws when dbUri missing/blank", () => {
+    expect(() => readAppDbDeprovisionJobData({ data: { appId: "a" } })).toThrow(
+      /missing data.dbUri/,
+    );
+    expect(() => readAppDbDeprovisionJobData({ data: { appId: "a", dbUri: "" } })).toThrow(
+      /missing data.dbUri/,
+    );
+  });
+});
+
+describe("app db deprovisioner injection", () => {
+  test("getAppDbDeprovisioner throws before it is wired", () => {
+    expect(() => getAppDbDeprovisioner()).toThrow(/not configured/);
+  });
+
+  test("dispatch decrypts the carried URI and delegates to the injected deprovisioner", async () => {
+    const calls: Array<{ appId: string; dsn: string }> = [];
+    const backend: AppDbDeprovisioner = {
+      deprovisionForApp: async (appId, dsn) => {
+        calls.push({ appId, dsn });
+        return { deprovisioned: true };
+      },
+    };
+    setAppDbDeprovisioner(backend);
+    // Plaintext DSN (env-DSN mode): decryptIfNeeded is a passthrough, so the
+    // dsn reaches the backend unchanged. (Encrypted mode is covered by
+    // field-encryption's own round-trip tests.)
+    const out = await dispatchAppDbDeprovisionJob({
+      data: { appId: "app-42", dbUri: "postgres://u:p@10.30.1.10:5432/app_42" },
+    });
+    expect(out).toEqual({ deprovisioned: true });
+    expect(calls).toEqual([{ appId: "app-42", dsn: "postgres://u:p@10.30.1.10:5432/app_42" }]);
+  });
+});
+
+describe("enqueueAppDbDeprovision", () => {
+  test("inserts an APP_DB_DEPROVISION job carrying appId + encrypted dbUri (pg-free writer)", async () => {
+    const inserted: ContainerJobInsert[] = [];
+    const writer: ContainerJobsWriter = {
+      insertJob: async (j) => {
+        inserted.push(j);
+        return { id: "job-1" };
+      },
+    };
+    const r = await enqueueAppDbDeprovision(writer, {
+      appId: "app-1",
+      organizationId: "org-1",
+      userId: "u-1",
+      dbUri: "enc:v1:ciphertext",
+    });
+    expect(r.id).toBe("job-1");
+    expect(inserted[0]).toEqual({
+      type: "app_db_deprovision",
+      organizationId: "org-1",
+      userId: "u-1",
+      data: { appId: "app-1", dbUri: "enc:v1:ciphertext" },
+    });
+  });
+});

--- a/packages/cloud-shared/src/lib/services/__tests__/provisioning-job-types.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/provisioning-job-types.test.ts
@@ -28,9 +28,12 @@ describe("JOB_TYPES", () => {
     expect(JOB_TYPES.AGENT_WAKE).toBe("agent_wake");
     // Apps lane (Product 2): the Worker enqueues APP_DEPLOY; the daemon runs it.
     expect(JOB_TYPES.APP_DEPLOY).toBe("app_deploy");
+    // Apps lane (Product 2): the Worker enqueues APP_DB_DEPROVISION on app
+    // delete; the daemon runs the isolated tenant-DB DROP + slot release.
+    expect(JOB_TYPES.APP_DB_DEPROVISION).toBe("app_db_deprovision");
     // Lock the size so a new entry without a matching assertion above
     // fails CI instead of being silently under-covered by tests below.
-    expect(Object.keys(JOB_TYPES)).toHaveLength(17);
+    expect(Object.keys(JOB_TYPES)).toHaveLength(18);
   });
 
   test("wire values are unique (no two symbols share a string)", () => {

--- a/packages/cloud-shared/src/lib/services/__tests__/user-database-deprovision.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/user-database-deprovision.test.ts
@@ -1,0 +1,73 @@
+/**
+ * #8342 — a deleted app with an ISOLATED tenant DB must release it. The DROP
+ * needs `pg`, which the cloud-api Worker can't load, so the Worker-side
+ * cleanupDatabase ENQUEUES a daemon job instead of silently no-opping. These
+ * tests pin that enqueue seam: it fires only when there is an isolated URI, an
+ * enqueuer is wired, and an owning org is known.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+const findStateByAppIdForWrite = mock();
+mock.module("../../../db/repositories/app-databases", () => ({
+  appDatabasesRepository: { findStateByAppIdForWrite },
+}));
+
+import { UserDatabaseService } from "../user-database";
+
+type Enqueued = {
+  appId: string;
+  dbUri: string;
+  organizationId: string;
+  userId?: string;
+};
+
+function makeService(): { svc: UserDatabaseService; enqueued: Enqueued[] } {
+  const enqueued: Enqueued[] = [];
+  const svc = new UserDatabaseService(); // no pg backend == the Worker singleton
+  svc.setDeprovisionEnqueuer(async (p) => {
+    enqueued.push(p as Enqueued);
+  });
+  return { svc, enqueued };
+}
+
+describe("cleanupDatabase — isolated tenant DB teardown enqueue", () => {
+  test("enqueues a deprovision job carrying the ENCRYPTED uri (survives cascade-delete)", async () => {
+    findStateByAppIdForWrite.mockResolvedValue({
+      user_database_uri: "enc:v1:ciphertext",
+      user_database_project_id: null,
+    });
+    const { svc, enqueued } = makeService();
+    await svc.cleanupDatabase("app-1", { organizationId: "org-1", userId: "u-1" });
+    expect(enqueued).toEqual([
+      { appId: "app-1", dbUri: "enc:v1:ciphertext", organizationId: "org-1", userId: "u-1" },
+    ]);
+  });
+
+  test("no enqueue when the app has no isolated DB", async () => {
+    findStateByAppIdForWrite.mockResolvedValue({
+      user_database_uri: null,
+      user_database_project_id: null,
+    });
+    const { svc, enqueued } = makeService();
+    await svc.cleanupDatabase("app-2", { organizationId: "org-1" });
+    expect(enqueued).toEqual([]);
+  });
+
+  test("no enqueue when the owning org is unknown (can't form the job row)", async () => {
+    findStateByAppIdForWrite.mockResolvedValue({
+      user_database_uri: "enc:v1:ciphertext",
+      user_database_project_id: null,
+    });
+    const { svc, enqueued } = makeService();
+    await svc.cleanupDatabase("app-3"); // no opts
+    expect(enqueued).toEqual([]);
+  });
+
+  test("no-ops cleanly when there is no database row at all", async () => {
+    findStateByAppIdForWrite.mockResolvedValue(null);
+    const { svc, enqueued } = makeService();
+    await svc.cleanupDatabase("app-4", { organizationId: "org-1" });
+    expect(enqueued).toEqual([]);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/app-db-deprovision-job-service.ts
+++ b/packages/cloud-shared/src/lib/services/app-db-deprovision-job-service.ts
@@ -1,0 +1,116 @@
+/**
+ * APP_DB_DEPROVISION job service (Apps / Product 2) — releases an isolated
+ * per-tenant DB when its app is deleted, WITHOUT the Worker ever touching `pg`.
+ *
+ * The Worker delete path ENQUEUES an APP_DB_DEPROVISION job (a plain DB insert,
+ * no `pg`) via {@link enqueueAppDbDeprovision}, carrying the app's *encrypted*
+ * tenant-DB URI in the payload. The URI is already ciphertext at rest in
+ * `app_databases`, so copying it into the job row adds no exposure — and it
+ * survives the app row's cascade-delete, so the daemon can still resolve the
+ * cluster after the app is gone. The provisioning-worker daemon claims the job
+ * and runs the real `DROP DATABASE` / `DROP ROLE` + cluster-slot release via
+ * {@link dispatchAppDbDeprovisionJob}, decrypting the URI on the node side
+ * where `pg` and the cluster admin DSN live.
+ *
+ * Without this, a deleted isolated app strands a live Postgres DB we keep
+ * paying for and permanently burns one of the cluster's finite slots (#8342) —
+ * because the only in-process deprovision path (UserDatabaseService.cleanupDatabase)
+ * runs on the Worker, which has no `pg` backend wired, so it silently no-ops.
+ *
+ * The executor backend is injected at daemon boot via {@link setAppDbDeprovisioner}
+ * (see apps-deploy-backend.ts), mirroring setAppDeployRunner — so this module
+ * imports no `pg`/SSH and stays safe to load on workerd.
+ */
+
+import type { ContainerJobsWriter } from "./container-job-service";
+import { containerJobsWriter } from "./container-jobs-writer";
+import { fieldEncryption } from "./field-encryption";
+import { JOB_TYPES } from "./provisioning-job-types";
+import { userDatabaseService } from "./user-database";
+
+/** Outcome of a tenant-DB deprovision (structural subset of TenantDbDeprovisionResult). */
+export interface AppDbDeprovisionOutcome {
+  deprovisioned: boolean;
+  reason?: string;
+}
+
+/** The node-side deprovisioner the daemon runs for APP_DB_DEPROVISION jobs. */
+export interface AppDbDeprovisioner {
+  deprovisionForApp(appId: string, dsn: string): Promise<AppDbDeprovisionOutcome>;
+}
+
+// ── runtime-injected executor (daemon side) ─────────────────────────────────
+let appDbDeprovisioner: AppDbDeprovisioner | null = null;
+
+/** Wire the node deprovisioner the daemon runs for APP_DB_DEPROVISION jobs. */
+export function setAppDbDeprovisioner(deprovisioner: AppDbDeprovisioner): void {
+  appDbDeprovisioner = deprovisioner;
+}
+
+/** Resolve the deprovisioner, or throw if the backend isn't wired yet. */
+export function getAppDbDeprovisioner(): AppDbDeprovisioner {
+  if (!appDbDeprovisioner) {
+    throw new Error("App DB deprovisioner not configured — call setAppDbDeprovisioner()");
+  }
+  return appDbDeprovisioner;
+}
+
+/** Extract + validate an APP_DB_DEPROVISION job payload (throws if malformed). */
+export function readAppDbDeprovisionJobData(job: { data: unknown }): {
+  appId: string;
+  dbUri: string;
+} {
+  const data = (job.data ?? {}) as Record<string, unknown>;
+  if (typeof data.appId !== "string" || data.appId.length === 0) {
+    throw new Error("APP_DB_DEPROVISION job missing data.appId");
+  }
+  if (typeof data.dbUri !== "string" || data.dbUri.length === 0) {
+    throw new Error("APP_DB_DEPROVISION job missing data.dbUri");
+  }
+  return { appId: data.appId, dbUri: data.dbUri };
+}
+
+/**
+ * Daemon: run the DROP + slot-release for a claimed APP_DB_DEPROVISION job.
+ * Decrypts the carried URI node-side (passthrough if already plaintext, e.g.
+ * the env-DSN mode) and delegates to the injected deprovisioner, which resolves
+ * the cluster from the DSN host, DROPs the DB + ROLE, then releases the slot.
+ */
+export async function dispatchAppDbDeprovisionJob(job: {
+  data: unknown;
+}): Promise<AppDbDeprovisionOutcome> {
+  const { appId, dbUri } = readAppDbDeprovisionJobData(job);
+  const dsn = await fieldEncryption.decryptIfNeeded(dbUri);
+  if (!dsn) {
+    // Nothing to resolve a cluster from — treat as already gone (idempotent).
+    return { deprovisioned: false, reason: "empty-dsn" };
+  }
+  return getAppDbDeprovisioner().deprovisionForApp(appId, dsn);
+}
+
+// ── enqueue (Worker / request side) ─────────────────────────────────────────
+/** Enqueue an APP_DB_DEPROVISION job (pg-free) over the shared job writer. */
+export function enqueueAppDbDeprovision(
+  writer: ContainerJobsWriter,
+  p: { appId: string; organizationId: string; userId?: string; dbUri: string },
+): Promise<{ id: string }> {
+  return writer.insertJob({
+    type: JOB_TYPES.APP_DB_DEPROVISION,
+    organizationId: p.organizationId,
+    userId: p.userId,
+    data: { appId: p.appId, dbUri: p.dbUri },
+  });
+}
+
+/**
+ * Worker boot (Apps / Product 2): wire the app-delete path to hand isolated
+ * tenant-DB teardown to the daemon via an APP_DB_DEPROVISION job, over the
+ * shared (pg-free) job writer. Call once in cloud-api boot — after this,
+ * deleting an app that has an isolated DB enqueues the real DROP the daemon
+ * runs. Safe to import on workerd (no `pg`).
+ */
+export function configureAppsDeprovisionTrigger(): void {
+  userDatabaseService.setDeprovisionEnqueuer((p) =>
+    enqueueAppDbDeprovision(containerJobsWriter, p),
+  );
+}

--- a/packages/cloud-shared/src/lib/services/apps-deploy-backend.ts
+++ b/packages/cloud-shared/src/lib/services/apps-deploy-backend.ts
@@ -24,6 +24,7 @@
  */
 
 import { logger } from "../utils/logger";
+import { setAppDbDeprovisioner } from "./app-db-deprovision-job-service";
 import { setAppDeployRunner } from "./app-deploy-job-service";
 import {
   type AppDeployRunnerDeps,
@@ -85,16 +86,20 @@ export function configureAppsDeployBackend(config: AppsDeployBackendConfig): voi
   // standard encrypted path via UserDatabaseService.
   const adminDsnFromEnv = process.env.APPS_TENANT_ADMIN_DSN;
   let runner: DefaultAppDeployRunner;
+  // Captured for the APP_DB_DEPROVISION executor below — both modes build a
+  // provisioning object whose deprovisionForApp DROPs the DB + releases the slot.
+  let tenantDbProvisioning: ReturnType<typeof makeTenantDbProvisioning>;
   if (adminDsnFromEnv) {
-    const provisioning = makeTenantDbProvisioning({ decrypt: async () => adminDsnFromEnv });
+    tenantDbProvisioning = makeTenantDbProvisioning({ decrypt: async () => adminDsnFromEnv });
     runner = makeDirectAppDeployRunner({
-      tenantDbProvisioning: provisioning,
+      tenantDbProvisioning,
       jobsWriter: containerJobsWriter,
       resolveImage,
       port: config.port,
     });
   } else {
-    const userDatabaseService = new UserDatabaseService(makeTenantDbProvisioning());
+    tenantDbProvisioning = makeTenantDbProvisioning();
+    const userDatabaseService = new UserDatabaseService(tenantDbProvisioning);
     runner = makeNodeAppDeployRunner({
       userDatabaseService,
       jobsWriter: containerJobsWriter,
@@ -108,6 +113,10 @@ export function configureAppsDeployBackend(config: AppsDeployBackendConfig): voi
   // called here (it runs on the Worker, which enqueues APP_DEPLOY).
   setAppDeployRunner(runner);
   setContainerExecutorDeps(buildContainerExecutorDeps);
+  // Daemon also runs APP_DB_DEPROVISION jobs (enqueued by the Worker on app
+  // delete): DROP the isolated DB + ROLE node-side and release the cluster slot
+  // — the Worker can't (no `pg`), so without this the DB + slot leak (#8342).
+  setAppDbDeprovisioner(tenantDbProvisioning);
 
   logger.info("[apps-deploy-backend] armed", {
     registry: config.registry ?? null,

--- a/packages/cloud-shared/src/lib/services/apps.ts
+++ b/packages/cloud-shared/src/lib/services/apps.ts
@@ -306,7 +306,12 @@ export class AppsService {
     if (app) {
       try {
         const { userDatabaseService } = await import("./user-database");
-        await userDatabaseService.cleanupDatabase(id);
+        // Pass owning org/user so an ISOLATED tenant DB can be torn down via a
+        // daemon job (the DROP needs `pg`; this delete runs on the Worker) — #8342.
+        await userDatabaseService.cleanupDatabase(id, {
+          organizationId: app.organization_id,
+          userId: app.created_by_user_id ?? undefined,
+        });
         logger.info("Cleaned up user database for app", { appId: id });
       } catch (error) {
         // Log but don't fail deletion - database might already be gone

--- a/packages/cloud-shared/src/lib/services/provisioning-job-types.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-job-types.ts
@@ -60,6 +60,15 @@ export const JOB_TYPES = {
    * `pg`/SSH off the workerd request path.
    */
   APP_DEPLOY: "app_deploy",
+  /**
+   * Tear down an app's ISOLATED per-tenant DB (Apps / Product 2): DROP DATABASE
+   * + DROP ROLE and release the cluster slot. The Worker delete path enqueues
+   * this (pg-free, carrying the app's encrypted DSN) and the provisioning-worker
+   * daemon claims it and runs the real DROP node-side — because `pg` and the
+   * cluster admin DSN only exist on the daemon. Without it, a deleted isolated
+   * app strands a live DB we keep paying for and burns a finite slot (#8342).
+   */
+  APP_DB_DEPROVISION: "app_db_deprovision",
 } as const;
 
 export type ProvisioningJobType = (typeof JOB_TYPES)[keyof typeof JOB_TYPES];

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -1472,9 +1472,33 @@ export class ProvisioningJobService {
       // Apps lane (Product 2): tear down a deleted app's isolated tenant DB.
       // The Worker enqueues this; the daemon runs the real DROP + slot release
       // via the injected deprovisioner (wired in apps-deploy-backend). (#8342)
-      case JOB_TYPES.APP_DB_DEPROVISION:
-        await dispatchAppDbDeprovisionJob(job);
+      case JOB_TYPES.APP_DB_DEPROVISION: {
+        const outcome = await dispatchAppDbDeprovisionJob(job);
+        // Mark terminal so recoverStaleJobs() can't re-sweep this job back to
+        // `pending` after the stale threshold. A re-run would call
+        // deprovisionTenantDbForApp -> releaseSlot() a SECOND time, and
+        // releaseSlot's GREATEST(0, database_count - 1) is NOT idempotent
+        // across separate successful runs: on a multi-tenant cluster the second
+        // decrement frees a phantom slot belonging to another LIVE tenant DB
+        // (capacity over-allocation — the inverse of the #8342 leak this very
+        // job fixes). Every AGENT_* executor self-marks completed for exactly
+        // this reason; the Apps-lane dispatchers historically relied on never
+        // being re-swept, which only bites this non-idempotent deprovision path.
+        //
+        // Follow-up (deeper hardening, separate PR): make releaseSlot itself
+        // idempotent by gating it on the DROP actually removing an existing DB
+        // (needs a row-returning query seam on TenantDbSqlExecutor). That would
+        // also close the micro-window where this updateStatus throws AFTER a
+        // successful releaseSlot and the retry re-decrements.
+        await jobsRepository.updateStatus(job.id, "completed", {
+          result: {
+            deprovisioned: outcome.deprovisioned,
+            reason: outcome.reason ?? null,
+          },
+          completed_at: new Date(),
+        });
         break;
+      }
       default:
         throw new Error(`Unknown job type: ${job.type}`);
     }

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -27,6 +27,7 @@ import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { jobs } from "../../db/schemas/jobs";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
 import { logger } from "../utils/logger";
+import { dispatchAppDbDeprovisionJob } from "./app-db-deprovision-job-service";
 import { dispatchAppDeployJob } from "./app-deploy-job-service";
 import { dispatchContainerJob, getContainerExecutorDeps } from "./container-job-service";
 import { elizaProvisionAdvisoryLockSql } from "./eliza-provision-lock";
@@ -1467,6 +1468,12 @@ export class ProvisioningJobService {
       // daemon runs the real isolated provision via the injected AppDeployRunner.
       case JOB_TYPES.APP_DEPLOY:
         await dispatchAppDeployJob(job);
+        break;
+      // Apps lane (Product 2): tear down a deleted app's isolated tenant DB.
+      // The Worker enqueues this; the daemon runs the real DROP + slot release
+      // via the injected deprovisioner (wired in apps-deploy-backend). (#8342)
+      case JOB_TYPES.APP_DB_DEPROVISION:
+        await dispatchAppDbDeprovisionJob(job);
         break;
       default:
         throw new Error(`Unknown job type: ${job.type}`);

--- a/packages/cloud-shared/src/lib/services/user-database.ts
+++ b/packages/cloud-shared/src/lib/services/user-database.ts
@@ -59,8 +59,22 @@ export interface DatabaseStatus {
   connectionUri?: string;
 }
 
+/**
+ * Worker-side enqueuer that hands an isolated tenant-DB teardown to the daemon
+ * (the DROP needs `pg`, which doesn't load on workerd). Injected at cloud-api
+ * boot via {@link UserDatabaseService.setDeprovisionEnqueuer}; carries the app's
+ * *encrypted* DSN so the job survives the app row's cascade-delete (#8342).
+ */
+export type IsolatedDbDeprovisionEnqueuer = (p: {
+  appId: string;
+  dbUri: string;
+  organizationId: string;
+  userId?: string;
+}) => Promise<unknown>;
+
 export class UserDatabaseService {
   private readonly tenantDbProvisioning?: TenantDbProvisioning;
+  private deprovisionEnqueuer?: IsolatedDbDeprovisionEnqueuer;
 
   /**
    * @param tenantDbProvisioning When provided, apps get a fully ISOLATED
@@ -71,6 +85,16 @@ export class UserDatabaseService {
    */
   constructor(tenantDbProvisioning?: TenantDbProvisioning) {
     this.tenantDbProvisioning = tenantDbProvisioning;
+  }
+
+  /**
+   * Wire the Worker-side enqueuer that hands isolated tenant-DB teardown to the
+   * daemon. Used when this instance has no local `pg` backend (the cloud-api
+   * Worker): {@link cleanupDatabase} enqueues an APP_DB_DEPROVISION job instead
+   * of silently no-opping the DROP. No-op on the daemon, which DROPs inline.
+   */
+  setDeprovisionEnqueuer(enqueuer: IsolatedDbDeprovisionEnqueuer): void {
+    this.deprovisionEnqueuer = enqueuer;
   }
 
   /**
@@ -220,8 +244,13 @@ export class UserDatabaseService {
    * Clean up database when app is deleted.
    *
    * @param appId App ID
+   * @param opts Owning org/user — required to enqueue the daemon-side isolated
+   *   DB teardown from the Worker (the job row carries organization_id/user_id).
    */
-  async cleanupDatabase(appId: string): Promise<void> {
+  async cleanupDatabase(
+    appId: string,
+    opts?: { organizationId?: string; userId?: string },
+  ): Promise<void> {
     logger.info("Cleaning up database for app", { appId });
 
     const database = await appDatabasesRepository.findStateByAppIdForWrite(appId);
@@ -232,25 +261,56 @@ export class UserDatabaseService {
 
     // ISOLATED (Apps / Product 2): DROP the app's OWN per-tenant DATABASE + ROLE
     // and release its cluster slot — otherwise we leak a live DB we keep paying
-    // for AND burn one of the cluster's finite slots forever (#8342). Only runs
-    // when the provisioning backend is wired (the daemon — DROP needs `pg`); on
-    // the Worker (shared-mode, no backend) this is a no-op.
+    // for AND burn one of the cluster's finite slots forever (#8342).
+    //
+    // The DROP needs `pg`, which only loads on the daemon. So:
+    //  - Daemon (provisioning backend wired): DROP inline.
+    //  - Worker (no backend, but enqueuer wired): enqueue an APP_DB_DEPROVISION
+    //    job the daemon runs — carrying the *encrypted* URI so it survives this
+    //    app row's cascade-delete. THIS is the live path: the delete route runs
+    //    on the Worker.
     const isolatedUri = database.user_database_uri;
-    if (this.tenantDbProvisioning && isolatedUri) {
-      try {
-        const dsn = await fieldEncryption.decryptIfNeeded(isolatedUri);
-        if (dsn) {
-          const result = await this.tenantDbProvisioning.deprovisionForApp(appId, dsn);
-          logger.info("Isolated tenant DB deprovisioned", {
+    if (isolatedUri) {
+      if (this.tenantDbProvisioning) {
+        try {
+          const dsn = await fieldEncryption.decryptIfNeeded(isolatedUri);
+          if (dsn) {
+            const result = await this.tenantDbProvisioning.deprovisionForApp(appId, dsn);
+            logger.info("Isolated tenant DB deprovisioned", {
+              appId,
+              deprovisioned: result.deprovisioned,
+            });
+          }
+        } catch (error) {
+          // Don't fail the app delete on a teardown hiccup; a reconciler sweeps orphans.
+          logger.warn("Failed to deprovision isolated tenant DB", {
             appId,
-            deprovisioned: result.deprovisioned,
+            error: error instanceof Error ? error.message : "Unknown",
           });
         }
-      } catch (error) {
-        // Don't fail the app delete on a teardown hiccup; a reconciler sweeps orphans.
-        logger.warn("Failed to deprovision isolated tenant DB", {
+      } else if (this.deprovisionEnqueuer && opts?.organizationId) {
+        try {
+          await this.deprovisionEnqueuer({
+            appId,
+            dbUri: isolatedUri,
+            organizationId: opts.organizationId,
+            userId: opts.userId,
+          });
+          logger.info("Enqueued isolated tenant DB deprovision job", { appId });
+        } catch (error) {
+          // Don't fail the app delete on an enqueue hiccup; a reconciler sweeps orphans.
+          logger.warn("Failed to enqueue isolated tenant DB deprovision", {
+            appId,
+            error: error instanceof Error ? error.message : "Unknown",
+          });
+        }
+      } else {
+        // No `pg` backend and no enqueuer (or missing org): the DROP can't run
+        // here. Surface it loudly so an orphan-DB reconciler can catch it.
+        logger.warn("Isolated tenant DB not torn down — no backend/enqueuer wired", {
           appId,
-          error: error instanceof Error ? error.message : "Unknown",
+          hasEnqueuer: Boolean(this.deprovisionEnqueuer),
+          hasOrg: Boolean(opts?.organizationId),
         });
       }
     }


### PR DESCRIPTION
## What

Fixes CRITICAL leak #2 from #8342: **a deleted app with an ISOLATED per-tenant DB never DROPped its Postgres or released its cluster slot** — so we kept paying for a stranded DB and permanently burned 1/`max_databases` of a cluster's finite slots.

## Why it was leaking

The deprovision logic already exists end to end — `deprovisionTenantDbForApp` + `cleanupDatabase`'s isolated branch + `releaseSlot` (`GREATEST(0, database_count - 1)`). It was **runtime-dead**: its only caller is the cloud-api **Worker**, whose `UserDatabaseService` singleton has no provisioning backend — correctly, because the `DROP` needs `pg`, which can't load on workerd. So the isolated branch silently no-opped, and on `appsRepository.delete` the `app_databases` row cascaded away, losing the only handle to the DB.

## Fix — mirror the `APP_DEPLOY` split

Run the DROP where `pg` lives (the daemon), triggered from the Worker:

- **New `APP_DB_DEPROVISION` job type** + `app-db-deprovision-job-service.ts` (same shape as `app-deploy-job-service.ts`). The Worker enqueues it (pg-free), carrying the app's **encrypted** DSN in the payload — it's already ciphertext at rest in `app_databases`, so copying it adds no exposure, and it **survives the app row's cascade-delete** so the daemon can still resolve the cluster.
- **`executeJob`** gains one additive `case` → `dispatchAppDbDeprovisionJob` (decrypts node-side, delegates to the injected deprovisioner: DROP DB + ROLE, then `releaseSlot`).
- **`apps-deploy-backend`** arms the deprovisioner with the same `makeTenantDbProvisioning()` it already builds (both env-DSN and encrypted modes).
- **`bootstrap-app`** wires the Worker enqueuer under the existing `APPS_DEPLOY_ENABLED` gate.
- **`apps.delete`** passes the owning org/user so the job row can be formed.

## Scope / safety

- Targets the **encrypted (canonical Product-2) path**. The env-DSN staging shortcut stores the DSN on the container rather than `app_databases`, so its teardown is a separate small follow-up (noted; staging isn't serving yet).
- **Idempotent + fail-soft:** an enqueue or DROP hiccup logs and lets the delete proceed; the missing-host / unknown-cluster cases return `{ deprovisioned: false }` rather than throwing. An orphan-DB reconciler remains the backstop.
- Purely additive to the agent/container dispatch paths — no change to `eliza-sandbox`, `container-billing`, or `hetzner-client`.

## Tests

10 new (all green), plus `typecheck` + `biome` clean:
- `app-db-deprovision-job-service.test.ts` — payload validation, dispatch decrypt+delegate, unwired-throw, enqueue shape.
- `user-database-deprovision.test.ts` — the `cleanupDatabase` enqueue seam: fires only with an isolated URI + wired enqueuer + known org; no-ops otherwise.

Part of the #8342 pre-go-live billing-correctness work. cc @standujar
