### PR TITLE
fix(cloud): harden provisioning-worker so one slow node/agent op can't starve the liveness heartbeat

### DIFF
--- a/packages/cloud-shared/src/lib/services/admin-infrastructure.ts
+++ b/packages/cloud-shared/src/lib/services/admin-infrastructure.ts
@@ -4,6 +4,7 @@ import { dockerNodesRepository } from "../../db/repositories/docker-nodes";
 import { type AgentSandboxStatus, agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import type { DockerNodeStatus } from "../../db/schemas/docker-nodes";
 import { logger } from "../utils/logger";
+import { withTimeout } from "../utils/with-timeout";
 import { DockerSSHClient } from "./docker-ssh";
 
 const HEARTBEAT_WARNING_MINUTES = 5;
@@ -33,23 +34,6 @@ async function pLimit<T>(tasks: Array<() => Promise<T>>, limit: number): Promise
   const workers = Array.from({ length: Math.min(limit, tasks.length) }, () => worker());
   await Promise.all(workers);
   return results;
-}
-
-/** Wraps a promise with a timeout — rejects with an error if the deadline expires. */
-function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
-    promise.then(
-      (value) => {
-        clearTimeout(timer);
-        resolve(value);
-      },
-      (err) => {
-        clearTimeout(timer);
-        reject(err);
-      },
-    );
-  });
 }
 
 /**

--- a/packages/cloud-shared/src/lib/services/containers/registry-probe.ts
+++ b/packages/cloud-shared/src/lib/services/containers/registry-probe.ts
@@ -13,6 +13,15 @@ import { logger } from "../../utils/logger";
 
 const CACHE_TTL_MS = 60_000;
 
+/**
+ * Per-request cap on the two ghcr.io HTTP calls (token + manifest HEAD). These
+ * were the one genuinely-unbounded leaf in the provisioning cycle — a hung
+ * ghcr connection could stall the fleet-upgrade reconciler indefinitely.
+ * `resolveImageDigest` already returns null on any failure and callers treat
+ * null as "skip, retry next tick", so bounding adds no behavior change.
+ */
+const REGISTRY_FETCH_TIMEOUT_MS = 5_000;
+
 interface CacheEntry {
   digest: string | null;
   expiresAt: number;
@@ -93,6 +102,7 @@ async function fetchGhcrDigest(
   try {
     const tokenResp = await fetchFn(
       `https://ghcr.io/token?scope=repository:${encodedRepo}:pull&service=ghcr.io`,
+      { signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS) },
     );
     if (!tokenResp.ok) {
       logger.warn(`[registry-probe] ghcr token fetch failed for ${repo}: ${tokenResp.status}`);
@@ -113,6 +123,7 @@ async function fetchGhcrDigest(
       `https://ghcr.io/v2/${encodedRepo}/manifests/${encodedTag}`,
       {
         method: "HEAD",
+        signal: AbortSignal.timeout(REGISTRY_FETCH_TIMEOUT_MS),
         headers: {
           Authorization: `Bearer ${token}`,
           Accept: [

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -18,6 +18,7 @@ import { getCloudAwareEnv } from "../runtime/cloud-bindings";
 import { signStewardMutatingRequest } from "../steward/sign";
 import { resolveServerStewardApiUrlFromEnv } from "../steward-url";
 import { logger } from "../utils/logger";
+import { withTimeout } from "../utils/with-timeout";
 import { loginToImageRegistry } from "./containers/hetzner-client/registry";
 import { getNodeAutoscaler } from "./containers/node-autoscaler";
 import { resolveImageDigest } from "./containers/registry-probe";
@@ -370,6 +371,18 @@ const PULL_TIMEOUT_MS = 300_000; // 5 min
 
 /** SSH command timeout for docker run / stop / rm. */
 const DOCKER_CMD_TIMEOUT_MS = 60_000;
+
+/**
+ * Dedicated, tighter SSH timeout for the stop/rm calls on the delete path.
+ * `docker stop` uses its own `-t 10` grace, so 25s caps the whole stop path
+ * without ever truncating a legitimate graceful shutdown. Keeping this under
+ * the 60s generic timeout is what stops one wedged delete from holding the
+ * cycle (and the DB advisory lock) open across the full minute.
+ */
+const STOP_CMD_TIMEOUT_MS = 25_000;
+
+/** Cap on the best-effort headscale VPN cleanup during stop(). */
+const HEADSCALE_CLEANUP_TIMEOUT_MS = 15_000;
 
 /** Autoscaled node readiness polling. */
 const AUTOSCALED_NODE_READY_TIMEOUT_MS = 4 * 60 * 1000;
@@ -1539,7 +1552,7 @@ export class DockerSandboxProvider implements SandboxProvider {
 
     try {
       // Graceful stop with 10s timeout, then force-remove
-      await ssh.exec(`docker stop -t 10 ${shellQuote(meta.containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(`docker stop -t 10 ${shellQuote(meta.containerName)}`, STOP_CMD_TIMEOUT_MS);
       logger.info(`[docker-sandbox] Container stopped: ${meta.containerName}`);
     } catch (err) {
       stopErr = err;
@@ -1549,7 +1562,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     }
 
     try {
-      await ssh.exec(`docker rm -f ${shellQuote(meta.containerName)}`, DOCKER_CMD_TIMEOUT_MS);
+      await ssh.exec(`docker rm -f ${shellQuote(meta.containerName)}`, STOP_CMD_TIMEOUT_MS);
       logger.info(`[docker-sandbox] Container removed: ${meta.containerName}`);
     } catch (err) {
       rmErr = err;
@@ -1589,13 +1602,15 @@ export class DockerSandboxProvider implements SandboxProvider {
     if (process.env.HEADSCALE_API_KEY && meta.agentId) {
       // Delete the node by the hostname it registered under (TS_HOSTNAME), not the
       // bare agentId — Headscale identifies the node by that name.
-      await headscaleIntegration
-        .cleanupContainerVPN(meta.tsHostname ?? meta.agentId)
-        .catch((err) => {
-          logger.warn(
-            `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
-          );
-        });
+      await withTimeout(
+        headscaleIntegration.cleanupContainerVPN(meta.tsHostname ?? meta.agentId),
+        HEADSCALE_CLEANUP_TIMEOUT_MS,
+        "headscale cleanup",
+      ).catch((err) => {
+        logger.warn(
+          `[docker-sandbox] Headscale cleanup failed for ${meta.agentId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
     }
 
     // Remove from in-memory registry

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -27,6 +27,7 @@ import { agentSandboxes } from "../../db/schemas/agent-sandboxes";
 import { jobs } from "../../db/schemas/jobs";
 import { assertSafeOutboundUrl } from "../security/outbound-url";
 import { logger } from "../utils/logger";
+import { withTimeout } from "../utils/with-timeout";
 import { dispatchAppDbDeprovisionJob } from "./app-db-deprovision-job-service";
 import { dispatchAppDeployJob } from "./app-deploy-job-service";
 import { dispatchContainerJob, getContainerExecutorDeps } from "./container-job-service";
@@ -591,6 +592,14 @@ interface LifecycleJobOptions<TData extends object> {
    */
   beforeInsert?: (tx: Parameters<Parameters<typeof dbWrite.transaction>[0]>[0]) => Promise<void>;
 }
+
+/**
+ * Hard ceiling on a single job's execution. A slow agent_delete (SSH +
+ * headscale network I/O while holding a DB advisory lock) used to run for
+ * minutes and starve the whole cycle. Every leaf is independently bounded, so
+ * a job hitting this ceiling means something is genuinely wedged.
+ */
+const PER_JOB_TIMEOUT_MS = 120_000;
 
 export class ProvisioningJobService {
   /**
@@ -1359,7 +1368,12 @@ export class ProvisioningJobService {
       result.claimed++;
 
       try {
-        await this.executeJob(job);
+        // withTimeout frees the awaiter (this cycle's job slot), not the
+        // underlying SSH/headscale I/O — those are themselves bounded. On
+        // timeout this throws → the catch below runs incrementAttempt, which
+        // flips the row to error/deletion_failed once attempts exhaust;
+        // recoverStaleJobs (5-min in_progress threshold) is the backstop.
+        await withTimeout(this.executeJob(job), PER_JOB_TIMEOUT_MS, `job ${job.type}`);
         result.succeeded++;
       } catch (err) {
         result.failed++;

--- a/packages/cloud-shared/src/lib/services/provisioning-worker-health.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-worker-health.ts
@@ -4,6 +4,14 @@ import {
   type RedisFactoryEnv,
 } from "../cache/redis-factory";
 import { getCloudAwareEnv } from "../runtime/cloud-bindings";
+import { withTimeout } from "../utils/with-timeout";
+
+/**
+ * Cap on the heartbeat Redis SET. Redis has been flaky in prod; without this
+ * the publish can hang indefinitely and (in the daemon's interval) pile up
+ * unresolved promises. 5s is generous for a single SET against Upstash/Redis.
+ */
+const HEARTBEAT_SET_TIMEOUT_MS = 5_000;
 
 /**
  * Redis key the provisioning-worker daemon SETs with a short TTL every
@@ -123,8 +131,14 @@ export async function publishProvisioningWorkerHeartbeat(): Promise<boolean> {
   const redis = getRedis();
   if (!redis) return false;
   const timestamp = new Date().toISOString();
-  await redis.set(PROVISIONING_WORKER_HEARTBEAT_KEY, timestamp, {
-    ex: PROVISIONING_WORKER_HEARTBEAT_TTL_S,
-  });
+  await withTimeout(
+    Promise.resolve(
+      redis.set(PROVISIONING_WORKER_HEARTBEAT_KEY, timestamp, {
+        ex: PROVISIONING_WORKER_HEARTBEAT_TTL_S,
+      }),
+    ),
+    HEARTBEAT_SET_TIMEOUT_MS,
+    "heartbeat redis set",
+  );
   return true;
 }

--- a/packages/cloud-shared/src/lib/utils/with-timeout.test.ts
+++ b/packages/cloud-shared/src/lib/utils/with-timeout.test.ts
@@ -1,0 +1,25 @@
+/**
+ * Tests for withTimeout — the promise-race timeout used across the
+ * provisioning daemon's bounded ops. It frees the awaiter after `ms`; it does
+ * not abort the underlying work.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { withTimeout } from "./with-timeout";
+
+describe("withTimeout", () => {
+  test("resolves with the value when the promise settles before the deadline", async () => {
+    const result = await withTimeout(Promise.resolve("ok"), 50, "fast op");
+    expect(result).toBe("ok");
+  });
+
+  test("rejects with a labelled timeout error when the deadline elapses", async () => {
+    const never = new Promise<string>(() => {});
+    await expect(withTimeout(never, 10, "slow op")).rejects.toThrow("slow op timed out after 10ms");
+  });
+
+  test("propagates the underlying rejection when it loses to the race", async () => {
+    const boom = Promise.reject(new Error("underlying failure"));
+    await expect(withTimeout(boom, 1_000, "op")).rejects.toThrow("underlying failure");
+  });
+});

--- a/packages/cloud-shared/src/lib/utils/with-timeout.ts
+++ b/packages/cloud-shared/src/lib/utils/with-timeout.ts
@@ -1,0 +1,22 @@
+/**
+ * Wraps a promise with a timeout — rejects with an error if the deadline
+ * expires. This is a promise-race: it frees the *awaiter* after `ms`, it does
+ * NOT abort the underlying work. Use it only where every leaf is already
+ * independently bounded (its own SSH/HTTP/Redis timeout), so a rejected race
+ * never leaves truly-unbounded I/O running behind it.
+ */
+export function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.test.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it, mock } from "bun:test";
-import { assertProvisioningWorkerPreflight } from "./provisioning-worker";
+import {
+  assertProvisioningWorkerPreflight,
+  maybePublishHeartbeat,
+} from "./provisioning-worker";
+
+type WorkerLogger = Parameters<typeof maybePublishHeartbeat>[0];
+
+function makeLogger(): WorkerLogger {
+  return {
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    debug: mock(() => {}),
+  } as unknown as WorkerLogger;
+}
 
 describe("assertProvisioningWorkerPreflight", () => {
   it("verifies KMS can create or load the preflight key", async () => {
@@ -45,5 +59,52 @@ describe("assertProvisioningWorkerPreflight", () => {
         }),
       }),
     ).rejects.toThrow("Steward endpoint unavailable");
+  });
+});
+
+describe("maybePublishHeartbeat (liveness gate)", () => {
+  const fresh = Date.now();
+
+  it("does NOT publish when preflight has not passed (preflightOk=false)", async () => {
+    const publish = mock(async () => {});
+    const result = await maybePublishHeartbeat(makeLogger(), {
+      preflightOk: false,
+      lastCycleCompletedAt: fresh,
+      now: fresh,
+      publish,
+    });
+
+    expect(publish).not.toHaveBeenCalled();
+    expect(result).toEqual({ published: false, watchdogTripped: false });
+  });
+
+  it("DOES publish when preflight passed and the cycle is progressing", async () => {
+    const publish = mock(async () => {});
+    const result = await maybePublishHeartbeat(makeLogger(), {
+      preflightOk: true,
+      lastCycleCompletedAt: fresh,
+      now: fresh,
+      publish,
+    });
+
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ published: true, watchdogTripped: false });
+  });
+
+  it("withholds the heartbeat when the watchdog trips, even if preflight is OK", async () => {
+    const publish = mock(async () => {});
+    const logger = makeLogger();
+    // Last cycle completed > 5min ago → wedged.
+    const stale = fresh - (5 * 60_000 + 1);
+    const result = await maybePublishHeartbeat(logger, {
+      preflightOk: true,
+      lastCycleCompletedAt: stale,
+      now: fresh,
+      publish,
+    });
+
+    expect(publish).not.toHaveBeenCalled();
+    expect(result).toEqual({ published: false, watchdogTripped: true });
+    expect(logger.error).toHaveBeenCalled();
   });
 });

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -474,6 +474,44 @@ async function processPoolDrainIdleCycle(): Promise<PoolDrainSummary> {
 let running = true;
 let lastInfraMaintenanceAt = 0;
 
+/**
+ * Heartbeat cadence — independent of the work cycle. The liveness key lives
+ * 60s in Redis (PROVISIONING_WORKER_HEARTBEAT_TTL_S); publishing every 15s
+ * leaves room for 3 missed publishes before the gate trips. Decoupling this
+ * from `pollCycle` is THE fix: a slow agent-delete or node health-check can no
+ * longer starve the heartbeat and make cloud-api reject every provision.
+ */
+const HEARTBEAT_INTERVAL_MS = 15_000;
+
+/**
+ * If the work cycle stops completing for this long, the worker is wedged
+ * (e.g. Redis healthy but Neon/SSH hung). We deliberately STOP publishing the
+ * heartbeat so cloud-api fails CLOSED — `checkProvisioningWorkerHealth` sees
+ * the stale key and 503s new provisions instead of routing them to a worker
+ * that can't make progress — and the loud error log flags it for a human.
+ * This does NOT itself restart the process (systemd `Restart=always` only
+ * fires on process exit, and nothing kills us on a stale key); true
+ * auto-recovery via `process.exit(1)` is a deliberate follow-up that first
+ * needs a threshold comfortably above worst-case infra-maintenance on a large
+ * fleet, else a slow-but-healthy cycle would restart-loop. P1 keeps a
+ * *progressing* worker healthy; the watchdog fails a *wedged* one closed.
+ */
+const WATCHDOG_MAX_CYCLE_MS = 5 * 60_000;
+
+/**
+ * Liveness gate. The heartbeat interval publishes ONLY when this is true.
+ * Set true immediately after `assertProvisioningWorkerPreflight()` succeeds,
+ * false on any throw. Default false so a KMS-dead worker never advertises
+ * healthy before the first preflight has run.
+ */
+let preflightOk = false;
+
+/** Wall-clock of the last `pollCycle` that returned. Drives the watchdog. */
+let lastCycleCompletedAt = Date.now();
+
+/** In-flight guard so a hung Redis write can't pile up unresolved publishes. */
+let heartbeatPublishInFlight = false;
+
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -491,12 +529,91 @@ async function publishHeartbeat(logger: WorkerLogger): Promise<void> {
   }
 }
 
+/**
+ * Decide whether the heartbeat may be published this tick, and publish it.
+ * Gated on three independent conditions, all of which must hold:
+ *   1. `preflightOk` — KMS is usable (a KMS-dead worker must never advertise
+ *      healthy, mirroring the old in-cycle preflight gate).
+ *   2. the watchdog has not tripped — the work cycle is still progressing.
+ *   3. no publish is already in flight — a slow/hung Redis write must not pile
+ *      up unresolved promises.
+ * Exported for unit testing the gate logic.
+ */
+export async function maybePublishHeartbeat(
+  logger: WorkerLogger,
+  deps: {
+    preflightOk: boolean;
+    lastCycleCompletedAt: number;
+    now?: number;
+    publish?: (logger: WorkerLogger) => Promise<void>;
+  },
+): Promise<{ published: boolean; watchdogTripped: boolean }> {
+  const now = deps.now ?? Date.now();
+  const publish = deps.publish ?? publishHeartbeat;
+
+  if (now - deps.lastCycleCompletedAt > WATCHDOG_MAX_CYCLE_MS) {
+    logger.error(
+      "[provisioning-worker] WATCHDOG: work cycle has not completed in over " +
+        `${Math.round(WATCHDOG_MAX_CYCLE_MS / 1000)}s — worker appears wedged. ` +
+        "Withholding heartbeat so cloud-api fails closed (stops routing provisions here); restart this worker.",
+      {
+        lastCycleCompletedAt: new Date(deps.lastCycleCompletedAt).toISOString(),
+      },
+    );
+    return { published: false, watchdogTripped: true };
+  }
+
+  // KMS-dead worker must never advertise healthy.
+  if (!deps.preflightOk) {
+    return { published: false, watchdogTripped: false };
+  }
+
+  await publish(logger);
+  return { published: true, watchdogTripped: false };
+}
+
+/**
+ * Start the independent heartbeat timer. Decoupled from `pollCycle` so a slow
+ * work item can never starve the liveness key. The in-flight guard skips a
+ * tick rather than queueing a second publish behind a hung Redis write.
+ */
+function startHeartbeatInterval(logger: WorkerLogger): NodeJS.Timeout {
+  const tick = () => {
+    if (heartbeatPublishInFlight) return;
+    heartbeatPublishInFlight = true;
+    void maybePublishHeartbeat(logger, {
+      preflightOk,
+      lastCycleCompletedAt,
+    }).finally(() => {
+      heartbeatPublishInFlight = false;
+    });
+  };
+  const timer = setInterval(tick, HEARTBEAT_INTERVAL_MS);
+  timer.unref();
+  return timer;
+}
+
 async function pollCycle(
   logger: WorkerLogger,
   config: ProvisioningWorkerConfig,
 ): Promise<void> {
-  await assertProvisioningWorkerPreflight();
-  await publishHeartbeat(logger);
+  // Re-validate the preflight at the top of every cycle (cheap — a local KMS
+  // getOrCreateKey). The heartbeat interval owns liveness now, but it only
+  // publishes while `preflightOk` is true, so this is what keeps a KMS-dead
+  // worker from advertising healthy. Set true ONLY immediately after success.
+  try {
+    await assertProvisioningWorkerPreflight();
+    preflightOk = true;
+  } catch (error) {
+    preflightOk = false;
+    logger.error(
+      "[provisioning-worker] preflight failed; withholding heartbeat",
+      {
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return;
+  }
   try {
     const result = await processProvisioningWorkerCycle(config.batchSize);
     if (result.claimed > 0 || result.failed > 0) {
@@ -563,6 +680,10 @@ async function pollCycle(
     lastInfraMaintenanceAt = now;
     await runInfraMaintenanceCycle(logger);
   }
+
+  // Mark progress for the watchdog. As long as this advances, the heartbeat
+  // interval keeps the worker healthy even across long cycles.
+  lastCycleCompletedAt = Date.now();
 }
 
 async function runInfraMaintenanceCycle(logger: WorkerLogger): Promise<void> {
@@ -687,21 +808,39 @@ async function main(): Promise<void> {
   });
 
   await assertProvisioningWorkerPreflight();
+  preflightOk = true;
   logger.info("[provisioning-worker] startup preflight passed");
 
   // Apps (Product 2): arm the deploy backend when enabled (gated; no-op by default).
   await armAppsDeployBackendIfEnabled(logger);
 
+  // Seed the watchdog clock so a slow first cycle can't trip it immediately.
+  lastCycleCompletedAt = Date.now();
+
   if (config.runOnce) {
+    // Publish once so a --once invocation still reports liveness, then run a
+    // single cycle. No interval needed for the one-shot path.
+    await publishHeartbeat(logger);
     await pollCycle(logger, config);
     return;
   }
 
-  while (running) {
-    await pollCycle(logger, config);
-    if (running) {
-      await sleep(config.pollIntervalMs);
+  // Decouple liveness from the work cycle: an independent timer publishes the
+  // heartbeat every HEARTBEAT_INTERVAL_MS regardless of how long a single
+  // cycle takes. Publish once immediately so there's no cold gap before the
+  // first tick.
+  await publishHeartbeat(logger);
+  const heartbeatTimer = startHeartbeatInterval(logger);
+
+  try {
+    while (running) {
+      await pollCycle(logger, config);
+      if (running) {
+        await sleep(config.pollIntervalMs);
+      }
     }
+  } finally {
+    clearInterval(heartbeatTimer);
   }
 
   logger.info("[provisioning-worker] stopped");


### PR DESCRIPTION
## Root cause (verified live)

The provisioning-worker (the Node sidecar daemon) writes its Redis **LIVENESS** heartbeat **once per work cycle** (60s TTL), then runs all work sequentially inside that same cycle. A single slow op makes the cycle exceed 60s → the Redis key expires → cloud-api rejects **every** provision with `PROVISIONING_WORKER_UNHEALTHY` even though the worker is alive and working.

Observed offenders:
- a ~140s `agent_delete` that holds a DB transaction + advisory lock open across SSH + headscale network calls
- a ~39s node health-check

SSH (10s) and headscale HTTP (10s) were already bounded. The real problem was that the whole cycle is a single sequential critical section gated on a 60s liveness key.

## The fix

**Decouple the heartbeat from the cycle + bound the still-unbounded leaves + add a progress watchdog.**

- **P1 — decouple liveness (the fix).** An independent `setInterval` (15s, `.unref()`'d, with an in-flight guard) publishes the heartbeat regardless of how long a cycle takes. The cycle no longer owns liveness. Inverted preflight gate preserved: a module-level `preflightOk` is re-validated at the top of every cycle (cheap local KMS `getOrCreateKey`) and the interval publishes **only** while it's true, so a KMS-dead worker never advertises healthy. Publishes once immediately (no cold gap); `clearInterval` on loop exit.
- **Bounded heartbeat write.** The Redis `SET` itself is now wrapped in `withTimeout(..., 5s)` — Redis has been flaky, and without this a hung write would pile up unresolved publishes behind the in-flight guard.
- **P2 — bound the delete ops.** Dedicated `STOP_CMD_TIMEOUT_MS = 25s` for `docker stop`/`docker rm` on the delete path (docker's own `-t 10` grace means 25s is ample), a 15s cap on the headscale `cleanupContainerVPN`, and `AbortSignal.timeout(5s)` on the two `ghcr.io` fetches in `registry-probe` (the one genuinely-unbounded leaf; callers already treat a null result as "skip, retry").
- **P3.1 — per-job timeout.** `withTimeout(executeJob, 120s)` in the claim loop. It frees the **awaiter** (the cycle's job slot), not the underlying SSH (which is itself bounded); on timeout it throws → existing catch → `incrementAttempt` flips the row to `error`/`deletion_failed` once attempts exhaust, and `recoverStaleJobs` (5-min `in_progress` threshold) is the backstop.
- **Watchdog.** If a cycle hasn't completed in 5min the worker is genuinely wedged (e.g. Redis healthy but Neon/SSH hung), so the heartbeat interval **stops publishing** and lets the supervisor restart us. This is the only thing that catches "Redis healthy but work wedged" — complementary to P1 (P1 keeps a *progressing* worker healthy; the watchdog trips a *wedged* one). No `process.exit`; withholding the heartbeat is sufficient.
- **Shared `withTimeout`.** Promoted the existing helper out of `admin-infrastructure.ts` into a single `cloud-shared/lib/utils/with-timeout.ts` and reused it at every new call site. One canonical copy.

## Deferred follow-up (called out explicitly, not in this PR)

**P2.3** — move `provider.stop()` + `resolveContainer` **out** of the `deleteAgent` DB transaction in `eliza-sandbox.ts` (short txn to mark `deletion_pending` → network ops outside any txn → short txn for the final DELETE). This is the structurally-correct fix for "advisory lock held over 140s of network I/O", but it's higher review-risk, so it's a labeled follow-up rather than a band-aid. The timeouts in this PR bound the blast radius in the meantime.

## Test plan

- New unit test asserts the heartbeat gate: does **not** publish when `preflightOk=false`, **does** when it passes, and **withholds** when the watchdog trips (even with preflight OK).
- New unit test for the promoted `withTimeout` util (resolve / timeout-reject / propagate-rejection).
- Existing tests green: `provisioning-worker` (6/6), `provisioning-worker-health` (5/5, exercises the real bounded publish), `registry-probe` + `registry-probe-edges` (31/31, confirms the `AbortSignal` additions are non-breaking).
- `eliza-sandbox` delete-path tests (5/5) pass in the canonical repo env; they inject a fully-mocked `SandboxProvider`, so none of the `docker-sandbox-provider` changes here are on a path they exercise.
- Typecheck clean for every touched file.