### PR TITLE
fix(cloud-frontend): default prod dashboard to classic OG, not canvas slop

### DIFF
--- a/packages/cloud-frontend/src/lib/stores/canvas-store.ts
+++ b/packages/cloud-frontend/src/lib/stores/canvas-store.ts
@@ -173,10 +173,13 @@ export const useCanvasStore = create<CanvasState>()(
   persist(
     (set, get) => ({
       // ── Initial state ──
-      canvasOpen: true,
-      canvasMode: "chat" as CanvasMode,
-      defaultUiMode: "canvas",
-      assistantOpen: true,
+      // Default to the classic dashboard (OG DashboardLayout). The interactive
+      // canvas UI remains available behind the toggle, but is no longer the
+      // default surface.
+      canvasOpen: false,
+      canvasMode: "idle" as CanvasMode,
+      defaultUiMode: "classic",
+      assistantOpen: false,
       messages: [],
       isProcessing: false,
       activeSpec: null,
@@ -881,6 +884,17 @@ export const useCanvasStore = create<CanvasState>()(
     }),
     {
       name: "eliza-cloud-canvas",
+      // Bumped to 1 to drop any stale persisted `defaultUiMode: "canvas"` so the
+      // classic dashboard becomes the default surface for existing users too
+      // (not just fresh sessions). The canvas remains available via the toggle.
+      version: 1,
+      migrate: (persisted, version) => {
+        const state = (persisted ?? {}) as Partial<CanvasState>;
+        if (version < 1) {
+          state.defaultUiMode = "classic";
+        }
+        return state as CanvasState;
+      },
       partialize: (state) => ({
         savedViews: state.savedViews,
         actionUsage: state.actionUsage,


### PR DESCRIPTION
## Summary
Prod (`elizacloud.ai`) is still serving the experimental canvas UI as the default dashboard — confirmed live: prod bundle has `defaultUiMode:\`canvas\``. Staging was already fixed via #8493 (merged to develop, `defaultUiMode:\`classic\`` confirmed live on staging.elizacloud.ai).

This cherry-picks #8493 (`9e2e1a3cd2`) onto main so prod matches staging: the OG dashboard is the default, canvas stays behind the toggle.

## What it does
- `canvas-store.ts`: `defaultUiMode: classic`, `canvasOpen: false`, `canvasView: idle`
- Adds persist `version: 1` + migrate so returning prod users with stale `eliza-cloud-canvas` localStorage (canvas) get reset to classic
- Canvas is NOT deleted — still reachable via the UI toggle

## Validation
- Confirmed prod bundle currently ships `defaultUiMode:\`canvas\`` (the bug); staging ships `classic` (the fix)
- Cherry-pick is a clean 1-file change, classic-default + canvasOpen:false verified on this branch

Co-authored-by: wakesync <shadow@shad0w.xyz>