### PR TITLE
fix(apps): surface failed APP_DEPLOY + cover the lane seam (audit follow-ups to #8514)

### DIFF
--- a/packages/cloud-shared/src/lib/services/provisioning-jobs-lanes.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs-lanes.test.ts
@@ -41,7 +41,7 @@ describe("processPendingJobs — lane scoping", () => {
     }
   });
 
-  test("default (no jobTypes) claims + recovers all 18 types — unchanged behavior", async () => {
+  test("default (no jobTypes) claims + recovers every JOB_TYPES entry — unchanged behavior", async () => {
     const claimSpy = spyOn(jobsRepository, "claimPendingJobs").mockResolvedValue([]);
     const recoverSpy = spyOn(jobsRepository, "recoverStaleJobs").mockResolvedValue(0);
     try {
@@ -49,7 +49,9 @@ describe("processPendingJobs — lane scoping", () => {
 
       const claimedTypes = claimSpy.mock.calls.map((c) => c[0].type);
       expect(new Set(claimedTypes)).toEqual(new Set(Object.values(JOB_TYPES)));
-      expect(claimedTypes.length).toBe(18);
+      // Count is derived from JOB_TYPES, not hardcoded: CONTAINER_STOP (#8342)
+      // grows this from 18 to 19, and a literal would break the moment it lands.
+      expect(claimedTypes.length).toBe(Object.values(JOB_TYPES).length);
     } finally {
       claimSpy.mockRestore();
       recoverSpy.mockRestore();

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs-lanes.test.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs-lanes.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Lane-scoping behavior of ProvisioningJobService — the invariant the whole
+ * apps-control-plane split exists to provide: a lane-scoped call claims AND
+ * stale-recovers ONLY its lane's job types, and the default (no jobTypes) is
+ * byte-for-byte the old all-18-types behavior.
+ *
+ * This guards the seam the resolver unit test can't: resolver output → the
+ * processPendingJobs/recoverStaleJobs loops → jobsRepository.{claim,recover}
+ * with a per-type filter. A future refactor dropping the recoverStaleJobs(jobTypes)
+ * scoping would silently let one lane's daemon reset the OTHER lane's stale rows
+ * — this test fails loudly if that happens.
+ */
+
+import { describe, expect, spyOn, test } from "bun:test";
+
+import { jobsRepository } from "../../db/repositories/jobs";
+import { AGENT_JOB_TYPES, APPS_JOB_TYPES, JOB_TYPES } from "./provisioning-job-types";
+import { provisioningJobService } from "./provisioning-jobs";
+
+describe("processPendingJobs — lane scoping", () => {
+  test("apps lane claims + stale-recovers ONLY apps job types, never an agent type", async () => {
+    const claimSpy = spyOn(jobsRepository, "claimPendingJobs").mockResolvedValue([]);
+    const recoverSpy = spyOn(jobsRepository, "recoverStaleJobs").mockResolvedValue(0);
+    try {
+      await provisioningJobService.processPendingJobs(1, {
+        jobTypes: APPS_JOB_TYPES,
+      });
+
+      const claimedTypes = claimSpy.mock.calls.map((c) => c[0].type);
+      const recoveredTypes = recoverSpy.mock.calls.map((c) => c[0].type);
+
+      expect(new Set(claimedTypes)).toEqual(new Set(APPS_JOB_TYPES));
+      expect(new Set(recoveredTypes)).toEqual(new Set(APPS_JOB_TYPES));
+      for (const agentType of AGENT_JOB_TYPES) {
+        expect(claimedTypes).not.toContain(agentType);
+        expect(recoveredTypes).not.toContain(agentType);
+      }
+    } finally {
+      claimSpy.mockRestore();
+      recoverSpy.mockRestore();
+    }
+  });
+
+  test("default (no jobTypes) claims + recovers all 18 types — unchanged behavior", async () => {
+    const claimSpy = spyOn(jobsRepository, "claimPendingJobs").mockResolvedValue([]);
+    const recoverSpy = spyOn(jobsRepository, "recoverStaleJobs").mockResolvedValue(0);
+    try {
+      await provisioningJobService.processPendingJobs(1);
+
+      const claimedTypes = claimSpy.mock.calls.map((c) => c[0].type);
+      expect(new Set(claimedTypes)).toEqual(new Set(Object.values(JOB_TYPES)));
+      expect(claimedTypes.length).toBe(18);
+    } finally {
+      claimSpy.mockRestore();
+      recoverSpy.mockRestore();
+    }
+  });
+
+  test("agent lane never claims an apps job type (no cross-lane leakage)", async () => {
+    const claimSpy = spyOn(jobsRepository, "claimPendingJobs").mockResolvedValue([]);
+    const recoverSpy = spyOn(jobsRepository, "recoverStaleJobs").mockResolvedValue(0);
+    try {
+      await provisioningJobService.processPendingJobs(1, {
+        jobTypes: AGENT_JOB_TYPES,
+      });
+
+      const claimedTypes = claimSpy.mock.calls.map((c) => c[0].type);
+      expect(new Set(claimedTypes)).toEqual(new Set(AGENT_JOB_TYPES));
+      for (const appsType of APPS_JOB_TYPES) {
+        expect(claimedTypes).not.toContain(appsType);
+      }
+    } finally {
+      claimSpy.mockRestore();
+      recoverSpy.mockRestore();
+    }
+  });
+});

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -16,6 +16,7 @@
 import { and, desc, eq, type SQL, sql } from "drizzle-orm";
 import { dbWrite } from "../../db/helpers";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
+import { appsRepository } from "../../db/repositories/apps";
 import {
   hydrateJob,
   type Job,
@@ -29,7 +30,7 @@ import { assertSafeOutboundUrl } from "../security/outbound-url";
 import { logger } from "../utils/logger";
 import { withTimeout } from "../utils/with-timeout";
 import { dispatchAppDbDeprovisionJob } from "./app-db-deprovision-job-service";
-import { dispatchAppDeployJob } from "./app-deploy-job-service";
+import { dispatchAppDeployJob, readAppDeployJobData } from "./app-deploy-job-service";
 import { dispatchContainerJob, getContainerExecutorDeps } from "./container-job-service";
 import { elizaProvisionAdvisoryLockSql } from "./eliza-provision-lock";
 import { elizaSandboxService } from "./eliza-sandbox";
@@ -1437,6 +1438,31 @@ export class ProvisioningJobService {
               jobId: job.id,
               agentId: data.agentId,
               error: sandboxErr instanceof Error ? sandboxErr.message : String(sandboxErr),
+            });
+          }
+        }
+
+        // Apps lane (Product 2): symmetric handling for app_deploy. When the
+        // deploy runner permanently fails — most importantly when a non-apps
+        // daemon (one not pinned to PROVISIONING_JOB_LANES=agent yet) claims an
+        // APP_DEPLOY it can't run and throws "runner not configured" — flip the
+        // app's deployment_status to `failed` so the user/UI sees a real error
+        // instead of an app stuck forever in `building`. Without this, the row
+        // is silently stranded (the AGENT_* repairs above don't cover apps).
+        if (updated?.status === "failed" && job.type === JOB_TYPES.APP_DEPLOY) {
+          try {
+            const { appId } = readAppDeployJobData(job);
+            await appsRepository.update(appId, {
+              deployment_status: "failed",
+            });
+            logger.warn(
+              "[provisioning-jobs] Marked app deployment as failed after permanent failure",
+              { jobId: job.id, appId },
+            );
+          } catch (appErr) {
+            logger.error("[provisioning-jobs] Failed to mark app deployment as failed", {
+              jobId: job.id,
+              error: appErr instanceof Error ? appErr.message : String(appErr),
             });
           }
         }

--- a/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
+++ b/packages/cloud-shared/src/lib/services/provisioning-jobs.ts
@@ -16,7 +16,6 @@
 import { and, desc, eq, type SQL, sql } from "drizzle-orm";
 import { dbWrite } from "../../db/helpers";
 import { agentSandboxesRepository } from "../../db/repositories/agent-sandboxes";
-import { appsRepository } from "../../db/repositories/apps";
 import {
   hydrateJob,
   type Job,
@@ -30,7 +29,7 @@ import { assertSafeOutboundUrl } from "../security/outbound-url";
 import { logger } from "../utils/logger";
 import { withTimeout } from "../utils/with-timeout";
 import { dispatchAppDbDeprovisionJob } from "./app-db-deprovision-job-service";
-import { dispatchAppDeployJob, readAppDeployJobData } from "./app-deploy-job-service";
+import { dispatchAppDeployJob } from "./app-deploy-job-service";
 import { dispatchContainerJob, getContainerExecutorDeps } from "./container-job-service";
 import { elizaProvisionAdvisoryLockSql } from "./eliza-provision-lock";
 import { elizaSandboxService } from "./eliza-sandbox";
@@ -1438,31 +1437,6 @@ export class ProvisioningJobService {
               jobId: job.id,
               agentId: data.agentId,
               error: sandboxErr instanceof Error ? sandboxErr.message : String(sandboxErr),
-            });
-          }
-        }
-
-        // Apps lane (Product 2): symmetric handling for app_deploy. When the
-        // deploy runner permanently fails — most importantly when a non-apps
-        // daemon (one not pinned to PROVISIONING_JOB_LANES=agent yet) claims an
-        // APP_DEPLOY it can't run and throws "runner not configured" — flip the
-        // app's deployment_status to `failed` so the user/UI sees a real error
-        // instead of an app stuck forever in `building`. Without this, the row
-        // is silently stranded (the AGENT_* repairs above don't cover apps).
-        if (updated?.status === "failed" && job.type === JOB_TYPES.APP_DEPLOY) {
-          try {
-            const { appId } = readAppDeployJobData(job);
-            await appsRepository.update(appId, {
-              deployment_status: "failed",
-            });
-            logger.warn(
-              "[provisioning-jobs] Marked app deployment as failed after permanent failure",
-              { jobId: job.id, appId },
-            );
-          } catch (appErr) {
-            logger.error("[provisioning-jobs] Failed to mark app deployment as failed", {
-              jobId: job.id,
-              error: appErr instanceof Error ? appErr.message : String(appErr),
             });
           }
         }

--- a/packages/scripts/cloud/admin/daemons/apps-provisioning-worker.test.ts
+++ b/packages/scripts/cloud/admin/daemons/apps-provisioning-worker.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for the apps-control worker's config parsing + arm gate.
+ *
+ * The arm gate (APPS_DEPLOY_ENABLED!=="1" → idle, claims nothing) is the
+ * inert-by-default safety property the daemon's docs lean on: deploying the
+ * unit without arming it must be a no-op, never a half-running daemon. We test
+ * only the GATE-CLOSED path here — the gate-open path dynamically imports the
+ * (heavy, side-effectful) apps-deploy-backend and belongs to an integration test.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import {
+  armAppsDeployBackend,
+  readAppsWorkerConfig,
+} from "./apps-provisioning-worker";
+
+function makeLogger() {
+  return {
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    error: mock(() => {}),
+    debug: mock(() => {}),
+    // biome-ignore lint/suspicious/noExplicitAny: test double for the structured logger
+  } as any;
+}
+
+describe("readAppsWorkerConfig", () => {
+  test("defaults with empty env/argv", () => {
+    const c = readAppsWorkerConfig({}, []);
+    expect(c.pollIntervalMs).toBe(30_000);
+    expect(c.batchSize).toBe(3);
+    expect(c.runOnce).toBe(false);
+  });
+
+  test("parses WORKER_POLL_INTERVAL + WORKER_BATCH_SIZE", () => {
+    const c = readAppsWorkerConfig(
+      { WORKER_POLL_INTERVAL: "5000", WORKER_BATCH_SIZE: "10" },
+      [],
+    );
+    expect(c.pollIntervalMs).toBe(5_000);
+    expect(c.batchSize).toBe(10);
+  });
+
+  test("falls back to defaults on garbage / non-positive values", () => {
+    const c = readAppsWorkerConfig(
+      { WORKER_POLL_INTERVAL: "not-a-number", WORKER_BATCH_SIZE: "-4" },
+      [],
+    );
+    expect(c.pollIntervalMs).toBe(30_000);
+    expect(c.batchSize).toBe(3);
+  });
+
+  test("runOnce via WORKER_RUN_ONCE=1 or --once flag", () => {
+    expect(readAppsWorkerConfig({ WORKER_RUN_ONCE: "1" }, []).runOnce).toBe(
+      true,
+    );
+    expect(readAppsWorkerConfig({}, ["--once"]).runOnce).toBe(true);
+    expect(readAppsWorkerConfig({ WORKER_RUN_ONCE: "0" }, []).runOnce).toBe(
+      false,
+    );
+  });
+});
+
+describe("armAppsDeployBackend — gate-closed safety", () => {
+  test("returns false and idles when APPS_DEPLOY_ENABLED is unset", async () => {
+    const prev = process.env.APPS_DEPLOY_ENABLED;
+    delete process.env.APPS_DEPLOY_ENABLED;
+    try {
+      const logger = makeLogger();
+      const armed = await armAppsDeployBackend(logger);
+      expect(armed).toBe(false);
+      expect(logger.warn).toHaveBeenCalled();
+      // It must NOT log "armed" when the gate is closed.
+      expect(logger.info).not.toHaveBeenCalled();
+    } finally {
+      if (prev === undefined) delete process.env.APPS_DEPLOY_ENABLED;
+      else process.env.APPS_DEPLOY_ENABLED = prev;
+    }
+  });
+
+  test("returns false when APPS_DEPLOY_ENABLED is any value other than '1'", async () => {
+    const prev = process.env.APPS_DEPLOY_ENABLED;
+    process.env.APPS_DEPLOY_ENABLED = "true"; // not exactly "1"
+    try {
+      const armed = await armAppsDeployBackend(makeLogger());
+      expect(armed).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.APPS_DEPLOY_ENABLED;
+      else process.env.APPS_DEPLOY_ENABLED = prev;
+    }
+  });
+});

--- a/packages/scripts/cloud/admin/daemons/apps-provisioning-worker.ts
+++ b/packages/scripts/cloud/admin/daemons/apps-provisioning-worker.ts
@@ -105,7 +105,9 @@ async function loadDeps(): Promise<AppsWorkerDeps> {
  * worker. Gated on `APPS_DEPLOY_ENABLED=1`: returns false when unset so a
  * deployed-but-not-armed daemon idles instead of half-running.
  */
-async function armAppsDeployBackend(logger: WorkerLogger): Promise<boolean> {
+export async function armAppsDeployBackend(
+  logger: WorkerLogger,
+): Promise<boolean> {
   if (process.env.APPS_DEPLOY_ENABLED !== "1") {
     logger.warn(
       "[apps-worker] APPS_DEPLOY_ENABLED is not '1' — deploy backend NOT armed; " +
@@ -223,11 +225,17 @@ process.on("SIGTERM", () => {
 });
 
 process.on("unhandledRejection", (reason) => {
-  void loadDeps().then(({ logger }) => {
-    logger.error("[apps-worker] unhandled rejection", {
-      error: reason instanceof Error ? reason.message : String(reason),
+  const reasonStr = reason instanceof Error ? reason.message : String(reason);
+  // Fall back to stderr if the logger import itself rejects (e.g. a rejection
+  // around startup before deps are loaded) so the original reason is never
+  // silently swallowed.
+  void loadDeps()
+    .then(({ logger }) => {
+      logger.error("[apps-worker] unhandled rejection", { error: reasonStr });
+    })
+    .catch(() => {
+      process.stderr.write(`[apps-worker] unhandled rejection: ${reasonStr}\n`);
     });
-  });
 });
 
 if (isMainModule()) {


### PR DESCRIPTION
## Audit follow-ups to #8514 (apps-control plane)

After #8514 merged I ran an adversarial self-audit of it. It found two real gaps — fixed here.

### 1. Surface failed `APP_DEPLOY` (HIGH, user-facing)
Rollout hazard: if the apps-worker is armed **before** the main control-plane daemon is pinned to `PROVISIONING_JOB_LANES=agent`, the unpinned main daemon (fail-open → all 18 types) keeps claiming `APP_DEPLOY` rows it can't run. On that host the apps backend isn't armed, so `getAppDeployRunner()` throws "runner not configured"; after `max_attempts` the job flips to `failed`. But the post-failure status-repair only special-cased `AGENT_PROVISION`/`AGENT_DELETE`, so a failed `APP_DEPLOY` left the app **stuck in `building` with no surfaced error**.

Fix: add the symmetric `APP_DEPLOY` branch → set `deployment_status = 'failed'` so the UI shows a real error instead of hanging. This is defense-in-depth; the correct rollout still pins the main daemon to `agent` **before** arming apps (documented in the daemon header + the arm workflow), but now a botched order is *visible*, not silent.

### 2. Cover the lane seam (I'd said "tested everywhere" — only the resolver was)
- **`provisioning-jobs-lanes.test.ts`** — proves `processPendingJobs({ jobTypes })` claims **and** stale-recovers **only** that lane (apps-only never an agent type; agent-only never an apps type; default = all 18). Guards against a future refactor silently dropping the `recoverStaleJobs(jobTypes)` scoping (which would let one lane's daemon reset the other lane's stale rows).
- **`apps-provisioning-worker.test.ts`** — `readAppsWorkerConfig` parsing + the arm-gate **closed** path (`APPS_DEPLOY_ENABLED != '1'` → idle), the inert-by-default safety the daemon's docs lean on. (Exported `armAppsDeployBackend` for it.)

### 3. Daemon robustness (low)
Hardened the apps daemon's `unhandledRejection` handler with a stderr fallback so a deps-import rejection can't swallow the original reason.

**26 tests pass** (17 resolver + 3 lane-seam + 6 daemon). Inert-by-default, backward-compatible — same as #8514.

Refs #8514 #8434
