### PR TITLE
ci(cloud-cf-deploy): route prod deploy to self-hosted (unblock queued prod deploy)

### DIFF
--- a/.github/workflows/cloud-cf-deploy.yml
+++ b/.github/workflows/cloud-cf-deploy.yml
@@ -59,7 +59,7 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-api:
     name: Deploy API Worker
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -186,7 +186,7 @@ jobs:
   # ---------------------------------------------------------------------------
   deploy-frontend:
     name: Deploy Frontend (Pages)
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && '["ubuntu-latest"]' || '["self-hosted","Linux","X64","hetzner-robot"]') }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 


### PR DESCRIPTION
odi's #8501 self-hosted routing landed on develop but not main. The prod deploy (push→main) still targets ubuntu-latest hosted runners = no budget = queued forever. This applies odi's exact conditional pattern to cloud-cf-deploy.yml's 2 deploy jobs so trusted events run on the hetzner-robot fleet while fork PRs keep hosted isolation. Unblocks #8502's prod classic-dashboard deploy.

Co-authored-by: wakesync <shadow@shad0w.xyz>