### PR TITLE
fix: normalize native agent binary responses

### DIFF
--- a/packages/ui/src/api/android-native-agent-transport.ts
+++ b/packages/ui/src/api/android-native-agent-transport.ts
@@ -305,7 +305,7 @@ export function createAndroidNativeAgentTransport(
  */
 function nativeResponseBody(
   result: NativeAgentRequestResult,
-): Uint8Array<ArrayBuffer> | string {
+): ArrayBuffer | string {
   const base64 = result.bodyBase64;
   if (typeof base64 === "string" && base64.length > 0) {
     const binary = atob(base64);
@@ -313,7 +313,7 @@ function nativeResponseBody(
     for (let i = 0; i < binary.length; i += 1) {
       bytes[i] = binary.charCodeAt(i);
     }
-    return bytes;
+    return bytes.buffer;
   }
   return result.body ?? "";
 }


### PR DESCRIPTION
## Why

`Cloud CF Deploy` typechecks `packages/cloud-frontend`, which pulls in the shared UI API transport. After the Android native-agent bridge started returning decoded binary response bodies as `Uint8Array`, the frontend typecheck rejected that value as a `Response` body under the current DOM typings.

Binary responses still need to stay lossless for native local-agent paths, especially audio payloads, so the fix preserves bytes instead of falling back to text.

## What changed

- Decode native `bodyBase64` into bytes as before.
- Pass the underlying `ArrayBuffer` to `new Response(...)` instead of the `Uint8Array` view.

## Verification

- `bun run --cwd packages/ui test -- src/api/android-native-agent-transport.test.ts`
- `bunx @biomejs/biome check packages/ui/src/api/android-native-agent-transport.ts`