### PR TITLE
fix(cloud-api): gate apps-deploy (503) + models/status GET 405 (launch hardening)

### DIFF
--- a/packages/cloud-api/v1/apps/[id]/deploy/route.ts
+++ b/packages/cloud-api/v1/apps/[id]/deploy/route.ts
@@ -25,6 +25,20 @@ const app = new Hono<AppEnv>();
 
 app.post("/", async (c) => {
   try {
+    // Product-2 container deploy is gated: until APPS_DEPLOY_ENABLED=1 on the
+    // Worker, the deploy trigger isn't wired (bootstrap-app.ts), so creating a
+    // deployment would flip the app to `building` with nothing to advance it —
+    // a stranded app, no URL, no recovery (#8434). Fail clean with 503 instead.
+    if (c.env.APPS_DEPLOY_ENABLED !== "1") {
+      return c.json(
+        {
+          success: false,
+          error: "App container deployment is not enabled",
+          code: "apps_deploy_disabled",
+        },
+        503,
+      );
+    }
     const user = await requireUserOrApiKeyWithOrg(c);
     const appId = c.req.param("id");
     if (!appId) {

--- a/packages/cloud-api/v1/models/status/route.ts
+++ b/packages/cloud-api/v1/models/status/route.ts
@@ -44,6 +44,20 @@ function isProviderUnavailable(modelId: string): {
 
 const app = new Hono<AppEnv>();
 
+// This endpoint is POST-only (it takes a body of model ids to check). Answer a
+// bare GET with a clean 405 instead of letting it fall through to the sibling
+// `[...model]` catalog splat, which 500s on the missing param.
+app.get("/", (c) =>
+  c.json(
+    {
+      success: false,
+      error: "Method not allowed; use POST",
+      code: "method_not_allowed",
+    },
+    405,
+  ),
+);
+
 app.post("/", async (c) => {
   try {
     await getCurrentUser(c).catch(() => null);


### PR DESCRIPTION
Two non-blocking hardening fixes surfaced by the launch-readiness verification sweep (do NOT gate launch; safe to land anytime).

**1. apps/[id]/deploy → 503 when not enabled.** Until Product-2 is armed (`APPS_DEPLOY_ENABLED=1` on the Worker), `POST /api/v1/apps/:id/deploy` would create a deployment that flips the app to `building` with no trigger to advance it → stranded app, no URL, no recovery. Now returns 503 `apps_deploy_disabled`. Auto-opens when `APPS_DEPLOY_ENABLED=1` lands (#8425). (Not web-reachable today — no deploy button — but closes the CLI footgun.)

**2. models/status GET → 405.** A bare GET fell through to the `[...model]` catalog splat and 500'd. Now a clean 405 (POST-only endpoint; POST unchanged). Verified live: POST works, all launch models `available:true`.

biome + typecheck clean. Refs #8434