### PR TITLE
fix(cloud): route staging alias to Pages

### DIFF
--- a/packages/cloud-api/src/index.test.ts
+++ b/packages/cloud-api/src/index.test.ts
@@ -31,7 +31,7 @@ describe("cloud-api worker entrypoint", () => {
     );
 
     expect(target?.toString()).toBe(
-      "https://develop.eliza-cloud.pages.dev/dashboard?tab=agents",
+      "https://develop.eliza-cloud-enq.pages.dev/dashboard?tab=agents",
     );
   });
 

--- a/packages/cloud-api/src/index.ts
+++ b/packages/cloud-api/src/index.ts
@@ -26,7 +26,7 @@ const FRONTEND_ALIAS_TARGETS: Record<
   { appHost: string; apiHost: string }
 > = {
   "staging.elizacloud.ai": {
-    appHost: "develop.eliza-cloud.pages.dev",
+    appHost: "develop.eliza-cloud-enq.pages.dev",
     apiHost: "api-staging.elizacloud.ai",
   },
 };

--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -230,6 +230,7 @@ TUNNEL_AUTH_KEY_COST_USD = "0.01"
 name = "eliza-cloud-api-staging"
 workers_dev = false
 routes = [
+  { pattern = "staging.elizacloud.ai/*", zone_name = "elizacloud.ai" },
   { pattern = "api-staging.elizacloud.ai/*", zone_name = "elizacloud.ai" },
 ]
 


### PR DESCRIPTION
## Summary
- point the staging frontend alias proxy at the active Cloudflare Pages project (develop.eliza-cloud-enq.pages.dev)
- persist the staging.elizacloud.ai/* staging worker route in wrangler.toml
- update the cloud-api entrypoint test expectation

## Test
- bun test packages/cloud-api/src/index.test.ts