### PR TITLE
fix(ci): build @elizaos/tui before ui in Build Agent Image renderer build

### DIFF
--- a/.github/workflows/build-agent-image.yml
+++ b/.github/workflows/build-agent-image.yml
@@ -129,7 +129,10 @@ jobs:
           (cd packages/core && bun run build.ts --node-only)
           # security → plugin-remote-manifest → plugin-worker-runtime: ordered by
           # build-time type deps; agent boot ERR_MODULE_NOT_FOUNDs without their dist.
-          for pkg in packages/shared packages/cloud-sdk packages/cloud-routing packages/skills packages/ui packages/security packages/plugin-remote-manifest packages/plugin-worker-runtime; do
+          # tui before ui: @elizaos/ui (workspace:* on @elizaos/tui) exposes the
+          # spatial/tui terminal renderer, and the app's `build:client` bundles it;
+          # without @elizaos/tui's dist the renderer build fails to resolve it.
+          for pkg in packages/shared packages/cloud-sdk packages/cloud-routing packages/skills packages/tui packages/ui packages/security packages/plugin-remote-manifest packages/plugin-worker-runtime; do
             if [[ -f "$pkg/package.json" ]] && jq -e '.scripts.build' "$pkg/package.json" >/dev/null; then
               echo "::group::Building $pkg"
               (cd "$pkg" && bun install --no-frozen-lockfile --ignore-scripts && bun run build)


### PR DESCRIPTION
Follow-up to the plugin-commands ordering fix (#8553). With that landed, **Build Agent Image** advanced past the plugin loop to the **Build UI** step and failed:

```
[vite]: Rolldown failed to resolve import "@elizaos/tui" from "packages/ui/src/spatial/tui/index.ts"
```

`@elizaos/ui` (depends on `@elizaos/tui: workspace:*`) exposes the spatial-view framework's `spatial/tui` terminal renderer; the app's `build:client` bundles it (the per-plugin `register-terminal-view.tsx` dynamic-imports it). The lane's **manual** pre-build list built `packages/ui` but never `packages/tui`, so its dist was absent. The Tests lane and `docker-ci-smoke.sh` build via turbo, which respects the `ui→tui` dependency and builds tui first — only this manual list diverged.

Fix: add `packages/tui` to the manual pre-build list, before `packages/ui`.

**Verified locally:** with `@elizaos/tui` built, the `@elizaos/app` renderer build succeeds (`✓ built in 13.89s`, exit 0). (Confirmed the alternative — stubbing `@elizaos/tui` in the browser build — is the wrong approach: it intercepts the module with an empty stub and breaks named imports.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)