### PR TITLE
fix(billing): default org credit_balance to $0, not $100 (kill the give-away footgun)

### DIFF
--- a/packages/cloud-shared/src/db/migrations/0143_org_credit_balance_default_zero.sql
+++ b/packages/cloud-shared/src/db/migrations/0143_org_credit_balance_default_zero.sql
@@ -1,0 +1,8 @@
+-- Default new organizations to $0.00 credit (was $100.000000).
+--
+-- The $100 default was a give-away footgun: any organization row created outside
+-- the signup path silently started with $100 of free credit. The signup path
+-- (steward-sync.ts) sets credit_balance explicitly and grants DEFAULT_INITIAL_CREDITS
+-- ($5), so it does not depend on this default — this change only affects non-signup
+-- creation paths, which should start at $0. Existing balances are untouched.
+ALTER TABLE "organizations" ALTER COLUMN "credit_balance" SET DEFAULT '0.000000';

--- a/packages/cloud-shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud-shared/src/db/migrations/meta/_journal.json
@@ -988,6 +988,13 @@
       "when": 1779409000000,
       "tag": "0142_container_billing_idempotency",
       "breakpoints": true
+    },
+    {
+      "idx": 141,
+      "version": "7",
+      "when": 1779409100000,
+      "tag": "0143_org_credit_balance_default_zero",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud-shared/src/db/schemas/organizations.ts
+++ b/packages/cloud-shared/src/db/schemas/organizations.ts
@@ -32,7 +32,10 @@ export const organizations = pgTable(
     slug: text("slug").notNull().unique(),
     credit_balance: numeric("credit_balance", { precision: 12, scale: 6 })
       .notNull()
-      .default("100.000000"),
+      // Default to $0. The signup path grants DEFAULT_INITIAL_CREDITS ($5) explicitly
+      // (steward-sync.ts), so this only affects orgs created via other paths — which
+      // must not start with free credit. The old $100 default was a give-away footgun.
+      .default("0.000000"),
 
     // Settings (kept for backward compatibility with container management)
     settings: jsonb("settings").$type<Record<string, unknown>>().default({}),


### PR DESCRIPTION
## What
`organizations.credit_balance` DB-defaults to **`100.000000`** (`organizations.ts:35`). Any org row created outside the signup path silently starts with **$100 of free credit**.

## Why it's safe
The signup/auto-provision path (`steward-sync.ts`) creates the org at `credit_balance: "0.00"` then grants `DEFAULT_INITIAL_CREDITS = $5` **explicitly** (sets `credit_balance` to the grant value). It never relies on the $100 default. So dropping the default to **$0** only affects orgs created via *other* paths — which should not get free credit. **Existing balances are untouched** (default change only).

## Change
- `organizations.ts`: `.default("100.000000")` → `.default("0.000000")`
- Migration `0143_org_credit_balance_default_zero.sql`: `ALTER COLUMN credit_balance SET DEFAULT '0.000000'` (+ journal entry)

## For the team to decide
Opening per the launch-QA footgun list (#8321). Given the budget, $0-default + the explicit $5 signup grant is the safe posture. If you want a different new-org grant, change `DEFAULT_INITIAL_CREDITS` — not the column default.