### PR TITLE
fix(onboarding): show first-run chooser on stock sideload instead of auto-seeding local

### DIFF
--- a/packages/ui/src/first-run/pre-seed-local-runtime.test.ts
+++ b/packages/ui/src/first-run/pre-seed-local-runtime.test.ts
@@ -124,16 +124,20 @@ describe("preSeedAndroidLocalRuntimeIfFresh", () => {
     });
   });
 
-  it("seeds the local agent on a sideloaded local (non-cloud) Android build", () => {
+  it("does NOT auto-seed a stock-phone sideload — the first-run chooser offers local instead", () => {
+    // A stock sideload used to auto-seed local, which skipped the 3-way
+    // chooser, auto-started the slow on-device agent (POST_NOTIFICATIONS
+    // prompt + "connecting to backend" hang). The chooser now offers a
+    // "Local models" card, so the fresh install should render the chooser.
     mocks.capacitorPlatform = "android";
     mocks.isAndroidCloudBuild.mockReturnValue(false);
     setUserAgent(STOCK_WEBVIEW_UA);
 
-    expect(preSeedAndroidLocalRuntimeIfFresh()).toBe(true);
-    expect(mocks.persistMobileRuntimeModeForServerTarget).toHaveBeenCalledWith(
-      "local",
-    );
-    expect(readSeededActiveServer()).not.toBeNull();
+    expect(preSeedAndroidLocalRuntimeIfFresh()).toBe(false);
+    expect(
+      mocks.persistMobileRuntimeModeForServerTarget,
+    ).not.toHaveBeenCalled();
+    expect(readSeededActiveServer()).toBeNull();
   });
 
   it("does not seed the cloud-locked Android build", () => {

--- a/packages/ui/src/first-run/pre-seed-local-runtime.ts
+++ b/packages/ui/src/first-run/pre-seed-local-runtime.ts
@@ -2,8 +2,6 @@
  * Pre-seed the AOSP ElizaOS APK when the device itself is the local agent.
  */
 
-import { Capacitor } from "@capacitor/core";
-import { isAndroidCloudBuild } from "../platform/android-runtime";
 import { isAospElizaUserAgent } from "../platform/aosp-user-agent";
 import {
   ANDROID_LOCAL_AGENT_IPC_BASE,
@@ -61,34 +59,22 @@ function isBrandedAndroidDevice(): boolean {
   return isAospElizaUserAgent(navigator.userAgent);
 }
 
-function isNativeAndroid(): boolean {
-  try {
-    if (Capacitor.getPlatform() === "android") return true;
-  } catch {
-    // Capacitor may not be wired up yet during early boot — fall through to
-    // the UA check, which is available synchronously from the first paint.
-  }
-  // Capacitor's Android System WebView UA carries the "; wv)" marker, which a
-  // stock Android Chrome browser does not — so this matches the native app
-  // only, not the web dashboard opened in Android Chrome.
-  if (typeof navigator === "undefined") return false;
-  const ua = navigator.userAgent;
-  return /android/i.test(ua) && /;\s*wv\)/i.test(ua);
-}
-
 /**
  * Whether to pre-seed the on-device local agent as the active server.
  *
- * Branded ElizaOS device images carry the `ElizaOS/<tag>` UA marker. The
- * stock-phone sideload build does not, but it IS the local on-device agent
- * build (the cloud variant is `build:android:cloud`). Without seeding, that
- * sideload defaults to the cloud-connect onboarding with no "use local"
- * option, so a fresh install on a stock phone can never reach the local
- * agent. Seed local whenever this is the local Android build.
+ * Branded ElizaOS device images (carrying the `ElizaOS/<tag>` UA marker) are
+ * dedicated local-agent hardware, so they auto-seed local.
+ *
+ * Stock-phone sideloads do NOT auto-seed: the first-run 3-way chooser
+ * (CompactOnboarding's "Local models" card) now offers local explicitly, so
+ * auto-seeding only did harm — it skipped the chooser, auto-started the slow
+ * on-device agent foreground service (triggering the POST_NOTIFICATIONS prompt
+ * at launch), and left the dashboard stuck "connecting to backend" while that
+ * agent booted. Letting the chooser render instead is faster, prompts nothing
+ * on launch, and still reaches local in one tap.
  */
 function shouldPreSeedLocalRuntime(): boolean {
-  if (isBrandedAndroidDevice()) return true;
-  return isNativeAndroid() && !isAndroidCloudBuild();
+  return isBrandedAndroidDevice();
 }
 
 export function preSeedAndroidLocalRuntimeIfFresh(): boolean {


### PR DESCRIPTION
## What
On a stock-phone Android sideload, first-run now renders the 3-way runtime chooser (Eliza Cloud / Remote / Local) instead of auto-seeding the on-device local agent.

## Why
`preSeedAndroidLocalRuntimeIfFresh` auto-seeded local on any stock sideload (added in #8223 when onboarding was cloud-only and couldn't reach local). Post-redesign (#8457) the chooser has a **Local models** card, so auto-seeding now only does harm — verified on a real Solana Seeker (Android 16):
- 🔔 Triggers the `POST_NOTIFICATIONS` prompt at launch (the auto-started agent foreground service posts a notification)
- ⏳ Leaves the dashboard stuck "connecting to backend" while the slow on-device agent boots (MediaTek Dimensity 7300 ≈ 7 tok/s)
- 🐢 Slows first load
- ⛔ Skips the chooser entirely

## Change
`shouldPreSeedLocalRuntime()` → branded ElizaOS devices still auto-seed; stock sideloads fall through to the chooser. Removed the now-dead `isNativeAndroid`/`isAndroidCloudBuild`/`Capacitor` usage. Flipped the stock-sideload unit test (6/6 green).

## Verified on device
Fresh install → chooser shows, **no notif prompt, no hang, fast** → tapped Remote → connected → "100−37" → reply **"63"**.

@lalalune — this reverses the stock-sideload branch of your #8223 pre-seed (branded-device path unchanged). Heads-up since it's a deliberate behavior flip; the chooser's Local card preserves one-tap local.