### PR TITLE
fix(ci): build plugin-commands before its dependents in Build Agent Image

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -160,7 +160,7 @@ jobs:
         run: |
           for plugin in plugin-sql plugin-video plugin-agent-skills plugin-pdf \
             plugin-browser plugin-capacitor-bridge plugin-coding-tools \
-            plugin-computeruse plugin-discord plugin-edge-tts plugin-elizacloud \
+            plugin-commands plugin-computeruse plugin-discord plugin-edge-tts plugin-elizacloud \
             plugin-imessage plugin-local-inference plugin-mcp plugin-signal \
             plugin-streaming plugin-telegram plugin-whatsapp plugin-wallet plugin-workflow \
             plugin-x402; do


### PR DESCRIPTION
**Build Agent Image** (develop) fails: `plugins/plugin-telegram/src/command-registration.ts(32,8): error TS2307: Cannot find module '@elizaos/plugin-commands'` (exit 2).

Root cause: the hardcoded plugin build loop in `build-agent-image.yml` builds `plugin-discord` + `plugin-telegram` (both import `@elizaos/plugin-commands`, whose types resolve from `dist/index.d.ts`) but **never builds `plugin-commands` itself**, so the blocking `tsc` declaration step can't find it. `packages/app-core/scripts/docker-ci-smoke.sh` already lists `plugin-commands` before the dependents and passes — the two loops diverged despite the "reuse the same loop" comment.

Fix: add `plugin-commands` to the agent-image loop in the same position as docker-ci-smoke. Verified locally: build plugin-commands → dist/index.d.ts emitted → plugin-telegram + plugin-discord builds pass (exit 0).

(The Cloud Tests biome failure seen earlier is already resolved on develop — `cloud-shared lint` is clean.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)