### PR TITLE
fix(cloud): make /api/auth/logout public so sign-out tears down the session

### DIFF
--- a/packages/cloud-api/src/middleware/auth.ts
+++ b/packages/cloud-api/src/middleware/auth.ts
@@ -45,6 +45,14 @@ const publicPathPrefixes = [
   "/api/auth/steward-session",
   "/api/auth/steward-nonce-exchange",
   "/api/auth/steward-refresh",
+  // Logout must be reachable without a valid session: the client clears the
+  // Steward cookies before (or independently of) this call, and an expired
+  // session still needs to tear down server state + clear cookies. The handler
+  // resolves the user best-effort and only ends sessions when one is present,
+  // so a public, idempotent logout is safe. Gating it (the prior behavior) made
+  // every logout 401 once cookies were gone, so the server-side teardown never
+  // ran and stale refresh cookies could silently re-mint a session.
+  "/api/auth/logout",
   "/api/set-anonymous-session",
   "/api/anonymous-session",
   "/api/auth/create-anonymous-session",

--- a/packages/cloud-frontend/src/components/canvas/cloud-canvas.tsx
+++ b/packages/cloud-frontend/src/components/canvas/cloud-canvas.tsx
@@ -6215,13 +6215,15 @@ export function CloudCanvas() {
       // Clear chat data (rooms, entityId, localStorage)
       useChatStore.getState().clearChatData();
 
+      // Server-side logout first (ends sessions + clears cookies while the
+      // session cookie is still present), then drop local Steward state.
+      await fetch("/api/auth/logout", { method: "POST" }).catch(() => {});
       if (stewardAuthenticated) {
         stewardSignOut();
         await fetch(STEWARD_SESSION_ENDPOINT, { method: "DELETE" }).catch(
           () => {},
         );
       }
-      await fetch("/api/auth/logout", { method: "POST" }).catch(() => {});
 
       // Use replace to avoid browser history pollution
       navigate("/", { replace: true });

--- a/packages/cloud-frontend/src/components/layout/user-menu.tsx
+++ b/packages/cloud-frontend/src/components/layout/user-menu.tsx
@@ -334,13 +334,16 @@ function UserMenuInner({ preserveWhileUnauthed = false }: UserMenuProps) {
       // Clear chat data (rooms, entityId, localStorage)
       clearChatData();
 
+      // Server-side logout first, while the Steward session cookie is still
+      // present, so it can end all sessions + clear cookies. Then drop the
+      // local Steward token and belt-and-suspenders the cookie clear.
+      await fetch("/api/auth/logout", { method: "POST" }).catch(() => {});
       if (stewardAuthenticated) {
         stewardSignOut();
         await fetch(STEWARD_SESSION_ENDPOINT, { method: "DELETE" }).catch(
           () => {},
         );
       }
-      await fetch("/api/auth/logout", { method: "POST" }).catch(() => {});
 
       // Use replace to avoid browser history pollution
       // This prevents back button issues after re-login

--- a/packages/cloud-frontend/src/dashboard/settings/_components/tabs/account-tab.tsx
+++ b/packages/cloud-frontend/src/dashboard/settings/_components/tabs/account-tab.tsx
@@ -74,23 +74,25 @@ export function AccountTab({ user, onTabChange }: AccountTabProps) {
     if (isLoggingOut) return;
     setIsLoggingOut(true);
 
-    // Clear chat data (rooms, entityId, localStorage)
-    clearChatData();
+    try {
+      // Clear chat data (rooms, entityId, localStorage)
+      clearChatData();
 
-    if (stewardAuthenticated) {
-      stewardSignOut();
-      await fetch(STEWARD_SESSION_ENDPOINT, {
-        method: "DELETE",
-      }).catch(() => {});
+      // Server-side logout first (ends sessions + clears cookies), then drop
+      // local Steward state. Every network step is best-effort: a failed call
+      // must never block the redirect or leave the button stuck spinning.
+      await fetch("/api/auth/logout", { method: "POST" }).catch(() => {});
+      if (stewardAuthenticated) {
+        stewardSignOut();
+        await fetch(STEWARD_SESSION_ENDPOINT, { method: "DELETE" }).catch(
+          () => {},
+        );
+      }
+
+      toast.success("Logged out successfully");
+    } finally {
+      window.location.href = "/";
     }
-
-    await fetch("/api/auth/logout", {
-      method: "POST",
-    });
-
-    toast.success("Logged out successfully");
-
-    window.location.href = "/";
   };
 
   const handleContactSupport = () => {


### PR DESCRIPTION
## Problem

Signing out of Eliza Cloud throws/sticks and can leave the user still logged in.

Root cause: **`/api/auth/logout` was missing from the auth gate's public-path allowlist** (`packages/cloud-api/src/middleware/auth.ts`) — the only `/api/auth/*` endpoint that wasn't public. The sign-out flow clears the Steward cookies first (`DELETE /api/auth/steward-session`), so by the time the client POSTs `/api/auth/logout` the request is unauthenticated → the global middleware returns **401** before the handler runs. Net effect:

- `userSessionsService.endAllUserSessions()` + audit emit never execute.
- The route's own cookie clear (which uses the correct parent-domain scope) never runs, so a surviving `steward-refresh-token` cookie can silently re-mint a session → "can't log out".

Verified against prod: `POST https://elizacloud.ai/api/auth/logout` currently returns `401 {"code":"authentication_required"}`.

## Fix

- **`middleware/auth.ts`**: add `/api/auth/logout` to `publicPathPrefixes`. The handler already resolves the user best-effort and only ends sessions when one is present, so a public, idempotent logout is safe — same posture as the other public `/api/auth/*` routes (`steward-session`, `steward-refresh`, `siwe`, …).
- **`user-menu.tsx` / `cloud-canvas.tsx` / `account-tab.tsx`**: call `POST /api/auth/logout` *first* (while the session cookie is still present, so it can actually end sessions), then drop local Steward state. Every network step is best-effort so a failed call can never block the redirect or leave the sign-out button stuck spinning (the previous `account-tab` handler had an uncaught `await` that left `isLoggingOut` stuck on any failure).

## Test

- `packages/cloud-api/__tests__/middleware-auth-soc2.test.ts` — 8 pass / 0 fail.
- No test pinned `/api/auth/logout` as gated; biome clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)