### PR TITLE
fix(cloud-api): drop stale affiliate per-key-permission e2e test

### DIFF
--- a/packages/cloud-api/test/e2e/group-k-affiliate.test.ts
+++ b/packages/cloud-api/test/e2e/group-k-affiliate.test.ts
@@ -46,19 +46,6 @@ describe("Group K — /api/affiliate/create-character", () => {
     expect(body.details).toBeUndefined();
   });
 
-  test("standard API key is forbidden without affiliate permission", async () => {
-    const res = await api.post(
-      "/api/affiliate/create-character",
-      {
-        character: { name: "Forbidden Affiliate Character" },
-        affiliateId: "worker-e2e",
-      },
-      { headers: bearerHeaders() },
-    );
-    expect(res.status).toBe(403);
-    expect(res.status).not.toBe(501);
-  });
-
   test("affiliate API key creates a real character", async () => {
     const res = await api.post(
       "/api/affiliate/create-character",


### PR DESCRIPTION
## What

`cloud-cf-deploy` has been red on `develop` since `bc4bb287d` — the **only** failing test is `group-k-affiliate.test.ts` → *"standard API key is forbidden without affiliate permission"* (expects 403).

That commit (and the follow-up `1cfc258e33`) intentionally removed per-key permission scopes. The `create-character` route now says it outright:

> `// Any valid, active API key for the owner's org may create affiliate characters — a key is just a key with full access (no per-key scopes).`

So the standard key now returns 201, not 403 — the assertion is stale. The middleware (`api-key-permission.ts`) and the other test references were already cleaned up in `bc4bb287d`; this one test file was just missed.

## Change

Remove the obsolete `forbidden without affiliate permission` test. The happy-path (201) and missing-auth (401) cases still cover the route. `bearerHeaders` stays referenced (setup + import), no orphan.

This greens the API Worker `test:e2e` and unblocks the `develop → main` promote.

cc @lalalune — finishing the api-key permission-scope removal from `bc4bb287d`.