### PR TITLE
feat(example-edad): optional per-tenant DB — edad becomes the all-features test app

### DIFF
--- a/packages/examples/cloud/edad/Dockerfile
+++ b/packages/examples/cloud/edad/Dockerfile
@@ -10,6 +10,7 @@ WORKDIR /app
 
 COPY package.json ./
 COPY server.ts ./
+COPY db.ts ./
 COPY public ./public
 
 ENV PORT=3000

--- a/packages/examples/cloud/edad/README.md
+++ b/packages/examples/cloud/edad/README.md
@@ -31,7 +31,8 @@ browser                                  app backend                         eli
 | `public/index.html` | landing + chat UI + OAuth sign-in + message loop |
 | `public/style.css` | dad-energy dark theme, SVG silhouette, responsive |
 | `public/meta.json` | app index metadata |
-| `server.ts` | standalone Bun server: serves `public/`, exposes `GET /api/config`, `POST /api/messages` (forwards to `/api/v1/messages` via @elizaos/cloud-sdk with `x-app-id`/`x-affiliate-code`), and `/health` |
+| `server.ts` | standalone Bun server: serves `public/`, exposes `GET /api/config`, `POST /api/messages` (forwards to `/api/v1/messages` via @elizaos/cloud-sdk with `x-app-id`/`x-affiliate-code`), `GET /api/history` (per-user persisted chat, when a DB is present), and `/health` |
+| `db.ts` | optional per-tenant Postgres persistence via native `Bun.sql` — saves each turn + serves history. No-op without `DATABASE_URL`, so the proxy still runs standalone |
 | `Dockerfile` | bun:1.2-alpine image, exposes :3000, includes `/health` for ECS health checks |
 
 ## Env required
@@ -40,7 +41,19 @@ browser                                  app backend                         eli
 ELIZA_APP_ID=<uuid of app registered via POST /api/v1/apps>
 ELIZA_CLOUD_URL=https://www.elizacloud.ai
 ELIZA_AFFILIATE_CODE=AFF-XXXXXX     # your affiliate code — drives per-call affiliate share earnings
+DATABASE_URL=postgres://...         # OPTIONAL — when set, chat history persists (see below)
 ```
+
+### Per-tenant database (optional)
+
+Deploy edad on Eliza Cloud with `databaseMode: "isolated"` and the platform
+provisions an isolated Postgres DB + injects `DATABASE_URL` (reachable only via
+the per-app DB ambassador — no other tenant can connect, no general egress).
+`db.ts` then persists each turn so a signed-in user's history survives across
+sessions, and `GET /api/history` serves it back. Without `DATABASE_URL` it's a
+silent no-op — the proxy runs stateless anywhere. This makes edad a single app
+that exercises the **whole** platform: monetized inference + container deploy +
+per-tenant DB + per-app auth + custom domain.
 
 There is **no operator-paid fallback**. The proxy rejects requests without a Steward JWT with 401. Reasoning:
 

--- a/packages/examples/cloud/edad/db.ts
+++ b/packages/examples/cloud/edad/db.ts
@@ -1,0 +1,98 @@
+/**
+ * Optional per-tenant Postgres persistence for edad-chat.
+ *
+ * When edad is deployed on Eliza Cloud with `databaseMode: "isolated"`, the
+ * platform provisions an isolated Postgres DB and injects `DATABASE_URL`
+ * (reachable only through the per-app DB ambassador — `REVOKE CONNECT` from
+ * every other tenant, no general egress). This module persists each chat turn
+ * there so a signed-in user's history survives across sessions — exercising the
+ * full per-tenant-DB path end to end.
+ *
+ * Best-effort by design: with no `DATABASE_URL` (or if the DB is briefly
+ * unreachable at boot) this is a silent no-op and the chat proxy still works
+ * standalone — the example runs anywhere. Uses native `Bun.sql`, no extra dep.
+ */
+
+import { SQL } from "bun";
+
+const DATABASE_URL = process.env.DATABASE_URL ?? "";
+
+let sql: SQL | null = null;
+
+/** True once a real per-tenant DB connection + schema are in place. */
+export function dbReady(): boolean {
+  return sql !== null;
+}
+
+/** Connect + ensure the schema. Never throws — falls back to no persistence. */
+export async function initDb(): Promise<void> {
+  if (!DATABASE_URL) {
+    console.log("[edad-chat] database: none (DATABASE_URL unset) — running stateless");
+    return;
+  }
+  try {
+    const db = new SQL(DATABASE_URL);
+    await db`
+      CREATE TABLE IF NOT EXISTS edad_messages (
+        id         bigserial   PRIMARY KEY,
+        user_ref   text        NOT NULL,
+        role       text        NOT NULL,
+        content    text        NOT NULL,
+        created_at timestamptz NOT NULL DEFAULT now()
+      )`;
+    await db`CREATE INDEX IF NOT EXISTS edad_messages_user_idx ON edad_messages (user_ref, id)`;
+    sql = db;
+    console.log("[edad-chat] database: connected — per-tenant chat persistence ON");
+  } catch (err) {
+    sql = null;
+    console.error(
+      "[edad-chat] database: init failed, continuing without persistence:",
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+/**
+ * Stable per-user key derived from the signed-in user's token. We persist
+ * history per user WITHOUT ever storing the token itself (one-way sha256).
+ */
+export function userRef(userToken: string): string {
+  return new Bun.CryptoHasher("sha256").update(userToken).digest("hex").slice(0, 32);
+}
+
+/** Append one turn. No-op when there is no DB or the content is empty. */
+export async function saveTurn(
+  ref: string,
+  role: "user" | "assistant",
+  content: string,
+): Promise<void> {
+  if (!sql || !content) return;
+  try {
+    await sql`INSERT INTO edad_messages (user_ref, role, content) VALUES (${ref}, ${role}, ${content})`;
+  } catch (err) {
+    console.error("[edad-chat] db saveTurn failed:", err instanceof Error ? err.message : err);
+  }
+}
+
+/** A user's recent turns, oldest-first. Empty when there is no DB. */
+export async function getHistory(
+  ref: string,
+  limit = 50,
+): Promise<Array<{ role: string; content: string; created_at: string }>> {
+  if (!sql) return [];
+  try {
+    const rows = (await sql`
+      SELECT role, content, created_at FROM edad_messages
+      WHERE user_ref = ${ref}
+      ORDER BY id DESC
+      LIMIT ${Math.min(Math.max(limit, 1), 200)}`) as Array<{
+      role: string;
+      content: string;
+      created_at: string;
+    }>;
+    return rows.reverse();
+  } catch (err) {
+    console.error("[edad-chat] db getHistory failed:", err instanceof Error ? err.message : err);
+    return [];
+  }
+}

--- a/packages/examples/cloud/edad/server.ts
+++ b/packages/examples/cloud/edad/server.ts
@@ -20,6 +20,7 @@
 
 import { join } from "node:path";
 import { CloudApiError, ElizaCloudClient } from "@elizaos/cloud-sdk";
+import { dbReady, getHistory, initDb, saveTurn, userRef } from "./db.ts";
 
 const PORT = Number(process.env.PORT ?? 3000);
 const PUBLIC_DIR = join(import.meta.dir, "public");
@@ -46,6 +47,42 @@ function jsonError(status: number, code: string, message: string): Response {
   });
 }
 
+// Flatten a message `content` (string, or an array of {text} parts) to plain
+// text for persistence. Defensive: unknown shapes collapse to "".
+function flattenContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((c) =>
+        typeof c === "string"
+          ? c
+          : typeof (c as { text?: unknown })?.text === "string"
+            ? (c as { text: string }).text
+            : "",
+      )
+      .join(" ")
+      .trim();
+  }
+  return "";
+}
+
+/** The user's latest message text from the forwarded request body. */
+function extractUserText(json: unknown): string {
+  const msgs = (json as { messages?: Array<{ role?: string; content?: unknown }> })?.messages;
+  if (Array.isArray(msgs)) {
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      if (msgs[i]?.role === "user") return flattenContent(msgs[i]?.content);
+    }
+  }
+  return "";
+}
+
+/** The assistant reply text from the upstream result (Anthropic-style shape). */
+function extractReplyText(result: unknown): string {
+  const r = result as { content?: unknown; message?: { content?: unknown } };
+  return flattenContent(r?.content) || flattenContent(r?.message?.content) || "";
+}
+
 async function forwardMessages(
   req: Request,
   userToken: string,
@@ -59,6 +96,14 @@ async function forwardMessages(
   try {
     const json = await req.json();
     const result = await cloud.routes.postApiV1Messages({ json });
+    // Persist the turn to this app's isolated per-tenant DB so history survives
+    // across sessions. No-op when the app has no DB (see db.ts); wrapped so a
+    // persistence error never affects the reply the user gets back.
+    if (dbReady()) {
+      const ref = userRef(userToken);
+      await saveTurn(ref, "user", extractUserText(json));
+      await saveTurn(ref, "assistant", extractReplyText(result));
+    }
     return Response.json(result);
   } catch (err) {
     if (err instanceof CloudApiError) {
@@ -87,6 +132,7 @@ async function handleApi(req: Request, segments: string[]): Promise<Response> {
         app_id: APP_ID || null,
         cloud_url: CLOUD_URL,
         affiliate_code: AFFILIATE_CODE,
+        db_enabled: dbReady(),
       },
       { headers: { "cache-control": "no-store" } },
     );
@@ -109,6 +155,16 @@ async function handleApi(req: Request, segments: string[]): Promise<Response> {
     return forwardMessages(req, userToken);
   }
 
+  // Signed-in user's persisted chat history from this app's per-tenant DB.
+  // Empty when the app has no isolated DB — the UI just starts a fresh chat.
+  if (segments.length === 1 && segments[0] === "history" && req.method === "GET") {
+    const messages = dbReady() ? await getHistory(userRef(userToken)) : [];
+    return Response.json(
+      { messages, db_enabled: dbReady() },
+      { headers: { "cache-control": "no-store" } },
+    );
+  }
+
   return jsonError(404, "not_found", "unknown route");
 }
 
@@ -119,6 +175,10 @@ async function serveStatic(pathname: string): Promise<Response | null> {
   if (!(await file.exists())) return null;
   return new Response(file, { headers: { "cache-control": "no-store" } });
 }
+
+// Connect the per-tenant DB (if any) before we start taking requests. Never
+// throws — a missing/unreachable DB just means stateless mode (see db.ts).
+await initDb();
 
 const server = Bun.serve({
   port: PORT,


### PR DESCRIPTION
## What
`edad-chat` was a stateless monetized-chat proxy. This adds **optional per-tenant Postgres persistence** so it exercises the *whole* Apps platform in one app.

- New `db.ts` (native `Bun.sql`, **no new dependency**): on boot, if `DATABASE_URL` is present, ensure an `edad_messages` table; persist each chat turn; serve it back.
- `server.ts`: saves `(user, assistant)` each turn, new `GET /api/history`, `db_enabled` in `/api/config`. Per-user key is a one-way sha256 of the token — **the token is never stored**.
- `Dockerfile`: `COPY db.ts`.

## Why
When edad is deployed with `databaseMode: "isolated"`, the platform injects `DATABASE_URL` (DB reachable only through the per-app ambassador). edad then persists history there — so **one app now covers monetized inference + container deploy + per-tenant DB + per-app auth + custom domain**. It's the single all-features QA subject (the matrix gap: no app exercised the per-tenant DB).

## Safety / no-break
- **Graceful**: no `DATABASE_URL` (or a DB hiccup at boot) → silent no-op, proxy runs stateless exactly as before. `initDb()` never throws; `saveTurn`/`getHistory` swallow errors so a persistence failure never affects the reply.
- The existing `test.ts` smoke test sets no `DATABASE_URL` → DB path is inert → **stays green**.
- Verified `db.ts` + `server.ts` compile via `bun build` (db.ts builds standalone; server.ts bundles server+db).

## Test it
Deploy edad with isolated DB (or `DATABASE_URL=postgres://...` locally) → chat → `GET /api/history` returns the persisted turns. The deploy+DB mechanics are also gated in CI by #8430.