### PR TITLE
fix(plugin-codex-cli): make the codex planner work with the native-tools planner

### DIFF
--- a/plugins/plugin-codex-cli/__tests__/codex-backend.test.ts
+++ b/plugins/plugin-codex-cli/__tests__/codex-backend.test.ts
@@ -80,6 +80,34 @@ describe("tool translation", () => {
       strict: false,
     });
   });
+
+  it("normalizes strict tool schemas (codex backend 400s on partial required / missing additionalProperties)", () => {
+    const out = toOpenAITool({
+      name: "TASKS",
+      description: "spawn/list coding sub-agents",
+      strict: true,
+      parameters: {
+        type: "object",
+        properties: {
+          action: { type: "string", enum: ["create", "list"] },
+          prompt: { type: "string" },
+        },
+        required: ["action"],
+      },
+    });
+    expect(out.strict).toBe(true);
+    // required must list EVERY property, additionalProperties:false, and the
+    // originally-optional `prompt` is made nullable to keep its optional meaning.
+    expect(out.parameters).toEqual({
+      type: "object",
+      properties: {
+        action: { type: "string", enum: ["create", "list"] },
+        prompt: { type: ["string", "null"] },
+      },
+      required: ["action", "prompt"],
+      additionalProperties: false,
+    });
+  });
 });
 
 describe("CodexBackend", () => {
@@ -145,5 +173,30 @@ describe("CodexBackend", () => {
       tools: [{ type: "function", name: "lookup" }],
       tool_choice: { type: "function", name: "lookup" },
     });
+  });
+
+  it("never forwards temperature or max_output_tokens (the codex backend 400s on them)", async () => {
+    const bodies: unknown[] = [];
+    const backend = new CodexBackend({
+      authPath: "/tmp/auth.json",
+      jitterMaxMs: 0,
+      loadAuth: async () => auth,
+      fetchImpl: (async (_url: string | URL | Request, init?: RequestInit) => {
+        bodies.push(JSON.parse(String(init?.body)));
+        return sseResponse([
+          'event: response.output_text.delta\ndata: {"delta":"ok"}\n\n',
+          'event: response.completed\ndata: {"response":{"stop_reason":"stop","usage":{"input_tokens":1,"output_tokens":1}}}\n\n',
+        ]);
+      }) as typeof fetch,
+    });
+
+    // The runtime's planner/response-handler calls always pass maxTokens (and
+    // often temperature); the ChatGPT codex backend rejects both with a 400
+    // "Unsupported parameter", which previously emptied every codex turn.
+    await backend.generate({ prompt: "hi", temperature: 0.7, maxTokens: 2048 });
+
+    const body = bodies[0] as Record<string, unknown>;
+    expect(body).not.toHaveProperty("temperature");
+    expect(body).not.toHaveProperty("max_output_tokens");
   });
 });

--- a/plugins/plugin-codex-cli/index.ts
+++ b/plugins/plugin-codex-cli/index.ts
@@ -1,4 +1,9 @@
-import type { GenerateTextParams, IAgentRuntime, Plugin, TextStreamResult } from "@elizaos/core";
+import type {
+  GenerateTextParams,
+  IAgentRuntime,
+  Plugin,
+  TextStreamResult,
+} from "@elizaos/core";
 import { logger, ModelType } from "@elizaos/core";
 import {
   CodexBackend,
@@ -7,10 +12,13 @@ import {
 } from "./src/codex-backend";
 
 const TEXT_NANO_MODEL_TYPE = (ModelType.TEXT_NANO ?? "TEXT_NANO") as string;
-const TEXT_MEDIUM_MODEL_TYPE = (ModelType.TEXT_MEDIUM ?? "TEXT_MEDIUM") as string;
+const TEXT_MEDIUM_MODEL_TYPE = (ModelType.TEXT_MEDIUM ??
+  "TEXT_MEDIUM") as string;
 const TEXT_MEGA_MODEL_TYPE = (ModelType.TEXT_MEGA ?? "TEXT_MEGA") as string;
-const RESPONSE_HANDLER_MODEL_TYPE = (ModelType.RESPONSE_HANDLER ?? "RESPONSE_HANDLER") as string;
-const ACTION_PLANNER_MODEL_TYPE = (ModelType.ACTION_PLANNER ?? "ACTION_PLANNER") as string;
+const RESPONSE_HANDLER_MODEL_TYPE = (ModelType.RESPONSE_HANDLER ??
+  "RESPONSE_HANDLER") as string;
+const ACTION_PLANNER_MODEL_TYPE = (ModelType.ACTION_PLANNER ??
+  "ACTION_PLANNER") as string;
 
 const CODEX_SUPPORTED_MODELS = [
   "gpt-5",
@@ -52,7 +60,8 @@ function createBackend(runtime: IAgentRuntime): CodexBackend {
   if (existing) return existing;
 
   const jitterRaw = getSetting(runtime, "CODEX_JITTER_MS_MAX");
-  const jitterMaxMs = jitterRaw === undefined ? undefined : Number.parseInt(jitterRaw, 10);
+  const jitterMaxMs =
+    jitterRaw === undefined ? undefined : Number.parseInt(jitterRaw, 10);
   const backend = new CodexBackend({
     authPath: getSetting(runtime, "CODEX_AUTH_PATH"),
     baseUrl: getSetting(runtime, "CODEX_BASE_URL"),
@@ -66,9 +75,13 @@ function createBackend(runtime: IAgentRuntime): CodexBackend {
 
 function toTextReturn(
   params: GenerateTextParams,
-  result: CodexGenerateResult
+  result: CodexGenerateResult,
 ): string | TextResultWithNativeTools {
-  if (params.tools?.length || params.messages?.length || result.toolCalls.length > 0) {
+  if (
+    params.tools?.length ||
+    params.messages?.length ||
+    result.toolCalls.length > 0
+  ) {
     return {
       text: result.text,
       toolCalls: result.toolCalls,
@@ -81,7 +94,7 @@ function toTextReturn(
 
 function buildCodexGenerateParams(
   runtime: IAgentRuntime,
-  params: GenerateTextParams
+  params: GenerateTextParams,
 ): CodexGenerateParams {
   // Honor `responseSchema` natively. OpenAI-compatible Codex models accept
   // `response_format: { type: "json_schema", schema }` for guaranteed JSON
@@ -112,7 +125,10 @@ function buildCodexGenerateParams(
   };
 }
 
-function streamTextWithCodex(runtime: IAgentRuntime, params: GenerateTextParams): TextStreamResult {
+function streamTextWithCodex(
+  runtime: IAgentRuntime,
+  params: GenerateTextParams,
+): TextStreamResult {
   const queue: string[] = [];
   let notify: (() => void) | undefined;
   let done = false;
@@ -148,9 +164,23 @@ function streamTextWithCodex(runtime: IAgentRuntime, params: GenerateTextParams)
     }
   }
 
+  // The planner streams (the Discord message handler sets onStreamChunk), so
+  // ACTION_PLANNER/RESPONSE_HANDLER go through THIS path. The runtime collapses
+  // the stream and only preserves native tool calls when `toolCalls` is present
+  // on the returned object (it duck-types `"toolCalls" in streamRaw`). Without
+  // it, a tool-only response (empty text + native toolCalls) collapses to a bare
+  // empty string and the planner never sees the tool call — it replans until the
+  // required-tool cap and gives up. Mirror plugin-openai: attach `toolCalls`
+  // whenever the call is native, and stamp the model name for trajectory pricing.
+  const shouldReturnNativeTools = Boolean(
+    params.messages?.length || params.tools?.length || params.toolChoice,
+  );
   return {
     textStream: textStream(),
     text: resultPromise.then((result) => result.text),
+    ...(shouldReturnNativeTools
+      ? { toolCalls: resultPromise.then((result) => result.toolCalls) }
+      : {}),
     usage: resultPromise.then((result) =>
       result.usage
         ? {
@@ -158,49 +188,68 @@ function streamTextWithCodex(runtime: IAgentRuntime, params: GenerateTextParams)
             completionTokens: result.usage.outputTokens,
             totalTokens: result.usage.totalTokens,
           }
-        : undefined
+        : undefined,
     ),
     finishReason: resultPromise.then((result) => result.finishReason),
+    providerMetadata: { modelName: getCodexModel(runtime) },
   };
 }
 
 async function generateTextWithCodex(
   runtime: IAgentRuntime,
   params: GenerateTextParams,
-  modelType: string
+  modelType: string,
 ): Promise<string | TextResultWithNativeTools | TextStreamResult> {
   const model = getCodexModel(runtime);
   logger.debug(`[codex-cli] Using ${modelType} model: ${model}`);
   if (params.stream) return streamTextWithCodex(runtime, params);
-  const result = await createBackend(runtime).generate(buildCodexGenerateParams(runtime, params));
+  const result = await createBackend(runtime).generate(
+    buildCodexGenerateParams(runtime, params),
+  );
   return toTextReturn(params, result);
 }
 
 const codexModels = {
-  [ModelType.TEXT_SMALL]: (runtime: IAgentRuntime, params: GenerateTextParams) =>
-    generateTextWithCodex(runtime, params, ModelType.TEXT_SMALL),
-  [TEXT_NANO_MODEL_TYPE]: (runtime: IAgentRuntime, params: GenerateTextParams) =>
-    generateTextWithCodex(runtime, params, TEXT_NANO_MODEL_TYPE),
-  [TEXT_MEDIUM_MODEL_TYPE]: (runtime: IAgentRuntime, params: GenerateTextParams) =>
-    generateTextWithCodex(runtime, params, TEXT_MEDIUM_MODEL_TYPE),
-  [ModelType.TEXT_LARGE]: (runtime: IAgentRuntime, params: GenerateTextParams) =>
-    generateTextWithCodex(runtime, params, ModelType.TEXT_LARGE),
-  [TEXT_MEGA_MODEL_TYPE]: (runtime: IAgentRuntime, params: GenerateTextParams) =>
-    generateTextWithCodex(runtime, params, TEXT_MEGA_MODEL_TYPE),
-  [RESPONSE_HANDLER_MODEL_TYPE]: (runtime: IAgentRuntime, params: GenerateTextParams) =>
-    generateTextWithCodex(runtime, params, RESPONSE_HANDLER_MODEL_TYPE),
-  [ACTION_PLANNER_MODEL_TYPE]: (runtime: IAgentRuntime, params: GenerateTextParams) =>
-    generateTextWithCodex(runtime, params, ACTION_PLANNER_MODEL_TYPE),
+  [ModelType.TEXT_SMALL]: (
+    runtime: IAgentRuntime,
+    params: GenerateTextParams,
+  ) => generateTextWithCodex(runtime, params, ModelType.TEXT_SMALL),
+  [TEXT_NANO_MODEL_TYPE]: (
+    runtime: IAgentRuntime,
+    params: GenerateTextParams,
+  ) => generateTextWithCodex(runtime, params, TEXT_NANO_MODEL_TYPE),
+  [TEXT_MEDIUM_MODEL_TYPE]: (
+    runtime: IAgentRuntime,
+    params: GenerateTextParams,
+  ) => generateTextWithCodex(runtime, params, TEXT_MEDIUM_MODEL_TYPE),
+  [ModelType.TEXT_LARGE]: (
+    runtime: IAgentRuntime,
+    params: GenerateTextParams,
+  ) => generateTextWithCodex(runtime, params, ModelType.TEXT_LARGE),
+  [TEXT_MEGA_MODEL_TYPE]: (
+    runtime: IAgentRuntime,
+    params: GenerateTextParams,
+  ) => generateTextWithCodex(runtime, params, TEXT_MEGA_MODEL_TYPE),
+  [RESPONSE_HANDLER_MODEL_TYPE]: (
+    runtime: IAgentRuntime,
+    params: GenerateTextParams,
+  ) => generateTextWithCodex(runtime, params, RESPONSE_HANDLER_MODEL_TYPE),
+  [ACTION_PLANNER_MODEL_TYPE]: (
+    runtime: IAgentRuntime,
+    params: GenerateTextParams,
+  ) => generateTextWithCodex(runtime, params, ACTION_PLANNER_MODEL_TYPE),
 } as Plugin["models"];
 
 export const codexCliPlugin: Plugin = {
   name: "codex-cli",
-  description: "ChatGPT Codex model provider using the codex CLI OAuth token cache",
+  description:
+    "ChatGPT Codex model provider using the codex CLI OAuth token cache",
   autoEnable: {
     // No env-key auto-enable; activated when an auth profile selects codex-cli
     // as its provider (e.g. via subscription onboarding).
     shouldEnable: (_env, config) => {
-      const auth = (config as { auth?: { profiles?: Record<string, unknown> } }).auth;
+      const auth = (config as { auth?: { profiles?: Record<string, unknown> } })
+        .auth;
       const profiles = auth?.profiles;
       if (!profiles || typeof profiles !== "object") return false;
       return Object.values(profiles).some((profile) => {
@@ -217,7 +266,9 @@ export const codexCliPlugin: Plugin = {
     CODEX_ORIGINATOR: readEnv("CODEX_ORIGINATOR") ?? null,
   },
   async init(): Promise<void> {
-    logger.info(`[codex-cli] initialized. Supported models: ${CODEX_SUPPORTED_MODELS.join(", ")}`);
+    logger.info(
+      `[codex-cli] initialized. Supported models: ${CODEX_SUPPORTED_MODELS.join(", ")}`,
+    );
   },
   models: codexModels,
 };

--- a/plugins/plugin-codex-cli/src/codex-backend.ts
+++ b/plugins/plugin-codex-cli/src/codex-backend.ts
@@ -74,8 +74,9 @@ interface CodexResponseBody {
   tools?: OpenAITool[];
   tool_choice?: "auto" | "none" | "required" | { type: "function"; name: string };
   text?: { format: { type: "json_object" } };
-  temperature?: number;
-  max_output_tokens?: number;
+  // NB: the ChatGPT codex backend rejects `temperature` and `max_output_tokens`
+  // (gpt-5.x reasoning models) with 400 "Unsupported parameter" — never include
+  // them in the request body.
 }
 
 const DEFAULT_MODEL = "gpt-5.5";
@@ -147,8 +148,12 @@ export class CodexBackend {
     if (tools.length > 0) body.tools = tools;
     const toolChoice = toCodexToolChoice(params.toolChoice);
     if (toolChoice !== undefined) body.tool_choice = toolChoice;
-    if (params.temperature !== undefined) body.temperature = params.temperature;
-    if (params.maxTokens !== undefined) body.max_output_tokens = params.maxTokens;
+    // The ChatGPT codex backend (gpt-5.x reasoning models on the Responses API)
+    // rejects `temperature` and `max_output_tokens` with a 400 "Unsupported
+    // parameter" — reasoning models honor neither, and the official codex CLI
+    // never sends them. The runtime's planner/response-handler calls always pass
+    // maxTokens (and often temperature), so forwarding them 400'd every codex
+    // turn → empty result → no reply. Never send them to the codex backend.
     if (isJsonResponse(params.responseFormat)) body.text = { format: { type: "json_object" } };
 
     let auth = await this.loadAuth(this.authPath);

--- a/plugins/plugin-codex-cli/src/tool-format-openai.ts
+++ b/plugins/plugin-codex-cli/src/tool-format-openai.ts
@@ -8,13 +8,73 @@ export interface OpenAITool {
   strict?: boolean;
 }
 
+type JsonSchema = Record<string, unknown>;
+
+/**
+ * The ChatGPT codex backend enforces OpenAI strict-function-schema rules whenever
+ * a tool is marked `strict: true`: every object schema MUST set
+ * `additionalProperties: false` and list ALL of its `properties` keys in
+ * `required`. elizaOS action tools (core's to-tool.ts) set `strict: true` but
+ * author schemas with partial `required` and no `additionalProperties`, so the
+ * backend rejects them with 400 "Invalid schema for function '<name>'". Other
+ * providers tolerate this; the codex backend does not.
+ *
+ * `makeStrictSchema` normalizes a schema to be strict-compliant: `required`
+ * becomes every property key, `additionalProperties` becomes false, and keys that
+ * were NOT originally required are made nullable (a `null` union member) so the
+ * now-required keys keep their optional semantics — the model may emit `null`
+ * instead of being forced to invent a value.
+ */
+function makeNullable(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object" || Array.isArray(schema)) return schema;
+  const s = schema as JsonSchema;
+  if (Array.isArray(s.type)) {
+    return (s.type as unknown[]).includes("null")
+      ? s
+      : { ...s, type: [...(s.type as unknown[]), "null"] };
+  }
+  if (typeof s.type === "string") return { ...s, type: [s.type, "null"] };
+  return s;
+}
+
+function makeStrictSchema(schema: unknown): unknown {
+  if (!schema || typeof schema !== "object") return schema;
+  if (Array.isArray(schema)) return schema.map(makeStrictSchema);
+  const out = { ...(schema as JsonSchema) };
+  if (out.type === "object" && out.properties && typeof out.properties === "object") {
+    const props = out.properties as JsonSchema;
+    const keys = Object.keys(props);
+    const origRequired = new Set(
+      Array.isArray(out.required) ? (out.required as string[]) : [],
+    );
+    const next: JsonSchema = {};
+    for (const key of keys) {
+      let prop = makeStrictSchema(props[key]);
+      if (!origRequired.has(key)) prop = makeNullable(prop);
+      next[key] = prop;
+    }
+    out.properties = next;
+    out.required = keys;
+    out.additionalProperties = false;
+  }
+  if (out.items) out.items = makeStrictSchema(out.items);
+  for (const key of ["anyOf", "oneOf", "allOf"] as const) {
+    if (Array.isArray(out[key])) out[key] = (out[key] as unknown[]).map(makeStrictSchema);
+  }
+  return out;
+}
+
 export function toOpenAITool(tool: ToolDefinition): OpenAITool {
+  const strict = tool.strict ?? false;
+  const parameters = (tool.parameters ?? { type: "object", properties: {} }) as object;
   return {
     type: "function",
     name: tool.name,
     description: tool.description ?? "",
-    parameters: (tool.parameters ?? { type: "object", properties: {} }) as object,
-    strict: tool.strict ?? false,
+    // Only strict tools need normalization; the backend accepts loose schemas
+    // verbatim when strict is false.
+    parameters: strict ? (makeStrictSchema(parameters) as object) : parameters,
+    strict,
   };
 }
 


### PR DESCRIPTION
The ChatGPT Codex backend provider (`@elizaos/plugin-codex-cli`) couldn't serve the V5 native-tools planner. Three independent gaps, all fixed here:

**1. Unsupported request params.** The codex backend (gpt-5.x reasoning models on the Responses API) rejects `temperature` and `max_output_tokens` with `400 Unsupported parameter`. The planner always passes `maxTokens` (and often `temperature`), so every codex planner turn 400'd. Dropped both from the request body.

**2. Strict tool schemas.** Core's `to-tool.ts` marks action tools `strict: true`, and the codex backend enforces OpenAI strict-function-schema rules (every object must set `additionalProperties: false` and list ALL `properties` in `required`). elizaOS schemas don't, so the backend 400'd on e.g. `TASKS`. Added `makeStrictSchema` to normalize when `strict` is set — `required` = all keys, `additionalProperties: false`, and originally-optional keys made nullable so their optional semantics are preserved.

**3. Streaming tool calls dropped.** The planner streams (the message handler sets `onStreamChunk`), so it goes through `streamTextWithCodex`, which returned `{ textStream, text, usage, finishReason }` but omitted `toolCalls`. The runtime only preserves native tool calls when `toolCalls` is present on the stream result (`"toolCalls" in streamRaw`), so a tool-only response (empty text + native toolCalls) collapsed to an empty string and the planner logged `no_tool_calls` and replanned to the cap. Now attaches `toolCalls` (+ `providerMetadata` for stage pricing) to the stream result, mirroring `plugin-openai`.

**Tests:** +2 regression tests (param drop; strict-schema normalization). Full plugin suite passes (7/7). Verified live end-to-end — the codex planner now spawns coding sub-agents and a built static page deploys + serves HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)