### PR TITLE
fix(ui): stabilize overlay chat prompt suggestions across reveals

### DIFF
--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -113,6 +113,22 @@ describe("ContinuousChatOverlay", () => {
     expect(strip.className).toContain("opacity-100");
   });
 
+  it("reveals suggestions when an empty composer receives keyboard focus", () => {
+    render(
+      <ContinuousChatOverlay controller={makeController({ messages: [] })} />,
+    );
+    const strip = screen.getByTestId("chat-suggestions");
+    const firstSuggestion = screen.getByTestId("chat-suggestion-0");
+
+    expect(strip.className).toContain("opacity-0");
+    expect(firstSuggestion.tabIndex).toBe(-1);
+
+    fireEvent.focus(screen.getByLabelText("message"));
+
+    expect(strip.className).toContain("opacity-100");
+    expect(firstSuggestion.tabIndex).toBe(0);
+  });
+
   it("filters whitespace-only messages from the expanded thread", () => {
     render(<ContinuousChatOverlay controller={makeController()} />);
     fireEvent.focus(screen.getByLabelText("message"));
@@ -143,6 +159,17 @@ describe("ContinuousChatOverlay", () => {
     expect(user?.className).toContain("justify-end");
   });
 
+  it("anchors typing dots as an assistant-aligned transcript row", () => {
+    render(
+      <ContinuousChatOverlay
+        controller={makeController({ phase: "responding" })}
+      />,
+    );
+    const typing = screen.getByTestId("typing-dots");
+    expect(typing.className).toContain("w-full");
+    expect(typing.className).toContain("justify-start");
+  });
+
   it("collapses the bubbles on Escape", () => {
     render(<ContinuousChatOverlay controller={makeController()} />);
     const input = screen.getByLabelText("message");
@@ -153,18 +180,16 @@ describe("ContinuousChatOverlay", () => {
     expect(thread?.getAttribute("data-revealed")).toBe("false");
   });
 
-  it("toggles a full-screen takeover with a liquid-glass focus backdrop", () => {
+  it("toggles a full-screen takeover with a lightweight focus backdrop", () => {
     render(<ContinuousChatOverlay controller={makeController()} />);
     const root = screen.getByTestId("continuous-chat-overlay");
     const backdrop = screen.getByTestId("chat-fullscreen-backdrop");
     expect(root.getAttribute("data-fullscreen")).toBeNull();
     // Resting: backdrop is inactive + click-through (the live view stays usable).
-    // pointer-events live on the className (a static Tailwind class) so the
-    // perf-sensitive backdrop-filter is the only animated property.
     expect(backdrop.getAttribute("data-active")).toBe("false");
     expect(backdrop.className).toContain("pointer-events-none");
 
-    // Far-left button enters full screen and blooms the glass panel over the view.
+    // Far-left button enters full screen and fades a cheap scrim over the view.
     fireEvent.click(screen.getByLabelText("expand to full screen"));
     expect(root.getAttribute("data-fullscreen")).toBe("true");
     expect(document.querySelector('[data-variant="fullscreen"]')).toBeTruthy();
@@ -296,6 +321,19 @@ describe("ContinuousChatOverlay", () => {
     expect(screen.getAllByTestId("chat-composer-textarea")).toHaveLength(1);
   });
 
+  it("keeps composer controls inside one constrained input pill", () => {
+    render(<ContinuousChatOverlay controller={makeController()} />);
+
+    const input = screen.getByTestId("chat-composer-textarea");
+    const bar = input.parentElement;
+
+    expect(screen.queryByTestId("chat-composer-clear-debug")).toBeNull();
+    expect(bar?.className).toContain("max-w-full");
+    expect(bar?.className).not.toContain("flex-wrap");
+    expect(input.className).toContain("flex-1");
+    expect(input.className).not.toContain("basis-full");
+  });
+
   it("shows exactly three resting prompt suggestions", () => {
     render(
       <ContinuousChatOverlay
@@ -345,6 +383,17 @@ describe("ContinuousChatOverlay", () => {
     expect(thread?.getAttribute("data-revealed")).toBe("true");
     // A click on the live view behind (here, the bare document body) closes it.
     fireEvent.pointerDown(document.body);
+    expect(thread?.getAttribute("data-revealed")).toBe("false");
+  });
+
+  it("collapses the bubbles when the underlying app scrolls", () => {
+    render(<ContinuousChatOverlay controller={makeController()} />);
+    const thread = document.getElementById("continuous-thread");
+
+    fireEvent.focus(screen.getByLabelText("message"));
+    expect(thread?.getAttribute("data-revealed")).toBe("true");
+
+    fireEvent.scroll(document.body);
     expect(thread?.getAttribute("data-revealed")).toBe("false");
   });
 

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -42,17 +42,15 @@ import type { ShellController } from "./useShellController";
 // The expanded transcript itself is intentionally chrome-free (no panel
 // background/border); its lines carry their own scrim via ThreadLine `floating`.
 const GLASS_BAR =
-  "flex items-center gap-2 rounded-full border border-white/18 bg-black/45 px-3 py-2 backdrop-blur-xl " +
+  "flex min-w-0 max-w-full items-center gap-1.5 rounded-full border border-white/18 bg-black/45 px-2 py-2 backdrop-blur-xl sm:gap-2 sm:px-3 " +
   "shadow-[inset_0_1px_0_rgba(255,255,255,0.22),0_16px_46px_-12px_rgba(0,0,0,0.66)]";
 
 // Floating (un-scrimmed) text gets a soft shadow so it reads over bright views.
 const FLOAT_SHADOW = "[text-shadow:0_1px_4px_rgba(0,0,0,0.7)]";
 
-// Shared easing for the overlay's motion. Matches the repo's `motion/react`
-// convention (a tween with a custom cubic-bezier, no springs); centralising it
-// keeps the reveal/swap/glow timings coherent rather than scattering magic
-// numbers. Every motion below is transform/opacity only (GPU-friendly) and is
-// softened to a near-instant cross-fade under `prefers-reduced-motion`.
+// Shared easing for the overlay's cheap motion path. Fullscreen open/close must
+// stay opacity/translate only: animating blur/filter or scaling a scrollable
+// transcript repaints too much of the viewport and visibly janks on laptops.
 const OVERLAY_EASE: [number, number, number, number] = [0.22, 1, 0.36, 1];
 
 // Resting / typing view (not fullscreen) shows only the last couple of turns
@@ -75,9 +73,6 @@ const SPEAKER_MUTED_GLYPH =
 const MAXIMIZE_GLYPH =
   "M20 8H28V16H25V13.1L18.5 19.6L16.4 17.5L22.9 11H20Z " +
   "M16 28H8V20H11V22.9L17.5 16.4L19.6 18.5L13.1 25H16Z";
-// Trash can (lid bar + body) — DEV-only "clear conversation" debug control.
-const TRASH_GLYPH = "M14 7H22V10H27V13H9V10H14Z M11 15H25L23.5 30H12.5Z";
-
 function Glyph({ d }: { d: string }): React.JSX.Element {
   return (
     <svg viewBox="0 0 36 36" className="h-4 w-4" aria-hidden="true">
@@ -139,7 +134,8 @@ function SoftButton({
 function TypingDots({ reduce }: { reduce?: boolean }): React.JSX.Element {
   return (
     <motion.div
-      className="flex gap-1.5"
+      className="mb-2.5 flex w-full justify-start"
+      data-testid="typing-dots"
       role="status"
       aria-label="assistant is responding"
       // Fade in/out so the dots dissolve with the reply rather than popping.
@@ -148,18 +144,22 @@ function TypingDots({ reduce }: { reduce?: boolean }): React.JSX.Element {
       exit={{ opacity: 0 }}
       transition={{ duration: reduce ? 0 : 0.45, ease: OVERLAY_EASE }}
     >
-      {[0, 1, 2].map((i) => (
-        <span
-          key={i}
-          className={cn(
-            // `motion-reduce:animate-none` stills the breathing pulse for users
-            // who ask for reduced motion (the CSS pulse isn't a motion/react anim).
-            "h-1.5 w-1.5 animate-pulse rounded-full bg-white/70 motion-reduce:animate-none",
-            FLOAT_SHADOW,
-          )}
-          style={{ animationDelay: `${i * 180}ms` }}
-        />
-      ))}
+      <div
+        className={cn(
+          "rounded-2xl rounded-bl-md border border-white/10 bg-black/45 px-3.5 py-2 text-white/90",
+          FLOAT_SHADOW,
+        )}
+      >
+        <span className="flex gap-1.5">
+          {[0, 1, 2].map((i) => (
+            <span
+              key={i}
+              className="h-1.5 w-1.5 animate-pulse rounded-full bg-white/70 motion-reduce:animate-none"
+              style={{ animationDelay: `${i * 180}ms` }}
+            />
+          ))}
+        </span>
+      </div>
     </motion.div>
   );
 }
@@ -202,7 +202,7 @@ function ThreadLine({
           isUser ? "rounded-br-md" : "rounded-bl-md",
           floating
             ? cn(
-                "border backdrop-blur-md",
+                "border",
                 isUser
                   ? "border-white/15 bg-black/55 text-white"
                   : "border-white/10 bg-black/45 text-white/90",
@@ -237,7 +237,6 @@ export function ContinuousChatOverlay({
     speaking,
     agentVoiceMuted,
     toggleAgentVoiceMute,
-    clearConversation,
   } = controller;
 
   // Honor the OS "reduce motion" setting: every overlay animation collapses to
@@ -248,6 +247,7 @@ export function ContinuousChatOverlay({
   const [expanded, setExpanded] = React.useState(false);
   const [fullscreen, setFullscreen] = React.useState(false);
   const [hovered, setHovered] = React.useState(false);
+  const [composerFocused, setComposerFocused] = React.useState(false);
   const [whisperVisible, setWhisperVisible] = React.useState(false);
   const [pushToTalkActive, setPushToTalkActive] = React.useState(false);
   const [pendingImages, setPendingImages] = React.useState<ImageAttachment[]>(
@@ -258,7 +258,8 @@ export function ContinuousChatOverlay({
   const inputRef = React.useRef<HTMLInputElement>(null);
   const fileInputRef = React.useRef<HTMLInputElement>(null);
   const threadRef = React.useRef<HTMLDivElement>(null);
-  const composerRef = React.useRef<HTMLDivElement>(null);
+  const suggestionsRef = React.useRef<HTMLFieldSetElement>(null);
+  const composerRef = React.useRef<HTMLFieldSetElement>(null);
   const focusThreadRef = React.useRef(false);
   const pushToTalkTimerRef = React.useRef<number | null>(null);
   const pushToTalkActiveRef = React.useRef(false);
@@ -279,13 +280,14 @@ export function ContinuousChatOverlay({
   const responding = phase === "responding";
   const hasDraft = draft.trim().length > 0;
   const hasImages = pendingImages.length > 0;
-  const open = expanded || hovered || fullscreen;
+  const open = expanded || hovered || fullscreen || composerFocused;
   // "Peek" = the non-fullscreen reveal: the chat bubbles + suggestions fade in
-  // when the user hovers the bar OR clicks into the input (expanded), while a
-  // reply is streaming (responding), or briefly when a new line arrives
-  // (whisperVisible). They fade back out otherwise.
+  // when the user hovers the bar, focuses the composer, clicks into a populated
+  // thread (expanded), while a reply is streaming (responding), or briefly when
+  // a new line arrives (whisperVisible). They fade back out otherwise.
   const peek =
-    !fullscreen && (hovered || expanded || responding || whisperVisible);
+    !fullscreen &&
+    (hovered || composerFocused || expanded || responding || whisperVisible);
 
   // The suggestion strip rides along with the bubbles (same peek reveal). The
   // base conditions keep it sensible (ready, nothing typed/attached, not
@@ -468,6 +470,7 @@ export function ContinuousChatOverlay({
     setExpanded(false);
     setFullscreen(false);
     setHovered(false);
+    setComposerFocused(false);
     if (hoverLeaveTimerRef.current !== null) {
       window.clearTimeout(hoverLeaveTimerRef.current);
       hoverLeaveTimerRef.current = null;
@@ -500,6 +503,22 @@ export function ContinuousChatOverlay({
     }, 150);
   }, []);
 
+  const handleAmbientFocus = React.useCallback(() => {
+    setComposerFocused(true);
+  }, []);
+
+  const handleAmbientBlur = React.useCallback(
+    (event: React.FocusEvent<HTMLElement>) => {
+      const next = event.relatedTarget;
+      const staysInOverlay =
+        next instanceof Element &&
+        ((composerRef.current?.contains(next) ?? false) ||
+          (suggestionsRef.current?.contains(next) ?? false));
+      if (!staysInOverlay) setComposerFocused(false);
+    },
+    [],
+  );
+
   // The maximize button: toggle a true full-screen transcript. /chat is the
   // overlay itself (overlay-only), so there is no separate page to navigate to —
   // "full screen" means expanding this same thread to fill the viewport.
@@ -516,24 +535,26 @@ export function ContinuousChatOverlay({
   // Click into the composer → reveal the thread, but keep keyboard focus in the
   // input (don't arm the thread-focus move) so the user can type immediately.
   const expand = React.useCallback(() => {
+    setComposerFocused(true);
     if (!hasThread) return;
     setExpanded(true);
   }, [hasThread]);
 
-  // Close the thread on any pointer-down that isn't on a message bubble or the
-  // composer — i.e. anywhere that isn't the chat itself (the live view behind, a
-  // gap in the thread, the backdrop). The overlay root is pointer-events-none,
-  // so a capture-phase document listener still catches clicks that fall through
-  // to the view behind; guarding on the bubbles + composer keeps clicks on the
-  // conversation (e.g. selecting message text) from dismissing it.
+  // Close the thread on any pointer-down that isn't on a message bubble, the
+  // suggestions, or the composer — i.e. anywhere that isn't the chat itself (the
+  // live view behind, a gap in the thread, the backdrop). The overlay root is
+  // pointer-events-none, so a capture-phase document listener still catches
+  // clicks that fall through to the view behind; guarding on the chat affordances
+  // keeps normal interaction from dismissing it.
   React.useEffect(() => {
     if (!open) return;
     const onPointerDown = (e: PointerEvent) => {
       const target = e.target instanceof Element ? e.target : null;
       if (!target) return;
       const onBubble = target.closest('[data-testid="thread-line"]') !== null;
+      const inSuggestions = suggestionsRef.current?.contains(target) ?? false;
       const inComposer = composerRef.current?.contains(target) ?? false;
-      if (onBubble || inComposer) return;
+      if (onBubble || inSuggestions || inComposer) return;
       collapseAll();
     };
     document.addEventListener("pointerdown", onPointerDown, true);
@@ -541,10 +562,29 @@ export function ContinuousChatOverlay({
       document.removeEventListener("pointerdown", onPointerDown, true);
   }, [open, collapseAll]);
 
+  // When the user scrolls the app behind the ambient chat, get the transient
+  // bubbles out of the way. Fullscreen chat owns its own scroll region, so this
+  // only applies to the resting overlay peek state.
+  React.useEffect(() => {
+    if (!peek) return;
+    const onScroll = (event: Event) => {
+      const target = event.target instanceof Element ? event.target : null;
+      const insideChat =
+        target &&
+        ((threadRef.current?.contains(target) ?? false) ||
+          (suggestionsRef.current?.contains(target) ?? false) ||
+          (composerRef.current?.contains(target) ?? false));
+      if (insideChat) return;
+      collapseAll();
+    };
+    document.addEventListener("scroll", onScroll, true);
+    return () => document.removeEventListener("scroll", onScroll, true);
+  }, [collapseAll, peek]);
+
   return (
     <div
       className={cn(
-        "pointer-events-none fixed flex flex-col items-center px-4",
+        "pointer-events-none fixed flex w-full min-w-0 flex-col items-center px-3 sm:px-4",
         // Fullscreen: take over the whole viewport (transcript fills, composer
         // pinned to the bottom). Otherwise: a bottom-anchored ambient bar.
         fullscreen
@@ -556,11 +596,8 @@ export function ContinuousChatOverlay({
       data-testid="continuous-chat-overlay"
       data-fullscreen={fullscreen ? "true" : undefined}
     >
-      {/* Focus backdrop — a LIQUID-GLASS sheet that frosts the live view behind
-          the conversation rather than blacking it out: a heavy backdrop-blur +
-          saturation, a faint diagonal specular sheen, and a soft scrim for text
-          contrast. Always mounted (so its testid is stable); opacity + the blur
-          itself animate the takeover in/out. Captures pointer events only while
+      {/* Focus backdrop — a cheap scrim over the live view. Always mounted (so
+          its testid is stable); only opacity animates. Captures pointer events only while
           fullscreen; clicking it exits via the outside-click handler. */}
       <motion.div
         aria-hidden="true"
@@ -568,23 +605,14 @@ export function ContinuousChatOverlay({
         data-active={fullscreen ? "true" : "false"}
         className={cn(
           "fixed inset-0",
-          // The glass tint: a diagonal sheen over a gentle scrim, so the frosted
-          // view keeps depth and the bubbles stay legible on light or dark views.
-          "bg-[linear-gradient(135deg,rgba(255,255,255,0.10)_0%,rgba(255,255,255,0.02)_36%,rgba(8,10,18,0.18)_100%)]",
+          "bg-[linear-gradient(135deg,rgba(255,255,255,0.08)_0%,rgba(8,10,18,0.64)_48%,rgba(0,0,0,0.70)_100%)]",
           fullscreen ? "pointer-events-auto" : "pointer-events-none",
         )}
         initial={false}
         animate={{
           opacity: fullscreen ? 1 : 0,
-          // Animate only the unprefixed property — framer-motion's animation
-          // target type doesn't include `WebkitBackdropFilter`. Modern targets
-          // (Chromium/Electrobun, Safari 18+/iOS WebView) support unprefixed
-          // `backdrop-filter`, so the frosted-glass takeover still animates.
-          backdropFilter: fullscreen
-            ? "blur(28px) saturate(160%)"
-            : "blur(0px) saturate(100%)",
         }}
-        transition={{ duration: reduce ? 0.12 : 0.72, ease: OVERLAY_EASE }}
+        transition={{ duration: reduce ? 0.08 : 0.16, ease: OVERLAY_EASE }}
       />
 
       {/* Cinematic bottom vignette — grounds the floating bar over bright views.
@@ -596,9 +624,8 @@ export function ContinuousChatOverlay({
         />
       ) : null}
 
-      {/* Fullscreen transcript — the full history on a liquid-glass panel that
-          BLOOMS open from the composer (spring: rise + scale + fade) and eases
-          shut. Its own AnimatePresence so the close animates too. */}
+      {/* Fullscreen transcript — full history in a plain composited panel. Keep
+          the transition to opacity/translate so long threads do not stutter. */}
       <AnimatePresence>
         {fullscreen && hasThread ? (
           <motion.div
@@ -618,31 +645,26 @@ export function ContinuousChatOverlay({
                 collapse();
               }
             }}
-            initial={
-              reduce ? { opacity: 0 } : { opacity: 0, y: 36, scale: 0.92 }
-            }
-            animate={reduce ? { opacity: 1 } : { opacity: 1, y: 0, scale: 1 }}
+            initial={reduce ? { opacity: 0 } : { opacity: 0, y: 12 }}
+            animate={reduce ? { opacity: 1 } : { opacity: 1, y: 0 }}
             exit={
               reduce
                 ? { opacity: 0 }
                 : {
                     opacity: 0,
-                    y: 22,
-                    scale: 0.955,
-                    transition: { duration: 0.5, ease: OVERLAY_EASE },
+                    y: 8,
+                    transition: { duration: 0.12, ease: OVERLAY_EASE },
                   }
             }
             transition={
               reduce
-                ? { duration: 0.15 }
-                : { type: "spring", stiffness: 130, damping: 26, mass: 1.1 }
+                ? { duration: 0.08 }
+                : { duration: 0.18, ease: OVERLAY_EASE }
             }
             className={cn(
               "pointer-events-auto relative mb-3 min-h-0 w-full max-w-3xl flex-1 origin-bottom overflow-y-auto px-5 py-6",
-              // The liquid-glass panel: frosted translucency, a bright top edge,
-              // an inner glow and a deep drop shadow for floating-pane depth.
-              "rounded-[28px] border border-white/12 bg-white/[0.045] backdrop-blur-2xl",
-              "shadow-[inset_0_1px_0_rgba(255,255,255,0.22),inset_0_0_60px_-22px_rgba(255,255,255,0.14),0_44px_130px_-32px_rgba(0,0,0,0.6)]",
+              "rounded-[24px] border border-white/12 bg-black/60",
+              "shadow-[inset_0_1px_0_rgba(255,255,255,0.16),0_28px_80px_-28px_rgba(0,0,0,0.62)]",
               // No visible scrollbar — the thread still scrolls, the chrome hides.
               "[scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40",
@@ -717,12 +739,16 @@ export function ContinuousChatOverlay({
           fade with them, so they only appear when the conversation does. Tapping
           one sends it immediately. */}
       {suggestionsBase ? (
-        <div
+        <fieldset
+          ref={suggestionsRef}
           onPointerEnter={handleHoverEnter}
           onPointerLeave={handleHoverLeave}
+          onFocus={handleAmbientFocus}
+          onBlur={handleAmbientBlur}
+          aria-label="Suggested prompts"
           aria-hidden={!suggestionsVisible}
           className={cn(
-            "relative mb-2 flex w-full max-w-3xl flex-wrap items-center justify-center gap-2 transition-opacity duration-200",
+            "relative m-0 mb-2 flex w-full max-w-3xl flex-wrap items-center justify-center gap-2 border-0 p-0 transition-opacity duration-200",
             suggestionsVisible
               ? "pointer-events-auto opacity-100"
               : "pointer-events-none opacity-0",
@@ -735,6 +761,7 @@ export function ContinuousChatOverlay({
               type="button"
               data-testid={`chat-suggestion-${i}`}
               aria-label={s}
+              tabIndex={suggestionsVisible ? 0 : -1}
               onClick={() => pickSuggestion(s)}
               className={cn(
                 "max-w-full truncate rounded-full border border-white/15 bg-black/40 px-3 py-1.5",
@@ -747,16 +774,19 @@ export function ContinuousChatOverlay({
               {s}
             </button>
           ))}
-        </div>
+        </fieldset>
       ) : null}
 
       {/* The always-present ambient composer (the heart of the layer). Hovering
           it (or the bubbles/suggestions) peeks the chat; leaving fades it out. */}
-      <div
+      <fieldset
         ref={composerRef}
         onPointerEnter={handleHoverEnter}
         onPointerLeave={handleHoverLeave}
-        className="pointer-events-auto relative w-full max-w-3xl"
+        onFocus={handleAmbientFocus}
+        onBlur={handleAmbientBlur}
+        aria-label="Chat composer"
+        className="pointer-events-auto relative m-0 w-full min-w-0 max-w-3xl border-0 p-0"
       >
         {/* Soft breath of light for live states — not a brand-colored alert ring.
             Always mounted; only opacity changes so it swells in/out over 700ms. */}
@@ -826,15 +856,6 @@ export function ContinuousChatOverlay({
         <div className={cn(GLASS_BAR, "relative")}>
           {/* No expand/collapse chevron: focusing the input opens the thread,
               and Escape / clicking outside collapses it. */}
-          {/* DEV-only: clear the conversation and start a fresh, greeted one. */}
-          {import.meta.env.DEV ? (
-            <SoftButton
-              glyph={TRASH_GLYPH}
-              label="clear conversation (debug)"
-              onClick={() => clearConversation?.()}
-              testId="chat-composer-clear-debug"
-            />
-          ) : null}
           <SoftButton
             glyph={MAXIMIZE_GLYPH}
             label={fullscreen ? "exit full screen" : "expand to full screen"}
@@ -869,7 +890,7 @@ export function ContinuousChatOverlay({
             aria-describedby={booting ? "cc-booting-hint" : undefined}
             aria-disabled={booting}
             readOnly={booting}
-            className="min-w-0 flex-1 border-none bg-transparent text-sm text-white/[0.92] outline-none placeholder:text-white/45"
+            className="h-8 min-w-0 flex-1 border-none bg-transparent px-1 text-sm text-white/[0.92] outline-none placeholder:text-white/45"
           />
           <span id="cc-booting-hint" className="sr-only">
             connecting — you can’t send yet
@@ -931,7 +952,7 @@ export function ContinuousChatOverlay({
             )}
           </motion.div>
         </div>
-      </div>
+      </fieldset>
     </div>
   );
 }

--- a/packages/ui/src/components/shell/usePromptSuggestions.test.ts
+++ b/packages/ui/src/components/shell/usePromptSuggestions.test.ts
@@ -10,7 +10,9 @@ vi.mock("../../api/client", () => ({ client: { fetch: fetchMock } }));
 
 import {
   computePromptSuggestions,
+  daypartForHour,
   pageScopeFromLocation,
+  resetPromptSuggestionMemory,
   usePromptSuggestions,
 } from "./usePromptSuggestions";
 
@@ -20,6 +22,7 @@ const msg = (id: string, role: ShellMessage["role"], content: string) =>
 afterEach(() => {
   cleanup();
   fetchMock.mockReset();
+  resetPromptSuggestionMemory();
 });
 
 describe("computePromptSuggestions", () => {
@@ -113,6 +116,48 @@ describe("usePromptSuggestions (model-backed)", () => {
     expect(result.current).toEqual(fallback);
   });
 
+  it("is stable across overlay open/close: a remount reuses the remembered set without refetching", async () => {
+    const model = ["Check my calendar", "Reply to Sam", "Summarize the thread"];
+    fetchMock.mockResolvedValue({ suggestions: model });
+    const thread = [msg("a", "user", "hi"), msg("b", "assistant", "hey")];
+
+    const first = renderHook(() =>
+      usePromptSuggestions(thread, { enabled: true }),
+    );
+    await waitFor(() => expect(first.result.current).toEqual(model));
+    first.unmount();
+
+    // Same conversation, new mount (user closed and reopened the overlay).
+    const second = renderHook(() =>
+      usePromptSuggestions(thread, { enabled: true }),
+    );
+    // The remembered set is there synchronously — no fallback flash, no re-roll.
+    expect(second.result.current).toEqual(model);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-rolls when the conversation advances (new last message)", async () => {
+    fetchMock.mockResolvedValueOnce({ suggestions: ["A1", "A2", "A3"] });
+    const thread = [msg("a", "user", "hi")];
+    const first = renderHook(() =>
+      usePromptSuggestions(thread, { enabled: true }),
+    );
+    await waitFor(() =>
+      expect(first.result.current).toEqual(["A1", "A2", "A3"]),
+    );
+    first.unmount();
+
+    fetchMock.mockResolvedValueOnce({ suggestions: ["B1", "B2", "B3"] });
+    const grown = [...thread, msg("b", "assistant", "hey there")];
+    const second = renderHook(() =>
+      usePromptSuggestions(grown, { enabled: true }),
+    );
+    await waitFor(() =>
+      expect(second.result.current).toEqual(["B1", "B2", "B3"]),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("sends the active page scope so the server can tailor per view (#8225)", async () => {
     fetchMock.mockResolvedValue({ suggestions: ["A", "B", "C"] });
     renderHook(() =>
@@ -123,6 +168,105 @@ describe("usePromptSuggestions (model-backed)", () => {
       (fetchMock.mock.calls[0][1] as { body: string }).body,
     );
     expect(body.scope).toBe("page-lifeops");
+  });
+
+  it("does not surface or remember heuristic-tier responses (retries on a later reveal)", async () => {
+    fetchMock.mockResolvedValueOnce({
+      suggestions: ["H1", "H2", "H3"],
+      tier: "heuristic",
+    });
+    const first = renderHook(() => usePromptSuggestions([], { enabled: true }));
+    const fallback = [...first.result.current];
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    // Heuristic filler is ignored; the deterministic fallback keeps showing.
+    expect(first.result.current).toEqual(fallback);
+    first.unmount();
+
+    // Next reveal retries and the real model set wins.
+    const model = ["Check my calendar", "Reply to Sam", "Summarize the thread"];
+    fetchMock.mockResolvedValueOnce({ suggestions: model, tier: "model" });
+    const second = renderHook(() =>
+      usePromptSuggestions([], { enabled: true }),
+    );
+    await waitFor(() => expect(second.result.current).toEqual(model));
+  });
+
+  it("banks a response that lands after the strip closes — the next reveal reuses it without refetching", async () => {
+    let resolveFetch: (value: unknown) => void = () => {};
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    const model = ["Check my calendar", "Reply to Sam", "Summarize the thread"];
+
+    const first = renderHook(() => usePromptSuggestions([], { enabled: true }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    // User closes the strip before the model responds.
+    first.unmount();
+    resolveFetch({ suggestions: model, tier: "model" });
+    // Let the in-flight promise settle into the cache.
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const second = renderHook(() =>
+      usePromptSuggestions([], { enabled: true }),
+    );
+    await waitFor(() => expect(second.result.current).toEqual(model));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("dedupes concurrent consumers of the same context onto one request", async () => {
+    const model = ["Check my calendar", "Reply to Sam", "Summarize the thread"];
+    fetchMock.mockResolvedValue({ suggestions: model, tier: "model" });
+    const a = renderHook(() => usePromptSuggestions([], { enabled: true }));
+    const b = renderHook(() => usePromptSuggestions([], { enabled: true }));
+    await waitFor(() => expect(a.result.current).toEqual(model));
+    await waitFor(() => expect(b.result.current).toEqual(model));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("never shows a previous context's model set on a cold key (falls back deterministically)", async () => {
+    fetchMock.mockResolvedValueOnce({
+      suggestions: ["A1", "A2", "A3"],
+      tier: "model",
+    });
+    const thread = [msg("a", "user", "hi")];
+    const { result, rerender } = renderHook(
+      ({ messages }: { messages: ShellMessage[] }) =>
+        usePromptSuggestions(messages, { enabled: true }),
+      { initialProps: { messages: thread } },
+    );
+    await waitFor(() => expect(result.current).toEqual(["A1", "A2", "A3"]));
+
+    // The conversation advances while the hook stays mounted (overlay never
+    // unmounts): the cold key must NOT bleed the old set while refetching.
+    let resolveFetch: (value: unknown) => void = () => {};
+    fetchMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+    const grown = [...thread, msg("b", "assistant", "hey there")];
+    rerender({ messages: grown });
+    expect(result.current).toEqual(computePromptSuggestions(grown));
+    expect(result.current).not.toEqual(["A1", "A2", "A3"]);
+    resolveFetch({ suggestions: ["B1", "B2", "B3"], tier: "model" });
+    await waitFor(() => expect(result.current).toEqual(["B1", "B2", "B3"]));
+  });
+});
+
+describe("daypartForHour", () => {
+  it("matches the timeOfDayLead boundaries", () => {
+    expect(daypartForHour(5)).toBe("morning");
+    expect(daypartForHour(11)).toBe("morning");
+    expect(daypartForHour(12)).toBe("afternoon");
+    expect(daypartForHour(17)).toBe("afternoon");
+    expect(daypartForHour(18)).toBe("evening");
+    expect(daypartForHour(23)).toBe("evening");
+    expect(daypartForHour(0)).toBe("evening");
+    expect(daypartForHour(4)).toBe("evening");
   });
 });
 

--- a/packages/ui/src/components/shell/usePromptSuggestions.ts
+++ b/packages/ui/src/components/shell/usePromptSuggestions.ts
@@ -24,6 +24,76 @@ const MAX_CONTEXT_MESSAGES = 6;
 const MAX_CONTEXT_CHARS = 240;
 const FETCH_TIMEOUT_MS = 6_000;
 
+// Resolved model sets, remembered across strip reveals and keyed by the same
+// context dimensions the fetch refreshes on. The overlay component stays
+// mounted on close (only the strip's reveal state flips), but the hook's React
+// state alone cannot give reveal-to-reveal stability: without this memory each
+// cold context would re-roll the model and show different suggestions for an
+// unchanged conversation. Bounded LRU, mirrored to sessionStorage so dev HMR
+// (which re-executes this module) and same-tab reloads keep the sets stable.
+const MODEL_SET_CACHE_MAX = 32;
+const MODEL_SET_STORAGE_KEY = "eliza:chat-suggestions:model-sets:v1";
+
+function readPersistedModelSets(): [string, string[]][] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.sessionStorage.getItem(MODEL_SET_STORAGE_KEY);
+    const parsed: unknown = raw ? JSON.parse(raw) : null;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (entry): entry is [string, string[]] =>
+        Array.isArray(entry) &&
+        typeof entry[0] === "string" &&
+        Array.isArray(entry[1]) &&
+        entry[1].every((item: unknown) => typeof item === "string"),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function persistModelSets(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(
+      MODEL_SET_STORAGE_KEY,
+      JSON.stringify([...modelSetCache]),
+    );
+  } catch {
+    // Storage blocked/full — memory-only is fine.
+  }
+}
+
+const modelSetCache = new Map<string, string[]>(readPersistedModelSets());
+
+// One request per context key at a time. The promise lives at module level so
+// closing the strip mid-fetch does NOT abort it — the response still lands in
+// the cache and the next reveal reads the same set instead of re-rolling.
+const inFlightModelSets = new Map<string, Promise<string[] | null>>();
+
+function rememberModelSet(key: string, value: string[]): void {
+  modelSetCache.delete(key);
+  modelSetCache.set(key, value);
+  if (modelSetCache.size > MODEL_SET_CACHE_MAX) {
+    const oldest = modelSetCache.keys().next().value;
+    if (oldest !== undefined) modelSetCache.delete(oldest);
+  }
+  persistModelSets();
+}
+
+/** Test-only: forget remembered/in-flight model sets so cases stay independent. */
+export function resetPromptSuggestionMemory(): void {
+  modelSetCache.clear();
+  inFlightModelSets.clear();
+  if (typeof window !== "undefined") {
+    try {
+      window.sessionStorage.removeItem(MODEL_SET_STORAGE_KEY);
+    } catch {
+      // Ignore storage failures in teardown.
+    }
+  }
+}
+
 // Cold-start starters — the stable pool the fallback always draws from.
 const STARTERS: readonly string[] = [
   "What can you do?",
@@ -47,6 +117,20 @@ function timeOfDayLead(hour: number | undefined): string {
   if (hour >= 5 && hour < 12) return "Plan my day";
   if (hour >= 12 && hour < 18) return "What's left today?";
   return "Recap my day";
+}
+
+/**
+ * Cache-key time bucket. Matches {@link timeOfDayLead}'s boundaries: the
+ * time-of-day dimension only exists to keep suggestions in step with the
+ * greeting, so the remembered set refreshes at the 3 daypart boundaries —
+ * not 24 times a day on every raw hour rollover.
+ */
+export function daypartForHour(
+  hour: number,
+): "morning" | "afternoon" | "evening" {
+  if (hour >= 5 && hour < 12) return "morning";
+  if (hour >= 12 && hour < 18) return "afternoon";
+  return "evening";
 }
 
 /**
@@ -114,8 +198,7 @@ async function fetchModelSuggestions(
   messages: readonly ShellMessage[],
   hour: number,
   scope: PageScope | undefined,
-  signal: AbortSignal,
-): Promise<string[]> {
+): Promise<{ set: string[]; tier: string | undefined }> {
   const recent = messages
     .filter((m) => m.content.trim().length > 0)
     .slice(-MAX_CONTEXT_MESSAGES)
@@ -123,7 +206,7 @@ async function fetchModelSuggestions(
       role: m.role === "assistant" ? "assistant" : "user",
       content: m.content.slice(0, MAX_CONTEXT_CHARS),
     }));
-  const data = await client.fetch<{ suggestions?: unknown }>(
+  const data = await client.fetch<{ suggestions?: unknown; tier?: unknown }>(
     "/api/suggestions",
     {
       method: "POST",
@@ -132,20 +215,59 @@ async function fetchModelSuggestions(
         hour,
         ...(scope ? { scope } : {}),
       }),
-      signal,
     },
     { allowNonOk: true, timeoutMs: FETCH_TIMEOUT_MS },
   );
-  return normalizeModelSuggestions(data?.suggestions);
+  return {
+    set: normalizeModelSuggestions(data?.suggestions),
+    tier: typeof data?.tier === "string" ? data.tier : undefined,
+  };
+}
+
+/**
+ * Resolve the model set for a context key: cache hit, then in-flight dedupe,
+ * then a fresh request. The request is deliberately NOT tied to the strip's
+ * lifecycle — the server has already started the model call, so the result is
+ * banked even when the user closes the strip before it lands (the next reveal
+ * then reads the identical set instead of re-rolling). The 6s client timeout
+ * bounds the request's lifetime. Heuristic-tier responses (the server's
+ * deterministic filler while the model is cold or failing) are NOT cached or
+ * surfaced: the client fallback is equally deterministic, and skipping them
+ * lets a later reveal retry for the real model set instead of pinning generic
+ * suggestions for the whole bucket.
+ */
+function requestModelSet(
+  messages: readonly ShellMessage[],
+  hour: number,
+  scope: PageScope | undefined,
+  key: string,
+): Promise<string[] | null> {
+  const cached = modelSetCache.get(key);
+  if (cached) return Promise.resolve(cached);
+  const pending = inFlightModelSets.get(key);
+  if (pending) return pending;
+  const request = fetchModelSuggestions(messages, hour, scope)
+    .then(({ set, tier }) => {
+      if (tier === "heuristic" || set.length < SUGGESTION_COUNT) return null;
+      rememberModelSet(key, set);
+      return set;
+    })
+    .catch(() => null)
+    .finally(() => {
+      inFlightModelSets.delete(key);
+    });
+  inFlightModelSets.set(key, request);
+  return request;
 }
 
 /**
  * Hook: returns exactly 3 suggestions. Yields the static fallback immediately,
  * then upgrades to the model-generated set once `POST /api/suggestions`
- * resolves. The fetch runs only while `enabled` (the strip is actually
- * visible), so the small model isn't invoked for a hidden strip; it refreshes
- * when the thread gains its first line, after each new turn, or across the
- * time-of-day boundary.
+ * resolves. The fetch starts only while `enabled` (the strip is actually
+ * visible), so the small model isn't invoked for a hidden strip. The set is
+ * stable for a given context — reopening the overlay reuses the remembered
+ * model set; only a new turn, a view change, the thread's first line, or a
+ * daypart boundary (morning/afternoon/evening) produces a fresh one.
  */
 export function usePromptSuggestions(
   messages: readonly ShellMessage[],
@@ -168,26 +290,34 @@ export function usePromptSuggestions(
     [hasThread, hour],
   );
 
-  const [model, setModel] = React.useState<string[] | null>(null);
+  const contextKey = `${scope ?? ""}|${lastId ?? ""}|${daypartForHour(hour)}|${hasThread ? 1 : 0}`;
+  const remembered = modelSetCache.get(contextKey);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: messages is read inside, but the fetch is intentionally keyed on enabled/hasThread/hour/lastId/scope (the dimensions worth a refresh); keying on the array identity would refetch on every render.
+  // Tagged with the key it was fetched for: the overlay stays mounted across
+  // reveals, so untagged state would bleed the previous context's set into a
+  // cold key (stale suggestions shown, then a visible mid-reveal swap).
+  const [model, setModel] = React.useState<{
+    key: string;
+    set: string[];
+  } | null>(null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: messages is read inside, but the fetch is intentionally keyed on enabled + contextKey (scope/lastId/daypart/hasThread — the dimensions worth a refresh); keying on the array identity would refetch on every render.
   React.useEffect(() => {
-    if (!enabled) return;
-    const controller = new AbortController();
-    let cancelled = false;
-    void fetchModelSuggestions(messages, hour, scope, controller.signal)
-      .then((next) => {
-        if (!cancelled && next.length >= SUGGESTION_COUNT) setModel(next);
-      })
-      .catch(() => {
-        // Keep the static fallback on any failure (offline, timeout, no API).
-      });
+    if (!enabled || modelSetCache.has(contextKey)) return;
+    let disposed = false;
+    void requestModelSet(messages, hour, scope, contextKey).then((set) => {
+      if (!disposed && set) setModel({ key: contextKey, set });
+    });
     return () => {
-      cancelled = true;
-      controller.abort();
+      // Only stop the state update — the request itself keeps going so its
+      // result is cached for the next reveal (see requestModelSet).
+      disposed = true;
     };
-  }, [enabled, hasThread, hour, lastId, scope]);
+  }, [enabled, contextKey]);
 
-  const source = model && model.length >= SUGGESTION_COUNT ? model : fallback;
+  // Remembered set first (stable across reveals for an unchanged context),
+  // then the freshly-fetched one (current key only), then the static fallback.
+  const modelSet = model && model.key === contextKey ? model.set : null;
+  const source = remembered ?? modelSet ?? fallback;
   return source.slice(0, SUGGESTION_COUNT);
 }


### PR DESCRIPTION
## Problem
The continuous-chat overlay re-rolled its 3 prompt suggestions **every time you open it**. The model-backed set (`POST /api/suggestions`) was refetched on each strip reveal, and closing the strip mid-flight aborted the request — so the next open showed a different set for an unchanged conversation. Observed repeatedly on web and on a physical Android device.

## Fix (`packages/ui/src/components/shell/`)
- **Cache** resolved model sets in a module LRU keyed by context (conversation tail / page scope / daypart), mirrored to `sessionStorage` so reopening reuses the same set.
- **Don't abort on close** — keep the in-flight request alive so its result is banked for the next reveal; dedupe concurrent requests per context.
- **Key-tagged state** — a cold context falls back deterministically instead of flashing the previous context's set.
- **Skip heuristic-tier responses** so a transient model failure can't pin generic suggestions; daypart bucketing replaces raw-hour churn.
- Lighter overlay open/close motion (opacity/translate over animated backdrop-filter/spring) + composer-focus reveal + scroll-to-collapse.

## Testing
`bun run --cwd packages/ui test usePromptSuggestions ContinuousChatOverlay` → **49 passing**, including new open/close-stability and re-roll-on-advance cases. Verified on a real Android device against a remote agent.

## Context
Extracted from #8340 (which drifted ~249 commits behind develop). These files are untouched on develop, so this rebases clean. #8340 is being split into focused PRs; this is the first.