### PR TITLE
fix(cloud): honor bridge-host fallback when injecting TS_AUTHKEY

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-headscale-route.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-headscale-route.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   DockerSandboxProvider,
+  headscaleVpnEnabled,
   requiresHeadscaleRoute,
   resolveContainerPort,
   resolveDockerSandboxImage,
@@ -75,6 +76,48 @@ describe("requiresHeadscaleRoute", () => {
         AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK: "1",
       }),
     ).toBe(false);
+  });
+});
+
+describe("headscaleVpnEnabled", () => {
+  test("enabled when an API key is configured and no fallback is requested", () => {
+    expect(headscaleVpnEnabled({ HEADSCALE_API_KEY: "secret" })).toBe(true);
+  });
+
+  test("disabled when no API key is configured", () => {
+    expect(headscaleVpnEnabled({})).toBe(false);
+    expect(headscaleVpnEnabled({ HEADSCALE_API_KEY: "" })).toBe(false);
+    expect(headscaleVpnEnabled({ HEADSCALE_API_KEY: "   " })).toBe(false);
+  });
+
+  test("disabled when the operator opts into legacy bridge-host fallback", () => {
+    // The fallback flag must also stop TS_AUTHKEY injection, not just relax the
+    // route-required guard — otherwise the container entrypoint hard-`tailscale
+    // up`s and dies under `set -e` on nodes that aren't on the mesh, which is
+    // exactly what the flag is meant to bypass.
+    expect(
+      headscaleVpnEnabled({
+        HEADSCALE_API_KEY: "secret",
+        AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK: "1",
+      }),
+    ).toBe(false);
+    expect(
+      headscaleVpnEnabled({
+        HEADSCALE_API_KEY: "secret",
+        AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK: "true",
+      }),
+    ).toBe(false);
+  });
+
+  test("stays consistent with requiresHeadscaleRoute under the fallback flag", () => {
+    // When the fallback is on, neither the route nor the VPN enrollment is
+    // required — the container boots over the legacy bridge-host path.
+    const env = {
+      HEADSCALE_API_KEY: "secret",
+      AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK: "1",
+    };
+    expect(requiresHeadscaleRoute(env)).toBe(false);
+    expect(headscaleVpnEnabled(env)).toBe(false);
   });
 });
 

--- a/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
+++ b/packages/cloud-shared/src/lib/services/docker-sandbox-provider.ts
@@ -303,6 +303,24 @@ export function requiresHeadscaleRoute(
   );
 }
 
+/**
+ * Whether the sandbox should actively enroll in the Headscale/tailnet VPN
+ * (inject TS_AUTHKEY, add the tun device + NET_ADMIN cap, and wait for a
+ * headscale_ip).
+ *
+ * Requires a configured `HEADSCALE_API_KEY` *and* that the operator has not
+ * explicitly opted into legacy bridge-host routing. Gating on the fallback
+ * flag here — not just in {@link requiresHeadscaleRoute} — keeps the escape
+ * hatch internally consistent: without it, `AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK`
+ * only relaxes the "must register a headscale_ip" guard while TS_AUTHKEY is
+ * still injected, so the container entrypoint hard-`tailscale up`s and dies
+ * under `set -e` when headscale is unreachable — the exact failure the flag is
+ * meant to bypass on nodes that aren't on the mesh.
+ */
+export function headscaleVpnEnabled(env: HeadscaleRouteEnv): boolean {
+  return hasConfiguredValue(env.HEADSCALE_API_KEY) && !isBridgeHostFallbackEnabled(env);
+}
+
 function buildStewardRefreshCommand(
   containerName: string,
   agentId: string,
@@ -786,7 +804,7 @@ export class DockerSandboxProvider implements SandboxProvider {
     // HEADSCALE_API_KEY presence check and the route-required decision read
     // from one consistent view of the environment.
     const headscaleRouteRequired = requiresHeadscaleRoute(env);
-    const headscaleEnabled = !!env.HEADSCALE_API_KEY?.trim();
+    const headscaleEnabled = headscaleVpnEnabled(env);
     if (headscaleRouteRequired && !headscaleEnabled) {
       const errorMessage =
         "Headscale routing is required for this cloud environment, but HEADSCALE_API_KEY is not configured. " +


### PR DESCRIPTION
## Why

Closes the one open code suggestion from the #8434 launch thread (0xSolace's note on the prod canary).

The `AGENT_ROUTER_ALLOW_BRIDGE_HOST_FALLBACK` escape hatch is meant to let agent containers boot on nodes that **aren't on the headscale mesh** (legacy public-host routing). But it was only half-honored: it relaxed `requiresHeadscaleRoute()` (stopped *requiring* a `headscale_ip`) while the provider still injected `TS_AUTHKEY` whenever `HEADSCALE_API_KEY` was set.

The container entrypoint (`docker-entrypoint.sh`, `set -eu`) runs `tailscale up` whenever `TS_AUTHKEY` is present. So on a non-mesh node, `tailscale up` fails → `set -e` exits before `exec node … start` → the app never boots → health never passes — the **exact failure the flag is meant to bypass**. On the 06-16 prod canary, the workaround was to disable `HEADSCALE_API_KEY` on the daemon entirely.

## What

Gate all VPN enrollment (TS_AUTHKEY injection, `NET_ADMIN` cap + `/dev/net/tun`, rollback cleanup, and the `headscale_ip` wait) through a single exported predicate:

```ts
export function headscaleVpnEnabled(env: HeadscaleRouteEnv): boolean {
  return hasConfiguredValue(env.HEADSCALE_API_KEY) && !isBridgeHostFallbackEnabled(env);
}
```

- **No-op for the validated prod/staging path** — the fallback flag is off there (you only get a `headscale_ip` if `TS_AUTHKEY` was injected, which the staging/prod E2E confirmed). Only the explicit legacy-fallback case changes behavior.
- Keeps the fallback flag internally consistent with `requiresHeadscaleRoute()`.
- Adds 4 regression tests; existing route-guard suite stays green (15 tests, 0 fail). Typecheck + biome clean.

## Test
`bun test packages/cloud-shared/src/lib/services/__tests__/docker-sandbox-headscale-route.test.ts` → 15 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)