### PR TITLE
fix(ci): make @elizaos/tui resolvable for plugin spatial tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,8 +232,13 @@ jobs:
 
       # plugin-xr's xr-bundle-coverage test asserts every view plugin has a
       # built dist/views/bundle.js; build them before running plugin tests.
+      # @elizaos/tui first: the spatial-view tests (45 plugins) import
+      # @elizaos/ui/spatial/tui, whose terminal renderer externalizes
+      # @elizaos/tui — without its dist, vitest fails to resolve the package.
       - name: Build view bundles
-        run: bun run build:views
+        run: |
+          bun run --cwd packages/tui build
+          bun run build:views
 
       - name: Run plugin tests
         # Cap step below the 95m job budget so a flaky plugin

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -4,6 +4,17 @@
   "description": "Terminal User Interface library with differential rendering for efficient text-based applications",
   "type": "module",
   "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "eliza-source": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "clean": "rm -rf dist",
     "build": "tsc -p tsconfig.build.json",


### PR DESCRIPTION
Greens the Plugin Tests lane: the 45 spatial-view tests import @elizaos/ui/spatial/tui → @elizaos/tui, which had no exports map and was never built before Plugin Tests, so vitest couldn't resolve it. Adds the standard exports map to @elizaos/tui + builds it before the plugin tests. Verified: plugin-wallet-ui InventorySpatialView.test.tsx 3/3 pass with ui+tui built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)