### PR TITLE
fix(ci): stop Cloud Live E2E swallowing real failures as 'provider unavailable'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -574,8 +574,16 @@ jobs:
             exit 0
           fi
 
-          if grep -Eiq 'CloudApiError:.*(404|not found)|status code: 404|HTTP 404|exceeded your current quota|quota exceeded|insufficient[_ -]?(quota|balance|funds|credits?)|billing details|credit balance|please add credits|top[_ -]?up your credits|invalid api key|unauthorized|authentication|status code: 429|too many requests|unexpected error occurred while processing the request|temporarily unavailable|service unavailable|internal server error|overloaded' "$log_file"; then
-            echo "::warning::Cloud Live E2E skipped because the configured external provider is unavailable."
+          # Soft-fail ONLY on genuine provider-side unavailability (HTTP 429/5xx, quota
+          # exhaustion, or network errors) that a contributor can't control. Client-side
+          # failures must redden the job so real regressions aren't masked: 4xx auth/permission
+          # (e.g. 403 access_denied / "missing required permission"), assertion failures and
+          # timeouts all fall through to exit 1. Patterns are anchored to HTTP status codes and
+          # error tokens so they can't collide with a benign test title (the old allowlist
+          # matched "credit balance" from the test name "gets credit balance and summary",
+          # swallowing every failure on every run).
+          if grep -Eiq '(status code|statusCode|HTTP)[: ]*429|too many requests|rate.?limit|(status code|statusCode|HTTP)[: ]*5[0-9][0-9]|service unavailable|internal server error|temporarily unavailable|overloaded|exceeded your current quota|quota exceeded|insufficient[_ -]?(quota|balance|funds|credits?)|please add credits|top[_ -]?up your credits|ECONNREFUSED|ENOTFOUND|ETIMEDOUT|ECONNRESET|socket hang up' "$log_file"; then
+            echo "::warning::Cloud Live E2E soft-failed: external provider unavailable (HTTP 429/5xx, quota, or network error). Genuine test failures are NOT suppressed."
             exit 0
           fi
 


### PR DESCRIPTION
## What

The `cloud-live-e2e` job in `test.yml` soft-fails when the live Eliza Cloud provider is genuinely down — good intent. But it did it by grepping the **whole vitest log** for loose English phrases, and one allowlist phrase — `credit balance` — matches the **test title** `gets credit balance and summary`, which prints on every run. So the grep matched on *every* run and rewrote *any* non-zero exit to `exit 0`. The green was lying.

## Proof

On the latest green develop run ([job 81448139590](https://github.com/elizaOS/eliza/actions/runs/27553234298/job/81448139590)) the suite actually reported:

```
Tests  2 failed | 4 passed | 12 skipped (18)
```

- `live.e2e.test.ts:166` — **403 `access_denied`**: `API key missing required permission: containers:read` (the `listContainers / getContainerQuota / listAgents` read surface that backs plugin-elizacloud + the dashboard)
- `live.e2e.test.ts:95` — CLI-login poll **timed out at 5s**

…both swallowed, job shipped **success**. The allowlist also matched `unauthorized` / `authentication`, so a genuine 401/403 authz regression could never redden the job either.

## Fix

Tighten the soft-fail to **only genuine provider-side unavailability** — HTTP `429`/`5xx`, quota/credit exhaustion, and network errors (`ECONNREFUSED`/`ENOTFOUND`/`ETIMEDOUT`/…) — anchored to status codes and error tokens so it **can't collide with a test title**. Client-side failures (4xx auth/permission, assertion failures, timeouts) now fall through to `exit 1` and redden the job. The warning message is also corrected (it no longer claims 'provider unavailable' for things that aren't).

Validated empirically against the real failing log:
- new regex vs the real `403`/timeout output → **no match → reddens** ✅
- genuine outages (`429`, `503`, `quota exceeded`, `ECONNREFUSED`, `500`) → still soft-fail ✅
- the colliding title `gets credit balance and summary` → no longer matches ✅
- zero collisions across all 15 test titles ✅

## Heads-up — this surfaces two real, pre-existing issues

The previous green hid them; this PR makes them visible (that's the point):

1. **CI Eliza Cloud API key is missing `containers:read`** → needs re-provisioning on the Steward/Cloud side (key scope, not code).
2. **CLI-login poll times out at 5s** → worth a look (real slowness or a too-tight timeout).

So `cloud-live-e2e` will now show an **honest red** on runs that have the secrets (develop / internal PRs / scheduled) until those are addressed. Fork/community PRs are unaffected — they skip the live job entirely (no secrets). Branch protection is off on develop, so nothing is merge-blocked either way.

## Scope note

I checked whether the **12 skipped** tests should run in CI — they're correctly gated behind destructive/paid/session flags (real container/agent create-delete, paid generation, key CRUD, profile writes). Left them as-is. The masking was purely the grep.

## Test plan

- [ ] CI runs; `cloud-live-e2e` reflects the **real** live result instead of a forced green (expected red here until the CI key gets `containers:read`)
- [ ] Confirm fork PRs still skip the live job (secret-presence gate untouched)