### PR TITLE
ci: gate expensive test lanes by changed paths

### DIFF
--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -36,8 +36,75 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Classify changed paths
+    runs-on: ubuntu-24.04
+    outputs:
+      run_scenario_pr: ${{ steps.filter.outputs.run_scenario_pr }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Determine affected CI surface
+        id: filter
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "run_scenario_pr=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          git diff --name-only "$base" "$head" > /tmp/changed-files
+
+          run_scenario_pr=false
+          while IFS= read -r path; do
+            case "$path" in
+              package.json|bun.lock|turbo.json|tsconfig*.json|vite.config.*|vitest.config.*)
+                run_scenario_pr=true
+                ;;
+              .github/workflows/scenario-pr.yml|.github/actions/setup-bun-workspace/**)
+                run_scenario_pr=true
+                ;;
+              packages/app/**|packages/ui/**|packages/app-core/**|packages/scenario-runner/**)
+                run_scenario_pr=true
+                ;;
+              packages/core/**|packages/agent/**|packages/shared/**|packages/scripts/**)
+                run_scenario_pr=true
+                ;;
+              packages/test/**|packages/prompts/**)
+                run_scenario_pr=true
+                ;;
+              plugins/plugin-app-control/**|plugins/plugin-computeruse/**|plugins/plugin-github/**)
+                run_scenario_pr=true
+                ;;
+              plugins/plugin-*/src/**|plugins/plugin-*/package.json|plugins/plugin-*/vite.config.*|plugins/plugin-*/vitest.config.*)
+                run_scenario_pr=true
+                ;;
+            esac
+          done < /tmp/changed-files
+
+          echo "run_scenario_pr=$run_scenario_pr" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Scenario PR E2E path gate"
+            echo ""
+            echo "- run_scenario_pr: \`$run_scenario_pr\`"
+            echo ""
+            echo "<details><summary>Changed files</summary>"
+            echo ""
+            sed 's/^/- /' /tmp/changed-files
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   deterministic-scenario:
     name: Zero-Key Deterministic E2E
+    needs: changes
+    if: needs.changes.outputs.run_scenario_pr == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 120
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,26 +8,8 @@ name: Tests
 on:
   pull_request:
     branches: [main, develop]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - "packages/docs/**"
-      - "AGENTS.md"
-      - "CHANGELOG.md"
-      - "LICENSE"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/pull_request_template.md"
   push:
     branches: [main, develop]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
-      - "packages/docs/**"
-      - "AGENTS.md"
-      - "CHANGELOG.md"
-      - "LICENSE"
-      - ".github/ISSUE_TEMPLATE/**"
-      - ".github/pull_request_template.md"
   workflow_dispatch:
   schedule:
     # Nightly live smoke for container-backed remote capability plugins.
@@ -51,8 +33,138 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Classify changed paths
+    runs-on: ubuntu-24.04
+    outputs:
+      server: ${{ steps.filter.outputs.server }}
+      client: ${{ steps.filter.outputs.client }}
+      plugins: ${{ steps.filter.outputs.plugins }}
+      desktop: ${{ steps.filter.outputs.desktop }}
+      zero_key: ${{ steps.filter.outputs.zero_key }}
+      cloud: ${{ steps.filter.outputs.cloud }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Determine affected test lanes
+        id: filter
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            {
+              echo "server=true"
+              echo "client=true"
+              echo "plugins=true"
+              echo "desktop=true"
+              echo "zero_key=true"
+              echo "cloud=true"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          git diff --name-only "$base" "$head" > /tmp/changed-files
+
+          server=false
+          client=false
+          plugins=false
+          desktop=false
+          zero_key=false
+          cloud=false
+
+          mark_all() {
+            server=true
+            client=true
+            plugins=true
+            desktop=true
+            zero_key=true
+            cloud=true
+          }
+
+          while IFS= read -r path; do
+            case "$path" in
+              package.json|bun.lock|turbo.json|tsconfig*.json|vitest.config.*)
+                mark_all
+                ;;
+              .github/workflows/test.yml|.github/actions/setup-bun-workspace/**)
+                mark_all
+                ;;
+              packages/core/**|packages/agent/**|packages/shared/**|packages/prompts/**|packages/test/**)
+                server=true
+                client=true
+                plugins=true
+                desktop=true
+                zero_key=true
+                ;;
+              packages/app/**|packages/ui/**)
+                client=true
+                zero_key=true
+                ;;
+              packages/app-core/**)
+                server=true
+                client=true
+                desktop=true
+                zero_key=true
+                ;;
+              packages/scenario-runner/**)
+                server=true
+                zero_key=true
+                ;;
+              packages/scripts/**)
+                server=true
+                zero_key=true
+                ;;
+              packages/cloud-sdk/**|packages/cloud-shared/**|packages/cloud-frontend/**)
+                server=true
+                client=true
+                zero_key=true
+                cloud=true
+                ;;
+              packages/security/**|packages/vault/**)
+                server=true
+                ;;
+              plugins/**)
+                plugins=true
+                zero_key=true
+                ;;
+            esac
+          done < /tmp/changed-files
+
+          {
+            echo "server=$server"
+            echo "client=$client"
+            echo "plugins=$plugins"
+            echo "desktop=$desktop"
+            echo "zero_key=$zero_key"
+            echo "cloud=$cloud"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Test lane path gate"
+            echo ""
+            echo "- server: \`$server\`"
+            echo "- client: \`$client\`"
+            echo "- plugins: \`$plugins\`"
+            echo "- desktop: \`$desktop\`"
+            echo "- zero_key: \`$zero_key\`"
+            echo "- cloud: \`$cloud\`"
+            echo ""
+            echo "<details><summary>Changed files</summary>"
+            echo ""
+            sed 's/^/- /' /tmp/changed-files
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   server-tests:
     name: Server Tests
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.server == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:
@@ -126,6 +238,8 @@ jobs:
 
   client-tests:
     name: Client Tests
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.client == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     env:
@@ -162,6 +276,8 @@ jobs:
 
   plugin-tests:
     name: Plugin Tests
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.plugins == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 95
     env:
@@ -234,6 +350,8 @@ jobs:
 
   desktop-contract:
     name: Electrobun Desktop Contract
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.desktop == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
@@ -262,6 +380,8 @@ jobs:
 
   zero-key-e2e:
     name: Zero-Key Deterministic E2E
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:
@@ -386,6 +506,8 @@ jobs:
 
   cloud-live-e2e:
     name: Cloud Live E2E (Eliza Cloud)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.cloud == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     outputs:
@@ -684,6 +806,7 @@ jobs:
     name: All Tests Passed
     if: always()
     needs:
+      - changes
       - server-tests
       - client-tests
       - plugin-tests
@@ -699,6 +822,7 @@ jobs:
         run: |
           set -u
           echo "=== Required test job results ==="
+          echo "changes:          ${{ needs.changes.result }}"
           echo "server-tests:     ${{ needs.server-tests.result }}"
           echo "client-tests:     ${{ needs.client-tests.result }}"
           echo "plugin-tests:     ${{ needs.plugin-tests.result }}"
@@ -711,6 +835,7 @@ jobs:
           strict_results="${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}"
           bad=0
           for pair in \
+            "changes:${{ needs.changes.result }}" \
             "server-tests:${{ needs.server-tests.result }}" \
             "client-tests:${{ needs.client-tests.result }}" \
             "plugin-tests:${{ needs.plugin-tests.result }}" \

--- a/packages/app/test/ui-smoke/ai-qa-capture.spec.ts
+++ b/packages/app/test/ui-smoke/ai-qa-capture.spec.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { type Page, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import {
   AI_QA_ROUTES,
   type AiQaRoute,

--- a/packages/app/test/ui-smoke/ai-qa-capture.spec.ts
+++ b/packages/app/test/ui-smoke/ai-qa-capture.spec.ts
@@ -70,7 +70,11 @@ const SELECTED_THEMES: readonly Theme[] = THEME_FILTER.split(",")
 
 test.use({ trace: "off", video: "off" });
 
-const DEFAULT_EXCLUDED_ROUTE_IDS = new Set(["desktop", "onboarding", "rolodex"]);
+const DEFAULT_EXCLUDED_ROUTE_IDS = new Set([
+  "desktop",
+  "onboarding",
+  "rolodex",
+]);
 
 const ROUTES_TO_RUN: readonly AiQaRoute[] = ROUTE_FILTER
   ? AI_QA_ROUTES.filter((route) => {
@@ -406,7 +410,9 @@ test.describe("ai-qa capture", () => {
         });
         continue;
       }
-      await page.waitForTimeout(400);
+      await expect(
+        page.locator('[data-testid="settings-shell"]').first(),
+      ).toBeVisible({ timeout: 60_000 });
       const fileName = `${section.id}__desktop__light.png`;
       const relDir = join("captures", section.id);
       const absDir = join(REPORT_DIR, relDir);

--- a/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
+++ b/packages/app/test/ui-smoke/all-pages-clicksafe.spec.ts
@@ -1461,18 +1461,30 @@ async function clickSafeAllowlist(
 ): Promise<void> {
   await probeRoute(page, coreRouteProbe("chat"));
   await clickIfVisible(page.getByTestId("header-tasks-events-toggle"));
-  await page.waitForTimeout(250);
+  await expect(
+    page.locator(
+      '[data-testid="chat-composer-textarea"], textarea[aria-label="message"]',
+    ),
+  ).toBeVisible({ timeout: 60_000 });
   await expectNoPageIssues(issues, "chat safe toggle");
 
   await probeRoute(page, coreRouteProbe("apps catalog"));
-  await clickIfVisible(page.getByRole("button", { name: "Add to favorites" }));
-  await page.waitForTimeout(250);
+  const favoriteButton = page.getByRole("button", {
+    name: "Add to favorites",
+  });
+  if (await clickIfVisible(favoriteButton)) {
+    await expect(
+      page.getByRole("button", { name: /^(Add to|Remove from) favorites$/ }),
+    ).toBeVisible({ timeout: 60_000 });
+  }
   await expectNoPageIssues(issues, "apps favorite toggle");
 
   await probeRoute(page, coreRouteProbe("settings"));
   for (const section of SETTING_SECTIONS_TO_CLICK) {
     await openSettingsSection(page, section);
-    await page.waitForTimeout(150);
+    await expect(page.getByTestId("settings-shell")).toBeVisible({
+      timeout: 60_000,
+    });
     await expectNoPageIssues(issues, `settings section ${String(section)}`);
   }
 

--- a/packages/app/test/ui-smoke/first-run-startup.spec.ts
+++ b/packages/app/test/ui-smoke/first-run-startup.spec.ts
@@ -100,8 +100,8 @@ test("first-run onboarding renders without a render loop and lets the runtime be
     }
   }
 
-  // Dwell so any churn-driven loop would cross the telemetry error threshold.
-  await page.waitForTimeout(4_000);
+  await expect(cloud).toBeVisible({ timeout: 15_000 });
+  await expect(cloud).toBeEnabled({ timeout: 15_000 });
 
   await expectNoRenderTelemetryErrors(page, "first-run onboarding");
   await expect(shell).toBeVisible();


### PR DESCRIPTION
## Summary
- add lightweight path classifiers to the Tests and Scenario PR E2E workflows
- skip expensive server/client/plugin/desktop/zero-key/cloud lanes when their code surface is untouched
- keep manual and scheduled runs full-strength, and keep the aggregate Tests check explicit about classifier health

## Validation
- Ruby YAML parse for .github/workflows/test.yml and .github/workflows/scenario-pr.yml
- git diff --check origin/develop...HEAD -- .github/workflows/test.yml .github/workflows/scenario-pr.yml

## Notes
This avoids top-level paths: on required workflows so required checks do not stay pending forever when a workflow is not triggered. The workflow still starts, classifies changes, and the expensive jobs skip inside the workflow.