### PR TITLE
feat(cloud-api): enable APPS_DEPLOY_ENABLED on production (cutover trigger)

### DIFF
--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -327,6 +327,13 @@ __filename = '"/worker.js"'
 
 [env.production.vars]
 NODE_ENV = "production"
+# Apps deploy (Product 2): arms the Worker-side deploy trigger (configureAppsDeployTrigger,
+# bootstrap-app.ts) so POST /api/v1/apps/:id/deploy enqueues a real APP_DEPLOY job instead of
+# the no-op stub. Mirrors [env.staging.vars]. CUTOVER GATE — only effective once the prod
+# daemon is armed (arm-apps-daemon.yml -f environment=production, sets APPS_DEPLOY_ENABLED via
+# #8422) AND the prod apps data plane exists (terraform). Do NOT merge develop→main until
+# staging QA is green and the prod data plane is applied.
+APPS_DEPLOY_ENABLED = "1"
 NEXT_PUBLIC_APP_URL = "https://elizacloud.ai"
 NEXT_PUBLIC_API_URL = "https://api.elizacloud.ai"
 ELIZA_CLOUD_URL = "https://elizacloud.ai"


### PR DESCRIPTION
## What
Adds `APPS_DEPLOY_ENABLED = "1"` to `[env.production.vars]` in `wrangler.toml` — the **only** apps var staging (#8406) has that production lacks. Arms the prod Worker's apps deploy trigger (`configureAppsDeployTrigger`, `bootstrap-app.ts`) so `POST /api/v1/apps/:id/deploy` enqueues a real `APP_DEPLOY` job instead of the no-op stub.

## ⚠️ DRAFT — this is the apps prod cutover trigger
Opened so the team can review/own the timing. **Do not merge until:**
1. Staging QA is green (Stan's headscale + the 3 staging secrets).
2. The prod apps **data plane** is applied (terraform-apps-shared + data-plane, `environment=production`).
3. The prod **daemon** is armed (`arm-apps-daemon.yml -f environment=production`, now sets `APPS_DEPLOY_ENABLED` via #8422).

Merging this before (1)-(3) would half-enable prod deploy (Worker enqueues jobs the unarmed daemon can't claim → apps stuck `building`). Full cutover checklist: #8321 (comment).

cc @standujar — this is the wrangler line from the cutover checklist, staged for your go.