### PR TITLE
ci(cloud-tests): route compute jobs to self-hosted hetzner-robot runners

### DIFF
--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -49,7 +49,7 @@ permissions:
 
 jobs:
   changed-paths:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, hetzner-robot]
     outputs:
       cloud_frontend: ${{ steps.filter.outputs.cloud_frontend }}
     steps:
@@ -92,7 +92,7 @@ jobs:
           fi
 
   lint-and-types:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, hetzner-robot]
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -101,7 +101,7 @@ jobs:
         run: bun run verify:cloud
 
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, hetzner-robot]
     timeout-minutes: 15
     env:
       NODE_ENV: test
@@ -112,7 +112,7 @@ jobs:
         run: bun run test:cloud
 
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, hetzner-robot]
     timeout-minutes: 25
     env:
       NODE_ENV: test
@@ -126,7 +126,7 @@ jobs:
         run: bun run test:cloud:integration
 
   e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, hetzner-robot]
     timeout-minutes: 35
     needs: [lint-and-types]
     env:


### PR DESCRIPTION
## Why
GitHub Actions hosted-minutes budget is exhausted → CI queue backlog. We stood up a 10-runner self-hosted fleet on `eliza-staging-robot-1` (isolated, non-root, resource-capped, validated end-to-end). This routes the heaviest *frequent* cloud workflow's compute jobs onto it to clear the queue + stop burning hosted minutes.

## Change
`cloud-tests.yml`: 5 pure-compute jobs → `runs-on: [self-hosted, linux, x64, hetzner-robot]`:
- changed-paths, lint-and-types, unit-tests, integration-tests, e2e-tests

These need **no root**: `cloud-setup-test-env` uses setup-node/setup-bun (home-dir) + bun + the docker group (postgres/redis service containers) — all available to the non-root `github-runner` user (node+bun also pre-installed on the box).

## Left on hosted (for now)
The 2 **playwright** jobs stay `ubuntu-latest` — they run `playwright install --with-deps chromium` which needs root/apt. Follow-up: pre-install playwright deps on the box, then route those too.

## Validation
This PR's own `cloud-tests` run executes the 5 routed jobs **on the fleet** — confirming they pick up + pass on self-hosted before this hits develop. Incremental by design (one workflow first, expand after).

Co-authored-by: wakesync <shadow@shad0w.xyz>