### PR TITLE
fix(release): publish with NPM_TOKEN instead of failing OIDC exchange (#8428)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,29 +33,31 @@ concurrency:
   group: npm-release-${{ github.ref }}
   cancel-in-progress: false
 
-# Required for npm OIDC trusted publishing. Each publish step mints a
-# short-lived OIDC token; npm verifies it against the Trusted Publisher entry
-# configured for the package on npmjs.com (SOC2 CC6.1 / CC9.2).
+# Publishing uses the NPM_TOKEN secret (a granular automation token with
+# read+write on the @elizaos/* scope).
 #
-# HUMAN-IN-LOOP — operator must configure on npmjs.com:
-#   https://docs.npmjs.com/trusted-publishers
-#   For each @elizaos/* package, add Trusted Publisher:
-#     Publisher:    GitHub Actions
-#     Organization: elizaOS
-#     Repository:   eliza
-#     Workflow:     release.yaml
-# npm tries trusted publishing before token auth in OIDC-capable runners, so a
-# missing or mismatched Trusted Publisher entry fails before NPM_TOKEN can be used.
+# We deliberately do NOT grant `id-token: write` here. When an OIDC token is
+# available, lerna 9.0.7 attempts npm trusted publishing *first* and hard-fails
+# the whole release if a package has no Trusted Publisher entry configured on
+# npmjs.com — it never falls back to NPM_TOKEN. The observed failure was:
+#   lerna verb oidc Failed token exchange request ... OIDC token exchange error - package not found
+#   lerna WARN notice Package failed to publish: @elizaos/agent
+#   lerna ERR! E404 Not found
+# (the E404 is the masked OIDC exchange failure, not a token-access problem).
+# Without `id-token: write` the OIDC env vars are absent, so lerna skips the
+# exchange and publishes with the token. Provenance is disabled for the same
+# reason (it requires id-token). To re-enable provenance + trusted publishing
+# later, configure a Trusted Publisher for every published @elizaos/* package
+# at https://docs.npmjs.com/trusted-publishers, then restore `id-token: write`
+# and `NPM_CONFIG_PROVENANCE: "true"`.
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
       contents: write   # release commits push lerna version bumps + git tags
-      id-token: write   # OIDC for npm publish
       packages: write   # publish to GitHub Packages mirror
       issues: write     # comment on release-tracking issues
       actions: read     # read other workflow runs for context
@@ -596,7 +598,6 @@ jobs:
         id: publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"
         run: |
           DIST_TAG="${{ steps.release_type.outputs.dist_tag }}"
 
@@ -651,7 +652,6 @@ jobs:
         if: steps.publish.outcome == 'success'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           DIST_TAG="${{ steps.release_type.outputs.dist_tag }}"


### PR DESCRIPTION
Fixes #8428.

## Real root cause (corrects the issue diagnosis)

The issue inferred "NPM_TOKEN lacks `@elizaos/*` publish access" from the `E404`. The failed-run logs show the E404 is actually a **masked npm OIDC trusted-publishing failure** — the token path is never reached:

```
lerna verb publish @elizaos/agent
lerna verb oidc Failed token exchange request with body message: OIDC token exchange error - package not found
lerna WARN notice Package failed to publish: @elizaos/agent
lerna ERR! E404 Not found
```

With `id-token: write` granted and `NPM_CONFIG_PROVENANCE: "true"`, **lerna 9.0.7 attempts the npm OIDC trusted-publishing token exchange first**. For any `@elizaos/*` package that has no Trusted Publisher entry configured on npmjs.com, npm returns a 404-masked "package not found" and lerna aborts the entire release — it never falls back to `NPM_TOKEN`.

Supporting evidence that the token is **not** the problem: betas published cleanly until OIDC/provenance were added (npm still serves `@elizaos/agent` `beta: 2.0.0-beta.2`), and the scope is owned by the elizaOS maintainers.

## Fix

Drop the OIDC path so lerna publishes with the existing `NPM_TOKEN` secret:
- remove `id-token: write` (workflow-level + job-level)
- remove `NPM_CONFIG_PROVENANCE: "true"` from the **Publish to NPM** and **Verify dist-tag** steps

Without an OIDC token available, lerna skips the exchange and authenticates with `NPM_TOKEN` (written to `~/.npmrc`), which is the path that worked for earlier betas.

## Operator action required (one-time)

`NPM_TOKEN` must be a **granular automation token** with **read+write** on the `@elizaos/*` scope. Generate at https://www.npmjs.com/settings/~/tokens and set it as the repo Actions secret `NPM_TOKEN` (https://github.com/elizaOS/eliza/settings/secrets/actions). No package code changes needed.

## Restoring provenance later (optional)

To bring back signed provenance + trusted publishing (SOC2 posture), configure a Trusted Publisher (GitHub Actions / `elizaOS` / `eliza` / `release.yaml`) for **every** published `@elizaos/*` package at https://docs.npmjs.com/trusted-publishers, then restore `id-token: write` and `NPM_CONFIG_PROVENANCE: "true"`. The how-to is captured in the workflow comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)