### PR TITLE
ci(app-core): resolve tsx runner imports from source

### DIFF
--- a/packages/app-core/scripts/run-node-tsx.mjs
+++ b/packages/app-core/scripts/run-node-tsx.mjs
@@ -44,7 +44,18 @@ function withWorkspaceNodePath(env) {
   };
 }
 
-const child = spawn(resolveNodeCmd(), ["--import", "tsx", ...args], {
+const nodeArgs = [
+  // WHY: this runner executes TypeScript workspace scripts before every
+  // workspace package has a fresh dist build. Prefer source exports for
+  // packages that declare the eliza-source condition, matching Vitest's
+  // source-mode aliases and avoiding stale/missing dist imports in CI probes.
+  "--conditions=eliza-source",
+  "--import",
+  "tsx",
+  ...args,
+];
+
+const child = spawn(resolveNodeCmd(), nodeArgs, {
   cwd: process.cwd(),
   env: withWorkspaceNodePath(process.env),
   stdio: "inherit",


### PR DESCRIPTION
## Summary
- make the app-core Node/tsx runner opt into the existing `eliza-source` export condition
- keep source-mode CI probes from requiring every workspace plugin to have a fresh `dist` build before they run

## Why
The Scenario PR E2E `Zero-Key unit + UI coverage` job failed in #8453 because `test:local-provisioning` imported the agent API server and lazily resolved `@elizaos/plugin-x402` to `dist/index.js`. In that lane, plugin-x402 had not been built yet, so Node failed with `ERR_MODULE_NOT_FOUND` even though the workspace source was present. This runner is specifically for TypeScript workspace scripts, so resolving packages through `eliza-source` matches the source-mode behavior already used by Vitest aliases.

## Verification
- `bunx @biomejs/biome check packages/app-core/scripts/run-node-tsx.mjs`
- `ELIZA_NODE_PATH=/Users/user1/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node packages/app-core/scripts/run-node-tsx.mjs -e "const m = await import('@elizaos/plugin-x402'); console.log(typeof m.default, m.x402Plugin?.name)"`
