### PR TITLE
fix(models): recommend healthy Cerebras defaults, not the flaky :nitro

### DIFF
--- a/packages/cloud-shared/src/lib/models/catalog.ts
+++ b/packages/cloud-shared/src/lib/models/catalog.ts
@@ -77,7 +77,8 @@ const BITROUTER_FEATURED_TEXT_MODELS: CatalogModel[] = [
     type: "language",
     context_window: 131072,
     max_tokens: 40960,
-    tags: ["reasoning", "open-weight", "cerebras"],
+    tags: ["recommended", "reasoning", "open-weight", "cerebras"],
+    recommended: true,
   },
   {
     id: BITROUTER_RECOMMENDED_TEXT_MODEL,
@@ -85,11 +86,10 @@ const BITROUTER_FEATURED_TEXT_MODELS: CatalogModel[] = [
     created: 0,
     owned_by: "openai",
     name: "GPT OSS 120B Nitro",
-    description: "Recommended BitRouter high-throughput open-weight reasoning model",
+    description: "BitRouter high-throughput open-weight reasoning model (gateway path)",
     type: "language",
     context_window: 131072,
-    tags: ["recommended", "reasoning", "open-weight", "nitro"],
-    recommended: true,
+    tags: ["reasoning", "open-weight", "nitro"],
   },
   {
     id: "openai/gpt-oss-120b",


### PR DESCRIPTION
## What
Per @shaw + @shad0w tonight: **small = `cerebras gpt-oss-120b`, large = `cerebras zai-glm-4.7`** — both Cerebras-native (the healthy path). The catalog flagged `openai/gpt-oss-120b:nitro` (BitRouter gateway) as `recommended`, but it's the flaky one.

## Why
Live: `openai/gpt-oss-120b:nitro` → **503 Bad Gateway** (BitRouter), while `cerebras:gpt-oss-120b` + `cerebras:zai-glm-4.7` → **200 in 3-4s**. `/api/v1/models/status` still reports `:nitro` `available:true`, so a new user landing on the recommended default hits a 503 first try.

## Change
- `CEREBRAS_DEFAULT_TEXT_SMALL_MODEL` (gpt-oss-120b) → now `recommended: true` (was missing the badge).
- `CEREBRAS_DEFAULT_TEXT_LARGE_MODEL` (zai-glm-4.7) → already recommended ✓.
- `openai/gpt-oss-120b:nitro` → drop `recommended` badge (still available, just not the default).

## Notes for the team to decide
- This changes the **catalog `recommended` flags** only — the runtime already routes both Cerebras defaults to Cerebras (`isCerebrasNativeModel`). The `BITROUTER_RECOMMENDED_TEXT_MODEL` constant still points at `:nitro` for the gateway free-model fallback map; left as-is (separate concern) — flag if you want it repointed.
- Follow-up worth considering: `/api/v1/models/status` reports unpriced/unhealthy models as `available:true` (membership check, not health) — not in this PR.