### PR TITLE
fix(cloud-api): stop orphaning `pending` agent sandboxes on non-atomic create→enqueue

### DIFF
--- a/packages/cloud-api/__tests__/eliza-agents-orphan-cleanup.test.ts
+++ b/packages/cloud-api/__tests__/eliza-agents-orphan-cleanup.test.ts
@@ -143,11 +143,24 @@ describe("POST /api/v1/eliza/agents — orphan cleanup", () => {
     prepareManagedElizaEnvironment.mockClear();
     enqueueAgentProvision.mockClear();
     triggerImmediate.mockClear();
+    deleteSandbox.mockResolvedValue(true);
     prepareManagedElizaEnvironment.mockResolvedValue({
       changed: false,
       environmentVars: {},
     });
   });
+
+  // The route has no local onError, so a thrown plain Error bubbles to Hono's
+  // default handler: HTTP 500, text/plain "Internal Server Error" (no JSON).
+  async function expectOrphanCleanedUp(response: Response) {
+    // createAgent committed exactly one row...
+    expect(createAgent).toHaveBeenCalledTimes(1);
+    // ...which was rolled back so the daemon can't strand it in `pending`.
+    expect(deleteSandbox).toHaveBeenCalledWith("sandbox-1", "org-1");
+    // The original error still surfaces to the caller (not swallowed).
+    expect(response.status).toBe(500);
+    expect(await response.text()).toBe("Internal Server Error");
+  }
 
   test("deletes the just-created sandbox when env prep throws (no orphaned pending row)", async () => {
     prepareManagedElizaEnvironment.mockRejectedValueOnce(
@@ -156,13 +169,9 @@ describe("POST /api/v1/eliza/agents — orphan cleanup", () => {
 
     const response = await postAgent();
 
-    // createAgent committed the row, but env prep blew up before the enqueue.
-    expect(createAgent).toHaveBeenCalledTimes(1);
+    // env prep blew up before the enqueue.
     expect(enqueueAgentProvision).not.toHaveBeenCalled();
-    // The orphan was rolled back so the daemon can't strand it in `pending`.
-    expect(deleteSandbox).toHaveBeenCalledWith("sandbox-1", "org-1");
-    // The error still surfaces to the caller (not swallowed).
-    expect(response.status).toBeGreaterThanOrEqual(500);
+    await expectOrphanCleanedUp(response);
   });
 
   test("deletes the just-created sandbox when the env update throws", async () => {
@@ -174,10 +183,36 @@ describe("POST /api/v1/eliza/agents — orphan cleanup", () => {
 
     const response = await postAgent();
 
-    expect(createAgent).toHaveBeenCalledTimes(1);
     expect(enqueueAgentProvision).not.toHaveBeenCalled();
-    expect(deleteSandbox).toHaveBeenCalledWith("sandbox-1", "org-1");
-    expect(response.status).toBeGreaterThanOrEqual(500);
+    await expectOrphanCleanedUp(response);
+  });
+
+  test("deletes the just-created sandbox when the provision-job enqueue throws", async () => {
+    enqueueAgentProvision.mockRejectedValueOnce(
+      new Error("job table write failed"),
+    );
+
+    const response = await postAgent();
+
+    // enqueue is the last write in the guarded span; the row must still roll back.
+    expect(enqueueAgentProvision).toHaveBeenCalledTimes(1);
+    // triggerImmediate fires only AFTER a successful enqueue — never here.
+    expect(triggerImmediate).not.toHaveBeenCalled();
+    await expectOrphanCleanedUp(response);
+  });
+
+  test("rethrows the original error even when the cleanup delete also fails", async () => {
+    prepareManagedElizaEnvironment.mockRejectedValueOnce(
+      new Error("KMS key mint failed"),
+    );
+    // The best-effort cleanup itself throws: withOrphanCleanup's nested catch
+    // logs cleanupErr but must rethrow the ORIGINAL err, not the cleanup error.
+    deleteSandbox.mockRejectedValueOnce(new Error("delete failed too"));
+
+    const response = await postAgent();
+
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    await expectOrphanCleanedUp(response);
   });
 
   test("happy path enqueues the provision job and never deletes the sandbox", async () => {

--- a/packages/cloud-api/__tests__/eliza-agents-orphan-cleanup.test.ts
+++ b/packages/cloud-api/__tests__/eliza-agents-orphan-cleanup.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+/**
+ * Regression test for the orphaned-`pending` sandbox bug.
+ *
+ * POST /api/v1/eliza/agents commits a `pending` sandbox row up front
+ * (`createAgent`) and only later enqueues its `agent_provision` job. The
+ * provisioning daemon ONLY claims rows that already have a job, so a throw in
+ * the create→enqueue window (e.g. prepareManagedElizaEnvironment minting a KMS
+ * key, or updateAgentEnvironment) would otherwise strand a `pending` row no
+ * worker can ever pick up. The route now wraps that whole span and deletes the
+ * just-created row on ANY failure, then rethrows.
+ */
+
+const requireUserOrApiKeyWithOrg = mock(async () => ({
+  id: "user-1",
+  organization_id: "org-1",
+}));
+
+const createAgent = mock(async () => ({
+  id: "sandbox-1",
+  agent_name: "e2e-dedicated-test",
+  status: "pending",
+  created_at: new Date("2026-06-14T00:00:00.000Z"),
+  execution_tier: "custom",
+  agent_config: undefined,
+  character_id: null,
+}));
+const updateAgentEnvironment = mock(async () => undefined);
+const deleteSandbox = mock(async () => true);
+const prepareManagedElizaEnvironment = mock(async () => ({
+  changed: false,
+  environmentVars: {},
+}));
+const enqueueAgentProvision = mock(async () => ({
+  id: "job-1",
+  status: "pending",
+  estimated_completion_at: null,
+}));
+const triggerImmediate = mock(async () => undefined);
+const checkAgentCreditGate = mock(async () => ({
+  allowed: true,
+  balance: 100,
+}));
+const checkProvisioningWorkerHealth = mock(async () => ({ ok: true }));
+
+mock.module("@/lib/auth/workers-hono-auth", () => ({
+  requireUserOrApiKeyWithOrg,
+}));
+
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: {
+    delete: deleteSandbox,
+    claimWarmContainer: mock(async () => null),
+  },
+}));
+
+mock.module("@/db/repositories/characters", () => ({
+  userCharactersRepository: {
+    findByIdsInOrganization: mock(async () => []),
+    findByIdInOrganizationForWrite: mock(async () => undefined),
+  },
+}));
+
+mock.module("@/lib/services/eliza-managed-launch", () => ({
+  prepareManagedElizaEnvironment,
+}));
+
+mock.module("@/lib/services/eliza-sandbox", () => ({
+  elizaSandboxService: {
+    createAgent,
+    updateAgentEnvironment,
+    listAgents: mock(async () => []),
+  },
+}));
+
+mock.module("@/lib/services/provisioning-jobs", () => ({
+  provisioningJobService: {
+    enqueueAgentProvision,
+    triggerImmediate,
+  },
+}));
+
+mock.module("@/lib/services/agent-billing-gate", () => ({
+  checkAgentCreditGate,
+}));
+
+mock.module("@/lib/services/provisioning-worker-health", () => ({
+  checkProvisioningWorkerHealth,
+  provisioningWorkerFailureBody: () => ({
+    success: false,
+    error: "worker unavailable",
+  }),
+}));
+
+// Force the eager-provision custom path so the route reaches createAgent →
+// enqueue (custom tier also skips the warm-pool branch).
+mock.module("@/lib/services/shared-runtime/agent-tier", () => ({
+  getAgentTier: () => "custom",
+  tierProvisionsEagerly: () => true,
+}));
+
+mock.module("@/lib/config/containers-env", () => ({
+  containersEnv: {
+    warmPoolEnabled: () => false,
+    defaultAgentImage: () => "ghcr.io/elizaos/eliza:stable",
+    publicBaseDomain: () => "elizacloud.ai",
+  },
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+  },
+}));
+
+const { default: app } = await import("../v1/eliza/agents/route");
+
+function postAgent() {
+  return app.fetch(
+    new Request("https://api.example.test/", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "X-API-Key": "test-key",
+      },
+      body: JSON.stringify({
+        agentName: "e2e-dedicated-test",
+        dockerImage: "ghcr.io/elizaos/eliza:stable",
+      }),
+    }),
+  );
+}
+
+describe("POST /api/v1/eliza/agents — orphan cleanup", () => {
+  beforeEach(() => {
+    createAgent.mockClear();
+    updateAgentEnvironment.mockClear();
+    deleteSandbox.mockClear();
+    prepareManagedElizaEnvironment.mockClear();
+    enqueueAgentProvision.mockClear();
+    triggerImmediate.mockClear();
+    prepareManagedElizaEnvironment.mockResolvedValue({
+      changed: false,
+      environmentVars: {},
+    });
+  });
+
+  test("deletes the just-created sandbox when env prep throws (no orphaned pending row)", async () => {
+    prepareManagedElizaEnvironment.mockRejectedValueOnce(
+      new Error("KMS key mint failed"),
+    );
+
+    const response = await postAgent();
+
+    // createAgent committed the row, but env prep blew up before the enqueue.
+    expect(createAgent).toHaveBeenCalledTimes(1);
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    // The orphan was rolled back so the daemon can't strand it in `pending`.
+    expect(deleteSandbox).toHaveBeenCalledWith("sandbox-1", "org-1");
+    // The error still surfaces to the caller (not swallowed).
+    expect(response.status).toBeGreaterThanOrEqual(500);
+  });
+
+  test("deletes the just-created sandbox when the env update throws", async () => {
+    prepareManagedElizaEnvironment.mockResolvedValueOnce({
+      changed: true,
+      environmentVars: { FOO: "bar" },
+    });
+    updateAgentEnvironment.mockRejectedValueOnce(new Error("db write failed"));
+
+    const response = await postAgent();
+
+    expect(createAgent).toHaveBeenCalledTimes(1);
+    expect(enqueueAgentProvision).not.toHaveBeenCalled();
+    expect(deleteSandbox).toHaveBeenCalledWith("sandbox-1", "org-1");
+    expect(response.status).toBeGreaterThanOrEqual(500);
+  });
+
+  test("happy path enqueues the provision job and never deletes the sandbox", async () => {
+    const response = await postAgent();
+
+    expect(createAgent).toHaveBeenCalledTimes(1);
+    expect(enqueueAgentProvision).toHaveBeenCalledTimes(1);
+    expect(deleteSandbox).not.toHaveBeenCalled();
+    expect(response.status).toBe(202);
+  });
+});

--- a/packages/cloud-api/cron/cleanup-stuck-provisioning/route.test.ts
+++ b/packages/cloud-api/cron/cleanup-stuck-provisioning/route.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+/**
+ * Wiring test for the cleanup-stuck-provisioning cron.
+ *
+ * The handler runs two scans on the write path: stuck-provisioning rows and
+ * orphaned-`pending` rows (committed by createAgent but never enqueued). This
+ * test pins the orphaned-pending scan: it must be called with the SAME
+ * NOW−10min cutoff the stuck scan uses, and the recovered rows must surface in
+ * the JSON response (count + agents) under the field names the route emits.
+ */
+
+const markStuckProvisioningWithoutActiveJobAsError = mock(
+  async () =>
+    [] as Array<{
+      agentId: string;
+      agentName: string | null;
+      organizationId: string;
+    }>,
+);
+const markOrphanedPendingWithoutJobAsError = mock(async () => [
+  {
+    agentId: "sandbox-orphan-1",
+    agentName: "orphaned-agent",
+    organizationId: "org-1",
+    createdAt: new Date("2026-06-14T00:00:00.000Z"),
+  },
+]);
+
+// verifyCronSecret returns null on success (auth passes), a Response otherwise.
+const verifyCronSecret = mock((): Response | null => null);
+
+mock.module("@/db/repositories/agent-sandboxes", () => ({
+  agentSandboxesRepository: {
+    markStuckProvisioningWithoutActiveJobAsError,
+    markOrphanedPendingWithoutJobAsError,
+  },
+}));
+
+mock.module("@/lib/auth/cron", () => ({
+  verifyCronSecret,
+}));
+
+mock.module("@/lib/utils/logger", () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+
+const { default: app } = await import("./route");
+
+const STUCK_THRESHOLD_MS = 10 * 60 * 1000;
+
+function postCron() {
+  return app.fetch(
+    new Request("https://api.example.test/", {
+      method: "POST",
+      headers: { "x-cron-secret": "cron-secret" },
+    }),
+    { CRON_SECRET: "cron-secret" },
+  );
+}
+
+describe("cleanup-stuck-provisioning cron — orphaned pending scan", () => {
+  beforeEach(() => {
+    markStuckProvisioningWithoutActiveJobAsError.mockClear();
+    markOrphanedPendingWithoutJobAsError.mockClear();
+    verifyCronSecret.mockClear();
+    verifyCronSecret.mockReturnValue(null);
+    markStuckProvisioningWithoutActiveJobAsError.mockResolvedValue([]);
+    markOrphanedPendingWithoutJobAsError.mockResolvedValue([
+      {
+        agentId: "sandbox-orphan-1",
+        agentName: "orphaned-agent",
+        organizationId: "org-1",
+        createdAt: new Date("2026-06-14T00:00:00.000Z"),
+      },
+    ]);
+  });
+
+  test("reconciles orphaned pending rows with a NOW−10min cutoff and exposes them", async () => {
+    const before = Date.now();
+    const response = await postCron();
+    const after = Date.now();
+
+    expect(response.status).toBe(200);
+
+    // (a) The orphaned-pending scan ran with the same NOW−10min cutoff the
+    // stuck scan uses (a Date roughly 10 minutes in the past).
+    expect(markOrphanedPendingWithoutJobAsError).toHaveBeenCalledTimes(1);
+    const cutoff = markOrphanedPendingWithoutJobAsError.mock
+      .calls[0]?.[0] as Date;
+    expect(cutoff).toBeInstanceOf(Date);
+    expect(cutoff.getTime()).toBeGreaterThanOrEqual(
+      before - STUCK_THRESHOLD_MS - 1000,
+    );
+    expect(cutoff.getTime()).toBeLessThanOrEqual(
+      after - STUCK_THRESHOLD_MS + 1000,
+    );
+    // Both scans share the exact same cutoff instance.
+    const stuckCutoff =
+      markStuckProvisioningWithoutActiveJobAsError.mock.calls[0]?.[0];
+    expect(stuckCutoff).toBe(cutoff);
+
+    // (b) The response exposes the orphaned count + the recovered agent.
+    const body = (await response.json()) as {
+      success: boolean;
+      data: {
+        cleanedOrphanedPending: number;
+        orphanedPendingAgents: Array<{
+          agentId: string;
+          agentName: string;
+          organizationId: string;
+        }>;
+      };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.cleanedOrphanedPending).toBe(1);
+    expect(body.data.orphanedPendingAgents).toEqual([
+      {
+        agentId: "sandbox-orphan-1",
+        agentName: "orphaned-agent",
+        organizationId: "org-1",
+      },
+    ]);
+  });
+
+  test("rejects an invalid cron secret and never touches the reconciler", async () => {
+    verifyCronSecret.mockReturnValueOnce(
+      Response.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+
+    const response = await app.fetch(
+      new Request("https://api.example.test/", {
+        method: "POST",
+        headers: { "x-cron-secret": "wrong" },
+      }),
+      { CRON_SECRET: "cron-secret" },
+    );
+
+    expect(response.status).toBe(401);
+    expect(markStuckProvisioningWithoutActiveJobAsError).not.toHaveBeenCalled();
+    expect(markOrphanedPendingWithoutJobAsError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cloud-api/cron/cleanup-stuck-provisioning/route.ts
+++ b/packages/cloud-api/cron/cleanup-stuck-provisioning/route.ts
@@ -118,16 +118,23 @@ async function handleCleanupStuckProvisioning(
         cutoff,
       );
 
-    if (orphanedPending.length > 0) {
+    // Orphans have no stuckSinceMinutes (the created_at staleness drives them,
+    // not updated_at), so project them once into the shared shape and reuse it
+    // for both the log and the response.
+    const orphanedPendingAgents: Array<
+      Pick<CleanupResult, "agentId" | "agentName" | "organizationId">
+    > = orphanedPending.map((row) => ({
+      agentId: row.agentId,
+      agentName: row.agentName,
+      organizationId: row.organizationId,
+    }));
+
+    if (orphanedPendingAgents.length > 0) {
       logger.warn(
         "[Cleanup Stuck Provisioning] Reset orphaned pending agents",
         {
-          count: orphanedPending.length,
-          agents: orphanedPending.map((r) => ({
-            agentId: r.agentId,
-            agentName: r.agentName,
-            organizationId: r.organizationId,
-          })),
+          count: orphanedPendingAgents.length,
+          agents: orphanedPendingAgents,
         },
       );
     }
@@ -136,15 +143,11 @@ async function handleCleanupStuckProvisioning(
       success: true,
       data: {
         cleaned: results.length,
-        cleanedOrphanedPending: orphanedPending.length,
+        cleanedOrphanedPending: orphanedPendingAgents.length,
         thresholdMinutes: STUCK_THRESHOLD_MINUTES,
         timestamp: new Date().toISOString(),
         agents: results,
-        orphanedPendingAgents: orphanedPending.map((r) => ({
-          agentId: r.agentId,
-          agentName: r.agentName,
-          organizationId: r.organizationId,
-        })),
+        orphanedPendingAgents,
       },
     });
   } catch (error) {

--- a/packages/cloud-api/cron/cleanup-stuck-provisioning/route.ts
+++ b/packages/cloud-api/cron/cleanup-stuck-provisioning/route.ts
@@ -104,13 +104,47 @@ async function handleCleanupStuckProvisioning(
       logger.info("[Cleanup Stuck Provisioning] No stuck agents found");
     }
 
+    /**
+     * Second scan: ORPHANED PENDING rows. A user sandbox can be committed as
+     * `pending` but never get an `agent_provision` job enqueued if the
+     * create→enqueue window throws (KMS key mint, managed-env write, job-table
+     * write). The daemon only claims rows that HAVE a job, so these are
+     * structurally unclaimable and would sit `pending` forever with a null
+     * error_message. Mark them `error` (never re-enqueue — env-prep may have
+     * failed) so the user sees the failure and can retry. Same cutoff/threshold.
+     */
+    const orphanedPending =
+      await agentSandboxesRepository.markOrphanedPendingWithoutJobAsError(
+        cutoff,
+      );
+
+    if (orphanedPending.length > 0) {
+      logger.warn(
+        "[Cleanup Stuck Provisioning] Reset orphaned pending agents",
+        {
+          count: orphanedPending.length,
+          agents: orphanedPending.map((r) => ({
+            agentId: r.agentId,
+            agentName: r.agentName,
+            organizationId: r.organizationId,
+          })),
+        },
+      );
+    }
+
     return Response.json({
       success: true,
       data: {
         cleaned: results.length,
+        cleanedOrphanedPending: orphanedPending.length,
         thresholdMinutes: STUCK_THRESHOLD_MINUTES,
         timestamp: new Date().toISOString(),
         agents: results,
+        orphanedPendingAgents: orphanedPending.map((r) => ({
+          agentId: r.agentId,
+          agentName: r.agentName,
+          organizationId: r.organizationId,
+        })),
       },
     });
   } catch (error) {

--- a/packages/cloud-api/v1/eliza/agents/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/route.ts
@@ -366,15 +366,7 @@ app.post("/", async (c) => {
     executionTier,
   });
 
-  // ── Atomicity guard: createAgent → enqueue is a split write ──────────────
-  // `createAgent` already COMMITTED a `pending` row. Everything up to the
-  // provision-job enqueue can still throw (prepareManagedElizaEnvironment mints
-  // a KMS-backed key; updateAgentEnvironment / enqueue hit the DB + job table).
-  // The daemon only claims rows that have a matching `agent_provision` job, so a
-  // throw in this window would strand a `pending` sandbox with no job — forever
-  // unclaimable. Wrap the whole span and delete the just-created row on ANY
-  // failure, then rethrow so the caller still sees the error (the reconciler in
-  // cleanup-stuck-provisioning is the safety net for rows that slip through).
+  // Atomicity guard: createAgent already committed a pending row — any throw before the job is enqueued must roll it back (see withOrphanCleanup).
   return await withOrphanCleanup(agent.id, user.organization_id, async () => {
     const managedEnvironment = await prepareManagedElizaEnvironment({
       existingEnv: parsed.data.environmentVars,

--- a/packages/cloud-api/v1/eliza/agents/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/route.ts
@@ -205,6 +205,47 @@ function toAgentListItemDto(
   };
 }
 
+/**
+ * Run the create→enqueue span and delete the just-created sandbox if ANY step
+ * throws. `createAgent` commits a `pending` row up front, but the daemon only
+ * provisions rows that have a matching `agent_provision` job — so an error
+ * before the enqueue (e.g. KMS key mint in prepareManagedElizaEnvironment, or
+ * the env/job DB writes) would otherwise leave a `pending` row no worker can
+ * ever claim. We roll the row back and rethrow so the caller still sees the
+ * failure. Cleanup is best-effort; the cleanup-stuck-provisioning cron is the
+ * safety net for rows that slip through.
+ */
+async function withOrphanCleanup<T>(
+  agentSandboxId: string,
+  organizationId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    try {
+      await agentSandboxesRepository.delete(agentSandboxId, organizationId);
+      logger.info("[agent-api] Cleaned up agent after create→enqueue failure", {
+        agentId: agentSandboxId,
+        orgId: organizationId,
+      });
+    } catch (cleanupErr) {
+      logger.error(
+        "[agent-api] Failed to clean up agent after create→enqueue failure",
+        {
+          agentId: agentSandboxId,
+          orgId: organizationId,
+          error:
+            cleanupErr instanceof Error
+              ? cleanupErr.message
+              : String(cleanupErr),
+        },
+      );
+    }
+    throw err;
+  }
+}
+
 app.get("/", async (c) => {
   const user = await requireUserOrApiKeyWithOrg(c);
   const agents = await elizaSandboxService.listAgents(user.organization_id);
@@ -325,184 +366,169 @@ app.post("/", async (c) => {
     executionTier,
   });
 
-  const managedEnvironment = await prepareManagedElizaEnvironment({
-    existingEnv: parsed.data.environmentVars,
-    organizationId: user.organization_id,
-    userId: user.id,
-    agentSandboxId: agent.id,
-  });
+  // ── Atomicity guard: createAgent → enqueue is a split write ──────────────
+  // `createAgent` already COMMITTED a `pending` row. Everything up to the
+  // provision-job enqueue can still throw (prepareManagedElizaEnvironment mints
+  // a KMS-backed key; updateAgentEnvironment / enqueue hit the DB + job table).
+  // The daemon only claims rows that have a matching `agent_provision` job, so a
+  // throw in this window would strand a `pending` sandbox with no job — forever
+  // unclaimable. Wrap the whole span and delete the just-created row on ANY
+  // failure, then rethrow so the caller still sees the error (the reconciler in
+  // cleanup-stuck-provisioning is the safety net for rows that slip through).
+  return await withOrphanCleanup(agent.id, user.organization_id, async () => {
+    const managedEnvironment = await prepareManagedElizaEnvironment({
+      existingEnv: parsed.data.environmentVars,
+      organizationId: user.organization_id,
+      userId: user.id,
+      agentSandboxId: agent.id,
+    });
 
-  if (managedEnvironment.changed) {
-    await elizaSandboxService.updateAgentEnvironment(
-      agent.id,
-      user.organization_id,
-      managedEnvironment.environmentVars,
-    );
-  }
+    if (managedEnvironment.changed) {
+      await elizaSandboxService.updateAgentEnvironment(
+        agent.id,
+        user.organization_id,
+        managedEnvironment.environmentVars,
+      );
+    }
 
-  logger.info("[agent-api] Agent created", {
-    agentId: agent.id,
-    orgId: user.organization_id,
-    autoProvision,
-    executionTier,
-  });
+    logger.info("[agent-api] Agent created", {
+      agentId: agent.id,
+      orgId: user.organization_id,
+      autoProvision,
+      executionTier,
+    });
 
-  if (executionTier === "shared") {
-    return c.json(
-      {
-        success: true,
-        created: true,
-        source: "shared_runtime",
-        data: {
-          id: agent.id,
-          agentId: agent.id,
-          agentName: agent.agent_name,
-          status: agent.status,
-          createdAt: agent.created_at,
-          executionTier: agent.execution_tier,
-        },
-      },
-      201,
-    );
-  }
-
-  if (!shouldProvisionEagerly) {
-    return c.json(
-      {
-        success: true,
-        created: true,
-        data: {
-          id: agent.id,
-          agentId: agent.id,
-          agentName: agent.agent_name,
-          status: agent.status,
-          createdAt: agent.created_at,
-          executionTier: agent.execution_tier,
-        },
-      },
-      201,
-    );
-  }
-
-  if (executionTier !== "custom" && containersEnv.warmPoolEnabled()) {
-    try {
-      const claimed = await agentSandboxesRepository.claimWarmContainer({
-        userAgentId: agent.id,
-        organizationId: user.organization_id,
-        image: containersEnv.defaultAgentImage(),
-        agentName: agent.agent_name ?? agent.id,
-        agentConfig:
-          (agent.agent_config as Record<string, unknown> | undefined) ??
-          undefined,
-        characterId: agent.character_id,
-      });
-      if (claimed) {
-        logger.info("[agent-api] Warm pool claim succeeded on create", {
-          agentId: agent.id,
-          orgId: user.organization_id,
-          poolNodeId: claimed.node_id,
-        });
-        return c.json(
-          {
-            success: true,
-            source: "warm_pool",
-            data: {
-              id: claimed.id,
-              agentName: claimed.agent_name,
-              status: claimed.status,
-              bridgeUrl: claimed.bridge_url,
-              healthUrl: claimed.health_url,
-              executionTier: claimed.execution_tier,
-            },
+    if (executionTier === "shared") {
+      return c.json(
+        {
+          success: true,
+          created: true,
+          source: "shared_runtime",
+          data: {
+            id: agent.id,
+            agentId: agent.id,
+            agentName: agent.agent_name,
+            status: agent.status,
+            createdAt: agent.created_at,
+            executionTier: agent.execution_tier,
           },
-          201,
+        },
+        201,
+      );
+    }
+
+    if (!shouldProvisionEagerly) {
+      return c.json(
+        {
+          success: true,
+          created: true,
+          data: {
+            id: agent.id,
+            agentId: agent.id,
+            agentName: agent.agent_name,
+            status: agent.status,
+            createdAt: agent.created_at,
+            executionTier: agent.execution_tier,
+          },
+        },
+        201,
+      );
+    }
+
+    if (executionTier !== "custom" && containersEnv.warmPoolEnabled()) {
+      try {
+        const claimed = await agentSandboxesRepository.claimWarmContainer({
+          userAgentId: agent.id,
+          organizationId: user.organization_id,
+          image: containersEnv.defaultAgentImage(),
+          agentName: agent.agent_name ?? agent.id,
+          agentConfig:
+            (agent.agent_config as Record<string, unknown> | undefined) ??
+            undefined,
+          characterId: agent.character_id,
+        });
+        if (claimed) {
+          logger.info("[agent-api] Warm pool claim succeeded on create", {
+            agentId: agent.id,
+            orgId: user.organization_id,
+            poolNodeId: claimed.node_id,
+          });
+          return c.json(
+            {
+              success: true,
+              source: "warm_pool",
+              data: {
+                id: claimed.id,
+                agentName: claimed.agent_name,
+                status: claimed.status,
+                bridgeUrl: claimed.bridge_url,
+                healthUrl: claimed.health_url,
+                executionTier: claimed.execution_tier,
+              },
+            },
+            201,
+          );
+        }
+      } catch (err) {
+        // Don't block on claim errors — fall through to the async job path.
+        logger.warn(
+          "[agent-api] Warm pool claim threw on create; falling back",
+          {
+            agentId: agent.id,
+            orgId: user.organization_id,
+            error: err instanceof Error ? err.message : String(err),
+          },
         );
       }
-    } catch (err) {
-      // Don't block on claim errors — fall through to the async job path.
-      logger.warn("[agent-api] Warm pool claim threw on create; falling back", {
-        agentId: agent.id,
-        orgId: user.organization_id,
-        error: err instanceof Error ? err.message : String(err),
-      });
     }
-  }
 
-  // ── Async path (default) ────────────────────────────────────────────────
-  // `expectedUpdatedAt` is intentionally omitted: the row was just created
-  // (and possibly touched by the managed-env update above), so there is no
-  // concurrent handle to guard against — passing the stale create timestamp
-  // would spuriously trip the race check after a managed-env write.
-  let job: Awaited<
-    ReturnType<typeof provisioningJobService.enqueueAgentProvision>
-  >;
-  try {
-    job = await provisioningJobService.enqueueAgentProvision({
+    // ── Async path (default) ──────────────────────────────────────────────
+    // `expectedUpdatedAt` is intentionally omitted: the row was just created
+    // (and possibly touched by the managed-env update above), so there is no
+    // concurrent handle to guard against — passing the stale create timestamp
+    // would spuriously trip the race check after a managed-env write.
+    const job = await provisioningJobService.enqueueAgentProvision({
       agentId: agent.id,
       organizationId: user.organization_id,
       userId: user.id,
       agentName: agent.agent_name ?? agent.id,
     });
-  } catch (enqueueErr) {
-    // Roll back the just-created agent so a failed enqueue doesn't leave an
-    // unprovisionable row behind (mirrors the orphaned-record cleanup the
-    // S2S /api/v1/agents route does for its character).
-    try {
-      await agentSandboxesRepository.delete(agent.id, user.organization_id);
-      logger.info("[agent-api] Cleaned up agent after enqueue failure", {
-        agentId: agent.id,
-        orgId: user.organization_id,
-      });
-    } catch (cleanupErr) {
-      logger.error(
-        "[agent-api] Failed to clean up agent after enqueue failure",
-        {
+
+    // Inline trigger: kick the worker now instead of waiting up to a minute for
+    // the next cron tick. Fire-and-forget; the cron is the safety net.
+    void provisioningJobService.triggerImmediate(c.env).catch(() => {
+      // Logged inside the service.
+    });
+
+    logger.info("[agent-api] Agent provisioning job enqueued on create", {
+      agentId: agent.id,
+      orgId: user.organization_id,
+      jobId: job.id,
+    });
+
+    return c.json(
+      {
+        success: true,
+        created: true,
+        message:
+          "Agent created. Provisioning job started — poll the job endpoint for status.",
+        data: {
           agentId: agent.id,
-          orgId: user.organization_id,
-          error:
-            cleanupErr instanceof Error
-              ? cleanupErr.message
-              : String(cleanupErr),
+          agentName: agent.agent_name,
+          status: job.status,
+          jobId: job.id,
+          estimatedCompletionAt: job.estimated_completion_at,
+          executionTier: agent.execution_tier,
         },
-      );
-    }
-    throw enqueueErr;
-  }
-
-  // Inline trigger: kick the worker now instead of waiting up to a minute for
-  // the next cron tick. Fire-and-forget; the cron is the safety net.
-  void provisioningJobService.triggerImmediate(c.env).catch(() => {
-    // Logged inside the service.
-  });
-
-  logger.info("[agent-api] Agent provisioning job enqueued on create", {
-    agentId: agent.id,
-    orgId: user.organization_id,
-    jobId: job.id,
-  });
-
-  return c.json(
-    {
-      success: true,
-      created: true,
-      message:
-        "Agent created. Provisioning job started — poll the job endpoint for status.",
-      data: {
-        agentId: agent.id,
-        agentName: agent.agent_name,
-        status: job.status,
-        jobId: job.id,
-        estimatedCompletionAt: job.estimated_completion_at,
-        executionTier: agent.execution_tier,
+        polling: {
+          endpoint: `/api/v1/jobs/${job.id}`,
+          intervalMs: 5000,
+          expectedDurationMs: 90000,
+        },
       },
-      polling: {
-        endpoint: `/api/v1/jobs/${job.id}`,
-        intervalMs: 5000,
-        expectedDurationMs: 90000,
-      },
-    },
-    202,
-  );
+      202,
+    );
+  });
 });
 
 export default app;

--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
@@ -67,9 +67,17 @@ describe("AgentSandboxesRepository", () => {
     // ...and have NO live agent_provision job.
     expect(sql).toContain("not exists");
     expect(sql).toContain("agent_provision");
+    // The job predicate is load-bearing: only LIVE jobs ('pending'/'in_progress')
+    // count, so a row whose only agent_provision job is completed/error is still
+    // reclaimed. Assert the live-state filter is present and dead states are not.
+    expect(sql).toContain("'pending', 'in_progress'");
+    expect(sql).not.toContain("'completed'");
+    expect(sql).not.toContain("'error'");
 
     // It MARKS ERROR (it never re-enqueues) with a clear, retry-able message.
     expect(capturedSet?.status).toBe("error");
     expect(String(capturedSet?.error_message)).toContain("no agent_provision job was enqueued");
+    // updated_at is bumped so the row no longer matches the cron on the next tick.
+    expect(capturedSet?.updated_at instanceof Date).toBe(true);
   });
 });

--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.test.ts
@@ -3,6 +3,7 @@ import type { SQL } from "drizzle-orm";
 import { PgDialect } from "drizzle-orm/pg-core";
 
 let capturedWhere: SQL | undefined;
+let capturedSet: Record<string, unknown> | undefined;
 
 const returning = mock(() => [
   {
@@ -14,7 +15,10 @@ const where = mock((clause: SQL) => {
   capturedWhere = clause;
   return { returning };
 });
-const set = mock(() => ({ where }));
+const set = mock((values: Record<string, unknown>) => {
+  capturedSet = values;
+  return { where };
+});
 const update = mock(() => ({ set }));
 const ensureAgentSandboxSchema = mock(async () => {});
 
@@ -38,5 +42,34 @@ describe("AgentSandboxesRepository", () => {
     expect(ensureAgentSandboxSchema).toHaveBeenCalled();
     if (!capturedWhere) throw new Error("trySetProvisioning did not build a where clause");
     expect(new PgDialect().sqlToQuery(capturedWhere).sql).toContain("'sleeping'");
+  });
+
+  test("marks only orphaned user-owned pending rows with no provision job as error", async () => {
+    capturedWhere = undefined;
+    capturedSet = undefined;
+
+    const { AgentSandboxesRepository } = await import("./agent-sandboxes");
+
+    const cutoff = new Date("2026-06-14T00:00:00.000Z");
+    await new AgentSandboxesRepository().markOrphanedPendingWithoutJobAsError(cutoff);
+
+    expect(ensureAgentSandboxSchema).toHaveBeenCalled();
+    if (!capturedWhere)
+      throw new Error("markOrphanedPendingWithoutJobAsError did not build a where clause");
+    const sql = new PgDialect().sqlToQuery(capturedWhere).sql.toLowerCase();
+    // Only `pending` rows are targeted...
+    expect(sql).toContain("'pending'");
+    // ...that are user-owned (warm-pool rows carry a pool_status, so skip them)...
+    expect(sql).toContain("pool_status");
+    expect(sql).toContain("is null");
+    // ...aged past the cutoff (keyed on created_at, not updated_at)...
+    expect(sql).toContain("created_at");
+    // ...and have NO live agent_provision job.
+    expect(sql).toContain("not exists");
+    expect(sql).toContain("agent_provision");
+
+    // It MARKS ERROR (it never re-enqueues) with a clear, retry-able message.
+    expect(capturedSet?.status).toBe("error");
+    expect(String(capturedSet?.error_message)).toContain("no agent_provision job was enqueued");
   });
 });

--- a/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
+++ b/packages/cloud-shared/src/db/repositories/agent-sandboxes.ts
@@ -330,6 +330,63 @@ export class AgentSandboxesRepository {
       });
   }
 
+  /**
+   * Recover ORPHANED PENDING sandboxes: a user-owned row that was committed as
+   * `pending` but never got an `agent_provision` job enqueued (a throw in the
+   * create→enqueue window of the agents/coding-container/eliza-app paths). The
+   * provisioning daemon only claims rows that HAVE a job, so such a row is
+   * structurally unclaimable and would sit in `pending` forever with a null
+   * error_message — a silent failure to the user.
+   *
+   * We MARK ERROR (never auto re-enqueue): the original env-prep may have
+   * failed, so re-provisioning could spin up a half-configured agent. A clear
+   * error makes the failure visible and lets the user retry the whole flow.
+   *
+   * `pool_status IS NULL` skips warm-pool rows, which are legitimately `pending`
+   * with no per-agent job until claimed. Keyed on `created_at` (not
+   * `updated_at`): the managed-env write bumps `updated_at`, so `created_at` is
+   * the honest "how long has this been stuck" signal.
+   */
+  async markOrphanedPendingWithoutJobAsError(cutoff: Date): Promise<
+    Array<{
+      agentId: string;
+      agentName: string | null;
+      organizationId: string;
+      createdAt: Date | null;
+    }>
+  > {
+    await ensureAgentSandboxSchema();
+    return dbWrite
+      .update(agentSandboxes)
+      .set({
+        status: "error",
+        error_message:
+          "Provisioning never started: no agent_provision job was enqueued " +
+          "(orphaned pending). Please retry.",
+        updated_at: new Date(),
+      })
+      .where(
+        and(
+          eq(agentSandboxes.status, "pending"),
+          sql`${agentSandboxes.pool_status} IS NULL`,
+          lt(agentSandboxes.created_at, cutoff),
+          sql`NOT EXISTS (
+            SELECT 1 FROM ${jobs}
+            WHERE  ${jobs.agent_id} = ${agentSandboxes.id}::text
+            AND    ${jobs.organization_id} = ${agentSandboxes.organization_id}
+            AND    ${jobs.type} = 'agent_provision'
+            AND    ${jobs.status} IN ('pending', 'in_progress')
+          )`,
+        ),
+      )
+      .returning({
+        agentId: agentSandboxes.id,
+        agentName: agentSandboxes.agent_name,
+        organizationId: agentSandboxes.organization_id,
+        createdAt: agentSandboxes.created_at,
+      });
+  }
+
   async update(id: string, data: Partial<NewAgentSandbox>): Promise<AgentSandbox | undefined> {
     await ensureAgentSandboxSchema();
     const [r] = await dbWrite


### PR DESCRIPTION
## What's broken

`POST /api/v1/eliza/agents` creates the sandbox row and enqueues its provision job as **two separate writes**, and the only rollback guarded just the enqueue. So a throw in the window between them strands a `pending` sandbox forever.

The window (`packages/cloud-api/v1/eliza/agents/route.ts`):
- `~315` `elizaSandboxService.createAgent(...)` — **commits** the row as `status='pending'`.
- `~328` `prepareManagedElizaEnvironment(...)` — mints a KMS-backed API key (can throw on KMS/Steward/DB).
- `~336` `elizaSandboxService.updateAgentEnvironment(...)` — can throw.
- `~440` `provisioningJobService.enqueueAgentProvision(...)` — the **only** call wrapped in a try/catch that deletes the row on failure (`~446-470`).

A throw anywhere in `315→439` (i.e. `prepareManagedElizaEnvironment` or `updateAgentEnvironment`) leaves a committed `pending` sandbox with **no provision job and no `error_message`**. The provisioning-worker daemon only claims rows from the `jobs` table (`type='agent_provision'`, `status='pending'`) — it **never scans `agent_sandboxes`** — so a job-less `pending` row is structurally unclaimable, and no sweeper covered it. It sits in `pending` forever; the dashboard surfaces "an unexpected error".

### Caught by a real live repro
A dashboard "Deploy Agent Instance" (dedicated sandbox) produced exactly this: an orphaned `pending` sandbox `e2e-dedicated-test` with **no** `agent_provision` job. Manually enqueuing the missing job let the daemon provision it normally → **proving only the trigger was missing**, the agent itself was fine.

### Same split-write elsewhere
- `packages/cloud-api/v1/coding-containers/route.ts` — the pre-enqueue `updateAgentEnvironment` (`~234-243`) sat between the committed row and the job enqueue (`~252`), guarded only at the enqueue.
- `packages/cloud-shared/src/lib/services/eliza-app/provisioning.ts` (`~90-107`) — `createAgent` then `enqueueAgentProvision` with **no** cleanup at all.

## The fix — 3 guarded paths + a reconciler

1. **agents POST** — wrap the whole `createAgent → enqueue` span in a `withOrphanCleanup` helper. Any throw deletes the just-created row (reusing the existing delete) and rethrows, so the caller still sees the error. The shared-runtime / warm-pool / `autoProvision=false` branches are untouched — they exit via clean `return`, never throw, so they pass straight through. The old enqueue-only try/catch is folded into the same wrapper.
2. **coding-containers** — guard the pre-enqueue `updateAgentEnvironment` write too, reusing the same orphan-delete the enqueue catch already performs.
3. **eliza-app provisioning** — guard the enqueue (delete the row + rethrow on failure).
4. **Reconciler / safety-net** — new `markOrphanedPendingWithoutJobAsError` in `agent-sandboxes.ts`, mirroring the existing `markStuckProvisioningWithoutActiveJobAsError` but for orphaned **pending** rows:
   - `status='pending'` **AND** `pool_status IS NULL` (real user sandbox, not a warm-pool row) **AND** no live `agent_provision` job **AND** `created_at` older than the same 10-min cutoff (`created_at`, not `updated_at`, because the managed-env write bumps `updated_at`).
   - **Marks `error`** with a clear message (`"Provisioning never started: no agent_provision job was enqueued (orphaned pending). Please retry."`) so the failure is visible instead of silent (today `error_message` stays null).
   - **Conservative by design — never re-enqueues.** The original env-prep may have failed, so re-provisioning could spin up a half-configured agent; a clean error lets the user retry the whole flow.
   - Wired into the **same** `cleanup-stuck-provisioning` cron that runs `markStuckProvisioningWithoutActiveJobAsError`.

## Out of scope
These are separate pre-existing **infra/config** issues, not this code bug, and are intentionally **not** touched here:
- Staging Steward auth-gate **500s** (degraded Steward tenant).
- Headscale API key **401**.

## Test plan
- `route guard`: mocking `prepareManagedElizaEnvironment` to throw **and** `updateAgentEnvironment` to throw each asserts the sandbox is deleted (`agentSandboxesRepository.delete`), no provision job is enqueued, and the error propagates (≥500). Happy path still enqueues and never deletes (202).
- `coding-containers`: a fresh (non-idempotent) row whose pre-enqueue env write throws → row deleted, no enqueue, 503.
- `eliza-app`: enqueue failure deletes the just-created sandbox and rethrows.
- `reconciler`: asserts the generated WHERE targets `pending` + `pool_status IS NULL` + `created_at` cutoff + `NOT EXISTS` agent_provision job, and the SET writes `status='error'` with the retry message.
- All 10 touched-area tests pass; typecheck + biome clean for the changed files.

**Do not merge** — leaving open for review.