### PR TITLE
test(cloud): align BitRouter infra contract

### DIFF
--- a/packages/cloud-infra/tests/bitrouter-service.test.ts
+++ b/packages/cloud-infra/tests/bitrouter-service.test.ts
@@ -9,26 +9,31 @@ function readBitRouterFile(file: string): string {
   return readFileSync(join(BITROUTER_DIR, file), "utf-8");
 }
 
+function expectEndpointChain(
+  models: Record<
+    string,
+    { endpoints?: Array<{ provider?: string; service_id?: string }> }
+  >,
+  modelId: string,
+  expected: Array<{ provider: string; service_id: string }>,
+) {
+  expect(models[modelId]?.endpoints).toEqual(expected);
+}
+
 describe("BitRouter Railway service", () => {
   test("runs BitRouter behind the authenticated proxy", () => {
     const dockerfile = readBitRouterFile("Dockerfile");
     const entrypoint = readBitRouterFile("entrypoint.sh");
     const proxy = readBitRouterFile("auth-proxy.mjs");
 
-    expect(dockerfile).toContain("npm install -g bitrouter");
+    expect(dockerfile).toContain("npm install -g bitrouter@0.33.0");
     expect(dockerfile).toContain("expect");
-    expect(dockerfile).toContain('grep -q "buffer-v2"');
-    expect(dockerfile).toContain('grep -q "openrouter:"');
-    expect(dockerfile).toContain(
-      'grep -q "api_protocol: openai"',
-    );
-    expect(dockerfile).toContain('grep -q "no_cache: 0.039"');
-    expect(dockerfile).toContain('grep -q "no_cache: 0.35"');
-    expect(dockerfile).toContain('grep -q "no_cache: 2.25"');
     expect(dockerfile).toContain('CMD ["/app/entrypoint.sh"]');
     expect(entrypoint).toContain(
       "bitrouter serve --config-file /app/bitrouter.yaml",
     );
+    expect(entrypoint).toContain("BITROUTER_CEREBRAS_API_KEY");
+    expect(entrypoint).toContain("CEREBRAS_API_KEY");
     expect(entrypoint).toContain("BITROUTER_OPENROUTER_API_KEY");
     expect(entrypoint).toContain("OPENROUTER_API_KEY");
     expect(entrypoint).toContain("bitrouter wallet create --name eliza-cloud");
@@ -63,45 +68,53 @@ describe("BitRouter Railway service", () => {
       providers: Record<
         string,
         {
+          api_base?: string;
+          api_key?: string;
+          auto_discover?: boolean;
           api_protocol?: string;
-          models?: Record<
-            string,
-            {
-              pricing?: {
-                input_tokens?: { no_cache?: number };
-                output_tokens?: { text?: number };
-              };
-            }
-          >;
         }
       >;
+      models?: Record<
+        string,
+        { endpoints?: Array<{ provider?: string; service_id?: string }> }
+      >;
+      inherit_defaults?: boolean;
     };
     const railway = readBitRouterFile("railway.toml");
 
     expect(config.server.listen).toBe("127.0.0.1:4356");
     expect(config.database.url).toBe("sqlite:/data/bitrouter.db");
-    expect(config.providers).toHaveProperty("bitrouter");
+    expect(config.providers).not.toHaveProperty("bitrouter");
     expect(config.providers).toHaveProperty("openrouter");
-    expect(
-      config.providers.openrouter?.models?.["openai/gpt-oss-120b"]?.pricing,
-    ).toEqual({
-      input_tokens: { no_cache: 0.039, cache_read: 0, cache_write: 0 },
-      output_tokens: { text: 0.18, reasoning: 0 },
+    expect(config.providers.openrouter).toEqual({});
+    expect(config.providers.cerebras).toEqual({
+      api_base: "https://api.cerebras.ai/v1",
+      api_key: "$" + "{BITROUTER_CEREBRAS_API_KEY}",
+      auto_discover: true,
     });
-    expect(config.providers.cerebras?.api_protocol).toBe("openai");
-    expect(
-      config.providers.cerebras?.models?.["gpt-oss-120b"]?.pricing,
-    ).toEqual({
-      input_tokens: { no_cache: 0.35, cache_read: 0, cache_write: 0 },
-      output_tokens: { text: 0.75, reasoning: 0 },
-    });
-    expect(
-      config.providers.cerebras?.models?.["zai-glm-4.7"]?.pricing,
-    ).toEqual({
-      input_tokens: { no_cache: 2.25, cache_read: 0, cache_write: 0 },
-      output_tokens: { text: 2.75, reasoning: 0 },
-    });
-    expect(config).not.toHaveProperty("models");
+    expect(config.inherit_defaults).toBe(true);
+    expect(config.models).toBeDefined();
+    expectEndpointChain(config.models ?? {}, "gpt-oss-120b", [
+      { provider: "cerebras", service_id: "gpt-oss-120b" },
+      { provider: "openrouter", service_id: "openai/gpt-oss-120b" },
+    ]);
+    expectEndpointChain(config.models ?? {}, "openai/gpt-oss-120b", [
+      { provider: "cerebras", service_id: "gpt-oss-120b" },
+      { provider: "openrouter", service_id: "openai/gpt-oss-120b" },
+    ]);
+    expectEndpointChain(config.models ?? {}, "openai/gpt-oss-120b:nitro", [
+      { provider: "cerebras", service_id: "gpt-oss-120b" },
+      { provider: "openrouter", service_id: "openai/gpt-oss-120b" },
+    ]);
+    expectEndpointChain(config.models ?? {}, "anthropic/claude-haiku-4.5", [
+      { provider: "openrouter", service_id: "anthropic/claude-haiku-4.5" },
+    ]);
+    expectEndpointChain(config.models ?? {}, "anthropic/claude-sonnet-4.6", [
+      { provider: "openrouter", service_id: "anthropic/claude-sonnet-4.6" },
+    ]);
+    expectEndpointChain(config.models ?? {}, "x-ai/grok-4.20", [
+      { provider: "openrouter", service_id: "x-ai/grok-4.20" },
+    ]);
     expect(railway).toContain("[deploy]");
     expect(railway).toContain('healthcheckPath = "/health"');
   });


### PR DESCRIPTION
## Summary

Updates the BitRouter Railway service smoke test to match the current service contract:

- assert the pinned `bitrouter@0.33.0` install instead of stale Dockerfile grep checks
- assert BitRouter Cloud is intentionally not enabled via `providers.bitrouter`
- assert the current Cerebras-first / OpenRouter-fallback model chains for `gpt-oss-120b` and `openai/gpt-oss-120b:nitro`
- keep coverage for the auth proxy, internal JWT path, cost-audit mode, Cerebras request fixes, and Railway healthcheck

## Why

`packages/cloud-infra` was failing because the test still expected the older provider-level pricing layout. The runtime now uses top-level `models:` aliases plus explicit Cerebras BYOK configuration, so the test had become stale even though the current service shape is intentional.

## Validation

- `bun test packages/cloud-infra/tests/bitrouter-service.test.ts`
- `bun run --cwd packages/cloud-infra test`
- `bunx @biomejs/biome check packages/cloud-infra/tests/bitrouter-service.test.ts`
- `git diff --check`