### PR TITLE
test(cloud-agents): characterization tests for the warm-pool decision engine

### DIFF
--- a/packages/cloud-shared/src/lib/services/containers/agent-warm-pool-forecast.test.ts
+++ b/packages/cloud-shared/src/lib/services/containers/agent-warm-pool-forecast.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Characterization tests for the warm-pool demand forecast.
+ *
+ * `agent-warm-pool-forecast.ts` advertises itself as "Pure functions" and the
+ * warm-pool manager docstring claims the decision layer is "tested in
+ * isolation" — but there was no test for `computeForecast` before this. These
+ * pin the invariants that decide the agent warm-pool's target size (the input
+ * to every replenish/drain decision), so the autoscaler tuning in #8348/#8353/
+ * #8357 can't silently change them.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  computeForecast,
+  DEFAULT_WARM_POOL_POLICY,
+  type ForecastInput,
+} from "./agent-warm-pool-forecast";
+
+const base: ForecastInput = {
+  bucketCounts: [],
+  emaAlpha: 0.5,
+  leadTimeBuckets: 1,
+  minPoolSize: 1,
+  maxPoolSize: 10,
+};
+
+describe("computeForecast — guards", () => {
+  test("throws when minPoolSize exceeds maxPoolSize", () => {
+    expect(() => computeForecast({ ...base, minPoolSize: 5, maxPoolSize: 4 })).toThrow(
+      /minPoolSize cannot exceed maxPoolSize/,
+    );
+  });
+
+  test("throws when emaAlpha is out of (0, 1]", () => {
+    expect(() => computeForecast({ ...base, emaAlpha: 0 })).toThrow(/emaAlpha/);
+    expect(() => computeForecast({ ...base, emaAlpha: -0.1 })).toThrow(/emaAlpha/);
+    expect(() => computeForecast({ ...base, emaAlpha: 1.5 })).toThrow(/emaAlpha/);
+  });
+
+  test("accepts the boundary emaAlpha = 1", () => {
+    expect(() => computeForecast({ ...base, emaAlpha: 1, bucketCounts: [3] })).not.toThrow();
+  });
+
+  test("throws when leadTimeBuckets is negative", () => {
+    expect(() => computeForecast({ ...base, leadTimeBuckets: -1 })).toThrow(
+      /leadTimeBuckets must be non-negative/,
+    );
+  });
+});
+
+describe("computeForecast — empty window", () => {
+  test("no buckets ⇒ rate 0, target floored at minPoolSize, observedBuckets 0", () => {
+    const out = computeForecast({ ...base, minPoolSize: 2, bucketCounts: [] });
+    expect(out.predictedRate).toBe(0);
+    expect(out.targetPoolSize).toBe(2);
+    expect(out.observedBuckets).toBe(0);
+  });
+});
+
+describe("computeForecast — EMA", () => {
+  test("a single bucket is honored (EMA seeded at the first observation)", () => {
+    // Seed = bucketCounts[0]; with one bucket the EMA stays at that value.
+    const out = computeForecast({ ...base, emaAlpha: 0.5, bucketCounts: [4] });
+    expect(out.predictedRate).toBe(4);
+    expect(out.observedBuckets).toBe(1);
+  });
+
+  test("alpha = 1 makes the forecast equal the most recent bucket", () => {
+    const out = computeForecast({ ...base, emaAlpha: 1, bucketCounts: [10, 0, 7] });
+    expect(out.predictedRate).toBe(7);
+  });
+
+  test("a steady rate forecasts to that rate", () => {
+    const out = computeForecast({ ...base, emaAlpha: 0.5, bucketCounts: [3, 3, 3, 3] });
+    expect(out.predictedRate).toBeCloseTo(3, 10);
+  });
+
+  test("recent buckets dominate older ones under EMA", () => {
+    const rising = computeForecast({ ...base, emaAlpha: 0.5, bucketCounts: [0, 0, 8] });
+    const falling = computeForecast({ ...base, emaAlpha: 0.5, bucketCounts: [8, 0, 0] });
+    expect(rising.predictedRate).toBeGreaterThan(falling.predictedRate);
+  });
+});
+
+describe("computeForecast — target sizing + clamp", () => {
+  test("target = ceil(rate × leadTime) + minPoolSize, then clamped", () => {
+    // rate 3 (steady), lead 1, floor 1 ⇒ ceil(3) + 1 = 4.
+    const out = computeForecast({
+      ...base,
+      minPoolSize: 1,
+      maxPoolSize: 10,
+      leadTimeBuckets: 1,
+      bucketCounts: [3, 3, 3],
+    });
+    expect(out.predictedRate).toBeCloseTo(3, 10);
+    expect(out.targetPoolSize).toBe(4);
+  });
+
+  test("a low non-zero rate still lifts target above the floor (ceil rounds up)", () => {
+    // rate 1, lead 0.025 ⇒ ceil(0.025) = 1, + floor 1 = 2.
+    const out = computeForecast({
+      ...base,
+      minPoolSize: 1,
+      maxPoolSize: 10,
+      leadTimeBuckets: 0.025,
+      bucketCounts: [1],
+    });
+    expect(out.targetPoolSize).toBe(2);
+  });
+
+  test("clamps up to maxPoolSize on a burst", () => {
+    const out = computeForecast({
+      ...base,
+      minPoolSize: 1,
+      maxPoolSize: 5,
+      leadTimeBuckets: 1,
+      bucketCounts: [100, 100, 100],
+    });
+    expect(out.targetPoolSize).toBe(5);
+  });
+
+  test("a zero rate keeps target exactly at the floor", () => {
+    const out = computeForecast({
+      ...base,
+      minPoolSize: 3,
+      maxPoolSize: 10,
+      bucketCounts: [0, 0, 0],
+    });
+    expect(out.predictedRate).toBe(0);
+    expect(out.targetPoolSize).toBe(3);
+  });
+
+  test("leadTimeBuckets = 0 pins target to the floor regardless of rate", () => {
+    const out = computeForecast({
+      ...base,
+      minPoolSize: 1,
+      maxPoolSize: 10,
+      leadTimeBuckets: 0,
+      bucketCounts: [50, 50],
+    });
+    expect(out.targetPoolSize).toBe(1);
+  });
+});
+
+describe("DEFAULT_WARM_POOL_POLICY", () => {
+  test("is internally consistent (floor ≤ ceiling, valid alpha, sane windows)", () => {
+    const p = DEFAULT_WARM_POOL_POLICY;
+    expect(p.minPoolSize).toBeLessThanOrEqual(p.maxPoolSize);
+    expect(p.emaAlpha).toBeGreaterThan(0);
+    expect(p.emaAlpha).toBeLessThanOrEqual(1);
+    expect(p.leadTimeBuckets).toBeGreaterThanOrEqual(0);
+    expect(p.replenishBurstLimit).toBeGreaterThan(0);
+    // The default policy must be a usable forecast input.
+    expect(() =>
+      computeForecast({
+        bucketCounts: [1, 2, 3],
+        emaAlpha: p.emaAlpha,
+        leadTimeBuckets: p.leadTimeBuckets,
+        minPoolSize: p.minPoolSize,
+        maxPoolSize: p.maxPoolSize,
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/cloud-shared/src/lib/services/containers/agent-warm-pool.test.ts
+++ b/packages/cloud-shared/src/lib/services/containers/agent-warm-pool.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Characterization tests for the warm-pool decision engine.
+ *
+ * The module docstring claims "Decision functions are pure and tested in
+ * isolation" — but `decideReplenish` / `decideDrain` / `decideRollout` had no
+ * tests. These functions decide how many agent containers get CREATED, which
+ * get DRAINED, and which get REPLACED on an image rollout — the core of the
+ * subsystem under active autoscaler tuning (#8348/#8353/#8357). This pins their
+ * branch matrix so that tuning can't silently change the contract.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  decideDrain,
+  decideReplenish,
+  decideRollout,
+  type PoolStateSnapshot,
+} from "./agent-warm-pool";
+import { DEFAULT_WARM_POOL_POLICY, type WarmPoolPolicy } from "./agent-warm-pool-forecast";
+
+function policy(overrides: Partial<WarmPoolPolicy> = {}): WarmPoolPolicy {
+  return { ...DEFAULT_WARM_POOL_POLICY, ...overrides };
+}
+
+function state(overrides: Partial<PoolStateSnapshot> = {}): PoolStateSnapshot {
+  return {
+    readyCount: 0,
+    provisioningCount: 0,
+    unclaimedRows: [],
+    predictedRate: 0,
+    targetPoolSize: 1,
+    ...overrides,
+  };
+}
+
+describe("decideReplenish", () => {
+  test("creates up to the deficit when under target with headroom + burst room", () => {
+    const d = decideReplenish(
+      state({ readyCount: 2, targetPoolSize: 5 }),
+      policy({ maxPoolSize: 10, replenishBurstLimit: 3 }),
+    );
+    expect(d.toCreate).toBe(3);
+    expect(d.reason).toContain("creating 3");
+    expect(d.reason).not.toContain("burst limit");
+  });
+
+  test("caps a large deficit at the burst limit and says so", () => {
+    const d = decideReplenish(
+      state({ readyCount: 1, targetPoolSize: 8 }),
+      policy({ maxPoolSize: 10, replenishBurstLimit: 3 }),
+    );
+    expect(d.toCreate).toBe(3);
+    expect(d.reason).toContain("burst limit 3");
+  });
+
+  test("counts in-flight provisioning toward the total (won't over-create)", () => {
+    const d = decideReplenish(
+      state({ readyCount: 1, provisioningCount: 2, targetPoolSize: 3 }),
+      policy({ maxPoolSize: 10, replenishBurstLimit: 5 }),
+    );
+    expect(d.toCreate).toBe(0);
+    expect(d.reason).toMatch(/steady/);
+  });
+
+  test("limits creation by headroom to maxPoolSize", () => {
+    const d = decideReplenish(
+      state({ readyCount: 8, targetPoolSize: 10 }),
+      policy({ maxPoolSize: 9, replenishBurstLimit: 3 }),
+    );
+    expect(d.toCreate).toBe(1); // headroom = 9 - 8
+  });
+
+  test("defers when already at maxPoolSize with an over-cap target", () => {
+    const d = decideReplenish(
+      state({ readyCount: 10, targetPoolSize: 12 }),
+      policy({ maxPoolSize: 10, replenishBurstLimit: 3 }),
+    );
+    expect(d.toCreate).toBe(0);
+    expect(d.reason).toContain("at maxPoolSize 10");
+  });
+
+  test("steady state creates nothing", () => {
+    const d = decideReplenish(
+      state({ readyCount: 3, targetPoolSize: 3 }),
+      policy({ maxPoolSize: 10 }),
+    );
+    expect(d.toCreate).toBe(0);
+    expect(d.reason).toMatch(/steady/);
+  });
+
+  test("never returns a negative toCreate when over target", () => {
+    const d = decideReplenish(
+      state({ readyCount: 6, targetPoolSize: 2 }),
+      policy({ maxPoolSize: 10 }),
+    );
+    expect(d.toCreate).toBe(0);
+  });
+});
+
+describe("decideDrain", () => {
+  const IDLE = 1000;
+
+  test("never drains while demand keeps the target above the floor", () => {
+    const d = decideDrain(
+      state({ readyCount: 5, targetPoolSize: 4 }),
+      policy({ minPoolSize: 1 }),
+      10_000,
+    );
+    expect(d.toDrain).toEqual([]);
+    expect(d.reason).toMatch(/above floor/);
+  });
+
+  test("never drains when at or below the floor", () => {
+    const d = decideDrain(
+      state({ readyCount: 1, targetPoolSize: 1 }),
+      policy({ minPoolSize: 1, idleScaleDownMs: IDLE }),
+      10_000,
+    );
+    expect(d.toDrain).toEqual([]);
+    expect(d.reason).toMatch(/at or below floor/);
+  });
+
+  test("holds surplus rows that are still inside the idle window", () => {
+    const now = 10_000;
+    const d = decideDrain(
+      state({
+        readyCount: 3,
+        targetPoolSize: 1,
+        unclaimedRows: [
+          {
+            id: "fresh",
+            pool_ready_at: new Date(now - 100),
+            docker_image: null,
+            node_id: null,
+            health_url: null,
+          },
+          {
+            id: "fresh2",
+            pool_ready_at: new Date(now - 200),
+            docker_image: null,
+            node_id: null,
+            health_url: null,
+          },
+        ],
+      }),
+      policy({ minPoolSize: 1, idleScaleDownMs: IDLE }),
+      now,
+    );
+    expect(d.toDrain).toEqual([]);
+    expect(d.reason).toMatch(/within idle window/);
+  });
+
+  test("drains the OLDEST surplus rows past the idle window, capped at the surplus", () => {
+    const now = 100_000;
+    const d = decideDrain(
+      state({
+        readyCount: 3, // surplus over floor 1 = 2
+        targetPoolSize: 1,
+        unclaimedRows: [
+          {
+            id: "newest",
+            pool_ready_at: new Date(now - 2000),
+            docker_image: null,
+            node_id: null,
+            health_url: null,
+          },
+          {
+            id: "oldest",
+            pool_ready_at: new Date(now - 9000),
+            docker_image: null,
+            node_id: null,
+            health_url: null,
+          },
+          {
+            id: "middle",
+            pool_ready_at: new Date(now - 5000),
+            docker_image: null,
+            node_id: null,
+            health_url: null,
+          },
+        ],
+      }),
+      policy({ minPoolSize: 1, idleScaleDownMs: IDLE }),
+      now,
+    );
+    // surplus = 2 ⇒ drain the two oldest, oldest first.
+    expect(d.toDrain).toEqual(["oldest", "middle"]);
+  });
+
+  test("ignores rows with no pool_ready_at timestamp", () => {
+    const now = 100_000;
+    const d = decideDrain(
+      state({
+        readyCount: 3,
+        targetPoolSize: 1,
+        unclaimedRows: [
+          { id: "noTs", pool_ready_at: null, docker_image: null, node_id: null, health_url: null },
+          {
+            id: "old",
+            pool_ready_at: new Date(now - 9000),
+            docker_image: null,
+            node_id: null,
+            health_url: null,
+          },
+        ],
+      }),
+      policy({ minPoolSize: 1, idleScaleDownMs: IDLE }),
+      now,
+    );
+    expect(d.toDrain).toEqual(["old"]);
+  });
+});
+
+describe("decideRollout", () => {
+  test("replaces rows whose image differs from the current image", () => {
+    const d = decideRollout(
+      [
+        { id: "ok", docker_image: "img:v2" },
+        { id: "stale", docker_image: "img:v1" },
+      ],
+      "img:v2",
+    );
+    expect(d.toReplace).toEqual(["stale"]);
+    expect(d.reason).toContain("replacing 1");
+  });
+
+  test("treats every row as current when all images match", () => {
+    const d = decideRollout(
+      [
+        { id: "a", docker_image: "img:v2" },
+        { id: "b", docker_image: "img:v2" },
+      ],
+      "img:v2",
+    );
+    expect(d.toReplace).toEqual([]);
+    expect(d.reason).toMatch(/all rows on current image/);
+  });
+
+  test("does NOT replace rows with an unknown (null) image", () => {
+    const d = decideRollout(
+      [
+        { id: "nullimg", docker_image: null },
+        { id: "stale", docker_image: "img:v1" },
+      ],
+      "img:v2",
+    );
+    expect(d.toReplace).toEqual(["stale"]);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/containers/image-rollout-status.test.ts
+++ b/packages/cloud-shared/src/lib/services/containers/image-rollout-status.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Characterization tests for the image-rollout pure helpers.
+ *
+ * These parse container image references and decide whether the warm pool is
+ * on the desired image — the gate that protects ready-pool replacement during
+ * an agent image rollout. They were untested; this pins the digest/tag pinning
+ * rules and the rollout state machine so a "productionSafe" judgement or a
+ * stale-row count can't drift silently.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  describeImageReference,
+  imageMatchesDesired,
+  type RolloutPoolRow,
+  summarizeImageRollout,
+} from "./image-rollout-status";
+
+const DIGEST_A = `sha256:${"a".repeat(64)}`;
+const DIGEST_B = `sha256:${"b".repeat(64)}`;
+const REPO = "ghcr.io/elizaos/agent";
+
+describe("describeImageReference — pinning + production safety", () => {
+  test("a full sha256 digest is production-safe with no warning", () => {
+    const r = describeImageReference(`${REPO}@${DIGEST_A}`);
+    expect(r.pinning).toBe("digest");
+    expect(r.digest).toBe(DIGEST_A);
+    expect(r.repository).toBe(REPO);
+    expect(r.productionSafe).toBe(true);
+    expect(r.warning).toBeNull();
+  });
+
+  test("a malformed digest is rejected as not production-safe", () => {
+    const r = describeImageReference(`${REPO}@sha256:tooshort`);
+    expect(r.pinning).toBe("digest");
+    expect(r.productionSafe).toBe(false);
+    expect(r.warning).toMatch(/full sha256/);
+  });
+
+  test("an explicit mutable tag is not production-safe", () => {
+    const r = describeImageReference(`${REPO}:v1.2.3`);
+    expect(r.pinning).toBe("tag");
+    expect(r.tag).toBe("v1.2.3");
+    expect(r.repository).toBe(REPO);
+    expect(r.productionSafe).toBe(false);
+    expect(r.warning).toMatch(/mutable without a digest/);
+  });
+
+  test("no tag and no digest resolves to implicit mutable latest", () => {
+    const r = describeImageReference(REPO);
+    expect(r.pinning).toBe("implicit-latest");
+    expect(r.tag).toBe("latest");
+    expect(r.productionSafe).toBe(false);
+    expect(r.warning).toMatch(/mutable latest/);
+  });
+
+  test("a registry host:port is not mistaken for a tag", () => {
+    const r = describeImageReference("registry.local:5000/elizaos/agent");
+    expect(r.pinning).toBe("implicit-latest");
+    expect(r.repository).toBe("registry.local:5000/elizaos/agent");
+    expect(r.tag).toBe("latest");
+  });
+
+  test("a registry host:port WITH a tag parses repository and tag correctly", () => {
+    const r = describeImageReference("registry.local:5000/elizaos/agent:v2");
+    expect(r.pinning).toBe("tag");
+    expect(r.repository).toBe("registry.local:5000/elizaos/agent");
+    expect(r.tag).toBe("v2");
+  });
+
+  test("digest pinning wins even when a tag is also present", () => {
+    const r = describeImageReference(`${REPO}:v1@${DIGEST_A}`);
+    expect(r.pinning).toBe("digest");
+    expect(r.digest).toBe(DIGEST_A);
+    expect(r.productionSafe).toBe(true);
+  });
+
+  test("trims surrounding whitespace", () => {
+    const r = describeImageReference(`  ${REPO}@${DIGEST_A}  `);
+    expect(r.reference).toBe(`${REPO}@${DIGEST_A}`);
+  });
+});
+
+describe("imageMatchesDesired", () => {
+  test("a null current image never matches", () => {
+    expect(imageMatchesDesired(null, `${REPO}@${DIGEST_A}`)).toBe(false);
+  });
+
+  test("digest-desired matches purely by digest (repository/tag noise ignored)", () => {
+    expect(imageMatchesDesired(`${REPO}@${DIGEST_A}`, `${REPO}@${DIGEST_A}`)).toBe(true);
+    expect(imageMatchesDesired(`other/repo@${DIGEST_A}`, `${REPO}@${DIGEST_A}`)).toBe(true);
+    expect(imageMatchesDesired(`${REPO}@${DIGEST_B}`, `${REPO}@${DIGEST_A}`)).toBe(false);
+  });
+
+  test("a tagged current image does not match a digest-desired image", () => {
+    expect(imageMatchesDesired(`${REPO}:v1`, `${REPO}@${DIGEST_A}`)).toBe(false);
+  });
+
+  test("tag-desired matches by exact reference", () => {
+    expect(imageMatchesDesired(`${REPO}:v1`, `${REPO}:v1`)).toBe(true);
+    expect(imageMatchesDesired(`${REPO}:v2`, `${REPO}:v1`)).toBe(false);
+  });
+});
+
+function row(id: string, image: string | null): RolloutPoolRow {
+  return { id, docker_image: image, node_id: null, pool_ready_at: null, health_url: null };
+}
+
+const DESIRED = `${REPO}@${DIGEST_A}`;
+
+describe("summarizeImageRollout — status state machine", () => {
+  test("disabled pool short-circuits regardless of rows", () => {
+    const s = summarizeImageRollout({
+      desiredImage: DESIRED,
+      enabled: false,
+      rows: [row("a", DESIRED)],
+    });
+    expect(s.status).toBe("disabled");
+    expect(s.safeNextAction).toBe("noop_pool_disabled");
+  });
+
+  test("an unpinned desired image is blocked from rollout", () => {
+    const s = summarizeImageRollout({ desiredImage: `${REPO}:latest`, enabled: true, rows: [] });
+    expect(s.status).toBe("blocked_unpinned_desired_image");
+    expect(s.safeNextAction).toBe("configure_pinned_desired_image");
+  });
+
+  test("a pinned desired image with no ready rows needs replenish", () => {
+    const s = summarizeImageRollout({ desiredImage: DESIRED, enabled: true, rows: [] });
+    expect(s.status).toBe("no_ready_pool");
+    expect(s.safeNextAction).toBe("replenish_pool");
+    expect(s.counts.totalReady).toBe(0);
+  });
+
+  test("all rows on the desired image ⇒ current, no action", () => {
+    const s = summarizeImageRollout({
+      desiredImage: DESIRED,
+      enabled: true,
+      rows: [row("a", DESIRED), row("b", DESIRED)],
+    });
+    expect(s.status).toBe("current");
+    expect(s.safeNextAction).toBe("none");
+    expect(s.counts).toMatchObject({
+      totalReady: 2,
+      matchingDesired: 2,
+      stale: 0,
+      unknownImage: 0,
+    });
+  });
+
+  test("a stale-image row triggers a rollout and is reported as stale", () => {
+    const s = summarizeImageRollout({
+      desiredImage: DESIRED,
+      enabled: true,
+      rows: [row("ok", DESIRED), row("old", `${REPO}@${DIGEST_B}`)],
+    });
+    expect(s.status).toBe("needs_rollout");
+    expect(s.safeNextAction).toBe("replace_stale_pool_entries");
+    expect(s.counts).toMatchObject({
+      totalReady: 2,
+      matchingDesired: 1,
+      stale: 1,
+      unknownImage: 0,
+    });
+    expect(s.staleRows.map((r) => r.id)).toEqual(["old"]);
+  });
+
+  test("a null-image row counts as unknown + stale", () => {
+    const s = summarizeImageRollout({
+      desiredImage: DESIRED,
+      enabled: true,
+      rows: [row("ok", DESIRED), row("mystery", null)],
+    });
+    expect(s.status).toBe("needs_rollout");
+    expect(s.counts).toMatchObject({
+      totalReady: 2,
+      matchingDesired: 1,
+      stale: 1,
+      unknownImage: 1,
+    });
+    const mystery = s.staleRows.find((r) => r.id === "mystery");
+    expect(mystery?.currentImage).toBeNull();
+  });
+
+  test("currentImages aggregates duplicates and sorts by image name", () => {
+    const s = summarizeImageRollout({
+      desiredImage: DESIRED,
+      enabled: true,
+      rows: [row("a", `${REPO}@${DIGEST_B}`), row("b", `${REPO}@${DIGEST_B}`), row("c", DESIRED)],
+    });
+    expect(s.currentImages).toHaveLength(2);
+    expect(s.currentImages.map((c) => c.image)).toEqual(
+      [...s.currentImages.map((c) => c.image)].sort((x, y) => x.localeCompare(y)),
+    );
+    const dup = s.currentImages.find((c) => c.image === `${REPO}@${DIGEST_B}`);
+    expect(dup?.count).toBe(2);
+  });
+
+  test("canary + rollback are always reported as unsupported", () => {
+    const s = summarizeImageRollout({
+      desiredImage: DESIRED,
+      enabled: true,
+      rows: [row("a", DESIRED)],
+    });
+    expect(s.unsupportedActions.map((a) => a.action).sort()).toEqual(["canary", "rollback"]);
+  });
+});


### PR DESCRIPTION
## What

50 net-new **characterization tests** for the agent **warm-pool decision engine** — the layer that keeps pre-warmed agent containers ready for instant claim. No source changed.

## Why

The warm pool is what makes launching a cloud agent feel instant, and its decision layer is pure + under active autoscaler tuning (#8348 / #8353 / #8357). The module docstrings literally say these functions are *"pure and tested in isolation"* — but there were **no tests** for any of them (verified: the `containers/` test dir had no `agent-warm-pool*` or `image-rollout-status` test). This locks the invariants so ongoing tuning can't silently change the contract, and gives a regression net for the subsystem.

## Coverage

- **`agent-warm-pool.ts`** — `decideReplenish` (deficit vs burst-limit vs headroom-to-max vs steady; never negative; counts in-flight provisioning), `decideDrain` (only below floor; oldest-first past the idle window; capped at surplus; ignores rows with no `pool_ready_at`), `decideRollout` (stale-image replace; null image never replaced).
- **`agent-warm-pool-forecast.ts`** — `computeForecast` (the three guard throws, EMA seeding at the first bucket, `ceil(rate × leadTime) + floor` clamped to `[min, max]`, empty-window ⇒ rate 0 at floor, `leadTime = 0` ⇒ floor) + `DEFAULT_WARM_POOL_POLICY` consistency.
- **`image-rollout-status.ts`** — `describeImageReference` (digest vs tag vs implicit-latest, `productionSafe` only for a valid full sha256, registry `host:port` not mistaken for a tag, digest-wins-over-tag), `imageMatchesDesired` (digest-by-digest vs tag-by-reference), `summarizeImageRollout` (the full state machine: disabled → blocked-unpinned → no-ready-pool → needs-rollout → current, plus counts/staleRows/sorted currentImages/unsupported canary+rollback).

## Safety

Pure net-new test files. Touches no source, no forbidden/hot files (no `eliza-sandbox`, `node-autoscaler` logic, containers route, billing, schema, or `hetzner-client`), and no in-flight PR adds these. **50/50 green, typecheck + biome clean.**

Part of helping ship cloud agents (reliability/regression-net track). cc @standujar
