### PR TITLE
fix(core): don't demote a model-chosen coding delegation to a simple direct reply

### DIFF
--- a/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
+++ b/packages/core/src/runtime/__tests__/message-handler-bogus-candidates.test.ts
@@ -216,6 +216,48 @@ describe("messageHandlerFromFieldResult — bogus candidate actions", () => {
 		expect(handler.plan.contexts).toEqual(["simple"]);
 	});
 
+	it("force-plans a build ask when the model explicitly routes to a non-simple context AND names TASKS_SPAWN_AGENT, even if its ack is a full sentence", () => {
+		// Live regression (OAuth Claude RESPONSE_HANDLER bridge, trajectories
+		// tj-5f6bd3a2f72799 / tj-56f7b842ac8db6): for "build me a ... web page" the
+		// model emitted contexts:["general"] + candidateActionNames:["TASKS_SPAWN_AGENT"]
+		// — i.e. it deliberately routed to planning and named the spawn action —
+		// but its ack read as a complete sentence ("On it — spawning a coding agent
+		// to build the dice roller page."). The OLD complete-direct-reply override
+		// fired on the sentence shape and pulled this back to contexts:["simple"],
+		// requiresTool:false, so TASKS_SPAWN_AGENT never ran and nothing built.
+		// Terse-ack planners ("On it.") were unaffected, masking the bug as
+		// model-specific. The fix is structural: when the model itself committed to
+		// delegation (non-simple context it chose + a runnable spawn-class candidate
+		// it named), a verbose ack is still an ack — never a finished direct reply.
+		const handler = messageHandlerFromFieldResult(
+			{
+				shouldRespond: "RESPOND",
+				contexts: ["general"],
+				candidateActionNames: ["TASKS_SPAWN_AGENT"],
+				replyText:
+					"On it — spawning a coding agent to build the dice roller page.",
+				intents: ["build dice roller web page", "spawn coding sub-agent"],
+				facts: [],
+				addressedTo: [],
+			},
+			undefined,
+			{
+				actions: REAL_ACTIONS,
+				messageText: "build me a simple dice roller web page",
+			},
+		);
+
+		expect(handler.plan.simple).toBe(false);
+		expect(handler.plan.requiresTool).toBe(true);
+		expect(handler.plan.contexts).toEqual(["general"]);
+		expect(handler.plan.candidateActions).toEqual(["TASKS_SPAWN_AGENT"]);
+		// The ack passes through as the brief reply; the planner sends the grounded
+		// follow-up after the spawn.
+		expect(handler.plan.reply).toBe(
+			"On it — spawning a coding agent to build the dice roller page.",
+		);
+	});
+
 	it("still force-plans a genuine build ask when the model only acked", () => {
 		const handler = messageHandlerFromFieldResult(
 			{

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -3481,10 +3481,33 @@ export function messageHandlerFromFieldResult(
 		processMessage === "RESPOND" &&
 		looksLikeNonRefusalStage1HonestyViolation(replyTextRaw);
 	const requestedPlanningForRouting = requestedPlanning || forceHonestyPlanning;
+	// The model can explicitly commit to delegation: for a genuine coding-work
+	// request it routes to a non-simple context of its OWN choosing AND names a
+	// runnable coding-delegation / spawn-class action in its OWN candidate list
+	// (not the runtime backstop's inferred one). When it does, a verbose
+	// sentence-shaped ack ("On it — spawning a coding agent to build the page.")
+	// is still an ACK, not a finished answer — so the complete-direct-reply
+	// override must NOT pull it back to the simple path. Without this guard,
+	// planner-models that write fuller acks (e.g. the OAuth Claude bridge) trip
+	// looksLikeCompleteDirectReply and the sub-agent never spawns, while terse-ack
+	// models ("On it.") plan correctly. Keyed on the parsed plan shape, the action
+	// registry, and the same structural coding-work classifier used by the
+	// candidate backstop (which excludes creative-writing / explanation asks), so
+	// it is model-agnostic and regresses neither the direct-answer nor the
+	// poem-about-an-app path.
+	const modelCommittedToDelegation =
+		!preemptDirect &&
+		initialPlanningContexts.length > 0 &&
+		looksLikeCodingWorkRequest(currentMessageText) &&
+		modelProvidedRunnableDelegationCandidate(
+			rawCandidateActions,
+			runtimeContext?.actions ?? [],
+		);
 	const preferCompleteDirectReply =
 		!preemptDirect &&
 		requestedPlanning &&
 		!stage1HonestyViolation &&
+		!modelCommittedToDelegation &&
 		shouldPreferCompleteDirectReply({
 			replyText: replyTextRaw,
 			candidateActions: effectiveCandidateActions,
@@ -3697,6 +3720,29 @@ function shouldPreferCompleteDirectReply(args: {
 }): boolean {
 	if (!looksLikeCompleteDirectReply(args.replyText)) return false;
 	return hasOnlyWeakDirectReplyPlanningSignals(args);
+}
+
+// True when the MODEL itself named a runnable coding-delegation / spawn-class
+// action in its own candidate list. Resolves by registry tags
+// (CODING_DELEGATION_ACTION_TAGS) first, then the legacy name set — the same
+// resolution findCodingDelegationActionName uses — so a registered
+// TASKS_SPAWN_AGENT (or simile) counts and a bogus/unexposed name does not. Used
+// to detect that the model committed to delegation on purpose, so a verbose ack
+// is not mistaken for a finished direct reply.
+function modelProvidedRunnableDelegationCandidate(
+	candidateActions: readonly string[],
+	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
+): boolean {
+	if (candidateActions.length === 0) return false;
+	const delegationActionName = findCodingDelegationActionName(actions);
+	if (!delegationActionName) return false;
+	const wanted = new Set<string>([
+		normalizeActionIdentifier(delegationActionName),
+		...LEGACY_CODING_DELEGATION_ACTION_NAMES.map(normalizeActionIdentifier),
+	]);
+	return candidateActions.some((name) =>
+		wanted.has(normalizeActionIdentifier(name)),
+	);
 }
 
 function shouldPreferInlineCodeSnippetDirectReply(args: {


### PR DESCRIPTION
The message-handler complete-direct-reply override (`shouldPreferCompleteDirectReply`) pulled a turn back to `contexts=[simple]`/`requiresTool=false` whenever the stage-1 ack looked like a terse acknowledgement — even when the model had correctly chosen to delegate to a coding sub-agent. Models that write a full-sentence ack ("On it — spawning a coding agent to build the page.") instead of the terse whitelist ("on it.") got their valid `TASKS_SPAWN_AGENT` plan demoted to a plain reply, so no build happened. Adds a `modelCommittedToDelegation` guard that vetoes the demotion when the model produced a runnable delegation candidate for a coding-work request. +1 fail-on-old regression test; message-handler suite (38 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)