### PR TITLE
fix(cloud): keep agents reachable over the idle tailnet (warm-keep: retry + hysteresis + proxy re-warm)

### DIFF
--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -121,6 +121,16 @@ export interface SnapshotResult {
 const MAX_BACKUPS = 10;
 const SHARED_RUNTIME_HISTORY_TTL_SECONDS = 60 * 60 * 24 * 30;
 const SHARED_RUNTIME_HISTORY_MAX_MESSAGES = 40;
+// Heartbeat probes the agent over the headscale tailnet. When idle the path
+// goes cold, so the first probe after a quiet period can fail while it
+// re-establishes — retry before evicting a healthy agent.
+const HEARTBEAT_PROBE_ATTEMPTS = 3;
+const HEARTBEAT_PROBE_RETRY_MS = 2_000;
+// A single failed cycle must not evict. Only mark disconnected after the agent
+// has been continuously unreachable this long — last_heartbeat_at (bumped only
+// on success) is the downtime clock. The ~30s heartbeat itself keeps the
+// WireGuard NAT mapping warm, so a reachable agent never trips this.
+const HEARTBEAT_DISCONNECT_AFTER_MS = 120_000;
 type LifecycleTx = Parameters<Parameters<Database["transaction"]>[0]>[0];
 
 function digestPinnedImageRef(imageRef: string, digest: string): string {
@@ -3200,26 +3210,54 @@ export class ElizaSandboxService {
     const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
     if (!rec?.bridge_url) return false;
 
-    const res = await (async () => {
+    // The agent is reached over the headscale tailnet, where an idle path goes
+    // cold; a single cold-path miss must not evict a healthy agent. Retry the
+    // probe (the first attempt re-warms the path), then apply hysteresis before
+    // giving up — seen live: a freshly-running agent was marked disconnected
+    // ~1 min after boot by one transient "fetch failed".
+    const heartbeatEndpoint = await this.getAgentApiEndpoint(rec, "/");
+    let res: Response | null = null;
+    for (let attempt = 0; attempt < HEARTBEAT_PROBE_ATTEMPTS; attempt++) {
+      if (attempt > 0) {
+        await new Promise((resolve) => setTimeout(resolve, HEARTBEAT_PROBE_RETRY_MS));
+      }
       try {
-        const heartbeatEndpoint = await this.getAgentApiEndpoint(rec, "/");
-        return await fetch(heartbeatEndpoint, {
+        res = await fetch(heartbeatEndpoint, {
           method: "GET",
           headers: this.getAgentJsonHeaders(rec),
           signal: AbortSignal.timeout(10_000),
         });
+        if (res.ok) break;
       } catch (error) {
-        logger.warn("[agent-sandbox] Heartbeat request failed", {
+        logger.debug("[agent-sandbox] Heartbeat probe attempt failed, retrying", {
           agentId,
+          attempt,
           error: error instanceof Error ? error.message : String(error),
         });
-        return null;
+        res = null;
       }
-    })();
+    }
 
     if (!res?.ok) {
-      logger.warn("[agent-sandbox] Heartbeat failed, marking disconnected", {
+      // Hysteresis: one failed cycle is not enough to evict. last_heartbeat_at
+      // is bumped only on success, so its age is how long the agent has been
+      // continuously unreachable. Stay running inside the grace window (the next
+      // cycle's retry re-warms the path); only disconnect once unreachable past
+      // it.
+      const lastOkMs = rec.last_heartbeat_at
+        ? new Date(rec.last_heartbeat_at).getTime()
+        : Date.now();
+      const downForMs = Date.now() - lastOkMs;
+      if (downForMs < HEARTBEAT_DISCONNECT_AFTER_MS) {
+        logger.warn("[agent-sandbox] Heartbeat miss within grace window, keeping running", {
+          agentId,
+          downForMs,
+        });
+        return false;
+      }
+      logger.warn("[agent-sandbox] Heartbeat failed past grace window, marking disconnected", {
         agentId,
+        downForMs,
       });
       await agentSandboxesRepository.update(rec.id, {
         status: "disconnected",

--- a/packages/scripts/cloud/admin/daemons/agent-router.ts
+++ b/packages/scripts/cloud/admin/daemons/agent-router.ts
@@ -42,6 +42,13 @@ const DEFAULT_BIND_HOST = "127.0.0.1";
 const DEFAULT_AGENT_BASE_DOMAIN = "elizacloud.ai";
 const AGENT_ID_RE =
   /^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i;
+// The first request to an agent after an idle period can hit a transiently cold
+// tailnet path that fails while it re-establishes. Retry idempotent requests
+// once (the first attempt re-warms the path) before surfacing the failure.
+// Non-idempotent requests are never retried (the warm-keep heartbeat holds the
+// path open between requests, so a cold POST is rare).
+const PROXY_TAILNET_RETRY_ATTEMPTS = 1;
+const PROXY_TAILNET_RETRY_DELAY_MS = 400;
 const HOP_BY_HOP_HEADERS = new Set([
   "connection",
   "content-length",
@@ -320,12 +327,24 @@ async function proxyAgentRequest(
     redirect: "manual",
     signal: AbortSignal.timeout(120_000),
   };
-  if (method !== "GET" && method !== "HEAD") {
+  const idempotent = method === "GET" || method === "HEAD";
+  if (!idempotent) {
     const body = await readIncomingBody(req);
     if (body) init.body = body;
   }
 
-  return fetch(targetUrl, init);
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fetch(targetUrl, init);
+    } catch (error) {
+      // Only idempotent requests are safe to replay, and only a transport
+      // failure (a cold/torn path) — never a real HTTP response — reaches here.
+      if (!idempotent || attempt >= PROXY_TAILNET_RETRY_ATTEMPTS) throw error;
+      await new Promise((resolve) =>
+        setTimeout(resolve, PROXY_TAILNET_RETRY_DELAY_MS),
+      );
+    }
+  }
 }
 
 async function handleRequest(


### PR DESCRIPTION
## What
Agents reach `running` (after #8441) but get evicted to `disconnected` ~1 min later, after which `<agent>.elizacloud.ai` 404s — the user can't reach their agent.

## Root cause (diagnosed live)
The agent is reached over the headscale tailnet. **Direct WireGuard works** (measured: 1ms via `host-IP:container-WG-port`), but the direct path's NAT mapping **expires when the agent is idle** → it falls back to a cold DERP relay → the first packet after idle fails while it re-establishes. The heartbeat did a single no-retry fetch and evicted the agent on that one cold packet; the router then 404s anything not `running`.

## Fix — robust warm-keep (prod-bound)
The ~30s heartbeat traffic itself keeps the WireGuard NAT mapping warm, so a reachable agent's path never goes cold — *as long as the heartbeat doesn't false-evict it*. So make the health path tolerant:
- **Heartbeat retry** — the first attempt re-warms a momentarily cold path.
- **Hysteresis** — don't evict on one failed cycle. `last_heartbeat_at` (bumped only on success) is the continuous-downtime clock; only mark `disconnected` after 120s continuously unreachable.
- **Proxy re-warm** — the agent-router retries an idempotent request once on a transport failure, so a user's first request after idle re-warms instead of failing.

Direct connectivity working (not structural DERP-only) is why warm-keep is the right call over re-architecting the container networking — confirmed live.

## Test plan
- [x] cloud-shared typecheck + biome + agent-router tests green.
- [ ] Staging after deploy: provision an agent, leave it idle >2 min, confirm it stays `running` and `<agent>.elizacloud.ai` stays routable.