### PR TITLE
feat(cloud-apps): arm build-from-repo on the daemon (the Vercel-like path)

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/node-builder-exec.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/node-builder-exec.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Arming gate for build-from-repo: makeNodeBuilderExec exposes the app node's
+ * SSH as a BuildExec ONLY when the container backend is configured, so the
+ * deploy backend cleanly falls back to prebuilt images otherwise (no accidental
+ * build-mode arming). Pins that safety property.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { makeNodeBuilderExec } from "../container-executor-deps";
+
+const SAVED = { ...process.env };
+
+function reset() {
+  for (const k of [
+    "APPS_CONTAINERS_ENABLED",
+    "CONTAINERS_DOCKER_NODES",
+    "CONTAINERS_SSH_KEY",
+    "CONTAINERS_SSH_KEY_PATH",
+  ]) {
+    delete process.env[k];
+  }
+}
+
+beforeEach(reset);
+afterEach(() => {
+  reset();
+  Object.assign(process.env, SAVED);
+});
+
+describe("makeNodeBuilderExec — arming gate", () => {
+  test("returns null when no docker node is configured (→ prebuilt fallback)", () => {
+    process.env.CONTAINERS_SSH_KEY = Buffer.from("fake-key").toString("base64");
+    // no CONTAINERS_DOCKER_NODES
+    expect(makeNodeBuilderExec()).toBeNull();
+  });
+
+  test("returns null when no SSH key is configured", () => {
+    process.env.CONTAINERS_DOCKER_NODES = "apps-node-1:10.0.0.1:20";
+    // no CONTAINERS_SSH_KEY / _PATH
+    expect(makeNodeBuilderExec()).toBeNull();
+  });
+
+  test("returns null when explicitly disabled even if node + key present", () => {
+    process.env.APPS_CONTAINERS_ENABLED = "0";
+    process.env.CONTAINERS_DOCKER_NODES = "apps-node-1:10.0.0.1:20";
+    process.env.CONTAINERS_SSH_KEY = Buffer.from("fake-key").toString("base64");
+    expect(makeNodeBuilderExec()).toBeNull();
+  });
+
+  test("returns a BuildExec (exec fn) when node + key are configured", () => {
+    process.env.CONTAINERS_DOCKER_NODES = "apps-node-1:10.0.0.1:20";
+    process.env.CONTAINERS_SSH_KEY = Buffer.from("fake-key").toString("base64");
+    const exec = makeNodeBuilderExec();
+    expect(exec).not.toBeNull();
+    expect(typeof exec?.exec).toBe("function");
+  });
+});

--- a/packages/cloud-shared/src/lib/services/apps-deploy-backend.ts
+++ b/packages/cloud-shared/src/lib/services/apps-deploy-backend.ts
@@ -34,7 +34,7 @@ import {
 } from "./app-deploy-runner";
 import { AppImageBuilder, type BuildExec } from "./app-image-builder";
 import { makeBuildFromRepoResolver } from "./app-image-resolver";
-import { buildContainerExecutorDeps } from "./container-executor-deps";
+import { buildContainerExecutorDeps, makeNodeBuilderExec } from "./container-executor-deps";
 import { setContainerExecutorDeps } from "./container-job-service";
 import { containerJobsWriter } from "./container-jobs-writer";
 import { makeTenantDbProvisioning } from "./tenant-db/make-tenant-db-provisioning";
@@ -64,19 +64,24 @@ export interface AppsDeployBackendConfig {
  * is processed.
  */
 export function configureAppsDeployBackend(config: AppsDeployBackendConfig): void {
-  // Build-from-repo resolver only when a builder exec is provided; otherwise the
-  // runner falls back to app.metadata.imageTag / APP_DEFAULT_IMAGE (prebuilt).
+  // BUILD-FROM-REPO ("Vercel-like": the platform builds the user's repo, no
+  // manual image push) is armed when a registry is configured. The builder exec
+  // is the explicit one if passed, else the app node's own SSH (it already has
+  // Docker + buildx) — so the common case needs only `APPS_IMAGE_REGISTRY` set on
+  // the daemon. With no registry, resolveImage stays undefined and the runner
+  // falls back to app.metadata.imageTag / APP_DEFAULT_IMAGE (the prebuilt path) —
+  // unchanged behavior.
+  const registry = config.registry ?? process.env.APPS_IMAGE_REGISTRY;
+  const dockerfile = config.dockerfile ?? process.env.APPS_BUILD_DOCKERFILE;
+  const buildExec = config.buildExec ?? (registry ? makeNodeBuilderExec() : null);
+
   let resolveImage: AppDeployRunnerDeps["resolveImage"] | undefined;
-  if (config.buildExec) {
-    if (!config.registry) {
+  if (buildExec) {
+    if (!registry) {
       throw new Error("[apps-deploy-backend] registry is required when buildExec is set");
     }
-    const builder = new AppImageBuilder({ exec: config.buildExec });
-    resolveImage = makeBuildFromRepoResolver({
-      builder,
-      registry: config.registry,
-      dockerfile: config.dockerfile,
-    });
+    const builder = new AppImageBuilder({ exec: buildExec });
+    resolveImage = makeBuildFromRepoResolver({ builder, registry, dockerfile });
   }
 
   // ENCRYPTION-FREE path (env-sourced cluster admin DSN): when
@@ -119,9 +124,9 @@ export function configureAppsDeployBackend(config: AppsDeployBackendConfig): voi
   setAppDbDeprovisioner(tenantDbProvisioning);
 
   logger.info("[apps-deploy-backend] armed", {
-    registry: config.registry ?? null,
+    registry: registry ?? null,
     port: config.port ?? 3000,
     mode: adminDsnFromEnv ? "env-sourced (no field-encryption)" : "encrypted",
-    images: config.buildExec ? "build-from-repo" : "prebuilt (imageTag/APP_DEFAULT_IMAGE)",
+    images: resolveImage ? "build-from-repo" : "prebuilt (imageTag/APP_DEFAULT_IMAGE)",
   });
 }

--- a/packages/cloud-shared/src/lib/services/container-executor-deps.ts
+++ b/packages/cloud-shared/src/lib/services/container-executor-deps.ts
@@ -21,6 +21,7 @@ import { containersEnv } from "../config/containers-env";
 import { logger } from "../utils/logger";
 import { AppContainerProvider, type AppContainerSsh } from "./app-container-provider";
 import { appContainerStore } from "./app-container-store";
+import type { BuildExec } from "./app-image-builder";
 import { addAppRoute, removeAppRoute } from "./apps-ingress-provisioner";
 import type { ContainerExecutorDeps } from "./container-job-executors";
 import { DockerSSHClient } from "./docker-ssh";
@@ -61,6 +62,24 @@ function selectNodeHost(): string {
     );
   }
   return host;
+}
+
+/**
+ * Expose the app node's SSH connection as a {@link BuildExec} so the deploy
+ * backend can build user images FROM THEIR REPO on the node (`docker buildx
+ * build --push <git-url>`) and push to the registry — the "Vercel-like" path
+ * where the platform does the build, not the user. The node already has Docker
+ * + buildx (it runs the containers); `AppContainerSsh.exec(cmd, timeoutMs)` is
+ * structurally identical to `BuildExec.exec`. Returns null when the node backend
+ * isn't configured, so the deploy backend cleanly falls back to prebuilt images.
+ *
+ * INFRA NOTE: the node must be `docker login`'d to the registry (push for build,
+ * pull for run). That credential is provisioned out-of-band (operator/cloud-init),
+ * not here — same as the container SSH key.
+ */
+export function makeNodeBuilderExec(): BuildExec | null {
+  if (!appsContainersEnabled()) return null;
+  return makeNodeSsh();
 }
 
 /** A pooled SSH connection to the chosen node, exposing the `AppContainerSsh` seam. */

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -656,12 +656,19 @@ async function armAppsDeployBackendIfEnabled(
   const port = process.env.APPS_DEPLOY_PORT
     ? Number(process.env.APPS_DEPLOY_PORT)
     : undefined;
-  configureAppsDeployBackend({ port });
+  // When APPS_IMAGE_REGISTRY is set, the backend arms BUILD-FROM-REPO (builds the
+  // user's repo on the app node via buildx and pushes to this registry — the
+  // Vercel-like path). Unset → prebuilt images (imageTag/APP_DEFAULT_IMAGE).
+  const registry = process.env.APPS_IMAGE_REGISTRY;
+  configureAppsDeployBackend({ port, registry });
   logger.info("[provisioning-worker] apps deploy backend armed", {
     tenantDbAdminDsn: process.env.APPS_TENANT_ADMIN_DSN
       ? "env-sourced"
       : "encrypted",
-    images: "prebuilt (imageTag/APP_DEFAULT_IMAGE)",
+    images: registry
+      ? "build-from-repo"
+      : "prebuilt (imageTag/APP_DEFAULT_IMAGE)",
+    registry: registry ?? null,
     port: port ?? 3000,
   });
 }


### PR DESCRIPTION
## What

Arms **build-from-repo** on the apps daemon — the "Vercel-like" path where the **platform builds the user's repo**, instead of requiring a manually pre-pushed image.

## Why

The full pipeline (buildx-over-SSH → push → pull → deploy) was already coded + unit-tested, but `configureAppsDeployBackend` was called with no `buildExec`, so the daemon armed **prebuilt-only**: `app.github_repo` was read but went nowhere, and every deploy needed a hand-built, pre-pushed image. That's the exact un-Vercel-like friction — the registry push is supposed to be *invisible plumbing the platform does*, not a manual prerequisite.

## How

- `makeNodeBuilderExec()` (container-executor-deps) exposes the **app node's own SSH** as a `BuildExec` — the node already has Docker + buildx (it runs the containers), and `AppContainerSsh.exec(cmd, timeoutMs)` is structurally identical to `BuildExec.exec`. Returns `null` when the container backend isn't configured.
- `configureAppsDeployBackend`: when a **registry** is configured (`APPS_IMAGE_REGISTRY` env or `config.registry`), it builds the user's repo on the node via buildx and pushes; the node then pulls + runs it.
- The daemon passes `registry: process.env.APPS_IMAGE_REGISTRY` at arm time.

## Safety

**Fully gated.** With `APPS_IMAGE_REGISTRY` **unset** (today's state), behavior is identical to before — prebuilt images (`imageTag`/`APP_DEFAULT_IMAGE`). No risk to the live path. 4 new tests pin the arming gate; typecheck + biome clean.

## Infra to actually turn it on (follow-up, needs @standujar)

The app node needs **buildx** + `docker login <registry>` (push for build, pull for run) — same out-of-band provisioning as the container SSH key. Then set `APPS_IMAGE_REGISTRY` (e.g. `ghcr.io/elizaos`) on the daemon and re-arm.

The remaining product gap after this is the browser **"import from GitHub"** UX (the dashboard create flow only registers externally-hosted apps today).

Found via a full vision-vs-reality gap scan of Product 2 — this was the **#1 gap** (the literal headline feature). cc @standujar
