### PR TITLE
fix(cloud): route the default gpt-oss-120b to Cerebras, not OpenRouter :nitro (new-user 503)

### DIFF
--- a/packages/cloud-infra/cloud/bitrouter/Dockerfile
+++ b/packages/cloud-infra/cloud/bitrouter/Dockerfile
@@ -4,7 +4,9 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl expect xz-utils \
   && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g bitrouter
+# Pin the version: an unpinned install can silently change routing/failover
+# semantics (e.g. how multi-endpoint `models:` lists are evaluated) on rebuild.
+RUN npm install -g bitrouter@0.33.0
 
 WORKDIR /app
 COPY bitrouter.yaml /app/bitrouter.yaml

--- a/packages/cloud-infra/cloud/bitrouter/bitrouter.yaml
+++ b/packages/cloud-infra/cloud/bitrouter/bitrouter.yaml
@@ -24,13 +24,30 @@ providers:
 # being the only provider that declares these ids in the published catalog,
 # Strategy 3 SHOULD also route them via openrouter — but the explicit form
 # is more deterministic for the models our agent actually uses.
+#
+# gpt-oss-120b routes Cerebras-FIRST (the ~2000 tok/s interactive path), with
+# OpenRouter as an ordered fallback for Cerebras 429s/outages. Previously these
+# aliases pointed only at OpenRouter, and the gateway/`:nitro` variants returned
+# 503 ("Failed after 3 attempts: Bad Gateway") on every new-user default — the
+# `:nitro` suffix is an OpenRouter convention with no healthy upstream here, so
+# it 502s and we surface 503. Multi-endpoint lists are tried in order (BitRouter
+# fallback chains), so a Cerebras error falls through to OpenRouter (plain id,
+# never `:nitro`). The bare `gpt-oss-120b` alias covers raw-provider callers
+# (apps chat); the Worker's own cerebras-direct path handles the dashboard
+# default before BitRouter is ever reached.
 models:
+  "gpt-oss-120b":
+    endpoints:
+      - { provider: cerebras, service_id: "gpt-oss-120b" }
+      - { provider: openrouter, service_id: "openai/gpt-oss-120b" }
   "openai/gpt-oss-120b":
     endpoints:
+      - { provider: cerebras, service_id: "gpt-oss-120b" }
       - { provider: openrouter, service_id: "openai/gpt-oss-120b" }
   "openai/gpt-oss-120b:nitro":
     endpoints:
-      - { provider: openrouter, service_id: "openai/gpt-oss-120b:nitro" }
+      - { provider: cerebras, service_id: "gpt-oss-120b" }
+      - { provider: openrouter, service_id: "openai/gpt-oss-120b" }
   "anthropic/claude-haiku-4.5":
     endpoints:
       - { provider: openrouter, service_id: "anthropic/claude-haiku-4.5" }

--- a/packages/cloud-shared/src/lib/models/catalog.ts
+++ b/packages/cloud-shared/src/lib/models/catalog.ts
@@ -41,10 +41,19 @@ export interface SelectorModel {
 }
 
 export const BITROUTER_RECOMMENDED_TEXT_MODEL = "openai/gpt-oss-120b:nitro";
-export const BITROUTER_DEFAULT_TEXT_MODEL = BITROUTER_RECOMMENDED_TEXT_MODEL;
 export const BITROUTER_DEFAULT_FREE_MODEL = "openai/gpt-oss-120b:free";
 export const CEREBRAS_DEFAULT_TEXT_SMALL_MODEL = "gpt-oss-120b";
 export const CEREBRAS_DEFAULT_TEXT_LARGE_MODEL = "zai-glm-4.7";
+
+// The default served text model (drives PRO_MODEL_ID / the new-user default).
+// This is the Cerebras-direct bare id "gpt-oss-120b" — HTTP 200 in ~3s in prod —
+// NOT the gateway id "openai/gpt-oss-120b:nitro". The :nitro id has no Cerebras
+// route: it goes through the self-hosted BitRouter to OpenRouter, whose nitro
+// upstream returns 502, which we surface as 503 ("Failed after 3 attempts: Bad
+// Gateway") — the error every new user hits on their first message. The bare id
+// makes getLanguageModel()'s isCerebrasNativeModel() short-circuit straight to
+// the Cerebras client (providers/language-model.ts), Shaw's ~2000 tok/s path.
+export const BITROUTER_DEFAULT_TEXT_MODEL = CEREBRAS_DEFAULT_TEXT_SMALL_MODEL;
 
 // Models force-marked `recommended` by the annotation layer. Point this at the
 // healthy Cerebras defaults — NOT openai/gpt-oss-120b:nitro, whose gateway path

--- a/packages/cloud-shared/src/lib/models/model-tiers.ts
+++ b/packages/cloud-shared/src/lib/models/model-tiers.ts
@@ -17,7 +17,7 @@ import {
 import {
   BITROUTER_DEFAULT_FREE_MODEL,
   BITROUTER_DEFAULT_TEXT_MODEL,
-  BITROUTER_RECOMMENDED_TEXT_MODEL,
+  CEREBRAS_DEFAULT_TEXT_SMALL_MODEL,
 } from "./catalog";
 
 export type ModelTier = "fast" | "pro" | "ultra";
@@ -238,11 +238,11 @@ export const DEFAULT_IMAGE_MODEL = IMAGE_MODELS[0];
 
 export const ADDITIONAL_MODELS: AdditionalModel[] = [
   {
-    id: "gpt-oss-120b-nitro",
-    name: "GPT OSS 120B Nitro",
-    description: "Recommended BitRouter high-throughput reasoning model",
-    modelId: BITROUTER_RECOMMENDED_TEXT_MODEL,
-    provider: "openai",
+    id: "gpt-oss-120b",
+    name: "GPT OSS 120B",
+    description: "Fast open-weight reasoning on Cerebras (~2000 tok/s)",
+    modelId: CEREBRAS_DEFAULT_TEXT_SMALL_MODEL,
+    provider: "cerebras",
     recommended: true,
   },
   {


### PR DESCRIPTION
## The bug, proven live on prod

Every new user's **first chat 503s**. Tested just now against `api.elizacloud.ai` with a real prod key:

| model id (what the request carries) | result | |
|---|---|---|
| `openai/gpt-oss-120b:nitro` — **today's new-user default** | **HTTP 503** in 12.3s | `Failed after 3 attempts. Last error: Bad Gateway` |
| `openai/gpt-oss-120b` — gateway id legacy clients send | **HTTP 503** in 9.0s | same |
| `gpt-oss-120b` — **the fix (Cerebras-direct)** | **HTTP 200** in **3.0s** | served by Cerebras |
| `zai-glm-4.7` — large Cerebras model | HTTP 200 in 21s | works |

## Root cause

A new user gets tier `pro` → `PRO_MODEL_ID` → `BITROUTER_DEFAULT_TEXT_MODEL`, which was `"openai/gpt-oss-120b:nitro"`. That id is **not** Cerebras-native, so `getLanguageModel()` (`isCerebrasNativeModel()` only matches bare `gpt-oss-120b`/`zai-glm-4.7`) sends it to our **self-hosted** BitRouter. `bitrouter.yaml` routed both the `:nitro` and plain gateway ids to **OpenRouter**. `:nitro` is an OpenRouter routing convention with no healthy upstream on our gateway → upstream 502 → we surface 503 (`toProviderHttpError` default branch). **Cerebras — Shaw's whole ~2000 tok/s point — was never touched**, despite being an already-declared provider in `bitrouter.yaml`.

`#8426` only moved the *recommended badge* to the Cerebras ids; it did **not** repoint `PRO_MODEL_ID`, so `:nitro` stayed the served default and the 503 stayed live.

## We self-host → we fix it in-repo, no partner needed

`BITROUTER_BASE_URL` points at our own Railway BitRouter; the yaml deliberately omits `bitrouter: {}` to avoid BitRouter Cloud's `brk_*` key. So we own the catalog and fix this entirely here. BitRouter's hosted-gateway notes (`:nitro` isn't their suffix; "use `:latency`") only matter if we ever switch to `api.bitrouter.ai`.

## Changes

- **`catalog.ts`** — `BITROUTER_DEFAULT_TEXT_MODEL` → `CEREBRAS_DEFAULT_TEXT_SMALL_MODEL` (`"gpt-oss-120b"`). The bare Cerebras-native id makes `getLanguageModel()` short-circuit to the Cerebras client directly — the path proven at **200/3s** above. (Kept `BITROUTER_RECOMMENDED_TEXT_MODEL` as the legacy gateway constant for the free-model map + catalog entry.)
- **`model-tiers.ts`** — replaced the selectable `:nitro` "More models" item with the working Cerebras `gpt-oss-120b` entry, so a user can't manually pick the 503 footgun.
- **`bitrouter.yaml`** — route `gpt-oss-120b` / `openai/gpt-oss-120b` / `openai/gpt-oss-120b:nitro` **Cerebras-first with OpenRouter as an ordered fallback** (BitRouter fallback chains are tried in order). This catches legacy clients + any persisted `:nitro` selection, and absorbs Cerebras 429s at launch.
- **`Dockerfile`** — pin `bitrouter@0.33.0` so a rebuild can't silently change failover semantics.

## Why this is safe

- The default flips to a path **already returning 200/3s in prod** — which also confirms `CEREBRAS_API_KEY` is set on the prod Worker (else bare `gpt-oss-120b` wouldn't work today).
- **Billing:** no pricing row is keyed on `:nitro`; forced rows exist for both `openai/gpt-oss-120b` and `cerebras:gpt-oss-120b`. The default's billed unit cost moves to the Cerebras row (`$0.35/$0.75` per 1M) — intended.
- The UI `provider` label is unchanged (`extractProvider("gpt-oss-120b")` → `"openai"`, same as the old `:nitro`).

## Deploy (two independent steps)

1. **BitRouter** (the yaml/Dockerfile): redeploy the Railway service — `railway up --service bitrouter packages/cloud-infra/cloud/bitrouter --path-as-root`. This alone stops the 503 for gateway/`:nitro` requests. Confirm `BITROUTER_CEREBRAS_API_KEY` is set on the service.
2. **cloud-shared** (catalog/tiers): ships with the normal Worker deploy on merge → new-user default becomes Cerebras-direct.

## Diagnosis method

Root-caused with a 6-agent workflow (4 parallel readers over catalog/dispatch/self-host-yaml/pricing → synthesize → adversarial verify), then confirmed end-to-end against live prod. Diagnosis verified line-by-line; the one residual unknown the adversary flagged — BitRouter's multi-endpoint failover ordering — is documented as fallback chains and is now version-pinned.

cc @lalalune @standujar — relates to bitrouter/bitrouter#572.
