### PR TITLE
fix(android): ship the full Capacitor plugin set that actually loads (#8387) + stop the first-run notification nag

### DIFF
--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/ElizaAgentService.java
@@ -2198,6 +2198,23 @@ public class ElizaAgentService extends Service {
         return !"cloud".equals(mode);
     }
 
+    /**
+     * True once the user (or the device image) has actually committed to
+     * running the on-device agent — a branded device, or a stock phone whose
+     * runtime mode has been explicitly persisted by the onboarding picker.
+     *
+     * Distinct from {@link #shouldAutoStart}: a fresh stock install has no
+     * persisted mode yet, so the agent still auto-starts (so the dashboard has
+     * something to talk to) but the user has chosen nothing. We use this to
+     * avoid cold-asking for notification consent during first-run onboarding —
+     * iOS-style, we ask only after there is a committed reason (the foreground
+     * service still runs without the grant; its notification is just
+     * suppressed until later granted).
+     */
+    public static boolean hasCommittedRuntimeChoice(Context context) {
+        return isBrandedDevice() || readRuntimeMode(context) != null;
+    }
+
     private static boolean isBrandedDevice() {
         // AOSP / ElizaOS images set ro.elizaos.product. White-label forks
         // that use a different sysprop should override shouldAutoStart locally.

--- a/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
+++ b/packages/app-core/platforms/android/app/src/main/java/ai/elizaos/app/MainActivity.java
@@ -104,9 +104,20 @@ public class MainActivity extends BridgeActivity {
         // the user opens the app.
         if (ElizaAgentService.shouldAutoStart(this)) {
             ElizaAgentService.start(this);
+            // Ask for notification consent only once the user (or the device
+            // image) has actually committed to running the on-device agent.
+            // A fresh stock install auto-starts the service so the dashboard
+            // has something to talk to, but the user has chosen nothing yet —
+            // cold-asking there is the first-run nag we want to avoid
+            // (iOS-style: ask only when there is a reason). The foreground
+            // service still runs without the grant; its notification is just
+            // suppressed until later granted in settings or on a later launch
+            // once a runtime mode is persisted.
+            if (ElizaAgentService.hasCommittedRuntimeChoice(this)) {
+                requestPostNotificationsIfNeeded();
+            }
         }
 
-        requestPostNotificationsIfNeeded();
         ElizaWorkScheduler.enqueuePeriodic(getApplicationContext());
     }
 

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -1104,6 +1104,46 @@ async function ensurePlatform(platform) {
  * (net::ERR_CONNECTION_REFUSED). Mirror the synced payload into androidDir.
  * No-op when both trees resolve to the same directory (standalone layout).
  */
+// `@elizaos/capacitor-bun-runtime` is an app-core-only native module (it powers
+// the on-device Bun agent runtime) and is NOT a `packages/app` dependency, so
+// `cap sync` never emits it. Now that `android.path` makes cap sync regenerate
+// capacitor.settings.gradle / capacitor.build.gradle in place, those files would
+// lose bun-runtime on every sync. Re-register it idempotently after each sync so
+// the on-device agent keeps building (exact module name + projectDir the
+// committed files used).
+function ensureBunRuntimeRegistered() {
+  const MODULE = "elizaos-capacitor-bun-runtime";
+  const PROJECT_DIR = "../../../../plugins/plugin-native-bun-runtime/android";
+  const settingsPath = path.join(androidDir, "capacitor.settings.gradle");
+  const buildGradlePath = path.join(
+    androidDir,
+    "app",
+    "capacitor.build.gradle",
+  );
+
+  if (fs.existsSync(settingsPath)) {
+    let settings = fs.readFileSync(settingsPath, "utf8");
+    if (!settings.includes(`':${MODULE}'`)) {
+      settings = `${settings.trimEnd()}\ninclude ':${MODULE}'\nproject(':${MODULE}').projectDir = new File('${PROJECT_DIR}')\n`;
+      fs.writeFileSync(settingsPath, settings);
+      console.log(
+        `[mobile-build] Re-registered ${MODULE} (cap sync omits this app-core-only module).`,
+      );
+    }
+  }
+
+  if (fs.existsSync(buildGradlePath)) {
+    let build = fs.readFileSync(buildGradlePath, "utf8");
+    if (!build.includes(`project(':${MODULE}')`)) {
+      build = build.replace(
+        /dependencies\s*\{/,
+        `dependencies {\n    implementation project(':${MODULE}')`,
+      );
+      fs.writeFileSync(buildGradlePath, build);
+    }
+  }
+}
+
 function mirrorCapacitorWebPayloadIntoAndroidDir() {
   const syncedAssets = path.join(
     appDir,
@@ -6032,6 +6072,7 @@ async function buildAndroid() {
   await buildMobileAgentBundle();
   await ensurePlatform("android");
   await runCapacitor(["sync", "android"]);
+  ensureBunRuntimeRegistered();
   mirrorCapacitorWebPayloadIntoAndroidDir();
 
   patchAndroidGradle();
@@ -6328,6 +6369,7 @@ async function buildAndroidCloud({ debug = false } = {}) {
   await buildWeb(debug ? "android-cloud-debug" : "android-cloud");
   await ensurePlatform("android");
   await runCapacitor(["sync", "android"]);
+  ensureBunRuntimeRegistered();
 
   patchAndroidGradle();
   await generateAndroidBrandAssets();
@@ -6419,6 +6461,7 @@ async function buildAndroidSmsGateway() {
   await buildWeb("android-cloud-debug");
   await ensurePlatform("android");
   await runCapacitor(["sync", "android"]);
+  ensureBunRuntimeRegistered();
 
   patchAndroidGradle();
   await generateAndroidBrandAssets();
@@ -6615,6 +6658,7 @@ async function buildAndroidSystem() {
   await buildMobileAgentBundle();
   await ensurePlatform("android");
   await runCapacitor(["sync", "android"]);
+  ensureBunRuntimeRegistered();
 
   patchAndroidGradle();
   await generateAndroidBrandAssets();

--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -1236,9 +1236,27 @@ function reconcilePluginManifestWithGradle(targetAssets) {
   const stubLlamaCpp =
     process.env.ELIZA_ANDROID_SKIP_FORK_LLAMA_LIB === "1" ||
     process.env.elizaSkipForkLlamaLib === "true";
+  // Third-party Capacitor plugins that `cap sync` includes (they ship an
+  // android/ dir, so they ARE in capacitor.settings.gradle) but whose Kotlin
+  // plugin class never lands in the app dex on AGP 8.x: both rely on AGP's
+  // built-in Kotlin instead of applying `org.jetbrains.kotlin.android`, so the
+  // built-in kotlinc compiles the .kt but does NOT bundle the .class into the
+  // library AAR. PluginManager.loadPluginClasses then throws "Could not find
+  // class …" on the first one and aborts the ENTIRE plugin load, so EVERY
+  // plugin (Browser, Haptics, Keyboard, …) silently fails to register. We can't
+  // edit node_modules durably, and neither is needed for the core Android app —
+  // background work uses WorkManager (ElizaWorkScheduler) and barcode scanning
+  // is a companion-pairing-only feature — so drop them from the manifest. (Our
+  // own native plugins fix this properly by applying the Kotlin plugin in their
+  // android/build.gradle.)
+  const nonBundlingThirdPartyPlugins = new Set([
+    "@capacitor/background-runner",
+    "@capacitor/barcode-scanner",
+  ]);
   const isCompiledAndUsable = (plugin) => {
     if (!compiledProjects.has(gradleProjectFor(plugin?.pkg))) return false;
     if (stubLlamaCpp && plugin?.pkg === "llama-cpp-capacitor") return false;
+    if (nonBundlingThirdPartyPlugins.has(plugin?.pkg)) return false;
     return true;
   };
   const kept = plugins.filter(isCompiledAndUsable);

--- a/packages/app/capacitor.config.ts
+++ b/packages/app/capacitor.config.ts
@@ -155,6 +155,15 @@ const config: CapacitorConfig = {
     webContentsDebuggingEnabled: webViewDebuggingEnabled,
   },
   android: {
+    // Point `cap sync` at the SAME android project gradle actually builds
+    // (packages/app-core/platforms/android, resolved relative to this config).
+    // Without this, cap sync writes a full project to packages/app/android while
+    // gradle builds app-core/platforms/android off a STALE committed
+    // capacitor.settings.gradle — so native plugins (@capacitor/browser, haptics,
+    // …) silently never compile and get pruned from the manifest (#8387). With
+    // the path unified, cap sync regenerates the full plugin set in place every
+    // build and nothing drifts.
+    path: "../app-core/platforms/android",
     backgroundColor: "#FF5800",
     allowMixedContent: false,
     captureInput: true,

--- a/plugins/plugin-native-appblocker/android/build.gradle
+++ b/plugins/plugin-native-appblocker/android/build.gradle
@@ -7,6 +7,11 @@ ext {
 }
 
 apply plugin: 'com.android.library'
+// Apply the Kotlin Android plugin so the plugin's .kt class is bundled into the
+// library AAR. Without it AGP's built-in kotlinc compiles the sources but does
+// NOT bundle the .class files, so the Capacitor plugin class is absent from the
+// app dex at runtime (PluginLoadException -> the whole plugin set fails to load).
+apply plugin: 'org.jetbrains.kotlin.android'
 android {
     namespace = "ai.eliza.plugins.appblocker"
     compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 34
@@ -27,6 +32,9 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
     }
 
 }

--- a/plugins/plugin-native-contacts/android/build.gradle
+++ b/plugins/plugin-native-contacts/android/build.gradle
@@ -3,6 +3,11 @@ ext {
 }
 
 apply plugin: 'com.android.library'
+// Apply the Kotlin Android plugin so the plugin's .kt class is bundled into the
+// library AAR. Without it AGP's built-in kotlinc compiles the sources but does
+// NOT bundle the .class files, so the Capacitor plugin class is absent from the
+// app dex at runtime (PluginLoadException -> the whole plugin set fails to load).
+apply plugin: 'org.jetbrains.kotlin.android'
 android {
     namespace = "ai.eliza.plugins.contacts"
     compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 34
@@ -13,6 +18,9 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
     }
 }
 

--- a/plugins/plugin-native-messages/android/build.gradle
+++ b/plugins/plugin-native-messages/android/build.gradle
@@ -3,6 +3,11 @@ ext {
 }
 
 apply plugin: 'com.android.library'
+// Apply the Kotlin Android plugin so the plugin's .kt class is bundled into the
+// library AAR. Without it AGP's built-in kotlinc compiles the sources but does
+// NOT bundle the .class files, so the Capacitor plugin class is absent from the
+// app dex at runtime (PluginLoadException -> the whole plugin set fails to load).
+apply plugin: 'org.jetbrains.kotlin.android'
 android {
     namespace = "ai.eliza.plugins.messages"
     compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 34
@@ -13,6 +18,9 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
     }
 }
 

--- a/plugins/plugin-native-phone/android/build.gradle
+++ b/plugins/plugin-native-phone/android/build.gradle
@@ -6,6 +6,11 @@ ext {
 }
 
 apply plugin: 'com.android.library'
+// Apply the Kotlin Android plugin so the plugin's .kt class is bundled into the
+// library AAR. Without it AGP's built-in kotlinc compiles the sources but does
+// NOT bundle the .class files, so the Capacitor plugin class is absent from the
+// app dex at runtime (PluginLoadException -> the whole plugin set fails to load).
+apply plugin: 'org.jetbrains.kotlin.android'
 android {
     namespace = "ai.eliza.plugins.phone"
     compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 34
@@ -16,6 +21,9 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
     }
 }
 

--- a/plugins/plugin-native-system/android/build.gradle
+++ b/plugins/plugin-native-system/android/build.gradle
@@ -4,6 +4,11 @@ ext {
 }
 
 apply plugin: 'com.android.library'
+// Apply the Kotlin Android plugin so the plugin's .kt class is bundled into the
+// library AAR. Without it AGP's built-in kotlinc compiles the sources but does
+// NOT bundle the .class files, so the Capacitor plugin class is absent from the
+// app dex at runtime (PluginLoadException -> the whole plugin set fails to load).
+apply plugin: 'org.jetbrains.kotlin.android'
 android {
     namespace = "ai.eliza.plugins.system"
     compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 34
@@ -14,6 +19,9 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
     }
 }
 

--- a/plugins/plugin-native-wifi/android/build.gradle
+++ b/plugins/plugin-native-wifi/android/build.gradle
@@ -3,6 +3,11 @@ ext {
 }
 
 apply plugin: 'com.android.library'
+// Apply the Kotlin Android plugin so the plugin's .kt class is bundled into the
+// library AAR. Without it AGP's built-in kotlinc compiles the sources but does
+// NOT bundle the .class files, so the Capacitor plugin class is absent from the
+// app dex at runtime (PluginLoadException -> the whole plugin set fails to load).
+apply plugin: 'org.jetbrains.kotlin.android'
 android {
     namespace = "ai.eliza.plugins.wifi"
     compileSdk project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 34
@@ -13,6 +18,9 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
     }
 }
 


### PR DESCRIPTION
Three self-contained Android prod-readiness fixes, split out of the overlay-motion work so they merge independently of the in-flight chat-sheet UI (no overlap with `ContinuousChatOverlay`/onboarding files shaw is tuning).

## 1. Restore `android.path` so `cap sync` ships the full plugin set (#8387)

`cap sync` wrote a full project to `packages/app/android` while gradle builds `packages/app-core/platforms/android` off a **stale committed** `capacitor.settings.gradle` — so native plugins (`@capacitor/browser`, `haptics`, `push-notifications`, …) silently never compiled and were pruned from the manifest. That's why **cloud sign-in (`Browser.open`) was a no-op** and detent haptics did nothing.

- `capacitor.config.ts`: point `android.path` at `../app-core/platforms/android` so `cap sync` regenerates the full plugin set **in place** every build.
- `run-mobile-build.mjs`: `ensureBunRuntimeRegistered()` re-appends `elizaos-capacitor-bun-runtime` after each `cap sync` (cap sync drops it; the on-device Bun agent needs it).

## 2. Make the full plugin set actually LOAD at runtime

After #1 the plugins compiled (APK +100 MB) but Capacitor still logged `E Capacitor: Error loading plugins` and **every** plugin reported "not implemented on android". Root cause: `PluginManager.loadPluginClasses` throws on the **first** plugin whose class isn't on the dex and aborts the whole load — so one bad plugin kills the entire set. 8 classes were in `capacitor.plugins.json` but missing from the dex, both for Kotlin-bundling reasons:

- **6 of our own native plugins** (system, phone, wifi, contacts, messages, appblocker) never applied `org.jetbrains.kotlin.android`. On AGP 8.x the built-in kotlinc compiles `.kt` but does **not** bundle the `.class` into the library AAR. Apply the Kotlin plugin (+ matching `jvmTarget`) in each `android/build.gradle`, exactly as the working plugins (camera) do.
- **`@capacitor/background-runner` + `@capacitor/barcode-scanner`** have the same upstream bug but live in `node_modules` (not committable) and aren't needed on Android (background work = WorkManager/`ElizaWorkScheduler`; barcode = companion-pairing only). Drop them from `capacitor.plugins.json` in the manifest reconciler.

**Result (verified on a Solana Seeker):** no more `Error loading plugins`; all 6 native classes on the dex; `@capacitor/browser` registers → **cloud sign-in's in-app Custom Tab opens immediately on "Start now"** (the "Open the sign-in page" fallback screen only appeared because `Browser.open` was throwing); haptics + keyboard work.

## 3. Don't cold-ask for notifications during first-run onboarding

On a stock phone a fresh install has no persisted runtime mode, so `shouldAutoStart()` returns true (agent auto-starts so the dashboard isn't stranded) and `MainActivity` fired the `POST_NOTIFICATIONS` dialog **during onboarding, before any choice**. Add `ElizaAgentService.hasCommittedRuntimeChoice()` (branded device, or an explicitly-persisted `mobile-runtime-mode`) and only ask once that's true. The FGS still runs; its notification is just suppressed until a mode is committed.

## Test plan
- [x] On-device build (`build:android`) succeeds; APK installs on a Seeker.
- [x] Cold first-run: no notification dialog; lands on the onboarding card.
- [x] `capacitor.plugins.json` is reconciled to the 26 plugins whose classes are on the dex; no `Error loading plugins` / `PluginLoadException` in logcat.
- [x] "Start now" → in-app Custom Tab opens the real `elizacloud.ai` CLI-auth page immediately (no second screen).
- [x] `run-mobile-build.mjs` passes `node --check`.