### PR TITLE
fix(cloud): shared agents serve /api/auth/me + /api/character + declare no-websocket

### DIFF
--- a/packages/cloud-api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
+++ b/packages/cloud-api/v1/eliza/agents/[agentId]/api/[...path]/route.ts
@@ -3,6 +3,8 @@ import { agentSandboxesRepository } from "@/db/repositories/agent-sandboxes";
 import { requireUserOrApiKeyWithOrg } from "@/lib/auth/workers-hono-auth";
 import { applyCorsHeaders, handleCorsOptions } from "@/lib/services/proxy/cors";
 import {
+  sharedRestAuthMe,
+  sharedRestCharacter,
   sharedRestConfig,
   sharedRestFirstRun,
   sharedRestFirstRunStatus,
@@ -60,7 +62,8 @@ function shellPath(c: Context<AppEnv>): string {
 async function resolveSharedAgent(
   c: Context<AppEnv>,
 ): Promise<
-  { error: string; status: 400 | 404 } | { agentId: string; agentName: string }
+  | { error: string; status: 400 | 404 }
+  | { agentId: string; agentName: string; orgId: string }
 > {
   const user = await requireUserOrApiKeyWithOrg(c);
   const agentId = c.req.param("agentId");
@@ -73,7 +76,11 @@ async function resolveSharedAgent(
   if (agent.execution_tier !== "shared") {
     return { error: "Not a shared-runtime agent", status: 404 };
   }
-  return { agentId, agentName: agent.agent_name ?? "Eliza" };
+  return {
+    agentId,
+    agentName: agent.agent_name ?? "Eliza",
+    orgId: user.organization_id,
+  };
 }
 
 app.options("/", () => handleCorsOptions(CORS_METHODS));
@@ -95,6 +102,15 @@ app.get("/", async (c) => {
       return json(sharedRestViews(c.req.query("viewType")));
     case "config":
       return json(sharedRestConfig());
+    case "auth/me":
+      // The app's hard startup auth gate. The caller is already an authed API
+      // key (resolveSharedAgent validated it), so report the authed machine
+      // identity instead of 404'ing into "server_unavailable".
+      return json(sharedRestAuthMe(r.agentId, r.agentName));
+    case "character":
+      // The exact character the shared turn answers as (reuses
+      // buildSharedRuntimeCharacter via the service).
+      return json(await sharedRestCharacter(r.agentId, r.orgId, r.agentName));
     default:
       // Genuinely-unknown shell endpoint — don't mask it with a default.
       return json(

--- a/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
+++ b/packages/cloud-shared/src/lib/services/eliza-sandbox.ts
@@ -1618,6 +1618,21 @@ export class ElizaSandboxService {
     return this.loadSharedRuntimeHistory(agentId, channelId);
   }
 
+  /**
+   * Resolve the effective character (name/system/bio/model) for a shared-runtime
+   * agent — the SAME `SharedAgentCharacter` the bridge `message.send` turn uses,
+   * so the REST `GET .../api/character` adapter returns exactly what the agent
+   * answers as. Returns `null` when no running shared sandbox matches the org.
+   */
+  async getSharedRuntimeCharacter(
+    agentId: string,
+    orgId: string,
+  ): Promise<SharedAgentCharacter | null> {
+    const rec = await agentSandboxesRepository.findRunningSandbox(agentId, orgId);
+    if (!rec || rec.execution_tier !== "shared") return null;
+    return this.buildSharedRuntimeCharacter(rec);
+  }
+
   // Bridge
 
   async bridge(agentId: string, orgId: string, rpc: BridgeRequest): Promise<BridgeResponse> {

--- a/packages/cloud-shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
+++ b/packages/cloud-shared/src/lib/services/shared-runtime/shared-rest-adapter.test.ts
@@ -4,7 +4,9 @@
  *   - the conversation is canonical (id === agentId === roomId), so the list is
  *     always one item and create is idempotent;
  *   - history maps SharedTurnMessage{role,content} → REST {id,role,text};
- *   - send forwards to the bridge `message.send` and returns its reply text.
+ *   - send forwards to the bridge `message.send` and returns its reply text;
+ *   - the startup shell (status/first-run/views/config/auth-me/character) returns
+ *     the exact shapes the mobile app probes on boot.
  *
  * Self-contained dependency mock: bun's `mock.module` is process-global and
  * leaks across files, so spying on the real `elizaSandboxService` singleton was
@@ -20,14 +22,17 @@ import * as realElizaSandbox from "../eliza-sandbox";
 
 const bridge = mock();
 const getSharedConversationHistory = mock();
+const getSharedRuntimeCharacter = mock();
 
 mock.module("../eliza-sandbox", () => ({
   ...realElizaSandbox,
-  elizaSandboxService: { bridge, getSharedConversationHistory },
+  elizaSandboxService: { bridge, getSharedConversationHistory, getSharedRuntimeCharacter },
 }));
 
 // Imported after the mock so the adapter binds to our stubbed service.
 const {
+  sharedRestAuthMe,
+  sharedRestCharacter,
   sharedRestConfig,
   sharedRestConversationCreate,
   sharedRestConversationsList,
@@ -91,8 +96,8 @@ describe("shared-rest-adapter — startup shell surface", () => {
     expect(sharedRestFirstRun()).toEqual({ complete: true, ok: true });
   });
 
-  test("config is an empty object the client tolerates", () => {
-    expect(sharedRestConfig()).toEqual({});
+  test("config advertises no websocket (shared agents stream via SSE/REST)", () => {
+    expect(sharedRestConfig()).toEqual({ websocket: false });
   });
 
   test("views returns the builtin chat view by default", () => {
@@ -112,6 +117,52 @@ describe("shared-rest-adapter — startup shell surface", () => {
     expect(sharedRestViews("gui").views).toHaveLength(1);
     expect(sharedRestViews("tui").views).toHaveLength(0);
     expect(sharedRestViews("xr").views).toHaveLength(0);
+  });
+
+  test("auth/me reports the authed machine identity (the app's hard gate)", () => {
+    expect(sharedRestAuthMe(AGENT, "Nova")).toEqual({
+      identity: { id: AGENT, displayName: "Nova", kind: "machine" },
+      session: { id: "bearer", kind: "machine", expiresAt: null },
+      access: { mode: "bearer", passwordConfigured: false, ownerConfigured: false },
+    });
+  });
+
+  test("auth/me falls back to a display name when the agent has none", () => {
+    expect(sharedRestAuthMe(AGENT, "").identity.displayName).toBe("Eliza");
+  });
+});
+
+describe("shared-rest-adapter — character", () => {
+  beforeEach(() => {
+    getSharedRuntimeCharacter.mockReset();
+  });
+
+  test("returns the shared runtime character the turn answers as", async () => {
+    getSharedRuntimeCharacter.mockResolvedValue({
+      name: "Nova",
+      system: "You are Nova.",
+      bio: ["curious"],
+      model: "gpt-oss-120b",
+    });
+    const out = await sharedRestCharacter(AGENT, ORG, "Nova");
+    expect(out).toEqual({
+      character: {
+        name: "Nova",
+        system: "You are Nova.",
+        bio: ["curious"],
+        model: "gpt-oss-120b",
+      },
+      agentName: "Nova",
+    });
+    expect(getSharedRuntimeCharacter).toHaveBeenCalledWith(AGENT, ORG);
+  });
+
+  test("falls back to an empty character object when the sandbox can't resolve", async () => {
+    getSharedRuntimeCharacter.mockResolvedValue(null);
+    expect(await sharedRestCharacter(AGENT, ORG, "")).toEqual({
+      character: {},
+      agentName: "Eliza",
+    });
   });
 });
 

--- a/packages/cloud-shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
+++ b/packages/cloud-shared/src/lib/services/shared-runtime/shared-rest-adapter.ts
@@ -19,6 +19,7 @@
 
 import type { BridgeRequest } from "../eliza-sandbox";
 import { elizaSandboxService } from "../eliza-sandbox";
+import type { SharedAgentCharacter } from "./run-shared-agent-turn";
 
 /** Minimal subset of the agent-server REST `Conversation` the chat client reads. */
 export interface SharedRestConversation {
@@ -182,11 +183,72 @@ export function sharedRestViews(viewType?: string): {
 
 /**
  * GET .../api/config — the dashboard's open-ended agent config. A shared agent
- * exposes no editable config through this adapter, so return the minimal empty
- * object the client tolerates (it reads `ui`/`cloud` defensively and falls back).
+ * exposes no editable config through this adapter, but it DOES declare its
+ * realtime transport: a Tier-0 agent runs in a stateless Worker with no
+ * persistent process, so there is no WebSocket to connect (per-turn streaming is
+ * the SSE `/stream` endpoint; chat send already works over REST). It advertises
+ * `websocket: false` so a client that honors it skips opening a WS to the shared
+ * base — avoiding the doomed reconnect loop + "Lost backend connection" overlay
+ * that otherwise paints over a fully working REST/SSE chat. The client still
+ * reads the rest of the object defensively (`ui`/`cloud`) and falls back.
  */
-export function sharedRestConfig(): Record<string, never> {
-  return {};
+export function sharedRestConfig(): { websocket: false } {
+  return { websocket: false };
+}
+
+/** The authed-identity shape `authMe()` (ui/src/api/auth-client.ts) parses. */
+export interface SharedRestAuthMe {
+  identity: { id: string; displayName: string; kind: "machine" };
+  session: { id: string; kind: "machine"; expiresAt: null };
+  access: { mode: "bearer"; passwordConfigured: false; ownerConfigured: false };
+}
+
+/**
+ * GET .../api/auth/me — the app's HARD startup gate (App.tsx auth gate →
+ * useAuthStatus → authMe()). A shared agent has no agent server and no
+ * owner-password flow; it is reached purely through the caller's authenticated
+ * API key, which the route already validated (resolveSharedAgent →
+ * requireUserOrApiKeyWithOrg). So the caller is, by construction, an authed
+ * machine identity — return it in the agent-server's `bearer-agent` shape
+ * (auth-routes.ts authorized branch: identity.kind "machine", session machine
+ * with no expiry, access mode "bearer"). Without an `ok:true` body here, the
+ * client maps the 404 to status 503 → "server_unavailable" → StartupFailureView
+ * and never reaches chat. The identity is the agent itself (id = agentId,
+ * displayName = agentName) — the only stable identity this adapter owns.
+ */
+export function sharedRestAuthMe(agentId: string, agentName: string): SharedRestAuthMe {
+  return {
+    identity: {
+      id: agentId,
+      displayName: agentName || "Eliza",
+      kind: "machine",
+    },
+    session: { id: "bearer", kind: "machine", expiresAt: null },
+    access: { mode: "bearer", passwordConfigured: false, ownerConfigured: false },
+  };
+}
+
+/** GET .../api/character body — mirrors the agent server (character-routes.ts). */
+export interface SharedRestCharacter {
+  character: SharedAgentCharacter | Record<string, never>;
+  agentName: string;
+}
+
+/**
+ * GET .../api/character — the character the app reads (getCharacter() →
+ * `{ character, agentName }`, character-routes.ts GET /api/character). Reuse the
+ * EXACT character the shared turn answers as: getSharedRuntimeCharacter resolves
+ * the same `SharedAgentCharacter` buildSharedRuntimeCharacter feeds into
+ * message.send. Falls back to an empty character object (the agent server's
+ * "no runtime" branch shape) if the sandbox can't be resolved.
+ */
+export async function sharedRestCharacter(
+  agentId: string,
+  orgId: string,
+  agentName: string,
+): Promise<SharedRestCharacter> {
+  const character = await elizaSandboxService.getSharedRuntimeCharacter(agentId, orgId);
+  return { character: character ?? {}, agentName: agentName || "Eliza" };
 }
 
 /** GET .../api/conversations — always the one canonical conversation. */


### PR DESCRIPTION
Develop sync of #8543 (merged to main for prod). Adds /api/auth/me (authed machine identity, exact app shape), /api/character (the character the shared turn answers as, via getSharedRuntimeCharacter), and {websocket:false} in /api/config so the app skips the doomed WS for shared bases. No Worker WS built. Test file reconciled onto develop's mock.module pattern; 17/17 pass, typecheck 0 errors, lint clean.