### PR TITLE
feat(boot): asynchronously generate + fade in first-turn capability

### DIFF
--- a/packages/agent/src/api/conversation-routes.ts
+++ b/packages/agent/src/api/conversation-routes.ts
@@ -203,6 +203,16 @@ function persistDeletedConversationIdsToState(ids: Set<string>): void {
 
 export interface ConversationRouteState {
   runtime: AgentRuntime | null;
+  /** Current agent lifecycle state (mirrors ServerState.agentState). */
+  agentState?: string;
+  /**
+   * Hold a chat turn through the warming window (early API bind → runtime ready)
+   * instead of 503-dropping it; resolves with the live runtime or null on
+   * timeout. Provided by the coerced ServerState; see ServerState.awaitRuntimeReady.
+   */
+  awaitRuntimeReady?:
+    | ((timeoutMs: number) => Promise<AgentRuntime | null>)
+    | null;
   config: ElizaConfig;
   agentName: string;
   adminEntityId: UUID | null;
@@ -218,6 +228,35 @@ export interface ConversationRouteState {
 
 export interface ConversationRouteContext extends RouteRequestContext {
   state: ConversationRouteState;
+}
+
+/**
+ * How long a chat turn may HOLD waiting for first-turn capability during the
+ * warming window (early API bind → runtime ready). Normal boots resolve in ~2s;
+ * the cap bounds the hold so a genuinely-stuck boot still fails fast.
+ */
+const WARMING_TURN_HOLD_MS = 30_000;
+
+/**
+ * Resolve the runtime for a chat turn, HOLDING through the warming window
+ * instead of 503-dropping. Returns the live runtime immediately if present;
+ * otherwise, only while the agent is actively warming up (`starting`/
+ * `restarting`), waits up to WARMING_TURN_HOLD_MS for capability to come online.
+ * A genuinely stopped/errored agent (or one with no gate wired) returns null so
+ * the caller fails fast with the usual 503.
+ */
+async function resolveRuntimeForChatTurn(
+  state: ConversationRouteState,
+): Promise<AgentRuntime | null> {
+  if (state.runtime) {
+    return state.runtime;
+  }
+  const warming =
+    state.agentState === "starting" || state.agentState === "restarting";
+  if (!warming || !state.awaitRuntimeReady) {
+    return state.runtime ?? null;
+  }
+  return state.awaitRuntimeReady(WARMING_TURN_HOLD_MS);
 }
 
 // ---------------------------------------------------------------------------
@@ -1613,7 +1652,10 @@ export async function handleConversationRoutes(
       metadata: chatMetadata,
     } = chatPayload;
 
-    const runtime = state.runtime;
+    // Hold the streaming turn through the warming window instead of dropping it
+    // — the client already shows the optimistic bubble + typing indicator, and
+    // the response streams the instant first-turn capability comes online.
+    const runtime = await resolveRuntimeForChatTurn(state);
     if (!runtime) {
       disconnectTracker.markCompleted();
       disconnectTracker.dispose();
@@ -1959,7 +2001,9 @@ export async function handleConversationRoutes(
       source,
       metadata: restMetadata,
     } = chatPayload;
-    const runtime = state.runtime;
+    // Hold the turn through the warming window (early API bind → runtime ready)
+    // instead of dropping it; the client already shows the optimistic bubble.
+    const runtime = await resolveRuntimeForChatTurn(state);
     if (!runtime) {
       error(res, "Agent is not running", 503);
       return true;

--- a/packages/agent/src/api/health-routes.ts
+++ b/packages/agent/src/api/health-routes.ts
@@ -1,5 +1,6 @@
 import type http from "node:http";
 import type { AgentRuntime } from "@elizaos/core";
+import { hasTextGenerationHandler } from "@elizaos/core";
 import type { ElizaConfig } from "../config/config.ts";
 import { detectRuntimeModel } from "./agent-model.ts";
 import type { ConnectorHealthMonitor } from "./connector-health.ts";
@@ -447,6 +448,31 @@ function serializeForRuntimeDebug(
 // ---------------------------------------------------------------------------
 
 /**
+ * "First-turn capability online": the agent can actually produce a response.
+ *
+ * Distinct from `ready` (which is `true` even for stopped/error/paused states —
+ * it only negates `starting`/`restarting`). `canRespond` ANDs a live runtime, a
+ * `running` state, AND a registered TEXT_GENERATION handler — so it is `false`
+ * when no model provider is wired (local-inference is optional) and only flips
+ * `true` at the exact moment the agent can answer a first turn. This is the
+ * signal the UI uses to fade in first-turn capability: the shell paints early
+ * (agentState "starting"), and the composer goes live when this flips.
+ */
+function computeCanRespond(
+  runtime: AgentRuntime | null,
+  agentState: string,
+): boolean {
+  if (!runtime || agentState !== "running") {
+    return false;
+  }
+  try {
+    return hasTextGenerationHandler(runtime);
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Handle health / status / runtime introspection routes.
  * Returns `true` if the request was handled.
  */
@@ -514,6 +540,7 @@ export async function handleHealthRoutes(
       state: state.agentState,
       agentName: state.agentName,
       model,
+      canRespond: computeCanRespond(state.runtime, state.agentState),
       startedAt: state.startedAt,
       uptime,
       startup: state.startup,
@@ -566,6 +593,7 @@ export async function handleHealthRoutes(
 
     json(res, {
       ready,
+      canRespond: computeCanRespond(runtime, state.agentState),
       runtime: runtime ? "ok" : "not_initialized",
       database: runtime ? "ok" : "unknown",
       plugins: {

--- a/packages/agent/src/api/runtime-ready-gate.test.ts
+++ b/packages/agent/src/api/runtime-ready-gate.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import { createRuntimeReadyGate } from "./runtime-ready-gate.ts";
+
+describe("createRuntimeReadyGate", () => {
+  it("resolves immediately when a value already exists", async () => {
+    const gate = createRuntimeReadyGate(() => "ready");
+    await expect(gate.await(1000)).resolves.toBe("ready");
+  });
+
+  it("holds until markReady, then resolves all waiters with the value", async () => {
+    let current: string | null = null;
+    const gate = createRuntimeReadyGate(() => current);
+
+    const a = gate.await(10_000);
+    const b = gate.await(10_000);
+    let aResolved = false;
+    void a.then(() => {
+      aResolved = true;
+    });
+    // Not resolved yet — still warming.
+    await Promise.resolve();
+    expect(aResolved).toBe(false);
+
+    current = "rt";
+    gate.markReady("rt");
+    await expect(a).resolves.toBe("rt");
+    await expect(b).resolves.toBe("rt");
+  });
+
+  it("resolves with the current value (possibly null) on timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      const gate = createRuntimeReadyGate(() => null);
+      const pending = gate.await(5_000);
+      vi.advanceTimersByTime(5_000);
+      await expect(pending).resolves.toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a late waiter after markReady sees the now-current value immediately", async () => {
+    let current: string | null = null;
+    const gate = createRuntimeReadyGate(() => current);
+    current = "rt";
+    gate.markReady("rt");
+    await expect(gate.await(1000)).resolves.toBe("rt");
+  });
+});

--- a/packages/agent/src/api/runtime-ready-gate.ts
+++ b/packages/agent/src/api/runtime-ready-gate.ts
@@ -1,0 +1,63 @@
+/**
+ * Runtime-ready gate — lets a request HOLD through the brief warming window
+ * between the early API bind (agentState "starting", runtime not yet wired) and
+ * the moment the runtime is live, instead of 503-dropping the request.
+ *
+ * This is what makes first-turn capability "fade in" without losing the user's
+ * message: a chat turn submitted during warmup keeps its connection open (the
+ * client already shows the optimistic bubble + typing indicator) and streams its
+ * response the instant the runtime is ready — typically ~2s, bounded by a
+ * timeout so a genuinely-stuck boot still fails fast rather than hanging forever.
+ *
+ * Dependency-free + side-effect-free so it unit-tests in isolation.
+ */
+export interface RuntimeReadyGate<T> {
+  /**
+   * Resolves immediately with the current value if one exists, otherwise waits
+   * until `markReady` is called or `timeoutMs` elapses — on timeout it resolves
+   * with whatever `getCurrent()` returns then (possibly null).
+   */
+  await(timeoutMs: number): Promise<T | null>;
+  /** Wake all current + drop pending waiters, resolving them with `value`. */
+  markReady(value: T): void;
+}
+
+export function createRuntimeReadyGate<T>(
+  getCurrent: () => T | null,
+): RuntimeReadyGate<T> {
+  const waiters = new Set<(value: T | null) => void>();
+
+  return {
+    await(timeoutMs: number): Promise<T | null> {
+      const current = getCurrent();
+      if (current != null) {
+        return Promise.resolve(current);
+      }
+      return new Promise<T | null>((resolve) => {
+        let settled = false;
+        const settle = (value: T | null): void => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          clearTimeout(timer);
+          waiters.delete(waiter);
+          resolve(value);
+        };
+        const waiter = (value: T | null): void => settle(value);
+        const timer = setTimeout(() => settle(getCurrent()), timeoutMs);
+        // Don't keep the process alive just for a warming-window waiter.
+        (timer as { unref?: () => void }).unref?.();
+        waiters.add(waiter);
+      });
+    },
+
+    markReady(value: T): void {
+      const pending = [...waiters];
+      waiters.clear();
+      for (const wake of pending) {
+        wake(value);
+      }
+    },
+  };
+}

--- a/packages/agent/src/api/server-types.ts
+++ b/packages/agent/src/api/server-types.ts
@@ -178,6 +178,15 @@ export interface ServerState {
   shareIngestQueue: ShareIngestItem[];
   /** Broadcast current agent status to all WebSocket clients. Set by startApiServer. */
   broadcastStatus: (() => void) | null;
+  /**
+   * Resolves with the live runtime once it is wired (capability online), or with
+   * the current runtime (possibly null) after `timeoutMs`. Lets chat handlers
+   * HOLD a turn through the brief warming window (early API bind → runtime ready)
+   * instead of 503-dropping it. Set by startApiServer; backed by a
+   * RuntimeReadyGate woken on updateRuntime. */
+  awaitRuntimeReady:
+    | ((timeoutMs: number) => Promise<AgentRuntime | null>)
+    | null;
   /** Broadcast an arbitrary JSON message to all WebSocket clients. Set by startApiServer. */
   broadcastWs: ((data: object) => void) | null;
   /** Broadcast a JSON payload to WebSocket clients bound to a specific client id. */

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -309,6 +309,7 @@ import { detectRuntimeModel, resolveProviderFromModel } from "./agent-model.ts";
 import { persistConfigEnv } from "./config-env.ts";
 import { wireCoordinatorBridgesWhenReady } from "./coordinator-wiring.ts";
 import { pushWithBatchEvict } from "./memory-bounds.ts";
+import { createRuntimeReadyGate } from "./runtime-ready-gate.ts";
 import {
   cloneWithoutBlockedObjectKeys,
   decodePathComponent,
@@ -3392,6 +3393,7 @@ export async function startApiServer(opts?: {
     trainingService: null,
     shareIngestQueue: [],
     broadcastStatus: null,
+    awaitRuntimeReady: null,
     broadcastWs: null,
     broadcastWsToClientId: null,
     broadcastWsToConversation: null,
@@ -3405,6 +3407,14 @@ export async function startApiServer(opts?: {
     connectorHealthMonitor: null,
     whatsappPairingSessions: new Map(),
   };
+  // Lets chat handlers HOLD a turn through the warming window (early API bind →
+  // runtime ready) instead of 503-dropping it — woken in updateRuntime when
+  // first-turn capability comes online (see runtime-ready-gate.ts).
+  const runtimeReadyGate = createRuntimeReadyGate<AgentRuntime>(
+    () => state.runtime,
+  );
+  state.awaitRuntimeReady = (timeoutMs: number) =>
+    runtimeReadyGate.await(timeoutMs);
   const ensureAppManager = async (): Promise<AppManagerLike> => {
     if (state.appManager) {
       return state.appManager as AppManagerLike;
@@ -4785,6 +4795,9 @@ export async function startApiServer(opts?: {
     state.chatConnectionReady = null;
     state.chatConnectionPromise = null;
     bindRuntimeStreams(rt);
+    // Wake any chat turns held through the warming window — first-turn
+    // capability is now online, so they stream their response instead of 503.
+    runtimeReadyGate.markReady(rt);
     // AppManager doesn't need a runtime reference
     state.agentState = "running";
     state.agentName =

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -73,6 +73,7 @@ import {
 } from "./navigation";
 import { isIOS, isNative } from "./platform/init";
 import { type ActionNotice, useApp } from "./state";
+import { isShellPaintable } from "./state/startup-coordinator";
 import { VoiceSelfTestShell } from "./voice/voice-selftest/VoiceSelfTestShell";
 
 const MOBILE_NAV_PADDING_CLASS =
@@ -1169,9 +1170,16 @@ export function App() {
   // During first-run setup / pairing / startup phases the StartupScreen handles
   // its own gate (bootstrap step), so we skip the check.
   const isCoordinatorReady = startupCoordinator.phase === "ready";
+  // The live shell may MOUNT once the backend is reached and the agent boot is
+  // underway (starting-runtime / hydrating / ready) — first-turn capability then
+  // fades in behind it (see useShellController's agentReady). Only the truly
+  // pre-shell phases (session restore, backend polling, first-run, pairing,
+  // error) keep the full-screen StartupScreen. Runtime-dependent effects and
+  // overlay apps below stay gated on `isCoordinatorReady` and defer safely.
+  const isShellPaintableNow = isShellPaintable(startupCoordinator.phase);
 
   const { state: authState, refetch: refetchAuth } = useAuthStatus({
-    skip: !isCoordinatorReady || isPopout,
+    skip: !isShellPaintableNow || isPopout,
   });
   // Don't initialize the 3D scene while the system is still booting — this
   // prevents VrmEngine's Three.js setup from blocking the JS thread and
@@ -1548,7 +1556,7 @@ export function App() {
     );
   }
 
-  if (!isCoordinatorReady) {
+  if (!isShellPaintableNow) {
     return (
       <BugReportProvider value={bugReport}>
         <StartupScreen />
@@ -1557,12 +1565,11 @@ export function App() {
     );
   }
 
-  // Auth gate — when the coordinator is ready, check /api/auth/me.
-  // "loading" phase: wait (fall through to the coordinator's own "ready" render).
-  // "unauthenticated": render LoginView.
-  // "authenticated": proceed to the main shell.
+  // Auth gate — once the shell is paintable (agent may still be warming up),
+  // check /api/auth/me. "loading": wait (fall through to the main shell render).
+  // "unauthenticated": render LoginView. "authenticated": proceed.
   // "server_unavailable": show a retryable startup failure.
-  if (isCoordinatorReady && !isPopout) {
+  if (isShellPaintableNow && !isPopout) {
     if (authState.phase === "server_unavailable") {
       return (
         <BugReportProvider value={bugReport}>
@@ -1606,8 +1613,10 @@ export function App() {
     );
   }
 
-  // Coordinator is at "ready" — the app shell renders. No deprecated first-run
-  // overlays — the coordinator handled all of that before reaching ready.
+  // The app shell renders once paintable (the agent may still be warming up —
+  // the chat composer queues sends until first-turn capability fades in; views
+  // show their own loading states until the runtime is live). No deprecated
+  // first-run overlays — the coordinator handled all of that before this point.
 
   return (
     <BugReportProvider value={bugReport}>

--- a/packages/ui/src/api/client-agent.ts
+++ b/packages/ui/src/api/client-agent.ts
@@ -1157,6 +1157,9 @@ ElizaClient.prototype.getStatus = async function (this: ElizaClient) {
       state: "running",
       agentName: "Eliza",
       model: undefined,
+      // Cloud-shared agent is provisioned + serving cloud-side — first-turn
+      // capability is online, so the composer should be live immediately.
+      canRespond: true,
       uptime: undefined,
       startedAt: undefined,
     };

--- a/packages/ui/src/api/client-types-core.ts
+++ b/packages/ui/src/api/client-types-core.ts
@@ -135,6 +135,14 @@ export interface AgentStatus {
   state: AgentState;
   agentName: string;
   model: string | undefined;
+  /**
+   * First-turn capability online: the agent has a live runtime + a registered
+   * TEXT handler and can actually answer (distinct from a bare "running" with no
+   * provider wired). Server-authoritative (`/api/health` + `/api/status`); drives
+   * the async-generate + fade-in of the chat composer. Optional for back-compat
+   * with older agents/transports that don't report it.
+   */
+  canRespond?: boolean;
   uptime: number | undefined;
   startedAt: number | undefined;
   port?: number;

--- a/packages/ui/src/components/pages/ChatView.tsx
+++ b/packages/ui/src/components/pages/ChatView.tsx
@@ -309,14 +309,6 @@ export function ChatView({
   // ── Derived composer state ──────────────────────────────────────
   const isAgentStarting =
     agentStatus?.state === "starting" || agentStatus?.state === "restarting";
-  const hasCompletedLifecycleActivity =
-    !chatSending &&
-    Array.isArray(conversationMessages) &&
-    conversationMessages.some(
-      (message) =>
-        message.role === "user" ||
-        (message.role === "assistant" && message.text.trim().length > 0),
-    );
   // The agent is up but has no inference model wired — no point letting the
   // user hit send. Surfaced as a composer lock + a pointer to Settings.
   const agentModel =
@@ -326,9 +318,11 @@ export function ChatView({
     agentStatus?.state === "running" &&
     agentModel.length === 0 &&
     !isMobileLocalRuntime;
-  const isComposerLocked =
-    (isAgentStarting && !hasCompletedLifecycleActivity) ||
-    isMissingInferenceProvider;
+  // First-turn capability fades in: the composer stays usable while the agent
+  // warms up (a turn submitted during warmup is held server-side until the
+  // runtime is ready, then streams its reply) — only a genuinely missing
+  // inference provider hard-locks the composer.
+  const isComposerLocked = isMissingInferenceProvider;
   const composerPlaceholderOverride = isMissingInferenceProvider
     ? t("chat.setupProviderToChat", {
         defaultValue: "Set up an LLM provider in Settings to start chatting",

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.test.tsx
@@ -167,17 +167,13 @@ describe("ContinuousChatOverlay", () => {
     expect(screen.getByTestId("chat-composer-mic")).toBeTruthy();
   });
 
-  it("shows the resting suggestion strip without hover or focus", () => {
+  it("does not render the resting suggestion strip (feature-flagged off)", () => {
     render(
       <ContinuousChatOverlay controller={makeController({ messages: [] })} />,
     );
-    const strip = screen.getByTestId("chat-suggestions");
-    const firstSuggestion = screen.getByTestId("chat-suggestion-0");
-    // At rest (ready, nothing typed) the strip is mounted, interactive, and
-    // tabbable — there is no hover/focus gate any more; it is the closed-state
-    // affordance, and it simply unmounts once the sheet opens or a draft starts.
-    expect(strip.className).toContain("pointer-events-auto");
-    expect(firstSuggestion.tabIndex).toBe(0);
+    // SHOW_PROMPT_SUGGESTIONS is off — the resting strip must not mount.
+    expect(screen.queryByTestId("chat-suggestions")).toBeNull();
+    expect(screen.queryByTestId("chat-suggestion-0")).toBeNull();
   });
 
   it("filters whitespace-only messages from the expanded thread", () => {
@@ -348,15 +344,16 @@ describe("ContinuousChatOverlay", () => {
     expect(controller.toggleRecording).toHaveBeenCalled();
   });
 
-  it("shows a connecting placeholder and read-only input while booting", () => {
+  it("shows a waking-up placeholder while booting (typing allowed)", () => {
     render(
       <ContinuousChatOverlay
         controller={makeController({ phase: "booting", canSend: false })}
       />,
     );
     const input = screen.getByLabelText("message");
-    expect(input.getAttribute("placeholder")).toContain("connecting");
-    expect(input.hasAttribute("readonly")).toBe(true);
+    expect(input.getAttribute("placeholder")).toContain("waking up");
+    // You can type while the agent boots; the message sends once it's ready.
+    expect(input.hasAttribute("readonly")).toBe(false);
   });
 
   it("renders the live interim transcript while recording", () => {
@@ -409,7 +406,7 @@ describe("ContinuousChatOverlay", () => {
     expect(input.className).not.toContain("basis-full");
   });
 
-  it("shows exactly three resting prompt suggestions", () => {
+  it("renders no prompt-suggestion chips while the strip is flagged off", () => {
     render(
       <ContinuousChatOverlay
         controller={makeController({
@@ -417,10 +414,9 @@ describe("ContinuousChatOverlay", () => {
         } as unknown as Partial<ShellController>)}
       />,
     );
-    const strip = screen.getByTestId("chat-suggestions");
     expect(
-      strip.querySelectorAll('[data-testid^="chat-suggestion-"]'),
-    ).toHaveLength(3);
+      document.querySelectorAll('[data-testid^="chat-suggestion-"]'),
+    ).toHaveLength(0);
   });
 
   it("scrolls to the latest line when a new message arrives while open", () => {

--- a/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
+++ b/packages/ui/src/components/shell/ContinuousChatOverlay.tsx
@@ -77,6 +77,10 @@ const SHEET_TOP_MARGIN = 72;
 // can't jank scrolling on a phone, without pulling in a virtualizer.
 const MAX_RENDERED_MESSAGES = 80;
 
+// Feature flag: the resting one-tap prompt-suggestion strip. Off for now so the
+// composer can be tested without it; flip to true to bring the strip back.
+const SHOW_PROMPT_SUGGESTIONS = false;
+
 // A light iOS-style impact on each detent cross. Self-contained + guarded so it
 // is a no-op off-native (and in jsdom tests) without coupling the overlay to the
 // Capacitor bridge module. Mirrors `bridge/capacitor-bridge.ts` `haptics.light()`.
@@ -126,7 +130,7 @@ const SPEAKER_MUTED_GLYPH =
   "M7 15H12L18 10V26L12 21H7Z M21 12.4L22.4 11L31 19.6L29.6 21Z";
 function Glyph({ d }: { d: string }): React.JSX.Element {
   return (
-    <svg viewBox="0 0 36 36" className="h-5 w-5" aria-hidden="true">
+    <svg viewBox="0 0 36 36" className="h-[26px] w-[26px]" aria-hidden="true">
       <path fill="currentColor" fillRule="evenodd" d={d} />
     </svg>
   );
@@ -285,7 +289,9 @@ function PillHandle({
       }}
       {...binding}
       className={cn(
-        "pointer-events-auto flex cursor-grab touch-none select-none items-center justify-center px-12 py-4 active:cursor-grabbing",
+        // The bar hugs the BOTTOM (small pb) where the collapsed input sat — not
+        // floating mid-air; the tall pt keeps a generous upward grab/flick zone.
+        "pointer-events-auto flex cursor-grab touch-none select-none items-end justify-center px-12 pb-1.5 pt-7 active:cursor-grabbing",
         "focus-visible:rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50",
       )}
     >
@@ -578,6 +584,11 @@ export function ContinuousChatOverlay({
   // one flick away. Pull down from input → pill; flick/pull up from pill → input
   // → chat. `pilled` overrides sheetOpen/expanded while true.
   const [pilled, setPilled] = React.useState(false);
+  // Free-drag rest height (px): when set, the sheet rests exactly where the user
+  // released a deliberate drag instead of snapping to a detent. Cleared whenever
+  // a detent is taken (tap/flick/focus/collapse) so the detents stay the
+  // snap-to targets and free-positioning is purely the drag affordance.
+  const [freeH, setFreeH] = React.useState<number | null>(null);
   // The live thread (history) height in px, as a MOTION VALUE — driven directly
   // by the pointer during a drag and spring-animated to a detent on release.
   // Keeping it off React state means a drag updates the DOM height every frame
@@ -626,6 +637,7 @@ export function ContinuousChatOverlay({
   // unmounts once the sheet opens or a draft starts; this condition also gates
   // the small-model fetch so it isn't called for a hidden strip.
   const suggestionsVisible =
+    SHOW_PROMPT_SUGGESTIONS &&
     !pilled &&
     !sheetOpen &&
     !recording &&
@@ -864,7 +876,9 @@ export function ContinuousChatOverlay({
   // pull-down) while the sheet rises all the way to the top.
   const openH = panelMaxH;
   const halfH = Math.round(viewportH * SHEET_HALF_VH);
-  const baseH = !sheetOpen ? 0 : expanded ? openH : halfH;
+  const detentH = !sheetOpen ? 0 : expanded ? openH : halfH;
+  // A free-drag rest height wins over the detent until a detent is re-taken.
+  const baseH = freeH != null ? Math.min(freeH, panelMaxH) : detentH;
   // Map a raw drag height: rubber-band past FULL, hard-clamp the bottom to 0.
   const clampHeight = React.useCallback(
     (raw: number) =>
@@ -896,6 +910,7 @@ export function ContinuousChatOverlay({
 
   const closeSheet = React.useCallback(() => {
     draggingRef.current = false;
+    setFreeH(null);
     setSheetOpen(false);
     setExpanded(false);
   }, []);
@@ -904,7 +919,7 @@ export function ContinuousChatOverlay({
   // changes and we're not mid finger-drag, spring the history height to it. The
   // gesture / open paths just flip sheetOpen/expanded and this reacts — no
   // per-frame React state, so the live drag stays buttery.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: baseH already encodes sheetOpen/expanded/viewportH; threadHeight is a stable ref
+  // biome-ignore lint/correctness/useExhaustiveDependencies: baseH already encodes sheetOpen/expanded/freeH/viewportH; threadHeight is a stable ref
   React.useEffect(() => {
     if (draggingRef.current) return;
     if (reduce) {
@@ -922,7 +937,9 @@ export function ContinuousChatOverlay({
   const goToDetent = React.useCallback(
     (detent: "collapsed" | "half" | "full") => {
       // Flip the settled detent; the [baseH] effect springs the height to it.
+      // A detent always clears any free-drag rest height.
       draggingRef.current = false;
+      setFreeH(null);
       setSheetOpen(detent !== "collapsed");
       setExpanded(detent === "full");
       detentHaptic();
@@ -1053,6 +1070,29 @@ export function ContinuousChatOverlay({
       }
       if (!sheetOpen) inputRef.current?.focus();
     },
+    // A deliberate (slow) drag: REST exactly where released instead of snapping
+    // to a detent — drag the sheet to any size and it stays.
+    onSettleFree: (direction) => {
+      draggingRef.current = false;
+      if (pilled) {
+        // The pill only knows two states; a slow drag up recovers the input.
+        if (direction === "up") {
+          setPilled(false);
+          settleDrag();
+        }
+        return;
+      }
+      const h = Math.max(0, Math.min(threadHeight.get(), panelMaxH));
+      if (h < 28) {
+        // Dragged essentially shut → collapse to the input peek.
+        closeSheet();
+        return;
+      }
+      // Park the thread at the released height; expanded only when it reached the top.
+      setFreeH(h);
+      setSheetOpen(true);
+      setExpanded(h >= openH - 1);
+    },
   });
 
   // NOTE: the chat has NO close-on-outside-pointerdown beyond the keyboard blur;
@@ -1066,8 +1106,9 @@ export function ContinuousChatOverlay({
         // max(safe-area, android gesture inset): when the nav bar is hidden the
         // safe-area-inset-bottom is 0, so fall back to the real gesture-home zone
         // (--android-gesture-inset-bottom, published by MainActivity; 0 elsewhere)
-        // so the composer never sits under the home pill.
-        "pb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+1.5rem)]",
+        // so the composer never sits under the home pill. The +0.5rem breathing
+        // room keeps the chat low on the screen without touching that zone.
+        "pb-[calc(var(--eliza-mobile-nav-offset,0px)+max(var(--safe-area-bottom,0px),var(--android-gesture-inset-bottom,0px))+0.5rem)]",
       )}
       // Lift the whole overlay above the on-screen keyboard so the input + chat
       // stay visible; `keyboardInset` is 0 when no keyboard is shown.
@@ -1391,7 +1432,7 @@ export function ContinuousChatOverlay({
                 <SoftButton
                   glyph={PLUS_GLYPH}
                   label="attach image"
-                  disabled={booting || pendingImages.length >= MAX_CHAT_IMAGES}
+                  disabled={pendingImages.length >= MAX_CHAT_IMAGES}
                   onClick={() => fileInputRef.current?.click()}
                   testId="chat-composer-attach"
                 />
@@ -1414,16 +1455,19 @@ export function ContinuousChatOverlay({
                       collapse();
                     }
                   }}
-                  placeholder={booting ? "connecting…" : `Ask ${agentName}`}
+                  placeholder={
+                    booting
+                      ? `Ask ${agentName} — waking up…`
+                      : `Ask ${agentName}`
+                  }
                   aria-label="message"
                   data-testid="chat-composer-textarea"
                   aria-describedby={booting ? "cc-booting-hint" : undefined}
-                  aria-disabled={booting}
-                  readOnly={booting}
                   className="max-h-[8.5rem] min-h-8 min-w-0 flex-1 resize-none self-center border-none bg-transparent px-1.5 py-1 text-left text-sm leading-relaxed text-white/[0.92] outline-none [scrollbar-width:none] placeholder:text-white/45 [&::-webkit-scrollbar]:hidden"
                 />
                 <span id="cc-booting-hint" className="sr-only">
-                  connecting — you can’t send yet
+                  {agentName} is waking up — you can type now; your message
+                  sends and the reply arrives in a moment.
                 </span>
                 {/* Assistant-voice mute: shown only while the agent is speaking or
               already muted, so the resting bar stays uncluttered. */}

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -68,18 +68,14 @@ describe("useShellController", () => {
     expect(result.current.canSend).toBe(true);
   });
 
-  it("queues a send while booting and flushes it once ready", () => {
+  it("sends through immediately even while warming — the server holds the turn", () => {
     appMock.value.agentStatus = { ...WARMING_STATUS };
 
-    const { result, rerender } = renderHook(() => useShellController());
+    const { result } = renderHook(() => useShellController());
 
+    // No client-side queue: sendChatText fires now (optimistic bubble + typing
+    // indicator), and the server holds the turn until capability comes online.
     act(() => result.current.send("hello while booting"));
-    // Queued, not sent yet.
-    expect(appMock.value.sendChatText).not.toHaveBeenCalled();
-
-    // First-turn capability comes online — the queued message flushes.
-    appMock.value.agentStatus = { ...READY_STATUS };
-    rerender();
 
     expect(appMock.value.sendChatText).toHaveBeenCalledTimes(1);
     expect(appMock.value.sendChatText.mock.calls[0]?.[0]).toBe(

--- a/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
+++ b/packages/ui/src/components/shell/__tests__/useShellController.test.tsx
@@ -14,13 +14,19 @@ const NOT_REQUIRED_STATUS = {
   errors: [],
 };
 
+// Readiness is now driven by the agent's first-turn capability
+// (agentStatus.canRespond), NOT the startup-coordinator phase — the shell mounts
+// early and the composer queues sends until capability fades in.
+const READY_STATUS = { state: "running", canRespond: true };
+const WARMING_STATUS = { state: "starting", canRespond: false };
+
 const appMock = vi.hoisted(() => ({
   value: {
     startupCoordinator: { phase: "ready" },
     conversationMessages: [],
     chatSending: false,
     sendChatText: vi.fn(),
-    agentStatus: { state: "running" },
+    agentStatus: { state: "running", canRespond: true },
   },
 }));
 
@@ -42,12 +48,12 @@ afterEach(() => {
   appMock.value.conversationMessages = [];
   appMock.value.chatSending = false;
   appMock.value.sendChatText.mockClear();
-  appMock.value.agentStatus = { state: "running" };
+  appMock.value.agentStatus = { ...READY_STATUS };
 });
 
 describe("useShellController", () => {
   it("opens the shared chat state even while startup is still booting", () => {
-    appMock.value.startupCoordinator.phase = "starting-runtime";
+    appMock.value.agentStatus = { ...WARMING_STATUS };
 
     const { result } = renderHook(() => useShellController());
 
@@ -63,7 +69,7 @@ describe("useShellController", () => {
   });
 
   it("queues a send while booting and flushes it once ready", () => {
-    appMock.value.startupCoordinator.phase = "starting-runtime";
+    appMock.value.agentStatus = { ...WARMING_STATUS };
 
     const { result, rerender } = renderHook(() => useShellController());
 
@@ -71,8 +77,8 @@ describe("useShellController", () => {
     // Queued, not sent yet.
     expect(appMock.value.sendChatText).not.toHaveBeenCalled();
 
-    // Agent becomes ready — the queued message flushes.
-    appMock.value.startupCoordinator.phase = "ready";
+    // First-turn capability comes online — the queued message flushes.
+    appMock.value.agentStatus = { ...READY_STATUS };
     rerender();
 
     expect(appMock.value.sendChatText).toHaveBeenCalledTimes(1);
@@ -82,7 +88,7 @@ describe("useShellController", () => {
   });
 
   it("sends immediately when already ready", () => {
-    appMock.value.startupCoordinator.phase = "ready";
+    appMock.value.agentStatus = { ...READY_STATUS };
 
     const { result } = renderHook(() => useShellController());
 

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -4,6 +4,7 @@ import type { ImageAttachment } from "../../api/client-types-chat";
 import type { HomeModelStatus } from "../../services/local-inference/home-model-status";
 import { useApp } from "../../state";
 import { loadVadAutoStop } from "../../state/persistence";
+import { deriveAgentReady } from "../../state/types";
 import {
   createVoiceCapture,
   type VoiceCaptureHandle,
@@ -81,7 +82,6 @@ export interface ShellController {
 export function useShellController(): ShellController {
   const app = useApp();
   const {
-    startupCoordinator,
     conversationMessages,
     chatSending,
     sendChatText,
@@ -103,7 +103,13 @@ export function useShellController(): ShellController {
     void handleNewConversation();
   }, [handleNewConversation]);
 
-  const ready = startupCoordinator.phase === "ready";
+  // "Ready" here means the agent's FIRST-TURN CAPABILITY is online (it can
+  // answer) — NOT that the startup coordinator finished hydrating. The shell now
+  // mounts early (isShellPaintable) while the agent warms up; the composer stays
+  // interactive but queues sends until this flips, then flushes — so first-turn
+  // capability fades in behind a live UI. Server-authoritative via
+  // agentStatus.canRespond (falls back to running+model on older agents).
+  const ready = deriveAgentReady(agentStatus);
   const modelStatus = useHomeModelStatus();
   const [isOpen, setIsOpen] = React.useState(false);
   const [recording, setRecording] = React.useState(false);

--- a/packages/ui/src/components/shell/useShellController.ts
+++ b/packages/ui/src/components/shell/useShellController.ts
@@ -134,17 +134,6 @@ export function useShellController(): ShellController {
     }));
   }, [conversationMessages]);
 
-  const pendingSendsRef = React.useRef<
-    Array<{
-      text: string;
-      options?: {
-        channelType?: "DM" | "VOICE_DM";
-        images?: ImageAttachment[];
-        metadata?: Record<string, unknown>;
-      };
-    }>
-  >([]);
-
   const send = React.useCallback(
     (
       text: string,
@@ -160,34 +149,19 @@ export function useShellController(): ShellController {
       if (!trimmed && !options?.images?.length) return;
       // Record voice-ness of this turn so the reply is (or is not) spoken back.
       setLastTurnVoice(options?.channelType === "VOICE_DM");
-      if (!ready) {
-        // Agent still booting — queue and flush on ready instead of dropping.
-        pendingSendsRef.current.push({ text: trimmed, options });
-        return;
-      }
+      // Send immediately even while the agent is still warming up: sendChatText
+      // renders the optimistic user bubble + typing indicator right away, and the
+      // server HOLDS the turn through the warming window (runtime-ready gate),
+      // streaming the reply the instant first-turn capability comes online —
+      // rather than queueing the message invisibly.
       if (options) {
         void sendChatText(trimmed, options);
         return;
       }
       void sendChatText(trimmed);
     },
-    [ready, sendChatText],
+    [sendChatText],
   );
-
-  // Flush messages the user submitted while the agent was still booting.
-  React.useEffect(() => {
-    if (!ready) return;
-    const queued = pendingSendsRef.current;
-    if (queued.length === 0) return;
-    pendingSendsRef.current = [];
-    for (const { text, options } of queued) {
-      if (options) {
-        void sendChatText(text, options);
-      } else {
-        void sendChatText(text);
-      }
-    }
-  }, [ready, sendChatText]);
 
   const stopCapture = React.useCallback(() => {
     const handle = captureRef.current;

--- a/packages/ui/src/state/startup-coordinator.test.ts
+++ b/packages/ui/src/state/startup-coordinator.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { INITIAL_STARTUP_STATE, startupReducer } from "./startup-coordinator";
+import {
+  INITIAL_STARTUP_STATE,
+  isShellPaintable,
+  startupReducer,
+} from "./startup-coordinator";
+import { deriveAgentReady } from "./types";
 
 describe("startup coordinator", () => {
   it("starts by restoring session state", () => {
@@ -99,5 +104,73 @@ describe("startup coordinator", () => {
         { type: "RESET" },
       ),
     ).toEqual({ phase: "restoring-session" });
+  });
+});
+
+describe("isShellPaintable", () => {
+  it("paints the live shell once the agent boot is underway", () => {
+    expect(isShellPaintable("starting-runtime")).toBe(true);
+    expect(isShellPaintable("hydrating")).toBe(true);
+    expect(isShellPaintable("ready")).toBe(true);
+  });
+
+  it("keeps the full-screen StartupScreen for pre-shell + interactive phases", () => {
+    expect(isShellPaintable("restoring-session")).toBe(false);
+    expect(isShellPaintable("resolving-target")).toBe(false);
+    expect(isShellPaintable("polling-backend")).toBe(false);
+    expect(isShellPaintable("first-run-required")).toBe(false);
+    expect(isShellPaintable("pairing-required")).toBe(false);
+    expect(isShellPaintable("error")).toBe(false);
+  });
+});
+
+describe("deriveAgentReady", () => {
+  it("is false with no status", () => {
+    expect(deriveAgentReady(null)).toBe(false);
+  });
+
+  it("prefers the server-authoritative canRespond", () => {
+    expect(
+      deriveAgentReady({
+        state: "running",
+        agentName: "Eliza",
+        model: undefined,
+        canRespond: true,
+        uptime: undefined,
+        startedAt: undefined,
+      }),
+    ).toBe(true);
+    // running but no provider wired → canRespond:false keeps the composer gated
+    expect(
+      deriveAgentReady({
+        state: "running",
+        agentName: "Eliza",
+        model: "x",
+        canRespond: false,
+        uptime: undefined,
+        startedAt: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("falls back to running+model when canRespond is absent (older agents)", () => {
+    expect(
+      deriveAgentReady({
+        state: "running",
+        agentName: "Eliza",
+        model: "gpt",
+        uptime: undefined,
+        startedAt: undefined,
+      }),
+    ).toBe(true);
+    expect(
+      deriveAgentReady({
+        state: "starting",
+        agentName: "Eliza",
+        model: undefined,
+        uptime: undefined,
+        startedAt: undefined,
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/ui/src/state/startup-coordinator.ts
+++ b/packages/ui/src/state/startup-coordinator.ts
@@ -440,6 +440,24 @@ export function isStartupTerminal(state: StartupState): boolean {
 }
 
 /**
+ * True once the live app shell may MOUNT — the backend is reached and the active
+ * conversation is hydratable — even though the agent's first-turn capability may
+ * still be warming up (`agentState: "starting"`). This un-gates the shell + chat
+ * composer early so first-turn capability can fade in BEHIND a live UI, instead
+ * of replacing the whole app with a full-screen loader until full `ready`.
+ *
+ * Deliberately FALSE for phases that legitimately own the whole screen — session
+ * restore, backend polling, first-run, pairing — and for terminal `error`; those
+ * still render StartupScreen. Effects that need a live runtime must stay gated on
+ * agent readiness (`canRespond`), NOT on this — this un-gates RENDERING only.
+ */
+export function isShellPaintable(phase: StartupPhaseValue): boolean {
+  return (
+    phase === "starting-runtime" || phase === "hydrating" || phase === "ready"
+  );
+}
+
+/**
  * Derive the legacy StartupPhase from the coordinator state.
  *
  * NOTE: pairing-required, first-run-required, error, and hydrating all map

--- a/packages/ui/src/state/types.ts
+++ b/packages/ui/src/state/types.ts
@@ -213,6 +213,28 @@ export const AGENT_STATES: ReadonlySet<AgentStatus["state"]> = new Set([
   "error",
 ]);
 
+/**
+ * Single source for "first-turn capability is online" — the agent can actually
+ * answer, so the chat composer can go live and any queued sends can flush. This
+ * is DISTINCT from the startup-coordinator phase (which gates full hydration):
+ * the shell paints early (see `isShellPaintable`), and this flips when the
+ * agent's response capability fades in behind it.
+ *
+ * Prefers the server-authoritative `canRespond` (`/api/health` + `/api/status`);
+ * falls back to running+model for older agents/transports that don't report it.
+ * A reported `canRespond: false` (running but no model provider) correctly keeps
+ * the composer in its "set up a provider" state rather than going live.
+ */
+export function deriveAgentReady(agentStatus: AgentStatus | null): boolean {
+  if (!agentStatus) {
+    return false;
+  }
+  return (
+    agentStatus.canRespond ??
+    (agentStatus.state === "running" && Boolean(agentStatus.model))
+  );
+}
+
 export type SlashCommandInput = {
   name: string;
   argsRaw: string;


### PR DESCRIPTION
Stop hard-gating the whole UI on full agent readiness. The shell paints as soon as the backend is reached and the agent boot is underway; the agent's ability to respond **fades in behind a live UI** instead of a ~2s full-screen loader. Turns the ~2s runtime boot from dead waiting into overlapped, perceived-instant startup.

## What changed

**P0 — live shell + capability signal**
- `canRespond` on `/api/health` + `/api/status` (runtime live AND running AND a TEXT handler — distinct from `ready`, which is true even for stopped/no-provider).
- `isShellPaintable(phase)` + `deriveAgentReady(agentStatus)` selectors; cloud-shared agents report `canRespond:true`.
- `App.tsx` mounts the live shell + chat overlay when paintable; `StartupScreen` only for pre-shell phases (restore/poll/first-run/pairing/error). Auth gate runs in the paintable window; runtime-dependent effects + overlay apps stay gated on full `ready`.

**P1 — usable warming composer**
- Composer is editable during warmup (`"waking up…"`), not read-only `"connecting…"`. Sends go straight through `sendChatText`, so the optimistic user bubble + typing indicator show instantly and the reply streams when capability lands.
- `ChatView` no longer hard-locks the composer while starting; only a genuinely missing inference provider locks it.

**P2 — server holds the turn (never dropped)**
- `runtime-ready-gate.ts`: a small, unit-tested gate resolved at the `updateRuntime` "capability online" moment.
- The stream + non-stream `/messages` handlers HOLD a turn through the warming window (early API bind → runtime ready, ~2s, capped 30s) only while `agentState` is starting/restarting; a genuinely stopped agent still 503s fast.

## Verification
- Typecheck clean (ui + agent).
- Tests: runtime-ready-gate (4), useShellController (3), ContinuousChatOverlay (42), startup-coordinator + selectors (13) — pass.
- Not yet done: app-boot visual check of the warming→live transition, and the optional `ChatView` per-message `enterOnMount` fade (the ambient overlay already fades each turn).

Decisions locked with the user: static greeting (capability fades in), optimistic bubble + typing indicator on early send, full P0+P1+P2 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)