### PR TITLE
fix(cloud): restore stable prod UI + api-key permission layer to staging (revert dexplorer slop)

### DIFF
--- a/packages/cloud-api/__tests__/middleware-auth-soc2.test.ts
+++ b/packages/cloud-api/__tests__/middleware-auth-soc2.test.ts
@@ -1,6 +1,7 @@
 /**
  * Unit tests for SOC2 auth-hardening middleware:
  *   - `assertOrgMembership` (cross-org IDOR closure)
+ *   - `requireApiKeyPermission` (API-key permission enforcement)
  *
  * These are pure middleware/helper tests — no Worker, no DB. The global
  * audit dispatcher is swapped for an in-memory sink so we can verify
@@ -11,10 +12,24 @@ import { beforeEach, describe, expect, test } from "bun:test";
 import { AuditDispatcher, InMemorySink } from "@elizaos/security/audit";
 import { Hono } from "hono";
 
+// Import from the dedicated `api-key-permission` module — not `auth.ts` —
+// so this test does not pull in the global auth-gate's transitive deps
+// (which are mocked-out by another test file in the same bun process).
+import { requireApiKeyPermission } from "../src/middleware/api-key-permission";
 import { assertOrgMembership } from "../src/middleware/org-membership";
 import { setAuditDispatcher } from "../src/services/audit-dispatcher-singleton";
 
 let sink: InMemorySink;
+
+type ApiKeyTestVariables = {
+  authMethod?: "api_key";
+  apiKeyId?: string;
+  apiKeyPermissions?: string[];
+  user?: {
+    id: string;
+    organization_id: string | null;
+  };
+};
 
 function errorStatus(err: Error): 403 | 500 {
   return err && typeof err === "object" && "status" in err
@@ -87,5 +102,89 @@ describe("assertOrgMembership", () => {
     const events = sink.snapshot();
     expect(events).toHaveLength(1);
     expect(events[0]?.action).toBe("secret.access");
+  });
+});
+
+describe("requireApiKeyPermission", () => {
+  function buildApp(perm: string) {
+    const app = new Hono<{ Variables: ApiKeyTestVariables }>();
+    app.use("*", requireApiKeyPermission(perm));
+    app.get("/", (c) => c.json({ ok: true }));
+    app.onError((err, c) => c.json({ error: err.message }, errorStatus(err)));
+    return app;
+  }
+
+  test("session-auth requests pass through (no permission check)", async () => {
+    const app = buildApp("agents:write");
+    // No authMethod set — same as session auth context.
+    const res = await app.request("/");
+    expect(res.status).toBe(200);
+  });
+
+  test("exact permission match passes", async () => {
+    const app = new Hono<{ Variables: ApiKeyTestVariables }>();
+    app.use("*", async (c, next) => {
+      c.set("authMethod", "api_key");
+      c.set("apiKeyId", "key-1");
+      c.set("apiKeyPermissions", ["agents:write"]);
+      await next();
+    });
+    app.use("*", requireApiKeyPermission("agents:write"));
+    app.get("/", (c) => c.json({ ok: true }));
+    const res = await app.request("/");
+    expect(res.status).toBe(200);
+  });
+
+  test("wildcard '*' grants any permission", async () => {
+    const app = new Hono<{ Variables: ApiKeyTestVariables }>();
+    app.use("*", async (c, next) => {
+      c.set("authMethod", "api_key");
+      c.set("apiKeyId", "key-1");
+      c.set("apiKeyPermissions", ["*"]);
+      await next();
+    });
+    app.use("*", requireApiKeyPermission("agents:write"));
+    app.get("/", (c) => c.json({ ok: true }));
+    const res = await app.request("/");
+    expect(res.status).toBe(200);
+  });
+
+  test("prefix wildcard grants matching scope", async () => {
+    const app = new Hono<{ Variables: ApiKeyTestVariables }>();
+    app.use("*", async (c, next) => {
+      c.set("authMethod", "api_key");
+      c.set("apiKeyId", "key-1");
+      c.set("apiKeyPermissions", ["agents:*"]);
+      await next();
+    });
+    app.use("*", requireApiKeyPermission("agents:write"));
+    app.get("/", (c) => c.json({ ok: true }));
+    const res = await app.request("/");
+    expect(res.status).toBe(200);
+  });
+
+  test("missing permission returns 403 + emits denied audit", async () => {
+    const app = new Hono<{ Variables: ApiKeyTestVariables }>();
+    app.use("*", async (c, next) => {
+      c.set("authMethod", "api_key");
+      c.set("apiKeyId", "key-1");
+      c.set("apiKeyPermissions", ["containers:deploy"]);
+      c.set("user", {
+        id: "user-1",
+        organization_id: "org-A",
+      });
+      await next();
+    });
+    app.use("*", requireApiKeyPermission("agents:write"));
+    app.get("/", (c) => c.json({ ok: true }));
+    app.onError((err, c) => c.json({ error: err.message }, errorStatus(err)));
+    const res = await app.request("/");
+    expect(res.status).toBe(403);
+    const events = sink.snapshot();
+    expect(events).toHaveLength(1);
+    expect(events[0]?.action).toBe("api_key.use");
+    expect(events[0]?.result).toBe("denied");
+    expect(events[0]?.actor.type).toBe("api_key");
+    expect(events[0]?.actor.id).toBe("key-1");
   });
 });

--- a/packages/cloud-api/affiliate/create-character/route.ts
+++ b/packages/cloud-api/affiliate/create-character/route.ts
@@ -1,7 +1,7 @@
 /**
  * POST /api/affiliate/create-character
  * Affiliate API endpoint for creating characters without requiring user signup.
- * Requires any valid, active API key (a key is just a key — full access).
+ * Requires an API key whose `permissions` include `affiliate:create-character`.
  *
  * This Workers port performs URL pass-through for image inputs: HTTP(S) URLs
  * in `character.avatar_url` and `metadata.imageUrls` are kept verbatim, and
@@ -28,6 +28,7 @@ import { getCorsHeaders } from "@/lib/utils/cors";
 import { logger } from "@/lib/utils/logger";
 import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
 
+const AFFILIATE_PERMISSION = "affiliate:create-character";
 const SESSION_TTL_DAYS = 7;
 const ANON_USER_TTL_MS = SESSION_TTL_DAYS * 24 * 60 * 60 * 1000;
 
@@ -123,8 +124,14 @@ async function authenticateAffiliate(c: AppContext) {
     throw AuthenticationError("API key has expired");
   }
 
-  // Any valid, active API key for the owner's org may create affiliate
-  // characters — a key is just a key with full access (no per-key scopes).
+  const permissions = Array.isArray(apiKey.permissions)
+    ? apiKey.permissions
+    : [];
+  if (!permissions.includes(AFFILIATE_PERMISSION)) {
+    throw ForbiddenError(
+      "This API key does not have permission to create characters via affiliate API",
+    );
+  }
   return apiKey;
 }
 

--- a/packages/cloud-api/src/middleware/api-key-permission.ts
+++ b/packages/cloud-api/src/middleware/api-key-permission.ts
@@ -1,0 +1,115 @@
+/**
+ * Per-route API-key permission scoping.
+ *
+ * `enforceApiKeyPermission(c, scope)` is the canonical check: it inspects the
+ * auth context populated by `requireUserOrApiKeyWithOrg` (`authMethod`,
+ * `apiKeyPermissions`) and throws `ForbiddenError` when an API key lacks the
+ * required scope. Call it INSIDE a handler, immediately after auth resolves —
+ * the auth context is only set once `requireUserOrApiKeyWithOrg` runs, so a
+ * pre-handler middleware would see `authMethod === undefined` and silently
+ * pass every request.
+ *
+ * `requireApiKeyPermission(scope)` is the Hono-middleware wrapper, used by
+ * routes whose handlers reject API keys outright (session-only management
+ * endpoints): the scope never matters for an API key because those handlers
+ * call `requireUserWithOrg`, so a no-op-on-undefined middleware is correct
+ * there. Do NOT use the middleware form on a route that accepts API keys.
+ *
+ * Session-authenticated (cookie / Steward JWT) requests are not scoped here —
+ * they are governed by user role + org-membership checks instead.
+ *
+ * Permission match rules:
+ *   - `*` (wildcard) on the key grants every permission.
+ *   - Exact-string match.
+ *   - Hierarchical prefix match: a key with `agents:*` grants `agents:write`.
+ *
+ * Denied requests emit an `api_key.use` audit event with `result: "denied"`.
+ */
+
+import type { MiddlewareHandler } from "hono";
+
+import { ForbiddenError } from "@/lib/api/cloud-worker-errors";
+import { logger } from "@/lib/utils/logger";
+import type { AppContext, AppEnv } from "@/types/cloud-worker-env";
+import { getAuditDispatcher } from "../services/audit-dispatcher-singleton";
+
+function isPermissionGranted(perms: string[], permission: string): boolean {
+  return perms.some(
+    (p) =>
+      p === "*" ||
+      p === permission ||
+      (p.endsWith(":*") && permission.startsWith(p.slice(0, -1))),
+  );
+}
+
+async function denyMissingPermission(
+  c: AppContext,
+  permission: string,
+  perms: string[],
+): Promise<never> {
+  const user = c.get("user");
+  const apiKeyId = c.get("apiKeyId");
+  try {
+    await getAuditDispatcher().emit({
+      actor: { type: "api_key", id: apiKeyId ?? "unknown" },
+      action: "api_key.use",
+      result: "denied",
+      resource: { type: "permission", id: permission },
+      org_id: user?.organization_id ?? undefined,
+      ip: c.req.header("x-forwarded-for")?.split(",")[0]?.trim() ?? undefined,
+      user_agent: c.req.header("user-agent") ?? undefined,
+      request_id: c.get("requestId"),
+      metadata: {
+        key_id: apiKeyId ?? "unknown",
+        scopes: perms,
+        reason: "missing_permission",
+      },
+    });
+  } catch (err) {
+    logger.warn("[requireApiKeyPermission] audit emit failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  throw ForbiddenError(`API key missing required permission: ${permission}`);
+}
+
+/**
+ * Enforce an API-key scope from inside a handler, after auth has resolved.
+ * No-op for session-authenticated requests.
+ */
+export async function enforceApiKeyPermission(
+  c: AppContext,
+  permission: string,
+): Promise<void> {
+  if (c.get("authMethod") !== "api_key") return;
+
+  const perms = c.get("apiKeyPermissions") ?? [];
+  if (isPermissionGranted(perms, permission)) return;
+
+  await denyMissingPermission(c, permission, perms);
+}
+
+/**
+ * Hono-middleware form for session-only management routes. See file header:
+ * do not use this on a route that accepts API keys (it cannot see the key's
+ * permissions because they are not resolved until the handler runs).
+ */
+export function requireApiKeyPermission(
+  permission: string,
+): MiddlewareHandler<AppEnv> {
+  return async (c, next) => {
+    if (c.get("authMethod") !== "api_key") {
+      await next();
+      return;
+    }
+
+    const perms = c.get("apiKeyPermissions") ?? [];
+    if (isPermissionGranted(perms, permission)) {
+      await next();
+      return;
+    }
+
+    await denyMissingPermission(c, permission, perms);
+  };
+}

--- a/packages/cloud-api/src/middleware/auth.ts
+++ b/packages/cloud-api/src/middleware/auth.ts
@@ -211,3 +211,12 @@ export const authMiddleware: MiddlewareHandler<AppEnv> = async (c, next) => {
   }
   await next();
 };
+
+// Re-export `requireApiKeyPermission` from its dedicated module so existing
+// route imports (`@/api-app/middleware/auth`) continue to work, while tests
+// and new code can import from the standalone file without pulling in the
+// full auth-gate transitive deps.
+export {
+  enforceApiKeyPermission,
+  requireApiKeyPermission,
+} from "./api-key-permission";

--- a/packages/cloud-api/test/e2e/agent-token-flow.test.ts
+++ b/packages/cloud-api/test/e2e/agent-token-flow.test.ts
@@ -140,6 +140,7 @@ describe("Foundation: agent token flow", () => {
       {
         name: `agent-token-flow-${Date.now()}`,
         description: "Foundation e2e test — created and revoked in afterAll.",
+        permissions: ["read"],
         rate_limit: 60,
       },
       { headers: { Cookie: sessionCookie } },

--- a/packages/cloud-api/test/e2e/group-b-account-billing.test.ts
+++ b/packages/cloud-api/test/e2e/group-b-account-billing.test.ts
@@ -170,6 +170,7 @@ describe("POST /api/v1/api-keys/:id/regenerate", () => {
       {
         name: `group-b-regenerate-${Date.now()}`,
         description: "Group B regen test — revoked in afterAll.",
+        permissions: ["read"],
         rate_limit: 60,
       },
       { headers: { Cookie: sessionCookie } },

--- a/packages/cloud-api/test/e2e/preload.ts
+++ b/packages/cloud-api/test/e2e/preload.ts
@@ -155,6 +155,7 @@ async function ensureTestUser({
     description: "Local cloud API e2e test key",
     organization_id: organization.id,
     user_id: user.id,
+    permissions: ["read", "write", "admin"],
     rate_limit: 10_000,
     is_active: true,
   });
@@ -190,6 +191,7 @@ const { plainKey: affiliatePlainKey } = await apiKeysService.create({
   description: "Local cloud API affiliate e2e test key",
   organization_id: affiliate.organization.id,
   user_id: affiliate.user.id,
+  permissions: ["read", "write", "affiliate:create-character"],
   rate_limit: 10_000,
   is_active: true,
 });

--- a/packages/cloud-api/v1/agents/[agentId]/publish/route.ts
+++ b/packages/cloud-api/v1/agents/[agentId]/publish/route.ts
@@ -7,6 +7,7 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
+import { requireApiKeyPermission } from "@/api-app/middleware/auth";
 import { assertOrgMembership } from "@/api-app/middleware/org-membership";
 import { userCharactersRepository } from "@/db/repositories/characters";
 import {
@@ -20,6 +21,8 @@ import { logger } from "@/lib/utils/logger";
 import type { AppEnv } from "@/types/cloud-worker-env";
 
 const app = new Hono<AppEnv>();
+
+app.use("*", requireApiKeyPermission("agents:write"));
 
 const PublishSchema = z.object({
   enableMonetization: z.boolean().optional().default(false),

--- a/packages/cloud-api/v1/api-keys/[id]/regenerate/route.ts
+++ b/packages/cloud-api/v1/api-keys/[id]/regenerate/route.ts
@@ -3,6 +3,7 @@
  */
 
 import { Hono } from "hono";
+import { requireApiKeyPermission } from "@/api-app/middleware/auth";
 import { assertOrgMembership } from "@/api-app/middleware/org-membership";
 import { getAuditDispatcher } from "@/api-app/services/audit-dispatcher-singleton";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
@@ -18,6 +19,7 @@ import type { AppEnv } from "@/types/cloud-worker-env";
 const app = new Hono<AppEnv>();
 
 app.use("*", rateLimit(RateLimitPresets.STRICT));
+app.use("*", requireApiKeyPermission("keys:write"));
 
 app.post("/", async (c) => {
   try {
@@ -86,6 +88,7 @@ app.post("/", async (c) => {
         description: updatedKey.description,
         key_prefix: updatedKey.key_prefix,
         created_at: updatedKey.created_at,
+        permissions: updatedKey.permissions,
         rate_limit: updatedKey.rate_limit,
         expires_at: updatedKey.expires_at,
       },

--- a/packages/cloud-api/v1/api-keys/[id]/route.ts
+++ b/packages/cloud-api/v1/api-keys/[id]/route.ts
@@ -5,6 +5,7 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
+import { requireApiKeyPermission } from "@/api-app/middleware/auth";
 import { assertOrgMembership } from "@/api-app/middleware/org-membership";
 import { getAuditDispatcher } from "@/api-app/services/audit-dispatcher-singleton";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
@@ -22,6 +23,7 @@ import { updateApiKeySchema } from "../schemas";
 const app = new Hono<AppEnv>();
 
 app.use("*", rateLimit(RateLimitPresets.STANDARD));
+app.use("*", requireApiKeyPermission("keys:write"));
 
 function isAgentSandboxKeyName(name: string): boolean {
   return name.startsWith("agent-sandbox:");
@@ -79,8 +81,14 @@ app.patch("/", async (c) => {
     });
 
     const body = await c.req.json();
-    const { name, description, rate_limit, is_active, expires_at } =
-      updateApiKeySchema.parse(body);
+    const {
+      name,
+      description,
+      permissions,
+      rate_limit,
+      is_active,
+      expires_at,
+    } = updateApiKeySchema.parse(body);
 
     if (name !== undefined && isAgentSandboxKeyName(name)) {
       return c.json(
@@ -95,6 +103,7 @@ app.patch("/", async (c) => {
     const updatedKey = await apiKeysService.update(id, {
       ...(name !== undefined && { name }),
       ...(description !== undefined && { description }),
+      ...(permissions !== undefined && { permissions }),
       ...(rate_limit !== undefined && { rate_limit }),
       ...(is_active !== undefined && { is_active }),
       ...(expires_at !== undefined && { expires_at }),
@@ -109,6 +118,7 @@ app.patch("/", async (c) => {
         description: updatedKey.description,
         key_prefix: updatedKey.key_prefix,
         created_at: updatedKey.created_at,
+        permissions: updatedKey.permissions,
         rate_limit: updatedKey.rate_limit,
         is_active: updatedKey.is_active,
         expires_at: updatedKey.expires_at,

--- a/packages/cloud-api/v1/api-keys/explorer/route.ts
+++ b/packages/cloud-api/v1/api-keys/explorer/route.ts
@@ -37,6 +37,7 @@ app.get("/", async (c) => {
         "Auto-generated key for testing APIs in the API Explorer. Usage is billed to your account.",
       organization_id: user.organization_id,
       user_id: user.id,
+      permissions: [],
       rate_limit: 100,
       expires_at: null,
       is_active: true,

--- a/packages/cloud-api/v1/api-keys/route.ts
+++ b/packages/cloud-api/v1/api-keys/route.ts
@@ -7,6 +7,7 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
+import { requireApiKeyPermission } from "@/api-app/middleware/auth";
 import { getAuditDispatcher } from "@/api-app/services/audit-dispatcher-singleton";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserWithOrg } from "@/lib/auth/workers-hono-auth";
@@ -23,6 +24,8 @@ import { createApiKeySchema } from "./schemas";
 const app = new Hono<AppEnv>();
 
 app.use("*", rateLimit(RateLimitPresets.STANDARD));
+// Create/list both require keys:write — managing keys is a privileged op.
+app.use("*", requireApiKeyPermission("keys:write"));
 
 function isAgentSandboxKeyName(name: string): boolean {
   return name.startsWith("agent-sandbox:");
@@ -36,6 +39,7 @@ function toClientApiKey(
     name: apiKey.name,
     description: apiKey.description,
     key_prefix: apiKey.key_prefix,
+    permissions: apiKey.permissions,
     rate_limit: apiKey.rate_limit,
     is_active: apiKey.is_active,
     usage_count: apiKey.usage_count,
@@ -60,7 +64,7 @@ app.post("/", async (c) => {
   try {
     const user = await requireUserWithOrg(c);
     const body = await c.req.json();
-    const { name, description, rate_limit, expires_at } =
+    const { name, description, permissions, rate_limit, expires_at } =
       createApiKeySchema.parse(body);
 
     if (isAgentSandboxKeyName(name)) {
@@ -78,6 +82,7 @@ app.post("/", async (c) => {
       description,
       organization_id: user.organization_id,
       user_id: user.id,
+      permissions,
       rate_limit,
       expires_at: expires_at ?? null,
       is_active: true,
@@ -94,6 +99,7 @@ app.post("/", async (c) => {
         metadata: {
           key_id: apiKey.id,
           name: apiKey.name,
+          scopes: apiKey.permissions ?? [],
         },
       })
       .catch((err: unknown) => {
@@ -110,6 +116,7 @@ app.post("/", async (c) => {
           description: apiKey.description,
           key_prefix: apiKey.key_prefix,
           created_at: apiKey.created_at,
+          permissions: apiKey.permissions,
           rate_limit: apiKey.rate_limit,
           expires_at: apiKey.expires_at,
         },

--- a/packages/cloud-api/v1/api-keys/schemas.ts
+++ b/packages/cloud-api/v1/api-keys/schemas.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+const permissionsSchema = z.array(z.string().trim().min(1)).max(50);
+
 const optionalExpiresAtSchema = z
   .union([z.string().trim().min(1), z.null()])
   .optional()
@@ -24,6 +26,7 @@ export const createApiKeySchema = z.object({
       const trimmed = value.trim();
       return trimmed.length ? trimmed : null;
     }),
+  permissions: permissionsSchema.default([]),
   rate_limit: z.coerce.number().int().min(1).max(100000).default(1000),
   expires_at: optionalExpiresAtSchema,
 });
@@ -40,6 +43,7 @@ export const updateApiKeySchema = z
         const trimmed = value.trim();
         return trimmed.length ? trimmed : null;
       }),
+    permissions: permissionsSchema.optional(),
     rate_limit: z.coerce.number().int().min(1).max(100000).optional(),
     is_active: z.boolean().optional(),
     expires_at: optionalExpiresAtSchema,

--- a/packages/cloud-api/v1/containers/route.test.ts
+++ b/packages/cloud-api/v1/containers/route.test.ts
@@ -4,6 +4,7 @@ import { type Context, Hono } from "hono";
 type TestVariables = {
   authMethod?: "api_key" | "session";
   apiKeyId?: string;
+  apiKeyPermissions?: string[];
   user?: { id: string; organization_id: string };
 };
 
@@ -17,14 +18,29 @@ type ContainersBody = {
 
 /**
  * Auth resolution sets the API-key context the same way the real
- * `requireUserOrApiKeyWithOrg` does. A key is just a key with full access — no
- * per-key scopes — so the route does no scope enforcement; this mock only needs
- * to resolve the user + org.
+ * `requireUserOrApiKeyWithOrg` does: `authMethod` + `apiKeyPermissions` come
+ * from the validated key, NOT from a route-level middleware. The route enforces
+ * the scope INSIDE the handler via the REAL `enforceApiKeyPermission`, so this
+ * mock populates the context for that check to fire. A handler that forgot to
+ * call `enforceApiKeyPermission` after auth would fail the 403 tests below —
+ * which is the production regression this suite must catch.
  */
 const requireUserOrApiKeyWithOrg = mock(
   async (c: Context<{ Variables: TestVariables }>) => {
-    c.set("authMethod", "api_key");
-    c.set("apiKeyId", "key-1");
+    const permissionsHeader = c.req.header("x-test-api-key-permissions");
+    if (permissionsHeader !== undefined) {
+      c.set("authMethod", "api_key");
+      c.set("apiKeyId", "key-1");
+      c.set(
+        "apiKeyPermissions",
+        permissionsHeader
+          .split(",")
+          .map((permission: string) => permission.trim())
+          .filter(Boolean),
+      );
+    } else {
+      c.set("authMethod", "session");
+    }
     c.set("user", { id: "user-1", organization_id: "org-1" });
     return { id: "user-1", organization_id: "org-1" };
   },
@@ -38,6 +54,9 @@ const createContainer = mock();
 const codingContainerImageAllowlist = mock(() => ["ghcr.io/elizaos/*"]);
 const auditEmit = mock(async () => undefined);
 
+// Use the REAL enforceApiKeyPermission / requireApiKeyPermission from
+// `@/api-app/middleware/auth`; only stub its audit dependency so a denied
+// request does not need a live dispatcher.
 mock.module("@/api-app/services/audit-dispatcher-singleton", () => ({
   getAuditDispatcher: () => ({ emit: auditEmit }),
 }));
@@ -169,10 +188,24 @@ describe("containers route", () => {
     auditEmit.mockClear();
   });
 
-  test("returns CloudContainer data on list for any valid key", async () => {
+  test("rejects an API key without containers:read on list (real enforcement)", async () => {
+    const response = await app.request("/api/v1/containers", {
+      headers: { "x-test-api-key-permissions": "agents:read" },
+    });
+
+    expect(response.status).toBe(403);
+    // The handler reached enforceApiKeyPermission AFTER auth resolved; if it
+    // skipped enforcement the data service would have been hit.
+    expect(listByOrganization).not.toHaveBeenCalled();
+    expect(auditEmit).toHaveBeenCalledTimes(1);
+  });
+
+  test("allows a wildcard-scoped API key and returns CloudContainer data", async () => {
     listByOrganization.mockResolvedValue([rawContainer()]);
 
-    const response = await app.request("/api/v1/containers");
+    const response = await app.request("/api/v1/containers", {
+      headers: { "x-test-api-key-permissions": "containers:*" },
+    });
 
     expect(response.status).toBe(200);
     const body = (await response.json()) as ContainersBody;
@@ -189,7 +222,9 @@ describe("containers route", () => {
   test("redacts secret and infrastructure fields from list responses", async () => {
     listByOrganization.mockResolvedValue([rawContainer()]);
 
-    const response = await app.request("/api/v1/containers");
+    const response = await app.request("/api/v1/containers", {
+      headers: { "x-test-api-key-permissions": "containers:read" },
+    });
 
     expect(response.status).toBe(200);
     const body = (await response.json()) as ContainersBody;
@@ -204,6 +239,24 @@ describe("containers route", () => {
     expect(body.data[0]).not.toHaveProperty("user_id");
   });
 
+  test("rejects an API key without containers:deploy on POST (real enforcement)", async () => {
+    const response = await app.request("/api/v1/containers", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-test-api-key-permissions": "containers:read",
+      },
+      body: JSON.stringify({
+        name: "App",
+        image: "ghcr.io/elizaos/app:latest",
+      }),
+    });
+
+    expect(response.status).toBe(403);
+    expect(getActiveByProjectName).not.toHaveBeenCalled();
+    expect(createContainer).not.toHaveBeenCalled();
+  });
+
   test("provisions and returns the deployed container under `data`", async () => {
     getActiveByProjectName.mockResolvedValue(null);
     checkQuota.mockResolvedValue({ allowed: true });
@@ -211,7 +264,10 @@ describe("containers route", () => {
 
     const response = await app.request("/api/v1/containers", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        "x-test-api-key-permissions": "containers:deploy",
+      },
       body: JSON.stringify({
         name: "App",
         image: "ghcr.io/elizaos/app:latest",
@@ -236,7 +292,10 @@ describe("containers route", () => {
 
     const response = await app.request("/api/v1/containers", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        "x-test-api-key-permissions": "containers:deploy",
+      },
       body: JSON.stringify({
         name: "App",
         projectName: "app",

--- a/packages/cloud-api/v1/containers/route.ts
+++ b/packages/cloud-api/v1/containers/route.ts
@@ -38,6 +38,7 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
+import { enforceApiKeyPermission } from "@/api-app/middleware/auth";
 import { failureResponse } from "@/lib/api/cloud-worker-errors";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { containersEnv } from "@/lib/config/containers-env";
@@ -181,6 +182,7 @@ function toContainerDto(container: Container | ContainerSummary): ContainerDto {
 app.get("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
+    await enforceApiKeyPermission(c, "containers:read");
     const containers = await containersService.listByOrganization(
       user.organization_id,
     );
@@ -194,6 +196,7 @@ app.get("/", async (c) => {
 app.get("/quota", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
+    await enforceApiKeyPermission(c, "containers:read");
     const quota = await containersService.checkQuota(user.organization_id);
     return c.json({ success: true, quota });
   } catch (error) {
@@ -205,6 +208,7 @@ app.get("/quota", async (c) => {
 app.get("/:id", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
+    await enforceApiKeyPermission(c, "containers:read");
     const container = await containersService.getById(
       c.req.param("id"),
       user.organization_id,
@@ -222,6 +226,7 @@ app.get("/:id", async (c) => {
 app.post("/", async (c) => {
   try {
     const user = await requireUserOrApiKeyWithOrg(c);
+    await enforceApiKeyPermission(c, "containers:deploy");
     const parsed = CreateContainerSchema.safeParse(
       await c.req.json().catch(() => null),
     );

--- a/packages/cloud-frontend/src/components/canvas/cloud-canvas.tsx
+++ b/packages/cloud-frontend/src/components/canvas/cloud-canvas.tsx
@@ -19,11 +19,13 @@ import {
   Eye,
   EyeOff,
   FileCode,
+  Fingerprint,
   Globe,
   Grid,
   Key,
   Link2,
   Loader2,
+  Lock,
   MessageSquare,
   Plug,
   Plus,
@@ -466,6 +468,13 @@ function PremiumNodeRenderer({
     location.pathname,
   ]);
 
+  // Biometric verification state for sensitive nodes
+  const [isBiometricsVerified, setIsBiometricsVerified] = useState(false);
+  const [verificationState, setVerificationState] = useState<
+    "idle" | "scanning" | "success" | "failed"
+  >("idle");
+  const [scanProgress, setScanProgress] = useState(0);
+
   // API Keys editing and import states
   const [editingKeyId, setEditingKeyId] = useState<string | null>(null);
   const [editingKeyName, setEditingKeyName] = useState("");
@@ -816,11 +825,21 @@ function PremiumNodeRenderer({
               description: `Pasted via Quick Set`,
             });
           } else {
+            let permissions = "read_write";
+            if (
+              ["full_admin", "admin", "full"].includes(valOrScope.toLowerCase())
+            ) {
+              permissions = "full_admin";
+            } else if (
+              ["read_only", "read"].includes(valOrScope.toLowerCase())
+            ) {
+              permissions = "read_only";
+            }
             const res = await api<{ apiKey: any; plainKey: string }>(
               "/api/v1/api-keys",
               {
                 method: "POST",
-                json: { name },
+                json: { name, permissions: [permissions] },
               },
             );
             if (res?.plainKey) {
@@ -828,11 +847,12 @@ function PremiumNodeRenderer({
             }
           }
         } else {
+          // Eliza Cloud Key without scope
           const res = await api<{ apiKey: any; plainKey: string }>(
             "/api/v1/api-keys",
             {
               method: "POST",
-              json: { name: line },
+              json: { name: line, permissions: ["read_write"] },
             },
           );
           if (res?.plainKey) {
@@ -889,6 +909,100 @@ function PremiumNodeRenderer({
       setIsSavingQuickPaste(false);
     }
   }, [quickPasteText, apiKeysQuery]);
+
+  const startVerification = useCallback(async () => {
+    setVerificationState("scanning");
+    setScanProgress(0);
+
+    let currentProgress = 0;
+    const progressInterval = setInterval(() => {
+      currentProgress += 5;
+      setScanProgress(Math.min(currentProgress, 90));
+    }, 50);
+
+    try {
+      if (typeof window !== "undefined" && window.PublicKeyCredential) {
+        const savedCredIdHex = localStorage.getItem(
+          "eliza_cloud_biometric_cred_id",
+        );
+        let credential: any;
+        const challenge = new Uint8Array(32);
+        window.crypto.getRandomValues(challenge);
+
+        if (savedCredIdHex) {
+          const credId = new Uint8Array(
+            savedCredIdHex
+              .match(/.{1,2}/g)
+              ?.map((byte) => parseInt(byte, 16)) || [],
+          );
+          credential = await navigator.credentials.get({
+            publicKey: {
+              challenge,
+              rpId: window.location.hostname,
+              allowCredentials: [
+                {
+                  type: "public-key",
+                  id: credId,
+                },
+              ],
+              userVerification: "required",
+              timeout: 60000,
+            },
+          });
+        } else {
+          credential = await navigator.credentials.create({
+            publicKey: {
+              challenge,
+              rp: {
+                name: "elizaOS Cloud",
+                id: window.location.hostname,
+              },
+              user: {
+                id: new Uint8Array([1, 2, 3, 4]),
+                name: "admin@eliza.cloud",
+                displayName: "elizaOS Administrator",
+              },
+              pubKeyCredParams: [
+                { alg: -7, type: "public-key" },
+                { alg: -257, type: "public-key" },
+              ],
+              authenticatorSelection: {
+                authenticatorAttachment: "platform",
+                userVerification: "required",
+                requireResidentKey: false,
+              },
+              timeout: 60000,
+            },
+          });
+
+          if (credential && "rawId" in credential) {
+            const rawIdBytes = new Uint8Array(credential.rawId);
+            const hexId = Array.from(rawIdBytes)
+              .map((b) => b.toString(16).padStart(2, "0"))
+              .join("");
+            localStorage.setItem("eliza_cloud_biometric_cred_id", hexId);
+          }
+        }
+
+        if (credential) {
+          clearInterval(progressInterval);
+          setScanProgress(100);
+          setVerificationState("success");
+          setTimeout(() => {
+            setIsBiometricsVerified(true);
+          }, 800);
+        } else {
+          throw new Error("No credential returned");
+        }
+      } else {
+        throw new Error("WebAuthn not supported");
+      }
+    } catch (error) {
+      clearInterval(progressInterval);
+      setVerificationState("failed");
+      console.error("Biometric verification error:", error);
+    }
+  }, []);
 
   // Containers state
   const [containers, setContainers] = useState<any[]>([]);
@@ -1029,6 +1143,7 @@ function PremiumNodeRenderer({
   });
   const [showApiKey, setShowApiKey] = useState(false);
   const [newKeyName, setNewKeyName] = useState("");
+  const [newKeyScope, setNewKeyScope] = useState("read_write");
   const [_mcpConfig, _setMcpConfig] = useState(
     JSON.stringify(
       {
@@ -1157,6 +1272,155 @@ function PremiumNodeRenderer({
   const agents = agentsQuery?.data ?? [];
   const apiKeys = apiKeysQuery?.data ?? [];
   const balance = creditBalance ?? 0;
+
+  // Biometric scanner check for sensitive API Keys node
+  if (node.type === "apikeys" && !isBiometricsVerified) {
+    return (
+      <div className="w-full h-full min-h-[240px] flex flex-col items-center justify-center p-6 text-center select-none bg-black/40 backdrop-blur-md rounded-xl relative overflow-hidden border border-white/10 animate-fade-in">
+        {/* CSS styles for the scan laser line */}
+        <style>{`
+          @keyframes scan-laser {
+            0% { top: 0%; opacity: 0; }
+            10% { opacity: 1; }
+            90% { opacity: 1; }
+            100% { top: 100%; opacity: 0; }
+          }
+          @keyframes ring-spin {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
+          }
+          .animate-scan-laser {
+            animation: scan-laser 2s ease-in-out infinite;
+          }
+          .animate-ring-spin {
+            animation: ring-spin 8s linear infinite;
+          }
+        `}</style>
+
+        {/* Hexagonal grid / security ambient background */}
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(255,88,0,0.05)_0%,transparent_70%)] pointer-events-none" />
+
+        {/* Scanner container */}
+        <div className="relative flex items-center justify-center w-28 h-28 mb-4">
+          {/* External decorative spinning circular rings */}
+          <div
+            className={`absolute inset-0 border border-dashed border-[#FF5800]/20 rounded-full ${verificationState === "scanning" ? "animate-ring-spin border-[#FF5800]/40" : ""}`}
+          />
+          <div
+            className={`absolute inset-2 border border-double border-white/5 rounded-full ${verificationState === "scanning" ? "border-emerald-500/20" : ""}`}
+          />
+
+          {/* Central Scanning Frame */}
+          <div
+            className={`relative w-20 h-20 rounded-2xl flex items-center justify-center border transition-all duration-300 bg-white/[0.02] ${
+              verificationState === "scanning"
+                ? "border-[#FF5800] shadow-[0_0_15px_rgba(255,88,0,0.2)] bg-[#FF5800]/5"
+                : verificationState === "success"
+                  ? "border-emerald-500 shadow-[0_0_15px_rgba(16,185,129,0.3)] bg-emerald-500/10"
+                  : verificationState === "failed"
+                    ? "border-rose-500 shadow-[0_0_15px_rgba(239,68,68,0.3)] bg-rose-500/10"
+                    : "border-white/10 hover:border-white/20"
+            }`}
+          >
+            {/* Holographic scanning laser line */}
+            {verificationState === "scanning" && (
+              <div className="absolute left-0 right-0 h-0.5 bg-[#FF5800] shadow-[0_0_8px_#FF5800] animate-scan-laser z-10" />
+            )}
+
+            {verificationState === "success" ? (
+              <svg
+                className="w-10 h-10 text-emerald-400 stroke-current animate-bounce"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth="3"
+                role="img"
+                aria-label="Success"
+              >
+                <title>Success</title>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M5 13l4 4L19 7"
+                />
+              </svg>
+            ) : (
+              <Fingerprint
+                className={`w-10 h-10 transition-all duration-300 ${
+                  verificationState === "scanning"
+                    ? "text-[#FF5800] scale-110"
+                    : verificationState === "failed"
+                      ? "text-rose-500"
+                      : "text-white/40 hover:text-white/60"
+                }`}
+              />
+            )}
+          </div>
+        </div>
+
+        {/* Text Header */}
+        <div className="z-10 max-w-sm mb-5">
+          <h3 className="text-sm font-bold tracking-wide text-white flex items-center justify-center gap-1.5">
+            <Lock className="w-3.5 h-3.5 text-[#FF5800]" />
+            {verificationState === "scanning"
+              ? "Biometric Scanning..."
+              : verificationState === "success"
+                ? "Access Granted"
+                : verificationState === "failed"
+                  ? "Verification Failed"
+                  : "Security Verification"}
+          </h3>
+          <p className="text-[11px] text-white/50 mt-1 leading-relaxed">
+            {verificationState === "scanning"
+              ? `Simulating local hardware credential handshake (${scanProgress}%)`
+              : verificationState === "success"
+                ? "Secure tunnel established. Decoding keys..."
+                : verificationState === "failed"
+                  ? "Biometric scan cancelled or not supported in this browser context."
+                  : "Verify your identity via Touch ID or Face ID to manage elizaOS Cloud API keys."}
+          </p>
+        </div>
+
+        {/* Verification Button */}
+        {verificationState === "idle" && (
+          <button
+            type="button"
+            onClick={startVerification}
+            className="px-5 py-2 text-xs font-bold text-black bg-[#FF5800] rounded-xl hover:bg-[#ff7426] active:scale-[0.98] transition-all shadow-[0_4px_12px_rgba(255,88,0,0.2)] hover:shadow-[0_4px_20px_rgba(255,88,0,0.4)] cursor-pointer"
+          >
+            Scan Biometrics
+          </button>
+        )}
+
+        {verificationState === "failed" && (
+          <div className="flex flex-col gap-2 w-full max-w-xs">
+            <button
+              type="button"
+              onClick={startVerification}
+              className="px-5 py-2 text-xs font-bold text-black bg-[#FF5800] rounded-xl hover:bg-[#ff7426] active:scale-[0.98] transition-all shadow-[0_4px_12px_rgba(255,88,0,0.2)] hover:shadow-[0_4px_20px_rgba(255,88,0,0.4)] cursor-pointer"
+            >
+              Retry Biometrics
+            </button>
+            <button
+              type="button"
+              onClick={() => setIsBiometricsVerified(true)}
+              className="px-5 py-2 text-xs font-bold text-white/70 bg-white/5 border border-white/10 rounded-xl hover:bg-white/10 hover:text-white active:scale-[0.98] transition-all cursor-pointer"
+            >
+              Developer Bypass (Dev Mode)
+            </button>
+          </div>
+        )}
+
+        {verificationState === "scanning" && (
+          <div className="w-24 h-1 bg-white/10 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-[#FF5800] transition-all duration-100"
+              style={{ width: `${scanProgress}%` }}
+            />
+          </div>
+        )}
+      </div>
+    );
+  }
 
   // Render minimized view
   if (!isMaximized) {
@@ -2980,6 +3244,21 @@ function PremiumNodeRenderer({
                     />
                   </div>
 
+                  <div className="flex flex-col gap-1.5">
+                    <label className="font-mono text-[9px] text-white/40 uppercase font-bold">
+                      Scope Permissions
+                    </label>
+                    <select
+                      value={newKeyScope}
+                      onChange={(e) => setNewKeyScope(e.target.value)}
+                      className="bg-black/40 border border-white/10 rounded-lg px-3 py-1.5 text-white outline-none focus:border-[#FF5800]/50"
+                    >
+                      <option value="read_only">Read-Only Access</option>
+                      <option value="read_write">Read & Write Access</option>
+                      <option value="full_admin">Full Administrator</option>
+                    </select>
+                  </div>
+
                   <button
                     type="button"
                     onClick={async () => {
@@ -2988,7 +3267,10 @@ function PremiumNodeRenderer({
                         "/api/v1/api-keys",
                         {
                           method: "POST",
-                          json: { name: newKeyName },
+                          json: {
+                            name: newKeyName,
+                            permissions: [newKeyScope],
+                          },
                         },
                       );
                       if (res?.plainKey) {
@@ -3015,6 +3297,7 @@ function PremiumNodeRenderer({
                       <tr className="border-b border-white/5 text-left text-[10px] font-mono text-white/30 uppercase">
                         <th className="pb-2 font-medium">Name</th>
                         <th className="pb-2 font-medium">Token Prefix</th>
+                        <th className="pb-2 font-medium">Scope</th>
                         <th className="pb-2 font-medium">Usage</th>
                         <th className="pb-2 font-medium">Rate Limit</th>
                         <th className="pb-2 font-medium">Status</th>
@@ -3121,6 +3404,20 @@ function PremiumNodeRenderer({
                             </td>
                             <td className="py-2.5 text-white/40">
                               eliza_live_••••{k.token?.slice(-4) || "4a2b"}
+                            </td>
+                            <td className="py-2.5">
+                              <span
+                                className={`text-[9px] px-1.5 py-0.5 rounded border uppercase font-bold ${
+                                  k.permissions === "full_admin"
+                                    ? "bg-rose-500/10 border-rose-500/20 text-rose-400"
+                                    : k.permissions === "read_write"
+                                      ? "bg-amber-500/10 border-amber-500/20 text-amber-400"
+                                      : "bg-sky-500/10 border-sky-500/20 text-sky-400"
+                                }`}
+                              >
+                                {k.permissions?.replace("_", " ") ||
+                                  "read write"}
+                              </span>
                             </td>
                             <td className="py-2.5 text-white/70">
                               {Number(k.usage_count || 0).toLocaleString()}{" "}

--- a/packages/cloud-frontend/src/dashboard/api-keys/Page.tsx
+++ b/packages/cloud-frontend/src/dashboard/api-keys/Page.tsx
@@ -84,6 +84,7 @@ function ApiKeysPageContent({
     status: getApiKeyStatus(key.is_active, key.expires_at),
     lastUsedAt: key.last_used_at,
     createdAt: key.created_at,
+    permissions: key.permissions,
     usageCount: key.usage_count,
     rateLimit: key.rate_limit,
     expiresAt: key.expires_at,

--- a/packages/cloud-frontend/src/dashboard/api-keys/_components/api-keys-page-client.tsx
+++ b/packages/cloud-frontend/src/dashboard/api-keys/_components/api-keys-page-client.tsx
@@ -72,6 +72,72 @@ const rateLimitPresets = [
   },
 ] as const;
 
+const permissionGroups = [
+  {
+    titleKey: "cloud.apiKeys.permGroupCore",
+    defaultTitle: "Core",
+    permissions: [
+      {
+        id: "read",
+        labelKey: "cloud.apiKeys.permReadData",
+        defaultLabel: "Read data",
+      },
+      {
+        id: "write",
+        labelKey: "cloud.apiKeys.permWriteData",
+        defaultLabel: "Write data",
+      },
+      {
+        id: "usage",
+        labelKey: "cloud.apiKeys.permViewUsage",
+        defaultLabel: "View usage",
+      },
+    ],
+  },
+  {
+    titleKey: "cloud.apiKeys.permGroupGenerations",
+    defaultTitle: "Generations",
+    permissions: [
+      {
+        id: "text",
+        labelKey: "cloud.apiKeys.permTextGen",
+        defaultLabel: "Text generation",
+      },
+      {
+        id: "image",
+        labelKey: "cloud.apiKeys.permImageGen",
+        defaultLabel: "Image generation",
+      },
+      {
+        id: "video",
+        labelKey: "cloud.apiKeys.permVideoGen",
+        defaultLabel: "Video generation",
+      },
+    ],
+  },
+  {
+    titleKey: "cloud.apiKeys.permGroupManagement",
+    defaultTitle: "Management",
+    permissions: [
+      {
+        id: "billing",
+        labelKey: "cloud.apiKeys.permBilling",
+        defaultLabel: "Billing",
+      },
+      {
+        id: "team",
+        labelKey: "cloud.apiKeys.permTeam",
+        defaultLabel: "Team management",
+      },
+      {
+        id: "keys",
+        labelKey: "cloud.apiKeys.permManageKeys",
+        defaultLabel: "Manage API keys",
+      },
+    ],
+  },
+] as const;
+
 export function ApiKeysPageClient({ keys, summary }: ApiKeysPageClientProps) {
   const t = useT();
   const queryClient = useQueryClient();
@@ -82,6 +148,7 @@ export function ApiKeysPageClient({ keys, summary }: ApiKeysPageClientProps) {
   const [rateLimitPreset, setRateLimitPreset] =
     useState<(typeof rateLimitPresets)[number]["value"]>("standard");
   const [isCreating, setIsCreating] = useState(false);
+  const [selectedPermissions, setSelectedPermissions] = useState<string[]>([]);
   const [formData, setFormData] = useState({
     name: "",
     description: "",
@@ -136,6 +203,7 @@ export function ApiKeysPageClient({ keys, summary }: ApiKeysPageClientProps) {
       body: JSON.stringify({
         name: formData.name,
         description: formData.description,
+        permissions: selectedPermissions,
         rate_limit: rateLimit,
       }),
     });
@@ -155,6 +223,7 @@ export function ApiKeysPageClient({ keys, summary }: ApiKeysPageClientProps) {
     // local state so it remains visible after the list refetches.
     setCreatedKey({ plainKey: data.plainKey, name: data.apiKey.name });
     setFormData({ name: "", description: "", rate_limit: 1000 });
+    setSelectedPermissions([]);
     setRateLimitPreset("standard");
     setCreateDialogOpen(false);
     toast.success(
@@ -425,6 +494,50 @@ export function ApiKeysPageClient({ keys, summary }: ApiKeysPageClientProps) {
                 rows={3}
                 className="rounded-sm border-white/10 bg-black/40 text-white placeholder:text-white/40 focus:ring-1 focus:ring-[#FF5800] focus:border-[#FF5800]"
               />
+            </div>
+
+            <div className="grid gap-2">
+              <p className="text-xs font-medium text-white/70 uppercase tracking-wide">
+                {t("cloud.apiKeys.permissionsLabel", {
+                  defaultValue: "Permissions",
+                })}
+              </p>
+              <div className="grid gap-3 rounded-sm border border-white/10 bg-black/40 p-4">
+                {permissionGroups.map((group) => (
+                  <div key={group.titleKey} className="space-y-2">
+                    <p className="text-xs font-medium uppercase tracking-wide text-white/50">
+                      {t(group.titleKey, { defaultValue: group.defaultTitle })}
+                    </p>
+                    <div className="flex flex-wrap gap-2">
+                      {group.permissions.map((permission) => {
+                        const isSelected = selectedPermissions.includes(
+                          permission.id,
+                        );
+                        return (
+                          <BrandButton
+                            key={permission.id}
+                            type="button"
+                            variant={isSelected ? "primary" : "outline"}
+                            size="sm"
+                            className="text-xs"
+                            onClick={() => {
+                              setSelectedPermissions((prev) =>
+                                isSelected
+                                  ? prev.filter((p) => p !== permission.id)
+                                  : [...prev, permission.id],
+                              );
+                            }}
+                          >
+                            {t(permission.labelKey, {
+                              defaultValue: permission.defaultLabel,
+                            })}
+                          </BrandButton>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
 
             <div className="grid gap-2">

--- a/packages/cloud-frontend/src/dashboard/api-keys/_components/types.ts
+++ b/packages/cloud-frontend/src/dashboard/api-keys/_components/types.ts
@@ -8,6 +8,7 @@ export interface ApiKeyDisplay {
   status: ApiKeyStatus;
   lastUsedAt?: string | null;
   createdAt: string;
+  permissions: string[];
   usageCount: number;
   rateLimit: number;
   expiresAt?: string | null;

--- a/packages/cloud-frontend/src/dashboard/settings/_components/tabs/apis-tab.tsx
+++ b/packages/cloud-frontend/src/dashboard/settings/_components/tabs/apis-tab.tsx
@@ -134,6 +134,7 @@ export function ApisTab({ user: _user }: ApisTabProps) {
       body: JSON.stringify({
         name: formState.name.trim(),
         description: formState.description.trim() || undefined,
+        permissions: [],
         rate_limit: 1000,
       }),
     });
@@ -317,9 +318,11 @@ export function ApisTab({ user: _user }: ApisTabProps) {
                             {apiKey.name}
                           </h4>
                           <span className="px-2 py-0.5 bg-[rgba(255,88,0,0.25)] border border-[var(--brand-orange)]/40 text-[var(--brand-orange)] text-xs font-mono uppercase flex-shrink-0">
-                            {t("cloud.apisTab.all", {
-                              defaultValue: "All",
-                            })}
+                            {apiKey.permissions.length > 0
+                              ? apiKey.permissions.join(", ")
+                              : t("cloud.apisTab.all", {
+                                  defaultValue: "All",
+                                })}
                           </span>
                         </div>
                         {apiKey.description && (
@@ -474,9 +477,11 @@ export function ApisTab({ user: _user }: ApisTabProps) {
                                 {apiKey.name}
                               </h4>
                               <span className="px-2 py-0.5 bg-[rgba(255,88,0,0.25)] border border-[var(--brand-orange)]/40 text-[var(--brand-orange)] text-xs font-mono uppercase">
-                                {t("cloud.apisTab.all", {
-                                  defaultValue: "All",
-                                })}
+                                {apiKey.permissions.length > 0
+                                  ? apiKey.permissions.join(", ")
+                                  : t("cloud.apisTab.all", {
+                                      defaultValue: "All",
+                                    })}
                               </span>
                             </div>
                             {apiKey.description && (

--- a/packages/cloud-shared/src/db/migrations/0145_drop_api_key_permissions.sql
+++ b/packages/cloud-shared/src/db/migrations/0145_drop_api_key_permissions.sql
@@ -1,3 +1,0 @@
--- API keys no longer carry per-key permission scopes. A key is just a key with
--- full access for its organization; scope enforcement + the column are removed.
-ALTER TABLE api_keys DROP COLUMN IF EXISTS permissions;

--- a/packages/cloud-shared/src/db/migrations/meta/_journal.json
+++ b/packages/cloud-shared/src/db/migrations/meta/_journal.json
@@ -1002,13 +1002,6 @@
       "when": 1779409200000,
       "tag": "0144_domain_purchase_idempotency",
       "breakpoints": true
-    },
-    {
-      "idx": 143,
-      "version": "7",
-      "when": 1779495600000,
-      "tag": "0145_drop_api_key_permissions",
-      "breakpoints": true
     }
   ]
 }

--- a/packages/cloud-shared/src/db/schemas/api-keys.ts
+++ b/packages/cloud-shared/src/db/schemas/api-keys.ts
@@ -3,6 +3,7 @@ import {
   boolean,
   index,
   integer,
+  jsonb,
   pgTable,
   text,
   timestamp,
@@ -43,6 +44,7 @@ export const apiKeys = pgTable(
     user_id: uuid("user_id")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
+    permissions: jsonb("permissions").$type<string[]>().default([]).notNull(),
     rate_limit: integer("rate_limit").notNull().default(1000),
     is_active: boolean("is_active").notNull().default(true),
     usage_count: integer("usage_count").default(0).notNull(),

--- a/packages/cloud-shared/src/lib/auth/workers-hono-auth.ts
+++ b/packages/cloud-shared/src/lib/auth/workers-hono-auth.ts
@@ -406,8 +406,11 @@ export async function requireUserOrApiKeyWithOrg(c: AppContext): Promise<
     const authed = toAuthedUser(user);
     c.set("user", authed);
     c.set("authMethod", "api_key");
-    // Expose the validated key id for downstream attribution/audit.
+    // Expose the validated key id + permissions so downstream middleware
+    // (e.g. requireApiKeyPermission) can enforce scoped access without
+    // re-validating the key.
     c.set("apiKeyId", validated.id);
+    c.set("apiKeyPermissions", Array.isArray(validated.permissions) ? validated.permissions : []);
     return authed as AuthedUser & {
       organization_id: string;
       organization: NonNullable<AuthedUser["organization"]>;
@@ -440,6 +443,7 @@ export async function requireUserOrApiKey(c: AppContext): Promise<AuthedUser> {
     c.set("user", authed);
     c.set("authMethod", "api_key");
     c.set("apiKeyId", validated.id);
+    c.set("apiKeyPermissions", Array.isArray(validated.permissions) ? validated.permissions : []);
     return authed;
   }
 

--- a/packages/cloud-shared/src/lib/client/api-keys.ts
+++ b/packages/cloud-shared/src/lib/client/api-keys.ts
@@ -7,6 +7,7 @@ export interface ClientApiKey {
   name: string;
   description: string | null;
   key_prefix: string;
+  permissions: string[];
   rate_limit: number;
   is_active: boolean;
   usage_count: number;

--- a/packages/cloud-shared/src/lib/services/api-keys.ts
+++ b/packages/cloud-shared/src/lib/services/api-keys.ts
@@ -266,6 +266,7 @@ export class ApiKeysService {
       description: `Auto-generated sandbox key for agent ${params.agentSandboxId}`,
       organization_id: params.organizationId,
       user_id: params.userId,
+      permissions: ["agent"],
       rate_limit: 1000,
       is_active: true,
       expires_at: null,

--- a/packages/cloud-shared/src/lib/services/apps.ts
+++ b/packages/cloud-shared/src/lib/services/apps.ts
@@ -238,6 +238,7 @@ export class AppsService {
       description: `API key for app: ${data.name}`,
       organization_id: data.organization_id,
       user_id: data.created_by_user_id,
+      permissions: ["apps.access", "generation.all"],
       rate_limit: 10000,
     });
 
@@ -596,6 +597,7 @@ export class AppsService {
       description: `Regenerated API key for app: ${app.name}`,
       organization_id: app.organization_id,
       user_id: app.created_by_user_id,
+      permissions: ["apps.access", "generation.all"],
       rate_limit: 10000,
     });
 

--- a/packages/cloud-shared/src/lib/services/cli-auth-sessions.ts
+++ b/packages/cloud-shared/src/lib/services/cli-auth-sessions.ts
@@ -84,6 +84,7 @@ export class CliAuthSessionsService {
       description: "Generated via CLI login command",
       organization_id: organizationId,
       user_id: userId,
+      permissions: [], // Full access
       rate_limit: 1000,
       is_active: true,
       expires_at: null, // Never expires by default

--- a/packages/cloud-shared/src/types/cloud-worker-env.ts
+++ b/packages/cloud-shared/src/types/cloud-worker-env.ts
@@ -147,6 +147,8 @@ export interface Variables {
   requestId: string;
   /** ID of the validated API key, when `authMethod === "api_key"`. */
   apiKeyId?: string;
+  /** Permission scopes attached to the validated API key. Empty array means no scopes granted. */
+  apiKeyPermissions?: string[];
 }
 
 export type AppEnv = {

--- a/packages/test/cloud-e2e/src/fixtures/seed.ts
+++ b/packages/test/cloud-e2e/src/fixtures/seed.ts
@@ -21,6 +21,9 @@ export interface SeedTestUserOptions {
   email?: string;
   stewardUserId?: string;
   role?: string;
+  /** API-key permission scopes. Defaults to ["read","write","admin"]; pass
+   *  ["*"] for a fully-scoped key (e.g. routes that enforce scopes). */
+  permissions?: string[];
 }
 
 /**
@@ -83,6 +86,7 @@ export async function seedTestUser(
     description: "cloud-e2e harness key",
     organization_id: organization.id,
     user_id: user.id,
+    permissions: opts.permissions ?? ["read", "write", "admin"],
     rate_limit: 10_000,
     is_active: true,
   });

--- a/packages/test/cloud-e2e/tests/affiliate-guest-billing.spec.ts
+++ b/packages/test/cloud-e2e/tests/affiliate-guest-billing.spec.ts
@@ -5,26 +5,60 @@ import { expect, test } from "../src/helpers/test-fixtures";
  * Affiliate (application) guest-session attribution contract.
  *
  * Grounded on the shipped change "bill affiliate guest sessions to the
- * application owner's credits" (affiliate/create-character/route.ts):
- *   • POST /api/affiliate/create-character authenticates ANY valid, active API
- *     key (a key is just a key — full access; route.ts:106-130).
+ * application owner's credits" (commit 25be60a0d2,
+ * affiliate/create-character/route.ts):
+ *   • POST /api/affiliate/create-character authenticates an API key carrying the
+ *     `affiliate:create-character` permission (route.ts:31,106-135).
  *   • The guest user + character are created INSIDE the API-key OWNER's org
  *     (resolveApplicationOwnerOrg uses apiKey.organization_id), not a shared
- *     `affiliate-characters` pool. The guest user is is_anonymous and the
- *     character records sponsorOrganizationId = the owner org.
+ *     `affiliate-characters` pool — route.ts:149-157,224-236,283-326. The guest
+ *     user is is_anonymous (route.ts:234) and the character records
+ *     sponsorOrganizationId = the owner org (route.ts:312).
  *
- * Asserts the real attribution behavior: the guest lands in the OWNER's org as
- * an anonymous user, no magic shared affiliate pool is created, and the route
- * still rejects a request with no valid key.
+ * SCOPE JUDGMENT CALL: the brief asked to "drive a billable action -> owner
+ * credit_balance decreased AND an app_owner_revenue_share redeemable-earnings
+ * ledger entry was written." That does not match the implementation: the commit
+ * does NOT bill or write any ledger entry — character creation is explicitly
+ * balance-agnostic, and `app_owner_revenue_share` is only ever written from
+ * credit PURCHASE splits (topup-handler.ts:439, crypto-payments.ts:1068,
+ * src/queue/stripe-event.ts:296), never from a guest inference path (which uses
+ * the "affiliate" earnings source — ai-billing.ts:256-269). Guest inference
+ * billing is also unreachable keyless (needs a live model + reserved credits).
+ * So this spec asserts the real, verifiable attribution behavior the change
+ * shipped: the guest lands in the OWNER's org as an anonymous user, and no
+ * magic shared affiliate pool is created.
  */
+
+const AFFILIATE_PERMISSION = "affiliate:create-character";
+
+async function mintAffiliateKey(
+  organizationId: string,
+  userId: string,
+): Promise<string> {
+  const { apiKeysService } = await import(
+    "@elizaos/cloud-shared/lib/services/api-keys"
+  );
+  const { plainKey } = await apiKeysService.create({
+    name: "cloud-e2e-affiliate",
+    description: "cloud-e2e affiliate key",
+    organization_id: organizationId,
+    user_id: userId,
+    permissions: ["read", AFFILIATE_PERMISSION],
+    rate_limit: 10_000,
+    is_active: true,
+  });
+  return plainKey;
+}
 
 test.describe("affiliate guest session attribution", () => {
   test("guest character + user land in the application owner's org", async ({
     stack,
     seededUser,
   }) => {
-    // Any valid, active key for the owner's org works (no per-key scopes).
-    const affiliateKey = seededUser.apiKey;
+    const affiliateKey = await mintAffiliateKey(
+      seededUser.organizationId,
+      seededUser.userId,
+    );
     const affiliateId = `app-${randomUUID().slice(0, 8)}`;
 
     const res = await fetch(
@@ -106,25 +140,30 @@ test.describe("affiliate guest session attribution", () => {
     ).toBeFalsy();
   });
 
-  test("a request without a valid API key is rejected", async ({ stack }) => {
+  test("the key's affiliate permission is required", async ({
+    stack,
+    seededUser,
+  }) => {
+    // The default seeded key has read/write/admin but NOT
+    // affiliate:create-character, so it must be forbidden.
     const res = await fetch(
       `${stack.urls.api}/api/affiliate/create-character`,
       {
         method: "POST",
         headers: {
-          Authorization: "Bearer not-a-real-key",
+          Authorization: `Bearer ${seededUser.apiKey}`,
           "Content-Type": "application/json",
           Origin: stack.urls.api,
         },
         body: JSON.stringify({
-          character: { name: "Nope", bio: "no key" },
+          character: { name: "Nope", bio: "no permission" },
           affiliateId: "denied",
         }),
       },
     );
     expect(
-      [401, 403],
-      `invalid key should be rejected, got ${res.status}`,
-    ).toContain(res.status);
+      res.status,
+      `non-affiliate key should be forbidden, got ${res.status}`,
+    ).toBe(403);
   });
 });

--- a/packages/test/cloud-e2e/tests/skill-api-contract.spec.ts
+++ b/packages/test/cloud-e2e/tests/skill-api-contract.spec.ts
@@ -10,6 +10,7 @@
  *   - `apps/{id}/users` is GET-only (POST must 404)
  *   - the documented org-credit and app-credit checkout bodies are accepted
  */
+import { seedTestUser } from "../src/fixtures/seed";
 import { authedClient } from "../src/helpers/monetization";
 import { expect, test } from "../src/helpers/test-fixtures";
 
@@ -22,11 +23,16 @@ function routeExists(status: number): boolean {
 test.describe("skill ↔ API contract", () => {
   test("every documented management-surface endpoint is reachable as written", async ({
     stack,
-    seededUser,
   }) => {
     const api = stack.urls.api;
-    // A key is just a key with full access — no per-key scopes to configure.
-    const c = authedClient(api, seededUser.apiKey);
+    // Fully-scoped key: some routes (e.g. /api/v1/containers) enforce an
+    // explicit API-key scope (`containers:read`); a `*` key exercises the whole
+    // documented surface the way a properly-scoped owner key would.
+    const owner = await seedTestUser({
+      slug: `skill-${Date.now().toString(36)}`,
+      permissions: ["*"],
+    });
+    const c = authedClient(api, owner.apiKey);
 
     // build-monetized-app: register app
     const created = await c<{ app?: { id?: string }; apiKey?: string }>(


### PR DESCRIPTION
## Goal
Get `staging.elizacloud.ai` stable again. Staging deploys from `develop`, which got broken by an AI-slop checkpoint commit.

## Root cause
`bc4bb287d2` ("chore: checkpoint working tree (parallel in-progress changes) to unblock push", authored by lalalune) force-committed a half-baked shared working tree onto develop. It:
- **gutted the canvas/dexplorer UI** (`cloud-canvas.tsx` -300) and api-keys dashboard → broke the staging UI
- **tore out the entire api-key permission system** mid-refactor: deleted `api-key-permission.ts` middleware, the permission guards on api-keys/publish/containers routes, the `permissions` schema column (+ a `0145_drop_api_key_permissions` migration), and the `apiKeyPermissions` context-set → broke the `group-k-affiliate` e2e (`standard API key is forbidden without affiliate permission → 403`) → **reddened Deploy API Worker** → staging deploy broken

Prod (`main`) is clean: full UI, full permission layer, no drop migration (main is at migration 0144; 0145 was slop). Nubs confirmed the dexplorer break is develop-only, never promoted.

## Fix: revert the slop to prod's stable state
Restored every slop-touched file to its `main` version (all now byte-identical to main):
- **Frontend:** `cloud-canvas.tsx`, api-keys dashboard (`Page.tsx`, `api-keys-page-client.tsx`, `types.ts`, `apis-tab.tsx`, `data/api-keys.ts`)
- **cloud-api:** `api-key-permission.ts` middleware, `auth.ts` re-exports, api-keys routes (+`[id]`, regenerate, explorer), publish route, containers route(+test), schemas
- **cloud-shared:** `api_keys` schema `permissions` column, `workers-hono-auth` context-set, client/service/env types; **removed the `0145_drop_api_key_permissions` migration** + reverted the journal
- **Tests:** `group-k-affiliate` back to the correct `403` expectation (NOT #8468's approach of weakening the test to accept the deleted gate), `middleware-auth-soc2` restored

## Preserved
The experimental UI + parallel work is snapshotted on `preserve/dexplorer-experimental-ui` (+ `feat/canvas-genui`). Nothing lost.

## NOT touched (legitimate develop progress)
`#8465` orphan-cleanup (`eliza/agents/route.ts`, `agent-sandboxes`) and other real forward work are untouched — only the slop is reverted.

This is a revert-to-stable toward prod, not new behavior. It should green Deploy API Worker (group-k-affiliate → 403) + restore the staging dashboard UI.

Co-authored-by: wakesync <shadow@shad0w.xyz>