### PR TITLE
fix(cloud): make /api/auth/logout public so sign-out tears down the session (prod hotfix)

### DIFF
--- a/packages/cloud-api/src/middleware/auth.ts
+++ b/packages/cloud-api/src/middleware/auth.ts
@@ -45,6 +45,14 @@ const publicPathPrefixes = [
   "/api/auth/steward-session",
   "/api/auth/steward-nonce-exchange",
   "/api/auth/steward-refresh",
+  // Logout must be reachable without a valid session: the client clears the
+  // Steward cookies before (or independently of) this call, and an expired
+  // session still needs to tear down server state + clear cookies. The handler
+  // resolves the user best-effort and only ends sessions when one is present,
+  // so a public, idempotent logout is safe. Gating it (the prior behavior) made
+  // every logout 401 once cookies were gone, so the server-side teardown never
+  // ran and stale refresh cookies could silently re-mint a session.
+  "/api/auth/logout",
   "/api/set-anonymous-session",
   "/api/anonymous-session",
   "/api/auth/create-anonymous-session",

--- a/packages/cloud-frontend/src/components/canvas/cloud-canvas.tsx
+++ b/packages/cloud-frontend/src/components/canvas/cloud-canvas.tsx
@@ -6328,13 +6328,15 @@ export function CloudCanvas() {
       // Clear chat data (rooms, entityId, localStorage)
       useChatStore.getState().clearChatData();
 
+      // Server-side logout first (ends sessions + clears cookies while the
+      // session cookie is still present), then drop local Steward state.
+      await fetch("/api/auth/logout", { method: "POST" }).catch(() => {});
       if (stewardAuthenticated) {
         stewardSignOut();
         await fetch(STEWARD_SESSION_ENDPOINT, { method: "DELETE" }).catch(
           () => {},
         );
       }
-      await fetch("/api/auth/logout", { method: "POST" }).catch(() => {});
 
       // Use replace to avoid browser history pollution
       navigate("/", { replace: true });

--- a/packages/cloud-frontend/src/components/layout/user-menu.tsx
+++ b/packages/cloud-frontend/src/components/layout/user-menu.tsx
@@ -334,13 +334,16 @@ function UserMenuInner({ preserveWhileUnauthed = false }: UserMenuProps) {
       // Clear chat data (rooms, entityId, localStorage)
       clearChatData();
 
+      // Server-side logout first, while the Steward session cookie is still
+      // present, so it can end all sessions + clear cookies. Then drop the
+      // local Steward token and belt-and-suspenders the cookie clear.
+      await fetch("/api/auth/logout", { method: "POST" }).catch(() => {});
       if (stewardAuthenticated) {
         stewardSignOut();
         await fetch(STEWARD_SESSION_ENDPOINT, { method: "DELETE" }).catch(
           () => {},
         );
       }
-      await fetch("/api/auth/logout", { method: "POST" }).catch(() => {});
 
       // Use replace to avoid browser history pollution
       // This prevents back button issues after re-login

--- a/packages/cloud-frontend/src/dashboard/settings/_components/tabs/account-tab.tsx
+++ b/packages/cloud-frontend/src/dashboard/settings/_components/tabs/account-tab.tsx
@@ -74,23 +74,25 @@ export function AccountTab({ user, onTabChange }: AccountTabProps) {
     if (isLoggingOut) return;
     setIsLoggingOut(true);
 
-    // Clear chat data (rooms, entityId, localStorage)
-    clearChatData();
+    try {
+      // Clear chat data (rooms, entityId, localStorage)
+      clearChatData();
 
-    if (stewardAuthenticated) {
-      stewardSignOut();
-      await fetch(STEWARD_SESSION_ENDPOINT, {
-        method: "DELETE",
-      }).catch(() => {});
+      // Server-side logout first (ends sessions + clears cookies), then drop
+      // local Steward state. Every network step is best-effort: a failed call
+      // must never block the redirect or leave the button stuck spinning.
+      await fetch("/api/auth/logout", { method: "POST" }).catch(() => {});
+      if (stewardAuthenticated) {
+        stewardSignOut();
+        await fetch(STEWARD_SESSION_ENDPOINT, { method: "DELETE" }).catch(
+          () => {},
+        );
+      }
+
+      toast.success("Logged out successfully");
+    } finally {
+      window.location.href = "/";
     }
-
-    await fetch("/api/auth/logout", {
-      method: "POST",
-    });
-
-    toast.success("Logged out successfully");
-
-    window.location.href = "/";
   };
 
   const handleContactSupport = () => {


### PR DESCRIPTION
**Prod hotfix** — production deploys from `main` (`cloud-cf-deploy.yml`). Forward-port to `develop`: elizaOS/eliza#8520.

## Problem

Signing out of Eliza Cloud (elizacloud.ai) throws/sticks and can leave the user still logged in.

Root cause: **`/api/auth/logout` is missing from the auth gate's public-path allowlist** (`packages/cloud-api/src/middleware/auth.ts`) — the only `/api/auth/*` endpoint that isn't public. Sign-out clears the Steward cookies first (`DELETE /api/auth/steward-session`), so the subsequent `POST /api/auth/logout` is unauthenticated and the global middleware returns **401** before the handler runs:

- `endAllUserSessions()` + audit never execute.
- The route's own parent-domain cookie clear never runs, so a surviving `steward-refresh-token` cookie can silently re-mint a session → "can't log out".

Verified live: `POST https://elizacloud.ai/api/auth/logout` returns `401 {"code":"authentication_required"}`.

## Fix

- `middleware/auth.ts`: add `/api/auth/logout` to `publicPathPrefixes`. The handler already resolves the user best-effort and only ends sessions when present, so a public, idempotent logout is safe (same posture as the other public `/api/auth/*` routes).
- `user-menu.tsx` / `cloud-canvas.tsx` / `account-tab.tsx`: call `POST /api/auth/logout` first (while the cookie is still present so it can end sessions), then drop local Steward state; every step best-effort so a failure can't block the redirect or stick the button (the old `account-tab` handler had an uncaught `await` that left `isLoggingOut` stuck).

## Test

- `packages/cloud-api/__tests__/middleware-auth-soc2.test.ts` — 8 pass / 0 fail. Biome clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)