### PR TITLE
fix(apps-arm): arm APPS_DEPLOY_ENABLED so the deploy runner activates

### DIFF
--- a/.github/workflows/arm-apps-daemon.yml
+++ b/.github/workflows/arm-apps-daemon.yml
@@ -143,6 +143,10 @@ jobs:
               printf '%s\n' "$k=\"$v\"" | sudo tee -a "$F" >/dev/null
             }
 
+            # APPS_DEPLOY_ENABLED arms the APP_DEPLOY runner; without it the daemon's
+            # armAppsDeployBackendIfEnabled() early-returns (provisioning-worker.ts:652)
+            # and APP_DEPLOY jobs never get claimed (apps stuck "building").
+            upsert APPS_DEPLOY_ENABLED 1
             upsert APPS_CONTAINERS_ENABLED 1
             upsert CONTAINERS_DOCKER_NODES "$APP_NODE"
             upsert CONTAINERS_SSH_USER deploy

--- a/packages/scripts/cloud/admin/arm-apps-daemon.mjs
+++ b/packages/scripts/cloud/admin/arm-apps-daemon.mjs
@@ -69,6 +69,11 @@ if (!sshKey)
 // omitted, so an operator can layer this onto a box that already has it set
 // (and we never clobber an agent-fleet value by accident — see the guard).
 const desired = {
+  // Arms the APP_DEPLOY runner (DefaultAppDeployRunner). Without this the daemon's
+  // armAppsDeployBackendIfEnabled() early-returns (provisioning-worker.ts:652) and
+  // APP_DEPLOY jobs are enqueued but never claimed — apps stay stuck "building".
+  APPS_DEPLOY_ENABLED: "1",
+  // Arms the container executor backend (AppContainerProvider over docker-over-SSH).
   APPS_CONTAINERS_ENABLED: "1",
   CONTAINERS_DOCKER_NODES: args["app-node"],
   CONTAINERS_SSH_USER: args["node-ssh-user"] || "deploy",


### PR DESCRIPTION
## What
The apps-daemon arm path (`arm-apps-daemon.yml` + its mirror `arm-apps-daemon.mjs`) upserts `APPS_CONTAINERS_ENABLED=1` (container executor) but **never** `APPS_DEPLOY_ENABLED=1`. So even after arming a CP node, the daemon's `armAppsDeployBackendIfEnabled()` early-returns (`provisioning-worker.ts:652`): `APP_DEPLOY` jobs get enqueued but **never claimed**, and apps stay stuck `deployment_status=building` with no URL (repro'd on prod: app `council`).

## Fix
Upsert `APPS_DEPLOY_ENABLED=1` in both mirrors, right before `APPS_CONTAINERS_ENABLED`. Now arming any CP node activates the **full** deploy path (APP_DEPLOY runner + container executor), not just the container backend.

## Why it matters for launch
This is a prerequisite for the staging→prod apps cutover. When the prod daemon is armed via `arm-apps-daemon.yml -f environment=production`, it now actually enables the deploy runner.

## ⚠️ Ordering (not auto-merge to main)
This is a develop-only prep. For the prod cutover the safe order is: (1) prod apps data plane applied (terraform), (2) prod Worker gets `APPS_DEPLOY_ENABLED` in `[env.production.vars]` (separate change), (3) merge develop→main, (4) arm the prod daemon with this fix. Do **not** flip prod until staging QA is green.

## Test
- `arm-apps-daemon.yml` run log already greps `^APPS_` for the on-box env dump → will now show `APPS_DEPLOY_ENABLED="1"`.
- No behavior change unless the arm workflow/script is dispatched.

cc @standujar — this is the arm-path gap from tonight's launch QA; pairs with your staging secrets work.