### PR TITLE
fix(cloud-shared): graceful same-gateway failover for BitRouter :nitro/:floor routing

### DIFF
--- a/packages/cloud-shared/src/lib/providers/bitrouter.test.ts
+++ b/packages/cloud-shared/src/lib/providers/bitrouter.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import type { OpenAIChatRequest } from "./types";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: () => {},
+    error: () => {},
+    info: () => {},
+    warn: () => {},
+  },
+}));
+
+// Imported after the logger mock so the provider binds to the stub.
+const { BitRouterProvider } = await import("./bitrouter");
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+function bodyModel(init: RequestInit | undefined): string {
+  return (JSON.parse(String(init?.body)) as { model: string }).model;
+}
+
+function badGateway(): Response {
+  return new Response(
+    JSON.stringify({ error: { message: "Bad Gateway", type: "service_unavailable" } }),
+    {
+      status: 503,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
+function ok(model: string): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-test",
+      object: "chat.completion",
+      created: 0,
+      model,
+      choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+const request: OpenAIChatRequest = {
+  model: "openai/gpt-oss-120b:nitro",
+  messages: [{ role: "user", content: "hi" }],
+  max_tokens: 5,
+};
+
+describe("BitRouterProvider routing-suffix failover", () => {
+  test("retries the base model when :nitro returns a retryable 503", async () => {
+    const models: string[] = [];
+    globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const model = bodyModel(init);
+      models.push(model);
+      return model.endsWith(":nitro") ? badGateway() : ok(model);
+    }) as typeof fetch;
+
+    const provider = new BitRouterProvider("test-key");
+    const response = await provider.chatCompletions(request);
+
+    expect(response.status).toBe(200);
+    expect(models).toEqual(["openai/gpt-oss-120b:nitro", "openai/gpt-oss-120b"]);
+  });
+
+  test("does not retry on a non-retryable error (400)", async () => {
+    const models: string[] = [];
+    globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      models.push(bodyModel(init));
+      return new Response(
+        JSON.stringify({ error: { message: "bad request", type: "invalid_request_error" } }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    }) as typeof fetch;
+
+    const provider = new BitRouterProvider("test-key");
+    await expect(provider.chatCompletions(request)).rejects.toMatchObject({ status: 400 });
+    expect(models).toEqual(["openai/gpt-oss-120b:nitro"]);
+  });
+
+  test("retries the base id at most once, then surfaces the failure", async () => {
+    const models: string[] = [];
+    globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      models.push(bodyModel(init));
+      return badGateway();
+    }) as typeof fetch;
+
+    const provider = new BitRouterProvider("test-key");
+    await expect(provider.chatCompletions(request)).rejects.toMatchObject({ status: 503 });
+    expect(models).toEqual(["openai/gpt-oss-120b:nitro", "openai/gpt-oss-120b"]);
+  });
+
+  test("does not attempt failover for a model without a routing suffix", async () => {
+    const models: string[] = [];
+    globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      models.push(bodyModel(init));
+      return badGateway();
+    }) as typeof fetch;
+
+    const provider = new BitRouterProvider("test-key");
+    await expect(
+      provider.chatCompletions({ ...request, model: "openai/gpt-oss-120b" }),
+    ).rejects.toMatchObject({ status: 503 });
+    expect(models).toEqual(["openai/gpt-oss-120b"]);
+  });
+});

--- a/packages/cloud-shared/src/lib/providers/bitrouter.ts
+++ b/packages/cloud-shared/src/lib/providers/bitrouter.ts
@@ -7,7 +7,8 @@
 
 import { logger } from "../utils/logger";
 import { type ProviderLabel, providerFetchWithTimeout } from "./_http";
-import { toBitRouterModelId } from "./model-id-translation";
+import { isRetryableProviderError } from "./failover";
+import { stripOpenRouterRoutingSuffix, toBitRouterModelId } from "./model-id-translation";
 import type {
   AIProvider,
   OpenAIChatRequest,
@@ -66,25 +67,54 @@ export class BitRouterProvider implements AIProvider {
     options?: ProviderRequestOptions,
   ): Promise<Response> {
     const { providerOptions: _providerOptions, ...rest } = request;
-    const translatedModel = toBitRouterModelId(rest.model);
-    const body = translatedModel === rest.model ? rest : { ...rest, model: translatedModel };
+    return await this.postChatCompletions(toBitRouterModelId(rest.model), rest, options, true);
+  }
+
+  /**
+   * POSTs a chat completion, with one same-gateway retry for OpenRouter routing
+   * suffixes: if `model` carries `:nitro` / `:floor` and the request fails with a
+   * retryable upstream error, retry once with the suffix stripped so a healthy
+   * default upstream serves the same model instead of hard-failing on the
+   * throughput-/price-priority path (bitrouter/bitrouter#572).
+   */
+  private async postChatCompletions(
+    model: string,
+    rest: Omit<OpenAIChatRequest, "providerOptions">,
+    options: ProviderRequestOptions | undefined,
+    allowRoutingFallback: boolean,
+  ): Promise<Response> {
+    const body = model === rest.model ? rest : { ...rest, model };
 
     logger.debug("[BitRouter] Forwarding chat completion request", {
-      model: translatedModel,
-      streaming: request.stream,
-      messageCount: request.messages.length,
+      model,
+      streaming: rest.stream,
+      messageCount: rest.messages.length,
     });
 
-    return await this.fetchWithTimeout(
-      `${this.baseUrl}/chat/completions`,
-      {
-        method: "POST",
-        headers: this.getHeaders(),
-        body: JSON.stringify(body),
-        signal: options?.signal,
-      },
-      options?.timeoutMs,
-    );
+    try {
+      return await this.fetchWithTimeout(
+        `${this.baseUrl}/chat/completions`,
+        {
+          method: "POST",
+          headers: this.getHeaders(),
+          body: JSON.stringify(body),
+          signal: options?.signal,
+        },
+        options?.timeoutMs,
+      );
+    } catch (error) {
+      const baseModel = allowRoutingFallback ? stripOpenRouterRoutingSuffix(model) : null;
+      if (baseModel && isRetryableProviderError(error)) {
+        logger.warn(
+          "[BitRouter] Routing-suffixed model %s failed (%d); retrying base %s",
+          model,
+          error.status,
+          baseModel,
+        );
+        return await this.postChatCompletions(baseModel, rest, options, false);
+      }
+      throw error;
+    }
   }
 
   async embeddings(request: OpenAIEmbeddingsRequest): Promise<Response> {

--- a/packages/cloud-shared/src/lib/providers/failover.ts
+++ b/packages/cloud-shared/src/lib/providers/failover.ts
@@ -9,22 +9,25 @@ import { logger } from "../utils/logger";
 import type { ProviderHttpError } from "./types";
 
 /**
+ * Upstream HTTP statuses worth retrying on a different provider or routing path:
+ * payment/capacity (402, 429) and gateway/outage (5xx). Shared by the
+ * `ProviderHttpError` failover here and the AI-SDK routing-suffix failover in
+ * `language-model.ts`.
+ */
+export const RETRYABLE_UPSTREAM_STATUSES: ReadonlySet<number> = new Set([
+  402, 429, 500, 502, 503, 504,
+]);
+
+/**
  * Whether a provider error is retryable via fallback.
  * Matches the structured `{ status, error }` shape (`ProviderHttpError`)
  * thrown by every provider implementation (BitRouter, OpenAI direct,
  * Anthropic direct, Groq).
  */
-function isRetryableProviderError(error: unknown): error is ProviderHttpError {
+export function isRetryableProviderError(error: unknown): error is ProviderHttpError {
   if (error && typeof error === "object" && "status" in error) {
     const status = (error as { status: unknown }).status;
-    return (
-      status === 402 ||
-      status === 429 ||
-      status === 500 ||
-      status === 502 ||
-      status === 503 ||
-      status === 504
-    );
+    return typeof status === "number" && RETRYABLE_UPSTREAM_STATUSES.has(status);
   }
   return false;
 }

--- a/packages/cloud-shared/src/lib/providers/language-model-nitro-failover.test.ts
+++ b/packages/cloud-shared/src/lib/providers/language-model-nitro-failover.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const ORIGINAL_FETCH = globalThis.fetch;
+
+process.env.BITROUTER_API_KEY = "test-key";
+delete process.env.BITROUTER_BASE_URL;
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: () => {},
+    error: () => {},
+    info: () => {},
+    warn: () => {},
+  },
+}));
+
+const { generateText } = await import("ai");
+const { getLanguageModel } = await import("./language-model");
+
+function bodyModel(init: RequestInit | undefined): string {
+  return (JSON.parse(String(init?.body)) as { model: string }).model;
+}
+
+function completion(model: string): Response {
+  return new Response(
+    JSON.stringify({
+      id: "chatcmpl-test",
+      object: "chat.completion",
+      created: 0,
+      model,
+      choices: [{ index: 0, message: { role: "assistant", content: "ok" }, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+describe("getLanguageModel BitRouter :nitro failover (AI SDK path)", () => {
+  let models: string[];
+
+  beforeEach(() => {
+    models = [];
+  });
+
+  test("falls back to the base model when :nitro returns 503", async () => {
+    globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      const model = bodyModel(init);
+      models.push(model);
+      if (model.endsWith(":nitro")) {
+        return new Response(JSON.stringify({ error: { message: "Bad Gateway" } }), { status: 503 });
+      }
+      return completion(model);
+    }) as typeof fetch;
+
+    const result = await generateText({
+      model: getLanguageModel("openai/gpt-oss-120b:nitro"),
+      prompt: "hi",
+      maxRetries: 0,
+    });
+
+    expect(result.text).toBe("ok");
+    expect(models).toEqual(["openai/gpt-oss-120b:nitro", "openai/gpt-oss-120b"]);
+  });
+
+  test("does not retry when the base model also fails (surfaces the error)", async () => {
+    globalThis.fetch = (async (_url: RequestInfo | URL, init?: RequestInit) => {
+      models.push(bodyModel(init));
+      return new Response(JSON.stringify({ error: { message: "Bad Gateway" } }), { status: 503 });
+    }) as typeof fetch;
+
+    await expect(
+      generateText({
+        model: getLanguageModel("openai/gpt-oss-120b:nitro"),
+        prompt: "hi",
+        maxRetries: 0,
+      }),
+    ).rejects.toBeDefined();
+    expect(models).toEqual(["openai/gpt-oss-120b:nitro", "openai/gpt-oss-120b"]);
+  });
+});

--- a/packages/cloud-shared/src/lib/providers/language-model.ts
+++ b/packages/cloud-shared/src/lib/providers/language-model.ts
@@ -1,6 +1,7 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createGatewayProvider, type GatewayProvider } from "@ai-sdk/gateway";
 import { createOpenAI } from "@ai-sdk/openai";
+import { APICallError, type LanguageModelMiddleware, RetryError, wrapLanguageModel } from "ai";
 import {
   BITROUTER_DEFAULT_FREE_MODEL,
   BITROUTER_RECOMMENDED_TEXT_MODEL,
@@ -10,7 +11,9 @@ import {
   isGroqNativeModel,
   isVastNativeModel,
 } from "../models";
-import { toBitRouterModelId } from "./model-id-translation";
+import { logger } from "../utils/logger";
+import { RETRYABLE_UPSTREAM_STATUSES } from "./failover";
+import { stripOpenRouterRoutingSuffix, toBitRouterModelId } from "./model-id-translation";
 import { getProviderKey } from "./provider-env";
 import { hasAnyVastProviderConfigured, resolveVastEndpointConfig } from "./vast-endpoints";
 
@@ -198,6 +201,76 @@ function normalizeBitRouterLanguageModelId(model: string): string {
   return toBitRouterModelId(model);
 }
 
+/** HTTP status of an AI-SDK provider error, unwrapping the retry envelope. */
+function aiSdkErrorStatus(error: unknown): number | null {
+  const unwrapped = RetryError.isInstance(error) ? error.lastError : error;
+  if (APICallError.isInstance(unwrapped) && typeof unwrapped.statusCode === "number") {
+    return unwrapped.statusCode;
+  }
+  return null;
+}
+
+function isRetryableAiSdkError(error: unknown): boolean {
+  const status = aiSdkErrorStatus(error);
+  return status !== null && RETRYABLE_UPSTREAM_STATUSES.has(status);
+}
+
+/**
+ * Resolves a BitRouter language model, adding a same-gateway routing-suffix
+ * failover for OpenRouter `:nitro` / `:floor` ids: if the throughput-/price-
+ * priority upstream fails with a retryable error, retry against the base model
+ * id (gateway default routing) instead of hard-failing — see
+ * bitrouter/bitrouter#572. Models without a routing suffix are returned as-is.
+ */
+function getBitRouterLanguageModel(model: string) {
+  const client = getBitRouterClient();
+  const primaryId = normalizeBitRouterLanguageModelId(model);
+  const baseId = stripOpenRouterRoutingSuffix(primaryId);
+  const primaryModel = client.chat(primaryId);
+  if (!baseId) {
+    return primaryModel;
+  }
+
+  const baseModel = client.chat(baseId);
+  const middleware: LanguageModelMiddleware = {
+    specificationVersion: "v3",
+    wrapGenerate: async ({ doGenerate, params }) => {
+      try {
+        return await doGenerate();
+      } catch (error) {
+        if (!isRetryableAiSdkError(error)) {
+          throw error;
+        }
+        logger.warn(
+          "[BitRouter] Routing-suffixed model %s failed (%d); retrying base %s",
+          primaryId,
+          aiSdkErrorStatus(error),
+          baseId,
+        );
+        return await baseModel.doGenerate(params);
+      }
+    },
+    wrapStream: async ({ doStream, params }) => {
+      try {
+        return await doStream();
+      } catch (error) {
+        if (!isRetryableAiSdkError(error)) {
+          throw error;
+        }
+        logger.warn(
+          "[BitRouter] Routing-suffixed model %s stream failed (%d); retrying base %s",
+          primaryId,
+          aiSdkErrorStatus(error),
+          baseId,
+        );
+        return await baseModel.doStream(params);
+      }
+    },
+  };
+
+  return wrapLanguageModel({ model: primaryModel, middleware });
+}
+
 function requiresBitRouterRouting(model: string): boolean {
   const bitRouterModel = toBitRouterModelId(model);
   return (
@@ -285,7 +358,7 @@ export function getLanguageModel(model: string) {
   }
 
   if (getBitRouterApiKey()) {
-    return getBitRouterClient().chat(normalizeBitRouterLanguageModelId(model));
+    return getBitRouterLanguageModel(model);
   }
 
   if (requiresBitRouterRouting(model)) {

--- a/packages/cloud-shared/src/lib/providers/model-id-translation.test.ts
+++ b/packages/cloud-shared/src/lib/providers/model-id-translation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { stripOpenRouterRoutingSuffix } from "./model-id-translation";
+
+describe("stripOpenRouterRoutingSuffix", () => {
+  test("strips :nitro from a provider-prefixed model id", () => {
+    expect(stripOpenRouterRoutingSuffix("openai/gpt-oss-120b:nitro")).toBe("openai/gpt-oss-120b");
+  });
+
+  test("strips :floor from a provider-prefixed model id", () => {
+    expect(stripOpenRouterRoutingSuffix("x-ai/grok-4:floor")).toBe("x-ai/grok-4");
+  });
+
+  test("strips :nitro from a dashed bare model id", () => {
+    expect(stripOpenRouterRoutingSuffix("gpt-oss-120b:nitro")).toBe("gpt-oss-120b");
+  });
+
+  test("does not strip :free (distinct free-tier variant)", () => {
+    expect(stripOpenRouterRoutingSuffix("openai/gpt-oss-120b:free")).toBeNull();
+  });
+
+  test("does not strip :online (changes behavior)", () => {
+    expect(stripOpenRouterRoutingSuffix("openai/gpt-oss-120b:online")).toBeNull();
+  });
+
+  test("returns null when there is no routing suffix", () => {
+    expect(stripOpenRouterRoutingSuffix("openai/gpt-oss-120b")).toBeNull();
+  });
+
+  test("does not mistake a forced-provider prefix for a suffix", () => {
+    expect(stripOpenRouterRoutingSuffix("cerebras:gpt-oss-120b")).toBeNull();
+  });
+
+  test("strips only the trailing routing suffix, keeping a forced-provider prefix", () => {
+    expect(stripOpenRouterRoutingSuffix("cerebras:gpt-oss-120b:nitro")).toBe(
+      "cerebras:gpt-oss-120b",
+    );
+  });
+
+  test("returns null for an opaque provider:nitro with no model id shape", () => {
+    expect(stripOpenRouterRoutingSuffix("foo:nitro")).toBeNull();
+  });
+
+  test("returns null for empty input", () => {
+    expect(stripOpenRouterRoutingSuffix("")).toBeNull();
+  });
+});

--- a/packages/cloud-shared/src/lib/providers/model-id-translation.ts
+++ b/packages/cloud-shared/src/lib/providers/model-id-translation.ts
@@ -26,6 +26,52 @@ const PREFIX_MAP: ReadonlyArray<readonly [string, string]> = [
   ["mistral/", "mistralai/"],
 ];
 
+/**
+ * OpenRouter-style routing suffixes that select a *provider preference* for a
+ * model without changing the model itself: `:nitro` sorts upstreams by
+ * throughput, `:floor` sorts by price. BitRouter accepts these as a drop-in
+ * OpenRouter replacement, but the preferred upstream can be unhealthy while the
+ * model's default routing is fine — see bitrouter/bitrouter#572, where
+ * `openai/gpt-oss-120b:nitro` returns 503 from the gateway while the same model
+ * served by a healthy upstream returns 200.
+ *
+ * These suffixes are routing *hints*, not part of model identity, so on a
+ * retryable upstream failure we can drop the suffix and retry the base id (which
+ * routes to the gateway default). Deliberately excluded: `:free` (a distinct
+ * free-tier variant with different pricing/SLA) and `:online` (enables web
+ * search) — stripping those would change billing or behavior.
+ */
+const OPENROUTER_ROUTING_SUFFIXES: ReadonlySet<string> = new Set(["nitro", "floor"]);
+
+/**
+ * If `model` carries an OpenRouter routing suffix (`:nitro` / `:floor`), returns
+ * the base model id with the suffix removed; otherwise returns `null`.
+ *
+ * The suffix is the last `:`-delimited token. A forced-provider prefix
+ * (`cerebras:gpt-oss-120b`) is never mistaken for a suffix because its token is
+ * not a known routing word, and a bare `provider:model` with no dash in the
+ * prefix is rejected so only real model ids (`openai/gpt-oss-120b:nitro`,
+ * `gpt-oss-120b:nitro`) match.
+ */
+export function stripOpenRouterRoutingSuffix(model: string): string | null {
+  const colonIndex = model.lastIndexOf(":");
+  if (colonIndex <= 0) {
+    return null;
+  }
+  const suffix = model.slice(colonIndex + 1);
+  if (!OPENROUTER_ROUTING_SUFFIXES.has(suffix)) {
+    return null;
+  }
+  const base = model.slice(0, colonIndex);
+  // A routing suffix attaches to a model id, which is either provider-prefixed
+  // (`openai/gpt-oss-120b`) or a dashed bare id that lost its prefix upstream
+  // (`gpt-oss-120b`). Anything else (`foo:nitro`) is treated as opaque.
+  if (!base.includes("/") && !base.includes("-")) {
+    return null;
+  }
+  return base;
+}
+
 const PROVIDER_KEY_MAP: Readonly<Record<string, string>> = {
   "x-ai": "xai",
   mistralai: "mistral",


### PR DESCRIPTION
## Problem

Reported in [bitrouter/bitrouter#572](https://github.com/bitrouter/bitrouter/issues/572): `openai/gpt-oss-120b:nitro` returns **503 "Bad Gateway"** from BitRouter Cloud, while the *same model* on a healthy upstream (e.g. Cerebras-direct) returns 200. The model is fine — only the `:nitro` (throughput-priority) gateway routing is failing — but Eliza Cloud routes the OpenAI-compatible request straight through and hard-503s on the caller's first request.

The OpenRouter `:nitro` (throughput) and `:floor` (price) suffixes are routing **hints**, not part of model identity. BitRouter accepts them as a drop-in OpenRouter replacement, so we should treat them as advisory and degrade gracefully when the preferred upstream is down — rather than only moving the *recommended default* off `:nitro` (#8426).

## Fix

On a retryable upstream error (402/429/5xx) for a `:nitro`/`:floor` model, retry **once** with the suffix stripped (the base model id), which routes to the gateway default. `:nitro` stays the fast path when healthy and degrades to the base model when the throughput route is down.

- **`model-id-translation.ts`** — `stripOpenRouterRoutingSuffix()`. Handles only `:nitro`/`:floor`; deliberately **not** `:free` (a distinct free-tier variant with different pricing/SLA) or `:online` (enables web search) — stripping those would change billing/behavior.
- **`failover.ts`** — export `isRetryableProviderError` + a shared `RETRYABLE_UPSTREAM_STATUSES` set.
- **`bitrouter.ts`** (raw provider path — `/v1/apps/[id]/chat`) — one same-gateway retry with the suffix stripped on a retryable `ProviderHttpError`.
- **`language-model.ts`** (AI SDK path — `/v1/chat/completions`, `/v1/messages`, `/v1/chat`, `/v1/generate-prompts`) — wrap the BitRouter model with a `wrapLanguageModel` middleware that retries the base id on a retryable `APICallError`, for both `generate` and `stream`. Models without a routing suffix are returned unwrapped (zero behavior change).

**Billing is unchanged:** `:nitro`/`:floor` and the base id are the same model, and pricing lookup already strips the suffix (#8319).

## Tests

`bun test packages/cloud-shared/src/lib/providers/` — 23 pass:

- `model-id-translation.test.ts` — suffix-stripping edge cases (provider-prefixed, dashed bare id, forced-provider prefix guard, `:free`/`:online` left intact).
- `bitrouter.test.ts` — raw-provider failover: `:nitro` 503 → base retry → 200; no retry on 400; at most one base retry; no failover for un-suffixed ids.
- `language-model-nitro-failover.test.ts` — **end-to-end AI SDK path**: `getLanguageModel("openai/gpt-oss-120b:nitro")` driven through `generateText` with a mocked gateway returns the base model's response after the `:nitro` 503.

## Verification

- `bun test packages/cloud-shared/src/lib/providers/` → 23 pass, 0 fail
- `bun run --cwd packages/cloud-shared typecheck` → 0 errors
- `biome check` on all touched files → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)