### PR TITLE
fix(plugin-agent-orchestrator): don't surface route-prefix or data-source URLs as the sub-agent deliverable

### DIFF
--- a/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
+++ b/plugins/plugin-agent-orchestrator/__tests__/unit/sub-agent-router.test.ts
@@ -1295,6 +1295,77 @@ describe("SubAgentRouter", () => {
       }
     });
 
+    it("does not surface route-prefix or data-source URLs as the deliverable for a non-build info-fetch", async () => {
+      // Live BTC regression (2026-06-13): a "what's BTC worth?" turn routed to
+      // the agent-home apps route. The spawn task carried the route's
+      // `--- URL Path Mapping ---` hint verbatim (so `initialTask`, the verify
+      // reference text, contained the bare `https://host/apps/` prefix) plus the
+      // CoinGecko data-source URL the sub-agent was told to fetch. Both probed
+      // 200, were promoted to `subAgentVerifiedUrls`, and the bare apps prefix
+      // was surfaced as the reply — clobbering the real answer. None of these
+      // URLs is a hosted-artifact PAGE the sub-agent built, so none may surface.
+      const appsPrefixPublic = "https://example.test/apps/";
+      const appsPrefixLocal = "http://127.0.0.1:6900/apps/";
+      const dataSource =
+        "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd";
+      // Everything the verifier could probe is reachable — the bug is purely
+      // that reachable != deliverable for these URLs.
+      const fetchMock = vi.fn(async () => {
+        return new Response("ok", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
+      });
+      stubFetch(fetchMock as typeof fetch);
+      session = sessionWithTask(
+        [
+          "--- URL Path Mapping ---",
+          "These mappings are authoritative for hosted artifacts:",
+          `- URL prefix ${appsPrefixPublic} maps to local path data/apps. For ${appsPrefixPublic}<slug>/, write files under data/apps/<slug>/.`,
+          `- URL prefix ${appsPrefixLocal} maps to local path data/apps. For ${appsPrefixLocal}<slug>/, write files under data/apps/<slug>/.`,
+          "--- User Task ---",
+          `Use the webfetch tool to GET this exact URL: ${dataSource}`,
+          "Reply with ONLY the USD number value from the response.",
+        ].join("\n"),
+        undefined,
+        {
+          workdirRoute: {
+            id: "static-apps",
+            workdir: "/tmp/agent-home",
+            urlMappings: [
+              { urlPrefix: appsPrefixLocal, localPath: "data/apps/" },
+              { urlPrefix: appsPrefixPublic, localPath: "data/apps/" },
+            ],
+          },
+        },
+      );
+      acp = makeAcpService(session);
+      const { runtime, handleMessage, spawnSession } = makeRuntime({
+        acp: acp.service,
+      });
+      await SubAgentRouter.start(runtime);
+
+      acp.emit(SESSION_ID, "task_complete", {
+        response:
+          "DECISION: task complete — reporting the fetched value.\n\n**64223**",
+      });
+      await new Promise((r) => setTimeout(r, 300));
+
+      expect(spawnSession).not.toHaveBeenCalled();
+      expect(handleMessage).toHaveBeenCalledTimes(1);
+      const posted = handleMessage.mock.calls[0]?.[1];
+      const text = posted?.content?.text ?? "";
+      // The real answer is preserved; no stray URL leaks into the reply.
+      expect(text).toContain("64223");
+      expect(text).not.toContain("/apps/");
+      expect(text).not.toContain("coingecko");
+      // No URL was a built deliverable, so none is recorded as verified.
+      const verified = posted?.content?.metadata?.subAgentVerifiedUrls as
+        | unknown[]
+        | undefined;
+      expect(verified ?? []).toEqual([]);
+    });
+
     it("rejects generated app pages that reference unreachable image assets", async () => {
       const appUrl = "https://example.test/apps/permit-garden/";
       const imageUrl = "https://cdn.example.test/permit-garden/sticker.png";

--- a/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
+++ b/plugins/plugin-agent-orchestrator/src/services/sub-agent-router.ts
@@ -1749,6 +1749,46 @@ function routeRelativePathForUrl(
   return routeMatchForUrl(url, mappings)?.relativePath;
 }
 
+// A bare route-mapping prefix (the collection root, e.g. `https://host/apps/`)
+// is the route's own URL-namespace documentation stem — `taskWithResolvedRoute`
+// writes it verbatim into the spawn task's `--- URL Path Mapping ---` hint, and
+// that hint is also the `verificationReferenceText`. The `<slug>` template form
+// (`.../apps/<slug>/`) is already skipped by `collectVerifiableUrlCandidates`,
+// but the bare-prefix form ("URL prefix https://host/apps/ maps to …") is not,
+// so it leaks into the verify list, probes 200 (the index page exists), and gets
+// surfaced as a "verified deliverable" — clobbering the sub-agent's real answer
+// for a non-build info-fetch (e.g. a price). It is never a built page: a real
+// app build claims `.../apps/<slug>/`, which has a path BEYOND the prefix and is
+// unaffected. Structural — keys on the configured `urlMappings[].urlPrefix`, not
+// on prose.
+function isBareRouteMappingPrefix(
+  url: string,
+  mappings: readonly RouteUrlMapping[],
+): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  const urlPath = parsed.pathname.endsWith("/")
+    ? parsed.pathname
+    : `${parsed.pathname}/`;
+  return mappings.some((mapping) => {
+    let prefix: URL;
+    try {
+      prefix = new URL(mapping.urlPrefix);
+    } catch {
+      return false;
+    }
+    if (parsed.origin !== prefix.origin) return false;
+    const prefixPath = prefix.pathname.endsWith("/")
+      ? prefix.pathname
+      : `${prefix.pathname}/`;
+    return urlPath === prefixPath && parsed.search === "" && parsed.hash === "";
+  });
+}
+
 function routeMatchForUrl(
   url: string,
   mappings: readonly RouteUrlMapping[],
@@ -2000,6 +2040,10 @@ export async function annotateUnverifiedUrls(
   const urls = expandRouteUrlAliases(
     extractVerifiableUrls(text, 5, referenceText, ignoredUrls),
     routeVerification,
+  ).filter(
+    (url) =>
+      routeVerification === undefined ||
+      !isBareRouteMappingPrefix(url, routeVerification.mappings),
   );
   if (urls.length === 0) return { text, dead: [], verifiedUrls: [] };
   log?.(
@@ -2166,13 +2210,40 @@ export async function annotateUnverifiedUrls(
   };
 }
 
+// A reachable URL is only a user-facing *deliverable* when it is a routed
+// hosted-artifact PAGE — a route-mapped page (or a bare `/apps/<slug>/` page
+// when no route map is configured). Data-source URLs the task told the sub-agent
+// to fetch (e.g. a CoinGecko price endpoint) and any other incidental URL are
+// inputs/mentions, not deliverables: probing them 200 must never promote them to
+// the reply that the completion evaluator surfaces. Without this gate, a
+// non-build info-fetch turn ("what's BTC worth?") had its real answer ("$64,223")
+// clobbered by the input data-source (or route-prefix) URL. Bare route-mapping
+// prefixes are excluded too — they are the route's documentation stem, not a
+// built page. Structural: keys on route-mapping shape + the `/apps/<slug>/`
+// page shape, never on prose.
+function isVerifiedDeliverableUrl(
+  url: string,
+  routeVerification: RouteUrlVerification | undefined,
+): boolean {
+  if (
+    routeVerification &&
+    isBareRouteMappingPrefix(url, routeVerification.mappings)
+  ) {
+    return false;
+  }
+  return isRoutedArtifactUrl(url, routeVerification);
+}
+
 function canonicalUserFacingVerifiedUrls(
   urls: string[],
   routeVerification: RouteUrlVerification | undefined,
 ): string[] {
-  if (!routeVerification) return urls;
+  const deliverables = urls.filter((url) =>
+    isVerifiedDeliverableUrl(url, routeVerification),
+  );
+  if (!routeVerification) return deliverables;
   const canonical = new Set<string>();
-  for (const url of urls) {
+  for (const url of deliverables) {
     const pageAliases = routePageAliasesForUrl(url, routeVerification);
     if (pageAliases.length > 0) {
       for (const alias of pageAliases) canonical.add(alias);


### PR DESCRIPTION
A live info-fetch (e.g. a BTC price) could have its real answer clobbered by an input-surface URL: bare route-prefixes and data-source URLs return HTTP 200 (reachable) and got promoted as the 'verified deliverable'. Confusing *reachable* with *deliverable*. Adds two structural gates (`isBareRouteMappingPrefix` filters bare prefixes from the probe set; `isVerifiedDeliverableUrl` gates so only routed artifact pages count) keyed on the route-mapping config shape, not prose. +1 fail-on-old regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)