### PR TITLE
fix(cloud): unbreak shared agents — resolve Cerebras pricing for direct-provider billing

### DIFF
--- a/packages/cloud-shared/src/lib/services/ai-pricing-variant-indexing.test.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing-variant-indexing.test.ts
@@ -212,6 +212,34 @@ describe("forced provider route pricing ids", () => {
     );
   });
 
+  test("bridges the slash provider form to the colon-keyed Cerebras forced rows", () => {
+    // The shared runtime hits Cerebras directly and bills by (bareModel, provider),
+    // so canonicalModelId("gpt-oss-120b", "cerebras") yields the slash form
+    // `cerebras/gpt-oss-120b`. The Cerebras forced pricing rows are keyed in
+    // BitRouter's colon-routing form (`cerebras:gpt-oss-120b`). Without the
+    // slash→colon bridge the lookup misses every Cerebras forced row and throws
+    // "Pricing unavailable for language:input cerebras/gpt-oss-120b", which the
+    // agent bridge masks as -32000 "Sandbox bridge is unreachable" — every shared
+    // agent turn fails silently.
+    expect(
+      expandPricingCatalogModelCandidates(canonicalModelId("gpt-oss-120b", "cerebras")),
+    ).toContain("cerebras:gpt-oss-120b");
+    expect(
+      expandPricingCatalogModelCandidates(canonicalModelId("zai-glm-4.7", "cerebras")),
+    ).toContain("cerebras:zai-glm-4.7");
+  });
+
+  test("does not synthesize a colon route id for namespace prefixes or variant ids", () => {
+    // `x-ai` is a dash-bearing BitRouter namespace, not a single-token
+    // forced-provider key, so it must not gain a `x-ai:` route spelling.
+    expect(expandPricingCatalogModelCandidates("x-ai/grok-4.20")).not.toContain("x-ai:grok-4.20");
+    // An id that already carries a colon (a `:nitro` routing variant) must not
+    // gain a second colon from the bridge.
+    expect(expandPricingCatalogModelCandidates("openai/gpt-oss-120b:nitro")).not.toContain(
+      "openai:gpt-oss-120b:nitro",
+    );
+  });
+
   test("adds synthetic Cerebras pricing rows to the BitRouter catalog", async () => {
     const previousApiKey = process.env.BITROUTER_API_KEY;
     const previousFetch = globalThis.fetch;

--- a/packages/cloud-shared/src/lib/services/ai-pricing/candidate-selection.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/candidate-selection.ts
@@ -102,6 +102,28 @@ function stripForcedProviderPrefix(model: string): string | null {
   return model.slice(colonIndex + 1);
 }
 
+/**
+ * Slash forced-provider form (`cerebras/gpt-oss-120b`) → colon routing form
+ * (`cerebras:gpt-oss-120b`). The pricing catalog keys forced provider rows in
+ * BitRouter's colon-routing spelling, but `canonicalModelId(bareModel, provider)`
+ * yields the slash spelling. A caller that hits the provider directly (e.g. the
+ * shared runtime calling Cerebras) bills by `(bareModel, provider)`, so without
+ * this bridge its lookup never reaches the colon-keyed row and throws
+ * "Pricing unavailable". Mirror of {@link stripForcedProviderPrefix} (colon → bare).
+ *
+ * Returns null when the prefix is a dash-bearing namespace (`x-ai/...`) rather
+ * than a single-token forced-provider key, or when the id already carries a colon
+ * (a routing/variant id like `openai/gpt-oss-120b:nitro`).
+ */
+function forcedProviderColonVariant(model: string): string | null {
+  if (model.includes(":")) return null;
+  const slashIndex = model.indexOf("/");
+  if (slashIndex <= 0) return null;
+  const prefix = model.slice(0, slashIndex);
+  if (prefix.includes("-")) return null;
+  return `${prefix}:${model.slice(slashIndex + 1)}`;
+}
+
 /** Manual gateway rename map + inverse (new id → legacy ids still in DB). */
 function collectGatewayPricingManualAliasCandidates(canonicalModel: string): string[] {
   const extras: string[] = [];
@@ -151,6 +173,10 @@ export function expandPricingCatalogModelCandidates(canonicalModel: string): str
   };
 
   pushWithTranslations(canonicalModel);
+  const colonForcedVariant = forcedProviderColonVariant(canonicalModel);
+  if (colonForcedVariant) {
+    pushWithTranslations(colonForcedVariant);
+  }
   const unforcedModel = stripForcedProviderPrefix(canonicalModel);
   if (unforcedModel) {
     pushWithTranslations(unforcedModel);


### PR DESCRIPTION
## Symptom (launch-critical)
Every **shared-runtime agent turn** (`POST /api/v1/eliza/agents/:id/bridge` → `message.send`) returns `-32000 "Sandbox bridge is unreachable"`. Verified live on prod: **100% deterministic**, independent of params, retries, or credit balance (my test org has $93). Shared agents simply cannot reply.

`status.get` / `heartbeat` return `runtime:"shared", ready:true` — so the agent is healthy; only `message.send` fails. The `-32000` is a **mask**: `ElizaSandboxService.bridge`'s catch logs the real error to the Worker log (eliza-sandbox.ts:1660) but returns the generic "unreachable" string to the caller.

## Root cause
Shared-runtime turns call **Cerebras directly** (`run-shared-agent-turn.ts` → `createOpenAI({baseURL: cerebras})`), not via BitRouter. So billing reserves credits with `model="gpt-oss-120b"`, `provider="cerebras"`. In the pricing path:

- `canonicalModelId("gpt-oss-120b", "cerebras")` → **`cerebras/gpt-oss-120b`** (slash form).
- The forced Cerebras pricing rows (`FORCED_BITROUTER_PRICING`) are keyed in BitRouter's colon-routing form **`cerebras:gpt-oss-120b`**.
- `expandPricingCatalogModelCandidates` bridged namespaces (`xai`↔`x-ai`) and stripped the colon prefix (colon→bare) — but had **no slash→colon bridge**.

So the candidate set was `["cerebras/gpt-oss-120b"]`, which never matches the colon-keyed forced row → `resolvePreparedPricingEntry` throws `Pricing unavailable for language:input cerebras/gpt-oss-120b`. `calculateTextCostFromCatalog` only `.catch()`es the **output** lookup (the input lookup is fatal), so the throw propagates `calculateCost → creditsService.reserve → reserveCredits` → re-thrown at eliza-sandbox.ts:1540 → bridge catch → masked `-32000`.

Inference (`/api/v1/chat/completions`) is unaffected because it resolves pricing under the routed (colon/bitrouter) id, not bare-model + cerebras-provider.

## Fix
Add `forcedProviderColonVariant` (mirror of the existing `stripForcedProviderPrefix`) and emit the colon spelling in `expandPricingCatalogModelCandidates`. A direct-provider caller now resolves the colon-keyed forced rows. Also fixes `cerebras:zai-glm-4.7` (same class). Dash-bearing namespace prefixes (`x-ai/`) and already-colon variant ids (`:nitro`) are deliberately left untouched.

This is the Cerebras sibling of the documented `openai/gpt-oss-120b` "Pricing unavailable" forced-row fix (PR #8307/#8319).

## Verification
- Pure-function probe: candidates for `cerebras/gpt-oss-120b` now include `cerebras:gpt-oss-120b` (provider + billingSource already matched).
- Added 2 regression tests in `ai-pricing-variant-indexing.test.ts` (slash→colon bridge + edge cases).
- `ai-pricing-variant-indexing` 37 pass / 0 fail; `ai-pricing-bitrouter-units` 6 pass / 0 fail.
- cloud-shared typecheck clean for the changed files.

Tracker: #8434 (Cloud 10-user launch)