### PR TITLE
Fix staging Steward API routing

### DIFF
--- a/packages/cloud-frontend/aesthetic-audit-output/manual-review/login.md
+++ b/packages/cloud-frontend/aesthetic-audit-output/manual-review/login.md
@@ -6,4 +6,5 @@ Screenshots: `../desktop/login.png`, `../desktop/login--hover.png`, `../mobile/l
 
 `good`
 
-Passkey primary + 4 sign-in options. No blue.
+Passkey and Magic Link remain clear on desktop/mobile. Copy now clarifies that
+Magic Link creates new accounts and passkey is available after setup. No blue.

--- a/packages/cloud-frontend/src/lib/api-fetch-bridge.test.ts
+++ b/packages/cloud-frontend/src/lib/api-fetch-bridge.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment-options {"url":"https://staging.elizacloud.ai/login"}
+
+import { STEWARD_TOKEN_KEY } from "@elizaos/shared/steward-session-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installApiFetchBridge } from "./api-fetch-bridge";
+
+const originalFetch = window.fetch;
+
+function resetBridge(): void {
+  delete (window as Window & { __elizaApiFetchBridgeInstalled?: boolean })
+    .__elizaApiFetchBridgeInstalled;
+}
+
+beforeEach(() => {
+  resetBridge();
+  window.localStorage.clear();
+  window.history.replaceState(null, "", "/login");
+});
+
+afterEach(() => {
+  resetBridge();
+  window.fetch = originalFetch;
+  window.localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("installApiFetchBridge", () => {
+  it("rewrites absolute same-origin staging Steward URLs to the staging API worker", async () => {
+    const fetchMock = vi.fn(async () => new Response("ok"));
+    window.fetch = fetchMock as unknown as typeof window.fetch;
+
+    installApiFetchBridge();
+
+    await fetch("https://staging.elizacloud.ai/steward/auth/providers");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api-staging.elizacloud.ai/steward/auth/providers",
+      expect.objectContaining({ credentials: "include" }),
+    );
+  });
+
+  it("rewrites absolute same-origin staging Steward requests and preserves auth headers", async () => {
+    const fetchMock = vi.fn(async () => new Response("ok"));
+    window.fetch = fetchMock as unknown as typeof window.fetch;
+    window.localStorage.setItem(STEWARD_TOKEN_KEY, "jwt");
+
+    installApiFetchBridge();
+
+    await fetch(
+      new Request("https://staging.elizacloud.ai/steward/tenants/config", {
+        headers: { "x-request-id": "test" },
+      }),
+    );
+
+    const calls = fetchMock.mock.calls as unknown as Array<
+      [RequestInfo | URL, RequestInit | undefined]
+    >;
+    const [request, init] = calls[0];
+    expect(request).toBeInstanceOf(Request);
+    expect((request as Request).url).toBe(
+      "https://api-staging.elizacloud.ai/steward/tenants/config",
+    );
+    expect(init?.credentials).toBe("include");
+    expect(init?.headers).toBeInstanceOf(Headers);
+    const headers = init?.headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer jwt");
+    expect(headers.get("x-request-id")).toBe("test");
+  });
+});

--- a/packages/cloud-frontend/src/lib/api-fetch-bridge.ts
+++ b/packages/cloud-frontend/src/lib/api-fetch-bridge.ts
@@ -34,12 +34,16 @@ function configuredApiBase(): string | null {
   return trimmed;
 }
 
-function browserApiBase(): string | null {
-  if (typeof window === "undefined") return null;
-  const host = window.location.hostname.toLowerCase();
+function apiBaseForHostname(hostname: string): string | null {
+  const host = hostname.toLowerCase();
   if (isLocalBrowserHost(host)) return null;
   if (host.endsWith(".pages.dev")) return "https://api-staging.elizacloud.ai";
   return configuredApiBase() ?? ELIZA_API_HOSTS[host] ?? null;
+}
+
+function browserApiBase(): string | null {
+  if (typeof window === "undefined") return null;
+  return apiBaseForHostname(window.location.hostname);
 }
 
 function isApiPath(path: string): boolean {
@@ -64,16 +68,37 @@ function withAuthHeaders(headers: HeadersInit | undefined): Headers {
 }
 
 function rewriteStringInput(input: string): string {
-  if (!isApiPath(input)) return input;
-  const base = browserApiBase();
-  return base ? `${base}${input}` : input;
+  if (isApiPath(input)) {
+    const base = browserApiBase();
+    return base ? `${base}${input}` : input;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return input;
+  }
+
+  if (typeof window === "undefined" || !isApiPath(url.pathname)) {
+    return input;
+  }
+
+  const base =
+    url.origin === window.location.origin
+      ? browserApiBase()
+      : apiBaseForHostname(url.hostname);
+  return base ? `${base}${url.pathname}${url.search}${url.hash}` : input;
 }
 
 function rewriteUrlInput(input: URL): URL | string {
-  if (input.origin !== window.location.origin || !isApiPath(input.pathname)) {
+  if (!isApiPath(input.pathname)) {
     return input;
   }
-  const base = browserApiBase();
+  const base =
+    input.origin === window.location.origin
+      ? browserApiBase()
+      : apiBaseForHostname(input.hostname);
   return base ? `${base}${input.pathname}${input.search}${input.hash}` : input;
 }
 
@@ -87,12 +112,15 @@ export function installApiFetchBridge(): void {
 
   const nativeFetch = window.fetch.bind(window);
   window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
-    if (typeof input === "string" && isApiPath(input)) {
-      return nativeFetch(rewriteStringInput(input), {
-        ...init,
-        credentials: init?.credentials ?? "include",
-        headers: withAuthHeaders(init?.headers),
-      });
+    if (typeof input === "string") {
+      const rewritten = rewriteStringInput(input);
+      if (rewritten !== input || isApiPath(input)) {
+        return nativeFetch(rewritten, {
+          ...init,
+          credentials: init?.credentials ?? "include",
+          headers: withAuthHeaders(init?.headers),
+        });
+      }
     }
 
     if (input instanceof URL && isApiPath(input.pathname)) {
@@ -105,11 +133,13 @@ export function installApiFetchBridge(): void {
 
     if (input instanceof Request) {
       const url = new URL(input.url, window.location.origin);
-      if (url.origin === window.location.origin && isApiPath(url.pathname)) {
+      const base =
+        url.origin === window.location.origin
+          ? browserApiBase()
+          : apiBaseForHostname(url.hostname);
+      if (base && isApiPath(url.pathname)) {
         const request = new Request(input, init);
-        const rewritten = browserApiBase()
-          ? `${browserApiBase()}${url.pathname}${url.search}${url.hash}`
-          : request.url;
+        const rewritten = `${base}${url.pathname}${url.search}${url.hash}`;
         return nativeFetch(new Request(rewritten, request), {
           headers: withAuthHeaders(request.headers),
           credentials: request.credentials ?? "include",

--- a/packages/cloud-frontend/src/pages/login/page.tsx
+++ b/packages/cloud-frontend/src/pages/login/page.tsx
@@ -42,7 +42,9 @@ export default function LoginPage() {
             draggable={false}
           />
           <h1 className="font-poppins text-2xl font-semibold text-white">
-            {t("cloud.login.signIn", { defaultValue: "Sign in" })}
+            {t("cloud.login.signIn", {
+              defaultValue: "Sign in or create an account",
+            })}
           </h1>
           <p className="text-sm text-white/70">
             {t("cloud.login.tagline", { defaultValue: "Run Eliza in Cloud." })}

--- a/packages/cloud-frontend/src/pages/login/steward-login-section.test.tsx
+++ b/packages/cloud-frontend/src/pages/login/steward-login-section.test.tsx
@@ -134,6 +134,9 @@ describe("StewardLoginSection", () => {
     expect(await screen.findByPlaceholderText("you@example.com")).toBeVisible();
     expect(screen.getByRole("button", { name: /passkey/i })).toBeVisible();
     expect(screen.getByRole("button", { name: /magic link/i })).toBeVisible();
+    expect(
+      screen.getByText(/choose magic link to create your account/i),
+    ).toBeVisible();
     expect(screen.getByText(/provider endpoint down/i)).toBeVisible();
   });
 

--- a/packages/cloud-frontend/src/pages/login/steward-login-section.tsx
+++ b/packages/cloud-frontend/src/pages/login/steward-login-section.tsx
@@ -648,6 +648,13 @@ export default function StewardLoginSection() {
         )}
       </div>
 
+      <p className="text-center text-xs leading-5 text-white/62">
+        {t("cloud.login.signupHint", {
+          defaultValue:
+            "New here? Enter your email and choose Magic Link to create your account. Passkey works after you add one.",
+        })}
+      </p>
+
       {hasOAuthProviders && (
         <div className="flex items-center gap-3">
           <div className="h-px flex-1 bg-white/14" />

--- a/packages/cloud-shared/src/lib/steward-url.test.ts
+++ b/packages/cloud-shared/src/lib/steward-url.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { resolveBrowserStewardApiUrl } from "./steward-url";
+
+const originalLocation = globalThis.location;
+
+function setLocation(hostname: string, origin = `https://${hostname}`): void {
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: { hostname, origin },
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "location", {
+    configurable: true,
+    value: originalLocation,
+  });
+});
+
+describe("resolveBrowserStewardApiUrl", () => {
+  test("routes staging cloud host to the staging API worker", () => {
+    setLocation("staging.elizacloud.ai");
+
+    expect(resolveBrowserStewardApiUrl()).toBe(
+      "https://api-staging.elizacloud.ai/steward",
+    );
+  });
+
+  test("routes production cloud host to the production API worker", () => {
+    setLocation("elizacloud.ai");
+
+    expect(resolveBrowserStewardApiUrl()).toBe(
+      "https://api.elizacloud.ai/steward",
+    );
+  });
+
+  test("falls back to same-origin steward mount for unknown hosts", () => {
+    setLocation("example.pages.dev", "https://example.pages.dev");
+
+    expect(resolveBrowserStewardApiUrl()).toBe(
+      "https://example.pages.dev/steward",
+    );
+  });
+});

--- a/packages/cloud-shared/src/lib/steward-url.ts
+++ b/packages/cloud-shared/src/lib/steward-url.ts
@@ -22,16 +22,16 @@ function getBrowserHostname(): string | undefined {
 /**
  * Hostnames where the browser SPA is co-hosted with a Cloudflare Pages
  * deployment that proxies `/steward/*` to the Workers API. We bypass the
- * proxy and call `api.elizacloud.ai` directly so login keeps working
+ * proxy and call the matching API worker directly so login keeps working
  * even when the Pages Functions bundle is missing or broken (the SPA
  * lives behind a CDN we do not always control).
  */
-const ELIZA_CLOUD_PROXIED_HOSTS = new Set([
-  "elizacloud.ai",
-  "www.elizacloud.ai",
-  "dev.elizacloud.ai",
-]);
-const ELIZA_CLOUD_DIRECT_API = "https://api.elizacloud.ai";
+const ELIZA_CLOUD_DIRECT_API_BY_HOST: Record<string, string> = {
+  "elizacloud.ai": "https://api.elizacloud.ai",
+  "www.elizacloud.ai": "https://api.elizacloud.ai",
+  "dev.elizacloud.ai": "https://api.elizacloud.ai",
+  "staging.elizacloud.ai": "https://api-staging.elizacloud.ai",
+};
 
 export type StewardUrlEnv = Record<string, unknown>;
 
@@ -49,8 +49,11 @@ export function resolveBrowserStewardApiUrl(origin?: string): string {
   // same-origin Pages Functions proxy and hit the Workers API directly.
   // The Workers API allowlists these origins for CORS + credentials.
   const browserHost = getBrowserHostname();
-  if (browserHost && ELIZA_CLOUD_PROXIED_HOSTS.has(browserHost)) {
-    return `${ELIZA_CLOUD_DIRECT_API}${STEWARD_PREFIX}`;
+  const directApi = browserHost
+    ? ELIZA_CLOUD_DIRECT_API_BY_HOST[browserHost]
+    : undefined;
+  if (directApi) {
+    return `${directApi}${STEWARD_PREFIX}`;
   }
 
   const resolvedOrigin = origin || getBrowserOrigin();


### PR DESCRIPTION
## Summary
- route Steward SDK calls from staging.elizacloud.ai to api-staging.elizacloud.ai
- rewrite absolute same-origin /steward fetches from the SDK, including https://staging.elizacloud.ai/steward/auth/providers and /steward/tenants/config
- keep production cloud hosts on api.elizacloud.ai
- clarify login copy so new users know Magic Link creates an account and passkey works after setup
- add resolver, fetch-bridge, and login coverage; update the login visual-review note

## Test
- bun test packages/cloud-shared/src/lib/steward-url.test.ts
- bun run --cwd packages/cloud-shared typecheck
- bun run --cwd packages/cloud-frontend test src/lib/api-fetch-bridge.test.ts
- bun run --cwd packages/cloud-frontend typecheck
- bunx @biomejs/biome check packages/cloud-frontend/src/lib/api-fetch-bridge.ts packages/cloud-frontend/src/lib/api-fetch-bridge.test.ts
- bunx @biomejs/biome check packages/cloud-frontend/src/pages/login/page.tsx packages/cloud-frontend/src/pages/login/steward-login-section.tsx packages/cloud-frontend/src/pages/login/steward-login-section.test.tsx
- git diff --check
- bun run --cwd packages/cloud-frontend audit:cloud (login desktop/mobile passed; overall run failed on unrelated desktop payment-request worker exit after 115/116 passed)

## Notes
- Focused login Vitest did not execute locally because Vite failed resolving react/jsx-dev-runtime before tests loaded, which appears to be local dependency/install state rather than this patch.