### PR TITLE
release: promote develop → main (agent provisioning fix chain: #8435 + #8441)

### DIFF
--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -1346,10 +1346,22 @@ export class DockerSandboxProvider implements SandboxProvider {
       headscaleIp: headscaleIp || undefined,
     };
 
+    // Over the headscale mesh the agent-router and the daemon's runtime calls
+    // reach the CONTAINER directly at its tailnet IP, where only the container-
+    // internal port is bound (the app binds 0.0.0.0:${containerPort}).
+    // bridge_port / web_ui_port are the HOST-published ports from
+    // `docker -p host:container`; they don't exist inside the container's
+    // network namespace, so they only work for legacy host routing. bridge_url
+    // and health_url are the single source of truth for reaching the agent —
+    // encode the port that is actually reachable over the chosen ingress.
+    const containerPortNum = Number.parseInt(containerPort, 10);
+    const bridgeUrlPort = headscaleIp ? containerPortNum : bridgePort;
+    const webUiUrlPort = headscaleIp ? containerPortNum : webUiPort;
+
     return {
       sandboxId: containerName,
-      bridgeUrl: `http://${targetHost}:${bridgePort}`,
-      healthUrl: `http://${targetHost}:${webUiPort}/api`,
+      bridgeUrl: `http://${targetHost}:${bridgeUrlPort}`,
+      healthUrl: `http://${targetHost}:${webUiUrlPort}/api`,
       metadata: { ...metadata },
     };
   }
@@ -1594,15 +1606,84 @@ export class DockerSandboxProvider implements SandboxProvider {
   // checkHealth
   // ------------------------------------------------------------------
 
+  /**
+   * Poll the agent's health endpoint over the headscale tailnet — the real
+   * ingress the agent-router uses. The daemon is a member of the mesh, so it
+   * dials the agent's tailnet IP directly. Retries until the app has booted AND
+   * the WireGuard/DERP path is warm, or the deadline passes. This is what keeps
+   * a freshly-registered container alive long enough to become reachable: the
+   * SSH host probe alone passes as soon as the app binds the container's docker
+   * bridge (eth0), which happens before the tailnet path is warm, so the first
+   * racing tailnet fetch (listRuntimeAgents) would tear a healthy agent down.
+   */
+  private async pollTailnetHealth(
+    handle: SandboxHandle,
+    meta: ContainerMeta,
+    deadline: number,
+  ): Promise<boolean> {
+    // handle.healthUrl is `http://<headscaleIp>:<containerPort>/api`; the agent
+    // serves liveness at /api/health on that same port.
+    const healthUrl = `${handle.healthUrl}/health`;
+    logger.info(
+      `[docker-sandbox] Polling tailnet health for ${meta.containerName} at ${healthUrl} (timeout: ${HEALTH_CHECK_TIMEOUT_MS / 1000}s)`,
+    );
+
+    while (Date.now() < deadline) {
+      try {
+        const res = await fetch(healthUrl, {
+          method: "GET",
+          signal: AbortSignal.timeout(5_000),
+        });
+        if ([200, 301, 302, 401].includes(res.status)) {
+          logger.info(
+            `[docker-sandbox] Tailnet health probe passed for ${meta.containerName} (${healthUrl})`,
+          );
+          return true;
+        }
+        logger.debug(
+          `[docker-sandbox] Tailnet health probe for ${meta.containerName} returned HTTP ${res.status}, retrying...`,
+        );
+      } catch (err) {
+        logger.debug(
+          `[docker-sandbox] Tailnet health probe failed for ${meta.containerName}, retrying: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.min(HEALTH_CHECK_POLL_INTERVAL_MS, remaining)),
+      );
+    }
+
+    logger.warn(
+      `[docker-sandbox] Tailnet health check timed out after ${HEALTH_CHECK_TIMEOUT_MS / 1000}s for ${meta.containerName} (${healthUrl})`,
+    );
+    return false;
+  }
+
   async checkHealth(handle: SandboxHandle): Promise<boolean> {
     const meta = await this.resolveContainer(handle.sandboxId);
+    const deadline = Date.now() + HEALTH_CHECK_TIMEOUT_MS;
+
+    // When the agent is reachable over the headscale mesh, validate THAT
+    // ingress: the agent-router and the post-create runtime calls reach the
+    // agent over the tailnet, and the daemon is itself on the mesh. The SSH host
+    // probe below only proves the app bound the container's docker bridge, which
+    // happens before the tailnet/DERP path is warm — gating on it would let the
+    // first racing tailnet fetch tear the agent down despite it being healthy.
+    const headscaleIp =
+      typeof handle.metadata?.headscaleIp === "string" ? handle.metadata.headscaleIp : undefined;
+    if (headscaleIp) {
+      return this.pollTailnetHealth(handle, meta, deadline);
+    }
+
     const ssh = DockerSSHClient.getClient(
       meta.hostname,
       meta.sshPort,
       meta.hostKeyFingerprint,
       meta.sshUser,
     );
-    const deadline = Date.now() + HEALTH_CHECK_TIMEOUT_MS;
     const inspectCmd = `docker inspect --format '{{.State.Health.Status}}' ${shellQuote(meta.containerName)}`;
     const hostProbeCmd = `sh -lc ${shellQuote(
       [

--- a/packages/scripts/cloud/admin/daemons/agent-router.test.ts
+++ b/packages/scripts/cloud/admin/daemons/agent-router.test.ts
@@ -7,37 +7,44 @@ import {
 } from "./agent-router";
 
 describe("resolveSandboxRouting", () => {
-  it("prefers headscale IP for the target when bridge metadata is available", () => {
+  it("routes over the tailnet to the container port encoded in bridge_url", () => {
+    // After provisioning, bridge_url encodes the agent's tailnet IP + the
+    // container-internal port (the app binds 0.0.0.0:<containerPort>). Over the
+    // mesh the container is reached directly there, so bridge and web UI share
+    // that one port.
     expect(
       resolveSandboxRouting({
         status: "running",
-        bridge_url: "http://172.18.0.10:18791",
+        bridge_url: "http://100.64.0.21:3000",
         headscale_ip: "100.64.0.21",
         web_ui_port: 20001,
       }),
     ).toEqual({
       headscaleIp: "100.64.0.21",
-      bridgePort: 18791,
-      webUiPort: 20001,
-      bridgeTarget: "100.64.0.21:18791",
-      webTarget: "100.64.0.21:20001",
-      target: "100.64.0.21:20001",
+      bridgePort: 3000,
+      webUiPort: 3000,
+      bridgeTarget: "100.64.0.21:3000",
+      webTarget: "100.64.0.21:3000",
+      target: "100.64.0.21:3000",
     });
   });
 
-  it("prefers persisted bridge port over bridge URL metadata", () => {
+  it("ignores the host bridge_port over the tailnet (container port from bridge_url wins)", () => {
+    // bridge_port / web_ui_port are HOST-published ports (docker -p) that do
+    // not exist inside the container's netns; routing them over the tailnet
+    // would always connection-refuse. The container port from bridge_url wins.
     expect(
       resolveSandboxRouting({
         status: "running",
-        bridge_url: "http://172.18.0.10:18791",
+        bridge_url: "http://100.64.0.21:3000",
         bridge_port: 18888,
         headscale_ip: "100.64.0.21",
         web_ui_port: 20001,
       }),
     ).toMatchObject({
-      bridgePort: 18888,
-      bridgeTarget: "100.64.0.21:18888",
-      webTarget: "100.64.0.21:20001",
+      bridgePort: 3000,
+      bridgeTarget: "100.64.0.21:3000",
+      webTarget: "100.64.0.21:3000",
     });
   });
 
@@ -71,7 +78,9 @@ describe("resolveSandboxRouting", () => {
     });
   });
 
-  it("routes valid headscale IP even when bridge URL is malformed", () => {
+  it("refuses to route a headscale sandbox when bridge_url has no usable port", () => {
+    // Over the tailnet there is no safe fallback — the host ports are
+    // unreachable, so without the container port we must not route at all.
     expect(
       resolveSandboxRouting({
         status: "running",
@@ -79,14 +88,7 @@ describe("resolveSandboxRouting", () => {
         headscale_ip: "100.64.0.21",
         web_ui_port: 20001,
       }),
-    ).toEqual({
-      headscaleIp: "100.64.0.21",
-      bridgePort: 20001,
-      webUiPort: 20001,
-      bridgeTarget: "100.64.0.21:20001",
-      webTarget: "100.64.0.21:20001",
-      target: "100.64.0.21:20001",
-    });
+    ).toBeNull();
   });
 
   it("only enables bridge-host fallback through the explicit env flag", () => {

--- a/packages/scripts/cloud/admin/daemons/agent-router.ts
+++ b/packages/scripts/cloud/admin/daemons/agent-router.ts
@@ -107,6 +107,18 @@ interface SandboxRoutingOptions {
   allowBridgeHostFallback?: boolean;
 }
 
+function parseUrlPort(url: string | null | undefined): number | null {
+  if (!url) return null;
+  try {
+    const { port } = new URL(url);
+    if (!port) return null;
+    const parsed = Number.parseInt(port, 10);
+    return Number.isFinite(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
 export function resolveSandboxRouting(
   sandbox: SandboxRoutingFields | null | undefined,
   options: SandboxRoutingOptions = {},
@@ -115,6 +127,32 @@ export function resolveSandboxRouting(
     return null;
   }
 
+  // Headscale mesh routing: the router reaches the CONTAINER directly at its
+  // tailnet IP, where only the container-internal port is bound. bridge_port /
+  // web_ui_port are the HOST-published ports (docker -p host:container) and do
+  // not exist inside the container's network namespace, so they are unreachable
+  // over the tailnet. bridge_url is the single source of truth and encodes the
+  // reachable container port; the bridge API and the web UI are both served on
+  // it. Without a parseable port we cannot route — refuse rather than guess a
+  // host port that would never connect.
+  const tailnetIp = sandbox.headscale_ip?.trim();
+  if (tailnetIp) {
+    const containerPort = parseUrlPort(sandbox.bridge_url);
+    if (!containerPort) return null;
+    const target = `${tailnetIp}:${containerPort}`;
+    return {
+      headscaleIp: tailnetIp,
+      bridgePort: containerPort,
+      webUiPort: containerPort,
+      bridgeTarget: target,
+      webTarget: target,
+      target,
+    };
+  }
+
+  // Legacy host routing (no headscale_ip): reach the agent through the docker
+  // host's published bridge/web ports. Off by default — requires the explicit
+  // AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK opt-in.
   let bridgePort: number | null =
     typeof sandbox.bridge_port === "number" ? sandbox.bridge_port : null;
   let bridgeHost: string | null = null;
@@ -130,17 +168,16 @@ export function resolveSandboxRouting(
     }
   }
 
-  const host = sandbox.headscale_ip?.trim() || bridgeHost;
-  if (!host) return null;
+  if (!bridgeHost) return null;
   if (!bridgePort || !Number.isFinite(bridgePort)) {
     bridgePort = sandbox.web_ui_port;
   }
 
   const webUiPort = sandbox.web_ui_port;
-  const bridgeTarget = `${host}:${bridgePort}`;
-  const webTarget = `${host}:${webUiPort}`;
+  const bridgeTarget = `${bridgeHost}:${bridgePort}`;
+  const webTarget = `${bridgeHost}:${webUiPort}`;
   return {
-    headscaleIp: host,
+    headscaleIp: bridgeHost,
     bridgePort,
     webUiPort,
     bridgeTarget,


### PR DESCRIPTION
Promote develop → main to ship the agent-provisioning fix chain to the prod daemon.

**What ships:**
- #8441 — route agents over the tailnet on the container port, not host ports (final agent fix; tailnet health-poll)
- (#8435 headscale_ip node-name lookup already in main)

Together with Steward #129 (the 403 `requireTenantAdminOrApiKey` fix, already deployed) this completes the agent provisioning path: Steward registration → headscale_ip registration → tailnet routing.

Per the #8434 ship plan (nubs). Merging through the known-unrelated red checks (Cloud Live E2E `containers:read` permission env issue + windows cloud-shared test — neither caused by this code; verified).

Promotes 1 commit. Co-authored-by: wakesync <shadow@shad0w.xyz>