### PR TITLE
feat(registry): add @agentradar/eliza-plugin

### DIFF
--- a/packages/registry/entries/third-party/agentradar__eliza-plugin.json
+++ b/packages/registry/entries/third-party/agentradar__eliza-plugin.json
@@ -1,0 +1,10 @@
+{
+  "package": "@agentradar/eliza-plugin",
+  "repository": "github:Bichev/agentradar-integrations",
+  "kind": "plugin",
+  "description": "AgentRadar trust for elizaOS — a VERIFY_AGENT action and trust provider that check a wallet/agent's on-chain trust score (ERC-8004 reputation + scam database + static analysis) before your agent interacts with or pays it.",
+  "homepage": "https://github.com/Bichev/agentradar-integrations/tree/main/eliza-plugin-agentradar",
+  "version": "0.1.0",
+  "directory": "eliza-plugin-agentradar",
+  "tags": ["trust", "verification", "x402", "erc-8004", "security", "agent-economy", "reputation"]
+}

--- a/packages/registry/generated-registry.json
+++ b/packages/registry/generated-registry.json
@@ -45,6 +45,53 @@
       "registryKind": "plugin",
       "directory": null
     },
+    "@agentradar/eliza-plugin": {
+      "git": {
+        "repo": "Bichev/agentradar-integrations",
+        "v0": {
+          "branch": null
+        },
+        "v1": {
+          "branch": null
+        },
+        "v2": {
+          "branch": "main"
+        }
+      },
+      "npm": {
+        "repo": "@agentradar/eliza-plugin",
+        "v0": null,
+        "v1": null,
+        "v2": "0.1.0"
+      },
+      "supports": {
+        "v0": false,
+        "v1": false,
+        "v2": true
+      },
+      "description": "AgentRadar trust for elizaOS — a VERIFY_AGENT action and trust provider that check a wallet/agent's on-chain trust score (ERC-8004 reputation + scam database + static analysis) before your agent interacts with or pays it.",
+      "homepage": "https://github.com/Bichev/agentradar-integrations/tree/main/eliza-plugin-agentradar",
+      "topics": [
+        "trust",
+        "verification",
+        "x402",
+        "erc-8004",
+        "security",
+        "agent-economy",
+        "reputation"
+      ],
+      "stargazers_count": 0,
+      "language": "TypeScript",
+      "origin": "third-party",
+      "source": "community",
+      "support": "community",
+      "builtIn": false,
+      "firstParty": false,
+      "thirdParty": true,
+      "kind": "plugin",
+      "registryKind": "plugin",
+      "directory": "eliza-plugin-agentradar"
+    },
     "@thecolony/elizaos-plugin": {
       "git": {
         "repo": "TheColonyCC/elizaos-plugin",


### PR DESCRIPTION
## What

Adds the **`@agentradar/eliza-plugin`** community plugin to the third-party registry, following the flow in [`packages/registry/README.md`](https://github.com/elizaOS/eliza/blob/develop/packages/registry/README.md).

[AgentRadar](https://api.vvpro.ai) is an on-chain meta-trust oracle for the x402 + ERC-8004 agent economy. The plugin gives an Eliza agent on-chain trust awareness:

- **`VERIFY_AGENT` action** — when a message contains an EVM address and asks about safety/trust, the agent replies with the AgentRadar composite score (0–100), verdict (`TRUSTED`/`VERIFIED`/`CAUTION`/`RISKY`/`BLOCKED`), and risk flags.
- **`AGENTRADAR_TRUST` provider** — injects trust context for any address mentioned, so the agent reasons with it before interacting or paying.

The signal is a composite of ERC-8004 reputation, a scam-wallet database, and static analysis — "verify before you transact" for autonomous agents.

## Changes

- `packages/registry/entries/third-party/agentradar__eliza-plugin.json` — the source entry (own `@agentradar` scope, not the reserved `@elizaos/*`).
- `packages/registry/generated-registry.json` — regenerated; only the new key is added (the existing 8 entries are byte-identical).

## Checklist

- [x] Published to npm: [`@agentradar/eliza-plugin`](https://www.npmjs.com/package/@agentradar/eliza-plugin) (MIT), typechecked against `@elizaos/core@1.7.2`.
- [x] `package` uses our own scope; `keywords` include `elizaos` (runtime auto-discovery) + `eliza-plugin`.
- [x] Public source repo with resolvable `repository:` — [Bichev/agentradar-integrations](https://github.com/Bichev/agentradar-integrations) (`directory: eliza-plugin-agentradar`).
- [x] Entry validates against `schema/registry-entry.schema.json` (required `package`/`repository`/`kind`; no extra properties).
- [x] `generated-registry.json` regenerated with the documented transform (existing entries unchanged).

Made with [Cursor](https://cursor.com)