### PR TITLE
chore(cloud): set prod STEWARD_TENANT_ID explicitly (no implicit default)

### DIFF
--- a/packages/cloud-api/wrangler.toml
+++ b/packages/cloud-api/wrangler.toml
@@ -343,6 +343,12 @@ NEXT_PUBLIC_APP_URL = "https://elizacloud.ai"
 NEXT_PUBLIC_API_URL = "https://api.elizacloud.ai"
 ELIZA_CLOUD_URL = "https://elizacloud.ai"
 ELIZA_CLOUD_AGENT_BASE_DOMAIN = "elizacloud.ai"
+# Pin the prod Steward tenant explicitly instead of leaning on the implicit
+# DEFAULT_STEWARD_TENANT_ID ("elizacloud") in steward-tenant-config.ts. That
+# implicit fallback is what the prod magic-link bug hinged on — make it explicit
+# so prod tenant scope can't silently shift if the code default ever changes.
+STEWARD_TENANT_ID = "elizacloud"
+NEXT_PUBLIC_STEWARD_TENANT_ID = "elizacloud"
 AGENT_ROUTER_ORIGIN_HOST = "eliza-production-1.elizacloud.ai"
 WAIFU_SERVICE_ORG_ID = "d96d3fc8-cc07-40be-b81c-ba7a7b4e8028"
 WAIFU_SERVICE_USER_ID = "90101225-836f-4fa7-a69c-f70691dcf256"


### PR DESCRIPTION
## what

Prod's `[env.production.vars]` in `packages/cloud-api/wrangler.toml` never set the Steward tenant, so prod silently relied on the implicit `DEFAULT_STEWARD_TENANT_ID = "elizacloud"` fallback in `steward-tenant-config.ts`. That implicit default is exactly what the prod magic-link bug hinged on.

This pins it explicitly:

```toml
STEWARD_TENANT_ID = "elizacloud"
NEXT_PUBLIC_STEWARD_TENANT_ID = "elizacloud"
```

## why elizacloud (not elizacloud-staging)

Confirmed from the code default. `resolveDefaultStewardTenantId()` resolves in this order:

```
NEXT_PUBLIC_STEWARD_TENANT_ID || STEWARD_TENANT_ID || DEFAULT_STEWARD_TENANT_ID
```

and `DEFAULT_STEWARD_TENANT_ID = "elizacloud"` (`packages/cloud-shared/src/lib/services/steward-tenant-config.ts:10`). Staging already sets `elizacloud-staging` explicitly; prod was the only env leaning on the implicit default.

## behavior

Value matches the current code default, so this is behavior-preserving today. The point is it can no longer silently shift if the code default ever changes. Staging block untouched, no other var touched — single file, +6 lines.

## check

`wrangler.toml` re-parses clean; prod vars now resolve `STEWARD_TENANT_ID=elizacloud` / `NEXT_PUBLIC_STEWARD_TENANT_ID=elizacloud`, staging still `elizacloud-staging`.
