### PR TITLE
fix(cloud-api): reconcile pricing catalog via OpenRouter fallback (no 500)

### DIFF
--- a/packages/cloud-shared/src/lib/services/ai-pricing/openrouter-fallback.test.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/openrouter-fallback.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Pins the OpenRouter pricing fallback that reconciles the catalog: any language
+ * model the API offers that BitRouter's catalog does not price (e.g.
+ * openai/gpt-5.5, anthropic/claude-haiku-4.5, x-ai/grok-4.20) gets a real
+ * per-token price from OpenRouter's public catalog instead of 500-ing
+ * "Pricing unavailable". Entries are low-priority (-1) so live BitRouter rows and
+ * forced rows always win.
+ */
+import { expect, test } from "bun:test";
+import {
+  buildOpenRouterPreparedEntries,
+  fetchOpenRouterCatalogEntries,
+} from "./providers/openrouter";
+import type { BitRouterCatalogModel } from "./types";
+
+const model = (id: string, pricing: Record<string, unknown>): BitRouterCatalogModel =>
+  ({ id, pricing }) as BitRouterCatalogModel;
+
+test("maps a language model's prices to per-token input/output fallback rows", () => {
+  const entries = buildOpenRouterPreparedEntries(
+    model("openai/gpt-5.5", { prompt: "0.000005", completion: "0.00003" }),
+  );
+  expect(entries.length).toBe(2);
+
+  const input = entries.find((e) => e.chargeType === "input");
+  expect(input?.unitPrice).toBe(0.000005);
+  expect(input?.productFamily).toBe("language");
+  expect(input?.unit).toBe("token");
+  expect(input?.provider).toBe("openai");
+  expect(input?.billingSource).toBe("bitrouter");
+  expect(input?.priority).toBe(-1); // fallback — live/forced rows win
+
+  expect(entries.find((e) => e.chargeType === "output")?.unitPrice).toBe(0.00003);
+});
+
+test("excludes non-language models and unpriced models", () => {
+  expect(
+    buildOpenRouterPreparedEntries(
+      model("google/gemini-3.1-flash-image-preview", { prompt: "0.0000005" }),
+    ),
+  ).toEqual([]);
+  expect(
+    buildOpenRouterPreparedEntries(
+      model("openai/text-embedding-3-small", { prompt: "0.00000002" }),
+    ),
+  ).toEqual([]);
+  expect(buildOpenRouterPreparedEntries(model("openai/gpt-5.5", {}))).toEqual([]);
+});
+
+test("fetchOpenRouterCatalogEntries parses a catalog payload (fetch mocked)", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        data: [
+          {
+            id: "anthropic/claude-haiku-4.5",
+            pricing: { prompt: "0.000001", completion: "0.000005" },
+          },
+          { id: "x-ai/grok-4.20", pricing: { prompt: "0.00000125", completion: "0.0000025" } },
+        ],
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    )) as typeof fetch;
+  try {
+    const entries = await fetchOpenRouterCatalogEntries();
+    const haikuInput = entries.find(
+      (e) => e.model === "anthropic/claude-haiku-4.5" && e.chargeType === "input",
+    );
+    expect(haikuInput?.unitPrice).toBe(0.000001);
+    expect(
+      entries.some(
+        (e) =>
+          e.model === "x-ai/grok-4.20" && e.chargeType === "output" && e.unitPrice === 0.0000025,
+      ),
+    ).toBe(true);
+  } finally {
+    globalThis.fetch = original;
+  }
+});
+
+test("fetchOpenRouterCatalogEntries is non-fatal when OpenRouter is unreachable", async () => {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    throw new Error("network down");
+  }) as typeof fetch;
+  try {
+    expect(await fetchOpenRouterCatalogEntries()).toEqual([]);
+  } finally {
+    globalThis.fetch = original;
+  }
+});

--- a/packages/cloud-shared/src/lib/services/ai-pricing/providers/bitrouter.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/providers/bitrouter.ts
@@ -9,6 +9,7 @@ import {
   EXTERNAL_CACHE_TTL_MS,
   type PreparedPricingEntry,
 } from "../types";
+import { fetchOpenRouterCatalogEntries } from "./openrouter";
 
 const CEREBRAS_PRICING_SOURCE_URL = "https://www.cerebras.ai/pricing";
 // OpenRouter doesn't return a priced row from BitRouter for `openai/gpt-oss-120b`,
@@ -363,9 +364,14 @@ export async function fetchBitRouterCatalogEntries(): Promise<PreparedPricingEnt
       data?: BitRouterCatalogModel[];
     }>(url);
     const models = Array.isArray(payload.data) ? payload.data : [];
+    // OpenRouter fallback (low-priority -1) fills any language model BitRouter's
+    // catalog does not price — a live BitRouter row or a forced row always wins.
+    // Non-fatal: returns [] if OpenRouter is unreachable.
+    const openRouterEntries = await fetchOpenRouterCatalogEntries();
     const entries = [
       ...models.flatMap((model) => buildBitRouterPreparedEntries(model)),
       ...buildForcedBitRouterPricingEntries(),
+      ...openRouterEntries,
     ];
     if (entries.length === 0) {
       logger.warn("[AI Pricing] BitRouter catalog returned no priced models", {

--- a/packages/cloud-shared/src/lib/services/ai-pricing/providers/openrouter.ts
+++ b/packages/cloud-shared/src/lib/services/ai-pricing/providers/openrouter.ts
@@ -1,0 +1,90 @@
+import { logger } from "../../../utils/logger";
+import { inferProviderFromCanonicalModel, parseNumericPrice } from "../dimensions";
+import {
+  type BitRouterCatalogModel,
+  EXTERNAL_CACHE_TTL_MS,
+  type PreparedPricingEntry,
+} from "../types";
+
+// OpenRouter publishes per-token USD prices (pricing.prompt / pricing.completion)
+// for hundreds of language models with NO auth. We append these as LOW-PRIORITY
+// (-1) fallback rows to the BitRouter gateway result so any model the API offers
+// that BitRouter's catalog does not price (e.g. openai/gpt-5.5,
+// anthropic/claude-haiku-4.5, x-ai/grok-4.20) still resolves a real price instead
+// of 500-ing "Pricing unavailable". A live BitRouter price or a FORCED row
+// (priority 0) always wins over these, so this never overrides a configured
+// price — it only fills gaps. Same source the gpt-oss-120b forced row cites.
+const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
+
+// Non-language families have dedicated pricing paths (image/video/tts/stt/
+// embedding charge by image/second/character, not per token). Only language
+// token pricing is mirrored from OpenRouter.
+const NON_LANGUAGE_MODEL_ID = /image|embedding|whisper|\btts\b|audio|video|moderation/i;
+
+export function buildOpenRouterPreparedEntries(
+  model: BitRouterCatalogModel,
+): PreparedPricingEntry[] {
+  if (!model?.id || NON_LANGUAGE_MODEL_ID.test(model.id)) return [];
+
+  const pricing = model.pricing ?? {};
+  const provider = inferProviderFromCanonicalModel(model.id);
+  const fetchedAt = new Date();
+  const staleAfter = new Date(fetchedAt.getTime() + EXTERNAL_CACHE_TTL_MS);
+
+  const buildEntry = (chargeType: "input" | "output", unitPrice: number): PreparedPricingEntry => ({
+    billingSource: "bitrouter",
+    provider,
+    model: model.id,
+    productFamily: "language",
+    chargeType,
+    unit: "token",
+    unitPrice,
+    sourceKind: "openrouter_catalog",
+    sourceUrl: OPENROUTER_MODELS_URL,
+    fetchedAt,
+    staleAfter,
+    // Fallback only — BitRouter live rows and FORCED rows (priority 0) win.
+    priority: -1,
+  });
+
+  const entries: PreparedPricingEntry[] = [];
+  // OpenRouter `prompt`/`completion` are USD per token (OpenRouter flat form),
+  // used as-is — matching resolveTokenUnitPrice's flat-field handling.
+  const promptPrice = parseNumericPrice(pricing.prompt);
+  if (promptPrice != null) {
+    entries.push(buildEntry("input", promptPrice));
+  }
+  const completionPrice = parseNumericPrice(pricing.completion);
+  if (completionPrice != null) {
+    entries.push(buildEntry("output", completionPrice));
+  }
+  return entries;
+}
+
+export async function fetchOpenRouterCatalogEntries(): Promise<PreparedPricingEntry[]> {
+  try {
+    const response = await fetch(OPENROUTER_MODELS_URL, {
+      headers: {
+        "User-Agent": "ElizaCloudPricingBot/1.0",
+        Accept: "application/json",
+      },
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) {
+      logger.warn("[AI Pricing] OpenRouter catalog fetch failed", {
+        status: response.status,
+      });
+      return [];
+    }
+    const payload = (await response.json()) as { data?: BitRouterCatalogModel[] };
+    const models = Array.isArray(payload.data) ? payload.data : [];
+    return models.flatMap((model) => buildOpenRouterPreparedEntries(model));
+  } catch (error) {
+    // Non-fatal: OpenRouter is a fallback price source. If it is unreachable the
+    // BitRouter catalog + forced rows still resolve every configured model.
+    logger.warn("[AI Pricing] OpenRouter catalog fetch error (non-fatal)", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return [];
+  }
+}


### PR DESCRIPTION
Models the API offers (e.g. `openai/gpt-5.5`, `anthropic/claude-haiku-4.5`, `x-ai/grok-4.20`, `openai/gpt-5-mini`) returned **HTTP 500 "Pricing unavailable"** when used — reproduced live against prod — because BitRouter's catalog returns no priced row for them and they aren't in `FORCED_BITROUTER_PRICING`.

**Fix:** a live **OpenRouter** pricing fallback (`providers/openrouter.ts`, public `/api/v1/models`, no auth — the same source the existing `gpt-oss-120b` forced row cites). It's appended to the BitRouter gateway result as **low-priority (-1)** language rows, so a live BitRouter price or a FORCED row (priority 0) always wins — OpenRouter only fills models BitRouter doesn't price. Image/embedding/audio excluded (dedicated paths). Fetch is **non-fatal** (returns [] if OpenRouter is unreachable). Real per-token prices, refreshed live — not a stale hand-maintained snapshot.

Pinned by `openrouter-fallback.test.ts` (4 tests: mapping, exclusions, parse, non-fatal). 3 files, +185.

🤖 Generated with [Claude Code](https://claude.com/claude-code)