### PR TITLE
fix(ui): unbrick remote-mode startup on mobile/desktop

### DIFF
--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -511,8 +511,8 @@ export class ElizaClient {
       }
     }
     if (!res.ok && !options?.allowNonOk) {
-      const body = (await res
-        .json()
+      const body = (await this.readBodyText(res, path, options?.timeoutMs)
+        .then((text) => JSON.parse(text) as Record<string, unknown>)
         .catch(() => ({ error: res.statusText }))) as Record<
         string,
         unknown
@@ -680,6 +680,42 @@ export class ElizaClient {
     });
   }
 
+  /**
+   * Reads a response body with the same budget the request itself had. The
+   * per-request abort timer in {@link rawRequestOnce} is cleared the moment
+   * HEADERS arrive, so without this a response whose body stream stalls
+   * (proxies, USB/adb relays, dropped radios) pends forever — JSON consumers
+   * must never await an unbounded body. Streaming consumers (SSE) keep their
+   * own idle timeout and do not go through here.
+   */
+  private async readBodyText(
+    res: Response,
+    path: string,
+    timeoutMs?: number,
+  ): Promise<string> {
+    const budgetMs = timeoutMs ?? defaultFetchTimeoutMs(path, undefined);
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        res.text(),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(() => {
+            reject(
+              new ApiError({
+                kind: "timeout",
+                path,
+                status: res.status,
+                message: `Response body timed out after ${budgetMs}ms`,
+              }),
+            );
+          }, budgetMs);
+        }),
+      ]);
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
   async fetch<T>(
     path: string,
     init?: RequestInit,
@@ -699,7 +735,7 @@ export class ElizaClient {
     if (res.status === 204) {
       return undefined as T;
     }
-    const text = await res.text();
+    const text = await this.readBodyText(res, path, options?.timeoutMs);
     if (text === "") {
       return undefined as T;
     }

--- a/packages/ui/src/api/csrf-client.test.ts
+++ b/packages/ui/src/api/csrf-client.test.ts
@@ -41,6 +41,40 @@ describe("fetchWithCsrf", () => {
     expect(headers.get("Authorization")).toBe("Bearer secret-token");
   });
 
+  it("resolves relative API paths against the configured apiBase (remote mobile)", async () => {
+    bootConfigMock.getBootConfig.mockReturnValue({
+      apiToken: "secret-token",
+      apiBase: "http://127.0.0.1:41337",
+    });
+    const transport = {
+      request: vi.fn().mockResolvedValue(new Response("{}", { status: 200 })),
+    };
+    desktopTransportMock.desktopHttpTransportForUrl.mockReturnValue(transport);
+
+    await fetchWithCsrf("/api/apps/favorites");
+
+    expect(
+      desktopTransportMock.desktopHttpTransportForUrl,
+    ).toHaveBeenCalledWith("http://127.0.0.1:41337/api/apps/favorites");
+  });
+
+  it("never rewrites an already-absolute URL even with an apiBase configured", async () => {
+    bootConfigMock.getBootConfig.mockReturnValue({
+      apiToken: "secret-token",
+      apiBase: "http://127.0.0.1:41337",
+    });
+    const transport = {
+      request: vi.fn().mockResolvedValue(new Response("{}", { status: 200 })),
+    };
+    desktopTransportMock.desktopHttpTransportForUrl.mockReturnValue(transport);
+
+    await fetchWithCsrf("http://127.0.0.1:41337/api/auth/me");
+
+    expect(
+      desktopTransportMock.desktopHttpTransportForUrl,
+    ).toHaveBeenCalledWith("http://127.0.0.1:41337/api/auth/me");
+  });
+
   it("passes the long message timeout through CSRF desktop transport calls", async () => {
     bootConfigMock.getBootConfig.mockReturnValue({ apiToken: null });
     const transport = {

--- a/packages/ui/src/api/csrf-client.ts
+++ b/packages/ui/src/api/csrf-client.ts
@@ -15,6 +15,7 @@
 
 import { getBootConfig } from "../config/boot-config";
 import { hydrateAndroidLocalAgentTokenForUrl } from "../first-run/local-agent-token";
+import { resolveApiUrl } from "../utils/asset-url";
 import { androidNativeAgentTransportForUrl } from "./android-native-agent-transport";
 import { CSRF_COOKIE_NAME, CSRF_HEADER_NAME } from "./auth/sessions";
 import { desktopHttpTransportForUrl } from "./desktop-http-transport";
@@ -45,6 +46,15 @@ export async function fetchWithCsrf(
   url: string,
   init: RequestInit = {},
 ): Promise<Response> {
+  // Resolve relative API paths against the configured API base. On Capacitor
+  // remote mode the page origin is the bundle's asset server, which answers
+  // ANY path with index.html and HTTP 200 — a relative "/api/..." fetch
+  // "succeeds" and then explodes at JSON parse. No-op when no base is set
+  // (plain same-origin web). Absolute and protocol-relative URLs pass through
+  // untouched — resolveApiUrl prefixes blindly and would corrupt them.
+  if (url.startsWith("/") && !url.startsWith("//")) {
+    url = resolveApiUrl(url);
+  }
   const method = (init.method ?? "GET").toUpperCase();
   const headers = new Headers(init.headers);
 

--- a/packages/ui/src/state/useStartupCoordinator.ts
+++ b/packages/ui/src/state/useStartupCoordinator.ts
@@ -14,6 +14,7 @@
  * in a "ready" effect that only cleans up on unmount (not on phase transitions).
  */
 
+import { logger } from "@elizaos/logger";
 import { useCallback, useEffect, useReducer, useRef } from "react";
 import { client } from "../api";
 import { isElectrobunRuntime } from "../bridge";
@@ -261,7 +262,17 @@ export function useStartupCoordinator(
     if (!currentDeps) return;
     const cancelled = { current: false };
 
-    runHydrating(currentDeps, dispatch, cancelled).catch(() => {});
+    runHydrating(currentDeps, dispatch, cancelled).catch((err) => {
+      // Hydration decorates the shell (wallet, avatar, autonomy replay…);
+      // everything past conversation restore is best-effort. Completing with
+      // partial data beats stranding the composer in "connecting" forever —
+      // and the reducer no-ops HYDRATION_COMPLETE outside "hydrating", so
+      // this can only ever unlock a stalled boot, never mis-transition.
+      logger.warn(
+        `[eliza][startup:init] hydration failed; completing with partial data: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      dispatch({ type: "HYDRATION_COMPLETE" });
+    });
 
     return () => {
       cancelled.current = true;


### PR DESCRIPTION
## Problem
Running the dashboard against a **remote agent** (Capacitor mobile, desktop remote-server) could hang forever at "connecting — you can't send yet", or fail the auth gate with "could not reach /api/auth/me". Root-caused on a physical Android device talking to a LAN agent.

Three stacked bugs:
1. **Unbounded body reads.** The per-request abort timer was cleared as soon as response *headers* arrived, so a stalled body stream (proxy / USB-adb relay / dropped radio) left `await res.text()` / `res.json()` pending forever. A `try/catch` around the hydrate step can't rescue a hang.
2. **Relative `/api` fetches hit the wrong server.** On Capacitor (`androidScheme: https`) the bundle asset-server answers *any* path with `index.html` + HTTP 200, so `fetch("/api/...")` that bypasses the typed client "succeeded" and then threw at JSON parse — silently breaking favorites, overlay presence, and view switching.
3. **Hydration could strand silently** when a decorate-only load failed.

## Fix (`packages/ui/src/`)
- `api/client-base.ts`: `readBodyText()` races the body read against the request's timeout budget (streaming/SSE paths keep their own idle timeout, untouched).
- `api/csrf-client.ts`: resolve **rooted** `/api` paths against the configured `apiBase`; absolute and protocol-relative URLs pass through unchanged (guards the auth-gate URL).
- `state/useStartupCoordinator.ts`: complete hydration with partial data + a warning instead of stranding the composer.

## Testing
`bun run --cwd packages/ui test csrf-client` → **4 passing** incl. relative-resolve and absolute-passthrough. Verified end-to-end on a real Android device (send + reply + reload) against a LAN agent.

## Context
Extracted from #8340 (drifted ~249 commits behind develop); these files are untouched on develop so this rebases clean. Part of the focused-PR split of #8340.