### PR TITLE
fix(cloud-infra): declare api_protocol on bitrouter cerebras provider (gpt-oss-120b 500)

### DIFF
--- a/packages/cloud-infra/cloud/bitrouter/bitrouter.yaml
+++ b/packages/cloud-infra/cloud/bitrouter/bitrouter.yaml
@@ -7,7 +7,12 @@ database:
 # Only declare providers we credential. Empty body + inherit_defaults: true
 # lets the built-in catalog fill api_base, api_protocol, env-resolved api_key.
 # - openrouter: built-in, uses OPENROUTER_API_KEY (exported by entrypoint.sh from BITROUTER_OPENROUTER_API_KEY)
-# - cerebras: NOT a built-in, declare api_base + api_key explicitly
+# - cerebras: NOT a built-in, so we must declare api_base, api_protocol, AND
+#   api_key explicitly (inherit_defaults only fills these for built-in providers).
+#   Omitting api_protocol makes bitrouter 500 with "provider 'cerebras' has no
+#   api_protocol configured" the moment an alias actually routes to it. Cerebras
+#   is OpenAI Chat Completions compatible → "chat_completions" (matches the
+#   built-in openrouter/openai entries).
 #
 # Crucially: do NOT declare `bitrouter: {}` — that enables BitRouter Cloud
 # (api.bitrouter.ai/v1) which 402s without a brk_* API key.
@@ -15,6 +20,7 @@ providers:
   openrouter: {}
   cerebras:
     api_base: "https://api.cerebras.ai/v1"
+    api_protocol: "chat_completions"
     api_key: "${BITROUTER_CEREBRAS_API_KEY}"
     auto_discover: true
 

--- a/packages/cloud-infra/cloud/bitrouter/bitrouter.yaml
+++ b/packages/cloud-infra/cloud/bitrouter/bitrouter.yaml
@@ -11,8 +11,8 @@ database:
 #   api_key explicitly (inherit_defaults only fills these for built-in providers).
 #   Omitting api_protocol makes bitrouter 500 with "provider 'cerebras' has no
 #   api_protocol configured" the moment an alias actually routes to it. Cerebras
-#   is OpenAI Chat Completions compatible → "chat_completions" (matches the
-#   built-in openrouter/openai entries).
+#   is OpenAI Chat Completions compatible → "openai" (the YAML protocol-family variant;
+#   matches the built-in openrouter/openai providers).
 #
 # Crucially: do NOT declare `bitrouter: {}` — that enables BitRouter Cloud
 # (api.bitrouter.ai/v1) which 402s without a brk_* API key.
@@ -20,7 +20,7 @@ providers:
   openrouter: {}
   cerebras:
     api_base: "https://api.cerebras.ai/v1"
-    api_protocol: "chat_completions"
+    api_protocol: openai
     api_key: "${BITROUTER_CEREBRAS_API_KEY}"
     auto_discover: true
 


### PR DESCRIPTION
## The bug
#8450 + #8458 pointed the `gpt-oss-120b` aliases at the self-hosted bitrouter's **cerebras** provider — but that provider only declared `api_base` + `api_key`, **no `api_protocol`**. `inherit_defaults` only fills `api_protocol` for *built-in* providers (openrouter); cerebras is custom, so the moment an alias actually routes to it, bitrouter 500s:
```
invalid request: provider 'cerebras' has no api_protocol configured
```
Latent until those PRs added the cerebras aliases. **Found live on prod** — after the Cerebras-only deploy, `openai/gpt-oss-120b` returned HTTP 500.

## The fix
Cerebras is OpenAI Chat Completions compatible, so declare `api_protocol: "chat_completions"` (matches the built-in `openrouter`/`openai` entries in bitrouter's provider catalog — verified against `crates/bitrouter-providers/providers/*.toml`).

## Verified
Fixed config deployed to the `steward-eliza/production` bitrouter service via `railway up`; `openai/gpt-oss-120b` now routes 200 (Cerebras).

**Scope:** the new-user default is unaffected (cerebras-**direct** via the Worker, never through bitrouter). This only fixes the legacy gateway-id + apps-chat paths that traverse bitrouter.

cc @lalalune