### PR TITLE
feat(core): infer view-requests from chat + trajectory hardening

### DIFF
--- a/packages/agent/src/actions/page-action-groups.ts
+++ b/packages/agent/src/actions/page-action-groups.ts
@@ -205,7 +205,7 @@ export const pageDelegateAction: PageActionGroup = {
   descriptionCompressed:
     "PAGE_DELEGATE {page browser|wallet|settings|connectors|phone|owner, action CHILD}",
   routingHint:
-    'main-chat browser/wallet/settings/page operations -> PAGE_DELEGATE; browser navigation uses {page:"browser", action:"BROWSER_OPEN", url} or {page:"browser", action:"BROWSER", subaction:"open", url} through the browser page',
+    'main-chat browser/wallet/settings/connectors/phone/owner data operations -> PAGE_DELEGATE. Do not use PAGE_DELEGATE for UI view/window/panel/app navigation, opening/closing views, view manager, split/tile layout, or notes/calendar/notepad view switching; those belong to VIEWS. Browser web navigation still uses {page:"browser", action:"BROWSER_OPEN", url} or {page:"browser", action:"BROWSER", subaction:"open", url}.',
   validate: async () => true,
   handler: async (
     runtime: IAgentRuntime,

--- a/packages/agent/src/runtime/trajectory-export.ts
+++ b/packages/agent/src/runtime/trajectory-export.ts
@@ -17,6 +17,8 @@ import type {
 } from "../types/trajectory.ts";
 import {
   enrichTrajectoryLlmCall,
+  normalizePersistedTrajectoryTiming,
+  normalizePersistedUpdatedAt,
   normalizeStatus,
   normalizeTrajectoryMetadata,
   type PersistedLlmCall,
@@ -120,15 +122,25 @@ export function trajectoryRowToListItem(
       batchId: record.batch_id,
     },
   );
+  const status = normalizeStatus(record.status, "completed");
+  const startTime = toNumber(record.start_time, Date.now());
+  const timing = normalizePersistedTrajectoryTiming({
+    status,
+    startTime,
+    endTime: toOptionalNumber(record.end_time) ?? null,
+    durationMs: toOptionalNumber(record.duration_ms) ?? null,
+    createdAt: record.created_at,
+    updatedAt: record.updated_at,
+  });
 
   return {
     id: toText(record.id ?? record.trajectory_id, ""),
     agentId: toText(record.agent_id, agentId),
     source: toText(record.source, "runtime"),
-    status: normalizeStatus(record.status, "completed"),
-    startTime: toNumber(record.start_time, Date.now()),
-    endTime: toOptionalNumber(record.end_time) ?? null,
-    durationMs: toOptionalNumber(record.duration_ms) ?? null,
+    status,
+    startTime,
+    endTime: timing.endTime,
+    durationMs: timing.durationMs,
     stepCount: toNumber(record.step_count, 0),
     llmCallCount: toNumber(record.llm_call_count, 0),
     providerAccessCount: toNumber(record.provider_access_count, 0),
@@ -148,6 +160,12 @@ export function trajectoryRowToListItem(
       record.created_at,
       new Date(toNumber(record.start_time, Date.now())).toISOString(),
     ),
+    updatedAt: normalizePersistedUpdatedAt({
+      startTime,
+      endTime: timing.endTime,
+      createdAt: record.created_at,
+      updatedAt: record.updated_at,
+    }),
     metadata: normalizedMetadata.metadata as Record<
       string,
       JsonValue | undefined
@@ -159,8 +177,14 @@ export function persistedTrajectoryToDetailRecord(
   persisted: PersistedTrajectory,
   agentId: string,
 ): Trajectory {
-  const endTime =
-    typeof persisted.endTime === "number" ? persisted.endTime : undefined;
+  const timing = normalizePersistedTrajectoryTiming({
+    status: persisted.status,
+    startTime: persisted.startTime,
+    endTime: persisted.endTime,
+    createdAt: persisted.createdAt,
+    updatedAt: persisted.updatedAt,
+  });
+  const endTime = timing.endTime ?? undefined;
   return {
     trajectoryId: persisted.id,
     agentId,
@@ -168,9 +192,7 @@ export function persistedTrajectoryToDetailRecord(
     status: persisted.status,
     startTime: persisted.startTime,
     ...(endTime !== undefined ? { endTime } : {}),
-    ...(endTime !== undefined
-      ? { durationMs: Math.max(0, endTime - persisted.startTime) }
-      : {}),
+    ...(timing.durationMs !== null ? { durationMs: timing.durationMs } : {}),
     ...(persisted.scenarioId ? { scenarioId: persisted.scenarioId } : {}),
     ...(persisted.batchId ? { batchId: persisted.batchId } : {}),
     steps: persisted.steps.map((step) =>

--- a/packages/agent/src/runtime/trajectory-internals.ts
+++ b/packages/agent/src/runtime/trajectory-internals.ts
@@ -1087,14 +1087,13 @@ async function forwardMigrateStepsJsonToRows(
     // Find trajectories that have steps_json content but no rows yet.
     const result = await executeRawSql(
       runtime,
-      `SELECT t.id AS id, t.steps_json AS steps_json
+      `SELECT t.id AS id, CAST(t.steps_json AS TEXT) AS steps_json
        FROM trajectories t
        LEFT JOIN trajectory_steps s ON s.trajectory_id = t.id
        WHERE s.id IS NULL
          AND t.steps_json IS NOT NULL
-         AND t.steps_json <> ''
-         AND t.steps_json <> '[]'
-       GROUP BY t.id, t.steps_json`,
+         AND CAST(t.steps_json AS TEXT) <> ''
+         AND CAST(t.steps_json AS TEXT) <> '[]'`,
     );
     const rows = extractRows(result);
     if (rows.length === 0) return;
@@ -1165,7 +1164,7 @@ async function forwardMigrateStepsJsonToRows(
     }
 
     if (migrated > 0) {
-      coreLogger.warn(
+      coreLogger.info(
         `[trajectory-persistence] Forward-migrated ${migrated} step rows from steps_json into trajectory_steps`,
       );
     }
@@ -1197,6 +1196,91 @@ export function normalizeStatus(
     return status;
   }
   return fallback;
+}
+
+export function toOptionalEpochMs(value: unknown): number | undefined {
+  const directNumber = toOptionalNumber(value);
+  if (directNumber !== undefined) return directNumber;
+  const text = toOptionalText(value);
+  if (!text) return undefined;
+  const parsed = Date.parse(text);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function normalizePersistedTrajectoryTiming(input: {
+  status: TrajectoryStatus;
+  startTime: number;
+  endTime: number | null | undefined;
+  durationMs?: number | null;
+  createdAt?: unknown;
+  updatedAt?: unknown;
+}): { endTime: number | null; durationMs: number | null } {
+  if (input.status === "active") {
+    return { endTime: null, durationMs: null };
+  }
+
+  const startTime = Number.isFinite(input.startTime) ? input.startTime : 0;
+  const existingEndTime =
+    typeof input.endTime === "number" &&
+    Number.isFinite(input.endTime) &&
+    input.endTime > 0 &&
+    input.endTime >= startTime
+      ? input.endTime
+      : null;
+  const fallbackEndTime = startTime > 0 ? startTime : Date.now();
+  const endTime =
+    existingEndTime ??
+    [
+      toOptionalEpochMs(input.updatedAt),
+      toOptionalEpochMs(input.createdAt),
+      fallbackEndTime,
+    ].find(
+      (candidate): candidate is number =>
+        typeof candidate === "number" &&
+        Number.isFinite(candidate) &&
+        candidate > 0 &&
+        candidate >= startTime,
+    ) ??
+    startTime;
+  const durationMs =
+    existingEndTime !== null &&
+    typeof input.durationMs === "number" &&
+    Number.isFinite(input.durationMs) &&
+    input.durationMs >= 0
+      ? input.durationMs
+      : Math.max(0, endTime - startTime);
+
+  return { endTime, durationMs };
+}
+
+export function normalizePersistedUpdatedAt(input: {
+  startTime: number;
+  endTime: number | null | undefined;
+  createdAt?: unknown;
+  updatedAt?: unknown;
+}): string {
+  const startTime = Number.isFinite(input.startTime) ? input.startTime : 0;
+  const floorTime =
+    typeof input.endTime === "number" && Number.isFinite(input.endTime)
+      ? input.endTime
+      : startTime;
+  const updatedAtMs = toOptionalEpochMs(input.updatedAt);
+  const createdAtMs = toOptionalEpochMs(input.createdAt);
+  const timestamp =
+    (typeof updatedAtMs === "number" &&
+    updatedAtMs > 0 &&
+    updatedAtMs >= floorTime
+      ? updatedAtMs
+      : null) ??
+    (typeof input.endTime === "number" &&
+    Number.isFinite(input.endTime) &&
+    input.endTime > 0
+      ? input.endTime
+      : null) ??
+    (typeof createdAtMs === "number" && createdAtMs > 0 ? createdAtMs : null) ??
+    (startTime > 0 ? startTime : Date.now());
+
+  return new Date(timestamp).toISOString();
 }
 
 export function normalizeStepId(value: unknown): string | null {
@@ -1559,8 +1643,20 @@ export function parsePersistedTrajectoryRow(
     readRecordValue(row, ["start_time", "startTime"]),
     Date.now(),
   );
-  const endTime =
-    toOptionalNumber(readRecordValue(row, ["end_time", "endTime"])) ?? null;
+  const status = normalizeStatus(readRecordValue(row, ["status"]), "completed");
+  const rawCreatedAt = readRecordValue(row, ["created_at", "createdAt"]);
+  const rawUpdatedAt = readRecordValue(row, ["updated_at", "updatedAt"]);
+  const timing = normalizePersistedTrajectoryTiming({
+    status,
+    startTime,
+    endTime:
+      toOptionalNumber(readRecordValue(row, ["end_time", "endTime"])) ?? null,
+    durationMs:
+      toOptionalNumber(readRecordValue(row, ["duration_ms", "durationMs"])) ??
+      null,
+    createdAt: rawCreatedAt,
+    updatedAt: rawUpdatedAt,
+  });
   const steps = parseSteps(
     readRecordValue(row, ["steps_json", "stepsJson", "steps"]),
   );
@@ -1585,9 +1681,9 @@ export function parsePersistedTrajectoryRow(
       fallbackId,
     ),
     source: toText(readRecordValue(row, ["source"]), "runtime"),
-    status: normalizeStatus(readRecordValue(row, ["status"]), "completed"),
+    status,
     startTime,
-    endTime,
+    endTime: timing.endTime,
     scenarioId: normalizedMetadata.scenarioId,
     batchId: normalizedMetadata.batchId,
     steps,
@@ -1596,14 +1692,13 @@ export function parsePersistedTrajectoryRow(
       readRecordValue(row, ["total_reward", "totalReward"]),
       0,
     ),
-    createdAt: toText(
-      readRecordValue(row, ["created_at", "createdAt"]),
-      new Date(startTime).toISOString(),
-    ),
-    updatedAt: toText(
-      readRecordValue(row, ["updated_at", "updatedAt"]),
-      new Date(endTime ?? startTime).toISOString(),
-    ),
+    createdAt: toText(rawCreatedAt, new Date(startTime).toISOString()),
+    updatedAt: normalizePersistedUpdatedAt({
+      startTime,
+      endTime: timing.endTime,
+      createdAt: rawCreatedAt,
+      updatedAt: rawUpdatedAt,
+    }),
   };
 }
 
@@ -1767,7 +1862,17 @@ export async function saveTrajectory(
 
   const summary = summarizeTrajectory(trajectory);
   const isActive = trajectory.status === "active";
-  const endTime = isActive ? null : (trajectory.endTime ?? summary.endTime);
+  const persistedEndTime =
+    typeof trajectory.endTime === "number" &&
+    Number.isFinite(trajectory.endTime) &&
+    trajectory.endTime >= summary.startTime
+      ? trajectory.endTime
+      : undefined;
+  const summaryEndTime =
+    Number.isFinite(summary.endTime) && summary.endTime >= summary.startTime
+      ? summary.endTime
+      : summary.startTime;
+  const endTime = isActive ? null : (persistedEndTime ?? summaryEndTime);
   const durationMs =
     typeof endTime === "number"
       ? Math.max(0, endTime - summary.startTime)

--- a/packages/agent/src/runtime/trajectory-steps.test.ts
+++ b/packages/agent/src/runtime/trajectory-steps.test.ts
@@ -15,9 +15,14 @@
 import type { IAgentRuntime } from "@elizaos/core";
 import { beforeEach, describe, expect, it } from "vitest";
 import {
+  persistedTrajectoryToDetailRecord,
+  trajectoryRowToListItem,
+} from "./trajectory-export";
+import {
   ensureTrajectoriesTable,
   loadTrajectoryById,
   type PersistedTrajectory,
+  parsePersistedTrajectoryRow,
   saveTrajectory,
 } from "./trajectory-internals";
 import {
@@ -394,6 +399,42 @@ describe("trajectory_steps dedicated table", () => {
     runtime = createMockRuntime(engine);
   });
 
+  it("normalizes completed legacy trajectory rows before list and detail export", () => {
+    const row = {
+      id: "legacy-trajectory",
+      agent_id: "agent-1",
+      source: "runtime",
+      status: "completed",
+      start_time: 1_700_000_000_000,
+      end_time: 0,
+      duration_ms: null,
+      step_count: 0,
+      llm_call_count: 0,
+      provider_access_count: 0,
+      total_prompt_tokens: 0,
+      total_completion_tokens: 0,
+      total_cache_read_input_tokens: 0,
+      total_cache_creation_input_tokens: 0,
+      total_reward: 0,
+      steps_json: "[]",
+      metadata: "{}",
+      created_at: "2023-11-14T22:13:20.000Z",
+      updated_at: "2023-11-14T22:13:24.000Z",
+    };
+
+    const parsed = parsePersistedTrajectoryRow(row, "fallback");
+    const listItem = trajectoryRowToListItem(row, "agent-1");
+    const detail = persistedTrajectoryToDetailRecord(parsed, "agent-1");
+
+    expect(parsed.endTime).toBe(1_700_000_004_000);
+    expect(parsed.updatedAt).toBe("2023-11-14T22:13:24.000Z");
+    expect(listItem?.endTime).toBe(1_700_000_004_000);
+    expect(listItem?.durationMs).toBe(4_000);
+    expect(listItem?.updatedAt).toBe("2023-11-14T22:13:24.000Z");
+    expect(detail.endTime).toBe(1_700_000_004_000);
+    expect(detail.durationMs).toBe(4_000);
+  });
+
   it("creates the trajectory_steps table with no script length cap", async () => {
     const ok = await ensureTrajectoriesTable(runtime);
     expect(ok).toBe(true);
@@ -404,6 +445,40 @@ describe("trajectory_steps dedicated table", () => {
     expect(stepsTable?.columns.has("trajectory_id")).toBe(true);
     expect(stepsTable?.columns.has("ordinal")).toBe(true);
     expect(stepsTable?.columns.has("script")).toBe(true);
+  });
+
+  it("migrates legacy steps_json rows without grouping by the JSON column", async () => {
+    const legacySteps = [
+      {
+        stepId: "legacy-step-1",
+        stepNumber: 0,
+        timestamp: 1_700_000_000_000,
+        kind: "action",
+        script: "console.log('legacy');",
+        llmCalls: [],
+        providerAccesses: [],
+      },
+    ];
+    const trajectories = newTable();
+    trajectories.columns.add("id");
+    trajectories.columns.add("steps_json");
+    trajectories.rows.set(trajectoryId, {
+      id: trajectoryId,
+      steps_json: JSON.stringify(legacySteps),
+    });
+    engine.tables.set("trajectories", trajectories);
+
+    const ok = await ensureTrajectoriesTable(runtime);
+
+    expect(ok).toBe(true);
+    const stepsTable = engine.tables.get("trajectory_steps");
+    expect(stepsTable?.rows.size).toBe(1);
+    const migrated = [...(stepsTable?.rows.values() ?? [])][0];
+    expect(migrated?.id).toBe("legacy-step-1");
+    expect(migrated?.trajectory_id).toBe(trajectoryId);
+    expect(migrated?.ordinal).toBe(0);
+    expect(migrated?.step_type).toBe("action");
+    expect(migrated?.script).toBe("console.log('legacy');");
   });
 
   it("inserts 1000 steps and paginates them", async () => {

--- a/packages/agent/src/runtime/trajectory-storage.ts
+++ b/packages/agent/src/runtime/trajectory-storage.ts
@@ -382,8 +382,19 @@ async function writeCompletedTrajectoryStep({
   trajectory.source = source?.trim() || trajectory.source || "runtime";
   trajectory.status = normalizeStatus(status, "completed");
   trajectory.metadata = mergeMetadata(trajectory.metadata, metadata);
-  trajectory.endTime = Math.max(trajectory.endTime ?? now, now);
-  trajectory.startTime = Math.min(trajectory.startTime, now);
+  const previousStartTime =
+    typeof trajectory.startTime === "number" &&
+    Number.isFinite(trajectory.startTime)
+      ? trajectory.startTime
+      : now;
+  trajectory.startTime = Math.min(previousStartTime, now);
+  const previousEndTime =
+    typeof trajectory.endTime === "number" &&
+    Number.isFinite(trajectory.endTime) &&
+    trajectory.endTime >= trajectory.startTime
+      ? trajectory.endTime
+      : now;
+  trajectory.endTime = Math.max(previousEndTime, now, trajectory.startTime);
   ensureStep(trajectory, stepId, now);
   trajectory.updatedAt = new Date(now).toISOString();
 
@@ -728,6 +739,7 @@ export async function installDatabaseTrajectoryLogger(
 
     const runtimeKey = runtime as object;
     lastWritePromises.set(runtimeKey, writePromise);
+    await writePromise;
   };
 
   // Add query methods for API endpoints
@@ -1316,6 +1328,7 @@ export class DatabaseTrajectoryLogger extends Service {
 
     const runtimeKey = this.runtime as object;
     lastWritePromises.set(runtimeKey, writePromise);
+    await writePromise;
   }
 
   logLlmCall(params: Record<string, unknown>): void {

--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -108,6 +108,7 @@ const PLUGIN_SQL_GLOBAL_SINGLETONS = Symbol.for(
   "elizaos.plugin-sql.global-singletons",
 );
 const ELIZA_AUTO_RESET_PGLITE_ERROR_CODE = "ELIZA_PGLITE_MANUAL_RESET_REQUIRED";
+const APP_ROUTE_PLUGIN_ALIASES = new Map([["personal-assistant", "lifeops"]]);
 
 export const shutdownRuntime = upstreamShutdownRuntime;
 
@@ -509,14 +510,17 @@ export function getDeferAppRoutesEnabled(
  * alias for forgiving matching: lowercase, drop the `@elizaos/plugin-` prefix
  * and the `:routes` / `-app` / `-ui` / `-routes` suffixes. So
  * `@elizaos/plugin-steward-app` and `steward` both normalize to `steward`.
+ * Legacy product names are normalized after structural cleanup, so `lifeops`
+ * still skips the personal-assistant route plugin.
  */
 export function normalizeAppRoutePluginId(id: string): string {
-  return id
+  const normalized = id
     .trim()
     .toLowerCase()
     .replace(/^@elizaos\/plugin-/, "")
     .replace(/:routes$/, "")
     .replace(/-(app|ui|routes)$/, "");
+  return APP_ROUTE_PLUGIN_ALIASES.get(normalized) ?? normalized;
 }
 
 function getAppRoutePluginLoaders(): AppRoutePluginRegistryEntry[] {

--- a/packages/app-core/src/runtime/eliza.ts
+++ b/packages/app-core/src/runtime/eliza.ts
@@ -108,7 +108,6 @@ const PLUGIN_SQL_GLOBAL_SINGLETONS = Symbol.for(
   "elizaos.plugin-sql.global-singletons",
 );
 const ELIZA_AUTO_RESET_PGLITE_ERROR_CODE = "ELIZA_PGLITE_MANUAL_RESET_REQUIRED";
-const APP_ROUTE_PLUGIN_ALIASES = new Map([["personal-assistant", "lifeops"]]);
 
 export const shutdownRuntime = upstreamShutdownRuntime;
 
@@ -510,17 +509,14 @@ export function getDeferAppRoutesEnabled(
  * alias for forgiving matching: lowercase, drop the `@elizaos/plugin-` prefix
  * and the `:routes` / `-app` / `-ui` / `-routes` suffixes. So
  * `@elizaos/plugin-steward-app` and `steward` both normalize to `steward`.
- * Legacy product names are normalized after structural cleanup, so `lifeops`
- * still skips the personal-assistant route plugin.
  */
 export function normalizeAppRoutePluginId(id: string): string {
-  const normalized = id
+  return id
     .trim()
     .toLowerCase()
     .replace(/^@elizaos\/plugin-/, "")
     .replace(/:routes$/, "")
     .replace(/-(app|ui|routes)$/, "");
-  return APP_ROUTE_PLUGIN_ALIASES.get(normalized) ?? normalized;
 }
 
 function getAppRoutePluginLoaders(): AppRoutePluginRegistryEntry[] {

--- a/packages/core/src/features/trajectories/TrajectoriesService.ts
+++ b/packages/core/src/features/trajectories/TrajectoriesService.ts
@@ -96,6 +96,7 @@ export interface TrajectoryListItem {
 	scenarioId: string | null;
 	batchId: string | null;
 	createdAt: string;
+	updatedAt?: string;
 }
 
 export interface TrajectoryStats {
@@ -164,6 +165,19 @@ function asIsoString(value: SqlCell | undefined): string {
 	const parsed = new Date(asText);
 	if (Number.isNaN(parsed.getTime())) return new Date(0).toISOString();
 	return parsed.toISOString();
+}
+
+function asEpochMs(value: SqlCell | undefined): number | null {
+	if (value instanceof Date) {
+		const timestamp = value.getTime();
+		return Number.isFinite(timestamp) ? timestamp : null;
+	}
+	const directNumber = asNumber(value);
+	if (directNumber !== null) return directNumber;
+	const asText = asString(value);
+	if (!asText) return null;
+	const parsed = Date.parse(asText);
+	return Number.isFinite(parsed) ? parsed : null;
 }
 
 function pickCell(row: SqlRow, ...keys: string[]): SqlCell | undefined {
@@ -747,6 +761,87 @@ type TrajectoryStatus =
 	| "error"
 	| "timeout"
 	| "terminated";
+
+function isFinalTrajectoryStatus(status: unknown): boolean {
+	return (
+		status === "completed" ||
+		status === "error" ||
+		status === "timeout" ||
+		status === "terminated"
+	);
+}
+
+function normalizeReadTrajectoryTiming(input: {
+	status: unknown;
+	startTime: number;
+	endTime: number | null;
+	durationMs: number | null;
+	createdAtMs?: number | null;
+	updatedAtMs?: number | null;
+}): { endTime: number | null; durationMs: number | null } {
+	if (!isFinalTrajectoryStatus(input.status)) {
+		return { endTime: null, durationMs: null };
+	}
+
+	const startTime = Number.isFinite(input.startTime) ? input.startTime : 0;
+	const existingEndTime =
+		typeof input.endTime === "number" &&
+		Number.isFinite(input.endTime) &&
+		input.endTime > 0 &&
+		input.endTime >= startTime
+			? input.endTime
+			: null;
+	const fallbackEndTime = startTime > 0 ? startTime : Date.now();
+	const endTime =
+		existingEndTime ??
+		[input.updatedAtMs, input.createdAtMs, fallbackEndTime].find(
+			(candidate): candidate is number =>
+				typeof candidate === "number" &&
+				Number.isFinite(candidate) &&
+				candidate > 0 &&
+				candidate >= startTime,
+		) ??
+		startTime;
+	const durationMs =
+		existingEndTime !== null &&
+		typeof input.durationMs === "number" &&
+		Number.isFinite(input.durationMs) &&
+		input.durationMs >= 0
+			? input.durationMs
+			: Math.max(0, endTime - startTime);
+
+	return { endTime, durationMs };
+}
+
+function normalizeReadTrajectoryUpdatedAt(input: {
+	startTime: number;
+	endTime: number | null;
+	createdAtMs?: number | null;
+	updatedAtMs?: number | null;
+}): string {
+	const startTime = Number.isFinite(input.startTime) ? input.startTime : 0;
+	const floorTime =
+		typeof input.endTime === "number" && Number.isFinite(input.endTime)
+			? input.endTime
+			: startTime;
+	const timestamp =
+		(typeof input.updatedAtMs === "number" &&
+		input.updatedAtMs > 0 &&
+		input.updatedAtMs >= floorTime
+			? input.updatedAtMs
+			: null) ??
+		(typeof input.endTime === "number" &&
+		Number.isFinite(input.endTime) &&
+		input.endTime > 0
+			? input.endTime
+			: null) ??
+		(typeof input.createdAtMs === "number" && input.createdAtMs > 0
+			? input.createdAtMs
+			: null) ??
+		(startTime > 0 ? startTime : Date.now());
+
+	return new Date(timestamp).toISOString();
+}
 
 type StartTrajectoryOptions = {
 	agentId?: string;
@@ -2184,7 +2279,7 @@ export class TrajectoriesService extends Service {
         id, agent_id, source, status, start_time, end_time, duration_ms,
         step_count, llm_call_count, total_prompt_tokens, total_completion_tokens,
         total_cache_read_input_tokens, total_cache_creation_input_tokens,
-        total_reward, scenario_id, batch_id, created_at
+        total_reward, scenario_id, batch_id, created_at, updated_at
       FROM trajectories
       ${whereClause}
       ORDER BY created_at DESC
@@ -2195,6 +2290,15 @@ export class TrajectoriesService extends Service {
 			const status =
 				(asString(pickCell(row, "status")) as TrajectoryListItem["status"]) ??
 				"completed";
+			const startTime = asNumber(pickCell(row, "start_time")) ?? 0;
+			const timing = normalizeReadTrajectoryTiming({
+				status,
+				startTime,
+				endTime: asNumber(pickCell(row, "end_time")),
+				durationMs: asNumber(pickCell(row, "duration_ms")),
+				createdAtMs: asEpochMs(pickCell(row, "created_at")),
+				updatedAtMs: asEpochMs(pickCell(row, "updated_at")),
+			});
 			const rawLlmCallCount = asNumber(pickCell(row, "llm_call_count")) ?? 0;
 			const llmCallCount = rawLlmCallCount;
 
@@ -2203,9 +2307,9 @@ export class TrajectoriesService extends Service {
 				agentId: asString(pickCell(row, "agent_id")) ?? "",
 				source: asString(pickCell(row, "source")) ?? "chat",
 				status,
-				startTime: asNumber(pickCell(row, "start_time")) ?? 0,
-				endTime: asNumber(pickCell(row, "end_time")),
-				durationMs: asNumber(pickCell(row, "duration_ms")),
+				startTime,
+				endTime: timing.endTime,
+				durationMs: timing.durationMs,
 				stepCount: asNumber(pickCell(row, "step_count")) ?? 0,
 				llmCallCount,
 				totalPromptTokens: asNumber(pickCell(row, "total_prompt_tokens")) ?? 0,
@@ -2219,6 +2323,12 @@ export class TrajectoriesService extends Service {
 				scenarioId: asString(pickCell(row, "scenario_id")),
 				batchId: asString(pickCell(row, "batch_id")),
 				createdAt: asIsoString(pickCell(row, "created_at")),
+				updatedAt: normalizeReadTrajectoryUpdatedAt({
+					startTime,
+					endTime: timing.endTime,
+					createdAtMs: asEpochMs(pickCell(row, "created_at")),
+					updatedAtMs: asEpochMs(pickCell(row, "updated_at")),
+				}),
 			};
 		});
 
@@ -2410,10 +2520,23 @@ export class TrajectoriesService extends Service {
 		updatedAt: string;
 	} {
 		const finalStatus = trajectory.metrics.finalStatus;
-		const normalizedEndTime =
-			typeof trajectory.endTime === "number" && trajectory.endTime > 0
-				? trajectory.endTime
-				: null;
+		const rawEndTime =
+			typeof trajectory.endTime === "number" ? trajectory.endTime : null;
+		const timingStatus = isFinalTrajectoryStatus(finalStatus)
+			? finalStatus
+			: rawEndTime
+				? "completed"
+				: "active";
+		const timing = normalizeReadTrajectoryTiming({
+			status: timingStatus,
+			startTime: trajectory.startTime,
+			endTime: rawEndTime,
+			durationMs:
+				typeof trajectory.durationMs === "number"
+					? trajectory.durationMs
+					: null,
+		});
+		const normalizedEndTime = timing.endTime;
 		const status: "active" | "completed" | "error" =
 			finalStatus === "timeout" ||
 			finalStatus === "terminated" ||
@@ -2448,12 +2571,7 @@ export class TrajectoriesService extends Service {
 			typeof value === "string" ? value : null;
 		const source =
 			typeof metadata.source === "string" ? metadata.source : "chat";
-		const normalizedDurationMs =
-			status === "active"
-				? null
-				: typeof trajectory.durationMs === "number"
-					? trajectory.durationMs
-					: null;
+		const normalizedDurationMs = status === "active" ? null : timing.durationMs;
 		const updatedAtMs =
 			normalizedEndTime ?? (trajectory.startTime || Date.now());
 
@@ -2640,14 +2758,30 @@ export class TrajectoriesService extends Service {
 	// ─────────────────────────────────────────────────────────────────────────
 
 	private rowToTrajectory(row: SqlRow): Trajectory {
+		const startTime = asNumber(pickCell(row, "start_time")) ?? 0;
+		const metrics = parseTrajectoryMetrics(
+			pickCell(row, "metrics_json", "metrics"),
+		);
+		const timing = normalizeReadTrajectoryTiming({
+			status:
+				asString(pickCell(row, "status")) ??
+				stringValue(metrics.finalStatus) ??
+				"completed",
+			startTime,
+			endTime: asNumber(pickCell(row, "end_time")),
+			durationMs: asNumber(pickCell(row, "duration_ms")),
+			createdAtMs: asEpochMs(pickCell(row, "created_at")),
+			updatedAtMs: asEpochMs(pickCell(row, "updated_at")),
+		});
+
 		return {
 			trajectoryId: (asString(pickCell(row, "id")) ??
 				"") as `${string}-${string}-${string}-${string}-${string}`,
 			agentId: (asString(pickCell(row, "agent_id")) ??
 				"") as `${string}-${string}-${string}-${string}-${string}`,
-			startTime: asNumber(pickCell(row, "start_time")) ?? 0,
-			endTime: asNumber(pickCell(row, "end_time")) ?? 0,
-			durationMs: asNumber(pickCell(row, "duration_ms")) ?? 0,
+			startTime,
+			endTime: timing.endTime ?? 0,
+			durationMs: timing.durationMs ?? 0,
 			scenarioId: asString(pickCell(row, "scenario_id")) ?? undefined,
 			episodeId: asString(pickCell(row, "episode_id")) ?? undefined,
 			batchId: asString(pickCell(row, "batch_id")) ?? undefined,
@@ -2657,7 +2791,7 @@ export class TrajectoriesService extends Service {
 			rewardComponents: parseRewardComponents(
 				pickCell(row, "reward_components_json", "reward_components"),
 			),
-			metrics: parseTrajectoryMetrics(pickCell(row, "metrics_json", "metrics")),
+			metrics,
 			metadata: parseTrajectoryMetadata(
 				pickCell(row, "metadata_json", "metadata"),
 			),

--- a/packages/core/src/runtime/action-retrieval.ts
+++ b/packages/core/src/runtime/action-retrieval.ts
@@ -178,7 +178,64 @@ const CANDIDATE_ACTION_PARENT_ALIASES: Record<string, string> = {
 	SEARCH_CHAT: "MESSAGE",
 	FIND_MESSAGES: "MESSAGE",
 	FIND_MESSAGE: "MESSAGE",
+	ARRANGE_VIEWS: "VIEWS",
+	CLOSE_ALL_VIEWS: "VIEWS",
+	CLOSE_VIEW: "VIEWS",
+	LIST_VIEWS: "VIEWS",
+	OPEN_APP: "VIEWS",
+	OPEN_APPLICATION: "VIEWS",
+	OPEN_VIEW: "VIEWS",
+	SHOW_APP: "VIEWS",
+	SHOW_APPLICATION: "VIEWS",
+	SHOW_VIEW: "VIEWS",
+	SPLIT_VIEW: "VIEWS",
+	SPLIT_VIEWS: "VIEWS",
+	SWITCH_VIEW: "VIEWS",
+	TILE_VIEWS: "VIEWS",
+	VIEW_MANAGER: "VIEWS",
 };
+
+const VIEW_SURFACE_TOKENS = new Set([
+	"VIEW",
+	"VIEWS",
+	"WINDOW",
+	"WINDOWS",
+	"PANEL",
+	"PANELS",
+	"APP",
+	"APPS",
+	"APPLICATION",
+	"APPLICATIONS",
+	"PLUGIN",
+	"PLUGINS",
+]);
+
+const VIEW_OPERATION_TOKENS = new Set([
+	"ADD",
+	"ARRANGE",
+	"CLOSE",
+	"CREATE",
+	"DELETE",
+	"DISMISS",
+	"GET",
+	"GO",
+	"HIDE",
+	"LAYOUT",
+	"LIST",
+	"MANAGER",
+	"NAVIGATE",
+	"OPEN",
+	"PIN",
+	"READ",
+	"REMOVE",
+	"SELECT",
+	"SET",
+	"SHOW",
+	"SPLIT",
+	"SWITCH",
+	"TILE",
+	"UPDATE",
+]);
 
 function resolveTierOverridesFromEnv():
 	| { topK: number; stageWeights: Partial<Record<RetrievalStageName, number>> }
@@ -218,7 +275,9 @@ export function retrieveActions(
 	const parentActionHints = dedupeNormalizedStrings([
 		...(input.parentActionHints ?? []),
 		...candidateActions.flatMap((actionName) =>
-			parentAliasesForCandidateAction(actionName),
+			candidateNamespaceParentExists(input.catalog.parents, actionName)
+				? []
+				: parentAliasesForCandidateAction(actionName),
 		),
 	]);
 	const recentConversationText = shouldUseRecentConversationForActionSearch(
@@ -762,10 +821,69 @@ function dedupeNormalizedStrings(values: string[] | undefined): string[] {
 	return result;
 }
 
-function parentAliasesForCandidateAction(actionName: string): string[] {
+export function parentAliasesForCandidateAction(actionName: string): string[] {
 	const normalized = normalizeActionName(actionName);
 	const parent = CANDIDATE_ACTION_PARENT_ALIASES[normalized];
-	return parent ? [parent] : [];
+	if (parent) return [parent];
+	if (looksLikeViewCandidateAction(normalized)) return ["VIEWS"];
+	return [];
+}
+
+function looksLikeViewCandidateAction(normalizedActionName: string): boolean {
+	if (!normalizedActionName) return false;
+	const tokens = new Set(normalizedActionName.split(/_+/).filter(Boolean));
+	const hasViewSurface = hasAnyToken(tokens, VIEW_SURFACE_TOKENS);
+	const hasViewOperation = hasAnyToken(tokens, VIEW_OPERATION_TOKENS);
+	const hasGeneratedCapabilityShape =
+		hasViewOperation && tokens.size >= 2 && !hasOnlyOperationTokens(tokens);
+	return hasViewOperation && (hasViewSurface || hasGeneratedCapabilityShape);
+}
+
+function hasAnyToken(tokens: Set<string>, expected: Set<string>): boolean {
+	for (const token of tokens) {
+		if (expected.has(token)) return true;
+	}
+	return false;
+}
+
+function hasOnlyOperationTokens(tokens: Set<string>): boolean {
+	for (const token of tokens) {
+		if (!VIEW_OPERATION_TOKENS.has(token)) return false;
+	}
+	return true;
+}
+
+export function candidateNamespaceParentExists(
+	parents: readonly Pick<ActionCatalogParent, "normalizedName">[],
+	actionName: string,
+): boolean {
+	const normalized = normalizeActionName(actionName);
+	const tokens = normalized.split("_").filter(Boolean);
+	if (
+		tokens.length < 2 ||
+		normalized === "VIEWS" ||
+		hasAnyToken(new Set(tokens), VIEW_SURFACE_TOKENS)
+	) {
+		return false;
+	}
+	const domainTokens = tokens.filter(
+		(token) => !VIEW_OPERATION_TOKENS.has(token) && token !== "VIEWS",
+	);
+	return parents.some((parent) =>
+		domainTokens.some((token) => actionTokenMatchesParent(token, parent)),
+	);
+}
+
+function actionTokenMatchesParent(
+	token: string,
+	parent: Pick<ActionCatalogParent, "normalizedName">,
+): boolean {
+	const parentName = parent.normalizedName;
+	return (
+		parentName === token ||
+		parentName === `${token}S` ||
+		(parentName.endsWith("S") && parentName.slice(0, -1) === token)
+	);
 }
 
 function shouldUseRecentConversationForActionSearch(

--- a/packages/core/src/runtime/action-tiering.ts
+++ b/packages/core/src/runtime/action-tiering.ts
@@ -3,7 +3,11 @@ import {
 	type ActionCatalogParent,
 	normalizeActionName,
 } from "./action-catalog";
-import type { ActionRetrievalResult } from "./action-retrieval";
+import {
+	type ActionRetrievalResult,
+	candidateNamespaceParentExists,
+	parentAliasesForCandidateAction,
+} from "./action-retrieval";
 
 export const TIER0_PROTOCOL_ACTIONS = [
 	"IGNORE",
@@ -106,7 +110,10 @@ export function tierActionResults(
 	// it to tier-B and the safety fallback would fire, leaving FILE/BASH in
 	// tier-A. By narrowing first we collapse tier-A to only the candidates,
 	// and the cap then applies to that smaller set.
-	const narrowSet = normalizeCandidateSet(input.narrowToCandidateActions);
+	const narrowSet = normalizeCandidateSet(
+		input.narrowToCandidateActions,
+		input.catalog.parents,
+	);
 	if (narrowSet.size > 0) {
 		const canonicalOwnersByCandidate = new Map<string, Set<string>>();
 		for (const candidate of narrowSet) {
@@ -349,6 +356,7 @@ function sortedUnique(values: readonly string[]): string[] {
 
 function normalizeCandidateSet(
 	values: readonly string[] | undefined,
+	parents: readonly Pick<ActionCatalogParent, "normalizedName">[],
 ): Set<string> {
 	// normalizeActionName produces the same UPPER_SNAKE_CASE form the catalog
 	// uses for normalizedName / childNormalizedNames, so candidate names line
@@ -364,6 +372,15 @@ function normalizeCandidateSet(
 		const normalized = normalizeActionName(value);
 		if (normalized) {
 			set.add(normalized);
+			if (candidateNamespaceParentExists(parents, normalized)) {
+				continue;
+			}
+			for (const parentAlias of parentAliasesForCandidateAction(normalized)) {
+				const normalizedAlias = normalizeActionName(parentAlias);
+				if (normalizedAlias) {
+					set.add(normalizedAlias);
+				}
+			}
 		}
 	}
 	return set;

--- a/packages/core/src/runtime/evaluator.ts
+++ b/packages/core/src/runtime/evaluator.ts
@@ -1,6 +1,10 @@
 import { computeCallCostUsd } from "../features/trajectories/pricing";
 import { evaluatorSchema, evaluatorTemplate } from "../prompts/evaluator";
-import { emitStreamingHook, getStreamingContext } from "../streaming-context";
+import {
+	emitStreamingHook,
+	getStreamingContext,
+	runWithStreamingContext,
+} from "../streaming-context";
 import type { EvaluationResult } from "../types/components";
 import {
 	type ChatMessage,
@@ -69,6 +73,7 @@ const DEFAULT_EVALUATOR_MAX_TOKENS = 1024;
 export async function runEvaluator(
 	params: RunEvaluatorParams,
 ): Promise<EvaluatorOutput> {
+	const streamingContext = getStreamingContext();
 	const renderedInput = renderEvaluatorModelInput({
 		context: params.context,
 		trajectory: params.trajectory,
@@ -103,16 +108,25 @@ export async function runEvaluator(
 	};
 	const startedAt = Date.now();
 	const modelType = params.modelType ?? ModelType.RESPONSE_HANDLER;
-	const raw = await params.runtime.useModel(
-		modelType,
-		{
-			messages: renderedInput.messages,
-			maxTokens: DEFAULT_EVALUATOR_MAX_TOKENS,
-			responseSchema: evaluatorSchema,
-			promptSegments: renderedInput.promptSegments,
-			providerOptions,
-		},
-		params.provider,
+	const raw = await runWithStreamingContext(
+		streamingContext
+			? {
+					...streamingContext,
+					onStreamChunk: async () => undefined,
+				}
+			: undefined,
+		() =>
+			params.runtime.useModel(
+				modelType,
+				{
+					messages: renderedInput.messages,
+					maxTokens: DEFAULT_EVALUATOR_MAX_TOKENS,
+					responseSchema: evaluatorSchema,
+					promptSegments: renderedInput.promptSegments,
+					providerOptions,
+				},
+				params.provider,
+			),
 	);
 	const endedAt = Date.now();
 	const output = sanitizeOutputMessage(
@@ -132,7 +146,6 @@ export async function runEvaluator(
 			params.trajectory,
 		),
 	);
-	const streamingContext = getStreamingContext();
 	await emitStreamingHook(streamingContext, "onEvaluation", {
 		evaluation: output,
 		messageId: streamingContext?.messageId,

--- a/packages/core/src/runtime/planner-loop.ts
+++ b/packages/core/src/runtime/planner-loop.ts
@@ -4,7 +4,11 @@ import { computeCallCostUsd } from "../features/trajectories/pricing";
 import { logger } from "../logger";
 import { plannerSchema, plannerTemplate } from "../prompts/planner";
 import { resolveOptimizedPromptForRuntime } from "../services/optimized-prompt-resolver";
-import { emitStreamingHook, getStreamingContext } from "../streaming-context";
+import {
+	emitStreamingHook,
+	getStreamingContext,
+	runWithStreamingContext,
+} from "../streaming-context";
 import type { ActionResult, ProviderDataRecord } from "../types/components";
 import type { ContextEvent, ContextObjectTool } from "../types/context-object";
 import {
@@ -1090,10 +1094,15 @@ async function callPlanner(params: {
 
 	const startedAt = Date.now();
 	const modelType = params.modelType ?? ModelType.ACTION_PLANNER;
-	const raw = await params.runtime.useModel(
-		modelType,
-		modelParams,
-		params.provider,
+	const streamingContext = getStreamingContext();
+	const raw = await runWithStreamingContext(
+		streamingContext
+			? {
+					...streamingContext,
+					onStreamChunk: async () => undefined,
+				}
+			: undefined,
+		() => params.runtime.useModel(modelType, modelParams, params.provider),
 	);
 	const endedAt = Date.now();
 

--- a/packages/core/src/services/message.ts
+++ b/packages/core/src/services/message.ts
@@ -2114,6 +2114,7 @@ async function collectV5PlannerCandidateActions(args: {
 	message: Memory;
 	state: State;
 	selectedContexts?: readonly AgentContext[];
+	candidateActions?: readonly string[];
 	userRoles?: readonly RoleGateRole[];
 }): Promise<Action[]> {
 	// We used to filter the candidate set by `action.contexts` against the
@@ -2128,6 +2129,7 @@ async function collectV5PlannerCandidateActions(args: {
 	// outside its declared context, while avoiding dead tools that the planner
 	// could select but execution would immediately reject.
 	const allRuntimeActions = args.runtime.actions;
+	const actionLookup = buildRuntimeActionLookup(args.runtime);
 	const actionsByName = new Map(
 		allRuntimeActions.map((action) => [action.name, action]),
 	);
@@ -2198,6 +2200,16 @@ async function collectV5PlannerCandidateActions(args: {
 
 	for (const action of allRuntimeActions) {
 		await appendIfAllowed(action);
+	}
+
+	for (const candidateName of args.candidateActions ?? []) {
+		const action = resolveRuntimeAction(actionLookup, candidateName);
+		if (!action) continue;
+		await appendIfAllowed(
+			action,
+			undefined,
+			mergeAgentContexts(args.selectedContexts, action.contexts),
+		);
 	}
 
 	for (let index = 0; index < selectedActions.length; index += 1) {
@@ -2339,7 +2351,7 @@ const ACTION_CATALOG_CACHE_LIMIT = 8;
 function actionCatalogCacheKey(actions: readonly Action[]): string {
 	let key = "";
 	for (const action of actions) {
-		key += `${action.name} `;
+		key += `${action.name}\u0000`;
 	}
 	return key;
 }
@@ -2747,6 +2759,43 @@ const BUILTIN_RESPONSE_HANDLER_EVALUATORS: readonly ResponseHandlerEvaluator[] =
 					clearReply: true,
 					debug: [
 						`voice turn signal suppressed reply (${signal?.source ?? "unknown"}; p=${typeof signal?.endOfTurnProbability === "number" ? signal.endOfTurnProbability.toFixed(3) : "n/a"}; next=${signal?.nextSpeaker ?? "unknown"})`,
+					],
+				};
+			},
+		},
+		{
+			name: "core.simple_registered_action_request",
+			description:
+				"Promotes simple-path replies to planning when the current user request matches a registered action's metadata.",
+			priority: 20,
+			shouldRun: ({ message, messageHandler, runtime }) => {
+				if (messageHandler.processMessage !== "RESPOND") return false;
+				if (messageHandler.plan.requiresTool === true) return false;
+				const nonSimpleContexts = (messageHandler.plan.contexts ?? []).filter(
+					(context) => context !== SIMPLE_CONTEXT_ID,
+				);
+				if (nonSimpleContexts.length > 0) return false;
+				const text = getUserMessageText(message);
+				if (!text?.trim()) return false;
+				return (
+					inferDirectCurrentRequestCandidateActions(runtime.actions ?? [], text)
+						.length > 0
+				);
+			},
+			evaluate: ({ message, runtime }) => {
+				const text = getUserMessageText(message) ?? "";
+				const candidateActions = inferDirectCurrentRequestCandidateActions(
+					runtime.actions ?? [],
+					text,
+				);
+				if (candidateActions.length === 0) return undefined;
+				return {
+					requiresTool: true,
+					addContexts: ["general"],
+					addCandidateActions: candidateActions,
+					reply: "On it.",
+					debug: [
+						`current request matched registered action metadata: ${candidateActions.join(", ")}`,
 					],
 				};
 			},
@@ -3412,19 +3461,23 @@ export function messageHandlerFromFieldResult(
 				...inferredAckCandidateActions,
 				...inferredDirectCandidateActions,
 			]);
+	const runnableCandidateActions = filterRunnableCandidateActions(
+		effectiveCandidateActions,
+		runtimeContext,
+	);
+	const planCandidateActions =
+		inferredDirectCandidateActions.length > 0 &&
+		candidateActions.length > 0 &&
+		!hasValidProvidedCandidate
+			? runnableCandidateActions
+			: effectiveCandidateActions;
 	// When the caller passes the runtime's `actions`, narrow the candidate set
 	// to those that are (a) registered actions OR (b) canonical control names
 	// (REPLY / IGNORE / STOP). All-bogus candidate lists collapse to length 0,
 	// which lets the routing logic below fall back to simple-reply when the
 	// only context is "simple". When no `runtimeContext` is provided, behaviour
 	// is unchanged (back-compat).
-	const validCandidateCount = runtimeContext
-		? effectiveCandidateActions.filter((name) => {
-				const normalized = normalizeActionIdentifier(name);
-				if (canonicalPlannerControlActionName(normalized) !== null) return true;
-				return exposedActionMatches(runtimeContext.actions, normalized);
-			}).length
-		: effectiveCandidateActions.length;
+	const validCandidateCount = runnableCandidateActions.length;
 	const facts = Array.isArray(result.facts)
 		? result.facts.map((fact) => String(fact).trim()).filter(Boolean)
 		: [];
@@ -3510,7 +3563,7 @@ export function messageHandlerFromFieldResult(
 		!modelCommittedToDelegation &&
 		shouldPreferCompleteDirectReply({
 			replyText: replyTextRaw,
-			candidateActions: effectiveCandidateActions,
+			candidateActions: runnableCandidateActions,
 			contexts: routedContexts,
 		});
 	const preferInlineCodeSnippetDirectReply =
@@ -3518,7 +3571,7 @@ export function messageHandlerFromFieldResult(
 		requestedPlanning &&
 		shouldPreferInlineCodeSnippetDirectReply({
 			currentMessageText,
-			candidateActions: effectiveCandidateActions,
+			candidateActions: runnableCandidateActions,
 			contexts: routedContexts,
 		});
 	const shouldPlan =
@@ -3555,9 +3608,9 @@ export function messageHandlerFromFieldResult(
 	if (
 		!preferCompleteDirectReply &&
 		!preferInlineCodeSnippetDirectReply &&
-		effectiveCandidateActions.length > 0
+		planCandidateActions.length > 0
 	) {
-		plan.candidateActions = effectiveCandidateActions;
+		plan.candidateActions = planCandidateActions;
 	}
 	const extract =
 		facts.length > 0 || relationships.length > 0 || addressedTo.length > 0
@@ -3655,6 +3708,74 @@ function candidateActionsContainRunnableAction(
 		if (canonicalPlannerControlActionName(normalized) !== null) return true;
 		return exposedActionMatches(runtimeContext.actions, normalized);
 	});
+}
+
+function filterRunnableCandidateActions(
+	candidateActions: readonly string[],
+	runtimeContext:
+		| {
+				actions: ReadonlyArray<Pick<Action, "name" | "similes">>;
+		  }
+		| undefined,
+): string[] {
+	if (!runtimeContext) return [...candidateActions];
+	return candidateActions.filter((name) => {
+		const normalized = normalizeActionIdentifier(name);
+		if (canonicalPlannerControlActionName(normalized) !== null) return true;
+		return exposedActionMatches(runtimeContext.actions, normalized);
+	});
+}
+
+function applyDirectCurrentCandidateBackstopToMessageHandler(
+	messageHandler: MessageHandlerResult,
+	runtimeContext:
+		| {
+				actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
+				messageText?: string;
+		  }
+		| undefined,
+): MessageHandlerResult {
+	const currentMessageText = runtimeContext?.messageText ?? "";
+	if (
+		messageHandler.processMessage !== "RESPOND" ||
+		!runtimeContext ||
+		currentMessageText.trim().length === 0
+	) {
+		return messageHandler;
+	}
+
+	const directCurrentCandidateActions =
+		inferDirectCurrentRequestCandidateActions(
+			runtimeContext.actions,
+			currentMessageText,
+		);
+	if (directCurrentCandidateActions.length === 0) return messageHandler;
+
+	const runnableCandidateActions = filterRunnableCandidateActions(
+		uniqueActionNames([
+			...getMessageHandlerCandidateActions(messageHandler),
+			...directCurrentCandidateActions,
+		]),
+		runtimeContext,
+	);
+	if (runnableCandidateActions.length === 0) return messageHandler;
+
+	const planningContexts = (messageHandler.plan.contexts ?? []).filter(
+		(context) => context !== SIMPLE_CONTEXT_ID,
+	);
+	return {
+		...messageHandler,
+		plan: {
+			...messageHandler.plan,
+			contexts:
+				planningContexts.length > 0
+					? Array.from(new Set(planningContexts))
+					: ["general"],
+			simple: false,
+			requiresTool: true,
+			candidateActions: runnableCandidateActions,
+		},
+	};
 }
 
 const PLANNING_ACK_REPLIES = new Set([
@@ -3921,6 +4042,13 @@ export function inferDirectCurrentRequestCandidateActions(
 		const codingAction = findCodingDelegationActionName(actions);
 		if (codingAction) return [codingAction];
 	}
+	const viewShellAction = findViewShellActionName(actions, messageText);
+	if (viewShellAction) return [viewShellAction];
+	const viewCapabilityAction = findViewCapabilityActionName(
+		actions,
+		messageText,
+	);
+	if (viewCapabilityAction) return [viewCapabilityAction];
 	if (looksLikeWebSearchRequest(messageText)) {
 		const lookupAction = findWebLookupActionName(actions);
 		if (lookupAction) return [lookupAction];
@@ -3940,6 +4068,7 @@ function shouldUseDirectReplyFastPath(args: {
 	) {
 		return false;
 	}
+	if (looksLikeContextDependentMutationRequest(text)) return false;
 	if (/https?:\/\//iu.test(text)) return false;
 	if (
 		/\b(?:search|browse|lookup|look\s+up|find|fetch|download|install|run|execute|build|deploy|commit|push|pull\s+request|pr\b|issue|debug|inspect|logs?|repo|github|terminal|shell|file|folder|save|send|create|edit|modify|fix|improve|rewrite|update|delete|remove|uninstall|schedule|remind|todo|task|calendar|email|contact|message|dm|call|wallet|balance|price|weather|news|latest|current|today|tomorrow|yesterday|remember|forget|settings?|password|secret|key|token|screen|screenshot|browser|click|open|close|app|view|plugin|window|device|workflow|automation|draw|sketch|paint|illustrate|render|picture|photo|photograph|image|speak|read\s+aloud|read\s+out|narrate|text\s*to\s*speech|tts|voice\s+this|voice\s+over|audio|video|animate|animation)\b/iu.test(
@@ -3949,6 +4078,40 @@ function shouldUseDirectReplyFastPath(args: {
 		return false;
 	}
 	return true;
+}
+
+function looksLikeContextDependentMutationRequest(text: string): boolean {
+	const tokens = new Set(
+		tokenizeActionMetadata(text).map(normalizeSingularToken),
+	);
+	const mutationTokens = [
+		"ADD",
+		"CREATE",
+		"DO",
+		"MAKE",
+		"PUT",
+		"SET",
+		"WRITE",
+		"EDIT",
+		"UPDATE",
+		"DELETE",
+		"REMOVE",
+	];
+	const contextReferenceTokens = [
+		"ANOTHER",
+		"IT",
+		"ONE",
+		"SAME",
+		"THAT",
+		"THEM",
+		"THESE",
+		"THIS",
+		"THOSE",
+	];
+	return (
+		mutationTokens.some((token) => tokens.has(token)) &&
+		contextReferenceTokens.some((token) => tokens.has(token))
+	);
 }
 
 function looksLikeHighStakesPersonalCrisisRequest(text: string): boolean {
@@ -4025,6 +4188,253 @@ function findCodingDelegationActionName(
 		)?.name ??
 		findAvailableActionName(actions, LEGACY_CODING_DELEGATION_ACTION_NAMES)
 	);
+}
+
+const VIEW_REQUEST_OPERATION_GROUPS = {
+	create: ["ADD", "CREATE", "MAKE", "NEW"],
+	read: ["FIND", "GET", "LIST", "READ", "SHOW", "WHAT", "WHICH"],
+	update: ["CHANGE", "EDIT", "MODIFY", "RENAME", "UPDATE"],
+	delete: ["DELETE", "REMOVE"],
+	open: ["GO", "NAVIGATE", "OPEN", "SWITCH"],
+	close: ["CLOSE", "DISMISS", "HIDE"],
+	layout: [
+		"ARRANGE",
+		"BOTTOM",
+		"HORIZONTAL",
+		"LEFT",
+		"LAYOUT",
+		"RIGHT",
+		"SPLIT",
+		"TILE",
+		"TOP",
+		"VERTICAL",
+	],
+	pin: ["DOCK", "PIN"],
+} as const;
+
+const VIEW_REQUEST_OPERATION_TOKENS: ReadonlySet<string> = new Set<string>(
+	Object.values(VIEW_REQUEST_OPERATION_GROUPS).flat(),
+);
+
+const VIEW_REQUEST_GENERIC_TOKENS: ReadonlySet<string> = new Set<string>([
+	"ACTION",
+	"ACTIONS",
+	"APP",
+	"APPS",
+	"APPLICATION",
+	"APPLICATIONS",
+	"BROADCAST",
+	"CALL",
+	"CAPABILITY",
+	"CAPABILITIES",
+	"CURRENT",
+	"EVENT",
+	"EVENTS",
+	"INVOKE",
+	"LAYOUT",
+	"MANAGER",
+	"MODE",
+	"NOTIFY",
+	"PANEL",
+	"PANELS",
+	"PIN",
+	"PLUGIN",
+	"PLUGINS",
+	"SCREEN",
+	"SIGNAL",
+	"UI",
+	"USE",
+	"VIEW",
+	"VIEWS",
+	"WINDOW",
+	"WINDOWS",
+	"WITH",
+]);
+
+const VIEW_REQUEST_SURFACE_TOKENS: ReadonlySet<string> = new Set<string>([
+	"APP",
+	"APPLICATION",
+	"MANAGER",
+	"PANEL",
+	"SCREEN",
+	"UI",
+	"VIEW",
+	"WINDOW",
+]);
+
+const VIEW_LAYOUT_FOLLOWUP_TOKENS: ReadonlySet<string> = new Set<string>([
+	"AGAIN",
+	"ALSO",
+	"HORIZONTAL",
+	"INSTEAD",
+	"NOW",
+	"TOO",
+	"VERTICAL",
+]);
+
+const VIEW_PLUGIN_SURFACE_TOKENS: ReadonlySet<string> = new Set<string>([
+	"BROWSER",
+	"CATALOG",
+	"MANAGER",
+	"MARKETPLACE",
+]);
+
+function findViewsActionName(
+	actions: ReadonlyArray<Pick<Action, "name" | "tags">>,
+): string | undefined {
+	return actions.find((action) => {
+		if (normalizeActionIdentifier(action.name) === "VIEWS") return true;
+		return (action.tags ?? []).some(
+			(tag) => normalizedMetadataPhrase(tag) === "VIEW_CAPABILITY",
+		);
+	})?.name;
+}
+
+function collectViewActionMetadataEntries(
+	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
+	viewActionName: string,
+): Array<Pick<Action, "name" | "similes" | "tags">> {
+	const normalizedViewActionName = normalizeActionIdentifier(viewActionName);
+	return actions.filter((action) => {
+		if (normalizeActionIdentifier(action.name) === normalizedViewActionName) {
+			return true;
+		}
+		return (action.tags ?? []).some(
+			(tag) => normalizedMetadataPhrase(tag) === "VIEW_CAPABILITY",
+		);
+	});
+}
+
+function findViewShellActionName(
+	actions: ReadonlyArray<Pick<Action, "name" | "tags">>,
+	messageText: string,
+): string | undefined {
+	if (looksLikeInstructionalViewQuestion(messageText)) return undefined;
+	const viewActionName = findViewsActionName(actions);
+	if (!viewActionName) return undefined;
+
+	const messageTokens = tokenizeActionMetadata(messageText).map(
+		normalizeSingularToken,
+	);
+	const messageOperationGroups = operationGroupsForTokens(messageTokens);
+	if (messageOperationGroups.size === 0) return undefined;
+
+	const tokenSet = new Set(messageTokens);
+	for (const token of VIEW_REQUEST_SURFACE_TOKENS) {
+		if (tokenSet.has(token)) return viewActionName;
+	}
+	if (
+		(tokenSet.has("PLUGIN") || tokenSet.has("PLUGINS")) &&
+		messageTokens.some((token) => VIEW_PLUGIN_SURFACE_TOKENS.has(token))
+	) {
+		return viewActionName;
+	}
+	if (
+		messageOperationGroups.has("layout") &&
+		messageTokens.some((token) => VIEW_LAYOUT_FOLLOWUP_TOKENS.has(token))
+	) {
+		return viewActionName;
+	}
+	return undefined;
+}
+
+function findViewCapabilityActionName(
+	actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>,
+	messageText: string,
+): string | undefined {
+	if (looksLikeInstructionalViewQuestion(messageText)) return undefined;
+	const viewActionName = findViewsActionName(actions);
+	if (!viewActionName) return undefined;
+	const viewActions = collectViewActionMetadataEntries(actions, viewActionName);
+	if (viewActions.length === 0) return undefined;
+
+	const messageTokens = tokenizeActionMetadata(messageText);
+	const messageTokenSet = new Set(messageTokens.map(normalizeSingularToken));
+	const messageOperationGroups = operationGroupsForTokens(messageTokens);
+	if (messageOperationGroups.size === 0) return undefined;
+
+	for (const viewAction of viewActions) {
+		for (const alias of [
+			viewAction.name,
+			...(viewAction.similes ?? []),
+			...(viewAction.tags ?? []),
+		]) {
+			const aliasTokens = tokenizeActionMetadata(String(alias));
+			if (aliasTokens.length === 0) continue;
+			const aliasOperationGroups = operationGroupsForTokens(aliasTokens);
+			if (
+				aliasOperationGroups.size > 0 &&
+				!setsIntersect(aliasOperationGroups, messageOperationGroups)
+			) {
+				continue;
+			}
+			const targetTokens = aliasTokens
+				.map(normalizeSingularToken)
+				.filter(
+					(token) =>
+						!VIEW_REQUEST_OPERATION_TOKENS.has(token) &&
+						!VIEW_REQUEST_GENERIC_TOKENS.has(token),
+				);
+			if (targetTokens.length === 0) continue;
+			if (targetTokens.every((token) => messageTokenSet.has(token))) {
+				return viewActionName;
+			}
+		}
+	}
+	return undefined;
+}
+
+function looksLikeInstructionalViewQuestion(messageText: string): boolean {
+	return /^\s*(?:explain|describe|teach|what\s+(?:is|are)|how\s+(?:do|can|to)\b)/iu.test(
+		messageText,
+	);
+}
+
+function tokenizeActionMetadata(value: string): string[] {
+	const matches = value
+		.replace(/([a-z])([A-Z])/g, "$1 $2")
+		.toUpperCase()
+		.match(/[A-Z0-9]+/g);
+	return matches ?? [];
+}
+
+function normalizedMetadataPhrase(value: string): string {
+	return tokenizeActionMetadata(value).map(normalizeSingularToken).join("_");
+}
+
+function normalizeSingularToken(token: string): string {
+	if (token === "CALENDER") return "CALENDAR";
+	if (token.length > 3 && token.endsWith("IES")) {
+		return `${token.slice(0, -3)}Y`;
+	}
+	if (token.length > 3 && token.endsWith("S")) {
+		return token.slice(0, -1);
+	}
+	return token;
+}
+
+function operationGroupsForTokens(tokens: readonly string[]): Set<string> {
+	const groups = new Set<string>();
+	for (const token of tokens.map(normalizeSingularToken)) {
+		for (const [group, groupTokens] of Object.entries(
+			VIEW_REQUEST_OPERATION_GROUPS,
+		)) {
+			if ((groupTokens as readonly string[]).includes(token)) {
+				groups.add(group);
+			}
+		}
+	}
+	return groups;
+}
+
+function setsIntersect<T>(
+	left: ReadonlySet<T>,
+	right: ReadonlySet<T>,
+): boolean {
+	for (const entry of left) {
+		if (right.has(entry)) return true;
+	}
+	return false;
 }
 
 function findAvailableActionName(
@@ -4296,18 +4706,29 @@ function synthesizePlannerFallbackFromStage1Failure(args: {
  */
 function parseMessageHandlerModelOutput(
 	raw: string | GenerateTextResult,
+	runtimeContext?: {
+		actions: ReadonlyArray<Pick<Action, "name" | "similes" | "tags">>;
+		messageText?: string;
+	},
 ): MessageHandlerResult | null {
+	const applyBackstops = (result: MessageHandlerResult | null) =>
+		result
+			? applyDirectCurrentCandidateBackstopToMessageHandler(
+					result,
+					runtimeContext,
+				)
+			: null;
 	if (typeof raw !== "string") {
 		const native = parseMessageHandlerNativeToolCall(raw);
-		if (native) return native;
+		if (native) return applyBackstops(native);
 		const text = getV5ModelText(raw);
-		return (
+		return applyBackstops(
 			parseMessageHandlerOutput(text) ??
-			synthesizeSimpleReplyFromPlainText(text)
+				synthesizeSimpleReplyFromPlainText(text),
 		);
 	}
-	return (
-		parseMessageHandlerOutput(raw) ?? synthesizeSimpleReplyFromPlainText(raw)
+	return applyBackstops(
+		parseMessageHandlerOutput(raw) ?? synthesizeSimpleReplyFromPlainText(raw),
 	);
 }
 
@@ -4784,6 +5205,15 @@ async function executeV5PlannedToolCall(
 	const action = executionActions.find(
 		(candidate) => candidate.name === toolCall.name,
 	);
+	const executorCtx = action
+		? {
+				...args.executorCtx,
+				activeContexts: mergeAgentContexts(
+					args.executorCtx.activeContexts,
+					action.contexts,
+				),
+			}
+		: args.executorCtx;
 
 	const hasDispatcherActionParameter =
 		plannerToolCallHasActionParameter(toolCall);
@@ -4792,7 +5222,7 @@ async function executeV5PlannedToolCall(
 			runtime: args.runtime as IAgentRuntime & PlannerRuntime,
 			action,
 			context: args.plannerContext,
-			ctx: args.executorCtx,
+			ctx: executorCtx,
 			options: args.executorOptions,
 			evaluate: args.evaluate,
 			evaluatorEffects: args.evaluatorEffects,
@@ -4806,7 +5236,7 @@ async function executeV5PlannedToolCall(
 
 	const actionResult = await executePlannedToolCall(
 		args.runtime,
-		args.executorCtx,
+		executorCtx,
 		toolCall,
 		{ ...(args.executorOptions ?? {}), actions: executionActions },
 	);
@@ -5306,7 +5736,10 @@ export async function runV5MessageRuntimeStage1(args: {
 			);
 		}
 		if (!messageHandler) {
-			messageHandler = parseMessageHandlerModelOutput(rawMessageHandler);
+			messageHandler = parseMessageHandlerModelOutput(rawMessageHandler, {
+				actions: args.runtime.actions,
+				messageText: getUserMessageText(args.message),
+			});
 		}
 		const stage1CompletionLimitHit = stage1HitCompletionLimit(
 			rawMessageHandler,
@@ -5617,11 +6050,23 @@ export async function runV5MessageRuntimeStage1(args: {
 			attachAvailableContexts(recomposedPlannerState, args.runtime),
 			selectedContextRoutingState,
 		);
+		const directPlannerCandidateActions =
+			inferDirectCurrentRequestCandidateActions(
+				args.runtime.actions ?? [],
+				getUserMessageText(args.message) ?? "",
+			);
+		if (directPlannerCandidateActions.length > 0) {
+			messageHandler.plan.candidateActions = uniqueActionNames([
+				...getMessageHandlerCandidateActions(messageHandler),
+				...directPlannerCandidateActions,
+			]);
+		}
 		const plannerCandidateActions = await collectV5PlannerCandidateActions({
 			runtime: args.runtime,
 			message: args.message,
 			state: plannerState,
 			selectedContexts,
+			candidateActions: getMessageHandlerCandidateActions(messageHandler),
 			userRoles: [senderRole],
 		});
 		const localizedExamplesProvider = getLocalizedExamplesProvider(


### PR DESCRIPTION
## What
Completes the dynamic-view-routing feature — #8445 shipped the plumbing (view interact channel + app-control actions); this adds the **brain**: the agent infers view open/close intent while handling a message and routes it through the interact channel. Plus streaming-suppression refinements and trajectory export/storage hardening.

## Changes
- **core/services/message.ts**: view-request inference. **3-way merged on develop**, preserving develop's `modelCommittedToDelegation` guard.
- **core/runtime**: `action-retrieval`, `action-tiering`, `planner-loop`, `evaluator` (streaming no-op refinements).
- **core trajectories** + **agent** `trajectory-internals`/`export`/`storage`.
- **agent** `page-action-groups`, **app-core** lifeops view alias.

## Validation
- Typecheck **clean** across `packages/core`, `packages/agent`, `packages/app-core` (only stale-local-dep noise in untouched develop files, which CI's fresh install resolves).
- Tests: **115 core** (action-tiering/retrieval/evaluator/TrajectoriesService/message-runtime/callsite-audit) + **9 agent** trajectory — all passing.

## Context
Extracted from #8340 (closed; ~249 commits behind develop). Pairs with #8445; all touched files except `message.ts` were untouched on develop (clean cherry-pick), `message.ts` 3-way merged. Fourth in the focused-PR split (#8443/#8444/#8445).