### PR TITLE
fix(cloud-api): payout-status resilience — unblock token redemption (no 500)

### DIFF
--- a/packages/cloud-shared/src/lib/services/__tests__/payout-status-resilience.test.ts
+++ b/packages/cloud-shared/src/lib/services/__tests__/payout-status-resilience.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Pins the payout-status resilience fix.
+ *
+ * Before: a malformed EVM payout key (privateKeyToAccount throws) or a network
+ * whose RPC setup throws (resolveEvmRpc/createPublicClient) would throw out of
+ * getStatus(), 500-ing the entire redemption flow (quote/status/execute) even
+ * when another network was fine. Now each per-network/per-wallet failure
+ * degrades that single network to "not_configured" and getStatus() never throws.
+ */
+import { beforeEach, expect, mock, test } from "bun:test";
+
+const getCloudAwareEnv = mock();
+mock.module("../../runtime/cloud-bindings", () => ({ getCloudAwareEnv }));
+
+const resolveEvmRpc = mock();
+mock.module("../../config/evm-rpc", () => ({ resolveEvmRpc }));
+
+const { payoutStatusService } = await import("../payout-status");
+
+beforeEach(() => {
+  getCloudAwareEnv.mockReset();
+  resolveEvmRpc.mockReset();
+  resolveEvmRpc.mockReturnValue({
+    source: "test",
+    url: "https://rpc.invalid.example",
+  });
+});
+
+test("getStatus() does not throw on a malformed EVM payout key", async () => {
+  getCloudAwareEnv.mockReturnValue({
+    EVM_PAYOUT_PRIVATE_KEY: "0xnot-a-valid-private-key",
+  });
+
+  // Must resolve, not throw (the old code threw in privateKeyToAccount).
+  const status = await payoutStatusService.getStatus(true);
+
+  expect(status.operational).toBe(false);
+  expect(status.networks.length).toBeGreaterThan(0);
+  expect(status.networks.every((n) => n.status !== "operational")).toBe(true);
+});
+
+test("getStatus() degrades a network whose RPC setup throws (no 500)", async () => {
+  getCloudAwareEnv.mockReturnValue({
+    EVM_PAYOUT_PRIVATE_KEY: `0x${"1".repeat(64)}`,
+  });
+  resolveEvmRpc.mockImplementation(() => {
+    throw new Error("RPC not configured for network");
+  });
+
+  // Resolves despite resolveEvmRpc throwing for every EVM network.
+  const status = await payoutStatusService.getStatus(true);
+
+  const base = status.networks.find((n) => n.network === "base");
+  expect(base).toBeDefined();
+  expect(base?.status).not.toBe("operational");
+  expect(status.operational).toBe(false);
+});
+
+test("isNetworkAvailable() reports unavailable instead of throwing", async () => {
+  getCloudAwareEnv.mockReturnValue({ EVM_PAYOUT_PRIVATE_KEY: "0xbad" });
+  const result = await payoutStatusService.isNetworkAvailable("base");
+  expect(result.available).toBe(false);
+  expect(typeof result.message).toBe("string");
+});

--- a/packages/cloud-shared/src/lib/services/payout-status.ts
+++ b/packages/cloud-shared/src/lib/services/payout-status.ts
@@ -83,14 +83,19 @@ class PayoutStatusService {
         : null;
 
     for (const network of ["ethereum", "base", "bnb"] as const) {
-      const status = skipLiveBalanceChecks
-        ? this.buildSkippedBalanceStatus(
-            network,
-            evmConfigured,
-            evmWalletAddress,
-            assumeOperational,
-          )
-        : await this.checkEvmNetwork(network, evmWalletAddress);
+      const status = await this.resolveNetworkStatus(
+        network,
+        evmConfigured,
+        () =>
+          skipLiveBalanceChecks
+            ? this.buildSkippedBalanceStatus(
+                network,
+                evmConfigured,
+                evmWalletAddress,
+                assumeOperational,
+              )
+            : this.checkEvmNetwork(network, evmWalletAddress),
+      );
       networks.push(status);
 
       if (status.status !== "operational") {
@@ -107,14 +112,19 @@ class PayoutStatusService {
         ? this.getSolanaWalletAddress(solanaPrivateKey)
         : null;
 
-    const solanaStatus = skipLiveBalanceChecks
-      ? this.buildSkippedBalanceStatus(
-          "solana",
-          solanaConfigured,
-          solanaWalletAddress,
-          assumeOperational,
-        )
-      : await this.checkSolanaNetwork(solanaWalletAddress);
+    const solanaStatus = await this.resolveNetworkStatus(
+      "solana",
+      solanaConfigured,
+      () =>
+        skipLiveBalanceChecks
+          ? this.buildSkippedBalanceStatus(
+              "solana",
+              solanaConfigured,
+              solanaWalletAddress,
+              assumeOperational,
+            )
+          : this.checkSolanaNetwork(solanaWalletAddress),
+    );
     networks.push(solanaStatus);
 
     if (solanaStatus.status !== "operational") {
@@ -239,21 +249,70 @@ class PayoutStatusService {
     };
   }
 
+  /**
+   * Run a per-network status producer and never let it throw out of
+   * getStatus(). Any failure degrades that single network to "not_configured"
+   * so one bad RPC / key / network can't 500 the entire redemption flow.
+   */
+  private async resolveNetworkStatus(
+    network: SupportedNetwork,
+    configured: boolean,
+    produce: () => NetworkStatus | Promise<NetworkStatus>,
+  ): Promise<NetworkStatus> {
+    try {
+      return await produce();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.warn(`[PayoutStatus] ${network} status check failed`, {
+        error: message,
+      });
+      return {
+        network,
+        configured,
+        walletAddress: null,
+        balance: 0,
+        hasBalance: false,
+        status: "not_configured",
+        message: `Status check failed: ${message}`,
+      };
+    }
+  }
+
   private getEvmWalletAddress(privateKey: string): string | null {
-    const key = privateKey.startsWith("0x")
-      ? (privateKey as `0x${string}`)
-      : (`0x${privateKey}` as `0x${string}`);
-    const account = privateKeyToAccount(key);
-    return account.address;
+    try {
+      const key = privateKey.startsWith("0x")
+        ? (privateKey as `0x${string}`)
+        : (`0x${privateKey}` as `0x${string}`);
+      const account = privateKeyToAccount(key);
+      return account.address;
+    } catch (error) {
+      // A malformed EVM payout key must not throw out of getStatus() and 500
+      // the whole redemption flow; treat EVM as unconfigured instead.
+      logger.warn(
+        "[PayoutStatus] Invalid EVM payout private key; treating EVM as unconfigured",
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+      return null;
+    }
   }
 
   private getSolanaWalletAddress(privateKey: string): string | null {
-    // Solana private key is base58 encoded
-    const { Keypair } = require("@solana/web3.js");
-    const bs58 = require("bs58");
-    const decoded = bs58.decode(privateKey);
-    const keypair = Keypair.fromSecretKey(decoded);
-    return keypair.publicKey.toBase58();
+    try {
+      // Solana private key is base58 encoded
+      const { Keypair } = require("@solana/web3.js");
+      const bs58 = require("bs58");
+      const decoded = bs58.decode(privateKey);
+      const keypair = Keypair.fromSecretKey(decoded);
+      return keypair.publicKey.toBase58();
+    } catch (error) {
+      logger.warn(
+        "[PayoutStatus] Invalid Solana payout private key; treating Solana as unconfigured",
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+      return null;
+    }
   }
 
   private async checkEvmNetwork(
@@ -272,15 +331,36 @@ class PayoutStatusService {
       };
     }
 
-    const chain = EVM_CHAINS[network];
     const tokenAddress = ELIZA_TOKEN_ADDRESSES[network] as Address;
     const decimals = ELIZA_DECIMALS[network];
 
-    const { url: rpcUrl } = resolveEvmRpc(network as EvmPayoutNetwork);
-    const publicClient = createPublicClient({
-      chain,
-      transport: http(rpcUrl),
-    });
+    // RPC resolution / client construction can throw when a network's RPC is
+    // not configured; degrade that single network instead of throwing out of
+    // getStatus() and 500-ing the whole redemption flow.
+    let publicClient: ReturnType<typeof createPublicClient>;
+    try {
+      const chain = EVM_CHAINS[network];
+      const { url: rpcUrl } = resolveEvmRpc(network as EvmPayoutNetwork);
+      publicClient = createPublicClient({
+        chain,
+        transport: http(rpcUrl),
+      });
+    } catch (setupError) {
+      const message =
+        setupError instanceof Error ? setupError.message : String(setupError);
+      logger.warn(`[PayoutStatus] ${network} RPC setup failed`, {
+        error: message,
+      });
+      return {
+        network,
+        configured: true,
+        walletAddress: this.maskAddress(walletAddress),
+        balance: 0,
+        hasBalance: false,
+        status: "not_configured",
+        message: `RPC unavailable: ${message}`,
+      };
+    }
 
     const ERC20_ABI = parseAbi(["function balanceOf(address account) view returns (uint256)"]);
 


### PR DESCRIPTION
Lands the final piece of the cloud-apps monetization work (the other 8 commits — Monetization→Apps rename, x402 image-gen example app, x402-earnings test, image-503 fix, redemption logging, clone-ur-crush Tailwind v4 fix, app_billing doc, operator runbook — are already on develop).

**Root cause:** `PayoutStatusService.getStatus()` derived the EVM wallet (`privateKeyToAccount`) and built each network's RPC client with no try/catch, so a single malformed payout key or one unconfigured-RPC network threw out of `getStatus()` and **500'd the entire token-redemption flow** (quote + status + execute) — found live by executing a real redemption. Now every per-network/per-wallet failure degrades to `not_configured` and `getStatus()` never throws. Pinned by `payout-status-resilience.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)