### PR TITLE
feat(views): dynamic view routing + agent-driven view interaction

### DIFF
--- a/packages/agent/src/api/builtin-views.ts
+++ b/packages/agent/src/api/builtin-views.ts
@@ -51,7 +51,15 @@ export const BUILTIN_VIEWS: ViewDeclaration[] = [
     icon: "Puzzle",
     path: "/apps/plugins",
     order: 60,
-    tags: ["plugins", "configuration", "extensions"],
+    tags: [
+      "plugins",
+      "plugin-browser",
+      "plugin browser",
+      "plugin-manager",
+      "plugin manager",
+      "configuration",
+      "extensions",
+    ],
     visibleInManager: true,
   },
   {

--- a/packages/agent/src/api/views-registry.ts
+++ b/packages/agent/src/api/views-registry.ts
@@ -9,6 +9,7 @@
 import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type { IAgentRuntime } from "@elizaos/core";
 import {
   logger,
@@ -96,10 +97,38 @@ async function resolvePluginPackageDir(
     // Package is not reachable from this module at all.
   }
 
+  const workspaceDir = await resolveWorkspacePluginPackageDir(pluginName);
+  if (workspaceDir) return workspaceDir;
+
   logger.warn(
     { src: "ViewRegistry", pluginName },
     `Could not resolve package directory for plugin "${pluginName}"; its view bundle will be unavailable`,
   );
+  return undefined;
+}
+
+async function resolveWorkspacePluginPackageDir(
+  pluginName: string,
+): Promise<string | undefined> {
+  if (!pluginName.startsWith("@elizaos/plugin-")) return undefined;
+
+  const shortName = pluginName.slice("@elizaos/".length);
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let depth = 0; depth < 14; depth += 1) {
+    const candidate = path.join(dir, "plugins", shortName);
+    if (await fileExists(path.join(candidate, "package.json"))) {
+      return candidate;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  const cwdCandidate = path.join(process.cwd(), "plugins", shortName);
+  if (await fileExists(path.join(cwdCandidate, "package.json"))) {
+    return cwdCandidate;
+  }
+
   return undefined;
 }
 

--- a/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
+++ b/packages/agent/src/api/views-routes.navigate-broadcast.test.ts
@@ -1,7 +1,11 @@
 import type http from "node:http";
 import { Readable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { registerBuiltinViews } from "./views-registry.ts";
+import {
+  registerBuiltinViews,
+  registerPluginViews,
+  unregisterPluginViews,
+} from "./views-registry.ts";
 import {
   clearCurrentViewState,
   getCurrentViewState,
@@ -56,6 +60,36 @@ function makeNavigateCtx(
   return { ctx, json, error, broadcastWs };
 }
 
+function makeInteractCtx(
+  id: string,
+  body: NavigateBody | null,
+): {
+  ctx: ViewsRouteContext;
+  json: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  broadcastWs: ReturnType<typeof vi.fn>;
+} {
+  const req = Readable.from(
+    body === null ? [] : [Buffer.from(JSON.stringify(body))],
+  ) as unknown as http.IncomingMessage;
+  const res = {} as http.ServerResponse;
+  const json = vi.fn();
+  const error = vi.fn();
+  const broadcastWs = vi.fn();
+  const pathname = `/api/views/${encodeURIComponent(id)}/interact`;
+  const ctx: ViewsRouteContext = {
+    req,
+    res,
+    method: "POST",
+    pathname,
+    url: new URL(`http://local${pathname}`),
+    json,
+    error,
+    broadcastWs,
+  };
+  return { ctx, json, error, broadcastWs };
+}
+
 describe("POST /api/views/:id/navigate broadcast contract", () => {
   beforeEach(() => {
     registerBuiltinViews();
@@ -64,6 +98,7 @@ describe("POST /api/views/:id/navigate broadcast contract", () => {
 
   afterEach(() => {
     clearCurrentViewState();
+    unregisterPluginViews("@test/views-route");
     vi.restoreAllMocks();
   });
 
@@ -116,6 +151,55 @@ describe("POST /api/views/:id/navigate broadcast contract", () => {
     });
   });
 
+  it("broadcasts close actions without requiring a navigation path consumer", async () => {
+    const { ctx, broadcastWs } = makeNavigateCtx("settings", {
+      action: "close",
+    });
+
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(broadcastWs).toHaveBeenCalledWith({
+      type: "shell:navigate:view",
+      viewId: "settings",
+      viewPath: "/settings",
+      viewLabel: "Settings",
+      viewType: "gui",
+      action: "close",
+    });
+  });
+
+  it("broadcasts split and tile layout metadata to the shell", async () => {
+    const { ctx, broadcastWs, json } = makeNavigateCtx("notes", {
+      action: "split-view",
+      views: ["notes", "calendar"],
+      layout: "horizontal",
+      placement: "right",
+    });
+
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(broadcastWs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "shell:navigate:view",
+        viewId: "notes",
+        action: "split-view",
+        views: ["notes", "calendar"],
+        layout: "horizontal",
+        placement: "right",
+      }),
+    );
+    expect(json).toHaveBeenCalledWith(
+      ctx.res,
+      expect.objectContaining({
+        ok: true,
+        action: "split-view",
+        views: ["notes", "calendar"],
+        layout: "horizontal",
+        placement: "right",
+      }),
+    );
+  });
+
   it("drops a non-boolean alwaysOnTop and a non-string action", async () => {
     const { ctx, broadcastWs } = makeNavigateCtx("settings", {
       action: 7,
@@ -156,6 +240,48 @@ describe("POST /api/views/:id/navigate broadcast contract", () => {
         viewId: "__view-manager__",
         viewPath: "/apps",
         viewType: "gui",
+      }),
+    );
+  });
+
+  it("broadcasts generic view update events after server-backed interactions", async () => {
+    await registerPluginViews(
+      {
+        name: "@test/views-route",
+        description: "Synthetic view route test plugin.",
+        views: [
+          {
+            id: "scratchpad",
+            label: "Scratchpad",
+            path: "/scratchpad",
+            capabilities: [{ id: "get-state", description: "Read state." }],
+            serverInteract: async () => ({
+              success: true,
+              text: "Read scratchpad state.",
+            }),
+          },
+        ],
+      },
+      process.cwd(),
+    );
+    const { ctx, json, broadcastWs } = makeInteractCtx("scratchpad", {
+      capability: "get-state",
+    });
+
+    await expect(handleViewsRoutes(ctx)).resolves.toBe(true);
+
+    expect(broadcastWs).toHaveBeenCalledWith({
+      type: "view:event",
+      viewEventType: "view:scratchpad:updated",
+      payload: { viewId: "scratchpad", capability: "get-state" },
+    });
+    expect(json).toHaveBeenCalledWith(
+      ctx.res,
+      expect.objectContaining({
+        success: true,
+        result: expect.objectContaining({
+          text: "Read scratchpad state.",
+        }),
       }),
     );
   });

--- a/packages/agent/src/api/views-routes.ts
+++ b/packages/agent/src/api/views-routes.ts
@@ -230,6 +230,9 @@ export interface CurrentViewState {
   viewLabel: string;
   viewType: ViewType;
   action?: string;
+  views?: string[];
+  layout?: string;
+  placement?: string;
   updatedAt: string;
 }
 
@@ -741,6 +744,13 @@ export async function handleViewsRoutes(
   // Optional body fields:
   //   action: "pin-tab"    — tells the shell to add to desktop tab bar
   //   action: "open-window" — tells the shell to open in a new Electrobun window
+  //   action: "close"      — tells the shell to close/hide the target view
+  //   action: "close-all"  — tells the shell to close/hide all open views
+  //   action: "split-view" — asks the shell to split multiple views
+  //   action: "tile-views" — asks the shell to tile multiple views
+  //   views: string[]      — view ids participating in split/tile actions
+  //   layout: string       — split/tile layout hint: horizontal, vertical, grid
+  //   placement: string    — optional split placement hint: left/right/top/bottom
   //   path: string         — override the navigation path
   //   alwaysOnTop: boolean — for open-window, ask the shell to keep it above normal windows
   if (method === "POST" && subResource === "navigate") {
@@ -760,6 +770,25 @@ export async function handleViewsRoutes(
     const viewLabel = entry?.label ?? id;
     const action = typeof body?.action === "string" ? body.action : undefined;
     const alwaysOnTop = body?.alwaysOnTop === true;
+    const layoutViews = Array.isArray(body?.views)
+      ? body.views.filter(
+          (value): value is string =>
+            typeof value === "string" && value.trim().length > 0,
+        )
+      : undefined;
+    const layout =
+      typeof body?.layout === "string" && body.layout.trim().length > 0
+        ? body.layout.trim()
+        : undefined;
+    const placement =
+      typeof body?.placement === "string" && body.placement.trim().length > 0
+        ? body.placement.trim()
+        : undefined;
+    const layoutPayload = {
+      ...(layoutViews && layoutViews.length > 0 ? { views: layoutViews } : {}),
+      ...(layout ? { layout } : {}),
+      ...(placement ? { placement } : {}),
+    };
 
     logger.info(
       { src: "ViewsRoutes", viewId: id, viewPath, action },
@@ -774,6 +803,7 @@ export async function handleViewsRoutes(
       viewType: resolvedViewType,
       ...(action ? { action } : {}),
       ...(alwaysOnTop ? { alwaysOnTop } : {}),
+      ...layoutPayload,
       updatedAt: new Date().toISOString(),
     };
     // Publish to the prompt-optimization layer so the planner upweights this
@@ -793,6 +823,7 @@ export async function handleViewsRoutes(
       viewType: resolvedViewType,
       ...(action ? { action } : {}),
       ...(alwaysOnTop ? { alwaysOnTop } : {}),
+      ...layoutPayload,
     });
 
     json(res, {
@@ -802,6 +833,7 @@ export async function handleViewsRoutes(
       viewType: resolvedViewType,
       ...(action ? { action } : {}),
       ...(alwaysOnTop ? { alwaysOnTop } : {}),
+      ...layoutPayload,
     });
     return true;
   }
@@ -914,6 +946,39 @@ export async function handleViewsRoutes(
       `[ViewsRoutes] Interact with view "${id}" capability="${capability}"`,
     );
 
+    if (typeof entry.serverInteract === "function") {
+      try {
+        const result = await entry.serverInteract(capability, params);
+        ctx.broadcastWs?.({
+          type: "view:event",
+          viewEventType: `view:${id}:updated`,
+          payload: { viewId: id, capability },
+        });
+        json(res, {
+          requestId,
+          success: resultSuccess(result),
+          result,
+        });
+      } catch (err) {
+        logger.warn(
+          { src: "ViewsRoutes", viewId: id, capability, requestId, err },
+          `[ViewsRoutes] Server interaction failed for view "${id}"`,
+        );
+        json(res, {
+          requestId,
+          success: false,
+          error: err instanceof Error ? err.message : String(err),
+          result: {
+            success: false,
+            text: `Cannot invoke capability "${capability}" on view "${id}": ${
+              err instanceof Error ? err.message : String(err)
+            }.`,
+          },
+        });
+      }
+      return true;
+    }
+
     // Register the pending slot before broadcasting — avoids a race where the
     // frontend responds before we start waiting.
     const resultPromise = pendingInteractRequests.waitFor(requestId, timeoutMs);
@@ -950,6 +1015,14 @@ export async function handleViewsRoutes(
 // ---------------------------------------------------------------------------
 // Private helpers
 // ---------------------------------------------------------------------------
+
+function resultSuccess(result: unknown): boolean {
+  if (!result || typeof result !== "object" || Array.isArray(result)) {
+    return true;
+  }
+  const success = (result as Record<string, unknown>).success;
+  return typeof success === "boolean" ? success : true;
+}
 
 function streamHeroImage(
   res: http.ServerResponse,

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -579,6 +579,15 @@ export interface ViewDeclaration {
 	bundleUrl?: string;
 	/** Capabilities the agent can exercise on this view when it is mounted. */
 	capabilities?: ViewCapability[];
+	/**
+	 * Optional backend capability handler for operations that do not require a
+	 * mounted UI surface. The view route invokes this before falling back to the
+	 * frontend `view:interact` WebSocket round-trip.
+	 */
+	serverInteract?: (
+		capability: string,
+		params?: Record<string, unknown>,
+	) => Promise<unknown>;
 	/** Allow this view to be pinned as a desktop tab. Default true. */
 	desktopTabEnabled?: boolean;
 	/** Show this view in the view manager grid. Default true. */

--- a/packages/ui/src/App.navigate-view-wiring.test.tsx
+++ b/packages/ui/src/App.navigate-view-wiring.test.tsx
@@ -67,6 +67,26 @@ const viewsManagerTuiView = {
   viewType: "tui" as const,
 };
 
+const notesView = {
+  id: "notes",
+  label: "Notes",
+  available: true,
+  pluginName: "@elizaos/plugin-simple-views",
+  path: "/notes",
+  bundleUrl: "/api/views/notes/bundle.js",
+  viewType: "gui" as const,
+};
+
+const calendarView = {
+  id: "calendar",
+  label: "Calendar",
+  available: true,
+  pluginName: "@elizaos/plugin-simple-views",
+  path: "/calendar",
+  bundleUrl: "/api/views/calendar/bundle.js",
+  viewType: "gui" as const,
+};
+
 vi.mock("@capacitor/keyboard", () => ({
   Keyboard: { setScroll: vi.fn(async () => undefined) },
 }));
@@ -90,7 +110,13 @@ vi.mock("./hooks/useDesktopTabs", () => ({
 
 vi.mock("./hooks/useAvailableViews", () => ({
   useAvailableViews: () => ({
-    views: [remoteLedgerView, viewsManagerView, viewsManagerTuiView],
+    views: [
+      remoteLedgerView,
+      viewsManagerView,
+      viewsManagerTuiView,
+      notesView,
+      calendarView,
+    ],
   }),
 }));
 
@@ -314,7 +340,7 @@ describe("App navigate-view event wiring", () => {
     appState.tab = "apps";
     window.history.replaceState(null, "", "/apps/remote-ledger");
 
-    const { getByTestId } = render(<App />);
+    const { container, getByTestId } = render(<App />);
 
     await waitFor(() => {
       expect(dynamicViewLoaderMock.render).toHaveBeenCalledWith(
@@ -332,6 +358,42 @@ describe("App navigate-view event wiring", () => {
     );
     expect(loader.getAttribute("data-view-id")).toBe("remote-ledger");
     expect(loader.getAttribute("data-view-type")).toBe("gui");
+    expect(
+      container
+        .querySelector('[data-shell-content-region="true"]')
+        ?.className.includes("pb-[var(--eliza-continuous-chat-clearance"),
+    ).toBe(true);
+  });
+
+  it("renders split-view events as a live dynamic view layout", async () => {
+    appState.tab = "views";
+    window.history.replaceState(null, "", "/views");
+
+    const { getAllByTestId, getByTestId } = render(<App />);
+
+    navigateView({
+      action: "split-view",
+      viewId: "notes",
+      views: ["notes", "calendar"],
+      layout: "horizontal",
+      placement: "right",
+    });
+
+    await waitFor(() => {
+      expect(getByTestId("view-layout-surface")).toBeTruthy();
+    });
+    expect(getByTestId("view-layout-pane-notes")).toBeTruthy();
+    expect(getByTestId("view-layout-pane-calendar")).toBeTruthy();
+    const loaders = getAllByTestId("dynamic-view-loader");
+    expect(
+      loaders.map((loader) => loader.getAttribute("data-view-id")),
+    ).toEqual(["notes", "calendar"]);
+    expect(desktopTabsMock.openTab).toHaveBeenCalledWith(notesView, {
+      pinned: false,
+    });
+    expect(desktopTabsMock.openTab).toHaveBeenCalledWith(calendarView, {
+      pinned: false,
+    });
   });
 
   it("keeps /views on the built-in manager page instead of the remote manager bundle", async () => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3,6 +3,7 @@
  */
 
 import { Keyboard } from "@capacitor/keyboard";
+import { X } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import "./components/chat/chat-source-registration";
 import {
@@ -16,7 +17,10 @@ import {
   useMemo,
   useState,
 } from "react";
-import { createNavigateViewHandler } from "./app-navigate-view";
+import {
+  type ActiveViewLayout,
+  createNavigateViewHandler,
+} from "./app-navigate-view";
 import {
   invokeDesktopBridgeRequest,
   subscribeDesktopBridgeEvent,
@@ -70,7 +74,7 @@ import { isIOS, isNative } from "./platform/init";
 import { type ActionNotice, useApp } from "./state";
 
 const MOBILE_NAV_PADDING_CLASS =
-  "pb-[calc(var(--eliza-mobile-nav-offset,0px)+var(--safe-area-bottom,0px))]";
+  "pb-[calc(var(--eliza-mobile-nav-offset,0px)+var(--safe-area-bottom,0px)+var(--eliza-continuous-chat-clearance,5.25rem))]";
 type ExtractComponent<TValue> =
   TValue extends ComponentType<infer Props> ? ComponentType<Props> : never;
 
@@ -343,7 +347,7 @@ function TabScrollView({
       main={
         <div
           data-shell-scroll-region="true"
-          className={`flex-1 min-h-0 min-w-0 w-full overflow-y-auto ${className}`}
+          className={`eliza-continuous-chat-scroll flex-1 min-h-0 min-w-0 w-full overflow-y-auto pb-[var(--eliza-continuous-chat-clearance,5.25rem)] ${className}`}
         >
           {children}
         </div>
@@ -358,7 +362,10 @@ function TabContentView({ children }: { children: ReactNode }) {
       testId="tab-content-view"
       chatDisabled
       main={
-        <div className="flex flex-col flex-1 min-h-0 min-w-0 w-full overflow-hidden">
+        <div
+          data-shell-content-region="true"
+          className="eliza-continuous-chat-scroll flex flex-col flex-1 min-h-0 min-w-0 w-full overflow-hidden pb-[var(--eliza-continuous-chat-clearance,5.25rem)]"
+        >
           {children}
         </div>
       }
@@ -548,6 +555,112 @@ function renderRemoteView(view: ViewRegistryEntry): ReactNode {
         viewId={view.id}
         viewType={view.viewType}
       />
+    </TabContentView>
+  );
+}
+
+function viewLayoutLabel(layout: ActiveViewLayout): string {
+  return layout.mode === "split" ? "Split view" : "Tiled views";
+}
+
+function splitLayoutIsStacked(layout: ActiveViewLayout): boolean {
+  const hint = `${layout.layout ?? ""} ${layout.placement ?? ""}`.toLowerCase();
+  return /\b(vertical|rows?|top|bottom|above|below)\b/.test(hint);
+}
+
+function viewLayoutGridClass(layout: ActiveViewLayout, count: number): string {
+  if (layout.mode === "split") {
+    return splitLayoutIsStacked(layout)
+      ? "grid-cols-1 grid-rows-2"
+      : "grid-cols-1 md:grid-cols-2";
+  }
+  if (count <= 1) return "grid-cols-1";
+  if (count === 2) return "grid-cols-1 md:grid-cols-2";
+  return "grid-cols-1 md:grid-cols-2 xl:grid-cols-3";
+}
+
+function ViewLayoutSurface({
+  availableViews,
+  layout,
+  onClear,
+}: {
+  availableViews: ViewRegistryEntry[];
+  layout: ActiveViewLayout;
+  onClear: () => void;
+}): ReactNode {
+  const entries = layout.viewIds
+    .map((viewId) => availableViews.find((view) => view.id === viewId))
+    .filter((view): view is ViewRegistryEntry => Boolean(view));
+  const paneClassName =
+    "flex min-h-[18rem] min-w-0 flex-col overflow-hidden border border-border/45 bg-bg";
+
+  return (
+    <TabContentView>
+      <section
+        data-testid="view-layout-surface"
+        className="flex h-full min-h-0 min-w-0 flex-1 flex-col bg-bg"
+      >
+        <header className="flex min-h-12 shrink-0 items-center justify-between gap-3 border-b border-border/45 px-3">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="truncate text-sm font-medium text-txt">
+              {viewLayoutLabel(layout)}
+            </span>
+            <span className="shrink-0 text-xs tabular-nums text-muted">
+              {entries.length}
+            </span>
+          </div>
+          <button
+            type="button"
+            aria-label="Close layout"
+            title="Close layout"
+            data-testid="view-layout-close"
+            onClick={onClear}
+            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-sm text-muted transition-colors hover:bg-border/35 hover:text-txt focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            <X className="h-4 w-4" aria-hidden />
+          </button>
+        </header>
+        <div
+          className={`grid min-h-0 flex-1 gap-2 overflow-auto p-2 ${viewLayoutGridClass(
+            layout,
+            entries.length,
+          )} eliza-continuous-chat-scroll pb-[calc(0.5rem+var(--eliza-continuous-chat-clearance,5.25rem))]`}
+        >
+          {entries.length > 0 ? (
+            entries.map((view) => (
+              <section
+                key={view.id}
+                data-testid={`view-layout-pane-${view.id}`}
+                className={paneClassName}
+              >
+                <div className="flex h-9 shrink-0 items-center border-b border-border/35 px-2.5">
+                  <span className="truncate text-xs font-medium text-muted">
+                    {view.label}
+                  </span>
+                </div>
+                <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+                  {view.bundleUrl ? (
+                    <DynamicViewLoader
+                      bundleUrl={view.bundleUrl}
+                      componentExport={view.componentExport}
+                      viewId={view.id}
+                      viewType={view.viewType}
+                    />
+                  ) : (
+                    <div className="flex h-full min-h-0 items-center justify-center px-4 text-center text-sm text-muted">
+                      {view.label} is not available as a dynamic view.
+                    </div>
+                  )}
+                </div>
+              </section>
+            ))
+          ) : (
+            <div className="flex min-h-[18rem] items-center justify-center border border-border/45 px-4 text-center text-sm text-muted">
+              Requested views are not available.
+            </div>
+          )}
+        </div>
+      </section>
     </TabContentView>
   );
 }
@@ -834,6 +947,7 @@ const APP_SHELL_CLASS =
 type ShellContentProps = {
   CompanionShell: ComponentType<CompanionShellComponentProps> | undefined;
   actionNotice: ActionNotice | null;
+  availableViewsForLayout: ViewRegistryEntry[];
   customActionsPanelOpen: boolean;
   desktopTabBar: ReactNode;
   isChat: boolean;
@@ -845,6 +959,8 @@ type ShellContentProps = {
   settingsInitialSection: string | null;
   tab: string;
   uiShellMode: string;
+  viewLayout: ActiveViewLayout | null;
+  onClearViewLayout: () => void;
 };
 
 function CompanionShellContent(props: ShellContentProps): ReactNode {
@@ -939,7 +1055,15 @@ function RoutedShellContent(props: ShellContentProps): ReactNode {
     <div key={`tab-shell-${props.tab}`} className={APP_SHELL_CLASS}>
       {props.desktopTabBar}
       <main className={routedShellMainClass(props.tab)}>
-        <ViewRouter settingsInitialSection={props.settingsInitialSection} />
+        {props.viewLayout ? (
+          <ViewLayoutSurface
+            availableViews={props.availableViewsForLayout}
+            layout={props.viewLayout}
+            onClear={props.onClearViewLayout}
+          />
+        ) : (
+          <ViewRouter settingsInitialSection={props.settingsInitialSection} />
+        )}
       </main>
     </div>
   );
@@ -1149,6 +1273,7 @@ export function App() {
     null,
   );
   const { views: availableViewsForDesktopTabs } = useAvailableViews();
+  const [viewLayout, setViewLayout] = useState<ActiveViewLayout | null>(null);
 
   const [editingAction, setEditingAction] = useState<
     import("./api").CustomActionDef | null
@@ -1198,15 +1323,30 @@ export function App() {
     if (typeof window === "undefined") return;
     const handleNavigateView = createNavigateViewHandler({
       availableViewsForDesktopTabs,
+      closeDesktopTab,
+      desktopTabs,
       invokeDesktopBridgeRequest,
       openDesktopTab,
       setActiveDesktopTabId,
       setTab,
+      setViewLayout,
     });
     window.addEventListener("eliza:navigate:view", handleNavigateView);
     return () =>
       window.removeEventListener("eliza:navigate:view", handleNavigateView);
-  }, [setTab, availableViewsForDesktopTabs, openDesktopTab]);
+  }, [
+    setTab,
+    availableViewsForDesktopTabs,
+    closeDesktopTab,
+    desktopTabs,
+    openDesktopTab,
+  ]);
+
+  useEffect(() => {
+    if (tab !== "views" && viewLayout) {
+      setViewLayout(null);
+    }
+  }, [tab, viewLayout]);
 
   useEffect(() => {
     if (isSettingsPage || settingsInitialSection === null) {
@@ -1241,6 +1381,7 @@ export function App() {
     (viewId: string) => {
       const dtab = desktopTabs.find((t) => t.viewId === viewId);
       if (!dtab) return;
+      setViewLayout(null);
       setActiveDesktopTabId(viewId);
       try {
         if (typeof window === "undefined") return;
@@ -1259,6 +1400,7 @@ export function App() {
 
   const handleDesktopTabClose = useCallback(
     (viewId: string) => {
+      setViewLayout(null);
       closeDesktopTab(viewId);
       if (activeDesktopTabId === viewId) {
         setActiveDesktopTabId(null);
@@ -1269,8 +1411,13 @@ export function App() {
   );
 
   const handleOpenViewManagerFromTabBar = useCallback(() => {
+    setViewLayout(null);
     setTab("views");
   }, [setTab]);
+
+  const handleClearViewLayout = useCallback(() => {
+    setViewLayout(null);
+  }, []);
 
   // desktopTabBar is computed here (after handlers) so the memo below can
   // reference a stable value. Rendered inside each shell variant, not at the
@@ -1314,6 +1461,7 @@ export function App() {
       <ShellContent
         CompanionShell={CompanionShell}
         actionNotice={actionNotice}
+        availableViewsForLayout={availableViewsForDesktopTabs}
         customActionsPanelOpen={customActionsPanelOpen}
         desktopTabBar={desktopTabBar}
         isChat={isChat}
@@ -1325,6 +1473,8 @@ export function App() {
         settingsInitialSection={settingsInitialSection}
         tab={tab}
         uiShellMode={uiShellMode}
+        viewLayout={viewLayout}
+        onClearViewLayout={handleClearViewLayout}
       />
     ),
     [
@@ -1338,6 +1488,9 @@ export function App() {
       customActionsPanelOpen,
       settingsInitialSection,
       desktopTabBar,
+      availableViewsForDesktopTabs,
+      viewLayout,
+      handleClearViewLayout,
     ],
   );
 

--- a/packages/ui/src/app-navigate-view.test.ts
+++ b/packages/ui/src/app-navigate-view.test.ts
@@ -29,25 +29,32 @@ function createHandlerFixture(views: ViewRegistryEntry[] = [view()]) {
         id: "app-1",
       }) as T,
   ) as DesktopBridgeRequest;
+  const closeDesktopTab = vi.fn();
   const navigatePath = vi.fn();
   const openDesktopTab = vi.fn();
   const setActiveDesktopTabId = vi.fn();
   const setTab = vi.fn();
+  const setViewLayout = vi.fn();
   const handler = createNavigateViewHandler({
     availableViewsForDesktopTabs: views,
+    closeDesktopTab,
+    desktopTabs: views.map((entry) => ({ viewId: entry.id })),
     invokeDesktopBridgeRequest,
     navigatePath,
     openDesktopTab,
     setActiveDesktopTabId,
     setTab,
+    setViewLayout,
   });
   return {
     handler,
+    closeDesktopTab,
     invokeDesktopBridgeRequest,
     navigatePath,
     openDesktopTab,
     setActiveDesktopTabId,
     setTab,
+    setViewLayout,
   };
 }
 
@@ -134,6 +141,91 @@ describe("App navigate-view shell handler", () => {
     });
     expect(fixture.setActiveDesktopTabId).toHaveBeenCalledWith("local-notes");
     expect(fixture.navigatePath).toHaveBeenCalledWith("/apps/local-notes");
+  });
+
+  it("closes a targeted desktop view tab and falls back to chat", () => {
+    const remoteLedger = view();
+    const fixture = createHandlerFixture([remoteLedger]);
+
+    fixture.handler(
+      navigateEvent({
+        viewId: "remote-ledger",
+        action: "close",
+      }),
+    );
+
+    expect(fixture.closeDesktopTab).toHaveBeenCalledWith("remote-ledger");
+    expect(fixture.setActiveDesktopTabId).toHaveBeenCalledWith(null);
+    expect(fixture.setTab).toHaveBeenCalledWith("chat");
+    expect(fixture.setViewLayout).toHaveBeenCalledWith(null);
+    expect(fixture.navigatePath).not.toHaveBeenCalled();
+    expect(fixture.openDesktopTab).not.toHaveBeenCalled();
+  });
+
+  it("closes all desktop view tabs and falls back to chat", () => {
+    const remoteLedger = view();
+    const localNotes = view({
+      id: "local-notes",
+      label: "Local Notes",
+      path: "/apps/local-notes",
+    });
+    const fixture = createHandlerFixture([remoteLedger, localNotes]);
+
+    fixture.handler(
+      navigateEvent({
+        viewId: "__all__",
+        action: "close-all",
+      }),
+    );
+
+    expect(fixture.closeDesktopTab).toHaveBeenCalledWith("remote-ledger");
+    expect(fixture.closeDesktopTab).toHaveBeenCalledWith("local-notes");
+    expect(fixture.setActiveDesktopTabId).toHaveBeenCalledWith(null);
+    expect(fixture.setTab).toHaveBeenCalledWith("chat");
+    expect(fixture.setViewLayout).toHaveBeenCalledWith(null);
+    expect(fixture.navigatePath).not.toHaveBeenCalled();
+  });
+
+  it("opens layout event participants as desktop tabs and activates layout state", () => {
+    const notes = view({
+      id: "notes",
+      label: "Notes",
+      path: "/notes",
+      desktopTabEnabled: true,
+    });
+    const calendar = view({
+      id: "calendar",
+      label: "Calendar",
+      path: "/calendar",
+      desktopTabEnabled: true,
+    });
+    const fixture = createHandlerFixture([notes, calendar]);
+
+    fixture.handler(
+      navigateEvent({
+        viewId: "notes",
+        action: "split-view",
+        views: ["notes", "calendar"],
+        layout: "horizontal",
+        placement: "right",
+      }),
+    );
+
+    expect(fixture.openDesktopTab).toHaveBeenCalledWith(notes, {
+      pinned: false,
+    });
+    expect(fixture.openDesktopTab).toHaveBeenCalledWith(calendar, {
+      pinned: false,
+    });
+    expect(fixture.setActiveDesktopTabId).toHaveBeenCalledWith("notes");
+    expect(fixture.setViewLayout).toHaveBeenCalledWith({
+      mode: "split",
+      viewIds: ["notes", "calendar"],
+      layout: "horizontal",
+      placement: "right",
+    });
+    expect(fixture.setTab).toHaveBeenCalledWith("views");
+    expect(fixture.navigatePath).toHaveBeenCalledWith("/notes");
   });
 
   it("opens a managed app window through the desktop bridge", async () => {

--- a/packages/ui/src/app-navigate-view.ts
+++ b/packages/ui/src/app-navigate-view.ts
@@ -7,13 +7,25 @@ export type NavigateViewDetail = {
   viewLabel?: string;
   viewType?: "gui" | "tui" | "xr";
   action?: string;
+  views?: string[];
+  layout?: string;
+  placement?: string;
   alwaysOnTop?: boolean;
+};
+
+export type ActiveViewLayout = {
+  mode: "split" | "tile";
+  viewIds: string[];
+  layout?: string;
+  placement?: string;
 };
 
 export type DesktopTabOpen = (
   view: ViewRegistryEntry,
   options?: { pinned?: boolean },
 ) => void;
+
+export type DesktopTabClose = (viewId: string) => void;
 
 export type DesktopBridgeRequest = <T>(options: {
   rpcMethod: string;
@@ -60,26 +72,87 @@ export function desktopEntryForDetail(
   return views.find((view) => view.id === viewId);
 }
 
+function layoutViewIdsForDetail(detail: NavigateViewDetail): string[] {
+  const ids = [
+    ...(Array.isArray(detail.views) ? detail.views : []),
+    ...(detail.viewId ? [detail.viewId] : []),
+  ];
+  const seen = new Set<string>();
+  return ids.flatMap((id) => {
+    const trimmed = id.trim();
+    if (!trimmed || seen.has(trimmed)) return [];
+    seen.add(trimmed);
+    return [trimmed];
+  });
+}
+
 export function createNavigateViewHandler({
   availableViewsForDesktopTabs,
+  closeDesktopTab,
+  desktopTabs = [],
   invokeDesktopBridgeRequest,
   navigatePath = navigateBrowserPath,
   openDesktopTab,
   setActiveDesktopTabId,
   setTab,
+  setViewLayout,
 }: {
   availableViewsForDesktopTabs: ViewRegistryEntry[];
+  closeDesktopTab?: DesktopTabClose;
+  desktopTabs?: Array<{ viewId: string }>;
   invokeDesktopBridgeRequest: DesktopBridgeRequest;
   navigatePath?: (path: string) => void;
   openDesktopTab: DesktopTabOpen;
-  setActiveDesktopTabId: (viewId: string) => void;
-  setTab: (tab: "views" | "apps") => void;
+  setActiveDesktopTabId: (viewId: string | null) => void;
+  setTab: (tab: "views" | "apps" | "chat") => void;
+  setViewLayout?: (layout: ActiveViewLayout | null) => void;
 }): (event: Event) => void {
   return (event: Event) => {
     const detail = (event as CustomEvent<NavigateViewDetail>).detail;
     if (!detail) return;
+    if (detail.action === "close" || detail.action === "close-all") {
+      setViewLayout?.(null);
+      if (detail.action === "close-all" || detail.viewId === "__all__") {
+        for (const tab of desktopTabs) {
+          closeDesktopTab?.(tab.viewId);
+        }
+      } else if (detail.viewId) {
+        closeDesktopTab?.(detail.viewId);
+      }
+      setActiveDesktopTabId(null);
+      setTab("chat");
+      return;
+    }
+    if (detail.action === "split-view" || detail.action === "tile-views") {
+      const viewIds = layoutViewIdsForDetail(detail);
+      const resolvedViewIds: string[] = [];
+      let primaryPath: string | null = detail.viewPath ?? null;
+      for (const viewId of viewIds) {
+        const entry = desktopEntryForDetail(
+          availableViewsForDesktopTabs,
+          viewId,
+        );
+        if (!entry) continue;
+        resolvedViewIds.push(entry.id);
+        recordRecentViewId(entry.id);
+        openDesktopTab(entry, { pinned: false });
+        primaryPath ??= entry.path ?? `/apps/${entry.id}`;
+      }
+      const primaryViewId = viewIds[0] ?? detail.viewId ?? null;
+      if (primaryViewId) setActiveDesktopTabId(primaryViewId);
+      setViewLayout?.({
+        mode: detail.action === "split-view" ? "split" : "tile",
+        viewIds: resolvedViewIds.length > 0 ? resolvedViewIds : viewIds,
+        layout: detail.layout,
+        placement: detail.placement,
+      });
+      setTab("views");
+      if (primaryPath) navigatePath(primaryPath);
+      return;
+    }
     const path = pathForNavigateViewDetail(detail);
     if (!path) return;
+    setViewLayout?.(null);
     const directTab = directTabForNavigateView(detail, path);
     if (detail.viewId) {
       recordRecentViewId(detail.viewId);

--- a/packages/ui/src/components/views/DynamicViewLoader.test.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.test.tsx
@@ -608,12 +608,9 @@ describe("DynamicViewLoader", () => {
         undefined,
       );
     });
-    expect(sendWsMessage).toHaveBeenCalledWith(
+    expect(sendWsMessage).not.toHaveBeenCalledWith(
       expect.objectContaining({
         requestId: "req-old-view",
-        success: false,
-        error:
-          'No interact handler registered for gui view "replace.first" - view may not be mounted',
       }),
     );
     expect(sendWsMessage).toHaveBeenCalledWith({

--- a/packages/ui/src/components/views/DynamicViewLoader.tsx
+++ b/packages/ui/src/components/views/DynamicViewLoader.tsx
@@ -30,6 +30,7 @@ import {
   useRef,
   useState,
 } from "react";
+import * as AgentSurfaceHost from "../../agent-surface";
 import {
   AgentElementOverlay,
   AgentSurfaceElementReporter,
@@ -136,7 +137,7 @@ const HOST_EXTERNAL_IMPORTERS: Record<string, HostExternalImporter> = {
   "@elizaos/plugin-health/screen-time/mobile-signal-setup": () =>
     import("@elizaos/plugin-health/screen-time/mobile-signal-setup"),
   "@elizaos/plugin-training": () => import("@elizaos/plugin-training"),
-  "@elizaos/ui/agent-surface": () => import("../../agent-surface/index.ts"),
+  "@elizaos/ui/agent-surface": async () => AgentSurfaceHost,
   "@elizaos/ui/api": () => import("../../api/index.ts"),
   "@elizaos/ui/bridge": () => import("../../bridge/index.ts"),
   "@elizaos/ui/components": () => import("../index.ts"),
@@ -247,6 +248,11 @@ async function importViewBundle(
     return window.__ELIZA_DYNAMIC_VIEW_BUNDLE_IMPORT__(bundleUrl);
   }
 
+  const hostExternalUrl = buildHostExternalBundleUrl(bundleUrl);
+  if (hostExternalUrl) {
+    return import(/* @vite-ignore */ hostExternalUrl);
+  }
+
   try {
     return await import(/* @vite-ignore */ bundleUrl);
   } catch (err) {
@@ -256,13 +262,26 @@ async function importViewBundle(
     }
   }
 
+  const rewrittenUrl = buildHostExternalBundleUrl(bundleUrl);
+  if (!rewrittenUrl) {
+    throw new Error(
+      `DynamicViewLoader: bundle at ${bundleUrl} could not use host externals`,
+    );
+  }
+  return import(/* @vite-ignore */ rewrittenUrl);
+}
+
+function buildHostExternalBundleUrl(bundleUrl: string): string | null {
+  if (typeof window === "undefined") return null;
   const rewrittenUrl = new URL(bundleUrl, window.location.href);
+  if (rewrittenUrl.origin !== window.location.origin) return null;
+  if (!rewrittenUrl.pathname.startsWith("/api/views/")) return null;
   rewrittenUrl.searchParams.set("hostExternalRuntime", "1");
   rewrittenUrl.searchParams.set(
     "hostExternalSpecifiers",
     HOST_EXTERNAL_IMPORTER_SPECIFIERS.join(","),
   );
-  return import(/* @vite-ignore */ rewrittenUrl.href);
+  return rewrittenUrl.href;
 }
 
 function loadBundleModule(
@@ -308,6 +327,24 @@ const STANDARD_CAPABILITIES = new Set([
   "get-text",
 ]);
 
+const DOM_FILLABLE_AGENT_ROLES = new Set([
+  "text-input",
+  "number-input",
+  "textarea",
+  "select",
+  "slider",
+]);
+
+const DOM_CLICKABLE_AGENT_ROLES = new Set([
+  "button",
+  "link",
+  "toggle",
+  "tab",
+  "menu-item",
+  "list-item",
+  "card",
+]);
+
 function resolveInteractTarget(
   containerEl: HTMLElement | null,
   params: Record<string, unknown> | undefined,
@@ -339,6 +376,158 @@ function setNativeInputValue(
   setter?.call(target, value);
   target.dispatchEvent(new Event("input", { bubbles: true }));
   target.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+function agentSelector(id: string): string {
+  return `[data-agent-id="${CSS.escape(id)}"]`;
+}
+
+function getAgentElementById(
+  containerEl: HTMLElement | null,
+  id: string,
+): HTMLElement | null {
+  return containerEl?.querySelector<HTMLElement>(agentSelector(id)) ?? null;
+}
+
+function readElementValue(el: HTMLElement): unknown {
+  if (
+    el instanceof HTMLInputElement ||
+    el instanceof HTMLTextAreaElement ||
+    el instanceof HTMLSelectElement
+  ) {
+    if (el instanceof HTMLInputElement && el.type === "checkbox") {
+      return el.checked;
+    }
+    return el.value;
+  }
+  return undefined;
+}
+
+function snapshotDomAgentElement(el: HTMLElement) {
+  const rect = el.getBoundingClientRect();
+  const role = el.getAttribute("data-agent-role") || "region";
+  return {
+    id: el.getAttribute("data-agent-id") || "",
+    role,
+    label: el.getAttribute("data-agent-label") || "",
+    status: el.getAttribute("data-state") || undefined,
+    value: readElementValue(el),
+    fillable: DOM_FILLABLE_AGENT_ROLES.has(role),
+    clickable: DOM_CLICKABLE_AGENT_ROLES.has(role),
+    focused:
+      typeof document !== "undefined" &&
+      (document.activeElement === el || el.contains(document.activeElement)),
+    visible: rect.width > 0 && rect.height > 0,
+    bounds: {
+      x: Math.round(rect.x),
+      y: Math.round(rect.y),
+      width: Math.round(rect.width),
+      height: Math.round(rect.height),
+    },
+  };
+}
+
+function listDomAgentElements(containerEl: HTMLElement | null) {
+  if (!containerEl) return [];
+  return [...containerEl.querySelectorAll<HTMLElement>("[data-agent-id]")]
+    .map(snapshotDomAgentElement)
+    .filter((item) => item.id.length > 0);
+}
+
+function handleDomAgentSurfaceCapability(
+  viewId: string,
+  viewType: "gui" | "tui" | "xr",
+  capability: string,
+  params: Record<string, unknown> | undefined,
+  containerEl: HTMLElement | null,
+): unknown {
+  switch (capability) {
+    case "list-elements": {
+      const role = typeof params?.role === "string" ? params.role : null;
+      const elements = listDomAgentElements(containerEl);
+      return role ? elements.filter((item) => item.role === role) : elements;
+    }
+
+    case "get-agent-state": {
+      const elements = listDomAgentElements(containerEl);
+      const focused = elements.find((item) => item.focused)?.id ?? null;
+      return {
+        viewId,
+        viewType,
+        elementCount: elements.length,
+        focusedId: focused,
+        elements,
+        updatedAt: Date.now(),
+      };
+    }
+
+    case "describe-element": {
+      const id = agentIdParam(params);
+      if (!id) throw new Error("describe-element requires an `id` parameter");
+      const el = getAgentElementById(containerEl, id);
+      if (!el) throw new Error(`No element registered with id "${id}"`);
+      return snapshotDomAgentElement(el);
+    }
+
+    case "get-focus": {
+      const elements = listDomAgentElements(containerEl);
+      const element = elements.find((item) => item.focused) ?? null;
+      return { focusedId: element?.id ?? null, element };
+    }
+
+    case "agent-focus": {
+      const id = agentIdParam(params);
+      if (!id) throw new Error("agent-focus requires an `id` parameter");
+      const el = getAgentElementById(containerEl, id);
+      if (!el) return { ok: false, id, reason: "element not found" };
+      el.focus();
+      return { ok: true, id };
+    }
+
+    case "agent-click": {
+      const id = agentIdParam(params);
+      if (!id) throw new Error("agent-click requires an `id` parameter");
+      const el = getAgentElementById(containerEl, id);
+      if (!el) return { ok: false, id, reason: "element not found" };
+      el.click();
+      return { ok: true, id };
+    }
+
+    case "agent-fill": {
+      const id = agentIdParam(params);
+      const value = typeof params?.value === "string" ? params.value : null;
+      if (!id) throw new Error("agent-fill requires an `id` parameter");
+      if (value === null) {
+        throw new Error("agent-fill requires a string `value` parameter");
+      }
+      const el = getAgentElementById(containerEl, id);
+      if (!el) return { ok: false, id, reason: "element not found" };
+      if (
+        el instanceof HTMLInputElement ||
+        el instanceof HTMLTextAreaElement ||
+        el instanceof HTMLSelectElement
+      ) {
+        setNativeInputValue(el, value);
+        return { ok: true, id, value };
+      }
+      return { ok: false, id, reason: "element is not a native field" };
+    }
+
+    case "agent-scroll-to": {
+      const id = agentIdParam(params);
+      if (!id) throw new Error("agent-scroll-to requires an `id` parameter");
+      const el = getAgentElementById(containerEl, id);
+      if (!el) return { ok: false, id, reason: "element not found" };
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      return { ok: true, id };
+    }
+
+    case "set-highlight":
+      return { highlighting: false };
+
+    default:
+      throw new Error(`Unknown agent-surface capability "${capability}"`);
+  }
 }
 
 /**
@@ -645,12 +834,16 @@ export const DynamicViewLoader = memo(function DynamicViewLoader({
         // Generic agent-surface capabilities (list-elements, agent-fill, …)
         // operate on the view's element registry.
         if (isAgentSurfaceCapability(capability)) {
-          if (!registry) {
-            throw new Error(
-              `View "${viewId}" has no agent surface registered yet`,
-            );
+          if (registry && registry.size() > 0) {
+            return handleAgentSurfaceCapability(registry, capability, params);
           }
-          return handleAgentSurfaceCapability(registry, capability, params);
+          return handleDomAgentSurfaceCapability(
+            viewId,
+            viewType,
+            capability,
+            params,
+            containerRef.current,
+          );
         }
         // Standard capabilities are handled here regardless of whether the
         // module exports interact — they operate on the registry or the DOM.

--- a/packages/ui/src/components/views/view-interact-registry.test.ts
+++ b/packages/ui/src/components/views/view-interact-registry.test.ts
@@ -65,7 +65,7 @@ describe("view-interact-registry", () => {
     });
   });
 
-  it("returns a failure result when no handler is registered", async () => {
+  it("ignores requests for unmounted views", async () => {
     const { dispatchViewInteract } = await import("./view-interact-registry");
 
     await dispatchViewInteract(
@@ -76,13 +76,7 @@ describe("view-interact-registry", () => {
       "req-missing",
     );
 
-    expect(sendWsMessage).toHaveBeenCalledWith({
-      type: "view:interact:result",
-      requestId: "req-missing",
-      success: false,
-      error:
-        'No interact handler registered for gui view "missing-view" - view may not be mounted',
-    });
+    expect(sendWsMessage).not.toHaveBeenCalled();
   });
 
   it("returns a failure result when a handler throws", async () => {
@@ -108,6 +102,32 @@ describe("view-interact-registry", () => {
       success: false,
       error: "interact failed",
     });
+  });
+
+  it("executes each request id at most once", async () => {
+    const { dispatchViewInteract, registerViewInteractHandler } = await import(
+      "./view-interact-registry"
+    );
+    const handler = vi.fn(async () => ({ ok: true }));
+    registerViewInteractHandler("notes", "gui", handler);
+
+    await dispatchViewInteract(
+      "notes",
+      "gui",
+      "create-note",
+      undefined,
+      "req-dupe",
+    );
+    await dispatchViewInteract(
+      "notes",
+      "gui",
+      "create-note",
+      undefined,
+      "req-dupe",
+    );
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(sendWsMessage).toHaveBeenCalledTimes(1);
   });
 
   it("stringifies non-Error handler failures", async () => {
@@ -174,11 +194,6 @@ describe("view-interact-registry", () => {
       undefined,
       "req-unregistered",
     );
-    expect(sendWsMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        requestId: "req-unregistered",
-        success: false,
-      }),
-    );
+    expect(sendWsMessage).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/views/view-interact-registry.ts
+++ b/packages/ui/src/components/views/view-interact-registry.ts
@@ -23,6 +23,8 @@ function handlerKey(viewId: string, viewType: ViewType): string {
 
 /** viewType:viewId → handler registered by the mounted DynamicViewLoader. */
 const handlers = new Map<string, InteractHandler>();
+const handledRequestIds = new Map<string, ReturnType<typeof setTimeout>>();
+const HANDLED_REQUEST_TTL_MS = 60_000;
 
 export function registerViewInteractHandler(
   viewId: string,
@@ -53,14 +55,19 @@ export async function dispatchViewInteract(
   const handler = handlers.get(handlerKey(viewId, resolvedViewType));
 
   if (!handler) {
-    client.sendWsMessage({
-      type: "view:interact:result",
-      requestId,
-      success: false,
-      error: `No interact handler registered for ${resolvedViewType} view "${viewId}" - view may not be mounted`,
-    });
+    // The API broadcasts view-interact requests to every connected shell.
+    // Clients that do not currently mount the target view must stay silent so
+    // they do not race the mounted client and resolve the request as failed.
     return;
   }
+  if (handledRequestIds.has(requestId)) {
+    return;
+  }
+  const timeout = setTimeout(() => {
+    handledRequestIds.delete(requestId);
+  }, HANDLED_REQUEST_TTL_MS);
+  (timeout as { unref?: () => void }).unref?.();
+  handledRequestIds.set(requestId, timeout);
 
   try {
     const result = await handler(capability, params);

--- a/plugins/plugin-app-control/src/actions/views-client.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-client.test.ts
@@ -16,10 +16,70 @@ function jsonResponse(body: unknown) {
 
 afterEach(() => {
 	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
 	coreMock.resolveServerOnlyPort.mockClear();
 });
 
 describe("views client", () => {
+	it("normalizes legacy capability metadata from the view registry", async () => {
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			expect(String(input)).toBe("http://127.0.0.1:3456/api/views");
+			return jsonResponse({
+				views: [
+					{
+						id: "remote-ledger",
+						label: "Remote Ledger",
+						pluginName: "@scenario/plugin-remote-ledger",
+						available: true,
+						capabilities: [
+							{
+								name: "fill-input",
+								description: "Fill a named input in the view.",
+								inputSchema: {
+									type: "object",
+									properties: {
+										name: {
+											type: "string",
+											description: "Input name.",
+										},
+										value: { type: "string" },
+									},
+									required: ["name", "value"],
+								},
+							},
+							{ description: "missing id/name should be ignored" },
+						],
+					},
+				],
+			});
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(createViewsClient().listViews()).resolves.toMatchObject([
+			{
+				id: "remote-ledger",
+				capabilities: [
+					{
+						id: "fill-input",
+						description: "Fill a named input in the view.",
+						params: {
+							name: {
+								type: "string",
+								description: "Input name.",
+								required: true,
+							},
+							value: {
+								type: "string",
+								description: "",
+								required: true,
+							},
+						},
+					},
+				],
+			},
+		]);
+	});
+
 	it("parses XR current-view state", async () => {
 		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
 			expect(String(input)).toBe("http://127.0.0.1:3456/api/views/current");

--- a/plugins/plugin-app-control/src/actions/views-client.ts
+++ b/plugins/plugin-app-control/src/actions/views-client.ts
@@ -37,6 +37,9 @@ export interface CurrentViewSummary {
 	viewLabel: string;
 	viewType: ViewType;
 	action?: string;
+	views?: string[];
+	layout?: string;
+	placement?: string;
 	updatedAt: string;
 }
 
@@ -47,6 +50,68 @@ function getApiBase(): string {
 
 function isObject(v: unknown): v is Record<string, unknown> {
 	return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
+type ViewCapabilityParams = NonNullable<ViewCapability["params"]>;
+
+function parseCapabilityParams(
+	value: unknown,
+): ViewCapabilityParams | undefined {
+	if (!isObject(value)) return undefined;
+	const params: ViewCapabilityParams = {};
+	for (const [key, rawParam] of Object.entries(value)) {
+		if (!isObject(rawParam) || typeof rawParam.type !== "string") continue;
+		params[key] = {
+			type: rawParam.type,
+			description:
+				typeof rawParam.description === "string" ? rawParam.description : "",
+			...(typeof rawParam.required === "boolean"
+				? { required: rawParam.required }
+				: {}),
+		};
+	}
+	return Object.keys(params).length > 0 ? params : undefined;
+}
+
+function parseJsonSchemaParams(
+	value: unknown,
+): ViewCapabilityParams | undefined {
+	if (!isObject(value) || !isObject(value.properties)) return undefined;
+	const required = Array.isArray(value.required)
+		? new Set(
+				value.required.filter(
+					(item): item is string => typeof item === "string",
+				),
+			)
+		: new Set<string>();
+	const params: ViewCapabilityParams = {};
+	for (const [key, rawProperty] of Object.entries(value.properties)) {
+		if (!isObject(rawProperty) || typeof rawProperty.type !== "string")
+			continue;
+		params[key] = {
+			type: rawProperty.type,
+			description:
+				typeof rawProperty.description === "string"
+					? rawProperty.description
+					: "",
+			...(required.has(key) ? { required: true } : {}),
+		};
+	}
+	return Object.keys(params).length > 0 ? params : undefined;
+}
+
+function parseViewCapability(entry: unknown): ViewCapability | null {
+	if (!isObject(entry)) return null;
+	const rawId = typeof entry.id === "string" ? entry.id : entry.name;
+	if (typeof rawId !== "string" || rawId.trim().length === 0) return null;
+	const params =
+		parseCapabilityParams(entry.params) ??
+		parseJsonSchemaParams(entry.inputSchema);
+	return {
+		id: rawId.trim(),
+		description: typeof entry.description === "string" ? entry.description : "",
+		...(params ? { params } : {}),
+	};
 }
 
 function parseViewSummary(entry: Record<string, unknown>): ViewSummary {
@@ -91,7 +156,11 @@ function parseViewSummary(entry: Record<string, unknown>): ViewSummary {
 		: undefined;
 
 	const capabilities = Array.isArray(entry.capabilities)
-		? (entry.capabilities.filter(isObject) as unknown as ViewCapability[])
+		? entry.capabilities
+				.map(parseViewCapability)
+				.filter(
+					(capability): capability is ViewCapability => capability !== null,
+				)
 		: undefined;
 
 	return {
@@ -149,7 +218,28 @@ function parseCurrentView(body: unknown): CurrentViewSummary | null {
 	}
 	const action =
 		typeof currentView.action === "string" ? currentView.action : undefined;
-	return { viewId, viewPath, viewLabel, viewType, action, updatedAt };
+	const views = Array.isArray(currentView.views)
+		? currentView.views.filter(
+				(view): view is string => typeof view === "string",
+			)
+		: undefined;
+	const layout =
+		typeof currentView.layout === "string" ? currentView.layout : undefined;
+	const placement =
+		typeof currentView.placement === "string"
+			? currentView.placement
+			: undefined;
+	return {
+		viewId,
+		viewPath,
+		viewLabel,
+		viewType,
+		action,
+		views,
+		layout,
+		placement,
+		updatedAt,
+	};
 }
 
 export interface ViewsClient {

--- a/plugins/plugin-app-control/src/actions/views-management.test.ts
+++ b/plugins/plugin-app-control/src/actions/views-management.test.ts
@@ -7,9 +7,11 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import type { ResponseHandlerEvaluatorContext } from "@elizaos/core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { viewFollowupRoutingEvaluator } from "../evaluators/view-followup-routing.js";
 import { runCreate } from "./app-create.js";
-import { createViewsAction } from "./views.js";
+import { createViewsAction, createViewsAliasAction } from "./views.js";
 import type { ViewSummary } from "./views-client.js";
 import { runViewsCreate } from "./views-create.js";
 import { runViewsDelete } from "./views-delete.js";
@@ -57,6 +59,22 @@ function message(text: string, roomId = "room-1") {
 		agentId: "agent-1",
 		content: { text },
 	};
+}
+
+function composedViewPrompt(userRequest: string) {
+	return [
+		"Answer the user request using the contextual documents below as the source of truth.",
+		"",
+		"<contextual_documents>",
+		'<source title="source-1" similarity="1.000">',
+		"Route chat through Cloud and configure purchase-share settings.",
+		"</source>",
+		"</contextual_documents>",
+		"",
+		"<user_request>",
+		userRequest,
+		"</user_request>",
+	].join("\n");
 }
 
 function view(patch: Partial<ViewSummary> = {}): ViewSummary {
@@ -117,6 +135,32 @@ function createRuntime({
 	return { runtime, codingHandler, tasks };
 }
 
+function evaluatorContext(
+	text: string,
+	overrides: Partial<ResponseHandlerEvaluatorContext> = {},
+): ResponseHandlerEvaluatorContext {
+	return {
+		runtime: {
+			agentId: "agent-1",
+			actions: [{ name: "VIEWS" }],
+			logger: coreMock.logger,
+		},
+		message: message(text) as never,
+		state: {},
+		messageHandler: {
+			processMessage: "RESPOND",
+			thought: "direct reply",
+			plan: {
+				contexts: ["simple"],
+				requiresTool: false,
+				reply: "Sure, what should the note be titled?",
+			},
+		},
+		availableContexts: [{ id: "general" }, { id: "simple" }],
+		...overrides,
+	} as ResponseHandlerEvaluatorContext;
+}
+
 function createRepoFixture() {
 	const repoRoot = mkdtempSync(path.join(tmpdir(), "views-actions-"));
 	const templateDir = path.join(
@@ -153,6 +197,102 @@ describe("view management actions", () => {
 
 	afterEach(() => {
 		vi.unstubAllGlobals();
+	});
+
+	it("routes active-view mutation follow-ups through VIEWS before direct reply", async () => {
+		const notesView = view({
+			id: "notes",
+			label: "Notes",
+			description: "Sticky notes board",
+			tags: ["notes", "sticky-notes"],
+			capabilities: [
+				{
+					id: "create-note",
+					description: "Create a sticky note",
+					params: {
+						title: { type: "string", description: "Optional note title" },
+						body: { type: "string", description: "Note body text" },
+					},
+				},
+				{
+					id: "delete-note",
+					description: "Delete a sticky note by id, title, or query",
+				},
+			],
+		});
+		vi.mocked(globalThis.fetch).mockImplementation(async (url) => {
+			const requestUrl = String(url);
+			if (requestUrl.endsWith("/api/views/current")) {
+				return {
+					ok: true,
+					status: 200,
+					json: async () => ({
+						currentView: {
+							viewId: "notes",
+							viewPath: "/notes",
+							viewLabel: "Notes",
+							viewType: "gui",
+							action: "open",
+							updatedAt: "2026-06-08T00:00:00.000Z",
+						},
+					}),
+				} as Response;
+			}
+			return {
+				ok: true,
+				status: 200,
+				json: async () => ({ views: [notesView] }),
+			} as Response;
+		});
+
+		const context = evaluatorContext(
+			"can you make another one saying i need to wake up at 3am",
+		);
+
+		expect(await viewFollowupRoutingEvaluator.shouldRun(context)).toBe(true);
+		await expect(
+			viewFollowupRoutingEvaluator.evaluate(context),
+		).resolves.toMatchObject({
+			requiresTool: true,
+			clearReply: true,
+			reply: "On it.",
+			addContexts: ["general"],
+			addCandidateActions: ["VIEWS"],
+			addParentActionHints: ["VIEWS"],
+		});
+	});
+
+	it("leaves ordinary non-view follow-ups on the direct path", async () => {
+		const context = evaluatorContext("can you make another joke", {
+			messageHandler: {
+				processMessage: "RESPOND",
+				thought: "direct reply",
+				plan: {
+					contexts: ["simple"],
+					requiresTool: false,
+					reply: "Here's another joke.",
+				},
+			},
+		} as never);
+
+		expect(await viewFollowupRoutingEvaluator.shouldRun(context)).toBe(false);
+		expect(globalThis.fetch).not.toHaveBeenCalled();
+	});
+
+	it("advertises UI view switching in its planner routing hint", () => {
+		const action = createViewsAction();
+		expect(action.routingHint).toContain("UI view/window/panel/app navigation");
+		expect(action.routingHint).toContain("Close/hide means VIEWS action=close");
+	});
+
+	it("stays available when stage 1 routes a view request to a domain context", () => {
+		const action = createViewsAction();
+		expect(action.contexts).toEqual(
+			expect.arrayContaining(["general", "calendar", "tasks", "documents"]),
+		);
+		expect(action.contextGate?.anyOf).toEqual(
+			expect.arrayContaining(["calendar", "tasks"]),
+		);
 	});
 
 	it("scaffolds a new view plugin and dispatches a coding task with the generated prompt", async () => {
@@ -371,6 +511,11 @@ describe("view management actions", () => {
 			status: 200,
 			json: async () => ({ ok: true }),
 		} as Response);
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
 
 		const result = await action.handler(
 			runtime as never,
@@ -406,6 +551,687 @@ describe("view management actions", () => {
 		expect(callback).toHaveBeenCalledWith(
 			expect.objectContaining({
 				text: 'Opened gui view "remote-ledger" in a separate window.',
+			}),
+		);
+	});
+
+	it("resolves existing registered view targets for natural-language window and pin requests", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({
+						id: "orchestrator",
+						label: "Orchestrator",
+						path: "/orchestrator",
+					}),
+					view({
+						id: "views-manager",
+						label: "Views",
+						path: "/views",
+						tags: ["views-manager"],
+					}),
+				]),
+				getCurrentView: vi.fn(async () => null),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch)
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ ok: true }),
+			} as Response)
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ ok: true }),
+			} as Response)
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ ok: true }),
+			} as Response)
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ ok: true }),
+			} as Response)
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ ok: true }),
+			} as Response)
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ ok: true }),
+			} as Response);
+
+		const windowResult = await action.handler(
+			runtime as never,
+			message("open orchestrator in a new window") as never,
+			undefined,
+			undefined,
+			callback,
+		);
+
+		expect(windowResult?.success).toBe(true);
+		expect(windowResult?.values).toMatchObject({
+			mode: "window",
+			viewId: "orchestrator",
+			viewType: "gui",
+			alwaysOnTop: false,
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/orchestrator/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "open-window",
+					alwaysOnTop: false,
+				}),
+			}),
+		);
+
+		const openActionWindowResult = await action.handler(
+			runtime as never,
+			message("open orchestrator in a new window") as never,
+			undefined,
+			{
+				action: "open",
+				view: "orchestrator",
+			},
+			callback,
+		);
+
+		expect(openActionWindowResult?.success).toBe(true);
+		expect(openActionWindowResult?.values).toMatchObject({
+			mode: "window",
+			viewId: "orchestrator",
+			viewType: "gui",
+			alwaysOnTop: false,
+		});
+		expect(globalThis.fetch).toHaveBeenLastCalledWith(
+			"http://127.0.0.1:3456/api/views/orchestrator/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "open-window",
+					alwaysOnTop: false,
+				}),
+			}),
+		);
+
+		const pinResult = await action.handler(
+			runtime as never,
+			message("pin views manager as a tab") as never,
+			undefined,
+			undefined,
+			callback,
+		);
+
+		expect(pinResult?.success).toBe(true);
+		expect(pinResult?.values).toMatchObject({
+			mode: "pin",
+			viewId: "views-manager",
+			viewType: "gui",
+		});
+		expect(globalThis.fetch).toHaveBeenLastCalledWith(
+			"http://127.0.0.1:3456/api/views/views-manager/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "pin-tab",
+					alwaysOnTop: false,
+				}),
+			}),
+		);
+
+		const explicitPinResult = await action.handler(
+			runtime as never,
+			message("pin views manager as a tab") as never,
+			undefined,
+			{
+				action: "pin",
+				view: "views manager",
+			},
+			callback,
+		);
+
+		expect(explicitPinResult?.success).toBe(true);
+		expect(explicitPinResult?.values).toMatchObject({
+			mode: "pin",
+			viewId: "views-manager",
+			viewType: "gui",
+		});
+		expect(globalThis.fetch).toHaveBeenLastCalledWith(
+			"http://127.0.0.1:3456/api/views/views-manager/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "pin-tab",
+					alwaysOnTop: false,
+				}),
+			}),
+		);
+
+		const pollutedSplitResult = await action.handler(
+			runtime as never,
+			message("split orchestrator and views manager side by side") as never,
+			undefined,
+			{
+				action: "split",
+				views: ["orchestrator", "views manager", "chat", "settings"],
+			},
+			callback,
+		);
+
+		expect(pollutedSplitResult?.success).toBe(true);
+		expect(pollutedSplitResult?.values).toMatchObject({
+			mode: "split",
+			viewIds: ["orchestrator", "views-manager"],
+			layout: "horizontal",
+		});
+		expect(globalThis.fetch).toHaveBeenLastCalledWith(
+			"http://127.0.0.1:3456/api/views/orchestrator/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "split-view",
+					views: ["orchestrator", "views-manager"],
+					layout: "horizontal",
+				}),
+			}),
+		);
+	});
+
+	it("routes split and tile requests through the shell layout navigate API", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({ id: "notes", label: "Notes", path: "/notes" }),
+					view({ id: "calendar", label: "Calendar", path: "/calendar" }),
+				]),
+				getCurrentView: vi.fn(async () => null),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+
+		const splitResult = await action.handler(
+			runtime as never,
+			message("split notes and calendar side by side") as never,
+			undefined,
+			undefined,
+			callback,
+		);
+
+		expect(splitResult?.success).toBe(true);
+		expect(splitResult?.values).toMatchObject({
+			mode: "split",
+			viewIds: ["notes", "calendar"],
+			layout: "horizontal",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "split-view",
+					views: ["notes", "calendar"],
+					layout: "horizontal",
+				}),
+			}),
+		);
+		expect(callback).toHaveBeenCalledWith(
+			expect.objectContaining({
+				text: "Split views: Notes, Calendar (horizontal).",
+			}),
+		);
+
+		const tileResult = await action.handler(
+			runtime as never,
+			message("tile my simple views") as never,
+			undefined,
+			{
+				action: "tile",
+				views: ["notes", "calendar"],
+			},
+			callback,
+		);
+
+		expect(tileResult?.success).toBe(true);
+		expect(tileResult?.values).toMatchObject({
+			mode: "tile",
+			viewIds: ["notes", "calendar"],
+			layout: "grid",
+		});
+		expect(globalThis.fetch).toHaveBeenLastCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "tile-views",
+					views: ["notes", "calendar"],
+					layout: "grid",
+				}),
+			}),
+		);
+	});
+
+	it("routes existing registered view layout requests without simple-view targets", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({
+						id: "chat",
+						label: "Chat",
+						path: "/chat",
+					}),
+					view({
+						id: "settings",
+						label: "Settings",
+						path: "/settings",
+					}),
+					view({
+						id: "orchestrator",
+						label: "Orchestrator",
+						path: "/orchestrator",
+					}),
+					view({
+						id: "views-manager",
+						label: "Views",
+						path: "/views",
+						tags: ["views-manager"],
+					}),
+				]),
+				getCurrentView: vi.fn(async () => null),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch)
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ ok: true }),
+			} as Response)
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ ok: true }),
+			} as Response)
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: async () => ({ ok: true }),
+			} as Response);
+
+		const splitResult = await action.handler(
+			runtime as never,
+			message("split orchestrator and views manager side by side") as never,
+			undefined,
+			undefined,
+			callback,
+		);
+
+		expect(splitResult?.success).toBe(true);
+		expect(splitResult?.values).toMatchObject({
+			mode: "split",
+			viewIds: ["orchestrator", "views-manager"],
+			layout: "horizontal",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/orchestrator/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "split-view",
+					views: ["orchestrator", "views-manager"],
+					layout: "horizontal",
+				}),
+			}),
+		);
+
+		const tileResult = await action.handler(
+			runtime as never,
+			message("tile chat settings orchestrator and views manager") as never,
+			undefined,
+			undefined,
+			callback,
+		);
+
+		expect(tileResult?.success).toBe(true);
+		expect(tileResult?.values).toMatchObject({
+			mode: "tile",
+			viewIds: ["chat", "settings", "orchestrator", "views-manager"],
+			layout: "grid",
+		});
+		expect(globalThis.fetch).toHaveBeenLastCalledWith(
+			"http://127.0.0.1:3456/api/views/chat/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "tile-views",
+					views: ["chat", "settings", "orchestrator", "views-manager"],
+					layout: "grid",
+				}),
+			}),
+		);
+
+		const plannerPartialTileResult = await action.handler(
+			runtime as never,
+			message("tile chat settings orchestrator and views manager") as never,
+			undefined,
+			{
+				action: "tile",
+				views: ["orchestrator", "views manager"],
+			},
+			callback,
+		);
+
+		expect(plannerPartialTileResult?.success).toBe(true);
+		expect(plannerPartialTileResult?.values).toMatchObject({
+			mode: "tile",
+			viewIds: ["chat", "settings", "orchestrator", "views-manager"],
+			layout: "grid",
+		});
+		expect(globalThis.fetch).toHaveBeenLastCalledWith(
+			"http://127.0.0.1:3456/api/views/chat/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "tile-views",
+					views: ["chat", "settings", "orchestrator", "views-manager"],
+					layout: "grid",
+				}),
+			}),
+		);
+
+		const badSplitModeTileResult = await action.handler(
+			runtime as never,
+			message("tile chat settings orchestrator and views manager") as never,
+			undefined,
+			{
+				action: "split",
+				views: ["orchestrator", "views manager"],
+			},
+			callback,
+		);
+
+		expect(badSplitModeTileResult?.success).toBe(true);
+		expect(badSplitModeTileResult?.values).toMatchObject({
+			mode: "tile",
+			viewIds: ["chat", "settings", "orchestrator", "views-manager"],
+			layout: "grid",
+		});
+		expect(globalThis.fetch).toHaveBeenLastCalledWith(
+			"http://127.0.0.1:3456/api/views/chat/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "tile-views",
+					views: ["chat", "settings", "orchestrator", "views-manager"],
+					layout: "grid",
+				}),
+			}),
+		);
+	});
+
+	it("uses the composed user_request block for layout target extraction", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({
+						id: "chat",
+						label: "Chat",
+						path: "/chat",
+					}),
+					view({
+						id: "settings",
+						label: "Settings",
+						path: "/settings",
+					}),
+					view({
+						id: "orchestrator",
+						label: "Orchestrator",
+						path: "/orchestrator",
+					}),
+					view({
+						id: "views-manager",
+						label: "Views",
+						path: "/views",
+						tags: ["views-manager"],
+					}),
+				]),
+				getCurrentView: vi.fn(async () => null),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message(
+				composedViewPrompt("split orchestrator and views manager side by side"),
+			) as never,
+			undefined,
+			{
+				action: "split",
+				views: ["orchestrator", "views manager"],
+			},
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			mode: "split",
+			viewIds: ["orchestrator", "views-manager"],
+			layout: "horizontal",
+		});
+		expect(globalThis.fetch).toHaveBeenLastCalledWith(
+			"http://127.0.0.1:3456/api/views/orchestrator/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "split-view",
+					views: ["orchestrator", "views-manager"],
+					layout: "horizontal",
+				}),
+			}),
+		);
+	});
+
+	it('treats "next to it" as split even when the planner passes action=open', async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({ id: "notes", label: "Notes", path: "/notes" }),
+					view({ id: "calendar", label: "Calendar", path: "/calendar" }),
+				]),
+				getCurrentView: vi.fn(async () => ({
+					viewId: "notes",
+					viewLabel: "Notes",
+					viewType: "gui",
+					viewPath: "/notes",
+				})),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message("now open the calender view next to it") as never,
+			undefined,
+			{ action: "open", view: "calendar" },
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			mode: "split",
+			viewIds: ["notes", "calendar"],
+			layout: "horizontal",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "split-view",
+					views: ["notes", "calendar"],
+					layout: "horizontal",
+				}),
+			}),
+		);
+	});
+
+	it("does not add the current chat view when split targets already include two explicit views", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({ id: "chat", label: "Chat", path: "/" }),
+					view({
+						id: "notes",
+						label: "Notes",
+						path: "/notes",
+						tags: ["notes", "notepad"],
+					}),
+					view({ id: "calendar", label: "Calendar", path: "/calendar" }),
+				]),
+				getCurrentView: vi.fn(async () => ({
+					viewId: "chat",
+					viewLabel: "Chat",
+					viewType: "gui",
+					viewPath: "/",
+				})),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message("now open the calender view next to it") as never,
+			undefined,
+			{
+				action: "split",
+				mode: "split",
+				view: "notepad",
+				views: ["notepad", "calendar"],
+				layout: "horizontal",
+				placement: "right",
+			},
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			mode: "split",
+			viewIds: ["notes", "calendar"],
+			layout: "horizontal",
+			placement: "right",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "split-view",
+					views: ["notes", "calendar"],
+					layout: "horizontal",
+					placement: "right",
+				}),
+			}),
+		);
+	});
+
+	it('treats "next to it" as split even when the planner passes action=tile', async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({
+						id: "notes",
+						label: "Notes",
+						path: "/notes",
+						tags: ["notes", "notepad"],
+					}),
+					view({ id: "calendar", label: "Calendar", path: "/calendar" }),
+				]),
+				getCurrentView: vi.fn(async () => null),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message("now open the calender view next to it") as never,
+			undefined,
+			{
+				action: "tile",
+				views: ["notepad", "calendar"],
+				layout: "horizontal",
+			},
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			mode: "split",
+			viewIds: ["notes", "calendar"],
+			layout: "horizontal",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "split-view",
+					views: ["notes", "calendar"],
+					layout: "horizontal",
+				}),
 			}),
 		);
 	});
@@ -695,6 +1521,1209 @@ describe("view management actions", () => {
 		} finally {
 			repo.cleanup();
 		}
+	});
+
+	it("routes explicit CLOSE_VIEW alias calls through non-destructive view close", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const client = {
+			listViews: vi.fn(async () => [
+				view({ id: "settings", label: "Settings", path: "/settings" }),
+			]),
+			getCurrentView: vi.fn(async () => null),
+		};
+		const action = createViewsAliasAction("CLOSE_VIEW", {
+			client,
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message("close settings") as never,
+			undefined,
+			{ target: "settings" },
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			mode: "close",
+			viewId: "settings",
+			viewType: "gui",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/settings/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({ action: "close", alwaysOnTop: false }),
+			}),
+		);
+		expect(callback).toHaveBeenCalledWith(
+			expect.objectContaining({ text: "Closed Settings." }),
+		);
+		expect(client.getCurrentView).not.toHaveBeenCalled();
+	});
+
+	it('treats VIEWS action=delete for "close all views" as close-all, not plugin deletion', async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [view()]),
+				getCurrentView: vi.fn(async () => null),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message("close all views") as never,
+			undefined,
+			{ action: "delete", mode: "delete", confirm: "yes" },
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			mode: "close",
+			scope: "all",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/__all__/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({ action: "close-all", alwaysOnTop: false }),
+			}),
+		);
+		expect(callback).toHaveBeenCalledWith(
+			expect.objectContaining({ text: "Closed all views." }),
+		);
+	});
+
+	it('treats action=delete for "close calendar view" as non-destructive close', async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const client = {
+			listViews: vi.fn(async () => [
+				view({ id: "calendar", label: "Calendar", path: "/calendar" }),
+			]),
+			getCurrentView: vi.fn(async () => null),
+		};
+		const action = createViewsAction({
+			client,
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message("close the calendar view") as never,
+			undefined,
+			{ action: "delete", mode: "delete", view: "calendar", confirm: "yes" },
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			mode: "close",
+			viewId: "calendar",
+			viewType: "gui",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/calendar/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({ action: "close", alwaysOnTop: false }),
+			}),
+		);
+		expect(callback).toHaveBeenCalledWith(
+			expect.objectContaining({ text: "Closed Calendar." }),
+		);
+		expect(client.getCurrentView).not.toHaveBeenCalled();
+	});
+
+	it('resolves casual aliases like "notepad" and "calender" for view navigation', async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({
+						id: "notes",
+						label: "Notes",
+						path: "/notes",
+						tags: ["notes", "notepad", "sticky-notes"],
+					}),
+					view({
+						id: "calendar",
+						label: "Calendar",
+						path: "/calendar",
+						tags: ["calendar", "calender"],
+					}),
+				]),
+				getCurrentView: vi.fn(async () => null),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: async () => "",
+		} as Response);
+
+		const notesResult = await action.handler(
+			runtime as never,
+			message("open the notepad pls") as never,
+			undefined,
+			undefined,
+			callback,
+		);
+		const calendarResult = await action.handler(
+			runtime as never,
+			message("open the calender view") as never,
+			undefined,
+			undefined,
+			callback,
+		);
+
+		expect(notesResult?.success).toBe(true);
+		expect(notesResult?.values).toMatchObject({
+			mode: "show",
+			viewId: "notes",
+		});
+		expect(calendarResult?.success).toBe(true);
+		expect(calendarResult?.values).toMatchObject({
+			mode: "show",
+			viewId: "calendar",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/navigate",
+			expect.objectContaining({ method: "POST" }),
+		);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/calendar/navigate",
+			expect.objectContaining({ method: "POST" }),
+		);
+	});
+
+	it("opens the plugins page from plugin-browser aliases", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({
+						id: "plugins-page",
+						label: "Plugins",
+						path: "/apps/plugins",
+						tags: [
+							"plugins",
+							"plugin-browser",
+							"plugin browser",
+							"plugin-manager",
+						],
+					}),
+				]),
+				getCurrentView: vi.fn(async () => null),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValue({
+			ok: true,
+			status: 200,
+			text: async () => "",
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message("open plugin browser") as never,
+			undefined,
+			{ action: "open", view: "plugin-browser" },
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			mode: "show",
+			viewId: "plugins-page",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/plugins-page/navigate",
+			expect.objectContaining({ method: "POST" }),
+		);
+	});
+
+	it("dispatches generated capability action names through the registered view catalog", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({
+						id: "notes",
+						label: "Notes",
+						path: "/notes",
+						tags: ["notes", "note wall", "sticky notes"],
+						capabilities: [
+							{
+								id: "create-note",
+								description: "Create a sticky note.",
+								params: {
+									title: { type: "string", description: "Note title." },
+									body: { type: "string", description: "Note body." },
+								},
+							},
+							{
+								id: "get-notes",
+								description: "Return all sticky notes as structured data.",
+							},
+							{
+								id: "delete-note",
+								description: "Delete one sticky note by id, title, or query.",
+								params: {
+									id: { type: "string", description: "Note id." },
+									title: {
+										type: "string",
+										description: "Exact note title.",
+									},
+									query: {
+										type: "string",
+										description: "Title/body search query.",
+									},
+									name: {
+										type: "string",
+										description: "Alias for title or query.",
+									},
+								},
+							},
+							{
+								id: "list-elements",
+								description: "List mounted view elements.",
+							},
+						],
+					}),
+					view({
+						id: "calendar",
+						label: "Calendar",
+						path: "/calendar",
+						tags: ["calendar", "events"],
+						capabilities: [
+							{
+								id: "get-calendar-state",
+								description:
+									"Return selected date and all calendar events as structured data.",
+							},
+							{
+								id: "create-calendar-event",
+								description: "Create a calendar event.",
+								params: {
+									title: { type: "string", description: "Event title." },
+									date: {
+										type: "string",
+										description: "Date in YYYY-MM-DD format.",
+									},
+									time: { type: "string", description: "Time label." },
+								},
+							},
+						],
+					}),
+				]),
+				getCurrentView: vi.fn(async () => ({
+					viewId: "notes",
+					viewLabel: "Notes",
+					viewType: "gui" as const,
+					viewPath: "/notes",
+				})),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				success: true,
+				result: { text: "Created.", success: true },
+			}),
+		} as Response);
+
+		const noteResult = await action.handler(
+			runtime as never,
+			message("create note") as never,
+			undefined,
+			{
+				action: "CREATE_NOTE",
+				title: "smoke note",
+				body: "created from routing",
+			},
+			callback,
+		);
+		const plannerCreateResult = await action.handler(
+			runtime as never,
+			message(
+				"create a note titled smoke note with body created from routing",
+			) as never,
+			undefined,
+			{
+				action: "create",
+				view: "smoke note",
+				intent: "Note titled smoke note with body created from routing.",
+			},
+			callback,
+		);
+		const showNotesResult = await action.handler(
+			runtime as never,
+			message("show me my notes") as never,
+			undefined,
+			{ action: "show", view: "notes" },
+			callback,
+		);
+		const listNotesAliasResult = await action.handler(
+			runtime as never,
+			message("show me my notes") as never,
+			undefined,
+			{ action: "interact", view: "notes", capability: "list-notes" },
+			callback,
+		);
+		const deleteNoteResult = await action.handler(
+			runtime as never,
+			message("delete note") as never,
+			undefined,
+			{ action: "DELETE_NOTE", id: "note-123" },
+			callback,
+		);
+		const deleteNoteByTextResult = await action.handler(
+			runtime as never,
+			message("delete the nubby note") as never,
+			undefined,
+			{ action: "delete" },
+			callback,
+		);
+		const createNoteFromMessageResult = await action.handler(
+			runtime as never,
+			message(
+				"can you make another one saying i need to wake up at 3am",
+			) as never,
+			undefined,
+			{ action: "create" },
+			callback,
+		);
+		const currentElementsResult = await action.handler(
+			runtime as never,
+			message("list elements in the current view") as never,
+			undefined,
+			{ action: "interact", capability: "list-elements" },
+			callback,
+		);
+		const calendarResult = await action.handler(
+			runtime as never,
+			message("add a calendar event") as never,
+			undefined,
+			{ action: "CALENDAR_CREATE_EVENT", title: "smoke event" },
+			callback,
+		);
+		const plannerCalendarResult = await action.handler(
+			runtime as never,
+			message("add a calendar event titled smoke event") as never,
+			undefined,
+			{
+				action: "create",
+				view: "calendar",
+				intent: "Create event titled smoke event on 2026-06-08 at 17:00",
+			},
+			callback,
+		);
+		const explicitCapabilityWordingCalendarResult = await action.handler(
+			runtime as never,
+			message("create calendar event through the VIEWS capability") as never,
+			undefined,
+			{
+				action: "create",
+				view: "calendar",
+				intent:
+					"Create calendar event through the VIEWS capability titled routed event on 2026-06-09 at 12:00",
+			},
+			callback,
+		);
+		const camelCalendarResult = await action.handler(
+			runtime as never,
+			message("add a calendar event titled smoke event") as never,
+			undefined,
+			{
+				action: "interact",
+				view: "calendar",
+				capability: "createEvent",
+				params: {
+					title: "camel event",
+					date: "2026-06-08",
+					time: "18:00",
+				},
+			},
+			callback,
+		);
+		const listEventsResult = await action.handler(
+			runtime as never,
+			message("show today's calendar events") as never,
+			undefined,
+			{
+				action: "interact",
+				view: "calendar",
+				capability: "list-events",
+				params: { date: "2026-06-08" },
+			},
+			callback,
+		);
+
+		expect(noteResult?.success).toBe(true);
+		expect(noteResult?.values).toMatchObject({
+			mode: "interact",
+			viewId: "notes",
+			capability: "create-note",
+		});
+		expect(plannerCreateResult?.success).toBe(true);
+		expect(plannerCreateResult?.values).toMatchObject({
+			mode: "interact",
+			viewId: "notes",
+			capability: "create-note",
+		});
+		expect(showNotesResult?.success).toBe(true);
+		expect(showNotesResult?.values).toMatchObject({
+			mode: "interact",
+			viewId: "notes",
+			capability: "get-notes",
+		});
+		expect(listNotesAliasResult?.success).toBe(true);
+		expect(listNotesAliasResult?.values).toMatchObject({
+			mode: "interact",
+			viewId: "notes",
+			capability: "get-notes",
+		});
+		expect(deleteNoteResult?.success).toBe(true);
+		expect(deleteNoteResult?.values).toMatchObject({
+			mode: "interact",
+			viewId: "notes",
+			capability: "delete-note",
+		});
+		expect(deleteNoteByTextResult?.success).toBe(true);
+		expect(deleteNoteByTextResult?.values).toMatchObject({
+			mode: "interact",
+			viewId: "notes",
+			capability: "delete-note",
+		});
+		expect(createNoteFromMessageResult?.success).toBe(true);
+		expect(createNoteFromMessageResult?.values).toMatchObject({
+			mode: "interact",
+			viewId: "notes",
+			capability: "create-note",
+		});
+		expect(currentElementsResult?.success).toBe(true);
+		expect(currentElementsResult?.values).toMatchObject({
+			mode: "interact",
+			viewId: "notes",
+			capability: "list-elements",
+		});
+		expect(calendarResult?.success).toBe(true);
+		expect(calendarResult?.values).toMatchObject({
+			mode: "interact",
+			viewId: "calendar",
+			capability: "create-calendar-event",
+		});
+		expect(plannerCalendarResult?.success).toBe(true);
+		expect(plannerCalendarResult?.values).toMatchObject({
+			mode: "interact",
+			viewId: "calendar",
+			capability: "create-calendar-event",
+		});
+		expect(explicitCapabilityWordingCalendarResult?.success).toBe(true);
+		expect(explicitCapabilityWordingCalendarResult?.values).toMatchObject({
+			mode: "interact",
+			viewId: "calendar",
+			capability: "create-calendar-event",
+		});
+		expect(camelCalendarResult?.success).toBe(true);
+		expect(camelCalendarResult?.values).toMatchObject({
+			mode: "interact",
+			viewId: "calendar",
+			capability: "create-calendar-event",
+		});
+		expect(listEventsResult?.success).toBe(true);
+		expect(listEventsResult?.values).toMatchObject({
+			mode: "interact",
+			viewId: "calendar",
+			capability: "get-calendar-state",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/interact?viewType=gui",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					capability: "create-note",
+					params: {
+						title: "smoke note",
+						body: "created from routing",
+					},
+					timeoutMs: 5_000,
+					viewType: "gui",
+				}),
+			}),
+		);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/interact?viewType=gui",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					capability: "create-note",
+					params: {
+						title: "smoke note",
+						body: "created from routing.",
+					},
+					timeoutMs: 5_000,
+					viewType: "gui",
+				}),
+			}),
+		);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/interact?viewType=gui",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					capability: "delete-note",
+					params: { query: "nubby" },
+					timeoutMs: 5_000,
+					viewType: "gui",
+				}),
+			}),
+		);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/interact?viewType=gui",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					capability: "create-note",
+					params: { body: "i need to wake up at 3am" },
+					timeoutMs: 5_000,
+					viewType: "gui",
+				}),
+			}),
+		);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/interact?viewType=gui",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					capability: "get-notes",
+					params: undefined,
+					timeoutMs: 5_000,
+					viewType: "gui",
+				}),
+			}),
+		);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/interact?viewType=gui",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					capability: "delete-note",
+					params: { id: "note-123" },
+					timeoutMs: 5_000,
+					viewType: "gui",
+				}),
+			}),
+		);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/interact?viewType=gui",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					capability: "list-elements",
+					params: undefined,
+					timeoutMs: 5_000,
+					viewType: "gui",
+				}),
+			}),
+		);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/calendar/interact?viewType=gui",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					capability: "create-calendar-event",
+					params: { title: "smoke event" },
+					timeoutMs: 5_000,
+					viewType: "gui",
+				}),
+			}),
+		);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/calendar/interact?viewType=gui",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					capability: "create-calendar-event",
+					params: {
+						title: "smoke event",
+						date: "2026-06-08",
+						time: "17:00",
+					},
+					timeoutMs: 5_000,
+					viewType: "gui",
+				}),
+			}),
+		);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/calendar/interact?viewType=gui",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					capability: "create-calendar-event",
+					params: {
+						title: "routed event",
+						date: "2026-06-09",
+						time: "12:00",
+					},
+					timeoutMs: 5_000,
+					viewType: "gui",
+				}),
+			}),
+		);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/calendar/interact?viewType=gui",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					capability: "create-calendar-event",
+					params: {
+						title: "camel event",
+						date: "2026-06-08",
+						time: "18:00",
+					},
+					timeoutMs: 5_000,
+					viewType: "gui",
+				}),
+			}),
+		);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/calendar/interact?viewType=gui",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					capability: "get-calendar-state",
+					params: { date: "2026-06-08" },
+					timeoutMs: 5_000,
+					viewType: "gui",
+				}),
+			}),
+		);
+	});
+
+	it("summarizes structured interaction results without dumping JSON into chat", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({
+						id: "settings",
+						label: "Settings",
+						path: "/settings",
+						capabilities: [
+							{
+								id: "get-state",
+								description: "Read settings state.",
+							},
+						],
+					}),
+				]),
+				getCurrentView: vi.fn(async () => null),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				success: true,
+				result: { theme: "dark", language: "en" },
+			}),
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message("get the state of settings") as never,
+			undefined,
+			{ action: "interact", view: "settings", capability: "get-state" },
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			mode: "interact",
+			viewId: "settings",
+			capability: "get-state",
+		});
+		expect(callback).toHaveBeenCalledWith(
+			expect.objectContaining({
+				text: 'Interacted with view "settings" — capability "get-state" (returned theme, language).',
+			}),
+		);
+		expect(callback.mock.calls[0]?.[0]?.text).not.toContain("{");
+	});
+
+	it('splits a single mentioned view "next to" the current view', async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({ id: "notes", label: "Notes", path: "/notes" }),
+					view({
+						id: "calendar",
+						label: "Calendar",
+						path: "/calendar",
+						tags: ["calendar", "calender"],
+					}),
+				]),
+				getCurrentView: vi.fn(async () => ({
+					viewId: "notes",
+					viewLabel: "Notes",
+					viewPath: "/notes",
+					viewType: "gui",
+				})),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message("now open the calender view next to it") as never,
+			undefined,
+			undefined,
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			mode: "split",
+			viewIds: ["notes", "calendar"],
+			layout: "horizontal",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "split-view",
+					views: ["notes", "calendar"],
+					layout: "horizontal",
+				}),
+			}),
+		);
+	});
+
+	it("splits a placed view against the current view for incremental layout requests", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({ id: "notes", label: "Notes", path: "/notes" }),
+					view({
+						id: "calendar",
+						label: "Calendar",
+						path: "/calendar",
+						tags: ["calendar", "calender"],
+					}),
+				]),
+				getCurrentView: vi.fn(async () => ({
+					viewId: "notes",
+					viewLabel: "Notes",
+					viewPath: "/notes",
+					viewType: "gui",
+				})),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message("and calender on the right") as never,
+			undefined,
+			undefined,
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			mode: "split",
+			viewIds: ["notes", "calendar"],
+			layout: "horizontal",
+			placement: "right",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "split-view",
+					views: ["notes", "calendar"],
+					layout: "horizontal",
+					placement: "right",
+				}),
+			}),
+		);
+	});
+
+	it("uses placement orientation over stale generated capability options for placement follow-ups", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({ id: "notes", label: "Notes", path: "/notes" }),
+					view({
+						id: "calendar",
+						label: "Calendar",
+						path: "/calendar",
+						tags: ["calendar", "calender"],
+						capabilities: [
+							{
+								id: "create-calendar-event",
+								description: "Create a calendar event.",
+							},
+						],
+					}),
+				]),
+				getCurrentView: vi.fn(async () => ({
+					viewId: "notes",
+					viewLabel: "Notes",
+					viewPath: "/notes",
+					viewType: "gui",
+				})),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message("and calender on the right") as never,
+			undefined,
+			{
+				action: "create-calendar-event",
+				view: "calendar",
+				layout: "vertical",
+			},
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.continueChain).toBe(false);
+		expect(result?.values).toMatchObject({
+			mode: "split",
+			viewIds: ["notes", "calendar"],
+			layout: "horizontal",
+			placement: "right",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "split-view",
+					views: ["notes", "calendar"],
+					layout: "horizontal",
+					placement: "right",
+				}),
+			}),
+		);
+	});
+
+	it("reuses current split views for layout-only split follow-ups", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({
+						id: "plugins-page",
+						label: "Plugins",
+						path: "/apps/plugins",
+					}),
+					view({ id: "calendar", label: "Calendar", path: "/calendar" }),
+				]),
+				getCurrentView: vi.fn(async () => ({
+					viewId: "plugins-page",
+					viewLabel: "Plugins",
+					viewPath: "/apps/plugins",
+					viewType: "gui",
+					action: "split-view",
+					views: ["plugins-page", "calendar"],
+					layout: "horizontal",
+				})),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message("split vertical instead") as never,
+			undefined,
+			{
+				action: "split",
+				layout: "vertical",
+				views: ["notes", "plugins-page", "calendar"],
+			},
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			mode: "split",
+			viewIds: ["plugins-page", "calendar"],
+			layout: "vertical",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/plugins-page/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "split-view",
+					views: ["plugins-page", "calendar"],
+					layout: "vertical",
+				}),
+			}),
+		);
+	});
+
+	it("reuses current split views for text-only layout follow-ups", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({
+						id: "plugins-page",
+						label: "Plugins",
+						path: "/apps/plugins",
+					}),
+					view({ id: "calendar", label: "Calendar", path: "/calendar" }),
+				]),
+				getCurrentView: vi.fn(async () => ({
+					viewId: "plugins-page",
+					viewLabel: "Plugins",
+					viewPath: "/apps/plugins",
+					viewType: "gui",
+					action: "split-view",
+					views: ["plugins-page", "calendar"],
+					layout: "horizontal",
+				})),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message("split vertical instead") as never,
+			undefined,
+			undefined,
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			mode: "split",
+			viewIds: ["plugins-page", "calendar"],
+			layout: "vertical",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/plugins-page/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "split-view",
+					views: ["plugins-page", "calendar"],
+					layout: "vertical",
+				}),
+			}),
+		);
+	});
+
+	it("reuses current split views when planner supplies a filtered view type", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const listViews = vi.fn(async (options?: { viewType?: string }) =>
+			options?.viewType === "tui"
+				? []
+				: [
+						view({
+							id: "plugins-page",
+							label: "Plugins",
+							path: "/apps/plugins",
+						}),
+						view({ id: "calendar", label: "Calendar", path: "/calendar" }),
+					],
+		);
+		const action = createViewsAction({
+			client: {
+				listViews,
+				getCurrentView: vi.fn(async () => ({
+					viewId: "plugins-page",
+					viewLabel: "Plugins",
+					viewPath: "/apps/plugins",
+					viewType: "gui",
+					action: "split-view",
+					views: ["plugins-page", "calendar"],
+					layout: "horizontal",
+				})),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message("split vertical instead") as never,
+			undefined,
+			{
+				action: "split",
+				layout: "vertical",
+				viewType: "tui",
+			},
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			mode: "split",
+			viewIds: ["plugins-page", "calendar"],
+			layout: "vertical",
+		});
+		expect(listViews).toHaveBeenCalledWith({ viewType: "tui" });
+		expect(listViews).toHaveBeenCalledWith();
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/plugins-page/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "split-view",
+					views: ["plugins-page", "calendar"],
+					layout: "vertical",
+				}),
+			}),
+		);
+	});
+
+	it("places a single current view without retrying split failures", async () => {
+		const { runtime } = createRuntime();
+		const callback = vi.fn();
+		const action = createViewsAction({
+			client: {
+				listViews: vi.fn(async () => [
+					view({ id: "notes", label: "Notes", path: "/notes" }),
+				]),
+				getCurrentView: vi.fn(async () => ({
+					viewId: "notes",
+					viewLabel: "Notes",
+					viewPath: "/notes",
+					viewType: "gui",
+				})),
+			},
+			hasOwnerAccess: vi.fn(async () => true),
+		});
+
+		vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			json: async () => ({ ok: true }),
+		} as Response);
+
+		const result = await action.handler(
+			runtime as never,
+			message("i want notes to be on left of screen") as never,
+			undefined,
+			{ action: "create" },
+			callback,
+		);
+
+		expect(result?.success).toBe(true);
+		expect(result?.values).toMatchObject({
+			mode: "split",
+			viewIds: ["notes"],
+			layout: "horizontal",
+			placement: "left",
+		});
+		expect(globalThis.fetch).toHaveBeenCalledWith(
+			"http://127.0.0.1:3456/api/views/notes/navigate",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					action: "split-view",
+					views: ["notes"],
+					layout: "horizontal",
+					placement: "left",
+				}),
+			}),
+		);
+		expect(callback).toHaveBeenCalledWith(
+			expect.objectContaining({
+				text: "Placed Notes on the left.",
+			}),
+		);
 	});
 
 	it("treats explicit create cancel as terminal even if the pending task is gone", async () => {

--- a/plugins/plugin-app-control/src/actions/views-show.ts
+++ b/plugins/plugin-app-control/src/actions/views-show.ts
@@ -37,6 +37,7 @@ const FILLER_WORDS = new Set([
 	"app",
 	"page",
 	"please",
+	"pls",
 	"now",
 	"my",
 	"a",

--- a/plugins/plugin-app-control/src/actions/views.ts
+++ b/plugins/plugin-app-control/src/actions/views.ts
@@ -16,11 +16,16 @@ import type {
 	IAgentRuntime,
 	Memory,
 	State,
+	ViewCapability,
 	ViewType,
 } from "@elizaos/core";
 import { hasOwnerAccess as defaultOwnerAccessFn, logger } from "@elizaos/core";
 import { normalizeActionOptions, readStringOption } from "../params.js";
-import { createViewsClient, type ViewsClient } from "./views-client.js";
+import {
+	createViewsClient,
+	type ViewSummary,
+	type ViewsClient,
+} from "./views-client.js";
 import {
 	hasPendingViewsCreateIntent,
 	isChoiceReply,
@@ -34,7 +39,7 @@ import {
 } from "./views-delete.js";
 import { runViewsEdit } from "./views-edit.js";
 import { runViewsList } from "./views-list.js";
-import { runViewsSearch } from "./views-search.js";
+import { runViewsSearch, scoreView } from "./views-search.js";
 import { runViewsShow } from "./views-show.js";
 
 export type ViewsMode =
@@ -42,6 +47,7 @@ export type ViewsMode =
 	| "current"
 	| "show"
 	| "open"
+	| "close"
 	| "search"
 	| "manager"
 	| "broadcast"
@@ -51,13 +57,16 @@ export type ViewsMode =
 	| "delete"
 	| "remove"
 	| "pin"
-	| "window";
+	| "window"
+	| "split"
+	| "tile";
 
 const MODES: readonly ViewsMode[] = [
 	"list",
 	"current",
 	"show",
 	"open",
+	"close",
 	"search",
 	"manager",
 	"broadcast",
@@ -68,6 +77,49 @@ const MODES: readonly ViewsMode[] = [
 	"remove",
 	"pin",
 	"window",
+	"split",
+	"tile",
+] as const;
+
+const VIEW_ACTION_CONTEXTS = [
+	"simple",
+	"general",
+	"memory",
+	"documents",
+	"knowledge",
+	"research",
+	"web",
+	"browser",
+	"code",
+	"files",
+	"terminal",
+	"email",
+	"calendar",
+	"contacts",
+	"tasks",
+	"todos",
+	"productivity",
+	"health",
+	"screen_time",
+	"subscriptions",
+	"finance",
+	"payments",
+	"wallet",
+	"crypto",
+	"messaging",
+	"phone",
+	"social",
+	"social_posting",
+	"media",
+	"automation",
+	"connectors",
+	"settings",
+	"character",
+	"secrets",
+	"admin",
+	"state",
+	"world",
+	"game",
 ] as const;
 
 // Intent regexes — order matters: more specific first.
@@ -88,6 +140,9 @@ const SHOW_APPS_VERBS =
 	/\b(show|open|go to|navigate to)\b\s+(?:the\s+)?(?:apps?|app page|apps page)\b/i;
 const CLOSE_VERBS =
 	/\b(close|dismiss|hide|exit|quit)\b.{0,40}\b(view|app|panel|window)\b/i;
+const CLOSE_ALL_VERBS =
+	/\b(close|dismiss|hide|exit|quit)\b.{0,30}\ball\b.{0,30}\b(views?|apps?|panels?|windows?|tabs?)\b/i;
+const CLOSE_PREFIX_VERBS = /^\s*(close|dismiss|hide|exit|quit)\b/i;
 const SHOW_VERBS =
 	/\b(show|open|navigate to|go to|switch to|launch|display|bring up|pull up)\b/i;
 const VIEW_NOUN = /\bview[s]?\b/i;
@@ -105,11 +160,58 @@ const PIN_VERBS =
 	/\b(pin|pin as tab|add.*tab|pin.*desktop|keep.*tab|dock)\b.{0,40}\bview\b/i;
 const WINDOW_VERBS =
 	/\b(open in.*window|new window|separate window|pop.?out|detach)\b.{0,40}\bview\b|\bview\b.{0,40}\b(new window|separate window|pop.?out|detach)\b/i;
+const SPLIT_VERBS =
+	/\b(split|side.?by.?side|next to|beside|alongside|left|right|top|bottom)\b.{0,80}\b(views?|apps?|panels?|windows?|tabs?)\b|\b(views?|apps?|panels?|windows?|tabs?)\b.{0,80}\b(split|side.?by.?side|next to|beside|alongside|left|right|top|bottom)\b/i;
+const TILE_VERBS =
+	/\b(tile|grid|arrange|layout)\b.{0,80}\b(views?|apps?|panels?|windows?|tabs?)\b|\b(views?|apps?|panels?|windows?|tabs?)\b.{0,80}\b(tile|grid|arrange|layout)\b/i;
+const LAYOUT_OVERRIDE_MODES = new Set([
+	"create",
+	"delete",
+	"edit",
+	"list",
+	"open",
+	"remove",
+	"show",
+]);
+const VIEW_SURFACE_TOKENS = new Set([
+	"app",
+	"apps",
+	"desktop",
+	"manager",
+	"panel",
+	"panels",
+	"screen",
+	"screens",
+	"tab",
+	"tabs",
+	"ui",
+	"view",
+	"views",
+	"window",
+	"windows",
+]);
+const USER_REQUEST_OPEN_TAG = "<user_request>";
+const USER_REQUEST_CLOSE_TAG = "</user_request>";
+
+function extractUserRequestText(text: string): string | null {
+	const start = text.lastIndexOf(USER_REQUEST_OPEN_TAG);
+	if (start < 0) return null;
+	const contentStart = start + USER_REQUEST_OPEN_TAG.length;
+	const end = text.indexOf(USER_REQUEST_CLOSE_TAG, contentStart);
+	if (end < 0) return null;
+	const value = text.slice(contentStart, end).trim();
+	return value.length > 0 ? value : null;
+}
+
+function viewRequestText(text: string): string {
+	return extractUserRequestText(text) ?? text;
+}
 
 function readViewTypeOption(
 	text: string,
 	options?: Record<string, unknown>,
 ): ViewType | undefined {
+	const requestText = viewRequestText(text);
 	const explicit =
 		readStringOption(options, "viewType") ??
 		readStringOption(options, "type") ??
@@ -124,9 +226,9 @@ function readViewTypeOption(
 	)
 		return "xr";
 
-	if (/\b(tui|terminal)\b/i.test(text)) return "tui";
-	if (/\b(xr|spatial|immersive)\b/i.test(text)) return "xr";
-	if (/\b(gui|graphical)\b/i.test(text)) return "gui";
+	if (/\b(tui|terminal)\b/i.test(requestText)) return "tui";
+	if (/\b(xr|spatial|immersive)\b/i.test(requestText)) return "xr";
+	if (/\b(gui|graphical)\b/i.test(requestText)) return "gui";
 	return undefined;
 }
 
@@ -193,31 +295,208 @@ function inferMode(
 ): ViewsMode | null {
 	const explicit =
 		readStringOption(options, "action") ?? readStringOption(options, "mode");
-	if (explicit && (MODES as readonly string[]).includes(explicit)) {
-		return explicit as ViewsMode;
+	const trimmed = viewRequestText(text).trim();
+	const normalizedExplicit = explicit?.trim().toLowerCase().replace(/-/g, "_");
+	if (
+		normalizedExplicit === "close" ||
+		normalizedExplicit === "close_view" ||
+		normalizedExplicit === "close_all" ||
+		normalizedExplicit === "close_all_views"
+	) {
+		return "close";
+	}
+	if (
+		normalizedExplicit === "split" ||
+		normalizedExplicit === "split_view" ||
+		normalizedExplicit === "split_views"
+	) {
+		if (isTileLayoutRequest(trimmed) && !isSplitLayoutRequest(trimmed)) {
+			return "tile";
+		}
+		return "split";
+	}
+	if (
+		(normalizedExplicit === "tile" ||
+			normalizedExplicit === "tile_view" ||
+			normalizedExplicit === "tile_views") &&
+		isSplitLayoutRequest(trimmed) &&
+		!isTileLayoutRequest(trimmed)
+	) {
+		return "split";
+	}
+	if (
+		normalizedExplicit === "tile" ||
+		normalizedExplicit === "tile_view" ||
+		normalizedExplicit === "tile_views"
+	) {
+		return "tile";
+	}
+	if (isNonDestructiveCloseRequest(trimmed)) {
+		return "close";
+	}
+	if (
+		(normalizedExplicit === "delete" || normalizedExplicit === "remove") &&
+		isNonDestructiveCloseRequest(trimmed) &&
+		!DELETE_VERBS_RE.test(trimmed)
+	) {
+		return "close";
+	}
+	if (normalizedExplicit && isGenericViewNavigationMode(normalizedExplicit)) {
+		if (isPinRequest(trimmed)) return "pin";
+		if (isWindowRequest(trimmed)) return "window";
+		if (isTileLayoutRequest(trimmed)) return "tile";
+		if (isSplitLayoutRequest(trimmed)) return "split";
+	}
+	if (
+		normalizedExplicit &&
+		!(MODES as readonly string[]).includes(normalizedExplicit)
+	) {
+		return "interact";
+	}
+	if (
+		normalizedExplicit &&
+		(MODES as readonly string[]).includes(normalizedExplicit)
+	) {
+		if (LAYOUT_OVERRIDE_MODES.has(normalizedExplicit)) {
+			if (isPinRequest(trimmed)) return "pin";
+			if (isWindowRequest(trimmed)) return "window";
+			if (isTileLayoutRequest(trimmed)) return "tile";
+			if (isSplitLayoutRequest(trimmed)) return "split";
+		}
+		return normalizedExplicit as ViewsMode;
 	}
 
-	const trimmed = text.trim();
 	if (!trimmed) return null;
 
 	if (DELETE_VERBS_RE.test(trimmed)) return "delete";
 	if (CREATE_VERBS.test(trimmed)) return "create";
 	if (EDIT_VERBS_RE.test(trimmed)) return "edit";
-	if (PIN_VERBS.test(trimmed)) return "pin";
-	if (WINDOW_VERBS.test(trimmed)) return "window";
+	if (isPinRequest(trimmed) || PIN_VERBS.test(trimmed)) return "pin";
+	if (isWindowRequest(trimmed) || WINDOW_VERBS.test(trimmed)) return "window";
+	if (isTileLayoutRequest(trimmed)) return "tile";
+	if (isSplitLayoutRequest(trimmed)) return "split";
 	if (INTERACT_VERBS.test(trimmed)) return "interact";
 	if (BROADCAST_VERBS.test(trimmed)) return "broadcast";
 	if (MANAGER_VERBS.test(trimmed)) return "manager";
 	if (SHOW_ALL_VIEWS_MANAGER.test(trimmed)) return "manager";
 	if (SHOW_APPS_VERBS.test(trimmed)) return "manager";
-	if (CLOSE_VERBS.test(trimmed)) return "manager";
+	if (CLOSE_VERBS.test(trimmed)) return "close";
+	if (CLOSE_PREFIX_VERBS.test(trimmed)) return "close";
 	if (SEARCH_VERBS.test(trimmed)) return "search";
 	if (CURRENT_VIEW_VERBS.test(trimmed)) return "current";
 	if (WHAT_VIEWS_VERB.test(trimmed)) return "list";
 	if (LIST_VERBS.test(trimmed) && VIEW_NOUN.test(trimmed)) return "list";
 	if (SHOW_VERBS.test(trimmed) && VIEW_NOUN.test(trimmed)) return "show";
+	if (
+		/^\s*(show|open|navigate to|go to|switch to|launch|display|bring up|pull up)\b/i.test(
+			trimmed,
+		)
+	)
+		return "show";
 
 	return null;
+}
+
+function isGenericViewNavigationMode(normalizedExplicit: string): boolean {
+	return (
+		normalizedExplicit === "open" ||
+		normalizedExplicit === "show" ||
+		normalizedExplicit === "view" ||
+		normalizedExplicit === "open_view" ||
+		normalizedExplicit === "show_view" ||
+		normalizedExplicit === "navigate" ||
+		normalizedExplicit === "navigate_to_view" ||
+		normalizedExplicit === "go_to_view" ||
+		normalizedExplicit === "switch" ||
+		normalizedExplicit === "switch_view"
+	);
+}
+
+function isTileLayoutRequest(text: string): boolean {
+	return (
+		TILE_VERBS.test(text) || /^\s*(tile|grid|arrange|layout)\b/i.test(text)
+	);
+}
+
+function isSplitLayoutRequest(text: string): boolean {
+	return (
+		SPLIT_VERBS.test(text) ||
+		/^\s*(split|side.?by.?side|next to|beside|alongside)\b/i.test(text) ||
+		/\b(?:left|right|top|bottom)\b.{0,60}\b(?:screen|side|pane|panel|window|layout)\b/i.test(
+			text,
+		) ||
+		/\b(?:on|to|at)\s+(?:the\s+)?(?:left|right|top|bottom)\b/i.test(text)
+	);
+}
+
+function normalizedWordSet(text: string): Set<string> {
+	return new Set(
+		normalizeLooseTerm(text)
+			.split(" ")
+			.map((token) => token.trim())
+			.filter(Boolean),
+	);
+}
+
+function hasAnyToken(tokens: ReadonlySet<string>, values: readonly string[]) {
+	return values.some((value) => tokens.has(value));
+}
+
+function mentionsViewSurface(tokens: ReadonlySet<string>): boolean {
+	for (const token of tokens) {
+		if (VIEW_SURFACE_TOKENS.has(token)) return true;
+	}
+	return false;
+}
+
+function isPinRequest(text: string): boolean {
+	const tokens = normalizedWordSet(text);
+	return hasAnyToken(tokens, ["dock", "pin"]) && mentionsViewSurface(tokens);
+}
+
+function isWindowRequest(text: string): boolean {
+	const tokens = normalizedWordSet(text);
+	const hasWindowIntent =
+		hasAnyToken(tokens, ["detach", "popout", "window", "windows"]) ||
+		(tokens.has("pop") && tokens.has("out"));
+	if (!hasWindowIntent) return false;
+	return (
+		hasAnyToken(tokens, [
+			"detach",
+			"display",
+			"launch",
+			"new",
+			"open",
+			"pop",
+			"popout",
+			"separate",
+			"show",
+			"window",
+			"windows",
+		]) && mentionsViewSurface(tokens)
+	);
+}
+
+function isLikelyViewContentOperation(text: string): boolean {
+	if (/\b(views?|apps?|panels?|windows?|tabs?|screen|layout)\b/i.test(text)) {
+		return false;
+	}
+	return (
+		/\b(add|create|make|new|delete|remove|edit|update|show|list|get|read)\b/i.test(
+			text,
+		) &&
+		/\b(notes?|events?|tasks?|todos?|records?|items?|entries?|reminders?)\b/i.test(
+			text,
+		)
+	);
+}
+
+function isNonDestructiveCloseRequest(text: string): boolean {
+	return (
+		CLOSE_ALL_VERBS.test(text) ||
+		CLOSE_VERBS.test(text) ||
+		CLOSE_PREFIX_VERBS.test(text)
+	);
 }
 
 function extractSearchQuery(
@@ -235,6 +514,1234 @@ function extractSearchQuery(
 	return match?.[1]?.trim() ?? text.trim();
 }
 
+const CLOSE_TARGET_VERBS = ["close", "dismiss", "hide", "exit", "quit"];
+const CLOSE_TARGET_FILLER = new Set([
+	"the",
+	"view",
+	"app",
+	"panel",
+	"window",
+	"tab",
+	"please",
+	"pls",
+	"now",
+]);
+
+function readViewTargetOption(
+	options?: Record<string, unknown>,
+): string | null {
+	return (
+		readStringOption(options, "view") ??
+		readStringOption(options, "viewId") ??
+		readStringOption(options, "id") ??
+		readStringOption(options, "name") ??
+		readStringOption(options, "target")
+	);
+}
+
+const CAPABILITY_PARAM_RESERVED_KEYS = new Set([
+	"action",
+	"mode",
+	"view",
+	"viewId",
+	"id",
+	"name",
+	"target",
+	"views",
+	"viewIds",
+	"targets",
+	"layout",
+	"placement",
+	"query",
+	"search",
+	"viewType",
+	"capability",
+	"params",
+	"timeoutMs",
+	"eventType",
+	"event",
+	"type",
+	"payload",
+	"alwaysOnTop",
+	"intent",
+	"editTarget",
+	"choice",
+	"confirm",
+]);
+
+type ResolvedViewCapability = {
+	view: ViewSummary;
+	capability: ViewCapability;
+};
+
+type OperationFamily = "create" | "read" | "update" | "delete" | "select";
+
+const OPERATION_TOKEN_FAMILIES: Record<OperationFamily, Set<string>> = {
+	create: new Set(["create", "add", "new", "make", "build", "generate"]),
+	read: new Set([
+		"get",
+		"show",
+		"read",
+		"list",
+		"view",
+		"display",
+		"state",
+		"contents",
+		"current",
+	]),
+	update: new Set(["update", "edit", "change", "rename", "set", "modify"]),
+	delete: new Set(["delete", "remove", "clear", "destroy"]),
+	select: new Set(["select", "choose", "pick"]),
+};
+
+function normalizeCapabilityKey(value: string | null | undefined): string {
+	return (value ?? "")
+		.trim()
+		.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function tokensFor(value: string | null | undefined): Set<string> {
+	const normalized = normalizeCapabilityKey(value);
+	if (!normalized) return new Set();
+	return new Set(normalized.split(" ").filter(Boolean));
+}
+
+function operationFamilyForTokens(tokens: Set<string>): OperationFamily | null {
+	for (const [family, familyTokens] of Object.entries(
+		OPERATION_TOKEN_FAMILIES,
+	) as [OperationFamily, Set<string>][]) {
+		for (const token of tokens) {
+			if (familyTokens.has(token)) return family;
+		}
+	}
+	return null;
+}
+
+function operationFamilyForCapability(
+	capability: ViewCapability,
+): OperationFamily | null {
+	return operationFamilyForTokens(
+		tokensFor(`${capability.id} ${capability.description ?? ""}`),
+	);
+}
+
+function viewTokens(view: ViewSummary): Set<string> {
+	return tokensFor(
+		[view.id, view.label, view.description, ...(view.tags ?? [])].join(" "),
+	);
+}
+
+function capabilityTokens(capability: ViewCapability): Set<string> {
+	return tokensFor(
+		[
+			capability.id,
+			capability.description,
+			...Object.keys(capability.params ?? {}),
+		].join(" "),
+	);
+}
+
+function countIntersection(left: Set<string>, right: Set<string>): number {
+	let count = 0;
+	for (const value of left) {
+		if (right.has(value)) count++;
+	}
+	return count;
+}
+
+function capabilityCandidates(
+	views: readonly ViewSummary[],
+	viewType?: ViewType,
+): ResolvedViewCapability[] {
+	return views
+		.filter((view) => !viewType || !view.viewType || view.viewType === viewType)
+		.flatMap((view) =>
+			(view.capabilities ?? []).map((capability) => ({ view, capability })),
+		);
+}
+
+function resolveViewTarget(
+	target: string | null,
+	views: readonly ViewSummary[],
+): ViewSummary | null {
+	if (!target) return null;
+	const match = resolveCloseTargetView(target, views);
+	return match.kind === "match" ? match.view : null;
+}
+
+function isViewPluginAuthoringRequest(
+	mode: ViewsMode,
+	text: string,
+	options?: Record<string, unknown>,
+): boolean {
+	if (
+		mode !== "create" &&
+		mode !== "edit" &&
+		mode !== "delete" &&
+		mode !== "remove"
+	) {
+		return false;
+	}
+	if (
+		readStringOption(options, "editTarget") ||
+		readStringOption(options, "choice") ||
+		readStringOption(options, "confirm")
+	) {
+		return true;
+	}
+	if (hasExplicitViewCapabilityIntent(text, options)) {
+		return false;
+	}
+	const intent = readStringOption(options, "intent");
+	const source = `${text} ${intent ?? ""}`;
+	return /\b(view|views|plugin|plugins)\b/i.test(source);
+}
+
+function hasExplicitViewCapabilityIntent(
+	text: string,
+	options?: Record<string, unknown>,
+): boolean {
+	if (readStringOption(options, "capability")) return true;
+
+	const explicitAction =
+		readStringOption(options, "action") ?? readStringOption(options, "mode");
+	const actionIsMode =
+		!!explicitAction &&
+		(MODES as readonly string[]).includes(explicitAction.trim().toLowerCase());
+	if (explicitAction && !actionIsMode) return true;
+
+	const intent = readStringOption(options, "intent");
+	const source = `${text} ${intent ?? ""}`;
+	return /\b(capability|interact|invoke)\b/i.test(source);
+}
+
+function isViewNavigationRequest(
+	mode: ViewsMode,
+	text: string,
+	options?: Record<string, unknown>,
+): boolean {
+	const explicit =
+		readStringOption(options, "action") ?? readStringOption(options, "mode");
+	const source = `${text} ${explicit ?? ""}`;
+	if (mode === "open") return true;
+	if (
+		/\b(open|launch|switch to|go to|navigate to|pull up|bring up)\b/i.test(
+			source,
+		)
+	) {
+		return true;
+	}
+	if (
+		(mode === "show" || mode === "list") &&
+		/\b(view|views|app|apps|panel|panels|tab|tabs|window|windows)\b/i.test(
+			source,
+		)
+	) {
+		return true;
+	}
+	return false;
+}
+
+function shouldResolveModeAsCapability(
+	mode: ViewsMode,
+	text: string,
+	options?: Record<string, unknown>,
+): boolean {
+	if (isViewPluginAuthoringRequest(mode, text, options)) return false;
+	if (isViewNavigationRequest(mode, text, options)) return false;
+	return (
+		mode === "create" ||
+		mode === "edit" ||
+		mode === "delete" ||
+		mode === "remove" ||
+		mode === "show" ||
+		mode === "list"
+	);
+}
+
+function resolveViewCapability({
+	views,
+	text,
+	options,
+	viewType,
+	currentViewId,
+}: {
+	views: readonly ViewSummary[];
+	text: string;
+	options?: Record<string, unknown>;
+	viewType?: ViewType;
+	currentViewId?: string | null;
+}): ResolvedViewCapability | null {
+	const explicitCapability = readStringOption(options, "capability");
+	const explicitAction =
+		readStringOption(options, "action") ?? readStringOption(options, "mode");
+	const actionIsMode =
+		!!explicitAction &&
+		(MODES as readonly string[]).includes(explicitAction.trim().toLowerCase());
+	const actionToken = actionIsMode ? null : explicitAction;
+	const requestedView = resolveViewTarget(readViewTargetOption(options), views);
+	const currentView = views.find((view) => view.id === currentViewId) ?? null;
+	const candidates = capabilityCandidates(views, viewType);
+
+	if (explicitCapability) {
+		const normalized = normalizeCapabilityKey(explicitCapability);
+		const exactCandidates = candidates.filter(
+			(candidate) =>
+				normalizeCapabilityKey(candidate.capability.id) === normalized &&
+				(!requestedView || candidate.view.id === requestedView.id),
+		);
+		if (requestedView && exactCandidates[0]) return exactCandidates[0];
+		const currentExact = exactCandidates.find(
+			(candidate) => candidate.view.id === currentView?.id,
+		);
+		if (currentExact) return currentExact;
+		if (exactCandidates.length === 1) return exactCandidates[0];
+	}
+
+	const sourceText = [actionToken ?? text, explicitCapability]
+		.filter(Boolean)
+		.join(" ");
+	const sourceTokens = tokensFor(sourceText);
+	const sourceOperation = operationFamilyForTokens(sourceTokens);
+	let best: { candidate: ResolvedViewCapability; score: number } | null = null;
+
+	for (const candidate of candidates) {
+		const vTokens = viewTokens(candidate.view);
+		const cTokens = capabilityTokens(candidate.capability);
+		const capOperation = operationFamilyForCapability(candidate.capability);
+		if (
+			explicitCapability &&
+			sourceOperation &&
+			capOperation &&
+			capOperation !== sourceOperation
+		) {
+			continue;
+		}
+		const viewMatches =
+			requestedView?.id === candidate.view.id ||
+			countIntersection(sourceTokens, vTokens) > 0 ||
+			currentView?.id === candidate.view.id;
+		if (!viewMatches) continue;
+
+		let score = 0;
+		if (requestedView?.id === candidate.view.id) score += 5;
+		if (currentViewId === candidate.view.id) score += 2;
+		score += countIntersection(sourceTokens, vTokens) * 2;
+		score += countIntersection(sourceTokens, cTokens);
+		if (sourceOperation && capOperation === sourceOperation) score += 4;
+		if (
+			actionToken &&
+			normalizeCapabilityKey(actionToken) ===
+				normalizeCapabilityKey(candidate.capability.id)
+		) {
+			score += 8;
+		}
+		if (sourceTokens.size > 0) {
+			const combined = new Set([...vTokens, ...cTokens]);
+			if ([...sourceTokens].every((token) => combined.has(token))) {
+				score += 3;
+			}
+		}
+
+		if (score >= 5 && (!best || score > best.score)) {
+			best = { candidate, score };
+		}
+	}
+
+	return best?.candidate ?? null;
+}
+
+function readCapabilityParams(
+	options: Record<string, unknown> | undefined,
+	capability?: ViewCapability | null,
+	resolvedView?: ViewSummary | null,
+	messageText?: string,
+): Record<string, unknown> | undefined {
+	const params: Record<string, unknown> = {};
+	const capabilityParamKeys = new Set(Object.keys(capability?.params ?? {}));
+	const nested = options?.params;
+	if (nested && typeof nested === "object" && !Array.isArray(nested)) {
+		Object.assign(params, nested);
+	}
+
+	for (const [key, value] of Object.entries(options ?? {})) {
+		if (key.startsWith("params.")) {
+			const paramKey = key.slice("params.".length).trim();
+			if (paramKey) params[paramKey] = value;
+			continue;
+		}
+		if (capabilityParamKeys.has(key)) {
+			params[key] = value;
+			continue;
+		}
+		if (!CAPABILITY_PARAM_RESERVED_KEYS.has(key)) {
+			params[key] = value;
+		}
+	}
+
+	const unresolvedTarget = readViewTargetOption(options);
+	const capabilityFamily = capability
+		? operationFamilyForCapability(capability)
+		: null;
+	if (
+		capabilityFamily !== "delete" &&
+		unresolvedTarget &&
+		!targetMatchesResolvedView(unresolvedTarget, resolvedView) &&
+		!params.title &&
+		capabilityParamKeys.has("title")
+	) {
+		params.title = unresolvedTarget;
+	} else if (
+		capabilityFamily !== "delete" &&
+		unresolvedTarget &&
+		!targetMatchesResolvedView(unresolvedTarget, resolvedView) &&
+		!params.name &&
+		capabilityParamKeys.has("name")
+	) {
+		params.name = unresolvedTarget;
+	}
+
+	const intent = readStringOption(options, "intent");
+	if (intent) {
+		Object.assign(
+			params,
+			deriveParamsFromIntent(intent, capabilityParamKeys, params),
+		);
+	}
+	if (messageText && capability) {
+		Object.assign(
+			params,
+			deriveParamsFromMessageText(
+				messageText,
+				capability,
+				capabilityParamKeys,
+				params,
+			),
+		);
+	}
+
+	for (const key of Object.keys(params)) {
+		if (
+			params[key] === undefined ||
+			params[key] === null ||
+			params[key] === ""
+		) {
+			delete params[key];
+		}
+	}
+
+	return Object.keys(params).length > 0 ? params : undefined;
+}
+
+function deriveParamsFromIntent(
+	intent: string,
+	capabilityParamKeys: Set<string>,
+	existing: Record<string, unknown>,
+): Record<string, unknown> {
+	const derived: Record<string, unknown> = {};
+	const trimmed = intent.trim();
+	if (!trimmed) return derived;
+
+	const title = extractIntentTitle(trimmed);
+	if (capabilityParamKeys.has("title") && !existing.title) {
+		derived.title = title ?? trimmed;
+	}
+	const body = extractIntentTextAfter(trimmed, ["body", "content"]);
+	if (capabilityParamKeys.has("body") && !existing.body && body) {
+		derived.body = body;
+	}
+	const notes = extractIntentTextAfter(trimmed, ["notes", "note"]);
+	if (capabilityParamKeys.has("notes") && !existing.notes && notes) {
+		derived.notes = notes;
+	}
+	const date = extractIsoDate(trimmed);
+	if (capabilityParamKeys.has("date") && !existing.date && date) {
+		derived.date = date;
+	}
+	const time = extractClockTime(trimmed);
+	if (capabilityParamKeys.has("time") && !existing.time && time) {
+		derived.time = time;
+	}
+
+	return derived;
+}
+
+function extractIntentTitle(intent: string): string | null {
+	const titled =
+		/\btitled?\s+["']?(.+?)(?:["']?\s+\b(?:with|on|at|for)\b|["']?$)/i.exec(
+			intent,
+		);
+	if (titled?.[1]?.trim()) {
+		return titled[1].trim();
+	}
+	const quoted = /["']([^"']{1,160})["']/.exec(intent);
+	return quoted?.[1]?.trim() ?? null;
+}
+
+function extractIntentTextAfter(
+	intent: string,
+	labels: readonly string[],
+): string | null {
+	for (const label of labels) {
+		const match = new RegExp(`\\b(?:with\\s+)?${label}\\s+(.+)$`, "i").exec(
+			intent,
+		);
+		if (match?.[1]?.trim()) return match[1].trim();
+	}
+	return null;
+}
+
+function deriveParamsFromMessageText(
+	text: string,
+	capability: ViewCapability,
+	capabilityParamKeys: Set<string>,
+	existing: Record<string, unknown>,
+): Record<string, unknown> {
+	const derived: Record<string, unknown> = {};
+	const trimmed = text.trim();
+	if (!trimmed) return derived;
+
+	const family = operationFamilyForCapability(capability);
+	if (family === "create") {
+		const body = extractIntentTextAfter(trimmed, [
+			"body",
+			"content",
+			"saying",
+			"says",
+			"say",
+		]);
+		if (capabilityParamKeys.has("body") && !existing.body && body) {
+			derived.body = body;
+		}
+		const title = extractIntentTitle(trimmed);
+		if (capabilityParamKeys.has("title") && !existing.title && title) {
+			derived.title = title;
+		}
+	}
+
+	if (family === "delete") {
+		if (existing.id || existing.query || existing.title || existing.name) {
+			return derived;
+		}
+		const target = extractDeleteTargetText(trimmed);
+		if (target) {
+			if (capabilityParamKeys.has("query")) {
+				derived.query = target;
+			} else if (capabilityParamKeys.has("title")) {
+				derived.title = target;
+			} else if (capabilityParamKeys.has("name")) {
+				derived.name = target;
+			}
+		}
+	}
+
+	return derived;
+}
+
+function extractDeleteTargetText(text: string): string | null {
+	const match =
+		/\b(?:delete|remove|drop|destroy)\s+(?:the\s+)?(.+?)(?:\s+(?:note|notes|event|events|record|records|item|items))?\s*$/i.exec(
+			text,
+		);
+	const target = match?.[1]?.trim();
+	if (!target) return null;
+	const cleaned = target
+		.replace(/\b(?:sticky|calendar)\b/gi, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+	return cleaned.length > 0 ? cleaned : null;
+}
+
+function extractIsoDate(intent: string): string | null {
+	return /\b(\d{4}-\d{2}-\d{2})\b/.exec(intent)?.[1] ?? null;
+}
+
+function extractClockTime(intent: string): string | null {
+	return /\b(?:at|time)\s+(\d{1,2}:\d{2})\b/i.exec(intent)?.[1] ?? null;
+}
+
+function targetMatchesResolvedView(
+	target: string,
+	resolvedView?: ViewSummary | null,
+): boolean {
+	const normalizedTarget = normalizeCapabilityKey(target);
+	return !!(
+		resolvedView &&
+		(normalizeCapabilityKey(resolvedView.id) === normalizedTarget ||
+			normalizeCapabilityKey(resolvedView.label) === normalizedTarget)
+	);
+}
+
+function isCloseAllRequest(
+	text: string,
+	options?: Record<string, unknown>,
+): boolean {
+	const requestText = viewRequestText(text);
+	const explicit = readViewTargetOption(options)?.trim().toLowerCase();
+	return (
+		readBooleanOption(options, "all") ||
+		explicit === "all" ||
+		explicit === "__all__" ||
+		CLOSE_ALL_VERBS.test(requestText)
+	);
+}
+
+function extractCloseTarget(
+	text: string,
+	options?: Record<string, unknown>,
+): string | null {
+	const explicit = readViewTargetOption(options);
+	if (explicit) return explicit;
+
+	const requestText = viewRequestText(text);
+	const lower = requestText.toLowerCase();
+	for (const verb of CLOSE_TARGET_VERBS) {
+		const idx = lower.indexOf(verb);
+		if (idx === -1) continue;
+		const rest = requestText.slice(idx + verb.length).trim();
+		if (!rest) continue;
+		const tokens = rest
+			.split(/[\s,!.?]+/)
+			.map((token) => token.trim())
+			.filter((token) => token.length > 0);
+		let start = 0;
+		while (
+			start < tokens.length &&
+			CLOSE_TARGET_FILLER.has(tokens[start].toLowerCase())
+		) {
+			start++;
+		}
+		let end = tokens.length;
+		while (
+			end > start &&
+			CLOSE_TARGET_FILLER.has(tokens[end - 1].toLowerCase())
+		) {
+			end--;
+		}
+		const candidate = tokens.slice(start, end).join(" ").toLowerCase();
+		if (
+			candidate &&
+			candidate !== "all" &&
+			candidate !== "current" &&
+			!CLOSE_TARGET_FILLER.has(candidate)
+		) {
+			return candidate;
+		}
+	}
+
+	return null;
+}
+
+function resolveCloseTargetView(
+	target: string,
+	views: readonly ViewSummary[],
+):
+	| { kind: "match"; view: ViewSummary }
+	| { kind: "ambiguous"; candidates: ViewSummary[] }
+	| { kind: "none" } {
+	const q = target.toLowerCase();
+	const byId = views.find((view) => view.id.toLowerCase() === q);
+	if (byId) return { kind: "match", view: byId };
+
+	const byLabel = views.find((view) => view.label.toLowerCase() === q);
+	if (byLabel) return { kind: "match", view: byLabel };
+
+	const normalizedTarget = normalizeLooseTerm(target);
+	const byLooseId = views.find(
+		(view) => normalizeLooseTerm(view.id) === normalizedTarget,
+	);
+	if (byLooseId) return { kind: "match", view: byLooseId };
+
+	const byLooseLabel = views.find(
+		(view) => normalizeLooseTerm(view.label) === normalizedTarget,
+	);
+	if (byLooseLabel) return { kind: "match", view: byLooseLabel };
+
+	const byTag = views.find((view) =>
+		(view.tags ?? []).some(
+			(tag) =>
+				tag.toLowerCase() === q || normalizeLooseTerm(tag) === normalizedTarget,
+		),
+	);
+	if (byTag) return { kind: "match", view: byTag };
+
+	const scored = views
+		.map((view) => ({ view, score: scoreView(view, target) }))
+		.filter(({ score }) => score > 0)
+		.sort((a, b) => b.score - a.score);
+	if (scored.length === 0) return { kind: "none" };
+	if (scored.length === 1) return { kind: "match", view: scored[0].view };
+
+	const topScore = scored[0].score;
+	const topTied = scored.filter(({ score }) => score === topScore);
+	if (topTied.length === 1) return { kind: "match", view: topTied[0].view };
+
+	return { kind: "ambiguous", candidates: topTied.map(({ view }) => view) };
+}
+
+function uniqueStrings(values: Iterable<string>): string[] {
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const value of values) {
+		const trimmed = value.trim();
+		if (!trimmed) continue;
+		const key = trimmed.toLowerCase();
+		if (seen.has(key)) continue;
+		seen.add(key);
+		out.push(trimmed);
+	}
+	return out;
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function normalizeLooseTerm(value: string): string {
+	return value
+		.toLowerCase()
+		.replace(/[-_./]+/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function textMentionsTerm(normalizedText: string, term: string): boolean {
+	const normalizedTerm = normalizeLooseTerm(term);
+	if (normalizedTerm.length < 3) return false;
+	const re = new RegExp(`(?:^|\\W)${escapeRegExp(normalizedTerm)}(?:\\W|$)`);
+	return re.test(normalizedText);
+}
+
+function readStringListOption(
+	options: Record<string, unknown> | undefined,
+	key: string,
+): string[] {
+	const value = options?.[key];
+	if (Array.isArray(value)) {
+		return uniqueStrings(
+			value.filter((item): item is string => typeof item === "string"),
+		);
+	}
+	if (typeof value !== "string") return [];
+	return uniqueStrings(value.split(/[,|]/));
+}
+
+function readLayoutTargetsFromOptions(
+	options?: Record<string, unknown>,
+): string[] {
+	const singleValueKeys = [
+		"view",
+		"id",
+		"name",
+		"target",
+		"withView",
+		"secondaryView",
+	];
+	return uniqueStrings([
+		...readStringListOption(options, "views"),
+		...readStringListOption(options, "viewIds"),
+		...readStringListOption(options, "targets"),
+		...singleValueKeys
+			.map((key) => readStringOption(options, key))
+			.filter((value): value is string => typeof value === "string"),
+	]);
+}
+
+function hasCapabilityPayloadOptions(
+	options?: Record<string, unknown>,
+): boolean {
+	for (const [key, value] of Object.entries(options ?? {})) {
+		if (value === undefined || value === null || value === "") continue;
+		if (
+			key === "params" &&
+			typeof value === "object" &&
+			!Array.isArray(value) &&
+			Object.keys(value).length > 0
+		) {
+			return true;
+		}
+		if (key.startsWith("params.")) return true;
+		if (!CAPABILITY_PARAM_RESERVED_KEYS.has(key)) return true;
+	}
+	return false;
+}
+
+function preferLayoutModeOverCapability({
+	text,
+	options,
+	views,
+}: {
+	text: string;
+	options?: Record<string, unknown>;
+	views: readonly ViewSummary[];
+}): "split" | "tile" | null {
+	const trimmed = viewRequestText(text).trim();
+	if (!trimmed || hasCapabilityPayloadOptions(options)) return null;
+
+	const mode = isTileLayoutRequest(trimmed)
+		? "tile"
+		: isSplitLayoutRequest(trimmed)
+			? "split"
+			: null;
+	if (!mode) return null;
+	if (isLikelyViewContentOperation(trimmed)) return null;
+
+	const targets = resolveLayoutTargets(trimmed, options, views);
+	return targets.length > 0 ? mode : null;
+}
+
+function resolveLayoutTargets(
+	text: string,
+	options: Record<string, unknown> | undefined,
+	views: readonly ViewSummary[],
+): ViewSummary[] {
+	const explicit = readLayoutTargetsFromOptions(options);
+	const explicitResolved: ViewSummary[] = [];
+	for (const target of explicit) {
+		const match = resolveCloseTargetView(target, views);
+		if (match.kind === "match") explicitResolved.push(match.view);
+	}
+
+	const requestText = viewRequestText(text);
+	const lower = requestText.toLowerCase();
+	const normalizedText = normalizeLooseTerm(requestText);
+	const textResolved: ViewSummary[] = [];
+	for (const view of views) {
+		const id = view.id.toLowerCase();
+		const label = view.label.toLowerCase();
+		const normalizedLabel = normalizeLooseTerm(label);
+		const labelIsGenericSurface = VIEW_SURFACE_TOKENS.has(normalizedLabel);
+		const terms = [
+			id,
+			...(labelIsGenericSurface ? [] : [label]),
+			...(view.tags ?? []).filter(
+				(tag) => !VIEW_SURFACE_TOKENS.has(normalizeLooseTerm(tag)),
+			),
+		];
+		if (
+			lower.includes(id) ||
+			(!labelIsGenericSurface && label.length >= 3 && lower.includes(label)) ||
+			terms.some((term) => textMentionsTerm(normalizedText, term))
+		) {
+			textResolved.push(view);
+		}
+	}
+
+	const explicitUnique = uniqueByViewId(explicitResolved);
+	const textUnique = uniqueByViewId(textResolved);
+	return textUnique.length >= 2
+		? textUnique
+		: textUnique.length === 1 && explicitUnique.length <= 1
+			? textUnique
+			: uniqueByViewId([...explicitUnique, ...textUnique]);
+}
+
+function isLayoutOnlyFollowupRequest(
+	text: string,
+	views: readonly ViewSummary[],
+): boolean {
+	const requestText = viewRequestText(text).trim();
+	if (!requestText) return false;
+	if (resolveLayoutTargets(requestText, undefined, views).length > 0)
+		return false;
+	return /\b(instead|again|horizontal|vertical|row|column|stack|side.?by.?side|left-right|top-bottom)\b/i.test(
+		requestText,
+	);
+}
+
+async function resolveSingleShellTargetView({
+	client,
+	text,
+	options,
+	viewType,
+}: {
+	client: ViewsClient;
+	text: string;
+	options?: Record<string, unknown>;
+	viewType?: ViewType;
+}): Promise<
+	| { kind: "match"; view: ViewSummary }
+	| { kind: "ambiguous"; candidates: ViewSummary[] }
+	| { kind: "none" }
+> {
+	const requestText = viewRequestText(text);
+	const explicit = readViewTargetOption(options)?.trim();
+	if (
+		explicit?.toLowerCase() === "current" ||
+		(!explicit && /\bcurrent\b/i.test(requestText))
+	) {
+		const currentView = await client.getCurrentView().catch(() => null);
+		if (!currentView?.viewId) return { kind: "none" };
+		return {
+			kind: "match",
+			view: {
+				id: currentView.viewId,
+				label: currentView.viewLabel ?? currentView.viewId,
+				available: true,
+				pluginName: "current",
+				viewType: currentView.viewType ?? viewType ?? "gui",
+				...(currentView.viewPath ? { path: currentView.viewPath } : {}),
+			},
+		};
+	}
+
+	const views = await client.listViews({ viewType });
+	if (explicit) return resolveCloseTargetView(explicit, views);
+
+	const targets = resolveLayoutTargets(requestText, undefined, views);
+	if (targets.length === 1) return { kind: "match", view: targets[0] };
+	if (targets.length > 1) return { kind: "ambiguous", candidates: targets };
+	return { kind: "none" };
+}
+
+function uniqueByViewId(views: readonly ViewSummary[]): ViewSummary[] {
+	const byId = new Map<string, ViewSummary>();
+	for (const view of views) byId.set(view.id, view);
+	return [...byId.values()];
+}
+
+function readLayoutValue(
+	text: string,
+	options?: Record<string, unknown>,
+): "horizontal" | "vertical" | "grid" {
+	const requestText = viewRequestText(text);
+	const explicit =
+		readStringOption(options, "layout") ??
+		readStringOption(options, "orientation") ??
+		readStringOption(options, "direction");
+	const value = explicit?.trim().toLowerCase();
+	if (
+		value === "horizontal" ||
+		value === "left-right" ||
+		value === "row" ||
+		value === "side-by-side"
+	)
+		return "horizontal";
+	if (
+		value === "vertical" ||
+		value === "top-bottom" ||
+		value === "column" ||
+		value === "stack"
+	)
+		return "vertical";
+	if (value === "grid" || value === "tile" || value === "tiled") return "grid";
+
+	if (/\b(left|right|horizontal|side.?by.?side)\b/i.test(requestText)) {
+		return "horizontal";
+	}
+	if (/\b(next to|beside|alongside)\b/i.test(requestText)) return "horizontal";
+	if (/\b(top|bottom|vertical|stack)\b/i.test(requestText)) return "vertical";
+	return "grid";
+}
+
+function readPlacementValue(
+	text: string,
+	options?: Record<string, unknown>,
+): "left" | "right" | "top" | "bottom" | undefined {
+	const requestText = viewRequestText(text);
+	const explicit = readStringOption(options, "placement")?.trim().toLowerCase();
+	if (
+		explicit === "left" ||
+		explicit === "right" ||
+		explicit === "top" ||
+		explicit === "bottom"
+	) {
+		return explicit;
+	}
+	const match = /\b(left|right|top|bottom)\b/i.exec(requestText);
+	const value = match?.[1]?.toLowerCase();
+	if (
+		value === "left" ||
+		value === "right" ||
+		value === "top" ||
+		value === "bottom"
+	) {
+		return value;
+	}
+	return undefined;
+}
+
+function layoutForPlacement(
+	placement?: "left" | "right" | "top" | "bottom",
+): "horizontal" | "vertical" | undefined {
+	if (placement === "left" || placement === "right") return "horizontal";
+	if (placement === "top" || placement === "bottom") return "vertical";
+	return undefined;
+}
+
+async function completeSplitTargetsWithCurrentView({
+	client,
+	targets,
+	views,
+	placement,
+}: {
+	client: ViewsClient;
+	targets: ViewSummary[];
+	views: readonly ViewSummary[];
+	placement?: "left" | "right" | "top" | "bottom";
+}): Promise<ViewSummary[]> {
+	if (targets.length !== 1) return targets;
+	const currentView = await client.getCurrentView().catch(() => null);
+	const currentId = currentView?.viewId;
+	if (!currentId || currentId === targets[0].id) return targets;
+	const currentSummary = views.find((view) => view.id === currentId);
+	if (!currentSummary) return targets;
+
+	if (placement === "left" || placement === "top") {
+		return [targets[0], currentSummary];
+	}
+	return [currentSummary, targets[0]];
+}
+
+async function completeSplitTargetsFromCurrentLayout({
+	client,
+	targets,
+	views,
+	preferCurrentLayout,
+}: {
+	client: ViewsClient;
+	targets: ViewSummary[];
+	views: readonly ViewSummary[];
+	preferCurrentLayout?: boolean;
+}): Promise<ViewSummary[]> {
+	const currentView = await client.getCurrentView().catch(() => null);
+	const currentLayoutIds = currentView?.views ?? [];
+	const byId = new Map(views.map((view) => [view.id, view]));
+	if (currentLayoutIds.some((viewId) => !byId.has(viewId))) {
+		const unfilteredViews = await client.listViews().catch(() => []);
+		for (const view of unfilteredViews) byId.set(view.id, view);
+	}
+	const currentTargets = currentLayoutIds.map((viewId) => {
+		const summary = byId.get(viewId);
+		if (summary) return summary;
+		return {
+			id: viewId,
+			label: viewId === currentView?.viewId ? currentView.viewLabel : viewId,
+			available: true,
+			pluginName: "current-layout",
+			viewType: currentView?.viewType ?? "gui",
+			...(viewId === currentView?.viewId && currentView.viewPath
+				? { path: currentView.viewPath }
+				: {}),
+		};
+	});
+	if (preferCurrentLayout && currentTargets.length >= 2) return currentTargets;
+	if (targets.length >= 2) return targets;
+	return currentTargets.length >= 2 ? currentTargets : targets;
+}
+
+async function runViewsClose({
+	client,
+	message,
+	options,
+	viewType,
+	callback,
+}: {
+	client: ViewsClient;
+	message: Memory;
+	options?: Record<string, unknown>;
+	viewType?: ViewType;
+	callback?: HandlerCallback;
+}): Promise<ActionResult> {
+	const text = message.content.text ?? "";
+	if (isCloseAllRequest(text, options)) {
+		const resultText = await navigateViewWithShellAction(
+			"__all__",
+			"close-all",
+			"Closed all views.",
+			"Requested closing all views.",
+		);
+		await callback?.({ text: resultText });
+		return {
+			success: true,
+			text: resultText,
+			values: { mode: "close", scope: "all" },
+			data: { viewId: "__all__", action: "close-all" },
+		};
+	}
+
+	const target = extractCloseTarget(text, options);
+	let viewId: string | null = null;
+	let label: string | null = null;
+	let resolvedViewType: ViewType | undefined;
+
+	if (!target || target.toLowerCase() === "current") {
+		const currentView = await client.getCurrentView();
+		viewId = currentView?.viewId ?? null;
+		label = currentView?.viewLabel ?? null;
+		resolvedViewType = viewType ?? currentView?.viewType;
+		if (!viewId) {
+			const reply =
+				"No current view has been reported yet. Tell me which view to close.";
+			await callback?.({ text: reply });
+			return { success: false, text: reply };
+		}
+	} else {
+		const views = await client.listViews({ viewType });
+		const resolution = resolveCloseTargetView(target, views);
+		if (resolution.kind === "none") {
+			const reply = `No view matches "${target}". Try action=list to see available views.`;
+			await callback?.({ text: reply });
+			return { success: false, text: reply, data: { target } };
+		}
+		if (resolution.kind === "ambiguous") {
+			const list = resolution.candidates
+				.map((view) => `- ${view.label} (${view.id})`)
+				.join("\n");
+			const reply = `"${target}" matches multiple views:\n${list}\nWhich one did you mean?`;
+			await callback?.({ text: reply });
+			return {
+				success: false,
+				text: reply,
+				data: { candidates: resolution.candidates },
+			};
+		}
+		viewId = resolution.view.id;
+		label = resolution.view.label;
+		resolvedViewType = viewType ?? resolution.view.viewType;
+	}
+
+	const resultText = await navigateViewWithShellAction(
+		viewId,
+		"close",
+		`Closed ${label ?? viewId}.`,
+		`Requested closing ${label ?? viewId}.`,
+		resolvedViewType === "gui" ? undefined : resolvedViewType,
+	);
+	await callback?.({ text: resultText });
+	return {
+		success: true,
+		text: resultText,
+		values: {
+			mode: "close",
+			viewId,
+			viewType: resolvedViewType ?? "gui",
+			label: label ?? viewId,
+		},
+		data: { viewId, viewType: resolvedViewType ?? "gui", action: "close" },
+	};
+}
+
+async function runViewsLayout({
+	client,
+	message,
+	mode,
+	options,
+	viewType,
+	callback,
+}: {
+	client: ViewsClient;
+	message: Memory;
+	mode: "split" | "tile";
+	options?: Record<string, unknown>;
+	viewType?: ViewType;
+	callback?: HandlerCallback;
+}): Promise<ActionResult> {
+	const text = message.content.text ?? "";
+	const views = await client.listViews({ viewType });
+	const placement =
+		mode === "split" ? readPlacementValue(text, options) : undefined;
+	const layoutOnlyFollowup =
+		mode === "split" ? isLayoutOnlyFollowupRequest(text, views) : false;
+	let targets =
+		mode === "split"
+			? await completeSplitTargetsWithCurrentView({
+					client,
+					targets: resolveLayoutTargets(text, options, views),
+					views,
+					placement,
+				})
+			: resolveLayoutTargets(text, options, views);
+	if (mode === "split") {
+		targets = await completeSplitTargetsFromCurrentLayout({
+			client,
+			targets,
+			views,
+			preferCurrentLayout: layoutOnlyFollowup,
+		});
+	}
+	const singleViewPlacement =
+		mode === "split" && targets.length === 1 && placement !== undefined;
+	if (targets.length < 2 && !singleViewPlacement) {
+		const reply =
+			mode === "split"
+				? 'Tell me two views to split, e.g. action=split views=["notes","calendar"] layout=horizontal.'
+				: 'Tell me two or more views to tile, e.g. action=tile views=["notes","calendar"].';
+		await callback?.({ text: reply });
+		return {
+			success: false,
+			text: reply,
+			data: { mode, resolvedCount: targets.length },
+		};
+	}
+
+	const layout =
+		mode === "tile"
+			? "grid"
+			: (layoutForPlacement(placement) ?? readLayoutValue(text, options));
+	const viewIds = targets.map((view) => view.id);
+	const labels = targets.map((view) => view.label).join(", ");
+	const action = mode === "split" ? "split-view" : "tile-views";
+	const primary = targets[0];
+	const resolvedViewType = layoutOnlyFollowup
+		? (primary.viewType ?? viewType)
+		: (viewType ?? primary.viewType);
+	const resultText = await navigateViewLayout({
+		viewId: primary.id,
+		action,
+		viewIds,
+		layout,
+		placement,
+		viewType: resolvedViewType === "gui" ? undefined : resolvedViewType,
+		successText: singleViewPlacement
+			? `Placed ${labels} on the ${placement}.`
+			: mode === "split"
+				? `Split views: ${labels} (${layout}).`
+				: `Tiled views: ${labels}.`,
+		fallbackText: singleViewPlacement
+			? `Requested placing ${labels} on the ${placement}.`
+			: mode === "split"
+				? `Requested split layout for views: ${labels}.`
+				: `Requested tiled layout for views: ${labels}.`,
+	});
+	await callback?.({ text: resultText });
+	return {
+		success: true,
+		text: resultText,
+		continueChain: false,
+		values: {
+			mode,
+			viewIds,
+			layout,
+			...(placement ? { placement } : {}),
+		},
+		data: {
+			viewId: primary.id,
+			viewIds,
+			action,
+			layout,
+			...(placement ? { placement } : {}),
+		},
+	};
+}
+
+function withViewsUserFacingText(result: ActionResult): ActionResult {
+	const text = typeof result.text === "string" ? result.text.trim() : "";
+	if (!text) return result;
+	return {
+		...result,
+		userFacingText: result.userFacingText ?? text,
+		verifiedUserFacing:
+			result.success === true
+				? (result.verifiedUserFacing ?? true)
+				: result.verifiedUserFacing,
+	};
+}
+
 export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 	const clientFactory = () => deps.client ?? createViewsClient();
 	const ownerCheck = deps.hasOwnerAccess ?? defaultOwnerAccessFn;
@@ -242,18 +1749,19 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 
 	return {
 		name: "VIEWS",
-		contexts: ["general", "automation", "settings", "code"],
-		contextGate: { anyOf: ["general", "automation", "settings", "code"] },
+		contexts: [...VIEW_ACTION_CONTEXTS],
+		contextGate: { anyOf: [...VIEW_ACTION_CONTEXTS] },
 		roleGate: { minRole: "USER" },
 		similes: [
 			"VIEW",
 			"SHOW_VIEW",
 			"OPEN_VIEW",
+			"CLOSE_VIEW",
+			"CLOSE_ALL_VIEWS",
 			"LIST_VIEWS",
 			"VIEW_MANAGER",
 			"VIEWS_LIST",
 			"SWITCH_VIEW",
-			"CLOSE_VIEW",
 			"SHOW_APPS",
 			"OPEN_APPS",
 			"GO_TO_VIEW",
@@ -267,6 +1775,21 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 			"INVOKE_VIEW_CAPABILITY",
 			"PIN_VIEW",
 			"OPEN_VIEW_WINDOW",
+			"SPLIT_VIEW",
+			"SPLIT_VIEWS",
+			"TILE_VIEWS",
+			"ARRANGE_VIEWS",
+			"USE_VIEW_CAPABILITY",
+			"CALL_VIEW_CAPABILITY",
+			"CREATE_NOTE",
+			"CREATE_STICKY_NOTE",
+			"SHOW_NOTES",
+			"GET_NOTES",
+			"LIST_NOTES",
+			"CREATE_CALENDAR_EVENT",
+			"ADD_CALENDAR_EVENT",
+			"GET_CALENDAR_EVENTS",
+			"LIST_CALENDAR_EVENTS",
 			"CREATE_VIEW",
 			"CREATE_PLUGIN",
 			"BUILD_VIEW",
@@ -278,21 +1801,36 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 			"REMOVE_PLUGIN",
 			"UNINSTALL_VIEW",
 		],
+		tags: [
+			"views",
+			"ui",
+			"window",
+			"panel",
+			"app",
+			"layout",
+			"view-capability",
+			"notes",
+			"sticky-notes",
+			"calendar",
+			"events",
+		],
 		description:
-			"Manage and navigate UI views. List available views, report the current view, open a specific view, search views by name or capability, show the view manager, broadcast events to views, interact with a mounted view, pin a view as a desktop tab, open a view in a separate window, create a new view plugin (scaffolds + coding agent), edit an existing view plugin (coding agent), or delete/uninstall a view plugin.",
+			"Manage and navigate UI views. List available views, report the current view, open a specific view, close/hide a view without deleting its plugin, search views by name or capability, show the view manager, broadcast events to views, invoke registered capabilities on plugin views for view-backed content such as notes, calendar events, dashboards, and records, pin a view as a desktop tab, open a view in a separate window, request split/tiled layouts across multiple views, create a new view plugin (scaffolds + coding agent), edit an existing view plugin (coding agent), or delete/uninstall a view plugin.",
 		descriptionCompressed:
-			"views list|current|show|open|search|manager|broadcast|interact|pin|window|create|edit|delete; navigate UI views; report current view; push events; click/read/focus elements; pin tabs; open windows; scaffold new plugins; edit or remove view plugins",
+			"views list|current|show|open|close|search|manager|broadcast|interact|pin|window|split|tile|create|edit|delete; navigate/close UI views; invoke registered view capabilities for notes/events/dashboards/records; click/read/focus elements; split/tile layouts; scaffold/edit/remove view plugins",
+		routingHint:
+			"UI view/window/panel/app navigation and layout -> VIEWS. Use VIEWS for open/show/switch/close/hide view requests, view manager, list views, split/tile views, pin view, open view in a separate window, or invoking a capability declared by a registered plugin view, including view-backed content operations like creating/listing notes or calendar events. For add/create calendar-event requests, use action=interact view=calendar capability=create-calendar-event; do not answer by opening or splitting the calendar unless the user asked for layout. Close/hide means VIEWS action=close, not delete/remove. For view capabilities use action=interact with view=<view id> and capability=<capability id>, or pass a generated capability action name that can be resolved from the view catalog. Pass capability data as params={...} or top-level keys such as title/body/date/time/notes/color; never use dotted keys such as params.title.",
+		allowAdditionalParameters: true,
 		suppressPostActionContinuation: true,
 
 		parameters: [
 			{
 				name: "action",
 				description:
-					"Operation: list | current | show | open | search | manager | broadcast | interact | pin | window | create | edit | delete | remove.",
+					"Operation: list | current | show | open | close | search | manager | broadcast | interact | pin | window | split | tile | create | edit | delete | remove, or a registered/generated view capability name to resolve through the view catalog.",
 				required: true,
 				schema: {
 					type: "string",
-					enum: [...MODES],
 				},
 			},
 			{
@@ -306,7 +1844,8 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 			},
 			{
 				name: "view",
-				description: "View name, label, or id (show / open / edit / delete).",
+				description:
+					"View name, label, or id (show / open / close / edit / delete).",
 				required: false,
 				schema: { type: "string" },
 			},
@@ -321,6 +1860,37 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 				description: "Alias for `view`.",
 				required: false,
 				schema: { type: "string" },
+			},
+			{
+				name: "target",
+				description:
+					"Alias for `view`, especially for close requests such as CLOSE_VIEW { target: 'settings' }.",
+				required: false,
+				schema: { type: "string" },
+			},
+			{
+				name: "views",
+				description:
+					"Multiple view ids/names for split or tile mode, e.g. ['notes','calendar'].",
+				required: false,
+				schema: { type: "array", items: { type: "string" } },
+			},
+			{
+				name: "layout",
+				description:
+					"Layout for split/tile mode: horizontal, vertical, or grid.",
+				required: false,
+				schema: { type: "string", enum: ["horizontal", "vertical", "grid"] },
+			},
+			{
+				name: "placement",
+				description:
+					"Optional split placement hint: left, right, top, or bottom.",
+				required: false,
+				schema: {
+					type: "string",
+					enum: ["left", "right", "top", "bottom"],
+				},
 			},
 			{
 				name: "query",
@@ -352,21 +1922,63 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 				name: "payload",
 				description: "JSON payload to include with the broadcast event.",
 				required: false,
-				schema: { type: "object" },
+				schema: { type: "object", additionalProperties: true },
 			},
 			{
 				name: "capability",
 				description:
-					"Capability to invoke on the view (interact mode), e.g. 'click-button', 'get-state', 'get-text', 'refresh', 'focus-element'.",
+					"Capability to invoke on the view (interact mode), e.g. 'create-note', 'get-notes', 'create-calendar-event', 'get-calendar-state', 'click-button', 'get-state', 'refresh', or 'focus-element'.",
 				required: false,
 				schema: { type: "string" },
 			},
 			{
 				name: "params",
 				description:
-					"Parameters for the capability (interact mode), e.g. { buttonId: 'submit' } or { selector: '#my-input' }.",
+					"Object parameters for the capability (interact mode), e.g. { title: 'launch checklist', body: 'test auth' } or { title: 'team sync', date: '2026-06-08', time: '17:00' }. Do not use dotted parameter names like 'params.title'.",
 				required: false,
-				schema: { type: "object" },
+				schema: { type: "object", additionalProperties: true },
+			},
+			{
+				name: "title",
+				description:
+					"Top-level passthrough for registered view capabilities that accept a title, such as create-note or create-calendar-event.",
+				required: false,
+				schema: { type: "string" },
+			},
+			{
+				name: "body",
+				description:
+					"Top-level passthrough for registered view capabilities that accept body/content text, such as create-note.",
+				required: false,
+				schema: { type: "string" },
+			},
+			{
+				name: "date",
+				description:
+					"Top-level passthrough for registered view capabilities that accept an ISO date, such as create-calendar-event.",
+				required: false,
+				schema: { type: "string" },
+			},
+			{
+				name: "time",
+				description:
+					"Top-level passthrough for registered view capabilities that accept a time label, such as create-calendar-event.",
+				required: false,
+				schema: { type: "string" },
+			},
+			{
+				name: "notes",
+				description:
+					"Top-level passthrough for registered view capabilities that accept notes/details text, such as create-calendar-event.",
+				required: false,
+				schema: { type: "string" },
+			},
+			{
+				name: "color",
+				description:
+					"Top-level passthrough for registered view capabilities that accept a color, such as notes or calendar events.",
+				required: false,
+				schema: { type: "string" },
 			},
 			{
 				name: "timeoutMs",
@@ -451,303 +2063,441 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 			options?: Record<string, unknown>,
 			callback?: HandlerCallback,
 		): Promise<ActionResult> => {
-			const actionOptions = normalizeActionOptions(options);
-			const client = clientFactory();
-			const text = message.content.text ?? "";
-			const roomId =
-				typeof message.roomId === "string" ? message.roomId : runtime.agentId;
+			const run = async (): Promise<ActionResult> => {
+				const actionOptions = normalizeActionOptions(options);
+				const client = clientFactory();
+				const text = message.content.text ?? "";
+				const roomId =
+					typeof message.roomId === "string" ? message.roomId : runtime.agentId;
 
-			// Multi-turn follow-up: choice reply for an in-progress create flow.
-			if (isChoiceReply(text)) {
-				if (await hasPendingViewsCreateIntent(runtime, roomId)) {
-					const views = await client.listViews();
-					return runViewsCreate({
-						runtime,
-						message,
-						options: actionOptions,
+				// Multi-turn follow-up: choice reply for an in-progress create flow.
+				if (isChoiceReply(text)) {
+					if (await hasPendingViewsCreateIntent(runtime, roomId)) {
+						const views = await client.listViews();
+						return runViewsCreate({
+							runtime,
+							message,
+							options: actionOptions,
+							views,
+							callback,
+							repoRoot: getRepoRoot(),
+						});
+					}
+				}
+
+				// Multi-turn follow-up: yes/no for a pending delete confirmation.
+				if (isDeleteConfirmation(text) || isDeleteCancellation(text)) {
+					if (await hasPendingDeleteConfirm(runtime, roomId)) {
+						const views = await client.listViews();
+						return runViewsDelete({
+							runtime,
+							message,
+							options: actionOptions,
+							views,
+							callback,
+							repoRoot: getRepoRoot(),
+						});
+					}
+				}
+
+				const mode = inferMode(text, actionOptions);
+				const viewType = readViewTypeOption(text, actionOptions);
+				if (!mode) {
+					const reply =
+						'Tell me what to do with views. Try: "list views", "open wallet view", "create a new view", or "delete the LifeOps plugin".';
+					await callback?.({ text: reply });
+					return { success: false, text: reply };
+				}
+
+				let effectiveMode = mode;
+				let prefetchedViews: ViewSummary[] | null = null;
+				let prefetchedCurrentView:
+					| Awaited<ReturnType<ViewsClient["getCurrentView"]>>
+					| null
+					| undefined;
+				let forcedResolvedCapability: ResolvedViewCapability | null = null;
+				const getViews = async () => {
+					prefetchedViews ??= await client.listViews();
+					return prefetchedViews;
+				};
+				const getCurrentView = async () => {
+					prefetchedCurrentView ??= await client
+						.getCurrentView()
+						.catch(() => null);
+					return prefetchedCurrentView;
+				};
+
+				if (effectiveMode === "interact") {
+					const views = await getViews().catch(() => []);
+					effectiveMode =
+						preferLayoutModeOverCapability({
+							text,
+							options: actionOptions,
+							views,
+						}) ?? effectiveMode;
+				}
+
+				if (shouldResolveModeAsCapability(effectiveMode, text, actionOptions)) {
+					const views = await getViews().catch(() => []);
+					const currentView = await getCurrentView();
+					forcedResolvedCapability = resolveViewCapability({
 						views,
-						callback,
-						repoRoot: getRepoRoot(),
-					});
-				}
-			}
-
-			// Multi-turn follow-up: yes/no for a pending delete confirmation.
-			if (isDeleteConfirmation(text) || isDeleteCancellation(text)) {
-				if (await hasPendingDeleteConfirm(runtime, roomId)) {
-					const views = await client.listViews();
-					return runViewsDelete({
-						runtime,
-						message,
-						options: actionOptions,
-						views,
-						callback,
-						repoRoot: getRepoRoot(),
-					});
-				}
-			}
-
-			const mode = inferMode(text, actionOptions);
-			const viewType = readViewTypeOption(text, actionOptions);
-			if (!mode) {
-				const reply =
-					'Tell me what to do with views. Try: "list views", "open wallet view", "create a new view", or "delete the LifeOps plugin".';
-				await callback?.({ text: reply });
-				return { success: false, text: reply };
-			}
-
-			logger.info(`[plugin-app-control] VIEWS mode=${mode}`);
-
-			switch (mode) {
-				case "list":
-					return runViewsList({ client, viewType, callback });
-
-				case "current": {
-					const currentView = await client.getCurrentView();
-					const resultText = currentView
-						? `Current view: ${currentView.viewLabel} (${currentView.viewType}) — ${currentView.viewId}${currentView.viewPath ? ` at ${currentView.viewPath}` : ""}.`
-						: "No current view has been reported yet.";
-					await callback?.({ text: resultText });
-					return {
-						success: true,
-						text: resultText,
-						values: {
-							mode: "current",
-							viewId: currentView?.viewId,
-							viewType: currentView?.viewType,
-						},
-						data: { currentView },
-					};
-				}
-
-				case "show":
-				case "open":
-					return runViewsShow({
-						client,
-						message,
+						text,
 						options: actionOptions,
 						viewType,
-						callback,
+						currentViewId: currentView?.viewId,
 					});
-
-				case "search": {
-					const query = extractSearchQuery(text, actionOptions);
-					return runViewsSearch({ client, query, viewType, callback });
-				}
-
-				case "manager": {
-					const managerView = {
-						id: "__view-manager__",
-						label: "View Manager",
-						path: "/views",
-						pluginName: "core",
-						available: true,
-					};
-					const resultText = await navigateToPath(
-						managerView.path,
-						managerView.label,
-					);
-					await callback?.({ text: resultText });
-					return {
-						success: true,
-						text: resultText,
-						values: { mode: "manager" },
-						data: { view: managerView },
-					};
-				}
-
-				case "broadcast": {
-					const eventType =
-						readStringOption(actionOptions, "eventType") ??
-						readStringOption(actionOptions, "event") ??
-						readStringOption(actionOptions, "type");
-					if (!eventType) {
-						const reply =
-							"Specify an event type to broadcast, e.g. action=broadcast eventType=wallet:refresh.";
-						await callback?.({ text: reply });
-						return { success: false, text: reply };
+					if (forcedResolvedCapability) {
+						effectiveMode = "interact";
 					}
-					const payload =
-						actionOptions?.payload !== null &&
-						typeof actionOptions?.payload === "object" &&
-						!Array.isArray(actionOptions?.payload)
-							? (actionOptions.payload as Record<string, unknown>)
-							: {};
-					const resultText = await broadcastViewEvent(eventType, payload);
-					await callback?.({ text: resultText });
-					return {
-						success: true,
-						text: resultText,
-						values: { mode: "broadcast", eventType },
-						data: { eventType, payload },
-					};
 				}
 
-				case "interact": {
-					let viewId =
-						readStringOption(actionOptions, "view") ??
-						readStringOption(actionOptions, "id") ??
-						readStringOption(actionOptions, "name");
-					const capability = readStringOption(actionOptions, "capability");
-					let resolvedViewType = viewType;
-					if (!viewId && /\bcurrent\b/i.test(text)) {
+				logger.info(`[plugin-app-control] VIEWS mode=${effectiveMode}`);
+
+				switch (effectiveMode) {
+					case "list":
+						return runViewsList({ client, viewType, callback });
+
+					case "current": {
 						const currentView = await client.getCurrentView();
-						viewId = currentView?.viewId ?? null;
-						resolvedViewType = viewType ?? currentView?.viewType;
+						const resultText = currentView
+							? `Current view: ${currentView.viewLabel} (${currentView.viewType}) — ${currentView.viewId}${currentView.viewPath ? ` at ${currentView.viewPath}` : ""}.`
+							: "No current view has been reported yet.";
+						await callback?.({ text: resultText });
+						return {
+							success: true,
+							text: resultText,
+							values: {
+								mode: "current",
+								viewId: currentView?.viewId,
+								viewType: currentView?.viewType,
+							},
+							data: { currentView },
+						};
 					}
-					if (!viewId || !capability) {
-						const reply =
-							"Specify view and capability, e.g. action=interact view=wallet capability=get-state, or ask for the current view after navigating.";
-						await callback?.({ text: reply });
-						return { success: false, text: reply };
+
+					case "show":
+					case "open":
+						return runViewsShow({
+							client,
+							message,
+							options: actionOptions,
+							viewType,
+							callback,
+						});
+
+					case "close":
+						return runViewsClose({
+							client,
+							message,
+							options: actionOptions,
+							viewType,
+							callback,
+						});
+
+					case "search": {
+						const query = extractSearchQuery(text, actionOptions);
+						return runViewsSearch({ client, query, viewType, callback });
 					}
-					const params =
-						actionOptions?.params !== null &&
-						typeof actionOptions?.params === "object" &&
-						!Array.isArray(actionOptions?.params)
-							? (actionOptions.params as Record<string, unknown>)
-							: undefined;
-					const timeoutMs =
-						typeof actionOptions?.timeoutMs === "number" &&
-						actionOptions.timeoutMs > 0
-							? actionOptions.timeoutMs
-							: 5_000;
-					const resultText = await interactWithView(
-						viewId,
-						capability,
-						params,
-						timeoutMs,
-						resolvedViewType,
-					);
-					await callback?.({ text: resultText });
-					return {
-						success: true,
-						text: resultText,
-						values: {
-							mode: "interact",
+
+					case "manager": {
+						const managerView = {
+							id: "__view-manager__",
+							label: "View Manager",
+							path: "/views",
+							pluginName: "core",
+							available: true,
+						};
+						const resultText = await navigateToPath(
+							managerView.path,
+							managerView.label,
+						);
+						await callback?.({ text: resultText });
+						return {
+							success: true,
+							text: resultText,
+							values: { mode: "manager" },
+							data: { view: managerView },
+						};
+					}
+
+					case "broadcast": {
+						const eventType =
+							readStringOption(actionOptions, "eventType") ??
+							readStringOption(actionOptions, "event") ??
+							readStringOption(actionOptions, "type");
+						if (!eventType) {
+							const reply =
+								"Specify an event type to broadcast, e.g. action=broadcast eventType=wallet:refresh.";
+							await callback?.({ text: reply });
+							return { success: false, text: reply };
+						}
+						const payload =
+							actionOptions?.payload !== null &&
+							typeof actionOptions?.payload === "object" &&
+							!Array.isArray(actionOptions?.payload)
+								? (actionOptions.payload as Record<string, unknown>)
+								: {};
+						const resultText = await broadcastViewEvent(eventType, payload);
+						await callback?.({ text: resultText });
+						return {
+							success: true,
+							text: resultText,
+							values: { mode: "broadcast", eventType },
+							data: { eventType, payload },
+						};
+					}
+
+					case "interact": {
+						let viewId =
+							readStringOption(actionOptions, "view") ??
+							readStringOption(actionOptions, "viewId") ??
+							readStringOption(actionOptions, "id") ??
+							readStringOption(actionOptions, "name") ??
+							readStringOption(actionOptions, "target");
+						let capability = readStringOption(actionOptions, "capability");
+						let resolvedViewType = viewType;
+						const views = await getViews().catch(() => []);
+						if (!viewId && /\bcurrent\b/i.test(text)) {
+							const currentView = await getCurrentView();
+							viewId = currentView?.viewId ?? null;
+							resolvedViewType = viewType ?? currentView?.viewType;
+						}
+						const currentViewForResolution =
+							!viewId && !forcedResolvedCapability
+								? await getCurrentView()
+								: null;
+						let resolvedCapability =
+							forcedResolvedCapability ??
+							resolveViewCapability({
+								views,
+								text,
+								options: actionOptions,
+								viewType,
+								currentViewId: viewId ?? currentViewForResolution?.viewId,
+							});
+						if (!resolvedCapability && (!viewId || !capability)) {
+							const currentView = await getCurrentView();
+							resolvedCapability = resolveViewCapability({
+								views,
+								text,
+								options: actionOptions,
+								viewType,
+								currentViewId: currentView?.viewId,
+							});
+							if (!viewId && currentView?.viewId) {
+								resolvedViewType = viewType ?? currentView.viewType;
+							}
+						}
+						if (resolvedCapability) {
+							viewId = resolvedCapability.view.id;
+							capability = resolvedCapability.capability.id;
+							resolvedViewType = viewType ?? resolvedCapability.view.viewType;
+						} else if (viewId) {
+							const resolved = resolveViewTarget(viewId, views);
+							if (resolved) {
+								viewId = resolved.id;
+								resolvedViewType = viewType ?? resolved.viewType;
+							}
+						}
+						if (!viewId || !capability) {
+							const reply =
+								"Specify view and capability, e.g. action=interact view=wallet capability=get-state, or ask for the current view after navigating.";
+							await callback?.({ text: reply });
+							return { success: false, text: reply };
+						}
+						const params = readCapabilityParams(
+							actionOptions,
+							resolvedCapability?.capability,
+							resolvedCapability?.view,
+							text,
+						);
+						const timeoutMs =
+							typeof actionOptions?.timeoutMs === "number" &&
+							actionOptions.timeoutMs > 0
+								? actionOptions.timeoutMs
+								: 5_000;
+						const interaction = await interactWithView(
 							viewId,
-							viewType: resolvedViewType ?? "gui",
-							capability,
-						},
-						data: {
-							viewId,
-							viewType: resolvedViewType ?? "gui",
 							capability,
 							params,
-						},
-					};
-				}
-
-				case "create": {
-					const views = await client.listViews();
-					return runViewsCreate({
-						runtime,
-						message,
-						options: actionOptions,
-						views,
-						callback,
-						repoRoot: getRepoRoot(),
-					});
-				}
-
-				case "edit": {
-					const views = await client.listViews();
-					return runViewsEdit({
-						runtime,
-						message,
-						options: actionOptions,
-						views,
-						callback,
-						repoRoot: getRepoRoot(),
-					});
-				}
-
-				case "delete":
-				case "remove": {
-					const views = await client.listViews();
-					return runViewsDelete({
-						runtime,
-						message,
-						options: actionOptions,
-						views,
-						callback,
-						repoRoot: getRepoRoot(),
-					});
-				}
-
-				case "pin": {
-					const pinViewId =
-						readStringOption(actionOptions, "view") ??
-						readStringOption(actionOptions, "id") ??
-						readStringOption(actionOptions, "name");
-					if (!pinViewId) {
-						const reply =
-							"Specify which view to pin as a desktop tab, e.g. action=pin view=wallet.";
-						await callback?.({ text: reply });
-						return { success: false, text: reply };
+							timeoutMs,
+							resolvedViewType,
+						);
+						const resultText = interaction.text;
+						await callback?.({ text: resultText });
+						return {
+							success: interaction.success,
+							text: resultText,
+							values: {
+								mode: "interact",
+								viewId,
+								viewType: resolvedViewType ?? "gui",
+								capability,
+							},
+							data: {
+								viewId,
+								viewType: resolvedViewType ?? "gui",
+								capability,
+								params,
+							},
+						};
 					}
-					const resolvedViewType = await resolveViewTypeForId(
-						client,
-						pinViewId,
-						readExplicitViewTypeOption(options) ?? viewType,
-					);
-					const pinResultText = await pinViewAsTab(
-						pinViewId,
-						resolvedViewType === "gui" ? undefined : resolvedViewType,
-					);
-					await callback?.({ text: pinResultText });
-					return {
-						success: true,
-						text: pinResultText,
-						values: {
-							mode: "pin",
-							viewId: pinViewId,
-							viewType: resolvedViewType ?? "gui",
-						},
-						data: { viewId: pinViewId, viewType: resolvedViewType ?? "gui" },
-					};
-				}
 
-				case "window": {
-					const windowViewId =
-						readStringOption(actionOptions, "view") ??
-						readStringOption(actionOptions, "id") ??
-						readStringOption(actionOptions, "name");
-					const alwaysOnTop = readBooleanOption(actionOptions, "alwaysOnTop");
-					if (!windowViewId) {
-						const reply =
-							"Specify which view to open in a new window, e.g. action=window view=wallet.";
-						await callback?.({ text: reply });
-						return { success: false, text: reply };
+					case "create": {
+						const views = await client.listViews();
+						return runViewsCreate({
+							runtime,
+							message,
+							options: actionOptions,
+							views,
+							callback,
+							repoRoot: getRepoRoot(),
+						});
 					}
-					const resolvedViewType = await resolveViewTypeForId(
-						client,
-						windowViewId,
-						readExplicitViewTypeOption(options) ?? viewType,
-					);
-					const windowResultText = await openViewInWindow(
-						windowViewId,
-						resolvedViewType === "gui" ? undefined : resolvedViewType,
-						alwaysOnTop,
-					);
-					await callback?.({ text: windowResultText });
-					return {
-						success: true,
-						text: windowResultText,
-						values: {
-							mode: "window",
-							viewId: windowViewId,
-							viewType: resolvedViewType ?? "gui",
+
+					case "edit": {
+						const views = await client.listViews();
+						return runViewsEdit({
+							runtime,
+							message,
+							options: actionOptions,
+							views,
+							callback,
+							repoRoot: getRepoRoot(),
+						});
+					}
+
+					case "delete":
+					case "remove": {
+						const views = await client.listViews();
+						return runViewsDelete({
+							runtime,
+							message,
+							options: actionOptions,
+							views,
+							callback,
+							repoRoot: getRepoRoot(),
+						});
+					}
+
+					case "pin": {
+						const resolution = await resolveSingleShellTargetView({
+							client,
+							text,
+							options: actionOptions,
+							viewType,
+						});
+						if (resolution.kind === "none") {
+							const reply =
+								"Specify which view to pin as a desktop tab, e.g. action=pin view=wallet.";
+							await callback?.({ text: reply });
+							return { success: false, text: reply };
+						}
+						if (resolution.kind === "ambiguous") {
+							const list = resolution.candidates
+								.map((view) => `- ${view.label} (${view.id})`)
+								.join("\n");
+							const reply = `That matches multiple views:\n${list}\nWhich one should I pin?`;
+							await callback?.({ text: reply });
+							return {
+								success: false,
+								text: reply,
+								data: { candidates: resolution.candidates },
+							};
+						}
+						const pinView = resolution.view;
+						const resolvedViewType =
+							readExplicitViewTypeOption(options) ??
+							viewType ??
+							pinView.viewType ??
+							(await resolveViewTypeForId(client, pinView.id));
+						const pinResultText = await pinViewAsTab(
+							pinView.id,
+							resolvedViewType === "gui" ? undefined : resolvedViewType,
+						);
+						await callback?.({ text: pinResultText });
+						return {
+							success: true,
+							text: pinResultText,
+							values: {
+								mode: "pin",
+								viewId: pinView.id,
+								viewType: resolvedViewType ?? "gui",
+							},
+							data: { viewId: pinView.id, viewType: resolvedViewType ?? "gui" },
+						};
+					}
+
+					case "window": {
+						const resolution = await resolveSingleShellTargetView({
+							client,
+							text,
+							options: actionOptions,
+							viewType,
+						});
+						const alwaysOnTop = readBooleanOption(actionOptions, "alwaysOnTop");
+						if (resolution.kind === "none") {
+							const reply =
+								"Specify which view to open in a new window, e.g. action=window view=wallet.";
+							await callback?.({ text: reply });
+							return { success: false, text: reply };
+						}
+						if (resolution.kind === "ambiguous") {
+							const list = resolution.candidates
+								.map((view) => `- ${view.label} (${view.id})`)
+								.join("\n");
+							const reply = `That matches multiple views:\n${list}\nWhich one should I open in a new window?`;
+							await callback?.({ text: reply });
+							return {
+								success: false,
+								text: reply,
+								data: { candidates: resolution.candidates },
+							};
+						}
+						const windowView = resolution.view;
+						const resolvedViewType =
+							readExplicitViewTypeOption(options) ??
+							viewType ??
+							windowView.viewType ??
+							(await resolveViewTypeForId(client, windowView.id));
+						const windowResultText = await openViewInWindow(
+							windowView.id,
+							resolvedViewType === "gui" ? undefined : resolvedViewType,
 							alwaysOnTop,
-						},
-						data: {
-							viewId: windowViewId,
-							viewType: resolvedViewType ?? "gui",
-							alwaysOnTop,
-						},
-					};
+						);
+						await callback?.({ text: windowResultText });
+						return {
+							success: true,
+							text: windowResultText,
+							values: {
+								mode: "window",
+								viewId: windowView.id,
+								viewType: resolvedViewType ?? "gui",
+								alwaysOnTop,
+							},
+							data: {
+								viewId: windowView.id,
+								viewType: resolvedViewType ?? "gui",
+								alwaysOnTop,
+							},
+						};
+					}
+
+					case "split":
+					case "tile":
+						return runViewsLayout({
+							client,
+							message,
+							mode: effectiveMode,
+							options: actionOptions,
+							viewType,
+							callback,
+						});
 				}
-			}
+			};
+
+			return withViewsUserFacingText(await run());
 		},
 
 		examples: [
@@ -806,6 +2556,32 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 			[
 				{
 					name: "{{user1}}",
+					content: { text: "split notes and calendar side by side" },
+				},
+				{
+					name: "{{agentName}}",
+					content: {
+						text: "Split views: Notes, Calendar (horizontal).",
+						action: "VIEWS",
+					},
+				},
+			],
+			[
+				{
+					name: "{{user1}}",
+					content: { text: "tile notes calendar and trajectories" },
+				},
+				{
+					name: "{{agentName}}",
+					content: {
+						text: "Tiled views: Notes, Calendar, Trajectories.",
+						action: "VIEWS",
+					},
+				},
+			],
+			[
+				{
+					name: "{{user1}}",
 					content: { text: "tell the wallet view to refresh" },
 				},
 				{
@@ -824,7 +2600,78 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 				{
 					name: "{{agentName}}",
 					content: {
-						text: 'Interacted with view "settings" — capability "get-state": {"theme":"dark","language":"en"}.',
+						text: 'Interacted with view "settings" — capability "get-state" (returned theme and language).',
+						action: "VIEWS",
+					},
+				},
+			],
+			[
+				{
+					name: "{{user1}}",
+					content: {
+						text: "create a sticky note titled launch checklist with body test auth and billing",
+					},
+				},
+				{
+					name: "{{agentName}}",
+					content: {
+						text: 'Created note "launch checklist".',
+						action: "VIEWS",
+					},
+				},
+			],
+			[
+				{
+					name: "{{user1}}",
+					content: { text: "show my notes" },
+				},
+				{
+					name: "{{agentName}}",
+					content: {
+						text: "1 note.",
+						action: "VIEWS",
+					},
+				},
+			],
+			[
+				{
+					name: "{{user1}}",
+					content: {
+						text: "add a calendar event titled team sync on 2026-06-08 at 17:00",
+					},
+				},
+				{
+					name: "{{agentName}}",
+					content: {
+						text: 'Created event "team sync".',
+						action: "VIEWS",
+					},
+				},
+			],
+			[
+				{
+					name: "{{user1}}",
+					content: {
+						text: "tomorrow is my birthday can you add that to calendar",
+					},
+				},
+				{
+					name: "{{agentName}}",
+					content: {
+						text: 'Created event "Birthday".',
+						action: "VIEWS",
+					},
+				},
+			],
+			[
+				{
+					name: "{{user1}}",
+					content: { text: "show calendar events for 2026-06-08" },
+				},
+				{
+					name: "{{agentName}}",
+					content: {
+						text: "1 event on 2026-06-08.",
 						action: "VIEWS",
 					},
 				},
@@ -872,6 +2719,36 @@ export function createViewsAction(deps: ViewsActionDeps = {}): Action {
 	};
 }
 
+export function createViewsAliasAction(
+	name: "CLOSE_VIEW" | "CLOSE_ALL_VIEWS",
+	deps: ViewsActionDeps = {},
+): Action {
+	const action = createViewsAction(deps);
+	const closeAll = name === "CLOSE_ALL_VIEWS";
+	return {
+		...action,
+		name,
+		similes: closeAll
+			? ["CLOSE_ALL_VIEW_TABS", "HIDE_ALL_VIEWS", "DISMISS_ALL_VIEWS"]
+			: ["HIDE_VIEW", "DISMISS_VIEW", "CLOSE_PANEL", "CLOSE_APP_VIEW"],
+		description: closeAll
+			? "Close or hide all currently open UI views/tabs without deleting plugins."
+			: "Close or hide one UI view/tab without deleting its plugin. Accepts view, id, name, or target.",
+		descriptionCompressed: closeAll
+			? "close all open UI views/tabs; never deletes plugins"
+			: "close one UI view/tab by view/id/name/target; never deletes plugins",
+		handler: async (runtime, message, state, options, callback) => {
+			const actionOptions = {
+				...normalizeActionOptions(options),
+				action: "close",
+				mode: "close",
+				...(closeAll ? { all: true, target: "__all__" } : {}),
+			};
+			return action.handler(runtime, message, state, actionOptions, callback);
+		},
+	};
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -914,7 +2791,7 @@ async function navigateToPath(pathStr: string, label: string): Promise<string> {
 
 async function navigateViewWithShellAction(
 	viewId: string,
-	action: "pin-tab" | "open-window",
+	action: "pin-tab" | "open-window" | "close" | "close-all",
 	successText: string,
 	fallbackText: string,
 	viewType?: ViewType,
@@ -931,6 +2808,58 @@ async function navigateViewWithShellAction(
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ action, viewType, alwaysOnTop }),
+				signal: AbortSignal.timeout(5_000),
+			},
+		);
+		if (resp.ok || resp.status === 501 || resp.status === 404) {
+			return successText;
+		}
+		logger.warn(
+			`[plugin-app-control] VIEWS/${action} navigate returned ${resp.status}`,
+		);
+	} catch {
+		// Network or timeout — not fatal.
+	}
+
+	return fallbackText;
+}
+
+async function navigateViewLayout({
+	viewId,
+	action,
+	viewIds,
+	layout,
+	placement,
+	viewType,
+	successText,
+	fallbackText,
+}: {
+	viewId: string;
+	action: "split-view" | "tile-views";
+	viewIds: string[];
+	layout: "horizontal" | "vertical" | "grid";
+	placement?: "left" | "right" | "top" | "bottom";
+	viewType?: ViewType;
+	successText: string;
+	fallbackText: string;
+}): Promise<string> {
+	const { resolveServerOnlyPort } = await import("@elizaos/core");
+	const port = resolveServerOnlyPort(process.env);
+	const base = `http://127.0.0.1:${port}`;
+
+	try {
+		const resp = await fetch(
+			`${base}/api/views/${encodeURIComponent(viewId)}/navigate${viewType ? `?viewType=${viewType}` : ""}`,
+			{
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					action,
+					views: viewIds,
+					layout,
+					...(placement ? { placement } : {}),
+					...(viewType ? { viewType } : {}),
+				}),
 				signal: AbortSignal.timeout(5_000),
 			},
 		);
@@ -982,7 +2911,7 @@ async function interactWithView(
 	params: Record<string, unknown> | undefined,
 	timeoutMs: number,
 	viewType?: ViewType,
-): Promise<string> {
+): Promise<{ success: boolean; text: string; result?: unknown }> {
 	const { resolveServerOnlyPort } = await import("@elizaos/core");
 	const port = resolveServerOnlyPort(process.env);
 	const base = `http://127.0.0.1:${port}`;
@@ -1002,14 +2931,23 @@ async function interactWithView(
 		logger.warn(
 			`[plugin-app-control] VIEWS/interact network error: ${err instanceof Error ? err.message : String(err)}`,
 		);
-		return `Failed to interact with view "${viewId}": network error.`;
+		return {
+			success: false,
+			text: `Failed to interact with view "${viewId}": network error.`,
+		};
 	}
 
 	if (resp.status === 504) {
-		return `View "${viewId}" did not respond to capability "${capability}" within ${timeoutMs}ms.`;
+		return {
+			success: false,
+			text: `View "${viewId}" did not respond to capability "${capability}" within ${timeoutMs}ms.`,
+		};
 	}
 	if (resp.status === 404) {
-		return `View "${viewId}" not found or not mounted.`;
+		return {
+			success: false,
+			text: `View "${viewId}" not found or not mounted.`,
+		};
 	}
 	if (resp.status === 400) {
 		let detail = "";
@@ -1019,25 +2957,93 @@ async function interactWithView(
 		} catch {
 			/* ignore */
 		}
-		return `Cannot invoke capability "${capability}" on view "${viewId}"${detail}.`;
+		return {
+			success: false,
+			text: `Cannot invoke capability "${capability}" on view "${viewId}"${detail}.`,
+		};
 	}
 	if (!resp.ok) {
 		logger.warn(
 			`[plugin-app-control] VIEWS/interact returned ${resp.status} for view "${viewId}"`,
 		);
-		return `Interact with view "${viewId}" failed (HTTP ${resp.status}).`;
+		return {
+			success: false,
+			text: `Interact with view "${viewId}" failed (HTTP ${resp.status}).`,
+		};
 	}
 
 	let result: unknown;
 	try {
 		result = await resp.json();
 	} catch {
-		return `Interacted with view "${viewId}" (capability "${capability}") — no parseable result.`;
+		return {
+			success: true,
+			text: `Interacted with view "${viewId}" (capability "${capability}") — no parseable result.`,
+		};
 	}
 
-	const resultStr =
-		result !== null && result !== undefined ? JSON.stringify(result) : "null";
-	return `Interacted with view "${viewId}" — capability "${capability}": ${resultStr}.`;
+	const text = textFromInteractionResult(result);
+	const success = successFromInteractionResult(result);
+	if (text) return { success, text, result };
+
+	return {
+		success,
+		text: `Interacted with view "${viewId}" — capability "${capability}" (${summarizeInteractionResult(result)}).`,
+		result,
+	};
+}
+
+function summarizeInteractionResult(result: unknown): string {
+	if (Array.isArray(result)) {
+		return `returned ${result.length} item${result.length === 1 ? "" : "s"}`;
+	}
+	if (!result || typeof result !== "object") {
+		return "completed with no additional details";
+	}
+	const record = result as Record<string, unknown>;
+	const payload =
+		record.result &&
+		typeof record.result === "object" &&
+		!Array.isArray(record.result)
+			? (record.result as Record<string, unknown>)
+			: record;
+	const keys = Object.keys(payload).filter(
+		(key) => key !== "success" && key !== "text",
+	);
+	if (keys.length === 0) return "completed with structured result";
+	const shown = keys.slice(0, 4).join(", ");
+	const suffix = keys.length > 4 ? `, and ${keys.length - 4} more` : "";
+	return `returned ${shown}${suffix}`;
+}
+
+function textFromInteractionResult(result: unknown): string | null {
+	if (!result || typeof result !== "object" || Array.isArray(result))
+		return null;
+	const record = result as Record<string, unknown>;
+	if (typeof record.text === "string" && record.text.trim()) {
+		return record.text.trim();
+	}
+	const nested = record.result;
+	if (nested && typeof nested === "object" && !Array.isArray(nested)) {
+		const nestedText = (nested as Record<string, unknown>).text;
+		if (typeof nestedText === "string" && nestedText.trim()) {
+			return nestedText.trim();
+		}
+	}
+	return null;
+}
+
+function successFromInteractionResult(result: unknown): boolean {
+	if (!result || typeof result !== "object" || Array.isArray(result))
+		return true;
+	const record = result as Record<string, unknown>;
+	if (typeof record.success === "boolean") return record.success;
+	const nested = record.result;
+	if (nested && typeof nested === "object" && !Array.isArray(nested)) {
+		const nestedSuccess = (nested as Record<string, unknown>).success;
+		if (typeof nestedSuccess === "boolean") return nestedSuccess;
+	}
+	return true;
 }
 
 /**
@@ -1071,3 +3077,6 @@ async function broadcastViewEvent(
 }
 
 export const viewsAction: Action = createViewsAction();
+export const closeViewAction: Action = createViewsAliasAction("CLOSE_VIEW");
+export const closeAllViewsAction: Action =
+	createViewsAliasAction("CLOSE_ALL_VIEWS");

--- a/plugins/plugin-app-control/src/evaluators/view-followup-routing.ts
+++ b/plugins/plugin-app-control/src/evaluators/view-followup-routing.ts
@@ -1,0 +1,190 @@
+import type {
+	ResponseHandlerEvaluator,
+	ResponseHandlerEvaluatorContext,
+	ViewCapability,
+} from "@elizaos/core";
+import {
+	createViewsClient,
+	type ViewSummary,
+} from "../actions/views-client.js";
+
+type CapabilityFamily = "create" | "delete" | "update";
+
+const VIEWS_ACTION_NAME = "VIEWS";
+const GENERAL_CONTEXT = "general";
+
+const CREATE_TOKENS = new Set(["ADD", "CREATE", "MAKE", "NEW", "PUT", "WRITE"]);
+const DELETE_TOKENS = new Set(["DELETE", "REMOVE", "CLEAR"]);
+const UPDATE_TOKENS = new Set([
+	"CHANGE",
+	"EDIT",
+	"MODIFY",
+	"RENAME",
+	"SET",
+	"UPDATE",
+]);
+const REFERENCE_TOKENS = new Set([
+	"ANOTHER",
+	"IT",
+	"ONE",
+	"SAME",
+	"THAT",
+	"THE",
+	"THEM",
+	"THESE",
+	"THIS",
+	"THOSE",
+]);
+const CONTENT_MARKER_TOKENS = new Set([
+	"BODY",
+	"CONTENT",
+	"DETAIL",
+	"DETAILS",
+	"NOTE",
+	"SAY",
+	"SAYING",
+	"SAYS",
+	"TEXT",
+	"TITLE",
+	"WITH",
+]);
+
+function textOf(value: unknown): string {
+	return typeof value === "string" ? value : "";
+}
+
+function tokenize(text: string): string[] {
+	return (
+		text
+			.toUpperCase()
+			.match(/[A-Z0-9]+/g)
+			?.map((token) => (token === "CALENDER" ? "CALENDAR" : token)) ?? []
+	);
+}
+
+function hasAny(
+	tokens: readonly string[],
+	accepted: ReadonlySet<string>,
+): boolean {
+	return tokens.some((token) => accepted.has(token));
+}
+
+function requestFamily(tokens: readonly string[]): CapabilityFamily | null {
+	if (hasAny(tokens, DELETE_TOKENS)) return "delete";
+	if (hasAny(tokens, UPDATE_TOKENS)) return "update";
+	if (hasAny(tokens, CREATE_TOKENS)) return "create";
+	return null;
+}
+
+function capabilityFamily(capability: ViewCapability): CapabilityFamily | null {
+	const tokens = tokenize(
+		[
+			capability.id,
+			capability.description,
+			...Object.keys(capability.params ?? {}),
+		].join(" "),
+	);
+	if (hasAny(tokens, DELETE_TOKENS)) return "delete";
+	if (hasAny(tokens, UPDATE_TOKENS)) return "update";
+	if (hasAny(tokens, CREATE_TOKENS)) return "create";
+	return null;
+}
+
+function viewSupportsFamily(
+	view: ViewSummary,
+	family: CapabilityFamily,
+): boolean {
+	return (view.capabilities ?? []).some(
+		(capability) => capabilityFamily(capability) === family,
+	);
+}
+
+function viewMentioned(tokens: readonly string[], view: ViewSummary): boolean {
+	const viewTokens = tokenize(
+		[
+			view.id,
+			view.label,
+			view.description,
+			...(view.tags ?? []),
+			...(view.capabilities ?? []).map((capability) => capability.id),
+		].join(" "),
+	);
+	const uniqueViewTokens = new Set(
+		viewTokens.filter((token) => token.length > 2 && !CREATE_TOKENS.has(token)),
+	);
+	return tokens.some((token) => uniqueViewTokens.has(token));
+}
+
+function hasRegisteredViewsAction(context: ResponseHandlerEvaluatorContext) {
+	return (context.runtime.actions ?? []).some(
+		(action) => action.name?.toUpperCase() === VIEWS_ACTION_NAME,
+	);
+}
+
+function shouldConsiderViewFollowup(
+	context: ResponseHandlerEvaluatorContext,
+): CapabilityFamily | null {
+	if (context.messageHandler.processMessage === "STOP") return null;
+	if (context.messageHandler.plan.requiresTool === true) return null;
+	if (!hasRegisteredViewsAction(context)) return null;
+
+	const tokens = tokenize(textOf(context.message.content?.text));
+	const family = requestFamily(tokens);
+	if (!family) return null;
+	if (!hasAny(tokens, REFERENCE_TOKENS)) return null;
+	if (family !== "delete" && !hasAny(tokens, CONTENT_MARKER_TOKENS)) {
+		return null;
+	}
+	return family;
+}
+
+async function resolveActiveViewForFamily(
+	family: CapabilityFamily,
+	tokens: readonly string[],
+): Promise<ViewSummary | null> {
+	const client = createViewsClient();
+	const current = await client.getCurrentView();
+	if (!current) return null;
+
+	const views = await client.listViews();
+	const activeView = views.find((view) => view.id === current.viewId);
+	if (!activeView || !viewSupportsFamily(activeView, family)) {
+		return null;
+	}
+	if (family === "delete" || viewMentioned(tokens, activeView)) {
+		return activeView;
+	}
+	if (hasAny(tokens, CONTENT_MARKER_TOKENS)) {
+		return activeView;
+	}
+	return null;
+}
+
+export const viewFollowupRoutingEvaluator: ResponseHandlerEvaluator = {
+	name: "app-control.view-followup-routing",
+	description:
+		"Routes context-dependent mutation follow-ups for the active UI view through the VIEWS action.",
+	priority: 20,
+	shouldRun: (context) => shouldConsiderViewFollowup(context) !== null,
+	evaluate: async (context) => {
+		const text = textOf(context.message.content?.text);
+		const tokens = tokenize(text);
+		const family = shouldConsiderViewFollowup(context);
+		if (!family) return undefined;
+
+		const activeView = await resolveActiveViewForFamily(family, tokens);
+		if (!activeView) return undefined;
+
+		return {
+			requiresTool: true,
+			clearReply: true,
+			reply: "On it.",
+			addContexts: [GENERAL_CONTEXT],
+			addCandidateActions: [VIEWS_ACTION_NAME],
+			addParentActionHints: [VIEWS_ACTION_NAME],
+			debug: [
+				`active view ${activeView.id} supports ${family}; routing follow-up through VIEWS`,
+			],
+		};
+	},
+};

--- a/plugins/plugin-app-control/src/index.ts
+++ b/plugins/plugin-app-control/src/index.ts
@@ -15,7 +15,12 @@
 import type { Plugin } from "@elizaos/core";
 import { appAction, createAppAction } from "./actions/app.js";
 import { homescreenAction } from "./actions/homescreen.js";
-import { viewsAction } from "./actions/views.js";
+import {
+	closeAllViewsAction,
+	closeViewAction,
+	viewsAction,
+} from "./actions/views.js";
+import { viewFollowupRoutingEvaluator } from "./evaluators/view-followup-routing.js";
 import { availableAppsProvider } from "./providers/available-apps.js";
 import { AppRegistryService } from "./services/app-registry-service.js";
 import { AppVerificationService } from "./services/app-verification.js";
@@ -32,10 +37,17 @@ export {
 	homescreenAction,
 } from "./actions/homescreen.js";
 export type { ViewsMode } from "./actions/views.js";
-export { createViewsAction, viewsAction } from "./actions/views.js";
+export {
+	closeAllViewsAction,
+	closeViewAction,
+	createViewsAction,
+	createViewsAliasAction,
+	viewsAction,
+} from "./actions/views.js";
 export type { ViewSummary } from "./actions/views-client.js";
 export type { AppControlClient } from "./client/api.js";
 export { createAppControlClient } from "./client/api.js";
+export { viewFollowupRoutingEvaluator } from "./evaluators/view-followup-routing.js";
 export {
 	APP_REGISTRY_SERVICE_TYPE,
 	type AppRegistryEntry,
@@ -68,10 +80,17 @@ export type {
 export { appAction, availableAppsProvider, createAppAction };
 
 export const appControlPlugin: Plugin = {
-	name: "app-control",
+	name: "@elizaos/plugin-app-control",
 	description:
 		"Launch, close, list, relaunch, load, and create Eliza apps from agent chat. Backed by the Eliza dashboard /api/apps/* HTTP surface. Also manages UI views via the VIEWS action.",
-	actions: [appAction, viewsAction, homescreenAction],
+	actions: [
+		appAction,
+		viewsAction,
+		closeViewAction,
+		closeAllViewsAction,
+		homescreenAction,
+	],
+	responseHandlerEvaluators: [viewFollowupRoutingEvaluator],
 	providers: [availableAppsProvider],
 	services: [
 		AppRegistryService,


### PR DESCRIPTION
## What
Adds dynamic plugin-view routing and an agent-driven interaction channel — the agent can **open / close / close-all / split / tile** plugin views, and views expose a server-side `interact` entrypoint so they can be driven programmatically.

## Changes
- **core** (`types/plugin.ts`): `ViewDeclaration.serverInteract` — plugins declare a server-handled interact entrypoint.
- **ui**: `DynamicViewLoader` + `view-interact-registry` (unmounted view clients stay silent; requestId dedup to drop stale replies), `app-navigate-view` wiring, `App` integration.
- **agent**: `views-routes` serverInteract handler, `views-registry`, `builtin-views`.
- **plugin-app-control**: `VIEWS` action close/close-all/split/tile sub-handlers, `views-client`, and a `view-followup-routing` evaluator.

## Scope notes
- The `plugin-simple-views` test fixture and the `ViewCatalog` restyle from the original branch are **intentionally excluded** — develop's `ViewCatalog` is used unchanged, and no new default plugin is registered. This keeps the PR to the routing infrastructure.
- All touched files are untouched on develop, so this rebases clean.

## Testing
`bun run --cwd packages/ui test` (view wiring/loader/interact-registry), `--cwd plugins/plugin-app-control test` (views), `--cwd packages/agent test` (views-routes) → **87 passing**. Cross-package typecheck via CI.

## Context
Extracted from #8340 (closed; drifted ~249 commits behind develop). Third in the focused-PR split, after #8443 and #8444.