### PR TITLE
fix(plugin-agent-orchestrator): route app-build spawns on the originating user request, not the planner's terse task

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/originating-request-routing.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/originating-request-routing.test.ts
@@ -1,0 +1,354 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { IAgentRuntime, Memory, State } from "@elizaos/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveOriginatingRequestText } from "../../src/actions/common.js";
+import { resolveSpawnWorkdir } from "../../src/services/task-agent-routing.js";
+
+// Regression coverage for the whole-stack-claude workdir-route miss: when the
+// planner dispatches TASKS_SPAWN_AGENT with a terse `task` and an
+// envelope-wrapped / empty `content.text`, route matching used to run against
+// the planner's wording and miss the configured route — silently falling
+// builds back to the default ACP workspace instead of the agent-home apps dir.
+//
+// The fix makes route matching planner-independent by recovering the genuine
+// originating user request from sources that are GUARANTEED populated
+// synchronously at action time — no DB round-trip, no persistence race:
+//   1. `content.currentMessageText` (the raw request connectors stamp);
+//   2. the state-composed conversation window
+//      (`state.data.providers.RECENT_MESSAGES.data.recentMessages`);
+//   3. `getMemories` only as a last resort.
+// These tests fail against the old code (which passed only the action's
+// `content.text` via the narrow `messageText()` reader).
+
+const AGENT_ID = "agent-xyz";
+
+function msg(overrides: Partial<Memory> = {}): Memory {
+  return {
+    id: "m1",
+    entityId: "user-1",
+    agentId: AGENT_ID,
+    roomId: "room-1",
+    content: { text: "" },
+    createdAt: Date.now(),
+    ...overrides,
+  } as never;
+}
+
+function stateWithRecentMessages(messages: Memory[]): State {
+  return {
+    values: {},
+    text: "",
+    data: {
+      providers: {
+        RECENT_MESSAGES: { data: { recentMessages: messages } },
+      },
+    },
+  } as never;
+}
+
+function bareRuntime(): IAgentRuntime {
+  return {
+    agentId: AGENT_ID,
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  } as never;
+}
+
+function runtimeWithRoomMessages(messages: Memory[]): IAgentRuntime {
+  return {
+    agentId: AGENT_ID,
+    getMemories: vi.fn(async () => messages),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  } as never;
+}
+
+describe("resolveOriginatingRequestText", () => {
+  it("recovers the raw request from content.currentMessageText when content.text is empty", async () => {
+    // Connector stamped the raw human message into currentMessageText; the
+    // envelope/planner left content.text empty. No state, no DB needed.
+    const action = msg({
+      content: {
+        text: "",
+        currentMessageText:
+          "build me a small markdown-to-html previewer web page",
+      },
+    });
+
+    const resolved = await resolveOriginatingRequestText(bareRuntime(), action);
+
+    expect(resolved).toContain("web page");
+    expect(resolved).toContain("markdown-to-html previewer");
+  });
+
+  it("recovers the request from the state-composed conversation window", async () => {
+    // The action message is a synthetic re-plan trigger with no usable text,
+    // but the user's original request is in the state-composed dialogue.
+    const action = msg({ content: { text: "" } });
+    const state = stateWithRecentMessages([
+      msg({
+        id: "m-user",
+        entityId: "user-1",
+        content: {
+          text: "build me a small markdown-to-html previewer web page",
+        },
+      }),
+      msg({
+        id: "m-agent",
+        entityId: AGENT_ID,
+        content: { text: "On it — spawning a coding agent now." },
+      }),
+    ]);
+
+    const resolved = await resolveOriginatingRequestText(
+      bareRuntime(),
+      action,
+      state,
+    );
+
+    expect(resolved).toContain("web page");
+    expect(resolved).toContain("markdown-to-html previewer");
+  });
+
+  it("skips the agent's own messages in the state window and keeps the human request", async () => {
+    const action = msg({ content: { text: "create a previewer" } });
+    const state = stateWithRecentMessages([
+      msg({
+        id: "m-user",
+        entityId: "user-1",
+        content: { text: "make me a static site for my bakery" },
+      }),
+      msg({
+        id: "m-agent",
+        entityId: AGENT_ID,
+        content: { text: "Sure, building a web page for you." },
+      }),
+    ]);
+
+    const resolved = await resolveOriginatingRequestText(
+      bareRuntime(),
+      action,
+      state,
+    );
+
+    // The agent message also said "web page", but we must route on the human's
+    // actual wording — assert the human request is present and unioned with the
+    // action's own (terse) text.
+    expect(resolved).toContain("static site for my bakery");
+    expect(resolved).toContain("create a previewer");
+  });
+
+  it("falls back to getMemories only when state has no usable request", async () => {
+    const action = msg({ content: { text: "" } });
+    const runtime = runtimeWithRoomMessages([
+      msg({
+        id: "m-agent",
+        entityId: AGENT_ID,
+        content: { text: "On it." },
+      }),
+      msg({
+        id: "m-user",
+        entityId: "user-1",
+        content: { text: "build me a stopwatch web page" },
+      }),
+    ]);
+
+    const resolved = await resolveOriginatingRequestText(
+      runtime,
+      action,
+      stateWithRecentMessages([]),
+    );
+
+    expect(resolved).toContain("stopwatch web page");
+  });
+
+  it("prefers the synchronous state source over getMemories", async () => {
+    const action = msg({ content: { text: "" } });
+    const getMemories = vi.fn(async () => [
+      msg({
+        id: "m-stale",
+        entityId: "user-1",
+        content: { text: "an older unrelated request" },
+      }),
+    ]);
+    const runtime = {
+      agentId: AGENT_ID,
+      getMemories,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    } as never as IAgentRuntime;
+    const state = stateWithRecentMessages([
+      msg({
+        id: "m-user",
+        entityId: "user-1",
+        content: { text: "build me a bmi calculator web page" },
+      }),
+    ]);
+
+    const resolved = await resolveOriginatingRequestText(
+      runtime,
+      action,
+      state,
+    );
+
+    expect(resolved).toContain("bmi calculator web page");
+    // The synchronous state source short-circuits before the DB read.
+    expect(getMemories).not.toHaveBeenCalled();
+  });
+
+  it("falls back to messageText when no source carries the request", async () => {
+    const action = msg({ content: { text: "build a static site" } });
+
+    const resolved = await resolveOriginatingRequestText(bareRuntime(), action);
+
+    expect(resolved).toBe("build a static site");
+  });
+
+  it("falls back to messageText when getMemories throws", async () => {
+    const action = msg({ content: { text: "build a static site" } });
+    const runtime = {
+      agentId: AGENT_ID,
+      getMemories: vi.fn(async () => {
+        throw new Error("db down");
+      }),
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+    } as never;
+
+    const resolved = await resolveOriginatingRequestText(runtime, action);
+
+    expect(resolved).toBe("build a static site");
+  });
+});
+
+describe("route matching uses the originating request, not the planner task", () => {
+  const ENV_KEY = "TASK_AGENT_WORKDIR_ROUTES";
+  let tmpRoot: string;
+  let appsDir: string;
+  let originalRoutes: string | undefined;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "originating-route-"));
+    appsDir = path.join(tmpRoot, "agent-home");
+    fs.mkdirSync(appsDir, { recursive: true });
+    originalRoutes = process.env[ENV_KEY];
+    process.env[ENV_KEY] = JSON.stringify([
+      {
+        id: "agent-home-local-apps",
+        workdir: appsDir,
+        matchAny: ["web page", "webpage", "static site", "landing page"],
+        excludeAny: ["production", "database", "auth"],
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    if (originalRoutes === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = originalRoutes;
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("FAILS-ON-OLD: terse planner task + empty content.text misses, recovered request matches", async () => {
+    // Planner emitted a terse task that drops the "web page" keyword and an
+    // empty content.text; the real user request lives on currentMessageText.
+    const plannerTask = "create a markdown-to-html previewer";
+    const action = msg({
+      content: {
+        text: "",
+        currentMessageText:
+          "build me a small markdown-to-html previewer web page",
+      },
+    });
+
+    // OLD behavior: resolveSpawnWorkdir(runtime, plannerTask, content.text, ...)
+    // where content.text === "" → no keyword → fallback (no route).
+    const oldUserRequest = (action.content as { text: string }).text;
+    const oldResult = resolveSpawnWorkdir(
+      bareRuntime(),
+      plannerTask,
+      oldUserRequest,
+      undefined,
+    );
+    expect(oldResult.route).toBeUndefined();
+
+    // NEW behavior: feed the recovered originating request as userRequest.
+    const routingRequest = await resolveOriginatingRequestText(
+      bareRuntime(),
+      action,
+    );
+    const newResult = resolveSpawnWorkdir(
+      bareRuntime(),
+      plannerTask,
+      routingRequest,
+      undefined,
+    );
+    expect(newResult.route?.id).toBe("agent-home-local-apps");
+    expect(newResult.workdir).toBe(appsDir);
+  });
+
+  it("recovers from the state window when the action message has no text at all", async () => {
+    const plannerTask = "create a previewer";
+    const action = msg({ content: { text: "" } });
+    const state = stateWithRecentMessages([
+      msg({
+        id: "m-user",
+        entityId: "user-1",
+        content: { text: "build me a markdown previewer web page" },
+      }),
+    ]);
+
+    const routingRequest = await resolveOriginatingRequestText(
+      bareRuntime(),
+      action,
+      state,
+    );
+    const result = resolveSpawnWorkdir(
+      bareRuntime(),
+      plannerTask,
+      routingRequest,
+      undefined,
+    );
+    expect(result.route?.id).toBe("agent-home-local-apps");
+    expect(result.workdir).toBe(appsDir);
+  });
+
+  it("does not regress the verbose-planner path (request text already carries the keyword)", async () => {
+    const verboseTask = "build me a stopwatch web page with start/stop";
+    const action = msg({ content: { text: verboseTask } });
+
+    const routingRequest = await resolveOriginatingRequestText(
+      bareRuntime(),
+      action,
+    );
+    const result = resolveSpawnWorkdir(
+      bareRuntime(),
+      verboseTask,
+      routingRequest,
+      undefined,
+    );
+    expect(result.route?.id).toBe("agent-home-local-apps");
+  });
+
+  it("does not invent a route when neither task nor request carries a keyword", async () => {
+    const plannerTask = "do the unremarkable thing";
+    const action = msg({ content: { text: "" } });
+    const state = stateWithRecentMessages([
+      msg({
+        id: "m-user",
+        entityId: "user-1",
+        content: { text: "fix a typo in my notes" },
+      }),
+    ]);
+
+    const routingRequest = await resolveOriginatingRequestText(
+      bareRuntime(),
+      action,
+      state,
+    );
+    const result = resolveSpawnWorkdir(
+      bareRuntime(),
+      plannerTask,
+      routingRequest,
+      undefined,
+    );
+    expect(result.route).toBeUndefined();
+  });
+});

--- a/plugins/plugin-agent-orchestrator/src/actions/common.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/common.ts
@@ -5,6 +5,7 @@ import type {
   Memory,
   State,
   StateValue,
+  UUID,
 } from "@elizaos/core";
 import type {
   AcpJsonRpcMessage,
@@ -135,6 +136,134 @@ export function messageText(message: Memory): string {
   if (typeof message.content === "string") return message.content;
   const content = contentRecord(message);
   return typeof content.text === "string" ? content.text : "";
+}
+
+/**
+ * Read the genuine user request text off a message.
+ *
+ * Connectors stamp the raw human message into `content.currentMessageText`
+ * (the discord connector does this via `extraContent.currentMessageText`)
+ * while `content.text` may be an envelope-wrapped header, a planner
+ * rephrasing, or empty. The canonical core reader (`getUserMessageText`)
+ * prefers `currentMessageText`; we inline the same precedence here to avoid a
+ * cross-package barrel/build dependency. The orchestrator's narrow
+ * `messageText()` only reads `content.text`, which is exactly why the terse
+ * claude path dropped the route keyword.
+ */
+function userRequestFromMessage(message: Memory): string {
+  const content = contentRecord(message);
+  const raw =
+    typeof content.currentMessageText === "string" &&
+    content.currentMessageText.trim().length > 0
+      ? content.currentMessageText
+      : typeof content.text === "string"
+        ? content.text
+        : "";
+  return raw.trim();
+}
+
+/**
+ * The actual conversation `Memory[]` the runtime composed into state before
+ * this action ran. `recentMessagesProvider` writes it to
+ * `state.data.providers.RECENT_MESSAGES.data.recentMessages`; this is the
+ * vetted access pattern (see core plugin-manager `relevance.ts`). Unlike a
+ * fresh `getMemories` read, this is already populated synchronously at action
+ * time, so it does not hit the "current message not yet persisted" race.
+ */
+function recentMessagesFromState(state: State | undefined): Memory[] {
+  const messages = (
+    state?.data as
+      | {
+          providers?: {
+            RECENT_MESSAGES?: { data?: { recentMessages?: unknown } };
+          };
+        }
+      | undefined
+  )?.providers?.RECENT_MESSAGES?.data?.recentMessages;
+  return Array.isArray(messages) ? (messages as Memory[]) : [];
+}
+
+/**
+ * Resolve the genuine originating user request for workdir-route matching.
+ *
+ * Workdir routes (`TASK_AGENT_WORKDIR_ROUTES`) match keyword phrases like
+ * "web page" against `${userRequest}\n${task}`. Feeding only the planner's
+ * `task` argument is unreliable: with a verbose planner (gpt-oss /
+ * TASKS_CREATE) the user's wording survives, but with a terser planner
+ * (claude / TASKS_SPAWN_AGENT) the action arrives with the planner's
+ * rephrasing — and the orchestrator's `messageText()` only reads
+ * `content.text`, which may be envelope-wrapped or empty — dropping the route
+ * keyword and silently falling the spawn back to the default ACP workspace.
+ * Builds then land in the wrong directory and never get hosted.
+ *
+ * The fix is planner-independent and reads only sources that are guaranteed
+ * populated synchronously at action time (no DB round-trip, no persistence
+ * race — the failure mode of the earlier `getMemories`-first attempt):
+ *   1. the message's own `content.currentMessageText` (the raw human request
+ *      the connector stamped), via `userRequestFromMessage`;
+ *   2. the newest non-agent message in the state-composed conversation window
+ *      (`state.data.providers.RECENT_MESSAGES.data.recentMessages`) — covers
+ *      the case where the action message is a synthetic re-plan trigger but
+ *      the user's original request is still in the dialogue;
+ *   3. a bounded `getMemories` read, kept ONLY as a last resort.
+ *
+ * Fail-open: every source is optional and the result is unioned with the
+ * action's own text, so routing never regresses below today's behavior.
+ */
+export async function resolveOriginatingRequestText(
+  runtime: IAgentRuntime,
+  message: Memory,
+  state?: State,
+  opts: { timeoutMs?: number; scanLimit?: number } = {},
+): Promise<string> {
+  // Primary: the raw request carried on the current message itself.
+  const direct = userRequestFromMessage(message);
+
+  // Secondary: the newest genuine (non-agent) request already in the
+  // state-composed conversation window. Synchronous; no persistence race.
+  const fromState = recentMessagesFromState(state)
+    .filter((m) => m.entityId && m.entityId !== runtime.agentId)
+    .map(userRequestFromMessage)
+    .filter((text) => text.length > 0 && text !== direct)
+    .at(-1);
+  if (fromState) {
+    return direct ? `${fromState}\n${direct}` : fromState;
+  }
+
+  // Last resort: a bounded room read. Demoted below the synchronous sources
+  // because at spawn time the CURRENT user message is mid-processing and not
+  // yet persisted, so this can only return older/stale messages.
+  const roomId = message.roomId;
+  if (typeof runtime.getMemories !== "function" || !roomId) {
+    return direct;
+  }
+  const timeoutMs = opts.timeoutMs ?? 2_000;
+  const scanLimit = opts.scanLimit ?? 8;
+  let recent: Memory[] = [];
+  try {
+    recent = await Promise.race([
+      runtime.getMemories({
+        roomId: roomId as UUID,
+        tableName: "messages",
+        count: scanLimit,
+        unique: false,
+        includeEmbedding: false,
+      }),
+      new Promise<Memory[]>((resolve) =>
+        setTimeout(() => resolve([]), timeoutMs),
+      ),
+    ]);
+  } catch {
+    return direct;
+  }
+  const latestUserText = recent
+    .filter((m) => m.entityId && m.entityId !== runtime.agentId)
+    .map(userRequestFromMessage)
+    .find((text) => text.length > 0);
+  if (!latestUserText || latestUserText === direct) {
+    return direct;
+  }
+  return direct ? `${latestUserText}\n${direct}` : latestUserText;
 }
 
 export function hasExplicitPayload(message: Memory, fields: string[]): boolean {

--- a/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
+++ b/plugins/plugin-agent-orchestrator/src/actions/tasks.ts
@@ -76,6 +76,7 @@ import {
   parseApproval,
   pickBoolean,
   pickString,
+  resolveOriginatingRequestText,
   resolveSession,
   setCurrentSession,
   setCurrentSessions,
@@ -495,6 +496,13 @@ async function runCreate(
   }
 
   const text = messageText(message);
+  // Genuine user request for workdir-route matching — see runSpawnAgent and
+  // resolveOriginatingRequestText. Keeps routing planner-independent.
+  const routingRequest = await resolveOriginatingRequestText(
+    runtime,
+    message,
+    state,
+  );
   const tasks = taskParts(params, content, text);
   if (tasks.length > MAX_CONCURRENT_AGENTS) {
     const msg = `Too many task agents requested (${tasks.length}); maximum is ${MAX_CONCURRENT_AGENTS}.`;
@@ -546,7 +554,7 @@ async function runCreate(
       const { workdir: sessionWorkdir, route } = resolveSpawnWorkdir(
         runtime,
         task,
-        text,
+        routingRequest,
         explicitWorkdir,
         { lockWorkdir: pickBoolean(params, content, "lockWorkdir") === true },
       );
@@ -750,6 +758,17 @@ async function runSpawnAgent(
   try {
     const text = messageText(message);
     const task = pickString(params, content, "task") ?? text;
+    // Route matching must see the genuine user request, not the planner's
+    // (possibly terse) rephrasing or an empty content.text. Without this, a
+    // request like "build me a … web page" routes correctly under a verbose
+    // planner but falls back to the default ACP workspace under a terser one.
+    // `state` carries the runtime-composed conversation window, which holds
+    // the real request synchronously even when content.text is empty.
+    const routingRequest = await resolveOriginatingRequestText(
+      runtime,
+      message,
+      state,
+    );
     // Operator-pinned adapter (ELIZA_DEFAULT_AGENT_TYPE +
     // ELIZA_AGENT_SELECTION_STRATEGY=fixed) is a deployment policy and
     // wins over the planner's `agentType` choice. The planner only sees
@@ -775,7 +794,7 @@ async function runSpawnAgent(
     const { workdir, route } = resolveSpawnWorkdir(
       runtime,
       task,
-      text,
+      routingRequest,
       pickString(params, content, "workdir"),
       { lockWorkdir: pickBoolean(params, content, "lockWorkdir") === true },
     );


### PR DESCRIPTION
A terse planner can leave `content.text` empty at spawn time, so workdir-route matching saw no keywords and picked the wrong workdir (e.g. a build landed in a PR-work checkout instead of the apps dir). `resolveOriginatingRequestText` recovers the genuine user request from synchronously-available sources (currentMessageText, the state-composed conversation window) with a bounded `getMemories` fallback, and feeds it to routing in both `runCreate` and `runSpawnAgent`. +11 tests including a fail-on-old regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)