### PR TITLE
ci: make expensive lanes label-gated and explainable

### DIFF
--- a/.github/workflows/CHANGELOG.md
+++ b/.github/workflows/CHANGELOG.md
@@ -1,0 +1,70 @@
+# CI Workflow Changelog
+
+This changelog tracks meaningful CI policy and workflow-architecture changes.
+It is intentionally scoped to `.github/workflows` so product/package changelogs
+do not have to carry CI-only history.
+
+## 2026-06-14
+
+### Added
+
+- Added `packages/scripts/ci-path-gate.mjs` as the shared PR path classifier for
+  expensive workflows.
+
+  Why: repeated inline shell classifiers made it too easy for workflows to drift
+  apart, and reviewers could not see a consistent explanation for why a lane ran
+  or skipped.
+
+- Added path-gate summaries to show changed files, selected lanes, and the path
+  or label reason for each lane.
+
+  Why: fast CI is only useful if contributors and maintainers trust the skip
+  decision. The summary turns the decision into reviewable evidence.
+
+- Added force labels including `ci:full`, `ci:e2e`, `ci:zero-key`,
+  `ci:server`, `ci:client`, `ci:plugins`, `ci:cloud`, `ci:docker`,
+  `ci:mobile`, `ci:ios`, `ci:android`, `ci:desktop`, `ci:windows`, and
+  `ci:dev-smoke`.
+
+  Why: maintainers need a no-code way to request broader coverage when a change
+  is risky, cross-cutting, or ambiguous.
+
+- Added `packages/scripts/ci-path-gate.self-test.mjs` and run it before the
+  `Tests` workflow consumes classifier outputs.
+
+  Why: the classifier is now part of the quality gate. Testing it in CI prevents
+  a future edit from silently skipping coverage that should have run.
+
+### Changed
+
+- Replaced inline path filters in `test.yml` and `scenario-pr.yml` with the
+  shared classifier.
+
+  Why: one implementation is easier to audit, document, and extend than several
+  workflow-local shell snippets.
+
+- Added classifier jobs to Docker, mobile, dev smoke, Windows dev smoke, and
+  Windows desktop preload smoke workflows.
+
+  Why: these lanes are valuable but expensive. Running them only for relevant
+  PRs keeps feedback fast while still preserving push/manual coverage.
+
+- Split deterministic zero-key E2E work into named parallel slices while keeping
+  the visible `Zero-Key Deterministic E2E` aggregate check.
+
+  Why: a single serial E2E log made failures slow to reach and hard to triage.
+  Parallel slices shorten wall-clock time and make the failing surface obvious
+  without removing the aggregate gate reviewers already understand.
+
+### Preserved
+
+- Push, scheduled, and manual runs keep broad/default behavior.
+
+  Why: those runs protect branch health, release readiness, and periodic
+  confidence. PR path gates optimize contributor feedback, not the repository's
+  deeper safety net.
+
+- The split E2E jobs keep the previous substantive commands.
+
+  Why: this change is a CI ergonomics and parallelism improvement, not a
+  reduction in coverage.

--- a/.github/workflows/CHANGELOG.md
+++ b/.github/workflows/CHANGELOG.md
@@ -56,6 +56,14 @@ do not have to carry CI-only history.
   Parallel slices shorten wall-clock time and make the failing surface obvious
   without removing the aggregate gate reviewers already understand.
 
+- Moved `coverage-gate` dependency setup behind changed-test detection and
+  switched it to the shared Bun workspace setup.
+
+  Why: the coverage gate is advisory for changed Bun-native tests. Docs-only and
+  no-test PRs should not install the whole workspace or fail on unrelated
+  registry/install noise, while test-bearing PRs should use the same
+  lockfile-validating setup path as the rest of CI.
+
 ### Preserved
 
 - Push, scheduled, and manual runs keep broad/default behavior.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -57,6 +57,7 @@ Maintainers can force specific lanes with labels:
 |-------|--------|
 | `ci:full` | Run every path-gated lane in workflows that honor the shared gate |
 | `ci:e2e` / `ci:zero-key` | Run deterministic zero-key E2E lanes |
+| `ci:scenario` | Run `scenario-pr.yml` deterministic scenario/browser E2E |
 | `ci:server` | Run server tests |
 | `ci:client` | Run client tests |
 | `ci:plugins` | Run plugin tests |
@@ -88,9 +89,9 @@ Quality contract:
 - Workflow, shared setup, toolchain, lockfile, and classifier changes should run
   the affected expensive lanes because they can change CI behavior even when
   product code did not move.
-- The classifier must be self-tested before its outputs are consumed by a
-  workflow. The self-test covers representative path matches and label forcing
-  so a future edit cannot silently weaken the gate.
+- The `Tests` workflow runs the classifier self-test before consuming classifier
+  outputs. That self-test covers representative path matches and label forcing
+  so a future edit cannot silently weaken the broadest PR test gate.
 - When splitting a long lane, keep the same substantive commands unless the PR
   explicitly documents the safety reason for removing one.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -69,6 +69,11 @@ Maintainers can force specific lanes with labels:
 Push, scheduled, and manual runs keep their broader/default behavior; the path
 gate mainly keeps PR feedback fast and explainable.
 
+Long deterministic E2E gates are split into named parallel slices for unit/UI
+coverage, browser coverage, diagnostics, and scenario execution. The visible
+`Zero-Key Deterministic E2E` check is an aggregate status over those slices, so
+reviewers can see the failing surface without opening one giant serial log.
+
 ### Main CI (`ci.yaml`)
 
 Runs on PRs and pushes to main:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -69,10 +69,48 @@ Maintainers can force specific lanes with labels:
 Push, scheduled, and manual runs keep their broader/default behavior; the path
 gate mainly keeps PR feedback fast and explainable.
 
+Why this exists:
+
+- OSS contributors should get useful feedback quickly without waiting on
+  unrelated mobile, Docker, desktop, Windows, or browser-heavy lanes.
+- Maintainers should be able to see why a lane ran or skipped from the job
+  summary, without reverse-engineering shell conditionals.
+- The quality gate should stay equivalent for affected code. Path gates decide
+  which surface is relevant; they do not replace the tests for that surface.
+- Push, scheduled, and manual runs remain broad because they protect branch
+  health, release readiness, and nightly confidence rather than one PR diff.
+
+Quality contract:
+
+- Any path-gated lane must be forced by `ci:full`.
+- Every expensive lane needs a matching force label so maintainers can request
+  coverage without pushing a no-op commit.
+- Workflow, shared setup, toolchain, lockfile, and classifier changes should run
+  the affected expensive lanes because they can change CI behavior even when
+  product code did not move.
+- The classifier must be self-tested before its outputs are consumed by a
+  workflow. The self-test covers representative path matches and label forcing
+  so a future edit cannot silently weaken the gate.
+- When splitting a long lane, keep the same substantive commands unless the PR
+  explicitly documents the safety reason for removing one.
+
 Long deterministic E2E gates are split into named parallel slices for unit/UI
 coverage, browser coverage, diagnostics, and scenario execution. The visible
 `Zero-Key Deterministic E2E` check is an aggregate status over those slices, so
 reviewers can see the failing surface without opening one giant serial log.
+
+Why the aggregate stays:
+
+- Branch protection and reviewer muscle memory can keep using one stable check.
+- The underlying slices can run in parallel and fail with precise names.
+- Manual review becomes easier because a browser failure, diagnostics failure,
+  or scenario-runner failure points at the relevant log immediately.
+
+Related CI docs:
+
+- `CHANGELOG.md` records workflow policy changes and the reason they happened.
+- `ROADMAP.md` tracks future CI performance work that should preserve gate
+  quality.
 
 ### Main CI (`ci.yaml`)
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -42,6 +42,33 @@ Publishes TypeScript/JavaScript packages to NPM.
 
 ## Test Workflows
 
+### PR Path Gates
+
+PR workflows use `packages/scripts/ci-path-gate.mjs` to keep expensive lanes
+targeted. Each classifier job writes a GitHub step summary showing:
+
+- which files changed
+- which lanes will run
+- which path or label caused each lane to run
+
+Maintainers can force specific lanes with labels:
+
+| Label | Effect |
+|-------|--------|
+| `ci:full` | Run every path-gated lane in workflows that honor the shared gate |
+| `ci:e2e` / `ci:zero-key` | Run deterministic zero-key E2E lanes |
+| `ci:server` | Run server tests |
+| `ci:client` | Run client tests |
+| `ci:plugins` | Run plugin tests |
+| `ci:cloud` | Run cloud live E2E where secrets are configured |
+| `ci:docker` | Run Docker CI smoke |
+| `ci:mobile` / `ci:ios` / `ci:android` | Run mobile smoke, or one mobile platform |
+| `ci:desktop` / `ci:windows` | Run desktop and Windows smoke lanes |
+| `ci:dev-smoke` | Run the `bun run dev` onboarding smoke |
+
+Push, scheduled, and manual runs keep their broader/default behavior; the path
+gate mainly keeps PR feedback fast and explainable.
+
 ### Main CI (`ci.yaml`)
 
 Runs on PRs and pushes to main:

--- a/.github/workflows/ROADMAP.md
+++ b/.github/workflows/ROADMAP.md
@@ -1,0 +1,79 @@
+# CI Workflow Roadmap
+
+This roadmap is for making CI faster and friendlier without weakening the
+quality gate.
+
+## Principles
+
+- Prefer affected-surface execution over blanket PR execution.
+
+  Why: contributors should not wait on unrelated platform builds, but affected
+  code still needs the same depth of verification.
+
+- Keep broad verification on push, schedule, and manual dispatch.
+
+  Why: selective PR checks optimize review latency; broad branch checks catch
+  integration issues that only appear after many changes compose.
+
+- Make every skip explainable and overridable.
+
+  Why: maintainers need confidence that a skipped lane was intentionally out of
+  scope, and they need a label escape hatch when judgment says to run it anyway.
+
+- Split long serial lanes before removing coverage.
+
+  Why: parallelism usually improves developer experience without trading away
+  signal.
+
+## Near Term
+
+- Record workflow-level and job-level duration trends for PR and `develop`
+  pushes.
+
+  Why: the current long pole can move as workflows are split. Duration data lets
+  us optimize the real bottleneck instead of guessing from one run.
+
+- Continue splitting long jobs into independently named slices with aggregate
+  status checks.
+
+  Why: aggregate checks preserve branch-protection simplicity while named slices
+  improve failure triage and parallelism.
+
+- Expand classifier self-tests when adding a new path-gated workflow.
+
+  Why: every new gate adds skip logic. The test suite should grow with the blast
+  radius of that logic.
+
+## Next
+
+- Move repeated setup into reusable actions where it does not hide important
+  workflow behavior.
+
+  Why: duplicated setup makes split jobs noisy, but overly opaque setup makes CI
+  harder to debug. Reusable actions should reduce repetition while keeping logs
+  readable.
+
+- Add a documented owner map for path-gate rules.
+
+  Why: package owners can judge whether a path belongs in server, client,
+  plugin, cloud, mobile, desktop, Docker, or E2E coverage better than a generic
+  workflow edit can.
+
+- Evaluate matrix shaping for Windows CI.
+
+  Why: recent completed `develop` runs show Windows CI as the workflow-level
+  long pole. More parallelism or tighter affected-surface routing there may
+  produce the biggest wall-clock win.
+
+## Later
+
+- Publish a compact CI timing summary on PRs.
+
+  Why: contributors should see whether the slowest check is queue time, setup,
+  test execution, artifact upload, or a platform-specific lane.
+
+- Add a periodic full-gate audit that compares path-gated PR behavior against a
+  broad run for representative diffs.
+
+  Why: selective CI needs periodic calibration so the faster path remains as
+  trustworthy as the older all-in path.

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -26,15 +26,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Bun
-        # oven-sh/setup-bun@v2
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
-        with:
-          bun-version: "canary"
-
-      - name: Install
-        run: bun install --frozen-lockfile || bun install --no-frozen-lockfile
-
       - name: Determine changed files
         id: changed
         run: |
@@ -63,7 +54,19 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
+      - name: Setup Bun workspace
+        if: steps.changed.outputs.tests != ''
+        # Keep dependency setup behind the changed-test check. The coverage gate
+        # is advisory for changed Bun-native tests, so docs-only and no-test PRs
+        # should not spend CI time or fail on unrelated registry/install noise.
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          install-native-deps: "false"
+          install-protoc: "false"
+          setup-python: "false"
+
       - name: Run changed Bun tests with coverage
+        if: steps.changed.outputs.tests != ''
         run: |
           cat > "$RUNNER_TEMP/changed-tests.txt" <<'EOF'
           ${{ steps.changed.outputs.tests }}
@@ -80,6 +83,7 @@ jobs:
           BUN_COVERAGE_DIR: coverage
 
       - name: Apply coverage gate (advisory)
+        if: steps.changed.outputs.tests != ''
         env:
           COVERAGE_GATE_ENFORCE: "0"   # flip to "1" once baseline established
         run: |

--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -3,15 +3,7 @@ name: Dev Smoke
 on:
   pull_request:
     branches: [main, develop]
-    paths:
-      - ".github/workflows/dev-smoke.yml"
-      - "package.json"
-      - "bun.lock"
-      - "packages/app/**"
-      - "packages/app-core/**"
-      - "packages/core/**"
-      - "packages/shared/**"
-      - "packages/ui/**"
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
   push:
     branches: [main, develop]
     paths:
@@ -48,8 +40,37 @@ env:
   ELIZAOS_CLOUD_API_KEY: ${{ secrets.ELIZAOS_CLOUD_API_KEY }}
 
 jobs:
+  changes:
+    name: Classify changed paths
+    runs-on: ubuntu-24.04
+    outputs:
+      dev_smoke: ${{ steps.filter.outputs.dev_smoke }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Determine affected dev smoke surface
+        id: filter
+        shell: bash
+        env:
+          PR_LABELS: ${{ github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name, ',') || '' }}
+        run: |
+          set -euo pipefail
+          node packages/scripts/ci-path-gate.mjs \
+            --config dev-smoke \
+            --event "${{ github.event_name }}" \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
+            --labels "$PR_LABELS" \
+            --output "$GITHUB_OUTPUT" \
+            --summary "$GITHUB_STEP_SUMMARY"
+
   dev-smoke:
     name: bun run dev onboarding chat
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.dev_smoke == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 35
     env:

--- a/.github/workflows/docker-ci-smoke.yml
+++ b/.github/workflows/docker-ci-smoke.yml
@@ -3,16 +3,50 @@ name: Docker CI Smoke
 on:
   pull_request:
     branches: [develop]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
   push:
     branches: [develop]
   workflow_dispatch:
+
+concurrency:
+  group: docker-ci-smoke-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Classify changed paths
+    runs-on: ubuntu-24.04
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Determine affected Docker smoke surface
+        id: filter
+        shell: bash
+        env:
+          PR_LABELS: ${{ github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name, ',') || '' }}
+        run: |
+          set -euo pipefail
+          node packages/scripts/ci-path-gate.mjs \
+            --config docker \
+            --event "${{ github.event_name }}" \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
+            --labels "$PR_LABELS" \
+            --output "$GITHUB_OUTPUT" \
+            --summary "$GITHUB_STEP_SUMMARY"
+
   docker-ci-smoke:
     name: Build production Docker image (+ smoke boot)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     env:

--- a/.github/workflows/mobile-build-smoke.yml
+++ b/.github/workflows/mobile-build-smoke.yml
@@ -3,15 +3,7 @@ name: Mobile Build Smoke Test
 on:
   pull_request:
     branches: [main, develop]
-    paths:
-      - "packages/agent/**"
-      - "packages/app/**"
-      - "packages/app-core/**"
-      - "packages/core/**"
-      - "packages/native/plugins/**"
-      - "packages/shared/**"
-      - "plugins/plugin-sql/**"
-      - ".github/workflows/mobile-build-smoke.yml"
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
   workflow_dispatch:
 
 concurrency:
@@ -26,8 +18,38 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Classify changed paths
+    runs-on: ubuntu-24.04
+    outputs:
+      ios: ${{ steps.filter.outputs.ios }}
+      android: ${{ steps.filter.outputs.android }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Determine affected mobile smoke surface
+        id: filter
+        shell: bash
+        env:
+          PR_LABELS: ${{ github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name, ',') || '' }}
+        run: |
+          set -euo pipefail
+          node packages/scripts/ci-path-gate.mjs \
+            --config mobile \
+            --event "${{ github.event_name }}" \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
+            --labels "$PR_LABELS" \
+            --output "$GITHUB_OUTPUT" \
+            --summary "$GITHUB_STEP_SUMMARY"
+
   build-ios:
     name: iOS Simulator Build
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.ios == 'true'
     runs-on: macos-15
     timeout-minutes: 30
     steps:
@@ -159,6 +181,8 @@ jobs:
 
   build-android:
     name: Android Debug Build
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.android == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -64,12 +64,12 @@ jobs:
             --output "$GITHUB_OUTPUT" \
             --summary "$GITHUB_STEP_SUMMARY"
 
-  deterministic-scenario:
-    name: Zero-Key Deterministic E2E
+  scenario-unit-coverage:
+    name: Zero-Key unit + UI coverage
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
@@ -89,6 +89,9 @@ jobs:
           skip-avatar-clone: "true"
           no-vision-deps: "true"
 
+      - name: Ensure generated shared i18n data
+        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
       - name: Scenario runner unit coverage
         run: bun run --cwd packages/scenario-runner test -- src/executor.test.ts src/runtime-factory.test.ts src/scenario-pr-workflow.test.ts src/__tests__/deterministic-action-coverage.test.ts
 
@@ -104,6 +107,34 @@ jobs:
 
       - name: App route + ui-smoke spec coverage gates
         run: bun run --cwd packages/app test -- test/route-coverage.test.ts test/ui-smoke-coverage.test.ts
+
+  app-browser-core:
+    name: Zero-Key app browser core
+    needs: changes
+    if: needs.changes.outputs.run_scenario_pr == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 55
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Ensure generated shared i18n data
+        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Install Playwright browsers
         run: bunx playwright install --with-deps chromium
@@ -135,8 +166,89 @@ jobs:
       - name: Actual app cloud keyless browser coverage
         run: bun run --cwd packages/app test:e2e test/ui-smoke/cloud-provisioning-startup.spec.ts test/ui-smoke/cloud-wallet-import.spec.ts test/ui-smoke/live-agent-chat.spec.ts test/ui-smoke/remote-capability-view.spec.ts --project=chromium
 
+      - name: Upload app browser core artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: scenario-pr-app-browser-core
+          path: |
+            packages/app/playwright-report/
+            packages/app/test-results/
+          if-no-files-found: ignore
+          retention-days: 3
+
+  app-browser-ratcheted:
+    name: Zero-Key app browser ratcheted
+    needs: changes
+    if: needs.changes.outputs.run_scenario_pr == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 55
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Ensure generated shared i18n data
+        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
+      - name: Install Playwright browsers
+        run: bunx playwright install --with-deps chromium
+
       - name: Actual app ratcheted keyless browser coverage
         run: bun run --cwd packages/app test:e2e test/ui-smoke/ai-qa-capture.spec.ts test/ui-smoke/android-system-apps.spec.ts test/ui-smoke/apps-session.spec.ts test/ui-smoke/apps-session-direct-a.spec.ts test/ui-smoke/apps-session-direct-b.spec.ts test/ui-smoke/auth-startup.spec.ts test/ui-smoke/automations.spec.ts test/ui-smoke/browser-workspace.spec.ts test/ui-smoke/computer-use.spec.ts test/ui-smoke/connectors.spec.ts test/ui-smoke/first-run-startup.spec.ts test/ui-smoke/game-apps.spec.ts test/ui-smoke/game-operator-gui-interactions.spec.ts test/ui-smoke/history-navigation.spec.ts test/ui-smoke/orchestrator-gui-workbench.spec.ts test/ui-smoke/reset-returns-to-onboarding.spec.ts test/ui-smoke/runtime-configurability.spec.ts test/ui-smoke/perf-load-kpi.spec.ts test/ui-smoke/screenshare-gui-interactions.spec.ts test/ui-smoke/task-coordinator-gui-interactions.spec.ts test/ui-smoke/terminal-plugin-view-command-contract.spec.ts test/ui-smoke/titlebar-navigation.spec.ts test/ui-smoke/ui-smoke.spec.ts --project=chromium
+
+      - name: Upload app browser ratcheted artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: scenario-pr-app-browser-ratcheted
+          path: |
+            packages/app/playwright-report/
+            packages/app/test-results/
+          if-no-files-found: ignore
+          retention-days: 3
+
+  app-diagnostics:
+    name: Zero-Key app diagnostics
+    needs: changes
+    if: needs.changes.outputs.run_scenario_pr == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Ensure generated shared i18n data
+        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Electrobun window and dynamic-view coverage
         run: bun run --cwd packages/app-core/platforms/electrobun test src/native/desktop-window.test.ts src/rpc-handlers.test.ts src/dynamic-view-rpc-schema.test.ts src/surface-windows.test.ts src/dynamic-views/host.test.ts
@@ -159,6 +271,34 @@ jobs:
       - name: Cloud screenshot quality diagnostics coverage
         run: bun run --cwd packages/cloud-frontend test -- tests/e2e/screenshot-quality.test.ts
 
+  scenario-runner-e2e:
+    name: Zero-Key scenario runner E2E
+    needs: changes
+    if: needs.changes.outputs.run_scenario_pr == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Ensure generated shared i18n data
+        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
       - name: Scenario catalog coverage gate
         run: node packages/scripts/check-scenario-workflow-coverage.mjs --report-dir reports/scenarios/catalog-inventory
 
@@ -178,3 +318,39 @@ jobs:
             reports/scenarios/catalog-inventory/
           if-no-files-found: ignore
           retention-days: 3
+
+  deterministic-scenario:
+    name: Zero-Key Deterministic E2E
+    needs:
+      - changes
+      - scenario-unit-coverage
+      - app-browser-core
+      - app-browser-ratcheted
+      - app-diagnostics
+      - scenario-runner-e2e
+    if: always() && needs.changes.outputs.run_scenario_pr == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check deterministic E2E slices
+        shell: bash
+        run: |
+          set -u
+          bad=0
+          for pair in \
+            "scenario-unit-coverage:${{ needs.scenario-unit-coverage.result }}" \
+            "app-browser-core:${{ needs.app-browser-core.result }}" \
+            "app-browser-ratcheted:${{ needs.app-browser-ratcheted.result }}" \
+            "app-diagnostics:${{ needs.app-diagnostics.result }}" \
+            "scenario-runner-e2e:${{ needs.scenario-runner-e2e.result }}"; do
+            name="${pair%%:*}"
+            result="${pair##*:}"
+            echo "$name: $result"
+            if [ "$result" != "success" ]; then
+              echo "::error title=Scenario PR E2E::$name finished with $result"
+              bad=1
+            fi
+          done
+          if [ "$bad" -ne 0 ]; then
+            exit 1
+          fi
+          echo "All deterministic E2E slices passed."

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -8,6 +8,7 @@ name: Scenario PR E2E
 on:
   pull_request:
     branches: [main, develop]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
   workflow_dispatch:
 
 concurrency:
@@ -50,56 +51,18 @@ jobs:
       - name: Determine affected CI surface
         id: filter
         shell: bash
+        env:
+          PR_LABELS: ${{ github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name, ',') || '' }}
         run: |
           set -euo pipefail
-
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            echo "run_scenario_pr=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          base="${{ github.event.pull_request.base.sha }}"
-          head="${{ github.event.pull_request.head.sha }}"
-          git diff --name-only "$base" "$head" > /tmp/changed-files
-
-          run_scenario_pr=false
-          while IFS= read -r path; do
-            case "$path" in
-              package.json|bun.lock|turbo.json|tsconfig*.json|vite.config.*|vitest.config.*)
-                run_scenario_pr=true
-                ;;
-              .github/workflows/scenario-pr.yml|.github/actions/setup-bun-workspace/**)
-                run_scenario_pr=true
-                ;;
-              packages/app/**|packages/ui/**|packages/app-core/**|packages/scenario-runner/**)
-                run_scenario_pr=true
-                ;;
-              packages/core/**|packages/agent/**|packages/shared/**|packages/scripts/**)
-                run_scenario_pr=true
-                ;;
-              packages/test/**|packages/prompts/**)
-                run_scenario_pr=true
-                ;;
-              plugins/plugin-app-control/**|plugins/plugin-computeruse/**|plugins/plugin-github/**)
-                run_scenario_pr=true
-                ;;
-              plugins/plugin-*/src/**|plugins/plugin-*/package.json|plugins/plugin-*/vite.config.*|plugins/plugin-*/vitest.config.*)
-                run_scenario_pr=true
-                ;;
-            esac
-          done < /tmp/changed-files
-
-          echo "run_scenario_pr=$run_scenario_pr" >> "$GITHUB_OUTPUT"
-          {
-            echo "### Scenario PR E2E path gate"
-            echo ""
-            echo "- run_scenario_pr: \`$run_scenario_pr\`"
-            echo ""
-            echo "<details><summary>Changed files</summary>"
-            echo ""
-            sed 's/^/- /' /tmp/changed-files
-            echo "</details>"
-          } >> "$GITHUB_STEP_SUMMARY"
+          node packages/scripts/ci-path-gate.mjs \
+            --config scenario-pr \
+            --event "${{ github.event_name }}" \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
+            --labels "$PR_LABELS" \
+            --output "$GITHUB_OUTPUT" \
+            --summary "$GITHUB_STEP_SUMMARY"
 
   deterministic-scenario:
     name: Zero-Key Deterministic E2E

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,9 @@ jobs:
           fetch-depth: 0
           submodules: false
 
+      - name: Validate CI path gate
+        run: node packages/scripts/ci-path-gate.self-test.mjs
+
       - name: Determine affected test lanes
         id: filter
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -283,12 +283,12 @@ jobs:
         working-directory: packages/app-core/platforms/electrobun
         run: bun run test
 
-  zero-key-e2e:
-    name: Zero-Key Deterministic E2E
+  zero-key-unit-coverage:
+    name: Zero-Key unit + UI coverage
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 30
     env:
       TEST_LANE: "pr"
       ELIZA_LIVE_TEST: "0"
@@ -346,6 +346,50 @@ jobs:
       - name: App route + ui-smoke spec coverage gates
         run: bun run --cwd packages/app test -- test/route-coverage.test.ts test/ui-smoke-coverage.test.ts test/view-interaction-coverage.test.ts
 
+  zero-key-browser:
+    name: Zero-Key app browser
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 35
+    env:
+      TEST_LANE: "pr"
+      ELIZA_LIVE_TEST: "0"
+      SCENARIO_USE_LLM_PROXY: "1"
+      CEREBRAS_API_KEY: ""
+      OPENAI_API_KEY: ""
+      ANTHROPIC_API_KEY: ""
+      GROQ_API_KEY: ""
+      OPENROUTER_API_KEY: ""
+      GOOGLE_GENERATIVE_AI_API_KEY: ""
+      XAI_API_KEY: ""
+      NVIDIA_API_KEY: ""
+      ELIZAOS_CLOUD_API_KEY: ""
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_REMOTE_ONLY: true
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Ensure generated shared i18n data
+        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
+
       - name: Install Playwright Chromium
         run: bunx playwright install --with-deps chromium
 
@@ -363,6 +407,61 @@ jobs:
 
       - name: Actual app plugin view browser coverage
         run: bun run --cwd packages/app test:e2e test/ui-smoke/plugin-views-visual.spec.ts test/ui-smoke/orchestrator-gui-workbench.spec.ts test/ui-smoke/screenshare-gui-interactions.spec.ts test/ui-smoke/task-coordinator-gui-interactions.spec.ts test/ui-smoke/game-operator-gui-interactions.spec.ts test/ui-smoke/terminal-plugin-view-command-contract.spec.ts --project=chromium
+
+      - name: Upload zero-key browser artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: tests-zero-key-browser
+          path: |
+            packages/app/playwright-report/
+            packages/app/test-results/
+          if-no-files-found: ignore
+          retention-days: 3
+
+  zero-key-diagnostics:
+    name: Zero-Key diagnostics
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      TEST_LANE: "pr"
+      ELIZA_LIVE_TEST: "0"
+      SCENARIO_USE_LLM_PROXY: "1"
+      CEREBRAS_API_KEY: ""
+      OPENAI_API_KEY: ""
+      ANTHROPIC_API_KEY: ""
+      GROQ_API_KEY: ""
+      OPENROUTER_API_KEY: ""
+      GOOGLE_GENERATIVE_AI_API_KEY: ""
+      XAI_API_KEY: ""
+      NVIDIA_API_KEY: ""
+      ELIZAOS_CLOUD_API_KEY: ""
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_REMOTE_ONLY: true
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      - name: Ensure generated shared i18n data
+        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Electrobun window and dynamic-view coverage
         run: bun run --cwd packages/app-core/platforms/electrobun test src/native/desktop-window.test.ts src/rpc-handlers.test.ts src/dynamic-view-rpc-schema.test.ts src/surface-windows.test.ts src/dynamic-views/host.test.ts
@@ -384,6 +483,53 @@ jobs:
 
       - name: Cloud screenshot quality diagnostics coverage
         run: bun run --cwd packages/cloud-frontend test -- tests/e2e/screenshot-quality.test.ts
+
+  zero-key-scenario-runner:
+    name: Zero-Key scenario runner
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    env:
+      TEST_LANE: "pr"
+      ELIZA_LIVE_TEST: "0"
+      SCENARIO_USE_LLM_PROXY: "1"
+      CEREBRAS_API_KEY: ""
+      OPENAI_API_KEY: ""
+      ANTHROPIC_API_KEY: ""
+      GROQ_API_KEY: ""
+      OPENROUTER_API_KEY: ""
+      GOOGLE_GENERATIVE_AI_API_KEY: ""
+      XAI_API_KEY: ""
+      NVIDIA_API_KEY: ""
+      ELIZAOS_CLOUD_API_KEY: ""
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+      TURBO_REMOTE_ONLY: true
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          submodules: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup workspace dependencies
+        uses: ./.github/actions/setup-bun-workspace
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          install-command: bun install --ignore-scripts --no-frozen-lockfile
+          install-native-deps: "false"
+          skip-avatar-clone: "true"
+          no-vision-deps: "true"
+
+      # The scenario CLI imports @elizaos/core from source, which imports the
+      # gitignored ./generated/validation-keyword-data.ts. --ignore-scripts skips
+      # postinstall, so generate it explicitly before any step resolves core.
+      - name: Ensure generated shared i18n data
+        run: node packages/app-core/scripts/ensure-shared-i18n-data.mjs
 
       - name: Scenario catalog coverage gate
         run: node packages/scripts/check-scenario-workflow-coverage.mjs --report-dir reports/scenarios/catalog-inventory
@@ -408,6 +554,40 @@ jobs:
       - name: Prune deterministic E2E scratch output
         if: always()
         run: rm -rf reports/scenarios/pr-deterministic reports/scenarios/catalog-inventory packages/app/playwright-report packages/app/test-results
+
+  zero-key-e2e:
+    name: Zero-Key Deterministic E2E
+    needs:
+      - changes
+      - zero-key-unit-coverage
+      - zero-key-browser
+      - zero-key-diagnostics
+      - zero-key-scenario-runner
+    if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true')
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check zero-key slices
+        shell: bash
+        run: |
+          set -u
+          bad=0
+          for pair in \
+            "zero-key-unit-coverage:${{ needs.zero-key-unit-coverage.result }}" \
+            "zero-key-browser:${{ needs.zero-key-browser.result }}" \
+            "zero-key-diagnostics:${{ needs.zero-key-diagnostics.result }}" \
+            "zero-key-scenario-runner:${{ needs.zero-key-scenario-runner.result }}"; do
+            name="${pair%%:*}"
+            result="${pair##*:}"
+            echo "$name: $result"
+            if [ "$result" != "success" ]; then
+              echo "::error title=Tests zero-key::$name finished with $result"
+              bad=1
+            fi
+          done
+          if [ "$bad" -ne 0 ]; then
+            exit 1
+          fi
+          echo "All zero-key slices passed."
 
   cloud-live-e2e:
     name: Cloud Live E2E (Eliza Cloud)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ name: Tests
 on:
   pull_request:
     branches: [main, develop]
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
   push:
     branches: [main, develop]
   workflow_dispatch:
@@ -52,114 +53,18 @@ jobs:
       - name: Determine affected test lanes
         id: filter
         shell: bash
+        env:
+          PR_LABELS: ${{ github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name, ',') || '' }}
         run: |
           set -euo pipefail
-
-          if [ "${{ github.event_name }}" != "pull_request" ]; then
-            {
-              echo "server=true"
-              echo "client=true"
-              echo "plugins=true"
-              echo "desktop=true"
-              echo "zero_key=true"
-              echo "cloud=true"
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          base="${{ github.event.pull_request.base.sha }}"
-          head="${{ github.event.pull_request.head.sha }}"
-          git diff --name-only "$base" "$head" > /tmp/changed-files
-
-          server=false
-          client=false
-          plugins=false
-          desktop=false
-          zero_key=false
-          cloud=false
-
-          mark_all() {
-            server=true
-            client=true
-            plugins=true
-            desktop=true
-            zero_key=true
-            cloud=true
-          }
-
-          while IFS= read -r path; do
-            case "$path" in
-              package.json|bun.lock|turbo.json|tsconfig*.json|vitest.config.*)
-                mark_all
-                ;;
-              .github/workflows/test.yml|.github/actions/setup-bun-workspace/**)
-                mark_all
-                ;;
-              packages/core/**|packages/agent/**|packages/shared/**|packages/prompts/**|packages/test/**)
-                server=true
-                client=true
-                plugins=true
-                desktop=true
-                zero_key=true
-                ;;
-              packages/app/**|packages/ui/**)
-                client=true
-                zero_key=true
-                ;;
-              packages/app-core/**)
-                server=true
-                client=true
-                desktop=true
-                zero_key=true
-                ;;
-              packages/scenario-runner/**)
-                server=true
-                zero_key=true
-                ;;
-              packages/scripts/**)
-                server=true
-                zero_key=true
-                ;;
-              packages/cloud-sdk/**|packages/cloud-shared/**|packages/cloud-frontend/**)
-                server=true
-                client=true
-                zero_key=true
-                cloud=true
-                ;;
-              packages/security/**|packages/vault/**)
-                server=true
-                ;;
-              plugins/**)
-                plugins=true
-                zero_key=true
-                ;;
-            esac
-          done < /tmp/changed-files
-
-          {
-            echo "server=$server"
-            echo "client=$client"
-            echo "plugins=$plugins"
-            echo "desktop=$desktop"
-            echo "zero_key=$zero_key"
-            echo "cloud=$cloud"
-          } >> "$GITHUB_OUTPUT"
-
-          {
-            echo "### Test lane path gate"
-            echo ""
-            echo "- server: \`$server\`"
-            echo "- client: \`$client\`"
-            echo "- plugins: \`$plugins\`"
-            echo "- desktop: \`$desktop\`"
-            echo "- zero_key: \`$zero_key\`"
-            echo "- cloud: \`$cloud\`"
-            echo ""
-            echo "<details><summary>Changed files</summary>"
-            echo ""
-            sed 's/^/- /' /tmp/changed-files
-            echo "</details>"
-          } >> "$GITHUB_STEP_SUMMARY"
+          node packages/scripts/ci-path-gate.mjs \
+            --config test \
+            --event "${{ github.event_name }}" \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
+            --labels "$PR_LABELS" \
+            --output "$GITHUB_OUTPUT" \
+            --summary "$GITHUB_STEP_SUMMARY"
 
   server-tests:
     name: Server Tests
@@ -851,7 +756,7 @@ jobs:
               continue
             fi
             if [ "$result" = "skipped" ] && [ "$strict_results" != "true" ]; then
-              echo "::warning title=Test gate::Live-only job '${name}' was skipped for this PR context."
+              echo "::notice title=Test gate::Path-gated job '${name}' was skipped for this PR context."
               continue
             fi
             if [ "$result" != "success" ]; then

--- a/.github/workflows/windows-desktop-preload-smoke.yml
+++ b/.github/workflows/windows-desktop-preload-smoke.yml
@@ -3,12 +3,7 @@ name: Windows Desktop Preload Smoke
 on:
   pull_request:
     branches: [main, develop]
-    paths:
-      - "packages/app-core/scripts/**"
-      - "packages/app-core/platforms/electrobun/**"
-      - "packages/app/**"
-      - "package.json"
-      - "bun.lock"
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
   workflow_dispatch:
 
 concurrency:
@@ -20,8 +15,37 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Classify changed paths
+    runs-on: ubuntu-24.04
+    outputs:
+      desktop_preload: ${{ steps.filter.outputs.desktop_preload }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Determine affected desktop preload surface
+        id: filter
+        shell: bash
+        env:
+          PR_LABELS: ${{ github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name, ',') || '' }}
+        run: |
+          set -euo pipefail
+          node packages/scripts/ci-path-gate.mjs \
+            --config desktop-preload \
+            --event "${{ github.event_name }}" \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
+            --labels "$PR_LABELS" \
+            --output "$GITHUB_OUTPUT" \
+            --summary "$GITHUB_STEP_SUMMARY"
+
   preload-smoke:
     name: desktop preload preflight (windows)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.desktop_preload == 'true'
     runs-on: windows-latest
     steps:
       - name: Enable long paths (Windows)

--- a/.github/workflows/windows-dev-smoke.yml
+++ b/.github/workflows/windows-dev-smoke.yml
@@ -3,12 +3,7 @@ name: Windows Dev Smoke
 on:
   pull_request:
     branches: [develop]
-    paths:
-      - "packages/app-core/scripts/**"
-      - "packages/app-core/platforms/electrobun/**"
-      - "packages/app/**"
-      - "package.json"
-      - "bun.lock"
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
   schedule:
     # Weekly Bun canary check (Mondays 06:00 UTC).
     - cron: "0 6 * * 1"
@@ -23,8 +18,37 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Classify changed paths
+    runs-on: ubuntu-24.04
+    outputs:
+      windows_dev: ${{ steps.filter.outputs.windows_dev }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          submodules: false
+
+      - name: Determine affected Windows dev smoke surface
+        id: filter
+        shell: bash
+        env:
+          PR_LABELS: ${{ github.event_name == 'pull_request' && join(github.event.pull_request.labels.*.name, ',') || '' }}
+        run: |
+          set -euo pipefail
+          node packages/scripts/ci-path-gate.mjs \
+            --config windows-dev \
+            --event "${{ github.event_name }}" \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
+            --labels "$PR_LABELS" \
+            --output "$GITHUB_OUTPUT" \
+            --summary "$GITHUB_STEP_SUMMARY"
+
   dev-smoke:
     name: Windows smoke (${{ matrix.bun-version }})
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.windows_dev == 'true'
     runs-on: windows-latest
     strategy:
       fail-fast: false

--- a/packages/scripts/ci-path-gate.mjs
+++ b/packages/scripts/ci-path-gate.mjs
@@ -381,6 +381,9 @@ function evaluate(config, { eventName, labels, base, head, changedFilesPath }) {
   const matchesByLane = new Map(config.outputs.map((output) => [output, []]));
   let changedFiles = [];
 
+  // PRs are the only place where this script narrows coverage by changed path.
+  // Push, scheduled, and manual runs stay broad because they protect branch
+  // health and release confidence after multiple PRs have composed.
   if (eventName !== "pull_request") {
     for (const lane of config.outputs) {
       addLane(matchesByLane, lane, {

--- a/packages/scripts/ci-path-gate.mjs
+++ b/packages/scripts/ci-path-gate.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { appendFileSync } from "node:fs";
+import { appendFileSync, readFileSync } from "node:fs";
 
 const CONFIGS = {
   test: {
@@ -377,7 +377,7 @@ function addLane(matchesByLane, lane, source) {
   matchesByLane.get(lane).push(source);
 }
 
-function evaluate(config, { eventName, labels, base, head }) {
+function evaluate(config, { eventName, labels, base, head, changedFilesPath }) {
   const matchesByLane = new Map(config.outputs.map((output) => [output, []]));
   let changedFiles = [];
 
@@ -391,7 +391,12 @@ function evaluate(config, { eventName, labels, base, head }) {
     return { changedFiles, matchesByLane };
   }
 
-  changedFiles = gitChangedFiles(base, head);
+  changedFiles = changedFilesPath
+    ? readFileSync(changedFilesPath, "utf8")
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+    : gitChangedFiles(base, head);
   const labelSet = new Set(
     labels
       .split(",")
@@ -498,12 +503,21 @@ function main() {
   const labels = args.labels || "";
   const base = args.base || "";
   const head = args.head || "";
+  const changedFilesPath = args["changed-files"] || "";
 
-  if (eventName === "pull_request" && (!base || !head)) {
-    throw new Error("--base and --head are required for pull_request events");
+  if (eventName === "pull_request" && !changedFilesPath && (!base || !head)) {
+    throw new Error(
+      "--base and --head are required for pull_request events unless --changed-files is provided",
+    );
   }
 
-  const result = evaluate(config, { eventName, labels, base, head });
+  const result = evaluate(config, {
+    eventName,
+    labels,
+    base,
+    head,
+    changedFilesPath,
+  });
   writeOutputs(
     args.output || process.env.GITHUB_OUTPUT,
     config,

--- a/packages/scripts/ci-path-gate.mjs
+++ b/packages/scripts/ci-path-gate.mjs
@@ -1,0 +1,521 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+
+const CONFIGS = {
+  test: {
+    title: "Tests path gate",
+    outputs: ["server", "client", "plugins", "desktop", "zero_key", "cloud"],
+    labels: {
+      "ci:full": [
+        "server",
+        "client",
+        "plugins",
+        "desktop",
+        "zero_key",
+        "cloud",
+      ],
+      "ci:server": ["server"],
+      "ci:client": ["client"],
+      "ci:plugins": ["plugins"],
+      "ci:desktop": ["desktop"],
+      "ci:e2e": ["zero_key"],
+      "ci:zero-key": ["zero_key"],
+      "ci:cloud": ["cloud"],
+    },
+    rules: [
+      {
+        lanes: ["server", "client", "plugins", "desktop", "zero_key", "cloud"],
+        patterns: [
+          "package.json",
+          "bun.lock",
+          "turbo.json",
+          "tsconfig*.json",
+          "vitest.config.*",
+        ],
+        reason: "workspace toolchain",
+      },
+      {
+        lanes: ["server", "client", "plugins", "desktop", "zero_key", "cloud"],
+        patterns: [
+          ".github/workflows/test.yml",
+          ".github/actions/setup-bun-workspace/**",
+          "packages/scripts/ci-path-gate.mjs",
+        ],
+        reason: "test workflow or shared CI setup",
+      },
+      {
+        lanes: ["server", "client", "plugins", "desktop", "zero_key"],
+        patterns: [
+          "packages/core/**",
+          "packages/agent/**",
+          "packages/shared/**",
+          "packages/prompts/**",
+          "packages/test/**",
+        ],
+        reason: "shared runtime surface",
+      },
+      {
+        lanes: ["client", "zero_key"],
+        patterns: ["packages/app/**", "packages/ui/**"],
+        reason: "app or shared UI",
+      },
+      {
+        lanes: ["server", "client", "desktop", "zero_key"],
+        patterns: ["packages/app-core/**"],
+        reason: "app-core host or desktop bridge",
+      },
+      {
+        lanes: ["server", "zero_key"],
+        patterns: ["packages/scenario-runner/**", "packages/scripts/**"],
+        reason: "scenario runner or repo scripts",
+      },
+      {
+        lanes: ["server", "client", "zero_key", "cloud"],
+        patterns: [
+          "packages/cloud-sdk/**",
+          "packages/cloud-shared/**",
+          "packages/cloud-frontend/**",
+        ],
+        reason: "cloud surface",
+      },
+      {
+        lanes: ["server"],
+        patterns: ["packages/security/**", "packages/vault/**"],
+        reason: "security or vault package",
+      },
+      {
+        lanes: ["plugins", "zero_key"],
+        patterns: ["plugins/**"],
+        reason: "plugin surface",
+      },
+    ],
+  },
+  "scenario-pr": {
+    title: "Scenario PR E2E path gate",
+    outputs: ["run_scenario_pr"],
+    labels: {
+      "ci:full": ["run_scenario_pr"],
+      "ci:e2e": ["run_scenario_pr"],
+      "ci:scenario": ["run_scenario_pr"],
+      "ci:zero-key": ["run_scenario_pr"],
+    },
+    rules: [
+      {
+        lanes: ["run_scenario_pr"],
+        patterns: [
+          "package.json",
+          "bun.lock",
+          "turbo.json",
+          "tsconfig*.json",
+          "vite.config.*",
+          "vitest.config.*",
+        ],
+        reason: "workspace toolchain",
+      },
+      {
+        lanes: ["run_scenario_pr"],
+        patterns: [
+          ".github/workflows/scenario-pr.yml",
+          ".github/actions/setup-bun-workspace/**",
+          "packages/scripts/ci-path-gate.mjs",
+        ],
+        reason: "scenario workflow or shared CI setup",
+      },
+      {
+        lanes: ["run_scenario_pr"],
+        patterns: [
+          "packages/app/**",
+          "packages/ui/**",
+          "packages/app-core/**",
+          "packages/scenario-runner/**",
+          "packages/core/**",
+          "packages/agent/**",
+          "packages/shared/**",
+          "packages/scripts/**",
+          "packages/test/**",
+          "packages/prompts/**",
+        ],
+        reason: "scenario runtime, UI, or support package",
+      },
+      {
+        lanes: ["run_scenario_pr"],
+        patterns: [
+          "plugins/plugin-app-control/**",
+          "plugins/plugin-computeruse/**",
+          "plugins/plugin-github/**",
+        ],
+        reason: "scenario-critical plugin",
+      },
+      {
+        lanes: ["run_scenario_pr"],
+        patterns: [
+          "plugins/plugin-*/src/**",
+          "plugins/plugin-*/package.json",
+          "plugins/plugin-*/vite.config.*",
+          "plugins/plugin-*/vitest.config.*",
+        ],
+        reason: "plugin implementation surface",
+      },
+    ],
+  },
+  docker: {
+    title: "Docker smoke path gate",
+    outputs: ["docker"],
+    labels: {
+      "ci:full": ["docker"],
+      "ci:docker": ["docker"],
+    },
+    rules: [
+      {
+        lanes: ["docker"],
+        patterns: [
+          ".github/workflows/docker-ci-smoke.yml",
+          ".github/actions/setup-bun-workspace/**",
+          "packages/scripts/ci-path-gate.mjs",
+          "package.json",
+          "bun.lock",
+          "bunfig.toml",
+          "turbo.json",
+          "packages/app-core/deploy/**",
+          "packages/app-core/scripts/docker-ci-smoke.sh",
+          "packages/app-core/scripts/docker-healthcheck.mjs",
+        ],
+        reason: "Docker smoke workflow or image contract",
+      },
+      {
+        lanes: ["docker"],
+        patterns: [
+          "packages/app-core/**",
+          "packages/agent/**",
+          "packages/core/**",
+          "packages/shared/**",
+          "packages/prompts/**",
+          "plugins/**",
+        ],
+        reason: "runtime included in production image",
+      },
+    ],
+  },
+  mobile: {
+    title: "Mobile smoke path gate",
+    outputs: ["ios", "android"],
+    labels: {
+      "ci:full": ["ios", "android"],
+      "ci:mobile": ["ios", "android"],
+      "ci:ios": ["ios"],
+      "ci:android": ["android"],
+    },
+    rules: [
+      {
+        lanes: ["ios", "android"],
+        patterns: [
+          ".github/workflows/mobile-build-smoke.yml",
+          ".github/actions/setup-bun-workspace/**",
+          "packages/scripts/ci-path-gate.mjs",
+          "package.json",
+          "bun.lock",
+          "packages/agent/**",
+          "packages/app/**",
+          "packages/app-core/**",
+          "packages/core/**",
+          "packages/native/plugins/**",
+          "packages/shared/**",
+          "plugins/plugin-sql/**",
+        ],
+        reason: "mobile app or runtime dependency",
+      },
+      {
+        lanes: ["ios"],
+        patterns: ["packages/app/ios/**", "packages/app-core/platforms/ios/**"],
+        reason: "iOS native surface",
+      },
+      {
+        lanes: ["android"],
+        patterns: [
+          "packages/app/android/**",
+          "packages/app-core/platforms/android/**",
+        ],
+        reason: "Android native surface",
+      },
+    ],
+  },
+  "dev-smoke": {
+    title: "Dev smoke path gate",
+    outputs: ["dev_smoke"],
+    labels: {
+      "ci:full": ["dev_smoke"],
+      "ci:dev-smoke": ["dev_smoke"],
+      "ci:e2e": ["dev_smoke"],
+    },
+    rules: [
+      {
+        lanes: ["dev_smoke"],
+        patterns: [
+          ".github/workflows/dev-smoke.yml",
+          ".github/actions/setup-bun-workspace/**",
+          "packages/scripts/ci-path-gate.mjs",
+          "package.json",
+          "bun.lock",
+          "packages/app/**",
+          "packages/app-core/**",
+          "packages/core/**",
+          "packages/shared/**",
+          "packages/ui/**",
+        ],
+        reason: "dev server or onboarding chat surface",
+      },
+    ],
+  },
+  "windows-dev": {
+    title: "Windows dev smoke path gate",
+    outputs: ["windows_dev"],
+    labels: {
+      "ci:full": ["windows_dev"],
+      "ci:windows": ["windows_dev"],
+      "ci:desktop": ["windows_dev"],
+    },
+    rules: [
+      {
+        lanes: ["windows_dev"],
+        patterns: [
+          ".github/workflows/windows-dev-smoke.yml",
+          ".github/actions/setup-bun-workspace/**",
+          "packages/scripts/ci-path-gate.mjs",
+          "package.json",
+          "bun.lock",
+          "packages/app-core/scripts/**",
+          "packages/app-core/platforms/electrobun/**",
+          "packages/app/**",
+        ],
+        reason: "Windows dev bootstrap surface",
+      },
+    ],
+  },
+  "desktop-preload": {
+    title: "Windows desktop preload path gate",
+    outputs: ["desktop_preload"],
+    labels: {
+      "ci:full": ["desktop_preload"],
+      "ci:windows": ["desktop_preload"],
+      "ci:desktop": ["desktop_preload"],
+    },
+    rules: [
+      {
+        lanes: ["desktop_preload"],
+        patterns: [
+          ".github/workflows/windows-desktop-preload-smoke.yml",
+          ".github/actions/setup-bun-workspace/**",
+          "packages/scripts/ci-path-gate.mjs",
+          "package.json",
+          "bun.lock",
+          "packages/app-core/scripts/**",
+          "packages/app-core/platforms/electrobun/**",
+          "packages/app/**",
+        ],
+        reason: "desktop preload or Electrobun surface",
+      },
+    ],
+  },
+};
+
+function parseArgs(argv) {
+  const args = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (!arg.startsWith("--")) {
+      throw new Error(`unexpected argument: ${arg}`);
+    }
+    const key = arg.slice(2);
+    const next = argv[index + 1];
+    if (next === undefined || next.startsWith("--")) {
+      args[key] = "true";
+    } else {
+      args[key] = next;
+      index += 1;
+    }
+  }
+  return args;
+}
+
+function globToRegExp(pattern) {
+  const sentinel = "\0";
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, sentinel)
+    .replace(/\*/g, "[^/]*")
+    .replaceAll(sentinel, ".*");
+  return new RegExp(`^${escaped}$`);
+}
+
+const patternCache = new Map();
+function matches(pattern, path) {
+  if (!patternCache.has(pattern)) {
+    patternCache.set(pattern, globToRegExp(pattern));
+  }
+  return patternCache.get(pattern).test(path);
+}
+
+function gitChangedFiles(base, head) {
+  const result = spawnSync("git", ["diff", "--name-only", base, head], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `git diff exited with ${result.status}`);
+  }
+  return result.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function addLane(matchesByLane, lane, source) {
+  if (!matchesByLane.has(lane)) {
+    matchesByLane.set(lane, []);
+  }
+  matchesByLane.get(lane).push(source);
+}
+
+function evaluate(config, { eventName, labels, base, head }) {
+  const matchesByLane = new Map(config.outputs.map((output) => [output, []]));
+  let changedFiles = [];
+
+  if (eventName !== "pull_request") {
+    for (const lane of config.outputs) {
+      addLane(matchesByLane, lane, {
+        kind: "event",
+        reason: `${eventName} runs this lane by default`,
+      });
+    }
+    return { changedFiles, matchesByLane };
+  }
+
+  changedFiles = gitChangedFiles(base, head);
+  const labelSet = new Set(
+    labels
+      .split(",")
+      .map((label) => label.trim())
+      .filter(Boolean),
+  );
+
+  for (const label of labelSet) {
+    for (const lane of config.labels[label] || []) {
+      addLane(matchesByLane, lane, {
+        kind: "label",
+        label,
+        reason: `forced by ${label}`,
+      });
+    }
+  }
+
+  for (const path of changedFiles) {
+    for (const rule of config.rules) {
+      const pattern = rule.patterns.find((candidate) =>
+        matches(candidate, path),
+      );
+      if (!pattern) {
+        continue;
+      }
+      for (const lane of rule.lanes) {
+        addLane(matchesByLane, lane, {
+          kind: "path",
+          path,
+          pattern,
+          reason: rule.reason,
+        });
+      }
+    }
+  }
+
+  return { changedFiles, matchesByLane };
+}
+
+function markdown(config, { changedFiles, matchesByLane, labels, eventName }) {
+  const lines = [
+    `### ${config.title}`,
+    "",
+    `- Event: \`${eventName}\``,
+    `- Force labels: \`${labels || "(none)"}\``,
+    "",
+    "| Lane | Run | Why |",
+    "| --- | --- | --- |",
+  ];
+
+  for (const lane of config.outputs) {
+    const sources = matchesByLane.get(lane) || [];
+    const reasons = sources.length
+      ? sources
+          .slice(0, 6)
+          .map((source) => {
+            if (source.kind === "path") {
+              return `\`${source.path}\` matched \`${source.pattern}\` (${source.reason})`;
+            }
+            if (source.kind === "label") {
+              return source.reason;
+            }
+            return source.reason;
+          })
+          .join("<br>")
+      : "No matching paths or force labels.";
+    lines.push(`| \`${lane}\` | \`${sources.length > 0}\` | ${reasons} |`);
+  }
+
+  if (changedFiles.length > 0) {
+    lines.push("", "<details><summary>Changed files</summary>", "");
+    for (const path of changedFiles) {
+      lines.push(`- \`${path}\``);
+    }
+    lines.push("", "</details>");
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function writeOutputs(path, config, matchesByLane) {
+  const body = config.outputs
+    .map((lane) => `${lane}=${(matchesByLane.get(lane) || []).length > 0}`)
+    .join("\n");
+  if (path) {
+    appendFileSync(path, `${body}\n`);
+  } else {
+    console.log(body);
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const configName = args.config;
+  const config = CONFIGS[configName];
+  if (!config) {
+    throw new Error(
+      `unknown config '${configName}'. Expected one of: ${Object.keys(CONFIGS).join(", ")}`,
+    );
+  }
+
+  const eventName =
+    args.event || process.env.GITHUB_EVENT_NAME || "pull_request";
+  const labels = args.labels || "";
+  const base = args.base || "";
+  const head = args.head || "";
+
+  if (eventName === "pull_request" && (!base || !head)) {
+    throw new Error("--base and --head are required for pull_request events");
+  }
+
+  const result = evaluate(config, { eventName, labels, base, head });
+  writeOutputs(
+    args.output || process.env.GITHUB_OUTPUT,
+    config,
+    result.matchesByLane,
+  );
+
+  const summary = markdown(config, { ...result, labels, eventName });
+  if (args.summary || process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(args.summary || process.env.GITHUB_STEP_SUMMARY, summary);
+  } else {
+    console.log(summary);
+  }
+}
+
+main();

--- a/packages/scripts/ci-path-gate.self-test.mjs
+++ b/packages/scripts/ci-path-gate.self-test.mjs
@@ -3,8 +3,9 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-const script = new URL("./ci-path-gate.mjs", import.meta.url).pathname;
+const script = fileURLToPath(new URL("./ci-path-gate.mjs", import.meta.url));
 
 function runGate({ config, files = [], labels = "" }) {
   const dir = mkdtempSync(join(tmpdir(), "ci-path-gate-"));

--- a/packages/scripts/ci-path-gate.self-test.mjs
+++ b/packages/scripts/ci-path-gate.self-test.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const script = new URL("./ci-path-gate.mjs", import.meta.url).pathname;
+
+function runGate({ config, files = [], labels = "" }) {
+  const dir = mkdtempSync(join(tmpdir(), "ci-path-gate-"));
+  const changedFiles = join(dir, "changed-files.txt");
+  const output = join(dir, "github-output.txt");
+  const summary = join(dir, "summary.md");
+  writeFileSync(changedFiles, `${files.join("\n")}\n`);
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      script,
+      "--config",
+      config,
+      "--event",
+      "pull_request",
+      "--changed-files",
+      changedFiles,
+      "--labels",
+      labels,
+      "--output",
+      output,
+      "--summary",
+      summary,
+    ],
+    { encoding: "utf8" },
+  );
+
+  if (result.status !== 0) {
+    throw new Error(
+      result.stderr || result.stdout || `ci-path-gate exited ${result.status}`,
+    );
+  }
+
+  const values = Object.fromEntries(
+    readOutput(output).map((line) => {
+      const [key, value] = line.split("=");
+      return [key, value];
+    }),
+  );
+  rmSync(dir, { recursive: true, force: true });
+  return values;
+}
+
+function readOutput(path) {
+  return readFileSync(path, "utf8").split(/\r?\n/).filter(Boolean);
+}
+
+function assertEqual(actual, expected, message) {
+  if (actual !== expected) {
+    throw new Error(`${message}: expected ${expected}, got ${actual}`);
+  }
+}
+
+function assertGate(name, actual, expected) {
+  for (const [key, value] of Object.entries(expected)) {
+    assertEqual(actual[key], value, `${name} ${key}`);
+  }
+}
+
+assertGate(
+  "app changes",
+  runGate({ config: "test", files: ["packages/app/src/App.tsx"] }),
+  {
+    server: "false",
+    client: "true",
+    plugins: "false",
+    desktop: "false",
+    zero_key: "true",
+    cloud: "false",
+  },
+);
+
+assertGate("full label", runGate({ config: "test", labels: "ci:full" }), {
+  server: "true",
+  client: "true",
+  plugins: "true",
+  desktop: "true",
+  zero_key: "true",
+  cloud: "true",
+});
+
+assertGate(
+  "android label",
+  runGate({ config: "mobile", labels: "ci:android" }),
+  {
+    ios: "false",
+    android: "true",
+  },
+);
+
+assertGate(
+  "docker runtime",
+  runGate({ config: "docker", files: ["plugins/plugin-openai/src/index.ts"] }),
+  {
+    docker: "true",
+  },
+);
+
+console.log("ci-path-gate self-test passed");


### PR DESCRIPTION
## Summary
- add a shared `packages/scripts/ci-path-gate.mjs` classifier for PR path gates
- replace inline bash classifiers in `test.yml` and `scenario-pr.yml` with the shared classifier and richer job summaries
- add lightweight classifier jobs for Docker, mobile, dev smoke, and Windows desktop smoke workflows so expensive jobs can skip with an explanation
- split the long deterministic zero-key E2E jobs into parallel named slices with the existing `Zero-Key Deterministic E2E` checks preserved as aggregate gates
- add force labels for maintainers: `ci:full`, `ci:e2e`, `ci:zero-key`, `ci:server`, `ci:client`, `ci:plugins`, `ci:cloud`, `ci:docker`, `ci:mobile`, `ci:ios`, `ci:android`, `ci:desktop`, `ci:windows`, `ci:dev-smoke`
- document the PR path-gate contract in `.github/workflows/README.md`
- add CI workflow changelog and roadmap docs with the WHYs behind path gates, parallel slices, force labels, and future long-pole work
- self-test the shared classifier in CI before workflow decisions consume it

## Validation
- `bunx @biomejs/biome check packages/scripts/ci-path-gate.mjs packages/scripts/ci-path-gate.self-test.mjs`
- `node --check packages/scripts/ci-path-gate.mjs`
- `node packages/scripts/ci-path-gate.self-test.mjs`
- YAML parse for touched workflow files via Ruby `YAML.load_file`
- `git diff --cached --check`
- `git diff --check`
- staged-tree classifier samples for `test`, `mobile`, and `docker`, including empty labels and `ci:android` label forcing
- YAML parse after splitting the `Tests` and `Scenario PR E2E` deterministic lanes

## Notes
- Push, scheduled, and manual runs keep broad/default behavior.
- PR label events now trigger the gated workflows so maintainers can force lanes without pushing a no-op commit.
- The visible deterministic E2E checks are now aggregate status jobs over parallel slices, so reviewers can inspect the failing surface directly instead of opening one giant serial log.
