### PR TITLE
fix(cloud-e2e): navigate to /dashboard/agents/deploy (green the lone stale e2e)

### DIFF
--- a/packages/test/cloud-e2e/tests/dashboard.spec.ts
+++ b/packages/test/cloud-e2e/tests/dashboard.spec.ts
@@ -47,10 +47,18 @@ test.describe("dashboard session", () => {
       expect(result.failed, JSON.stringify(result.errors)).toBe(0);
     };
 
-    await authenticatedPage.goto(`${stack.urls.frontend}/dashboard/agents`);
-    await authenticatedPage
-      .getByPlaceholder("e.g. trading-assistant")
-      .fill("e2e-dashboard-agent");
+    // Post-#8339 canvas redesign: the deploy form only mounts at the
+    // `/dashboard/agents/deploy` route (cloud-canvas.tsx selects the "deploy"
+    // item + maximizes there), not on the bare `/dashboard/agents` list. Go
+    // straight to it and wait for the name field before filling.
+    await authenticatedPage.goto(
+      `${stack.urls.frontend}/dashboard/agents/deploy`,
+    );
+    const nameField = authenticatedPage.getByPlaceholder(
+      "e.g. trading-assistant",
+    );
+    await nameField.waitFor({ state: "visible" });
+    await nameField.fill("e2e-dashboard-agent");
     // The dashboard now exposes the deploy flow inside the canvas workspace.
     // Custom images are always deployed to dedicated sandboxes; the UI
     // auto-selects and locks that tier so the API receives a routable image.


### PR DESCRIPTION
Greens the single deterministic cloud-e2e red (41 pass / 1 fail). After the #8339 canvas redesign the deploy form mounts only at `/dashboard/agents/deploy` (cloud-canvas.tsx:449), but the 'deploys an agent with a custom image' spec navigated to the bare `/dashboard/agents` list and filled immediately → no name field → `.fill()` fails. Navigate straight to `/deploy` + `waitFor({state:'visible'})` before filling. **Product is unaffected** — all backend provision/billing/IDOR E2Es pass; this is purely the test catching up to the route change.

Caveat: cloud-e2e needs the full mock stack to run, which I couldn't spin up locally — CI validates. If CI still flags it, the alternative is marking cloud-e2e non-required for the promote (the synthesis's fallback). Refs #8434