### PR TITLE
fix(agent): seed CEREBRAS_MODEL default at boot for direct own-key Cerebras

### DIFF
--- a/packages/agent/src/runtime/eliza.ts
+++ b/packages/agent/src/runtime/eliza.ts
@@ -1016,6 +1016,19 @@ export async function configureLocalEmbeddingPlugin(
       : "openai/gpt-oss-120b",
   );
 
+  // Default Cerebras model — plugin-openai's Cerebras mode otherwise falls
+  // back to OpenAI-only ids (gpt-5 / gpt-5.4-mini) when CEREBRAS_MODEL is
+  // unset, which 404 on api.cerebras.ai for direct own-key sessions that
+  // never hit the first-run / provider-switch path. Seed the approved GPT-OSS
+  // default before plugin init (mirrors the Groq handling above; Cerebras
+  // shares one CEREBRAS_MODEL for both small and large).
+  setEnvIfMissing(
+    "CEREBRAS_MODEL",
+    currentSharedLargeModel && !isLikelyOpenAiTextModel(currentSharedLargeModel)
+      ? currentSharedLargeModel
+      : "gpt-oss-120b",
+  );
+
   logger.info(
     `[eliza] Configured local embedding env: ${process.env.LOCAL_EMBEDDING_MODEL} (repo: ${process.env.LOCAL_EMBEDDING_MODEL_REPO ?? "auto"}, dims: ${process.env.LOCAL_EMBEDDING_DIMENSIONS ?? "auto"}, ctx: ${process.env.LOCAL_EMBEDDING_CONTEXT_SIZE ?? "auto"}, GPU: ${process.env.LOCAL_EMBEDDING_GPU_LAYERS}, mmap: ${process.env.LOCAL_EMBEDDING_USE_MMAP})`,
   );


### PR DESCRIPTION
## Problem
A self-hosted user who configures **only** `CEREBRAS_API_KEY` (no first-run wizard / provider-switch event) gets inference 404s: plugin-openai's Cerebras mode (`isCerebrasMode` fires on a bare key) falls through its model getter chain to OpenAI-only ids — `getLargeModel` → `gpt-5`, `getSmallModel` → `gpt-5.4-mini` — which `api.cerebras.ai` rejects. The `CEREBRAS_MODEL=gpt-oss-120b` default exists only in `PROVIDER_DEFAULT_MODELS.cerebras` and is stamped solely through `applyFirstRunConnectionConfig` (first-run / UI switch / hot-reload), **never at plain boot**.

## Repro
Set only `CEREBRAS_API_KEY=…` (no `OPENAI_API_KEY`, no `CEREBRAS_MODEL`), start the agent normally (not first-run). Any TEXT_LARGE call resolves to `gpt-5` and 404s on Cerebras.

## Fix
Seed `CEREBRAS_MODEL=gpt-oss-120b` before plugin init in `packages/agent/src/runtime/eliza.ts`, **mirroring the Groq boot-seed a few lines above** (`GROQ_SMALL/LARGE_MODEL`) — same `isLikelyOpenAiTextModel` guard so an explicit non-OpenAI shared model is respected. No new module, no change to the provider-switch state machine. Cloud inference is unaffected (own catalog; never resolves these ids).

## Note for @lalalune
This is the conservative shape (boot-seed parallel to Groq). There's a second, slightly broader option you may prefer instead: guard inside the plugin getters (`plugins/plugin-openai/utils/config.ts` — default `getCerebrasModel` + skip OpenAI-only `OPENAI_*_MODEL` values when `isCerebrasMode`), which **also** covers the case where a user keeps an explicit `OPENAI_LARGE_MODEL=gpt-4o` set while switching to Cerebras. Happy to switch to that approach if you'd rather centralize it in the plugin — flagging since this sits on the provider-routing surface you maintain.

## Context
Last of the focused PRs split out of the (now-closed) #8340. Verified `eliza.ts` typechecks clean.