### PR TITLE
fix(cloud): poll Headscale by the node's TS_HOSTNAME, not the bare agentId

### DIFF
--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -88,6 +88,8 @@ interface ContainerMeta {
   bridgePort: number;
   webUiPort: number;
   agentId: string;
+  /** Headscale node name (TS_HOSTNAME) used at registration, for cleanup lookup. */
+  tsHostname?: string;
   sshPort: number;
   sshUser: string;
   hostKeyFingerprint?: string;
@@ -1230,7 +1232,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       }
       // Clean up Headscale pre-auth key if VPN was prepared
       if (headscaleEnabled) {
-        await headscaleIntegration.cleanupContainerVPN(agentId).catch((cleanupErr) => {
+        await headscaleIntegration.cleanupContainerVPN(vpnEnvVars.TS_HOSTNAME ?? agentId).catch((cleanupErr) => {
           logger.warn(
             `[docker-sandbox] Headscale cleanup failed during rollback for ${agentId}: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}`,
           );
@@ -1248,6 +1250,9 @@ export class DockerSandboxProvider implements SandboxProvider {
       bridgePort,
       webUiPort,
       agentId,
+      // Headscale node name (TS_HOSTNAME) the container registered under, so
+      // cleanup can find + delete the node by the same name it was created with.
+      tsHostname: vpnEnvVars.TS_HOSTNAME,
       sshPort,
       sshUser,
       hostKeyFingerprint,
@@ -1257,7 +1262,14 @@ export class DockerSandboxProvider implements SandboxProvider {
     // 8. Wait for Headscale VPN registration if enabled
     if (headscaleEnabled) {
       try {
-        headscaleIp = await headscaleIntegration.waitForVPNRegistration(agentId, 60_000);
+        // Poll by the node's TS_HOSTNAME (what the container registers under via
+        // inferTailscaleHostname), NOT the bare agentId — Headscale only knows the
+        // node by that hostname, so polling by agentId never matched and the node
+        // "timed out" registering despite being online.
+        headscaleIp = await headscaleIntegration.waitForVPNRegistration(
+          vpnEnvVars.TS_HOSTNAME ?? agentId,
+          60_000,
+        );
         if (headscaleIp) {
           logger.info(
             `[docker-sandbox] Container ${containerName} registered on VPN: ${headscaleIp}`,
@@ -1558,7 +1570,9 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     // Clean up Headscale VPN registration if enabled
     if (process.env.HEADSCALE_API_KEY && meta.agentId) {
-      await headscaleIntegration.cleanupContainerVPN(meta.agentId).catch((err) => {
+      // Delete the node by the hostname it registered under (TS_HOSTNAME), not the
+      // bare agentId — Headscale identifies the node by that name.
+      await headscaleIntegration.cleanupContainerVPN(meta.tsHostname ?? meta.agentId).catch((err) => {
         logger.warn(
           `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
         );

--- a/packages/cloud-shared/src/lib/services/headscale-integration.test.ts
+++ b/packages/cloud-shared/src/lib/services/headscale-integration.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { inferHeadscaleUser, inferTailscaleHostname } from "./headscale-integration";
+import {
+  HeadscaleIntegration,
+  inferHeadscaleUser,
+  inferTailscaleHostname,
+} from "./headscale-integration";
+import type { HeadscaleClient } from "./headscale-client";
 
 const savedEnv = { ...process.env };
 
@@ -36,5 +41,51 @@ describe("Headscale identity inference", () => {
         agentId: "11111111-1111-4111-8111-111111111111",
       }),
     ).toBe("my-agent-11111111-111");
+  });
+});
+
+describe("Headscale node lookup is keyed on the node name (not the agentId)", () => {
+  // Regression guard: the container registers under TS_HOSTNAME
+  // (inferTailscaleHostname = `<agentName>-<id12>`), so lookups must use that
+  // name. Polling/cleaning up by the bare agentId never matched the node — it
+  // "timed out" registering and orphaned the node despite it being online.
+  const nodeName = inferTailscaleHostname({
+    agentName: "My Agent",
+    agentId: "11111111-1111-4111-8111-111111111111",
+  });
+
+  test("waitForVPNRegistration polls getNodeByName with the node name", async () => {
+    const lookups: string[] = [];
+    const fake = {
+      getNodeByName: async (name: string) => {
+        lookups.push(name);
+        return { id: "node-1", name, ipAddresses: ["100.64.0.7"] };
+      },
+    } as unknown as HeadscaleClient;
+
+    const ip = await new HeadscaleIntegration(fake).waitForVPNRegistration(nodeName, 1_000);
+
+    expect(ip).toBe("100.64.0.7");
+    expect(lookups).toEqual([nodeName]);
+    expect(nodeName).not.toBe("11111111-1111-4111-8111-111111111111");
+  });
+
+  test("cleanupContainerVPN deletes the node found by the node name", async () => {
+    const lookups: string[] = [];
+    let deletedId: string | null = null;
+    const fake = {
+      getNodeByName: async (name: string) => {
+        lookups.push(name);
+        return { id: "node-9", name, ipAddresses: ["100.64.0.7"] };
+      },
+      deleteNode: async (id: string) => {
+        deletedId = id;
+      },
+    } as unknown as HeadscaleClient;
+
+    await new HeadscaleIntegration(fake).cleanupContainerVPN(nodeName);
+
+    expect(lookups).toEqual([nodeName]);
+    expect(deletedId).toBe("node-9");
   });
 });

--- a/packages/cloud-shared/src/lib/services/headscale-integration.ts
+++ b/packages/cloud-shared/src/lib/services/headscale-integration.ts
@@ -9,7 +9,7 @@
  *  1. prepareContainerVPN(input) — generates a pre-auth key + env vars
  *  2. Container boots, runs `tailscale up --authkey=... --hostname=...`
  *  3. waitForVPNRegistration(agentId) — polls headscale until the node appears
- *  4. cleanupContainerVPN(agentId) — removes the VPN node when the container dies
+ *  4. cleanupContainerVPN(nodeName) — removes the VPN node when the container dies
  */
 
 import { logger } from "../utils/logger";
@@ -97,16 +97,17 @@ export class HeadscaleIntegration {
    * until the node appears and has at least one IP address, or the timeout
    * expires.
    *
-   * @param agentId   Hostname the container registers with (matches TS_HOSTNAME).
+   * @param nodeName  Headscale node name the container registers under
+   *                  (TS_HOSTNAME = inferTailscaleHostname; NOT the bare agentId).
    * @param timeoutMs Maximum time to wait (default 60 s).
    * @returns The first VPN IP address, or `null` if the timeout was reached.
    */
   async waitForVPNRegistration(
-    agentId: string,
+    nodeName: string,
     timeoutMs: number = DEFAULT_REGISTRATION_TIMEOUT_MS,
   ): Promise<string | null> {
     logger.info(
-      `[headscale-integration] waiting for VPN registration: ${agentId} (timeout ${timeoutMs}ms)`,
+      `[headscale-integration] waiting for VPN registration: ${nodeName} (timeout ${timeoutMs}ms)`,
     );
 
     const deadline = Date.now() + timeoutMs;
@@ -114,11 +115,11 @@ export class HeadscaleIntegration {
 
     while (Date.now() < deadline) {
       try {
-        const node = await this.client.getNodeByName(agentId);
+        const node = await this.client.getNodeByName(nodeName);
 
         if (node && node.ipAddresses.length > 0) {
           const ip = node.ipAddresses[0];
-          logger.info(`[headscale-integration] VPN registered for ${agentId}: ${ip}`);
+          logger.info(`[headscale-integration] VPN registered for ${nodeName}: ${ip}`);
           return ip;
         }
       } catch (err) {
@@ -126,12 +127,12 @@ export class HeadscaleIntegration {
         // Distinguish auth errors (401/403) from transient failures
         if (msg.includes("401") || msg.includes("403")) {
           logger.error(
-            `[headscale-integration] Auth error polling VPN for ${agentId}: ${msg} — check HEADSCALE_API_KEY`,
+            `[headscale-integration] Auth error polling VPN for ${nodeName}: ${msg} — check HEADSCALE_API_KEY`,
           );
           return null; // bail early, retrying won't help
         }
         // Transient errors (network, timeout) — keep polling
-        logger.debug(`[headscale-integration] Poll error for ${agentId}: ${msg}`);
+        logger.debug(`[headscale-integration] Poll error for ${nodeName}: ${msg}`);
       }
 
       // Exponential backoff with jitter to avoid thundering-herd on
@@ -143,7 +144,7 @@ export class HeadscaleIntegration {
       interval = Math.min(interval * 1.5, POLL_INTERVAL_MAX_MS);
     }
 
-    logger.warn(`[headscale-integration] VPN registration timeout for ${agentId}`);
+    logger.warn(`[headscale-integration] VPN registration timeout for ${nodeName}`);
     return null;
   }
 
@@ -153,24 +154,24 @@ export class HeadscaleIntegration {
    * Finds the node by hostname and deletes it from the Headscale network.
    * Silently succeeds if the node was already removed.
    */
-  async cleanupContainerVPN(agentId: string): Promise<void> {
-    logger.info(`[headscale-integration] cleaning up VPN node for ${agentId}`);
+  async cleanupContainerVPN(nodeName: string): Promise<void> {
+    logger.info(`[headscale-integration] cleaning up VPN node for ${nodeName}`);
 
     try {
-      const node = await this.client.getNodeByName(agentId);
+      const node = await this.client.getNodeByName(nodeName);
 
       if (!node) {
         logger.info(
-          `[headscale-integration] no VPN node found for ${agentId}, nothing to clean up`,
+          `[headscale-integration] no VPN node found for ${nodeName}, nothing to clean up`,
         );
         return;
       }
 
       await this.client.deleteNode(node.id);
-      logger.info(`[headscale-integration] VPN node cleaned up for ${agentId}`);
+      logger.info(`[headscale-integration] VPN node cleaned up for ${nodeName}`);
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
-      logger.warn(`[headscale-integration] error cleaning up VPN for ${agentId}:`, msg);
+      logger.warn(`[headscale-integration] error cleaning up VPN for ${nodeName}:`, msg);
       // Don't rethrow — cleanup failures should not block container deletion
     }
   }
@@ -180,12 +181,12 @@ export class HeadscaleIntegration {
    *
    * @returns The first VPN IP, or `null` if the node isn't registered.
    */
-  async getContainerVPNIP(agentId: string): Promise<string | null> {
+  async getContainerVPNIP(nodeName: string): Promise<string | null> {
     try {
-      return await this.client.getNodeIP(agentId);
+      return await this.client.getNodeIP(nodeName);
     } catch (error: unknown) {
       const msg = error instanceof Error ? error.message : String(error);
-      logger.warn(`[headscale-integration] error getting VPN IP for ${agentId}:`, msg);
+      logger.warn(`[headscale-integration] error getting VPN IP for ${nodeName}:`, msg);
       return null;
     }
   }


### PR DESCRIPTION
## What
`waitForVPNRegistration` and `cleanupContainerVPN` looked the Headscale node up via `getNodeByName(agentId)`, but the agent container registers under its **TS_HOSTNAME** — `inferTailscaleHostname({agentId, agentName})` = `<agentName>-<id12>`, not the bare agent UUID. So the lookup never matched: registration "timed out" (the daemon marked the sandbox `running` with **no `headscale_ip`**) and teardown orphaned the node — even though the node was **online** in Headscale.

Surfaced while bringing staging's Headscale tunnel up end-to-end: once the control plane could actually register nodes, the daemon still never recorded the `headscale_ip` because of this name mismatch.

## Fix
Pass the real node name the container registers under:
- `waitForVPNRegistration` / rollback `cleanupContainerVPN` → `vpnEnvVars.TS_HOSTNAME` (the value injected into the container).
- post-hoc `cleanupContainerVPN` → a new `ContainerMeta.tsHostname` (stored at provisioning) so teardown finds the node by the same name.
- Renamed the lookup-helper params `agentId` → `nodeName` so a future caller can't reintroduce the mismatch.

## Notes / follow-ups
- `getContainerVPNIP` carries the same `agentId`-vs-hostname pattern but is **dead code** (zero callers) — left as-is; delete or fix when it's wired up.
- Containers provisioned **before** this change have no `tsHostname` in persisted metadata, so their teardown falls back to `meta.agentId` (old no-op behavior). No regression, but already-orphaned nodes won't be auto-reaped — prune manually / via node GC.

## Test
- New sociable tests assert `getNodeByName` is called with `inferTailscaleHostname(...)`, not the bare agentId, for both `waitForVPNRegistration` and `cleanupContainerVPN`.
- `bun test .../headscale-integration.test.ts` → 5 pass; typecheck clean.

## Context
Part of moving Headscale off Railway's HTTP/2 edge (which drops the TS2021 `Upgrade` header → nodes can't register) onto the control plane behind nginx. That infra change is being codified separately; this is the daemon-side bug that blocked the `headscale_ip` from ever being recorded.