### PR TITLE
feat(apps): dedicated apps-control provisioning daemon + job lanes (Product 2)

### DIFF
--- a/.github/workflows/arm-apps-daemon.yml
+++ b/.github/workflows/arm-apps-daemon.yml
@@ -34,6 +34,11 @@ on:
         type: choice
         default: staging
         options: [staging, production]
+      target:
+        description: "Which daemon to arm: the shared control-plane provisioning-worker (cp-daemon) or the dedicated apps-control worker (apps-worker, Product-2 isolated path)"
+        type: choice
+        default: cp-daemon
+        options: [cp-daemon, apps-worker]
       app_node:
         description: "CONTAINERS_DOCKER_NODES (id:ip:capacity), e.g. apps-node-1:167.233.112.155:20"
         type: string
@@ -67,8 +72,14 @@ jobs:
     environment: ${{ github.event.inputs.environment }}
     timeout-minutes: 10
     env:
-      DEPLOY_HOST: ${{ secrets.ELIZA_PROVISIONING_HOST }}
-      DEPLOY_SSH_KEY: ${{ secrets.ELIZA_PROVISIONING_SSH_KEY }}
+      # Target the dedicated apps-control host (apps-worker) or the shared
+      # control-plane host (cp-daemon). The apps-worker path arms the isolated
+      # Product-2 daemon on a host that sits on the apps private net (so it can
+      # reach the tenant DB) and runs no agent jobs — never touching the agent
+      # control plane.
+      DEPLOY_HOST: ${{ github.event.inputs.target == 'apps-worker' && secrets.ELIZA_APPS_WORKER_HOST || secrets.ELIZA_PROVISIONING_HOST }}
+      DEPLOY_SSH_KEY: ${{ github.event.inputs.target == 'apps-worker' && secrets.ELIZA_APPS_WORKER_SSH_KEY || secrets.ELIZA_PROVISIONING_SSH_KEY }}
+      SYSTEMD_UNIT: ${{ github.event.inputs.target == 'apps-worker' && 'eliza-apps-worker.service' || 'eliza-provisioning-worker.service' }}
       BASE_DOMAIN: ${{ vars.APPS_BASE_DOMAIN }}
       APP_NODE: ${{ github.event.inputs.app_node }}
       TENANT_ADMIN_DSN: ${{ github.event.inputs.tenant_admin_dsn }}
@@ -77,8 +88,10 @@ jobs:
       - name: Preflight
         run: |
           fail=0
-          [ -n "$DEPLOY_HOST" ] || { echo "::error::missing secret ELIZA_PROVISIONING_HOST on the '${{ github.event.inputs.environment }}' environment"; fail=1; }
-          [ -n "$DEPLOY_SSH_KEY" ] || { echo "::error::missing secret ELIZA_PROVISIONING_SSH_KEY"; fail=1; }
+          HOST_SECRET="${{ github.event.inputs.target == 'apps-worker' && 'ELIZA_APPS_WORKER_HOST' || 'ELIZA_PROVISIONING_HOST' }}"
+          KEY_SECRET="${{ github.event.inputs.target == 'apps-worker' && 'ELIZA_APPS_WORKER_SSH_KEY' || 'ELIZA_PROVISIONING_SSH_KEY' }}"
+          [ -n "$DEPLOY_HOST" ] || { echo "::error::missing secret $HOST_SECRET on the '${{ github.event.inputs.environment }}' environment (target=${{ github.event.inputs.target }})"; fail=1; }
+          [ -n "$DEPLOY_SSH_KEY" ] || { echo "::error::missing secret $KEY_SECRET"; fail=1; }
           [ -n "$BASE_DOMAIN" ] || { echo "::error::set vars.APPS_BASE_DOMAIN on the '${{ github.event.inputs.environment }}' environment"; fail=1; }
           [ -n "$APP_NODE" ] || { echo "::error::app_node input is required (id:ip:capacity)"; fail=1; }
           # Derive the Caddy admin URL from the app node IP (2nd colon field).
@@ -124,7 +137,7 @@ jobs:
           key: ${{ env.DEPLOY_SSH_KEY }}
           command_timeout: 5m
           # Only the values; the upsert logic is fixed here (mirrors arm-apps-daemon.mjs).
-          envs: APP_NODE,BASE_DOMAIN,CADDY_ADMIN,TENANT_ADMIN_DSN,EGRESS_PROXY
+          envs: APP_NODE,BASE_DOMAIN,CADDY_ADMIN,TENANT_ADMIN_DSN,EGRESS_PROXY,SYSTEMD_UNIT
           script: |
             set -euo pipefail
             F=/opt/eliza/cloud/.env.local
@@ -159,8 +172,11 @@ jobs:
             sudo grep -E '^(APPS_|CONTAINERS_(DOCKER_NODES|SSH_USER|PUBLIC_BASE_DOMAIN|EGRESS_PROXY_URL))' "$F" \
               | sed -E 's/(DSN|KEY)=.*/\1=<redacted>/'
 
-            sudo systemctl restart eliza-provisioning-worker.service
+            # Restart whichever daemon we armed: the dedicated apps-worker on the
+            # apps-control host, or the shared control-plane provisioning-worker.
+            UNIT="${SYSTEMD_UNIT:-eliza-provisioning-worker.service}"
+            sudo systemctl restart "$UNIT"
             sleep 2
-            echo "--- daemon status ---"
-            systemctl is-active eliza-provisioning-worker.service
-            journalctl -u eliza-provisioning-worker.service -n 10 --no-pager | tail -10 || true
+            echo "--- daemon status ($UNIT) ---"
+            systemctl is-active "$UNIT"
+            journalctl -u "$UNIT" -n 10 --no-pager | tail -10 || true

--- a/.github/workflows/deploy-apps-worker.yml
+++ b/.github/workflows/deploy-apps-worker.yml
@@ -1,0 +1,277 @@
+name: Deploy Apps Worker (Product 2)
+
+# SSHes to the apps-control host, fetches the target branch, installs the
+# systemd unit shipped at packages/scripts/cloud/admin/eliza-apps-worker.service,
+# and restarts the eliza-apps-worker daemon (the Product-2 deploy daemon).
+#
+# This is the slim sibling of deploy-eliza-provisioning-worker.yml: it deploys
+# ONLY the apps-worker — NO agent-router, and NO headscale wiring (the apps
+# worker reaches the per-tenant Postgres over the apps PRIVATE network, never the
+# agent mesh). The apps env (APPS_DEPLOY_ENABLED, APPS_TENANT_ADMIN_DSN,
+# CONTAINERS_DOCKER_NODES, …) is written separately by arm-apps-daemon.yml — this
+# workflow only ships code + the unit, keeping the two concerns split.
+#
+# First-time setup: bootstrap an apps-control VM on the apps PRIVATE network (so
+# it can reach the tenant DB at 10.30.1.10) that runs NO untrusted containers,
+# then set the env's ELIZA_APPS_WORKER_HOST + ELIZA_APPS_WORKER_SSH_KEY secrets.
+
+on:
+  push:
+    branches: [develop, main]
+    paths:
+      - '.github/workflows/deploy-apps-worker.yml'
+      - 'packages/scripts/cloud/admin/daemons/apps-provisioning-worker.ts'
+      - 'packages/scripts/cloud/admin/daemons/provisioning-worker.ts'
+      - 'packages/scripts/cloud/admin/eliza-apps-worker.service'
+      - 'packages/cloud-shared/src/lib/services/provisioning-jobs.ts'
+      - 'packages/cloud-shared/src/lib/services/provisioning-job-types.ts'
+      - 'packages/cloud-shared/src/lib/services/apps-deploy-backend.ts'
+      - 'packages/cloud-shared/src/lib/services/tenant-db/**'
+      - 'packages/cloud-shared/src/lib/services/app-deploy-runner.ts'
+      - 'packages/cloud-sdk/**'
+      - 'packages/core/**'
+      - 'plugins/plugin-sql/**'
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment (host + secrets resolved from this)'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - staging
+          - production
+
+concurrency:
+  group: deploy-apps-worker-${{ github.event.inputs.environment || (github.ref == 'refs/heads/main' && 'production' || 'staging') }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  determine-env:
+    name: Determine environment
+    runs-on: ubuntu-latest
+    outputs:
+      environment: ${{ steps.env.outputs.environment }}
+      branch: ${{ steps.env.outputs.branch }}
+    steps:
+      - id: env
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            env="${{ github.event.inputs.environment }}"
+          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            env="production"
+          else
+            env="staging"
+          fi
+          branch=$([ "$env" = "production" ] && echo "main" || echo "develop")
+          echo "environment=$env" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch"   >> "$GITHUB_OUTPUT"
+          echo "Resolved: environment=$env branch=$branch"
+
+  deploy:
+    name: Deploy apps worker to apps-control host (${{ needs.determine-env.outputs.environment }})
+    runs-on: ubuntu-latest
+    needs: determine-env
+    environment: ${{ needs.determine-env.outputs.environment }}
+    timeout-minutes: 15
+    env:
+      SYSTEMD_UNIT: eliza-apps-worker.service
+      DEPLOY_HOST: ${{ secrets.ELIZA_APPS_WORKER_HOST }}
+      DEPLOY_SSH_KEY: ${{ secrets.ELIZA_APPS_WORKER_SSH_KEY }}
+      DEPLOY_BRANCH: ${{ needs.determine-env.outputs.branch }}
+    steps:
+      - name: Check deploy configuration
+        id: deploy_config
+        run: |
+          if [ -z "$DEPLOY_HOST" ] || [ -z "$DEPLOY_SSH_KEY" ]; then
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Missing ELIZA_APPS_WORKER_HOST or ELIZA_APPS_WORKER_SSH_KEY; skipping apps-worker deploy."
+            {
+              echo "### Apps worker deploy skipped"
+              echo ""
+              echo "Missing \`ELIZA_APPS_WORKER_HOST\` or \`ELIZA_APPS_WORKER_SSH_KEY\` for this environment."
+              echo "Bootstrap an apps-control VM on the apps private network and set those secrets first."
+            } >> "$GITHUB_STEP_SUMMARY"
+            if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+              echo "::error::Manual deployment requires ELIZA_APPS_WORKER_HOST and ELIZA_APPS_WORKER_SSH_KEY."
+              exit 1
+            fi
+            exit 0
+          fi
+          echo "configured=true" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure host prereqs (Node 24, swap, bunx symlink)
+        if: steps.deploy_config.outputs.configured == 'true'
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
+        with:
+          host: ${{ env.DEPLOY_HOST }}
+          username: deploy
+          key: ${{ env.DEPLOY_SSH_KEY }}
+          command_timeout: 5m
+          script: |
+            set -euo pipefail
+            if ! command -v node >/dev/null 2>&1; then
+              echo "[host-prereqs] installing Node 24"
+              curl -fsSL https://deb.nodesource.com/setup_24.x | sudo bash -
+              sudo apt-get install -y nodejs
+            fi
+            if [ ! -f /swapfile ]; then
+              echo "[host-prereqs] adding 8GB swap"
+              sudo fallocate -l 8G /swapfile
+              sudo chmod 600 /swapfile
+              sudo mkswap /swapfile
+              sudo swapon /swapfile
+              grep -q '^/swapfile ' /etc/fstab || echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab >/dev/null
+            fi
+            if [ ! -e /home/deploy/.bun/bin/bunx ] && [ -e /home/deploy/.bun/bin/bun ]; then
+              echo "[host-prereqs] creating bunx symlink"
+              ln -sf bun /home/deploy/.bun/bin/bunx
+            fi
+
+      - name: Deploy and restart apps worker
+        if: steps.deploy_config.outputs.configured == 'true'
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
+        with:
+          host: ${{ env.DEPLOY_HOST }}
+          username: deploy
+          key: ${{ env.DEPLOY_SSH_KEY }}
+          command_timeout: 10m
+          envs: DEPLOY_BRANCH,SYSTEMD_UNIT
+          script: |
+            set -euo pipefail
+            echo "=== Deploying eliza-apps-worker (branch: $DEPLOY_BRANCH) ==="
+
+            cd /opt/eliza
+            export GIT_CONFIG_COUNT=1
+            export GIT_CONFIG_KEY_0=safe.directory
+            export GIT_CONFIG_VALUE_0=/opt/eliza
+
+            rm -f .git/index.lock
+            sudo chown -R deploy:deploy .git
+
+            git reset --hard HEAD 2>/dev/null || true
+            git clean -fdx \
+              -e .env \
+              -e .env.local \
+              -e '.env.*' \
+              -e cloud/.env.local \
+              -e 'cloud/.env.*' \
+              -e node_modules
+
+            find packages -type f \( -name '*.d.ts' -o -name '*.d.ts.map' \) \
+              ! -path '*/node_modules/*' -delete 2>/dev/null || true
+            rm -f bun.lock
+
+            git -c fetch.recurseSubmodules=no fetch --no-recurse-submodules \
+              origin "+$DEPLOY_BRANCH:refs/remotes/origin/$DEPLOY_BRANCH"
+            git -c submodule.recurse=false checkout --no-recurse-submodules \
+              -B "$DEPLOY_BRANCH" "origin/$DEPLOY_BRANCH"
+
+            if ! command -v bun >/dev/null 2>&1; then
+              curl -fsSL https://bun.sh/install | bash -s "canary"
+              export BUN_INSTALL="$HOME/.bun"
+              export PATH="$BUN_INSTALL/bin:$PATH"
+            fi
+
+            cd /opt/eliza
+            for attempt in 1 2 3; do
+              if bun install --no-save --ignore-scripts; then
+                break
+              fi
+              if [ "$attempt" -eq 3 ]; then exit 1; fi
+              echo "bun install attempt $attempt failed; retrying in 10s..."
+              sleep 10
+            done
+
+            # The daemon runs under Node/tsx, which resolves linked workspace
+            # packages through their built `node` exports — refresh dist files.
+            bun run build:core
+            mkdir -p plugins/plugin-sql/node_modules/@elizaos
+            rm -rf plugins/plugin-sql/node_modules/@elizaos/core
+            ln -s ../../../../packages/core plugins/plugin-sql/node_modules/@elizaos/core
+            bun run --cwd plugins/plugin-sql build
+
+            # packages/scripts has no package.json, so bun's workspace graph
+            # doesn't link @elizaos/cloud-shared for the daemon — create it.
+            mkdir -p node_modules/@elizaos
+            ln -sfn ../../packages/cloud-shared node_modules/@elizaos/cloud-shared
+
+            sudo install -m 0644 \
+              packages/scripts/cloud/admin/eliza-apps-worker.service \
+              "/etc/systemd/system/$SYSTEMD_UNIT"
+            sudo systemctl daemon-reload
+            sudo systemctl enable "$SYSTEMD_UNIT"
+            sudo systemctl restart "$SYSTEMD_UNIT"
+            echo "=== Restart issued for apps worker ==="
+
+      - name: Health check
+        if: steps.deploy_config.outputs.configured == 'true'
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2
+        with:
+          host: ${{ env.DEPLOY_HOST }}
+          username: deploy
+          key: ${{ env.DEPLOY_SSH_KEY }}
+          command_timeout: 5m
+          envs: SYSTEMD_UNIT
+          script: |
+            set -euo pipefail
+            # The apps worker has no HTTP endpoint; health = active + stable +
+            # no fatal/restart-loop in the journal since deploy.
+            HEALTH_SINCE_TS="$(date -u '+%Y-%m-%d %H:%M:%S')"
+            STABLE_THRESHOLD_SEC=20
+            FATAL_LOG_PATTERN="\[apps-worker\] (fatal|unhandled rejection)|node:internal/.*Error:|Error \[ERR_|^[A-Za-z]+Error:"
+            for attempt in $(seq 1 18); do
+              if sudo systemctl is-active --quiet "$SYSTEMD_UNIT"; then
+                JOURNAL=$(sudo journalctl -u "$SYSTEMD_UNIT" --since "$HEALTH_SINCE_TS" --no-pager 2>/dev/null || true)
+                if echo "$JOURNAL" | grep -qE "$FATAL_LOG_PATTERN"; then
+                  echo "::error::Apps worker logged a fatal error since deploy."
+                  echo "$JOURNAL" | tail -n 50
+                  exit 1
+                fi
+                UPTIME_SEC=$(systemctl show "$SYSTEMD_UNIT" --property=ActiveEnterTimestampMonotonic --value | awk '{ print int($1 / 1e6) }')
+                NOW_SEC=$(awk '{print int($1)}' /proc/uptime)
+                AGE=$(( NOW_SEC - UPTIME_SEC ))
+                if [ "$AGE" -ge "$STABLE_THRESHOLD_SEC" ]; then
+                  echo "Apps worker active and stable (${AGE}s) on attempt $attempt."
+                  exit 0
+                fi
+                echo "Health check attempt $attempt/18: active but only ${AGE}s old, waiting for stability..."
+              else
+                echo "Health check attempt $attempt/18: not active yet."
+              fi
+              sleep 5
+            done
+
+            echo "::error::$SYSTEMD_UNIT failed to become healthy within 90s."
+            sudo systemctl status "$SYSTEMD_UNIT" --no-pager || true
+            sudo journalctl -u "$SYSTEMD_UNIT" -n 200 --no-pager || true
+            exit 1
+
+      - name: Notify Discord (Success)
+        if: success() && steps.deploy_config.outputs.configured == 'true'
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          ack_no_webhook: true
+          title: "🚀 Eliza Apps Worker Deployed (Product 2)"
+          nodetail: true
+          description: |
+            Branch: ${{ needs.determine-env.outputs.branch }}
+            Commit: ${{ github.sha }}
+          color: 0x00ff00
+
+      - name: Notify Discord (Failure)
+        if: failure() && steps.deploy_config.outputs.configured == 'true'
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          ack_no_webhook: true
+          title: "❌ Eliza Apps Worker Deploy Failed"
+          nodetail: true
+          description: |
+            Branch: ${{ needs.determine-env.outputs.branch }}
+            Commit: ${{ github.sha }}
+          color: 0xff0000

--- a/packages/cloud-shared/src/lib/services/provisioning-job-types.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-job-types.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the provisioning job LANES — the split that lets a dedicated
+ * apps-control daemon claim only the `apps` lane (CONTAINER_* / APP_*) while the
+ * agent control-plane worker keeps the `agent` lane, both sharing one `jobs`
+ * table. Two properties matter most:
+ *
+ *   1. COMPLETENESS — every JOB_TYPES value belongs to exactly one lane. A type
+ *      in NEITHER lane would be silently un-claimable by any scoped daemon
+ *      (stuck pending forever); a type in BOTH would be double-claimed.
+ *   2. FAIL-OPEN — an empty/garbage `PROVISIONING_JOB_LANES` resolves to ALL
+ *      types (the historical single-daemon behavior), never to "claim nothing".
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  AGENT_JOB_TYPES,
+  APPS_JOB_TYPES,
+  JOB_TYPES,
+  type ProvisioningJobType,
+  resolveJobTypesForLanes,
+} from "./provisioning-job-types";
+
+const ALL = Object.values(JOB_TYPES) as ProvisioningJobType[];
+
+describe("job lanes — completeness invariant", () => {
+  test("agent ∪ apps covers EVERY job type (none orphaned)", () => {
+    const union = new Set<ProvisioningJobType>([...AGENT_JOB_TYPES, ...APPS_JOB_TYPES]);
+    const missing = ALL.filter((t) => !union.has(t));
+    expect(missing).toEqual([]);
+    expect(union.size).toBe(ALL.length);
+  });
+
+  test("agent and apps lanes are DISJOINT (no type double-claimed)", () => {
+    const apps = new Set<ProvisioningJobType>(APPS_JOB_TYPES);
+    const overlap = AGENT_JOB_TYPES.filter((t) => apps.has(t));
+    expect(overlap).toEqual([]);
+  });
+
+  test("apps lane is exactly the CONTAINER_* + APP_* rows", () => {
+    expect([...APPS_JOB_TYPES].sort()).toEqual(
+      [
+        JOB_TYPES.CONTAINER_PROVISION,
+        JOB_TYPES.CONTAINER_DELETE,
+        JOB_TYPES.CONTAINER_RESTART,
+        JOB_TYPES.CONTAINER_UPGRADE,
+        JOB_TYPES.CONTAINER_LOGS,
+        JOB_TYPES.APP_DEPLOY,
+        JOB_TYPES.APP_DB_DEPROVISION,
+      ].sort(),
+    );
+  });
+
+  test("no AGENT_* type leaked into the apps lane", () => {
+    const leaked = (APPS_JOB_TYPES as readonly string[]).filter((t) => t.startsWith("agent_"));
+    expect(leaked).toEqual([]);
+  });
+});
+
+describe("resolveJobTypesForLanes — fail-open to ALL", () => {
+  test.each([undefined, null, "", "   ", ",", " , "])("%p → all types", (spec) => {
+    expect(resolveJobTypesForLanes(spec as string | null | undefined)).toEqual(ALL);
+  });
+
+  test("an unrecognized lane name → all types (never claim nothing)", () => {
+    expect(resolveJobTypesForLanes("bogus")).toEqual(ALL);
+    expect(resolveJobTypesForLanes("agentz,appz")).toEqual(ALL);
+  });
+});
+
+describe("resolveJobTypesForLanes — scoping", () => {
+  test("'apps' → exactly the apps lane", () => {
+    expect(new Set(resolveJobTypesForLanes("apps"))).toEqual(new Set(APPS_JOB_TYPES));
+  });
+
+  test("'agent' → exactly the agent lane", () => {
+    expect(new Set(resolveJobTypesForLanes("agent"))).toEqual(new Set(AGENT_JOB_TYPES));
+  });
+
+  test("'agent,apps' → all types (both lanes)", () => {
+    expect(new Set(resolveJobTypesForLanes("agent,apps"))).toEqual(new Set(ALL));
+    // order-independent
+    expect(new Set(resolveJobTypesForLanes("apps,agent"))).toEqual(new Set(ALL));
+  });
+
+  test("case-insensitive + whitespace tolerant", () => {
+    expect(new Set(resolveJobTypesForLanes(" APPS "))).toEqual(new Set(APPS_JOB_TYPES));
+    expect(new Set(resolveJobTypesForLanes("Agent , Apps"))).toEqual(new Set(ALL));
+  });
+
+  test("a recognized lane alongside garbage → just the recognized lane", () => {
+    expect(new Set(resolveJobTypesForLanes("bogus,apps"))).toEqual(new Set(APPS_JOB_TYPES));
+  });
+
+  test("preserves JOB_TYPES declaration order", () => {
+    const apps = resolveJobTypesForLanes("apps");
+    const appsInDeclOrder = ALL.filter((t) => (APPS_JOB_TYPES as readonly string[]).includes(t));
+    expect(apps).toEqual(appsInDeclOrder);
+  });
+});

--- a/packages/cloud-shared/src/lib/services/provisioning-job-types.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-job-types.ts
@@ -72,3 +72,77 @@ export const JOB_TYPES = {
 } as const;
 
 export type ProvisioningJobType = (typeof JOB_TYPES)[keyof typeof JOB_TYPES];
+
+// ── Lanes (which daemon claims which jobs) ──────────────────────────────────
+// The one `jobs` table + ProvisioningJobService codepath is shared, but the
+// rows split into two INDEPENDENT lanes that can be claimed by SEPARATE daemons:
+//
+//   - `agent` — the AGENT_* sandbox lifecycle (Product 1). Owned by the
+//     control-plane provisioning-worker, which ALSO holds the agent-fleet
+//     singletons (liveness heartbeat, fleet upgrade, node autoscale, warm pool).
+//   - `apps`  — the CONTAINER_* / APP_* lifecycle (Product 2). Provisioning a
+//     per-tenant DB needs `pg` reach to the PRIVATE tenant Postgres, and running
+//     untrusted user containers wants isolation from the agent control plane.
+//     Owned by a dedicated apps-control daemon that lives ON the apps private
+//     network (so it can reach the tenant DB) and runs NONE of the agent
+//     singletons — so it can never race/duplicate the live fleet.
+//
+// A daemon scopes itself with `PROVISIONING_JOB_LANES` (comma list). Unset → ALL
+// types (the historical single-daemon behavior), so this split is INERT until a
+// second daemon is actually deployed and each side is pinned to its lane.
+export const AGENT_JOB_TYPES = [
+  JOB_TYPES.AGENT_PROVISION,
+  JOB_TYPES.AGENT_DELETE,
+  JOB_TYPES.AGENT_SUSPEND,
+  JOB_TYPES.AGENT_RESUME,
+  JOB_TYPES.AGENT_RESTART,
+  JOB_TYPES.AGENT_LOGS,
+  JOB_TYPES.AGENT_MESSAGE,
+  JOB_TYPES.AGENT_SNAPSHOT,
+  JOB_TYPES.AGENT_UPGRADE,
+  JOB_TYPES.AGENT_SLEEP,
+  JOB_TYPES.AGENT_WAKE,
+] as const satisfies readonly ProvisioningJobType[];
+
+export const APPS_JOB_TYPES = [
+  JOB_TYPES.CONTAINER_PROVISION,
+  JOB_TYPES.CONTAINER_DELETE,
+  JOB_TYPES.CONTAINER_RESTART,
+  JOB_TYPES.CONTAINER_UPGRADE,
+  JOB_TYPES.CONTAINER_LOGS,
+  JOB_TYPES.APP_DEPLOY,
+  JOB_TYPES.APP_DB_DEPROVISION,
+] as const satisfies readonly ProvisioningJobType[];
+
+export const JOB_LANES = {
+  agent: AGENT_JOB_TYPES,
+  apps: APPS_JOB_TYPES,
+} as const;
+
+export type JobLane = keyof typeof JOB_LANES;
+
+/**
+ * Resolve the job types a daemon should claim from a `PROVISIONING_JOB_LANES`
+ * spec (comma-separated `agent`/`apps`, case-insensitive).
+ *
+ * Fail-OPEN to the historical all-types behavior in every ambiguous case:
+ *   - empty / undefined  → ALL types (one daemon does both lanes);
+ *   - no recognized lane → ALL types (never silently claim nothing).
+ * Unknown lane tokens are ignored. The returned list preserves `JOB_TYPES`
+ * order so logs/iteration are stable.
+ */
+export function resolveJobTypesForLanes(spec: string | undefined | null): ProvisioningJobType[] {
+  const all = Object.values(JOB_TYPES);
+  if (!spec || !spec.trim()) return all;
+  const wanted = new Set<ProvisioningJobType>();
+  let matchedAnyLane = false;
+  for (const raw of spec.split(",")) {
+    const lane = raw.trim().toLowerCase();
+    if (lane in JOB_LANES) {
+      matchedAnyLane = true;
+      for (const t of JOB_LANES[lane as JobLane]) wanted.add(t);
+    }
+  }
+  if (!matchedAnyLane) return all;
+  return all.filter((t) => wanted.has(t));
+}

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -1323,9 +1323,17 @@ export class ProvisioningJobService {
    * double-process the same job.
    *
    * @param batchSize - Max jobs to process per invocation.
+   * @param opts.jobTypes - Restrict claiming + stale-recovery to this lane of
+   *   job types (e.g. `APPS_JOB_TYPES` for the dedicated apps-control daemon).
+   *   Omitted → ALL types (the single-daemon default). Scoping is what lets two
+   *   daemons share the `jobs` table without one claiming-and-failing the
+   *   other's lane.
    * @returns Summary of processing results.
    */
-  async processPendingJobs(batchSize = 5): Promise<ProcessingResult> {
+  async processPendingJobs(
+    batchSize = 5,
+    opts: { jobTypes?: readonly ProvisioningJobType[] } = {},
+  ): Promise<ProcessingResult> {
     const result: ProcessingResult = {
       claimed: 0,
       succeeded: 0,
@@ -1333,13 +1341,16 @@ export class ProvisioningJobService {
       errors: [],
     };
 
-    // Process each job type
-    for (const jobType of Object.values(JOB_TYPES)) {
+    const jobTypes = opts.jobTypes ?? Object.values(JOB_TYPES);
+
+    // Process each job type in this daemon's lane
+    for (const jobType of jobTypes) {
       await this.processJobType(jobType, batchSize, result);
     }
 
-    // Recover stale jobs (stuck in_progress for >5 minutes)
-    const recovered = await this.recoverStaleJobs();
+    // Recover stale jobs (stuck in_progress for >5 minutes), scoped to the same
+    // lane so a lane-scoped daemon never resets the OTHER lane's stale rows.
+    const recovered = await this.recoverStaleJobs(jobTypes);
     if (recovered > 0) {
       logger.info("[provisioning-jobs] Recovered stale jobs", { recovered });
     }
@@ -2156,12 +2167,14 @@ export class ProvisioningJobService {
     return { total, succeeded, failed };
   }
 
-  private async recoverStaleJobs(): Promise<number> {
+  private async recoverStaleJobs(
+    jobTypes: readonly ProvisioningJobType[] = Object.values(JOB_TYPES),
+  ): Promise<number> {
     let totalRecovered = 0;
 
     // Recover stale jobs per type across all organizations. The repository now
     // handles org-agnostic recovery, so we can do this in one pass.
-    for (const jobType of Object.values(JOB_TYPES)) {
+    for (const jobType of jobTypes) {
       const recovered = await jobsRepository.recoverStaleJobs({
         type: jobType,
         staleThresholdMs: 5 * 60 * 1000, // 5 minutes

--- a/packages/scripts/cloud/admin/daemons/apps-provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/apps-provisioning-worker.ts
@@ -1,0 +1,240 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * Apps-control provisioning worker (Eliza Cloud Apps / Product 2).
+ *
+ * A PURPOSE-BUILT, deliberately slim sibling of `provisioning-worker.ts`. It
+ * claims ONLY the apps lane (`APPS_JOB_TYPES`: CONTAINER_* + APP_DEPLOY +
+ * APP_DB_DEPROVISION) and arms ONLY the apps deploy backend. It runs NONE of the
+ * agent-fleet singletons the main worker owns — no liveness heartbeat, no fleet
+ * image-upgrade, no node autoscale, no warm-pool drain — so a second copy of
+ * THIS daemon can never race, duplicate, or disrupt the live agent control
+ * plane. The two daemons coexist on the shared `jobs` table purely via
+ * lane-scoped, `FOR UPDATE SKIP LOCKED` claiming.
+ *
+ * WHY A SEPARATE DAEMON / HOST: provisioning a per-tenant DB runs `pg` DDL
+ * (CREATE ROLE/DATABASE) against the PRIVATE tenant Postgres, which is only
+ * reachable on the apps private network — somewhere the agent control-plane node
+ * (a different Hetzner project) is not. So this daemon is meant to run on a
+ * TRUSTED node that sits ON the apps private net (reaches the tenant DB
+ * privately) but runs NO untrusted user containers (those live on the separate
+ * app node) — keeping the cluster ADMIN DSN off any box that runs user code.
+ *
+ * Deploy target is therefore the apps-control node (NOT the agent control plane,
+ * NOT the untrusted app node). Pin the main worker to `PROVISIONING_JOB_LANES=agent`
+ * once this is live so it stops claiming-and-failing apps jobs it can't run.
+ *
+ * Usage:
+ *   npx tsx packages/scripts/cloud/admin/daemons/apps-provisioning-worker.ts
+ *   npx tsx packages/scripts/cloud/admin/daemons/apps-provisioning-worker.ts --once
+ *
+ * Required env (in /opt/eliza/cloud/.env.local, same shape arm-apps-daemon writes):
+ *   APPS_DEPLOY_ENABLED=1            arm gate (without it this daemon idles)
+ *   DATABASE_URL=...                 the cloud Postgres (Neon) — the jobs queue
+ *   APPS_TENANT_ADMIN_DSN=...        admin DSN of the tenant DB cluster (private IP)
+ *   CONTAINERS_DOCKER_NODES=...      the app node(s) the deploy runner SSHes to
+ *   CONTAINERS_SSH_USER, APPS_CADDY_ADMIN_URL, CONTAINERS_PUBLIC_BASE_DOMAIN, ...
+ */
+
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { APPS_JOB_TYPES } from "@elizaos/cloud-shared/lib/services/provisioning-job-types";
+import type { ProcessingResult } from "@elizaos/cloud-shared/lib/services/provisioning-jobs";
+import { loadLocalEnv } from "./shared/load-env";
+
+type WorkerLogger =
+  typeof import("@elizaos/cloud-shared/lib/utils/logger").logger;
+type WorkerService =
+  typeof import("@elizaos/cloud-shared/lib/services/provisioning-jobs").provisioningJobService;
+
+interface AppsWorkerDeps {
+  logger: WorkerLogger;
+  provisioningJobService: WorkerService;
+}
+
+export interface AppsWorkerConfig {
+  pollIntervalMs: number;
+  batchSize: number;
+  runOnce: boolean;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+const DEFAULT_BATCH_SIZE = 3;
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function hasFlag(argv: readonly string[], flag: string): boolean {
+  return argv.includes(flag);
+}
+
+export function readAppsWorkerConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  argv: readonly string[] = process.argv.slice(2),
+): AppsWorkerConfig {
+  return {
+    pollIntervalMs: parsePositiveInt(
+      env.WORKER_POLL_INTERVAL,
+      DEFAULT_POLL_INTERVAL_MS,
+    ),
+    batchSize: parsePositiveInt(env.WORKER_BATCH_SIZE, DEFAULT_BATCH_SIZE),
+    runOnce: env.WORKER_RUN_ONCE === "1" || hasFlag(argv, "--once"),
+  };
+}
+
+let depsPromise: Promise<AppsWorkerDeps> | null = null;
+
+async function loadDeps(): Promise<AppsWorkerDeps> {
+  if (!depsPromise) {
+    depsPromise = Promise.all([
+      import("@elizaos/cloud-shared/lib/services/provisioning-jobs"),
+      import("@elizaos/cloud-shared/lib/utils/logger"),
+    ]).then(([jobsModule, loggerModule]) => ({
+      provisioningJobService: jobsModule.provisioningJobService,
+      logger: loggerModule.logger,
+    }));
+  }
+  return depsPromise;
+}
+
+/**
+ * Arm the node deploy backend (per-tenant DB provisioning + container executor +
+ * build-from-repo resolver). Mirrors `armAppsDeployBackendIfEnabled` in the main
+ * worker. Gated on `APPS_DEPLOY_ENABLED=1`: returns false when unset so a
+ * deployed-but-not-armed daemon idles instead of half-running.
+ */
+async function armAppsDeployBackend(logger: WorkerLogger): Promise<boolean> {
+  if (process.env.APPS_DEPLOY_ENABLED !== "1") {
+    logger.warn(
+      "[apps-worker] APPS_DEPLOY_ENABLED is not '1' — deploy backend NOT armed; " +
+        "daemon will idle (claims no jobs). Set APPS_DEPLOY_ENABLED=1 to arm.",
+    );
+    return false;
+  }
+  const { configureAppsDeployBackend } = await import(
+    "@elizaos/cloud-shared/lib/services/apps-deploy-backend"
+  );
+  const port = process.env.APPS_DEPLOY_PORT
+    ? Number(process.env.APPS_DEPLOY_PORT)
+    : undefined;
+  // APPS_IMAGE_REGISTRY set → BUILD-FROM-REPO (buildx on the app node, push to
+  // this registry). Unset → prebuilt images (imageTag / APP_DEFAULT_IMAGE).
+  const registry = process.env.APPS_IMAGE_REGISTRY;
+  configureAppsDeployBackend({ port, registry });
+  logger.info("[apps-worker] apps deploy backend armed", {
+    tenantDbAdminDsn: process.env.APPS_TENANT_ADMIN_DSN
+      ? "env-sourced"
+      : "encrypted",
+    images: registry
+      ? "build-from-repo"
+      : "prebuilt (imageTag/APP_DEFAULT_IMAGE)",
+    registry: registry ?? null,
+    port: port ?? 3000,
+    dockerNodes: process.env.CONTAINERS_DOCKER_NODES ?? "(unset)",
+  });
+  return true;
+}
+
+function resultContext(result: ProcessingResult): Record<string, unknown> {
+  return {
+    claimed: result.claimed,
+    succeeded: result.succeeded,
+    failed: result.failed,
+    errors: result.errors,
+  };
+}
+
+let running = true;
+let armed = false;
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * One work cycle: claim + process the apps lane only. No heartbeat, no infra
+ * maintenance — those are the agent control plane's job, not ours.
+ */
+async function pollCycle(
+  logger: WorkerLogger,
+  config: AppsWorkerConfig,
+): Promise<void> {
+  if (!armed) return; // not armed → nothing to claim; stay a quiet no-op.
+  try {
+    const { provisioningJobService } = await loadDeps();
+    const result = await provisioningJobService.processPendingJobs(
+      config.batchSize,
+      { jobTypes: APPS_JOB_TYPES },
+    );
+    if (result.claimed > 0 || result.failed > 0) {
+      logger.info("[apps-worker] cycle complete", resultContext(result));
+    }
+  } catch (error) {
+    logger.error("[apps-worker] cycle failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+async function main(): Promise<void> {
+  loadLocalEnv(import.meta.url);
+
+  const config = readAppsWorkerConfig();
+  const { logger } = await loadDeps();
+
+  logger.info("[apps-worker] starting", {
+    pollIntervalMs: config.pollIntervalMs,
+    batchSize: config.batchSize,
+    runOnce: config.runOnce,
+    lane: "apps",
+    jobTypes: APPS_JOB_TYPES,
+  });
+
+  armed = await armAppsDeployBackend(logger);
+
+  if (config.runOnce) {
+    await pollCycle(logger, config);
+    return;
+  }
+
+  while (running) {
+    await pollCycle(logger, config);
+    if (running) {
+      await sleep(config.pollIntervalMs);
+    }
+  }
+
+  logger.info("[apps-worker] stopped");
+}
+
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  return entry ? path.resolve(entry) === fileURLToPath(import.meta.url) : false;
+}
+
+process.on("SIGINT", () => {
+  running = false;
+});
+
+process.on("SIGTERM", () => {
+  running = false;
+});
+
+process.on("unhandledRejection", (reason) => {
+  void loadDeps().then(({ logger }) => {
+    logger.error("[apps-worker] unhandled rejection", {
+      error: reason instanceof Error ? reason.message : String(reason),
+    });
+  });
+});
+
+if (isMainModule()) {
+  main().catch((error) => {
+    process.stderr.write(
+      `[apps-worker] fatal: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/provisioning-worker.ts
@@ -14,6 +14,10 @@
 
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  type ProvisioningJobType,
+  resolveJobTypesForLanes,
+} from "@elizaos/cloud-shared/lib/services/provisioning-job-types";
 import type {
   HeartbeatResult,
   ProcessingResult,
@@ -67,6 +71,14 @@ export interface ProvisioningWorkerConfig {
   batchSize: number;
   runOnce: boolean;
   nodeHealthIntervalMs: number;
+  /**
+   * Job types this daemon claims, from `PROVISIONING_JOB_LANES`. Unset → ALL
+   * (the single-daemon default; behavior unchanged). Pin to `agent` once a
+   * dedicated apps-control daemon owns the `apps` lane so this control-plane
+   * worker stops claiming (and failing) APP_DEPLOY/CONTAINER_* jobs it can't
+   * reach the private tenant DB to run.
+   */
+  jobTypes: readonly ProvisioningJobType[];
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
@@ -103,6 +115,7 @@ export function readWorkerConfig(
       env.WORKER_NODE_HEALTH_INTERVAL,
       DEFAULT_NODE_HEALTH_INTERVAL_MS,
     ),
+    jobTypes: resolveJobTypesForLanes(env.PROVISIONING_JOB_LANES),
   };
 }
 
@@ -208,9 +221,10 @@ export async function assertProvisioningWorkerPreflight(
 
 async function processProvisioningWorkerCycle(
   batchSize = readWorkerConfig().batchSize,
+  jobTypes?: readonly ProvisioningJobType[],
 ): Promise<ProcessingResult> {
   const { provisioningJobService } = await loadDeps();
-  return provisioningJobService.processPendingJobs(batchSize);
+  return provisioningJobService.processPendingJobs(batchSize, { jobTypes });
 }
 
 async function processHeartbeatCycle(
@@ -615,7 +629,10 @@ async function pollCycle(
     return;
   }
   try {
-    const result = await processProvisioningWorkerCycle(config.batchSize);
+    const result = await processProvisioningWorkerCycle(
+      config.batchSize,
+      config.jobTypes,
+    );
     if (result.claimed > 0 || result.failed > 0) {
       logger.info(
         "[provisioning-worker] cycle complete",
@@ -805,6 +822,10 @@ async function main(): Promise<void> {
     batchSize: config.batchSize,
     runOnce: config.runOnce,
     nodeHealthIntervalMs: config.nodeHealthIntervalMs,
+    // Surface the claim scope: empty PROVISIONING_JOB_LANES → all 18 types.
+    // When a dedicated apps daemon ships, pin this one to `agent`.
+    jobLanes: process.env.PROVISIONING_JOB_LANES || "(all)",
+    jobTypeCount: config.jobTypes.length,
   });
 
   await assertProvisioningWorkerPreflight();

--- a/packages/scripts/cloud/admin/eliza-apps-worker.service
+++ b/packages/scripts/cloud/admin/eliza-apps-worker.service
@@ -1,0 +1,42 @@
+[Unit]
+Description=Eliza Apps Worker (Product 2 apps-control deploy daemon)
+Documentation=https://github.com/elizaOS/eliza
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=deploy
+Group=deploy
+WorkingDirectory=/opt/eliza
+EnvironmentFile=/opt/eliza/cloud/.env.local
+# ssh2 + dockerode (via the deploy backend) are Node-only, so the daemon runs
+# under tsx (not bun). Use the installed workspace binary directly.
+Environment=NODE_OPTIONS=--max-old-space-size=1024
+ExecStart=/opt/eliza/node_modules/.bin/tsx --tsconfig /opt/eliza/packages/cloud-shared/tsconfig.json /opt/eliza/packages/scripts/cloud/admin/daemons/apps-provisioning-worker.ts
+
+Restart=always
+RestartSec=5
+
+MemoryMax=1536M
+MemoryHigh=1024M
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=eliza-apps-worker
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+# Private writable /tmp for the service. tsx needs to create /tmp/tsx-${UID}
+# for its IPC server, which ProtectSystem=strict otherwise blocks.
+PrivateTmp=true
+ReadWritePaths=/opt/eliza
+ReadOnlyPaths=/home/deploy/.ssh
+
+# 30s for an in-flight app-deploy cycle to finish before SIGKILL.
+TimeoutStopSec=30
+KillMode=mixed
+KillSignal=SIGTERM
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Dedicated apps-control provisioning daemon + job lanes (Product 2)

### Why
Standing up Product-2 (per-app isolated DB + container hosting) on **prod** surfaced a real architecture gap (tracker #8434): per-app DB provisioning runs `pg` DDL against the **private-only** tenant Postgres (`10.30.1.10`, no public 5432 by design), but the agent control-plane provisioning-worker lives in a **separate Hetzner project** and can't reach it — so arming the existing daemon would leave every app stuck "building".

Every shortcut weakens the security posture:
- exposing the tenant DB publicly puts the **shared multi-tenant** DB on the internet;
- running the deploy daemon on the **app node** co-locates the **cluster admin DSN (master creds to every tenant DB)** with **untrusted user containers** → a container escape = full multi-tenant compromise;
- running a *second copy of the agent daemon* would race/duplicate the agent-fleet singletons (liveness heartbeat, fleet upgrade, node autoscale, warm-pool drain) → could drain live agent nodes.

### What
A **purpose-built, slim apps-control daemon** that runs on a TRUSTED node **on the apps private net** (reaches the tenant DB privately) which runs **no untrusted containers** (those stay on the separate app node). It is **additive** — it touches zero existing infra (not the mesh, not the agent CP daemon's behavior, not the deploy code path) — so it cannot destabilize the live agent launch.

- **`provisioning-job-types`** — split `JOB_TYPES` into `AGENT_JOB_TYPES` / `APPS_JOB_TYPES` lanes + `resolveJobTypesForLanes(PROVISIONING_JOB_LANES)`. **Fail-open to ALL types** so the split is **inert** until two daemons are deployed and each is pinned to its lane.
- **`provisioning-jobs`** — `processPendingJobs` + `recoverStaleJobs` take an optional `jobTypes` lane (default = all → **behavior unchanged**, backward-compatible; the one other caller, `container-control-plane`, is unaffected).
- **`provisioning-worker` (main)** — reads `PROVISIONING_JOB_LANES`; default all, so the **live CP worker is unchanged** until we pin it to `agent`.
- **NEW `apps-provisioning-worker`** — claims **only** the apps lane, arms **only** the apps deploy backend, runs **none** of the agent singletons (no heartbeat/fleet-upgrade/autoscale/warm-pool). Two daemons coexist on the shared `jobs` table purely via lane-scoped `FOR UPDATE SKIP LOCKED` claims.
- **NEW `eliza-apps-worker.service`** systemd unit.

### Safety / tests
- **Inert by default**: no env is set anywhere; with `PROVISIONING_JOB_LANES` unset the main daemon claims all 18 types exactly as today (`readWorkerConfig({}).jobTypes.length === 18`).
- **Lane completeness invariant** test: every `JOB_TYPES` value is in **exactly one** lane (catches a future type orphaned from both daemons or double-claimed), plus disjointness + resolver fail-open/scoping. **17 pass.**
- Existing daemon tests still pass (6/6); both daemons load clean under tsx.

### Follow-up (not in this PR)
- Deploy workflow + a dedicated apps-control node on the apps net; arm `APPS_DEPLOY_ENABLED=1` there; pin the CP worker to `PROVISIONING_JOB_LANES=agent`; e2e-verify (isolated DB + container + HTTPS + cross-tenant REJECTED + teardown).
- Container-runtime hardening (gVisor/Kata/userns/seccomp) on the untrusted app node before real users at scale.

Refs #8434 #8425


---
### Update — full Path-A toolchain now in this PR
Beyond the daemon + lanes, this PR now ships the **end-to-end deploy/arm tooling** so standing it up is purely operational:
- **`deploy-apps-worker.yml`** — slim deploy (no agent-router, no headscale wiring) targeting `ELIZA_APPS_WORKER_HOST`; skips cleanly until that secret is set.
- **`arm-apps-daemon.yml`** — new `target: cp-daemon | apps-worker` input; `apps-worker` arms the apps env on the apps-control host + restarts `eliza-apps-worker.service`. Default `cp-daemon` = unchanged.

So once merged: bootstrap an apps-control node on the apps net → set the host secrets → `deploy-apps-worker` → `arm-apps-daemon target=apps-worker` → pin the CP worker to `PROVISIONING_JOB_LANES=agent` → e2e-verify. No further code needed.
