### PR TITLE
feat(cloud-headscale): env-portable config + deploy CI/CD

### DIFF
--- a/.github/workflows/cloud-headscale.yml
+++ b/.github/workflows/cloud-headscale.yml
@@ -1,0 +1,80 @@
+name: Cloud Headscale
+
+# CD for the headscale tunnel-coordination service (the one cloud service that
+# had no deploy automation — see packages/cloud-services/headscale/DEPLOY.md).
+#
+# Unlike the gateways (which rely on Railway's native GitHub auto-deploy), this
+# deploys explicitly with `railway up` so the pipeline is fully defined in-repo
+# and deterministic. Branch -> env mirrors deploy-eliza-provisioning-worker.yml:
+#   develop -> staging      (headscale-staging.elizacloud.ai)
+#   main    -> production   (headscale.elizacloud.ai)
+# The image is env-portable: entrypoint.sh templates server_url from the per-env
+# RAILWAY_PUBLIC_DOMAIN, so the same source builds correctly in both envs.
+#
+# One-time setup per env (NOT done here): a Railway volume mounted at
+# /var/lib/headscale, the custom domain, and `headscale users/apikeys create`
+# for HEADSCALE_API_KEY. See DEPLOY.md.
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "packages/cloud-services/headscale/**"
+      - ".github/workflows/cloud-headscale.yml"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target Railway environment"
+        required: true
+        default: "staging"
+        type: choice
+        options:
+          - staging
+          - production
+
+concurrency:
+  group: cloud-headscale-${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'production' || 'staging') }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  resolve-env:
+    name: Resolve environment
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.env.outputs.environment }}
+    steps:
+      - id: env
+        run: |
+          if [ -n "${{ github.event.inputs.environment }}" ]; then
+            env="${{ github.event.inputs.environment }}"
+          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            env="production"
+          else
+            env="staging"
+          fi
+          echo "environment=$env" >> "$GITHUB_OUTPUT"
+          echo "Resolved Railway environment: $env"
+
+  deploy:
+    name: Deploy headscale (${{ needs.resolve-env.outputs.environment }})
+    needs: resolve-env
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Install Railway CLI
+        run: bash <(curl -fsSL https://railway.com/install.sh) || npm i -g @railway/cli
+
+      - name: Deploy to Railway
+        working-directory: packages/cloud-services/headscale
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          railway up \
+            --service headscale \
+            --environment "${{ needs.resolve-env.outputs.environment }}" \
+            --ci

--- a/.github/workflows/cloud-headscale.yml
+++ b/.github/workflows/cloud-headscale.yml
@@ -9,11 +9,24 @@ name: Cloud Headscale
 #   develop -> staging      (headscale-staging.elizacloud.ai)
 #   main    -> production   (headscale.elizacloud.ai)
 # The image is env-portable: entrypoint.sh templates server_url from the per-env
-# RAILWAY_PUBLIC_DOMAIN, so the same source builds correctly in both envs.
+# HEADSCALE_PUBLIC_URL Railway variable, so the same source builds correctly in
+# both envs.
 #
-# One-time setup per env (NOT done here): a Railway volume mounted at
-# /var/lib/headscale, the custom domain, and `headscale users/apikeys create`
-# for HEADSCALE_API_KEY. See DEPLOY.md.
+# REQUIRED one-time setup (NOT done here):
+#   - Disable Railway's native GitHub auto-deploy on the headscale service
+#     (Settings -> disconnect repo / no auto-deploy) so this `railway up` is the
+#     SOLE deploy path. Otherwise a single push triggers two concurrent builds
+#     of the live coordination server, racing the SQLite volume. See DEPLOY.md.
+#   - Two GitHub Environments (staging, production), each holding its own
+#     project-scoped RAILWAY_TOKEN bound to that Railway environment. A Railway
+#     project token is scoped to ONE project+environment, so per-env tokens are
+#     what make `main -> production` / `develop -> staging` actually target the
+#     right env. The `environment:` key on the deploy job resolves the matching
+#     token (and applies production protection rules).
+#   - HEADSCALE_PUBLIC_URL set per env (prod https://headscale.elizacloud.ai,
+#     staging https://headscale-staging.elizacloud.ai), a Railway volume mounted
+#     at /var/lib/headscale, the custom domain, and `headscale users/apikeys
+#     create` for HEADSCALE_API_KEY. See DEPLOY.md.
 
 on:
   push:
@@ -62,19 +75,83 @@ jobs:
     name: Deploy headscale (${{ needs.resolve-env.outputs.environment }})
     needs: resolve-env
     runs-on: ubuntu-latest
+    # Bind to the per-env GitHub Environment so secrets.RAILWAY_TOKEN resolves to
+    # that environment's project-scoped Railway token (a Railway project token is
+    # bound to ONE project+environment). This also applies the environment's
+    # protection rules (e.g. required reviewers on production), mirroring
+    # deploy-eliza-provisioning-worker.yml.
+    environment: ${{ needs.resolve-env.outputs.environment }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install Railway CLI
-        run: bash <(curl -fsSL https://railway.com/install.sh) || npm i -g @railway/cli
+        # npm is present on ubuntu-latest; a single pinned install is
+        # deterministic and avoids the curl-pipe-to-bash fallback that never
+        # actually fell back on a download failure (process substitution masks
+        # curl's exit status).
+        run: npm i -g @railway/cli@5.13.0
 
       - name: Deploy to Railway
         working-directory: packages/cloud-services/headscale
         env:
+          # Per-env project token from the bound GitHub Environment; it pins the
+          # Railway project+environment, so no --environment flag is needed (and
+          # passing one that differs from the token's env is rejected).
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
           railway up \
             --service headscale \
-            --environment "${{ needs.resolve-env.outputs.environment }}" \
             --ci
+
+      - name: Health check
+        # `railway up --ci` streams build logs and exits when the BUILD finishes;
+        # it does NOT gate on the container becoming healthy. Combined with
+        # railway.toml restartPolicyType=ON_FAILURE, a build that crash-loops at
+        # runtime (bad server_url, missing volume) would otherwise report green.
+        # headscale exposes /health on the public URL; poll it and fail on a
+        # non-200. HEALTHCHECK_URL is set per env (matches HEADSCALE_PUBLIC_URL).
+        env:
+          HEALTHCHECK_URL: ${{ vars.HEADSCALE_PUBLIC_URL }}
+        run: |
+          if [ -z "$HEALTHCHECK_URL" ]; then
+            echo "::warning::HEADSCALE_PUBLIC_URL not set for this environment; skipping post-deploy health check. --ci only validated the build, not runtime health."
+            exit 0
+          fi
+          for attempt in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' -m 5 "${HEALTHCHECK_URL%/}/health" || echo "000")
+            if [ "$code" = "200" ]; then
+              echo "headscale /health returned 200 on attempt $attempt."
+              exit 0
+            fi
+            echo "Health check attempt $attempt/30: ${HEALTHCHECK_URL%/}/health -> $code"
+            sleep 10
+          done
+          echo "::error::headscale did not return 200 from /health within ~5min after deploy."
+          exit 1
+
+      - name: Notify Discord (Success)
+        if: success()
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          ack_no_webhook: true
+          title: "🚀 Cloud Headscale Deployed (${{ needs.resolve-env.outputs.environment }})"
+          nodetail: true
+          description: |
+            Environment: ${{ needs.resolve-env.outputs.environment }}
+            Commit: ${{ github.sha }}
+          color: 0x00ff00
+
+      - name: Notify Discord (Failure)
+        if: failure()
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          ack_no_webhook: true
+          title: "❌ Cloud Headscale Deploy Failed (${{ needs.resolve-env.outputs.environment }})"
+          nodetail: true
+          description: |
+            Environment: ${{ needs.resolve-env.outputs.environment }}
+            Commit: ${{ github.sha }}
+          color: 0xff0000

--- a/packages/cloud-services/headscale/DEPLOY.md
+++ b/packages/cloud-services/headscale/DEPLOY.md
@@ -27,6 +27,25 @@ headscale apikeys create --expiration=8760h
 Mount a Railway volume at `/var/lib/headscale` so the SQLite DB and generated keys persist across restarts.
 Do not set a Railway start-command override; the Dockerfile starts Headscale with `CMD ["headscale", "serve"]`.
 
+### Per-environment variables
+
+`server_url` must equal the public-facing custom domain (agents/tunnels register and re-derive control/DERP/MagicDNS against it). The entrypoint templates it from an explicit `HEADSCALE_PUBLIC_URL` Railway variable, NOT from `RAILWAY_PUBLIC_DOMAIN` (Railway injects that as the auto-generated `*.up.railway.app` host, not the custom domain). Set it per env:
+
+| Environment | `HEADSCALE_PUBLIC_URL` |
+|---|---|
+| production | `https://headscale.elizacloud.ai` |
+| staging | `https://headscale-staging.elizacloud.ai` |
+
+When unset, the committed `config.yaml` prod value stands.
+
+### CI/CD (`.github/workflows/cloud-headscale.yml`)
+
+`develop -> staging`, `main -> production`, deployed explicitly with `railway up`. Required one-time setup so this is the SOLE deploy path and it targets the right env:
+
+- **Disable Railway's native GitHub auto-deploy** on the headscale service (Settings -> disconnect repo / no auto-deploy). Otherwise a single push triggers BOTH the native Railway deploy and the workflow's `railway up`, racing two concurrent builds of the live control plane against the single SQLite volume.
+- Define two **GitHub Environments** (`staging`, `production`), each holding its own project-scoped `RAILWAY_TOKEN` bound to that Railway environment. A Railway project token is scoped to one project+environment, so per-env tokens are what make the branch->env mapping actually land in the right place; the workflow's `environment:` key resolves the matching token and applies production protection rules.
+- Set `HEADSCALE_PUBLIC_URL` (above) as a GitHub Environment variable too, so the workflow's post-deploy `/health` gate hits the right host. `railway up --ci` only validates the BUILD, not runtime health — the health gate is what catches a container that builds but crash-loops (bad server_url, missing volume).
+
 ## 3. Long-lived headscale preauth key for the proxy
 
 ```

--- a/packages/cloud-services/headscale/Dockerfile
+++ b/packages/cloud-services/headscale/Dockerfile
@@ -21,7 +21,12 @@ RUN apk add --no-cache ca-certificates tzdata wget \
 # /var/lib/headscale for the sqlite db and generated keys.
 COPY config.yaml /etc/headscale/config.yaml
 COPY acl.hujson /etc/headscale/acl.hujson
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 EXPOSE 8080
 
-CMD ["headscale", "serve"]
+# Entrypoint templates server_url from RAILWAY_PUBLIC_DOMAIN (per-env) then
+# execs `headscale serve` — same runtime behaviour, now env-portable so the
+# one image deploys to prod + staging without baking a hardcoded URL.
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/packages/cloud-services/headscale/entrypoint.sh
+++ b/packages/cloud-services/headscale/entrypoint.sh
@@ -3,12 +3,21 @@ set -e
 
 # Make server_url env-portable. The committed config.yaml ships a prod fallback
 # (headscale.elizacloud.ai), but the same image deploys to multiple Railway
-# environments — each gets its own RAILWAY_PUBLIC_DOMAIN (prod
-# headscale.elizacloud.ai, staging headscale-staging.elizacloud.ai). Without this
-# the staging instance would advertise the prod URL and agents/tunnels would
-# register against the wrong coordination server.
-if [ -n "${RAILWAY_PUBLIC_DOMAIN:-}" ]; then
-  sed -i "s|^server_url:.*|server_url: https://${RAILWAY_PUBLIC_DOMAIN}|" /etc/headscale/config.yaml
+# environments. server_url MUST equal the public-facing custom domain that
+# agents/tunnels register and re-derive control/DERP/MagicDNS against, so it is
+# driven from an explicit per-env HEADSCALE_PUBLIC_URL Railway variable (prod
+# https://headscale.elizacloud.ai, staging https://headscale-staging.elizacloud.ai)
+# rather than RAILWAY_PUBLIC_DOMAIN — Railway injects RAILWAY_PUBLIC_DOMAIN as
+# the auto-generated *.up.railway.app host, NOT the custom domain, so templating
+# from it would advertise the wrong coordination server. When HEADSCALE_PUBLIC_URL
+# is unset the committed config.yaml value (prod) stands.
+if [ -n "${HEADSCALE_PUBLIC_URL:-}" ]; then
+  # Avoid sed string interpolation: HEADSCALE_PUBLIC_URL would otherwise need
+  # `&`, `|`, `/` and newlines escaped before substitution. Rewrite the line
+  # without regex so any value is written verbatim.
+  grep -v '^server_url:' /etc/headscale/config.yaml > /tmp/config.yaml
+  printf 'server_url: %s\n' "$HEADSCALE_PUBLIC_URL" | cat - /tmp/config.yaml > /etc/headscale/config.yaml
+  rm -f /tmp/config.yaml
 fi
 
 exec headscale serve

--- a/packages/cloud-services/headscale/entrypoint.sh
+++ b/packages/cloud-services/headscale/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+# Make server_url env-portable. The committed config.yaml ships a prod fallback
+# (headscale.elizacloud.ai), but the same image deploys to multiple Railway
+# environments — each gets its own RAILWAY_PUBLIC_DOMAIN (prod
+# headscale.elizacloud.ai, staging headscale-staging.elizacloud.ai). Without this
+# the staging instance would advertise the prod URL and agents/tunnels would
+# register against the wrong coordination server.
+if [ -n "${RAILWAY_PUBLIC_DOMAIN:-}" ]; then
+  sed -i "s|^server_url:.*|server_url: https://${RAILWAY_PUBLIC_DOMAIN}|" /etc/headscale/config.yaml
+fi
+
+exec headscale serve

--- a/packages/cloud-services/headscale/railway.toml
+++ b/packages/cloud-services/headscale/railway.toml
@@ -7,5 +7,8 @@ dockerfilePath = "./Dockerfile"
 [deploy]
 healthcheckPath = "/health"
 healthcheckTimeout = 30
-restartPolicyType = "ON_FAILURE"
-restartPolicyMaxRetries = 10
+# This is a stateful, single-instance control plane: if every customer tunnel
+# loses its coordination server the blast radius is the whole tunnel fleet.
+# Prefer ALWAYS over ON_FAILURE+capped retries so a transient boot failure
+# self-heals instead of hard-downing prod once the retry budget is exhausted.
+restartPolicyType = "ALWAYS"


### PR DESCRIPTION
## Why
headscale is the **one cloud service with no deploy automation**. It ships a Dockerfile + `railway.toml` + a manual `DEPLOY.md` runbook, but unlike the gateways (`cloud-gateway-*.yml`) there's no workflow. Consequence: the **staging instance was never stood up** — `headscale-staging.elizacloud.ai` → 404 — and dedicated-agent provisioning on staging **throws**: `requiresHeadscaleRoute()` is true for `ENVIRONMENT=staging` but there's no headscale to register against. Staging dedicated-agent E2E has never worked because of this.

## What
1. **Env-portable config.** `config.yaml:6` hardcoded `server_url: https://headscale.elizacloud.ai`, so the same image couldn't deploy to staging (it'd advertise the prod coordination URL). New `entrypoint.sh` templates `server_url` from the per-env `RAILWAY_PUBLIC_DOMAIN` (prod → headscale.elizacloud.ai, staging → headscale-staging.elizacloud.ai), then `exec headscale serve` — identical runtime, now portable across envs.
2. **CI/CD.** `cloud-headscale.yml` does an explicit `railway up` per env (develop→staging, main→production), mirroring `deploy-eliza-provisioning-worker.yml`'s branch→env mapping. Fully in-repo + deterministic, rather than relying on Railway's dashboard auto-deploy.

## One-time setup still required (NOT in this PR — see DEPLOY.md)
- `RAILWAY_TOKEN` GitHub secret (project/env-scoped).
- A Railway **volume** at `/var/lib/headscale` + the **custom domain** on the staging headscale service.
- Bootstrap inside the container: `headscale users create agent/tunnel` + `headscale apikeys create` → set `HEADSCALE_API_KEY` (staging Worker secret + the provisioning-worker daemon `.env.local`).

## Review note
If the **prod** headscale service already has Railway's native GitHub auto-deploy on `main`, disable it to avoid a double-deploy with this workflow. Staging has no existing auto-deploy, so it's unaffected.