### PR TITLE
feat(ui): home-pinned interactive Tutorial + searchable Help views

### DIFF
--- a/packages/app/test/ui-smoke/tutorial-help-views.spec.ts
+++ b/packages/app/test/ui-smoke/tutorial-help-views.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test";
+import { installDefaultAppRoutes, openAppPath } from "./helpers";
+
+/**
+ * Verifies the two new home-pinned views:
+ *  - Tutorial + Help tiles are pinned to the home screen (Tutorial first).
+ *  - The Tutorial tile opens the launcher, and Start activates the interactive
+ *    spotlight overlay (the tour card) that survives navigation.
+ *  - The Help view searches the knowledge base and shows matching answers.
+ */
+
+test("Tutorial + Help are pinned to home and both work", async ({ page }) => {
+  await installDefaultAppRoutes(page);
+  await openAppPath(page, "/chat"); // the home screen (tiles)
+
+  // 1. Both tiles are pinned to the home screen.
+  const tutorialTile = page.getByTestId("home-tile-tutorial");
+  const helpTile = page.getByTestId("home-tile-help");
+  await expect(tutorialTile).toBeVisible({ timeout: 25_000 });
+  await expect(helpTile).toBeVisible();
+
+  // Tutorial is the FIRST tile.
+  const tileIds = await page
+    .locator('[data-testid^="home-tile-"]')
+    .evaluateAll((els) =>
+      els.map((e) => e.getAttribute("data-testid")?.replace("home-tile-", "")),
+    );
+  expect(tileIds[0]).toBe("tutorial");
+  expect(tileIds).toContain("help");
+
+  // 2. Tutorial → launcher → Start → the interactive spotlight overlay appears.
+  await tutorialTile.click();
+  await expect(page.getByTestId("tutorial-launcher")).toBeVisible();
+  await page.getByTestId("tutorial-start-text").click();
+  const card = page.getByTestId("tutorial-card");
+  await expect(card).toBeVisible();
+  await expect(card).toContainText(/Step 1 of/i);
+
+  // It survives navigation and can be dismissed.
+  await page.getByText("Skip tutorial").click();
+  await expect(card).toHaveCount(0);
+
+  // 3. Help → search the knowledge base → a matching answer with a deep-link.
+  await page.getByTestId("home-tile-help").click();
+  await expect(page.getByTestId("help-view")).toBeVisible();
+  await page.getByTestId("help-search").fill("change the model");
+  const entry = page.getByTestId("help-entry-change-model");
+  await expect(entry).toBeVisible();
+  await entry.click();
+  await expect(entry).toContainText(/AI Model/i);
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -32,6 +32,7 @@ import { SaveCommandModal } from "./components/chat/SaveCommandModal";
 import { CustomActionEditor } from "./components/custom-actions/CustomActionEditor";
 import { CustomActionsPanel } from "./components/custom-actions/CustomActionsPanel";
 import { AppsPageView } from "./components/pages/AppsPageView";
+import { TutorialOverlay } from "./components/pages/tutorial/TutorialOverlay";
 import { SecretsManagerModalRoot } from "./components/settings/SecretsManagerSection";
 import { AssistantOverlay } from "./components/shell/AssistantOverlay";
 import { BugReportModal } from "./components/shell/BugReportModal";
@@ -161,6 +162,14 @@ const PhonePageView = lazyNamedView(
 const SettingsView = lazyNamedView(
   () => import("./components/pages/SettingsView"),
   "SettingsView",
+);
+const TutorialView = lazyNamedView(
+  () => import("./components/pages/tutorial/TutorialView"),
+  "TutorialView",
+);
+const HelpView = lazyNamedView(
+  () => import("./components/pages/help/HelpView"),
+  "HelpView",
 );
 const StreamView = lazyNamedView(
   () => import("./components/pages/StreamView"),
@@ -721,6 +730,16 @@ function renderStaticViewRouterTab({
 }): ReactNode {
   const directViews: Record<string, ReactNode> = {
     onboarding: <FirstRunScreen />,
+    tutorial: (
+      <TabContentView>
+        <TutorialView />
+      </TabContentView>
+    ),
+    help: (
+      <TabContentView>
+        <HelpView />
+      </TabContentView>
+    ),
     chat: <ViewUnavailableFallback />,
     browser: <BrowserWorkspaceView />,
     companion: <ViewUnavailableFallback />,
@@ -1662,6 +1681,11 @@ export function App() {
           behind stays live.
         */}
         <ContinuousChatOverlayMount />
+        {/* Interactive tutorial: a persistent spotlight overlay that survives
+            navigation (it sends the user to Settings, back home, …). Renders
+            only when the tutorial is active (launched from the home Tutorial
+            tile or the Help view). */}
+        <TutorialOverlay />
         <ShellOverlays actionNotice={actionNotice} />
         <SaveCommandModal
           open={contextMenu.saveCommandModalOpen}

--- a/packages/ui/src/components/pages/help/HelpView.tsx
+++ b/packages/ui/src/components/pages/help/HelpView.tsx
@@ -1,0 +1,192 @@
+import * as React from "react";
+
+import { useApp } from "../../../state";
+import { startTutorial } from "../tutorial/tutorial-controller";
+import {
+  HELP_CATEGORIES,
+  HELP_ENTRIES,
+  type HelpCategory,
+  type HelpDeepLink,
+  type HelpEntry,
+} from "./help-content";
+
+/**
+ * Help — a searchable FAQ / knowledge base. Type a question or pick a category;
+ * each answer can deep-link straight to the relevant screen (or launch the
+ * interactive tutorial). Pinned to the home screen next to Tutorial.
+ */
+
+const BRAND = "#FF5800";
+
+function scoreEntry(entry: HelpEntry, q: string): number {
+  if (!q) return 1;
+  const needle = q.toLowerCase();
+  const tokens = needle.split(/\s+/).filter(Boolean);
+  const hay =
+    `${entry.question} ${entry.answer} ${entry.keywords.join(" ")}`.toLowerCase();
+  let score = 0;
+  for (const t of tokens) {
+    if (entry.question.toLowerCase().includes(t)) score += 3;
+    else if (entry.keywords.some((k) => k.includes(t))) score += 2;
+    else if (hay.includes(t)) score += 1;
+    else return 0; // every token must match somewhere
+  }
+  return score;
+}
+
+export function HelpView(): React.ReactElement {
+  const { setTab } = useApp();
+  const [query, setQuery] = React.useState("");
+  const [category, setCategory] = React.useState<HelpCategory | "All">("All");
+  const [openId, setOpenId] = React.useState<string | null>(null);
+
+  const results = React.useMemo(() => {
+    return HELP_ENTRIES.map((e) => ({ e, score: scoreEntry(e, query) }))
+      .filter(
+        ({ e, score }) =>
+          score > 0 && (category === "All" || e.category === category),
+      )
+      .sort((a, b) => b.score - a.score)
+      .map(({ e }) => e);
+  }, [query, category]);
+
+  const navigate = React.useCallback(
+    (link: HelpDeepLink) => {
+      if (link.startTutorial) {
+        startTutorial();
+        setTab("chat");
+        return;
+      }
+      if (link.settingsSection) {
+        try {
+          window.location.hash = link.settingsSection;
+        } catch {
+          /* ignore */
+        }
+        setTab("settings");
+        return;
+      }
+      if (link.tab) setTab(link.tab);
+    },
+    [setTab],
+  );
+
+  return (
+    <div
+      className="flex h-full w-full flex-col overflow-hidden"
+      data-testid="help-view"
+    >
+      <div className="px-5 pt-5">
+        <h1 className="text-xl font-semibold text-txt-strong">Help</h1>
+        <p className="mt-0.5 text-[13px] text-txt/60">
+          Search for anything, or browse by topic. Answers can take you straight
+          there.
+        </p>
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Ask a question… e.g. “how do I change the model?”"
+          data-testid="help-search"
+          aria-label="Search help"
+          className="mt-3 w-full rounded-xl border border-white/12 bg-white/5 px-4 py-2.5 text-[14px] text-txt-strong outline-none placeholder:text-txt/40 focus:border-white/25"
+        />
+        <div className="mt-3 flex flex-wrap gap-1.5 pb-3">
+          {(["All", ...HELP_CATEGORIES] as const).map((c) => {
+            const activeCat = category === c;
+            return (
+              <button
+                key={c}
+                type="button"
+                onClick={() => setCategory(c)}
+                className="rounded-full border px-2.5 py-1 text-[12px] transition-colors"
+                style={
+                  activeCat
+                    ? {
+                        backgroundColor: BRAND,
+                        borderColor: BRAND,
+                        color: "#fff",
+                      }
+                    : {
+                        borderColor: "rgba(255,255,255,0.14)",
+                        color: "rgba(255,255,255,0.7)",
+                      }
+                }
+              >
+                {c}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-8">
+        {results.length === 0 ? (
+          <p className="mt-6 text-center text-[13px] text-txt/50">
+            No answers matched “{query}”. Try simpler words, or ask the chat
+            directly — Eliza can help in the moment.
+          </p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {results.map((entry) => {
+              const open = openId === entry.id;
+              return (
+                <li
+                  key={entry.id}
+                  className="overflow-hidden rounded-xl border border-white/10 bg-white/[0.03]"
+                  data-testid={`help-entry-${entry.id}`}
+                >
+                  <button
+                    type="button"
+                    onClick={() => setOpenId(open ? null : entry.id)}
+                    aria-expanded={open}
+                    className="flex w-full items-center justify-between gap-3 px-4 py-3 text-left transition-colors hover:bg-white/[0.04]"
+                  >
+                    <span className="text-[14px] font-medium text-txt-strong">
+                      {entry.question}
+                    </span>
+                    <span
+                      className="shrink-0 text-txt/40 transition-transform"
+                      style={{ transform: open ? "rotate(90deg)" : "none" }}
+                      aria-hidden
+                    >
+                      ›
+                    </span>
+                  </button>
+                  {open && (
+                    <div className="px-4 pb-4">
+                      <p className="text-[13px] leading-relaxed text-txt/75">
+                        {entry.answer}
+                      </p>
+                      {entry.deepLink && (
+                        <button
+                          type="button"
+                          onClick={() =>
+                            navigate(entry.deepLink as HelpDeepLink)
+                          }
+                          className="mt-3 inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-[13px] font-semibold text-white transition-colors"
+                          style={{ backgroundColor: BRAND }}
+                          onMouseEnter={(e) => {
+                            e.currentTarget.style.backgroundColor = "#D44A00";
+                          }}
+                          onMouseLeave={(e) => {
+                            e.currentTarget.style.backgroundColor = BRAND;
+                          }}
+                        >
+                          {entry.deepLink.label} →
+                        </button>
+                      )}
+                      <div className="mt-2 text-[11px] uppercase tracking-wide text-txt/35">
+                        {entry.category}
+                      </div>
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/pages/help/help-content.ts
+++ b/packages/ui/src/components/pages/help/help-content.ts
@@ -1,0 +1,546 @@
+/**
+ * Eliza Help knowledge base. Plain-language answers to what a confused new user
+ * actually asks, each with an optional deep-link into the app (a tab, or a
+ * Settings section). Searched client-side over question + answer + keywords.
+ *
+ * Keep answers short (2-4 sentences), accurate to the product, and jargon-light.
+ */
+
+export interface HelpDeepLink {
+  label: string;
+  /** Navigate to this tab/view. */
+  tab?: string;
+  /** Open Settings to this section id (identity | ai-model | runtime | appearance). */
+  settingsSection?: string;
+  /** Launch the interactive tutorial. */
+  startTutorial?: boolean;
+}
+
+export interface HelpEntry {
+  id: string;
+  category: HelpCategory;
+  question: string;
+  answer: string;
+  keywords: string[];
+  deepLink?: HelpDeepLink;
+}
+
+export type HelpCategory =
+  | "Getting started"
+  | "Chat & navigation"
+  | "AI models"
+  | "Privacy & data"
+  | "Voice"
+  | "Connecting apps"
+  | "Eliza Cloud"
+  | "What Eliza can do"
+  | "Troubleshooting";
+
+export const HELP_CATEGORIES: HelpCategory[] = [
+  "Getting started",
+  "Chat & navigation",
+  "AI models",
+  "Privacy & data",
+  "Voice",
+  "Connecting apps",
+  "Eliza Cloud",
+  "What Eliza can do",
+  "Troubleshooting",
+];
+
+export const HELP_ENTRIES: HelpEntry[] = [
+  // ── Getting started ───────────────────────────────────────────────────────
+  {
+    id: "what-is-eliza",
+    category: "Getting started",
+    question: "What is Eliza?",
+    answer:
+      "Eliza is your personal AI agent. It chats with you by text or voice, can run on your own device or in the cloud, and can do real work — answer questions, manage tasks, use connected apps, and control its own screens. You drive all of it through one chat that floats over every view.",
+    keywords: ["what", "eliza", "about", "agent", "ai", "assistant", "intro"],
+    deepLink: { label: "Take the 90-second tour", startTutorial: true },
+  },
+  {
+    id: "first-thing",
+    category: "Getting started",
+    question: "I just opened Eliza — what do I do first?",
+    answer:
+      "Take the interactive tutorial (the first tile on your home screen). It walks you through the chat, switching screens, and Settings in about 90 seconds, checking each step as you go.",
+    keywords: ["start", "first", "begin", "new", "tutorial", "onboarding"],
+    deepLink: { label: "Start the tutorial", startTutorial: true },
+  },
+  {
+    id: "the-chat-pill",
+    category: "Getting started",
+    question: "What is the glowing pill at the bottom?",
+    answer:
+      "That's your chat — the one place you talk to Eliza. It floats over every screen so it's always reachable. Tap it to open, type or talk, drag the handle up to expand it, or swipe down to shrink it back to the pill.",
+    keywords: ["pill", "bubble", "bottom", "floating", "chat", "capsule"],
+  },
+
+  // ── Chat & navigation ─────────────────────────────────────────────────────
+  {
+    id: "open-chat",
+    category: "Chat & navigation",
+    question: "How do I open and close the chat?",
+    answer:
+      "Tap the floating pill to open the chat. To expand it full-screen, drag the handle at the top upward (or tap it). To minimize, swipe down on the handle — it collapses back to the pill but stays one tap away.",
+    keywords: [
+      "open",
+      "close",
+      "expand",
+      "minimize",
+      "maximize",
+      "hide",
+      "show",
+      "chat",
+      "collapse",
+    ],
+  },
+  {
+    id: "switch-views",
+    category: "Chat & navigation",
+    question: "How do I switch screens / views?",
+    answer:
+      "Two ways: tap a tile on the home screen, or just ask the chat — type or say things like “open settings”, “go home”, or “show my tasks” and Eliza navigates there for you.",
+    keywords: [
+      "switch",
+      "change",
+      "view",
+      "screen",
+      "navigate",
+      "tab",
+      "move",
+      "go",
+    ],
+    deepLink: { label: "Open Views", tab: "views" },
+  },
+  {
+    id: "navigate-by-talking",
+    category: "Chat & navigation",
+    question: "Can I really navigate just by talking to it?",
+    answer:
+      "Yes. Eliza understands navigation requests in plain language. In the chat, type or speak “open settings”, “take me home”, “show the model settings”, etc., and it switches screens for you — no menus required.",
+    keywords: [
+      "talk",
+      "voice",
+      "navigate",
+      "command",
+      "ask",
+      "say",
+      "natural language",
+    ],
+  },
+  {
+    id: "get-to-settings",
+    category: "Chat & navigation",
+    question: "How do I get to Settings?",
+    answer:
+      "Tap the Settings tile on the home screen, or ask the chat to “open settings”. Settings is where you choose your AI model, turn on voice, connect apps, and pick local vs cloud.",
+    keywords: ["settings", "preferences", "options", "configure", "setup"],
+    deepLink: { label: "Open Settings", tab: "settings" },
+  },
+
+  // ── AI models ─────────────────────────────────────────────────────────────
+  {
+    id: "change-model",
+    category: "AI models",
+    question: "How do I change the AI model?",
+    answer:
+      "Go to Settings → AI Model. You can pick a cloud provider (like Anthropic or OpenAI with your key, or Eliza Cloud) or download a local model that runs entirely on your device.",
+    keywords: [
+      "model",
+      "change",
+      "switch",
+      "llm",
+      "ai",
+      "provider",
+      "anthropic",
+      "openai",
+      "gpt",
+      "claude",
+    ],
+    deepLink: {
+      label: "Open AI Model settings",
+      tab: "settings",
+      settingsSection: "ai-model",
+    },
+  },
+  {
+    id: "local-inference",
+    category: "AI models",
+    question: "Can Eliza run AI on my own device (offline)?",
+    answer:
+      "Yes — that's local inference. In Settings → AI Model you can download a local model that runs on-device with no cloud calls, so it works offline and keeps everything private. The recommended local model is eliza-1, but you can search and download many models.",
+    keywords: [
+      "local",
+      "offline",
+      "on-device",
+      "private",
+      "download",
+      "model",
+      "inference",
+      "eliza-1",
+      "no internet",
+    ],
+    deepLink: {
+      label: "Open AI Model settings",
+      tab: "settings",
+      settingsSection: "ai-model",
+    },
+  },
+  {
+    id: "recommended-model",
+    category: "AI models",
+    question: "Which model should I use?",
+    answer:
+      "For a fully local, private setup, eliza-1 is the recommended on-device model. If you want maximum capability and don't mind using the cloud, connect a frontier provider (Anthropic/OpenAI) or log in to Eliza Cloud.",
+    keywords: [
+      "recommended",
+      "best",
+      "which",
+      "model",
+      "eliza-1",
+      "good",
+      "default",
+    ],
+    deepLink: {
+      label: "Open AI Model settings",
+      tab: "settings",
+      settingsSection: "ai-model",
+    },
+  },
+
+  // ── Privacy & data ────────────────────────────────────────────────────────
+  {
+    id: "is-data-local",
+    category: "Privacy & data",
+    question: "Is my data private / stored locally?",
+    answer:
+      "Eliza is local-first. Your conversations and data live on your device by default, in local storage. If you choose a cloud model or log in to Eliza Cloud, only the requests needed for that service leave your device — you stay in control.",
+    keywords: [
+      "privacy",
+      "private",
+      "data",
+      "local",
+      "stored",
+      "where",
+      "secure",
+      "cloud",
+      "offline",
+    ],
+    deepLink: {
+      label: "Open runtime settings",
+      tab: "settings",
+      settingsSection: "runtime",
+    },
+  },
+  {
+    id: "topologies",
+    category: "Privacy & data",
+    question: "What's the difference between local, cloud, and remote?",
+    answer:
+      "Local: the agent and models run on your device (most private, works offline). Cloud: a hosted agent runs in Eliza Cloud (best for mobile, nothing to manage). Local + Cloud: a local agent that uses cloud models/services when it needs more power. You can switch in Settings → Runtime.",
+    keywords: [
+      "local",
+      "cloud",
+      "remote",
+      "topology",
+      "difference",
+      "mode",
+      "hosted",
+      "device",
+    ],
+    deepLink: {
+      label: "Open runtime settings",
+      tab: "settings",
+      settingsSection: "runtime",
+    },
+  },
+
+  // ── Voice ─────────────────────────────────────────────────────────────────
+  {
+    id: "talk-by-voice",
+    category: "Voice",
+    question: "How do I talk to Eliza by voice?",
+    answer:
+      "Open the chat and tap the microphone. Speak naturally — Eliza transcribes you, replies, and can speak its answer back. You can even navigate by voice (“open settings”, “go home”).",
+    keywords: [
+      "voice",
+      "talk",
+      "speak",
+      "microphone",
+      "mic",
+      "say",
+      "hands-free",
+      "audio",
+    ],
+  },
+  {
+    id: "enable-voice",
+    category: "Voice",
+    question: "How do I turn voice on or pick a voice?",
+    answer:
+      "Open Settings and find the voice options to enable spoken replies and choose a voice. Voice works locally on-device or via the cloud depending on your setup.",
+    keywords: [
+      "voice",
+      "enable",
+      "turn on",
+      "settings",
+      "tts",
+      "speak",
+      "sound",
+      "choose voice",
+    ],
+    deepLink: { label: "Open Settings", tab: "settings" },
+  },
+  {
+    id: "voice-not-working",
+    category: "Voice",
+    question: "Voice isn't working — what do I check?",
+    answer:
+      "Make sure you granted microphone permission, your device isn't muted, and a voice model is ready (first use may download one). Try toggling voice off and on in Settings, then tap the mic again.",
+    keywords: [
+      "voice",
+      "not working",
+      "broken",
+      "microphone",
+      "permission",
+      "mute",
+      "no sound",
+      "troubleshoot",
+    ],
+    deepLink: { label: "Open Settings", tab: "settings" },
+  },
+
+  // ── Connecting apps ───────────────────────────────────────────────────────
+  {
+    id: "what-are-connectors",
+    category: "Connecting apps",
+    question: "What are connectors?",
+    answer:
+      "Connectors let Eliza work with your other apps and platforms — Discord, Telegram, Slack, X, WhatsApp, and more — so it can read and send messages there on your behalf. You add them in Settings.",
+    keywords: [
+      "connector",
+      "connect",
+      "integration",
+      "apps",
+      "platform",
+      "discord",
+      "telegram",
+      "slack",
+    ],
+    deepLink: { label: "Open Settings", tab: "settings" },
+  },
+  {
+    id: "connect-discord",
+    category: "Connecting apps",
+    question: "How do I connect Discord / Telegram / Slack?",
+    answer:
+      "Open Settings, find Connectors, choose the platform, and follow the steps to paste a token or authorize it. Once connected, Eliza can chat on that platform alongside your local chat.",
+    keywords: [
+      "discord",
+      "telegram",
+      "slack",
+      "whatsapp",
+      "connect",
+      "add",
+      "token",
+      "platform",
+      "x",
+      "twitter",
+    ],
+    deepLink: { label: "Open Settings", tab: "settings" },
+  },
+
+  // ── Eliza Cloud ───────────────────────────────────────────────────────────
+  {
+    id: "what-is-cloud",
+    category: "Eliza Cloud",
+    question: "What is Eliza Cloud?",
+    answer:
+      "Eliza Cloud is the optional managed backend. It can host your agent, route AI requests, handle login and billing, and run server-side workloads — so you don't have to manage a model or keys yourself. It's optional: Eliza runs fully local without it.",
+    keywords: [
+      "cloud",
+      "eliza cloud",
+      "hosted",
+      "managed",
+      "backend",
+      "service",
+      "what",
+    ],
+  },
+  {
+    id: "do-i-need-cloud",
+    category: "Eliza Cloud",
+    question: "Do I need to log in to Eliza Cloud?",
+    answer:
+      "No. Eliza works fully on your device without any account. Logging in to Eliza Cloud is optional and just unlocks hosted models, cross-device sync, and managed services if you want them.",
+    keywords: [
+      "cloud",
+      "login",
+      "account",
+      "need",
+      "required",
+      "sign in",
+      "optional",
+    ],
+    deepLink: {
+      label: "Open AI Model / Cloud settings",
+      tab: "settings",
+      settingsSection: "ai-model",
+    },
+  },
+  {
+    id: "cloud-login",
+    category: "Eliza Cloud",
+    question: "How do I log in to Eliza Cloud?",
+    answer:
+      "Open Settings → AI Model (Cloud) and choose to connect Eliza Cloud, then follow the sign-in. Once linked, you can use hosted models and services without managing your own keys.",
+    keywords: [
+      "login",
+      "log in",
+      "sign in",
+      "cloud",
+      "connect",
+      "account",
+      "authenticate",
+    ],
+    deepLink: {
+      label: "Open Cloud settings",
+      tab: "settings",
+      settingsSection: "ai-model",
+    },
+  },
+
+  // ── What Eliza can do ─────────────────────────────────────────────────────
+  {
+    id: "what-can-it-do",
+    category: "What Eliza can do",
+    question: "What can Eliza actually do?",
+    answer:
+      "Beyond chatting, Eliza can manage tasks and reminders, search and remember things, use connected apps, browse, run skills, and even open and control its own screens. What's available depends on the model and connectors you've set up.",
+    keywords: [
+      "do",
+      "capabilities",
+      "features",
+      "what",
+      "can",
+      "abilities",
+      "tasks",
+      "actions",
+    ],
+    deepLink: { label: "Browse Views", tab: "views" },
+  },
+  {
+    id: "what-are-skills",
+    category: "What Eliza can do",
+    question: "What are skills?",
+    answer:
+      "Skills are packages of know-how that teach Eliza how to do specific things — like using a particular app, following a workflow, or a specialized task. You can browse the skills it has and add more.",
+    keywords: [
+      "skills",
+      "abilities",
+      "knowledge",
+      "use_skill",
+      "packages",
+      "capabilities",
+    ],
+    deepLink: { label: "Open Skills", tab: "skills" },
+  },
+  {
+    id: "views-and-apps",
+    category: "What Eliza can do",
+    question: "What are Views and Apps?",
+    answer:
+      "Views and Apps are the screens Eliza can show you — things like your tasks, documents, memories, settings, or specialized tools. You can open them from the home tiles or by asking the chat; Eliza can also open them for you.",
+    keywords: [
+      "views",
+      "apps",
+      "screens",
+      "tools",
+      "tiles",
+      "surfaces",
+      "what",
+    ],
+    deepLink: { label: "Open Views", tab: "views" },
+  },
+
+  // ── Troubleshooting ───────────────────────────────────────────────────────
+  {
+    id: "not-responding",
+    category: "Troubleshooting",
+    question: "Eliza isn't responding to my messages.",
+    answer:
+      "Most often there's no AI model set up yet. Open Settings → AI Model and either add a provider key, log in to Eliza Cloud, or download a local model. If a model is set, give it a moment — the first reply after startup can take a few seconds.",
+    keywords: [
+      "not responding",
+      "no reply",
+      "stuck",
+      "broken",
+      "silent",
+      "no answer",
+      "model",
+      "provider",
+    ],
+    deepLink: {
+      label: "Open AI Model settings",
+      tab: "settings",
+      settingsSection: "ai-model",
+    },
+  },
+  {
+    id: "slow-start",
+    category: "Troubleshooting",
+    question: "Eliza is slow to start up.",
+    answer:
+      "On first launch it may download a model in the background, which takes time once. After that, the app is usable the moment it opens — the agent's first-reply ability fades in a second or two behind a live screen.",
+    keywords: [
+      "slow",
+      "startup",
+      "loading",
+      "boot",
+      "wait",
+      "warming up",
+      "download",
+      "first run",
+    ],
+  },
+  {
+    id: "reset",
+    category: "Troubleshooting",
+    question: "How do I reset or start fresh?",
+    answer:
+      "You can reset settings and data from Settings → Runtime (look for reset/advanced options). Be careful: resetting clears local data. If you only want a fresh conversation, start a new chat instead.",
+    keywords: [
+      "reset",
+      "start over",
+      "fresh",
+      "clear",
+      "wipe",
+      "delete",
+      "factory",
+    ],
+    deepLink: {
+      label: "Open runtime settings",
+      tab: "settings",
+      settingsSection: "runtime",
+    },
+  },
+  {
+    id: "rerun-tutorial",
+    category: "Troubleshooting",
+    question: "How do I see the tutorial again?",
+    answer:
+      "Tap the Tutorial tile on your home screen any time to re-run the interactive tour. It's always available — nothing is one-time-only.",
+    keywords: [
+      "tutorial",
+      "again",
+      "replay",
+      "re-run",
+      "tour",
+      "walkthrough",
+      "help",
+    ],
+    deepLink: { label: "Start the tutorial", startTutorial: true },
+  },
+];

--- a/packages/ui/src/components/pages/tutorial/TutorialOverlay.tsx
+++ b/packages/ui/src/components/pages/tutorial/TutorialOverlay.tsx
@@ -1,0 +1,157 @@
+import * as React from "react";
+
+import { useApp } from "../../../state";
+import { TutorialSpotlight } from "./TutorialSpotlight";
+import {
+  goToStep,
+  setTutorialMode,
+  stopTutorial,
+  useTutorial,
+} from "./tutorial-controller";
+import { TUTORIAL_STEPS, type TutorialObservable } from "./tutorial-steps";
+
+/**
+ * The always-mounted interactive tutorial engine. When the tutorial is active it
+ * samples real UI state (chat detents via stable test ids, the current tab),
+ * AUTO-ADVANCES the instant the user performs the step's action, narrates each
+ * step via the browser speech API in voice mode, and renders the spotlight that
+ * both points at the next control and blocks every other one. Every step also
+ * exposes a timed Continue fallback, so a missed auto-detection never traps the
+ * user. Mounted once in App.tsx alongside the chat overlay.
+ */
+
+function speak(text: string): void {
+  try {
+    const synth = window.speechSynthesis;
+    if (!synth) return;
+    synth.cancel();
+    const u = new SpeechSynthesisUtterance(text);
+    u.rate = 1;
+    u.pitch = 1;
+    synth.speak(u);
+  } catch {
+    /* no speech synthesis — text mode still works */
+  }
+}
+
+function cancelSpeech(): void {
+  try {
+    window.speechSynthesis?.cancel();
+  } catch {
+    /* ignore */
+  }
+}
+
+function has(selector: string): boolean {
+  return typeof document !== "undefined" && !!document.querySelector(selector);
+}
+
+function readObservable(
+  tab: string,
+  secondsOnStep: number,
+): TutorialObservable {
+  const pilled = has('[data-testid="chat-pill"]');
+  const sheet = has('[data-testid="chat-sheet"]');
+  const grabber =
+    typeof document !== "undefined"
+      ? document.querySelector('[data-testid="chat-sheet-grabber"]')
+      : null;
+  const grabberExpanded = grabber?.getAttribute("aria-expanded") === "true";
+  return {
+    tab,
+    chatOpen: !pilled,
+    chatExpanded: sheet || grabberExpanded,
+    chatPilled: pilled,
+    secondsOnStep,
+  };
+}
+
+export function TutorialOverlay(): React.ReactElement | null {
+  const { active, stepIndex, mode } = useTutorial();
+  const tab = useApp().tab;
+
+  const [secondsOnStep, setSecondsOnStep] = React.useState(0);
+  const [succeeded, setSucceeded] = React.useState(false);
+  const stepStartRef = React.useRef<number>(0);
+
+  const step = active ? TUTORIAL_STEPS[stepIndex] : undefined;
+
+  const advance = React.useCallback(() => {
+    cancelSpeech();
+    if (stepIndex >= TUTORIAL_STEPS.length - 1) {
+      stopTutorial();
+    } else {
+      goToStep(stepIndex + 1);
+    }
+  }, [stepIndex]);
+
+  // Reset per-step timers whenever the step (or active) changes. stepIndex/active
+  // are intentional re-run triggers, not values read in the body.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: stepIndex/active are reset triggers
+  React.useEffect(() => {
+    stepStartRef.current = Date.now();
+    setSecondsOnStep(0);
+    setSucceeded(false);
+  }, [stepIndex, active]);
+
+  // Narrate the step in voice mode.
+  React.useEffect(() => {
+    if (!active || mode !== "voice" || !step) return;
+    speak(step.voiceLine);
+    return () => cancelSpeech();
+  }, [active, mode, step]);
+
+  // Sample observable UI state + auto-detect success.
+  React.useEffect(() => {
+    if (!active || !step || succeeded) return;
+    const id = window.setInterval(() => {
+      const secs = (Date.now() - stepStartRef.current) / 1000;
+      setSecondsOnStep(secs);
+      if (step.isComplete?.(readObservable(tab, secs))) {
+        setSucceeded(true);
+      }
+    }, 200);
+    return () => window.clearInterval(id);
+  }, [active, step, succeeded, tab]);
+
+  // After a brief "you did it" beat, advance.
+  React.useEffect(() => {
+    if (!succeeded) return;
+    const t = window.setTimeout(advance, 850);
+    return () => window.clearTimeout(t);
+  }, [succeeded, advance]);
+
+  if (!active || !step) return null;
+
+  const showContinue =
+    step.manualContinue ||
+    (step.continueAfterSec != null && secondsOnStep >= step.continueAfterSec);
+  const isLast = stepIndex >= TUTORIAL_STEPS.length - 1;
+
+  return (
+    <TutorialSpotlight
+      targetSelector={step.targetSelector}
+      blockOutside={step.blockOutside && !succeeded}
+      title={succeeded ? "Nice — you got it! ✓" : step.title}
+      body={
+        succeeded
+          ? "Moving on…"
+          : mode === "voice" && step.voiceCommandHint
+            ? `${step.body}\n\n🎙️ Say: “${step.voiceCommandHint}”`
+            : step.body
+      }
+      stepIndex={stepIndex}
+      totalSteps={TUTORIAL_STEPS.length}
+      mode={mode}
+      voiceBusy={
+        mode === "voice" &&
+        typeof window !== "undefined" &&
+        !!window.speechSynthesis?.speaking
+      }
+      onToggleMode={() => setTutorialMode(mode === "voice" ? "text" : "voice")}
+      onSkip={stopTutorial}
+      onContinue={showContinue ? advance : undefined}
+      continueLabel={isLast ? "Done" : step.continueLabel}
+    />
+  );
+}

--- a/packages/ui/src/components/pages/tutorial/TutorialSpotlight.tsx
+++ b/packages/ui/src/components/pages/tutorial/TutorialSpotlight.tsx
@@ -1,0 +1,291 @@
+import * as React from "react";
+import { createPortal } from "react-dom";
+
+/**
+ * The tutorial spotlight: a full-screen overlay that
+ *  - dims everything EXCEPT a hole cut around the target element (4 backdrop
+ *    rects), so the target stays clickable and every other control is BLOCKED
+ *    (the backdrop captures the click) — this is the "block wrong actions" seam;
+ *  - draws a breathing orange glow ring around the target (the "glowing
+ *    indicator pointing at the next control");
+ *  - floats an instruction card near the target (auto-flips above/below to fit).
+ *
+ * When `targetSelector` is null (e.g. the welcome / finish step) it dims the
+ * whole screen and centers the card — no hole, nothing to point at.
+ *
+ * Brand orange (#FF5800) is the accent; resting→hover stays orange→darker.
+ */
+
+const BRAND = "#FF5800";
+const PAD = 8; // glow ring inset around the target
+
+export interface SpotlightCardProps {
+  title: string;
+  body: string;
+  stepIndex: number;
+  totalSteps: number;
+  mode: "text" | "voice";
+  onToggleMode: () => void;
+  onSkip: () => void;
+  /** Optional manual-advance button (steps with no auto-detected success). */
+  onContinue?: () => void;
+  continueLabel?: string;
+  /** Voice is currently speaking / listening — pulse the mode chip. */
+  voiceBusy?: boolean;
+}
+
+export interface TutorialSpotlightProps extends SpotlightCardProps {
+  /** CSS selector for the element to spotlight, or null for a centered card. */
+  targetSelector: string | null;
+  /** Block interaction everywhere except the target hole. */
+  blockOutside: boolean;
+}
+
+interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+function measure(selector: string | null): Rect | null {
+  if (!selector || typeof document === "undefined") return null;
+  const el = document.querySelector(selector);
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  if (r.width === 0 && r.height === 0) return null;
+  return { top: r.top, left: r.left, width: r.width, height: r.height };
+}
+
+export function TutorialSpotlight({
+  targetSelector,
+  blockOutside,
+  ...card
+}: TutorialSpotlightProps): React.ReactPortal | null {
+  const [rect, setRect] = React.useState<Rect | null>(() =>
+    measure(targetSelector),
+  );
+
+  // Follow the target as it moves/resizes/scrolls (rAF loop is the simplest
+  // reliable tracker across layout shifts, animations, and the chat expanding).
+  React.useEffect(() => {
+    if (!targetSelector) {
+      setRect(null);
+      return;
+    }
+    let raf = 0;
+    let prev = "";
+    const tick = () => {
+      const next = measure(targetSelector);
+      const sig = next
+        ? `${Math.round(next.top)},${Math.round(next.left)},${Math.round(next.width)},${Math.round(next.height)}`
+        : "";
+      if (sig !== prev) {
+        prev = sig;
+        setRect(next);
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [targetSelector]);
+
+  if (typeof document === "undefined") return null;
+
+  const hole = rect
+    ? {
+        top: Math.max(0, rect.top - PAD),
+        left: Math.max(0, rect.left - PAD),
+        width: rect.width + PAD * 2,
+        height: rect.height + PAD * 2,
+      }
+    : null;
+
+  // Card placement: below the target if there's room, else above; centered when
+  // there's no target.
+  const cardStyle: React.CSSProperties = hole
+    ? hole.top + hole.height + 180 < window.innerHeight
+      ? { top: hole.top + hole.height + 14, left: clampLeft(hole.left) }
+      : { top: Math.max(14, hole.top - 172), left: clampLeft(hole.left) }
+    : {
+        top: "50%",
+        left: "50%",
+        transform: "translate(-50%, -50%)",
+      };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[2147483000]"
+      // Pass clicks through when not blocking AND not over a backdrop rect.
+      style={{ pointerEvents: "none" }}
+      aria-live="polite"
+    >
+      <style>{SPOTLIGHT_KEYFRAMES}</style>
+
+      {/* Dimming backdrop. With a hole: 4 rects around the target (block the rest,
+          leave the target clickable). Without a hole: one full-screen dim. */}
+      {blockOutside &&
+        (hole ? (
+          <BackdropWithHole hole={hole} />
+        ) : (
+          <div
+            className="absolute inset-0 bg-black/55"
+            style={{ pointerEvents: "auto" }}
+          />
+        ))}
+
+      {/* The breathing glow ring around the target. */}
+      {hole && (
+        <div
+          className="absolute rounded-xl"
+          style={{
+            top: hole.top,
+            left: hole.left,
+            width: hole.width,
+            height: hole.height,
+            pointerEvents: "none",
+            boxShadow: `0 0 0 2px ${BRAND}, 0 0 0 9999px rgba(0,0,0,0)`,
+            animation: "tutorial-glow 1.6s ease-in-out infinite",
+          }}
+        />
+      )}
+
+      <SpotlightCard {...card} cardStyle={cardStyle} />
+    </div>,
+    document.body,
+  );
+}
+
+function clampLeft(left: number): number {
+  const w = 320;
+  return Math.min(Math.max(14, left), window.innerWidth - w - 14);
+}
+
+function BackdropWithHole({ hole }: { hole: Rect }): React.ReactElement {
+  // Four dim rects framing the hole; each blocks clicks. The center (target)
+  // is left open so only the intended control is interactive.
+  const dim = "absolute bg-black/55";
+  const block: React.CSSProperties = { pointerEvents: "auto" };
+  return (
+    <>
+      <div
+        className={dim}
+        style={{ ...block, top: 0, left: 0, right: 0, height: hole.top }}
+      />
+      <div
+        className={dim}
+        style={{
+          ...block,
+          top: hole.top + hole.height,
+          left: 0,
+          right: 0,
+          bottom: 0,
+        }}
+      />
+      <div
+        className={dim}
+        style={{
+          ...block,
+          top: hole.top,
+          left: 0,
+          width: hole.left,
+          height: hole.height,
+        }}
+      />
+      <div
+        className={dim}
+        style={{
+          ...block,
+          top: hole.top,
+          left: hole.left + hole.width,
+          right: 0,
+          height: hole.height,
+        }}
+      />
+    </>
+  );
+}
+
+function SpotlightCard({
+  title,
+  body,
+  stepIndex,
+  totalSteps,
+  mode,
+  onToggleMode,
+  onSkip,
+  onContinue,
+  continueLabel,
+  voiceBusy,
+  cardStyle,
+}: SpotlightCardProps & {
+  cardStyle: React.CSSProperties;
+}): React.ReactElement {
+  return (
+    <div
+      className="absolute w-[320px] max-w-[calc(100vw-28px)] rounded-2xl border border-white/12 bg-neutral-950/95 p-4 text-white shadow-2xl backdrop-blur-md motion-safe:animate-[shell-overlay-in_220ms_ease-out]"
+      style={{ ...cardStyle, pointerEvents: "auto" }}
+      data-testid="tutorial-card"
+      role="dialog"
+      aria-label="Tutorial step"
+    >
+      <div className="mb-1 flex items-center justify-between">
+        <span
+          className="text-xs font-semibold tracking-wide"
+          style={{ color: BRAND }}
+        >
+          Step {stepIndex + 1} of {totalSteps}
+        </span>
+        <button
+          type="button"
+          onClick={onToggleMode}
+          className={`rounded-full border border-white/15 px-2 py-0.5 text-[11px] text-white/80 transition-colors hover:bg-white/10 ${
+            voiceBusy ? "animate-pulse" : ""
+          }`}
+          aria-label={`Switch to ${mode === "voice" ? "text" : "voice"} mode`}
+        >
+          {mode === "voice" ? "🔊 Voice" : "💬 Text"}
+        </button>
+      </div>
+      <h3 className="text-[15px] font-semibold leading-snug">{title}</h3>
+      <p className="mt-1 whitespace-pre-line text-[13px] leading-relaxed text-white/75">
+        {body}
+      </p>
+      <div className="mt-3 flex items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={onSkip}
+          className="text-[12px] text-white/45 underline-offset-2 hover:text-white/70 hover:underline"
+        >
+          Skip tutorial
+        </button>
+        {onContinue && (
+          <button
+            type="button"
+            onClick={onContinue}
+            className="rounded-lg px-3 py-1.5 text-[13px] font-semibold text-white transition-colors"
+            style={{ backgroundColor: BRAND }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor = "#D44A00";
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = BRAND;
+            }}
+          >
+            {continueLabel ?? "Continue"}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const SPOTLIGHT_KEYFRAMES = `
+@keyframes tutorial-glow {
+  0%, 100% { box-shadow: 0 0 0 2px ${BRAND}, 0 0 14px 3px rgba(255,88,0,0.55); }
+  50%      { box-shadow: 0 0 0 3px ${BRAND}, 0 0 26px 8px rgba(255,88,0,0.85); }
+}
+@media (prefers-reduced-motion: reduce) {
+  [style*="tutorial-glow"] { animation: none !important; }
+}
+`;

--- a/packages/ui/src/components/pages/tutorial/TutorialView.tsx
+++ b/packages/ui/src/components/pages/tutorial/TutorialView.tsx
@@ -1,0 +1,87 @@
+import * as React from "react";
+
+import { useApp } from "../../../state";
+import { startTutorial } from "./tutorial-controller";
+import { TUTORIAL_STEPS } from "./tutorial-steps";
+
+/**
+ * The Tutorial launcher — the view the home "Tutorial" tile opens. It's a warm
+ * intro screen; pressing a Start button activates the global TutorialOverlay (the
+ * actual interactive tour) and drops the user back on the home base so the tour
+ * can spotlight the real chat + tiles. Text and voice are two ways to take the
+ * SAME tour (voice narrates each step aloud); both are one tap.
+ */
+
+const BRAND = "#FF5800";
+
+export function TutorialView(): React.ReactElement {
+  const { setTab } = useApp();
+
+  const begin = React.useCallback(
+    (mode: "text" | "voice") => {
+      startTutorial(mode);
+      // Return to the home base so the tour overlays the real app (chat + tiles).
+      setTab("chat");
+    },
+    [setTab],
+  );
+
+  return (
+    <div
+      className="flex h-full w-full flex-col items-center justify-center overflow-y-auto px-6 py-10 text-center"
+      data-testid="tutorial-launcher"
+    >
+      <div className="flex max-w-md flex-col items-center">
+        <div
+          className="mb-5 flex h-16 w-16 items-center justify-center rounded-2xl text-3xl"
+          style={{
+            backgroundColor: "rgba(255,88,0,0.14)",
+            boxShadow: `0 0 28px 4px rgba(255,88,0,0.35)`,
+          }}
+          aria-hidden
+        >
+          ✨
+        </div>
+        <h1 className="text-2xl font-semibold text-txt-strong">
+          Learn Eliza in 90 seconds
+        </h1>
+        <p className="mt-2 text-[15px] leading-relaxed text-txt/70">
+          A quick, hands-on tour. Glowing pointers show you exactly what to tap;
+          Eliza checks each step as you go. You'll learn to open, expand and
+          shrink the chat, switch screens just by asking, and find Settings.
+        </p>
+
+        <div className="mt-7 flex w-full flex-col gap-2.5 sm:flex-row sm:justify-center">
+          <button
+            type="button"
+            onClick={() => begin("text")}
+            data-testid="tutorial-start-text"
+            className="rounded-xl px-5 py-2.5 text-[15px] font-semibold text-white transition-colors"
+            style={{ backgroundColor: BRAND }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor = "#D44A00";
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = BRAND;
+            }}
+          >
+            Start the tour
+          </button>
+          <button
+            type="button"
+            onClick={() => begin("voice")}
+            data-testid="tutorial-start-voice"
+            className="rounded-xl border border-white/15 px-5 py-2.5 text-[15px] font-semibold text-txt-strong transition-colors hover:bg-white/8"
+          >
+            🔊 Start with voice
+          </button>
+        </div>
+
+        <p className="mt-4 text-[12px] text-txt/45">
+          {TUTORIAL_STEPS.length} short steps · you can skip any time · re-run
+          it whenever you like
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/pages/tutorial/tutorial-controller.ts
+++ b/packages/ui/src/components/pages/tutorial/tutorial-controller.ts
@@ -1,0 +1,88 @@
+import * as React from "react";
+
+/**
+ * Global tutorial controller. The interactive tour is a persistent OVERLAY (not
+ * a tab view) because it navigates the user around the real app — to Settings,
+ * back home — and must survive those navigations. The home "Tutorial" tile and
+ * the launcher view call `startTutorial()`; the always-mounted `TutorialOverlay`
+ * (in App.tsx) subscribes and renders the spotlight + step engine when active.
+ *
+ * Module-level store (shared via globalThis so a single instance survives HMR
+ * and is reachable from the tile handler outside React) + useSyncExternalStore.
+ */
+
+const COMPLETED_KEY = "eliza:tutorial-completed";
+
+export type TutorialMode = "text" | "voice";
+
+export interface TutorialState {
+  active: boolean;
+  stepIndex: number;
+  mode: TutorialMode;
+}
+
+interface TutorialStore {
+  state: TutorialState;
+  listeners: Set<() => void>;
+}
+
+function store(): TutorialStore {
+  const g = globalThis as Record<PropertyKey, unknown>;
+  const k = Symbol.for("elizaos.ui.tutorial-controller");
+  const existing = g[k] as TutorialStore | undefined;
+  if (existing) return existing;
+  const created: TutorialStore = {
+    state: { active: false, stepIndex: 0, mode: "text" },
+    listeners: new Set(),
+  };
+  g[k] = created;
+  return created;
+}
+
+function set(next: Partial<TutorialState>): void {
+  const s = store();
+  s.state = { ...s.state, ...next };
+  for (const l of s.listeners) l();
+}
+
+export function startTutorial(mode?: TutorialMode): void {
+  set({ active: true, stepIndex: 0, mode: mode ?? store().state.mode });
+}
+
+/** Stop + mark complete so it never nags again (but stays re-runnable from the tile). */
+export function stopTutorial(): void {
+  set({ active: false, stepIndex: 0 });
+  try {
+    localStorage.setItem(COMPLETED_KEY, "1");
+  } catch {
+    /* storage unavailable — fine */
+  }
+}
+
+export function goToStep(index: number): void {
+  set({ stepIndex: Math.max(0, index) });
+}
+
+export function setTutorialMode(mode: TutorialMode): void {
+  set({ mode });
+}
+
+export function isTutorialCompleted(): boolean {
+  try {
+    return localStorage.getItem(COMPLETED_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function useTutorial(): TutorialState {
+  const s = store();
+  return React.useSyncExternalStore(
+    (l) => {
+      s.listeners.add(l);
+      return () => s.listeners.delete(l);
+    },
+    () => s.state,
+    () => s.state,
+  );
+}

--- a/packages/ui/src/components/pages/tutorial/tutorial-steps.ts
+++ b/packages/ui/src/components/pages/tutorial/tutorial-steps.ts
@@ -1,0 +1,156 @@
+/**
+ * The interactive tutorial script. Each step points a glowing spotlight at one
+ * real control, gives a text + voice instruction, and (where possible) AUTO-
+ * ADVANCES the moment the user actually performs the action — so the tutorial
+ * "checks when the user does something right". Steps with no reliable auto-signal
+ * fall back to a manual Continue button (still spotlit + instructive).
+ *
+ * Targets are existing stable test ids on the live UI (chat-pill,
+ * chat-sheet-grabber, chat-sheet, chat-composer-textarea, home-tile-settings),
+ * so the spotlight always lands on the genuine control.
+ */
+
+/** Live, observable UI state the engine samples each frame (see TutorialView). */
+export interface TutorialObservable {
+  /** Current nav tab / view. */
+  tab: string;
+  /** The chat is open (not collapsed to the pill). */
+  chatOpen: boolean;
+  /** The chat sheet is expanded (HALF/FULL detent). */
+  chatExpanded: boolean;
+  /** The chat is collapsed to the small floating pill. */
+  chatPilled: boolean;
+  /** Seconds elapsed on the current step (drives Continue fallbacks). */
+  secondsOnStep: number;
+}
+
+export interface TutorialStep {
+  id: string;
+  title: string;
+  /** On-screen instruction. */
+  body: string;
+  /** Spoken instruction (TTS) in voice mode. */
+  voiceLine: string;
+  /** CSS selector for the control to spotlight, or null for a centered card. */
+  targetSelector: string | null;
+  /** Dim + block everything except the target (the "block wrong action" gate). */
+  blockOutside: boolean;
+  /** Auto-advance when this predicate becomes true. */
+  isComplete?: (s: TutorialObservable) => boolean;
+  /** Offer a manual Continue button (after `continueAfterSec`, if auto-detected). */
+  manualContinue?: boolean;
+  continueLabel?: string;
+  /** Show the Continue fallback after N seconds even on auto-detected steps. */
+  continueAfterSec?: number;
+  /** In voice mode, the command the user should speak for this step. */
+  voiceCommandHint?: string;
+}
+
+export const TUTORIAL_STEPS: TutorialStep[] = [
+  {
+    id: "welcome",
+    title: "Welcome to Eliza 👋",
+    body: "Eliza is your AI agent. This 90-second tour shows you the one thing that runs everything: the chat. Ready?",
+    voiceLine:
+      "Welcome to Eliza, your A I agent. In about ninety seconds I'll show you how everything works. The secret is the chat. Let's go.",
+    targetSelector: null,
+    blockOutside: true,
+    manualContinue: true,
+    continueLabel: "Start the tour",
+  },
+  {
+    id: "meet-chat",
+    title: "This is your chat",
+    body: "The glowing capsule floats over every screen — it's how you talk to Eliza by text or voice. Tap it to open the chat.",
+    voiceLine:
+      "See the glowing capsule? That's your chat. It floats over every screen. Tap it now to open it.",
+    targetSelector: '[data-testid="chat-pill"]',
+    blockOutside: true,
+    isComplete: (s) => s.chatOpen && !s.chatPilled,
+    continueAfterSec: 12,
+  },
+  {
+    id: "expand-chat",
+    title: "Make it bigger",
+    body: "Drag the little handle up — or tap it — to expand the chat to full screen for longer conversations.",
+    voiceLine:
+      "Now make the chat bigger. Drag the handle at the top of the chat upward, or just tap it, to expand it to full screen.",
+    targetSelector: '[data-testid="chat-sheet-grabber"]',
+    blockOutside: true,
+    isComplete: (s) => s.chatExpanded,
+    continueAfterSec: 14,
+  },
+  {
+    id: "minimize-chat",
+    title: "Shrink it back",
+    body: "Swipe down on the handle (or tap it) to collapse the chat back into the floating pill. It's never in your way.",
+    voiceLine:
+      "Great. Now shrink it back down. Swipe down on the handle, or tap it, to collapse the chat into the little pill.",
+    targetSelector: '[data-testid="chat-sheet-grabber"]',
+    blockOutside: true,
+    isComplete: (s) => s.chatPilled,
+    continueAfterSec: 14,
+  },
+  {
+    id: "switch-by-text",
+    title: "Just ask to go somewhere",
+    body: "You can move around Eliza by talking to it. Open the chat and type “open settings”, then press Enter.",
+    voiceLine:
+      "Here's the magic: you can move around Eliza just by asking. Open the chat and type, open settings, then press enter.",
+    targetSelector: '[data-testid="chat-composer-textarea"]',
+    blockOutside: false,
+    isComplete: (s) => s.tab === "settings",
+    manualContinue: true,
+    continueAfterSec: 18,
+    continueLabel: "Take me to Settings",
+    voiceCommandHint: "open settings",
+  },
+  {
+    id: "settings-tour",
+    title: "You're in Settings",
+    body: "This is where you choose your AI model, turn voice on, connect apps, and pick local vs cloud. Have a look, then continue.",
+    voiceLine:
+      "Nicely done — you navigated by talking. This is Settings, where you choose your A I model, turn on voice, connect apps, and pick local or cloud. Take a look, then continue.",
+    targetSelector: null,
+    blockOutside: false,
+    manualContinue: true,
+    continueLabel: "Got it",
+  },
+  {
+    id: "say-it",
+    title: "Now try your voice",
+    body: "Tap the mic in the chat and say “go home”. Eliza listens and navigates — hands-free.",
+    voiceLine:
+      "Let's try voice. Tap the microphone in the chat and say, go home. Eliza will take you there, hands free.",
+    targetSelector: '[data-testid="chat-pill"]',
+    blockOutside: false,
+    isComplete: (s) =>
+      s.tab === "home" || s.tab === "views" || s.tab === "chat",
+    manualContinue: true,
+    continueAfterSec: 16,
+    continueLabel: "Skip voice",
+    voiceCommandHint: "go home",
+  },
+  {
+    id: "help",
+    title: "Stuck? Open Help",
+    body: "The Help tile on your home screen has searchable answers for everything — what Eliza is, models, voice, privacy, connecting apps, and more.",
+    voiceLine:
+      "Any time you're stuck, open the Help tile on your home screen. It has searchable answers for everything.",
+    targetSelector: '[data-testid="home-tile-help"]',
+    blockOutside: false,
+    manualContinue: true,
+    continueLabel: "Finish",
+  },
+  {
+    id: "done",
+    title: "You're ready 🎉",
+    body: "That's it! The chat is your remote control — tap, expand, type, or talk. Re-run this tour any time from the Tutorial tile.",
+    voiceLine:
+      "That's it — you're ready. The chat is your remote control. Tap, expand, type, or talk. You can re-run this tour any time from the Tutorial tile. Have fun with Eliza.",
+    targetSelector: null,
+    blockOutside: true,
+    manualContinue: true,
+    continueLabel: "Done",
+  },
+];

--- a/packages/ui/src/components/shell/HomeScreen.tsx
+++ b/packages/ui/src/components/shell/HomeScreen.tsx
@@ -4,9 +4,11 @@ import {
   CalendarCheck,
   CheckCircle2,
   Contact,
+  GraduationCap,
   Hand,
   Inbox,
   LayoutGrid,
+  LifeBuoy,
   Loader2,
   type LucideIcon,
   MessageCircle,
@@ -68,6 +70,20 @@ interface HomeTile {
 }
 
 const HOME_TILES: HomeTile[] = [
+  {
+    // Pinned first: the interactive tour that teaches the whole UI. Opens a
+    // launcher view that kicks off the global tutorial overlay.
+    id: "tutorial",
+    label: "Tutorial",
+    icon: GraduationCap,
+    target: { kind: "tab", tab: "tutorial" },
+  },
+  {
+    id: "help",
+    label: "Help",
+    icon: LifeBuoy,
+    target: { kind: "tab", tab: "help" },
+  },
   {
     id: "settings",
     label: "Settings",

--- a/packages/ui/src/navigation/index.ts
+++ b/packages/ui/src/navigation/index.ts
@@ -74,6 +74,8 @@ export type BuiltinTab =
   | "database"
   | "desktop"
   | "settings"
+  | "tutorial"
+  | "help"
   | "logs";
 
 /**
@@ -270,6 +272,8 @@ export const TAB_PATHS: Record<BuiltinTab, string> = {
   database: "/apps/database",
   desktop: "/desktop",
   settings: "/settings",
+  tutorial: "/tutorial",
+  help: "/help",
   logs: "/apps/logs",
 };
 


### PR DESCRIPTION
Two new views pinned to the home screen (**Tutorial first**, **Help** next) so anyone can learn how Eliza's UI works and find answers when confused.

## Tutorial — interactive guided tour (text + voice)
- A persistent **spotlight overlay** (a portal that survives navigation — it sends the user to Settings and back) that points a **breathing orange glow** at the exact next control and **blocks every other one** (a dim backdrop with a hole only at the target = the "block wrong action" gate).
- **Checks each action and auto-advances** the instant the user does it right — chat open/expand/minimize via DOM detents, view switches via the current tab. Every step also has a **timed Continue fallback** so a missed detection never traps the user.
- **Voice mode** narrates each step via the browser speech API; spoken commands go through the real chat mic and the tour detects the outcome. One-tap voice/text toggle.
- Steps: welcome → open chat → expand → minimize → switch view by typing → see Settings → switch by voice → find Help → done. Launched from the home tile (re-runnable any time).

## Help — searchable FAQ / knowledge base
- 30 entries across 9 categories: what Eliza is, the chat, navigation, models + local inference, privacy/topology, voice, connectors, Eliza Cloud, capabilities, troubleshooting.
- Client-side fuzzy search + category filter; each answer can **deep-link** straight to the relevant tab / Settings section, or launch the tour.

## Wiring & verification
- `HOME_TILES` (the live home screen — note `home-grid-apps.ts` is dead code), App.tsx `directViews` + lazy views + the global `TutorialOverlay` mount, `BuiltinTab` + `TAB_PATHS`.
- Typecheck clean (ui). Home/nav unit tests pass (10). **Mock-backed Playwright e2e passes** (`tutorial-help-views`): tiles pinned (Tutorial first), launcher → Start → spotlight card "Step 1 of…", skip works, Help searches + deep-links.

Follow-ups (not blocking): register as builtin views for Views-catalog discoverability; optional auto-launch on first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)