### PR TITLE
feat(cloud-api): enable APPS_DEPLOY_ENABLED on staging

### DIFF
--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -239,6 +239,12 @@ __filename = '"/worker.js"'
 
 [env.staging.vars]
 NODE_ENV = "production"
+# Apps (Product 2): wire the real deploy trigger so POST /api/v1/apps/:id/deploy
+# enqueues an APP_DEPLOY job the provisioning-worker daemon runs (instead of the
+# legacy status-only stub). Staging only — the apps data plane (tenant DB +
+# Caddy app node + armed daemon) is live on staging. Gates configureAppsDeployTrigger
+# in bootstrap-app.ts; no effect on Product-1 / agent paths.
+APPS_DEPLOY_ENABLED = "1"
 NEXT_PUBLIC_APP_URL = "https://staging.elizacloud.ai"
 NEXT_PUBLIC_API_URL = "https://api-staging.elizacloud.ai"
 ELIZA_CLOUD_URL = "https://staging.elizacloud.ai"


### PR DESCRIPTION
Turns on the real apps deploy trigger on the staging Worker now that the apps data plane (apps-shared tenant DB + Caddy app node + armed daemon) is live on staging. Staging vars only, gates configureAppsDeployTrigger, no Product-1 impact. cc @standujar