### PR TITLE
fix(ui): skip websocket for shared cloud agents

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -171,6 +171,10 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
           install-command: bun install --ignore-scripts --no-frozen-lockfile
           install-native-deps: "false"
+          # Biome only needs JS dependencies; skipping Python/protoc keeps this
+          # 5-minute format gate away from apt mirrors and Rust build tooling.
+          setup-python: "false"
+          install-protoc: "false"
           run-postinstall: "false"
 
       - name: Run biome format check

--- a/packages/ui/src/api/client-base-websocket.test.ts
+++ b/packages/ui/src/api/client-base-websocket.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ElizaClient } from "./client-base";
+
+function stubWebSocket(): string[] {
+  const createdUrls: string[] = [];
+  class WebSocketStub {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    readonly readyState = WebSocketStub.CONNECTING;
+
+    constructor(url: string) {
+      createdUrls.push(url);
+    }
+
+    send(): void {}
+  }
+  vi.stubGlobal("WebSocket", WebSocketStub);
+  return createdUrls;
+}
+
+describe("ElizaClient websocket connection policy", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("treats shared-runtime REST adapter bases as connected without opening a websocket", () => {
+    const createdUrls = stubWebSocket();
+
+    const client = new ElizaClient(
+      "https://api.elizacloud.ai/api/v1/eliza/agents/agent-123",
+      "cloud-token",
+    );
+
+    client.connectWs();
+
+    expect(createdUrls).toEqual([]);
+    expect(client.getConnectionState()).toEqual({
+      state: "connected",
+      reconnectAttempt: 0,
+      maxReconnectAttempts: 15,
+      disconnectedAt: null,
+    });
+  });
+
+  it("also skips websocket setup for the legacy shared-runtime bridge base", () => {
+    const createdUrls = stubWebSocket();
+
+    const client = new ElizaClient(
+      "https://api.elizacloud.ai/api/v1/eliza/agents/agent-123/bridge",
+      "cloud-token",
+    );
+
+    client.connectWs();
+
+    expect(createdUrls).toEqual([]);
+    expect(client.getConnectionState().state).toBe("connected");
+  });
+
+  it("still opens a websocket for regular HTTP agent bases", () => {
+    const createdUrls = stubWebSocket();
+
+    const client = new ElizaClient("https://agent.example.test", "agent-token");
+
+    client.connectWs();
+
+    expect(createdUrls).toHaveLength(1);
+    expect(createdUrls[0]).toContain("wss://agent.example.test/ws?");
+    expect(createdUrls[0]).toContain("token=agent-token");
+  });
+});

--- a/packages/ui/src/api/client-base.ts
+++ b/packages/ui/src/api/client-base.ts
@@ -207,6 +207,33 @@ function isLocalAgentIpcBase(value: string | null | undefined): boolean {
   return isMobileLocalAgentIpcUrl(normalized);
 }
 
+function isSharedRuntimeRestAdapterBase(
+  value: string | null | undefined,
+): boolean {
+  const normalized = normalizeBaseUrl(value);
+  if (!normalized) return false;
+  try {
+    const url = new URL(normalized);
+    // Shared-runtime agents are served by the Cloud Worker over REST/SSE, not
+    // by a stateful agent server with `/ws`. Treat both the current adapter
+    // base and the legacy bridge base as connected so the shell does not show
+    // the lost-connection overlay while REST chat remains usable.
+    return /^\/api\/v1\/eliza\/agents\/[^/]+(?:\/bridge)?$/.test(url.pathname);
+  } catch {
+    return false;
+  }
+}
+
+function shouldTreatAsConnectedWithoutWebSocket(
+  value: string | null | undefined,
+): boolean {
+  return (
+    isIosInProcessLocalAgentBase(value) ||
+    isLocalAgentIpcBase(value) ||
+    isSharedRuntimeRestAdapterBase(value)
+  );
+}
+
 function getInjectedWsBase(): string | undefined {
   if (typeof window === "undefined") return undefined;
   const values = [
@@ -764,10 +791,7 @@ export class ElizaClient {
   // --- WebSocket ---
 
   connectWs(): void {
-    if (
-      isIosInProcessLocalAgentBase(this.baseUrl) ||
-      isLocalAgentIpcBase(this.baseUrl)
-    ) {
+    if (shouldTreatAsConnectedWithoutWebSocket(this.baseUrl)) {
       this.backoffMs = 500;
       this.reconnectAttempt = 0;
       this.disconnectedAt = null;


### PR DESCRIPTION
## Summary
- Treat direct shared-runtime Cloud agent bases as REST/SSE-only in the UI API client.
- Reuse the existing synthetic connected state instead of attempting /ws for those bases.
- Add regression coverage for current shared adapter bases, legacy bridge bases, and normal HTTP agent WebSockets.

## Why
Shared-runtime agents run in the Cloud Worker. They now expose REST chat endpoints and /api/config advertises websocket:false, but the UI client still derived wss://api.elizacloud.ai/ws from the adapter base. After reconnect attempts failed, the shell showed ConnectionLostOverlay even though REST chat could work.

## Validation
- bun run --cwd packages/ui test -- client-base-websocket.test.ts
- bunx @biomejs/biome check packages/ui/src/api/client-base.ts packages/ui/src/api/client-base-websocket.test.ts
- git diff --check

Note: bun run --cwd packages/ui typecheck currently fails on develop due existing src/spatial/tui imports for @elizaos/tui, unrelated to this change.