### PR TITLE
fix(apps): DirectPgExecutor accepts the tenant DB self-signed cert (real Product-2 blocker)

### DIFF
--- a/packages/cloud-shared/src/lib/services/tenant-db/direct-pg-executor.ts
+++ b/packages/cloud-shared/src/lib/services/tenant-db/direct-pg-executor.ts
@@ -21,7 +21,24 @@ export class DirectPgExecutor implements TenantDbSqlExecutor {
   }
 
   private async run(connectionString: string, statements: readonly string[]): Promise<void> {
-    const client = new Client({ connectionString });
+    // The apps tenant Postgres is a self-managed node on the PRIVATE apps
+    // network (10.30.x), provisioned with a self-signed cert. Current `pg`
+    // parses `sslmode=require` in the DSN as `verify-full` and rejects the
+    // self-signed chain ("self-signed certificate") — which would fail EVERY
+    // tenant-DB provision in prod. Strip `sslmode` from the DSN textually (NOT
+    // via `new URL().toString()`, which re-encodes the userinfo and can corrupt
+    // the admin password) and set `ssl` explicitly: still TLS in-transit, but
+    // skip CA-chain verification (safe — already private-network isolated). A
+    // DSN-level `sslmode` would otherwise win over an explicit `ssl` object.
+    // Verified live against the prod tenant DB (10.30.1.10) via the apps-control
+    // node e2e (connection reaches auth; the self-signed reject is gone).
+    const cleaned = connectionString
+      .replace(/[?&]sslmode=[^&]*/gi, (m) => (m[0] === "?" ? "?" : ""))
+      .replace(/\?$/, "");
+    const client = new Client({
+      connectionString: cleaned,
+      ssl: { rejectUnauthorized: false },
+    });
     await client.connect();
     try {
       for (const sql of statements) {


### PR DESCRIPTION
## Found by a LIVE e2e against the prod tenant DB

Stood up the dedicated apps-control node, armed the apps-worker, and ran an isolated-DB provisioning e2e directly against the prod tenant DB (10.30.1.10). **Every provision threw `self-signed certificate`.**

**Root cause:** the apps tenant Postgres is a self-managed node on the private apps net with a self-signed cert. Current `pg` parses the DSN's `sslmode=require` as `verify-full` and rejects the self-signed chain → `DirectPgExecutor` could never connect → **Product-2 could never provision a tenant DB in prod.** The unit tests mock the executor, so they couldn't catch this — only a live run could.

**Fix:** strip `sslmode` from the DSN textually (NOT via `new URL().toString()`, which re-encodes the userinfo and corrupts the admin password — I hit that too) and set `ssl: { rejectUnauthorized: false }` explicitly. Still TLS in-transit; skips CA-chain verification, which is safe on the isolated private network.

Verified live: the self-signed rejection is gone (the connection now reaches auth).

> Separately surfaced a prod ops issue (NOT this PR): the terraform `tenant_db_admin_dsn` password no longer matches the live tenant DB ('password authentication failed for user postgres') — flagged to @standujar to reconcile. Refs #8434 #8514