### PR TITLE
fix(ui/tutorial): peek-aware chat steps + manual-continue navigation

### DIFF
--- a/packages/app/test/ui-smoke/tutorial-help-walkthrough.spec.ts
+++ b/packages/app/test/ui-smoke/tutorial-help-walkthrough.spec.ts
@@ -1,0 +1,148 @@
+import { expect, type Page, test } from "@playwright/test";
+import {
+  installDefaultAppRoutes,
+  openAppPath,
+  seedAppStorage,
+} from "./helpers";
+
+/**
+ * Screenshot-driven walkthrough of the full Tutorial tour + Help view, for
+ * manual visual verification. Captures every key state to /tmp/tut-shots so the
+ * spotlight glow, targeting, cards, and Help layout can be eyeballed. Drives the
+ * real chat detents where possible; falls back to the card's Continue button.
+ */
+
+const SHOTS = "/tmp/tut-shots";
+
+async function shot(page: Page, name: string): Promise<void> {
+  await page.screenshot({ path: `${SHOTS}/${name}.png` });
+}
+
+async function cardText(page: Page): Promise<string> {
+  return (await page.getByTestId("tutorial-card").textContent()) ?? "";
+}
+
+// Click the card's Continue button if present (label varies per step).
+async function clickContinue(page: Page): Promise<boolean> {
+  const card = page.getByTestId("tutorial-card");
+  const btn = card.getByRole("button").last();
+  if (await btn.isVisible().catch(() => false)) {
+    const label = (await btn.textContent())?.toLowerCase() ?? "";
+    if (!label.includes("voice") && !label.includes("text")) {
+      await btn.click().catch(() => {});
+      return true;
+    }
+  }
+  return false;
+}
+
+test("full tutorial walkthrough + Help — screenshots", async ({ page }) => {
+  await seedAppStorage(page, { "eliza:tutorial-autolaunched": "1" });
+  await installDefaultAppRoutes(page);
+  await openAppPath(page, "/chat");
+
+  // 1. Home screen with the pinned tiles.
+  await expect(page.getByTestId("home-tile-tutorial")).toBeVisible({
+    timeout: 25_000,
+  });
+  await shot(page, "01-home-tiles");
+
+  // 2. Tutorial launcher.
+  await page.getByTestId("home-tile-tutorial").click();
+  await expect(page.getByTestId("tutorial-launcher")).toBeVisible();
+  await shot(page, "02-launcher");
+
+  // 3. Start the tour → welcome card (spotlight overlay).
+  await page.getByTestId("tutorial-start-text").click();
+  await expect(page.getByTestId("tutorial-card")).toBeVisible();
+  expect(await cardText(page)).toMatch(/Step 1 of/);
+  await shot(page, "03-step1-welcome");
+
+  // 4. Continue → meet-chat. Regression: it must NOT auto-skip (the chat starts
+  // in "peek", so a chatOpen-only check would instantly complete) — it shows a
+  // real step-2 card with the spotlight on the composer.
+  await clickContinue(page);
+  await expect(page.getByTestId("tutorial-card")).toContainText(
+    /This is your chat/i,
+  );
+  await shot(page, "04-step2-meet-chat-spotlight");
+
+  // 5. Drive the chat: tap the pill to open it (best-effort).
+  await page
+    .getByTestId("chat-pill")
+    .click({ timeout: 3000 })
+    .catch(() => {});
+  await page.waitForTimeout(1200);
+  await shot(page, "05-after-open-chat");
+
+  // 6. Walk the remaining steps via Continue, screenshotting each, until "done".
+  for (let i = 0; i < 8; i++) {
+    const txt = await cardText(page).catch(() => "");
+    if (!txt) break;
+    await shot(page, `06-walk-${i}`);
+    // Try driving the chat grabber on the expand/minimize steps.
+    await page
+      .getByTestId("chat-sheet-grabber")
+      .click({ timeout: 800 })
+      .catch(() => {});
+    await page.waitForTimeout(400);
+    const advanced = await clickContinue(page);
+    if (!advanced) {
+      // auto-only step that didn't advance — record and bail the loop.
+      await shot(page, `06-stuck-${i}`);
+    }
+    await page.waitForTimeout(500);
+    if (
+      (await page
+        .getByTestId("tutorial-card")
+        .count()
+        .catch(() => 0)) === 0
+    ) {
+      break; // tour finished
+    }
+  }
+  await shot(page, "07-after-walk");
+
+  // 8. Voice mode toggle on a fresh tour.
+  await page.evaluate(() => {
+    try {
+      localStorage.removeItem("eliza:tutorial-completed");
+    } catch {}
+  });
+  await openAppPath(page, "/tutorial");
+  await page.getByTestId("tutorial-start-voice").click();
+  await expect(page.getByTestId("tutorial-card")).toBeVisible();
+  await shot(page, "08-voice-mode");
+  await page
+    .getByText("Skip tutorial")
+    .click({ timeout: 3000 })
+    .catch(() => {});
+
+  // 9. Help view: open, search, expand, deep-link.
+  await openAppPath(page, "/help");
+  await expect(page.getByTestId("help-view")).toBeVisible();
+  await shot(page, "09-help-home");
+  await page.getByTestId("help-search").fill("voice");
+  await page.waitForTimeout(300);
+  await shot(page, "10-help-search-voice");
+  const firstEntry = page.locator('[data-testid^="help-entry-"]').first();
+  await firstEntry.click();
+  await page.waitForTimeout(300);
+  await shot(page, "11-help-entry-expanded");
+
+  // 10. Help category filter.
+  await page.getByRole("button", { name: "AI models" }).click();
+  await page.waitForTimeout(300);
+  await shot(page, "12-help-category-ai-models");
+
+  expect(true).toBe(true);
+});
+
+test("auto-launch screenshot for a brand-new user", async ({ page }) => {
+  await installDefaultAppRoutes(page);
+  await openAppPath(page, "/chat");
+  await expect(page.getByTestId("tutorial-card")).toBeVisible({
+    timeout: 25_000,
+  });
+  await page.screenshot({ path: `${SHOTS}/13-auto-launch.png` });
+});

--- a/packages/ui/src/components/pages/tutorial/TutorialOverlay.tsx
+++ b/packages/ui/src/components/pages/tutorial/TutorialOverlay.tsx
@@ -71,7 +71,7 @@ function readObservable(
 
 export function TutorialOverlay(): React.ReactElement | null {
   const { active, stepIndex, mode } = useTutorial();
-  const tab = useApp().tab;
+  const { tab, setTab } = useApp();
 
   const [secondsOnStep, setSecondsOnStep] = React.useState(0);
   const [succeeded, setSucceeded] = React.useState(false);
@@ -87,6 +87,16 @@ export function TutorialOverlay(): React.ReactElement | null {
       goToStep(stepIndex + 1);
     }
   }, [stepIndex]);
+
+  // Manual Continue: if the step would normally advance by the user navigating
+  // somewhere (e.g. "open settings"), perform that navigation on their behalf so
+  // the fallback actually takes them there, then advance.
+  const handleManualContinue = React.useCallback(() => {
+    if (step?.advanceNavigateTo) {
+      setTab(step.advanceNavigateTo);
+    }
+    advance();
+  }, [step, setTab, advance]);
 
   // First-run auto-launch: once ever, the first time a brand-new user lands on
   // the home base (tab "chat"), start the tour after a short beat so the home
@@ -167,7 +177,7 @@ export function TutorialOverlay(): React.ReactElement | null {
       }
       onToggleMode={() => setTutorialMode(mode === "voice" ? "text" : "voice")}
       onSkip={stopTutorial}
-      onContinue={showContinue ? advance : undefined}
+      onContinue={showContinue ? handleManualContinue : undefined}
       continueLabel={isLast ? "Done" : step.continueLabel}
     />
   );

--- a/packages/ui/src/components/pages/tutorial/tutorial-steps.ts
+++ b/packages/ui/src/components/pages/tutorial/tutorial-steps.ts
@@ -42,6 +42,13 @@ export interface TutorialStep {
   continueLabel?: string;
   /** Show the Continue fallback after N seconds even on auto-detected steps. */
   continueAfterSec?: number;
+  /**
+   * When the user advances this step MANUALLY (the Continue fallback) rather than
+   * doing the action themselves, navigate to this tab first — so a "Take me to
+   * Settings" fallback actually lands them there instead of stranding them on the
+   * next step's screen. Not applied on auto-detected success (they already moved).
+   */
+  advanceNavigateTo?: string;
   /** In voice mode, the command the user should speak for this step. */
   voiceCommandHint?: string;
 }
@@ -61,13 +68,13 @@ export const TUTORIAL_STEPS: TutorialStep[] = [
   {
     id: "meet-chat",
     title: "This is your chat",
-    body: "The glowing capsule floats over every screen — it's how you talk to Eliza by text or voice. Tap it to open the chat.",
+    body: "The bar at the bottom is your chat — it floats over every screen and is how you talk to Eliza by text or voice. Tap it, then continue.",
     voiceLine:
-      "See the glowing capsule? That's your chat. It floats over every screen. Tap it now to open it.",
-    targetSelector: '[data-testid="chat-pill"]',
-    blockOutside: true,
-    isComplete: (s) => s.chatOpen && !s.chatPilled,
-    continueAfterSec: 12,
+      "The bar at the bottom is your chat. It floats over every screen and it's how you talk to Eliza, by text or voice. Tap it, then press continue.",
+    targetSelector: '[data-testid="chat-composer-textarea"]',
+    blockOutside: false,
+    manualContinue: true,
+    continueLabel: "Got it",
   },
   {
     id: "expand-chat",
@@ -78,18 +85,29 @@ export const TUTORIAL_STEPS: TutorialStep[] = [
     targetSelector: '[data-testid="chat-sheet-grabber"]',
     blockOutside: true,
     isComplete: (s) => s.chatExpanded,
-    continueAfterSec: 14,
+    continueAfterSec: 12,
   },
   {
     id: "minimize-chat",
-    title: "Shrink it back",
-    body: "Swipe down on the handle (or tap it) to collapse the chat back into the floating pill. It's never in your way.",
+    title: "Shrink it to a pill",
+    body: "Now swipe down on the handle (or tap it) to collapse the whole chat into a small floating pill, out of your way.",
     voiceLine:
-      "Great. Now shrink it back down. Swipe down on the handle, or tap it, to collapse the chat into the little pill.",
+      "Great. Now shrink it down. Swipe down on the handle, or tap it, to collapse the chat into a small floating pill.",
     targetSelector: '[data-testid="chat-sheet-grabber"]',
     blockOutside: true,
     isComplete: (s) => s.chatPilled,
-    continueAfterSec: 14,
+    continueAfterSec: 12,
+  },
+  {
+    id: "reopen-chat",
+    title: "Bring it back",
+    body: "There's your pill. Tap it to open the chat again — it's always one tap away, on every screen.",
+    voiceLine:
+      "There's your pill. Tap it to open the chat again. It's always one tap away, on every screen.",
+    targetSelector: '[data-testid="chat-pill"]',
+    blockOutside: true,
+    isComplete: (s) => s.chatOpen && !s.chatPilled,
+    continueAfterSec: 12,
   },
   {
     id: "switch-by-text",
@@ -103,6 +121,7 @@ export const TUTORIAL_STEPS: TutorialStep[] = [
     manualContinue: true,
     continueAfterSec: 18,
     continueLabel: "Take me to Settings",
+    advanceNavigateTo: "settings",
     voiceCommandHint: "open settings",
   },
   {
@@ -124,11 +143,11 @@ export const TUTORIAL_STEPS: TutorialStep[] = [
       "Let's try voice. Tap the microphone in the chat and say, go home. Eliza will take you there, hands free.",
     targetSelector: '[data-testid="chat-pill"]',
     blockOutside: false,
-    isComplete: (s) =>
-      s.tab === "home" || s.tab === "views" || s.tab === "chat",
+    isComplete: (s) => s.tab === "chat" || s.tab === "views",
     manualContinue: true,
     continueAfterSec: 16,
     continueLabel: "Skip voice",
+    advanceNavigateTo: "chat",
     voiceCommandHint: "go home",
   },
   {


### PR DESCRIPTION
A screenshot-driven verification pass of the Tutorial (#8538) surfaced two real bugs; this fixes them. **Manually reviewed 14 captured screenshots** confirming the home tiles, launcher, spotlight glow, Help, voice mode, and auto-launch all render correctly.

## Bugs fixed
1. **`meet-chat` auto-skipped and taught nothing.** The chat starts in the *peek* detent (composer bar visible, no `chat-pill` element), so `chatOpen && !chatPilled` was already true — the step instantly showed "Nice, you got it ✓" and the spotlight had no target (it pointed at the absent pill). Reworked the chat steps to the **real detents**: meet-chat (informational, spotlight on the composer) → expand → minimize-to-pill → **new "reopen from the pill"** step. Each step now targets a present element and teaches a genuine action. *(Before/after screenshots: step 2 went from an instant auto-skip to a real "This is your chat" card with the glow on the composer.)*
2. **Manual-continue fallbacks didn't navigate.** "Take me to Settings" / "Skip voice" just advanced the step, stranding the user on the next step's screen. Added `advanceNavigateTo` so the fallback performs the navigation it was demonstrating, then advances. Auto-detected success is unchanged.

## Verification
- UI typecheck clean.
- New mock-backed Playwright walkthrough spec captures + (manually) verifies 14 screenshots of the full flow, with a regression assertion that meet-chat no longer auto-skips.
- All 4 tutorial/help e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)