### PR TITLE
fix(apps-data-plane): partition app-node private IP per env (prod↔staging collision)

### DIFF
--- a/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
+++ b/packages/cloud-infra/cloud/terraform/hetzner/apps-data-plane/main.tf
@@ -121,7 +121,14 @@ resource "hcloud_server_network" "app_node" {
 
   server_id  = each.value.id
   network_id = local.apps_network_id
-  ip         = cidrhost(local.apps_subnet_cidr, 20 + tonumber(each.key))
+  # staging + production app nodes share the apps-shared subnet, so the private-IP
+  # offset MUST be partitioned per environment or the prod node #1 collides with
+  # the staging node #1 (both at host 21 → "API request failed" on attach).
+  # staging → 21,22,…  production → 31,32,… (DB node is host 10).
+  ip = cidrhost(
+    local.apps_subnet_cidr,
+    (var.environment == "production" ? 30 : 20) + tonumber(each.key),
+  )
 }
 
 # ── Ingress DNS: wildcard for per-app URLs -> app node (single-node draft) ─────


### PR DESCRIPTION
Prod apps data-plane `terraform apply` failed at `hcloud_server_network.app_node` with "API request failed": staging + production app nodes share the apps-shared subnet, but the private-IP offset was `20 + node_index` for **both** envs, so prod node #1 tried to claim `10.30.1.21` — already held by the staging app node.

Fix: partition the base per env — staging `20+` (21,22,…), production `30+` (31,32,…); tenant DB stays at host 10. Staging is unchanged (still .21), so no drift on the existing staging node. Verified by re-running the prod apply off this branch.

Part of standing up the prod apps data-plane (Product-2 per-app DB + container hosting). Tracker #8434.