### PR TITLE
fix(deps): break workspace package dependency cycles (phantom deps)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2046,7 +2046,6 @@
         "@anthropic-ai/sdk": "^0.71.0",
         "@aws-sdk/client-s3": "^3.943.0",
         "@aws-sdk/lib-storage": "^3.943.0",
-        "@feed/agents": "workspace:*",
         "@feed/shared": "workspace:*",
         "@vercel/blob": "2.3.2",
         "graphql": "16.13.2",
@@ -2930,7 +2929,6 @@
       "name": "@elizaos/plugin-agent-orchestrator",
       "version": "2.0.3-beta.14",
       "dependencies": {
-        "@elizaos/plugin-task-coordinator": "workspace:*",
         "@octokit/rest": "^22.0.0",
         "coding-agent-adapters": "0.16.3",
         "drizzle-orm": "^0.45.1",
@@ -3917,8 +3915,6 @@
       "name": "@elizaos/plugin-health",
       "version": "2.0.3-beta.14",
       "dependencies": {
-        "@elizaos/agent": "workspace:*",
-        "@elizaos/app-core": "workspace:*",
         "@elizaos/core": "workspace:*",
         "@elizaos/shared": "workspace:*",
         "@elizaos/ui": "workspace:*",

--- a/packages/feed/packages/api/package.json
+++ b/packages/feed/packages/api/package.json
@@ -17,7 +17,6 @@
     "@anthropic-ai/sdk": "^0.71.0",
     "@aws-sdk/client-s3": "^3.943.0",
     "@aws-sdk/lib-storage": "^3.943.0",
-    "@feed/agents": "workspace:*",
     "@feed/shared": "workspace:*",
     "@vercel/blob": "2.3.2",
     "graphql": "16.13.2",

--- a/packages/feed/packages/api/tsconfig.json
+++ b/packages/feed/packages/api/tsconfig.json
@@ -14,9 +14,7 @@
       "@feed/db": ["../db/src/index.ts"],
       "@feed/db/*": ["../db/src/*"],
       "@feed/engine": ["../engine/src/index.ts"],
-      "@feed/engine/*": ["../engine/src/*"],
-      "@feed/agents": ["../agents/dist/index.d.ts"],
-      "@feed/agents/*": ["../agents/dist/*"]
+      "@feed/engine/*": ["../engine/src/*"]
     }
   },
   "include": ["src/**/*", "src/**/*.d.ts"],

--- a/plugins/plugin-agent-orchestrator/package.json
+++ b/plugins/plugin-agent-orchestrator/package.json
@@ -71,7 +71,6 @@
     "git-workspace-service": "0.4.5"
   },
   "dependencies": {
-    "@elizaos/plugin-task-coordinator": "workspace:*",
     "@octokit/rest": "^22.0.0",
     "coding-agent-adapters": "0.16.3",
     "drizzle-orm": "^0.45.1",

--- a/plugins/plugin-health/package.json
+++ b/plugins/plugin-health/package.json
@@ -66,8 +66,6 @@
     "lint:check": "bunx @biomejs/biome check ."
   },
   "dependencies": {
-    "@elizaos/agent": "workspace:*",
-    "@elizaos/app-core": "workspace:*",
     "@elizaos/core": "workspace:*",
     "@elizaos/shared": "workspace:*",
     "@elizaos/ui": "workspace:*",

--- a/plugins/plugin-health/src/__tests__/smoke.test.ts
+++ b/plugins/plugin-health/src/__tests__/smoke.test.ts
@@ -18,11 +18,9 @@
  */
 
 /**
- * Direct sub-module imports keep the test isolated from `health-oauth.ts`
- * (which transitively imports `@elizaos/agent` → `@elizaos/app-core` and
- * pulls in a lot of dist code that's not relevant to the smoke surface).
- * The top-level `../index.js` aggregate is verified by the package build,
- * not by this smoke test.
+ * Direct sub-module imports keep the test focused on the registry surfaces
+ * rather than the full `../index.js` aggregate, which is verified by the
+ * package build, not by this smoke test.
  */
 import { describe, expect, it } from "vitest";
 import type {

--- a/plugins/plugin-health/tsconfig.json
+++ b/plugins/plugin-health/tsconfig.json
@@ -22,16 +22,12 @@
     "declarationMap": false,
     "sourceMap": false,
     "paths": {
-      "@elizaos/app-core": ["../../packages/app-core/src/index.ts"],
-      "@elizaos/app-core/*": ["../../packages/app-core/src/*"],
       "@elizaos/ui": ["../../packages/ui/src/index.ts"],
       "@elizaos/ui/*": ["../../packages/ui/src/*"],
       "@elizaos/core": ["../../packages/core/src/index.node.ts"],
       "@elizaos/core/*": ["../../packages/core/src/*"],
       "@elizaos/shared": ["../../packages/shared/src/index.ts"],
       "@elizaos/shared/*": ["../../packages/shared/src/*"],
-      "@elizaos/agent": ["../../packages/agent/src/index.ts"],
-      "@elizaos/agent/*": ["../../packages/agent/src/*"],
       "react": ["../../packages/app-core/node_modules/@types/react/index.d.ts"],
       "react/jsx-runtime": [
         "../../packages/app-core/node_modules/@types/react/jsx-runtime.d.ts"

--- a/plugins/plugin-health/vite.config.views.ts
+++ b/plugins/plugin-health/vite.config.views.ts
@@ -6,5 +6,4 @@ export default createViewBundleConfig({
   entry: "./src/components/health/health-view-bundle.ts",
   outDir: "dist/views",
   componentExport: "HealthView",
-  additionalExternals: ["@elizaos/app-core"],
 });


### PR DESCRIPTION
## What

Removes **4 phantom workspace dependencies** (declared in `package.json` but never imported in source) that were closing two strongly-connected components in the workspace package graph.

### SCC 1 — `@elizaos/*` (the one bun warned about)
`plugin-health ⇄ app-core` **and** `agent → orchestrator → task-coordinator → calendar → agent`, joined into one SCC. Closed by:
- `plugin-health → @elizaos/agent` — 0 source imports
- `plugin-health → @elizaos/app-core` — 0 source imports
- `plugin-agent-orchestrator → @elizaos/plugin-task-coordinator` — only the string literals `"surface:task-coordinator"`, never a module import

### SCC 2 — `@feed/*`
`@feed/agents ⇄ @feed/api` (+ `@feed/a2a`). Closed by:
- `@feed/api → @feed/agents` — only a stale comment about removed on-chain reputation code; zero imports

## Also cleaned up
- Dead tsconfig `paths` mappings for the removed deps (plugin-health, feed/api)
- A dead vite `additionalExternals` entry (plugin-health)
- A stale smoke-test comment referencing a now-nonexistent import

## What stays (real edges, no longer cyclic)
`plugin-calendar → @elizaos/agent` (`renderGroundedActionReply`), `plugin-calendar → @elizaos/app-core` (`native-library-policy`), `plugin-task-coordinator → @elizaos/plugin-calendar`, `@feed/agents → @feed/api` (23 files).

## Verification
- Tarjan SCC over the full workspace: **0 multi-node cycles, 0 self-loops** in both the runtime (deps+peerDeps) and full (incl. devDeps) graphs.
- `@elizaos/plugin-health`, `@elizaos/plugin-agent-orchestrator`, and `@feed/api` typecheck clean.
- `bun install` emits no circular-dependency warning; `bun.lock` diff is exactly the 4 removed edges (no version churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)