### PR TITLE
ci: run trusted linux jobs on self-hosted runners

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -42,6 +42,26 @@ Publishes TypeScript/JavaScript packages to NPM.
 
 ## Test Workflows
 
+### Linux Self-Hosted Runner Policy
+
+Linux CI jobs that previously ran on hosted Ubuntu now target the shared
+`self-hosted`, `Linux`, `X64`, `hetzner-robot` runner pool for trusted events
+such as same-repository PRs, pushes, schedules, and manual runs.
+
+Fork PRs still fall back to the equivalent GitHub-hosted Ubuntu image. This is
+intentional: the repo is public, and untrusted fork code should keep GitHub's
+ephemeral runner isolation rather than execute on persistent self-hosted
+machines with repository-adjacent state.
+
+Why this exists:
+
+- Same-repository CI can use the larger runner pool to reduce queue time and
+  unblock parallel slices without weakening the quality gate.
+- Fork contributors keep a predictable, isolated hosted environment.
+- Existing workflow commands stay the same; only runner placement changes.
+- macOS, Windows, ARM, GPU, and virtualization-dependent jobs should stay on
+  purpose-built runners until matching self-hosted labels and capacity exist.
+
 ### PR Path Gates
 
 PR workflows use `packages/scripts/ci-path-gate.mjs` to keep expensive lanes

--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -59,7 +59,7 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-api:
     name: Deploy API Worker
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -186,7 +186,7 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-frontend:
     name: Deploy Frontend (Pages)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 

--- a/.github/workflows/cloud-e2e.yml
+++ b/.github/workflows/cloud-e2e.yml
@@ -29,7 +29,7 @@ permissions:
 jobs:
   e2e:
     name: Mock-stack E2E
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 30
     env:
       NODE_ENV: test

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -49,7 +49,7 @@ permissions:
 
 jobs:
   changed-paths:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     outputs:
       cloud_frontend: ${{ steps.filter.outputs.cloud_frontend }}
     steps:
@@ -92,7 +92,7 @@ jobs:
           fi
 
   lint-and-types:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -101,7 +101,7 @@ jobs:
         run: bun run verify:cloud
 
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 15
     env:
       NODE_ENV: test
@@ -112,7 +112,7 @@ jobs:
         run: bun run test:cloud
 
   integration-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 25
     env:
       NODE_ENV: test
@@ -126,7 +126,7 @@ jobs:
         run: bun run test:cloud:integration
 
   e2e-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 35
     needs: [lint-and-types]
     env:
@@ -140,7 +140,7 @@ jobs:
         run: bun run test:cloud:e2e
 
   playwright:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 35
     needs: [changed-paths, lint-and-types]
     # WHY: the full dashboard Playwright audit currently carries pre-existing
@@ -172,7 +172,7 @@ jobs:
         run: bun run --cwd packages/cloud-frontend test:e2e -- --project=${{ matrix.project }} --shard=${{ matrix.shard }}
 
   playwright-smoke:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 20
     needs: [changed-paths, lint-and-types]
     if: needs.changed-paths.outputs.cloud_frontend == 'true'

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   coverage:
     name: coverage on changed files
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     steps:
       - name: Checkout
         # actions/checkout@v4

--- a/.github/workflows/dev-smoke.yml
+++ b/.github/workflows/dev-smoke.yml
@@ -47,7 +47,7 @@ env:
 jobs:
   changes:
     name: Classify changed paths
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     outputs:
       dev_smoke: ${{ steps.filter.outputs.dev_smoke }}
     steps:
@@ -76,7 +76,7 @@ jobs:
     name: bun run dev onboarding chat
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.dev_smoke == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 35
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/docker-ci-smoke.yml
+++ b/.github/workflows/docker-ci-smoke.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   changes:
     name: Classify changed paths
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     outputs:
       docker: ${{ steps.filter.outputs.docker }}
     steps:
@@ -47,7 +47,7 @@ jobs:
     name: Build production Docker image (+ smoke boot)
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.docker == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 90
     env:
       BUN_VERSION: "canary"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   gitleaks:
     name: gitleaks
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     steps:
       - name: Checkout
         # actions/checkout@v4

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -46,7 +46,7 @@ permissions:
 jobs:
   homepage-build:
     name: Homepage Build (PR smoke)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 15
     permissions:
       contents: write
@@ -153,7 +153,7 @@ jobs:
 
   format-check:
     name: Format Check (biome)
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

--- a/.github/workflows/scenario-pr.yml
+++ b/.github/workflows/scenario-pr.yml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   changes:
     name: Classify changed paths
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     outputs:
       run_scenario_pr: ${{ steps.filter.outputs.run_scenario_pr }}
     steps:
@@ -68,7 +68,7 @@ jobs:
     name: Zero-Key unit + UI coverage
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -127,7 +127,7 @@ jobs:
     name: Zero-Key app browser core
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -186,7 +186,7 @@ jobs:
     name: Zero-Key app browser view lifecycle
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -240,7 +240,7 @@ jobs:
     name: Zero-Key app browser all-pages
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -285,7 +285,7 @@ jobs:
     name: Zero-Key app browser feature interactions
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 55
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -330,7 +330,7 @@ jobs:
     name: Zero-Key app browser cloud keyless
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -375,7 +375,7 @@ jobs:
     name: Zero-Key app browser ratcheted
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 55
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -420,7 +420,7 @@ jobs:
     name: Zero-Key app diagnostics
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -469,7 +469,7 @@ jobs:
     name: Zero-Key scenario runner E2E
     needs: changes
     if: needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 35
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -527,7 +527,7 @@ jobs:
       - app-diagnostics
       - scenario-runner-e2e
     if: always() && needs.changes.outputs.run_scenario_pr == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     steps:
       - name: Check deterministic E2E slices
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   changes:
     name: Classify changed paths
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     outputs:
       server: ${{ steps.filter.outputs.server }}
       client: ${{ steps.filter.outputs.client }}
@@ -73,7 +73,7 @@ jobs:
     name: Server Tests
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.server == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 60
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -148,7 +148,7 @@ jobs:
     name: Client Tests
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.client == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 60
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -186,7 +186,7 @@ jobs:
     name: Plugin Tests
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.plugins == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 95
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -260,7 +260,7 @@ jobs:
     name: Electrobun Desktop Contract
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.desktop == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -290,7 +290,7 @@ jobs:
     name: Zero-Key unit + UI coverage
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 30
     env:
       TEST_LANE: "pr"
@@ -353,7 +353,7 @@ jobs:
     name: Zero-Key app browser
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 35
     env:
       TEST_LANE: "pr"
@@ -426,7 +426,7 @@ jobs:
     name: Zero-Key diagnostics
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 30
     env:
       TEST_LANE: "pr"
@@ -491,7 +491,7 @@ jobs:
     name: Zero-Key scenario runner
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 30
     env:
       TEST_LANE: "pr"
@@ -567,7 +567,7 @@ jobs:
       - zero-key-diagnostics
       - zero-key-scenario-runner
     if: always() && (github.event_name != 'pull_request' || needs.changes.outputs.zero_key == 'true')
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     steps:
       - name: Check zero-key slices
         shell: bash
@@ -596,7 +596,7 @@ jobs:
     name: Cloud Live E2E (Eliza Cloud)
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.cloud == 'true'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 60
     outputs:
       skip: ${{ steps.cloud.outputs.skip }}
@@ -729,7 +729,7 @@ jobs:
 
   provider-live-e2e:
     name: Remote Capability Provider Live E2E
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 45
     outputs:
       skip: ${{ steps.providers.outputs.skip }}
@@ -856,7 +856,7 @@ jobs:
       - cloud-live-e2e
       - provider-live-e2e
     if: always() && (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && (needs.cloud-live-e2e.outputs.capability_skip != 'true' || needs.provider-live-e2e.outputs.skip != 'true')
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     timeout-minutes: 15
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -911,7 +911,7 @@ jobs:
       - cloud-live-e2e
       - provider-live-e2e
       - github-live-artifact-validate
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-24.04"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     steps:
       - name: Check test results
         shell: bash


### PR DESCRIPTION
## Summary
- Move trusted Linux CI jobs from hosted Ubuntu to the self-hosted Linux x64 Hetzner runner pool.
- Preserve GitHub-hosted Ubuntu fallback for fork PRs so untrusted code keeps ephemeral runner isolation.
- Document the runner policy and why non-Linux/specialized lanes should stay on purpose-built runners until matching labels exist.

## Why
The project now has online self-hosted Linux x64 runners. Routing same-repository PRs, pushes, schedules, and manual runs there should reduce queue time and let the existing parallel CI slices do useful work without removing checks or weakening the quality gate. Fork PRs deliberately keep hosted runners because this is a public repo and self-hosted runners are persistent infrastructure.

## Validation
- Parsed updated workflow YAML with Ruby YAML loader.
- Ran git diff --check.
- Verified targeted workflow files no longer contain direct hosted Ubuntu Linux runs-on entries.