### PR TITLE
fix(cloud): accept shared-runtime in BOTH first-run paths (native launch blocker)

### DIFF
--- a/packages/ui/src/first-run/use-first-run-controller.ts
+++ b/packages/ui/src/first-run/use-first-run-controller.ts
@@ -613,6 +613,11 @@ export function useFirstRunController(): FirstRunController {
         name,
         bio,
         onProgress: () => {},
+        // Cloud returns a shared-runtime agent (no dedicated container) for the
+        // default tier on every non-iOS platform. Without this flag the client
+        // throws "shared runtime has no sandbox bridge" and first-run bricks for
+        // new Android/desktop users. Mirrors the useFirstRunCallbacks path.
+        allowSharedRuntime: true,
       });
       client.setBaseUrl(provisionedAgent.bridgeUrl);
       client.setToken(authToken);

--- a/packages/ui/src/state/useFirstRunCallbacks.ts
+++ b/packages/ui/src/state/useFirstRunCallbacks.ts
@@ -647,7 +647,18 @@ export function useFirstRunCallbacks(deps: FirstRunCallbacksDeps) {
             name: firstRunName,
             bio: style?.bio ?? ["An autonomous AI agent."],
             onProgress: () => {},
-            allowSharedRuntime: shouldUseIosCloudLocalAgent(),
+            // Shared runtime is the shipping cloud provisioning mode —
+            // dedicated per-agent container-deploy is gated off for launch, so
+            // the cloud provisions every agent on the shared runtime and the
+            // client must accept it on EVERY platform (not just iOS). Without
+            // this, Android/desktop first-run threw "shared runtime has no
+            // sandbox bridge" right after a successful sign-in. The iOS-only
+            // on-device IPC routing below stays gated on
+            // shouldUseIosCloudLocalAgent(); only the accept decision is
+            // platform-independent. When dedicated sandboxes return, the
+            // provision response carries a bridgeUrl and the non-shared branch
+            // handles it unchanged.
+            allowSharedRuntime: true,
           });
 
           const iosCloudLocalAgent = shouldUseIosCloudLocalAgent();


### PR DESCRIPTION
## Problem
After a successful Eliza Cloud sign-in, Android/desktop first-run threw **"Failed to start provisioning: shared runtime has no sandbox bridge"** and bounced the user back to onboarding. (Reproduced on a Solana Seeker: Google sign-in succeeded, agent was created `201`, then provisioning "failed".)

## Root cause
The cloud provisions every agent on the **shared runtime** today — dedicated per-agent container-deploy is gated off for launch — so `POST /api/v1/eliza/agents/:id/provision` returns `source: "shared_runtime"`. `ElizaClient.provisionCloudSandbox` only accepts that when `options.allowSharedRuntime` is true; otherwise it throws (`client-cloud.ts:2524`).

The first-run caller passed `allowSharedRuntime: shouldUseIosCloudLocalAgent()` — an **iOS-only** signal — so on Android/desktop it was `false` and *every* cloud sign-in failed at provisioning.

## Fix
Pass `allowSharedRuntime: true` unconditionally in `useFirstRunCallbacks`. Accepting the shared runtime is platform-independent (it's the only mode the cloud offers right now). The iOS-only on-device IPC routing right below stays gated on `shouldUseIosCloudLocalAgent()` — only the *accept* decision changes. When dedicated sandboxes return, the provision response carries a real `bridgeUrl` and the existing non-shared branch handles it unchanged.

On shared runtime the client connects via the cloud bridge route `/api/v1/eliza/agents/:id/bridge` (already deployed).

## Test plan
- [x] `bun run --cwd packages/ui typecheck` — clean
- [x] `bun run --cwd packages/ui lint` — clean
- [ ] On-device: Google sign-in → agent provisions on shared runtime → lands in chat (verifying in a combined build)