### PR TITLE
fix(cloud): reconcile live prod hotfixes into main (Cerebras pricing + reasoning floor)

### DIFF
--- a/packages/cloud-shared/src/lib/pricing-reasoning-detection.test.ts
+++ b/packages/cloud-shared/src/lib/pricing-reasoning-detection.test.ts
@@ -34,6 +34,16 @@ describe("modelUsesReasoningTokens", () => {
     "z-ai/glm-4.6-thinking",
     "moonshotai/kimi-k2.6-think",
     "x-ai/grok-4-reasoning",
+    // Cloud launch defaults — gpt-oss spends output tokens on hidden reasoning,
+    // and the Cerebras zai-glm-4.x series is catalog-tagged reasoning. Both must
+    // get the response-token floor or low/default max_tokens returns empty
+    // (billed) output. (gpt-oss-120b = default TEXT_SMALL, zai-glm-4.7 = TEXT_LARGE.)
+    "gpt-oss-120b",
+    "openai/gpt-oss-120b",
+    "cerebras:gpt-oss-120b",
+    "openai/gpt-oss-120b:nitro",
+    "zai-glm-4.7",
+    "cerebras:zai-glm-4.7",
   ])("treats %s as a reasoning model", (model) => {
     expect(modelUsesReasoningTokens(model)).toBe(true);
   });

--- a/packages/cloud-shared/src/lib/pricing.ts
+++ b/packages/cloud-shared/src/lib/pricing.ts
@@ -145,8 +145,17 @@ const REASONING_MODEL_PATTERNS: RegExp[] = [
   /(think|thinking|reasoning|reasoner)(:|$|-)/,
   // Grok reasoning builds
   /^grok.*(reasoning|think)/,
-  // Z.ai GLM reasoning
+  // Z.ai GLM reasoning — both the bare `glm-...-thinking` form and the
+  // Cerebras `zai-glm-4.x` series (catalog-tagged "reasoning"; no "think" token
+  // in the id). The cloud's TEXT_LARGE default `zai-glm-4.7` lives here.
   /^glm-.*(think|reasoning)/,
+  /^zai-glm-/,
+  // OpenAI gpt-oss open-weight reasoning models (gpt-oss-120b / gpt-oss-20b).
+  // gpt-oss-120b is the cloud's default TEXT_SMALL model and spends output
+  // tokens on hidden reasoning before answering, so it MUST get the response
+  // floor — otherwise a default/low max_tokens truncates mid-reasoning and
+  // returns empty (but billed) output, intermittently per call.
+  /^gpt-oss/,
 ];
 
 /**

--- a/packages/cloud-shared/src/lib/services/ai-pricing-variant-indexing.test.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing-variant-indexing.test.ts
@@ -212,6 +212,34 @@ describe("forced provider route pricing ids", () => {
     );
   });
 
+  test("bridges the slash provider form to the colon-keyed Cerebras forced rows", () => {
+    // The shared runtime hits Cerebras directly and bills by (bareModel, provider),
+    // so canonicalModelId("gpt-oss-120b", "cerebras") yields the slash form
+    // `cerebras/gpt-oss-120b`. The Cerebras forced pricing rows are keyed in
+    // BitRouter's colon-routing form (`cerebras:gpt-oss-120b`). Without the
+    // slash→colon bridge the lookup misses every Cerebras forced row and throws
+    // "Pricing unavailable for language:input cerebras/gpt-oss-120b", which the
+    // agent bridge masks as -32000 "Sandbox bridge is unreachable" — every shared
+    // agent turn fails silently.
+    expect(
+      expandPricingCatalogModelCandidates(canonicalModelId("gpt-oss-120b", "cerebras")),
+    ).toContain("cerebras:gpt-oss-120b");
+    expect(
+      expandPricingCatalogModelCandidates(canonicalModelId("zai-glm-4.7", "cerebras")),
+    ).toContain("cerebras:zai-glm-4.7");
+  });
+
+  test("does not synthesize a colon route id for namespace prefixes or variant ids", () => {
+    // `x-ai` is a dash-bearing BitRouter namespace, not a single-token
+    // forced-provider key, so it must not gain a `x-ai:` route spelling.
+    expect(expandPricingCatalogModelCandidates("x-ai/grok-4.20")).not.toContain("x-ai:grok-4.20");
+    // An id that already carries a colon (a `:nitro` routing variant) must not
+    // gain a second colon from the bridge.
+    expect(expandPricingCatalogModelCandidates("openai/gpt-oss-120b:nitro")).not.toContain(
+      "openai:gpt-oss-120b:nitro",
+    );
+  });
+
   test("adds synthetic Cerebras pricing rows to the BitRouter catalog", async () => {
     const previousApiKey = process.env.BITROUTER_API_KEY;
     const previousFetch = globalThis.fetch;

--- a/packages/cloud-shared/src/lib/services/ai-pricing/candidate-selection.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/candidate-selection.ts
@@ -102,6 +102,28 @@ function stripForcedProviderPrefix(model: string): string | null {
   return model.slice(colonIndex + 1);
 }
 
+/**
+ * Slash forced-provider form (`cerebras/gpt-oss-120b`) → colon routing form
+ * (`cerebras:gpt-oss-120b`). The pricing catalog keys forced provider rows in
+ * BitRouter's colon-routing spelling, but `canonicalModelId(bareModel, provider)`
+ * yields the slash spelling. A caller that hits the provider directly (e.g. the
+ * shared runtime calling Cerebras) bills by `(bareModel, provider)`, so without
+ * this bridge its lookup never reaches the colon-keyed row and throws
+ * "Pricing unavailable". Mirror of {@link stripForcedProviderPrefix} (colon → bare).
+ *
+ * Returns null when the prefix is a dash-bearing namespace (`x-ai/...`) rather
+ * than a single-token forced-provider key, or when the id already carries a colon
+ * (a routing/variant id like `openai/gpt-oss-120b:nitro`).
+ */
+function forcedProviderColonVariant(model: string): string | null {
+  if (model.includes(":")) return null;
+  const slashIndex = model.indexOf("/");
+  if (slashIndex <= 0) return null;
+  const prefix = model.slice(0, slashIndex);
+  if (prefix.includes("-")) return null;
+  return `${prefix}:${model.slice(slashIndex + 1)}`;
+}
+
 /** Manual gateway rename map + inverse (new id → legacy ids still in DB). */
 function collectGatewayPricingManualAliasCandidates(canonicalModel: string): string[] {
   const extras: string[] = [];
@@ -151,6 +173,10 @@ export function expandPricingCatalogModelCandidates(canonicalModel: string): str
   };
 
   pushWithTranslations(canonicalModel);
+  const colonForcedVariant = forcedProviderColonVariant(canonicalModel);
+  if (colonForcedVariant) {
+    pushWithTranslations(colonForcedVariant);
+  }
   const unforcedModel = stripForcedProviderPrefix(canonicalModel);
   if (unforcedModel) {
     pushWithTranslations(unforcedModel);


### PR DESCRIPTION
**This is the already-live prod hotfix; merging it makes `main` reflect what's running on prod.**

The shared-runtime Cerebras pricing fix (full root cause in #8484) was deployed to prod as a scoped hotfix cut from `main` tip (`4be79c3386`) — `cloud-cf-deploy → production`, Deploy API Worker succeeded, verified live (shared agents reply, billing deducts). But the fix is **only on this hotfix branch + #8484 (develop)** — it is **not on `main`**.

⚠️ **Why this matters for the cutover:** the next `main` → prod deploy (Stan's develop→main staging replication, which also carries #8465) will rebuild the Worker from `main`. If `main` lacks this fix, that deploy **reverts the shared-agent fix on prod** and every `message.send` goes back to `-32000`.

Two equivalent ways to keep prod fixed; either is fine:
1. Merge this PR → `main` carries the fix directly (standard hotfix-into-base reconciliation), **or**
2. Ensure **#8484** is merged to `develop` before the develop→main promote (the fix rides the promote).

Same one-commit change as #8484 (candidate-selection.ts + regression tests). If the develop promote lands first, this becomes a no-op.