### PR TITLE
ci(cloud): add Headscale control-plane arm workflow

### DIFF
--- a/.github/workflows/arm-headscale-control-plane.yml
+++ b/.github/workflows/arm-headscale-control-plane.yml
@@ -1,0 +1,105 @@
+name: Arm Headscale Control Plane
+
+# Converges Headscale on the Hetzner control-plane host. This is the
+# repeatable version of the launch runbook: configure server_url/listen_addr,
+# install the committed ACL, ensure users exist, upsert daemon env, restart
+# headscale + provisioning-worker, and fail if local /health is not green.
+#
+# WHY: agent provisioning must not be allowed to "sort of" work. If the daemon
+# has a Headscale key, docker-sandbox-provider requires a real headscale_ip
+# before marking a sandbox running. This workflow makes that dependency explicit
+# and keeps prod/staging wiring in GitHub Environments instead of hand-edited
+# shell history on the host.
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target control-plane environment"
+        type: choice
+        default: staging
+        options: [staging, production]
+      headscale_public_url:
+        description: "Public Headscale URL. Empty = vars.HEADSCALE_PUBLIC_URL"
+        type: string
+        required: false
+        default: ""
+      headscale_api_url:
+        description: "Daemon-local Headscale API URL"
+        type: string
+        required: false
+        default: "http://127.0.0.1:8081"
+      listen_addr:
+        description: "Headscale listen_addr on the CP"
+        type: string
+        required: false
+        default: "127.0.0.1:8081"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: arm-headscale-control-plane-${{ github.event.inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  arm:
+    runs-on: ubuntu-latest
+    environment: ${{ github.event.inputs.environment }}
+    timeout-minutes: 10
+    env:
+      DEPLOY_HOST: ${{ secrets.ELIZA_PROVISIONING_HOST }}
+      DEPLOY_SSH_KEY: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
+      HEADSCALE_API_KEY: ${{ secrets.HEADSCALE_API_KEY }}
+      AGENT_TOKEN_PRIVATE_KEY_PEM: ${{ secrets.AGENT_TOKEN_PRIVATE_KEY_PEM }}
+      ELIZA_LOCAL_ROOT_KEY: ${{ secrets.ELIZA_LOCAL_ROOT_KEY }}
+      HEADSCALE_PUBLIC_URL_INPUT: ${{ github.event.inputs.headscale_public_url }}
+      HEADSCALE_PUBLIC_URL_VAR: ${{ vars.HEADSCALE_PUBLIC_URL }}
+      HEADSCALE_API_URL: ${{ github.event.inputs.headscale_api_url }}
+      HEADSCALE_LISTEN_ADDR: ${{ github.event.inputs.listen_addr }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Preflight
+        run: |
+          fail=0
+          [ -n "$DEPLOY_HOST" ] || { echo "::error::missing secret ELIZA_PROVISIONING_HOST"; fail=1; }
+          [ -n "$DEPLOY_SSH_KEY" ] || { echo "::error::missing secret ELIZA_PROVISIONING_SSH_KEY"; fail=1; }
+          [ -n "$HEADSCALE_API_KEY" ] || { echo "::error::missing secret HEADSCALE_API_KEY"; fail=1; }
+          if [ -n "$HEADSCALE_PUBLIC_URL_INPUT" ]; then
+            echo "HEADSCALE_PUBLIC_URL=$HEADSCALE_PUBLIC_URL_INPUT" >> "$GITHUB_ENV"
+          elif [ -n "$HEADSCALE_PUBLIC_URL_VAR" ]; then
+            echo "HEADSCALE_PUBLIC_URL=$HEADSCALE_PUBLIC_URL_VAR" >> "$GITHUB_ENV"
+          else
+            echo "::error::set vars.HEADSCALE_PUBLIC_URL or provide headscale_public_url"
+            fail=1
+          fi
+          [ "$fail" = 0 ] || exit 1
+
+      - name: Write SSH key
+        run: |
+          install -d -m 700 "$RUNNER_TEMP/headscale"
+          printf '%s\n' "$DEPLOY_SSH_KEY" > "$RUNNER_TEMP/headscale/deploy_ed25519"
+          chmod 600 "$RUNNER_TEMP/headscale/deploy_ed25519"
+          echo "DEPLOY_SSH_KEY_PATH=$RUNNER_TEMP/headscale/deploy_ed25519" >> "$GITHUB_ENV"
+
+      - name: Arm Headscale and daemon env
+        run: |
+          node packages/scripts/cloud/admin/arm-headscale-control-plane.mjs \
+            --host "$DEPLOY_HOST" \
+            --ssh-key "$DEPLOY_SSH_KEY_PATH" \
+            --headscale-public-url "$HEADSCALE_PUBLIC_URL" \
+            --headscale-api-url "$HEADSCALE_API_URL" \
+            --listen-addr "$HEADSCALE_LISTEN_ADDR"
+
+      - name: Summary
+        run: |
+          {
+            echo "### Headscale control plane armed"
+            echo ""
+            echo "- Environment: \`${{ github.event.inputs.environment }}\`"
+            echo "- Public URL: \`$HEADSCALE_PUBLIC_URL\`"
+            echo "- Daemon API URL: \`$HEADSCALE_API_URL\`"
+            echo ""
+            echo "Next: set matching Cloudflare Worker secrets, then run the provision E2E."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
@@ -94,33 +94,54 @@ no-ops for an already-provisioned CP. To roll a bootstrap fix, taint the
 VM and re-apply — but that wipes local state (headscale DB, cloudflared
 creds, /opt/eliza checkout). Plan that out before touching prod.
 
-**Headscale handoff on a fresh CP.** Cloud-init installs the `headscale`
-package (binary, systemd unit, `/var/lib/headscale` state dir owned by the
-package user) but stops the auto-started service so it doesn't bind with a
-fresh empty DB. On first deploy the operator overlays the prior CP's
-config + state:
+**Headscale arm/handoff on a CP.** Cloud-init installs the `headscale` package
+(binary, systemd unit, `/var/lib/headscale` state dir owned by the package user)
+but stops the auto-started service so it does not bind with a fresh empty DB
+before the environment is intentionally wired.
+
+For the normal staging/prod path, use the idempotent workflow:
+
+```bash
+gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza --ref main \
+  -f environment=production \
+  -f headscale_api_url=http://127.0.0.1:8081 \
+  -f listen_addr=127.0.0.1:8081
+```
+
+That workflow installs the committed ACL, converges `server_url` and
+`listen_addr`, ensures the `agent`/`tunnel` users exist, upserts the daemon's
+Headscale env in `/opt/eliza/cloud/.env.local`, restarts both services, and
+checks local `/health`. See
+[`../../../../../cloud-services/headscale/DEPLOY.md`](../../../../../cloud-services/headscale/DEPLOY.md)
+for the required GitHub Environment secrets and the "why" behind each one.
+
+If you are replacing a CP and must preserve an existing tailnet, copy the state
+first, then run the arm workflow to converge config and daemon env:
+
 ```bash
 # From the prior CP
 ssh root@PRIOR_CP 'sudo tar czf /tmp/hs.tgz -C /var/lib/headscale db.sqlite noise_private.key'
 scp root@PRIOR_CP:/tmp/hs.tgz /tmp/hs.tgz
-ssh root@PRIOR_CP 'sudo cat /etc/headscale/config.yaml' > /tmp/headscale-config.yaml
-
-# Adjust server_url for the new CP's hostname
-sed -i -E 's|^server_url:.*|server_url: https://eliza-${env}-1.elizacloud.ai|' /tmp/headscale-config.yaml
 
 # Push to NEW CP
-scp /tmp/headscale-config.yaml /tmp/hs.tgz deploy@NEW_CP:/tmp/
+scp /tmp/hs.tgz deploy@NEW_CP:/tmp/
 ssh deploy@NEW_CP '
-  sudo mv /tmp/headscale-config.yaml /etc/headscale/config.yaml
+  sudo systemctl stop headscale || true
   sudo tar xzf /tmp/hs.tgz -C /var/lib/headscale
   sudo chown -R headscale:headscale /var/lib/headscale
-  sudo systemctl enable --now headscale
 '
 ```
 
+Why the workflow comes after the state copy: `server_url`, ACL path, API URL,
+and daemon env are environment-specific. Reusing the prior host's
+`config.yaml` risks advertising the wrong coordination server and recreating
+the exact "node registers against the wrong service" failure mode.
+
 ## What this module does NOT manage (yet)
 
-- Headscale state (preauth keys, ACLs) — manual via `headscale` CLI.
+- Headscale state (preauth keys/API key rotation) — manual via `headscale`
+  CLI; config + ACL + daemon env are converged by
+  `arm-headscale-control-plane.yml`.
 - Cloudflared tunnels — config lives at `/root/.cloudflared/` on the VM and
   is created via `cloudflared tunnel create` one-shot.
 - The systemd units — installed by `deploy-eliza-provisioning-worker.yml`

--- a/packages/cloud-services/headscale/DEPLOY.md
+++ b/packages/cloud-services/headscale/DEPLOY.md
@@ -1,6 +1,82 @@
-# Deploying tunnel infrastructure
+# Deploying Headscale / tunnel infrastructure
 
-End-to-end checklist to bring the customer-tunnel stack online. Railway owns the Headscale runtime; Wrangler owns the Eliza Cloud Worker config and secrets.
+End-to-end checklist to bring the Headscale-backed tailnet online. Headscale is
+the coordination server for both internal agent containers and customer tunnel
+nodes. The runtime can be hosted on Railway for the customer-tunnel service, but
+the launch control-plane path runs Headscale on the Hetzner control-plane VM so
+agent provisioning and the provisioning worker share a private, loopback API.
+
+Why this matters: when `HEADSCALE_API_KEY` is configured, the sandbox provider
+requires a real `headscale_ip` before a container is marked `running`. That is
+the safety gate that prevents a launched-but-unreachable agent from looking
+healthy in prod.
+
+## Hetzner control-plane runtime (agent launch path)
+
+Use this for staging/prod agent provisioning. The workflow below configures the
+host idempotently instead of relying on hand-edited `/etc/headscale/config.yaml`
+or `/opt/eliza/cloud/.env.local`.
+
+### Required GitHub Environment values
+
+Set these on each GitHub Environment (`staging`, `production`):
+
+| Name | Type | Why |
+|---|---|---|
+| `ELIZA_PROVISIONING_HOST` | secret | Public IP of the control-plane host; SSH hostnames are Cloudflare-proxied and do not carry TCP/22. |
+| `ELIZA_PROVISIONING_SSH_KEY` | secret | Deploy-user SSH key used by the provisioning-worker deploy workflow. |
+| `HEADSCALE_API_KEY` | secret | Existing Headscale API key; create/rotate on the host with `headscale apikeys create --expiration=8760h`. |
+| `AGENT_TOKEN_PRIVATE_KEY_PEM` | secret | Optional but launch-critical when steward agent JWT auth is enabled; must match the Worker secret. |
+| `ELIZA_LOCAL_ROOT_KEY` | secret | Optional but launch-critical for local root-token paths; must match the Worker secret. |
+| `HEADSCALE_PUBLIC_URL` | variable | `https://headscale-staging.elizacloud.ai` or `https://headscale.elizacloud.ai`. |
+
+### Run the arm workflow
+
+```bash
+gh workflow run arm-headscale-control-plane.yml --repo elizaOS/eliza --ref main \
+  -f environment=production \
+  -f headscale_api_url=http://127.0.0.1:8081 \
+  -f listen_addr=127.0.0.1:8081
+```
+
+The workflow:
+
+1. writes the committed `acl.hujson` to `/etc/headscale/acl.hujson`;
+2. converges `server_url`, `listen_addr`, metrics, and gRPC addresses in
+   `/etc/headscale/config.yaml`;
+3. ensures Headscale users `agent` and `tunnel` exist;
+4. upserts `HEADSCALE_PUBLIC_URL`, `HEADSCALE_API_URL`,
+   `HEADSCALE_API_KEY`, `HEADSCALE_USER`, and optional agent-token secrets into
+   `/opt/eliza/cloud/.env.local`;
+5. restarts `headscale` and `eliza-provisioning-worker.service`;
+6. fails if local `/health` is not green.
+
+The matching Cloudflare Worker secrets still need to be set through the normal
+Worker secret path. Keep host and Worker values identical for
+`HEADSCALE_API_KEY`, `AGENT_TOKEN_PRIVATE_KEY_PEM`, and `ELIZA_LOCAL_ROOT_KEY`;
+otherwise the daemon can mint state that the Worker cannot validate.
+
+### Manual equivalent
+
+```bash
+node packages/scripts/cloud/admin/arm-headscale-control-plane.mjs \
+  --host <control-plane-ip> \
+  --ssh-key <deploy-key> \
+  --headscale-public-url https://headscale.elizacloud.ai \
+  --headscale-api-url http://127.0.0.1:8081 \
+  --listen-addr 127.0.0.1:8081 \
+  --headscale-api-key "$HEADSCALE_API_KEY"
+```
+
+Do not paste a newly generated API key into issue comments or workflow inputs.
+Generate it on the host, store it as a GitHub/Worker secret, and let the script
+consume it from the environment.
+
+## Railway runtime (customer-tunnel legacy/service path)
+
+The rest of this document covers the Railway-hosted tunnel stack. Keep it for
+the customer-tunnel service and for historical context, but do not use it to arm
+the Hetzner provisioning-worker host.
 
 ## 1. DNS
 

--- a/packages/scripts/cloud/admin/arm-headscale-control-plane.mjs
+++ b/packages/scripts/cloud/admin/arm-headscale-control-plane.mjs
@@ -1,0 +1,312 @@
+#!/usr/bin/env node
+/**
+ * Arm Headscale on a Hetzner control-plane host.
+ *
+ * This is the repeatable counterpart to the launch runbook hand edits:
+ *   - converge /etc/headscale/config.yaml to the public URL + loopback listener
+ *   - install the committed ACL policy
+ *   - ensure the `agent` and `tunnel` users exist
+ *   - upsert the daemon env that makes sandbox provisioning require Headscale
+ *   - restart Headscale and the provisioning worker, then health-check both
+ *
+ * The API key is treated as pre-existing secret material. Generate or rotate it
+ * on the box with `headscale apikeys create --expiration=8760h`, then pass it
+ * through --headscale-api-key or HEADSCALE_API_KEY. This script never creates or
+ * prints a fresh key because GitHub Actions logs are the wrong place for that.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ENV_PATH = "/opt/eliza/cloud/.env.local";
+const HEADSCALE_CONFIG = "/etc/headscale/config.yaml";
+const HEADSCALE_ACL = "/etc/headscale/acl.hujson";
+const HEADSCALE_STATE_DIR = "/var/lib/headscale";
+const SYSTEMD_UNIT = "eliza-provisioning-worker.service";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, "../../../..");
+const aclPath = resolve(
+  repoRoot,
+  "packages/cloud-services/headscale/acl.hujson",
+);
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (!a.startsWith("--")) continue;
+    const key = a.slice(2);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) {
+      out[key] = true;
+    } else {
+      out[key] = next;
+      i += 1;
+    }
+  }
+  return out;
+}
+
+function readArg(args, key, envKey) {
+  const value =
+    args[key] ?? process.env[envKey ?? key.toUpperCase().replaceAll("-", "_")];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function die(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", `'\\''`)}'`;
+}
+
+function envValueQuote(value) {
+  // systemd EnvironmentFile values must stay single-line. Agent-token PEM
+  // parsing intentionally expands literal "\\n" sequences back to newlines.
+  return `"${String(value)
+    .replaceAll("\r\n", "\\n")
+    .replaceAll("\n", "\\n")
+    .replaceAll('"', '\\"')}"`;
+}
+
+function validateHttpsUrl(name, value) {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "https:") throw new Error("must be https");
+  } catch {
+    die(`${name} must be an https URL (received ${value})`);
+  }
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help || args.h) {
+  console.log(`
+Arm Headscale on a control-plane host.
+
+Required:
+  --host <ip-or-host>                  Control-plane SSH host.
+  --ssh-key <path>                     Deploy-user SSH private key.
+  --headscale-public-url <https-url>   Public Headscale URL.
+  --headscale-api-key <key>            Existing Headscale API key.
+
+Optional:
+  --headscale-api-url <url>            Daemon API URL (default http://127.0.0.1:8081).
+  --listen-addr <addr:port>            Headscale listen_addr (default 127.0.0.1:8081).
+  --headscale-user <user>              User for agent preauth keys (default agent).
+  --agent-token-private-key-pem <pem>  Upsert daemon env when already generated.
+  --eliza-local-root-key <key>         Upsert daemon env when already generated.
+  --dry-run                            Print remote script, do not SSH.
+
+Environment fallbacks use uppercase option names, e.g. HEADSCALE_API_KEY.
+`);
+  process.exit(0);
+}
+
+const host = readArg(args, "host", "DEPLOY_HOST");
+const sshKey = readArg(args, "ssh-key", "DEPLOY_SSH_KEY");
+const publicUrl = readArg(args, "headscale-public-url", "HEADSCALE_PUBLIC_URL");
+const apiUrl =
+  readArg(args, "headscale-api-url", "HEADSCALE_API_URL") ??
+  "http://127.0.0.1:8081";
+const apiKey = readArg(args, "headscale-api-key", "HEADSCALE_API_KEY");
+const listenAddr =
+  readArg(args, "listen-addr", "HEADSCALE_LISTEN_ADDR") ?? "127.0.0.1:8081";
+const headscaleUser =
+  readArg(args, "headscale-user", "HEADSCALE_USER") ?? "agent";
+const agentTokenPrivateKey = readArg(
+  args,
+  "agent-token-private-key-pem",
+  "AGENT_TOKEN_PRIVATE_KEY_PEM",
+);
+const localRootKey = readArg(
+  args,
+  "eliza-local-root-key",
+  "ELIZA_LOCAL_ROOT_KEY",
+);
+
+if (!host) die("--host or DEPLOY_HOST is required");
+if (!sshKey) die("--ssh-key or DEPLOY_SSH_KEY is required");
+if (!existsSync(sshKey)) die(`SSH key not found: ${sshKey}`);
+if (!publicUrl)
+  die("--headscale-public-url or HEADSCALE_PUBLIC_URL is required");
+if (!apiKey) die("--headscale-api-key or HEADSCALE_API_KEY is required");
+if (!existsSync(aclPath)) die(`ACL file not found: ${aclPath}`);
+validateHttpsUrl("HEADSCALE_PUBLIC_URL", publicUrl);
+
+const aclBase64 = Buffer.from(readFileSync(aclPath, "utf8"), "utf8").toString(
+  "base64",
+);
+
+const daemonEnv = {
+  HEADSCALE_PUBLIC_URL: publicUrl,
+  HEADSCALE_API_URL: apiUrl,
+  HEADSCALE_API_KEY: apiKey,
+  HEADSCALE_USER: headscaleUser,
+  ...(agentTokenPrivateKey
+    ? { AGENT_TOKEN_PRIVATE_KEY_PEM: agentTokenPrivateKey }
+    : {}),
+  ...(localRootKey ? { ELIZA_LOCAL_ROOT_KEY: localRootKey } : {}),
+};
+
+const upserts = Object.entries(daemonEnv)
+  .map(([key, value]) => {
+    const line = `${key}=${envValueQuote(value)}`;
+    return [
+      `sudo sed -i ${shellQuote(`/^${key}=/d`)} "$F"`,
+      `printf '%s\\n' ${shellQuote(line)} | sudo tee -a "$F" >/dev/null`,
+    ].join("\n");
+  })
+  .join("\n");
+
+const remote = `
+set -euo pipefail
+PUBLIC_URL=${shellQuote(publicUrl)}
+API_URL=${shellQuote(apiUrl)}
+LISTEN_ADDR=${shellQuote(listenAddr)}
+F=${ENV_PATH}
+
+command -v headscale >/dev/null 2>&1 || {
+  echo "headscale binary not found; install the headscale package before arming this host"
+  exit 1
+}
+
+sudo install -d -m 0755 /etc/headscale
+sudo install -d -o headscale -g headscale -m 0750 ${HEADSCALE_STATE_DIR}
+
+printf '%s' ${shellQuote(aclBase64)} | base64 -d | sudo tee ${HEADSCALE_ACL} >/dev/null
+sudo chown root:root ${HEADSCALE_ACL}
+sudo chmod 0644 ${HEADSCALE_ACL}
+
+if [ ! -f ${HEADSCALE_CONFIG} ]; then
+  sudo tee ${HEADSCALE_CONFIG} >/dev/null <<'YAML'
+noise:
+  private_key_path: /var/lib/headscale/noise_private.key
+prefixes:
+  v4: 100.64.0.0/10
+  v6: fd7a:115c:a1e0::/48
+derp:
+  urls:
+    - https://controlplane.tailscale.com/derpmap/default
+  auto_update_enabled: true
+  update_frequency: 24h
+disable_check_updates: true
+ephemeral_node_inactivity_timeout: 15m
+node_update_check_interval: 10s
+database:
+  type: sqlite
+  sqlite:
+    path: /var/lib/headscale/db.sqlite
+    write_ahead_log: true
+log:
+  level: info
+  format: json
+dns:
+  magic_dns: true
+  base_domain: tunnel.eliza.local
+  nameservers:
+    global:
+      - 1.1.1.1
+      - 9.9.9.9
+policy:
+  mode: file
+  path: /etc/headscale/acl.hujson
+unix_socket: /var/lib/headscale/headscale.sock
+unix_socket_permission: "0770"
+YAML
+fi
+
+set_config() {
+  local key="$1"
+  local value="$2"
+  if sudo grep -qE "^$key:" ${HEADSCALE_CONFIG}; then
+    sudo sed -i -E "s|^$key:.*|$key: $value|" ${HEADSCALE_CONFIG}
+  else
+    printf '%s: %s\\n' "$key" "$value" | sudo tee -a ${HEADSCALE_CONFIG} >/dev/null
+  fi
+}
+
+set_config server_url "$PUBLIC_URL"
+set_config listen_addr "$LISTEN_ADDR"
+set_config metrics_listen_addr "127.0.0.1:9090"
+set_config grpc_listen_addr "127.0.0.1:50443"
+set_config grpc_allow_insecure "false"
+
+sudo grep -qE '^policy:' ${HEADSCALE_CONFIG} || sudo tee -a ${HEADSCALE_CONFIG} >/dev/null <<'YAML'
+policy:
+  mode: file
+  path: /etc/headscale/acl.hujson
+YAML
+
+sudo chown root:headscale ${HEADSCALE_CONFIG} || true
+sudo chmod 0640 ${HEADSCALE_CONFIG} || true
+sudo systemctl enable --now headscale
+sudo systemctl restart headscale
+
+for attempt in $(seq 1 30); do
+  if curl -sf -m 3 "$API_URL/health" >/dev/null; then
+    echo "headscale local health passed on attempt $attempt"
+    break
+  fi
+  if [ "$attempt" = 30 ]; then
+    echo "headscale local health failed"
+    sudo systemctl status headscale --no-pager || true
+    sudo journalctl -u headscale -n 80 --no-pager || true
+    exit 1
+  fi
+  sleep 2
+done
+
+for user in agent tunnel; do
+  if ! sudo headscale users list -o json 2>/dev/null | grep -q "\\"name\\"[[:space:]]*:[[:space:]]*\\"$user\\""; then
+    sudo headscale users create "$user"
+  fi
+done
+
+sudo test -f "$F" || { echo "env file $F not found on host"; exit 1; }
+sudo cp -n "$F" "$F.bak.arm-headscale" 2>/dev/null || true
+${upserts}
+
+echo "--- headscale env now on the box (secrets redacted) ---"
+sudo grep -E '^(HEADSCALE_|AGENT_TOKEN_PRIVATE_KEY_PEM|ELIZA_LOCAL_ROOT_KEY)' "$F" \\
+  | sed -E 's/(KEY|PEM)=.*/\\1=<redacted>/'
+
+sudo systemctl restart ${SYSTEMD_UNIT}
+sleep 2
+systemctl is-active headscale
+systemctl is-active ${SYSTEMD_UNIT}
+`;
+
+if (args["dry-run"]) {
+  console.log("# DRY RUN - remote script that WOULD run on", host, ":\n");
+  console.log(remote);
+  process.exit(0);
+}
+
+const result = spawnSync(
+  "ssh",
+  [
+    "-i",
+    sshKey,
+    "-o",
+    "IdentitiesOnly=yes",
+    "-o",
+    "StrictHostKeyChecking=accept-new",
+    "-o",
+    "ConnectTimeout=15",
+    `deploy@${host}`,
+    "bash -s",
+  ],
+  { input: remote, stdio: ["pipe", "inherit", "inherit"] },
+);
+
+if (result.status !== 0)
+  die(`remote Headscale arm failed (exit ${result.status})`);
+
+console.log(
+  "\nHeadscale armed. Next: set matching Worker secrets, then run one provision E2E.",
+);


### PR DESCRIPTION
## What
Adds a repeatable Headscale control-plane arming path for staging/production:

- new arm-headscale-control-plane.yml workflow using GitHub Environment-scoped host/SSH/Headscale secrets
- new packages/scripts/cloud/admin/arm-headscale-control-plane.mjs operator script for the same convergence locally
- docs for the Hetzner control-plane Headscale path, including WHY the daemon requires a real headscale_ip before marking agents running

## Why
The launch tracker exposed that prod Headscale wiring was still a hand-run sequence: set server_url, copy ACL/config, wire daemon env, align host/Worker secrets, restart services, then prove /health. This PR moves the repo-owned half into an idempotent workflow.

## Safety
- Does not generate or print a Headscale API key; it requires an existing HEADSCALE_API_KEY secret.
- Writes the committed ACL policy from the repo.
- Keeps PEM secrets single-line for systemd EnvironmentFile by storing literal \n sequences.
- Fails if local Headscale /health does not come up.
- Leaves Cloudflare Worker secrets as an explicit operator step; host and Worker values still need to match.

## Validation
- node --check packages/scripts/cloud/admin/arm-headscale-control-plane.mjs
- node packages/scripts/cloud/admin/arm-headscale-control-plane.mjs --help
- dry-run render with fake SSH key path and PEM-like input
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/arm-headscale-control-plane.yml")'
- bunx @biomejs/biome check .github/workflows/arm-headscale-control-plane.yml packages/scripts/cloud/admin/arm-headscale-control-plane.mjs packages/cloud-services/headscale/DEPLOY.md packages/cloud-infra/cloud/terraform/hetzner/control-plane/README.md
- git diff --check