### PR TITLE
fix(cloud): floor response tokens for gpt-oss + zai-glm — stop intermittent empty replies on the default model

### DIFF
--- a/packages/cloud-shared/src/lib/pricing-reasoning-detection.test.ts
+++ b/packages/cloud-shared/src/lib/pricing-reasoning-detection.test.ts
@@ -34,6 +34,16 @@ describe("modelUsesReasoningTokens", () => {
     "z-ai/glm-4.6-thinking",
     "moonshotai/kimi-k2.6-think",
     "x-ai/grok-4-reasoning",
+    // Cloud launch defaults — gpt-oss spends output tokens on hidden reasoning,
+    // and the Cerebras zai-glm-4.x series is catalog-tagged reasoning. Both must
+    // get the response-token floor or low/default max_tokens returns empty
+    // (billed) output. (gpt-oss-120b = default TEXT_SMALL, zai-glm-4.7 = TEXT_LARGE.)
+    "gpt-oss-120b",
+    "openai/gpt-oss-120b",
+    "cerebras:gpt-oss-120b",
+    "openai/gpt-oss-120b:nitro",
+    "zai-glm-4.7",
+    "cerebras:zai-glm-4.7",
   ])("treats %s as a reasoning model", (model) => {
     expect(modelUsesReasoningTokens(model)).toBe(true);
   });

--- a/packages/cloud-shared/src/lib/pricing.ts
+++ b/packages/cloud-shared/src/lib/pricing.ts
@@ -145,8 +145,17 @@ const REASONING_MODEL_PATTERNS: RegExp[] = [
   /(think|thinking|reasoning|reasoner)(:|$|-)/,
   // Grok reasoning builds
   /^grok.*(reasoning|think)/,
-  // Z.ai GLM reasoning
+  // Z.ai GLM reasoning — both the bare `glm-...-thinking` form and the
+  // Cerebras `zai-glm-4.x` series (catalog-tagged "reasoning"; no "think" token
+  // in the id). The cloud's TEXT_LARGE default `zai-glm-4.7` lives here.
   /^glm-.*(think|reasoning)/,
+  /^zai-glm-/,
+  // OpenAI gpt-oss open-weight reasoning models (gpt-oss-120b / gpt-oss-20b).
+  // gpt-oss-120b is the cloud's default TEXT_SMALL model and spends output
+  // tokens on hidden reasoning before answering, so it MUST get the response
+  // floor — otherwise a default/low max_tokens truncates mid-reasoning and
+  // returns empty (but billed) output, intermittently per call.
+  /^gpt-oss/,
 ];
 
 /**


### PR DESCRIPTION
## Symptom
On prod, `/v1/chat/completions` to `gpt-oss-120b` (the cloud's **default** TEXT_SMALL model) **intermittently returns empty content** at default/low `max_tokens` — the *same* prompt returns a full answer on one call and empty (but billed) output on the next. `zai-glm-4.7` (default TEXT_LARGE) has the same exposure.

## Root cause
`/v1/chat/completions` floors `max_tokens` at `MIN_RESPONSE_TOKENS` (4096) for reasoning models so the hidden chain-of-thought can't eat the whole budget and truncate the answer. But that floor only fires when `modelUsesReasoningTokens(model)` is true, and **neither launch model was detected**:
- name patterns in `REASONING_MODEL_PATTERNS` don't cover `gpt-oss*` or `zai-glm-*`;
- the authoritative catalog `supported_parameters` lookup is best-effort and fails in prod (falls back to name patterns).

So the handler's default `max_tokens` of **500** applies, and gpt-oss-120b — which spends output tokens on reasoning before answering — truncates mid-reasoning whenever the reasoning happens to exceed ~500 tokens (nondeterministic per call). Confirmed live: `modelUsesReasoningTokens("gpt-oss-120b", undefined) === false` before this change.

## Fix
Add `/^gpt-oss/` and `/^zai-glm-/` to `REASONING_MODEL_PATTERNS`. Both are reasoning models (gpt-oss is OpenAI's open-weight reasoning series; zai-glm-4.x is catalog-tagged `reasoning`). The 4096 floor now fires for both, on every id form (`gpt-oss-120b`, `cerebras:gpt-oss-120b`, `openai/gpt-oss-120b:nitro`, `zai-glm-4.7`, `cerebras:zai-glm-4.7`). Non-reasoning models (gpt-4o-mini, haiku) stay false — no over-matching.

## Verification
- Pure-fn probe: all launch-model id forms now detect `reasoning=true`.
- 6 regression cases added to `pricing-reasoning-detection.test.ts`; suite green (44/0).
- Already verified live: prod hotfix off `main` carries this + the #8484 Cerebras-pricing fix.

Tracker: #8434