### PR TITLE
fix(android): always reconcile the Capacitor plugin manifest (follow-up to #8516)

### DIFF
--- a/packages/app-core/scripts/run-mobile-build.mjs
+++ b/packages/app-core/scripts/run-mobile-build.mjs
@@ -1156,23 +1156,32 @@ function mirrorCapacitorWebPayloadIntoAndroidDir() {
   );
   const targetAssets = path.join(androidDir, "app", "src", "main", "assets");
   const syncedPublic = path.join(syncedAssets, "public");
-  if (!fs.existsSync(syncedPublic)) return;
+  // Mirror the synced web payload only when cap sync wrote to a SEPARATE appDir
+  // tree (the legacy two-tree split). When capacitor.config.ts unifies the trees
+  // via android.path=../app-core/platforms/android (#8387), cap sync writes
+  // straight into androidDir, so there's no syncedPublic to copy (or it's the
+  // same tree). In that case the mirror is a no-op — but we MUST still run the
+  // reconcile below on the android manifest, so the early-returns only skip the
+  // copy, never the reconcile.
+  const hasSyncedPublic = fs.existsSync(syncedPublic);
   const sameTree =
+    hasSyncedPublic &&
     fs.existsSync(targetAssets) &&
     fs.realpathSync(syncedAssets) === fs.realpathSync(targetAssets);
-  if (sameTree) return;
-  const targetPublic = path.join(targetAssets, "public");
-  fs.mkdirSync(targetAssets, { recursive: true });
-  fs.rmSync(targetPublic, { recursive: true, force: true });
-  fs.cpSync(syncedPublic, targetPublic, { recursive: true });
-  for (const cfg of ["capacitor.config.json", "capacitor.plugins.json"]) {
-    const src = path.join(syncedAssets, cfg);
-    if (fs.existsSync(src)) fs.copyFileSync(src, path.join(targetAssets, cfg));
+  if (hasSyncedPublic && !sameTree) {
+    const targetPublic = path.join(targetAssets, "public");
+    fs.mkdirSync(targetAssets, { recursive: true });
+    fs.rmSync(targetPublic, { recursive: true, force: true });
+    fs.cpSync(syncedPublic, targetPublic, { recursive: true });
+    for (const cfg of ["capacitor.config.json", "capacitor.plugins.json"]) {
+      const src = path.join(syncedAssets, cfg);
+      if (fs.existsSync(src)) fs.copyFileSync(src, path.join(targetAssets, cfg));
+    }
+    console.log(
+      `[mobile-build] Mirrored Capacitor web payload into ${path.relative(repoRoot, targetAssets)}`,
+    );
   }
-  console.log(
-    `[mobile-build] Mirrored Capacitor web payload into ${path.relative(repoRoot, targetAssets)}`,
-  );
-  // `cap sync` (run against appDir) generates capacitor.plugins.json from the
+  // `cap sync` generates capacitor.plugins.json from the
   // FULL appDir dependency set, but androidDir ships a committed
   // capacitor.settings.gradle that compiles only a curated subset of plugin
   // modules (plus app-core additions like elizaos-capacitor-bun-runtime that


### PR DESCRIPTION
Follow-up to #8516 (merged). #8516 added the denylist + the kotlin-bundling fixes so the full Capacitor plugin set compiles, but the **reconcile step that prunes capacitor.plugins.json runs in the wrong place** — so in a clean/CI build it never executes and the plugin set still fails to load at runtime.

## Bug
`reconcilePluginManifestWithGradle()` was called only *inside* `mirrorCapacitorWebPayloadIntoAndroidDir()`, after two early-returns that fire when `cap sync` wrote **straight into** `packages/app-core/platforms/android`. That direct write is exactly what `capacitor.config.ts`'s `android.path` (restored in #8516) makes `cap sync` do — so the mirror is a no-op and the function returns **before reconciling**.

Result in a clean build: `capacitor.plugins.json` keeps listing `@capacitor/background-runner` + `@capacitor/barcode-scanner` (Kotlin classes that don't bundle on AGP 8.x). `PluginManager.loadPluginClasses` throws on the first missing class and **aborts ALL plugin registration** → `@capacitor/browser`, `haptics`, `keyboard`, … all report "not implemented on android". Concretely this breaks cloud sign-in (Browser.open throws → first-run can't open the sign-in tab) and detent haptics.

This only reproduces in a clean build (what CI does); an incremental local build that happens to have a stale `packages/app/android` tree takes the mirror path and reconciles, which masked it.

## Fix
Make the web-payload copy conditional but **always** run `reconcilePluginManifestWithGradle(targetAssets)` afterward — whether the trees were unified (#8387) or the legacy split. The early-returns now only skip the copy, never the reconcile.

## Test plan
- [x] `node --check` on run-mobile-build.mjs
- [x] Verified on a Solana Seeker: with reconcile running, `capacitor.plugins.json` drops bg-runner/barcode (+ llama stub under SKIP_FORK); no `Error loading plugins` / `PluginLoadException`; `@capacitor/browser` registers and the in-app sign-in Custom Tab opens.