### PR TITLE
fix(ci): @elizaos/tui src resolution + relationships LLM journey + biome

### DIFF
--- a/packages/agent/src/__tests__/plugin-view-llm-mock-coverage.test.ts
+++ b/packages/agent/src/__tests__/plugin-view-llm-mock-coverage.test.ts
@@ -108,7 +108,7 @@ describe("plugin view LLM mock coverage", () => {
     const visualCases = readVisualMatrixCases();
     const visualMockCases = PLUGIN_VIEW_LLM_MOCK_CASES.filter(isGuiOrTui);
 
-    expect(visualCases.length).toBe(62);
+    expect(visualCases.length).toBe(63);
     expect(new Set(visualCases.map(caseKey))).toEqual(
       new Set(visualMockCases.map(caseKey)),
     );
@@ -137,7 +137,7 @@ describe("plugin view LLM mock coverage", () => {
       ]),
     );
 
-    expect(PLUGIN_VIEW_LLM_MOCK_CASES.length).toBe(88);
+    expect(PLUGIN_VIEW_LLM_MOCK_CASES.length).toBe(89);
     expect(PLUGIN_VIEW_LLM_MOCK_JOURNEYS).toHaveLength(
       PLUGIN_VIEW_LLM_MOCK_CASES.length,
     );

--- a/packages/agent/src/__tests__/view-user-journeys.ts
+++ b/packages/agent/src/__tests__/view-user-journeys.ts
@@ -52,6 +52,7 @@ export const PLUGIN_VIEW_LLM_MOCK_CASES: PluginViewMockCase[] = [
   { id: "goals", viewType: "gui", path: "/goals" },
   { id: "health", viewType: "gui", path: "/health" },
   { id: "inbox", viewType: "gui", path: "/inbox" },
+  { id: "relationships", viewType: "gui", path: "/relationships" },
   { id: "todos", viewType: "gui", path: "/todos" },
   { id: "messages", viewType: "gui", path: "/messages" },
   { id: "messages", viewType: "tui", path: "/messages/tui" },

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -2458,6 +2458,7 @@ export const INVALID_TRACER_PROVIDER = {};
         }
 
         const uiSource = path.resolve(elizaRoot, "packages/ui/src");
+        const tuiSource = path.resolve(elizaRoot, "packages/tui/src");
 
         return [
           ...generatedAliases,
@@ -2468,6 +2469,16 @@ export const INVALID_TRACER_PROVIDER = {};
           {
             find: /^@elizaos\/ui\/(.+)$/,
             replacement: path.join(uiSource, "$1"),
+          },
+          // @elizaos/tui resolves from source like the rest of the workspace.
+          // @elizaos/ui's spatial/tui terminal renderer imports it; without a
+          // src alias it falls back to dist/index.js (no `exports`/`eliza-source`
+          // map), which is absent in renderer builds that don't pre-build tui,
+          // failing with "Failed to resolve entry for package @elizaos/tui".
+          // The terminal registration it carries never executes in the browser.
+          {
+            find: /^@elizaos\/tui$/,
+            replacement: path.join(tuiSource, "index.ts"),
           },
           {
             find: /^@elizaos\/app-core\/first-run\/first-run-config$/,

--- a/plugins/plugin-discord/__tests__/interactions.test.ts
+++ b/plugins/plugin-discord/__tests__/interactions.test.ts
@@ -5,7 +5,9 @@ import { renderDiscordInteractions } from "../interactions";
 
 describe("renderDiscordInteractions", () => {
 	it("passes plain replies through with no components", () => {
-		const out = renderDiscordInteractions({ text: "a normal reply" } as Content);
+		const out = renderDiscordInteractions({
+			text: "a normal reply",
+		} as Content);
 		expect(out.text).toBe("a normal reply");
 		expect(out.components).toHaveLength(0);
 	});
@@ -23,14 +25,23 @@ describe("renderDiscordInteractions", () => {
 		const first = row.components[0];
 		expect(first.type).toBe(2);
 		expect(first.label).toBe("Yes, ship it");
-		expect(decodeCallback(first.custom_id)).toEqual({ kind: "reply", value: "yes" });
+		expect(decodeCallback(first.custom_id)).toEqual({
+			kind: "reply",
+			value: "yes",
+		});
 	});
 
 	it("renders a task card as a link button when a url resolver is provided", () => {
 		const id = "abc12345-def6-7890-abcd-ef1234567890";
-		const out = renderDiscordInteractions({ text: `[TASK:${id}]Ship it[/TASK]` } as Content, {
-			resolveUrl: (b) => (b.kind === "task" ? `https://app/tasks?taskId=${b.threadId}` : undefined),
-		});
+		const out = renderDiscordInteractions(
+			{ text: `[TASK:${id}]Ship it[/TASK]` } as Content,
+			{
+				resolveUrl: (b) =>
+					b.kind === "task"
+						? `https://app/tasks?taskId=${b.threadId}`
+						: undefined,
+			},
+		);
 		const button = out.components[0]?.components[0];
 		expect(button?.style).toBe(5); // Link
 		expect(button?.url).toContain(id);
@@ -38,7 +49,10 @@ describe("renderDiscordInteractions", () => {
 	});
 
 	it("caps action rows at the Discord limit of 5", () => {
-		const options = Array.from({ length: 30 }, (_, i) => `o${i}=Option ${i}`).join("\n");
+		const options = Array.from(
+			{ length: 30 },
+			(_, i) => `o${i}=Option ${i}`,
+		).join("\n");
 		const out = renderDiscordInteractions({
 			text: `[CHOICE:s id=c]\n${options}\n[/CHOICE]`,
 		} as Content);

--- a/plugins/plugin-discord/interactions.ts
+++ b/plugins/plugin-discord/interactions.ts
@@ -45,7 +45,13 @@ export interface DiscordInteractionOptions {
 function toComponent(button: NeutralButton): DiscordComponentOptions | null {
 	if (button.url) {
 		// Link buttons carry no custom_id; discord.js requires the URL + Link style.
-		return { type: 2, custom_id: "", label: button.label, style: LINK_STYLE, url: button.url };
+		return {
+			type: 2,
+			custom_id: "",
+			label: button.label,
+			style: LINK_STYLE,
+			url: button.url,
+		};
 	}
 	if (button.callbackData) {
 		return {
@@ -69,7 +75,11 @@ export function renderDiscordInteractions(
 ): DiscordInteractionRender {
 	const { blocks, cleanedText } = parseInteractionBlocks(content.text ?? "");
 	if (blocks.length === 0) {
-		return { text: content.text ?? "", components: [], needsFreeTextReply: false };
+		return {
+			text: content.text ?? "",
+			components: [],
+			needsFreeTextReply: false,
+		};
 	}
 
 	const rows: DiscordActionRow[] = [];
@@ -95,6 +105,8 @@ export function renderDiscordInteractions(
 		if (!producedButton && layout.text) extraLines.push(layout.text);
 	}
 
-	const text = [cleanedText, ...extraLines].filter((s) => s.trim().length > 0).join("\n\n");
+	const text = [cleanedText, ...extraLines]
+		.filter((s) => s.trim().length > 0)
+		.join("\n\n");
 	return { text, components: rows.slice(0, MAX_ROWS), needsFreeTextReply };
 }


### PR DESCRIPTION
Three develop CI-lane fixes (all verified locally):
- **Zero-Key app browser / renderer builds**: alias `@elizaos/tui` to its src in the app vite config — it lacks an exports/eliza-source map so renderer builds that don't pre-build it failed to resolve it. Verified: app build passes with tui's dist deleted.
- **Server Tests**: add the relationships gui case so its LLM mock journey auto-generates (4/4 gate pass).
- **Quality (Extended)**: biome-format 2 plugin-discord files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)