### PR TITLE
docs(cloud): refresh launch status and cutover runbooks

### DIFF
--- a/packages/cloud-infra/cloud/bitrouter/README.md
+++ b/packages/cloud-infra/cloud/bitrouter/README.md
@@ -16,6 +16,22 @@ routing.
   - `BITROUTER_BASE_URL=https://<railway-domain>`
   - `BITROUTER_API_KEY=<same value as BITROUTER_PROXY_TOKEN>`
 
+## gpt-oss routing policy
+
+`gpt-oss-120b` is intentionally routed Cerebras-first:
+
+- `gpt-oss-120b` is the bare Cerebras-native id used by the Cloud default path.
+- `openai/gpt-oss-120b` and `openai/gpt-oss-120b:nitro` are legacy gateway
+  aliases kept for stored settings and older clients.
+- All three aliases route to Cerebras first, then to OpenRouter with the plain
+  `openai/gpt-oss-120b` id as fallback.
+
+**Why:** the `:nitro` suffix is an OpenRouter routing convention, not a healthy
+model id for this self-hosted BitRouter path. Leaving new users on
+`openai/gpt-oss-120b:nitro` surfaced upstream 502s as Cloud 503s, while the
+bare Cerebras model was already proven live. The fallback keeps legacy callers
+working without making OpenRouter the first hop.
+
 ## Railway variables
 
 Required:
@@ -48,6 +64,9 @@ railway variables --service bitrouter --set "CEREBRAS_API_KEY=<csk_...>" --skip-
 railway up --service bitrouter packages/cloud-infra/cloud/bitrouter --path-as-root
 railway domain --service bitrouter
 ```
+
+Redeploy BitRouter whenever `bitrouter.yaml` changes. Worker deploys alone do
+not update the Railway service catalog or fallback chain.
 
 After deploy, set Cloud API Worker secrets:
 

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/README.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/README.md
@@ -1,9 +1,27 @@
-# Eliza Cloud Apps — per-env data plane (Hetzner)
+# Eliza Cloud Apps - per-env data plane (Hetzner)
 
-> The IaC half of "Eliza Cloud Apps" (Product 2). The application code is built
-> + verified in **PR #8293**; this terraform stands up the per-env worker nodes
-> + wildcard DNS. Shared resources (private network + tenant Postgres) live in
-> the sibling [`apps-shared`](../apps-shared/) module — apply that one **first**.
+> The IaC half of "Eliza Cloud Apps" (Product 2). This terraform stands up the
+> per-env worker nodes and wildcard DNS. Shared resources (private network and
+> tenant Postgres) live in the sibling [`apps-shared`](../apps-shared/) module;
+> apply that one first.
+
+## Launch status
+
+- Apps deploy mechanics are CI-proven by
+  [PR #8430](https://github.com/elizaOS/eliza/pull/8430): build a real app
+  image, provision a per-tenant DB, run an isolated container, verify own-DB
+  access, verify cross-tenant rejection, and verify no public egress.
+- eDad is the all-features test app after
+  [PR #8433](https://github.com/elizaOS/eliza/pull/8433): when deployed with
+  `databaseMode: "isolated"`, it persists chat history through the injected
+  `DATABASE_URL`.
+- Production deploy remains behind the draft cutover switch
+  [PR #8425](https://github.com/elizaOS/eliza/pull/8425) until this module has
+  been applied for production and the production daemon is armed.
+
+**Why:** `APPS_DEPLOY_ENABLED` on the Worker only enqueues app deploy jobs. The
+daemon still needs a real app node, registry/build settings, and the tenant DB
+admin DSN; merging the Worker flag early can leave apps stuck in `building`.
 
 ## What this provisions
 
@@ -21,7 +39,7 @@ secret live in [`../apps-shared`](../apps-shared/). This module reads them via
 a `terraform_remote_state` data source pointed at
 `hetzner/apps-shared/shared.tfstate`.
 
-## How it connects to the code (PR #8293)
+## How it connects to the code
 1. Apply `../apps-shared` once → `outputs.tenant_db_admin_dsn` (sensitive) +
    `tenant_db_private_ip`.
 2. Encrypt the admin DSN, seed it into **`tenant_db_clusters`** (`provider='direct_pg'`,
@@ -31,7 +49,7 @@ a `terraform_remote_state` data source pointed at
 4. Set daemon/Worker env: `CONTAINERS_DOCKER_NODES` (= `app_node_ips`),
    `CONTAINERS_PUBLIC_BASE_DOMAIN` (= `apps_base_domain`), `CONTAINERS_EGRESS_PROXY_URL`,
    the image registry.
-5. Wire the 2 gated boot one-liners: cloud-api `configureAppsDeployTrigger()` +
+5. Wire the two gated boot one-liners: cloud-api `configureAppsDeployTrigger()` +
    daemon `configureAppsDeployBackend({ registry, buildExec })`.
 6. Flip the feature gate for an allowlist; **on-node kernel re-check** (throwaway
    `--internal` scratch net) before opening to users.

--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-shared/README.md
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-shared/README.md
@@ -1,4 +1,4 @@
-# Eliza Cloud Apps — shared infra (Hetzner)
+# Eliza Cloud Apps - shared infra (Hetzner)
 
 The **shared** half of the Apps (Product 2) data plane. Owns the resources
 that are physically a single piece of infrastructure across staging + production
@@ -14,6 +14,18 @@ app worker nodes:
 Per-env app worker nodes + the `*.<apps_base_domain>` Cloudflare record live in
 the sibling [`apps-data-plane`](../apps-data-plane/) module, which consumes
 this module's outputs through a `terraform_remote_state` data source.
+
+## Launch role
+
+This module is the shared dependency for both staging and production app
+workers. It must exist before `apps-data-plane` can be applied in either
+environment, and its sensitive `tenant_db_admin_dsn` is what the apps daemon
+uses to create per-tenant roles and databases.
+
+**Why:** isolated app DB mode is only real when every deployed app receives a
+tenant-specific DSN created from this shared cluster. Without this state, the
+Worker can accept deploy requests but the daemon cannot provision isolated
+database access.
 
 ## State
 

--- a/packages/docs/cloud/apps.mdx
+++ b/packages/docs/cloud/apps.mdx
@@ -19,6 +19,20 @@ An Eliza Cloud app provides:
 
 Use a **project** for deployable product workspace state and container `project_name`. Use the **Cloud app** `id` when calling `/api/v1/apps/{id}/chat`.
 
+## Launch Readiness
+
+Container deploys and isolated app databases are behind an explicit production
+gate. Staging has a CI-backed deploy proof, but production deploy is only live
+after operators apply the production apps data plane, merge the
+`APPS_DEPLOY_ENABLED` cutover switch, and arm the production daemon.
+
+**Why:** the Worker flag only decides whether deploy requests enqueue real
+`APP_DEPLOY` jobs. The daemon still needs the app node list, registry settings,
+tenant DB admin DSN, and matching feature flag; otherwise requests can be
+accepted while apps remain stuck in `building`.
+
+See [Launch Status](/cloud/launch-status) for the current cutover checklist.
+
 ## Quick Start
 
 ```bash
@@ -147,6 +161,8 @@ Redeem available earnings for elizaOS tokens from [Dashboard -> Earnings](https:
 - Forward user bearer tokens for user-facing app-scoped chat.
 - Store the Cloud app `id` separately from container `project_name`.
 - Patch `app_url` and `allowed_origins` after container deployment.
+- Treat `databaseMode: "isolated"` as the production default for apps that need
+  persistence; verify the deployed image reads the injected `DATABASE_URL`.
 - Handle 402 responses by sending users to [Dashboard -> Billing](https://elizacloud.ai/dashboard/billing).
 
 ## Next Steps

--- a/packages/docs/cloud/changelog.mdx
+++ b/packages/docs/cloud/changelog.mdx
@@ -9,6 +9,42 @@ Stay up to date with the latest changes to elizaOS Cloud.
 
 ---
 
+## June 2026
+
+### Jun 16, 2026
+
+**Cloud launch readiness — staging agent gate, apps E2E, Cerebras routing**
+
+- **Staging agent provisioning proven** — A fresh staging agent registered on
+  Headscale, received `headscale_ip`, passed the tailnet health probe after the
+  boot/warmup retry, and reached `running`. **Why:** the launch-critical path is
+  now known-good outside a local machine: Worker, daemon, Headscale, tailnet
+  routing, and agent router all complete the same flow.
+- **Tailnet warm-keep merged** — Agent health now tolerates cold idle packets
+  with retry, heartbeat hysteresis, and proxy re-warm. **Why:** one transient
+  DERP/WireGuard re-warm should not mark an agent disconnected or cause a public
+  subdomain to 404.
+- **Apps deploy E2E in CI** — The apps CI now builds a real app image,
+  provisions an isolated tenant DB, runs the app in an isolated container,
+  proves own-DB access, proves cross-tenant rejection, and checks no egress.
+  **Why:** app cutover needs a repeatable quality gate instead of a manual
+  staging-only proof.
+- **eDad all-features test app** — eDad can persist chat history when
+  `DATABASE_URL` is injected by isolated DB mode, while staying stateless when
+  no DB is present. **Why:** one deploy now covers monetized inference, app
+  container deploy, per-tenant DB, per-app auth, and custom domain routing.
+- **Cerebras-first default routing** — `gpt-oss-120b` now routes through the
+  Cerebras-direct path, and legacy `openai/gpt-oss-120b` plus
+  `openai/gpt-oss-120b:nitro` aliases route Cerebras-first with OpenRouter
+  fallback in self-hosted BitRouter. **Why:** the old `:nitro` default surfaced
+  503s through OpenRouter even though the bare Cerebras model was already
+  returning successfully.
+
+See [Launch Status](/cloud/launch-status) for the current production gates and
+operator sequence.
+
+---
+
 ## April 2026
 
 ### Apr 28, 2026

--- a/packages/docs/cloud/launch-status.mdx
+++ b/packages/docs/cloud/launch-status.mdx
@@ -1,0 +1,105 @@
+---
+title: Launch Status
+description: Current Eliza Cloud 10-user launch status, gates, and operator sequence.
+---
+
+# Launch Status
+
+This page records the repository-visible state for the Eliza Cloud 10-user
+launch as of **June 16, 2026**. It summarizes issue
+[#8434](https://github.com/elizaOS/eliza/issues/8434), the apps audit in
+[#8321](https://github.com/elizaOS/eliza/issues/8321), and the current PR
+state so operators do not have to reconstruct the plan from stale tracker
+body text.
+
+<Warning>
+  GitHub issue bodies can lag behind merged PRs. For launch decisions, use the
+  latest issue comments, the PR state, and the checks on the current branch.
+</Warning>
+
+## Current State
+
+- **Agent provisioning is proven on staging.** A fresh staging agent registered
+  on Headscale, received `headscale_ip`, passed the tailnet health probe after
+  a boot/warmup retry, and reached `running`. **Why:** this proves the launch
+  gate that was unknown: the daemon, Worker, Headscale, and agent router can
+  complete a real provision flow.
+- **Agent fix chain is merged to `develop`.** PRs
+  [#8435](https://github.com/elizaOS/eliza/pull/8435),
+  [#8441](https://github.com/elizaOS/eliza/pull/8441), and
+  [#8448](https://github.com/elizaOS/eliza/pull/8448) cover Headscale node
+  lookup by `TS_HOSTNAME`, tailnet container-port routing, health-probe backoff,
+  heartbeat hysteresis, and proxy re-warm. **Why:** one cold idle packet must
+  not mark a healthy agent disconnected or make the public route 404.
+- **Apps deploy mechanics are CI-proven.** PR
+  [#8430](https://github.com/elizaOS/eliza/pull/8430) added the apps deploy and
+  tenant-DB E2E workflow. It builds a real app image, provisions a tenant
+  Postgres database, runs the app in an isolated container, verifies the app can
+  reach its own DB, verifies it is rejected from another tenant DB, and checks
+  no public egress. **Why:** production cutover should depend on a repeatable CI
+  gate, not a manual run on one operator machine.
+- **eDad is the all-features test app.** PR
+  [#8433](https://github.com/elizaOS/eliza/pull/8433) added optional
+  per-tenant DB persistence to `packages/examples/cloud/edad`. **Why:** one app
+  now exercises monetized inference, container deploy, isolated DB injection,
+  per-app auth, custom domain routing, and persisted chat history.
+- **New-user first chat was root-caused and fixed on `develop`.** PR
+  [#8450](https://github.com/elizaOS/eliza/pull/8450) routes the default
+  `gpt-oss-120b` path to Cerebras and makes legacy
+  `openai/gpt-oss-120b` / `openai/gpt-oss-120b:nitro` aliases
+  Cerebras-first with OpenRouter fallback in self-hosted BitRouter. **Why:** the
+  `:nitro` route was reaching OpenRouter through self-hosted BitRouter and
+  surfacing 503s for new users instead of using the already-working Cerebras
+  path.
+
+## Production Gates
+
+1. **Replicate the staging Headscale setup to production.** The production
+   control plane must expose `https://headscale.elizacloud.ai`, use that value
+   as Headscale `server_url`, and have matching daemon/Worker secrets for
+   `HEADSCALE_API_KEY`, `HEADSCALE_PUBLIC_URL`, and
+   `AGENT_TOKEN_PRIVATE_KEY_PEM`. **Why:** staging is proven; production must
+   be the same recipe before a prod provision E2E is meaningful.
+2. **Run one clean production provision E2E.** A fresh prod agent must receive a
+   non-null `headscale_ip`, reach `running`, stay routable after idle warm-keep,
+   and serve `/pair`. **Why:** this proves prod carries the same end-to-end
+   behavior as staging, including the idle-tailnet fix.
+3. **Apply the production apps data plane.** Run
+   `terraform-apps-data-plane.yml` for `environment=production` after confirming
+   the GitHub Environment variables listed in the apps data-plane runbook.
+   **Why:** the Worker cutover flag only enqueues deploy jobs; without a prod app
+   node and wildcard DNS, jobs can be accepted but not completed.
+4. **Merge the cutover switch PR.** PR
+   [#8425](https://github.com/elizaOS/eliza/pull/8425) is intentionally draft
+   until the prod apps data plane exists and the daemon is ready. **Why:**
+   merging `APPS_DEPLOY_ENABLED="1"` early half-enables production deploys and
+   can leave apps stuck in `building`.
+5. **Arm the production apps daemon.** Run `arm-apps-daemon.yml` with the prod
+   app node and tenant DB DSN from shared state. **Why:** the Worker and daemon
+   must agree that app deploy is live, and the daemon must know where to run
+   containers.
+6. **Deploy eDad and reset stuck apps.** Deploy eDad with isolated DB mode and
+   confirm `https://edad.apps.elizacloud.ai` plus `GET /api/history`; reset the
+   stuck `council` app so it re-enters the now-armed path. **Why:** eDad is the
+   single launch smoke that covers the whole apps platform, while stuck pre-gate
+   records should not be treated as fresh failures.
+
+## PR Triage
+
+| PR | State | Launch Meaning |
+| --- | --- | --- |
+| [#8430](https://github.com/elizaOS/eliza/pull/8430) | Merged | Apps deploy and tenant-DB E2E is now a CI gate. |
+| [#8433](https://github.com/elizaOS/eliza/pull/8433) | Merged | eDad can exercise per-tenant DB as the all-features test app. |
+| [#8448](https://github.com/elizaOS/eliza/pull/8448) | Merged | Idle tailnet false-eviction fix is on `develop`; promote before relying on prod idle behavior. |
+| [#8450](https://github.com/elizaOS/eliza/pull/8450) | Merged | Cerebras-first default/fallback routing is on `develop`; deploy BitRouter and Worker paths before claiming prod fixed. |
+| [#8425](https://github.com/elizaOS/eliza/pull/8425) | Open draft | Production apps cutover switch; un-draft only after prod data plane and daemon are ready. |
+| [#8451](https://github.com/elizaOS/eliza/pull/8451) | Open draft | Adds deploy automation for ARM Headscale control-plane work; useful follow-up, not an apps cutover prerequisite. |
+| [#8351](https://github.com/elizaOS/eliza/pull/8351), [#8356](https://github.com/elizaOS/eliza/pull/8356), [#8292](https://github.com/elizaOS/eliza/pull/8292) | Open/stale | Do not merge as-is for launch; split or close after comparing against merged focused PRs. |
+
+## Quality Gate
+
+The launch standard is unchanged: code can become faster and more path-gated,
+but it must not skip isolation, billing, routing, or production-readiness proof.
+For apps, the minimum gate is the #8430 E2E plus one production eDad deployment.
+For agents, the minimum gate is a fresh prod provision, `headscale_ip`, running
+status, reachable route, `/pair`, and idle warm-keep survival.

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -394,6 +394,7 @@
               "cloud/rate-limits",
               "cloud/errors",
               "cloud/sdks",
+              "cloud/launch-status",
               "cloud/changelog"
             ]
           },

--- a/packages/docs/tracks/cloud/apps.mdx
+++ b/packages/docs/tracks/cloud/apps.mdx
@@ -1,41 +1,52 @@
 ---
 title: Cloud Apps
-description: "Register an appId, version, and publish."
+description: "Register a Cloud app, route app-scoped chat, and prepare container deploys."
 ---
 
-An **app** in Cloud is a registered product that bundles metadata, allowed redirect URIs, billing settings, and deployment configuration. Registering an app gives you an `appId` that:
+An **app** in Cloud is a registered product that bundles metadata, allowed
+origins, billing settings, and deployment configuration. Registering an app
+gives you an `id` that:
 
 - Identifies the app to Cloud-routed inference, billing, and analytics.
-- Lets the app use Cloud OAuth flows.
+- Lets the app use app-scoped chat and app-owned admin APIs.
 - Enables container deploys and domain binding.
 - Powers creator monetization (earnings tied to app usage).
 
 ## Register
 
-`POST /v1/apps`
+`POST /api/v1/apps`
 
 Body:
 
 ```json
 {
   "name": "My App",
+  "app_url": "https://placeholder.invalid",
+  "allowed_origins": ["https://placeholder.invalid"],
   "description": "What it does.",
-  "redirectUris": ["https://my-app.example.com/oauth/callback"],
-  "monetization": { "enabled": true }
+  "skipGitHubRepo": true
 }
 ```
 
-Response includes the assigned `appId` and a client secret. Store the secret server-side.
+Response includes the assigned app `id` and a one-time app API key. Store the
+key server-side.
 
 ## Lifecycle
 
-- `GET /v1/apps/:id` — fetch.
-- `PATCH /v1/apps/:id` — update metadata, redirects, settings.
-- `DELETE /v1/apps/:id` — soft-delete.
+- `GET /api/v1/apps/:id` - fetch.
+- `PATCH /api/v1/apps/:id` - update metadata, URLs, origins, and settings.
+- `DELETE /api/v1/apps/:id` - soft-delete.
 
-## Versioning
+## Deploy Readiness
 
-App versions track deployed releases. Versions can be published, rolled back, and marked stable / beta.
+App deploys are gated in production by `APPS_DEPLOY_ENABLED`. The cutover is
+operator-controlled: apply the production apps data plane, merge the production
+Worker flag, arm the production daemon, then deploy the all-features eDad test
+app with isolated DB mode.
+
+**Why:** the app record, Worker route, daemon, app node, tenant DB, and wildcard
+domain must agree before production can safely accept deploy jobs. See
+[Launch Status](/cloud/launch-status) for the current gate.
 
 ## Source
 


### PR DESCRIPTION
## What

- Add a canonical Cloud launch status page for the 10-user launch state as of June 16, 2026.
- Refresh Cloud changelog and app docs with the current staging agent proof, apps deploy E2E, eDad all-features test role, and Cerebras-first routing fix.
- Update apps shared/data-plane and BitRouter runbooks with the current cutover gates and WHYs.

## Why

The tracker body in #8434 now lags behind merged PR reality: #8430, #8433, #8448, and #8450 are merged, while #8425 remains the intentional production cutover switch. Operators need a stable repo doc that separates proven staging/CI facts from the remaining production gates.

## Verification

- `bun run --cwd packages/docs test`
- `git diff --check`

## Notes

Docs-only. No cloud-frontend UI changes, so the cloud visual audit is not required.