### PR TITLE
fix(cloud): registry-probe handles digest-pinned image refs (ghcr token 400)

### DIFF
--- a/packages/cloud-shared/src/lib/services/containers/registry-probe.ts
+++ b/packages/cloud-shared/src/lib/services/containers/registry-probe.ts
@@ -44,6 +44,20 @@ export async function resolveImageDigest(
   const cached = cache.get(imageRef);
   if (cached && cached.expiresAt > now()) return cached.digest;
 
+  // A digest-pinned ref (`repo@sha256:...`) is already resolved — the digest IS
+  // the answer, and there is no newer digest to fetch. Short-circuit before the
+  // tag path: parseImageRef would keep the `@sha256` in the repo
+  // (`elizaos/eliza@sha256`), corrupting the ghcr token scope
+  // `repository:<repo>:pull` → HTTP 400, which makes the fleet-upgrade probe
+  // skip every digest-pinned fleet (the prod agent image is digest-pinned).
+  const atIdx = imageRef.indexOf("@");
+  if (atIdx !== -1) {
+    const digest = imageRef.slice(atIdx + 1);
+    const resolved = /^sha256:[0-9a-f]{64}$/.test(digest) ? digest : null;
+    cache.set(imageRef, { digest: resolved, expiresAt: now() + CACHE_TTL_MS });
+    return resolved;
+  }
+
   const parsed = parseImageRef(imageRef);
   if (!parsed || parsed.registry !== "ghcr.io") {
     cache.set(imageRef, { digest: null, expiresAt: now() + CACHE_TTL_MS });


### PR DESCRIPTION
## Bug
`resolveImageDigest` runs a **digest-pinned** ref (`repo@sha256:...`) through `parseImageRef`, which keeps the `@sha256` in the repo (`elizaos/eliza@sha256`) → corrupts the ghcr token scope `repository:elizaos/eliza@sha256:pull` → **HTTP 400**. The fleet-upgrade reconciler logs `[registry-probe] ghcr token fetch failed ... 400` and `skip_no_digest`s every cycle, so a digest-pinned fleet never auto-upgrades.

**The prod agent image is digest-pinned** (`ghcr.io/elizaos/eliza@sha256:4abb...`), so this fired on every prod provisioning-worker heartbeat — surfaced during the prod dedicated-provision e2e (tracker #8434). @standujar independently flagged the same scope bug in his staging E2E writeup.

## Fix
A digest-pinned ref is already resolved — the digest **is** the answer. Short-circuit before the tag path and return it (validated `sha256:<64hex>`), no token/manifest fetch. Tag-based refs unchanged.

cc @standujar @lalalune