### PR TITLE
chore(cloud-headscale): drive HEADSCALE_PUBLIC_URL from CI + document volume/domain setup

### DIFF
--- a/.github/workflows/cloud-headscale.yml
+++ b/.github/workflows/cloud-headscale.yml
@@ -23,10 +23,13 @@ name: Cloud Headscale
 #     what make `main -> production` / `develop -> staging` actually target the
 #     right env. The `environment:` key on the deploy job resolves the matching
 #     token (and applies production protection rules).
-#   - HEADSCALE_PUBLIC_URL set per env (prod https://headscale.elizacloud.ai,
-#     staging https://headscale-staging.elizacloud.ai), a Railway volume mounted
-#     at /var/lib/headscale, the custom domain, and `headscale users/apikeys
-#     create` for HEADSCALE_API_KEY. See DEPLOY.md.
+#   - HEADSCALE_PUBLIC_URL as a GitHub Environment variable per env (prod
+#     https://headscale.elizacloud.ai, staging
+#     https://headscale-staging.elizacloud.ai). The deploy job syncs it onto the
+#     Railway service before `railway up`, so the GH var is the single source of
+#     truth — no manual Railway dashboard edit. Also: a Railway volume mounted at
+#     /var/lib/headscale, the custom domain, and `headscale users/apikeys create`
+#     for HEADSCALE_API_KEY. See DEPLOY.md.
 
 on:
   push:
@@ -91,6 +94,23 @@ jobs:
         # actually fell back on a download failure (process substitution masks
         # curl's exit status).
         run: npm i -g @railway/cli@5.13.0
+
+      - name: Sync HEADSCALE_PUBLIC_URL to Railway
+        # entrypoint.sh templates headscale's server_url from the
+        # HEADSCALE_PUBLIC_URL var in the Railway container env. Drive that var
+        # from the GitHub Environment var (the single source of truth) on every
+        # deploy instead of hand-setting it in the Railway dashboard, so a new env
+        # only needs the GH var defined. --skip-deploys persists the value without
+        # triggering a redeploy here; the `railway up` below is the one deploy and
+        # picks it up. No-op when the value already matches.
+        if: vars.HEADSCALE_PUBLIC_URL != ''
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          railway variables \
+            --service headscale \
+            --set "HEADSCALE_PUBLIC_URL=${{ vars.HEADSCALE_PUBLIC_URL }}" \
+            --skip-deploys
 
       - name: Deploy to Railway
         working-directory: packages/cloud-services/headscale

--- a/packages/cloud-services/headscale/DEPLOY.md
+++ b/packages/cloud-services/headscale/DEPLOY.md
@@ -29,14 +29,14 @@ Do not set a Railway start-command override; the Dockerfile starts Headscale wit
 
 ### Per-environment variables
 
-`server_url` must equal the public-facing custom domain (agents/tunnels register and re-derive control/DERP/MagicDNS against it). The entrypoint templates it from an explicit `HEADSCALE_PUBLIC_URL` Railway variable, NOT from `RAILWAY_PUBLIC_DOMAIN` (Railway injects that as the auto-generated `*.up.railway.app` host, not the custom domain). Set it per env:
+`server_url` must equal the public-facing custom domain (agents/tunnels register and re-derive control/DERP/MagicDNS against it). The entrypoint templates it from an explicit `HEADSCALE_PUBLIC_URL` Railway variable, NOT from `RAILWAY_PUBLIC_DOMAIN` (Railway injects that as the auto-generated `*.up.railway.app` host, not the custom domain). Per env:
 
 | Environment | `HEADSCALE_PUBLIC_URL` |
 |---|---|
 | production | `https://headscale.elizacloud.ai` |
 | staging | `https://headscale-staging.elizacloud.ai` |
 
-When unset, the committed `config.yaml` prod value stands.
+You do not set this on the Railway service by hand: it lives as a **GitHub Environment variable** (below) and the CI/CD workflow syncs it onto the Railway service (`railway variables --set … --skip-deploys`) before each `railway up`. The GitHub var is the single source of truth. When the var is unset entirely, the committed `config.yaml` prod value stands.
 
 ### CI/CD (`.github/workflows/cloud-headscale.yml`)
 
@@ -44,7 +44,9 @@ When unset, the committed `config.yaml` prod value stands.
 
 - **Disable Railway's native GitHub auto-deploy** on the headscale service (Settings -> disconnect repo / no auto-deploy). Otherwise a single push triggers BOTH the native Railway deploy and the workflow's `railway up`, racing two concurrent builds of the live control plane against the single SQLite volume.
 - Define two **GitHub Environments** (`staging`, `production`), each holding its own project-scoped `RAILWAY_TOKEN` bound to that Railway environment. A Railway project token is scoped to one project+environment, so per-env tokens are what make the branch->env mapping actually land in the right place; the workflow's `environment:` key resolves the matching token and applies production protection rules.
-- Set `HEADSCALE_PUBLIC_URL` (above) as a GitHub Environment variable too, so the workflow's post-deploy `/health` gate hits the right host. `railway up --ci` only validates the BUILD, not runtime health — the health gate is what catches a container that builds but crash-loops (bad server_url, missing volume).
+- Set `HEADSCALE_PUBLIC_URL` (above) as a GitHub Environment variable. The workflow uses it twice: it syncs it onto the Railway service (so the entrypoint's `server_url` is correct) AND points its post-deploy `/health` gate at that host. `railway up --ci` only validates the BUILD, not runtime health — the health gate is what catches a container that builds but crash-loops (bad server_url, missing volume).
+
+> **IaC scope.** The Railway **volume** (`/var/lib/headscale`) and the **custom domain** are stateful Railway service resources — Railway's `railway.toml` only declares build + deploy config (`[build]`, `[deploy]`), so neither can be expressed there. They are one-time setup, created via the Railway dashboard or API and persisted as service state; this file is their reproducible record. `HEADSCALE_PUBLIC_URL` is the exception: it IS codified, as the GitHub Environment variable the workflow pushes to Railway on every deploy.
 
 ## 3. Long-lived headscale preauth key for the proxy
 


### PR DESCRIPTION
Follow-up to #8423. Small IaC tidy-ups for the headscale CD — no behaviour change to a healthy deploy, just makes the per-env config reproducible instead of hand-set.

## What

**1. `HEADSCALE_PUBLIC_URL` is now CI-driven.** The deploy job syncs it onto the Railway service from the GitHub Environment var (`railway variables --set … --skip-deploys`) right before `railway up`. `entrypoint.sh` reads it to template headscale's `server_url`, so this makes the GH Environment var the single source of truth. A new env only needs the GH var defined — no manual Railway dashboard edit. `--skip-deploys` means it doesn't trigger a redeploy on its own; the `railway up` right after is the one deploy and picks up the value (no-op when unchanged).

**2. DEPLOY.md spells out the IaC scope.** The Railway **volume** (`/var/lib/headscale`) and the **custom domain** are stateful Railway service resources — `railway.toml` only declares `[build]` + `[deploy]`, so neither can live there. They stay one-time setup, created via the Railway API/dashboard and documented here as their reproducible record. `HEADSCALE_PUBLIC_URL` is the one piece that IS codified (the GH var the workflow pushes).

## Why

After #8423 the per-env `HEADSCALE_PUBLIC_URL` was set by hand on Railway, and there was no in-repo record of the volume + custom domain that the service needs. This closes both gaps without pretending Railway's `railway.toml` can declare volumes/domains (it can't).

## Test plan
- [ ] CI green (the new step only runs when `vars.HEADSCALE_PUBLIC_URL` is set on the env; it's a no-op when the value already matches)
- [ ] Next staging deploy: confirm the Railway `HEADSCALE_PUBLIC_URL` matches the GH Environment var and `server_url` is templated correctly