### PR TITLE
fix(cloud-frontend): default to classic OG dashboard, not the canvas slop

### DIFF
--- a/packages/cloud-frontend/src/lib/stores/canvas-store.ts
+++ b/packages/cloud-frontend/src/lib/stores/canvas-store.ts
@@ -173,10 +173,13 @@ export const useCanvasStore = create<CanvasState>()(
   persist(
     (set, get) => ({
       // ── Initial state ──
-      canvasOpen: true,
-      canvasMode: "chat" as CanvasMode,
-      defaultUiMode: "canvas",
-      assistantOpen: true,
+      // Default to the classic dashboard (OG DashboardLayout). The interactive
+      // canvas UI remains available behind the toggle, but is no longer the
+      // default surface.
+      canvasOpen: false,
+      canvasMode: "idle" as CanvasMode,
+      defaultUiMode: "classic",
+      assistantOpen: false,
       messages: [],
       isProcessing: false,
       activeSpec: null,
@@ -881,6 +884,17 @@ export const useCanvasStore = create<CanvasState>()(
     }),
     {
       name: "eliza-cloud-canvas",
+      // Bumped to 1 to drop any stale persisted `defaultUiMode: "canvas"` so the
+      // classic dashboard becomes the default surface for existing users too
+      // (not just fresh sessions). The canvas remains available via the toggle.
+      version: 1,
+      migrate: (persisted, version) => {
+        const state = (persisted ?? {}) as Partial<CanvasState>;
+        if (version < 1) {
+          state.defaultUiMode = "classic";
+        }
+        return state as CanvasState;
+      },
       partialize: (state) => ({
         savedViews: state.savedViews,
         actionUsage: state.actionUsage,


### PR DESCRIPTION
## Goal
Stabilize `staging.elizacloud.ai`: boot into the **classic OG `DashboardLayout`**, not dEXploarer's half-baked experimental canvas UI.

## Root cause
The interactive-canvas genui UI (`#8339`) was wired as the DEFAULT surface in the canvas store:
```
canvasOpen: true
defaultUiMode: "canvas"
```
So `App.tsx`'s `{canvasOpen ? <CanvasLayout /> : <DashboardLayout />}` boots the experimental canvas instead of the stable classic dashboard. (This is on both develop and main — the canvas became the default, not just a staging regression.)

## Fix (minimal, non-destructive — 1 file)
`canvas-store.ts`:
- initial state → `canvasOpen: false`, `defaultUiMode: "classic"`, `canvasMode: "idle"`
- bump persist `version: 1` + `migrate` so existing users with a stale `defaultUiMode: "canvas"` in localStorage **also** reset to classic (not just fresh sessions)

The canvas UI is **NOT removed** — it stays fully available behind the toggle (`setDefaultUiMode`). The experimental work is preserved on `preserve/dexplorer-experimental-ui`. This just flips the default surface back to the stable OG dashboard.

## Verified
- typecheck clean for the change
- OG render chain intact: `App.tsx` → `<DashboardLayout/>` (when canvasOpen=false) → `DashboardShell` (Header + Sidebar + routed pages), zero canvas dependency
- only diff: 1 file, +18/-4

Note: prod (main) has the same canvas-default — flagging that a follow-up may want the same flip on prod, but this PR targets develop/staging per the current goal.

Co-authored-by: wakesync <shadow@shad0w.xyz>