### PR TITLE
fix(cloud): automate Docker-node onboarding + kill the stale-ghcr-cred robot bug

### DIFF
--- a/packages/cloud-shared/src/lib/services/containers/hetzner-client/client.ts
+++ b/packages/cloud-shared/src/lib/services/containers/hetzner-client/client.ts
@@ -43,7 +43,7 @@ import {
   validateContainerMountPath,
   validateEnvKey,
 } from "./paths";
-import { loginToImageRegistry, readPulledImageDigest } from "./registry";
+import { ensureRegistryAccess, readPulledImageDigest } from "./registry";
 import { findNodeInLocation, findStickyNodeForProject, getDockerNodeLocation } from "./scheduling";
 import {
   type ContainerBootstrapFile,
@@ -202,7 +202,7 @@ export class HetznerContainersClient {
         status: "building",
         deployment_log: `Pulling image ${input.image} on ${node.node_id}...`,
       });
-      await loginToImageRegistry(ssh, input.image);
+      await ensureRegistryAccess(ssh, input.image);
       await ssh.exec(`docker pull ${shellQuote(input.image)}`, 5 * 60 * 1000);
       const imageDigest = await readPulledImageDigest(ssh, input.image);
 

--- a/packages/cloud-shared/src/lib/services/containers/hetzner-client/registry.test.ts
+++ b/packages/cloud-shared/src/lib/services/containers/hetzner-client/registry.test.ts
@@ -19,7 +19,9 @@ mock.module("../../../config/containers-env", () => ({
   },
 }));
 
-const { getImageRegistryHost, loginToImageRegistry } = await import("./registry");
+const { getImageRegistryHost, loginToImageRegistry, ensureRegistryAccess } = await import(
+  "./registry"
+);
 
 describe("getImageRegistryHost", () => {
   test("returns ghcr.io for fully qualified GHCR refs", () => {
@@ -54,5 +56,59 @@ describe("loginToImageRegistry", () => {
     await loginToImageRegistry({ exec } as never, "ghcr.io/elizaos/eliza:stable");
     expect(exec).toHaveBeenCalledTimes(1);
     expect(exec.mock.calls[0]?.[0]).toContain("docker login 'ghcr.io'");
+  });
+});
+
+describe("ensureRegistryAccess", () => {
+  beforeEach(() => {
+    registryUsername.mockReset();
+    registryToken.mockReset();
+    registryTokenFile.mockReset();
+    registryUsername.mockReturnValue(undefined);
+    registryToken.mockReturnValue(undefined);
+    registryTokenFile.mockReturnValue(undefined);
+  });
+
+  test("logs out the registry host when NO token is configured (clears stale cred)", async () => {
+    const exec = mock(async () => "");
+    await ensureRegistryAccess({ exec } as never, "ghcr.io/elizaos/eliza:stable");
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(exec.mock.calls[0]?.[0]).toContain("docker logout 'ghcr.io'");
+  });
+
+  test("logs in (no logout) when a registry token IS configured", async () => {
+    registryUsername.mockReturnValue("robot");
+    registryToken.mockReturnValue("ghp_test_token");
+    const exec = mock(async () => "");
+    await ensureRegistryAccess({ exec } as never, "ghcr.io/elizaos/eliza:stable");
+    expect(exec).toHaveBeenCalledTimes(1);
+    expect(exec.mock.calls[0]?.[0]).toContain("docker login 'ghcr.io'");
+    expect(exec.mock.calls[0]?.[0]).not.toContain("docker logout");
+  });
+
+  test("is a no-op for implicit docker-hub refs (no registry host)", async () => {
+    const exec = mock(async () => "");
+    await ensureRegistryAccess({ exec } as never, "library/nginx:latest");
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  test("swallows a logout failure (best-effort, never blocks the pull)", async () => {
+    const exec = mock(async () => {
+      throw new Error("ssh boom");
+    });
+    await expect(
+      ensureRegistryAccess({ exec } as never, "ghcr.io/elizaos/eliza:stable"),
+    ).resolves.toBeUndefined();
+  });
+
+  test("swallows a login failure when a token is configured", async () => {
+    registryUsername.mockReturnValue("robot");
+    registryToken.mockReturnValue("ghp_test_token");
+    const exec = mock(async () => {
+      throw new Error("ssh boom");
+    });
+    await expect(
+      ensureRegistryAccess({ exec } as never, "ghcr.io/elizaos/eliza:stable"),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/cloud-shared/src/lib/services/containers/hetzner-client/registry.ts
+++ b/packages/cloud-shared/src/lib/services/containers/hetzner-client/registry.ts
@@ -63,6 +63,48 @@ export async function loginToImageRegistry(ssh: DockerSSHClient, image: string):
   );
 }
 
+/**
+ * Guarantee deterministic registry access on a node before pulling `image`.
+ *
+ * The managed agent image (`ghcr.io/elizaos/eliza`) is public, so an anonymous
+ * pull works with no credentials. But a node that ever ran `docker login` with
+ * a token that has since expired/rotated keeps a stale entry in
+ * `~/.docker/config.json` which OVERRIDES anonymous access — the pull then fails
+ * with `denied` even though the image is public. This is the failure class that
+ * bricks Hetzner robot hosts whose creds rotated out from under them.
+ *
+ * Two idempotent, best-effort branches:
+ *   - registry token configured → `loginToImageRegistry` writes a fresh cred.
+ *   - no token configured       → `docker logout <registryHost>` clears any
+ *     stale cred so the pull falls back to deterministic anonymous access.
+ *
+ * Never hard-fails: a logout/login hiccup must not block the pull that follows.
+ */
+export async function ensureRegistryAccess(ssh: DockerSSHClient, image: string): Promise<void> {
+  const registryHost = getImageRegistryHost(image);
+  if (!registryHost) return;
+
+  if (containersEnv.registryToken() || containersEnv.registryTokenFile()) {
+    await loginToImageRegistry(ssh, image).catch((error) => {
+      logger.warn(`[ensureRegistryAccess] docker login to ${registryHost} failed; continuing`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+    return;
+  }
+
+  // No token configured: proactively drop any stale stored credential so the
+  // public-image pull uses anonymous access deterministically.
+  await ssh
+    .exec(`docker logout ${shellQuote(registryHost)} >/dev/null 2>&1 || true`, 30_000)
+    .catch((error) => {
+      logger.warn(
+        `[ensureRegistryAccess] docker logout ${registryHost} failed; a stale cred may block the public pull`,
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+    });
+}
+
 export async function readPulledImageDigest(
   ssh: DockerSSHClient,
   image: string,

--- a/packages/cloud-shared/src/lib/services/containers/node-bootstrap.test.ts
+++ b/packages/cloud-shared/src/lib/services/containers/node-bootstrap.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { buildContainerNodeUserData } from "./node-bootstrap";
+
+const REGISTRY_ENV_KEYS = [
+  "CONTAINERS_REGISTRY_TOKEN",
+  "ELIZA_APP_IMAGE_REGISTRY_TOKEN",
+  "GHCR_TOKEN",
+  "GITHUB_TOKEN",
+  "GH_TOKEN",
+  "CR_PAT",
+  "CONTAINERS_REGISTRY_USERNAME",
+  "ELIZA_APP_IMAGE_REGISTRY_USERNAME",
+  "GHCR_USERNAME",
+  "GITHUB_ACTOR",
+];
+
+function clearRegistryEnv(): void {
+  for (const key of REGISTRY_ENV_KEYS) delete process.env[key];
+}
+
+afterEach(() => {
+  clearRegistryEnv();
+});
+
+const baseInput = {
+  nodeId: "node-1",
+  controlPlanePublicKey: "ssh-ed25519 AAAA root@cp",
+};
+
+describe("buildContainerNodeUserData — ghcr access", () => {
+  test("clears stale ghcr creds (logout) when no registry token is configured", () => {
+    clearRegistryEnv();
+    const userData = buildContainerNodeUserData(baseInput);
+    expect(userData).toContain("docker logout 'ghcr.io' >/dev/null 2>&1 || true");
+    expect(userData).not.toContain("docker login");
+  });
+
+  test("logs in (no logout) when a registry token + username are configured", () => {
+    clearRegistryEnv();
+    process.env.GHCR_TOKEN = "ghp_test_token";
+    process.env.GHCR_USERNAME = "robot";
+    const userData = buildContainerNodeUserData(baseInput);
+    expect(userData).toContain("docker login 'ghcr.io'");
+    expect(userData).toContain("--password-stdin");
+    expect(userData).not.toContain("docker logout");
+  });
+
+  test("ghcr-access step runs after the bridge network and before the pre-pull", () => {
+    clearRegistryEnv();
+    const userData = buildContainerNodeUserData(baseInput);
+    const networkIdx = userData.indexOf("docker network create");
+    const accessIdx = userData.indexOf("docker logout 'ghcr.io'");
+    const pullIdx = userData.indexOf("docker pull");
+    expect(networkIdx).toBeGreaterThanOrEqual(0);
+    expect(accessIdx).toBeGreaterThan(networkIdx);
+    expect(pullIdx).toBeGreaterThan(accessIdx);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/containers/node-bootstrap.ts
+++ b/packages/cloud-shared/src/lib/services/containers/node-bootstrap.ts
@@ -19,6 +19,7 @@
 
 import { containersEnv } from "../../config/containers-env";
 import { validateDockerPlatform } from "../docker-sandbox-utils";
+import { getImageRegistryHost } from "./hetzner-client/registry";
 
 export interface NodeBootstrapInput {
   /** Logical node id (must match what the control plane will register). */
@@ -66,8 +67,35 @@ export function buildContainerNodeUserData(input: NodeBootstrapInput): string {
     ? sanitizeShellSingleQuoted(input.registrationSecret)
     : "";
 
-  const prePullCommands = prePull
-    .filter((image) => image && image.length > 0)
+  const prePullImages = prePull.filter((image) => image && image.length > 0);
+
+  // Ensure deterministic registry access before pre-pulling. The managed agent
+  // image is public, so a node must NOT carry a stale stored ghcr credential
+  // (an expired token in /root/.docker/config.json overrides anonymous access
+  // and the pull fails with `denied`). Mirror `ensureRegistryAccess`:
+  //   - no token configured → `docker logout <host>` clears any stale cred.
+  //   - token configured     → `docker login <host>` writes a fresh cred.
+  // Hosts are derived from the pre-pull images (ghcr.io for the default image).
+  const registryHosts = Array.from(
+    new Set(
+      prePullImages
+        .map((image) => getImageRegistryHost(image))
+        .filter((host): host is string => host !== null),
+    ),
+  );
+  const registryToken = containersEnv.registryToken();
+  const registryUsername = containersEnv.registryUsername();
+  const registryAccessCommands = registryHosts
+    .map((host) => {
+      const quotedHost = sanitizeShellSingleQuoted(host);
+      if (registryToken && registryUsername) {
+        return `  - printf %s '${sanitizeShellSingleQuoted(registryToken)}' | docker login '${quotedHost}' -u '${sanitizeShellSingleQuoted(registryUsername)}' --password-stdin >/dev/null 2>&1 || true`;
+      }
+      return `  - docker logout '${quotedHost}' >/dev/null 2>&1 || true`;
+    })
+    .join("\n");
+
+  const prePullCommands = prePullImages
     .map(
       (image) =>
         `  - docker pull${prePullPlatformFlag} '${sanitizeShellSingleQuoted(image)}' || true`,
@@ -110,6 +138,7 @@ runcmd:
   - curl -fsSL https://get.docker.com | sh
   - systemctl enable --now docker
   - docker network inspect '${sanitizeShellSingleQuoted(network)}' >/dev/null 2>&1 || docker network create --driver bridge '${sanitizeShellSingleQuoted(network)}'
+${registryAccessCommands}
 ${prePullCommands}${registerSection}
 `;
 }

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -19,7 +19,7 @@ import { signStewardMutatingRequest } from "../steward/sign";
 import { resolveServerStewardApiUrlFromEnv } from "../steward-url";
 import { logger } from "../utils/logger";
 import { withTimeout } from "../utils/with-timeout";
-import { loginToImageRegistry } from "./containers/hetzner-client/registry";
+import { ensureRegistryAccess } from "./containers/hetzner-client/registry";
 import { getNodeAutoscaler } from "./containers/node-autoscaler";
 import { resolveImageDigest } from "./containers/registry-probe";
 import { isAlreadyGoneMessage } from "./docker-error-classifier";
@@ -1008,7 +1008,7 @@ export class DockerSandboxProvider implements SandboxProvider {
       // credentials are configured; otherwise rely on anonymous public pulls.
       logger.info(`[docker-sandbox] Pulling image ${resolvedImage} on ${nodeId}`);
       try {
-        await loginToImageRegistry(ssh, resolvedImage);
+        await ensureRegistryAccess(ssh, resolvedImage);
         await ssh.exec(
           ["docker pull", ...platformFlags, shellQuote(resolvedImage)].join(" "),
           PULL_TIMEOUT_MS,

--- a/packages/scripts/cloud/admin/onboard-docker-node.test.ts
+++ b/packages/scripts/cloud/admin/onboard-docker-node.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "bun:test";
+import {
+  parseArgs,
+  parseDockerPs,
+  selectZombieAgentContainers,
+} from "./onboard-docker-node";
+
+describe("parseDockerPs", () => {
+  it("parses name/state pairs and drops blank + stderr lines", () => {
+    const out = [
+      "agent-abc\texited",
+      "",
+      "cloud-container-xyz\trunning",
+      "[stderr] some warning",
+      "  unrelated-svc\tcreated  ",
+    ].join("\n");
+    expect(parseDockerPs(out)).toEqual([
+      { name: "agent-abc", state: "exited" },
+      { name: "cloud-container-xyz", state: "running" },
+      { name: "unrelated-svc", state: "created" },
+    ]);
+  });
+
+  it("returns empty for empty output", () => {
+    expect(parseDockerPs("")).toEqual([]);
+  });
+});
+
+describe("selectZombieAgentContainers", () => {
+  it("selects exited/created/dead agent containers (both naming schemes)", () => {
+    const rows = [
+      { name: "agent-1", state: "exited" },
+      { name: "cloud-container-2", state: "created" },
+      { name: "agent-3", state: "dead" },
+    ];
+    expect(selectZombieAgentContainers(rows)).toEqual([
+      "agent-1",
+      "cloud-container-2",
+      "agent-3",
+    ]);
+  });
+
+  it("never selects a running/restarting/paused agent container (active sandbox safe)", () => {
+    const rows = [
+      { name: "agent-live", state: "running" },
+      { name: "cloud-container-live", state: "restarting" },
+      { name: "agent-paused", state: "paused" },
+    ];
+    expect(selectZombieAgentContainers(rows)).toEqual([]);
+  });
+
+  it("ignores non-agent containers even when exited", () => {
+    const rows = [
+      { name: "caddy", state: "exited" },
+      { name: "postgres", state: "dead" },
+      { name: "my-agent-helper", state: "exited" }, // does not START with a prefix
+    ];
+    expect(selectZombieAgentContainers(rows)).toEqual([]);
+  });
+});
+
+describe("parseArgs", () => {
+  const emptyEnv = {} as NodeJS.ProcessEnv;
+
+  it("parses flags with defaults", () => {
+    const args = parseArgs(
+      ["--host", "1.2.3.4", "--node-id", "robot-1", "--key", "/k/id"],
+      emptyEnv,
+    );
+    expect(args).toMatchObject({
+      host: "1.2.3.4",
+      nodeId: "robot-1",
+      keyPath: "/k/id",
+      sshPort: 22,
+      sshUser: "root",
+      capacity: 8,
+      dryRun: false,
+    });
+  });
+
+  it("honors --dry-run and explicit overrides", () => {
+    const args = parseArgs(
+      [
+        "--host",
+        "h",
+        "--node-id",
+        "n",
+        "--ssh-port",
+        "2222",
+        "--ssh-user",
+        "ops",
+        "--capacity",
+        "4",
+        "--dry-run",
+      ],
+      emptyEnv,
+    );
+    expect(args).toMatchObject({
+      sshPort: 2222,
+      sshUser: "ops",
+      capacity: 4,
+      dryRun: true,
+    });
+  });
+
+  it("falls back to env vars when flags are absent", () => {
+    const env = {
+      ONBOARD_NODE_HOST: "5.6.7.8",
+      ONBOARD_NODE_ID: "env-node",
+      ONBOARD_NODE_CAPACITY: "16",
+    } as NodeJS.ProcessEnv;
+    const args = parseArgs([], env);
+    expect(args).toMatchObject({
+      host: "5.6.7.8",
+      nodeId: "env-node",
+      capacity: 16,
+    });
+  });
+
+  it("throws when host or node-id is missing", () => {
+    expect(() => parseArgs(["--host", "h"], emptyEnv)).toThrow("node-id");
+    expect(() => parseArgs(["--node-id", "n"], emptyEnv)).toThrow("host");
+  });
+
+  it("rejects an out-of-range capacity and ssh-port", () => {
+    expect(() =>
+      parseArgs(
+        ["--host", "h", "--node-id", "n", "--capacity", "99"],
+        emptyEnv,
+      ),
+    ).toThrow("capacity");
+    expect(() =>
+      parseArgs(["--host", "h", "--node-id", "n", "--ssh-port", "0"], emptyEnv),
+    ).toThrow("ssh-port");
+  });
+
+  it("throws when a flag is missing its value", () => {
+    expect(() => parseArgs(["--host", "--node-id", "n"], emptyEnv)).toThrow(
+      "requires a value",
+    );
+  });
+});

--- a/packages/scripts/cloud/admin/onboard-docker-node.ts
+++ b/packages/scripts/cloud/admin/onboard-docker-node.ts
@@ -1,0 +1,341 @@
+#!/usr/bin/env bun
+/**
+ * Onboard an EXISTING host (e.g. a Hetzner robot box) as an elizaOS Cloud
+ * Docker node — with zero manual SSH/DB steps.
+ *
+ * A robot/auctioned host can't be cloud-init'd (it's already running), so this
+ * script runs the bootstrap-equivalent steps over SSH and then registers the
+ * node into `docker_nodes` the same way the autoscaler / bootstrap-callback do.
+ * It is the operator-side counterpart to `buildContainerNodeUserData`.
+ *
+ * Every step is idempotent and safe to re-run:
+ *   1. verify/install Docker + ensure the daemon is running,
+ *   2. ensure the shared bridge network exists,
+ *   3. ensure deterministic ghcr access — THE robot fix: clear any stale
+ *      stored credential (an expired ghcr token in /root/.docker/config.json
+ *      overrides anonymous access and bricks the public-image pull with
+ *      `denied`). Reuses `ensureRegistryAccess`.
+ *   4. clean zombie/stale agent containers (exited/created orphans matching the
+ *      agent naming scheme — never an active sandbox),
+ *   5. upsert the node into `docker_nodes` (update if it already exists),
+ *   6. print a clear summary of what changed vs. was already in place.
+ *
+ * No secrets are hard-coded: the registry token (if any) comes from the
+ * control-plane env via `containersEnv`; the DB target from `DATABASE_URL`.
+ *
+ * Usage:
+ *   DATABASE_URL=... bun run packages/scripts/cloud/admin/onboard-docker-node.ts \
+ *     --host 1.2.3.4 --key ~/.ssh/id_ed25519_eliza --node-id robot-fsn1-01
+ *
+ * Flags (env fallback in parens):
+ *   --host        <ip|hostname>  SSH target (ONBOARD_NODE_HOST)              [required]
+ *   --node-id     <id>           Logical node id (ONBOARD_NODE_ID)          [required]
+ *   --key         <path>         SSH private key path (ONBOARD_NODE_SSH_KEY) [default ~/.ssh/id_ed25519]
+ *   --ssh-port    <n>            SSH port (ONBOARD_NODE_SSH_PORT)            [default 22]
+ *   --ssh-user    <user>         SSH user (ONBOARD_NODE_SSH_USER)           [default root]
+ *   --capacity    <n>            Agent capacity (ONBOARD_NODE_CAPACITY)     [default 8]
+ *   --dry-run                    Print the planned steps, touch nothing.
+ */
+
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The cloud-shared modules are imported lazily inside main() (see loadDeps) so
+// importing this file for its pure helpers — e.g. from the unit test — does not
+// drag in the Drizzle / plugin-sql DB stack.
+async function loadDeps() {
+  const [
+    { dockerNodesRepository },
+    { ensureRegistryAccess },
+    dockerUtils,
+    { DockerSSHClient },
+  ] = await Promise.all([
+    import("@elizaos/cloud-shared/db/repositories/docker-nodes"),
+    import(
+      "@elizaos/cloud-shared/lib/services/containers/hetzner-client/registry"
+    ),
+    import("@elizaos/cloud-shared/lib/services/docker-sandbox-utils"),
+    import("@elizaos/cloud-shared/lib/services/docker-ssh"),
+  ]);
+  return {
+    dockerNodesRepository,
+    ensureRegistryAccess,
+    buildEnsureNetworkCmd: dockerUtils.buildEnsureNetworkCmd,
+    shellQuote: dockerUtils.shellQuote,
+    DockerSSHClient,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested in onboard-docker-node.test.ts)
+// ---------------------------------------------------------------------------
+
+/** Container-name prefixes the cloud control plane uses for agent workloads. */
+export const AGENT_CONTAINER_PREFIXES = ["agent-", "cloud-container-"] as const;
+
+/** Docker states that mean a container is NOT actively serving — safe to reap. */
+const REAPABLE_STATES = ["exited", "created", "dead"] as const;
+
+export interface DockerPsRow {
+  name: string;
+  state: string;
+}
+
+/**
+ * Parse the output of `docker ps -a --format '{{.Names}}\t{{.State}}'`.
+ * Tolerant of blank lines and trailing whitespace.
+ */
+export function parseDockerPs(output: string): DockerPsRow[] {
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("[stderr]"))
+    .map((line) => {
+      const [name, state] = line.split("\t");
+      return {
+        name: (name ?? "").trim(),
+        state: (state ?? "").trim().toLowerCase(),
+      };
+    })
+    .filter((row) => row.name.length > 0);
+}
+
+/**
+ * Conservative zombie filter: an agent-named container in a non-running state.
+ * Running / restarting / paused containers are NEVER selected, so an active
+ * sandbox is never touched even if its DB row drifted.
+ */
+export function selectZombieAgentContainers(rows: DockerPsRow[]): string[] {
+  return rows
+    .filter(
+      (row) =>
+        AGENT_CONTAINER_PREFIXES.some((prefix) =>
+          row.name.startsWith(prefix),
+        ) && (REAPABLE_STATES as readonly string[]).includes(row.state),
+    )
+    .map((row) => row.name);
+}
+
+export interface OnboardArgs {
+  host: string;
+  nodeId: string;
+  keyPath: string;
+  sshPort: number;
+  sshUser: string;
+  capacity: number;
+  dryRun: boolean;
+}
+
+/** Parse argv + env into a validated config. Throws on missing required fields. */
+export function parseArgs(argv: string[], env: NodeJS.ProcessEnv): OnboardArgs {
+  const flags = new Map<string, string>();
+  let dryRun = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === undefined) continue;
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      const key = arg.slice(2);
+      const value = argv[i + 1];
+      if (value === undefined || value.startsWith("--")) {
+        throw new Error(`Flag --${key} requires a value`);
+      }
+      flags.set(key, value);
+      i++;
+    }
+  }
+
+  const host = flags.get("host") ?? env.ONBOARD_NODE_HOST;
+  const nodeId = flags.get("node-id") ?? env.ONBOARD_NODE_ID;
+  if (!host) throw new Error("Missing --host (or ONBOARD_NODE_HOST)");
+  if (!nodeId) throw new Error("Missing --node-id (or ONBOARD_NODE_ID)");
+
+  const keyPath =
+    flags.get("key") ??
+    env.ONBOARD_NODE_SSH_KEY ??
+    path.join(os.homedir(), ".ssh", "id_ed25519");
+  const sshPort = Number.parseInt(
+    flags.get("ssh-port") ?? env.ONBOARD_NODE_SSH_PORT ?? "22",
+    10,
+  );
+  const sshUser = flags.get("ssh-user") ?? env.ONBOARD_NODE_SSH_USER ?? "root";
+  const capacityRaw = flags.get("capacity") ?? env.ONBOARD_NODE_CAPACITY ?? "8";
+  const capacity = Number.parseInt(capacityRaw, 10);
+
+  if (!Number.isInteger(sshPort) || sshPort < 1 || sshPort > 65535) {
+    throw new Error(
+      `Invalid ssh-port: ${flags.get("ssh-port") ?? env.ONBOARD_NODE_SSH_PORT}`,
+    );
+  }
+  if (!Number.isInteger(capacity) || capacity < 1 || capacity > 64) {
+    throw new Error(`Invalid capacity (must be 1..64): ${capacityRaw}`);
+  }
+
+  return { host, nodeId, keyPath, sshPort, sshUser, capacity, dryRun };
+}
+
+// ---------------------------------------------------------------------------
+// Onboarding flow
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2), process.env);
+
+  // Resolve network/image from config for the preview. `containersEnv` is a
+  // light import; the heavier DB/SSH stack is only loaded once we commit to
+  // touching the host, so --dry-run stays side-effect-free.
+  const { containersEnv } = await import(
+    "@elizaos/cloud-shared/lib/config/containers-env"
+  );
+  const network = containersEnv.dockerNetwork();
+  const image = containersEnv.defaultAgentImage();
+
+  console.log(
+    `[onboard] target ${args.sshUser}@${args.host}:${args.sshPort} as node "${args.nodeId}"`,
+  );
+  console.log(
+    `[onboard] network=${network} image=${image} capacity=${args.capacity}`,
+  );
+  if (args.dryRun) {
+    console.log("[onboard] --dry-run: no changes will be made.");
+    return;
+  }
+
+  const {
+    dockerNodesRepository,
+    ensureRegistryAccess,
+    buildEnsureNetworkCmd,
+    shellQuote,
+    DockerSSHClient,
+  } = await loadDeps();
+  const summary: string[] = [];
+
+  const ssh = new DockerSSHClient({
+    hostname: args.host,
+    port: args.sshPort,
+    username: args.sshUser,
+    privateKeyPath: args.keyPath,
+  });
+
+  try {
+    // 1. Docker present + running (install via get.docker.com only if missing).
+    const hasDocker = await ssh
+      .exec("command -v docker >/dev/null 2>&1 && echo yes || echo no", 30_000)
+      .then((out) => out.includes("yes"));
+    if (!hasDocker) {
+      console.log("[onboard] docker not found — installing via get.docker.com");
+      await ssh.exec("curl -fsSL https://get.docker.com | sh", 5 * 60 * 1000);
+      summary.push("installed Docker");
+    } else {
+      summary.push("Docker already present");
+    }
+    await ssh.exec(
+      "systemctl enable --now docker >/dev/null 2>&1 || true",
+      60_000,
+    );
+    await ssh.exec("docker info >/dev/null 2>&1", 30_000);
+    summary.push("Docker daemon running");
+
+    // 2. Shared bridge network (idempotent, race-safe).
+    await ssh.exec(buildEnsureNetworkCmd(network), 30_000);
+    summary.push(`network "${network}" ensured`);
+
+    // 3. THE robot fix: deterministic registry access (clear stale ghcr cred).
+    await ensureRegistryAccess(ssh, image);
+    summary.push(
+      containersEnv.registryToken() || containersEnv.registryTokenFile()
+        ? "ghcr login refreshed (token configured)"
+        : "ghcr stale creds cleared (anonymous pull)",
+    );
+
+    // 4. Reap zombie agent containers (orphaned, non-running). Conservative.
+    const psOutput = await ssh.exec(
+      "docker ps -a --format '{{.Names}}\t{{.State}}'",
+      30_000,
+    );
+    const zombies = selectZombieAgentContainers(parseDockerPs(psOutput));
+    if (zombies.length > 0) {
+      await ssh.exec(
+        `docker rm -f ${zombies.map(shellQuote).join(" ")}`,
+        60_000,
+      );
+      summary.push(
+        `removed ${zombies.length} zombie container(s): ${zombies.join(", ")}`,
+      );
+    } else {
+      summary.push("no zombie containers");
+    }
+
+    // 5. Pull the agent image now so the first deploy on this node is warm.
+    console.log(
+      `[onboard] pre-pulling ${image} (first run can take a few minutes)`,
+    );
+    await ssh
+      .exec(`docker pull ${shellQuote(image)}`, 10 * 60 * 1000)
+      .then(() => summary.push("agent image pulled"))
+      .catch((err) => {
+        console.warn(
+          `[onboard] image pre-pull failed (node still registers; will retry on deploy): ${err instanceof Error ? err.message : String(err)}`,
+        );
+        summary.push("agent image pre-pull FAILED (non-fatal)");
+      });
+
+    // 6. Register / upsert into docker_nodes — same shape as bootstrap-callback.
+    const existing = await dockerNodesRepository.findByNodeId(args.nodeId);
+    if (existing) {
+      await dockerNodesRepository.update(existing.id, {
+        hostname: args.host,
+        ssh_port: args.sshPort,
+        ssh_user: args.sshUser,
+        capacity: args.capacity,
+        status: "unknown",
+        metadata: {
+          ...((existing.metadata as Record<string, unknown>) ?? {}),
+          provider: "operator-onboarded",
+          lastOnboardedAt: new Date().toISOString(),
+        },
+      });
+      summary.push(`docker_nodes row updated (${args.nodeId})`);
+    } else {
+      await dockerNodesRepository.create({
+        node_id: args.nodeId,
+        hostname: args.host,
+        ssh_port: args.sshPort,
+        ssh_user: args.sshUser,
+        capacity: args.capacity,
+        enabled: true,
+        status: "unknown",
+        allocated_count: 0,
+        metadata: {
+          provider: "operator-onboarded",
+          onboardedAt: new Date().toISOString(),
+        },
+      });
+      summary.push(`docker_nodes row created (${args.nodeId})`);
+    }
+  } finally {
+    await ssh.disconnect().catch(() => {});
+  }
+
+  console.log("\n[onboard] done:");
+  for (const line of summary) console.log(`  - ${line}`);
+}
+
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  return entry ? path.resolve(entry) === fileURLToPath(import.meta.url) : false;
+}
+
+if (isMainModule()) {
+  main().catch((error) => {
+    console.error(
+      "[onboard] failed:",
+      error instanceof Error ? error.message : String(error),
+    );
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## What & why

\"Plan B\": bring any Docker node online for elizaOS Cloud — cloud-provisioned OR an existing Hetzner robot host — with **zero manual SSH/DB steps**, and make sure it reliably pulls + runs the agent image.

The agent image `ghcr.io/elizaos/eliza` is **public** — anonymous `docker pull` works with no creds, and cloud-provisioned nodes pull fine. The robot host was failing the pull with `denied` for one reason only: a **stale `/root/.docker/config.json`** holding an expired ghcr token that **overrides** anonymous access. The staging daemon sets no registry token, so nodes are meant to pull anonymously; a node that ever ran `docker login` with a since-rotated token bricks its own pull. `docker logout ghcr.io` fixes it. That's THE bug.

## Three pieces (one PR)

### 1. `ensureRegistryAccess(ssh, image)` — the actual fix (registry.ts)
Runs before every node pull:
- registry token configured → `loginToImageRegistry` (fresh cred).
- no token configured → proactive `docker logout <host>` so the pull uses deterministic anonymous access.

Both branches idempotent + best-effort (log on failure, never hard-fail the pull). Wired into **both** pull sites that used to call `loginToImageRegistry`: `hetzner-client/client.ts` (autoscaler path) and `docker-sandbox-provider.ts` (the main agent provisioning path).

### 2. Codify clean ghcr into node-bootstrap cloud-init
`buildContainerNodeUserData` now emits the same step between the bridge-network create and the pre-pull: `docker logout <host>` when no token is configured, or a token-based `docker login` when one is injected into the node env. Every freshly bootstrapped node now starts with deterministic ghcr access.

### 3. `onboard-docker-node.ts` — idempotent existing-host/robot onboarding (bun)
SSHes into an existing host as root and idempotently: verifies/installs docker → ensures it's running → ensures the bridge network (reuses `buildEnsureNetworkCmd`) → runs the Piece-1 ghcr fix (clears the stale cred) → reaps zombie agent containers (only `agent-*` / `cloud-container-*` in `exited`/`created`/`dead` — never an active sandbox) → pre-pulls → upserts into `docker_nodes` via the canonical `findByNodeId → update|create` path (same shape `bootstrap-callback` uses) → prints a summary. Safe to re-run. No hard-coded secrets.

**Onboard the robot (idempotent — re-run any time):**
```bash
DATABASE_URL=... bun run packages/scripts/cloud/admin/onboard-docker-node.ts \
  --host <robot-ip> --key ~/.ssh/id_ed25519_eliza --node-id robot-fsn1-01
```

## Where reality differed from the brief
- `loginToImageRegistry` had **2** call sites, not 1 — `client.ts:205` (autoscaler) **and** `docker-sandbox-provider.ts:998` (the main agent path). Both now route through `ensureRegistryAccess`.
- On current `develop`, `loginToImageRegistry` already no longer throws when creds are absent — it warns and returns (anonymous pull). `ensureRegistryAccess` builds on top: the no-token branch now *actively clears* a stale cred rather than just hoping there isn't one.
- A third pull site (`docker-node-manager.ts` pre-pull cycle) does no login at all and already relies on anonymous pull — left as-is (out of scope, and it's the warm-pool prepull, not the deploy path).
- Canonical registration = `dockerNodesRepository` `findByNodeId → update|create` (the upsert `bootstrap-callback/route.ts` runs). The script reuses the **repository directly** (matching `live-cloud-provision-smoke.ts`, which imports repos directly) rather than POSTing the HTTP endpoint — cleaner for a bun script and avoids needing the bootstrap secret / a reachable control plane.

## Design fork
Node-bootstrap derives the registry host(s) from the pre-pull image list (ghcr.io for the default image) rather than hard-coding `ghcr.io`, so the logout/login targets the right registry if the default image is ever repointed. Picked the generic-derive option over a hard-coded literal — same robustness, no future foot-gun.

## Tests
- `ensureRegistryAccess`: token → login path; no-token → logout path; no-op for hub refs; both swallow ssh.exec failures (mocked at the exec boundary).
- `node-bootstrap`: runcmd renders logout (no token) vs login (token), in the right order.
- onboard script pure helpers: zombie filter, `docker ps` parser, arg parser.
- Existing registry tests stay green.

## Do not merge
Leave open for human review.